### PR TITLE
Fix crash annotating first word of line in PDF

### DIFF
--- a/h/static/scripts/annotator/anchoring/pdf.coffee
+++ b/h/static/scripts/annotator/anchoring/pdf.coffee
@@ -18,6 +18,8 @@ getSiblingIndex = (node) ->
 
 
 getNodeTextLayer = (node) ->
+  if node is null
+    return null
   until node.classList?.contains('page')
     node = node.parentNode
   return node.getElementsByClassName('textLayer')[0]
@@ -248,6 +250,10 @@ exports.describe = (root, range, options = {}) ->
 
   startTextLayer = getNodeTextLayer(range.start)
   endTextLayer = getNodeTextLayer(range.end)
+
+  if startTextLayer is null
+    startTextLayer = endTextLayer
+    range.start = range.end
 
   # XXX: range covers only one page
   if startTextLayer isnt endTextLayer


### PR DESCRIPTION
Fixes #54.

This change reliably fixes the crash seen in the console, on the example PDF file given in #54, when double-clicking to select the first word of a line and then annotating.

I don't _think_ this change breaks anything else but there are [so many issues with selecting text and annotating on PDFs](https://github.com/hypothesis/client/labels/PDF) (or perhaps one issue with lots of symptons) that it's hard to tell.