### PR TITLE
Rename options to config in annotator

### DIFF
--- a/src/annotator/config.js
+++ b/src/annotator/config.js
@@ -10,7 +10,7 @@ var docs = 'https://h.readthedocs.io/en/latest/embedding.html';
  *
  * @param {Window} window_ - The Window object to read config from.
  */
-function config(window_) {
+function configFrom(window_) {
   var options = {
     app: window_.
       document.querySelector('link[type="application/annotator+html"]').href,
@@ -54,4 +54,4 @@ function config(window_) {
   return options;
 }
 
-module.exports = config;
+module.exports = configFrom;

--- a/src/annotator/config.js
+++ b/src/annotator/config.js
@@ -11,14 +11,14 @@ var docs = 'https://h.readthedocs.io/en/latest/embedding.html';
  * @param {Window} window_ - The Window object to read config from.
  */
 function configFrom(window_) {
-  var options = {
+  var config = {
     app: window_.
       document.querySelector('link[type="application/annotator+html"]').href,
   };
 
   // Parse config from `<script class="js-hypothesis-config">` tags
   try {
-    Object.assign(options, settings(window_.document));
+    Object.assign(config, settings(window_.document));
   } catch (err) {
     console.warn('Could not parse settings from js-hypothesis-config tags',
       err);
@@ -27,16 +27,16 @@ function configFrom(window_) {
   // Parse config from `window.hypothesisConfig` function
   if (window_.hasOwnProperty('hypothesisConfig')) {
     if (typeof window_.hypothesisConfig === 'function') {
-      Object.assign(options, window_.hypothesisConfig());
+      Object.assign(config, window_.hypothesisConfig());
     } else {
       throw new TypeError('hypothesisConfig must be a function, see: ' + docs);
     }
   }
 
-  // Convert legacy keys/values in options to corresponding current
+  // Convert legacy keys/values in config to corresponding current
   // configuration.
-  if (typeof options.showHighlights === 'boolean') {
-    options.showHighlights = options.showHighlights ? 'always' : 'never';
+  if (typeof config.showHighlights === 'boolean') {
+    config.showHighlights = config.showHighlights ? 'always' : 'never';
   }
 
   // Extract the default query from the URL.
@@ -49,9 +49,9 @@ function configFrom(window_) {
   // we try to retrieve it from the URL here.
   var directLinkedID = annotationQuery.extractAnnotationQuery(window_.location.href);
   if (directLinkedID) {
-    Object.assign(options, directLinkedID);
+    Object.assign(config, directLinkedID);
   }
-  return options;
+  return config;
 }
 
 module.exports = configFrom;

--- a/src/annotator/delegator.coffee
+++ b/src/annotator/delegator.coffee
@@ -30,7 +30,7 @@ module.exports = class Delegator
 # hash and extends the @options object.
 #
 # element - The DOM element that this instance represents.
-# options - An Object literal of options.
+# config - An Object literal of config settings.
 #
 # Examples
 #
@@ -40,8 +40,8 @@ module.exports = class Delegator
 #   })
 #
 # Returns a new instance of Delegator.
-  constructor: (element, options) ->
-    @options = $.extend(true, {}, @options, options)
+  constructor: (element, config) ->
+    @options = $.extend(true, {}, @options, config)
     @element = $(element)
 
     # Delegator creates closures for each event it binds. This is a private

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -55,7 +55,7 @@ module.exports = class Guest extends Delegator
   html:
     adder: '<hypothesis-adder></hypothesis-adder>'
 
-  constructor: (element, options) ->
+  constructor: (element, config) ->
     super
 
     this.adder = $(this.html.adder).appendTo(@element).hide()

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -3,14 +3,14 @@ $ = require('jquery')
 Guest = require('./guest')
 
 module.exports = class Host extends Guest
-  constructor: (element, options) ->
+  constructor: (element, config) ->
 
-    # Some options' values are not JSON-stringifiable (e.g. JavaScript
-    # functions) and will be omitted when the options are JSON-stringified.
+    # Some config settings are not JSON-stringifiable (e.g. JavaScript
+    # functions) and will be omitted when the config is JSON-stringified.
     # Add a JSON-stringifiable option for each of these so that the sidebar can
     # at least know whether the callback functions were provided or not.
-    if options.services?[0]
-      service = options.services[0]
+    if config.services?[0]
+      service = config.services[0]
       if service.onLoginRequest
         service.onLoginRequestProvided = true
       if service.onLogoutRequest
@@ -22,14 +22,15 @@ module.exports = class Host extends Guest
       if service.onHelpRequest
         service.onHelpRequestProvided = true
 
-    # Make a copy of all options except `options.app`, the app base URL, and `options.pluginClasses`
+    # Make a copy of all config settings except `config.app`, the app base URL,
+    # and `config.pluginClasses`
     configParam = 'config=' + encodeURIComponent(
-      JSON.stringify(Object.assign({}, options, {app:undefined, pluginClasses: undefined }))
+      JSON.stringify(Object.assign({}, config, {app:undefined, pluginClasses: undefined }))
     )
-    if options.app and '?' in options.app
-      options.app += '&' + configParam
+    if config.app and '?' in config.app
+      config.app += '&' + configParam
     else
-      options.app += '?' + configParam
+      config.app += '?' + configParam
 
     # Create the iframe
     app = $('<iframe></iframe>')
@@ -37,7 +38,7 @@ module.exports = class Host extends Guest
     # enable media in annotations to be shown fullscreen
     .attr('allowfullscreen', '')
     .attr('seamless', '')
-    .attr('src', options.app)
+    .attr('src', config.app)
     .addClass('h-sidebar-iframe')
 
     @frame = $('<div></div>')
@@ -51,10 +52,10 @@ module.exports = class Host extends Guest
 
     this.on 'panelReady', =>
       # Initialize tool state.
-      if options.showHighlights == undefined
+      if config.showHighlights == undefined
         # Highlights are on by default.
-        options.showHighlights = 'always'
-      this.setVisibleHighlights(options.showHighlights == 'always')
+        config.showHighlights = 'always'
+      this.setVisibleHighlights(config.showHighlights == 'always')
 
       # Show the UI
       @frame.css('display', '')

--- a/src/annotator/main.js
+++ b/src/annotator/main.js
@@ -38,20 +38,20 @@ var pluginClasses = {
 
 var appLinkEl =
   document.querySelector('link[type="application/annotator+html"]');
-var options = configFrom(window);
+var config = configFrom(window);
 
 $.noConflict(true)(function() {
   var Klass = window.PDFViewerApplication ?
       PdfSidebar :
       Sidebar;
-  if (options.hasOwnProperty('constructor')) {
-    Klass = options.constructor;
-    delete options.constructor;
+  if (config.hasOwnProperty('constructor')) {
+    Klass = config.constructor;
+    delete config.constructor;
   }
 
-  options.pluginClasses = pluginClasses;
+  config.pluginClasses = pluginClasses;
 
-  window.annotator = new Klass(document.body, options);
+  window.annotator = new Klass(document.body, config);
   appLinkEl.addEventListener('destroy', function () {
     appLinkEl.parentElement.removeChild(appLinkEl);
     window.annotator.destroy();

--- a/src/annotator/main.js
+++ b/src/annotator/main.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var configFrom = require('./config');
 require('../shared/polyfills');
 
 
@@ -37,7 +38,7 @@ var pluginClasses = {
 
 var appLinkEl =
   document.querySelector('link[type="application/annotator+html"]');
-var options = require('./config')(window);
+var options = configFrom(window);
 
 $.noConflict(true)(function() {
   var Klass = window.PDFViewerApplication ?

--- a/src/annotator/plugin/bucket-bar.coffee
+++ b/src/annotator/plugin/bucket-bar.coffee
@@ -49,7 +49,7 @@ module.exports = class BucketBar extends Plugin
         </div>
         """
 
-  # Plugin configuration
+  # Plugin options
   options:
     # gapSize parameter is used by the clustering algorithm
     # If an annotation is farther then this gapSize from the next bucket

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -23,11 +23,11 @@ module.exports = class Sidebar extends Host
   renderFrame: null
   gestureState: null
 
-  constructor: (element, options) ->
+  constructor: (element, config) ->
     super
     this.hide()
 
-    if options.openSidebar || options.annotations || options.query
+    if config.openSidebar || config.annotations || config.query
       this.on 'panelReady', => this.show()
 
     if @plugins.BucketBar?
@@ -37,7 +37,7 @@ module.exports = class Sidebar extends Host
       this._setupGestures()
 
     # The partner-provided callback functions.
-    serviceConfig = options.services?[0]
+    serviceConfig = config.services?[0]
     if serviceConfig
       @onLoginRequest = serviceConfig.onLoginRequest
       @onLogoutRequest = serviceConfig.onLogoutRequest

--- a/src/annotator/test/config-test.js
+++ b/src/annotator/test/config-test.js
@@ -5,7 +5,7 @@ var proxyquire = require('proxyquire');
 var fakeSettings = sinon.stub();
 var fakeExtractAnnotationQuery = {};
 
-var config = proxyquire('../config', {
+var configFrom = proxyquire('../config', {
   '../shared/settings': fakeSettings,
   './util/extract-annotation-query': fakeExtractAnnotationQuery,
 });
@@ -53,7 +53,7 @@ describe('annotator.config', function() {
     });
 
     it("returns the <link>'s href as options.app", function() {
-      assert.equal(config(window).app, link.href);
+      assert.equal(configFrom(window).app, link.href);
     });
   });
 
@@ -62,14 +62,14 @@ describe('annotator.config', function() {
       var window_ = fakeWindow();
       window_.document.querySelector.returns(null);
 
-      assert.throws(function() { config(window_); }, TypeError);
+      assert.throws(function() { configFrom(window_); }, TypeError);
     });
   });
 
   it('gets the JSON settings from the document', function() {
     var window_ = fakeWindow();
 
-    config(window_);
+    configFrom(window_);
 
     assert.calledOnce(fakeSettings);
     assert.calledWithExactly(fakeSettings, window_.document);
@@ -77,11 +77,11 @@ describe('annotator.config', function() {
 
   context('when settings() returns a non-empty object', function() {
     it('reads the setting into the returned options', function() {
-      // config() just blindly adds any key: value settings that settings()
+      // configFrom() just blindly adds any key: value settings that settings()
       // returns into the returns options object.
       fakeSettings.returns({foo: 'bar'});
 
-      var options = config(fakeWindow());
+      var options = configFrom(fakeWindow());
 
       assert.equal(options.foo, 'bar');
     });
@@ -93,11 +93,11 @@ describe('annotator.config', function() {
     });
 
     it('catches the error', function() {
-      config(fakeWindow());
+      configFrom(fakeWindow());
     });
 
     it('logs a warning', function() {
-      config(fakeWindow());
+      configFrom(fakeWindow());
 
       assert.called(console.warn);
     });
@@ -108,7 +108,7 @@ describe('annotator.config', function() {
       var window_ = fakeWindow();
       window_.hypothesisConfig = sinon.stub().returns({foo: 'bar'});
 
-      var options = config(window_);
+      var options = configFrom(window_);
 
       assert.equal(options.foo, 'bar');
     });
@@ -119,7 +119,7 @@ describe('annotator.config', function() {
         foo: 'fooFromHypothesisConfigFunc'});
       fakeSettings.returns({foo: 'fooFromJSHypothesisConfigObj'});
 
-      var options = config(window_);
+      var options = configFrom(window_);
 
       assert.equal(options.foo, 'fooFromHypothesisConfigFunc');
     });
@@ -129,7 +129,7 @@ describe('annotator.config', function() {
         var window_ = fakeWindow();
         window_.hypothesisConfig = sinon.stub().returns(42);
 
-        var options = config(window_);
+        var options = configFrom(window_);
 
         delete options.app; // We don't care about options.app for this test.
         assert.deepEqual({}, options);
@@ -143,7 +143,7 @@ describe('annotator.config', function() {
       window_.hypothesisConfig = 'notAFunction';
 
       assert.throws(
-        function() { config(window_); }, TypeError,
+        function() { configFrom(window_); }, TypeError,
         'hypothesisConfig must be a function, see: https://h.readthedocs.io/en/latest/embedding.html'
       );
     });
@@ -172,7 +172,7 @@ describe('annotator.config', function() {
       it(test.name, function() {
         fakeSettings.returns({showHighlights: test.in});
 
-        var options = config(fakeWindow());
+        var options = configFrom(fakeWindow());
 
         assert.equal(options.showHighlights, test.out);
       });
@@ -180,7 +180,7 @@ describe('annotator.config', function() {
   });
 
   it("extracts the annotation query from the parent page's URL", function() {
-    config(fakeWindow());
+    configFrom(fakeWindow());
 
     assert.calledOnce(fakeExtractAnnotationQuery.extractAnnotationQuery);
     assert.calledWithExactly(
@@ -195,7 +195,7 @@ describe('annotator.config', function() {
     });
 
     it('blindly adds the properties of the object to the options', function() {
-      assert.equal(config(fakeWindow()).foo, 'bar');
+      assert.equal(configFrom(fakeWindow()).foo, 'bar');
     });
 
     specify('settings from extractAnnotationQuery override others', function() {
@@ -210,7 +210,7 @@ describe('annotator.config', function() {
         foo: 'fromHypothesisConfig',
       });
 
-      assert.equal(config(window_).foo, 'fromExtractAnnotationQuery');
+      assert.equal(configFrom(window_).foo, 'fromExtractAnnotationQuery');
     });
   });
 });

--- a/src/annotator/test/config-test.js
+++ b/src/annotator/test/config-test.js
@@ -52,7 +52,7 @@ describe('annotator.config', function() {
       document.head.removeChild(link);
     });
 
-    it("returns the <link>'s href as options.app", function() {
+    it("returns the <link>'s href as config.app", function() {
       assert.equal(configFrom(window).app, link.href);
     });
   });
@@ -76,14 +76,14 @@ describe('annotator.config', function() {
   });
 
   context('when settings() returns a non-empty object', function() {
-    it('reads the setting into the returned options', function() {
+    it('reads the setting into the returned config', function() {
       // configFrom() just blindly adds any key: value settings that settings()
-      // returns into the returns options object.
+      // returns into the returned config object.
       fakeSettings.returns({foo: 'bar'});
 
-      var options = configFrom(fakeWindow());
+      var config = configFrom(fakeWindow());
 
-      assert.equal(options.foo, 'bar');
+      assert.equal(config.foo, 'bar');
     });
   });
 
@@ -104,13 +104,13 @@ describe('annotator.config', function() {
   });
 
   context("when there's a window.hypothesisConfig() function", function() {
-    it('reads arbitrary settings from hypothesisConfig() into options', function() {
+    it('reads arbitrary settings from hypothesisConfig() into config', function() {
       var window_ = fakeWindow();
       window_.hypothesisConfig = sinon.stub().returns({foo: 'bar'});
 
-      var options = configFrom(window_);
+      var config = configFrom(window_);
 
-      assert.equal(options.foo, 'bar');
+      assert.equal(config.foo, 'bar');
     });
 
     specify('hypothesisConfig() settings override js-hypothesis-config ones', function() {
@@ -119,20 +119,20 @@ describe('annotator.config', function() {
         foo: 'fooFromHypothesisConfigFunc'});
       fakeSettings.returns({foo: 'fooFromJSHypothesisConfigObj'});
 
-      var options = configFrom(window_);
+      var config = configFrom(window_);
 
-      assert.equal(options.foo, 'fooFromHypothesisConfigFunc');
+      assert.equal(config.foo, 'fooFromHypothesisConfigFunc');
     });
 
     context('if hypothesisConfig() returns a non-object value', function() {
-      it("doesn't add anything into the options", function() {
+      it("doesn't add anything into the config", function() {
         var window_ = fakeWindow();
         window_.hypothesisConfig = sinon.stub().returns(42);
 
-        var options = configFrom(window_);
+        var config = configFrom(window_);
 
-        delete options.app; // We don't care about options.app for this test.
-        assert.deepEqual({}, options);
+        delete config.app; // We don't care about config.app for this test.
+        assert.deepEqual({}, config);
       });
     });
   });
@@ -162,7 +162,7 @@ describe('annotator.config', function() {
         out:  'never',
       },
       // It adds any arbitrary string value for showHighlights to the
-      // returned options, unmodified.
+      // returned config, unmodified.
       {
         name: 'passes arbitrary strings through unmodified',
         in:   'foo',
@@ -172,9 +172,9 @@ describe('annotator.config', function() {
       it(test.name, function() {
         fakeSettings.returns({showHighlights: test.in});
 
-        var options = configFrom(fakeWindow());
+        var config = configFrom(fakeWindow());
 
-        assert.equal(options.showHighlights, test.out);
+        assert.equal(config.showHighlights, test.out);
       });
     });
   });
@@ -194,7 +194,7 @@ describe('annotator.config', function() {
       });
     });
 
-    it('blindly adds the properties of the object to the options', function() {
+    it('blindly adds the properties of the object to the config', function() {
       assert.equal(configFrom(fakeWindow()).foo, 'bar');
     });
 

--- a/src/annotator/test/guest-test.coffee
+++ b/src/annotator/test/guest-test.coffee
@@ -50,12 +50,12 @@ describe 'Guest', ->
   sandbox = sinon.sandbox.create()
   CrossFrame = null
   fakeCrossFrame = null
-  guestOptions = null
+  guestConfig = null
 
-  createGuest = (options={}) ->
-    options = Object.assign({}, guestOptions, options)
+  createGuest = (config={}) ->
+    config = Object.assign({}, guestConfig, config)
     element = document.createElement('div')
-    return new Guest(element, options)
+    return new Guest(element, config)
 
   beforeEach ->
     FakeAdder::instance = null
@@ -64,7 +64,7 @@ describe 'Guest', ->
       selectionFocusRect: sinon.stub()
     }
     selections = null
-    guestOptions = {pluginClasses: {}}
+    guestConfig = {pluginClasses: {}}
 
     Guest = proxyquire('../guest', {
       './adder': {Adder: FakeAdder},
@@ -89,7 +89,7 @@ describe 'Guest', ->
     }
 
     CrossFrame = sandbox.stub().returns(fakeCrossFrame)
-    guestOptions.pluginClasses['CrossFrame'] = CrossFrame
+    guestConfig.pluginClasses['CrossFrame'] = CrossFrame
 
   afterEach ->
     sandbox.restore()
@@ -100,7 +100,7 @@ describe 'Guest', ->
 
     beforeEach ->
       FakePlugin::instance = null
-      guestOptions.pluginClasses['FakePlugin'] = FakePlugin
+      guestConfig.pluginClasses['FakePlugin'] = FakePlugin
       guest = createGuest(FakePlugin: {})
       fakePlugin = FakePlugin::instance
 

--- a/src/annotator/test/host-test.coffee
+++ b/src/annotator/test/host-test.coffee
@@ -5,13 +5,13 @@ describe 'Host', ->
   sandbox = sinon.sandbox.create()
   CrossFrame = null
   fakeCrossFrame = null
-  hostOptions = {pluginClasses: {}}
+  hostConfig = {pluginClasses: {}}
 
-  createHost = (options={}, element=null) ->
-    options = Object.assign({app: '/base/annotator/test/empty.html'}, hostOptions, options)
+  createHost = (config={}, element=null) ->
+    config = Object.assign({app: '/base/annotator/test/empty.html'}, hostConfig, config)
     if !element
       element = document.createElement('div')
-    return new Host(element, options)
+    return new Host(element, config)
 
   beforeEach ->
     # Disable any Host logging.
@@ -24,7 +24,7 @@ describe 'Host', ->
 
     CrossFrame = sandbox.stub()
     CrossFrame.returns(fakeCrossFrame)
-    hostOptions.pluginClasses['CrossFrame'] = CrossFrame
+    hostConfig.pluginClasses['CrossFrame'] = CrossFrame
 
   afterEach ->
     sandbox.restore()
@@ -67,7 +67,7 @@ describe 'Host', ->
       }])
       assert.notCalled(frame.contentWindow.focus)
 
-  describe 'options', ->
+  describe 'config', ->
     it 'disables highlighting if showHighlights: false is given', (done) ->
       host = createHost(showHighlights: false)
       host.on 'panelReady', ->
@@ -82,7 +82,7 @@ describe 'Host', ->
         done()
       host.publish('panelReady')
 
-    it 'passes options to the sidebar iframe', ->
+    it 'passes config to the sidebar iframe', ->
       appURL = new URL('/base/annotator/test/empty.html', window.location.href)
       host = createHost({annotations: '1234'})
       configStr = encodeURIComponent(JSON.stringify({annotations: '1234'}))

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -46,18 +46,18 @@ function FakeCrossFrame() {
 
 describe('anchoring', function () {
   var guest;
-  var guestOptions;
+  var guestConfig;
   var container;
 
   before(function () {
-    guestOptions = {pluginClasses: {CrossFrame: FakeCrossFrame}};
+    guestConfig = {pluginClasses: {CrossFrame: FakeCrossFrame}};
   });
 
   beforeEach(function () {
     container = document.createElement('div');
     container.innerHTML = require('./test-page.html');
     document.body.appendChild(container);
-    guest = new Guest(container, guestOptions);
+    guest = new Guest(container, guestConfig);
   });
 
   afterEach(function () {

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -7,12 +7,12 @@ describe 'Sidebar', ->
   sandbox = sinon.sandbox.create()
   CrossFrame = null
   fakeCrossFrame = null
-  sidebarOptions = {pluginClasses: {}}
+  sidebarConfig = {pluginClasses: {}}
 
-  createSidebar = (options={}) ->
-    options = Object.assign({}, sidebarOptions, options)
+  createSidebar = (config={}) ->
+    config = Object.assign({}, sidebarConfig, config)
     element = document.createElement('div')
-    return new Sidebar(element, options)
+    return new Sidebar(element, config)
 
   beforeEach ->
     fakeCrossFrame = {}
@@ -23,7 +23,7 @@ describe 'Sidebar', ->
 
     CrossFrame = sandbox.stub()
     CrossFrame.returns(fakeCrossFrame)
-    sidebarOptions.pluginClasses['CrossFrame'] = CrossFrame
+    sidebarConfig.pluginClasses['CrossFrame'] = CrossFrame
 
   afterEach ->
     sandbox.restore()
@@ -49,21 +49,21 @@ describe 'Sidebar', ->
     describe 'on LOGIN_REQUESTED event', ->
       it 'calls the onLoginRequest callback function if one was provided', ->
         onLoginRequest = sandbox.stub()
-        sidebar = createSidebar(options={services: [{onLoginRequest: onLoginRequest}]})
+        sidebar = createSidebar(config={services: [{onLoginRequest: onLoginRequest}]})
 
         emitEvent(events.LOGIN_REQUESTED)
 
         assert.called(onLoginRequest)
 
       it 'only calls the onLoginRequest callback of the first service', ->
-        # Even though options.services is an array it only calls the onLoginRequest
+        # Even though config.services is an array it only calls the onLoginRequest
         # callback function of the first service. The onLoginRequests of any other
         # services are ignored.
         firstOnLogin  = sandbox.stub()
         secondOnLogin = sandbox.stub()
         thirdOnLogin  = sandbox.stub()
         sidebar = createSidebar(
-          options={
+          config={
             services: [
               {onLoginRequest: firstOnLogin},
               {onLoginRequest: secondOnLogin},
@@ -84,7 +84,7 @@ describe 'Sidebar', ->
         secondOnLogin = sandbox.stub()
         thirdOnLogin  = sandbox.stub()
         sidebar = createSidebar(
-          options={
+          config={
             services: [
               {},
               {onLoginRequest: secondOnLogin},
@@ -99,21 +99,21 @@ describe 'Sidebar', ->
         assert.notCalled(thirdOnLogin)
 
       it 'does not crash if there is no services', ->
-        sidebar = createSidebar(options={})  # No options.services
+        sidebar = createSidebar(config={})  # No config.services
         emitEvent(events.LOGIN_REQUESTED)
 
       it 'does not crash if services is an empty array', ->
-        sidebar = createSidebar(options={services: []})
+        sidebar = createSidebar(config={services: []})
         emitEvent(events.LOGIN_REQUESTED)
 
       it 'does not crash if the first service has no onLoginRequest', ->
-        sidebar = createSidebar(options={services: [{}]})
+        sidebar = createSidebar(config={services: [{}]})
         emitEvent(events.LOGIN_REQUESTED)
 
     describe 'on LOGOUT_REQUESTED event', ->
       it 'calls the onLogoutRequest callback function', ->
         onLogoutRequest = sandbox.stub()
-        sidebar = createSidebar(options={services: [{onLogoutRequest: onLogoutRequest}]})
+        sidebar = createSidebar(config={services: [{onLogoutRequest: onLogoutRequest}]})
 
         emitEvent(events.LOGOUT_REQUESTED)
 
@@ -122,7 +122,7 @@ describe 'Sidebar', ->
     describe 'on SIGNUP_REQUESTED event', ->
       it 'calls the onSignupRequest callback function', ->
         onSignupRequest = sandbox.stub()
-        sidebar = createSidebar(options={services: [{onSignupRequest: onSignupRequest}]})
+        sidebar = createSidebar(config={services: [{onSignupRequest: onSignupRequest}]})
 
         emitEvent(events.SIGNUP_REQUESTED)
 
@@ -131,7 +131,7 @@ describe 'Sidebar', ->
     describe 'on PROFILE_REQUESTED event', ->
       it 'calls the onProfileRequest callback function', ->
         onProfileRequest = sandbox.stub()
-        sidebar = createSidebar(options={services: [{onProfileRequest: onProfileRequest}]})
+        sidebar = createSidebar(config={services: [{onProfileRequest: onProfileRequest}]})
 
         emitEvent(events.PROFILE_REQUESTED)
 
@@ -140,7 +140,7 @@ describe 'Sidebar', ->
     describe 'on HELP_REQUESTED event', ->
       it 'calls the onHelpRequest callback function', ->
         onHelpRequest = sandbox.stub()
-        sidebar = createSidebar(options={services: [{onHelpRequest: onHelpRequest}]})
+        sidebar = createSidebar(config={services: [{onHelpRequest: onHelpRequest}]})
 
         emitEvent(events.HELP_REQUESTED)
 


### PR DESCRIPTION
Another pre-step that I wanted to get in before I propose a refactoring of the settings/config/options code:

The `config()` function that creates the `config` (formerly `options`)
object is renamed to `configure()` so that the name doesn't clash with
that of the `config` object. `configure()` is also the name used for the
equivalent function in h.

There are two reasons for renaming the `options` object to `config`:

**First**, it's more consistent. The file that creates this object is
called `config.js`, and the function that creates the object is called
`configure()`, and yet the object ends up getting called `options` (but
you have to look in another file, `main.js`, to find this out).

`config` is also used elsewhere as the name for the main configuration
object, for example in Pyramid/h, in the client docs ("Configuring the
Client", "configuration settings") and public API
(`class="js-hypothesis-config"` scripts and `window.hypothesisConfig()`
functions), etc.

These "options" that the `src/annotator/` code reads from the host page
also end up getting renamed to `hostPageConfig` when they get passed
over in to the `src/sidebar/` code.

**Second**, it's more unique. There are a number of other objects in the
`src/annotator/` code that are called options, sometimes the main
options object and another local options object are even used in the
same function. There's no other objects called config.