### PR TITLE
Always use OAuth if cookie storage is blocked

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -109,10 +109,24 @@ function processAppOpts() {
   }
 }
 
+function canSetCookies() {
+  // Try to add a short-lived cookie. Note the `document.cookie` setter has
+  // unusual semantics, this doesn't overwrite other cookies.
+  document.cookie = 'cookie-setter-test=1;max-age=5';
+  return document.cookie.indexOf('cookie-setter-test=1') !== -1;
+}
+
 function shouldUseOAuth() {
   if (serviceConfig(settings)) {
+    // If the host page supplies annotation service configuration, including a
+    // grant token, use OAuth.
     return true;
   }
+  if (!canSetCookies()) {
+    // If cookie storage is blocked by the browser, we have to use OAuth.
+    return true;
+  }
+  // Otherwise, use OAuth only if the feature flag is enabled.
   return settings.oauthClientId && settings.oauthEnabled;
 }
 


### PR DESCRIPTION
If third party cookies are blocked then OAuth is the only option for
authentication. Third party cookies may be blocked either by
privacy-enhancing extensions or browser settings, for example:

In Safari:
 1. Go to Settings -> Privacy
 2. Set "Cookies and website data" to "Allow from current website only"

In Chrome:
 1. Go to chrome://settings/content/cookies
 2. Enable "Block third-party cookies"
 3. Check that the h service domain is not listed under "Allow", which
    is something that the Hypothesis extensions do automatically.

Once OAuth has been shipped for all users, this code can be deleted.

----

To test this:

1. Configure an OAuth client for the Hypothesis client at http://localhost:5000/admin/oauthclients/ . Set the redirect URL to `http://localhost:5000` and enable the "Trusted" flag. Use the default setting for other values.
2. Restart the h dev server with an OAuth client ID configured by setting the `CLIENT_OAUTH_ID` env var to the ID of the OAuth client created in step 1
3. Go to http://example.org (or any other non-localhost page) and load the dev bookmarklet (you can get a copy from the http://localhost:5000 homepage). Try to login, observe that the login form appears inline in the sidebar.
4. Configure your browser to block third-party cookies using the steps above
5. Repeat step 3 and observe that when logging in, the login appears in a popup window.