### PR TITLE
Work around `getComputedStyle` bug in Firefox

### DIFF
--- a/src/sidebar/components/test/thread-list-test.js
+++ b/src/sidebar/components/test/thread-list-test.js
@@ -82,7 +82,7 @@ describe('threadList', function () {
     // Create a scrollable container for the `<thread-list>` so that scrolling
     // can be tested.
     var parentEl = document.createElement('div');
-    parentEl.classList.add('js-scrollable');
+    parentEl.classList.add('js-thread-list-scroll-root');
     parentEl.style.overflow = 'scroll';
     parentEl.style.height = '100px';
 
@@ -213,15 +213,9 @@ describe('threadList', function () {
       sinon.match(annotFixtures.annotation));
   });
 
-  // See https://github.com/hypothesis/client/issues/341
-  it('finds correct scroll root if `window.getComputedStyle` fails', function () {
-    sinon.stub(window, 'getComputedStyle').returns(null);
-    var element = createThreadList();
-    element.scope.$digest();
-
+  it('uses the correct scroll root', function () {
+    createThreadList();
     var scrollRoot = fakeVirtualThread.options.scrollRoot;
-    assert.isTrue(scrollRoot.classList.contains('js-scrollable'));
-
-    window.getComputedStyle.restore();
+    assert.isTrue(scrollRoot.classList.contains('js-thread-list-scroll-root'));
   });
 });

--- a/src/sidebar/components/test/thread-list-test.js
+++ b/src/sidebar/components/test/thread-list-test.js
@@ -42,12 +42,13 @@ var threadFixtures = immutable({
 
 var fakeVirtualThread;
 
-function FakeVirtualThreadList($scope, $window, rootThread) {
+function FakeVirtualThreadList($scope, $window, rootThread, options) {
 
   fakeVirtualThread = this; // eslint-disable-line consistent-this
 
   var thread = rootThread;
 
+  this.options = options;
   this.setRootThread = function (_thread) {
     thread = _thread;
   };
@@ -81,6 +82,7 @@ describe('threadList', function () {
     // Create a scrollable container for the `<thread-list>` so that scrolling
     // can be tested.
     var parentEl = document.createElement('div');
+    parentEl.classList.add('js-scrollable');
     parentEl.style.overflow = 'scroll';
     parentEl.style.height = '100px';
 
@@ -209,5 +211,17 @@ describe('threadList', function () {
     util.sendEvent(annotation, 'click');
     assert.calledWithMatch(inputs.onSelect.callback,
       sinon.match(annotFixtures.annotation));
+  });
+
+  // See https://github.com/hypothesis/client/issues/341
+  it('finds correct scroll root if `window.getComputedStyle` fails', function () {
+    sinon.stub(window, 'getComputedStyle').returns(null);
+    var element = createThreadList();
+    element.scope.$digest();
+
+    var scrollRoot = fakeVirtualThread.options.scrollRoot;
+    assert.isTrue(scrollRoot.classList.contains('js-scrollable'));
+
+    window.getComputedStyle.restore();
   });
 });

--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -44,6 +44,23 @@ var virtualThreadOptions = {
 };
 
 /**
+ * Return true if the given element is scrollable.
+ */
+function isScrollable(el) {
+  // Check the computed style to see if this element is marked as scrollable.
+  var computedStyle = window.getComputedStyle(el);
+  if (computedStyle !== null && computedStyle.overflowY === 'scroll') {
+    return true;
+  }
+  // In Firefox, `getComputedStyle` may return `null` if `window` is inside a
+  // non-rendered (`display:none`) iframe. In this case, fall back to requiring
+  // the developer to annotate the element with a special class.
+  // See https://bugzilla.mozilla.org/show_bug.cgi?id=548397 and
+  // https://github.com/w3c/csswg-drafts/issues/572
+  return el.classList.contains('js-scrollable');
+}
+
+/**
  * Return the closest ancestor of `el` which is scrollable.
  *
  * @param {Element} el
@@ -51,8 +68,7 @@ var virtualThreadOptions = {
 function closestScrollableAncestor(el) {
   var parentEl = el;
   while (parentEl !== document.body) {
-    var computedStyle = window.getComputedStyle(parentEl);
-    if (computedStyle.overflowY === 'scroll') {
+    if (isScrollable(parentEl)) {
       return parentEl;
     }
     parentEl = parentEl.parentElement;

--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -43,39 +43,6 @@ var virtualThreadOptions = {
   },
 };
 
-/**
- * Return true if the given element is scrollable.
- */
-function isScrollable(el) {
-  // Check the computed style to see if this element is marked as scrollable.
-  var computedStyle = window.getComputedStyle(el);
-  if (computedStyle !== null && computedStyle.overflowY === 'scroll') {
-    return true;
-  }
-  // In Firefox, `getComputedStyle` may return `null` if `window` is inside a
-  // non-rendered (`display:none`) iframe. In this case, fall back to requiring
-  // the developer to annotate the element with a special class.
-  // See https://bugzilla.mozilla.org/show_bug.cgi?id=548397 and
-  // https://github.com/w3c/csswg-drafts/issues/572
-  return el.classList.contains('js-scrollable');
-}
-
-/**
- * Return the closest ancestor of `el` which is scrollable.
- *
- * @param {Element} el
- */
-function closestScrollableAncestor(el) {
-  var parentEl = el;
-  while (parentEl !== document.body) {
-    if (isScrollable(parentEl)) {
-      return parentEl;
-    }
-    parentEl = parentEl.parentElement;
-  }
-  return parentEl;
-}
-
 // @ngInject
 function ThreadListController($element, $scope, VirtualThreadList) {
   // `visibleThreads` keeps track of the subset of all threads matching the
@@ -86,7 +53,12 @@ function ThreadListController($element, $scope, VirtualThreadList) {
 
   // `scrollRoot` is the `Element` to scroll when scrolling a given thread into
   // view.
-  this.scrollRoot = closestScrollableAncestor($element[0]);
+  //
+  // For now there is only one `<thread-list>` instance in the whole
+  // application so we simply require the scroll root to be annotated with a
+  // specific class. A more generic mechanism was removed due to issues in
+  // Firefox. See https://github.com/hypothesis/client/issues/341
+  this.scrollRoot = document.querySelector('.js-thread-list-scroll-root');
 
   var options = Object.assign({
     scrollRoot: this.scrollRoot,

--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -11,7 +11,7 @@ var scopeTimeout = require('../util/scope-timeout');
 
 /**
  * Returns the height of the thread for an annotation if it exists in the view
- * or undefined otherwise.
+ * or `null` otherwise.
  */
 function getThreadHeight(id) {
   var threadElement = document.getElementById(id);
@@ -19,11 +19,16 @@ function getThreadHeight(id) {
     return null;
   }
 
+  // Note: `getComputedStyle` may return `null` in Firefox if the iframe is
+  // hidden. See https://bugzilla.mozilla.org/show_bug.cgi?id=548397
+  var style = window.getComputedStyle(threadElement);
+  if (!style) {
+    return null;
+  }
+
   // Get the height of the element inside the border-box, excluding
   // top and bottom margins.
   var elementHeight = threadElement.getBoundingClientRect().height;
-
-  var style = window.getComputedStyle(threadElement);
 
   // Get the bottom margin of the element. style.margin{Side} will return
   // values of the form 'Npx', from which we extract 'N'.

--- a/src/sidebar/templates/hypothesis_app.html
+++ b/src/sidebar/templates/hypothesis_app.html
@@ -1,4 +1,4 @@
-<div class="app-content-wrapper" h-branding="appBackgroundColor">
+<div class="app-content-wrapper js-scrollable" h-branding="appBackgroundColor">
   <top-bar
     auth="vm.auth"
     on-login="vm.login()"

--- a/src/sidebar/templates/hypothesis_app.html
+++ b/src/sidebar/templates/hypothesis_app.html
@@ -1,4 +1,4 @@
-<div class="app-content-wrapper js-scrollable" h-branding="appBackgroundColor">
+<div class="app-content-wrapper js-thread-list-scroll-root" h-branding="appBackgroundColor">
   <top-bar
     auth="vm.auth"
     on-login="vm.login()"


### PR DESCRIPTION
`<thread-list>` uses `getComputedStyle` to find the nearest scrollable
ancestor element which it needs to know in order to scroll specific
annotations into view and determine which annotations are visible.

In Firefox `getComputedStyle` may return `null` if the iframe is hidden which may be the case when this code is called in the sidebar.  This is considered a bug upstream. Work around it in the meantime by adding a specific class to the scrollable element and testing for that ~~as a fallback~~ _instead_.

Fixes #341