### PR TITLE
Prevent Adder toolbar from inheriting CSS property values from host page

### DIFF
--- a/src/styles/annotator/adder.scss
+++ b/src/styles/annotator/adder.scss
@@ -1,6 +1,14 @@
 $adder-transition-duration: 80ms;
 
+// Main class for the root element of the "adder" toolbar that appears when the
+// user makes a text selection.
 .annotator-adder {
+
+  // Reset all inherited properties to their initial values. This prevents CSS
+  // property values from the host page being inherited by elements of the
+  // Adder, even when using Shadow DOM.
+  all: initial;
+
   // Adder entry animation settings
   animation-duration: $adder-transition-duration;
   animation-timing-function: ease-in;


### PR DESCRIPTION
The adder toolbar uses Shadow DOM or `!important` to prevent CSS rules
in the host page from directly affecting the styling of the toolbar.

However even inside Shadow DOM elements can still inherit CSS property
values from parent elements [1].

This commit fixes that problem for current browsers (except Edge [2]) by
using `all: initial` on the Adder's root element. On browsers that do not support
this property (IE, Edge, old Safari) it will have no effect.

[1] See https://github.com/w3c/webcomponents/issues/314
[2] http://caniuse.com/#feat=css-all

Fixes #382