### PR TITLE
Move session state to the Redux store

### DIFF
--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -39,6 +39,7 @@ var thunk = require('redux-thunk').default;
 var reducers = require('./reducers');
 var annotationsReducer = require('./reducers/annotations');
 var selectionReducer = require('./reducers/selection');
+var sessionReducer = require('./reducers/session');
 var viewerReducer = require('./reducers/viewer');
 var util = require('./reducers/util');
 
@@ -90,6 +91,7 @@ module.exports = function ($rootScope, settings) {
   var actionCreators = redux.bindActionCreators(Object.assign({},
     annotationsReducer.actions,
     selectionReducer.actions,
+    sessionReducer.actions,
     viewerReducer.actions
   ), store.dispatch);
 

--- a/h/static/scripts/directive/sidebar-tutorial.js
+++ b/h/static/scripts/directive/sidebar-tutorial.js
@@ -12,7 +12,7 @@ function SidebarTutorialController(session) {
   };
 
   this.dismiss = function () {
-    session.dismiss_sidebar_tutorial();
+    session.dismissSidebarTutorial();
   };
 }
 

--- a/h/static/scripts/reducers/index.js
+++ b/h/static/scripts/reducers/index.js
@@ -19,6 +19,7 @@
 
 var annotations = require('./annotations');
 var selection = require('./selection');
+var session = require('./session');
 var viewer = require('./viewer');
 var util = require('./util');
 
@@ -27,6 +28,7 @@ function init(settings) {
     {},
     annotations.init(),
     selection.init(settings),
+    session.init(),
     viewer.init()
   );
 }
@@ -34,6 +36,7 @@ function init(settings) {
 var update = util.createReducer(Object.assign(
   annotations.update,
   selection.update,
+  session.update,
   viewer.update
 ));
 

--- a/h/static/scripts/reducers/session.js
+++ b/h/static/scripts/reducers/session.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var util = require('./util');
+
+function init() {
+  return {
+    /**
+     * The state of the user's login session.
+     *
+     * This includes their user ID, set of enabled features, and the list of
+     * groups they are a member of.
+     */
+    session: {
+      /**
+       * The CSRF token for requests to API endpoints that use cookie
+       * authentication.
+       */
+      csrf: null,
+
+      /** A map of features that are enabled for the current user. */
+      features: {},
+      /** List of groups that the current user is a member of. */
+      groups: [],
+      /**
+       * The authenticated user ID or null if the user is not logged in.
+       */
+      userid: null,
+    },
+  };
+}
+
+var update = {
+  UPDATE_SESSION: function (state, action) {
+    return {
+      session: action.session,
+    };
+  },
+};
+
+var actions = util.actionTypes(update);
+
+/**
+ * Update the session state.
+ */
+function updateSession(session) {
+  return {
+    type: actions.UPDATE_SESSION,
+    session: session,
+  };
+}
+
+module.exports = {
+  init: init,
+  update: update,
+
+  actions: {
+    updateSession: updateSession,
+  },
+};

--- a/h/static/scripts/reducers/test/session-test.js
+++ b/h/static/scripts/reducers/test/session-test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var session = require('../session');
+
+var util = require('../util');
+
+var init = session.init;
+var actions = session.actions;
+var update = util.createReducer(session.update);
+
+describe('session reducer', function () {
+  describe('#updateSession', function () {
+    it('updates the session state', function () {
+      var newSession = Object.assign(init(), {userid: 'john'});
+      var state = update(init(), actions.updateSession(newSession));
+      assert.deepEqual(state.session, newSession);
+    });
+  });
+});

--- a/h/static/scripts/test/session-test.js
+++ b/h/static/scripts/test/session-test.js
@@ -20,21 +20,32 @@ describe('h:session', function () {
       .service('session', require('../session'));
   });
 
-  beforeEach(mock.module('h'));
-
-  beforeEach(mock.module(function ($provide) {
+  beforeEach(function () {
     sandbox = sinon.sandbox.create();
+
+    var state = {};
+    var fakeAnnotationUI = {
+      getState: function () {
+        return {session: state};
+      },
+      updateSession: function (session) {
+        state = session;
+      },
+    };
     fakeFlash = {error: sandbox.spy()};
     fakeRaven = {
       setUserInfo: sandbox.spy(),
     };
 
-    $provide.value('settings', {
-      serviceUrl: 'https://test.hypothes.is/root/',
+    mock.module('h', {
+      annotationUI: fakeAnnotationUI,
+      flash: fakeFlash,
+      raven: fakeRaven,
+      settings: {
+        serviceUrl: 'https://test.hypothes.is/root/',
+      },
     });
-    $provide.value('flash', fakeFlash);
-    $provide.value('raven', fakeRaven);
-  }));
+  });
 
 
   beforeEach(mock.inject(function (_$httpBackend_, _$rootScope_, _session_) {
@@ -237,11 +248,11 @@ describe('h:session', function () {
     });
   });
 
-  describe('#dismiss_sidebar_tutorial()', function () {
+  describe('#dismissSidebarTutorial()', function () {
     var url = 'https://test.hypothes.is/root/app/dismiss_sidebar_tutorial';
     it('disables the tutorial for the user', function () {
       $httpBackend.expectPOST(url).respond({});
-      session.dismiss_sidebar_tutorial();
+      session.dismissSidebarTutorial();
       $httpBackend.flush();
     });
   });


### PR DESCRIPTION
As part of a process of moving all important app state into the Redux store, this moves the session state out of the `session` service.

This enables logic in reducers and action creators to access the logged-in user, list of groups and active feature flags, which in turn will allow us to move a bunch of other app logic out of the UI or services and into `reducers/` modules.