### PR TITLE
Support current versions of PDF.js

### DIFF
--- a/h/static/scripts/annotator/anchoring/pdf.coffee
+++ b/h/static/scripts/annotator/anchoring/pdf.coffee
@@ -4,8 +4,8 @@ Annotator = require('annotator')
 xpathRange = Annotator.Range
 
 html = require('./html')
+RenderingStates = require('../pdfjs-rendering-states')
 {TextPositionAnchor, TextQuoteAnchor} = require('./types')
-
 
 # Caches for performance
 pageTextCache = {}

--- a/h/static/scripts/annotator/pdfjs-rendering-states.js
+++ b/h/static/scripts/annotator/pdfjs-rendering-states.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/**
+ * Enum values for page rendering states (IRenderableView#renderingState)
+ * in PDF.js. Taken from web/pdf_rendering_queue.js in the PDF.js library.
+ *
+ * Reproduced here because this enum is not exported consistently across
+ * different versions of PDF.js
+ */
+var RenderingStates = {
+  INITIAL: 0,
+  RUNNING: 1,
+  PAUSED: 2,
+  FINISHED: 3,
+};
+
+module.exports = RenderingStates;

--- a/h/static/scripts/annotator/plugin/pdf.coffee
+++ b/h/static/scripts/annotator/plugin/pdf.coffee
@@ -1,6 +1,7 @@
 extend = require('extend')
 Annotator = require('annotator')
 
+RenderingStates = require('../pdfjs-rendering-states')
 
 module.exports = class PDF extends Annotator.Plugin
   documentLoaded: null


### PR DESCRIPTION
In current versions of PDF.js, the `RenderingStates` enum is no longer
exported as a global, and the export method appears to be dependent on
the build configuration.

Since `RenderingStates` is a trivial enum, this commit fixes the problem
by just reproducing it in `pdfjs-rendering-states.js`.

This PR allows the bookmarklet to be loaded into documents containing newer versions of PDF.js than the one we currently ship with the browser extension, which is from August 2015. The change is backwards compatible with that version.