### PR TITLE
Fuzz tests for HTML anchoring

### DIFF
--- a/h/static/scripts/annotator/anchoring/html.coffee
+++ b/h/static/scripts/annotator/anchoring/html.coffee
@@ -85,13 +85,18 @@ exports.anchor = (root, selectors, options = {}) ->
 
 
 exports.describe = (root, range, options = {}) ->
-  types = [FragmentAnchor, RangeAnchor, TextPositionAnchor, TextQuoteAnchor]
+  types = [RangeAnchor, TextPositionAnchor, TextQuoteAnchor]
+
+  if typeof options.fragment == 'undefined' || options.fragment
+    types.unshift(FragmentAnchor)
 
   selectors = for type in types
     try
       anchor = type.fromRange(root, range, options)
       selector = anchor.toSelector(options)
-    catch
+    catch err
+      if typeof options.ignoreErrors != 'undefined' && !options.ignoreErrors
+        throw err
       continue
 
   return selectors

--- a/h/static/scripts/annotator/anchoring/test/html-fuzz-test.js
+++ b/h/static/scripts/annotator/anchoring/test/html-fuzz-test.js
@@ -1,0 +1,180 @@
+'use strict';
+
+var html = require('../html');
+var unroll = require('../../../test/util').unroll;
+
+var prng = require('./prng');
+var randomDom = require('./random-dom');
+
+/**
+ * Return the 1-based index of `node` within its siblings of the same node type
+ * and tag name.
+ */
+function siblingIndex(node) {
+  var children = Array.from(node.parentNode.childNodes);
+  var siblingIndex = 1;
+  var sibling;
+
+  for (var i=0; i < children.indexOf(node); i++) {
+    sibling = children[i];
+    if (sibling.nodeType === node.nodeType && sibling.tagName === node.tagName) {
+      ++siblingIndex;
+    }
+  }
+
+  return siblingIndex;
+}
+
+/**
+ * Returns an XPath-like string representing the path from `root` to `node`.
+ *
+ * @param {Node} root - An ancestor of `node`
+ * @param {Node} node - A descendant of `root`
+ */
+function pathToNode(root, node) {
+  var current = node;
+  var path = [];
+  while (current !== root) {
+    var indexStr = '[' + String(siblingIndex(current)) + ']';
+    if (current.nodeType === Node.TEXT_NODE) {
+      path.push('text()' + indexStr);
+    } else if (current.nodeType === Node.ELEMENT_NODE) {
+      path.push(current.tagName.toLowerCase() + indexStr);
+    }
+    current = current.parentNode;
+  }
+  return path.reverse().join('/');
+}
+
+function describePoint(dom, node, offset) {
+  return pathToNode(dom, node) + ':' + String(offset);
+}
+
+/**
+ * Return a string describing the DOM structure and Range from a given fuzz test.
+ *
+ * Used to generate messages when new failures are found to aid understanding
+ * the error and writing new unit tests.
+ */
+function describeCase(dom, range) {
+  return 'Input: ' + dom.innerHTML + '\nRange: ' +
+    describePoint(dom, range.startContainer, range.startOffset) + ' => ' +
+    describePoint(dom, range.endContainer, range.endOffset);
+}
+
+describe('HTML anchoring (fuzz tests)', function () {
+
+  var containers;
+
+  beforeEach(function () {
+    containers = [];
+  });
+
+  afterEach(function () {
+    containers.forEach(function (el) {
+      el.remove();
+    });
+    containers = [];
+  });
+
+  // Each run picks a set of random seed values, creates a PRNG using that seed
+  // and uses the PRNG to create a randomized DOM structure and a randomized
+  // Range starting and ending within that DOM tree.
+  //
+  // If a test fails, the description will include the seed. To reproduce the
+  // failure, comment out the `randomSeeds` generator below and replace with
+  // `[{seed: <the seed that failed>}]`
+  var randomSeeds = Array(100).fill(0).map(function () {
+    return { seed: Math.round(Math.random() * 1000) };
+  });
+
+  // Patterns for error messages and stack traces from known failure cases which
+  // need to be fixed, along with the seed value needed to reproduce the error.
+  //
+  // Caveats:
+  //
+  // 1) Patterns can only match function names and error messages, not source
+  //    file names since these are not reported in the original stack but added
+  //    later when the trace is reformatted.
+  // 2) The example seed values are invalidated if the test case generation
+  //    algorithm or PRNG is changed in any way. Failures should be translated
+  //    into test cases in the unit tests in `html-test.js`
+  //
+  var knownFailures = [
+
+    // Bugs in Text{Quote,Position}Selector describing/anchoring
+    // Most of these should be fixed by https://github.com/hypothesis/client/pull/159
+
+    // Example seed: 154
+    /undefined is not an object \(evaluating 'node.nodeType'\)[^]*\bgetFirstTextNode\b/,
+    // Example seed: 332
+    /null is not an object \(evaluating 'node.nodeType'\)[^]*\bisText\b/,
+    // Example seed: 479
+    /null is not an object \(evaluating 'endNode.textContent'\)[^]*\bfromRange\b/,
+    // Example seed: 29
+    /null is not an object \(evaluating 'startNode.textContent'\)[^]*\bfromRange\b/,
+
+    // Bugs in RangeSelector describing/anchoring
+
+    // Example seed: 539
+    /NotFoundError: DOM Exception 8[^]*setEnd@\[native code\]/,
+    // Example seed: 121
+    /null is not an object \(evaluating 'slices.shift'\)/,
+    // Example seed: 649
+    /Couldn't find offset [0-9]+ in element/,
+    // Example seed: 33
+    /null is not an object[^]*getLastTextNodeUpTo/,
+    // Example seed: 355
+    /null is not an object \(evaluating 'r.end.nodeValue'\)[^]*normalize/,
+    // Example seed: 346
+    /null is not an object \(evaluating 'nr.start.nodeValue.length'\)/,
+    // Example seed: 641
+    /undefined is not a constructor \(evaluating 'xpathRange.sniff\(range\).normalize\(this.root\)'\)/,
+  ];
+
+  function isKnownFailure(err) {
+    var errStr = err.message + ' ' + err.stack;
+    return knownFailures.some(function (pat) {
+      return errStr.match(pat);
+    });
+  }
+
+  unroll('describes and anchors a random range in a random DOM (seed: #seed)', function (testCase) {
+    var genRandom = prng(testCase.seed);
+    var dom = randomDom.generateRandomDOM(genRandom);
+    document.body.appendChild(dom);
+    containers.push(dom);
+
+    var range = randomDom.randomRange(dom, genRandom);
+
+    var selectors;
+    try {
+      selectors = html.describe(dom.parentNode, range, {
+        fragment: false,
+        ignoreErrors: false,
+      });
+    } catch (err) {
+      if (isKnownFailure(err)) {
+        return Promise.resolve();
+      } else {
+        console.error('Failed to describe:', describeCase(dom, range));
+        throw err;
+      }
+    }
+
+    var types = selectors.map(function (s) { return s.type; });
+    assert.deepEqual(types, ['RangeSelector', 'TextPositionSelector', 'TextQuoteSelector']);
+
+    var anchored = selectors.map(function (sel) {
+      return html.anchor(dom.parentNode, [sel]);
+    });
+
+    return Promise.all(anchored)
+      .catch(function (err) {
+        if (!isKnownFailure(err)) {
+          console.error('Failed to anchor:', describeCase(dom, range));
+          throw err;
+        }
+      });
+  }, randomSeeds);
+});

