### PR TITLE
Get the list of groups from the new endpoint and update it where applicable

### DIFF
--- a/src/sidebar/frame-sync.js
+++ b/src/sidebar/frame-sync.js
@@ -192,7 +192,6 @@ function FrameSync($rootScope, $window, Discovery, annotationUI, bridge) {
       }
 
       $rootScope.$broadcast(events.FRAME_CONNECTED);
-
       annotationUI.connectFrame({
         id: info.frameIdentifier,
         metadata: info.metadata,

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -53,11 +53,11 @@ if(settings.googleAnalytics){
 }
 
 // Fetch external state that the app needs before it can run. This includes the
-// authenticated user state, the API endpoint URLs and WebSocket connection.
+// user's profile and list of groups.
 var resolve = {
   // @ngInject
-  sessionState: function (session) {
-    return session.load();
+  state: function (groups, session) {
+    return Promise.all([groups.load(), session.load()]);
   },
 };
 

--- a/src/sidebar/reducers/session.js
+++ b/src/sidebar/reducers/session.js
@@ -13,8 +13,6 @@ function init() {
     session: {
       /** A map of features that are enabled for the current user. */
       features: {},
-      /** List of groups that the current user is a member of. */
-      groups: [],
       /** A map of preference names and values. */
       preferences: {},
       /**

--- a/src/sidebar/session.js
+++ b/src/sidebar/session.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var angular = require('angular');
-
 var events = require('./events');
 var retryUtil = require('./retry-util');
 
@@ -97,7 +95,6 @@ function session($q, $rootScope, analytics, annotationUI, auth,
   function update(model) {
     var prevSession = annotationUI.getState().session;
     var userChanged = model.userid !== prevSession.userid;
-    var groupsChanged = !angular.equals(model.groups, prevSession.groups);
 
     // Update the session model used by the application
     annotationUI.updateSession(model);
@@ -118,10 +115,6 @@ function session($q, $rootScope, analytics, annotationUI, auth,
       } else {
         raven.setUserInfo(undefined);
       }
-    }
-
-    if (groupsChanged) {
-      $rootScope.$broadcast(events.GROUPS_CHANGED);
     }
 
     // Return the model

--- a/src/sidebar/store.js
+++ b/src/sidebar/store.js
@@ -178,7 +178,11 @@ function store($http, $q, apiRoutes, auth) {
         delete: apiCall('group.member.delete'),
       },
     },
+    groups: {
+      list: apiCall('groups.read'),
+    },
     profile: {
+      groups: apiCall('profile.groups'),
       read: apiCall('profile.read'),
       update: apiCall('profile.update'),
     },

--- a/src/sidebar/streamer.js
+++ b/src/sidebar/streamer.js
@@ -92,6 +92,7 @@ function Streamer($rootScope, annotationMapper, annotationUI, auth,
 
   function handleSessionChangeNotification(message) {
     session.update(message.model);
+    groups.load();
   }
 
   function handleSocketOnError (event) {

--- a/src/sidebar/test/groups-test.js
+++ b/src/sidebar/test/groups-test.js
@@ -2,21 +2,17 @@
 
 var events = require('../events');
 var groups = require('../groups');
+var unroll = require('../../shared/test/util').unroll;
 
 // Return a mock session service containing three groups.
 var sessionWithThreeGroups = function() {
   return {
-    state: {
-      groups: [
-        {name: 'Group 1', id: 'id1'},
-        {name: 'Group 2', id: 'id2'},
-        {name: 'Group 3', id: 'id3'},
-      ],
-    },
+    state: {},
   };
 };
 
 describe('groups', function() {
+  var fakeAnnotationUI;
   var fakeSession;
   var fakeStore;
   var fakeLocalStorage;
@@ -27,27 +23,41 @@ describe('groups', function() {
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
 
+    fakeAnnotationUI = {
+      searchUris: sinon.stub().returns(['http://example.org']),
+    };
     fakeSession = sessionWithThreeGroups();
     fakeLocalStorage = {
       getItem: sandbox.stub(),
       setItem: sandbox.stub(),
     };
     fakeRootScope = {
-      eventCallbacks: [],
+      eventCallbacks: {},
 
-      $broadcast: sandbox.stub(),
+      $apply: function(callback) {
+        callback();
+      },
 
       $on: function(event, callback) {
-        if (event === events.GROUPS_CHANGED) {
-          this.eventCallbacks.push(callback);
+        if (event === events.GROUPS_CHANGED || event === events.USER_CHANGED || event === events.FRAME_CONNECTED) {
+          this.eventCallbacks[event] = callback;
         }
       },
+
+      $broadcast: sandbox.stub(),
     };
     fakeStore = {
       group: {
         member: {
           delete: sandbox.stub().returns(Promise.resolve()),
         },
+      },
+      groups: {
+        list: sandbox.stub().returns(Promise.resolve([
+          {name: 'Group 1', id: 'id1'},
+          {name: 'Group 2', id: 'id2'},
+          {name: 'Group 3', id: 'id3'},
+        ])),
       },
     };
     fakeServiceUrl = sandbox.stub();
@@ -58,125 +68,160 @@ describe('groups', function() {
   });
 
   function service() {
-    return groups(fakeLocalStorage, fakeServiceUrl, fakeSession,
+    return groups(fakeAnnotationUI, fakeLocalStorage, fakeServiceUrl, fakeSession,
       fakeRootScope, fakeStore);
   }
 
-  describe('.all()', function() {
+  describe('#all()', function() {
     it('returns no groups if there are none in the session', function() {
-      fakeSession = {state: {groups: []}};
+      fakeSession = {state: {}};
 
       var groups = service().all();
 
       assert.equal(groups.length, 0);
     });
 
-    it('returns the groups from the session when there are some', function() {
-      var groups = service().all();
+    it('returns the groups when there are some', function() {
+      var svc = service();
 
-      assert.equal(groups.length, 3);
-      assert.deepEqual(groups, [
-        {name: 'Group 1', id: 'id1'},
-        {name: 'Group 2', id: 'id2'},
-        {name: 'Group 3', id: 'id3'},
-      ]);
+      return svc.load().then(() => {
+        var groups = svc.all();
+        assert.equal(groups.length, 3);
+        assert.deepEqual(groups, [
+          {name: 'Group 1', id: 'id1'},
+          {name: 'Group 2', id: 'id2'},
+          {name: 'Group 3', id: 'id3'},
+        ]);
+      });
     });
   });
 
-  describe('.get() method', function() {
-    it('returns the requested group', function() {
-      var group = service().get('id2');
+  describe('#load() method', function() {
+    it('loads all available groups', function() {
+      var svc = service();
 
-      assert.equal(group.id, 'id2');
+      return svc.load().then(() => {
+        assert.equal(svc.all().length, 3);
+      });
+    });
+
+    it('focuses on the first in the list of groups if user leaves the focused group', function () {
+      var svc = service();
+
+      return svc.load().then(() => {
+        svc.focus('id2');
+      }).then(() => {
+        fakeStore.groups.list = sandbox.stub().returns(Promise.resolve([
+          {name: 'Group 3', id: 'id3'},
+          {name: 'Group 1', id: 'id1'},
+        ]));
+        return svc.load();
+      }).then(() => {
+        assert.equal(svc.focused().id, 'id3');
+      });
+    });
+  });
+
+  describe('#get() method', function() {
+    it('returns the requested group', function() {
+      var svc = service();
+
+      return svc.load().then(() => {
+        var group = svc.get('id2');
+        assert.equal(group.id, 'id2');
+      });
     });
 
     it("returns null if the group doesn't exist", function() {
-      var group = service().get('foobar');
+      var svc = service();
 
-      assert.isNull(group);
+      return svc.load().then(() => {
+        var group = svc.get('foobar');
+        assert.isNull(group);
+      });
     });
   });
 
-  describe('.focused() method', function() {
+  describe('#focused() method', function() {
     it('returns the focused group', function() {
-      var s = service();
-      s.focus('id2');
+      var svc = service();
 
-      assert.equal(s.focused().id, 'id2');
+      return svc.load().then(() => {
+        svc.focus('id2');
+        assert.equal(svc.focused().id, 'id2');
+      });
     });
 
     it('returns the first group initially', function() {
-      var s = service();
+      var svc = service();
 
-      assert.equal(s.focused().id, 'id1');
+      return svc.load().then(() => {
+        assert.equal(svc.focused().id, 'id1');
+      });
     });
 
     it('returns the group selected in localStorage if available', function() {
       fakeLocalStorage.getItem.returns('id3');
-      var s = service();
+      var svc = service();
 
-      assert.equal(s.focused().id, 'id3');
-    });
-
-    it('should update if the user leaves the focused group', function () {
-      var s = service();
-      s.focus('id2');
-
-      var leaveGroup = function(id) {
-        fakeSession.state.groups =
-          fakeSession.state.groups.slice().filter(function (group) {
-            return group.id !== id;
-          });
-        fakeRootScope.eventCallbacks.forEach(function (callback) {
-          callback();
-        });
-      };
-
-      leaveGroup('id3');
-      assert.equal(s.focused().id, 'id2');
-      leaveGroup('id2');
-      assert.notEqual(s.focused().id, 'id2');
+      return svc.load().then(() => {
+        assert.equal(svc.focused().id, 'id3');
+      });
     });
   });
 
-  describe('.focus()', function() {
+  describe('#focus()', function() {
     it('sets the focused group to the named group', function() {
-      var s = service();
-      s.focus('id2');
+      var svc = service();
 
-      assert.equal(s.focused().id, 'id2');
+      return svc.load().then(() => {
+        svc.focus('id2');
+
+        assert.equal(svc.focused().id, 'id2');
+      });
     });
 
     it('does nothing if the named group isn\'t recognised', function() {
-      var s = service();
-      s.focus('foobar');
+      var svc = service();
 
-      assert.equal(s.focused().id, 'id1');
+      return svc.load().then(() => {
+        svc.focus('foobar');
+
+        assert.equal(svc.focused().id, 'id1');
+      });
     });
 
     it('stores the focused group id in localStorage', function() {
-      var s = service();
-      s.focus('id3');
+      var svc = service();
 
-      assert.calledWithMatch(fakeLocalStorage.setItem, sinon.match.any, 'id3');
+      return svc.load().then(() => {
+        svc.focus('id3');
+
+        assert.calledWithMatch(fakeLocalStorage.setItem, sinon.match.any, 'id3');
+      });
     });
 
     it('emits the GROUP_FOCUSED event if the focused group changed', function () {
-      var s = service();
-      s.focus('id3');
-      assert.calledWith(fakeRootScope.$broadcast, events.GROUP_FOCUSED, 'id3');
+      var svc = service();
+
+      return svc.load().then(() => {
+        svc.focus('id3');
+        assert.calledWith(fakeRootScope.$broadcast, events.GROUP_FOCUSED, 'id3');
+      });
     });
 
     it('does not emit GROUP_FOCUSED if the focused group did not change', function () {
-      var s = service();
-      s.focus('id3');
-      fakeRootScope.$broadcast = sinon.stub();
-      s.focus('id3');
-      assert.notCalled(fakeRootScope.$broadcast);
+      var svc = service();
+      return svc.load().then(() => {
+        svc.focus('id3');
+        fakeRootScope.$broadcast = sinon.stub();
+        svc.focus('id3');
+        assert.notCalled(fakeRootScope.$broadcast);
+      });
     });
   });
 
-  describe('.leave()', function () {
+  describe('#leave()', function () {
     it('should call the group leave API', function () {
       var s = service();
       return s.leave('id2').then(() => {
@@ -186,5 +231,21 @@ describe('groups', function() {
         });
       });
     });
+  });
+
+  describe('calls load on various events', function () {
+    var changeEvents = [
+      {event: events.GROUPS_CHANGED},
+      {event: events.USER_CHANGED},
+      {event: events.FRAME_CONNECTED},
+    ];
+
+    unroll('should fetch the list of groups from the server when #event occurs', function (testCase) {
+      service();
+
+      return fakeRootScope.eventCallbacks[testCase.event]().then(() => {
+        assert.calledOnce(fakeStore.groups.list);
+      });
+    }, changeEvents);
   });
 });

--- a/src/sidebar/test/session-test.js
+++ b/src/sidebar/test/session-test.js
@@ -171,17 +171,6 @@ describe('sidebar.session', function () {
   });
 
   describe('#update()', function () {
-    it('broadcasts GROUPS_CHANGED when the groups change', function () {
-      var groupChangeCallback = sinon.stub();
-      $rootScope.$on(events.GROUPS_CHANGED, groupChangeCallback);
-      session.update({
-        groups: [{
-          id: 'groupid',
-        }],
-      });
-      assert.calledOnce(groupChangeCallback);
-    });
-
     it('broadcasts USER_CHANGED when the user changes', function () {
       var userChangeCallback = sinon.stub();
       $rootScope.$on(events.USER_CHANGED, userChangeCallback);

--- a/src/sidebar/test/streamer-test.js
+++ b/src/sidebar/test/streamer-test.js
@@ -124,6 +124,7 @@ describe('Streamer', function () {
 
     fakeGroups = {
       focused: sinon.stub().returns({id: 'public'}),
+      load: sinon.stub(),
     };
 
     fakeSession = {
@@ -416,6 +417,7 @@ describe('Streamer', function () {
           model: model,
         });
         assert.ok(fakeSession.update.calledWith(model));
+        assert.calledOnce(fakeGroups.load);
       });
     });
   });

--- a/src/sidebar/util/state-util.js
+++ b/src/sidebar/util/state-util.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * Return a value from app state when it meets certain criteria.
+ *
+ * `await` returns a Promise which resolves when a selector function,
+ * which reads values from a Redux store, returns non-null.
+ *
+ * @param {Object} store - Redux store
+ * @param {Function<T|null>} selector - Function which returns a value from the
+ *   store if the criteria is met or `null` otherwise.
+ * @return {Promise<T>}
+ */
+function awaitStateChange(store, selector) {
+  var result = selector(store);
+  if (result !== null) {
+    return Promise.resolve(result);
+  }
+  return new Promise(resolve => {
+    var unsubscribe = store.subscribe(() => {
+      var result = selector(store);
+      if (result !== null) {
+        unsubscribe();
+        resolve(result);
+      }
+    });
+  });
+}
+
+module.exports = { awaitStateChange } ;

--- a/src/sidebar/util/test/state-util-test.js
+++ b/src/sidebar/util/test/state-util-test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var fakeStore = require('../../test/fake-redux-store');
+var stateUtil = require('../state-util');
+
+describe('state-util', function () {
+  var store;
+
+  beforeEach(function() {
+    store = fakeStore({ val: 0 });
+  });
+
+  describe('awaitStateChange()', function () {
+    function getValWhenGreaterThanTwo(store) {
+      if (store.getState().val < 3) {
+        return null;
+      }
+      return store.getState().val;
+    }
+
+    it('should return promise that resolves to a non-null value', function () {
+      var expected = 5;
+
+      store.setState({ val: 5 });
+
+      return stateUtil.awaitStateChange(store, getValWhenGreaterThanTwo).then(function (actual) {
+        assert.equal(actual, expected);
+      });
+    });
+
+    it('should wait for awaitStateChange to return a non-null value', function () {
+      var valPromise;
+      var expected = 5;
+
+      store.setState({ val: 2 });
+      valPromise = stateUtil.awaitStateChange(store, getValWhenGreaterThanTwo);
+      store.setState({ val: 5 });
+
+      return valPromise.then(function (actual) {
+        assert.equal(actual, expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Get the list of groups from the new endpoint and update it wherever applicable.
    
Fetch the list of groups from the new `/api/groups` endpoint instead of using the groups list returned in the `/api/profile` result. This supports providing the current document URI as a parameter, which enables the server to change the list of open groups returned depending on the current URL.
    
In order to update the groups list correctly, taking into account the current document URI, when the user joins or leaves a group, the `streamer` service now handles "session change" notifications by triggering a re-fetch of groups from the `/api/groups` endpoint instead of updating the groups directly from the payload of the WebSocket message.
