### PR TITLE
Make Annotation and Notes tab bar sticky

### DIFF
--- a/h/static/styles/selection-tabs.scss
+++ b/h/static/styles/selection-tabs.scss
@@ -1,13 +1,31 @@
 .selection-tabs {
+  @include grey-background;
+
   display: flex;
   flex-direction: row;
   color: $grey-5;
   @include font-normal;
-  margin: 0px 0px 10px 0px;
 
   &:hover {
     color: $grey-6;
   }
+
+  // Make the tabs scroll with the content until they reach the top of the
+  // sidebar, at which point they will stick to the top.
+  margin-top: -10px;
+  padding-bottom: 10px;
+  padding-top: 10px;
+  position: sticky;
+  top: 40px;
+  z-index: 1;
+
+  // Make the background overlap the container slightly on the left/right
+  // so that the background of the tabs fully overlaps the annotation cards
+  // below, including their drop shadow when the list is scrolled.
+  margin-left: -5px;
+  padding-left: 5px;
+  margin-right: -5px;
+  padding-right: 5px;
 }
 
 .selection-tabs--selected {


### PR DESCRIPTION
Make Annotation and Notes tab bar sticky

Make Annotation and Notes tab bar stick to top of the viewport when the
annotation list is scrolled down.

This relies on support for `position: sticky` which is available in
recent versions of Firefox and Safari*. On browsers where
`position: sticky` is not supported, the tab bar will just scroll
off-screen when scrolling the annotation list down.

Because annotation cards may now be displayed under the tabs, add a
background color, Z index and negative horizontal margin to the tabs
component so that any part of an annotation card under the tab bar is
not visible.

* In Chrome v52 this feature is available but only when the
  'Experimental web platform features' flag is on.
