### PR TITLE
Simplify request preparation in `store.js`

### DIFF
--- a/h/static/scripts/store.js
+++ b/h/static/scripts/store.js
@@ -6,16 +6,10 @@ var get = require('lodash.get');
 var retryUtil = require('./retry-util');
 var urlUtil = require('./util/url-util');
 
-function prependTransform(defaults, transform) {
-  // We can't guarantee that the default transformation is an array
-  var result = angular.isArray(defaults) ? defaults.slice(0) : [defaults];
-  result.unshift(transform);
-  return result;
-}
-
-// stripInternalProperties returns a shallow clone of `obj`, lacking all
-// properties that begin with a character that marks them as internal
-// (currently '$' or '_');
+/**
+ * Return a shallow clone of `obj` with all client-only properties removed.
+ * Client-only properties are marked by a '$' prefix.
+ */
 function stripInternalProperties(obj) {
   var result = {};
 
@@ -95,15 +89,11 @@ function createAPICall($http, links, route) {
       var descriptor = get(links, route);
       var url = urlUtil.replaceURLParams(descriptor.url, params);
       var req = {
-        data: data,
+        data: data ? stripInternalProperties(data) : null,
         method: descriptor.method,
         params: url.params,
         paramSerializer: serializeParams,
         url: url.url,
-        transformRequest: prependTransform(
-          $http.defaults.transformRequest,
-          stripInternalProperties
-        ),
       };
       return $http(req);
     }).then(function (result) {

--- a/h/static/scripts/store.js
+++ b/h/static/scripts/store.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var angular = require('angular');
 var get = require('lodash.get');
 
 var retryUtil = require('./retry-util');
@@ -33,8 +32,8 @@ function forEachSorted(obj, iterator, context) {
 
 
 function serializeValue(v) {
-  if (angular.isObject(v)) {
-    return angular.isDate(v) ? v.toISOString() : angular.toJson(v);
+  if (typeof v === 'object') {
+    return v instanceof Date ? v.toISOString() : JSON.stringify(v);
   }
   return v;
 }
@@ -63,8 +62,8 @@ function serializeParams(params) {
     if (value === null || typeof value === 'undefined') {
       return;
     }
-    if (angular.isArray(value)) {
-      angular.forEach(value, function(v, k) {
+    if (Array.isArray(value)) {
+      value.forEach(function(v) {
         parts.push(encodeUriQuery(key)  + '=' + encodeUriQuery(serializeValue(v)));
       });
     } else {


### PR DESCRIPTION
This PR includes a couple of cleanups and simplifications to the code that prepares API requests in store.js:

1. Strip internal properties from annotation objects using just a function call rather than using Angular's $http transform mechanism.
2. Use ES standard library functions in favor of Angular utility methods unless there is a clear documented reason not to do so.