### PR TITLE
Exchange access token and fetch profile via API when a grant token is provided

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -37,7 +37,12 @@ _Boolean_. Controls whether the in-document highlights are shown by default.
 
 ### `services`
 
-_Array_. A list of annotation services which the client should retrieve
-annotations from, optionally including information about the identity of the
-user on that service. When omitted, the client will default to connecting to
-the public [Hypothesis](https://hypothes.is/) service.
+_Array_. A list of additional annotation services which the client should
+retrieve annotations from, optionally including information about the identity
+of the user on that service. This list is in addition to the public
+[Hypothesis](https://hypothes.is/) service.
+
+Each service description is an object with the keys:
+
+ * `authority` _String_. The domain name which the annotation service is associated with.
+ * `grantToken` _String|null_. An OAuth grant token which the client can exchange for an access token in order to make authenticated requests to the service. If _null_, the user will only be able to read rather than create or modify annotations. (Default: _null_)

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,3 +34,10 @@ _Boolean_. Controls whether the sidebar opens automatically on startup.
 
 _Boolean_. Controls whether the in-document highlights are shown by default.
 (Default: _true_.)
+
+### `services`
+
+_Array_. A list of annotation services which the client should retrieve
+annotations from, optionally including information about the identity of the
+user on that service. When omitted, the client will default to connecting to
+the public [Hypothesis](https://hypothes.is/) service.

--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -99,6 +99,13 @@ function processAppOpts() {
   }
 }
 
+var authService;
+if (Array.isArray(settings.services)) {
+  authService = require('./oauth-auth');
+} else {
+  authService = require('./auth');
+}
+
 module.exports = angular.module('h', [
   // Angular addons which export the Angular module name
   // via module.exports
@@ -163,7 +170,7 @@ module.exports = angular.module('h', [
   .service('analytics', require('./analytics'))
   .service('annotationMapper', require('./annotation-mapper'))
   .service('annotationUI', require('./annotation-ui'))
-  .service('auth', require('./auth'))
+  .service('auth', authService)
   .service('bridge', require('../shared/bridge'))
   .service('drafts', require('./drafts'))
   .service('features', require('./features'))

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -26,6 +26,7 @@ function hostPageConfig(window) {
     'openLoginForm',
     'openSidebar',
     'showHighlights',
+    'services',
   ];
 
   return Object.keys(config).reduce(function (result, key) {

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -1,0 +1,69 @@
+'use strict';
+
+var queryString = require('query-string');
+
+var resolve = require('./util/url-util').resolve;
+
+/**
+ * OAuth-based authentication service used for publisher accounts.
+ *
+ * A grant token embedded on the page by the publisher is exchanged for
+ * an opaque access token.
+ */
+// @ngInject
+function auth($http, settings) {
+
+  var cachedToken;
+  var tokenUrl = resolve('token', settings.apiUrl);
+
+  var grantToken;
+  if (Array.isArray(settings.services) && settings.services.length > 0) {
+    grantToken = settings.services[0].grantToken;
+  }
+
+  // Exchange the JWT grant token for an access token.
+  // See https://tools.ietf.org/html/rfc7523#section-4
+  function exchangeToken(grantToken) {
+    var data = queryString.stringify({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: grantToken,
+    });
+    var requestConfig = {
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    };
+    return $http.post(tokenUrl, data, requestConfig)
+      .then(function (response) {
+        if (response.status !== 200) {
+          throw new Error('Failed to retrieve access token');
+        }
+        return response.data;
+      });
+  }
+
+  function tokenGetter() {
+    if (cachedToken && cachedToken.expiresAt > Date.now()) {
+      return Promise.resolve(cachedToken.token);
+    } else if (grantToken) {
+      return exchangeToken(grantToken).then(function (tokenInfo) {
+        cachedToken = {
+          token: tokenInfo.access_token,
+          expiresAt: Date.now() + tokenInfo.expires_in * 1000,
+        };
+        return cachedToken.token;
+      });
+    } else {
+      return Promise.resolve(null);
+    }
+  }
+
+  function clearCache() {
+    cachedToken = null;
+  }
+
+  return {
+    clearCache: clearCache,
+    tokenGetter: tokenGetter,
+  };
+}
+
+module.exports = auth;

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -41,13 +41,16 @@ function auth($http, settings) {
   }
 
   function tokenGetter() {
-    if (cachedToken && cachedToken.expiresAt > Date.now()) {
+    // performance.now() is used instead of Date.now() because it is
+    // monotonically increasing.
+    if (cachedToken && cachedToken.expiresAt > performance.now()) {
       return Promise.resolve(cachedToken.token);
     } else if (grantToken) {
+      var refreshStart = performance.now();
       return exchangeToken(grantToken).then(function (tokenInfo) {
         cachedToken = {
           token: tokenInfo.access_token,
-          expiresAt: Date.now() + tokenInfo.expires_in * 1000,
+          expiresAt: refreshStart + tokenInfo.expires_in * 1000,
         };
         return cachedToken.token;
       });

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -84,8 +84,12 @@ function session($http, $resource, $rootScope, annotationUI, auth,
       // the /app endpoint.
       lastLoadTime = Date.now();
       lastLoad = retryUtil.retryPromiseOperation(function () {
-        if (Array.isArray(settings.services)) {
-          return store.profile().then(update);
+        var authority;
+        if (Array.isArray(settings.services) && settings.services.length > 0) {
+          authority = settings.services[0].authority;
+        }
+        if (authority) {
+          return store.profile({authority: authority}).then(update);
         } else {
           return resource._load().$promise;
         }

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -49,7 +49,7 @@ function sessionActions(options) {
  * @ngInject
  */
 function session($http, $resource, $rootScope, annotationUI, auth,
-                 flash, raven, settings) {
+                 flash, raven, settings, store) {
   // Headers sent by every request made by the session service.
   var headers = {};
   var actions = sessionActions({
@@ -84,7 +84,11 @@ function session($http, $resource, $rootScope, annotationUI, auth,
       // the /app endpoint.
       lastLoadTime = Date.now();
       lastLoad = retryUtil.retryPromiseOperation(function () {
-        return resource._load().$promise;
+        if (Array.isArray(settings.services)) {
+          return store.profile().then(update);
+        } else {
+          return resource._load().$promise;
+        }
       }).then(function (session) {
         lastLoadTime = Date.now();
         return session;

--- a/src/sidebar/store.js
+++ b/src/sidebar/store.js
@@ -143,6 +143,7 @@ function store($http, $q, auth, settings) {
       get: apiCall('annotation.read'),
       update: apiCall('annotation.update'),
     },
+    profile: apiCall('profile'),
   };
 }
 

--- a/src/sidebar/test/host-config-test.js
+++ b/src/sidebar/test/host-config-test.js
@@ -18,6 +18,9 @@ describe('hostPageConfig', function () {
       openSidebar: true,
       openLoginForm: true,
       showHighlights: true,
+      services: [{
+        authority: 'hypothes.is',
+      }],
     });
 
     assert.deepEqual(hostPageConfig(window_), {
@@ -26,6 +29,9 @@ describe('hostPageConfig', function () {
       openSidebar: true,
       openLoginForm: true,
       showHighlights: true,
+      services: [{
+        authority: 'hypothes.is',
+      }],
     });
   });
 

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+var authService = require('../oauth-auth');
+
+var DEFAULT_TOKEN_EXPIRES_IN_SECS = 1000;
+
+describe('oauth auth', function () {
+
+  var auth;
+  var clock;
+  var fakeHttp;
+  var fakeSettings;
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers();
+
+    fakeHttp = {
+      post: sinon.stub().returns(Promise.resolve({
+        status: 200,
+        data: {
+          access_token: 'an-access-token',
+          expires_in: DEFAULT_TOKEN_EXPIRES_IN_SECS,
+        },
+      })),
+    };
+
+    fakeSettings = {
+      apiUrl: 'https://hypothes.is/api/',
+      services: [{
+        authority: 'publisher.org',
+        grantToken: 'a.jwt.token',
+      }],
+    };
+
+    auth = authService(fakeHttp, fakeSettings);
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  describe('#tokenGetter', function () {
+    it('should request an access token if a grant token was provided', function () {
+      return auth.tokenGetter().then(function (token) {
+        var expectedBody =
+          'assertion=a.jwt.token' +
+          '&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer';
+        assert.calledWith(fakeHttp.post, 'https://hypothes.is/api/token', expectedBody, {
+          headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        });
+        assert.equal(token, 'an-access-token');
+      });
+    });
+
+    it('should cache tokens for future use', function () {
+      return auth.tokenGetter().then(function () {
+        fakeHttp.post.reset();
+        return auth.tokenGetter();
+      }).then(function (token) {
+        assert.equal(token, 'an-access-token');
+        assert.notCalled(fakeHttp.post);
+      });
+    });
+
+    it('should return null if no grant token was provided', function () {
+      var auth = authService(fakeHttp, {
+        services: [{authority: 'publisher.org'}],
+      });
+      return auth.tokenGetter().then(function (token) {
+        assert.notCalled(fakeHttp.post);
+        assert.equal(token, null);
+      });
+    });
+
+    it('should refresh the access token if it has expired', function () {
+      return auth.tokenGetter().then(function () {
+        clock.tick(DEFAULT_TOKEN_EXPIRES_IN_SECS * 1000 + 100);
+        fakeHttp.post.returns(Promise.resolve({
+          status: 200,
+          data: {
+            access_token: 'a-different-access-token',
+            expires_in: DEFAULT_TOKEN_EXPIRES_IN_SECS,
+          },
+        }));
+        return auth.tokenGetter();
+      }).then(function (token) {
+        assert.equal(token, 'a-different-access-token');
+      });
+    });
+  });
+
+  describe('#clearCache', function () {
+    it('should clear cached tokens', function () {
+      return auth.tokenGetter().then(function () {
+        fakeHttp.post.reset();
+        auth.clearCache();
+        return auth.tokenGetter();
+      }).then(function () {
+        assert.calledOnce(fakeHttp.post);
+      });
+    });
+  });
+});

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -7,12 +7,13 @@ var DEFAULT_TOKEN_EXPIRES_IN_SECS = 1000;
 describe('oauth auth', function () {
 
   var auth;
-  var clock;
+  var nowStub;
   var fakeHttp;
   var fakeSettings;
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers();
+    nowStub = sinon.stub(window.performance, 'now');
+    nowStub.returns(300);
 
     fakeHttp = {
       post: sinon.stub().returns(Promise.resolve({
@@ -36,7 +37,7 @@ describe('oauth auth', function () {
   });
 
   afterEach(function () {
-    clock.restore();
+    performance.now.restore();
   });
 
   describe('#tokenGetter', function () {
@@ -74,7 +75,8 @@ describe('oauth auth', function () {
 
     it('should refresh the access token if it has expired', function () {
       return auth.tokenGetter().then(function () {
-        clock.tick(DEFAULT_TOKEN_EXPIRES_IN_SECS * 1000 + 100);
+        var now = performance.now();
+        nowStub.returns(now + DEFAULT_TOKEN_EXPIRES_IN_SECS * 1000 + 100);
         fakeHttp.post.returns(Promise.resolve({
           status: 200,
           data: {

--- a/src/sidebar/test/session-test.js
+++ b/src/sidebar/test/session-test.js
@@ -175,6 +175,12 @@ describe('session', function () {
 
       it('should fetch profile data from the API', function () {
         return session.load().then(function () {
+          assert.calledWith(fakeStore.profile, {authority: 'publisher.org'});
+        });
+      });
+
+      it('should update the session with the profile data from the API', function () {
+        return session.load().then(function () {
           assert.equal(session.state.userid, 'acct:user@publisher.org');
         });
       });

--- a/src/sidebar/test/store-test.js
+++ b/src/sidebar/test/store-test.js
@@ -148,11 +148,11 @@ describe('store', function () {
 
   it("fetches the user's profile", function (done) {
     var profile = {userid: 'acct:user@publisher.org'};
-    store.profile().then(function (profile_) {
+    store.profile({authority: 'publisher.org'}).then(function (profile_) {
       assert.deepEqual(profile_, profile);
       done();
     });
-    $httpBackend.expectGET('http://example.com/api/profile')
+    $httpBackend.expectGET('http://example.com/api/profile?authority=publisher.org')
       .respond(function () { return [200, profile, {}]; });
     $httpBackend.flush();
   });

--- a/src/sidebar/test/store-test.js
+++ b/src/sidebar/test/store-test.js
@@ -71,6 +71,10 @@ describe('store', function () {
           method: 'GET',
           url: 'http://example.com/api/search',
         },
+        profile: {
+          method: 'GET',
+          url: 'http://example.com/api/profile',
+        },
       },
     });
     $httpBackend.flush();
@@ -139,6 +143,17 @@ describe('store', function () {
 
     $httpBackend.expectGET('http://example.com/api/search?uri=http%3A%2F%2Fexample.com%2F%3Ffoo%3Dbar%3Bbaz%3Dqux')
       .respond(function () { return [200, {}, {}]; });
+    $httpBackend.flush();
+  });
+
+  it("fetches the user's profile", function (done) {
+    var profile = {userid: 'acct:user@publisher.org'};
+    store.profile().then(function (profile_) {
+      assert.deepEqual(profile_, profile);
+      done();
+    });
+    $httpBackend.expectGET('http://example.com/api/profile')
+      .respond(function () { return [200, profile, {}]; });
     $httpBackend.flush();
   });
 });

--- a/src/sidebar/util/url-util.js
+++ b/src/sidebar/util/url-util.js
@@ -25,6 +25,17 @@ function replaceURLParams(url, params) {
   return {url: url, params: unusedParams};
 }
 
+/**
+ * Resolve a relative URL against a base URL to get an absolute URL.
+ *
+ * @param {string} relativeURL
+ * @param {string} baseURL
+ */
+function resolve(relativeURL, baseURL) {
+  return new URL(relativeURL, baseURL).href;
+}
+
 module.exports = {
   replaceURLParams: replaceURLParams,
+  resolve: resolve,
 };


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/198**

This PR implements the logic to fetch an access token for API authentication and fetch the user's profile using the new `/api/profile` endpoint when the page embedding Hypothesis provides a service configuration like this:

```js
window.hypothesisConfig = function () {
  return {
    services: [{authority: 'publisher.org', grantToken: 'a.jwt.token'}],
  }
}
```

The PR uses an alternate implementation of the "auth" service which is chosen on startup when the host page supplies custom annotation service configuration, as above. For the time being, the default API endpoints specified in app.html are used when connecting to a custom service. In future that could be part of this configuration however.

To test this manually:

1. Clone https://github.com/hypothesis/publisher-account-example-site and follow the steps in the README to set up a test site for publisher accounts locally. Before running the demo site, set the `HYPOTHESIS_SERVICE` env var to point to `http://localhost:5000`
2. On the example site, create a user account by entering a username at the top of the page and clicking "Sign up".
3. When the page reloads, if you open the account drop-down menu in the Hypothesis client you should see that it displays the same username that you are logged into on the page. You should also see that the client makes the following requests when it starts:
3.1 `POST /api/token` to fetch an access token
3.2 `GET /api/profile?authority=...` to fetch the user's profile, supplying the access token from the previous step in the Authorization header
3.3 `GET /api/search?...` to fetch annotations, again supplying the access token from the previous step in the Authorization header.

**What is not yet implemented:**
1. Actually posting an annotation does not yet work because the service still returns the public group from the Hypothesis service as the user's only group, and 3rd-party users are not allowed to post to this group.
1. Login and logout functionality is still present and continues to log the user into or out of the public service. This functionality will be removed in future when using 3rd party accounts.
1. Refreshing the access token when it expires is done just by re-exchanging the grant token. Once refresh tokens are implemented in the service, the client will be modified to use those instead.
