### PR TITLE
Make client search form accessible for screenreader users

### DIFF
--- a/src/sidebar/templates/search-input.html
+++ b/src/sidebar/templates/search-input.html
@@ -1,8 +1,9 @@
 <form class="simple-search-form"
       name="searchForm"
+      role="search"
       ng-class="!vm.query && 'simple-search-inactive'">
   <input class="simple-search-input"
-         type="text"
+         type="search"
          name="query"
          placeholder="{{vm.loading && 'Loading' || 'Search'}}…"
          ng-disabled="vm.loading"
@@ -10,7 +11,7 @@
   <button type="button" class="simple-search-icon top-bar__btn" ng-hide="vm.loading">
     <i class="h-icon-search"></i>
   </button>
-  <button type="button" class="simple-search-icon btn btn-clean" ng-show="vm.loading" disabled>
+  <button type="button" class="simple-search-icon btn btn-clean" aria-label="Search" ng-show="vm.loading" disabled>
     <span class="btn-icon"><span class="spinner"></span></span>
   </button>
 </form>


### PR DESCRIPTION
Part of accessibility fixes for clients as described in [Product Backlog #679](https://github.com/hypothesis/product-backlog/issues/679)
- The `form` element now contains `role="search"`
- The `text` input has `type="search"` instead of `type="text"`
- The `search` button has an `aria-label="Search"`