### PR TITLE
Bundle the clean theme related config options into the theme = 'clean…

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -18,14 +18,7 @@ function configFrom(window_) {
     // URL of the client's boot script. Used when injecting the client into
     // child iframes.
     clientUrl: settings.clientUrl,
-    disableToolbarCloseBtn:settings.hostPageSetting('disableToolbarCloseBtn', {defaultValue: true}),
-    disableToolbarMinimizeBtn: settings.hostPageSetting('disableToolbarMinimizeBtn'),
-    disableToolbarHighlightsBtn: settings.hostPageSetting('disableToolbarHighlightsBtn'),
-    disableToolbarNewNoteBtn: settings.hostPageSetting('disableToolbarNewNoteBtn'),
-    disableBucketBar: settings.hostPageSetting('disableBucketBar'),
-    enableCleanOnboardingTheme: settings.hostPageSetting('enableCleanOnboardingTheme'),
     enableExperimentalNewNoteButton: settings.hostPageSetting('enableExperimentalNewNoteButton'),
-    enableSidebarDropShadow: settings.hostPageSetting('enableSidebarDropShadow'),
     theme: settings.hostPageSetting('theme'),
     usernameUrl: settings.hostPageSetting('usernameUrl'),
     onLayoutChange: settings.hostPageSetting('onLayoutChange'),

--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -45,7 +45,7 @@ module.exports = class Host extends Guest
     .css('display', 'none')
     .addClass('annotator-frame annotator-outer')
 
-    if config.enableSidebarDropShadow
+    if config.theme == 'clean'
       @frame.addClass('annotator-frame--drop-shadow-enabled')
 
     @frame.appendTo(element)

--- a/src/annotator/main.js
+++ b/src/annotator/main.js
@@ -59,7 +59,7 @@ $.noConflict(true)(function() {
     window.__hypothesis_frame = true;
   }
 
-  if(config.disableBucketBar) {
+  if(config.theme === 'clean') {
     delete pluginClasses.BucketBar;
   }
 

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -36,15 +36,10 @@ module.exports = class Sidebar extends Host
 
     if @plugins.Toolbar?
       @toolbarWidth = @plugins.Toolbar.getWidth()
-
-      if config.disableToolbarMinimizeBtn
+      if config.theme == 'clean'
         @plugins.Toolbar.disableMinimizeBtn()
-      if config.disableToolbarHighlightsBtn
         @plugins.Toolbar.disableHighlightsBtn()
-      if config.disableToolbarNewNoteBtn
         @plugins.Toolbar.disableNewNoteBtn()
-      if config.disableToolbarCloseBtn
-        @plugins.Toolbar.disableCloseBtn()
 
       this._setupGestures()
 

--- a/src/annotator/test/host-test.coffee
+++ b/src/annotator/test/host-test.coffee
@@ -81,6 +81,6 @@ describe 'Host', ->
       configStr = encodeURIComponent(JSON.stringify({annotations: '1234'}))
       assert.equal(host.frame[0].children[0].src, appURL + '?config=' + configStr)
 
-    it 'adds drop shadow if in enableSidebarDropShadow', ->
-      host = createHost({enableSidebarDropShadow: true})
+    it 'adds drop shadow if the clean theme is enabled', ->
+      host = createHost({theme: 'clean'})
       assert.isTrue(host.frame.hasClass('annotator-frame--drop-shadow-enabled'))

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -278,25 +278,20 @@ describe 'Sidebar', ->
 
   context 'Hide toolbar buttons', ->
 
-    it 'disables minimize btn', ->
-      sidebar = createSidebar(config={disableToolbarMinimizeBtn: true})
+    it 'disables minimize btn for the clean theme', ->
+      sidebar = createSidebar(config={theme: 'clean'})
 
       assert.called(sidebar.plugins.Toolbar.disableMinimizeBtn)
 
-    it 'disables minimize btn', ->
-      sidebar = createSidebar(config={disableToolbarHighlightsBtn: true})
+    it 'disables toolbar highlights btn for the clean theme', ->
+      sidebar = createSidebar(config={theme: 'clean'})
 
       assert.called(sidebar.plugins.Toolbar.disableHighlightsBtn)
 
-    it 'disables minimize btn', ->
-      sidebar = createSidebar(config={disableToolbarNewNoteBtn: true})
+    it 'disables new note btn for the clean theme', ->
+      sidebar = createSidebar(config={theme: 'clean'})
 
       assert.called(sidebar.plugins.Toolbar.disableNewNoteBtn)
-
-    it 'disables minimize btn', ->
-      sidebar = createSidebar(config={disableToolbarCloseBtn: true})
-
-      assert.called(sidebar.plugins.Toolbar.disableCloseBtn)
 
 
   describe 'layout change notifier', ->

--- a/src/sidebar/components/sidebar-tutorial.js
+++ b/src/sidebar/components/sidebar-tutorial.js
@@ -2,7 +2,7 @@
 
 // @ngInject
 function SidebarTutorialController(session, settings) {
-  this.cleanOnboardingThemeEnabled = settings.enableCleanOnboardingTheme;
+  this.isThemeClean = settings.theme === 'clean';
 
   this.showSidebarTutorial = function () {
     if (session.state.preferences) {

--- a/src/sidebar/components/test/sidebar-tutorial-test.js
+++ b/src/sidebar/components/test/sidebar-tutorial-test.js
@@ -5,7 +5,7 @@ var Controller = require('../sidebar-tutorial').controller;
 describe('SidebarTutorialController', function () {
 
   describe('showSidebarTutorial', function () {
-    var settings = { enableCleanOnboardingTheme: true };
+    var settings = { theme: 'theme' };
 
     it('returns true if show_sidebar_tutorial is true', function () {
       var session = {

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -35,9 +35,6 @@ function hostPageConfig(window) {
     // This should be removed once new note button is enabled for everybody.
     'enableExperimentalNewNoteButton',
 
-    // New onboarding theme override.
-    'enableCleanOnboardingTheme',
-
     // Theme which can either be specified as 'clean'.
     // If nothing is the specified the classic look is applied.
     'theme',

--- a/src/sidebar/templates/sidebar-tutorial.html
+++ b/src/sidebar/templates/sidebar-tutorial.html
@@ -1,4 +1,4 @@
-<div class="sheet" ng-if="vm.showSidebarTutorial() &&  !vm.cleanOnboardingThemeEnabled">
+<div class="sheet" ng-if="vm.showSidebarTutorial() &&  !vm.isThemeClean">
   <i class="close h-icon-close" role="button" title="Close"
      ng-click="vm.dismiss()"></i>
   <h1 class="sidebar-tutorial__header">How to get started</h1>
@@ -41,7 +41,7 @@
     </li>
   </ol>
 </div>
-<div class="sheet sheet--is-theme-clean" ng-if="vm.showSidebarTutorial() && vm.cleanOnboardingThemeEnabled">
+<div class="sheet sheet--is-theme-clean" ng-if="vm.showSidebarTutorial() && vm.isThemeClean">
   <i class="close h-icon-close" role="button" title="Close"
      ng-click="vm.dismiss()"></i>
   <h1 class="sidebar-tutorial__header sidebar-tutorial__header--is-theme-clean">


### PR DESCRIPTION
…' setting.

Some of the config settings don't work well with the clean theme. Some others don't work
without the clean theme. It would be better to remove the following config options and
have each of these elements tied to the over all 'theme' of the sidebar for consistency:
disableToolbarCloseBtn
disableToolbarMinimizeBtn
disableToolbarHighlightsBtn
disableToolbarNewNoteBtn
disableBucketBar
enableSidebarDropShadow
enableCleanOnboardingTheme

See https://github.com/hypothesis/product-backlog/issues/380