### PR TITLE
Support recent versions of PDF.js

### DIFF
--- a/src/annotator/plugin/pdf-metadata.js
+++ b/src/annotator/plugin/pdf-metadata.js
@@ -38,13 +38,20 @@ class PDFMetadata {
     this._loaded = new Promise(resolve => {
       const finish = () => {
         window.removeEventListener('documentload', finish);
+        window.removeEventListener('documentloaded', finish);
         resolve(app);
       };
 
       if (app.downloadComplete) {
         resolve(app);
       } else {
+        // Listen for either the `documentload` (older PDF.js) or
+        // `documentloaded` (newer PDF.js) events which signal that the document
+        // has been downloaded and the first page has been rendered.
+        //
+        // See https://github.com/mozilla/pdf.js/commit/7bc4bfcc8b7f52b14107f0a551becdf01643c5c2
         window.addEventListener('documentload', finish);
+        window.addEventListener('documentloaded', finish);
       }
     });
   }

--- a/src/annotator/plugin/pdf-metadata.js
+++ b/src/annotator/plugin/pdf-metadata.js
@@ -41,7 +41,7 @@ class PDFMetadata {
         resolve(app);
       };
 
-      if (app.documentFingerprint) {
+      if (app.downloadComplete) {
         resolve(app);
       } else {
         window.addEventListener('documentload', finish);
@@ -61,7 +61,7 @@ class PDFMetadata {
     return this._loaded.then(app => {
       let uri = getPDFURL(app);
       if (!uri) {
-        uri = fingerprintToURN(app.documentFingerprint);
+        uri = fingerprintToURN(app.pdfDocument.fingerprint);
       }
       return uri;
     });
@@ -86,7 +86,7 @@ class PDFMetadata {
       }
 
       const link = [
-        {href: fingerprintToURN(app.documentFingerprint)},
+        {href: fingerprintToURN(app.pdfDocument.fingerprint)},
       ];
 
       const url = getPDFURL(app);
@@ -97,7 +97,7 @@ class PDFMetadata {
       return {
         title: title,
         link: link,
-        documentFingerprint: app.documentFingerprint,
+        documentFingerprint: app.pdfDocument.fingerprint,
       };
     });
   }

--- a/src/annotator/plugin/test/pdf-metadata-test.js
+++ b/src/annotator/plugin/test/pdf-metadata-test.js
@@ -53,9 +53,9 @@ class FakePDFViewerApplication {
   /**
    * Simulate completion of PDF document loading.
    */
-  finishLoading({ url, fingerprint, metadata, title }) {
+  finishLoading({ url, fingerprint, metadata, title, eventName = 'documentload' }) {
     const event = document.createEvent('Event');
-    event.initEvent('documentload', false, false);
+    event.initEvent(eventName, false, false);
     window.dispatchEvent(event);
 
     this.url = url;
@@ -75,17 +75,25 @@ class FakePDFViewerApplication {
 }
 
 describe('annotator/plugin/pdf-metadata', function () {
-  it('waits for the PDF to load before returning metadata', function () {
-    const fakeApp = new FakePDFViewerApplication;
-    const pdfMetadata = new PDFMetadata(fakeApp);
+  [
+    // Event dispatched in older PDF.js versions (pre-7bc4bfcc).
+    'documentload',
+    // Event dispatched in newer PDF.js versions (post-7bc4bfcc).
+    'documentloaded',
+  ].forEach(eventName => {
+    it('waits for the PDF to load before returning metadata', function () {
+      const fakeApp = new FakePDFViewerApplication;
+      const pdfMetadata = new PDFMetadata(fakeApp);
 
-    fakeApp.finishLoading({
-      url: 'http://fake.com',
-      fingerprint: 'fakeFingerprint',
-    });
+      fakeApp.finishLoading({
+        eventName,
+        url: 'http://fake.com',
+        fingerprint: 'fakeFingerprint',
+      });
 
-    return pdfMetadata.getUri().then(function (uri) {
-      assert.equal(uri, 'http://fake.com/');
+      return pdfMetadata.getUri().then(function (uri) {
+        assert.equal(uri, 'http://fake.com/');
+      });
     });
   });
 


### PR DESCRIPTION
This PR adapts the code that fetches PDF metadata from PDF.js to work with recent versions of PDF.js. In particular the following changes affect us:

- The `PDFViewerApplication.documentFingerprint` property [was removed](https://github.com/mozilla/pdf.js/commit/e522b2d87e8eb3d4eb8a391a098a0f6f157e8c12)
- The name of the DOM event emitted when the document finishes loading [changed from `documentload` to `documentloaded`](https://github.com/mozilla/pdf.js/commit/7bc4bfcc8b7f52b14107f0a551becdf01643c5c2)

The first commit refactors the PDF metadata tests to make sure they all use the same fake implementation of the PDF.js API. The remaining commits adapt the code to the above changes.

Publishers may continue to embed older versions of PDF.js on their sites and we still ship older versions of PDF.js with the Chrome extension, Via and in [this repository we provide for publishers](https://github.com/hypothesis/pdf.js-hypothes.is). Therefore the changes made in this PR are backwards compatible.

Fixes https://github.com/hypothesis/product-backlog/issues/881

----

**Testing**

1. Load a PDF in the internal PDF viewer of Firefox 63 and activate the bookmarklet from a local dev. build of the client/h.
2. Load a PDF in a local version of Via, which is configured to use the local dev build of the client/h.
