### PR TITLE
Don't reset the sortKey unless actually switching tabs

### DIFF
--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -190,11 +190,16 @@ function initializeAnnot(annotation) {
  * This function accepts the name of a tab and returns an object which must be
  * merged into the current state to achieve the desired tab change.
  */
-function selectTab(newTab) {
+function selectTab(state, newTab) {
   // Do nothing if the "new tab" is not a valid tab.
   if ([uiConstants.TAB_ANNOTATIONS,
        uiConstants.TAB_NOTES,
        uiConstants.TAB_ORPHANS].indexOf(newTab) === -1) {
+    return {};
+  }
+  // Shortcut if the tab is already correct, to avoid resetting the sortKey
+  // unnecessarily.
+  if (state.selectedTab === newTab) {
     return {};
   }
   return {
@@ -262,7 +267,7 @@ function annotationsReducer(state, action) {
         {},
         state,
         {annotations: annots},
-        selectTab(selectedTab)
+        selectTab(state, selectedTab)
       );
     }
   case types.CLEAR_ANNOTATIONS:
@@ -311,7 +316,7 @@ function reducer(state, action) {
   case types.HIGHLIGHT_ANNOTATIONS:
     return Object.assign({}, state, {highlighted: action.highlighted});
   case types.SELECT_TAB:
-    return Object.assign({}, state, selectTab(action.tab));
+    return Object.assign({}, state, selectTab(state, action.tab));
   case types.SET_FILTER_QUERY:
     return Object.assign({}, state, {
       filterQuery: action.query,

--- a/h/static/scripts/test/annotation-ui-test.js
+++ b/h/static/scripts/test/annotation-ui-test.js
@@ -429,6 +429,17 @@ describe('annotationUI', function () {
       annotationUI.selectTab(uiConstants.TAB_ORPHANS);
       assert.deepEqual(annotationUI.getState().sortKey, 'Location');
     });
+
+    it('does not reset the sort key unless necessary', function () {
+      // Select the tab, setting sort key to 'Oldest', and then manually
+      // override the sort key.
+      annotationUI.selectTab(uiConstants.TAB_NOTES);
+      annotationUI.setSortKey('Newest');
+
+      annotationUI.selectTab(uiConstants.TAB_NOTES);
+
+      assert.equal(annotationUI.getState().sortKey, 'Newest');
+    });
   });
 
   describe('#updatingAnchorStatus', function () {


### PR DESCRIPTION
Creating a new annotation or page note would reset the sortKey for the sidebar to the default, because doing so can trigger a call to `selectTab`.

This change ensures that we shortcut the state update if we're already on the correct tab, and don't update `sortKey` in that case.