### PR TITLE
Separate anchored and unanchored annotations into tabs.

### DIFF
--- a/h/static/scripts/annotation-metadata.js
+++ b/h/static/scripts/annotation-metadata.js
@@ -101,14 +101,37 @@ function isNew(annotation) {
   return !annotation.id;
 }
 
-/** Return `true` if the given annotation is a page note, `false` otherwise. */
+/**
+ * Return `true` if `annotation` has a selector.
+ *
+ * An annotation which has a selector refers to a specific part of a document,
+ * as opposed to a Page Note which refers to the whole document or a reply,
+ * which refers to another annotation.
+ */
+function hasSelector(annotation) {
+  return !!(annotation.target &&
+            annotation.target.length > 0 &&
+            annotation.target[0].selector);
+}
+
+/** Return `true` if the given annotation is not yet anchored. */
+function isWaitingToAnchor(annotation) {
+  return hasSelector(annotation) && (typeof annotation.$orphan === 'undefined');
+}
+
+/** Return `true` if the given annotation is an orphan. */
+function isOrphan(annotation) {
+  return hasSelector(annotation) && annotation.$orphan;
+}
+
+/** Return `true` if the given annotation is a page note. */
 function isPageNote(annotation) {
-  return !isAnnotation(annotation) && !isReply(annotation);
+  return !hasSelector(annotation) && !isReply(annotation);
 }
 
 /** Return `true` if the given annotation is a top level annotation, `false` otherwise. */
 function isAnnotation(annotation) {
-  return !!(annotation.target && annotation.target.length > 0 && annotation.target[0].selector);
+  return !!(hasSelector(annotation) && !isOrphan(annotation));
 }
 
 /** Return a numeric key that can be used to sort annotations by location.
@@ -137,7 +160,9 @@ module.exports = {
   domainAndTitle: domainAndTitle,
   isAnnotation: isAnnotation,
   isNew: isNew,
+  isOrphan: isOrphan,
   isPageNote: isPageNote,
   isReply: isReply,
+  isWaitingToAnchor: isWaitingToAnchor,
   location: location,
 };

--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -10,6 +10,7 @@
 
 var immutable = require('seamless-immutable');
 var redux = require('redux');
+var uiConstants = require('./ui-constants');
 
 function freeze(selection) {
   if (Object.keys(selection).length) {
@@ -62,7 +63,7 @@ function initialState(settings) {
 
     filterQuery: null,
 
-    selectedTab: null,
+    selectedTab: uiConstants.TAB_ANNOTATIONS,
 
     // Key by which annotations are currently sorted.
     sortKey: 'Location',

--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -10,7 +10,10 @@
 
 var immutable = require('seamless-immutable');
 var redux = require('redux');
+
+var metadata = require('./annotation-metadata');
 var uiConstants = require('./ui-constants');
+var countIf = require('./util/array-util').countIf;
 
 function freeze(selection) {
   if (Object.keys(selection).length) {
@@ -121,8 +124,18 @@ function annotationsReducer(state, action) {
     return Object.assign({}, state,
         {annotations: state.annotations.concat(action.annotations)});
   case types.REMOVE_ANNOTATIONS:
-    return Object.assign({}, state,
-        {annotations: excludeAnnotations(state.annotations, action.annotations)});
+    {
+      var annots = excludeAnnotations(state.annotations, action.annotations);
+      var selectedTab = state.selectedTab;
+      if (selectedTab === uiConstants.TAB_ORPHANS &&
+          countIf(annots, metadata.isOrphan) === 0) {
+        selectedTab = uiConstants.TAB_ANNOTATIONS;
+      }
+      return Object.assign({}, state, {
+        annotations: annots,
+        selectedTab: selectedTab,
+      });
+    }
   case types.CLEAR_ANNOTATIONS:
     return Object.assign({}, state, {annotations: []});
   case types.UPDATE_ANCHOR_STATUS:

--- a/h/static/scripts/app-controller.js
+++ b/h/static/scripts/app-controller.js
@@ -137,10 +137,13 @@ module.exports = function AppController(
   };
 
   $scope.clearSelection = function () {
-    if (!annotationUI.getState().selectedTab) {
-      annotationUI.selectTab(uiConstants.TAB_ANNOTATIONS);
+    var selectedTab = annotationUI.getState().selectedTab;
+    if (!annotationUI.getState().selectedTab || annotationUI.getState().selectedTab === uiConstants.TAB_ORPHANS) {
+      selectedTab = uiConstants.TAB_ANNOTATIONS;
     }
+
     annotationUI.clearSelectedAnnotations();
+    annotationUI.selectTab(selectedTab);
   };
 
   $scope.search = {

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -443,7 +443,11 @@ function AnnotationController(
   vm.target = function() {
     return vm.annotation.target;
   };
-
+  
+  vm.isOrphan = function() {
+    return vm.annotation.$orphan;
+  };
+  
   vm.updated = function() {
     return vm.annotation.updated;
   };

--- a/h/static/scripts/directive/search-status-bar.js
+++ b/h/static/scripts/directive/search-status-bar.js
@@ -10,6 +10,7 @@ module.exports = function () {
     controller: function () {
       this.TAB_ANNOTATIONS = uiConstants.TAB_ANNOTATIONS;
       this.TAB_NOTES = uiConstants.TAB_NOTES;
+      this.TAB_ORPHANS = uiConstants.TAB_ORPHANS;
     },
     restrict: 'E',
     scope: {

--- a/h/static/scripts/directive/selection-tabs.js
+++ b/h/static/scripts/directive/selection-tabs.js
@@ -7,21 +7,28 @@ module.exports = function () {
     bindToController: true,
     controllerAs: 'vm',
     //@ngInject
-    controller: function ($element, annotationUI) {
+    controller: function ($element, annotationUI, features) {
       this.TAB_ANNOTATIONS = uiConstants.TAB_ANNOTATIONS;
       this.TAB_NOTES = uiConstants.TAB_NOTES;
+      this.TAB_ORPHANS = uiConstants.TAB_ORPHANS;
 
       this.selectTab = function (type) {
         annotationUI.clearSelectedAnnotations();
         annotationUI.selectTab(type);
       };
+
+      this.orphansTabFlagEnabled = function () {
+        return features.flagEnabled('orphans_tab');
+      };
     },
     restrict: 'E',
     scope: {
       isLoading: '<',
+      isWaitingToAnchorAnnotations: '<',
       selectedTab: '<',
       totalAnnotations: '<',
       totalNotes: '<',
+      totalOrphans: '<',
     },
     template: require('../../../templates/client/selection_tabs.html'),
   };

--- a/h/static/scripts/directive/test/selection-tabs-test.js
+++ b/h/static/scripts/directive/test/selection-tabs-test.js
@@ -12,8 +12,13 @@ describe('selectionTabs', function () {
 
   beforeEach(function () {
     var fakeAnnotationUI = {};
+    var fakeFeatures = {
+      flagEnabled: sinon.stub().returns(true),
+    };
+
     angular.mock.module('app', {
       annotationUI: fakeAnnotationUI,
+      features: fakeFeatures,
     });
   });
 

--- a/h/static/scripts/root-thread.js
+++ b/h/static/scripts/root-thread.js
@@ -60,15 +60,29 @@ function RootThread($rootScope, annotationUI, features, searchFilter, viewFilter
 
     var threadFilterFn;
     if (features.flagEnabled('selection_tabs') && !state.filterQuery && state.selectedTab) {
-      threadFilterFn = function (thread) {
-        if (state.selectedTab === uiConstants.TAB_ANNOTATIONS) {
-          return thread.annotation && metadata.isAnnotation(thread.annotation);
-        } else if (state.selectedTab === uiConstants.TAB_NOTES) {
-          return thread.annotation && metadata.isPageNote(thread.annotation);
-        } else {
-          throw new Error('Invalid selected tab');
-        }
-      };
+      if (!features.flagEnabled('orphans_tab')) {
+        threadFilterFn = function (thread) {
+          if (state.selectedTab === uiConstants.TAB_ANNOTATIONS || state.selectedTab === uiConstants.TAB_ORPHANS) {
+            return thread.annotation && (metadata.isAnnotation(thread.annotation) || metadata.isOrphan(thread.annotation));
+          } else if (state.selectedTab === uiConstants.TAB_NOTES) {
+            return thread.annotation && metadata.isPageNote(thread.annotation);
+          } else {
+            throw new Error('Invalid selected tab');
+          }
+        };
+      } else {
+        threadFilterFn = function (thread) {
+          if (state.selectedTab === uiConstants.TAB_ANNOTATIONS) {
+            return thread.annotation && metadata.isAnnotation(thread.annotation);
+          } else if (state.selectedTab === uiConstants.TAB_NOTES) {
+            return thread.annotation && metadata.isPageNote(thread.annotation);
+          } else if (state.selectedTab === uiConstants.TAB_ORPHANS) {
+            return thread.annotation && metadata.isOrphan(thread.annotation);
+          } else {
+            throw new Error('Invalid selected tab');
+          }
+        };
+      }
     }
 
     // Get the currently loaded annotations and the set of inputs which

--- a/h/static/scripts/tab-counts.js
+++ b/h/static/scripts/tab-counts.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var metadata = require('./annotation-metadata');
+
+function countIf(list, predicate) {
+  return list.reduce(function (count, item) {
+    return predicate(item) ? count + 1 : count;
+  }, 0);
+}
+
+/**
+ * Return a count of the number of Annotations, Page Notes, Orphans and
+ * annotations still being anchored in a set of `annotations`
+ */
+function tabCounts(annotations, opts) {
+  opts = opts || {separateOrphans: false};
+
+  var counts = {
+    notes: countIf(annotations, metadata.isPageNote),
+    annotations: countIf(annotations, metadata.isAnnotation),
+    orphans: countIf(annotations, metadata.isOrphan),
+    anchoring: countIf(annotations, metadata.isWaitingToAnchor),
+  };
+
+  if (opts.separateOrphans) {
+    return counts;
+  } else {
+    return Object.assign({}, counts, {
+      annotations: counts.annotations + counts.orphans,
+      orphans: 0,
+    });
+  }
+}
+
+module.exports = tabCounts;

