### PR TITLE
Use a pointer cursor for highlights

### DIFF
--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -9,13 +9,7 @@ $base-font-size: 14px;
 .annotator-highlights-always-on {
   .annotator-hl {
     background-color: $highlight-color;
-
-    // cursor pointer gives mobile devices click
-    // event support. Using the pointer:coarse gives
-    // us good targeting to mobile devices that this effects
-    @media (pointer:coarse) {
-      cursor: pointer;
-    }
+    cursor: pointer;
   }
 
   .annotator-hl .annotator-hl {


### PR DESCRIPTION
The `annotator-hl` class contains a `cursor: pointer;` rule already, but
it only applies to mobile devices (more precisely, devices which lack a
sufficiently accurate primary pointer, like a mouse). I simply removed
this restriction so that the rule applies across the board.

Closes: hypothesis/product-backlog#703