### PR TITLE
Add invisible threads list to allow render time saving for out of vie…

### DIFF
--- a/src/sidebar/directive/thread-list.js
+++ b/src/sidebar/directive/thread-list.js
@@ -33,6 +33,16 @@ function getThreadHeight(id) {
   return elementHeight + marginHeight;
 }
 
+var virtualThreadOptions = {
+  // identify the thread types that need to be rendered
+  // but not actually visible to the user
+  invisibleThreadFilter: function(thread){
+    // new highlights should always get rendered so we don't
+    // miss saving them via the render-save process
+    return thread.annotation.$highlight && metadata.isNew(thread.annotation);
+  },
+};
+
 // @ngInject
 function ThreadListController($scope, VirtualThreadList) {
   // `visibleThreads` keeps track of the subset of all threads matching the
@@ -40,10 +50,11 @@ function ThreadListController($scope, VirtualThreadList) {
   // only those threads, using placeholders above and below the visible threads
   // to reserve space for threads which are not actually rendered.
   var self = this;
-  var visibleThreads = new VirtualThreadList($scope, window, this.thread);
+  var visibleThreads = new VirtualThreadList($scope, window, this.thread, virtualThreadOptions);
   visibleThreads.on('changed', function (state) {
     self.virtualThreadList = {
       visibleThreads: state.visibleThreads,
+      invisibleThreads: state.invisibleThreads,
       offscreenUpperHeight: state.offscreenUpperHeight + 'px',
       offscreenLowerHeight: state.offscreenLowerHeight + 'px',
     };

--- a/src/sidebar/templates/thread_list.html
+++ b/src/sidebar/templates/thread_list.html
@@ -14,6 +14,11 @@
         on-force-visible="vm.onForceVisible({thread: thread})">
       </annotation-thread>
   </li>
+  <li id="{{child.id}}"
+      ng-show="false"
+      ng-repeat="child in vm.virtualThreadList.invisibleThreads track by child.id">
+      <annotation-thread thread="child" />
+  </li>
   <li class="thread-list__spacer"
       ng-style="{height: vm.virtualThreadList.offscreenLowerHeight}"></li>
 </ul>


### PR DESCRIPTION
…wport threads

fixes https://github.com/hypothesis/h/issues/4298

Adding new highlights to an invisible thread list so it will still go through all of the saving logic tied to rendering but in a way that doesn't cause conflicts with it being presented in the wrong context.

Testing this, I would get master going where you make a bunch of highlights (north of 15 of them) and you will start to notice that creating a new highlight deletes the previous one. Once you get to that state, load up this new extension and watch that behavior go away.

