### PR TITLE
Increase robustness of frame destruction

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -22,7 +22,7 @@ function configFrom(window_) {
     // Needed by the multi-frame feature for now
     enableMultiFrameSupport: settings.hostPageSetting('enableMultiFrameSupport'),
     embedScriptUrl: settings.hostPageSetting('embedScriptUrl'),
-    subFrameInstance: settings.hostPageSetting('subFrameInstance'),
+    subFrameIdentifier: settings.hostPageSetting('subFrameIdentifier'),
 
     // Temporary feature flag override for 1st-party OAuth
     oauthEnabled: settings.hostPageSetting('oauthEnabled'),

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -53,6 +53,7 @@ module.exports = class Guest extends Delegator
   plugins: null
   anchors: null
   visibleHighlights: false
+  frameIdentifier: null
 
   html:
     adder: '<hypothesis-adder></hypothesis-adder>'
@@ -81,6 +82,10 @@ module.exports = class Guest extends Delegator
 
     this.plugins = {}
     this.anchors = []
+
+    # Set the frame identifier if it's available.
+    # The "top" guest instance will have this as null since it's in a top frame not a sub frame
+    this.frameIdentifier = config.subFrameIdentifier || null
 
     cfOptions =
       config: config
@@ -132,8 +137,12 @@ module.exports = class Guest extends Delegator
       link: [{href: decodeURIComponent(window.location.href)}]
     })
 
-    return Promise.all([metadataPromise, uriPromise]).then ([metadata, href]) ->
-      return {uri: normalizeURI(href, baseURI), metadata}
+    return Promise.all([metadataPromise, uriPromise]).then ([metadata, href]) =>
+      return {
+        uri: normalizeURI(href, baseURI),
+        metadata,
+        frameIdentifier: this.frameIdentifier
+      }
 
   _setupInitialState: (config) ->
     this.publish('panelReady')

--- a/src/annotator/main.js
+++ b/src/annotator/main.js
@@ -51,7 +51,7 @@ $.noConflict(true)(function() {
     delete config.constructor;
   }
 
-  if (config.enableMultiFrameSupport && config.subFrameInstance) {
+  if (config.enableMultiFrameSupport && config.subFrameIdentifier) {
     Klass = Guest;
 
     // Other modules use this to detect if this

--- a/src/annotator/util/frame-util.js
+++ b/src/annotator/util/frame-util.js
@@ -16,8 +16,7 @@ function injectHypothesis (iframe, scriptUrl, config) {
   var configElement = document.createElement('script');
   configElement.className = 'js-hypothesis-config';
   configElement.type = 'application/json';
-  var configObject = Object.assign({}, config, {subFrameInstance: true});
-  configElement.innerText = JSON.stringify(configObject);
+  configElement.innerText = JSON.stringify(config);
 
   var src = scriptUrl;
   var embedElement = document.createElement('script');

--- a/src/shared/polyfills.js
+++ b/src/shared/polyfills.js
@@ -2,6 +2,7 @@
 
 // ES2015 polyfills
 require('core-js/es6/promise');
+require('core-js/es6/map');
 require('core-js/es6/set');
 require('core-js/es6/symbol');
 require('core-js/fn/array/find');

--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -124,9 +124,7 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
       $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED, annot);
     });
 
-    bridge.on('destroyFrame', function (uri) {
-      destroyFrame(uri);
-    });
+    bridge.on('destroyFrame', destroyFrame.bind(this));
 
     // Anchoring an annotation in the frame completed
     bridge.on('sync', function (events_) {
@@ -182,16 +180,17 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
       $rootScope.$broadcast(events.FRAME_CONNECTED);
 
       annotationUI.connectFrame({
+        id: info.frameIdentifier,
         metadata: info.metadata,
         uri: info.uri,
       });
     });
   }
 
-  function destroyFrame(uri) {
+  function destroyFrame(frameIdentifier) {
     var frames = annotationUI.frames();
     var frameToDestroy = frames.find(function (frame) {
-      return frame.uri === uri;
+      return frame.id === frameIdentifier;
     });
     if (frameToDestroy) {
       annotationUI.destroyFrame(frameToDestroy);

--- a/src/sidebar/test/frame-sync-test.js
+++ b/src/sidebar/test/frame-sync-test.js
@@ -28,6 +28,7 @@ var fixtures = {
     metadata: {
       link: [],
     },
+    frameIdentifier: null,
   },
 
   // Response to the `getDocumentInfo` channel message for a frame displaying
@@ -38,10 +39,12 @@ var fixtures = {
       documentFingerprint: '1234',
       link: [{href: 'http://example.org/paper.pdf'}, {href:'urn:1234'}],
     },
+    frameIdentifier: null,
   },
 
   // The entry in the list of frames currently connected
   framesListEntry: {
+    id: 'abc',
     uri: 'http://example.com',
     isAnnotationFetchComplete: true,
   },
@@ -215,6 +218,7 @@ describe('FrameSync', function () {
       fakeBridge.emit('connect', fakeChannel);
 
       assert.calledWith(fakeAnnotationUI.connectFrame, {
+        id: frameInfo.frameIdentifier,
         metadata: frameInfo.metadata,
         uri: frameInfo.uri,
       });
@@ -222,10 +226,10 @@ describe('FrameSync', function () {
   });
 
   context('when a frame is destroyed', function () {
-    var frameUri = fixtures.framesListEntry.uri;
+    var frameId = fixtures.framesListEntry.id;
 
-    it("adds the page's metadata to the frames list", function () {
-      fakeBridge.emit('destroyFrame', frameUri);
+    it('removes the frame from the frames list', function () {
+      fakeBridge.emit('destroyFrame', frameId);
 
       assert.calledWith(fakeAnnotationUI.destroyFrame, fixtures.framesListEntry);
     });


### PR DESCRIPTION
The previous implementation of this used the iframe’s `src` uri as the key for identifying which frames needed to be removed from the sidebar’s frame-sync state.
We can’t rely on this uri because there could be one or more iframes sharing the same src uri, for example ‘about:blank’ with/without `srcdoc` attribute usage.
Another problem is with a `blob:` uri as the src. Once again the uri in the src can’t be used as the key since it won’t match what frame-sync thinks the proper uri is if it’s being substituted with  `baseURI`.

The way this works now is by tagging the frame info with a random ID called the frameIdentifier. The handling of this tag is coordinated with the relevant modules, cross frame, bridge, frame-sync, etc.