### PR TITLE
Adding client metric tracking for interactions with annotations

### DIFF
--- a/src/sidebar/analytics.js
+++ b/src/sidebar/analytics.js
@@ -50,8 +50,27 @@ function analytics($analytics, $window, settings) {
      *  in our analytics. Example: 'sidebarOpened'. Use camelCase to track multiple
      *  words.
      */
-    track: function(event){
-      $analytics.eventTrack(event, options);
+    track: function(event, label, metricValue){
+      $analytics.eventTrack(event, Object.assign({}, {
+        label: label || undefined,
+        metricValue: isNaN(metricValue) ? undefined : metricValue,
+      }, options));
+    },
+
+    events: {
+      ANNOTATION_CREATED: 'annotationCreated',
+      ANNOTATION_DELETED: 'annotationDeleted',
+      ANNOTATION_UPDATED: 'annotationUpdated',
+      HIGHLIGHT_CREATED: 'highlightCreated',
+      HIGHLIGHT_UPDATED: 'highlightUpdated',
+      HIGHLIGHT_DELETED: 'highlightDeleted',
+      PAGE_NOTE_CREATED: 'pageNoteCreated',
+      PAGE_NOTE_UPDATED: 'pageNoteUpdated',
+      PAGE_NOTE_DELETED: 'pageNoteDeleted',
+      REPLY_CREATED: 'replyCreated',
+      REPLY_UPDATED: 'replyUpdated',
+      REPLY_DELETED: 'replyDeleted',
+      SIDEBAR_OPENED: 'sidebarOpened',
     },
   };
 }

