### PR TITLE
Fix edge case with Adder

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -214,6 +214,12 @@ function Adder(container, options) {
     top = Math.max(top, view.pageYOffset);
     top = Math.min(top, view.pageYOffset + view.innerHeight - height());
 
+    // Offset the adder position, to handle situations where the document is larger than the screen
+    var bodyOffset = document.body.getBoundingClientRect();
+    if (bodyOffset.left < 0) {
+      left = left - bodyOffset.left;
+    }
+
     return {top: top, left: left, arrowDirection: arrowDirection};
   };
 


### PR DESCRIPTION
An issue with the adder not showing up was encountered when testing the integration with the Readium EPUB reader.
The issue was caused by the way Readium renders the document content. CSS Multiple Columns properties are applied at the root element level which cause the body element to be "split" into columns with multiple left based offsets.

The fix is to query the body element's client rectangle geometry at the time the adder is being displayed and adjust by the left offsets.