### PR TITLE
Add missing polyfill for IE 11 compatibility when annotating PDFs

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "dom-anchor-fragment": "^1.0.1",
     "dom-anchor-text-position": "^4.0.0",
     "dom-anchor-text-quote": "^4.0.2",
+    "dom-node-iterator": "^3.5.3",
     "dom-seek": "^4.0.3",
     "end-of-stream": "^1.1.0",
     "escape-html": "^1.0.3",

--- a/src/annotator/anchoring/pdf.coffee
+++ b/src/annotator/anchoring/pdf.coffee
@@ -1,5 +1,8 @@
 seek = require('dom-seek')
 
+# `dom-node-iterator` polyfills optional arguments of `createNodeIterator`
+# and properties of the returned `NodeIterator` for IE 11 compatibility.
+createNodeIterator = require('dom-node-iterator/polyfill')()
 xpathRange = require('./range')
 
 html = require('./html')
@@ -285,9 +288,7 @@ exports.describe = (root, range, options = {}) ->
   startPageIndex = getSiblingIndex(startTextLayer.parentNode)
   endPageIndex = getSiblingIndex(endTextLayer.parentNode)
 
-  # The `whatToShow`, `filter` and `expandEntityReferences` arguments are
-  # mandatory in IE although optional according to the spec.
-  iter = document.createNodeIterator(startTextLayer, NodeFilter.SHOW_TEXT, null, false);
+  iter = createNodeIterator.call(document, startTextLayer, NodeFilter.SHOW_TEXT)
 
   start = seek(iter, range.start)
   end = seek(iter, range.end) + start + range.end.textContent.length

--- a/yarn.lock
+++ b/yarn.lock
@@ -2416,7 +2416,7 @@ dom-anchor-text-quote@^4.0.2:
     diff-match-patch "^1.0.0"
     dom-anchor-text-position "^4.0.0"
 
-dom-node-iterator@^3.5.0:
+dom-node-iterator@^3.5.0, dom-node-iterator@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/dom-node-iterator/-/dom-node-iterator-3.5.3.tgz#32b68aa440962f1734487029f544a3db704637b7"
   integrity sha1-MraKpECWLxc0SHAp9USj23BGN7c=


### PR DESCRIPTION
The `seek` function from the `dom-seek` package expects its
`NodeIterator` argument to have a `referenceNode` property, which is
missing in IE 11.

Use the dom-node-iterator package recommended by the dom-seek README [1] to
polyfill optional-ness of arguments to `document.createNodeIterator` and
the missing properties on the returned `NodeIterator` object.

dom-node-iterator provides several ways to use the polyfill. This commit
uses the method that prefers the browser's native implementation if possible
and does not pollute the global scope, which could affect JS code
outside of the Hypothesis client.

There is one other place where we use `createNodeIterator` but in that
context the missing properties are not used so the polyfill is not
needed.

Fixes #762

[1] https://github.com/tilgovi/dom-seek/blob/master/README.md