### PR TITLE
Use CrossFrame to show/hide the Sidebar

### DIFF
--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -39,6 +39,8 @@ module.exports = class Guest extends Delegator
     ".annotator-hl click":               "onHighlightClick"
     ".annotator-hl mouseover":           "onHighlightMouseover"
     ".annotator-hl mouseout":            "onHighlightMouseout"
+    "click":                             "onElementClick"
+    "touchstart":                        "onElementTouchStart"
 
   options:
     Document: {}
@@ -336,6 +338,7 @@ module.exports = class Guest extends Delegator
     targets.then(-> self.publish('beforeAnnotationCreated', [annotation]))
     targets.then(-> self.anchor(annotation))
 
+    @crossframe?.call('showSidebar') unless annotation.$highlight
     annotation
 
   createHighlight: ->
@@ -374,6 +377,7 @@ module.exports = class Guest extends Delegator
   showAnnotations: (annotations) ->
     tags = (a.$tag for a in annotations)
     @crossframe?.call('showAnnotations', tags)
+    @crossframe?.call('showSidebar')
 
   toggleAnnotationSelection: (annotations) ->
     tags = (a.$tag for a in annotations)
@@ -420,6 +424,21 @@ module.exports = class Guest extends Delegator
       this.toggleAnnotationSelection annotations
     else
       this.showAnnotations annotations
+
+  # Moved from Sidebar.coffee to Guest
+  onElementClick: (event) ->
+    if !@selectedTargets?.length
+      @crossframe?.call('hideSidebar')
+
+  # Moved from Sidebar.coffee to Guest
+  onElementTouchStart: (event) ->
+    # Mobile browsers do not register click events on
+    # elements without cursor: pointer. So instead of
+    # adding that to every element, we can add the initial
+    # touchstart event which is always registered to
+    # make up for the lack of click support for all elements.
+    if !@selectedTargets?.length
+      @crossframe?.call('hideSidebar')
 
   onHighlightMouseover: (event) ->
     return unless @visibleHighlights

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -425,12 +425,10 @@ module.exports = class Guest extends Delegator
     else
       this.showAnnotations annotations
 
-  # Moved from Sidebar.coffee to Guest
   onElementClick: (event) ->
     if !@selectedTargets?.length
       @crossframe?.call('hideSidebar')
 
-  # Moved from Sidebar.coffee to Guest
   onElementTouchStart: (event) ->
     # Mobile browsers do not register click events on
     # elements without cursor: pointer. So instead of

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -50,6 +50,7 @@ module.exports = class Sidebar extends Host
 
   _setupSidebarEvents: ->
     annotationCounts(document.body, @crossframe)
+    sidebarTrigger(document.body, => this.show())
 
     @crossframe.on('showSidebar', => this.show())
     @crossframe.on('hideSidebar', => this.hide())

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -47,29 +47,12 @@ module.exports = class Sidebar extends Host
       @onHelpRequest = serviceConfig.onHelpRequest
 
     this._setupSidebarEvents()
-    this._setupDocumentEvents()
-
-  _setupDocumentEvents: ->
-    sidebarTrigger(document.body, => this.show())
-
-    @element.on 'click', (event) =>
-      if !@selectedTargets?.length
-        this.hide()
-
-    # Mobile browsers do not register click events on
-    # elements without cursor: pointer. So instead of
-    # adding that to every element, we can add the initial
-    # touchstart event which is always registered to
-    # make up for the lack of click support for all elements.
-    @element.on 'touchstart', (event) =>
-      if !@selectedTargets?.length
-        this.hide()
-
-    return this
 
   _setupSidebarEvents: ->
     annotationCounts(document.body, @crossframe)
 
