### PR TITLE
Fix PDF quote anchoring

### DIFF
--- a/src/annotator/anchoring/pdf.coffee
+++ b/src/annotator/anchoring/pdf.coffee
@@ -46,6 +46,8 @@ getPageTextContent = (pageIndex) ->
     return pageTextCache[pageIndex]
 
 
+# Return the offset in the text for the whole document at which the text for
+# `pageIndex` begins.
 getPageOffset = (pageIndex) ->
   index = -1
 
@@ -59,6 +61,8 @@ getPageOffset = (pageIndex) ->
   return next(0)
 
 
+# Return an {index, offset, textContent} object for the page where the given
+# `offset` in the full text of the document occurs.
 findPage = (offset) ->
   index = 0
   total = 0
@@ -125,6 +129,7 @@ anchorByPosition = (page, anchor, options) ->
 
 
 # Search for a quote (with optional position hint) in the given pages.
+# Returns a `Promise<Range>` for the location of the quote.
 findInPages = ([pageIndex, rest...], quote, position) ->
   unless pageIndex?
     return Promise.reject('quote not found')
@@ -244,6 +249,19 @@ exports.anchor = (root, selectors, options = {}) ->
   return promise
 
 
+###*
+# Convert a DOM Range object into a set of selectors.
+#
+# Converts a DOM `Range` object describing a start and end point within a
+# `root` `Element` and converts it to a `[position, quote]` tuple of selectors
+# which can be saved into an annotation and later passed to `anchor` to map
+# the selectors back to a `Range`.
+#
+# :param Element root: The root Element
+# :param Range range: DOM Range object
+# :param Object options: Options passed to `TextQuoteAnchor` and
+#                        `TextPositionAnchor`'s `toSelector` methods.
+###
 exports.describe = (root, range, options = {}) ->
 
   range = new xpathRange.BrowserRange(range).normalize()
@@ -282,6 +300,11 @@ exports.describe = (root, range, options = {}) ->
     return Promise.all([position, quote])
 
 
+###*
+# Clear the internal caches of page text contents and quote locations.
+#
+# This exists mainly as a helper for use in tests.
+###
 exports.purgeCache = ->
   pageTextCache = {}
   quotePositionCache = {}

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -167,6 +167,24 @@ describe('PDF anchoring', function () {
       });
     });
 
