### PR TITLE
Use `serviceConfig()` everywhere

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var addAnalytics = require('./ga');
+var serviceConfig = require('./service-config');
 require('../shared/polyfills');
 
 var raven;
@@ -106,7 +107,7 @@ function processAppOpts() {
 }
 
 var authService;
-if (Array.isArray(settings.services)) {
+if (serviceConfig(settings)) {
   authService = require('./oauth-auth');
 } else {
   authService = require('./auth');

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -3,6 +3,7 @@
 var queryString = require('query-string');
 
 var resolve = require('./util/url-util').resolve;
+var serviceConfig = require('./service-config');
 
 /**
  * OAuth-based authentication service used for publisher accounts.
@@ -127,11 +128,7 @@ function auth($http, flash, settings) {
 
   function tokenGetter() {
     if (!accessTokenPromise) {
-      var grantToken;
-
-      if (Array.isArray(settings.services) && settings.services.length > 0) {
-        grantToken = settings.services[0].grantToken;
-      }
+      var grantToken = (serviceConfig(settings) || {}).grantToken;
 
       if (grantToken) {
         accessTokenPromise = exchangeToken(grantToken).then(function (tokenInfo) {

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -4,6 +4,7 @@ var angular = require('angular');
 
 var events = require('./events');
 var retryUtil = require('./retry-util');
+var serviceConfig = require('./service-config');
 
 var CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
@@ -63,10 +64,11 @@ function session($http, $q, $resource, $rootScope, analytics, annotationUI, auth
   // Return the authority from the first service defined in the settings.
   // Return null if there are no services defined in the settings.
   function getAuthority() {
-    if (Array.isArray(settings.services) && settings.services.length > 0) {
-      return settings.services[0].authority;
+    var service = serviceConfig(settings);
+    if (service === null) {
+      return null;
     }
-    return null;
+    return service.authority;
   }
 
   /**


### PR DESCRIPTION
Always use `serviceConfig()` instead of accessing `settings.services`
directly.