### PR TITLE
Extract isBrowserExtension() into a separate settings function

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -24,15 +24,7 @@ function configFrom(window_) {
     annotations: settings.annotations(window_.location.href),
   };
 
-  var chromeExt = 'chrome-extension://';
-  var mozExt = 'moz-extension://';
-  var edgeExt = 'ms-browser-extension://';
-
-  // If the client is injected by the browser extension, ignore
-  // the rest of the host page config.
-  if (config.app.indexOf(chromeExt) === 0 ||
-    config.app.indexOf(mozExt) === 0||
-    config.app.indexOf(edgeExt) === 0) {
+  if (settings.isBrowserExtension(config)) {
     return config;
   }
 

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -102,9 +102,28 @@ function configFuncSettingsFrom(window_) {
   return window_.hypothesisConfig();
 }
 
+/**
+ * Return true if the client is from a browser extension.
+ *
+ * @returns {boolean} true if this instance of the Hypothesis client is one
+ *   distributed in a browser extension, false if it's one embedded in a
+ *   website.
+ *
+ */
+function isBrowserExtension(config) {
+  if (config.app.indexOf('chrome-extension://') === 0 ||
+    config.app.indexOf('moz-extension://') === 0 ||
+    config.app.indexOf('ms-browser-extension://') === 0) {
+    return true;
+  }
+
+  return false;
+}
+
 module.exports = {
   app: app,
   annotations: annotations,
   query: query,
   configFuncSettingsFrom: configFuncSettingsFrom,
+  isBrowserExtension: isBrowserExtension,
 };

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -111,13 +111,7 @@ function configFuncSettingsFrom(window_) {
  *
  */
 function isBrowserExtension(config) {
-  if (config.app.indexOf('chrome-extension://') === 0 ||
-    config.app.indexOf('moz-extension://') === 0 ||
-    config.app.indexOf('ms-browser-extension://') === 0) {
-    return true;
-  }
-
-  return false;
+  return !(config.app.startsWith('http://') || config.app.startsWith('https://'));
 }
 
 module.exports = {

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -18,7 +18,7 @@ function fakeWindow() {
   };
 }
 
-describe('annotator.config', function() {
+describe('annotator.config.index', function() {
   beforeEach('reset fakeSharedSettings', function() {
     fakeSharedSettings.jsonConfigsFrom = sinon.stub().returns({});
   });

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -28,6 +28,7 @@ describe('annotator.config', function() {
     fakeSettings.annotations = sinon.stub().returns(null);
     fakeSettings.query = sinon.stub().returns(null);
     fakeSettings.configFuncSettingsFrom = sinon.stub().returns({});
+    fakeSettings.isBrowserExtension = sinon.stub().returns(false);
   });
 
   it('gets the config.app setting', function() {
@@ -188,39 +189,38 @@ describe('annotator.config', function() {
   });
 
   context('when the client is injected by the browser extension', function() {
-    beforeEach(function() {
+    beforeEach('configure a browser extension client', function() {
+      fakeSettings.isBrowserExtension.returns(true);
+    });
+
+    it('still reads the config.app setting from the host page', function() {
+      fakeSettings.app.returns('SOME_APP_URL');
+
+      assert.equal(configFrom(fakeWindow()).app, fakeSettings.app());
+    });
+
+    it('still reads the config.query setting from the host page', function() {
+      fakeSettings.query.returns('SOME_QUERY');
+
+      assert.equal(configFrom(fakeWindow()).query, fakeSettings.query());
+    });
+
+    it('still reads the config.annotations setting from the host page', function() {
       fakeSettings.annotations.returns('SOME_ANNOTATION_ID');
+
+      assert.equal(configFrom(fakeWindow()).annotations, fakeSettings.annotations());
+    });
+
+    it('ignores settings from JSON objects in the host page', function() {
       fakeSharedSettings.jsonConfigsFrom.returns({foo: 'bar'});
+
+      assert.isUndefined(configFrom(fakeWindow()).foo);
     });
 
-    it('ignores the host page config on chrome', function() {
-      fakeSettings.app.returns('chrome-extension://abcdef');
+    it('ignores settings from the hypothesisConfig() function in the host page', function() {
+      fakeSettings.configFuncSettingsFrom.returns({foo: 'bar'});
 
-      var config = configFrom(fakeWindow());
-
-      assert.equal(config.app, 'chrome-extension://abcdef');
-      assert.equal(config.annotations, 'SOME_ANNOTATION_ID');
-      assert.isUndefined(config.foo);
-    });
-
-    it('ignores the host page config on firefox', function() {
-      fakeSettings.app.returns('moz-extension://abcdef');
-
-      var config = configFrom(fakeWindow());
-
-      assert.equal(config.app, 'moz-extension://abcdef');
-      assert.equal(config.annotations, 'SOME_ANNOTATION_ID');
-      assert.isUndefined(config.foo);
-    });
-
-    it('ignores the host page config on edge', function() {
-      fakeSettings.app.returns('ms-browser-extension://abcdef');
-
-      var config = configFrom(fakeWindow());
-
-      assert.equal(config.app, 'ms-browser-extension://abcdef');
-      assert.equal(config.annotations, 'SOME_ANNOTATION_ID');
-      assert.isUndefined(config.foo);
+      assert.isUndefined(configFrom(fakeWindow()).foo);
     });
   });
 

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -4,7 +4,7 @@ var settings = require('../settings');
 
 var sandbox = sinon.sandbox.create();
 
-describe('annotation.config.settings', function() {
+describe('annotator.config.settings', function() {
 
   afterEach('reset the sandbox', function() {
     sandbox.restore();

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -236,4 +236,39 @@ describe('annotation.config.settings', function() {
       });
     });
   });
+
+  describe('#isBrowserExtension', function() {
+    [
+      {
+        url: 'chrome-extension://abcxyz',
+        returns: true,
+      },
+      {
+        url: 'moz-extension://abcxyz',
+        returns: true,
+      },
+      {
+        url: 'ms-browser-extension://abcxyz',
+        returns: true,
+      },
+      {
+        url: 'http://partner.org',
+        returns: false,
+      },
+      {
+        url: 'https://partner.org',
+        returns: false,
+      },
+      {
+        url: 'ftp://partner.org',
+        returns: false,
+      },
+    ].forEach(function(test) {
+      it('returns ' + test.returns + ' for ' + test.url, function() {
+        assert.equal(
+          settings.isBrowserExtension({app: test.url}),
+          test.returns);
+      });
+    });
+  });
 });

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -259,9 +259,10 @@ describe('annotation.config.settings', function() {
         url: 'https://partner.org',
         returns: false,
       },
+      // It considers anything not http(s) to be a browser extension.
       {
         url: 'ftp://partner.org',
-        returns: false,
+        returns: true,
       },
     ].forEach(function(test) {
       it('returns ' + test.returns + ' for ' + test.url, function() {


### PR DESCRIPTION
Also reverse its polarity so that `isBrowserExtension()` becomes `isEmbedded()` and takes a whitelist approach returning `true` only for http and https URLs. I think this is safer and also makes the code simpler. (Admittedly this actually makes the `index.js` part of the code more awkward - `if (!isEmbedded(` rather than `if (isBrowserExtension(` but I expect this logic to be getting factored out of `index.js` in the future and then it might look nicer).