### PR TITLE
Add documentation for externalContainerSelector

### DIFF
--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -345,6 +345,28 @@ loads.
 
     ``Number``. The current visible width of the sidebar.
 
+.. option:: externalContainerSelector
+
+   .. warning::
+
+      This is an experimental API and may change in future.
+
+  ``string``. A CSS selector specifying the containing element into which the
+  sidebar iframe will be placed.
+
+  This option provides the publisher with more control over where the sidebar
+  is displayed on the screen and how and when it appears and disappears.
+
+  When this option is not specified, Hypothesis chooses where to place the
+  sidebar, typically on the right side of the page, and provides the user with
+  controls to open and close it.
+
+  When this option is specified, the sidebar will be created and placed inside
+  the specified element. Hypothesis will not display its own controls for
+  opening and closing the sidebar and will not display the "bucket bar" showing
+  where annotations are located on the page relative to the current scroll
+  position.
+
 
 Asset and Sidebar App Location
 ##############################


### PR DESCRIPTION
Document externalContainerSelector configuration option.

This is marked as experimental since it is new and may change based on
feedback from early users (eg. Atypon).

This API is also currently incomplete in that there are a number of
additional APIs needed to fully implement a custom sidebar container
which do not exist, eg. the ability for the host page to know when to
show or hide the sidebar as the user interacts with highlights in the
page.