### PR TITLE
Coordinate OAuth token refresh & usage across tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-util": "^3.0.7",
     "hammerjs": "^2.0.4",
+    "idb-mutex": "^0.11.0",
     "inherits": "^2.0.1",
     "isparta": "^4.0.0",
     "istanbul": "^0.4.5",

--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -200,6 +200,7 @@ module.exports = angular.module('h', [
   .service('frameSync', require('./frame-sync').default)
   .service('groups', require('./groups'))
   .service('localStorage', require('./local-storage'))
+  .service('mutex', require('./mutex'))
   .service('permissions', require('./permissions'))
   .service('queryParser', require('./query-parser'))
   .service('rootThread', require('./root-thread'))

--- a/src/sidebar/events.js
+++ b/src/sidebar/events.js
@@ -15,6 +15,11 @@ module.exports = {
   GROUPS_CHANGED: 'groupsChanged',
   /** The logged-in user changed */
   USER_CHANGED: 'userChanged',
+  /**
+   * API tokens were fetched and saved to local storage by another client
+   * instance.
+   */
+  OAUTH_TOKENS_CHANGED: 'oauthTokensChanged',
 
   // UI state changes
 

--- a/src/sidebar/mutex.js
+++ b/src/sidebar/mutex.js
@@ -1,16 +1,19 @@
 'use strict';
 
-function storageKey(name) {
-  return `hypothesis.mutex.${name}`;
-}
+var Mutex = require('idb-mutex').default;
 
 /**
- * Return a Promise that resolves after `ms` milliseconds.
+ * A dummy mutex implementation for use in browsers where IndexedDB is not
+ * available.
  */
-function delay(ms) {
-  return new Promise(resolve => {
-    setTimeout(resolve, ms);
-  });
+class FallbackMutex {
+  lock() {
+    return Promise.resolve();
+  }
+
+  unlock() {
+    return Promise.resolve();
+  }
 }
 
 /**
@@ -18,109 +21,72 @@ function delay(ms) {
  * running in different tabs.
  */
 // @ngInject
-function mutex(localStorage, random) {
-  // A random unique ID for this client instance.
-  var id = random.generateHexString(10);
+function mutex() {
 
-  // Amount of time to wait between "spins" waiting for a lock to be released.
+  var mu;
   var spinDelay = 50;
+  var expiry = 5000;
 
-  // Maximum amount of time that a lock's expiry date can be in the future.
-  var maxExpiry = 10 * 1000;
-
-  function isLocked(lock) {
-    var now = Date.now();
-
-    return lock && typeof lock.expiresAt === 'number' &&
-           lock.expiresAt > now &&
-           lock.expiresAt - now < maxExpiry;
-  }
-
-  /**
-   * "Spin" until a lock is released or it expires.
-   *
-   * @param {string} name - Name of the lock.
-   * @return {Promise} - Promise that resolves when the lock is unlocked.
-   */
-  function spinUnlock(name) {
-    // This could be optimized by listening for the "storage" event sent when the
-    // current owner releases the lock.
-    return delay(spinDelay).then(() => {
-      var lock = localStorage.getObject(storageKey(name));
-      if (!isLocked(lock)) {
-        return null;
-      } else {
-        return spinUnlock(name);
-      }
-    });
-  }
-
-  /**
-   * Acquire a lock with a given `name` for up to `expiry` ms.
-   *
-   * @param {string} name - The name of the lock.
-   * @param [number] expiry - The delay (in ms) before the lock will expire.
-   *   This can be at most ten seconds.
-   * @return {Promise} - Promise that resolves when the lock has been
-   *   aquired.
-   */
-  function lock(name, expiry = 5000) {
-    expiry = Math.min(maxExpiry, expiry);
-
-    var key = storageKey(name);
-    var currentLock = localStorage.getObject(key);
-    if (!isLocked(currentLock)) {
-      // Try to acquire the lock.
-      var lockDesc = { id, expiresAt: Date.now() + expiry };
-      localStorage.setObject(key, lockDesc);
-
-      // The delay here is meant to be long enough that this client will see any
-      // concurrent writes to the same key by another client.
-      return delay(spinDelay).then(() => {
-        var newLock = localStorage.getObject(key);
-        if (!newLock || (isLocked(newLock) && newLock.id !== id)) {
-          // Another client tried to acquire the lock at the same time and won.
-          return lock(name, expiry);
-        } else {
-          // We got the lock.
-          return null;
-        }
+  function init() {
+    try {
+      mu = new Mutex('hyp-mutex', null, {
+        spinDelay,
+        expiry,
       });
-    } else {
-      // Wait for the lock to expire or be released, then try locking again.
-      return spinUnlock(name).then(() => {
-        return lock(name, expiry);
-      });
+    } catch (err) {
+      console.warning('Using fallback mutex'); // eslint-disable-line no-console
+      mu = new FallbackMutex;
     }
   }
 
   /**
-   * Release a lock.
+   * Acquire the lock.
    *
-   * @param {string} name - Name of the lock.
+   * If another client already holds the lock, the returned Promise will not
+   * resolve until the lock is released or it expires.
+   *
+   * @return {Promise}
    */
-  function unlock(name) {
-    var key = storageKey(name);
-    var lock = localStorage.getObject(key);
-    if (!lock) {
-      throw new Error('Lock is not held');
-    }
-    if (lock.id !== id) {
-      throw new Error('Lock held by a different client');
-    }
-    localStorage.removeItem(key);
+  function lock() {
+    return mu.lock();
   }
 
   /**
-   * Adjust the delay between "spins" waiting for a mutex to be unlocked.
+   * Release the lock.
+   *
+   * @return {Promise}
    */
-  function setSpinDelay(ms) {
-    spinDelay = ms;
+  function unlock() {
+    return mu.unlock();
   }
+
+  /**
+   * Configure how long the mutex waits between "spins" if the lock is
+   * contended.
+   *
+   * @param {number} delay - Duration in ms.
+   */
+  function setSpinDelay(delay) {
+    spinDelay = delay;
+    init();
+  }
+
+  /**
+   * Configure how soon mutex locks auto-expire.
+   *
+   * @param {number} delay - Duration in ms.
+   */
+  function setExpiry(delay) {
+    expiry = delay;
+    init();
+  }
+
+  init();
 
   return {
     lock,
     unlock,
+    setExpiry,
     setSpinDelay,
   };
 }

--- a/src/sidebar/mutex.js
+++ b/src/sidebar/mutex.js
@@ -1,0 +1,128 @@
+'use strict';
+
+function storageKey(name) {
+  return `hypothesis.mutex.${name}`;
+}
+
+/**
+ * Return a Promise that resolves after `ms` milliseconds.
+ */
+function delay(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * A service that provides mutual exclusion between instances of the client
+ * running in different tabs.
+ */
+// @ngInject
+function mutex(localStorage, random) {
+  // A random unique ID for this client instance.
+  var id = random.generateHexString(10);
+
+  // Amount of time to wait between "spins" waiting for a lock to be released.
+  var spinDelay = 50;
+
+  // Maximum amount of time that a lock's expiry date can be in the future.
+  var maxExpiry = 10 * 1000;
+
+  function isLocked(lock) {
+    var now = Date.now();
+
+    return lock && typeof lock.expiresAt === 'number' &&
+           lock.expiresAt > now &&
+           lock.expiresAt - now < maxExpiry;
+  }
+
+  /**
+   * "Spin" until a lock is released or it expires.
+   *
+   * @param {string} name - Name of the lock.
+   * @return {Promise} - Promise that resolves when the lock is unlocked.
+   */
+  function spinUnlock(name) {
+    // This could be optimized by listening for the "storage" event sent when the
+    // current owner releases the lock.
+    return delay(spinDelay).then(() => {
+      var lock = localStorage.getObject(storageKey(name));
+      if (!isLocked(lock)) {
+        return null;
+      } else {
+        return spinUnlock(name);
+      }
+    });
+  }
+
+  /**
+   * Acquire a lock with a given `name` for up to `expiry` ms.
+   *
+   * @param {string} name - The name of the lock.
+   * @param [number] expiry - The delay (in ms) before the lock will expire.
+   *   This can be at most ten seconds.
+   * @return {Promise} - Promise that resolves when the lock has been
+   *   aquired.
+   */
+  function lock(name, expiry = 5000) {
+    expiry = Math.min(maxExpiry, expiry);
+
+    var key = storageKey(name);
+    var currentLock = localStorage.getObject(key);
+    if (!isLocked(currentLock)) {
+      // Try to acquire the lock.
+      var lockDesc = { id, expiresAt: Date.now() + expiry };
+      localStorage.setObject(key, lockDesc);
+
+      // The delay here is meant to be long enough that this client will see any
+      // concurrent writes to the same key by another client.
+      return delay(spinDelay).then(() => {
+        var newLock = localStorage.getObject(key);
+        if (!newLock || (isLocked(newLock) && newLock.id !== id)) {
+          // Another client tried to acquire the lock at the same time and won.
+          return lock(name, expiry);
+        } else {
+          // We got the lock.
+          return null;
+        }
+      });
+    } else {
+      // Wait for the lock to expire or be released, then try locking again.
+      return spinUnlock(name).then(() => {
+        return lock(name, expiry);
+      });
+    }
+  }
+
+  /**
+   * Release a lock.
+   *
+   * @param {string} name - Name of the lock.
+   */
+  function unlock(name) {
+    var key = storageKey(name);
+    var lock = localStorage.getObject(key);
+    if (!lock) {
+      throw new Error('Lock is not held');
+    }
+    if (lock.id !== id) {
+      throw new Error('Lock held by a different client');
+    }
+    localStorage.removeItem(key);
+  }
+
+  /**
+   * Adjust the delay between "spins" waiting for a mutex to be unlocked.
+   */
+  function setSpinDelay(ms) {
+    spinDelay = ms;
+  }
+
+  return {
+    lock,
+    unlock,
+    setSpinDelay,
+  };
+}
+
+module.exports = mutex;

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -2,6 +2,7 @@
 
 var queryString = require('query-string');
 
+var events = require('./events');
 var resolve = require('./util/url-util').resolve;
 var serviceConfig = require('./service-config');
 
@@ -18,7 +19,7 @@ var serviceConfig = require('./service-config');
  * an opaque access token.
  */
 // @ngInject
-function auth($http, $window, flash, localStorage, mutex, random, settings) {
+function auth($http, $rootScope, $window, flash, localStorage, mutex, random, settings) {
 
   /**
    * Authorization code from auth popup window.
@@ -293,6 +294,7 @@ function auth($http, $window, flash, localStorage, mutex, random, settings) {
     $window.addEventListener('storage', ({ key }) => {
       if (key === storageKey()) {
         loadAndUseToken();
+        $rootScope.$broadcast(events.OAUTH_TOKENS_CHANGED);
       }
     });
   }

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -231,6 +231,10 @@ function session($http, $q, $resource, $rootScope, analytics, annotationUI, auth
     return resource.load();
   }
 
+  $rootScope.$on(events.OAUTH_TOKENS_CHANGED, () => {
+    reload();
+  });
+
   return {
     dismissSidebarTutorial: dismissSidebarTutorial,
     load: resource.load,

--- a/src/sidebar/test/mutex-test.js
+++ b/src/sidebar/test/mutex-test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+var mutex = require('../mutex');
+
+class FakeLocalStorage {
+  constructor() {
+    this._store = {};
+  }
+
+  setObject(key, obj) {
+    assert.isObject(obj);
+    this._store[key] = obj;
+  }
+
+  getObject(key) {
+    return this._store[key] || null;
+  }
+
+  removeItem(key) {
+    delete this._store[key];
+  }
+}
+
+describe('sidebar.mutex', () => {
+  var fakeLocalStorage;
+
+  function createMutex(id) {
+    var fakeRandom = {
+      generateHexString: () => id,
+    };
+
+    var mtx = mutex(fakeLocalStorage, fakeRandom);
+
+    // Reduce spin delay to speed up tests.
+    mtx.setSpinDelay(5);
+
+    return mtx;
+  }
+
+  beforeEach(() => {
+    fakeLocalStorage = new FakeLocalStorage;
+  });
+
+  describe('#lock', () => {
+    it('locks the mutex', () => {
+      var mtx = createMutex('id');
+      return mtx.lock('foo').then(() => {
+        assert.isObject(fakeLocalStorage.getObject('hypothesis.mutex.foo'));
+      });
+    });
+
+    it('waits until the mutex is unlocked', () => {
+      var mtxA = createMutex('a');
+      var mtxB = createMutex('b');
+
+      var lockTimeA;
+      var lockTimeB;
+
+      var lockedA = mtxA.lock('foo').then(() => {
+        lockTimeA = Date.now();
+      });
+      var lockedB = mtxB.lock('foo').then(() => {
+        lockTimeB = Date.now();
+      });
+
+      setTimeout(() => {
+        mtxA.unlock('foo');
+      }, 50);
+
+      return Promise.all([lockedA, lockedB]).then(() => {
+        var delta = lockTimeB - lockTimeA;
+        assert.isAbove(delta, 50);
+      });
+    });
+
+    context('if another client fails to unlock the mutex', () => {
+      it('waits until the mutex expires', () => {
+        var mtxA = createMutex('a');
+        var mtxB = createMutex('b');
+
+        var lockTimeA;
+        var lockTimeB;
+
+        var lockedA = mtxA.lock('foo', 50).then(() => {
+          lockTimeA = Date.now();
+        });
+        var lockedB = mtxB.lock('foo', 50).then(() => {
+          lockTimeB = Date.now();
+        });
+
+        return Promise.all([lockedA, lockedB]).then(() => {
+          var delta = lockTimeB - lockTimeA;
+          assert.isAbove(delta, 45);
+        });
+      });
+    });
+  });
+
+  describe('#unlock', () => {
+    it('throws an error if the mutex is not locked', () => {
+      var mtx = createMutex('id');
+      assert.throws(() => {
+        return mtx.unlock('foo');
+      });
+    });
+
+    it('throws an error if a different client locked the mutex', () => {
+      var mtxA = createMutex('a');
+      var mtxB = createMutex('b');
+
+      return mtxA.lock('foo').then(() => {
+        assert.throws(() => {
+          mtxB.unlock('foo');
+        });
+      });
+    });
+
+    it('unlocks the mutex', () => {
+      var mtx = createMutex('id');
+      return mtx.lock('foo').then(() => {
+        mtx.unlock('foo');
+
+        assert.isNull(fakeLocalStorage.getObject('hypothesis.mutex.foo'));
+      });
+    });
+  });
+});

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -91,7 +91,7 @@ describe('sidebar.oauth-auth', function () {
 
     fakeMutex = {
       lock: () => Promise.resolve(),
-      unlock: sinon.stub(),
+      unlock: () => Promise.resolve(),
     };
 
     fakeRandom = {

--- a/src/sidebar/test/session-test.js
+++ b/src/sidebar/test/session-test.js
@@ -6,7 +6,7 @@ var events = require('../events');
 
 var mock = angular.mock;
 
-describe('session', function () {
+describe('sidebar.session', function () {
   var $httpBackend;
   var $rootScope;
 
@@ -389,6 +389,27 @@ describe('session', function () {
       });
 
       $httpBackend.flush();
+    });
+  });
+
+  context('when another client changes the current login', () => {
+    it('reloads the profile', () => {
+      fakeAuth.login = sinon.stub().returns(Promise.resolve());
+      fakeStore.profile.read.returns(Promise.resolve({
+        userid: 'acct:initial_user@hypothes.is',
+      }));
+
+      return session.load().then(() => {
+
+        // Simulate login change happening in a different tab.
+        fakeStore.profile.read.returns(Promise.resolve({
+          userid: 'acct:different_user@hypothes.is',
+        }));
+        $rootScope.$broadcast(events.OAUTH_TOKENS_CHANGED);
+
+      }).then(() => {
+        assert.equal(session.state.userid, 'acct:different_user@hypothes.is');
+      });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3111,6 +3111,10 @@ iconv-lite@0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
+idb-mutex@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/idb-mutex/-/idb-mutex-0.11.0.tgz#1573321f74ab83c12c3d200c7cf22ee7c6800d2d"
+
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/514**

This PR implements coordination of OAuth token refresh & usage across tabs so that, if I open an OAuth-enabled client in multiple tabs:

1. Different tabs will not attempt to refresh OAuth tokens at the same time.
2. When one tab refreshes OAuth tokens, other tabs will pick up and start using the refreshed tokens immediately.
3. Switching accounts in one tab will be reflected immediately in another tab in the same browser.

Note that (3) depends partly on https://github.com/hypothesis/client/pull/501. Without #501, logging out in one tab is not immediately reflected in other tabs.

During the implementation, I looked at various options for coordinating actions across browser tabs and discovered that it is a bit of a hole in the web platform at the moment - there are no ubiquitous APIs that directly solve the problem. There are some [existing solutions](https://stackoverflow.com/a/36036135/434243) but they are based on localStorage. I suspected that not to be very wise in modern browsers and [the Chrome devs said as much](https://groups.google.com/a/chromium.org/forum/#!topic/chromium-dev/O7cTL4oC_VE). In response I wrote [a library which uses IndexedDB](https://github.com/robertknight/idb-mutex) as per the Chrome developers suggestion and used that here.

It might be the case that in practice two tabs trying to refresh a token at exactly the same time is rare enough that we could just ignore it. I've tried to make the code that handles mutual exclusion be easy to remove if we decide that is the case.