### PR TITLE
Fix group focus change checks

### DIFF
--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -113,14 +113,16 @@ function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, ses
   }
 
   // Persist the focused group to storage when it changes.
-  var prevFocused = store.focusedGroup();
+  var prevFocusedId = store.focusedGroupId();
   store.subscribe(() => {
-    var focused = store.focusedGroup();
-    if (focused && focused !== prevFocused) {
-      localStorage.setItem(STORAGE_KEY, focused.id);
+    var focusedId = store.focusedGroupId();
+    if (focusedId !== prevFocusedId) {
+      prevFocusedId = focusedId;
+
+      localStorage.setItem(STORAGE_KEY, focusedId);
 
       // Emit the `GROUP_FOCUSED` event for code that still relies on it.
-      $rootScope.$broadcast(events.GROUP_FOCUSED, focused.id);
+      $rootScope.$broadcast(events.GROUP_FOCUSED, focusedId);
     }
   });
 

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -49,6 +49,10 @@ describe('groups', function() {
       searchUris() {
         return this.getState().searchUris;
       },
+      focusedGroupId() {
+        var group = this.getState().focusedGroup;
+        return group ? group.id : null;
+      },
     });
     fakeSession = sessionWithThreeGroups();
     fakeIsSidebar = true;
@@ -210,6 +214,16 @@ describe('groups', function() {
       fakeStore.setState({ groups: dummyGroups, focusedGroup: dummyGroups[1] });
 
       assert.calledWith(fakeRootScope.$broadcast, events.GROUP_FOCUSED, dummyGroups[1].id);
+    });
+
+    it('does not emit GROUP_FOCUSED if the focused group did not change', () => {
+      service();
+
+      fakeStore.setState({ groups: dummyGroups, focusedGroup: dummyGroups[1] });
+      fakeRootScope.$broadcast.reset();
+      fakeStore.setState({ groups: dummyGroups, focusedGroup: dummyGroups[1] });
+
+      assert.notCalled(fakeRootScope.$broadcast);
     });
   });
 

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -83,6 +83,15 @@ function focusedGroup(state) {
 }
 
 /**
+ * Return the current focused group ID or `null`.
+ *
+ * @return {string|null}
+ */
+function focusedGroupId(state) {
+  return state.focusedGroupId;
+}
+
+/**
  * Return the list of all groups.
  *
  * @return {Group[]}
@@ -111,5 +120,6 @@ module.exports = {
     allGroups,
     getGroup,
     focusedGroup,
+    focusedGroupId,
   },
 };

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -82,4 +82,16 @@ describe('sidebar.store.modules.groups', () => {
       assert.deepEqual(store.focusedGroup(), privateGroup);
     });
   });
+
+  describe('focusedGroupId', () => {
+    it('returns `null` if no group is focused', () => {
+      assert.equal(store.focusedGroupId(), null);
+    });
+
+    it('returns the focused group ID if a group has been focused', () => {
+      store.loadGroups([privateGroup]);
+      store.focusGroup(privateGroup.id);
+      assert.equal(store.focusedGroupId(), privateGroup.id);
+    });
+  });
 });


### PR DESCRIPTION
The focused group change check had several issues:

 - The `prevFocused` variable was not updated after the focused group
   changed, so the `GROUP_FOCUSED` event was emitted every time the app
   state changed.

 - Groups were compared by reference rather than by ID, which means that
   a change which modified a property of the group but not its ID would
   cause the event to fire.

The first issue made it impossible to create annotations because the
unnecessary `GROUP_FOCUSED` event triggered a cascade of reactions which
crashed the app.