### PR TITLE
Remove unnecessary extra `/api/groups` call on startup

### DIFF
--- a/src/sidebar/events.js
+++ b/src/sidebar/events.js
@@ -11,8 +11,6 @@ module.exports = {
 
   // Session state changes
 
-  /** The list of groups changed */
-  GROUPS_CHANGED: 'groupsChanged',
   /** The logged-in user changed */
   USER_CHANGED: 'userChanged',
   /**

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -20,11 +20,6 @@ var serviceConfig = require('../service-config');
 // @ngInject
 function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, session,
                 settings) {
-
-  // The document URI passed to the most recent `GET /api/groups` call in order
-  // to include groups associated with this page.
-  var documentUri;
-
   var svc = serviceConfig(settings);
   var authority = svc ? svc.authority : null;
 
@@ -42,6 +37,12 @@ function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, ses
     }
     return awaitStateChange(store, mainUri);
   }
+
+  // The document URI passed to the most recent `GET /api/groups` call in order
+  // to include groups associated with this page. This is retained to determine
+  // whether we need to re-fetch groups if the URLs of frames connected to the
+  // sidebar app changes.
+  var documentUri;
 
   /**
    * Fetch the list of applicable groups from the API.

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -20,6 +20,9 @@ var serviceConfig = require('../service-config');
 // @ngInject
 function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, session,
                 settings) {
+
+  // The document URI passed to the most recent `GET /api/groups` call in order
+  // to include groups associated with this page.
   var documentUri;
 
   var svc = serviceConfig(settings);
@@ -61,6 +64,7 @@ function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, ses
       if (uri) {
         params.document_uri = uri;
       }
+      documentUri = uri;
       return api.groups.list(params);
     }).then(groups => {
       var isFirstLoad = store.allGroups().length === 0;
@@ -141,8 +145,6 @@ function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, ses
 
   // refetch the list of groups when document url changes
   $rootScope.$on(events.FRAME_CONNECTED, () => {
-    // FIXME Makes a third api call on page load. better way?
-    // return for use in test
     return getDocumentUriForGroupSearch().then(uri => {
       if (documentUri !== uri) {
         documentUri = uri;

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -130,12 +130,6 @@ function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, ses
     }
   });
 
-  // reset the focused group if the user leaves it
-  $rootScope.$on(events.GROUPS_CHANGED, function () {
-    // return for use in test
-    return load();
-  });
-
   // refetch the list of groups when user changes
   $rootScope.$on(events.USER_CHANGED, () => {
     // FIXME Makes a second api call on page load. better way?

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -68,7 +68,7 @@ describe('groups', function() {
       },
 
       $on: function(event, callback) {
-        if (event === events.GROUPS_CHANGED || event === events.USER_CHANGED || event === events.FRAME_CONNECTED) {
+        if (event === events.USER_CHANGED || event === events.FRAME_CONNECTED) {
           this.eventCallbacks[event] = callback;
         }
       },
@@ -250,18 +250,13 @@ describe('groups', function() {
   });
 
   describe('calls load on various events', function () {
-    var changeEvents = [
-      {event: events.GROUPS_CHANGED},
-      {event: events.USER_CHANGED},
-    ];
-
-    unroll('should fetch the list of groups from the server when #event occurs', function (testCase) {
+    it('refetches groups when the logged-in user changes', () => {
       service();
 
-      return fakeRootScope.eventCallbacks[testCase.event]().then(() => {
+      return fakeRootScope.eventCallbacks[events.USER_CHANGED]().then(() => {
         assert.calledOnce(fakeApi.groups.list);
       });
-    }, changeEvents);
+    });
 
     context('when a new frame connects', () => {
       it('should refetch groups if main frame URL has changed', () => {

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -3,7 +3,6 @@
 var events = require('../../events');
 var fakeReduxStore = require('../../test/fake-redux-store');
 var groups = require('../groups');
-var unroll = require('../../../shared/test/util').unroll;
 
 // Return a mock session service containing three groups.
 var sessionWithThreeGroups = function() {


### PR DESCRIPTION
This PR fixes an unnecessary extra `GET /api/groups` call on startup. See the first commit for details. Note that on a typical startup there will often still be _two_ `GET /api/groups` calls. Fixing the second extra call is a task for a separate PR.

The second commit cleans up some related code by removing a `GROUPS_CHANGED` event handler which never gets called any more.