### PR TITLE
Set a useful title on the sidebar iframe

### DIFF
--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -39,6 +39,7 @@ module.exports = class Host extends Guest
     .attr('allowfullscreen', '')
     .attr('seamless', '')
     .attr('src', sidebarAppSrc)
+    .attr('title', 'Hypothesis annotation viewer')
     .addClass('h-sidebar-iframe')
 
     externalContainer = null


### PR DESCRIPTION
This makes it easier to identify the purpose of the frame when
navigating the page with assistive technology.

I noticed this when testing the behaviour of the spinner PR with VoiceOver enabled.

Fixes https://github.com/hypothesis/product-backlog/issues/784