### PR TITLE
Remove phantom-ownpropertynames

### DIFF
--- a/h/static/scripts/karma.config.js
+++ b/h/static/scripts/karma.config.js
@@ -59,11 +59,7 @@ module.exports = function(config) {
       configure: function (bundle) {
         bundle
           .transform('coffeeify')
-          .plugin('proxyquire-universal')
-          // fix for Proxyquire in PhantomJS 1.x.
-          // See https://github.com/bitwit/proxyquireify-phantom-menace
-          .require(require.resolve('phantom-ownpropertynames/implement'),
-            {entry: true});
+          .plugin('proxyquire-universal');
       }
     },
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3469,11 +3469,6 @@
       "from": "pff@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/pff/-/pff-1.0.0.tgz"
     },
-    "phantom-ownpropertynames": {
-      "version": "1.0.0",
-      "from": "phantom-ownpropertynames@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/phantom-ownpropertynames/-/phantom-ownpropertynames-1.0.0.tgz"
-    },
     "pify": {
       "version": "2.3.0",
       "from": "pify@>=2.0.0 <3.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "mocha": "^2.4.5",
     "ng-tags-input": "^3.1.1",
     "node-uuid": "^1.4.3",
-    "phantom-ownpropertynames": "^1.0.0",
     "postcss": "^5.0.6",
     "postcss-url": "^5.1.1",
     "proxyquire": "^1.7.4",


### PR DESCRIPTION
This was a workaround for an issue with proxyquire and PhantomJS 1.9.

It is no longer needed following the upgrade to PhantomJS 2.x