### PR TITLE
Support filtering annotations by display name

### DIFF
--- a/src/sidebar/services/test/search-filter-test.js
+++ b/src/sidebar/services/test/search-filter-test.js
@@ -57,6 +57,21 @@ describe('sidebar.search-filter', () => {
       assert.equal(result.any[2], 'hi-fi');
       assert.equal(result.any[3], 'a:bc');
     });
+
+    it('supports quoting terms', () => {
+      const parsed = searchFilter.toObject('user:"Dan Whaley"');
+      assert.deepEqual(parsed, {
+        user: ['Dan Whaley'],
+      });
+    });
+
+    it('assigns unquoted terms to "any" category', () => {
+      const parsed = searchFilter.toObject('user:Dan Whaley');
+      assert.deepEqual(parsed, {
+        any: ['Whaley'],
+        user: ['Dan'],
+      });
+    });
   });
 
   describe('#generateFacetedFilter', () => {

--- a/src/sidebar/services/test/view-filter-test.js
+++ b/src/sidebar/services/test/view-filter-test.js
@@ -153,10 +153,11 @@ describe('sidebar/services/view-filter', () => {
       const anns = [
         annotationWithUser('johnsmith'),
         annotationWithUser('jamesdean'),
+        annotationWithUser('johnjones'),
       ];
-      const result = viewFilter.filter(anns, userQuery('johnsmith'));
+      const result = viewFilter.filter(anns, userQuery('john'));
 
-      assert.deepEqual(result, [anns[0].id]);
+      assert.deepEqual(result, [anns[0].id, anns[2].id]);
     });
 
     it("matches user's display name if present", () => {
@@ -164,6 +165,8 @@ describe('sidebar/services/view-filter', () => {
         // Users with display names set.
         annotationWithUser('jsmith', 'John Smith'),
         annotationWithUser('jdean', 'James Dean'),
+        annotationWithUser('jherriot', 'James Herriot'),
+        annotationWithUser('jadejames', 'Jade'),
 
         // User with no display name.
         annotationWithUser('fmercury'),
@@ -173,7 +176,7 @@ describe('sidebar/services/view-filter', () => {
       ];
       const result = viewFilter.filter(anns, userQuery('james'));
 
-      assert.deepEqual(result, [anns[1].id]);
+      assert.deepEqual(result, [anns[1].id, anns[2].id, anns[3].id]);
     });
 
     it('ignores display name if not set', () => {

--- a/src/sidebar/services/test/view-filter-test.js
+++ b/src/sidebar/services/test/view-filter-test.js
@@ -132,6 +132,57 @@ describe('sidebar/services/view-filter', () => {
     });
   });
 
+  describe('"user" field', () => {
+    let id = 0;
+    function annotationWithUser(username, displayName = null) {
+      ++id;
+      return {
+        id,
+        user: `acct:${username}@example.com`,
+        user_info: {
+          display_name: displayName,
+        },
+      };
+    }
+
+    function userQuery(term) {
+      return { user: { terms: [term], operator: 'or' } };
+    }
+
+    it('matches username', () => {
+      const anns = [
+        annotationWithUser('johnsmith'),
+        annotationWithUser('jamesdean'),
+      ];
+      const result = viewFilter.filter(anns, userQuery('johnsmith'));
+
+      assert.deepEqual(result, [anns[0].id]);
+    });
+
+    it("matches user's display name if present", () => {
+      const anns = [
+        // Users with display names set.
+        annotationWithUser('jsmith', 'John Smith'),
+        annotationWithUser('jdean', 'James Dean'),
+
+        // User with no display name.
+        annotationWithUser('fmercury'),
+
+        // Annotation with no extended user info.
+        { id: 100, user: 'acct:jim@example.com' },
+      ];
+      const result = viewFilter.filter(anns, userQuery('james'));
+
+      assert.deepEqual(result, [anns[1].id]);
+    });
+
+    it('ignores display name if not set', () => {
+      const anns = [annotationWithUser('msmith')];
+      const result = viewFilter.filter(anns, userQuery('null'));
+      assert.deepEqual(result, []);
+    });
+  });
+
   describe('"since" field', () => {
     it('matches if the annotation is newer than the query', () => {
       const annotation = {

--- a/src/sidebar/services/view-filter.js
+++ b/src/sidebar/services/view-filter.js
@@ -4,6 +4,13 @@
 // breaks browserify-ngannotate.
 let unused; // eslint-disable-line
 
+function displayName(ann) {
+  if (!ann.user_info) {
+    return '';
+  }
+  return ann.user_info.display_name || '';
+}
+
 /**
  * Filter annotations against parsed search queries.
  *
@@ -133,7 +140,7 @@ function viewFilter(unicode) {
     },
     user: {
       autofalse: ann => typeof ann.user !== 'string',
-      value: ann => ann.user,
+      value: ann => ann.user + ' ' + displayName(ann),
       match: (term, value) => value.indexOf(term) > -1,
     },
   };


### PR DESCRIPTION
Allow `user:{term}` filters in the search bar to match display names as
well as usernames.

I have allowed for annotations having no `user_info` field as with other
code in the client that handles annotation objects. However "h" will always
populate that field currently.

Fixes https://github.com/hypothesis/product-backlog/issues/943