### PR TITLE
Rename the `$$tag` annotation property to `$tag`.

### DIFF
--- a/h/static/scripts/annotator/annotation-sync.coffee
+++ b/h/static/scripts/annotator/annotation-sync.coffee
@@ -40,7 +40,7 @@ module.exports = class AnnotationSync
   _channelListeners:
     'deleteAnnotation': (body, cb) ->
       annotation = this._parse(body)
-      delete @cache[annotation.$$tag]
+      delete @cache[annotation.$tag]
       @_emit('annotationDeleted', annotation)
       cb(null, this._format(annotation))
 
@@ -52,7 +52,7 @@ module.exports = class AnnotationSync
   # Handlers for events coming from this frame, to send them across the channel
   _eventListeners:
     'beforeAnnotationCreated': (annotation) ->
-      return if annotation.$$tag?
+      return if annotation.$tag?
       this._mkCallRemotelyAndParseResults('beforeCreateAnnotation')(annotation)
 
   _mkCallRemotelyAndParseResults: (method, callBack) ->
@@ -76,9 +76,9 @@ module.exports = class AnnotationSync
   # Assign a non-enumerable tag to objects which cross the bridge.
   # This tag is used to identify the objects between message.
   _tag: (ann, tag) ->
-    return ann if ann.$$tag
+    return ann if ann.$tag
     tag = tag or window.btoa(Math.random())
-    Object.defineProperty(ann, '$$tag', value: tag)
+    Object.defineProperty(ann, '$tag', value: tag)
     @cache[tag] = ann
     ann
 
@@ -93,6 +93,6 @@ module.exports = class AnnotationSync
   _format: (ann) ->
     this._tag(ann)
     {
-      tag: ann.$$tag
+      tag: ann.$tag
       msg: ann
     }

--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -125,12 +125,12 @@ module.exports = class Guest extends Annotator
   _connectAnnotationUISync: (crossframe) ->
     crossframe.on 'focusAnnotations', (tags=[]) =>
       for anchor in @anchors when anchor.highlights?
-        toggle = anchor.annotation.$$tag in tags
+        toggle = anchor.annotation.$tag in tags
         $(anchor.highlights).toggleClass('annotator-hl-focused', toggle)
 
     crossframe.on 'scrollToAnnotation', (tag) =>
       for anchor in @anchors when anchor.highlights?
-        if anchor.annotation.$$tag is tag
+        if anchor.annotation.$tag is tag
           scrollIntoView(anchor.highlights[0])
 
     crossframe.on 'getDocumentInfo', (cb) =>
@@ -348,19 +348,19 @@ module.exports = class Guest extends Annotator
     annotation
 
   showAnnotations: (annotations) ->
-    tags = (a.$$tag for a in annotations)
+    tags = (a.$tag for a in annotations)
     @crossframe?.call('showAnnotations', tags)
 
   toggleAnnotationSelection: (annotations) ->
-    tags = (a.$$tag for a in annotations)
+    tags = (a.$tag for a in annotations)
     @crossframe?.call('toggleAnnotationSelection', tags)
 
   updateAnnotations: (annotations) ->
-    tags = (a.$$tag for a in annotations)
+    tags = (a.$tag for a in annotations)
     @crossframe?.call('updateAnnotations', tags)
 
   focusAnnotations: (annotations) ->
-    tags = (a.$$tag for a in annotations)
+    tags = (a.$tag for a in annotations)
     @crossframe?.call('focusAnnotations', tags)
 
   _onSelection: (range) ->

--- a/h/static/scripts/annotator/test/annotation-sync-test.coffee
+++ b/h/static/scripts/annotator/test/annotation-sync-test.coffee
@@ -36,7 +36,7 @@ describe 'AnnotationSync', ->
   describe 'channel event handlers', ->
     assertBroadcast = (channelEvent, publishEvent) ->
       it 'broadcasts the "' + publishEvent + '" event over the local event bus', ->
-        ann = {id: 1, $$tag: 'tag1'}
+        ann = {id: 1, $tag: 'tag1'}
         annSync = createAnnotationSync()
         eventStub = sinon.stub()
         options.on(publishEvent, eventStub)
@@ -47,7 +47,7 @@ describe 'AnnotationSync', ->
 
     assertReturnValue = (channelEvent) ->
       it 'calls back with a formatted annotation', (done) ->
-        ann = {id: 1, $$tag: 'tag1'}
+        ann = {id: 1, $tag: 'tag1'}
         annSync = createAnnotationSync()
 
         callback = (err, ret) ->
@@ -60,14 +60,14 @@ describe 'AnnotationSync', ->
       it 'removes an existing entry from the cache before the event is triggered', ->
         options.emit = -> assert(!annSync.cache['tag1'])
 
-        ann = {id: 1, $$tag: 'tag1'}
+        ann = {id: 1, $tag: 'tag1'}
         annSync = createAnnotationSync()
         annSync.cache['tag1'] = ann
 
         publish(channelEvent, {msg: ann}, ->)
 
       it 'ensures the annotation is inserted in the cache', ->
-        ann = {id: 1, $$tag: 'tag1'}
+        ann = {id: 1, $tag: 'tag1'}
         annSync = createAnnotationSync()
 
         publish(channelEvent, {msg: ann}, ->)
