### PR TITLE
Don't throw if hypothesisConfig() isn't a function

### DIFF
--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -84,13 +84,8 @@ function query(url) {
  *
  * If there's no window.hypothesisConfig() function then return {}.
  *
- * If there is a window.hypothesisConfig but it isn't a function then throw an
- * error.
- *
  * @param {Window} window_ - The window to search for a hypothesisConfig() function
  * @return {Object} - Any config settings returned by hypothesisConfig()
- *
- * @throws {TypeError} - If window.hypothesisConfig() isn't a function
  *
  */
 function configFuncSettingsFrom(window_) {
@@ -100,7 +95,8 @@ function configFuncSettingsFrom(window_) {
 
   if (typeof window_.hypothesisConfig !== 'function') {
     var docs = 'https://h.readthedocs.io/projects/client/en/latest/publishers/config/#window.hypothesisConfig';
-    throw new TypeError('hypothesisConfig must be a function, see: ' + docs);
+    console.warn('hypothesisConfig must be a function, see: ' + docs);
+    return {};
   }
 
   return window_.hypothesisConfig();

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -136,14 +136,6 @@ describe('annotator.config', function() {
     });
   });
 
-  context('when configFuncSettingsFrom() throws an error', function() {
-    it('throws the same error', function() {
-      fakeSettings.configFuncSettingsFrom.throws(new TypeError());
-
-      assert.throws(function() { configFrom(fakeWindow()); }, TypeError);
-    });
-  });
-
   describe('showHighlights', function() {
     [
       {

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -2,7 +2,14 @@
 
 var settings = require('../settings');
 
+var sandbox = sinon.sandbox.create();
+
 describe('annotation.config.settings', function() {
+
+  afterEach('reset the sandbox', function() {
+    sandbox.restore();
+  });
+
   describe('#app', function() {
     function appendLinkToDocument(href) {
       var link = document.createElement('link');
@@ -197,13 +204,25 @@ describe('annotation.config.settings', function() {
     });
 
     context("when window.hypothesisConfig() isn't a function", function() {
-      it('throws an error', function() {
-        var fakeWindow = { hypothesisConfig: 42 };
+      beforeEach('stub console.warn()', function() {
+        sandbox.stub(console, 'warn');
+      });
 
-        assert.throws(
-          function() { settings.configFuncSettingsFrom(fakeWindow); },
-          TypeError
-        );
+      function fakeWindow() {
+        return {hypothesisConfig: 42};
+      }
+
+      it('returns {}', function() {
+        assert.deepEqual(settings.configFuncSettingsFrom(fakeWindow()), {});
+      });
+
+      it('logs a warning', function() {
+        settings.configFuncSettingsFrom(fakeWindow());
+
+        assert.calledOnce(console.warn);
+        assert.isTrue(console.warn.firstCall.args[0].startsWith(
+          'hypothesisConfig must be a function'
+        ));
       });
     });
 


### PR DESCRIPTION
Log a warning, rather than throwing an error, if
window.hypothesisConfig() exists but isn't a function.

"Warn but continue" is in line with our general approach to handling
invalid configuration in the client. For example if there's an invalid
js-hypothesis-config script in the page it logs a warning and continues.

For some required config settings, such as config.app, if the setting is
invalid then the client crashes out immediately because it can't
continue. But otherwise it should warn and continue.