+    it('anchors using a quote if the position anchor fails', function () {
+      viewer.setCurrentPage(0);
+      var range = findText(container, 'Pride And Prejudice');
+      return pdfAnchoring.describe(container, range).then(function (selectors) {
+        var position = selectors[0];
+        var quote = selectors[1];
+
+        // Manipulate the position selector so that it is no longer valid.
+        // Anchoring should fall back to the quote selector instead.
+        position.start += 5;
+        position.end += 5;
+
+        return pdfAnchoring.anchor(container, [position, quote]);
+      }).then(function (range) {
+        assert.equal(range.toString(), 'Pride And Prejudice');
+      });
+    });
+
     it('anchors to a placeholder element if the page is not rendered', function () {
       viewer.setCurrentPage(2);
       var range = findText(container, 'Netherfield Park');

--- a/src/annotator/anchoring/test/types-test.js
+++ b/src/annotator/anchoring/test/types-test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var types = require('../types');
+
+var TextQuoteAnchor = types.TextQuoteAnchor;
+var TextPositionAnchor = types.TextPositionAnchor;
+
+// These are primarily basic API tests for the anchoring classes. Tests for
+// anchoring a variety of HTML and PDF content exist in `html-test` and
+// `pdf-test`.
+describe('Anchoring classes', function () {
+  var container;
+
+  before(function () {
+    container = document.createElement('div');
+    container.innerHTML = [
+      'Four score and seven years ago our fathers brought forth on this continent,',
+      'a new nation, conceived in Liberty, and dedicated to the proposition that',
+      'all men are created equal.',
+    ].join(' ');
+    document.body.appendChild(container);
+  });
+
+  after(function () {
+    container.remove();
+  });
+
+  describe('TextQuoteAnchor', function () {
+    describe('#toRange', function () {
+      it('returns a valid DOM Range', function () {
+        var quoteAnchor = new TextQuoteAnchor(container, 'Liberty');
+        var range = quoteAnchor.toRange();
+        assert.instanceOf(range, Range);
+        assert.equal(range.toString(), 'Liberty');
+      });
+
+      it('throws if the quote is not found', function () {
+        var quoteAnchor = new TextQuoteAnchor(container, 'five score and nine years ago');
+        assert.throws(function () {
+          quoteAnchor.toRange();
+        });
+      });
+    });
+
+    describe('#toPositionAnchor', function () {
+      it('returns a TextPositionAnchor', function () {
+        var quoteAnchor = new TextQuoteAnchor(container, 'Liberty');
+        var pos = quoteAnchor.toPositionAnchor();
+        assert.instanceOf(pos, TextPositionAnchor);
+      });
+
+      it('throws if the quote is not found', function () {
+        var quoteAnchor = new TextQuoteAnchor(container, 'some are more equal than others');
+        assert.throws(function () {
+          quoteAnchor.toPositionAnchor();
+        });
+      });
+    });
+  });
+});

--- a/src/annotator/anchoring/test/types-test.js
+++ b/src/annotator/anchoring/test/types-test.js
@@ -8,7 +8,7 @@ var TextPositionAnchor = types.TextPositionAnchor;
 // These are primarily basic API tests for the anchoring classes. Tests for
 // anchoring a variety of HTML and PDF content exist in `html-test` and
 // `pdf-test`.
-describe('Anchoring classes', function () {
+describe('types', function () {
   var container;
 
   before(function () {

--- a/src/annotator/anchoring/types.coffee
+++ b/src/annotator/anchoring/types.coffee
@@ -1,3 +1,11 @@
+# This module exports a set of classes for converting between DOM `Range`
+# objects and different types of selector. It is mostly a thin wrapper around a
+# set of anchoring libraries. It serves two main purposes:
+#
+#  1. Providing a consistent interface across different types of anchor.
+#  2. Insulating the rest of the code from API changes in the underyling anchoring
+#     libraries.
+
 domAnchorTextPosition = require('dom-anchor-text-position')
 domAnchorTextQuote = require('dom-anchor-text-quote')
 
@@ -105,6 +113,12 @@ class TextQuoteAnchor
     if range == null
       throw new Error('Quote not found')
     range
+
+  toPositionAnchor: (options = {}) ->
+    anchor = domAnchorTextQuote.toTextPosition(@root, this.toSelector(), options)
+    if anchor == null
+      throw new Error('Quote not found')
+    new TextPositionAnchor(@root, anchor.start, anchor.end)
 
 
 exports.RangeAnchor = RangeAnchor


### PR DESCRIPTION
https://github.com/hypothesis/client/commit/270932b84c853231209e177ea57d093380e0cddc broke anchoring using quote selectors in PDFs because the re-implementation of the `TextQuoteAnchor` class was missing a method, `toPositionAnchor`, which PDF anchoring tried to call.

This did not affect the majority of annotations because it only affected cases where the position selector failed to anchor and so anchoring fell back to the quote selector.

Fixes https://github.com/hypothesis/product-backlog/issues/146 . Note that after creating the annotation as described in the issue _the highlighted region is offset_. This issue existed in Hypothesis v0.50 as well.

This PR:
 - Adds the missing method and a test for it
 - Adds a higher-level test in the PDF anchoring tests
 - Adds some documentation to the PDF anchoring code to clarify what a few of the different functions do.

While implementing this fix, I noticed that quote anchoring is broken in PDFs in other ways too - if the quote is not found on the first page that anchoring checks then it will never be found at all. I'm going to fix this separately.