### PR TITLE
Enable conditional inclusion of code based on NODE_ENV checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "katex": "^0.10.0",
     "lodash.debounce": "^4.0.3",
     "lodash.get": "^4.3.0",
+    "loose-envify": "^1.4.0",
     "mkdirp": "^0.5.1",
     "mocha": "^6.0.0",
     "ng-tags-input": "^3.1.1",

--- a/scripts/gulp/create-bundle.js
+++ b/scripts/gulp/create-bundle.js
@@ -10,6 +10,7 @@ const babelify = require('babelify');
 const browserify = require('browserify');
 const coffeeify = require('coffeeify');
 const exorcist = require('exorcist');
+const envify = require('loose-envify/custom');
 const gulpUtil = require('gulp-util');
 const mkdirp = require('mkdirp');
 const through = require('through2');
@@ -224,6 +225,16 @@ module.exports = function createBundle(config, buildOpts) {
   if (config.minify) {
     bundle.transform({global: true}, uglifyify);
   }
+
+  // Include or disable debugging checks in our code and dependencies by
+  // replacing references to `process.env.NODE_ENV`.
+  bundle.transform(envify({
+    NODE_ENV: process.env.NODE_ENV || 'development',
+  }), {
+    // Ideally packages should configure this transform in their package.json
+    // file if they need it, but not all of them do.
+    global: true,
+  });
 
   function build() {
     const output = fs.createWriteStream(bundlePath);

--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -3,6 +3,7 @@
 /* global __dirname */
 
 const path = require('path');
+const envify = require('loose-envify/custom');
 
 module.exports = function(config) {
   config.set({
@@ -94,6 +95,8 @@ module.exports = function(config) {
             ],
           },
         ],
+        // Enable debugging checks in libraries that use `NODE_ENV` guards.
+        [envify({ NODE_ENV: 'development' }), { global: true }],
       ],
     },
 


### PR DESCRIPTION
Packages in the React ecosystem often include debugging checks guarded
by:

```
if (process.env.NODE_ENV === 'development') { ... }
```

OR

```
if (process.env.NODE_ENV !== 'production') { ... }
```

This commit uses loose-envify to replace the `process.env.$VAR`
expression with a literal string value when building JS bundles. This enables
debugging checks in dev builds and causes the minifier to remove the
code entirely in production builds.

Some packages don't need this because their package.json file includes a
"browserify" key which already configures this transform, however not
all of them do. Therefore the transform is configured to run globally.