### PR TITLE
Branded sidebar

### DIFF
--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -63,6 +63,7 @@
       overflow-hysteresis="20"
       content-data="selector.exact">
       <blockquote class="annotation-quote"
+        h-branding="selectionFontFamily"
         ng-bind="selector.exact"
         ng-repeat="selector in target.selector
           | filter : {'type': 'TextQuoteSelector'}

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -107,7 +107,8 @@
     <a class="annotation-link u-strong" ng-show="vm.canCollapseBody"
       ng-click="vm.toggleCollapseBody($event)"
       ng-title="vm.collapseBody ? 'Show the full annotation text' : 'Show the first few lines only'"
-      ng-bind="vm.collapseBody ? 'More' : 'Less'"></a>
+      ng-bind="vm.collapseBody ? 'More' : 'Less'"
+      h-branding="highlightColor"></a>
   </div>
   <!-- / Tags -->
 

--- a/src/sidebar/templates/app.html
+++ b/src/sidebar/templates/app.html
@@ -1,39 +1,41 @@
-<top-bar
-  auth="auth"
-  on-login="login()"
-  on-logout="logout()"
-  on-share-page="share()"
-  on-show-help-panel="helpPanel.visible = true"
-  is-sidebar="::isSidebar"
-  pending-update-count="countPendingUpdates()"
-  on-apply-pending-updates="applyPendingUpdates()"
-  search-controller="search"
-  sort-key="sortKey()"
-  sort-keys-available="sortKeysAvailable()"
-  on-change-sort-key="setSortKey(sortKey)">
-</top-bar>
+<div class="app-content-wrapper" h-branding="appBackgroundColor">
+  <top-bar
+    auth="auth"
+    on-login="login()"
+    on-logout="logout()"
+    on-share-page="share()"
+    on-show-help-panel="helpPanel.visible = true"
+    is-sidebar="::isSidebar"
+    pending-update-count="countPendingUpdates()"
+    on-apply-pending-updates="applyPendingUpdates()"
+    search-controller="search"
+    sort-key="sortKey()"
+    sort-keys-available="sortKeysAvailable()"
+    on-change-sort-key="setSortKey(sortKey)">
+  </top-bar>
 
-<div class="create-account-banner" ng-if="isSidebar && auth.status === 'logged-out'" ng-cloak>
-  To annotate this document
-  <a href="{{ serviceUrl('signup') }}" target="_blank">
-    create a free account
-  </a>
-  or <a href="" ng-click="login()">log in</a>
-</div>
+  <div class="create-account-banner" ng-if="isSidebar && auth.status === 'logged-out'" ng-cloak>
+    To annotate this document
+    <a href="{{ serviceUrl('signup') }}" target="_blank">
+      create a free account
+    </a>
+    or <a href="" ng-click="login()">log in</a>
+  </div>
 
-<div class="content" ng-cloak>
-  <login-form
-    ng-if="accountDialog.visible"
-    on-close="accountDialog.visible = false">
-  </login-form>
-  <sidebar-tutorial ng-if="isSidebar"></sidebar-tutorial>
-  <share-dialog
-    ng-if="shareDialog.visible"
-    on-close="shareDialog.visible = false">
-  </share-dialog>
-  <help-panel ng-if="helpPanel.visible"
-    on-close="helpPanel.visible = false"
-    auth="auth">
-  </help-panel>
-  <main ng-view=""></main>
+  <div class="content" ng-cloak>
+    <login-form
+      ng-if="accountDialog.visible"
+      on-close="accountDialog.visible = false">
+    </login-form>
+    <sidebar-tutorial ng-if="isSidebar"></sidebar-tutorial>
+    <share-dialog
+      ng-if="shareDialog.visible"
+      on-close="shareDialog.visible = false">
+    </share-dialog>
+    <help-panel ng-if="helpPanel.visible"
+      on-close="helpPanel.visible = false"
+      auth="auth">
+    </help-panel>
+    <main ng-view=""></main>
+  </div>
 </div>

--- a/src/sidebar/templates/dropdown_menu_btn.html
+++ b/src/sidebar/templates/dropdown_menu_btn.html
@@ -1,14 +1,16 @@
-<div class="dropdown-menu-btn">
+<div class="dropdown-menu-btn" >
   <button
     class="dropdown-menu-btn__btn"
     ng-bind="vm.label"
     ng-click="vm.onClick($event)"
-    ng-disabled="vm.isDisabled">
+    ng-disabled="vm.isDisabled"
+    h-branding="ctaTextColor, ctaBackgroundColor">
   </button>
   <button
     class="dropdown-menu-btn__dropdown-arrow"
     title="{{vm.dropdownMenuLabel}}"
-    ng-click="vm.toggleDropdown($event)">
+    ng-click="vm.toggleDropdown($event)"
+    h-branding="ctaTextColor, ctaBackgroundColor">
     <div class="dropdown-menu-btn__dropdown-arrow-separator"></div>
     <div class="dropdown-menu-btn__dropdown-arrow-indicator">
       <div>▼</div>

--- a/src/sidebar/templates/dropdown_menu_btn.html
+++ b/src/sidebar/templates/dropdown_menu_btn.html
@@ -9,10 +9,11 @@
   <button
     class="dropdown-menu-btn__dropdown-arrow"
     title="{{vm.dropdownMenuLabel}}"
-    ng-click="vm.toggleDropdown($event)"
-    h-branding="ctaTextColor, ctaBackgroundColor">
+    ng-click="vm.toggleDropdown($event)">
     <div class="dropdown-menu-btn__dropdown-arrow-separator"></div>
