### PR TITLE
Remove obsolete comment

### DIFF
--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -5,10 +5,7 @@ const util = require('../util');
 function init() {
   return {
     /**
-     * The state of the user's login session.
-     *
-     * This includes their user ID, set of enabled features, and the list of
-     * groups they are a member of.
+     * Profile/session information for the active user.
      */
     session: {
       /** A map of features that are enabled for the current user. */


### PR DESCRIPTION
The sidebar no longer makes use of any group information returned via
the profile API.

Though this PR is trivial, I'm CC-ing you @lyzadanger as you had a question yesterday about what information the client gets from the profile API that it needs to be able to get in some form in future. This file contains that info. Briefly: Account ID (as `acct:username@domain` string), feature flags (as `str -> bool` map) and preferences (as `key -> value` map). The only preference that currently exists is the sidebar tutorial flag.