### PR TITLE
Don't delete cached OAuth access token

### DIFF
--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -59,8 +59,11 @@ function auth($http, settings) {
     }
   }
 
+  // clearCache() isn't implemented (or needed) yet for OAuth.
+  // In the future, for example when OAuth-authenticated users can login and
+  // logout of the client, this clearCache() will need to clear the access
+  // token and cancel any scheduled refresh token requests.
   function clearCache() {
-    cachedToken = null;
   }
 
   return {

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -59,6 +59,16 @@ function session($http, $resource, $rootScope, annotationUI, auth,
   var lastLoad;
   var lastLoadTime;
 
+
+  // Return the authority from the first service defined in the settings.
+  // Return null if there are no services defined in the settings.
+  function getAuthority() {
+    if (Array.isArray(settings.services) && settings.services.length > 0) {
+      return settings.services[0].authority;
+    }
+    return null;
+  }
+
   /**
    * @name session.load()
    * @description Fetches the session data from the server.
@@ -79,10 +89,7 @@ function session($http, $resource, $rootScope, annotationUI, auth,
       // the /app endpoint.
       lastLoadTime = Date.now();
       lastLoad = retryUtil.retryPromiseOperation(function () {
-        var authority;
-        if (Array.isArray(settings.services) && settings.services.length > 0) {
-          authority = settings.services[0].authority;
-        }
+        var authority = getAuthority();
         if (authority) {
           return store.profile.read({authority: authority}).then(update);
         } else {
@@ -138,7 +145,9 @@ function session($http, $resource, $rootScope, annotationUI, auth,
     lastLoadTime = Date.now();
 
     if (userChanged) {
-      auth.clearCache();
+      if (!getAuthority()) {
+        auth.clearCache();
+      }
 
       $rootScope.$broadcast(events.USER_CHANGED, {
         initialLoad: isInitialLoad,

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -90,16 +90,4 @@ describe('oauth auth', function () {
       });
     });
   });
-
-  describe('#clearCache', function () {
-    it('should clear cached tokens', function () {
-      return auth.tokenGetter().then(function () {
-        fakeHttp.post.reset();
-        auth.clearCache();
-        return auth.tokenGetter();
-      }).then(function () {
-        assert.calledOnce(fakeHttp.post);
-      });
-    });
-  });
 });

--- a/src/sidebar/test/session-test.js
+++ b/src/sidebar/test/session-test.js
@@ -263,6 +263,17 @@ describe('session', function () {
         id: 'anne',
       });
     });
+
+    it('does not clear the access token when the host page provides a grant token', function () {
+      fakeSettings.services = [{
+        authority: 'publisher.org',
+        grantToken: 'a.jwt.token',
+      }];
+
+      session.update({userid: 'different-user', csrf: 'dummytoken'});
+
+      assert.notCalled(fakeAuth.clearCache);
+    });
   });
 
   describe('#dismissSidebarTutorial()', function () {


### PR DESCRIPTION
Don't delete the cached OAuth access token
This fixes an issue that, when the client is embedded on a partner site
using third-party auth:

1. The client reads grant token that the client embeds in their page
   from the page
2. The oauth-auth service sends a grant token request, receives back an
   access token which it caches
3. session.js calls oauth-auth's clearCache(), which deletes the access
   token
4. The next time the access token is needed the oauth-auth sends a
   second grant token request, with the same grant token, and gets a
   second access token

So two grant token requests are sent, when only one was needed, because
the cached access token is deleted unnecessarily.

The fix is to make clearCache() in oauth-auth a no-op for now. For now
it never makes sense for oauth-auth to clear its cached access token.
OAuth is currently only used when the client is embedded in partner
sites and the grant token is embedded in the page by the client. Since
the grant token never changes, there's never any reason to clear the
access token and request a new one using the same grant token again (you
would just be requesting a new access token for the same user account).