### PR TITLE
Add Currently Viewing, Featured, & My Groups sections to group drop down

### DIFF
--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -67,6 +67,17 @@ function GroupListController(
   };
 
   /**
+   * This is a quick and dirty hack to show styling, and needs refactoring.
+   */
+  this.toggleGroupDetails = function() {
+    const groupDetails = $window.document.getElementById(
+      'group-details-out-of-scope'
+    );
+    groupDetails.classList.toggle('expanded');
+    $window.event.stopPropagation();
+  };
+
+  /**
    * Show the share link for the group if it is not a third-party group
    * AND if the URL needed is present in the group object. We should be able
    * to simplify this once the API is adjusted only to return the link

--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -4,16 +4,25 @@ const { isThirdPartyUser } = require('../util/account-id');
 const isThirdPartyService = require('../util/is-third-party-service');
 const serviceConfig = require('../service-config');
 const memoize = require('../util/memoize');
-const groupOrganizations = memoize(require('../util/group-organizations'));
+const groupsByOrganization = require('../util/group-organizations');
+
+const groupOrganizations = memoize(groupsByOrganization);
+
+const myGroupOrgs = memoize(groupsByOrganization);
+
+const featuredGroupOrgs = memoize(groupsByOrganization);
+
+const currentlyViewingGroupOrgs = memoize(groupsByOrganization);
 
 // @ngInject
 function GroupListController(
   $window,
   analytics,
+  features,
   groups,
   settings,
   serviceUrl,
-  features
+  store
 ) {
   this.groups = groups;
 
@@ -55,6 +64,18 @@ function GroupListController(
 
   this.groupOrganizations = function() {
     return groupOrganizations(this.groups.all());
+  };
+
+  this.currentlyViewingGroupOrganizations = function() {
+    return currentlyViewingGroupOrgs(store.getCurrentlyViewingGroups());
+  };
+
+  this.featuredGroupOrganizations = function() {
+    return featuredGroupOrgs(store.getFeaturedGroups());
+  };
+
+  this.myGroupOrganizations = function() {
+    return myGroupOrgs(store.getMyGroups());
   };
 
   this.viewGroupActivity = function() {

--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -26,6 +26,9 @@ function GroupListController(
 ) {
   this.groups = groups;
 
+  // Track which non-selectable groups have their group details expanded.
+  this.groupDetailsExpanded = {};
+
   this.createNewGroup = function() {
     $window.open(serviceUrl('groups.new'), '_blank');
   };
@@ -87,15 +90,21 @@ function GroupListController(
     groups.focus(groupId);
   };
 
+  this.isGroupDetailsExpanded = function(groupId) {
+    if (!(groupId in this.groupDetailsExpanded)) {
+      this.groupDetailsExpanded[groupId] = false;
+    }
+    return this.groupDetailsExpanded[groupId];
+  };
+
   /**
-   * This is a quick and dirty hack to show styling, and needs refactoring.
+   * Toggle the expanded setting on un-selectable groups.
    */
