### PR TITLE
Change asset root URL to point to the `build/` dir instead of the package root

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -48,7 +48,9 @@ Hypothesis service at [hypothes.is](https://hypothes.is).
 
 ### `assetRoot`
 
-_String_. The URL from which client assets are loaded.
+_String_. The root URL from which client assets are loaded. This should be set to
+the root URL where the contents of the client's `build` directory are found, including
+the trailing slash. (Default: _https://cdn.hypothes.is/hypothesis/X.Y.Z/build/_)
 
 ### `sidebarAppUrl`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -46,17 +46,6 @@ These keys configure which annotation services the client connects to and where
 it loads assets from. By default, the client will connect to the public
 Hypothesis service at [hypothes.is](https://hypothes.is).
 
-### `assetRoot`
-
-_String_. The root URL from which client assets are loaded. This should be set to
-the root URL where the contents of the client's `build` directory are found, including
-the trailing slash. (Default: _https://cdn.hypothes.is/hypothesis/X.Y.Z/build/_)
-
-### `sidebarAppUrl`
-
-_String_. The URL for the sidebar application which displays annotations
-(Default: _https://hypothes.is/app.html_).
-
 ### `services`
 
 _Array_. A list of additional annotation services which the client should
@@ -69,3 +58,20 @@ Each service description is an object with the keys:
  * `authority` _String_. The domain name which the annotation service is associated with.
  * `grantToken` _String|null_. An OAuth grant token which the client can exchange for an access token in order to make authenticated requests to the service. If _null_, the user will only be able to read rather than create or modify annotations. (Default: _null_)
  * `icon` _String|null_. The URL to an image for the annotation service. This image will appear to the left of the name of the currently selected group. The image should be suitable for display at 16x16px and the recommended format is SVG.
+
+## Asset and sidebar app location
+
+These keys configure where the client's assets are loaded from.
+
+### `assetRoot`
+
+_String_. The root URL from which assets are loaded. This should be set to the
+URL where the contents of the `build` directory are hosted, including the
+trailing slash. (Default: For production builds:
+_https://cdn.hypothes.is/hypothesis/X.Y.Z/build/_, for development builds:
+_http://localhost:3001/hypothesis/X.Y.Z/build/_. _X.Y.Z_ is the package version from `package.json`)
+
+### `sidebarAppUrl`
+
+_String_. The URL for the sidebar application which displays annotations
+(Default: _https://hypothes.is/app.html_ . If the `H_SERVICE_URL` env var is set, defaults to `${H_SERVICE_URL}/app.html`)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -269,9 +269,9 @@ function generateBootScript(manifest) {
   var defaultAssetRoot;
 
   if (process.env.NODE_ENV === 'production') {
-    defaultAssetRoot = `https://cdn.hypothes.is/hypothesis/${version}/`;
+    defaultAssetRoot = `https://cdn.hypothes.is/hypothesis/${version}/build/`;
   } else {
-    defaultAssetRoot = `http://${packageServerHostname()}:3001/hypothesis/${version}/`;
+    defaultAssetRoot = `http://${packageServerHostname()}:3001/hypothesis/${version}/build/`;
   }
 
   if (isFirstBuild) {

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -21,7 +21,7 @@ function injectScript(doc, src) {
 
 function injectAssets(doc, config, assets) {
   assets.forEach(function (path) {
-    var url = config.assetRoot + 'build/' + config.manifest[path];
+    var url = config.assetRoot + config.manifest[path];
     if (url.match(/\.css/)) {
       injectStylesheet(doc, url);
     } else {

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -48,7 +48,7 @@ describe('bootstrap', function () {
 
     boot(iframe.contentDocument, {
       sidebarAppUrl: 'https://marginal.ly/app.html',
-      assetRoot: 'https://marginal.ly/client/',
+      assetRoot: 'https://marginal.ly/client/build/',
       manifest: manifest,
     });
   }


### PR DESCRIPTION
This PR changes the way the asset root URL config works to point to the root of the `build/` dir _inside_ the package instead of to the root of the package.

It also improves the documentation for the client asset settings and puts them in their own section of the docs, instead of under 'Annotation services' where it was incorrectly located previously.

The reason for this change is that in the browser extension, we want to put the client's assets at a path (relative to the root of the extension) that makes sense in that context (eg. `/client`) rather than say `/build` or `/client/build`. This does mean that using the config requires a little bit more knowledge about the structure of the package's contents (the fact that the assets are in a dir called `/build`) but I don't think that's a major problem.