### PR TITLE
Fix client failing to load on pages that define `self`

### DIFF
--- a/scripts/gulp/create-bundle.js
+++ b/scripts/gulp/create-bundle.js
@@ -94,9 +94,11 @@ module.exports = function createBundle(config, buildOpts) {
       // the `global`, `self` and `window` globals in that order.
       //
       // This can break on web pages which provide their own definition of
-      // `global`. See https://github.com/hypothesis/h/issues/2723
+      // `global` or `self` that is not an alias for `window`. See
+      // https://github.com/hypothesis/h/issues/2723 and
+      // https://github.com/hypothesis/client/issues/277
       global: function () {
-        return 'typeof self !== "undefined" ? self : window';
+        return 'window';
       },
     },
   };


### PR DESCRIPTION
Fix client failing to load on pages that define `self` to be something
other than `window`.

When AnnotatorJS is bundled by browserify, it is first processed by
browserify-shim* which adds references to a variable called 'global',
which exists in Node but not the browser. Browserify then processes the
result and assigns `global` to the value of the first variable from
['global', 'self', 'window'] which is already defined.

https://github.com/hypothesis/h/pull/3385 fixed the problem when the
page defines a variable called 'global' that is not an alias for
'window' by reducing this list to ['self', 'window']. This still leaves
pages that define 'self'.

This commit fixes the problem by making `global` (within CommonJS
modules) always be assigned the value of `window`.

* browserify-shim deals with the fact that AnnotatorJS 1.2.x is not a
CommonJS module and exports its entry point as `window.Annotator`.

Fixes https://github.com/hypothesis/client/issues/277