### PR TITLE
Don't reuse OAuth grant tokens

### DIFF
--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -41,16 +41,12 @@ function auth($http, settings) {
   }
 
   function tokenGetter() {
-    // performance.now() is used instead of Date.now() because it is
-    // monotonically increasing.
-    if (cachedToken && cachedToken.expiresAt > performance.now()) {
+    if (cachedToken) {
       return Promise.resolve(cachedToken.token);
     } else if (grantToken) {
-      var refreshStart = performance.now();
       return exchangeToken(grantToken).then(function (tokenInfo) {
         cachedToken = {
           token: tokenInfo.access_token,
-          expiresAt: refreshStart + tokenInfo.expires_in * 1000,
         };
         return cachedToken.token;
       });

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -16,11 +16,6 @@ function auth($http, settings) {
   var cachedToken;
   var tokenUrl = resolve('token', settings.apiUrl);
 
-  var grantToken;
-  if (Array.isArray(settings.services) && settings.services.length > 0) {
-    grantToken = settings.services[0].grantToken;
-  }
-
   // Exchange the JWT grant token for an access token.
   // See https://tools.ietf.org/html/rfc7523#section-4
   function exchangeToken(grantToken) {
@@ -43,15 +38,23 @@ function auth($http, settings) {
   function tokenGetter() {
     if (cachedToken) {
       return Promise.resolve(cachedToken.token);
-    } else if (grantToken) {
+    } else {
+      var grantToken;
+
+      if (Array.isArray(settings.services) && settings.services.length > 0) {
+        grantToken = settings.services[0].grantToken;
+      }
+
+      if (!grantToken) {
+        return Promise.resolve(null);
+      }
+
       return exchangeToken(grantToken).then(function (tokenInfo) {
         cachedToken = {
           token: tokenInfo.access_token,
         };
         return cachedToken.token;
       });
-    } else {
-      return Promise.resolve(null);
     }
   }
 

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -72,23 +72,6 @@ describe('oauth auth', function () {
         assert.equal(token, null);
       });
     });
-
-    it('should refresh the access token if it has expired', function () {
-      return auth.tokenGetter().then(function () {
-        var now = performance.now();
-        nowStub.returns(now + DEFAULT_TOKEN_EXPIRES_IN_SECS * 1000 + 100);
-        fakeHttp.post.returns(Promise.resolve({
-          status: 200,
-          data: {
-            access_token: 'a-different-access-token',
-            expires_in: DEFAULT_TOKEN_EXPIRES_IN_SECS,
-          },
-        }));
-        return auth.tokenGetter();
-      }).then(function (token) {
-        assert.equal(token, 'a-different-access-token');
-      });
-    });
   });
 
   describe('#clearCache', function () {


### PR DESCRIPTION
Don't reuse the OAuth grant token if the access token has expired.

The grant token is only intended to be used once, and if the access
token has expired then the grant token will likely have expired as well anyway.

A later commit will add support for refreshing an expired access token
using its refresh token, instead.