### PR TITLE
Remove reference to `group.url`

### DIFF
--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -35,6 +35,17 @@ function GroupListController($window, analytics, groups, settings, serviceUrl) {
     groups.focus(groupId);
   };
 
+  /**
+   * Show the share link for the group if it is not a third-party group
+   * AND if the URL needed is present in the group object. We should be able
+   * to simplify this once the API is adjusted only to return the link
+   * when applicable.
+   */
+  this.shouldShowActivityLink = function (groupId) {
+    const group = groups.get(groupId);
+    return group.links && group.links.html && !this.isThirdPartyService;
+  };
+
   var svc = serviceConfig(settings);
   if (svc && svc.icon) {
     this.thirdPartyGroupIcon = svc.icon;

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -129,6 +129,22 @@ describe('groupList', function () {
     assert.equal(link[2].href, RESTRICTED_GROUP_LINK);
   });
 
+  it('should not render share links if they are not present', function () {
+    groups = [
+      {
+        type: 'private',
+      },
+      {
+        id: 'anOpenGroup',
+        type: 'open',
+        links: {},
+      },
+    ];
+    var element = createGroupList();
+    var links = element.find('.share-link-container');
+    assert.equal(links.length, 0);
+  });
+
   [{
     // Logged-in third party user.
     firstPartyAuthDomain: 'example.com',

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -54,19 +54,25 @@ describe('groupList', function () {
 
     groups = [{
       id: 'public',
+      links: {
+        html: OPEN_GROUP_LINK,
+      },
       name: 'Public Group',
       type: 'open',
-      url: OPEN_GROUP_LINK,
     },{
       id: 'h-devs',
+      links: {
+        html: PRIVATE_GROUP_LINK,
+      },
       name: 'Hypothesis Developers',
       type: 'private',
-      url: PRIVATE_GROUP_LINK,
     }, {
       id: 'restricto',
+      links: {
+        html: RESTRICTED_GROUP_LINK,
+      },
       name: 'Hello Restricted',
       type: 'restricted',
-      url: RESTRICTED_GROUP_LINK,
     }];
 
     fakeGroups = {

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -45,7 +45,7 @@
           </div>
           <div class="share-link-container" ng-click="$event.stopPropagation()" ng-if="!vm.isThirdPartyService">
             <a class="share-link"
-               href="{{group.url}}"
+               href="{{group.links.html}}"
                target="_blank"
                ng-click="vm.viewGroupActivity()">
               View group activity

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -43,7 +43,7 @@
                {{group.name}}
             </a>
           </div>
-          <div class="share-link-container" ng-click="$event.stopPropagation()" ng-if="!vm.isThirdPartyService">
+          <div class="share-link-container" ng-click="$event.stopPropagation()" ng-if="vm.shouldShowActivityLink(group.id)">
             <a class="share-link"
                href="{{group.links.html}}"
                target="_blank"


### PR DESCRIPTION
This PR is part of https://github.com/hypothesis/product-backlog/issues/542

It removes reference to `group.url` in the `group-list` component in favor of `links.html`. It also moves logic for determining whether to display a share link into the controller to abstract it out.