### PR TITLE
Dont hyperlink annotation timestamps when the annotation has no href

### DIFF
--- a/src/sidebar/components/timestamp.js
+++ b/src/sidebar/components/timestamp.js
@@ -50,7 +50,5 @@ module.exports = {
     href: '<',
     timestamp: '<',
   },
-  template: `<a class="{{ vm.className }}" target="_blank"
-                title="{{ vm.absoluteTimestamp }}"
-                href="{{ vm.href }}">{{ vm.relativeTimestamp }}</a>`,
+  template: require('../templates/timestamp.html'),
 };

--- a/src/sidebar/templates/timestamp.html
+++ b/src/sidebar/templates/timestamp.html
@@ -1,0 +1,5 @@
+<a class="{{ vm.className }}"
+   target="_blank"
+   title="{{ vm.absoluteTimestamp }}"
+   href="{{ vm.href }}">{{ vm.relativeTimestamp }}
+</a>

--- a/src/sidebar/templates/timestamp.html
+++ b/src/sidebar/templates/timestamp.html
@@ -1,5 +1,14 @@
-<a class="{{ vm.className }}"
-   target="_blank"
-   title="{{ vm.absoluteTimestamp }}"
-   href="{{ vm.href }}">{{ vm.relativeTimestamp }}
-</a>
+<div ng-switch="vm.href">
+  <span ng-switch-when=""
+        class="{{ vm.className }}"
+        title="{{ vm.absoluteTimestamp }}">
+    {{ vm.relativeTimestamp }}
+  </span>
+  <a ng-switch-default
+     class="{{ vm.className }}"
+     target="_blank"
+     title="{{ vm.absoluteTimestamp }}"
+     href="{{ vm.href }}">
+     {{ vm.relativeTimestamp }}
+  </a>
+</div>


### PR DESCRIPTION
This is part of the fix for <https://github.com/hypothesis/client/issues/612>. The other part is <https://github.com/hypothesis/h/pull/4711>.

A first-party annotation from the annotation read or search API looks like:

```json
{
  ...,
  links: {
    json: "http://localhost:5000/api/annotations/QvplEtX1EeeOhK9ondpFvw",
    html: "http://localhost:5000/a/QvplEtX1EeeOhK9ondpFvw",
    incontext: "http://localhost:8000/QvplEtX1EeeOhK9ondpFvw/localhost:3000/"
  },
  ...,
}
```

Notice the `html` link. A third-party annotation has no `html` or `incontext` link:

```json
{
  ...,
  links: {
    json: "http://localhost:5000/api/annotations/QvplEtX1EeeOhK9ondpFvw",
  },
  ...,
}
```

Or at least, once I've fixed h to not include these links, they won't.

With this PR the client renders the timestamps of first-party annotations as:

```html
<div ng-switch="vm.href">
  <a ng-switch-default
     target="_blank"
     title="27 Feb"
     href="https://hypothes.is/...">
       2 months ago
  </a>
</div>
```

And third-party ones as:

```html
<div ng-switch="vm.href">
  <span ng-switch-when="">
    2 months ago
  </span>
</div>
```

Annotations that are newly-created in the client and not saved to the server yet get the `<span>` version too.