### PR TITLE
Set the visibleHighlights state for multiple Guests

### DIFF
--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -92,7 +92,7 @@ module.exports = class Guest extends Delegator
     this.addPlugin('CrossFrame', cfOptions)
     @crossframe = this.plugins.CrossFrame
 
-    @crossframe.onConnect(=> this.publish('panelReady'))
+    @crossframe.onConnect(=> this._setupInitialState(config))
     this._connectAnnotationSync(@crossframe)
     this._connectAnnotationUISync(@crossframe)
 
@@ -134,6 +134,10 @@ module.exports = class Guest extends Delegator
 
     return Promise.all([metadataPromise, uriPromise]).then ([metadata, href]) ->
       return {uri: normalizeURI(href, baseURI), metadata}
+
+  _setupInitialState: (config) ->
+    this.publish('panelReady')
+    this.setVisibleHighlights(config.showHighlights == 'always')
 
   _connectAnnotationSync: (crossframe) ->
     this.subscribe 'annotationDeleted', (annotation) =>

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -471,9 +471,7 @@ module.exports = class Guest extends Delegator
 
   # Pass true to show the highlights in the frame or false to disable.
   setVisibleHighlights: (shouldShowHighlights) ->
-    @crossframe?.call('setVisibleHighlights', shouldShowHighlights)
     this.toggleHighlightClass(shouldShowHighlights)
-    this.publish 'setVisibleHighlights', shouldShowHighlights
 
   toggleHighlightClass: (shouldShowHighlights) ->
     if shouldShowHighlights

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -83,8 +83,7 @@ module.exports = class Guest extends Delegator
     this.anchors = []
 
     cfOptions =
-      enableMultiFrameSupport: config.enableMultiFrameSupport
-      embedScriptUrl: config.embedScriptUrl
+      config: config
       on: (event, handler) =>
         this.subscribe(event, handler)
       emit: (event, args...) =>

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -28,9 +28,9 @@ module.exports = class Host extends Guest
       JSON.stringify(Object.assign({}, config, {sidebarAppUrl: undefined, pluginClasses: undefined }))
     )
     if config.sidebarAppUrl and '?' in config.sidebarAppUrl
-      config.sidebarAppUrl += '&' + configParam
+      sidebarAppSrc = config.sidebarAppUrl + '&' + configParam
     else
-      config.sidebarAppUrl += '?' + configParam
+      sidebarAppSrc = config.sidebarAppUrl + '?' + configParam
 
     # Create the iframe
     app = $('<iframe></iframe>')
@@ -38,7 +38,7 @@ module.exports = class Host extends Guest
     # enable media in annotations to be shown fullscreen
     .attr('allowfullscreen', '')
     .attr('seamless', '')
-    .attr('src', config.sidebarAppUrl)
+    .attr('src', sidebarAppSrc)
     .addClass('h-sidebar-iframe')
 
     @frame = $('<div></div>')

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -64,3 +64,9 @@ module.exports = class Host extends Guest
   destroy: ->
     @frame.remove()
     super
+
+  setAllVisibleHighlights: (shouldShowHighlights) ->
+    @crossframe.call('setVisibleHighlights', shouldShowHighlights)
+
+    # Let the Toolbar know about this event
+    this.publish 'setVisibleHighlights', shouldShowHighlights

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -64,9 +64,3 @@ module.exports = class Host extends Guest
   destroy: ->
     @frame.remove()
     super
-
-  setAllVisibleHighlights: (shouldShowHighlights) ->
-    @crossframe.call('setVisibleHighlights', shouldShowHighlights)
-
-    # Let the Toolbar know about this event
-    this.publish 'setVisibleHighlights', shouldShowHighlights

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -51,9 +51,6 @@ module.exports = class Host extends Guest
     app.appendTo(@frame)
 
     this.on 'panelReady', =>
-      # Initialize tool state.
-      this.setVisibleHighlights(config.showHighlights == 'always')
-
       # Show the UI
       @frame.css('display', '')
 

--- a/src/annotator/plugin/cross-frame.coffee
+++ b/src/annotator/plugin/cross-frame.coffee
@@ -22,6 +22,7 @@ module.exports = class CrossFrame extends Plugin
   constructor: (elem, options) ->
     super
 
+    config = options.config
     opts = extract(options, 'server')
     discovery = new Discovery(window, opts)
 
@@ -36,7 +37,7 @@ module.exports = class CrossFrame extends Plugin
         bridge.createChannel(source, origin, token)
       discovery.startDiscovery(onDiscoveryCallback)
 
-      if options.enableMultiFrameSupport
+      if config.enableMultiFrameSupport
         frameObserver.observe(_injectToFrame, _iframeUnloaded);
 
     this.destroy = ->
@@ -60,8 +61,11 @@ module.exports = class CrossFrame extends Plugin
 
     _injectToFrame = (frame) ->
       if !FrameUtil.hasHypothesis(frame)
+        # Take the embed script location from the config
+        # until an alternative solution comes around.
+        embedScriptUrl = config.embedScriptUrl
         FrameUtil.isLoaded frame, () ->
-          FrameUtil.injectHypothesis(frame, options.embedScriptUrl)
+          FrameUtil.injectHypothesis(frame, embedScriptUrl, config)
 
     _iframeUnloaded = (frame) ->
       # TODO: Bridge call here not yet implemented, placeholder for now

--- a/src/annotator/plugin/test/cross-frame-test.coffee
+++ b/src/annotator/plugin/test/cross-frame-test.coffee
@@ -16,6 +16,7 @@ describe 'CrossFrame', ->
 
   createCrossFrame = (options) ->
     defaults =
