### PR TITLE
Observe and react to URL changes made via History API

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "katex": "^0.7.1",
     "lodash.debounce": "^4.0.3",
     "lodash.get": "^4.3.0",
+    "lodash.isequal": "^4.5.0",
     "mkdirp": "^0.5.1",
     "mocha": "^2.4.5",
     "ng-tags-input": "^3.1.1",

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -9,6 +9,8 @@ $ = require('jquery')
 adder = require('./adder')
 highlighter = require('./highlighter')
 historyObservable = require('./util/history-observable')
+metaObservable = require('./util/document-meta-observable')
+{ buffer, merge } = require('./util/observable')
 rangeUtil = require('./range-util')
 selections = require('./selections')
 xpathRange = require('./anchoring/range')
@@ -92,16 +94,18 @@ module.exports = class Guest extends Delegator
     this._connectAnnotationSync(@crossframe)
     this._connectAnnotationUISync(@crossframe)
 
-    # Observe URL changes made via
-    # `window.history.{pushState, replaceState, popState}` in SPAs and web pages
+    # Observe document metadata and URL changes in SPAs and web pages
     # using PJAX.
-    @historyChanges = historyObservable().subscribe(=>
-      # Clear cached metadata
-      this.plugins.Document?.refreshMetadata()
-      this.getDocumentInfo().then((info) =>
-        @crossframe.call('updateFrame', info)
+    historyChanges = historyObservable()
+    metaChanges = metaObservable()
+    @historyOrMetaChanges = buffer(50, merge([historyChanges, metaChanges]))
+      .subscribe(=>
+        # Clear cached metadata
+        this.plugins.Document?.refreshMetadata()
+        this.getDocumentInfo().then((info) =>
+          @crossframe.call('updateFrame', info)
+        )
       )
-    )
 
     # Load plugins
     for own name, opts of @options
@@ -188,7 +192,7 @@ module.exports = class Guest extends Delegator
     $('#annotator-dynamic-style').remove()
 
     this.selections.unsubscribe()
-    this.historyChanges.unsubscribe()
+    this.historyOrMetaChanges.unsubscribe()
     @adder.remove()
 
     @element.find('.annotator-hl').each ->

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -96,6 +96,8 @@ module.exports = class Guest extends Delegator
     # `window.history.{pushState, replaceState, popState}` in SPAs and web pages
     # using PJAX.
     @historyChanges = historyObservable().subscribe(=>
+      # Clear cached metadata
+      this.plugins.Document?.refreshMetadata()
       this.getDocumentInfo().then((info) =>
         @crossframe.call('updateFrame', info)
       )

--- a/src/annotator/plugin/document.js
+++ b/src/annotator/plugin/document.js
@@ -35,7 +35,7 @@ class DocumentMeta extends Plugin {
     this.baseURI = this.options.baseURI || baseURI;
     this.document = this.options.document || document;
 
-    this.getDocumentMetadata();
+    this.refreshMetadata();
   }
 
   /**
@@ -77,7 +77,7 @@ class DocumentMeta extends Plugin {
   /**
    * Return metadata for the current page.
    */
-  getDocumentMetadata() {
+  refreshMetadata() {
     this.metadata = {};
 
     // first look for some common metadata types

--- a/src/annotator/plugin/test/document-test.js
+++ b/src/annotator/plugin/test/document-test.js
@@ -268,4 +268,23 @@ describe('DocumentMeta', function() {
       assert.equal(doc.uri(), canonicalLink.href);
     });
   });
+
+  describe('#refreshMetadata', () => {
+    it('clears the cached metadata', () => {
+      // This relies on the "citation_title" meta tag created by the metadata
+      // tests above.
+      const titleEl = $('meta[name="citation_title"]')[0];
+      titleEl.content = 'First title';
+      const doc = new DocumentMeta($('<div></div>')[0], {});
+      doc.pluginInit();
+
+      assert.equal(doc.metadata.title, 'First title');
+
+      titleEl.content = 'Second title';
+      assert.equal(doc.metadata.title, 'First title');
+
+      doc.refreshMetadata();
+      assert.equal(doc.metadata.title, 'Second title');
+    });
+  });
 });

