### PR TITLE
Fix PDF quote anchoring (Part II)

### DIFF
--- a/src/annotator/anchoring/pdf.coffee
+++ b/src/annotator/anchoring/pdf.coffee
@@ -160,8 +160,9 @@ findInPages = ([pageIndex, rest...], quote, position) ->
   offset = getPageOffset(pageIndex)
 
   return Promise.all([page, content, offset])
-  .then(attempt, next)
+  .then(attempt)
   .then(cacheAndFinish)
+  .catch(next)
 
 
 # When a position anchor is available, quote search can prioritize pages by

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -139,7 +139,7 @@ describe('PDF anchoring', function () {
   describe('#anchor', function () {
     it('anchors previously created selectors if the page is rendered', function () {
       viewer.setCurrentPage(2);
-      var range = findText(container, 'Netherfield Park');
+      var range = findText(container, 'My dear Mr. Bennet');
       return pdfAnchoring.describe(container, range).then(function (selectors) {
         var position = selectors[0];
         var quote = selectors[1];
@@ -149,8 +149,7 @@ describe('PDF anchoring', function () {
         var subsets = [
           [position, quote],
           [position],
-          // FIXME - Anchoring a quote on its own does not currently work
-          // [quote],
+          [quote],
         ];
         var subsetsAnchored = subsets.map(function (subset) {
           var types = subset.map(function (s) { return s.type; });

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -18,7 +18,7 @@ function findText(container, text) {
 
 var fixtures = {
   // Each item in this list contains the text for one page of the "PDF"
-  pdfContent: [
+  pdfPages: [
     'Pride And Prejudice And Zombies\n' +
     'By Jane Austin and Seth Grahame-Smith ',
 
@@ -49,7 +49,7 @@ describe('PDF anchoring', function () {
 
     window.PDFViewerApplication = viewer = new FakePDFViewerApplication({
       container: container,
-      content: fixtures.pdfContent,
+      content: fixtures.pdfPages,
     });
     viewer.setCurrentPage(0);
   });
@@ -74,7 +74,7 @@ describe('PDF anchoring', function () {
       viewer.setCurrentPage(2);
       var quote = 'Netherfield Park';
       var range = findText(container, quote);
-      var contentStr = fixtures.pdfContent.join('');
+      var contentStr = fixtures.pdfPages.join('');
       var expectedPos = contentStr.replace(/\n/g,'').lastIndexOf(quote);
 
       return pdfAnchoring.describe(container, range).then(function (selectors) {
@@ -125,7 +125,7 @@ describe('PDF anchoring', function () {
         commonAncestorContainer: staticRange.commonAncestorContainer,
       };
 
-      var contentStr = fixtures.pdfContent.join('');
+      var contentStr = fixtures.pdfPages.join('');
       var expectedPos = contentStr.replace(/\n/g,'').lastIndexOf(quote);
 
       return pdfAnchoring.describe(container, range).then(function (selectors) {
@@ -178,6 +178,24 @@ describe('PDF anchoring', function () {
         // Anchoring should fall back to the quote selector instead.
         position.start += 5;
         position.end += 5;
+
+        return pdfAnchoring.anchor(container, [position, quote]);
+      }).then(function (range) {
+        assert.equal(range.toString(), 'Pride And Prejudice');
+      });
+    });
+
+    it('anchors using a quote if the position selector refers to the wrong page', function () {
+      viewer.setCurrentPage(0);
+      var range = findText(container, 'Pride And Prejudice');
+      return pdfAnchoring.describe(container, range).then(function (selectors) {
+        var position = selectors[0];
+        var quote = selectors[1];
+
+        // Manipulate the position selector so that it refers to a location
+        // a long way away, on a different page, than the quote.
+        position.start += fixtures.pdfPages[0].length + 10;
+        position.end += fixtures.pdfPages[0].length + 10;
 
         return pdfAnchoring.anchor(container, [position, quote]);
       }).then(function (range) {


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/261**~~

This PR fixes two additional issues related to anchoring of quote selectors in PDFs:

1. Quote anchoring only ever checked the text content of a single page, even though it was clearly supposed to check multiple pages starting with those closest to the location in the document given by the position selector.
2. Anchoring quote selectors failed if the annotation had no position selector, though it is clear from the code that the position selector was supposed to be optional, as it is for HTML anchoring.

