### PR TITLE
Use access token to authenticate WebSocket connections

### DIFF
--- a/src/sidebar/streamer.js
+++ b/src/sidebar/streamer.js
@@ -187,21 +187,38 @@ function Streamer($rootScope, annotationMapper, annotationUI, auth,
     });
   };
 
-  var connect = function () {
+  /**
+   * Connect to the Hypothesis real time update service.
+   *
+   * If the service has already connected this does nothing.
+   *
+   * @return {Promise} Promise which resolves once the WebSocket connection
+   *                   process has started.
+   */
+  function connect() {
     if (socket) {
       return Promise.resolve();
     }
 
     return _connect();
-  };
+  }
 
-  var reconnect = function () {
+  /**
+   * Connect to the Hypothesis real time update service.
+   *
+   * If the service has already connected this closes the existing connection
+   * and reconnects.
+   *
+   * @return {Promise} Promise which resolves once the WebSocket connection
+   *                   process has started.
+   */
+  function reconnect() {
     if (socket) {
       socket.close();
     }
 
     return _connect();
-  };
+  }
 
   function applyPendingUpdates() {
     var updates = Object.values(pendingUpdates);

--- a/src/sidebar/streamer.js
+++ b/src/sidebar/streamer.js
@@ -182,6 +182,14 @@ function Streamer($rootScope, annotationMapper, annotationUI, auth,
         messageType: 'client_id',
         value: clientId,
       });
+
+      // Send a "whoami" message. The server will respond with a "whoyouare"
+      // reply which is useful for verifying that authentication worked as
+      // expected.
+      setConfig('auth-check', {
+        type: 'whoami',
+        id: 1,
+      });
     }).catch(function (err) {
       console.error('Failed to fetch token for WebSocket authentication', err);
     });

--- a/src/sidebar/test/streamer-test.js
+++ b/src/sidebar/test/streamer-test.js
@@ -157,12 +157,24 @@ describe('Streamer', function () {
     assert.ok(activeStreamer.clientId);
   });
 
-  it('should send the client ID on connection', function () {
+  it('should send the client ID after connecting', function () {
     createDefaultStreamer();
     return activeStreamer.connect().then(function () {
-      assert.equal(fakeWebSocket.messages.length, 1);
-      assert.equal(fakeWebSocket.messages[0].messageType, 'client_id');
-      assert.equal(fakeWebSocket.messages[0].value, activeStreamer.clientId);
+      var clientIdMsg = fakeWebSocket.messages.find(function (msg) {
+        return msg.messageType === 'client_id';
+      });
+      assert.ok(clientIdMsg);
+      assert.equal(clientIdMsg.value, activeStreamer.clientId);
+    });
+  });
+
+  it('should request the logged-in user ID after connecting', function () {
+    createDefaultStreamer();
+    return activeStreamer.connect().then(function () {
+      var whoamiMsg = fakeWebSocket.messages.find(function (msg) {
+        return msg.type === 'whoami';
+      });
+      assert.ok(whoamiMsg);
     });
   });
 
@@ -409,8 +421,11 @@ describe('Streamer', function () {
       return activeStreamer.connect().then(function () {
         fakeWebSocket.messages = [];
         fakeWebSocket.emit('open');
-        assert.equal(fakeWebSocket.messages.length, 1);
-        assert.equal(fakeWebSocket.messages[0].messageType, 'client_id');
+
+        var configMsgTypes = fakeWebSocket.messages.map(function (msg) {
+          return msg.type || msg.messageType;
+        });
+        assert.deepEqual(configMsgTypes, ['client_id', 'whoami']);
       });
     });
   });


### PR DESCRIPTION
In order to support clients using an OAuth access token rather than a cookie for authentication everywhere, this PR adds the access token to the URL when connecting to the WebSocket. A backend change (https://github.com/hypothesis/h/pull/4330) will allow the WS server to extract the auth token and use it for authentication.

Since token fetching is asynchronous, this means that `Streamer.{connect, reconnect}` also now become asynchronous since they have to fetch the token before initiating the connection. They now return a void Promise once auth token has been retrieved and the connection has been initiated.

We are including credentials in the URL rather than a custom header because the browser `WebSocket` API does not support setting custom headers for the initial handshake request. See https://github.com/hypothesis/product-backlog/issues/154 for further discussion.