### PR TITLE
Count deletions as pending updates

### DIFF
--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -104,6 +104,7 @@ module.exports = function ($rootScope, settings) {
     isAnnotationSelected: selectionReducer.isAnnotationSelected,
     hasSelectedAnnotations: selectionReducer.hasSelectedAnnotations,
 
+    annotationExists: annotationsReducer.annotationExists,
     savedAnnotations: annotationsReducer.savedAnnotations,
 
     isSidebar: viewerReducer.isSidebar,

--- a/h/static/scripts/reducers/annotations.js
+++ b/h/static/scripts/reducers/annotations.js
@@ -258,6 +258,13 @@ function savedAnnotations(state) {
   });
 }
 
+/** Return true if the annotation with a given ID is currently loaded. */
+function annotationExists(state, id) {
+  return state.annotations.some(function (annot) {
+    return annot.id === id;
+  });
+}
+
 module.exports = {
   init: init,
   update: update,
@@ -269,5 +276,6 @@ module.exports = {
   },
 
   // Selectors
+  annotationExists: annotationExists,
   savedAnnotations: savedAnnotations,
 };

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -61,12 +61,6 @@ module.exports = function WidgetController(
 
   $scope.$on('$destroy', unsubscribeAnnotationUI);
 
-  function annotationExists(id) {
-    return annotationUI.getState().annotations.some(function (annot) {
-      return annot.id === id;
-    });
-  }
-
   function focusAnnotation(annotation) {
     var highlights = [];
     if (annotation) {
@@ -302,7 +296,7 @@ module.exports = function WidgetController(
     var selectedID = firstKey(annotationUI.getState().selectedAnnotationMap);
     return !isLoading() &&
            !!selectedID &&
-           !annotationExists(selectedID);
+           !annotationUI.annotationExists(selectedID);
   };
 
   $scope.shouldShowLoggedOutMessage = function () {
@@ -323,7 +317,7 @@ module.exports = function WidgetController(
     var selectedID = firstKey(annotationUI.getState().selectedAnnotationMap);
     return !isLoading() &&
            !!selectedID &&
-           annotationExists(selectedID);
+           annotationUI.annotationExists(selectedID);
   };
 
   $scope.isLoading = isLoading;


### PR DESCRIPTION
_**This depends on #112**_

When calculating the count of pending updates that is used to determine
whether to show the 'Apply Updates' icon or not, count deletions.
 
In addition to changing the count calculation itself, this also requires
that pending deletions are discarded for annotations that are not
currently loaded. Such notifications may be received because the
deletion may have happened in an un-focused group. Unlike create/update
notifications, no group information is included in the notification
itself so we look up the ID in the local store.
