### PR TITLE
Fix off-screen empty drafts not being removed when a new annotation is created

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -122,10 +122,6 @@ function AnnotationController(
       */
     newlyCreatedByHighlightButton = vm.annotation.$highlight || false;
 
-    // When a new annotation is created, remove any existing annotations that
-    // are empty.
-    $scope.$on(events.BEFORE_ANNOTATION_CREATED, deleteIfNewAndEmpty);
-
     // Call `onGroupFocused()` whenever the currently-focused group changes.
     $scope.$on(events.GROUP_FOCUSED, onGroupFocused);
 
@@ -155,12 +151,6 @@ function AnnotationController(
       if (isNew(vm.annotation) || drafts.get(vm.annotation)) {
         vm.edit();
       }
-    }
-  }
-
-  function deleteIfNewAndEmpty() {
-    if (isNew(vm.annotation) && !vm.state().text && vm.state().tags.length === 0) {
-      vm.revert();
     }
   }
 

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -867,51 +867,6 @@ describe('annotation', function() {
       });
     });
 
-    describe('when another new annotation is created', function () {
-      it('removes the current annotation if empty', function () {
-        var annotation = fixtures.newEmptyAnnotation();
-        createDirective(annotation);
-        $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED,
-          fixtures.newAnnotation());
-        assert.calledWith(fakeDrafts.remove, annotation);
-      });
-
-      it('does not remove the current annotation if is is not new', function () {
-        createDirective(fixtures.defaultAnnotation());
-        fakeDrafts.get.returns({text: '', tags: []});
-        $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED,
-          fixtures.newAnnotation());
-        assert.notCalled(fakeDrafts.remove);
-      });
-
-      it('does not remove the current annotation if the scope was destroyed', function () {
-        var annotation = fixtures.newEmptyAnnotation();
-        var parts = createDirective(annotation);
-        parts.scope.$destroy();
-        $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED,
-          fixtures.newAnnotation());
-        assert.notCalled(fakeDrafts.remove);
-      });
-
-      it('does not remove the current annotation if it has text', function () {
-        var annotation = fixtures.newAnnotation();
-        createDirective(annotation);
-        fakeDrafts.get.returns({text: 'An incomplete thought'});
-        $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED,
-          fixtures.newAnnotation());
-        assert.notCalled(fakeDrafts.remove);
-      });
-
-      it('does not remove the current annotation if it has tags', function () {
-        var annotation = fixtures.newAnnotation();
-        createDirective(annotation);
-        fakeDrafts.get.returns({tags: ['a-tag']});
-        $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED,
-          fixtures.newAnnotation());
-        assert.notCalled(fakeDrafts.remove);
-      });
-    });
-
     describe('when the focused group changes', function() {
       it('moves new annotations to the focused group', function () {
         var annotation = fixtures.newAnnotation();

--- a/h/static/scripts/drafts.js
+++ b/h/static/scripts/drafts.js
@@ -1,6 +1,17 @@
 'use strict';
 
 /**
+ * Return true if a given `draft` is empty and can be discarded without losing
+ * any user input
+ */
+function isEmpty(draft) {
+  if (!draft) {
+    return true;
+  }
+  return !draft.text && draft.tags.length === 0;
+}
+
+/**
  * The drafts service provides temporary storage for unsaved edits to new or
  * existing annotations.
  *
@@ -63,6 +74,15 @@ function DraftStore() {
       }
     }
     return null;
+  };
+
+  /**
+   * Returns the draft changes for an annotation, or null if no draft exists
+   * or the draft is empty.
+   */
+  this.getIfNotEmpty = function (model) {
+    var draft = this.get(model);
+    return isEmpty(draft) ? null : draft;
   };
 
   /**

--- a/h/static/scripts/test/drafts-test.js
+++ b/h/static/scripts/test/drafts-test.js
@@ -2,11 +2,49 @@
 
 var draftsService = require('../drafts');
 
+var fixtures = {
+  draftWithText: {
+    isPrivate: false,
+    text: 'some text',
+    tags: [],
+  },
+  draftWithTags: {
+    isPrivate: false,
+    text: '',
+    tags: ['atag'],
+  },
+  emptyDraft: {
+    isPrivate: false,
+    text: '',
+    tags: [],
+  },
+};
+
 describe('drafts', function () {
   var drafts;
 
   beforeEach(function () {
     drafts = draftsService();
+  });
+
+  describe('#getIfNotEmpty', function () {
+    it('returns the draft if it has tags', function () {
+      var model = {id: 'foo'};
+      drafts.update(model, fixtures.draftWithTags);
+      assert.deepEqual(drafts.getIfNotEmpty(model), fixtures.draftWithTags);
+    });
+
+    it('returns the draft if it has text', function () {
+      var model = {id: 'foo'};
+      drafts.update(model, fixtures.draftWithText);
+      assert.deepEqual(drafts.getIfNotEmpty(model), fixtures.draftWithText);
+    });
+
+    it('returns null if the text and tags are empty', function () {
+      var model = {id: 'foo'};
+      drafts.update(model, fixtures.emptyDraft);
+      assert.isNull(drafts.getIfNotEmpty(model));
+    });
   });
 
   describe('#update', function () {

--- a/h/static/scripts/test/integration/threading-test.js
+++ b/h/static/scripts/test/integration/threading-test.js
@@ -45,6 +45,7 @@ describe('annotation threading', function () {
 
     angular.module('app', [])
       .service('annotationUI', require('../../annotation-ui'))
+      .service('drafts', require('../../drafts'))
       .service('rootThread', require('../../root-thread'))
       .service('searchFilter', require('../../search-filter'))
       .service('viewFilter', require('../../view-filter'))


### PR DESCRIPTION
The logic to remove new and empty annotations used to live in the
`<annotation>` component because that was the only part of the code that
had access to the state of unsaved changes.

Since `<annotation>` instances are only created for on-screen annotations,
this can result in empty drafts not being removed if the empty
annotation is off-screen.

Now that the canonical content of unsaved annotations is stored in the
drafts service, we can move the logic outside of the annotation
component and fix this problem.

As with https://github.com/hypothesis/client/pull/106, drafts should live in the app state which would make implementing this kind of logic very easy, but that is blocked on other refactoring. This PR at least fixes the issue and documents (via tests) the intended behavior.

Fixes #97