### PR TITLE
Fix new replies being moved to the newly focused group

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -175,7 +175,7 @@ function AnnotationController(
 
   function onGroupFocused() {
     // New annotations move to the new group, when a new group is focused.
-    if (isNew(vm.annotation)) {
+    if (isNew(vm.annotation) && !isReply(vm.annotation)) {
       vm.annotation.group = groups.focused().id;
     }
   }

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -359,19 +359,18 @@ function AnnotationController(
     */
   vm.reply = function() {
     var references = (vm.annotation.references || []).concat(vm.annotation.id);
-    var reply = annotationMapper.createAnnotation({
-      references: references,
-      uri: vm.annotation.uri
-    });
-    reply.group = vm.annotation.group;
-
+    var group = vm.annotation.group;
+    var replyPermissions;
     if (session.state.userid) {
-      if (vm.state().isPrivate) {
-        reply.permissions = permissions.private();
-      } else {
-        reply.permissions = permissions.shared(reply.group);
-      }
+      replyPermissions = vm.state().isPrivate ?
+        permissions.private() : permissions.shared(group);
     }
+    annotationMapper.createAnnotation({
+      group: group,
+      references: references,
+      permissions: replyPermissions,
+      uri: vm.annotation.uri,
+    });
   };
 
   /**

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -927,18 +927,26 @@ describe('annotation', function() {
         assert.equal(annotation.group, 'new-group-id');
       });
 
-      it('does not modify the group of saved annotations',
-        function () {
-          var annotation = fixtures.oldAnnotation();
-          annotation.group = 'old-group-id';
-          createDirective(annotation);
-          fakeGroups.focused = sandbox.stub().returns({id: 'new-group-id'});
+      it('does not move replies to the focused group', function () {
+        var annotation = fixtures.newReply();
+        fakeGroups.focused = sandbox.stub().returns({id: 'new-group-id'});
+        createDirective(annotation);
+        fakeGroups.focused = sandbox.stub().returns({id: 'new-group-id-2'});
+        $rootScope.$broadcast(events.GROUP_FOCUSED);
 
-          $rootScope.$broadcast(events.GROUP_FOCUSED);
+        assert.equal(annotation.group, 'new-group-id');
+      });
 
-          assert.equal(annotation.group, 'old-group-id');
-        }
-      );
+      it('does not modify the group of saved annotations', function () {
+        var annotation = fixtures.oldAnnotation();
+        annotation.group = 'old-group-id';
+        createDirective(annotation);
+        fakeGroups.focused = sandbox.stub().returns({id: 'new-group-id'});
+
+        $rootScope.$broadcast(events.GROUP_FOCUSED);
+
+        assert.equal(annotation.group, 'old-group-id');
+      });
     });
 
     describe('reverting edits', function () {

--- a/h/static/scripts/test/annotation-fixtures.js
+++ b/h/static/scripts/test/annotation-fixtures.js
@@ -30,6 +30,18 @@ function newAnnotation() {
   };
 }
 
+/** Return a new reply */
+function newReply() {
+  return {
+    id: undefined,
+    $highlight: undefined,
+    target: ['foo', 'bar'],
+    references: ['parent-id'],
+    text: 'Annotation text',
+    tags: ['tag_1', 'tag_2']
+  };
+}
+
 /** Return a new annotation which has no tags or text. */
 function newEmptyAnnotation() {
   return {
@@ -111,6 +123,7 @@ module.exports = {
   newAnnotation: newAnnotation,
   newEmptyAnnotation: newEmptyAnnotation,
   newHighlight: newHighlight,
+  newReply: newReply,
   oldAnnotation: oldAnnotation,
   oldHighlight: oldHighlight,
   oldPageNote: oldPageNote,


### PR DESCRIPTION
_This builds on top of #8_

Only new top level annotations should be moved to the new group when
switching groups.

Fixes hypothesis/h#3559
