### PR TITLE
Refactor Redux store into smaller modules

### DIFF
--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -8,332 +8,13 @@
  * responding to UI state changes.
  */
 
-var immutable = require('seamless-immutable');
 var redux = require('redux');
+var thunk = require('redux-thunk').default;
 
-var metadata = require('./annotation-metadata');
-var uiConstants = require('./ui-constants');
-var arrayUtil = require('./util/array-util');
-
-/**
- * Default starting tab.
- */
-var TAB_DEFAULT = uiConstants.TAB_ANNOTATIONS;
-
-/**
- * Default sort keys for each tab.
- */
-var TAB_SORTKEY_DEFAULT = {};
-TAB_SORTKEY_DEFAULT[uiConstants.TAB_ANNOTATIONS] = 'Location';
-TAB_SORTKEY_DEFAULT[uiConstants.TAB_NOTES] = 'Oldest';
-TAB_SORTKEY_DEFAULT[uiConstants.TAB_ORPHANS] = 'Location';
-
-/**
- * Available sort keys for each tab.
- */
-var TAB_SORTKEYS_AVAILABLE = {};
-TAB_SORTKEYS_AVAILABLE[uiConstants.TAB_ANNOTATIONS] = ['Newest', 'Oldest', 'Location'];
-TAB_SORTKEYS_AVAILABLE[uiConstants.TAB_NOTES] = ['Newest', 'Oldest'];
-TAB_SORTKEYS_AVAILABLE[uiConstants.TAB_ORPHANS] = ['Newest', 'Oldest', 'Location'];
-
-function freeze(selection) {
-  if (Object.keys(selection).length) {
-    return immutable(selection);
-  } else {
-    return null;
-  }
-}
-
-function toSet(list) {
-  return list.reduce(function (set, key) {
-    set[key] = true;
-    return set;
-  }, {});
-}
-
-function initialSelection(settings) {
-  var selection = {};
-  if (settings.annotations) {
-    selection[settings.annotations] = true;
-  }
-  return freeze(selection);
-}
-
-function initialState(settings) {
-  return Object.freeze({
-    // Flag that indicates whether the app is the sidebar and connected to
-    // a page where annotations are being shown in context
-    isSidebar: true,
-
-    // List of all loaded annotations
-    annotations: [],
-
-    visibleHighlights: false,
-
-    // Contains a map of annotation tag:true pairs.
-    focusedAnnotationMap: null,
-
-    // Contains a map of annotation id:true pairs.
-    selectedAnnotationMap: initialSelection(settings),
-
-    // Map of annotation IDs to expanded/collapsed state. For annotations not
-    // present in the map, the default state is used which depends on whether
-    // the annotation is a top-level annotation or a reply, whether it is
-    // selected and whether it matches the current filter.
-    expanded: initialSelection(settings) || {},
-
-    // Set of IDs of annotations that have been explicitly shown
-    // by the user even if they do not match the current search filter
-    forceVisible: {},
-
-    // IDs of annotations that should be highlighted
-    highlighted: [],
-
-    filterQuery: null,
-
-    selectedTab: TAB_DEFAULT,
-
-    // Key by which annotations are currently sorted.
-    sortKey: TAB_SORTKEY_DEFAULT[TAB_DEFAULT],
-    // Keys by which annotations can be sorted.
-    sortKeysAvailable: TAB_SORTKEYS_AVAILABLE[TAB_DEFAULT],
-  });
-}
-
-var types = {
-  CLEAR_SELECTION: 'CLEAR_SELECTION',
-  SELECT_ANNOTATIONS: 'SELECT_ANNOTATIONS',
-  FOCUS_ANNOTATIONS: 'FOCUS_ANNOTATIONS',
-  HIGHLIGHT_ANNOTATIONS: 'HIGHLIGHT_ANNOTATIONS',
-  SET_HIGHLIGHTS_VISIBLE: 'SET_HIGHLIGHTS_VISIBLE',
-  SET_FORCE_VISIBLE: 'SET_FORCE_VISIBLE',
-  SET_EXPANDED: 'SET_EXPANDED',
-  ADD_ANNOTATIONS: 'ADD_ANNOTATIONS',
-  REMOVE_ANNOTATIONS: 'REMOVE_ANNOTATIONS',
-  CLEAR_ANNOTATIONS: 'CLEAR_ANNOTATIONS',
-  SET_FILTER_QUERY: 'SET_FILTER_QUERY',
-  SET_SORT_KEY: 'SET_SORT_KEY',
-  SELECT_TAB: 'SELECT_TAB',
-  /**
-   * Update an annotation's status flags after attempted anchoring in the
-   * document completes.
-   */
-  UPDATE_ANCHOR_STATUS: 'UPDATE_ANCHOR_STATUS',
-  /**
-   * Set whether the app is the sidebar or not.
-   *
-   * When not in the sidebar, we do not expect annotations to anchor and always
-   * display all annotations, rather than only those in the current tab.
-   */
-  SET_SIDEBAR: 'SET_SIDEBAR',
-};
-
-/**
- * Return a copy of `current` with all matching annotations in `annotations`
- * removed.
- */
-function excludeAnnotations(current, annotations) {
-  var ids = {};
-  var tags = {};
-  annotations.forEach(function (annot) {
-    if (annot.id) {
-      ids[annot.id] = true;
-    }
-    if (annot.$$tag) {
-      tags[annot.$$tag] = true;
-    }
-  });
-  return current.filter(function (annot) {
-    var shouldRemove = (annot.id && (annot.id in ids)) ||
-                       (annot.$$tag && (annot.$$tag in tags));
-    return !shouldRemove;
-  });
-}
-
-function findByID(annotations, id) {
-  return annotations.find(function (annot) {
-    return annot.id === id;
-  });
-}
-
-function findByTag(annotations, tag) {
-  return annotations.find(function (annot) {
-    return annot.$$tag === tag;
-  });
-}
-
-/**
- * Initialize the status flags and properties of a new annotation.
- */
-function initializeAnnot(annotation) {
-  if (annotation.id) {
-    return annotation;
-  }
-
-  // Currently the user ID, permissions and group of new annotations are
-  // initialized in the <annotation> component controller because the session
-  // state and focused group are not stored in the Redux store. Once they are,
-  // that initialization should be moved here.
-
-  return Object.assign({}, annotation, {
-    // Copy $$tag explicitly because it is non-enumerable.
-    //
-    // FIXME: change $$tag to $tag and make it enumerable so annotations can be
-    // handled more simply in the sidebar.
-    $$tag: annotation.$$tag,
-    // New annotations must be anchored
-    $orphan: false,
-  });
-}
-
-
-/**
- * Return state updates necessary to select a different tab.
- *
- * This function accepts the name of a tab and returns an object which must be
- * merged into the current state to achieve the desired tab change.
- */
-function selectTab(state, newTab) {
-  // Do nothing if the "new tab" is not a valid tab.
-  if ([uiConstants.TAB_ANNOTATIONS,
-       uiConstants.TAB_NOTES,
-       uiConstants.TAB_ORPHANS].indexOf(newTab) === -1) {
-    return {};
-  }
-  // Shortcut if the tab is already correct, to avoid resetting the sortKey
-  // unnecessarily.
-  if (state.selectedTab === newTab) {
-    return {};
-  }
-  return {
-    selectedTab: newTab,
-    sortKey: TAB_SORTKEY_DEFAULT[newTab],
-    sortKeysAvailable: TAB_SORTKEYS_AVAILABLE[newTab],
-  };
-}
-
-
-function annotationsReducer(state, action) {
-  switch (action.type) {
-  case types.ADD_ANNOTATIONS:
-    {
-      var updatedIDs = {};
-      var updatedTags = {};
-
-      var added = [];
-      var unchanged = [];
-      var updated = [];
-
-      action.annotations.forEach(function (annot) {
-        var existing;
-        if (annot.id) {
-          existing = findByID(state.annotations, annot.id);
-        }
-        if (!existing && annot.$$tag) {
-          existing = findByTag(state.annotations, annot.$$tag);
-        }
-
-        if (existing) {
-          // Merge the updated annotation with the private fields from the local
-          // annotation
-          updated.push(Object.assign({}, existing, annot));
-          if (annot.id) {
-            updatedIDs[annot.id] = true;
-          }
-          if (existing.$$tag) {
-            updatedTags[existing.$$tag] = true;
-          }
-        } else {
-          added.push(initializeAnnot(annot));
-        }
-      });
-
-      state.annotations.forEach(function (annot) {
-        if (!updatedIDs[annot.id] && !updatedTags[annot.$$tag]) {
-          unchanged.push(annot);
-        }
-      });
-
-      return Object.assign({}, state, {
-        annotations: added.concat(updated).concat(unchanged),
-      });
-    }
-  case types.REMOVE_ANNOTATIONS:
-    {
-      var annots = excludeAnnotations(state.annotations, action.annotations);
-      var selectedTab = state.selectedTab;
-      if (selectedTab === uiConstants.TAB_ORPHANS &&
-          arrayUtil.countIf(annots, metadata.isOrphan) === 0) {
-        selectedTab = uiConstants.TAB_ANNOTATIONS;
-      }
-      return Object.assign(
-        {},
-        state,
-        {annotations: annots},
-        selectTab(state, selectedTab)
-      );
-    }
-  case types.CLEAR_ANNOTATIONS:
-    return Object.assign({}, state, {annotations: []});
-  case types.UPDATE_ANCHOR_STATUS:
-    {
-      var annotations = state.annotations.map(function (annot) {
-        var match = (annot.id && annot.id === action.id) ||
-                    (annot.$$tag && annot.$$tag === action.tag);
-        if (match) {
-          return Object.assign({}, annot, {
-            $orphan: action.isOrphan,
-            $$tag: action.tag,
-          });
-        } else {
-          return annot;
-        }
-      });
-      return Object.assign({}, state, {annotations: annotations});
-    }
-  default:
-    return state;
-  }
-}
-
-function reducer(state, action) {
-  /*jshint maxcomplexity: false*/
-  state = annotationsReducer(state, action);
-
-  switch (action.type) {
-  case types.CLEAR_SELECTION:
-    return Object.assign({}, state, {
-      filterQuery: null,
-      selectedAnnotationMap: null,
-    });
-  case types.SELECT_ANNOTATIONS:
-    return Object.assign({}, state, {selectedAnnotationMap: action.selection});
-  case types.FOCUS_ANNOTATIONS:
-    return Object.assign({}, state, {focusedAnnotationMap: action.focused});
-  case types.SET_HIGHLIGHTS_VISIBLE:
-    return Object.assign({}, state, {visibleHighlights: action.visible});
-  case types.SET_FORCE_VISIBLE:
-    return Object.assign({}, state, {forceVisible: action.forceVisible});
-  case types.SET_EXPANDED:
-    return Object.assign({}, state, {expanded: action.expanded});
-  case types.HIGHLIGHT_ANNOTATIONS:
-    return Object.assign({}, state, {highlighted: action.highlighted});
-  case types.SELECT_TAB:
-    return Object.assign({}, state, selectTab(state, action.tab));
-  case types.SET_FILTER_QUERY:
-    return Object.assign({}, state, {
-      filterQuery: action.query,
-      forceVisible: {},
-      expanded: {},
-    });
-  case types.SET_SIDEBAR:
-    return Object.assign({}, state, {isSidebar: action.isSidebar});
-  case types.SET_SORT_KEY:
-    return Object.assign({}, state, {sortKey: action.key});
-  default:
-    return state;
-  }
-}
+var reducers = require('./reducers');
+var annotationsReducer = require('./reducers/annotations');
+var selectionReducer = require('./reducers/selection');
+var viewerReducer = require('./reducers/viewer');
 
 /**
  * Redux middleware which triggers an Angular change-detection cycle
@@ -370,22 +51,11 @@ function angularDigestMiddleware($rootScope) {
 // @ngInject
 module.exports = function ($rootScope, settings) {
   var enhancer = redux.applyMiddleware(
+    thunk,
     angularDigestMiddleware.bind(null, $rootScope)
   );
-  var store = redux.createStore(reducer, initialState(settings), enhancer);
-
-  function select(annotations) {
-    store.dispatch({
-      type: types.SELECT_ANNOTATIONS,
-      selection: freeze(annotations),
-    });
-  }
-
-  function findByID(id) {
-    return store.getState().annotations.find(function (annot) {
-      return annot.id === id;
-    });
-  }
+  var store = redux.createStore(reducers.update, reducers.init(settings),
+    enhancer);
 
   return {
     /**
@@ -397,239 +67,72 @@ module.exports = function ($rootScope, settings) {
     /** Listen for changes to the UI state of the sidebar. */
     subscribe: store.subscribe,
 
