### PR TITLE
Remove create account banner

### DIFF
--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -57,8 +57,6 @@ function HypothesisAppController(
     frameSync.connect();
   }
 
-  this.serviceUrl = serviceUrl;
-
   this.sortKey = function () {
     return annotationUI.getState().sortKey;
   };

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -265,11 +265,6 @@ describe('sidebar.components.hypothesis-app', function () {
     });
   });
 
-  it('exposes the serviceUrl on the controller', function () {
-    var ctrl = createController();
-    assert.equal(ctrl.serviceUrl, fakeServiceUrl);
-  });
-
   it('does not show the share dialog at start', function () {
     var ctrl = createController();
     assert.isFalse(ctrl.shareDialog.visible);

--- a/src/sidebar/templates/hypothesis-app.html
+++ b/src/sidebar/templates/hypothesis-app.html
@@ -15,14 +15,6 @@
     on-change-sort-key="vm.setSortKey(sortKey)">
   </top-bar>
 
-  <div class="create-account-banner" ng-if="vm.isSidebar && vm.auth.status === 'logged-out'">
-    To annotate this document
-    <a href="{{ vm.serviceUrl('signup') }}" target="_blank">
-      create a free account
-    </a>
-    or <a href="" ng-click="vm.login()">log in</a>
-  </div>
-
   <div class="content">
     <sidebar-tutorial ng-if="vm.isSidebar"></sidebar-tutorial>
     <share-dialog

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -88,24 +88,6 @@ hypothesis-app {
 // Elements in root template (viewer.html)
 // ---------------------------------------
 
-.create-account-banner {
-  background-color: $gray-dark;
-  border-radius: 2px;
-  color: $color-silver-chalice;
-  font-weight: bold;
-  height: 34px;
-  line-height: 34px;
-  margin-bottom: .72em;
-  margin-left: auto;
-  margin-right: auto;
-  text-align: center;
-  width: 100%;
-}
-
-.create-account-banner a {
-  color: $white;
-}
-
 .sheet {
   border: solid 1px $gray-lighter;
   border-radius: 2px;


### PR DESCRIPTION
The text is potentially inappropriate in the context of publisher-managed accounts where the account might not be free and the user might not be able to create one themselves.
    
In the first party account context we agreed that the banner is a bit redundant anyway. See https://hypothes-is.slack.com/archives/C07NXBDNW/p1510080494000386