### PR TITLE
Minify production build and fix prod build in non-ES6 browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "jquery": "$"
   },
   "scripts": {
-    "build": "gulp build",
+    "build": "NODE_ENV=production gulp build",
     "deps": "check-dependencies",
     "lint": "eslint .",
     "test": "gulp test",

--- a/src/sidebar/ga.js
+++ b/src/sidebar/ga.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let loaded = false;
+var loaded = false;
 
 module.exports = function(trackingId){
 


### PR DESCRIPTION
Set the NODE_ENV flag to 'production' in package.json so that JS and CSS assets are optimized/minified when running `npm run build` or `npm run prepublish` (the latter is what Jenkins does).

I initially looked at adding separate Gulp tasks to create the prod builds but just setting the env var before running the build tasks turned out to be simpler (avoids adding many more gulp tasks for dev vs. prod, or logic to generate two sets of tasks), while keeping the ability to run all tasks in either debug or prod mode which is convenient for development.

I also removed an ES6 feature usage (`let`) in `ga.js` which doesn't work in older browsers (primarily IE 10/11).

Fixes #209 

**Testing:** Run `npm prepublish` and verify that the CSS and JS bundles in build/{scripts, styles} are minified.
