### PR TITLE
Add a branding directive to bring custom branding to sidebar

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -167,6 +167,7 @@ module.exports = angular.module('h', [
   .directive('formInput', require('./directive/form-input'))
   .directive('formValidate', require('./directive/form-validate'))
   .directive('hAutofocus', require('./directive/h-autofocus'))
+  .directive('hBranding', require('./directive/h-branding'))
   .directive('hOnTouch', require('./directive/h-on-touch'))
   .directive('hTooltip', require('./directive/h-tooltip'))
   .directive('spinner', require('./directive/spinner'))

--- a/src/sidebar/directive/h-branding.js
+++ b/src/sidebar/directive/h-branding.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * The BrandingDirective brings theming configuration to our sidebar
+ * by allowing the branding hypothesis settings to be reflected on items
+ * that use this directive with the corresponding branding value.
+ *
+ * How to use:
+ *   <element h-branding="supportedProp1, supportedProp2">
+ *
+ * Use `h-branding` to trigger this directive. Inside the attribute value,
+ * add a comma separated list of what branding properties should be applied.
+ * The attribute values match what the integrator would specify. For example,
+ * if "superSpecialTextColor" is supported, the integrator could specify
+ * `superSpecialTextColor: 'blue'` in the branding settings. Then any element that
+ * included `h-branding="superSpecialTextColor"` would have blue placed on the
+ * text's color.
+ *
+ * See below for the supported properties.
+ */
+
+// @ngInject
+function BrandingDirective(settings) {
+
+  var _hasBranding = !!settings.branding;
+
+  // This is the list of supported property declarations
+  // we support. The key is the name and how it should be reflected in the
+  // settings by the integrator while the value (in the whitelist) is
+  // the type of .style property being set. The types are pretty simple for now
+  // and are a one-to-one mapping between the branding type and style property.
+  var _supportedPropSettings = {
+    highlightColor: 'color',
+    appBackgroundColor: 'backgroundColor',
+    ctaBackgroundColor: 'backgroundColor',
+    ctaTextColor: 'color',
+    selectionFontFamily: 'fontFamily',
+    annotationFontFamily: 'fontFamily',
+  };
+
+  // filter all attribute values down to the supported
+  // branding properties
+  var _getValidBrandingAttribut = function(attrString){
+    return attrString.split(',').map(function(attr){
+      return attr.trim();
+    }).filter(function filterAgainstWhitelist(attr){
+      return attr in _supportedPropSettings;
+    });
+  };
+
+
+  return {
+    restrict: 'A',
+    link: function(scope, $elem, attrs) {
+      if(_hasBranding){
+        _getValidBrandingAttribut(attrs.hBranding).forEach(function(attr){
+          var propVal = settings.branding[attr];
+          if(propVal){
+            // the _supportedPropSettings holds the .style property name
+            // that is being set
+            $elem[0].style[ _supportedPropSettings[attr] ] = propVal;
+          }
+        });
+      }
+    },
+  };
+}
+
+module.exports = BrandingDirective;

--- a/src/sidebar/directive/test/h-branding-fixtures.js
+++ b/src/sidebar/directive/test/h-branding-fixtures.js
@@ -1,0 +1,76 @@
+'use strict';
+// Test data for the firehose of branding combinations
+module.exports = [
+
+  // ALL SUPPORTED PROPERTIES
+  {
+    settings: {appBackgroundColor: 'blue'},
+    attrs: 'h-branding="appBackgroundColor"',
+    styleChanged: 'backgroundColor',
+    expectedPropValue: 'blue',
+  },
+  {
+    settings: {highlightColor: 'red'},
+    attrs: 'h-branding="highlightColor"',
+    styleChanged: 'color',
+    expectedPropValue: 'red',
+  },
+  {
+    settings: {ctaBackgroundColor: 'red'},
+    attrs: 'h-branding="ctaBackgroundColor"',
+    styleChanged: 'backgroundColor',
+    expectedPropValue: 'red',
+  },
+  {
+    settings: {ctaTextColor: 'yellow'},
+    attrs: 'h-branding="ctaTextColor"',
+    styleChanged: 'color',
+    expectedPropValue: 'yellow',
+  },
+  {
+    settings: {selectionFontFamily: 'georgia, arial'},
+    attrs: 'h-branding="selectionFontFamily"',
+    styleChanged: 'fontFamily',
+    expectedPropValue: 'georgia, arial',
+  },
+  {
+    settings: {annotationFontFamily: 'georgia, arial'},
+    attrs: 'h-branding="annotationFontFamily"',
+    styleChanged: 'fontFamily',
+    expectedPropValue: 'georgia, arial',
+  },
+
+  // EMPTY VALUE
+  {
+    settings: {appBackgroundColor: ''},
+    attrs: 'h-branding="appBackgroundColor"',
+    styleChanged: 'backgroundColor',
+    expectedPropValue: '',
+  },
+
+  // MULTIPLES
+  {
+    settings: {appBackgroundColor: 'blue', annotationFontFamily: 'arial'},
+    attrs: 'h-branding="appBackgroundColor, annotationFontFamily"',
+    styleChanged: ['backgroundColor', 'fontFamily'],
+    expectedPropValue: ['blue', 'arial'],
+  },
+  {
+    settings: {appBackgroundColor: 'orange', annotationFontFamily: 'helvetica'},
+    attrs: 'h-branding="appBackgroundColor,annotationFontFamily"',
+    styleChanged: ['backgroundColor', 'fontFamily'],
+    expectedPropValue: ['orange', 'helvetica'],
+  },
+  {
+    settings: {appBackgroundColor: 'blue', annotationFontFamily: 'arial'},
+    attrs: 'h-branding="appBackgroundColor"',
+    styleChanged: ['backgroundColor', 'fontFamily'],
+    expectedPropValue: ['blue', ''],
+  },
+  {
+    settings: {appBackgroundColor: 'blue'},
+    attrs: 'h-branding="appBackgroundColor, annotationFontFamily"',
+    styleChanged: ['backgroundColor', 'fontFamily'],
+    expectedPropValue: ['blue', ''],
+  },
+];

--- a/src/sidebar/directive/test/h-branding-test.js
+++ b/src/sidebar/directive/test/h-branding-test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+var angular = require('angular');
+var unroll = require('../../../shared/test/util').unroll;
+
+describe('BrandingDirective', function () {
+
+  var $compile;
+  var $rootScope;
+  var customSettings;
+
+  // Settings are set and frozen when the app initializes.
+  // This function allows us a way to quickly setup our environment
+  // with desired settings. Note, needs to be called for angular
+  // to be initialized for the test
+  var setSettingsAndBootApp = function(){
+
+    angular.module('app', [])
+      .directive('hBranding', require('../h-branding'));
+
+    angular.mock.module('app', {
+      settings: customSettings || {},
+    });
+
+    angular.mock.inject(function (_$compile_, _$rootScope_) {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+    });
+  };
+
+  // convenience method to only worry about what the test
+  // should be doing, applying settings variants.
+  var applyBrandingSettings = function(brandingSettings){
+
+    customSettings = brandingSettings ? {
+      branding: brandingSettings,
+    } : null;
+
+    setSettingsAndBootApp();
+  };
+
+  // creates a new element with the attribute string provided.
+  // Allowing us to do many attribute configurations before
+  // compilation happens.
+  var makeElementWithAttrs = function(attrString){
+    var $element = angular.element('<span ' + attrString + ' ></span>');
+    $compile($element)($rootScope.$new());
+    $rootScope.$digest();
+    return $element;
+  };
+
+  afterEach(function(){
+    customSettings = {};
+  });
+
+  it('branding should not happen on elements with unknown branding attributes', function () {
+
+    // note, we need to set some form of branding settings or this
+    // test will pass simply because branding isn't required
+    applyBrandingSettings({
+      appBackgroundColor: 'blue',
+    });
+
+    var el = makeElementWithAttrs('h-branding="randomBackgroundColor"');
+    assert.equal(el[0].style.backgroundColor, '');
+  });
+
+  unroll('applies branding to elements', function (testCase) {
+    applyBrandingSettings(testCase.settings);
+
+    var el = makeElementWithAttrs(testCase.attrs);
+
+    if(Array.isArray(testCase.styleChanged)){
+        // we expect that if styleChanged is an array
+        // that expectedPropValue will be an equal length array
+      testCase.styleChanged.forEach(function(styleChanged, index){
+        assert.equal(el[0].style[styleChanged], testCase.expectedPropValue[index]);
+      });
+    }else{
+      assert.equal(el[0].style[testCase.styleChanged], testCase.expectedPropValue);
+    }
+
+  }, require('./h-branding-fixtures'));
+
+});

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -25,11 +25,12 @@ function hostPageConfig(window) {
     'appType',
 
     // Config params documented at
-    // https://github.com/hypothesis/client/blob/master/docs/config.md
+    // https://h.readthedocs.io/projects/client/en/latest/publishers/config/
     'openLoginForm',
     'openSidebar',
     'showHighlights',
     'services',
+    'branding',
   ];
 
   return Object.keys(config).reduce(function (result, key) {


### PR DESCRIPTION
fixes #213

This commit only adds the branding directive to the app. There will be a follow-up ticket to actually start using the branding directive. To test, you can add `branding branding-app-background-color` to the `<top-bar>` element in the app.html template. Then change the docs/help template (which has the embedded client) to have a `branding: { appBackgroudColor: 'blue' }` in the hypothesis config