-    /**
-     * Sets whether annotation highlights in connected documents are shown
-     * or not.
-     */
-    setShowHighlights: function (show) {
-      store.dispatch({
-        type: types.SET_HIGHLIGHTS_VISIBLE,
-        visible: show,
-      });
-    },
-
-    /**
-     * Sets which annotations are currently focused.
-     *
-     * @param {Array<string>} Tags of annotations to focus
-     */
-    focusAnnotations: function (tags) {
-      store.dispatch({
-        type: types.FOCUS_ANNOTATIONS,
-        focused: freeze(toSet(tags)),
-      });
-    },
-
-    /**
-     * Return true if any annotations are currently selected.
-     */
-    hasSelectedAnnotations: function () {
-      return !!store.getState().selectedAnnotationMap;
-    },
-
-    /**
-     * Sets whether replies to the annotation with ID `id` are collapsed.
-     *
-     * @param {string} id - Annotation ID
-     * @param {boolean} collapsed
-     */
-    setCollapsed: function (id, collapsed) {
-      var expanded = Object.assign({}, store.getState().expanded);
-      expanded[id] = !collapsed;
-      store.dispatch({
-        type: types.SET_EXPANDED,
-        expanded: expanded,
-      });
-    },
-
-    /**
-     * Sets whether a given annotation should be visible, even if it does not
-     * match the current search query.
-     *
-     * @param {string} id - Annotation ID
-     * @param {boolean} visible
-     */
-    setForceVisible: function (id, visible) {
-      var forceVisible = Object.assign({}, store.getState().forceVisible);
-      forceVisible[id] = visible;
-      store.dispatch({
-        type: types.SET_FORCE_VISIBLE,
-        forceVisible: forceVisible,
-      });
-    },
-
-    /**
-     * Returns true if the annotation with the given `id` is selected.
-     */
-    isAnnotationSelected: function (id) {
-      return (store.getState().selectedAnnotationMap || {}).hasOwnProperty(id);
-    },
-
-    /**
-     * Set the currently selected annotation IDs.
-     */
-    selectAnnotations: function (ids) {
-      select(toSet(ids));
-    },
-
-    /** Toggle whether annotations are selected or not. */
-    toggleSelectedAnnotations: function (ids) {
-      var selection = Object.assign({}, store.getState().selectedAnnotationMap);
-      for (var i = 0; i < ids.length; i++) {
-        var id = ids[i];
-        if (selection[id]) {
-          delete selection[id];
-        } else {
-          selection[id] = true;
-        }
-      }
-      select(selection);
-    },
-
-    /** De-select an annotation. */
-    removeSelectedAnnotation: function (id) {
-      var selection = Object.assign({}, store.getState().selectedAnnotationMap);
-      if (!selection || !id) {
-        return;
-      }
-      delete selection[id];
-      select(selection);
-    },
-
-    /** De-select all annotations. */
-    clearSelectedAnnotations: function () {
-      store.dispatch({type: 'CLEAR_SELECTION'});
-    },
-
-    /** Add annotations to the currently displayed set. */
+    // Wrappers around annotation actions
     addAnnotations: function (annotations, now) {
-      now = now || new Date();
-
-      var added = annotations.filter(function (annot) {
-        return !findByID(annot.id);
-      });
-
-      // Add dates to new annotations. These are ignored by the server but used
-      // when sorting unsaved annotation cards.
-      annotations = annotations.map(function (annot) {
-        if (annot.id) { return annot; }
-        return Object.assign({
-          // Copy $$tag explicitly because it is non-enumerable.
-          //
-          // FIXME: change $$tag to $tag and make it enumerable so annotations
-          // can be handled more simply in the sidebar.
-          $$tag: annot.$$tag,
-          // Date.prototype.toISOString returns a 0-offset (UTC) ISO8601
-          // datetime.
-          created: now.toISOString(),
-          updated: now.toISOString(),
-        }, annot);
-      });
-
-      store.dispatch({
-        type: types.ADD_ANNOTATIONS,
-        annotations: annotations,
-      });
-
-      if (!store.getState().isSidebar) {
-        return;
-      }
-
-      // If anchoring fails to complete in a reasonable amount of time, then
-      // we assume that the annotation failed to anchor. If it does later
-      // successfully anchor then the status will be updated.
-      var ANCHORING_TIMEOUT = 500;
-
-      var anchoringAnnots = added.filter(metadata.isWaitingToAnchor);
-      if (anchoringAnnots.length) {
-        setTimeout(function () {
-          arrayUtil
-            .filterMap(anchoringAnnots, function (annot) {
-              return findByID(annot.id);
-            })
-            .filter(metadata.isWaitingToAnchor)
-            .forEach(function (orphan) {
-              store.dispatch({
-                type: types.UPDATE_ANCHOR_STATUS,
-                id: orphan.id,
-                tag: orphan.$$tag,
-                isOrphan: true,
-              });
-            });
-        }, ANCHORING_TIMEOUT);
-      }
+      store.dispatch(annotationsReducer.addAnnotations(annotations, now));
     },
 
