### PR TITLE
Convert Adder to an ES2015 class

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -132,6 +132,7 @@ class Adder {
    */
   constructor(container, options) {
     this.element = createAdderDOM(container);
+    this._container = container;
 
     // Set initial style
     Object.assign(container.style, {
@@ -151,7 +152,7 @@ class Adder {
     this.element.style.visibility = 'hidden';
 
     var view = this.element.ownerDocument.defaultView;
-    var enterTimeout;
+    this._enterTimeout = null;
 
     var handleCommand = (event) => {
       event.preventDefault();
@@ -178,7 +179,7 @@ class Adder {
 
     /** Hide the adder */
     this.hide = () => {
-      clearTimeout(enterTimeout);
+      clearTimeout(this._enterTimeout);
       this.element.className = classnames({'annotator-adder': true});
       this.element.style.visibility = 'hidden';
     };
@@ -268,17 +269,17 @@ class Adder {
       // Typically the adder is a child of the `<body>` and the NPA is the root
       // `<html>` element. However page styling may make the `<body>` positioned.
       // See https://github.com/hypothesis/client/issues/487.
-      var positionedAncestor = nearestPositionedAncestor(container);
+      var positionedAncestor = nearestPositionedAncestor(this._container);
       var parentRect = positionedAncestor.getBoundingClientRect();
 
-      Object.assign(container.style, {
+      Object.assign(this._container.style, {
         top: toPx(top - parentRect.top),
         left: toPx(left - parentRect.left),
       });
       this.element.style.visibility = 'visible';
 
-      clearTimeout(enterTimeout);
-      enterTimeout = setTimeout(() => {
+      clearTimeout(this._enterTimeout);
+      this._enterTimeout = setTimeout(() => {
         this.element.className += ' is-active';
       }, 1);
     };

--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -240,49 +240,49 @@ class Adder {
 
       return {top, left, arrowDirection};
     };
+  }
 
-    /**
-     * Show the adder at the given position and with the arrow pointing in
-     * `arrowDirection`.
-     *
-     * @param {number} left - Horizontal offset from left edge of viewport.
-     * @param {number} top - Vertical offset from top edge of viewport.
-     */
-    this.showAt = (left, top, arrowDirection) => {
-      this.element.className = classnames({
-        'annotator-adder': true,
-        'annotator-adder--arrow-down': arrowDirection === ARROW_POINTING_DOWN,
-        'annotator-adder--arrow-up': arrowDirection === ARROW_POINTING_UP,
-      });
+  /**
+   * Show the adder at the given position and with the arrow pointing in
+   * `arrowDirection`.
+   *
+   * @param {number} left - Horizontal offset from left edge of viewport.
+   * @param {number} top - Vertical offset from top edge of viewport.
+   */
+  showAt(left, top, arrowDirection) {
+    this.element.className = classnames({
+      'annotator-adder': true,
+      'annotator-adder--arrow-down': arrowDirection === ARROW_POINTING_DOWN,
+      'annotator-adder--arrow-up': arrowDirection === ARROW_POINTING_UP,
+    });
 
-      // Some sites make big assumptions about interactive
-      // elements on the page. Some want to hide interactive elements
-      // after use. So we need to make sure the button stays displayed
-      // the way it was originally displayed - without the inline styles
-      // See: https://github.com/hypothesis/client/issues/137
-      this.element.querySelector(ANNOTATE_BTN_SELECTOR).style.display = '';
-      this.element.querySelector(HIGHLIGHT_BTN_SELECTOR).style.display = '';
+    // Some sites make big assumptions about interactive
+    // elements on the page. Some want to hide interactive elements
+    // after use. So we need to make sure the button stays displayed
+    // the way it was originally displayed - without the inline styles
+    // See: https://github.com/hypothesis/client/issues/137
+    this.element.querySelector(ANNOTATE_BTN_SELECTOR).style.display = '';
+    this.element.querySelector(HIGHLIGHT_BTN_SELECTOR).style.display = '';
 
-      // Translate the (left, top) viewport coordinates into positions relative to
-      // the adder's nearest positioned ancestor (NPA).
-      //
-      // Typically the adder is a child of the `<body>` and the NPA is the root
-      // `<html>` element. However page styling may make the `<body>` positioned.
-      // See https://github.com/hypothesis/client/issues/487.
-      var positionedAncestor = nearestPositionedAncestor(this._container);
-      var parentRect = positionedAncestor.getBoundingClientRect();
+    // Translate the (left, top) viewport coordinates into positions relative to
+    // the adder's nearest positioned ancestor (NPA).
+    //
+    // Typically the adder is a child of the `<body>` and the NPA is the root
+    // `<html>` element. However page styling may make the `<body>` positioned.
+    // See https://github.com/hypothesis/client/issues/487.
+    var positionedAncestor = nearestPositionedAncestor(this._container);
+    var parentRect = positionedAncestor.getBoundingClientRect();
 
-      Object.assign(this._container.style, {
-        top: toPx(top - parentRect.top),
-        left: toPx(left - parentRect.left),
-      });
-      this.element.style.visibility = 'visible';
+    Object.assign(this._container.style, {
+      top: toPx(top - parentRect.top),
+      left: toPx(left - parentRect.left),
+    });
+    this.element.style.visibility = 'visible';
 
-      clearTimeout(this._enterTimeout);
-      this._enterTimeout = setTimeout(() => {
-        this.element.className += ' is-active';
-      }, 1);
-    };
+    clearTimeout(this._enterTimeout);
+    this._enterTimeout = setTimeout(() => {
+      this.element.className += ' is-active';
+    }, 1);
   }
 }
 

--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -119,170 +119,176 @@ function createAdderDOM(container) {
 /**
  * Annotation 'adder' toolbar which appears next to the selection
  * and provides controls for the user to create new annotations.
- *
- * @param {Element} container - The DOM element into which the adder will be created
- * @param {Object} options - Options object specifying `onAnnotate` and `onHighlight`
- *        event handlers.
  */
-function Adder(container, options) {
-
-  var self = this;
-  self.element = createAdderDOM(container);
-
-  // Set initial style
-  Object.assign(container.style, {
-    display: 'block',
-
-    // take position out of layout flow initially
-    position: 'absolute',
-    top: 0,
-
-    // Assign a high Z-index so that the adder shows above any content on the
-    // page
-    zIndex: 999,
-  });
-
-  // The adder is hidden using the `visibility` property rather than `display`
-  // so that we can compute its size in order to position it before display.
-  self.element.style.visibility = 'hidden';
-
-  var view = self.element.ownerDocument.defaultView;
-  var enterTimeout;
-
-  self.element.querySelector(ANNOTATE_BTN_SELECTOR)
-    .addEventListener('click', handleCommand);
-  self.element.querySelector(HIGHLIGHT_BTN_SELECTOR)
-    .addEventListener('click', handleCommand);
-
-  function handleCommand(event) {
-    event.preventDefault();
-    event.stopPropagation();
-
-    var isAnnotateCommand = this.classList.contains(ANNOTATE_BTN_CLASS);
-
-    if (isAnnotateCommand) {
-      options.onAnnotate();
-    } else {
-      options.onHighlight();
-    }
-
-    self.hide();
-  }
-
-  function width() {
-    return self.element.getBoundingClientRect().width;
-  }
-
-  function height() {
-    return self.element.getBoundingClientRect().height;
-  }
-
-  /** Hide the adder */
-  this.hide = function () {
-    clearTimeout(enterTimeout);
-    self.element.className = classnames({'annotator-adder': true});
-    self.element.style.visibility = 'hidden';
-  };
-
+class Adder {
   /**
-   * Return the best position to show the adder in order to target the
-   * selected text in `targetRect`.
+   * Construct the toolbar and populate the UI.
    *
-   * @param {Rect} targetRect - The rect of text to target, in viewport
-   *        coordinates.
-   * @param {boolean} isSelectionBackwards - True if the selection was made
-   *        backwards, such that the focus point is mosty likely at the top-left
-   *        edge of `targetRect`.
-   * @return {Target}
-   */
-  this.target = function (targetRect, isSelectionBackwards) {
-    // Set the initial arrow direction based on whether the selection was made
-    // forwards/upwards or downwards/backwards.
-    var arrowDirection;
-    if (isSelectionBackwards) {
-      arrowDirection = ARROW_POINTING_DOWN;
-    } else {
-      arrowDirection = ARROW_POINTING_UP;
-    }
-    var top;
-    var left;
-
-    // Position the adder such that the arrow it is above or below the selection
-    // and close to the end.
-    var hMargin = Math.min(ARROW_H_MARGIN, targetRect.width);
-    if (isSelectionBackwards) {
-      left = targetRect.left - width() / 2 + hMargin;
-    } else {
-      left = targetRect.left + targetRect.width - width() / 2 - hMargin;
-    }
-
-    // Flip arrow direction if adder would appear above the top or below the
-    // bottom of the viewport.
-    if (targetRect.top - height() < 0 &&
-        arrowDirection === ARROW_POINTING_DOWN) {
-      arrowDirection = ARROW_POINTING_UP;
-    } else if (targetRect.top + height() > view.innerHeight) {
-      arrowDirection = ARROW_POINTING_DOWN;
-    }
-
-    if (arrowDirection === ARROW_POINTING_UP) {
-      top = targetRect.top + targetRect.height + ARROW_HEIGHT;
-    } else {
-      top = targetRect.top - height() - ARROW_HEIGHT;
-    }
-
-    // Constrain the adder to the viewport.
-    left = Math.max(left, 0);
-    left = Math.min(left, view.innerWidth - width());
-
-    top = Math.max(top, 0);
-    top = Math.min(top, view.innerHeight - height());
-
-    return {top, left, arrowDirection};
-  };
-
-  /**
-   * Show the adder at the given position and with the arrow pointing in
-   * `arrowDirection`.
+   * The adder is initially hidden.
    *
-   * @param {number} left - Horizontal offset from left edge of viewport.
-   * @param {number} top - Vertical offset from top edge of viewport.
+   * @param {Element} container - The DOM element into which the adder will be created
+   * @param {Object} options - Options object specifying `onAnnotate` and `onHighlight`
+   *        event handlers.
    */
-  this.showAt = function (left, top, arrowDirection) {
-    self.element.className = classnames({
-      'annotator-adder': true,
-      'annotator-adder--arrow-down': arrowDirection === ARROW_POINTING_DOWN,
-      'annotator-adder--arrow-up': arrowDirection === ARROW_POINTING_UP,
-    });
+  constructor(container, options) {
+    var self = this;
+    self.element = createAdderDOM(container);
 
-    // Some sites make big assumptions about interactive
-    // elements on the page. Some want to hide interactive elements
-    // after use. So we need to make sure the button stays displayed
-    // the way it was originally displayed - without the inline styles
-    // See: https://github.com/hypothesis/client/issues/137
-    self.element.querySelector(ANNOTATE_BTN_SELECTOR).style.display = '';
-    self.element.querySelector(HIGHLIGHT_BTN_SELECTOR).style.display = '';
-
-    // Translate the (left, top) viewport coordinates into positions relative to
-    // the adder's nearest positioned ancestor (NPA).
-    //
-    // Typically the adder is a child of the `<body>` and the NPA is the root
-    // `<html>` element. However page styling may make the `<body>` positioned.
-    // See https://github.com/hypothesis/client/issues/487.
-    var positionedAncestor = nearestPositionedAncestor(container);
-    var parentRect = positionedAncestor.getBoundingClientRect();
-
+    // Set initial style
     Object.assign(container.style, {
-      top: toPx(top - parentRect.top),
-      left: toPx(left - parentRect.left),
-    });
-    self.element.style.visibility = 'visible';
+      display: 'block',
 
-    clearTimeout(enterTimeout);
-    enterTimeout = setTimeout(function () {
-      self.element.className += ' is-active';
-    }, 1);
-  };
+      // take position out of layout flow initially
+      position: 'absolute',
+      top: 0,
+
+      // Assign a high Z-index so that the adder shows above any content on the
+      // page
+      zIndex: 999,
+    });
+
+    // The adder is hidden using the `visibility` property rather than `display`
+    // so that we can compute its size in order to position it before display.
+    self.element.style.visibility = 'hidden';
+
+    var view = self.element.ownerDocument.defaultView;
+    var enterTimeout;
+
+    self.element.querySelector(ANNOTATE_BTN_SELECTOR)
+      .addEventListener('click', handleCommand);
+    self.element.querySelector(HIGHLIGHT_BTN_SELECTOR)
+      .addEventListener('click', handleCommand);
+
+    function handleCommand(event) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      var isAnnotateCommand = this.classList.contains(ANNOTATE_BTN_CLASS);
+
+      if (isAnnotateCommand) {
+        options.onAnnotate();
+      } else {
+        options.onHighlight();
+      }
+
+      self.hide();
+    }
+
+    function width() {
+      return self.element.getBoundingClientRect().width;
+    }
+
+    function height() {
+      return self.element.getBoundingClientRect().height;
+    }
+
+    /** Hide the adder */
+    this.hide = function () {
+      clearTimeout(enterTimeout);
+      self.element.className = classnames({'annotator-adder': true});
+      self.element.style.visibility = 'hidden';
+    };
+
+    /**
+     * Return the best position to show the adder in order to target the
+     * selected text in `targetRect`.
+     *
+     * @param {Rect} targetRect - The rect of text to target, in viewport
+     *        coordinates.
+     * @param {boolean} isSelectionBackwards - True if the selection was made
+     *        backwards, such that the focus point is mosty likely at the top-left
+     *        edge of `targetRect`.
+     * @return {Target}
+     */
+    this.target = function (targetRect, isSelectionBackwards) {
+      // Set the initial arrow direction based on whether the selection was made
+      // forwards/upwards or downwards/backwards.
+      var arrowDirection;
+      if (isSelectionBackwards) {
+        arrowDirection = ARROW_POINTING_DOWN;
+      } else {
+        arrowDirection = ARROW_POINTING_UP;
+      }
+      var top;
+      var left;
+
+      // Position the adder such that the arrow it is above or below the selection
+      // and close to the end.
+      var hMargin = Math.min(ARROW_H_MARGIN, targetRect.width);
+      if (isSelectionBackwards) {
+        left = targetRect.left - width() / 2 + hMargin;
+      } else {
+        left = targetRect.left + targetRect.width - width() / 2 - hMargin;
+      }
+
+      // Flip arrow direction if adder would appear above the top or below the
+      // bottom of the viewport.
+      if (targetRect.top - height() < 0 &&
+          arrowDirection === ARROW_POINTING_DOWN) {
+        arrowDirection = ARROW_POINTING_UP;
+      } else if (targetRect.top + height() > view.innerHeight) {
+        arrowDirection = ARROW_POINTING_DOWN;
+      }
+
+      if (arrowDirection === ARROW_POINTING_UP) {
+        top = targetRect.top + targetRect.height + ARROW_HEIGHT;
+      } else {
+        top = targetRect.top - height() - ARROW_HEIGHT;
+      }
+
+      // Constrain the adder to the viewport.
+      left = Math.max(left, 0);
+      left = Math.min(left, view.innerWidth - width());
+
+      top = Math.max(top, 0);
+      top = Math.min(top, view.innerHeight - height());
+
+      return {top, left, arrowDirection};
+    };
+
+    /**
+     * Show the adder at the given position and with the arrow pointing in
+     * `arrowDirection`.
+     *
+     * @param {number} left - Horizontal offset from left edge of viewport.
+     * @param {number} top - Vertical offset from top edge of viewport.
+     */
+    this.showAt = function (left, top, arrowDirection) {
+      self.element.className = classnames({
+        'annotator-adder': true,
+        'annotator-adder--arrow-down': arrowDirection === ARROW_POINTING_DOWN,
+        'annotator-adder--arrow-up': arrowDirection === ARROW_POINTING_UP,
+      });
+
+      // Some sites make big assumptions about interactive
+      // elements on the page. Some want to hide interactive elements
+      // after use. So we need to make sure the button stays displayed
+      // the way it was originally displayed - without the inline styles
+      // See: https://github.com/hypothesis/client/issues/137
+      self.element.querySelector(ANNOTATE_BTN_SELECTOR).style.display = '';
+      self.element.querySelector(HIGHLIGHT_BTN_SELECTOR).style.display = '';
+
+      // Translate the (left, top) viewport coordinates into positions relative to
+      // the adder's nearest positioned ancestor (NPA).
+      //
+      // Typically the adder is a child of the `<body>` and the NPA is the root
+      // `<html>` element. However page styling may make the `<body>` positioned.
+      // See https://github.com/hypothesis/client/issues/487.
+      var positionedAncestor = nearestPositionedAncestor(container);
+      var parentRect = positionedAncestor.getBoundingClientRect();
+
+      Object.assign(container.style, {
+        top: toPx(top - parentRect.top),
+        left: toPx(left - parentRect.left),
+      });
+      self.element.style.visibility = 'visible';
+
+      clearTimeout(enterTimeout);
+      enterTimeout = setTimeout(function () {
+        self.element.className += ' is-active';
+      }, 1);
+    };
+  }
 }
 
 module.exports = {

--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -176,70 +176,70 @@ class Adder {
 
     this._width = () => this.element.getBoundingClientRect().width;
     this._height = () => this.element.getBoundingClientRect().height;
+  }
 
-    /** Hide the adder */
-    this.hide = () => {
-      clearTimeout(this._enterTimeout);
-      this.element.className = classnames({'annotator-adder': true});
-      this.element.style.visibility = 'hidden';
-    };
+  /** Hide the adder */
+  hide() {
+    clearTimeout(this._enterTimeout);
+    this.element.className = classnames({'annotator-adder': true});
+    this.element.style.visibility = 'hidden';
+  }
 
-    /**
-     * Return the best position to show the adder in order to target the
-     * selected text in `targetRect`.
-     *
-     * @param {Rect} targetRect - The rect of text to target, in viewport
-     *        coordinates.
-     * @param {boolean} isSelectionBackwards - True if the selection was made
-     *        backwards, such that the focus point is mosty likely at the top-left
-     *        edge of `targetRect`.
-     * @return {Target}
-     */
-    this.target = (targetRect, isSelectionBackwards) => {
-      // Set the initial arrow direction based on whether the selection was made
-      // forwards/upwards or downwards/backwards.
-      var arrowDirection;
-      if (isSelectionBackwards) {
-        arrowDirection = ARROW_POINTING_DOWN;
-      } else {
-        arrowDirection = ARROW_POINTING_UP;
-      }
-      var top;
-      var left;
+  /**
+   * Return the best position to show the adder in order to target the
+   * selected text in `targetRect`.
+   *
+   * @param {Rect} targetRect - The rect of text to target, in viewport
+   *        coordinates.
+   * @param {boolean} isSelectionBackwards - True if the selection was made
+   *        backwards, such that the focus point is mosty likely at the top-left
+   *        edge of `targetRect`.
+   * @return {Target}
+   */
+  target(targetRect, isSelectionBackwards) {
+    // Set the initial arrow direction based on whether the selection was made
+    // forwards/upwards or downwards/backwards.
+    var arrowDirection;
+    if (isSelectionBackwards) {
+      arrowDirection = ARROW_POINTING_DOWN;
+    } else {
+      arrowDirection = ARROW_POINTING_UP;
+    }
+    var top;
+    var left;
 
-      // Position the adder such that the arrow it is above or below the selection
-      // and close to the end.
-      var hMargin = Math.min(ARROW_H_MARGIN, targetRect.width);
-      if (isSelectionBackwards) {
-        left = targetRect.left - this._width() / 2 + hMargin;
-      } else {
-        left = targetRect.left + targetRect.width - this._width() / 2 - hMargin;
-      }
+    // Position the adder such that the arrow it is above or below the selection
+    // and close to the end.
+    var hMargin = Math.min(ARROW_H_MARGIN, targetRect.width);
+    if (isSelectionBackwards) {
+      left = targetRect.left - this._width() / 2 + hMargin;
+    } else {
+      left = targetRect.left + targetRect.width - this._width() / 2 - hMargin;
+    }
 
-      // Flip arrow direction if adder would appear above the top or below the
-      // bottom of the viewport.
-      if (targetRect.top - this._height() < 0 &&
-          arrowDirection === ARROW_POINTING_DOWN) {
-        arrowDirection = ARROW_POINTING_UP;
-      } else if (targetRect.top + this._height() > this._view.innerHeight) {
-        arrowDirection = ARROW_POINTING_DOWN;
-      }
+    // Flip arrow direction if adder would appear above the top or below the
+    // bottom of the viewport.
+    if (targetRect.top - this._height() < 0 &&
+        arrowDirection === ARROW_POINTING_DOWN) {
+      arrowDirection = ARROW_POINTING_UP;
+    } else if (targetRect.top + this._height() > this._view.innerHeight) {
+      arrowDirection = ARROW_POINTING_DOWN;
+    }
 
-      if (arrowDirection === ARROW_POINTING_UP) {
-        top = targetRect.top + targetRect.height + ARROW_HEIGHT;
-      } else {
-        top = targetRect.top - this._height() - ARROW_HEIGHT;
-      }
+    if (arrowDirection === ARROW_POINTING_UP) {
+      top = targetRect.top + targetRect.height + ARROW_HEIGHT;
+    } else {
+      top = targetRect.top - this._height() - ARROW_HEIGHT;
+    }
 
-      // Constrain the adder to the viewport.
-      left = Math.max(left, 0);
-      left = Math.min(left, this._view.innerWidth - this._width());
+    // Constrain the adder to the viewport.
+    left = Math.max(left, 0);
+    left = Math.min(left, this._view.innerWidth - this._width());
 
-      top = Math.max(top, 0);
-      top = Math.min(top, this._view.innerHeight - this._height());
+    top = Math.max(top, 0);
+    top = Math.min(top, this._view.innerHeight - this._height());
 
-      return {top, left, arrowDirection};
-    };
+    return {top, left, arrowDirection};
   }
 
   /**

--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -131,8 +131,7 @@ class Adder {
    *        event handlers.
    */
   constructor(container, options) {
-    var self = this;
-    self.element = createAdderDOM(container);
+    this.element = createAdderDOM(container);
 
     // Set initial style
     Object.assign(container.style, {
@@ -149,21 +148,16 @@ class Adder {
 
     // The adder is hidden using the `visibility` property rather than `display`
     // so that we can compute its size in order to position it before display.
-    self.element.style.visibility = 'hidden';
+    this.element.style.visibility = 'hidden';
 
-    var view = self.element.ownerDocument.defaultView;
+    var view = this.element.ownerDocument.defaultView;
     var enterTimeout;
 
-    self.element.querySelector(ANNOTATE_BTN_SELECTOR)
-      .addEventListener('click', handleCommand);
-    self.element.querySelector(HIGHLIGHT_BTN_SELECTOR)
-      .addEventListener('click', handleCommand);
-
-    function handleCommand(event) {
+    var handleCommand = (event) => {
       event.preventDefault();
       event.stopPropagation();
 
-      var isAnnotateCommand = this.classList.contains(ANNOTATE_BTN_CLASS);
+      var isAnnotateCommand = event.target.classList.contains(ANNOTATE_BTN_CLASS);
 
       if (isAnnotateCommand) {
         options.onAnnotate();
@@ -171,22 +165,22 @@ class Adder {
         options.onHighlight();
       }
 
-      self.hide();
-    }
+      this.hide();
+    };
 
-    function width() {
-      return self.element.getBoundingClientRect().width;
-    }
+    this.element.querySelector(ANNOTATE_BTN_SELECTOR)
+      .addEventListener('click', handleCommand);
+    this.element.querySelector(HIGHLIGHT_BTN_SELECTOR)
+      .addEventListener('click', handleCommand);
 
-    function height() {
-      return self.element.getBoundingClientRect().height;
-    }
+    var width = () => this.element.getBoundingClientRect().width;
+    var height = () => this.element.getBoundingClientRect().height;
 
     /** Hide the adder */
-    this.hide = function () {
+    this.hide = () => {
       clearTimeout(enterTimeout);
-      self.element.className = classnames({'annotator-adder': true});
-      self.element.style.visibility = 'hidden';
+      this.element.className = classnames({'annotator-adder': true});
+      this.element.style.visibility = 'hidden';
     };
 
     /**
@@ -200,7 +194,7 @@ class Adder {
      *        edge of `targetRect`.
      * @return {Target}
      */
-    this.target = function (targetRect, isSelectionBackwards) {
+    this.target = (targetRect, isSelectionBackwards) => {
       // Set the initial arrow direction based on whether the selection was made
       // forwards/upwards or downwards/backwards.
       var arrowDirection;
@@ -253,8 +247,8 @@ class Adder {
      * @param {number} left - Horizontal offset from left edge of viewport.
      * @param {number} top - Vertical offset from top edge of viewport.
      */
-    this.showAt = function (left, top, arrowDirection) {
-      self.element.className = classnames({
+    this.showAt = (left, top, arrowDirection) => {
+      this.element.className = classnames({
         'annotator-adder': true,
         'annotator-adder--arrow-down': arrowDirection === ARROW_POINTING_DOWN,
         'annotator-adder--arrow-up': arrowDirection === ARROW_POINTING_UP,
@@ -265,8 +259,8 @@ class Adder {
       // after use. So we need to make sure the button stays displayed
       // the way it was originally displayed - without the inline styles
       // See: https://github.com/hypothesis/client/issues/137
-      self.element.querySelector(ANNOTATE_BTN_SELECTOR).style.display = '';
-      self.element.querySelector(HIGHLIGHT_BTN_SELECTOR).style.display = '';
+      this.element.querySelector(ANNOTATE_BTN_SELECTOR).style.display = '';
+      this.element.querySelector(HIGHLIGHT_BTN_SELECTOR).style.display = '';
 
       // Translate the (left, top) viewport coordinates into positions relative to
       // the adder's nearest positioned ancestor (NPA).
@@ -281,11 +275,11 @@ class Adder {
         top: toPx(top - parentRect.top),
         left: toPx(left - parentRect.left),
       });
-      self.element.style.visibility = 'visible';
+      this.element.style.visibility = 'visible';
 
       clearTimeout(enterTimeout);
-      enterTimeout = setTimeout(function () {
-        self.element.className += ' is-active';
+      enterTimeout = setTimeout(() => {
+        this.element.className += ' is-active';
       }, 1);
     };
   }

--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -151,7 +151,7 @@ class Adder {
     // so that we can compute its size in order to position it before display.
     this.element.style.visibility = 'hidden';
 
-    var view = this.element.ownerDocument.defaultView;
+    this._view = this.element.ownerDocument.defaultView;
     this._enterTimeout = null;
 
     var handleCommand = (event) => {
@@ -174,8 +174,8 @@ class Adder {
     this.element.querySelector(HIGHLIGHT_BTN_SELECTOR)
       .addEventListener('click', handleCommand);
 
-    var width = () => this.element.getBoundingClientRect().width;
-    var height = () => this.element.getBoundingClientRect().height;
+    this._width = () => this.element.getBoundingClientRect().width;
+    this._height = () => this.element.getBoundingClientRect().height;
 
     /** Hide the adder */
     this.hide = () => {
@@ -211,32 +211,32 @@ class Adder {
       // and close to the end.
       var hMargin = Math.min(ARROW_H_MARGIN, targetRect.width);
       if (isSelectionBackwards) {
-        left = targetRect.left - width() / 2 + hMargin;
+        left = targetRect.left - this._width() / 2 + hMargin;
       } else {
-        left = targetRect.left + targetRect.width - width() / 2 - hMargin;
+        left = targetRect.left + targetRect.width - this._width() / 2 - hMargin;
       }
 
       // Flip arrow direction if adder would appear above the top or below the
       // bottom of the viewport.
-      if (targetRect.top - height() < 0 &&
+      if (targetRect.top - this._height() < 0 &&
           arrowDirection === ARROW_POINTING_DOWN) {
         arrowDirection = ARROW_POINTING_UP;
-      } else if (targetRect.top + height() > view.innerHeight) {
+      } else if (targetRect.top + this._height() > this._view.innerHeight) {
         arrowDirection = ARROW_POINTING_DOWN;
       }
 
       if (arrowDirection === ARROW_POINTING_UP) {
         top = targetRect.top + targetRect.height + ARROW_HEIGHT;
       } else {
-        top = targetRect.top - height() - ARROW_HEIGHT;
+        top = targetRect.top - this._height() - ARROW_HEIGHT;
       }
 
       // Constrain the adder to the viewport.
       left = Math.max(left, 0);
-      left = Math.min(left, view.innerWidth - width());
+      left = Math.min(left, this._view.innerWidth - this._width());
 
       top = Math.max(top, 0);
-      top = Math.min(top, view.innerHeight - height());
+      top = Math.min(top, this._view.innerHeight - this._height());
 
       return {top, left, arrowDirection};
     };


### PR DESCRIPTION
This is some prep refactoring before making the changes to the adder toolbar shown in https://github.com/hypothesis/product-backlog/issues/489.

It converts `Adder` to an ES2015 class and does some associated cleanup, such as replacing `var self = this`. See commit messages for details.