### PR TITLE
Remove use of ngResource for search and annotation queries

### DIFF
--- a/h/static/scripts/annotation-mapper.js
+++ b/h/static/scripts/annotation-mapper.js
@@ -24,7 +24,7 @@ function annotationMapper($rootScope, annotationUI, store) {
         $rootScope.$emit(events.ANNOTATION_UPDATED, existing);
         return;
       }
-      loaded.push(new store.AnnotationResource(annotation));
+      loaded.push(annotation);
     });
 
     $rootScope.$emit(events.ANNOTATIONS_LOADED, loaded);
@@ -42,13 +42,12 @@ function annotationMapper($rootScope, annotationUI, store) {
   }
 
   function createAnnotation(annotation) {
-    annotation = new store.AnnotationResource(annotation);
     $rootScope.$emit(events.BEFORE_ANNOTATION_CREATED, annotation);
     return annotation;
   }
 
   function deleteAnnotation(annotation) {
-    return annotation.$delete({
+    return store.annotation.delete({
       id: annotation.id
     }).then(function () {
       $rootScope.$emit(events.ANNOTATION_DELETED, annotation);

--- a/h/static/scripts/annotation-viewer-controller.js
+++ b/h/static/scripts/annotation-viewer-controller.js
@@ -9,16 +9,16 @@ var angular = require('angular');
  */
 function fetchThread(store, id) {
   var annot;
-  return store.AnnotationResource.get({id: id}).$promise.then(function (annot) {
+  return store.annotation.get({id: id}).then(function (annot) {
     if (annot.references && annot.references.length) {
       // This is a reply, fetch the top-level annotation
-      return store.AnnotationResource.get({id: annot.references[0]}).$promise;
+      return store.annotation.get({id: annot.references[0]});
     } else {
       return annot;
     }
   }).then(function (annot_) {
     annot = annot_;
-    return store.SearchResource.get({references: annot.id}).$promise;
+    return store.search({references: annot.id});
   }).then(function (searchResult) {
     return [annot].concat(searchResult.rows);
   });

--- a/h/static/scripts/app.js
+++ b/h/static/scripts/app.js
@@ -34,10 +34,6 @@ var resolve = {
   sessionState: function (session) {
     return session.load();
   },
-  // @ngInject
-  store: function (store) {
-    return store.$promise;
-  },
   streamer: streamer.connect,
 };
 

--- a/h/static/scripts/cross-frame.coffee
+++ b/h/static/scripts/cross-frame.coffee
@@ -26,7 +26,7 @@ module.exports = class CrossFrame
             formatted[k] = v
           formatted
         parser: (annotation) ->
-          parsed = new store.AnnotationResource()
+          parsed = {}
           for k, v of annotation when k in whitelist
             parsed[k] = v
           parsed

--- a/h/static/scripts/search-client.js
+++ b/h/static/scripts/search-client.js
@@ -8,15 +8,15 @@ var inherits = require('inherits');
  *
  * SearchClient handles paging through results, canceling search etc.
  *
- * @param {Object} resource - ngResource class instance for the /search API
+ * @param {Object} searchFn - Function for querying the search API
  * @param {Object} opts - Search options
  * @constructor
  */
-function SearchClient(resource, opts) {
+function SearchClient(searchFn, opts) {
   opts = opts || {};
 
   var DEFAULT_CHUNK_SIZE = 200;
-  this._resource = resource;
+  this._searchFn = searchFn;
   this._chunkSize = opts.chunkSize || DEFAULT_CHUNK_SIZE;
   if (typeof opts.incremental !== 'undefined') {
     this._incremental = opts.incremental;
@@ -37,7 +37,7 @@ SearchClient.prototype._getBatch = function (query, offset) {
   }, query);
 
   var self = this;
-  this._resource.get(searchQuery).$promise.then(function (results) {
+  this._searchFn(searchQuery).then(function (results) {
     if (self._canceled) {
       return;
     }

--- a/h/static/scripts/stream-controller.coffee
+++ b/h/static/scripts/stream-controller.coffee
@@ -20,11 +20,13 @@ module.exports = class StreamController
       searchParams = searchFilter.toObject($routeParams.q)
       query = angular.extend(options, searchParams)
       query._separate_replies = true
-      store.SearchResource.get(query, load)
+      store.search(query)
+        .then(load)
+        .catch((err) -> console.error err)
 
     load = ({rows, replies}) ->
-        offset += rows.length
-        annotationMapper.loadAnnotations(rows, replies)
+      offset += rows.length
+      annotationMapper.loadAnnotations(rows, replies)
 
     # Reload on query change (ignore hash change)
     lastQuery = $routeParams.q

--- a/h/static/scripts/test/annotation-mapper-test.js
+++ b/h/static/scripts/test/annotation-mapper-test.js
@@ -13,7 +13,9 @@ describe('annotationMapper', function() {
 
   beforeEach(function () {
     fakeStore = {
-      AnnotationResource: sandbox.stub().returns({}),
+      annotation: {
+        delete: sinon.stub().returns(Promise.resolve({})),
+      },
     };
     angular.module('app', [])
       .service('annotationMapper', require('../annotation-mapper'))
@@ -40,7 +42,7 @@ describe('annotationMapper', function() {
       annotationMapper.loadAnnotations(annotations);
       assert.called($rootScope.$emit);
       assert.calledWith($rootScope.$emit, events.ANNOTATIONS_LOADED,
-        [{}, {}, {}]);
+        [{id: 1}, {id: 2}, {id: 3}]);
     });
 
     it('also includes replies in the annotationLoaded event', function () {
@@ -50,7 +52,7 @@ describe('annotationMapper', function() {
       annotationMapper.loadAnnotations(annotations, replies);
       assert.called($rootScope.$emit);
       assert.calledWith($rootScope.$emit, events.ANNOTATIONS_LOADED,
-        [{}, {}, {}]);
+        [{id: 1}, {id: 2}, {id: 3}]);
     });
 
     it('triggers the annotationUpdated event for each loaded annotation', function () {
@@ -122,25 +124,16 @@ describe('annotationMapper', function() {
   });
 
   describe('#createAnnotation()', function () {
-    it('creates a new annotaton resource', function () {
+    it('creates a new annotation resource', function () {
       var ann = {};
-      fakeStore.AnnotationResource.returns(ann);
       var ret = annotationMapper.createAnnotation(ann);
       assert.equal(ret, ann);
-    });
-
-    it('creates a new resource with the new keyword', function () {
-      var ann = {};
-      fakeStore.AnnotationResource.returns(ann);
-      annotationMapper.createAnnotation();
-      assert.calledWithNew(fakeStore.AnnotationResource);
     });
 
     it('emits the "beforeAnnotationCreated" event', function () {
       sandbox.stub($rootScope, '$emit');
       var ann = {};
-      fakeStore.AnnotationResource.returns(ann);
-      annotationMapper.createAnnotation();
+      annotationMapper.createAnnotation(ann);
       assert.calledWith($rootScope.$emit,
         events.BEFORE_ANNOTATION_CREATED, ann);
     });
@@ -148,16 +141,14 @@ describe('annotationMapper', function() {
 
   describe('#deleteAnnotation()', function () {
     it('deletes the annotation on the server', function () {
-      var p = Promise.resolve();
-      var ann = {$delete: sandbox.stub().returns(p)};
+      var ann = {id: 'test-id'};
       annotationMapper.deleteAnnotation(ann);
-      assert.called(ann.$delete);
+      assert.calledWith(fakeStore.annotation.delete, {id: 'test-id'});
     });
 
     it('triggers the "annotationDeleted" event on success', function (done) {
       sandbox.stub($rootScope, '$emit');
-      var p = Promise.resolve();
-      var ann = {$delete: sandbox.stub().returns(p)};
+      var ann = {};
       annotationMapper.deleteAnnotation(ann).then(function () {
         assert.calledWith($rootScope.$emit,
           events.ANNOTATION_DELETED, ann);
@@ -165,21 +156,12 @@ describe('annotationMapper', function() {
       $rootScope.$apply();
     });
 
-    it('does nothing on error', function (done) {
+    it('does not emit an event on error', function (done) {
       sandbox.stub($rootScope, '$emit');
-      var p = Promise.reject();
-      var ann = {$delete: sandbox.stub().returns(p)};
+      fakeStore.annotation.delete.returns(Promise.reject());
+      var ann = {id: 'test-id'};
       annotationMapper.deleteAnnotation(ann).catch(function () {
         assert.notCalled($rootScope.$emit);
-      }).then(done, done);
-      $rootScope.$apply();
-    });
-
-    it('return a promise that resolves to the deleted annotation', function (done) {
-      var p = Promise.resolve();
-      var ann = {$delete: sandbox.stub().returns(p)};
-      annotationMapper.deleteAnnotation(ann).then(function (value) {
-        assert.equal(value, ann);
       }).then(done, done);
       $rootScope.$apply();
     });

--- a/h/static/scripts/test/annotation-viewer-controller-test.js
+++ b/h/static/scripts/test/annotation-viewer-controller-test.js
@@ -7,7 +7,7 @@ var angular = require('angular');
 function FakeStore(annots) {
   this.annots = annots;
 
-  this.AnnotationResource = {
+  this.annotation = {
     get: function (query) {
       var result;
       if (query.id) {
@@ -15,20 +15,18 @@ function FakeStore(annots) {
           return a.id === query.id;
         });
       }
-      return {$promise: Promise.resolve(result)};
+      return Promise.resolve(result);
     }
   };
 
-  this.SearchResource = {
-    get: function (query) {
-      var result;
-      if (query.references) {
-        result = annots.filter(function (a) {
-          return a.references && a.references.indexOf(query.references) !== -1;
-        });
-      }
-      return {$promise: Promise.resolve({rows: result})};
+  this.search = function (query) {
+    var result;
+    if (query.references) {
+      result = annots.filter(function (a) {
+        return a.references && a.references.indexOf(query.references) !== -1;
+      });
     }
+    return Promise.resolve({rows: result});
   };
 }
 

--- a/h/static/scripts/test/stream-controller-test.coffee
+++ b/h/static/scripts/test/stream-controller-test.coffee
@@ -62,9 +62,7 @@ describe 'StreamController', ->
     }
 
     fakeStore = {
-      SearchResource: {
-        get: sandbox.spy()
-      }
+      search: sandbox.spy(-> Promise.resolve({rows: [], total: 0}))
     }
 
     fakeStreamer = {
@@ -103,22 +101,21 @@ describe 'StreamController', ->
 
   it 'calls the search API with _separate_replies: true', ->
     createController()
-    assert.equal(
-      fakeStore.SearchResource.get.firstCall.args[0]._separate_replies, true)
+    assert.equal(fakeStore.search.firstCall.args[0]._separate_replies, true)
 
   it 'passes the annotations and replies from search to loadAnnotations()', ->
-    fakeStore.SearchResource.get = (query, func) ->
-      func({
+    fakeStore.search = (query) ->
+      Promise.resolve({
         'rows': ['annotation_1', 'annotation_2']
         'replies': ['reply_1', 'reply_2', 'reply_3']
       })
 
     createController()
 
-    assert fakeAnnotationMapper.loadAnnotations.calledOnce
-    assert fakeAnnotationMapper.loadAnnotations.calledWith(
-      ['annotation_1', 'annotation_2'], ['reply_1', 'reply_2', 'reply_3']
-    )
+    Promise.resolve().then ->
+      assert.calledOnce fakeAnnotationMapper.loadAnnotations
+      assert.calledWith fakeAnnotationMapper.loadAnnotations,
+        ['annotation_1', 'annotation_2'], ['reply_1', 'reply_2', 'reply_3']
 
 
   describe 'on $routeUpdate', ->

--- a/h/static/scripts/test/widget-controller-test.js
+++ b/h/static/scripts/test/widget-controller-test.js
@@ -9,8 +9,8 @@ var events = require('../events');
 var noCallThru = require('./util').noCallThru;
 
 var searchClients;
-function FakeSearchClient(resource, opts) {
-  assert.ok(resource);
+function FakeSearchClient(searchFn, opts) {
+  assert.ok(searchFn);
   searchClients.push(this);
   this.cancel = sinon.stub();
   this.incremental = !!opts.incremental;
@@ -118,7 +118,7 @@ describe('WidgetController', function () {
     fakeSettings = {};
 
     fakeStore = {
-      SearchResource: {},
+      search: sinon.stub(),
     };
 
     $provide.value('VirtualThreadList', FakeVirtualThreadList);

--- a/h/static/scripts/util/test/url-util-test.js
+++ b/h/static/scripts/util/test/url-util-test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var urlUtil = require('../url-util');
+
+describe('url-util', function () {
+  describe('replaceURLParams()', function () {
+    it('should replace params in URLs', function () {
+      var replaced = urlUtil.replaceURLParams('http://foo.com/things/:id',
+        {id: 'test'});
+      assert.equal(replaced.url, 'http://foo.com/things/test');
+    });
+
+    it('should return unused params', function () {
+      var replaced = urlUtil.replaceURLParams('http://foo.com/:id',
+        {id: 'test', 'q': 'unused'});
+      assert.deepEqual(replaced.params, {q: 'unused'});
+    });
+  });
+});

--- a/h/static/scripts/util/url-util.js
+++ b/h/static/scripts/util/url-util.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * Replace parameters in a URL template with values from a `params` object.
+ *
+ * Returns an object containing the expanded URL and a dictionary of unused
+ * parameters.
+ *
+ *   replaceURLParams('/things/:id', {id: 'foo', q: 'bar'}) =>
+ *     {url: '/things/foo', params: {q: 'bar'}}
+ */
+function replaceURLParams(url, params) {
+  var unusedParams = {};
+  for (var param in params) {
+    if (params.hasOwnProperty(param)) {
+      var value = params[param];
+      var urlParam = ':' + param;
+      if (url.indexOf(urlParam) !== -1) {
+        url = url.replace(urlParam, value);
+      } else {
+        unusedParams[param] = value;
+      }
+    }
+  }
+  return {url: url, params: unusedParams};
+}
+
+module.exports = {
+  replaceURLParams: replaceURLParams,
+};

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -189,7 +189,7 @@ module.exports = function WidgetController(
   }
 
   function _loadAnnotationsFor(uris, group) {
-    var searchClient = new SearchClient(store.SearchResource, {
+    var searchClient = new SearchClient(store.search, {
       // If no group is specified, we are fetching annotations from
       // all groups in order to find out which group contains the selected
       // annotation, therefore we need to load all chunks before processing

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "karma-phantomjs-launcher": "^0.2.3",
     "karma-sinon": "^1.0.4",
     "lodash.debounce": "^4.0.3",
+    "lodash.get": "^4.3.0",
     "mkdirp": "^0.5.1",
     "mocha": "^2.4.5",
     "ng-tags-input": "^3.1.1",


### PR DESCRIPTION
_Moved from https://github.com/hypothesis/h/pull/3556. Note that this depends on #3_

Several aspects of ngResource make it sub-optimal for our needs:

 1. It mutates the model object directly after making an API call, which
    does not fit well with usage in a Redux app where the UI state should
    be an immutable object.

 2. The ngResource classes can only be constructed once the API
    description has been retrieved. At least one place in our code,
    which handled newly created annotations arriving from the page,
    failed to account for this.

This commit therefore replaces use of ngResource for making API calls
to the search and annotation endpoints with a simple wrapper around HTTP
requests which makes a call and then returns the resulting object.

The new wrapper will wait until the API description has been received
before attempting to make an API call, avoiding problem (2) above.

As a bonus, this brings us a step towards decoupling the JS API client
from Angular so we could re-use it outside the app in future.

 * Replace ngResource with simple $http wrapper in store.js

 * Add tests for annotation update and deletion API calls

 * Change tests in annotation-test.js from
   `assert(predicate(actual, expected))` form to
   `assert.predicate(actual, expected))` form as this results in errors
   that are _much_ easier to debug when they fail.