### PR TITLE
Fix quote anchoring in pages which add enumerable properties on Array.prototype

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1587,9 +1587,9 @@
       }
     },
     "dom-anchor-text-quote": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "from": "dom-anchor-text-quote@latest",
-      "resolved": "https://registry.npmjs.org/dom-anchor-text-quote/-/dom-anchor-text-quote-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dom-anchor-text-quote/-/dom-anchor-text-quote-4.0.2.tgz",
       "dev": true
     },
     "dom-node-iterator": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "document-base-uri": "^1.0.0",
     "dom-anchor-fragment": "^1.0.1",
     "dom-anchor-text-position": "^4.0.0",
-    "dom-anchor-text-quote": "^4.0.1",
+    "dom-anchor-text-quote": "^4.0.2",
     "dom-seek": "^1.0.1",
     "end-of-stream": "^1.1.0",
     "escape-html": "^1.0.3",


### PR DESCRIPTION
Update dom-anchor-text-quote to incorporate
tilgovi/dom-anchor-text-quote#11 which fixes quote anchoring on pages
which include JS that adds enumerable properties to `Array.prototype`.

See https://github.com/hypothesis/product-backlog/issues/143#issuecomment-274135334 for a detailed explanation of the problem and https://github.com/hypothesis/product-backlog/issues/143#issuecomment-279143898 for URLs to test with using a production extension build.

Fixes hypothesis/product-backlog#143