### PR TITLE
Use atomic git push during release process

### DIFF
--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -13,7 +13,8 @@ fi
 
 # nb. The remote refname is fully qualified because this script is run in a CI
 # environment where not all heads may have been fetched.
-git push https://github.com/hypothesis/client.git HEAD:refs/heads/$BRANCH_NAME --follow-tags
+git push https://github.com/hypothesis/client.git HEAD:refs/heads/$BRANCH_NAME \
+  --follow-tags --atomic
 
 # Wait a moment to give GitHub a chance to realize that the tag exists
 sleep 2


### PR DESCRIPTION
Ensure that the release tag is only pushed to GitHub if the release
commit can also be pushed to master.

We are likely to change the release process soon to avoid the need to
push to master at all (see https://github.com/hypothesis/client/issues/810)
but in the meantime this prevents a scenario where:

 - A tag vX.Y.Z gets created
 - The package version is still at X.Y.(Z-1) on master
 - Subsequent builds of master fail because they try and fail to create
   a tag vX.Y.Z which already exists