### PR TITLE
Annotation / Notes tabs copy update and style tweaks

### DIFF
--- a/h/static/styles/selection-tabs.scss
+++ b/h/static/styles/selection-tabs.scss
@@ -37,6 +37,8 @@
 
   // Disable focus ring for selected tab
   outline: none;
+
+  user-select: none;
 }
 
 .selection-tabs__type.is-selected {
@@ -49,6 +51,7 @@
   font-size: 10px;
 }
 
-.selection-loading {
-  text-align: center;
+.selection-tabs__empty-message {
+  position: relative;
+  top: 10px;
 }

--- a/h/templates/client/selection_tabs.html
+++ b/h/templates/client/selection_tabs.html
@@ -15,7 +15,7 @@
     <span class="selection-tabs__count" ng-if="vm.totalNotes > 0">{{ vm.totalNotes }}</sup>
   </a>
 </div>
-<div ng-if="!vm.isLoading()">
+<div ng-if="!vm.isLoading()" class="selection-tabs__empty-message">
   <div ng-if="vm.selectedTab === vm.TAB_NOTES && vm.totalNotes === 0"  class="annotation-unavailable-message">
     <p class="annotation-unavailable-message__label">
       There are no page notes in this group.

--- a/h/templates/client/selection_tabs.html
+++ b/h/templates/client/selection_tabs.html
@@ -11,7 +11,7 @@
      href="#"
      ng-class="{'is-selected': vm.selectedTab === vm.TAB_NOTES}"
      h-on-touch="vm.selectTab('note')">
-    Notes
+    Page Notes
     <span class="selection-tabs__count" ng-if="vm.totalNotes > 0">{{ vm.totalNotes }}</sup>
   </a>
 </div>
@@ -28,6 +28,9 @@
   <div ng-if="vm.selectedTab === vm.TAB_ANNOTATIONS && vm.totalAnnotations === 0"  class="annotation-unavailable-message">
     <p class="annotation-unavailable-message__label">
       There are no annotations in this group.
+      <br />
+      Create one by selecting some text and clicking the
+      <i class="help-icon h-icon-annotate"></i> button.
     </p>
   </div>
 </div>


### PR DESCRIPTION
These are some updates to the copy and styling of annotation tabs following discussion in Slack this morning:

1. Fix the top border of annotation tabs being clipped
2. Prevent the user from selecting the text of the tabs
3. Change 'Notes' to 'Page Notes' to better differentiate notes vs. annotations
4. Make the empty state for the Annotations tab more helpful and consistent with the Notes tab by explaining how to create an annotation.