### PR TITLE
Fix "No results for {query}" message

### DIFF
--- a/src/sidebar/templates/sidebar-content.html
+++ b/src/sidebar/templates/sidebar-content.html
@@ -13,7 +13,7 @@
   filter-active="!!vm.search.query()"
   filter-match-count="vm.visibleCount()"
   on-clear-selection="vm.clearSelection()"
-  search-query="vm.search ? vm.search.query : ''"
+  search-query="vm.search.query()"
   selection-count="vm.selectedAnnotationCount()"
   total-count="vm.topLevelThreadCount()"
   selected-tab="vm.selectedTab"


### PR DESCRIPTION
Usage of `vm.search.query` in the `<sidebar-content>` template was
incorrect. `vm.search` is always set and `query` is a function that
returns a string, not a string.

Fixes #9