### PR TITLE
Convert "flash" service to JS

### DIFF
--- a/src/sidebar/flash.coffee
+++ b/src/sidebar/flash.coffee
@@ -1,6 +1,0 @@
-module.exports = ['toastr', (toastr) ->
-  info: angular.bind(toastr, toastr.info)
-  success: angular.bind(toastr, toastr.success)
-  warning: angular.bind(toastr, toastr.warning)
-  error: angular.bind(toastr, toastr.error)
-]

--- a/src/sidebar/flash.js
+++ b/src/sidebar/flash.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/**
+ * A service for displaying "flash" notification messages.
+ */
+
+// @ngInject
+function flash(toastr) {
+  return {
+    info: toastr.info.bind(toastr),
+    success: toastr.success.bind(toastr),
+    warning: toastr.warning.bind(toastr),
+    error: toastr.error.bind(toastr),
+  };
+}
+
+module.exports = flash;

--- a/src/sidebar/test/flash-test.js
+++ b/src/sidebar/test/flash-test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var flash = require('../flash');
+
+describe('sidebar.flash', () => {
+  ['info', 'success', 'warning', 'error'].forEach(method => {
+    describe(`#${method}`, () => {
+      it(`calls toastr's "${method}" method`, () => {
+        var fakeToastr = {
+          info: sinon.stub(),
+          success: sinon.stub(),
+          warning: sinon.stub(),
+          error: sinon.stub(),
+        };
+
+        var svc = flash(fakeToastr);
+        svc[method]('message', 'title');
+
+        assert.calledWith(fakeToastr[method], 'message', 'title');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Remove `angular.bind` dependency since `Function.prototype.bind` is now
ubiquitous.