### PR TITLE
Hide the direct-link CTA for third party accounts

### DIFF
--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -2,6 +2,7 @@
 
 var SearchClient = require('../search-client');
 var events = require('../events');
+var isThirdPartyService = require('../util/is-third-party-service');
 var memoize = require('../util/memoize');
 var tabs = require('../tabs');
 var uiConstants = require('../ui-constants');
@@ -289,6 +290,12 @@ function SidebarContentController(
     // If user has not landed on a direct linked annotation
     // don't show the CTA.
     if (!settings.annotations) {
+      return false;
+    }
+
+    // The CTA text and links are only applicable when using Hypothesis
+    // accounts.
+    if (isThirdPartyService(settings)) {
       return false;
     }
 

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -506,6 +506,17 @@ describe('sidebar.components.sidebar-content', function () {
       $scope.$digest();
       assert.isFalse(ctrl.shouldShowLoggedOutMessage());
     });
+
+    it('does not show loggedout message if using third-party accounts', function () {
+      fakeSettings.services = [{ authority: 'publisher.com' }];
+      addFrame();
+      ctrl.auth = { status: 'logged-out' };
+      annotationUI.addAnnotations([{id: '123'}]);
+      annotationUI.selectAnnotations(['123']);
+      $scope.$digest();
+
+      assert.isFalse(ctrl.shouldShowLoggedOutMessage());
+    });
   });
 
   describe('deferred websocket connection', function () {


### PR DESCRIPTION
The CTA message shown when an anonymous user visits a direct link
contains links to the Hypothesis site and makes other assumptions, such
as the user being able to create accounts and those accounts being free,
which may not be applicable on sites that use third party accounts.

For now, just hide this CTA if the page uses third party accounts.

Fixes #656
Fixes #657

----

Example of inappropriate message with current released client:

<img width="503" alt="screenshot 2018-01-30 12 20 42" src="https://user-images.githubusercontent.com/2458/35566434-4bd49fba-05b9-11e8-8575-397551a5545a.png">
