### PR TITLE
Cache access token promise not access token

### DIFF
--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -36,25 +36,23 @@ function auth($http, settings) {
   }
 
   function tokenGetter() {
-    if (accessTokenPromise) {
-      return accessTokenPromise;
-    } else {
+    if (!accessTokenPromise) {
       var grantToken;
 
       if (Array.isArray(settings.services) && settings.services.length > 0) {
         grantToken = settings.services[0].grantToken;
       }
 
-      if (!grantToken) {
-        return Promise.resolve(null);
+      if (grantToken) {
+        accessTokenPromise = exchangeToken(grantToken).then(function (tokenInfo) {
+          return tokenInfo.access_token;
+        });
+      } else {
+        accessTokenPromise = Promise.resolve(null);
       }
-
-      accessTokenPromise = exchangeToken(grantToken).then(function (tokenInfo) {
-        return tokenInfo.access_token;
-      });
-
-      return accessTokenPromise;
     }
+
+    return accessTokenPromise;
   }
 
   // clearCache() isn't implemented (or needed) yet for OAuth.

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -13,7 +13,7 @@ var resolve = require('./util/url-util').resolve;
 // @ngInject
 function auth($http, settings) {
 
-  var cachedToken;
+  var accessTokenPromise;
   var tokenUrl = resolve('token', settings.apiUrl);
 
   // Exchange the JWT grant token for an access token.
@@ -36,8 +36,8 @@ function auth($http, settings) {
   }
 
   function tokenGetter() {
-    if (cachedToken) {
-      return Promise.resolve(cachedToken.token);
+    if (accessTokenPromise) {
+      return accessTokenPromise;
     } else {
       var grantToken;
 
@@ -49,12 +49,11 @@ function auth($http, settings) {
         return Promise.resolve(null);
       }
 
-      return exchangeToken(grantToken).then(function (tokenInfo) {
-        cachedToken = {
-          token: tokenInfo.access_token,
-        };
-        return cachedToken.token;
+      accessTokenPromise = exchangeToken(grantToken).then(function (tokenInfo) {
+        return tokenInfo.access_token;
       });
+
+      return accessTokenPromise;
     }
   }
 


### PR DESCRIPTION
Cache the access token request promise, not just the access token
itself.

This commit fixes a problem that the client would send multiple concurrent
access token requests if tokenGetter() was called multiple times before
a response to any of the HTTP requests was received:

1. tokenGetter() is called, sends an HTTP request for the access token
   and returns a Promise for the access token from the request's response

2. Before the HTTP response is received tokenGetter() is called again,
   sends another HTTP request, returns another Promise.

As soon as one access token response is received then tokenGetter()
caches the access token and just returns it, doesn't send any more HTTP
requests, but each time tokenGetter() is called *before the first access
token response has been received* it sends another, concurrent access
token request. It does not "know" that it already has an access token
request in-flight.

The fix is to cache the first access token request Promise when the first
access token request is sent and then just keep returning that Promise, instead
of sending more requests:

Instead of caching the access token itself (`cachedToken`) we now cache
a Promise for the access token (`accessTokenPromise`) the first
time we send the access token request.

Each further time that `tokenGetter()` is called, if it already has a
`accessTokenPromise`, then it just returns the Promise and doesn't
send another HTTP request. It now "knows" that it already has an access
token request in-flight.