### PR TITLE
Do not try to setup communication to host frame on stream

### DIFF
--- a/h/static/scripts/app-controller.js
+++ b/h/static/scripts/app-controller.js
@@ -24,7 +24,7 @@ function authStateFromUserID(userid) {
 // @ngInject
 module.exports = function AppController(
   $controller, $document, $location, $rootScope, $route, $scope,
-  $window, annotationUI, auth, drafts, features, groups,
+  $window, annotationUI, auth, drafts, features, frameSync, groups,
   serviceUrl, session, settings, streamer
 ) {
   $controller('AnnotationUIController', {$scope: $scope});
@@ -51,6 +51,9 @@ module.exports = function AppController(
   // Check to see if we're in the sidebar, or on a standalone page such as
   // the stream page or an individual annotation page.
   $scope.isSidebar = $window.top !== $window;
+  if ($scope.isSidebar) {
+    frameSync.connect();
+  }
 
   $scope.serviceUrl = serviceUrl;
 

--- a/h/static/scripts/app.js
+++ b/h/static/scripts/app.js
@@ -83,14 +83,6 @@ function configureRoutes($routeProvider) {
 }
 
 // @ngInject
-function setupFrameSync(frameSync) {
-  // Setup the connection to the frame hosting the sidebar app.
-  // This should only be done if this is the sidebar app, not the stream or
-  // standalone annotation pages.
-  return frameSync.connect();
-}
-
-// @ngInject
 function configureHttp($httpProvider, jwtInterceptorProvider) {
   // Use the Pyramid XSRF header name
   $httpProvider.defaults.xsrfHeaderName = 'X-CSRF-Token';
@@ -211,7 +203,6 @@ module.exports = angular.module('h', [
   .config(configureLocation)
   .config(configureRoutes)
 
-  .run(setupFrameSync)
   .run(setupHttp);
 
 processAppOpts();

--- a/h/static/scripts/test/app-controller-test.js
+++ b/h/static/scripts/test/app-controller-test.js
@@ -15,6 +15,7 @@ describe('AppController', function () {
   var fakeAuth = null;
   var fakeDrafts = null;
   var fakeFeatures = null;
+  var fakeFrameSync = null;
   var fakeLocation = null;
   var fakeParams = null;
   var fakeSession = null;
@@ -76,6 +77,10 @@ describe('AppController', function () {
       flagEnabled: sandbox.stub().returns(false),
     };
 
+    fakeFrameSync = {
+      connect: sandbox.spy(),
+    };
+
     fakeLocation = {
       search: sandbox.stub().returns({}),
     };
@@ -106,6 +111,7 @@ describe('AppController', function () {
     $provide.value('auth', fakeAuth);
     $provide.value('drafts', fakeDrafts);
     $provide.value('features', fakeFeatures);
+    $provide.value('frameSync', fakeFrameSync);
     $provide.value('serviceUrl', fakeServiceUrl);
     $provide.value('session', fakeSession);
     $provide.value('settings', fakeSettings);
@@ -140,6 +146,18 @@ describe('AppController', function () {
       createController();
       assert.isTrue($scope.isSidebar);
     });
+  });
+
+  it('connects to host frame in the sidebar app', function () {
+    fakeWindow.top = {};
+    createController();
+    assert.called(fakeFrameSync.connect);
+  });
+
+  it('does not connect to the host frame in the stream', function () {
+    fakeWindow.top = fakeWindow;
+    createController();
+    assert.notCalled(fakeFrameSync.connect);
   });
 
   it('auth.status is "unknown" on startup', function () {


### PR DESCRIPTION
This fixes the [most frequent client error reported by Sentry](https://sentry.io/hypothesis/prod-client/issues/145726152/) which happens when trying to load the Hypothesis client on the stream or standalone annotation pages, caused by both the stream app and the sidebar app trying to set up a 'Discovery' server for annotation 'guests' to connect to.

With this change, only the sidebar app will set up a Discovery server and hence it is now possible to annotate the stream and standalone annotation pages.