### PR TITLE
Pass "authority" query param when fetching groups list

### DIFF
--- a/src/sidebar/groups.js
+++ b/src/sidebar/groups.js
@@ -15,9 +15,11 @@ var STORAGE_KEY = 'hypothesis.groups.focus';
 
 var events = require('./events');
 var { awaitStateChange } = require('./util/state-util');
+var serviceConfig = require('./service-config');
 
 // @ngInject
-function groups(annotationUI, isSidebar, localStorage, serviceUrl, session, $rootScope, store) {
+function groups(annotationUI, isSidebar, localStorage, serviceUrl, session,
+                settings, $rootScope, store) {
   // The currently focused group. This is the group that's shown as selected in
   // the groups dropdown, the annotations displayed are filtered to only ones
   // that belong to this group, and any new annotations that the user creates
@@ -25,6 +27,9 @@ function groups(annotationUI, isSidebar, localStorage, serviceUrl, session, $roo
   var focusedGroupId;
   var groups = [];
   var documentUri;
+
+  var svc = serviceConfig(settings);
+  var authority = svc ? svc.authority : null;
 
   function getDocumentUriForGroupSearch() {
     function mainUri() {
@@ -54,6 +59,9 @@ function groups(annotationUI, isSidebar, localStorage, serviceUrl, session, $roo
     }
     return uri.then(uri => {
       var params = {};
+      if (authority) {
+        params.authority = authority;
+      }
       if (uri) {
         params.document_uri = uri;
       }

--- a/src/sidebar/test/groups-test.js
+++ b/src/sidebar/test/groups-test.js
@@ -16,6 +16,7 @@ describe('groups', function() {
   var fakeAnnotationUI;
   var fakeIsSidebar;
   var fakeSession;
+  var fakeSettings;
   var fakeStore;
   var fakeLocalStorage;
   var fakeRootScope;
@@ -68,6 +69,7 @@ describe('groups', function() {
       },
     };
     fakeServiceUrl = sandbox.stub();
+    fakeSettings = {};
   });
 
   afterEach(function () {
@@ -76,7 +78,7 @@ describe('groups', function() {
 
   function service() {
     return groups(fakeAnnotationUI, fakeIsSidebar, fakeLocalStorage, fakeServiceUrl, fakeSession,
-      fakeRootScope, fakeStore);
+      fakeSettings, fakeRootScope, fakeStore);
   }
 
   describe('#all()', function() {
@@ -153,6 +155,14 @@ describe('groups', function() {
         return svc.load().then(() => {
           assert.calledWith(fakeStore.groups.list, {});
         });
+      });
+    });
+
+    it('passes authority argument when using a third-party authority', () => {
+      fakeSettings.services = [{ authority: 'publisher.org' }];
+      var svc = service();
+      return svc.load().then(() => {
+        assert.calledWith(fakeStore.groups.list, sinon.match({ authority: 'publisher.org' }));
       });
     });
   });


### PR DESCRIPTION
Without this argument, the "h" service does not know which authority's
groups should be returned if the user is not logged in.

Consequently if you go to an eLife article page at the moment and are not logged in, you see the Hypothesis "Public" group (!) - https://elifesciences.org/articles/32077