### PR TITLE
Rename H_SERVICE_URL to SIDEBAR_APP_URL

### DIFF
--- a/docs/developers/developing.rst
+++ b/docs/developers/developing.rst
@@ -83,7 +83,7 @@ run:
 
 .. code-block:: sh
 
-   export H_SERVICE_URL=http://localhost:5000
+   export SIDEBAR_APP_URL=http://localhost:5000/app.html
    gulp watch
 
 **In the `hypothesis/h` repository**, set the :envvar:`CLIENT_URL` env var to

--- a/docs/developers/envvars.rst
+++ b/docs/developers/envvars.rst
@@ -4,10 +4,12 @@ Environment Variables
 This section documents all the environment variables supported by the client's
 build tasks.
 
-.. envvar:: H_SERVICE_URL
+.. envvar:: SIDEBAR_APP_URL
 
-   The URL of the service which hosts the HTML entry point for the client's
-   sidebar application.
+   The default value for the :option:`sidebarAppUrl` config setting (the URL of
+   the sidebar app's iframe), used when the host page does not contain a
+   :option:`sidebarAppUrl` setting.
+   ``https://hypothes.is/app.html`` by default.
 
 .. envvar:: PACKAGE_SERVER_HOSTNAME
 

--- a/docs/developers/mobile.rst
+++ b/docs/developers/mobile.rst
@@ -39,7 +39,7 @@ tested with at least current versions of iOS Safari and Chrome for Android.
 
       make dev
 
-#. Set the :envvar:`H_SERVICE_URL` and :envvar:`PACKAGE_SERVER_HOSTNAME`
+#. Set the :envvar:`SIDEBAR_APP_URL` and :envvar:`PACKAGE_SERVER_HOSTNAME`
    environment variables to load assets from this hostname and start the dev
    server:
 
@@ -48,7 +48,7 @@ tested with at least current versions of iOS Safari and Chrome for Android.
       # In the client repository
 
       # Set URL which sidebar app ("app.html") is loaded from
-      export H_SERVICE_URL=http://<HOSTNAME>:5000
+      export SIDEBAR_APP_URL=http://<HOSTNAME>:5000/app.html
       # Set hostname used when generating client asset URLs
       export PACKAGE_SERVER_HOSTNAME=<HOSTNAME>
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -264,8 +264,8 @@ var isFirstBuild = true;
 function generateBootScript(manifest) {
   var { version } = require('./package.json');
 
-  var defaultSidebarAppUrl = process.env.H_SERVICE_URL ?
-    `${process.env.H_SERVICE_URL}/app.html` : 'https://hypothes.is/app.html';
+  var defaultSidebarAppUrl = process.env.SIDEBAR_APP_URL ?
+    `${process.env.SIDEBAR_APP_URL}` : 'https://hypothes.is/app.html';
 
   var defaultAssetRoot;
 


### PR DESCRIPTION
The `H_SERVICE_URL` environment variable is only used for one thing: to
set the value of the `defaultSidebarAppUrl` variable (to
https://hypothes.is/app.html in production or localhost:5000/app.html in dev)
by appending `/app.html` to the end of the environment variable's value.

For consistency with the config setting and variables that it's used to
control, rename `H_SERVICE_URL` to `SIDEBAR_APP_URL` and require the
user to include the `/app.html` ending in the environment variable's
value.

Also rewrite the documentation for this environment variable to make it
clearer what it's used for.

**Note**: This change means that developers who're using the
`H_SERVICE_URL` environment variable in their development environments
will need to:

1. Rename `H_SERVICE_URL` it to `SIDEBAR_APP_URL` in their environment
2. Append `/app.html` to the end of the environment variable's value

For example:

    export SIDEBAR_APP_URL="http://localhost:5000/app.html"

The developer docs for this environment variable have been updated to reflect
this.