### PR TITLE
Disable deferred updates on the stream and standalone annotation pages

### DIFF
--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -105,6 +105,8 @@ module.exports = function ($rootScope, settings) {
     hasSelectedAnnotations: selectionReducer.hasSelectedAnnotations,
 
     savedAnnotations: annotationsReducer.savedAnnotations,
+
+    isSidebar: viewerReducer.isSidebar,
   }, store.getState);
 
   return Object.assign(store, actionCreators, selectors);

--- a/h/static/scripts/reducers/test/viewer-test.js
+++ b/h/static/scripts/reducers/test/viewer-test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var viewer = require('../viewer');
+
+var util = require('../util');
+
+var init = viewer.init;
+var actions = viewer.actions;
+var update = util.createReducer(viewer.update);
+
+describe('viewer reducer', function () {
+  describe('#setAppIsSidebar', function () {
+    it('sets a flag indicating that the app is the sidebar', function () {
+      var state = update(init(), actions.setAppIsSidebar(true));
+      assert.isTrue(viewer.isSidebar(state));
+    });
+
+    it('sets a flag indicating that the app is not the sidebar', function () {
+      var state = update(init(), actions.setAppIsSidebar(false));
+      assert.isFalse(viewer.isSidebar(state));
+    });
+  });
+});

--- a/h/static/scripts/reducers/viewer.js
+++ b/h/static/scripts/reducers/viewer.js
@@ -41,6 +41,14 @@ function setShowHighlights(show) {
   return {type: actions.SET_HIGHLIGHTS_VISIBLE, visible: show};
 }
 
+/**
+ * Returns true if the app is being used as the sidebar in the annotation
+ * client, as opposed to the standalone annotation page or stream views.
+ */
+function isSidebar(state) {
+  return state.isSidebar;
+}
+
 module.exports = {
   init: init,
   update: update,
@@ -48,4 +56,7 @@ module.exports = {
     setAppIsSidebar: setAppIsSidebar,
     setShowHighlights: setShowHighlights,
   },
+
+  // Selectors
+  isSidebar: isSidebar,
 };

--- a/h/static/scripts/streamer.js
+++ b/h/static/scripts/streamer.js
@@ -19,7 +19,8 @@ var Socket = require('./websocket');
  * @param settings - Application settings
  */
 // @ngInject
-function Streamer($rootScope, annotationMapper, features, groups, session, settings) {
+function Streamer($rootScope, annotationMapper, annotationUI, features, groups,
+                  session, settings) {
   // The randomly generated session UUID
   var clientId = uuid.v4();
 
@@ -59,7 +60,7 @@ function Streamer($rootScope, annotationMapper, features, groups, session, setti
         // Only include annotations from the focused group, since we reload all
         // annotations and discard pending updates and deletions when switching
         // groups
-        if (ann.group === groups.focused().id) {
+        if (ann.group === groups.focused().id || !annotationUI.isSidebar()) {
           pendingUpdates[ann.id] = ann;
         }
       });
@@ -72,7 +73,8 @@ function Streamer($rootScope, annotationMapper, features, groups, session, setti
       break;
     }
 
-    if (!features.flagEnabled('defer_realtime_updates')) {
+    if (!features.flagEnabled('defer_realtime_updates') ||
+        !annotationUI.isSidebar()) {
       applyPendingUpdates();
     }
   }

--- a/h/templates/client/top_bar.html
+++ b/h/templates/client/top_bar.html
@@ -10,15 +10,6 @@
       always-expanded="true">
     </search-input>
     <div class="top-bar__expander"></div>
-    <a class="top-bar__apply-update-btn"
-       ng-if="pendingUpdateCount > 0"
-       ng-click="onApplyPendingUpdates()"
-       h-tooltip
-       tooltip-direction="up"
-       aria-label="View {{pendingUpdateCount}} updates">
-       <svg-icon class="top-bar__apply-icon" name="'refresh'"></svg-icon>
-       {{pendingUpdateCount}}
-    </a>
     <login-control
       auth="auth"
       new-style="false"


### PR DESCRIPTION
The deferred update UI was added primarily to avoid the problem of
annotation updates being distracting while a user is composing
annotations in the sidebar. This is less relevant on the stream.

Additionally do not filter updates by group on the stream, since the stream
shows annotations from all groups.