### PR TITLE
Add HTML baseline tests

### DIFF
--- a/h/static/scripts/annotator/anchoring/test/html-baselines/index.js
+++ b/h/static/scripts/annotator/anchoring/test/html-baselines/index.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// Fixtures for anchoring baseline tests. The goals of these tests are to:
+//
+// 1) Check for unexpected changes in the selectors captured when describing
+//    a Range in a web page.
+// 2) Test anchoring in larger and more complex pages than the basic anchoring
+//    unit tests.
+//
+// Each fixture consists of:
+//
+//  - An HTML file for a web page
+//  - A set of annotations in the JSON format returned by the Hypothesis API
+//
+// To add a new fixture:
+//
+//  1. Open up a web page in the browser and annotate it.
+//  2. Save the web page (HTML only) via File -> Save Page As... as
+//     `<fixture name>.html` in this directory.
+//     It is important to save the page exactly as it was when annotated, since
+//     many pages have at least some dynamic content.
+//  3. Fetch the annotations for the web page via the Hypothesis API and save
+//     them as `<fixture name>.json` in this directory
+//  4. Add an entry to the fixture list below.
+
+module.exports = [{
+  name: 'Minimal Document',
+  html: require('./minimal.html'),
+  annotations: require('./minimal.json'),
+},{
+  name: 'Wikipedia - Regression Testing',
+  html: require('./wikipedia-regression-testing.html'),
+  annotations: require('./wikipedia-regression-testing.json'),
+}];

--- a/h/static/scripts/annotator/anchoring/test/html-baselines/minimal.html
+++ b/h/static/scripts/annotator/anchoring/test/html-baselines/minimal.html
@@ -1,0 +1,1 @@
+<body><div>One Two Three</div></body>

--- a/h/static/scripts/annotator/anchoring/test/html-baselines/minimal.json
+++ b/h/static/scripts/annotator/anchoring/test/html-baselines/minimal.json
@@ -1,0 +1,24 @@
+{
+  "total": 1,
+  "rows": [{
+    "id": "test",
+    "target": [{
+      "selector": [{
+        "type": "RangeSelector",
+        "startContainer": "/div[1]",
+        "endContainer": "/div[1]",
+        "startOffset": 4,
+        "endOffset": 7,
+      },{
+        "type": "TextPositionSelector",
+        "start": 4,
+        "end": 7,
+      },{
+        "type": "TextQuoteSelector",
+        "prefix": "One ",
+        "suffix": " Three\n",
+        "exact": "Two",
+      }],
+    }],
+  }],
+}

