### PR TITLE
Add temporary timestamps to new annotations (for sorting)

### DIFF
--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -176,7 +176,10 @@ function initializeAnnot(annotation) {
   // that initialization should be moved here.
 
   return Object.assign({}, annotation, {
-    // Copy $$tag explicitly because it is non-enumerable
+    // Copy $$tag explicitly because it is non-enumerable.
+    //
+    // FIXME: change $$tag to $tag and make it enumerable so annotations can be
+    // handled more simply in the sidebar.
     $$tag: annotation.$$tag,
     // New annotations must be anchored
     $orphan: false,
@@ -499,9 +502,28 @@ module.exports = function ($rootScope, settings) {
     },
 
     /** Add annotations to the currently displayed set. */
-    addAnnotations: function (annotations) {
+    addAnnotations: function (annotations, now) {
+      now = now || new Date();
+
       var added = annotations.filter(function (annot) {
         return !findByID(annot.id);
+      });
+
+      // Add dates to new annotations. These are ignored by the server but used
+      // when sorting unsaved annotation cards.
+      annotations = annotations.map(function (annot) {
+        if (annot.id) { return annot; }
+        return Object.assign({
+          // Copy $$tag explicitly because it is non-enumerable.
+          //
+          // FIXME: change $$tag to $tag and make it enumerable so annotations
+          // can be handled more simply in the sidebar.
+          $$tag: annot.$$tag,
+          // Date.prototype.toISOString returns a 0-offset (UTC) ISO8601
+          // datetime.
+          created: now.toISOString(),
+          updated: now.toISOString(),
+        }, annot);
       });
 
       store.dispatch({

--- a/h/static/scripts/test/annotation-ui-test.js
+++ b/h/static/scripts/test/annotation-ui-test.js
@@ -93,6 +93,33 @@ describe('annotationUI', function () {
       assert.equal(annots[0].id, 'server-id');
     });
 
+    // We add temporary created and updated timestamps to annotations to ensure
+    // that they sort correctly in the sidebar. These fields are ignored by the
+    // server.
+    it('adds created/updated timestamps to new annotations', function () {
+      var now = new Date();
+      var nowStr = now.toISOString();
+
+      annotationUI.addAnnotations([newAnnotation()], now);
+      var annot = annotationUI.getState().annotations[0];
+
+      assert.equal(annot.created, nowStr);
+      assert.equal(annot.updated, nowStr);
+    });
+
+    it('does not overwrite existing created/updated timestamps in new annotations', function () {
+      var now = new Date();
+      var annot = newAnnotation();
+      annot.created = '2000-01-01T01:02:03Z';
+      annot.updated = '2000-01-01T04:05:06Z';
+
+      annotationUI.addAnnotations([annot], now);
+      var result = annotationUI.getState().annotations[0];
+
+      assert.equal(result.created, annot.created);
+      assert.equal(result.updated, annot.updated);
+    });
+
     it('preserves anchoring status of updated annotations', function () {
       var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot]);


### PR DESCRIPTION
Brand new annotations (and page notes) are currently displayed as editor widgets in the sidebar alongside all the existing annotation cards. This means they need to be sortable.

Sorting by location isn't a problem, because the annotation already carries the document location information by the time it gets to `addAnnotations`, but sorting by the updated date is, because currently the `created` and `updated` fields are only provided when the server sends back the saved annotation.

This commit changes that by adding temporary `created` and `updated` timestamps to new annotations (those without an ID). These will be ignored entirely by the server, and overwritten when the annotation is saved.

If for whatever reason `addAnnotations` is called with a new annotation that already has these fields, they will not be overwritten.

Fixes (the rest of) #96.