### PR TITLE
Delete only invalid highlight when anchor has multiple highlights

### DIFF
--- a/src/annotator/plugin/pdf.coffee
+++ b/src/annotator/plugin/pdf.coffee
@@ -72,9 +72,9 @@ module.exports = class PDF extends Plugin
       # If the highlights are no longer in the document it means that either
       # the page was destroyed by PDF.js or the placeholder was removed above.
       # The annotations for these anchors need to be refreshed.
-      for hl in anchor.highlights
+      for hl, index in anchor.highlights
         if not document.body.contains(hl)
-          delete anchor.highlights
+          anchor.highlights.splice(index, 1)
           delete anchor.range
           refreshAnnotations.push(anchor.annotation)
           break


### PR DESCRIPTION
When hypothesis client works with PDF.js, there is a bug here.  Description as following:

1. An anchor has multiple highlights, this happens when you select content from crosslines.
2. Click the 'search' button on the left side of pdf.js viewer.
3. Input any text but is part of the crossline highlights.
4. The BUG occurs! The part of the crossline highlights will be highlighted again!

This happens because of the following code from guest.coffee can't remove all the highlights which will be updated and re-anchor.

` else if anchor.highlights?`
`      # These highlights are no longer valid and should be removed.`
`      deadHighlights = deadHighlights.concat(anchor.highlights) `