### PR TITLE
change links in help panel

### DIFF
--- a/src/sidebar/templates/help-panel.html
+++ b/src/sidebar/templates/help-panel.html
@@ -16,8 +16,8 @@
       auth="vm.auth"
       date-time="vm.dateTime">
     </help-link> if you have any questions or want to give us feedback.
-    You can also send <a class="help-panel-content__link" href="https://hypothesis.zendesk.com/hc/en-us/requests/new" target="_blank">a support ticket</a>
-    or visit our <a class="help-panel-content__link" href="https://hypothesis.zendesk.com/hc/en-us" target="_blank"> help documents</a>.
+    You can also send <a class="help-panel-content__link" href="https://web.hypothes.is/get-help/" target="_blank">a support ticket</a>
+    or visit our <a class="help-panel-content__link" href="https://web.hypothes.is/help/" target="_blank"> help documents</a>.
   </div>
   <header class="help-panel-title">
     About this version


### PR DESCRIPTION
"send a suppport ticket" now leads to `https://web.hypothes.is/get-help` and "visit our help documents" leads to `https://web.hypothes.is/help`