### PR TITLE
Fix error when annotations are removed before the anchoring timeout expires

### DIFF
--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -13,7 +13,7 @@ var redux = require('redux');
 
 var metadata = require('./annotation-metadata');
 var uiConstants = require('./ui-constants');
-var countIf = require('./util/array-util').countIf;
+var arrayUtil = require('./util/array-util');
 
 function freeze(selection) {
   if (Object.keys(selection).length) {
@@ -128,7 +128,7 @@ function annotationsReducer(state, action) {
       var annots = excludeAnnotations(state.annotations, action.annotations);
       var selectedTab = state.selectedTab;
       if (selectedTab === uiConstants.TAB_ORPHANS &&
-          countIf(annots, metadata.isOrphan) === 0) {
+          arrayUtil.countIf(annots, metadata.isOrphan) === 0) {
         selectedTab = uiConstants.TAB_ANNOTATIONS;
       }
       return Object.assign({}, state, {
@@ -375,8 +375,8 @@ module.exports = function ($rootScope, settings) {
       var anchoringAnnots = annotations.filter(metadata.isWaitingToAnchor);
       if (anchoringAnnots.length) {
         setTimeout(function () {
-          anchoringAnnots
-            .map(function (annot) {
+          arrayUtil
+            .filterMap(anchoringAnnots, function (annot) {
               return findByID(annot.id);
             })
             .filter(metadata.isWaitingToAnchor)

--- a/h/static/scripts/test/annotation-ui-test.js
+++ b/h/static/scripts/test/annotation-ui-test.js
@@ -92,6 +92,17 @@ describe('annotationUI', function () {
 
       assert.isFalse(isOrphan());
     });
+
+    it('does not attempt to modify orphan status if annotations are removed before anchoring timeout expires', function () {
+      var annot = defaultAnnotation();
+      annotationUI.addAnnotations([annot]);
+      annotationUI.updateAnchorStatus(annot.id, 'atag', false);
+      annotationUI.removeAnnotations([annot]);
+
+      assert.doesNotThrow(function () {
+        clock.tick(ANCHOR_TIME_LIMIT);
+      });
+    });
   });
 
   describe('#removeAnnotations()', function () {

--- a/h/static/scripts/util/array-util.js
+++ b/h/static/scripts/util/array-util.js
@@ -1,11 +1,37 @@
 'use strict';
 
+/**
+ * Return the number of elements in `ary` for which `predicate` returns true.
+ *
+ * @param {Array} ary
+ * @param {Function} predicate
+ */
 function countIf(ary, predicate) {
   return ary.reduce(function (count, item) {
     return predicate(item) ? count + 1 : count;
   }, 0);
 }
 
+/**
+ * Create a new array with the result of calling `mapFn` on every element in
+ * `ary`.
+ *
+ * Only truthy values are included in the resulting array.
+ *
+ * @param {Array} ary
+ * @param {Function} mapFn
+ */
+function filterMap(ary, mapFn) {
+  return ary.reduce(function (newArray, item) {
+    var mapped = mapFn(item);
+    if (mapped) {
+      newArray.push(mapped);
+    }
+    return newArray;
+  }, []);
+}
+
 module.exports = {
   countIf: countIf,
+  filterMap: filterMap,
 };


### PR DESCRIPTION
If an annotation is loaded and then quickly removed before the anchoring
timeout expires, the call to `findByID()` will return null, causing an
error when trying to check the `$orphan` flag in `isWaitingToAnchor`.

Fix this by ignoring annotations which no longer exist when the timeout
expires.