--- a/h/static/scripts/annotator/anchoring/test/html-baselines/wikipedia-regression-testing.html
+++ b/h/static/scripts/annotator/anchoring/test/html-baselines/wikipedia-regression-testing.html
@@ -1,0 +1,311 @@
+<!DOCTYPE html>
+<html class="client-nojs" lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8"/>
+<title>Regression testing - Wikipedia</title>
+<script>document.documentElement.className = document.documentElement.className.replace( /(^|\s)client-nojs(\s|$)/, "$1client-js$2" );</script>
+<script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,"wgPageName":"Regression_testing","wgTitle":"Regression testing","wgCurRevisionId":748923973,"wgRevisionId":748923973,"wgArticleId":38411,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":["Software testing","Extreme programming"],"wgBreakFrames":false,"wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgSeparatorTransformTable":["",""],"wgDigitTransformTable":["",""],"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgMonthNamesShort":["","Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"wgRelevantPageName":"Regression_testing","wgRelevantArticleId":38411,"wgRequestId":"WEwO5wpAAD8AAC6azfAAAABV","wgIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgFlaggedRevsParams":{"tags":{"status":{"levels":1,"quality":2,"pristine":3}}},"wgStableRevisionId":null,"wgWikiEditorEnabledModules":{"toolbar":true,"dialogs":true,"preview":false,"publish":false},"wgBetaFeaturesFeatures":[],"wgMediaViewerOnClick":true,"wgMediaViewerEnabledByDefault":true,"wgVisualEditor":{"pageLanguageCode":"en","pageLanguageDir":"ltr","usePageImages":true,"usePageDescriptions":true},"wgPreferredVariant":"en","wgMFDisplayWikibaseDescriptions":{"search":true,"nearby":true,"watchlist":true,"tagline":false},"wgRelatedArticles":null,"wgRelatedArticlesUseCirrusSearch":true,"wgRelatedArticlesOnlyUseCirrusSearch":false,"wgULSCurrentAutonym":"English","wgNoticeProject":"wikipedia","wgCentralNoticeCookiesToDelete":[],"wgCentralNoticeCategoriesUsingLegacy":["Fundraising","fundraising"],"wgCategoryTreePageCategoryOptions":"{\"mode\":0,\"hideprefix\":20,\"showcount\":true,\"namespaces\":false}","wgWikibaseItemId":"Q917415","wgCentralAuthMobileDomain":false,"wgVisualEditorToolbarScrollOffset":0,"wgEditSubmitButtonLabelPublish":false});mw.loader.state({"ext.globalCssJs.user.styles":"ready","ext.globalCssJs.site.styles":"ready","site.styles":"ready","noscript":"ready","user.styles":"ready","user":"ready","user.options":"loading","user.tokens":"loading","ext.cite.styles":"ready","wikibase.client.init":"ready","ext.visualEditor.desktopArticleTarget.noscript":"ready","ext.uls.interlanguage":"ready","ext.wikimediaBadges":"ready","mediawiki.legacy.shared":"ready","mediawiki.legacy.commonPrint":"ready","mediawiki.sectionAnchor":"ready","mediawiki.skinning.interface":"ready","skins.vector.styles":"ready","ext.globalCssJs.user":"ready","ext.globalCssJs.site":"ready"});mw.loader.implement("user.options@0j3lz3q",function($,jQuery,require,module){mw.user.options.set({"variant":"en"});});mw.loader.implement("user.tokens@1dqfd7l",function ( $, jQuery, require, module ) {
+mw.user.tokens.set({"editToken":"+\\","patrolToken":"+\\","watchToken":"+\\","csrfToken":"+\\"});/*@nomin*/;
+
+});mw.loader.load(["ext.cite.a11y","mediawiki.toc","mediawiki.action.view.postEdit","site","mediawiki.page.startup","mediawiki.user","mediawiki.hidpi","mediawiki.page.ready","mediawiki.legacy.wikibits","mediawiki.searchSuggest","ext.gadget.teahouse","ext.gadget.ReferenceTooltips","ext.gadget.watchlist-notice","ext.gadget.DRN-wizard","ext.gadget.charinsert","ext.gadget.refToolbar","ext.gadget.extra-toolbar-buttons","ext.gadget.switcher","ext.gadget.featured-articles-links","ext.centralauth.centralautologin","mmv.head","mmv.bootstrap.autostart","ext.visualEditor.desktopArticleTarget.init","ext.visualEditor.targetLoader","ext.eventLogging.subscriber","ext.wikimediaEvents","ext.navigationTiming","ext.uls.eventlogger","ext.uls.init","ext.uls.interface","ext.quicksurveys.init","ext.centralNotice.geoIP","ext.centralNotice.startUp","skins.vector.js"]);});</script>
+<link rel="stylesheet" href="/w/load.php?debug=false&amp;lang=en&amp;modules=ext.cite.styles%7Cext.uls.interlanguage%7Cext.visualEditor.desktopArticleTarget.noscript%7Cext.wikimediaBadges%7Cmediawiki.legacy.commonPrint%2Cshared%7Cmediawiki.sectionAnchor%7Cmediawiki.skinning.interface%7Cskins.vector.styles%7Cwikibase.client.init&amp;only=styles&amp;skin=vector"/>
+<script async="" src="/w/load.php?debug=false&amp;lang=en&amp;modules=startup&amp;only=scripts&amp;skin=vector"></script>
+<meta name="ResourceLoaderDynamicStyles" content=""/>
+<link rel="stylesheet" href="/w/load.php?debug=false&amp;lang=en&amp;modules=site.styles&amp;only=styles&amp;skin=vector"/>
+<meta name="generator" content="MediaWiki 1.29.0-wmf.5"/>
+<meta name="referrer" content="origin-when-cross-origin"/>
+<link rel="alternate" href="android-app://org.wikipedia/http/en.m.wikipedia.org/wiki/Regression_testing"/>
+<link rel="alternate" type="application/x-wiki" title="Edit this page" href="/w/index.php?title=Regression_testing&amp;action=edit"/>
+<link rel="edit" title="Edit this page" href="/w/index.php?title=Regression_testing&amp;action=edit"/>
+<link rel="apple-touch-icon" href="/static/apple-touch/wikipedia.png"/>
+<link rel="shortcut icon" href="/static/favicon/wikipedia.ico"/>
+<link rel="search" type="application/opensearchdescription+xml" href="/w/opensearch_desc.php" title="Wikipedia (en)"/>
+<link rel="EditURI" type="application/rsd+xml" href="//en.wikipedia.org/w/api.php?action=rsd"/>
+<link rel="copyright" href="//creativecommons.org/licenses/by-sa/3.0/"/>
+<link rel="canonical" href="https://en.wikipedia.org/wiki/Regression_testing"/>
+<link rel="dns-prefetch" href="//login.wikimedia.org"/>
+<link rel="dns-prefetch" href="//meta.wikimedia.org" />
+</head>
+<body class="mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject page-Regression_testing rootpage-Regression_testing skin-vector action-view">		<div id="mw-page-base" class="noprint"></div>
+		<div id="mw-head-base" class="noprint"></div>
+		<div id="content" class="mw-body" role="main">
+			<a id="top"></a>
+
+							<div id="siteNotice"><!-- CentralNotice --></div>
+						<div class="mw-indicators">
+</div>
+			<h1 id="firstHeading" class="firstHeading" lang="en">Regression testing</h1>
+									<div id="bodyContent" class="mw-body-content">
+									<div id="siteSub">From Wikipedia, the free encyclopedia</div>
+								<div id="contentSub"></div>
+												<div id="jump-to-nav" class="mw-jump">
+					Jump to:					<a href="#mw-head">navigation</a>, 					<a href="#p-search">search</a>
+				</div>
+				<div id="mw-content-text" lang="en" dir="ltr" class="mw-content-ltr"><script>function mfTempOpenSection(id){var block=document.getElementById("mf-section-"+id);block.className+=" open-block";block.previousSibling.className+=" open-block";}</script><p><b>Regression testing</b> is a type of <a href="/wiki/Software_testing" title="Software testing">software testing</a> that verifies that software previously developed and tested still performs correctly even after it was changed or interfaced with other software. Changes may include software enhancements, <a href="/wiki/Patch_(computing)" title="Patch (computing)">patches</a>, <a href="/wiki/Configuration_file" title="Configuration file">configuration</a> changes, etc. During regression testing, new <a href="/wiki/Software_bug" title="Software bug">software bugs</a> or <i><a href="/wiki/Software_regression" title="Software regression">regressions</a></i> may be uncovered. Sometimes a software change impact analysis is performed to determine what areas could be affected by the proposed changes. These areas may include <a href="/wiki/Functional_testing" title="Functional testing">functional</a> and <a href="/wiki/Non-functional_testing" title="Non-functional testing">non-functional</a> areas of the system.</p>
+<p>The purpose of regression testing is to ensure that changes such as those mentioned above have not introduced new faults.<sup id="cite_ref-1" class="reference"><a href="#cite_note-1">[1]</a></sup> One of the main reasons for regression testing is to determine whether a change in one part of the software affects other parts of the software.<sup id="cite_ref-2" class="reference"><a href="#cite_note-2">[2]</a></sup></p>
+<p>Common methods of regression testing include re-running previously completed tests and checking whether program behavior has changed and whether previously fixed faults have re-emerged. Regression testing can be performed to test a system efficiently by systematically selecting the appropriate minimum set of tests needed to adequately cover a particular change.</p>
+<p>Contrast with <a href="/wiki/Non-regression_testing" title="Non-regression testing">non-regression testing</a> (usually validation-test for a new issue), which aims to verify whether, after introducing or updating a given software application, the change has had the intended effect.</p>
+<p></p>
+<div id="toc" class="toc">
+<div id="toctitle">
+<h2>Contents</h2>
+</div>
+<ul>
+<li class="toclevel-1 tocsection-1"><a href="#Background"><span class="tocnumber">1</span> <span class="toctext">Background</span></a></li>
+<li class="toclevel-1 tocsection-2"><a href="#Techniques"><span class="tocnumber">2</span> <span class="toctext">Techniques</span></a>
+<ul>
+<li class="toclevel-2 tocsection-3"><a href="#Retest_all"><span class="tocnumber">2.1</span> <span class="toctext">Retest all</span></a></li>
+<li class="toclevel-2 tocsection-4"><a href="#Regression_test_selection"><span class="tocnumber">2.2</span> <span class="toctext">Regression test selection</span></a></li>
+<li class="toclevel-2 tocsection-5"><a href="#Test_case_prioritization"><span class="tocnumber">2.3</span> <span class="toctext">Test case prioritization</span></a>
+<ul>
+<li class="toclevel-3 tocsection-6"><a href="#Types_of_test_case_prioritization"><span class="tocnumber">2.3.1</span> <span class="toctext">Types of test case prioritization</span></a></li>
+</ul>
+</li>
+<li class="toclevel-2 tocsection-7"><a href="#Hybrid"><span class="tocnumber">2.4</span> <span class="toctext">Hybrid</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-8"><a href="#Benefits_and_drawbacks"><span class="tocnumber">3</span> <span class="toctext">Benefits and drawbacks</span></a></li>
+<li class="toclevel-1 tocsection-9"><a href="#Uses"><span class="tocnumber">4</span> <span class="toctext">Uses</span></a></li>
+<li class="toclevel-1 tocsection-10"><a href="#See_also"><span class="tocnumber">5</span> <span class="toctext">See also</span></a></li>
+<li class="toclevel-1 tocsection-11"><a href="#References"><span class="tocnumber">6</span> <span class="toctext">References</span></a></li>
+<li class="toclevel-1 tocsection-12"><a href="#External_links"><span class="tocnumber">7</span> <span class="toctext">External links</span></a></li>
+</ul>
+</div>
+<p></p>
+<h2><span class="mw-headline" id="Background">Background</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Regression_testing&amp;action=edit&amp;section=1" title="Edit section: Background">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<p>As software is fixed or changed, emergence of new faults and/or re-emergence of old faults is quite common. Sometimes re-emergence occurs because a fix gets lost through poor <a href="/wiki/Revision_control" class="mw-redirect" title="Revision control">revision control</a> practices (or simple human error in revision control). Often, a fix for a problem will be "<a href="/wiki/Software_brittleness" title="Software brittleness">fragile</a>" in that it fixes the problem in the narrow case where it was first observed but not in more general cases which may arise over the lifetime of the software. Frequently, a fix for a problem in one area inadvertently causes a <a href="/wiki/Software_bug" title="Software bug">software bug</a> in another area. Finally, it may happen that, when some feature is redesigned, some of the same mistakes that were made in the original implementation of the feature are made in the redesign.</p>
+<p>Therefore, in most software development situations, it is considered <a href="/wiki/Best_Coding_Practices" class="mw-redirect" title="Best Coding Practices">good coding practice</a>, when a bug is located and fixed, to record a test that exposes the bug and re-run that test regularly after subsequent changes to the program.<sup id="cite_ref-kolawa_3-0" class="reference"><a href="#cite_note-kolawa-3">[3]</a></sup> Although this may be done through <a href="/wiki/Manual_testing" title="Manual testing">manual testing</a> procedures using programming techniques, it is often done using <a href="/wiki/Automated_testing" class="mw-redirect" title="Automated testing">automated testing</a> tools.<sup id="cite_ref-4" class="reference"><a href="#cite_note-4">[4]</a></sup> Such a <a href="/wiki/Test_suite" title="Test suite">test suite</a> contains software tools that allow the testing environment to execute all the regression <a href="/wiki/Test_case" title="Test case">test cases</a> automatically; some projects even set up automated systems to re-run all regression tests at specified intervals and report any failures (which could imply a regression or an out-of-date test).<sup id="cite_ref-5" class="reference"><a href="#cite_note-5">[5]</a></sup> Common strategies are to run such a system after every successful compile (for small projects), every night, or once a week. Those strategies can be automated by an external tool.</p>
+<p>Regression testing is an integral part of the <a href="/wiki/Extreme_programming" title="Extreme programming">extreme programming</a> software development method. In this method, design documents are replaced by extensive, repeatable, and automated testing of the entire software package throughout each stage of the <a href="/wiki/Software_development_process" title="Software development process">software development process</a>. Regression testing is done after functional testing has concluded, to verify that the other functionalities are working.</p>
+<p>In the corporate world, regression testing has traditionally been performed by a <a href="/wiki/Software_quality_assurance" title="Software quality assurance">software quality assurance</a> team after the development team has completed work. However, defects found at this stage are the most costly to fix. This problem is being addressed by the rise of <a href="/wiki/Unit_testing" title="Unit testing">unit testing</a>. Although developers have always written test cases as part of the development cycle, these test cases have generally been either <a href="/wiki/Functional_testing" title="Functional testing">functional tests</a> or <a href="/wiki/Unit_testing" title="Unit testing">unit tests</a> that verify only intended outcomes. Developer testing compels a developer to focus on unit testing and to include both positive and negative test cases.<sup id="cite_ref-6" class="reference"><a href="#cite_note-6">[6]</a></sup></p>
+<h2><span class="mw-headline" id="Techniques">Techniques</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Regression_testing&amp;action=edit&amp;section=2" title="Edit section: Techniques">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<p>The various regression testing techniques are:</p>
+<h3><span class="mw-headline" id="Retest_all">Retest all</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Regression_testing&amp;action=edit&amp;section=3" title="Edit section: Retest all">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<p>This technique checks all the test cases on the current program to check its integrity. Though it is expensive as it needs to re-run all the cases, it ensures that there are no errors because of the modified code.<sup id="cite_ref-:0_7-0" class="reference"><a href="#cite_note-:0-7">[7]</a></sup></p>
+<h3><span class="mw-headline" id="Regression_test_selection">Regression test selection</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Regression_testing&amp;action=edit&amp;section=4" title="Edit section: Regression test selection">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<p>Unlike Retest all, This technique runs a part of the <a href="/wiki/Test_suite" title="Test suite">test suite</a> (owing to the cost of retest all) if cost of selecting the part of test suite is less than retest all technique.<sup id="cite_ref-:0_7-1" class="reference"><a href="#cite_note-:0-7">[7]</a></sup></p>
+<h3><span class="mw-headline" id="Test_case_prioritization">Test case prioritization</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Regression_testing&amp;action=edit&amp;section=5" title="Edit section: Test case prioritization">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<p>Prioritize the test cases so as to increase a test suite's rate of fault detection. Test case prioritization techniques schedule test cases so that the test cases that are higher in priority are executed before the test cases that have a lesser priority.<sup id="cite_ref-:0_7-2" class="reference"><a href="#cite_note-:0-7">[7]</a></sup></p>
+<h4><span class="mw-headline" id="Types_of_test_case_prioritization">Types of test case prioritization</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Regression_testing&amp;action=edit&amp;section=6" title="Edit section: Types of test case prioritization">edit</a><span class="mw-editsection-bracket">]</span></span></h4>
+<ul>
+<li>General prioritization - Prioritize test cases that will be beneficial on subsequent versions</li>
+</ul>
+<ul>
+<li>Version-specific prioritization - Prioritize test cases with respect to a particular version of the software.</li>
+</ul>
+<h3><span class="mw-headline" id="Hybrid">Hybrid</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Regression_testing&amp;action=edit&amp;section=7" title="Edit section: Hybrid">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<p>This technique is a Hybrid Approach of both Regression Test Selection and Test Case Prioritization. Algorithms for the approach that have been proposed are test selection algorithm and hybrid technique proposed<sup id="cite_ref-:0_7-3" class="reference"><a href="#cite_note-:0-7">[7]</a></sup></p>
+<h2><span class="mw-headline" id="Benefits_and_drawbacks">Benefits and drawbacks</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Regression_testing&amp;action=edit&amp;section=8" title="Edit section: Benefits and drawbacks">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<p>Regression testing is performed when changes are made to the existing functionality of the software or if there is a bug fix in the software. Regression testing can be achieved through multiple approaches, if a <i>test all</i> approach is followed it provides certainty that the changes made to the software have not affected the existing functionalities, which are unaltered, in any way.<sup id="cite_ref-:1_8-0" class="reference"><a href="#cite_note-:1-8">[8]</a></sup></p>
+<p>In an agile project management process, where the software development life cycles are very short, resources are scarce and changes to the software are very frequent; Regression testing might introduce a lot of unnecessary overheads.<sup id="cite_ref-:1_8-1" class="reference"><a href="#cite_note-:1-8">[8]</a></sup></p>
+<p>Typically, regression testing is carried out by automation tools, but the existing generation of regression testing tools is not equipped to handle <a href="/wiki/Database" title="Database">database</a> application. For this reason, performing a regression test on a database application could prove to be taxing as it would require a great deal of manual effort.<sup id="cite_ref-9" class="reference"><a href="#cite_note-9">[9]</a></sup></p>
+<p>Moreover, performing regression testing in a software development environment which tends to use black box components from a third party can get a bit tricky as any change in the third party component may interfere with the rest of the system and performing regression testing on a third party component is difficult because it is an unknown entity.<sup id="cite_ref-:1_8-2" class="reference"><a href="#cite_note-:1-8">[8]</a></sup></p>
+<h2><span class="mw-headline" id="Uses">Uses</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Regression_testing&amp;action=edit&amp;section=9" title="Edit section: Uses">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<p>Regression testing can be used not only for testing the <i><a href="/wiki/Correctness_(computer_science)" title="Correctness (computer science)">correctness</a></i> of a program, but often also for tracking the quality of its output.<sup id="cite_ref-10" class="reference"><a href="#cite_note-10">[10]</a></sup> For instance, in the design of a <a href="/wiki/Compiler" title="Compiler">compiler</a>, regression testing could track the code size, and the time it takes to compile and execute the test suite cases.</p>
+<blockquote class="templatequote">
+<p>Also as a consequence of the introduction of new bugs, program maintenance requires far more system testing per statement written than any other programming. Theoretically, after each fix one must run the entire batch of test cases previously run against the system, to ensure that it has not been damaged in an obscure way. In practice, such <i>regression testing</i> must indeed approximate this theoretical idea, and it is very costly.</p>
+<div class="templatequotecite"><cite>— <a href="/wiki/Fred_Brooks" title="Fred Brooks">Fred Brooks</a>, <i><a href="/wiki/The_Mythical_Man_Month" class="mw-redirect" title="The Mythical Man Month">The Mythical Man Month</a></i>, p. 122</cite></div>
+</blockquote>
+<p>Regression tests can be broadly categorized as <a href="/wiki/Functional_test" class="mw-redirect" title="Functional test">functional tests</a> or <a href="/wiki/Unit_testing" title="Unit testing">unit tests</a>. Functional tests exercise the complete program with various inputs. Unit tests exercise individual functions, <a href="/wiki/Subroutine" title="Subroutine">subroutines</a>, or object methods. Both functional testing tools and unit testing tools tend to be automated and a third-party product that are not part of the compiler suite. A functional test may be a scripted series of program inputs, possibly even involving an automated mechanism for controlling mouse movements and clicks. A unit test may be a set of separate functions within the code itself, or a driver layer that links to the code without altering the code being tested.</p>
+<h2><span class="mw-headline" id="See_also">See also</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Regression_testing&amp;action=edit&amp;section=10" title="Edit section: See also">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<div role="navigation" aria-label="Portals" class="noprint portal plainlist tright" style="margin:0.5em 0 0.5em 1em;border:solid #aaa 1px">
+<ul style="display:table;box-sizing:border-box;padding:0.1em;max-width:175px;background:#f9f9f9;font-size:85%;line-height:110%;font-style:italic;font-weight:bold">
+<li style="display:table-row"><span style="display:table-cell;padding:0.2em;vertical-align:middle;text-align:center"><a href="/wiki/File:Green_bug_and_broom.svg" class="image"><img alt="icon" src="//upload.wikimedia.org/wikipedia/commons/thumb/8/83/Green_bug_and_broom.svg/32px-Green_bug_and_broom.svg.png" width="32" height="28" class="noviewer" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/8/83/Green_bug_and_broom.svg/48px-Green_bug_and_broom.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/8/83/Green_bug_and_broom.svg/64px-Green_bug_and_broom.svg.png 2x" data-file-width="447" data-file-height="385" /></a></span><span style="display:table-cell;padding:0.2em 0.2em 0.2em 0.3em;vertical-align:middle"><a href="/wiki/Portal:Software_Testing" class="mw-redirect" title="Portal:Software Testing">Software Testing portal</a></span></li>
+</ul>
+</div>
+<ul>
+<li><a href="/wiki/Characterization_test" title="Characterization test">Characterization test</a></li>
+<li><a href="/wiki/Quality_control" title="Quality control">Quality control</a></li>
+<li><a href="/wiki/Smoke_testing_(software)" title="Smoke testing (software)">Smoke testing</a></li>
+<li><a href="/wiki/Test-driven_development" title="Test-driven development">Test-driven development</a></li>
+</ul>
+<h2><span class="mw-headline" id="References">References</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Regression_testing&amp;action=edit&amp;section=11" title="Edit section: References">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<div class="reflist columns references-column-width" style="-moz-column-width: 30em; -webkit-column-width: 30em; column-width: 30em; list-style-type: decimal;">
+<ol class="references">
+<li id="cite_note-1"><span class="mw-cite-backlink"><b><a href="#cite_ref-1">^</a></b></span> <span class="reference-text"><cite class="citation book">Myers, Glenford (2004). <i>The Art of Software Testing</i>. Wiley. <a href="/wiki/International_Standard_Book_Number" title="International Standard Book Number">ISBN</a>&#160;<a href="/wiki/Special:BookSources/978-0-471-46912-4" title="Special:BookSources/978-0-471-46912-4">978-0-471-46912-4</a>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3ARegression+testing&amp;rft.aufirst=Glenford&amp;rft.aulast=Myers&amp;rft.btitle=The+Art+of+Software+Testing&amp;rft.date=2004&amp;rft.genre=book&amp;rft.isbn=978-0-471-46912-4&amp;rft.pub=Wiley&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-2"><span class="mw-cite-backlink"><b><a href="#cite_ref-2">^</a></b></span> <span class="reference-text"><cite class="citation book">Savenkov, Roman (2008). <i>How to Become a Software Tester</i>. Roman Savenkov Consulting. p.&#160;386. <a href="/wiki/International_Standard_Book_Number" title="International Standard Book Number">ISBN</a>&#160;<a href="/wiki/Special:BookSources/978-0-615-23372-7" title="Special:BookSources/978-0-615-23372-7">978-0-615-23372-7</a>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3ARegression+testing&amp;rft.aufirst=Roman&amp;rft.aulast=Savenkov&amp;rft.btitle=How+to+Become+a+Software+Tester&amp;rft.date=2008&amp;rft.genre=book&amp;rft.isbn=978-0-615-23372-7&amp;rft.pages=386&amp;rft.pub=Roman+Savenkov+Consulting&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-kolawa-3"><span class="mw-cite-backlink"><b><a href="#cite_ref-kolawa_3-0">^</a></b></span> <span class="reference-text"><cite class="citation book">Kolawa, Adam; Huizinga, Dorota (2007). <a rel="nofollow" class="external text" href="http://www.wiley.com/WileyCDA/WileyTitle/productCd-0470042125.html"><i>Automated Defect Prevention: Best Practices in Software Management</i></a>. Wiley-IEEE Computer Society Press. p.&#160;73. <a href="/wiki/International_Standard_Book_Number" title="International Standard Book Number">ISBN</a>&#160;<a href="/wiki/Special:BookSources/0-470-04212-5" title="Special:BookSources/0-470-04212-5">0-470-04212-5</a>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3ARegression+testing&amp;rft.aufirst=Adam&amp;rft.au=Huizinga%2C+Dorota&amp;rft.aulast=Kolawa&amp;rft.btitle=Automated+Defect+Prevention%3A+Best+Practices+in+Software+Management&amp;rft.date=2007&amp;rft.genre=book&amp;rft_id=http%3A%2F%2Fwww.wiley.com%2FWileyCDA%2FWileyTitle%2FproductCd-0470042125.html&amp;rft.isbn=0-470-04212-5&amp;rft.pages=73&amp;rft.pub=Wiley-IEEE+Computer+Society+Press&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-4"><span class="mw-cite-backlink"><b><a href="#cite_ref-4">^</a></b></span> <span class="reference-text"><a rel="nofollow" class="external text" href="http://safari.oreilly.com/0201794292/ch08lev1sec4">Automate Regression Tests When Feasible</a>, Automated Testing: Selected Best Practices, Elfriede Dustin, Safari Books Online</span></li>
+<li id="cite_note-5"><span class="mw-cite-backlink"><b><a href="#cite_ref-5">^</a></b></span> <span class="reference-text"><cite class="citation web">daVeiga, Nada (February 2008). <a rel="nofollow" class="external text" href="http://www.ddj.com/development-tools/206105233;jsessionid=2HN1TRYZ4JGVAQSNDLRSKH0CJUNN2JVN">"Change Code Without Fear: Utilize a Regression Safety Net"</a>. <i><a href="/wiki/Dr._Dobb%27s_Journal" title="Dr. Dobb's Journal">Dr. Dobb's Journal</a></i>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3ARegression+testing&amp;rft.atitle=Change+Code+Without+Fear%3A+Utilize+a+Regression+Safety+Net&amp;rft.aufirst=Nada&amp;rft.aulast=daVeiga&amp;rft.date=2008-02&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.ddj.com%2Fdevelopment-tools%2F206105233%3Bjsessionid%3D2HN1TRYZ4JGVAQSNDLRSKH0CJUNN2JVN&amp;rft.jtitle=Dr.+Dobb%27s+Journal&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-6"><span class="mw-cite-backlink"><b><a href="#cite_ref-6">^</a></b></span> <span class="reference-text"><cite class="citation web">Dudney, Bill (2004-12-08). <a rel="nofollow" class="external text" href="http://www.sys-con.com/read/47359.htm">"Developer Testing Is 'In': An interview with Alberto Savoia and Kent Beck"</a><span class="reference-accessdate">. Retrieved <span class="nowrap">2007-11-29</span></span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3ARegression+testing&amp;rft.aufirst=Bill&amp;rft.aulast=Dudney&amp;rft.btitle=Developer+Testing+Is+%27In%27%3A+An+interview+with+Alberto+Savoia+and+Kent+Beck&amp;rft.date=2004-12-08&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.sys-con.com%2Fread%2F47359.htm&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-:0-7"><span class="mw-cite-backlink">^ <a href="#cite_ref-:0_7-0"><sup><i><b>a</b></i></sup></a> <a href="#cite_ref-:0_7-1"><sup><i><b>b</b></i></sup></a> <a href="#cite_ref-:0_7-2"><sup><i><b>c</b></i></sup></a> <a href="#cite_ref-:0_7-3"><sup><i><b>d</b></i></sup></a></span> <span class="reference-text"><cite class="citation journal">"UNDERSTANDING REGRESSION TESTING TECHNIQUES". <i>Citeseerx</i>. 2008.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3ARegression+testing&amp;rft.atitle=UNDERSTANDING+REGRESSION+TESTING+TECHNIQUES&amp;rft.date=2008&amp;rft.genre=article&amp;rft.jtitle=Citeseerx&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-:1-8"><span class="mw-cite-backlink">^ <a href="#cite_ref-:1_8-0"><sup><i><b>a</b></i></sup></a> <a href="#cite_ref-:1_8-1"><sup><i><b>b</b></i></sup></a> <a href="#cite_ref-:1_8-2"><sup><i><b>c</b></i></sup></a></span> <span class="reference-text"><cite class="citation journal">"Regression Testing Minimisation, Selection and Prioritisation: A Survey; S. Yoo, M. Harman". <i>Published online in Wiley InterScience</i>. 2007.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3ARegression+testing&amp;rft.atitle=Regression+Testing+Minimisation%2C+Selection+and+Prioritisation%3A+A+Survey%3B+S.+Yoo%2C+M.+Harman&amp;rft.date=2007&amp;rft.genre=article&amp;rft.jtitle=Published+online+in+Wiley+InterScience&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-9"><span class="mw-cite-backlink"><b><a href="#cite_ref-9">^</a></b></span> <span class="reference-text"><cite class="citation journal">"Efficient Regression Tests for Database Applications". <i>Springer Journal</i>. 2006.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3ARegression+testing&amp;rft.atitle=Efficient+Regression+Tests+for+Database+Applications&amp;rft.date=2006&amp;rft.genre=article&amp;rft.jtitle=Springer+Journal&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+<li id="cite_note-10"><span class="mw-cite-backlink"><b><a href="#cite_ref-10">^</a></b></span> <span class="reference-text"><cite class="citation web"><a href="/wiki/Adam_Kolawa" title="Adam Kolawa">Kolawa, Adam</a>. <a rel="nofollow" class="external text" href="http://www.wrox.com/WileyCDA/Section/id-291252.html">"Regression Testing, Programmer to Programmer"</a>. <i>Wrox</i>.</cite><span title="ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3ARegression+testing&amp;rft.atitle=Regression+Testing%2C+Programmer+to+Programmer&amp;rft.aufirst=Adam&amp;rft.aulast=Kolawa&amp;rft.genre=unknown&amp;rft_id=http%3A%2F%2Fwww.wrox.com%2FWileyCDA%2FSection%2Fid-291252.html&amp;rft.jtitle=Wrox&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal" class="Z3988"><span style="display:none;">&#160;</span></span></span></li>
+</ol>
+</div>
+<h2><span class="mw-headline" id="External_links">External links</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Regression_testing&amp;action=edit&amp;section=12" title="Edit section: External links">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<div class="refbegin" style="">
+<ul>
+<li><a rel="nofollow" class="external text" href="http://msdn.microsoft.com/en-us/library/aa292167(VS.71).aspx">Microsoft regression testing recommendations</a></li>
+<li><a rel="nofollow" class="external text" href="https://gnunet.org/gauger/">Gauger performance regression visualization tool</a></li>
+<li><a rel="nofollow" class="external text" href="http://smartbear.com/products/qa-tools/what-is-regression-testing/">What is Regression Testing</a> by Scott Barber and Tom Huston</li>
+</ul>
+</div>
+
+
+<!-- 
+NewPP limit report
+Parsed by mw1173
+Cached time: 20161201012247
+Cache expiry: 2592000
+Dynamic content: false
+CPU time usage: 0.108 seconds
+Real time usage: 0.134 seconds
+Preprocessor visited node count: 569/1000000
+Preprocessor generated node count: 0/1500000
+Post‐expand include size: 14044/2097152 bytes
+Template argument size: 569/2097152 bytes
+Highest expansion depth: 7/40
+Expensive parser function count: 0/500
+Lua time usage: 0.046/10.000 seconds
+Lua memory usage: 2.67 MB/50 MB
+-->
+
+<!-- 
+Transclusion expansion time report (%,ms,calls,template)
+100.00%  105.238      1 - -total
+ 65.88%   69.331      1 - Template:Reflist
+ 31.62%   33.279      3 - Template:Cite_book
+ 25.38%   26.710      1 - Template:Quotation
+ 21.39%   22.509      1 - Template:Comma_separated_entries
+ 10.20%   10.739      3 - Template:Cite_journal
+  9.77%   10.279      3 - Template:Cite_web
+  5.87%    6.174      1 - Template:Portal
+  5.03%    5.295      3 - Template:If_empty
+  1.66%    1.742      1 - Template:Refbegin
+-->
+
+<!-- Saved in parser cache with key enwiki:pcache:idhash:38411-0!*!0!!en!4!* and timestamp 20161201012246 and revision id 748923973
+ -->
+<noscript><img src="//en.wikipedia.org/wiki/Special:CentralAutoLogin/start?type=1x1" alt="" title="" width="1" height="1" style="border: none; position: absolute;" /></noscript></div>					<div class="printfooter">
+						Retrieved from "<a dir="ltr" href="https://en.wikipedia.org/w/index.php?title=Regression_testing&amp;oldid=748923973">https://en.wikipedia.org/w/index.php?title=Regression_testing&amp;oldid=748923973</a>"					</div>
+				<div id="catlinks" class="catlinks" data-mw="interface"><div id="mw-normal-catlinks" class="mw-normal-catlinks"><a href="/wiki/Help:Category" title="Help:Category">Categories</a>: <ul><li><a href="/wiki/Category:Software_testing" title="Category:Software testing">Software testing</a></li><li><a href="/wiki/Category:Extreme_programming" title="Category:Extreme programming">Extreme programming</a></li></ul></div></div>				<div class="visualClear"></div>
+							</div>
+		</div>
+		<div id="mw-navigation">
+			<h2>Navigation menu</h2>
+
+			<div id="mw-head">
+									<div id="p-personal" role="navigation" class="" aria-labelledby="p-personal-label">
+						<h3 id="p-personal-label">Personal tools</h3>
+						<ul>
+							<li id="pt-anonuserpage">Not logged in</li><li id="pt-anontalk"><a href="/wiki/Special:MyTalk" title="Discussion about edits from this IP address [n]" accesskey="n">Talk</a></li><li id="pt-anoncontribs"><a href="/wiki/Special:MyContributions" title="A list of edits made from this IP address [y]" accesskey="y">Contributions</a></li><li id="pt-createaccount"><a href="/w/index.php?title=Special:CreateAccount&amp;returnto=Regression+testing" title="You are encouraged to create an account and log in; however, it is not mandatory">Create account</a></li><li id="pt-login"><a href="/w/index.php?title=Special:UserLogin&amp;returnto=Regression+testing" title="You're encouraged to log in; however, it's not mandatory. [o]" accesskey="o">Log in</a></li>						</ul>
+					</div>
+									<div id="left-navigation">
+										<div id="p-namespaces" role="navigation" class="vectorTabs" aria-labelledby="p-namespaces-label">
+						<h3 id="p-namespaces-label">Namespaces</h3>
+						<ul>
+															<li  id="ca-nstab-main" class="selected"><span><a href="/wiki/Regression_testing"  title="View the content page [c]" accesskey="c">Article</a></span></li>
+															<li  id="ca-talk"><span><a href="/wiki/Talk:Regression_testing"  title="Discussion about the content page [t]" accesskey="t" rel="discussion">Talk</a></span></li>
+													</ul>
+					</div>
+										<div id="p-variants" role="navigation" class="vectorMenu emptyPortlet" aria-labelledby="p-variants-label">
+												<h3 id="p-variants-label">
+							<span>Variants</span><a href="#"></a>
+						</h3>
+
+						<div class="menu">
+							<ul>
+															</ul>
+						</div>
+					</div>
+									</div>
+				<div id="right-navigation">
+										<div id="p-views" role="navigation" class="vectorTabs" aria-labelledby="p-views-label">
+						<h3 id="p-views-label">Views</h3>
+						<ul>
+															<li id="ca-view" class="selected"><span><a href="/wiki/Regression_testing" >Read</a></span></li>
+															<li id="ca-edit"><span><a href="/w/index.php?title=Regression_testing&amp;action=edit"  title="Edit this page [e]" accesskey="e">Edit</a></span></li>
+															<li id="ca-history" class="collapsible"><span><a href="/w/index.php?title=Regression_testing&amp;action=history"  title="Past revisions of this page [h]" accesskey="h">View history</a></span></li>
+													</ul>
+					</div>
+										<div id="p-cactions" role="navigation" class="vectorMenu emptyPortlet" aria-labelledby="p-cactions-label">
+						<h3 id="p-cactions-label"><span>More</span><a href="#"></a></h3>
+
+						<div class="menu">
+							<ul>
+															</ul>
+						</div>
+					</div>
+										<div id="p-search" role="search">
+						<h3>
+							<label for="searchInput">Search</label>
+						</h3>
+
+						<form action="/w/index.php" id="searchform">
+							<div id="simpleSearch">
+							<input type="search" name="search" placeholder="Search Wikipedia" title="Search Wikipedia [f]" accesskey="f" id="searchInput"/><input type="hidden" value="Special:Search" name="title"/><input type="submit" name="fulltext" value="Search" title="Search Wikipedia for this text" id="mw-searchButton" class="searchButton mw-fallbackSearchButton"/><input type="submit" name="go" value="Go" title="Go to a page with this exact name if it exists" id="searchButton" class="searchButton"/>							</div>
+						</form>
+					</div>
+									</div>
+			</div>
+			<div id="mw-panel">
+				<div id="p-logo" role="banner"><a class="mw-wiki-logo" href="/wiki/Main_Page"  title="Visit the main page"></a></div>
+						<div class="portal" role="navigation" id='p-navigation' aria-labelledby='p-navigation-label'>
+			<h3 id='p-navigation-label'>Navigation</h3>
+
+			<div class="body">
+									<ul>
+						<li id="n-mainpage-description"><a href="/wiki/Main_Page" title="Visit the main page [z]" accesskey="z">Main page</a></li><li id="n-contents"><a href="/wiki/Portal:Contents" title="Guides to browsing Wikipedia">Contents</a></li><li id="n-featuredcontent"><a href="/wiki/Portal:Featured_content" title="Featured content – the best of Wikipedia">Featured content</a></li><li id="n-currentevents"><a href="/wiki/Portal:Current_events" title="Find background information on current events">Current events</a></li><li id="n-randompage"><a href="/wiki/Special:Random" title="Load a random article [x]" accesskey="x">Random article</a></li><li id="n-sitesupport"><a href="https://donate.wikimedia.org/wiki/Special:FundraiserRedirector?utm_source=donate&amp;utm_medium=sidebar&amp;utm_campaign=C13_en.wikipedia.org&amp;uselang=en" title="Support us">Donate to Wikipedia</a></li><li id="n-shoplink"><a href="//shop.wikimedia.org" title="Visit the Wikipedia store">Wikipedia store</a></li>					</ul>
+							</div>
+		</div>
+			<div class="portal" role="navigation" id='p-interaction' aria-labelledby='p-interaction-label'>
+			<h3 id='p-interaction-label'>Interaction</h3>
+
+			<div class="body">
+									<ul>
+						<li id="n-help"><a href="/wiki/Help:Contents" title="Guidance on how to use and edit Wikipedia">Help</a></li><li id="n-aboutsite"><a href="/wiki/Wikipedia:About" title="Find out about Wikipedia">About Wikipedia</a></li><li id="n-portal"><a href="/wiki/Wikipedia:Community_portal" title="About the project, what you can do, where to find things">Community portal</a></li><li id="n-recentchanges"><a href="/wiki/Special:RecentChanges" title="A list of recent changes in the wiki [r]" accesskey="r">Recent changes</a></li><li id="n-contactpage"><a href="//en.wikipedia.org/wiki/Wikipedia:Contact_us" title="How to contact Wikipedia">Contact page</a></li>					</ul>
+							</div>
+		</div>
+			<div class="portal" role="navigation" id='p-tb' aria-labelledby='p-tb-label'>
+			<h3 id='p-tb-label'>Tools</h3>
+
+			<div class="body">
+									<ul>
+						<li id="t-whatlinkshere"><a href="/wiki/Special:WhatLinksHere/Regression_testing" title="List of all English Wikipedia pages containing links to this page [j]" accesskey="j">What links here</a></li><li id="t-recentchangeslinked"><a href="/wiki/Special:RecentChangesLinked/Regression_testing" rel="nofollow" title="Recent changes in pages linked from this page [k]" accesskey="k">Related changes</a></li><li id="t-upload"><a href="/wiki/Wikipedia:File_Upload_Wizard" title="Upload files [u]" accesskey="u">Upload file</a></li><li id="t-specialpages"><a href="/wiki/Special:SpecialPages" title="A list of all special pages [q]" accesskey="q">Special pages</a></li><li id="t-permalink"><a href="/w/index.php?title=Regression_testing&amp;oldid=748923973" title="Permanent link to this revision of the page">Permanent link</a></li><li id="t-info"><a href="/w/index.php?title=Regression_testing&amp;action=info" title="More information about this page">Page information</a></li><li id="t-wikibase"><a href="https://www.wikidata.org/wiki/Q917415" title="Link to connected data repository item [g]" accesskey="g">Wikidata item</a></li><li id="t-cite"><a href="/w/index.php?title=Special:CiteThisPage&amp;page=Regression_testing&amp;id=748923973" title="Information on how to cite this page">Cite this page</a></li>					</ul>
+							</div>
+		</div>
+			<div class="portal" role="navigation" id='p-coll-print_export' aria-labelledby='p-coll-print_export-label'>
+			<h3 id='p-coll-print_export-label'>Print/export</h3>
+
+			<div class="body">
+									<ul>
+						<li id="coll-create_a_book"><a href="/w/index.php?title=Special:Book&amp;bookcmd=book_creator&amp;referer=Regression+testing">Create a book</a></li><li id="coll-download-as-rdf2latex"><a href="/w/index.php?title=Special:Book&amp;bookcmd=render_article&amp;arttitle=Regression+testing&amp;returnto=Regression+testing&amp;oldid=748923973&amp;writer=rdf2latex">Download as PDF</a></li><li id="t-print"><a href="/w/index.php?title=Regression_testing&amp;printable=yes" title="Printable version of this page [p]" accesskey="p">Printable version</a></li>					</ul>
+							</div>
+		</div>
+			<div class="portal" role="navigation" id='p-lang' aria-labelledby='p-lang-label'>
+			<h3 id='p-lang-label'>Languages</h3>
+
+			<div class="body">
+									<ul>
+						<li class="interlanguage-link interwiki-be"><a href="https://be.wikipedia.org/wiki/%D0%A0%D1%8D%D0%B3%D1%80%D1%8D%D1%81%D1%96%D0%B9%D0%BD%D0%B0%D0%B5_%D1%82%D1%8D%D1%81%D1%82%D0%B0%D0%B2%D0%B0%D0%BD%D0%BD%D0%B5" title="Рэгрэсійнае тэставанне – Belarusian" lang="be" hreflang="be" class="interlanguage-link-target">Беларуская</a></li><li class="interlanguage-link interwiki-ca"><a href="https://ca.wikipedia.org/wiki/Prova_de_regressi%C3%B3" title="Prova de regressió – Catalan" lang="ca" hreflang="ca" class="interlanguage-link-target">Català</a></li><li class="interlanguage-link interwiki-de"><a href="https://de.wikipedia.org/wiki/Regressionstest" title="Regressionstest – German" lang="de" hreflang="de" class="interlanguage-link-target">Deutsch</a></li><li class="interlanguage-link interwiki-et"><a href="https://et.wikipedia.org/wiki/Regressioonitestimine" title="Regressioonitestimine – Estonian" lang="et" hreflang="et" class="interlanguage-link-target">Eesti</a></li><li class="interlanguage-link interwiki-es"><a href="https://es.wikipedia.org/wiki/Pruebas_de_regresi%C3%B3n" title="Pruebas de regresión – Spanish" lang="es" hreflang="es" class="interlanguage-link-target">Español</a></li><li class="interlanguage-link interwiki-fa"><a href="https://fa.wikipedia.org/wiki/%D8%A2%D8%B2%D9%85%D9%88%D9%86_%D8%B1%DA%AF%D8%B1%D8%B3%DB%8C%D9%88%D9%86" title="آزمون رگرسیون – Persian" lang="fa" hreflang="fa" class="interlanguage-link-target">فارسی</a></li><li class="interlanguage-link interwiki-fr"><a href="https://fr.wikipedia.org/wiki/Test_de_r%C3%A9gression" title="Test de régression – French" lang="fr" hreflang="fr" class="interlanguage-link-target">Français</a></li><li class="interlanguage-link interwiki-ko"><a href="https://ko.wikipedia.org/wiki/%ED%9A%8C%EA%B7%80_%ED%85%8C%EC%8A%A4%ED%8A%B8" title="회귀 테스트 – Korean" lang="ko" hreflang="ko" class="interlanguage-link-target">한국어</a></li><li class="interlanguage-link interwiki-ia"><a href="https://ia.wikipedia.org/wiki/Proba_de_regression" title="Proba de regression – Interlingua" lang="ia" hreflang="ia" class="interlanguage-link-target">Interlingua</a></li><li class="interlanguage-link interwiki-it"><a href="https://it.wikipedia.org/wiki/Collaudo_del_software#Il_collaudo_di_regressione" title="Collaudo del software – Italian" lang="it" hreflang="it" class="interlanguage-link-target">Italiano</a></li><li class="interlanguage-link interwiki-he"><a href="https://he.wikipedia.org/wiki/%D7%91%D7%93%D7%99%D7%A7%D7%95%D7%AA_%D7%A0%D7%A1%D7%99%D7%92%D7%94" title="בדיקות נסיגה – Hebrew" lang="he" hreflang="he" class="interlanguage-link-target">עברית</a></li><li class="interlanguage-link interwiki-lt"><a href="https://lt.wikipedia.org/wiki/Regresija_(klaida)" title="Regresija (klaida) – Lithuanian" lang="lt" hreflang="lt" class="interlanguage-link-target">Lietuvių</a></li><li class="interlanguage-link interwiki-nl"><a href="https://nl.wikipedia.org/wiki/Regressietest" title="Regressietest – Dutch" lang="nl" hreflang="nl" class="interlanguage-link-target">Nederlands</a></li><li class="interlanguage-link interwiki-pt"><a href="https://pt.wikipedia.org/wiki/Teste_de_regress%C3%A3o" title="Teste de regressão – Portuguese" lang="pt" hreflang="pt" class="interlanguage-link-target">Português</a></li><li class="interlanguage-link interwiki-ru"><a href="https://ru.wikipedia.org/wiki/%D0%A0%D0%B5%D0%B3%D1%80%D0%B5%D1%81%D1%81%D0%B8%D0%BE%D0%BD%D0%BD%D0%BE%D0%B5_%D1%82%D0%B5%D1%81%D1%82%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5" title="Регрессионное тестирование – Russian" lang="ru" hreflang="ru" class="interlanguage-link-target">Русский</a></li><li class="interlanguage-link interwiki-sv"><a href="https://sv.wikipedia.org/wiki/Regressionstestning" title="Regressionstestning – Swedish" lang="sv" hreflang="sv" class="interlanguage-link-target">Svenska</a></li><li class="interlanguage-link interwiki-tr"><a href="https://tr.wikipedia.org/wiki/Regresyon_Testi" title="Regresyon Testi – Turkish" lang="tr" hreflang="tr" class="interlanguage-link-target">Türkçe</a></li><li class="interlanguage-link interwiki-uk"><a href="https://uk.wikipedia.org/wiki/%D0%A0%D0%B5%D0%B3%D1%80%D0%B5%D1%81%D0%B8%D0%B2%D0%BD%D0%B5_%D1%82%D0%B5%D1%81%D1%82%D1%83%D0%B2%D0%B0%D0%BD%D0%BD%D1%8F" title="Регресивне тестування – Ukrainian" lang="uk" hreflang="uk" class="interlanguage-link-target">Українська</a></li><li class="interlanguage-link interwiki-zh"><a href="https://zh.wikipedia.org/wiki/%E5%9B%9E%E5%BD%92%E6%B5%8B%E8%AF%95" title="回归测试 – Chinese" lang="zh" hreflang="zh" class="interlanguage-link-target">中文</a></li><li class="uls-p-lang-dummy"><a href="#"></a></li>					</ul>
+				<div class='after-portlet after-portlet-lang'><span class="wb-langlinks-edit wb-langlinks-link"><a href="https://www.wikidata.org/wiki/Q917415#sitelinks-wikipedia" title="Edit interlanguage links" class="wbc-editpage">Edit links</a></span></div>			</div>
+		</div>
+				</div>
+		</div>
+		<div id="footer" role="contentinfo">
+							<ul id="footer-info">
+											<li id="footer-info-lastmod"> This page was last modified on 11 November 2016, at 05:56.</li>
+											<li id="footer-info-copyright">Text is available under the <a rel="license" href="//en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License">Creative Commons Attribution-ShareAlike License</a><a rel="license" href="//creativecommons.org/licenses/by-sa/3.0/" style="display:none;"></a>;
+additional terms may apply.  By using this site, you agree to the <a href="//wikimediafoundation.org/wiki/Terms_of_Use">Terms of Use</a> and <a href="//wikimediafoundation.org/wiki/Privacy_policy">Privacy Policy</a>. Wikipedia® is a registered trademark of the <a href="//www.wikimediafoundation.org/">Wikimedia Foundation, Inc.</a>, a non-profit organization.</li>
+									</ul>
+							<ul id="footer-places">
+											<li id="footer-places-privacy"><a href="https://wikimediafoundation.org/wiki/Privacy_policy" class="extiw" title="wmf:Privacy policy">Privacy policy</a></li>
+											<li id="footer-places-about"><a href="/wiki/Wikipedia:About" title="Wikipedia:About">About Wikipedia</a></li>
+											<li id="footer-places-disclaimer"><a href="/wiki/Wikipedia:General_disclaimer" title="Wikipedia:General disclaimer">Disclaimers</a></li>
+											<li id="footer-places-contact"><a href="//en.wikipedia.org/wiki/Wikipedia:Contact_us">Contact Wikipedia</a></li>
+											<li id="footer-places-developers"><a href="https://www.mediawiki.org/wiki/Special:MyLanguage/How_to_contribute">Developers</a></li>
+											<li id="footer-places-cookiestatement"><a href="https://wikimediafoundation.org/wiki/Cookie_statement">Cookie statement</a></li>
+											<li id="footer-places-mobileview"><a href="//en.m.wikipedia.org/w/index.php?title=Regression_testing&amp;mobileaction=toggle_view_mobile" class="noprint stopMobileRedirectToggle">Mobile view</a></li>
+									</ul>
+										<ul id="footer-icons" class="noprint">
+											<li id="footer-copyrightico">
+							<a href="https://wikimediafoundation.org/"><img src="/static/images/wikimedia-button.png" srcset="/static/images/wikimedia-button-1.5x.png 1.5x, /static/images/wikimedia-button-2x.png 2x" width="88" height="31" alt="Wikimedia Foundation"/></a>						</li>
+											<li id="footer-poweredbyico">
+							<a href="//www.mediawiki.org/"><img src="/static/images/poweredby_mediawiki_88x31.png" alt="Powered by MediaWiki" srcset="/static/images/poweredby_mediawiki_132x47.png 1.5x, /static/images/poweredby_mediawiki_176x62.png 2x" width="88" height="31"/></a>						</li>
+									</ul>
+						<div style="clear:both"></div>
+		</div>
+		<script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgBackendResponseTime":51,"wgHostname":"mw1268"});});</script>
+	</body>
+</html>

