### PR TITLE
Hide "Public" group for unauthenticated users (alternate implementation)

### DIFF
--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -237,6 +237,20 @@ function SidebarContentController(
     store.profile().userid,
     ...store.searchUris(),
   ]), ([currentGroupId], [prevGroupId]) => {
+    // FIXME - There is a bug here where the set of displayed annotations can
+    // end up not matching the focused group when the user logs out.
+    //
+    // When a user logs in or out, we re-fetch profile and group information
+    // concurrently. If the profile fetch completes first, it will trigger
+    // an annotation fetch. If the group fetch then completes before the
+    // annotation fetch, and the focused group changes due to the previous
+    // focused group not being in the new set of groups, then the `if` below
+    // will skip refetching annotations a second time. This will result in the
+    // wrong set of displayed annotations.
+    //
+    // This should only affect users logging out because the set of groups for
+    // logged-in users is currently a superset of those for logged-out users on
+    // any given page.
 
     if (currentGroupId !== prevGroupId) {
       // The focused group may be changed during loading annotations as a result

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -137,15 +137,13 @@ function createAPICall($http, $q, links, route, tokenGetter) {
     // `$q.all` is used here rather than `Promise.all` because testing code that
     // mixes native Promises with the `$q` promises returned by `$http`
     // functions gets awkward in tests.
-    var token;
-    return $q.all([links, tokenGetter()]).then(function (linksAndToken) {
-      var links = linksAndToken[0];
-      token = linksAndToken[1];
-
+    var accessToken;
+    return $q.all([links, tokenGetter()]).then(([links, token]) => {
       var descriptor = get(links, route);
       var url = urlUtil.replaceURLParams(descriptor.url, params);
       var headers = {};
 
+      accessToken = token;
       if (token) {
         headers.Authorization = 'Bearer ' + token;
       }
@@ -161,7 +159,7 @@ function createAPICall($http, $q, links, route, tokenGetter) {
       return $http(req);
     }).then(function (response) {
       if (options.includeMetadata) {
-        return { data: response.data, token };
+        return { data: response.data, token: accessToken };
       } else {
         return response.data;
       }

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -95,6 +95,15 @@ function serializeParams(params) {
 }
 
 /**
+ * Function which makes an API request.
+ *
+ * @typedef {function} APICallFunction
+ * @param [any] params - A map of URL and query string parameters to include with the request.
+ * @param [any] data - The body of the request.
+ * @return {Promise<any>}
+ */
+
+/**
  * Creates a function that will make an API call to a named route.
  *
  * @param $http - The Angular HTTP service
@@ -104,6 +113,7 @@ function serializeParams(params) {
  * @param route - The dotted path of the named API route (eg. `annotation.create`)
  * @param {Function} tokenGetter - Function which returns a Promise for an
  *                   access token for the API.
+ * @return {APICallFunction}
  */
 function createAPICall($http, $q, links, route, tokenGetter) {
   return function (params, data) {
@@ -148,7 +158,16 @@ function createAPICall($http, $q, links, route, tokenGetter) {
  * API client for the Hypothesis REST API.
  *
  * Returns an object that with keys that match the routes in
- * the Hypothesis API (see http://h.readthedocs.io/en/latest/api/).
+ * the Hypothesis API (see http://h.readthedocs.io/en/latest/api/). See
+ * `APICallFunction` for the syntax of API calls. For example:
+ *
+ * ```
+ * api.annotations.update({ id: '1234' }, annotation).then(ann => {
+ *   // Do something with the updated annotation.
+ * }).catch(err => {
+ *   // Do something if the API call fails.
+ * });
+ * ```
  *
  * This service handles authenticated calls to the API, using the `auth` service
  * to get auth tokens. The URLs for API endpoints are fetched from the `/api`

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -38,17 +38,65 @@ function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, ses
     return awaitStateChange(store, mainUri);
   }
 
+  /**
+   * Filter the returned list of groups from the API.
+   *
+   * `filterGroups` performs client-side filtering to hide the "Public" group
+   * for logged-out users under certain conditions.
+   *
+   * @param {Group[]} groups
+   * @param {boolean} isLoggedIn
+   * @param {string|null} directLinkedAnnotationId
+   * @return {Promise<Group[]>}
+   */
+  function filterGroups(groups, isLoggedIn, directLinkedAnnotationId) {
+    // Logged-in users always see the "Public" group.
+    if (isLoggedIn) {
+      return Promise.resolve(groups);
+    }
+
+    // If the main document URL has no groups associated with it, always show
+    // the "Public" group.
+    var pageHasAssociatedGroups = groups.some(g => g.id !== '__world__');
+    if (!pageHasAssociatedGroups) {
+      return Promise.resolve(groups);
+    }
+
+    // Hide the "Public" group, unless the user specifically visited a direct-
+    // link to an annotation in that group.
+    var nonWorldGroups = groups.filter(g => g.id !== '__world__');
+
+    if (!directLinkedAnnotationId) {
+      return Promise.resolve(nonWorldGroups);
+    }
+
+    return api.annotation.get({ id: directLinkedAnnotationId }).then(ann => {
+      if (ann.group === '__world__') {
+        return groups;
+      } else {
+        return nonWorldGroups;
+      }
+    }).catch(() => {
+      // Annotation does not exist or we do not have permission to read it.
+      // Assume it is not in "Public".
+      return nonWorldGroups;
+    });
+  }
+
   // The document URI passed to the most recent `GET /api/groups` call in order
   // to include groups associated with this page. This is retained to determine
   // whether we need to re-fetch groups if the URLs of frames connected to the
   // sidebar app changes.
   var documentUri;
 
+
   /**
    * Fetch the list of applicable groups from the API.
    *
    * The list of applicable groups depends on the current userid and the URI of
    * the attached frames.
+   *
+   * @return {Promise<Group[]>}
    */
   function load() {
     var uri = Promise.resolve(null);
@@ -66,7 +114,13 @@ function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, ses
         params.document_uri = uri;
       }
       documentUri = uri;
-      return api.groups.list(params);
+
+      // Fetch groups from the API.
+      return api.groups.list(params, null, { includeMetadata: true });
+    }).then(({ data, token }) => {
+      var isLoggedIn = token !== null;
+      var directLinkedAnnotation = settings.annotations;
+      return filterGroups(data, isLoggedIn, directLinkedAnnotation);
     }).then(groups => {
       var isFirstLoad = store.allGroups().length === 0;
       var prevFocusedGroup = localStorage.getItem(STORAGE_KEY);
@@ -76,7 +130,7 @@ function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, ses
         store.focusGroup(prevFocusedGroup);
       }
 
-      return store.allGroups();
+      return groups;
     });
   }
 

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -303,4 +303,31 @@ describe('sidebar.services.api', function () {
       $httpBackend.flush();
     });
   });
+
+  it('API calls return just the JSON response if `includeMetadata` is false', () => {
+    api.profile.read({}).then(response => {
+      assert.match(response, sinon.match({
+        userid: 'acct:user@example.com',
+      }));
+    });
+
+    $httpBackend.expectGET('http://example.com/api/profile')
+    .respond(() => [200, { userid: 'acct:user@example.com' }]);
+    $httpBackend.flush();
+  });
+
+  it('API calls return an `APIResponse` if `includeMetadata` is true', () => {
+    api.profile.read({}, null, { includeMetadata: true }).then(response => {
+      assert.match(response, sinon.match({
+        data: {
+          userid: 'acct:user@example.com',
+        },
+        token: 'faketoken',
+      }));
+    });
+
+    $httpBackend.expectGET('http://example.com/api/profile')
+    .respond(() => [200, { userid: 'acct:user@example.com' }]);
+    $httpBackend.flush();
+  });
 });


### PR DESCRIPTION
This is an alternate implementation for 
https://github.com/hypothesis/product-backlog/issues/702 which hides the "Public" group for logged-out users. Unlike my first attempt in https://github.com/hypothesis/client/pull/751 it localizes the changes to the "groups" service and avoids introducing a new distinction between the "loaded" groups and "visible" groups which then potentially complicates a lot of other code.

There _is_ a known bug when logging out. See the comment in `sidebar-content.js`. However while I think that ought to be addressed, I don't think it is really going to bother users and so IMO we can leave it for a separate task.

The first two commits add some API docs for the "api" service and introduce a new capability to return additional metadata to callers beyond just the JSON response. Currently this includes the access token that was used to make the request.

The groups service then makes use of this metadata when calling `/api/groups` to determine whether the groups were fetched as a logged-in or logged-out user and filter out the "Public" group accordingly. The reason for doing this rather than just looking at `store.profile().userid` is because we fetch the user's profile and groups concurrently on startup and don't want to have to serialize the requests as this would add a delay before we can start loading annotations.