### PR TITLE
Add annotations:group:GROUP_ID fragment url

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -23,6 +23,7 @@ function configFrom(window_) {
     enableExperimentalNewNoteButton: settings.hostPageSetting(
       'enableExperimentalNewNoteButton'
     ),
+    group: settings.group,
     theme: settings.hostPageSetting('theme'),
     usernameUrl: settings.hostPageSetting('usernameUrl'),
     onLayoutChange: settings.hostPageSetting('onLayoutChange'),

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -102,6 +102,28 @@ function settingsFrom(window_) {
     return jsonConfigs.annotations || annotationsFromURL();
   }
 
+  /**
+   * Return the `#annotations:group:*` ID from the given URL's fragment.
+   *
+   * If the URL contains a `#annotations:group:<GROUP_ID>` fragment then return
+   * the group ID extracted from the fragment. Otherwise return `null`.
+   *
+   * @return {string|null} - The extracted ID, or null.
+   */
+  function group() {
+    function groupFromURL() {
+      const groupFragmentMatch = window_.location.href.match(
+        /#annotations:group:([A-Za-z0-9_-]+)$/
+      );
+      if (groupFragmentMatch) {
+        return groupFragmentMatch[1];
+      }
+      return null;
+    }
+
+    return jsonConfigs.group || groupFromURL();
+  }
+
   function showHighlights() {
     let showHighlights_ = hostPageSetting('showHighlights');
 
@@ -178,6 +200,9 @@ function settingsFrom(window_) {
     },
     get clientUrl() {
       return clientUrl();
+    },
+    get group() {
+      return group();
     },
     get showHighlights() {
       return showHighlights();

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -27,17 +27,17 @@ describe('annotator.config.index', function() {
     assert.calledWithExactly(fakeSettingsFrom, 'WINDOW');
   });
 
-  ['sidebarAppUrl', 'query', 'annotations', 'showHighlights'].forEach(function(
-    settingName
-  ) {
-    it('returns the ' + settingName + ' setting', function() {
-      fakeSettingsFrom()[settingName] = 'SETTING_VALUE';
+  ['sidebarAppUrl', 'query', 'annotations', 'group', 'showHighlights'].forEach(
+    settingName => {
+      it('returns the ' + settingName + ' setting', () => {
+        fakeSettingsFrom()[settingName] = 'SETTING_VALUE';
 
-      const config = configFrom('WINDOW');
+        const config = configFrom('WINDOW');
 
-      assert.equal(config[settingName], 'SETTING_VALUE');
-    });
-  });
+        assert.equal(config[settingName], 'SETTING_VALUE');
+      });
+    }
+  );
 
   context("when there's no application/annotator+html <link>", function() {
     beforeEach('remove the application/annotator+html <link>', function() {

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -289,6 +289,29 @@ describe('annotator.config.settingsFrom', function() {
     });
   });
 
+  [
+    {
+      description:
+        "returns an object with the group ID when there's a valid #annotations:group:<ID> fragment",
+      url: 'http://localhost:3000#annotations:group:alphanum3ric_-only',
+      returns: 'alphanum3ric_-only',
+    },
+    {
+      description: "returns null when there's a non-alphanumeric group ID",
+      url: 'http://localhost:3000#annotations:group:not%20alphanumeric',
+      returns: null,
+    },
+    {
+      description: "return null when there's an empty group ID",
+      url: 'http://localhost:3000#annotations:group:',
+      returns: null,
+    },
+  ].forEach(test => {
+    it(test.description, () => {
+      assert.deepEqual(settingsFrom(fakeWindow(test.url)).group, test.returns);
+    });
+  });
+
   describe('#query', function() {
     context(
       'when the host page has a js-hypothesis-config with a query setting',

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -17,6 +17,9 @@ function hostPageConfig(window) {
     // Direct-linked annotation ID
     'annotations',
 
+    // Direct-linked group ID
+    'group',
+
     // Default query passed by url
     'query',
 

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -232,6 +232,7 @@ function api(apiRoutes, auth, store) {
       member: {
         delete: apiCall('group.member.delete'),
       },
+      read: apiCall('group.read'),
     },
     groups: {
       list: apiCall('groups.read'),

--- a/src/sidebar/services/test/api-index.json
+++ b/src/sidebar/services/test/api-index.json
@@ -29,6 +29,11 @@
           "method": "DELETE",
           "desc": "Remove the current user from a group."
         }
+      },
+      "read": {
+        "url": "https://example.com/api/groups/:id",
+        "method": "GET",
+        "desc": "Fetch a group."
       }
     },
     "links": {

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -124,6 +124,14 @@ describe('sidebar.services.api', function() {
     return api.group.member.delete({ pubid: 'an-id', userid: 'me' });
   });
 
+  it('gets a group by provided group id', () => {
+    const group = { id: 'group-id', name: 'Group' };
+    expectCall('get', 'groups/group-id', 200, group);
+    return api.group.read({ id: 'group-id' }).then(group_ => {
+      assert.deepEqual(group_, group);
+    });
+  });
+
   it('removes internal properties before sending data to the server', () => {
     const annotation = {
       $highlight: true,

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -50,7 +50,6 @@ describe('groups', function() {
   let fakeLocalStorage;
   let fakeRootScope;
   let fakeServiceUrl;
-  let sandbox;
 
   beforeEach(function() {
     fakeAuth = {
@@ -59,7 +58,6 @@ describe('groups', function() {
     fakeFeatures = {
       flagEnabled: sinon.stub().returns(false),
     };
-    sandbox = sinon.sandbox.create();
 
     fakeStore = fakeReduxStore(
       {
@@ -92,8 +90,8 @@ describe('groups', function() {
     fakeSession = sessionWithThreeGroups();
     fakeIsSidebar = true;
     fakeLocalStorage = {
-      getItem: sandbox.stub(),
-      setItem: sandbox.stub(),
+      getItem: sinon.stub(),
+      setItem: sinon.stub(),
     };
     fakeRootScope = {
       eventCallbacks: {},
@@ -108,7 +106,7 @@ describe('groups', function() {
         }
       },
 
-      $broadcast: sandbox.stub(),
+      $broadcast: sinon.stub(),
     };
     fakeApi = {
       annotation: {
@@ -117,24 +115,21 @@ describe('groups', function() {
 
       group: {
         member: {
-          delete: sandbox.stub().returns(Promise.resolve()),
+          delete: sinon.stub().returns(Promise.resolve()),
         },
+        read: sinon.stub().returns(Promise.resolve()),
       },
       groups: {
-        list: sandbox.stub().returns(dummyGroups),
+        list: sinon.stub().returns(dummyGroups),
       },
       profile: {
         groups: {
-          read: sandbox.stub().returns(Promise.resolve([dummyGroups[0]])),
+          read: sinon.stub().returns(Promise.resolve([dummyGroups[0]])),
         },
       },
     };
-    fakeServiceUrl = sandbox.stub();
+    fakeServiceUrl = sinon.stub();
     fakeSettings = {};
-  });
-
-  afterEach(function() {
-    sandbox.restore();
   });
 
   function service() {

--- a/src/sidebar/test/host-config-test.js
+++ b/src/sidebar/test/host-config-test.js
@@ -14,6 +14,7 @@ describe('hostPageConfig', function() {
   it('parses config from location string and returns whitelisted params', function() {
     const window_ = fakeWindow({
       annotations: '1234',
+      group: 'abc12',
       appType: 'bookmarklet',
       openSidebar: true,
       requestConfigFromFrame: 'https://embedder.com',
@@ -27,6 +28,7 @@ describe('hostPageConfig', function() {
 
     assert.deepEqual(hostPageConfig(window_), {
       annotations: '1234',
+      group: 'abc12',
       appType: 'bookmarklet',
       openSidebar: true,
       requestConfigFromFrame: 'https://embedder.com',


### PR DESCRIPTION
Add ability to link to a group in the client. This is a partial fix for https://github.com/hypothesis/product-backlog/issues/987 Note this does not include handling for groups that the user doesn't have permission to, don't exist, or aren't viewable on the page-that will be done in a follow up PR.

This should be merged after https://github.com/hypothesis/client/pull/1060. As it is built on top of that branch.