### PR TITLE
Fix scrolling to new annotations

### DIFF
--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -79,7 +79,7 @@ function ThreadListController($scope, VirtualThreadList) {
     // Note: This assumes that the element occupies the entire height of the
     // containing document. It would be preferable if only the contents of the
     // <thread-list> itself scrolled.
-    var maxYOffset = document.body.clientHeight - window.innerHeight;
+    var maxYOffset = document.body.scrollHeight - window.innerHeight;
     return Math.min(maxYOffset, visibleThreads.yOffsetOf(id));
   }
 


### PR DESCRIPTION
Short version: Scrolling to new annotations which were off-screen failed because the function which computed the vertical offset to scroll the sidebar to when a new annotation was added always returned 0.  This was due to using the wrong geometry property of `document.body` to get the height of the content.

The previous method _happened_ to work prior to what should have been an innocent change in #306 which set the height of the `<hypothesis-app>` element to the height of the viewport.

----

Longer version: See https://github.com/hypothesis/client/issues/319#issuecomment-290055924

----

**Testing**: Build a prod Chrome extension and follow the steps in #319

Fixes #319