### PR TITLE
Search by DOI: Add document metadata to app state

### DIFF
--- a/src/sidebar/annotation-ui.js
+++ b/src/sidebar/annotation-ui.js
@@ -118,6 +118,7 @@ module.exports = function ($rootScope, settings) {
     savedAnnotations: annotationsReducer.savedAnnotations,
 
     frames: framesReducer.frames,
+    searchUris: framesReducer.searchUris,
 
     isSidebar: viewerReducer.isSidebar,
   }, store.getState);

--- a/src/sidebar/components/help-panel.js
+++ b/src/sidebar/components/help-panel.js
@@ -24,7 +24,7 @@ module.exports = {
           return;
         }
         this.url = frames[0].uri;
-        this.documentFingerprint = frames[0].documentFingerprint;
+        this.documentFingerprint = frames[0].metadata.documentFingerprint;
       }.bind(this)
     );
   },

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -172,17 +172,6 @@ function SidebarContentController(
       client.cancel();
     });
 
-    var frames = annotationUI.frames();
-    var searchUris = frames.reduce(function (uris, frame) {
-      for (var i = 0; i < frame.searchUris.length; i++) {
-        var uri = frame.searchUris[i];
-        if (uris.indexOf(uri) === -1) {
-          uris.push(uri);
-        }
-      }
-      return uris;
-    }, []);
-
     // If there is no selection, load annotations only for the focused group.
     //
     // If there is a selection, we load annotations for all groups, find out
@@ -197,6 +186,7 @@ function SidebarContentController(
     var group = annotationUI.hasSelectedAnnotations() ?
       null : groups.focused().id;
 
+    var searchUris = annotationUI.searchUris();
     if (searchUris.length > 0) {
       _loadAnnotationsFor(searchUris, group);
 

--- a/src/sidebar/components/test/help-panel-test.js
+++ b/src/sidebar/components/test/help-panel-test.js
@@ -29,7 +29,9 @@ describe('helpPanel', function () {
   it('displays the URL and fingerprint of the first connected frame', function () {
     fakeAnnotationUI.frames.returns([{
       uri: 'https://publisher.org/article.pdf',
-      documentFingerprint: '12345',
+      metadata: {
+        documentFingerprint: '12345',
+      },
     }]);
 
     var $scope = $rootScope.$new();

--- a/src/sidebar/components/test/help-panel-test.js
+++ b/src/sidebar/components/test/help-panel-test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var angular = require('angular');
+
+describe('helpPanel', function () {
+  var fakeAnnotationUI;
+  var $componentController;
+  var $rootScope;
+
+  beforeEach(function () {
+    fakeAnnotationUI = {
+      frames: sinon.stub().returns([]),
+    };
+
+    angular.module('h', [])
+      .component('helpPanel', require('../help-panel'));
+
+    angular.mock.module('h', {
+      annotationUI: fakeAnnotationUI,
+      serviceUrl: sinon.stub(),
+    });
+
+    angular.mock.inject(function (_$componentController_, _$rootScope_) {
+      $componentController = _$componentController_;
+      $rootScope = _$rootScope_;
+    });
+  });
+
+  it('displays the URL and fingerprint of the first connected frame', function () {
+    fakeAnnotationUI.frames.returns([{
+      uri: 'https://publisher.org/article.pdf',
+      documentFingerprint: '12345',
+    }]);
+
+    var $scope = $rootScope.$new();
+    var ctrl = $componentController('helpPanel', { $scope: $scope });
+    $scope.$digest();
+
+    assert.equal(ctrl.url, 'https://publisher.org/article.pdf');
+    assert.equal(ctrl.documentFingerprint, '12345');
+  });
+});

--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -166,18 +166,16 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
         searchUris = [info.uri];
       }
 
-      var documentFingerprint;
       if (info.metadata && info.metadata.documentFingerprint) {
-        documentFingerprint = info.metadata.documentFingerprint;
         searchUris = info.metadata.link.map(function (link) {
           return link.href;
         });
       }
 
       annotationUI.connectFrame({
+        metadata: info.metadata,
         uri: info.uri,
         searchUris: searchUris,
-        documentFingerprint: documentFingerprint,
       });
     });
   }

--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -158,24 +158,14 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
    */
   function addFrame(channel) {
     channel.call('getDocumentInfo', function (err, info) {
-      var searchUris = [];
-
       if (err) {
         channel.destroy();
-      } else {
-        searchUris = [info.uri];
-      }
-
-      if (info.metadata && info.metadata.documentFingerprint) {
-        searchUris = info.metadata.link.map(function (link) {
-          return link.href;
-        });
+        return;
       }
 
       annotationUI.connectFrame({
         metadata: info.metadata,
         uri: info.uri,
-        searchUris: searchUris,
       });
     });
   }

--- a/src/sidebar/reducers/frames.js
+++ b/src/sidebar/reducers/frames.js
@@ -58,6 +58,28 @@ function frames(state) {
   return state.frames;
 }
 
+function searchUrisForFrame(frame) {
+  var uris = [frame.uri];
+
+  if (frame.metadata && frame.metadata.documentFingerprint) {
+    uris = frame.metadata.link.map(function (link) {
+      return link.href;
+    });
+  }
+
+  return uris;
+}
+
+/**
+ * Return the set of URIs that should be used to search for annotations on the
+ * current page.
+ */
+function searchUris(state) {
+  return state.frames.reduce(function (uris, frame) {
+    return uris.concat(searchUrisForFrame(frame));
+  }, []);
+}
+
 module.exports = {
   init: init,
   update: update,
@@ -69,4 +91,5 @@ module.exports = {
 
   // Selectors
   frames: frames,
+  searchUris: searchUris,
 };

--- a/src/sidebar/reducers/test/frames-test.js
+++ b/src/sidebar/reducers/test/frames-test.js
@@ -2,6 +2,7 @@
 
 var frames = require('../frames');
 var util = require('../util');
+var unroll = require('../../../shared/test/util').unroll;
 
 var init = frames.init;
 var actions = frames.actions;
@@ -40,5 +41,54 @@ describe('frames reducer', function () {
         actions.updateFrameAnnotationFetchStatus('http://anotherexample.com', true));
       assert.deepEqual(frames.frames(updatedState), [frame]);
     });
+  });
+
+  describe('#searchUris', function () {
+    unroll('returns the expected search URIs (#when)', function (testCase) {
+      var state = init();
+      testCase.frames.forEach(function (frame) {
+        state = update(state, actions.connectFrame(frame));
+      });
+      assert.deepEqual(frames.searchUris(state), testCase.searchUris);
+    },[{
+      when: 'one HTML frame',
+      frames: [{
+        uri: 'https://publisher.org/article.html',
+      }],
+      searchUris: ['https://publisher.org/article.html'],
+    },{
+      when: 'one PDF frame',
+      frames: [{
+        uri: 'https://publisher.org/article.pdf',
+        metadata: {
+          documentFingerprint: '1234',
+          link: [{
+            href: 'urn:x-pdf:1234',
+          },{
+            // When a document fingerprint is provided, we currently rely on the
+            // host frame to include the original URL of the document in the
+            // `metadata.link` list.
+            //
+            // This may be omitted if the URI is a `file:///` URI.
+            href: 'https://publisher.org/article.pdf?from_meta_link=1',
+          }],
+        },
+      }],
+      searchUris: [
+        'urn:x-pdf:1234',
+        'https://publisher.org/article.pdf?from_meta_link=1',
+      ],
+    },{
+      when: 'multiple HTML frames',
+      frames: [{
+        uri: 'https://publisher.org/article.html',
+      },{
+        uri: 'https://publisher.org/article2.html',
+      }],
+      searchUris: [
+        'https://publisher.org/article.html',
+        'https://publisher.org/article2.html',
+      ],
+    }]);
   });
 });

