### PR TITLE
Fix Mobile Safari Scrolling

### DIFF
--- a/src/sidebar/test/virtual-thread-list-test.js
+++ b/src/sidebar/test/virtual-thread-list-test.js
@@ -47,7 +47,6 @@ describe('VirtualThreadList', function () {
     fakeScope = {$digest: sinon.stub()};
 
     fakeScrollRoot = {
-      className: 'app-content-wrapper',
       scrollTop: 0,
       listeners: {},
       addEventListener: function (event, listener) {
@@ -83,17 +82,10 @@ describe('VirtualThreadList', function () {
         });
       },
       innerHeight: 100,
-      document: {
-        querySelector: function(selector){
-          if(selector === '.' + fakeScrollRoot.className){
-            return fakeScrollRoot;
-          }
-          return null;
-        },
-      },
     };
 
     threadOptions.invisibleThreadFilter = sinon.stub().returns(false);
+    threadOptions.scrollRoot = fakeScrollRoot;
 
     var rootThread = {annotation: undefined, children: []};
     threadList = new VirtualThreadList(fakeScope, fakeWindow, rootThread, threadOptions);

--- a/src/sidebar/virtual-thread-list.js
+++ b/src/sidebar/virtual-thread-list.js
@@ -36,16 +36,17 @@ function VirtualThreadList($scope, window_, rootThread, options) {
   this._heights = {};
 
   this.window = window_;
+  this.scrollRoot = this.window.document.querySelector('.app-content-wrapper');
 
   var debouncedUpdate = debounce(function () {
     self._updateVisibleThreads();
     $scope.$digest();
   }, 20);
-  this.window.addEventListener('scroll', debouncedUpdate);
+  this.scrollRoot.addEventListener('scroll', debouncedUpdate);
   this.window.addEventListener('resize', debouncedUpdate);
 
   this._detach = function () {
-    this.window.removeEventListener('scroll', debouncedUpdate);
+    this.scrollRoot.removeEventListener('scroll', debouncedUpdate);
     this.window.removeEventListener('resize', debouncedUpdate);
   };
 }
@@ -153,17 +154,20 @@ VirtualThreadList.prototype._updateVisibleThreads = function () {
   for (var i = 0; i < allThreads.length; i++) {
     thread = allThreads[i];
     var threadHeight = this._height(thread.id);
+
     var added = false;
 
-    if (usedHeight + threadHeight < this.window.pageYOffset - MARGIN_ABOVE) {
+    if (usedHeight + threadHeight < this.scrollRoot.scrollTop - MARGIN_ABOVE) {
       // Thread is above viewport
       offscreenUpperHeight += threadHeight;
     } else if (usedHeight <
-      this.window.pageYOffset + visibleHeight + MARGIN_BELOW) {
+      this.scrollRoot.scrollTop + visibleHeight + MARGIN_BELOW) {
+
       // Thread is either in or close to the viewport
       visibleThreads.push(thread);
       added = true;
     } else {
+
       // Thread is below viewport
       offscreenLowerHeight += threadHeight;
     }

--- a/src/sidebar/virtual-thread-list.js
+++ b/src/sidebar/virtual-thread-list.js
@@ -5,6 +5,16 @@ var debounce = require('lodash.debounce');
 var inherits = require('inherits');
 
 /**
+ * @typedef Options
+ * @property {Function} [invisibleThreadFilter] - Function used to determine
+ *   whether an off-screen thread should be rendered or not.  Called with a
+ *   `Thread` and if it returns `true`, the thread is rendered even if offscreen.
+ * @property {Element} [scrollRoot] - The scrollable Element which contains the
+ *   thread list. The set of on-screen threads is determined based on the scroll
+ *   position and height of this element.
+ */
+
+/**
  * VirtualThreadList is a helper for virtualizing the annotation thread list.
  *
  * 'Virtualizing' the thread list improves UI performance by only creating
@@ -20,10 +30,7 @@ var inherits = require('inherits');
  * @param {Window} container - The Window displaying the list of annotation threads.
  * @param {Thread} rootThread - The initial Thread object for the top-level
  *        threads.
- * @param {Object} options - The render-time options to help make final adjustments
- *        to what is and is not rendered.
- *        options.invisibleThreadFilter allows integrator to tell us what should be
- *          rerendered but not visible to the user yet.
+ * @param {Options} options
  */
 function VirtualThreadList($scope, window_, rootThread, options) {
   var self = this;
@@ -36,7 +43,7 @@ function VirtualThreadList($scope, window_, rootThread, options) {
   this._heights = {};
 
   this.window = window_;
-  this.scrollRoot = this.window.document.querySelector('.app-content-wrapper');
+  this.scrollRoot = options.scrollRoot || document.body;
 
   var debouncedUpdate = debounce(function () {
     self._updateVisibleThreads();

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -57,6 +57,9 @@ hypothesis-app {
   @include grey-background;
 
   min-height: 100%;
+  height: 100%;
+  overflow: scroll;
+  -webkit-overflow-scrolling: touch;
   padding: $sidebar-h-padding;
   padding-top: $sidebar-h-padding + $top-bar-height;
 

--- a/src/styles/top-bar.scss
+++ b/src/styles/top-bar.scss
@@ -6,7 +6,7 @@
   border-bottom: solid 1px $gray-lighter;
   height: $top-bar-height;
   font-size: 15px;
-  position: fixed;
+  position: absolute;
   left: 0;
   right: 0;
   top: 0;


### PR DESCRIPTION
Fixes #250 

Added the scrolling properties to the app-content-wrapper so that we can get a working scroll behavior for the main thread content. Moving the scroll to that layer caused the geometry to be off again so I updated the virtual thread list to use a scroll root which is the element in the tree that contains the overflow:scroll property. 

I changed the top-bar to position:absolute because the same fixed effect is achieved with absolute positioning and it does not cause as sporadic of jumping behavior to the top bar on mobile scrolling. There is still jumping behavior with the top bar, but that is out of the scope to be solved here. Though adding this absolute positioning made it less bad in the mean time.