### PR TITLE
Feature-flag orphan quote strikethrough on annotation cards

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -443,11 +443,15 @@ function AnnotationController(
   vm.target = function() {
     return vm.annotation.target;
   };
-  
+
+  // Note: We fetch the feature flag outside the `isOrphan` method to avoid a
+  // lookup on every $digest cycle
+  var indicateOrphans = features.flagEnabled('orphans_tab');
+
   vm.isOrphan = function() {
-    return vm.annotation.$orphan;
+    return vm.annotation.$orphan && indicateOrphans;
   };
-  
+
   vm.updated = function() {
     return vm.annotation.updated;
   };


### PR DESCRIPTION
When the orphans feature flag is not set, do not indicate orphans in
annotation cards by striking through their quotes.

The feature flag is hoisted outside of the `isOrphan` call because I
recall that `flagEnabled` was actually quite an expensive call in the
past so we want to avoid invoking it during every digest cycle.