### PR TITLE
On group change, reset tab selection to annotations if the selected t…

### DIFF
--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -325,9 +325,6 @@ module.exports = function WidgetController(
     }
     annotationUI.clearSelectedAnnotations();
     loadAnnotations(crossframe.frames);
-
-    // When switching groups, reset back to the annotations tab
-    annotationUI.selectTab(uiConstants.TAB_ANNOTATIONS);
   });
 
   // Watch anything that may require us to reload annotations.


### PR DESCRIPTION
On group change, reset tab selection to annotations if the selected tab is orphans. Otherwise carry the tab selection to the changed group.

https://trello.com/c/77XapyTt/427-update-rules-for-determining-which-tab-is-selected-in-the-sidebar