### PR TITLE
Use Node v6.2 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     # 'node_js' is listed for each job to ensure that only two builds are run.
     # See https://github.com/hypothesis/client/pull/27#discussion_r70611726
     - env: ACTION=lint
-      node_js: '4.3'
+      node_js: '6.2'
       script: npm run lint
     - env: ACTION=test
-      node_js: '4.3'
+      node_js: '6.2'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 node {
     checkout scm
 
-    nodeEnv = docker.image("node:4")
+    nodeEnv = docker.image("node:6.2")
     workspace = pwd()
 
     stage 'Build'


### PR DESCRIPTION
This keeps things consistent with the version of Node used by h:

    https://github.com/hypothesis/h/commit/cc71f6c571829344e1f50a05b33504a2d42725d4