--- a/src/annotator/util/document-meta-info.js
+++ b/src/annotator/util/document-meta-info.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * @typedef MetadataMap
+ * @prop {Object} meta - Map of `<meta>` tag names to values
+ * @prop {Object} links - Map of `<link>` tag names to values
+ */
+
+/**
+ * Return a map of document metadata.
+ *
+ * @param {HTMLHeadElement} headEl
+ * @return {MetadataMap}
+ */
+function documentMetaInfo(headEl) {
+  const metaEls = [...headEl.querySelectorAll('meta')];
+  const linkEls = [...headEl.querySelectorAll('link')];
+
+  return {
+    meta: metaEls.reduce((map, el) => {
+      map[el.name] = el.content;
+      return map;
+    }, {}),
+
+    links: linkEls.reduce((map, el) => {
+      map[el.rel] = el.href;
+      return map;
+    }, {}),
+  };
+}
+
+module.exports = documentMetaInfo;

--- a/src/annotator/util/document-meta-observable.js
+++ b/src/annotator/util/document-meta-observable.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const isEqual = require('lodash.isequal');
+const Observable = require('zen-observable');
+
+const documentMetaInfo = require('./document-meta-info');
+
+/**
+ * Create an Observable of document metadata gathered from `<meta>` and `<link>`
+ * tags.
+ *
+ * @return {Observable<MetadataMap>}
+ */
+function documentMetaObservable() {
+  const headEl = document.querySelector('head');
+
+  return new Observable(observer => {
+    let prevMeta = documentMetaInfo(headEl);
+
+    function checkForMetaChange() {
+      const currentMeta = documentMetaInfo(headEl);
+      if (!isEqual(currentMeta, prevMeta)) {
+        prevMeta = currentMeta;
+        observer.next(prevMeta);
+      }
+    }
+
+    const mo = new MutationObserver(() => {
+      mo.takeRecords();
+      checkForMetaChange();
+    });
+
+    mo.observe(headEl, {
+      attributeFilter: ['name', 'content', 'rel', 'href'],
+      attributes: true,
+      childList: true,
+      subtree: true,
+    });
+
+    return () => {
+      mo.disconnect();
+    };
+  });
+}
+
+module.exports = documentMetaObservable;

--- a/src/annotator/util/history-observable.js
+++ b/src/annotator/util/history-observable.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const Observable = require('zen-observable');
+
+const interceptMethod = require('./intercept-method');
+
+/**
+ * Observe URL changes made via the History API.
+ *
+ * @param [History] history
+ * @param [Location] location
+ * @return {Observable<string>}
+ */
+function historyObservable(history = window.history, location = window.location) {
+  return new Observable(observer => {
+    let prevUrl = location.href;
+
+    function checkForUrlChange() {
+      const currentUrl = location.href;
+      if (currentUrl !== prevUrl) {
+        prevUrl = currentUrl;
+        observer.next(currentUrl);
+      }
+    }
+
+    // There are currently no browser events for URL changes made via the
+    // History API 😞, so we monkey-patch the `window.history` object instead.
+    const removeInterceptFns = [
+      interceptMethod(history, 'pushState', checkForUrlChange),
+      interceptMethod(history, 'replaceState', checkForUrlChange),
+      interceptMethod(history, 'popState', checkForUrlChange),
+    ];
+
+    return () => {
+      removeInterceptFns.forEach(fn => fn());
+    };
+  });
+}
+
+module.exports = historyObservable;

--- a/src/annotator/util/intercept-method.js
+++ b/src/annotator/util/intercept-method.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * Monkey-patch `object` to observe calls to `method`.
+ *
+ * Replaces `object[method]` with a wrapper which calls the original method and
+ * then passes the arguments to the callback. Returns a function which undoes
+ * the patch.
+ *
+ * @param {Object} object
+ * @param {string} method
+ * @param {Function} callback
+ * @return {Function} Function which removes the patch
+ */
+function interceptMethod(object, method, callback) {
+  let enabled = true;
+
+  const origMethod = object[method];
+  function wrapper(...args) {
+    const result = origMethod.call(object, ...args);
+    if (enabled) {
+      callback(...args);
+    }
+    return result;
+  }
+  object[method] = wrapper;
+
+  // Remove the intercept if nobody else has also tried to monkey-patch in the
+  // meantime. If they have, just stop the callback being executed.
+  function removeIntercept() {
+    enabled = false;
+    if (object[method] === wrapper) {
+      object[method] = origMethod;
+    }
+  }
+
+  return removeIntercept;
+}
+
+module.exports = interceptMethod;

