### PR TITLE
Add script to initiate a client release

### DIFF
--- a/scripts/release-it
+++ b/scripts/release-it
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+SEMVER=./node_modules/.bin/semver
+CURRENT_VERSION=$(jq -r .version package.json)
+NEW_VERSION=$($SEMVER -i minor "$CURRENT_VERSION")
+yarn config set version-sign-git-tag true
+yarn version --new-version $NEW_VERSION


### PR DESCRIPTION
Add a script to handle creating a new client release using yarn,
ensuring that the Git tag is signed. Unfortunately yarn's default is for
this setting to be turned off. Also unlike `npm version`, `yarn version`
does not support automatically incrementing the package version.

This fixes an issue that Lyza and me ran into recently with the previous instructions to run `npm version minor` where `npm version` tries to re-add `package-lock.json` even though we are using yarn for the client and therefore don't have that file in the repo.