@@ -81,14 +81,14 @@ describe 'AnnotationSync', ->
       it 'removes an existing entry from the cache before the event is triggered', ->
         options.emit = -> assert(!annSync.cache['tag1'])
 
-        ann = {id: 1, $$tag: 'tag1'}
+        ann = {id: 1, $tag: 'tag1'}
         annSync = createAnnotationSync()
         annSync.cache['tag1'] = ann
 
         publish('deleteAnnotation', {msg: ann}, ->)
 
       it 'removes the annotation from the cache', ->
-        ann = {id: 1, $$tag: 'tag1'}
+        ann = {id: 1, $tag: 'tag1'}
         annSync = createAnnotationSync()
 
         publish('deleteAnnotation', {msg: ann}, ->)
@@ -101,8 +101,8 @@ describe 'AnnotationSync', ->
         options.on('annotationsLoaded', loadedStub)
         annSync = createAnnotationSync()
 
-        annotations = [{id: 1, $$tag: 'tag1'}, {id: 2, $$tag: 'tag2'}, {id: 3, $$tag: 'tag3'}]
-        bodies = ({msg: ann, tag: ann.$$tag} for ann in annotations)
+        annotations = [{id: 1, $tag: 'tag1'}, {id: 2, $tag: 'tag2'}, {id: 3, $tag: 'tag3'}]
+        bodies = ({msg: ann, tag: ann.$tag} for ann in annotations)
         publish('loadAnnotations', bodies, ->)
 
         assert.calledWith(loadedStub, annotations)
@@ -116,10 +116,10 @@ describe 'AnnotationSync', ->
 
         assert.called(fakeBridge.call)
         assert.calledWith(fakeBridge.call, 'beforeCreateAnnotation',
-          {msg: ann, tag: ann.$$tag}, sinon.match.func)
+          {msg: ann, tag: ann.$tag}, sinon.match.func)
 
       it 'returns early if the annotation has a tag', ->
-        ann = {id: 1, $$tag: 'tag1'}
+        ann = {id: 1, $tag: 'tag1'}
         annSync = createAnnotationSync()
         options.emit('beforeAnnotationCreated', ann)
 

--- a/h/static/scripts/annotator/test/guest-test.coffee
+++ b/h/static/scripts/annotator/test/guest-test.coffee
@@ -124,15 +124,15 @@ describe 'Guest', ->
         options = CrossFrame.lastCall.args[1]
 
       it 'detaches annotations on "annotationDeleted"', ->
-        ann = {id: 1, $$tag: 'tag1'}
+        ann = {id: 1, $tag: 'tag1'}
         sandbox.stub(guest, 'detach')
         options.emit('annotationDeleted', ann)
         assert.calledOnce(guest.detach)
         assert.calledWith(guest.detach, ann)
 
       it 'anchors annotations on "annotationsLoaded"', ->
-        ann1 = {id: 1, $$tag: 'tag1'}
-        ann2 = {id: 2, $$tag: 'tag2'}
+        ann1 = {id: 1, $tag: 'tag1'}
+        ann2 = {id: 2, $tag: 'tag2'}
         sandbox.stub(guest, 'anchor')
         options.emit('annotationsLoaded', [ann1, ann2])
         assert.calledTwice(guest.anchor)
@@ -162,8 +162,8 @@ describe 'Guest', ->
         highlight1 = $('<span></span>')
         guest = createGuest()
         guest.anchors = [
-          {annotation: {$$tag: 'tag1'}, highlights: highlight0.toArray()}
-          {annotation: {$$tag: 'tag2'}, highlights: highlight1.toArray()}
+          {annotation: {$tag: 'tag1'}, highlights: highlight0.toArray()}
+          {annotation: {$tag: 'tag2'}, highlights: highlight1.toArray()}
         ]
         emitGuestEvent('focusAnnotations', ['tag1'])
         assert.isTrue(highlight0.hasClass('annotator-hl-focused'))
@@ -173,8 +173,8 @@ describe 'Guest', ->
         highlight1 = $('<span class="annotator-hl-focused"></span>')
         guest = createGuest()
         guest.anchors = [
-          {annotation: {$$tag: 'tag1'}, highlights: highlight0.toArray()}
-          {annotation: {$$tag: 'tag2'}, highlights: highlight1.toArray()}
+          {annotation: {$tag: 'tag1'}, highlights: highlight0.toArray()}
+          {annotation: {$tag: 'tag2'}, highlights: highlight1.toArray()}
         ]
         emitGuestEvent('focusAnnotations', 'ctx', ['tag1'])
         assert.isFalse(highlight1.hasClass('annotator-hl-focused'))
@@ -188,7 +188,7 @@ describe 'Guest', ->
         highlight = $('<span></span>')
         guest = createGuest()
         guest.anchors = [
-          {annotation: {$$tag: 'tag1'}, highlights: highlight.toArray()}
+          {annotation: {$tag: 'tag1'}, highlights: highlight.toArray()}
         ]
         emitGuestEvent('scrollToAnnotation', 'tag1')
         assert.called(scrollIntoView)


### PR DESCRIPTION
This property previously had a "$$" prefix instead of the conventional
single "$" prefix for local-only properties of annotations for
historical reasons.

This is a followup PR to:
https://github.com/hypothesis/client/pull/126