### PR TITLE
Remove assetRoot and sidebarAppUrl from annotator

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -18,8 +18,6 @@ function configFrom(window_) {
     openSidebar: settings.hostPageSetting('openSidebar', {allowInBrowserExt: true}),
     showHighlights: settings.hostPageSetting('showHighlights'),
     branding: settings.hostPageSetting('branding'),
-    assetRoot: settings.hostPageSetting('assetRoot'),
-    sidebarAppUrl: settings.hostPageSetting('sidebarAppUrl'),
     services: settings.hostPageSetting('services'),
   };
 

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -75,8 +75,6 @@ describe('annotator.config.index', function() {
   [
     'showHighlights',
     'branding',
-    'assetRoot',
-    'sidebarAppUrl',
     'services',
   ].forEach(function(settingName) {
     it('reads ' + settingName + ' from the host page only when in an embedded client', function() {
@@ -91,8 +89,6 @@ describe('annotator.config.index', function() {
     'openSidebar',
     'showHighlights',
     'branding',
-    'assetRoot',
-    'sidebarAppUrl',
     'services',
   ].forEach(function(settingName) {
     it('returns the ' + settingName + ' value from the host page', function() {
@@ -101,8 +97,6 @@ describe('annotator.config.index', function() {
         'openSidebar': 'OPEN_SIDEBAR_SETTING',
         'showHighlights': 'SHOW_HIGHLIGHTS_SETTING',
         'branding': 'BRANDING_SETTING',
-        'assetRoot': 'ASSET_ROOT_SETTING',
-        'sidebarAppUrl': 'SIDEBAR_APP_URL_SETTING',
         'services': 'SERVICES_SETTING',
       };
       fakeSettingsFrom().hostPageSetting = function(settingName) {


### PR DESCRIPTION
Remove the assetRoot and sidebarAppUrl config settings, which are read
from js-hypothesis-config objects in the host page, from the
src/annotator code.

These settings aren't used in the src/annotator code, they're used in
the src/boot code only.