### PR TITLE
Default to notes tab when only notes present

### DIFF
--- a/src/sidebar/reducers/selection.js
+++ b/src/sidebar/reducers/selection.js
@@ -14,6 +14,7 @@ var immutable = require('seamless-immutable');
 
 var toSet = require('../util/array-util').toSet;
 var uiConstants = require('../ui-constants');
+var tabs = require('../tabs');
 
 var util = require('./util');
 
@@ -130,6 +131,17 @@ var update = {
       sortKey: TAB_SORTKEY_DEFAULT[action.tab],
       sortKeysAvailable: TAB_SORTKEYS_AVAILABLE[action.tab],
     };
+  },
+
+  ADD_ANNOTATIONS(state, action) {
+    var counts = tabs.counts(action.annotations);
+    // If there are no annotations at all, ADD_ANNOTATIONS will not be called.
+    var haveOnlyPageNotes = counts.notes === action.annotations.length;
+    // If this is the init phase and there are only page notes, select the page notes tab.
+    if (state.annotations.length === 0 && haveOnlyPageNotes){
+      return {selectedTab: uiConstants.TAB_NOTES};
+    }
+    return {};
   },
 
   SET_FILTER_QUERY: function (state, action) {

--- a/src/sidebar/test/annotation-ui-test.js
+++ b/src/sidebar/test/annotation-ui-test.js
@@ -80,7 +80,7 @@ describe('annotationUI', function () {
         [sinon.match(annot)]);
     });
 
-    it('does not change selectedTab state if annotations are already loaded', function () {
+    it('does not change `selectedTab` state if annotations are already loaded', function () {
       var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot]);
       var page = oldPageNote();
@@ -88,13 +88,13 @@ describe('annotationUI', function () {
       assert.equal(annotationUI.getState().selectedTab, uiConstants.TAB_ANNOTATIONS);
     });
 
-    it('sets the selectedTab to page if only page notes are present', function () {
+    it('sets `selectedTab` to "note" if only page notes are present', function () {
       var page = oldPageNote();
       annotationUI.addAnnotations([page]);
       assert.equal(annotationUI.getState().selectedTab, uiConstants.TAB_NOTES);
     });
 
-    it('leaves the selectedTab as annotation if annotations and/or page notes are present', function () {
+    it('leaves `selectedTab` as "annotation" if annotations and/or page notes are present', function () {
       var page = oldPageNote();
       var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot, page]);

--- a/src/sidebar/test/annotation-ui-test.js
+++ b/src/sidebar/test/annotation-ui-test.js
@@ -10,6 +10,7 @@ var uiConstants = require('../ui-constants');
 
 var defaultAnnotation = annotationFixtures.defaultAnnotation;
 var newAnnotation = annotationFixtures.newAnnotation;
+var oldPageNote = annotationFixtures.oldPageNote;
 
 var fixtures = immutable({
   pair: [
@@ -77,6 +78,27 @@ describe('annotationUI', function () {
       annotationUI.addAnnotations([annot]);
       assert.match(annotationUI.getState().annotations,
         [sinon.match(annot)]);
+    });
+
+    it('does not change selectedTab state if annotations are already loaded', function () {
+      var annot = defaultAnnotation();
+      annotationUI.addAnnotations([annot]);
+      var page = oldPageNote();
+      annotationUI.addAnnotations([page]);
+      assert.equal(annotationUI.getState().selectedTab, uiConstants.TAB_ANNOTATIONS);
+    });
+
+    it('sets the selectedTab to page if only page notes are present', function () {
+      var page = oldPageNote();
+      annotationUI.addAnnotations([page]);
+      assert.equal(annotationUI.getState().selectedTab, uiConstants.TAB_NOTES);
+    });
+
+    it('leaves the selectedTab as annotation if annotations and/or page notes are present', function () {
+      var page = oldPageNote();
+      var annot = defaultAnnotation();
+      annotationUI.addAnnotations([annot, page]);
+      assert.equal(annotationUI.getState().selectedTab, uiConstants.TAB_ANNOTATIONS);
     });
 
     it('assigns a local tag to annotations', function () {


### PR DESCRIPTION

When only page notes are present default the focused tab to be page notes instead of the annotations tab. This is a fix for https://github.com/hypothesis/product-backlog/issues/375.