### PR TITLE
Initialize `target` field for new replies

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -359,6 +359,7 @@ function AnnotationController(
       group: group,
       references: references,
       permissions: replyPermissions,
+      target: [{source: vm.annotation.target[0].source}],
       uri: vm.annotation.uri,
     });
   };

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -524,6 +524,9 @@ describe('annotation', function() {
         var controller = createDirective(annotation).controller;
         var reply = sinon.match({
           references: [annotation.id],
+          target: [{
+            source: annotation.target[0].source,
+          }],
           uri: annotation.uri,
         });
         controller.reply();


### PR DESCRIPTION
Annotations must have a `target` field and those returned by the server
always do. For compatibility reasons the server allows clients to submit
new annotations which provide the data in the `url` field instead.

The `target` field was omitted when creating new replies in the client and this
broke an assumption in the `quote()` function used to extract the text to render in the quote
area of the card.

The logic for creating the reply and extracting the quote is in the
wrong place, but I've left it here for the moment to keep the diff
minimal.

---

**Steps to test**

1. On master (or using released client), create a new reply to an existing annotation and observe errors spewed in the dev console. Observe that when _saving_ a new reply, the request payload has no `target` field.
2. In this branch, repeat step (1) and observe errors are fixed. Observe that when saving a new reply, the request payload has a `target` field that is the same as the `url` field.

If we're agreed that `url` is deprecated then we can look into removing use of this entirely from the client in future, but that will be a larger refactoring.