### PR TITLE
ESLint - Enforce consistent return in functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
   "rules": {
     "array-callback-return": "error",
     "block-scoped-var": "error",
+    "consistent-return": "error",
     "curly": "error",
     "dot-notation": "error",
     "eqeqeq": "error",

--- a/h/static/scripts/app-controller.js
+++ b/h/static/scripts/app-controller.js
@@ -127,7 +127,7 @@ module.exports = function AppController(
     });
     drafts.discard();
     $scope.accountDialog.visible = false;
-    return auth.logout();
+    auth.logout();
   };
 
   $scope.clearSelection = function () {

--- a/h/static/scripts/directive/excerpt.js
+++ b/h/static/scripts/directive/excerpt.js
@@ -90,7 +90,7 @@ function excerpt(ExcerptOverflowMonitor) {
         contentHeight: function () {
           var contentElem = elem[0].querySelector('.excerpt');
           if (!contentElem) {
-            return;
+            return null;
           }
           return contentElem.scrollHeight;
         },

--- a/h/static/scripts/directive/markdown.js
+++ b/h/static/scripts/directive/markdown.js
@@ -113,8 +113,8 @@ module.exports = function($sanitize) {
 
       // Keyboard shortcuts for bold, italic, and link.
       elem.on('keydown', function(e) {
-        var shortcuts =
-        {66: scope.insertBold,
+        var shortcuts = {
+          66: scope.insertBold,
           73: scope.insertItalic,
           75: scope.insertLink
         };
@@ -122,7 +122,7 @@ module.exports = function($sanitize) {
         var shortcut = shortcuts[e.keyCode];
         if (shortcut && (e.ctrlKey || e.metaKey)) {
           e.preventDefault();
-          return shortcut();
+          shortcut();
         }
       });
 

--- a/h/static/scripts/drafts.js
+++ b/h/static/scripts/drafts.js
@@ -62,6 +62,7 @@ function DraftStore() {
         };
       }
     }
+    return null;
   };
 
   /**

--- a/h/static/scripts/groups.js
+++ b/h/static/scripts/groups.js
@@ -35,6 +35,7 @@ function groups(localStorage, session, settings, $rootScope, $http) {
         return gs[i];
       }
     }
+    return null;
   }
 
   /** Leave the group with the given ID.

--- a/h/static/scripts/media-embedder.js
+++ b/h/static/scripts/media-embedder.js
@@ -36,53 +36,57 @@ var embedGenerators = [
   // Matches URLs like https://www.youtube.com/watch?v=rw6oWkCojpw
   function iframeFromYouTubeWatchURL(link) {
     if (link.hostname !== 'www.youtube.com') {
-      return;
+      return null;
     }
 
     if (!/\/watch\/?/.test(link.pathname)) {
-      return;
+      return null;
     }
 
     var groups = /[&\?]v=([^&#]+)/.exec(link.search);
     if (groups) {
       return youTubeEmbed(groups[1]);
     }
+    return null;
   },
 
   // Matches URLs like https://youtu.be/rw6oWkCojpw
   function iframeFromYouTubeShareURL(link) {
     if (link.hostname !== 'youtu.be') {
-      return;
+      return null;
     }
 
     var groups = /^\/([^\/]+)\/?$/.exec(link.pathname);
     if (groups) {
       return youTubeEmbed(groups[1]);
     }
+    return null;
   },
 
   // Matches URLs like https://vimeo.com/149000090
   function iFrameFromVimeoLink(link) {
     if (link.hostname !== 'vimeo.com') {
-      return;
+      return null;
     }
 
     var groups = /^\/([^\/\?#]+)\/?$/.exec(link.pathname);
     if (groups) {
       return vimeoEmbed(groups[1]);
     }
+    return null;
   },
 
   // Matches URLs like https://vimeo.com/channels/staffpicks/148845534
   function iFrameFromVimeoChannelLink(link) {
     if (link.hostname !== 'vimeo.com') {
-      return;
+      return null;
     }
 
     var groups = /^\/channels\/[^\/]+\/([^\/?#]+)\/?$/.exec(link.pathname);
     if (groups) {
       return vimeoEmbed(groups[1]);
     }
+    return null;
   },
 ];
 
@@ -104,6 +108,7 @@ function embedForLink(link) {
       return embed;
     }
   }
+  return null;
 }
 
 /** Replace the given link element with an embed.

--- a/h/static/scripts/root-thread.js
+++ b/h/static/scripts/root-thread.js
@@ -65,6 +65,8 @@ function RootThread($rootScope, annotationUI, features, searchFilter, viewFilter
           return thread.annotation && metadata.isAnnotation(thread.annotation);
         } else if (state.selectedTab === uiConstants.TAB_NOTES) {
           return thread.annotation && metadata.isPageNote(thread.annotation);
+        } else {
+          throw new Error('Invalid selected tab');
         }
       };
     }

--- a/h/static/scripts/session.js
+++ b/h/static/scripts/session.js
@@ -156,7 +156,7 @@ function session($http, $resource, $rootScope, flash, raven, settings) {
 
   function process(data, headersGetter, status) {
     if (status < 200 || status >= 500) {
-      return;
+      return null;
     }
 
     data = angular.fromJson(data);

--- a/h/static/scripts/test/groups-test.js
+++ b/h/static/scripts/test/groups-test.js
@@ -85,10 +85,10 @@ describe('groups', function() {
       assert.equal(group.id, 'id2');
     });
 
-    it("returns undefined if the group doesn't exist", function() {
+    it("returns null if the group doesn't exist", function() {
       var group = service().get('foobar');
 
-      assert.isUndefined(group);
+      assert.isNull(group);
     });
   });
 

--- a/h/static/scripts/time.js
+++ b/h/static/scripts/time.js
@@ -144,6 +144,8 @@ function getBreakpoint(date, now) {
       return breakpoint;
     }
   }
+
+  return null;
 }
 
 function nextFuzzyUpdate(date) {

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -27,7 +27,7 @@ function groupIDFromSelection(selection, results) {
     return annot.id === id;
   });
   if (!annot) {
-    return;
+    return null;
   }
   return annot.group;
 }
@@ -67,7 +67,7 @@ module.exports = function WidgetController(
   function getThreadHeight(id) {
     var threadElement = document.getElementById(id);
     if (!threadElement) {
-      return;
+      return null;
     }
 
     // Get the height of the element inside the border-box, excluding
@@ -155,11 +155,13 @@ module.exports = function WidgetController(
     if (!annot) {
       return null;
     }
+
     if (metadata.isAnnotation(annot)) {
       return uiConstants.TAB_ANNOTATIONS;
-    }
-    if (metadata.isPageNote(annot)) {
+    } else if (metadata.isPageNote(annot)) {
       return uiConstants.TAB_NOTES;
+    } else {
+      return null;
     }
   }
 
@@ -316,7 +318,7 @@ module.exports = function WidgetController(
     }
 
     annotationUI.clearSelectedAnnotations();
-    return loadAnnotations(crossframe.frames);
+    loadAnnotations(crossframe.frames);
   });
 
   // Watch anything that may require us to reload annotations.


### PR DESCRIPTION
This builds on #27 and enables the ESLint rule which checks that all functions are consistent in either not returning a value or returning a value through all code paths. This caught several mistakes in the code, although no user facing bugs.