### PR TITLE
Fix sidebar app failing to load in Firefox extension.

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -225,5 +225,16 @@ module.exports = angular.module('h', [
 
 processAppOpts();
 
+// Work around a check in Angular's $sniffer service that causes it to
+// incorrectly determine that Firefox extensions are Chrome Packaged Apps which
+// do not support the HTML 5 History API. This results Angular redirecting the
+// browser on startup and thus the app fails to load.
+// See https://github.com/angular/angular.js/blob/a03b75c6a812fcc2f616fc05c0f1710e03fca8e9/src/ng/sniffer.js#L30
+if (window.chrome && !window.chrome.app) {
+  window.chrome.app = {
+    dummyAddedByHypothesisClient: true,
+  };
+}
+
 var appEl = document.querySelector('hypothesis-app');
 angular.bootstrap(appEl, ['h'], {strictDi: true});


### PR DESCRIPTION
I noticed a regression with the Firefox extension yesterday which makes it no longer usable. There are a couple of problems in the extension itself, but the main issue is that the sidebar app does not load properly, which is fixed by this hack.

----

Angular has a check for Chrome Packaged Apps in its `$sniffer` service
which changes the behavior of the $location service and in the Firefox
extension, triggers a redirect from `/client/app.html` to
`/#client/app.html` on startup, breaking the sidebar app.

This commit works around the problem by adding a fake
`window.chrome.app` object to convince Angular that the Firefox
extension is not a Chrome Packaged App.

Issue reported upstream at https://github.com/angular/angular.js/issues/16068