### PR TITLE
Add config option to show highlights only when sidebar is open

### DIFF
--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -71,8 +71,18 @@ loads.
 
 .. option:: showHighlights
 
-   ``Boolean``. Controls whether the in-document highlights are shown by default.
-   (Default: ``true``.)
+   ``String|Boolean``. Controls whether the in-document highlights are shown by default.
+   (Default: ``"always"``). Enum with the following values:
+
+   ``"always"`` - Highlights are always shown by default.
+
+   ``"never"`` - Highlights are never shown by default, the user must explicitly
+   enable them.
+
+   ``"whenSidebarOpen"`` - Highlights are only shown when the sidebar is open.
+
+   For backwards compatibility, this value can also be a boolean where ``true``
+   means ``"always"`` and ``false`` means ``"never"``.
 
 .. option:: services
 

--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -72,17 +72,20 @@ loads.
 .. option:: showHighlights
 
    ``String|Boolean``. Controls whether the in-document highlights are shown by default.
-   (Default: ``"always"``). Enum with the following values:
+   (Default: ``"always"``).
 
-   ``"always"`` - Highlights are always shown by default.
+   ``true`` or ``"always"`` - Highlights are always shown by default.
 
-   ``"never"`` - Highlights are never shown by default, the user must explicitly
+   ``false`` or ``"never"`` - Highlights are never shown by default, the user must explicitly
    enable them.
 
    ``"whenSidebarOpen"`` - Highlights are only shown when the sidebar is open.
 
-   For backwards compatibility, this value can also be a boolean where ``true``
-   means ``"always"`` and ``false`` means ``"never"``.
+   .. warning::
+
+      The "always", "never" and "whenSidebarOpen" values are currently still
+      experimental and may change in future. ``true`` and ``false`` values
+      are the stable API.
 
 .. option:: services
 

--- a/src/annotator/config.js
+++ b/src/annotator/config.js
@@ -33,6 +33,12 @@ function config(window_) {
     }
   }
 
+  // Convert legacy keys/values in options to corresponding current
+  // configuration.
+  if (typeof options.showHighlights === 'boolean') {
+    options.showHighlights = options.showHighlights ? 'always' : 'never';
+  }
+
   // Extract the default query from the URL.
   //
   // The Chrome extension or proxy may already have provided this config

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -35,8 +35,8 @@ module.exports = class Host extends Guest
       # Initialize tool state.
       if options.showHighlights == undefined
         # Highlights are on by default.
-        options.showHighlights = true
-      this.setVisibleHighlights(options.showHighlights)
+        options.showHighlights = 'always'
+      this.setVisibleHighlights(options.showHighlights == 'always')
 
       # Show the UI
       @frame.css('display', '')

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -175,6 +175,9 @@ module.exports = class Sidebar extends Host
       .removeClass('h-icon-chevron-left')
       .addClass('h-icon-chevron-right')
 
+    if @options.showHighlights == 'whenSidebarOpen'
+      @setVisibleHighlights(true)
+
   hide: ->
     @frame.css 'margin-left': ''
     @frame.addClass 'annotator-collapsed'
@@ -183,6 +186,9 @@ module.exports = class Sidebar extends Host
       @toolbar.find('[name=sidebar-toggle]')
       .removeClass('h-icon-chevron-right')
       .addClass('h-icon-chevron-left')
+
+    if @options.showHighlights == 'whenSidebarOpen'
+      @setVisibleHighlights(false)
 
   isOpen: ->
     !@frame.hasClass('annotator-collapsed')

--- a/src/annotator/test/config-test.js
+++ b/src/annotator/test/config-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var config = require('../config');
+var unroll = require('../../shared/test/util').unroll;
 
 describe('annotator configuration', function () {
   var fakeScriptConfig;
@@ -71,4 +72,15 @@ describe('annotator configuration', function () {
       annotations: '456',
     });
   });
+
+  unroll('migrates legacy config keys', function (testCase) {
+    fakeScriptConfig = JSON.stringify(testCase.config);
+    assert.deepEqual(config(fakeWindowBase), testCase.expectedConfig);
+  }, [{
+    config: { showHighlights: true },
+    expectedConfig: { app: 'app.html', showHighlights: 'always' },
+  },{
+    config: { showHighlights: false },
+    expectedConfig: { app: 'app.html', showHighlights: 'never' },
+  }]);
 });

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -206,3 +206,27 @@ describe 'Sidebar', ->
       sidebar.destroy()
       assert.called(fakeCrossFrame.destroy)
       assert.equal(sidebar.frame[0].parentElement, null)
+
+  describe '#show', ->
+
+    it 'shows highlights if "showHighlights" is set to "whenSidebarOpen"', ->
+      sidebar = createSidebar({ showHighlights: 'whenSidebarOpen' })
+      assert.isFalse sidebar.visibleHighlights
+      sidebar.show()
+      assert.isTrue sidebar.visibleHighlights
+
+    it 'does not show highlights otherwise', ->
+      sidebar = createSidebar({ showHighlights: 'never' })
+      assert.isFalse sidebar.visibleHighlights
+      sidebar.show()
+      assert.isFalse sidebar.visibleHighlights
+
+  describe '#hide', ->
+
+    it 'hides highlights if "showHighlights" is set to "whenSidebarOpen"', ->
+      sidebar = createSidebar({ showHighlights: 'whenSidebarOpen' })
+
+      sidebar.show()
+      sidebar.hide()
+
+      assert.isFalse sidebar.visibleHighlights


### PR DESCRIPTION
This PR implements a configuration option to only show highlights automatically when the sidebar is open. When the sidebar is open or closed the user can still toggle highlights on or off via the sidebar's vertical toolbar. The purpose of this is to enable a cleaner reading experience by default until the user chooses to view the annotation layer.

The "showHighlights" boolean configuration option has been changed to alternatively accept the enum values "always", "never" or "whenSidebarOpen". The boolean values `true` and `false` are mapped to `"always"` and `"never"` respectively.

The intended use of this option is that the sidebar is configured such that it will not overlap the main content of the page at the initial width. No such option currently exists, that will be a separate task.

Fixes https://github.com/hypothesis/product-backlog/issues/273