### PR TITLE
Port h-tooltip directive to React

### DIFF
--- a/src/sidebar/components/test/render-utils.js
+++ b/src/sidebar/components/test/render-utils.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * Additional utilities for testing UI components.
+ */
+
+const { options } = require('preact');
+
+/**
+ * Run a function that does Preact component rendering and flush any async tasks
+ * that are enqueued (`setState` calls, `useEffect` hooks etc.). Repeat until
+ * everything stabilizies and no more tasks are enqueued.
+ *
+ * The `act` function (https://reactjs.org/docs/test-utils.html#act) from the
+ * `preact/test-utils` package should do this, but the Preact version is currently
+ * missing the "repeat until stable" part.
+ */
+function runUntilIdle(callback) {
+  const prevOptions = {
+    debounceRendering: options.debounceRendering,
+    requestAnimationFrame: options.requestAnimationFrame,
+  };
+  const maxFrames = 10;
+
+  try {
+    // Temporarily override functions used to enqueue async tasks within Preact.
+    let pendingTasks = [];
+    const enqueueTask = task => pendingTasks.push(task);
+    options.debounceRendering = enqueueTask;
+    options.requestAnimationFrame = enqueueTask;
+
+    // Run the passed function.
+    callback();
+
+    // Repeatedly flush until idle.
+    let frameCount = 0;
+    while (pendingTasks.length > 0 && frameCount < maxFrames) {
+      const callbacks = [...pendingTasks];
+      pendingTasks.splice(0, pendingTasks.length);
+      callbacks.forEach(cb => cb());
+      ++frameCount;
+    }
+
+    // Catch bugs which cause infinite rendering loops.
+    if (pendingTasks.length > 0) {
+      throw new Error(
+        `Rendering failed to become idle after ${frameCount} frames`
+      );
+    }
+  } finally {
+    // Undo overrides.
+    Object.assign(options, prevOptions);
+  }
+}
+
+module.exports = { runUntilIdle };

--- a/src/sidebar/components/test/tooltip-test.js
+++ b/src/sidebar/components/test/tooltip-test.js
@@ -6,6 +6,8 @@ const propTypes = require('prop-types');
 
 const { useTooltip } = require('../tooltip');
 
