### PR TITLE
Remove "assertion" GET param from token requests

### DIFF
--- a/h/static/scripts/test/auth-test.js
+++ b/h/static/scripts/test/auth-test.js
@@ -13,10 +13,13 @@ describe('auth', function () {
   beforeEach(function () {
     fakeTokenIndex = 0;
     fakeHttp = {
+      defaults: {xsrfHeaderName: 'X-CSRF-Token'},
       get: sinon.spy(function (url, config) {
         assert.equal(config.skipAuthorization, true);
         assert.equal(url, 'https://test.hypothes.is/api/token');
-        assert.equal(config.params.assertion, fakeSession.state.csrf);
+        assert.deepEqual(config.headers, {
+          'X-CSRF-Token': fakeSession.state.csrf,
+        });
 
         var result = {status: 200, data: fakeTokens[fakeTokenIndex]};
         ++fakeTokenIndex;


### PR DESCRIPTION
When fetching a JWT from the server, the client needs to supply the session CSRF token in order to prevent third-party pages from being able to fetch and use tokens without the user's permission.

Previously, we supplied the CSRF token in an "assertion" GET parameter (partially in an attempt to make this look a bit like an OAuth token issuance API) but in Pyramid 1.7 this isn't allowed. (This is good: allowing the CSRF to be passed as a GET parameter makes it easier to construct a cross-domain attack which retrieves a token for the user).

This commit moves the CSRF token into a request header, which works because there are only two legitimate situations in which this request is made:

- from an embed iframe, which is on the same origin as the service
- from a Chrome extension iframe, which is permitted to make cross-origin XHR requests to URLs specified in the manifest (in our case, `<all_urls>`).

Note that we cannot rely on Angular's built-in CSRF support here, because it does not operate for cross-domain requests.