### PR TITLE
Reorganize annotation sync tests

### DIFF
--- a/src/annotator/test/annotation-sync-test.js
+++ b/src/annotator/test/annotation-sync-test.js
@@ -45,8 +45,8 @@ describe('AnnotationSync', function() {
     sandbox.restore();
   });
 
-  describe('channel event handlers', function() {
-    describe('the "deleteAnnotation" event', function() {
+  describe('#constructor', function() {
+    context('when "deleteAnnotation" is published', function() {
       it('broadcasts the "annotationDeleted" event over the local event bus', function() {
         var ann = {id: 1, $tag: 'tag1'};
         var eventStub = sinon.stub();
@@ -90,7 +90,7 @@ describe('AnnotationSync', function() {
       });
     });
 
-    describe('the "loadAnnotations" event', function() {
+    context('when "loadAnnotations" is published', function() {
       it('publishes the "annotationsLoaded" event', function() {
         var annotations = [
           {id: 1, $tag: 'tag1'},
@@ -111,10 +111,8 @@ describe('AnnotationSync', function() {
         assert.calledWith(loadedStub, annotations);
       });
     });
-  });
 
-  describe('event handlers', function() {
-    describe('the "beforeAnnotationCreated" event', function() {
+    context('when "beforeAnnotationCreated" is emitted', function() {
       it('proxies the event over the bridge', function() {
         var ann = {id: 1};
         createAnnotationSync();

--- a/src/annotator/test/annotation-sync-test.js
+++ b/src/annotator/test/annotation-sync-test.js
@@ -47,7 +47,7 @@ describe('AnnotationSync', function() {
 
   describe('#constructor', function() {
     context('when "deleteAnnotation" is published', function() {
-      it('broadcasts the "annotationDeleted" event over the local event bus', function() {
+      it('calls emit("annotationDeleted")', function() {
         var ann = {id: 1, $tag: 'tag1'};
         var eventStub = sinon.stub();
         options.on('annotationDeleted', eventStub);
@@ -58,7 +58,7 @@ describe('AnnotationSync', function() {
         assert.calledWith(eventStub, ann);
       });
 
-      it('calls back with a formatted annotation', function(done) {
+      it("calls the 'deleteAnnotation' event's callback function", function(done) {
         var ann = {id: 1, $tag: 'tag1'};
         var callback = function(err, ret) {
           assert.isNull(err);
@@ -70,7 +70,7 @@ describe('AnnotationSync', function() {
         publish('deleteAnnotation', {msg: ann}, callback);
       });
 
-      it('removes an existing entry from the cache before the event is triggered', function() {
+      it('deletes any existing annotation from its cache before calling emit', function() {
         var ann = {id: 1, $tag: 'tag1'};
         var annSync = createAnnotationSync();
         annSync.cache.tag1 = ann;
@@ -79,7 +79,7 @@ describe('AnnotationSync', function() {
         publish('deleteAnnotation', {msg: ann}, function() {});
       });
 
-      it('removes the annotation from the cache', function() {
+      it('deletes any existing annotation from its cache', function() {
         var ann = {id: 1, $tag: 'tag1'};
         var annSync = createAnnotationSync();
         annSync.cache.tag1 = ann;
@@ -91,7 +91,7 @@ describe('AnnotationSync', function() {
     });
 
     context('when "loadAnnotations" is published', function() {
-      it('publishes the "annotationsLoaded" event', function() {
+      it('calls emit("annotationsLoaded")', function() {
         var annotations = [
           {id: 1, $tag: 'tag1'},
           {id: 2, $tag: 'tag2'},
@@ -113,7 +113,7 @@ describe('AnnotationSync', function() {
     });
 
     context('when "beforeAnnotationCreated" is emitted', function() {
-      it('proxies the event over the bridge', function() {
+      it('calls bridge.call() passing the event', function() {
         var ann = {id: 1};
         createAnnotationSync();
 
@@ -125,13 +125,15 @@ describe('AnnotationSync', function() {
           sinon.match.func);
       });
 
-      it('returns early if the annotation has a tag', function() {
-        var ann = {id: 1, $tag: 'tag1'};
-        createAnnotationSync();
+      context('if the annotation has a $tag', function() {
+        it('does not call bridge.call()', function() {
+          var ann = {id: 1, $tag: 'tag1'};
+          createAnnotationSync();
 
-        options.emit('beforeAnnotationCreated', ann);
+          options.emit('beforeAnnotationCreated', ann);
 
-        assert.notCalled(fakeBridge.call);
+          assert.notCalled(fakeBridge.call);
+        });
       });
     });
   });


### PR DESCRIPTION
# Reorganize AnnotationSync tests by method

If the tests are grouped according to what class / method / function
they're testing, then it's a lot easier to see what is being tested and
what isn't, and it's easier to find the tests for `foo()` or to know where
to put new tests for `foo()`.

On the other hand when you names tests like
`describe('channel event handlers',` `describe('event handlers',`
`describe('the "loadAnnotations" event',`,
`describe('the "deleteAnnotation" event',` etc then it can be a lot
harder for a reader coming along later to understand how the tests are
organized and how this organization relates to the code itself.

Most of the examples on https://mochajs.org/ use this style of
organizing tests:

    describe('Array', function() {
      describe('#indexOf()', function() {
        it(...
        ...
      });

      describe('#concat()', function () {
        it(...
        ...
      });

      describe('#slice()', function () {
        it(...
        ...
      });

    describe('User', function() {
      describe('#save()', function() {
        it(...

    describe('Connection', function() {
      describe('#find()', function() {
        it(...

This commit reorganizes the AnnotationSync tests along the same lines.

I've also made use of Mocha's `context()` function to group tests
**within a `describe()` for a method** by context. `context()` is just
an alias for `describe()`, but it has different semantics. (This is
also in line with how `context()` is used in the mochajs.org examples).

* * *

# Improve AnnotationSync test names

Rename all the tests to better reflect what they actually test.

Mostly replacing broadcast local event bus publisher proxying with
"calls function", plus a couple of other clarifications.

Before:

  AnnotationSync
    channel event handlers
      the "deleteAnnotation" event
        ✓ broadcasts the "annotationDeleted" event over the local event bus
        ✓ calls back with a formatted annotation
        ✓ removes an existing entry from the cache before the event is triggered
        ✓ removes the annotation from the cache
      the "loadAnnotations" event
        ✓ publishes the "annotationsLoaded" event
    event handlers
      the "beforeAnnotationCreated" event
        ✓ proxies the event over the bridge
        ✓ returns early if the annotation has a tag

After:

  AnnotationSync
    #constructor
      when "deleteAnnotation" is published
        ✓ calls emit("annotationDeleted")
        ✓ calls the 'deleteAnnotation' event's callback function
        ✓ deletes any existing annotation from its cache before calling emit
        ✓ deletes any existing annotation from its cache
      when "loadAnnotations" is published
        ✓ calls emit("annotationsLoaded")
      when "beforeAnnotationCreated" is emitted
        ✓ calls bridge.call() passing the event
        if the annotation has a $tag
          ✓ does not call bridge.call()