### PR TITLE
Don't call Function.bind in src/annotator

### DIFF
--- a/src/annotator/annotation-sync.coffee
+++ b/src/annotator/annotation-sync.coffee
@@ -22,12 +22,14 @@ module.exports = class AnnotationSync
     @_emit = options.emit
 
     # Listen locally for interesting events
-    for event, handler of @_eventListeners
-      this._on(event, handler.bind(this))
+    Object.keys(@_eventListeners).forEach (event) =>
+      handler = @_eventListeners[event]
+      this._on(event, (a,b,c) => handler.call(this,a,b,c))
 
     # Register remotely invokable methods
-    for method, func of @_channelListeners
-      @bridge.on(method, func.bind(this))
+    Object.keys(@_channelListeners).forEach (method) =>
+      handler = @_channelListeners[method]
+      @bridge.on(method, (a,b,c) => handler.call(this,a,b,c))
 
   sync: (annotations) ->
     annotations = (this._format a for a in annotations)

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -42,7 +42,7 @@ module.exports = class Sidebar extends Host
     this._setupSidebarEvents()
 
   _setupDocumentEvents: ->
-    sidebarTrigger(document.body, @show.bind(this))
+    sidebarTrigger(document.body, => this.show())
 
     @element.on 'click', (event) =>
       if !@selectedTargets?.length
@@ -62,8 +62,8 @@ module.exports = class Sidebar extends Host
   _setupSidebarEvents: ->
     annotationCounts(document.body, @crossframe)
 
-    @crossframe.on('show', this.show.bind(this))
-    @crossframe.on('hide', this.hide.bind(this))
+    @crossframe.on('show', => this.show())
+    @crossframe.on('hide', => this.hide())
     @crossframe.on(events.DO_LOGIN, =>
       if @onLoginRequest
         @onLoginRequest()


### PR DESCRIPTION
Don't call the parent browsing environment's Function.bind() function
from the src/annotator code.

Some parent pages modify Function.protoype.bind(), for example replacing
it with their own broken bind() polyfill, and this causes our code to
crash.

Work around this by just not using bind().

Fixes https://github.com/hypothesis/client/issues/245