### PR TITLE
Enable feature flagged highlighter interface

### DIFF
--- a/src/annotator/features.js
+++ b/src/annotator/features.js
@@ -14,7 +14,7 @@ module.exports = {
   init: function(crossframe) {
     crossframe.on(events.FEATURE_FLAGS_UPDATED, _set);
   },
-  
+
   reset: function() {
     _set({});
   },

--- a/src/annotator/highlighter/dom-wrap-highlighter/index.coffee
+++ b/src/annotator/highlighter/dom-wrap-highlighter/index.coffee
@@ -1,6 +1,5 @@
 $ = require('jquery')
 
-
 # Public: Wraps the DOM Nodes within the provided range with a highlight
 # element of the specified class and returns the highlight Elements.
 #

--- a/src/annotator/highlighter/dom-wrap-highlighter/test.coffee
+++ b/src/annotator/highlighter/dom-wrap-highlighter/test.coffee
@@ -1,7 +1,7 @@
-Range = require('../anchoring/range')
+Range = require('../../anchoring/range')
 $ = require('jquery')
 
-highlighter = require('../highlighter')
+highlighter = require('./index')
 
 describe "highlightRange", ->
   it 'wraps a highlight span around the given range', ->

--- a/src/annotator/highlighter/index.js
+++ b/src/annotator/highlighter/index.js
@@ -1,8 +1,27 @@
 'use strict';
 
 const domWrapHighlighter = require('./dom-wrap-highlighter');
+const overlayHighlighter = require('./overlay-highlighter');
+const features = require('../features');
 
-// this is where were will determine what highlighter
-// to use based on the environment and any flags
+// we need a facade for the highlighter interface
+// that will let us lazy check the overlay_highlighter feature
+// flag and later determine which interface should be used.
+const highlighterFacade = {};
+let overlayFlagEnabled;
 
-module.exports = domWrapHighlighter;
+Object.keys(domWrapHighlighter).forEach((methodName)=>{
+  highlighterFacade[methodName] = (...args)=>{
+    // lazy check the value but we will
+    // use that first value as the rule throughout
+    // the in memory session
+    if(overlayFlagEnabled === undefined){
+      overlayFlagEnabled = features.flagEnabled('overlay_highlighter');
+    }
+
+    const method = overlayFlagEnabled ? overlayHighlighter[methodName] : domWrapHighlighter[methodName];
+    return method.apply(null, args);
+  };
+});
+
+module.exports = highlighterFacade;

--- a/src/annotator/highlighter/index.js
+++ b/src/annotator/highlighter/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const domWrapHighlighter = require('./dom-wrap-highlighter');
+
+// this is where were will determine what highlighter
+// to use based on the environment and any flags
+
+module.exports = domWrapHighlighter;

--- a/src/annotator/highlighter/overlay-highlighter/index.js
+++ b/src/annotator/highlighter/overlay-highlighter/index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  highlightRange: () => {
+    // eslint-disable-next-line no-console
+    console.log('highlightRange not implemented');
+  },
+
+  removeHighlights: () => {
+    // eslint-disable-next-line no-console
+    console.log('removeHighlights not implemented');
+  },
+
+  getBoundingClientRect: () => {
+    // eslint-disable-next-line no-console
+    console.log('getBoundingClientRect not implemented');
+  },
+};

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -69,6 +69,7 @@ module.exports = class Sidebar extends Host
 
   _setupSidebarEvents: ->
     annotationCounts(document.body, @crossframe)
+    features.init(@crossframe);
 
     @crossframe.on(events.LOGIN_REQUESTED, =>
       if @onLoginRequest

--- a/src/annotator/test/guest-test.coffee
+++ b/src/annotator/test/guest-test.coffee
@@ -58,6 +58,8 @@ describe 'Guest', ->
     return new Guest(element, config)
 
   beforeEach ->
+    sinon.stub(console, 'warn')
+
     FakeAdder::instance = null
     rangeUtil = {
       isSelectionBackwards: sinon.stub()
@@ -93,6 +95,7 @@ describe 'Guest', ->
 
   afterEach ->
     sandbox.restore()
+    console.warn.restore()
 
   describe 'plugins', ->
     fakePlugin = null

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -54,6 +54,7 @@ describe('anchoring', function () {
   });
 
   beforeEach(function () {
+    sinon.stub(console, 'warn');
     container = document.createElement('div');
     container.innerHTML = require('./test-page.html');
     document.body.appendChild(container);
@@ -63,6 +64,7 @@ describe('anchoring', function () {
   afterEach(function () {
     guest.destroy();
     container.parentNode.removeChild(container);
+    console.warn.restore();
   });
 
   unroll('should highlight #tag when annotations are loaded', function (testCase) {


### PR DESCRIPTION
so that we can have a standard location for highlighter. We are moving highlighters to a dedicated directory and using `highlighter/index.js` to resolve which module should be used - though currently only dom-wrap-highlighter is implemented

Feature flags are not available immediately, so we will have to delay when we make the decision to pick which highlighter to use. Highlighting happens after we get the user info/feature flags so this pattern works well

There are a few test changes in other areas that call highlighter code (which subsequently calls flagEnabled and the console.warn will complain that the flag is unknown). That is needed for now but should be something easy to clean up later with an annotation layer logger.
