### PR TITLE
build env in containers using compose (fixed)

### DIFF
--- a/Dockerfile.devenv
+++ b/Dockerfile.devenv
@@ -9,8 +9,6 @@ EXPOSE 3000
 ENV LANG C.UTF-8
 ENV PATH /usr/local/bin:$PATH
 
-COPY . ./
 RUN npm install --global gulp-cli
 
 CMD make dev
-

--- a/Dockerfile.devenv
+++ b/Dockerfile.devenv
@@ -1,0 +1,10 @@
+FROM node:4
+MAINTAINER Hypothes.is Project and contributors
+
+VOLUME /client
+WORKDIR /client
+EXPOSE 3000
+
+RUN npm install --global gulp-cli
+CMD ["gulp", "watch"]
+

--- a/Dockerfile.devenv
+++ b/Dockerfile.devenv
@@ -1,10 +1,13 @@
 FROM node:4
 MAINTAINER Hypothes.is Project and contributors
 
-VOLUME /client
 WORKDIR /client
+VOLUME /client
+
 EXPOSE 3000
 
-RUN npm install --global gulp-cli
-CMD ["gulp", "watch"]
+ENV LANG C.UTF-8
+ENV PATH /usr/local/bin:$PATH
+
+CMD gulp watch
 

--- a/Dockerfile.devenv
+++ b/Dockerfile.devenv
@@ -9,5 +9,8 @@ EXPOSE 3000
 ENV LANG C.UTF-8
 ENV PATH /usr/local/bin:$PATH
 
-CMD gulp watch
+COPY . ./
+RUN npm install --global gulp-cli
+
+CMD make dev
 

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,19 @@ clean:
 test: node_modules/.uptodate
 	npm test
 
+## Run the development client locally
+.PHONY: dev
+dev: node_modules
+	gulp watch
+
 .PHONY: lint
 lint: node_modules/.uptodate
 	npm run lint
 
 ################################################################################
+
+node_modules:
+	npm install
 
 build/manifest.json: node_modules/.uptodate
 	npm run-script build

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test: node_modules/.uptodate
 
 ## Run the development client locally
 .PHONY: dev
-dev: node_modules
+dev: node_modules/.update
 	gulp watch
 
 .PHONY: lint
@@ -25,9 +25,6 @@ lint: node_modules/.uptodate
 	npm run lint
 
 ################################################################################
-
-node_modules:
-	npm install
 
 build/manifest.json: node_modules/.uptodate
 	npm run-script build

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test: node_modules/.uptodate
 
 ## Run the development client locally
 .PHONY: dev
-dev: node_modules/.update
+dev: node_modules/.uptodate
 	gulp watch
 
 .PHONY: lint

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -261,7 +261,7 @@ gulp.task('watch-manifest', function () {
 
 gulp.task('start-live-reload-server', function () {
   var LiveReloadServer = require('./scripts/gulp/live-reload-server');
-  liveReloadServer = new LiveReloadServer(3000, 'http://localhost:5000');
+  liveReloadServer = new LiveReloadServer(3000, 'http://h:5000');
 });
 
 gulp.task('build-app',


### PR DESCRIPTION
Ref: hypothesis/h#3888

Here's the benefits of having the client build in a container too:

make setup quicker and lowers the bar to contributions
don't need to pollute your local workstation with dev packages
docker compose can start up everything together
ensures that everyone is testing in the same setup, for reproducibility
