### PR TITLE
Fix "Log in" links in sidebar content area not opening login prompt.

### DIFF
--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -355,6 +355,7 @@ module.exports = {
   bindings: {
     auth: '<',
     search: '<',
+    onLogin: '&',
   },
   template: require('../templates/sidebar-content.html'),
 };

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -82,7 +82,7 @@ function configureRoutes($routeProvider) {
       resolve: resolve,
     });
   $routeProvider.otherwise({
-    template: '<sidebar-content search="vm.search" auth="vm.auth"></sidebar-content>',
+    template: '<sidebar-content search="vm.search" auth="vm.auth" on-login="vm.login()"></sidebar-content>',
     reloadOnSearch: false,
     resolve: resolve,
   });

--- a/src/sidebar/templates/sidebar-content.html
+++ b/src/sidebar/templates/sidebar-content.html
@@ -29,7 +29,7 @@
       This annotation is not available.
       <br>
       You may need to
-      <a class="loggedout-message__link" href="" ng-click="vm.login()">log in</a>
+      <a class="loggedout-message__link" href="" ng-click="vm.onLogin()">log in</a>
       to see it.
     </span>
     <span ng-if="vm.auth.status === 'logged-in'">
@@ -47,5 +47,5 @@
   thread="vm.rootThread">
 </thread-list>
 
-<loggedout-message ng-if="vm.shouldShowLoggedOutMessage()" on-login="vm.login()">
+<loggedout-message ng-if="vm.shouldShowLoggedOutMessage()" on-login="vm.onLogin()">
 </loggedout-message>


### PR DESCRIPTION
The loggedout-message controller should bind onLogin. The sidebar-content
controller should also bind onLogin and call vm.login(). Previously this behavior
was broken and resulted in nothing happening when the user clicked the log in text.

This is a fix for https://github.com/hypothesis/h/issues/5234.

