### PR TITLE
Stop exporting the main annotation layer object as `window.annotator`

### DIFF
--- a/src/annotator/main.js
+++ b/src/annotator/main.js
@@ -61,10 +61,9 @@ $.noConflict(true)(function() {
 
   config.pluginClasses = pluginClasses;
 
-  window.annotator = new Klass(document.body, config);
+  var annotator = new Klass(document.body, config);
   appLinkEl.addEventListener('destroy', function () {
     appLinkEl.parentElement.removeChild(appLinkEl);
-    window.annotator.destroy();
-    window.annotator = undefined;
+    annotator.destroy();
   });
 });


### PR DESCRIPTION
The main application object in the code which runs in the host page was
made visible to other code on the page as `window.annotator`.

This export existed for legacy reasons (the client's Annotator.js
heritage), is not part of the public API of the client and we do not
make any effort to avoid breaking changes to it between releases.
Removing this export should prevent third parties writing code which
depends on its interface.

This issue came up because I saw that a development version of epub.js was trying to use it: https://annotating.slack.com/archives/C5CE202DT/p1505987618000151