### PR TITLE
Add a service which provides Hypothesis service URLs

### DIFF
--- a/h/static/scripts/app-controller.js
+++ b/h/static/scripts/app-controller.js
@@ -25,7 +25,7 @@ function authStateFromUserID(userid) {
 module.exports = function AppController(
   $controller, $document, $location, $rootScope, $route, $scope,
   $window, annotationUI, auth, drafts, features, groups,
-  session, settings
+  serviceUrl, session, settings
 ) {
   $controller('AnnotationUIController', {$scope: $scope});
 
@@ -52,7 +52,7 @@ module.exports = function AppController(
   // the stream page or an individual annotation page.
   $scope.isSidebar = $window.top !== $window;
 
-  $scope.serviceUrl = settings.serviceUrl;
+  $scope.serviceUrl = serviceUrl;
 
   $scope.sortKey = function () {
     return annotationUI.getState().sortKey;

--- a/h/static/scripts/app.js
+++ b/h/static/scripts/app.js
@@ -182,6 +182,7 @@ module.exports = angular.module('h', [
   .service('queryParser', require('./query-parser'))
   .service('rootThread', require('./root-thread'))
   .service('searchFilter', require('./search-filter'))
+  .service('serviceUrl', require('./service-url'))
   .service('session', require('./session'))
   .service('streamer', require('./streamer'))
   .service('streamFilter', require('./stream-filter'))

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -50,8 +50,8 @@ function updateModel(annotation, changes, permissions) {
 // @ngInject
 function AnnotationController(
   $document, $q, $rootScope, $scope, $timeout, $window, annotationUI,
-  annotationMapper, drafts, flash, features, groups, permissions, session,
-  settings, store) {
+  annotationMapper, drafts, flash, features, groups, permissions, serviceUrl,
+  session, store) {
 
   var vm = this;
   var newlyCreatedByHighlightButton;
@@ -93,8 +93,7 @@ function AnnotationController(
     // The remaining properties on vm are read-only properties for the
     // templates.
 
-    /** The URL for the Hypothesis service, e.g. 'https://hypothes.is/'. */
-    vm.serviceUrl = settings.serviceUrl;
+    vm.serviceUrl = serviceUrl;
 
     /** Give the template access to the feature flags. */
     vm.feature = features.flagEnabled;
@@ -438,7 +437,7 @@ function AnnotationController(
   };
 
   vm.tagStreamURL = function(tag) {
-    return vm.serviceUrl + 'stream?q=tag:' + encodeURIComponent(tag);
+    return serviceUrl('search.tag', {tag: tag});
   };
 
   vm.target = function() {

--- a/h/static/scripts/directive/group-list.js
+++ b/h/static/scripts/directive/group-list.js
@@ -19,18 +19,18 @@ function GroupListController($scope, $window, groups) {
 /**
  * @ngdoc directive
  * @name groupList
- * @restrict AE
+ * @restrict E
  * @description Displays a list of groups of which the user is a member.
  */
 // @ngInject
-function groupList( $window, groups, settings) {
+function groupList($window, groups, serviceUrl) {
   return {
     controller: GroupListController,
     link: function ($scope) {
       $scope.groups = groups;
 
       $scope.createNewGroup = function() {
-        $window.open(settings.serviceUrl + 'groups/new', '_blank');
+        $window.open(serviceUrl('groups.new'), '_blank');
       };
     },
     restrict: 'E',

--- a/h/static/scripts/directive/help-panel.js
+++ b/h/static/scripts/directive/help-panel.js
@@ -11,11 +11,11 @@ module.exports = function () {
     bindToController: true,
     controllerAs: 'vm',
     // @ngInject
-    controller: function ($scope, $window, settings, crossframe) {
+    controller: function ($scope, $window, crossframe, serviceUrl) {
       this.userAgent = $window.navigator.userAgent;
       this.version = '__VERSION__';  // replaced by versionify
       this.dateTime = new Date();
-      this.serviceUrl = settings.serviceUrl;
+      this.serviceUrl = serviceUrl;
 
       $scope.$watchCollection(
         function () {

--- a/h/static/scripts/directive/loggedout-message.js
+++ b/h/static/scripts/directive/loggedout-message.js
@@ -5,8 +5,8 @@ module.exports = function () {
     bindToController: true,
     controllerAs: 'vm',
     //@ngInject
-    controller: function (settings) {
-      this.serviceUrl = settings.serviceUrl;
+    controller: function (serviceUrl) {
+      this.serviceUrl = serviceUrl;
     },
     restrict: 'E',
     scope: {

--- a/h/static/scripts/directive/login-control.js
+++ b/h/static/scripts/directive/login-control.js
@@ -5,8 +5,8 @@ module.exports = function () {
     bindToController: true,
     controllerAs: 'vm',
     //@ngInject
-    controller: function (settings) {
-      this.serviceUrl = settings.serviceUrl;
+    controller: function (serviceUrl) {
+      this.serviceUrl = serviceUrl;
     },
     restrict: 'E',
     scope: {

--- a/h/static/scripts/directive/login-form.js
+++ b/h/static/scripts/directive/login-form.js
@@ -3,7 +3,7 @@
 var angular = require('angular');
 
 // @ngInject
-function Controller($scope, $timeout, flash, session, formRespond, settings) {
+function Controller($scope, $timeout, flash, session, formRespond, serviceUrl) {
   var pendingTimeout = null;
 
   function success(data) {
@@ -52,7 +52,7 @@ function Controller($scope, $timeout, flash, session, formRespond, settings) {
     pendingTimeout = null;
   }
 
-  this.serviceUrl = settings.serviceUrl;
+  this.serviceUrl = serviceUrl;
 
   this.submit = function submit(form) {
     formRespond(form);

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -87,6 +87,7 @@ describe('annotation', function() {
     var fakeFlash;
     var fakeGroups;
     var fakePermissions;
+    var fakeServiceUrl;
     var fakeSession;
     var fakeStore;
     var sandbox;
@@ -169,9 +170,7 @@ describe('annotation', function() {
         },
       };
 
-      var fakeSettings = {
-        serviceUrl: 'https://test.hypothes.is/',
-      };
+      fakeServiceUrl = sinon.stub();
 
       fakeGroups = {
         focused: function() {
@@ -199,7 +198,7 @@ describe('annotation', function() {
       $provide.value('groups', fakeGroups);
       $provide.value('permissions', fakePermissions);
       $provide.value('session', fakeSession);
-      $provide.value('settings', fakeSettings);
+      $provide.value('serviceUrl', fakeServiceUrl);
       $provide.value('store', fakeStore);
     }));
 
@@ -945,6 +944,10 @@ describe('annotation', function() {
 
     describe('tag display', function () {
       it('displays links to tags on the stream', function () {
+        fakeServiceUrl
+          .withArgs('search.tag', {tag: 'atag'})
+          .returns('https://test.hypothes.is/stream?q=tag:atag');
+
         var directive = createDirective({
           id: '1234',
           tags: ['atag'],
@@ -953,6 +956,7 @@ describe('annotation', function() {
         var tagLinks = links.filter(function (link) {
           return link.textContent === 'atag';
         });
+
         assert.equal(tagLinks.length, 1);
         assert.equal(tagLinks[0].href,
                      'https://test.hypothes.is/stream?q=tag:atag');

--- a/h/static/scripts/directive/test/group-list-test.js
+++ b/h/static/scripts/directive/test/group-list-test.js
@@ -12,23 +12,21 @@ describe('groupList', function () {
 
   var groups;
   var fakeGroups;
-  var fakeSettings = {
-    serviceUrl: 'https://test.hypothes.is/',
-  };
+  var fakeServiceUrl;
 
   before(function() {
     angular.module('app', [])
       .directive('groupList', groupList.directive)
       .factory('groups', function () {
         return fakeGroups;
-      })
-      .factory('settings', function () {
-        return fakeSettings;
       });
   });
 
   beforeEach(function () {
-    angular.mock.module('app');
+    fakeServiceUrl = sinon.stub();
+    angular.mock.module('app', {
+      serviceUrl: fakeServiceUrl,
+    });
   });
 
   beforeEach(angular.mock.inject(function (_$window_) {
@@ -112,12 +110,16 @@ describe('groupList', function () {
   });
 
   it('should open a window when "New Group" is clicked', function () {
+    fakeServiceUrl
+      .withArgs('groups.new')
+      .returns('https://test.hypothes.is/groups/new');
+
     var element = createGroupList();
     $window.open = sinon.stub();
     var newGroupLink =
       element[0].querySelector('.new-group-btn a');
     angular.element(newGroupLink).click();
-    assert.calledWith($window.open, fakeSettings.serviceUrl + 'groups/new',
+    assert.calledWith($window.open, 'https://test.hypothes.is/groups/new',
       '_blank');
   });
 });

--- a/h/static/scripts/groups.js
+++ b/h/static/scripts/groups.js
@@ -16,7 +16,7 @@ var STORAGE_KEY = 'hypothesis.groups.focus';
 var events = require('./events');
 
 // @ngInject
-function groups(localStorage, session, settings, $rootScope, $http) {
+function groups(localStorage, serviceUrl, session, $rootScope, $http) {
   // The currently focused group. This is the group that's shown as selected in
   // the groups dropdown, the annotations displayed are filtered to only ones
   // that belong to this group, and any new annotations that the user creates
@@ -44,7 +44,7 @@ function groups(localStorage, session, settings, $rootScope, $http) {
   function leave(id) {
     var response = $http({
       method: 'POST',
-      url: settings.serviceUrl + 'groups/' + id + '/leave',
+      url: serviceUrl('groups.leave', {id: id}),
     });
 
     // the groups list will be updated in response to a session state

--- a/h/static/scripts/service-url.js
+++ b/h/static/scripts/service-url.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var urlUtil = require('./util/url-util');
+
+/**
+ * A map of all route names to relative URLs on the Hypothesis service that
+ * the client links to.
+ *
+ * The URLs are relative to the `serviceUrl` URL in the app's settings.
+ */
+var ROUTES = {
+  'account.settings': 'account/settings',
+  'forgot-password': 'forgot-password',
+  'groups.leave': 'groups/:id/leave',
+  'groups.new': 'groups/new',
+  'help': 'docs/help',
+  'signup': 'signup',
+  'search.tag': 'stream?q=tag::tag',
+  'user': 'u/:user',
+};
+
+/**
+ * A service which maps route names to URLs on the Hypothesis annotation
+ * service.
+ */
+// @ngInject
+function serviceUrl(settings) {
+  return function (route, params) {
+    params = params || {};
+
+    var path = ROUTES[route];
+    if (!path) {
+      throw new Error('Unknown route ' + route);
+    }
+    var url = urlUtil.replaceURLParams(path, params);
+
+    var unused = Object.keys(url.params);
+    if (unused.length > 0) {
+      throw new Error('Unknown route parameters: ' + unused.join(', '));
+    }
+
+    return settings.serviceUrl + url.url;
+  };
+}
+
+module.exports = serviceUrl;

--- a/h/static/scripts/test/app-controller-test.js
+++ b/h/static/scripts/test/app-controller-test.js
@@ -20,6 +20,7 @@ describe('AppController', function () {
   var fakeSession = null;
   var fakeGroups = null;
   var fakeRoute = null;
+  var fakeServiceUrl = null;
   var fakeSettings = null;
   var fakeWindow = null;
 
@@ -93,14 +94,14 @@ describe('AppController', function () {
       confirm: sandbox.stub(),
     };
 
-    fakeSettings = {
-      serviceUrl: 'http://fake.service.com/',
-    };
+    fakeServiceUrl = sinon.stub();
+    fakeSettings = {};
 
     $provide.value('annotationUI', fakeAnnotationUI);
     $provide.value('auth', fakeAuth);
     $provide.value('drafts', fakeDrafts);
     $provide.value('features', fakeFeatures);
+    $provide.value('serviceUrl', fakeServiceUrl);
     $provide.value('session', fakeSession);
     $provide.value('settings', fakeSettings);
     $provide.value('groups', fakeGroups);
@@ -187,7 +188,7 @@ describe('AppController', function () {
 
   it('exposes the serviceUrl on the scope', function () {
     createController();
-    assert.equal($scope.serviceUrl, 'http://fake.service.com/');
+    assert.equal($scope.serviceUrl, fakeServiceUrl);
   });
 
   it('does not show login form for logged in users', function () {

--- a/h/static/scripts/test/groups-test.js
+++ b/h/static/scripts/test/groups-test.js
@@ -21,9 +21,7 @@ describe('groups', function() {
   var fakeLocalStorage;
   var fakeRootScope;
   var fakeHttp;
-  var fakeSettings = {
-    serviceUrl: 'https://test.hypothes.is/',
-  };
+  var fakeServiceUrl;
   var sandbox;
 
   beforeEach(function() {
@@ -46,6 +44,7 @@ describe('groups', function() {
       },
     };
     fakeHttp = sandbox.stub();
+    fakeServiceUrl = sandbox.stub();
   });
 
   afterEach(function () {
@@ -53,8 +52,8 @@ describe('groups', function() {
   });
 
   function service() {
-    return groups(fakeLocalStorage, fakeSession,
-                  fakeSettings, fakeRootScope, fakeHttp);
+    return groups(fakeLocalStorage, fakeServiceUrl, fakeSession,
+      fakeRootScope, fakeHttp);
   }
 
   describe('.all()', function() {
@@ -174,9 +173,12 @@ describe('groups', function() {
   describe('.leave()', function () {
     it('should call the /groups/<id>/leave service', function () {
       var s = service();
+      fakeServiceUrl
+        .withArgs('groups.leave', {id: 'id2'})
+        .returns('https://hyp.is/groups/leave');
       s.leave('id2');
       assert.calledWithMatch(fakeHttp, {
-        url: fakeSettings.serviceUrl + 'groups/id2/leave',
+        url: 'https://hyp.is/groups/leave',
         method: 'POST',
       });
     });

--- a/h/static/scripts/test/login-form-test.coffee
+++ b/h/static/scripts/test/login-form-test.coffee
@@ -36,7 +36,7 @@ describe 'loginForm.Controller', ->
     $provide.value 'flash', mockFlash
     $provide.value 'session', new MockSession()
     $provide.value 'formRespond', mockFormRespond
-    $provide.value 'settings', sandbox.spy()
+    $provide.value 'serviceUrl', sandbox.spy()
     return
 
   beforeEach inject (_$controller_, $rootScope, _$timeout_, _session_) ->

--- a/h/static/scripts/test/service-url-test.js
+++ b/h/static/scripts/test/service-url-test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var serviceUrl = require('../service-url');
+
+describe('serviceUrl', function () {
+  var service;
+
+  beforeEach(function () {
+    service = serviceUrl({serviceUrl: 'https://test.hypothes.is/'});
+  });
+
+  it('returns route URLs', function () {
+    assert.equal(service('help'), 'https://test.hypothes.is/docs/help');
+  });
+
+  it('expands route parameters', function () {
+    assert.equal(service('user', {user: 'jim'}),
+      'https://test.hypothes.is/u/jim');
+  });
+});

--- a/h/static/scripts/util/test/url-util-test.js
+++ b/h/static/scripts/util/test/url-util-test.js
@@ -10,6 +10,12 @@ describe('url-util', function () {
       assert.equal(replaced.url, 'http://foo.com/things/test');
     });
 
+    it('should URL encode params in URLs', function () {
+      var replaced = urlUtil.replaceURLParams('http://foo.com/things/:id',
+        {id: 'foo=bar'});
+      assert.equal(replaced.url, 'http://foo.com/things/foo%3Dbar');
+    });
+
     it('should return unused params', function () {
       var replaced = urlUtil.replaceURLParams('http://foo.com/:id',
         {id: 'test', 'q': 'unused'});

--- a/h/static/scripts/util/url-util.js
+++ b/h/static/scripts/util/url-util.js
@@ -16,7 +16,7 @@ function replaceURLParams(url, params) {
       var value = params[param];
       var urlParam = ':' + param;
       if (url.indexOf(urlParam) !== -1) {
-        url = url.replace(urlParam, value);
+        url = url.replace(urlParam, encodeURIComponent(value));
       } else {
         unusedParams[param] = value;
       }

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -8,7 +8,7 @@
     <span ng-if="vm.user()">
       <a class="annotation-header__user"
         target="_blank"
-        ng-href="{{::vm.serviceUrl}}u/{{vm.user()}}"
+        ng-href="{{vm.serviceUrl('user',{user:vm.user()})}}"
         >{{vm.username()}}</a>
       <span class="annotation-collapsed-replies">
         <a class="annotation-link" href=""

--- a/h/templates/client/app.html
+++ b/h/templates/client/app.html
@@ -13,7 +13,7 @@
 
 <div class="create-account-banner" ng-if="isSidebar && auth.status === 'logged-out'" ng-cloak>
   To annotate this document
-  <a href="{{ serviceUrl }}signup" target="_blank">
+  <a href="{{ serviceUrl('signup') }}" target="_blank">
     create a free account
   </a>
   or <a href="" ng-click="login()">log in</a>

--- a/h/templates/client/help_panel.html
+++ b/h/templates/client/help_panel.html
@@ -17,7 +17,7 @@
       date-time="vm.dateTime">
     </help-link>
     if you have any questions or want to give us feedback.
-    You can also visit our <a class="help-panel-content__link" href="{{vm.serviceUrl}}docs/help" target="_blank"> help documents</a>.
+    You can also visit our <a class="help-panel-content__link" href="{{vm.serviceUrl('help')}}" target="_blank"> help documents</a>.
   </div>
   <header class="help-panel-title">
     About this version

--- a/h/templates/client/loggedout_message.html
+++ b/h/templates/client/loggedout_message.html
@@ -4,7 +4,7 @@
     This is a public annotation created with Hypothesis.
     <br>
     To reply or make your own annotations on this document,
-    <a class="loggedout-message__link" href="{{vm.serviceUrl}}signup" target="_blank">create a free account</a>
+    <a class="loggedout-message__link" href="{{vm.serviceUrl('signup')}}" target="_blank">create a free account</a>
     or
     <a class="loggedout-message__link" href="" ng-click="vm.onLogin()">log in</a>.
   </span>

--- a/h/templates/client/login_control.html
+++ b/h/templates/client/login_control.html
@@ -3,7 +3,7 @@
       ng-if="vm.newStyle && vm.auth.status === 'unknown'">⋯</span>
 <span class="login-text"
       ng-if="vm.newStyle && vm.auth.status === 'logged-out'">
-  <a href="{{vm.serviceUrl}}signup" target="_blank">Sign up</a>
+  <a href="{{vm.serviceUrl('signup')}}" target="_blank">Sign up</a>
   / <a href="" ng-click="vm.onLogin()">Log in</a>
 </span>
 <div ng-if="vm.newStyle"
@@ -20,13 +20,13 @@
   </a>
   <ul class="dropdown-menu pull-right" role="menu">
     <li class="dropdown-menu__row" ng-if="vm.auth.status === 'logged-in'">
-      <a href="{{vm.serviceUrl}}stream?q=user:{{vm.auth.username}}"
+      <a href="{{vm.serviceUrl('user',{user: vm.auth.username})}}"
          class="dropdown-menu__link"
          title="View all your annotations"
          target="_blank">{{vm.auth.username}}</a>
     </li>
     <li class="dropdown-menu__row" ng-if="vm.auth.status === 'logged-in'">
-      <a class="dropdown-menu__link" href="{{vm.serviceUrl}}profile" target="_blank">Account settings</a>
+      <a class="dropdown-menu__link" href="{{vm.serviceUrl('account.settings')}}" target="_blank">Account settings</a>
     </li>
     <li class="dropdown-menu__row">
       <a class="dropdown-menu__link" ng-click="vm.onShowHelpPanel()">Help</a>
@@ -55,13 +55,13 @@
   </span>
   <ul class="dropdown-menu pull-right" role="menu">
     <li class="dropdown-menu__row" ng-if="vm.auth.status === 'logged-in'">
-      <a class="dropdown-menu__link" href="{{vm.serviceUrl}}profile" target="_blank">Account</a>
+      <a class="dropdown-menu__link" href="{{vm.serviceUrl('account.settings')}}" target="_blank">Account</a>
     </li>
     <li class="dropdown-menu__row" >
       <a class="dropdown-menu__link" ng-click="vm.onShowHelpPanel()">Help</a>
     </li>
     <li class="dropdown-menu__row" ng-if="vm.auth.status === 'logged-in'">
-      <a class="dropdown-menu__link" href="{{vm.serviceUrl}}stream?q=user:{{vm.auth.username}}"
+      <a class="dropdown-menu__link" href="{{vm.serviceUrl('user',{user: vm.auth.username})}}"
          target="_blank">My Annotations</a>
     </li>
     <li class="dropdown-menu__row" ng-if="vm.auth.status === 'logged-in'">

--- a/h/templates/client/login_form.html
+++ b/h/templates/client/login_form.html
@@ -53,7 +53,7 @@
 
         <div class="form-actions">
           <div class="form-actions-message">
-            <a href="{{vm.serviceUrl}}forgot-password" target="_blank">Forgot your password?</a>
+            <a href="{{vm.serviceUrl('forgot-password')}}" target="_blank">Forgot your password?</a>
           </div>
           <div class="form-actions-buttons">
             <button class="btn btn-primary" type="submit" name="login"


### PR DESCRIPTION
_Note: This should be updated and merged after https://github.com/hypothesis/client/pull/68. The routes defined in `service-url.js` will then need to be updated to refer to the new URLs for all routes_

Add a `serviceUrl` service which maps named, parameterized routes to corresponding
URLs on the Hypothesis service.

This makes it easier to identify which URLs the client links to on the
service and update all uses of a particular URL.

In the process this fixes an inconsistency where links to users linked to `/u/:user` annotation cards but `/stream?q=user:<username>` in the settings menu.