### PR TITLE
Add additional preversion checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "lint": "eslint .",
     "test": "gulp test",
     "report-coverage": "codecov -f coverage/coverage-final.json",
-    "preversion": "npm run test",
+    "preversion": "./scripts/preversion.sh",
     "version": "make clean all && ./scripts/update-changelog.js && git add CHANGELOG.md",
     "postversion": "./scripts/postversion.sh",
     "prepublish": "npm run-script build"

--- a/scripts/preversion.sh
+++ b/scripts/preversion.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -eu
+
+# Check that tag signing works
+git tag --sign --message "Dummy Tag" dummy-tag
+git tag --delete dummy-tag > /dev/null
+
+# Check GitHub API access token
+CLIENT_INFO_URL=https://api.github.com/repos/hypothesis/client
+REPO_TMPFILE=/tmp/client-repo.json
+curl -s -H "Authorization: Bearer $GITHUB_TOKEN" $CLIENT_INFO_URL > $REPO_TMPFILE
+CAN_PUSH=$(node -p -e "perms = require('$REPO_TMPFILE').permissions, perms && perms.push")
+
+if [ "$CAN_PUSH" != "true" ]; then
+  echo "Cannot push to GitHub using the access token '$GITHUB_TOKEN'"
+  exit 1
+fi
+
+# Check that we're not releasing broken code
+make test


### PR DESCRIPTION
Before bumping the package version and creating the tag, verify that:

 - Git is set up to create signed tags

 - GITHUB_TOKEN is set to an access token with permissions to push to
   the hypothesis/client repository

**Testing:** Run `npm run preversion`. Try without GITHUB_TOKEN set and with GITHUB_TOKEN set to an incorrect value.