### PR TITLE
Specify npm package version to publish to S3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,9 +5,14 @@ node {
 
     nodeEnv = docker.image("kkarczmarczyk/node-yarn:7.5")
     workspace = pwd()
+    pkgVersion = sh (
+      script: 'cat package.json | jq -r .version',
+      returnStdout: true
+    ).trim()
 
     stage 'Build'
     nodeEnv.inside("-e HOME=${workspace}") {
+        sh "echo Building Hypothesis client \"${pkgVersion}\""
         sh 'make clean'
         sh 'make'
     }
@@ -33,7 +38,7 @@ node {
         // Upload the contents of the package to an S3 bucket, which it
         // will then be served from.
         docker.image('nickstenning/s3-npm-publish')
-              .withRun('', 'hypothesis s3://cdn.hypothes.is') { c ->
+              .withRun('', "hypothesis@${pkgVersion} s3://cdn.hypothes.is") { c ->
                 sh "docker logs --follow ${c.id}"
               }
     }


### PR DESCRIPTION
Sometimes the "Publish" step has ended up publishing version N-1 to the
CDN when building the tag for version N. I believe this happens due to
npm's package publishing API not guaranteeing immediate visiblity of the
latest version when it returns. If the publish task runs before the
update has propagated inside their network, then the publish step
re-uploads the previous version to the CDN.

This commit attempts to resolve the issue by specifying a package
version explicitly. We might find that this is not enough and that the
publish step either has to wait until the update has propagated or we
have to use a locally-built tarball.

Fixes #602