### PR TITLE
Use build milestones to automatically abort old builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,8 +65,10 @@ node {
         return
     }
 
+    milestone()
     stage('Publish') {
         input(message: "Publish new client release?")
+        milestone()
 
         newPkgVersion = bumpMinorVersion(pkgVersion)
         if (versionSuffix != "") {


### PR DESCRIPTION
Use milestones to automatically abort older builds when a newer build
reaches the same step of the pipeline.

This mirrors the use of milestones in h's Jenkins pipeline.

See https://wiki.jenkins.io/display/JENKINS/Pipeline+Milestone+Step+Plugin and https://github.com/hypothesis/h/blob/59dbbf6a7424ea2e4e44bef75b0d27e35a48d74a/Jenkinsfile#L56