### PR TITLE
Remove orphans tab feature flag checks

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -447,14 +447,7 @@ function AnnotationController(
     return serviceUrl('search.tag', {tag: tag});
   };
 
-  // Note: We fetch the feature flag outside the `isOrphan` method to avoid a
-  // lookup on every $digest cycle
-  var indicateOrphans = features.flagEnabled('orphans_tab');
-
   this.isOrphan = function() {
-    if (!indicateOrphans) {
-      return false;
-    }
     if (typeof self.annotation.$orphan === 'undefined') {
       return self.annotation.$anchorTimeout;
     }

--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -19,10 +19,6 @@ module.exports = {
       annotationUI.selectTab(type);
     };
 
-    this.orphansTabFlagEnabled = function () {
-      return features.flagEnabled('orphans_tab');
-    };
-
     this.showAnnotationsUnavailableMessage = function () {
       return this.selectedTab === this.TAB_ANNOTATIONS &&
         this.totalAnnotations === 0 &&

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -48,7 +48,7 @@ function SidebarContentController(
     self.rootThread = thread();
     self.selectedTab = state.selectedTab;
 
-    var counts = tabs.counts(state.annotations, true /* separate orphans */);
+    var counts = tabs.counts(state.annotations);
 
     Object.assign(self, {
       totalNotes: counts.notes,
@@ -226,7 +226,7 @@ function SidebarContentController(
     focusAnnotation(selectedAnnot);
     scrollToAnnotation(selectedAnnot);
 
-    annotationUI.selectTab(tabs.tabForAnnotation(selectedAnnot, true /* separate orphans */));
+    annotationUI.selectTab(tabs.tabForAnnotation(selectedAnnot));
   });
 
   // Re-fetch annotations when focused group, logged-in user or connected frames

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -48,8 +48,7 @@ function SidebarContentController(
     self.rootThread = thread();
     self.selectedTab = state.selectedTab;
 
-    var separateOrphans = tabs.shouldSeparateOrphans(state);
-    var counts = tabs.counts(state.annotations, separateOrphans);
+    var counts = tabs.counts(state.annotations, true /* separate orphans */);
 
     Object.assign(self, {
       totalNotes: counts.notes,
@@ -227,8 +226,7 @@ function SidebarContentController(
     focusAnnotation(selectedAnnot);
     scrollToAnnotation(selectedAnnot);
 
-    var separateOrphans = tabs.shouldSeparateOrphans(annotationUI.getState());
-    annotationUI.selectTab(tabs.tabForAnnotation(selectedAnnot, separateOrphans));
+    annotationUI.selectTab(tabs.tabForAnnotation(selectedAnnot, true /* separate orphans */));
   });
 
   // Re-fetch annotations when focused group, logged-in user or connected frames

--- a/src/sidebar/root-thread.js
+++ b/src/sidebar/root-thread.js
@@ -66,8 +66,7 @@ function RootThread($rootScope, annotationUI, drafts, searchFilter, viewFilter) 
           return false;
         }
 
-        return tabs.shouldShowInTab(thread.annotation, state.selectedTab,
-          true /* separate orphans */);
+        return tabs.shouldShowInTab(thread.annotation, state.selectedTab);
       };
     }
 

--- a/src/sidebar/root-thread.js
+++ b/src/sidebar/root-thread.js
@@ -66,9 +66,8 @@ function RootThread($rootScope, annotationUI, drafts, searchFilter, viewFilter) 
           return false;
         }
 
-        var separateOrphans = tabs.shouldSeparateOrphans(state);
         return tabs.shouldShowInTab(thread.annotation, state.selectedTab,
-          separateOrphans);
+          true /* separate orphans */);
       };
     }
 

--- a/src/sidebar/tabs.js
+++ b/src/sidebar/tabs.js
@@ -11,11 +11,9 @@ var uiConstants = require('./ui-constants');
  * Return the tab in which an annotation should be displayed.
  *
  * @param {Annotation} ann
- * @param {boolean} separateOrphans - True if orphans should be displayed in a
- *        separate tab.
  */
