### PR TITLE
Multiple frame detection and injection

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -326,6 +326,7 @@ gulp.task('serve-live-reload', ['serve-package'], function () {
   var LiveReloadServer = require('./scripts/gulp/live-reload-server');
   liveReloadServer = new LiveReloadServer(3000, {
     clientUrl: `http://${packageServerHostname()}:3001/hypothesis`,
+    enableMultiFrameSupport: !!process.env.MULTI_FRAME_SUPPORT,
   });
 });
 

--- a/scripts/gulp/live-reload-server.js
+++ b/scripts/gulp/live-reload-server.js
@@ -124,7 +124,7 @@ function LiveReloadServer(port, config) {
               if (!iframeIsAdded) {
                 var iframe1 = document.querySelector('#iframe1');
                 var iframeNew = iframe1.cloneNode();
-                iframeNew.srcdoc = "/document/changelog";
+                iframeNew.src = "/document/changelog";
                 iframeNew.id = "iframe2";
                 iframeIsAdded = true;
                 document.querySelector('#iframe2-container').appendChild(iframeNew);

--- a/scripts/gulp/live-reload-server.js
+++ b/scripts/gulp/live-reload-server.js
@@ -4,9 +4,18 @@ var fs = require('fs');
 var gulpUtil = require('gulp-util');
 var http = require('http');
 var WebSocketServer = require('websocket').server;
+var urlParser = require('url');
+
+function readmeText() {
+  return fs.readFileSync('./README.md', 'utf-8');
+}
+
+function licenseText() {
+  return fs.readFileSync('./LICENSE', 'utf-8');
+}
 
 function changelogText() {
-  return fs.readFileSync('./README.md', 'utf-8');
+  return fs.readFileSync('./CHANGELOG.md', 'utf-8');
 }
 
 /**
@@ -33,43 +42,103 @@ function LiveReloadServer(port, config) {
   function listen() {
     var log = gulpUtil.log;
     var server = http.createServer(function (req, response) {
-      var content = `
-    <html>
-    <head>
-      <meta charset="UTF-8">
-      <title>Hypothesis Client Test</title>
-    </head>
-    <body>
-      <div data-hypothesis-trigger style="margin: 75px 0 0 75px;">
-        Number of annotations:
-        <span data-hypothesis-annotation-count>...</span>
-      </div>
-      <pre style="margin: 20px 75px 75px 75px;">${changelogText()}</pre>
-      <script>
-      var appHost = document.location.hostname;
+      var url = urlParser.parse(req.url);
+      var content;
 
-      window.hypothesisConfig = function () {
-        return {
-          liveReloadServer: 'ws://' + appHost + ':${port}',
+      if (url.pathname === '/document/license') {
+        content = `
+          <html>
+          <head>
+            <meta charset="UTF-8">
+            <title>Hypothesis in-line frame document - License</title>
+          </head>
+          <body>
+            <pre style="margin: 20px;">${licenseText()}</pre>
+          </body>
+          </html>
+        `;
+      } else if (url.pathname === '/document/changelog') {
+        content = `
+          <html>
+          <head>
+            <meta charset="UTF-8">
+            <title>Hypothesis in-line frame document - Changelog</title>
+          </head>
+          <body>
+            <pre style="margin: 20px;">${changelogText()}</pre>
+          </body>
+          </html>
+        `;
+      } else {
+        var multiFrameContent = config.enableMultiFrameSupport ? `
+          <div style="margin: 10px 0 0 75px;">
+            <button id="add-test" style="padding: 0.6em; font-size: 0.75em">Toggle 2nd Frame</button>
+          </div>
+          <div style="margin: 10px 0 0 75px;">
+            <iframe id="iframe1" src="/document/license" style="width: 50%;height: 300px;"></iframe>
+          </div>
+          <div id="iframe2-container" style="margin: 10px 0 0 75px;">
+          </div>` : '';
 
-          // Open the sidebar when the page loads
-          openSidebar: true,
-        };
-      };
-
-      window.addEventListener('message', function (event) {
-        if (event.data.type && event.data.type === 'reloadrequest') {
-          window.location.reload();
-        }
-      });
-
-      var embedScript = document.createElement('script');
-      embedScript.src = '${config.clientUrl}';
-      document.body.appendChild(embedScript);
-      </script>
-    </body>
-    </html>
-      `;
+        content = `
+          <html>
+          <head>
+            <meta charset="UTF-8">
+            <title>Hypothesis Client Test</title>
+          </head>
+          <body>
+            <div data-hypothesis-trigger style="margin: 75px 0 0 75px;">
+              Number of annotations:
+              <span data-hypothesis-annotation-count>...</span>
+            </div>
+            ${multiFrameContent}
+            <pre style="margin: 20px 75px 75px 75px;">${readmeText()}</pre>
+            <script>
+            var appHost = document.location.hostname;
+      
+            window.hypothesisConfig = function () {
+              return {
+                liveReloadServer: 'ws://' + appHost + ':${port}',
+      
+                // Open the sidebar when the page loads
+                openSidebar: true,
+                
+                // Needed for multi frame support
+                enableMultiFrameSupport: ${config.enableMultiFrameSupport},
+                embedScriptUrl: '${config.clientUrl}'
+              };
+            };
+      
+            window.addEventListener('message', function (event) {
+              if (event.data.type && event.data.type === 'reloadrequest') {
+                window.location.reload();
+              }
+            });
+      
+            var embedScript = document.createElement('script');
+            embedScript.src = '${config.clientUrl}';
+            document.body.appendChild(embedScript);
+            
+            var iframeIsAdded = false;
+            document.querySelector('#add-test').addEventListener('click', function() {
+              if (!iframeIsAdded) {
+                var iframe1 = document.querySelector('#iframe1');
+                var iframeNew = iframe1.cloneNode();
+                iframeNew.srcdoc = "/document/changelog";
+                iframeNew.id = "iframe2";
+                iframeIsAdded = true;
+                document.querySelector('#iframe2-container').appendChild(iframeNew);
+              } else {
+                var iframe2 = document.querySelector('#iframe2');
+                iframe2.parentNode.removeChild(iframe2);
+                iframeIsAdded = false;
+              }
+            });
+            </script>
+          </body>
+          </html>
+        `;
+      }
       response.end(content);
     });
 

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -81,6 +81,8 @@ module.exports = class Guest extends Delegator
     this.anchors = []
 
     cfOptions =
+      enableMultiFrameSupport: config.enableMultiFrameSupport
+      embedScriptUrl: config.embedScriptUrl
       on: (event, handler) =>
         this.subscribe(event, handler)
       emit: (event, args...) =>

--- a/src/annotator/main.js
+++ b/src/annotator/main.js
@@ -20,6 +20,7 @@ if (window.wgxpath) {
 var $ = require('jquery');
 
 // Applications
+var Guest = require('./guest');
 var Sidebar = require('./sidebar');
 var PdfSidebar = require('./pdf-sidebar');
 
@@ -46,6 +47,8 @@ $.noConflict(true)(function() {
       Sidebar;
   if (config.hasOwnProperty('constructor')) {
     Klass = config.constructor;
+    if (Klass === "Guest") Klass = Guest;
+
     delete config.constructor;
   }
 

--- a/src/annotator/main.js
+++ b/src/annotator/main.js
@@ -45,11 +45,19 @@ $.noConflict(true)(function() {
   var Klass = window.PDFViewerApplication ?
       PdfSidebar :
       Sidebar;
+
   if (config.hasOwnProperty('constructor')) {
     Klass = config.constructor;
-    if (Klass === "Guest") Klass = Guest;
-
     delete config.constructor;
+  }
+
+  if (config.enableMultiFrameSupport && config.subFrameInstance) {
+    Klass = Guest;
+
+    // Other modules use this to detect if this
+    // frame context belongs to hypothesis.
+    // Needs to be a global property that's set.
+    window.__hypothesis_frame = true;
   }
 
   config.pluginClasses = pluginClasses;

--- a/src/annotator/plugin/cross-frame.coffee
+++ b/src/annotator/plugin/cross-frame.coffee
@@ -3,6 +3,7 @@ Plugin = require('../plugin')
 AnnotationSync = require('../annotation-sync')
 Bridge = require('../../shared/bridge')
 Discovery = require('../../shared/discovery')
+frameUtil = require('../util/frame-util')
 
 
 # Extracts individual keys from an object and returns a new one.
@@ -33,6 +34,11 @@ module.exports = class CrossFrame extends Plugin
         bridge.createChannel(source, origin, token)
       discovery.startDiscovery(onDiscoveryCallback)
 
+      # THESIS TODO: Disabled until fully implemented.
+      # 
+      # Find, and inject Hypothesis into Guest's iframes
+      # _discoverOwnFrames()
+
     this.destroy = ->
       # super doesnt work here :(
       Plugin::destroy.apply(this, arguments)
@@ -50,3 +56,20 @@ module.exports = class CrossFrame extends Plugin
 
     this.onConnect = (fn) ->
       bridge.onConnect(fn)
+
+    _discoverOwnFrames = () ->
+      # Discover existing iframes
+      iframes = frameUtil.findIFrames(elem)
+      _handleIFrames(iframes)
+
+    _handleIFrame = (iframe) ->
+      if !frameUtil.isAccessible(iframe) then return
+
+      if !frameUtil.hasHypothesis(iframe)
+        frameUtil.injectHypothesis(iframe)
+
+    _handleIFrames = (iframes) ->
+      for own index, iframe of iframes
+        _handleIFrame(iframe)
+
+

--- a/src/annotator/plugin/cross-frame.coffee
+++ b/src/annotator/plugin/cross-frame.coffee
@@ -94,6 +94,5 @@ module.exports = class CrossFrame extends Plugin
         _injectToFrame(frame)
 
     _iframeUnloaded = (frame) ->
+      # TODO: Bridge call here not yet implemented, placeholder for now
       bridge.call('destroyFrame', frame.src);
-      
-

--- a/src/annotator/plugin/cross-frame.coffee
+++ b/src/annotator/plugin/cross-frame.coffee
@@ -90,10 +90,7 @@ module.exports = class CrossFrame extends Plugin
 
     _handleFrame = (frame) ->
       if !FrameUtil.isAccessible(frame) then return
-      if frame.contentDocument.readyState != 'complete'
-        frame.addEventListener 'load', ->
-          _injectToFrame(frame)
-      else
+      FrameUtil.isLoaded frame, () ->
         _injectToFrame(frame)
 
     _iframeUnloaded = (frame) ->

--- a/src/annotator/plugin/cross-frame.coffee
+++ b/src/annotator/plugin/cross-frame.coffee
@@ -68,7 +68,7 @@ module.exports = class CrossFrame extends Plugin
       _discoverOwnFrames()
 
       # Listen for DOM mutations, to know when frames are added / removed
-      observer = new MutationObserver(debounce(_discoverOwnFrames, 300))
+      observer = new MutationObserver(debounce(_discoverOwnFrames, 300, leading: true))
       observer.observe(elem, {childList: true, subtree: true});
 
     _discoverOwnFrames = ->

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -1,0 +1,172 @@
+'use strict';
+
+var proxyquire = require('proxyquire');
+var isLoaded = require('../../util/frame-util.js').isLoaded;
+
+describe('CrossFrame multi-frame scenario', function () {
+  var fakeAnnotationSync;
+  var fakeBridge;
+  var proxyAnnotationSync;
+  var proxyBridge;
+  var container;
+  var crossFrame;
+  var options;
+
+  var sandbox = sinon.sandbox.create();
+
+  beforeEach(function () {
+    fakeBridge = {
+      createChannel: sandbox.stub(),
+      call: sandbox.stub(),
+      destroy: sandbox.stub(),
+    };
+    fakeAnnotationSync = {};
+    proxyAnnotationSync = sandbox.stub().returns(fakeAnnotationSync);
+    proxyBridge = sandbox.stub().returns(fakeBridge);
+
+    var CrossFrame = proxyquire('../../plugin/cross-frame', {
+      '../annotation-sync': proxyAnnotationSync,
+      '../../shared/bridge': proxyBridge,
+    });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    options = {
+      enableMultiFrameSupport: true,
+      embedScriptUrl: 'data:,', // empty data uri
+      on: sandbox.stub(),
+      emit: sandbox.stub(),
+    };
+
+    crossFrame = new CrossFrame(container, options);
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+    crossFrame.destroy();
+    container.parentNode.removeChild(container);
+  });
+
+  it('detects frames on page', function () {
+    // Create a frame before initializing
+    var validFrame = document.createElement('iframe');
+    container.appendChild(validFrame);
+
+    // Create another that mimics the sidebar frame
+    // This one should should not be detected
+    var invalidFrame = document.createElement('iframe');
+    invalidFrame.className = 'h-sidebar-iframe';
+    container.appendChild(invalidFrame);
+
+    // Now initialize
+    crossFrame.pluginInit();
+
+    var validFramePromise = new Promise(function (resolve) {
+      isLoaded(validFrame, function () {
+        assert(validFrame.contentDocument.body.hasChildNodes(),
+          'expected valid frame to be modified');
+        resolve();
+      });
+    });
+    var invalidFramePromise = new Promise(function (resolve) {
+      isLoaded(invalidFrame, function () {
+        assert(!invalidFrame.contentDocument.body.hasChildNodes(),
+          'expected invalid frame to not be modified');
+        resolve();
+      });
+    });
+
+    return Promise.all([validFramePromise, invalidFramePromise]);
+  });
+
+  it('detects removed frames', function () {
+    // Create a frame before initializing
+    var frame = document.createElement('iframe');
+    container.appendChild(frame);
+
+    // Now initialize
+    crossFrame.pluginInit();
+
+    // Remove the frame
+    frame.remove();
+
+    assert.calledWith(fakeBridge.call, 'destroyFrame');
+  });
+
+  it('injects embed script in frame', function () {
+    var frame = document.createElement('iframe');
+    container.appendChild(frame);
+
+    crossFrame.pluginInit();
+
+    return new Promise(function (resolve) {
+      isLoaded(frame, function () {
+        var scriptElement = frame.contentDocument.querySelector('script[src]');
+        assert(scriptElement, 'expected embed script to be injected');
+        assert.equal(scriptElement.src, options.embedScriptUrl,
+          'unexpected embed script source');
+        resolve();
+      });
+    });
+  });
+
+  it('excludes injection from already injected frames', function () {
+    var frame = document.createElement('iframe');
+    frame.srcdoc = '<script>window.__hypothesis_frame = true;</script>';
+    container.appendChild(frame);
+
+    crossFrame.pluginInit();
+
+    return new Promise(function (resolve) {
+      isLoaded(frame, function () {
+        var scriptElement = frame.contentDocument.querySelector('script[src]');
+        assert(!scriptElement, 'expected embed script to not be injected');
+        resolve();
+      });
+    });
+  });
+
+  it('detects dynamically added frames', function () {
+    // Initialize with no initial frame, unlike before
+    crossFrame.pluginInit();
+
+    // Add a frame to the DOM
+    var frame = document.createElement('iframe');
+    container.appendChild(frame);
+
+    return new Promise(function (resolve) {
+      // Yield to let the DOM and CrossFrame catch up
+      setTimeout(function () {
+        isLoaded(frame, function () {
+          assert(frame.contentDocument.body.hasChildNodes(),
+            'expected dynamically added frame to be modified');
+          resolve();
+        });
+      }, 0);
+    });
+  });
+
+  it('detects dynamically removed frames', function () {
+    // Create a frame before initializing
+    var frame = document.createElement('iframe');
+    container.appendChild(frame);
+
+    // Now initialize
+    crossFrame.pluginInit();
+
+    return new Promise(function (resolve) {
+      // Yield to let the DOM and CrossFrame catch up
+      setTimeout(function () {
+        frame.remove();
+
+        // Yield again
+        setTimeout(function () {
+          assert.calledWith(fakeBridge.call, 'destroyFrame');
+          resolve();
+        }, 0);
+      }, 0);
+    });
+  });
+
+});

--- a/src/annotator/util/frame-util.js
+++ b/src/annotator/util/frame-util.js
@@ -43,10 +43,21 @@ function isValid (iframe) {
   return iframe.className !== 'h-sidebar-iframe';
 }
 
+function isLoaded (iframe, callback) {
+  if (iframe.contentDocument.readyState !== 'complete') {
+    iframe.addEventListener('load', function () {
+      callback();
+    });
+  } else {
+    callback();
+  }
+}
+
 module.exports = {
   findFrames: findFrames,
   hasHypothesis: hasHypothesis,
   injectHypothesis: injectHypothesis,
   isAccessible: isAccessible,
   isValid: isValid,
+  isLoaded: isLoaded,
 };

--- a/src/annotator/util/frame-util.js
+++ b/src/annotator/util/frame-util.js
@@ -20,6 +20,7 @@ function injectHypothesis (iframe, scriptUrl) {
 
   var src = scriptUrl;
   var embed = document.createElement('script');
+  embed.className = 'js-hypothesis-embed';
   embed.async = true;
   embed.src = src;
 

--- a/src/annotator/util/frame-util.js
+++ b/src/annotator/util/frame-util.js
@@ -1,0 +1,102 @@
+'use strict';
+// THESIS TODO: Once this module is finalized (more or less), then make
+// sure to remove JQuery and refactor.
+var $ = require('jquery');
+
+module.exports = {
+  findIFrames,
+  hasHypothesis,
+  injectHypothesis,
+  isAccessible,
+  isValid,
+};
+
+// Find all iframes within this iframe only
+function findIFrames(iframe) {
+  var iframes = [];
+
+  $('iframe', iframe).each(function(index, iframe) {
+    if ( isValid(iframe) ) {
+      iframes.push(iframe);
+    } 
+  });
+
+  return iframes;
+}
+
+// Check if the iframe has already been injected
+function hasHypothesis(iframe) {
+  // THESIS TODO: Are there better identifiers to use?
+  var scripts = {
+    src: [
+      '/hypothesis',
+      '/embed.js',
+    ]
+  };
+
+  var frameBody = iframe.ownerDocument.body;
+  var childNodes = frameBody.childNodes;
+  var hasHypothesis = false;
+  for (var i = 0; i < childNodes.length-1; i++) {
+    var node = childNodes[i];
+    if (node.tagName !== 'SCRIPT') continue; // Skip to next increment
+
+    for (var j = 0; j < scripts.src.length-1; j++) {
+      var src = scripts.src[j];
+      if (node.src.includes(src)) {
+        hasHypothesis = true;
+        return; // Found our answer, stop looping.
+      }
+    }
+  }
+
+  return hasHypothesis;
+}
+
+// Inject embed.js into the iframe
+function injectHypothesis(iframe, i) {
+  if (!iframe) return;
+
+  var iframes;
+  // Support arrays via recursion
+  if (iframe.constructor === Array) {
+    if (!iframe.length) return;
+    iframes = iframe;
+    i = (i != undefined) ? i : 0; // if set, use i. Otherwise, use 0
+    iframe = iframes[i];
+  }
+
+  var config = document.createElement('script');
+  config.className = "js-hypothesis-config";
+  config.type = "application/json";
+  config.innerText = ' {"constructor": "Guest" }';
+
+  // THESIS TODO: Temporarily hardcoded
+  var src = 'http://localhost:3001/hypothesis';
+  var embed = document.createElement('script');
+  embed.async = true;
+  embed.src = src;
+
+  iframe.contentDocument.body.appendChild(config);
+  iframe.contentDocument.body.appendChild(embed);
+
+  if (iframes && i < iframes.length-1) {
+    this._injectHypothesis(iframes, ++i);
+  }
+}
+
+// Check if we can access this iframe's document
+function isAccessible(iframe) {
+  try {
+    iframe.contentDocument;
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+// Check if this is an iframe that we want to inject embed.js into
+function isValid(iframe) {
+  // Currently only checks if it's not the h-sidebar
+  return (iframe.className !== 'h-sidebar-iframe');
+}

--- a/src/shared/frame-rpc.js
+++ b/src/shared/frame-rpc.js
@@ -52,7 +52,7 @@ function RPC (src, dst, origin, methods) {
     
     this._onmessage = function (ev) {
         if (self._destroyed) return;
-        if (self.dst != ev.source) return;
+        if (self.dst !== ev.source) return;
         if (self.origin !== '*' && ev.origin !== self.origin) return;
         if (!ev.data || typeof ev.data !== 'object') return;
         if (ev.data.protocol !== 'frame-rpc') return;

--- a/src/shared/frame-rpc.js
+++ b/src/shared/frame-rpc.js
@@ -52,6 +52,7 @@ function RPC (src, dst, origin, methods) {
     
     this._onmessage = function (ev) {
         if (self._destroyed) return;
+        if (self.dst != ev.source) return;
         if (self.origin !== '*' && ev.origin !== self.origin) return;
         if (!ev.data || typeof ev.data !== 'object') return;
         if (ev.data.protocol !== 'frame-rpc') return;

--- a/src/shared/polyfills.js
+++ b/src/shared/polyfills.js
@@ -6,6 +6,7 @@ require('core-js/es6/set');
 require('core-js/fn/array/find');
 require('core-js/fn/array/find-index');
 require('core-js/fn/array/from');
+require('core-js/fn/array/includes');
 require('core-js/fn/object/assign');
 
 // ES2017

--- a/src/shared/test/bridge-test.coffee
+++ b/src/shared/test/bridge-test.coffee
@@ -160,6 +160,7 @@ describe 'Bridge', ->
       }
 
       event = {
+        source: fakeWindow
         origin: 'http://example.com'
         data: data
       }
@@ -182,6 +183,7 @@ describe 'Bridge', ->
       }
 
       event = {
+        source: fakeWindow
         origin: 'http://example.com'
         data: data
       }


### PR DESCRIPTION
This is part of the ongoing development of multiple iframe document support.

These changes add a way for the `CrossFrame` module to detect other frames on the page and inject hypothesis client code as an embed script in these frames. Once a frame has been injected the existing code will go on and do a handshake (`Discovery`) to establish communication between the frames (`Bridge`). This works under the assumption that the frames will be cross domain accessible in some way.

Merging in these changes will not activate the new code paths because of a "feature flag" that needs to be enabled. You can give the changes a try by setting the `MULTI_FRAME_SUPPORT=true` environment variable in your shell for development, or by using the `enableMultiFrameSupport: true` key/value pair in a hypothesis client config object.

