### PR TITLE
Fix scrolling to direct-linked annotations

### DIFF
--- a/h/static/scripts/test/widget-controller-test.js
+++ b/h/static/scripts/test/widget-controller-test.js
@@ -271,7 +271,7 @@ describe('WidgetController', function () {
       };
       annotationUI.addAnnotations([annot]);
       $scope.$digest();
-      $rootScope.$broadcast(events.ANNOTATIONS_SYNCED, [{tag: 'atag'}]);
+      $rootScope.$broadcast(events.ANNOTATIONS_SYNCED, ['atag']);
       assert.calledWith(fakeFrameSync.focusAnnotations, ['atag']);
       assert.calledWith(fakeFrameSync.scrollToAnnotation, 'atag');
     });

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -241,7 +241,7 @@ module.exports = function WidgetController(
       return;
     }
     var matchesSelection = tags.some(function (tag) {
-      return tag.tag === selectedAnnot.$$tag;
+      return tag === selectedAnnot.$$tag;
     });
     if (!matchesSelection) {
       return;


### PR DESCRIPTION
The FrameSync service introduced in 55093ebb8c1020e emitted an
ANNOTATIONS_SYNCED event which unintentionally had a different type for
the `tags` argument than the previous code (`string[]`, instead of
`Array<{tag:string}>`)

This commit updates the code in WidgetController to expect `tags`
to be of type `string[]`. There are no other consumers of this event in the code.

Fixes #129