### PR TITLE
Fix 'time' tests in timezones behind UTC

### DIFF
--- a/h/static/scripts/test/time-test.js
+++ b/h/static/scripts/test/time-test.js
@@ -44,6 +44,13 @@ describe('time', function () {
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
     sandbox.useFakeTimers();
+
+    // Ensure that the current local date is 01/01/1970, as this is assumed by
+    // test expectations
+    var offset = new Date().getTimezoneOffset();
+    if (offset > 0) {
+      sandbox.clock.tick(offset * 60 * 1000);
+    }
   });
 
   afterEach(function () {


### PR DESCRIPTION
Several test fixtures have expectations that the "current date", where
"current" is reset to the Unix epoch at the start of the tests, is 1st
Jan 1970. This is true in timezones equal to or ahead of UTC but not the
case for timezones behind UTC.

Resolve the issue by just advancing the fake clock forwards to midnight
on 01/01/1970 if the timezone is behind UTC at the start of the tests.