### PR TITLE
Update Code Style docs to mention ESLint and Prettier

### DIFF
--- a/docs/developers/developing.rst
+++ b/docs/developers/developing.rst
@@ -144,18 +144,20 @@ Code Style
 JavaScript
 ##########
 
-Hypothesis uses ESLint to help maintain style consistency. You can check your
-changes for conformance using:
+Hypothesis uses ESLint_ (a linter) and Prettier_ (an automated code formatter)
+to ensure style consistency and help prevent common mistakes. Plugins are
+available for most editors for these tools. We recommend that you set these up
+before making changes to the code.
+
+To auto-format code and run lint checks locally using the CLI, run:
 
 .. code-block:: sh
 
+   make format
    make lint
 
-Many lint errors can be fixed automatically using:
-
-.. code-block:: sh
-
-   ./node_modules/.bin/eslint --fix
+.. _ESLint: https://eslint.org
+.. _Prettier: https://prettier.io
 
 CSS
 ###

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "deps": "check-dependencies",
     "lint": "eslint .",
     "checkformatting": "prettier --check 'src/**/*.js'",
-    "format": "prettier --write 'src/**/*.js'",
+    "format": "prettier --list-different --write 'src/**/*.js'",
     "test": "gulp test",
     "report-coverage": "codecov -f coverage/coverage-final.json",
     "version": "make clean build/manifest.json",


### PR DESCRIPTION
Update the developer documentation to mention automated code formatting.

I also changed the `make format` command slightly to only print the names of changed source files. The default output prints the names of all source files but uses a different color for unchanged files.