### PR TITLE
Include DOI in search URIs as a "doi:" URI

### DIFF
--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -178,10 +178,7 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
 
       if ( info.metadata && info.metadata.link ) {
         info.metadata.link.forEach(function(link) {
-          if ( link.href &&
-               typeof(link.href.startsWith)==='function' &&
-               link.href.startsWith('doi:')
-             ) {
+          if ( link.href && link.href.slice(0,3)==='doi:' ) {
             searchUris.push(link.href);
           }
         });

--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -178,7 +178,7 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
 
       if ( info.metadata && info.metadata.link ) {
         info.metadata.link.forEach(function(link) {
-          if ( link.href.startsWith('doi:') ) {
+          if ( link.href && link.href.startsWith('doi:') ) {
             searchUris.push(link.href);
           }
         });

--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -175,7 +175,6 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
       }
 
       // if doi available as highwire or dc meta, include in search
-
       if ( info.metadata && info.metadata.link ) {
         info.metadata.link.forEach(function(link) {
           if ( link.href && link.href.slice(0,4)==='doi:' ) {

--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -178,7 +178,7 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
 
       if ( info.metadata && info.metadata.link ) {
         info.metadata.link.forEach(function(link) {
-          if ( link.href && link.href.slice(0,3)==='doi:' ) {
+          if ( link.href && link.href.slice(0,4)==='doi:' ) {
             searchUris.push(link.href);
           }
         });

--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -174,6 +174,16 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
         });
       }
 
+      // if doi available as highwire or dc meta, include in search
+
+      if ( info.metadata && info.metadata.link ) {
+        info.metadata.link.forEach(function(link) {
+          if ( link.href.startsWith('doi:') ) {
+            searchUris.push(link.href);
+          }
+        });
+      }
+
       annotationUI.connectFrame({
         uri: info.uri,
         searchUris: searchUris,

--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -178,7 +178,10 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
 
       if ( info.metadata && info.metadata.link ) {
         info.metadata.link.forEach(function(link) {
-          if ( link.href && link.href.startsWith('doi:') ) {
+          if ( link.href &&
+               typeof(link.href.startsWith)==='function' &&
+               link.href.startsWith('doi:')
+             ) {
             searchUris.push(link.href);
           }
         });

--- a/src/sidebar/test/frame-sync-test.js
+++ b/src/sidebar/test/frame-sync-test.js
@@ -39,6 +39,17 @@ var fixtures = {
       link: [{href: 'http://example.org/paper.pdf'}, {href:'urn:1234'}],
     },
   },
+
+  // Response to the `getDocumentInfo` channel message for a frame displaying
+  // a document with a doi: url in its link array
+  doiDocumentInfo: {
+    uri: 'http://example.org/paper.html',
+    metadata: {
+      link: [{href: 'http://example.org/paper.html'}, {href:'doi:1234'}],
+    },
+  },
+
+
 };
 
 describe('FrameSync', function () {
@@ -225,6 +236,19 @@ describe('FrameSync', function () {
         uri: frameInfo.uri,
       });
     });
+
+    it('adds the doi url to the searchUris list', function () {
+      frameInfo = fixtures.doiDocumentInfo;
+
+      fakeBridge.emit('connect', fakeChannel);
+
+      assert.calledWith(fakeAnnotationUI.connectFrame, {
+        documentFingerprint: undefined,
+        searchUris: [frameInfo.uri, 'doi:1234'],
+        uri: frameInfo.uri,
+      });
+    });
+
   });
 
   describe('on "showAnnotations" message', function () {


### PR DESCRIPTION
While addressing @robertknight's comment (https://github.com/hypothesis/client/pull/395/files/5b7bd4d304a511b92631a23fe3e462b8e6da4e2b#r118462382) I messed up the branch for https://github.com/hypothesis/client/pull/395 so I'm restarting here.

This version of the proposed change uses the doi: link that already exists in info.metadata.link:
 https://github.com/hypothesis/client/blob/4efa180a9ef64883c302155c42cb39eb196c123f/src/annotator/plugin/document.coffee#L151.

(Note, There are helpful notes about the document equivalence machinery in in the original PR: https://github.com/hypothesis/client/pull/395#issuecomment-303324099.)