### PR TITLE
Open thirdPartyUsernameLink in current browser window

### DIFF
--- a/src/sidebar/templates/annotation-header.html
+++ b/src/sidebar/templates/annotation-header.html
@@ -7,7 +7,6 @@
       ng-href="{{vm.serviceUrl('user',{user:vm.user()})}}"
       >{{vm.displayName()}}</a>
     <a class="annotation-header__user"
-      target="_blank"
       ng-if="vm.isThirdPartyUser() && vm.thirdPartyUsernameLink()"
       href="{{ vm.thirdPartyUsernameLink() }}"
       >{{vm.displayName()}}</a>


### PR DESCRIPTION
The introduction of the `target="_blank"` is here: https://github.com/hypothesis/client/commit/396fce0e486d6d12b320a32f9026d15cf5fbdc3d

The implementation of the `usernameUrl` needs more work if it is to be an option that can serve many use cases. It should be implemented in the same way as `onLoginRequest` but have the `username` passed as a parameter, so we can determine the action of clicking on the link, the decision to open in a new window should be a configuration option.

@robertknight wrote on slack on Nov 28th 12:38pm:

"My suggestion here is that we should make the username link work the same as other service-provided handlers eg. for login & logout, namely:

- It should be part of the service configuration, rather than top-level configuration, since each service will want its own username links
- It should be a callback function (like `onLoginRequest`) that allows the host page to handle as they see fit - whether that is opening a popup window, opening a new tab or changing the current route in a web app"

Until we implement the ideal solution can we request that we drop the `target="_blank"`. It does not provide the best user experience for us.