### PR TITLE
Fix variance in annotation share dialog test coverage

### DIFF
--- a/src/sidebar/components/annotation-share-dialog.js
+++ b/src/sidebar/components/annotation-share-dialog.js
@@ -4,70 +4,71 @@ var angular = require('angular');
 
 var scopeTimeout = require('../util/scope-timeout');
 
-module.exports = {
-  controllerAs: 'vm',
-  template: require('../templates/annotation-share-dialog.html'),
-  // @ngInject
-  controller: function ($scope, $element, analytics) {
-    var shareLinkInput = $element.find('input')[0];
+// @ngInject
+function AnnotationShareDialogController($element, $scope, analytics) {
+  var self = this;
+  var shareLinkInput = $element.find('input')[0];
 
-    $scope.$watch('vm.isOpen', function (isOpen) {
-      if (isOpen) {
-        // Focus the input and select it once the dialog has become visible
-        scopeTimeout($scope, function () {
-          shareLinkInput.focus();
-          shareLinkInput.select();
-        });
-
-        var hideListener = function (event) {
-          $scope.$apply(function () {
-            if (!$element[0].contains(event.target)) {
-              document.removeEventListener('click', hideListener);
-              this.onClose();
-            }
-          }.bind(this));
-        }.bind(this);
-
-        // Stop listening for clicks outside the dialog once it is closed.
-        // The setTimeout() here is to ignore the initial click that opens
-        // the dialog.
-        scopeTimeout($scope, function () {
-          document.addEventListener('click', hideListener);
-        }, 0);
-      }
-    }.bind(this));
-
-    this.copyToClipboard = function (event) {
-      var $container = angular.element(event.currentTarget).parent();
-      var shareLinkInput = $container.find('input')[0];
-
-      try {
+  $scope.$watch('vm.isOpen', function (isOpen) {
+    if (isOpen) {
+      // Focus the input and select it once the dialog has become visible
+      scopeTimeout($scope, function () {
+        shareLinkInput.focus();
         shareLinkInput.select();
+      });
 
-        // In some browsers, execCommand() returns false if it fails,
-        // in others, it may throw an exception instead.
-        if (!document.execCommand('copy')) {
-          throw new Error('Copying link failed');
-        }
+      var hideListener = function (event) {
+        $scope.$apply(function () {
+          if (!$element[0].contains(event.target)) {
+            document.removeEventListener('click', hideListener);
+            self.onClose();
+          }
+        });
+      };
 
-        this.copyToClipboardMessage = 'Link copied to clipboard!';
-      } catch (ex) {
-        this.copyToClipboardMessage = 'Select and copy to share.';
-      } finally {
-        setTimeout(function () {
-          this.copyToClipboardMessage = null;
-          $scope.$digest();
-        }.bind(this),
-          1000);
+      // Stop listening for clicks outside the dialog once it is closed.
+      // The setTimeout() here is to ignore the initial click that opens
+      // the dialog.
+      scopeTimeout($scope, function () {
+        document.addEventListener('click', hideListener);
+      }, 0);
+    }
+  });
+
+  this.copyToClipboard = function (event) {
+    var $container = angular.element(event.currentTarget).parent();
+    var shareLinkInput = $container.find('input')[0];
+
+    try {
+      shareLinkInput.select();
+
+      // In some browsers, execCommand() returns false if it fails,
+      // in others, it may throw an exception instead.
+      if (!document.execCommand('copy')) {
+        throw new Error('Copying link failed');
       }
-    }.bind(this);
 
-    $scope.onShareClick = function(target){
-      if(target){
-        analytics.track(analytics.events.ANNOTATION_SHARED, target);
-      }
-    };
-  },
+      self.copyToClipboardMessage = 'Link copied to clipboard!';
+    } catch (ex) {
+      self.copyToClipboardMessage = 'Select and copy to share.';
+    } finally {
+      setTimeout(function () {
+        self.copyToClipboardMessage = null;
+        $scope.$digest();
+      }, 1000);
+    }
+  };
+
+  this.onShareClick = function(target){
+    if(target){
+      analytics.track(analytics.events.ANNOTATION_SHARED, target);
+    }
+  };
+}
+
+module.exports = {
+  controller: AnnotationShareDialogController,
+  controllerAs: 'vm',
   bindings: {
     group: '<',
     uri: '<',
@@ -75,4 +76,5 @@ module.exports = {
     isOpen: '<',
     onClose: '&',
   },
+  template: require('../templates/annotation-share-dialog.html'),
 };

--- a/src/sidebar/components/annotation-share-dialog.js
+++ b/src/sidebar/components/annotation-share-dialog.js
@@ -16,22 +16,6 @@ function AnnotationShareDialogController($element, $scope, analytics) {
         shareLinkInput.focus();
         shareLinkInput.select();
       });
-
-      var hideListener = function (event) {
-        $scope.$apply(function () {
-          if (!$element[0].contains(event.target)) {
-            document.removeEventListener('click', hideListener);
-            self.onClose();
-          }
-        });
-      };
-
-      // Stop listening for clicks outside the dialog once it is closed.
-      // The setTimeout() here is to ignore the initial click that opens
-      // the dialog.
-      scopeTimeout($scope, function () {
-        document.addEventListener('click', hideListener);
-      }, 0);
     }
   });
 

