### PR TITLE
Update UI state after search API request completes with no results

### DIFF
--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -224,8 +224,14 @@ module.exports = function WidgetController(
       }
     });
     searchClient.on('end', function () {
-      // Remove client from list of active search clients
-      searchClients.splice(searchClients.indexOf(searchClient), 1);
+      // Remove client from list of active search clients.
+      //
+      // $evalAsync is required here because search results are emitted
+      // asynchronously. A better solution would be that the loading state is
+      // tracked as part of the app state.
+      $scope.$evalAsync(function () {
+        searchClients.splice(searchClients.indexOf(searchClient), 1);
+      });
     });
     searchClient.get({uri: uris, group: group});
   }


### PR DESCRIPTION
When a search API request returns results, the returned annotations are
added to the app state and this transition triggers a digest cycle.

When there are no results however, this was not happening and the value
of the 'isLoading()' function changed but no digest cycle was triggered
to pick this up and reflect it in the UI.

Since SearchClient's 'end' event is emitted asynchronously via a Promise
callback, $scope.$apply() or $evalAsync() must be used to ensure that
change detection runs.

The real solution will be to store all the information required to
determine the loading/not-loading state in the Redux store, so that any
transition automatically triggers a digest cycle. This requires some
more extensive refactoring however.
