### PR TITLE
Make failed API calls reject with an Error

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -11,27 +11,6 @@ var isNew = annotationMetadata.isNew;
 var isReply = annotationMetadata.isReply;
 var isPageNote = annotationMetadata.isPageNote;
 
-/** Return a human-readable error message for the given server error.
- *
- * @param {object} reason The error object from the server. Should have
- * `status` and, if `status` is not `0`, `statusText` and (optionally)
- * `data.reason` properties.
- *
- * @returns {string}
- */
-function errorMessage(reason) {
-  var message;
-  if (reason.status <= 0) {
-    message = 'Service unreachable.';
-  } else {
-    message = reason.status + ' ' + reason.statusText;
-    if (reason.data && reason.data.reason) {
-      message = message + ': ' + reason.data.reason;
-    }
-  }
-  return message;
-}
-
 /**
  * Return a copy of `annotation` with changes made in the editor applied.
  */
@@ -226,9 +205,8 @@ function AnnotationController(
     * @description Flag the annotation.
     */
   vm.flag = function() {
-    var onRejected = function(reason) {
-      flash.error(
-        errorMessage(reason), 'Flagging annotation failed');
+    var onRejected = function(err) {
+      flash.error(err.message, 'Flagging annotation failed');
     };
     annotationMapper.flagAnnotation(vm.annotation).then(function(){
       analytics.track(analytics.events.ANNOTATION_FLAGGED);
@@ -245,9 +223,8 @@ function AnnotationController(
     return $timeout(function() {  // Don't use confirm inside the digest cycle.
       var msg = 'Are you sure you want to delete this annotation?';
       if ($window.confirm(msg)) {
-        var onRejected = function(reason) {
-          flash.error(
-            errorMessage(reason), 'Deleting annotation failed');
+        var onRejected = function(err) {
+          flash.error(err.message, 'Deleting annotation failed');
         };
         $scope.$apply(function() {
           annotationMapper.deleteAnnotation(vm.annotation).then(function(){
@@ -429,11 +406,10 @@ function AnnotationController(
       drafts.remove(vm.annotation);
 
       $rootScope.$broadcast(event, updatedModel);
-    }).catch(function (reason) {
+    }).catch(function (err) {
       vm.isSaving = false;
       vm.edit();
-      flash.error(
-        errorMessage(reason), 'Saving annotation failed');
+      flash.error(err.message, 'Saving annotation failed');
     });
   };
 

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -653,31 +653,11 @@ describe('annotation', function() {
         }
       );
 
-      it(
-        'flashes a generic error if the server cannot be reached',
-        function(done) {
-          var controller = createDirective().controller;
-          sandbox.stub($window, 'confirm').returns(true);
-          fakeAnnotationMapper.deleteAnnotation.returns($q.reject({
-            status: 0,
-          }));
-          controller.delete().then(function() {
-            assert.calledWith(fakeFlash.error,
-              'Service unreachable.', 'Deleting annotation failed');
-            done();
-          });
-          $timeout.flush();
-        }
-      );
-
       it('flashes an error if the delete fails on the server', function(done) {
         var controller = createDirective().controller;
         sandbox.stub($window, 'confirm').returns(true);
-        fakeAnnotationMapper.deleteAnnotation.returns($q.reject({
-          status: 500,
-          statusText: 'Server Error',
-          data: {},
-        }));
+        var err = new Error('500 Server Error');
+        fakeAnnotationMapper.deleteAnnotation.returns($q.reject(err));
         controller.delete().then(function() {
           assert.calledWith(fakeFlash.error,
             '500 Server Error', 'Deleting annotation failed');
@@ -717,10 +697,8 @@ describe('annotation', function() {
 
       it('flashes an error if the flag fails', function(done) {
         var controller = createDirective().controller;
-        fakeAnnotationMapper.flagAnnotation.returns(Promise.reject({
-          status: 500,
-          statusText: 'Server error',
-        }));
+        var err = new Error('500 Server error');
+        fakeAnnotationMapper.flagAnnotation.returns(Promise.reject(err));
         controller.flag();
         setTimeout(function () {
           assert.calledWith(fakeFlash.error, '500 Server error', 'Flagging annotation failed');
@@ -814,24 +792,10 @@ describe('annotation', function() {
         });
       });
 
-      it('flashes a generic error if the server can\'t be reached', function() {
-        var controller = createController();
-        fakeStore.annotation.create = sinon.stub().returns(Promise.reject({
-          status: 0,
-        }));
-        return controller.save().then(function() {
-          assert.calledWith(fakeFlash.error,
-            'Service unreachable.', 'Saving annotation failed');
-        });
-      });
-
       it('flashes an error if saving the annotation fails on the server', function() {
         var controller = createController();
-        fakeStore.annotation.create = sinon.stub().returns(Promise.reject({
-          status: 500,
-          statusText: 'Server Error',
-          data: {},
-        }));
+        var err = new Error('500 Server Error');
+        fakeStore.annotation.create = sinon.stub().returns(Promise.reject(err));
         return controller.save().then(function() {
           assert.calledWith(fakeFlash.error,
             '500 Server Error', 'Saving annotation failed');
@@ -888,24 +852,10 @@ describe('annotation', function() {
         return createDirective(annotation).controller;
       }
 
-      it('flashes a generic error if the server cannot be reached', function () {
-        var controller = createController();
-        fakeStore.annotation.update = sinon.stub().returns(Promise.reject({
-          status: -1,
-        }));
-        return controller.save().then(function() {
-          assert.calledWith(fakeFlash.error,
-            'Service unreachable.', 'Saving annotation failed');
-        });
-      });
-
       it('flashes an error if saving the annotation fails on the server', function () {
         var controller = createController();
-        fakeStore.annotation.update = sinon.stub().returns(Promise.reject({
-          status: 500,
-          statusText: 'Server Error',
-          data: {},
-        }));
+        var err = new Error('500 Server Error');
+        fakeStore.annotation.update = sinon.stub().returns(Promise.reject(err));
         return controller.save().then(function() {
           assert.calledWith(fakeFlash.error,
             '500 Server Error', 'Saving annotation failed');


### PR DESCRIPTION
Previously failed API calls from the `store` module were rejected with a
`{ status, statusText, data, headers }` response object.

This had several problems:

 * This violated the convention that promises should be rejected with
   Error or Error-like objects, so callers could not rely on the result
   having a `message` property.

 * It was up to each of the callers to translate the result into
   a message suitable for display, which is likely to lead to
   inconsistency.

 * Testing the translation of different kinds of failures into
   messages was mixed up in the `<annotation>` component tests.

This commit moves the translation of $http responses to `Error` objects
into the API client (`store`) module and adds tests.