### PR TITLE
Only display CC 0 license for shared annotations in public groups

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -541,6 +541,17 @@ function AnnotationController(
     };
   };
 
+  /**
+   * Return true if the CC 0 license notice should be shown beneath the
+   * annotation body.
+   */
+  vm.shouldShowLicense = function () {
+    if (!vm.editing() || !vm.isShared()) {
+      return false;
+    }
+    return vm.group().public;
+  };
+
   init();
 }
 

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -82,7 +82,7 @@
     </div>
 
     <div class="annotation-section annotation-license"
-      ng-show="vm.isShared() && vm.editing()">
+         ng-show="vm.shouldShowLicense()">
       <a class="annotation-license__link" href="http://creativecommons.org/publicdomain/zero/1.0/"
         title="View more information about the Creative Commons Public Domain dedication"
         target="_blank">


### PR DESCRIPTION
Do not display the CC 0 license for annotations that are shared in a private group.

Fixes https://github.com/hypothesis/product-backlog/issues/145