### PR TITLE
Use fallback when local storage throws

### DIFF
--- a/src/sidebar/local-storage.js
+++ b/src/sidebar/local-storage.js
@@ -28,14 +28,15 @@ class InMemoryStorage {
  */
 // @ngInject
 function localStorage($window) {
-  var storage = $window.localStorage;
+  let storage;
+  let testKey = 'hypothesis.testKey';
 
   try {
     // Test whether we can read/write localStorage.
-    var key = 'hypothesis.testKey';
-    $window.localStorage.setItem(key, key);
-    $window.localStorage.getItem(key);
-    $window.localStorage.removeItem(key);
+    storage = $window.localStorage;
+    $window.localStorage.setItem(testKey, testKey);
+    $window.localStorage.getItem(testKey);
+    $window.localStorage.removeItem(testKey);
   } catch (e) {
     storage = new InMemoryStorage();
   }

--- a/src/sidebar/test/local-storage-test.js
+++ b/src/sidebar/test/local-storage-test.js
@@ -1,14 +1,34 @@
 'use strict';
 
 var angular = require('angular');
+var service = require('../local-storage');
 
 describe('sidebar.localStorage', () => {
   var fakeWindow;
 
   before(() =>
     angular.module('h', [])
-      .service('localStorage', require('../local-storage'))
+      .service('localStorage', service)
   );
+
+  context('when accessing localStorage throws an Error', () => {
+    it('returns the fallback implementation', () => {
+      var badWindow = {};
+      var fakeWindow = {};
+
+      Object.defineProperty(badWindow, 'localStorage', {
+        get: () => {
+          throw Error('denied');
+        },
+      });
+
+      var prototypes = [badWindow, fakeWindow]
+          .map(service)
+          .map(Object.getPrototypeOf)
+      ;
+      assert.strictEqual(prototypes[0], prototypes[1]);
+    });
+  });
 
   context('when browser localStorage is *not* accessible', () => {
     var localStorage = null;


### PR DESCRIPTION
In some environments, accessing the "localStorage" property of the
window is enough to throw an error.