+const { runUntilIdle } = require('./render-utils');
+
 describe('useTooltip', () => {
   function Button({ hidden = false }) {
     const tooltip = useTooltip();
@@ -48,7 +50,7 @@ describe('useTooltip', () => {
     assert.equal(currentTooltipLabel(), 'Reply to message');
   });
 
-  it('positions the tooltip near the target element', done => {
+  it('positions the tooltip near the target element', () => {
     // Create a container with a fixed position and font size so that
     // the tooltip appears in a predictable location.
     const container = document.createElement('div');
@@ -59,20 +61,19 @@ describe('useTooltip', () => {
     document.body.appendChild(container);
 
     // Render component and trigger tooltip display.
-    render(<Button />, container);
-    container.querySelector('button').dispatchEvent(new Event('mouseover'));
+    runUntilIdle(() => {
+      render(<Button />, container);
+      container.querySelector('button').dispatchEvent(new Event('mouseover'));
+    });
 
     // Wait for tooltip to render, measure its size and then position
     // itself in its final location.
-    setTimeout(() => {
-      const { left, top } = currentTooltipPos();
+    const { left, top } = currentTooltipPos();
 
-      assert.closeTo(left, 130, 10);
-      assert.closeTo(top, 180, 10);
+    assert.closeTo(left, 130, 10);
+    assert.closeTo(top, 180, 10);
 
-      container.remove();
-      done();
-    }, 5);
+    container.remove();
   });
 
   it('hides the tooltip when the element is unhovered', () => {

--- a/src/sidebar/components/test/tooltip-test.js
+++ b/src/sidebar/components/test/tooltip-test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const { mount } = require('enzyme');
+const { createElement, render } = require('preact');
+const propTypes = require('prop-types');
+
+const { useTooltip } = require('../tooltip');
+
+describe('useTooltip', () => {
+  function Button({ hidden = false }) {
+    const tooltip = useTooltip();
+
+    if (hidden) {
+      return null;
+    }
+    return (
+      <button ref={tooltip} aria-label="Reply to message">
+        Reply
+      </button>
+    );
+  }
+  Button.propTypes = { hidden: propTypes.bool };
+
+  function currentTooltipLabel() {
+    const container = document.querySelector('tooltip-container');
+    return container.textContent || null;
+  }
+
+  function currentTooltipPos() {
+    const container = document.querySelector('tooltip-container');
+    const tooltipEl = container.firstChild;
+    if (!tooltipEl) {
+      return { top: null, left: null };
+    }
+    const rect = tooltipEl.getBoundingClientRect();
+    return { top: rect.top, left: rect.left };
+  }
+
+  it('shows the tooltip when the element is hovered', () => {
+    const wrapper = mount(<Button />);
+    const button = wrapper.find('button').getDOMNode();
+
+    // Use DOM APIs instead of `wrapper.simulate(event)` here because Enzyme
+    // doesn't guarantee to dispatch an actual DOM event in order to trigger
+    // event handler props (`onClick` etc).
+    button.dispatchEvent(new Event('mouseover'));
+
+    assert.equal(currentTooltipLabel(), 'Reply to message');
+  });
+
+  it('positions the tooltip near the target element', done => {
+    // Create a container with a fixed position and font size so that
+    // the tooltip appears in a predictable location.
+    const container = document.createElement('div');
+    container.style.position = 'fixed';
+    container.style.top = '200px';
+    container.style.left = '200px';
+    container.style.fontSize = '13px';
+    document.body.appendChild(container);
+
+    // Render component and trigger tooltip display.
+    render(<Button />, container);
+    container.querySelector('button').dispatchEvent(new Event('mouseover'));
+
+    // Wait for tooltip to render, measure its size and then position
+    // itself in its final location.
+    setTimeout(() => {
+      const { left, top } = currentTooltipPos();
+
+      assert.closeTo(left, 130, 10);
+      assert.closeTo(top, 180, 10);
+
+      container.remove();
+      done();
+    }, 5);
+  });
+
+  it('hides the tooltip when the element is unhovered', () => {
+    const wrapper = mount(<Button />);
+    const button = wrapper.find('button').getDOMNode();
+
+    button.dispatchEvent(new Event('mouseover'));
+    button.dispatchEvent(new Event('mouseout'));
+
+    assert.equal(currentTooltipLabel(), null);
+  });
+
+  it('hides the tooltip when the element is removed', () => {
+    const wrapper = mount(<Button />);
+    const button = wrapper.find('button').getDOMNode();
+
+    button.dispatchEvent(new Event('mouseover'));
+    wrapper.setProps({ hidden: true });
+
+    assert.equal(currentTooltipLabel(), null);
+  });
+});

--- a/src/sidebar/components/tooltip.js
+++ b/src/sidebar/components/tooltip.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const classnames = require('classnames');
+const { createElement, render } = require('preact');
+const { useCallback, useEffect, useRef, useState } = require('preact/hooks');
+const propTypes = require('prop-types');
+
+/**
+ * A tooltip which points at a target DOM element.
+ *
+ * There is typically only one instance of this component rendered at any time,
+ * via the `showTooltip` and `hideTooltip` functions.
+ *
+ * The tooltip's label is taken from the target's `aria-label` attribute.
+ */
+function Tooltip({ target }) {
+  const label = target.getAttribute('aria-label');
+  const targetRect = target.getBoundingClientRect();
+  const TOOLTIP_ARROW_HEIGHT = 7;
+
+  const [top, setTop] = useState(null);
+  const [left, setLeft] = useState(null);
+  const tooltipRef = useRef();
+
+  useEffect(() => {
+    // Once the tooltip has been rendered, measure its size and reposition it
+    // above the target.
+    const tooltipRect = tooltipRef.current.getBoundingClientRect();
+    const newTop = targetRect.top - tooltipRect.height - TOOLTIP_ARROW_HEIGHT;
+    const newLeft = targetRect.right - tooltipRect.width;
+
+    setTop(newTop);
+    setLeft(newLeft);
+  }, [setLeft, setTop, target]);
+
+  return (
+    <div
+      className={classnames('tooltip', 'tooltip--down')}
+      style={{
+        visibility: top === null ? 'hidden' : '',
+        top,
+        left,
+        position: 'fixed',
+      }}
+      ref={tooltipRef}
+    >
+      <span className="tooltip-label">{label}</span>
+    </div>
+  );
+}
+
+Tooltip.propTypes = {
+  /** The DOM element that the tooltip should point to. */
+  target: propTypes.object,
+};
+
+/**
+ * DOM element where the global tooltip is rendered.
+ */
+let tooltipContainer;
+
+/**
+ * The DOM element which the global tooltip is currently pointing at.
+ */
+let currentTarget;
+
+/**
+ * Show the global tooltip, pointing at `element`.
+ *
+ * The tooltip label will be taken from the element's "aria-label" attribute.
+ *
+ * @param {Element} element
+ */
+function showTooltip(element) {
+  if (!tooltipContainer) {
+    // Use a custom element name to make it obvious what this element is when
+    // eg. using the DOM inspector.
+    tooltipContainer = document.createElement('tooltip-container');
+    document.body.appendChild(tooltipContainer);
+  }
+  currentTarget = element;
+  render(<Tooltip target={element} />, tooltipContainer);
+}
+
+/**
+ * Hide the global tooltip, if currently pointing at `element`.
+ *
+ * @param {Element} element
+ */
+function hideTooltip(element) {
+  if (element !== currentTarget) {
+    return;
+  }
+  render(null, tooltipContainer);
+  currentTarget = null;
+}
+
+/**
+ * A React hook which causes a tooltip to be shown when an element is hovered.
+ *
+ * Returns a function which can be used as a `ref` prop on an element.
+ *
+ * @example
+ *   function IconButton() {
+ *     return (
+ *      <button ref={useTooltip()} aria-label="Do something">
+ *       <img .../>
+ *      </button>
+ *     );
+ *   }
+ * @return {(el: HTMLElement|null) => void}
+ */
+function useTooltip() {
+  const prevEl = useRef();
+  return useCallback(el => {
+    if (prevEl.current) {
+      // The element this tooltip was used with was changed or removed.
+      hideTooltip(prevEl.current);
+    }
+    prevEl.current = el;
+
+    if (el !== null) {
+      el.addEventListener('mouseover', () => showTooltip(el));
+      el.addEventListener('mouseout', () => hideTooltip(el));
+    }
+  }, []);
+}
+
+module.exports = {
+  hideTooltip,
+  showTooltip,
+  useTooltip,
+};

--- a/src/sidebar/components/tooltip.js
+++ b/src/sidebar/components/tooltip.js
@@ -15,7 +15,6 @@ const propTypes = require('prop-types');
  */
 function Tooltip({ target }) {
   const label = target.getAttribute('aria-label');
-  const targetRect = target.getBoundingClientRect();
   const TOOLTIP_ARROW_HEIGHT = 7;
 
   const [top, setTop] = useState(null);
@@ -25,6 +24,7 @@ function Tooltip({ target }) {
   useEffect(() => {
     // Once the tooltip has been rendered, measure its size and reposition it
     // above the target.
+    const targetRect = target.getBoundingClientRect();
     const tooltipRect = tooltipRef.current.getBoundingClientRect();
     const newTop = targetRect.top - tooltipRect.height - TOOLTIP_ARROW_HEIGHT;
     const newLeft = targetRect.right - tooltipRect.width;


### PR DESCRIPTION
This "directive" is responsible for showing a customized tooltip based on an element's "aria-label" attribute when it is hovered.

I have some slight doubts about whether we want to continue using custom tooltips. They don't work on mobile at the moment, so no UI in the client should be reliant on them to be usable, although maybe they may still be helpful on desktop. If we did want to enable them on mobile in future, we could follow the example of [Material Design's tooltips](https://material.io/design/components/tooltips.html#placement) which use long-press activation.

**Current example of custom tooltips in the client:**

<img width="419" alt="Screenshot 2019-04-04 16 28 25" src="https://user-images.githubusercontent.com/2458/55567989-b4fe0280-56f6-11e9-824d-b4c963c2199d.png">

----

**Implementation notes**

There are various ways that an Angular directive could be translated to
React. The approach taken here is to create a [hook](https://reactjs.org/docs/hooks-intro.html), `useTooltip`, which
creates a function that accepts a DOM element and shows a tooltip when
that element is hovered. This function can be passed as the
`ref` prop for an element and React will call it when the DOM node is
created, changed or removed.

This was informed by the approach in
https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node

One disadvantage is that because the same hooks must be called in the
same order on every render, `useTooltip` must be called if it _might_ be
used, whether or not the element with the tooltip is actually rendered.