### PR TITLE
Fix document metadata tests in chrome

### DIFF
--- a/src/annotator/plugin/document.coffee
+++ b/src/annotator/plugin/document.coffee
@@ -1,4 +1,3 @@
-$ = require('jquery')
 baseURI = require('document-base-uri')
 
 Plugin = require('../plugin')
@@ -85,9 +84,9 @@ module.exports = class Document extends Plugin
 
   _getMetaTags: (prefix, attribute, delimiter) =>
     tags = {}
-    for meta in $("meta")
-      name = $(meta).attr(attribute)
-      content = $(meta).prop("content")
+    for meta in @document.querySelectorAll('meta')
+      name = meta.getAttribute(attribute)
+      content = meta.content
       if name
         match = name.match(RegExp("^#{prefix}#{delimiter}(.+)$", "i"))
         if match
@@ -112,19 +111,18 @@ module.exports = class Document extends Plugin
     else if @metadata.dc.title
       @metadata.title = @metadata.dc.title[0]
     else
-      @metadata.title = $("head title").text()
+      @metadata.title = @document.title
 
   _getLinks: =>
     # we know our current location is a link for the document
     @metadata.link = [href: this._getDocumentHref()]
 
     # look for some relevant link relations
-    for link in $("link")
-      l = $(link)
-      href = this._absoluteUrl(l.prop('href')) # get absolute url
-      rel = l.prop('rel')
-      type = l.prop('type')
-      lang = l.prop('hreflang')
+    for link in @document.querySelectorAll('link')
+      href = this._absoluteUrl(link.href) # get absolute url
+      rel = link.rel
+      type = link.type
+      lang = link.hreflang
 
       if rel not in ["alternate", "canonical", "bookmark", "shortlink"] then continue
 
@@ -177,8 +175,8 @@ module.exports = class Document extends Plugin
       @metadata.documentFingerprint = dcUrn
 
   _getFavicon: =>
-    for link in $("link")
-      if $(link).prop("rel") in ["shortcut icon", "icon"]
+    for link in @document.querySelectorAll('link')
+      if link.rel in ["shortcut icon", "icon"]
         @metadata["favicon"] = this._absoluteUrl(link.href)
 
   # Hack to get a absolute url from a possibly relative one

--- a/src/annotator/plugin/document.coffee
+++ b/src/annotator/plugin/document.coffee
@@ -28,8 +28,7 @@ module.exports = class Document extends Plugin
 
     this.getDocumentMetadata()
 
-# returns the primary URI for the document being annotated
-
+  # Returns the primary URI for the document being annotated
   uri: =>
     uri = decodeURIComponent(this._getDocumentHref())
     for link in @metadata.link
@@ -37,8 +36,7 @@ module.exports = class Document extends Plugin
         uri = link.href
     return uri
 
-# returns all uris for the document being annotated
-
+  # Returns all uris for the document being annotated
   uris: =>
     uniqueUrls = {}
     for link in @metadata.link
@@ -117,7 +115,7 @@ module.exports = class Document extends Plugin
       @metadata.title = $("head title").text()
 
   _getLinks: =>
-# we know our current location is a link for the document
+    # we know our current location is a link for the document
     @metadata.link = [href: this._getDocumentHref()]
 
     # look for some relevant link relations
@@ -131,7 +129,7 @@ module.exports = class Document extends Plugin
       if rel not in ["alternate", "canonical", "bookmark", "shortlink"] then continue
 
       if rel is 'alternate'
-# Ignore feeds resources
+        # Ignore feeds resources
         if type and type.match /^application\/(rss|atom)\+xml/ then continue
         # Ignore alternate languages
         if lang then continue
@@ -150,7 +148,6 @@ module.exports = class Document extends Plugin
       # kind of a hack to express DOI identifiers as links but it's a
       # convenient place to look them up later, and somewhat sane since
       # they don't have a type
-
       if name == "doi"
         for doi in values
           if doi[0..3] != "doi:"

--- a/src/annotator/plugin/test/document-test.coffee
+++ b/src/annotator/plugin/test/document-test.coffee
@@ -176,6 +176,7 @@ describe 'Document', ->
     createDoc = (href, baseURI) ->
       fakeDocument =
         createElement: document.createElement.bind(document),
+        querySelectorAll: document.querySelectorAll.bind(document),
         location:
           href: href
       doc = new Document($('<div></div>')[0], {


### PR DESCRIPTION
This PR was extracted out of https://github.com/hypothesis/client/pull/717 and fixes a failure in the tests for `src/annotator/plugin/document.coffee` when run under Chrome or another browser with a more spec-compliant `URL` constructor than PhantomJS.

The cause of the failure was a change to the `<link>` and `<meta>` elements in one test interfering with a later test, creating a scenario in which `document.coffee` tried to resolve a relative URL from a `<link>` against a non-HTTP/file `<base>` URI using `new URL(relativeURL, nonHTTPBaseURI)`. That particular scenario is an edge case that could theoretically happen but is unlikely enough in practice IMO that we can punt on it for now.

What this PR addresses instead is the lack of isolation between tests in `document-test.coffee` which caused the above scenario to happen unintentionally. See the commit messages for details.
