### PR TITLE
Reload tokens and profile when stored tokens are changed by another client instance

### DIFF
--- a/src/sidebar/events.js
+++ b/src/sidebar/events.js
@@ -15,6 +15,11 @@ module.exports = {
   GROUPS_CHANGED: 'groupsChanged',
   /** The logged-in user changed */
   USER_CHANGED: 'userChanged',
+  /**
+   * API tokens were fetched and saved to local storage by another client
+   * instance.
+   */
+  OAUTH_TOKENS_CHANGED: 'oauthTokensChanged',
 
   // UI state changes
 

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -205,6 +205,20 @@ function auth($http, $window, flash, localStorage, random, settings) {
   }
 
   /**
+   * Listen for updated access & refresh tokens saved by other instances of the
+   * client.
+   */
+  function listenForTokenStorageEvents() {
+    $window.addEventListener('storage', ({ key }) => {
+      if (key === storageKey()) {
+        // Reset cached token information. Tokens will be reloaded from storage
+        // on the next call to `tokenGetter()`.
+        tokenInfoPromise = null;
+      }
+    });
+  }
+
+  /**
    * Retrieve an access token for the API.
    *
    * @return {Promise<string>} The API access token.
@@ -356,6 +370,8 @@ function auth($http, $window, flash, localStorage, random, settings) {
       clearCache();
     });
   }
+
+  listenForTokenStorageEvents();
 
   return {
     clearCache,

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -2,6 +2,7 @@
 
 var queryString = require('query-string');
 
+var events = require('./events');
 var resolve = require('./util/url-util').resolve;
 var serviceConfig = require('./service-config');
 
@@ -27,7 +28,7 @@ var serviceConfig = require('./service-config');
  * an opaque access token.
  */
 // @ngInject
-function auth($http, $window, flash, localStorage, random, settings) {
+function auth($http, $rootScope, $window, flash, localStorage, random, settings) {
 
   /**
    * Authorization code from auth popup window.
@@ -214,6 +215,7 @@ function auth($http, $window, flash, localStorage, random, settings) {
         // Reset cached token information. Tokens will be reloaded from storage
         // on the next call to `tokenGetter()`.
         tokenInfoPromise = null;
+        $rootScope.$broadcast(events.OAUTH_TOKENS_CHANGED);
       }
     });
   }

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -241,7 +241,9 @@ function auth($http, $rootScope, $window, flash, localStorage, random, settings)
       } else if (authCode) {
         // Exchange authorization code retrieved from login popup for a new
         // access token.
-        tokenInfoPromise = exchangeAuthCode(authCode).then((tokenInfo) => {
+        var code = authCode;
+        authCode = null; // Auth codes can only be used once.
+        tokenInfoPromise = exchangeAuthCode(code).then((tokenInfo) => {
           saveToken(tokenInfo);
           return tokenInfo;
         });

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -258,6 +258,10 @@ function session($http, $q, $resource, $rootScope, analytics, annotationUI, auth
     return resource.load();
   }
 
+  $rootScope.$on(events.OAUTH_TOKENS_CHANGED, () => {
+    reload();
+  });
+
   return {
     dismissSidebarTutorial: dismissSidebarTutorial,
     load: resource.load,

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -3,6 +3,8 @@
 var angular = require('angular');
 var { stringify } = require('query-string');
 
+var events = require('../events');
+
 var DEFAULT_TOKEN_EXPIRES_IN_SECS = 1000;
 var TOKEN_KEY = 'hypothesis.oauth.hypothes%2Eis.token';
 
@@ -51,6 +53,7 @@ class FakeWindow {
 
 describe('sidebar.oauth-auth', function () {
 
+  var $rootScope;
   var auth;
   var nowStub;
   var fakeHttp;
@@ -137,8 +140,9 @@ describe('sidebar.oauth-auth', function () {
       settings: fakeSettings,
     });
 
-    angular.mock.inject((_auth_) => {
+    angular.mock.inject((_auth_, _$rootScope_) => {
       auth = _auth_;
+      $rootScope = _$rootScope_;
     });
   });
 
@@ -445,12 +449,8 @@ describe('sidebar.oauth-auth', function () {
       });
     });
 
-    it('reloads tokens when refreshed by another client instance', () => {
-      return login().then(() => {
-        return auth.tokenGetter();
-      }).then(token => {
-        assert.equal(token, 'firstAccessToken');
-
+    context('when another client instance saves new tokens', () => {
+      function notifyStoredTokenChange() {
         // Trigger "storage" event as if another client refreshed the token.
         var storageEvent = new Event('storage');
         storageEvent.key = TOKEN_KEY;
@@ -462,10 +462,29 @@ describe('sidebar.oauth-auth', function () {
         });
 
         fakeWindow.trigger(storageEvent);
+      }
 
-        return auth.tokenGetter();
-      }).then(token => {
-        assert.equal(token, 'storedAccessToken');
+      it('reloads tokens from storage', () => {
+        return login().then(() => {
+          return auth.tokenGetter();
+        }).then(token => {
+          assert.equal(token, 'firstAccessToken');
+
+          notifyStoredTokenChange();
+
+          return auth.tokenGetter();
+        }).then(token => {
+          assert.equal(token, 'storedAccessToken');
+        });
+      });
+
+      it('notifies other services about the change', () => {
+        var onTokenChange = sinon.stub();
+        $rootScope.$on(events.OAUTH_TOKENS_CHANGED, onTokenChange);
+
+        notifyStoredTokenChange();
+
+        assert.called(onTokenChange);
       });
     });
   });

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -31,17 +31,21 @@ class FakeWindow {
 
   removeEventListener(event, callback) {
     this.callbacks = this.callbacks.filter((cb) =>
-      cb.event === event && cb.callback === callback
+      !(cb.event === event && cb.callback === callback)
     );
+  }
+
+  trigger(event) {
+    this.callbacks.forEach((cb) => {
+      if (cb.event === event.type) {
+        cb.callback(event);
+      }
+    });
   }
 
   sendMessage(data) {
     var evt = new MessageEvent('message', { data });
-    this.callbacks.forEach(({event, callback}) => {
-      if (event === 'message') {
-        callback(evt);
-      }
-    });
+    this.trigger(evt);
   }
 }
 
@@ -438,6 +442,30 @@ describe('sidebar.oauth-auth', function () {
             assert.equal(token, null);
           });
         });
+      });
+    });
+
+    it('reloads tokens when refreshed by another client instance', () => {
+      return login().then(() => {
+        return auth.tokenGetter();
+      }).then(token => {
+        assert.equal(token, 'firstAccessToken');
+
+        // Trigger "storage" event as if another client refreshed the token.
+        var storageEvent = new Event('storage');
+        storageEvent.key = TOKEN_KEY;
+
+        fakeLocalStorage.getObject.returns({
+          accessToken: 'storedAccessToken',
+          refreshToken: 'storedRefreshToken',
+          expiresAt: Date.now() + 100,
+        });
+
+        fakeWindow.trigger(storageEvent);
+
+        return auth.tokenGetter();
+      }).then(token => {
+        assert.equal(token, 'storedAccessToken');
       });
     });
   });

--- a/src/sidebar/test/session-test.js
+++ b/src/sidebar/test/session-test.js
@@ -6,7 +6,7 @@ var events = require('../events');
 
 var mock = angular.mock;
 
-describe('session', function () {
+describe('sidebar.session', function () {
   var $httpBackend;
   var $rootScope;
 
@@ -423,6 +423,27 @@ describe('session', function () {
         return session.logout().then(() => {
           assert.isFalse(session.state.loggedIn);
         });
+      });
+    });
+  });
+
+  context('when another client changes the current login', () => {
+    it('reloads the profile', () => {
+      fakeAuth.login = sinon.stub().returns(Promise.resolve());
+      fakeStore.profile.read.returns(Promise.resolve({
+        userid: 'acct:initial_user@hypothes.is',
+      }));
+
+      return session.load().then(() => {
+
+        // Simulate login change happening in a different tab.
+        fakeStore.profile.read.returns(Promise.resolve({
+          userid: 'acct:different_user@hypothes.is',
+        }));
+        $rootScope.$broadcast(events.OAUTH_TOKENS_CHANGED);
+
+      }).then(() => {
+        assert.equal(session.state.userid, 'acct:different_user@hypothes.is');
       });
     });
   });


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/517**

Trigger a reload of tokens from local storage when the persisted tokens are changed by another client instance in a different tab. This happens when another client instance a) refreshes the current tokens or b) the user logs out in a different tab or c) the user logs in in a different tab.

Steps to test:

1. Open http://localhost:3000 in two tabs
2. Log in, in tab A.
3. Switch to tab B and check that the client shows the same login state as tab A.
4. Log out, in tab B
5. Switch back to tab A and check that the client shows the same login state as tab B.