### PR TITLE
Search by DOI: Include DOI URIs in search URI list

### DIFF
--- a/src/shared/polyfills.js
+++ b/src/shared/polyfills.js
@@ -7,6 +7,8 @@ require('core-js/fn/array/find');
 require('core-js/fn/array/find-index');
 require('core-js/fn/array/from');
 require('core-js/fn/object/assign');
+require('core-js/fn/string/ends-with');
+require('core-js/fn/string/starts-with');
 
 // ES2017
 require('core-js/fn/object/values');

--- a/src/sidebar/reducers/frames.js
+++ b/src/sidebar/reducers/frames.js
@@ -1,6 +1,9 @@
 'use strict';
 
+var session = require('./session');
 var util = require('./util');
+
+var isFeatureEnabled = session.isFeatureEnabled;
 
 function init() {
   return {
@@ -58,13 +61,23 @@ function frames(state) {
   return state.frames;
 }
 
-function searchUrisForFrame(frame) {
+function searchUrisForFrame(frame, includeDoi) {
   var uris = [frame.uri];
 
   if (frame.metadata && frame.metadata.documentFingerprint) {
     uris = frame.metadata.link.map(function (link) {
       return link.href;
     });
+  }
+
+  if (includeDoi) {
+    if (frame.metadata && frame.metadata.link) {
+      frame.metadata.link.forEach(function (link) {
+        if (link.href.startsWith('doi:')) {
+          uris.push(link.href);
+        }
+      });
+    }
   }
 
   return uris;
@@ -75,8 +88,9 @@ function searchUrisForFrame(frame) {
  * current page.
  */
 function searchUris(state) {
+  var includeDoi = isFeatureEnabled(state, 'search_for_doi');
   return state.frames.reduce(function (uris, frame) {
-    return uris.concat(searchUrisForFrame(frame));
+    return uris.concat(searchUrisForFrame(frame, includeDoi));
   }, []);
 }
 

--- a/src/sidebar/reducers/test/frames-test.js
+++ b/src/sidebar/reducers/test/frames-test.js
@@ -1,12 +1,16 @@
 'use strict';
 
 var frames = require('../frames');
+var session = require('../session');
 var util = require('../util');
 var unroll = require('../../../shared/test/util').unroll;
 
-var init = frames.init;
 var actions = frames.actions;
 var update = util.createReducer(frames.update);
+
+function init() {
+  return Object.assign({}, frames.init(), session.init());
+}
 
 describe('frames reducer', function () {
   describe('#connectFrame', function () {
@@ -46,6 +50,9 @@ describe('frames reducer', function () {
   describe('#searchUris', function () {
     unroll('returns the expected search URIs (#when)', function (testCase) {
       var state = init();
+      if (testCase.features) {
+        state.session.features = testCase.features;
+      }
       testCase.frames.forEach(function (frame) {
         state = update(state, actions.connectFrame(frame));
       });
@@ -88,6 +95,39 @@ describe('frames reducer', function () {
       searchUris: [
         'https://publisher.org/article.html',
         'https://publisher.org/article2.html',
+      ],
+    },{
+      when: 'searching for DOIs is enabled',
+      features: {
+        search_for_doi: true,
+      },
+      frames: [{
+        uri: 'https://publisher.org/article.html',
+        metadata: {
+          link: [{
+            href: 'doi:10.1.1/1234',
+          }],
+        },
+      }],
+      searchUris: [
+        'https://publisher.org/article.html',
+        'doi:10.1.1/1234',
+      ],
+    },{
+      when: 'searching for DOIs is disabled',
+      features: {
+        search_for_doi: false,
+      },
+      frames: [{
+        uri: 'https://publisher.org/article.html',
+        metadata: {
+          link: [{
+            href: 'doi:10.1.1/1234',
+          }],
+        },
+      }],
+      searchUris: [
+        'https://publisher.org/article.html',
       ],
     }]);
   });


### PR DESCRIPTION
_This is the change originally implemented by @judell in https://github.com/hypothesis/client/pull/402 but implemented on top of https://github.com/hypothesis/client/pull/417 , which needs to be reviewed first._

When the "search_for_doi" feature flag is enabled, the client will include "doi:<doi>" URIs in the list of search URIs when visiting a page that has "citation_doi" `<meta>` tags. The end result is that annotations made on one URL which self-identify as being associated with a particular DOI will also show up when visiting a different URL which self-identify as the same DOI, without any URL equivalence having been established between the two URLs first.

As an example, these two URLs are different presentations of the same article:

http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0156419
https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4883742/

Both of them have the same DOI (as identified by the "citation_doi" meta tag). With this PR, an annotation created on one of these URLs should appear on the other without having to first create annotations on both URLs in order to establish document equivalence.