### PR TITLE
Add ESLint plugin to check React hooks usage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,9 @@
   "rules": {
     "mocha/no-exclusive-tests": "error",
     "no-var": "error",
-    "indent": "off"
+    "indent": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "error"
   },
   "parserOptions": {
     "ecmaVersion": 2018,
@@ -19,7 +21,8 @@
   },
   "plugins": [
     "mocha",
-    "react"
+    "react",
+    "react-hooks"
   ],
   "settings": {
     "react": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-config-hypothesis": "^1.0.0",
     "eslint-plugin-mocha": "^5.2.1",
     "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-react-hooks": "^1.6.0",
     "exorcist": "^1.0.1",
     "express": "^4.14.1",
     "extend": "^3.0.2",

--- a/scripts/.eslintrc
+++ b/scripts/.eslintrc
@@ -4,6 +4,7 @@
   },
   "rules": {
     "no-console": "off",
+    "react-hooks/rules-of-hooks": "off"
   },
   "parserOptions": {
     "ecmaVersion": 2018

--- a/yarn.lock
+++ b/yarn.lock
@@ -3724,6 +3724,11 @@ eslint-plugin-mocha@^5.2.1:
   dependencies:
     ramda "^0.26.1"
 
+eslint-plugin-react-hooks@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
+  integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
+
 eslint-plugin-react@^7.12.4:
   version "7.12.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"


### PR DESCRIPTION
Usage of "hooks" [1] in React has to follow certain rules [2]. This adds the official ESLint plugin to check for this.

All the checks are marked as errors following the "no warnings, only
errors" principle. ESLint suppressions can be used to ignore any cases
where we decide not to follow a "rule".

----

[1]: Hooks are functions in the React API used to do "non functional" things when a component is rendered like persisting state between renders or running logic with side-effects (eg. focusing a DOM element) after the render completes. See [official docs](https://reactjs.org/docs/hooks-intro.html). There is also an alternative, older, class-based API for this. Having converted a few components now, the hooks API has been quite convenient to work with, so I'm inclined to favour this newer API.
[2]: https://reactjs.org/docs/hooks-rules.html