### PR TITLE
Adapt to change of `getAll` method name

### DIFF
--- a/scripts/generate-change-list.js
+++ b/scripts/generate-change-list.js
@@ -50,7 +50,7 @@ async function* itemsInGitHubAPIResponse(octokit, response) {
 async function getPRsMergedSince(octokit, org, repo, tag) {
   const tagDate = getTagDate(tag);
 
-  let response = await octokit.pullRequests.getAll({
+  let response = await octokit.pullRequests.list({
     owner: org,
     repo,
     state: 'closed',


### PR DESCRIPTION
This fixes the changelog update script.

See https://github.com/octokit/rest.js/pull/1094