### PR TITLE
Make the adder a self-contained component

### DIFF
--- a/h/static/scripts/annotator/adder.html
+++ b/h/static/scripts/annotator/adder.html
@@ -1,10 +1,10 @@
-<hypothesis-adder class="annotator-adder">
-    <hypothesis-adder-actions class="annotator-adder-actions">
-      <button class="annotator-adder-actions__button h-icon-annotate" data-action="comment">
-        <span class="annotator-adder-actions__label" data-action="comment">Annotate</span>
-      </button>
-      <button class="annotator-adder-actions__button h-icon-highlight" data-action="highlight">
-        <span class="annotator-adder-actions__label" data-action="highlight">Highlight</span>
-      </button>
-    </hypothesis-adder-actions>
-</hypothesis-adder>
+<hypothesis-adder-toolbar class="annotator-adder js-adder">
+  <hypothesis-adder-actions class="annotator-adder-actions">
+    <button class="annotator-adder-actions__button h-icon-annotate js-annotate-btn">
+      <span class="annotator-adder-actions__label" data-action="comment">Annotate</span>
+    </button>
+    <button class="annotator-adder-actions__button h-icon-highlight js-highlight-btn">
+      <span class="annotator-adder-actions__label" data-action="highlight">Highlight</span>
+    </button>
+  </hypothesis-adder-actions>
+</hypothesis-adder-toolbar>

--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -35,9 +35,6 @@ module.exports = class Guest extends Annotator
 
   # Events to be bound on Annotator#element.
   events:
-    ".annotator-adder button click":     "onAdderClick"
-    ".annotator-adder button mousedown": "onAdderMousedown"
-    ".annotator-adder button mouseup":   "onAdderMouseup"
     ".annotator-hl click":               "onHighlightClick"
     ".annotator-hl mouseover":           "onHighlightMouseover"
     ".annotator-hl mouseout":            "onHighlightMouseout"
@@ -54,13 +51,21 @@ module.exports = class Guest extends Annotator
   visibleHighlights: false
 
   html: extend {}, Annotator::html,
-    adder: adder.template()
+    adder: '<hypothesis-adder></hypothesis-adder>';
 
   constructor: (element, options) ->
     super
 
     self = this
-    this.adderCtrl = new adder.Adder(@adder[0])
+    this.adderCtrl = new adder.Adder(@adder[0], {
+      onAnnotate: ->
+        self.createAnnotation()
+        Annotator.Util.getGlobal().getSelection().removeAllRanges()
+      onHighlight: ->
+        self.setVisibleHighlights(true)
+        self.createHighlight()
+        Annotator.Util.getGlobal().getSelection().removeAllRanges()
+    })
     this.selections = selections(document).subscribe
       next: (range) ->
         if range
@@ -434,20 +439,3 @@ module.exports = class Guest extends Annotator
 
     @visibleHighlights = shouldShowHighlights
 
-  onAdderMouseup: (event) ->
-    event.preventDefault()
-    event.stopPropagation()
-
-  onAdderMousedown: ->
-
-  onAdderClick: (event) ->
-    event.preventDefault?()
-    event.stopPropagation?()
-    this.adderCtrl.hide()
-    switch $(event.target).data('action')
-      when 'highlight'
-        this.setVisibleHighlights true
-        this.createHighlight()
-      when 'comment'
-        this.createAnnotation()
-    Annotator.Util.getGlobal().getSelection().removeAllRanges()

