### PR TITLE
Explicitly add Authorization header to API requests

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -79,12 +79,9 @@ function configureRoutes($routeProvider) {
 }
 
 // @ngInject
-function configureHttp($httpProvider, jwtInterceptorProvider) {
+function configureHttp($httpProvider) {
   // Use the Pyramid XSRF header name
   $httpProvider.defaults.xsrfHeaderName = 'X-CSRF-Token';
-  // Setup JWT tokens for API requests
-  $httpProvider.interceptors.push('jwtInterceptor');
-  jwtInterceptorProvider.tokenGetter = require('./auth').tokenGetter;
 }
 
 // @ngInject
@@ -161,7 +158,7 @@ module.exports = angular.module('h', [
 
   .service('annotationMapper', require('./annotation-mapper'))
   .service('annotationUI', require('./annotation-ui'))
-  .service('auth', require('./auth').service)
+  .service('auth', require('./auth'))
   .service('bridge', require('../shared/bridge'))
   .service('drafts', require('./drafts'))
   .service('features', require('./features'))

--- a/src/sidebar/test/store-test.js
+++ b/src/sidebar/test/store-test.js
@@ -22,12 +22,44 @@ describe('store', function () {
       })));
   });
 
-  beforeEach(angular.mock.module('h'));
-
-  beforeEach(angular.mock.module(function ($provide) {
+  beforeEach(function () {
     sandbox = sinon.sandbox.create();
-    $provide.value('settings', {apiUrl: 'http://example.com/api'});
-  }));
+
+    var fakeTokenGetter = function () {
+      return Promise.resolve('faketoken');
+    };
+
+    angular.mock.module('h', {
+      auth: {
+        tokenGetter: fakeTokenGetter,
+      },
+      settings: {apiUrl: 'http://example.com/api'},
+    });
+  });
+
+  /**
+   * Wrapper around $httpBackend.flush() which allows for methods under test
+   * needing to fetch data using Promise-returning functions before they
+   * actually make an HTTP request.
+   *
+   * @param {number} [maxTicks] - Maximum number of event loop turns to wait.
+   */
+  function flushHttpRequests(maxTicks) {
+    try {
+      $httpBackend.flush();
+      return null;
+    } catch (err) {
+      if (maxTicks === 0) {
+        throw new Error('No HTTP request was made');
+      }
+      // No HTTP request was made yet. Try again on the next tick of the event
+      // loop.
+      maxTicks = maxTicks || 5;
+      return Promise.resolve().then(function () {
+        flushHttpRequests(maxTicks - 1);
+      });
+    }
+  }
 
   afterEach(function () {
     $httpBackend.verifyNoOutstandingExpectation();
@@ -66,32 +98,41 @@ describe('store', function () {
   }));
 
   it('saves a new annotation', function () {
-    store.annotation.create({}, {}).then(function (saved) {
+    var done = store.annotation.create({}, {}).then(function (saved) {
       assert.isNotNull(saved.id);
     });
+
     $httpBackend.expectPOST('http://example.com/api/annotations')
       .respond(function () {
         return [201, {id: 'new-id'}, {}];
       });
-    $httpBackend.flush();
+    flushHttpRequests();
+
+    return done;
   });
 
   it('updates an annotation', function () {
-    store.annotation.update({id: 'an-id'}, {text: 'updated'});
+    var done = store.annotation.update({id: 'an-id'}, {text: 'updated'});
+
     $httpBackend.expectPUT('http://example.com/api/annotations/an-id')
       .respond(function () {
         return [200, {}, {}];
       });
-    $httpBackend.flush();
+    flushHttpRequests();
+
+    return done;
   });
 
   it('deletes an annotation', function () {
-    store.annotation.delete({id: 'an-id'}, {});
+    var done = store.annotation.delete({id: 'an-id'}, {});
+
     $httpBackend.expectDELETE('http://example.com/api/annotations/an-id')
       .respond(function () {
         return [200, {}, {}];
       });
-    $httpBackend.flush();
+    flushHttpRequests();
+
+    return done;
   });
 
   it('removes internal properties before sending data to the server', function () {
@@ -100,20 +141,26 @@ describe('store', function () {
       $notme: 'nooooo!',
       allowed: 123,
     };
-    store.annotation.create({}, annotation);
+    var done = store.annotation.create({}, annotation);
+
     $httpBackend.expectPOST('http://example.com/api/annotations', {
       allowed: 123,
     })
-      .respond(function () { return {id: 'test'}; });
-    $httpBackend.flush();
+      .respond(function () { return [200, {id: 'test'}, {}]; });
+    flushHttpRequests();
+
+    return done;
   });
 
   // Our backend service interprets semicolons as query param delimiters, so we
   // must ensure to encode them in the query string.
   it('encodes semicolons in query parameters', function () {
-    store.search({'uri': 'http://example.com/?foo=bar;baz=qux'});
+    var done = store.search({'uri': 'http://example.com/?foo=bar;baz=qux'});
+
     $httpBackend.expectGET('http://example.com/api/search?uri=http%3A%2F%2Fexample.com%2F%3Ffoo%3Dbar%3Bbaz%3Dqux')
       .respond(function () { return [200, {}, {}]; });
-    $httpBackend.flush();
+    flushHttpRequests();
+
+    return done;
   });
 });


### PR DESCRIPTION
Remove the global HTTP interceptor provided by angular-jwt which added
the Authorization header to API requests and replace it with explicit
logic in store.js to do the same thing.

This will enable replacing the JWT tokens with opaque access tokens when
using a publisher-provided grant token for authentication.

It also provides a more explicit way to only include the access token
with requests to the API, rather than filtering based on the URL prefix
of the request in the `tokenGetter` implementation.

 * Remove angular-jwt's HTTP interceptor and replace it with logic in
   store.js to explicitly fetch an access token using the `auth` module
   and add an Authorization header to API requests.

 * Convert standalone functions and global variables in auth.js to
   methods on the auth service. This will enable swapping out the
   current auth service implementation which uses cookies + CSRF
   for authentication with one that uses the OAuth grant token.

 * Fix several cases in store-test.js where functions that made
   assertions inside Promise callbacks did not explicitly wait for the
   Promise to resolve before finishing the test.