### PR TITLE
Add showHighlights() settings function

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -9,25 +9,16 @@ var settingsFrom = require('./settings');
  */
 function configFrom(window_) {
   var settings = settingsFrom(window_);
-
-  var config = {
+  return {
     app: settings.app,
     query: settings.query,
     annotations: settings.annotations,
+    showHighlights: settings.showHighlights,
     openLoginForm: settings.hostPageSetting('openLoginForm', {allowInBrowserExt: true}),
     openSidebar: settings.hostPageSetting('openSidebar', {allowInBrowserExt: true}),
-    showHighlights: settings.hostPageSetting('showHighlights'),
     branding: settings.hostPageSetting('branding'),
     services: settings.hostPageSetting('services'),
   };
-
-  // Convert legacy keys/values in config to corresponding current
-  // configuration.
-  if (typeof config.showHighlights === 'boolean') {
-    config.showHighlights = config.showHighlights ? 'always' : 'never';
-  }
-
-  return config;
 }
 
 module.exports = configFrom;

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -61,6 +61,17 @@ function settingsFrom(window_) {
     return jsonConfigs.annotations || annotationsFromURL();
   }
 
+  function showHighlights() {
+    var showHighlights_ = hostPageSetting('showHighlights');
+
+    // Convert legacy keys/values to corresponding current configuration.
+    if (typeof showHighlights_ === 'boolean') {
+      return showHighlights_ ? 'always' : 'never';
+    }
+
+    return showHighlights_;
+  }
+
   /**
    * Return the config.query setting from the host page or from the URL.
    *
@@ -109,6 +120,7 @@ function settingsFrom(window_) {
   return {
     get app() { return app(); },
     get annotations() { return annotations(); },
+    get showHighlights() { return showHighlights(); },
     get query() { return query(); },
     hostPageSetting: hostPageSetting,
   };

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -114,7 +114,11 @@ function settingsFrom(window_) {
       return configFuncSettings[name];
     }
 
-    return jsonConfigs[name];
+    if (jsonConfigs.hasOwnProperty(name)) {
+      return jsonConfigs[name];
+    }
+
+    return null;
   }
 
   return {

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -64,6 +64,10 @@ function settingsFrom(window_) {
   function showHighlights() {
     var showHighlights_ = hostPageSetting('showHighlights');
 
+    if (showHighlights_ === null) {
+      showHighlights_ = 'always';  // The default value is 'always'.
+    }
+
     // Convert legacy keys/values to corresponding current configuration.
     if (typeof showHighlights_ === 'boolean') {
       return showHighlights_ ? 'always' : 'never';

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -29,6 +29,7 @@ describe('annotator.config.index', function() {
     'app',
     'query',
     'annotations',
+    'showHighlights',
   ].forEach(function(settingName) {
     it('returns the ' + settingName + ' setting', function() {
       fakeSettingsFrom()[settingName] = 'SETTING_VALUE';
@@ -73,7 +74,6 @@ describe('annotator.config.index', function() {
   });
 
   [
-    'showHighlights',
     'branding',
     'services',
   ].forEach(function(settingName) {
@@ -87,7 +87,6 @@ describe('annotator.config.index', function() {
   [
     'openLoginForm',
     'openSidebar',
-    'showHighlights',
     'branding',
     'services',
   ].forEach(function(settingName) {
@@ -95,7 +94,6 @@ describe('annotator.config.index', function() {
       var settings = {
         'openLoginForm': 'OPEN_LOGIN_FORM_SETTING',
         'openSidebar': 'OPEN_SIDEBAR_SETTING',
-        'showHighlights': 'SHOW_HIGHLIGHTS_SETTING',
         'branding': 'BRANDING_SETTING',
         'services': 'SERVICES_SETTING',
       };
@@ -106,38 +104,6 @@ describe('annotator.config.index', function() {
       var settingValue = configFrom('WINDOW')[settingName];
 
       assert.equal(settingValue, settings[settingName]);
-    });
-  });
-
-  describe('showHighlights', function() {
-    [
-      {
-        name: 'changes `true` to `"always"`',
-        input:   true,
-        output:  'always',
-      },
-      {
-        name: 'changes `false` to `"never"`',
-        input:   false,
-        output:  'never',
-      },
-      // It adds any arbitrary string value for showHighlights to the
-      // returned config, unmodified.
-      {
-        name: 'passes arbitrary strings through unmodified',
-        input:   'foo',
-        output:  'foo',
-      },
-    ].forEach(function(test) {
-      it(test.name, function() {
-        fakeSettingsFrom().hostPageSetting = function (settingName) {
-          return {'showHighlights': test.input}[settingName];
-        };
-
-        var config = configFrom('WINDOW');
-
-        assert.equal(config.showHighlights, test.output);
-      });
     });
   });
 });

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -459,7 +459,7 @@ describe('annotator.config.settingsFrom', function() {
             {allowInBrowserExt: test.allowInBrowserExt || false}
           );
 
-          assert.equal(setting, test.expected);
+          assert.strictEqual(setting, test.expected);
         });
       });
     });

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -348,8 +348,8 @@ describe('annotator.config.settingsFrom', function() {
       });
     });
 
-    it("returns undefined if there's no showHighlights setting in the host page", function() {
-      assert.isUndefined(settingsFrom(fakeWindow()).showHighlights);
+    it("returns null if there's no showHighlights setting in the host page", function() {
+      assert.isNull(settingsFrom(fakeWindow()).showHighlights);
     });
 
     context('when the client is in a browser extension', function() {
@@ -414,11 +414,11 @@ describe('annotator.config.settingsFrom', function() {
       },
       {
         when: 'the client is embedded in a web page',
-        specify: "it returns undefined if the setting isn't defined anywhere",
+        specify: "it returns null if the setting isn't defined anywhere",
         isBrowserExtension: false,
         configFuncSettings: {},
         jsonSettings: {},
-        expected: undefined,
+        expected: null,
       },
       {
         when: 'the client is in a browser extension',

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -303,10 +303,13 @@ describe('annotator.config.settingsFrom', function() {
         input: 42,
         output: 42,
       },
+      // If the host page sets showHighlights to null this will be mistaken
+      // for the host page not containing a showHighlights setting at all and
+      // showHighlights will be set to 'always'.
       {
-        it: 'passes null through unmodified',
+        it: 'defaults to "always"',
         input: null,
-        output: null,
+        output: 'always',
       },
       {
         it: 'passes undefined through unmodified',
@@ -348,8 +351,8 @@ describe('annotator.config.settingsFrom', function() {
       });
     });
 
-    it("returns null if there's no showHighlights setting in the host page", function() {
-      assert.isNull(settingsFrom(fakeWindow()).showHighlights);
+    it("defaults to 'always' if there's no showHighlights setting in the host page", function() {
+      assert.equal(settingsFrom(fakeWindow()).showHighlights, 'always');
     });
 
     context('when the client is in a browser extension', function() {
@@ -357,15 +360,15 @@ describe('annotator.config.settingsFrom', function() {
         fakeIsBrowserExtension.returns(true);
       });
 
-      it("doesn't read the setting from the host page", function() {
+      it("doesn't read the setting from the host page, defaults to 'always'", function() {
         fakeSharedSettings.jsonConfigsFrom.returns({
-          'showHighlights': 'always',
+          'showHighlights': 'never',
         });
         fakeConfigFuncSettingsFrom.returns({
-          'showHighlights': 'always',
+          'showHighlights': 'never',
         });
 
-        assert.isNull(settingsFrom(fakeWindow()).showHighlights);
+        assert.equal(settingsFrom(fakeWindow()).showHighlights, 'always');
       });
     });
   });

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -266,6 +266,110 @@ describe('annotator.config.settingsFrom', function() {
     });
   });
 
+  describe('#showHighlights', function() {
+    [
+      {
+        it: 'returns an "always" setting from the host page unmodified',
+        input: 'always',
+        output: 'always',
+      },
+      {
+        it: 'returns a "never" setting from the host page unmodified',
+        input: 'never',
+        output: 'never',
+      },
+      {
+        it: 'returns a "whenSidebarOpen" setting from the host page unmodified',
+        input: 'whenSidebarOpen',
+        output: 'whenSidebarOpen',
+      },
+      {
+        it: 'changes true to "always"',
+        input: true,
+        output: 'always',
+      },
+      {
+        it: 'changes false to "never"',
+        input: false,
+        output: 'never',
+      },
+      {
+        it: 'passes invalid string values through unmodified',
+        input: 'invalid',
+        output: 'invalid',
+      },
+      {
+        it: 'passes numbers through unmodified',
+        input: 42,
+        output: 42,
+      },
+      {
+        it: 'passes null through unmodified',
+        input: null,
+        output: null,
+      },
+      {
+        it: 'passes undefined through unmodified',
+        input: undefined,
+        output: undefined,
+      },
+      {
+        it: 'passes arrays through unmodified',
+        input: [1, 2, 3],
+        output: [1, 2, 3],
+      },
+      {
+        it: 'passes objects through unmodified',
+        input: {foo: 'bar'},
+        output: {foo: 'bar'},
+      },
+      {
+        it: 'passes regular expressions through unmodified',
+        input: /regex/,
+        output: /regex/,
+      },
+    ].forEach(function(test) {
+      it(test.it, function() {
+        fakeSharedSettings.jsonConfigsFrom.returns({
+          'showHighlights': test.input,
+        });
+        var settings = settingsFrom(fakeWindow());
+
+        assert.deepEqual(settings.showHighlights, test.output);
+      });
+
+      it(test.it, function() {
+        fakeConfigFuncSettingsFrom.returns({
+          'showHighlights': test.input,
+        });
+        var settings = settingsFrom(fakeWindow());
+
+        assert.deepEqual(settings.showHighlights, test.output);
+      });
+    });
+
+    it("returns undefined if there's no showHighlights setting in the host page", function() {
+      assert.isUndefined(settingsFrom(fakeWindow()).showHighlights);
+    });
+
+    context('when the client is in a browser extension', function() {
+      beforeEach('configure a browser extension client', function() {
+        fakeIsBrowserExtension.returns(true);
+      });
+
+      it("doesn't read the setting from the host page", function() {
+        fakeSharedSettings.jsonConfigsFrom.returns({
+          'showHighlights': 'always',
+        });
+        fakeConfigFuncSettingsFrom.returns({
+          'showHighlights': 'always',
+        });
+
+        assert.isNull(settingsFrom(fakeWindow()).showHighlights);
+      });
+    });
+  });
+
   describe('#hostPageSetting', function() {
     [
       {

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -52,9 +52,6 @@ module.exports = class Host extends Guest
 
     this.on 'panelReady', =>
       # Initialize tool state.
-      if config.showHighlights == undefined
-        # Highlights are on by default.
-        config.showHighlights = 'always'
       this.setVisibleHighlights(config.showHighlights == 'always')
 
       # Show the UI

--- a/src/annotator/test/host-test.coffee
+++ b/src/annotator/test/host-test.coffee
@@ -75,13 +75,6 @@ describe 'Host', ->
         done()
       host.publish('panelReady')
 
-    it 'enables highlighting when no showHighlights option is given', (done) ->
-      host = createHost({})
-      host.on 'panelReady', ->
-        assert.isTrue(host.visibleHighlights)
-        done()
-      host.publish('panelReady')
-
     it 'passes config to the sidebar iframe', ->
       appURL = new URL('/base/annotator/test/empty.html', window.location.href)
       host = createHost({annotations: '1234'})


### PR DESCRIPTION
This groups all of the logic for the config.showHighlights setting (both
how it's read from the host page, and how the host page's value is
transformed afterwards) into one unit-tested place.