### PR TITLE
Use correct case for `flagCount` key

### DIFF
--- a/src/sidebar/annotation-metadata.js
+++ b/src/sidebar/annotation-metadata.js
@@ -188,7 +188,7 @@ function flagCount(ann) {
   if (!ann.moderation) {
     return 0;
   }
-  return ann.moderation.flag_count;
+  return ann.moderation.flagCount;
 }
 
 module.exports = {

--- a/src/sidebar/components/test/moderation-banner-test.js
+++ b/src/sidebar/components/test/moderation-banner-test.js
@@ -66,7 +66,7 @@ describe('moderationBanner', function () {
   it('displays in a more compact form if the annotation is a reply', function () {
     var ann = Object.assign(fixtures.oldReply(), {
       moderation: {
-        flag_count: 10,
+        flagCount: 10,
       },
     });
     var banner = createBanner({ annotation: ann });

--- a/src/sidebar/test/annotation-fixtures.js
+++ b/src/sidebar/test/annotation-fixtures.js
@@ -162,7 +162,7 @@ function moderatedAnnotation(modInfo) {
     id: 'ann-id',
     hidden: !!modInfo.hidden,
     moderation: {
-      flag_count: modInfo.flagCount || 0,
+      flagCount: modInfo.flagCount || 0,
     },
   });
 }


### PR DESCRIPTION
This property is camelCased rather than snake_cased in the annotation
response from the service.

Slack discussion: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1491567323997506