### PR TITLE
Fix `yarn version` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "lint": "eslint .",
     "test": "gulp test",
     "report-coverage": "codecov -f coverage/coverage-final.json",
-    "version": "make clean all && ./scripts/update-changelog.js && git add CHANGELOG.md",
+    "version": "make clean build/manifest.json && ./scripts/update-changelog.js && git add CHANGELOG.md",
     "postversion": "./scripts/postversion.sh",
     "prepublish": "yarn run build"
   }


### PR DESCRIPTION
b778c9ad8a13e33a75a9e7af81121a26307ab265 refactored the Makefile and
removed the `all` target. This target was still referenced by
package.json however.