### PR TITLE
Exclude vendor code from coverage metrics

### DIFF
--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -64,7 +64,12 @@ module.exports = function(config) {
       transform: [
         'coffeeify',
         istanbul({
-          ignore: ['**/node_modules/**', '**/*.html', '**/*.svg'],
+          ignore: [
+            // Third party code
+            '**/node_modules/**', '**/vendor/*',
+            // Non JS modules
+            '**/*.html', '**/*.svg',
+          ],
 
           // There is an outstanding bug with karma-coverage and istanbul
           // in regards to doing source mapping and transpiling CoffeeScript.


### PR DESCRIPTION
Exclude vendored third-party code, including Annotator.js, from code
coverage metrics.

We were already ignoring code from npm packages, but not code in `src/annotator/vendor`.