--- a/src/annotator/util/test/document-meta-observable-test.js
+++ b/src/annotator/util/test/document-meta-observable-test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const documentMetaObservable = require('../document-meta-observable');
+
+describe('annotator.util.document-meta-observable', () => {
+  let subscriptions = [];
+
+  function observeMeta(callback) {
+    const observable = documentMetaObservable();
+    const subscription = observable.subscribe({
+      next: callback,
+    });
+    subscriptions.push(subscription);
+    return subscription;
+  }
+
+  function createMeta(name, content) {
+    const metaEl = document.createElement('meta');
+    metaEl.name = name;
+    metaEl.content = content;
+    return metaEl;
+  }
+
+  function createLink(rel, href) {
+    const linkEl = document.createElement('link');
+    linkEl.rel = rel;
+    linkEl.href = href;
+    return linkEl;
+  }
+
+  afterEach(() => {
+    subscriptions.forEach(s => s.unsubscribe());
+  });
+
+  describe('documentMetaObservable', () => {
+    it('notifies when `<meta>` metadata changes', () => {
+      const metaChanged = new Promise(resolve => observeMeta(resolve));
+
+      const headEl = document.querySelector('head');
+      const metaEl = createMeta('meta_key', 'meta_value');
+      headEl.appendChild(metaEl);
+
+      return metaChanged.then((meta) => {
+        assert.equal(meta.meta.meta_key, 'meta_value');
+      });
+    });
+
+    it('notifies when `<link>` metadata changes', () => {
+      const metaChanged = new Promise(resolve => observeMeta(resolve));
+
+      const headEl = document.querySelector('head');
+      const linkEl = createLink('link_rel', 'https://example.com');
+      headEl.appendChild(linkEl);
+
+      return metaChanged.then((meta) => {
+        assert.equal(meta.links.link_rel, 'https://example.com/');
+      });
+    });
+
+    it('does not notify if metadata is unchanged', done => {
+      const headEl = document.querySelector('head');
+      const linkEl = createLink('link_rel', 'https://example.com');
+      headEl.appendChild(linkEl);
+      
+      let didChange = false;
+      observeMeta(() => didChange = true);
+
+      const otherLinkEl = createLink('link_rel', 'https://example.com');
+      headEl.appendChild(otherLinkEl);
+
+      setTimeout(() => {
+        assert.equal(didChange, false);
+        done();
+      }, 0);
+    });
+  });
+});

--- a/src/annotator/util/test/history-observable-test.js
+++ b/src/annotator/util/test/history-observable-test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const historyObservable = require('../history-observable');
+
+describe('annotator.util.history-observer', () => {
+  const ORIG_URL = 'https://example.com';
+  const NEW_URL = 'https://example.com/new-url';
+
+  let fakeHistory;
+  let fakeLocation;
+
+  beforeEach(() => {
+    fakeHistory = {
+      pushState: sinon.stub(),
+      replaceState: sinon.stub(),
+      popState: sinon.stub(),
+    };
+
+    fakeLocation = {
+      href: ORIG_URL,
+    };
+  });
+
+  function observeHistory(callback) {
+    const observable = historyObservable(fakeHistory, fakeLocation);
+    const subscription = observable.subscribe({
+      next: callback,
+    });
+    return subscription;
+  }
+
+  it('reports URL changes that happen via `history.pushState`', () => {
+    const urlChanged = sinon.stub();
+    observeHistory(urlChanged);
+
+    fakeLocation.href = NEW_URL;
+    fakeHistory.pushState({}, 'A title', NEW_URL);
+
+    assert.calledWith(urlChanged, NEW_URL);
+  });
+
+  it('reports URL changes that happen via `history.replaceState`', () => {
+    const urlChanged = sinon.stub();
+    observeHistory(urlChanged);
+
+    fakeLocation.href = NEW_URL;
+    fakeHistory.replaceState({}, 'A title', NEW_URL);
+
+    assert.calledWith(urlChanged, NEW_URL);
+  });
+
+  it('reports URL changes that happen via `history.popState`', () => {
+    const urlChanged = sinon.stub();
+    observeHistory(urlChanged);
+
+    fakeLocation.href = NEW_URL;
+    fakeHistory.popState();
+
+    assert.calledWith(urlChanged, NEW_URL);
+  });
+
+  it('does not report a change if the URL remains the same', () => {
+    const urlChanged = sinon.stub();
+    observeHistory(urlChanged);
+
+    fakeLocation.href = ORIG_URL;
+    fakeHistory.replaceState({}, 'A title', ORIG_URL);
+
+    assert.notCalled(urlChanged);
+  });
+
+  it('reports multiple URL changes', () => {
+    const urls = [
+      'https://example.com/first',
+      'https://example.com/second',
+      'https://example.com/third',
+    ];
+    const urlChanged = sinon.stub();
+    observeHistory(urlChanged);
+
+    urls.forEach(url => {
+      fakeLocation.href = url;
+      fakeHistory.replaceState({}, 'A title', url);
+
+      assert.calledWith(urlChanged, url);
+      urlChanged.reset();
+    });
+  });
+
+  it('does not report URL changes after unsubscribing', () => {
+    const urlChanged = sinon.stub();
+    const subscription = observeHistory(urlChanged);
+
+    subscription.unsubscribe();
+    fakeLocation.href = NEW_URL;
+    fakeHistory.replaceState({}, 'A title', NEW_URL);
+
+    assert.notCalled(urlChanged);
+  });
+});

