### PR TITLE
Fix warnings about `Buffer` constructor during `gulp build`

### DIFF
--- a/scripts/gulp/manifest.js
+++ b/scripts/gulp/manifest.js
@@ -29,7 +29,7 @@ module.exports = function (opts) {
   }, function (callback) {
     var manifestFile = new VinylFile({
       path: opts.name,
-      contents: new Buffer(JSON.stringify(manifest, null, 2), 'utf-8'),
+      contents: Buffer.from(JSON.stringify(manifest, null, 2), 'utf-8'),
     });
     this.push(manifestFile);
     callback();


### PR DESCRIPTION
Fix warning about deprecated `Buffer` usage in Node 10 at the end of
`gulp build`.

See https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe