### PR TITLE
Update flag count after moderator flags an annotation themselves

### DIFF
--- a/src/sidebar/reducers/annotations.js
+++ b/src/sidebar/reducers/annotations.js
@@ -150,9 +150,20 @@ var update = {
     var annotations = state.annotations.map(function (annot) {
       var match = (annot.id && annot.id === action.id);
       if (match) {
-        return Object.assign({}, annot, {
+        if (annot.flagged === action.isFlagged) {
+          return annot;
+        }
+
+        var newAnn = Object.assign({}, annot, {
           flagged: action.isFlagged,
         });
+        if (newAnn.moderation) {
+          var countDelta = action.isFlagged ? 1 : -1;
+          newAnn.moderation = Object.assign(annot.moderation, {
+            flagCount: annot.moderation.flagCount + countDelta,
+          });
+        }
+        return newAnn;
       } else {
         return annot;
       }

--- a/src/sidebar/reducers/annotations.js
+++ b/src/sidebar/reducers/annotations.js
@@ -159,7 +159,7 @@ var update = {
         });
         if (newAnn.moderation) {
           var countDelta = action.isFlagged ? 1 : -1;
-          newAnn.moderation = Object.assign(annot.moderation, {
+          newAnn.moderation = Object.assign({}, annot.moderation, {
             flagCount: annot.moderation.flagCount + countDelta,
           });
         }

--- a/src/sidebar/reducers/test/annotations-test.js
+++ b/src/sidebar/reducers/test/annotations-test.js
@@ -7,6 +7,7 @@ var thunk = require('redux-thunk').default;
 var annotations = require('../annotations');
 var fixtures = require('../../test/annotation-fixtures');
 var util = require('../util');
+var unroll = require('../../../shared/test/util').unroll;
 
 var actions = annotations.actions;
 
@@ -75,5 +76,19 @@ describe('annotations reducer', function () {
       var storeAnn = annotations.findAnnotationByID(store.getState(), ann.id);
       assert.equal(storeAnn.hidden, false);
     });
+  });
+
+  describe('#updateFlagStatus', function () {
+    unroll('updates the flagged status of an annotation', function (testCase) {
+      var store = createStore();
+      var ann = fixtures.defaultAnnotation();
+      ann.flagged = !testCase.flagged;
+
+      store.dispatch(actions.addAnnotations([ann]));
+      store.dispatch(actions.updateFlagStatus(ann.id, testCase.flagged));
+
+      var storeAnn = annotations.findAnnotationByID(store.getState(), ann.id);
+      assert.equal(storeAnn.flagged, testCase.flagged);
+    }, [{ flagged: true}, { flagged: false }]);
   });
 });

--- a/src/sidebar/reducers/test/annotations-test.js
+++ b/src/sidebar/reducers/test/annotations-test.js
@@ -86,35 +86,51 @@ describe('annotations reducer', function () {
     unroll('updates the flagged status of an annotation', function (testCase) {
       var store = createStore();
       var ann = fixtures.defaultAnnotation();
-      ann.flagged = !testCase.flagged;
+      ann.flagged = testCase.wasFlagged;
+      ann.moderation = testCase.oldModeration;
 
       store.dispatch(actions.addAnnotations([ann]));
-      store.dispatch(actions.updateFlagStatus(ann.id, testCase.flagged));
+      store.dispatch(actions.updateFlagStatus(ann.id, testCase.nowFlagged));
 
       var storeAnn = annotations.findAnnotationByID(store.getState(), ann.id);
-      assert.equal(storeAnn.flagged, testCase.flagged);
-    }, [{ flagged: true}, { flagged: false }]);
-
-    it('does not add moderation info if not present', function () {
-      var store = createStore();
-      var ann = fixtures.defaultAnnotation();
-
-      store.dispatch(actions.addAnnotations([ann]));
-      store.dispatch(actions.updateFlagStatus(ann.id, true));
-
-      var storeAnn = annotations.findAnnotationByID(store.getState(), ann.id);
-      assert.notOk(storeAnn.moderation);
-    });
-
-    it('increments the flag count if moderation info is present', function () {
-      var store = createStore();
-      var ann = fixtures.moderatedAnnotation({ flagCount: 0 });
-
-      store.dispatch(actions.addAnnotations([ann]));
-      store.dispatch(actions.updateFlagStatus(ann.id, true));
-
-      var storeAnn = annotations.findAnnotationByID(store.getState(), ann.id);
-      assert.equal(storeAnn.moderation.flagCount, 1);
-    });
+      assert.equal(storeAnn.flagged, testCase.nowFlagged);
+      assert.deepEqual(storeAnn.moderation, testCase.newModeration);
+    }, [{
+      // Non-moderator flags annotation
+      wasFlagged: false,
+      nowFlagged: true,
+      oldModeration: undefined,
+      newModeration: undefined,
+    }, {
+      // Non-moderator un-flags annotation
+      wasFlagged: true,
+      nowFlagged: false,
+      oldModeration: undefined,
+      newModeration: undefined,
+    },{
+      // Moderator un-flags an already unflagged annotation
+      wasFlagged: false,
+      nowFlagged: false,
+      oldModeration: { flagCount: 1 },
+      newModeration: { flagCount: 1 },
+    },{
+      // Moderator flags an already flagged annotation
+      wasFlagged: true,
+      nowFlagged: true,
+      oldModeration: { flagCount: 1 },
+      newModeration: { flagCount: 1 },
+    },{
+      // Moderator flags annotation
+      wasFlagged: false,
+      nowFlagged: true,
+      oldModeration: { flagCount: 0 },
+      newModeration: { flagCount: 1 },
+    },{
+      // Moderator un-flags annotation
+      wasFlagged: true,
+      nowFlagged: false,
+      oldModeration: { flagCount: 1 },
+      newModeration: { flagCount: 0 },
+    }]);
   });
 });

