### PR TITLE
Avoid using build executor while waiting for deployment confirmation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,11 +62,11 @@ node {
             sh 'make test'
         }
     }
+}
 
-    if (env.BRANCH_NAME != releaseFromBranch) {
-        echo "Skipping deployment because this is not the ${releaseFromBranch} branch"
-        return
-    }
+if (env.BRANCH_NAME != releaseFromBranch) {
+    echo "Skipping deployment because ${env.BRANCH_NAME} is not the ${releaseFromBranch} branch"
+    return
 }
 
 milestone()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,9 +67,11 @@ node {
         echo "Skipping deployment because this is not the ${releaseFromBranch} branch"
         return
     }
+}
 
-    milestone()
-    stage('Publish to QA') {
+milestone()
+stage('Publish to QA') {
+    node {
         qaVersion = pkgVersion + "-${lastCommitHash}"
         nodeEnv.inside("-e HOME=${workspace}") {
             withCredentials([
@@ -104,12 +106,14 @@ node {
             }
         }
     }
+}
 
+milestone()
+stage('Publish') {
+    input(message: "Publish new client release?")
     milestone()
-    stage('Publish') {
-        input(message: "Publish new client release?")
-        milestone()
 
+    node {
         echo "Publishing ${pkgName} v${newPkgVersion} from ${releaseFromBranch} branch."
 
         nodeEnv.inside("-e HOME=${workspace} -e BRANCH_NAME=${env.BRANCH_NAME}") {


### PR DESCRIPTION
The Jenkinsfile previously has this structure:

```
node {
  // Do checkout, run tests etc.
  ...
  stage('Deploy to prod') {
    input(message: "Deploy to prod")
  }
}
```

While any steps inside the `node` block are running or waiting, the pipeline
will consume a build executor slot. If several client builds were waiting for
manual input, this could prevent other Jenkins jobs from running.

This commit restructures the Jenkinsfile like so:

```
node {
  // Do checkout, run tests etc.
}

stage('Deploy to prod') {
  input(message: 'Deploy to prod?')
  node {
    // Do the deployment
  }
}
```

As a result, a client build waiting to be deployed to production will no longer
consume a build executor slot.

See also the "7. Don't: Use input within a node" tip in [1]

Fixes #955

[1] https://www.cloudbees.com/blog/top-10-best-practices-jenkins-pipeline-plugin