### PR TITLE
Don’t link tags to activity pages on eLife

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -444,6 +444,9 @@ function AnnotationController(
   };
 
   this.tagSearchURL = function(tag) {
+    if (this.isThirdPartyUser()) {
+      return null;
+    }
     return serviceUrl('search.tag', {tag: tag});
   };
 

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -1071,10 +1071,10 @@ describe('annotation', function() {
       beforeEach('make serviceUrl() return a URL for the tag', function() {
         fakeServiceUrl
           .withArgs('search.tag', {tag: 'atag'})
-          .returns('https://test.hypothes.is/stream?q=tag:atag');
+          .returns('https://hypothes.is/search?q=tag:atag');
       });
 
-      /*
+      /**
        * Return an annotation directive with a single tag.
        */
       function annotationWithOneTag() {
@@ -1100,10 +1100,10 @@ describe('annotation', function() {
           fakeAccountID.isThirdPartyUser.returns(false);
         });
 
-        it('displays links to tags on the stream', function () {
+        it('displays links to tag search pages', function () {
           var tagLink = tagLinkFrom(annotationWithOneTag());
 
-          assert.equal(tagLink.href, 'https://test.hypothes.is/stream?q=tag:atag');
+          assert.equal(tagLink.href, 'https://hypothes.is/search?q=tag:atag');
         });
       });
 


### PR DESCRIPTION
Depends on https://github.com/hypothesis/client/pull/622

Tags are still links on localhost:3000:

![peek 2017-12-06 15-26](https://user-images.githubusercontent.com/22498/33669333-165296ac-da9a-11e7-86c4-159000fda4f5.gif)

But on localhost:5050 they look the same but aren't linked:

![peek 2017-12-06 15-27](https://user-images.githubusercontent.com/22498/33669352-25bd0bfe-da9a-11e7-917b-8ce62fa36d1e.gif)

You still get the "clickable" cursor when hovering over a tag but I don't think this is to do with the tags - the entire bottom area of the annotation card has a clickable cursor (and clicking does nothing).

Fixes https://github.com/hypothesis/client/issues/616