### PR TITLE
Rename the "$$tag" annotation property and remove Object.assign() hacks

### DIFF
--- a/h/static/scripts/annotation-ui-sync.js
+++ b/h/static/scripts/annotation-ui-sync.js
@@ -19,7 +19,7 @@ var uiConstants = require('./ui-constants');
 function AnnotationUISync($rootScope, $window, annotationUI, bridge) {
   function lookupByTag(tag) {
     return annotationUI.getState().annotations.find(function (annot) {
-      return annot.$$tag === tag;
+      return annot.$tag === tag;
     });
   }
 

--- a/h/static/scripts/build-thread.js
+++ b/h/static/scripts/build-thread.js
@@ -4,7 +4,7 @@
 var DEFAULT_THREAD_STATE = {
   /**
    * The ID of this thread. This will be the same as the annotation ID for
-   * created annotations or the `$$tag` property for new annotations.
+   * created annotations or the `$tag` property for new annotations.
    */
   id: undefined,
   /**
@@ -40,11 +40,11 @@ var DEFAULT_THREAD_STATE = {
 /**
  * Returns a persistent identifier for an Annotation.
  * If the Annotation has been created on the server, it will have
- * an ID assigned, otherwise we fall back to the local-only '$$tag'
+ * an ID assigned, otherwise we fall back to the local-only '$tag'
  * property.
  */
 function id(annotation) {
-  return annotation.id || annotation.$$tag;
+  return annotation.id || annotation.$tag;
 }
 
 /**

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -37,7 +37,7 @@ function errorMessage(reason) {
 function updateModel(annotation, changes, permissions) {
   return Object.assign({}, annotation, {
     // Explicitly copy across the non-enumerable local tag for the annotation
-    $$tag: annotation.$$tag,
+    $tag: annotation.$tag,
 
     // Apply changes from the draft
     tags: changes.tags,
@@ -67,7 +67,7 @@ function AnnotationController(
     return saved.then(function (savedAnnot) {
       // Copy across internal properties which are not part of the annotation
       // model saved on the server
-      savedAnnot.$$tag = annot.$$tag;
+      savedAnnot.$tag = annot.$tag;
       Object.keys(annot).forEach(function (k) {
         if (k[0] === '$') {
           savedAnnot[k] = annot[k];
@@ -176,7 +176,7 @@ function AnnotationController(
       // Highlights are always private.
       vm.annotation.permissions = permissions.private();
       save(vm.annotation).then(function(model) {
-        model.$$tag = vm.annotation.$$tag;
+        model.$tag = vm.annotation.$tag;
         $rootScope.$broadcast(events.ANNOTATION_CREATED, model);
       });
     } else {

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -36,9 +36,6 @@ function errorMessage(reason) {
  */
 function updateModel(annotation, changes, permissions) {
   return Object.assign({}, annotation, {
-    // Explicitly copy across the non-enumerable local tag for the annotation
-    $tag: annotation.$tag,
-
     // Apply changes from the draft
     tags: changes.tags,
     text: changes.text,

--- a/h/static/scripts/directive/test/thread-list-test.js
+++ b/h/static/scripts/directive/test/thread-list-test.js
@@ -11,14 +11,14 @@ var threadList = require('../thread-list');
 var util = require('./util');
 
 var annotFixtures = immutable({
-  annotation: {$$tag: 't1', id: '1', text: 'text'},
+  annotation: {$tag: 't1', id: '1', text: 'text'},
   reply: {
-    $$tag: 't2',
+    $tag: 't2',
     id: '2',
     references: ['1'],
     text: 'areply',
   },
-  highlight: {$highlight: true, $$tag: 't3', id: '3'},
+  highlight: {$highlight: true, $tag: 't3', id: '3'},
 });
 
 var threadFixtures = immutable({

--- a/h/static/scripts/directive/thread-list.js
+++ b/h/static/scripts/directive/thread-list.js
@@ -61,7 +61,7 @@ function ThreadListController($scope, VirtualThreadList) {
 
   /**
    * Return the vertical scroll offset for the document in order to position the
-   * annotation thread with a given `id` or $$tag at the top-left corner
+   * annotation thread with a given `id` or $tag at the top-left corner
    * of the view.
    */
   function scrollOffset(id) {
@@ -72,7 +72,7 @@ function ThreadListController($scope, VirtualThreadList) {
     return Math.min(maxYOffset, visibleThreads.yOffsetOf(id));
   }
 
-  /** Scroll the annotation with a given ID or $$tag into view. */
+  /** Scroll the annotation with a given ID or $tag into view. */
   function scrollIntoView(id) {
     var estimatedYOffset = scrollOffset(id);
     window.scroll(0, estimatedYOffset);
@@ -101,7 +101,7 @@ function ThreadListController($scope, VirtualThreadList) {
       return;
     }
     self.onClearSelection();
-    scrollIntoView(annotation.$$tag);
+    scrollIntoView(annotation.$tag);
   });
 
   this.$onChanges = function (changes) {

--- a/h/static/scripts/drafts.js
+++ b/h/static/scripts/drafts.js
@@ -37,7 +37,7 @@ function DraftStore() {
    * Annotations are matched by ID or local tag.
    */
   function match(draft, model) {
-    return (draft.model.$$tag && model.$$tag === draft.model.$$tag) ||
+    return (draft.model.$tag && model.$tag === draft.model.$tag) ||
            (draft.model.id && model.id === draft.model.id);
   }
 
@@ -53,7 +53,7 @@ function DraftStore() {
    * Returns a list of local tags of new annotations for which unsaved drafts
    * exist.
    *
-   * @return {Array<{$$tag: string}>}
+   * @return {Array<{$tag: string}>}
    */
   this.unsaved = function unsaved() {
     return this._drafts.filter(function(draft) {
@@ -93,7 +93,7 @@ function DraftStore() {
    */
   this.update = function update(model, changes) {
     var newDraft = {
-      model: {id: model.id, $$tag: model.$$tag},
+      model: {id: model.id, $tag: model.$tag},
       isPrivate: changes.isPrivate,
       tags: changes.tags,
       text: changes.text,

--- a/h/static/scripts/frame-sync.js
+++ b/h/static/scripts/frame-sync.js
@@ -22,7 +22,7 @@ var metadata = require('./annotation-metadata');
   */
 function formatAnnot(ann) {
   return {
-    tag: ann.$$tag,
+    tag: ann.$tag,
     msg: {
       document: ann.document,
       target: ann.target,
@@ -69,13 +69,13 @@ function FrameSync($rootScope, $window, AnnotationUISync, Discovery,
           return;
         }
 
-        inSidebar.add(annot.$$tag);
-        if (!inFrame.has(annot.$$tag)) {
+        inSidebar.add(annot.$tag);
+        if (!inFrame.has(annot.$tag)) {
           added.push(annot);
         }
       });
       var deleted = prevAnnotations.filter(function (annot) {
-        return !inSidebar.has(annot.$$tag);
+        return !inSidebar.has(annot.$tag);
       });
       prevAnnotations = state.annotations;
 
@@ -85,12 +85,12 @@ function FrameSync($rootScope, $window, AnnotationUISync, Discovery,
       if (added.length > 0) {
         bridge.call('loadAnnotations', added.map(formatAnnot));
         added.forEach(function (annot) {
-          inFrame.add(annot.$$tag);
+          inFrame.add(annot.$tag);
         });
       }
       deleted.forEach(function (annot) {
         bridge.call('deleteAnnotation', formatAnnot(annot));
-        inFrame.delete(annot.$$tag);
+        inFrame.delete(annot.$tag);
       });
     });
   }
@@ -103,7 +103,7 @@ function FrameSync($rootScope, $window, AnnotationUISync, Discovery,
     // A new annotation, note or highlight was created in the frame
     bridge.on('beforeCreateAnnotation', function (event) {
       inFrame.add(event.tag);
-      var annot = Object.assign({}, event.msg, {$$tag: event.tag});
+      var annot = Object.assign({}, event.msg, {$tag: event.tag});
       $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED, annot);
     });
 

--- a/h/static/scripts/reducers/annotations.js
+++ b/h/static/scripts/reducers/annotations.js
@@ -172,11 +172,6 @@ function addAnnotations(annotations, now) {
   annotations = annotations.map(function (annot) {
     if (annot.id) { return annot; }
     return Object.assign({
-      // Copy $tag explicitly because it is non-enumerable.
-      //
-      // FIXME: change $tag to $tag and make it enumerable so annotations
-      // can be handled more simply in the sidebar.
-      $tag: annot.$tag,
       // Date.prototype.toISOString returns a 0-offset (UTC) ISO8601
       // datetime.
       created: now.toISOString(),

--- a/h/static/scripts/reducers/annotations.js
+++ b/h/static/scripts/reducers/annotations.js
@@ -23,13 +23,13 @@ function excludeAnnotations(current, annotations) {
     if (annot.id) {
       ids[annot.id] = true;
     }
-    if (annot.$$tag) {
-      tags[annot.$$tag] = true;
+    if (annot.$tag) {
+      tags[annot.$tag] = true;
     }
   });
   return current.filter(function (annot) {
     var shouldRemove = (annot.id && (annot.id in ids)) ||
-                       (annot.$$tag && (annot.$$tag in tags));
+                       (annot.$tag && (annot.$tag in tags));
     return !shouldRemove;
   });
 }
@@ -42,7 +42,7 @@ function findByID(annotations, id) {
 
 function findByTag(annotations, tag) {
   return annotations.find(function (annot) {
-    return annot.$$tag === tag;
+    return annot.$tag === tag;
   });
 }
 
@@ -63,7 +63,7 @@ function initializeAnnot(annotation, tag) {
   }
 
   return Object.assign({}, annotation, {
-    $$tag: annotation.$$tag || tag,
+    $tag: annotation.$tag || tag,
     $orphan: orphan,
   });
 }
@@ -93,8 +93,8 @@ var update = {
       if (annot.id) {
         existing = findByID(state.annotations, annot.id);
       }
-      if (!existing && annot.$$tag) {
-        existing = findByTag(state.annotations, annot.$$tag);
+      if (!existing && annot.$tag) {
+        existing = findByTag(state.annotations, annot.$tag);
       }
 
       if (existing) {
@@ -104,8 +104,8 @@ var update = {
         if (annot.id) {
           updatedIDs[annot.id] = true;
         }
-        if (existing.$$tag) {
-          updatedTags[existing.$$tag] = true;
+        if (existing.$tag) {
+          updatedTags[existing.$tag] = true;
         }
       } else {
         added.push(initializeAnnot(annot, 't' + nextTag));
@@ -114,7 +114,7 @@ var update = {
     });
 
     state.annotations.forEach(function (annot) {
-      if (!updatedIDs[annot.id] && !updatedTags[annot.$$tag]) {
+      if (!updatedIDs[annot.id] && !updatedTags[annot.$tag]) {
         unchanged.push(annot);
       }
     });
@@ -147,11 +147,11 @@ var update = {
   UPDATE_ANCHOR_STATUS: function (state, action) {
     var annotations = state.annotations.map(function (annot) {
       var match = (annot.id && annot.id === action.id) ||
-                  (annot.$$tag && annot.$$tag === action.tag);
+                  (annot.$tag && annot.$tag === action.tag);
       if (match) {
         return Object.assign({}, annot, {
           $orphan: action.isOrphan,
-          $$tag: action.tag,
+          $tag: action.tag,
         });
       } else {
         return annot;
@@ -172,11 +172,11 @@ function addAnnotations(annotations, now) {
   annotations = annotations.map(function (annot) {
     if (annot.id) { return annot; }
     return Object.assign({
-      // Copy $$tag explicitly because it is non-enumerable.
+      // Copy $tag explicitly because it is non-enumerable.
       //
-      // FIXME: change $$tag to $tag and make it enumerable so annotations
+      // FIXME: change $tag to $tag and make it enumerable so annotations
       // can be handled more simply in the sidebar.
-      $$tag: annot.$$tag,
+      $tag: annot.$tag,
       // Date.prototype.toISOString returns a 0-offset (UTC) ISO8601
       // datetime.
       created: now.toISOString(),
@@ -215,7 +215,7 @@ function addAnnotations(annotations, now) {
             dispatch({
               type: actions.UPDATE_ANCHOR_STATUS,
               id: orphan.id,
-              tag: orphan.$$tag,
+              tag: orphan.$tag,
               isOrphan: true,
             });
           });

--- a/h/static/scripts/root-thread.js
+++ b/h/static/scripts/root-thread.js
@@ -166,9 +166,9 @@ function RootThread($rootScope, annotationUI, drafts, features, searchFilter, vi
       return metadata.isNew(ann) && !metadata.isReply(ann);
     }).map(function (ann) {
       return Object.assign(ann, {
-        // FIXME - $$tag is currently a non-enumerable property so it has to be
+        // FIXME - $tag is currently a non-enumerable property so it has to be
         // copied explicitly
-        $$tag: ann.$$tag,
+        $tag: ann.$tag,
         group: focusedGroupId,
       });
     });

--- a/h/static/scripts/root-thread.js
+++ b/h/static/scripts/root-thread.js
@@ -166,9 +166,6 @@ function RootThread($rootScope, annotationUI, drafts, features, searchFilter, vi
       return metadata.isNew(ann) && !metadata.isReply(ann);
     }).map(function (ann) {
       return Object.assign(ann, {
-        // FIXME - $tag is currently a non-enumerable property so it has to be
-        // copied explicitly
-        $tag: ann.$tag,
         group: focusedGroupId,
       });
     });

--- a/h/static/scripts/test/annotation-mapper-test.js
+++ b/h/static/scripts/test/annotation-mapper-test.js
@@ -81,7 +81,7 @@ describe('annotationMapper', function() {
     it('replaces the properties on the cached annotation with those from the loaded one', function () {
       sandbox.stub($rootScope, '$broadcast');
       var annotations = [{id: 1, url: 'http://example.com'}];
-      annotationUI.addAnnotations([{id:1, $$tag: 'tag1'}]);
+      annotationUI.addAnnotations([{id:1, $tag: 'tag1'}]);
 
       annotationMapper.loadAnnotations(annotations);
       assert.called($rootScope.$broadcast);
@@ -94,7 +94,7 @@ describe('annotationMapper', function() {
     it('excludes cached annotations from the annotationLoaded event', function () {
       sandbox.stub($rootScope, '$broadcast');
       var annotations = [{id: 1, url: 'http://example.com'}];
-      annotationUI.addAnnotations([{id: 1, $$tag: 'tag1'}]);
+      annotationUI.addAnnotations([{id: 1, $tag: 'tag1'}]);
 
       annotationMapper.loadAnnotations(annotations);
       assert.called($rootScope.$broadcast);
@@ -114,7 +114,7 @@ describe('annotationMapper', function() {
     it('replaces the properties on the cached annotation with those from the deleted one', function () {
       sandbox.stub($rootScope, '$broadcast');
       var annotations = [{id: 1, url: 'http://example.com'}];
-      annotationUI.addAnnotations([{id: 1, $$tag: 'tag1'}]);
+      annotationUI.addAnnotations([{id: 1, $tag: 'tag1'}]);
 
       annotationMapper.unloadAnnotations(annotations);
       assert.calledWith($rootScope.$broadcast, events.ANNOTATIONS_UNLOADED, [{

--- a/h/static/scripts/test/annotation-ui-sync-test.js
+++ b/h/static/scripts/test/annotation-ui-sync-test.js
@@ -42,9 +42,9 @@ describe('AnnotationUISync', function () {
 
     annotationUI = annotationUIFactory($rootScope, {});
     annotationUI.addAnnotations([
-      {id: 'id1', $$tag: 'tag1'},
-      {id: 'id2', $$tag: 'tag2'},
-      {id: 'id3', $$tag: 'tag3'},
+      {id: 'id1', $tag: 'tag1'},
+      {id: 'id2', $tag: 'tag2'},
+      {id: 'id3', $tag: 'tag3'},
     ]);
     createAnnotationUISync = function () {
       new AnnotationUISync(

--- a/h/static/scripts/test/annotation-ui-test.js
+++ b/h/static/scripts/test/annotation-ui-test.js
@@ -13,12 +13,12 @@ var newAnnotation = annotationFixtures.newAnnotation;
 
 var fixtures = immutable({
   pair: [
-    Object.assign(defaultAnnotation(), {id: 1, $$tag: 't1'}),
-    Object.assign(defaultAnnotation(), {id: 2, $$tag: 't2'}),
+    Object.assign(defaultAnnotation(), {id: 1, $tag: 't1'}),
+    Object.assign(defaultAnnotation(), {id: 2, $tag: 't2'}),
   ],
   newPair: [
-    Object.assign(newAnnotation(), {$$tag: 't1'}),
-    Object.assign(newAnnotation(), {$$tag: 't2'}),
+    Object.assign(newAnnotation(), {$tag: 't1'}),
+    Object.assign(newAnnotation(), {$tag: 't2'}),
   ],
 });
 
@@ -78,7 +78,7 @@ describe('annotationUI', function () {
       annotationUI.addAnnotations([annotA, annotB]);
 
       var tags = annotationUI.getState().annotations.map(function (a) {
-        return a.$$tag;
+        return a.$tag;
       });
 
       assert.deepEqual(tags, ['t1','t2']);
@@ -96,7 +96,7 @@ describe('annotationUI', function () {
 
     it('updates annotations with matching tags in the store', function () {
       var annot = newAnnotation();
-      annot.$$tag = 'local-tag';
+      annot.$tag = 'local-tag';
       annotationUI.addAnnotations([annot]);
 
       var saved = Object.assign({}, annot, {id: 'server-id'});
@@ -232,12 +232,12 @@ describe('annotationUI', function () {
 
     it('matches annotations to remove by tag', function () {
       annotationUI.addAnnotations(fixtures.pair);
-      annotationUI.removeAnnotations([{$$tag: fixtures.pair[0].$$tag}]);
+      annotationUI.removeAnnotations([{$tag: fixtures.pair[0].$tag}]);
 
       var tags = annotationUI.getState().annotations.map(function (a) {
-        return a.$$tag;
+        return a.$tag;
       });
-      assert.deepEqual(tags, [fixtures.pair[1].$$tag]);
+      assert.deepEqual(tags, [fixtures.pair[1].$tag]);
     });
 
     it('switches back to the Annotations tab when the last orphan is removed', function () {
@@ -496,7 +496,7 @@ describe('annotationUI', function () {
       var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot]);
       annotationUI.updateAnchorStatus(annot.id, 'atag', true);
-      assert.equal(annotationUI.getState().annotations[0].$$tag, 'atag');
+      assert.equal(annotationUI.getState().annotations[0].$tag, 'atag');
     });
 
     it("updates the annotation's orphan flag", function () {

--- a/h/static/scripts/test/build-thread-test.js
+++ b/h/static/scripts/test/build-thread-test.js
@@ -150,7 +150,7 @@ describe('build-thread', function () {
 
     it('threads new annotations which have tags but not IDs', function () {
       var fixture = [{
-        $$tag: 't1',
+        $tag: 't1',
       }];
       var thread = createThread(fixture);
       assert.deepEqual(thread, [{annotation: fixture[0], children: []}]);
@@ -159,9 +159,9 @@ describe('build-thread', function () {
     it('threads new replies which have tags but not IDs', function () {
       var fixture = [{
         id: '1',
-        $$tag: 't1',
+        $tag: 't1',
       },{
-        $$tag: 't2',
+        $tag: 't2',
         references: ['1'],
       }];
       var thread = createThread(fixture, {}, ['parent']);

--- a/h/static/scripts/test/drafts-test.js
+++ b/h/static/scripts/test/drafts-test.js
@@ -73,8 +73,8 @@ describe('drafts', function () {
     });
 
     it('should replace drafts with the same tag', function () {
-      var modelA = {$$tag: 'foo'};
-      var modelB = {$$tag: 'foo'};
+      var modelA = {$tag: 'foo'};
+      var modelB = {$tag: 'foo'};
       drafts.update(modelA, {isPrivate:true, tags:['foo'], text:'foo'});
       drafts.update(modelB, {isPrivate:true, tags:['foo'], text:'bar'});
       assert.equal(drafts.get(modelA).text, 'bar');
@@ -92,7 +92,7 @@ describe('drafts', function () {
 
   describe('#unsaved', function () {
     it('should return drafts for unsaved annotations', function () {
-      var model = {$$tag: 'local-tag', id: undefined};
+      var model = {$tag: 'local-tag', id: undefined};
       drafts.update(model, {text: 'bar'});
       assert.deepEqual(drafts.unsaved(), [model]);
     });

--- a/h/static/scripts/test/frame-sync-test.js
+++ b/h/static/scripts/test/frame-sync-test.js
@@ -10,7 +10,7 @@ var fakeStore = require('./fake-redux-store');
 var formatAnnot = require('../frame-sync').formatAnnot;
 
 var fixtures = {
-  ann: Object.assign({$$tag: 't1'}, annotationFixtures.defaultAnnotation()),
+  ann: Object.assign({$tag: 't1'}, annotationFixtures.defaultAnnotation()),
 
   // New annotation received from the frame
   newAnnFromFrame: {
@@ -97,7 +97,7 @@ describe('FrameSync', function () {
     });
 
     it('sends a "loadAnnotations" message only for new annotations', function () {
-      var ann2 = Object.assign({}, fixtures.ann, {$$tag: 't2', id: 'a2'});
+      var ann2 = Object.assign({}, fixtures.ann, {$tag: 't2', id: 'a2'});
       fakeAnnotationUI.setState({annotations: [fixtures.ann]});
       fakeBridge.call.reset();
 
@@ -132,7 +132,7 @@ describe('FrameSync', function () {
       fakeBridge.emit('beforeCreateAnnotation', {tag: 't1', msg: ann});
 
       assert.calledWithMatch(onCreated, sinon.match.any, sinon.match({
-        $$tag: 't1',
+        $tag: 't1',
         target: [],
       }));
     });

--- a/h/static/scripts/test/root-thread-test.js
+++ b/h/static/scripts/test/root-thread-test.js
@@ -354,7 +354,7 @@ describe('rootThread', function () {
         onDelete = sinon.stub();
         $rootScope.$on(events.ANNOTATION_DELETED, onDelete);
 
-        existingNewAnnot = {$$tag: 'a-new-tag'};
+        existingNewAnnot = {$tag: 'a-new-tag'};
         fakeAnnotationUI.state.annotations.push(existingNewAnnot);
       });
 
@@ -403,12 +403,12 @@ describe('rootThread', function () {
 
   describe('when the focused group changes', function () {
     it('moves new annotations to the focused group', function () {
-      fakeAnnotationUI.state.annotations = [{$$tag: 'a-tag'}];
+      fakeAnnotationUI.state.annotations = [{$tag: 'a-tag'}];
 
       $rootScope.$broadcast(events.GROUP_FOCUSED, 'private-group');
 
       assert.calledWith(fakeAnnotationUI.addAnnotations, sinon.match([{
-        $$tag: 'a-tag',
+        $tag: 'a-tag',
         group: 'private-group',
       }]));
     });

--- a/h/static/scripts/test/widget-controller-test.js
+++ b/h/static/scripts/test/widget-controller-test.js
@@ -266,7 +266,7 @@ describe('WidgetController', function () {
       annotationUI.selectAnnotations(['123']);
       fakeFrameSync.frames.push({uri: uri, searchUris: [uri]});
       var annot = {
-        $$tag: 'atag',
+        $tag: 'atag',
         id: '123',
       };
       annotationUI.addAnnotations([annot]);

--- a/h/static/scripts/virtual-thread-list.js
+++ b/h/static/scripts/virtual-thread-list.js
@@ -77,7 +77,7 @@ VirtualThreadList.prototype.setRootThread = function (thread) {
  * the actual or 'last-seen' height is used if known. Otherwise an estimate
  * is used.
  *
- * @param {string} id - The annotation ID or $$tag
+ * @param {string} id - The annotation ID or $tag
  * @param {number} height - The height of the annotation thread.
  */
 VirtualThreadList.prototype.setThreadHeight = function (id, height) {

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -64,7 +64,7 @@ module.exports = function WidgetController(
   function focusAnnotation(annotation) {
     var highlights = [];
     if (annotation) {
-      highlights = [annotation.$$tag];
+      highlights = [annotation.$tag];
     }
     frameSync.focusAnnotations(highlights);
   }
@@ -73,7 +73,7 @@ module.exports = function WidgetController(
     if (!annotation) {
       return;
     }
-    frameSync.scrollToAnnotation(annotation.$$tag);
+    frameSync.scrollToAnnotation(annotation.$tag);
   }
 
   /** Returns the annotation type - note or annotation of the first annotation
@@ -241,7 +241,7 @@ module.exports = function WidgetController(
       return;
     }
     var matchesSelection = tags.some(function (tag) {
-      return tag === selectedAnnot.$$tag;
+      return tag === selectedAnnot.$tag;
     });
     if (!matchesSelection) {
       return;


### PR DESCRIPTION
The "$$tag" annotation property which stores the local ID of annotations had a "$$" prefix for historical reasons and had to be explicitly copied when shallow-cloning annotation objects with `Object.assign()` because it was non-enumerable.

Following https://github.com/hypothesis/client/pull/116 , this can now be cleaned up within the sidebar app. This PR renames `$$tag` to `$tag` to match the other local-only annotation properties and removes the `Object.assign()` hacks.