--- a/h/static/scripts/annotator/anchoring/test/prng.js
+++ b/h/static/scripts/annotator/anchoring/test/prng.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// XorShift128+ is the PRNG algorithm used by recent versions of V8
+var XorShift = require('xorshift').constructor;
+
+/**
+ * Return a PRNG initialized with a given seed.
+ *
+ * @param {number} seed - Integer >= 0 used as the seed for the PRNG
+ * @return {() => number} - PRNG function with the same API as Math.random()
+ */
+function prng(seed) {
+  // XorShift constructor requires 4 integers as the need, here we perform some
+  // arbitrarily chosen operations on the input integer
+  var seedList = [seed, seed << 5, seed * 149, seed * 79];
+  var prng = new XorShift(seedList);
+  // FIXME - Works around initial value too often being very small (why does
+  // this happen?)
+  prng.random();
+  return prng.random.bind(prng);
+}
+
+module.exports = prng;

--- a/h/static/scripts/annotator/anchoring/test/random-dom-test.js
+++ b/h/static/scripts/annotator/anchoring/test/random-dom-test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var prng = require('./prng');
+var unroll = require('../../../test/util').unroll;
+var randomDom = require('./random-dom');
+
+describe('Random DOM generator', function () {
+  describe('generateRandomDOM', function () {
+    var el;
+
+    afterEach(function () {
+      if (el) {
+        el.remove();
+      }
+    });
+
+    // Generate a set of randomized DOM trees, implicitly check that no
+    // exceptions are thrown.
+    //
+    // The initial seed here is fixed so the same set of DOM trees will be
+    // generated on every run.
+    var cases = [];
+    var genRandom = prng(100);
+    for (var i=0; i < 20; i++) {
+      cases.push({seed: Math.round(genRandom() * 5000)});
+    }
+
+    unroll('generates a randomized DOM', function (testCase) {
+      var genRandom = prng(testCase.seed);
+      randomDom.generateRandomDOM(genRandom);
+    }, cases);
+  });
+
+  describe('randomRange', function () {
+    var el;
+
+    afterEach(function () {
+      if (el) {
+        el.remove();
+      }
+    });
+
+    unroll('generates a randomized range', function (testCase) {
+      var genRandom = prng(testCase.seed);
+      el = document.createElement('div');
+      el.innerHTML = '<div><span></span><div>Foo</div><span>bar</span></div>';
+      document.body.appendChild(el);
+      var range = randomDom.randomRange(el, genRandom);
+      assert.equal(range.toString(), range);
+    }, [{
+      seed: 100,
+      range: 'foobar',
+    }]);
+  });
+});

