### PR TITLE
Hide non-applicable tutorial steps for third party users

### DIFF
--- a/src/sidebar/components/sidebar-tutorial.js
+++ b/src/sidebar/components/sidebar-tutorial.js
@@ -1,9 +1,13 @@
 'use strict';
 
 const sessionUtil = require('../util/session-util');
+const isThirdPartyService = require('../util/is-third-party-service');
 
 // @ngInject
 function SidebarTutorialController(session, settings) {
+  // Compute once since this doesn't change after the app starts.
+  const isThirdPartyService_ = isThirdPartyService(settings);
+
   this.isThemeClean = settings.theme === 'clean';
 
   this.showSidebarTutorial = function () {
@@ -12,6 +16,20 @@ function SidebarTutorialController(session, settings) {
 
   this.dismiss = function () {
     session.dismissSidebarTutorial();
+  };
+
+  this.canCreatePrivateGroup = () => {
+    // Private group creation in the client is limited to first party users.
+    // In future we may extend this to third party users, but still disable
+    // private group creation in certain contexts (eg. the LMS app).
+    return !isThirdPartyService_;
+  };
+
+  this.canSharePage = () => {
+    // The "Share document" icon in the toolbar is limited to first party users.
+    // In future we may extend this to third party users, but still disable it
+    // in certain contexts (eg. the LMS app).
+    return !isThirdPartyService_;
   };
 }
 

--- a/src/sidebar/components/test/sidebar-tutorial-test.js
+++ b/src/sidebar/components/test/sidebar-tutorial-test.js
@@ -2,9 +2,17 @@
 
 const Controller = require('../sidebar-tutorial').controller;
 
-describe('SidebarTutorialController', function () {
+describe('sidebar/components/sidebar-tutorial', function () {
+  const defaultSession = {state: {preferences: {}}};
+  const firstPartySettings = {};
+  const thirdPartySettings = {
+    services: [{
+      authority: 'publisher.org',
+    }],
+  };
 
-  describe('showSidebarTutorial', function () {
+
+  describe('#showSidebarTutorial', function () {
     const settings = {};
 
     it('returns true if show_sidebar_tutorial is true', function () {
@@ -44,6 +52,30 @@ describe('SidebarTutorialController', function () {
       const result = controller.showSidebarTutorial();
 
       assert.equal(result, false);
+    });
+  });
+
+  describe('#canSharePage', () => {
+    it('is true for first party users', () => {
+      const controller = new Controller(defaultSession, firstPartySettings);
+      assert.isTrue(controller.canSharePage());
+    });
+
+    it('is false for third party users', () => {
+      const controller = new Controller(defaultSession, thirdPartySettings);
+      assert.isFalse(controller.canSharePage());
+    });
+  });
+
+  describe('#canCreatePrivateGroup', () => {
+    it('is true for first party users', () => {
+      const controller = new Controller(defaultSession, firstPartySettings);
+      assert.isTrue(controller.canSharePage());
+    });
+
+    it('is false for third party users', () => {
+      const controller = new Controller(defaultSession, thirdPartySettings);
+      assert.isFalse(controller.canSharePage());
     });
   });
 });

--- a/src/sidebar/templates/sidebar-tutorial.html
+++ b/src/sidebar/templates/sidebar-tutorial.html
@@ -27,13 +27,13 @@
         <i class="h-icon-annotation-reply"></i>&nbsp;<strong>Reply</strong>&nbsp;link.
       </p>
     </li>
-    <li class="sidebar-tutorial__list-item">
+    <li class="sidebar-tutorial__list-item" ng-if="vm.canSharePage()">
       <p class="sidebar-tutorial__list-item-content">
         To share an annotated page, click the
         <i class="h-icon-annotation-share"></i>&nbsp;button at the top.
       </p>
     </li>
-    <li class="sidebar-tutorial__list-item">
+    <li class="sidebar-tutorial__list-item" ng-if="vm.canCreatePrivateGroup()">
       <p class="sidebar-tutorial__list-item-content">
         To create a private group, select <strong>Public</strong>,
         open the dropdown, click&nbsp;<strong>+&nbsp;New&nbsp;group</strong>.


### PR DESCRIPTION
Hide steps in the sidebar tutorial which are not available to
third-party users. It is expected that the conditions under which these
actions are available may change in future, but they will still be
unavailable in at least some contexts.

nb. This affects third party authorities _in general_ but not eLife, since they are using
a different version of the sidebar tutorial which already has the unavailable steps omitted.

Fixes https://github.com/hypothesis/product-backlog/issues/842