### PR TITLE
Fixing sidebar not closing on outside content click issue

### DIFF
--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -47,6 +47,16 @@ module.exports = class Sidebar extends Host
     @element.on 'click', (event) =>
       if !@selectedTargets?.length
         this.hide()
+
+    # Mobile browsers do not register click events on
+    # elements without cursor: pointer. So instead of
+    # adding that to every element, we can add the initial
+    # touchstart event which is always registered to
+    # make up for the lack of click support for all elements.
+    @element.on 'touchstart', (event) =>
+      if !@selectedTargets?.length
+        this.hide()
+
     return this
 
   _setupSidebarEvents: ->

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -176,6 +176,9 @@ module.exports = class Sidebar extends Host
       .removeClass('h-icon-chevron-right')
       .addClass('h-icon-chevron-left')
 
+  isOpen: ->
+    !@frame.hasClass('annotator-collapsed')
+
   createAnnotation: (annotation = {}) ->
     super
     this.show() unless annotation.$highlight

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -173,3 +173,16 @@ describe 'Sidebar', ->
       hide = sandbox.stub(sidebar, 'hide')
       sidebar.onSwipe({type: 'swiperight'})
       assert.calledOnce(hide)
+
+  describe 'document events', ->
+
+    sidebar = null
+
+    beforeEach ->
+      sidebar = createSidebar({})
+
+    it 'closes the sidebar when the user taps or clicks in the page', ->
+      for event in ['click', 'touchstart']
+        sidebar.show()
+        sidebar.element.trigger(event)
+        assert.isFalse(sidebar.isOpen())


### PR DESCRIPTION
Fixes #252 

Since click is not registered for elements without `cursor: pointer` we will listen for the touchstart in addition to the click event so we can get around this issue for mobile devices.