### PR TITLE
Move the list of connected frames to the Redux store

### DIFF
--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -38,6 +38,7 @@ var thunk = require('redux-thunk').default;
 
 var reducers = require('./reducers');
 var annotationsReducer = require('./reducers/annotations');
+var framesReducer = require('./reducers/frames');
 var selectionReducer = require('./reducers/selection');
 var sessionReducer = require('./reducers/session');
 var viewerReducer = require('./reducers/viewer');
@@ -93,6 +94,7 @@ module.exports = function ($rootScope, settings) {
   //
   var actionCreators = redux.bindActionCreators(Object.assign({},
     annotationsReducer.actions,
+    framesReducer.actions,
     selectionReducer.actions,
     sessionReducer.actions,
     viewerReducer.actions
@@ -112,6 +114,8 @@ module.exports = function ($rootScope, settings) {
     annotationExists: annotationsReducer.annotationExists,
     findIDsForTags: annotationsReducer.findIDsForTags,
     savedAnnotations: annotationsReducer.savedAnnotations,
+
+    frames: framesReducer.frames,
 
     isSidebar: viewerReducer.isSidebar,
   }, store.getState);

--- a/h/static/scripts/directive/help-panel.js
+++ b/h/static/scripts/directive/help-panel.js
@@ -11,15 +11,15 @@ module.exports = function () {
     bindToController: true,
     controllerAs: 'vm',
     // @ngInject
-    controller: function ($scope, $window, frameSync, serviceUrl) {
+    controller: function ($scope, $window, annotationUI, serviceUrl) {
       this.userAgent = $window.navigator.userAgent;
       this.version = '__VERSION__';  // replaced by versionify
       this.dateTime = new Date();
       this.serviceUrl = serviceUrl;
 
-      $scope.$watchCollection(
+      $scope.$watch(
         function () {
-          return frameSync.frames;
+          return annotationUI.frames();
         },
         function (frames) {
           if (frames.length === 0) {

--- a/h/static/scripts/directive/share-dialog.js
+++ b/h/static/scripts/directive/share-dialog.js
@@ -3,7 +3,7 @@
 var VIA_PREFIX = 'https://via.hypothes.is/';
 
 // @ngInject
-function ShareDialogController($scope, $element, frameSync) {
+function ShareDialogController($scope, $element, annotationUI) {
   var self = this;
 
   function updateViaLink(frames) {
@@ -24,7 +24,7 @@ function ShareDialogController($scope, $element, frameSync) {
   viaInput.focus();
   viaInput.select();
 
-  $scope.$watchCollection(function () { return frameSync.frames; },
+  $scope.$watch(function () { return annotationUI.frames(); },
     updateViaLink);
 }
 

--- a/h/static/scripts/directive/test/share-dialog-test.js
+++ b/h/static/scripts/directive/test/share-dialog-test.js
@@ -5,28 +5,30 @@ var angular = require('angular');
 var util = require('./util');
 
 describe('shareDialog', function () {
-  var fakeFrameSync;
+  var fakeAnnotationUI;
 
   beforeEach(function () {
-    fakeFrameSync = { frames: [] };
+    fakeAnnotationUI = { frames: sinon.stub().returns([]) };
 
     angular.module('h', [])
       .directive('shareDialog', require('../share-dialog'))
-      .value('frameSync', fakeFrameSync)
+      .value('annotationUI', fakeAnnotationUI)
       .value('urlEncodeFilter', function (val) { return val; });
     angular.mock.module('h');
   });
 
   it('generates new via link', function () {
     var element = util.createDirective(document, 'shareDialog', {});
-    fakeFrameSync.frames.push({ uri: 'http://example.com' });
+    fakeAnnotationUI.frames.returns([{ uri: 'http://example.com' }]);
     element.scope.$digest();
     assert.equal(element.ctrl.viaPageLink, 'https://via.hypothes.is/http://example.com');
   });
 
   it('does not generate new via link if already on via', function () {
     var element = util.createDirective(document, 'shareDialog', {});
-    fakeFrameSync.frames.push({ uri: 'https://via.hypothes.is/http://example.com' });
+    fakeAnnotationUI.frames.returns([{
+      uri: 'https://via.hypothes.is/http://example.com',
+    }]);
     element.scope.$digest();
     assert.equal(element.ctrl.viaPageLink, 'https://via.hypothes.is/http://example.com');
   });

--- a/h/static/scripts/frame-sync.js
+++ b/h/static/scripts/frame-sync.js
@@ -40,9 +40,6 @@ function formatAnnot(ann) {
 // @ngInject
 function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
 
-  // List of frames currently connected to the sidebar
-  var frames = [];
-
   // Set of tags of annotations that are currently loaded into the frame
   var inFrame = new Set();
 
@@ -157,14 +154,10 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
         });
       }
 
-      // The `frames` list is currently stored by this service but should in
-      // future be moved to the app state.
-      $rootScope.$apply(function () {
-        frames.push({
-          uri: info.uri,
-          searchUris: searchUris,
-          documentFingerprint: documentFingerprint,
-        });
+      annotationUI.connectFrame({
+        uri: info.uri,
+        searchUris: searchUris,
+        documentFingerprint: documentFingerprint,
       });
     });
   }
@@ -201,12 +194,6 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
   this.scrollToAnnotation = function (tag) {
     bridge.call('scrollToAnnotation', tag);
   };
-
-  /**
-   * List of frames that are connected to the app.
-   * @type {FrameInfo}
-   */
-  this.frames = frames;
 }
 
 module.exports = {

--- a/h/static/scripts/reducers/frames.js
+++ b/h/static/scripts/reducers/frames.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var util = require('./util');
+
+function init() {
+  return {
+    // The list of frames connected to the sidebar app
+    frames: [],
+  };
+}
+
+var update = {
+  CONNECT_FRAME: function (state, action) {
+    return {frames: state.frames.concat(action.frame)};
+  },
+};
+
+var actions = util.actionTypes(update);
+
+/**
+ * Add a frame to the list of frames currently connected to the sidebar app.
+ */
+function connectFrame(frame) {
+  return {type: actions.CONNECT_FRAME, frame: frame};
+}
+
+/**
+ * Return the list of frames currently connected to the sidebar app.
+ */
+function frames(state) {
+  return state.frames;
+}
+
+module.exports = {
+  init: init,
+  update: update,
+
+  actions: {
+    connectFrame: connectFrame,
+  },
+
+  // Selectors
+  frames: frames,
+};

--- a/h/static/scripts/reducers/index.js
+++ b/h/static/scripts/reducers/index.js
@@ -18,6 +18,7 @@
  */
 
 var annotations = require('./annotations');
+var frames = require('./frames');
 var selection = require('./selection');
 var session = require('./session');
 var viewer = require('./viewer');
@@ -27,6 +28,7 @@ function init(settings) {
   return Object.assign(
     {},
     annotations.init(),
+    frames.init(),
     selection.init(settings),
     session.init(),
     viewer.init()
@@ -35,6 +37,7 @@ function init(settings) {
 
 var update = util.createReducer(Object.assign(
   annotations.update,
+  frames.update,
   selection.update,
   session.update,
   viewer.update

--- a/h/static/scripts/reducers/test/frames-test.js
+++ b/h/static/scripts/reducers/test/frames-test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var frames = require('../frames');
+var util = require('../util');
+
+var init = frames.init;
+var actions = frames.actions;
+var update = util.createReducer(frames.update);
+
+describe('frames reducer', function () {
+  describe('#connectFrame', function () {
+    it('adds the frame to the list of connected frames', function () {
+      var frame = {uri: 'http://example.com'};
+      var state = update(init(), actions.connectFrame(frame));
+      assert.deepEqual(frames.frames(state), [frame]);
+    });
+  });
+});

--- a/h/static/scripts/test/frame-sync-test.js
+++ b/h/static/scripts/test/frame-sync-test.js
@@ -54,6 +54,7 @@ describe('FrameSync', function () {
 
   beforeEach(function () {
     fakeAnnotationUI = fakeStore({annotations: []}, {
+      connectFrame: sinon.stub(),
       findIDsForTags: sinon.stub(),
       focusAnnotations: sinon.stub(),
       selectAnnotations: sinon.stub(),
@@ -174,11 +175,11 @@ describe('FrameSync', function () {
 
       fakeBridge.emit('connect', fakeChannel);
 
-      assert.deepEqual(frameSync.frames, [{
+      assert.calledWith(fakeAnnotationUI.connectFrame, {
         documentFingerprint: undefined,
         searchUris: [frameInfo.uri],
         uri: frameInfo.uri,
-      }]);
+      });
     });
 
     it('adds the document fingerprint for PDFs', function () {
@@ -186,11 +187,11 @@ describe('FrameSync', function () {
 
       fakeBridge.emit('connect', fakeChannel);
 
-      assert.deepEqual(frameSync.frames, [{
+      assert.calledWith(fakeAnnotationUI.connectFrame, {
         documentFingerprint: frameInfo.metadata.documentFingerprint,
         searchUris: [frameInfo.uri, 'urn:1234'],
         uri: frameInfo.uri,
-      }]);
+      });
     });
   });
 

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -160,7 +160,7 @@ module.exports = function WidgetController(
   }
 
   function isLoading() {
-    if (!frameSync.frames.some(function (frame) { return frame.uri; })) {
+    if (!annotationUI.frames().some(function (frame) { return frame.uri; })) {
       // The document's URL isn't known so the document must still be loading.
       return true;
     }
@@ -262,12 +262,12 @@ module.exports = function WidgetController(
       return;
     }
     annotationUI.clearSelectedAnnotations();
-    loadAnnotations(frameSync.frames);
+    loadAnnotations(annotationUI.frames());
   });
 
   // Watch anything that may require us to reload annotations.
-  $scope.$watchCollection(function () {
-    return frameSync.frames;
+  $scope.$watch(function () {
+    return annotationUI.frames();
   }, loadAnnotations);
 
   $scope.setCollapsed = function (id, collapsed) {


### PR DESCRIPTION
_This is part of https://github.com/hypothesis/client/issues/176_

Move metadata about the frames that are connected to the sidebar app,
such as the document's URL and fingerprint, to the central app state
store.

This is part of an effort to unify how important application state is
managed.