--- a/h/static/scripts/tab-counts.js
+++ b/h/static/scripts/tab-counts.js
@@ -1,12 +1,7 @@
 'use strict';
 
 var metadata = require('./annotation-metadata');
-
-function countIf(list, predicate) {
-  return list.reduce(function (count, item) {
-    return predicate(item) ? count + 1 : count;
-  }, 0);
-}
+var countIf = require('./util/array-util').countIf;
 
 /**
  * Return a count of the number of Annotations, Page Notes, Orphans and

--- a/h/static/scripts/test/annotation-metadata-test.js
+++ b/h/static/scripts/test/annotation-metadata-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var annotationMetadata = require('../annotation-metadata');
+var fixtures = require('./annotation-fixtures');
 
 var documentMetadata = annotationMetadata.documentMetadata;
 var domainAndTitle = annotationMetadata.domainAndTitle;
@@ -243,6 +244,48 @@ describe('annotation-metadata', function () {
     });
     it ('returns false if an annotation has no target', function () {
       assert.isFalse(annotationMetadata.isAnnotation({}));
+    });
+  });
+
+  describe('.isOrphan', function () {
+    it('returns true if an annotation failed to anchor', function () {
+      var annotation = Object.assign(fixtures.defaultAnnotation(), {$orphan: true});
+      assert.isTrue(annotationMetadata.isOrphan(annotation));
+    });
+
+    it('returns false if an annotation successfully anchored', function() {
+      var orphan = Object.assign(fixtures.defaultAnnotation(), {$orphan: false});
+      assert.isFalse(annotationMetadata.isOrphan(orphan));
+    });
+  });
+
+  describe('.isWaitingToAnchor', function () {
+    var isWaitingToAnchor = annotationMetadata.isWaitingToAnchor;
+
+    it('returns true for annotations that are not yet anchored', function () {
+      assert.isTrue(isWaitingToAnchor(fixtures.defaultAnnotation()));
+    });
+
+    it('returns false for annotations that are anchored', function () {
+      var anchored = Object.assign({}, fixtures.defaultAnnotation(), {
+        $orphan: false,
+      });
+      assert.isFalse(isWaitingToAnchor(anchored));
+    });
+
+    it('returns false for annotations that failed to anchor', function () {
+      var anchored = Object.assign({}, fixtures.defaultAnnotation(), {
+        $orphan: true,
+      });
+      assert.isFalse(isWaitingToAnchor(anchored));
+    });
+
+    it('returns false for replies', function () {
+      assert.isFalse(isWaitingToAnchor(fixtures.oldReply()));
+    });
+
+    it('returns false for page notes', function () {
+      assert.isFalse(isWaitingToAnchor(fixtures.oldPageNote()));
     });
   });
 });

--- a/h/static/scripts/test/annotation-ui-test.js
+++ b/h/static/scripts/test/annotation-ui-test.js
@@ -5,6 +5,7 @@ var immutable = require('seamless-immutable');
 var annotationUIFactory = require('../annotation-ui');
 var annotationFixtures = require('./annotation-fixtures');
 var unroll = require('./util').unroll;
+var uiConstants = require('../ui-constants');
 
 var defaultAnnotation = annotationFixtures.defaultAnnotation;
 
@@ -71,6 +72,14 @@ describe('annotationUI', function () {
       annotationUI.addAnnotations(fixtures.pair);
       annotationUI.removeAnnotations([{$$tag: fixtures.pair[0].$$tag}]);
       assert.deepEqual(annotationUI.getState().annotations, [fixtures.pair[1]]);
+    });
+
+    it('switches back to the Annotations tab when the last orphan is removed', function () {
+      var orphan = Object.assign(defaultAnnotation(), {$orphan: true});
+      annotationUI.addAnnotations([orphan]);
+      annotationUI.selectTab(uiConstants.TAB_ORPHANS);
+      annotationUI.removeAnnotations([orphan]);
+      assert.equal(annotationUI.getState().selectedTab, uiConstants.TAB_ANNOTATIONS);
     });
   });
 

--- a/h/static/scripts/test/root-thread-test.js
+++ b/h/static/scripts/test/root-thread-test.js
@@ -6,6 +6,7 @@ var immutable = require('seamless-immutable');
 
 var annotationFixtures = require('./annotation-fixtures');
 var events = require('../events');
+var uiConstants = require('../ui-constants');
 var util = require('./util');
 
 var unroll = util.unroll;
@@ -186,11 +187,11 @@ describe('rootThread', function () {
   });
 
   describe('when the thread filter query is set', function () {
-    it('generates a thread filter function to match annotations', function () {
+    it('filter matches only annotations when Annotations tab is selected', function () {
       fakeBuildThread.reset();
 
       fakeAnnotationUI.state = Object.assign({}, fakeAnnotationUI.state,
-        {selectedTab: 'annotation'});
+        {selectedTab: uiConstants.TAB_ANNOTATIONS});
 
       rootThread.thread(fakeAnnotationUI.state);
       var threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
@@ -199,30 +200,55 @@ describe('rootThread', function () {
       assert.isDefined(threadFilterFn({annotation: annotation}));
     });
 
-    it('generates a thread filter function to match notes', function () {
+    it('filter matches only notes when Notes tab is selected', function () {
       fakeBuildThread.reset();
-      fakeBuildThread.annotation = {target: [{}]};
 
       fakeAnnotationUI.state = Object.assign({}, fakeAnnotationUI.state,
-        {selectedTab: 'note'});
+        {selectedTab: uiConstants.TAB_NOTES});
 
       rootThread.thread(fakeAnnotationUI.state);
       var threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
 
-      assert.isTrue(threadFilterFn(fakeBuildThread));
+      assert.isTrue(threadFilterFn({annotation: {target: [{}]}}));
     });
 
-    it('generates a thread filter function for annotations, when all annotations are of type notes', function () {
+    it('filter matches only orphans when Orphans tab is selected', function () {
       fakeBuildThread.reset();
-      fakeBuildThread.annotation = {target: [{}]};
 
       fakeAnnotationUI.state = Object.assign({}, fakeAnnotationUI.state,
-        {selectedTab: 'annotation'});
+        {selectedTab: uiConstants.TAB_ORPHANS});
 
       rootThread.thread(fakeAnnotationUI.state);
       var threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
 
-      assert.isFalse(threadFilterFn(fakeBuildThread));
+      var orphan = Object.assign(annotationFixtures.defaultAnnotation(),
+        {$orphan: true});
+
+      assert.isTrue(threadFilterFn({annotation: orphan}));
+    });
+
+    it('filter does not match notes when Annotations tab is selected', function () {
+      fakeBuildThread.reset();
+
+      fakeAnnotationUI.state = Object.assign({}, fakeAnnotationUI.state,
+        {selectedTab: uiConstants.TAB_ANNOTATIONS});
+
+      rootThread.thread(fakeAnnotationUI.state);
+      var threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
+
+      assert.isFalse(threadFilterFn({annotation: {target: [{}]}}));
+    });
+
+    it('filter does not match orphans when Annotations tab is selected', function () {
+      fakeBuildThread.reset();
+
+      fakeAnnotationUI.state = Object.assign({}, fakeAnnotationUI.state,
+        {selectedTab: uiConstants.TAB_ANNOTATIONS});
+
+      rootThread.thread(fakeAnnotationUI.state);
+      var threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
+
+      assert.isFalse(threadFilterFn({annotation: {$orphan: true}}));
     });
   });
 

--- a/h/static/scripts/test/tab-counts-test.js
+++ b/h/static/scripts/test/tab-counts-test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var fixtures = require('./annotation-fixtures');
+var tabCounts = require('../tab-counts');
+
+describe('tabCounts', function () {
+  var annotation = Object.assign(fixtures.defaultAnnotation(), {$orphan:false});
+  var orphan = Object.assign(fixtures.defaultAnnotation(), {$orphan:true});
+
+  it('counts Annotations and Orphans together when the Orphans tab is not enabled', function () {
+    assert.deepEqual(tabCounts([annotation, orphan]), {
+      anchoring: 0,
+      annotations: 2,
+      notes: 0,
+      orphans: 0,
+    });
+  });
+
+  it('counts Annotations and Orphans separately when the Orphans tab is enabled', function () {
+    assert.deepEqual(tabCounts([annotation, orphan], {separateOrphans: true}), {
+      anchoring: 0,
+      annotations: 1,
+      notes: 0,
+      orphans: 1,
+    });
+  });
+});

--- a/h/static/scripts/ui-constants.js
+++ b/h/static/scripts/ui-constants.js
@@ -7,4 +7,5 @@
 module.exports = {
   TAB_ANNOTATIONS: 'annotation',
   TAB_NOTES: 'note',
+  TAB_ORPHANS: 'orphan',
 };

--- a/h/static/scripts/util/array-util.js
+++ b/h/static/scripts/util/array-util.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function countIf(ary, predicate) {
+  return ary.reduce(function (count, item) {
+    return predicate(item) ? count + 1 : count;
+  }, 0);
+}
+
+module.exports = {
+  countIf: countIf,
+};

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -34,10 +34,30 @@ function groupIDFromSelection(selection, results) {
 
 // @ngInject
 module.exports = function WidgetController(
-  $scope, $rootScope, annotationUI, crossframe, annotationMapper,
-  drafts, features, groups, rootThread, settings, streamer, streamFilter, store,
+  $scope, annotationUI, crossframe, annotationMapper, drafts,
+  features, groups, rootThread, settings, streamer, streamFilter, store,
   VirtualThreadList
 ) {
+
+  /**
+   * Returns the number of annotations which are not yet anchored.
+   */
+  function countWaitingToAnchorAnnotations (annotations) {
+    var total = annotations.reduce(function (count, annotation) {
+      return annotation && metadata.isWaitingToAnchor(annotation) ? count + 1 : count;
+    }, 0);
+    return total;
+  }
+
+  /**
+   * Returns the number of top level annotations which are unanchored i.e orphans.
+   */
+  function countOrphans(annotations) {
+    var total = annotations.reduce(function (count, annotation) {
+      return annotation && metadata.isOrphan(annotation) ? count + 1 : count;
+    }, 0);
+    return total;
+  }
 
   /**
    * Returns the number of top level annotations which are of type annotations
@@ -97,8 +117,16 @@ module.exports = function WidgetController(
     visibleThreads.setRootThread(thread());
     $scope.selectedTab = annotationUI.getState().selectedTab;
 
-    $scope.totalAnnotations = countAnnotations(annotationUI.getState().annotations);
+    $scope.waitingToAnchorAnnotations = countWaitingToAnchorAnnotations(annotationUI.getState().annotations) > 0;
+
     $scope.totalNotes = countNotes(annotationUI.getState().annotations);
+    $scope.totalOrphans = countOrphans(annotationUI.getState().annotations);
+
+    if (!features.flagEnabled('orphans_tab')) {
+      $scope.totalAnnotations = $scope.totalAnnotations + $scope.totalOrphans;
+    } else {
+      $scope.totalAnnotations = countAnnotations(annotationUI.getState().annotations);
+    }
   });
 
   $scope.$on('$destroy', unsubscribeAnnotationUI);
@@ -158,12 +186,22 @@ module.exports = function WidgetController(
       return null;
     }
 
-    if (metadata.isAnnotation(annot)) {
+    if (metadata.isOrphan(annot)) {
+      return uiConstants.TAB_ORPHANS;
+    } else if (metadata.isAnnotation(annot)) {
       return uiConstants.TAB_ANNOTATIONS;
     } else if (metadata.isPageNote(annot)) {
       return uiConstants.TAB_NOTES;
     } else {
       return null;
+    }
+  }
+
+  function selectAppropriateTab() {
+    if (annotationUI.getState().selectedTab === uiConstants.TAB_ORPHANS) {
+      annotationUI.selectTab(uiConstants.TAB_ANNOTATIONS);
+    } else {
+      annotationUI.selectTab(annotationUI.getState().selectedTab);
     }
   }
 
@@ -204,9 +242,15 @@ module.exports = function WidgetController(
     searchClients.push(searchClient);
     searchClient.on('results', function (results) {
       if (annotationUI.hasSelectedAnnotations()) {
-        // Select appropriate tab - notes or annotations, for selection
-        annotationUI.selectTab(
-          tabTypeFromSelection(annotationUI.getState().selectedAnnotationMap, results));
+        // Select appropriate tab - notes, annotations or orphans, for selection
+        $scope.$on(events.ANNOTATIONS_SYNCED, function () {
+          var tabToSelect = tabTypeFromSelection(annotationUI.getState().selectedAnnotationMap, results);
+          if (tabToSelect) {
+            annotationUI.selectTab(tabToSelect);
+          } else {
+            selectAppropriateTab();
+          }
+        });
 
         // Focus the group containing the selected annotation and filter
         // annotations to those from this group
@@ -314,9 +358,11 @@ module.exports = function WidgetController(
     streamer.reconnect();
   });
 
-  // When a direct-linked annotation is successfully anchored in the page,
-  // focus and scroll to it
   $scope.$on(events.ANNOTATIONS_SYNCED, function (event, tags) {
+    selectAppropriateTab();
+
+    // When a direct-linked annotation is successfully anchored in the page,
+    // focus and scroll to it
     var selectedAnnot = firstSelectedAnnotation();
     if (!selectedAnnot) {
       return;
@@ -339,9 +385,10 @@ module.exports = function WidgetController(
     if (isLoading()) {
       return;
     }
-
     annotationUI.clearSelectedAnnotations();
     loadAnnotations(crossframe.frames);
+
+    selectAppropriateTab();
   });
 
   // Watch anything that may require us to reload annotations.
@@ -407,7 +454,6 @@ module.exports = function WidgetController(
   };
 
   $scope.isLoading = isLoading;
-  annotationUI.selectTab(uiConstants.TAB_ANNOTATIONS);
 
   var visibleCount = memoize(function (thread) {
     return thread.children.reduce(function (count, child) {

--- a/h/static/styles/annotation.scss
+++ b/h/static/styles/annotation.scss
@@ -140,6 +140,10 @@
   margin-bottom: $layout-h-margin - 3px;
 }
 
+.annotation-quote-list.is-orphan {
+  text-decoration: line-through;
+}
+
 .annotation-media-embed {
   width: 369px;
   height: 208px;

--- a/h/static/styles/selection-tabs.scss
+++ b/h/static/styles/selection-tabs.scss
@@ -40,3 +40,7 @@
   position: relative;
   top: 10px;
 }
+
+.selection-tabs__type--orphan {
+  margin-left: -5px;
+}

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -51,6 +51,7 @@
 
   <!-- Excerpts -->
   <section class="annotation-quote-list"
+    ng-class="{'is-orphan' : vm.isOrphan()}"
     ng-repeat="target in vm.target() track by $index"
     ng-if="vm.hasQuotes()">
     <excerpt collapsed-height="35"

--- a/h/templates/client/search_status_bar.html
+++ b/h/templates/client/search_status_bar.html
@@ -15,7 +15,7 @@
   <button class="primary-action-btn primary-action-btn--short"
           ng-click="vm.onClearSelection()"
           title="Clear the selection and show all annotations">
-    <span ng-if="!vm.selectedTab">
+    <span ng-if="!vm.selectedTab || vm.selectedTab === vm.TAB_ORPHANS">
       Show all annotations and notes
     </span>
     <span ng-if="vm.selectedTab === vm.TAB_ANNOTATIONS">

--- a/h/templates/client/selection_tabs.html
+++ b/h/templates/client/selection_tabs.html
@@ -3,16 +3,33 @@
   <a class="selection-tabs__type"
      href="#"
      ng-class="{'is-selected': vm.selectedTab === vm.TAB_ANNOTATIONS}"
-     h-on-touch="vm.selectTab('annotation')">
+     h-on-touch="vm.selectTab(vm.TAB_ANNOTATIONS)">
     Annotations
-    <span class="selection-tabs__count" ng-if="vm.totalAnnotations > 0">{{ vm.totalAnnotations }}</sup>
+    <span class="selection-tabs__count"
+      ng-if="vm.totalAnnotations > 0 && !vm.isWaitingToAnchorAnnotations">
+      {{ vm.totalAnnotations }}
+    </span>
   </a>
   <a class="selection-tabs__type"
      href="#"
      ng-class="{'is-selected': vm.selectedTab === vm.TAB_NOTES}"
-     h-on-touch="vm.selectTab('note')">
+     h-on-touch="vm.selectTab(vm.TAB_NOTES)">
     Page Notes
-    <span class="selection-tabs__count" ng-if="vm.totalNotes > 0">{{ vm.totalNotes }}</sup>
+    <span class="selection-tabs__count"
+      ng-if="vm.totalNotes > 0 && !vm.isWaitingToAnchorAnnotations">
+      {{ vm.totalNotes }}
+    </span>
+  </a>
+  <a class="selection-tabs__type selection-tabs__type--orphan"
+    ng-if="vm.orphansTabFlagEnabled() && vm.totalOrphans > 0"
+    href="#"
+    ng-class="{'is-selected': vm.selectedTab === vm.TAB_ORPHANS}"
+    h-on-touch="vm.selectTab(vm.TAB_ORPHANS)">
+    Orphans
+    <span class="selection-tabs__count"
+      ng-if="vm.totalOrphans > 0 && !vm.isWaitingToAnchorAnnotations">
+      {{ vm.totalOrphans }}
+    </span>
   </a>
 </div>
 <div ng-if="!vm.isLoading()" class="selection-tabs__empty-message">

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -1,8 +1,12 @@
-<selection-tabs ng-if="feature('selection_tabs') && !search.query() && selectedAnnotationCount() === 0"
+<selection-tabs ng-if="feature('selection_tabs') &&
+    !search.query() &&
+    selectedAnnotationCount() === 0"
+  is-waiting-to-anchor-annotations="waitingToAnchorAnnotations"
   is-loading="isLoading"
   selected-tab="selectedTab"
   total-annotations="totalAnnotations"
-  total-notes="totalNotes">
+  total-notes="totalNotes"
+  total-orphans="totalOrphans">
 </selection-tabs>
 
 <!-- Annotation thread view
@@ -10,6 +14,7 @@
 (See gh2642 for rationale for 'ng-show="true"')
  -->
 <ul class="thread-list ng-hide"
+    ng-if="!waitingToAnchorAnnotations"
     ng-show="true"
     window-scroll="loadMore(20)">
   <search-status-bar


### PR DESCRIPTION
Default to the annotations tab when user switches between groups, clears a selection or reloads a page.
The ANNOTATIONS_SYNCED event is emitted when annotations for a document have finished anchoring. Because annotations are not marked as orphans until they fail to anchor, select the annotations tab after they have finished anchoring.

Test cases:
-------------
(1). On page load localhost:3000
-    annotations tab is selected.
-    clicking on new note switches to the notes tab with a new draft created.
-    switching between tabs maintains tab selection, if notes or annotations.
-    when tab selected is orphans, changing groups defaults to the annotations tab.

(2). On page load localhost:3000/#annotations:<id>
-    clicking on new page note should select the notes tab.
-    When an annotation/note is selected, the tab selection carries between group changes.
-    all tests listed in num1 above should apply.

(3). On page load  localhost:3000/#annotations:<orphan_id>
-   clicking on “show all annotations and notes” selects the annotations tab and displays all annotations.
-    all tests listed in num1 and num2 above should apply.
-    switching between groups selects the annotations tab by default


https://trello.com/c/1NVK2jwv/400-add-a-tab-for-unanchored-annotations
https://trello.com/c/OLdLTlLT/342-separate-annotations-and-notes

Hide orphans tab behind orphans_tab flag.
Add tests.