+      config: {}
       on: sandbox.stub()
       emit: sandbox.stub()
     element = document.createElement('div')

--- a/src/annotator/plugin/toolbar.coffee
+++ b/src/annotator/plugin/toolbar.coffee
@@ -49,7 +49,7 @@ module.exports = class Toolbar extends Plugin
           event.preventDefault()
           event.stopPropagation()
           state = not @annotator.visibleHighlights
-          @annotator.setVisibleHighlights state
+          @annotator.setAllVisibleHighlights state
     ,
       "title": "New Page Note"
       "class": "h-icon-note"

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -190,3 +190,9 @@ module.exports = class Sidebar extends Host
 
   isOpen: ->
     !@frame.hasClass('annotator-collapsed')
+
+  setAllVisibleHighlights: (shouldShowHighlights) ->
+    @crossframe.call('setVisibleHighlights', shouldShowHighlights)
+
+    # Let the Toolbar know about this event
+    this.publish 'setVisibleHighlights', shouldShowHighlights

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -39,8 +39,10 @@ describe('CrossFrame multi-frame scenario', function () {
     document.body.appendChild(container);
 
     options = {
-      enableMultiFrameSupport: true,
-      embedScriptUrl: 'data:,', // empty data uri
+      config: {
+        enableMultiFrameSupport: true,
+        embedScriptUrl: 'data:,', // empty data uri
+      },
       on: sandbox.stub(),
       emit: sandbox.stub(),
     };
@@ -110,7 +112,7 @@ describe('CrossFrame multi-frame scenario', function () {
       isLoaded(frame, function () {
         var scriptElement = frame.contentDocument.querySelector('script[src]');
         assert(scriptElement, 'expected embed script to be injected');
-        assert.equal(scriptElement.src, options.embedScriptUrl,
+        assert.equal(scriptElement.src, options.config.embedScriptUrl,
           'unexpected embed script source');
         resolve();
       });

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -243,3 +243,13 @@ describe 'Sidebar', ->
       sidebar.hide()
 
       assert.isFalse sidebar.visibleHighlights
+
+  describe '#setAllVisibleHighlights', ->
+
+    it 'sets the state through crossframe and emits', ->
+      sidebar = createSidebar({})
+      sandbox.stub(sidebar, 'publish')
+      sidebar.setAllVisibleHighlights(true)
+      assert.calledWith(fakeCrossFrame.call, 'setVisibleHighlights', true)
+      assert.calledWith(sidebar.publish, 'setVisibleHighlights', true)
+

--- a/src/annotator/util/frame-util.js
+++ b/src/annotator/util/frame-util.js
@@ -12,20 +12,21 @@ function hasHypothesis (iframe) {
 }
 
 // Inject embed.js into the iframe
-function injectHypothesis (iframe, scriptUrl) {
-  var config = document.createElement('script');
-  config.className = 'js-hypothesis-config';
-  config.type = 'application/json';
-  config.innerText = '{"enableMultiFrameSupport": true, "subFrameInstance": true}';
+function injectHypothesis (iframe, scriptUrl, config) {
+  var configElement = document.createElement('script');
+  configElement.className = 'js-hypothesis-config';
+  configElement.type = 'application/json';
+  var configObject = Object.assign({}, config, {subFrameInstance: true});
+  configElement.innerText = JSON.stringify(configObject);
 
   var src = scriptUrl;
-  var embed = document.createElement('script');
-  embed.className = 'js-hypothesis-embed';
-  embed.async = true;
-  embed.src = src;
+  var embedElement = document.createElement('script');
+  embedElement.className = 'js-hypothesis-embed';
+  embedElement.async = true;
+  embedElement.src = src;
 
-  iframe.contentDocument.body.appendChild(config);
-  iframe.contentDocument.body.appendChild(embed);
+  iframe.contentDocument.body.appendChild(configElement);
+  iframe.contentDocument.body.appendChild(embedElement);
 }
 
 // Check if we can access this iframe's document

--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -150,14 +150,17 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
       $rootScope.$broadcast('sidebarOpened');
     });
 
-    // These merely relay calls
+    // These invoke the matching methods by name on the Guests
     bridge.on('showSidebar', function () {
       bridge.call('showSidebar');
     });
-
     bridge.on('hideSidebar', function () {
       bridge.call('hideSidebar');
     });
+    bridge.on('setVisibleHighlights', function (state) {
+      bridge.call('setVisibleHighlights', state);
+    });
+
   }
 
   /**

--- a/src/sidebar/test/frame-sync-test.js
+++ b/src/sidebar/test/frame-sync-test.js
@@ -262,5 +262,11 @@ describe('FrameSync', function () {
 
       assert.calledWith(fakeBridge.call, 'hideSidebar');
     });
+
+    it ('calls "setVisibleHighlights"', function() {
+      fakeBridge.emit('setVisibleHighlights');
+
+      assert.calledWith(fakeBridge.call, 'setVisibleHighlights');
+    });
   });
 });


### PR DESCRIPTION
(This is part of the ongoing development of multiple iframe document support.)

The objective of these changes is to implement the highlights visibility state at the multi-frame guest level. This includes setting the correct initial state for each guest and having this state change be applied to each guest whenever the toolbar toggles the visibility of the highlights.

To set the initial state there needed to be a way to read the `showHighlights` config at each Guest instance. This meant there needed to be a change that passed the config object from the top to the lower sub-frame levels. There's more details in my commit messages explaining this change.