### PR TITLE
Replace Annotations / Page Notes / Orphans selection tabs with a standard view switcher component

### DIFF
--- a/src/sidebar/templates/selection-tabs.html
+++ b/src/sidebar/templates/selection-tabs.html
@@ -1,36 +1,42 @@
 <!-- Tabbed display of annotations and notes. -->
 <div class="selection-tabs">
-  <a class="selection-tabs__type"
-     href="#"
-     ng-class="{'is-selected': vm.selectedTab === vm.TAB_ANNOTATIONS}"
-     h-on-touch="vm.selectTab(vm.TAB_ANNOTATIONS)">
-    Annotations
+  <button class="selection-tabs__type"
+          ng-class="{'is-selected': vm.selectedTab === vm.TAB_ANNOTATIONS}"
+          h-on-touch="vm.selectTab(vm.TAB_ANNOTATIONS)">
+    <span class="selection-tabs__label">
+      Annotations
+    </span>
+
     <span class="selection-tabs__count"
-      ng-if="vm.totalAnnotations > 0 && !vm.isWaitingToAnchorAnnotations">
+          ng-if="!vm.isWaitingToAnchorAnnotations">
       {{ vm.totalAnnotations }}
     </span>
-  </a>
-  <a class="selection-tabs__type"
-     href="#"
-     ng-class="{'is-selected': vm.selectedTab === vm.TAB_NOTES}"
-     h-on-touch="vm.selectTab(vm.TAB_NOTES)">
-    Page Notes
+  </button>
+  <button class="selection-tabs__type"
+          href="#"
+          ng-class="{'is-selected': vm.selectedTab === vm.TAB_NOTES}"
+          h-on-touch="vm.selectTab(vm.TAB_NOTES)">
+    <span class="selection-tabs__label">
+      Page Notes
+    </span>
+
     <span class="selection-tabs__count"
-      ng-if="vm.totalNotes > 0 && !vm.isWaitingToAnchorAnnotations">
+          ng-if="!vm.isWaitingToAnchorAnnotations">
       {{ vm.totalNotes }}
     </span>
-  </a>
-  <a class="selection-tabs__type selection-tabs__type--orphan"
-    ng-if="vm.orphansTabFlagEnabled() && vm.totalOrphans > 0"
-    href="#"
-    ng-class="{'is-selected': vm.selectedTab === vm.TAB_ORPHANS}"
-    h-on-touch="vm.selectTab(vm.TAB_ORPHANS)">
-    Orphans
-    <span class="selection-tabs__count"
-      ng-if="vm.totalOrphans > 0 && !vm.isWaitingToAnchorAnnotations">
-      {{ vm.totalOrphans }}
+  </button>
+  <button class="selection-tabs__type selection-tabs__type--orphan"
+          href="#"
+          ng-class="{'is-selected': vm.selectedTab === vm.TAB_ORPHANS}"
+          h-on-touch="vm.selectTab(vm.TAB_ORPHANS)">
+    <span class="selection-tabs__label">
+      Orphans
     </span>
-  </a>
+
+    <span class="selection-tabs__count">
+      12
+    </span>
+  </button>
 </div>
 <div ng-if="!vm.isLoading()" class="selection-tabs__empty-message">
   <div ng-if="vm.showNotesUnavailableMessage()"  class="annotation-unavailable-message">

--- a/src/styles/selection-tabs.scss
+++ b/src/styles/selection-tabs.scss
@@ -12,12 +12,14 @@
   height: 30px;
   width: 106px;
 
-  background-color: #fff;
+  font-weight: bold;
 
-  border: 1px solid #d3d3d3;
+  color: #626262;
+  background-color: rgb(236, 236, 236);
+  transition: background-color 100ms linear;
+
+  border: 1px solid #626262;
   border-right-width: 0;
-
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
 
   padding-left: 12px;
   padding-right: calc(12px - 7px);
