### PR TITLE
Don't show duplicate toastr messages at once

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -82,6 +82,13 @@ function configureRoutes($routeProvider) {
 }
 
 // @ngInject
+function configureToastr(toastrConfig) {
+  angular.extend(toastrConfig, {
+    preventOpenDuplicates: true,
+  });
+}
+
+// @ngInject
 function configureHttp($httpProvider) {
   // Use the Pyramid XSRF header name
   $httpProvider.defaults.xsrfHeaderName = 'X-CSRF-Token';
@@ -208,6 +215,7 @@ module.exports = angular.module('h', [
   .config(configureHttp)
   .config(configureLocation)
   .config(configureRoutes)
+  .config(configureToastr)
 
   .run(setupHttp);
 


### PR DESCRIPTION
On master if the user repeatedly takes some action that produces a toastr message (for example: repeatedly clicking on the flag button when they can't actually flag an annotation because they're not logged in) then we get a stack of duplicate toastr messages filling the screen and obscuring most of the sidebar.

There are many ways that these duplicate toastr messages do happen in our UX. For example just repeatedly click on the flag button on an annotation while not logged in. Or you can hack h to error when you try to create an annotation:

```diff
diff --git a/h/views/api.py b/h/views/api.py
index c6b7dccc1..0bd5ef4d4 100644
--- a/h/views/api.py
+++ b/h/views/api.py
@@ -206,6 +206,7 @@ def search(request):
             description='Create an annotation')
 def create(request):
     """Create an annotation from the POST payload."""
+    raise PayloadError()
     schema = CreateAnnotationSchema(request)
     appstruct = schema.validate(_json_payload(request))
     group_service = request.find_service(IGroupService)
```

Then just try to create an annotation and hit the _Post_ button repeatedly:

![peek 2017-04-27 12-07](https://cloud.githubusercontent.com/assets/22498/25480957/0cdeb800-2b43-11e7-8106-df3aaf56671a.gif)

Prevent this by configuring toastr to not show duplicate messages. If the user takes some action that would produce a toastr message, and the same exact toastr message is already on screen, then just nothing happens (I think it might refresh the lifetime until the message disappears, but not sure):

![peek 2017-04-27 12-08](https://cloud.githubusercontent.com/assets/22498/25480977/194c0a2a-2b43-11e7-8022-642a480db995.gif)

This has to be set globally for all toastr messages, can't be set on a per-message basis, due to a limitation of angular-toastr: https://github.com/Foxandxss/angular-toastr/issues/168#issuecomment-190223264

I say "if the user takes an action" but of course this applies whenever the code shows a toastr message, in response to a user action or not.