### PR TITLE
Enable first-party users to flag annotations

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -482,6 +482,13 @@ function AnnotationController(
     return annotationUI.isHiddenByModerator(vm.annotation.id);
   };
 
+  vm.canFlag = function () {
+    if (persona.isThirdPartyUser(vm.annotation.user, settings.authDomain)) {
+      return true;
+    }
+    return features.flagEnabled('flag_action');
+  };
+
   vm.isFlagged = function() {
     return vm.annotation.flagged;
   };

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -1036,5 +1036,12 @@ describe('annotation', function() {
       flagBtn.click();
       assert.called(fakeAnnotationMapper.flagAnnotation);
     });
+
+    it('highlights the "Flag" button if the annotation is flagged', function () {
+      var ann = Object.assign(fixtures.defaultAnnotation(), { flagged: true });
+      var el = createDirective(ann).element;
+      var flaggedBtn = el[0].querySelector('button[aria-label="Annotation has been flagged"]');
+      assert.ok(flaggedBtn);
+    });
   });
 });

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -83,6 +83,7 @@ describe('annotation', function() {
     var fakeAnnotationMapper;
     var fakeAnnotationUI;
     var fakeDrafts;
+    var fakeFeatures;
     var fakeFlash;
     var fakeGroups;
     var fakePermissions;
@@ -155,7 +156,7 @@ describe('annotation', function() {
         get: sandbox.stub(),
       };
 
-      var fakeFeatures = {
+      fakeFeatures = {
         flagEnabled: sandbox.stub().returns(true),
       };
 
@@ -195,7 +196,8 @@ describe('annotation', function() {
       };
 
       fakeSettings = {
-        authDomain: 'example.com',
+        // "localhost" is the host used by 'first party' annotation fixtures
+        authDomain: 'localhost',
       };
 
       fakeStore = {
@@ -764,6 +766,24 @@ describe('annotation', function() {
       });
     });
 
+    describe('#canFlag', function () {
+      it('returns true if the user is a third-party user', function () {
+        var ann = fixtures.thirdPartyAnnotation();
+        var controller = createDirective(ann).controller;
+        assert.isTrue(controller.canFlag());
+      });
+
+      it('returns the value of the `flag_action` feature flag', function () {
+        var controller = createDirective().controller;
+
+        fakeFeatures.flagEnabled.returns(false);
+        assert.equal(controller.canFlag(), false);
+
+        fakeFeatures.flagEnabled.returns(true);
+        assert.equal(controller.canFlag(), true);
+      });
+    });
+
     describe('saving a new annotation', function() {
       var annotation;
 
@@ -1007,6 +1027,14 @@ describe('annotation', function() {
           'annotation-body is-hidden': true,
         },
       });
+    });
+
+    it('flags the annotation when the user clicks the "Flag" button', function () {
+      fakeAnnotationMapper.flagAnnotation.returns(Promise.resolve());
+      var el = createDirective().element;
+      var flagBtn = el[0].querySelector('button[aria-label="Flag"]');
+      flagBtn.click();
+      assert.called(fakeAnnotationMapper.flagAnnotation);
     });
   });
 });

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -188,7 +188,7 @@
           on-close="vm.showShareDialog = false">
         </annotation-share-dialog>
       </span>
-      <span ng-if="vm.isThirdPartyUser()">
+      <span ng-if="vm.canFlag()">
         <button class="btn btn-clean annotation-action-btn"
           ng-if="!vm.isFlagged()"
           ng-click="vm.flag()"

--- a/src/sidebar/test/annotation-fixtures.js
+++ b/src/sidebar/test/annotation-fixtures.js
@@ -17,6 +17,15 @@ function defaultAnnotation() {
 }
 
 /**
+ * Return a fake annotation created by a third-party user.
+ */
+function thirdPartyAnnotation() {
+  return Object.assign(defaultAnnotation(), {
+    user: 'acct:ben@publisher.org',
+  });
+}
+
+/**
  * Return a fake public annotation with the basic properties filled in.
  */
 function publicAnnotation() {
@@ -148,4 +157,5 @@ module.exports = {
   oldHighlight: oldHighlight,
   oldPageNote: oldPageNote,
   oldReply: oldReply,
+  thirdPartyAnnotation: thirdPartyAnnotation,
 };


### PR DESCRIPTION
Enable first-party users to flag annotations if the `flag_action` feature flag is enabled for them.

I've also added a missing test to check that the state of the Flag button reflects whether the annotation is flagged or not and that clicking the button flags it if not.