### PR TITLE
Call partner provided login callback

### DIFF
--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -5,6 +5,7 @@ Hammer = require('hammerjs')
 Host = require('./host')
 annotationCounts = require('./annotation-counts')
 sidebarTrigger = require('./sidebar-trigger')
+events = require('../shared/bridge-events');
 
 # Minimum width to which the frame can be resized.
 MIN_RESIZE = 280
@@ -35,6 +36,9 @@ module.exports = class Sidebar extends Host
     if @plugins.Toolbar?
       this._setupGestures()
 
+    # The partner-provided login callback function (if any).
+    @onLogin = options.services?[0]?.onLogin
+
     this._setupSidebarEvents()
 
   _setupDocumentEvents: ->
@@ -50,6 +54,10 @@ module.exports = class Sidebar extends Host
 
     @crossframe.on('show', this.show.bind(this))
     @crossframe.on('hide', this.hide.bind(this))
+    @crossframe.on(events.DO_LOGIN, =>
+      if @onLogin
+        @onLogin()
+    );
 
     # Return this for chaining
     this

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -1,4 +1,5 @@
 Annotator = require('annotator')
+events = require('../../shared/bridge-events')
 
 proxyquire = require('proxyquire')
 Sidebar = proxyquire('../sidebar', {
@@ -45,6 +46,70 @@ describe 'Sidebar', ->
         sidebar = createSidebar()
         emitEvent('hide')
         assert.called(target)
+
+    describe 'on DO_LOGIN event', ->
+      it 'calls the onLogin callback function if one was provided', ->
+        onLogin = sandbox.stub()
+        sidebar = createSidebar(options={services: [{onLogin: onLogin}]})
+
+        emitEvent(events.DO_LOGIN)
+
+        assert.called(onLogin)
+
+      it 'only calls the onLogin callback of the first service', ->
+        # Even though options.services is an array it only calls the onLogin
+        # callback function of the first service. The onLogins of any other
+        # services are ignored.
+        firstOnLogin  = sandbox.stub()
+        secondOnLogin = sandbox.stub()
+        thirdOnLogin  = sandbox.stub()
+        sidebar = createSidebar(
+          options={
+            services: [
+              {onLogin: firstOnLogin},
+              {onLogin: secondOnLogin},
+              {onLogin: thirdOnLogin},
+            ]
+          }
+        )
+
+        emitEvent(events.DO_LOGIN)
+
+        assert.called(firstOnLogin)
+        assert.notCalled(secondOnLogin)
+        assert.notCalled(thirdOnLogin)
+
+      it 'never calls the onLogin callbacks of further services', ->
+        # Even if the first service doesn't have an onLogin, it still doesn't
+        # call the onLogins of further services.
+        secondOnLogin = sandbox.stub()
+        thirdOnLogin  = sandbox.stub()
+        sidebar = createSidebar(
+          options={
+            services: [
+              {},
+              {onLogin: secondOnLogin},
+              {onLogin: thirdOnLogin},
+            ]
+          }
+        )
+
+        emitEvent(events.DO_LOGIN)
+
+        assert.notCalled(secondOnLogin)
+        assert.notCalled(thirdOnLogin)
+
+      it 'does not crash if there is no services', ->
+        sidebar = createSidebar(options={})  # No options.services
+        emitEvent(events.DO_LOGIN)
+
+      it 'does not crash if services is an empty array', ->
+        sidebar = createSidebar(options={services: []})
+        emitEvent(events.DO_LOGIN)
+
+      it 'does not crash if the first service has no onLogin', ->
+        sidebar = createSidebar(options={services: [{}]})
+        emitEvent(events.DO_LOGIN)
 
   describe 'pan gestures', ->
     sidebar = null

--- a/src/shared/bridge-events.js
+++ b/src/shared/bridge-events.js
@@ -11,6 +11,12 @@ module.exports = {
   /** The set of annotations was updated. */
   PUBLIC_ANNOTATION_COUNT_CHANGED: 'publicAnnotationCountChanged',
 
+  /** The sidebar is asking the annotator to do a partner site login.
+   *  (for example, pop up a login window). This is used when the client is
+   *  embedded in a partner site and a login button in the client is clicked.
+   */
+  DO_LOGIN: 'doLogin',
+
   // Events that the annotator sends to the sidebar
   // ----------------------------------------------
 };

--- a/src/shared/bridge-events.js
+++ b/src/shared/bridge-events.js
@@ -5,6 +5,12 @@
  * across the bridge between the sidebar and annotator
  */
 module.exports = {
+  // Events that the sidebar sends to the annotator
+  // ----------------------------------------------
+
   /** The set of annotations was updated. */
   PUBLIC_ANNOTATION_COUNT_CHANGED: 'publicAnnotationCountChanged',
+
+  // Events that the annotator sends to the sidebar
+  // ----------------------------------------------
 };

--- a/src/sidebar/app-controller.js
+++ b/src/sidebar/app-controller.js
@@ -6,6 +6,8 @@ var events = require('./events');
 var parseAccountID = require('./filter/persona').parseAccountID;
 var scopeTimeout = require('./util/scope-timeout');
 var uiConstants = require('./ui-constants');
+var serviceConfig = require('./service-config');
+var bridgeEvents = require('../shared/bridge-events');
 
 function authStateFromUserID(userid) {
   if (userid) {
@@ -24,7 +26,7 @@ function authStateFromUserID(userid) {
 // @ngInject
 module.exports = function AppController(
   $document, $location, $rootScope, $route, $scope,
-  $window, annotationUI, auth, drafts, features, frameSync, groups,
+  $window, annotationUI, auth, bridge, drafts, features, frameSync, groups,
   serviceUrl, session, settings, streamer
 ) {
 
@@ -98,6 +100,11 @@ module.exports = function AppController(
 
   // Start the login flow. This will present the user with the login dialog.
   $scope.login = function () {
+    if (serviceConfig(settings)) {
+      bridge.call(bridgeEvents.DO_LOGIN);
+      return;
+    }
+
     $scope.accountDialog.visible = true;
     scrollToView('login-form');
   };


### PR DESCRIPTION
If the partner site provides an `onLogin` callback as in https://github.com/hypothesis/publisher-account-example-site/pull/7 then this will make the client call it.

![peek 2017-02-22 17-18](https://cloud.githubusercontent.com/assets/22498/23223448/03d2ae26-f923-11e6-85b5-22ba2692652e.gif)
