### PR TITLE
Enable async-await support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,9 @@
       }
     }]
   ],
-  "plugins": ["angularjs-annotate"],
+  "plugins": [
+    "angularjs-annotate",
+    "transform-async-to-promises"
+  ],
   "ignore": ["**/vendor/*"]
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "aws-sdk": "^2.345.0",
     "babel-plugin-angularjs-annotate": "^0.10.0",
     "babel-plugin-istanbul": "^5.1.0",
+    "babel-plugin-transform-async-to-promises": "^0.8.6",
     "babel-preset-env": "^1.7.0",
     "babelify": "^10.0.0",
     "browserify": "^16.2.3",

--- a/src/sidebar/services/oauth-auth.js
+++ b/src/sidebar/services/oauth-auth.js
@@ -281,15 +281,14 @@ function auth(
    *
    * This revokes and then forgets any OAuth credentials that the user has.
    */
-  function logout() {
-    return Promise.all([tokenInfoPromise, oauthClient()])
-      .then(([token, client]) => {
-        return client.revokeToken(token.accessToken);
-      })
-      .then(() => {
-        tokenInfoPromise = Promise.resolve(null);
-        localStorage.removeItem(storageKey());
-      });
+  async function logout() {
+    const [token, client] = await Promise.all([
+      tokenInfoPromise,
+      oauthClient(),
+    ]);
+    await client.revokeToken(token.accessToken);
+    tokenInfoPromise = Promise.resolve(null);
+    localStorage.removeItem(storageKey());
   }
 
   listenForTokenStorageEvents();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1419,6 +1419,11 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-async-to-promises@^0.8.6:
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.6.tgz#da21f782ee9847ccd47e993de3914193b9d2b77c"
+  integrity sha512-bKgtoXHueZZQ+NjWaUj3juhtIU/7aqVUkhUnAWWBgnPVL4oAgKP0AOzz5kYvWzD+GB9ZIA6MKHhqWe0K3rSdqA==
+
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"


### PR DESCRIPTION
This PR enables support for [async / await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) syntax in the client, which should help us to write more readable code that involves multiple async steps, where we currently have a series of chained promises.

I have converted one small function as a test case to check that it works and also make sure the generated code is what I expect to see.

There are multiple ways to support async/await in older browsers, I picked one that generates short and readable code and has a decent test suite. See the notes on the first commit message for details.