### PR TITLE
Embed release version in built package

### DIFF
--- a/h/static/scripts/directive/help-panel.js
+++ b/h/static/scripts/directive/help-panel.js
@@ -13,7 +13,7 @@ module.exports = function () {
     // @ngInject
     controller: function ($scope, $window, settings, crossframe) {
       this.userAgent = $window.navigator.userAgent;
-      this.version = settings.release;
+      this.version = '__VERSION__';  // replaced by versionify
       this.dateTime = new Date();
       this.serviceUrl = settings.serviceUrl;
 

--- a/h/static/scripts/raven.js
+++ b/h/static/scripts/raven.js
@@ -74,7 +74,7 @@ function translateSourceURLs(data) {
 
 function init(config) {
   Raven.config(config.dsn, {
-    release: config.release,
+    release: '__VERSION__',  // replaced by versionify
     dataCallback: translateSourceURLs,
   }).install();
   installUnhandledPromiseErrorHandler();

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -634,6 +634,23 @@
       "from": "browserify-transform-tools@>=1.5.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/browserify-transform-tools/-/browserify-transform-tools-1.6.0.tgz"
     },
+    "browserify-versionify": {
+      "version": "1.0.6",
+      "from": "browserify-versionify@>=1.0.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-versionify/-/browserify-versionify-1.0.6.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@0.6.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz"
+        }
+      }
+    },
     "browserify-zlib": {
       "version": "0.1.4",
       "from": "browserify-zlib@>=0.1.2 <0.2.0",
@@ -1602,6 +1619,11 @@
       "version": "0.3.0",
       "from": "find-parent-dir@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz"
+    },
+    "find-root": {
+      "version": "0.1.2",
+      "from": "find-root@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz"
     },
     "find-up": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "browserify": "^13.0.0",
     "browserify-ngannotate": "^1.0.1",
     "browserify-shim": "^3.8.12",
+    "browserify-versionify": "^1.0.6",
     "chai": "^3.5.0",
     "check-dependencies": "^0.12.0",
     "classnames": "^2.2.4",
@@ -95,6 +96,7 @@
     "transform": [
       "browserify-ngannotate",
       "browserify-shim",
+      "browserify-versionify",
       [
         "stringify",
         {


### PR DESCRIPTION
Rather than relying on the release version being passed in as config, build the current release version (as read from `package.json`) into the bundle.

We use browserify-versionify for this, rather than simply requiring `package.json`, as our current build toolchain does not support any kind of tree-shaking, so `require('package.json')` would pull the whole of the `package.json` file into the bundle.