### PR TITLE
Use a URN derived from DC meta tags for creating equivalent doc links

### DIFF
--- a/src/annotator/plugin/document.coffee
+++ b/src/annotator/plugin/document.coffee
@@ -159,21 +159,20 @@ module.exports = class Document extends Plugin
           if id[0..3] == "doi:"
             @metadata.link.push(href: id)
 
-    # look for a link to identify the resource in dublincore data
-    dcMetaConcat = []
-    # sort by name for a consistent ordering of the concatenated metadata
-    for name in Object.keys(@metadata.dc).sort()
-      # right now only look for these two terms
-      if name == 'source' || name == 'identifier'
-        values = @metadata.dc[name].sort().map (v) -> encodeURIComponent(v)
-        dcMetaConcat.push(name + ':' + values.join(','))
-
-    dcMetaUrn = 'urn:x-dc-meta:' + dcMetaConcat.join('/')
-    if dcMetaConcat.length == 2
-      # only do this if both terms are provided, for now
-      @metadata.link.push(href: dcMetaUrn)
+    # look for a link to identify the resource in dublincore metadata
+    dcRelationValues = @metadata.dc['relation.ispartof']
+    dcIdentifierValues = @metadata.dc['identifier']
+    if dcRelationValues && dcIdentifierValues
+      dcUrnRelationComponent =
+        dcRelationValues[dcRelationValues.length - 1]
+      dcUrnIdentifierComponent =
+        dcIdentifierValues[dcIdentifierValues.length - 1]
+      dcUrn = 'urn:x-dc:' +
+        encodeURIComponent(dcUrnRelationComponent) + '/' +
+        encodeURIComponent(dcUrnIdentifierComponent)
+      @metadata.link.push(href: dcUrn)
       # set this as the documentFingerprint as a hint to include this in search queries
-      @metadata.documentFingerprint = dcMetaUrn
+      @metadata.documentFingerprint = dcUrn
 
   _getFavicon: =>
     for link in $("link")

--- a/src/annotator/plugin/document.coffee
+++ b/src/annotator/plugin/document.coffee
@@ -159,6 +159,22 @@ module.exports = class Document extends Plugin
           if id[0..3] == "doi:"
             @metadata.link.push(href: id)
 
+    # look for a link to identify the resource in dublincore data
+    dcMetaConcat = []
+    # sort by name for a consistent ordering of the concatenated metadata
+    for name in Object.keys(@metadata.dc).sort()
+      # right now only look for these two terms
+      if name == 'source' || name == 'identifier'
+        values = @metadata.dc[name].sort().map (v) -> encodeURIComponent(v)
+        dcMetaConcat.push(name + ':' + values.join(','))
+
+    dcMetaUrn = 'urn:x-dc-meta:' + dcMetaConcat.join('/')
+    if dcMetaConcat.length == 2
+      # only do this if both terms are provided, for now
+      @metadata.link.push(href: dcMetaUrn)
+      # set this as the documentFingerprint as a hint to include this in search queries
+      @metadata.documentFingerprint = dcMetaUrn
+
   _getFavicon: =>
     for link in $("link")
       if $(link).prop("rel") in ["shortcut icon", "icon"]

--- a/src/annotator/plugin/test/document-test.coffee
+++ b/src/annotator/plugin/test/document-test.coffee
@@ -42,6 +42,7 @@ describe 'Document', ->
     head.append('<meta name="citation_pdf_url" content="foo.pdf">')
     head.append('<meta name="dc.identifier" content="doi:10.1175/JCLI-D-11-00015.1">')
     head.append('<meta name="dc:identifier" content="isbn:123456789">')
+    head.append('<meta name="dc:source" content="urn:example:abcxyz">')
     head.append('<meta name="DC.type" content="Article">')
     head.append('<meta property="og:url" content="http://example.com">')
     head.append('<meta name="twitter:site" content="@okfn">')
@@ -65,7 +66,7 @@ describe 'Document', ->
 
     it 'should have links with absolute hrefs and types', ->
       assert.ok(metadata.link)
-      assert.equal(metadata.link.length, 9)
+      assert.equal(metadata.link.length, 10)
       assert.match(metadata.link[0].href, docBaseUri)
       assert.equal(metadata.link[1].rel, "alternate")
       assert.match(metadata.link[1].href, /^.+foo\.pdf$/)
@@ -84,8 +85,16 @@ describe 'Document', ->
       assert.equal(metadata.link[7].type, "application/pdf")
       assert.equal(metadata.link[8].href, "doi:10.1175/JCLI-D-11-00015.1")
 
