### PR TITLE
Use custom name for global `require` function

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -287,7 +287,7 @@ function generateBootScript(manifest) {
     .pipe(replace('__SIDEBAR_APP_URL__', defaultSidebarAppUrl))
     // Strip sourcemap link. It will have been invalidated by the previous
     // replacements and the bundle is so small that it isn't really valuable.
-    .pipe(replace(/^\/\/# sourceMappingURL=[^ ]+$/m,''))
+    .pipe(replace(/^\/\/# sourceMappingURL=\S+$/m,''))
     .pipe(rename('boot.js'))
     .pipe(gulp.dest('build/'));
 }


### PR DESCRIPTION
Browserify bundles that make their modules available for other bundles to consume define a global `require` function. This is then imported by other bundles and used to resolve module lookups.

This `require` name can clash with web pages that use eg. RequireJS.
Most of the time this isn't a problem because all of the page's own code
has run by the time Hypothesis loads. If however the page loads
additional scripts after Hypothesis has been loaded, they will end up
finding Hypothesis's `require` instead of their own.

This commit resolves the issue by renaming the global `require` function
to `hypothesisRequire` in two steps:

 - The `externalRequireName` Browserify option changes the _exported_
   name.
 - A custom transform stream post-processes the Browserify bundle code
   to change the _imported_ name, since Browserify doesn't have an
   option for this itself.

A small fix was needed to the `boot.js` script build to avoid stripping
lines _after_ the sourcemap URL comment, instead of just that comment.

Fixes #779