### PR TITLE
Use Shadow DOM to isolate adder from host page's CSS

### DIFF
--- a/h/static/scripts/annotator/test/adder-test.js
+++ b/h/static/scripts/annotator/test/adder-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var adder = require('../adder');
+var unroll = require('../../test/util').unroll;
 
 function rect(left, top, width, height) {
   return {left: left, top: top, width: width, height: height};
@@ -35,6 +36,30 @@ describe('adder', function () {
     var rect = adderCtrl.element.getBoundingClientRect();
     return {width: rect.width, height: rect.height};
   }
+
+  context('when Shadow DOM is supported', function () {
+    unroll('creates the adder DOM in a shadow root', function (testCase) {
+      var adderEl = document.createElement('div');
+      var shadowEl;
+      adderEl[testCase.attachFn] = sinon.spy(function () {
+        shadowEl = document.createElement('shadow-root');
+        adderEl.appendChild(shadowEl);
+        return shadowEl;
+      });
+      document.body.appendChild(adderEl);
+
+      new adder.Adder(adderEl, adderCallbacks);
+
+      assert.called(adderEl[testCase.attachFn]);
+      assert.equal(shadowEl.childNodes[0].tagName.toLowerCase(), 'hypothesis-adder-toolbar');
+
+      adderEl.remove();
+    },[{
+      attachFn: 'createShadowRoot', // Shadow DOM v0 API
+    },{
+      attachFn: 'attachShadow', // Shadow DOM v1 API
+    }]);
+  });
 
   describe('button handling', function () {
     it('calls onHighlight callback when Highlight button is clicked', function () {


### PR DESCRIPTION
_This builds on #48_

In browsers that support [Shadow DOM](https://developers.google.com/web/fundamentals/primers/shadowdom/) (currently only Chrome, plus Firefox
behind a feature flag and [Safari 10](https://webkit.org/blog/4096/introducing-shadow-dom-api/)), use it to isolate the adder from the host page's
CSS.

This fixes various problems where very generic CSS on the page could
affect the adder's styling, eg. on https://developers.google.com/web/showcase/2016/iowa2016 where the adder toolbar labels are clipped because of extra spacing that gets added.

This is not the only fix we could use. #48 makes it easier to use a combination of different fixes to the problem. So if we wanted to try a same-origin `<iframe>` as another alternative, we could do that instead.

----

- [x] Check that styling and behavior of adder is identical in Chrome with and without Shadow DOM
- [x] Add a link to the StackOverflow post re. the comment about external stylesheets in shadow roots
