### PR TITLE
(config 2/n): Move configFuncSettingsFrom() into its own file

### DIFF
--- a/src/annotator/config/config-func-settings-from.js
+++ b/src/annotator/config/config-func-settings-from.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/**
+ * Return an object containing config settings from window.hypothesisConfig().
+ *
+ * Return an object containing config settings returned by the
+ * window.hypothesisConfig() function provided by the host page:
+ *
+ *   {
+ *     fooSetting: 'fooValue',
+ *     barSetting: 'barValue',
+ *     ...
+ *   }
+ *
+ * If there's no window.hypothesisConfig() function then return {}.
+ *
+ * @param {Window} window_ - The window to search for a hypothesisConfig() function
+ * @return {Object} - Any config settings returned by hypothesisConfig()
+ *
+ */
+function configFuncSettingsFrom(window_) {
+  if (!window_.hasOwnProperty('hypothesisConfig')) {
+    return {};
+  }
+
+  if (typeof window_.hypothesisConfig !== 'function') {
+    var docs = 'https://h.readthedocs.io/projects/client/en/latest/publishers/config/#window.hypothesisConfig';
+    console.warn('hypothesisConfig must be a function, see: ' + docs);
+    return {};
+  }
+
+  return window_.hypothesisConfig();
+}
+
+module.exports = configFuncSettingsFrom;

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -3,6 +3,7 @@
 var settings = require('./settings');
 var sharedSettings = require('../../shared/settings');
 var isBrowserExtension = require('./is-browser-extension');
+var configFuncSettingsFrom = require('./config-func-settings-from');
 
 /**
  * Reads the Hypothesis configuration from the environment.
@@ -30,7 +31,7 @@ function configFrom(window_) {
   }
 
   Object.assign(config, sharedSettings.jsonConfigsFrom(window_.document));
-  Object.assign(config, settings.configFuncSettingsFrom(window_));
+  Object.assign(config, configFuncSettingsFrom(window_));
 
   // Convert legacy keys/values in config to corresponding current
   // configuration.

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -70,41 +70,8 @@ function query(url) {
   return null;
 }
 
-/**
- * Return an object containing config settings from window.hypothesisConfig().
- *
- * Return an object containing config settings returned by the
- * window.hypothesisConfig() function provided by the host page:
- *
- *   {
- *     fooSetting: 'fooValue',
- *     barSetting: 'barValue',
- *     ...
- *   }
- *
- * If there's no window.hypothesisConfig() function then return {}.
- *
- * @param {Window} window_ - The window to search for a hypothesisConfig() function
- * @return {Object} - Any config settings returned by hypothesisConfig()
- *
- */
-function configFuncSettingsFrom(window_) {
-  if (!window_.hasOwnProperty('hypothesisConfig')) {
-    return {};
-  }
-
-  if (typeof window_.hypothesisConfig !== 'function') {
-    var docs = 'https://h.readthedocs.io/projects/client/en/latest/publishers/config/#window.hypothesisConfig';
-    console.warn('hypothesisConfig must be a function, see: ' + docs);
-    return {};
-  }
-
-  return window_.hypothesisConfig();
-}
-
 module.exports = {
   app: app,
   annotations: annotations,
   query: query,
-  configFuncSettingsFrom: configFuncSettingsFrom,
 };

--- a/src/annotator/config/test/config-func-settings-from-test.js
+++ b/src/annotator/config/test/config-func-settings-from-test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var configFuncSettingsFrom = require('../config-func-settings-from');
+
+describe('annotator.config.configFuncSettingsFrom', function() {
+  var sandbox = sinon.sandbox.create();
+
+  afterEach('reset the sandbox', function() {
+    sandbox.restore();
+  });
+
+  context("when there's no window.hypothesisConfig() function", function() {
+    it('returns {}', function() {
+      var fakeWindow = {};
+
+      assert.deepEqual(configFuncSettingsFrom(fakeWindow), {});
+    });
+  });
+
+  context("when window.hypothesisConfig() isn't a function", function() {
+    beforeEach('stub console.warn()', function() {
+      sandbox.stub(console, 'warn');
+    });
+
+    function fakeWindow() {
+      return {hypothesisConfig: 42};
+    }
+
+    it('returns {}', function() {
+      assert.deepEqual(configFuncSettingsFrom(fakeWindow()), {});
+    });
+
+    it('logs a warning', function() {
+      configFuncSettingsFrom(fakeWindow());
+
+      assert.calledOnce(console.warn);
+      assert.isTrue(console.warn.firstCall.args[0].startsWith(
+        'hypothesisConfig must be a function'
+      ));
+    });
+  });
+
+  context('when window.hypothesisConfig() is a function', function() {
+    it('returns whatever window.hypothesisConfig() returns', function () {
+      // It just blindly returns whatever hypothesisConfig() returns
+      // (even if it's not an object).
+      var fakeWindow = { hypothesisConfig: sinon.stub().returns(42) };
+
+      assert.equal(configFuncSettingsFrom(fakeWindow), 42);
+    });
+  });
+});

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -5,11 +5,13 @@ var util = require('../../../shared/test/util');
 
 var fakeSharedSettings = {};
 var fakeSettings = {};
