### PR TITLE
Fix annotation ID not being passed to moderation banner correctly.

### DIFF
--- a/src/sidebar/components/test/annotation-thread-test.js
+++ b/src/sidebar/components/test/annotation-thread-test.js
@@ -25,7 +25,13 @@ function PageObject(element) {
 describe('annotationThread', function () {
   before(function () {
     angular.module('app', [])
-      .component('annotationThread', annotationThread);
+      .component('annotationThread', annotationThread)
+      .component('moderationBanner', {
+        bindings: {
+          annotationId: '<',
+          isReply: '<',
+        },
+      });
   });
 
   beforeEach(function () {
@@ -174,6 +180,24 @@ describe('annotationThread', function () {
       assert.calledWith(onForceVisible, thread.parent);
       assert.calledWith(onForceVisible, thread);
       assert.calledWith(onForceVisible, thread.children[0]);
+    });
+  });
+
+  it('renders the moderation banner', function () {
+    var thread = {
+      id: '123',
+      parent: null,
+      children: [],
+    };
+    var element = util.createDirective(document, 'annotationThread', {
+      thread: thread,
+    });
+    var moderationBanner = element
+      .find('moderation-banner')
+      .controller('moderationBanner');
+    assert.deepEqual(moderationBanner, {
+      isReply: false,
+      annotationId: '123',
     });
   });
 });

--- a/src/sidebar/templates/annotation_thread.html
+++ b/src/sidebar/templates/annotation_thread.html
@@ -11,7 +11,7 @@
   </div>
   <div class="annotation-thread__content">
     <moderation-banner is-reply="!vm.isTopLevelThread()"
-                       annotation-id="thread.id">
+                       annotation-id="vm.thread.id">
     </moderation-banner>
     <annotation ng-class="vm.annotationClasses()"
              annotation="vm.thread.annotation"


### PR DESCRIPTION
Add missing `vm.` prefix and test. This was missed when testing the PR
because the banner was enabled by modifying the banner's controller
instead of the app state, which would have revealed the problem.