### PR TITLE
Move away from `public` property in application components

### DIFF
--- a/src/sidebar/components/publish-annotation-btn.js
+++ b/src/sidebar/components/publish-annotation-btn.js
@@ -14,8 +14,8 @@ module.exports = {
       return this.isShared ? this.group.name : this.privateLabel;
     };
 
-    this.groupType = function () {
-      return this.group.public ? 'public' : 'group';
+    this.groupCategory = function () {
+      return this.group.type === 'private' ? 'group' : 'public';
     };
 
     this.setPrivacy = function (level) {

--- a/src/sidebar/components/test/annotation-share-dialog-test.js
+++ b/src/sidebar/components/test/annotation-share-dialog-test.js
@@ -91,8 +91,7 @@ describe('annotationShareDialog', function () {
         {
           group: {
             name: 'Public',
-            type: 'public',
-            public: true,
+            type: 'open',
           },
           uri: 'fakeURI',
           isPrivate: false,
@@ -142,7 +141,7 @@ describe('annotationShareDialog', function () {
     it('is available to a group', function () {
       element = util.createDirective(document, 'annotationShareDialog', {
         group: {
-          public: false,
+          type: 'private',
         },
         isPrivate: false,
       });

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -8,8 +8,9 @@ var util = require('../../directive/test/util');
 describe('groupList', function () {
   var $window;
 
-  var GROUP_LINK = 'https://hypothes.is/groups/hdevs';
-  var PUBLIC_GROUP_LINK = 'https://hypothes.is/groups/pub';
+  var PRIVATE_GROUP_LINK = 'https://hypothes.is/groups/hdevs';
+  var OPEN_GROUP_LINK = 'https://hypothes.is/groups/pub';
+  var RESTRICTED_GROUP_LINK = 'https://hypothes.is/groups/restricto';
 
   var groups;
   var fakeGroups;
@@ -53,14 +54,19 @@ describe('groupList', function () {
 
     groups = [{
       id: 'public',
-      public: true,
+      name: 'Public Group',
       type: 'open',
-      url: PUBLIC_GROUP_LINK,
+      url: OPEN_GROUP_LINK,
     },{
       id: 'h-devs',
       name: 'Hypothesis Developers',
       type: 'private',
-      url: GROUP_LINK,
+      url: PRIVATE_GROUP_LINK,
+    }, {
+      id: 'restricto',
+      name: 'Hello Restricted',
+      type: 'restricted',
+      url: RESTRICTED_GROUP_LINK,
     }];
 
     fakeGroups = {
@@ -94,15 +100,27 @@ describe('groupList', function () {
     assert.equal(groupItems.length, groups.length + 1);
   });
 
+  it('should render appropriate group name link title per group type', function() {
+    var element = createGroupList();
+    var nameLinks = element.find('.group-name-link');
+    assert.equal(nameLinks.length, groups.length + 1);
+
+    assert.include(nameLinks[0].title, 'Show public annotations'); // Open
+    assert.include(nameLinks[1].title, 'Show and create annotations in'); // Private
+    assert.include(nameLinks[2].title, 'Show public annotations'); // Restricted
+  });
+
   it('should render share links', function () {
     var element = createGroupList();
     var shareLinks = element.find('.share-link-container');
-    assert.equal(shareLinks.length, 2);
+    assert.equal(shareLinks.length, groups.length);
 
     var link = element.find('.share-link');
-    assert.equal(link.length, 2);
-    assert.equal(link[0].href, PUBLIC_GROUP_LINK);
-    assert.equal(link[1].href, GROUP_LINK);
+    assert.equal(link.length, groups.length);
+
+    assert.equal(link[0].href, OPEN_GROUP_LINK);
+    assert.equal(link[1].href, PRIVATE_GROUP_LINK);
+    assert.equal(link[2].href, RESTRICTED_GROUP_LINK);
   });
 
   [{

--- a/src/sidebar/components/test/publish-annotation-btn-test.js
+++ b/src/sidebar/components/test/publish-annotation-btn-test.js
@@ -34,13 +34,37 @@ describe('publishAnnotationBtn', function () {
     element = util.createDirective(document, 'publishAnnotationBtn', {
       group: {
         name: 'Public',
-        type: 'public',
       },
       canPost: true,
       isShared: false,
       onSave: function () {},
       onSetPrivacy: function () {},
       onCancel: function () {},
+    });
+  });
+
+  [
+    {
+      groupType: 'open',
+      expectedIcon: 'public',
+    },
+    {
+      groupType: 'restricted',
+      expectedIcon: 'public',
+    },
+    {
+      groupType: 'private',
+      expectedIcon: 'group',
+    },
+  ].forEach(({ groupType, expectedIcon }) => {
+    it('should set the correct group-type icon class', function () {
+      element.ctrl.group = {
+        name: 'My Group',
+        type: groupType,
+      };
+      element.scope.$digest();
+      var iconElement = element.find('.group-icon-container > i');
+      assert.isTrue(iconElement.hasClass(`h-icon-${expectedIcon}`));
     });
   });
 
@@ -53,7 +77,6 @@ describe('publishAnnotationBtn', function () {
   it('should display "Post to Research Lab"', function () {
     element.ctrl.group = {
       name: 'Research Lab',
-      type: 'group',
     };
     element.ctrl.isShared = true;
     element.scope.$digest();

--- a/src/sidebar/templates/annotation-share-dialog.html
+++ b/src/sidebar/templates/annotation-share-dialog.html
@@ -36,7 +36,7 @@
       <i class="h-icon-clipboard btn-icon"></i>
     </button>
   </div>
-  <div class="annotation-share-dialog-msg" ng-if="vm.group && !vm.group.public && !vm.isPrivate">
+  <div class="annotation-share-dialog-msg" ng-if="vm.group && vm.group.type === 'private' && !vm.isPrivate">
     <span class="annotation-share-dialog-msg__audience">
       Group.
     </span>

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -39,7 +39,7 @@
           <div class="group-name-container">
             <a class="group-name-link"
                href=""
-               title="{{ group.public ? 'Show public annotations' : 'Show and create annotations in ' + group.name }}">
+               title="{{ group.type === 'private' ? 'Show and create annotations in ' + group.name : 'Show public annotations'  }}">
                {{group.name}}
             </a>
           </div>

--- a/src/sidebar/templates/publish-annotation-btn.html
+++ b/src/sidebar/templates/publish-annotation-btn.html
@@ -12,7 +12,7 @@
       <li class="dropdown-menu__row" ng-click="vm.setPrivacy('shared')">
         <div class="group-item">
           <div class="group-icon-container">
-            <i class="small" ng-class="'h-icon-' + vm.groupType()"></i>
+            <i class="small" ng-class="'h-icon-' + vm.groupCategory()"></i>
           </div>
           <div class="group-details">
             <div class="group-name-container">


### PR DESCRIPTION
This PR is part of https://github.com/hypothesis/product-backlog/issues/542

This PR begins the task of extricating legacy (and in some cases, downright wrong!) uses of the `group.public` attribute as a preliminary step to removing it from the API responses. This turns out to be a bigger task than expected, so this PR contains the removal of `group.public` from all places I was able to locate **_except_ for the large, complex `annotation` component**, which will be addressed in a separate PR to keep this from getting too huge at once.

`public` has been removed here from several components, in favor of switching on `type`. In several places I have also endeavored to improve test coverage and clarity. The term `public` is used in various ways in the client, and much of it is inaccurate, so I'm glad we're addressing this!

Also, while working on this, I noticed an inconsistency in icon usage for the Publish Annotation Button (arrow points at it in image below). It renders a "world" icon for restricted groups, whereas in other cases, restricted groups uses a "group" icon. **I have left this behavior as I found it** but it would be easy enough to change if that makes sense at this point. /cc @dawariley 

![image](https://user-images.githubusercontent.com/439947/37681908-62a7be22-2c5e-11e8-89df-ea04be4d28f6.png)