-    /** Remove annotations from the currently displayed set. */
     removeAnnotations: function (annotations) {
-      store.dispatch({
-        type: types.REMOVE_ANNOTATIONS,
-        annotations: annotations,
-      });
+      store.dispatch(annotationsReducer.removeAnnotations(annotations));
     },
 
-    /** Set the currently displayed annotations to the empty set. */
     clearAnnotations: function () {
-      store.dispatch({type: types.CLEAR_ANNOTATIONS});
+      store.dispatch(annotationsReducer.clearAnnotations());
     },
 
-    /**
-     * Updating the local tag and anchoring status of an annotation.
-     *
-     * @param {string|null} id - Annotation ID
-     * @param {string} tag - The local tag assigned to this annotation to link
-     *        the object in the page and the annotation in the sidebar
-     * @param {boolean} isOrphan - True if the annotation failed to anchor
-     */
     updateAnchorStatus: function (id, tag, isOrphan) {
-      store.dispatch({
-        type: types.UPDATE_ANCHOR_STATUS,
-        id: id,
-        tag: tag,
-        isOrphan: isOrphan,
-      });
+      store.dispatch(annotationsReducer.updateAnchorStatus(id, tag, isOrphan));
     },
 
-    /** Set the type annotations to be displayed. */
-    selectTab: function (type) {
-      store.dispatch({
-        type: types.SELECT_TAB,
-        tab: type,
-      });
+    // Wrappers around selection actions
+    clearSelectedAnnotations: function () {
+      store.dispatch(selectionReducer.clearSelectedAnnotations());
     },
-
-    /** Set the query used to filter displayed annotations. */
-    setFilterQuery: function (query) {
-      store.dispatch({
-        type: types.SET_FILTER_QUERY,
-        query: query,
-      });
+    focusAnnotations: function (tags) {
+      store.dispatch(selectionReducer.focusAnnotations(tags));
     },
-
-    /** Sets the sort key for the annotation list. */
-    setSortKey: function (key) {
-      store.dispatch({
-        type: types.SET_SORT_KEY,
-        key: key,
-      });
-    },
-
-    /**
-     * Highlight annotations with the given `ids`.
-     *
-     * This is used to indicate the specific annotation in a thread that was
-     * linked to for example.
-     */
     highlightAnnotations: function (ids) {
-      store.dispatch({
-        type: types.HIGHLIGHT_ANNOTATIONS,
-        highlighted: ids,
-      });
+      store.dispatch(selectionReducer.highlightAnnotations(ids));
+    },
+    removeSelectedAnnotation: function (id) {
+      store.dispatch(selectionReducer.removeSelectedAnnotation(id));
+    },
+    selectAnnotations: function (ids) {
+      store.dispatch(selectionReducer.selectAnnotations(ids));
+    },
+    selectTab: function (tab) {
+      store.dispatch(selectionReducer.selectTab(tab));
+    },
+    setCollapsed: function (id, collapsed) {
+      store.dispatch(selectionReducer.setCollapsed(id, collapsed));
+    },
+    setFilterQuery: function (query) {
+      store.dispatch(selectionReducer.setFilterQuery(query));
+    },
+    setForceVisible: function (id, visible) {
+      store.dispatch(selectionReducer.setForceVisible(id, visible));
+    },
+    setSortKey: function (key) {
+      store.dispatch(selectionReducer.setSortKey(key));
+    },
+    toggleSelectedAnnotations: function (ids) {
+      store.dispatch(selectionReducer.toggleSelectedAnnotations(ids));
     },
 
-    /** Set whether the app is the sidebar */
+    // Wrappers around selection selectors
+    isAnnotationSelected: function (id) {
+      return selectionReducer.isAnnotationSelected(store.getState(), id);
+    },
+    hasSelectedAnnotations: function () {
+      return selectionReducer.hasSelectedAnnotations(store.getState());
+    },
+
+    // Wrappers around viewer actions
+    setShowHighlights: function (show) {
+      store.dispatch(viewerReducer.setShowHighlights(show));
+    },
     setAppIsSidebar: function (isSidebar) {
-      store.dispatch({type: types.SET_SIDEBAR, isSidebar: isSidebar});
+      store.dispatch(viewerReducer.setAppIsSidebar(isSidebar));
     },
   };
 };

