### PR TITLE
Preserve types when passing config options to the sidebar app

### DIFF
--- a/h/static/scripts/annotator/host.coffee
+++ b/h/static/scripts/annotator/host.coffee
@@ -1,5 +1,4 @@
 Annotator = require('annotator')
-queryString = require('query-string')
 $ = Annotator.$
 
 Guest = require('./guest')
@@ -7,13 +6,13 @@ Guest = require('./guest')
 module.exports = class Host extends Guest
   constructor: (element, options) ->
     # Make a copy of all options except `options.app`, the app base URL.
-    appOpts = queryString.stringify(
-      Object.assign({}, options, {app: undefined})
+    configParam = 'config=' + encodeURIComponent(
+      JSON.stringify(Object.assign({}, options, {app:undefined}))
     )
     if options.app and '?' in options.app
-      options.app += '&' + appOpts
+      options.app += '&' + configParam
     else
-      options.app += '?' + appOpts
+      options.app += '?' + configParam
 
     # Create the iframe
     app = $('<iframe></iframe>')

--- a/h/static/scripts/annotator/test/host-test.coffee
+++ b/h/static/scripts/annotator/test/host-test.coffee
@@ -89,4 +89,5 @@ describe 'Host', ->
     it 'passes options to the sidebar iframe', ->
       appURL = new URL('/base/test/empty.html', window.location.href)
       host = createHost({annotations: '1234'})
-      assert.equal(host.frame[0].children[0].src, appURL + '?annotations=1234')
+      configStr = encodeURIComponent(JSON.stringify({annotations: '1234'}))
+      assert.equal(host.frame[0].children[0].src, appURL + '?config=' + configStr)

--- a/h/static/scripts/app-controller.js
+++ b/h/static/scripts/app-controller.js
@@ -80,10 +80,7 @@ module.exports = function AppController(
     // after first install of the extension.
     $scope.auth = authStateFromUserID(state.userid);
 
-    // FIXME: Fix this horrendous !== 'false' conditional. Unfortunately, we
-    // currently pass settings from the hosting page into the sidebar via the
-    // URL query string, so type information is lost. Ugh.
-    if (!state.userid && settings.openLoginForm && settings.openLoginForm !== 'false') {
+    if (!state.userid && settings.openLoginForm) {
       $scope.login();
     }
   });

--- a/h/static/scripts/app.js
+++ b/h/static/scripts/app.js
@@ -8,8 +8,9 @@ var raven;
 
 // Initialize Raven. This is required at the top of this file
 // so that it happens early in the app's startup flow
+var configParam = queryString.parse(window.location.search).config || 'null';
 var settings = require('./settings')(document);
-Object.assign(settings, queryString.parse(window.location.search));
+Object.assign(settings, JSON.parse(configParam));
 if (settings.raven) {
   raven = require('./raven');
   raven.init(settings.raven);


### PR DESCRIPTION
This is a follow up to #63 which fixes the hazard caused by loss of type information when passing config settings into the app by encoding the config settings as a JSON string which is then passed as a single query string parameter.