### PR TITLE
Add custom client version header to api requests

### DIFF
--- a/src/sidebar/services/api-routes.js
+++ b/src/sidebar/services/api-routes.js
@@ -14,7 +14,12 @@ function apiRoutes($http, settings) {
   let linkCache;
 
   function getJSON(url) {
-    return $http.get(url).then(({ status, data }) => {
+    const config = {
+      headers: {
+        'Hypothesis-Client-Version': '__VERSION__', // replaced by versionify
+      },
+    };
+    return $http.get(url, config).then(({ status, data }) => {
       if (status !== 200) {
         throw new Error(`Fetching ${url} failed`);
       }

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -143,7 +143,9 @@ function createAPICall($http, $q, links, route, tokenGetter) {
       .then(([links, token]) => {
         const descriptor = get(links, route);
         const url = urlUtil.replaceURLParams(descriptor.url, params);
-        const headers = {};
+        const headers = {
+          'Hypothesis-Client-Version': '__VERSION__', // replaced by versionify
+        };
 
         accessToken = token;
         if (token) {

--- a/src/sidebar/services/test/api-routes-test.js
+++ b/src/sidebar/services/test/api-routes-test.js
@@ -89,6 +89,14 @@ describe('sidebar.api-routes', () => {
         assert.deepEqual(routes, apiIndexResponse.links);
       });
     });
+
+    it('sends client version custom request header', () => {
+      return apiRoutes.routes().then(() => {
+        assert.calledWith(fakeHttp.get, fakeSettings.apiUrl, {
+          headers: { 'Hypothesis-Client-Version': '__VERSION__' },
+        });
+      });
+    });
   });
 
   describe('#links', () => {

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -364,4 +364,16 @@ describe('sidebar.services.api', function() {
       .respond(() => [200, { userid: 'acct:user@example.com' }]);
     $httpBackend.flush();
   });
+
+  it('sends client version custom request header', () => {
+    api.profile.read({});
+
+    $httpBackend
+      .expectGET(
+        'https://example.com/api/profile',
+        headers => headers['Hypothesis-Client-Version'] === '__VERSION__'
+      )
+      .respond(() => [200, { userid: 'acct:user@example.com' }]);
+    $httpBackend.flush();
+  });
 });


### PR DESCRIPTION
Add a custom http request header named 'Hypothesis-Client-Version' to all api requests sent from the client to h. 

This will enable us to track which versions of the clients are in use and also help us distinguish between api calls issued from our client vs api calls issued from another party. This is useful so we can tell for instance which api features our customers depend on and which features we can deprecate, or what clients are still in-play so we don't cause any backwards compatibility issues between client updates and server updates.