### PR TITLE
Simplify annotation component by removing duplicated state

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -31,46 +31,6 @@ function errorMessage(reason) {
   return message;
 }
 
-
-
-/** Restore unsaved changes to this annotation from the drafts service.
- *
- * If there are no draft changes to this annotation, does nothing.
- *
- */
-function restoreFromDrafts(drafts, vm) {
-  var draft = drafts.get(vm.annotation);
-  if (draft) {
-    vm.isPrivate = draft.isPrivate;
-    vm.form.tags = draft.tags;
-    vm.form.text = draft.text;
-  }
-}
-
-/**
-  * Save the given annotation to the drafts service.
-  *
-  * Any existing drafts for this annotation will be overwritten.
-  *
-  * @param {object} drafts - The drafts service
-  * @param {object} vm.annotation - The full vm.annotation object of the
-  *   annotation to be saved. This full vm.annotation model is not retrieved
-  *   again from drafts, it's only used to identify the annotation's draft in
-  *   order to retrieve the fields below.
-  * @param {object} vm - The view model object containing the user's unsaved
-  *   changes to the annotation.
-  *
-  */
-function saveToDrafts(drafts, vm) {
-  drafts.update(
-    vm.annotation,
-    {
-      isPrivate: vm.isPrivate,
-      tags: vm.form.tags,
-      text: vm.form.text,
-    });
-}
-
 /** Update `annotation` from vm.
  *
  * Copy any properties from vm that might have been modified by the user into
@@ -81,9 +41,9 @@ function saveToDrafts(drafts, vm) {
  *
  */
 function updateDomainModel(annotation, vm, permissions) {
-  annotation.text = vm.form.text;
-  annotation.tags = vm.form.tags;
-  if (vm.isPrivate) {
+  annotation.text = vm.state().text;
+  annotation.tags = vm.state().tags;
+  if (vm.state().isPrivate) {
     annotation.permissions = permissions.private();
   } else {
     annotation.permissions = permissions.shared(annotation.group);
@@ -91,13 +51,7 @@ function updateDomainModel(annotation, vm, permissions) {
 }
 
 /** Update the view model from the domain model changes. */
-function updateViewModel($scope, vm, permissions) {
-
-  vm.form = {
-    text: vm.annotation.text,
-    tags: vm.annotation.tags,
-  };
-
+function updateViewModel($scope, vm) {
   if (vm.annotation.links) {
     vm.linkInContext = vm.annotation.links.incontext ||
                        vm.annotation.links.html ||
@@ -107,9 +61,6 @@ function updateViewModel($scope, vm, permissions) {
     vm.linkInContext = '';
     vm.linkHTML = '';
   }
-
-  vm.isPrivate = permissions.isPrivate(
-    vm.annotation.permissions, vm.annotation.user);
 
   vm.documentMeta = annotationMetadata.domainAndTitle(vm.annotation);
 }
@@ -162,10 +113,6 @@ function AnnotationController(
     * can call the methods.
     */
   function init() {
-    /** vm.form is the read-write part of vm for the templates: it contains
-     *  the variables that the templates will write changes to via ng-model. */
-    vm.form = {};
-
     // The remaining properties on vm are read-only properties for the
     // templates.
 
@@ -174,9 +121,6 @@ function AnnotationController(
 
     /** Give the template access to the feature flags. */
     vm.feature = features.flagEnabled;
-
-    /** Whether or not this annotation is private. */
-    vm.isPrivate = false;
 
     /** Determines whether controls to expand/collapse the annotation body
      * are displayed adjacent to the tags field.
@@ -212,9 +156,6 @@ function AnnotationController(
     // When a new annotation is created, remove any existing annotations that
     // are empty
     $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, deleteIfNewAndEmpty);
-
-    // Call `onDestroy()` when the component is destroyed.
-    $scope.$on('$destroy', onDestroy);
 
     // Call `onGroupFocused()` whenever the currently-focused group changes.
     $scope.$on(events.GROUP_FOCUSED, onGroupFocused);
@@ -256,26 +197,13 @@ function AnnotationController(
 
   function onAnnotationUpdated(event, updatedDomainModel) {
     if (updatedDomainModel.id === vm.annotation.id) {
-      vm.annotation = updatedDomainModel;
       updateView();
     }
   }
 
   function deleteIfNewAndEmpty() {
-    if (isNew(vm.annotation) && !vm.form.text && vm.form.tags.length === 0) {
+    if (isNew(vm.annotation) && !vm.state().text && vm.state().tags.length === 0) {
       vm.revert();
-    }
-  }
-
-  function onDestroy() {
-    // If the annotation component is destroyed whilst the annotation is being
-    // edited, persist temporary state so that we can restore it if the
-    // annotation editor is later recreated.
-    //
-    // The annotation component may be destroyed when switching accounts,
-    // when switching groups or when the component is scrolled off-screen.
-    if (vm.editing()) {
-      saveToDrafts(drafts, vm);
     }
   }
 
@@ -317,7 +245,7 @@ function AnnotationController(
       });
     } else {
       // User isn't logged in, save to drafts.
-      saveToDrafts(drafts, vm);
+      drafts.update(vm.annotation, vm.state());
     }
   }
 
@@ -366,14 +294,8 @@ function AnnotationController(
     */
   vm.edit = function() {
     if (!drafts.get(vm.annotation)) {
-      drafts.update(vm.annotation, {
-        tags: vm.annotation.tags,
-        text: vm.annotation.text,
-        isPrivate: permissions.isPrivate(vm.annotation.permissions,
-          session.state.userid),
-      });
+      drafts.update(vm.annotation, vm.state());
     }
-    restoreFromDrafts(drafts, vm);
   };
 
   /**
@@ -402,7 +324,7 @@ function AnnotationController(
     *   otherwise.
     */
   vm.hasContent = function() {
-    return vm.form.text.length > 0 || vm.form.tags.length > 0;
+    return vm.state().text.length > 0 || vm.state().tags.length > 0;
   };
 
   /**
@@ -448,7 +370,7 @@ function AnnotationController(
     * current group or with everyone).
     */
   vm.isShared = function() {
-    return !vm.isPrivate;
+    return !vm.state().isPrivate;
   };
 
   // Save on Meta + Enter or Ctrl + Enter.
@@ -479,7 +401,7 @@ function AnnotationController(
     reply.group = vm.annotation.group;
 
     if (session.state.userid) {
-      if (vm.isPrivate) {
+      if (vm.state().isPrivate) {
         reply.permissions = permissions.private();
       } else {
         reply.permissions = permissions.shared(reply.group);
@@ -566,7 +488,11 @@ function AnnotationController(
     if (!isReply(vm.annotation)) {
       permissions.setDefault(privacy);
     }
-    vm.isPrivate = (privacy === 'private');
+    drafts.update(vm.annotation, {
+      tags: vm.state().tags,
+      text: vm.state().text,
+      isPrivate: privacy === 'private'
+    });
   };
 
   vm.tagStreamURL = function(tag) {
@@ -609,11 +535,32 @@ function AnnotationController(
   };
 
   vm.setText = function (text) {
-    vm.form.text = text;
+    drafts.update(vm.annotation, {
+      isPrivate: vm.state().isPrivate,
+      tags: vm.state().tags,
+      text: text,
+    });
   };
 
   vm.setTags = function (tags) {
-    vm.form.tags = tags;
+    drafts.update(vm.annotation, {
+      isPrivate: vm.state().isPrivate,
+      tags: tags,
+      text: vm.state().text,
+    });
+  };
+
+  vm.state = function () {
+    var draft = drafts.get(vm.annotation);
+    if (draft) {
+      return draft;
+    }
+    return {
+      tags: vm.annotation.tags,
+      text: vm.annotation.text,
+      isPrivate: permissions.isPrivate(vm.annotation.permissions,
+        vm.annotation.user),
+    };
   };
 
   init();

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -1,10 +1,9 @@
 /* jshint node: true */
 'use strict';
 
-var angular = require('angular');
-
 var annotationMetadata = require('../annotation-metadata');
 var events = require('../events');
+var memoize = require('../util/memoize');
 var persona = require('../filter/persona');
 
 var isNew = annotationMetadata.isNew;
@@ -45,21 +44,6 @@ function updateModel(annotation, changes, permissions) {
     permissions: changes.isPrivate ?
       permissions.private() : permissions.shared(annotation.group),
   });
-}
-
-/** Update the view model from the domain model changes. */
-function updateViewModel($scope, vm) {
-  if (vm.annotation.links) {
-    vm.linkInContext = vm.annotation.links.incontext ||
-                       vm.annotation.links.html ||
-                       '';
-    vm.linkHTML = vm.annotation.links.html || '';
-  } else {
-    vm.linkInContext = '';
-    vm.linkHTML = '';
-  }
-
-  vm.documentMeta = annotationMetadata.domainAndTitle(vm.annotation);
 }
 
 // @ngInject
@@ -138,13 +122,6 @@ function AnnotationController(
       */
     newlyCreatedByHighlightButton = vm.annotation.$highlight || false;
 
-    // Call `onAnnotationUpdated()` whenever the "annotationUpdated" event is
-    // emitted. This event is emitted after changes to the annotation are
-    // successfully saved to the server, and also when changes to the
-    // annotation made by another client are received by this client from the
-    // server.
-    $rootScope.$on(events.ANNOTATION_UPDATED, onAnnotationUpdated);
-
     // When a new annotation is created, remove any existing annotations that
     // are empty
     $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, deleteIfNewAndEmpty);
@@ -171,8 +148,6 @@ function AnnotationController(
     // log in.
     saveNewHighlight();
 
-    updateView();
-
     // If this annotation is not a highlight and if it's new (has just been
     // created by the annotate button) or it has edits not yet saved to the
     // server - then open the editor on AnnotationController instantiation.
@@ -180,16 +155,6 @@ function AnnotationController(
       if (isNew(vm.annotation) || drafts.get(vm.annotation)) {
         vm.edit();
       }
-    }
-  }
-
-  function updateView() {
-    updateViewModel($scope, vm, permissions);
-  }
-
-  function onAnnotationUpdated(event, updatedDomainModel) {
-    if (updatedDomainModel.id === vm.annotation.id) {
-      updateView();
     }
   }
 
@@ -233,7 +198,6 @@ function AnnotationController(
       save(vm.annotation).then(function(model) {
         model.$$tag = vm.annotation.$$tag;
         $rootScope.$emit(events.ANNOTATION_CREATED, model);
-        updateView();
       });
     } else {
       // User isn't logged in, save to drafts.
@@ -410,8 +374,6 @@ function AnnotationController(
     drafts.remove(vm.annotation);
     if (isNew(vm.annotation)) {
       $rootScope.$emit(events.ANNOTATION_DELETED, vm.annotation);
-    } else {
-      updateView();
     }
   };
 
@@ -499,6 +461,17 @@ function AnnotationController(
     return isReply(vm.annotation);
   };
 
+  vm.links = function () {
+    if (vm.annotation.links) {
+      return {incontext: vm.annotation.links.incontext ||
+                         vm.annotation.links.html ||
+                         '',
+              html: vm.annotation.links.html};
+    } else {
+      return {incontext: '', html: ''};
+    }
+  };
+
   /**
    * Sets whether or not the controls for expanding/collapsing the body of
    * lengthy annotations should be shown.
@@ -541,6 +514,11 @@ function AnnotationController(
       isPrivate: permissions.isPrivate(vm.annotation.permissions,
         vm.annotation.user),
     };
+  };
+
+  var documentMeta = memoize(annotationMetadata.domainAndTitle);
+  vm.documentMeta = function () {
+    return documentMeta(vm.annotation);
   };
 
   init();

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -123,8 +123,17 @@ function AnnotationController(
     newlyCreatedByHighlightButton = vm.annotation.$highlight || false;
 
     // When a new annotation is created, remove any existing annotations that
-    // are empty
-    $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, deleteIfNewAndEmpty);
+    // are empty.
+    //
+    // This event is currently emitted with $emit rather than $broadcast so
+    // we have to listen for it on the $rootScope and manually de-register
+    // on destruction.
+    var removeNewAnnotListener =
+      $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, deleteIfNewAndEmpty);
+
+    vm.$onDestroy = function () {
+      removeNewAnnotListener();
+    };
 
     // Call `onGroupFocused()` whenever the currently-focused group changes.
     $scope.$on(events.GROUP_FOCUSED, onGroupFocused);

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -377,7 +377,7 @@ describe('annotation', function() {
       });
     });
 
-    describe('.isHighlight()', function() {
+    describe('#isHighlight()', function() {
       it('returns true for new highlights', function() {
         var annotation = fixtures.newHighlight();
 
@@ -906,8 +906,8 @@ describe('annotation', function() {
       });
     });
 
-    describe('onGroupFocused()', function() {
-      it('updates domainModel.group if the annotation is new', function () {
+    describe('when the focused group changes', function() {
+      it('moves new annotations to the focused group', function () {
         var annotation = fixtures.newAnnotation();
         annotation.group = 'old-group-id';
         createDirective(annotation);
@@ -918,7 +918,7 @@ describe('annotation', function() {
         assert.equal(annotation.group, 'new-group-id');
       });
 
-      it('does not update domainModel.group if the annotation is not new',
+      it('does not modify the group of saved annotations',
         function () {
           var annotation = fixtures.oldAnnotation();
           annotation.group = 'old-group-id';
@@ -931,7 +931,6 @@ describe('annotation', function() {
         }
       );
     });
-
 
     describe('reverting edits', function () {
       it('removes the current draft', function() {
@@ -950,7 +949,7 @@ describe('annotation', function() {
     });
 
     describe('tag display', function () {
-      it('displays annotation tags', function () {
+      it('displays links to tags on the stream', function () {
         var directive = createDirective({
           id: '1234',
           tags: ['atag']

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -887,6 +887,15 @@ describe('annotation', function() {
         assert.notCalled(fakeDrafts.remove);
       });
 
+      it('does not remove the current annotation if the scope was destroyed', function () {
+        var annotation = fixtures.newEmptyAnnotation();
+        var parts = createDirective(annotation);
+        parts.scope.$destroy();
+        $rootScope.$emit(events.BEFORE_ANNOTATION_CREATED,
+          fixtures.newAnnotation());
+        assert.notCalled(fakeDrafts.remove);
+      });
+
       it('does not remove the current annotation if it has text', function () {
         var annotation = fixtures.newAnnotation();
         createDirective(annotation);

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -1154,16 +1154,14 @@ describe('annotation', function() {
       });
 
       it('reverts to the most recently saved version', function () {
-        fakeStore.annotation.update = function (params, ann) {
-          return Promise.resolve(Object.assign({}, ann));
-        };
-
         var controller = createDirective({
           id: 'new-annot',
           user: 'acct:bill@localhost',
+          text: 'saved-text',
         }).controller;
         controller.edit();
         controller.form.text = 'New annotation text';
+
         return controller.save().then(function () {
           controller.edit();
           controller.form.text = 'Updated annotation text';
@@ -1171,7 +1169,7 @@ describe('annotation', function() {
         }).then(function () {
           controller.edit();
           controller.revert();
-          assert.equal(controller.form.text, 'Updated annotation text');
+          assert.equal(controller.form.text, controller.annotation.text);
         });
       });
     });

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -40,38 +40,29 @@ describe('annotation', function() {
       };
     }
 
-    function fakeGroups() {
-      return {
-        focused: function() {return {};},
-      };
-    }
-
     it('copies text from viewModel into domainModel', function() {
       var domainModel = {};
-      var viewModel = {form: {text: 'bar', tags: []}};
+      var viewModel = {state: sinon.stub.returns({text: 'bar', tags: []})};
 
-      updateDomainModel(domainModel, viewModel, fakePermissions(),
-                        fakeGroups());
+      updateDomainModel(domainModel, viewModel, fakePermissions());
 
-      assert.equal(domainModel.text, viewModel.form.text);
+      assert.equal(domainModel.text, viewModel.state().text);
     });
 
     it('overwrites text in domainModel', function() {
       var domainModel = {text: 'foo'};
-      var viewModel = {form: {text: 'bar', tags: []}};
+      var viewModel = {state: sinon.stub.returns({text: 'bar', tags: []})};
 
-      updateDomainModel(domainModel, viewModel, fakePermissions(),
-                        fakeGroups());
+      updateDomainModel(domainModel, viewModel, fakePermissions());
 
-      assert.equal(domainModel.text, viewModel.form.text);
+      assert.equal(domainModel.text, viewModel.state().text);
     });
 
     it('doesn\'t touch other properties in domainModel', function() {
       var domainModel = {foo: 'foo', bar: 'bar'};
-      var viewModel = {form: {foo: 'FOO', tags: []}};
+      var viewModel = {state: sinon.stub.returns({foo: 'FOO', tags: []})};
 
-      updateDomainModel(domainModel, viewModel, fakePermissions(),
-                        fakeGroups());
+      updateDomainModel(domainModel, viewModel, fakePermissions());
 
       assert.equal(
         domainModel.bar, 'bar',
@@ -82,13 +73,12 @@ describe('annotation', function() {
     it('copies tag texts from viewModel into domainModel', function() {
       var domainModel = {};
       var viewModel = {
-        form: {
+        state: sinon.stub().returns({
           tags: ['foo', 'bar'],
-        }
+        })
       };
 
-      updateDomainModel(domainModel, viewModel, fakePermissions(),
-                        fakeGroups());
+      updateDomainModel(domainModel, viewModel, fakePermissions());
 
       assert.deepEqual(domainModel.tags, ['foo', 'bar']);
     });
@@ -96,15 +86,15 @@ describe('annotation', function() {
     it('sets domainModel.permissions to private if vm.isPrivate', function() {
       var domainModel = {};
       var viewModel = {
-        isPrivate: true,
-        form: {
+        state: sinon.stub().returns({
+          isPrivate: true,
           text: 'foo',
-        },
+        }),
       };
       var permissions = fakePermissions();
       permissions.private = sinon.stub().returns('private permissions');
 
-      updateDomainModel(domainModel, viewModel, permissions, fakeGroups());
+      updateDomainModel(domainModel, viewModel, permissions);
 
       assert.equal(domainModel.permissions, 'private permissions');
     });
@@ -112,15 +102,15 @@ describe('annotation', function() {
     it('sets domainModel.permissions to shared if !vm.isPrivate', function() {
       var domainModel = {};
       var viewModel = {
-        isPrivate: false,
-        form: {
+        state: sinon.stub().returns({
+          isPrivate: false,
           text: 'foo',
-        },
+        }),
       };
       var permissions = fakePermissions();
       permissions.shared = sinon.stub().returns('shared permissions');
 
-      updateDomainModel(domainModel, viewModel, permissions, fakeGroups());
+      updateDomainModel(domainModel, viewModel, permissions);
 
       assert.equal(domainModel.permissions, 'shared permissions');
     });
@@ -570,7 +560,7 @@ describe('annotation', function() {
         'does not add the world readable principal if the parent is private',
         function() {
           var controller = createDirective(annotation).controller;
-          controller.isPrivate = true;
+          fakePermissions.isPrivate.returns(true);
           var reply = {};
           fakeAnnotationMapper.createAnnotation.returns(reply);
           controller.reply();
@@ -594,78 +584,49 @@ describe('annotation', function() {
     describe('#setPrivacy', function() {
       it('makes the annotation private when level is "private"', function() {
         var parts = createDirective();
-
-        // Make this annotation shared.
-        parts.controller.isPrivate = false;
-        fakePermissions.isPrivate.returns(false);
-
-        // Edit the annotation and make it private.
-        parts.controller.edit();
         parts.controller.setPrivacy('private');
-        fakePermissions.isPrivate.returns(true);
-
-        return parts.controller.save().then(function() {
-          // Verify that the permissions are updated once the annotation
-          // is saved.
-          assert.equal(parts.controller.isPrivate, true);
-        });
+        assert.calledWith(fakeDrafts.update, parts.controller.annotation, sinon.match({
+          isPrivate: true,
+        }));
       });
 
       it('makes the annotation shared when level is "shared"', function() {
         var parts = createDirective();
-        parts.controller.isPrivate = true;
-        parts.controller.edit();
-        parts.controller.form.text = 'test';
         parts.controller.setPrivacy('shared');
-        return parts.controller.save().then(function() {
-          assert.equal(parts.controller.isPrivate, false);
-        });
+        assert.calledWith(fakeDrafts.update, parts.controller.annotation, sinon.match({
+          isPrivate: false,
+        }));
       });
 
-      it('saves the "shared" visibility level to localStorage', function() {
+      it('sets the default visibility level if "shared"', function() {
         var parts = createDirective();
         parts.controller.edit();
         parts.controller.setPrivacy('shared');
-        parts.controller.form.text = 'test';
-        return parts.controller.save().then(function() {
-          assert.calledWith(fakePermissions.setDefault, 'shared');
-        });
+        assert.calledWith(fakePermissions.setDefault, 'shared');
       });
 
-      it('saves the "private" visibility level to localStorage', function() {
+      it('sets the default visibility if "private"', function() {
         var parts = createDirective();
         parts.controller.edit();
         parts.controller.setPrivacy('private');
-        return parts.controller.save().then(function() {
-          assert.calledWith(fakePermissions.setDefault, 'private');
-        });
+        assert.calledWith(fakePermissions.setDefault, 'private');
       });
 
       it('doesn\'t save the visibility if the annotation is a reply', function() {
-        var parts = createDirective();
-        parts.annotation.references = ['parent id'];
-        parts.controller.edit();
+        var parts = createDirective(fixtures.oldReply());
         parts.controller.setPrivacy('private');
-        return parts.controller.save().then(function() {
-          assert.notCalled(fakePermissions.setDefault);
-        });
+        assert.notCalled(fakePermissions.setDefault);
       });
     });
 
     describe('#hasContent', function() {
       it('returns false if the annotation has no tags or text', function() {
-        var controller = createDirective().controller;
-        controller.form.text = '';
-        controller.form.tags = [];
+        var controller = createDirective(fixtures.oldHighlight()).controller;
         assert.ok(!controller.hasContent());
       });
 
       it('returns true if the annotation has tags or text', function() {
-        var controller = createDirective().controller;
-        controller.form.text = 'bar';
-        assert.ok(controller.hasContent());
-        controller.form.text = '';
-        controller.form.tags = ['foo'];
+        var controller = createDirective(fixtures.oldAnnotation()).controller;
         assert.ok(controller.hasContent());
       });
     });
@@ -781,21 +742,19 @@ describe('annotation', function() {
         annotation = fixtures.newAnnotation();
       });
 
-      function controllerWithActionCreate() {
-        var controller = createDirective(annotation).controller;
-        controller.form.text = 'new annotation';
-        return controller;
+      function createController() {
+        return createDirective(annotation).controller;
       }
 
       it('removes the draft when saving an annotation succeeds', function () {
-        var controller = controllerWithActionCreate();
+        var controller = createController();
         return controller.save().then(function () {
           assert.calledWith(fakeDrafts.remove, annotation);
         });
       });
 
       it('emits annotationCreated when saving an annotation succeeds', function () {
-        var controller = controllerWithActionCreate();
+        var controller = createController();
         sandbox.spy($rootScope, '$emit');
         return controller.save().then(function() {
           assert.calledWith($rootScope.$emit, events.ANNOTATION_CREATED);
@@ -803,7 +762,7 @@ describe('annotation', function() {
       });
 
       it('flashes a generic error if the server can\'t be reached', function() {
-        var controller = controllerWithActionCreate();
+        var controller = createController();
         fakeStore.annotation.create = sinon.stub().returns(Promise.reject({
           status: 0
         }));
@@ -814,7 +773,7 @@ describe('annotation', function() {
       });
 
       it('flashes an error if saving the annotation fails on the server', function() {
-        var controller = controllerWithActionCreate();
+        var controller = createController();
         fakeStore.annotation.create = sinon.stub().returns(Promise.reject({
           status: 500,
           statusText: 'Server Error',
@@ -827,13 +786,14 @@ describe('annotation', function() {
       });
 
       it('doesn\'t flash an error when saving an annotation succeeds', function() {
-        var controller = controllerWithActionCreate();
-        controller.save();
-        assert.notCalled(fakeFlash.error);
+        var controller = createController();
+        return controller.save().then(function () {
+          assert.notCalled(fakeFlash.error);
+        });
       });
 
       it('shows a saving indicator when saving an annotation', function() {
-        var controller = controllerWithActionCreate();
+        var controller = createController();
         var create;
         fakeStore.annotation.create = sinon.stub().returns(new Promise(function (resolve) {
           create = resolve;
@@ -847,7 +807,7 @@ describe('annotation', function() {
       });
 
       it('does not remove the draft if saving fails', function () {
-        var controller = controllerWithActionCreate();
+        var controller = createController();
         var failCreation;
         fakeStore.annotation.create = sinon.stub().returns(new Promise(function (resolve, reject) {
           failCreation = reject;
@@ -885,18 +845,17 @@ describe('annotation', function() {
 
       beforeEach(function() {
         annotation = fixtures.defaultAnnotation();
+        fakeDrafts.get.returns({text: 'unsaved change'});
       });
 
-      function controllerWithActionEdit() {
-        var controller = createDirective(annotation).controller;
-        controller.form.text = 'updated text';
-        return controller;
+      function createController() {
+        return createDirective(annotation).controller;
       }
 
       it(
         'flashes a generic error if the server cannot be reached',
         function() {
-          var controller = controllerWithActionEdit();
+          var controller = createController();
           fakeStore.annotation.update = sinon.stub().returns(Promise.reject({
             status: -1
           }));
@@ -907,31 +866,25 @@ describe('annotation', function() {
         }
       );
 
-      it(
-        'flashes an error if saving the annotation fails on the server',
-        function() {
-          var controller = controllerWithActionEdit();
-          fakeStore.annotation.update = sinon.stub().returns(Promise.reject({
-            status: 500,
-            statusText: 'Server Error',
-            data: {}
-          }));
-          return controller.save().then(function() {
-            assert.calledWith(fakeFlash.error,
-              '500 Server Error', 'Saving annotation failed');
-          });
-        }
-      );
+      it('flashes an error if saving the annotation fails on the server', function () {
+        var controller = createController();
+        fakeStore.annotation.update = sinon.stub().returns(Promise.reject({
+          status: 500,
+          statusText: 'Server Error',
+          data: {}
+        }));
+        return controller.save().then(function() {
+          assert.calledWith(fakeFlash.error,
+            '500 Server Error', 'Saving annotation failed');
+        });
+      });
 
-      it(
-        'doesn\'t flash an error if saving the annotation succeeds',
-        function() {
-          var controller = controllerWithActionEdit();
-          controller.form.text = 'updated text';
-          controller.save();
+      it('doesn\'t flash an error if saving the annotation succeeds', function () {
+        var controller = createController();
+        return controller.save().then(function () {
           assert.notCalled(fakeFlash.error);
-        }
-      );
+        });
+      });
     });
 
     describe('drafts', function() {
@@ -950,8 +903,8 @@ describe('annotation', function() {
           text: 'unsaved-text'
         });
         var controller = createDirective().controller;
-        assert.deepEqual(controller.form.tags, ['unsaved-tag']);
-        assert.equal(controller.form.text, 'unsaved-text');
+        assert.deepEqual(controller.state().tags, ['unsaved-tag']);
+        assert.equal(controller.state().text, 'unsaved-text');
       });
 
       it('removes the draft when changes are discarded', function() {
@@ -964,8 +917,7 @@ describe('annotation', function() {
       it('removes the draft when changes are saved', function() {
         var annotation = fixtures.defaultAnnotation();
         var controller = createDirective(annotation).controller;
-        controller.edit();
-        controller.form.text = 'test annotation';
+        fakeDrafts.get.returns({text: 'unsaved changes'});
         return controller.save().then(function() {
           assert.calledWith(fakeDrafts.remove, annotation);
         });
@@ -973,29 +925,26 @@ describe('annotation', function() {
     });
 
     describe('onAnnotationUpdated()', function() {
-      it('updates vm.form.text', function() {
+      it('updates vm.annotation', function() {
         var parts = createDirective();
         var updatedModel = {
           id: parts.annotation.id,
-          text: 'new text',
+          links: {html: 'http://hyp.is/new-link'}
         };
-
+        parts.controller.annotation = updatedModel;
         $rootScope.$emit(events.ANNOTATION_UPDATED, updatedModel);
-
-        assert.equal(parts.controller.form.text, 'new text');
+        assert.equal(parts.controller.linkHTML, 'http://hyp.is/new-link');
       });
 
       it('doesn\'t update if a different annotation was updated', function() {
         var parts = createDirective();
-        parts.controller.form.text = 'original text';
         var updatedModel = {
           id: 'different annotation id',
-          text: 'new text',
+          links: {html: 'http://hyp.is/new-link'},
         };
 
         $rootScope.$emit(events.ANNOTATION_UPDATED, updatedModel);
-
-        assert.equal(parts.controller.form.text, 'original text');
+        assert.notEqual(parts.controller.linkHTML, 'http://hyp.is/new-link');
       });
     });
 
@@ -1009,9 +958,8 @@ describe('annotation', function() {
       });
 
       it('does not remove the current annotation if is is not new', function () {
-        var parts = createDirective(fixtures.defaultAnnotation());
-        parts.controller.form.text = '';
-        parts.controller.form.tags = [];
+        createDirective(fixtures.defaultAnnotation());
+        fakeDrafts.get.returns({text: '', tags: []});
         $rootScope.$emit(events.BEFORE_ANNOTATION_CREATED,
           fixtures.newAnnotation());
         assert.notCalled(fakeDrafts.remove);
@@ -1019,8 +967,8 @@ describe('annotation', function() {
 
       it('does not remove the current annotation if it has text', function () {
         var annotation = fixtures.newAnnotation();
-        var parts = createDirective(annotation);
-        parts.controller.form.text = 'An incomplete thought';
+        createDirective(annotation);
+        fakeDrafts.get.returns({text: 'An incomplete thought'});
         $rootScope.$emit(events.BEFORE_ANNOTATION_CREATED,
           fixtures.newAnnotation());
         assert.notCalled(fakeDrafts.remove);
@@ -1028,42 +976,12 @@ describe('annotation', function() {
 
       it('does not remove the current annotation if it has tags', function () {
         var annotation = fixtures.newAnnotation();
-        var parts = createDirective(annotation);
-        parts.controller.form.tags = ['a-tag'];
+        createDirective(annotation);
+        fakeDrafts.get.returns({tags: ['a-tag']});
         $rootScope.$emit(events.BEFORE_ANNOTATION_CREATED,
           fixtures.newAnnotation());
         assert.notCalled(fakeDrafts.remove);
       });
-    });
-
-    describe('when component is destroyed', function () {
-      it('if the annotation is being edited it updates drafts', function() {
-        var parts = createDirective();
-        parts.controller.isPrivate = true;
-        parts.controller.edit();
-        parts.controller.form.text = 'unsaved-text';
-        parts.controller.form.tags = [];
-        fakeDrafts.get = sinon.stub().returns({
-          text: 'old-draft'
-        });
-        fakeDrafts.update = sinon.stub();
-
-        parts.scope.$broadcast('$destroy');
-
-        assert.calledWith(
-          fakeDrafts.update,
-          parts.annotation, {isPrivate:true, tags:[], text:'unsaved-text'});
-      });
-
-      it('if the annotation isn\'t being edited it doesn\'t update drafts', function() {
-         var parts = createDirective();
-         parts.controller.isPrivate = true;
-         fakeDrafts.update = sinon.stub();
-
-         parts.scope.$broadcast('$destroy');
-
-         assert.notCalled(fakeDrafts.update);
-       });
     });
 
     describe('onGroupFocused()', function() {
@@ -1094,27 +1012,11 @@ describe('annotation', function() {
 
 
     describe('reverting edits', function () {
-      it('restores the original text', function() {
-        var controller = createDirective({
-          id: 'test-annotation-id',
-          user: 'acct:bill@localhost',
-          text: 'Initial annotation body text',
-        }).controller;
+      it('removes the current draft', function() {
+        var controller = createDirective(fixtures.defaultAnnotation()).controller;
         controller.edit();
-        controller.form.text = 'changed by test code';
         controller.revert();
-        assert.equal(controller.form.text, controller.annotation.text);
-      });
-
-      it('clears the text if the text was originally empty', function() {
-        var controller = createDirective({
-          id: 'test-annotation-id',
-          user: 'acct:bill@localhost',
-        }).controller;
-        controller.edit();
-        controller.form.text = 'this should be reverted';
-        controller.revert();
-        assert.equal(controller.form.text, '');
+        assert.calledWith(fakeDrafts.remove, controller.annotation);
       });
 
       it('deletes the annotation if it was new', function () {

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -11,6 +11,12 @@ var util = require('./util');
 
 var inject = angular.mock.inject;
 
+var fakeDocumentMeta = {
+  domain: 'docs.io',
+  titleLink: 'http://docs.io/doc.html',
+  titleText: 'Dummy title',
+};
+
 /**
  * Returns the annotation directive with helpers stubbed out.
  */
@@ -19,10 +25,13 @@ function annotationDirective() {
 
   var annotation = proxyquire('../annotation', {
     angular: testUtil.noCallThru(angular),
-    '../filter/document-domain': noop,
-    '../filter/document-title': noop,
     '../filter/persona': {
       username: noop,
+    },
+    '../annotation-metadata': {
+      domainAndTitle: function (annot) {
+        return fakeDocumentMeta;
+      },
     }
   });
 
@@ -684,6 +693,14 @@ describe('annotation', function() {
       });
     });
 
+    describe('#documentMeta()', function () {
+      it('returns the domain, title link and text for the annotation', function () {
+        var annot = fixtures.defaultAnnotation();
+        var controller = createDirective(annot).controller;
+        assert.deepEqual(controller.documentMeta(), fakeDocumentMeta);
+      });
+    });
+
     describe('saving a new annotation', function() {
       var annotation;
 
@@ -853,30 +870,6 @@ describe('annotation', function() {
       });
     });
 
-    describe('onAnnotationUpdated()', function() {
-      it('updates vm.annotation', function() {
-        var parts = createDirective();
-        var updatedModel = {
-          id: parts.annotation.id,
-          links: {html: 'http://hyp.is/new-link'}
-        };
-        parts.controller.annotation = updatedModel;
-        $rootScope.$emit(events.ANNOTATION_UPDATED, updatedModel);
-        assert.equal(parts.controller.linkHTML, 'http://hyp.is/new-link');
-      });
-
-      it('doesn\'t update if a different annotation was updated', function() {
-        var parts = createDirective();
-        var updatedModel = {
-          id: 'different annotation id',
-          links: {html: 'http://hyp.is/new-link'},
-        };
-
-        $rootScope.$emit(events.ANNOTATION_UPDATED, updatedModel);
-        assert.notEqual(parts.controller.linkHTML, 'http://hyp.is/new-link');
-      });
-    });
-
     describe('when another new annotation is created', function () {
       it('removes the current annotation if empty', function () {
         var annotation = fixtures.newEmptyAnnotation();
@@ -973,7 +966,7 @@ describe('annotation', function() {
     });
 
     describe('annotation links', function () {
-      it('linkInContext uses the in-context links when available', function () {
+      it('uses the in-context links when available', function () {
         var annotation = Object.assign({}, fixtures.defaultAnnotation(), {
           links: {
             html: 'https://test.hypothes.is/a/deadbeef',
@@ -981,22 +974,20 @@ describe('annotation', function() {
           },
         });
         var controller = createDirective(annotation).controller;
-
-        assert.equal(controller.linkInContext, annotation.links.incontext);
+        assert.equal(controller.links().incontext, annotation.links.incontext);
       });
 
-      it('linkInContext falls back to the HTML link when in-context links are missing', function () {
+      it('falls back to the HTML link when in-context links are missing', function () {
         var annotation = Object.assign({}, fixtures.defaultAnnotation(), {
           links: {
             html: 'https://test.hypothes.is/a/deadbeef',
           },
         });
         var controller = createDirective(annotation).controller;
-
-        assert.equal(controller.linkInContext, annotation.links.html);
+        assert.equal(controller.links().html, annotation.links.html);
       });
 
-      it('linkHTML uses the HTML link when available', function () {
+      it('uses the HTML link when available', function () {
         var annotation = Object.assign({}, fixtures.defaultAnnotation(), {
           links: {
             html: 'https://test.hypothes.is/a/deadbeef',
@@ -1004,22 +995,19 @@ describe('annotation', function() {
           },
         });
         var controller = createDirective(annotation).controller;
-
-        assert.equal(controller.linkHTML, annotation.links.html);
+        assert.equal(controller.links().html, annotation.links.html);
       });
 
-      it('linkInContext is blank when unknown', function () {
+      it('in-context link is blank when unknown', function () {
         var annotation = fixtures.defaultAnnotation();
         var controller = createDirective(annotation).controller;
-
-        assert.equal(controller.linkInContext, '');
+        assert.equal(controller.links().incontext, '');
       });
 
-      it('linkHTML is blank when unknown', function () {
+      it('HTML is blank when unknown', function () {
         var annotation = fixtures.defaultAnnotation();
         var controller = createDirective(annotation).controller;
-
-        assert.equal(controller.linkHTML, '');
+        assert.equal(controller.links().html, '');
       });
     });
   });

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -22,7 +22,7 @@
           target="_blank" ng-if="vm.group() && vm.group().url" href="{{vm.group().url}}">
           <i class="h-icon-group"></i><span class="annotation-header__group-name">{{vm.group().name}}</span>
         </a>
-        <span ng-show="vm.isPrivate"
+        <span ng-show="vm.state().isPrivate"
           title="This annotation is visible only to you.">
           <i class="h-icon-lock"></i><span class="annotation-header__group-name" ng-show="!vm.group().url">Only me</span>
         </span>
@@ -75,8 +75,8 @@
       collapse="vm.collapseBody"
       collapsed-height="400"
       overflow-hysteresis="20"
-      content-data="vm.form.text">
-      <markdown text="vm.form.text"
+      content-data="vm.state().text">
+      <markdown text="vm.state().text"
         on-edit-text="vm.setText(text)"
         read-only="!vm.editing()">
       </markdown>
@@ -86,14 +86,14 @@
 
   <!-- Tags -->
   <div class="annotation-body form-field" ng-if="vm.editing()">
-    <tag-editor tags="vm.form.tags"
+    <tag-editor tags="vm.state().tags"
                 on-edit-tags="vm.setTags(tags)"></tag-editor>
   </div>
 
   <div class="annotation-body u-layout-row tags tags-read-only"
-       ng-if="(vm.canCollapseBody || vm.form.tags.length) && !vm.editing()">
+       ng-if="(vm.canCollapseBody || vm.state().tags.length) && !vm.editing()">
     <ul class="tag-list">
-      <li class="tag-item" ng-repeat="tag in vm.form.tags">
+      <li class="tag-item" ng-repeat="tag in vm.state().tags">
         <a ng-href="{{vm.tagStreamURL(tag)}}" target="_blank">{{tag}}</a>
       </li>
     </ul>
@@ -171,7 +171,7 @@
         <annotation-share-dialog
           group="vm.group()"
           uri="vm.linkInContext"
-          is-private="vm.isPrivate"
+          is-private="vm.state().isPrivate"
           is-open="vm.showShareDialog"
           on-close="vm.showShareDialog = false">
         </annotation-share-dialog>

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -28,14 +28,14 @@
         </span>
         <i class="h-icon-border-color" ng-show="vm.isHighlight() && !vm.editing()" title="This is a highlight. Click 'edit' to add a note or tag."></i>
         <span ng-if="::vm.showDocumentInfo">
-          <span class="annotation-citation" ng-if="vm.documentMeta.titleLink">
-            on "<a ng-href="{{vm.documentMeta.titleLink}}">{{vm.documentMeta.titleText}}</a>"
+          <span class="annotation-citation" ng-if="vm.documentMeta().titleLink">
+            on "<a ng-href="{{vm.documentMeta().titleLink}}">{{vm.documentMeta().titleText}}</a>"
           </span>
-          <span class="annotation-citation" ng-if="!vm.documentMeta.titleLink">
-            on "{{vm.documentMeta.titleText}}"
+          <span class="annotation-citation" ng-if="!vm.documentMeta().titleLink">
+            on "{{vm.documentMeta().titleText}}"
           </span>
           <span class="annotation-citation-domain"
-                ng-if="vm.documentMeta.domain">({{vm.documentMeta.domain}})</span>
+                ng-if="vm.documentMeta().domain">({{vm.documentMeta().domain}})</span>
         </span>
       </span>
     </span>
@@ -45,7 +45,7 @@
     <timestamp
       class-name="'annotation-header__timestamp'"
       timestamp="vm.updated()"
-      href="vm.linkHTML"
+      href="vm.links().html"
       ng-if="!vm.editing() && vm.updated()"></timestamp>
   </header>
 
@@ -170,7 +170,7 @@
         </button>
         <annotation-share-dialog
           group="vm.group()"
-          uri="vm.linkInContext"
+          uri="vm.links().incontext"
           is-private="vm.state().isPrivate"
           is-open="vm.showShareDialog"
           on-close="vm.showShareDialog = false">


### PR DESCRIPTION
_Note: This PR depends on #7_

This PR simplifies the annotation component by removing the private state (annotation object, modified tags/text/privacy, editing vs. viewing state) which duplicated data from the annotation it was displaying and the drafts service.

This PR makes the displayed annotation a function of:
 1. The current saved or just-created annotation (accessed via `vm.annotation`)
 2. The current draft (accessed via `drafts.get(vm.annotation)`)
 3. A flag indicating whether the annotation is being saved. This is still kept in `AnnotationController` at the moment but will move to the app state in future

As a consequence of this cleanup, many issues related to drafts re-appearing when switching groups or when clicking Cancel and switching groups have been fixed. Many tests of external <-> private state syncing for the `<annotation>` component have now been rendered redundant.

I would recommend commit-by-commit review, but testing the whole set together.

Fixes hypothesis/h#3380
Fixes hypothesis/h#3560
Fixes hypothesis/h#3561