### PR TITLE
Extract OAuth client into a separate module

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -196,6 +196,7 @@ module.exports = angular.module('h', [
 
   .value('Discovery', require('../shared/discovery'))
   .value('ExcerptOverflowMonitor', require('./util/excerpt-overflow-monitor'))
+  .value('OAuthClient', require('./util/oauth-client'))
   .value('VirtualThreadList', require('./virtual-thread-list'))
   .value('random', require('./util/random'))
   .value('raven', require('./raven'))

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -230,6 +230,13 @@ function auth($http, $rootScope, $window, OAuthClient,
         // Token expired. Attempt to refresh.
         tokenInfoPromise = refreshAccessToken(token.refreshToken, {
           persist: shouldPersist,
+        }).then(token => {
+          // Sanity check that prevents an infinite loop. Mostly useful in
+          // tests.
+          if (Date.now() > token.expiresAt) {
+            throw new Error('Refreshed token expired in the past');
+          }
+          return token;
         }).catch(() => {
           // If refreshing the token fails, the user is simply logged out.
           return null;

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -11,10 +11,17 @@ var serviceConfig = require('./service-config');
  */
 
 /**
- * OAuth-based authorization service.
+ * Authorization service.
  *
- * A grant token embedded on the page by the publisher is exchanged for
- * an opaque access token.
+ * This service is responsible for acquiring access tokens for making API
+ * requests and making them available via the `tokenGetter()` method.
+ *
+ * Access tokens are acquired via the OAuth authorization flow, loading valid
+ * tokens from a previous session or, on some websites, by exchanging a grant
+ * token provided by the host page.
+ *
+ * Interaction with OAuth endpoints in the annotation service is delegated to
+ * the `OAuthClient` class.
  */
 // @ngInject
 function auth($http, $rootScope, $window, OAuthClient,

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var queryString = require('query-string');
-
 var events = require('./events');
 var resolve = require('./util/url-util').resolve;
 var serviceConfig = require('./service-config');
@@ -28,8 +26,8 @@ var serviceConfig = require('./service-config');
  * an opaque access token.
  */
 // @ngInject
-function auth($http, $rootScope, $window,
-              apiRoutes, flash, localStorage, random, settings) {
+function auth($http, $rootScope, $window, OAuthClient,
+              apiRoutes, flash, localStorage, settings) {
 
   /**
    * Authorization code from auth popup window.
@@ -45,6 +43,9 @@ function auth($http, $rootScope, $window,
    * @type {Promise<TokenInfo|null>}
    */
   var tokenInfoPromise;
+
+  /** @type {OAuthClient} */
+  var client;
 
   /**
    * Absolute URL of the `/api/token` endpoint.
@@ -64,34 +65,6 @@ function auth($http, $rootScope, $window,
         timeOut: 0,
       }
     );
-  }
-
-  /**
-   * Return a new TokenInfo object from the given tokenUrl endpoint response.
-   * @param {Object} response - The HTTP response from a POST to the tokenUrl
-   *                            endpoint (an Angular $http response object).
-   * @returns {TokenInfo}
-   */
-  function tokenInfoFrom(response) {
-    var data = response.data;
-    return {
-      accessToken:  data.access_token,
-
-      // Set the expiry date to some time slightly before that implied by
-      // `expires_in` to account for the delay in the client receiving the
-      // response.
-      expiresAt: Date.now() + ((data.expires_in - 10) * 1000),
-
-      refreshToken: data.refresh_token,
-    };
-  }
-
-  function formPost(url, data) {
-    data = queryString.stringify(data);
-    var requestConfig = {
-      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-    };
-    return $http.post(url, data, requestConfig);
   }
 
   /**
@@ -139,56 +112,20 @@ function auth($http, $rootScope, $window,
     localStorage.setObject(storageKey(), token);
   }
 
-  // Exchange the JWT grant token for an access token.
-  // See https://tools.ietf.org/html/rfc7523#section-4
-  function exchangeJWT(grantToken) {
-    var data = {
-      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
-      assertion: grantToken,
-    };
-    return formPost(tokenUrl, data).then(function (response) {
-      if (response.status !== 200) {
-        throw new Error('Failed to retrieve access token');
-      }
-      return tokenInfoFrom(response);
-    });
-  }
-
-  /**
-   * Exchange an authorization code from the `/oauth/authorize` endpoint for
-   * access and refresh tokens.
-   */
-  function exchangeAuthCode(code) {
-    var data = {
-      client_id: settings.oauthClientId,
-      grant_type: 'authorization_code',
-      code,
-    };
-    return formPost(tokenUrl, data).then((response) => {
-      if (response.status !== 200) {
-        throw new Error('Authorization code exchange failed');
-      }
-      return tokenInfoFrom(response);
-    });
-  }
-
   /**
    * Exchange the refresh token for a new access token and refresh token pair.
-   * See https://tools.ietf.org/html/rfc6749#section-6
    *
    * @param {string} refreshToken
    * @param {RefreshOptions} options
    * @return {Promise<TokenInfo>} Promise for the new access token
    */
   function refreshAccessToken(refreshToken, options) {
-    var data = { grant_type: 'refresh_token', refresh_token: refreshToken };
-    return formPost(tokenUrl, data).then((response) => {
-      var tokenInfo = tokenInfoFrom(response);
-
+    return oauthClient().then(client =>
+      client.refreshToken(refreshToken)
+    ).then(tokenInfo => {
       if (options.persist) {
         saveToken(tokenInfo);
       }
-
       return tokenInfo;
     });
   }
@@ -208,6 +145,21 @@ function auth($http, $rootScope, $window,
     });
   }
 
+  function oauthClient() {
+    if (client) {
+      return Promise.resolve(client);
+    }
+    return apiRoutes.links().then(links => {
+      client = new OAuthClient($http, {
+        clientId: settings.oauthClientId,
+        authorizationEndpoint: links['oauth.authorize'],
+        revokeEndpoint: links['oauth.revoke'],
+        tokenEndpoint: tokenUrl,
+      });
+      return client;
+    });
+  }
+
   /**
    * Retrieve an access token for the API.
    *
@@ -223,9 +175,9 @@ function auth($http, $rootScope, $window,
         if (cfg.grantToken) {
           // User is logged-in on the publisher's website.
           // Exchange the grant token for a new access token.
-          tokenInfoPromise = exchangeJWT(cfg.grantToken).then((tokenInfo) => {
-            return tokenInfo;
-          }).catch(function(err) {
+          tokenInfoPromise = oauthClient().then(client =>
+            client.exchangeGrantToken(cfg.grantToken)
+          ).catch(err => {
             showAccessTokenExpiredErrorMessage(
               'You must reload the page to annotate.');
             throw err;
@@ -239,7 +191,9 @@ function auth($http, $rootScope, $window,
         // access token.
         var code = authCode;
         authCode = null; // Auth codes can only be used once.
-        tokenInfoPromise = exchangeAuthCode(code).then((tokenInfo) => {
+        tokenInfoPromise = oauthClient().then(client =>
+          client.exchangeAuthCode(code)
+        ).then(tokenInfo => {
           saveToken(tokenInfo);
           return tokenInfo;
         });
@@ -296,86 +250,12 @@ function auth($http, $rootScope, $window,
    * then exchange for access and refresh tokens.
    */
   function login() {
-    // Random state string used to check that auth messages came from the popup
-    // window that we opened.
-    var state = random.generateHexString(16);
-
-    // Promise which resolves or rejects when the user accepts or closes the
-    // auth popup.
-    var authResponse = new Promise((resolve, reject) => {
-      function authRespListener(event) {
-        if (typeof event.data !== 'object') {
-          return;
-        }
-
-        if (event.data.state !== state) {
-          // This message came from a different popup window.
-          return;
-        }
-
-        if (event.data.type === 'authorization_response') {
-          resolve(event.data);
-        }
-        if (event.data.type === 'authorization_canceled') {
-          reject(new Error('Authorization window was closed'));
-        }
-        $window.removeEventListener('message', authRespListener);
-      }
-      $window.addEventListener('message', authRespListener);
-    });
-
-    // Authorize user and retrieve grant token
-
-    // In Chrome & Firefox the sizes passed to `window.open` are used for the
-    // viewport size. In Safari the size is used for the window size including
-    // title bar etc. There is enough vertical space at the bottom to allow for
-    // this.
-    //
-    // See https://bugs.webkit.org/show_bug.cgi?id=143678
-    var width  = 475;
-    var height = 430;
-    var left   = $window.screen.width / 2 - width / 2;
-    var top    = $window.screen.height /2 - height / 2;
-
-    // Generate settings for `window.open` in the required comma-separated
-    // key=value format.
-    var authWindowSettings = queryString.stringify({
-      left: left,
-      top: top,
-      width: width,
-      height: height,
-    }).replace(/&/g, ',');
-
-    // Open the auth window before fetching the `oauth.authorize` URL to ensure
-    // that the `window.open` call happens in the same turn of the event loop
-    // that was initiated by the user clicking the "Log in" link.
-    //
-    // Otherwise the `window.open` call is not deemed to be in response to a
-    // user gesture in Firefox & IE 11 and their popup blocking heuristics will
-    // prevent the window being opened. See
-    // https://github.com/hypothesis/client/issues/534 and
-    // https://github.com/hypothesis/client/issues/535.
-    //
-    // Chrome, Safari & Edge have different heuristics and are not affected by
-    // this problem.
-    var authWindow = $window.open('about:blank', 'Login to Hypothesis', authWindowSettings);
-
-    return apiRoutes.links().then(links => {
-      var authUrl = links['oauth.authorize'];
-      authUrl += '?' + queryString.stringify({
-        client_id: settings.oauthClientId,
-        origin: $window.location.origin,
-        response_mode: 'web_message',
-        response_type: 'code',
-        state: state,
-      });
-      authWindow.location = authUrl;
-
-      return authResponse;
-    }).then((resp) => {
+    return oauthClient().then(client => {
+      return client.authorize($window);
+    }).then(code => {
       // Save the auth code. It will be exchanged for an access token when the
       // next API request is made.
-      authCode = resp.code;
+      authCode = code;
       tokenInfoPromise = null;
     });
   }
@@ -386,12 +266,9 @@ function auth($http, $rootScope, $window,
    * This revokes and then forgets any OAuth credentials that the user has.
    */
   function logout() {
-    return Promise.all([tokenInfoPromise, apiRoutes.links()])
-      .then(([token, links]) => {
-        var revokeUrl = links['oauth.revoke'];
-        return formPost(revokeUrl, {
-          token: token.accessToken,
-        });
+    return Promise.all([tokenInfoPromise, oauthClient()])
+      .then(([token, client]) => {
+        return client.revokeToken(token.accessToken);
       }).then(() => {
         tokenInfoPromise = Promise.resolve(null);
         localStorage.removeItem(storageKey());

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -11,15 +11,6 @@ var serviceConfig = require('./service-config');
  */
 
 /**
- * An object holding the details of an access token from the tokenUrl endpoint.
- * @typedef {Object} TokenInfo
- * @property {string} accessToken  - The access token itself.
- * @property {number} expiresAt    - The date when the timestamp will expire.
- * @property {string} refreshToken - The refresh token that can be used to
- *                                   get a new access token.
- */
-
-/**
  * OAuth-based authorization service.
  *
  * A grant token embedded on the page by the publisher is exchanged for

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -1,65 +1,13 @@
 'use strict';
 
 var angular = require('angular');
-var { stringify } = require('query-string');
 
 var events = require('../events');
 
+var FakeWindow = require('../util/test/fake-window');
+
 var DEFAULT_TOKEN_EXPIRES_IN_SECS = 1000;
 var TOKEN_KEY = 'hypothesis.oauth.hypothes%2Eis.token';
-
-class FakeWindow {
-  constructor() {
-    this.callbacks = [];
-
-    this.screen = {
-      width: 1024,
-      height: 768,
-    };
-
-
-    this.location = 'https://client.hypothes.is/app.html';
-    this.open = sinon.spy(href => {
-      var win = new FakeWindow;
-      win.location = href;
-      return win;
-    });
-
-    this.setTimeout = window.setTimeout.bind(window);
-    this.clearTimeout = window.clearTimeout.bind(window);
-  }
-
-  get location() {
-    return this.url;
-  }
-
-  set location(href) {
-    this.url = new URL(href);
-  }
-
-  addEventListener(event, callback) {
-    this.callbacks.push({event, callback});
-  }
-
-  removeEventListener(event, callback) {
-    this.callbacks = this.callbacks.filter((cb) =>
-      !(cb.event === event && cb.callback === callback)
-    );
-  }
-
-  trigger(event) {
-    this.callbacks.forEach((cb) => {
-      if (cb.event === event.type) {
-        cb.callback(event);
-      }
-    });
-  }
-
-  sendMessage(data) {
-    var evt = new MessageEvent('message', { data });
-    this.trigger(evt);
-  }
-}
 
 describe('sidebar.oauth-auth', function () {
 
@@ -67,10 +15,9 @@ describe('sidebar.oauth-auth', function () {
   var auth;
   var nowStub;
   var fakeApiRoutes;
-  var fakeHttp;
+  var fakeClient;
   var fakeFlash;
   var fakeLocalStorage;
-  var fakeRandom;
   var fakeWindow;
   var fakeSettings;
   var clock;
@@ -80,13 +27,13 @@ describe('sidebar.oauth-auth', function () {
    * Login and retrieve an auth code.
    */
   function login() {
-    var loggedIn = auth.login();
-    fakeWindow.sendMessage({
-      type: 'authorization_response',
-      code: 'acode',
-      state: 'notrandom',
-    });
-    return loggedIn;
+    fakeClient.authorize.returns(Promise.resolve('acode'));
+    fakeClient.exchangeAuthCode.returns(Promise.resolve({
+      accessToken: 'firstAccessToken',
+      refreshToken: 'firstRefreshToken',
+      expiresAt: Date.now() + 100,
+    }));
+    return auth.login();
   }
 
   before(() => {
@@ -102,19 +49,6 @@ describe('sidebar.oauth-auth', function () {
     nowStub = sinon.stub(window.performance, 'now');
     nowStub.returns(300);
 
-    successfulFirstAccessTokenPromise = Promise.resolve({
-      status: 200,
-      data: {
-        access_token: 'firstAccessToken',
-        expires_in: DEFAULT_TOKEN_EXPIRES_IN_SECS,
-        refresh_token: 'firstRefreshToken',
-      },
-    });
-
-    fakeHttp = {
-      post: sinon.stub().returns(successfulFirstAccessTokenPromise),
-    };
-
     fakeApiRoutes = {
       links: sinon.stub().returns(Promise.resolve({
         'oauth.authorize': 'https://hypothes.is/oauth/authorize/',
@@ -126,10 +60,6 @@ describe('sidebar.oauth-auth', function () {
       error: sinon.stub(),
     };
 
-    fakeRandom = {
-      generateHexString: sinon.stub().returns('notrandom'),
-    };
-
     fakeSettings = {
       apiUrl: 'https://hypothes.is/api/',
       oauthClientId: 'the-client-id',
@@ -139,22 +69,30 @@ describe('sidebar.oauth-auth', function () {
       }],
     };
 
-    fakeWindow = new FakeWindow();
-
     fakeLocalStorage = {
       getObject: sinon.stub().returns(null),
       setObject: sinon.stub(),
       removeItem: sinon.stub(),
     };
 
+    fakeClient = {
+      exchangeAuthCode: sinon.stub().returns(Promise.resolve(null)),
+      exchangeGrantToken: sinon.stub().returns(Promise.resolve(null)),
+      revokeToken: sinon.stub().returns(Promise.resolve(null)),
+      refreshToken: sinon.stub().returns(Promise.resolve(null)),
+      authorize: sinon.stub().returns(Promise.resolve(null)),
+    };
+
+    fakeWindow = new FakeWindow;
+
     angular.mock.module('app', {
-      $http: fakeHttp,
+      $http: {},
       $window: fakeWindow,
       apiRoutes: fakeApiRoutes,
       flash: fakeFlash,
       localStorage: fakeLocalStorage,
-      random: fakeRandom,
       settings: fakeSettings,
+      OAuthClient: () => fakeClient,
     });
 
     angular.mock.inject((_auth_, _$rootScope_) => {
@@ -169,21 +107,25 @@ describe('sidebar.oauth-auth', function () {
   });
 
   describe('#tokenGetter', function () {
+    var successfulTokenResponse = Promise.resolve({
+      accessToken: 'firstAccessToken',
+      refreshToken: 'firstRefreshToken',
+      expiresAt: 100,
+    });
+
     it('exchanges the grant token for an access token if provided', function () {
-      return auth.tokenGetter().then(function (token) {
-        var expectedBody =
-          'assertion=a.jwt.token' +
-          '&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer';
-        assert.calledWith(fakeHttp.post, 'https://hypothes.is/api/token', expectedBody, {
-          headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-        });
+      fakeClient.exchangeGrantToken.returns(successfulTokenResponse);
+
+      return auth.tokenGetter().then(token => {
+        assert.calledWith(fakeClient.exchangeGrantToken, 'a.jwt.token');
         assert.equal(token, 'firstAccessToken');
       });
     });
 
     context('when the access token request fails', function() {
+      var expectedErr = new Error('Grant token exchange failed');
       beforeEach('make access token requests fail', function () {
-        fakeHttp.post.returns(Promise.resolve({status: 500}));
+        fakeClient.exchangeGrantToken.returns(Promise.reject(expectedErr));
       });
 
       function assertThatAccessTokenPromiseWasRejectedAnd(func) {
@@ -206,19 +148,20 @@ describe('sidebar.oauth-auth', function () {
       });
 
       it('returns a rejected promise', function () {
-        return assertThatAccessTokenPromiseWasRejectedAnd(function(error) {
-          assert.equal(error.message, 'Failed to retrieve access token');
+        return assertThatAccessTokenPromiseWasRejectedAnd(err => {
+          assert.equal(err.message, expectedErr.message);
         });
       });
     });
 
     it('should cache tokens for future use', function () {
+      fakeClient.exchangeGrantToken.returns(successfulTokenResponse);
       return auth.tokenGetter().then(function () {
-        resetHttpSpy();
+        fakeClient.exchangeGrantToken.reset();
         return auth.tokenGetter();
       }).then(function (token) {
         assert.equal(token, 'firstAccessToken');
-        assert.notCalled(fakeHttp.post);
+        assert.notCalled(fakeClient.exchangeGrantToken);
       });
     });
 
@@ -228,7 +171,7 @@ describe('sidebar.oauth-auth', function () {
     // concurrent HTTP request).
     it('should not make two concurrent access token requests', function () {
       var respond;
-      fakeHttp.post.returns(new Promise(resolve => {
+      fakeClient.exchangeGrantToken.returns(new Promise(resolve => {
         respond = resolve;
       }));
 
@@ -236,60 +179,47 @@ describe('sidebar.oauth-auth', function () {
       // request and returns a Promise for the access token.
       var tokens = [auth.tokenGetter(), auth.tokenGetter()];
 
-      assert.equal(fakeHttp.post.callCount, 1);
-
       // Resolve the initial request for an access token in exchange for a JWT.
       respond({
-        status: 200,
-        data: {
-          access_token: 'foo',
-          refresh_token: 'bar',
-          expires_in: 3600,
-        },
+        accessToken: 'foo',
+        refreshToken: 'bar',
+        expiresAt: 100,
       });
-      return Promise.all(tokens);
+      return Promise.all(tokens).then(() => {
+        assert.equal(fakeClient.exchangeGrantToken.callCount, 1);
+      });
     });
 
     it('should not attempt to exchange a grant token if none was provided', function () {
       fakeSettings.services = [{ authority: 'publisher.org' }];
       return auth.tokenGetter().then(function (token) {
-        assert.notCalled(fakeHttp.post);
+        assert.notCalled(fakeClient.exchangeGrantToken);
         assert.equal(token, null);
       });
     });
 
     it('should refresh the access token if it expired', function () {
+      fakeClient.exchangeGrantToken.returns(Promise.resolve(successfulTokenResponse));
+
       function callTokenGetter () {
         var tokenPromise = auth.tokenGetter();
 
-        fakeHttp.post.returns(Promise.resolve({
-          status: 200,
-          data: {
-            access_token: 'secondAccessToken',
-            expires_in: DEFAULT_TOKEN_EXPIRES_IN_SECS,
-            refresh_token: 'secondRefreshToken',
-          },
+        fakeClient.refreshToken.returns(Promise.resolve({
+          accessToken: 'secondAccessToken',
+          expiresIn: 100,
+          refreshToken: 'secondRefreshToken',
         }));
 
         return tokenPromise;
       }
 
       function assertRefreshTokenWasUsed (refreshToken) {
-        return function() {
-          var expectedBody =
-            'grant_type=refresh_token&refresh_token=' + refreshToken;
-
-          assert.calledWith(
-            fakeHttp.post,
-            'https://hypothes.is/api/token',
-            expectedBody,
-            {headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-            });
+        return () => {
+          assert.calledWith(fakeClient.refreshToken, refreshToken);
         };
       }
 
       return callTokenGetter()
-        .then(resetHttpSpy)
         .then(expireAccessToken)
         .then(() => auth.tokenGetter())
         .then(token => assert.equal(token, 'secondAccessToken'))
@@ -301,41 +231,39 @@ describe('sidebar.oauth-auth', function () {
     it('does not send more than one refresh request', function () {
       // Perform an initial token fetch which will exchange the JWT grant for an
       // access token.
+      fakeClient.exchangeGrantToken.returns(Promise.resolve(successfulTokenResponse));
       return auth.tokenGetter()
         .then(() => {
           // Expire the access token to trigger a refresh request on the next
           // token fetch.
-          fakeHttp.post.reset();
           expireAccessToken();
 
           // Delay the response to the refresh request.
           var respond;
-          fakeHttp.post.returns(new Promise(resolve => {
-            respond = resolve;
-          }));
+          fakeClient.refreshToken.returns(new Promise(resolve => respond = resolve));
 
           // Request an auth token multiple times.
           var tokens = Promise.all([auth.tokenGetter(), auth.tokenGetter()]);
 
           // Finally, respond to the refresh request.
-          respond({ access_token: 'a_new_token', refresh_token: 'a_delayed_token', expires_in: 3600 });
+          respond({
+            accessToken: 'a_new_token',
+            refreshToken: 'a_delayed_token',
+            expiresAt: Date.now() + 1000,
+          });
 
           return tokens;
         })
         .then(() => {
           // Check that only one refresh request was made.
-          assert.equal(fakeHttp.post.callCount, 1);
+          assert.equal(fakeClient.refreshToken.callCount, 1);
         });
     });
 
     context('when a refresh request fails', function() {
       beforeEach('make refresh token requests fail', function () {
-        fakeHttp.post = function(url, queryString) {
-          if (queryString.indexOf('refresh_token') !== -1) {
-            return Promise.resolve({status: 500});
-          }
-          return Promise.resolve(successfulFirstAccessTokenPromise);
-        };
+        fakeClient.refreshToken.returns(Promise.reject(new Error('failed')));
+        fakeClient.exchangeGrantToken.returns(successfulFirstAccessTokenPromise);
       });
 
       it('logs the user out', function () {
@@ -358,14 +286,15 @@ describe('sidebar.oauth-auth', function () {
       grantToken: null,
       expectedToken: null,
     }].forEach(({ authority, grantToken, expectedToken }) => {
-      it('should not persist access tokens if a grant token was provided', () => {
+      it(`should not persist access tokens if a grant token (${grantToken}) was provided`, () => {
         fakeSettings.services = [{ authority, grantToken }];
         return auth.tokenGetter().then(() => {
           assert.notCalled(fakeLocalStorage.setObject);
         });
       });
 
-      it('should not read persisted access tokens if a grant token was set', () => {
+      it(`should not read persisted access tokens if a grant token (${grantToken}) was set`, () => {
+        fakeClient.exchangeGrantToken.returns(Promise.resolve(successfulTokenResponse));
         fakeSettings.services = [{ authority, grantToken }];
         return auth.tokenGetter().then(token => {
           assert.equal(token, expectedToken);
@@ -383,22 +312,19 @@ describe('sidebar.oauth-auth', function () {
         assert.calledWith(fakeLocalStorage.setObject, TOKEN_KEY, {
           accessToken: 'firstAccessToken',
           refreshToken: 'firstRefreshToken',
-          expiresAt: 990000,
+          expiresAt: 100,
         });
       });
     });
 
     function expireAndRefreshAccessToken() {
-      fakeLocalStorage.setObject.reset();
-      fakeHttp.post.returns(Promise.resolve({
-        status: 200,
-        data: {
-          access_token: 'secondToken',
-          expires_in: DEFAULT_TOKEN_EXPIRES_IN_SECS,
-          refresh_token: 'secondRefreshToken',
-        },
-      }));
       expireAccessToken();
+      fakeLocalStorage.setObject.reset();
+      fakeClient.refreshToken.returns(Promise.resolve({
+        accessToken: 'secondToken',
+        expiresAt: Date.now() + 1000,
+        refreshToken: 'secondRefreshToken',
+      }));
       return auth.tokenGetter();
     }
 
@@ -416,7 +342,7 @@ describe('sidebar.oauth-auth', function () {
         assert.calledWith(fakeLocalStorage.setObject, TOKEN_KEY, {
           accessToken: 'secondToken',
           refreshToken: 'secondRefreshToken',
-          expiresAt: 1990000,
+          expiresAt: Date.now() + 1000,
         });
       });
     });
@@ -455,13 +381,10 @@ describe('sidebar.oauth-auth', function () {
         refreshToken: 'bar',
         expiresAt: 123,
       });
-      fakeHttp.post.returns(Promise.resolve({
-        status: 200,
-        data: {
-          access_token: 'secondToken',
-          expires_in: DEFAULT_TOKEN_EXPIRES_IN_SECS,
-          refresh_token: 'secondRefreshToken',
-        },
+      fakeClient.refreshToken.returns(Promise.resolve({
+        accessToken: 'secondToken',
+        expiresAt: Date.now() + 100,
+        refreshToken: 'secondRefreshToken',
       }));
 
       // Fetch the token again from the service and check that it gets
@@ -474,7 +397,7 @@ describe('sidebar.oauth-auth', function () {
           {
             accessToken: 'secondToken',
             refreshToken: 'secondRefreshToken',
-            expiresAt: 990200,
+            expiresAt: Date.now() + 100,
           }
         );
       });
@@ -555,107 +478,42 @@ describe('sidebar.oauth-auth', function () {
       fakeSettings.services = [];
     });
 
-    it('opens the auth endpoint in a popup window', () => {
-      auth.login();
-
-      return fakeApiRoutes.links().then((links) => {
-        var authUrl = links['oauth.authorize'];
-        var params = {
-          client_id: fakeSettings.oauthClientId,
-          origin: 'https://client.hypothes.is',
-          response_mode: 'web_message',
-          response_type: 'code',
-          state: 'notrandom',
-        };
-        var expectedAuthUrl = `${authUrl}?${stringify(params)}`;
-
-        // Check that the auth window was opened and then set to the expected
-        // location. The final URL is not passed to `window.open` to work around
-        // a pop-up blocker issue.
-        assert.calledWith(
-          fakeWindow.open,
-          'about:blank',
-          'Login to Hypothesis',
-          'height=430,left=274.5,top=169,width=475'
-        );
-        var authPopup = fakeWindow.open.returnValues[0];
-        assert.equal(authPopup.location.href, expectedAuthUrl);
-      });
-    });
-
-    it('ignores auth responses if the state does not match', () => {
-      var loggedIn = false;
-
-      auth.login().then(() => {
-        loggedIn = true;
-      });
-
-      fakeWindow.sendMessage({
-        // Successful response with wrong state
-        type: 'authorization_response',
-        code: 'acode',
-        state: 'wrongstate',
-      });
-
-      return Promise.resolve().then(() => {
-        assert.isFalse(loggedIn);
+    it('calls OAuthClient#authorize', () => {
+      return auth.login().then(() => {
+        assert.calledWith(fakeClient.authorize, fakeWindow);
       });
     });
 
     it('resolves when auth completes successfully', () => {
-      var loggedIn = auth.login();
-
-      fakeWindow.sendMessage({
-        // Successful response
-        type: 'authorization_response',
-        code: 'acode',
-        state: 'notrandom',
-      });
+      fakeClient.authorize.returns(Promise.resolve('acode'));
 
       // 1. Verify that login completes.
-      return loggedIn.then(() => {
+      return auth.login().then(() => {
         return auth.tokenGetter();
       }).then(() => {
         // 2. Verify that auth code is exchanged for access & refresh tokens.
-        var expectedBody =
-          'client_id=the-client-id' +
-          '&code=acode' +
-          '&grant_type=authorization_code';
-        assert.calledWith(fakeHttp.post, 'https://hypothes.is/api/token', expectedBody, {
-          headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-        });
+        assert.calledWith(fakeClient.exchangeAuthCode, 'acode');
       });
     });
 
     it('rejects when auth is canceled', () => {
-      var loggedIn = auth.login();
+      var expectedErr = new Error('Authorization failed');
+      fakeClient.authorize.returns(Promise.reject(expectedErr));
 
-      fakeWindow.sendMessage({
-        // Error response
-        type: 'authorization_canceled',
-        state: 'notrandom',
-      });
-
-      return loggedIn.catch((err) => {
-        assert.equal(err.message, 'Authorization window was closed');
+      return auth.login().catch(err => {
+        assert.equal(err.message, expectedErr.message);
       });
     });
 
     it('rejects if auth code exchange fails', () => {
-      var loggedIn = auth.login();
+      var expectedErr = new Error('Auth code exchange failed');
+      fakeClient.authorize.returns(Promise.resolve('acode'));
+      fakeClient.exchangeAuthCode.returns(Promise.reject(expectedErr));
 
-      // Successful response from authz popup.
-      fakeWindow.sendMessage({
-        type: 'authorization_response',
-        code: 'acode',
-        state: 'notrandom',
-      });
-
-      // Error response from auth code => token exchange.
-      fakeHttp.post.returns(Promise.resolve({status: 400}));
-
-      return loggedIn.catch(err => {
-        assert.equal(err.message, 'Authorization code exchange failed');
+      return auth.login().then(() => {
+        return auth.tokenGetter();
+      }).catch(err => {
+        assert.equal(err.message, expectedErr.message);
       });
     });
   });
@@ -670,8 +528,6 @@ describe('sidebar.oauth-auth', function () {
         return auth.tokenGetter();
       }).then(token => {
         assert.notEqual(token, null);
-
-        fakeHttp.post.reset();
       });
     });
 
@@ -691,10 +547,7 @@ describe('sidebar.oauth-auth', function () {
 
     it('revokes tokens', () => {
       return auth.logout().then(() => {
-        var expectedBody = 'token=firstAccessToken';
-        assert.calledWith(fakeHttp.post, 'https://hypothes.is/oauth/revoke/', expectedBody, {
-          headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-        });
+        assert.calledWith(fakeClient.revokeToken, 'firstAccessToken');
       });
     });
   });
@@ -702,10 +555,5 @@ describe('sidebar.oauth-auth', function () {
   // Advance time forward so that any current access tokens will have expired.
   function expireAccessToken () {
     clock.tick(DEFAULT_TOKEN_EXPIRES_IN_SECS * 1000);
-  }
-
-  // Reset fakeHttp's spy history (.called, .callCount, etc).
-  function resetHttpSpy () {
-    fakeHttp.post.resetHistory();
   }
 });

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -1,0 +1,200 @@
+'use strict';
+
+var queryString = require('query-string');
+
+var random = require('./random');
+
+/**
+ * Return a new TokenInfo object from the given tokenUrl endpoint response.
+ * @param {Object} response - The HTTP response from a POST to the tokenUrl
+ *                            endpoint (an Angular $http response object).
+ * @returns {TokenInfo}
+ */
+function tokenInfoFrom(response) {
+  var data = response.data;
+  return {
+    accessToken:  data.access_token,
+
+    // Set the expiry date to some time slightly before that implied by
+    // `expires_in` to account for the delay in the client receiving the
+    // response.
+    expiresAt: Date.now() + ((data.expires_in - 10) * 1000),
+
+    refreshToken: data.refresh_token,
+  };
+}
+
+function generateState() {
+  return random.generateHexString(16);
+}
+
+/**
+ * OAuthClient handles interaction with the annotation service's OAuth
+ * endpoints.
+ */
+class OAuthClient {
+  constructor($http, config) {
+    this.$http = $http;
+
+    this.clientId = config.clientId;
+    this.tokenEndpoint = config.tokenEndpoint;
+    this.authorizationEndpoint = config.authorizationEndpoint;
+    this.revokeEndpoint = config.revokeEndpoint;
+
+    // Test seam
+    this.generateState = config.generateState || generateState;
+  }
+
+  /**
+   * Exchange an authorization code for access and refresh tokens.
+   */
+  exchangeAuthCode(code) {
+    var data = {
+      client_id: this.clientId,
+      grant_type: 'authorization_code',
+      code,
+    };
+    return this._formPost(this.tokenEndpoint, data).then((response) => {
+      if (response.status !== 200) {
+        throw new Error('Authorization code exchange failed');
+      }
+      return tokenInfoFrom(response);
+    });
+  }
+
+  /**
+   * Exchange a grant token for access and refresh tokens.
+   *
+   * See https://tools.ietf.org/html/rfc7523#section-4
+   */
+  exchangeGrantToken(token) {
+    var data = {
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: token,
+    };
+    return this._formPost(this.tokenEndpoint, data).then(response => {
+      if (response.status !== 200) {
+        throw new Error('Failed to retrieve access token');
+      }
+      return tokenInfoFrom(response);
+    });
+  }
+
+  /**
+   * Refresh an access and refresh token pair.
+   *
+   * See https://tools.ietf.org/html/rfc6749#section-6
+   */
+  refreshToken(refreshToken) {
+    var data = { grant_type: 'refresh_token', refresh_token: refreshToken };
+    return this._formPost(this.tokenEndpoint, data).then((response) => {
+      if (response.status !== 200) {
+        throw new Error('Failed to refresh access token');
+      }
+      return tokenInfoFrom(response);
+    });
+  }
+
+  /**
+   * Revoke an access and refresh token pair.
+   */
+  revokeToken(accessToken) {
+    return this._formPost(this.revokeEndpoint, { token: accessToken });
+  }
+
+  /**
+   * Prompt the user for permission to access their data.
+   *
+   * Returns an authorization code which can be passed to `exchangeAuthCode`.
+   */
+  authorize($window) {
+    // Random state string used to check that auth messages came from the popup
+    // window that we opened.
+    var state = this.generateState();
+
+    // Promise which resolves or rejects when the user accepts or closes the
+    // auth popup.
+    var authResponse = new Promise((resolve, reject) => {
+      function authRespListener(event) {
+        if (typeof event.data !== 'object') {
+          return;
+        }
+
+        if (event.data.state !== state) {
+          // This message came from a different popup window.
+          return;
+        }
+
+        if (event.data.type === 'authorization_response') {
+          resolve(event.data);
+        }
+        if (event.data.type === 'authorization_canceled') {
+          reject(new Error('Authorization window was closed'));
+        }
+        $window.removeEventListener('message', authRespListener);
+      }
+      $window.addEventListener('message', authRespListener);
+    });
+
+    // Authorize user and retrieve grant token
+
+    // In Chrome & Firefox the sizes passed to `window.open` are used for the
+    // viewport size. In Safari the size is used for the window size including
+    // title bar etc. There is enough vertical space at the bottom to allow for
+    // this.
+    //
+    // See https://bugs.webkit.org/show_bug.cgi?id=143678
+    var width  = 475;
+    var height = 430;
+    var left   = $window.screen.width / 2 - width / 2;
+    var top    = $window.screen.height /2 - height / 2;
+
+    // Generate settings for `window.open` in the required comma-separated
+    // key=value format.
+    var authWindowSettings = queryString.stringify({
+      left: left,
+      top: top,
+      width: width,
+      height: height,
+    }).replace(/&/g, ',');
+
+    // Open the auth window before fetching the `oauth.authorize` URL to ensure
+    // that the `window.open` call happens in the same turn of the event loop
+    // that was initiated by the user clicking the "Log in" link.
+    //
+    // Otherwise the `window.open` call is not deemed to be in response to a
+    // user gesture in Firefox & IE 11 and their popup blocking heuristics will
+    // prevent the window being opened. See
+    // https://github.com/hypothesis/client/issues/534 and
+    // https://github.com/hypothesis/client/issues/535.
+    //
+    // Chrome, Safari & Edge have different heuristics and are not affected by
+    // this problem.
+    var authWindow = $window.open('about:blank', 'Login to Hypothesis', authWindowSettings);
+
+    var authUrl = this.authorizationEndpoint;
+    authUrl += '?' + queryString.stringify({
+      client_id: this.clientId,
+      origin: $window.location.origin,
+      response_mode: 'web_message',
+      response_type: 'code',
+      state: state,
+    });
+    authWindow.location = authUrl;
+
+    return authResponse.then(rsp => rsp.code);
+  }
+
+  /**
+   * Make an `application/x-www-form-urlencoded` POST request.
+   */
+  _formPost(url, data) {
+    data = queryString.stringify(data);
+    var requestConfig = {
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    };
+    return this.$http.post(url, data, requestConfig);
+  }
+}
+
+module.exports = OAuthClient;

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -5,6 +5,15 @@ var queryString = require('query-string');
 var random = require('./random');
 
 /**
+ * An object holding the details of an access token from the tokenUrl endpoint.
+ * @typedef {Object} TokenInfo
+ * @property {string} accessToken  - The access token itself.
+ * @property {number} expiresAt    - The date when the timestamp will expire.
+ * @property {string} refreshToken - The refresh token that can be used to
+ *                                   get a new access token.
+ */
+
+/**
  * Return a new TokenInfo object from the given tokenUrl endpoint response.
  * @param {Object} response - The HTTP response from a POST to the tokenUrl
  *                            endpoint (an Angular $http response object).

--- a/src/sidebar/util/test/fake-window.js
+++ b/src/sidebar/util/test/fake-window.js
@@ -1,0 +1,56 @@
+'use strict';
+
+class FakeWindow {
+  constructor() {
+    this.callbacks = [];
+
+    this.screen = {
+      width: 1024,
+      height: 768,
+    };
+
+
+    this.location = 'https://client.hypothes.is/app.html';
+    this.open = sinon.spy(href => {
+      var win = new FakeWindow;
+      win.location = href;
+      return win;
+    });
+
+    this.setTimeout = window.setTimeout.bind(window);
+    this.clearTimeout = window.clearTimeout.bind(window);
+  }
+
+  get location() {
+    return this.url;
+  }
+
+  set location(href) {
+    this.url = new URL(href);
+  }
+
+  addEventListener(event, callback) {
+    this.callbacks.push({event, callback});
+  }
+
+  removeEventListener(event, callback) {
+    this.callbacks = this.callbacks.filter((cb) =>
+      !(cb.event === event && cb.callback === callback)
+    );
+  }
+
+  trigger(event) {
+    this.callbacks.forEach((cb) => {
+      if (cb.event === event.type) {
+        cb.callback(event);
+      }
+    });
+  }
+
+  sendMessage(data) {
+    var evt = new MessageEvent('message', { data });
+    this.trigger(evt);
+  }
+}
+
+module.exports = FakeWindow;

--- a/src/sidebar/util/test/oauth-client-test.js
+++ b/src/sidebar/util/test/oauth-client-test.js
@@ -1,0 +1,251 @@
+'use strict';
+
+var { stringify } = require('query-string');
+var sinon = require('sinon');
+
+var OAuthClient = require('../oauth-client');
+var FakeWindow = require('./fake-window');
+
+var fixtures = {
+  tokenResponse: {
+    status: 200,
+    data: {
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expires_in: 360,
+    },
+  },
+
+  parsedToken: {
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+
+    // This assumes the `tokenResponse` above was received when
+    // `Date.now() === 0`.
+    expiresAt: 350000,
+  },
+
+  formPostParams: {
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+  },
+};
+
+describe('sidebar.util.oauth-client', () => {
+  var fakeHttp;
+  var client;
+  var clock;
+  var config = {
+    clientId: '1234-5678',
+    authorizationEndpoint: 'https://annota.te/oauth/authorize',
+    tokenEndpoint: 'https://annota.te/api/token',
+    revokeEndpoint: 'https://annota.te/oauth/revoke',
+    generateState: () => 'notrandom',
+  };
+
+  beforeEach(() => {
+    fakeHttp = {
+      post: sinon.stub().returns(Promise.resolve({status: 200})),
+    };
+    clock = sinon.useFakeTimers();
+
+    client = new OAuthClient(fakeHttp, config);
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  describe('#exchangeAuthCode', () => {
+    it('makes a POST request to the authorization endpoint', () => {
+      fakeHttp.post.returns(Promise.resolve(fixtures.tokenResponse));
+      return client.exchangeAuthCode('letmein').then(() => {
+        var expectedBody = 'client_id=1234-5678&code=letmein&grant_type=authorization_code';
+        assert.calledWith(fakeHttp.post, 'https://annota.te/api/token', expectedBody, fixtures.formPostParams);
+      });
+    });
+
+    it('resolves with the parsed token data', () => {
+      fakeHttp.post.returns(Promise.resolve(fixtures.tokenResponse));
+      return client.exchangeAuthCode('letmein').then(token => {
+        assert.deepEqual(token, fixtures.parsedToken);
+      });
+    });
+
+    it('rejects if the request fails', () => {
+      fakeHttp.post.returns(Promise.resolve({status: 400}));
+      return client.exchangeAuthCode('unknowncode').catch(err => {
+        assert.equal(err.message, 'Authorization code exchange failed');
+      });
+    });
+  });
+
+  describe('#exchangeGrantToken', () => {
+    it('makes a POST request to the token endpoint', () => {
+      fakeHttp.post.returns(Promise.resolve(fixtures.tokenResponse));
+      return client.exchangeGrantToken('letmein').then(() => {
+        var expectedBody =
+          'assertion=letmein' +
+          '&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer';
+        assert.calledWith(fakeHttp.post, 'https://annota.te/api/token', expectedBody, fixtures.formPostParams);
+      });
+    });
+
+    it('resolves with the parsed token data', () => {
+      fakeHttp.post.returns(Promise.resolve(fixtures.tokenResponse));
+
+      return client.exchangeGrantToken('letmein').then(token => {
+        assert.deepEqual(token, fixtures.parsedToken);
+      });
+    });
+
+    it('rejects if the request fails', () => {
+      fakeHttp.post.returns(Promise.resolve({status: 400}));
+      return client.exchangeGrantToken('unknowntoken').catch(err => {
+        assert.equal(err.message, 'Failed to retrieve access token');
+      });
+    });
+  });
+
+  describe('#refreshToken', () => {
+    it('makes a POST request to the token endpoint', () => {
+      fakeHttp.post.returns(Promise.resolve(fixtures.tokenResponse));
+
+      return client.refreshToken('valid-refresh-token').then(() => {
+        var expectedBody =
+          'grant_type=refresh_token&refresh_token=valid-refresh-token';
+
+        assert.calledWith(
+          fakeHttp.post,
+          'https://annota.te/api/token',
+          expectedBody,
+          fixtures.formPostParams
+        );
+      });
+    });
+
+    it('resolves with the parsed token data', () => {
+      fakeHttp.post.returns(Promise.resolve(fixtures.tokenResponse));
+
+      return client.refreshToken('valid-refresh-token').then(token => {
+        assert.deepEqual(token, fixtures.parsedToken);
+      });
+    });
+
+    it('rejects if the request fails', () => {
+      fakeHttp.post.returns(Promise.resolve({status: 400}));
+      return client.refreshToken('invalid-token').catch(err => {
+        assert.equal(err.message, 'Failed to refresh access token');
+      });
+    });
+  });
+
+  describe('#revokeToken', () => {
+    it('makes a POST request to the revoke endpoint', () => {
+      fakeHttp.post.returns(Promise.resolve(fixtures.tokenResponse));
+
+      return client.revokeToken('valid-access-token').then(() => {
+        var expectedBody = 'token=valid-access-token';
+        assert.calledWith(fakeHttp.post, 'https://annota.te/oauth/revoke', expectedBody, fixtures.formPostParams);
+      });
+    });
+
+    it('resolves if the request succeeds', () => {
+      fakeHttp.post.returns(Promise.resolve({status: 200}));
+      return client.revokeToken('valid-access-token');
+    });
+
+    it('rejects if the request fails', () => {
+      fakeHttp.post.returns(Promise.resolve({status: 400}));
+      return client.revokeToken('invalid-token').catch(err => {
+        assert.equal(err.message, 'failed');
+      });
+    });
+  });
+
+  describe('#authorize', () => {
+    var fakeWindow;
+
+    beforeEach(() => {
+      fakeWindow = new FakeWindow;
+    });
+
+    it('opens a popup window at the authorization URL', () => {
+      var authorized = client.authorize(fakeWindow);
+
+      fakeWindow.sendMessage({
+        type: 'authorization_response',
+        code: 'expected-code',
+        state: 'notrandom',
+      });
+
+      return authorized.then(() => {
+        var params = {
+          client_id: config.clientId,
+          origin: 'https://client.hypothes.is',
+          response_mode: 'web_message',
+          response_type: 'code',
+          state: 'notrandom',
+        };
+        var expectedAuthUrl = `${config.authorizationEndpoint}?${stringify(params)}`;
+        // Check that the auth window was opened and then set to the expected
+        // location. The final URL is not passed to `window.open` to work around
+        // a pop-up blocker issue.
+        assert.calledWith(
+          fakeWindow.open,
+          'about:blank',
+          'Login to Hypothesis',
+          'height=430,left=274.5,top=169,width=475'
+        );
+        var authPopup = fakeWindow.open.returnValues[0];
+        assert.equal(authPopup.location.href, expectedAuthUrl);
+      });
+    });
+
+    it('resolves with an auth code if successful', () => {
+      var authorized = client.authorize(fakeWindow);
+
+      fakeWindow.sendMessage({
+        type: 'authorization_response',
+        code: 'expected-code',
+        state: 'notrandom',
+      });
+
+      return authorized.then(code => {
+        assert.equal(code, 'expected-code');
+      });
+    });
+
+    it('rejects with an error if canceled', () => {
+      var authorized = client.authorize(fakeWindow);
+
+      fakeWindow.sendMessage({
+        type: 'authorization_canceled',
+        state: 'notrandom',
+      });
+
+      return authorized.catch(err => {
+        assert.equal(err.message, 'Authorization window was closed');
+      });
+    });
+
+    it('ignores responses with incorrect "state" values', () => {
+      var authorized = client.authorize(fakeWindow);
+
+      fakeWindow.sendMessage({
+        type: 'authorization_response',
+        code: 'first-code',
+        state: 'wrongstate',
+      });
+
+      fakeWindow.sendMessage({
+        type: 'authorization_response',
+        code: 'second-code',
+        state: 'notrandom',
+      });
+
+      return authorized.then(code => {
+        assert.equal(code, 'second-code');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR simplifies the authorization service in oauth-auth.js by extracting the code which handles the details of interaction with the OAuth endpoints in the "h" service into a separate `OAuthClient` class in sidebar/util/oauth-client.js

This has several benefits:

- Separates the concerns of _how_ to interact with the OAuth endpoints from _when_ to do so and with _what_ values.
- Makes tests for the authorization service easier to follow because they just stub Promise-returning methods in `OAuthClient` rather than having to stub the full HTTP requests and auth window interaction.
- The oauth-client module, although not explicitly packaged for re-use yet, is something that would be much easier for third parties to use as a reference for implementing their own clients as it has minimal dependencies on other parts of the application or Angular.