### PR TITLE
Deprecate openLoginForm setting and make a no-op when using OAuth

### DIFF
--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -64,6 +64,11 @@ loads.
    startup, as if the user had clicked "Log in" themselves.
    (Default: ``false``.)
 
+   .. warning::
+
+      This option is deprecated and has no effect when the client is using OAuth
+      for authorization.
+
 .. option:: openSidebar
 
    ``Boolean``. Controls whether the sidebar opens automatically on startup.

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -76,7 +76,7 @@ function HypothesisAppController(
     // after first install of the extension.
     self.auth = authStateFromUserID(state.userid);
 
-    if (!state.userid && settings.openLoginForm) {
+    if (!state.userid && settings.openLoginForm && !auth.login) {
       self.login();
     }
   });

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -7,7 +7,7 @@ var events = require('../../events');
 var bridgeEvents = require('../../../shared/bridge-events');
 var util = require('../../../shared/test/util');
 
-describe('hypothesisApp', function () {
+describe('sidebar.components.hypothesis-app', function () {
   var $componentController = null;
   var $scope = null;
   var $rootScope = null;
@@ -158,7 +158,7 @@ describe('hypothesisApp', function () {
     sandbox.restore();
   });
 
-  describe('isSidebar property', function () {
+  describe('#isSidebar', function () {
 
     it('is false if the window is the top window', function () {
       fakeWindow.top = fakeWindow;
@@ -262,6 +262,27 @@ describe('hypothesisApp', function () {
     fakeRoute.reload = sinon.spy();
     $scope.$broadcast(events.USER_CHANGED, {initialLoad: false});
     assert.calledOnce(fakeRoute.reload);
+  });
+
+  context('when the "openLoginForm" setting is enabled', () => {
+    beforeEach(() => {
+      fakeSettings.openLoginForm = true;
+    });
+
+    it('shows the login form if not using OAuth', () => {
+      var ctrl = createController();
+      return fakeSession.load().then(() => {
+        assert.isTrue(ctrl.accountDialog.visible);
+      });
+    });
+
+    it('does not show the login form if using OAuth', () => {
+      fakeAuth.login = sandbox.stub();
+      var ctrl = createController();
+      return fakeSession.load().then(() => {
+        assert.isFalse(ctrl.accountDialog.visible);
+      });
+    });
   });
 
   describe('#signUp', function () {


### PR DESCRIPTION
When using OAuth clicking "Log In" triggers a pop-up window which
requires user interaction in most browsers. Therefore the
"openLoginForm" option cannot be respected when using OAuth and would be
annoying anyway.

Fixes #515