### PR TITLE
Fix Jenkins builds failing if package.json or shrinkwrap change after branch is initially pushed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ node {
 
     stage 'Build'
     nodeEnv.inside("-e HOME=${workspace}") {
+        sh 'make clean'
         sh 'make'
     }
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,6 @@ lint: node_modules/.uptodate
 build/manifest.json: node_modules/.uptodate
 	npm run-script build
 
-node_modules/.uptodate:
+node_modules/.uptodate: package.json npm-shrinkwrap.json
 	npm run-script deps 2>/dev/null || npm install
 	@touch $@

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3948,14 +3948,36 @@
       }
     },
     "request": {
-      "version": "2.71.0",
-      "from": "request@>=2.61.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.71.0.tgz",
+      "version": "2.76.0",
+      "from": "request@latest",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
       "dependencies": {
         "extend": {
           "version": "3.0.0",
           "from": "extend@>=3.0.0 <3.1.0",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+        },
+        "form-data": {
+          "version": "2.1.1",
+          "from": "form-data@>=2.1.1 <2.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.1.tgz",
+          "dependencies": {
+            "mime-types": {
+              "version": "2.1.12",
+              "from": "mime-types@>=2.1.12 <3.0.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.24.0",
+          "from": "mime-db@>=1.24.0 <1.25.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "from": "tough-cookie@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "raven-js": "^3.7.0",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",
-    "request": "^2.72.0",
+    "request": "^2.76.0",
     "retry": "^0.8.0",
     "scroll-into-view": "^1.3.1",
     "seamless-immutable": "^6.0.1",


### PR DESCRIPTION
This fixes an issue where Jenkins builds would fail if a push on a branch that had already been built at least once by Jenkins changed `package.json` or `npm-shrinkwrap.json`.

The problem was that Jenkins re-uses workspaces between builds of the same branch, but running `make` did not trigger re-installation of dependencies in the client if `package.json` changed.

This PR triggers `make clean` to clean the build dir before building the branch in case any problematic assets are left over from a previous build and also adds `package.json` and `npm-shrinkwrap.json` as dependencies of the `make node_modules/.uptodate` marker file. This step required updating npm-shrinkwrap.json which had not been updated after "requests" was upgraded to v2.72.