### PR TITLE
Inject a default organization into groups objects without organizations

### DIFF
--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -1,6 +1,15 @@
 'use strict';
 
 var STORAGE_KEY = 'hypothesis.groups.focus';
+const DEFAULT_ORG_ID = '__default__';
+
+/**
+ * FIXME: There is almost assuredly a better way to handle a fallback, default logo
+ */
+const DEFAULT_ORGANIZATION = {
+  id: DEFAULT_ORG_ID,
+  logo: 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" class="svg-icon masthead-logo" height="28" viewBox="0 0 24 28" width="24"><path d="M3.886 3.945H21.03v16.047H3.886z" fill="#fff" /><path d="M0 2.005C0 .898.897 0 2.005 0h19.99C23.102 0 24 .897 24 2.005v19.99A2.005 2.005 0 0 1 21.995 24H2.005A2.005 2.005 0 0 1 0 21.995V2.005zM9 24l3 4 3-4H9zM7.008 4H4v16h3.008v-4.997C7.008 12.005 8.168 12.01 9 12c1 .007 2.019.06 2.019 2.003V20h3.008v-6.891C14.027 10 12 9.003 10 9.003c-1.99 0-2 0-2.992 1.999V4zM19 19.987c1.105 0 2-.893 2-1.994A1.997 1.997 0 0 0 19 16c-1.105 0-2 .892-2 1.993s.895 1.994 2 1.994z" fill="currentColor" fill-rule="evenodd" /></svg>',
+};
 
 var events = require('../events');
 var { awaitStateChange } = require('../util/state-util');
@@ -72,6 +81,22 @@ function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, ses
     });
   }
 
+  /**
+   * For any group that does not have an associated organization, populate with
+   * the default Hypothesis organization.
+   *
+   * Mutates group objects in place
+   *
+   * @param {Group[]} groups
+   */
+  function injectOrganizations(groups) {
+    groups.forEach(group => {
+      if (!group.organization || typeof group.organization !== 'object') {
+        group.organization = DEFAULT_ORGANIZATION;
+      }
+    });
+  }
+
   // The document URI passed to the most recent `GET /api/groups` call in order
   // to include groups associated with this page. This is retained to determine
   // whether we need to re-fetch groups if the URLs of frames connected to the
@@ -111,6 +136,8 @@ function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, ses
       var directLinkedAnnotation = settings.annotations;
       return filterGroups(data, isLoggedIn, directLinkedAnnotation);
     }).then(groups => {
+      injectOrganizations(groups);
+
       var isFirstLoad = store.allGroups().length === 0;
       var prevFocusedGroup = localStorage.getItem(STORAGE_KEY);
 

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -205,6 +205,21 @@ describe('groups', function() {
       });
     });
 
+    it('injects a defalt organization if group is missing an organization', function () {
+      var svc = service();
+      const groups = [
+        { id: '39r39f', name: 'Ding Dong!' },
+      ];
+      fakeApi.groups.list.returns(Promise.resolve({
+          token: '1234',
+          data: groups,
+      }));
+      return svc.load().then(groups => {
+        assert.isObject(groups[0].organization);
+        assert.hasAllKeys(groups[0].organization, ['id', 'logo']);
+      });
+    });
+
     truthTable(3).forEach(([ loggedIn, pageHasAssociatedGroups, directLinkToPublicAnnotation ]) => {
       it('excludes the "Public" group if user logged out and page has associated groups', () => {
         var svc = service();


### PR DESCRIPTION
The way the client app is currently structured, things fall apart if a given group doesn't have an associated organization object with a logo. I spent quite some time and some dead-end branches trying to be more clever about a fallback logo and situation when a group doesn't have an organization, but it got wildly complex, almost immediately.

This approach felt like the safest way to make the client tolerate groups with missing organization relations until we can look at the bigger picture here. Any group without an organization will be treated as if it is within the default, Hypothesis organization—and will carry the Hypothesis logo, for now.

This will allow us to support third-party private groups in the client in the short term—and we're under some time pressure here.

This PR does _not_ have any dependencies on changes in `h` (though the inverse is most definitely not true).