--- a/src/sidebar/directive/test/annotation-test.js
+++ b/src/sidebar/directive/test/annotation-test.js
@@ -82,6 +82,7 @@ describe('annotation', function() {
     var $scope;
     var $timeout;
     var $window;
+    var fakeAnalytics;
     var fakeAnnotationMapper;
     var fakeDrafts;
     var fakeFlash;
@@ -120,6 +121,11 @@ describe('annotation', function() {
     beforeEach(angular.mock.module('h'));
     beforeEach(angular.mock.module(function($provide) {
       sandbox = sinon.sandbox.create();
+
+      fakeAnalytics = {
+        track: sandbox.stub(),
+        events: {},
+      };
 
       fakeAnnotationMapper = {
         createAnnotation: sandbox.stub().returns({
@@ -195,6 +201,7 @@ describe('annotation', function() {
         hasPendingDeletion: sinon.stub(),
       };
 
+      $provide.value('analytics', fakeAnalytics);
       $provide.value('annotationMapper', fakeAnnotationMapper);
       $provide.value('annotationUI', fakeAnnotationUI);
       $provide.value('drafts', fakeDrafts);

--- a/src/sidebar/test/analytics-test.js
+++ b/src/sidebar/test/analytics-test.js
@@ -2,6 +2,14 @@
 
 var analyticsService = require('../analytics');
 
+var createEventObj = function(override){
+  return {
+    category: override.category,
+    label: override.label,
+    metricValue: override.metricValue,
+  };
+};
+
 describe('analytics', function () {
 
   var $analyticsStub;
@@ -32,31 +40,47 @@ describe('analytics', function () {
       var validTypes = ['chrome-extension', 'embed', 'bookmarklet', 'via'];
       validTypes.forEach(function(appType, index){
         analyticsService($analyticsStub, $windowStub, {appType: appType}).track('event' + index);
-        assert.deepEqual(eventTrackStub.args[index], ['event' + index, {category: appType}]);
+        assert.deepEqual(eventTrackStub.args[index], ['event' + index, createEventObj({category: appType})]);
       });
     });
 
     it('sets category as embed if no other matches can be made', function () {
       analyticsService($analyticsStub, $windowStub).track('eventA');
-      assert.deepEqual(eventTrackStub.args[0], ['eventA', {category: 'embed'}]);
+      assert.deepEqual(eventTrackStub.args[0], ['eventA', createEventObj({category: 'embed'})]);
     });
 
     it('sets category as via if url matches the via uri pattern', function () {
       $windowStub.document.referrer = 'https://via.hypothes.is/';
       analyticsService($analyticsStub, $windowStub).track('eventA');
-      assert.deepEqual(eventTrackStub.args[0], ['eventA', {category: 'via'}]);
+      assert.deepEqual(eventTrackStub.args[0], ['eventA', createEventObj({category: 'via'})]);
 
       // match staging as well
       $windowStub.document.referrer = 'https://qa-via.hypothes.is/';
       analyticsService($analyticsStub, $windowStub).track('eventB');
-      assert.deepEqual(eventTrackStub.args[1], ['eventB', {category: 'via'}]);
+      assert.deepEqual(eventTrackStub.args[1], ['eventB', createEventObj({category: 'via'})]);
     });
 
     it('sets category as chrome-extension if protocol matches chrome-extension:', function () {
       $windowStub.location.protocol = 'chrome-extension:';
       analyticsService($analyticsStub, $windowStub).track('eventA');
-      assert.deepEqual(eventTrackStub.args[0], ['eventA', {category: 'chrome-extension'}]);
+      assert.deepEqual(eventTrackStub.args[0], ['eventA', createEventObj({category: 'chrome-extension'})]);
     });
 
   });
+
+  it('allows custom labels to be sent for an event', function () {
+    analyticsService($analyticsStub, $windowStub, {appType: 'embed'}).track('eventA', 'labelA');
+    assert.deepEqual(eventTrackStub.args[0], ['eventA', createEventObj({category: 'embed', label: 'labelA'})]);
+  });
+
+  it('allows custom metricValues to be sent for an event', function () {
+    analyticsService($analyticsStub, $windowStub, {appType: 'embed'}).track('eventA', null, 242.2);
+    assert.deepEqual(eventTrackStub.args[0], ['eventA', createEventObj({category: 'embed', metricValue: 242.2})]);
+  });
+
+  it('allows custom metricValues and labels to be sent for an event', function () {
+    analyticsService($analyticsStub, $windowStub, {appType: 'embed'}).track('eventA', 'labelabc', 242.2);
+    assert.deepEqual(eventTrackStub.args[0], ['eventA', createEventObj({category: 'embed', label: 'labelabc', metricValue: 242.2})]);
+  });
+
 });

--- a/src/sidebar/test/annotation-fixtures.js
+++ b/src/sidebar/test/annotation-fixtures.js
@@ -71,7 +71,7 @@ function oldAnnotation() {
   return {
     id: 'annotation_id',
     $highlight: undefined,
-    target: ['foo', 'bar'],
+    target: [{source: 'source', 'selector': [] }],
     references: [],
     text: 'This is my annotation',
     tags: ['tag_1', 'tag_2'],

--- a/src/sidebar/test/app-controller-test.js
+++ b/src/sidebar/test/app-controller-test.js
@@ -12,6 +12,7 @@ describe('AppController', function () {
   var $rootScope = null;
   var fakeAnnotationMetadata = null;
   var fakeAnnotationUI = null;
+  var fakeAnalytics = null;
   var fakeAuth = null;
   var fakeDrafts = null;
   var fakeFeatures = null;
@@ -56,6 +57,11 @@ describe('AppController', function () {
     fakeAnnotationUI = {
       tool: 'comment',
       clearSelectedAnnotations: sandbox.spy(),
+    };
+
+    fakeAnalytics = {
+      track: sandbox.stub(),
+      events: {},
     };
 
     fakeAuth = {};
@@ -107,6 +113,7 @@ describe('AppController', function () {
 
     $provide.value('annotationUI', fakeAnnotationUI);
     $provide.value('auth', fakeAuth);
+    $provide.value('analytics', fakeAnalytics);
     $provide.value('drafts', fakeDrafts);
     $provide.value('features', fakeFeatures);
     $provide.value('frameSync', fakeFrameSync);

--- a/src/sidebar/test/widget-controller-test.js
+++ b/src/sidebar/test/widget-controller-test.js
@@ -71,7 +71,8 @@ describe('WidgetController', function () {
     sandbox = sinon.sandbox.create();
 
     fakeAnalytics = {
-      track: sandbox.spy(),
+      track: sandbox.stub(),
+      events: {},
     };
 
     fakeAnnotationMapper = {

--- a/src/sidebar/widget-controller.js
+++ b/src/sidebar/widget-controller.js
@@ -202,7 +202,7 @@ module.exports = function WidgetController(
 
   $scope.$on('sidebarOpened', function () {
 
-    analytics.track('sidebarOpened');
+    analytics.track(analytics.events.SIDEBAR_OPENED);
 
     streamer.connect();
   });


### PR DESCRIPTION
Things you will find in this PR

- Adding metrics for the create, update, and delete of annotations, highlights, page notes, and replies.
- Moving analytics events to the analytics service as a first step towards a standard list of metrics being tracked
- Adding label and metric value options to track event
  - they aren't used here (didn't get the chance) but they are just adding the fields to the options that are alrready supported
- isHighlight in the annotation directive now uses the annotation metadata standard method for determining this
  - a subsequent test fixture update was needed as it was incorrect before