### PR TITLE
Replace "firstRun" config option with "openSidebar" and "openLoginForm"

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,30 @@
+Configuring the sidebar
+=======================
+
+The Hypothesis sidebar can be configured by providing a settings object in the
+body of the hosting page:
+
+```html
+<script type="application/json" class="js-hypothesis-config">
+  {
+    "openSidebar": true
+  }
+</script>
+<script async src="https://hypothes.is/embed.js"></script>
+```
+
+**N.B.** The body of the `.js-hypothesis-config` tag must be [valid
+JSON](http://jsonlint.com/) -- invalid JSON will cause the entire config object
+to be ignored.
+
+Config keys
+-----------
+
+### `openLoginForm`
+
+_Boolean_. Controls whether the login panel is automatically opened on startup,
+as if the user had clicked "Log in" themselves.
+
+### `openSidebar`
+
+_Boolean_. Controls whether the sidebar opens automatically on startup.

--- a/h/static/scripts/annotator/sidebar.coffee
+++ b/h/static/scripts/annotator/sidebar.coffee
@@ -24,7 +24,7 @@ module.exports = class Sidebar extends Host
     super
     this.hide()
 
-    if options.firstRun || options.annotations
+    if options.openSidebar || options.annotations
       this.on 'panelReady', => this.show()
 
     if @plugins.BucketBar?

--- a/h/static/scripts/annotator/test/config-test.js
+++ b/h/static/scripts/annotator/test/config-test.js
@@ -55,12 +55,12 @@ describe('annotator configuration', function () {
   it('merges the config from hypothesisConfig()', function () {
     var fakeWindow = Object.assign({}, fakeWindowBase, {
       hypothesisConfig: function () {
-        return {firstRun: true};
+        return {foo: true};
       },
     });
     assert.deepEqual(config(fakeWindow), {
       app: 'app.html',
-      firstRun: true,
+      foo: true,
     });
   });
 

--- a/h/static/scripts/app-controller.js
+++ b/h/static/scripts/app-controller.js
@@ -79,7 +79,11 @@ module.exports = function AppController(
     // update the auth info in the top bar and show the login form
     // after first install of the extension.
     $scope.auth = authStateFromUserID(state.userid);
-    if (!state.userid && settings.firstRun) {
+
+    // FIXME: Fix this horrendous !== 'false' conditional. Unfortunately, we
+    // currently pass settings from the hosting page into the sidebar via the
+    // URL query string, so type information is lost. Ugh.
+    if (!state.userid && settings.openLoginForm && settings.openLoginForm !== 'false') {
       $scope.login();
     }
   });

--- a/h/static/scripts/test/app-controller-test.js
+++ b/h/static/scripts/test/app-controller-test.js
@@ -94,7 +94,6 @@ describe('AppController', function () {
     };
 
     fakeSettings = {
-      firstRun: false,
       serviceUrl: 'http://fake.service.com/',
     };
 

--- a/scripts/gulp/live-reload-server.js
+++ b/scripts/gulp/live-reload-server.js
@@ -45,7 +45,7 @@ function LiveReloadServer(port, appServer) {
           liveReloadServer: 'ws://' + appHost + ':${port}',
 
           // Open the sidebar when the page loads
-          firstRun: true,
+          openSidebar: true,
         };
       };
 


### PR DESCRIPTION
This commit deprecates the confusingly-named "firstRun" embed script option with two which actually describe the relevant actions triggered.

Unfortunately, at the moment this requires a fairly horrific check that the string value of a config option is not the literal 'false', due to the way that the Host code passes configuration from the page frame to the sidebar frame (using URL query string parameters).

To make up for that, I've added a `docs/config.md` file in which to document these configuration options.