### PR TITLE
Allow publishers to customize log out, profile and help links

### DIFF
--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -187,6 +187,14 @@ loads.
 
      This setting can only be set using :js:func:`window.hypothesisConfig`.
 
+   .. option:: onProfileRequest
+
+     ``function``. A JavaScript function that will be called when the user clicks
+     the user profile (user name) link in the sidebar. No arguments are passed
+     and the return value is unused.
+
+     This setting can only be set using :js:func:`window.hypothesisConfig`.
+
 .. option:: branding
 
   Branding lets you adjust certain aspects of the sidebar's look and feel to better fit your site's own look.

--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -159,6 +159,26 @@ loads.
      :option:`grantToken` for the logged-in user in the :option:`services`
      configuration setting.
 
+   .. option:: onLogoutRequest
+
+     ``function``. A JavaScript function that the Hypothesis client will
+     call in order to log out (for example, when the user clicks a log out
+     button in the Hypothesis client's sidebar).
+
+     This setting can only be set using :js:func:`window.hypothesisConfig`.
+
+     If the hosting page provides an :option:`onLogoutRequest` function then
+     the Hypothesis client will call this function instead of doing its usual
+     procedure for logging out of the public service at
+     `hypothes.is <https://hypothes.is/>`_.
+
+     No arguments are passed to the :option:`onLogoutRequest` function.
+
+     The :option:`onLogoutRequest` function should cause a log out procedure
+     for the hosting page to be performed. After a successful log out the
+     hosting page should reload the original page with no :option:`grantToken`
+     in the :option:`services` configuration setting.
+
    .. option:: onSignupRequest
 
      ``function``. A JavaScript function that will be called when the user clicks

--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -195,6 +195,14 @@ loads.
 
      This setting can only be set using :js:func:`window.hypothesisConfig`.
 
+   .. option:: onHelpRequest
+
+     ``function``. A JavaScript function that will be called when the user clicks
+     the "Help" link in the sidebar. No arguments are passed and the return
+     value is unused.
+
+     This setting can only be set using :js:func:`window.hypothesisConfig`.
+
 .. option:: branding
 
   Branding lets you adjust certain aspects of the sidebar's look and feel to better fit your site's own look.

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -4,6 +4,24 @@ Guest = require('./guest')
 
 module.exports = class Host extends Guest
   constructor: (element, options) ->
+
+    # Some options' values are not JSON-stringifiable (e.g. JavaScript
+    # functions) and will be omitted when the options are JSON-stringified.
+    # Add a JSON-stringifiable option for each of these so that the sidebar can
+    # at least know whether the callback functions were provided or not.
+    if options.services?[0]
+      service = options.services[0]
+      if service.onLoginRequest
+        service.onLoginRequestProvided = true
+      if service.onLogoutRequest
+        service.onLogoutRequestProvided = true
+      if service.onSignupRequest
+        service.onSignupRequestProvided = true
+      if service.onProfileRequest
+        service.onProfileRequestProvided = true
+      if service.onHelpRequest
+        service.onHelpRequestProvided = true
+
     # Make a copy of all options except `options.app`, the app base URL, and `options.pluginClasses`
     configParam = 'config=' + encodeURIComponent(
       JSON.stringify(Object.assign({}, options, {app:undefined, pluginClasses: undefined }))

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -42,6 +42,7 @@ module.exports = class Sidebar extends Host
       @onLoginRequest = serviceConfig.onLoginRequest
       @onLogoutRequest = serviceConfig.onLogoutRequest
       @onSignupRequest = serviceConfig.onSignupRequest
+      @onProfileRequest = serviceConfig.onProfileRequest
 
     this._setupSidebarEvents()
     this._setupDocumentEvents()
@@ -80,6 +81,10 @@ module.exports = class Sidebar extends Host
     @crossframe.on(events.SIGNUP_REQUESTED, =>
       if @onSignupRequest
         @onSignupRequest()
+    );
+    @crossframe.on(events.PROFILE_REQUESTED, =>
+      if @onProfileRequest
+        @onProfileRequest()
     );
 
     # Return this for chaining

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -43,6 +43,7 @@ module.exports = class Sidebar extends Host
       @onLogoutRequest = serviceConfig.onLogoutRequest
       @onSignupRequest = serviceConfig.onSignupRequest
       @onProfileRequest = serviceConfig.onProfileRequest
+      @onHelpRequest = serviceConfig.onHelpRequest
 
     this._setupSidebarEvents()
     this._setupDocumentEvents()
@@ -85,6 +86,10 @@ module.exports = class Sidebar extends Host
     @crossframe.on(events.PROFILE_REQUESTED, =>
       if @onProfileRequest
         @onProfileRequest()
+    );
+    @crossframe.on(events.HELP_REQUESTED, =>
+      if @onHelpRequest
+        @onHelpRequest()
     );
 
     # Return this for chaining

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -40,6 +40,7 @@ module.exports = class Sidebar extends Host
     serviceConfig = options.services?[0]
     if serviceConfig
       @onLoginRequest = serviceConfig.onLoginRequest
+      @onLogoutRequest = serviceConfig.onLogoutRequest
       @onSignupRequest = serviceConfig.onSignupRequest
 
     this._setupSidebarEvents()
@@ -71,6 +72,10 @@ module.exports = class Sidebar extends Host
     @crossframe.on(events.LOGIN_REQUESTED, =>
       if @onLoginRequest
         @onLoginRequest()
+    );
+    @crossframe.on(events.LOGOUT_REQUESTED, =>
+      if @onLogoutRequest
+        @onLogoutRequest()
     );
     @crossframe.on(events.SIGNUP_REQUESTED, =>
       if @onSignupRequest

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -137,6 +137,15 @@ describe 'Sidebar', ->
 
         assert.called(onProfileRequest)
 
+    describe 'on HELP_REQUESTED event', ->
+      it 'calls the onHelpRequest callback function', ->
+        onHelpRequest = sandbox.stub()
+        sidebar = createSidebar(options={services: [{onHelpRequest: onHelpRequest}]})
+
+        emitEvent(events.HELP_REQUESTED)
+
+        assert.called(onHelpRequest)
+
   describe 'pan gestures', ->
     sidebar = null
 

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -110,6 +110,15 @@ describe 'Sidebar', ->
         sidebar = createSidebar(options={services: [{}]})
         emitEvent(events.LOGIN_REQUESTED)
 
+    describe 'on LOGOUT_REQUESTED event', ->
+      it 'calls the onLogoutRequest callback function', ->
+        onLogoutRequest = sandbox.stub()
+        sidebar = createSidebar(options={services: [{onLogoutRequest: onLogoutRequest}]})
+
+        emitEvent(events.LOGOUT_REQUESTED)
+
+        assert.called(onLogoutRequest)
+
     describe 'on SIGNUP_REQUESTED event', ->
       it 'calls the onSignupRequest callback function', ->
         onSignupRequest = sandbox.stub()

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -128,6 +128,14 @@ describe 'Sidebar', ->
 
         assert.called(onSignupRequest)
 
+    describe 'on PROFILE_REQUESTED event', ->
+      it 'calls the onProfileRequest callback function', ->
+        onProfileRequest = sandbox.stub()
+        sidebar = createSidebar(options={services: [{onProfileRequest: onProfileRequest}]})
+
+        emitEvent(events.PROFILE_REQUESTED)
+
+        assert.called(onProfileRequest)
 
   describe 'pan gestures', ->
     sidebar = null

--- a/src/shared/bridge-events.js
+++ b/src/shared/bridge-events.js
@@ -28,6 +28,11 @@ module.exports = {
    */
   SIGNUP_REQUESTED: 'signupRequested',
 
+  /**
+   * The sidebar is asking the annotator to open the partner site profile page.
+   */
+  PROFILE_REQUESTED: 'profileRequested',
+
   // Events that the annotator sends to the sidebar
   // ----------------------------------------------
 };

--- a/src/shared/bridge-events.js
+++ b/src/shared/bridge-events.js
@@ -17,6 +17,12 @@ module.exports = {
    */
   LOGIN_REQUESTED: 'loginRequested',
 
+  /** The sidebar is asking the annotator to do a partner site log out.
+   *  This is used when the client is embedded in a partner site and a log out
+   *  button in the client is clicked.
+   */
+  LOGOUT_REQUESTED: 'logoutRequested',
+
   /**
    * The sidebar is asking the annotator to do a partner site sign-up.
    */

--- a/src/shared/bridge-events.js
+++ b/src/shared/bridge-events.js
@@ -33,6 +33,11 @@ module.exports = {
    */
   PROFILE_REQUESTED: 'profileRequested',
 
+  /**
+   * The sidebar is asking the annotator to open the partner site help page.
+   */
+  HELP_REQUESTED: 'helpRequested',
+
   // Events that the annotator sends to the sidebar
   // ----------------------------------------------
 };

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -119,6 +119,17 @@ function HypothesisAppController(
     scrollToView('share-dialog');
   };
 
+  this.showHelpPanel = function () {
+    var service = serviceConfig(settings) || {};
+    if (service.onHelpRequestProvided) {
+      // Let the host page handle the help request.
+      bridge.call(bridgeEvents.HELP_REQUESTED);
+      return;
+    }
+
+    this.helpPanel.visible = true;
+  };
+
   // Prompt to discard any unsaved drafts.
   var promptToLogout = function () {
     // TODO - Replace this with a UI which doesn't look terrible.

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -142,6 +142,13 @@ function HypothesisAppController(
       $rootScope.$emit(events.ANNOTATION_DELETED, draft);
     });
     drafts.discard();
+
+    if (serviceConfig(settings)) {
+      // Let the host page handle the signup request
+      bridge.call(bridgeEvents.LOGOUT_REQUESTED);
+      return;
+    }
+
     this.accountDialog.visible = false;
     session.logout();
   };

--- a/src/sidebar/components/login-control.js
+++ b/src/sidebar/components/login-control.js
@@ -1,13 +1,16 @@
 'use strict';
 
+var bridgeEvents = require('../../shared/bridge-events');
 var persona = require('../filter/persona');
 var serviceConfig = require('../service-config');
 
 module.exports = {
   controllerAs: 'vm',
+
   //@ngInject
-  controller: function (serviceUrl, settings) {
+  controller: function (bridge, serviceUrl, settings, $window) {
     this.serviceUrl = serviceUrl;
+
     this.isThirdPartyUser = function() {
       return persona.isThirdPartyUser(this.auth.userid, settings.authDomain);
     };
@@ -23,7 +26,23 @@ module.exports = {
       return true;
     };
 
+    this.shouldEnableProfileButton = function () {
+      var service = serviceConfig(settings);
+      if (service) {
+        return service.onProfileRequestProvided;
+      }
+      return true;
+    };
+
+    this.showProfile = function () {
+      if (this.isThirdPartyUser()) {
+        bridge.call(bridgeEvents.PROFILE_REQUESTED);
+        return;
+      }
+      $window.open(this.serviceUrl('user', {user: this.auth.username}));
+    };
   },
+
   bindings: {
     /**
      * An object representing the current authentication status.

--- a/src/sidebar/components/login-control.js
+++ b/src/sidebar/components/login-control.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var persona = require('../filter/persona');
+var serviceConfig = require('../service-config');
 
 module.exports = {
   controllerAs: 'vm',
@@ -10,6 +11,18 @@ module.exports = {
     this.isThirdPartyUser = function() {
       return persona.isThirdPartyUser(this.auth.userid, settings.authDomain);
     };
+
+    this.shouldShowLogOutButton = function () {
+      if (this.auth.status !== 'logged-in') {
+        return false;
+      }
+      var service = serviceConfig(settings);
+      if (service && !service.onLogoutRequestProvided) {
+        return false;
+      }
+      return true;
+    };
+
   },
   bindings: {
     /**

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -292,6 +292,67 @@ describe('hypothesisApp', function () {
     });
   });
 
+  describe('#showHelpPanel', function () {
+    context('when using a third-party service', function () {
+      context("when there's no onHelpRequest callback function", function () {
+        beforeEach('configure a service with no onHelpRequest', function () {
+          fakeServiceConfig.returns({});
+        });
+
+        it('does not send an event', function () {
+          createController().showHelpPanel();
+
+          assert.notCalled(fakeBridge.call);
+        });
+
+        it('shows the help panel', function () {
+          var ctrl = createController();
+
+          ctrl.showHelpPanel();
+
+          assert.isTrue(ctrl.helpPanel.visible);
+        });
+      });
+
+      context("when there's an onHelpRequest callback function", function () {
+        beforeEach('provide an onHelpRequest callback', function () {
+          fakeServiceConfig.returns({onHelpRequestProvided: true});
+        });
+
+        it('sends the HELP_REQUESTED event', function () {
+          createController().showHelpPanel();
+
+          assert.calledWith(fakeBridge.call, bridgeEvents.HELP_REQUESTED);
+        });
+
+        it('does not show the help panel', function () {
+          var ctrl = createController();
+
+          ctrl.showHelpPanel();
+
+          assert.isFalse(ctrl.helpPanel.visible);
+        });
+      });
+
+    });
+
+    context('when not using a third-party service', function () {
+      it('does not send an event', function () {
+        createController().showHelpPanel();
+
+        assert.notCalled(fakeBridge.call);
+      });
+
+      it('shows the help panel', function () {
+        var ctrl = createController();
+
+        ctrl.showHelpPanel();
+
+        assert.isTrue(ctrl.helpPanel.visible);
+      });
+    });
+  });
+
   describe('#login()', function () {
     it('shows the login dialog if not using a third-party service', function () {
       // If no third-party annotation service is in use then it should show the

--- a/src/sidebar/components/test/login-control-test.js
+++ b/src/sidebar/components/test/login-control-test.js
@@ -4,24 +4,26 @@ var angular = require('angular');
 
 var util = require('../../directive/test/util');
 
-function PageObject(element) {
-  this.unknownLoginText = function () {
-    return element[0].querySelector('.login-text').textContent;
-  };
-  this.loginText = function () {
-    return Array.from(element[0].querySelectorAll('.login-text a'))
-      .map(function (el) { return el.textContent; });
-  };
-  this.menuLinks = function () {
-    return Array.from(element[0].querySelectorAll('.login-control-menu .dropdown-menu a'))
-      .map(function (el) { return el.textContent; });
-  };
-  this.disabledMenuItems = function () {
-    return Array.from(element[0].querySelectorAll('.login-control-menu .dropdown-menu__link--disabled'))
-      .map(function (el) { return el.textContent.trim(); });
-  };
-  this.menuText = function () {
-    return element[0].querySelector('span').textContent;
+function pageObject(element) {
+  return {
+    unknownLoginText: function () {
+      return element[0].querySelector('.login-text').textContent;
+    },
+    loginText: function () {
+      return Array.from(element[0].querySelectorAll('.login-text a'))
+        .map(function (el) { return el.textContent; });
+    },
+    menuLinks: function () {
+      return Array.from(element[0].querySelectorAll('.login-control-menu .dropdown-menu a'))
+                  .map(function (el) { return el.textContent; });
+    },
+    disabledMenuItems: function () {
+      return Array.from(element[0].querySelectorAll('.login-control-menu .dropdown-menu__link--disabled'))
+        .map(function (el) { return el.textContent.trim(); });
+    },
+    menuText: function () {
+      return element[0].querySelector('span').textContent;
+    },
   };
 }
 
@@ -58,10 +60,10 @@ describe('loginControl', function () {
         },
         newStyle: true,
       });
-      var pageObject = new PageObject(el);
+      var page = pageObject(el);
 
-      assert.equal(pageObject.unknownLoginText(), '⋯');
-      assert.deepEqual(pageObject.menuLinks(), ['Help']);
+      assert.equal(page.unknownLoginText(), '⋯');
+      assert.deepEqual(page.menuLinks(), ['Help']);
     });
   });
 
@@ -73,10 +75,10 @@ describe('loginControl', function () {
         },
         newStyle: true,
       });
-      var pageObject = new PageObject(el);
+      var page = pageObject(el);
 
-      assert.deepEqual(pageObject.loginText(), ['Sign up', 'Log in']);
-      assert.deepEqual(pageObject.menuLinks(), ['Help']);
+      assert.deepEqual(page.loginText(), ['Sign up', 'Log in']);
+      assert.deepEqual(page.menuLinks(), ['Help']);
     });
   });
 
@@ -89,9 +91,9 @@ describe('loginControl', function () {
         },
         newStyle: true,
       });
-      var pageObject = new PageObject(el);
+      var page = pageObject(el);
 
-      assert.deepEqual(pageObject.menuLinks(),
+      assert.deepEqual(page.menuLinks(),
         ['someUsername', 'Account settings', 'Help', 'Log out']);
     });
   });
@@ -106,10 +108,10 @@ describe('loginControl', function () {
         },
         newStyle: true,
       });
-      var pageObject = new PageObject(el);
+      var page = pageObject(el);
 
-      assert.deepEqual(pageObject.menuLinks(), ['Help']);
-      assert.deepEqual(pageObject.disabledMenuItems(), ['someUsername']);
+      assert.deepEqual(page.menuLinks(), ['Help']);
+      assert.deepEqual(page.disabledMenuItems(), ['someUsername']);
     });
   });
 
@@ -122,11 +124,11 @@ describe('loginControl', function () {
         },
         newStyle: false,
       });
-      var pageObject = new PageObject(el);
+      var page = pageObject(el);
 
-      assert.deepEqual(pageObject.menuLinks(),
+      assert.deepEqual(page.menuLinks(),
         ['Account', 'Help', 'My Annotations', 'Log out']);
-      assert.include(pageObject.menuText(), 'someUsername');
+      assert.include(page.menuText(), 'someUsername');
     });
   });
 
@@ -138,10 +140,10 @@ describe('loginControl', function () {
         },
         newStyle: false,
       });
-      var pageObject = new PageObject(el);
+      var page = pageObject(el);
 
-      assert.include(pageObject.menuText(), 'Log in');
-      assert.deepEqual(pageObject.menuLinks(), ['Help']);
+      assert.include(page.menuText(), 'Log in');
+      assert.deepEqual(page.menuLinks(), ['Help']);
     });
   });
 
@@ -153,10 +155,10 @@ describe('loginControl', function () {
         },
         newStyle: false,
       });
-      var pageObject = new PageObject(el);
+      var page = pageObject(el);
 
-      assert.equal(pageObject.menuText(), '⋯');
-      assert.deepEqual(pageObject.menuLinks(), ['Help']);
+      assert.equal(page.menuText(), '⋯');
+      assert.deepEqual(page.menuLinks(), ['Help']);
     });
   });
 });

--- a/src/sidebar/templates/hypothesis-app.html
+++ b/src/sidebar/templates/hypothesis-app.html
@@ -5,7 +5,7 @@
     on-sign-up="vm.signUp()"
     on-logout="vm.logout()"
     on-share-page="vm.share()"
-    on-show-help-panel="vm.helpPanel.visible = true"
+    on-show-help-panel="vm.showHelpPanel()"
     is-sidebar="::vm.isSidebar"
     pending-update-count="vm.countPendingUpdates()"
     on-apply-pending-updates="vm.applyPendingUpdates()"

--- a/src/sidebar/templates/login-control.html
+++ b/src/sidebar/templates/login-control.html
@@ -21,22 +21,22 @@
   <ul class="dropdown-menu pull-right" role="menu">
     <li class="dropdown-menu__row" ng-if="vm.auth.status === 'logged-in'">
       <span ng-if="vm.isThirdPartyUser()"
-            class="dropdown-menu__link dropdown-menu__link--disabled">
+            class="dropdown-menu__link dropdown-menu__link--disabled dropdown-menu__disabled-user-profile-btn">
         {{vm.auth.username}}</span>
       <a ng-if="!vm.isThirdPartyUser()"
          href="{{vm.serviceUrl('user',{user: vm.auth.username})}}"
-         class="dropdown-menu__link"
+         class="dropdown-menu__link dropdown-menu__user-profile-btn"
          title="View all your annotations"
          target="_blank">{{vm.auth.username}}</a>
     </li>
     <li class="dropdown-menu__row" ng-if="vm.auth.status === 'logged-in' && !vm.isThirdPartyUser()">
-      <a class="dropdown-menu__link" href="{{vm.serviceUrl('account.settings')}}" target="_blank">Account settings</a>
+      <a class="dropdown-menu__link dropdown-menu__account-settings-btn" href="{{vm.serviceUrl('account.settings')}}" target="_blank">Account settings</a>
     </li>
     <li class="dropdown-menu__row">
-      <a class="dropdown-menu__link" ng-click="vm.onShowHelpPanel()">Help</a>
+      <a class="dropdown-menu__link dropdown-menu__help-btn" ng-click="vm.onShowHelpPanel()">Help</a>
     </li>
     <li class="dropdown-menu__row" ng-if="vm.auth.status === 'logged-in' && !vm.isThirdPartyUser()">
-      <a class="dropdown-menu__link dropdown-menu__link--subtle"
+      <a class="dropdown-menu__link dropdown-menu__link--subtle dropdown-menu__log-out-btn"
          href="" ng-click="vm.onLogout()">Log out</a>
     </li>
   </ul>

--- a/src/sidebar/templates/login-control.html
+++ b/src/sidebar/templates/login-control.html
@@ -35,7 +35,7 @@
     <li class="dropdown-menu__row">
       <a class="dropdown-menu__link dropdown-menu__help-btn" ng-click="vm.onShowHelpPanel()">Help</a>
     </li>
-    <li class="dropdown-menu__row" ng-if="vm.auth.status === 'logged-in' && !vm.isThirdPartyUser()">
+    <li class="dropdown-menu__row" ng-if="vm.shouldShowLogOutButton()">
       <a class="dropdown-menu__link dropdown-menu__link--subtle dropdown-menu__log-out-btn"
          href="" ng-click="vm.onLogout()">Log out</a>
     </li>

--- a/src/sidebar/templates/login-control.html
+++ b/src/sidebar/templates/login-control.html
@@ -20,11 +20,11 @@
   </a>
   <ul class="dropdown-menu pull-right" role="menu">
     <li class="dropdown-menu__row" ng-if="vm.auth.status === 'logged-in'">
-      <span ng-if="vm.isThirdPartyUser()"
+      <span ng-if="!vm.shouldEnableProfileButton()"
             class="dropdown-menu__link dropdown-menu__link--disabled dropdown-menu__disabled-user-profile-btn">
         {{vm.auth.username}}</span>
-      <a ng-if="!vm.isThirdPartyUser()"
-         href="{{vm.serviceUrl('user',{user: vm.auth.username})}}"
+      <a ng-if="vm.shouldEnableProfileButton()"
+         ng-click="vm.showProfile()"
          class="dropdown-menu__link dropdown-menu__user-profile-btn"
          title="View all your annotations"
          target="_blank">{{vm.auth.username}}</a>


### PR DESCRIPTION
Add new `onLogoutRequested`, `onProfileRequested` and `onHelpRequested` settings to the service configuration, enabling partner sites that embed Hypothesis to provide JavaScript callback functions that will be called instead of the normal behavior when the user clicks on the log out, profile (username) or help buttons in the sidebar.

Corresponding publisher test site pull request: https://github.com/hypothesis/publisher-account-test-site/pull/21