### PR TITLE
Show error when trying to hightlight/annotate while not logged in

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -53,6 +53,7 @@ function AnnotationController(
   store,
   annotationMapper,
   api,
+  bridge,
   drafts,
   flash,
   groups,
@@ -195,6 +196,12 @@ function AnnotationController(
     if (!isNew(self.annotation)) {
       // Already saved.
       return;
+    }
+
+    if (!self.annotation.user) {
+      // make the bug https://github.com/hypothesis/client/issues/12 explicit to user so they can at least log in
+      bridge.call('showSidebar');
+      flash.error('Sorry, drafts are currently broken. Please log in first.');
     }
 
     if (!self.isHighlight()) {

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -117,6 +117,7 @@ describe('annotation', function() {
     let fakeSession;
     let fakeSettings;
     let fakeApi;
+    let fakeBridge;
     let fakeStreamer;
     let sandbox;
 
@@ -246,6 +247,10 @@ describe('annotation', function() {
           },
         };
 
+        fakeBridge = {
+          call: sinon.stub(),
+        };
+
         fakeStreamer = {
           hasPendingDeletion: sinon.stub(),
         };
@@ -254,6 +259,7 @@ describe('annotation', function() {
         $provide.value('annotationMapper', fakeAnnotationMapper);
         $provide.value('store', fakeStore);
         $provide.value('api', fakeApi);
+        $provide.value('bridge', fakeBridge);
         $provide.value('drafts', fakeDrafts);
         $provide.value('flash', fakeFlash);
         $provide.value('groups', fakeGroups);


### PR DESCRIPTION
This is an attempt to work around https://github.com/hypothesis/client/issues/12 by at least making sure the user notices that they are not logged in. 

I am not really sure the bit of code I added is at the right spot, as in, I feel like it would be more appropriate to detect whether the user is logged in [here](https://github.com/hypothesis/client/blob/master/src/annotator/guest.coffee#L350), but I've struggled to get the `session` object in the `guest.coffee` file so I could check the login state. I'm not really familiar with coffeescript and javascript architectures generally, so not sure if that even possible?

Although, I noticed, that if there were annotations already present on the page (by other users), the [annotation header](https://github.com/hypothesis/client/blob/master/src/sidebar/templates/annotation.html#L1-L3) tends to jump around and might end up at the very bottom (haven't had time to debug it). So perhaps we should just always show toast?

Anyway, I'm happy to help and please let me know if you have a different vision for fixing this!