### PR TITLE
Don't treat annotation quotes (TextQuoteSelector.exact) as HTML

### DIFF
--- a/src/sidebar/directive/test/annotation-test.js
+++ b/src/sidebar/directive/test/annotation-test.js
@@ -989,5 +989,15 @@ describe('annotation', function() {
         assert.equal(controller.links().html, '');
       });
     });
+
+    it('renders quotes as plain text', function () {
+      var ann = fixtures.defaultAnnotation();
+      ann.target[0].selector = [{
+        type: 'TextQuoteSelector',
+        exact: '<<-&->>',
+      }];
+      var el = createDirective(ann).element;
+      assert.equal(el[0].querySelector('blockquote').textContent, '<<-&->>');
+    });
   });
 });

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -63,7 +63,7 @@
       overflow-hysteresis="20"
       content-data="selector.exact">
       <blockquote class="annotation-quote"
-        ng-bind-html="selector.exact"
+        ng-bind="selector.exact"
         ng-repeat="selector in target.selector
           | filter : {'type': 'TextQuoteSelector'}
           track by $index"></blockquote>


### PR DESCRIPTION
The annotation quote, as plucked from the TextQuoteSelector, is not HTML, and so shouldn't be rendered as such.

Fixes hypothesis/h#2896.

_I'm not really sure how to test this atm. Thoughts?_