### PR TITLE
Add `expand` param to all groups.list requests

### DIFF
--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -58,7 +58,9 @@ function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, ses
       uri = getDocumentUriForGroupSearch();
     }
     return uri.then(uri => {
-      var params = {};
+      var params = {
+        expand: 'organization',
+      };
       if (authority) {
         params.authority = authority;
       }
@@ -141,7 +143,7 @@ function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, ses
       }
     }
   }
-  
+
   // reset the focused group if the user leaves it
   $rootScope.$on(events.GROUPS_CHANGED, function () {
     // return for use in test

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -114,6 +114,15 @@ describe('groups', function() {
       });
     });
 
+    it('always sends the `expand` parameter', function () {
+      const svc = service();
+      return svc.load().then(() => {
+        const call = fakeApi.groups.list.getCall(0);
+        assert.isObject(call.args[0]);
+        assert.equal(call.args[0].expand, 'organization');
+      });
+    });
+
     it('focuses on the first in the list of groups if user leaves the focused group', function () {
       var svc = service();
 
@@ -139,7 +148,10 @@ describe('groups', function() {
         fakeStore.setState({ searchUris: ['https://asite.com'] });
 
         return loaded.then(() => {
-          assert.calledWith(fakeApi.groups.list, { document_uri: 'https://asite.com' });
+          assert.calledWith(fakeApi.groups.list, {
+            document_uri: 'https://asite.com',
+            expand: 'organization',
+          });
         });
       });
     });
@@ -153,7 +165,9 @@ describe('groups', function() {
         fakeStore.setState({ searchUris: [] });
         var svc = service();
         return svc.load().then(() => {
-          assert.calledWith(fakeApi.groups.list, {});
+          assert.calledWith(fakeApi.groups.list, {
+            expand: 'organization',
+          });
         });
       });
     });


### PR DESCRIPTION
This is part of https://github.com/hypothesis/product-backlog/issues/571

This PR adds the `expand` parameter to requests to the groups endpoint. This will expand `organization` objects as needed to represent them in the group control menu.

_Note_: There is a failing test that is not related to this work (it's from the special Apr. 1 Easter Egg feature).