### PR TITLE
Fix various failures when running test suite under Chrome

### DIFF
--- a/src/annotator/anchoring/test/html-baselines/wikipedia-regression-testing.html
+++ b/src/annotator/anchoring/test/html-baselines/wikipedia-regression-testing.html
@@ -300,9 +300,9 @@ additional terms may apply.  By using this site, you agree to the <a href="//wik
 									</ul>
 										<ul id="footer-icons" class="noprint">
 											<li id="footer-copyrightico">
-							<a href="https://wikimediafoundation.org/"><img src="/static/images/wikimedia-button.png" srcset="/static/images/wikimedia-button-1.5x.png 1.5x, /static/images/wikimedia-button-2x.png 2x" width="88" height="31" alt="Wikimedia Foundation"/></a>						</li>
+							<a href="https://wikimediafoundation.org/"><img src="" srcset="" width="88" height="31" alt="Wikimedia Foundation"/></a>						</li>
 											<li id="footer-poweredbyico">
-							<a href="//www.mediawiki.org/"><img src="/static/images/poweredby_mediawiki_88x31.png" alt="Powered by MediaWiki" srcset="/static/images/poweredby_mediawiki_132x47.png 1.5x, /static/images/poweredby_mediawiki_176x62.png 2x" width="88" height="31"/></a>						</li>
+							<a href="//www.mediawiki.org/"><img src="" alt="Powered by MediaWiki" srcset="" width="88" height="31"/></a>						</li>
 									</ul>
 						<div style="clear:both"></div>
 		</div>

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -58,9 +58,14 @@ describe('annotator.adder', function () {
   }
 
   context('when Shadow DOM is supported', function () {
-    unroll('creates the adder DOM in a shadow root', function (testCase) {
+    unroll('creates the adder DOM in a shadow root (using #attachFn)', function (testCase) {
       var adderEl = document.createElement('div');
       var shadowEl;
+
+      // Disable use of native Shadow DOM for this element, if supported.
+      adderEl.createShadowRoot = null;
+      adderEl.attachShadow = null;
+
       adderEl[testCase.attachFn] = sinon.spy(function () {
         shadowEl = document.createElement('shadow-root');
         adderEl.appendChild(shadowEl);

--- a/src/annotator/test/annotation-counts-test.js
+++ b/src/annotator/test/annotation-counts-test.js
@@ -15,15 +15,15 @@ describe('annotationCounts', function () {
     sandbox = sinon.sandbox.create();
 
     countEl1 = document.createElement('button');
-    countEl1.setAttribute('data-hypothesis-annotation-count');
+    countEl1.setAttribute('data-hypothesis-annotation-count', '');
     document.body.appendChild(countEl1);
 
     countEl2 = document.createElement('button');
-    countEl2.setAttribute('data-hypothesis-annotation-count');
+    countEl2.setAttribute('data-hypothesis-annotation-count', '');
     document.body.appendChild(countEl2);
 
     fakeCrossFrame.on = sandbox.stub().returns(fakeCrossFrame);
-    
+
     CrossFrame = sandbox.stub();
     CrossFrame.returns(fakeCrossFrame);
   });

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -124,15 +124,15 @@ describe('CrossFrame multi-frame scenario', function () {
   it('excludes injection from already injected frames', function () {
     var frame = document.createElement('iframe');
     frame.setAttribute('enable-annotation', '');
-    frame.srcdoc = '<script>window.__hypothesis_frame = true;</script>';
     container.appendChild(frame);
+    frame.contentWindow.eval('window.__hypothesis_frame = true');
 
     crossFrame.pluginInit();
 
     return new Promise(function (resolve) {
       isLoaded(frame, function () {
         var scriptElement = frame.contentDocument.querySelector('script[src]');
-        assert(!scriptElement, 'expected embed script to not be injected');
+        assert.isNull(scriptElement, 'expected embed script to not be injected');
         resolve();
       });
     });

--- a/src/annotator/test/range-util-test.js
+++ b/src/annotator/test/range-util-test.js
@@ -29,7 +29,7 @@ describe('annotator.range-util', function () {
 
   beforeEach(function () {
     selection = window.getSelection();
-    selection.collapse();
+    selection.collapse(null);
 
     testNode = document.createElement('span');
     testNode.innerHTML = 'Some text <br>content here';

--- a/src/annotator/test/sidebar-trigger-test.js
+++ b/src/annotator/test/sidebar-trigger-test.js
@@ -8,11 +8,11 @@ describe('sidebarTrigger', function () {
 
   beforeEach(function () {
     triggerEl1 = document.createElement('button');
-    triggerEl1.setAttribute('data-hypothesis-trigger');
+    triggerEl1.setAttribute('data-hypothesis-trigger', '');
     document.body.appendChild(triggerEl1);
 
     triggerEl2 = document.createElement('button');
-    triggerEl2.setAttribute('data-hypothesis-trigger');
+    triggerEl2.setAttribute('data-hypothesis-trigger', '');
     document.body.appendChild(triggerEl2);
   });
 

--- a/src/sidebar/components/test/timestamp-test.js
+++ b/src/sidebar/components/test/timestamp-test.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var angular = require('angular');
-var escapeStringRegexp = require('escape-string-regexp');
 
+var dateUtil = require('../../util/date');
 var util = require('../../directive/test/util');
 
 describe('timestamp', function () {
@@ -83,8 +83,7 @@ describe('timestamp', function () {
 
       // The exact format of the result will depend on the current locale,
       // but check that at least the current year and time are present
-      assert.match(element.ctrl.absoluteTimestamp, new RegExp('.*2016.*' +
-        escapeStringRegexp(expectedDate.toLocaleTimeString())));
+      assert.match(element.ctrl.absoluteTimestamp, dateUtil.format(expectedDate));
     });
   });
 });

--- a/src/sidebar/test/annotation-metadata-test.js
+++ b/src/sidebar/test/annotation-metadata-test.js
@@ -94,6 +94,7 @@ describe('annotation-metadata', function () {
     context('when an annotation has a direct link', function () {
       it('returns the direct link as a title link', function () {
         var model = {
+          uri: 'https://annotatedsite.com/',
           links: {
             incontext: 'https://example.com',
           },
@@ -116,6 +117,7 @@ describe('annotation-metadata', function () {
     context('when the annotation title is shorter than 30 characters', function () {
       it('returns the annotation title as title text', function () {
         var model = {
+          uri: 'https://annotatedsite.com/',
           document: {
             title: ['A Short Document Title'],
           },
@@ -170,6 +172,7 @@ describe('annotation-metadata', function () {
     context('when the document has no domain', function () {
       it('returns an empty domain text string', function() {
         var model = {
+          uri: 'doi:10.1234/5678',
           document : {
             title: ['example.com'],
           },


### PR DESCRIPTION
This PR fixes most issues when running our test suite under Chrome, a step towards using a modern headless browser for running our tests rather than PhantomJS (see https://github.com/hypothesis/client/pull/717 for original context).

Please see individual commit messages for details. ~~There is one remaining group of failures in `src/annotator/plugin/test/document-test.coffee` which I'll put in a separate PR.~~ (_Done and merged_)

**Testing**
1. Edit `src/karma.conf.js` and set the `browsers` field to `[]`
2. Run `gulp test-watch`
3. Once Karma is up and running, open the URL shown in the console in Chrome.
4. Let the tests run and verify that all tests pass. ~~the only test failures reported in the console are related to `Document` (which refers to `document-test.coffee`)~~