### PR TITLE
Selection tabs tweaks.

### DIFF
--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -63,7 +63,7 @@ function initialState(settings) {
 
     filterQuery: null,
 
-    selectedTab: uiConstants.TAB_ANNOTATIONS,
+    selectedTab: undefined,
 
     // Key by which annotations are currently sorted.
     sortKey: 'Location',

--- a/h/static/scripts/directive/selection-tabs.js
+++ b/h/static/scripts/directive/selection-tabs.js
@@ -13,6 +13,7 @@ module.exports = function () {
     },
     restrict: 'E',
     scope: {
+      isLoading: '<',
       selectedTab: '<',
       totalAnnotations: '<',
       totalNotes: '<',

--- a/h/static/scripts/directive/test/selection-tabs-test.js
+++ b/h/static/scripts/directive/test/selection-tabs-test.js
@@ -28,12 +28,11 @@ describe('selectionTabs', function () {
       });
 
       var tabs = elem[0].querySelectorAll('li');
-      var sups = elem[0].querySelectorAll('sup');
 
       assert.include(tabs[0].textContent, "Annotations");
       assert.include(tabs[1].textContent, "Notes");
-      assert.include(sups[0].textContent, "123");
-      assert.include(sups[1].textContent, "456");
+      assert.include(tabs[0].textContent, "123");
+      assert.include(tabs[1].textContent, "456");
     });
 
     it('should display annotations tab as selected', function () {

--- a/h/static/scripts/root-thread.js
+++ b/h/static/scripts/root-thread.js
@@ -59,7 +59,7 @@ function RootThread($rootScope, annotationUI, features, searchFilter, viewFilter
     }
 
     var threadFilterFn;
-    if (features.flagEnabled('selection_tabs') && !state.filterQuery) {
+    if (features.flagEnabled('selection_tabs') && !state.filterQuery && state.selectedTab) {
       threadFilterFn = function (thread) {
         if (state.selectedTab === uiConstants.TAB_ANNOTATIONS) {
           return thread.annotation && metadata.isAnnotation(thread.annotation);

--- a/h/static/scripts/test/annotation-metadata-test.js
+++ b/h/static/scripts/test/annotation-metadata-test.js
@@ -237,12 +237,12 @@ describe('annotation-metadata', function () {
 
   describe ('.isAnnotation', function () {
     it ('returns true if an annotation is a top level annotation', function () {
-      assert(annotationMetadata.isAnnotation({
+      assert.isArray(annotationMetadata.isAnnotation({
         target: [{selector: []}]
       }));
     });
-    it ('returns false if an annotation has no target', function () {
-      assert.equal(annotationMetadata.isAnnotation({}), undefined);
+    it ('returns undefined if an annotation has no target', function () {
+      assert.isUndefined(annotationMetadata.isAnnotation({}));
     });
   });
 });

--- a/h/static/scripts/test/root-thread-test.js
+++ b/h/static/scripts/test/root-thread-test.js
@@ -196,7 +196,7 @@ describe('rootThread', function () {
       var threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
 
       var annotation = {target: [{ selector: {} }]};
-      assert(threadFilterFn({annotation: annotation}));
+      assert.isDefined(threadFilterFn({annotation: annotation}));
     });
 
     it('generates a thread filter function to match notes', function () {
@@ -209,7 +209,7 @@ describe('rootThread', function () {
       rootThread.thread(fakeAnnotationUI.state);
       var threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
 
-      assert.equal(threadFilterFn(fakeBuildThread), true);
+      assert.isTrue(threadFilterFn(fakeBuildThread));
     });
 
     it('generates a thread filter function for annotations, when all annotations are of type notes', function () {
@@ -222,7 +222,7 @@ describe('rootThread', function () {
       rootThread.thread(fakeAnnotationUI.state);
       var threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
 
-      assert.equal(threadFilterFn(fakeBuildThread), undefined);
+      assert.isUndefined(threadFilterFn(fakeBuildThread));
     });
   });
 
@@ -238,7 +238,7 @@ describe('rootThread', function () {
       var filterFn = fakeBuildThread.args[0][1].filterFn;
 
       fakeViewFilter.filter.returns([annotation]);
-      assert.equal(filterFn(annotation), true);
+      assert.isTrue(filterFn(annotation));
       assert.calledWith(fakeViewFilter.filter, sinon.match([annotation]),
         filters);
     });

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -95,9 +95,15 @@ module.exports = function WidgetController(
   var visibleThreads = new VirtualThreadList($scope, window, thread());
   annotationUI.subscribe(function () {
     visibleThreads.setRootThread(thread());
+
     $scope.totalAnnotations = countAnnotations(annotationUI.getState().annotations);
     $scope.totalNotes = countNotes(annotationUI.getState().annotations);
-    $scope.selectedTab = annotationUI.getState().selectedTab;
+
+    if (annotationUI.getState().selectedTab) {
+      $scope.selectedTab = annotationUI.getState().selectedTab;
+    } else {
+      $scope.selectedTab = uiConstants.TAB_ANNOTATIONS;
+    }
   });
 
   visibleThreads.on('changed', function (state) {
@@ -381,6 +387,7 @@ module.exports = function WidgetController(
   };
 
   $scope.isLoading = isLoading;
+  annotationUI.selectTab(uiConstants.TAB_ANNOTATIONS);
   $scope.tabAnnotations = uiConstants.TAB_ANNOTATIONS;
   $scope.tabNotes = uiConstants.TAB_NOTES;
   $scope.selectionTabsFlagEnabled = features.flagEnabled('selection_tabs');

--- a/h/static/styles/app.scss
+++ b/h/static/styles/app.scss
@@ -38,7 +38,7 @@ body {
 
   @include grey-background;
   font-family: $sans-font-family;
-  font-weight: 300;
+  font-weight: normal;
   padding: $sidebar-h-padding;
   padding-top: $sidebar-h-padding + $top-bar-height;
   -webkit-overflow-scrolling: touch;

--- a/h/static/styles/selection-tabs.scss
+++ b/h/static/styles/selection-tabs.scss
@@ -1,17 +1,33 @@
 .selection-tabs {
   display: flex;
   flex-direction: row;
-  color: $grey-4;
+  color: $grey-5;
   @include font-normal;
-  font-weight: bold;
-  margin: 10px 0px;
+  margin: 0px 0px 10px 0px;
+
+  &:hover {
+    color: $grey-6;
+  }
 }
 
 .selection-tabs--selected {
   color: $grey-6;
+  font-weight: bold;
 }
 
 .selection-tabs__type {
   margin-right: 20px;
   cursor: pointer;
+  min-width: 85px;
+  min-height: 18px;
+}
+
+.selection-tabs__count {
+  position: relative;
+  bottom: 3px;
+  font-size: 10px;
+}
+
+.selection-loading {
+  text-align: center;
 }

--- a/h/templates/client/selection_tabs.html
+++ b/h/templates/client/selection_tabs.html
@@ -2,10 +2,26 @@
 <ul class="selection-tabs">
   <li class="selection-tabs__type" ng-class="{'selection-tabs--selected': vm.selectedTab === vm.tabAnnotations}" ng-click="vm.selectTab('annotation')">
     Annotations
-    <sup ng-if="vm.totalAnnotations > 0">{{ vm.totalAnnotations }}</sup>
+    <span class="selection-tabs__count" ng-if="vm.totalAnnotations > 0">{{ vm.totalAnnotations }}</sup>
   </li>
   <li class="selection-tabs__type" ng-class="{'selection-tabs--selected': vm.selectedTab === vm.tabNotes}" ng-click="vm.selectTab('note')">
     Notes
-    <sup ng-if="vm.totalNotes > 0">{{ vm.totalNotes }}</sup>
+    <span class="selection-tabs__count" ng-if="vm.totalNotes > 0">{{ vm.totalNotes }}</sup>
+  </li>
+</ul>
+<ul ng-if="!vm.isLoading()">
+  <li ng-if="vm.selectedTab === vm.tabNotes && vm.totalNotes === 0"  class="annotation-unavailable-message">
+    <p class="annotation-unavailable-message__label">
+      There are no notes available.
+      <br />
+      Create one by clicking the
+      <i class="help-icon h-icon-note"></i>
+      button.
+    </p>
+  </li>
+  <li ng-if="vm.selectedTab === vm.tabAnnotations && vm.totalAnnotations === 0"  class="annotation-unavailable-message">
+    <p class="annotation-unavailable-message__label">
+      There are no annotations available.
+    </p>
   </li>
 </ul>

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -3,6 +3,7 @@
 (See gh2642 for rationale for 'ng-show="true"')
  -->
 <selection-tabs ng-if="selectionTabsFlagEnabled && !search.query() && selectedAnnotationCount() <= 0"
+  is-loading="isLoading"
   selected-tab="selectedTab"
   total-annotations="totalAnnotations"
   total-notes="totalNotes"


### PR DESCRIPTION
Trello:
https://trello.com/c/OLdLTlLT/342-separate-annotations-and-notes

Original PR:
https://github.com/hypothesis/h/pull/3504

Fix PR comments including some UI tweaks and bug fixes.
Hide no annotations/notes message when annotations are still loading.
Fix broken standalone note page.
If selected annotation/note is deleted, default selected tab to annotation.