### PR TITLE
Refactor export of bound selectors from Redux store

### DIFF
--- a/src/sidebar/annotation-ui.js
+++ b/src/sidebar/annotation-ui.js
@@ -109,23 +109,14 @@ module.exports = function ($rootScope, settings) {
   //   selection.isAnnotationSelected(annotationUI.getState(), id)
   // You can use:
   //   annotationUI.isAnnotationSelected(id)
-  var selectors = util.bindSelectors({
-    isAnnotationSelected: selectionReducer.isAnnotationSelected,
-    hasSelectedAnnotations: selectionReducer.hasSelectedAnnotations,
-
-    annotationExists: annotationsReducer.annotationExists,
-    findAnnotationByID: annotationsReducer.findAnnotationByID,
-    findIDsForTags: annotationsReducer.findIDsForTags,
-    savedAnnotations: annotationsReducer.savedAnnotations,
-
-    frames: framesReducer.frames,
-    searchUris: framesReducer.searchUris,
-
-    isSidebar: viewerReducer.isSidebar,
-
-    isFeatureEnabled: sessionReducer.isFeatureEnabled,
-    profile: sessionReducer.profile,
-  }, store.getState);
+  var selectors = util.bindSelectors(Object.assign({},
+    annotationsReducer.selectors,
+    framesReducer.selectors,
+    linksReducer.selectors,
+    selectionReducer.selectors,
+    sessionReducer.selectors,
+    viewerReducer.selectors
+  ), store.getState);
 
   return Object.assign(store, actionCreators, selectors);
 };

--- a/src/sidebar/reducers/annotations.js
+++ b/src/sidebar/reducers/annotations.js
@@ -389,9 +389,10 @@ module.exports = {
     unhideAnnotation: unhideAnnotation,
   },
 
-  // Selectors
-  annotationExists: annotationExists,
-  findAnnotationByID: findAnnotationByID,
-  findIDsForTags: findIDsForTags,
-  savedAnnotations: savedAnnotations,
+  selectors: {
+    annotationExists,
+    findAnnotationByID,
+    findIDsForTags,
+    savedAnnotations,
+  },
 };

--- a/src/sidebar/reducers/frames.js
+++ b/src/sidebar/reducers/frames.js
@@ -111,7 +111,8 @@ module.exports = {
     updateFrameAnnotationFetchStatus: updateFrameAnnotationFetchStatus,
   },
 
-  // Selectors
-  frames: frames,
-  searchUris: searchUris,
+  selectors: {
+    frames,
+    searchUris,
+  },
 };

--- a/src/sidebar/reducers/links.js
+++ b/src/sidebar/reducers/links.js
@@ -24,4 +24,5 @@ module.exports = {
   init:    init,
   update:  { UPDATE_LINKS: updateLinks },
   actions: { updateLinks: updateLinksAction },
+  selectors: {},
 };

--- a/src/sidebar/reducers/selection.js
+++ b/src/sidebar/reducers/selection.js
@@ -311,7 +311,8 @@ module.exports = {
     toggleSelectedAnnotations: toggleSelectedAnnotations,
   },
 
-  // Selectors
-  hasSelectedAnnotations: hasSelectedAnnotations,
-  isAnnotationSelected: isAnnotationSelected,
+  selectors: {
+    hasSelectedAnnotations,
+    isAnnotationSelected,
+  },
 };

--- a/src/sidebar/reducers/session.js
+++ b/src/sidebar/reducers/session.js
@@ -73,7 +73,8 @@ module.exports = {
     updateSession,
   },
 
-  // Selectors
-  isFeatureEnabled,
-  profile,
+  selectors: {
+    isFeatureEnabled,
+    profile,
+  },
 };

--- a/src/sidebar/reducers/test/annotations-test.js
+++ b/src/sidebar/reducers/test/annotations-test.js
@@ -9,7 +9,7 @@ var fixtures = require('../../test/annotation-fixtures');
 var util = require('../util');
 var unroll = require('../../../shared/test/util').unroll;
 
