### PR TITLE
Set initial annotation counts to 0 because annotation counters are not…

### DIFF
--- a/src/annotator/annotation-counts.js
+++ b/src/annotator/annotation-counts.js
@@ -13,6 +13,8 @@ var ANNOTATION_COUNT_ATTR = 'data-hypothesis-annotation-count';
  */
 
 function annotationCounts(rootEl, crossframe) {
+  updateAnnotationCountElems(0);
+
   crossframe.on(events.PUBLIC_ANNOTATION_COUNT_CHANGED, updateAnnotationCountElems);
 
   function updateAnnotationCountElems(newCount) {


### PR DESCRIPTION
… updated if a page has no annotations.