### PR TITLE
Emit an event on the Guest element, ‘scrollToRange’

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "redux-thunk": "^2.1.0",
     "request": "^2.76.0",
     "retry": "^0.8.0",
-    "scroll-into-view": "^1.3.1",
+    "scroll-into-view": "^1.8.2",
     "seamless-immutable": "^6.0.1",
     "showdown": "^1.6.4",
     "sinon": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "coffeeify": "^1.0.0",
     "commander": "^2.9.0",
     "core-js": "^1.2.5",
+    "custom-event": "^1.0.1",
     "diff": "^2.2.2",
     "diff-match-patch": "^1.0.0",
     "document-base-uri": "^1.0.0",

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -166,7 +166,7 @@ module.exports = class Guest extends Delegator
     crossframe.on 'scrollToAnnotation', (tag) =>
       for anchor in @anchors when anchor.highlights?
         if anchor.annotation.$tag is tag
-          event = new CustomEvent('scrollToRange', {
+          event = new CustomEvent('scrolltorange', {
             bubbles: true
             cancelable: true
             detail: anchor.range

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -165,7 +165,14 @@ module.exports = class Guest extends Delegator
     crossframe.on 'scrollToAnnotation', (tag) =>
       for anchor in @anchors when anchor.highlights?
         if anchor.annotation.$tag is tag
-          scrollIntoView(anchor.highlights[0])
+          event = new CustomEvent('scrollToRange', {
+            bubbles: true
+            cancelable: true
+            detail: anchor.range
+          })
+          defaultNotPrevented = @element[0].dispatchEvent(event)
+          if defaultNotPrevented
+            scrollIntoView(anchor.highlights[0])
 
     crossframe.on 'getDocumentInfo', (cb) =>
       this.getDocumentInfo()

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -2,6 +2,7 @@ baseURI = require('document-base-uri')
 extend = require('extend')
 raf = require('raf')
 scrollIntoView = require('scroll-into-view')
+CustomEvent = require('custom-event')
 
 Delegator = require('./delegator')
 $ = require('jquery')

--- a/src/annotator/test/guest-test.coffee
+++ b/src/annotator/test/guest-test.coffee
@@ -238,6 +238,36 @@ describe 'Guest', ->
         assert.called(scrollIntoView)
         assert.calledWith(scrollIntoView, highlight[0])
 
+      context 'when dispatching the "scrollToRange" event', ->
+
+        it 'emits with the range', ->
+          highlight = $('<span></span>')
+          guest = createGuest()
+          fakeRange = sinon.stub()
+          guest.anchors = [
+            {annotation: {$tag: 'tag1'}, highlights: highlight.toArray(), range: fakeRange}
+          ]
+
+          return new Promise (resolve) ->
+            guest.element.on 'scrollToRange', (event) ->
+              assert.equal(event.detail, fakeRange)
+              resolve()
+
+            emitGuestEvent('scrollToAnnotation', 'tag1')
+
+        it 'allows the default scroll behaviour to be prevented', ->
+          highlight = $('<span></span>')
+          guest = createGuest()
+          fakeRange = sinon.stub()
+          guest.anchors = [
+            {annotation: {$tag: 'tag1'}, highlights: highlight.toArray(), range: fakeRange}
+          ]
+
+          guest.element.on 'scrollToRange', (event) -> event.preventDefault()
+          emitGuestEvent('scrollToAnnotation', 'tag1')
+          assert.notCalled(scrollIntoView)
+
+
     describe 'on "getDocumentInfo" event', ->
       guest = null
 

--- a/src/annotator/test/guest-test.coffee
+++ b/src/annotator/test/guest-test.coffee
@@ -238,7 +238,7 @@ describe 'Guest', ->
         assert.called(scrollIntoView)
         assert.calledWith(scrollIntoView, highlight[0])
 
-      context 'when dispatching the "scrollToRange" event', ->
+      context 'when dispatching the "scrolltorange" event', ->
 
         it 'emits with the range', ->
           highlight = $('<span></span>')
@@ -249,7 +249,7 @@ describe 'Guest', ->
           ]
 
           return new Promise (resolve) ->
-            guest.element.on 'scrollToRange', (event) ->
+            guest.element.on 'scrolltorange', (event) ->
               assert.equal(event.detail, fakeRange)
               resolve()
 
@@ -263,7 +263,7 @@ describe 'Guest', ->
             {annotation: {$tag: 'tag1'}, highlights: highlight.toArray(), range: fakeRange}
           ]
 
-          guest.element.on 'scrollToRange', (event) -> event.preventDefault()
+          guest.element.on 'scrolltorange', (event) -> event.preventDefault()
           emitGuestEvent('scrollToAnnotation', 'tag1')
           assert.notCalled(scrollIntoView)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1571,7 +1571,7 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-custom-event@~1.0.0:
+custom-event@^1.0.1, custom-event@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5254,9 +5254,9 @@ sass-graph@^2.1.1:
     scss-tokenizer "^0.2.1"
     yargs "^6.6.0"
 
-scroll-into-view@^1.3.1:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/scroll-into-view/-/scroll-into-view-1.8.0.tgz#47e8c64aba25c80d1123cf1a2144c68eb0069110"
+scroll-into-view@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/scroll-into-view/-/scroll-into-view-1.8.2.tgz#6c5b613553ee853cf7592f4d3b5e4c000f14282d"
   dependencies:
     raf "^3.1.0"
 


### PR DESCRIPTION
This allows attached handlers to hook into the behaviour of bringing a highlight anchor into view.
The event.detail property contains a native DOM range representing the anchor.
The default scroll behaviour can be prevented with the event.preventDefault method.

This is needed by EPUB integration because in most cases the reader has a better idea on how to change it's view to bring the anchor into view.