### PR TITLE
Add "requestConfigFromFrame" string setting

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -24,6 +24,7 @@ function configFrom(window_) {
     onLayoutChange: settings.hostPageSetting('onLayoutChange'),
     openSidebar: settings.hostPageSetting('openSidebar', {allowInBrowserExt: true}),
     query: settings.query,
+    requestConfigFromFrame: settings.hostPageSetting('requestConfigFromFrame'),
     services: settings.hostPageSetting('services'),
     showHighlights: settings.showHighlights,
     sidebarAppUrl: settings.sidebarAppUrl,

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -87,15 +87,17 @@ describe('annotator.config.index', function() {
 
   [
     'assetRoot',
-    'openSidebar',
     'branding',
+    'openSidebar',
+    'requestConfigFromFrame',
     'services',
   ].forEach(function(settingName) {
     it('returns the ' + settingName + ' value from the host page', function() {
       var settings = {
         'assetRoot': 'chrome-extension://1234/client/',
-        'openSidebar': 'OPEN_SIDEBAR_SETTING',
         'branding': 'BRANDING_SETTING',
+        'openSidebar': 'OPEN_SIDEBAR_SETTING',
+        'requestConfigFromFrame': 'https://embedder.com',
         'services': 'SERVICES_SETTING',
       };
       fakeSettingsFrom().hostPageSetting = function(settingName) {

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -35,6 +35,9 @@ function hostPageConfig(window) {
     // This should be removed once new note button is enabled for everybody.
     'enableExperimentalNewNoteButton',
 
+    // Fetch config from a parent frame.
+    'requestConfigFromFrame',
+
     // Theme which can either be specified as 'clean'.
     // If nothing is the specified the classic look is applied.
     'theme',

--- a/src/sidebar/test/host-config-test.js
+++ b/src/sidebar/test/host-config-test.js
@@ -16,6 +16,7 @@ describe('hostPageConfig', function () {
       annotations: '1234',
       appType: 'bookmarklet',
       openSidebar: true,
+      requestConfigFromFrame: 'https://embedder.com',
       showHighlights: true,
       services: [{
         authority: 'hypothes.is',
@@ -26,6 +27,7 @@ describe('hostPageConfig', function () {
       annotations: '1234',
       appType: 'bookmarklet',
       openSidebar: true,
+      requestConfigFromFrame: 'https://embedder.com',
       showHighlights: true,
       services: [{
         authority: 'hypothes.is',


### PR DESCRIPTION
This setting will cause the sidebar app to fetch its configuration via
a postMessage request to frames with the given origin on startup.

The setting is not actually used yet. This is coming in future commits.