### PR TITLE
Revert "Remove feature flag from group service"

### DIFF
--- a/src/sidebar/components/group-list-section.js
+++ b/src/sidebar/components/group-list-section.js
@@ -4,11 +4,7 @@
 function GroupListSectionController() {
   this.isSelectable = function(groupId) {
     const group = this.sectionGroups.find(g => g.id === groupId);
-    return (
-      !this.disableOosGroupSelection ||
-      !group.scopes.enforced ||
-      group.isScopedToUri
-    );
+    return !this.disableOosGroupSelection || group.isScopedToUri;
   };
 }
 

--- a/src/sidebar/components/test/group-list-section-test.js
+++ b/src/sidebar/components/test/group-list-section-test.js
@@ -31,49 +31,26 @@ describe('groupListSection', () => {
       {
         description: 'always returns true if disableOosGroupSelection is false',
         fakeDisableOosGroupSelection: false,
-        scopesEnforced: true,
         expectedIsSelectable: [true, true],
       },
       {
         description:
           'always returns true if disableOosGroupSelection is undefined',
         fakeDisableOosGroupSelection: undefined,
-        scopesEnforced: true,
         expectedIsSelectable: [true, true],
       },
       {
         description:
           'returns false if disableOosGroupSelection is true and group is out of scope',
         fakeDisableOosGroupSelection: true,
-        scopesEnforced: true,
         expectedIsSelectable: [true, false],
       },
-      {
-        description:
-          'returns true if disableOosGroupSelection is true and group is out of scope but not enforced',
-        fakeDisableOosGroupSelection: true,
-        scopesEnforced: false,
-        expectedIsSelectable: [true, true],
-      },
     ].forEach(
-      ({
-        description,
-        fakeDisableOosGroupSelection,
-        scopesEnforced,
-        expectedIsSelectable,
-      }) => {
+      ({ description, fakeDisableOosGroupSelection, expectedIsSelectable }) => {
         it(description, () => {
           const fakeSectionGroups = [
-            {
-              isScopedToUri: true,
-              scopes: { enforced: scopesEnforced },
-              id: 0,
-            },
-            {
-              isScopedToUri: false,
-              scopes: { enforced: scopesEnforced },
-              id: 1,
-            },
+            { isScopedToUri: true, id: 0 },
+            { isScopedToUri: false, id: 1 },
           ];
 
           const element = createGroupListSection(

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -158,17 +158,6 @@ const getCurrentlyViewingGroups = memoize(state => {
   );
 });
 
-/**
- * Return groups that are scoped to the uri. This is used to return the groups
- * that show up in the old groups menu. This should be removed once the new groups
- * menu is permanent.
- *
- * @return {Group[]}
- */
-const getInScopeGroups = memoize(state => {
-  return state.groups.filter(g => g.isScopedToUri);
-});
-
 module.exports = {
   init,
   update,
@@ -182,7 +171,6 @@ module.exports = {
     getCurrentlyViewingGroups,
     getFeaturedGroups,
     getMyGroups,
-    getInScopeGroups,
     focusedGroup,
     focusedGroupId,
   },

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -134,13 +134,6 @@ describe('sidebar.store.modules.groups', () => {
     });
   });
 
-  describe('getInScopeGroups', () => {
-    it('returns all groups that are in scope', () => {
-      store.loadGroups([publicGroup, privateGroup, restrictedOutOfScopeGroup]);
-      assert.deepEqual(store.getInScopeGroups(), [publicGroup, privateGroup]);
-    });
-  });
-
   describe('getGroup', () => {
     it('returns the group with the given ID', () => {
       store.loadGroups([publicGroup, privateGroup]);

--- a/src/sidebar/util/groups.js
+++ b/src/sidebar/util/groups.js
@@ -35,9 +35,10 @@ function combineGroups(userGroups, featuredGroups, uri) {
 }
 
 function isScopedToUri(group, uri) {
-  // Groups with no scopes or groups with no uri_patterns defined
-  // are considered in scope.
-  if (group.scopes && group.scopes.uri_patterns.length > 0) {
+  // If the group has scope info, the scoping is enforced,
+  // and the uri patterns don't include this page's uri
+  // the group is not selectable, otherwise it is.
+  if (group.scopes && group.scopes.enforced) {
     return uriMatchesScopes(uri, group.scopes.uri_patterns);
   }
   return true;

--- a/src/sidebar/util/test/groups-test.js
+++ b/src/sidebar/util/test/groups-test.js
@@ -102,14 +102,14 @@ describe('sidebar.util.groups', () => {
       {
         description: 'sets `isScopedToUri` to true if `scopes` is missing',
         scopes: undefined,
-        isScopedToUri: true,
+        shouldBeSelectable: true,
         uri: 'https://foo.com/bar',
       },
       {
         description:
-          'sets `isScopedToUri` to true if `scopes.uri_patterns` is empty',
-        scopes: { uri_patterns: [] },
-        isScopedToUri: true,
+          'sets `isScopedToUri` to true if `scopes.enforced` is false',
+        scopes: { enforced: false },
+        shouldBeSelectable: true,
         uri: 'https://foo.com/bar',
       },
       {
@@ -119,20 +119,20 @@ describe('sidebar.util.groups', () => {
           enforced: true,
           uri_patterns: ['http://foo.com*', 'https://foo.com*'],
         },
-        isScopedToUri: true,
+        shouldBeSelectable: true,
         uri: 'https://foo.com/bar',
       },
       {
         description:
           'sets `isScopedToUri` to false if `scopes.uri_patterns` do not match the uri',
         scopes: { enforced: true, uri_patterns: ['http://foo.com*'] },
-        isScopedToUri: false,
+        shouldBeSelectable: false,
         uri: 'https://foo.com/bar',
       },
       {
         description: 'it permits multiple *s in the scopes uri pattern',
         scopes: { enforced: true, uri_patterns: ['https://foo.com*bar*'] },
-        isScopedToUri: true,
+        shouldBeSelectable: true,
         uri: 'https://foo.com/boo/bar/baz',
       },
       {
@@ -141,17 +141,17 @@ describe('sidebar.util.groups', () => {
           enforced: true,
           uri_patterns: ['https://foo.com?bar=foo$[^]($){mu}+&boo=*'],
         },
-        isScopedToUri: true,
+        shouldBeSelectable: true,
         uri: 'https://foo.com?bar=foo$[^]($){mu}+&boo=foo',
       },
-    ].forEach(({ description, scopes, isScopedToUri, uri }) => {
+    ].forEach(({ description, scopes, shouldBeSelectable, uri }) => {
       it(description, () => {
         const userGroups = [{ id: 'groupa', name: 'GroupA', scopes: scopes }];
         const featuredGroups = [];
 
         const groups = combineGroups(userGroups, featuredGroups, uri);
 
-        groups.forEach(g => assert.equal(g.isScopedToUri, isScopedToUri));
+        groups.forEach(g => assert.equal(g.isScopedToUri, shouldBeSelectable));
       });
     });
 


### PR DESCRIPTION
Reverts hypothesis/client#1052

When a user direct links to an annotation not visible on the sidebar (aka: https://hypothes.is/a/rGSnNwCKSuiG3VT__k3VvA), the document uri is left as null thus the previously feature flagged code must be able to handle the case where the uri is null or perhaps in this case it could be '' instead of null.
```
  function load() {
    let uri = Promise.resolve(null);
    if (isSidebar) { // <- This case isn't entered when we aren't viewing an annotation from the sidebar.
      uri = getDocumentUriForGroupSearch();
    }
```