### PR TITLE
Fix Google Analytics event reporting

### DIFF
--- a/src/sidebar/services/test/analytics-test.js
+++ b/src/sidebar/services/test/analytics-test.js
@@ -108,4 +108,26 @@ describe('analytics', function() {
       assert.notCalled(ga);
     });
   });
+
+  it('sends events to the current analytics.js command queue', () => {
+    const initialQueue = $windowStub.ga;
+    const queueAfterLoad = sinon.stub();
+
+    // Send a page view hit before analytics.js loads.
+    svc.sendPageView();
+
+    assert.called($windowStub.ga);
+
+    // Simulate analytics.js loading, which will replace the command queue.
+    $windowStub.ga = queueAfterLoad;
+    initialQueue.reset();
+
+    // Report a user interaction after analytics.js loads.
+    svc.track('someEvent');
+
+    // Check that the event was passed to the right queue.
+    assert.notCalled(initialQueue);
+    assert.called(queueAfterLoad);
+    checkEventSent('embed', 'someEvent');
+  });
 });


### PR DESCRIPTION
Fix a race condition where events would not be reported if the analytics
service was instantiated before Google Analytics had fully loaded.

The main interface to Google Analytics, `window.ga`, is initially a
simple function which just records commands in a buffer. When
analytics.js loads it sends the buffered events and replaces `window.ga`
with a function that sends new events immediately. The analytics service
captured the value of `window.ga` at the time it was instantiated and did
not use the replacement after GA loaded. As a result tracked events were
just stored in a buffer and never send to GA.

Fix this by removing the `GoogleAnalytics` wrapper class and always invoking
the _current_ `window.ga` function.

Also update the documentation of the service's methods and add pointers to
relevant Google Analytics docs.

Fixes #976