### PR TITLE
Allow publishers to customize "Sign up" link handling

### DIFF
--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -159,6 +159,14 @@ loads.
      :option:`grantToken` for the logged-in user in the :option:`services`
      configuration setting.
 
+   .. option:: onSignupRequest
+
+     ``function``. A JavaScript function that will be called when the user clicks
+     the "Sign up" link in the sidebar. No arguments are passed and the return
+     value is unused.
+
+     This setting can only be set using :js:func:`window.hypothesisConfig`.
+
 .. option:: branding
 
   Branding lets you adjust certain aspects of the sidebar's look and feel to better fit your site's own look.

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -67,11 +67,11 @@ module.exports = class Sidebar extends Host
 
     @crossframe.on('show', => this.show())
     @crossframe.on('hide', => this.hide())
-    @crossframe.on(events.DO_LOGIN, =>
+    @crossframe.on(events.LOGIN_REQUESTED, =>
       if @onLoginRequest
         @onLoginRequest()
     );
-    @crossframe.on(events.DO_SIGNUP, =>
+    @crossframe.on(events.SIGNUP_REQUESTED, =>
       if @onSignupRequest
         @onSignupRequest()
     );

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -36,8 +36,11 @@ module.exports = class Sidebar extends Host
     if @plugins.Toolbar?
       this._setupGestures()
 
-    # The partner-provided login callback function (if any).
-    @onLoginRequest = options.services?[0]?.onLoginRequest
+    # The partner-provided callback functions.
+    serviceConfig = options.services?[0]
+    if serviceConfig
+      @onLoginRequest = serviceConfig.onLoginRequest
+      @onSignupRequest = serviceConfig.onSignupRequest
 
     this._setupSidebarEvents()
 
@@ -67,6 +70,10 @@ module.exports = class Sidebar extends Host
     @crossframe.on(events.DO_LOGIN, =>
       if @onLoginRequest
         @onLoginRequest()
+    );
+    @crossframe.on(events.DO_SIGNUP, =>
+      if @onSignupRequest
+        @onSignupRequest()
     );
 
     # Return this for chaining

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -111,6 +111,16 @@ describe 'Sidebar', ->
         sidebar = createSidebar(options={services: [{}]})
         emitEvent(events.DO_LOGIN)
 
+    describe 'on DO_SIGNUP event', ->
+      it 'calls the onSignupRequest callback function', ->
+        onSignupRequest = sandbox.stub()
+        sidebar = createSidebar(options={services: [{onSignupRequest: onSignupRequest}]})
+
+        emitEvent(events.DO_SIGNUP)
+
+        assert.called(onSignupRequest)
+
+
   describe 'pan gestures', ->
     sidebar = null
 

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -47,12 +47,12 @@ describe 'Sidebar', ->
         emitEvent('hide')
         assert.called(target)
 
-    describe 'on DO_LOGIN event', ->
+    describe 'on LOGIN_REQUESTED event', ->
       it 'calls the onLoginRequest callback function if one was provided', ->
         onLoginRequest = sandbox.stub()
         sidebar = createSidebar(options={services: [{onLoginRequest: onLoginRequest}]})
 
-        emitEvent(events.DO_LOGIN)
+        emitEvent(events.LOGIN_REQUESTED)
 
         assert.called(onLoginRequest)
 
@@ -73,7 +73,7 @@ describe 'Sidebar', ->
           }
         )
 
-        emitEvent(events.DO_LOGIN)
+        emitEvent(events.LOGIN_REQUESTED)
 
         assert.called(firstOnLogin)
         assert.notCalled(secondOnLogin)
@@ -94,29 +94,29 @@ describe 'Sidebar', ->
           }
         )
 
-        emitEvent(events.DO_LOGIN)
+        emitEvent(events.LOGIN_REQUESTED)
 
         assert.notCalled(secondOnLogin)
         assert.notCalled(thirdOnLogin)
 
       it 'does not crash if there is no services', ->
         sidebar = createSidebar(options={})  # No options.services
-        emitEvent(events.DO_LOGIN)
+        emitEvent(events.LOGIN_REQUESTED)
 
       it 'does not crash if services is an empty array', ->
         sidebar = createSidebar(options={services: []})
-        emitEvent(events.DO_LOGIN)
+        emitEvent(events.LOGIN_REQUESTED)
 
       it 'does not crash if the first service has no onLoginRequest', ->
         sidebar = createSidebar(options={services: [{}]})
-        emitEvent(events.DO_LOGIN)
+        emitEvent(events.LOGIN_REQUESTED)
 
-    describe 'on DO_SIGNUP event', ->
+    describe 'on SIGNUP_REQUESTED event', ->
       it 'calls the onSignupRequest callback function', ->
         onSignupRequest = sandbox.stub()
         sidebar = createSidebar(options={services: [{onSignupRequest: onSignupRequest}]})
 
-        emitEvent(events.DO_SIGNUP)
+        emitEvent(events.SIGNUP_REQUESTED)
 
         assert.called(onSignupRequest)
 

