### PR TITLE
Add group-organizations utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "browserify-shim": "^3.8.12",
     "browserify-versionify": "^1.0.6",
     "chai": "^3.5.0",
+    "chance": "^1.0.13",
     "check-dependencies": "^0.12.0",
     "classnames": "^2.2.4",
     "codecov": "^1.0.1",

--- a/src/sidebar/test/group-fixtures.js
+++ b/src/sidebar/test/group-fixtures.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const Chance = require('chance');
+const chance = new Chance();
+
+function group () {
+  const id = chance.hash({length: 15});
+  const name = chance.string();
+  const group = {
+    id: id,
+    name: name,
+    links: {
+      html: `http://localhost:5000/groups/${id}/${name}`,
+    },
+    type: 'private',
+  };
+  return group;
+}
+
+function organization (options={}) {
+  const org = {
+    id: chance.hash({length : 15}),
+    name: chance.string(),
+    logo: chance.url(),
+  };
+  return Object.assign(org, options);
+}
+
+function defaultOrganization () {
+  return {
+    id: '__default__',
+    name: 'Hypothesis',
+    logo: 'http://example.com/hylogo',
+  };
+}
+
+function expandedGroup (options={}) {
+  const expanded = group();
+  expanded.organization = organization();
+
+  return Object.assign(expanded, options);
+}
+
+function expandedOrganizations () {
+  return [
+    {
+        id: 'BQg9ywB1',
+        name: 'Allez!',
+        links: {
+          html: 'http://localhost:5000/groups/BQg9ywB1/allez',
+        },
+        organization: {
+          id: 'bumbaorg',
+          name: 'Bumbas',
+          logo: 'http://www.example.com/bumba',
+        },
+        type: 'open',
+    },
+    {
+      id: 'MamPRxn8',
+      name: 'BumbasActuallyRoll',
+      links: {
+        html: 'http://localhost:5000/groups/MamPRxn8/bumbasactuallyroll',
+      },
+      organization: {
+        id: 'bumbaorg',
+        name: 'Bumbas',
+        logo: 'http://www.example.com/bumba',
+      },
+      type: 'restricted',
+    },
+    {
+      id: 'Q2VaM9wQ',
+      name: 'This One is Charmed',
+      links: {
+        html: 'http://localhost:5000/groups/Q2VaM9wQ/this-one-is-charmed',
+      },
+      organization: {
+        id: '__default__',
+        name: 'Hypothesis',
+        logo: 'http://www.example.com/logo/hy',
+      },
+      type: 'open',
+    },
+    {
+      id: '__world__',
+      name: 'Public',
+      links: {
+        html: 'http://localhost:5000/groups/__world__/public',
+      },
+      organization: {
+        id: '__default__',
+        name: 'Hypothesis',
+        logo: 'http://www.example.com/logo/hy',
+      },
+      type: 'open',
+    },
+    {
+      id: 'MZgB75MN',
+      name: 'Aardvark',
+      links: {
+        html: 'http://localhost:5000/groups/MXgB75MN/aardvark',
+      },
+      organization: {
+        id: 'arcane',
+        name: 'Arcane',
+        logo: 'http://www.example.com/logo/arcane',
+      },
+      type: 'private',
+    },
+    {
+      id: 'V1e22Mgz',
+      name: 'Football',
+      links: {
+        html: 'http://localhost:5000/groups/V1e22Mgz/football',
+      },
+      organization: {
+        id: '__default__',
+        name: 'Hypothesis',
+        logo: 'http://www.example.com/logo/hy',
+      },
+      type: 'private',
+    },
+    {
+      id: '38ZNqr52',
+      name: 'How Can This Work?',
+      links: {
+        html: 'http://localhost:5000/groups/38ZNqr53/how-can-this-work',
+      },
+      organization: {
+        id: '__default__',
+        name: 'Hypothesis',
+        logo: 'http://www.example.com/logo/hy',
+      },
+      type: 'private',
+    },
+    {
+      id: 'dxp7MRpZ',
+      name: 'Lilac',
+      links: {
+        html: 'http://localhost:5000/groups/dxp7MRpZ/lilac',
+      },
+      organization: {
+        id: 'bumbaorg',
+        name: 'Bumbas',
+        logo: 'http://www.example.com/bumba',
+      },
+      type: 'private',
+    },
+    {
+      id: 'bG8e2DL1',
+      name: 'Moribund',
+      links: {
+        html: 'http://localhost:5000/groups/bG8e2DL1/moribund',
+      },
+      organization: {
+        id: 'alchemy',
+        name: 'Alchemy',
+        logo: 'http://www.example.com/alchemy',
+      },
+      type: 'private',
+    },
+  ];
+}
+
+module.exports = {
+  group,
+  expandedGroup,
+  organization,
+  defaultOrganization,
+  expandedOrganizations,
+};

