### PR TITLE
Remove unused controller properties

### DIFF
--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -36,14 +36,6 @@ function HypothesisAppController(
   // used by templates to show an intermediate or loading state.
   this.auth = {status: 'unknown'};
 
-  // Allow all child scopes to look up feature flags as:
-  //
-  //     if ($scope.feature('foo')) { ... }
-  this.feature = features.flagEnabled;
-
-  // Allow all child scopes access to the session
-  this.session = session;
-
   // App dialogs
   this.accountDialog = {visible: false};
   this.shareDialog = {visible: false};


### PR DESCRIPTION
Now that `<hypothesis-app>` has been converted to a component, it is
easier to see that the `feature` and `session` properties are not used
because they are not referenced elsewhere in the controller or the
template (as `vm.{property}`) and are not accessible to any child components
any more.