### PR TITLE
Get OAuth authorization endpoints from `/api/links`

### DIFF
--- a/src/sidebar/api-routes.js
+++ b/src/sidebar/api-routes.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var { retryPromiseOperation } = require('./retry-util');
+
+/**
+ * A service which fetches and caches API route metadata.
+ */
+// @ngInject
+function apiRoutes($http, settings) {
+  // Cache of route name => route metadata from API root.
+  var routeCache;
+  // Cache of links to pages on the service fetched from the API's "links"
+  // endpoint.
+  var linkCache;
+
+  function getJSON(url) {
+    return $http.get(url).then(({ status, data }) => {
+      if (status !== 200) {
+        throw new Error(`Fetching ${url} failed`);
+      }
+      return data;
+    });
+  }
+
+  /**
+   * Fetch and cache API route metadata.
+   *
+   * Routes are fetched without any authentication and therefore assumed to be
+   * the same regardless of whether the user is authenticated or not.
+   *
+   * @return {Promise<Object>} - Map of routes to route metadata.
+   */
+  function routes() {
+    if (!routeCache) {
+      routeCache = retryPromiseOperation(() => getJSON(settings.apiUrl))
+        .then((index) => index.links);
+    }
+    return routeCache;
+  }
+
+  /**
+   * Fetch and cache service page links from the API.
+   *
+   * @return {Promise<Object>} - Map of link name to URL
+   */
+  function links() {
+    if (!linkCache) {
+      linkCache = routes().then(routes => {
+        return getJSON(routes.links.url);
+      });
+    }
+    return linkCache;
+  }
+
+  return { routes, links };
+}
+
+module.exports = apiRoutes;

