### PR TITLE
Add new config option that scopes annotation sync to just sub frames

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -30,6 +30,7 @@ function configFrom(window_) {
     // Subframe identifier given when a frame is being embedded into
     // by a top level client
     subFrameIdentifier: settings.hostPageSetting('subFrameIdentifier', {allowInBrowserExt: true}),
+    onlySubFrameAnnotations: settings.hostPageSetting('onlySubFrameAnnotations', {allowInBrowserExt: true}),
   };
 }
 

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -55,6 +55,7 @@ module.exports = class Guest extends Delegator
   anchors: null
   visibleHighlights: false
   frameIdentifier: null
+  onlyTargetsSubFrame: false
 
   html:
     adder: '<hypothesis-adder></hypothesis-adder>'
@@ -88,6 +89,8 @@ module.exports = class Guest extends Delegator
     # The "top" guest instance will have this as null since it's in a top frame not a sub frame
     this.frameIdentifier = config.subFrameIdentifier || null
 
+    this.onlyTargetsSubFrame = !config.subFrameIdentifier && config.onlySubFrameAnnotations
+
     cfOptions =
       config: config
       on: (event, handler) =>
@@ -99,7 +102,10 @@ module.exports = class Guest extends Delegator
     @crossframe = this.plugins.CrossFrame
 
     @crossframe.onConnect(=> this._setupInitialState(config))
-    this._connectAnnotationSync(@crossframe)
+
+    if !this.onlyTargetsSubFrame
+      this._connectAnnotationSync(@crossframe)
+
     this._connectAnnotationUISync(@crossframe)
 
     # Load plugins
@@ -412,6 +418,9 @@ module.exports = class Guest extends Delegator
     @crossframe?.call('focusAnnotations', tags)
 
   _onSelection: (range) ->
+    if this.onlyTargetsSubFrame 
+      return
+      
     selection = document.getSelection()
     isBackwards = rangeUtil.isSelectionBackwards(selection)
     focusRect = rangeUtil.selectionFocusRect(selection)


### PR DESCRIPTION
This introduces a new config option `onlySubFrameAnnotations`

This is helpful when using multi-frame support. In some cases, annotating content should only happen at the sub frame level. If similar content is being annotated at either the sub frame level or the top frame level, the anchoring of annotations may not work as intended.

Please see #631 for more details.

When this config is used, it conditionally disables the `_connectAnnotationSync` handler and the `_onSelection` handler.

This relates to the ePub support for the NYU-Readium reader.