### PR TITLE
Add window.hypothesisConfig props to settings on client boot. Fix #652

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -23,6 +23,7 @@ function configFrom(window_) {
     usernameUrl: settings.hostPageSetting('usernameUrl'),
     onLayoutChange: settings.hostPageSetting('onLayoutChange'),
     openSidebar: settings.hostPageSetting('openSidebar', {allowInBrowserExt: true}),
+    alwaysOpen: settings.hostPageSetting('alwaysOpen'),
     query: settings.query,
     services: settings.hostPageSetting('services'),
     showHighlights: settings.showHighlights,

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -446,7 +446,7 @@ module.exports = class Guest extends Delegator
       this.showAnnotations annotations
 
   onElementClick: (event) ->
-    if !@selectedTargets?.length
+    if !@selectedTargets?.length && !@crossframe.options.config.alwaysOpen
       @crossframe?.call('hideSidebar')
 
   onElementTouchStart: (event) ->
@@ -455,7 +455,7 @@ module.exports = class Guest extends Delegator
     # adding that to every element, we can add the initial
     # touchstart event which is always registered to
     # make up for the lack of click support for all elements.
-    if !@selectedTargets?.length
+    if !@selectedTargets?.length && !@crossframe.options.config.alwaysOpen
       @crossframe?.call('hideSidebar')
 
   onHighlightMouseover: (event) ->

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -12,10 +12,12 @@
 /* global __MANIFEST__ */
 
 var boot = require('./boot');
-var settings = require('../shared/settings').jsonConfigsFrom(document);
+var settings = require('../shared/settings');
+
+var config = settings.jsonConfigsFromWindow(settings.jsonConfigsFrom(document));
 
 boot(document, {
-  assetRoot: settings.assetRoot || '__ASSET_ROOT__',
+  assetRoot: config.assetRoot || '__ASSET_ROOT__',
   manifest: __MANIFEST__,
-  sidebarAppUrl: settings.sidebarAppUrl || '__SIDEBAR_APP_URL__',
+  sidebarAppUrl: config.sidebarAppUrl || '__SIDEBAR_APP_URL__',
 });

--- a/src/shared/settings.js
+++ b/src/shared/settings.js
@@ -46,6 +46,33 @@ function jsonConfigsFrom(document) {
   return config;
 }
 
+/**
+ * Returns a `hypothesisConfig` object from the window, or `{}`.
+ *
+ * Find the `window.hypothesisConfig` object and merge the properties
+ * of it onto the config parameter passed in.
+ *
+ * If the `config` param doesn't exist, instantiate a new object.
+ *
+ * If the `window.hypothesisConfig` exists as a function and returns an
+ * object containing properties, add it to the return object.
+ *
+ * @param {HypothesisConfig} config - an existing config object.
+ * @returns {HypothesisConfig} - an updated config object.
+ */
+function jsonConfigsFromWindow(config) {
+  var config = config || {};
+
+  if (window && typeof window.hypothesisConfig === 'function') {
+    var windowConfig = window.hypothesisConfig();
+
+    if (windowConfig) assign(config, windowConfig);
+  }
+
+  return config;
+}
+
 module.exports = {
   jsonConfigsFrom: jsonConfigsFrom,
+  jsonConfigsFromWindow: jsonConfigsFromWindow
 };


### PR DESCRIPTION
Fixes an issue with `assetRoot` not being read if the property is set from the `window.hypothesisConfig` function.