### PR TITLE
Add show section logic

### DIFF
--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -7,7 +7,14 @@ const memoize = require('../util/memoize');
 const groupOrganizations = memoize(require('../util/group-organizations'));
 
 // @ngInject
-function GroupListController($window, analytics, groups, settings, serviceUrl) {
+function GroupListController(
+  $window,
+  analytics,
+  groups,
+  settings,
+  serviceUrl,
+  features
+) {
   this.groups = groups;
 
   this.createNewGroup = function() {
@@ -78,7 +85,19 @@ function GroupListController($window, analytics, groups, settings, serviceUrl) {
   this.isThirdPartyService = isThirdPartyService(settings);
 
   this.showGroupsMenu = () => {
-    return !(this.isThirdPartyService && this.groups.all().length <= 1);
+    if (features.flagEnabled('community_groups')) {
+      return this.groups.all().length > 1;
+    } else {
+      return !(this.isThirdPartyService && this.groups.all().length <= 1);
+    }
+  };
+
+  /**
+   * Expose the feature flag so it can be used in the template logic to show
+   * or hide the new groups menu.
+   */
+  this.isFeatureFlagEnabled = flag => {
+    return features.flagEnabled(flag);
   };
 }
 

--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -86,6 +86,7 @@ function GroupListController(
 
   this.showGroupsMenu = () => {
     if (features.flagEnabled('community_groups')) {
+      // Only show the drop down menu if there is more than one group.
       return this.groups.all().length > 1;
     } else {
       return !(this.isThirdPartyService && this.groups.all().length <= 1);

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -382,7 +382,7 @@ describe('groupList', function() {
       const dropdownToggle = element.find('.dropdown-toggle');
       const arrowIcon = element.find('.h-icon-arrow-drop-down');
       const dropdownMenu = element.find('.dropdown-menu__top-arrow');
-      const dropdownOptions = element.find('.dropdown-menu__row ');
+      const dropdownOptions = element.find('.dropdown-menu__row');
 
       assert.isFalse(showGroupsMenu);
       assert.lengthOf(dropdownToggle, 0);
@@ -406,7 +406,7 @@ describe('groupList', function() {
       const dropdownToggle = element.find('.dropdown-toggle');
       const arrowIcon = element.find('.h-icon-arrow-drop-down');
       const dropdownMenu = element.find('.dropdown-menu__top-arrow');
-      const dropdownOptions = element.find('.dropdown-menu__row ');
+      const dropdownOptions = element.find('.dropdown-menu__row');
 
       assert.isTrue(showGroupsMenu);
       assert.lengthOf(dropdownToggle, 1);
@@ -425,7 +425,7 @@ describe('groupList', function() {
       const dropdownToggle = element.find('.dropdown-toggle');
       const arrowIcon = element.find('.h-icon-arrow-drop-down');
       const dropdownMenu = element.find('.dropdown-menu__top-arrow');
-      const dropdownOptions = element.find('.dropdown-menu__row ');
+      const dropdownOptions = element.find('.dropdown-menu__row');
 
       assert.isTrue(showGroupsMenu);
       assert.lengthOf(dropdownToggle, 1);
@@ -444,7 +444,7 @@ describe('groupList', function() {
       const dropdownToggle = element.find('.dropdown-toggle');
       const arrowIcon = element.find('.h-icon-arrow-drop-down');
       const dropdownMenu = element.find('.dropdown-menu__top-arrow');
-      const dropdownOptions = element.find('.dropdown-menu__row ');
+      const dropdownOptions = element.find('.dropdown-menu__row');
 
       assert.isTrue(showGroupsMenu);
       assert.lengthOf(dropdownToggle, 1);
@@ -463,7 +463,7 @@ describe('groupList', function() {
       const dropdownToggle = element.find('.dropdown-toggle');
       const arrowIcon = element.find('.h-icon-arrow-drop-down');
       const dropdownMenu = element.find('.dropdown-menu__top-arrow');
-      const dropdownOptions = element.find('.dropdown-menu__row ');
+      const dropdownOptions = element.find('.dropdown-menu__row');
 
       assert.isFalse(showGroupsMenu);
       assert.lengthOf(dropdownToggle, 0);

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -10,9 +10,65 @@ const groupFixtures = require('../../test/group-fixtures');
 describe('groupList', function() {
   let $window;
 
-  const PRIVATE_GROUP_LINK = 'https://hypothes.is/groups/hdevs';
-  const OPEN_GROUP_LINK = 'https://hypothes.is/groups/pub';
-  const RESTRICTED_GROUP_LINK = 'https://hypothes.is/groups/restricto';
+  const PRIVATE_GROUP = {
+    id: 'private',
+    links: {
+      html: 'https://hypothes.is/groups/hdevs',
+    },
+    name: 'Private',
+    organization: groupFixtures.defaultOrganization(),
+    type: 'private',
+    isMember: true,
+    isScopedToUri: true,
+  };
+
+  const RESTRICTED_GROUP = {
+    id: 'restricted',
+    links: {
+      html: 'https://hypothes.is/groups/restricto',
+    },
+    name: 'Restricted',
+    organization: groupFixtures.defaultOrganization(),
+    type: 'restricted',
+    isMember: false,
+    isScopedToUri: true,
+  };
+
+  const RESTRICTED_UNSCOPED_GROUP = {
+    id: 'restricted',
+    links: {
+      html: 'https://hypothes.is/groups/restricto',
+    },
+    name: 'Restricted',
+    organization: groupFixtures.defaultOrganization(),
+    type: 'restricted',
+    isMember: false,
+    isScopedToUri: false,
+  };
+
+  const OPEN_GROUP = {
+    id: 'open',
+    links: {
+      html: 'https://hypothes.is/groups/pub',
+    },
+    name: 'Open',
+    organization: groupFixtures.defaultOrganization(),
+    type: 'open',
+    isMember: false,
+    isScopedToUri: true,
+  };
+
+  const PUBLIC_GROUP = {
+    id: '__world__',
+    links: {
+      html: 'https://hypothes.is/groups/__world__/public',
+    },
+    name: 'Public',
+    organization: groupFixtures.defaultOrganization(),
+    type: 'open',
+    isMember: true,
+    isScopedToUri: true,
+  };
 
   let groups;
   let fakeGroups;
@@ -55,35 +111,7 @@ describe('groupList', function() {
     angular.mock.inject(function(_$window_) {
       $window = _$window_;
 
-      groups = [
-        {
-          id: 'public',
-          links: {
-            html: OPEN_GROUP_LINK,
-          },
-          name: 'Public Group',
-          organization: groupFixtures.defaultOrganization(),
-          type: 'open',
-        },
-        {
-          id: 'h-devs',
-          links: {
-            html: PRIVATE_GROUP_LINK,
-          },
-          name: 'Hypothesis Developers',
-          organization: groupFixtures.defaultOrganization(),
-          type: 'private',
-        },
-        {
-          id: 'restricto',
-          links: {
-            html: RESTRICTED_GROUP_LINK,
-          },
-          name: 'Hello Restricted',
-          organization: groupFixtures.defaultOrganization(),
-          type: 'restricted',
-        },
-      ];
+      groups = [PUBLIC_GROUP, PRIVATE_GROUP, RESTRICTED_GROUP];
 
       fakeGroups = {
         all: function() {
@@ -240,9 +268,9 @@ describe('groupList', function() {
     const link = element.find('.share-link');
     assert.equal(link.length, groups.length);
 
-    assert.equal(link[0].href, OPEN_GROUP_LINK);
-    assert.equal(link[1].href, PRIVATE_GROUP_LINK);
-    assert.equal(link[2].href, RESTRICTED_GROUP_LINK);
+    assert.equal(link[0].href, PUBLIC_GROUP.links.html);
+    assert.equal(link[1].href, PRIVATE_GROUP.links.html);
+    assert.equal(link[2].href, RESTRICTED_GROUP.links.html);
   });
 
   it('should not render share links if they are not present', function() {
@@ -313,7 +341,7 @@ describe('groupList', function() {
   it('should leave group when the leave icon is clicked', function() {
     const element = createGroupList();
     clickLeaveIcon(element, true);
-    assert.ok(fakeGroups.leave.calledWith('h-devs'));
+    assert.ok(fakeGroups.leave.calledWith(PRIVATE_GROUP.id));
     assert.calledWith(fakeAnalytics.track, fakeAnalytics.events.GROUP_LEAVE);
   });
 
@@ -369,20 +397,7 @@ describe('groupList', function() {
       ];
 
       // Configure only one group.
-      const groups = [
-        {
-          id: 'h-devs',
-          links: {
-            html: PRIVATE_GROUP_LINK,
-          },
-          name: 'Hypothesis Developers',
-          organization: groupFixtures.defaultOrganization(),
-          type: 'private',
-        },
-      ];
-      fakeGroups.all = () => {
-        return groups;
-      };
+      groups = [PRIVATE_GROUP];
 
       const element = createGroupList();
 
@@ -425,20 +440,7 @@ describe('groupList', function() {
 
     it('is shown when it is not a third party service', function() {
       // Configure only one group.
-      const groups = [
-        {
-          id: 'h-devs',
-          links: {
-            html: PRIVATE_GROUP_LINK,
-          },
-          name: 'Hypothesis Developers',
-          organization: groupFixtures.defaultOrganization(),
-          type: 'private',
-        },
-      ];
-      fakeGroups.all = () => {
-        return groups;
-      };
+      groups = [PRIVATE_GROUP];
 
       const element = createGroupList();
 

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const util = require('../util');
+const { selectors: sessionSelectors } = require('./session');
+const { isLoggedIn } = sessionSelectors;
 
 function init() {
   return {
@@ -118,6 +120,43 @@ function getGroup(state, id) {
   return state.groups.find(g => g.id === id);
 }
 
+/**
+ * Return groups that don't show up in Featured and My Groups.
+ *
+ * @return {Group[]}
+ */
+function getCurrentlyViewingGroups(state) {
+  const myGroups = getMyGroups(state);
+  const featuredGroups = getFeaturedGroups(state);
+
+  return state.groups.filter(
+    g => !myGroups.includes(g) && !featuredGroups.includes(g)
+  );
+}
+
+/**
+ * Return groups the logged in user is a member of.
+ *
+ * @return {Group[]}
+ */
+function getMyGroups(state) {
+  // If logged out, the Public group still has isMember set to true so only
+  // return groups with membership in logged in state.
+  if (isLoggedIn(state)) {
+    return state.groups.filter(g => g.isMember);
+  }
+  return [];
+}
+
+/**
+ * Return groups the user isn't a member of that are scoped to the URI.
+ *
+ * @return {Group[]}
+ */
+function getFeaturedGroups(state) {
+  return state.groups.filter(group => !group.isMember && group.isScopedToUri);
+}
+
 module.exports = {
   init,
   update,
@@ -128,6 +167,9 @@ module.exports = {
   selectors: {
     allGroups,
     getGroup,
+    getCurrentlyViewingGroups,
+    getFeaturedGroups,
+    getMyGroups,
     focusedGroup,
     focusedGroupId,
   },

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -41,6 +41,15 @@ function updateSession(session) {
 }
 
 /**
+ * Return true if a user is logged in and false otherwise.
+ *
+ * @param {object} state - The application state
+ */
+function isLoggedIn(state) {
+  return state.session.userid !== null;
+}
+
+/**
  * Return true if a given feature flag is enabled.
  *
  * @param {object} state - The application state
@@ -70,6 +79,7 @@ module.exports = {
 
   selectors: {
     isFeatureEnabled,
+    isLoggedIn,
     profile,
   },
 };

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -16,6 +16,19 @@ describe('sidebar.reducers.session', function() {
     });
   });
 
+  describe('#isLoggedIn', () => {
+    [
+      { userid: 'john', expectedIsLoggedIn: true },
+      { userid: null, expectedIsLoggedIn: false },
+    ].forEach(({ userid, expectedIsLoggedIn }) => {
+      it('returns whether the user is logged in', () => {
+        const newSession = Object.assign(init(), { userid: userid });
+        const state = update(init(), actions.updateSession(newSession));
+        assert.equal(selectors.isLoggedIn(state), expectedIsLoggedIn);
+      });
+    });
+  });
+
   describe('#profile', () => {
     it("returns the user's profile", () => {
       const newSession = Object.assign(init(), { userid: 'john' });


### PR DESCRIPTION
- [x] Add getMyGroups
- [x] Add getFeaturedGroups
- [x] Add getCurrentlyViewingGroups
- [x] Only showGroupMenu if there's > 1 group when community_groups feature flag is set
- [x] Add isFeatureFlagEnabled to be used in template logic
- [x] Add isLoggedIn to session
- [x] Cleanup existing group-list tests: 
   - `groups` is a const defined for all tests but some tests where making a new groups const or overriding the `fakeGroups.all` when they should have overridden the value of the `groups` const. 
   - Define and re-use group constants rather than re-creating them for each test.

This is a partial fix for [hypothesis/product-backlog#938](https://github.com/hypothesis/product-backlog/issues/938).