### PR TITLE
Remove "assertion" GET param from token requests

### DIFF
--- a/h/static/scripts/auth.js
+++ b/h/static/scripts/auth.js
@@ -24,12 +24,9 @@ var cachedToken = INITIAL_TOKEN;
  * @return {Promise} - A promise for a new JWT token.
  */
 // @ngInject
-function fetchToken($http, session, settings) {
+function fetchToken($http, settings) {
   var tokenUrl = new URL('token', settings.apiUrl).href;
   var config = {
-    params: {
-      assertion: session.state.csrf,
-    },
     // Skip JWT authorization for the token request itself.
     skipAuthorization: true,
     transformRequest: function (data) {
@@ -50,7 +47,7 @@ function fetchToken($http, session, settings) {
 // @ngInject
 function fetchOrReuseToken($http, jwtHelper, session, settings) {
   function refreshToken() {
-    return fetchToken($http, session, settings).then(function (token) {
+    return fetchToken($http, settings).then(function (token) {
       return token;
     });
   }

--- a/h/static/scripts/test/auth-test.js
+++ b/h/static/scripts/test/auth-test.js
@@ -16,7 +16,6 @@ describe('auth', function () {
       get: sinon.spy(function (url, config) {
         assert.equal(config.skipAuthorization, true);
         assert.equal(url, 'https://test.hypothes.is/api/token');
-        assert.equal(config.params.assertion, fakeSession.state.csrf);
 
         var result = {status: 200, data: fakeTokens[fakeTokenIndex]};
         ++fakeTokenIndex;


### PR DESCRIPTION
When fetching a JWT from the server, the client needs to supply the session CSRF token in order to prevent third-party pages from being able to fetch and use tokens without the user's permission.

Previously, it was necessary to supply this token in the "assertion" GET parameter -- in an attempt to make this look a bit like an OAuth token issuance API -- but in Pyramid 1.7 this isn't allowed, and it turns out not to be necessary, because Angular's CSRF support retrieves the token from an XSRF-TOKEN cookie set in earlier requests and sets the X-CSRF-Token request header automatically.