### PR TITLE
Replace $http with fetch in api service

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -97,8 +97,8 @@ function configureToastr(toastrConfig) {
 }
 
 // @ngInject
-function setupHttp($http, streamer) {
-  $http.defaults.headers.common['X-Client-Id'] = streamer.clientId;
+function setupApi(api, streamer) {
+  api.setClientId(streamer.clientId);
 }
 
 /**
@@ -227,7 +227,7 @@ function startAngularApp(config) {
     .config(configureToastr)
 
     .run(sendPageView)
-    .run(setupHttp)
+    .run(setupApi)
     .run(crossOriginRPC.server.start);
 
   if (config.liveReloadServer) {

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -1,28 +1,24 @@
 'use strict';
 
 const get = require('lodash.get');
+const queryString = require('query-string');
 
-const urlUtil = require('../util/url-util');
+const { replaceURLParams } = require('../util/url-util');
 
 /**
  * Translate the response from a failed API call into an Error-like object.
- *
- * The details of the response are available on the `response` property of the
- * error.
  */
-function translateResponseToError(response) {
+function translateResponseToError(response, data) {
   let message;
   if (response.status <= 0) {
     message = 'Service unreachable.';
   } else {
     message = response.status + ' ' + response.statusText;
-    if (response.data && response.data.reason) {
-      message = message + ': ' + response.data.reason;
+    if (data && data.reason) {
+      message = message + ': ' + data.reason;
     }
   }
-  const err = new Error(message);
-  err.response = response;
-  return err;
+  return new Error(message);
 }
 
 /**
@@ -41,62 +37,10 @@ function stripInternalProperties(obj) {
   return result;
 }
 
-function forEachSorted(obj, iterator, context) {
-  const keys = Object.keys(obj).sort();
-  for (let i = 0; i < keys.length; i++) {
-    iterator.call(context, obj[keys[i]], keys[i]);
-  }
-  return keys;
-}
-
-function serializeValue(v) {
-  if (typeof v === 'object') {
-    return v instanceof Date ? v.toISOString() : JSON.stringify(v);
-  }
-  return v;
-}
-
-function encodeUriQuery(val) {
-  return encodeURIComponent(val).replace(/%20/g, '+');
-}
-
-// Serialize an object containing parameters into a form suitable for a query
-// string.
-//
-// This is an almost identical copy of the default Angular parameter serializer
-// ($httpParamSerializer), with one important change. In Angular 1.4.x
-// semicolons are not encoded in query parameter values. This is a problem for
-// us as URIs around the web may well contain semicolons, which our backend will
-// then proceed to parse as a delimiter in the query string. To avoid this
-// problem we use a very conservative encoder, found above.
-function serializeParams(params) {
-  if (!params) {
-    return '';
-  }
-  const parts = [];
-  forEachSorted(params, function(value, key) {
-    if (value === null || typeof value === 'undefined') {
-      return;
-    }
-    if (Array.isArray(value)) {
-      value.forEach(function(v) {
-        parts.push(
-          encodeUriQuery(key) + '=' + encodeUriQuery(serializeValue(v))
-        );
-      });
-    } else {
-      parts.push(
-        encodeUriQuery(key) + '=' + encodeUriQuery(serializeValue(value))
-      );
-    }
-  });
-
-  return parts.join('&');
-}
-
 /**
  * @typedef APIResponse
- * @prop {any} data - The JSON response from the API call.
+ * @prop {any} data -
+ *  The JSON response from the API call, unless this call return 204 No Content.
  * @prop {string|null} token - The access token that was used to make the call
  *   or `null` if unauthenticated.
  */
@@ -135,8 +79,6 @@ const noop = () => {};
 /**
  * Creates a function that will make an API call to a named route.
  *
- * @param $http - The Angular HTTP service
- * @param $q - The Angular Promises ($q) service.
  * @param links - Object or promise for an object mapping named API routes to
  *                URL templates and methods
  * @param route - The dotted path of the named API route (eg. `annotation.create`)
@@ -144,8 +86,6 @@ const noop = () => {};
  * @return {APICallFunction}
  */
 function createAPICall(
-  $http,
-  $q,
   links,
   route,
   {
@@ -161,12 +101,11 @@ function createAPICall(
     // mixes native Promises with the `$q` promises returned by `$http`
     // functions gets awkward in tests.
     let accessToken;
-    return $q
-      .all([links, getAccessToken()])
+    return Promise.all([links, getAccessToken()])
       .then(([links, token]) => {
         const descriptor = get(links, route);
-        const url = urlUtil.replaceURLParams(descriptor.url, params);
         const headers = {
+          'Content-Type': 'application/json',
           'Hypothesis-Client-Version': '__VERSION__', // replaced by versionify
         };
 
@@ -175,34 +114,44 @@ function createAPICall(
           headers.Authorization = 'Bearer ' + token;
         }
 
-        const req = {
-          data: data ? stripInternalProperties(data) : null,
-          headers: headers,
+        const { url, params: queryParams } = replaceURLParams(
+          descriptor.url,
+          params
+        );
+        const apiUrl = new URL(url);
+        apiUrl.search = queryString.stringify(queryParams);
+
+        return fetch(apiUrl.toString(), {
+          body: data ? JSON.stringify(stripInternalProperties(data)) : null,
+          headers,
           method: descriptor.method,
-          params: url.params,
-          paramSerializer: serializeParams,
-          url: url.url,
-        };
-        return $http(req);
+        });
       })
-      .then(function(response) {
+      .then(response => {
+        let data;
+
+        const status = response.status;
+        if (status >= 200 && status !== 204 && status < 500) {
+          data = response.json();
+        } else {
+          data = response.text();
+        }
+        return Promise.all([response, data]);
+      })
+      .then(([response, data]) => {
         onRequestFinished();
+
+        if (response.status >= 400) {
+          // Translate the API result into an `Error` to follow the convention that
+          // Promises should be rejected with an Error or Error-like object.
+          throw translateResponseToError(response, data);
+        }
 
         if (options.includeMetadata) {
-          return { data: response.data, token: accessToken };
+          return { data, token: accessToken };
         } else {
-          return response.data;
+          return data;
         }
-      })
-      .catch(function(response) {
-        onRequestFinished();
-
-        // Translate the API result into an `Error` to follow the convention that
-        // Promises should be rejected with an Error or Error-like object.
-        //
-        // Use `$q.reject` rather than just rethrowing the Error here due to
-        // mishandling of errors thrown inside `catch` handlers in Angular < 1.6
-        return $q.reject(translateResponseToError(response));
       });
   };
 }
@@ -228,10 +177,11 @@ function createAPICall(
  * not use authentication.
  */
 // @ngInject
-function api($http, $q, apiRoutes, auth, store) {
+function api(apiRoutes, auth, store) {
   const links = apiRoutes.routes();
+
   function apiCall(route) {
-    return createAPICall($http, $q, links, route, {
+    return createAPICall(links, route, {
       getAccessToken: auth.tokenGetter,
       onRequestStarted: store.apiRequestStarted,
       onRequestFinished: store.apiRequestFinished,

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -101,9 +101,6 @@ function createAPICall(
   return function(params, data, options = {}) {
     onRequestStarted();
 
-    // `$q.all` is used here rather than `Promise.all` because testing code that
-    // mixes native Promises with the `$q` promises returned by `$http`
-    // functions gets awkward in tests.
     let accessToken;
     return Promise.all([links, getAccessToken()])
       .then(([links, token]) => {

--- a/src/sidebar/services/oauth-auth.js
+++ b/src/sidebar/services/oauth-auth.js
@@ -25,7 +25,6 @@ const serviceConfig = require('../service-config');
  */
 // @ngInject
 function auth(
-  $http,
   $rootScope,
   $window,
   OAuthClient,

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -1,9 +1,8 @@
 'use strict';
 
-const angular = require('angular');
-const proxyquire = require('proxyquire');
+const fetchMock = require('fetch-mock');
 
-const util = require('../../../shared/test/util');
+const apiFactory = require('../api');
 
 // API route directory.
 //
@@ -17,302 +16,172 @@ const util = require('../../../shared/test/util');
 const routes = require('./api-index.json').links;
 
 describe('sidebar.services.api', function() {
-  let $httpBackend;
-  let $q;
   let fakeAuth;
   let fakeStore;
-  let sandbox;
   let api;
 
-  before(function() {
-    angular.module('h', []).service(
-      'api',
-      proxyquire(
-        '../api',
-        util.noCallThru({
-          angular: angular,
-          '../retry-util': {
-            retryPromiseOperation: function(fn) {
-              return fn();
-            },
-          },
-        })
-      )
-    );
-  });
+  function defaultBodyForStatus(status) {
+    if (status === 204) {
+      return '';
+    } else {
+      return {};
+    }
+  }
 
-  beforeEach(function() {
-    sandbox = sinon.sandbox.create();
+  /**
+   * Expect an HTTP call using `window.fetch`.
+   *
+   * @param {string} method - Expected HTTP method (lower case)
+   * @param {string} pathAndQuery - Expected part of URL after API root
+   * @param {number} status - Expected HTTP status
+   * @param {Object} body - Expected response body
+   */
+  function expectCall(
+    method,
+    pathAndQuery,
+    status = 200,
+    body = defaultBodyForStatus(status)
+  ) {
+    const url = `https://example.com/api/${pathAndQuery}`;
+    fetchMock.mock(url, { status, body }, { method });
+  }
 
+  beforeEach(() => {
     const fakeApiRoutes = {
       links: sinon.stub(),
-      routes: sinon.stub(),
+      routes: sinon.stub().returns(Promise.resolve(routes)),
     };
     fakeAuth = {
-      tokenGetter: sinon.stub(),
+      tokenGetter: sinon.stub().returns(Promise.resolve('faketoken')),
     };
     fakeStore = {
       apiRequestStarted: sinon.stub(),
       apiRequestFinished: sinon.stub(),
     };
 
-    angular.mock.module('h', {
-      apiRoutes: fakeApiRoutes,
-      auth: fakeAuth,
-      settings: { apiUrl: 'https://example.com/api/' },
-      store: fakeStore,
-    });
+    api = apiFactory(fakeApiRoutes, fakeAuth, fakeStore);
 
-    angular.mock.inject(function(_$q_) {
-      $q = _$q_;
-      fakeAuth.tokenGetter.returns($q.resolve('faketoken'));
-
-      fakeApiRoutes.routes.returns($q.resolve(routes));
+    fetchMock.catch(() => {
+      throw new Error('Unexpected `fetch` call');
     });
   });
 
-  afterEach(function() {
-    $httpBackend.verifyNoOutstandingExpectation();
-    $httpBackend.verifyNoOutstandingRequest();
-    sandbox.restore();
+  afterEach(() => {
+    fetchMock.restore();
   });
 
-  beforeEach(
-    angular.mock.inject(function(_$httpBackend_, _api_) {
-      $httpBackend = _$httpBackend_;
-      api = _api_;
-    })
-  );
+  it('saves a new annotation', () => {
+    expectCall('post', 'annotations', 201, { id: 'new-id' });
 
-  it('saves a new annotation', function(done) {
-    api.annotation.create({}, {}).then(function(saved) {
-      assert.isNotNull(saved.id);
-      done();
-    });
-
-    $httpBackend
-      .expectPOST('https://example.com/api/annotations')
-      .respond(function() {
-        return [201, { id: 'new-id' }, {}];
-      });
-    $httpBackend.flush();
-  });
-
-  it('updates an annotation', function(done) {
-    api.annotation
-      .update({ id: 'an-id' }, { text: 'updated' })
-      .then(function() {
-        done();
-      });
-
-    $httpBackend
-      .expectPATCH('https://example.com/api/annotations/an-id')
-      .respond(function() {
-        return [200, {}, {}];
-      });
-    $httpBackend.flush();
-  });
-
-  it('deletes an annotation', function(done) {
-    api.annotation.delete({ id: 'an-id' }, {}).then(function() {
-      done();
-    });
-
-    $httpBackend
-      .expectDELETE('https://example.com/api/annotations/an-id')
-      .respond(function() {
-        return [200, {}, {}];
-      });
-    $httpBackend.flush();
-  });
-
-  it('flags an annotation', function(done) {
-    api.annotation.flag({ id: 'an-id' }).then(function() {
-      done();
-    });
-
-    $httpBackend
-      .expectPUT('https://example.com/api/annotations/an-id/flag')
-      .respond(function() {
-        return [204, {}, {}];
-      });
-    $httpBackend.flush();
-  });
-
-  it('hides an annotation', function(done) {
-    api.annotation.hide({ id: 'an-id' }).then(function() {
-      done();
-    });
-
-    $httpBackend
-      .expectPUT('https://example.com/api/annotations/an-id/hide')
-      .respond(function() {
-        return [204, {}, {}];
-      });
-    $httpBackend.flush();
-  });
-
-  it('unhides an annotation', function(done) {
-    api.annotation.unhide({ id: 'an-id' }).then(function() {
-      done();
-    });
-
-    $httpBackend
-      .expectDELETE('https://example.com/api/annotations/an-id/hide')
-      .respond(function() {
-        return [204, {}, {}];
-      });
-    $httpBackend.flush();
-  });
-
-  describe('#group.member.delete', () => {
-    it('removes current user from a group', done => {
-      api.group.member
-        .delete({ pubid: 'an-id', userid: 'me' })
-        .then(function() {
-          done();
-        });
-
-      $httpBackend
-        .expectDELETE('https://example.com/api/groups/an-id/members/me')
-        .respond(() => {
-          return [204, {}, {}];
-        });
-      $httpBackend.flush();
+    return api.annotation.create({}, {}).then(ann => {
+      assert.equal(ann.id, 'new-id');
     });
   });
 
-  it('removes internal properties before sending data to the server', function(done) {
+  it('updates an annotation', () => {
+    expectCall('patch', 'annotations/an-id');
+    return api.annotation.update({ id: 'an-id' }, { text: 'updated' });
+  });
+
+  it('deletes an annotation', () => {
+    expectCall('delete', 'annotations/an-id');
+    return api.annotation.delete({ id: 'an-id' }, {});
+  });
+
+  it('flags an annotation', () => {
+    expectCall('put', 'annotations/an-id/flag', 204);
+    return api.annotation.flag({ id: 'an-id' });
+  });
+
+  it('hides an annotation', () => {
+    expectCall('put', 'annotations/an-id/hide', 204);
+    return api.annotation.hide({ id: 'an-id' });
+  });
+
+  it('unhides an annotation', () => {
+    expectCall('delete', 'annotations/an-id/hide', 204);
+    return api.annotation.unhide({ id: 'an-id' });
+  });
+
+  it('removes current user from a group', () => {
+    expectCall('delete', 'groups/an-id/members/me', 204);
+    return api.group.member.delete({ pubid: 'an-id', userid: 'me' });
+  });
+
+  it('removes internal properties before sending data to the server', () => {
     const annotation = {
       $highlight: true,
       $notme: 'nooooo!',
       allowed: 123,
     };
-    api.annotation.create({}, annotation).then(function() {
-      done();
+    expectCall('post', 'annotations', 200, { id: 'test' });
+    return api.annotation.create({}, annotation).then(() => {
+      const [, options] = fetchMock.lastCall();
+      assert.deepEqual(options.body, JSON.stringify({ allowed: 123 }));
     });
-
-    $httpBackend
-      .expectPOST('https://example.com/api/annotations', {
-        allowed: 123,
-      })
-      .respond(function() {
-        return [200, { id: 'test' }, {}];
-      });
-    $httpBackend.flush();
   });
 
   // Our backend service interprets semicolons as query param delimiters, so we
   // must ensure to encode them in the query string.
-  it('encodes semicolons in query parameters', function(done) {
-    api.search({ uri: 'http://foobar.com/?foo=bar;baz=qux' }).then(function() {
-      done();
-    });
-
-    $httpBackend
-      .expectGET(
-        'https://example.com/api/search?uri=http%3A%2F%2Ffoobar.com%2F%3Ffoo%3Dbar%3Bbaz%3Dqux'
-      )
-      .respond(function() {
-        return [200, {}, {}];
-      });
-    $httpBackend.flush();
-  });
-
-  it("fetches the user's profile", function(done) {
-    const profile = { userid: 'acct:user@publisher.org' };
-    api.profile.read({ authority: 'publisher.org' }).then(function(profile_) {
-      assert.deepEqual(profile_, profile);
-      done();
-    });
-    $httpBackend
-      .expectGET('https://example.com/api/profile?authority=publisher.org')
-      .respond(function() {
-        return [200, profile, {}];
-      });
-    $httpBackend.flush();
-  });
-
-  it("updates a user's profile", function(done) {
-    api.profile.update({}, { preferences: {} }).then(function() {
-      done();
-    });
-
-    $httpBackend
-      .expectPATCH('https://example.com/api/profile')
-      .respond(function() {
-        return [200, {}, {}];
-      });
-    $httpBackend.flush();
-  });
-
-  context('when an API calls fail', function() {
-    util.unroll(
-      'rejects the call with an Error',
-      function(done, testCase) {
-        api.profile.update({}, { preferences: {} }).catch(function(err) {
-          assert(err instanceof Error);
-          assert.equal(err.message, testCase.expectedMessage);
-          done();
-        });
-        $httpBackend
-          .expectPATCH('https://example.com/api/profile')
-          .respond(function() {
-            return [testCase.status, testCase.body, {}, testCase.statusText];
-          });
-        $httpBackend.flush();
-      },
-      [
-        {
-          // Network error
-          status: -1,
-          body: null,
-          expectedMessage: 'Service unreachable.',
-        },
-        {
-          // Request failed with an error given in the JSON body
-          status: 404,
-          statusText: 'Not found',
-          body: {
-            reason: 'Thing not found',
-          },
-          expectedMessage: '404 Not found: Thing not found',
-        },
-        {
-          // Request failed with a non-JSON response
-          status: 500,
-          statusText: 'Server Error',
-          body: 'Internal Server Error',
-          expectedMessage: '500 Server Error',
-        },
-      ]
+  it('encodes semicolons in query parameters', () => {
+    expectCall(
+      'get',
+      'search?uri=http%3A%2F%2Ffoobar.com%2F%3Ffoo%3Dbar%3Bbaz%3Dqux'
     );
+    return api.search({ uri: 'http://foobar.com/?foo=bar;baz=qux' });
+  });
 
-    it("exposes details in the Error's `response` property", function(done) {
-      api.profile.update({}, { preferences: {} }).catch(function(err) {
-        assert.match(
-          err.response,
-          sinon.match({
-            status: 404,
-            statusText: 'Not found',
-            data: {
-              reason: 'User not found',
-            },
-          })
-        );
-        done();
-      });
-      $httpBackend
-        .expectPATCH('https://example.com/api/profile')
-        .respond(function() {
-          return [404, { reason: 'User not found' }, {}, 'Not found'];
+  it("fetches the user's profile", () => {
+    const profile = { userid: 'acct:user@publisher.org' };
+    expectCall('get', 'profile?authority=publisher.org', 200, profile);
+    return api.profile.read({ authority: 'publisher.org' }).then(profile_ => {
+      assert.deepEqual(profile_, profile);
+    });
+  });
+
+  it("updates a user's profile", () => {
+    expectCall('patch', 'profile');
+    return api.profile.update({}, { preferences: {} });
+  });
+
+  context('when an API call fails', () => {
+    [
+      {
+        // Network error
+        status: -1,
+        body: null,
+        expectedMessage: 'Service unreachable.',
+      },
+      {
+        // Request failed with an error given in the JSON body
+        status: 404,
+        statusText: 'Not found',
+        body: {
+          reason: 'Thing not found',
+        },
+        expectedMessage: '404 Not Found: Thing not found',
+      },
+      {
+        // Request failed with a non-JSON response
+        status: 500,
+        statusText: 'Server Error',
+        body: 'Internal Server Error',
+        expectedMessage: '500 Internal Server Error',
+      },
+    ].forEach(({ status, body, expectedMessage }) => {
+      it('rejects the call with an error', () => {
+        expectCall('patch', 'profile', status, body);
+        return api.profile.update({}, { preferences: {} }).catch(err => {
+          assert(err instanceof Error);
+          assert.equal(err.message, expectedMessage);
         });
-      $httpBackend.flush();
+      });
     });
   });
 
   it('API calls return just the JSON response if `includeMetadata` is false', () => {
-    api.profile.read({}).then(response => {
+    expectCall('get', 'profile', 200, { userid: 'acct:user@example.com' });
+    return api.profile.read({}).then(response => {
       assert.match(
         response,
         sinon.match({
@@ -320,92 +189,65 @@ describe('sidebar.services.api', function() {
         })
       );
     });
-
-    $httpBackend
-      .expectGET('https://example.com/api/profile')
-      .respond(() => [200, { userid: 'acct:user@example.com' }]);
-    $httpBackend.flush();
   });
 
   it('API calls return an `APIResponse` if `includeMetadata` is true', () => {
-    api.profile.read({}, null, { includeMetadata: true }).then(response => {
-      assert.match(
-        response,
-        sinon.match({
-          data: {
-            userid: 'acct:user@example.com',
-          },
-          token: 'faketoken',
-        })
-      );
-    });
-
-    $httpBackend
-      .expectGET('https://example.com/api/profile')
-      .respond(() => [200, { userid: 'acct:user@example.com' }]);
-    $httpBackend.flush();
+    expectCall('get', 'profile', 200, { userid: 'acct:user@example.com' });
+    return api.profile
+      .read({}, null, { includeMetadata: true })
+      .then(response => {
+        assert.match(
+          response,
+          sinon.match({
+            data: {
+              userid: 'acct:user@example.com',
+            },
+            token: 'faketoken',
+          })
+        );
+      });
   });
 
   it('omits Authorization header if no access token is available', () => {
-    fakeAuth.tokenGetter.returns($q.resolve(null));
-    api.profile.read();
-
-    $httpBackend
-      .expectGET(
-        'https://example.com/api/profile',
-        headers => !('Authorization' in headers)
-      )
-      .respond(() => [200, { userid: 'acct:user@example.com' }]);
-    $httpBackend.flush();
+    fakeAuth.tokenGetter.returns(Promise.resolve(null));
+    expectCall('get', 'profile');
+    return api.profile.read().then(() => {
+      const [, options] = fetchMock.lastCall();
+      assert.isFalse('Authorization' in options.headers);
+    });
   });
 
   it('sets Authorization header if access token is available', () => {
-    api.profile.read();
-
-    $httpBackend
-      .expectGET(
-        'https://example.com/api/profile',
-        headers => headers.Authorization === 'Bearer faketoken'
-      )
-      .respond(() => [200, { userid: 'acct:user@example.com' }]);
-    $httpBackend.flush();
+    expectCall('get', 'profile');
+    return api.profile.read().then(() => {
+      const [, options] = fetchMock.lastCall();
+      assert.equal(options.headers.Authorization, 'Bearer faketoken');
+    });
   });
 
   it('sends client version custom request header', () => {
-    api.profile.read({});
-
-    $httpBackend
-      .expectGET(
-        'https://example.com/api/profile',
-        headers => headers['Hypothesis-Client-Version'] === '__VERSION__'
-      )
-      .respond(() => [200, { userid: 'acct:user@example.com' }]);
-    $httpBackend.flush();
+    expectCall('get', 'profile');
+    return api.profile.read({}).then(() => {
+      const [, options] = fetchMock.lastCall();
+      assert.equal(options.headers['Hypothesis-Client-Version'], '__VERSION__');
+    });
   });
 
   it('dispatches store actions when an API request starts and completes successfully', () => {
-    api.profile.read({}).then(() => {
+    expectCall('get', 'profile');
+    return api.profile.read({}).then(() => {
       assert.isTrue(
         fakeStore.apiRequestFinished.calledAfter(fakeStore.apiRequestStarted)
       );
     });
-
-    $httpBackend
-      .expectGET('https://example.com/api/profile')
-      .respond(() => [200, { userid: 'acct:user@example.com' }]);
-    $httpBackend.flush();
   });
 
   it('dispatches store actions when an API request starts and fails', () => {
-    api.profile.read({}).catch(() => {
+    expectCall('get', 'profile', 400);
+    return api.profile.read({}).catch(() => {
       assert.isTrue(
         fakeStore.apiRequestFinished.calledAfter(fakeStore.apiRequestStarted)
       );
     });
-
-    $httpBackend
-      .expectGET('https://example.com/api/profile')
-      .respond(() => [400, { reason: 'Something went wrong' }]);
-    $httpBackend.flush();
   });
 });

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -250,4 +250,21 @@ describe('sidebar.services.api', function() {
       );
     });
   });
+
+  it('does not send a client ID by default', () => {
+    expectCall('get', 'profile');
+    return api.profile.read({}).then(() => {
+      const [, options] = fetchMock.lastCall();
+      assert.isFalse('X-Client-Id' in options.headers);
+    });
+  });
+
+  it('sends a client ID in the X-Client-Id header if configured', () => {
+    expectCall('get', 'profile');
+    api.setClientId('1234-5678');
+    return api.profile.read({}).then(() => {
+      const [, options] = fetchMock.lastCall();
+      assert.equal(options.headers['X-Client-Id'], '1234-5678');
+    });
+  });
 });

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -35,10 +35,10 @@ describe('sidebar.services.api', function() {
    *
    * @param {string} method - Expected HTTP method (lower case)
    * @param {string} pathAndQuery - Expected part of URL after API root
-   * @param {number} status -
-   *   Expected HTTP status. If <= 0 then the call to `fetch` will reject with
+   * @param {number|null} status -
+   *   Expected HTTP status. If `null` then the call to `fetch` will reject with
    *   the content of `body` as the error message.
-   * @param {Object|string} body - Expected response body
+   * @param {Object|string} body - Expected response body or error message
    */
   function expectCall(
     method,
@@ -86,7 +86,8 @@ describe('sidebar.services.api', function() {
   });
 
   it('saves a new annotation', () => {
-    expectCall('post', 'annotations', 201, { id: 'new-id' });
+    // nb. The Hypothesis API returns 200 here not 201 as one might expect.
+    expectCall('post', 'annotations', 200, { id: 'new-id' });
 
     return api.annotation.create({}, {}).then(ann => {
       assert.equal(ann.id, 'new-id');
@@ -166,7 +167,7 @@ describe('sidebar.services.api', function() {
     [
       {
         // Network error
-        status: -1,
+        status: null,
         body: 'Service unreachable.',
         expectedMessage: 'Service unreachable.',
       },
@@ -270,7 +271,7 @@ describe('sidebar.services.api', function() {
   });
 
   it('dispatches store actions if API request fails with a network error', () => {
-    expectCall('get', 'profile', -1, 'Network error');
+    expectCall('get', 'profile', null, 'Network error');
 
     return api.profile.read({}).catch(() => {
       assert.isTrue(

--- a/src/sidebar/services/test/oauth-auth-test.js
+++ b/src/sidebar/services/test/oauth-auth-test.js
@@ -17,7 +17,6 @@ describe('sidebar.oauth-auth', function() {
   let fakeApiRoutes;
   let fakeClient;
   let fakeFlash;
-  let fakeHttp;
   let fakeLocalStorage;
   let fakeWindow;
   let fakeSettings;
@@ -96,10 +95,7 @@ describe('sidebar.oauth-auth', function() {
 
     fakeWindow = new FakeWindow();
 
-    fakeHttp = {};
-
     angular.mock.module('app', {
-      $http: fakeHttp,
       $window: fakeWindow,
       apiRoutes: fakeApiRoutes,
       flash: fakeFlash,


### PR DESCRIPTION
This replaces usage of Angular's $http service with `fetch` in the api service. Part of #974.

Testing for this PR is similar to #997 and #998 except that it applies to all API requests made by the client.