--- a/h/static/scripts/annotator/anchoring/test/html-baselines/wikipedia-regression-testing.json
+++ b/h/static/scripts/annotator/anchoring/test/html-baselines/wikipedia-regression-testing.json
@@ -1,0 +1,320 @@
+{
+   "total" : 5,
+   "rows" : [
+      {
+         "id" : "LOCXbsOCEeaQl6f6fQh87Q",
+         "user" : "acct:mark@localhost",
+         "text" : "Footer",
+         "tags" : [],
+         "uri" : "https://en.wikipedia.org/wiki/Regression_testing",
+         "group" : "__world__",
+         "target" : [
+            {
+               "source" : "https://en.wikipedia.org/wiki/Regression_testing",
+               "selector" : [
+                  {
+                     "conformsTo" : "https://tools.ietf.org/html/rfc3236",
+                     "value" : "footer-info-lastmod",
+                     "type" : "FragmentSelector"
+                  },
+                  {
+                     "endOffset" : 48,
+                     "endContainer" : "/div[5]/ul[1]/li[1]",
+                     "startOffset" : 32,
+                     "startContainer" : "/div[5]/ul[1]/li[1]",
+                     "type" : "RangeSelector"
+                  },
+                  {
+                     "start" : 11881,
+                     "type" : "TextPositionSelector",
+                     "end" : 11897
+                  },
+                  {
+                     "suffix" : ", at 05:56.\n\t\t\t\t\t\t\t\t\t\t\tText is a",
+                     "exact" : "11 November 2016",
+                     "type" : "TextQuoteSelector",
+                     "prefix" : " This page was last modified on "
+                  }
+               ]
+            }
+         ],
+         "links" : {
+            "html" : "http://localhost:5000/a/LOCXbsOCEeaQl6f6fQh87Q",
+            "json" : "http://localhost:5000/api/annotations/LOCXbsOCEeaQl6f6fQh87Q"
+         },
+         "updated" : "2016-12-16T11:24:14.673557+00:00",
+         "document" : {
+            "title" : [
+               "Regression testing - Wikipedia"
+            ]
+         },
+         "permissions" : {
+            "read" : [
+               "group:__world__"
+            ],
+            "admin" : [
+               "acct:mark@localhost"
+            ],
+            "delete" : [
+               "acct:mark@localhost"
+            ],
+            "update" : [
+               "acct:mark@localhost"
+            ]
+         },
+         "created" : "2016-12-16T11:24:14.673557+00:00"
+      },
+      {
+         "permissions" : {
+            "admin" : [
+               "acct:mark@localhost"
+            ],
+            "read" : [
+               "group:__world__"
+            ],
+            "delete" : [
+               "acct:mark@localhost"
+            ],
+            "update" : [
+               "acct:mark@localhost"
+            ]
+         },
+         "created" : "2016-12-16T11:23:56.096030+00:00",
+         "links" : {
+            "html" : "http://localhost:5000/a/Ic6rNsOCEeaQl--ofD7IUg",
+            "json" : "http://localhost:5000/api/annotations/Ic6rNsOCEeaQl--ofD7IUg"
+         },
+         "updated" : "2016-12-16T11:23:56.096030+00:00",
+         "document" : {
+            "title" : [
+               "Regression testing - Wikipedia"
+            ]
+         },
+         "uri" : "https://en.wikipedia.org/wiki/Regression_testing",
+         "target" : [
+            {
+               "source" : "https://en.wikipedia.org/wiki/Regression_testing",
+               "selector" : [
+                  {
+                     "type" : "FragmentSelector",
+                     "conformsTo" : "https://tools.ietf.org/html/rfc3236",
+                     "value" : "mw-content-text"
+                  },
+                  {
+                     "endContainer" : "/div[3]/div[3]/div[4]/p[8]",
+                     "startContainer" : "/div[3]/div[3]/div[4]/p[8]",
+                     "startOffset" : 0,
+                     "type" : "RangeSelector",
+                     "endOffset" : 232
+                  },
+                  {
+                     "end" : 2960,
+                     "type" : "TextPositionSelector",
+                     "start" : 2728
+                  },
+                  {
+                     "suffix" : ".[3] Although this may be done t",
+                     "exact" : "Therefore, in most software development situations, it is considered good coding practice, when a bug is located and fixed, to record a test that exposes the bug and re-run that test regularly after subsequent changes to the program",
+                     "type" : "TextQuoteSelector",
+                     "prefix" : "ature are made in the redesign.\n"
+                  }
+               ]
+            }
+         ],
+         "group" : "__world__",
+         "id" : "Ic6rNsOCEeaQl--ofD7IUg",
+         "text" : "Body",
+         "user" : "acct:mark@localhost",
+         "tags" : []
+      },
+      {
+         "links" : {
+            "html" : "http://localhost:5000/a/0v-8NMOBEeaQl88x78UnFQ",
+            "json" : "http://localhost:5000/api/annotations/0v-8NMOBEeaQl88x78UnFQ"
+         },
+         "updated" : "2016-12-16T11:21:43.892188+00:00",
+         "document" : {
+            "title" : [
+               "Regression testing - Wikipedia"
+            ]
+         },
+         "created" : "2016-12-16T11:21:43.892188+00:00",
+         "permissions" : {
+            "read" : [
+               "group:__world__"
+            ],
+            "admin" : [
+               "acct:mark@localhost"
+            ],
+            "update" : [
+               "acct:mark@localhost"
+            ],
+            "delete" : [
+               "acct:mark@localhost"
+            ]
+         },
+         "id" : "0v-8NMOBEeaQl88x78UnFQ",
+         "tags" : [],
+         "text" : "Quote",
+         "user" : "acct:mark@localhost",
+         "group" : "__world__",
+         "target" : [
+            {
+               "selector" : [
+                  {
+                     "value" : "mw-content-text",
+                     "conformsTo" : "https://tools.ietf.org/html/rfc3236",
+                     "type" : "FragmentSelector"
+                  },
+                  {
+                     "endOffset" : 156,
+                     "endContainer" : "/div[3]/div[3]/div[4]/blockquote[1]/p[1]",
+                     "type" : "RangeSelector",
+                     "startOffset" : 0,
+                     "startContainer" : "/div[3]/div[3]/div[4]/blockquote[1]/p[1]"
+                  },
+                  {
+                     "start" : 7511,
+                     "type" : "TextPositionSelector",
+                     "end" : 7667
+                  },
+                  {
+                     "prefix" : " execute the test suite cases.\n\n",
+                     "suffix" : ". Theoretically, after each fix ",
+                     "exact" : "Also as a consequence of the introduction of new bugs, program maintenance requires far more system testing per statement written than any other programming",
+                     "type" : "TextQuoteSelector"
+                  }
+               ],
+               "source" : "https://en.wikipedia.org/wiki/Regression_testing"
+            }
+         ],
+         "uri" : "https://en.wikipedia.org/wiki/Regression_testing"
+      },
+      {
+         "id" : "wy1stsOBEeaQlychltExbg",
+         "user" : "acct:mark@localhost",
+         "text" : "Introduction",
+         "tags" : [],
+         "uri" : "https://en.wikipedia.org/wiki/Regression_testing",
+         "target" : [
+            {
+               "selector" : [
+                  {
+                     "value" : "mw-content-text",
+                     "conformsTo" : "https://tools.ietf.org/html/rfc3236",
+                     "type" : "FragmentSelector"
+                  },
+                  {
+                     "endOffset" : 120,
+                     "startContainer" : "/div[3]/div[3]/div[4]/p[2]",
+                     "startOffset" : 0,
+                     "type" : "RangeSelector",
+                     "endContainer" : "/div[3]/div[3]/div[4]/p[2]"
+                  },
+                  {
+                     "start" : 896,
+                     "type" : "TextPositionSelector",
+                     "end" : 1016
+                  },
+                  {
+                     "type" : "TextQuoteSelector",
+                     "suffix" : ".[1] One of the main reasons for",
+                     "exact" : "The purpose of regression testing is to ensure that changes such as those mentioned above have not introduced new faults",
+                     "prefix" : "functional areas of the system.\n"
+                  }
+               ],
+               "source" : "https://en.wikipedia.org/wiki/Regression_testing"
+            }
+         ],
+         "group" : "__world__",
+         "links" : {
+            "html" : "http://localhost:5000/a/wy1stsOBEeaQlychltExbg",
+            "json" : "http://localhost:5000/api/annotations/wy1stsOBEeaQlychltExbg"
+         },
+         "document" : {
+            "title" : [
+               "Regression testing - Wikipedia"
+            ]
+         },
+         "updated" : "2016-12-16T11:21:17.341308+00:00",
+         "created" : "2016-12-16T11:21:17.341308+00:00",
+         "permissions" : {
+            "update" : [
+               "acct:mark@localhost"
+            ],
+            "delete" : [
+               "acct:mark@localhost"
+            ],
+            "read" : [
+               "group:__world__"
+            ],
+            "admin" : [
+               "acct:mark@localhost"
+            ]
+         }
+      },
+      {
+         "uri" : "https://en.wikipedia.org/wiki/Regression_testing",
+         "group" : "__world__",
+         "target" : [
+            {
+               "selector" : [
+                  {
+                     "type" : "FragmentSelector",
+                     "value" : "firstHeading",
+                     "conformsTo" : "https://tools.ietf.org/html/rfc3236"
+                  },
+                  {
+                     "endOffset" : 18,
+                     "endContainer" : "/div[3]/h1[1]",
+                     "startOffset" : 0,
+                     "startContainer" : "/div[3]/h1[1]",
+                     "type" : "RangeSelector"
+                  },
+                  {
+                     "type" : "TextPositionSelector",
+                     "end" : 51,
+                     "start" : 33
+                  },
+                  {
+                     "prefix" : "\t\n\t\t\n\t\t\n\t\t\t\n\n\t\t\t\t\t\t\t\n\t\t\t\t\t\t\n\n\t\t\t",
+                     "exact" : "Regression testing",
+                     "suffix" : "\n\t\t\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t\t\tFrom Wikiped",
+                     "type" : "TextQuoteSelector"
+                  }
+               ],
+               "source" : "https://en.wikipedia.org/wiki/Regression_testing"
+            }
+         ],
+         "text" : "Heading",
+         "user" : "acct:mark@localhost",
+         "tags" : [],
+         "id" : "rvTr_MOBEeaQl9tXcHfSkw",
+         "created" : "2016-12-16T11:20:43.422096+00:00",
+         "permissions" : {
+            "admin" : [
+               "acct:mark@localhost"
+            ],
+            "read" : [
+               "group:__world__"
+            ],
+            "delete" : [
+               "acct:mark@localhost"
+            ],
+            "update" : [
+               "acct:mark@localhost"
+            ]
+         },
+         "document" : {
+            "title" : [
+               "Regression testing - Wikipedia"
+            ]
+         },
+         "updated" : "2016-12-16T11:20:43.422096+00:00",
+         "links" : {
+            "html" : "http://localhost:5000/a/rvTr_MOBEeaQl9tXcHfSkw",
+            "json" : "http://localhost:5000/api/annotations/rvTr_MOBEeaQl9tXcHfSkw"
+         }
+      }
+   ]
+}


### PR DESCRIPTION
**Blocks https://github.com/hypothesis/client/pull/159**

Add a set of baseline tests for HTML anchoring which attempt to anchor a
set of selectors for an annotation using data in the format returned by
the Hypothesis API and then verify that the same selectors are generated
when re-describing the anchored range.

The purpose of these tests is to help ensure that any changes to anchoring do not result in unexpected changes to the selectors that are generated.

The initial commit includes two test pages and associated annotations - a minimal web page as a basic sanity check of the selectors produced by anchoring in HTML documents and a more representative web page from Wikipedia.