### PR TITLE
Remove auth => session dependency

### DIFF
--- a/src/sidebar/app-controller.js
+++ b/src/sidebar/app-controller.js
@@ -132,7 +132,7 @@ module.exports = function AppController(
     });
     drafts.discard();
     $scope.accountDialog.visible = false;
-    auth.logout();
+    session.logout();
   };
 
   $scope.clearSelection = function () {

--- a/src/sidebar/auth.js
+++ b/src/sidebar/auth.js
@@ -1,122 +1,53 @@
 'use strict';
 
-var INITIAL_TOKEN = {
-  // The user ID which the current cached token is valid for
-  userid: undefined,
-  // Promise for the API token for 'userid'.
-  // This is initialized when fetchOrReuseToken() is called and
-  // reset when logging out via logout()
-  token: undefined,
-};
-
-/**
- * Fetches a new API token for the current logged-in user.
- *
- * @return {Promise} - A promise for a new JWT token.
- */
-function fetchToken($http, session, settings) {
-  var tokenUrl = new URL('token', settings.apiUrl).href;
-
-  // Explicitly include the CSRF token in the headers. This won't be done
-  // automatically in the extension as this will be a cross-domain request, and
-  // Angular's CSRF support doesn't operate automatically cross-domain.
-  var headers = {};
-  headers[$http.defaults.xsrfHeaderName] = session.state.csrf;
-
-  var config = {
-    headers: headers,
-    // Skip JWT authorization for the token request itself.
-    skipAuthorization: true,
-  };
-
-  return $http.get(tokenUrl, config).then(function (response) {
-    return response.data;
-  });
-}
+var NULL_TOKEN = Promise.resolve(null);
 
 /**
  * Service for fetching and caching access tokens for the Hypothesis API.
  */
 // @ngInject
-function auth($http, flash, jwtHelper, session, settings) {
+function auth($http, jwtHelper, settings) {
 
-  var cachedToken = INITIAL_TOKEN;
+  var cachedToken = NULL_TOKEN;
 
   /**
-   * Fetches or returns a cached JWT API token for the current user.
+   * Fetch a new API token for the current logged-in user.
    *
-   * @return {Promise} - A promise for a JWT API token for the current
-   *                     user.
+   * The user is authenticated using their session cookie.
+   *
+   * @return {Promise<string>} - A promise for a new JWT token.
    */
-  // @ngInject
-  function fetchOrReuseToken($http, jwtHelper, session, settings) {
-    function refreshToken() {
-      return fetchToken($http, session, settings).then(function (token) {
+  function fetchToken() {
+    var tokenUrl = new URL('token', settings.apiUrl).href;
+    return $http.get(tokenUrl, {}).then(function (response) {
+      return response.data;
+    });
+  }
+
+  /**
+   * Fetch or return a cached JWT API token for the current user.
+   *
+   * @return {Promise<string>} - A promise for a JWT API token for the current
+   *                             user.
+   */
+  function tokenGetter() {
+    return cachedToken.then(function (token) {
+      if (!token || jwtHelper.isTokenExpired(token)) {
+        cachedToken = fetchToken();
+        return cachedToken;
+      } else {
         return token;
-      });
-    }
-
-    var userid;
-
-    return session.load()
-      .then(function (data) {
-        userid = data.userid;
-        if (userid === cachedToken.userid && cachedToken.token) {
-          return cachedToken.token;
-        } else {
-          cachedToken = {
-            userid: userid,
-            token: refreshToken(),
-          };
-          return cachedToken.token;
-        }
-      })
-      .then(function (token) {
-        if (jwtHelper.isTokenExpired(token)) {
-          cachedToken = {
-            userid: userid,
-            token: refreshToken(),
-          };
-          return cachedToken.token;
-        } else {
-          return token;
-        }
-      });
+      }
+    });
   }
 
   function clearCache() {
-    cachedToken = INITIAL_TOKEN;
-  }
-
-  /**
-   * Log out from the API and clear any cached tokens.
-   *
-   * @return {Promise<void>} - A promise for when logout has completed.
-   */
-  function logout() {
-    return session.logout({}).$promise
-      .then(function() {
-        clearCache();
-      })
-      .catch(function(err) {
-        flash.error('Log out failed!');
-        throw err;
-      });
-  }
-
-  /**
-   * Return an access token for authenticating API requests.
-   *
-   * @return {Promise<string>}
-   */
-  function tokenGetter() {
-    return fetchOrReuseToken($http, jwtHelper, session, settings);
+    cachedToken = NULL_TOKEN;
   }
 
   return {
     clearCache: clearCache,
     tokenGetter: tokenGetter,
-    logout: logout,
   };
 }
 

--- a/src/sidebar/test/app-controller-test.js
+++ b/src/sidebar/test/app-controller-test.js
@@ -58,9 +58,7 @@ describe('AppController', function () {
       clearSelectedAnnotations: sandbox.spy(),
     };
 
-    fakeAuth = {
-      logout: sandbox.stub().returns(Promise.resolve()),
-    };
+    fakeAuth = {};
 
     fakeDrafts = {
       contains: sandbox.stub(),
@@ -88,6 +86,7 @@ describe('AppController', function () {
 
     fakeSession = {
       load: sandbox.stub().returns(Promise.resolve({userid: null})),
+      logout: sandbox.stub(),
     };
 
     fakeGroups = {focus: sandbox.spy()};
@@ -254,7 +253,13 @@ describe('AppController', function () {
     });
   });
 
-  describe('logout()', function () {
+  describe('#logout()', function () {
+    it('calls session.logout()', function () {
+      createController();
+      $scope.logout();
+      assert.called(fakeSession.logout);
+    });
+
     it('prompts the user if there are drafts', function () {
       fakeDrafts.count.returns(1);
       createController();


### PR DESCRIPTION
Simplify the "auth" service and remove the dependency on the
"session" service. This will make it possible to introduce a "store" =>
"session" dependency in future in order to support fetching the user's
profile from the access token-authenticated /api/profile endpoint
instead of the cookie-authenticated /app endpoint.

The 'auth' service depended on 'session' for three things:

 - Being able to call `session.load()` in order to retrieve a CSRF
   token. This token is not needed for the `GET /api/token` endpoint
   following https://github.com/hypothesis/h/pull/4322

 - Calling `session.logout()`. This is fixed by removing the
   `auth.logout()` endpoint and changing the caller to call
   `session.logout()` directly instead. `session.logout()` in turn
   calls `auth.clearCache()` to clear cached API tokens.

 - Determining the current user ID in order to invalidate
   the cached token when that changes. The logic to clear the
   cache has instead been moved to the session service.

This commit also adds additional tests for session logout.