### PR TITLE
Use correct request params when exchanging auth code for tokens

### DIFF
--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -506,8 +506,9 @@ describe('sidebar.oauth-auth', function () {
       }).then(() => {
         // 2. Verify that auth code is exchanged for access & refresh tokens.
         var expectedBody =
-          'assertion=acode' +
-          '&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer';
+          'client_id=the-client-id' +
+          '&code=acode' +
+          '&grant_type=authorization_code';
         assert.calledWith(fakeHttp.post, 'https://hypothes.is/api/token', expectedBody, {
           headers: {'Content-Type': 'application/x-www-form-urlencoded'},
         });

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -528,6 +528,24 @@ describe('sidebar.oauth-auth', function () {
         assert.equal(err.message, 'Authorization window was closed');
       });
     });
+
+    it('rejects if auth code exchange fails', () => {
+      var loggedIn = auth.login();
+
+      // Successful response from authz popup.
+      fakeWindow.sendMessage({
+        type: 'authorization_response',
+        code: 'acode',
+        state: 'notrandom',
+      });
+
+      // Error response from auth code => token exchange.
+      fakeHttp.post.returns(Promise.resolve({status: 400}));
+
+      return loggedIn.catch(err => {
+        assert.equal(err.message, 'Authorization code exchange failed');
+      });
+    });
   });
 
   // Advance time forward so that any current access tokens will have expired.


### PR DESCRIPTION
Since the h service now supports authorization codes rather than faking
them with JWT grant tokens, use the appropriate request parameters in
the call to exchange the auth code for tokens.

Together with https://github.com/hypothesis/h/pull/4616 this enables the OAuth login flow to work end-to-end after a suitable OAuth client has been created in the service and configured by setting the `CLIENT_OAUTH_ID` env var when running the service.