### PR TITLE
Refactor Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,28 @@
 .PHONY: default
-default: all
+default: help
 
-.PHONY: all
-all: build/manifest.json
+.PHONY: help
+help:
+	@echo "make help              Show this help message"
+	@echo "make dev               Run the app in the development server"
+	@echo "make lint              Run the code linter(s) and print any warnings"
+	@echo "make test              Run the unit tests"
+	@echo "make docs              Build docs website and serve it locally"
+	@echo "make checkdocs         Crash if building the docs website fails"
+	@echo "make clean             Delete development artefacts (cached files, "
+	@echo "                       dependencies, etc)"
 
-## Remove build artifacts
-.PHONY: clean
-clean:
-	rm -f node_modules/.uptodate
-	rm -rf build
+.PHONY: dev
+dev: build/manifest.json
+	gulp watch
 
-## Run test suite
 .PHONY: test
 test: node_modules/.uptodate
+ifdef FILTER
+	yarn test --grep $(FILTER)
+else
 	yarn test
+endif
 
 .PHONY: lint
 lint: node_modules/.uptodate
@@ -27,7 +36,10 @@ docs:
 checkdocs:
 	tox -e py3-checkdocs
 
-################################################################################
+.PHONY: clean
+clean:
+	rm -f node_modules/.uptodate
+	rm -rf build
 
 build/manifest.json: node_modules/.uptodate
 	yarn run build

--- a/docs/developers/developing.rst
+++ b/docs/developers/developing.rst
@@ -58,7 +58,7 @@ extension itself, but not to h.
 
     .. code-block:: sh
 
-       gulp watch
+       make dev
 
 #. After making changes to the client, you will need to run ``make`` in the
    browser extension repo and reload the extension in Chrome to see changes.
@@ -84,7 +84,7 @@ run:
 .. code-block:: sh
 
    export SIDEBAR_APP_URL=http://localhost:5000/app.html
-   gulp watch
+   make dev
 
 Next, you'll need to create an OAuth client which enables the Hypothesis client
 to request an access token from the service in order to make API calls.
@@ -126,7 +126,7 @@ Hypothesis uses Karma and mocha for testing. To run all the tests once, run:
 
 .. code-block:: sh
 
-   gulp test
+   make test
 
 To run tests and automatically re-run them whenever any source files change, run:
 
@@ -134,8 +134,8 @@ To run tests and automatically re-run them whenever any source files change, run
 
    gulp test-watch
 
-You can filter the tests which are run by passing ``--grep <pattern>`` as an
-argument to ``gulp test``. See the documentation for Mocha's
+You can filter the tests which are run by running ``make test FILTER=<pattern>``.
+See the documentation for Mocha's
 `grep <https://mochajs.org/#g---grep-pattern>`_ option.
 
 Code Style

--- a/docs/developers/mobile.rst
+++ b/docs/developers/mobile.rst
@@ -52,11 +52,11 @@ tested with at least current versions of iOS Safari and Chrome for Android.
       # Set hostname used when generating client asset URLs
       export PACKAGE_SERVER_HOSTNAME=<HOSTNAME>
 
-      gulp watch
+      make dev
 
    .. tip::
 
-      When ``gulp watch`` runs, it will print out the URLs used for h
+      When ``make dev`` runs, it will print out the URLs used for h
       and client assets. These should include ``<HOSTNAME>`` instead of
       ``localhost``.
 


### PR DESCRIPTION
Refactor Makefile to be the same as for our other projects:

    $ make help
    make help              Show this help message
    make dev               Run the app in the development server
    make lint              Run the code linter(s) and print any warnings
    make test              Run the unit tests
    make docs              Build docs website and serve it locally
    make checkdocs         Crash if building the docs website fails
    make clean             Delete development artefacts (cached files,
                           dependencies, etc)

Other make commands that our other projects have but the client doesn't
yet:

`make shell` -- Not relevant to the client? (Unless we can get a useful
JavaScript shell in the terminal.)

`make sql` -- Not relevant.

`make format` and `checkformatting` -- We can't use Black code
formatting for the client of course but maybe we could use Prettier or
something else. (Our Python apps could also be extended to have `make
format` format the JavaScript code as well.)

`make coverage` and `codecov` -- Print the unit test coverage report to
the terminal, and post it to codecov. These should be doable?