### PR TITLE
Fix spinner animation

### DIFF
--- a/src/styles/sidebar/components/spinner.scss
+++ b/src/styles/sidebar/components/spinner.scss
@@ -11,7 +11,7 @@ $container-height: $container-width;
 $part-width: .1em;
 $part-height: 3 * $part-width;
 
-@keyframes(spin) {
+@keyframes spin {
   to { transform: rotate(1turn); }
 }
 


### PR DESCRIPTION
I noticed that the little spinner which appears in the top bar when the client is fetching data ... does not actually spin. It usually isn't that noticeable on a fast internet connection because it only appears very briefly in most cases.

`@keyframes($name)` is [not legal syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/%40keyframes). I'm unsure if this ever worked
in the past in older browsers or if it was previously converted by a
post-processor to valid syntax.