### PR TITLE
Remove obsolete `ng-cloak` directives

### DIFF
--- a/src/sidebar/templates/hypothesis_app.html
+++ b/src/sidebar/templates/hypothesis_app.html
@@ -15,7 +15,7 @@
     on-change-sort-key="vm.setSortKey(sortKey)">
   </top-bar>
 
-  <div class="create-account-banner" ng-if="vm.isSidebar && vm.auth.status === 'logged-out'" ng-cloak>
+  <div class="create-account-banner" ng-if="vm.isSidebar && vm.auth.status === 'logged-out'">
     To annotate this document
     <a href="{{ vm.serviceUrl('signup') }}" target="_blank">
       create a free account
@@ -23,7 +23,7 @@
     or <a href="" ng-click="vm.login()">log in</a>
   </div>
 
-  <div class="content" ng-cloak>
+  <div class="content">
     <login-form
       ng-if="vm.accountDialog.visible"
       on-close="vm.accountDialog.visible = false">

--- a/src/sidebar/templates/sort_dropdown.html
+++ b/src/sidebar/templates/sort_dropdown.html
@@ -1,4 +1,4 @@
-<span class="ng-cloak" dropdown keyboard-nav>
+<span dropdown keyboard-nav>
   <button
     type="button"
     class="top-bar__btn"


### PR DESCRIPTION
[ng-cloak](https://docs.angularjs.org/api/ng/directive/ngCloak) exists to hide Angular templates in the HTML page until they
are processed by Angular's template compiler. This is now unnecessary
since the only thing present in the initial HTML page is the empty
`<hypothesis-app>` element.