--- a/h/static/scripts/annotator/anchoring/test/random-dom.js
+++ b/h/static/scripts/annotator/anchoring/test/random-dom.js
@@ -1,0 +1,180 @@
+'use strict';
+
+/**
+ * @typedef {() => number} PRNG - Function which generates a random number in [0, 1)
+ */
+
+/**
+ * Test helpers for generating randomized DOM trees and ranges for use
+ * in fuzz testing.
+ */
+
+var opcodes = {
+  /** Append an element of a randomly selected type to the current element. */
+  APPEND_CHILD: 0,
+  /** Append a text node with randomly selected content to the current element. */
+  APPEND_TEXT: 1,
+  /** Set the current element to the current element's parent node. */
+  GO_UP: 2,
+  /** Set the current element to a randomly selected child of the current node. */
+  GO_DOWN: 3,
+};
+
+var elementTypes = [
+  'div',
+  'h3',
+  'label',
+  'p',
+  'section',
+  'span',
+];
+
+// Contents for text nodes. Each string has a start ('^') and end ('$') marker
+// so that the bounds of individual text nodes can be seen when the DOM tree is
+// serialized using Element#innerHTML
+var phrases = [
+  '',
+  '-',
+  '^aa$',
+  '^bbb$',
+  '^c$',
+  '^ddddd$',
+];
+
+/**
+ * Return a random value in [min, max]
+ *
+ * @param {number} min
+ * @param {number} max
+ * @param {PRNG} genRandom
+ * @return {number}
+ */
+function randomInRange(min, max, genRandom) {
+  if (min > max) {
+    throw new Error('Bounds error: min > max');
+  }
+  return min + Math.round(genRandom() * (max - min));
+}
+
+/**
+ * Return a randomly selected element from an array.
+ *
+ * @param {T[]} array
+ * @param {PRNG} genRandom
+ * @return {T}
+ */
+function randomElement(array, genRandom) {
+  return array[randomInRange(0, array.length-1, genRandom)];
+}
+
+/**
+ * Generate a randomized DOM tree.
+ *
+ * @param {PRNG} genRandom
+ * @return {Element} The container element of the randomly generated DOM tree.
+ */
+function generateRandomDOM(genRandom) {
+  var seqLength = randomInRange(3, 100, genRandom);
+  var root = document.createElement('div');
+  var current = root;
+
+  var opcodeList = Object.values(opcodes);
+
+  for (var i=0; i < seqLength; i++) {
+    var op = randomElement(opcodeList, genRandom);
+    switch (op) {
+    case opcodes.APPEND_CHILD:
+      {
+        var tagName = randomElement(elementTypes, genRandom);
+        var element = document.createElement(tagName);
+        current.appendChild(element);
+      }
+      break;
+    case opcodes.APPEND_TEXT:
+      {
+        var content = randomElement(phrases, genRandom);
+        current.appendChild(document.createTextNode(content));
+      }
+      break;
+    case opcodes.GO_UP:
+      if (current !== root) {
+        current = current.parentNode;
+      }
+      break;
+    case opcodes.GO_DOWN:
+      {
+        var children = Array.from(current.childNodes).filter(function (n) {
+          return n.nodeType === Node.ELEMENT_NODE;
+        });
+        if (children.length > 0) {
+          current = randomElement(children, genRandom);
+        }
+      }
+      break;
+    }
+  }
+
+  return root;
+}
+
+/**
+ * Return the maximum offset for the start/end point of a Range where the
+ * `startContainer` or `endContainer` is `node`.
+ *
+ * @param {Node} node
+ */
+function maxOffset(node) {
+  switch (node.nodeType) {
+  case Node.TEXT_NODE:
+    return node.nodeValue.length;
+  case Node.ELEMENT_NODE:
+    return node.childNodes.length;
+  default:
+    return 0;
+  }
+}
+
+/**
+ * Generate a Range between random start and end points within a `root`
+ * container Node.
+ *
+ * @param {Node} root - Root DOM node to generate a `Range` within
+ * @param {PRNG} genRandom
+ * @return {Range} A valid DOM Range instance
+ */
+function randomRange(root, genRandom) {
+  var nodeIter = root.ownerDocument.createNodeIterator(root,
+    NodeFilter.SHOW_ALL, null /* filter */, false /* expandEntityReferences */);
+
+  var currentNode;
+  var nodes = [];
+  while (currentNode = nodeIter.nextNode()) { // eslint-disable-line no-cond-assign
+    nodes.push(currentNode);
+  }
+
+  var startIdx = randomInRange(0, nodes.length-1, genRandom);
+  var endIdx = randomInRange(startIdx, nodes.length-1, genRandom);
+
+  var startContainer = nodes[startIdx];
+  var endContainer = nodes[endIdx];
+
+  var startOffset = randomInRange(0, maxOffset(startContainer), genRandom);
+  var endOffset;
+
+  if (startContainer === endContainer) {
+    endOffset = randomInRange(startOffset, maxOffset(endContainer), genRandom);
+  } else {
+    endOffset = randomInRange(0, maxOffset(endContainer), genRandom);
+  }
+
+  var range = root.ownerDocument.createRange();
+  range.setStart(startContainer, startOffset);
+  range.setEnd(endContainer, endOffset);
+
+  return range;
+}
+
+module.exports = {
+  generateRandomDOM: generateRandomDOM,
+  randomRange: randomRange,
+};

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -3,6 +3,7 @@
 // ES2015 polyfills
 require('core-js/es6/promise');
 require('core-js/es6/set');
+require('core-js/fn/array/fill');
 require('core-js/fn/array/find');
 require('core-js/fn/array/find-index');
 require('core-js/fn/array/from');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4906,6 +4906,11 @@
       "from": "xmlhttprequest-ssl@1.5.1",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
     },
+    "xorshift": {
+      "version": "1.0.0",
+      "from": "xorshift@latest",
+      "resolved": "https://registry.npmjs.org/xorshift/-/xorshift-1.0.0.tgz"
+    },
     "xregexp": {
       "version": "3.1.1",
       "from": "xregexp@>=3.0.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "vinyl": "^1.1.1",
     "watchify": "^3.7.0",
     "websocket": "^1.0.22",
+    "xorshift": "^1.0.0",
     "zen-observable": "^0.3.0"
   },
   "browserify": {


### PR DESCRIPTION
Add a fuzz test that generates a randomized DOM structure and randomized
Range within that DOM structure.

It then attempts to describe the range using the HTML anchoring module
and re-anchor each of the generated selectors using the HTML anchoring
module.

The test currently triggers numerous exceptions during describing and
anchoring. Each of the known failure cases is whitelisted by a regex on
the exception message and stacktrace. As issues are fixed, the
corresponding entries can be removed from the whitelist.
