### PR TITLE
Fix inconsistent component exports

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -129,7 +129,7 @@ module.exports = angular.module('h', [
   .component('hypothesisApp', require('./components/hypothesis-app'))
 
   // UI components
-  .component('annotation', require('./components/annotation').component)
+  .component('annotation', require('./components/annotation'))
   .component('annotationShareDialog', require('./components/annotation-share-dialog'))
   .component('annotationThread', require('./components/annotation-thread'))
   .component('annotationViewerContent', require('./components/annotation-viewer-content'))
@@ -140,7 +140,7 @@ module.exports = angular.module('h', [
   .component('helpPanel', require('./components/help-panel'))
   .component('loggedoutMessage', require('./components/loggedout-message'))
   .component('loginControl', require('./components/login-control'))
-  .component('loginForm', require('./components/login-form').component)
+  .component('loginForm', require('./components/login-form'))
   .component('markdown', require('./components/markdown'))
   .component('moderationBanner', require('./components/moderation-banner'))
   .component('publishAnnotationBtn', require('./components/publish-annotation-btn'))
@@ -148,7 +148,7 @@ module.exports = angular.module('h', [
   .component('searchStatusBar', require('./components/search-status-bar'))
   .component('selectionTabs', require('./components/selection-tabs'))
   .component('sidebarContent', require('./components/sidebar-content'))
-  .component('sidebarTutorial', require('./components/sidebar-tutorial').component)
+  .component('sidebarTutorial', require('./components/sidebar-tutorial'))
   .component('shareDialog', require('./components/share-dialog'))
   .component('sortDropdown', require('./components/sort-dropdown'))
   .component('streamContent', require('./components/stream-content'))

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -573,7 +573,7 @@ function AnnotationController(
   init();
 }
 
-var component = {
+module.exports = {
   controller: AnnotationController,
   controllerAs: 'vm',
   bindings: {
@@ -584,17 +584,7 @@ var component = {
     isCollapsed: '<',
   },
   template: require('../templates/annotation.html'),
-};
 
-module.exports = {
-  // These private helper functions aren't meant to be part of the public
-  // interface of this module. They've been exported temporarily to enable them
-  // to be unit tested.
-  // FIXME: The code should be refactored to enable unit testing without having
-  // to do this.
+  // Private helper exposed for use in unit tests.
   updateModel: updateModel,
-
-  // These are meant to be the public API of this module.
-  component: component,
-  Controller: AnnotationController,
 };

--- a/src/sidebar/components/login-form.js
+++ b/src/sidebar/components/login-form.js
@@ -96,16 +96,11 @@ function Controller($scope, $timeout, analytics, flash, session, formRespond, se
   });
 }
 
-var component = {
+module.exports = {
   controller: Controller,
   controllerAs: 'vm',
   bindings: {
     onClose: '&',
   },
   template: require('../templates/login_form.html'),
-};
-
-module.exports = {
-  component: component,
-  Controller: Controller,
 };

--- a/src/sidebar/components/sidebar-tutorial.js
+++ b/src/sidebar/components/sidebar-tutorial.js
@@ -22,11 +22,8 @@ function SidebarTutorialController(session) {
  */
 // @ngInject
 module.exports = {
-  component: {
-    controller: SidebarTutorialController,
-    controllerAs: 'vm',
-    bindings: {},
-    template: require('../templates/sidebar_tutorial.html'),
-  },
-  Controller: SidebarTutorialController,
+  controller: SidebarTutorialController,
+  controllerAs: 'vm',
+  bindings: {},
+  template: require('../templates/sidebar_tutorial.html'),
 };

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -1,4 +1,3 @@
-/* jshint node: true */
 'use strict';
 
 var angular = require('angular');
@@ -23,7 +22,7 @@ var fakeDocumentMeta = {
 function annotationComponent() {
   var noop = function () { return ''; };
 
-  var annotation = proxyquire('../annotation', {
+  return proxyquire('../annotation', {
     angular: testUtil.noCallThru(angular),
     '../filter/persona': {
       username: noop,
@@ -34,8 +33,6 @@ function annotationComponent() {
       },
     },
   });
-
-  return annotation.component;
 }
 
 describe('annotation', function() {

--- a/src/sidebar/components/test/login-form-test.coffee
+++ b/src/sidebar/components/test/login-form-test.coffee
@@ -31,7 +31,7 @@ describe 'loginForm.Controller', ->
 
   before ->
     angular.module('h', [])
-    .controller('loginFormController', require('../login-form').Controller)
+    .controller('loginFormController', require('../login-form').controller)
 
   beforeEach module('h')
 

--- a/src/sidebar/components/test/sidebar-tutorial-test.js
+++ b/src/sidebar/components/test/sidebar-tutorial-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Controller = require('../sidebar-tutorial').Controller;
+var Controller = require('../sidebar-tutorial').controller;
 
 describe('SidebarTutorialController', function () {
 


### PR DESCRIPTION
This fixes a small inconsistency in that most component modules exported
the object defining the component directly, whereas others exported an
object with the component as a property. There is no good reason to do
the latter.