### PR TITLE
Rename config.app to sidebarAppUrl

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -10,7 +10,7 @@ var settingsFrom = require('./settings');
 function configFrom(window_) {
   var settings = settingsFrom(window_);
   return {
-    app: settings.app,
+    sidebarAppUrl: settings.sidebarAppUrl,
     query: settings.query,
     annotations: settings.annotations,
     showHighlights: settings.showHighlights,

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -23,7 +23,7 @@ function settingsFrom(window_) {
    *   no href.
    *
    */
-  function app() {
+  function sidebarAppUrl() {
     var link = window_.document.querySelector('link[type="application/annotator+html"]');
 
     if (!link) {
@@ -110,7 +110,7 @@ function settingsFrom(window_) {
   function hostPageSetting(name, options = {}) {
     var allowInBrowserExt = options.allowInBrowserExt || false;
 
-    if (!allowInBrowserExt && isBrowserExtension(app())) {
+    if (!allowInBrowserExt && isBrowserExtension(sidebarAppUrl())) {
       return null;
     }
 
@@ -126,7 +126,7 @@ function settingsFrom(window_) {
   }
 
   return {
-    get app() { return app(); },
+    get sidebarAppUrl() { return sidebarAppUrl(); },
     get annotations() { return annotations(); },
     get showHighlights() { return showHighlights(); },
     get query() { return query(); },

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -26,7 +26,7 @@ describe('annotator.config.index', function() {
   });
 
   [
-    'app',
+    'sidebarAppUrl',
     'query',
     'annotations',
     'showHighlights',
@@ -44,7 +44,7 @@ describe('annotator.config.index', function() {
     beforeEach('remove the application/annotator+html <link>', function() {
       Object.defineProperty(
         fakeSettingsFrom(),
-        'app',
+        'sidebarAppUrl',
         {
           get: sinon.stub().throws(new Error("there's no link")),
         }

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -29,7 +29,7 @@ describe('annotator.config.settingsFrom', function() {
     fakeSharedSettings.jsonConfigsFrom = sinon.stub().returns({});
   });
 
-  describe('#app', function() {
+  describe('#sidebarAppUrl', function() {
     function appendLinkToDocument(href) {
       var link = document.createElement('link');
       link.type = 'application/annotator+html';
@@ -52,7 +52,7 @@ describe('annotator.config.settingsFrom', function() {
       });
 
       it('returns the href from the link', function() {
-        assert.equal(settingsFrom(window).app, 'http://example.com/app.html');
+        assert.equal(settingsFrom(window).sidebarAppUrl, 'http://example.com/app.html');
       });
     });
 
@@ -71,7 +71,7 @@ describe('annotator.config.settingsFrom', function() {
       });
 
       it('returns the href from the first one', function() {
-        assert.equal(settingsFrom(window).app, 'http://example.com/app1');
+        assert.equal(settingsFrom(window).sidebarAppUrl, 'http://example.com/app1');
       });
     });
 
@@ -89,7 +89,7 @@ describe('annotator.config.settingsFrom', function() {
       it('throws an error', function() {
         assert.throws(
           function() {
-            settingsFrom(window).app; // eslint-disable-line no-unused-expressions
+            settingsFrom(window).sidebarAppUrl; // eslint-disable-line no-unused-expressions
           },
           'application/annotator+html link has no href'
         );
@@ -100,7 +100,7 @@ describe('annotator.config.settingsFrom', function() {
       it('throws an error', function() {
         assert.throws(
           function() {
-            settingsFrom(window).app; // eslint-disable-line no-unused-expressions
+            settingsFrom(window).sidebarAppUrl; // eslint-disable-line no-unused-expressions
           },
           'No application/annotator+html link in the document'
         );

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -22,15 +22,15 @@ module.exports = class Host extends Guest
       if service.onHelpRequest
         service.onHelpRequestProvided = true
 
-    # Make a copy of all config settings except `config.app`, the app base URL,
+    # Make a copy of all config settings except `config.sidebarAppUrl`, the app base URL,
     # and `config.pluginClasses`
     configParam = 'config=' + encodeURIComponent(
-      JSON.stringify(Object.assign({}, config, {app:undefined, pluginClasses: undefined }))
+      JSON.stringify(Object.assign({}, config, {sidebarAppUrl: undefined, pluginClasses: undefined }))
     )
-    if config.app and '?' in config.app
-      config.app += '&' + configParam
+    if config.sidebarAppUrl and '?' in config.sidebarAppUrl
+      config.sidebarAppUrl += '&' + configParam
     else
-      config.app += '?' + configParam
+      config.sidebarAppUrl += '?' + configParam
 
     # Create the iframe
     app = $('<iframe></iframe>')
@@ -38,7 +38,7 @@ module.exports = class Host extends Guest
     # enable media in annotations to be shown fullscreen
     .attr('allowfullscreen', '')
     .attr('seamless', '')
-    .attr('src', config.app)
+    .attr('src', config.sidebarAppUrl)
     .addClass('h-sidebar-iframe')
 
     @frame = $('<div></div>')

--- a/src/annotator/test/host-test.coffee
+++ b/src/annotator/test/host-test.coffee
@@ -8,7 +8,7 @@ describe 'Host', ->
   hostConfig = {pluginClasses: {}}
 
   createHost = (config={}, element=null) ->
-    config = Object.assign({app: '/base/annotator/test/empty.html'}, hostConfig, config)
+    config = Object.assign({sidebarAppUrl: '/base/annotator/test/empty.html'}, hostConfig, config)
     if !element
       element = document.createElement('div')
     return new Host(element, config)


### PR DESCRIPTION
The code in `src/boot/` reads the `sidebarAppUrl` setting from
`js-hypothesis-config` JSON objects in the host page (defaulting to the
value of the build-time `__SIDEBAR_APP_URL__` template variable, if there's
no `sidebarAppUrl` setting in the host page).

`boot/` then writes `sidebarAppUrl` as the value of the `href` of a
`<link type="application/annotator+html">` element that it injects into
the host page.

Later, the code in `src/annotator/` reads this `<link>` element's `href`
in as the `config.app` setting, which it uses as the `src` of the
sidebar app's `<iframe>` that it injects into the host page.

So the variable that's named `sidebarAppUrl` / `__SIDEBAR_APP_URL__` at
boot / build time* gets renamed to `config.app` when it makes it into
the `src/annotator` code.

Fix this by renaming `config.app` in `src/annotator` to
`config.sidebarAppUrl` so that the variable is named consistently.

`*` In the build-time code there's also a `defaultSidebarAppUrl`
variable, and an `H_SERVICE_URL` environment variable, which also belong to
the same sidebarAppUrl config setting.