### PR TITLE
Make re-fetching of annotations when the logged-in user ID changes work with OAuth

### DIFF
--- a/src/sidebar/annotation-ui.js
+++ b/src/sidebar/annotation-ui.js
@@ -121,6 +121,9 @@ module.exports = function ($rootScope, settings) {
     searchUris: framesReducer.searchUris,
 
     isSidebar: viewerReducer.isSidebar,
+
+    isFeatureEnabled: sessionReducer.isFeatureEnabled,
+    profile: sessionReducer.profile,
   }, store.getState);
 
   return Object.assign(store, actionCreators, selectors);

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -74,10 +74,6 @@ function HypothesisAppController(
   $scope.$on(events.USER_CHANGED, function (event, data) {
     self.auth = authStateFromProfile(data.profile);
     self.accountDialog.visible = false;
-
-    if (!data || !data.initialLoad) {
-      $route.reload();
-    }
   });
 
   session.load().then(function (profile) {

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -231,23 +231,27 @@ function SidebarContentController(
     annotationUI.selectTab(tabs.tabForAnnotation(selectedAnnot, separateOrphans));
   });
 
-  $scope.$on(events.GROUP_FOCUSED, function () {
-    // The focused group may be changed during loading annotations as a result
-    // of switching to the group containing a direct-linked annotation.
-    //
-    // In that case, we don't want to trigger reloading annotations again.
-    if (isLoading()) {
-      return;
-    }
-    annotationUI.clearSelectedAnnotations();
-    loadAnnotations();
-  });
-
-  // Re-fetch annotations when logged-in user or connected frames change.
+  // Re-fetch annotations when focused group, logged-in user or connected frames
+  // change.
   $scope.$watch(() => ([
+    groups.focused().id,
     annotationUI.profile().userid,
     ...annotationUI.searchUris(),
-  ]), loadAnnotations, true);
+  ]), ([currentGroupId], [prevGroupId]) => {
+
+    if (currentGroupId !== prevGroupId) {
+      // The focused group may be changed during loading annotations as a result
+      // of switching to the group containing a direct-linked annotation.
+      //
+      // In that case, we don't want to trigger reloading annotations again.
+      if (isLoading()) {
+        return;
+      }
+      annotationUI.clearSelectedAnnotations();
+    }
+
+    loadAnnotations();
+  }, true);
 
   this.setCollapsed = function (id, collapsed) {
     annotationUI.setCollapsed(id, collapsed);

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -243,12 +243,11 @@ function SidebarContentController(
     loadAnnotations();
   });
 
