### PR TITLE
Only build client before publishing, not when running `yarn install`

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,6 @@
     "test": "gulp test",
     "report-coverage": "codecov -f coverage/coverage-final.json",
     "version": "make clean build/manifest.json",
-    "prepublish": "yarn run build"
+    "prepublishOnly": "make clean build/manifest.json"
   }
 }


### PR DESCRIPTION
Change the behavior where a production build of the client was triggered
whenever `yarn install` was run. Instead only create a prod build when
bumping the version or before publishing.

This mostly makes local development more convenient as it avoids
unnecessarily rebuilding the client after installing dependencies. It
will also speed up Travis builds slightly as Travis always runs `yarn install`.

Some Jenkins builds will be a little faster. Jenkins runs `make test`
directly, which only runs `yarn install` if dependencies have changed
since the last build. We may decide in future that Jenkins builds should always
do a prod build as part of the testing process. Currently the prod build
happens as part of the QA release step.

This commit also changes the version and publishing lifecycle scripts to
run the same commands. Previously they ran different commands without an
obvious reason for doing so.