### PR TITLE
Avoid mutating frames array in DESTROY_FRAME action.

### DIFF
--- a/src/sidebar/reducers/frames.js
+++ b/src/sidebar/reducers/frames.js
@@ -18,11 +18,9 @@ var update = {
   },
 
   DESTROY_FRAME: function (state, action) {
-    var index = state.frames.indexOf(action.frame);
-    if (index >= 0) {
-      state.frames.splice(index, 1);
-    }
-    return {frames: state.frames};
+    return {
+      frames: state.frames.filter(f => f !== action.frame),
+    };
   },
 
   UPDATE_FRAME_ANNOTATION_FETCH_STATUS: function (state, action) {


### PR DESCRIPTION
The state is supposed to be immutable. `Array#splice` modifies its
argument. Use `Array#filter` instead which returns a new array.