### PR TITLE
Use group.links\.html instead of group\.url

### DIFF
--- a/src/sidebar/templates/annotation-header.html
+++ b/src/sidebar/templates/annotation-header.html
@@ -23,12 +23,12 @@
     <br>
     <span class="annotation-header__share-info">
       <a class="annotation-header__group"
-        target="_blank" ng-if="vm.group() && vm.group().url" href="{{vm.group().url}}">
+        target="_blank" ng-if="vm.group() && vm.group().links.html" href="{{vm.group().links.html}}">
         <i class="h-icon-group"></i><span class="annotation-header__group-name">{{vm.group().name}}</span>
       </a>
       <span ng-show="vm.isPrivate"
         title="This annotation is visible only to you.">
-        <i class="h-icon-lock"></i><span class="annotation-header__group-name" ng-show="!vm.group().url">Only me</span>
+        <i class="h-icon-lock"></i><span class="annotation-header__group-name" ng-show="!vm.group().links.html">Only me</span>
       </span>
       <i class="h-icon-border-color" ng-show="vm.isHighlight && !vm.isEditing" title="This is a highlight. Click 'edit' to add a note or tag."></i>
       <span ng-if="::vm.showDocumentInfo">


### PR DESCRIPTION
Because group.url is going to be soon be removed from the group response object, remove it's usage form the client.

Fixes: https://github.com/hypothesis/product-backlog/issues/542
Also see: https://github.com/hypothesis/product-backlog/issues/486