### PR TITLE
(config 4/n): Introduce hostPageSetting() method

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -1,9 +1,6 @@
 'use strict';
 
 var settingsFrom = require('./settings');
-var sharedSettings = require('../../shared/settings');
-var isBrowserExtension = require('./is-browser-extension');
-var configFuncSettingsFrom = require('./config-func-settings-from');
 
 /**
  * Reads the Hypothesis configuration from the environment.
@@ -15,25 +12,16 @@ function configFrom(window_) {
 
   var config = {
     app: settings.app,
-
-    // Extract the default annotation ID or query from the URL.
-    //
-    // The Chrome extension or proxy may already have provided this config via
-    // a tag injected into the DOM, which avoids the problem where the page's
-    // JS rewrites the URL before Hypothesis loads.
-    //
-    // In environments where the config has not been injected into the DOM,
-    // we try to retrieve it from the URL here.
     query: settings.query,
     annotations: settings.annotations,
+    openLoginForm: settings.hostPageSetting('openLoginForm'),
+    openSidebar: settings.hostPageSetting('openSidebar'),
+    showHighlights: settings.hostPageSetting('showHighlights'),
+    branding: settings.hostPageSetting('branding'),
+    assetRoot: settings.hostPageSetting('assetRoot'),
+    sidebarAppUrl: settings.hostPageSetting('sidebarAppUrl'),
+    services: settings.hostPageSetting('services'),
   };
-
-  if (isBrowserExtension(config.app)) {
-    return config;
-  }
-
-  Object.assign(config, sharedSettings.jsonConfigsFrom(window_.document));
-  Object.assign(config, configFuncSettingsFrom(window_));
 
   // Convert legacy keys/values in config to corresponding current
   // configuration.

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -46,13 +46,19 @@ function settingsFrom(window_) {
    * @return {string|null} - The extracted ID, or null.
    */
   function annotations() {
-    // Annotation IDs are url-safe-base64 identifiers
-    // See https://tools.ietf.org/html/rfc4648#page-7
-    var annotFragmentMatch = window_.location.href.match(/#annotations:([A-Za-z0-9_-]+)$/);
-    if (annotFragmentMatch) {
-      return annotFragmentMatch[1];
+
+    /** Return the annotations from the URL, or null. */
+    function annotationsFromURL() {
+      // Annotation IDs are url-safe-base64 identifiers
+      // See https://tools.ietf.org/html/rfc4648#page-7
+      var annotFragmentMatch = window_.location.href.match(/#annotations:([A-Za-z0-9_-]+)$/);
+      if (annotFragmentMatch) {
+        return annotFragmentMatch[1];
+      }
+      return null;
     }
-    return null;
+
+    return jsonConfigs.annotations || annotationsFromURL();
   }
 
   /**

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -1,6 +1,13 @@
 'use strict';
 
+var configFuncSettingsFrom = require('./config-func-settings-from');
+var isBrowserExtension = require('./is-browser-extension');
+var sharedSettings = require('../../shared/settings');
+
 function settingsFrom(window_) {
+
+  var jsonConfigs = sharedSettings.jsonConfigsFrom(window_.document);
+  var configFuncSettings = configFuncSettingsFrom(window_);
 
   /**
    * Return the href URL of the first annotator link in the given document.
@@ -69,10 +76,23 @@ function settingsFrom(window_) {
     return null;
   }
 
+  function hostPageSetting(name) {
+    if (isBrowserExtension(app())) {
+      return null;
+    }
+
+    if (configFuncSettings.hasOwnProperty(name)) {
+      return configFuncSettings[name];
+    }
+
+    return jsonConfigs[name];
+  }
+
   return {
     get app() { return app(); },
     get annotations() { return annotations(); },
     get query() { return query(); },
+    hostPageSetting: hostPageSetting,
   };
 }
 

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -56,24 +56,34 @@ function settingsFrom(window_) {
   }
 
   /**
-   * Return the `#annotations:query:*` query from the given URL's fragment.
+   * Return the config.query setting from the host page or from the URL.
    *
-   * If the URL contains a `#annotations:query:*` (or `#annotatons:q:*`) fragment
-   * then return a the query part extracted from the fragment.
-   * Otherwise return `null`.
+   * If the host page contains a js-hypothesis-config script containing a
+   * query setting then return that.
    *
-   * @return {string|null} - The extracted query, or null.
+   * Otherwise if the host page's URL has a `#annotations:query:*` (or
+   * `#annotations:q:*`) fragment then return the query value from that.
+   *
+   * Otherwise return null.
+   *
+   * @return {string|null} - The config.query setting, or null.
    */
   function query() {
-    var queryFragmentMatch = window_.location.href.match(/#annotations:(query|q):(.+)$/i);
-    if (queryFragmentMatch) {
-      try {
-        return decodeURI(queryFragmentMatch[2]);
-      } catch (err) {
-        // URI Error should return the page unfiltered.
+
+    /** Return the query from the URL, or null. */
+    function queryFromURL() {
+      var queryFragmentMatch = window_.location.href.match(/#annotations:(query|q):(.+)$/i);
+      if (queryFragmentMatch) {
+        try {
+          return decodeURI(queryFragmentMatch[2]);
+        } catch (err) {
+          // URI Error should return the page unfiltered.
+        }
       }
+      return null;
     }
-    return null;
+
+    return jsonConfigs.query || queryFromURL();
   }
 
   function hostPageSetting(name) {

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -120,6 +120,24 @@ describe('annotator.config.settingsFrom', function() {
   }
 
   describe('#annotations', function() {
+    context('when the host page has a js-hypothesis-config with an annotations setting', function() {
+      beforeEach('add a js-hypothesis-config annotations setting', function() {
+        fakeSharedSettings.jsonConfigsFrom.returns({annotations: 'annotationsFromJSON'});
+      });
+
+      it('returns the annotations from the js-hypothesis-config script', function() {
+        assert.equal(settingsFrom(fakeWindow()).annotations, 'annotationsFromJSON');
+      });
+
+      context("when there's also an annotations in the URL fragment", function() {
+        specify('js-hypothesis-config annotations override URL ones', function() {
+          var window_ = fakeWindow('http://localhost:3000#annotations:annotationsFromURL');
+
+          assert.equal(settingsFrom(window_).annotations, 'annotationsFromJSON');
+        });
+      });
+    });
+
     [
       {
         describe: "when there's a valid #annotations:<ID> fragment",

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -156,6 +156,24 @@ describe('annotator.config.settingsFrom', function() {
   });
 
   describe('#query', function() {
+    context('when the host page has a js-hypothesis-config with a query setting', function() {
+      beforeEach('add a js-hypothesis-config query setting', function() {
+        fakeSharedSettings.jsonConfigsFrom.returns({query: 'queryFromJSON'});
+      });
+
+      it('returns the query from the js-hypothesis-config script', function() {
+        assert.equal(settingsFrom(fakeWindow()).query, 'queryFromJSON');
+      });
+
+      context("when there's also a query in the URL fragment", function() {
+        specify('js-hypothesis-config queries override URL ones', function() {
+          var window_ = fakeWindow('http://localhost:3000#annotations:query:queryFromUrl');
+
+          assert.equal(settingsFrom(window_).query, 'queryFromJSON');
+        });
+      });
+    });
+
     [
       {
         describe: "when there's a #annotations:query:<QUERY> fragment",


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/client/pull/435>, <https://github.com/hypothesis/client/pull/436> and <https://github.com/hypothesis/client/pull/437>.

This PR adds a new `annotator.config.settingsFrom#hostPageSetting(settingName)` method that makes a bunch of logic explicit, encapsulates it in one place, and unit tests it:

- `hostPageSetting()` always returns `null` if the client is from a browser extension. Browser extensions don't read settings from the host page.

- If the host page's `window.hypothesisConfig()` function returned a value for the requested setting, it returns that value.

- If `hypothesisConfig()` doesn't return the setting it looks for it in `js-hypothesis-config` scripts in the host page

- If the setting isn't defined in either place it returns `undefined`.

This PR also means that all of the config settings are now named explicitly in `index.js`. Previously `index.js` blindly assigned a lot of property names and values fo the `config` object using a couple of `Object.assign()` calls:

```
Object.assign(config, sharedSettings.jsonConfigsFrom(window_.document));
Object.assign(config, configFuncSettingsFrom(window_));
```

These `Object.assign()`s are now gone, and instead it explicitly assigns each property to the `config` object by name:

```
var config = {
  app: settings.app,
  query: settings.query,
  ...
  openLoginForm: settings.hostPageSetting('openLoginForm'),
  openSidebar: settings.hostPageSetting('openSidebar'),
  ...
};
```

This also means that `index.js` no longer uses `jsonConfigsFrom()`, `configFuncSettingsFrom()` or `isBrowserExtension()` - those are all encapsulated in `settings.js`.

Finally, this PR groups the true logic of the `config.query` and `config.annotations` settings (that they're read from js-hypothesis-config scripts, and failing that are then read from the URL fragment) into one place (the `settings.query()` and `settings.annotations()` methods), makes the logic explicit, and unit tests it.