### PR TITLE
Work around Chrome bug causing sidebar to become invisible

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var addAnalytics = require('./ga');
+var disableOpenerForExternalLinks = require('./util/disable-opener-for-external-links');
 var getApiUrl = require('./get-api-url');
 var serviceConfig = require('./service-config');
 require('../shared/polyfills');
@@ -29,6 +30,9 @@ settings.apiUrl = getApiUrl(settings);
 // The `ng-csp` attribute must be set on some HTML element in the document
 // _before_ Angular is require'd for the first time.
 document.body.setAttribute('ng-csp', '');
+
+// Prevent tab-jacking.
+disableOpenerForExternalLinks(document.body);
 
 var angular = require('angular');
 

--- a/src/sidebar/util/disable-opener-for-external-links.js
+++ b/src/sidebar/util/disable-opener-for-external-links.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * Prevent windows or tabs opened via links under `root` from accessing their
+ * opening `Window`.
+ *
+ * This makes links with `target="blank"` attributes act as if they also had
+ * the `rel="noopener"` [1] attribute set.
+ *
+ * In addition to preventing tab-jacking [2], this also enables multi-process
+ * browsers to more easily use a new process for instances of Hypothesis in the
+ * newly-opened tab and works around a bug in Chrome [3]
+ *
+ * [1] https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types#noopener
+ * [2] https://mathiasbynens.github.io/rel-noopener/
+ * [3] https://bugs.chromium.org/p/chromium/issues/detail?id=753314
+ *
+ * @param {Element} root - Root element
+ */
+function disableOpenerForExternalLinks(root) {
+  root.addEventListener('click', event => {
+    if (event.target.tagName === 'A') {
+      var linkEl = event.target;
+      if (linkEl.target === '_blank') {
+        linkEl.rel = 'noopener';
+      }
+    }
+  });
+}
+
+module.exports = disableOpenerForExternalLinks;

--- a/src/sidebar/util/test/disable-opener-for-external-links-test.js
+++ b/src/sidebar/util/test/disable-opener-for-external-links-test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var disableOpenerForExternalLinks = require('../disable-opener-for-external-links');
+
+describe('sidebar.util.disable-opener-for-external-links', () => {
+  var containerEl;
+  var linkEl;
+
+  beforeEach(() => {
+    containerEl = document.createElement('div');
+    linkEl = document.createElement('a');
+    containerEl.appendChild(linkEl);
+    document.body.appendChild(containerEl);
+  });
+
+  afterEach(() => {
+    containerEl.remove();
+  });
+
+  function clickLink() {
+    linkEl.dispatchEvent(new Event('click', {
+      bubbles: true,
+      cancelable: true,
+    }));
+  }
+
+  it('disables opener for external links', () => {
+    linkEl.target = '_blank';
+
+    disableOpenerForExternalLinks(containerEl);
+    clickLink();
+
+    assert.equal(linkEl.rel, 'noopener');
+  });
+
+  it('does not disable opener for internal links', () => {
+    disableOpenerForExternalLinks(containerEl);
+    clickLink();
+    assert.equal(linkEl.rel, '');
+  });
+});


### PR DESCRIPTION
Work around a Chrome bug [1] that can cause the sidebar to become
invisible if:

 1. The sidebar app is loaded from a Chrome extension AND
 2. The current tab was opened by clicking a link inside the sidebar
    app in a different tab.

When the issue occurs, the sidebar web app loads and runs normally but
is just not visible on screen. Temporarily hiding and showing the iframe
resolves the problem. At the point when the temporary hide & show
occurs, the iframe is positioned to the right of the viewport, so the
user does not see the visibility change.

Fixes #516

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=753314