### PR TITLE
Implement logout when using OAuth

### DIFF
--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -360,11 +360,9 @@ function auth($http, $window, flash, localStorage, random, settings) {
   }
 
   /**
-   * Log the user out of the service.
+   * Log out of the service (in the client only).
    *
-   * Currently this just forgets any API authz credentials which the client has.
-   * When the service provides a means to revoke credentials, this method should
-   * use it.
+   * This revokes and then forgets any OAuth credentials that the user has.
    */
   function logout() {
     return accessTokenPromise.then(accessToken => {

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -208,8 +208,25 @@ function session($http, $q, $resource, $rootScope, analytics, annotationUI, auth
     return update(model);
   }
 
+  /**
+   * Log the user out of the current session.
+   */
   function logout() {
-    return resource.logout().$promise.then(function () {
+    var loggedOut;
+
+    if (auth.logout) {
+      loggedOut = auth.logout().then(() => {
+        // When using OAuth, we have to explicitly re-fetch the logged-out
+        // user's profile.
+        // When using cookie-based auth, `resource.logout()` handles this
+        // automatically.
+        return reload();
+      });
+    } else {
+      loggedOut = resource.logout().$promise;
+    }
+
+    return loggedOut.then(function () {
       auth.clearCache();
     }).catch(function (err) {
       flash.error('Log out failed');

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -20,6 +20,9 @@ class FakeWindow {
     };
 
     this.open = sinon.stub();
+
+    this.setTimeout = window.setTimeout.bind(window);
+    this.clearTimeout = window.clearTimeout.bind(window);
   }
 
   addEventListener(event, callback) {
@@ -55,12 +58,29 @@ describe('sidebar.oauth-auth', function () {
   var clock;
   var successfulFirstAccessTokenPromise;
 
+  /**
+   * Login and retrieve an auth code.
+   */
+  function login() {
+    var loggedIn = auth.login();
+    fakeWindow.sendMessage({
+      type: 'authorization_response',
+      code: 'acode',
+      state: 'notrandom',
+    });
+    return loggedIn;
+  }
+
   before(() => {
     angular.module('app', [])
       .service('auth', require('../oauth-auth'));
   });
 
   beforeEach(function () {
+    // Setup fake clock. This has to be done before setting up the `window`
+    // fake which makes use of timers.
+    clock = sinon.useFakeTimers();
+
     nowStub = sinon.stub(window.performance, 'now');
     nowStub.returns(300);
 
@@ -100,6 +120,7 @@ describe('sidebar.oauth-auth', function () {
     fakeLocalStorage = {
       getObject: sinon.stub().returns(null),
       setObject: sinon.stub(),
+      removeItem: sinon.stub(),
     };
 
     angular.mock.module('app', {
@@ -114,8 +135,6 @@ describe('sidebar.oauth-auth', function () {
     angular.mock.inject((_auth_) => {
       auth = _auth_;
     });
-
-    clock = sinon.useFakeTimers();
   });
 
   afterEach(function () {
@@ -319,19 +338,6 @@ describe('sidebar.oauth-auth', function () {
   });
 
   describe('persistence of tokens to storage', () => {
-    /**
-     * Login and retrieve an auth code.
-     */
-    function login() {
-      var loggedIn = auth.login();
-      fakeWindow.sendMessage({
-        type: 'authorization_response',
-        code: 'acode',
-        state: 'notrandom',
-      });
-      return loggedIn;
-    }
-
     beforeEach(() => {
       fakeSettings.services = [];
     });
@@ -544,6 +550,34 @@ describe('sidebar.oauth-auth', function () {
 
       return loggedIn.catch(err => {
         assert.equal(err.message, 'Authorization code exchange failed');
+      });
+    });
+  });
+
+  describe('#logout', () => {
+    beforeEach(() => {
+      // logout() is only currently used when using the public
+      // Hypothesis service.
+      fakeSettings.services = [];
+
+      return login().then(() => {
+        return auth.tokenGetter();
+      }).then(token => {
+        assert.notEqual(token, null);
+      });
+    });
+
+    it('forgets access tokens', () => {
+      return auth.logout().then(() => {
+        return auth.tokenGetter();
+      }).then(token => {
+        assert.equal(token, null);
+      });
+    });
+
+    it('removes cached tokens', () => {
+      return auth.logout().then(() => {
+        assert.calledWith(fakeLocalStorage.removeItem, TOKEN_KEY);
       });
     });
   });

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -109,6 +109,7 @@ describe('sidebar.oauth-auth', function () {
       apiUrl: 'https://hypothes.is/api/',
       oauthAuthorizeUrl: 'https://hypothes.is/oauth/authorize/',
       oauthClientId: 'the-client-id',
+      oauthRevokeUrl: 'https://hypothes.is/oauth/revoke/',
       services: [{
         authority: 'publisher.org',
         grantToken: 'a.jwt.token',
@@ -564,6 +565,8 @@ describe('sidebar.oauth-auth', function () {
         return auth.tokenGetter();
       }).then(token => {
         assert.notEqual(token, null);
+
+        fakeHttp.post.reset();
       });
     });
 
@@ -578,6 +581,15 @@ describe('sidebar.oauth-auth', function () {
     it('removes cached tokens', () => {
       return auth.logout().then(() => {
         assert.calledWith(fakeLocalStorage.removeItem, TOKEN_KEY);
+      });
+    });
+
+    it('revokes tokens', () => {
+      return auth.logout().then(() => {
+        var expectedBody = 'token=firstAccessToken';
+        assert.calledWith(fakeHttp.post, 'https://hypothes.is/oauth/revoke/', expectedBody, {
+          headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        });
       });
     });
   });

--- a/src/sidebar/test/session-test.js
+++ b/src/sidebar/test/session-test.js
@@ -295,11 +295,8 @@ describe('session', function () {
       });
     });
 
-    it('does not clear the access token when the host page provides a grant token', function () {
-      fakeServiceConfig.returns({
-        authority: 'publisher.org',
-        grantToken: 'a.jwt.token',
-      });
+    it('does not clear the access token when using OAuth-based authorization', function () {
+      fakeAuth.login = Promise.resolve();
 
       session.update({userid: 'different-user', csrf: 'dummytoken'});
 


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/514**

This is an initial implementation of the "Log out" action when using OAuth. When OAuth is in use, clicking "Log out" will:

1. Clear any cached tokens from localStorage and memory.
2. Reload the user's profile.

The service does not currently provide a way to revoke access & refresh tokens, so they will remain valid.

Logging out of the client when using OAuth does not log the user out of the web service. That's consistent with the idea of client & service login being separate but it does mean that switching between two different user accounts is no longer as easy as it was without some changes to the way the OAuth authorization endpoint behaves.