### PR TITLE
Changed background to selected element in PDF.js to visualize the searched content

### DIFF
--- a/src/styles/annotator/pdfjs-overrides.scss
+++ b/src/styles/annotator/pdfjs-overrides.scss
@@ -6,3 +6,8 @@
   ::selection { background: rgba(0, 0, 255, .2); }
   ::-moz-selection { background: rgba(0 , 0 , 255, .2); }
 }
+
+// When using search funcionality of PDF.js the matches should highlight the content but not cover it. Fix for #648
+.textLayer .highlight.selected {
+  background-color: rgba(0, 100, 0, 0.5);
+}


### PR DESCRIPTION
This PR fixes #648. 
<img width="1220" alt="captura de pantalla 2018-03-21 a las 11 09 38 a m" src="https://user-images.githubusercontent.com/6429012/37704153-684b8922-2cf8-11e8-9f7e-cffd9f5895a5.png">
