### PR TITLE
Remove unused SESSION_CHANGED event

### DIFF
--- a/src/sidebar/events.js
+++ b/src/sidebar/events.js
@@ -11,10 +11,6 @@ module.exports = {
   GROUPS_CHANGED: 'groupsChanged',
   /** The logged-in user changed */
   USER_CHANGED: 'userChanged',
-  /**
-   * The session state was updated.
-   */
-  SESSION_CHANGED: 'sessionChanged',
 
   // UI state changes
 

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -137,10 +137,6 @@ function session($http, $resource, $rootScope, annotationUI, auth,
     lastLoad = Promise.resolve(model);
     lastLoadTime = Date.now();
 
-    $rootScope.$broadcast(events.SESSION_CHANGED, {
-      initialLoad: isInitialLoad,
-    });
-
     if (userChanged) {
       auth.clearCache();
 

--- a/src/sidebar/test/session-test.js
+++ b/src/sidebar/test/session-test.js
@@ -227,33 +227,6 @@ describe('session', function () {
   });
 
   describe('#update()', function () {
-    it('broadcasts SESSION_CHANGED when the session changes', function () {
-      var sessionChangeCallback = sinon.stub();
-
-      // the initial load should trigger a SESSION_CHANGED event
-      // with initialLoad set
-      $rootScope.$on(events.SESSION_CHANGED, sessionChangeCallback);
-      session.update({
-        groups: [{
-          id: 'groupid',
-        }],
-        csrf: 'dummytoken',
-      });
-      assert.calledWith(sessionChangeCallback, sinon.match({}),
-        {initialLoad: true});
-
-      // subsequent loads should trigger a SESSION_CHANGED event
-      sessionChangeCallback.reset();
-      session.update({
-        groups: [{
-          id: 'groupid2',
-        }],
-        csrf: 'dummytoken',
-      });
-      assert.calledWith(sessionChangeCallback, sinon.match({}),
-        {initialLoad: false});
-    });
-
     it('broadcasts GROUPS_CHANGED when the groups change', function () {
       var groupChangeCallback = sinon.stub();
       $rootScope.$on(events.GROUPS_CHANGED, groupChangeCallback);


### PR DESCRIPTION
This event was fired by the `session` service but not listened for by any
other module.