### PR TITLE
Add a new entry point script for the client application

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -20,6 +20,11 @@ to be ignored.
 Config keys
 -----------
 
+## Client behavior
+
+These keys configure the behavior and initial state of the client when it
+loads.
+
 ### `openLoginForm`
 
 _Boolean_. Controls whether the login panel is automatically opened on startup,
@@ -34,6 +39,21 @@ _Boolean_. Controls whether the sidebar opens automatically on startup.
 
 _Boolean_. Controls whether the in-document highlights are shown by default.
 (Default: _true_.)
+
+## Annotation services
+
+These keys configure which annotation services the client connects to and where
+it loads assets from. By default, the client will connect to the public
+Hypothesis service at [hypothes.is](https://hypothes.is).
+
+### `assetRoot`
+
+_String_. The URL from which client assets are loaded.
+
+### `sidebarAppUrl`
+
+_String_. The URL for the sidebar application which displays annotations
+(Default: _https://hypothes.is/app.html_).
 
 ### `services`
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,8 @@ var gulpIf = require('gulp-if');
 var gulpUtil = require('gulp-util');
 var postcss = require('gulp-postcss');
 var postcssURL = require('postcss-url');
+var replace = require('gulp-replace');
+var rename = require('gulp-rename');
 var sass = require('gulp-sass');
 var sourcemaps = require('gulp-sourcemaps');
 var through = require('through2');
@@ -94,6 +96,12 @@ var appBundleBaseConfig = {
 };
 
 var appBundles = [{
+  // The entry point for both the Hypothesis client and the sidebar
+  // application. This is responsible for loading the rest of the assets needed
+  // by the client.
+  name: 'boot',
+  entry: './src/boot/index',
+},{
   // The sidebar application for displaying and editing annotations.
   name: 'app',
   transforms: ['coffee'],
@@ -231,6 +239,19 @@ function triggerLiveReload(changedFiles) {
 }
 
 /**
+ * Generates the `build/boot.js` script which serves as the entry point for
+ * the Hypothesis client.
+ *
+ * @param {Object} manifest - Manifest mapping asset paths to cache-busted URLs
+ */
+function generateBootScript(manifest) {
+  gulp.src('build/scripts/boot.bundle.js')
+    .pipe(replace('__MANIFEST__', JSON.stringify(manifest)))
+    .pipe(rename('boot.js'))
+    .pipe(gulp.dest('build/'));
+}
+
+/**
  * Generate a JSON manifest mapping file paths to
  * URLs containing cache-busting query string parameters.
  */
@@ -240,10 +261,14 @@ function generateManifest() {
     .pipe(through.obj(function (file, enc, callback) {
       gulpUtil.log('Updated asset manifest');
 
+      // Trigger a reload of the client in the dev server at localhost:3000
       var newManifest = JSON.parse(file.contents.toString());
       var changed = changedAssets(prevManifest, newManifest);
       prevManifest = newManifest;
       triggerLiveReload(changed);
+
+      // Expand template vars in boot script bundle
+      generateBootScript(newManifest);
 
       this.push(file);
       callback();

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -728,6 +728,12 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
       "dev": true
     },
+    "binaryextensions": {
+      "version": "1.0.1",
+      "from": "binaryextensions@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.1.tgz",
+      "dev": true
+    },
     "blob": {
       "version": "0.0.4",
       "from": "blob@0.0.4",
@@ -2558,6 +2564,18 @@
       "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-6.1.0.tgz",
       "dev": true
     },
+    "gulp-rename": {
+      "version": "1.2.2",
+      "from": "gulp-rename@latest",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
+      "dev": true
+    },
+    "gulp-replace": {
+      "version": "0.5.4",
+      "from": "gulp-replace@latest",
+      "resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-0.5.4.tgz",
+      "dev": true
+    },
     "gulp-sass": {
       "version": "2.2.0",
       "from": "gulp-sass@>=2.2.0 <3.0.0",
@@ -3168,6 +3186,12 @@
           "dev": true
         }
       }
+    },
+    "istextorbinary": {
+      "version": "1.0.2",
+      "from": "istextorbinary@1.0.2",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
+      "dev": true
     },
     "jade": {
       "version": "0.26.3",
@@ -4966,6 +4990,12 @@
         }
       }
     },
+    "replacestream": {
+      "version": "4.0.2",
+      "from": "replacestream@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.2.tgz",
+      "dev": true
+    },
     "request": {
       "version": "2.76.0",
       "from": "request@latest",
@@ -5603,6 +5633,12 @@
       "version": "0.2.0",
       "from": "text-table@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "dev": true
+    },
+    "textextensions": {
+      "version": "1.0.2",
+      "from": "textextensions@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.2.tgz",
       "dev": true
     },
     "throttleit": {

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "hammerjs": "Hammer",
     "jquery": "$"
   },
+  "main": "./build/boot.js",
   "scripts": {
     "build": "NODE_ENV=production gulp build",
     "deps": "check-dependencies",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "gulp-changed": "^1.3.0",
     "gulp-if": "^2.0.0",
     "gulp-postcss": "^6.1.0",
+    "gulp-rename": "^1.2.2",
+    "gulp-replace": "^0.5.4",
     "gulp-sass": "^2.2.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-util": "^3.0.7",

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -21,7 +21,7 @@ function injectScript(doc, src) {
 
 function injectAssets(doc, config, assets) {
   assets.forEach(function (path) {
-    var url = config.assetRoot + config.manifest[path];
+    var url = config.assetRoot + 'build/' + config.manifest[path];
     if (url.match(/\.css/)) {
       injectStylesheet(doc, url);
     } else {

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -47,7 +47,7 @@ function bootHypothesisClient(doc, config) {
   // presence of the Hypothesis client on the page.
   var baseUrl = doc.createElement('link');
   baseUrl.rel = 'sidebar';
-  baseUrl.href = config.appHtmlUrl;
+  baseUrl.href = config.sidebarAppUrl;
   baseUrl.type = 'application/annotator+html';
   doc.head.appendChild(baseUrl);
 

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -1,0 +1,100 @@
+'use strict';
+
+function injectStylesheet(doc, href) {
+  var link = doc.createElement('link');
+  link.rel = 'stylesheet';
+  link.type = 'text/css';
+  link.href = href;
+  doc.head.appendChild(link);
+}
+
+function injectScript(doc, src) {
+  var script = doc.createElement('script');
+  script.type = 'text/javascript';
+  script.src = src;
+
+  // Set 'async' to false to maintain execution order of scripts.
+  // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
+  script.async = false;
+  doc.head.appendChild(script);
+}
+
+function injectAssets(doc, config, assets) {
+  assets.forEach(function (path) {
+    var url = config.assetRoot + config.manifest[path];
+    if (url.match(/\.css/)) {
+      injectStylesheet(doc, url);
+    } else {
+      injectScript(doc, url);
+    }
+  });
+}
+
+/**
+ * Bootstrap the Hypothesis client.
+ *
+ * This triggers loading of the necessary resources for the client
+ */
+function bootHypothesisClient(doc, config) {
+  // Detect presence of Hypothesis in the page
+  var appLinkEl = doc.querySelector('link[type="application/annotator+html"]');
+  if (appLinkEl) {
+    return;
+  }
+
+  // Register the URL of the sidebar app which the Hypothesis client should load.
+  // The <link> tag is also used by browser extensions etc. to detect the
+  // presence of the Hypothesis client on the page.
+  var baseUrl = doc.createElement('link');
+  baseUrl.rel = 'sidebar';
+  baseUrl.href = config.appHtmlUrl;
+  baseUrl.type = 'application/annotator+html';
+  doc.head.appendChild(baseUrl);
+
+  injectAssets(doc, config, [
+    // Vendor code and polyfills
+    'scripts/polyfills.bundle.js',
+    'scripts/jquery.bundle.js',
+
+    // Main entry point for the client
+    'scripts/injector.bundle.js',
+
+    'styles/icomoon.css',
+    'styles/inject.css',
+    'styles/pdfjs-overrides.css',
+  ]);
+}
+
+/**
+ * Bootstrap the sidebar application which displays annotations.
+ */
+function bootSidebarApp(doc, config) {
+  injectAssets(doc, config, [
+    // Vendor code and polyfills required by app.bundle.js
+    'scripts/raven.bundle.js',
+    'scripts/angular.bundle.js',
+    'scripts/katex.bundle.js',
+    'scripts/showdown.bundle.js',
+    'scripts/polyfills.bundle.js',
+    'scripts/unorm.bundle.js',
+
+    // The sidebar app
+    'scripts/app.bundle.js',
+
+    'styles/angular-csp.css',
+    'styles/angular-toastr.css',
+    'styles/icomoon.css',
+    'styles/katex.min.css',
+    'styles/app.css',
+  ]);
+}
+
+function boot(document_, config) {
+  if (document_.querySelector('hypothesis-app')) {
+    bootSidebarApp(document_, config);
+  } else {
+    bootHypothesisClient(document_, config);
+  }
+}
+
+module.exports = boot;

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -10,14 +10,14 @@
 /* global __MANIFEST__ */
 
 var boot = require('./boot');
+var settings = require('../shared/settings')(document);
 
-// The HYP* properties are set (if at all) by the service which is serving the
-// Hypothesis client to tell it where to load the sidebar and assets from.
-var appHtmlUrl = window.__HYP_APP_HTML_URL__ || 'https://hypothes.is/app.html';
-var assetRoot = window.__HYP_CLIENT_ASSET_ROOT__ || 'https://hypothes.is/assets/client/';
+// The `sidebarAppUrl` and `assetRoot` settings are set by the service which is
+// serving the Hypothesis client to tell it where to load the sidebar and assets
+// from.
 
 boot(document, {
-  appHtmlUrl: appHtmlUrl,
-  assetRoot: assetRoot,
+  assetRoot: settings.assetRoot || 'https://hypothes.is/assets/client/',
   manifest: __MANIFEST__,  // Replaced by build script
+  sidebarAppUrl: settings.sidebarAppUrl || 'https://hypothes.is/app.html',
 });

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// This is the main entry point for the Hypothesis client in the host page
+// and the sidebar application.
+
+/* global __MANIFEST__ */
+
+var boot = require('./boot');
+
+// The HYP* properties are set (if at all) by the service which is serving the
+// Hypothesis client to tell it where to load the sidebar and assets from.
+var appHtmlUrl = window.__HYP_APP_HTML_URL__ || 'https://hypothes.is/app.html';
+var assetRoot = window.__HYP_CLIENT_ASSET_ROOT__ || 'https://hypothes.is/assets/client/';
+
+boot(document, {
+  appHtmlUrl: appHtmlUrl,
+  assetRoot: assetRoot,
+  manifest: __MANIFEST__,  // Replaced by build script
+});

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -2,6 +2,10 @@
 
 // This is the main entry point for the Hypothesis client in the host page
 // and the sidebar application.
+//
+// The same boot script is used for both entry points so that the browser
+// already has it cached when it encounters the reference in the sidebar
+// application.
 
 /* global __MANIFEST__ */
 

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -77,7 +77,7 @@ describe('bootstrap', function () {
         'styles/inject.1234.css',
         'styles/pdfjs-overrides.1234.css',
       ].map(function (url) {
-        return 'https://marginal.ly/client/' + url;
+        return 'https://marginal.ly/client/build/' + url;
       });
 
       assert.deepEqual(findAssets(iframe.contentDocument), expectedAssets);
@@ -131,7 +131,7 @@ describe('bootstrap', function () {
         'styles/icomoon.1234.css',
         'styles/katex.min.1234.css',
       ].map(function (url) {
-        return 'https://marginal.ly/client/' + url;
+        return 'https://marginal.ly/client/build/' + url;
       });
 
       assert.deepEqual(findAssets(iframe.contentDocument), expectedAssets);

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -1,0 +1,140 @@
+'use strict';
+
+var boot = require('../boot');
+
+describe('bootstrap', function () {
+  var iframe;
+
+  beforeEach(function () {
+    iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+  });
+
+  afterEach(function () {
+    iframe.remove();
+  });
+
+  function runBoot() {
+    var assetNames = [
+      // Annotation layer
+      'scripts/polyfills.bundle.js',
+      'scripts/jquery.bundle.js',
+      'scripts/injector.bundle.js',
+      'styles/icomoon.css',
+      'styles/inject.css',
+      'styles/pdfjs-overrides.css',
+
+      // Sidebar app
+      'scripts/raven.bundle.js',
+      'scripts/angular.bundle.js',
+      'scripts/katex.bundle.js',
+      'scripts/showdown.bundle.js',
+      'scripts/polyfills.bundle.js',
+      'scripts/unorm.bundle.js',
+      'scripts/app.bundle.js',
+
+      'styles/angular-csp.css',
+      'styles/angular-toastr.css',
+      'styles/icomoon.css',
+      'styles/katex.min.css',
+      'styles/app.css',
+    ];
+
+    var manifest = assetNames.reduce(function (manifest, path) {
+      var url = path.replace(/\.([a-z]+)$/, '.1234.$1');
+      manifest[path] = url;
+      return manifest;
+    }, {});
+
+    boot(iframe.contentDocument, {
+      appHtmlUrl: 'https://marginal.ly/app.html',
+      assetRoot: 'https://marginal.ly/client/',
+      manifest: manifest,
+    });
+  }
+
+  function findAssets(doc_) {
+    var scripts = Array.from(doc_.querySelectorAll('script')).map(function (el) {
+      return el.src;
+    });
+
+    var styles = Array.from(doc_.querySelectorAll('link[rel="stylesheet"]'))
+      .map(function (el) {
+        return el.href;
+      });
+
+    return scripts.concat(styles).sort();
+  }
+
+  context('in the host page', function () {
+    it('loads assets for the annotation layer', function () {
+      runBoot();
+      var expectedAssets = [
+        'scripts/injector.bundle.1234.js',
+        'scripts/jquery.bundle.1234.js',
+        'scripts/polyfills.bundle.1234.js',
+        'styles/icomoon.1234.css',
+        'styles/inject.1234.css',
+        'styles/pdfjs-overrides.1234.css',
+      ].map(function (url) {
+        return 'https://marginal.ly/client/' + url;
+      });
+
+      assert.deepEqual(findAssets(iframe.contentDocument), expectedAssets);
+    });
+
+    it('creates the link to the sidebar iframe', function () {
+      runBoot();
+
+      var sidebarAppLink = iframe.contentDocument
+        .querySelector('link[type="application/annotator+html"]');
+      assert.ok(sidebarAppLink);
+      assert.equal(sidebarAppLink.href, 'https://marginal.ly/app.html');
+    });
+
+    it('does nothing if Hypothesis is already loaded in the document', function () {
+      var link = iframe.contentDocument.createElement('link');
+      link.type = 'application/annotator+html';
+      iframe.contentDocument.head.appendChild(link);
+
+      runBoot();
+
+      assert.deepEqual(findAssets(iframe.contentDocument), []);
+    });
+  });
+
+  context('in the sidebar application', function () {
+    var appRootElement;
+
+    beforeEach(function () {
+      appRootElement = iframe.contentDocument.createElement('hypothesis-app');
+      iframe.contentDocument.body.appendChild(appRootElement);
+    });
+
+    afterEach(function () {
+      appRootElement.remove();
+    });
+
+    it('loads assets for the sidebar application', function () {
+      runBoot();
+      var expectedAssets = [
+        'scripts/angular.bundle.1234.js',
+        'scripts/app.bundle.1234.js',
+        'scripts/katex.bundle.1234.js',
+        'scripts/polyfills.bundle.1234.js',
+        'scripts/raven.bundle.1234.js',
+        'scripts/showdown.bundle.1234.js',
+        'scripts/unorm.bundle.1234.js',
+        'styles/angular-csp.1234.css',
+        'styles/angular-toastr.1234.css',
+        'styles/app.1234.css',
+        'styles/icomoon.1234.css',
+        'styles/katex.min.1234.css',
+      ].map(function (url) {
+        return 'https://marginal.ly/client/' + url;
+      });
+
+      assert.deepEqual(findAssets(iframe.contentDocument), expectedAssets);
+    });
+  });
+});

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -47,7 +47,7 @@ describe('bootstrap', function () {
     }, {});
 
     boot(iframe.contentDocument, {
-      appHtmlUrl: 'https://marginal.ly/app.html',
+      sidebarAppUrl: 'https://marginal.ly/app.html',
       assetRoot: 'https://marginal.ly/client/',
       manifest: manifest,
     });

--- a/src/shared/settings.js
+++ b/src/shared/settings.js
@@ -1,5 +1,16 @@
 'use strict';
 
+// `Object.assign()`-like helper. Used because this script needs to work
+// in IE 10/11 without polyfills.
+function assign(dest, src) {
+  for (var k in src) {
+    if (src.hasOwnProperty(k)) {
+      dest[k] = src[k];
+    }
+  }
+  return dest;
+}
+
 /**
  * Return application configuration information from the host page.
  *
@@ -21,7 +32,7 @@ function settings(document, settingsClass) {
 
   var config = {};
   for (var i=0; i < settingsElements.length; i++) {
-    Object.assign(config, JSON.parse(settingsElements[i].textContent));
+    assign(config, JSON.parse(settingsElements[i].textContent));
   }
   return config;
 }


### PR DESCRIPTION
Add a new bundle (build/boot.js) which serves as the main entry point
for the client. This entry point will be used in two places:

 1. When embedded in a host web page it will add the bundle for the
    annotation layer (injector.bundle.js) to the page plus supporting
    assets.

 2. When included as the sole asset in the sidebar's HTML page
    it will add the bundle for the sidebar app (app.bundle.js) to the
    page plus supporting assets.

Having both entry points be a single script means that when it is
referenced in app.html, the browser will already have it cached locally,
saving a roundtrip.

In this commit the script just adds all <script> and <link> tags for the
annotation layer or sidebar to the document. In future it can be made
smarter - eg. by preloading sidebar assets when loaded in the host page
and not loading polyfills in newer browsers.

This PR does not otherwise change the structure of the client, so it will continue to work with the service's own boot code for the client until the service has been modified to use this entry point.