### PR TITLE
Update to Node 10 for Jenkins and Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ matrix:
     # 'node_js' is listed for each job to ensure that only two builds are run.
     # See https://github.com/hypothesis/client/pull/27#discussion_r70611726
     - env: ACTION=lint
-      node_js: '6.10'
+      node_js: '10'
       script: yarn run lint
     - env: ACTION=test
-      node_js: '6.10'
+      node_js: '10'
       after_success:
         yarn run report-coverage

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 node {
     checkout scm
 
-    nodeEnv = docker.image("kkarczmarczyk/node-yarn:7.5")
+    nodeEnv = docker.image("node:10")
     workspace = pwd()
     pkgVersion = sh (
       script: 'cat package.json | jq -r .version',


### PR DESCRIPTION
The official Docker node builds now have yarn preinstalled, so I switched to use that instead of a community-provided image.