### PR TITLE
Use the `group.member.delete` API route to leave a group

### DIFF
--- a/src/sidebar/groups.js
+++ b/src/sidebar/groups.js
@@ -16,7 +16,7 @@ var STORAGE_KEY = 'hypothesis.groups.focus';
 var events = require('./events');
 
 // @ngInject
-function groups(localStorage, serviceUrl, session, $rootScope, $http) {
+function groups(localStorage, serviceUrl, session, $rootScope, store) {
   // The currently focused group. This is the group that's shown as selected in
   // the groups dropdown, the annotations displayed are filtered to only ones
   // that belong to this group, and any new annotations that the user creates
@@ -38,20 +38,18 @@ function groups(localStorage, serviceUrl, session, $rootScope, $http) {
     return null;
   }
 
-  /** Leave the group with the given ID.
+  /**
+   * Leave the group with the given ID.
    * Returns a promise which resolves when the action completes.
    */
   function leave(id) {
-    var response = $http({
-      method: 'POST',
-      url: serviceUrl('groups.leave', {id: id}),
-    });
-
-    // the groups list will be updated in response to a session state
+    // The groups list will be updated in response to a session state
     // change notification from the server. We could improve the UX here
     // by optimistically updating the session state
-
-    return response;
+    return store.group.member.delete({
+      pubid: id,
+      user: 'me',
+    });
   }
 
 

--- a/src/sidebar/store.js
+++ b/src/sidebar/store.js
@@ -173,6 +173,11 @@ function store($http, $q, apiRoutes, auth) {
       hide: apiCall('annotation.hide'),
       unhide: apiCall('annotation.unhide'),
     },
+    group: {
+      member: {
+        delete: apiCall('group.member.delete'),
+      },
+    },
     profile: {
       read: apiCall('profile.read'),
       update: apiCall('profile.update'),

--- a/src/sidebar/test/groups-test.js
+++ b/src/sidebar/test/groups-test.js
@@ -18,9 +18,9 @@ var sessionWithThreeGroups = function() {
 
 describe('groups', function() {
   var fakeSession;
+  var fakeStore;
   var fakeLocalStorage;
   var fakeRootScope;
-  var fakeHttp;
   var fakeServiceUrl;
   var sandbox;
 
@@ -43,7 +43,13 @@ describe('groups', function() {
         }
       },
     };
-    fakeHttp = sandbox.stub();
+    fakeStore = {
+      group: {
+        member: {
+          delete: sandbox.stub().returns(Promise.resolve()),
+        },
+      },
+    };
     fakeServiceUrl = sandbox.stub();
   });
 
@@ -53,7 +59,7 @@ describe('groups', function() {
 
   function service() {
     return groups(fakeLocalStorage, fakeServiceUrl, fakeSession,
-      fakeRootScope, fakeHttp);
+      fakeRootScope, fakeStore);
   }
 
   describe('.all()', function() {
@@ -171,15 +177,13 @@ describe('groups', function() {
   });
 
   describe('.leave()', function () {
-    it('should call the /groups/<id>/leave service', function () {
+    it('should call the group leave API', function () {
       var s = service();
-      fakeServiceUrl
-        .withArgs('groups.leave', {id: 'id2'})
-        .returns('https://hyp.is/groups/leave');
-      s.leave('id2');
-      assert.calledWithMatch(fakeHttp, {
-        url: 'https://hyp.is/groups/leave',
-        method: 'POST',
+      return s.leave('id2').then(() => {
+        assert.calledWithMatch(fakeStore.group.member.delete, {
+          pubid: 'id2',
+          user: 'me',
+        });
       });
     });
   });

--- a/src/sidebar/test/store-test.js
+++ b/src/sidebar/test/store-test.js
@@ -36,6 +36,14 @@ var routes = {
       url: 'http://example.com/api/annotations/:id/hide',
     },
   },
+  group: {
+    member: {
+      delete: {
+        method: 'DELETE',
+        url: 'http://example.com/api/groups/:pubid/members/:user',
+      },
+    },
+  },
   search: {
     method: 'GET',
     url: 'http://example.com/api/search',
@@ -176,6 +184,20 @@ describe('sidebar.store', function () {
         return [204, {}, {}];
       });
     $httpBackend.flush();
+  });
+
+  describe('#group.member.delete', () => {
+    it('removes current user from a group', (done) => {
+      store.group.member.delete({pubid: 'an-id', user: 'me'}).then(function () {
+        done();
+      });
+
+      $httpBackend.expectDELETE('http://example.com/api/groups/an-id/members/me')
+        .respond(() => {
+          return [204, {}, {}];
+        });
+      $httpBackend.flush();
+    });
   });
 
   it('removes internal properties before sending data to the server', function (done) {


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/h/pull/4630 ~~and the resolution of [this comment](https://github.com/hypothesis/h/pull/4630#issuecomment-324289283)~~**

Replace use of the undocumented and cookie-authenticated
`POST /groups/:id/leave` endpoint for leaving a group with the API
token-authenticated and documented (in the API route directory) method
for leaving a group.

This enables leaving a group to work when cookie authentication is
unavailable.

Part of https://github.com/hypothesis/product-backlog/issues/157.