### PR TITLE
Render "censored text" for hidden annotations

### DIFF
--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -1056,15 +1056,33 @@ describe('annotation', function() {
       assert.equal(el[0].querySelector('blockquote').textContent, '<<-&->>');
     });
 
-    it('renders hidden annotations with a custom text class', function () {
-      var ann = fixtures.moderatedAnnotation({ hidden: true });
-      var el = createDirective(ann).element;
+    unroll('renders hidden annotations with a custom text class (#context)', function (testCase) {
+      var el = createDirective(testCase.ann).element;
       assert.match(el.find('markdown').controller('markdown'), sinon.match({
-        customTextClass: {
-          'annotation-body is-hidden': true,
-        },
+        customTextClass: testCase.textClass,
       }));
-    });
+    }, [{
+      context: 'for moderators',
+      ann: Object.assign(fixtures.moderatedAnnotation({ hidden: true }), {
+        // Content still present.
+        text: 'Some offensive content',
+      }),
+      textClass: {
+        'annotation-body is-hidden': true,
+        'has-content': true,
+      },
+    },{
+      context: 'for non-moderators',
+      ann: Object.assign(fixtures.moderatedAnnotation({ hidden: true }), {
+        // Content filtered out by service.
+        tags: [],
+        text: '',
+      }),
+      textClass: {
+        'annotation-body is-hidden': true,
+        'has-content': false,
+      },
+    }]);
 
     it('flags the annotation when the user clicks the "Flag" button', function () {
       fakeAnnotationMapper.flagAnnotation.returns(Promise.resolve());

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -39,7 +39,8 @@
       overflow-hysteresis="20"
       content-data="vm.state().text">
       <markdown text="vm.state().text"
-                custom-text-class="{'annotation-body is-hidden':vm.isHiddenByModerator()}"
+                custom-text-class="{'annotation-body is-hidden':vm.isHiddenByModerator(),
+                                    'has-content':vm.hasContent()}"
                 on-edit-text="vm.setText(text)"
                 read-only="!vm.editing()">
       </markdown>

--- a/src/styles/annotation.scss
+++ b/src/styles/annotation.scss
@@ -102,9 +102,24 @@
   margin-left: 0px;
 }
 
-.annotation-body.is-hidden {
+// Hidden annotations displayed to moderators, where the content is still
+// present.
+.annotation-body.is-hidden.has-content {
   text-decoration: line-through;
   filter: grayscale(100%) contrast(65%);
+}
+
+// Hidden annotations displayed to non-moderators, where the content has been
+// filtered out by the service.
+.annotation-body.is-hidden:not(.has-content) {
+  // Create a column of horizontal stripes, giving the impression of text
+  // underneath that has been censored.
+  display: block;
+  height: 60px;
+  background: repeating-linear-gradient(
+    to bottom,
+    $grey-2, $grey-2 15px, white 15px, white 20px
+  );
 }
 
 // the footer at the bottom of an annotation displaying


### PR DESCRIPTION
Display a column of horizontal stripes to give the impression of
censored text for hidden annotations if the annotation's content has
been removed by the service.

Implements mock at https://github.com/hypothesis/product-backlog/issues/231#issuecomment-295600762

The easiest way to test this is:

1. Create an annotation with some text & text on a page.
2. Create a highlight on the same page, with no tags or text, matching how a censored annotation will be returned by the display.
3. Modify `h.formatters.annotation_hidden.format` in the service to always return `{'hidden': True}`
4. Reload the page in the client

The annotation will now be displayed as a hidden annotation would be displayed to moderators. The highlight will now be displayed as an annotation will look to non-moderators, for whom the content will be filtered out.

There are some other things that need to be addressed, such as the moderation banner being displayed to non-moderators and the "highlight" icon being shown on the annotation card if the content has been censored. I'm going to fix those separately.