### PR TITLE
Update tag service urls

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -413,7 +413,7 @@ function AnnotationController(
     });
   };
 
-  vm.tagStreamURL = function(tag) {
+  vm.tagSearchURL = function(tag) {
     return serviceUrl('search.tag', {tag: tag});
   };
 

--- a/h/static/scripts/service-url.js
+++ b/h/static/scripts/service-url.js
@@ -15,7 +15,7 @@ var ROUTES = {
   'groups.new': 'groups/new',
   'help': 'docs/help',
   'signup': 'signup',
-  'search.tag': 'stream?q=tag::tag',
+  'search.tag': 'search?q=tag:":tag"',
   'user': 'u/:user',
 };
 

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -95,7 +95,7 @@
        ng-if="(vm.canCollapseBody || vm.state().tags.length) && !vm.editing()">
     <ul class="tag-list">
       <li class="tag-item" ng-repeat="tag in vm.state().tags">
-        <a ng-href="{{vm.tagStreamURL(tag)}}" target="_blank">{{tag}}</a>
+        <a ng-href="{{vm.tagSearchURL(tag)}}" target="_blank">{{tag}}</a>
       </li>
     </ul>
     <div class="u-stretch"></div>


### PR DESCRIPTION
This updates the tag links in the client to point to `/search?tag:"{value}"`.

Once this is pushed out with a new version of the browser extension (and embed), we should wait another few weeks and then remove [the redirect in h](https://github.com/hypothesis/h/blob/25a6b55b8f8512952c67a429db64c9bd7f7ade28/h/views/main.py#L61-L68).