### PR TITLE
Remove sticky tab bar behavior

### DIFF
--- a/h/static/styles/selection-tabs.scss
+++ b/h/static/styles/selection-tabs.scss
@@ -10,22 +10,7 @@
     color: $grey-6;
   }
 
-  // Make the tabs scroll with the content until they reach the top of the
-  // sidebar, at which point they will stick to the top.
-  margin-top: -10px;
   padding-bottom: 10px;
-  padding-top: 10px;
-  position: sticky;
-  top: 40px;
-  z-index: 1;
-
-  // Make the background overlap the container slightly on the left/right
-  // so that the background of the tabs fully overlaps the annotation cards
-  // below, including their drop shadow when the list is scrolled.
-  margin-left: -5px;
-  padding-left: 5px;
-  margin-right: -5px;
-  padding-right: 5px;
 }
 
 .selection-tabs__type {


### PR DESCRIPTION
The sticky tab bar behavior has some UI issues that need to be resolved
before we could ship it. For example, when switching between tabs the
scroll position needs to be reset to the top.

For the time being, this commit removes the behavior, so that in all browsers the Annotations and Notes tab bar will scroll with the content of the sidebar.