--- a/src/sidebar/util/group-organizations.js
+++ b/src/sidebar/util/group-organizations.js
@@ -1,0 +1,98 @@
+'use strict';
+
+ // TODO: Update when this is a property available on the API response
+const DEFAULT_ORG_ID = '__default__';
+
+/**
+ * Generate consistent object keys for organizations so that they
+ * may be sorted
+ *
+ * @param {Object} organization
+ * @return {String}
+ */
+function orgKey (organization) {
+  if (organization.id === DEFAULT_ORG_ID) {  return DEFAULT_ORG_ID; }
+  return `${organization.name.toLowerCase()}${organization.id}`;
+}
+
+/**
+ * Add a clone of the group object to the given organization object's
+ * groups Array.
+ *
+ * @param {Group} group
+ * @param {Object} organization
+ * @return undefined - organization is mutated in place
+ */
+function addGroup (group, organization) {
+  // Object.assign won't suffice because of nested objects on groups
+  const groupObj = JSON.parse(JSON.stringify(group));
+  const groupList = organization.groups;
+
+  if (!groupList.length && group.organization.logo) {
+    groupObj.logo = group.organization.logo;
+  }
+
+  groupList.push(groupObj);
+}
+
+/**
+ * Iterate over groups and located unique organizations. Slot groups into
+ * their appropriate "parent" organizations.
+ *
+ * @param {Array<Group>} groups
+ * @return {Object} - A collection of all unique organizations, containing
+ *                    their groups. Keyed by each org's "orgKey"
+ */
+function organizations (groups) {
+  const orgs = {};
+  groups.forEach(group => {
+    // Ignore groups with undefined or non-object organizations
+    if (typeof group.organization !== 'object') { return; }
+    const orgId = orgKey(group.organization);
+    if (typeof orgs[orgId] === 'undefined') { // First time we've seen this org
+      orgs[orgId] = Object.assign({}, group.organization);
+      orgs[orgId].groups = []; // Will hold this org's groups
+    }
+    addGroup(group, orgs[orgId]); // Add the current group to its organization's groups
+  });
+  return orgs;
+}
+
+/**
+ * Take groups as returned from API service and sort them by which organization
+ * they are in (all groups within a given organization will be contiguous
+ * in the resulting Array).
+ *
+ * Groups with no organization or an unexpanded organization
+ * will be omitted from the resulting Array.
+ *
+ * Organization ordering is by name, secondarily (pub)ID. Groups in the default
+ * organization will appear at the end of the list. The first group
+ * in each organization will have a logo property (if available on the
+ * organization).
+ *
+ * @param {Array<Group>} groups
+ * @return {Array<Object>} - groups sorted by which organization they're in
+ */
+function groupsByOrganization (groups) {
+  const orgs = organizations(groups);
+  const defaultOrganizationGroups = [];
+  const sortedGroups = [];
+
+  const sortedOrgKeys = Object.keys(orgs).sort();
+  sortedOrgKeys.forEach(orgKey => {
+    if (orgKey === DEFAULT_ORG_ID) { // Handle default groups separately
+      defaultOrganizationGroups.push(...orgs[orgKey].groups);
+    } else {
+      sortedGroups.push(...orgs[orgKey].groups);
+    }
+  });
+
+  if (defaultOrganizationGroups.length) { // Put default groups at end
+    sortedGroups.push(...defaultOrganizationGroups);
+  }
+
+  return sortedGroups;
+}
+
+module.exports = groupsByOrganization;

