### PR TITLE
Only wait for document URI before fetching groups in sidebar

### DIFF
--- a/src/sidebar/groups.js
+++ b/src/sidebar/groups.js
@@ -17,7 +17,7 @@ var events = require('./events');
 var { awaitStateChange } = require('./util/state-util');
 
 // @ngInject
-function groups(annotationUI, localStorage, serviceUrl, session, $rootScope, store) {
+function groups(annotationUI, isSidebar, localStorage, serviceUrl, session, $rootScope, store) {
   // The currently focused group. This is the group that's shown as selected in
   // the groups dropdown, the annotations displayed are filtered to only ones
   // that belong to this group, and any new annotations that the user creates
@@ -48,8 +48,16 @@ function groups(annotationUI, localStorage, serviceUrl, session, $rootScope, sto
    * the attached frames.
    */
   function load() {
-    return getDocumentUriForGroupSearch().then(uri => {
-      return store.groups.list({ document_uri: uri });
+    var uri = Promise.resolve(null);
+    if (isSidebar) {
+      uri = getDocumentUriForGroupSearch();
+    }
+    return uri.then(uri => {
+      var params = {};
+      if (uri) {
+        params.document_uri = uri;
+      }
+      return store.groups.list(params);
     }).then(gs => {
       $rootScope.$apply(() => {
         var focGroup = focused();

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -61,6 +61,9 @@ var resolve = {
   },
 };
 
+var isSidebar = !(window.location.pathname.startsWith('/stream') ||
+                  window.location.pathname.startsWith('/a/'));
+
 // @ngInject
 function configureLocation($locationProvider) {
   // Use HTML5 history
@@ -211,6 +214,7 @@ module.exports = angular.module('h', [
   .value('ExcerptOverflowMonitor', require('./util/excerpt-overflow-monitor'))
   .value('OAuthClient', require('./util/oauth-client'))
   .value('VirtualThreadList', require('./virtual-thread-list'))
+  .value('isSidebar', isSidebar)
   .value('random', require('./util/random'))
   .value('raven', require('./raven'))
   .value('serviceConfig', serviceConfig)

--- a/src/sidebar/reducers/viewer.js
+++ b/src/sidebar/reducers/viewer.js
@@ -10,7 +10,10 @@ var util = require('./util');
 function init() {
   return {
     // Flag that indicates whether the app is the sidebar and connected to
-    // a page where annotations are being shown in context
+    // a page where annotations are being shown in context.
+    //
+    // Note that this flag is not available early in the lifecycle of the
+    // application.
     isSidebar: true,
 
     visibleHighlights: false,


### PR DESCRIPTION
Fixes a regression after 36c466084 where the stream and single
annotation page views failed to load.

36c466084 made the groups service wait for the host page's document URI
to be determined before making a call to the `/api/groups` endpoint
passing that URI as a parameter. In the stream (`/stream`) and single
annotation page routes, there is no host page and so
the promise returned by `getDocumentUriForGroupSearch` never resolved.
Avoid waiting for this URI in that case and avoid passing the
`document_uri` parameter to the `/api/groups` endpoint.

This commit introduces a new `isSidebar` test rather than using
`annotationUI.isSidebar` because that piece of app state is not yet
initialized at the point when `groups.load()` is called in the route's
`resolve` function in src/sidebar/index.js.