### PR TITLE
Upgrade raven node package

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3838,9 +3838,9 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
     },
     "raven-js": {
-      "version": "2.3.0",
-      "from": "raven-js@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-2.3.0.tgz"
+      "version": "3.7.0",
+      "from": "raven-js@>=3.7.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.7.0.tgz"
     },
     "raw-body": {
       "version": "2.1.7",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "proxyquireify": "^3.1.1",
     "query-string": "^3.0.1",
     "raf": "^3.1.0",
-    "raven-js": "^2.0.2",
+    "raven-js": "^3.7.0",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",
     "request": "^2.72.0",


### PR DESCRIPTION
This is part one of getting caught up on Sentry. We are upgrading the client side library. Next, we are going to reset the events in Sentry. After we let that bake for a while, we will triage the tickets that are actually worth prioritizing. We will also assess the correct course of action for whitelisting if we see a pattern forming that makes sense.

With this change, I read through the change logs for raven and found nothing that is a breaking change - only new features. I manually tested that triggered errors are going up to sentry as well.

See: https://sentry.io/hypothesis/dev/issues/162934563/