### PR TITLE
Update Showdown from 1.3.0 to 1.6.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2350,6 +2350,12 @@
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "dev": true
     },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "from": "get-caller-file@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "dev": true
+    },
     "get-stdin": {
       "version": "4.0.1",
       "from": "get-stdin@>=4.0.1 <5.0.0",
@@ -5066,6 +5072,18 @@
       "resolved": "https://registry.npmjs.org/require-deps/-/require-deps-1.0.1.tgz",
       "dev": true
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "from": "require-directory@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "from": "require-main-filename@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "dev": true
+    },
     "require-uncached": {
       "version": "1.0.2",
       "from": "require-uncached@>=1.0.2 <2.0.0",
@@ -5196,6 +5214,12 @@
       "resolved": "http://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
       "dev": true
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "from": "set-blocking@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "dev": true
+    },
     "setprototypeof": {
       "version": "1.0.1",
       "from": "setprototypeof@1.0.1",
@@ -5233,10 +5257,36 @@
       "dev": true
     },
     "showdown": {
-      "version": "1.3.0",
-      "from": "showdown@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.3.0.tgz",
-      "dev": true
+      "version": "1.6.4",
+      "from": "showdown@latest",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.6.4.tgz",
+      "dev": true,
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "from": "camelcase@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "from": "cliui@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "from": "string-width@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "dev": true
+        },
+        "yargs": {
+          "version": "6.6.0",
+          "from": "yargs@>=6.6.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "dev": true
+        }
+      }
     },
     "sigmund": {
       "version": "1.0.1",
@@ -6188,6 +6238,12 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
       "dev": true
     },
+    "which-module": {
+      "version": "1.0.0",
+      "from": "which-module@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "dev": true
+    },
     "window-size": {
       "version": "0.1.4",
       "from": "window-size@>=0.1.2 <0.2.0",
@@ -6198,6 +6254,12 @@
       "version": "0.0.2",
       "from": "wordwrap@0.0.2",
       "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "from": "wrap-ansi@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "dev": true
     },
     "wrappy": {
@@ -6265,6 +6327,20 @@
       "from": "yargs@>=3.27.0 <3.28.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
       "dev": true
+    },
+    "yargs-parser": {
+      "version": "4.2.1",
+      "from": "yargs-parser@>=4.2.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "from": "camelcase@^3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "dev": true
+        }
+      }
     },
     "yauzl": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "retry": "^0.8.0",
     "scroll-into-view": "^1.3.1",
     "seamless-immutable": "^6.0.1",
-    "showdown": "^1.2.1",
+    "showdown": "^1.6.4",
     "sinon": "^1.17.3",
     "stringify": "^5.1.0",
     "through2": "^2.0.1",

--- a/src/sidebar/test/render-markdown-test.js
+++ b/src/sidebar/test/render-markdown-test.js
@@ -68,8 +68,8 @@ describe('render-markdown', function () {
 
     it('should render mixed blocks', function () {
       assert.equal(render('one $$x*2$$ two $$x*3$$ three'),
-        '<p>one </p>\n\n<p>math+display:x*2</p>\n\n' +
-        '<p>two </p>\n\n<p>math+display:x*3</p>\n\n<p>three</p>');
+        '<p>one </p>\n<p>math+display:x*2</p>\n' +
+        '<p>two </p>\n<p>math+display:x*3</p>\n<p>three</p>');
     });
 
     it('should not sanitize math renderer output', function () {
@@ -77,12 +77,12 @@ describe('render-markdown', function () {
         return html.toLowerCase();
       };
       assert.equal(render('$$X*2$$ FOO', fakeSanitize),
-        '<p>math+display:X*2</p>\n\n<p>foo</p>');
+        '<p>math+display:X*2</p>\n<p>foo</p>');
     });
 
     it('should render mixed inline and block math', function () {
       assert.equal(render('one \\(x*2\\) three $$x*3$$'),
-        '<p>one math:x*2 three </p>\n\n<p>math+display:x*3</p>');
+        '<p>one math:x*2 three </p>\n<p>math+display:x*3</p>');
     });
   });
 


### PR DESCRIPTION
Improves performance and includes a number of bug fixes. See
https://github.com/showdownjs/showdown/blob/master/CHANGELOG.md for
changes.

Several tests required small changes because the rendering of
`para1\n\npara2` changed from:

  `<p>para1</p>\n\n<p>para2</p>`

To the visually equivalent:

  `<p>para1</p>\n<p>para2</p>`