### PR TITLE
Add --force to yarn install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,5 @@ build/manifest.json: node_modules/.uptodate
 	yarn run build
 
 node_modules/.uptodate: package.json yarn.lock
-	yarn run deps 2>/dev/null || yarn install
+	yarn run deps 2>/dev/null || yarn install --force
 	@touch $@


### PR DESCRIPTION
Attempting to fix this error with the client build on Jenkins:

    Error during loading "/data/jenkins/workspace/client_master-*/node_modules/karma-phantomjs-launcher" plugin:
      Path must be a string. Received null