### PR TITLE
issue #659 make build platform independent by using cross-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "coffeeify": "^1.0.0",
     "commander": "^2.9.0",
     "core-js": "^1.2.5",
+    "cross-env": "^5.1.4",
     "custom-event": "^1.0.1",
     "diff": "^2.2.2",
     "diff-match-patch": "^1.0.0",
@@ -137,7 +138,7 @@
   },
   "main": "./build/boot.js",
   "scripts": {
-    "build": "NODE_ENV=production gulp build",
+    "build": "cross-env NODE_ENV=production gulp build",
     "deps": "check-dependencies",
     "lint": "eslint .",
     "test": "gulp test",


### PR DESCRIPTION
Fixes issue of build (npm link) failing on windows machines, as described in [issue #659](https://github.com/hypothesis/client/issues/659)