### PR TITLE
Remove activity page links for third-party open groups

### DIFF
--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var { isThirdPartyUser } = require('../util/account-id');
+var isThirdPartyService = require('../util/is-third-party-service');
 var serviceConfig = require('../service-config');
 
 // @ngInject
@@ -38,6 +39,8 @@ function GroupListController($window, analytics, groups, settings, serviceUrl) {
   if (svc && svc.icon) {
     this.thirdPartyGroupIcon = svc.icon;
   }
+
+  this.isThirdPartyService = isThirdPartyService(settings);
 }
 
 module.exports = {

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -79,11 +79,11 @@ describe('groupList', function () {
     };
   }));
 
-  function createGroupList() {
+  function createGroupList({ userid } = { userid: 'acct:person@example.com' }) {
     return util.createDirective(document, 'groupList', {
       auth: {
-        status: 'logged-in',
-        userid: 'acct:person@example.com',
+        status: userid ? 'logged-in' : 'logged-out',
+        userid,
       },
     });
   }
@@ -103,6 +103,30 @@ describe('groupList', function () {
     assert.equal(link.length, 2);
     assert.equal(link[0].href, PUBLIC_GROUP_LINK);
     assert.equal(link[1].href, GROUP_LINK);
+  });
+
+  [{
+    // Logged-in third party user.
+    firstPartyAuthDomain: 'example.com',
+    authDomain: 'publisher.org',
+    userid: 'acct:person@publisher.org',
+  },{
+    // Logged-out third party user.
+    firstPartyAuthDomain: 'example.com',
+    authDomain: 'publisher.org',
+    userid: null,
+  }].forEach(({ firstPartyAuthDomain, authDomain, userid }) => {
+    it('should not render share links for third-party groups', () => {
+      fakeSettings.authDomain = firstPartyAuthDomain;
+      fakeSettings.services = [{
+        authority: authDomain,
+      }];
+
+      var element = createGroupList({ userid });
+      var shareLinks = element.find('.share-link-container');
+
+      assert.equal(shareLinks.length, 0);
+    });
   });
 
   it('should track metrics when a user attempts to view a groups activity', function () {

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -43,7 +43,7 @@
                {{group.name}}
             </a>
           </div>
-          <div class="share-link-container" ng-click="$event.stopPropagation()">
+          <div class="share-link-container" ng-click="$event.stopPropagation()" ng-if="!vm.isThirdPartyService">
             <a class="share-link"
                href="{{group.url}}"
                target="_blank"


### PR DESCRIPTION
Activity pages are currently only supported for open groups belonging to
the h service's first party authority.

This PR fixes the issue from the client side by hiding the group link in this case. An alternate solution would be to avoid generating these links and including them in the `/api/groups` response in the first place since they don't currently display anything useful.

----

**Testing**

1. Go to https://elifesciences.org/articles/35034.
2. Click “Annotations” link at top of page
3. Click “eLIFE” label at top of sidebar

**Expected**

No "View group activity" link under the eLIFE group

**Actual**

A "View group activity" link appears under the eLIFE group. Clicking it goes to a page that 404s.