### PR TITLE
Use new profile update endpoint for dismissing sidebar tutorial

### DIFF
--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -20,11 +20,6 @@ function sessionActions(options) {
     },
 
     _load: { method: 'GET' },
-
-    dismiss_sidebar_tutorial: {
-      method: 'POST',
-      params: { path: 'dismiss_sidebar_tutorial' },
-    },
   };
 
   Object.keys(actions).forEach(function (action) {
@@ -103,6 +98,16 @@ function session($http, $resource, $rootScope, annotationUI, auth,
     }
     return lastLoad;
   };
+
+  /**
+   * @name session.dismissSidebarTutorial()
+   *
+   * @description Stores the preference server-side that the user dismissed
+   *              the sidebar tutorial, and then updates the session state.
+   */
+  function dismissSidebarTutorial() {
+    return store.profile.update({}, {preferences: {show_sidebar_tutorial: false}}).then(update);
+  }
 
   /**
    * @name session.update()
@@ -203,7 +208,7 @@ function session($http, $resource, $rootScope, annotationUI, auth,
   }
 
   return {
-    dismissSidebarTutorial: resource.dismiss_sidebar_tutorial,
+    dismissSidebarTutorial: dismissSidebarTutorial,
     load: resource.load,
     login: resource.login,
     logout: logout,

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -89,7 +89,7 @@ function session($http, $resource, $rootScope, annotationUI, auth,
           authority = settings.services[0].authority;
         }
         if (authority) {
-          return store.profile({authority: authority}).then(update);
+          return store.profile.read({authority: authority}).then(update);
         } else {
           return resource._load().$promise;
         }

--- a/src/sidebar/store.js
+++ b/src/sidebar/store.js
@@ -145,6 +145,7 @@ function store($http, $q, auth, settings) {
     },
     profile: {
       read: apiCall('profile.read'),
+      update: apiCall('profile.update'),
     },
   };
 }

--- a/src/sidebar/store.js
+++ b/src/sidebar/store.js
@@ -143,7 +143,9 @@ function store($http, $q, auth, settings) {
       get: apiCall('annotation.read'),
       update: apiCall('annotation.update'),
     },
-    profile: apiCall('profile.read'),
+    profile: {
+      read: apiCall('profile.read'),
+    },
   };
 }
 

--- a/src/sidebar/test/session-test.js
+++ b/src/sidebar/test/session-test.js
@@ -45,6 +45,7 @@ describe('session', function () {
     fakeStore = {
       profile: {
         read: sandbox.stub(),
+        update: sandbox.stub().returns(Promise.resolve({})),
       },
     };
     fakeSettings = {
@@ -292,11 +293,21 @@ describe('session', function () {
   });
 
   describe('#dismissSidebarTutorial()', function () {
-    var url = 'https://test.hypothes.is/root/app/dismiss_sidebar_tutorial';
+    beforeEach(function () {
+      fakeStore.profile.update.returns(Promise.resolve({
+        preferences: {},
+      }));
+    });
+
     it('disables the tutorial for the user', function () {
-      $httpBackend.expectPOST(url).respond({});
       session.dismissSidebarTutorial();
-      $httpBackend.flush();
+      assert.calledWith(fakeStore.profile.update, {}, {preferences: {show_sidebar_tutorial: false}});
+    });
+
+    it('should update the session with the response from the API', function () {
+      return session.dismissSidebarTutorial().then(function () {
+        assert.isNotOk(session.state.preferences.show_sidebar_tutorial);
+      });
     });
   });
 

--- a/src/sidebar/test/session-test.js
+++ b/src/sidebar/test/session-test.js
@@ -43,7 +43,9 @@ describe('session', function () {
       setUserInfo: sandbox.spy(),
     };
     fakeStore = {
-      profile: sandbox.stub(),
+      profile: {
+        read: sandbox.stub(),
+      },
     };
     fakeSettings = {
       serviceUrl: 'https://test.hypothes.is/root/',
@@ -168,14 +170,14 @@ describe('session', function () {
           authority: 'publisher.org',
           grantToken: 'a.jwt.token',
         }];
-        fakeStore.profile.returns(Promise.resolve({
+        fakeStore.profile.read.returns(Promise.resolve({
           userid: 'acct:user@publisher.org',
         }));
       });
 
       it('should fetch profile data from the API', function () {
         return session.load().then(function () {
-          assert.calledWith(fakeStore.profile, {authority: 'publisher.org'});
+          assert.calledWith(fakeStore.profile.read, {authority: 'publisher.org'});
         });
       });
 

--- a/src/sidebar/test/store-test.js
+++ b/src/sidebar/test/store-test.js
@@ -76,6 +76,10 @@ describe('store', function () {
             method: 'GET',
             url: 'http://example.com/api/profile',
           },
+          update: {
+            method: 'PATCH',
+            url: 'http://example.com/api/profile',
+          },
         },
       },
     });
@@ -156,6 +160,18 @@ describe('store', function () {
     });
     $httpBackend.expectGET('http://example.com/api/profile?authority=publisher.org')
       .respond(function () { return [200, profile, {}]; });
+    $httpBackend.flush();
+  });
+
+  it("updates a user's profile", function (done) {
+    store.profile.update({}, {preferences: {}}).then(function () {
+      done();
+    });
+
+    $httpBackend.expectPATCH('http://example.com/api/profile')
+      .respond(function () {
+        return [200, {}, {}];
+      });
     $httpBackend.flush();
   });
 });

--- a/src/sidebar/test/store-test.js
+++ b/src/sidebar/test/store-test.js
@@ -150,7 +150,7 @@ describe('store', function () {
 
   it("fetches the user's profile", function (done) {
     var profile = {userid: 'acct:user@publisher.org'};
-    store.profile({authority: 'publisher.org'}).then(function (profile_) {
+    store.profile.read({authority: 'publisher.org'}).then(function (profile_) {
       assert.deepEqual(profile_, profile);
       done();
     });


### PR DESCRIPTION
This new endpoint is authenticated with an API token rather than a cookie. Which will make this work with third-party users as well.