--- a/src/sidebar/util/test/group-organizations-test.js
+++ b/src/sidebar/util/test/group-organizations-test.js
@@ -1,0 +1,174 @@
+'use strict';
+
+var groupsByOrganization = require('../group-organizations');
+var orgFixtures = require('../../test/group-fixtures');
+
+describe('group-organizations', function () {
+  context ('when sorting organizations and their contained groups', function () {
+
+    it ('should put the default organization groups last', function () {
+      const defaultOrg = orgFixtures.defaultOrganization();
+      const groups = [orgFixtures.expandedGroup({ organization: defaultOrg }),
+                      orgFixtures.expandedGroup(),
+                      orgFixtures.expandedGroup()];
+
+      const sortedGroups = groupsByOrganization(groups);
+
+      assert.equal(sortedGroups[2].organization.id, defaultOrg.id);
+    });
+
+    it ('should sort organizations by name', function () {
+      const org1 = orgFixtures.organization({ name: 'zzzzz' });
+      const org2 = orgFixtures.organization({ name: 'aaaaa' });
+      const org3 = orgFixtures.organization({ name: 'yyyyy' });
+      const groups = [orgFixtures.expandedGroup({ organization: org1 }),
+                      orgFixtures.expandedGroup({ organization: org2 }),
+                      orgFixtures.expandedGroup({ organization: org3 })];
+
+      const sortedGroups = groupsByOrganization(groups);
+
+      assert.equal(sortedGroups[0].organization.name, 'aaaaa');
+      assert.equal(sortedGroups[1].organization.name, 'yyyyy');
+      assert.equal(sortedGroups[2].organization.name, 'zzzzz');
+    });
+
+    it ('should sort organizations secondarily by id', function () {
+      const org1 = orgFixtures.organization({ name: 'zzzzz', id: 'zzzzz' });
+      const org2 = orgFixtures.organization({ name: 'zzzzz', id: 'aaaaa' });
+      const org3 = orgFixtures.organization({ name: 'zzzzz', id: 'yyyyy' });
+      const groups = [orgFixtures.expandedGroup({ organization: org1 }),
+                      orgFixtures.expandedGroup({ organization: org2 }),
+                      orgFixtures.expandedGroup({ organization: org3 })];
+
+      const sortedGroups = groupsByOrganization(groups);
+
+      assert.equal(sortedGroups[0].organization.id, 'aaaaa');
+      assert.equal(sortedGroups[1].organization.id, 'yyyyy');
+      assert.equal(sortedGroups[2].organization.id, 'zzzzz');
+    });
+
+    it ('should only include logo for first group in each organization', function () {
+      const org = orgFixtures.organization({ name: 'Aluminum' });
+      const org2 = orgFixtures.organization({ name: 'Zirconium' });
+      const groups = [
+        { name: 'Aluminum', organization: org },
+        { name: 'Beryllium', organization: org2},
+        { name: 'Butane', organization: org2 },
+        { name: 'Cadmium', organization: org},
+      ];
+
+      const sortedGroups = groupsByOrganization(groups);
+
+      assert(typeof sortedGroups[0].logo === 'string');
+      assert(typeof sortedGroups[1].logo === 'undefined');
+      assert(typeof sortedGroups[2].logo === 'string');
+      assert(typeof sortedGroups[3].logo === 'undefined');
+
+    });
+  });
+
+  context('when encountering missing data', function () {
+
+    it('should be able to sort without any groups in the default org', function () {
+      const org = orgFixtures.organization({ name:'Aluminum' });
+      const groups = [
+        { name: 'Aluminum', organization: org },
+        { name: 'Beryllium', organization: org},
+        { name: 'Cadmium', organization: org},
+      ];
+
+      const sortedGroups = groupsByOrganization(groups);
+
+      sortedGroups.forEach((group, idx) => {
+        assert.equal(group.name, groups[idx].name);
+      });
+
+    });
+
+    it('should omit any groups without an organization', function () {
+      const org = orgFixtures.organization({ name:'Europium' });
+      const groups = [
+        { name: 'Aluminum', organization: org },
+        { name: 'Beryllium', organization: org},
+        { name: 'Butane' },
+        { name: 'Cadmium', organization: org},
+      ];
+
+      const sortedGroups = groupsByOrganization(groups);
+
+      assert.equal(sortedGroups.length, groups.length - 1);
+      sortedGroups.forEach(group => {
+        assert.notEqual(group.name, 'Butane');
+      });
+    });
+
+    it('should omit any groups with unexpanded organizations', function () {
+      const org = orgFixtures.organization({ name:'Europium' });
+      const groups = [
+        { name: 'Aluminum', organization: org },
+        { name: 'Beryllium', organization: org},
+        { name: 'Butane', organization: 'foobar' },
+        { name: 'Cadmium', organization: org},
+      ];
+
+      const sortedGroups = groupsByOrganization(groups);
+
+      assert.equal(sortedGroups.length, groups.length - 1);
+      sortedGroups.forEach(group => {
+        assert.notEqual(group.name, 'Butane');
+      });
+
+    });
+
+    it ('should omit logo property if not present on organization', function () {
+      const org = orgFixtures.organization({ logo: undefined });
+      const org2 = orgFixtures.organization({ logo: null });
+      const groups = [
+        { name: 'Aluminum', organization: org },
+        { name: 'Beryllium', organization: org2},
+        { name: 'Butane', organization: org2 },
+        { name: 'Cadmium', organization: org},
+      ];
+
+      const sortedGroups = groupsByOrganization(groups);
+
+      sortedGroups.forEach(group => {
+        assert(typeof group.logo === 'undefined');
+      });
+    });
+  });
+
+  context('when building data structures', function () {
+
+    it ('should deep-clone group objects', function () {
+      const group = orgFixtures.expandedGroup({name: 'Halfnium'});
+      const groups = [group];
+
+      const sortedGroups = groupsByOrganization(groups);
+      sortedGroups[0].name = 'Something Else';
+      sortedGroups[0].links.html = 'foobar';
+
+      assert(sortedGroups[0] !== group);
+      assert(group.name === 'Halfnium');
+      assert(group.links.html !== sortedGroups[0].links.html);
+
+    });
+
+
+    it ('should shallow-clone organization objects', function () {
+      const org = orgFixtures.organization({ name: 'Lanthanum' });
+      const group = orgFixtures.expandedGroup({
+        name: 'Halfnium',
+        organization: org,
+      });
+      const groups = [group];
+
+      const sortedGroups = groupsByOrganization(groups);
+      sortedGroups[0].organization.name = 'Tantalum';
+
+      assert(sortedGroups[0].organization !== org);
+      assert(org.name !== 'Tantalum');
+    });
+
+  });
+});


### PR DESCRIPTION
This PR is part of https://github.com/hypothesis/product-backlog/issues/571

This PR introduces a new, standalone utility module in the client that can take an Array of groups (as returned by the API) and sort them by their organization, as well as decorating them with a few needed items (e.g. `logo` where appropriate).

Locally, I've tested that dropping this list of groups of in place of `groups.all()` in the `group-list` component template "works" (groups are re-ordered by organization).

The UI/display changes will come in a separate PR, but this one gets the data in the correct "shape."