### PR TITLE
Send search URIs to other frames by postMessage()

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -4,6 +4,7 @@ var addAnalytics = require('./ga');
 var disableOpenerForExternalLinks = require('./util/disable-opener-for-external-links');
 var getApiUrl = require('./get-api-url');
 var serviceConfig = require('./service-config');
+var crossOriginRPC = require('./cross-origin-rpc.js');
 require('../shared/polyfills');
 
 var raven;
@@ -248,7 +249,8 @@ module.exports = angular.module('h', [
   .config(configureRoutes)
   .config(configureToastr)
 
-  .run(setupHttp);
+  .run(setupHttp)
+  .run(crossOriginRPC.server.start);
 
 processAppOpts();
 

--- a/src/sidebar/cross-origin-rpc.js
+++ b/src/sidebar/cross-origin-rpc.js
@@ -1,0 +1,70 @@
+'use strict';
+
+/**
+ * Begin responding to JSON-RPC requests from frames on other origins.
+ *
+ * Register a window.postMessage() event listener that receives and responds to
+ * JSON-RPC requests sent by frames on other origins using postMessage() as the
+ * transport layer.
+ *
+ * Only frames whose origin is in the rpcAllowedOrigins config setting will be
+ * responded to.
+ *
+ * This is a very partial implementation of a JSON-RPC 2.0 server:
+ *
+ * http://www.jsonrpc.org/specification
+ *
+ * The only part that we support so far is receiving JSON-RPC 2.0 requests (not
+ * notifications) without any parameters and sending back a successful
+ * response. Notifications (JSON-RPC calls that don't require a response),
+ * method parameters, and error responses are not yet supported.
+ *
+ */
+// @ngInject
+function start(annotationUI, settings, $window) {
+  $window.addEventListener('message', function receiveMessage(event) {
+    let allowedOrigins = settings.rpcAllowedOrigins || [];
+
+    if (!allowedOrigins.includes(event.origin)) {
+      return;
+    }
+
+    // The entire JSON-RPC request object is contained in the postMessage()
+    // data param.
+    let jsonRpcRequest = event.data;
+
+    event.source.postMessage(jsonRpcResponse(jsonRpcRequest), event.origin);
+  });
+
+  /** Return a JSON-RPC response to the given JSON-RPC request object. */
+  function jsonRpcResponse(request) {
+    // The set of methods that clients can call.
+    let methods = {
+      'searchUris': annotationUI.searchUris,
+    };
+
+    let method = methods[request.method];
+
+    let response = {
+      'jsonrpc': '2.0',
+      'id': request.id,
+    };
+
+    if (method) {
+      response.result = method();
+    } else {
+      response.error = {
+        'code': -32601,
+        'message': 'Method not found',
+      };
+    }
+
+    return response;
+  }
+}
+
+module.exports = {
+  server: {
+    start: start,
+  },
+};

--- a/src/sidebar/test/cross-origin-rpc-test.js
+++ b/src/sidebar/test/cross-origin-rpc-test.js
@@ -1,0 +1,139 @@
+'use strict';
+
+var crossOriginRPC = require('../cross-origin-rpc');
+
+describe('crossOriginRPC', function() {
+  describe('server', function() {
+    let addedListener;  // The postMessage() listener that the server adds.
+    let fakeAnnotationUI;
+    let fakeWindow;
+    let settings;
+    let source;
+
+    beforeEach(function() {
+      fakeAnnotationUI = {
+        searchUris: sinon.stub().returns('THE_SEARCH_URIS'),
+      };
+
+      fakeWindow = {
+        addEventListener: sinon.stub().callsFake(function(type, listener) {
+          // Save the registered listener function in a variable so test code
+          // can access it later.
+          addedListener = listener;
+        }),
+      };
+
+      settings = {
+        rpcAllowedOrigins: ['https://allowed1.com', 'https://allowed2.com'],
+      };
+
+      source = { postMessage: sinon.stub() };
+    });
+
+    /**
+     * Directly call the postMessage() listener func that the server
+     * registered. This simulates what would happen if window.postMessage()
+     * were called.
+     */
+    function postMessage(event) {
+      addedListener(event);
+    }
+
+    it('adds a postMessage() event listener function', function() {
+      crossOriginRPC.server.start(fakeAnnotationUI, {}, fakeWindow);
+
+      assert.isTrue(fakeWindow.addEventListener.calledOnce);
+      assert.isTrue(fakeWindow.addEventListener.calledWith('message'));
+    });
+
+    it('sends a response with the result from the called method', function() {
+      crossOriginRPC.server.start(fakeAnnotationUI, settings, fakeWindow);
+
+      postMessage({
+        data: { method: 'searchUris', id: 42 },
+        origin: 'https://allowed1.com',
+        source: source,
+      });
+
+      assert.isTrue(source.postMessage.calledOnce);
+      assert.isTrue(source.postMessage.calledWithExactly(
+        {
+          jsonrpc: '2.0',
+          id: 42,
+          result: 'THE_SEARCH_URIS',
+        },
+        'https://allowed1.com'
+      ));
+    });
+
+    [
+      {},
+      { rpcAllowedOrigins: [] },
+      { rpcAllowedOrigins: ['https://allowed1.com', 'https://allowed2.com'] },
+    ].forEach(function(settings) {
+      it("doesn't respond if the origin isn't allowed", function() {
+        crossOriginRPC.server.start(fakeAnnotationUI, settings, fakeWindow);
+
+        postMessage({
+          origin: 'https://notallowed.com',
+          data: { method: 'searchUris', id: 42 },
+          source: source,
+        });
+
+        assert.isTrue(source.postMessage.notCalled);
+      });
+    });
+
+    it("responds with an error if there's no method", function() {
+      crossOriginRPC.server.start(fakeAnnotationUI, settings, fakeWindow);
+      let jsonRpcRequest = { id: 42 };  // No "method" member.
+
+      postMessage({
+        origin: 'https://allowed1.com',
+        data: jsonRpcRequest,
+        source: source,
+      });
+
+      assert.isTrue(source.postMessage.calledOnce);
+      assert.isTrue(source.postMessage.calledWithExactly(
+        {
+          jsonrpc: '2.0',
+          id: 42,
+          error: {
+            code: -32601,
+            message: 'Method not found',
+          },
+        },
+        'https://allowed1.com'
+      ));
+    });
+
+    [
+      'unknownMethod',
+      null,
+    ].forEach(function(method) {
+      it('responds with an error if the method is unknown', function() {
+        crossOriginRPC.server.start(fakeAnnotationUI, settings, fakeWindow);
+
+        postMessage({
+          origin: 'https://allowed1.com',
+          data: { method: method, id: 42 },
+          source: source,
+        });
+
+        assert.isTrue(source.postMessage.calledOnce);
+        assert.isTrue(source.postMessage.calledWithExactly(
+          {
+            jsonrpc: '2.0',
+            id: 42,
+            error: {
+              code: -32601,
+              message: 'Method not found',
+            },
+          },
+          'https://allowed1.com'
+        ));
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add a cross-origin RPC (remote procedure call) server that allows frames on other origins (e.g. the LTI app running at lti.hypothes.is) to call methods in the Hypothesis sidebar and receive the result. The only method that can be called so far is `searchUris()`, which our LTI app will call in order to get the URIs of the document that the client is annotating when the student clicks the submit assignment button in the LTI app. (A corresponding PR for the LTI app is coming soon.)

Add `cross-origin-rpc.js`, a partial implementation of a [JSON-RPC 2.0 server](http://www.jsonrpc.org/specification). The server only supports receiving JSON-RPC requests and sending back responses, it does not support notifications (JSON-RPC messages that don't require a response), does not support error responses (except "method not found"), and does not support method parameters. All of these features could be added without breaking backwards compatibility when we need them.

[`window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) is used as the transport layer over which to send the JSON-RPC messages. `postMessage()` is the DOM's way of allowing frames on different origins to communicate with each other.

Only frames whose origin is listed in the `rpcAllowedOrigins` config setting will be responded to. The plan is that only `lti.hypothes.is` will be listed in this config setting, so any other frames that try to send RPC messages to the client will be ignored. There will be a corresponding pull request to h coming, to add this config setting to h (h will then pass the config setting into the client).

## See also

* [h PR to enable this client feature](https://github.com/hypothesis/h/pull/4670)
* [LTI app PR to make it use this client feature](https://github.com/hypothesis/lti/pull/112)

## How to test this

1. Run a local dev instance of Canvas
1. Checkout out [this h PR](https://github.com/hypothesis/h/pull/4670) and run an h dev env on that branch.
1. Make sure that in your h dev env the `CLIENT_RPC_ALLOWED_ORIGINS` env var is set to the origin of your dev LTI app: `export CLIENT_RPC_ALLOWED_ORIGINS="http://localhost:8001"`
1. Checkout this client branch and run a client dev env on this branch.
1. Run a via dev env (yes you need this)
1. Checkout [this WIP LTI PR](https://github.com/hypothesis/lti/pull/112) and run an lti dev env on that branch.
1. Make sure that the `VIA_URL` and `CLIENT_ORIGIN` env vars are set in your LTI dev env: `export VIA_URL="http://localhost:9080"; export CLIENT_ORIGIN="http://localhost:5000"`.
1. Login to Canvas as a teacher, create a course, invite a student to the course, upload a PDF file to the course, create a Hypothesis assignment for the PDF file
1. Login to Canvas as the student, do the PDF assignment and submit some annotations
1. Login to Canvas as the teacher again, open the PDF assignment in the Speed Grader, check that you can see the student's annotations in the grader
1. Also check the h API search that the grader did, check that it searched using the PDF fingerprint