--- a/src/annotator/util/test/intercept-method-test.js
+++ b/src/annotator/util/test/intercept-method-test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const interceptMethod = require('../intercept-method');
+
+describe('annotator.util.intercept-method', () => {
+  let someWebApi;
+
+  beforeEach(() => {
+    someWebApi = {
+      aMethod: sinon.stub(),
+    };
+  });
+
+  describe('interceptMethod', () => {
+    it('invokes callback when method is called', () => {
+      const intercept = sinon.stub();
+
+      interceptMethod(someWebApi, 'aMethod', intercept);
+      someWebApi.aMethod(1, 2, 3);
+
+      assert.calledWith(intercept, 1, 2, 3);
+    });
+
+    it('passes arguments to original method', () => {
+      const originalMethod = someWebApi.aMethod;
+
+      interceptMethod(someWebApi, 'aMethod', sinon.stub());
+      someWebApi.aMethod(1, 2, 3);
+
+      assert.calledWith(originalMethod, 1, 2, 3);
+    });
+
+    it('returns result of original method', () => {
+      const originalMethod = someWebApi.aMethod;
+      originalMethod.returns(42);
+
+      interceptMethod(someWebApi, 'aMethod', sinon.stub());
+      assert.equal(someWebApi.aMethod(1, 2, 3), 42);
+    });
+
+    it('reverts patch when returned function is called', () => {
+      const originalMethod = someWebApi.aMethod;
+      const revert = interceptMethod(someWebApi, 'aMethod', sinon.stub());
+
+      revert();
+
+      assert.equal(someWebApi.aMethod, originalMethod);
+    });
+
+    it('does not revert patch if method is patched again', () => {
+      const originalMethod = someWebApi.aMethod;
+      const revert = interceptMethod(someWebApi, 'aMethod', sinon.stub());
+
+      // Simulate some other code patching the same method after it has already
+      // been patched by us.
+      interceptMethod(someWebApi, 'aMethod', sinon.stub());
+      revert();
+
+      assert.notEqual(someWebApi.aMethod, originalMethod);
+    });
+  });
+});

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -127,6 +127,7 @@ function FrameSync($rootScope, $window, Discovery, store, bridge) {
     });
 
     bridge.on('destroyFrame', destroyFrame.bind(this));
+    bridge.on('updateFrame', updateFrame.bind(this));
 
     // Map of annotation tag to anchoring status
     // ('anchored'|'orphan'|'timeout').
@@ -198,6 +199,10 @@ function FrameSync($rootScope, $window, Discovery, store, bridge) {
         uri: info.uri,
       });
     });
