### PR TITLE
Remove sourcemap link from boot script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -284,6 +284,9 @@ function generateBootScript(manifest) {
     .pipe(replace('__MANIFEST__', JSON.stringify(manifest)))
     .pipe(replace('__ASSET_ROOT__', defaultAssetRoot))
     .pipe(replace('__SIDEBAR_APP_URL__', defaultSidebarAppUrl))
+    // Strip sourcemap link. It will have been invalidated by the previous
+    // replacements and the bundle is so small that it isn't really valuable.
+    .pipe(replace(/.*sourceMappingURL.*/,''))
     .pipe(rename('boot.js'))
     .pipe(gulp.dest('build/'));
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -286,7 +286,7 @@ function generateBootScript(manifest) {
     .pipe(replace('__SIDEBAR_APP_URL__', defaultSidebarAppUrl))
     // Strip sourcemap link. It will have been invalidated by the previous
     // replacements and the bundle is so small that it isn't really valuable.
-    .pipe(replace(/.*sourceMappingURL.*/,''))
+    .pipe(replace(/^\/\/# sourceMappingURL=[^ ]+$/m,''))
     .pipe(rename('boot.js'))
     .pipe(gulp.dest('build/'));
 }


### PR DESCRIPTION
This fixes an issue where some browsers (eg. Safari) complain that they cannot retrieve the `boot.bundle.js.map` source map file when the client loads. This file contains mappings from the tiny `boot.js` bundle back to the original source files in `src/boot`. The source map locations and URL become invalid when the script is copied from `build/scripts/boot.bundle.js` to `build/boot.js` and placeholders in the code are replaced with values. 

Since the script is tiny the debug info is not that valuable so this commit just removes the sourcemap URL to avoid browsers complaining that they cannot retrieve it.

Testing:
 1. Check out this branch, run `gulp build`
 2. `cat build/boot.js` verify that the last line of the script does not contain `sourceMappingURL=...`