### PR TITLE
Adjust the preferred initial size of the OAuth popup window.

### DIFF
--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -326,8 +326,15 @@ function auth($http, $rootScope, $window,
     });
 
     // Authorize user and retrieve grant token
-    var width  = 400;
-    var height = 400;
+
+    // In Chrome & Firefox the sizes passed to `window.open` are used for the
+    // viewport size. In Safari the size is used for the window size including
+    // title bar etc. There is enough vertical space at the bottom to allow for
+    // this.
+    //
+    // See https://bugs.webkit.org/show_bug.cgi?id=143678
+    var width  = 475;
+    var height = 430;
     var left   = $window.screen.width / 2 - width / 2;
     var top    = $window.screen.height /2 - height / 2;
 

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -535,7 +535,7 @@ describe('sidebar.oauth-auth', function () {
           fakeWindow.open,
           'about:blank',
           'Login to Hypothesis',
-          'height=400,left=312,top=184,width=400'
+          'height=430,left=274.5,top=169,width=475'
         );
         var authPopup = fakeWindow.open.returnValues[0];
         assert.equal(authPopup.location.href, expectedAuthUrl);


### PR DESCRIPTION
Add more vertical and horizontal space per the designs for what the
popup view should ideally look like [1], if the screen size is large
enough and the user agent permits it.

As noted in the code, I added a little extra vertical space to work around an issue with Safari. I didn't bother to try and add that space _only_ in Safari because the design works fine with a small amount of extra vertical space in other browsers.

[1] https://github.com/hypothesis/product-backlog/issues/348