### PR TITLE
Fix IE 11 JS error which annotating PDFs.

### DIFF
--- a/src/annotator/anchoring/pdf.coffee
+++ b/src/annotator/anchoring/pdf.coffee
@@ -285,7 +285,9 @@ exports.describe = (root, range, options = {}) ->
   startPageIndex = getSiblingIndex(startTextLayer.parentNode)
   endPageIndex = getSiblingIndex(endTextLayer.parentNode)
 
-  iter = document.createNodeIterator(startTextLayer, NodeFilter.SHOW_TEXT)
+  # The `whatToShow`, `filter` and `expandEntityReferences` arguments are
+  # mandatory in IE although optional according to the spec.
+  iter = document.createNodeIterator(startTextLayer, NodeFilter.SHOW_TEXT, null, false);
 
   start = seek(iter, range.start)
   end = seek(iter, range.end) + start + range.end.textContent.length


### PR DESCRIPTION
The `whatToShow`, `filter` and `expandEntityReferences` arguments for
`Document.createNodeIterator()` are mandatory in IE although optional
according to the spec.
Pass default values to fix JS console errors.

See: https://github.com/hypothesis/client/issues/762