### PR TITLE
Update icon for restricted groups in publish-annotation-button

### DIFF
--- a/src/sidebar/components/publish-annotation-btn.js
+++ b/src/sidebar/components/publish-annotation-btn.js
@@ -15,7 +15,7 @@ module.exports = {
     };
 
     this.groupCategory = function () {
-      return this.group.type === 'private' ? 'group' : 'public';
+      return this.group.type === 'open' ? 'public' : 'group';
     };
 
     this.setPrivacy = function (level) {

--- a/src/sidebar/components/test/publish-annotation-btn-test.js
+++ b/src/sidebar/components/test/publish-annotation-btn-test.js
@@ -50,7 +50,7 @@ describe('publishAnnotationBtn', function () {
     },
     {
       groupType: 'restricted',
-      expectedIcon: 'public',
+      expectedIcon: 'group',
     },
     {
       groupType: 'private',


### PR DESCRIPTION
This tiny PR fixes a small icon inconsistency.

I noted yesterday that the icon displayed for restricted groups in the drop-down menu here was inconsistent with what is shown in the header.

BEFORE:

![screen shot 2018-03-21 at 2 05 07 pm](https://user-images.githubusercontent.com/439947/37729072-611b8692-2d12-11e8-9911-2b78a88357c7.png)

AFTER:

![screen shot 2018-03-21 at 2 14 36 pm](https://user-images.githubusercontent.com/439947/37729078-63cd9f88-2d12-11e8-8324-6e13646eee6d.png)
