### PR TITLE
Use token instead of store.profile to calc isLoggedIn

### DIFF
--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -27,6 +27,7 @@ function groups(
   serviceUrl,
   session,
   settings,
+  auth,
   features
 ) {
   const svc = serviceConfig(settings);
@@ -158,17 +159,23 @@ function groups(
           };
           const profileGroupsApi = api.profile.groups.read(profileParams);
           const listGroupsApi = api.groups.list(params);
-          return Promise.all([profileGroupsApi, listGroupsApi]).then(
-            ([myGroups, featuredGroups]) =>
-              combineGroups(myGroups, featuredGroups)
-          );
+          return Promise.all([
+            profileGroupsApi,
+            listGroupsApi,
+            auth.tokenGetter(),
+          ]).then(([myGroups, featuredGroups, token]) => [
+            combineGroups(myGroups, featuredGroups),
+            token,
+          ]);
         } else {
           // Fetch groups from the API.
-          return api.groups.list(params);
+          return api.groups
+            .list(params, null, { includeMetadata: true })
+            .then(({ data, token }) => [data, token]);
         }
       })
-      .then(groups => {
-        const isLoggedIn = store.profile().userid !== null;
+      .then(([groups, token]) => {
+        const isLoggedIn = token !== null;
         const directLinkedAnnotation = settings.annotations;
         return filterGroups(groups, isLoggedIn, directLinkedAnnotation);
       })


### PR DESCRIPTION
This is a fix for: https://github.com/hypothesis/product-backlog/issues/957. 
In summary, since groups and profile are called concurrently on startup, we cannot depend on store.profile().userid to determine whether a user is logged in or not because that call may not have completed by the time we need it in the groups service.