### PR TITLE
Sort notes tab by date

### DIFF
--- a/h/static/scripts/test/annotation-ui-test.js
+++ b/h/static/scripts/test/annotation-ui-test.js
@@ -391,9 +391,43 @@ describe('annotationUI', function () {
 
   describe('#selectTab()', function () {
     it('sets the selected tab', function () {
-      var annotationTab = 'annotation';
-      annotationUI.selectTab(annotationTab);
-      assert.equal(annotationUI.getState().selectedTab, annotationTab);
+      annotationUI.selectTab(uiConstants.TAB_ANNOTATIONS);
+      assert.equal(annotationUI.getState().selectedTab, uiConstants.TAB_ANNOTATIONS);
+    });
+
+    it('ignores junk tag names', function () {
+      annotationUI.selectTab('flibbertigibbert');
+      assert.equal(annotationUI.getState().selectedTab, uiConstants.TAB_ANNOTATIONS);
+    });
+
+    it('allows sorting annotations by time and document location', function () {
+      annotationUI.selectTab(uiConstants.TAB_ANNOTATIONS);
+      assert.deepEqual(annotationUI.getState().sortKeysAvailable, ['Newest', 'Oldest', 'Location']);
+    });
+
+    it('allows sorting page notes by time', function () {
+      annotationUI.selectTab(uiConstants.TAB_NOTES);
+      assert.deepEqual(annotationUI.getState().sortKeysAvailable, ['Newest', 'Oldest']);
+    });
+
+    it('allows sorting orphans by time and document location', function () {
+      annotationUI.selectTab(uiConstants.TAB_ORPHANS);
+      assert.deepEqual(annotationUI.getState().sortKeysAvailable, ['Newest', 'Oldest', 'Location']);
+    });
+
+    it('sorts annotations by document location by default', function () {
+      annotationUI.selectTab(uiConstants.TAB_ANNOTATIONS);
+      assert.deepEqual(annotationUI.getState().sortKey, 'Location');
+    });
+
+    it('sorts page notes from oldest to newest by default', function () {
+      annotationUI.selectTab(uiConstants.TAB_NOTES);
+      assert.deepEqual(annotationUI.getState().sortKey, 'Oldest');
+    });
+
+    it('sorts orphans by document location by default', function () {
+      annotationUI.selectTab(uiConstants.TAB_ORPHANS);
+      assert.deepEqual(annotationUI.getState().sortKey, 'Location');
     });
   });
 


### PR DESCRIPTION
This PR prevents page notes from being sorted by "Location" (i.e. document location), a meaningless property for page notes, which would result in them being sorted unpredictably.

Instead, we define a default sort key and a set of allowable sort keys for each sidebar tab. When switching between tabs, the sort key is updated to the default, and the set of allowable sort keys updated depending on the tab.

This results in page notes being sorted (by default) in ascending order of their most recent update. Using "updated" rather than "created" is a bit dubious, but changing this requires a bit of care to avoid strange behaviour on the stream, so I've left that for another time.

N.B. As implemented, the sort key on each tab will be reset to the default every time the tab changes. This is less surprising than preserving the sort key across tab switches, and doesn't involve any requirement to remember system state across tab switches. We can also revisit this in the future if it seems wrong.

Fixes #96.