### PR TITLE
Try to be smart about choosing initial width of sidebar

### DIFF
--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -5,11 +5,11 @@ Hammer = require('hammerjs')
 Host = require('./host')
 annotationCounts = require('./annotation-counts')
 sidebarTrigger = require('./sidebar-trigger')
-events = require('../shared/bridge-events');
+smartInitialWidth = require('./smart-initial-width')
+events = require('../shared/bridge-events')
 
 # Minimum width to which the frame can be resized.
 MIN_RESIZE = 280
-
 
 module.exports = class Sidebar extends Host
   options:
@@ -118,10 +118,12 @@ module.exports = class Sidebar extends Host
 
       # Process the resize gesture
       if @gestureState.final isnt @gestureState.initial
-        m = @gestureState.final
-        w = -m
-        @frame.css('margin-left', "#{m}px")
-        if w >= MIN_RESIZE then @frame.css('width', "#{w}px")
+        @_setSidebarWidth(-@gestureState.final)
+
+  _setSidebarWidth: (width) ->
+    margin = -width
+    @frame.css('margin-left', "#{margin}px")
+    if width >= MIN_RESIZE then @frame.css('width', "#{width}px")
 
   onPan: (event) =>
     switch event.type
@@ -167,7 +169,12 @@ module.exports = class Sidebar extends Host
   show: ->
     @crossframe.call('sidebarOpened')
 
-    @frame.css 'margin-left': "#{-1 * @frame.width()}px"
+    initialWidth = smartInitialWidth({ min: MIN_RESIZE, max: 428 })
+    if initialWidth
+      @_setSidebarWidth(initialWidth)
+    else
+      @frame.css 'margin-left': "#{-1 * @frame.width()}px"
+
     @frame.removeClass 'annotator-collapsed'
 
     if @toolbar?

--- a/src/annotator/smart-initial-width.js
+++ b/src/annotator/smart-initial-width.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * Return a preferred initial width for the sidebar.
+ *
+ * Calculate a "preferred" initial width for the sidebar which will not overlap
+ * the main content of the page. This assumes that the main content is text
+ * contained in paragraphs. If no substantial text content can be found or there
+ * simply isn't room between the right edge of the content and the right edge of
+ * the window then this function will return `null`.
+ *
+ * @return {number|null} - Preferred width of the sidebar in px or null if
+ *   no ideal width could be determined.
+ */
+function smartInitialWidth(options) {
+  // Width in px of the "stops" for the left edge of the sidebar
+  var BUCKET_WIDTH = 20;
+
+  // Minimum length of paragraphs to consider when trying to find the main
+  // content for the article.
+  var MIN_PARA_LENGTH = 200;
+
+  // Margin to leave to the left of the sidebar app iframe
+  var SIDEBAR_LEFT_MARGIN = 15;
+
+  // Find the most dominant right edge for content in the document.
+  var includeP = function (el) {
+    return el.textContent.length > MIN_PARA_LENGTH && el.getBoundingClientRect().right > 10;
+  };
+
+  var paras = Array.from(document.querySelectorAll('p'))
+                   .filter(includeP);
+
+  // Buckets counting the total length of content which has its right edge
+  // within ranges of `BUCKET_WIDTH` pixels across the page.
+  var buckets = Array(100).fill(0);
+
+  paras.forEach(function (p) {
+    var idx = Math.floor(p.getBoundingClientRect().right / BUCKET_WIDTH);
+    buckets[idx] += p.textContent.length;
+  });
+
+  var maxLength = 0;
+  var maxLengthIdx = -1;
+
+  buckets.forEach(function (nChars, idx) {
+    if (nChars > maxLength) {
+      maxLength = nChars;
+      maxLengthIdx = idx;
+    }
+  });
+
+  if (maxLength < 300) {
+    return null;
+  }
+
+  // Calculate the preferred width of the sidebar given the position where the
+  // predominant right edge of the content is.
+  var idealLeftEdge = ((maxLengthIdx * BUCKET_WIDTH) + BUCKET_WIDTH + SIDEBAR_LEFT_MARGIN);
+  var defaultWidth = Math.min(options.max, window.innerWidth - idealLeftEdge);
+
+  if (defaultWidth < options.min) {
+    return null;
+  }
+
+  return defaultWidth;
+}
+
+module.exports = smartInitialWidth;


### PR DESCRIPTION
This is an attempt to make the client smart about choosing the initial width of the sidebar such that it does not overlap the main content of the page, using a fairly dumb algorithm to determine the right edge of the main content.

This is hopefully useful on many pages but especially for sites that choose to disable highlights except when the sidebar is open, as eLife would like to do.

An alternative approach for publishers would be to allow them to specify a fixed width for the sidebar or a main content container element. The advantage of an automated method is that it can work on pages that are not integrating the client themselves.