### PR TITLE
Show error messages when OAuth access token and refresh token requests fail

### DIFF
--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -11,7 +11,7 @@ var resolve = require('./util/url-util').resolve;
  * an opaque access token.
  */
 // @ngInject
-function auth($http, settings) {
+function auth($http, flash, settings) {
 
   var accessTokenPromise;
   var tokenUrl = resolve('token', settings.apiUrl);
@@ -101,6 +101,17 @@ function auth($http, settings) {
         accessTokenPromise = exchangeToken(grantToken).then(function (tokenInfo) {
           refreshAccessTokenBeforeItExpires(tokenInfo);
           return tokenInfo.accessToken;
+        }).catch(function(err) {
+          flash.error(
+            'You must reload the page to annotate.',
+            'Hypothesis login failed',
+            {
+              extendedTimeOut: 0,
+              tapToDismiss: false,
+              timeOut: 0,
+            }
+          );
+          throw err;
         });
       } else {
         accessTokenPromise = Promise.resolve(null);

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -74,6 +74,16 @@ function auth($http, flash, settings) {
       var tokenInfo = tokenInfoFrom(response);
       refreshAccessTokenBeforeItExpires(tokenInfo);
       accessTokenPromise = Promise.resolve(tokenInfo.accessToken);
+    }).catch(function() {
+      flash.error(
+        'You must reload the page to continue annotating.',
+        'Hypothesis login lost',
+        {
+          extendedTimeOut: 0,
+          tapToDismiss: false,
+          timeOut: 0,
+        }
+      );
     });
   }
 

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -9,6 +9,7 @@ describe('oauth auth', function () {
   var auth;
   var nowStub;
   var fakeHttp;
+  var fakeFlash;
   var fakeSettings;
   var clock;
 
@@ -27,6 +28,10 @@ describe('oauth auth', function () {
       })),
     };
 
+    fakeFlash = {
+      error: sinon.stub(),
+    };
+
     fakeSettings = {
       apiUrl: 'https://hypothes.is/api/',
       services: [{
@@ -35,7 +40,7 @@ describe('oauth auth', function () {
       }],
     };
 
-    auth = authService(fakeHttp, fakeSettings);
+    auth = authService(fakeHttp, fakeFlash, fakeSettings);
 
     clock = sinon.useFakeTimers();
   });
@@ -104,7 +109,7 @@ describe('oauth auth', function () {
     });
 
     it('should return null if no grant token was provided', function () {
-      var auth = authService(fakeHttp, {
+      var auth = authService(fakeHttp, fakeFlash, {
         services: [{authority: 'publisher.org'}],
       });
       return auth.tokenGetter().then(function (token) {


### PR DESCRIPTION
Show an error if the initial request for an OAuth access token or a later request to refresh an access token fails.

When the client is embedded in a page that includes a services
configuration setting (see <http://h.readthedocs.io/projects/client/en/latest/publishers/config/#cmdoption-arg-services>)
then it tries to login to Hypothesis using OAuth, exchanging the grant
token from the services config setting for an access token from the
Hypothesis API.

If this request for an access token fails (for example, if the
Hypothesis server responds with an error) then the client ends up in an
invalid state. Some of the sidebar components are not fully rendered,
with visible parts missing, no annotations are shown, and actions such
as trying to create an annotation fail in broken ways.

For example you can hack h to always return an error for the access token request like this:

```diff
diff --git a/h/services/oauth.py b/h/services/oauth.py
index ca2745c3d..140dc9f9b 100644
--- a/h/services/oauth.py
+++ b/h/services/oauth.py
@@ -69,6 +69,8 @@ class OAuthService(object):
         :returns: a tuple with the user and authclient
         :rtype: tuple
         """
+        raise OAuthTokenError('Not a valid grant token',
+                              'invalid_request')
         if 'assertion' not in body:
             raise OAuthTokenError('required assertion parameter is missing',
                                   'invalid_request')
```

and then the client will look like this:

![peek 2017-04-27 13-30](https://cloud.githubusercontent.com/assets/22498/25483447/c8b55c96-2b4d-11e7-8e2e-fa15fe38ad2a.gif)

We should really fix the completely broken appearance and behavior of
the client in this state, but that'll be a big job. For now, at least show an
error message to the user telling them that they need to reload the page:

![peek 2017-04-27 13-33](https://cloud.githubusercontent.com/assets/22498/25483524/2347f9ac-2b4e-11e7-80c1-de0a3384581a.gif)

(This error message doesn't disappear until the page reloads, not even if the user clicks on it.)

There's currently no facility to retry the access token request but if
the user reloads the page the whole process will begin again and the
request will be tried again.

Additionally, when embedded in a publisher site like this the client needs to refresh the access token every hour. If the refresh request fails then things stop working. For example here trying to dismiss the sidebar tutorial fails silently, while trying to create an annotation gives an unfriendly error message:

![peek 2017-04-27 14-44](https://cloud.githubusercontent.com/assets/22498/25486112/0ba3388e-2b58-11e7-9bbe-55049b17ef99.gif)

You can hack h to make access tokens expire after 5 seconds and to make all requests to refresh them fail like this:

```diff
diff --git a/h/services/oauth.py b/h/services/oauth.py
index ca2745c3d..f0e8e098c 100644
--- a/h/services/oauth.py
+++ b/h/services/oauth.py
@@ -12,7 +12,7 @@ from h.exceptions import OAuthTokenError
 from h._compat import text_type
 
 # TTL of an OAuth token
-TOKEN_TTL = datetime.timedelta(hours=1)
+TOKEN_TTL = datetime.timedelta(seconds=5)
 
 
 class OAuthService(object):
@@ -103,6 +103,9 @@ class OAuthService(object):
                 raise
 
     def _verify_refresh_token(self, body):
+        raise OAuthTokenError('not valid',
+                              'invalid_request')
+
         refresh_token = body.get('refresh_token')
 
         if not refresh_token:
```

Again, the user has to reload the page. We don't retry the refresh request (and even if we did, once the access token has expired it can no longer succeed). When a refresh request fails show a permanent error message telling the user to reload the page:

![peek 2017-04-27 14-45](https://cloud.githubusercontent.com/assets/22498/25486323/b073c39c-2b58-11e7-9795-ac8a21dca287.gif)