### PR TITLE
Add service.groups setting to filter groups

### DIFF
--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -186,6 +186,15 @@ loads.
       group. The image should be suitable for display at 16x16px and the
       recommended format is SVG.
 
+   .. option:: groups
+
+      ``String[]|null``. An array of group IDs. If provided, the list of groups
+      fetched from the API will be filtered against this list so that the user
+      can only select from these groups.
+
+      This can be useful in contexts where it is important that annotations
+      are made in a particular group.
+
    .. option:: onLoginRequest
 
      ``function``. A JavaScript function that the Hypothesis client will

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -48,6 +48,13 @@ function groups($rootScope, store, api, isSidebar, localStorage, serviceUrl, ses
    * @return {Promise<Group[]>}
    */
   function filterGroups(groups, isLoggedIn, directLinkedAnnotationId) {
+    // If service groups are specified only return those.
+    // If a service group doesn't exist in the list of groups don't return it.
+    if (svc && svc.groups) {
+      const focusedGroups = groups.filter(g => svc.groups.includes(g.id));
+      return Promise.resolve(focusedGroups);
+    }
+
     // Logged-in users always see the "Public" group.
     if (isLoggedIn) {
       return Promise.resolve(groups);

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -253,6 +253,46 @@ describe('groups', function() {
         });
       });
     });
+
+    [{
+      description: 'shows service groups',
+      services: [{ groups: ['abc123']}],
+      expected: ['abc123'],
+    },{
+      description: 'only shows service groups that exist',
+      services: [{ groups: ['abc123', 'no_exist']}],
+      expected: ['abc123'],
+    },{
+      description: 'shows no groups if no service groups exist',
+      services: [{ groups: ['no_exist']}],
+      expected: [],
+    },{
+      description: 'shows all groups if service is null',
+      services: null,
+      expected: ['__world__', 'abc123'],
+    },{
+      description: 'shows all groups if service groups does not exist',
+      services: [{}],
+      expected: ['__world__', 'abc123'],
+    }].forEach(({ description, services, expected }) => {
+      it(description, () => {
+        fakeSettings.services = services;
+        const svc = service();
+
+        // Create groups response from server.
+        const groups = [{ name: 'Public', id: '__world__' }, { name: 'ABC', id: 'abc123'}];
+
+        fakeApi.groups.list.returns(Promise.resolve({
+          token: '1234',
+          data: groups,
+        }));
+
+        return svc.load().then(groups => {
+          let displayedGroups = groups.map(g => g.id);
+          assert.deepEqual(displayedGroups, expected);
+        });
+      });
+    });
   });
 
   describe('#get', function() {


### PR DESCRIPTION
service.groups config option is used to specify a subset of groups to be displayed in the group drop down list on the sidebar.

This is a fix for https://github.com/hypothesis/product-backlog/issues/852.