### PR TITLE
Fix leaving a group from the client

### DIFF
--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -169,7 +169,7 @@ function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, ses
     // by optimistically updating the session state
     return api.group.member.delete({
       pubid: id,
-      user: 'me',
+      userid: 'me',
     });
   }
 

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -314,7 +314,7 @@ describe('groups', function() {
       return s.leave('id2').then(() => {
         assert.calledWithMatch(fakeApi.group.member.delete, {
           pubid: 'id2',
-          user: 'me',
+          userid: 'me',
         });
       });
     });


### PR DESCRIPTION
https://github.com/hypothesis/h/commit/46e4bbadc991d550ca9706b5237e35d68675a6cc
made a breaking change to the public API of the endpoint for removing
the current user from a group by renaming the "user" path parameter to
"userid".

Given that this change has been out for some time, I have opted to fix
the client rather than revert the change in the service.

Fixes #774