### PR TITLE
Add Symbol polyfill

### DIFF
--- a/src/shared/polyfills.js
+++ b/src/shared/polyfills.js
@@ -3,6 +3,7 @@
 // ES2015 polyfills
 require('core-js/es6/promise');
 require('core-js/es6/set');
+require('core-js/es6/symbol');
 require('core-js/fn/array/find');
 require('core-js/fn/array/find-index');
 require('core-js/fn/array/from');


### PR DESCRIPTION
This is needed for various ES6 language constructs, such as `for ... of`
loops, to work because the transpiled code depends on references to
properties of the `Symbol` object (eg. `Symbol.iterator`).

Context: https://hypothes-is.slack.com/archives/C076LQFA4/p1497398766420977