### PR TITLE
Fix timestamp tooltips in annotation cards

### DIFF
--- a/src/sidebar/components/timestamp.js
+++ b/src/sidebar/components/timestamp.js
@@ -50,7 +50,7 @@ module.exports = {
     href: '<',
     timestamp: '<',
   },
-  template: ['<a class="{{vm.className}}" target="_blank" ng-title="vm.absoluteTimestamp"',
-             ' href="{{vm.href}}"',
-             '>{{vm.relativeTimestamp}}</a>'].join(''),
+  template: `<a class="{{ vm.className }}" target="_blank"
+                title="{{ vm.absoluteTimestamp }}"
+                href="{{ vm.href }}">{{ vm.relativeTimestamp }}</a>`,
 };


### PR DESCRIPTION
Timestamps on annotation cards are supposed to display the full date and
time in the tooltip. This didn't work because `ng-title` is not a thing.

CC @judell 