--- a/h/static/scripts/annotator/test/adder-test.js
+++ b/h/static/scripts/annotator/test/adder-test.js
@@ -8,13 +8,17 @@ function rect(left, top, width, height) {
 
 describe('adder', function () {
   var adderCtrl;
-  beforeEach(function () {
-    var adderEl = document.createElement('div');
-    adderEl.innerHTML = adder.template();
-    adderEl = adderEl.firstChild;
-    document.body.appendChild(adderEl.firstChild);
+  var adderCallbacks;
 
-    adderCtrl = new adder.Adder(adderEl.firstChild);
+  beforeEach(function () {
+    adderCallbacks = {
+      onAnnotate: sinon.stub(),
+      onHighlight: sinon.stub(),
+    };
+    var adderEl = document.createElement('div');
+    document.body.appendChild(adderEl);
+
+    adderCtrl = new adder.Adder(adderEl, adderCallbacks);
   });
 
   afterEach(function () {
@@ -31,6 +35,20 @@ describe('adder', function () {
     var rect = adderCtrl.element.getBoundingClientRect();
     return {width: rect.width, height: rect.height};
   }
+
+  describe('button handling', function () {
+    it('calls onHighlight callback when Highlight button is clicked', function () {
+      var highlightBtn = adderCtrl.element.querySelector('.js-highlight-btn');
+      highlightBtn.dispatchEvent(new Event('click'));
+      assert.called(adderCallbacks.onHighlight);
+    });
+
+    it('calls onAnnotate callback when Annotate button is clicked', function () {
+      var annotateBtn = adderCtrl.element.querySelector('.js-annotate-btn');
+      annotateBtn.dispatchEvent(new Event('click'));
+      assert.called(adderCallbacks.onAnnotate);
+    });
+  });
 
   describe('#target', function () {
     it('positions the adder below the selection if the selection is forwards', function () {

--- a/h/static/scripts/annotator/test/adder-test.js
+++ b/h/static/scripts/annotator/test/adder-test.js
@@ -54,16 +54,12 @@ describe('adder', function () {
     it('positions the adder below the selection if the selection is forwards', function () {
       var target = adderCtrl.target(rect(100,200,100,20), false);
       assert.isAbove(target.top, 220);
-      assert.isAbove(target.left, 100);
-      assert.isBelow(target.left, 200);
       assert.equal(target.arrowDirection, adder.ARROW_POINTING_UP);
     });
 
     it('positions the adder above the selection if the selection is backwards', function () {
       var target = adderCtrl.target(rect(100,200,100,20), true);
       assert.isBelow(target.top, 200);
-      assert.isAbove(target.left, 100);
-      assert.isBelow(target.left, 200);
       assert.equal(target.arrowDirection, adder.ARROW_POINTING_DOWN);
     });
 

--- a/h/static/scripts/annotator/test/guest-test.coffee
+++ b/h/static/scripts/annotator/test/guest-test.coffee
@@ -281,19 +281,6 @@ describe 'Guest', ->
       return guest.getDocumentInfo().then ({uri}) ->
         assert.equal uri, 'urn:x-pdf:aabbcc'
 
-  describe '#onAdderMouseUp()', ->
-    it 'it prevents the default browser action when triggered', () ->
-      event = jQuery.Event('mouseup')
-      guest = createGuest()
-      guest.onAdderMouseup(event)
-      assert.isTrue(event.isDefaultPrevented())
-
-    it 'it stops any further event bubbling', () ->
-      event = jQuery.Event('mouseup')
-      guest = createGuest()
-      guest.onAdderMouseup(event)
-      assert.isTrue(event.isPropagationStopped())
-
   describe '#createAnnotation()', ->
     it 'adds metadata to the annotation object', ->
       guest = createGuest()

--- a/h/static/styles/annotator/adder.scss
+++ b/h/static/styles/annotator/adder.scss
@@ -13,7 +13,6 @@ $adder-transition-duration: 80ms;
   border: 1px solid rgba(0,0,0,0.20);
   border-radius: 4px;
   box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.25);
-  z-index: 999;
 
   // Give the adder a very low opacity initially.  It will then fade-in when
   // shown.


### PR DESCRIPTION
Move adder event handling and UI creation to Adder component, so that
Guest does not need to know about its internal structure or handle
events for it. Instead it just supplies callbacks to invoke when the
Annotate and Highlight buttons are clicked.

This makes it easier to test event handling for the adder and to make
changes to the UI of the Adder or how events are handled.
