### PR TITLE
adding console log capture to karma

### DIFF
--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -112,6 +112,12 @@ module.exports = function(config) {
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
     logLevel: config.LOG_INFO,
 
+    browserConsoleLogOptions: {
+      level: 'log',
+      format: '%b %T: %m',
+      terminal: true,
+    },
+
     // enable / disable watching file and executing tests whenever any file changes
     autoWatch: true,
 


### PR DESCRIPTION
This hasn't been an issue for me until lately. But this is a reinforcement that console.logs in karma tests should mirror back to the terminal output