### PR TITLE
Git push to hardcoded https URL and master branch

### DIFF
--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -4,7 +4,7 @@ set -eu
 
 cd "$(dirname "$0")"
 
-git push --follow-tags
+git push https://github.com/hypothesis/client.git master:master --follow-tags
 
 # Wait a moment to give GitHub a chance to realize that the tag exists
 sleep 2


### PR DESCRIPTION
Change the `git push` command that the `npm version minor` command runs
when doing a client release to:

1. Hardcode the https URL of the client repo, instead of assuming the
   user's `origin` is set to it

2. Push only the user's master branch to the remote master branch
   (instead of potentially pushing other local branches as well)