### PR TITLE
Remove redundant corejs requires

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,10 +2,6 @@
 
 'use strict';
 
-require('core-js/es6/promise');
-require('core-js/fn/object/assign');
-require('core-js/fn/string');
-
 var path = require('path');
 
 var batch = require('gulp-batch');

--- a/h/static/scripts/raven.js
+++ b/h/static/scripts/raven.js
@@ -12,8 +12,6 @@
  * as a dependency.
  */
 
-require('core-js/fn/object/assign');
-
 var Raven = require('raven-js');
 
 // This is only used in apps where Angular is used,

--- a/h/static/scripts/settings.js
+++ b/h/static/scripts/settings.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('core-js/fn/object/assign');
-
 /**
  * Return application configuration information from the host page.
  *


### PR DESCRIPTION
 * The corejs polyfills are not needed in the Gulpfile since we switched
   to a more recent version of Node

 * The Object.assign() polyfill does not need to be included in 'raven'
   or 'settings' because it is already included by the polyfills.js
   script