### PR TITLE
Fix OAuth popup being blocked by pop-up blocker in Firefox and IE

### DIFF
--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -337,6 +337,27 @@ function auth($http, $rootScope, $window,
     var left   = $window.screen.width / 2 - width / 2;
     var top    = $window.screen.height /2 - height / 2;
 
+    var authWindowSettings = queryString.stringify({
+      left: left,
+      top: top,
+      width: width,
+      height: height,
+    }).replace(/&/g, ',');
+
+    // Open the auth window before fetching the `oauth.authorize` URL to ensure
+    // that the `window.open` call happens in the same turn of the event loop
+    // that was initiated by the user clicking the "Log in" link.
+    //
+    // Otherwise the `window.open` call is not deemed to be in response to a
+    // user gesture in Firefox & IE 11 and their popup blocking heuristics will
+    // prevent the window being opened. See
+    // https://github.com/hypothesis/client/issues/534 and
+    // https://github.com/hypothesis/client/issues/535.
+    //
+    // Chrome, Safari & Edge have different heuristics and are not affected by
+    // this problem.
+    var authWindow = $window.open('about:blank', 'Login to Hypothesis', authWindowSettings);
+
     return apiRoutes.links().then(links => {
       var authUrl = links['oauth.authorize'];
       authUrl += '?' + queryString.stringify({
@@ -346,13 +367,7 @@ function auth($http, $rootScope, $window,
         response_type: 'code',
         state: state,
       });
-      var authWindowSettings = queryString.stringify({
-        left: left,
-        top: top,
-        width: width,
-        height: height,
-      }).replace(/&/g, ',');
-      $window.open(authUrl, 'Login to Hypothesis', authWindowSettings);
+      authWindow.location = authUrl;
 
       return authResponse;
     }).then((resp) => {

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -337,6 +337,8 @@ function auth($http, $rootScope, $window,
     var left   = $window.screen.width / 2 - width / 2;
     var top    = $window.screen.height /2 - height / 2;
 
+    // Generate settings for `window.open` in the required comma-separated
+    // key=value format.
     var authWindowSettings = queryString.stringify({
       left: left,
       top: top,


### PR DESCRIPTION
When the user clicked the "Log in" link, the URL of the
"oauth.authorize" endpoint was fetched via an async Promise-returning
method before the `window.open` call was made. This meant that the
`window.open` call did not happen in the turn of the event loop that was
triggered by the user action and so Firefox & IE's popup blockers deemed
the call to have happened outside the context of a user gesture and
prevented the window being opened.

Chrome, Safari & Edge have different heuristics and did not block the
popup before.

Fix the issue by opening the window directly when the user clicks on the
"Log in" button, at a dummy URL ("about:blank"), and then changing the
window's location once the authorization endpoint URL has been fetched.

Fixes #534

**Testing note:** OAuth login does not yet work in IE for other reasons which will be fixed separately, so for the moment, just test following the steps in #534.