### PR TITLE
Do not render moderation banner if annotation is missing

### DIFF
--- a/src/sidebar/components/test/annotation-thread-test.js
+++ b/src/sidebar/components/test/annotation-thread-test.js
@@ -198,4 +198,18 @@ describe('annotationThread', function () {
       .controller('moderationBanner');
     assert.deepEqual(moderationBanner, { annotation: ann });
   });
+
+  it('does not render the annotation or moderation banner if there is no annotation', function () {
+    var thread = {
+      annotation: null,
+      id: '123',
+      parent: null,
+      children: [],
+    };
+    var element = util.createDirective(document, 'annotationThread', {
+      thread: thread,
+    });
+    assert.notOk(element[0].querySelector('moderation-banner'));
+    assert.notOk(element[0].querySelector('annotation'));
+  });
 });

--- a/src/sidebar/templates/annotation-thread.html
+++ b/src/sidebar/templates/annotation-thread.html
@@ -10,7 +10,8 @@
     <div class="annotation-thread__thread-line"></div>
   </div>
   <div class="annotation-thread__content">
-    <moderation-banner annotation="vm.thread.annotation">
+    <moderation-banner annotation="vm.thread.annotation"
+                       ng-if="vm.thread.annotation">
     </moderation-banner>
     <annotation ng-class="vm.annotationClasses()"
              annotation="vm.thread.annotation"


### PR DESCRIPTION
Fix exception when rendering a thread if the thread item has no
annotation. This happens if the thread item was created for an
annotation whose prior existence was inferred by a reply but no longer
exists.

Sentry issue: https://sentry.io/hypothesis/client/issues/250997445/ (and many others)

Steps to reproduce: Build an extension using this branch and follow the steps at https://hypothes-is.slack.com/archives/C1M8NH76X/p1493029540097014