### PR TITLE
WIP: Client modifications for community groups

### DIFF
--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -58,6 +58,9 @@ function GroupListController($window, analytics, groups, settings, serviceUrl) {
     groups.focus(groupId);
   };
 
+  /**
+   * This is a quick and dirty hack to show styling, and needs refactoring.
+   */
   this.toggleGroupDetails = function () {
     const groupDetails = $window.document.getElementById('group-details-example');
     groupDetails.classList.toggle('expanded');

--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -58,6 +58,12 @@ function GroupListController($window, analytics, groups, settings, serviceUrl) {
     groups.focus(groupId);
   };
 
+  this.toggleGroupDetails = function () {
+    const groupDetails = $window.document.getElementById('group-details-example');
+    groupDetails.classList.toggle('expanded');
+    $window.event.stopPropagation();
+  };
+
   /**
    * Show the share link for the group if it is not a third-party group
    * AND if the URL needed is present in the group object. We should be able

--- a/src/sidebar/components/sidebar-header.js
+++ b/src/sidebar/components/sidebar-header.js
@@ -1,8 +1,16 @@
 'use strict';
 
+const { isThirdPartyUser } = require('../util/account-id');
+const isThirdPartyService = require('../util/is-third-party-service');
+const serviceConfig = require('../service-config');
+
 // @ngInject
 function SidebarHeaderController(groups) {
   this.groups = groups;
+
+  this.showHeader = function() {
+    return !( this.isThirdPartyService && (this.groups.all().length <= 1) );
+  };
 
   this.focusedIcon = function() {
     const focusedGroup = this.groups.focused();

--- a/src/sidebar/components/sidebar-header.js
+++ b/src/sidebar/components/sidebar-header.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// @ngInject
+function SidebarHeaderController(groups) {
+  this.groups = groups;
+
+  this.focusedIcon = function() {
+    const focusedGroup = this.groups.focused();
+    return focusedGroup && (
+      focusedGroup.organization.logo || this.thirdPartyGroupIcon
+    );
+  };
+
+  this.focusedIconClass = function() {
+    const focusedGroup = this.groups.focused();
+    return (focusedGroup && focusedGroup.type === 'private') ? 'group' : 'public';
+  };
+
+}
+
+/**
+ * @name sidebarHeader
+ * @description Displays a heading and a link to the currently selected group page.
+ */
+// @ngInject
+module.exports = {
+  controller: SidebarHeaderController,
+  controllerAs: 'vm',
+  bindings: {},
+  template: require('../templates/sidebar-header.html'),
+};

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -157,6 +157,7 @@ function startAngularApp(config) {
   .component('searchStatusBar', require('./components/search-status-bar'))
   .component('selectionTabs', require('./components/selection-tabs'))
   .component('sidebarContent', require('./components/sidebar-content'))
+  .component('sidebarHeader', require('./components/sidebar-header'))
   .component('sidebarTutorial', require('./components/sidebar-tutorial'))
   .component('shareDialog', require('./components/share-dialog'))
   .component('sortDropdown', require('./components/sort-dropdown'))

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -8,31 +8,81 @@
         Groups
         <i class="h-icon-arrow-drop-down top-bar__dropdown-arrow"></i>
   </button>
-  <ul class="dropdown-menu" role="menu" ng-if="vm.showGroupsMenu()">
-    <li class="dropdown-menu__row dropdown-menu__row--unpadded "
-        ng-repeat="group in vm.groupOrganizations() track by group.id">
-      <div ng-class="{'group-item': true, selected: group.id == vm.groups.focused().id}"
-           ng-click="vm.focusGroup(group.id)" tabindex="0">
-        <!-- the group icon !-->
-        <div class="group-menu-icon-container">
-          <img class="group-list-label__icon group-list-label__icon--organization"
-            alt="{{ vm.orgName(group.id) }}"
-            ng-src="{{ group.logo }}"
-            ng-if="group.logo">
+  <div class="dropdown-menu" role="menu" ng-if="vm.showGroupsMenu()">
+    <h2 class="dropdown-menu__section-heading">Currently Viewing</h2>
+    <ul class="dropdown-menu__section">
+      <li class="dropdown-menu__row dropdown-menu__row--unpadded">
+        <div ng-class="{'group-item': true}"
+             ng-click="vm.focusGroup(vm.groups.focused().id)" tabindex="0">
+          <!-- the group icon !-->
+          <div class="group-menu-icon-container">
+            <img class="group-list-label__icon group-list-label__icon--organization"
+              alt="{{ vm.orgName(vm.groups.focused().id) }}"
+              ng-src="{{ vm.groups.focused().logo }}"
+              ng-if="vm.groups.focused().logo">
+          </div>
+          <!-- the group name and share link !-->
+          <div class="group-details">
+            {{vm.groups.focused().name}}
+          </div>
         </div>
-        <!-- the group name and share link !-->
-        <div class="group-details">
-          {{group.name}}
+      </li>
+    </ul>
+
+    <!-- TODO: Add ng-if logic for Featured Groups -->
+    <!-- TODO: Fix group info display (name, org logo, etc.) -->
+    <h2 class="dropdown-menu__section-heading">Featured Groups</h2>
+    <ul class="dropdown-menu__section">
+      <li class="dropdown-menu__row dropdown-menu__row--unpadded">
+        <div ng-class="{'group-item': true, selected: group.id == vm.groups.focused().id}"
+             ng-click="vm.focusGroup(group.id)" tabindex="0">
+          <!-- the group icon !-->
+          <div class="group-menu-icon-container">
+            <img class="group-list-label__icon group-list-label__icon--organization"
+              alt="{{ vm.orgName(group.id) }}"
+              ng-src="{{ group.logo }}"
+              ng-if="group.logo">
+          </div>
+          <!-- the group name and share link !-->
+          <div class="group-details">
+            Example featured group
+          </div>
         </div>
-      </div>
-    </li>
-    <li ng-if="vm.auth.status === 'logged-in' && !vm.isThirdPartyUser()" class="dropdown-menu__row dropdown-menu__row--unpadded new-group-btn">
-      <div class="group-item" ng-click="vm.createNewGroup()" tabindex="0">
-        <div class="group-icon-container"><i class="h-icon-add"></i></div>
-        <div class="group-details">
-          New private group
+      </li>
+    </ul>
+
+    <!-- TODO: Convert to ng-repeat for current user's groups (pending API endpoint) -->
+    <!-- TODO: Fix group info display (name, org logo, etc.) -->
+    <h2 class="dropdown-menu__section-heading">My Groups</h2>
+    <ul class="dropdown-menu__section">
+      <li class="dropdown-menu__row dropdown-menu__row--unpadded"
+          ng-repeat="group in vm.groupOrganizations() track by group.id">
+        <div ng-class="{'group-item': true, selected: group.id == vm.groups.focused().id}"
+             ng-click="vm.focusGroup(group.id)" tabindex="0">
+          <!-- the group icon !-->
+          <div class="group-menu-icon-container">
+            <img class="group-list-label__icon group-list-label__icon--organization"
+              alt="{{ vm.orgName(group.id) }}"
+              ng-src="{{ group.logo }}"
+              ng-if="group.logo">
+          </div>
+          <!-- the group name and share link !-->
+          <div class="group-details">
+            {{group.name}}
+          </div>
         </div>
-      </div>
-    </li>
-  </ul>
+      </li>
+    </ul>
+
+    <ul class="dropdown-menu__section dropdown-menu__section--no-header">
+      <li ng-if="vm.auth.status === 'logged-in' && !vm.isThirdPartyUser()" class="dropdown-menu__row dropdown-menu__row--unpadded new-group-btn">
+        <div class="group-item" ng-click="vm.createNewGroup()" tabindex="0">
+          <div class="group-icon-container"><i class="h-icon-add"></i></div>
+          <div class="group-details">
+            New private group
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
 </div>

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -1,7 +1,4 @@
-<div class="pull-right"
-     dropdown
-     keyboard-nav>
-  <!-- Show a drop down menu if showGroupsMenu is true. -->
+<div dropdown keyboard-nav>
   <button class="btn dropdown-toggle"
         dropdown-toggle
         data-toggle="dropdown"
@@ -16,23 +13,11 @@
           <path d="M0 0h24v24H0z" fill="none"/>
         </svg>
   </button>
-  <!-- Do not show a drop down menu if showGroupsMenu is false. -->
-  <div ng-if="!vm.showGroupsMenu()">
-    <img class="group-list-label__icon group-list-label__icon--organization"
-         ng-src="{{ vm.focusedIcon() }}"
-         alt="{{ vm.orgName(vm.groups.focused().id)}}"
-         ng-if="vm.focusedIcon()">
-         <i class="group-list-label__icon h-icon-{{ vm.focusedIconClass() }}"
-             ng-if="!vm.focusedIcon()"></i><!-- nospace
-    !--><span class="group-list-label__label">{{vm.groups.focused().name}}</span>
-  </div>
-  <!-- Only build the drop down menu if showGroupsMenu is true. -->
-  <div class="dropdown-menu__top-arrow" ng-if="vm.showGroupsMenu()"></div>
-  <ul class="dropdown-menu pull-none" role="menu" ng-if="vm.showGroupsMenu()">
+  <ul class="dropdown-menu" role="menu" ng-if="vm.showGroupsMenu()">
     <li class="dropdown-menu__row dropdown-menu__row--unpadded "
         ng-repeat="group in vm.groupOrganizations() track by group.id">
       <div ng-class="{'group-item': true, selected: group.id == vm.groups.focused().id}"
-           ng-click="vm.focusGroup(group.id)">
+           ng-click="vm.focusGroup(group.id)" tabindex="0">
         <!-- the group icon !-->
         <div class="group-menu-icon-container">
           <img class="group-list-label__icon group-list-label__icon--organization"
@@ -42,41 +27,15 @@
         </div>
         <!-- the group name and share link !-->
         <div class="group-details">
-          <div class="group-name-container">
-            <a class="group-name-link"
-               href=""
-               title="{{ group.type === 'private' ? 'Show and create annotations in ' + group.name : 'Show public annotations'  }}">
-               {{group.name}}
-            </a>
-          </div>
-          <div class="share-link-container" ng-click="$event.stopPropagation()" ng-if="vm.shouldShowActivityLink(group.id)">
-            <a class="share-link"
-               href="{{group.links.html}}"
-               target="_blank"
-               ng-click="vm.viewGroupActivity()">
-              View group activity
-              <span ng-if="group.type === 'private'">
-                and invite others
-              </span>
-            </a>
-          </div>
-        </div>
-        <!-- the 'Leave group' icon !-->
-        <div class="group-cancel-icon-container" ng-click="$event.stopPropagation()">
-          <i class="h-icon-cancel-outline btn--cancel"
-             ng-if="group.type === 'private'"
-             ng-click="vm.leaveGroup(group.id)"
-             title="Leave '{{group.name}}'"></i>
+          {{group.name}}
         </div>
       </div>
     </li>
     <li ng-if="vm.auth.status === 'logged-in' && !vm.isThirdPartyUser()" class="dropdown-menu__row dropdown-menu__row--unpadded new-group-btn">
-      <div class="group-item" ng-click="vm.createNewGroup()">
+      <div class="group-item" ng-click="vm.createNewGroup()" tabindex="0">
         <div class="group-icon-container"><i class="h-icon-add"></i></div>
         <div class="group-details">
-          <a href="" class="group-name-link" title="Create a new group to share annotations">
-            New private group
-          </a>
+          New private group
         </div>
       </div>
     </li>

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -2,21 +2,20 @@
      dropdown
      keyboard-nav>
   <!-- Show a drop down menu if showGroupsMenu is true. -->
-  <div class="dropdown-toggle"
+  <button class="btn dropdown-toggle"
         dropdown-toggle
         data-toggle="dropdown"
         role="button"
         tabindex="0"
         ng-if="vm.showGroupsMenu()">
-    <img class="group-list-label__icon group-list-label__icon--organization"
-         ng-src="{{ vm.focusedIcon() }}"
-         alt="{{ vm.orgName(vm.groups.focused().id)}}"
-         ng-if="vm.focusedIcon()">
-         <i class="group-list-label__icon h-icon-{{ vm.focusedIconClass() }}"
-             ng-if="!vm.focusedIcon()"></i><!-- nospace
-    !--><span class="group-list-label__label"><a class="group-list-label__toggle">{{vm.groups.focused().name}}</a><!-- nospace
-      !--><i class="h-icon-arrow-drop-down"></i></span>
-  </div>
+        Groups
+        <svg class="svg-icon icon-expand select__expand-icon"
+             xmlns="http://www.w3.org/2000/svg" width="auto" height="100%" viewBox="0 0 24 24" aria-labelledby="icon-expand-title">
+          <title id="icon-expand-title">Expand</title>
+          <path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/>
+          <path d="M0 0h24v24H0z" fill="none"/>
+        </svg>
+  </button>
   <!-- Do not show a drop down menu if showGroupsMenu is false. -->
   <div ng-if="!vm.showGroupsMenu()">
     <img class="group-list-label__icon group-list-label__icon--organization"

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -1,4 +1,15 @@
 <div dropdown keyboard-nav>
+  <!-- Do not show a drop down menu if showGroupsMenu is false. -->
+  <div ng-if="!vm.showGroupsMenu()">
+    <img class="group-list-label__icon group-list-label__icon--organization"
+         ng-src="{{ vm.focusedIcon() }}"
+         alt="{{ vm.orgName(vm.groups.focused().id)}}"
+         ng-if="vm.focusedIcon()">
+         <i class="group-list-label__icon h-icon-{{ vm.focusedIconClass() }}"
+             ng-if="!vm.focusedIcon()"></i><!-- nospace
+    !--><span class="group-list-label__label">{{vm.groups.focused().name}}</span>
+  </div>
+
   <button class="btn dropdown-toggle group-list__toggle"
         dropdown-toggle
         data-toggle="dropdown"
@@ -76,7 +87,7 @@
       </li>
 
       <!-- TODO: Integrate this display state into the My Groups loop, only
-                 list items in this state if group is scoped, and out of scope -->
+                 list items in this state if group is scoped, AND out of scope -->
       <li class="dropdown-menu__row dropdown-menu__row--unpadded">
         <div class="group-item--oos"
              ng-class="{'group-item': true, selected: group.id == vm.groups.focused().id}"

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -74,6 +74,37 @@
           </div>
         </div>
       </li>
+
+      <!-- TODO: Integrate this display state into the My Groups loop, only
+                 list items in this state if group is scoped, and out of scope -->
+      <li class="dropdown-menu__row dropdown-menu__row--unpadded">
+        <div class="group-item--oos"
+             ng-class="{'group-item': true, selected: group.id == vm.groups.focused().id}"
+             ng-click="vm.toggleGroupDetails()" tabindex="0">
+          <!-- the group icon !-->
+          <div class="group-menu-icon-container">
+            <img class="group-list-label__icon group-list-label__icon--organization"
+              alt="{{ vm.orgName(group.id) }}"
+              ng-src="{{ group.logo }}"
+              ng-if="group.logo">
+          </div>
+          <!-- the group name and share link !-->
+          <div class="group-details" id="group-details-example">
+            <svg class="svg-icon group__icon--unavailable" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24">
+              <path fill="none" d="M0 0h24v24H0V0z"/>
+              <path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/>
+            </svg>
+            Scoped group, out of scope<br>
+            <p class="group-details__toggle">Why is this group unavailable?</p>
+            <p class="group-details__unavailable-message">
+              This group has been restricted to selected domains by its administrators.
+            </p>
+            <p class="group-details__actions">
+              <a class="button button--text group-details__group-page-link" href="#">Go to group page</a>
+            </p>
+          </div>
+        </div>
+      </li>
     </ul>
 
     <ul class="dropdown-menu__section dropdown-menu__section--no-header">

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -9,8 +9,10 @@
         <i class="h-icon-arrow-drop-down top-bar__dropdown-arrow"></i>
   </button>
   <div class="dropdown-menu" role="menu" ng-if="vm.showGroupsMenu()">
-    <h2 class="dropdown-menu__section-heading">Currently Viewing</h2>
-    <ul class="dropdown-menu__section">
+
+    <!-- TODO: Fix org logo display -->
+    <h2 class="dropdown-menu__section-heading dropdown-menu__section-heading--current">Currently Viewing</h2>
+    <ul class="dropdown-menu__section dropdown-menu__section--current">
       <li class="dropdown-menu__row dropdown-menu__row--unpadded">
         <div ng-class="{'group-item': true}"
              ng-click="vm.focusGroup(vm.groups.focused().id)" tabindex="0">

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -1,5 +1,5 @@
 <div dropdown keyboard-nav>
-  <button class="btn dropdown-toggle"
+  <button class="btn dropdown-toggle group-list__toggle"
         dropdown-toggle
         data-toggle="dropdown"
         role="button"

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -6,12 +6,7 @@
         tabindex="0"
         ng-if="vm.showGroupsMenu()">
         Groups
-        <svg class="svg-icon icon-expand select__expand-icon"
-             xmlns="http://www.w3.org/2000/svg" width="auto" height="100%" viewBox="0 0 24 24" aria-labelledby="icon-expand-title">
-          <title id="icon-expand-title">Expand</title>
-          <path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/>
-          <path d="M0 0h24v24H0z" fill="none"/>
-        </svg>
+        <i class="h-icon-arrow-drop-down top-bar__dropdown-arrow"></i>
   </button>
   <ul class="dropdown-menu" role="menu" ng-if="vm.showGroupsMenu()">
     <li class="dropdown-menu__row dropdown-menu__row--unpadded "

--- a/src/sidebar/templates/sidebar-content.html
+++ b/src/sidebar/templates/sidebar-content.html
@@ -1,3 +1,6 @@
+<sidebar-header>
+</sidebar-header>
+
 <selection-tabs
   ng-if="!vm.search.query() && vm.selectedAnnotationCount() === 0"
   is-waiting-to-anchor-annotations="vm.waitingToAnchorAnnotations"

--- a/src/sidebar/templates/sidebar-header.html
+++ b/src/sidebar/templates/sidebar-header.html
@@ -4,7 +4,7 @@
       href="{{ vm.groups.focused().links.html }}"
       target="_blank"
       ng-click="vm.viewGroupActivity()">
-      <img class="sidebar-header__organization-icon"
+      <img class="sidebar-header__organization-icon {{ vm.focusedIconClass() }}"
         ng-src="{{ vm.focusedIcon() }}"
         alt="{{ vm.orgName(vm.groups.focused().id)}}"
         ng-if="vm.focusedIcon()">

--- a/src/sidebar/templates/sidebar-header.html
+++ b/src/sidebar/templates/sidebar-header.html
@@ -1,0 +1,19 @@
+<header class="sidebar-header">
+  <h1 class="sidebar-header__heading">
+    <a class="sidebar-header__link"
+      href="{{ vm.groups.focused().links.html }}"
+      target="_blank"
+      ng-click="vm.viewGroupActivity()">
+      <img class="sidebar-header__organization-icon"
+        ng-src="{{ vm.focusedIcon() }}"
+        alt="{{ vm.orgName(vm.groups.focused().id)}}"
+        ng-if="vm.focusedIcon()">
+      {{ vm.groups.focused().name }}
+      <svg class="icon-launch sidebar-header__icon-launch" xmlns="http://www.w3.org/2000/svg" width="auto" height="100%" viewBox="0 0 24 24" aria-labelledby="icon-launch__title">
+        <title id="icon-launch__title">Launch</title>
+        <path d="M0 0h24v24H0z" fill="none"/>
+        <path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/>
+      </svg>
+    </a>
+  </h1>
+</header>

--- a/src/sidebar/templates/sidebar-header.html
+++ b/src/sidebar/templates/sidebar-header.html
@@ -1,5 +1,5 @@
 <header class="sidebar-header">
-  <h1 class="sidebar-header__heading">
+  <h1 class="sidebar-header__heading" ng-if="vm.showHeader()">
     <a class="sidebar-header__link"
       href="{{ vm.groups.focused().links.html }}"
       target="_blank"

--- a/src/sidebar/templates/top-bar.html
+++ b/src/sidebar/templates/top-bar.html
@@ -25,7 +25,7 @@
        the stream view.
   !-->
   <div class="top-bar__inner content" ng-if="::vm.isSidebar">
-    <group-list class="group-list" auth="vm.auth"></group-list>
+    <group-list class="group-list" auth="vm.auth" ng-if="!vm.showGroupsMenu()"></group-list>
     <div class="top-bar__expander"></div>
     <a class="top-bar__apply-update-btn"
        ng-if="vm.pendingUpdateCount > 0"

--- a/src/sidebar/templates/top-bar.html
+++ b/src/sidebar/templates/top-bar.html
@@ -26,7 +26,6 @@
   !-->
   <div class="top-bar__inner content" ng-if="::vm.isSidebar">
     <group-list class="group-list" auth="vm.auth" ng-if="!vm.showGroupsMenu()"></group-list>
-    <div class="top-bar__expander"></div>
     <a class="top-bar__apply-update-btn"
        ng-if="vm.pendingUpdateCount > 0"
        ng-click="vm.onApplyPendingUpdates()"

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -134,13 +134,10 @@ $base-font-size: 14px;
     box-shadow: none;
     border-radius: 0px;
     border-style: none none solid solid;
+    height: $top-bar-height;
+    margin-bottom: 10px;
     padding-right: 6px;
     width: 36px;
-    margin-bottom: 10px;
-
-    // the height of the sidebar toggle is set
-    // to match the height of the top bar
-    height: 40px;
   }
 
   .annotator-frame-button--sidebar_close {

--- a/src/styles/mixins/forms.scss
+++ b/src/styles/mixins/forms.scss
@@ -89,4 +89,3 @@
 @function shade($color, $percent){
   @return mix(black, $color, $percent);
 }
-

--- a/src/styles/sidebar/common.scss
+++ b/src/styles/sidebar/common.scss
@@ -199,10 +199,6 @@ html {
     @include smallshadow;
     visibility: visible;
   }
-
-  & > .dropdown-toggle {
-    background: $gray-lighter;
-  }
 }
 
 // A 'standalone' arrow for the top of a dropdown menu.

--- a/src/styles/sidebar/common.scss
+++ b/src/styles/sidebar/common.scss
@@ -65,11 +65,18 @@ html {
 
 //DROPDOWNS////////////////////////////////
 .dropdown {
+  position: relative;
+  span {
+    cursor: pointer;
+    &:hover {
+      color: black;
+    }
+  }
 }
 
 .dropdown-toggle {
   background: $white;
-  border-radius: 4px;
+  border-radius: 2px;
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;

--- a/src/styles/sidebar/common.scss
+++ b/src/styles/sidebar/common.scss
@@ -76,13 +76,14 @@ html {
 
 .dropdown-toggle {
   background: $white;
+  border: solid 1px rgba(0, 0, 0, 0.15);
   border-radius: 2px;
+  box-shadow: none;
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
   line-height: 1.25;
   text-shadow: none;
-  text-transform: uppercase;
 
   &:active {
     outline: 0;

--- a/src/styles/sidebar/common.scss
+++ b/src/styles/sidebar/common.scss
@@ -65,20 +65,28 @@ html {
 
 //DROPDOWNS////////////////////////////////
 .dropdown {
-  position: relative;
-  span {
-    cursor: pointer;
-    &:hover {
-      color: black;
-    }
-  }
 }
 
 .dropdown-toggle {
+  background: $white;
+  border-radius: 4px;
   cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.25;
+  text-transform: uppercase;
 
   &:active {
     outline: 0;
+  }
+
+  .icon-expand {
+    fill: $button-text-color;
+    height: 1.25em;
+    line-height: 1;
+    overflow: hidden;
+    vertical-align: text-top;
+    width: 1.25em;
   }
 }
 

--- a/src/styles/sidebar/common.scss
+++ b/src/styles/sidebar/common.scss
@@ -259,10 +259,6 @@ html {
 
   min-height: 40px;
   min-width: 120px;
-
-  &:not(:first-child) {
-    border-top: dotted 1px $gray-lighter;
-  }
 }
 
 .dropdown-menu__row--unpadded {

--- a/src/styles/sidebar/common.scss
+++ b/src/styles/sidebar/common.scss
@@ -81,6 +81,7 @@ html {
   font-size: 14px;
   font-weight: 500;
   line-height: 1.25;
+  text-shadow: none;
   text-transform: uppercase;
 
   &:active {
@@ -197,6 +198,10 @@ html {
   & > .dropdown-menu {
     @include smallshadow;
     visibility: visible;
+  }
+
+  & > .dropdown-toggle {
+    background: $gray-lighter;
   }
 }
 

--- a/src/styles/sidebar/components/group-list.scss
+++ b/src/styles/sidebar/components/group-list.scss
@@ -22,6 +22,10 @@ $group-list-spacing-below: 50px;
     }
   }
 
+  .dropdown-menu__section--current {
+    background-color: $gray-lightest;
+  }
+
   .dropdown-menu__section--no-header {
     border-top: solid 1px rgba(0, 0, 0, 0.15);
 
@@ -34,13 +38,17 @@ $group-list-spacing-below: 50px;
     color: $gray-light;
     font-size: 12px;
     line-height: 1;
-    margin: 1px;
+    margin: 1px 1px 0;
     padding: 12px 10px 0;
     text-transform: uppercase;
 
     &:not(:first-child) {
       border-top: solid 1px rgba(0, 0, 0, 0.15);
     }
+  }
+
+  .dropdown-menu__section-heading--current {
+    background-color: $gray-lightest;
   }
 
   .group-item {

--- a/src/styles/sidebar/components/group-list.scss
+++ b/src/styles/sidebar/components/group-list.scss
@@ -9,10 +9,11 @@ $group-list-spacing-below: 50px;
   }
 
   .dropdown-menu {
-    width: $group-list-width;
+    margin-top: 2px;
     max-height: 500px;  // fallback for browsers lacking support for vh/calc
     max-height: calc(100vh - #{$top-bar-height} - #{$group-list-spacing-below});
     overflow-y: auto;
+    width: $group-list-width;
 
     .group-name {
       overflow: hidden;
@@ -22,12 +23,19 @@ $group-list-spacing-below: 50px;
   }
 
   .group-item {
+    border: solid 1px transparent;
     display: flex;
     flex-direction: row;
     flex-grow: 1;
+    margin: 1px;
 
     padding: 10px;
     cursor: pointer;
+
+    &:focus {
+      outline: none;
+      @include focus-outline;
+    }
 
     &:hover {
       .group-name-link {

--- a/src/styles/sidebar/components/group-list.scss
+++ b/src/styles/sidebar/components/group-list.scss
@@ -78,6 +78,11 @@ $group-list-spacing-below: 50px;
     }
   }
 
+  .group-item--oos {
+    background-color: $gray-lightest;
+    color: $gray-light;
+  }
+
   .group-icon-container {
     margin-right: 10px;
   }
@@ -96,10 +101,58 @@ $group-list-spacing-below: 50px;
     margin-right: 2px;
   }
 
+  .group__icon--unavailable {
+    fill: $gray-light;
+    float: right;
+    height: 20px;
+    width: auto;
+  }
+
   .group-details {
     flex-grow: 1;
     flex-shrink: 1;
     font-weight: 500;
+
+    .group-details__unavailable-message,
+    .group-details__actions {
+      display: none;
+    }
+
+    &.expanded {
+      .group-details__toggle {
+        display: none;
+      }
+
+      .group-details__unavailable-message,
+      .group-details__actions {
+        display: block;
+      }
+    }
+  }
+
+  .group-details__toggle {
+    font-size: 0.8em;
+    font-style: italic;
+    margin: 0;
+    text-decoration: underline;
+  }
+
+  .group-details__unavailable-message {
+    font-size: 0.8em;
+    line-height: 1.5;
+    white-space: normal;
+    width: $group-list-width - 60px;
+  }
+
+  .group-details__actions {
+    text-align: right;
+  }
+
+  .group-details__group-page-link {
+    color: inherit;
+    font-size: 0.8em;
+    text-decoration: underline;
+    text-transform: uppercase;
   }
 
   .new-group-btn {

--- a/src/styles/sidebar/components/group-list.scss
+++ b/src/styles/sidebar/components/group-list.scss
@@ -1,6 +1,6 @@
 /* The groups dropdown list. */
 
-$group-list-width: 270px;
+$group-list-width: 300px;
 $group-list-spacing-below: 50px;
 
 .group-list {
@@ -19,6 +19,27 @@ $group-list-spacing-below: 50px;
       overflow: hidden;
       text-overflow: ellipsis;
       width: $group-list-width - 30px;
+    }
+  }
+
+  .dropdown-menu__section--no-header {
+    border-top: solid 1px rgba(0, 0, 0, 0.15);
+
+    .group-details {
+      font-weight: 400;
+    }
+  }
+
+  .dropdown-menu__section-heading {
+    color: $gray-light;
+    font-size: 12px;
+    line-height: 1;
+    margin: 1px;
+    padding: 12px 10px 0;
+    text-transform: uppercase;
+
+    &:not(:first-child) {
+      border-top: solid 1px rgba(0, 0, 0, 0.15);
     }
   }
 
@@ -70,6 +91,7 @@ $group-list-spacing-below: 50px;
   .group-details {
     flex-grow: 1;
     flex-shrink: 1;
+    font-weight: 500;
   }
 
   .new-group-btn {

--- a/src/styles/sidebar/components/group-list.scss
+++ b/src/styles/sidebar/components/group-list.scss
@@ -38,9 +38,7 @@ $group-list-spacing-below: 50px;
     }
 
     &:hover {
-      .group-name-link {
-        color: $brand-color;
-      }
+      background: $gray-lightest;
     }
 
     &.selected {

--- a/src/styles/sidebar/components/group-list.scss
+++ b/src/styles/sidebar/components/group-list.scss
@@ -125,3 +125,10 @@ $group-list-spacing-below: 50px;
   white-space: nowrap;
   color: inherit;
 }
+
+
+.open {
+  & > .group-list__toggle {
+    background: $gray-lighter;
+  }
+}

--- a/src/styles/sidebar/components/sidebar-header.scss
+++ b/src/styles/sidebar/components/sidebar-header.scss
@@ -1,0 +1,29 @@
+
+.sidebar-header__heading {
+  font-size: 24px;
+  font-weight: 400;
+  line-height: 1.25;
+  margin-top: 0.25em;
+}
+
+.sidebar-header__link {
+  color: $text-color;
+  display: flex;
+  align-items: center;
+  line-height: inherit;
+}
+
+.sidebar-header__organization-icon {
+  height: 24px;
+  line-height: inherit;
+  margin-right: 0.25em;
+  width: auto;
+}
+
+.sidebar-header__icon-launch {
+  fill: $text-color;
+  height: 24px;
+  line-height: inherit;
+  margin-left: 0.25em;
+  width: auto;
+}

--- a/src/styles/sidebar/components/sidebar-header.scss
+++ b/src/styles/sidebar/components/sidebar-header.scss
@@ -11,6 +11,10 @@
   display: flex;
   align-items: center;
   line-height: inherit;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 .sidebar-header__organization-icon {

--- a/src/styles/sidebar/components/top-bar.scss
+++ b/src/styles/sidebar/components/top-bar.scss
@@ -38,7 +38,8 @@
 }
 
 .top-bar__inner .group-list {
-  margin-right: .75em;
+  justify-self: flex-start;
+  margin-right: auto;
   white-space: nowrap;
 }
 

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -26,6 +26,7 @@ $base-line-height: 20px;
 @import './components/search-status-bar';
 @import './components/selection-tabs';
 @import './components/share-link';
+@import './components/sidebar-header';
 @import './components/sidebar-tutorial';
 @import './components/simple-search';
 @import './components/spinner';

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -125,7 +125,7 @@ $highlight-color: rgba(255, 255, 60, 0.3);
 $highlight-color-second: rgba(206, 206, 60, 0.4);
 $highlight-color-third: rgba(192, 192, 49, 0.4);
 $highlight-color-focus: rgba(156, 230, 255, 0.5);
-$top-bar-height: 40px;
+$top-bar-height: 48px;
 
 // Mixins
 // ------


### PR DESCRIPTION
Fixes https://github.com/hypothesis/product-backlog/issues/848

This PR adds a true heading to the client, and thus eases the functionality burden on the groups selector; and modifies the group selector menu to clarify the difference between the groups available to them.

## Caveats

- This PR does not currently address testing. Tests written against the existing menu will need to be removed, and new tests still need to be written.
- Static markup is included to show necessary styling. When the new API endpoints are ready, those will need to be integrated.

## Goals

- The logic of what shows up in the groups menu and why, should be transparent to the users
- Don't make the groups menu any more complex than it already is, and if possible, reduce complexity

## Approach

- Take the name of the currently selected group out of the menu toggle button, and convert it to a heading at the top of the sidebar
- Remove functionality not related to selecting a group from the groups menu
- Organize the groups menu into sections: "Currently Viewing," "Featured Groups," and "My Groups"

## Rationale

### Heading

![screen shot 2019-01-14 at 10 50 40 am](https://user-images.githubusercontent.com/1348738/51133690-87d24000-17ea-11e9-8412-21ebb128b17e.png)

Adding a heading with the name of the currently selected group at the top of the client confers a number of advantages over the existing design:
- The larger font size (not possible in the current group selector toggle) adds much-needed visual hierarchy, improving scannability.
- A static group name heading is a more logical place for the link to the group activity page, compared to the awkward placement of the current link in each group menu list item.
- Since there’s no need to repeat the group name in the group selector button, the text in that button can be static (i.e. consistent width), and shorter; which gives us more room in the top bar

### Menu

![screen shot 2019-01-14 at 10 50 59 am](https://user-images.githubusercontent.com/1348738/51133710-928cd500-17ea-11e9-8132-98e7b0564252.png)

Organizing the menu in sections makes it more clear to the user why a given group appears in the menu. My Groups remains constant (as long as there’s no change in group membership), and Featured Groups changes based on the current site. Currently Viewing stands in for the heading, which is covered by the menu, and gives us a place to show a group that is focused with a link (one of QDR’s requests).

Introducing the sections increases the complexity of the group selector component, which is currently already (too) complex. To reduce its complexity, the group page link moves to its more natural location, attached to the group name heading; and the “Leave group” link is removed entirely, because it doesn’t have anything to do with the site/document being viewed/annotated, and therefore doesn’t belong in the client.

### Edge cases

- Out-of-scope scoped groups: the design intent is for the "My Groups" section to show all groups to which the current user belongs, at all times (i.e. group membership, and only group membership, is what determines what groups appear in that section). However, users who belong to scoped groups will see those groups even if out of scope. The group should not be selectable in that case, and we should tell the user why. Current design for this is shown below, and the markup/CSS to implement it is present in this PR.

Disclaimer: I don't love this - it adds some of the complexity we're removing right back in - but this is the least bad way of dealing with this edge case, IMO.

![screen shot 2019-01-16 at 2 57 11 pm](https://user-images.githubusercontent.com/1348738/51284311-ec82cb80-199f-11e9-83d3-c52c9bdd6899.png)

## Work left to be done

Items described in "Caveats" above, plus:

- The argument has been raised that having one location to manage group membership quickly is useful, and I absolutely agree, I just think it’s a better fit for `h`. While it’s worth noting that there’s no functionality being completely removed from our service as a whole - it’s still perfectly possible to leave a group - changing "Create group" to "Manage Groups" in the "Groups" dropdown in `h`, and introducing a screen as shown in the comp below, would restore the user's ability to quickly manage their group memberships.

![screen shot 2019-01-15 at 3 06 04 pm](https://user-images.githubusercontent.com/1348738/51215942-80d52b80-18d7-11e9-8dc3-ad8d6e224c0d.png)
