### PR TITLE
Ignore invalid URLs in `<link>` and `<meta>` tags

### DIFF
--- a/src/annotator/plugin/document.js
+++ b/src/annotator/plugin/document.js
@@ -160,34 +160,34 @@ class DocumentMeta extends Plugin {
   }
 
   _getLinks() {
-    // we know our current location is a link for the document
-    let href;
-    let type;
-    let values;
+    // We know our current location is a link for the document.
     this.metadata.link = [{href: this._getDocumentHref()}];
 
-    // look for some relevant link relations
-    for (let link of Array.from(this.document.querySelectorAll('link'))) {
-      href = this._absoluteUrl(link.href); // get absolute url
-      const { rel } = link;
-      ({ type } = link);
-      const lang = link.hreflang;
-
-      if (!['alternate', 'canonical', 'bookmark', 'shortlink'].includes(rel)) { continue; }
-
-      if (rel === 'alternate') {
-        // Ignore feeds resources
-        if (type && type.match(/^application\/(rss|atom)\+xml/)) { continue; }
-        // Ignore alternate languages
-        if (lang) { continue; }
+    // Extract links from certain `<link>` tags.
+    const linkElements = Array.from(this.document.querySelectorAll('link'));
+    for (let link of linkElements) {
+      if (!['alternate', 'canonical', 'bookmark', 'shortlink'].includes(link.rel)) {
+        continue;
       }
 
-      this.metadata.link.push({href, rel, type});
+      if (link.rel === 'alternate') {
+        // Ignore RSS feed links.
+        if (link.type && link.type.match(/^application\/(rss|atom)\+xml/)) {
+          continue;
+        }
+        // Ignore alternate languages.
+        if (link.hreflang) {
+          continue;
+        }
+      }
+
+      const href = this._absoluteUrl(link.href);
+      this.metadata.link.push({href, rel: link.rel, type: link.type});
     }
 
     // look for links in scholar metadata
     for (let name of Object.keys(this.metadata.highwire)) {
-      values = this.metadata.highwire[name];
+      const values = this.metadata.highwire[name];
       if (name === 'pdf_url') {
         for (let url of values) {
           this.metadata.link.push({
@@ -212,7 +212,7 @@ class DocumentMeta extends Plugin {
 
     // look for links in dublincore data
     for (let name of Object.keys(this.metadata.dc)) {
-      values = this.metadata.dc[name];
+      const values = this.metadata.dc[name];
       if (name === 'identifier') {
         for (let id of values) {
           if (id.slice(0, 4) === 'doi:') {
@@ -247,7 +247,6 @@ class DocumentMeta extends Plugin {
     }
   }
 
-  // Hack to get a absolute url from a possibly relative one
   _absoluteUrl(url) {
     return normalizeURI(url, this.baseURI);
   }

--- a/src/annotator/plugin/test/document-test.js
+++ b/src/annotator/plugin/test/document-test.js
@@ -17,41 +17,54 @@ const $ = require('jquery');
 const DocumentMeta = require('../document');
 
 describe('DocumentMeta', function() {
+  let tempDocument;
+  let tempDocumentHead;
   let testDocument = null;
 
   beforeEach(function() {
-    testDocument = new DocumentMeta($('<div></div>')[0], {});
+    tempDocument = document.createDocumentFragment();
+    tempDocument.location = { href: 'https://example.com' };
+    tempDocumentHead = document.createElement('head');
+    tempDocument.appendChild(tempDocumentHead);
+
+    testDocument = new DocumentMeta(tempDocument, {
+      document: tempDocument,
+    });
     testDocument.pluginInit();
   });
 
   afterEach(() => $(document).unbind());
 
   describe('annotation should have some metadata', function() {
-    // Add some metadata to the page
-    const head = $('head');
-    head.append('<link rel="alternate" href="foo.pdf" type="application/pdf"></link>');
-    head.append('<link rel="alternate" href="foo.doc" type="application/msword"></link>');
-    head.append('<link rel="bookmark" href="http://example.com/bookmark"></link>');
-    head.append('<link rel="shortlink" href="http://example.com/bookmark/short"></link>');
-    head.append('<link rel="alternate" href="es/foo.html" hreflang="es" type="text/html"></link>');
-    head.append('<meta name="citation_doi" content="10.1175/JCLI-D-11-00015.1">');
-    head.append('<meta name="citation_title" content="Foo">');
-    head.append('<meta name="citation_pdf_url" content="foo.pdf">');
-    head.append('<meta name="dc.identifier" content="doi:10.1175/JCLI-D-11-00015.1">');
-    head.append('<meta name="dc:identifier" content="foobar-abcxyz">');
-    head.append('<meta name="dc.relation.ispartof" content="isbn:123456789">');
-    head.append('<meta name="DC.type" content="Article">');
-    head.append('<meta property="og:url" content="http://example.com">');
-    head.append('<meta name="twitter:site" content="@okfn">');
-    head.append('<link rel="icon" href="http://example.com/images/icon.ico"></link>');
-    head.append('<meta name="eprints.title" content="Computer Lib / Dream Machines">');
-    head.append('<meta name="prism.title" content="Literary Machines">');
-    head.append('<link rel="alternate" href="feed" type="application/rss+xml"></link>');
-    head.append('<link rel="canonical" href="http://example.com/canonical"></link>');
-
     let metadata = null;
 
-    beforeEach(() => metadata = testDocument.metadata);
+    beforeEach(() => {
+      // Add some metadata to the page
+      tempDocumentHead.innerHTML = `
+        <link rel="alternate" href="foo.pdf" type="application/pdf"></link>
+        <link rel="alternate" href="foo.doc" type="application/msword"></link>
+        <link rel="bookmark" href="http://example.com/bookmark"></link>
+        <link rel="shortlink" href="http://example.com/bookmark/short"></link>
+        <link rel="alternate" href="es/foo.html" hreflang="es" type="text/html"></link>
+        <meta name="citation_doi" content="10.1175/JCLI-D-11-00015.1">
+        <meta name="citation_title" content="Foo">
+        <meta name="citation_pdf_url" content="foo.pdf">
+        <meta name="dc.identifier" content="doi:10.1175/JCLI-D-11-00015.1">
+        <meta name="dc:identifier" content="foobar-abcxyz">
+        <meta name="dc.relation.ispartof" content="isbn:123456789">
+        <meta name="DC.type" content="Article">
+        <meta property="og:url" content="http://example.com">
+        <meta name="twitter:site" content="@okfn">
+        <link rel="icon" href="http://example.com/images/icon.ico"></link>
+        <meta name="eprints.title" content="Computer Lib / Dream Machines">
+        <meta name="prism.title" content="Literary Machines">
+        <link rel="alternate" href="feed" type="application/rss+xml"></link>
+        <link rel="canonical" href="http://example.com/canonical"></link>
+      `;
+
+      testDocument.getDocumentMetadata();
+      metadata = testDocument.metadata;
+    });
 
     it('should have metadata', () => assert.ok(metadata));
 


### PR DESCRIPTION
When extracting document metadata from HTML documents, skip any URLs in `<link>` and `<meta>` tags which are not valid relative or absolute URIs. "Valid" in this context means that the URI can be parsed by `new URL(uri, base)`.

- The first commit cleans up some code that was converted from CoffeeScript to remove or narrow the scope of several variables.
- The second commit refactors some of the tests for document metadata parsing to isolate tests from each other better.
- The third commit adds logic to skip over invalid URLs when parsing document metadata

Fixes https://github.com/hypothesis/product-backlog/issues/742