### PR TITLE
Adding auth metrics for login, logout, and signup requested

### DIFF
--- a/src/sidebar/analytics.js
+++ b/src/sidebar/analytics.js
@@ -41,7 +41,7 @@ var globalGAOptions = function(win, settings){
  */
 // @ngInject
 function analytics($analytics, $window, settings) {
-  var options = globalGAOptions($window, settings);
+  var options = $window ? globalGAOptions($window, settings) : {};
 
   return {
 
@@ -67,6 +67,10 @@ function analytics($analytics, $window, settings) {
       HIGHLIGHT_CREATED: 'highlightCreated',
       HIGHLIGHT_UPDATED: 'highlightUpdated',
       HIGHLIGHT_DELETED: 'highlightDeleted',
+      LOGIN_FAILURE: 'loginFailure',
+      LOGIN_SUCCESS: 'loginSuccessful',
+      LOGOUT_FAILURE: 'logoutFailure',
+      LOGOUT_SUCCESS: 'logoutSuccessful',
       PAGE_NOTE_CREATED: 'pageNoteCreated',
       PAGE_NOTE_UPDATED: 'pageNoteUpdated',
       PAGE_NOTE_DELETED: 'pageNoteDeleted',
@@ -74,6 +78,7 @@ function analytics($analytics, $window, settings) {
       REPLY_UPDATED: 'replyUpdated',
       REPLY_DELETED: 'replyDeleted',
       SIDEBAR_OPENED: 'sidebarOpened',
+      SIGN_UP_REQUESTED: 'signUpRequested',
     },
   };
 }

--- a/src/sidebar/app-controller.js
+++ b/src/sidebar/app-controller.js
@@ -26,7 +26,7 @@ function authStateFromUserID(userid) {
 // @ngInject
 module.exports = function AppController(
   $document, $location, $rootScope, $route, $scope,
-  $window, annotationUI, auth, bridge, drafts, features, frameSync, groups,
+  $window, analytics, annotationUI, auth, bridge, drafts, features, frameSync, groups,
   serviceUrl, session, settings, streamer
 ) {
 
@@ -107,6 +107,10 @@ module.exports = function AppController(
 
     $scope.accountDialog.visible = true;
     scrollToView('login-form');
+  };
+
+  $scope.signUp = function(){
+    analytics.track(analytics.events.SIGN_UP_REQUESTED);
   };
 
   // Display the dialog for sharing the current page

--- a/src/sidebar/components/login-control.js
+++ b/src/sidebar/components/login-control.js
@@ -25,6 +25,10 @@ module.exports = {
      */
     onLogin: '&',
     /**
+     * Called when the user clicks on the "Sign Up" text.
+     */
+    onSignUp: '&',
+    /**
      * Called when the user clicks on the "Log out" text.
      */
     onLogout: '&',

--- a/src/sidebar/components/login-form.js
+++ b/src/sidebar/components/login-form.js
@@ -3,13 +3,14 @@
 var angular = require('angular');
 
 // @ngInject
-function Controller($scope, $timeout, flash, session, formRespond, serviceUrl) {
+function Controller($scope, $timeout, analytics, flash, session, formRespond, serviceUrl) {
   var pendingTimeout = null;
 
   function success(data) {
     if (data.userid) {
       $scope.$emit('auth', null, data);
     }
+    analytics.track(analytics.events.LOGIN_SUCCESS);
 
     angular.copy({}, $scope.model);
 
@@ -30,6 +31,8 @@ function Controller($scope, $timeout, flash, session, formRespond, serviceUrl) {
         'Please try again later!';
     }
 
+    analytics.track(analytics.events.LOGIN_FAILURE);
+    
     return formRespond(form, errors, reason);
   }
 

--- a/src/sidebar/directive/top-bar.js
+++ b/src/sidebar/directive/top-bar.js
@@ -9,6 +9,7 @@ module.exports = function () {
       isSidebar: '<',
       onShowHelpPanel: '&',
       onLogin: '&',
+      onSignUp: '&',
       onLogout: '&',
       onSharePage: '&',
       searchController: '<',

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -43,7 +43,7 @@ function sessionActions(options) {
  *
  * @ngInject
  */
-function session($http, $resource, $rootScope, annotationUI, auth,
+function session($http, $q, $resource, $rootScope, analytics, annotationUI, auth,
                  flash, raven, settings, store) {
   // Headers sent by every request made by the session service.
   var headers = {};
@@ -208,9 +208,13 @@ function session($http, $resource, $rootScope, annotationUI, auth,
       auth.clearCache();
     }).catch(function (err) {
       flash.error('Log out failed');
-      throw err;
+      analytics.track(analytics.events.LOGOUT_FAILURE);
+      return $q.reject(new Error(err));
+    }).then(function(){
+      analytics.track(analytics.events.LOGOUT_SUCCESS);
     });
   }
+
 
   return {
     dismissSidebarTutorial: dismissSidebarTutorial,

--- a/src/sidebar/templates/app.html
+++ b/src/sidebar/templates/app.html
@@ -2,6 +2,7 @@
   <top-bar
     auth="auth"
     on-login="login()"
+    on-sign-up="signUp()"
     on-logout="logout()"
     on-share-page="share()"
     on-show-help-panel="helpPanel.visible = true"

--- a/src/sidebar/templates/login_control.html
+++ b/src/sidebar/templates/login_control.html
@@ -3,7 +3,7 @@
       ng-if="vm.newStyle && vm.auth.status === 'unknown'">⋯</span>
 <span class="login-text"
       ng-if="vm.newStyle && vm.auth.status === 'logged-out'">
-  <a href="{{vm.serviceUrl('signup')}}" target="_blank" h-branding="highlightColor">Sign up</a>
+  <a href="{{vm.serviceUrl('signup')}}" ng-click="vm.onSignUp()" target="_blank" h-branding="highlightColor">Sign up</a>
   / <a href="" ng-click="vm.onLogin()" h-branding="highlightColor">Log in</a>
 </span>
 <div ng-if="vm.newStyle"

--- a/src/sidebar/templates/top_bar.html
+++ b/src/sidebar/templates/top_bar.html
@@ -56,7 +56,8 @@
       new-style="true"
       on-show-help-panel="onShowHelpPanel()"
       on-login="onLogin()"
-      on-logout="onLogout()">
+      on-logout="onLogout()"
+      on-sign-up="onSignUp()">
     </login-control>
   </div>
 </div>

--- a/src/sidebar/test/app-controller-test.js
+++ b/src/sidebar/test/app-controller-test.js
@@ -69,7 +69,7 @@ describe('AppController', function () {
 
     fakeAnalytics = {
       track: sandbox.stub(),
-      events: {},
+      events: require('../analytics')().events,
     };
 
     fakeAuth = {};
@@ -254,6 +254,12 @@ describe('AppController', function () {
     fakeRoute.reload = sinon.spy();
     $scope.$broadcast(events.USER_CHANGED, {initialLoad: false});
     assert.calledOnce(fakeRoute.reload);
+  });
+
+  it('tracks sign up requests in analytics', function () {
+    createController();
+    $scope.signUp();
+    assert.calledWith(fakeAnalytics.track, fakeAnalytics.events.SIGN_UP_REQUESTED);
   });
 
   describe('#login()', function () {


### PR DESCRIPTION
This ticket is meant to add analytics on the success and failure of login/logout functions as well as the signup requested link. These events can tell us a whole bunch about issues and opportunities with our authentication and provide a metric for validation once we start improving it. The sign up is really valuable because this can tell us where people are converting to users - this is _massively_ important for business insights.

The changeset touches a lot of files because of how we are propagating functions from the app controller all the way to the login controller and signup was never needed.