### PR TITLE
Hide banner for third party users

### DIFF
--- a/src/sidebar/app.js
+++ b/src/sidebar/app.js
@@ -136,6 +136,7 @@ module.exports = angular.module('h', [
   .component('annotationShareDialog', require('./components/annotation-share-dialog'))
   .component('annotationThread', require('./components/annotation-thread'))
   .component('annotationViewerContent', require('./components/annotation-viewer-content'))
+  .component('createAccountBanner', require('./components/create-account-banner'))
   .component('dropdownMenuBtn', require('./components/dropdown-menu-btn'))
   .component('excerpt', require('./components/excerpt'))
   .component('groupList', require('./components/group-list'))

--- a/src/sidebar/components/create-account-banner.js
+++ b/src/sidebar/components/create-account-banner.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// @ngInject
+function CreateAccountBannerController(serviceUrl) {
+  this.serviceUrl = serviceUrl;
+}
+
+module.exports = {
+  controller: CreateAccountBannerController,
+  controllerAs: 'vm',
+  bindings: {
+    onLogin: '&',
+  },
+  template: require('../templates/create-account-banner.html'),
+};

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -179,6 +179,13 @@ function HypothesisAppController(
 
   this.countPendingUpdates = streamer.countPendingUpdates;
   this.applyPendingUpdates = streamer.applyPendingUpdates;
+
+  this.shouldShowBanner = () => {
+    if (!this.isSidebar || this.auth.status === 'logged-in') {
+      return false;
+    }
+    return true;
+  };
 }
 
 module.exports = {

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -184,6 +184,9 @@ function HypothesisAppController(
     if (!this.isSidebar || this.auth.status === 'logged-in') {
       return false;
     }
+    if (serviceConfig(settings)) {
+      return false;
+    }
     return true;
   };
 }

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -558,5 +558,16 @@ describe('sidebar.components.hypothesis-app', function () {
         assert.isFalse(ctrl.shouldShowBanner());
       });
     });
+
+    it('returns false when the annotation service uses third-party accounts', () => {
+      fakeServiceConfig.returns({});
+      fakeSession.load = () => Promise.resolve({ userid: null });
+
+      var ctrl = createController();
+
+      return fakeSession.load().then(() => {
+        assert.isFalse(ctrl.shouldShowBanner());
+      });
+    });
   });
 });

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -532,4 +532,31 @@ describe('sidebar.components.hypothesis-app', function () {
       });
     });
   });
+
+  describe('#shouldShowBanner', () => {
+    it('returns false in the stream', () => {
+      fakeWindow.top = fakeWindow;
+      fakeSession.load = () => Promise.resolve({ userid: null });
+      var ctrl = createController();
+      return fakeSession.load().then(() => {
+        assert.isFalse(ctrl.shouldShowBanner());
+      });
+    });
+
+    it('returns true if user is logged out', () => {
+      fakeSession.load = () => Promise.resolve({ userid: null });
+      var ctrl = createController();
+      return fakeSession.load().then(() => {
+        assert.isTrue(ctrl.shouldShowBanner());
+      });
+    });
+
+    it('returns false if user is logged in', () => {
+      fakeSession.load = () => Promise.resolve({ userid: 'acct:jim@hypothes.is' });
+      var ctrl = createController();
+      return fakeSession.load().then(() => {
+        assert.isFalse(ctrl.shouldShowBanner());
+      });
+    });
+  });
 });

--- a/src/sidebar/templates/create-account-banner.html
+++ b/src/sidebar/templates/create-account-banner.html
@@ -1,0 +1,7 @@
+<div class="create-account-banner">
+  To annotate this document
+  <a href="{{ vm.serviceUrl('signup') }}" target="_blank">
+    create a free account
+  </a>
+  or <a href="" ng-click="vm.onLogin()">log in</a>
+</div>

--- a/src/sidebar/templates/hypothesis-app.html
+++ b/src/sidebar/templates/hypothesis-app.html
@@ -15,13 +15,9 @@
     on-change-sort-key="vm.setSortKey(sortKey)">
   </top-bar>
 
-  <div class="create-account-banner" ng-if="vm.isSidebar && vm.auth.status === 'logged-out'">
-    To annotate this document
-    <a href="{{ vm.serviceUrl('signup') }}" target="_blank">
-      create a free account
-    </a>
-    or <a href="" ng-click="vm.login()">log in</a>
-  </div>
+  <create-account-banner
+    ng-if="vm.isSidebar && vm.auth.status === 'logged-out'"
+    on-login="vm.login()"></create-account-banner>
 
   <div class="content">
     <sidebar-tutorial ng-if="vm.isSidebar"></sidebar-tutorial>

--- a/src/sidebar/templates/hypothesis-app.html
+++ b/src/sidebar/templates/hypothesis-app.html
@@ -16,7 +16,7 @@
   </top-bar>
 
   <create-account-banner
-    ng-if="vm.isSidebar && vm.auth.status === 'logged-out'"
+    ng-if="vm.shouldShowBanner()"
     on-login="vm.login()"></create-account-banner>
 
   <div class="content">

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -11,6 +11,7 @@ $base-line-height: 20px;
 @import './annotation';
 @import './annotation-share-dialog';
 @import './annotation-thread';
+@import './create-account-banner';
 @import './dropdown-menu-btn';
 @import './excerpt';
 @import './group-list';
@@ -87,24 +88,6 @@ hypothesis-app {
 
 // Elements in root template (viewer.html)
 // ---------------------------------------
-
-.create-account-banner {
-  background-color: $gray-dark;
-  border-radius: 2px;
-  color: $color-silver-chalice;
-  font-weight: bold;
-  height: 34px;
-  line-height: 34px;
-  margin-bottom: .72em;
-  margin-left: auto;
-  margin-right: auto;
-  text-align: center;
-  width: 100%;
-}
-
-.create-account-banner a {
-  color: $white;
-}
 
 .sheet {
   border: solid 1px $gray-lighter;

--- a/src/styles/create-account-banner.scss
+++ b/src/styles/create-account-banner.scss
@@ -1,0 +1,17 @@
+.create-account-banner {
+  background-color: $gray-dark;
+  border-radius: 2px;
+  color: $color-silver-chalice;
+  font-weight: bold;
+  height: 34px;
+  line-height: 34px;
+  margin-bottom: .72em;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+  width: 100%;
+}
+
+.create-account-banner a {
+  color: $white;
+}


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/627**

This hides the "To annotate, create a free account or log in" banner on pages that use third-party accounts.