### PR TITLE
Fix login flow triggering popup blocker in Firefox and IE

### DIFF
--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -255,8 +255,9 @@ function auth($http, $rootScope, $window, OAuthClient,
    * then exchange for access and refresh tokens.
    */
   function login() {
+    var authWindow = OAuthClient.createLoginPopupWindow($window);
     return oauthClient().then(client => {
-      return client.authorize($window);
+      return client.authorize($window, authWindow);
     }).then(code => {
       // Save the auth code. It will be exchanged for an access token when the
       // next API request is made.

--- a/src/sidebar/oauth-auth.js
+++ b/src/sidebar/oauth-auth.js
@@ -255,7 +255,7 @@ function auth($http, $rootScope, $window, OAuthClient,
    * then exchange for access and refresh tokens.
    */
   function login() {
-    var authWindow = OAuthClient.createLoginPopupWindow($window);
+    var authWindow = OAuthClient.openAuthPopupWindow($window);
     return oauthClient().then(client => {
       return client.authorize($window, authWindow);
     }).then(code => {

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -12,6 +12,7 @@ var TOKEN_KEY = 'hypothesis.oauth.hypothes%2Eis.token';
 describe('sidebar.oauth-auth', function () {
 
   var $rootScope;
+  var FakeOAuthClient;
   var auth;
   var nowStub;
   var fakeApiRoutes;
@@ -83,6 +84,13 @@ describe('sidebar.oauth-auth', function () {
       authorize: sinon.stub().returns(Promise.resolve(null)),
     };
 
+    FakeOAuthClient = ($http, config) => {
+      fakeClient.$http = $http;
+      fakeClient.config = config;
+      return fakeClient;
+    };
+    FakeOAuthClient.createLoginPopupWindow = sinon.stub();
+
     fakeWindow = new FakeWindow;
 
     fakeHttp = {};
@@ -94,11 +102,7 @@ describe('sidebar.oauth-auth', function () {
       flash: fakeFlash,
       localStorage: fakeLocalStorage,
       settings: fakeSettings,
-      OAuthClient: ($http, config) => {
-        fakeClient.$http = $http;
-        fakeClient.config = config;
-        return fakeClient;
-      },
+      OAuthClient: FakeOAuthClient,
     });
 
     angular.mock.inject((_auth_, _$rootScope_) => {
@@ -499,8 +503,10 @@ describe('sidebar.oauth-auth', function () {
     });
 
     it('calls OAuthClient#authorize', () => {
+      var fakePopup = {};
+      FakeOAuthClient.createLoginPopupWindow.returns(fakePopup);
       return auth.login().then(() => {
-        assert.calledWith(fakeClient.authorize, fakeWindow);
+        assert.calledWith(fakeClient.authorize, fakeWindow, fakePopup);
       });
     });
 

--- a/src/sidebar/test/oauth-auth-test.js
+++ b/src/sidebar/test/oauth-auth-test.js
@@ -89,7 +89,7 @@ describe('sidebar.oauth-auth', function () {
       fakeClient.config = config;
       return fakeClient;
     };
-    FakeOAuthClient.createLoginPopupWindow = sinon.stub();
+    FakeOAuthClient.openAuthPopupWindow = sinon.stub();
 
     fakeWindow = new FakeWindow;
 
@@ -504,7 +504,7 @@ describe('sidebar.oauth-auth', function () {
 
     it('calls OAuthClient#authorize', () => {
       var fakePopup = {};
-      FakeOAuthClient.createLoginPopupWindow.returns(fakePopup);
+      FakeOAuthClient.openAuthPopupWindow.returns(fakePopup);
       return auth.login().then(() => {
         assert.calledWith(fakeClient.authorize, fakeWindow, fakePopup);
       });

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -153,7 +153,7 @@ class OAuthClient {
    *
    * @param {Window} $window - Window which will receive the auth response.
    * @param {Window} authWindow - Popup window where the login prompt will be shown.
-   *   This should be created using `createLoginPopupWindow`.
+   *   This should be created using `openAuthPopupWindow`.
    * @return {Promise<string>}
    */
   authorize($window, authWindow) {
@@ -214,17 +214,17 @@ class OAuthClient {
   }
 
   /**
-   * Create a pop-up window for use with `OAuthClient#authorize`.
+   * Create and show a pop-up window for use with `OAuthClient#authorize`.
    *
    * This function _must_ be called in the same turn of the event loop as the
    * button or link which initiates login to avoid triggering the popup blocker
    * in certain browsers. See https://github.com/hypothesis/client/issues/534
    * and https://github.com/hypothesis/client/issues/535.
    *
-   * @param {Window} $window - The parent of the popup window.
-   * @return {Window}
+   * @param {Window} $window - The parent of the created window.
+   * @return {Window} The new popup window.
    */
-  static createLoginPopupWindow($window) {
+  static openAuthPopupWindow($window) {
     // In Chrome & Firefox the sizes passed to `window.open` are used for the
     // viewport size. In Safari the size is used for the window size including
     // title bar etc. There is enough vertical space at the bottom to allow for

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -245,7 +245,7 @@ class OAuthClient {
       height: height,
     }).replace(/&/g, ',');
 
-    return $window.open('about:blank', 'Login to Hypothesis', authWindowSettings);
+    return $window.open('about:blank', 'Log in to Hypothesis', authWindowSettings);
   }
 }
 

--- a/src/sidebar/util/test/oauth-client-test.js
+++ b/src/sidebar/util/test/oauth-client-test.js
@@ -162,10 +162,10 @@ describe('sidebar.util.oauth-client', () => {
     });
   });
 
-  describe('.createLoginPopupWindow', () => {
-    it('creates and returns the popup window', () => {
+  describe('.openAuthPopupWindow', () => {
+    it('opens a popup window', () => {
       var fakeWindow = new FakeWindow;
-      var popupWindow = OAuthClient.createLoginPopupWindow(fakeWindow);
+      var popupWindow = OAuthClient.openAuthPopupWindow(fakeWindow);
       assert.equal(popupWindow, fakeWindow.open.returnValues[0]);
       assert.calledWith(
         fakeWindow.open,
@@ -184,7 +184,7 @@ describe('sidebar.util.oauth-client', () => {
     });
 
     function authorize() {
-      var popupWindow = OAuthClient.createLoginPopupWindow(fakeWindow);
+      var popupWindow = OAuthClient.openAuthPopupWindow(fakeWindow);
       var authorized = client.authorize(fakeWindow, popupWindow);
       return { authorized, popupWindow };
     }

--- a/src/sidebar/util/test/oauth-client-test.js
+++ b/src/sidebar/util/test/oauth-client-test.js
@@ -170,7 +170,7 @@ describe('sidebar.util.oauth-client', () => {
       assert.calledWith(
         fakeWindow.open,
         'about:blank',
-        'Login to Hypothesis',
+        'Log in to Hypothesis',
         'height=430,left=274.5,top=169,width=475'
       );
     });


### PR DESCRIPTION
hypothesis/client#603 broke the login popup window in Firefox and IE
because the call to `window.open` no longer happens in the same turn of
the event loop as the user's click on the "Login" link. It is therefore
no longer considered in FF to have happened "in response to a user
gesture".

This PR fixes the issue by separating creation and use of the popup
window into separate functions and moving creation to happen earlier, in
the same event loop turn as the "Login" button click.

Fixes #534

The browser behaviour here is something that I think ought to be clarified in the spec, so I filed https://bugzilla.mozilla.org/show_bug.cgi?id=1425419 and got linked to some related discussion in https://github.com/whatwg/html/issues/1903 