### PR TITLE
Fix incorrect usage of Sinon assertions

### DIFF
--- a/h/static/scripts/annotator/test/guest-test.coffee
+++ b/h/static/scripts/annotator/test/guest-test.coffee
@@ -504,7 +504,7 @@ describe 'Guest', ->
 
       guest.anchor(annotation).then ->
         assert.equal(guest.anchors.length, 0)
-        assert.calledOnce(removeHighlights, highlights)
+        assert.calledOnce(removeHighlights)
         assert.calledWith(removeHighlights, highlights)
       .then(done, done)
 

--- a/h/static/scripts/test/login-form-test.coffee
+++ b/h/static/scripts/test/login-form-test.coffee
@@ -152,9 +152,9 @@ describe 'loginForm.Controller', ->
       assert.called $timeout
 
       $timeout.lastCall.args[0]()
-      assert.called $scope.form.$setPristine, 'the form is pristine'
+      assert.called $scope.form.$setPristine
       assert.deepEqual $scope.model, {}, 'the model is erased'
-      assert.called mockFlash.info, 'a flash notification is shown'
+      assert.called mockFlash.info
 
     it 'should not happen if the model is empty', ->
       $scope.model = undefined


### PR DESCRIPTION
This fixes a couple of incorrect usages of Sinon assertions which
resulted in test failures with the latest patch version of Sinon.

 * `assert.calledOnce()` only takes one argument

 * Sinon assertions do not take a message argument as Chai assertions
   do. See http://sinonjs.org/docs/#assertions

This PR doesn't actually update the Sinon client library, but I found the issue when using an alternative npm client which didn't respect npm-shrinkwrap.json