@@ -34,20 +36,20 @@
 }
 
 .selection-tabs__type:first-child {
-  border-top-left-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-top-left-radius: 2px;
+  border-bottom-left-radius: 2px;
 }
 
 .selection-tabs__type:last-child {
-  border-right-color: #ccc;
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-right-width: 1px;
 }
 
 .selection-tabs__type:hover,
 .selection-tabs__type.is-selected {
-  background-color: #e6e6e6;
+  color: #f1f1f1;
+  background-color: #626262;
 }
 
 .selection-tabs__label {

--- a/src/styles/selection-tabs.scss
+++ b/src/styles/selection-tabs.scss
@@ -1,45 +1,66 @@
 .selection-tabs {
-
   display: flex;
-  flex-direction: row;
-  color: $grey-5;
-  @include font-normal;
+  justify-content: center;
 
-  &:hover {
-    color: $grey-6;
-  }
-
-  padding-bottom: 10px;
+  margin-top: 1px;
+  margin-bottom: 6px;
 }
 
 .selection-tabs__type {
-  color: $grey-6;
-  margin-right: 20px;
+  display: flex;
+  justify-content: center;
+  height: 30px;
+  width: 106px;
+
+  background-color: #fff;
+
+  border: 1px solid #d3d3d3;
+  border-right-width: 0;
+
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+
+  padding-left: 12px;
+  padding-right: calc(12px - 7px);
+
+  touch-action: manipulation;
   cursor: pointer;
-  min-width: 85px;
-  min-height: 18px;
-
-  // Disable focus ring for selected tab
-  outline: none;
-
   user-select: none;
+
+  -webkit-appearance: button;
 }
 
+.selection-tabs__type:focus {
+  outline:0 !important;
+}
+
+.selection-tabs__type:first-child {
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+
+.selection-tabs__type:last-child {
+  border-right-color: #ccc;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+  border-right-width: 1px;
+}
+
+.selection-tabs__type:hover,
 .selection-tabs__type.is-selected {
-  font-weight: bold;
+  background-color: #e6e6e6;
+}
+
+.selection-tabs__label {
+  flex-basis: 200px;
 }
 
 .selection-tabs__count {
-  position: relative;
-  bottom: 3px;
-  font-size: 10px;
+  flex-basis: 21px;
+  padding-left: 7px;
+  padding-right: 7px;
 }
 
 .selection-tabs__empty-message {
   position: relative;
   top: 10px;
-}
-
-.selection-tabs__type--orphan {
-  margin-left: -5px;
 }


### PR DESCRIPTION
_The code in this PR is fully working but it's not final code - if we decide to do this I'll tidy up the code. This PR is for UX discussion._

The sidebar has a set of 2-3 of what our code calls "selection tabs" at the top for switching the view between annotations, page notes and orphans:

![peek 2017-06-07 18-14](https://user-images.githubusercontent.com/22498/26891576-675aca0a-4bad-11e7-8729-3774f19ff658.gif)

(The orphans tab only appears when there are orphans, the other two tabs are there all the time whether there are annotations or page notes or not.)

In my opinion there are some problems with this control:

* The buttons are small and hard to click. Since they're actually just links not buttons you actually have to click on the (small) text itself. This isn't good for accessibility (for people with fine pointer control issues) or for touch or mobile.

* Users may not realise that these are clickable: the buttons don't look like buttons (no rounded rect border and background colour like a button, as opposed to a link, usually has) and they don't look like links either (they aren't blue or purple or underlined like most links on the web).

  These buttons also look different than other buttons (and links) in the sidebar itself.

* Because bold text is used to indicate the currently selected tab, when you click on a different tab the other tabs jump around horizontally (as can be seen in the gif above). Admittedly this one is fixable without completely changing the control.

* It doesn't look like common controllers used in many web and native apps for the same purpose - doesn't look familiar to users, won't be immediately recognisable as this kind of control, users may not immediately realise what it is.

* The use of superscript text to show the number of items in each view doesn't look very good (in my subjective opinion). It's also an unusual way to display the number of items contained in a view, again this won't be familiar or recognisable to users who're used to seeing badges with numbers in them used for this same purpose in many web and native apps. Superscript is usually used to indicate a footnote.

* It uses HTML `<a>` elements with `href="#"`, which I don't believe is correct for these controllers, which are really buttons not links. They should be `<button>`s. (Again, this one is fixable without completely changing the control.)

* It generally doesn't look very good (in my subjective opinion)

* It looks odd that it's left-aligned rather than centred (again, my subjective opinion). (Also fixable without completely changing the control.)

   _Tabs_ (where the number of tabs can change dynamically, tabs opening and closing in response to events or user actions, like in a desktop web browser) are normally left aligned. _View switchers_ (which are like tabs except that the set of tabs is fixed and generally doesn't change dynamically) are usually centre-aligned. Here we have a fixed number of buttons that don't expand and contract during use and aren't as wide as the sidebar that contains them - centre-aligned definitely feels right to me.

This pull request changes this control to look more like a typical view switcher control as seen in many web and native apps, and also to look like the buttons used elsewhere in the sidebar itself:

![peek 2017-06-07 18-28](https://user-images.githubusercontent.com/22498/26892097-15294b88-4baf-11e7-9680-163e2897f7ea.gif)

Here's how it look when there aren't any orphans:

![peek 2017-06-07 18-30](https://user-images.githubusercontent.com/22498/26892218-7a3b8338-4baf-11e7-998b-ea6f390b5f79.gif)

I think this is an improvement because:

* It looks better
* The look of the control fits in with / is consistent with the rest of the controls in the sidebar
* It is more familiar and recognisable to users
* The buttons are easier to hit, especially on mobile

## Prior Art (!)

I think one of the main advantages of this change is that the controller should be familiar and recognisable to users based on similar-looking standard controllers that are used for this same purpose on most web and native app platforms and toolkits.

I think the fact that this is a common, standard type of control also backs up the argument that it looks better and is easier to use (e.g. easier to touch or click on).

Examples:

[View switchers in the GNOME HIG](https://developer.gnome.org/hig/stable/view-switchers.html.en):

![view-switcher](https://user-images.githubusercontent.com/22498/26890898-187a65dc-4bab-11e7-8b73-fbe7552cf36f.png)

In iOS this is called a [segmented control](https://developer.apple.com/ios/human-interface-guidelines/ui-controls/segmented-controls/):

![ios-26-basic-segmented-control](https://user-images.githubusercontent.com/22498/26891111-bebe282a-4bab-11e7-9f62-063c48207f8d.gif)

In macOS these seem to be called [tab views](https://developer.apple.com/macos/human-interface-guidelines/windows-and-views/tab-views/):
![tabviews](https://user-images.githubusercontent.com/22498/26891290-65654988-4bac-11e7-965b-61a38316d8d7.png)

Bootstrap calls it a [button group](http://getbootstrap.com/components/#btn-groups):
![screenshot from 2017-06-07 18-11-08](https://user-images.githubusercontent.com/22498/26891403-ca9053a2-4bac-11e7-9e23-7906c8035b52.png)

## Design Notes

* The buttons are designed to look like other buttons on the sidebar. Same background colour, same border thickness and colour, same rounded corners, same drop shadow, same height.
   ![screenshot from 2017-06-07 19-18-51](https://user-images.githubusercontent.com/22498/26894384-2ee9b934-4bb6-11e7-83c2-0294dce605bc.png)

* When you hover over a button it looks as it will like after you click on it / as the currently clicked button looks. Helps to hint at that it is clickable and what clicking it does.

   ![peek 2017-06-07 19-16](https://user-images.githubusercontent.com/22498/26894354-0ae64674-4bb6-11e7-9fd1-da54e0e5c651.gif)

* The buttons are vertically aligned with (and the same height as) the button next to it in the bucket bar:

   ![1](https://user-images.githubusercontent.com/22498/26893914-bb7a589c-4bb4-11e7-93d8-ace7cf155043.png)

   This is unlike the existing controls, which are top-aligned with the bucket bar button but aren't the same height as it:

   ![screenshot from 2017-06-07 19-09-43](https://user-images.githubusercontent.com/22498/26893975-ee9b361a-4bb4-11e7-950e-70c4f61daf4d.png)

* The first annotation card is now vertically aligned with the top of the next button in the bucket bar:

   ![2](https://user-images.githubusercontent.com/22498/26894030-1ee8afa0-4bb5-11e7-841c-9d28625b1df1.png)

   This also means that the vertical gap between the new buttons and the first annotation is the same height as the gap between the two buttons in the bucket bar.

   Again, this is not aligned in the current design:

   ![screenshot from 2017-06-07 19-09-43](https://user-images.githubusercontent.com/22498/26894148-778e9d22-4bb5-11e7-915b-bff4cd39ee74.png)

* This vertical alignment does mean that the vertical gap above the new view switcher (between the top bar and the view switcher) is larger than the gap below the view switcher (down to the first annotation). Unfortunately you can't have everything aligned on a grid (without tweaking positions of existing components in the sidebar first).

   ![screenshot from 2017-06-07 19-04-08](https://user-images.githubusercontent.com/22498/26894199-9078f378-4bb5-11e7-95ce-bd65bae17f7f.png)

* It is centre-aligned, as these controls usually are (see examples above)

* The buttons are all same width, even though the text labels are not the same length. They remain the same width with or without a count number showing as well. This just looks better.

* The buttons remain the same width when selected and when not selected, so things don't jump around when you click on them:

   ![peek 2017-06-07 19-21](https://user-images.githubusercontent.com/22498/26894480-7dab3e9e-4bb6-11e7-8d71-d01994836ce3.gif)

  In the current design they jump around:

   ![peek 2017-06-07 19-22](https://user-images.githubusercontent.com/22498/26894542-a0e39f0a-4bb6-11e7-90ac-ec803800453d.gif)