### PR TITLE
WIP - settings.pageGroups configures publisher-promoted groups in sidebar groups dropdown

### DIFF
--- a/scripts/gulp/live-reload-server.js
+++ b/scripts/gulp/live-reload-server.js
@@ -99,7 +99,10 @@ function LiveReloadServer(port, config) {
 
                 // Open the sidebar when the page loads
                 openSidebar: true,
-                pageGroups: ["http://h.hypothesis:5000/groups/MGkYz9j2/http-test-localhost"]
+                pageGroups: [
+                  "http://h.hypothesis:5000/groups/MGkYz9j2/http-test-localhost", // will 404
+                  "http://h.hypothesis:5000/groups/2JKqAjYE/scipub-com-open-group",
+                ]
               };
             };
 

--- a/scripts/gulp/live-reload-server.js
+++ b/scripts/gulp/live-reload-server.js
@@ -99,6 +99,7 @@ function LiveReloadServer(port, config) {
 
                 // Open the sidebar when the page loads
                 openSidebar: true,
+                pageGroups: ["http://h.hypothesis:5000/groups/MGkYz9j2/http-test-localhost"]
               };
             };
 

--- a/scripts/gulp/live-reload-server.js
+++ b/scripts/gulp/live-reload-server.js
@@ -100,8 +100,9 @@ function LiveReloadServer(port, config) {
                 // Open the sidebar when the page loads
                 openSidebar: true,
                 pageGroups: [
-                  "http://h.hypothesis:5000/groups/MGkYz9j2/http-test-localhost", // will 404
+                  // "http://h.hypothesis:5000/groups/MGkYz9j2/http-test-localhost", // will 404
                   "http://h.hypothesis:5000/groups/2JKqAjYE/scipub-com-open-group",
+                  "http://h.hypothesis:5000/groups/wg54vyqQ/h-hypothesis-open",
                 ]
               };
             };

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -23,6 +23,7 @@ function configFrom(window_) {
     onLayoutChange: settings.hostPageSetting('onLayoutChange'),
     openLoginForm: settings.hostPageSetting('openLoginForm', {allowInBrowserExt: true}),
     openSidebar: settings.hostPageSetting('openSidebar', {allowInBrowserExt: true}),
+    pageGroups: settings.hostPageSetting('pageGroups'),
     query: settings.query,
     services: settings.hostPageSetting('services'),
     showHighlights: settings.showHighlights,

--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -12,6 +12,8 @@ var raven;
 // Read settings rendered into sidebar app HTML by service/extension.
 var settings = require('../shared/settings').jsonConfigsFrom(document);
 
+console.log('sidebar settings', settings)
+
 if (settings.raven) {
   // Initialize Raven. This is required at the top of this file
   // so that it happens early in the app's startup flow
@@ -58,6 +60,10 @@ var resolve = {
   // @ngInject
   sessionState: function (session) {
     return session.load();
+  },
+  // @ngInject
+  pageGroups: function (groups) {
+    return groups.pageGroups();
   },
 };
 
@@ -175,6 +181,7 @@ module.exports = angular.module('h', [
   .component('dropdownMenuBtn', require('./components/dropdown-menu-btn'))
   .component('excerpt', require('./components/excerpt'))
   .component('groupList', require('./components/group-list'))
+  .component('newGroupList', require('./components/new-group-list'))
   .component('helpLink', require('./components/help-link'))
   .component('helpPanel', require('./components/help-panel'))
   .component('loggedoutMessage', require('./components/loggedout-message'))

--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -12,8 +12,6 @@ var raven;
 // Read settings rendered into sidebar app HTML by service/extension.
 var settings = require('../shared/settings').jsonConfigsFrom(document);
 
-console.log('sidebar settings', settings)
-
 if (settings.raven) {
   // Initialize Raven. This is required at the top of this file
   // so that it happens early in the app's startup flow
@@ -60,10 +58,6 @@ var resolve = {
   // @ngInject
   sessionState: function (session) {
     return session.load();
-  },
-  // @ngInject
-  pageGroups: function (groups) {
-    return groups.pageGroups();
   },
 };
 
@@ -250,7 +244,8 @@ module.exports = angular.module('h', [
   .value('settings', settings)
   .value('time', require('./time'))
   .value('urlEncodeFilter', require('./filter/url').encode)
-
+  .value('debugFilter', require('./filter/debug').debug)
+  
   .config(configureHttp)
   .config(configureLocation)
   .config(configureRoutes)

--- a/src/sidebar/components/new-group-list.js
+++ b/src/sidebar/components/new-group-list.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var persona = require('../filter/persona');
+var serviceConfig = require('../service-config');
+
+// @ngInject
+function NewGroupListController($window, analytics, groups, settings, serviceUrl) {
+  this.groups = groups;
+
+  this.createNewGroup = function() {
+    $window.open(serviceUrl('groups.new'), '_blank');
+  };
+
+  this.isThirdPartyUser = function () {
+    return persona.isThirdPartyUser(this.auth.userid, settings.authDomain);
+  };
+
+  this.leaveGroup = function (groupId) {
+    var groupName = groups.get(groupId).name;
+    var message = 'Are you sure you want to leave the group "' +
+      groupName + '"?';
+    if ($window.confirm(message)) {
+      analytics.track(analytics.events.GROUP_LEAVE);
+      groups.leave(groupId);
+    }
+  };
+
+  this.viewGroupActivity = function () {
+    analytics.track(analytics.events.GROUP_VIEW_ACTIVITY);
+  };
+
+  this.focusGroup = function (groupId) {
+    analytics.track(analytics.events.GROUP_SWITCH);
+    groups.focus(groupId);
+  };
+
+  var svc = serviceConfig(settings);
+  if (svc && svc.icon) {
+    this.thirdPartyGroupIcon = svc.icon;
+  }
+}
+
+module.exports = {
+  controller: NewGroupListController,
+  controllerAs: 'vm',
+  bindings: {
+    auth: '<',
+  },
+  template: require('../templates/new-group-list.html'),
+};

--- a/src/sidebar/components/new-group-list.js
+++ b/src/sidebar/components/new-group-list.js
@@ -3,7 +3,10 @@
 var persona = require('../filter/persona');
 var serviceConfig = require('../service-config');
 
-// @ngInject
+/**
+ * Controller for new-group-list - https://docs.google.com/presentation/d/1ESiIotb91xJnUj9v6M2R2qW0o7akT1MbwsIMPjab6Ho/edit#slide=id.g2576362aea_1_2
+ * @ngInject
+ */
 function NewGroupListController($window, analytics, groups, settings, serviceUrl) {
   this.groups = groups;
 

--- a/src/sidebar/components/new-group-list.js
+++ b/src/sidebar/components/new-group-list.js
@@ -45,6 +45,7 @@ module.exports = {
   controllerAs: 'vm',
   bindings: {
     auth: '<',
+    groups: '<',
   },
   template: require('../templates/new-group-list.html'),
 };

--- a/src/sidebar/components/test/new-group-list-test.js
+++ b/src/sidebar/components/test/new-group-list-test.js
@@ -1,0 +1,166 @@
+'use strict';
+
+var angular = require('angular');
+
+var groupList = require('../new-group-list');
+var util = require('../../directive/test/util');
+
+describe('groupList', function () {
+  var $window;
+
+  var GROUP_LINK = 'https://hypothes.is/groups/hdevs';
+
+  var groups;
+  var fakeGroups;
+  var fakeAnalytics;
+  var fakeServiceUrl;
+  var fakeSettings;
+
+  before(function() {
+    angular.module('app', [])
+      .component('groupList', groupList)
+      .factory('groups', function () {
+        return fakeGroups;
+      });
+  });
+
+  beforeEach(function () {
+
+    fakeAnalytics = {
+      track: sinon.stub(),
+      events: {
+        GROUP_LEAVE: 'groupLeave',
+        GROUP_SWITCH: 'groupSwitch',
+        GROUP_VIEW_ACTIVITY: 'groupViewActivity',
+      },
+    };
+
+    fakeServiceUrl = sinon.stub();
+    fakeSettings = {
+      authDomain: 'example.com',
+    };
+
+    angular.mock.module('app', {
+      analytics: fakeAnalytics,
+      serviceUrl: fakeServiceUrl,
+      settings: fakeSettings,
+    });
+  });
+
+  beforeEach(angular.mock.inject(function (_$window_) {
+    $window = _$window_;
+
+    groups = [{
+      id: 'public',
+      public: true,
+    },{
+      id: 'h-devs',
+      name: 'Hypothesis Developers',
+      url: GROUP_LINK,
+    }];
+
+    fakeGroups = {
+      all: function () {
+        return groups;
+      },
+      get: function (id) {
+        var match = this.all().filter(function (group) {
+          return group.id === id;
+        });
+        return match.length > 0 ? match[0] : undefined;
+      },
+      leave: sinon.stub(),
+      focus: sinon.stub(),
+      focused: sinon.stub(),
+    };
+  }));
+
+  function createGroupList() {
+    return util.createDirective(document, 'groupList', {
+      auth: {
+        status: 'logged-in',
+        userid: 'acct:person@example.com',
+      },
+    });
+  }
+
+  it('should render groups', function () {
+    var element = createGroupList();
+    var groupItems = element.find('.group-item');
+    assert.equal(groupItems.length, groups.length + 1);
+  });
+
+  it('should render share links', function () {
+    var element = createGroupList();
+    var shareLinks = element.find('.share-link-container');
+    assert.equal(shareLinks.length, 1);
+
+    var link = element.find('.share-link');
+    assert.equal(link.length, 1);
+    assert.equal(link[0].href, GROUP_LINK);
+  });
+
+  it('should track metrics when a user attempts to view a groups activity', function () {
+    var element = createGroupList();
+    var link = element.find('.share-link');
+    link.click();
+    assert.calledWith(fakeAnalytics.track, fakeAnalytics.events.GROUP_VIEW_ACTIVITY);
+  });
+
+  function clickLeaveIcon(element, acceptPrompt) {
+    var leaveLink = element.find('.h-icon-cancel-outline');
+
+    // accept prompt to leave group
+    $window.confirm = function () {
+      return acceptPrompt;
+    };
+    leaveLink.click();
+  }
+
+  it('should leave group when the leave icon is clicked', function () {
+    var element = createGroupList();
+    clickLeaveIcon(element, true);
+    assert.ok(fakeGroups.leave.calledWith('h-devs'));
+    assert.calledWith(fakeAnalytics.track, fakeAnalytics.events.GROUP_LEAVE);
+  });
+
+  it('should not leave group when confirmation is dismissed', function () {
+    var element = createGroupList();
+    clickLeaveIcon(element, false);
+    assert.notCalled(fakeGroups.leave);
+    assert.notCalled(fakeAnalytics.track);
+  });
+
+  it('should not change the focused group when leaving', function () {
+    var element = createGroupList();
+    clickLeaveIcon(element, true);
+    assert.notCalled(fakeGroups.focus);
+    assert.calledWith(fakeAnalytics.track, fakeAnalytics.events.GROUP_LEAVE);
+  });
+
+  it('should change current group focus when click another group', function () {
+    var element = createGroupList();
+    var groupItems = element.find('.group-item');
+
+    // click the second group
+    groupItems[1].click();
+
+    assert.calledOnce(fakeGroups.focus);
+    assert.calledWith(fakeAnalytics.track, fakeAnalytics.events.GROUP_SWITCH);
+  });
+
+  it('should open a window when "New Group" is clicked', function () {
+    fakeServiceUrl
+      .withArgs('groups.new')
+      .returns('https://test.hypothes.is/groups/new');
+
+    var element = createGroupList();
+    $window.open = sinon.stub();
+
+    var newGroupLink =
+      element[0].querySelector('.new-group-btn a');
+    angular.element(newGroupLink).click();
+    assert.calledWith($window.open, 'https://test.hypothes.is/groups/new',
+      '_blank');
+  });
+});

--- a/src/sidebar/filter/debug.js
+++ b/src/sidebar/filter/debug.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  debug: debug,
+};
+
+// angular template filter to debug a variable - i.e. console.debug and return string representation
+function debug(input) {
+  // eslint-disable-next-line no-console
+  console.debug('debug filter', input);
+  if (input === '') { return 'empty string'; }
+  return input ? input : ('' + input);
+}

--- a/src/sidebar/groups.js
+++ b/src/sidebar/groups.js
@@ -96,10 +96,10 @@ function groups(localStorage, serviceUrl, session, $rootScope, store, settings) 
 
   /**
    * Wrap an async function such that it is only called once and the result is cached and promised on subsequent calls.
-   * @param {Function<any, Promise<any>} fetch - Go fetch some value
-   * @param {Function<any, any>} withResult - Function call with the reuslt the first time it's fetched. `this` will be same as `this` in cached() call
+   * @param {(...args: any) => any} fetch - Go fetch some value. Will be Promise.resolved
+   * @param {(...args: any) => any} [withResult] - Function call with the reuslt the first time it's fetched. `this` will be same as `this` in cached() call. Will be Promise.resolved and awaited.
    */
-  function cached(fetch, withResult) {
+  function cached(fetch, withResult=()=>{}) {
     var result = false;
     var fetching = false;
     return function (...args) {

--- a/src/sidebar/groups.js
+++ b/src/sidebar/groups.js
@@ -16,7 +16,7 @@ var STORAGE_KEY = 'hypothesis.groups.focus';
 var events = require('./events');
 
 // @ngInject
-function groups(localStorage, serviceUrl, session, $rootScope, store) {
+function groups(localStorage, serviceUrl, session, $rootScope, store, settings) {
   // The currently focused group. This is the group that's shown as selected in
   // the groups dropdown, the annotations displayed are filtered to only ones
   // that belong to this group, and any new annotations that the user creates
@@ -82,6 +82,13 @@ function groups(localStorage, serviceUrl, session, $rootScope, store) {
     }
   }
 
+  function pageGroups() {
+    console.log('settings.pageGroups', settings.pageGroups)
+    return (settings.pageGroups || []).map(function (group) {
+      return store.group.read(group)
+    })
+  }
+
   // reset the focused group if the user leaves it
   $rootScope.$on(events.GROUPS_CHANGED, function () {
     if (focusedGroup) {
@@ -95,6 +102,7 @@ function groups(localStorage, serviceUrl, session, $rootScope, store) {
   return {
     all: all,
     get: get,
+    pageGroups: pageGroups,
 
     leave: leave,
 

--- a/src/sidebar/groups.js
+++ b/src/sidebar/groups.js
@@ -83,10 +83,9 @@ function groups(localStorage, serviceUrl, session, $rootScope, store, settings) 
   }
 
   function pageGroups() {
-    console.log('settings.pageGroups', settings.pageGroups)
-    return (settings.pageGroups || []).map(function (group) {
-      return store.group.read(group)
-    })
+    return Promise.all((settings.pageGroups || []).map(function (group) {
+      return store.group.read(group);
+    }));
   }
 
   // reset the focused group if the user leaves it

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -35,6 +35,8 @@ function hostPageConfig(window) {
     // OAuth feature flag override.
     // This should be removed once OAuth is enabled for first party accounts.
     'oauthEnabled',
+
+    'pageGroups',
   ];
 
   return Object.keys(config).reduce(function (result, key) {

--- a/src/sidebar/store.js
+++ b/src/sidebar/store.js
@@ -114,9 +114,9 @@ function createAPICall($http, $q, links, route, tokenGetter) {
       var links = linksAndToken[0];
       var token = linksAndToken[1];
 
-      var descriptor = typeof route === 'string' && get(links, route)
+      var descriptor = typeof route === 'string' && get(links, route);
       var urlAndParams = descriptor && descriptor.url && urlUtil.replaceURLParams(descriptor.url, params)
-                      || (route.url && typeof params === 'string') && { url: params, params: {} }
+                      || (route.url && typeof params === 'string') && { url: params, params: {} };
 
       var headers = {};
 

--- a/src/sidebar/store.js
+++ b/src/sidebar/store.js
@@ -114,8 +114,10 @@ function createAPICall($http, $q, links, route, tokenGetter) {
       var links = linksAndToken[0];
       var token = linksAndToken[1];
 
-      var descriptor = get(links, route);
-      var url = urlUtil.replaceURLParams(descriptor.url, params);
+      var descriptor = typeof route === 'string' && get(links, route)
+      var urlAndParams = descriptor && descriptor.url && urlUtil.replaceURLParams(descriptor.url, params)
+                      || (route.url && typeof params === 'string') && { url: params, params: {} }
+
       var headers = {};
 
       if (token) {
@@ -125,10 +127,10 @@ function createAPICall($http, $q, links, route, tokenGetter) {
       var req = {
         data: data ? stripInternalProperties(data) : null,
         headers: headers,
-        method: descriptor.method,
-        params: url.params,
+        method: descriptor && descriptor.method || 'GET',
+        params: urlAndParams.params,
         paramSerializer: serializeParams,
-        url: url.url,
+        url: urlAndParams.url,
       };
       return $http(req);
     }).then(function (response) {
@@ -174,6 +176,7 @@ function store($http, $q, apiRoutes, auth) {
       unhide: apiCall('annotation.unhide'),
     },
     group: {
+      read: apiCall({ url: true }),
       member: {
         delete: apiCall('group.member.delete'),
       },

--- a/src/sidebar/templates/new-group-list.html
+++ b/src/sidebar/templates/new-group-list.html
@@ -1,0 +1,89 @@
+<span ng-if="vm.auth.status === 'logged-out'"
+      ng-switch on="vm.groups.focused().public">
+  <img class="group-list-label__icon group-list-label__icon--third-party"
+    ng-src="{{ vm.thirdPartyGroupIcon }}"
+    ng-if="vm.thirdPartyGroupIcon"
+    ng-switch-when="true"><!-- nospace
+  !--><i class="group-list-label__icon h-icon-public"
+    ng-if="!vm.thirdPartyGroupIcon"
+    ng-switch-when="true"></i><!-- nospace
+  !--><i class="group-list-label__icon h-icon-group" ng-switch-default></i>
+  <span class="group-list-label__label">{{vm.groups.focused().name}}</span>
+</span>
+
+<div class="pull-right"
+     ng-if="vm.auth.status === 'logged-in'"
+     dropdown
+     keyboard-nav>
+  <div class="dropdown-toggle"
+        dropdown-toggle
+        data-toggle="dropdown"
+        role="button"
+        ng-switch on="vm.groups.focused().public"
+        title="Change the selected group">
+    <img class="group-list-label__icon group-list-label__icon--third-party"
+         ng-src="{{ vm.thirdPartyGroupIcon }}"
+         ng-if="vm.thirdPartyGroupIcon"
+         ng-switch-when="true"><!-- nospace
+    !--><i class="group-list-label__icon h-icon-public"
+           ng-switch-when="true"
+           ng-if="!vm.thirdPartyGroupIcon"></i><!-- nospace
+    !--><i class="group-list-label__icon h-icon-group"
+           ng-switch-default></i>
+    <span class="group-list-label__label">{{vm.groups.focused().name}}</span><!-- nospace
+    !--><i class="h-icon-arrow-drop-down"></i>
+  </div>
+  <div class="dropdown-menu__top-arrow"></div>
+  <ul class="dropdown-menu pull-none" role="menu">
+    <li class="dropdown-menu__row dropdown-menu__row--unpadded "
+        ng-repeat="group in vm.groups.all()">
+      <div ng-class="{'group-item': true, selected: group.id == vm.groups.focused().id}"
+           ng-click="vm.focusGroup(group.id)">
+        <!-- the group icon !-->
+        <div class="group-icon-container" ng-switch on="group.public">
+          <img class="group-list-label__icon group-list-label__icon--third-party"
+               ng-src="{{ vm.thirdPartyGroupIcon }}"
+               ng-if="vm.thirdPartyGroupIcon"
+               ng-switch-when="true">
+          <i class="h-icon-public" ng-if="!vm.thirdPartyGroupIcon" ng-switch-when="true"></i>
+          <i class="h-icon-group" ng-switch-default></i>
+        </div>
+        <!-- the group name and share link !-->
+        <div class="group-details">
+          <div class="group-name-container">
+            <a class="group-name-link"
+               href=""
+               title="{{ group.public ? 'Show public annotations' : 'Show and create annotations in ' + group.name }}">
+               {{group.name}}
+            </a>
+          </div>
+          <div class="share-link-container" ng-click="$event.stopPropagation()" ng-if="!group.public">
+            <a class="share-link"
+               href="{{group.url}}"
+               target="_blank"
+               ng-click="vm.viewGroupActivity()">
+              View group activity and invite others
+            </a>
+          </div>
+        </div>
+        <!-- the 'Leave group' icon !-->
+        <div class="group-cancel-icon-container" ng-click="$event.stopPropagation()">
+          <i class="h-icon-cancel-outline btn--cancel"
+             ng-if="!group.public"
+             ng-click="vm.leaveGroup(group.id)"
+             title="Leave '{{group.name}}'"></i>
+        </div>
+      </div>
+    </li>
+    <li ng-if="!vm.isThirdPartyUser()" class="dropdown-menu__row dropdown-menu__row--unpadded new-group-btn">
+      <div class="group-item" ng-click="vm.createNewGroup()">
+        <div class="group-icon-container"><i class="h-icon-add"></i></div>
+        <div class="group-details">
+          <a href="" class="group-name-link" title="Create a new group to share annotations">
+            New group
+          </a>
+        </div>
+      </div>
+    </li>
+  </ul>
+</div>

--- a/src/sidebar/templates/new-group-list.html
+++ b/src/sidebar/templates/new-group-list.html
@@ -75,6 +75,49 @@
         </div>
       </div>
     </li>
+
+    <!-- Page Groups -->
+    <li class="dropdown-menu__row dropdown-menu__row--unpadded "
+        ng-repeat="group in vm.groups.pageGroups() track by group.id">
+      <div ng-class="{'group-item': true, selected: group.id == vm.groups.focused().id}"
+          ng-click="vm.focusGroup(group.id)">
+        <!-- the group icon !-->
+        <div class="group-icon-container" ng-switch on="group.public">
+          <img class="group-list-label__icon group-list-label__icon--third-party"
+              ng-src="{{ vm.thirdPartyGroupIcon }}"
+              ng-if="vm.thirdPartyGroupIcon"
+              ng-switch-when="true">
+          <i class="h-icon-public" ng-if="!vm.thirdPartyGroupIcon" ng-switch-when="true"></i>
+          <i class="h-icon-group" ng-switch-default></i>
+        </div>
+        <!-- the group name and share link !-->
+        <div class="group-details">
+          <div class="group-name-container">
+            <a class="group-name-link"
+              href=""
+              title="{{ group.public ? 'Show public annotations' : 'Show and create annotations in ' + group.name }}">
+              {{group.name}}
+            </a>
+          </div>
+          <div class="share-link-container" ng-click="$event.stopPropagation()" ng-if="!group.public">
+            <a class="share-link"
+              href="{{group.url}}"
+              target="_blank"
+              ng-click="vm.viewGroupActivity()">
+              View group activity and invite others
+            </a>
+          </div>
+        </div>
+        <!-- the 'Leave group' icon !-->
+        <div class="group-cancel-icon-container" ng-click="$event.stopPropagation()">
+          <i class="h-icon-cancel-outline btn--cancel"
+            ng-if="!group.public"
+            ng-click="vm.leaveGroup(group.id)"
+            title="Leave '{{group.name}}'"></i>
+        </div>
+      </div>
+    </li>
+
     <li ng-if="!vm.isThirdPartyUser()" class="dropdown-menu__row dropdown-menu__row--unpadded new-group-btn">
       <div class="group-item" ng-click="vm.createNewGroup()">
         <div class="group-icon-container"><i class="h-icon-add"></i></div>

--- a/src/sidebar/templates/top-bar.html
+++ b/src/sidebar/templates/top-bar.html
@@ -24,7 +24,7 @@
        the stream view.
   !-->
   <div class="top-bar__inner content" ng-if="::vm.isSidebar">
-    <group-list class="group-list" auth="vm.auth"></group-list>
+    <new-group-list class="new-group-list" auth="vm.auth"></new-group-list>
     <div class="top-bar__expander"></div>
     <a class="top-bar__apply-update-btn"
        ng-if="vm.pendingUpdateCount > 0"

--- a/src/sidebar/test/groups-test.js
+++ b/src/sidebar/test/groups-test.js
@@ -39,8 +39,11 @@ describe('groups', function() {
     fakeRootScope = {
       eventCallbacks: [],
 
+      $apply: (doStuff) => {
+        if (typeof doStuff === 'function') { doStuff.call(this); }
+      },
       $broadcast: sandbox.stub(),
-
+      
       $on: function(event, callback) {
         if (event === events.GROUPS_CHANGED) {
           this.eventCallbacks.push(callback);

--- a/src/sidebar/test/store-test.js
+++ b/src/sidebar/test/store-test.js
@@ -200,6 +200,20 @@ describe('sidebar.store', function () {
     });
   });
 
+  describe('#group.read', () => {
+    it('reads a group by url', (done) => {
+      var groupUrl = 'http://h.hypothesis:5000/groups/MGkYz9j2/http-test-localhost';
+      var group = {pubid: '2JKqAjYE', description: null, name: 'SciPub.com Open Group'};
+      store.group.read(groupUrl).then(function (group_) {
+        assert.deepEqual(group_, group);
+        done();
+      });
+      $httpBackend.expectGET(groupUrl)
+        .respond(function () { return [200, group, {}]; });
+      $httpBackend.flush();
+    });
+  });
+
   it('removes internal properties before sending data to the server', function (done) {
     var annotation = {
       $highlight: true,

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -14,6 +14,7 @@ $base-line-height: 20px;
 @import './dropdown-menu-btn';
 @import './excerpt';
 @import './group-list';
+@import './new-group-list';
 @import './help-panel';
 @import './loggedout-message';
 @import './login-control';

--- a/src/styles/new-group-list.scss
+++ b/src/styles/new-group-list.scss
@@ -1,0 +1,109 @@
+/* The groups dropdown list. */
+
+$new-group-list-width: 270px;
+$new-group-list-spacing-below: 50px;
+
+.new-group-list {
+  .dropdown {
+    white-space: nowrap;
+  }
+
+  .dropdown-menu {
+    width: $new-group-list-width;
+    max-height: 500px;  // fallback for browsers lacking support for vh/calc
+    max-height: calc(100vh - #{$top-bar-height} - #{$new-group-list-spacing-below});
+    overflow-y: auto;
+
+    .group-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      width: $new-group-list-width - 30px;
+    }
+  }
+
+  .group-item {
+    display: flex;
+    flex-direction: row;
+    flex-grow: 1;
+
+    padding: 10px;
+    cursor: pointer;
+
+    &:hover {
+      .group-name-link {
+        color: $brand-color;
+      }
+    }
+
+    &.selected {
+      .group-name-link {
+        font-size: $body2-font-size;
+        font-weight: 600;
+      }
+    }
+  }
+
+  .group-icon-container {
+    margin-right: 10px;
+  }
+
+  .group-cancel-icon-container {
+    // the 'Leave group' icon is shifted down slightly
+    // so that it lines up vertically with the 'chat heads' icon on the
+    // left-hand side of the groups list
+    padding-top: 3px;
+    margin-right: 2px;
+  }
+
+  .group-details {
+    flex-grow: 1;
+    flex-shrink: 1;
+  }
+
+  .new-group-btn {
+    background-color: $gray-lightest;
+
+    .group-item {
+      padding-top: 12px;
+      padding-bottom: 12px;
+    }
+
+    .h-icon-add {
+      font-weight: bold;
+    }
+  }
+}
+
+// the icon indicating the type of group currently selected at
+// the top of the groups list
+.new-group-list-label__icon {
+  color: $color-gray;
+  display: inline-block;
+  margin-right: 4px;
+  position: relative;
+  vertical-align: baseline;
+
+  // align the base of the chat-heads icon for groups
+  // with the baseline of the group name label
+  transform: translateY(1px);
+}
+
+.new-group-list-label__icon--third-party {
+  height: 15px;
+  width: 15px;
+  top: 2px;
+}
+
+// the label showing the currently selected group which opens
+// the drop-down list when clicked
+.new-group-list-label__label {
+  font-size: $body2-font-size;
+  font-weight:bold;
+}
+
+// the name of a group in the groups drop-down list
+// and 'Post to <Group>' button for saving annotations
+.group-name-link {
+  white-space: nowrap;
+  color: inherit;
+}


### PR DESCRIPTION
This is a work in progress. Publishing to facilitate 11/27 meetings.

We're adding the ability for publishers to configure hypothesis/clients to feature one or more groups. So the client will show groups you're a member of, but now also groups the publisher want to promote.

This PR depends on functionality added to h in [this PR](https://github.com/gobengo/h/pull/1).

Publishers can configure one or more `pageGroups` (happy to change that to whatever) like:
```
window.hypothesisConfig = function () {
    return {
        pageGroups: [
            "http://h.hypothesis:5000/groups/2JKqAjYE/scipub-com-open-group",
            "http://h.hypothesis:5000/groups/wg54vyqQ/h-hypothesis-open",
        ]
    };
};
```

The idea is here is it's "Just the group URL" that you'd get by using a web browser to find the group. The client then requests JSON from that URL to resolve up-to-date group information, before rendering the groups in the groups dropdown.

Right now this PR just gets these groups rendering in the top-right groups dropdown using the same template as groups that you're a member of. Eventually I'm told it should look like [these designs](https://docs.google.com/presentation/d/1ESiIotb91xJnUj9v6M2R2qW0o7akT1MbwsIMPjab6Ho/edit#slide=id.g2576362aea_1_2).

This PR does:
* annotator/config - new hostPageSetting `pageGroups`
* sidebar/app
  * `newGroupList` - oy. I plan to just copy this over the existing group-list, or will rename to something new to reflect component with still-required design changes.
  * `debugFilter` - an angular template filter to debug values. I found it useful but can remove if asked.
* sidebar/components/new-group-list - Like existing group-list, but now binds to groups and uses new-group-list.html template
* src/sidebar/groups - `.pageGroups` will look at the configured value of group URLs, fetch them from h API, and return those objects. It'll also cache the value, so only the first call makes an HTTP request. In the future this may have to change if we want to allow the set of configured groups to change throughout the document lifetime
* sidebar/store
  * `createAPICall` changes to accomodate for the fact that we want to dereference those group URLs directly by their value. We don't need to look up the real URL in the routes list that other methods here use. So now createAPICall can create calls that just accept a url. `apiCall({ url: true })`
  * createAPICall request method defaults to GET

Questions
* [] - cool with `pageGroups` as configuration option and method names? Or what should I change it to?
* [] - new-group-list is not a good final name. What is? Or should I just make edits to the existing groups-list

What's next
* Implement new designs for the groups dropdown in sidebar