### PR TITLE
Do not show highlight indicator for censored annotations

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -309,11 +309,18 @@ function AnnotationController(
       return false;
     } else {
       // Once an annotation has been saved to the server there's no longer a
-      // simple property that says whether it's a highlight or not.  For
-      // example there's no vm.annotation.highlight: true.  Instead a highlight is
-      // defined as an annotation that isn't a page note or a reply and that
-      // has no text or tags.
-      return (!isPageNote(vm.annotation) && !isReply(vm.annotation) && !vm.hasContent());
+      // simple property that says whether it's a highlight or not. Instead an
+      // annotation is considered a highlight if it has a) content and b) is
+      // linked to a specific part of the document.
+      if (isPageNote(vm.annotation) || isReply(vm.annotation)) {
+        return false;
+      }
+      if (vm.annotation.hidden) {
+        // Annotation has been censored so we have to assume that it had
+        // content.
+        return false;
+      }
+      return !vm.hasContent();
     }
   };
 

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -487,6 +487,18 @@ describe('annotation', function() {
 
         assert.isTrue(vm.isHighlight());
       });
+
+      it('returns false for censored annotations', function() {
+        var ann = Object.assign(fixtures.oldAnnotation(), {
+          hidden: true,
+          text: '',
+          tags: [],
+        });
+
+        var vm = createDirective(ann).controller;
+
+        assert.isFalse(vm.isHighlight());
+      });
     });
 
     describe('when the annotation is a highlight', function() {


### PR DESCRIPTION
_This is part of https://github.com/hypothesis/product-backlog/issues/231_

For annotations that have been saved we decide whether it is a highlight
based on whether it has a) selectors and b) content (tags or text). For
a censored/hidden annotation a non-moderator cannot tell whether it has
content.

Assume that censored annotations have content and are therefore not
highlights.