### PR TITLE
Use new endpoint for creating an annotation flag

### DIFF
--- a/src/sidebar/annotation-mapper.js
+++ b/src/sidebar/annotation-mapper.js
@@ -55,8 +55,8 @@ function annotationMapper($rootScope, annotationUI, store) {
   }
 
   function flagAnnotation(annot) {
-    return store.flag.create(null,{
-      annotation: annot.id,
+    return store.annotation.flag({
+      id: annot.id,
     }).then(function () {
       $rootScope.$broadcast(events.ANNOTATION_FLAGGED, annot);
       return annot;

--- a/src/sidebar/store.js
+++ b/src/sidebar/store.js
@@ -142,9 +142,7 @@ function store($http, $q, auth, settings) {
       delete: apiCall('annotation.delete'),
       get: apiCall('annotation.read'),
       update: apiCall('annotation.update'),
-    },
-    flag: {
-      create: apiCall('flag.create'),
+      flag: apiCall('annotation.flag'),
     },
     profile: {
       read: apiCall('profile.read'),

--- a/src/sidebar/test/annotation-mapper-test.js
+++ b/src/sidebar/test/annotation-mapper-test.js
@@ -16,9 +16,7 @@ describe('annotationMapper', function() {
     fakeStore = {
       annotation: {
         delete: sinon.stub().returns(Promise.resolve({})),
-      },
-      flag: {
-        create: sinon.stub().returns(Promise.resolve({})),
+        flag: sinon.stub().returns(Promise.resolve({})),
       },
     };
     angular.module('app', [])
@@ -131,8 +129,8 @@ describe('annotationMapper', function() {
     it('flags an annotation', function () {
       var ann = {id: 'test-id'};
       annotationMapper.flagAnnotation(ann);
-      assert.calledOnce(fakeStore.flag.create);
-      assert.calledWith(fakeStore.flag.create, null, {annotation: ann.id});
+      assert.calledOnce(fakeStore.annotation.flag);
+      assert.calledWith(fakeStore.annotation.flag, {id: ann.id});
     });
 
     it('emits the "annotationFlagged" event', function (done) {

--- a/src/sidebar/test/store-test.js
+++ b/src/sidebar/test/store-test.js
@@ -66,11 +66,9 @@ describe('store', function () {
             method: 'PUT',
             url: 'http://example.com/api/annotations/:id',
           },
-        },
-        flag: {
-          create: {
-            method: 'POST',
-            url: 'http://example.com/api/flags',
+          flag: {
+            method: 'PUT',
+            url: 'http://example.com/api/annotations/:id/flag',
           },
         },
         search: {
@@ -130,11 +128,11 @@ describe('store', function () {
   });
 
   it('flags an annotation', function (done) {
-    store.flag.create(null, {annotation: 'an-id'}).then(function () {
+    store.annotation.flag({id: 'an-id'}).then(function () {
       done();
     });
 
-    $httpBackend.expectPOST('http://example.com/api/flags')
+    $httpBackend.expectPUT('http://example.com/api/annotations/an-id/flag')
       .respond(function () {
         return [204, {}, {}];
       });


### PR DESCRIPTION
This is the client version of hypothesis/h#4454, meaning the endpoint that the client is using here won't be available until the h PR is merged.

We decided to change the flagging API, so we need to change the client a bit for when a user flags an annotation.

I suggest not merging this until the h PR is merged, in case there are some review comments that would need client changes as well.