### PR TITLE
Don't show page share button on eLife pages

### DIFF
--- a/src/sidebar/components/top-bar.js
+++ b/src/sidebar/components/top-bar.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var isThirdPartyService = require('../util/is-third-party-service');
+
 module.exports = {
   controllerAs: 'vm',
   //@ngInject
@@ -9,6 +11,10 @@ module.exports = {
     } else {
       this.isThemeClean = false;
     }
+
+    this.showSharePageButton = function () {
+      return !isThirdPartyService(settings);
+    };
   },
   bindings: {
     auth: '<',

--- a/src/sidebar/templates/top-bar.html
+++ b/src/sidebar/templates/top-bar.html
@@ -48,6 +48,7 @@
     </sort-dropdown>
     <a class="top-bar__btn"
        ng-click="vm.onSharePage()"
+       ng-if="vm.showSharePageButton()"
        title="Share this page">
       <i class="h-icon-annotation-share"></i>
     </a>

--- a/src/sidebar/util/is-third-party-service.js
+++ b/src/sidebar/util/is-third-party-service.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const serviceConfig = require('../service-config');
+
+/**
+ * Return `true` if the first configured service is a "third-party" service.
+ *
+ * Return `true` if the first custom annotation service configured in the
+ * services array in the host page is a third-party service, `false` otherwise.
+ *
+ * If no custom annotation services are configured then return `false`.
+ *
+ * @param {Object} settings - the sidebar settings object
+ *
+ */
+function isThirdPartyService(settings) {
+  const service = serviceConfig(settings);
+
+  if (service === null) {
+    return false;
+  }
+
+  if (!service.hasOwnProperty('authority')) {
+    return false;
+  }
+
+  return (service.authority !== settings.authDomain);
+}
+
+module.exports = isThirdPartyService;

--- a/src/sidebar/util/test/is-third-party-service-test.js
+++ b/src/sidebar/util/test/is-third-party-service-test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const proxyquire = require('proxyquire');
+
+describe('sidebar.util.isThirdPartyService', () => {
+  let fakeServiceConfig;
+  let fakeSettings;
+  let isThirdPartyService;
+
+  beforeEach(() => {
+    fakeServiceConfig = sinon.stub();
+    fakeSettings = {authDomain: 'hypothes.is'};
+
+    isThirdPartyService = proxyquire('../is-third-party-service', {
+      '../service-config': fakeServiceConfig,
+      '@noCallThru': true,
+    });
+  });
+
+  it('returns false for first-party services', () => {
+    fakeServiceConfig.returns({authority: 'hypothes.is'});
+
+    assert.isFalse(isThirdPartyService(fakeSettings));
+  });
+
+  it('returns true for third-party services', () => {
+    fakeServiceConfig.returns({authority: 'elifesciences.org'});
+
+    assert.isTrue(isThirdPartyService(fakeSettings));
+  });
+
+  it("returns false if there's no service config", () => {
+    fakeServiceConfig.returns(null);
+
+    assert.isFalse(isThirdPartyService(fakeSettings));
+  });
+
+  // It's not valid for a service config object to not contain an authority
+  // (authority is a required field) but at the time of writing the config
+  // isn't validated when it's read in, so make sure that isThirdPartyService()
+  // handles invalid configs.
+  it("returns false if the service config doesn't contain an authority", () => {
+    fakeServiceConfig.returns({});
+
+    assert.isFalse(isThirdPartyService(fakeSettings));
+  });
+});


### PR DESCRIPTION
Don't show the "Share this page" button in the top-right of the sidebar
on pages, such as eLife's, that have both an embedded Hypothesis client
and a services config including their own `authority` string.

The "Share this page" button is a Via link, and Via doesn't work with
pages using a third-party authority config.

Fixes https://github.com/hypothesis/client/issues/615

On first-party sites, e.g. localhost:3000, share button still shows:

![screenshot from 2017-12-05 18-48-55](https://user-images.githubusercontent.com/22498/33624695-13e23038-d9ed-11e7-85b4-68e20185a07a.png)

On third-party sites, e.g. publisher test site, no share button:

![screenshot from 2017-12-05 18-49-17](https://user-images.githubusercontent.com/22498/33624705-1e8ca4e6-d9ed-11e7-81e6-56a804e87674.png)
