### PR TITLE
Persist access and refresh tokens to localStorage.

### DIFF
--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -108,9 +108,10 @@ function auth($http, $window, flash, localStorage, random, settings) {
   }
 
   /**
-   * Read the last-saved access/refresh tokens for `authority`.
+   * Fetch the last-saved access/refresh tokens for `authority` from local
+   * storage.
    */
-  function readLastUsedToken(authority) {
+  function loadToken(authority) {
     var token = localStorage.getObject(storageKey(authority));
 
     if (!token ||
@@ -241,7 +242,7 @@ function auth($http, $window, flash, localStorage, random, settings) {
       } else {
         // Attempt to load the tokens from the previous session.
         var authority = getAuthority(settings);
-        var tokenInfo = readLastUsedToken(authority);
+        var tokenInfo = loadToken(authority);
         if (!tokenInfo) {
           // No token. The user will need to log in.
           accessTokenPromise = Promise.resolve(null);

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -4,6 +4,7 @@ var angular = require('angular');
 var { stringify } = require('query-string');
 
 var DEFAULT_TOKEN_EXPIRES_IN_SECS = 1000;
+var TOKEN_KEY = 'hypothesis.oauth.hypothes%2Eis.token';
 
 class FakeWindow {
   constructor() {
@@ -339,7 +340,7 @@ describe('sidebar.oauth-auth', function () {
       return login().then(() => {
         return auth.tokenGetter();
       }).then(() => {
-        assert.calledWith(fakeLocalStorage.setObject, 'hypothesis.oauth.default.token', {
+        assert.calledWith(fakeLocalStorage.setObject, TOKEN_KEY, {
           accessToken: 'firstAccessToken',
           refreshToken: 'firstRefreshToken',
           expiresAt: 910000,
@@ -366,7 +367,7 @@ describe('sidebar.oauth-auth', function () {
         return auth.tokenGetter();
       }).then(() => {
         // 3. Check that updated token was persisted to storage.
-        assert.calledWith(fakeLocalStorage.setObject, 'hypothesis.oauth.default.token', {
+        assert.calledWith(fakeLocalStorage.setObject, TOKEN_KEY, {
           accessToken: 'secondToken',
           refreshToken: 'secondRefreshToken',
           expiresAt: 1910000,
@@ -375,7 +376,7 @@ describe('sidebar.oauth-auth', function () {
     });
 
     it('loads and uses tokens from storage', () => {
-      fakeLocalStorage.getObject.withArgs('hypothesis.oauth.default.token').returns({
+      fakeLocalStorage.getObject.withArgs(TOKEN_KEY).returns({
         accessToken: 'foo',
         refreshToken: 'bar',
         expiresAt: 123,
@@ -389,7 +390,7 @@ describe('sidebar.oauth-auth', function () {
     it('refreshes the token if it expired after loading from storage', () => {
       // Store an expired access token.
       clock.tick(200);
-      fakeLocalStorage.getObject.withArgs('hypothesis.oauth.default.token').returns({
+      fakeLocalStorage.getObject.withArgs(TOKEN_KEY).returns({
         accessToken: 'foo',
         refreshToken: 'bar',
         expiresAt: 123,
@@ -409,7 +410,7 @@ describe('sidebar.oauth-auth', function () {
         assert.equal(token, 'secondToken');
         assert.calledWith(
           fakeLocalStorage.setObject,
-          'hypothesis.oauth.default.token',
+          TOKEN_KEY,
           {
             accessToken: 'secondToken',
             refreshToken: 'secondRefreshToken',


### PR DESCRIPTION
Persist access and refresh tokens to localStorage, under the key:

  hypothesis.oauth.<authority>.token

Where `<authority>` is the domain of the annotation service and the
structure is the JSON-encoded object:
````
  {
    accessToken: <token>,
    refreshToken: <token>,
    expiresAt: <UNIX timestamp in ms>
  }
````
When an API token is requested for the first time during startup, the
existing token for the current authority is loaded from storage,
validated locally and then used if possible.

There are several things not currently handled by this PR which will be handled by follow-up work:

- Gracefully handling failed refresh requests
- Gracefully handling JSON parse errors when reading objects from localStorage
- Listening for access & refresh token updates made by client instances in other tabs.

----

**Manual testing**

1. Follow the manual testing steps from the previous OAuth PR: https://github.com/hypothesis/client/pull/476
2. Reload the page and check that the user remains logged in, even if they logged out of the web service in the meantime.
3. Clear localStorage for the service's domain, reload the page and verify that you are now logged out.