### PR TITLE
correcting CC0 terminology

### DIFF
--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -121,7 +121,7 @@
     <div class="annotation-section annotation-license"
       ng-show="vm.isShared() && vm.editing()">
       <a class="annotation-license__link" href="http://creativecommons.org/publicdomain/zero/1.0/"
-        title="View more information about the Creative Commons Public Domain license"
+        title="View more information about the Creative Commons Public Domain dedication"
         target="_blank">
         <i class="h-icon-cc-logo"></i><i class="h-icon-cc-zero"></i>
         Annotations can be freely reused by anyone for any purpose.


### PR DESCRIPTION
CC0 is not a license. Licenses are applied to copyrighted works to permit certain kinds of use. CC0 is used to waive copyright and dedicate a work immediately into the public domain.  Read CC0 [FAQs](https://wiki.creativecommons.org/wiki/CC0_FAQ0) or [summary](https://creativecommons.org/share-your-work/public-domain/cc0/).