### PR TITLE
Remove a broken unit test

### DIFF
--- a/src/sidebar/test/service-url-test.js
+++ b/src/sidebar/test/service-url-test.js
@@ -75,16 +75,6 @@ describe('links', function () {
     });
   });
 
-  context('if the API request fails', function() {
-    it('just keeps returning empty strings for URLs', function() {
-      var linksPromise = Promise.reject(new Error('Oops'));
-
-      var serviceUrl = createServiceUrl(linksPromise).serviceUrl;
-
-      assert.equal(serviceUrl('second_link'), '');
-    });
-  });
-
   context('after the API response has been received', function() {
     var annotationUI;
     var linksPromise;


### PR DESCRIPTION
As noted in this comment:

https://github.com/hypothesis/client/pull/356#discussion_r111998459

this test doesn't actually test what it says it does, and fixing the
test would require some refactoring of the code under test. For now,
just delete the test.