### PR TITLE
Defer realtime update

### DIFF
--- a/h/static/images/icons/refresh.svg
+++ b/h/static/images/icons/refresh.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="12px" height="16px" viewBox="0 0 12 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 39.1 (31720) - http://www.bohemiancoding.com/sketch -->
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Artboard" fill="#FFFFFF">
+            <path d="M7.58578644,4 L6,4 L6,6 L7.58578644,6 L6.29289322,7.29289322 L5.58578644,8 L7,9.41421356 L7.70710678,8.70710678 L10.7071068,5.70710678 L11.4142136,5 L11.0606602,4.64644661 L10.7071068,4.29289322 L7.70710678,1.29289322 L7,0.585786438 L5.58578644,2 L6.29289322,2.70710678 L7.58578644,4 Z M6,4 L6,6 C6,6 2,6 2,10 C2,10 2,14 6,14 C6,14 10,14 10,10 C10,10 12,10 12,10 C12,10 12,16 6,16 C6,16 0,16 0,10 C0,10 0,4 6,4 Z" id="Combined-Shape"></path>
+        </g>
+    </g>
+</svg>

--- a/h/static/scripts/app-controller.js
+++ b/h/static/scripts/app-controller.js
@@ -25,7 +25,7 @@ function authStateFromUserID(userid) {
 module.exports = function AppController(
   $controller, $document, $location, $rootScope, $route, $scope,
   $window, annotationUI, auth, drafts, features, groups,
-  serviceUrl, session, settings
+  serviceUrl, session, settings, streamer
 ) {
   $controller('AnnotationUIController', {$scope: $scope});
 
@@ -151,4 +151,7 @@ module.exports = function AppController(
       annotationUI.setFilterQuery(query);
     },
   };
+
+  $scope.countPendingUpdates = streamer.countPendingUpdates;
+  $scope.applyPendingUpdates = streamer.applyPendingUpdates;
 };

