### PR TITLE
Stop fetching result pages if current page is empty

### DIFF
--- a/h/static/scripts/search-client.js
+++ b/h/static/scripts/search-client.js
@@ -49,8 +49,14 @@ SearchClient.prototype._getBatch = function (query, offset) {
       self._results = self._results.concat(chunk);
     }
 
+    // Check if there are additional pages of results to fetch. In addition to
+    // checking the `total` figure from the server, we also require that at
+    // least one result was returned in the current page, otherwise we would
+    // end up repeating the same query for the next page. If the server's
+    // `total` count is incorrect for any reason, that will lead to the client
+    // polling the server indefinitely.
     var nextOffset = offset + results.rows.length;
-    if (results.total > nextOffset) {
+    if (results.total > nextOffset && chunk.length > 0) {
       self._getBatch(query, nextOffset);
     } else {
       if (!self._incremental) {


### PR DESCRIPTION
Yesterday a brief issue occurred where the server reported an incorrect
(too high) total number of results for a URL due to the search index
being out of date. Once the client reached the end of the actually
available results, it made queries to the search endpoint which returned
an empty result set but had a `total` figure implying that there should
be more pages. The client then ended up polling the server indefinitely
for more results.

This commit defensively makes the client stop fetching more result pages
if the current page is empty.