### PR TITLE
Remove the ban on using console.log() in tests

### DIFF
--- a/h/static/scripts/karma-phantomjs-polyfill.js
+++ b/h/static/scripts/karma-phantomjs-polyfill.js
@@ -22,13 +22,3 @@ require('./polyfills');
 // PhantomJS 2.x includes a `URL` constructor so `new URL` works
 // but it appears to be broken.
 require('js-polyfills/url');
-
-// disallow console output during tests
-['debug', 'log', 'warn', 'error'].forEach(function (method) {
-  var realFn = window.console[method];
-  window.console[method] = function () {
-    var args = [].slice.apply(arguments);
-    realFn.apply(console, args);
-    throw new Error('Tests must not log console warnings');
-  };
-});


### PR DESCRIPTION
This was intended to prevent console.{log,warn,...} calls accidentally
being left in test code.

However the result was very confusing for H developers who only
occassionally worked with the H client test suite.

This problem is better solved by a linter.