### PR TITLE
Don't show share dialog if no incontext link

### DIFF
--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -126,7 +126,7 @@
         label="'Reply'"
         on-click="vm.reply()"
       ></annotation-action-button>
-      <span class="annotation-share-dialog-wrapper">
+      <span class="annotation-share-dialog-wrapper" ng-if="vm.incontextLink()">
         <annotation-action-button
          icon="'h-icon-annotation-share'"
          is-disabled="vm.isDeleted()"


### PR DESCRIPTION
If the annotation received from the API contains no incontext link (as is the case with third-party annotations, for example) then don't render the annotation share dialog that contains the incontext link.

This is one half of the fix for <https://github.com/hypothesis/client/issues/613>, the other half is <https://github.com/hypothesis/h/pull/4714>.