### PR TITLE
Update PDF anchoring for changes in PDF.js API

### DIFF
--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -72,9 +72,10 @@ function getPageTextContent(pageIndex) {
     return textContent;
   };
 
-  // FIXME - `pdfViewer.getPageTextContent` was removed in recent versions of PDF.js.
-  pageTextCache[pageIndex] = PDFViewerApplication.pdfViewer
-    .getPageTextContent(pageIndex)
+  pageTextCache[pageIndex] = getPage(pageIndex).pdfPage
+    .getTextContent({
+      normalizeWhitespace: true,
+    })
     .then(joinItems);
 
   return pageTextCache[pageIndex];


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/887 and then https://github.com/hypothesis/client/pull/888.**

Update PDF anchoring to match changes in PDF.js's exposed interfaces

PDF.js commit e293c12afcf3a9a55669b6bf095d657e7780ba16 removed the
`getPageTextContent` method from `PDFViewer`, so we need to call the
underlying method on the `PDFPageProxy` object instead.

This change is backwards compatible with earlier versions of PDF.js.

Fixes https://github.com/hypothesis/product-backlog/issues/915