### PR TITLE
Use OAuth for first party login if enabled.

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -109,8 +109,15 @@ function processAppOpts() {
   }
 }
 
+function shouldUseOAuth() {
+  if (serviceConfig(settings)) {
+    return true;
+  }
+  return settings.oauthClientId && settings.oauthEnabled;
+}
+
 var authService;
-if (serviceConfig(settings)) {
+if (shouldUseOAuth()) {
   authService = require('./oauth-auth');
 } else {
   authService = require('./auth');
@@ -211,6 +218,7 @@ module.exports = angular.module('h', [
   .value('Discovery', require('../shared/discovery'))
   .value('ExcerptOverflowMonitor', require('./util/excerpt-overflow-monitor'))
   .value('VirtualThreadList', require('./virtual-thread-list'))
+  .value('random', require('./util/random'))
   .value('raven', require('./raven'))
   .value('serviceConfig', serviceConfig)
   .value('settings', settings)

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -39,7 +39,12 @@ function hostPageConfig(window) {
 
   return Object.keys(config).reduce(function (result, key) {
     if (paramWhiteList.indexOf(key) !== -1) {
-      result[key] = config[key];
+      // Ignore `null` values as these indicate a default value.
+      // In this case the config value set in the sidebar app HTML config is
+      // used.
+      if (config[key] !== null) {
+        result[key] = config[key];
+      }
     }
     return result;
   }, {});

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -6,14 +6,24 @@ var resolve = require('./util/url-util').resolve;
 var serviceConfig = require('./service-config');
 
 /**
- * OAuth-based authentication service used for publisher accounts.
+ * OAuth-based authorization service.
  *
  * A grant token embedded on the page by the publisher is exchanged for
  * an opaque access token.
  */
 // @ngInject
-function auth($http, flash, settings) {
+function auth($http, $window, flash, random, settings) {
 
+  /**
+   * Authorization code from auth popup window.
+   * @type {string}
+   */
+  var authCode;
+
+  /**
+   * Access token retrieved via `POST /token` endpoint.
+   * @type {Promise<string>}
+   */
   var accessTokenPromise;
   var tokenUrl = resolve('token', settings.apiUrl);
 
@@ -80,6 +90,9 @@ function auth($http, flash, settings) {
   // See https://tools.ietf.org/html/rfc7523#section-4
   function exchangeToken(grantToken) {
     var data = {
+      // FIXME: This should be set to the appropriate grant type if we are
+      //        exchanging an authorization code for a grant token, which
+      //        is the case for first-party accounts.
       grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
       assertion: grantToken,
     };
@@ -128,7 +141,7 @@ function auth($http, flash, settings) {
 
   function tokenGetter() {
     if (!accessTokenPromise) {
-      var grantToken = (serviceConfig(settings) || {}).grantToken;
+      var grantToken = (serviceConfig(settings) || {}).grantToken || authCode;
 
       if (grantToken) {
         accessTokenPromise = exchangeToken(grantToken).then(function (tokenInfo) {
@@ -154,9 +167,76 @@ function auth($http, flash, settings) {
   function clearCache() {
   }
 
+  /**
+   * Login to the annotation service using OAuth.
+   *
+   * This displays a popup window which allows the user to login to the service
+   * (if necessary) and then responds with an auth code which the client can
+   * then exchange for access and refresh tokens.
+   */
+  function login() {
+    // Random state string used to check that auth messages came from the popup
+    // window that we opened.
+    var state = random.hexString(16);
+
+    // Promise which resolves or rejects when the user accepts or closes the
+    // auth popup.
+    var authResponse = new Promise((resolve, reject) => {
+      function authRespListener(event) {
+        if (typeof event.data !== 'object') {
+          return;
+        }
+
+        if (event.data.state !== state) {
+          // This message came from a different popup window.
+          return;
+        }
+
+        if (event.data.type === 'authorization_response') {
+          resolve(event.data);
+        }
+        if (event.data.type === 'authorization_canceled') {
+          reject(new Error('Authorization window was closed'));
+        }
+        $window.removeEventListener('message', authRespListener);
+      }
+      $window.addEventListener('message', authRespListener);
+    });
+
+    // Authorize user and retrieve grant token
+    var width  = 400;
+    var height = 400;
+    var left   = $window.screen.width / 2 - width / 2;
+    var top    = $window.screen.height /2 - height / 2;
+
+    var authUrl = settings.oauthAuthorizeUrl;
+    authUrl += '?' + queryString.stringify({
+      client_id: settings.oauthClientId,
+      origin: $window.location.origin,
+      response_mode: 'web_message',
+      response_type: 'code',
+      state: state,
+    });
+    var authWindowSettings = queryString.stringify({
+      left: left,
+      top: top,
+      width: width,
+      height: height,
+    }).replace(/&/g, ',');
+    $window.open(authUrl, 'Login to Hypothesis', authWindowSettings);
+
+    return authResponse.then((resp) => {
+      // Save the auth code. It will be exchanged for an access token when the
+      // next API request is made.
+      authCode = resp.code;
+      accessTokenPromise = null;
+    });
+  }
+
   return {
-    clearCache: clearCache,
-    tokenGetter: tokenGetter,
+    clearCache,
+    login,
+    tokenGetter,
   };
 }
 

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -177,7 +177,7 @@ function auth($http, $window, flash, random, settings) {
   function login() {
     // Random state string used to check that auth messages came from the popup
     // window that we opened.
-    var state = random.hexString(16);
+    var state = random.generateHexString(16);
 
     // Promise which resolves or rejects when the user accepts or closes the
     // auth popup.

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -91,8 +91,12 @@ function session($http, $q, $resource, $rootScope, analytics, annotationUI, auth
       lastLoadTime = Date.now();
       lastLoad = retryUtil.retryPromiseOperation(function () {
         var authority = getAuthority();
-        if (authority) {
-          return store.profile.read({authority: authority}).then(update);
+        if (auth.login || authority) {
+          var opts = {};
+          if (authority) {
+            opts.authority = authority;
+          }
+          return store.profile.read(opts).then(update);
         } else {
           return resource._load().$promise;
         }
@@ -216,12 +220,23 @@ function session($http, $q, $resource, $rootScope, analytics, annotationUI, auth
     });
   }
 
+  /**
+   * Clear the cached profile information and re-fetch it from the server.
+   *
+   * This can be used to refresh the user's profile state after logging in.
+   */
+  function reload() {
+    lastLoad = null;
+    lastLoadTime = null;
+    return resource.load();
+  }
 
   return {
     dismissSidebarTutorial: dismissSidebarTutorial,
     load: resource.load,
     login: resource.login,
     logout: logout,
+    reload: reload,
 
     // For the moment, we continue to expose the session state as a property on
     // this service. In future, other services which access the session state

--- a/src/sidebar/test/host-config-test.js
+++ b/src/sidebar/test/host-config-test.js
@@ -44,4 +44,12 @@ describe('hostPageConfig', function () {
 
     assert.deepEqual(hostPageConfig(window_), {});
   });
+
+  it('ignores `null` values in config', function () {
+    var window_ = fakeWindow({
+      oauthEnabled: null,
+    });
+
+    assert.deepEqual(hostPageConfig(window_), {});
+  });
 });

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -76,7 +76,7 @@ describe('sidebar.oauth-auth', function () {
     };
 
     fakeRandom = {
-      hexString: sinon.stub().returns('notrandom'),
+      generateHexString: sinon.stub().returns('notrandom'),
     };
 
     fakeSettings = {

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -1,15 +1,55 @@
 'use strict';
 
+var { stringify } = require('query-string');
+
 var authService = require('../oauth-auth');
 
 var DEFAULT_TOKEN_EXPIRES_IN_SECS = 1000;
 
-describe('oauth auth', function () {
+class FakeWindow {
+  constructor() {
+    this.callbacks = [];
+
+    this.location = {
+      origin: 'client.hypothes.is',
+    };
+
+    this.screen = {
+      width: 1024,
+      height: 768,
+    };
+
+    this.open = sinon.stub();
+  }
+
+  addEventListener(event, callback) {
+    this.callbacks.push({event, callback});
+  }
+
+  removeEventListener(event, callback) {
+    this.callbacks = this.callbacks.filter((cb) =>
+      cb.event === event && cb.callback === callback
+    );
+  }
+
+  sendMessage(data) {
+    var evt = new MessageEvent('message', { data });
+    this.callbacks.forEach(({event, callback}) => {
+      if (event === 'message') {
+        callback(evt);
+      }
+    });
+  }
+}
+
+describe('sidebar.oauth-auth', function () {
 
   var auth;
   var nowStub;
   var fakeHttp;
   var fakeFlash;
+  var fakeRandom;
+  var fakeWindow;
   var fakeSettings;
   var clock;
   var successfulFirstAccessTokenPromise;
@@ -35,15 +75,29 @@ describe('oauth auth', function () {
       error: sinon.stub(),
     };
 
+    fakeRandom = {
+      hexString: sinon.stub().returns('notrandom'),
+    };
+
     fakeSettings = {
       apiUrl: 'https://hypothes.is/api/',
+      oauthAuthorizeUrl: 'https://hypothes.is/oauth/authorize/',
+      oauthClientId: 'the-client-id',
       services: [{
         authority: 'publisher.org',
         grantToken: 'a.jwt.token',
       }],
     };
 
-    auth = authService(fakeHttp, fakeFlash, fakeSettings);
+    fakeWindow = new FakeWindow();
+
+    auth = authService(
+      fakeHttp,
+      fakeWindow,
+      fakeFlash,
+      fakeRandom,
+      fakeSettings
+    );
 
     clock = sinon.useFakeTimers();
   });
@@ -131,9 +185,7 @@ describe('oauth auth', function () {
     });
 
     it('should return null if no grant token was provided', function () {
-      var auth = authService(fakeHttp, fakeFlash, {
-        services: [{authority: 'publisher.org'}],
-      });
+      fakeSettings.services = [{ authority: 'publisher.org' }];
       return auth.tokenGetter().then(function (token) {
         assert.notCalled(fakeHttp.post);
         assert.equal(token, null);
@@ -240,6 +292,91 @@ describe('oauth auth', function () {
           .then(expireAccessToken)
           .then(function () { clock.tick(1); })
           .then(assertThatErrorMessageWasShown);
+      });
+    });
+  });
+
+  describe('#login', () => {
+
+    beforeEach(() => {
+      // login() is only currently used when using the public
+      // Hypothesis service.
+      fakeSettings.services = [];
+    });
+
+    it('opens the auth endpoint in a popup window', () => {
+      auth.login();
+
+      var params = {
+        client_id: fakeSettings.oauthClientId,
+        origin: 'client.hypothes.is',
+        response_mode: 'web_message',
+        response_type: 'code',
+        state: 'notrandom',
+      };
+      var expectedAuthUrl = `${fakeSettings.oauthAuthorizeUrl}?${stringify(params)}`;
+      assert.calledWith(
+        fakeWindow.open,
+        expectedAuthUrl,
+        'Login to Hypothesis',
+        'height=400,left=312,top=184,width=400'
+      );
+    });
+
+    it('ignores auth responses if the state does not match', () => {
+      var loggedIn = false;
+
+      auth.login().then(() => {
+        loggedIn = true;
+      });
+
+      fakeWindow.sendMessage({
+        // Successful response with wrong state
+        type: 'authorization_response',
+        code: 'acode',
+        state: 'wrongstate',
+      });
+
+      return Promise.resolve().then(() => {
+        assert.isFalse(loggedIn);
+      });
+    });
+
+    it('resolves when auth completes successfully', () => {
+      var loggedIn = auth.login();
+
+      fakeWindow.sendMessage({
+        // Successful response
+        type: 'authorization_response',
+        code: 'acode',
+        state: 'notrandom',
+      });
+
+      // 1. Verify that login completes.
+      return loggedIn.then(() => {
+        return auth.tokenGetter();
+      }).then(() => {
+        // 2. Verify that auth code is exchanged for access & refresh tokens.
+        var expectedBody =
+          'assertion=acode' +
+          '&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer';
+        assert.calledWith(fakeHttp.post, 'https://hypothes.is/api/token', expectedBody, {
+          headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        });
+      });
+    });
+
+    it('rejects when auth is canceled', () => {
+      var loggedIn = auth.login();
+
+      fakeWindow.sendMessage({
+        // Error response
+        type: 'authorization_canceled',
+        state: 'notrandom',
+      });
+
+      return loggedIn.catch((err) => {
+        assert.equal(err.message, 'Authorization window was closed');
       });
     });
   });

--- a/src/sidebar/util/random.js
+++ b/src/sidebar/util/random.js
@@ -13,12 +13,12 @@ function byteToHex(val) {
  * @param {number} - An even-numbered length string to generate.
  * @return {string}
  */
-function hexString(len) {
+function generateHexString(len) {
   var bytes = new Uint8Array(len / 2);
   crypto.getRandomValues(bytes);
   return Array.from(bytes).map(byteToHex).join('');
 }
 
 module.exports = {
-  hexString,
+  generateHexString,
 };

--- a/src/sidebar/util/random.js
+++ b/src/sidebar/util/random.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/* global Uint8Array */
+
+function byteToHex(val) {
+  var str = val.toString(16);
+  return str.length === 1 ? '0' + str : str;
+}
+
+/**
+ * Generate a random hex string of `len` chars.
+ *
+ * @param {number} - An even-numbered length string to generate.
+ * @return {string}
+ */
+function hexString(len) {
+  var bytes = new Uint8Array(len / 2);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes).map(byteToHex).join('');
+}
+
+module.exports = {
+  hexString,
+};

--- a/src/sidebar/util/test/random-test.js
+++ b/src/sidebar/util/test/random-test.js
@@ -3,11 +3,11 @@
 var random = require('../random');
 
 describe('sidebar.util.random', () => {
-  describe('#hexString', () => {
+  describe('#generateHexString', () => {
     [2,4,8,16].forEach((len) => {
       it(`returns a ${len} digit hex string`, () => {
         var re = new RegExp(`^[0-9a-fA-F]{${len}}$`);
-        var str = random.hexString(len);
+        var str = random.generateHexString(len);
         assert.isTrue(re.test(str));
       });
     });

--- a/src/sidebar/util/test/random-test.js
+++ b/src/sidebar/util/test/random-test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var random = require('../random');
+
+describe('sidebar.util.random', () => {
+  describe('#hexString', () => {
+    [2,4,8,16].forEach((len) => {
+      it(`returns a ${len} digit hex string`, () => {
+        var re = new RegExp(`^[0-9a-fA-F]{${len}}$`);
+        var str = random.hexString(len);
+        assert.isTrue(re.test(str));
+      });
+    });
+  });
+});


### PR DESCRIPTION
This is my current WIP work for minimal use of OAuth-based authorization in the client. There is no automatic login for first party clients yet and no persistence of tokens.

If the service provides an OAuth client ID and sets the "oauthEnabled"
flag in the app configuration, use OAuth for first party login.

This initial implementation does not persist the token for future use,
so the user has to login every time they use the app.

----

Manual testing steps:

1. In the service, register an OAuth client with the authority set to `localhost`. Make a note of the client ID.
    ```sh
    ./bin/hypothesis --dev authclient add --name "hclient" --authority "localhost"
    # OAuth client for localhost created
    # Client ID: 3cf82ae0-657b-11e7-934f-af4d7793094a
    # Client Secret: nStaaxyT607hrJ_0i0CTstGBl_43-Z4BAdL8E6kJ5nM
    ```
2. Using the latest version of the service, set the  `CLIENT_OAUTH_ID` env var to the client ID before running the service.
    ````
    export CLIENT_OAUTH_ID=3cf82ae0-657b-11e7-934f-af4d7793094a
    make dev
    ````
3. Go to a test page with OAuth enabled such as http://localhost:5000/docs/help?__feature__[client_oauth]
4. Observe that you should be _logged out_ of the client when it loads.
5. Clicking "Log in" in the top right corner should display a popup window.
6. Logging into the service and clicking "Accept" should result in the user being logged into the client.