### PR TITLE
Add a delay after pushing a new tag before trying to create a GH release

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "test": "gulp test-app",
     "preversion": "npm run test",
     "version": "make clean all && ./scripts/update-changelog.js && git add CHANGELOG.md",
-    "postversion": "git push && git push --tags && ./scripts/create-github-release.js",
+    "postversion": "./scripts/postversion.sh",
     "prepublish": "npm run-script build"
   }
 }

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+SCRIPT_DIR=$(dirname `readlink -f "$0"`)
+
+git push
+git push --tags
+
+# Wait a moment to give GitHub a chance to realize that the tag exists
+sleep 2
+
+$SCRIPT_DIR/create-github-release.js


### PR DESCRIPTION
Avoid an issue where trying to create a GH release immediately after
pushing the tag often fails.

This is the same hack that is used in the `release` script in the `h` repo, though I've doubled the timeout, since that obviously makes the solution twice as good.