### PR TITLE
Add ADR for adopting a component-based architecture for the UI

### DIFF
--- a/docs/arch/adr-001.md
+++ b/docs/arch/adr-001.md
@@ -4,7 +4,7 @@ ADR 1: Component architecture for sidebar application
 Context
 -------
 
-## Background
+### Background
 
 Historically front-end web frameworks, including Angular 1.x, used a variety of
 MVC-based patterns for structuring the user interface part of an application
@@ -36,7 +36,7 @@ controllerAs). Angular JS 1.5x introduced [explicit
 support](https://docs.angularjs.org/guide/component) for this architecture via
 `.component()`.
 
-## Components in the client
+### Components in the client
 
 The client historically used traditional Angular 1.x methods of passing data
 between parts of the UI - properties on the scope inherited by child scopes and

--- a/docs/arch/adr-001.md
+++ b/docs/arch/adr-001.md
@@ -1,0 +1,72 @@
+ADR 1: Component architecture for sidebar application
+=====================================================
+
+Context
+-------
+
+Historically front-end web frameworks, including Angular 1.x, used a variety of
+MVC-based patterns for structuring the user interface part of an application
+, which of course is much of the code for a web app.
+
+More recently (especially since React in 2013), web frameworks have generally
+moved to a simpler model where an application is structured as a tree of
+components with several key properties:
+
+ * Each component's internals are hidden from other components.
+ * Data is explicitly passed from one component to another and in one direction.
+ * Components have an explicitly declared API.
+ * Communication from child to parent happens via callback inputs.
+ * Components have a standard set of lifecycle hooks for creation, input changes
+   and destruction.
+
+A further pattern that emerged on top of this was to split components into those
+which purely reflect their inputs ("presentational" components) and those which
+are connected to services and state in the application ("container" or
+"connected" components).
+
+This pattern made it easier to reason about, re-use and change pieces of the
+application in isolation, as well as enabling important optimizations and
+simpler framework implementations.
+
+In Angular JS prior to v1.5, this pattern could be achieved by using a
+combination of features (element directives, isolate scope, bind-to-controller,
+controllerAs) and all of our new UI components written during 2016 followed this
+pattern. However, it isn't that obvious until you know the codebase well that
+this is the way the UI is structured.
+
+Angular JS 1.5x introduced [explicit
+support](https://docs.angularjs.org/guide/component) for this architecture via
+`.component()`.
+
+Decision
+--------
+
+We will convert all element directives in `src/sidebar/directive` to components
+and move them to `src/sidebar/components`. This change will be simple in most
+cases and will require some moderate refactoring for others.
+
+The top-level of the UI which consists of a mix of router, controller
+and templates unlike the rest of the UI will also be converted to this pattern.
+
+Status
+------
+
+In discussion
+
+Consequences
+------------
+
+In the short term, this change should improve the consistency of how UI
+components are defined and how they communicate with one another. It should also
+make it easier to understand and refactor parts of the client in isolation. It
+is hoped this will also make it easier for newcomers to understand how the UI is
+structured and reduce the number of concepts that they need to grok.
+
+In the medium term, this brings the architecture of the client more into
+alignment with how it would be structured in other frameworks and gives us the
+opportunity to incrementally migrate to a more actively developed (and
+potentially smaller, faster, simpler) library for building our UI in future.
+
+Presentational components can be potentially be extracted into their own
+packages for re-use in other parts of Hypothesis, though this is not an active
+priority.

--- a/docs/arch/adr-001.md
+++ b/docs/arch/adr-001.md
@@ -4,6 +4,8 @@ ADR 1: Component architecture for sidebar application
 Context
 -------
 
+## Background
+
 Historically front-end web frameworks, including Angular 1.x, used a variety of
 MVC-based patterns for structuring the user interface part of an application
 , which of course is much of the code for a web app.
@@ -30,23 +32,40 @@ simpler framework implementations.
 
 In Angular JS prior to v1.5, this pattern could be achieved by using a
 combination of features (element directives, isolate scope, bind-to-controller,
-controllerAs) and all of our new UI components written during 2016 followed this
-pattern. However, it isn't that obvious until you know the codebase well that
-this is the way the UI is structured.
-
-Angular JS 1.5x introduced [explicit
+controllerAs). Angular JS 1.5x introduced [explicit
 support](https://docs.angularjs.org/guide/component) for this architecture via
 `.component()`.
+
+## Components in the client
+
+The client historically used traditional Angular 1.x methods of passing data
+between parts of the UI - properties on the scope inherited by child scopes and
+events. As the app grew larger it became harder to reason about where data in
+templates came from and who could change it ("$scope soup"). Newer parts of the
+UI have used element directives with isolate scopes to implement a
+component-based architecture, thus avoiding this problem. However:
+
+- This requires a bunch of boilerplate for each directive.
+- It isn't clear that we use this pattern from looking at the entry point to the
+  sidebar.
+- Important parts of the top level of the UI (the `*-controller.js` files and
+  `viewer.html`) do not use this pattern and suffer from being hard to
+  understand in isolation. Additionally they use a different mechanism
+  (`ngRouter`) to control what is displayed than the rest of the UI, where we use
+  `ng-if` guards.
+- This lack of consistency makes it difficult to understand how the top level of
+  the UI works.
 
 Decision
 --------
 
-We will convert all element directives in `src/sidebar/directive` to components
-and move them to `src/sidebar/components`. This change will be simple in most
-cases and will require some moderate refactoring for others.
+* We will convert all element directives in `src/sidebar/directive` to
+  components (ie. change them to use `angular.component()` and any refactoring
+  this implies) and move them to `src/sidebar/components`. This change will be
+  simple in most cases and will require some moderate refactoring for others.
 
-The top-level of the UI which consists of a mix of router, controller
-and templates unlike the rest of the UI will also be converted to this pattern.
+* The top-level of the application will also be converted to a set of components
+  using the same pattern and the router will be removed.
 
 Status
 ------
@@ -56,11 +75,8 @@ In discussion
 Consequences
 ------------
 
-In the short term, this change should improve the consistency of how UI
-components are defined and how they communicate with one another. It should also
-make it easier to understand and refactor parts of the client in isolation. It
-is hoped this will also make it easier for newcomers to understand how the UI is
-structured and reduce the number of concepts that they need to grok.
+In the short term this should make it easier to understand the sidebar app by
+improving consistency.
 
 In the medium term, this brings the architecture of the client more into
 alignment with how it would be structured in other frameworks and gives us the

--- a/docs/arch/index.md
+++ b/docs/arch/index.md
@@ -1,0 +1,11 @@
+Architecture decision records
+=============================
+
+Here you will find documents which describe significant architectural decisions
+made or proposed when developing the Hypothesis client. We record these in
+order to provide a reference for the history, motivation, and rationale for past
+decisions.
+
+See [the
+introduction in the "h" repository](https://github.com/hypothesis/h/blob/master/docs/arch/index.rst)
+for more details.


### PR DESCRIPTION
This is a draft ADR which attempts to document at least part of the answer to "how do we use Angular" right now, and some steps we can take to make this more obvious and reduce inconsistencies between different parts of the UI.

The draft is currently written in Markdown because I have yet to learn rST - I'm happy to address that before merging.