### PR TITLE
Combine groups from multiple endpoints when feature flag is set

### DIFF
--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -225,7 +225,9 @@ function api($http, $q, apiRoutes, auth) {
       list: apiCall('groups.read'),
     },
     profile: {
-      groups: apiCall('profile.groups'),
+      groups: {
+        read: apiCall('profile.groups.read'),
+      },
       read: apiCall('profile.read'),
       update: apiCall('profile.update'),
     },

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -14,6 +14,7 @@ const DEFAULT_ORGANIZATION = {
 
 const events = require('../events');
 const { awaitStateChange } = require('../util/state-util');
+const { combineGroups } = require('../util/groups');
 const serviceConfig = require('../service-config');
 
 // @ngInject
@@ -25,7 +26,8 @@ function groups(
   localStorage,
   serviceUrl,
   session,
-  settings
+  settings,
+  features
 ) {
   const svc = serviceConfig(settings);
   const authority = svc ? svc.authority : null;
@@ -150,14 +152,28 @@ function groups(
         }
         documentUri = uri;
 
-      // Fetch groups from the API.
-      return api.groups.list(params);
-    }).then(groups => {
-      const isLoggedIn = store.profile().userid !== null;
-      const directLinkedAnnotation = settings.annotations;
-      return filterGroups(groups, isLoggedIn, directLinkedAnnotation);
-    }).then(groups => {
-      injectOrganizations(groups);
+        if (features.flagEnabled('community_groups')) {
+          const profileParams = {
+            expand: ['organization'],
+          };
+          const profileGroupsApi = api.profile.groups.read(profileParams);
+          const listGroupsApi = api.groups.list(params);
+          return Promise.all([profileGroupsApi, listGroupsApi]).then(
+            ([myGroups, featuredGroups]) =>
+              combineGroups(myGroups, featuredGroups)
+          );
+        } else {
+          // Fetch groups from the API.
+          return api.groups.list(params);
+        }
+      })
+      .then(groups => {
+        const isLoggedIn = store.profile().userid !== null;
+        const directLinkedAnnotation = settings.annotations;
+        return filterGroups(groups, isLoggedIn, directLinkedAnnotation);
+      })
+      .then(groups => {
+        injectOrganizations(groups);
 
         const isFirstLoad = store.allGroups().length === 0;
         const prevFocusedGroup = localStorage.getItem(STORAGE_KEY);

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -150,16 +150,14 @@ function groups(
         }
         documentUri = uri;
 
-        // Fetch groups from the API.
-        return api.groups.list(params, null, { includeMetadata: true });
-      })
-      .then(({ data, token }) => {
-        const isLoggedIn = token !== null;
-        const directLinkedAnnotation = settings.annotations;
-        return filterGroups(data, isLoggedIn, directLinkedAnnotation);
-      })
-      .then(groups => {
-        injectOrganizations(groups);
+      // Fetch groups from the API.
+      return api.groups.list(params);
+    }).then(groups => {
+      const isLoggedIn = store.profile().userid !== null;
+      const directLinkedAnnotation = settings.annotations;
+      return filterGroups(groups, isLoggedIn, directLinkedAnnotation);
+    }).then(groups => {
+      injectOrganizations(groups);
 
         const isFirstLoad = store.allGroups().length === 0;
         const prevFocusedGroup = localStorage.getItem(STORAGE_KEY);

--- a/src/sidebar/util/groups.js
+++ b/src/sidebar/util/groups.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * Combine groups from multiple api calls together to form a unique list of groups.
+ * Add an isMember property to each group indicating whether the logged in user is a member.
+ *
+ * @param {Group[]} userGroups - groups the user is a member of
+ * @param {Group[]} featuredGroups - groups scoped to the particular uri, authority, and user
+ */
+function combineGroups(userGroups, featuredGroups) {
+  const worldGroup = featuredGroups.find(g => g.id === '__world__');
+  if (worldGroup) {
+    userGroups.unshift(worldGroup);
+  }
+
+  const myGroupIds = userGroups.map(g => g.id);
+  featuredGroups = featuredGroups.filter(g => !myGroupIds.includes(g.id));
+
+  // Set the isMember property indicating user membership.
+  featuredGroups.forEach(group => (group.isMember = false));
+  userGroups.forEach(group => (group.isMember = true));
+
+  return userGroups.concat(featuredGroups);
+}
+
+module.exports = {
+  combineGroups,
+};

--- a/src/sidebar/util/test/groups-test.js
+++ b/src/sidebar/util/test/groups-test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const { combineGroups } = require('../groups');
+
+describe('sidebar.util.groups', () => {
+  describe('combineGroups', () => {
+    it('labels groups in both lists as isMember true', () => {
+      const userGroups = [{ id: 'groupa', name: 'GroupA' }];
+      const featuredGroups = [{ id: 'groupa', name: 'GroupA' }];
+      const groups = combineGroups(userGroups, featuredGroups);
+      const groupA = groups.find(g => g.id === 'groupa');
+      assert.equal(groupA.isMember, true);
+    });
+
+    it('combines groups from both lists uniquely', () => {
+      const userGroups = [
+        { id: 'groupa', name: 'GroupA' },
+        { id: 'groupb', name: 'GroupB' },
+      ];
+      const featuredGroups = [
+        { id: 'groupa', name: 'GroupA' },
+        { id: '__world__', name: 'Public' },
+      ];
+      const groups = combineGroups(userGroups, featuredGroups);
+      const ids = groups.map(g => g.id);
+      assert.deepEqual(ids, ['__world__', 'groupa', 'groupb']);
+    });
+
+    it('adds isMember attribute to each group', () => {
+      const userGroups = [{ id: 'groupa', name: 'GroupA' }];
+      const featuredGroups = [
+        { id: 'groupb', name: 'GroupB' },
+        { id: '__world__', name: 'Public' },
+      ];
+
+      const expectedMembership = {
+        __world__: true,
+        groupa: true,
+        groupb: false,
+      };
+
+      const groups = combineGroups(userGroups, featuredGroups);
+      groups.forEach(g => assert.equal(g.isMember, expectedMembership[g.id]));
+    });
+
+    it('maintains the original ordering', () => {
+      const userGroups = [
+        { id: 'one', name: 'GroupA' },
+        { id: 'two', name: 'GroupB' },
+      ];
+      const featuredGroups = [
+        { id: 'one', name: 'GroupA' },
+        { id: 'three', name: 'GroupC' },
+      ];
+
+      const groups = combineGroups(userGroups, featuredGroups);
+      const ids = groups.map(g => g.id);
+      assert.deepEqual(ids, ['one', 'two', 'three']);
+    });
+
+    it('lists the Public group first', () => {
+      const userGroups = [{ id: 'one', name: 'GroupA' }];
+      const featuredGroups = [{ id: '__world__', name: 'Public' }];
+
+      const groups = combineGroups(userGroups, featuredGroups);
+      assert.equal(groups[0].id, '__world__');
+    });
+
+    it('handles case where there is no Public group', () => {
+      const userGroups = [];
+      const featuredGroups = [];
+
+      const groups = combineGroups(userGroups, featuredGroups);
+      assert.deepEqual(groups, []);
+    });
+  });
+});


### PR DESCRIPTION
If the 'community-groups' feature flag is enabled, combine the groups from api.profile.groups with the groups from api.groups.list. 

api.profile.groups contains the list of all the user's groups for which there is membership, where as api.groups.list contains the groups scoped to the particular page. This means in the future, community groups will appear in the list of groups returned from the api.profile.groups endpoint.

There is a need to display the groups under different sections in the groups-list drop down aka: `My Groups` and `Featured Groups`. In order to distinguish where each group belongs, ```groupList: myGroups``` was added to groups that belong under the `My Groups` header (this includes the Public group). 

Note this includes a refactor to use the store to determine whether a user is logged in or not as opposed to depending on the token returned by passing metadata: true to the api call.