+var fakeConfigFuncSettingsFrom = sinon.stub();
 var fakeIsBrowserExtension = sinon.stub();
 
 var configFrom = proxyquire('../index', util.noCallThru({
   './settings': fakeSettings,
   './is-browser-extension': fakeIsBrowserExtension,
+  './config-func-settings-from': fakeConfigFuncSettingsFrom,
   '../../shared/settings': fakeSharedSettings,
 }));
 
@@ -29,12 +31,16 @@ describe('annotator.config.index', function() {
     fakeSettings.app = sinon.stub().returns('IFRAME_URL');
     fakeSettings.annotations = sinon.stub().returns(null);
     fakeSettings.query = sinon.stub().returns(null);
-    fakeSettings.configFuncSettingsFrom = sinon.stub().returns({});
   });
 
   beforeEach('reset fakeIsBrowserExtension()', function() {
     fakeIsBrowserExtension.reset();
     fakeIsBrowserExtension.returns(false);
+  });
+
+  beforeEach('reset fakeConfigFuncSettingsFrom()', function() {
+    fakeConfigFuncSettingsFrom.reset();
+    fakeConfigFuncSettingsFrom.returns({});
   });
 
   it('gets the config.app setting', function() {
@@ -92,13 +98,13 @@ describe('annotator.config.index', function() {
 
     configFrom(window_);
 
-    assert.calledOnce(fakeSettings.configFuncSettingsFrom);
-    assert.calledWithExactly(fakeSettings.configFuncSettingsFrom, window_);
+    assert.calledOnce(fakeConfigFuncSettingsFrom);
+    assert.calledWithExactly(fakeConfigFuncSettingsFrom, window_);
   });
 
   context('when configFuncSettingsFrom() returns an object', function() {
     it('reads arbitrary settings from configFuncSettingsFrom() into config', function() {
-      fakeSettings.configFuncSettingsFrom.returns({foo: 'bar'});
+      fakeConfigFuncSettingsFrom.returns({foo: 'bar'});
 
       var config = configFrom(fakeWindow());
 
@@ -106,7 +112,7 @@ describe('annotator.config.index', function() {
     });
 
     specify('hypothesisConfig() settings override js-hypothesis-config ones', function() {
-      fakeSettings.configFuncSettingsFrom.returns({
+      fakeConfigFuncSettingsFrom.returns({
         foo: 'fooFromHypothesisConfigFunc'});
       fakeSharedSettings.jsonConfigsFrom.returns({
         foo: 'fooFromJSHypothesisConfigObj',
@@ -224,7 +230,7 @@ describe('annotator.config.index', function() {
     });
 
     it('ignores settings from the hypothesisConfig() function in the host page', function() {
-      fakeSettings.configFuncSettingsFrom.returns({foo: 'bar'});
+      fakeConfigFuncSettingsFrom.returns({foo: 'bar'});
 
       assert.isUndefined(configFrom(fakeWindow()).foo);
     });

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -2,13 +2,7 @@
 
 var settings = require('../settings');
 
-var sandbox = sinon.sandbox.create();
-
 describe('annotator.config.settings', function() {
-
-  afterEach('reset the sandbox', function() {
-    sandbox.restore();
-  });
 
   describe('#app', function() {
     function appendLinkToDocument(href) {
@@ -190,49 +184,6 @@ describe('annotator.config.settings', function() {
         var url = 'http://localhost:3000#annotations:query:abc123';
 
         assert.isNull(settings.query(url));
-      });
-    });
-  });
-
-  describe('#configFuncSettingsFrom', function() {
-    context("when there's no window.hypothesisConfig() function", function() {
-      it('returns {}', function() {
-        var fakeWindow = {};
-
-        assert.deepEqual(settings.configFuncSettingsFrom(fakeWindow), {});
-      });
-    });
-
-    context("when window.hypothesisConfig() isn't a function", function() {
-      beforeEach('stub console.warn()', function() {
-        sandbox.stub(console, 'warn');
-      });
-
-      function fakeWindow() {
-        return {hypothesisConfig: 42};
-      }
-
-      it('returns {}', function() {
-        assert.deepEqual(settings.configFuncSettingsFrom(fakeWindow()), {});
-      });
-
-      it('logs a warning', function() {
-        settings.configFuncSettingsFrom(fakeWindow());
-
-        assert.calledOnce(console.warn);
-        assert.isTrue(console.warn.firstCall.args[0].startsWith(
-          'hypothesisConfig must be a function'
-        ));
-      });
-    });
-
-    context('when window.hypothesisConfig() is a function', function() {
-      it('returns whatever window.hypothesisConfig() returns', function () {
-        // It just blindly returns whatever hypothesisConfig() returns
-        // (even if it's not an object).
-        var fakeWindow = { hypothesisConfig: sinon.stub().returns(42) };
-
-        assert.equal(settings.configFuncSettingsFrom(fakeWindow), 42);
       });
     });
   });


### PR DESCRIPTION
Cut-paste the configFuncSettingsFrom() function and its unit tests out
of settings.js and into its own config-func-settings-from.js file.

This is because in a future refactoring index.js isn't going to call
configFuncSettingsFrom() anymore, only settings.js will call it, which
would make configFuncSettingsFrom() a private helper function of
settings.js, but I don't want to lose configFuncSettingsFrom()'s unit
tests so I'm moving it into its own file from where settings.js (in the
future, index.js currently) can import and use it. This way
configFuncSettingsFrom() remains part of the public API of its
containing module and can have unit tests.