### PR TITLE
Update jQuery to current version & slim build

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "inherits": "^2.0.1",
     "isparta": "^4.0.0",
     "istanbul": "^0.4.5",
-    "jquery": "1.11.1",
+    "jquery": "^3.2.1",
     "js-polyfills": "^0.1.16",
     "karma": "^1.1.0",
     "karma-browserify": "^5.0.5",
@@ -122,7 +122,8 @@
     ]
   },
   "browser": {
-    "hammerjs": "./node_modules/hammerjs/hammer.js"
+    "hammerjs": "./node_modules/hammerjs/hammer.js",
+    "jquery": "./node_modules/jquery/dist/jquery.slim.js"
   },
   "browserify-shim": {
     "angular": {

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -127,15 +127,15 @@ describe 'Sidebar', ->
       sidebar = createSidebar({})
 
     describe 'panstart event', ->
-      beforeEach ->
-        sandbox.stub(window, 'getComputedStyle').returns({marginLeft: '100px'})
+      it 'disables pointer events and transitions on the widget', ->
         sidebar.onPan({type: 'panstart'})
 
-      it 'disables pointer events and transitions on the widget', ->
         assert.isTrue(sidebar.frame.hasClass('annotator-no-transition'))
         assert.equal(sidebar.frame.css('pointer-events'), 'none')
 
       it 'captures the left margin as the gesture initial state', ->
+        sandbox.stub(window, 'getComputedStyle').returns({marginLeft: '100px'})
+        sidebar.onPan({type: 'panstart'})
         assert.equal(sidebar.gestureState.initial, '100')
 
     describe 'panend event', ->

--- a/yarn.lock
+++ b/yarn.lock
@@ -3393,9 +3393,9 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-jquery@1.11.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.11.1.tgz#b6ec928590112ebed69e1e49cbfd0025ccd60ddb"
+jquery@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
 
 js-base64@^2.1.5, js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.1.9"


### PR DESCRIPTION
Update our horrifically old jQuery build which included workarounds for
browsers we no longer support (IE <= 8) to the current stable version of jQuery.

Also switch to using the [slim build](https://blog.jquery.com/2016/06/09/jquery-3-0-final-released/) which excludes features (AJAX, some JS animation effects) we don't
use.

This reduces the size of the minified jQuery bundle from 96KB to 68KB.