### PR TITLE
Move API activity state to store

### DIFF
--- a/src/sidebar/components/search-input.js
+++ b/src/sidebar/components/search-input.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // @ngInject
-function SearchInputController($element, $http, $scope) {
+function SearchInputController($element, store) {
   const self = this;
   const button = $element.find('button');
   const input = $element.find('input')[0];
@@ -11,19 +11,12 @@ function SearchInputController($element, $http, $scope) {
     input.focus();
   });
 
-  $scope.$watch(
-    function() {
-      return $http.pendingRequests.length;
-    },
-    function(count) {
-      self.loading = count > 0;
-    }
-  );
-
   form.onsubmit = function(e) {
     e.preventDefault();
     self.onSearch({ $query: input.value });
   };
+
+  this.isLoading = () => store.isLoading();
 
   this.inputClasses = function() {
     return { 'is-expanded': self.alwaysExpanded || self.query };

--- a/src/sidebar/components/test/search-input-test.js
+++ b/src/sidebar/components/test/search-input-test.js
@@ -5,7 +5,7 @@ const angular = require('angular');
 const util = require('../../directive/test/util');
 
 describe('searchInput', function() {
-  let fakeHttp;
+  let fakeStore;
 
   before(function() {
     angular
@@ -14,9 +14,9 @@ describe('searchInput', function() {
   });
 
   beforeEach(function() {
-    fakeHttp = { pendingRequests: [] };
+    fakeStore = { isLoading: sinon.stub().returns(false) };
     angular.mock.module('app', {
-      $http: fakeHttp,
+      store: fakeStore,
     });
   });
 
@@ -45,17 +45,23 @@ describe('searchInput', function() {
   });
 
   describe('loading indicator', function() {
-    it('is hidden when there are no network requests in flight', function() {
+    it('is hidden when there are no API requests in flight', function() {
       const el = util.createDirective(document, 'search-input', {});
       const spinner = el[0].querySelector('spinner');
+
+      fakeStore.isLoading.returns(false);
+      el.scope.$digest();
+
       assert.equal(util.isHidden(spinner), true);
     });
 
-    it('is visible when there are network requests in flight', function() {
+    it('is visible when there are API requests in flight', function() {
       const el = util.createDirective(document, 'search-input', {});
       const spinner = el[0].querySelector('spinner');
-      fakeHttp.pendingRequests.push([{}]);
+
+      fakeStore.isLoading.returns(true);
       el.scope.$digest();
+
       assert.equal(util.isHidden(spinner), false);
     });
   });

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -34,6 +34,7 @@
 const createStore = require('./create-store');
 const debugMiddleware = require('./debug-middleware');
 
+const activity = require('./modules/activity');
 const annotations = require('./modules/annotations');
 const frames = require('./modules/frames');
 const links = require('./modules/links');
@@ -83,6 +84,7 @@ function store($rootScope, settings) {
   ];
 
   const modules = [
+    activity,
     annotations,
     frames,
     links,

--- a/src/sidebar/store/modules/activity.js
+++ b/src/sidebar/store/modules/activity.js
@@ -1,0 +1,79 @@
+'use strict';
+
+/**
+ * Store module which tracks activity happening in the application that may
+ * need to be reflected in the UI.
+ */
+
+const { actionTypes } = require('../util');
+
+function init() {
+  return {
+    activity: {
+      /**
+       * The number of API requests that have started and not yet completed.
+       */
+      activeApiRequests: 0,
+    },
+  };
+}
+
+const update = {
+  API_REQUEST_STARTED(state) {
+    const { activity } = state;
+    return {
+      activity: {
+        ...activity,
+        activeApiRequests: activity.activeApiRequests + 1,
+      },
+    };
+  },
+
+  API_REQUEST_FINISHED(state) {
+    const { activity } = state;
+    if (activity.activeApiRequests === 0) {
+      throw new Error(
+        'API_REQUEST_FINISHED action when no requests were active'
+      );
+    }
+
+    return {
+      activity: {
+        ...activity,
+        activeApiRequests: activity.activeApiRequests - 1,
+      },
+    };
+  },
+};
+
+const actions = actionTypes(update);
+
+function apiRequestStarted() {
+  return { type: actions.API_REQUEST_STARTED };
+}
+
+function apiRequestFinished() {
+  return { type: actions.API_REQUEST_FINISHED };
+}
+
+/**
+ * Return true when any activity is happening in the app that needs to complete
+ * before the UI will be idle.
+ */
+function isLoading(state) {
+  return state.activity.activeApiRequests > 0;
+}
+
+module.exports = {
+  init,
+  update,
+
+  actions: {
+    apiRequestStarted,
+    apiRequestFinished,
+  },
+
+  selectors: {
+    isLoading,
+  },
+};

--- a/src/sidebar/store/modules/test/activity-test.js
+++ b/src/sidebar/store/modules/test/activity-test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const createStore = require('../../create-store');
+const activity = require('../activity');
+
+describe('sidebar/store/modules/activity', () => {
+  let store;
+
+  beforeEach(() => {
+    store = createStore([activity]);
+  });
+
+  describe('#isLoading', () => {
+    it('returns false with the initial state', () => {
+      assert.equal(store.isLoading(), false);
+    });
+
+    it('returns true when API requests are in flight', () => {
+      store.apiRequestStarted();
+      assert.equal(store.isLoading(), true);
+    });
+
+    it('returns false when all requests end', () => {
+      store.apiRequestStarted();
+      store.apiRequestStarted();
+      store.apiRequestFinished();
+
+      assert.equal(store.isLoading(), true);
+
+      store.apiRequestFinished();
+
+      assert.equal(store.isLoading(), false);
+    });
+  });
+
+  describe('#apiRequestFinished', () => {
+    it('triggers an error if no requests are in flight', () => {
+      assert.throws(() => {
+        store.apiRequestFinished();
+      });
+    });
+  });
+});

--- a/src/sidebar/templates/search-input.html
+++ b/src/sidebar/templates/search-input.html
@@ -4,11 +4,11 @@
   <input class="simple-search-input"
          type="text"
          name="query"
-         placeholder="{{vm.loading && 'Loading' || 'Search'}}…"
-         ng-disabled="vm.loading"
+         placeholder="{{vm.isLoading() && 'Loading' || 'Search'}}…"
+         ng-disabled="vm.isLoading()"
          ng-class="vm.inputClasses()"/>
-  <button type="button" class="simple-search-icon top-bar__btn" ng-hide="vm.loading">
+  <button type="button" class="simple-search-icon top-bar__btn" ng-hide="vm.isLoading()">
     <i class="h-icon-search"></i>
   </button>
-  <spinner class="top-bar__btn" ng-show="vm.loading" title="Loading…"></spinner>
+  <spinner class="top-bar__btn" ng-show="vm.isLoading()" title="Loading…"></spinner>
 </form>


### PR DESCRIPTION
This PR modifies the way that the loading spinner in the top bar works to remove a dependency on Angular's `$http` service, as part of the migration of the API client from `$http` to `fetch`.

Previously this spinner reflected the value of the `$http.pendingRequests` variable which counts the number of outstanding HTTP requests.

The spinner instead now reflects state in an "activity" module in the store. When an API request starts, an `apiRequestStarted` action is dispatched. When an API request completes or fails, an `apiRequestFinished` action is dispatched. The store internally maintains a count of in-flight requests which is reflected via a `store.isLoading` selector. The spinner's visibility then reflects the result of this method.