--- a/src/shared/bridge-events.js
+++ b/src/shared/bridge-events.js
@@ -17,6 +17,11 @@ module.exports = {
    */
   DO_LOGIN: 'doLogin',
 
+  /**
+   * The sidebar is asking the annotator to do a parter site sign-up.
+   */
+  DO_SIGNUP: 'doSignup',
+
   // Events that the annotator sends to the sidebar
   // ----------------------------------------------
 };

--- a/src/shared/bridge-events.js
+++ b/src/shared/bridge-events.js
@@ -15,12 +15,12 @@ module.exports = {
    *  (for example, pop up a login window). This is used when the client is
    *  embedded in a partner site and a login button in the client is clicked.
    */
-  DO_LOGIN: 'doLogin',
+  LOGIN_REQUESTED: 'loginRequested',
 
   /**
    * The sidebar is asking the annotator to do a parter site sign-up.
    */
-  DO_SIGNUP: 'doSignup',
+  SIGNUP_REQUESTED: 'signupRequested',
 
   // Events that the annotator sends to the sidebar
   // ----------------------------------------------

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -93,6 +93,7 @@ function HypothesisAppController(
   // Start the login flow. This will present the user with the login dialog.
   this.login = function () {
     if (serviceConfig(settings)) {
+      // Let the host page handle the login request
       bridge.call(bridgeEvents.DO_LOGIN);
       return;
     }
@@ -103,6 +104,13 @@ function HypothesisAppController(
 
   this.signUp = function(){
     analytics.track(analytics.events.SIGN_UP_REQUESTED);
+
+    if (serviceConfig(settings)) {
+      // Let the host page handle the signup request
+      bridge.call(bridgeEvents.DO_SIGNUP);
+      return;
+    }
+    $window.open(serviceUrl('signup'));
   };
 
   // Display the dialog for sharing the current page

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -94,7 +94,7 @@ function HypothesisAppController(
   this.login = function () {
     if (serviceConfig(settings)) {
       // Let the host page handle the login request
-      bridge.call(bridgeEvents.DO_LOGIN);
+      bridge.call(bridgeEvents.LOGIN_REQUESTED);
       return;
     }
 
@@ -107,7 +107,7 @@ function HypothesisAppController(
 
     if (serviceConfig(settings)) {
       // Let the host page handle the signup request
-      bridge.call(bridgeEvents.DO_SIGNUP);
+      bridge.call(bridgeEvents.SIGNUP_REQUESTED);
       return;
     }
     $window.open(serviceUrl('signup'));

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -269,10 +269,10 @@ describe('hypothesisApp', function () {
         fakeServiceConfig.returns({});
       });
 
-      it('sends DO_SIGNUP event', function () {
+      it('sends SIGNUP_REQUESTED event', function () {
         var ctrl = createController();
         ctrl.signUp();
-        assert.calledWith(fakeBridge.call, bridgeEvents.DO_SIGNUP);
+        assert.calledWith(fakeBridge.call, bridgeEvents.SIGNUP_REQUESTED);
       });
 
       it('does not open a URL directly', function () {
@@ -301,9 +301,9 @@ describe('hypothesisApp', function () {
       assert.equal(ctrl.accountDialog.visible, true);
     });
 
-    it('sends DO_LOGIN if a third-party service is in use', function () {
+    it('sends LOGIN_REQUESTED if a third-party service is in use', function () {
       // If the client is using a third-party annotation service then clicking
-      // on a login button should send the DO_LOGIN event over the bridge
+      // on a login button should send the LOGIN_REQUESTED event over the bridge
       // (so that the partner site we're embedded in can do its own login
       // thing).
       fakeServiceConfig.returns({});
@@ -312,7 +312,7 @@ describe('hypothesisApp', function () {
       ctrl.login();
 
       assert.equal(fakeBridge.call.callCount, 1);
-      assert.isTrue(fakeBridge.call.calledWithExactly(bridgeEvents.DO_LOGIN));
+      assert.isTrue(fakeBridge.call.calledWithExactly(bridgeEvents.LOGIN_REQUESTED));
     });
   });
 

--- a/src/sidebar/templates/login-control.html
+++ b/src/sidebar/templates/login-control.html
@@ -3,7 +3,7 @@
       ng-if="vm.newStyle && vm.auth.status === 'unknown'">⋯</span>
 <span class="login-text"
       ng-if="vm.newStyle && vm.auth.status === 'logged-out'">
-  <a href="{{vm.serviceUrl('signup')}}" ng-click="vm.onSignUp()" target="_blank" h-branding="highlightColor">Sign up</a>
+  <a href="" ng-click="vm.onSignUp()" target="_blank" h-branding="highlightColor">Sign up</a>
   / <a href="" ng-click="vm.onLogin()" h-branding="highlightColor">Log in</a>
 </span>
 <div ng-if="vm.newStyle"


### PR DESCRIPTION
Allow third-party annotation services to customize sign-up link handling
    
Allow third-party annotation services to define an `onSignupRequest` callback which is
invoked to handle the "Sign up" link in the client, in a similar way to
how the "Login" link is handled in this case.

Fixes https://github.com/hypothesis/product-backlog/issues/286