--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -1,14 +1,39 @@
 'use strict';
 
 /**
- * AnnotationUI provides the central store of UI state for the application,
- * using [Redux](http://redux.js.org/).
+ * AnnotationUI is the central store of state for the sidebar application,
+ * managed using [Redux](http://redux.js.org/).
  *
- * Redux is used to provide a predictable way of updating UI state and
- * responding to UI state changes.
+ * State management in Redux apps work as follows:
+ *
+ *  1. All important application state is stored in a single, immutable object.
+ *  2. The user interface is a presentation of this state. Interaction with the
+ *     UI triggers updates by creating `actions`.
+ *  3. Actions are plain JS objects which describe some event that happened in
+ *     the application. Updates happen by passing actions to a `reducer`
+ *     function which takes the current application state, the action and
+ *     returns the new application state.
+ *
+ *     The process of updating the app state using an action is known as
+ *     'dispatching' the action.
+ *  4. Other parts of the app can subscribe to changes in the app state.
+ *     This is used to to update the UI etc.
+ *
+ * "middleware" functions can wrap the dispatch process in order to implement
+ *  logging, trigger side effects etc.
+ *
+ * Tests for a given action consist of:
+ *
+ *  1. Checking that the UI (or other event source) dispatches the correct
+ *     action when something happens.
+ *  2. Checking that given an initial state, and an action, a reducer returns
+ *     the correct resulting state.
+ *  3. Checking that the UI correctly presents a given state.
  */
 
 var redux = require('redux');
+
+// `.default` is needed because 'redux-thunk' is built as an ES2015 module
 var thunk = require('redux-thunk').default;
 
 var reducers = require('./reducers');