--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -191,6 +191,7 @@ module.exports = angular.module('h', [
   .service('analytics', require('./analytics'))
   .service('annotationMapper', require('./annotation-mapper'))
   .service('annotationUI', require('./annotation-ui'))
+  .service('apiRoutes', require('./api-routes'))
   .service('auth', authService)
   .service('bridge', require('../shared/bridge'))
   .service('drafts', require('./drafts'))

--- a/src/sidebar/service-url.js
+++ b/src/sidebar/service-url.js
@@ -33,9 +33,9 @@ var urlUtil = require('./util/url-util');
  *
  * @ngInject
  */
-function serviceUrl(annotationUI, store) {
+function serviceUrl(annotationUI, apiRoutes) {
 
-  store.links()
+  apiRoutes.links()
     .then(annotationUI.updateLinks)
     .catch(function(error) {
       console.warn('The links API request was rejected: ' + error.message);

--- a/src/sidebar/store.js
+++ b/src/sidebar/store.js
@@ -2,7 +2,6 @@
 
 var get = require('lodash.get');
 
-var retryUtil = require('./retry-util');
 var urlUtil = require('./util/url-util');
 
 /**
@@ -150,15 +149,15 @@ function createAPICall($http, $q, links, route, tokenGetter) {
  *
  * Returns an object that with keys that match the routes in
  * the Hypothesis API (see http://h.readthedocs.io/en/latest/api/).
+ *
+ * This service handles authenticated calls to the API, using the `auth` service
+ * to get auth tokens. The URLs for API endpoints are fetched from the `/api`
+ * endpoint, a responsibility delegated to the `apiRoutes` service which does
+ * not use authentication.
  */
 // @ngInject
-function store($http, $q, auth, settings) {
-  var links = retryUtil.retryPromiseOperation(function () {
-    return $http.get(settings.apiUrl);
-  }).then(function (response) {
-    return response.data.links;
-  });
-
+function store($http, $q, apiRoutes, auth) {
+  var links = apiRoutes.routes();
   function apiCall(route) {
     return createAPICall($http, $q, links, route, auth.tokenGetter);
   }
@@ -178,7 +177,9 @@ function store($http, $q, auth, settings) {
       read: apiCall('profile.read'),
       update: apiCall('profile.update'),
     },
-    links: apiCall('links'),
+
+    // The `links` endpoint is not included here. Clients should fetch these
+    // from the `apiRoutes` service.
   };
 }
 

--- a/src/sidebar/test/api-routes-test.js
+++ b/src/sidebar/test/api-routes-test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+var apiRoutesFactory = require('../api-routes');
+
+// Abridged version of the response returned by https://hypothes.is/api,
+// with the domain name changed.
+var apiIndexResponse = {
+  message: 'Annotation Service API',
+  links: {
+    annotation: {
+      read: {
+        url: 'https://annotation.service/api/annotations/:id',
+        method: 'GET',
+        description: 'Fetch an annotation',
+      },
+    },
+    links: {
+      url: 'https://annotation.service/api/links',
+      method: 'GET',
+      description: 'Fetch links to pages on the service',
+    },
+  },
+};
+
+// Abridged version of the response returned by https://hypothes.is/api/links,
+// with the domain name changed.
+var linksResponse = {
+  'forgot-password': 'https://annotation.service/forgot-password',
+  'help': 'https://annotation.service/docs/help',
+  'groups.new': 'https://annotation.service/groups/new',
+  'groups.leave': 'https://annotation.service/groups/:id/leave',
+  'search.tag': 'https://annotation.service/search?q=tag:":tag"',
+  'account.settings': 'https://annotation.service/account/settings',
+  'oauth.revoke': 'https://annotation.service/oauth/revoke',
+  'signup': 'https://annotation.service/signup',
+  'oauth.authorize': 'https://annotation.service/oauth/authorize',
+};
+
+describe('sidebar.api-routes', () => {
+  var apiRoutes;
+  var fakeHttp;
+  var fakeSettings;
+
+  function httpResponse(status, data) {
+    return Promise.resolve({ status, data });
+  }
+
+  beforeEach(() => {
+    // Use a Sinon stub rather than Angular's fake $http service here to avoid
+    // the hassles that come with mixing `$q` and regular promises.
+    fakeHttp = {
+      get: sinon.stub(),
+    };
+
+    fakeHttp.get.withArgs('https://annotation.service/api/')
+      .returns(httpResponse(200, apiIndexResponse));
+    fakeHttp.get.withArgs('https://annotation.service/api/links')
+      .returns(httpResponse(200, linksResponse));
+
+    fakeSettings = {
+      apiUrl: 'https://annotation.service/api/',
+    };
+
+    apiRoutes = apiRoutesFactory(fakeHttp, fakeSettings);
+  });
+
+  describe('#routes', () => {
+    it('returns the route directory', () => {
+      return apiRoutes.routes().then(routes => {
+        assert.deepEqual(routes, apiIndexResponse.links);
+      });
+    });
+
+    it('caches the route directory', () => {
+      // Call `routes()` multiple times, check that only one HTTP call is made.
+      return Promise.all([apiRoutes.routes(), apiRoutes.routes()])
+        .then(([routesA, routesB]) => {
+          assert.equal(routesA, routesB);
+          assert.equal(fakeHttp.get.callCount, 1);
+        });
+    });
+
+    it('retries the route fetch until it succeeds', () => {
+      fakeHttp.get.onFirstCall().returns(httpResponse(500, null));
+      return apiRoutes.routes().then(routes => {
+        assert.deepEqual(routes, apiIndexResponse.links);
+      });
+    });
+  });
+
+  describe('#links', () => {
+    it('returns page links', () => {
+      return apiRoutes.links().then(links => {
+        assert.deepEqual(links, linksResponse);
+      });
+    });
+
+    it('caches the returned links', () => {
+      // Call `links()` multiple times, check that only two HTTP calls are made
+      // (one for the index, one for the page links).
+      return Promise.all([apiRoutes.links(), apiRoutes.links()])
+        .then(([linksA, linksB]) => {
+          assert.equal(linksA, linksB);
+          assert.deepEqual(fakeHttp.get.callCount, 2);
+        });
+    });
+  });
+});

--- a/src/sidebar/test/service-url-test.js
+++ b/src/sidebar/test/service-url-test.js
@@ -26,19 +26,19 @@ function createServiceUrl(linksPromise) {
 
   var annotationUI = fakeAnnotationUI();
 
-  var store = {
+  var apiRoutes = {
     links: sinon.stub().returns(linksPromise),
   };
 
   return {
     annotationUI: annotationUI,
-    store: store,
-    serviceUrl: serviceUrlFactory(annotationUI, store),
+    apiRoutes,
+    serviceUrl: serviceUrlFactory(annotationUI, apiRoutes),
     replaceURLParams: replaceURLParams,
   };
 }
 
-describe('links', function () {
+describe('sidebar.service-url', function () {
 
   beforeEach(function() {
     sinon.stub(console, 'warn');
@@ -50,7 +50,7 @@ describe('links', function () {
 
   context('before the API response has been received', function() {
     var serviceUrl;
-    var store;
+    var apiRoutes;
 
     beforeEach(function() {
       // Create a serviceUrl function with an unresolved Promise that will
@@ -58,12 +58,12 @@ describe('links', function () {
       var parts = createServiceUrl(new Promise(function() {}));
 
       serviceUrl = parts.serviceUrl;
-      store = parts.store;
+      apiRoutes = parts.apiRoutes;
     });
 
     it('sends one API request for the links at boot time', function() {
-      assert.calledOnce(store.links);
-      assert.isTrue(store.links.calledWithExactly());
+      assert.calledOnce(apiRoutes.links);
+      assert.isTrue(apiRoutes.links.calledWithExactly());
     });
 
     it('returns an empty string for any link', function() {

--- a/src/sidebar/test/store-test.js
+++ b/src/sidebar/test/store-test.js
@@ -5,13 +5,60 @@ var proxyquire = require('proxyquire');
 
 var util = require('../../shared/test/util');
 
-describe('store', function () {
+// API route directory.
+// This should mirror the structure (but not the exact URLs) of
+// https://hypothes.is/api/.
+var routes = {
+  annotation: {
+    create: {
+      method: 'POST',
+      url: 'http://example.com/api/annotations',
+    },
+    delete: {
+      method: 'DELETE',
+      url: 'http://example.com/api/annotations/:id',
+    },
+    read: {},
+    update: {
+      method: 'PUT',
+      url: 'http://example.com/api/annotations/:id',
+    },
+    flag: {
+      method: 'PUT',
+      url: 'http://example.com/api/annotations/:id/flag',
+    },
+    hide: {
+      method: 'PUT',
+      url: 'http://example.com/api/annotations/:id/hide',
+    },
+    unhide: {
+      method: 'DELETE',
+      url: 'http://example.com/api/annotations/:id/hide',
+    },
+  },
+  search: {
+    method: 'GET',
+    url: 'http://example.com/api/search',
+  },
+  profile: {
+    read: {
+      method: 'GET',
+      url: 'http://example.com/api/profile',
+    },
+    update: {
+      method: 'PATCH',
+      url: 'http://example.com/api/profile',
+    },
+  },
+};
+
+describe('sidebar.store', function () {
   var $httpBackend = null;
   var sandbox = null;
   var store = null;
 
   before(function () {
-    angular.module('h')
+    angular.module('h', [])
       .service('store', proxyquire('../store', util.noCallThru({
         angular: angular,
         './retry-util': {
@@ -25,9 +72,14 @@ describe('store', function () {
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
 
+    var fakeApiRoutes = {
+      links: sinon.stub(),
+      routes: sinon.stub(),
+    };
     var fakeAuth = {};
 
     angular.mock.module('h', {
+      apiRoutes: fakeApiRoutes,
       auth: fakeAuth,
       settings: {apiUrl: 'http://example.com/api/'},
     });
@@ -37,6 +89,8 @@ describe('store', function () {
       fakeAuth.tokenGetter = function () {
         return $q.resolve('faketoken');
       };
+
+      fakeApiRoutes.routes.returns($q.resolve(routes));
     });
   });
 
@@ -49,56 +103,6 @@ describe('store', function () {
   beforeEach(angular.mock.inject(function (_$httpBackend_, _store_) {
     $httpBackend = _$httpBackend_;
     store = _store_;
-
-    $httpBackend.expectGET('http://example.com/api/').respond({
-      // Return an API route directory.
-      // This should mirror the structure (but not the exact URLs) of
-      // https://hypothes.is/api/.
-      links: {
-        annotation: {
-          create: {
-            method: 'POST',
-            url: 'http://example.com/api/annotations',
-          },
-          delete: {
-            method: 'DELETE',
-            url: 'http://example.com/api/annotations/:id',
-          },
-          read: {},
-          update: {
-            method: 'PUT',
-            url: 'http://example.com/api/annotations/:id',
-          },
-          flag: {
-            method: 'PUT',
-            url: 'http://example.com/api/annotations/:id/flag',
-          },
-          hide: {
-            method: 'PUT',
-            url: 'http://example.com/api/annotations/:id/hide',
-          },
-          unhide: {
-            method: 'DELETE',
-            url: 'http://example.com/api/annotations/:id/hide',
-          },
-        },
-        search: {
-          method: 'GET',
-          url: 'http://example.com/api/search',
-        },
-        profile: {
-          read: {
-            method: 'GET',
-            url: 'http://example.com/api/profile',
-          },
-          update: {
-            method: 'PATCH',
-            url: 'http://example.com/api/profile',
-          },
-        },
-      },
-    });
-    $httpBackend.flush();
   }));
 
   it('saves a new annotation', function (done) {


### PR DESCRIPTION
This is a series of commits to enable the client to get the OAuth endpoints (`/oauth/authorize` and `/oauth/revoke`) from the page links returned by the `/api/links` endpoint, instead of using a separate keys in the app configuration (`oauthAuthorizeUrl`, `oauthRevokeUrl`).

- The first two commits are some refactoring of the services in the client, introducing a new "apiRoutes" service, to make fetching `/api/links` possible without a dependency on the authentication service.
- The last commit makes the authentication service use the "apiRoutes" service to get the endpoint links.

See individual commit messages for more details.