### PR TITLE
Modernize PDFMetadata class

### DIFF
--- a/src/annotator/plugin/pdf-metadata.js
+++ b/src/annotator/plugin/pdf-metadata.js
@@ -3,73 +3,98 @@
 const { normalizeURI } = require('../util/url');
 
 /**
- * This PDFMetadata service extracts metadata about a loading/loaded PDF
- * document from a PDF.js PDFViewerApplication object.
- *
- * This hides from users of this service the need to wait until the PDF document
- * is loaded before extracting the relevant metadata.
+ * @typedef Link
+ * @prop {string} href
  */
-function PDFMetadata(app) {
-  this._loaded = new Promise(function (resolve) {
-    var finish = function () {
-      window.removeEventListener('documentload', finish);
-      resolve(app);
-    };
 
-    if (app.documentFingerprint) {
-      resolve(app);
-    } else {
-      window.addEventListener('documentload', finish);
-    }
-  });
+/**
+ * @typedef Metadata
+ * @prop {string} title - The document title
+ * @prop {Link[]} link - Array of URIs associated with this document
+ * @prop {string} documentFingerprint - The fingerprint of this PDF. This is
+ *   referred to as the "File Identifier" in the PDF spec. It may be a hash of
+ *   part of the content if the PDF file does not have a File Identifier.
+ */
+
+/**
+ * PDFMetadata extracts metadata about a loading/loaded PDF document from a
+ * PDF.js PDFViewerApplication object.
+ */
+class PDFMetadata {
+  /**
+   * Construct a `PDFMetadata` that returns URIs/metadata associated with a
+   * given PDF viewer.
+   *
+   * @param {PDFViewerApplication} app
+   */
+  constructor(app) {
+    this._loaded = new Promise(resolve => {
+      var finish = () => {
+        window.removeEventListener('documentload', finish);
+        resolve(app);
+      };
+
+      if (app.documentFingerprint) {
+        resolve(app);
+      } else {
+        window.addEventListener('documentload', finish);
+      }
+    });
+  }
+
+  /**
+   * Return the URI of the PDF.
+   *
+   * If the PDF is currently loading, the returned promise resolves once loading
+   * is complete.
+   *
+   * @return {Promise<string>}
+   */
+  getUri() {
+    return this._loaded.then(app => {
+      var uri = getPDFURL(app);
+      if (!uri) {
+        uri = fingerprintToURN(app.documentFingerprint);
+      }
+      return uri;
+    });
+  }
+
+  /**
+   * Returns metadata about the document.
+   *
+   * If the PDF is currently loading, the returned promise resolves once loading
+   * is complete.
+   *
+   * @return {Promise<Metadata>}
+   */
+  getMetadata() {
+    return this._loaded.then(app => {
+      var title = document.title;
+
+      if (app.metadata && app.metadata.has('dc:title') && app.metadata.get('dc:title') !== 'Untitled') {
+        title = app.metadata.get('dc:title');
+      } else if (app.documentInfo && app.documentInfo.Title) {
+        title = app.documentInfo.Title;
+      }
+
+      var link = [
+        {href: fingerprintToURN(app.documentFingerprint)},
+      ];
+
+      var url = getPDFURL(app);
+      if (url) {
+        link.push({href: url});
+      }
+
+      return {
+        title: title,
+        link: link,
+        documentFingerprint: app.documentFingerprint,
+      };
+    });
+  }
 }
-
-/**
- * Returns a promise of the URI of the loaded PDF.
- */
-PDFMetadata.prototype.getUri = function () {
-  return this._loaded.then(function (app) {
-    var uri = getPDFURL(app);
-    if (!uri) {
-      uri = fingerprintToURN(app.documentFingerprint);
-    }
-    return uri;
-  });
-};
-
-/**
- * Returns a promise of a metadata object, containing:
- *
- * title(string) - The document title
- * link(array) - An array of link objects representing URIs for the document
- * documentFingerprint(string) - The document fingerprint
- */
-PDFMetadata.prototype.getMetadata = function () {
-  return this._loaded.then(function (app) {
-    var title = document.title;
-
-    if (app.metadata && app.metadata.has('dc:title') && app.metadata.get('dc:title') !== 'Untitled') {
-      title = app.metadata.get('dc:title');
-    } else if (app.documentInfo && app.documentInfo.Title) {
-      title = app.documentInfo.Title;
-    }
-
-    var link = [
-      {href: fingerprintToURN(app.documentFingerprint)},
-    ];
-
-    var url = getPDFURL(app);
-    if (url) {
-      link.push({href: url});
-    }
-
-    return {
-      title: title,
-      link: link,
-      documentFingerprint: app.documentFingerprint,
-    };
-  });
-};
 
 function fingerprintToURN(fingerprint) {
   return 'urn:x-pdf:' + String(fingerprint);

--- a/src/annotator/plugin/pdf-metadata.js
+++ b/src/annotator/plugin/pdf-metadata.js
@@ -19,6 +19,13 @@ const { normalizeURI } = require('../util/url');
 /**
  * PDFMetadata extracts metadata about a loading/loaded PDF document from a
  * PDF.js PDFViewerApplication object.
+ *
+ * @example
+ * // Invoke in a PDF.js viewer, before or after the PDF has finished loading.
+ * const meta = new PDFMetadata(window.PDFViewerApplication)
+ * meta.getUri().then(uri => {
+ *    // Do something with the URL of the PDF.
+ * })
  */
 class PDFMetadata {
   /**


### PR DESCRIPTION
In preparation for fixing https://github.com/hypothesis/product-backlog/issues/579, modernize the code which extracts URLs from PDFs.

 - Convert `PDFMetadata` to an ES2015 class

 - Convert the ad-hoc type documentation to tool-readable JSDoc

 - Add a little more detail in doc comments about what
   `documentFingerprint` is