### PR TITLE
Skip builds of automated commits on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,16 @@ node {
         npmTag = "prerelease"
     }
 
+    lastCommitAuthor = sh (
+      script: 'git show HEAD --no-patch --format="%an"',
+      returnStdout: true
+    ).trim()
+
+    if (lastCommitAuthor == "jenkins-hypothesis") {
+        echo "Skipping build of automated commit created by Jenkins"
+        return
+    }
+
     pkgName = sh (
       script: 'cat package.json | jq -r .name',
       returnStdout: true


### PR DESCRIPTION
As part of the deployment process Jenkins creates a new commit on master
in order to bump the npm package version.

There is no point in creating an automated build of these commits, which
can be identified by the commiter name.