### PR TITLE
Remove `group.public` property from annotation component

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -547,7 +547,7 @@ function AnnotationController(
     if (!self.editing() || !self.isShared()) {
       return false;
     }
-    return self.group().public;
+    return self.group().type !== 'private';
   };
 
   init();

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -20,12 +20,17 @@ var groupFixtures = {
   private: {
     id: 'private',
     url: 'https://example.org/g/private',
-    public: false,
+    type: 'private',
   },
-  public: {
+  open: {
     id: 'world',
-    url: 'https://example.org/g/public',
-    public: true,
+    url: 'https://example.org/g/open',
+    type: 'open',
+  },
+  restricted: {
+    id: 'restricto',
+    url: 'https://example.org/g/restricto',
+    type: 'restricted',
   },
 };
 
@@ -213,8 +218,8 @@ describe('annotation', function() {
       fakeServiceUrl = sinon.stub();
 
       fakeGroups = {
-        focused: sinon.stub().returns(groupFixtures.public),
-        get: sinon.stub().returns(groupFixtures.public),
+        focused: sinon.stub().returns(groupFixtures.open),
+        get: sinon.stub().returns(groupFixtures.open),
       };
 
       fakeSettings = {
@@ -878,12 +883,12 @@ describe('annotation', function() {
       }, [{
         case_: 'the annotation is not being edited',
         draft: null,
-        group: groupFixtures.public,
+        group: groupFixtures.open,
         expected: false,
       },{
         case_: 'the draft is private',
         draft: draftFixtures.private,
-        group: groupFixtures.public,
+        group: groupFixtures.open,
         expected: false,
       },{
         case_: 'the group is private',
@@ -891,9 +896,14 @@ describe('annotation', function() {
         group: groupFixtures.private,
         expected: false,
       },{
-        case_: 'the draft is shared and the group is public',
+        case_: 'the draft is shared and the group is open',
         draft: draftFixtures.shared,
-        group: groupFixtures.public,
+        group: groupFixtures.open,
+        expected: true,
+      },{
+        case_: 'the draft is shared and the group is restricted',
+        draft: draftFixtures.shared,
+        group: groupFixtures.restricted,
         expected: true,
       }]);
     });


### PR DESCRIPTION
This PR is part of https://github.com/hypothesis/product-backlog/issues/542

This finishes—I _believe_—the removal of `group.public` in the client components in favor of `group.type` switching. Updating the `annotation` component ended up being less work than it seemed; lots of references to the name `public` but really only one code change: logic for whether to display license or not.