### PR TITLE
Output logs from s3-npm-publish Docker container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,9 @@ node {
         // Upload the contents of the package to an S3 bucket, which it
         // will then be served from.
         docker.image('nickstenning/s3-npm-publish')
-              .withRun('', 'hypothesis s3://cdn.hypothes.is') { /* empty */ }
+              .withRun('', 'hypothesis s3://cdn.hypothes.is') { c ->
+                sh "docker logs --follow ${c.id}"
+              }
     }
 }
 


### PR DESCRIPTION
To help debug publishing failures, output logs from the container.  See
https://hypothes-is.slack.com/archives/C076LQFA4/p1490705667081734

See https://go.cloudbees.com/docs/cloudbees-documentation/cje-user-guide/index.html#docker-workflow-sect-run for docs on the Jenkins plugin that we use to run Docker. Note that unlike the example they give, I use `--follow` to make sure that we output _all_ of the logs until the task exits.