### PR TITLE
Fix build under Node 11

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5669,9 +5669,9 @@ native-promise-only@^0.8.1:
   integrity sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=
 
 natives@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
-  integrity sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g==
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+  integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Upgrade `natives` indirect dependency using method described at
https://github.com/yarnpkg/yarn/issues/4986#issuecomment-395036563.

See also: https://github.com/isaacs/natives/issues/14