@@ -51,6 +76,9 @@ function angularDigestMiddleware($rootScope) {
 // @ngInject
 module.exports = function ($rootScope, settings) {
   var enhancer = redux.applyMiddleware(
+    // The `thunk` middleware handles actions which are functions.
+    // This is used to implement actions which have side effects or are
+    // asynchronous (see https://github.com/gaearon/redux-thunk#motivation)
     thunk,
     angularDigestMiddleware.bind(null, $rootScope)
   );

--- a/h/static/scripts/reducers/annotations.js
+++ b/h/static/scripts/reducers/annotations.js
@@ -129,7 +129,7 @@ var update = {
     var tabUpdateFn = selection.update.SELECT_TAB;
     return Object.assign(
       {annotations: annots},
-      tabUpdateFn(state, selection.selectTab(selectedTab))
+      tabUpdateFn(state, selection.actions.selectTab(selectedTab))
     );
   },
 
@@ -250,10 +250,10 @@ function updateAnchorStatus(id, tag, isOrphan) {
 module.exports = {
   init: init,
   update: update,
-
-  // Actions
-  addAnnotations: addAnnotations,
-  clearAnnotations: clearAnnotations,
-  removeAnnotations: removeAnnotations,
-  updateAnchorStatus: updateAnchorStatus,
+  actions: {
+    addAnnotations: addAnnotations,
+    clearAnnotations: clearAnnotations,
+    removeAnnotations: removeAnnotations,
+    updateAnchorStatus: updateAnchorStatus,
+  },
 };

--- a/h/static/scripts/reducers/annotations.js
+++ b/h/static/scripts/reducers/annotations.js
@@ -1,0 +1,273 @@
+/**
+ * State management for the set of annotations currently loaded into the
+ * sidebar.
+ */
+
+'use strict';
+
+var arrayUtil = require('../util/array-util');
+var metadata = require('../annotation-metadata');
+var uiConstants = require('../ui-constants');
+
+var selection = require('./selection');
+
+var actions = {
+  ADD_ANNOTATIONS: 'ADD_ANNOTATIONS',
+  REMOVE_ANNOTATIONS: 'REMOVE_ANNOTATIONS',
+  CLEAR_ANNOTATIONS: 'CLEAR_ANNOTATIONS',
+
+  /**
+   * Update an annotation's status flags after attempted anchoring in the
+   * document completes.
+   */
+  UPDATE_ANCHOR_STATUS: 'UPDATE_ANCHOR_STATUS',
+};
+
+/**
+ * Return a copy of `current` with all matching annotations in `annotations`
+ * removed.
+ */
+function excludeAnnotations(current, annotations) {
+  var ids = {};
+  var tags = {};
+  annotations.forEach(function (annot) {
+    if (annot.id) {
+      ids[annot.id] = true;
+    }
+    if (annot.$$tag) {
+      tags[annot.$$tag] = true;
+    }
+  });
+  return current.filter(function (annot) {
+    var shouldRemove = (annot.id && (annot.id in ids)) ||
+                       (annot.$$tag && (annot.$$tag in tags));
+    return !shouldRemove;
+  });
+}
+
+function findByID(annotations, id) {
+  return annotations.find(function (annot) {
+    return annot.id === id;
+  });
+}
+
+function findByTag(annotations, tag) {
+  return annotations.find(function (annot) {
+    return annot.$$tag === tag;
+  });
+}
+
+/**
+ * Initialize the status flags and properties of a new annotation.
+ */
+function initializeAnnot(annotation) {
+  if (annotation.id) {
+    return annotation;
+  }
+
+  // Currently the user ID, permissions and group of new annotations are
+  // initialized in the <annotation> component controller because the session
+  // state and focused group are not stored in the Redux store. Once they are,
+  // that initialization should be moved here.
+
+  return Object.assign({}, annotation, {
+    // Copy $$tag explicitly because it is non-enumerable.
+    //
+    // FIXME: change $$tag to $tag and make it enumerable so annotations can be
+    // handled more simply in the sidebar.
+    $$tag: annotation.$$tag,
+    // New annotations must be anchored
+    $orphan: false,
+  });
+}
+
+function init() {
+  return {
+    annotations: [],
+  };
+}
+
+function update(state, action) {
+  switch (action.type) {
+  case actions.ADD_ANNOTATIONS:
+    {
+      var updatedIDs = {};
+      var updatedTags = {};
+
+      var added = [];
+      var unchanged = [];
+      var updated = [];
+
+      action.annotations.forEach(function (annot) {
+        var existing;
+        if (annot.id) {
+          existing = findByID(state.annotations, annot.id);
+        }
+        if (!existing && annot.$$tag) {
+          existing = findByTag(state.annotations, annot.$$tag);
+        }
+
+        if (existing) {
+          // Merge the updated annotation with the private fields from the local
+          // annotation
+          updated.push(Object.assign({}, existing, annot));
+          if (annot.id) {
+            updatedIDs[annot.id] = true;
+          }
+          if (existing.$$tag) {
+            updatedTags[existing.$$tag] = true;
+          }
+        } else {
+          added.push(initializeAnnot(annot));
+        }
+      });
+
+      state.annotations.forEach(function (annot) {
+        if (!updatedIDs[annot.id] && !updatedTags[annot.$$tag]) {
+          unchanged.push(annot);
+        }
+      });
+
+      return Object.assign({}, state, {
+        annotations: added.concat(updated).concat(unchanged),
+      });
+    }
+  case actions.REMOVE_ANNOTATIONS:
+    {
+      var annots = excludeAnnotations(state.annotations, action.annotations);
+      var selectedTab = state.selectedTab;
+      if (selectedTab === uiConstants.TAB_ORPHANS &&
+          arrayUtil.countIf(annots, metadata.isOrphan) === 0) {
+        selectedTab = uiConstants.TAB_ANNOTATIONS;
+      }
+      return Object.assign(
+        {},
+        state,
+        {annotations: annots},
+        selection.selectTabHelper(state, selectedTab)
+      );
+    }
+  case actions.CLEAR_ANNOTATIONS:
+    return Object.assign({}, state, {annotations: []});
+  case actions.UPDATE_ANCHOR_STATUS:
+    {
+      var annotations = state.annotations.map(function (annot) {
+        var match = (annot.id && annot.id === action.id) ||
+                    (annot.$$tag && annot.$$tag === action.tag);
+        if (match) {
+          return Object.assign({}, annot, {
+            $orphan: action.isOrphan,
+            $$tag: action.tag,
+          });
+        } else {
+          return annot;
+        }
+      });
+      return Object.assign({}, state, {annotations: annotations});
+    }
+  default:
+    return state;
+  }
+}
+
+/** Add annotations to the currently displayed set. */
+function addAnnotations(annotations, now) {
+  now = now || new Date();
+
+  // Add dates to new annotations. These are ignored by the server but used
+  // when sorting unsaved annotation cards.
+  annotations = annotations.map(function (annot) {
+    if (annot.id) { return annot; }
+    return Object.assign({
+      // Copy $$tag explicitly because it is non-enumerable.
+      //
+      // FIXME: change $$tag to $tag and make it enumerable so annotations
+      // can be handled more simply in the sidebar.
+      $$tag: annot.$$tag,
+      // Date.prototype.toISOString returns a 0-offset (UTC) ISO8601
+      // datetime.
+      created: now.toISOString(),
+      updated: now.toISOString(),
+    }, annot);
+  });
+
+  return function (dispatch, getState) {
+    var added = annotations.filter(function (annot) {
+      return !findByID(getState().annotations, annot.id);
+    });
+
+    dispatch({
+      type: actions.ADD_ANNOTATIONS,
+      annotations: annotations,
+    });
+
+    if (!getState().isSidebar) {
+      return;
+    }
+
+    // If anchoring fails to complete in a reasonable amount of time, then
+    // we assume that the annotation failed to anchor. If it does later
+    // successfully anchor then the status will be updated.
+    var ANCHORING_TIMEOUT = 500;
+
+    var anchoringAnnots = added.filter(metadata.isWaitingToAnchor);
+    if (anchoringAnnots.length) {
+      setTimeout(function () {
+        arrayUtil
+          .filterMap(anchoringAnnots, function (annot) {
+            return findByID(getState().annotations, annot.id);
+          })
+          .filter(metadata.isWaitingToAnchor)
+          .forEach(function (orphan) {
+            dispatch({
+              type: actions.UPDATE_ANCHOR_STATUS,
+              id: orphan.id,
+              tag: orphan.$$tag,
+              isOrphan: true,
+            });
+          });
+      }, ANCHORING_TIMEOUT);
+    }
+  };
+}
+
+/** Remove annotations from the currently displayed set. */
+function removeAnnotations(annotations) {
+  return {
+    type: actions.REMOVE_ANNOTATIONS,
+    annotations: annotations,
+  };
+}
+
+/** Set the currently displayed annotations to the empty set. */
+function clearAnnotations() {
+  return {type: actions.CLEAR_ANNOTATIONS};
+}
+
+/**
+ * Updating the local tag and anchoring status of an annotation.
+ *
+ * @param {string|null} id - Annotation ID
+ * @param {string} tag - The local tag assigned to this annotation to link
+ *        the object in the page and the annotation in the sidebar
+ * @param {boolean} isOrphan - True if the annotation failed to anchor
+ */
+function updateAnchorStatus(id, tag, isOrphan) {
+  return {
+    type: actions.UPDATE_ANCHOR_STATUS,
+    id: id,
+    tag: tag,
+    isOrphan: isOrphan,
+  };
+}
+
+module.exports = {
+  init: init,
+  update: update,
+
+  // Actions
+  addAnnotations: addAnnotations,
+  clearAnnotations: clearAnnotations,
+  removeAnnotations: removeAnnotations,
+  updateAnchorStatus: updateAnchorStatus,
+};

--- a/h/static/scripts/reducers/index.js
+++ b/h/static/scripts/reducers/index.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * This module defines the main update function (or 'reducer' in Redux's
+ * terminology) that handles app state updates.
+ *
+ * Each sub-module in this folder defines:
+ *
+ *  - An `init` function that returns the initial state relating to some aspect
+ *    of the application
+ *  - An `update` object mapping action types to a state update function for
+ *    that action
+ *  - A set of action creators - functions that return actions that can then
+ *    be passed to `store.dispatch()`
+ *  - A set of selectors - Utility functions that calculate some derived data
+ *    from the state
+ */
+
+var annotations = require('./annotations');
+var selection = require('./selection');
+var viewer = require('./viewer');
+var util = require('./util');
+
+function init(settings) {
+  return Object.assign(
+    {},
+    annotations.init(),
+    selection.init(settings),
+    viewer.init()
+  );
+}
+
+var update = util.composeReducers([
+  annotations.update,
+  selection.update,
+  viewer.update,
+]);
+
+module.exports = {
+  init: init,
+  update: update,
+};

--- a/h/static/scripts/reducers/index.js
+++ b/h/static/scripts/reducers/index.js
@@ -31,11 +31,11 @@ function init(settings) {
   );
 }
 
-var update = util.composeReducers([
+var update = util.createReducer(Object.assign(
   annotations.update,
   selection.update,
-  viewer.update,
-]);
+  viewer.update
+));
 
 module.exports = {
   init: init,

--- a/h/static/scripts/reducers/index.js
+++ b/h/static/scripts/reducers/index.js
@@ -2,7 +2,8 @@
 
 /**
  * This module defines the main update function (or 'reducer' in Redux's
- * terminology) that handles app state updates.
+ * terminology) that handles app state updates. For an overview of how state
+ * management in Redux works, see the comments at the top of `annotation-ui.js`
  *
  * Each sub-module in this folder defines:
  *

--- a/h/static/scripts/reducers/selection.js
+++ b/h/static/scripts/reducers/selection.js
@@ -1,0 +1,331 @@
+/**
+ * This module handles state related to the current sort, search and filter
+ * settings in the UI, including:
+ *
+ * - The set of annotations that are currently focused (hovered) or selected
+ * - The selected tab
+ * - The current sort order
+ * - The current filter query
+ */
+
+'use strict';
+
+var immutable = require('seamless-immutable');
+
+var uiConstants = require('../ui-constants');
+
+/**
+* Default starting tab.
+*/
+var TAB_DEFAULT = uiConstants.TAB_ANNOTATIONS;
+
+ /**
+  * Default sort keys for each tab.
+  */
+var TAB_SORTKEY_DEFAULT = {};
+TAB_SORTKEY_DEFAULT[uiConstants.TAB_ANNOTATIONS] = 'Location';
+TAB_SORTKEY_DEFAULT[uiConstants.TAB_NOTES] = 'Oldest';
+TAB_SORTKEY_DEFAULT[uiConstants.TAB_ORPHANS] = 'Location';
+
+/**
+ * Available sort keys for each tab.
+ */
+var TAB_SORTKEYS_AVAILABLE = {};
+TAB_SORTKEYS_AVAILABLE[uiConstants.TAB_ANNOTATIONS] = ['Newest', 'Oldest', 'Location'];
+TAB_SORTKEYS_AVAILABLE[uiConstants.TAB_NOTES] = ['Newest', 'Oldest'];
+TAB_SORTKEYS_AVAILABLE[uiConstants.TAB_ORPHANS] = ['Newest', 'Oldest', 'Location'];
+
+function initialSelection(settings) {
+  var selection = {};
+  if (settings.annotations) {
+    selection[settings.annotations] = true;
+  }
+  return freeze(selection);
+}
+
+function freeze(selection) {
+  if (Object.keys(selection).length) {
+    return immutable(selection);
+  } else {
+    return null;
+  }
+}
+
+function toSet(list) {
+  return list.reduce(function (set, key) {
+    set[key] = true;
+    return set;
+  }, {});
+}
+
+/**
+ * Return state updates necessary to select a different tab.
+ *
+ * This function accepts the name of a tab and returns an object which must be
+ * merged into the current state to achieve the desired tab change.
+ */
+function selectTabHelper(state, newTab) {
+  // Do nothing if the "new tab" is not a valid tab.
+  if ([uiConstants.TAB_ANNOTATIONS,
+      uiConstants.TAB_NOTES,
+      uiConstants.TAB_ORPHANS].indexOf(newTab) === -1) {
+    return {};
+  }
+  // Shortcut if the tab is already correct, to avoid resetting the sortKey
+  // unnecessarily.
+  if (state.selectedTab === newTab) {
+    return {};
+  }
+  return {
+    selectedTab: newTab,
+    sortKey: TAB_SORTKEY_DEFAULT[newTab],
+    sortKeysAvailable: TAB_SORTKEYS_AVAILABLE[newTab],
+  };
+}
+
+var actions = {
+  CLEAR_SELECTION: 'CLEAR_SELECTION',
+  SELECT_ANNOTATIONS: 'SELECT_ANNOTATIONS',
+  FOCUS_ANNOTATIONS: 'FOCUS_ANNOTATIONS',
+  HIGHLIGHT_ANNOTATIONS: 'HIGHLIGHT_ANNOTATIONS',
+  SET_FORCE_VISIBLE: 'SET_FORCE_VISIBLE',
+  SET_EXPANDED: 'SET_EXPANDED',
+  SET_FILTER_QUERY: 'SET_FILTER_QUERY',
+  SET_SORT_KEY: 'SET_SORT_KEY',
+  SELECT_TAB: 'SELECT_TAB',
+};
+
+function init(settings) {
+  return {
+    // Contains a map of annotation tag:true pairs.
+    focusedAnnotationMap: null,
+
+    // Contains a map of annotation id:true pairs.
+    selectedAnnotationMap: initialSelection(settings),
+
+    // Map of annotation IDs to expanded/collapsed state. For annotations not
+    // present in the map, the default state is used which depends on whether
+    // the annotation is a top-level annotation or a reply, whether it is
+    // selected and whether it matches the current filter.
+    expanded: initialSelection(settings) || {},
+
+    // Set of IDs of annotations that have been explicitly shown
+    // by the user even if they do not match the current search filter
+    forceVisible: {},
+
+    // IDs of annotations that should be highlighted
+    highlighted: [],
+
+    filterQuery: null,
+
+    selectedTab: TAB_DEFAULT,
+
+    // Key by which annotations are currently sorted.
+    sortKey: TAB_SORTKEY_DEFAULT[TAB_DEFAULT],
+    // Keys by which annotations can be sorted.
+    sortKeysAvailable: TAB_SORTKEYS_AVAILABLE[TAB_DEFAULT],
+  };
+}
+
+function update(state, action) {
+  switch (action.type) {
+  case actions.CLEAR_SELECTION:
+    return Object.assign({}, state, {
+      filterQuery: null,
+      selectedAnnotationMap: null,
+    });
+  case actions.SELECT_ANNOTATIONS:
+    return Object.assign({}, state, {selectedAnnotationMap: action.selection});
+  case actions.FOCUS_ANNOTATIONS:
+    return Object.assign({}, state, {focusedAnnotationMap: action.focused});
+  case actions.SET_FORCE_VISIBLE:
+    return Object.assign({}, state, {forceVisible: action.forceVisible});
+  case actions.SET_EXPANDED:
+    return Object.assign({}, state, {expanded: action.expanded});
+  case actions.HIGHLIGHT_ANNOTATIONS:
+    return Object.assign({}, state, {highlighted: action.highlighted});
+  case actions.SELECT_TAB:
+    return Object.assign({}, state, selectTabHelper(state, action.tab));
+  case actions.SET_FILTER_QUERY:
+    return Object.assign({}, state, {
+      filterQuery: action.query,
+      forceVisible: {},
+      expanded: {},
+    });
+  case actions.SET_SORT_KEY:
+    return Object.assign({}, state, {sortKey: action.key});
+  default:
+    return state;
+  }
+}
+
+function select(annotations) {
+  return {
+    type: actions.SELECT_ANNOTATIONS,
+    selection: freeze(annotations),
+  };
+}
+
+/**
+ * Set the currently selected annotation IDs.
+ */
+function selectAnnotations(ids) {
+  return select(toSet(ids));
+}
+
+/** Toggle whether annotations are selected or not. */
+function toggleSelectedAnnotations(ids) {
+  return function (dispatch, getState) {
+    var selection = Object.assign({}, getState().selectedAnnotationMap);
+    for (var i = 0; i < ids.length; i++) {
+      var id = ids[i];
+      if (selection[id]) {
+        delete selection[id];
+      } else {
+        selection[id] = true;
+      }
+    }
+    dispatch(select(selection));
+  };
+}
+
+/**
+ * Sets whether a given annotation should be visible, even if it does not
+ * match the current search query.
+ *
+ * @param {string} id - Annotation ID
+ * @param {boolean} visible
+ */
+function setForceVisible(id, visible) {
+  // FIXME: This should be converted to a plain action and accessing the state
+  // should happen in the update() function
+  return function (dispatch, getState) {
+    var forceVisible = Object.assign({}, getState().forceVisible);
+    forceVisible[id] = visible;
+    dispatch({
+      type: actions.SET_FORCE_VISIBLE,
+      forceVisible: forceVisible,
+    });
+  };
+}
+
+/**
+ * Sets which annotations are currently focused.
+ *
+ * @param {Array<string>} Tags of annotations to focus
+ */
+function focusAnnotations(tags) {
+  return {
+    type: actions.FOCUS_ANNOTATIONS,
+    focused: freeze(toSet(tags)),
+  };
+}
+
+function setCollapsed(id, collapsed) {
+  // FIXME: This should be converted to a plain action and accessing the state
+  // should happen in the update() function
+  return function (dispatch, getState) {
+    var expanded = Object.assign({}, getState().expanded);
+    expanded[id] = !collapsed;
+    dispatch({
+      type: actions.SET_EXPANDED,
+      expanded: expanded,
+    });
+  };
+}
+
+/**
+ * Highlight annotations with the given `ids`.
+ *
+ * This is used to indicate the specific annotation in a thread that was
+ * linked to for example.
+ */
+function highlightAnnotations(ids) {
+  return {
+    type: actions.HIGHLIGHT_ANNOTATIONS,
+    highlighted: ids,
+  };
+}
+
+
+/** Set the type annotations to be displayed. */
+function selectTab(type) {
+  return {
+    type: actions.SELECT_TAB,
+    tab: type,
+  };
+}
+
+/** Set the query used to filter displayed annotations. */
+function setFilterQuery(query) {
+  return {
+    type: actions.SET_FILTER_QUERY,
+    query: query,
+  };
+}
+
+/** Sets the sort key for the annotation list. */
+function setSortKey(key) {
+  return {
+    type: actions.SET_SORT_KEY,
+    key: key,
+  };
+}
+
+/**
+ * Returns true if the annotation with the given `id` is selected.
+ */
+function isAnnotationSelected(state, id) {
+  return (state.selectedAnnotationMap || {}).hasOwnProperty(id);
+}
+
+/**
+ * Return true if any annotations are currently selected.
+ */
+function hasSelectedAnnotations(state) {
+  return !!state.selectedAnnotationMap;
+}
+
+/** De-select an annotation. */
+function removeSelectedAnnotation(id) {
+  // FIXME: This should be converted to a plain action and accessing the state
+  // should happen in the update() function
+  return function (dispatch, getState) {
+    var selection = Object.assign({}, getState().selectedAnnotationMap);
+    if (!selection || !id) {
+      return;
+    }
+    delete selection[id];
+    dispatch(select(selection));
+  };
+}
+
+/** De-select all annotations. */
+function clearSelectedAnnotations() {
+  return {type: actions.CLEAR_SELECTION};
+}
+
+module.exports = {
+  init: init,
+  update: update,
+
+  // Actions
+  clearSelectedAnnotations: clearSelectedAnnotations,
+  focusAnnotations: focusAnnotations,
+  highlightAnnotations: highlightAnnotations,
+  removeSelectedAnnotation: removeSelectedAnnotation,
+  selectAnnotations: selectAnnotations,
+  selectTab: selectTab,
+  setCollapsed: setCollapsed,
+  setFilterQuery: setFilterQuery,
+  setForceVisible: setForceVisible,
+  setSortKey: setSortKey,
+  toggleSelectedAnnotations: toggleSelectedAnnotations,
+
+  // Selectors
+  hasSelectedAnnotations: hasSelectedAnnotations,
+  isAnnotationSelected: isAnnotationSelected,
+
+  // Helpers
+  selectTabHelper: selectTabHelper,
+};

--- a/h/static/scripts/reducers/selection.js
+++ b/h/static/scripts/reducers/selection.js
@@ -301,18 +301,19 @@ module.exports = {
   init: init,
   update: update,
 
-  // Actions
-  clearSelectedAnnotations: clearSelectedAnnotations,
-  focusAnnotations: focusAnnotations,
-  highlightAnnotations: highlightAnnotations,
-  removeSelectedAnnotation: removeSelectedAnnotation,
-  selectAnnotations: selectAnnotations,
-  selectTab: selectTab,
-  setCollapsed: setCollapsed,
-  setFilterQuery: setFilterQuery,
-  setForceVisible: setForceVisible,
-  setSortKey: setSortKey,
-  toggleSelectedAnnotations: toggleSelectedAnnotations,
+  actions: {
+    clearSelectedAnnotations: clearSelectedAnnotations,
+    focusAnnotations: focusAnnotations,
+    highlightAnnotations: highlightAnnotations,
+    removeSelectedAnnotation: removeSelectedAnnotation,
+    selectAnnotations: selectAnnotations,
+    selectTab: selectTab,
+    setCollapsed: setCollapsed,
+    setFilterQuery: setFilterQuery,
+    setForceVisible: setForceVisible,
+    setSortKey: setSortKey,
+    toggleSelectedAnnotations: toggleSelectedAnnotations,
+  },
 
   // Selectors
   hasSelectedAnnotations: hasSelectedAnnotations,

--- a/h/static/scripts/reducers/test/util-test.js
+++ b/h/static/scripts/reducers/test/util-test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+var util = require('../util');
+
+var fixtures = {
+  update: {
+    ADD_ANNOTATIONS: function (state, action) {
+      if (!state.annotations) {
+        return {annotations: action.annotations};
+      }
+      return {annotations: state.annotations.concat(action.annotations)};
+    },
+    SELECT_TAB: function (state, action) {
+      return {tab: action.tab};
+    },
+  },
+  countAnnotations: function (state) {
+    return state.annotations.length;
+  },
+};
+
+describe('reducer utils', function () {
+  describe('#actionTypes', function () {
+    it('returns an object with values equal to keys', function () {
+      assert.deepEqual(util.actionTypes({
+        SOME_ACTION: sinon.stub(),
+        ANOTHER_ACTION: sinon.stub(),
+      }), {
+        SOME_ACTION: 'SOME_ACTION',
+        ANOTHER_ACTION: 'ANOTHER_ACTION',
+      });
+    });
+  });
+
+  describe('#createReducer', function () {
+    it('returns a reducer that combines each update function from the input object', function () {
+      var reducer = util.createReducer(fixtures.update);
+      var newState = reducer({}, {
+        type: 'ADD_ANNOTATIONS',
+        annotations: [{id: 1}],
+      });
+      assert.deepEqual(newState, {
+        annotations: [{id: 1}],
+      });
+    });
+
+    it('returns a new object if the action was handled', function () {
+      var reducer = util.createReducer(fixtures.update);
+      var originalState = {someFlag: false};
+      assert.notEqual(reducer(originalState, {type: 'SELECT_TAB', tab: 'notes'}),
+        originalState);
+    });
+
+    it('returns the original object if the action was not handled', function () {
+      var reducer = util.createReducer(fixtures.update);
+      var originalState = {someFlag: false};
+      assert.equal(reducer(originalState, {type: 'UNKNOWN_ACTION'}), originalState);
+    });
+
+    it('preserves state not modified by the update function', function () {
+      var reducer = util.createReducer(fixtures.update);
+      var newState = reducer({otherFlag: false}, {
+        type: 'ADD_ANNOTATIONS',
+        annotations: [{id: 1}],
+      });
+      assert.deepEqual(newState, {
+        otherFlag: false,
+        annotations: [{id: 1}],
+      });
+    });
+  });
+
+  describe('#bindSelectors', function () {
+    it('bound functions call original functions with current value of getState()', function () {
+      var annotations = [{id: 1}];
+      var getState = sinon.stub().returns({annotations: annotations});
+      var bound = util.bindSelectors({
+        countAnnotations: fixtures.countAnnotations,
+      }, getState);
+
+      assert.equal(bound.countAnnotations(), 1);
+
+      getState.returns({annotations: annotations.concat([{id: 2}])});
+      assert.equal(bound.countAnnotations(), 2);
+    });
+  });
+});

--- a/h/static/scripts/reducers/util.js
+++ b/h/static/scripts/reducers/util.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/**
+ * Compose a list of `(state, action) => new state` reducer functions
+ * into a single reducer.
+ */
+function composeReducers(reducers) {
+  return function (state, action) {
+    return reducers.reduce(function (state, reducer) {
+      return reducer(state, action);
+    }, state);
+  };
+}
+
+module.exports = {
+  composeReducers: composeReducers,
+};

--- a/h/static/scripts/reducers/util.js
+++ b/h/static/scripts/reducers/util.js
@@ -1,17 +1,30 @@
 'use strict';
 
 /**
- * Compose a list of `(state, action) => new state` reducer functions
- * into a single reducer.
+ * Return an object where each key in `updateFns` is mapped to the key itself.
  */
-function composeReducers(reducers) {
+function actionTypes(updateFns) {
+  return Object.keys(updateFns).reduce(function (types, key) {
+    types[key] = key;
+    return types;
+  }, {});
+}
+
+/**
+ * Given an object which maps action names to update functions, this returns
+ * a reducer function that can be passed to the redux `createStore` function.
+ */
+function createReducer(updateFns) {
   return function (state, action) {
-    return reducers.reduce(function (state, reducer) {
-      return reducer(state, action);
-    }, state);
+    var fn = updateFns[action.type];
+    if (!fn) {
+      return state;
+    }
+    return Object.assign({}, state, fn(state, action));
   };
 }
 
 module.exports = {
-  composeReducers: composeReducers,
+  actionTypes: actionTypes,
+  createReducer: createReducer,
 };

--- a/h/static/scripts/reducers/util.js
+++ b/h/static/scripts/reducers/util.js
@@ -24,7 +24,26 @@ function createReducer(updateFns) {
   };
 }
 
+/**
+ * Takes an object mapping keys to selector functions and the `getState()`
+ * function from the store and returns an object with the same keys but where
+ * the values are functions that call the original functions with the `state`
+ * argument set to the current value of `getState()`
+ */
+function bindSelectors(selectors, getState) {
+  return Object.keys(selectors).reduce(function (bound, key) {
+    var selector = selectors[key];
+    bound[key] = function () {
+      var args = [].slice.apply(arguments);
+      args.unshift(getState());
+      return selector.apply(null, args);
+    };
+    return bound;
+  }, {});
+}
+
 module.exports = {
   actionTypes: actionTypes,
+  bindSelectors: bindSelectors,
   createReducer: createReducer,
 };

--- a/h/static/scripts/reducers/viewer.js
+++ b/h/static/scripts/reducers/viewer.js
@@ -1,22 +1,11 @@
 'use strict';
 
+var util = require('./util');
+
 /**
  * This module defines actions and state related to the display mode of the
  * sidebar.
  */
-
-var actions = {
-  /** Sets whether annotated text is highlighted in the page. */
-  SET_HIGHLIGHTS_VISIBLE: 'SET_HIGHLIGHTS_VISIBLE',
-
-  /**
-   * Set whether the app is the sidebar or not.
-   *
-   * When not in the sidebar, we do not expect annotations to anchor and always
-   * display all annotations, rather than only those in the current tab.
-   */
-  SET_SIDEBAR: 'SET_SIDEBAR',
-};
 
 function init() {
   return {
@@ -28,16 +17,16 @@ function init() {
   };
 }
 
-function update(state, action) {
-  switch (action.type) {
-  case actions.SET_SIDEBAR:
-    return Object.assign({}, state, {isSidebar: action.isSidebar});
-  case actions.SET_HIGHLIGHTS_VISIBLE:
-    return Object.assign({}, state, {visibleHighlights: action.visible});
-  default:
-    return state;
-  }
-}
+var update = {
+  SET_SIDEBAR: function (state, action) {
+    return {isSidebar: action.isSidebar};
+  },
+  SET_HIGHLIGHTS_VISIBLE: function (state, action) {
+    return {visibleHighlights: action.visible};
+  },
+};
+
+var actions = util.actionTypes(update);
 
 /** Set whether the app is the sidebar */
 function setAppIsSidebar(isSidebar) {

--- a/h/static/scripts/reducers/viewer.js
+++ b/h/static/scripts/reducers/viewer.js
@@ -1,0 +1,62 @@
+'use strict';
+
+/**
+ * This module defines actions and state related to the display mode of the
+ * sidebar.
+ */
+
+var actions = {
+  /** Sets whether annotated text is highlighted in the page. */
+  SET_HIGHLIGHTS_VISIBLE: 'SET_HIGHLIGHTS_VISIBLE',
+
+  /**
+   * Set whether the app is the sidebar or not.
+   *
+   * When not in the sidebar, we do not expect annotations to anchor and always
+   * display all annotations, rather than only those in the current tab.
+   */
+  SET_SIDEBAR: 'SET_SIDEBAR',
+};
+
+function init() {
+  return {
+    // Flag that indicates whether the app is the sidebar and connected to
+    // a page where annotations are being shown in context
+    isSidebar: true,
+
+    visibleHighlights: false,
+  };
+}
+
+function update(state, action) {
+  switch (action.type) {
+  case actions.SET_SIDEBAR:
+    return Object.assign({}, state, {isSidebar: action.isSidebar});
+  case actions.SET_HIGHLIGHTS_VISIBLE:
+    return Object.assign({}, state, {visibleHighlights: action.visible});
+  default:
+    return state;
+  }
+}
+
+/** Set whether the app is the sidebar */
+function setAppIsSidebar(isSidebar) {
+  return {type: actions.SET_SIDEBAR, isSidebar: isSidebar};
+}
+
+/**
+ * Sets whether annotation highlights in connected documents are shown
+ * or not.
+ */
+function setShowHighlights(show) {
+  return {type: actions.SET_HIGHLIGHTS_VISIBLE, visible: show};
+}
+
+module.exports = {
+  init: init,
+  update: update,
+
+  // Actions
+  setAppIsSidebar: setAppIsSidebar,
+  setShowHighlights: setShowHighlights,
+};

--- a/h/static/scripts/reducers/viewer.js
+++ b/h/static/scripts/reducers/viewer.js
@@ -44,8 +44,8 @@ function setShowHighlights(show) {
 module.exports = {
   init: init,
   update: update,
-
-  // Actions
-  setAppIsSidebar: setAppIsSidebar,
-  setShowHighlights: setShowHighlights,
+  actions: {
+    setAppIsSidebar: setAppIsSidebar,
+    setShowHighlights: setShowHighlights,
+  },
 };

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "raf": "^3.1.0",
     "raven-js": "^2.0.2",
     "redux": "^3.5.2",
+    "redux-thunk": "^2.1.0",
     "request": "^2.72.0",
     "retry": "^0.8.0",
     "scroll-into-view": "^1.3.1",


### PR DESCRIPTION
The `annotationUI` module evolved from before we used Redux to manage app state and it was getting large and doing too much. This PR splits out most of the logic into smaller modules in the `reducers` folder. The `annotationUI` module continues to present the same exports as before to avoid needing to change too much in one PR. Each module in `reducers/` defines:

 - An `init` function which returns the initial state relating to some
   aspect of the application
 - A set of action types, relating to that aspect of the application
 - An `update` function which processes those actions
 - A set of action creators, which are helper functions that create
   these actions
 - A set of selector functions, which are helper functions that return
   derived data from this state

There is a root module in `reducers/index.js` which combines the actions,
init function and update functions from each module into a single init
and update function which can be used to initialize the Redux store.

Action creators which require access to the current app state or are
asynchronous, such as `addAnnotations` return thunks. See
https://github.com/gaearon/redux-thunk#motivation . Several
selection-related action creators currently return thunks but can be
refactored in future into plain actions.

This PR continues to rely on the existing tests for `annotationUI`, but in future we can split those out into a test module per reducer module.
