### PR TITLE
Don't throw on invalid JSON

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -43,14 +43,7 @@ function configFrom(window_) {
     return config;
   }
 
-  // Parse config from `<script class="js-hypothesis-config">` tags
-  try {
-    Object.assign(config, sharedSettings.jsonConfigsFrom(window_.document));
-  } catch (err) {
-    console.warn('Could not parse settings from js-hypothesis-config tags',
-      err);
-  }
-
+  Object.assign(config, sharedSettings.jsonConfigsFrom(window_.document));
   Object.assign(config, settings.configFuncSettingsFrom(window_));
 
   // Convert legacy keys/values in config to corresponding current

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -10,7 +10,6 @@ var configFrom = proxyquire('../index', util.noCallThru({
   './settings': fakeSettings,
   '../../shared/settings': fakeSharedSettings,
 }));
-var sandbox = sinon.sandbox.create();
 
 function fakeWindow() {
   return {
@@ -20,10 +19,6 @@ function fakeWindow() {
 }
 
 describe('annotator.config', function() {
-  beforeEach('stub console.warn()', function() {
-    sandbox.stub(console, 'warn');
-  });
-
   beforeEach('reset fakeSharedSettings', function() {
     fakeSharedSettings.jsonConfigsFrom = sinon.stub().returns({});
   });
@@ -33,10 +28,6 @@ describe('annotator.config', function() {
     fakeSettings.annotations = sinon.stub();
     fakeSettings.query = sinon.stub();
     fakeSettings.configFuncSettingsFrom = sinon.stub().returns({});
-  });
-
-  afterEach('reset the sandbox', function() {
-    sandbox.restore();
   });
 
   it('gets the config.app setting', function() {
@@ -86,22 +77,6 @@ describe('annotator.config', function() {
       var config = configFrom(fakeWindow());
 
       assert.equal(config.foo, 'bar');
-    });
-  });
-
-  context('when jsonConfigsFrom() throws an error', function() {
-    beforeEach(function() {
-      fakeSharedSettings.jsonConfigsFrom.throws();
-    });
-
-    it('catches the error', function() {
-      configFrom(fakeWindow());
-    });
-
-    it('logs a warning', function() {
-      configFrom(fakeWindow());
-
-      assert.called(console.warn);
     });
   });
 

--- a/src/shared/settings.js
+++ b/src/shared/settings.js
@@ -28,13 +28,21 @@ function assign(dest, src) {
  * @param {Document|Element} document - The root element to search.
  */
 function jsonConfigsFrom(document) {
+  var config = {};
   var settingsElements =
     document.querySelectorAll('script.js-hypothesis-config');
 
-  var config = {};
   for (var i=0; i < settingsElements.length; i++) {
-    assign(config, JSON.parse(settingsElements[i].textContent));
+    var settings;
+    try {
+      settings = JSON.parse(settingsElements[i].textContent);
+    } catch (err) {
+      console.warn('Could not parse settings from js-hypothesis-config tags', err);
+      settings = {};
+    }
+    assign(config, settings);
   }
+
   return config;
 }
 

--- a/src/shared/test/settings-test.js
+++ b/src/shared/test/settings-test.js
@@ -2,7 +2,14 @@
 
 var settings = require('../settings');
 
+var sandbox = sinon.sandbox.create();
+
 describe('settings', function () {
+
+  afterEach('reset the sandbox', function() {
+    sandbox.restore();
+  });
+
   describe('#jsonConfigsFrom', function() {
     var jsonConfigsFrom = settings.jsonConfigsFrom;
 
@@ -64,15 +71,28 @@ describe('settings', function () {
     });
 
     context("when there's a JSON script containing invalid JSON", function() {
+      beforeEach('stub console.warn()', function() {
+        sandbox.stub(console, 'warn');
+      });
+
       beforeEach('add a JSON script containing invalid JSON', function() {
         appendJSHypothesisConfig(document, 'this is not valid json');
       });
 
-      it('throws a SyntaxError', function() {
-        assert.throws(
-          function() { jsonConfigsFrom(document); },
-          SyntaxError
-        );
+      it('logs a warning', function() {
+        jsonConfigsFrom(document);
+
+        assert.called(console.warn);
+      });
+
+      it('returns {}', function() {
+        assert.deepEqual(jsonConfigsFrom(document), {});
+      });
+
+      it('still returns settings from other JSON scripts', function() {
+        appendJSHypothesisConfig(document, '{"foo": "FOO", "bar": "BAR"}');
+
+        assert.deepEqual(jsonConfigsFrom(document), {foo: 'FOO', bar: 'BAR'});
       });
     });
 


### PR DESCRIPTION
Don't throw an error when parsing an invalid js-hypothesis-config JSON
script.

This error thrown by shared.settings#jsonConfigsFrom() was caught in one
of the places where that function is called, but not in other places
where it's called.

Move the error catching and warning logging into the shared function
instead.

This now means, for example, that boot/index.js no longer crashes
(bringing down the entire app) if the host page contains an invalid
js-hypothesis-config.

Unfortunately since jsonConfigsFrom() is called _twice_ on page load to
read the same js-hypothesis-config objects from the host page (it's
called once by boot/index.js and once by annotator/config/config.js) if
there's an invalid js-hypothesis-config a warning about it will be
logged twice.