### PR TITLE
Remove initial redirect when sidebar loads

### DIFF
--- a/h/static/scripts/app.js
+++ b/h/static/scripts/app.js
@@ -63,13 +63,6 @@ function configureRoutes($routeProvider) {
       reloadOnSearch: false,
       resolve: resolve,
     });
-  $routeProvider.when('/viewer',
-    {
-      controller: 'WidgetController',
-      template: VIEWER_TEMPLATE,
-      reloadOnSearch: false,
-      resolve: resolve,
-    });
   $routeProvider.when('/stream',
     {
       controller: 'StreamController',
@@ -77,8 +70,11 @@ function configureRoutes($routeProvider) {
       reloadOnSearch: false,
       resolve: resolve,
     });
-  return $routeProvider.otherwise({
-    redirectTo: '/viewer',
+  $routeProvider.otherwise({
+    controller: 'WidgetController',
+    template: VIEWER_TEMPLATE,
+    reloadOnSearch: false,
+    resolve: resolve,
   });
 }
 


### PR DESCRIPTION
Avoid redirecting to '/viewer' when the sidebar loads.

This redirect is unnecessary since the sidebar never changes its mode
once loaded and it caused the viewer embedded on a page to fail to load
when restoring a closed tab in Chrome.

This may also resolve issues where the user agent disallows the
`window.history.replaceState` call in certain situations (search prod-client reports on
Sentry for "replaceState")

Fixes #178

Note - As a consequence of this, the URL that is reported for the sidebar in Google Analytics will change. Those page views are currently reported as hits against `/viewer` but will be reported as hits against `app.html` instead.

----

Steps to reproduce:

1. In Chrome, go to http://localhost:5000/docs/help
2. Once the page and the sidebar have loaded, close it
3. Re-open the tab with Ctrl/Cmd+Shift+T . On master, the viewer fails to load. In this branch, the sidebar should load successfully.