### PR TITLE
[WIP] Initial support for multiple documents

### DIFF
--- a/src/annotator/annotation-sync.coffee
+++ b/src/annotator/annotation-sync.coffee
@@ -29,6 +29,17 @@ module.exports = class AnnotationSync
     for method, func of @_channelListeners
       @bridge.on(method, func.bind(this))
 
+  # THESIS TODO: Add support for multiple @_on and @_emit
+  registerMethods: (options, guestId) ->
+    @_on = options.on
+    @_emit = options.emit
+
+    for event, handler of @_eventListeners
+      this._on(event, handler.bind(this))
+
+    for method, func of @_channelListeners
+      @bridge.on(method, func.bind(this), guestId)
+
   sync: (annotations) ->
     annotations = (this._format a for a in annotations)
     @bridge.call 'sync', annotations, (err, annotations = []) =>

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -55,19 +55,21 @@ module.exports = class Guest extends Annotator
     adder: '<hypothesis-adder></hypothesis-adder>';
 
   constructor: (element, options) ->
+    this.document = options.document || document
+    element = this.document.body
     super
 
     self = this
     this.adderCtrl = new adder.Adder(@adder[0], {
       onAnnotate: ->
         self.createAnnotation()
-        Annotator.Util.getGlobal().getSelection().removeAllRanges()
+        self.document.getSelection().removeAllRanges()
       onHighlight: ->
         self.setVisibleHighlights(true)
         self.createHighlight()
-        Annotator.Util.getGlobal().getSelection().removeAllRanges()
+        self.document.getSelection().removeAllRanges()
     })
-    this.selections = selections(document).subscribe
+    this.selections = selections(this.document).subscribe
       next: (range) ->
         if range
           self._onSelection(range)
@@ -365,7 +367,7 @@ module.exports = class Guest extends Annotator
     @crossframe?.call('focusAnnotations', tags)
 
   _onSelection: (range) ->
-    selection = Annotator.Util.getGlobal().getSelection()
+    selection = this.document.getSelection()
     isBackwards = rangeUtil.isSelectionBackwards(selection)
     focusRect = rangeUtil.selectionFocusRect(selection)
     if !focusRect

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -64,8 +64,9 @@ module.exports = class Guest extends Annotator
     self = this
     @guestDocument = element.ownerDocument
     @guestId = options.guestId || "default"
-    # THESIS TODO: Consider using a trigger instead, via crossframe
-    @showSidebarCb = options.showSidebarCb
+    # THESIS TODO: With great power, comes great responsibility.
+    # This may be too much power... have a discussion about it.
+    @hostCallback = options.hostCallback
 
     this.selections = selections(@guestDocument).subscribe
       next: (range) ->
@@ -275,6 +276,9 @@ module.exports = class Guest extends Annotator
       # Add the anchors for this annotation to instance storage.
       self.anchors = self.anchors.concat(anchors)
 
+      # Tell the host about the new information
+      self.hostCallback('updateAnchors')
+
       # Let plugins know about the new information.
       self.plugins.BucketBar?.update()
       self.plugins.CrossFrame?.sync([annotation])
@@ -332,7 +336,7 @@ module.exports = class Guest extends Annotator
 
     ranges = @selectedRanges ? []
     @selectedRanges = null
