### PR TITLE
Rename the onLogin callback to onLoginRequest

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -96,20 +96,20 @@ with the following keys:
 
  * `icon` _String|null_. The URL to an image for the annotation service. This image will appear to the left of the name of the currently selected group. The image should be suitable for display at 16x16px and the recommended format is SVG.
 
- * `onLogin` _function_. A JavaScript function that the Hypothesis client will
-   call in order to login (for example, when the user clicks a login button in
-   the Hypothesis client's sidebar).
+ * `onLoginRequest` _function_. A JavaScript function that the Hypothesis client
+   will call in order to login (for example, when the user clicks a login button
+   in the Hypothesis client's sidebar).
 
    This setting can only be [set using window.hypothesisConfig](#configuring-the-client-using-javascript).
 
-   If the hosting page provides an `onLogin` function then the Hypothesis client
-   will call this function instead of doing its usual procedure for logging in
-   to the public service at [hypothes.is](https://hypothes.is/).
+   If the hosting page provides an `onLoginRequest` function then the Hypothesis
+   client will call this function instead of doing its usual procedure for
+   logging in to the public service at [hypothes.is](https://hypothes.is/).
 
-   No arguments are passed to the `onLogin` function.
+   No arguments are passed to the `onLoginRequest` function.
 
-   The `onLogin` function should cause a login procedure for the hosting page
-   to be performed - for example by redirecting to a login page, or by opening
-   a popup login window. After a successful login the hosting page should
-   reload the original page with a non-null `grantToken` for the logged-in user
-   in the `services` configuration setting.
+   The `onLoginRequest` function should cause a login procedure for the hosting
+   page to be performed - for example by redirecting to a login page, or by
+   opening a popup login window. After a successful login the hosting page
+   should reload the original page with a non-null `grantToken` for the
+   logged-in user in the `services` configuration setting.

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -37,7 +37,7 @@ module.exports = class Sidebar extends Host
       this._setupGestures()
 
     # The partner-provided login callback function (if any).
-    @onLogin = options.services?[0]?.onLogin
+    @onLoginRequest = options.services?[0]?.onLoginRequest
 
     this._setupSidebarEvents()
 
@@ -55,8 +55,8 @@ module.exports = class Sidebar extends Host
     @crossframe.on('show', this.show.bind(this))
     @crossframe.on('hide', this.hide.bind(this))
     @crossframe.on(events.DO_LOGIN, =>
-      if @onLogin
-        @onLogin()
+      if @onLoginRequest
+        @onLoginRequest()
     );
 
     # Return this for chaining

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -48,17 +48,17 @@ describe 'Sidebar', ->
         assert.called(target)
 
     describe 'on DO_LOGIN event', ->
-      it 'calls the onLogin callback function if one was provided', ->
-        onLogin = sandbox.stub()
-        sidebar = createSidebar(options={services: [{onLogin: onLogin}]})
+      it 'calls the onLoginRequest callback function if one was provided', ->
+        onLoginRequest = sandbox.stub()
+        sidebar = createSidebar(options={services: [{onLoginRequest: onLoginRequest}]})
 
         emitEvent(events.DO_LOGIN)
 
-        assert.called(onLogin)
+        assert.called(onLoginRequest)
 
-      it 'only calls the onLogin callback of the first service', ->
-        # Even though options.services is an array it only calls the onLogin
-        # callback function of the first service. The onLogins of any other
+      it 'only calls the onLoginRequest callback of the first service', ->
+        # Even though options.services is an array it only calls the onLoginRequest
+        # callback function of the first service. The onLoginRequests of any other
         # services are ignored.
         firstOnLogin  = sandbox.stub()
         secondOnLogin = sandbox.stub()
@@ -66,9 +66,9 @@ describe 'Sidebar', ->
         sidebar = createSidebar(
           options={
             services: [
-              {onLogin: firstOnLogin},
-              {onLogin: secondOnLogin},
-              {onLogin: thirdOnLogin},
+              {onLoginRequest: firstOnLogin},
+              {onLoginRequest: secondOnLogin},
+              {onLoginRequest: thirdOnLogin},
             ]
           }
         )
@@ -79,17 +79,17 @@ describe 'Sidebar', ->
         assert.notCalled(secondOnLogin)
         assert.notCalled(thirdOnLogin)
 
-      it 'never calls the onLogin callbacks of further services', ->
-        # Even if the first service doesn't have an onLogin, it still doesn't
-        # call the onLogins of further services.
+      it 'never calls the onLoginRequest callbacks of further services', ->
+        # Even if the first service doesn't have an onLoginRequest, it still doesn't
+        # call the onLoginRequests of further services.
         secondOnLogin = sandbox.stub()
         thirdOnLogin  = sandbox.stub()
         sidebar = createSidebar(
           options={
             services: [
               {},
-              {onLogin: secondOnLogin},
-              {onLogin: thirdOnLogin},
+              {onLoginRequest: secondOnLogin},
+              {onLoginRequest: thirdOnLogin},
             ]
           }
         )
@@ -107,7 +107,7 @@ describe 'Sidebar', ->
         sidebar = createSidebar(options={services: []})
         emitEvent(events.DO_LOGIN)
 
-      it 'does not crash if the first service has no onLogin', ->
+      it 'does not crash if the first service has no onLoginRequest', ->
         sidebar = createSidebar(options={services: [{}]})
         emitEvent(events.DO_LOGIN)
 


### PR DESCRIPTION
The trigger for invoking this callback function is the user requesting that a login flow be started. In other words, at the point this callback is invoked, a login has not occurred, and indeed may never occur if the user does not complete the login flow.

As such, it seems clearer to have this callback called "onLoginRequest" rather than "onLogin."

Fixes #274.