--- a/src/sidebar/test/frame-sync-test.js
+++ b/src/sidebar/test/frame-sync-test.js
@@ -208,7 +208,7 @@ describe('FrameSync', function () {
       fakeBridge.emit('connect', fakeChannel);
 
       assert.calledWith(fakeAnnotationUI.connectFrame, {
-        documentFingerprint: undefined,
+        metadata: frameInfo.metadata,
         searchUris: [frameInfo.uri],
         uri: frameInfo.uri,
       });
@@ -220,7 +220,7 @@ describe('FrameSync', function () {
       fakeBridge.emit('connect', fakeChannel);
 
       assert.calledWith(fakeAnnotationUI.connectFrame, {
-        documentFingerprint: frameInfo.metadata.documentFingerprint,
+        metadata: frameInfo.metadata,
         searchUris: [frameInfo.uri, 'urn:1234'],
         uri: frameInfo.uri,
       });

--- a/src/sidebar/test/frame-sync-test.js
+++ b/src/sidebar/test/frame-sync-test.js
@@ -209,19 +209,6 @@ describe('FrameSync', function () {
 
       assert.calledWith(fakeAnnotationUI.connectFrame, {
         metadata: frameInfo.metadata,
-        searchUris: [frameInfo.uri],
-        uri: frameInfo.uri,
-      });
-    });
-
-    it('adds the document fingerprint for PDFs', function () {
-      frameInfo = fixtures.pdfDocumentInfo;
-
-      fakeBridge.emit('connect', fakeChannel);
-
-      assert.calledWith(fakeAnnotationUI.connectFrame, {
-        metadata: frameInfo.metadata,
-        searchUris: [frameInfo.uri, 'urn:1234'],
         uri: frameInfo.uri,
       });
     });


### PR DESCRIPTION
This is some refactoring in preparation for enabling the client to search for annotations for the current document based on its DOI (as given in `<meta name="citation_doi">` tags) as well as its URL, which @judell started working on in https://github.com/hypothesis/client/pull/402 .

When the client starts up, it requests the URL and metadata from the host page via a "getDocumentInfo" RPC call. From this metadata a list of "search URIs" are produced which are included in the request to the `/annotations/search` endpoint via the "uri" query string parameter.  Annotations associated with any of the URIs in this list are then returned and displayed.

In order to find annotations based on the DOI associated with the current page, the plan is to also include "doi:<doi>" URIs in the search URI list. We want to do this behind a feature flag initially to make sure we can easily turn this off if we see any problems.

Currently the set of "search URIs" for each frame is calculated _when the frame connects to the sidebar_ (in frame-sync.js), which happens before we have retrieved the user's profile (and thus feature flags). In order to be able to feature-flag this change, this PR changes the code in "frame-sync.js" to only store the URI and metadata of the frame when it connects and calculate the set of search URIs later just before making the `/annotations/search` request. At that point we have the feature flags and user profile loaded. 