### PR TITLE
Fix display of annotations on stream with orphans flag enabled

### DIFF
--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -40,6 +40,10 @@ function initialSelection(settings) {
 
 function initialState(settings) {
   return Object.freeze({
+    // Flag that indicates whether the app is the sidebar and connected to
+    // a page where annotations are being shown in context
+    isSidebar: true,
+
     // List of all loaded annotations
     annotations: [],
 
@@ -94,6 +98,13 @@ var types = {
    * document completes.
    */
   UPDATE_ANCHOR_STATUS: 'UPDATE_ANCHOR_STATUS',
+  /**
+   * Set whether the app is the sidebar or not.
+   *
+   * When not in the sidebar, we do not expect annotations to anchor and always
+   * display all annotations, rather than only those in the current tab.
+   */
+  SET_SIDEBAR: 'SET_SIDEBAR',
 };
 
 /**
@@ -187,6 +198,8 @@ function reducer(state, action) {
       forceVisible: {},
       expanded: {},
     });
+  case types.SET_SIDEBAR:
+    return Object.assign({}, state, {isSidebar: action.isSidebar});
   case types.SET_SORT_KEY:
     return Object.assign({}, state, {sortKey: action.key});
   default:
@@ -367,6 +380,10 @@ module.exports = function ($rootScope, settings) {
         annotations: annotations,
       });
 
+      if (!store.getState().isSidebar) {
+        return;
+      }
+
       // If anchoring fails to complete in a reasonable amount of time, then
       // we assume that the annotation failed to anchor. If it does later
       // successfully anchor then the status will be updated.
@@ -457,6 +474,11 @@ module.exports = function ($rootScope, settings) {
         type: types.HIGHLIGHT_ANNOTATIONS,
         highlighted: ids,
       });
+    },
+
+    /** Set whether the app is the sidebar */
+    setAppIsSidebar: function (isSidebar) {
+      store.dispatch({type: types.SET_SIDEBAR, isSidebar: isSidebar});
     },
   };
 };

--- a/h/static/scripts/annotation-viewer-controller.js
+++ b/h/static/scripts/annotation-viewer-controller.js
@@ -29,6 +29,8 @@ function AnnotationViewerController (
   $location, $routeParams, $scope,
   annotationUI, rootThread, streamer, store, streamFilter, annotationMapper
 ) {
+  annotationUI.setAppIsSidebar(false);
+
   var id = $routeParams.id;
 
   // Provide no-ops until these methods are moved elsewere. They only apply

--- a/h/static/scripts/root-thread.js
+++ b/h/static/scripts/root-thread.js
@@ -59,7 +59,7 @@ function RootThread($rootScope, annotationUI, features, searchFilter, viewFilter
     }
 
     var threadFilterFn;
-    if (!state.filterQuery && state.selectedTab) {
+    if (state.isSidebar && !state.filterQuery) {
       if (!features.flagEnabled('orphans_tab')) {
         threadFilterFn = function (thread) {
           if (state.selectedTab === uiConstants.TAB_ANNOTATIONS || state.selectedTab === uiConstants.TAB_ORPHANS) {

--- a/h/static/scripts/stream-controller.coffee
+++ b/h/static/scripts/stream-controller.coffee
@@ -13,6 +13,8 @@ module.exports = class StreamController
      queryParser,   rootThread,   searchFilter,   store,
      streamer,   streamFilter,   annotationMapper
   ) ->
+    annotationUI.setAppIsSidebar(false)
+
     offset = 0
 
     fetch = (limit) ->

--- a/h/static/scripts/test/annotation-ui-test.js
+++ b/h/static/scripts/test/annotation-ui-test.js
@@ -103,6 +103,20 @@ describe('annotationUI', function () {
         clock.tick(ANCHOR_TIME_LIMIT);
       });
     });
+
+    it('does not expect annotations to anchor on the stream', function () {
+      var isOrphan = function () {
+        return !!metadata.isOrphan(annotationUI.getState().annotations[0]);
+      };
+
+      var annot = defaultAnnotation();
+      annotationUI.setAppIsSidebar(false);
+      annotationUI.addAnnotations([annot]);
+
+      clock.tick(ANCHOR_TIME_LIMIT);
+
+      assert.isFalse(isOrphan());
+    });
   });
 
   describe('#removeAnnotations()', function () {

--- a/h/static/scripts/test/annotation-viewer-controller-test.js
+++ b/h/static/scripts/test/annotation-viewer-controller-test.js
@@ -57,6 +57,7 @@ describe('AnnotationViewerController', function () {
         search: {},
       },
       annotationUI: {
+        setAppIsSidebar: sinon.stub(),
         setCollapsed: sinon.stub(),
         highlightAnnotations: sinon.stub(),
         subscribe: sinon.stub(),

--- a/h/static/scripts/test/root-thread-test.js
+++ b/h/static/scripts/test/root-thread-test.js
@@ -38,6 +38,7 @@ describe('rootThread', function () {
         focusedAnnotationMap: null,
         forceVisible: {},
         highlighted: [],
+        isSidebar: true,
         selectedAnnotationMap: null,
         sortKey: 'Location',
         sortKeysAvailable: ['Location'],
@@ -186,7 +187,7 @@ describe('rootThread', function () {
     ]);
   });
 
-  describe('when the thread filter query is set', function () {
+  describe('when no filter query is set', function () {
     it('filter matches only annotations when Annotations tab is selected', function () {
       fakeBuildThread.reset();
 
@@ -249,6 +250,19 @@ describe('rootThread', function () {
       var threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
 
       assert.isFalse(threadFilterFn({annotation: {$orphan: true}}));
+    });
+
+    it('does not filter annotations when not in the sidebar', function () {
+      fakeBuildThread.reset();
+      fakeAnnotationUI.state = Object.assign({}, fakeAnnotationUI.state,
+        {isSidebar: false});
+
+      rootThread.thread(fakeAnnotationUI.state);
+      var threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
+
+      // There should be no thread filter function on the stream and standalone
+      // pages, since we show all types of annotations here
+      assert.notOk(threadFilterFn);
     });
   });
 

--- a/h/static/scripts/test/stream-controller-test.coffee
+++ b/h/static/scripts/test/stream-controller-test.coffee
@@ -40,6 +40,7 @@ describe 'StreamController', ->
 
     fakeAnnotationUI = {
       clearAnnotations: sandbox.spy()
+      setAppIsSidebar: sandbox.spy()
       setCollapsed: sandbox.spy()
       setForceVisible: sandbox.spy()
       setSortKey: sandbox.spy()


### PR DESCRIPTION
 - Only mark annotations as orphans after a timeout in the sidebar,
   not in the stream where anchoring does not happen.
 - Do not filter annotations by type on the stream, where annotation
   tabs are not displayed.