### PR TITLE
(config 1/n): Move isBrowserExtension() into own file

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -25,7 +25,7 @@ function configFrom(window_) {
     annotations: settings.annotations(window_.location.href),
   };
 
-  if (isBrowserExtension(config)) {
+  if (isBrowserExtension(config.app)) {
     return config;
   }
 

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -2,6 +2,7 @@
 
 var settings = require('./settings');
 var sharedSettings = require('../../shared/settings');
+var isBrowserExtension = require('./is-browser-extension');
 
 /**
  * Reads the Hypothesis configuration from the environment.
@@ -24,7 +25,7 @@ function configFrom(window_) {
     annotations: settings.annotations(window_.location.href),
   };
 
-  if (settings.isBrowserExtension(config)) {
+  if (isBrowserExtension(config)) {
     return config;
   }
 

--- a/src/annotator/config/is-browser-extension.js
+++ b/src/annotator/config/is-browser-extension.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+ * Return true if the client is from a browser extension.
+ *
+ * @returns {boolean} true if this instance of the Hypothesis client is one
+ *   distributed in a browser extension, false if it's one embedded in a
+ *   website.
+ *
+ */
+function isBrowserExtension(config) {
+  return !(config.app.startsWith('http://') || config.app.startsWith('https://'));
+}
+
+module.exports = isBrowserExtension;

--- a/src/annotator/config/is-browser-extension.js
+++ b/src/annotator/config/is-browser-extension.js
@@ -8,8 +8,8 @@
  *   website.
  *
  */
-function isBrowserExtension(config) {
-  return !(config.app.startsWith('http://') || config.app.startsWith('https://'));
+function isBrowserExtension(app) {
+  return !(app.startsWith('http://') || app.startsWith('https://'));
 }
 
 module.exports = isBrowserExtension;

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -102,22 +102,9 @@ function configFuncSettingsFrom(window_) {
   return window_.hypothesisConfig();
 }
 
-/**
- * Return true if the client is from a browser extension.
- *
- * @returns {boolean} true if this instance of the Hypothesis client is one
- *   distributed in a browser extension, false if it's one embedded in a
- *   website.
- *
- */
-function isBrowserExtension(config) {
-  return !(config.app.startsWith('http://') || config.app.startsWith('https://'));
-}
-
 module.exports = {
   app: app,
   annotations: annotations,
   query: query,
   configFuncSettingsFrom: configFuncSettingsFrom,
-  isBrowserExtension: isBrowserExtension,
 };

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -5,9 +5,11 @@ var util = require('../../../shared/test/util');
 
 var fakeSharedSettings = {};
 var fakeSettings = {};
+var fakeIsBrowserExtension = sinon.stub();
 
 var configFrom = proxyquire('../index', util.noCallThru({
   './settings': fakeSettings,
+  './is-browser-extension': fakeIsBrowserExtension,
   '../../shared/settings': fakeSharedSettings,
 }));
 
@@ -28,7 +30,11 @@ describe('annotator.config.index', function() {
     fakeSettings.annotations = sinon.stub().returns(null);
     fakeSettings.query = sinon.stub().returns(null);
     fakeSettings.configFuncSettingsFrom = sinon.stub().returns({});
-    fakeSettings.isBrowserExtension = sinon.stub().returns(false);
+  });
+
+  beforeEach('reset fakeIsBrowserExtension()', function() {
+    fakeIsBrowserExtension.reset();
+    fakeIsBrowserExtension.returns(false);
   });
 
   it('gets the config.app setting', function() {
@@ -190,7 +196,7 @@ describe('annotator.config.index', function() {
 
   context('when the client is injected by the browser extension', function() {
     beforeEach('configure a browser extension client', function() {
-      fakeSettings.isBrowserExtension.returns(true);
+      fakeIsBrowserExtension.returns(true);
     });
 
     it('still reads the config.app setting from the host page', function() {

--- a/src/annotator/config/test/is-browser-extension-test.js
+++ b/src/annotator/config/test/is-browser-extension-test.js
@@ -31,7 +31,7 @@ describe('annotator.config.isBrowserExtension', function() {
     },
   ].forEach(function(test) {
     it('returns ' + test.returns + ' for ' + test.url, function() {
-      assert.equal(isBrowserExtension({app: test.url}), test.returns);
+      assert.equal(isBrowserExtension(test.url), test.returns);
     });
   });
 });

--- a/src/annotator/config/test/is-browser-extension-test.js
+++ b/src/annotator/config/test/is-browser-extension-test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var isBrowserExtension = require('../is-browser-extension');
+
+describe('annotator.config.isBrowserExtension', function() {
+  [
+    {
+      url: 'chrome-extension://abcxyz',
+      returns: true,
+    },
+    {
+      url: 'moz-extension://abcxyz',
+      returns: true,
+    },
+    {
+      url: 'ms-browser-extension://abcxyz',
+      returns: true,
+    },
+    {
+      url: 'http://partner.org',
+      returns: false,
+    },
+    {
+      url: 'https://partner.org',
+      returns: false,
+    },
+    // It considers anything not http(s) to be a browser extension.
+    {
+      url: 'ftp://partner.org',
+      returns: true,
+    },
+  ].forEach(function(test) {
+    it('returns ' + test.returns + ' for ' + test.url, function() {
+      assert.equal(isBrowserExtension({app: test.url}), test.returns);
+    });
+  });
+});

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -236,40 +236,4 @@ describe('annotator.config.settings', function() {
       });
     });
   });
-
-  describe('#isBrowserExtension', function() {
-    [
-      {
-        url: 'chrome-extension://abcxyz',
-        returns: true,
-      },
-      {
-        url: 'moz-extension://abcxyz',
-        returns: true,
-      },
-      {
-        url: 'ms-browser-extension://abcxyz',
-        returns: true,
-      },
-      {
-        url: 'http://partner.org',
-        returns: false,
-      },
-      {
-        url: 'https://partner.org',
-        returns: false,
-      },
-      // It considers anything not http(s) to be a browser extension.
-      {
-        url: 'ftp://partner.org',
-        returns: true,
-      },
-    ].forEach(function(test) {
-      it('returns ' + test.returns + ' for ' + test.url, function() {
-        assert.equal(
-          settings.isBrowserExtension({app: test.url}),
-          test.returns);
-      });
-    });
-  });
 });


### PR DESCRIPTION
Cut-paste the `isBrowserExtension()` function and its unit tests out of `settings.js` and into its own `is-browser-extension.js` file.

This is because in a future refactoring `index.js` isn't going to call `isBrowserExtension()` anymore, only `settings.js` will call it, which would make `isBrowserExtension()` a private helper function of `settings.js`, but I don't want to lose `isBrowserExtension()`'s unit tests so I'm moving it into its own file from where `settings.js` (in the future, `index.js` currently) can import and use it. This way `isBrowserExtension()` remains part of the public API of its containing module and can have unit tests.

The second commit - tweaking `isBrowserExtension()` to take just the `config.app` string that it needs and not the entire `config` object as argument - is necessary for `isBrowserExtension()` to be called by `settings.js` instead of `index.js` in the future - when it's called by `settings.js` the `config` object as a whole won't be available (and hasn't been constructed yet).