### PR TITLE
Fix annotation state not being updated when annotations are saved

### DIFF
--- a/h/static/scripts/root-thread.js
+++ b/h/static/scripts/root-thread.js
@@ -89,6 +89,7 @@ function RootThread($rootScope, annotationUI, features, searchFilter, viewFilter
   // the Redux store in annotationUI.
   var loadEvents = [events.BEFORE_ANNOTATION_CREATED,
                     events.ANNOTATION_CREATED,
+                    events.ANNOTATION_UPDATED,
                     events.ANNOTATIONS_LOADED];
   loadEvents.forEach(function (event) {
     $rootScope.$on(event, function (event, annotation) {

--- a/h/static/scripts/test/root-thread-test.js
+++ b/h/static/scripts/test/root-thread-test.js
@@ -255,6 +255,7 @@ describe('rootThread', function () {
     }, [
       {event: events.BEFORE_ANNOTATION_CREATED, annotations: annot},
       {event: events.ANNOTATION_CREATED, annotations: annot},
+      {event: events.ANNOTATION_UPDATED, annotations: annot},
       {event: events.ANNOTATIONS_LOADED, annotations: [annot]},
     ]);
 


### PR DESCRIPTION
Annotations in the app's local state store were not being updated
after a save was successfully committed on the server.

Fixes hypothesis/h#2965