### PR TITLE
Fix warning about loading Angular twice in tests

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -212,6 +212,7 @@ module.exports = angular.module('h', [
   .value('ExcerptOverflowMonitor', require('./util/excerpt-overflow-monitor'))
   .value('VirtualThreadList', require('./virtual-thread-list'))
   .value('raven', require('./raven'))
+  .value('serviceConfig', serviceConfig)
   .value('settings', settings)
   .value('time', require('./time'))
   .value('urlEncodeFilter', require('./filter/url').encode)

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -4,7 +4,6 @@ var angular = require('angular');
 
 var events = require('./events');
 var retryUtil = require('./retry-util');
-var serviceConfig = require('./service-config');
 
 var CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
@@ -45,7 +44,7 @@ function sessionActions(options) {
  * @ngInject
  */
 function session($http, $q, $resource, $rootScope, analytics, annotationUI, auth,
-                 flash, raven, settings, store) {
+                 flash, raven, settings, serviceConfig, store) {
   // Headers sent by every request made by the session service.
   var headers = {};
   var actions = sessionActions({

--- a/src/sidebar/test/session-test.js
+++ b/src/sidebar/test/session-test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var angular = require('angular');
-var proxyquire = require('proxyquire');
 
 var events = require('../events');
 
@@ -15,7 +14,7 @@ describe('session', function () {
   var fakeAuth;
   var fakeFlash;
   var fakeRaven;
-  var fakeServiceConfig = sinon.stub();
+  var fakeServiceConfig;
   var fakeSettings;
   var fakeStore;
   var sandbox;
@@ -23,10 +22,7 @@ describe('session', function () {
 
   before(function () {
     angular.module('h', ['ngResource'])
-      .service(
-        'session',
-        proxyquire('../session', {'./service-config': fakeServiceConfig})
-      );
+      .service('session', require('../session'));
   });
 
   beforeEach(function () {
@@ -58,8 +54,7 @@ describe('session', function () {
         update: sandbox.stub().returns(Promise.resolve({})),
       },
     };
-    fakeServiceConfig.reset();
-    fakeServiceConfig.returns(null);
+    fakeServiceConfig = sinon.stub().returns(null);
     fakeSettings = {
       serviceUrl: 'https://test.hypothes.is/root/',
     };
@@ -71,6 +66,7 @@ describe('session', function () {
       flash: fakeFlash,
       raven: fakeRaven,
       settings: fakeSettings,
+      serviceConfig: fakeServiceConfig,
       store: fakeStore,
     });
   });


### PR DESCRIPTION
The Angular.js bundle was evaluated a second time because a module that
required angular was proxyquire-d in session-test.js. When
`proxyquire(...)` loads a module, it does so with a fresh, empty module
cache [1] which is removed once the `proxyquire(...)` call returns.

As a result, every module that is transitively required by the
proxyquire'd module will be re-evaluated during the `proxyquire(...)`
call.

Aside from the performance cost for large modules, this is also bad for
any module which has side-effects as part of its evaluation. Angular
happens to detect this and abort when evaluated a second time.

The fix here is to use Angular's DI system to mock the only stubbed
dependencies instead of proxyquire.

[1] The _module cache_ is a (module ID/name => exports object) map which maintained by the Browserify _prelude_, a small piece of code that appears at the start of every Browserify bundle.