### PR TITLE
Refactor extract annotation query

### DIFF
--- a/src/annotator/config.js
+++ b/src/annotator/config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var annotationQuery = require('./util/extract-annotation-query');
+var extractAnnotationQuery = require('./util/extract-annotation-query');
 var settings = require('../shared/settings');
 
 var docs = 'https://h.readthedocs.io/en/latest/embedding.html';
@@ -47,7 +47,7 @@ function configFrom(window_) {
   //
   // In environments where the config has not been injected into the DOM,
   // we try to retrieve it from the URL here.
-  var directLinkedID = annotationQuery.extractAnnotationQuery(window_.location.href);
+  var directLinkedID = extractAnnotationQuery(window_.location.href);
   if (directLinkedID) {
     Object.assign(config, directLinkedID);
   }

--- a/src/annotator/test/config-test.js
+++ b/src/annotator/test/config-test.js
@@ -5,7 +5,7 @@ var proxyquire = require('proxyquire');
 var fakeSettings = {
   jsonConfigsFrom: sinon.stub(),
 };
-var fakeExtractAnnotationQuery = {};
+var fakeExtractAnnotationQuery = sinon.stub();
 
 var configFrom = proxyquire('../config', {
   '../shared/settings': fakeSettings,
@@ -33,7 +33,8 @@ describe('annotator.config', function() {
   });
 
   beforeEach('reset fakeExtractAnnotationQuery', function() {
-    fakeExtractAnnotationQuery.extractAnnotationQuery = sinon.stub();
+    fakeExtractAnnotationQuery.reset();
+    fakeExtractAnnotationQuery.returns(null);
   });
 
   afterEach('reset the sandbox', function() {
@@ -187,16 +188,13 @@ describe('annotator.config', function() {
   it("extracts the annotation query from the parent page's URL", function() {
     configFrom(fakeWindow());
 
-    assert.calledOnce(fakeExtractAnnotationQuery.extractAnnotationQuery);
-    assert.calledWithExactly(
-      fakeExtractAnnotationQuery.extractAnnotationQuery, 'LOCATION_HREF');
+    assert.calledOnce(fakeExtractAnnotationQuery);
+    assert.calledWithExactly(fakeExtractAnnotationQuery, 'LOCATION_HREF');
   });
 
   context('when extractAnnotationQuery() returns an object', function() {
     beforeEach(function() {
-      fakeExtractAnnotationQuery.extractAnnotationQuery.returns({
-        foo: 'bar',
-      });
+      fakeExtractAnnotationQuery.returns({foo: 'bar'});
     });
 
     it('blindly adds the properties of the object to the config', function() {
@@ -207,9 +205,7 @@ describe('annotator.config', function() {
       // Settings returned by extractAnnotationQuery() override ones from
       // jsonConfigsFrom() or from window.hypothesisConfig().
       var window_ = fakeWindow();
-      fakeExtractAnnotationQuery.extractAnnotationQuery.returns({
-        foo: 'fromExtractAnnotationQuery',
-      });
+      fakeExtractAnnotationQuery.returns({foo: 'fromExtractAnnotationQuery'});
       fakeSettings.jsonConfigsFrom.returns({foo: 'fromSettings'});
       window_.hypothesisConfig = sinon.stub().returns({
         foo: 'fromHypothesisConfig',

--- a/src/annotator/util/extract-annotation-query.js
+++ b/src/annotator/util/extract-annotation-query.js
@@ -8,24 +8,24 @@
  * @return {Object} - An object with either an annotation ID or a filter string.
  */
 function extractAnnotationQuery(url) {
-  var filter = {};
   // Annotation IDs are url-safe-base64 identifiers
   // See https://tools.ietf.org/html/rfc4648#page-7
   var annotFragmentMatch = url.match(/#annotations:([A-Za-z0-9_-]+)$/);
   var queryFragmentMatch = url.match(/#annotations:(query|q):(.+)$/i);
+
   if (queryFragmentMatch) {
     try {
-      filter.query = decodeURI(queryFragmentMatch[2]);
+      return {query: decodeURI(queryFragmentMatch[2])};
     } catch (err) {
       // URI Error should return the page unfiltered.
-      filter = null;
     }
-  } else if (annotFragmentMatch) {
-    filter.annotations = annotFragmentMatch[1];
-  } else {
-    filter = null;
   }
-  return filter;
+
+  if (annotFragmentMatch) {
+    return {annotations: annotFragmentMatch[1]};
+  }
+
+  return null;
 }
 
 module.exports = extractAnnotationQuery;

--- a/src/annotator/util/extract-annotation-query.js
+++ b/src/annotator/util/extract-annotation-query.js
@@ -28,6 +28,4 @@ function extractAnnotationQuery(url) {
   return filter;
 }
 
-module.exports = {
-  extractAnnotationQuery: extractAnnotationQuery,
-};
+module.exports = extractAnnotationQuery;

--- a/src/annotator/util/extract-annotation-query.js
+++ b/src/annotator/util/extract-annotation-query.js
@@ -9,20 +9,20 @@
  */
 function extractAnnotationQuery(url) {
   var filter = {};
-  try {
-    // Annotation IDs are url-safe-base64 identifiers
-    // See https://tools.ietf.org/html/rfc4648#page-7
-    var annotFragmentMatch = url.match(/#annotations:([A-Za-z0-9_-]+)$/);
-    var queryFragmentMatch = url.match(/#annotations:(query|q):(.+)$/i);
-    if (queryFragmentMatch) {
+  // Annotation IDs are url-safe-base64 identifiers
+  // See https://tools.ietf.org/html/rfc4648#page-7
+  var annotFragmentMatch = url.match(/#annotations:([A-Za-z0-9_-]+)$/);
+  var queryFragmentMatch = url.match(/#annotations:(query|q):(.+)$/i);
+  if (queryFragmentMatch) {
+    try {
       filter.query = decodeURI(queryFragmentMatch[2]);
-    } else if (annotFragmentMatch) {
-      filter.annotations = annotFragmentMatch[1];
-    } else {
+    } catch (err) {
+      // URI Error should return the page unfiltered.
       filter = null;
     }
-  } catch (err) {
-    // URI Error should return the page unfiltered.
+  } else if (annotFragmentMatch) {
+    filter.annotations = annotFragmentMatch[1];
+  } else {
     filter = null;
   }
   return filter;

--- a/src/annotator/util/extract-annotation-query.js
+++ b/src/annotator/util/extract-annotation-query.js
@@ -1,11 +1,20 @@
 'use strict';
 
 /**
- * Extracts an annotation selection or default filter from a url.
+ * Return the `#annotations:*` ID or query from the given URL's fragment.
  *
- * @param {string} url - The URL which may contain a '#annotations:<ID>'
- *        fragment.
- * @return {Object} - An object with either an annotation ID or a filter string.
+ * If the URL contains a `#annotations:query:*` (or `#annotatons:q:*`) fragment
+ * then return a `{query: *}` object containing the query extracted from the
+ * fragment.
+ *
+ * If the URL contains a `#annotations:<ANNOTATION_ID>` fragment then return a
+ * `{annotations: *}` object containing the annotation ID extracted from the
+ * fragment.
+ *
+ * If the given URL contains neither then return `null`.
+ *
+ * @param {string} url - The URL to extract the ID or query from.
+ * @return {Object|null} - An object containing the extracted query or ID, or null.
  */
 function extractAnnotationQuery(url) {
   var annotFragmentMatch;

--- a/src/annotator/util/extract-annotation-query.js
+++ b/src/annotator/util/extract-annotation-query.js
@@ -8,9 +8,7 @@
  * @return {Object} - An object with either an annotation ID or a filter string.
  */
 function extractAnnotationQuery(url) {
-  // Annotation IDs are url-safe-base64 identifiers
-  // See https://tools.ietf.org/html/rfc4648#page-7
-  var annotFragmentMatch = url.match(/#annotations:([A-Za-z0-9_-]+)$/);
+  var annotFragmentMatch;
   var queryFragmentMatch = url.match(/#annotations:(query|q):(.+)$/i);
 
   if (queryFragmentMatch) {
@@ -21,6 +19,9 @@ function extractAnnotationQuery(url) {
     }
   }
 
+  // Annotation IDs are url-safe-base64 identifiers
+  // See https://tools.ietf.org/html/rfc4648#page-7
+  annotFragmentMatch = url.match(/#annotations:([A-Za-z0-9_-]+)$/);
   if (annotFragmentMatch) {
     return {annotations: annotFragmentMatch[1]};
   }

--- a/src/annotator/util/test/extract-annotation-query-test.js
+++ b/src/annotator/util/test/extract-annotation-query-test.js
@@ -2,18 +2,18 @@
 
 var unroll = require('../../../shared/test/util').unroll;
 
-var annotationIds = require('../extract-annotation-query');
+var extractAnnotationQuery = require('../extract-annotation-query');
 
 describe('annotation queries', function () {
          
   it ('returns null on invalid fragment', function () {
-    assert.equal(annotationIds.extractAnnotationQuery(
+    assert.equal(extractAnnotationQuery(
       'http://localhost:3000#annotations:\"TRYINGTOGETIN\");EVILSCRIPT()'),
       null);
   });
          
   unroll('accepts annotation fragment from urls', function (testCase) {
-    assert.equal(annotationIds.extractAnnotationQuery(testCase.url).annotations, testCase.result);
+    assert.equal(extractAnnotationQuery(testCase.url).annotations, testCase.result);
   }, [{
     url: 'http://localhost:3000#annotations:alphanum3ric_-only',
     result: 'alphanum3ric_-only',
@@ -21,7 +21,7 @@ describe('annotation queries', function () {
   ]);
 
   unroll('accepts query from annotation fragment', function(testCase) {
-    assert.equal(annotationIds.extractAnnotationQuery(testCase.url).query, testCase.result);
+    assert.equal(extractAnnotationQuery(testCase.url).query, testCase.result);
   }, [{
     url: 'http://localhost:3000#annotations:q:user:USERNAME',
     result: 'user:USERNAME',

--- a/src/annotator/util/test/extract-annotation-query-test.js
+++ b/src/annotator/util/test/extract-annotation-query-test.js
@@ -1,38 +1,94 @@
 'use strict';
 
-var unroll = require('../../../shared/test/util').unroll;
-
 var extractAnnotationQuery = require('../extract-annotation-query');
 
-describe('annotation queries', function () {
-         
-  it ('returns null on invalid fragment', function () {
-    assert.equal(extractAnnotationQuery(
-      'http://localhost:3000#annotations:\"TRYINGTOGETIN\");EVILSCRIPT()'),
-      null);
+describe('annotator.util.extractAnnotationQuery', function () {
+  [
+    // #annotations:<ANNOTATION_ID> fragments.
+    {
+      describe: "when there's a valid #annotations:<ID> fragment",
+      it: 'returns an object containing the annotation ID',
+      url: 'http://localhost:3000#annotations:alphanum3ric_-only',
+      returns: {annotations: 'alphanum3ric_-only'},
+    },
+    {
+      describe: "when there's a non-alphanumeric annotation ID",
+      it: 'returns null',
+      url: 'http://localhost:3000#annotations:not%20alphanumeric',
+      returns: null,
+    },
+
+    // #annotations:query:<QUERY> fragments, in their various forms.
+    {
+      describe: "when there's a #annotations:query:<QUERY> fragment",
+      it: 'returns an object containing the query',
+      url: 'http://localhost:3000#annotations:query:user:fred',
+      returns: {query: 'user:fred'},
+    },
+    {
+      describe: "when there's a #annotations:q:<QUERY> fragment",
+      it: 'returns an object containing the query',
+      url: 'http://localhost:3000#annotations:q:user:fred',
+      returns: {query: 'user:fred'},
+    },
+    {
+      describe: "when there's a #annotations:QuerY:<QUERY> fragment",
+      it: 'returns an object containing the query',
+      url: 'http://localhost:3000#annotations:QuerY:user:fred',
+      returns: {query: 'user:fred'},
+    },
+    {
+      describe: 'when the query contains both a username and a tag',
+      it: 'returns an object containing the query',
+      url: 'http://localhost:3000#annotations:q:user:fred%20tag:foo',
+      returns: {query: 'user:fred tag:foo'},
+    },
+    {
+      describe: 'when the query contains URI escape sequences',
+      it: 'decodes the escape sequences',
+      url: 'http://localhost:3000#annotations:query:foo%20bar',
+      returns: {query: 'foo bar'},
+    },
+
+    // Unrecognised or missing #fragments.
+    {
+      describe: "when there's an unrecognised URL fragment",
+      it: 'returns null',
+      url: 'http://localhost:3000#unknown',
+      returns: null,
+    },
+    {
+      describe: "when there's no URL fragment",
+      it: 'returns null',
+      url: 'http://localhost:3000',
+      returns: null,
+    },
+  ].forEach(function(test) {
+    describe(test.describe, function() {
+      it(test.it, function() {
+        assert.deepEqual(extractAnnotationQuery(test.url), test.returns);
+      });
+    });
   });
-         
-  unroll('accepts annotation fragment from urls', function (testCase) {
-    assert.equal(extractAnnotationQuery(testCase.url).annotations, testCase.result);
-  }, [{
-    url: 'http://localhost:3000#annotations:alphanum3ric_-only',
-    result: 'alphanum3ric_-only',
-  },
-  ]);
 
-  unroll('accepts query from annotation fragment', function(testCase) {
-    assert.equal(extractAnnotationQuery(testCase.url).query, testCase.result);
-  }, [{
-    url: 'http://localhost:3000#annotations:q:user:USERNAME',
-    result: 'user:USERNAME',
-  },
-  {
-    url: 'http://localhost:3000#annotations:QuerY:user:USERNAME',
-    result: 'user:USERNAME',
-  }, {
-    url: 'http://localhost:3000#annotations:q:user:USERNAME%20tag:KEYWORD',
-    result: 'user:USERNAME tag:KEYWORD',
-  }]);
+  describe('when the URL contains an invalid fragment', function() {
+    var decodeURI;
+
+    beforeEach('make decodeURI throw an error', function() {
+      decodeURI = sinon.stub(window, 'decodeURI').throws();
+    });
+
+    afterEach('reset decodeURI', function() {
+      decodeURI.reset();
+    });
+
+    it('returns null', function() {
+      // Note: we need a #annotations:query:* fragment here, not just a
+      // #annotations:* one or an unrecognised one, otherwise
+      // extractAnnotationQuery() won't try to URI-decode the fragment.
+      var url = 'http://localhost:3000#annotations:query:abc123';
+
+      assert.isNull(extractAnnotationQuery(url));
+    });
+  });
 });
-
-


### PR DESCRIPTION
Refactor the `extractAnnotationQuery()` code, docstring and tests for clarity.