### PR TITLE
Speed up PDF anchoring

### DIFF
--- a/h/static/scripts/annotator/anchoring/pdf.coffee
+++ b/h/static/scripts/annotator/anchoring/pdf.coffee
@@ -7,6 +7,8 @@ RenderingStates = require('../pdfjs-rendering-states')
 {TextPositionAnchor, TextQuoteAnchor} = require('./types')
 
 # Caches for performance
+
+# Map of page index to Promise<string>
 pageTextCache = {}
 quotePositionCache = {}
 
@@ -28,7 +30,7 @@ getPage = (pageIndex) ->
 
 getPageTextContent = (pageIndex) ->
   if pageTextCache[pageIndex]?
-    return Promise.resolve(pageTextCache[pageIndex])
+    return pageTextCache[pageIndex]
   else
     joinItems = ({items}) ->
       # Skip empty items since PDF-js leaves their text layer divs blank.
@@ -37,11 +39,11 @@ getPageTextContent = (pageIndex) ->
       # See the appendText method of TextLayerBuilder in pdf.js.
       nonEmpty = (item.str for item in items when /\S/.test(item.str))
       textContent = nonEmpty.join('')
-      pageTextCache[pageIndex] = textContent
       return textContent
 
-    return PDFViewerApplication.pdfViewer.getPageTextContent(pageIndex)
+    pageTextCache[pageIndex] = PDFViewerApplication.pdfViewer.getPageTextContent(pageIndex)
     .then(joinItems)
+    return pageTextCache[pageIndex]
 
 
 getPageOffset = (pageIndex) ->


### PR DESCRIPTION
This fixes an inefficiency in the PDF anchoring code that caused the text of the same page to be requested from PDF.js _many_ times when anchoring many annotations on the same PDF.

Time to anchor 88 annotations [1] on https://www.jyu.fi/edu/laitokset/okl/koulutusala/vkluoko/tietopankki/tutkimusta/viittomakielinen_juhlajulkaisu_nettiversio.pdf:

Mean of 5 runs:

**Before:** 17479ms
**After:** 2883ms

[1] Measured using this diff:

```diff
diff --git a/h/static/scripts/annotator/guest.coffee b/h/static/scripts/annotator/guest.coffee
index 049edfb..b9f3e67 100644
--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -120,8 +120,15 @@ module.exports = class Guest extends Annotator
       this.detach(annotation)
 
     this.subscribe 'annotationsLoaded', (annotations) =>
+      done = []
       for annotation in annotations
-        this.anchor(annotation)
+        done.push(this.anchor(annotation))
+
+      start = Date.now()
+      Promise.all(done).then(->
+        end = Date.now()
+        console.log 'Anchoring took %d ms', (end-start)
+      )
 
   _connectAnnotationUISync: (crossframe) ->
     crossframe.on 'focusAnnotations', (tags=[]) =>

```