### PR TITLE
Enable CORS support in package content server

### DIFF
--- a/scripts/gulp/serve-package.js
+++ b/scripts/gulp/serve-package.js
@@ -21,6 +21,13 @@ var { version } = require('../../package.json');
 function servePackage(port, hostname) {
   var app = express();
 
+  // Enable CORS for assets so that cross-origin font loading works.
+  app.use(function (req, res, next) {
+    res.append('Access-Control-Allow-Origin', '*');
+    res.append('Access-Control-Allow-Methods', 'GET');
+    next();
+  });
+
   var serveBootScript = function (req, res) {
     var entryPath = require.resolve('../..');
     var entryScript = readFileSync(entryPath).toString('utf-8');


### PR DESCRIPTION
Add CORS headers to assets served by the client's dev server, otherwise
the client's icon font will fail to load in many browsers.

Testing:

1. Check out the latest master of the client and h repos. Enable the `use_client_boot_script` feature flag in the Hypothesis service.
2. Set `CLIENT_URL=http://localhost:3001/hypothesis` before running `make dev` in the service
3. Set `H_SERVICE_URL=http://localhost:5000` before running `gulp watch` in the client
4. Go to `http://localhost:3000` in Chrome or Firefox and see the client's icons fail to load
5. Check out this branch of the client, restart `gulp watch` and verify that the client's icons load