-var actions = annotations.actions;
+var { actions, selectors } = annotations;
 
 /**
  * Create a Redux store which only handles annotation actions.
@@ -26,7 +26,7 @@ function createStore() {
 
 describe('annotations reducer', function () {
   describe('#savedAnnotations', function () {
-    var savedAnnotations = annotations.savedAnnotations;
+    var savedAnnotations = selectors.savedAnnotations;
 
     it('returns annotations which are saved', function () {
       var state = {
@@ -37,7 +37,7 @@ describe('annotations reducer', function () {
   });
 
   describe('#findIDsForTags', function () {
-    var findIDsForTags = annotations.findIDsForTags;
+    var findIDsForTags = selectors.findIDsForTags;
 
     it('returns the IDs corresponding to the provided local tags', function () {
       var ann = fixtures.defaultAnnotation();
@@ -64,7 +64,7 @@ describe('annotations reducer', function () {
       store.dispatch(actions.addAnnotations([ann]));
       store.dispatch(actions.hideAnnotation(ann.id));
 
-      var storeAnn = annotations.findAnnotationByID(store.getState(), ann.id);
+      var storeAnn = selectors.findAnnotationByID(store.getState(), ann.id);
       assert.equal(storeAnn.hidden, true);
     });
   });
@@ -77,7 +77,7 @@ describe('annotations reducer', function () {
       store.dispatch(actions.addAnnotations([ann]));
       store.dispatch(actions.unhideAnnotation(ann.id));
 
-      var storeAnn = annotations.findAnnotationByID(store.getState(), ann.id);
+      var storeAnn = selectors.findAnnotationByID(store.getState(), ann.id);
       assert.equal(storeAnn.hidden, false);
     });
   });
@@ -92,7 +92,7 @@ describe('annotations reducer', function () {
       store.dispatch(actions.addAnnotations([ann]));
       store.dispatch(actions.updateFlagStatus(ann.id, testCase.nowFlagged));
 
-      var storeAnn = annotations.findAnnotationByID(store.getState(), ann.id);
+      var storeAnn = selectors.findAnnotationByID(store.getState(), ann.id);
       assert.equal(storeAnn.flagged, testCase.nowFlagged);
       assert.deepEqual(storeAnn.moderation, testCase.newModeration);
     }, [{

--- a/src/sidebar/reducers/test/frames-test.js
+++ b/src/sidebar/reducers/test/frames-test.js
@@ -7,6 +7,7 @@ var unroll = require('../../../shared/test/util').unroll;
 
 var actions = frames.actions;
 var update = util.createReducer(frames.update);
+var selectors = frames.selectors;
 
 function init() {
   return Object.assign({}, frames.init(), session.init());
@@ -17,7 +18,7 @@ describe('frames reducer', function () {
     it('adds the frame to the list of connected frames', function () {
       var frame = {uri: 'http://example.com'};
       var state = update(init(), actions.connectFrame(frame));
-      assert.deepEqual(frames.frames(state), [frame]);
+      assert.deepEqual(selectors.frames(state), [frame]);
     });
   });
 
@@ -28,9 +29,9 @@ describe('frames reducer', function () {
       frameList.forEach(function (frame) {
         state = update(state, actions.connectFrame(frame));
       });
-      assert.deepEqual(frames.frames(state), frameList);
+      assert.deepEqual(selectors.frames(state), frameList);
       var updatedState = update(state, actions.destroyFrame(frameList[0]));
-      assert.deepEqual(frames.frames(updatedState), [frameList[1]]);
+      assert.deepEqual(selectors.frames(updatedState), [frameList[1]]);
     });
   });
 
@@ -46,7 +47,7 @@ describe('frames reducer', function () {
       var connectedState = update(init(), actions.connectFrame(frame));
       var updatedState = update(connectedState,
         actions.updateFrameAnnotationFetchStatus(frame.uri, true));
-      assert.deepEqual(frames.frames(updatedState), [expectedFrame]);
+      assert.deepEqual(selectors.frames(updatedState), [expectedFrame]);
     });
 
     it('does not update the isAnnotationFetchComplete status of the wrong frame', function () {
@@ -56,7 +57,7 @@ describe('frames reducer', function () {
       var connectedState = update(init(), actions.connectFrame(frame));
       var updatedState = update(connectedState,
         actions.updateFrameAnnotationFetchStatus('http://anotherexample.com', true));
-      assert.deepEqual(frames.frames(updatedState), [frame]);
+      assert.deepEqual(selectors.frames(updatedState), [frame]);
     });
   });
 
@@ -69,7 +70,7 @@ describe('frames reducer', function () {
       testCase.frames.forEach(function (frame) {
         state = update(state, actions.connectFrame(frame));
       });
-      assert.deepEqual(frames.searchUris(state), testCase.searchUris);
+      assert.deepEqual(selectors.searchUris(state), testCase.searchUris);
     },[{
       when: 'one HTML frame',
       frames: [{

--- a/src/sidebar/reducers/test/session-test.js
+++ b/src/sidebar/reducers/test/session-test.js
@@ -4,8 +4,7 @@ var session = require('../session');
 
 var util = require('../util');
 
-var init = session.init;
-var actions = session.actions;
+var { init, actions, selectors } = session;
 var update = util.createReducer(session.update);
 
 describe('sidebar.reducers.session', function () {
@@ -21,7 +20,7 @@ describe('sidebar.reducers.session', function () {
     it("returns the user's profile", () => {
       var newSession = Object.assign(init(), {userid: 'john'});
       var state = update(init(), actions.updateSession(newSession));
-      assert.equal(session.profile(state), newSession);
+      assert.equal(selectors.profile(state), newSession);
     });
   });
 });

--- a/src/sidebar/reducers/test/viewer-test.js
+++ b/src/sidebar/reducers/test/viewer-test.js
@@ -4,20 +4,19 @@ var viewer = require('../viewer');
 
 var util = require('../util');
 
-var init = viewer.init;
-var actions = viewer.actions;
+var { init, actions, selectors } = viewer;
 var update = util.createReducer(viewer.update);
 
 describe('viewer reducer', function () {
   describe('#setAppIsSidebar', function () {
     it('sets a flag indicating that the app is the sidebar', function () {
       var state = update(init(), actions.setAppIsSidebar(true));
-      assert.isTrue(viewer.isSidebar(state));
+      assert.isTrue(selectors.isSidebar(state));
     });
 
     it('sets a flag indicating that the app is not the sidebar', function () {
       var state = update(init(), actions.setAppIsSidebar(false));
-      assert.isFalse(viewer.isSidebar(state));
+      assert.isFalse(selectors.isSidebar(state));
     });
   });
 });

--- a/src/sidebar/reducers/viewer.js
+++ b/src/sidebar/reducers/viewer.js
@@ -57,6 +57,7 @@ module.exports = {
     setShowHighlights: setShowHighlights,
   },
 
-  // Selectors
-  isSidebar: isSidebar,
+  selectors: {
+    isSidebar,
+  },
 };


### PR DESCRIPTION
This is a small cleanup of the exports of the Redux modules in `src/sidebar/reducers/` in preparation for upcoming changes as part of the groups work.

Group the selector functions in each Redux module together in a `selectors` object so they can be re-exported as methods on the Redux store without having to list each of them manually.

This also just makes it easier to visually see which exported functions from a Redux module are selectors.