-    <div class="dropdown-menu-btn__dropdown-arrow-indicator">
+    <div
+      class="dropdown-menu-btn__dropdown-arrow-indicator"
+      h-branding="ctaTextColor, ctaBackgroundColor">
       <div>▼</div>
     </div>
   </button>

--- a/src/sidebar/templates/excerpt.html
+++ b/src/sidebar/templates/excerpt.html
@@ -9,11 +9,13 @@
          ng-show="vm.showInlineControls()">
       <span class="excerpt__toggle-link" ng-show="vm.isExpandable()">
         … <a ng-click="vm.toggle($event)"
-            title="Show the full excerpt">More</a>
+            title="Show the full excerpt"
+            h-branding="highlightColor">More</a>
       </span>
       <span class="excerpt__toggle-link" ng-show="vm.isCollapsible()">
         <a ng-click="vm.toggle($event)"
-            title="Show the first few lines only">Less</a>
+            title="Show the first few lines only"
+            h-branding="highlightColor">Less</a>
       </span>
     </div>
   </div>

--- a/src/sidebar/templates/login_control.html
+++ b/src/sidebar/templates/login_control.html
@@ -3,8 +3,8 @@
       ng-if="vm.newStyle && vm.auth.status === 'unknown'">⋯</span>
 <span class="login-text"
       ng-if="vm.newStyle && vm.auth.status === 'logged-out'">
-  <a href="{{vm.serviceUrl('signup')}}" target="_blank">Sign up</a>
-  / <a href="" ng-click="vm.onLogin()">Log in</a>
+  <a href="{{vm.serviceUrl('signup')}}" target="_blank" h-branding="highlightColor">Sign up</a>
+  / <a href="" ng-click="vm.onLogin()" h-branding="highlightColor">Log in</a>
 </span>
 <div ng-if="vm.newStyle"
      class="pull-right login-control-menu"

--- a/src/sidebar/templates/login_form.html
+++ b/src/sidebar/templates/login_form.html
@@ -53,7 +53,7 @@
 
         <div class="form-actions">
           <div class="form-actions-message">
-            <a href="{{vm.serviceUrl('forgot-password')}}" target="_blank">Forgot your password?</a>
+            <a href="{{vm.serviceUrl('forgot-password')}}" target="_blank" h-branding="highlightColor">Forgot your password?</a>
           </div>
           <div class="form-actions-buttons">
             <button class="btn btn-primary" type="submit" name="login"

--- a/src/sidebar/templates/markdown.html
+++ b/src/sidebar/templates/markdown.html
@@ -15,8 +15,11 @@
 </div>
 <textarea class="form-input form-textarea js-markdown-input"
           ng-show="showEditor()"
-          ng-click="$event.stopPropagation()"></textarea>
+          ng-click="$event.stopPropagation()"
+          h-branding="annotationFontFamily"
+          ></textarea>
 <div class="markdown-body js-markdown-preview"
      ng-class="preview && 'markdown-preview'"
      ng-dblclick="togglePreview()"
-     ng-show="!showEditor()"></div>
+     ng-show="!showEditor()"
+     h-branding="annotationFontFamily"></div>

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -34,15 +34,23 @@ $base-line-height: 20px;
 
 // Top-level styles
 // ----------------
+
 body {
+  @include grey-background;
+
+  font-family: $sans-font-family;
+  font-weight: normal;
+  -webkit-overflow-scrolling: touch;
+}
+
+.app-content-wrapper {
   $sidebar-h-padding: 9px;
 
   @include grey-background;
-  font-family: $sans-font-family;
-  font-weight: normal;
+
+  display: block;
   padding: $sidebar-h-padding;
   padding-top: $sidebar-h-padding + $top-bar-height;
-  -webkit-overflow-scrolling: touch;
 
   @include respond-to(tablets desktops) {
     padding-bottom: 4rem;

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -34,6 +34,9 @@ $base-line-height: 20px;
 
 // Top-level styles
 // ----------------
+html, body {
+  height: 100%;
+}
 
 body {
   @include grey-background;
@@ -43,12 +46,17 @@ body {
   -webkit-overflow-scrolling: touch;
 }
 
+hypothesis-app {
+  display: block;
+  height: 100%;
+}
+
 .app-content-wrapper {
   $sidebar-h-padding: 9px;
 
   @include grey-background;
 
-  display: block;
+  min-height: 100%;
   padding: $sidebar-h-padding;
   padding-top: $sidebar-h-padding + $top-bar-height;
 

--- a/src/styles/selection-tabs.scss
+++ b/src/styles/selection-tabs.scss
@@ -1,5 +1,4 @@
 .selection-tabs {
-  @include grey-background;
 
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
work for https://github.com/hypothesis/product-backlog/issues/214

I used `help.html.jinja2` in the h directory to help me work on this. I recommend using that for testing as well.

Settings I used to get it like we proposed to eLife:

```
     "branding": {
        "highlightColor": "#1689CE",
        "appBackgroundColor": "#fff",
        "ctaBackgroundColor": "#1689CE",
        "ctaTextColor": "#fff",
        "selectionFontFamily": "georgia",
        "annotationFontFamily": "georgia"
      }
```

For reference, hat we presented to elife: https://docs.google.com/presentation/d/1XSQoSwfmuPjtPPW6mUeGo_4d1YnBB7ds1fpP939XqMg/edit#slide=id.g1c59f62e74_0_7

### What to test
Just play around with the settings and make sure they are propagating properly. There is some "massaging" of the UI that we planned on doing to make it play well with elife's design. Arti and I will go over the latter part. Code reviewer reference the ticket mentioned above and review the areas affected by settings.


