### PR TITLE
Update reference to annotator CSS bundle.

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -90,7 +90,7 @@ function createAdderDOM(container) {
     var adderStyles = Array.from(document.styleSheets).map(function (sheet) {
       return sheet.href;
     }).filter(function (url) {
-      return (url || '').match(/(icomoon|inject)\.css/);
+      return (url || '').match(/(icomoon|annotator)\.css/);
     });
 
     // Stylesheet <link> elements are inert inside shadow roots [1]. Until


### PR DESCRIPTION
`adder.js` contains a reference to the main CSS bundle generated from
src/styles/annotator which was not updated when the CSS bundle's name
was changed in f0b61e6a043e867a7480f5c51b03ea59bc84c307

We ought to rework how this reference works to make it less hidden, but this is a minimal change so we can get a patch release out quickly.