### PR TITLE
Add isSelectable property to groups based on group scope

### DIFF
--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -154,8 +154,9 @@ function groups(
         documentUri = uri;
 
         if (features.flagEnabled('community_groups')) {
+          params.expand = ['organization', 'scopes'];
           const profileParams = {
-            expand: ['organization'],
+            expand: ['organization', 'scopes'],
           };
           const profileGroupsApi = api.profile.groups.read(profileParams);
           const listGroupsApi = api.groups.list(params);
@@ -164,7 +165,7 @@ function groups(
             listGroupsApi,
             auth.tokenGetter(),
           ]).then(([myGroups, featuredGroups, token]) => [
-            combineGroups(myGroups, featuredGroups),
+            combineGroups(myGroups, featuredGroups, documentUri),
             token,
           ]);
         } else {

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -203,11 +203,11 @@ describe('groups', function() {
       return svc.load().then(() => {
         assert.calledWith(
           fakeApi.profile.groups.read,
-          sinon.match({ expand: ['organization'] })
+          sinon.match({ expand: ['organization', 'scopes'] })
         );
         assert.calledWith(
           fakeApi.groups.list,
-          sinon.match({ expand: 'organization' })
+          sinon.match({ expand: ['organization', 'scopes'] })
         );
       });
     });

--- a/src/sidebar/util/groups.js
+++ b/src/sidebar/util/groups.js
@@ -36,15 +36,10 @@ function combineGroups(userGroups, featuredGroups, uri) {
 
 function isScopedToUri(group, uri) {
   // If the group has scope info, the scoping is enforced,
-  // and the uri patterns don't inlude this page's uri
+  // and the uri patterns don't include this page's uri
   // the group is not selectable, otherwise it is.
-  if (
-    group.scopes &&
-    group.scopes.enforced &&
-    group.scopes.uri_patterns &&
-    !uriMatchesScopes(uri, group.scopes.uri_patterns)
-  ) {
-    return false;
+  if (group.scopes && group.scopes.enforced) {
+    return uriMatchesScopes(uri, group.scopes.uri_patterns);
   }
   return true;
 }

--- a/src/sidebar/util/groups.js
+++ b/src/sidebar/util/groups.js
@@ -1,13 +1,18 @@
 'use strict';
 
+const escapeStringRegexp = require('escape-string-regexp');
+
 /**
  * Combine groups from multiple api calls together to form a unique list of groups.
  * Add an isMember property to each group indicating whether the logged in user is a member.
+ * Add an isScopedToUri property to each group indicating whether the group can be annotated
+ *   in based on group scoping and the uri of the current page.
  *
  * @param {Group[]} userGroups - groups the user is a member of
  * @param {Group[]} featuredGroups - groups scoped to the particular uri, authority, and user
+ * @param {string} uri - uri of the current page
  */
-function combineGroups(userGroups, featuredGroups) {
+function combineGroups(userGroups, featuredGroups, uri) {
   const worldGroup = featuredGroups.find(g => g.id === '__world__');
   if (worldGroup) {
     userGroups.unshift(worldGroup);
@@ -20,7 +25,42 @@ function combineGroups(userGroups, featuredGroups) {
   featuredGroups.forEach(group => (group.isMember = false));
   userGroups.forEach(group => (group.isMember = true));
 
-  return userGroups.concat(featuredGroups);
+  const groups = userGroups.concat(featuredGroups);
+
+  // Add isScopedToUri property indicating whether a group can be
+  // annotated in at this particular url.
+  groups.forEach(group => (group.isScopedToUri = isScopedToUri(group, uri)));
+
+  return groups;
+}
+
+function isScopedToUri(group, uri) {
+  // If the group has scope info, the scoping is enforced,
+  // and the uri patterns don't inlude this page's uri
+  // the group is not selectable, otherwise it is.
+  if (
+    group.scopes &&
+    group.scopes.enforced &&
+    group.scopes.uri_patterns &&
+    !uriMatchesScopes(uri, group.scopes.uri_patterns)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function uriMatchesScopes(uri, scopes) {
+  return (
+    scopes.find(uriRegex =>
+      uri.match(
+        // Convert *'s to .*'s for regex matching and escape all other special characters.
+        uriRegex
+          .split('*')
+          .map(escapeStringRegexp)
+          .join('.*')
+      )
+    ) !== undefined
+  );
 }
 
 module.exports = {

--- a/src/sidebar/util/test/groups-test.js
+++ b/src/sidebar/util/test/groups-test.js
@@ -107,22 +107,8 @@ describe('sidebar.util.groups', () => {
       },
       {
         description:
-          'sets `isScopedToUri` to true if `scopes.enforced` is missing',
-        scopes: {},
-        shouldBeSelectable: true,
-        uri: 'https://foo.com/bar',
-      },
-      {
-        description:
           'sets `isScopedToUri` to true if `scopes.enforced` is false',
         scopes: { enforced: false },
-        shouldBeSelectable: true,
-        uri: 'https://foo.com/bar',
-      },
-      {
-        description:
-          'sets `isScopedToUri` to true if `scopes.uri_patterns` is undefined',
-        scopes: { enforced: true, uri_patterns: undefined },
         shouldBeSelectable: true,
         uri: 'https://foo.com/bar',
       },

--- a/src/sidebar/util/test/groups-test.js
+++ b/src/sidebar/util/test/groups-test.js
@@ -7,7 +7,11 @@ describe('sidebar.util.groups', () => {
     it('labels groups in both lists as isMember true', () => {
       const userGroups = [{ id: 'groupa', name: 'GroupA' }];
       const featuredGroups = [{ id: 'groupa', name: 'GroupA' }];
-      const groups = combineGroups(userGroups, featuredGroups);
+      const groups = combineGroups(
+        userGroups,
+        featuredGroups,
+        'https://foo.com/bar'
+      );
       const groupA = groups.find(g => g.id === 'groupa');
       assert.equal(groupA.isMember, true);
     });
@@ -21,7 +25,11 @@ describe('sidebar.util.groups', () => {
         { id: 'groupa', name: 'GroupA' },
         { id: '__world__', name: 'Public' },
       ];
-      const groups = combineGroups(userGroups, featuredGroups);
+      const groups = combineGroups(
+        userGroups,
+        featuredGroups,
+        'https://foo.com/bar'
+      );
       const ids = groups.map(g => g.id);
       assert.deepEqual(ids, ['__world__', 'groupa', 'groupb']);
     });
@@ -39,7 +47,11 @@ describe('sidebar.util.groups', () => {
         groupb: false,
       };
 
-      const groups = combineGroups(userGroups, featuredGroups);
+      const groups = combineGroups(
+        userGroups,
+        featuredGroups,
+        'https://foo.com/bar'
+      );
       groups.forEach(g => assert.equal(g.isMember, expectedMembership[g.id]));
     });
 
@@ -53,7 +65,11 @@ describe('sidebar.util.groups', () => {
         { id: 'three', name: 'GroupC' },
       ];
 
-      const groups = combineGroups(userGroups, featuredGroups);
+      const groups = combineGroups(
+        userGroups,
+        featuredGroups,
+        'https://foo.com/bar'
+      );
       const ids = groups.map(g => g.id);
       assert.deepEqual(ids, ['one', 'two', 'three']);
     });
@@ -62,7 +78,11 @@ describe('sidebar.util.groups', () => {
       const userGroups = [{ id: 'one', name: 'GroupA' }];
       const featuredGroups = [{ id: '__world__', name: 'Public' }];
 
-      const groups = combineGroups(userGroups, featuredGroups);
+      const groups = combineGroups(
+        userGroups,
+        featuredGroups,
+        'https://foo.com/bar'
+      );
       assert.equal(groups[0].id, '__world__');
     });
 
@@ -70,8 +90,96 @@ describe('sidebar.util.groups', () => {
       const userGroups = [];
       const featuredGroups = [];
 
-      const groups = combineGroups(userGroups, featuredGroups);
+      const groups = combineGroups(
+        userGroups,
+        featuredGroups,
+        'https://foo.com/bar'
+      );
       assert.deepEqual(groups, []);
+    });
+
+    [
+      {
+        description: 'sets `isScopedToUri` to true if `scopes` is missing',
+        scopes: undefined,
+        shouldBeSelectable: true,
+        uri: 'https://foo.com/bar',
+      },
+      {
+        description:
+          'sets `isScopedToUri` to true if `scopes.enforced` is missing',
+        scopes: {},
+        shouldBeSelectable: true,
+        uri: 'https://foo.com/bar',
+      },
+      {
+        description:
+          'sets `isScopedToUri` to true if `scopes.enforced` is false',
+        scopes: { enforced: false },
+        shouldBeSelectable: true,
+        uri: 'https://foo.com/bar',
+      },
+      {
+        description:
+          'sets `isScopedToUri` to true if `scopes.uri_patterns` is undefined',
+        scopes: { enforced: true, uri_patterns: undefined },
+        shouldBeSelectable: true,
+        uri: 'https://foo.com/bar',
+      },
+      {
+        description:
+          'sets `isScopedToUri` to true if at least one of the `scopes.uri_patterns` match the uri',
+        scopes: {
+          enforced: true,
+          uri_patterns: ['http://foo.com*', 'https://foo.com*'],
+        },
+        shouldBeSelectable: true,
+        uri: 'https://foo.com/bar',
+      },
+      {
+        description:
+          'sets `isScopedToUri` to false if `scopes.uri_patterns` do not match the uri',
+        scopes: { enforced: true, uri_patterns: ['http://foo.com*'] },
+        shouldBeSelectable: false,
+        uri: 'https://foo.com/bar',
+      },
+      {
+        description: 'it permits multiple *s in the scopes uri pattern',
+        scopes: { enforced: true, uri_patterns: ['https://foo.com*bar*'] },
+        shouldBeSelectable: true,
+        uri: 'https://foo.com/boo/bar/baz',
+      },
+      {
+        description: 'it escapes non-* chars in the scopes uri pattern',
+        scopes: {
+          enforced: true,
+          uri_patterns: ['https://foo.com?bar=foo$[^]($){mu}+&boo=*'],
+        },
+        shouldBeSelectable: true,
+        uri: 'https://foo.com?bar=foo$[^]($){mu}+&boo=foo',
+      },
+    ].forEach(({ description, scopes, shouldBeSelectable, uri }) => {
+      it(description, () => {
+        const userGroups = [{ id: 'groupa', name: 'GroupA', scopes: scopes }];
+        const featuredGroups = [];
+
+        const groups = combineGroups(userGroups, featuredGroups, uri);
+
+        groups.forEach(g => assert.equal(g.isScopedToUri, shouldBeSelectable));
+      });
+    });
+
+    it('adds `isScopedToUri` property to groups', () => {
+      const userGroups = [{ id: 'one', name: 'GroupA' }];
+      const featuredGroups = [{ id: '__world__', name: 'Public' }];
+
+      const groups = combineGroups(
+        userGroups,
+        featuredGroups,
+        'https://foo.com/bar'
+      );
+
+      groups.forEach(g => assert.equal(g.isScopedToUri, true));
     });
   });
 });


### PR DESCRIPTION
Add a new property called isSelectable that will indicate whether a group can be annotated in based on the defined scope of the group and the uri of the current page. This will be used in the UX to determine whether a group should be greyed out or not within the group drop down list.