### PR TITLE
Allow "oauthEnabled" setting to be overridden in client config

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -23,6 +23,9 @@ function configFrom(window_) {
     enableMultiFrameSupport: settings.hostPageSetting('enableMultiFrameSupport'),
     embedScriptUrl: settings.hostPageSetting('embedScriptUrl'),
     subFrameInstance: settings.hostPageSetting('subFrameInstance'),
+
+    // Temporary feature flag override for 1st-party OAuth
+    oauthEnabled: settings.hostPageSetting('oauthEnabled'),
   };
 }
 

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -94,6 +94,7 @@ describe('annotator.config.index', function() {
       var settings = {
         'openLoginForm': 'OPEN_LOGIN_FORM_SETTING',
         'openSidebar': 'OPEN_SIDEBAR_SETTING',
+        'oauthEnabled': true,
         'branding': 'BRANDING_SETTING',
         'services': 'SERVICES_SETTING',
       };

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -16,7 +16,7 @@ function hostPageConfig(window) {
   var paramWhiteList = [
     // Direct-linked annotation ID
     'annotations',
-                        
+
     // Default query passed by url
     'query',
 
@@ -31,6 +31,10 @@ function hostPageConfig(window) {
     'showHighlights',
     'services',
     'branding',
+
+    // OAuth feature flag override.
+    // This should be removed once OAuth is enabled for first party accounts.
+    'oauthEnabled',
   ];
 
   return Object.keys(config).reduce(function (result, key) {

--- a/src/sidebar/test/host-config-test.js
+++ b/src/sidebar/test/host-config-test.js
@@ -15,6 +15,7 @@ describe('hostPageConfig', function () {
     var window_ = fakeWindow({
       annotations: '1234',
       appType: 'bookmarklet',
+      oauthEnabled: true,
       openSidebar: true,
       openLoginForm: true,
       showHighlights: true,
@@ -26,6 +27,7 @@ describe('hostPageConfig', function () {
     assert.deepEqual(hostPageConfig(window_), {
       annotations: '1234',
       appType: 'bookmarklet',
+      oauthEnabled: true,
       openSidebar: true,
       openLoginForm: true,
       showHighlights: true,


### PR DESCRIPTION
This will enable testing of 1st party OAuth in the client by creating a
custom bookmarklet or test page which embeds the client. Such a test page is added to the service in the form of `/docs/help?__feature__[client_oauth]` by https://github.com/hypothesis/h/pull/4583

The default value for this setting comes from the service. See https://github.com/hypothesis/h/pull/4583