+  }
+
+  function updateFrame({ frameIdentifier, metadata, uri }) {
+    store.updateFrame({ id: frameIdentifier, metadata, uri });
   }
 
   function destroyFrame(frameIdentifier) {

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -65,6 +65,7 @@ describe('sidebar.frame-sync', function () {
     fakeStore = createFakeStore({annotations: []}, {
       connectFrame: sinon.stub(),
       destroyFrame: sinon.stub(),
+      updateFrame: sinon.stub(),
       findIDsForTags: sinon.stub(),
       focusAnnotations: sinon.stub(),
       frames: sinon.stub().returns([fixtures.framesListEntry]),
@@ -264,6 +265,18 @@ describe('sidebar.frame-sync', function () {
       fakeBridge.emit('destroyFrame', frameId);
 
       assert.calledWith(fakeStore.destroyFrame, fixtures.framesListEntry);
+    });
+  });
+
+  context('when a frame is updated', () => {
+    it('updates the metadata and URI for the frame', () => {
+      var id = null;
+      var uri = 'https://example.com/new-url';
+      var metadata = { title: 'New Page' };
+
+      fakeBridge.emit('updateFrame', { frameIdentifier: id, uri, metadata  });
+
+      assert.calledWith(fakeStore.updateFrame, { id, uri, metadata });
     });
   });
 

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -20,6 +20,17 @@ var update = {
     };
   },
 
+  UPDATE_FRAME: function (state, { id, metadata, uri }) {
+    return {
+      frames: state.frames.map(frame => {
+        if (frame.id !== id) {
+          return frame;
+        }
+        return Object.assign({}, frame, { id, metadata, uri });
+      }),
+    };
+  },
+
   UPDATE_FRAME_ANNOTATION_FETCH_STATUS: function (state, action) {
     var frames = state.frames.map(function (frame) {
       var match = (frame.uri && frame.uri === action.uri);
@@ -51,6 +62,13 @@ function connectFrame(frame) {
  */
 function destroyFrame(frame) {
   return {type: actions.DESTROY_FRAME, frame: frame};
+}
+
+/**
+ * Update the metadata and/or URI for a frame.
+ */
+function updateFrame({ id, metadata, uri }) {
+  return { type: actions.UPDATE_FRAME, id: id || null, metadata, uri };
 }
 
 /**
@@ -108,6 +126,7 @@ module.exports = {
   actions: {
     connectFrame: connectFrame,
     destroyFrame: destroyFrame,
+    updateFrame: updateFrame,
     updateFrameAnnotationFetchStatus: updateFrameAnnotationFetchStatus,
   },
 

--- a/src/sidebar/store/modules/test/frames-test.js
+++ b/src/sidebar/store/modules/test/frames-test.js
@@ -13,7 +13,7 @@ function init() {
   return Object.assign({}, frames.init(), session.init());
 }
 
-describe('frames reducer', function () {
+describe('sidebar.reducers.frames', function () {
   describe('#connectFrame', function () {
     it('adds the frame to the list of connected frames', function () {
       var frame = {uri: 'http://example.com'};
@@ -32,6 +32,26 @@ describe('frames reducer', function () {
       assert.deepEqual(selectors.frames(state), frameList);
       var updatedState = update(state, actions.destroyFrame(frameList[0]));
       assert.deepEqual(selectors.frames(updatedState), [frameList[1]]);
+    });
+  });
+
+  describe('#updateFrame', () => {
+    it('updates the metadata and URI of frames with a matching ID', () => {
+      var frameList = [{
+        id: null,
+        uri: 'http://example.com',
+        metadata: {
+          title: 'First Page',
+        },
+      }];
+      var state = init();
+      frameList.forEach(frame => state = update(state, actions.connectFrame(frame)));
+
+      var metadata = { title: 'Second Page' };
+      var uri = 'http://example.com/foo';
+      var updatedState = update(state, actions.updateFrame({ id: null, uri, metadata }));
+
+      assert.deepEqual(selectors.frames(updatedState), [{ id: null, uri, metadata }]);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4387,6 +4387,10 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"


### PR DESCRIPTION
This is a first step to towards making the Hypothesis client work better with SPAs and sites that use PJAX (eg. GitHub, Medium).

Web pages can change the current URL without loading a complete new page from the server by using `window.history` functions. This PR makes the client observe these URL changes and update the set of displayed annotations in response, as well as the URL and metadata associated with subsequently created annotations.

## Testing

1. Go to https://medium.com
2. Activate the Hypothesis client
3. Click on a link in Medium that takes you to a page for a specific article. Note that the browser doesn't actually load a new page but displays a custom progress bar at the top of the content area.
4. Annotate the document

Expected result on master: Annotation created in step (4) is associated with URL from step (1) instead of URL from step (3).

Expected result on this branch: Annotation created in step (4) is associated with URL from step (3).

## Implementation overview

- The first commit adds a utility function (`historyObservable`) which monkey-patches `window.history` methods in order to observe URL changes and returns an `Observable<string>` [1] of URL changes that consumers can subscribe to. The monkey-patching is necessary because there are no DOM events triggered the URL is changed in this way.
- The second commit uses this utility to watch for URL changes and send a message from the host frame to the sidebar with the updated URL and document metadata for the frame.
- The third commit listens for this message in the sidebar and updates the frame metadata in the app state in response. This in turn triggers the client to unload annotations for the previous URL and fetch annotations for the new URL.

[1] For those new to Observables in JS, see [this explainer](https://github.com/tc39/proposal-observable). The TL;DR is that it is a standard API for working with push-based data sources.

## Caveats

There are some limitations with this initial implementation:

1. Hypothesis assumes the new content has already been loaded by the time the URL changes, or will at least have loaded by the time it has fetched the annotations for the new URL and tries to anchor them. If the new content is still being loaded by the web app at the point when the annotations are fetched, the client may fail to anchor them.

2. There is no monitoring of URL changes in iframes.

Both of these can be resolved but I left them out to keep this first PR smaller. My current thinking for (1) is that the client will observe DOM changes using `MutationObserver` and retry anchoring of orphans when this happens. Resolving (2) just requires some additional plumbing.