--- a/src/sidebar/components/test/annotation-share-dialog-test.js
+++ b/src/sidebar/components/test/annotation-share-dialog-test.js
@@ -28,7 +28,7 @@ describe('annotationShareDialog', function () {
     angular.mock.module('app');
   });
 
-  describe('The annotation share dialog', function () {
+  describe('the share dialog', function () {
     it('has class is-open set when it is open', function () {
       element = util.createDirective(document, 'annotationShareDialog', {
         isOpen: true,
@@ -66,7 +66,7 @@ describe('annotationShareDialog', function () {
 
   });
 
-  describe('vm.copyToClipboard()', function () {
+  describe('clipboard copy button', function () {
     var stub;
 
     beforeEach(function () {

--- a/src/sidebar/components/test/annotation-share-dialog-test.js
+++ b/src/sidebar/components/test/annotation-share-dialog-test.js
@@ -64,6 +64,21 @@ describe('annotationShareDialog', function () {
       assert.equal(fakeAnalytics.track.args[3][1], 'email');
     });
 
+    it('focuses and selects the link when the dialog is opened', function (done) {
+      var uri = 'https://hyp.is/a/foo';
+      element = util.createDirective(document, 'annotationShareDialog', {
+        isOpen: true,
+        uri: uri,
+      });
+
+      setTimeout(function () {
+        var shareLink = element.find('input')[0];
+        assert.equal(document.activeElement, shareLink);
+        assert.equal(shareLink.selectionStart, 0);
+        assert.equal(shareLink.selectionEnd, uri.length);
+        done();
+      }, 1);
+    });
   });
 
   describe('clipboard copy button', function () {

--- a/src/sidebar/templates/annotation-share-dialog.html
+++ b/src/sidebar/templates/annotation-share-dialog.html
@@ -5,22 +5,22 @@
       target="_blank"
       title="Tweet link"
       class="annotation-share-dialog-target__icon h-icon-twitter"
-      ng-click="onShareClick('twitter')"></a>
+      ng-click="vm.onShareClick('twitter')"></a>
     <a href="https://www.facebook.com/sharer/sharer.php?u={{vm.uri | urlEncode}}"
       target="_blank"
       title="Share on Facebook"
       class="annotation-share-dialog-target__icon h-icon-facebook"
-      ng-click="onShareClick('facebook')"></a>
+      ng-click="vm.onShareClick('facebook')"></a>
     <a href="https://plus.google.com/share?url={{vm.uri | urlEncode}}"
       target="_blank"
       title="Post on Google Plus"
       class="annotation-share-dialog-target__icon h-icon-google-plus"
-      ng-click="onShareClick('googlePlus')"></a>
+      ng-click="vm.onShareClick('googlePlus')"></a>
     <a href="mailto:?subject=Let's%20Annotate&amp;body={{vm.uri}}"
       target="_blank"
       title="Share via email"
       class="annotation-share-dialog-target__icon h-icon-mail"
-      ng-click="onShareClick('email')"></a>
+      ng-click="vm.onShareClick('email')"></a>
   </div>
   <div class="annotation-share-dialog-link" type="text">
     <input class="annotation-share-dialog-link__text"

--- a/src/sidebar/templates/annotation-share-dialog.html
+++ b/src/sidebar/templates/annotation-share-dialog.html
@@ -1,3 +1,6 @@
+<div class="annotation-share-dialog__backdrop"
+     ng-if="vm.isOpen"
+     ng-click="vm.onClose()"></div>
 <div class="annotation-share-dialog" ng-class="{'is-open': vm.isOpen}">
   <div class="annotation-share-dialog-target">
     <span class="annotation-share-dialog-target__label">Share:</span>

--- a/src/styles/annotation-share-dialog.scss
+++ b/src/styles/annotation-share-dialog.scss
@@ -45,6 +45,19 @@
   }
 }
 
+// Transparent backdrop behind the share dialog which intercepts clicks in order
+// to hide the dialog.
+.annotation-share-dialog__backdrop {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  background-color: black;
+  opacity: 0.01;
+  z-index: 1;
+}
+
 .annotation-share-dialog-msg {
   color: $gray-light;
   margin: -5px 10px 10px 10px;


### PR DESCRIPTION
This is a set of changes to fix the variance in the test coverage of `annotation-share-dialog` between test runs, causing spurious test coverage increase/decrease reports in unrelated PRs, and simplifies the implementation in the process.

I suggest looking at it commit-by-commit.

1. The first commit is some general refactoring to make `<annotation-share-dialog>` more consistent with other components. See commit message for details.
2. The second commit removes the need for code to add and remove document-level event handlers to intercept clicks behind the dialog by adding a transparent backdrop element behind the dialog. This backdrop element closes the dialog when clicked. This removes some code which sometimes ran and sometimes didn't in test runs.
3. The third commit adds a test for the focus and selection behaviour of the dialog when it is opened. This ensures that some code which sometimes ran in a test run is now always executed.

