### PR TITLE
Fix view switcher flash on iOS

### DIFF
--- a/src/styles/view-switcher.scss
+++ b/src/styles/view-switcher.scss
@@ -21,6 +21,10 @@
   background: $white;
   transition: background-color .1s linear;
 
+  // This fixes the tabs flashing gray for a moment each time you tap on one
+  // in iOS Safari.
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+
   border: 1px solid $gray-lighter;
 
   cursor: pointer;


### PR DESCRIPTION
The view switcher tabs at the top of the sidebar would flash grey for a
moment after you clicked one. This removes the flash.

This webkit "tap highlight" is actually an iOS Safari usability feature,
it indicates to the user that their tap is being successfully recognized, and
indicates which element they're tapping on. But I don't think it looks
good with these tabs of ours, and it seems to interact badly with the
background colour animated transition we're using (it seems to do the
animated transition first and _then_ flash the tap highlight colour for
a second).

We're providing this indication by changing the colour of the tab
anyway, so disable it.