### PR TITLE
Render the display name if set

### DIFF
--- a/src/sidebar/components/annotation-header.js
+++ b/src/sidebar/components/annotation-header.js
@@ -12,8 +12,12 @@ function AnnotationHeaderController(groups, settings, serviceUrl) {
     return self.annotation.user;
   };
 
-  this.username = function () {
-    return persona.username(self.annotation.user);
+  this.displayName = () => {
+    var userInfo = this.annotation.user_info;
+    if (userInfo && userInfo.display_name) {
+      return userInfo.display_name;
+    }
+    return persona.username(this.annotation.user);
   };
 
   this.isThirdPartyUser = function () {

--- a/src/sidebar/components/test/annotation-header-test.js
+++ b/src/sidebar/components/test/annotation-header-test.js
@@ -11,7 +11,7 @@ var fakeDocumentMeta = {
   titleText: 'Dummy title',
 };
 
-describe('annotationHeader', function () {
+describe('sidebar.components.annotation-header', function () {
   var $componentController;
   var fakeGroups;
   var fakeSettings;
@@ -70,6 +70,27 @@ describe('annotationHeader', function () {
           annotation: ann,
         });
         assert.deepEqual(ctrl.documentMeta(), fakeDocumentMeta);
+      });
+    });
+
+    describe('#displayName', () => {
+      it('returns the username if no display name is set', () => {
+        var ann = fixtures.defaultAnnotation();
+        var ctrl = $componentController('annotationHeader', {}, {
+          annotation: ann,
+        });
+        assert.deepEqual(ctrl.displayName(), 'bill');
+      });
+
+      it('returns the display name if set', () => {
+        var ann = fixtures.defaultAnnotation();
+        ann.user_info = {
+          display_name: 'Bill Jones',
+        };
+        var ctrl = $componentController('annotationHeader', {}, {
+          annotation: ann,
+        });
+        assert.deepEqual(ctrl.displayName(), 'Bill Jones');
       });
     });
   });

--- a/src/sidebar/templates/annotation-header.html
+++ b/src/sidebar/templates/annotation-header.html
@@ -5,10 +5,10 @@
       target="_blank"
       ng-if="!vm.isThirdPartyUser()"
       ng-href="{{vm.serviceUrl('user',{user:vm.user()})}}"
-      >{{vm.username()}}</a>
+      >{{vm.displayName()}}</a>
     <span class="annotation-header__user"
       ng-if="vm.isThirdPartyUser()"
-      >{{vm.username()}}</span>
+      >{{vm.displayName()}}</span>
     <span class="annotation-collapsed-replies">
       <a class="annotation-link" href=""
         ng-click="vm.onReplyCountClick()"


### PR DESCRIPTION
~~**h service PR: https://github.com/hypothesis/h/pull/4645**~~

If the display name is provided by the server in the annotation's
`user_info` field, render it instead of the username in annotation card
headers.