### PR TITLE
Use `this` or `self` to refer to the controller instance in annotations

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -74,21 +74,12 @@ function AnnotationController(
   }
 
   /**
-    * Initialize this AnnotationController instance.
+    * Initialize the controller instance.
     *
-    * Initialize the `vm` object and any other variables that it needs,
-    * register event listeners, etc.
-    *
-    * All initialization code intended to run when a new AnnotationController
-    * instance is instantiated should go into this function, except defining
-    * methods on `vm`. This function is called on AnnotationController
-    * instantiation after all of the methods have been defined on `vm`, so it
-    * can call the methods.
+    * All initialization code except for assigning the controller instance's
+    * methods goes here.
     */
   function init() {
-    // The remaining properties on vm are read-only properties for the
-    // templates.
-
     /** Determines whether controls to expand/collapse the annotation body
      * are displayed adjacent to the tags field.
      */


### PR DESCRIPTION
This is just a small piece of cleanup for something that annoyed me having implemented a bunch of changes in this file recently.

Make `sidebar/components/annotation` consistent with other code by using
`this` or `self` to refer to the controller instance instead of `vm`.

 * Replace `vm` with `this` or `self` (in nested functions)

 * Remove ESLint exception at the top of the file

 * Remove unused `$q` import