### PR TITLE
Fix prevent default override

### DIFF
--- a/h/static/scripts/annotator/adder.js
+++ b/h/static/scripts/annotator/adder.js
@@ -95,6 +95,7 @@ function createAdderDOM(container) {
  */
 function Adder(container, options) {
 
+  var self = this;
   var element = createAdderDOM(container);
 
   Object.assign(container.style, {
@@ -119,21 +120,23 @@ function Adder(container, options) {
   var enterTimeout;
 
   element.querySelector('.js-annotate-btn')
-    .addEventListener('click', handleCommand.bind(this, 'annotate'));
+    .addEventListener('click', handleCommand);
   element.querySelector('.js-highlight-btn')
-    .addEventListener('click', handleCommand.bind(this, 'highlight'));
+    .addEventListener('click', handleCommand);
 
-  function handleCommand(command, event) {
+  function handleCommand(event) {
     event.preventDefault();
     event.stopPropagation();
 
-    if (command === 'annotate') {
+    var isAnnotateCommand = this.classList.contains('js-annotate-btn');
+
+    if (isAnnotateCommand) {
       options.onAnnotate();
     } else {
       options.onHighlight();
     }
 
-    this.hide();
+    self.hide();
   }
 
   function width() {
@@ -220,6 +223,14 @@ function Adder(container, options) {
       'annotator-adder--arrow-down': arrowDirection === ARROW_POINTING_DOWN,
       'annotator-adder--arrow-up': arrowDirection === ARROW_POINTING_UP,
     });
+
+    // Some sites make big assumptions about interactive
+    // elements on the page. Some want to hide interactive elements
+    // after use. So we need to make sure the button stays displayed
+    // the way it was originally displayed - withouth the inline styles
+    // See: https://github.com/hypothesis/client/issues/137
+    this.element.querySelector(ANNOTATE_BTN_SELECTOR).style.display = '';
+    this.element.querySelector(HIGHLIGHT_BTN_SELECTOR).style.display = '';
 
     Object.assign(container.style, {
       top: toPx(top),

--- a/h/static/scripts/annotator/adder.js
+++ b/h/static/scripts/annotator/adder.js
@@ -4,6 +4,11 @@ var classnames = require('classnames');
 
 var template = require('./adder.html');
 
+var ANNOTATE_BTN_CLASS = 'js-annotate-btn';
+var ANNOTATE_BTN_SELECTOR = '.js-annotate-btn';
+
+var HIGHLIGHT_BTN_SELECTOR = '.js-highlight-btn';
+
 /**
  * Show the adder above the selection with an arrow pointing down at the
  * selected text.
@@ -119,16 +124,16 @@ function Adder(container, options) {
   var view = element.ownerDocument.defaultView;
   var enterTimeout;
 
-  element.querySelector('.js-annotate-btn')
+  element.querySelector(ANNOTATE_BTN_SELECTOR)
     .addEventListener('click', handleCommand);
-  element.querySelector('.js-highlight-btn')
+  element.querySelector(HIGHLIGHT_BTN_SELECTOR)
     .addEventListener('click', handleCommand);
 
   function handleCommand(event) {
     event.preventDefault();
     event.stopPropagation();
 
-    var isAnnotateCommand = this.classList.contains('js-annotate-btn');
+    var isAnnotateCommand = this.classList.contains(ANNOTATE_BTN_CLASS);
 
     if (isAnnotateCommand) {
       options.onAnnotate();
@@ -227,7 +232,7 @@ function Adder(container, options) {
     // Some sites make big assumptions about interactive
     // elements on the page. Some want to hide interactive elements
     // after use. So we need to make sure the button stays displayed
-    // the way it was originally displayed - withouth the inline styles
+    // the way it was originally displayed - without the inline styles
     // See: https://github.com/hypothesis/client/issues/137
     this.element.querySelector(ANNOTATE_BTN_SELECTOR).style.display = '';
     this.element.querySelector(HIGHLIGHT_BTN_SELECTOR).style.display = '';


### PR DESCRIPTION
#137 Refactoring how we bind to click events and making sure our adder buttons are set to `display:block`

Looking at code on: 
http://bibliobs.nouvelobs.com/paroles-d-haiti/20100121.BIB4760/tout-bouge-autour-de-moi.html
I saw they are slicing the arguments that are sent to the event handler. Before now, we were using `.bind(this, 'commandName')` to help identify what command the click handler is attempting to run. Because we used that bind, the first argument is going to be the `'commandName'` and the second argument will be the event that we invoke `event.preventDefault` on. As mentioned, the site's overriding is causing us to receive only the first argument and then invoking `preventDefault` on an undefined object. 

After fixing that, I found that the site is assuming that the thing that gets clicked is ephemeral and should be hidden. With our injected buttons, we need to make sure we have visible buttons when we display them on the dom