### PR TITLE
Fix issue that could lead to user being logged into normal Hypothesis account on websites using third-party accounts

### DIFF
--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -264,9 +264,18 @@ function auth($http, $rootScope, $window,
       }
 
       if (Date.now() > token.expiresAt) {
+        var shouldPersist = true;
+
+        // If we are using automatic login via a grant token, do not persist the
+        // initial access token or refreshed tokens.
+        var cfg = serviceConfig(settings);
+        if (cfg && typeof cfg.grantToken !== 'undefined') {
+          shouldPersist = false;
+        }
+
         // Token expired. Attempt to refresh.
         tokenInfoPromise = refreshAccessToken(token.refreshToken, {
-          persist: true,
+          persist: shouldPersist,
         }).catch(() => {
           // If refreshing the token fails, the user is simply logged out.
           return null;


### PR DESCRIPTION
This fixes an issue where the client could end up using OAuth tokens for a regular Hypothesis account from a previous session when visiting a website which configures the client to use third-party accounts. This happened if the user was anonymous on the third-party website and so the "grantToken" property in the service configuration was `null`.

Fixes #571