--- a/src/sidebar/reducers/test/annotations-test.js
+++ b/src/sidebar/reducers/test/annotations-test.js
@@ -60,8 +60,10 @@ describe('annotations reducer', function () {
     it('sets the `hidden` state to `true`', function () {
       var store = createStore();
       var ann = fixtures.moderatedAnnotation({ hidden: false });
+
       store.dispatch(actions.addAnnotations([ann]));
       store.dispatch(actions.hideAnnotation(ann.id));
+
       var storeAnn = annotations.findAnnotationByID(store.getState(), ann.id);
       assert.equal(storeAnn.hidden, true);
     });
@@ -71,8 +73,10 @@ describe('annotations reducer', function () {
     it('sets the `hidden` state to `false`', function () {
       var store = createStore();
       var ann = fixtures.moderatedAnnotation({ hidden: true });
+
       store.dispatch(actions.addAnnotations([ann]));
       store.dispatch(actions.unhideAnnotation(ann.id));
+
       var storeAnn = annotations.findAnnotationByID(store.getState(), ann.id);
       assert.equal(storeAnn.hidden, false);
     });
@@ -90,5 +94,27 @@ describe('annotations reducer', function () {
       var storeAnn = annotations.findAnnotationByID(store.getState(), ann.id);
       assert.equal(storeAnn.flagged, testCase.flagged);
     }, [{ flagged: true}, { flagged: false }]);
+
+    it('does not add moderation info if not present', function () {
+      var store = createStore();
+      var ann = fixtures.defaultAnnotation();
+
+      store.dispatch(actions.addAnnotations([ann]));
+      store.dispatch(actions.updateFlagStatus(ann.id, true));
+
+      var storeAnn = annotations.findAnnotationByID(store.getState(), ann.id);
+      assert.notOk(storeAnn.moderation);
+    });
+
+    it('increments the flag count if moderation info is present', function () {
+      var store = createStore();
+      var ann = fixtures.moderatedAnnotation({ flagCount: 0 });
+
+      store.dispatch(actions.addAnnotations([ann]));
+      store.dispatch(actions.updateFlagStatus(ann.id, true));
+
+      var storeAnn = annotations.findAnnotationByID(store.getState(), ann.id);
+      assert.equal(storeAnn.moderation.flagCount, 1);
+    });
   });
 });

--- a/src/sidebar/test/annotation-ui-test.js
+++ b/src/sidebar/test/annotation-ui-test.js
@@ -507,15 +507,6 @@ describe('annotationUI', function () {
     });
   });
 
-  describe('#updateFlagStatus', function () {
-    it('updates the flaged status of an annotation', function () {
-      var annot = defaultAnnotation();
-      annotationUI.addAnnotations([annot]);
-      annotationUI.updateFlagStatus(annot.id, true);
-      assert.equal(annotationUI.getState().annotations[0].flagged, true);
-    });
-  });
-
   describe('selector functions', function () {
     // The individual state management modules in reducers/*.js define various
     // 'selector' functions for extracting data from the app state. These are


### PR DESCRIPTION
When a user who is also a moderator flags an annotation, the client updated the `flagged` key in its local copy of the annotation but not the `moderation.flag_count` key (if present), so the moderation banner did not reflect the change in flag status.

In the scenario where an unflagged annotation is flagged by a moderator, this meant that the moderation banner did not appear and the user had to reload the page to actually hide the annotation.

Fixes https://github.com/hypothesis/client/issues/346