### PR TITLE
Hide "Public" group for logged-out users under certain conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",
     "request": "^2.76.0",
+    "reselect": "^3.0.1",
     "retry": "^0.8.0",
     "scroll-into-view": "^1.8.2",
     "seamless-immutable": "^6.0.1",

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+var { createSelector } = require('reselect');
+
 var arrayUtil = require('../../util/array-util');
 var metadata = require('../../annotation-metadata');
 var uiConstants = require('../../ui-constants');
@@ -383,13 +385,15 @@ function findAnnotationByID(state, id) {
  *
  * @return {Annotation|null}
  */
-function directLinkedAnnotation(state) {
-  var id = selection.selectors.directLinkedAnnotationId(state);
-  if (!id) {
-    return null;
+var directLinkedAnnotation = createSelector(
+  [state => state.annotations, selection.selectors.directLinkedAnnotationId],
+  (annotations, directLinkedAnnotationId) => {
+    if (!directLinkedAnnotationId) {
+      return null;
+    }
+    return findByID(annotations, directLinkedAnnotationId);
   }
-  return findAnnotationByID(state, id);
-}
+);
 
 module.exports = {
   init: init,

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -376,6 +376,21 @@ function findAnnotationByID(state, id) {
   return findByID(state.annotations, id);
 }
 
+/**
+ * Return the annotation that the user followed a direct-link to.
+ *
+ * Returns `null` if the annotation has not been loaded.
+ *
+ * @return {Annotation|null}
+ */
+function directLinkedAnnotation(state) {
+  var id = selection.selectors.directLinkedAnnotationId(state);
+  if (!id) {
+    return null;
+  }
+  return findAnnotationByID(state, id);
+}
+
 module.exports = {
   init: init,
   update: update,
@@ -391,6 +406,7 @@ module.exports = {
 
   selectors: {
     annotationExists,
+    directLinkedAnnotation,
     findAnnotationByID,
     findIDsForTags,
     savedAnnotations,

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -5,8 +5,6 @@
 
 'use strict';
 
-var { createSelector } = require('reselect');
-
 var arrayUtil = require('../../util/array-util');
 var metadata = require('../../annotation-metadata');
 var uiConstants = require('../../ui-constants');
@@ -76,6 +74,14 @@ function init() {
   return {
     annotations: [],
 
+    /**
+     * The ID of the group which the direct-linked annotation belongs to.
+     *
+     * This is stored as a separate field so it can be remembered even after
+     * the direct-linked annotation is unloaded.
+     */
+    directLinkedAnnotationGroup: null,
+
     // The local tag to assign to the next annotation that is loaded into the
     // app
     nextTag: 1,
@@ -92,10 +98,16 @@ var update = {
     var updated = [];
     var nextTag = state.nextTag;
 
+    var directLinkedAnnotationGroup = state.directLinkedAnnotationGroup;
+
     action.annotations.forEach(function (annot) {
       var existing;
       if (annot.id) {
         existing = findByID(state.annotations, annot.id);
+
+        if (annot.id === selection.selectors.directLinkedAnnotationId(state)) {
+          directLinkedAnnotationGroup = annot.group;
+        }
       }
       if (!existing && annot.$tag) {
         existing = findByTag(state.annotations, annot.$tag);
@@ -125,6 +137,7 @@ var update = {
 
     return {
       annotations: added.concat(updated).concat(unchanged),
+      directLinkedAnnotationGroup,
       nextTag: nextTag,
     };
   },
@@ -379,21 +392,14 @@ function findAnnotationByID(state, id) {
 }
 
 /**
- * Return the annotation that the user followed a direct-link to.
+ * Return the ID of the group that the direct-linked annotation belongs to.
  *
- * Returns `null` if the annotation has not been loaded.
- *
- * @return {Annotation|null}
+ * Returns `null` if no direct-linked annotation or it has not been loaded yet
+ * at least once.
  */
-var directLinkedAnnotation = createSelector(
-  [state => state.annotations, selection.selectors.directLinkedAnnotationId],
-  (annotations, directLinkedAnnotationId) => {
-    if (!directLinkedAnnotationId) {
-      return null;
-    }
-    return findByID(annotations, directLinkedAnnotationId);
-  }
-);
+function directLinkedAnnotationGroup(state) {
+  return state.directLinkedAnnotationGroup;
+}
 
 module.exports = {
   init: init,
@@ -410,7 +416,7 @@ module.exports = {
 
   selectors: {
     annotationExists,
-    directLinkedAnnotation,
+    directLinkedAnnotationGroup,
     findAnnotationByID,
     findIDsForTags,
     savedAnnotations,

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -4,7 +4,7 @@ const { createSelector } = require('reselect');
 
 const util = require('../util');
 const { profile } = require('./session').selectors;
-const { directLinkedAnnotation } = require('./annotations').selectors;
+const { directLinkedAnnotationGroup } = require('./annotations').selectors;
 
 function init() {
   return {
@@ -112,15 +112,14 @@ const hasNonWorldGroup = createSelector(
  * Return true if the "Public" group should be shown.
  */
 const shouldShowWorldGroup = createSelector(
-  [hasNonWorldGroup, profile, directLinkedAnnotation],
-  (hasNonWorldGroup, profile, directLinkedAnnotation) => {
+  [hasNonWorldGroup, profile, directLinkedAnnotationGroup],
+  (hasNonWorldGroup, profile, directLinkedAnnotationGroup) => {
     // Hide the "Public" group for logged-out users if the page has groups
     // associated with it, unless the user has followed a direct link to an
     // annotation in the "Public" group.
     let includeWorldGroup = true;
     if (hasNonWorldGroup && !profile.userid) {
-      const ann = directLinkedAnnotation;
-      includeWorldGroup = !!ann && isWorldGroup(ann.group);
+      includeWorldGroup = isWorldGroup(directLinkedAnnotationGroup);
     }
     return includeWorldGroup;
   }

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -114,14 +114,13 @@ const hasNonWorldGroup = createSelector(
 const shouldShowWorldGroup = createSelector(
   [hasNonWorldGroup, profile, directLinkedAnnotationGroup],
   (hasNonWorldGroup, profile, directLinkedAnnotationGroup) => {
-    // Hide the "Public" group for logged-out users if the page has groups
-    // associated with it, unless the user has followed a direct link to an
-    // annotation in the "Public" group.
-    let includeWorldGroup = true;
-    if (hasNonWorldGroup && !profile.userid) {
-      includeWorldGroup = isWorldGroup(directLinkedAnnotationGroup);
+    if (profile.userid !== null) {
+      // Logged-in users always see the "Public" group.
+      return true;
     }
-    return includeWorldGroup;
+    // Logged-out users only see it if it is the only group or they followed a
+    // direct link to an annotation in the "Public" group.
+    return !hasNonWorldGroup || isWorldGroup(directLinkedAnnotationGroup);
   }
 );
 

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -59,6 +59,8 @@ function freeze(selection) {
 
 function init(settings) {
   return {
+    directLinkedAnnotationId: settings.annotations,
+
     // Contains a map of annotation tag:true pairs.
     focusedAnnotationMap: null,
 
@@ -305,6 +307,10 @@ function clearSelectedAnnotations() {
   return {type: actions.CLEAR_SELECTION};
 }
 
+function directLinkedAnnotationId(state) {
+  return state.directLinkedAnnotationId;
+}
+
 module.exports = {
   init: init,
   update: update,
@@ -324,6 +330,7 @@ module.exports = {
   },
 
   selectors: {
+    directLinkedAnnotationId,
     hasSelectedAnnotations,
     isAnnotationSelected,
   },

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -122,30 +122,39 @@ describe('annotations reducer', function () {
     }]);
   });
 
-  describe('#directLinkedAnnotation', () => {
+  describe('#directLinkedAnnotationGroup', () => {
     var directLinkedAnn = {
       id: 'abcdef',
+      group: 'the-group-id',
     };
 
     it('returns null if no direct-linked annotation', () => {
       var store = createStore([annotations, selection], [{}]);
-      assert.equal(store.directLinkedAnnotation(), null);
+      assert.equal(store.directLinkedAnnotationGroup(), null);
     });
 
     it('returns null if direct-linked annotation not yet loaded', () => {
       var store = createStore([annotations, selection], [{
         annotations: directLinkedAnn.id,
       }]);
-      assert.equal(store.directLinkedAnnotation(), null);
+      assert.equal(store.directLinkedAnnotationGroup(), null);
     });
 
-    it('returns the direct-linked annotation if loaded', () => {
+    it("returns the direct-linked annotation's group after it is loaded", () => {
       var store = createStore([annotations, selection], [{
         annotations: directLinkedAnn.id,
       }]);
       store.addAnnotations([directLinkedAnn]);
-      assert.ok(store.directLinkedAnnotation());
-      assert.deepEqual(store.directLinkedAnnotation().id, directLinkedAnn.id);
+      assert.equal(store.directLinkedAnnotationGroup(), directLinkedAnn.group);
+    });
+
+    it('remembers the group after the direct-linked annotation is unloaded', () => {
+      var store = createStore([annotations, selection], [{
+        annotations: directLinkedAnn.id,
+      }]);
+      store.addAnnotations([directLinkedAnn]);
+      store.removeAnnotations([directLinkedAnn]);
+      assert.equal(store.directLinkedAnnotationGroup(), directLinkedAnn.group);
     });
   });
 });

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const createStore = require('../../create-store');
+const selection = require('../selection');
+
+// nb. Tests for most of the functionality in the "selection" module are
+// currently in the tests for the whole Redux store.
+
+describe('sidebar.store.modules.selection', () => {
+  describe('#directLinkedAnnotationId', () => {
+    it('returns null/undefined if no direct link was followed', () => {
+      const store = createStore([selection], [{}]);
+      assert.notOk(store.directLinkedAnnotationId());
+    });
+
+    it('returns direct-linked ID if specified', () => {
+      const store = createStore([selection], [{
+        annotations: 'some-id',
+      }]);
+      assert.equal(store.directLinkedAnnotationId(), 'some-id');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5973,6 +5973,10 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+
 resolve-dir@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"


### PR DESCRIPTION
As discussed in https://github.com/hypothesis/product-backlog/issues/702, hide the "Public" group in the client if:

 - The user is logged out
 - The page has associated groups
 - The user has not visited a direct link to an annotation in the "Public" group

This is implemented by making the `store.allGroups()` selector used by
the group list exclude the "Public" group under the above conditions.

A `directLinkedAnnotationId` field has been added to the selection state
to support this. This field is initialized from the settings passed
through to the sidebar app when it starts.

----

**TODO**

Two problems with the current approach:

- [ ] If the "Public" group is initially hidden, and the user logs in and selects it, then logs out again, the "Public" group remains selected but is no longer visible in the drop-down menu. This is because the `LOAD_GROUPS` action does not reset the focused group in that case.
- [ ] If the "Public" group was focused in a previous session, and if `groups.load()` completes _before_ the profile is fetched on startup, then `groups.load()` will have to make a decision about whether to focus the "Public" group without the guarantee that the current profile has been loaded first. In other words, the user _could_ be logged in (so "Public" should be kept focused), but `profile.userid` might be `null` (because the profile is still being fetched) at the point in `groups.load()` where the focus from the previous session is restored.

Also need to consider whether there could be other issues arising from introducing a difference between the groups that are _loaded_ (exist in the store) and the ones that are _displayed_ in the drop down list.