### PR TITLE
Add servetests to makefile for interactive test debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ help:
 	@echo "make lint              Run the code linter(s) and print any warnings"
 	@echo "make checkformatting   Check code formatting"
 	@echo "make format            Automatically format code"
-	@echo "make test              Run the unit tests"
+	@echo "make test              Run the unit tests once"
+	@echo "make servetests        Start the unit test server on localhost"
 	@echo "make docs              Build docs website and serve it locally"
 	@echo "make checkdocs         Crash if building the docs website fails"
 	@echo "make clean             Delete development artefacts (cached files, "
@@ -25,6 +26,10 @@ ifdef FILTER
 else
 	yarn test
 endif
+
+.PHONY: servetests
+servetests: node_modules/.uptodate
+	gulp test-watch
 
 .PHONY: lint
 lint: node_modules/.uptodate

--- a/docs/developers/developing.rst
+++ b/docs/developers/developing.rst
@@ -128,15 +128,20 @@ Hypothesis uses Karma and mocha for testing. To run all the tests once, run:
 
    make test
 
+You can filter the tests which are run by running ``make test FILTER=<pattern>``.
+See the documentation for Mocha's
+`grep <https://mochajs.org/#g---grep-pattern>`_ option.
+
 To run tests and automatically re-run them whenever any source files change, run:
 
 .. code-block:: sh
 
-   gulp test-watch
+   make servetests
 
-You can filter the tests which are run by running ``make test FILTER=<pattern>``.
-See the documentation for Mocha's
-`grep <https://mochajs.org/#g---grep-pattern>`_ option.
+This command will also serve the tests on localhost (typically `http://localhost:9876`)
+so that break points can be set and the browser's console can be used for interactive
+debugging. 
+
 
 Code Style
 ----------


### PR DESCRIPTION
Add `make servetests` command to Makefile. This command will run the unit tests and serve them on http://localhost:9877 so that any `debugger;` breakpoints take effect and the browser console can be used to interact live with the code. 