--- a/h/static/scripts/app.js
+++ b/h/static/scripts/app.js
@@ -162,6 +162,7 @@ module.exports = angular.module('h', [
   .directive('sortDropdown', require('./directive/sort-dropdown'))
   .directive('spinner', require('./directive/spinner'))
   .directive('statusButton', require('./directive/status-button'))
+  .directive('svgIcon', require('./directive/svg-icon'))
   .directive('tagEditor', require('./directive/tag-editor'))
   .directive('threadList', require('./directive/thread-list'))
   .directive('timestamp', require('./directive/timestamp'))

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -51,7 +51,7 @@ function updateModel(annotation, changes, permissions) {
 function AnnotationController(
   $document, $q, $rootScope, $scope, $timeout, $window, annotationUI,
   annotationMapper, drafts, flash, features, groups, permissions, serviceUrl,
-  session, store) {
+  session, store, streamer) {
 
   var vm = this;
   var newlyCreatedByHighlightButton;
@@ -462,6 +462,10 @@ function AnnotationController(
 
   vm.username = function() {
     return persona.username(vm.annotation.user);
+  };
+
+  vm.isDeleted = function () {
+    return streamer.hasPendingDeletion(vm.annotation.id);
   };
 
   vm.isReply = function () {

--- a/h/static/scripts/directive/h-tooltip.js
+++ b/h/static/scripts/directive/h-tooltip.js
@@ -38,8 +38,17 @@ function Tooltip(rootElement) {
     var tooltipRect = this._el.getBoundingClientRect();
 
     var targetRect = target.getBoundingClientRect();
-    var top = targetRect.top - tooltipRect.height - TOOLTIP_ARROW_HEIGHT;
+    var top;
+
+    if (this.state.direction === 'up') {
+      top = targetRect.bottom + TOOLTIP_ARROW_HEIGHT;
+    } else {
+      top = targetRect.top - tooltipRect.height - TOOLTIP_ARROW_HEIGHT;
+    }
     var left = targetRect.right - tooltipRect.width;
+
+    this._el.classList.toggle('tooltip--up', this.state.direction === 'up');
+    this._el.classList.toggle('tooltip--down', this.state.direction === 'down');
 
     Object.assign(this._el.style, {
       visibility: '',
@@ -51,10 +60,13 @@ function Tooltip(rootElement) {
   this._el = rootElement.ownerDocument.createElement('div');
   this._el.innerHTML = '<span class="tooltip-label js-tooltip-label"></span>';
   this._el.className = 'tooltip';
+
   rootElement.appendChild(this._el);
   this._labelEl = this._el.querySelector('.js-tooltip-label');
 
-  this.setState({});
+  this.setState({
+    direction: 'down',
+  });
 }
 
 /**
@@ -78,7 +90,11 @@ module.exports = function () {
       var el = $element[0];
 
       el.addEventListener('mouseover', function () {
-        theTooltip.setState({target: el});
+        var direction = el.getAttribute('tooltip-direction') || 'down';
+        theTooltip.setState({
+          direction: direction,
+          target: el,
+        });
       });
 
       el.addEventListener('mouseout', function () {

--- a/h/static/scripts/directive/svg-icon.js
+++ b/h/static/scripts/directive/svg-icon.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/**
+ * The <svg-icon> component renders SVG icons using inline <svg> tags,
+ * enabling their appearance to be customized via CSS.
+ *
+ * This matches the way we do icons on the website, see
+ * https://github.com/hypothesis/h/pull/3675
+ */
+
+// The list of supported icons
+var icons = {
+  refresh: require('../../images/icons/refresh.svg'),
+};
+
+// @ngInject
+function SvgIconController($element) {
+  if (!icons[this.name]) {
+    throw new Error('Unknown icon: ' + this.name);
+  }
+  $element[0].innerHTML = icons[this.name];
+}
+
+module.exports = function () {
+  return {
+    bindToController: true,
+    controllerAs: 'vm',
+    restrict: 'E',
+    controller: SvgIconController,
+    scope: {
+      /** The name of the icon to load. */
+      name: '<',
+    },
+  };
+};

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -90,6 +90,7 @@ describe('annotation', function() {
     var fakeServiceUrl;
     var fakeSession;
     var fakeStore;
+    var fakeStreamer;
     var sandbox;
 
     function createDirective(annotation) {
@@ -190,6 +191,10 @@ describe('annotation', function() {
         },
       };
 
+      fakeStreamer = {
+        hasPendingDeletion: sinon.stub(),
+      };
+
       $provide.value('annotationMapper', fakeAnnotationMapper);
       $provide.value('annotationUI', fakeAnnotationUI);
       $provide.value('drafts', fakeDrafts);
@@ -200,6 +205,7 @@ describe('annotation', function() {
       $provide.value('session', fakeSession);
       $provide.value('serviceUrl', fakeServiceUrl);
       $provide.value('store', fakeStore);
+      $provide.value('streamer', fakeStreamer);
     }));
 
     beforeEach(
@@ -675,6 +681,20 @@ describe('annotation', function() {
         var annot = fixtures.defaultAnnotation();
         var controller = createDirective(annot).controller;
         assert.deepEqual(controller.documentMeta(), fakeDocumentMeta);
+      });
+    });
+
+    describe('#isDeleted', function () {
+      it('returns true if the annotation has been marked as deleted', function () {
+        var controller = createDirective().controller;
+        fakeStreamer.hasPendingDeletion.returns(true);
+        assert.equal(controller.isDeleted(), true);
+      });
+
+      it('returns false if the annotation has not been marked as deleted', function () {
+        var controller = createDirective().controller;
+        fakeStreamer.hasPendingDeletion.returns(false);
+        assert.equal(controller.isDeleted(), false);
       });
     });
 

--- a/h/static/scripts/directive/test/h-tooltip-test.js
+++ b/h/static/scripts/directive/test/h-tooltip-test.js
@@ -44,6 +44,16 @@ describe('h-tooltip', function () {
     assert.equal(tooltipEl.textContent, 'Share');
   });
 
+  it('sets the direction from the target\'s "tooltip-direction" attribute', function () {
+    targetEl.setAttribute('tooltip-direction', 'up');
+    util.sendEvent(targetEl, 'mouseover');
+    assert.deepEqual(Array.from(tooltipEl.classList), ['tooltip','tooltip--up']);
+
+    targetEl.setAttribute('tooltip-direction', 'down');
+    util.sendEvent(targetEl, 'mouseover');
+    assert.deepEqual(Array.from(tooltipEl.classList), ['tooltip','tooltip--down']);
+  });
+
   it('disappears when the target is unhovered', function () {
     util.sendEvent(targetEl, 'mouseout');
     assert.equal(tooltipEl.style.visibility, 'hidden');

--- a/h/static/scripts/directive/test/svg-icon-test.js
+++ b/h/static/scripts/directive/test/svg-icon-test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var angular = require('angular');
+
+var util = require('./util');
+
+describe('svgIcon', function () {
+  before(function () {
+    angular.module('app', [])
+      .directive('svgIcon', require('../svg-icon'));
+  });
+
+  beforeEach(function () {
+    angular.mock.module('app');
+  });
+
+  it("sets the element's content to the content of the SVG", function () {
+    var el = util.createDirective(document, 'svgIcon', {name: 'refresh'});
+    assert.ok(el[0].querySelector('svg'));
+  });
+
+  it('throws an error if the icon is unknown', function () {
+    assert.throws(function () {
+      util.createDirective(document, 'svgIcon', {name: 'unknown'});
+    });
+  });
+});

--- a/h/static/scripts/directive/test/top-bar-test.js
+++ b/h/static/scripts/directive/test/top-bar-test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var angular = require('angular');
+
+var util = require('./util');
+
+describe('topBar', function () {
+  before(function () {
+    angular.module('app', [])
+      .directive('topBar', require('../top-bar'));
+  });
+
+  beforeEach(function () {
+    angular.mock.module('app');
+  });
+
+  function applyUpdateBtn(el) {
+    return el.querySelector('.top-bar__apply-update-btn');
+  }
+
+  function createTopBar(inputs) {
+    var defaultInputs = {
+      isSidebar: true,
+    };
+    return util.createDirective(document, 'topBar',
+      Object.assign(defaultInputs, inputs));
+  }
+
+  it('shows the pending update count', function () {
+    var el = createTopBar({
+      pendingUpdateCount: 1,
+    });
+    var applyBtn = applyUpdateBtn(el[0]);
+    assert.equal(applyBtn.textContent.trim(), '1');
+  });
+
+  it('does not show the pending update count when there are no updates', function () {
+    var el = createTopBar({
+      pendingUpdateCount: 0,
+    });
+    var applyBtn = applyUpdateBtn(el[0]);
+    assert.notOk(applyBtn);
+  });
+
+  it('applies updates when clicked', function () {
+    var onApplyPendingUpdates = sinon.stub();
+    var el = createTopBar({
+      pendingUpdateCount: 1,
+      onApplyPendingUpdates: onApplyPendingUpdates,
+    });
+    var applyBtn = applyUpdateBtn(el[0]);
+    applyBtn.click();
+    assert.called(onApplyPendingUpdates);
+  });
+});

--- a/h/static/scripts/directive/top-bar.js
+++ b/h/static/scripts/directive/top-bar.js
@@ -2,6 +2,7 @@
 
 module.exports = function () {
   return {
+    controller: function () {},
     restrict: 'E',
     scope: {
       auth: '<',

--- a/h/static/scripts/directive/top-bar.js
+++ b/h/static/scripts/directive/top-bar.js
@@ -16,6 +16,8 @@ module.exports = function () {
       sortKey: '<',
       sortKeysAvailable: '<',
       onChangeSortKey: '&',
+      pendingUpdateCount: '<',
+      onApplyPendingUpdates: '&',
     },
     template: require('../../../templates/client/top_bar.html'),
   };

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -7,6 +7,9 @@ require('core-js/fn/array/find-index');
 require('core-js/fn/array/from');
 require('core-js/fn/object/assign');
 
+// ES2017
+require('core-js/fn/object/values');
+
 // URL constructor, required by IE 10/11,
 // early versions of Microsoft Edge.
 try {

--- a/h/static/scripts/streamer.js
+++ b/h/static/scripts/streamer.js
@@ -206,6 +206,11 @@ function Streamer($rootScope, annotationMapper, features, groups, session, setti
     });
   }
 
+  function clearPendingUpdates() {
+    pendingUpdates = {};
+    pendingDeletions = {};
+  }
+
   var updateEvents = [
     events.ANNOTATION_DELETED,
     events.ANNOTATION_UPDATED,
@@ -215,6 +220,7 @@ function Streamer($rootScope, annotationMapper, features, groups, session, setti
   updateEvents.forEach(function (event) {
     $rootScope.$on(event, removePendingUpdates);
   });
+  $rootScope.$on(events.GROUP_FOCUSED, clearPendingUpdates);
 
   this.applyPendingUpdates = applyPendingUpdates;
   this.countPendingUpdates = countPendingUpdates;

--- a/h/static/scripts/streamer.js
+++ b/h/static/scripts/streamer.js
@@ -2,6 +2,7 @@
 
 var uuid = require('node-uuid');
 
+var events = require('./events');
 var Socket = require('./websocket');
 
 /**
@@ -18,7 +19,7 @@ var Socket = require('./websocket');
  * @param settings - Application settings
  */
 // @ngInject
-function Streamer($rootScope, annotationMapper, groups, session, settings) {
+function Streamer($rootScope, annotationMapper, features, groups, session, settings) {
   // The randomly generated session UUID
   var clientId = uuid.v4();
 
@@ -29,6 +30,23 @@ function Streamer($rootScope, annotationMapper, groups, session, settings) {
   // established.
   var configMessages = {};
 
+  // The streamer maintains a set of pending updates and deletions which have
+  // been received via the WebSocket but not yet applied to the contents of the
+  // app.
+  //
+  // This state should be managed as part of the global app state in
+  // annotationUI, but that is currently difficult because applying updates
+  // requires filtering annotations against the focused group (information not
+  // currently stored in the app state) and triggering events in order to update
+  // the annotations displayed in the page.
+
+  // Map of ID -> updated annotation for updates that have been received over
+  // the WS but not yet applied
+  var pendingUpdates = {};
+  // Set of IDs of annotations which have been deleted but for which the
+  // deletion has not yet been applied
+  var pendingDeletions = {};
+
   function handleAnnotationNotification(message) {
     var action = message.options.action;
     var annotations = message.payload;
@@ -37,25 +55,24 @@ function Streamer($rootScope, annotationMapper, groups, session, settings) {
       return;
     }
 
-    // Discard annotations that aren't from the currently focused group.
-    // Unless the action is delete, where we only get an id
-    // FIXME: Have the server only send us annotations from the focused
-    // group in the first place.
-    if (action !== 'delete') {
-      annotations = annotations.filter(function (ann) {
-        return ann.group === groups.focused().id;
-      });
-    }
-
     switch (action) {
     case 'create':
     case 'update':
     case 'past':
-      annotationMapper.loadAnnotations(annotations);
+      annotations.forEach(function (ann) {
+        pendingUpdates[ann.id] = ann;
+      });
       break;
     case 'delete':
-      annotationMapper.unloadAnnotations(annotations);
+      annotations.forEach(function (ann) {
+        delete pendingUpdates[ann.id];
+        pendingDeletions[ann.id] = true;
+      });
       break;
+    }
+
+    if (!features.flagEnabled('defer_realtime_updates')) {
+      applyPendingUpdates();
     }
   }
 
@@ -155,6 +172,53 @@ function Streamer($rootScope, annotationMapper, groups, session, settings) {
     _connect();
   };
 
+  function applyPendingUpdates() {
+    var updates = Object.values(pendingUpdates).filter(function (ann) {
+      // Ignore updates to annotations that are not in the focused group
+      return ann.group === groups.focused().id;
+    });
+    var deletions = Object.keys(pendingDeletions).map(function (id) {
+      return {id: id};
+    });
+
+    annotationMapper.loadAnnotations(updates);
+    annotationMapper.unloadAnnotations(deletions);
+
+    pendingUpdates = {};
+    pendingDeletions = {};
+  }
+
+  function countPendingUpdates() {
+    return Object.keys(pendingUpdates).length;
+  }
+
+  function hasPendingDeletion(id) {
+    return pendingDeletions.hasOwnProperty(id);
+  }
+
+  function removePendingUpdates(event, anns) {
+    if (!Array.isArray(anns)) {
+      anns = [anns];
+    }
+    anns.forEach(function (ann) {
+      delete pendingUpdates[ann.id];
+      delete pendingDeletions[ann.id];
+    });
+  }
+
+  var updateEvents = [
+    events.ANNOTATION_DELETED,
+    events.ANNOTATION_UPDATED,
+    events.ANNOTATIONS_UNLOADED,
+  ];
+
+  updateEvents.forEach(function (event) {
+    $rootScope.$on(event, removePendingUpdates);
+  });
+
+  this.applyPendingUpdates = applyPendingUpdates;
+  this.countPendingUpdates = countPendingUpdates;
+  this.hasPendingDeletion = hasPendingDeletion;
   this.clientId = clientId;
   this.configMessages = configMessages;
   this.connect = connect;

--- a/h/static/scripts/test/app-controller-test.js
+++ b/h/static/scripts/test/app-controller-test.js
@@ -22,6 +22,7 @@ describe('AppController', function () {
   var fakeRoute = null;
   var fakeServiceUrl = null;
   var fakeSettings = null;
+  var fakeStreamer = null;
   var fakeWindow = null;
 
   var sandbox = null;
@@ -96,6 +97,10 @@ describe('AppController', function () {
 
     fakeServiceUrl = sinon.stub();
     fakeSettings = {};
+    fakeStreamer = {
+      countPendingUpdates: sinon.stub(),
+      applyPendingUpdates: sinon.stub(),
+    };
 
     $provide.value('annotationUI', fakeAnnotationUI);
     $provide.value('auth', fakeAuth);
@@ -104,6 +109,7 @@ describe('AppController', function () {
     $provide.value('serviceUrl', fakeServiceUrl);
     $provide.value('session', fakeSession);
     $provide.value('settings', fakeSettings);
+    $provide.value('streamer', fakeStreamer);
     $provide.value('groups', fakeGroups);
     $provide.value('$route', fakeRoute);
     $provide.value('$location', fakeLocation);

--- a/h/static/scripts/test/streamer-test.js
+++ b/h/static/scripts/test/streamer-test.js
@@ -1,9 +1,44 @@
 'use strict';
 
-var inherits = require('inherits');
 var EventEmitter = require('tiny-emitter');
-
+var inherits = require('inherits');
 var proxyquire = require('proxyquire');
+
+var events = require('../events');
+var unroll = require('./util').unroll;
+
+var fixtures = {
+  createNotification: {
+    type: 'annotation-notification',
+    options: {
+      action: 'create',
+    },
+    payload: [{
+      id: 'an-id',
+      group: 'public',
+    }],
+  },
+  updateNotification: {
+    type: 'annotation-notification',
+    options: {
+      action: 'create',
+    },
+    payload: [{
+      id: 'an-id',
+      group: 'public',
+    }],
+  },
+  deleteNotification: {
+    type: 'annotation-notification',
+    options: {
+      action: 'delete',
+    },
+    payload: [{
+      id: 'an-id',
+      group: 'public',
+    }],
+  },
+};
 
 // the most recently created FakeSocket instance
 var fakeWebSocket = null;
@@ -32,6 +67,7 @@ inherits(FakeSocket, EventEmitter);
 
 describe('Streamer', function () {
   var fakeAnnotationMapper;
+  var fakeFeatures;
   var fakeGroups;
   var fakeRootScope;
   var fakeSession;
@@ -43,6 +79,7 @@ describe('Streamer', function () {
     activeStreamer = new Streamer(
       fakeRootScope,
       fakeAnnotationMapper,
+      fakeFeatures,
       fakeGroups,
       fakeSession,
       fakeSettings
@@ -50,9 +87,15 @@ describe('Streamer', function () {
   }
 
   beforeEach(function () {
+    var emitter = new EventEmitter();
+
     fakeRootScope = {
       $apply: function (callback) {
         callback();
+      },
+      $on: emitter.on.bind(emitter),
+      $broadcast: function (event, data) {
+        emitter.emit(event, {event: event}, data);
       },
     };
 
@@ -61,9 +104,13 @@ describe('Streamer', function () {
       unloadAnnotations: sinon.stub(),
     };
 
+    fakeFeatures = {
+      flagEnabled: sinon.stub().returns(false),
+    };
+
     fakeGroups = {
       focused: function () {
-        return 'public';
+        return {id: 'public'};
       },
     };
 
@@ -78,6 +125,10 @@ describe('Streamer', function () {
     Streamer = proxyquire('../streamer', {
       './websocket': FakeSocket,
     });
+  });
+
+  afterEach(function () {
+    activeStreamer = null;
   });
 
   it('should not create a websocket connection if websocketUrl is not provided', function () {
@@ -134,35 +185,124 @@ describe('Streamer', function () {
   });
 
   describe('annotation notifications', function () {
-    it('should load new annotations', function () {
+    beforeEach(function () {
       createDefaultStreamer();
       activeStreamer.connect();
-      fakeWebSocket.notify({
-        type: 'annotation-notification',
-        options: {
-          action: 'create',
-        },
-        payload: [{
-          group: 'public',
-        }],
-      });
-      assert.ok(fakeAnnotationMapper.loadAnnotations.calledOnce);
     });
 
-    it('should unload deleted annotations', function () {
+    context('when realtime updates are not deferred', function () {
+      it('should load new annotations', function () {
+        fakeWebSocket.notify(fixtures.createNotification);
+        assert.ok(fakeAnnotationMapper.loadAnnotations.calledOnce);
+      });
+
+      it('should unload deleted annotations', function () {
+        fakeWebSocket.notify(fixtures.deleteNotification);
+        assert.ok(fakeAnnotationMapper.unloadAnnotations.calledOnce);
+      });
+    });
+
+    context('when realtime updates are deferred', function () {
+      beforeEach(function () {
+        fakeFeatures.flagEnabled.returns(true);
+      });
+
+      it('saves pending updates', function () {
+        fakeWebSocket.notify(fixtures.createNotification);
+        assert.equal(activeStreamer.countPendingUpdates(), 1);
+      });
+
+      it('saves pending deletions', function () {
+        var id = fixtures.deleteNotification.payload[0].id;
+        fakeWebSocket.notify(fixtures.deleteNotification);
+        assert.isTrue(activeStreamer.hasPendingDeletion(id));
+      });
+
+      it('saves one pending update per annotation', function () {
+        fakeWebSocket.notify(fixtures.createNotification);
+        fakeWebSocket.notify(fixtures.updateNotification);
+        assert.equal(activeStreamer.countPendingUpdates(), 1);
+      });
+
+      it('discards pending updates if an annotation is deleted', function () {
+        fakeWebSocket.notify(fixtures.createNotification);
+        fakeWebSocket.notify(fixtures.deleteNotification);
+        assert.equal(activeStreamer.countPendingUpdates(), 0);
+      });
+
+      it('does not apply updates immediately', function () {
+        fakeWebSocket.notify(fixtures.createNotification);
+        assert.notCalled(fakeAnnotationMapper.loadAnnotations);
+      });
+
+      it('does not apply deletions immediately', function () {
+        fakeWebSocket.notify(fixtures.deleteNotification);
+        assert.notCalled(fakeAnnotationMapper.unloadAnnotations);
+      });
+    });
+  });
+
+  describe('#applyPendingUpdates', function () {
+    beforeEach(function () {
       createDefaultStreamer();
       activeStreamer.connect();
-      fakeWebSocket.notify({
-        type: 'annotation-notification',
-        options: {
-          action: 'delete',
-        },
-        payload: [{
-          group: 'public',
-        }],
-      });
-      assert.ok(fakeAnnotationMapper.unloadAnnotations.calledOnce);
+      fakeFeatures.flagEnabled.returns(true);
     });
+
+    it('applies pending updates', function () {
+      fakeWebSocket.notify(fixtures.createNotification);
+      activeStreamer.applyPendingUpdates();
+      assert.calledWith(fakeAnnotationMapper.loadAnnotations,
+        fixtures.createNotification.payload);
+    });
+
+    it('does not apply pending updates for annotations in unfocused groups', function () {
+      fakeWebSocket.notify(fixtures.createNotification);
+      fakeGroups.focused = function () { return {id: 'private'}; };
+      activeStreamer.applyPendingUpdates();
+      assert.calledWith(fakeAnnotationMapper.loadAnnotations, []);
+    });
+
+    it('applies pending deletions', function () {
+      fakeWebSocket.notify(fixtures.deleteNotification);
+      activeStreamer.applyPendingUpdates();
+      assert.calledWithMatch(fakeAnnotationMapper.unloadAnnotations,
+        sinon.match([{id: 'an-id'}]));
+    });
+
+    it('clears the set of pending updates', function () {
+      fakeWebSocket.notify(fixtures.createNotification);
+      activeStreamer.applyPendingUpdates();
+      assert.equal(activeStreamer.countPendingUpdates(), 0);
+    });
+  });
+
+  describe('when annotations are unloaded, updated or deleted', function () {
+    var changeEvents = [
+      {event: events.ANNOTATION_DELETED},
+      {event: events.ANNOTATION_UPDATED},
+      {event: events.ANNOTATIONS_UNLOADED},
+    ];
+
+    beforeEach(function () {
+      createDefaultStreamer();
+      activeStreamer.connect();
+      fakeFeatures.flagEnabled.returns(true);
+    });
+
+    unroll('discards pending updates when #event occurs', function (testCase) {
+      fakeWebSocket.notify(fixtures.createNotification);
+      assert.equal(activeStreamer.countPendingUpdates(), 1);
+      fakeRootScope.$broadcast(testCase.event, {id: 'an-id'});
+      assert.equal(activeStreamer.countPendingUpdates(), 0);
+    }, changeEvents);
+
+    unroll('discards pending deletions when #event occurs', function (testCase) {
+      fakeWebSocket.notify(fixtures.deleteNotification);
+      assert.isTrue(activeStreamer.hasPendingDeletion('an-id'));
+      fakeRootScope.$broadcast(testCase.event, {id: 'an-id'});
+      assert.isFalse(activeStreamer.hasPendingDeletion('an-id'));
+    }, changeEvents);
   });
 
   describe('session change notifications', function () {

--- a/h/static/scripts/test/streamer-test.js
+++ b/h/static/scripts/test/streamer-test.js
@@ -305,6 +305,19 @@ describe('Streamer', function () {
     }, changeEvents);
   });
 
+  describe('when the focused group changes', function () {
+    it('clears pending updates and deletions', function () {
+      createDefaultStreamer();
+      activeStreamer.connect();
+      fakeFeatures.flagEnabled.returns(true);
+
+      fakeWebSocket.notify(fixtures.createNotification);
+      fakeRootScope.$broadcast(events.GROUP_FOCUSED);
+
+      assert.equal(activeStreamer.countPendingUpdates(), 0);
+    });
+  });
+
   describe('session change notifications', function () {
     it('updates the session when a notification is received', function () {
       createDefaultStreamer();

--- a/h/static/styles/annotation.scss
+++ b/h/static/styles/annotation.scss
@@ -165,6 +165,10 @@
   font-weight: normal;
   padding: 0;
   margin: 0px 0px 0px 12px;
+
+  &[disabled] {
+    opacity: 0.2;
+  }
 }
 
 .annotation-quote {

--- a/h/static/styles/tooltip.scss
+++ b/h/static/styles/tooltip.scss
@@ -30,10 +30,16 @@
 }
 
 // Arrow at the bottom of the tooltip pointing down at the target element.
-.tooltip:before {
+.tooltip--down:before {
   @include tooltip-arrow(45deg);
   content: "";
   top: calc(100% - 5px);
+}
+
+.tooltip--up:before {
+  @include tooltip-arrow(225deg);
+  content: "";
+  top: -3px;
 }
 
 .tooltip-label {

--- a/h/static/styles/tooltip.scss
+++ b/h/static/styles/tooltip.scss
@@ -1,3 +1,8 @@
+// Tooltips
+// --------
+// Custom tooltips that appear instantly, replacing the browser's default
+// tooltip
+
 @mixin tooltip-arrow($rotation) {
   transform: rotate($rotation);
   background: $grey-7;
@@ -14,6 +19,7 @@
   width: 6px;
 }
 
+// The tooltip background
 .tooltip {
   @include font-small;
 
@@ -29,19 +35,23 @@
   z-index: $zindex-tooltip;
 }
 
-// Arrow at the bottom of the tooltip pointing down at the target element.
+// Arrow at the bottom of the tooltip pointing at the target element
+
+// Variant for tooltips above the target that point down at it
 .tooltip--down:before {
   @include tooltip-arrow(45deg);
   content: "";
   top: calc(100% - 5px);
 }
 
+// Variant for tooltips below the target that point up at it
 .tooltip--up:before {
   @include tooltip-arrow(225deg);
   content: "";
   top: -3px;
 }
 
+// The text content inside the tooltip
 .tooltip-label {
   // Make the label a positioned element so that it appears _above_ the
   // tooltip's arrow, which partially overlaps the content of the tooltip.

--- a/h/static/styles/top-bar.scss
+++ b/h/static/styles/top-bar.scss
@@ -70,6 +70,7 @@
 // on the current page and applies them when clicked
 .top-bar__apply-update-btn {
   display: inline-block;
+  flex-shrink: 0;
   margin-right: 5px;
 
   background-color: $brand;

--- a/h/static/styles/top-bar.scss
+++ b/h/static/styles/top-bar.scss
@@ -66,6 +66,24 @@
   }
 }
 
+// Button which indicates that other users have made or edited annotations
+// on the current page and applies them when clicked
+.top-bar__apply-update-btn {
+  display: inline-block;
+  margin-right: 5px;
+
+  background-color: $brand;
+  border-radius: 2px;
+  color: white;
+  cursor: pointer;
+  font-weight: bold;
+  padding-bottom: 2px;
+  padding-left: 5px;
+  padding-right: 5px;
+  padding-top: 2px;
+  user-select: none;
+}
+
 .top-bar__dropdown-arrow {
   color: $color-dove-gray;
 }

--- a/h/static/styles/top-bar.scss
+++ b/h/static/styles/top-bar.scss
@@ -68,8 +68,13 @@
 
 // Button which indicates that other users have made or edited annotations
 // on the current page and applies them when clicked
+//
+// The button displays a 'refresh' icon and an update count, both of which
+// should be vertically centered within the icon.
 .top-bar__apply-update-btn {
-  display: inline-block;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   flex-shrink: 0;
   margin-right: 5px;
 
@@ -83,6 +88,12 @@
   padding-right: 5px;
   padding-top: 2px;
   user-select: none;
+}
+
+.top-bar__apply-icon {
+  display: inline-block;
+  line-height: 12px;
+  margin-right: 5px;
 }
 
 .top-bar__dropdown-arrow {

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -145,6 +145,7 @@
       <button class="btn btn-clean annotation-action-btn"
         ng-show="vm.authorize('update') && !vm.isSaving"
         ng-click="vm.edit()"
+        ng-disabled="vm.isDeleted()"
         aria-label="Edit"
         h-tooltip>
         <i class="h-icon-annotation-edit btn-icon "></i>
@@ -152,12 +153,14 @@
       <button class="btn btn-clean annotation-action-btn"
         ng-show="vm.authorize('delete')"
         ng-click="vm.delete()"
+        ng-disabled="vm.isDeleted()"
         aria-label="Delete"
         h-tooltip>
         <i class="h-icon-annotation-delete btn-icon "></i>
       </button>
       <button class="btn btn-clean annotation-action-btn"
         ng-click="vm.reply()"
+        ng-disabled="vm.isDeleted()"
         aria-label="Reply"
         h-tooltip>
         <i class="h-icon-annotation-reply btn-icon "></i>
@@ -165,6 +168,7 @@
       <span class="annotation-share-dialog-wrapper">
         <button class="btn btn-clean annotation-action-btn"
           ng-click="vm.showShareDialog = true"
+          ng-disabled="vm.isDeleted()"
           aria-label="Share"
           h-tooltip>
           <i class="h-icon-annotation-share btn-icon "></i>

--- a/h/templates/client/app.html
+++ b/h/templates/client/app.html
@@ -5,6 +5,8 @@
   on-share-page="share()"
   on-show-help-panel="helpPanel.visible = true"
   is-sidebar="::isSidebar"
+  pending-update-count="countPendingUpdates()"
+  on-apply-pending-updates="applyPendingUpdates()"
   search-controller="search"
   sort-key="sortKey()"
   sort-keys-available="sortKeysAvailable()"

--- a/h/templates/client/top_bar.html
+++ b/h/templates/client/top_bar.html
@@ -10,6 +10,14 @@
       always-expanded="true">
     </search-input>
     <div class="top-bar__expander"></div>
+    <a class="top-bar__apply-update-btn"
+       ng-if="pendingUpdateCount > 0"
+       ng-click="onApplyPendingUpdates()"
+       h-tooltip
+       tooltip-direction="up"
+       aria-label="View {{pendingUpdateCount}} updates">
+       <i class="h-icon-feed"></i> {{pendingUpdateCount}}
+    </a>
     <login-control
       auth="auth"
       new-style="false"

--- a/h/templates/client/top_bar.html
+++ b/h/templates/client/top_bar.html
@@ -16,7 +16,8 @@
        h-tooltip
        tooltip-direction="up"
        aria-label="View {{pendingUpdateCount}} updates">
-       <i class="h-icon-feed"></i> {{pendingUpdateCount}}
+       <svg-icon class="top-bar__apply-icon" name="'refresh'"></svg-icon>
+       {{pendingUpdateCount}}
     </a>
     <login-control
       auth="auth"
@@ -40,7 +41,8 @@
        h-tooltip
        tooltip-direction="up"
        aria-label="View {{pendingUpdateCount}} updates">
-       <i class="h-icon-feed"></i> {{pendingUpdateCount}}
+       <svg-icon class="top-bar__apply-icon" name="'refresh'"></svg-icon>
+       {{pendingUpdateCount}}
     </a>
     <search-input
       class="search-input"

--- a/h/templates/client/top_bar.html
+++ b/h/templates/client/top_bar.html
@@ -26,6 +26,13 @@
   <div class="top-bar__inner content" ng-if="::isSidebar">
     <group-list class="group-list" auth="auth"></group-list>
     <div class="top-bar__expander"></div>
+    <a class="top-bar__apply-update-btn"
+       ng-if="pendingUpdateCount > 0"
+       ng-click="onApplyPendingUpdates()"
+       h-tooltip
+       aria-label="View {{pendingUpdateCount}} updates">
+       <i class="h-icon-feed"></i> {{pendingUpdateCount}}
+    </a>
     <search-input
       class="search-input"
       query="searchController.query()"

--- a/h/templates/client/top_bar.html
+++ b/h/templates/client/top_bar.html
@@ -30,6 +30,7 @@
        ng-if="pendingUpdateCount > 0"
        ng-click="onApplyPendingUpdates()"
        h-tooltip
+       tooltip-direction="up"
        aria-label="View {{pendingUpdateCount}} updates">
        <i class="h-icon-feed"></i> {{pendingUpdateCount}}
     </a>

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
         {
           "appliesTo": {
             "includeExtensions": [
-              ".html"
+              ".html",
+              ".svg"
             ]
           }
         }


### PR DESCRIPTION
_This requires the `defer_realtime_updates` feature flag added in https://github.com/hypothesis/h/pull/3865 to be merged and enabled in the H service_

This implements the design for deferring application of updates received via the WS from https://trello.com/c/tRZ2H7iH/452-defer-applying-realtime-updates

When the `defer_realtime_updates` flag is enabled, any updates received via the WS are not applied immediately but instead an icon is shown in the top bar which applies the updates when clicked. This is shown both in the sidebar and stream.

When a realtime deletion is received, the action icons for the annotation are disabled but the annotation is not actually removed from the loaded set until updates are applied.

**Implementation Notes**

The set of pending updates and deletions is currently maintained by the `Streamer` service. It should be moved to the app state, but that is currently undergoing a significant refactoring (https://github.com/hypothesis/client/pull/104) and also applying updates currently involves accessing the active group, information which is not currently stored in the app state. Putting this state in the `Streamer` service for the time being will enable us to ship this quicker and sort out UX.

**Known Issues**
 - The Refresh icon is currently missing, I've used one of the existing icons instead and will add that in a follow-up
 - If deletion notifications have been received but no create/update notifications, the 'Apply updates' button is not shown and the user has no way to expunge the deleted annotations from the list, except by switching groups or reloading the page