### PR TITLE
Clarify in tooltip what flag button does

### DIFF
--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -1120,7 +1120,7 @@ describe('annotation', function() {
     it('flags the annotation when the user clicks the "Flag" button', function () {
       fakeAnnotationMapper.flagAnnotation.returns(Promise.resolve());
       var el = createDirective().element;
-      var flagBtn = findActionButton(el, 'Flag');
+      var flagBtn = findActionButton(el, 'Report this annotation to the moderators');
       flagBtn.onClick();
       assert.called(fakeAnnotationMapper.flagAnnotation);
     });
@@ -1128,7 +1128,7 @@ describe('annotation', function() {
     it('highlights the "Flag" button if the annotation is flagged', function () {
       var ann = Object.assign(fixtures.defaultAnnotation(), { flagged: true });
       var el = createDirective(ann).element;
-      var flaggedBtn = findActionButton(el, 'Annotation has been flagged');
+      var flaggedBtn = findActionButton(el, 'Annotation has been reported to the moderators');
       assert.ok(flaggedBtn);
     });
   });

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -145,14 +145,14 @@
         <annotation-action-button
          icon="'h-icon-annotation-flag'"
          is-disabled="vm.isDeleted()"
-         label="'Flag'"
+         label="'Report this annotation to the moderators'"
          ng-if="!vm.isFlagged()"
          on-click="vm.flag()"
         ></annotation-action-button>
         <annotation-action-button
          icon="'h-icon-annotation-flag annotation--flagged'"
          is-disabled="vm.isDeleted()"
-         label="'Annotation has been flagged'"
+         label="'Annotation has been reported to the moderators'"
          ng-if="vm.isFlagged()"
         ></annotation-action-button>
       </span>


### PR DESCRIPTION
The flag button on an annotation has a tooltip that says simply "Flag"
(or "Annotation has been flagged" if it's already flagged) but there's
no indication to the user what flagging is or does (even when they click
the button, all that happens is the flag turns red):

![screenshot from 2017-04-26 16-21-46](https://cloud.githubusercontent.com/assets/22498/25442734/baf255b0-2a9d-11e7-8362-a6a0d76b1199.png)

![screenshot from 2017-04-26 16-22-06](https://cloud.githubusercontent.com/assets/22498/25442746/c1e1925a-2a9d-11e7-99bf-04c957f32f9a.png)

(or, err, _blue??_ not sure what happened in this screenshot)

"Flagging" can certainly be misinterpreted. I think some apps use it as
a way to keep track of "special" or "favorite" items (usually called
"starring" in most modern apps), or have a variety of different "flags"
that you can apply to an email or whatever it is (important, work,
personal, etc, this is usually called "tagging" or "labelling" in most
modern apps).

This commit changes the tooltips to clarify that what the button does is
report the annotation to the moderators. I've used the verb "report"
rather than "flag" as I think "Report this annotation to the moderators"
sounds better than "Flag this annotation to the moderators".  Either way
I think "to the moderators" is important to clarify that this button
sends a message to the moderators and isn't, for example, just flagging
for personal use like starring / tagging / labeling.

![peek 2017-04-26 16-34](https://cloud.githubusercontent.com/assets/22498/25443004/8230b70c-2a9e-11e7-8fde-88491a6c7556.gif)