### PR TITLE
Fix formatting changes made via toolbar buttons not persisting

### DIFF
--- a/h/static/scripts/directive/markdown.js
+++ b/h/static/scripts/directive/markdown.js
@@ -41,6 +41,8 @@ module.exports = function($sanitize) {
         // changed. This re-focuses the input field but really it should
         // happen automatically.
         input.focus();
+
+        scope.onEditText({text: input.value});
       }
 
       function focusInput() {

--- a/h/static/scripts/directive/test/markdown-test.js
+++ b/h/static/scripts/directive/test/markdown-test.js
@@ -19,6 +19,10 @@ describe('markdown', function () {
     return editor[0].querySelector('.markdown-body');
   }
 
+  function toolbarButtons(editor) {
+    return Array.from(editor[0].querySelectorAll('.markdown-tools-button'));
+  }
+
   function getRenderedHTML(editor) {
     var contentElement = viewElement(editor);
     if (isHidden(contentElement)) {
@@ -140,12 +144,28 @@ describe('markdown', function () {
         text: 'Hello World',
       });
       var input = inputElement(editor);
-      var buttons = editor[0].querySelectorAll('.markdown-tools-button');
-      for (var i=0; i < buttons.length; i++) {
+      toolbarButtons(editor).forEach(function (button) {
         input.value = 'original text';
-        angular.element(buttons[i]).click();
+        angular.element(button).click();
         assert.equal(input.value, mockFormattingCommand().text);
-      }
+      });
+    });
+
+    it('should notify parent that the text changed', function () {
+      var onEditText = sinon.stub();
+      var editor = util.createDirective(document, 'markdown', {
+        readOnly: false,
+        text: 'Hello World',
+        onEditText: {
+          args: ['text'],
+          callback: onEditText,
+        },
+      });
+      toolbarButtons(editor).forEach(function (button) {
+        onEditText.reset();
+        angular.element(button).click();
+        assert.calledWith(onEditText, inputElement(editor).value);
+      });
     });
   });
 


### PR DESCRIPTION
When making formatting changes to the text of an annotation with the
toolbar buttons without subsequently making a manual edit before clicking
Preview or Save, the `onEditText()` callback was never triggered and so
the unsaved changes were reverted when exiting edit mode.

This happened because onEditText() was only fired in response to the
'input' event which is not triggered in response to programmatic changes
to the `<input>`'s value.


Fixes #147