### PR TITLE
Use profile display name in account menu

### DIFF
--- a/src/sidebar/components/test/login-control-test.js
+++ b/src/sidebar/components/test/login-control-test.js
@@ -43,7 +43,11 @@ function loggedOutPage() {
 
 function firstPartyUserPage() {
   return pageObject(createLoginControl({
-    auth: {username: 'someUsername', status: 'logged-in'},
+    auth: {
+      displayName: 'Jim Smith',
+      username: 'someUsername',
+      status: 'logged-in',
+    },
     newStyle: true,
   }));
 }
@@ -127,6 +131,11 @@ describe('loginControl', function () {
     context('when a first-party user is logged in', function () {
       it('shows the enabled user profile button', function () {
         assert.isTrue(isUserProfileButtonEnabled(firstPartyUserPage()));
+      });
+
+      it('displays the display name', () => {
+        var profileBtn = firstPartyUserPage().userProfileButton;
+        assert.equal(profileBtn.textContent, 'Jim Smith');
       });
 
       it('does not send any events', function() {

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -161,7 +161,7 @@ function session($http, $q, $resource, $rootScope, analytics, annotationUI, auth
 
       $rootScope.$broadcast(events.USER_CHANGED, {
         initialLoad: isInitialLoad,
-        userid: model.userid,
+        profile: model,
       });
 
       // associate error reports with the current user in Sentry

--- a/src/sidebar/templates/login-control.html
+++ b/src/sidebar/templates/login-control.html
@@ -22,12 +22,12 @@
     <li class="dropdown-menu__row" ng-if="vm.auth.status === 'logged-in'">
       <span ng-if="!vm.shouldEnableProfileButton()"
             class="dropdown-menu__link dropdown-menu__link--disabled js-user-profile-btn is-disabled">
-        {{vm.auth.username}}</span>
+        {{vm.auth.displayName}}</span>
       <a ng-if="vm.shouldEnableProfileButton()"
          ng-click="vm.showProfile()"
          class="dropdown-menu__link js-user-profile-btn is-enabled"
          title="View all your annotations"
-         target="_blank">{{vm.auth.username}}</a>
+         target="_blank">{{vm.auth.displayName}}</a>
     </li>
     <li class="dropdown-menu__row" ng-if="vm.auth.status === 'logged-in' && !vm.isThirdPartyUser()">
       <a class="dropdown-menu__link js-account-settings-btn" href="{{vm.serviceUrl('account.settings')}}" target="_blank">Account settings</a>


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/h/pull/4651**

If the user (or the publisher who created the user account) sets a display name for their profile, show that in the account menu instead of the username.

We might decide in future that we want to show the username as well, if different from the display name. However this change will make the account menu show the expected content in eLife's context.