### PR TITLE
Coalesce anchoring status updates

### DIFF
--- a/src/sidebar/annotation-ui.js
+++ b/src/sidebar/annotation-ui.js
@@ -114,6 +114,7 @@ module.exports = function ($rootScope, settings) {
     hasSelectedAnnotations: selectionReducer.hasSelectedAnnotations,
 
     annotationExists: annotationsReducer.annotationExists,
+    findAnnotationByID: annotationsReducer.findAnnotationByID,
     findIDsForTags: annotationsReducer.findIDsForTags,
     savedAnnotations: annotationsReducer.savedAnnotations,
 

--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -130,7 +130,7 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
     bridge.on('sync', function (events_) {
       events_.forEach(function (event) {
         inFrame.add(event.tag);
-        annotationUI.updateAnchorStatus(null, event.tag, event.msg.$orphan);
+        annotationUI.updateAnchorStatus(event.tag, event.msg.$orphan);
         $rootScope.$broadcast(events.ANNOTATIONS_SYNCED, [event.tag]);
       });
     });

--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var debounce = require('lodash.debounce');
+
 var events = require('./events');
 var bridgeEvents = require('../shared/bridge-events');
 var metadata = require('./annotation-metadata');
@@ -126,12 +128,24 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
 
     bridge.on('destroyFrame', destroyFrame.bind(this));
 
+    // Map of annotation tag to anchoring status
+    // ('anchored'|'orphan'|'timeout').
+    //
+    // Updates are coalesced to reduce the overhead from processing
+    // triggered by each `UPDATE_ANCHOR_STATUS` action that is dispatched.
+    var anchoringStatusUpdates = {};
+    var scheduleAnchoringStatusUpdate = debounce(() => {
+      annotationUI.updateAnchorStatus(anchoringStatusUpdates);
+      $rootScope.$broadcast(events.ANNOTATIONS_SYNCED, Object.keys(anchoringStatusUpdates));
+      anchoringStatusUpdates = {};
+    }, 10);
+
     // Anchoring an annotation in the frame completed
     bridge.on('sync', function (events_) {
       events_.forEach(function (event) {
         inFrame.add(event.tag);
-        annotationUI.updateAnchorStatus(event.tag, event.msg.$orphan);
-        $rootScope.$broadcast(events.ANNOTATIONS_SYNCED, [event.tag]);
+        anchoringStatusUpdates[event.tag] = event.msg.$orphan ? 'orphan' : 'anchored';
+        scheduleAnchoringStatusUpdate();
       });
     });
 

--- a/src/sidebar/reducers/annotations.js
+++ b/src/sidebar/reducers/annotations.js
@@ -173,13 +173,10 @@ var update = {
 
   UPDATE_ANCHOR_STATUS: function (state, action) {
     var annotations = state.annotations.map(function (annot) {
-      var match = (annot.id && annot.id === action.id) ||
-                  (annot.$tag && annot.$tag === action.tag);
-      if (match) {
+      if (annot.$tag === action.tag) {
         return Object.assign({}, annot, {
           $anchorTimeout: action.anchorTimeout || annot.$anchorTimeout,
           $orphan: action.isOrphan,
-          $tag: action.tag,
         });
       } else {
         return annot;
@@ -274,7 +271,6 @@ function addAnnotations(annotations, now) {
             dispatch({
               type: actions.UPDATE_ANCHOR_STATUS,
               anchorTimeout: true,
-              id: orphan.id,
               tag: orphan.$tag,
             });
           });
@@ -297,19 +293,16 @@ function clearAnnotations() {
 }
 
 /**
- * Updating the local tag and anchoring status of an annotation.
+ * Update the anchoring status of an annotation.
  *
- * @param {string|null} id - Annotation ID
- * @param {string} tag - The local tag assigned to this annotation to link
- *        the object in the page and the annotation in the sidebar
+ * @param {string} tag - The annotation's local tag
  * @param {boolean} isOrphan - True if the annotation failed to anchor
  */
-function updateAnchorStatus(id, tag, isOrphan) {
+function updateAnchorStatus(tag, isOrphan) {
   return {
     type: actions.UPDATE_ANCHOR_STATUS,
-    id: id,
-    tag: tag,
-    isOrphan: isOrphan,
+    tag,
+    isOrphan,
   };
 }
 

--- a/src/sidebar/test/annotation-ui-test.js
+++ b/src/sidebar/test/annotation-ui-test.js
@@ -26,6 +26,14 @@ describe('annotationUI', function () {
   var annotationUI;
   var fakeRootScope;
 
+  function tagForID(id) {
+    var storeAnn = annotationUI.findAnnotationByID(id);
+    if (!storeAnn) {
+      throw new Error(`No annotation with ID ${id}`);
+    }
+    return storeAnn.$tag;
+  }
+
   beforeEach(function () {
     fakeRootScope = {$applyAsync: sinon.stub()};
     annotationUI = annotationUIFactory(fakeRootScope, {});
@@ -137,7 +145,7 @@ describe('annotationUI', function () {
     it('preserves anchoring status of updated annotations', function () {
       var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot]);
-      annotationUI.updateAnchorStatus(annot.id, null, false /* not an orphan */);
+      annotationUI.updateAnchorStatus(tagForID(annot.id), false /* not an orphan */);
 
       var update = Object.assign({}, defaultAnnotation(), {text: 'update'});
       annotationUI.addAnnotations([update]);
@@ -158,7 +166,7 @@ describe('annotationUI', function () {
     it('does not set the timeout flag on annotations that do anchor within a time limit', function () {
       var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot]);
-      annotationUI.updateAnchorStatus(annot.id, 'atag', false);
+      annotationUI.updateAnchorStatus(tagForID(annot.id), false);
 
       clock.tick(ANCHOR_TIME_LIMIT);
 
@@ -168,7 +176,7 @@ describe('annotationUI', function () {
     it('does not attempt to modify orphan status if annotations are removed before anchoring timeout expires', function () {
       var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot]);
-      annotationUI.updateAnchorStatus(annot.id, 'atag', false);
+      annotationUI.updateAnchorStatus(tagForID(annot.id), false);
       annotationUI.removeAnnotations([annot]);
 
       assert.doesNotThrow(function () {
@@ -483,27 +491,11 @@ describe('annotationUI', function () {
   });
 
   describe('#updatingAnchorStatus', function () {
-    it("updates the annotation's tag", function () {
-      var annot = defaultAnnotation();
-      annotationUI.addAnnotations([annot]);
-      annotationUI.updateAnchorStatus(annot.id, 'atag', true);
-      assert.equal(annotationUI.getState().annotations[0].$tag, 'atag');
-    });
-
     it("updates the annotation's orphan flag", function () {
       var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot]);
-      annotationUI.updateAnchorStatus(annot.id, 'atag', true);
+      annotationUI.updateAnchorStatus(tagForID(annot.id), true);
       assert.equal(annotationUI.getState().annotations[0].$orphan, true);
-    });
-
-    it('updates annotations by tag', function () {
-      annotationUI.addAnnotations(fixtures.newPair);
-      annotationUI.updateAnchorStatus(null, 't2', true);
-
-      var annots = annotationUI.getState().annotations;
-      assert.isFalse(annots[0].$orphan);
-      assert.isTrue(annots[1].$orphan);
     });
   });
 

--- a/src/sidebar/test/annotation-ui-test.js
+++ b/src/sidebar/test/annotation-ui-test.js
@@ -145,7 +145,7 @@ describe('annotationUI', function () {
     it('preserves anchoring status of updated annotations', function () {
       var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot]);
-      annotationUI.updateAnchorStatus(tagForID(annot.id), false /* not an orphan */);
+      annotationUI.updateAnchorStatus({ [tagForID(annot.id)]: 'anchored' });
 
       var update = Object.assign({}, defaultAnnotation(), {text: 'update'});
       annotationUI.addAnnotations([update]);
@@ -166,7 +166,7 @@ describe('annotationUI', function () {
     it('does not set the timeout flag on annotations that do anchor within a time limit', function () {
       var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot]);
-      annotationUI.updateAnchorStatus(tagForID(annot.id), false);
+      annotationUI.updateAnchorStatus({ [tagForID(annot.id)]: 'anchored' });
 
       clock.tick(ANCHOR_TIME_LIMIT);
 
@@ -176,7 +176,7 @@ describe('annotationUI', function () {
     it('does not attempt to modify orphan status if annotations are removed before anchoring timeout expires', function () {
       var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot]);
-      annotationUI.updateAnchorStatus(tagForID(annot.id), false);
+      annotationUI.updateAnchorStatus({ [tagForID(annot.id)]: 'anchored' });
       annotationUI.removeAnnotations([annot]);
 
       assert.doesNotThrow(function () {
@@ -494,7 +494,7 @@ describe('annotationUI', function () {
     it("updates the annotation's orphan flag", function () {
       var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot]);
-      annotationUI.updateAnchorStatus(tagForID(annot.id), true);
+      annotationUI.updateAnchorStatus({ [tagForID(annot.id)]: 'orphan' });
       assert.equal(annotationUI.getState().annotations[0].$orphan, true);
     });
   });

--- a/src/sidebar/test/frame-sync-test.js
+++ b/src/sidebar/test/frame-sync-test.js
@@ -50,7 +50,7 @@ var fixtures = {
   },
 };
 
-describe('FrameSync', function () {
+describe('sidebar.frame-sync', function () {
   var fakeAnnotationUI;
   var fakeBridge;
   var frameSync;
@@ -189,9 +189,40 @@ describe('FrameSync', function () {
   });
 
   context('when anchoring completes', function () {
+    var clock = sinon.stub();
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    function expireDebounceTimeout() {
+      // "Wait" for debouncing timeout to expire and pending anchoring status
+      // updates to be applied.
+      clock.tick(20);
+    }
+
     it('updates the anchoring status for the annotation', function () {
       fakeBridge.emit('sync', [{tag: 't1', msg: {$orphan: false}}]);
-      assert.calledWith(fakeAnnotationUI.updateAnchorStatus, 't1', false);
+
+      expireDebounceTimeout();
+
+      assert.calledWith(fakeAnnotationUI.updateAnchorStatus, { t1: 'anchored' });
+    });
+
+    it('coalesces multiple "sync" messages', () => {
+      fakeBridge.emit('sync', [{tag: 't1', msg: {$orphan: false}}]);
+      fakeBridge.emit('sync', [{tag: 't2', msg: {$orphan: true}}]);
+
+      expireDebounceTimeout();
+
+      assert.calledWith(fakeAnnotationUI.updateAnchorStatus, {
+        t1: 'anchored',
+        t2: 'orphan',
+      });
     });
 
     it('emits an ANNOTATIONS_SYNCED event', function () {
@@ -199,6 +230,7 @@ describe('FrameSync', function () {
       $rootScope.$on(events.ANNOTATIONS_SYNCED, onSync);
 
       fakeBridge.emit('sync', [{tag: 't1', msg: {$orphan: false}}]);
+      expireDebounceTimeout();
 
       assert.calledWithMatch(onSync, sinon.match.any, sinon.match(['t1']));
     });

--- a/src/sidebar/test/frame-sync-test.js
+++ b/src/sidebar/test/frame-sync-test.js
@@ -191,7 +191,7 @@ describe('FrameSync', function () {
   context('when anchoring completes', function () {
     it('updates the anchoring status for the annotation', function () {
       fakeBridge.emit('sync', [{tag: 't1', msg: {$orphan: false}}]);
-      assert.calledWith(fakeAnnotationUI.updateAnchorStatus, null, 't1', false);
+      assert.calledWith(fakeAnnotationUI.updateAnchorStatus, 't1', false);
     });
 
     it('emits an ANNOTATIONS_SYNCED event', function () {


### PR DESCRIPTION
Profiling the test case in #556 showed significant overhead from the
processing involved in or triggered by each `UPDATE_ANCHOR_STATUS`
action handled by the store. Previously one `UPDATE_ANCHOR_STATUS`
action was dispatched for each annotation whose anchoring status
changed.

Improve the situation by making the `UPDATE_ANCHOR_STATUS` action handle
updates for multiple annotations at once and modifying the `frameSync`
service to coalesce anchoring status updates from the host page into
a smaller number of `UPDATE_ANCHOR_STATUS` actions.

This commit also takes the opportunity to remove the logic to update
annotation tags when handling this action since it is no longer
required.

With this change the test case in #556 is not perfectly smooth, but it is significantly better and good enough to be usable on many systems.

Fixes #556