-  this.toggleGroupDetails = function() {
-    const groupDetails = $window.document.getElementById(
-      'group-details-out-of-scope'
-    );
-    groupDetails.classList.toggle('expanded');
-    $window.event.stopPropagation();
+  this.toggleGroupDetails = function(event, groupId) {
+    event.stopPropagation();
+    // Call the isGroupDetailsExpanded method so that if the groupId doesn't exist,
+    // it gets added before toggling it.
+    this.groupDetailsExpanded[groupId] = !this.isGroupDetailsExpanded(groupId);
   };
 
   /**

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -452,6 +452,45 @@ describe('groupList', function() {
       }
     );
   });
+  describe('group details expanded on out of scope groups', () => {
+    it('sets the default for the given groupid to false and returns it', () => {
+      const element = createGroupList();
+
+      const expanded = element.ctrl.isGroupDetailsExpanded('groupid');
+
+      assert.isFalse(expanded);
+      assert.isFalse(element.ctrl.groupDetailsExpanded.groupid);
+    });
+
+    it('gets expanded value for the given groupid if already present', () => {
+      const element = createGroupList();
+
+      element.ctrl.groupDetailsExpanded = { groupid: true };
+      const expanded = element.ctrl.isGroupDetailsExpanded('groupid');
+
+      assert.isTrue(expanded);
+    });
+
+    it('toggles the expanded value for the given groupid', () => {
+      const element = createGroupList();
+      let fakeEvent = { stopPropagation: sinon.stub() };
+
+      element.ctrl.toggleGroupDetails(fakeEvent, 'groupid');
+      assert.isTrue(element.ctrl.groupDetailsExpanded.groupid);
+
+      element.ctrl.toggleGroupDetails(fakeEvent, 'groupid');
+      assert.isFalse(element.ctrl.groupDetailsExpanded.groupid);
+    });
+
+    it('stops the event from propogating when toggling', () => {
+      const element = createGroupList();
+      let fakeEvent = { stopPropagation: sinon.spy() };
+
+      element.ctrl.toggleGroupDetails(fakeEvent, 'groupid');
+
+      sinon.assert.called(fakeEvent.stopPropagation);
+    });
+  });
 
   it('displays out of scope groups as non-selectable', () => {
     fakeFeatures.flagEnabled.withArgs('community_groups').returns(true);

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const util = require('../util');
+const memoize = require('../../util/memoize');
 const { selectors: sessionSelectors } = require('./session');
 const { isLoggedIn } = sessionSelectors;
 
@@ -121,41 +122,41 @@ function getGroup(state, id) {
 }
 
 /**
- * Return groups that don't show up in Featured and My Groups.
- *
- * @return {Group[]}
- */
-function getCurrentlyViewingGroups(state) {
-  const myGroups = getMyGroups(state);
-  const featuredGroups = getFeaturedGroups(state);
-
-  return state.groups.filter(
-    g => !myGroups.includes(g) && !featuredGroups.includes(g)
-  );
-}
-
-/**
  * Return groups the logged in user is a member of.
  *
  * @return {Group[]}
  */
-function getMyGroups(state) {
+const getMyGroups = memoize(state => {
   // If logged out, the Public group still has isMember set to true so only
   // return groups with membership in logged in state.
   if (isLoggedIn(state)) {
     return state.groups.filter(g => g.isMember);
   }
   return [];
-}
+});
 
 /**
  * Return groups the user isn't a member of that are scoped to the URI.
  *
  * @return {Group[]}
  */
-function getFeaturedGroups(state) {
+const getFeaturedGroups = memoize(state => {
   return state.groups.filter(group => !group.isMember && group.isScopedToUri);
-}
+});
+
+/**
+ * Return groups that don't show up in Featured and My Groups.
+ *
+ * @return {Group[]}
+ */
+const getCurrentlyViewingGroups = memoize(state => {
+  const myGroups = getMyGroups(state);
+  const featuredGroups = getFeaturedGroups(state);
+
+  return state.groups.filter(
+    g => !myGroups.includes(g) && !featuredGroups.includes(g)
+  );
+});
 
 module.exports = {
   init,

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -168,7 +168,7 @@
         <!-- Show the group as not selectable if it is not scoped to this page !-->
         <div class="group-item--out-of-scope"
              ng-class="{'group-item-community-groups': true, 'is-selected': group.id == vm.groups.focused().id}"
-             ng-click="vm.toggleGroupDetails()" tabindex="0"  ng-if="!group.isScopedToUri">
+             ng-click="vm.toggleGroupDetails($event, group.id)" tabindex="0"  ng-if="!group.isScopedToUri">
           <!-- the group icon !-->
           <div class="group-menu-icon-container">
             <img class="group-list-label__icon group-list-label__icon--organization"
@@ -177,7 +177,7 @@
               ng-if="group.logo">
           </div>
           <!-- the group name and share link !-->
-          <div class="group-details-community-groups" id="group-details-out-of-scope">
+          <div ng-class="{'group-details-community-groups': true, expanded: vm.isGroupDetailsExpanded(group.id)}">
             <svg class="svg-icon group__icon--unavailable" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24">
               <path fill="none" d="M0 0h24v24H0V0z"/>
               <path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/>

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -28,8 +28,10 @@
     !--><span class="group-list-label__label">{{vm.groups.focused().name}}</span>
   </div>
   <!-- Only build the drop down menu if showGroupsMenu is true. -->
-  <div class="dropdown-menu__top-arrow" ng-if="vm.showGroupsMenu()"></div>
-  <ul class="dropdown-menu pull-none" role="menu" ng-if="vm.showGroupsMenu()">
+
+  <!-- Original groups menu. -->
+  <div class="dropdown-menu__top-arrow" ng-if="vm.showGroupsMenu() && !vm.isFeatureFlagEnabled('community_groups')"></div>
+  <ul class="dropdown-menu pull-none" role="menu" ng-if="vm.showGroupsMenu() && !vm.isFeatureFlagEnabled('community_groups')">
     <li class="dropdown-menu__row dropdown-menu__row--unpadded "
         ng-repeat="group in vm.groupOrganizations() track by group.id">
       <div ng-class="{'group-item': true, selected: group.id == vm.groups.focused().id}"
@@ -82,4 +84,132 @@
       </div>
     </li>
   </ul>
+
+  <!-- Show new menu if community_groups feature flag is enabled. -->
+  <div class="dropdown-menu" role="menu" ng-if="vm.showGroupsMenu() && vm.isFeatureFlagEnabled('community_groups')">
+
+    <!-- Display Currently Viewing. -->
+    <h2 class="dropdown-menu__section-heading" ng-if="vm.currentlyViewingGroupOrganizations().length > 0">Currently Viewing</h2>
+    <ul class="dropdown-menu__section" ng-if="vm.currentlyViewingGroupOrganizations().length > 0">
+      <li class="dropdown-community-groups-menu__row dropdown-menu__row--unpadded"
+          ng-repeat="group in vm.currentlyViewingGroupOrganizations() track by group.id">
+        <div ng-class="{'group-item-community-groups': true, 'is-selected': group.id == vm.groups.focused().id}"
+             ng-click="vm.focusGroup(group.id)" tabindex="0">
+          <!-- the group icon !-->
+          <div class="group-menu-icon-container">
+            <img class="group-list-label__icon group-list-label__icon--organization"
+              alt="{{ vm.orgName(group.id) }}"
+              ng-src="{{ group.logo }}"
+              ng-if="group.logo">
+          </div>
+        <!-- the group name and share link !-->
+        <div class="group-details-community-groups">
+          <a class="group-name-link"
+             href=""
+             title="{{ group.type === 'private' ? 'Show and create annotations in ' + group.name : 'Show public annotations'  }}">
+             {{group.name}}
+          </a>
+        </div>
+      </li>
+    </ul>
+    <!-- Display Featured groups section. -->
+    <h2 class="dropdown-menu__section-heading" ng-if="vm.featuredGroupOrganizations().length > 0">Featured Groups</h2>
+    <ul class="dropdown-menu__section" ng-if="vm.featuredGroupOrganizations().length > 0">
+      <li class="dropdown-community-groups-menu__row dropdown-menu__row--unpadded"
+          ng-repeat="group in vm.featuredGroupOrganizations() track by group.id">
+        <div ng-class="{'group-item-community-groups': true, 'is-selected': group.id == vm.groups.focused().id}"
+             ng-click="vm.focusGroup(group.id)" tabindex="0">
+          <!-- the group icon !-->
+          <div class="group-menu-icon-container">
+            <img class="group-list-label__icon group-list-label__icon--organization"
+              alt="{{ vm.orgName(group.id) }}"
+              ng-src="{{ group.logo }}"
+              ng-if="group.logo">
+          </div>
+        <!-- the group name and share link !-->
+        <div class="group-details-community-groups">
+          <a class="group-name-link"
+             href=""
+             title="{{ group.type === 'private' ? 'Show and create annotations in ' + group.name : 'Show public annotations'  }}">
+             {{group.name}}
+          </a>
+        </div>
+      </li>
+    </ul>
+
+
+    <!-- Display My Groups groups section if user is logged in. -->
+    <h2 class="dropdown-menu__section-heading" ng-if="vm.myGroupOrganizations().length > 0">My Groups</h2>
+    <ul class="dropdown-menu__section" ng-if="vm.myGroupOrganizations().length > 0">
+
+      <li class="dropdown-community-groups-menu__row dropdown-menu__row--unpadded"
+          ng-repeat="group in vm.myGroupOrganizations() track by group.id">
+
+        <!-- Show the group like normal if it is scoped to this page -->
+        <div ng-class="{'group-item-community-groups': true, 'is-selected': group.id == vm.groups.focused().id}"
+             ng-click="vm.focusGroup(group.id)" tabindex="0" ng-if="group.isScopedToUri">
+          <!-- the group icon !-->
+          <div class="group-menu-icon-container">
+            <img class="group-list-label__icon group-list-label__icon--organization"
+              alt="{{ vm.orgName(group.id) }}"
+              ng-src="{{ group.logo }}"
+              ng-if="group.logo">
+          </div>
+          <!-- the group name and share link -->
+          <div class="group-details-community-groups">
+            <a class="group-name-link"
+               href=""
+               title="{{ group.type === 'private' ? 'Show and create annotations in ' + group.name : 'Show public annotations'  }}">
+               {{group.name}}
+            </a>
+          </div>
+        </div>
+
+        <!-- Show the group as not selectable if it is not scoped to this page !-->
+        <div class="group-item--out-of-scope"
+             ng-class="{'group-item-community-groups': true, 'is-selected': group.id == vm.groups.focused().id}"
+             ng-click="vm.toggleGroupDetails()" tabindex="0"  ng-if="!group.isScopedToUri">
+          <!-- the group icon !-->
+          <div class="group-menu-icon-container">
+            <img class="group-list-label__icon group-list-label__icon--organization"
+              alt="{{ vm.orgName(group.id) }}"
+              ng-src="{{ group.logo }}"
+              ng-if="group.logo">
+          </div>
+          <!-- the group name and share link !-->
+          <div class="group-details-community-groups" id="group-details-out-of-scope">
+            <svg class="svg-icon group__icon--unavailable" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24">
+              <path fill="none" d="M0 0h24v24H0V0z"/>
+              <path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/>
+            </svg>
+            <a class="group-name-link"
+               href=""
+               title="Group not annotatable on this domain.">
+               {{group.name}}
+            </a><br>
+            <p class="group-details__toggle">Why is this group unavailable?</p>
+            <p class="group-details__unavailable-message">
+              This group has been restricted to selected domains by its administrators.
+            </p>
+            <p class="group-details__actions">
+              <a class="button button--text group-details__group-page-link" href="{{group.links.html}}"
+               target="_blank"
+               ng-click="vm.viewGroupActivity()">Go to group page</a>
+            </p>
+          </div>
+        </div>
+      </li>
+    </ul>
+
+    <ul class="dropdown-menu__section dropdown-menu__section--no-header">
+      <li ng-if="vm.auth.status === 'logged-in' && !vm.isThirdPartyUser()" class="dropdown-community-groups-menu__row dropdown-menu__row--unpadded new-group-btn">
+        <div class="group-item-community-groups" ng-click="vm.createNewGroup()" tabindex="0">
+          <div class="group-icon-container"><i class="h-icon-add"></i></div>
+          <div class="group-details-community-groups">
+            New private group
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
 </div>

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -137,10 +137,7 @@ $base-font-size: 14px;
     padding-right: 6px;
     width: 36px;
     margin-bottom: 10px;
-
-    // the height of the sidebar toggle is set
-    // to match the height of the top bar
-    height: 40px;
+    height: $top-bar-height;
   }
 
   .annotator-frame-button--sidebar_close {

--- a/src/styles/sidebar/common.scss
+++ b/src/styles/sidebar/common.scss
@@ -242,6 +242,22 @@ html {
 
   min-height: 40px;
   min-width: 120px;
+
+  &:not(:first-child) {
+    border-top: dotted 1px $gray-lighter;
+  }
+}
+
+// Row in a dropdown menu
+.dropdown-community-groups-menu__row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding-left: 8px;
+  padding-right: 16px;
+
+  min-height: 40px;
+  min-width: 120px;
 }
 
 .dropdown-menu__row--unpadded {

--- a/src/styles/sidebar/common.scss
+++ b/src/styles/sidebar/common.scss
@@ -242,10 +242,6 @@ html {
 
   min-height: 40px;
   min-width: 120px;
-
-  &:not(:first-child) {
-    border-top: dotted 1px $gray-lighter;
-  }
 }
 
 .dropdown-menu__row--unpadded {

--- a/src/styles/sidebar/components/group-list.scss
+++ b/src/styles/sidebar/components/group-list.scss
@@ -21,10 +21,6 @@ $group-list-spacing-below: 50px;
     }
   }
 
-  .dropdown-menu__section--current {
-    background-color: $gray-lightest;
-  }
-
   .dropdown-menu__section--no-header {
     border-top: solid 1px rgba(0, 0, 0, 0.15);
 
@@ -44,10 +40,6 @@ $group-list-spacing-below: 50px;
     &:not(:first-child) {
       border-top: solid 1px rgba(0, 0, 0, 0.15);
     }
-  }
-
-  .dropdown-menu__section-heading--current {
-    background-color: $gray-lightest;
   }
 
   .group-item {
@@ -91,7 +83,7 @@ $group-list-spacing-below: 50px;
       background: $gray-lightest;
     }
 
-    &.selected {
+    &.is-selected {
       .group-name-link {
         font-size: $body2-font-size;
         font-weight: 600;
@@ -156,14 +148,14 @@ $group-list-spacing-below: 50px;
   }
 
   .group-details__toggle {
-    font-size: 0.8em;
+    font-size: $body1-font-size;
     font-style: italic;
     margin: 0;
     text-decoration: underline;
   }
 
   .group-details__unavailable-message {
-    font-size: 0.8em;
+    font-size: $body1-font-size;
     line-height: 1.5;
     white-space: normal;
     width: $group-list-width - 60px;
@@ -175,7 +167,7 @@ $group-list-spacing-below: 50px;
 
   .group-details__group-page-link {
     color: inherit;
-    font-size: 0.8em;
+    font-size: $body1-font-size;
     text-decoration: underline;
     text-transform: uppercase;
   }

--- a/src/styles/sidebar/components/group-list.scss
+++ b/src/styles/sidebar/components/group-list.scss
@@ -1,6 +1,6 @@
 /* The groups dropdown list. */
 
-$group-list-width: 270px;
+$group-list-width: 300px;
 $group-list-spacing-below: 50px;
 
 .group-list {
@@ -19,6 +19,35 @@ $group-list-spacing-below: 50px;
       text-overflow: ellipsis;
       width: $group-list-width - 30px;
     }
+  }
+
+  .dropdown-menu__section--current {
+    background-color: $gray-lightest;
+  }
+
+  .dropdown-menu__section--no-header {
+    border-top: solid 1px rgba(0, 0, 0, 0.15);
+
+    .group-details {
+      font-weight: 400;
+    }
+  }
+
+  .dropdown-menu__section-heading {
+    color: $gray-light;
+    font-size: 12px;
+    line-height: 1;
+    margin: 1px 1px 0;
+    padding: 12px 10px 0;
+    text-transform: uppercase;
+
+    &:not(:first-child) {
+      border-top: solid 1px rgba(0, 0, 0, 0.15);
+    }
+  }
+
+  .dropdown-menu__section-heading--current {
+    background-color: $gray-lightest;
   }
 
   .group-item {
@@ -43,6 +72,38 @@ $group-list-spacing-below: 50px;
     }
   }
 
+  .group-item-community-groups {
+    border: solid 1px transparent;
+    display: flex;
+    flex-direction: row;
+    flex-grow: 1;
+    margin: 1px;
+
+    padding: 10px;
+    cursor: pointer;
+
+    &:focus {
+      outline: none;
+      @include focus-outline;
+    }
+
+    &:hover {
+      background: $gray-lightest;
+    }
+
+    &.selected {
+      .group-name-link {
+        font-size: $body2-font-size;
+        font-weight: 600;
+      }
+    }
+  }
+
+  .group-item--out-of-scope {
+    background-color: $gray-lightest;
+    color: $gray-light;
+  }
+
   .group-icon-container {
     margin-right: 10px;
   }
@@ -61,9 +122,62 @@ $group-list-spacing-below: 50px;
     margin-right: 2px;
   }
 
+  .group__icon--unavailable {
+    fill: $gray-light;
+    float: right;
+    height: 20px;
+    width: auto;
+  }
+
   .group-details {
     flex-grow: 1;
     flex-shrink: 1;
+  }
+  .group-details-community-groups {
+    flex-grow: 1;
+    flex-shrink: 1;
+    font-weight: 500;
+
+    .group-details__unavailable-message,
+    .group-details__actions {
+      display: none;
+    }
+
+    &.expanded {
+      .group-details__toggle {
+        display: none;
+      }
+
+      .group-details__unavailable-message,
+      .group-details__actions {
+        display: block;
+      }
+    }
+  }
+
+  .group-details__toggle {
+    font-size: 0.8em;
+    font-style: italic;
+    margin: 0;
+    text-decoration: underline;
+  }
+
+  .group-details__unavailable-message {
+    font-size: 0.8em;
+    line-height: 1.5;
+    white-space: normal;
+    width: $group-list-width - 60px;
+  }
+
+  .group-details__actions {
+    text-align: right;
+  }
+
+  .group-details__group-page-link {
+    color: inherit;
+    font-size: 0.8em;
+    text-decoration: underline;
+    text-transform: uppercase;
   }
 
   .new-group-btn {
@@ -118,4 +232,11 @@ $group-list-spacing-below: 50px;
 .group-name-link {
   white-space: nowrap;
   color: inherit;
+}
+
+
+.open {
+  & > .group-list__toggle {
+    background: $gray-lighter;
+  }
 }

--- a/src/styles/sidebar/components/top-bar.scss
+++ b/src/styles/sidebar/components/top-bar.scss
@@ -38,7 +38,8 @@
 }
 
 .top-bar__inner .group-list {
-  margin-right: .75em;
+  justify-self: flex-start;
+  margin-right: auto;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
Organize the group drop down menu into sections `Currently Viewing`, `Featured Groups`, and `My Groups`. `My Groups` is a list of groups for which the user is a member and this list never changes based on the page being annotated. `Featured Groups` is a list of groups that are scoped to the page with no concept of membership and may change depending on the page. All other groups show up in `Currently Viewing`. Cases for a group showing in `Currently Viewing` are the Public group when it is linked to or a restricted group that was linked to that would otherwise not show up on the page. Some groups in `My Groups` may not be scoped to the page so while they still show up they are not selectable to be annotated in and are greyed out. 

This is a fix for https://github.com/hypothesis/product-backlog/issues/938.
Based on @dwolfe 's [PR](https://github.com/hypothesis/client/pull/830).

If the user is logged out:

1. There is only one publicly visible group so show it without the drop down. 
![image](https://user-images.githubusercontent.com/30059933/53459207-cebc7380-39ed-11e9-8207-c048662f2028.png)
2. There are no publicly visible groups so show the public group without the drop down. 
![image](https://user-images.githubusercontent.com/30059933/53459299-21962b00-39ee-11e9-9798-678bf85f0caf.png)
3. There are multiple publicly visible groups so show them in the drop down. 
![image](https://user-images.githubusercontent.com/30059933/53459862-03c9c580-39f0-11e9-98a0-92fbeb8c1a78.png)

4. The public group's annotations have been linked to but the group has publicly visible groups so show the public group under the `Currently Viewing` header. 
![image](https://user-images.githubusercontent.com/30059933/53465711-e30b6b00-3a03-11e9-848e-f57e5ed3e3cb.png)


If the user is logged in:

1. There are no featured groups so don't show them. 
![image](https://user-images.githubusercontent.com/30059933/53459456-bc8f0500-39ee-11e9-9977-0d7de77e9335.png)

2. There is only one group so don't show the drop down menu. 
![image](https://user-images.githubusercontent.com/30059933/53459560-31fad580-39ef-11e9-9e7d-8101f0d99f07.png)

3. There are open groups and they show up under the `Featured Groups`. 
![image](https://user-images.githubusercontent.com/30059933/53459493-f06a2a80-39ee-11e9-9e6e-71d45dd7d861.png)

4. There is an out-of-scope restricted group which the user is a member of shown in the My Groups list as un-selectable group. 
![image](https://user-images.githubusercontent.com/30059933/54388916-21d42e80-465c-11e9-9d87-bc9b4f0431a0.png)


5. There is a restricted group which is in-scope and the user is a member shown in the My Groups list. 
![image](https://user-images.githubusercontent.com/30059933/53463844-f8c96200-39fc-11e9-8657-639e9001d7f8.png)


6. There is a restricted group which is in-scope and the user is not a member so it's shown in the Featured Groups list. 
![image](https://user-images.githubusercontent.com/30059933/53463774-c455a600-39fc-11e9-8fb2-f3b62a4063eb.png)





