### PR TITLE
Strikethrough & apply greyscale/contrast effects to hidden annotations

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -505,6 +505,10 @@ function AnnotationController(
     return streamer.hasPendingDeletion(vm.annotation.id);
   };
 
+  vm.isHiddenByModerator = function () {
+    return annotationUI.isHiddenByModerator(vm.annotation.id);
+  };
+
   vm.isReply = function () {
     return isReply(vm.annotation);
   };

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -84,6 +84,7 @@ describe('annotation', function() {
     var $window;
     var fakeAnalytics;
     var fakeAnnotationMapper;
+    var fakeAnnotationUI;
     var fakeDrafts;
     var fakeFlash;
     var fakeGroups;
@@ -116,7 +117,12 @@ describe('annotation', function() {
 
     before(function() {
       angular.module('h', [])
-        .component('annotation', annotationComponent());
+        .component('annotation', annotationComponent())
+        .component('markdown', {
+          bindings: {
+            textClass: '<?',
+          },
+        });
     });
 
     beforeEach(angular.mock.module('h'));
@@ -141,7 +147,9 @@ describe('annotation', function() {
         flagAnnotation: sandbox.stub(),
       };
 
-      var fakeAnnotationUI = {};
+      fakeAnnotationUI = {
+        isHiddenByModerator: sandbox.stub().returns(false),
+      };
 
       fakeDrafts = {
         update: sandbox.stub(),
@@ -1040,6 +1048,17 @@ describe('annotation', function() {
       }];
       var el = createDirective(ann).element;
       assert.equal(el[0].querySelector('blockquote').textContent, '<<-&->>');
+    });
+
+    it('renders hidden annotations with a custom text class', function () {
+      var ann = fixtures.defaultAnnotation();
+      fakeAnnotationUI.isHiddenByModerator.returns(true);
+      var el = createDirective(ann).element;
+      assert.deepEqual(el.find('markdown').controller('markdown'), {
+        textClass: {
+          'annotation-body is-hidden': true,
+        },
+      });
     });
   });
 });

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -120,7 +120,7 @@ describe('annotation', function() {
         .component('annotation', annotationComponent())
         .component('markdown', {
           bindings: {
-            textClass: '<?',
+            customTextClass: '<?',
           },
         });
     });
@@ -1055,7 +1055,7 @@ describe('annotation', function() {
       fakeAnnotationUI.isHiddenByModerator.returns(true);
       var el = createDirective(ann).element;
       assert.deepEqual(el.find('markdown').controller('markdown'), {
-        textClass: {
+        customTextClass: {
           'annotation-body is-hidden': true,
         },
       });

--- a/src/sidebar/directive/markdown.js
+++ b/src/sidebar/directive/markdown.js
@@ -165,9 +165,9 @@ module.exports = function($sanitize) {
 
     restrict: 'E',
     scope: {
+      customTextClass: '<?',
       readOnly: '<',
       text: '<?',
-      textClass: '<?',
       onEditText: '&',
     },
     template: require('../templates/markdown.html'),

--- a/src/sidebar/directive/markdown.js
+++ b/src/sidebar/directive/markdown.js
@@ -167,6 +167,7 @@ module.exports = function($sanitize) {
     scope: {
       readOnly: '<',
       text: '<?',
+      textClass: '<?',
       onEditText: '&',
     },
     template: require('../templates/markdown.html'),

--- a/src/sidebar/directive/test/markdown-test.js
+++ b/src/sidebar/directive/test/markdown-test.js
@@ -250,4 +250,15 @@ describe('markdown', function () {
       assert.isFalse(isPreviewing());
     });
   });
+
+  describe('custom text class', function () {
+    it('should apply custom text class to text container', function () {
+      var editor = util.createDirective(document, 'markdown', {
+        readOnly: true,
+        textClass: 'fancy-effect',
+      });
+      var viewEl = viewElement(editor);
+      assert.include(viewEl.className, 'fancy-effect');
+    });
+  });
 });

--- a/src/sidebar/directive/test/markdown-test.js
+++ b/src/sidebar/directive/test/markdown-test.js
@@ -254,8 +254,8 @@ describe('markdown', function () {
   describe('custom text class', function () {
     it('should apply custom text class to text container', function () {
       var editor = util.createDirective(document, 'markdown', {
+        customTextClass: 'fancy-effect',
         readOnly: true,
-        textClass: 'fancy-effect',
       });
       var viewEl = viewElement(editor);
       assert.include(viewEl.className, 'fancy-effect');

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -82,7 +82,7 @@
       overflow-hysteresis="20"
       content-data="vm.state().text">
       <markdown text="vm.state().text"
-                text-class="{'annotation-body is-hidden':vm.isHiddenByModerator()}"
+                custom-text-class="{'annotation-body is-hidden':vm.isHiddenByModerator()}"
                 on-edit-text="vm.setText(text)"
                 read-only="!vm.editing()">
       </markdown>

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -82,8 +82,9 @@
       overflow-hysteresis="20"
       content-data="vm.state().text">
       <markdown text="vm.state().text"
-        on-edit-text="vm.setText(text)"
-        read-only="!vm.editing()">
+                text-class="{'annotation-body is-hidden':vm.isHiddenByModerator()}"
+                on-edit-text="vm.setText(text)"
+                read-only="!vm.editing()">
       </markdown>
     </excerpt>
   </section>

--- a/src/sidebar/templates/markdown.html
+++ b/src/sidebar/templates/markdown.html
@@ -17,6 +17,6 @@
           ng-show="showEditor()"
           ng-click="$event.stopPropagation()"></textarea>
 <div class="markdown-body js-markdown-preview"
-     ng-class="preview && 'markdown-preview'"
+     ng-class="(preview && 'markdown-preview') || textClass"
      ng-dblclick="togglePreview()"
      ng-show="!showEditor()"></div>

--- a/src/sidebar/templates/markdown.html
+++ b/src/sidebar/templates/markdown.html
@@ -17,6 +17,6 @@
           ng-show="showEditor()"
           ng-click="$event.stopPropagation()"></textarea>
 <div class="markdown-body js-markdown-preview"
-     ng-class="(preview && 'markdown-preview') || textClass"
+     ng-class="(preview && 'markdown-preview') || customTextClass"
      ng-dblclick="togglePreview()"
      ng-show="!showEditor()"></div>

--- a/src/styles/annotation.scss
+++ b/src/styles/annotation.scss
@@ -102,6 +102,11 @@
   margin-left: 0px;
 }
 
+.annotation-body.is-hidden {
+  text-decoration: line-through;
+  filter: grayscale(100%) contrast(65%);
+}
+
 // the footer at the bottom of an annotation displaying
 // the annotation actions and reply counts
 .annotation-footer {


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/285 and will need rebasing**~~

This PR implements the rendering effects on hidden annotations from [the designs](https://github.com/hypothesis/product-backlog/issues/183). For hidden annotations:

* The text is struck through
* Links, images and videos are greyscaled
* The contrast is reduced

The last two effects require CSS filter support and so will not appear in IE, but that's fine. Any moderators using an old browser will just get the moderation banner and struck-through text.

<img width="422" alt="hidden-annotation" src="https://cloud.githubusercontent.com/assets/2458/24146381/59eb70a8-0e2d-11e7-828e-b8c280f342b8.png">
