### PR TITLE
Fix adder from affecting website's height on load

### DIFF
--- a/h/static/scripts/annotator/adder.js
+++ b/h/static/scripts/annotator/adder.js
@@ -102,8 +102,11 @@ function Adder(container, options) {
     // property rather than `display` so that we can compute its size in order to
     // position it before display.
     display: 'block',
-    position: 'absolute',
     visibility: 'hidden',
+
+    // take position out of flow and off screen initially
+    position: 'absolute',
+    top: 0,
 
     // Assign a high Z-index so that the adder shows above any content on the
     // page


### PR DESCRIPTION
#125 I tried pretty hard to get tests going for this. However, it seems that phantom either does not see the same issue or the lack of support for things like outerHeight and height on computed client rects limits this ability. That said, the change is rather easy to test against: http://jsfiddle.net/sean_roberts/4gnbz2y2/