### PR TITLE
Handle non percent-encoded URLs when replacing links with media embeds

### DIFF
--- a/src/sidebar/media-embedder.js
+++ b/src/sidebar/media-embedder.js
@@ -301,7 +301,10 @@ function embedForLink(link) {
  *
  */
 function replaceLinkWithEmbed(link) {
-  if (link.href !== link.textContent) {
+  // The link's text may or may not be percent encoded. The `link.href` property
+  // will always be percent encoded. When comparing the two we need to be
+  // agnostic as to which representation is used.
+  if (link.href !== link.textContent && decodeURI(link.href) !== link.textContent) {
     return;
   }
   var embed = embedForLink(link);

--- a/src/sidebar/test/media-embedder-test.js
+++ b/src/sidebar/test/media-embedder-test.js
@@ -297,15 +297,26 @@ describe('media-embedder', function () {
       'https://www.w3schools.com/html/horse.ogg',
       'https://www.w3schools.com/html/horse.ogg#fragment',
       'https://www.w3schools.com/html/horse.ogg?foo=bar&id=31',
+      'https://wisc.pb.unizin.org/frenchcscr/wp-content/uploads/sites/208/2018/03/6Léry_Conclusion.mp3',
+      'https://wisc.pb.unizin.org/frenchcscr/wp-content/uploads/sites/208/2018/03/6L%25C3%25A9ry_Conclusion.mp3',
     ];
     urls.forEach(function (url) {
       var element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
 
+      let encodedURL;
+      if (decodeURI(url) !== url) {
+        // Test URL is already percent-encoded.
+        encodedURL = url;
+      } else {
+        // Test URL needs percent-encoding.
+        encodedURL = encodeURI(url);
+      }
+
       assert.equal(element.childElementCount, 1);
       assert.equal(element.children[0].tagName, 'AUDIO');
-      assert.equal(element.children[0].src, url.toLowerCase());
+      assert.equal(element.children[0].src, encodedURL);
     });
   });
 


### PR DESCRIPTION
When a user pastes a link to a video or audio file in an annotation,
handle the case where the link contains non-ASCII characters but the
link's text has not been percent-encoded.

In that case the link's text content will be the unencoded form of the
URL, but the `link.href` property will return the percent-encoded form,
so the two do not compare equal and therefore the link was not replaced.