### PR TITLE
Rename JS bundles to match corresponding source directory

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,13 +105,13 @@ var appBundles = [{
   transforms: ['babel'],
 },{
   // The sidebar application for displaying and editing annotations.
-  name: 'app',
+  name: 'sidebar',
   transforms: ['babel', 'coffee'],
   entry: './src/sidebar/index',
 },{
   // The annotation layer which handles displaying highlights, presenting
   // annotation tools on the page and instantiating the sidebar application.
-  name: 'injector',
+  name: 'annotator',
   entry: './src/annotator/index',
   transforms: ['babel', 'coffee'],
 }];

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -65,7 +65,7 @@ function bootHypothesisClient(doc, config) {
     'scripts/jquery.bundle.js',
 
     // Main entry point for the client
-    'scripts/injector.bundle.js',
+    'scripts/annotator.bundle.js',
 
     'styles/icomoon.css',
     'styles/annotator.css',
@@ -87,7 +87,7 @@ function bootSidebarApp(doc, config) {
     'scripts/unorm.bundle.js',
 
     // The sidebar app
-    'scripts/app.bundle.js',
+    'scripts/sidebar.bundle.js',
 
     'styles/angular-csp.css',
     'styles/angular-toastr.css',

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -19,7 +19,7 @@ describe('bootstrap', function () {
       // Annotation layer
       'scripts/polyfills.bundle.js',
       'scripts/jquery.bundle.js',
-      'scripts/injector.bundle.js',
+      'scripts/annotator.bundle.js',
       'styles/annotator.css',
       'styles/icomoon.css',
       'styles/pdfjs-overrides.css',
@@ -31,7 +31,7 @@ describe('bootstrap', function () {
       'scripts/showdown.bundle.js',
       'scripts/polyfills.bundle.js',
       'scripts/unorm.bundle.js',
-      'scripts/app.bundle.js',
+      'scripts/sidebar.bundle.js',
 
       'styles/angular-csp.css',
       'styles/angular-toastr.css',
@@ -70,7 +70,7 @@ describe('bootstrap', function () {
     it('loads assets for the annotation layer', function () {
       runBoot();
       var expectedAssets = [
-        'scripts/injector.bundle.1234.js',
+        'scripts/annotator.bundle.1234.js',
         'scripts/jquery.bundle.1234.js',
         'scripts/polyfills.bundle.1234.js',
         'styles/annotator.1234.css',
@@ -119,11 +119,11 @@ describe('bootstrap', function () {
       runBoot();
       var expectedAssets = [
         'scripts/angular.bundle.1234.js',
-        'scripts/app.bundle.1234.js',
         'scripts/katex.bundle.1234.js',
         'scripts/polyfills.bundle.1234.js',
         'scripts/raven.bundle.1234.js',
         'scripts/showdown.bundle.1234.js',
+        'scripts/sidebar.bundle.1234.js',
         'scripts/unorm.bundle.1234.js',
         'styles/angular-csp.1234.css',
         'styles/angular-toastr.1234.css',


### PR DESCRIPTION
This is part of a series of PRs to address some low hanging fruit to hopefully make it easier for newcomers to find their way around the client code.

Rename the "injector" and "app" bundles to "annotator" and "sidebar"
respectively to match the source directory which produces those bundles.