+      # link derived from dc resource identifiers
+      # should be in the form of `urn:x-dc-meta: identifier: <doi>,<isbn> / source: <example>`
+      # it's a comma separated list for when there's multiple identifiers
+      assert.equal(
+        metadata.link[9].href
+        "urn:x-dc-meta:identifier:doi%3A10.1175%2FJCLI-D-11-00015.1,isbn%3A123456789/source:urn%3Aexample%3Aabcxyz"
+      )
+
     it 'should ignore atom and RSS feeds and alternate languages', ->
-      assert.equal(metadata.link.length, 9)
+      assert.equal(metadata.link.length, 10)
 
     it 'should have highwire metadata', ->
       assert.ok(metadata.highwire)
@@ -96,6 +105,7 @@ describe 'Document', ->
     it 'should have dublincore metadata', ->
       assert.ok(metadata.dc)
       assert.deepEqual(metadata.dc.identifier, ["doi:10.1175/JCLI-D-11-00015.1", "isbn:123456789"])
+      assert.deepEqual(metadata.dc.source, ["urn:example:abcxyz"])
       assert.deepEqual(metadata.dc.type, ["Article"])
 
     it 'should have facebook metadata', ->
@@ -116,7 +126,7 @@ describe 'Document', ->
 
     it 'should have unique uris', ->
       uris = testDocument.uris()
-      assert.equal(uris.length, 7)
+      assert.equal(uris.length, 8)
 
     it 'uri() returns the canonical uri', ->
       uri = testDocument.uri()
@@ -127,6 +137,10 @@ describe 'Document', ->
         metadata.favicon
         'http://example.com/images/icon.ico'
       )
+
+    it 'should have a documentFingerprint as the dc resource identifiers URN href', ->
+      assert.equal(metadata.documentFingerprint, metadata.link[9].href)
+
 
   describe '#_absoluteUrl', ->
 

--- a/src/annotator/plugin/test/document-test.coffee
+++ b/src/annotator/plugin/test/document-test.coffee
@@ -41,8 +41,8 @@ describe 'Document', ->
     head.append('<meta name="citation_title" content="Foo">')
     head.append('<meta name="citation_pdf_url" content="foo.pdf">')
     head.append('<meta name="dc.identifier" content="doi:10.1175/JCLI-D-11-00015.1">')
-    head.append('<meta name="dc:identifier" content="isbn:123456789">')
-    head.append('<meta name="dc:source" content="urn:example:abcxyz">')
+    head.append('<meta name="dc:identifier" content="foobar-abcxyz">')
+    head.append('<meta name="dc.relation.ispartof" content="isbn:123456789">')
     head.append('<meta name="DC.type" content="Article">')
     head.append('<meta property="og:url" content="http://example.com">')
     head.append('<meta name="twitter:site" content="@okfn">')
@@ -85,12 +85,12 @@ describe 'Document', ->
       assert.equal(metadata.link[7].type, "application/pdf")
       assert.equal(metadata.link[8].href, "doi:10.1175/JCLI-D-11-00015.1")
 
-      # link derived from dc resource identifiers
-      # should be in the form of `urn:x-dc-meta: identifier: <doi>,<isbn> / source: <example>`
-      # it's a comma separated list for when there's multiple identifiers
+      # Link derived from dc resource identifiers in the form of urn:x-dc:<container>/<identifier>
+      # Where <container> is the percent-encoded value of the last dc.relation.ispartof meta element
+      # and <identifier> is the percent-encoded value of the last dc.identifier meta element.
       assert.equal(
         metadata.link[9].href
-        "urn:x-dc-meta:identifier:doi%3A10.1175%2FJCLI-D-11-00015.1,isbn%3A123456789/source:urn%3Aexample%3Aabcxyz"
+        "urn:x-dc:isbn%3A123456789/foobar-abcxyz"
       )
 
     it 'should ignore atom and RSS feeds and alternate languages', ->
@@ -104,8 +104,8 @@ describe 'Document', ->
 
     it 'should have dublincore metadata', ->
       assert.ok(metadata.dc)
-      assert.deepEqual(metadata.dc.identifier, ["doi:10.1175/JCLI-D-11-00015.1", "isbn:123456789"])
-      assert.deepEqual(metadata.dc.source, ["urn:example:abcxyz"])
+      assert.deepEqual(metadata.dc.identifier, ["doi:10.1175/JCLI-D-11-00015.1", "foobar-abcxyz"])
+      assert.deepEqual(metadata.dc['relation.ispartof'], ["isbn:123456789"])
       assert.deepEqual(metadata.dc.type, ["Article"])
 
     it 'should have facebook metadata', ->


### PR DESCRIPTION
The URN is a link that is consistent in documents that provide ‘dc:source’ and ‘dc:identifier’ tags, even for documents with different URIs.

This link is now the documentIdentifier (for non-PDF cases) in the document metadata. This metadata is shared with the sidebar, which means this link will be in the list of links for the Search API calls