### PR TITLE
(config 3/n): Turn the settings obj into a settingsFrom function 

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var settings = require('./settings');
+var settingsFrom = require('./settings');
 var sharedSettings = require('../../shared/settings');
 var isBrowserExtension = require('./is-browser-extension');
 var configFuncSettingsFrom = require('./config-func-settings-from');
@@ -11,8 +11,10 @@ var configFuncSettingsFrom = require('./config-func-settings-from');
  * @param {Window} window_ - The Window object to read config from.
  */
 function configFrom(window_) {
+  var settings = settingsFrom(window_);
+
   var config = {
-    app: settings.app(window_.document),
+    app: settings.app,
 
     // Extract the default annotation ID or query from the URL.
     //
@@ -22,8 +24,8 @@ function configFrom(window_) {
     //
     // In environments where the config has not been injected into the DOM,
     // we try to retrieve it from the URL here.
-    query: settings.query(window_.location.href),
-    annotations: settings.annotations(window_.location.href),
+    query: settings.query,
+    annotations: settings.annotations,
   };
 
   if (isBrowserExtension(config.app)) {

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -1,77 +1,79 @@
 'use strict';
 
-/**
- * Return the href URL of the first annotator link in the given document.
- *
- * Return the value of the href attribute of the first
- * `<link type="application/annotator+html">` element in the given document.
- *
- * This URL is used as the src of the sidebar's iframe.
- *
- * @param {Document} - The document to search.
- * @return {string} - The URL to use for the sidebar's iframe.
- *
- * @throws {Error} - If there's no annotator link or the first annotator has
- *   no href.
- *
- */
-function app(document_) {
-  var link = document_.querySelector('link[type="application/annotator+html"]');
+function settingsFrom(window_) {
 
-  if (!link) {
-    throw new Error('No application/annotator+html link in the document');
-  }
+  /**
+   * Return the href URL of the first annotator link in the given document.
+   *
+   * Return the value of the href attribute of the first
+   * `<link type="application/annotator+html">` element in the given document.
+   *
+   * This URL is used as the src of the sidebar's iframe.
+   *
+   * @return {string} - The URL to use for the sidebar's iframe.
+   *
+   * @throws {Error} - If there's no annotator link or the first annotator has
+   *   no href.
+   *
+   */
+  function app() {
+    var link = window_.document.querySelector('link[type="application/annotator+html"]');
 
-  if (!link.href) {
-    throw new Error('application/annotator+html link has no href');
-  }
-
-  return link.href;
-}
-
-/**
- * Return the `#annotations:*` ID from the given URL's fragment.
- *
- * If the URL contains a `#annotations:<ANNOTATION_ID>` fragment then return
- * the annotation ID extracted from the fragment. Otherwise return `null`.
- *
- * @param {string} url - The URL to extract the ID from.
- * @return {string|null} - The extracted ID, or null.
- */
-function annotations(url) {
-  // Annotation IDs are url-safe-base64 identifiers
-  // See https://tools.ietf.org/html/rfc4648#page-7
-  var annotFragmentMatch = url.match(/#annotations:([A-Za-z0-9_-]+)$/);
-  if (annotFragmentMatch) {
-    return annotFragmentMatch[1];
-  }
-  return null;
-}
-
-/**
- * Return the `#annotations:query:*` query from the given URL's fragment.
- *
- * If the URL contains a `#annotations:query:*` (or `#annotatons:q:*`) fragment
- * then return a the query part extracted from the fragment.
- * Otherwise return `null`.
- *
- * @param {string} url - The URL to extract the query from.
- * @return {string|null} - The extracted query, or null.
- */
-function query(url) {
-  var queryFragmentMatch = url.match(/#annotations:(query|q):(.+)$/i);
-  if (queryFragmentMatch) {
-    try {
-      return decodeURI(queryFragmentMatch[2]);
-    } catch (err) {
-      // URI Error should return the page unfiltered.
+    if (!link) {
+      throw new Error('No application/annotator+html link in the document');
     }
+
+    if (!link.href) {
+      throw new Error('application/annotator+html link has no href');
+    }
+
+    return link.href;
   }
-  return null;
+
+  /**
+   * Return the `#annotations:*` ID from the given URL's fragment.
+   *
+   * If the URL contains a `#annotations:<ANNOTATION_ID>` fragment then return
+   * the annotation ID extracted from the fragment. Otherwise return `null`.
+   *
+   * @return {string|null} - The extracted ID, or null.
+   */
+  function annotations() {
+    // Annotation IDs are url-safe-base64 identifiers
+    // See https://tools.ietf.org/html/rfc4648#page-7
+    var annotFragmentMatch = window_.location.href.match(/#annotations:([A-Za-z0-9_-]+)$/);
+    if (annotFragmentMatch) {
+      return annotFragmentMatch[1];
+    }
+    return null;
+  }
+
+  /**
+   * Return the `#annotations:query:*` query from the given URL's fragment.
+   *
+   * If the URL contains a `#annotations:query:*` (or `#annotatons:q:*`) fragment
+   * then return a the query part extracted from the fragment.
+   * Otherwise return `null`.
+   *
+   * @return {string|null} - The extracted query, or null.
+   */
+  function query() {
+    var queryFragmentMatch = window_.location.href.match(/#annotations:(query|q):(.+)$/i);
+    if (queryFragmentMatch) {
+      try {
+        return decodeURI(queryFragmentMatch[2]);
+      } catch (err) {
+        // URI Error should return the page unfiltered.
+      }
+    }
+    return null;
+  }
+
+  return {
+    get app() { return app(); },
+    get annotations() { return annotations(); },
+    get query() { return query(); },
+  };
 }
 
-module.exports = {
-  app: app,
-  annotations: annotations,
-  query: query,
-};
+module.exports = settingsFrom;

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var settings = require('../settings');
+var settingsFrom = require('../settings');
 
-describe('annotator.config.settings', function() {
+describe('annotator.config.settingsFrom', function() {
 
   describe('#app', function() {
     function appendLinkToDocument(href) {
@@ -27,7 +27,7 @@ describe('annotator.config.settings', function() {
       });
 
       it('returns the href from the link', function() {
-        assert.equal(settings.app(document), 'http://example.com/app.html');
+        assert.equal(settingsFrom(window).app, 'http://example.com/app.html');
       });
     });
 
@@ -46,7 +46,7 @@ describe('annotator.config.settings', function() {
       });
 
       it('returns the href from the first one', function() {
-        assert.equal(settings.app(document), 'http://example.com/app1');
+        assert.equal(settingsFrom(window).app, 'http://example.com/app1');
       });
     });
 
@@ -63,7 +63,9 @@ describe('annotator.config.settings', function() {
 
       it('throws an error', function() {
         assert.throws(
-          function() { settings.app(document); },
+          function() {
+            settingsFrom(window).app; // eslint-disable-line no-unused-expressions
+          },
           'application/annotator+html link has no href'
         );
       });
@@ -72,12 +74,22 @@ describe('annotator.config.settings', function() {
     context("when there's no annotator+html link", function() {
       it('throws an error', function() {
         assert.throws(
-          function() { settings.app(document); },
+          function() {
+            settingsFrom(window).app; // eslint-disable-line no-unused-expressions
+          },
           'No application/annotator+html link in the document'
         );
       });
     });
   });
+
+  function fakeWindow(href) {
+    return {
+      location: {
+        href: href,
+      },
+    };
+  }
 
   describe('#annotations', function() {
     [
@@ -108,7 +120,8 @@ describe('annotator.config.settings', function() {
     ].forEach(function(test) {
       describe(test.describe, function() {
         it(test.it, function() {
-          assert.deepEqual(settings.annotations(test.url), test.returns);
+          assert.deepEqual(
+            settingsFrom(fakeWindow(test.url)).annotations, test.returns);
         });
       });
     });
@@ -161,7 +174,8 @@ describe('annotator.config.settings', function() {
     ].forEach(function(test) {
       describe(test.describe, function() {
         it(test.it, function() {
-          assert.deepEqual(settings.query(test.url), test.returns);
+          assert.deepEqual(
+            settingsFrom(fakeWindow(test.url)).query, test.returns);
         });
       });
     });
@@ -183,7 +197,7 @@ describe('annotator.config.settings', function() {
         // query() won't try to URI-decode the fragment.
         var url = 'http://localhost:3000#annotations:query:abc123';
 
-        assert.isNull(settings.query(url));
+        assert.isNull(settingsFrom(fakeWindow(url)).query);
       });
     });
   });


### PR DESCRIPTION
Depends on https://github.com/hypothesis/client/pull/435 and https://github.com/hypothesis/client/pull/436

annotator.config.settings currently exports an object containing
individual standalone functions for returning different settings'
values:

    module.exports = {
      app: appFunction,
      annotations: annotationsFunction,
      ...
    };

Change it to export just a single constructor function - settingsFrom() - 
that returns an object containing the previously-exported functions as
methods:

    function settingsFrom(window_) {
      ...
      return {
        get app() { return app(); },
        get annotations() { return annotations(); },
        ...
      };
    }

    module.exports = settingsFrom;

Note that ES5 getters are used so that, even though app() and
annotations() are methods rather than simple properties, they can
still be accessed as properties - settings.app not settings.app(). This
makes the code that uses this object slightly simpler, and makes mocking
this object in unit tests simpler. I think it also enforces that code outside of
`settings.js` can't change the values of these properties.

The diff of this commit looks big, because the indentation of a lot of
code is changed, but it really is just changing functions into methods
and not actually changing the code of any of those functions.

The reason for turning functions into an object with methods is so that
the object that settingsFrom() returns can have state (by having closure
variables inside the settingsFrom() function). We don't make any use of
this state yet but future commits will do.