-    @showSidebarCb() unless annotation.$highlight || !@showSidebarCb
+    @hostCallback('show') unless annotation.$highlight || !@hostCallback
 
     getSelectors = (range) ->
       options = {
@@ -388,7 +392,7 @@ module.exports = class Guest extends Annotator
   showAnnotations: (annotations) ->
     tags = (a.$tag for a in annotations)
     @crossframe?.call('showAnnotations', tags)
-    @showSidebarCb() unless !@showSidebarCb
+    @hostCallback('show') unless !@hostCallback
 
   toggleAnnotationSelection: (annotations) ->
     tags = (a.$tag for a in annotations)

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -67,15 +67,6 @@ module.exports = class Guest extends Annotator
     # THESIS TODO: Consider using a trigger instead, via crossframe
     @showSidebarCb = options.showSidebarCb
 
-    this.adderCtrl = new adder.Adder(@adder[0], {
-      onAnnotate: ->
-        self.createAnnotation()
-        self.guestDocument.getSelection().removeAllRanges()
-      onHighlight: ->
-        self.setVisibleHighlights(true)
-        self.createHighlight()
-        self.guestDocument.getSelection().removeAllRanges()
-    })
     this.selections = selections(@guestDocument).subscribe
       next: (range) ->
         if range
@@ -399,6 +390,15 @@ module.exports = class Guest extends Annotator
     tags = (a.$tag for a in annotations)
     @crossframe?.call('focusAnnotations', tags)
 
+  _onAnnotate: ->
+    @createAnnotation()
+    @guestDocument.getSelection().removeAllRanges()
+
+  _onHighlight: ->
+    @setVisibleHighlights(true)
+    @createHighlight()
+    @guestDocument.getSelection().removeAllRanges()
+
   _onSelection: (range) ->
     selection = @guestDocument.getSelection()
     isBackwards = rangeUtil.isSelectionBackwards(selection)
@@ -415,7 +415,13 @@ module.exports = class Guest extends Annotator
       .removeClass('h-icon-note')
       .addClass('h-icon-annotate');
 
+    this.adderCtrl.setCommands({
+      "onAnnotate": @_onAnnotate.bind(this),
+      "onHighlight": @_onHighlight.bind(this)
+    })
+    this.adderCtrl.setGuestElement(@guestDocument.body)
     {left, top, arrowDirection} = this.adderCtrl.target(focusRect, isBackwards)
+
     this.adderCtrl.showAt(left, top, arrowDirection)
 
   _onClearSelection: () ->

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -382,6 +382,9 @@ module.exports = class Guest extends Annotator
 
     annotation
 
+  hasSelection: ->
+    return if @selectedRanges then @selectedRanges[0] != undefined else false
+
   showAnnotations: (annotations) ->
     tags = (a.$tag for a in annotations)
     @crossframe?.call('showAnnotations', tags)

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -50,24 +50,28 @@ module.exports = class Guest extends Annotator
   # Internal state
   anchors: null
   visibleHighlights: false
+  guestDocument: null
 
   html: extend {}, Annotator::html,
     adder: '<hypothesis-adder></hypothesis-adder>';
 
   constructor: (element, options) ->
-    super
+    guestElement = options.guestElement || element
+    super(guestElement, options)
 
     self = this
+    this.guestDocument = guestElement.ownerDocument
+
     this.adderCtrl = new adder.Adder(@adder[0], {
       onAnnotate: ->
         self.createAnnotation()
-        Annotator.Util.getGlobal().getSelection().removeAllRanges()
+        self.guestDocument.getSelection().removeAllRanges()
       onHighlight: ->
         self.setVisibleHighlights(true)
         self.createHighlight()
-        Annotator.Util.getGlobal().getSelection().removeAllRanges()
+        self.guestDocument.getSelection().removeAllRanges()
     })
-    this.selections = selections(document).subscribe
+    this.selections = selections(@guestDocument).subscribe
       next: (range) ->
         if range
           self._onSelection(range)
@@ -365,7 +369,7 @@ module.exports = class Guest extends Annotator
     @crossframe?.call('focusAnnotations', tags)
 
   _onSelection: (range) ->
-    selection = Annotator.Util.getGlobal().getSelection()
+    selection = @guestDocument.getSelection()
     isBackwards = rangeUtil.isSelectionBackwards(selection)
     focusRect = rangeUtil.selectionFocusRect(selection)
     if !focusRect

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -75,28 +75,23 @@ module.exports = class Guest extends Annotator
           self._onClearSelection()
 
     @anchors = []
-    @plugins = options.hostPlugins unless !options.hostPlugins
 
     # If options.crossframe is set, it is assumed that this is NOT the default guest, and
     # so a crossframe needs to be set
     if (options.crossframe)
-      @_setCrossframe(options.crossframe)
+      @setCrossframe(options.crossframe)
       @setVisibleHighlights(options.showHighlights)
       @adderCtrl = options.adderCtrl
     else # Otherwise, the crossframe and plugins have to be initialized
       @_setupDefaultGuest()
 
-  _setupDefaultGuest: ->
-    @_setCrossframe()
+  getAdder: ->
+    return @adderCtrl
 
-    for own name, opts of @options
-      if not @plugins[name] and Annotator.Plugin[name]
-        @addPlugin(name, opts)
+  getCrossframe: ->
+    return @crossframe
 
-    @crossframe.onConnect(=> @publish('panelReady'))
-    @adderCtrl = new adder.Adder(@adder[0])
-
-  _setCrossframe: (crossframe) ->
+  setCrossframe: (crossframe) ->
     cfOptions =
       on: (event, handler) =>
         @subscribe(event, handler)
@@ -113,6 +108,14 @@ module.exports = class Guest extends Annotator
 
     @_connectAnnotationSync(@crossframe)
     @_connectAnnotationUISync(@crossframe, @guestId)
+
+  setPlugins: ( plugins ) ->
+    @plugins = plugins
+
+    # Add any other plugins we need
+    for own name, opts of @options
+      if not @plugins[name] and Annotator.Plugin[name]
+        @addPlugin(name, opts)
 
   # Get the document info
   getDocumentInfo: ->
@@ -165,6 +168,12 @@ module.exports = class Guest extends Annotator
     crossframe.on 'setVisibleHighlights', (state) =>
       this.setVisibleHighlights(state)
     , guestId
+
+  _setupDefaultGuest: ->
+    @setCrossframe()
+
+    @crossframe.onConnect(=> @publish('panelReady'))
+    @adderCtrl = new adder.Adder(@adder[0])
 
   _setupWrapper: ->
     @wrapper = @element

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -55,21 +55,19 @@ module.exports = class Guest extends Annotator
     adder: '<hypothesis-adder></hypothesis-adder>';
 
   constructor: (element, options) ->
-    this.document = options.document || document
-    element = this.document.body
     super
 
     self = this
     this.adderCtrl = new adder.Adder(@adder[0], {
       onAnnotate: ->
         self.createAnnotation()
-        self.document.getSelection().removeAllRanges()
+        Annotator.Util.getGlobal().getSelection().removeAllRanges()
       onHighlight: ->
         self.setVisibleHighlights(true)
         self.createHighlight()
-        self.document.getSelection().removeAllRanges()
+        Annotator.Util.getGlobal().getSelection().removeAllRanges()
     })
-    this.selections = selections(this.document).subscribe
+    this.selections = selections(document).subscribe
       next: (range) ->
         if range
           self._onSelection(range)
@@ -367,7 +365,7 @@ module.exports = class Guest extends Annotator
     @crossframe?.call('focusAnnotations', tags)
 
   _onSelection: (range) ->
-    selection = this.document.getSelection()
+    selection = Annotator.Util.getGlobal().getSelection()
     isBackwards = rangeUtil.isSelectionBackwards(selection)
     focusRect = rangeUtil.selectionFocusRect(selection)
     if !focusRect

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -99,7 +99,7 @@ module.exports = class Guest extends Annotator
         @publish(event, args)
 
     if (crossframe)
-      @crossframe = @options.crossframe
+      @crossframe = crossframe
       @crossframe.reloadAnnotations()
       @crossframe.registerMethods(cfOptions, this.guestId)
     else

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -39,9 +39,10 @@ module.exports = class Host extends Annotator
         @addPlugin(name, opts)
 
     guest = @addGuest(element, "default", options)
-    # @plugins gets passed into the guest, and so crossframe is directly added to the @plugins object
-    @crossframe = @plugins.CrossFrame
-    @adderCtrl = guest.adderCtrl
+    @crossframe = guest.getCrossframe()
+    @adderCtrl = guest.getAdder()
+    @plugins.CrossFrame = @crossframe
+    guest.setPlugins( @plugins )
 
     app.appendTo(@frame)
 
@@ -66,9 +67,8 @@ module.exports = class Host extends Annotator
   addGuest: (guestElement, guestId, guestOptions) ->
     options = guestOptions
     options.guestId = guestId
-    options.crossframe = @crossframe
-    options.hostPlugins = @plugins
-    options.adderCtrl = @adderCtrl
+    if @crossframe then options.crossframe = @crossframe
+    if @adderCtrl then options.adderCtrl = @adderCtrl
     guest = new Guest(guestElement, options)
 
     @guests[guestId] = guest

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -41,6 +41,7 @@ module.exports = class Host extends Annotator
     guest = @addGuest(element, "default", options)
     # @plugins gets passed into the guest, and so crossframe is directly added to the @plugins object
     @crossframe = @plugins.CrossFrame
+    @adderCtrl = guest.adderCtrl
 
     app.appendTo(@frame)
 
@@ -67,6 +68,7 @@ module.exports = class Host extends Annotator
     options.guestId = guestId
     options.crossframe = @crossframe
     options.hostPlugins = @plugins
+    options.adderCtrl = @adderCtrl
     guest = new Guest(guestElement, options)
 
     @guests[guestId] = guest

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -70,6 +70,7 @@ module.exports = class Host extends Annotator
     if @crossframe then options.crossframe = @crossframe
     if @adderCtrl then options.adderCtrl = @adderCtrl
     guest = new Guest(guestElement, options)
+    guest.setPlugins( @plugins )
 
     @guests[guestId] = guest
     return guest

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -74,6 +74,7 @@ module.exports = class Host extends Annotator
     options = @options
     options.guestId = guestId
     options.crossframe = @crossframe
+    options.plugins = @plugins
     guest = new Guest(guestElement, options)
     guest.setVisibleHighlights(@showHighlights)
 

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -67,6 +67,7 @@ module.exports = class Host extends Annotator
   addGuest: (guestElement, guestId, guestOptions) ->
     options = guestOptions
     options.guestId = guestId
+    options.hostCallback = @_hostCallback.bind(this)
     if @crossframe then options.crossframe = @crossframe
     if @adderCtrl then options.adderCtrl = @adderCtrl
     guest = new Guest(guestElement, options)
@@ -100,8 +101,31 @@ module.exports = class Host extends Annotator
     @guests[guestId].destroy()
     delete @guests[guestId]
 
+  getAnchors: ->
+    anchors = []
+    for guestId, guest of @guests
+      anchors = anchors.concat(guest.anchors)
+
+    return anchors
+
+  # THESIS TODO: Investigate how to deal with annotations from multiple guests
+  selectAnnotations: (annotations) ->
+    # guestId = annotations[0].guestId
+    guestId = "default"
+    @guests[guestId].selectAnnotations(annotations)
+
   setVisibleHighlights: (state) ->
     @visibleHighlights = state
 
     for guestId, guest of @guests
       guest.setVisibleHighlights(state)
+
+  # THESIS TODO: Investigate if there are any performance concerns.
+  # This gets called every time a guest updates its anchors object
+  # getAnchors loops through all guests each time
+  updateAnchors: ->
+    @anchors = @getAnchors()
+
+  _hostCallback: (functionName, args...) ->
+    this[functionName].apply(this, args)
+

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -75,6 +75,19 @@ module.exports = class Host extends Annotator
     @guests[guestId] = guest
     return guest
 
+  createAnnotation: ->
+    foundSelected = false
+    # Iterate through the guests, and check if any of them have a selection
+    # If so, then create an annotation with said guest
+    for guestId, guest of @guests
+      if guest.hasSelection()
+        guest.createAnnotation()
+        foundSelected = true
+        return
+
+    # If none of the guests have a selection, then we want to make a page note
+    if !foundSelected then @guests["default"].createAnnotation()
+
   destroy: ->
     @frame.remove()
     @destroyAllGuests()
@@ -86,3 +99,9 @@ module.exports = class Host extends Annotator
   destroyGuest: (guestId) ->
     @guests[guestId].destroy()
     delete @guests[guestId]
+
+  setVisibleHighlights: (state) ->
+    @visibleHighlights = state
+
+    for guestId, guest of @guests
+      guest.setVisibleHighlights(state)

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -36,7 +36,7 @@ module.exports = class Host extends Annotator
 
     for own name, opts of @options
       if not @plugins[name] and Annotator.Plugin[name]
-        this.addPlugin(name, opts)
+        @addPlugin(name, opts)
 
     guest = @addGuest(element, "default", options)
     # @plugins gets passed into the guest, and so crossframe is directly added to the @plugins object
@@ -69,7 +69,7 @@ module.exports = class Host extends Annotator
     options.hostPlugins = @plugins
     guest = new Guest(guestElement, options)
 
-    this.guests[guestId] = guest
+    @guests[guestId] = guest
     return guest
 
   destroy: ->

--- a/src/annotator/main.js
+++ b/src/annotator/main.js
@@ -51,10 +51,17 @@ Annotator.noConflict().$.noConflict(true)(function() {
     delete options.constructor;
   }
 
-  window.annotator = new Klass(document.body, options);
-  appLinkEl.addEventListener('destroy', function () {
-    appLinkEl.parentElement.removeChild(appLinkEl);
-    window.annotator.destroy();
-    window.annotator = undefined;
+  // Testing only
+  ReadiumSDK.once(ReadiumSDK.Events.READER_INITIALIZED, function(readium) {
+    readium.once(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, function($iframe, spineItem) {
+      var readerDoc = $iframe[0].contentDocument;
+      options.document = readerDoc;
+      window.annotator = new Klass(document.body, options);
+      appLinkEl.addEventListener('destroy', function () {
+          appLinkEl.parentElement.removeChild(appLinkEl);
+          window.annotator.destroy();
+          window.annotator = undefined;
+      });
+    });
   });
 });

--- a/src/annotator/main.js
+++ b/src/annotator/main.js
@@ -51,17 +51,10 @@ Annotator.noConflict().$.noConflict(true)(function() {
     delete options.constructor;
   }
 
-  // Testing only
-  ReadiumSDK.once(ReadiumSDK.Events.READER_INITIALIZED, function(readium) {
-    readium.once(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, function($iframe, spineItem) {
-      var readerDoc = $iframe[0].contentDocument;
-      options.document = readerDoc;
-      window.annotator = new Klass(document.body, options);
-      appLinkEl.addEventListener('destroy', function () {
-          appLinkEl.parentElement.removeChild(appLinkEl);
-          window.annotator.destroy();
-          window.annotator = undefined;
-      });
-    });
+  window.annotator = new Klass(document.body, options);
+  appLinkEl.addEventListener('destroy', function () {
+    appLinkEl.parentElement.removeChild(appLinkEl);
+    window.annotator.destroy();
+    window.annotator = undefined;
   });
 });

--- a/src/annotator/main.js
+++ b/src/annotator/main.js
@@ -23,6 +23,7 @@ Annotator.Guest = require('./guest');
 Annotator.Host = require('./host');
 Annotator.Sidebar = require('./sidebar');
 Annotator.PdfSidebar = require('./pdf-sidebar');
+Annotator.ReadiumSidebar = require('./readium-sidebar');
 
 // UI plugins
 Annotator.Plugin.BucketBar = require('./plugin/bucket-bar');
@@ -30,6 +31,7 @@ Annotator.Plugin.Toolbar = require('./plugin/toolbar');
 
 // Document type plugins
 Annotator.Plugin.PDF = require('./plugin/pdf');
+Annotator.Plugin.Readium = require('./plugin/readium');
 require('./vendor/annotator.document');  // Does not export the plugin :(
 
 // Cross-frame communication
@@ -43,9 +45,13 @@ var appLinkEl =
 var options = require('./config')(window);
 
 Annotator.noConflict().$.noConflict(true)(function() {
-  var Klass = window.PDFViewerApplication ?
-      Annotator.PdfSidebar :
-      Annotator.Sidebar;
+  var Klass = Annotator.Sidebar;
+  if (window.PDFViewerApplication) {
+    Klass = Annotator.PdfSidebar;
+  } else if (window.ReadiumSDK) {
+    Klass = Annotator.ReadiumSidebar;
+  }
+
   if (options.hasOwnProperty('constructor')) {
     Klass = options.constructor;
     delete options.constructor;

--- a/src/annotator/plugin/bucket-bar.coffee
+++ b/src/annotator/plugin/bucket-bar.coffee
@@ -109,23 +109,28 @@ module.exports = class BucketBar extends Annotator.Plugin
     below = []
 
     # Construct indicator points
-    points = @annotator.anchors.reduce (points, anchor, i) =>
-      unless anchor.highlights?.length
-        return points
+    # THESIS TODO: This 'unless' was put in place to prevent an error
+    # At some point, investigate how plguins work, and how to avoid the error
+    unless @annotator.anchors
+      points = []
+    else
+      points = @annotator.anchors.reduce (points, anchor, i) =>
+        unless anchor.highlights?.length
+          return points
 
-      rect = highlighter.getBoundingClientRect(anchor.highlights)
-      x = rect.top
-      h = rect.bottom - rect.top
+        rect = highlighter.getBoundingClientRect(anchor.highlights)
+        x = rect.top
+        h = rect.bottom - rect.top
 
-      if x < BUCKET_TOP_THRESHOLD
-        if anchor not in above then above.push anchor
-      else if x > window.innerHeight - BUCKET_NAV_SIZE
-        if anchor not in below then below.push anchor
-      else
-        points.push [x, 1, anchor]
-        points.push [x + h, -1, anchor]
-      points
-    , []
+        if x < BUCKET_TOP_THRESHOLD
+          if anchor not in above then above.push anchor
+        else if x > window.innerHeight - BUCKET_NAV_SIZE
+          if anchor not in below then below.push anchor
+        else
+          points.push [x, 1, anchor]
+          points.push [x + h, -1, anchor]
+        points
+      , []
 
     # Accumulate the overlapping annotations into buckets.
     # The algorithm goes like this:

--- a/src/annotator/plugin/bucket-bar.coffee
+++ b/src/annotator/plugin/bucket-bar.coffee
@@ -109,28 +109,23 @@ module.exports = class BucketBar extends Annotator.Plugin
     below = []
 
     # Construct indicator points
-    # THESIS TODO: This 'unless' was put in place to prevent an error
-    # At some point, investigate how plguins work, and how to avoid the error
-    unless @annotator.anchors
-      points = []
-    else
-      points = @annotator.anchors.reduce (points, anchor, i) =>
-        unless anchor.highlights?.length
-          return points
+    points = @annotator.anchors.reduce (points, anchor, i) =>
+      unless anchor.highlights?.length
+        return points
 
-        rect = highlighter.getBoundingClientRect(anchor.highlights)
-        x = rect.top
-        h = rect.bottom - rect.top
+      rect = highlighter.getBoundingClientRect(anchor.highlights)
+      x = rect.top
+      h = rect.bottom - rect.top
 
-        if x < BUCKET_TOP_THRESHOLD
-          if anchor not in above then above.push anchor
-        else if x > window.innerHeight - BUCKET_NAV_SIZE
-          if anchor not in below then below.push anchor
-        else
-          points.push [x, 1, anchor]
-          points.push [x + h, -1, anchor]
-        points
-      , []
+      if x < BUCKET_TOP_THRESHOLD
+        if anchor not in above then above.push anchor
+      else if x > window.innerHeight - BUCKET_NAV_SIZE
+        if anchor not in below then below.push anchor
+      else
+        points.push [x, 1, anchor]
+        points.push [x + h, -1, anchor]
+      points
+    , []
 
     # Accumulate the overlapping annotations into buckets.
     # The algorithm goes like this:

--- a/src/annotator/plugin/cross-frame.coffee
+++ b/src/annotator/plugin/cross-frame.coffee
@@ -20,6 +20,9 @@ module.exports = class CrossFrame extends Annotator.Plugin
 
     bridge = new CrossFrame.Bridge()
 
+    # THESIS TODO: Don't forget to remove this. Debugging only.
+    window.bridge = bridge
+
     opts = extract(options, 'on', 'emit')
     @annotationSync = new CrossFrame.AnnotationSync(bridge, opts)
 
@@ -37,6 +40,9 @@ module.exports = class CrossFrame extends Annotator.Plugin
     this.registerMethods = (options, guestId) ->
       @annotationSync.registerMethods(options, guestId)
 
+    this.removeMethods = (guestId) ->
+      @annotationSync.removeMethods(guestId)
+
     this.sync = (annotations, cb) ->
       @annotationSync.sync(annotations, cb)
 
@@ -45,6 +51,10 @@ module.exports = class CrossFrame extends Annotator.Plugin
 
     this.call = (message, args...) ->
       bridge.call(message, args...)
+
+    # THESIS TODO: Temporary name for function. Will need a more suitable name.
+    this.reloadAnnotations = () ->
+      bridge.call("reloadAnnotations");
 
     this.onConnect = (fn) ->
       bridge.onConnect(fn)

--- a/src/annotator/plugin/cross-frame.coffee
+++ b/src/annotator/plugin/cross-frame.coffee
@@ -34,6 +34,9 @@ module.exports = class CrossFrame extends Annotator.Plugin
       bridge.destroy()
       discovery.stopDiscovery()
 
+    this.registerMethods = (options, guestId) ->
+      @annotationSync.registerMethods(options, guestId)
+
     this.sync = (annotations, cb) ->
       @annotationSync.sync(annotations, cb)
 

--- a/src/annotator/plugin/cross-frame.coffee
+++ b/src/annotator/plugin/cross-frame.coffee
@@ -20,9 +20,6 @@ module.exports = class CrossFrame extends Annotator.Plugin
 
     bridge = new CrossFrame.Bridge()
 
-    # THESIS TODO: Don't forget to remove this. Debugging only.
-    window.bridge = bridge
-
     opts = extract(options, 'on', 'emit')
     @annotationSync = new CrossFrame.AnnotationSync(bridge, opts)
 

--- a/src/annotator/plugin/cross-frame.coffee
+++ b/src/annotator/plugin/cross-frame.coffee
@@ -21,7 +21,7 @@ module.exports = class CrossFrame extends Annotator.Plugin
     bridge = new CrossFrame.Bridge()
 
     opts = extract(options, 'on', 'emit')
-    annotationSync = new CrossFrame.AnnotationSync(bridge, opts)
+    @annotationSync = new CrossFrame.AnnotationSync(bridge, opts)
 
     this.pluginInit = ->
       onDiscoveryCallback = (source, origin, token) ->
@@ -35,13 +35,16 @@ module.exports = class CrossFrame extends Annotator.Plugin
       discovery.stopDiscovery()
 
     this.sync = (annotations, cb) ->
-      annotationSync.sync(annotations, cb)
+      @annotationSync.sync(annotations, cb)
 
-    this.on = (event, fn) ->
-      bridge.on(event, fn)
+    this.on = (event, fn, guestId) ->
+      bridge.on(event, fn, guestId)
 
     this.call = (message, args...) ->
       bridge.call(message, args...)
 
     this.onConnect = (fn) ->
       bridge.onConnect(fn)
+
+    this.removeGuestListener = (guestId) ->
+      bridge.removeGuestListener(guestId)

--- a/src/annotator/plugin/readium.coffee
+++ b/src/annotator/plugin/readium.coffee
@@ -1,0 +1,162 @@
+extend = require('extend')
+Annotator = require('annotator')
+
+RenderingStates = require('../pdfjs-rendering-states')
+
+module.exports = class Readium extends Annotator.Plugin
+
+  $ = Annotator.$
+
+  events:
+    'beforeAnnotationCreated': 'beforeAnnotationCreated'
+
+  pluginInit: ->
+    this.getDocumentMetadata()
+
+# returns the primary URI for the document being annotated
+
+  uri: =>
+    uri = decodeURIComponent document.location.href
+    for link in @metadata.link
+      if link.rel == "canonical"
+        uri = link.href
+    return uri
+
+# returns all uris for the document being annotated
+
+  uris: =>
+    uniqueUrls = {}
+    for link in @metadata.link
+      uniqueUrls[link.href] = true if link.href
+    return (href for href of uniqueUrls)
+
+  beforeAnnotationCreated: (annotation) =>
+    annotation.document = @metadata
+
+  getDocumentMetadata: =>
+    @metadata = {}
+
+    # first look for some common metadata types
+    # TODO: look for microdata/rdfa?
+    this._getHighwire()
+    this._getDublinCore()
+    this._getFacebook()
+    this._getEprints()
+    this._getPrism()
+    this._getTwitter()
+    this._getFavicon()
+
+    # extract out/normalize some things
+    this._getTitle()
+    this._getLinks()
+
+    return @metadata
+
+  _getHighwire: =>
+    return @metadata.highwire = this._getMetaTags("citation", "name", "_")
+
+  _getFacebook: =>
+    return @metadata.facebook = this._getMetaTags("og", "property", ":")
+
+  _getTwitter: =>
+    return @metadata.twitter = this._getMetaTags("twitter", "name", ":")
+
+  _getDublinCore: =>
+    return @metadata.dc = this._getMetaTags("dc", "name", ".")
+
+  _getPrism: =>
+    return @metadata.prism = this._getMetaTags("prism", "name", ".")
+
+  _getEprints: =>
+    return @metadata.eprints = this._getMetaTags("eprints", "name", ".")
+
+  _getMetaTags: (prefix, attribute, delimiter) =>
+    tags = {}
+    for meta in $("meta")
+      name = $(meta).attr(attribute)
+      content = $(meta).prop("content")
+      if name
+        match = name.match(RegExp("^#{prefix}#{delimiter}(.+)$", "i"))
+        if match
+          n = match[1]
+          if tags[n]
+            tags[n].push(content)
+          else
+            tags[n] = [content]
+    return tags
+
+  _getTitle: =>
+    if @metadata.highwire.title
+      @metadata.title = @metadata.highwire.title[0]
+    else if @metadata.eprints.title
+      @metadata.title = @metadata.eprints.title[0]
+    else if @metadata.prism.title
+      @metadata.title = @metadata.prism.title[0]
+    else if @metadata.facebook.title
+      @metadata.title = @metadata.facebook.title[0]
+    else if @metadata.twitter.title
+      @metadata.title = @metadata.twitter.title[0]
+    else if @metadata.dc.title
+      @metadata.title = @metadata.dc.title[0]
+    else
+      @metadata.title = $("head title").text()
+
+  _getLinks: =>
+# we know our current location is a link for the document
+    @metadata.link = [href: document.location.href]
+
+    # look for some relevant link relations
+    for link in $("link")
+      l = $(link)
+      href = this._absoluteUrl(l.prop('href')) # get absolute url
+      rel = l.prop('rel')
+      type = l.prop('type')
+      lang = l.prop('hreflang')
+
+      if rel not in ["alternate", "canonical", "bookmark", "shortlink"] then continue
+
+      if rel is 'alternate'
+# Ignore feeds resources
+        if type and type.match /^application\/(rss|atom)\+xml/ then continue
+        # Ignore alternate languages
+        if lang then continue
+
+      @metadata.link.push(href: href, rel: rel, type: type)
+
+    # look for links in scholar metadata
+    for name, values of @metadata.highwire
+
+      if name == "pdf_url"
+        for url in values
+          @metadata.link.push
+            href: this._absoluteUrl(url)
+            type: "application/pdf"
+
+      # kind of a hack to express DOI identifiers as links but it's a
+      # convenient place to look them up later, and somewhat sane since
+      # they don't have a type
+
+      if name == "doi"
+        for doi in values
+          if doi[0..3] != "doi:"
+            doi = "doi:" + doi
+          @metadata.link.push(href: doi)
+
+    # look for links in dublincore data
+    for name, values of @metadata.dc
+      if name == "identifier"
+        for id in values
+          if id[0..3] == "doi:"
+            @metadata.link.push(href: id)
+
+  _getFavicon: =>
+    for link in $("link")
+      if $(link).prop("rel") in ["shortcut icon", "icon"]
+        @metadata["favicon"] = this._absoluteUrl(link.href)
+
+# hack to get a absolute url from a possibly relative one
+
+  _absoluteUrl: (url) ->
+    d = document.createElement('a')
+    d.href = url
+    d.href

--- a/src/annotator/plugin/test/cross-frame-test.coffee
+++ b/src/annotator/plugin/test/cross-frame-test.coffee
@@ -22,11 +22,14 @@ describe 'Annotator.Plugin.CrossFrame', ->
       destroy: sandbox.stub()
       createChannel: sandbox.stub()
       onConnect: sandbox.stub()
+      removeGuestListener: sandbox.stub()
       call: sandbox.stub()
       on: sandbox.stub()
 
     fakeAnnotationSync =
       sync: sandbox.stub()
+      registerMethods: sandbox.stub()
+      removeMethods: sandbox.stub()
 
     CrossFrame.AnnotationSync = sandbox.stub().returns(fakeAnnotationSync)
     CrossFrame.Discovery = sandbox.stub().returns(fakeDiscovery)
@@ -82,6 +85,25 @@ describe 'Annotator.Plugin.CrossFrame', ->
       cf = createCrossFrame()
       cf.destroy()
       assert.called(fakeBridge.destroy)
+
+  describe '.removeGuestListener', ->
+    it 'calls removeGuestListener in Bridge', ->
+      cf = createCrossFrame()
+      cf.removeGuestListener()
+      assert.called fakeBridge.removeGuestListener
+
+  describe '.registerMethods', ->
+    it 'calls registerMethods in AnnotationSync', ->
+      cf = createCrossFrame()
+      options = {}
+      cf.registerMethods(options, "guestId")
+      assert.called fakeAnnotationSync.registerMethods
+
+  describe '.removeMethods', ->
+    it 'calls removeMethods in AnnotationSync', ->
+      cf = createCrossFrame()
+      cf.removeMethods()
+      assert.called fakeAnnotationSync.removeMethods
 
   describe '.sync', ->
     it 'syncs the annotations with the other frame', ->

--- a/src/annotator/readium-sidebar.coffee
+++ b/src/annotator/readium-sidebar.coffee
@@ -12,18 +12,15 @@ module.exports = class ReadiumSidebar extends Sidebar
 
   constructor: (element, options) ->
     ReadiumSDK = window.ReadiumSDK
+    super(element, options)
 
     ReadiumSDK.once(ReadiumSDK.Events.READER_INITIALIZED, (readium) =>
-      readium.once(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, ($iframe, spineItem) =>
-        super(element, options)
+      readium.on(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, ($iframe, spineItem) =>
+        guestElement = $iframe[0].contentDocument.body
+        this.addGuest(guestElement, spineItem.href)
+      )
 
-        readium.on(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, ($iframe, spineItem) =>
-          guestElement = $iframe[0].contentDocument.body
-          this.addGuest(guestElement, spineItem.href)
-        )
-
-        readium.on(ReadiumSDK.Events.CONTENT_DOCUMENT_UNLOADED, ($iframe, spineItem) =>
-          this.destroyGuest(spineItem.href)
-        )
+      readium.on(ReadiumSDK.Events.CONTENT_DOCUMENT_UNLOADED, ($iframe, spineItem) =>
+        this.destroyGuest(spineItem.href)
       )
     )

--- a/src/annotator/readium-sidebar.coffee
+++ b/src/annotator/readium-sidebar.coffee
@@ -11,13 +11,19 @@ module.exports = class ReadiumSidebar extends Sidebar
       container: '.annotator-frame'
 
   constructor: (element, options) ->
-    console.log 'this works right'
-
     ReadiumSDK = window.ReadiumSDK
 
     ReadiumSDK.once(ReadiumSDK.Events.READER_INITIALIZED, (readium) =>
       readium.once(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, ($iframe, spineItem) =>
-        options.guestElement = $iframe[0].contentDocument.body
         super(element, options)
+
+        readium.on(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, ($iframe, spineItem) =>
+          guestElement = $iframe[0].contentDocument.body
+          this.addGuest(guestElement, spineItem.href)
+        )
+
+        readium.on(ReadiumSDK.Events.CONTENT_DOCUMENT_UNLOADED, ($iframe, spineItem) =>
+          this.destroyGuest(spineItem.href)
+        )
       )
     )

--- a/src/annotator/readium-sidebar.coffee
+++ b/src/annotator/readium-sidebar.coffee
@@ -42,3 +42,4 @@ module.exports = class ReadiumSidebar extends Sidebar
     bucketStyle.width += offset
     bucketStyle.left += "-" + offset
     bucketStyle.borderLeft = "1px solid rgba(0,0,0, 0.07)"
+    bucketStyle.borderRight = "1px solid rgba(0,0,0, 0.03)"

--- a/src/annotator/readium-sidebar.coffee
+++ b/src/annotator/readium-sidebar.coffee
@@ -24,3 +24,21 @@ module.exports = class ReadiumSidebar extends Sidebar
         this.destroyGuest(spineItem.href)
       )
     )
+
+    this._shiftNativeElements()
+
+  # THESIS TODO: Placed in ReadiumSidebar to avoid breaking unknown sites
+  # If the solution seems safe, then consider moving it into Sidebar
+  #
+  # Shift the elements native to the website, so that they don't conflict
+  # with our own.
+  _shiftNativeElements: ->
+    annoWrapper = document.getElementsByClassName('annotator-wrapper')[0]
+    offset = this.toolbar.css('width')
+    annoWrapper.style.marginRight += offset
+
+    bucketEl = this.plugins.BucketBar.element[0]
+    bucketStyle = bucketEl.style
+    bucketStyle.width += offset
+    bucketStyle.left += "-" + offset
+    bucketStyle.borderLeft = "1px solid rgba(0,0,0, 0.07)"

--- a/src/annotator/readium-sidebar.coffee
+++ b/src/annotator/readium-sidebar.coffee
@@ -1,0 +1,23 @@
+Sidebar = require('./sidebar')
+
+
+module.exports = class ReadiumSidebar extends Sidebar
+  options:
+    Readium: {}
+    TextSelection: {}
+    BucketBar:
+      container: '.annotator-frame'
+    Toolbar:
+      container: '.annotator-frame'
+
+  constructor: (element, options) ->
+    console.log 'this works right'
+
+    ReadiumSDK = window.ReadiumSDK
+
+    ReadiumSDK.once(ReadiumSDK.Events.READER_INITIALIZED, (readium) =>
+      readium.once(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, ($iframe, spineItem) =>
+        options.guestElement = $iframe[0].contentDocument.body
+        super(element, options)
+      )
+    )

--- a/src/annotator/readium-sidebar.coffee
+++ b/src/annotator/readium-sidebar.coffee
@@ -12,6 +12,7 @@ module.exports = class ReadiumSidebar extends Sidebar
 
   constructor: (element, options) ->
     ReadiumSDK = window.ReadiumSDK
+    options.shiftNativeElements = true
     super(element, options)
 
     ReadiumSDK.once(ReadiumSDK.Events.READER_INITIALIZED, (readium) =>
@@ -24,22 +25,3 @@ module.exports = class ReadiumSidebar extends Sidebar
         this.destroyGuest(spineItem.href)
       )
     )
-
-    this._shiftNativeElements()
-
-  # THESIS TODO: Placed in ReadiumSidebar to avoid breaking unknown sites
-  # If the solution seems safe, then consider moving it into Sidebar
-  #
-  # Shift the elements native to the website, so that they don't conflict
-  # with our own.
-  _shiftNativeElements: ->
-    annoWrapper = document.getElementsByClassName('annotator-wrapper')[0]
-    offset = this.toolbar.css('width')
-    annoWrapper.style.marginRight += offset
-
-    bucketEl = this.plugins.BucketBar.element[0]
-    bucketStyle = bucketEl.style
-    bucketStyle.width += offset
-    bucketStyle.left += "-" + offset
-    bucketStyle.borderLeft = "1px solid rgba(0,0,0, 0.07)"
-    bucketStyle.borderRight = "1px solid rgba(0,0,0, 0.03)"

--- a/src/annotator/readium-sidebar.coffee
+++ b/src/annotator/readium-sidebar.coffee
@@ -19,9 +19,18 @@ module.exports = class ReadiumSidebar extends Sidebar
       readium.on(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, ($iframe, spineItem) =>
         guestElement = $iframe[0].contentDocument.body
         this.addGuest(guestElement, spineItem.href)
+        @injectCSS($iframe)
       )
 
       readium.on(ReadiumSDK.Events.CONTENT_DOCUMENT_UNLOADED, ($iframe, spineItem) =>
         this.destroyGuest(spineItem.href)
       )
     )
+
+  injectCSS: (iframe) ->
+    linkEl = document.createElement('link')
+    # THESIS TODO: Temporarily hardcoded. Improve at some point.
+    linkEl.href = "http://127.0.0.1:5000/assets/client/styles/inject.css?356cf8"
+    linkEl.rel = "stylesheet"
+    linkEl.type = "text/css"
+    iframe[0].contentDocument.head.appendChild(linkEl)

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -115,7 +115,7 @@ module.exports = class Sidebar extends Host
 
     guestEl.on 'click', (event) =>
       if !@selectedTargets?.length
-        this.hide()
+        @hide()
 
   onPan: (event) =>
     switch event.type
@@ -177,11 +177,3 @@ module.exports = class Sidebar extends Host
       @toolbar.find('[name=sidebar-toggle]')
       .removeClass('h-icon-chevron-right')
       .addClass('h-icon-chevron-left')
-
-  createAnnotation: (annotation = {}) ->
-    super
-    this.show() unless annotation.$highlight
-
-  showAnnotations: (annotations) ->
-    super
-    this.show()

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -107,7 +107,7 @@ module.exports = class Sidebar extends Host
 
   addGuest: (guestElement, guestId, options) ->
     options = @options
-    options.showSidebarCb = _.bind(@show, this)
+    options.showSidebarCb = @show.bind(this)
     super(guestElement, guestId, options)
 
     guestEl = @guests[guestId]

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -41,6 +41,9 @@ module.exports = class Sidebar extends Host
 
     this._setupSidebarEvents()
 
+    if options.shiftNativeElements
+      @_shiftNativeElements()
+
   _setupDocumentEvents: ->
     sidebarTrigger(document.body, @show.bind(this))
 
@@ -83,6 +86,22 @@ module.exports = class Sidebar extends Host
 
     # Return this for chaining
     this
+
+  # THESIS TODO: This modifies the styling of the BucketBar, which isn't ideal.
+  #
+  # Shift the elements native to the website, so that they don't conflict
+  # with our own.
+  _shiftNativeElements: ->
+    annoWrapper = document.getElementsByClassName('annotator-wrapper')[0]
+    offset = this.toolbar.css('width')
+    annoWrapper.style.marginRight += offset
+
+    bucketEl = this.plugins.BucketBar.element[0]
+    bucketStyle = bucketEl.style
+    bucketStyle.width += offset
+    bucketStyle.left += "-" + offset
+    bucketStyle.borderLeft = "1px solid rgba(0,0,0, 0.07)"
+    bucketStyle.borderRight = "1px solid rgba(0,0,0, 0.03)"
 
   _initializeGestureState: ->
     @gestureState =

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -42,7 +42,7 @@ module.exports = class Sidebar extends Host
     this._setupSidebarEvents()
 
   _setupDocumentEvents: ->
-    sidebarTrigger(this.document.body, @show.bind(this))
+    sidebarTrigger(document.body, @show.bind(this))
 
     @element.on 'click', (event) =>
       if !@selectedTargets?.length
@@ -50,7 +50,7 @@ module.exports = class Sidebar extends Host
     return this
 
   _setupSidebarEvents: ->
-    annotationCounts(this.document.body, @crossframe)
+    annotationCounts(document.body, @crossframe)
 
     @crossframe.on('show', this.show.bind(this))
     @crossframe.on('hide', this.hide.bind(this))

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -42,7 +42,7 @@ module.exports = class Sidebar extends Host
     this._setupSidebarEvents()
 
   _setupDocumentEvents: ->
-    sidebarTrigger(document.body, @show.bind(this))
+    sidebarTrigger(this.document.body, @show.bind(this))
 
     @element.on 'click', (event) =>
       if !@selectedTargets?.length
@@ -50,7 +50,7 @@ module.exports = class Sidebar extends Host
     return this
 
   _setupSidebarEvents: ->
-    annotationCounts(document.body, @crossframe)
+    annotationCounts(this.document.body, @crossframe)
 
     @crossframe.on('show', this.show.bind(this))
     @crossframe.on('hide', this.hide.bind(this))

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -105,6 +105,16 @@ module.exports = class Sidebar extends Host
         @frame.css('margin-left', "#{m}px")
         if w >= MIN_RESIZE then @frame.css('width', "#{w}px")
 
+  addGuest: (guestElement, guestId) ->
+    super(guestElement, guestId)
+
+    guestEl = @guests[guestId]
+    sidebarTrigger(guestEl.element[0], @show.bind(this))
+
+    guestEl.on 'click', (event) =>
+      if !@selectedTargets?.length
+        this.hide()
+
   onPan: (event) =>
     switch event.type
       when 'panstart'

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -105,8 +105,10 @@ module.exports = class Sidebar extends Host
         @frame.css('margin-left', "#{m}px")
         if w >= MIN_RESIZE then @frame.css('width', "#{w}px")
 
-  addGuest: (guestElement, guestId) ->
-    super(guestElement, guestId)
+  addGuest: (guestElement, guestId, options) ->
+    options = @options
+    options.showSidebarCb = _.bind(@show, this)
+    super(guestElement, guestId, options)
 
     guestEl = @guests[guestId]
     sidebarTrigger(guestEl.element[0], @show.bind(this))

--- a/src/annotator/test/annotation-sync-test.coffee
+++ b/src/annotator/test/annotation-sync-test.coffee
@@ -124,3 +124,27 @@ describe 'AnnotationSync', ->
         options.emit('beforeAnnotationCreated', ann)
 
         assert.notCalled(fakeBridge.call)
+
+  describe 'registerMethods', ->
+    it 'adds an _emit method for a given guest', ->
+      annSync = createAnnotationSync()
+      annSync.registerMethods(options, "guestId")
+      assert.isFunction(annSync._emit["guestId"])
+
+    it 'adds an _on method for a given guest', ->
+      annSync = createAnnotationSync()
+      annSync.registerMethods(options, "guestId")
+      assert.isFunction(annSync._on["guestId"])
+
+  describe 'removeMethods', ->
+    it 'removes _emit from the guest its associated with', ->
+      annSync = createAnnotationSync()
+      annSync.registerMethods(options, "guestId")
+      annSync.removeMethods("guestId")
+      assert.isUndefined(annSync._emit["guestId"])
+
+    it 'removes _on from the guest its associated with', ->
+      annSync = createAnnotationSync()
+      annSync.registerMethods(options, "guestId")
+      annSync.removeMethods("guestId")
+      assert.isUndefined(annSync._on["guestId"])

--- a/src/annotator/test/guest-test.coffee
+++ b/src/annotator/test/guest-test.coffee
@@ -68,8 +68,11 @@ describe 'Guest', ->
     })
 
     fakeCrossFrame = {
+      call: sinon.stub()
       onConnect: sinon.stub()
       on: sinon.stub()
+      registerMethods: sinon.stub()
+      reloadAnnotations: sinon.stub()
       sync: sinon.stub()
     }
 
@@ -260,6 +263,36 @@ describe 'Guest', ->
       guest = createGuest()
       selections.next(null)
       assert.called FakeAdder::instance.hide
+
+  describe 'when a second guest is created', ->
+    guestOne = null
+    guestTwo = null
+
+    beforeEach ->
+      guestOne = createGuest()
+
+      options = {
+        adderCtrl: guestOne.adderCtrl,
+        crossframe: guestOne.crossframe,
+        guestId: "guestTwo.html"
+      }
+      guestTwo = createGuest(options)
+      guestTwo.setPlugins(guestOne.plugins)
+
+    it 'shares the same crossframe with the first guest', ->
+      assert.strictEqual guestOne.crossframe, guestTwo.crossframe
+
+    it 'shares the same adderCtrl with the first guest', ->
+      assert.strictEqual guestOne.adderCtrl, guestTwo.adderCtrl
+
+    it 'shares the same plugins with the first guest', ->
+      assert.strictEqual guestOne.plugins, guestTwo.plugins
+
+    it 'calls crossframe\'s registerMethods', ->
+      assert.called guestTwo.crossframe.registerMethods
+
+    it 'has a different guestId', ->
+      assert.notEqual guestTwo.guestId, guestOne.guestId
 
   describe '#getDocumentInfo()', ->
     guest = null

--- a/src/annotator/test/guest-test.coffee
+++ b/src/annotator/test/guest-test.coffee
@@ -28,6 +28,8 @@ class FakeAdder
     this.hide = sinon.stub()
     this.showAt = sinon.stub()
     this.target = sinon.stub()
+    this.setCommands = sinon.stub()
+    this.setGuestElement = sinon.stub()
 
 # A little helper which returns a promise that resolves after a timeout
 timeoutPromise = (millis = 0) ->

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -44,6 +44,9 @@ function FakeCrossFrame() {
   this.onConnect = sinon.stub();
   this.on = sinon.stub();
   this.sync = sinon.stub();
+  this.removeGuestListener = sinon.stub();
+  this.registerMethods = sinon.stub();
+  this.removeMethods = sinon.stub();
 }
 
 describe('anchoring', function () {

--- a/src/shared/bridge.coffee
+++ b/src/shared/bridge.coffee
@@ -7,17 +7,16 @@ module.exports = class Bridge
   # Connected links to other frames
   links: null
   channelListeners: null
+  guestListeners: null
   onConnectListeners: null
 
   constructor: ->
     @links = []
-    # THESIS TODO: @guestListeners are currently never used. Figure out where
-    # @channelListeners are used, and add support for @guestListeners
     @guestListeners = {}
-    # THESIS TODO: FOR DEBUG PURPOSES, REMOVE AT SOME POINT
-    window.guestListeners = @guestListeners
     @channelListeners = {}
     @onConnectListeners = []
+    # THESIS TODO: FOR DEBUG PURPOSES, REMOVE AT SOME POINT
+    window.guestListeners = @guestListeners
 
   # Tear down the bridge. We destroy each RPC "channel" object we know about.
   # This removes the `onmessage` event listeners, thus removing references to
@@ -121,6 +120,7 @@ module.exports = class Bridge
 
   removeGuestListener: (guestId) ->
     delete @guestListeners[guestId]
+    this
 
   # Add a function to be called upon a new connection
   onConnect: (callback) ->

--- a/src/shared/bridge.coffee
+++ b/src/shared/bridge.coffee
@@ -17,6 +17,7 @@ module.exports = class Bridge
     @onConnectListeners = []
     # THESIS TODO: FOR DEBUG PURPOSES, REMOVE AT SOME POINT
     window.guestListeners = @guestListeners
+    window.channelListeners = @channelListeners
 
   # Tear down the bridge. We destroy each RPC "channel" object we know about.
   # This removes the `onmessage` event listeners, thus removing references to

--- a/src/shared/frame-rpc.js
+++ b/src/shared/frame-rpc.js
@@ -101,9 +101,13 @@ RPC.prototype._handle = function (msg) {
             // A guestId will have to be passed in at some point
             if (!this._methods.guestListeners) return;
 
-            _.each(this._methods.guestListeners, function(guestListener, key) {
-                if (guestListener.hasOwnProperty(msg.method)) methodsObject = guestListener;
-            });
+            var guestListeners = this._methods.guestListeners;
+            for (var key in guestListeners) {
+                if (guestListeners.hasOwnProperty(key)) {
+                    var guestListener = guestListeners[key]
+                    if (guestListener.hasOwnProperty(msg.method)) methodsObject = guestListener;
+                }
+            }
             if (!methodsObject) return;
         } else methodsObject = this._methods
 

--- a/src/shared/test/bridge-test.coffee
+++ b/src/shared/test/bridge-test.coffee
@@ -139,12 +139,35 @@ describe 'Bridge', ->
       assert.throws ->
         bridge.on('message1', sandbox.spy())
 
+    it 'adds a guest method to the guest method registry', ->
+      channel = createChannel()
+      bridge.on('message1', sandbox.spy(), "guestId")
+      assert.isFunction(bridge.guestListeners["guestId"]['message1'])
+
+    it 'Only allows registering the same method once per guest', ->
+      bridge.on('message1', sandbox.spy(), "guestId")
+      assert.throws ->
+        bridge.on('message1', sandbox.spy(), "guestId")
+
   describe '.off', ->
     it 'removes the method from the method registry', ->
       channel = createChannel()
       bridge.on('message1', sandbox.spy())
       bridge.off('message1')
       assert.isUndefined(bridge.channelListeners['message1'])
+
+    it 'removed a guest method from the guest method registry', ->
+      channel = createChannel()
+      bridge.on('message1', sandbox.spy(), 'guestId')
+      bridge.off('message1', "guestId")
+      assert.isUndefined(bridge.guestListeners["guestId"]["message1"])
+
+  describe '.removeGuestListener', ->
+    it 'deletes an entry within guestListeners', ->
+      channel = createChannel()
+      bridge.on('message1', sandbox.spy(), 'guestId')
+      bridge.removeGuestListener('guestId')
+      assert.isUndefined(bridge.guestListeners["guestId"])
 
   describe '.onConnect', ->
     it 'adds a callback that is called when a channel is connected', (done) ->

--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -56,8 +56,6 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
     annotationUI.subscribe(updateAnnotations);
   }
 
-  // THESIS TODO: This was put into its own function for debugging, and potential future use. Revert if nothing becomes of it.
-  // prevAnnotations, prevFrames, and prevPublicAnns were located in setupSyncToFrame prior to this
   function updateAnnotations() {
     var state = annotationUI.getState();
     if (state.annotations === prevAnnotations &&

--- a/src/styles/annotator/inject.scss
+++ b/src/styles/annotator/inject.scss
@@ -8,15 +8,15 @@ $base-font-size: 14px;
 //HIGHLIGHTS////////////////////////////////
 .annotator-highlights-always-on {
   .annotator-hl {
-    background-color: $highlight-color;
+    background-color: $highlight-color !important;
   }
 
   .annotator-hl .annotator-hl {
-    background-color: $highlight-color-second;
+    background-color: $highlight-color-second !important;
   }
 
   .annotator-hl .annotator-hl .annotator-hl {
-    background-color: $highlight-color-third;
+    background-color: $highlight-color-third !important;
   }
 }
 


### PR DESCRIPTION
This is a part of the NYU project that aims to integrate Readium and Hypothesis. 
Initial decoupling between Guest and Sidebar, towards the  support of multiple concurrent documents.

Key changes:
- Host no longer extends off of Guest, and instantiates / manages them instead
- The default Guest (a Guest that gets instantiated when Host is created) still creates the necessary components, such as CrossFrame, Adder, and Document. However, these will be shared among additional guests
- Each guest is given a "guestId", which would ideally correspond to a unique document id
- "THESIS TODO" is used throughout to indicate concerns/tasks that need to be worked on. "Thesis" being our internal codename used to refer to this project.

Class diagram showing the changes to the Guest and Sidebar:
- PDF: https://www.dropbox.com/s/jr3gs66z2reqejo/Changes%20to%20Sidebar%252FGuest%20Class%20Diagram.pdf?dl=0
- Source: https://drive.google.com/file/d/0B_3IOMQDd3A7c0RBd1J2VmM2OWc/view?usp=sharing

Sequence diagram showing the creation / removal of guests:
- PDF: https://www.dropbox.com/s/cwr4n23vdv2yegy/Add%252FRemove%20Guest%20Sequence%20Diagram.pdf?dl=0
- Source: https://drive.google.com/file/d/0B_3IOMQDd3A7S2p2MHVBQlFha0U/view?usp=sharing

Issues / Concerns:
- There's no support for multiple guests for the host frame (or rather, the frame designated as the server). Until this is implemented, the temporary bandaid solution is to loop over all guests wherever a guestId could not be provided. The extent of the consequences are unknown at this time.