### PR TITLE
Include DOI in search URIs as a "doi:" URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Entries in this change log follow the format suggested at http://keepachangelog.
 
 # Change Log
 
-## [Unreleased]
+## [1.19.0] - 2017-05-23
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Entries in this change log follow the format suggested at http://keepachangelog.
 
 # Change Log
 
+## [Unreleased]
+
+### Changed
+
+- Reduce client size slightly by switching to jQuery slim build
+  ([#391](https://github.com/hypothesis/client/pull/391)).
+
+- Add config option to show highlights only when sidebar is open
+  ([#392](https://github.com/hypothesis/client/pull/392)).
+
 ## [1.18.0] - 2017-05-22
 
 ### Changed

--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -71,8 +71,21 @@ loads.
 
 .. option:: showHighlights
 
-   ``Boolean``. Controls whether the in-document highlights are shown by default.
-   (Default: ``true``.)
+   ``String|Boolean``. Controls whether the in-document highlights are shown by default.
+   (Default: ``"always"``).
+
+   ``true`` or ``"always"`` - Highlights are always shown by default.
+
+   ``false`` or ``"never"`` - Highlights are never shown by default, the user must explicitly
+   enable them.
+
+   ``"whenSidebarOpen"`` - Highlights are only shown when the sidebar is open.
+
+   .. warning::
+
+      The "always", "never" and "whenSidebarOpen" values are currently still
+      experimental and may change in future. ``true`` and ``false`` values
+      are the stable API.
 
 .. option:: services
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypothesis",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Annotate with anyone, anywhere.",
   "license": "BSD-2-Clause",
   "homepage": "https://hypothes.is",

--- a/src/annotator/config.js
+++ b/src/annotator/config.js
@@ -33,6 +33,12 @@ function config(window_) {
     }
   }
 
+  // Convert legacy keys/values in options to corresponding current
+  // configuration.
+  if (typeof options.showHighlights === 'boolean') {
+    options.showHighlights = options.showHighlights ? 'always' : 'never';
+  }
+
   // Extract the default query from the URL.
   //
   // The Chrome extension or proxy may already have provided this config

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -53,8 +53,8 @@ module.exports = class Host extends Guest
       # Initialize tool state.
       if options.showHighlights == undefined
         # Highlights are on by default.
-        options.showHighlights = true
-      this.setVisibleHighlights(options.showHighlights)
+        options.showHighlights = 'always'
+      this.setVisibleHighlights(options.showHighlights == 'always')
 
       # Show the UI
       @frame.css('display', '')

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -190,6 +190,9 @@ module.exports = class Sidebar extends Host
       .removeClass('h-icon-chevron-left')
       .addClass('h-icon-chevron-right')
 
+    if @options.showHighlights == 'whenSidebarOpen'
+      @setVisibleHighlights(true)
+
   hide: ->
     @frame.css 'margin-left': ''
     @frame.addClass 'annotator-collapsed'
@@ -198,6 +201,9 @@ module.exports = class Sidebar extends Host
       @toolbar.find('[name=sidebar-toggle]')
       .removeClass('h-icon-chevron-right')
       .addClass('h-icon-chevron-left')
+
+    if @options.showHighlights == 'whenSidebarOpen'
+      @setVisibleHighlights(false)
 
   isOpen: ->
     !@frame.hasClass('annotator-collapsed')

--- a/src/annotator/test/config-test.js
+++ b/src/annotator/test/config-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var config = require('../config');
+var unroll = require('../../shared/test/util').unroll;
 
 describe('annotator configuration', function () {
   var fakeScriptConfig;
@@ -71,4 +72,15 @@ describe('annotator configuration', function () {
       annotations: '456',
     });
   });
+
+  unroll('migrates legacy config keys', function (testCase) {
+    fakeScriptConfig = JSON.stringify(testCase.config);
+    assert.deepEqual(config(fakeWindowBase), testCase.expectedConfig);
+  }, [{
+    config: { showHighlights: true },
+    expectedConfig: { app: 'app.html', showHighlights: 'always' },
+  },{
+    config: { showHighlights: false },
+    expectedConfig: { app: 'app.html', showHighlights: 'never' },
+  }]);
 });

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -232,3 +232,27 @@ describe 'Sidebar', ->
       sidebar.destroy()
       assert.called(fakeCrossFrame.destroy)
       assert.equal(sidebar.frame[0].parentElement, null)
+
+  describe '#show', ->
+
+    it 'shows highlights if "showHighlights" is set to "whenSidebarOpen"', ->
+      sidebar = createSidebar({ showHighlights: 'whenSidebarOpen' })
+      assert.isFalse sidebar.visibleHighlights
+      sidebar.show()
+      assert.isTrue sidebar.visibleHighlights
+
+    it 'does not show highlights otherwise', ->
+      sidebar = createSidebar({ showHighlights: 'never' })
+      assert.isFalse sidebar.visibleHighlights
+      sidebar.show()
+      assert.isFalse sidebar.visibleHighlights
+
+  describe '#hide', ->
+
+    it 'hides highlights if "showHighlights" is set to "whenSidebarOpen"', ->
+      sidebar = createSidebar({ showHighlights: 'whenSidebarOpen' })
+
+      sidebar.show()
+      sidebar.hide()
+
+      assert.isFalse sidebar.visibleHighlights

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -472,20 +472,20 @@ describe('hypothesisApp', function () {
 
       doSharedTests();
 
-      it('sends LOGOUT_REQUESTED if a third-party service is in use', function () {
+      it('sends LOGOUT_REQUESTED', function () {
         createController().logout();
 
         assert.calledOnce(fakeBridge.call);
         assert.calledWithExactly(fakeBridge.call, bridgeEvents.LOGOUT_REQUESTED);
       });
 
-      it('does not send LOGIN_REQUESTED if the user cancels the prompt', function () {
+      it('does not send LOGOUT_REQUESTED if the user cancels the prompt', function () {
         fakeDrafts.count.returns(1);
         fakeWindow.confirm.returns(false);
 
         createController().logout();
 
-        assert.notCalled(fakeDrafts.discard);
+        assert.notCalled(fakeBridge.call);
       });
 
       it('does not call session.logout()', function () {

--- a/src/sidebar/components/test/login-control-test.js
+++ b/src/sidebar/components/test/login-control-test.js
@@ -15,11 +15,10 @@ function pageObject(element) {
     menuText: function () {
       return element[0].querySelector('span').textContent;
     },
-    userProfileButton: element[0].querySelector('.dropdown-menu__user-profile-btn'),
-    disabledUserProfileButton: element[0].querySelector('.dropdown-menu__disabled-user-profile-btn'),
-    accountSettingsButton: element[0].querySelector('.dropdown-menu__account-settings-btn'),
-    helpButton: element[0].querySelector('.dropdown-menu__help-btn'),
-    logOutButton: element[0].querySelector('.dropdown-menu__log-out-btn'),
+    userProfileButton: element[0].querySelector('.js-user-profile-btn'),
+    accountSettingsButton: element[0].querySelector('.js-account-settings-btn'),
+    helpButton: element[0].querySelector('.js-help-btn'),
+    logOutButton: element[0].querySelector('.js-log-out-btn'),
   };
 }
 
@@ -102,23 +101,15 @@ describe('loginControl', function () {
      * disabled, and null if no user profile button is rendered.
      */
     function isUserProfileButtonEnabled(page) {
-      var enabledUserProfileButton  = page.userProfileButton;
-      var disabledUserProfileButton = page.disabledUserProfileButton;
+      if (page.userProfileButton === null) {
+        return null;
+      }
 
-      assert.isTrue(
-        enabledUserProfileButton === null || disabledUserProfileButton === null,
-        'It should never show both the enabled and disabled buttons at once'
-      );
-
-      if (enabledUserProfileButton) {
+      if (page.userProfileButton.classList.contains('is-enabled')) {
         return true;
       }
 
-      if (disabledUserProfileButton) {
-        return false;
-      }
-
-      return null;
+      return false;
     }
 
     context('when the user auth status is unknown', function () {

--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -174,6 +174,16 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
         });
       }
 
+      // if doi available as highwire or dc meta, include in search
+
+      if ( info.metadata && info.metadata.link ) {
+        info.metadata.link.forEach(function(link) {
+          if ( link.href.startsWith('doi:') ) {
+            searchUris.push(link.href);
+          }
+        });
+      }
+
       annotationUI.connectFrame({
         uri: info.uri,
         searchUris: searchUris,

--- a/src/sidebar/templates/login-control.html
+++ b/src/sidebar/templates/login-control.html
@@ -21,22 +21,22 @@
   <ul class="dropdown-menu pull-right" role="menu">
     <li class="dropdown-menu__row" ng-if="vm.auth.status === 'logged-in'">
       <span ng-if="!vm.shouldEnableProfileButton()"
-            class="dropdown-menu__link dropdown-menu__link--disabled dropdown-menu__disabled-user-profile-btn">
+            class="dropdown-menu__link dropdown-menu__link--disabled js-user-profile-btn is-disabled">
         {{vm.auth.username}}</span>
       <a ng-if="vm.shouldEnableProfileButton()"
          ng-click="vm.showProfile()"
-         class="dropdown-menu__link dropdown-menu__user-profile-btn"
+         class="dropdown-menu__link js-user-profile-btn is-enabled"
          title="View all your annotations"
          target="_blank">{{vm.auth.username}}</a>
     </li>
     <li class="dropdown-menu__row" ng-if="vm.auth.status === 'logged-in' && !vm.isThirdPartyUser()">
-      <a class="dropdown-menu__link dropdown-menu__account-settings-btn" href="{{vm.serviceUrl('account.settings')}}" target="_blank">Account settings</a>
+      <a class="dropdown-menu__link js-account-settings-btn" href="{{vm.serviceUrl('account.settings')}}" target="_blank">Account settings</a>
     </li>
     <li class="dropdown-menu__row">
-      <a class="dropdown-menu__link dropdown-menu__help-btn" ng-click="vm.onShowHelpPanel()">Help</a>
+      <a class="dropdown-menu__link js-help-btn" ng-click="vm.onShowHelpPanel()">Help</a>
     </li>
     <li class="dropdown-menu__row" ng-if="vm.shouldShowLogOutButton()">
-      <a class="dropdown-menu__link dropdown-menu__link--subtle dropdown-menu__log-out-btn"
+      <a class="dropdown-menu__link dropdown-menu__link--subtle js-log-out-btn"
          href="" ng-click="vm.onLogout()">Log out</a>
     </li>
   </ul>

--- a/src/styles/annotator/adder.scss
+++ b/src/styles/annotator/adder.scss
@@ -1,6 +1,14 @@
 $adder-transition-duration: 80ms;
 
+// Main class for the root element of the "adder" toolbar that appears when the
+// user makes a text selection.
 .annotator-adder {
+
+  // Reset all inherited properties to their initial values. This prevents CSS
+  // property values from the host page being inherited by elements of the
+  // Adder, even when using Shadow DOM.
+  all: initial;
+
   // Adder entry animation settings
   animation-duration: $adder-transition-duration;
   animation-timing-function: ease-in;


### PR DESCRIPTION
Addresses the problem, felt most acutely by @memartone and her SciCrunch colleagues (hi, @tgbugs), of the client not finding SciBot annotations on variants and syndicated copies of articles.

I think it may be redundant to include the non-DOI URI in the list of URIs to search, and originally I didn't, but I don't think it's harmful, and including both more closely matches how we search for PDFs (URI plus fingerprint).