+    @crossframe.on('showSidebar', => this.show())
+    @crossframe.on('hideSidebar', => this.hide())
     @crossframe.on(events.LOGIN_REQUESTED, =>
       if @onLoginRequest
         @onLoginRequest()
@@ -205,11 +188,3 @@ module.exports = class Sidebar extends Host
 
   isOpen: ->
     !@frame.hasClass('annotator-collapsed')
-
-  createAnnotation: (annotation = {}) ->
-    super
-    this.show() unless annotation.$highlight
-
-  showAnnotations: (annotations) ->
-    super
-    this.show()

--- a/src/annotator/test/guest-test.coffee
+++ b/src/annotator/test/guest-test.coffee
@@ -84,6 +84,7 @@ describe 'Guest', ->
     fakeCrossFrame = {
       onConnect: sinon.stub()
       on: sinon.stub()
+      call: sinon.stub()
       sync: sinon.stub()
       destroy: sinon.stub()
     }
@@ -276,6 +277,24 @@ describe 'Guest', ->
         guest.plugins.PDF.getMetadata.returns(promise)
 
         emitGuestEvent('getDocumentInfo', assertComplete)
+
+  describe 'document events', ->
+
+    guest = null
+
+    beforeEach ->
+      guest = createGuest()
+
+    it 'emits "hideSidebar" on cross frame when the user taps or clicks in the page', ->
+      methods =
+        'click': 'onElementClick'
+        'touchstart': 'onElementTouchStart'
+
+      for event in ['click', 'touchstart']
+        sandbox.spy(guest, methods[event])
+        guest.element.trigger(event)
+        assert.called(guest[methods[event]])
+        assert.calledWith(guest.plugins.CrossFrame.call, 'hideSidebar')
 
   describe 'when the selection changes', ->
     it 'shows the adder if the selection contains text', ->

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -32,6 +32,20 @@ describe 'Sidebar', ->
     emitEvent = (event, args...) ->
       fn(args...) for [evt, fn] in fakeCrossFrame.on.args when event == evt
 
+    describe 'on "show" event', ->
+      it 'shows the frame', ->
+        target = sandbox.stub(Sidebar.prototype, 'show')
+        sidebar = createSidebar()
+        emitEvent('showSidebar')
+        assert.called(target)
+
+    describe 'on "hide" event', ->
+      it 'hides the frame', ->
+        target = sandbox.stub(Sidebar.prototype, 'hide')
+        sidebar = createSidebar()
+        emitEvent('hideSidebar')
+        assert.called(target)
+
     describe 'on LOGIN_REQUESTED event', ->
       it 'calls the onLoginRequest callback function if one was provided', ->
         onLoginRequest = sandbox.stub()
@@ -194,19 +208,6 @@ describe 'Sidebar', ->
       hide = sandbox.stub(sidebar, 'hide')
       sidebar.onSwipe({type: 'swiperight'})
       assert.calledOnce(hide)
-
-  describe 'document events', ->
-
-    sidebar = null
-
-    beforeEach ->
-      sidebar = createSidebar({})
-
-    it 'closes the sidebar when the user taps or clicks in the page', ->
-      for event in ['click', 'touchstart']
-        sidebar.show()
-        sidebar.element.trigger(event)
-        assert.isFalse(sidebar.isOpen())
 
   describe 'destruction', ->
     sidebar = null

--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -149,6 +149,15 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
     bridge.on('sidebarOpened', function () {
       $rootScope.$broadcast('sidebarOpened');
     });
+
+    // These merely relay calls
+    bridge.on('showSidebar', function () {
+      bridge.call('showSidebar');
+    });
+
+    bridge.on('hideSidebar', function () {
+      bridge.call('hideSidebar');
+    });
   }
 
   /**

--- a/src/sidebar/test/frame-sync-test.js
+++ b/src/sidebar/test/frame-sync-test.js
@@ -249,4 +249,18 @@ describe('FrameSync', function () {
       assert.called(onSidebarOpened);
     });
   });
+
+  describe ('on a relayed bridge call', function() {
+    it ('calls "showSidebar"', function() {
+      fakeBridge.emit('showSidebar');
+
+      assert.calledWith(fakeBridge.call, 'showSidebar');
+    });
+
+    it ('calls "hideSidebar"', function() {
+      fakeBridge.emit('hideSidebar');
+
+      assert.calledWith(fakeBridge.call, 'hideSidebar');
+    });
+  });
 });


### PR DESCRIPTION
This is part of the ongoing development of multiple iframe document support.

Before these changes when a user clicks/taps on an area to hide the sidebar it could only be done at the top level frame. Because of the planned multi-frame support we need to introduce a change so other frames can do this hiding through `CrossFrame`.

Showing the sidebar is now relayed through `CrossFrame` as well. This is so the sub-frames can also bring up the sidebar when necessary.

The goal of this is to leave the original behaviour with a single top level frame intact, while setting up for the multi-frame support.