### PR TITLE
Use vendor-prefixed `msCrypto` property for IE 11

### DIFF
--- a/src/sidebar/util/random.js
+++ b/src/sidebar/util/random.js
@@ -14,6 +14,7 @@ function byteToHex(val) {
  * @return {string}
  */
 function generateHexString(len) {
+  var crypto = window.crypto || window.msCrypto /* IE 11 */;
   var bytes = new Uint8Array(len / 2);
   crypto.getRandomValues(bytes);
   return Array.from(bytes).map(byteToHex).join('');


### PR DESCRIPTION
Together with [1] this fixes the OAuth popup failing to appear when
clicking "Log in" in IE 11.

The OAuth login flow still doesn't actually work in IE 11 with these two PRs because of issues with cross-domain `window.postMessage`. However, it does fix part of the problem.

[1] https://github.com/hypothesis/client/pull/537