### PR TITLE
Do not display moderation banner unless moderation metadata is present

### DIFF
--- a/src/sidebar/annotation-metadata.js
+++ b/src/sidebar/annotation-metadata.js
@@ -182,11 +182,13 @@ function location(annotation) {
 
 /**
  * Return the number of times the annotation has been flagged
- * by other users. If moderation data is unavailable, returns 0.
+ * by other users. If moderation metadata is not present, returns `null`.
+ *
+ * @return {number|null}
  */
 function flagCount(ann) {
   if (!ann.moderation) {
-    return 0;
+    return null;
   }
   return ann.moderation.flagCount;
 }

--- a/src/sidebar/components/moderation-banner.js
+++ b/src/sidebar/components/moderation-banner.js
@@ -14,6 +14,11 @@ function ModerationBannerController(annotationUI, flash, store) {
     return self.annotation.hidden;
   };
 
+  this.isHiddenOrFlagged = function () {
+    var flagCount = self.flagCount();
+    return flagCount !== null && (flagCount > 0 || self.isHidden());
+  };
+
   this.isReply = function () {
     return annotationMetadata.isReply(self.annotation);
   };

--- a/src/sidebar/templates/moderation-banner.html
+++ b/src/sidebar/templates/moderation-banner.html
@@ -1,5 +1,5 @@
 <div class="moderation-banner"
-     ng-if="vm.flagCount() > 0 || vm.isHidden()"
+     ng-if="vm.isHiddenOrFlagged()"
      ng-class="{'is-flagged': vm.flagCount() > 0,
                 'is-hidden': vm.isHidden(),
                 'is-reply': vm.isReply()}">

--- a/src/sidebar/test/annotation-metadata-test.js
+++ b/src/sidebar/test/annotation-metadata-test.js
@@ -320,8 +320,8 @@ describe('annotation-metadata', function () {
   describe('.flagCount', function () {
     var flagCount = annotationMetadata.flagCount;
 
-    it('returns 0 if the user is not a moderator', function () {
-      assert.equal(flagCount(fixtures.defaultAnnotation()), 0);
+    it('returns `null` if the user is not a moderator', function () {
+      assert.equal(flagCount(fixtures.defaultAnnotation()), null);
     });
 
     it('returns the flag count if present', function () {


### PR DESCRIPTION
_This is part of https://github.com/hypothesis/product-backlog/issues/231_

Previously the moderation banner was shown either if the annotation had moderation metadata and the flag count was non-zero, _or_ the annotation had been hidden.

However annotations which are hidden may still be returned to non-moderators with the `hidden` flag set if they have replies. In this case the moderation banner should not be shown.

This PR changes the condition to only display the banner if moderation metadata is present _and_ the annotation has either been flagged or hidden. 