### PR TITLE
Add application state debugging utility

### DIFF
--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -43,6 +43,8 @@ var sessionReducer = require('./reducers/session');
 var viewerReducer = require('./reducers/viewer');
 var util = require('./reducers/util');
 
+var debugMiddleware = require('./reducers/debug-middleware');
+
 /**
  * Redux middleware which triggers an Angular change-detection cycle
  * if no cycle is currently in progress.
@@ -75,6 +77,7 @@ module.exports = function ($rootScope, settings) {
     // This is used to implement actions which have side effects or are
     // asynchronous (see https://github.com/gaearon/redux-thunk#motivation)
     thunk,
+    debugMiddleware,
     angularDigestMiddleware.bind(null, $rootScope)
   );
   var store = redux.createStore(reducers.update, reducers.init(settings),

--- a/h/static/scripts/reducers/debug-middleware.js
+++ b/h/static/scripts/reducers/debug-middleware.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * A debug utility that prints information about internal application state
+ * changes to the console.
+ *
+ * Debugging is enabled by setting `window.debug` to a truthy value.
+ *
+ * When enabled, every action that changes application state will be printed
+ * to the console, along with the application state before and after the action
+ * was handled.
+ */
+function debugMiddleware(store) {
+  /* eslint-disable no-console */
+  var serial = 0;
+
+  return function (next) {
+    return function (action) {
+      if (!window.debug) {
+        next(action);
+        return;
+      }
+
+      ++serial;
+
+      var groupTitle = action.type + ' (' + serial.toString() + ')';
+      console.group(groupTitle);
+      console.log('Prev State:', store.getState());
+      console.log('Action:', action);
+
+      next(action);
+
+      console.log('Next State:', store.getState());
+      console.groupEnd(groupTitle);
+    };
+  };
+  /* eslint-enable no-console */
+}
+
+module.exports = debugMiddleware;

--- a/h/static/scripts/reducers/test/debug-middleware-test.js
+++ b/h/static/scripts/reducers/test/debug-middleware-test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/* eslint-disable no-console */
+
+var redux = require('redux');
+
+var debugMiddleware = require('../debug-middleware');
+
+function id(state) {
+  return state;
+}
+
+describe('debug middleware', function () {
+  var store;
+
+  beforeEach(function () {
+    sinon.stub(console, 'log');
+    sinon.stub(console, 'group');
+    sinon.stub(console, 'groupEnd');
+
+    var enhancer = redux.applyMiddleware(debugMiddleware);
+    store = redux.createStore(id, {}, enhancer);
+  });
+
+  afterEach(function () {
+    console.log.restore();
+    console.group.restore();
+    console.groupEnd.restore();
+
+    delete window.debug;
+  });
+
+  it('logs app state changes when "window.debug" is truthy', function () {
+    window.debug = true;
+    store.dispatch({type: 'SOMETHING_HAPPENED'});
+    assert.called(console.log);
+  });
+
+  it('logs nothing when "window.debug" is falsey', function () {
+    store.dispatch({type: 'SOMETHING_HAPPENED'});
+    assert.notCalled(console.log);
+  });
+});


### PR DESCRIPTION
This adds a debug utility which prints the application state before and
after each action to the console when `window.debug` is set to a truthy
value.

For example, if you enable `window.debug` and create an annotation, you'll see something like this:

![redux-debug](https://cloud.githubusercontent.com/assets/2458/19343485/504afd06-912e-11e6-8f60-a43ada6bc5b2.png)

This provides a way to quickly narrow down the search space when investigating bugs in the sidebar app, by checking after a given interaction:

* Did the right sequence of actions occur?
* Did the state update correctly after each action?
* Does the UI correctly reflect the final state?

There are [existing libraries on npm](https://github.com/evgenyrodionov/redux-logger) which do similar things. This implementation is very minimal though so we can include it in production builds and turn it on and off at runtime, which I think is useful when you run into a bug unexpectedly while doing something else.