-function tabForAnnotation(ann, separateOrphans) {
-  if (metadata.isOrphan(ann) && separateOrphans) {
+function tabForAnnotation(ann) {
+  if (metadata.isOrphan(ann)) {
     return uiConstants.TAB_ORPHANS;
   } else if (metadata.isPageNote(ann)) {
     return uiConstants.TAB_NOTES;
@@ -29,26 +27,22 @@ function tabForAnnotation(ann, separateOrphans) {
  *
  * @param {Annotation} ann
  * @param {number} tab - The TAB_* value indicating the tab
- * @param {boolean} separateOrphans - True if orphans should be separated into
- *        their own tab.
  */
-function shouldShowInTab(ann, tab, separateOrphans) {
-  if (metadata.isWaitingToAnchor(ann) && separateOrphans) {
+function shouldShowInTab(ann, tab) {
+  if (metadata.isWaitingToAnchor(ann)) {
     // Until this annotation anchors or fails to anchor, we do not know which
     // tab it should be displayed in.
     return false;
   }
-  return tabForAnnotation(ann, separateOrphans) === tab;
+  return tabForAnnotation(ann) === tab;
 }
 
 /**
  * Return the counts for the headings of different tabs.
  *
  * @param {Annotation[]} annotations - List of annotations to display
- * @param {boolean} separateOrphans - True if orphans should be displayed in a
- *        separate tab.
  */
-function counts(annotations, separateOrphans) {
+function counts(annotations) {
   var counts = {
     notes: countIf(annotations, metadata.isPageNote),
     annotations: countIf(annotations, metadata.isAnnotation),
@@ -56,14 +50,7 @@ function counts(annotations, separateOrphans) {
     anchoring: countIf(annotations, metadata.isWaitingToAnchor),
   };
 
-  if (separateOrphans) {
-    return counts;
-  } else {
-    return Object.assign({}, counts, {
-      annotations: counts.annotations + counts.orphans,
-      orphans: 0,
-    });
-  }
+  return counts;
 }
 
 module.exports = {

--- a/src/sidebar/tabs.js
+++ b/src/sidebar/tabs.js
@@ -5,17 +5,7 @@
 
 var countIf = require('./util/array-util').countIf;
 var metadata = require('./annotation-metadata');
-var session = require('./reducers/session');
 var uiConstants = require('./ui-constants');
-
-/**
- * Return true if Annotations and Orphans should be displayed in separate tabs.
- *
- * @param {object} state - The current application state.
- */
-function shouldSeparateOrphans(state) {
-  return session.isFeatureEnabled(state, 'orphans_tab');
-}
 
 /**
  * Return the tab in which an annotation should be displayed.
@@ -78,7 +68,6 @@ function counts(annotations, separateOrphans) {
 
 module.exports = {
   counts: counts,
-  shouldSeparateOrphans: shouldSeparateOrphans,
   shouldShowInTab: shouldShowInTab,
   tabForAnnotation: tabForAnnotation,
 };

--- a/src/sidebar/templates/selection-tabs.html
+++ b/src/sidebar/templates/selection-tabs.html
@@ -22,7 +22,7 @@
     </span>
   </a>
   <a class="selection-tabs__type selection-tabs__type--orphan"
-    ng-if="vm.orphansTabFlagEnabled() && vm.totalOrphans > 0"
+    ng-if="vm.totalOrphans > 0"
     href="#"
     ng-class="{'is-selected': vm.selectedTab === vm.TAB_ORPHANS}"
     h-on-touch="vm.selectTab(vm.TAB_ORPHANS)">

--- a/src/sidebar/test/root-thread-test.js
+++ b/src/sidebar/test/root-thread-test.js
@@ -46,7 +46,7 @@ describe('rootThread', function () {
         isSidebar: true,
         selectedAnnotationMap: null,
         session: {
-          features: {'orphans_tab': true},
+          features: {},
         },
         sortKey: 'Location',
         sortKeysAvailable: ['Location'],

--- a/src/sidebar/test/tabs-test.js
+++ b/src/sidebar/test/tabs-test.js
@@ -6,26 +6,6 @@ var tabs = require('../tabs');
 var unroll = require('../../shared/test/util').unroll;
 
 describe('tabs', function () {
-  describe('shouldSeparateOrphans', function () {
-    it('returns true if the "orphans_tab" flag is enabled', function () {
-      var state = {
-        session: {
-          features: {'orphans_tab': true},
-        },
-      };
-      assert.isTrue(tabs.shouldSeparateOrphans(state));
-    });
-
-    it('returns false if the "orphans_tab" flag is not enabled', function () {
-      var state = {
-        session: {
-          features: {'orphans_tab': false},
-        },
-      };
-      assert.isFalse(tabs.shouldSeparateOrphans(state));
-    });
-  });
-
   describe('tabForAnnotation', function () {
     unroll('shows annotation in correct tab', function (testCase) {
       var ann = testCase.ann;

--- a/src/sidebar/test/tabs-test.js
+++ b/src/sidebar/test/tabs-test.js
@@ -10,7 +10,7 @@ describe('tabs', function () {
     unroll('shows annotation in correct tab', function (testCase) {
       var ann = testCase.ann;
       var expectedTab = testCase.expectedTab;
-      assert.equal(tabs.tabForAnnotation(ann, true /* separateOrphans */), expectedTab);
+      assert.equal(tabs.tabForAnnotation(ann), expectedTab);
     }, [{
       ann: fixtures.defaultAnnotation(),
       expectedTab: uiConstants.TAB_ANNOTATIONS,
@@ -29,58 +29,33 @@ describe('tabs', function () {
       ann.$anchorTimeout = testCase.anchorTimeout;
       ann.$orphan = testCase.orphan;
 
-      assert.equal(tabs.shouldShowInTab(ann, uiConstants.TAB_ANNOTATIONS,
-        testCase.separateOrphans), testCase.expectedTab === uiConstants.TAB_ANNOTATIONS);
-      assert.equal(tabs.shouldShowInTab(ann, uiConstants.TAB_ORPHANS,
-        testCase.separateOrphans), testCase.expectedTab === uiConstants.TAB_ORPHANS);
+      assert.equal(tabs.shouldShowInTab(ann, uiConstants.TAB_ANNOTATIONS), testCase.expectedTab === uiConstants.TAB_ANNOTATIONS);
+      assert.equal(tabs.shouldShowInTab(ann, uiConstants.TAB_ORPHANS), testCase.expectedTab === uiConstants.TAB_ORPHANS);
     }, [{
-      // Orphans tab disabled, anchoring in progress.
+      // Anchoring in progress.
       anchorTimeout: false,
       orphan: undefined,
-      separateOrphans: false,
-      expectedTab: uiConstants.TAB_ANNOTATIONS,
-    },{
-      // Orphans tab disabled, anchoring succeeded.
-      anchorTimeout: false,
-      orphan: false,
-      separateOrphans: false,
-      expectedTab: uiConstants.TAB_ANNOTATIONS,
-    },{
-      // Orphans tab disabled, anchoring failed
-      anchorTimeout: false,
-      orphan: true,
-      separateOrphans: false,
-      expectedTab: uiConstants.TAB_ANNOTATIONS,
-    },{
-      // Orphans tab enabled, anchoring in progress.
-      anchorTimeout: false,
-      orphan: undefined,
-      separateOrphans: true,
       expectedTab: null,
     },{
-      // Orphans tab enabled, anchoring succeeded.
+      // Anchoring succeeded.
       anchorTimeout: false,
       orphan: false,
-      separateOrphans: true,
       expectedTab: uiConstants.TAB_ANNOTATIONS,
     },{
-      // Orphans tab enabled, anchoring failed.
+      // Anchoring failed.
       anchorTimeout: false,
       orphan: true,
-      separateOrphans: true,
       expectedTab: uiConstants.TAB_ORPHANS,
     },{
-      // Orphans tab enabled, anchoring timed out.
+      // Anchoring timed out.
       anchorTimeout: true,
       orphan: undefined,
-      separateOrphans: true,
       expectedTab: uiConstants.TAB_ANNOTATIONS,
     },{
-      // Orphans tab enabled, anchoring initially timed out but eventually
+      // Anchoring initially timed out but eventually
       // failed.
       anchorTimeout: true,
       orphan: true,
-      separateOrphans: true,
       expectedTab: uiConstants.TAB_ORPHANS,
     }]);
   });
@@ -89,16 +64,7 @@ describe('tabs', function () {
     var annotation = Object.assign(fixtures.defaultAnnotation(), {$orphan:false});
     var orphan = Object.assign(fixtures.defaultAnnotation(), {$orphan:true});
 
-    it('counts Annotations and Orphans together when the Orphans tab is not enabled', function () {
-      assert.deepEqual(tabs.counts([annotation, orphan], false), {
-        anchoring: 0,
-        annotations: 2,
-        notes: 0,
-        orphans: 0,
-      });
-    });
-
-    it('counts Annotations and Orphans separately when the Orphans tab is enabled', function () {
+    it('counts Annotations and Orphans separately', function () {
       assert.deepEqual(tabs.counts([annotation, orphan], true), {
         anchoring: 0,
         annotations: 1,


### PR DESCRIPTION
This PR removes a set of obsolete code paths for supporting the case where the "Orphans" tab was disabled. After this is merged, we can remove the "orphans_tab" feature flag from the service.

There is no time pressure on this one, but I've had it sitting around for a while locally and we should always be getting rid of code that no longer serves a purpose.