### PR TITLE
Only import known config params from the host page

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -1,21 +1,20 @@
 'use strict';
 
-var queryString = require('query-string');
-
 var addAnalytics = require('./ga');
 require('../shared/polyfills');
 
 var raven;
 
-// Initialize Raven. This is required at the top of this file
-// so that it happens early in the app's startup flow
-var configParam = queryString.parse(window.location.search).config || 'null';
 var settings = require('../shared/settings')(document);
-Object.assign(settings, JSON.parse(configParam));
 if (settings.raven) {
+  // Initialize Raven. This is required at the top of this file
+  // so that it happens early in the app's startup flow
   raven = require('./raven');
   raven.init(settings.raven);
 }
+
+var hostPageConfig = require('./host-config');
+Object.assign(settings, hostPageConfig(window));
 
 // Disable Angular features that are not compatible with CSP.
 //

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -17,6 +17,10 @@ function hostPageConfig(window) {
     // Direct-linked annotation ID
     'annotations',
 
+    // Config param added by the extension, Via etc.  indicating how Hypothesis
+    // was added to the page.
+    'appType',
+
     // Config params documented at
     // https://github.com/hypothesis/client/blob/master/docs/config.md
     'openLoginForm',

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var queryString = require('query-string');
+
+/**
+ * Return the app configuration specified by the frame embedding the Hypothesis
+ * client.
+ */
+function hostPageConfig(window) {
+  var configJSON = queryString.parse(window.location.search).config;
+  var config = JSON.parse(configJSON || '{}');
+
+  // Known configuration parameters which we will import from the host page.
+  // Note that since the host page is untrusted code, the filtering needs to
+  // be done here.
+  var paramWhiteList = [
+    // Direct-linked annotation ID
+    'annotations',
+
+    // Config params documented at
+    // https://github.com/hypothesis/client/blob/master/docs/config.md
+    'openLoginForm',
+    'openSidebar',
+    'showHighlights',
+  ];
+
+  return Object.keys(config).reduce(function (result, key) {
+    if (paramWhiteList.indexOf(key) !== -1) {
+      result[key] = config[key];
+    }
+    return result;
+  }, {});
+}
+
+module.exports = hostPageConfig;

--- a/src/sidebar/test/host-config-test.js
+++ b/src/sidebar/test/host-config-test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var hostPageConfig = require('../host-config');
+
+function fakeWindow(config) {
+  return {
+    location: {
+      search: '?config=' + JSON.stringify(config),
+    },
+  };
+}
+
+describe('hostPageConfig', function () {
+  it('parses config from location string and returns whitelisted params', function () {
+    var window_ = fakeWindow({
+      annotations: '1234',
+      openSidebar: true,
+      openLoginForm: true,
+      showHighlights: true,
+    });
+
+    assert.deepEqual(hostPageConfig(window_), {
+      annotations: '1234',
+      openSidebar: true,
+      openLoginForm: true,
+      showHighlights: true,
+    });
+  });
+
+  it('ignores non-whitelisted config params', function () {
+    var window_ = fakeWindow({
+      apiUrl: 'https://not-the-hypothesis/api',
+    });
+
+    assert.deepEqual(hostPageConfig(window_), {});
+  });
+});

--- a/src/sidebar/test/host-config-test.js
+++ b/src/sidebar/test/host-config-test.js
@@ -14,6 +14,7 @@ describe('hostPageConfig', function () {
   it('parses config from location string and returns whitelisted params', function () {
     var window_ = fakeWindow({
       annotations: '1234',
+      appType: 'bookmarklet',
       openSidebar: true,
       openLoginForm: true,
       showHighlights: true,
@@ -21,6 +22,7 @@ describe('hostPageConfig', function () {
 
     assert.deepEqual(hostPageConfig(window_), {
       annotations: '1234',
+      appType: 'bookmarklet',
       openSidebar: true,
       openLoginForm: true,
       showHighlights: true,


### PR DESCRIPTION
The previous method of importing config params allowed the host page to
override any configuration parameter provided by the service hosting the
client's app.html file, potentially introducing vulnerabilities.

This PR limits the client to importing only config parameters from a
whitelist. This also has the benefit of clearly documenting all the
parameters that can come from the host page in one place in the code.