-  // Watch anything that may require us to reload annotations.
-  $scope.$watch(function () {
-    return annotationUI.frames().map(function(frame) {
-      return frame.uri;
-    });
-  }, loadAnnotations, true);
+  // Re-fetch annotations when logged-in user or connected frames change.
+  $scope.$watch(() => ([
+    annotationUI.profile().userid,
+    ...annotationUI.searchUris(),
+  ]), loadAnnotations, true);
 
   this.setCollapsed = function (id, collapsed) {
     annotationUI.setCollapsed(id, collapsed);

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -251,7 +251,6 @@ describe('sidebar.components.hypothesis-app', function () {
     var ctrl = createController();
     return fakeSession.load().then(function () {
       $scope.$broadcast(events.USER_CHANGED, {
-        initialLoad: false,
         profile: {
           userid: 'acct:john@hypothes.is',
         },
@@ -279,26 +278,6 @@ describe('sidebar.components.hypothesis-app', function () {
   it('does not show the share dialog at start', function () {
     var ctrl = createController();
     assert.isFalse(ctrl.shareDialog.visible);
-  });
-
-  it('does not reload the view when the logged-in user changes on first load', function () {
-    var profile = { userid: 'acct:jim@hypothes.is' };
-    createController();
-    fakeRoute.reload = sinon.spy();
-
-    $scope.$broadcast(events.USER_CHANGED, { initialLoad: true, profile });
-
-    assert.notCalled(fakeRoute.reload);
-  });
-
-  it('reloads the view when the logged-in user changes after first load', function () {
-    var profile = { userid: 'acct:jim@hypothes.is' };
-    createController();
-    fakeRoute.reload = sinon.spy();
-
-    $scope.$broadcast(events.USER_CHANGED, { initialLoad: false, profile });
-
-    assert.calledOnce(fakeRoute.reload);
   });
 
   context('when the "openLoginForm" setting is enabled', () => {

--- a/src/sidebar/reducers/session.js
+++ b/src/sidebar/reducers/session.js
@@ -60,14 +60,24 @@ function isFeatureEnabled(state, feature) {
   return !!state.session.features[feature];
 }
 
+/**
+ * Return the user's profile.
+ *
+ * Returns the current user's profile fetched from the `/api/profile` endpoint.
+ */
+function profile(state) {
+  return state.session;
+}
+
 module.exports = {
-  init: init,
-  update: update,
+  init,
+  update,
 
   actions: {
-    updateSession: updateSession,
+    updateSession,
   },
 
   // Selectors
-  isFeatureEnabled: isFeatureEnabled,
+  isFeatureEnabled,
+  profile,
 };

--- a/src/sidebar/reducers/test/session-test.js
+++ b/src/sidebar/reducers/test/session-test.js
@@ -8,12 +8,20 @@ var init = session.init;
 var actions = session.actions;
 var update = util.createReducer(session.update);
 
-describe('session reducer', function () {
+describe('sidebar.reducers.session', function () {
   describe('#updateSession', function () {
     it('updates the session state', function () {
       var newSession = Object.assign(init(), {userid: 'john'});
       var state = update(init(), actions.updateSession(newSession));
       assert.deepEqual(state.session, newSession);
+    });
+  });
+
+  describe('#profile', () => {
+    it("returns the user's profile", () => {
+      var newSession = Object.assign(init(), {userid: 'john'});
+      var state = update(init(), actions.updateSession(newSession));
+      assert.equal(session.profile(state), newSession);
     });
   });
 });

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -132,9 +132,6 @@ function session($http, $q, $resource, $rootScope, analytics, annotationUI, auth
    */
   function update(model) {
     var prevSession = annotationUI.getState().session;
-
-    var isInitialLoad = !prevSession.csrf;
-
     var userChanged = model.userid !== prevSession.userid;
     var groupsChanged = !angular.equals(model.groups, prevSession.groups);
 
@@ -160,7 +157,6 @@ function session($http, $q, $resource, $rootScope, analytics, annotationUI, auth
       }
 
       $rootScope.$broadcast(events.USER_CHANGED, {
-        initialLoad: isInitialLoad,
         profile: model,
       });
 
@@ -175,9 +171,7 @@ function session($http, $q, $resource, $rootScope, analytics, annotationUI, auth
     }
 
     if (groupsChanged) {
-      $rootScope.$broadcast(events.GROUPS_CHANGED, {
-        initialLoad: isInitialLoad,
-      });
+      $rootScope.$broadcast(events.GROUPS_CHANGED);
     }
 
     // Return the model


### PR DESCRIPTION
This fixes an issue where annotations were not re-fetched when switching user with OAuth. As a result, private annotations did not appear or disappear as expected when logging in / out if using OAuth.

----

Refetching of annotations when the logged-in user ID changes was
previously triggered by a complete reload of the `<sidebar-content>`
component via a `$route.reload()` call. This happened in response to a
`USER_CHANGED` event except for the first time that the profile was
fetched.

When using OAuth this broke because the test for whether this was the
first profile fetch or not was based on a change from null => non null
CSRF token (see `isInitialLoad` initialization). When using OAuth
however, there is no CSRF token.

This commit reworks refetching of annotations to remove the route
reloading and instead trigger it in the same way that it is triggered
when frames connect or disconnect, by calling
`SidebarContentController#loadAnnotations` when the logged-in userid
changes.