### PR TITLE
Split viewer.html template into one template per app type

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -59,26 +59,24 @@ function configureLocation($locationProvider) {
 }
 
 // @ngInject
-var VIEWER_TEMPLATE = require('./templates/viewer.html');
-
 function configureRoutes($routeProvider) {
   $routeProvider.when('/a/:id',
     {
       controller: 'AnnotationViewerController',
-      template: VIEWER_TEMPLATE,
+      template: require('./templates/annotation_viewer_content.html'),
       reloadOnSearch: false,
       resolve: resolve,
     });
   $routeProvider.when('/stream',
     {
       controller: 'StreamController',
-      template: VIEWER_TEMPLATE,
+      template: require('./templates/stream_content.html'),
       reloadOnSearch: false,
       resolve: resolve,
     });
   $routeProvider.otherwise({
     controller: 'WidgetController',
-    template: VIEWER_TEMPLATE,
+    template: require('./templates/sidebar_content.html'),
     reloadOnSearch: false,
     resolve: resolve,
   });

--- a/src/sidebar/templates/annotation_thread.html
+++ b/src/sidebar/templates/annotation_thread.html
@@ -16,8 +16,6 @@
     <annotation ng-class="vm.annotationClasses()"
              annotation="vm.thread.annotation"
              is-collapsed="vm.thread.collapsed"
-             is-last-reply="$last"
-             is-sidebar="::vm.isSidebar"
              name="annotation"
              ng-mouseenter="vm.annotationHovered = true"
              ng-mouseleave="vm.annotationHovered = false"

--- a/src/sidebar/templates/annotation_viewer_content.html
+++ b/src/sidebar/templates/annotation_viewer_content.html
@@ -1,0 +1,9 @@
+<thread-list
+  on-change-collapsed="setCollapsed(id, collapsed)"
+  on-clear-selection="clearSelection()"
+  on-focus="focus(annotation)"
+  on-force-visible="forceVisible(thread)"
+  on-select="scrollTo(annotation)"
+  show-document-info="true"
+  thread="rootThread">
+</thread-list>

--- a/src/sidebar/templates/annotation_viewer_content.html
+++ b/src/sidebar/templates/annotation_viewer_content.html
@@ -1,9 +1,6 @@
 <thread-list
   on-change-collapsed="setCollapsed(id, collapsed)"
-  on-clear-selection="clearSelection()"
-  on-focus="focus(annotation)"
   on-force-visible="forceVisible(thread)"
-  on-select="scrollTo(annotation)"
   show-document-info="true"
   thread="rootThread">
 </thread-list>

--- a/src/sidebar/templates/sidebar_content.html
+++ b/src/sidebar/templates/sidebar_content.html
@@ -10,7 +10,6 @@
 
 <search-status-bar
   ng-show="!isLoading()"
-  ng-if="!isStream"
   filter-active="!!search.query()"
   filter-match-count="visibleCount()"
   on-clear-selection="clearSelection()"
@@ -39,18 +38,16 @@
   </p>
 </div>
 
-<span window-scroll="loadMore(20)">
-  <thread-list
-    on-change-collapsed="setCollapsed(id, collapsed)"
-    on-clear-selection="clearSelection()"
-    on-focus="focus(annotation)"
-    on-force-visible="forceVisible(thread)"
-    on-select="scrollTo(annotation)"
-    show-document-info="::!isSidebar"
-    thread="rootThread">
-  </thread-list>
-</span>
+<thread-list
+  on-change-collapsed="setCollapsed(id, collapsed)"
+  on-clear-selection="clearSelection()"
+  on-focus="focus(annotation)"
+  on-force-visible="forceVisible(thread)"
+  on-select="scrollTo(annotation)"
+  show-document-info="false"
+  thread="rootThread">
+</thread-list>
 
-<loggedout-message ng-if="isSidebar && shouldShowLoggedOutMessage()"
+<loggedout-message ng-if="shouldShowLoggedOutMessage()"
   on-login="login()" ng-cloak>
 </loggedout-message>

--- a/src/sidebar/templates/sidebar_content.html
+++ b/src/sidebar/templates/sidebar_content.html
@@ -48,6 +48,5 @@
   thread="rootThread">
 </thread-list>
 
-<loggedout-message ng-if="shouldShowLoggedOutMessage()"
-  on-login="login()" ng-cloak>
+<loggedout-message ng-if="shouldShowLoggedOutMessage()" on-login="login()">
 </loggedout-message>

--- a/src/sidebar/templates/stream_content.html
+++ b/src/sidebar/templates/stream_content.html
@@ -1,0 +1,11 @@
+<span window-scroll="loadMore(20)">
+  <thread-list
+    on-change-collapsed="setCollapsed(id, collapsed)"
+    on-clear-selection="clearSelection()"
+    on-focus="focus(annotation)"
+    on-force-visible="forceVisible(thread)"
+    on-select="scrollTo(annotation)"
+    show-document-info="true"
+    thread="rootThread">
+  </thread-list>
+</span>

--- a/src/sidebar/templates/stream_content.html
+++ b/src/sidebar/templates/stream_content.html
@@ -1,10 +1,7 @@
 <span window-scroll="loadMore(20)">
   <thread-list
     on-change-collapsed="setCollapsed(id, collapsed)"
-    on-clear-selection="clearSelection()"
-    on-focus="focus(annotation)"
     on-force-visible="forceVisible(thread)"
-    on-select="scrollTo(annotation)"
     show-document-info="true"
     thread="rootThread">
   </thread-list>


### PR DESCRIPTION
In preparation for component-izing the top level of the application, this PR splits the "viewer.html" template which provides the UI structure for everything below the top bar in the sidebar into three - one per app type (sidebar, stream, single annotation + replies page).

Splitting up the template enables a bunch of conditionals to be removed or simplified, as well as removing things that are not used in one app type (such as the `window-scroll` infinite scroll helper for the stream) from the other app types.

A subsequent step will be to convert each of the controllers (WidgetController, StreamController, AnnotationViewerController) into a component which uses the appropriate template. The bottom of the `app.html` template will eventually end up looking something like this:

```html
<span ng-if="vm.hasFetchedProfile()">
  <sidebar-content ng-if="vm.appType === 'sidebar'"></sidebar-content>
  <stream-content ng-if="vm.appType === 'stream'"></stream-content>
  <annotation-viewer-content ng-if="vm.appType === 'annotation'"></annotation-viewer-content>
</span>
```