### PR TITLE
Verify userid after connecting to WebSocket

### DIFF
--- a/src/sidebar/streamer.js
+++ b/src/sidebar/streamer.js
@@ -123,6 +123,11 @@ function Streamer($rootScope, annotationMapper, annotationUI, auth,
         handleAnnotationNotification(message);
       } else if (message.type === 'session-change') {
         handleSessionChangeNotification(message);
+      } else if (message.type === 'whoyouare') {
+        var userid = annotationUI.getState().session.userid;
+        if (message.userid !== userid) {
+          console.warn('WebSocket user ID "%s" does not match logged-in ID "%s"', message.userid, userid);
+        }
       } else {
         console.warn('received unsupported notification', message.type);
       }


### PR DESCRIPTION
After connecting to the WebSocket, the client sends a [whoami](http://h.readthedocs.io/en/latest/realtime/#whoami) request to make it easy to check that the client is authenticated as the same user on the WebSocket and app. On master, this currently logs a warning because the client does not handle the "whoyouare" message sent in reply.

This PR adds logic to handle the 'whoyouare' reply to the 'whoami' request and logs a warning if the authenticated userid on the WebSocket does not match the logged in userid (as shown in the account menu) for any reason. This is useful for us initially as the WS supports multiple authentication methods (cookie - that is always sent by the client and we cannot prevent that, token) and we want to make sure it is using the right one.