### PR TITLE
Convert `WidgetController` into a `<sidebar-content>` component

### DIFF
--- a/src/sidebar/app-controller.js
+++ b/src/sidebar/app-controller.js
@@ -5,7 +5,6 @@ var scrollIntoView = require('scroll-into-view');
 var events = require('./events');
 var parseAccountID = require('./filter/persona').parseAccountID;
 var scopeTimeout = require('./util/scope-timeout');
-var uiConstants = require('./ui-constants');
 var serviceConfig = require('./service-config');
 var bridgeEvents = require('../shared/bridge-events');
 
@@ -140,16 +139,6 @@ module.exports = function AppController(
     drafts.discard();
     $scope.accountDialog.visible = false;
     session.logout();
-  };
-
-  $scope.clearSelection = function () {
-    var selectedTab = annotationUI.getState().selectedTab;
-    if (!annotationUI.getState().selectedTab || annotationUI.getState().selectedTab === uiConstants.TAB_ORPHANS) {
-      selectedTab = uiConstants.TAB_ANNOTATIONS;
-    }
-
-    annotationUI.clearSelectedAnnotations();
-    annotationUI.selectTab(selectedTab);
   };
 
   $scope.search = {

--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -75,6 +75,10 @@ function configureRoutes($routeProvider) {
       resolve: resolve,
     });
   $routeProvider.otherwise({
+    // Trivial template for use until the other controllers are also converted
+    // to components and we can remove the router entirely.
+    //
+    // The "search" and "auth" properties are provided by "AppController".
     template: '<sidebar-content search="search" auth="auth"></sidebar-content>',
     reloadOnSearch: false,
     resolve: resolve,

--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -75,8 +75,7 @@ function configureRoutes($routeProvider) {
       resolve: resolve,
     });
   $routeProvider.otherwise({
-    controller: 'WidgetController',
-    template: require('./templates/sidebar_content.html'),
+    template: '<sidebar-content search="search" auth="auth"></sidebar-content>',
     reloadOnSearch: false,
     resolve: resolve,
   });
@@ -128,7 +127,6 @@ module.exports = angular.module('h', [
 
   .controller('AnnotationViewerController', require('./annotation-viewer-controller'))
   .controller('StreamController', require('./stream-controller'))
-  .controller('WidgetController', require('./widget-controller'))
 
   // The root component for the application
   .directive('hypothesisApp', require('./directive/app'))
@@ -150,6 +148,7 @@ module.exports = angular.module('h', [
   .component('searchInput', require('./components/search-input'))
   .component('searchStatusBar', require('./components/search-status-bar'))
   .component('selectionTabs', require('./components/selection-tabs'))
+  .component('sidebarContent', require('./components/sidebar-content'))
   .component('sidebarTutorial', require('./components/sidebar-tutorial').component)
   .component('shareDialog', require('./components/share-dialog'))
   .component('sortDropdown', require('./components/sort-dropdown'))

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -4,6 +4,7 @@ var SearchClient = require('../search-client');
 var events = require('../events');
 var memoize = require('../util/memoize');
 var tabs = require('../tabs');
+var uiConstants = require('../ui-constants');
 
 function firstKey(object) {
   for (var k in object) {
@@ -323,6 +324,16 @@ function SidebarContentController(
 
   this.topLevelThreadCount = function () {
     return thread().totalChildren;
+  };
+
+  this.clearSelection = function () {
+    var selectedTab = annotationUI.getState().selectedTab;
+    if (!annotationUI.getState().selectedTab || annotationUI.getState().selectedTab === uiConstants.TAB_ORPHANS) {
+      selectedTab = uiConstants.TAB_ANNOTATIONS;
+    }
+
+    annotationUI.clearSelectedAnnotations();
+    annotationUI.selectTab(selectedTab);
   };
 }
 

--- a/src/sidebar/templates/sidebar_content.html
+++ b/src/sidebar/templates/sidebar_content.html
@@ -1,52 +1,52 @@
 <selection-tabs
-  ng-if="!search.query() && selectedAnnotationCount() === 0"
-  is-waiting-to-anchor-annotations="waitingToAnchorAnnotations"
-  is-loading="isLoading"
-  selected-tab="selectedTab"
-  total-annotations="totalAnnotations"
-  total-notes="totalNotes"
-  total-orphans="totalOrphans">
+  ng-if="!vm.search.query() && vm.selectedAnnotationCount() === 0"
+  is-waiting-to-anchor-annotations="vm.waitingToAnchorAnnotations"
+  is-loading="vm.isLoading"
+  selected-tab="vm.selectedTab"
+  total-annotations="vm.totalAnnotations"
+  total-notes="vm.totalNotes"
+  total-orphans="vm.totalOrphans">
 </selection-tabs>
 
 <search-status-bar
-  ng-show="!isLoading()"
-  filter-active="!!search.query()"
-  filter-match-count="visibleCount()"
-  on-clear-selection="clearSelection()"
-  search-query="search ? search.query : ''"
-  selection-count="selectedAnnotationCount()"
-  total-count="topLevelThreadCount()"
-  selected-tab="selectedTab"
-  total-annotations="totalAnnotations"
-  total-notes="totalNotes">
+  ng-show="!vm.isLoading()"
+  filter-active="!!vm.search.query()"
+  filter-match-count="vm.visibleCount()"
+  on-clear-selection="vm.clearSelection()"
+  search-query="vm.search ? vm.search.query : ''"
+  selection-count="vm.selectedAnnotationCount()"
+  total-count="vm.topLevelThreadCount()"
+  selected-tab="vm.selectedTab"
+  total-annotations="vm.totalAnnotations"
+  total-notes="vm.totalNotes">
 </search-status-bar>
 
 <div class="annotation-unavailable-message"
-    ng-if="selectedAnnotationUnavailable()">
+    ng-if="vm.selectedAnnotationUnavailable()">
   <div class="annotation-unavailable-message__icon"></div>
   <p class="annotation-unavailable-message__label">
-    <span ng-if="auth.status === 'logged-out'">
+    <span ng-if="vm.auth.status === 'logged-out'">
       This annotation is not available.
       <br>
       You may need to
-      <a class="loggedout-message__link" href="" ng-click="login()">log in</a>
+      <a class="loggedout-message__link" href="" ng-click="vm.login()">log in</a>
       to see it.
     </span>
-    <span ng-if="auth.status === 'logged-in'">
+    <span ng-if="vm.auth.status === 'logged-in'">
       You do not have permission to view this annotation.
     </span>
   </p>
 </div>
 
 <thread-list
-  on-change-collapsed="setCollapsed(id, collapsed)"
-  on-clear-selection="clearSelection()"
-  on-focus="focus(annotation)"
-  on-force-visible="forceVisible(thread)"
-  on-select="scrollTo(annotation)"
+  on-change-collapsed="vm.setCollapsed(id, collapsed)"
+  on-clear-selection="vm.clearSelection()"
+  on-focus="vm.focus(annotation)"
+  on-force-visible="vm.forceVisible(thread)"
+  on-select="vm.scrollTo(annotation)"
   show-document-info="false"
-  thread="rootThread">
+  thread="vm.rootThread">
 </thread-list>
 
-<loggedout-message ng-if="shouldShowLoggedOutMessage()" on-login="login()">
+<loggedout-message ng-if="vm.shouldShowLoggedOutMessage()" on-login="vm.login()">
 </loggedout-message>


### PR DESCRIPTION
This is a follow-up to https://github.com/hypothesis/client/pull/308 . It converts the `WidgetController` controller which provides the logic for the content area of the sidebar application into a `<sidebar-content>` component which follows the same structure as the rest of the UI.

Some notes about the conversion:

* Scope properties set by `AppController` are no longer implicitly available to the sidebar content's controller. Instead the "auth" and "search" properties are passed explicitly (in future we can probably simplify or remove them) and the "clearSelection" function has been moved into SidebarContentController since only the sidebar uses it.
* The router is still used to select the content of the `<main ng-view>` element but for the sidebar it now just uses a trivial template which renders a `<sidebar-content>` instance. Once all of the three app types have been converted the same way, we can remove the router entirely.

----

**Testing** - Check that all the basic functionality of the top-level elements below the top bar in the sidebar still works (eg. thread list still renders, clearing search works, zero state messages displayed correctly for different tabs).