### PR TITLE
Fix feature flag race condition

### DIFF
--- a/src/sidebar/components/group-list-section.js
+++ b/src/sidebar/components/group-list-section.js
@@ -4,7 +4,7 @@
 function GroupListSectionController() {
   this.isSelectable = function(groupId) {
     const group = this.sectionGroups.find(g => g.id === groupId);
-    return !this.disableOosGroupSelection || group.isScopedToUri;
+    return !group.scopes.enforced || group.isScopedToUri;
   };
 }
 
@@ -16,8 +16,6 @@ module.exports = {
     sectionGroups: '<',
     /* The string name of the group list section. */
     heading: '<',
-    /* A boolean indicating whether out of scope group selection should be disabled. */
-    disableOosGroupSelection: '<',
   },
   template: require('../templates/group-list-section.html'),
 };

--- a/src/sidebar/components/test/group-list-section-test.js
+++ b/src/sidebar/components/test/group-list-section-test.js
@@ -13,59 +13,50 @@ describe('groupListSection', () => {
     angular.mock.module('app', {});
   });
 
-  const createGroupListSection = (
-    fakeSectionGroups,
-    fakeDisableOosGroupSelection
-  ) => {
-    const config = {
+  const createGroupListSection = fakeSectionGroups => {
+    return util.createDirective(document, 'groupListSection', {
       sectionGroups: fakeSectionGroups,
-    };
-    if (fakeDisableOosGroupSelection !== undefined) {
-      config.disableOosGroupSelection = fakeDisableOosGroupSelection;
-    }
-    return util.createDirective(document, 'groupListSection', config);
+    });
   };
 
   describe('isSelectable', () => {
     [
       {
-        description: 'always returns true if disableOosGroupSelection is false',
-        fakeDisableOosGroupSelection: false,
-        expectedIsSelectable: [true, true],
-      },
-      {
         description:
-          'always returns true if disableOosGroupSelection is undefined',
-        fakeDisableOosGroupSelection: undefined,
-        expectedIsSelectable: [true, true],
-      },
-      {
-        description:
-          'returns false if disableOosGroupSelection is true and group is out of scope',
-        fakeDisableOosGroupSelection: true,
+          'returns false if group is out of scope and scope is enforced',
+        scopesEnforced: true,
         expectedIsSelectable: [true, false],
       },
-    ].forEach(
-      ({ description, fakeDisableOosGroupSelection, expectedIsSelectable }) => {
-        it(description, () => {
-          const fakeSectionGroups = [
-            { isScopedToUri: true, id: 0 },
-            { isScopedToUri: false, id: 1 },
-          ];
+      {
+        description:
+          'returns true if group is out of scope but scope is not enforced',
+        scopesEnforced: false,
+        expectedIsSelectable: [true, true],
+      },
+    ].forEach(({ description, scopesEnforced, expectedIsSelectable }) => {
+      it(description, () => {
+        const fakeSectionGroups = [
+          {
+            isScopedToUri: true,
+            scopes: { enforced: scopesEnforced },
+            id: 0,
+          },
+          {
+            isScopedToUri: false,
+            scopes: { enforced: scopesEnforced },
+            id: 1,
+          },
+        ];
 
-          const element = createGroupListSection(
-            fakeSectionGroups,
-            fakeDisableOosGroupSelection
-          );
+        const element = createGroupListSection(fakeSectionGroups);
 
-          fakeSectionGroups.forEach(g =>
-            assert.equal(
-              element.ctrl.isSelectable(g.id),
-              expectedIsSelectable[g.id]
-            )
-          );
-        });
-      }
-    );
+        fakeSectionGroups.forEach(g =>
+          assert.equal(
+            element.ctrl.isSelectable(g.id),
+            expectedIsSelectable[g.id]
+          )
+        );
+      });
+    });
   });
 });

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -70,6 +70,9 @@ describe('groups', function() {
         allGroups() {
           return this.getState().groups;
         },
+        getInScopeGroups() {
+          return this.getState().groups;
+        },
         focusedGroup() {
           return this.getState().focusedGroup;
         },
@@ -114,12 +117,7 @@ describe('groups', function() {
         },
       },
       groups: {
-        list: sandbox.stub().returns(
-          Promise.resolve({
-            data: dummyGroups,
-            token: '1234',
-          })
-        ),
+        list: sandbox.stub().returns(dummyGroups),
       },
       profile: {
         groups: {
@@ -151,15 +149,24 @@ describe('groups', function() {
   }
 
   describe('#all', function() {
-    it('returns all groups', function() {
+    it('returns all groups from store.allGroups when community-groups feature flag is enabled', () => {
       const svc = service();
-      fakeStore.setState({ groups: dummyGroups });
+      fakeStore.allGroups = sinon.stub().returns(dummyGroups);
+      fakeFeatures.flagEnabled.withArgs('community_groups').returns(true);
       assert.deepEqual(svc.all(), dummyGroups);
+      assert.called(fakeStore.allGroups);
+    });
+
+    it('returns all groups from store.getInScopeGroups when community-groups feature flag is disabled', () => {
+      const svc = service();
+      fakeStore.getInScopeGroups = sinon.stub().returns(dummyGroups);
+      assert.deepEqual(svc.all(), dummyGroups);
+      assert.called(fakeStore.getInScopeGroups);
     });
   });
 
   describe('#load', function() {
-    it('combines groups from both endpoints if community-groups feature flag is set', function() {
+    it('combines groups from both endpoints', function() {
       const svc = service();
 
       const groups = [
@@ -169,7 +176,6 @@ describe('groups', function() {
 
       fakeApi.profile.groups.read.returns(Promise.resolve(groups));
       fakeApi.groups.list.returns(Promise.resolve([groups[0]]));
-      fakeFeatures.flagEnabled.withArgs('community_groups').returns(true);
 
       return svc.load().then(() => {
         assert.calledWith(fakeStore.loadGroups, groups);
@@ -184,21 +190,11 @@ describe('groups', function() {
       });
     });
 
-    it('always sends the `expand` parameter', function() {
-      const svc = service();
-      return svc.load().then(() => {
-        const call = fakeApi.groups.list.getCall(0);
-        assert.isObject(call.args[0]);
-        assert.equal(call.args[0].expand, 'organization');
-      });
-    });
-
-    it('sends `expand` parameter when community-groups feature flag is enabled', function() {
+    it('sends `expand` parameter', function() {
       const svc = service();
       fakeApi.groups.list.returns(
         Promise.resolve([{ id: 'groupa', name: 'GroupA' }])
       );
-      fakeFeatures.flagEnabled.withArgs('community_groups').returns(true);
 
       return svc.load().then(() => {
         assert.calledWith(
@@ -241,7 +237,7 @@ describe('groups', function() {
         return loaded.then(() => {
           assert.calledWith(fakeApi.groups.list, {
             document_uri: 'https://asite.com',
-            expand: 'organization',
+            expand: ['organization', 'scopes'],
           });
         });
       });
@@ -257,7 +253,7 @@ describe('groups', function() {
         const svc = service();
         return svc.load().then(() => {
           assert.calledWith(fakeApi.groups.list, {
-            expand: 'organization',
+            expand: ['organization', 'scopes'],
           });
         });
       });
@@ -277,12 +273,7 @@ describe('groups', function() {
     it('injects a defalt organization if group is missing an organization', function() {
       const svc = service();
       const groups = [{ id: '39r39f', name: 'Ding Dong!' }];
-      fakeApi.groups.list.returns(
-        Promise.resolve({
-          token: '1234',
-          data: groups,
-        })
-      );
+      fakeApi.groups.list.returns(Promise.resolve(groups));
       return svc.load().then(groups => {
         assert.isObject(groups[0].organization);
         assert.hasAllKeys(groups[0].organization, ['id', 'logo']);
@@ -317,12 +308,9 @@ describe('groups', function() {
             groups.push({ name: 'BioPub', id: 'biopub' });
           }
 
-          fakeApi.groups.list.returns(
-            Promise.resolve({
-              token: loggedIn ? '1234' : null,
-              data: groups,
-            })
-          );
+          fakeAuth.tokenGetter.returns(loggedIn ? '1234' : null);
+          fakeApi.groups.list.returns(Promise.resolve(groups));
+          fakeApi.profile.groups.read.returns(Promise.resolve([]));
 
           return svc.load().then(groups => {
             const publicGroupShown = groups.some(g => g.id === '__world__');
@@ -375,12 +363,8 @@ describe('groups', function() {
           { name: 'DEF', id: 'def456', groupid: null },
         ];
 
-        fakeApi.groups.list.returns(
-          Promise.resolve({
-            token: '1234',
-            data: groups,
-          })
-        );
+        fakeApi.groups.list.returns(Promise.resolve(groups));
+        fakeApi.profile.groups.read.returns(Promise.resolve([]));
 
         return svc.load().then(groups => {
           let displayedGroups = groups.map(g => g.id);

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -163,6 +163,22 @@ describe('groups', function() {
       assert.deepEqual(svc.all(), dummyGroups);
       assert.called(fakeStore.getInScopeGroups);
     });
+
+    [[0, 1, 2, 3], [2, 0, 1, 3], [0, 3, 1, 2]].forEach(groupInputOrder => {
+      it('sorts the groups in the following order: scoped, public, private maintaining order within each category.', () => {
+        const groups = [
+          { id: 0, type: 'open' },
+          { id: 1, type: 'restricted' },
+          { id: '__world__', type: 'open' },
+          { id: 3, type: 'private' },
+        ];
+        const svc = service();
+        fakeStore.getInScopeGroups = sinon
+          .stub()
+          .returns(groupInputOrder.map(id => groups[id]));
+        assert.deepEqual(svc.all(), groups);
+      });
+    });
   });
 
   describe('#load', function() {

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -30,7 +30,11 @@ const sessionWithThreeGroups = function() {
 };
 
 const dummyGroups = [
-  { name: 'Group 1', id: 'id1' },
+  {
+    name: 'Group 1',
+    id: 'id1',
+    scopes: { enforced: false, uri_patterns: ['http://foo.com'] },
+  },
   { name: 'Group 2', id: 'id2' },
   { name: 'Group 3', id: 'id3' },
 ];

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -158,6 +158,17 @@ const getCurrentlyViewingGroups = memoize(state => {
   );
 });
 
+/**
+ * Return groups that are scoped to the uri. This is used to return the groups
+ * that show up in the old groups menu. This should be removed once the new groups
+ * menu is permanent.
+ *
+ * @return {Group[]}
+ */
+const getInScopeGroups = memoize(state => {
+  return state.groups.filter(g => g.isScopedToUri);
+});
+
 module.exports = {
   init,
   update,
@@ -171,6 +182,7 @@ module.exports = {
     getCurrentlyViewingGroups,
     getFeaturedGroups,
     getMyGroups,
+    getInScopeGroups,
     focusedGroup,
     focusedGroupId,
   },

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -134,6 +134,13 @@ describe('sidebar.store.modules.groups', () => {
     });
   });
 
+  describe('getInScopeGroups', () => {
+    it('returns all groups that are in scope', () => {
+      store.loadGroups([publicGroup, privateGroup, restrictedOutOfScopeGroup]);
+      assert.deepEqual(store.getInScopeGroups(), [publicGroup, privateGroup]);
+    });
+  });
+
   describe('getGroup', () => {
     it('returns the group with the given ID', () => {
       store.loadGroups([publicGroup, privateGroup]);

--- a/src/sidebar/templates/group-list.html
+++ b/src/sidebar/templates/group-list.html
@@ -162,7 +162,6 @@
       class="group-list-section"
       heading="'My Groups'"
       section-groups="vm.myGroupOrganizations()"
-      disable-oos-group-selection="true"
       ng-if="vm.myGroupOrganizations().length > 0"
     >
     </group-list-section>

--- a/src/sidebar/util/groups.js
+++ b/src/sidebar/util/groups.js
@@ -27,18 +27,22 @@ function combineGroups(userGroups, featuredGroups, uri) {
 
   const groups = userGroups.concat(featuredGroups);
 
-  // Add isScopedToUri property indicating whether a group can be
-  // annotated in at this particular url.
+  // Add isScopedToUri property indicating whether a group is within scope
+  // of the given uri. If the scope check cannot be performed, isScopedToUri
+  // defaults to true.
   groups.forEach(group => (group.isScopedToUri = isScopedToUri(group, uri)));
 
   return groups;
 }
 
 function isScopedToUri(group, uri) {
-  // If the group has scope info, the scoping is enforced,
-  // and the uri patterns don't include this page's uri
-  // the group is not selectable, otherwise it is.
-  if (group.scopes && group.scopes.enforced) {
+  /* If a scope check cannot be performed, meaning:
+   * - the group doesn't have a scopes attribute
+   * - the group has no scopes.uri_patterns present
+   * - there is no uri to compare against (aka: uri=null)
+   * the group is defaulted to in-scope.
+   */
+  if (group.scopes && group.scopes.uri_patterns.length > 0 && uri) {
     return uriMatchesScopes(uri, group.scopes.uri_patterns);
   }
   return true;

--- a/src/sidebar/util/test/groups-test.js
+++ b/src/sidebar/util/test/groups-test.js
@@ -102,14 +102,14 @@ describe('sidebar.util.groups', () => {
       {
         description: 'sets `isScopedToUri` to true if `scopes` is missing',
         scopes: undefined,
-        shouldBeSelectable: true,
+        isScopedToUri: true,
         uri: 'https://foo.com/bar',
       },
       {
         description:
-          'sets `isScopedToUri` to true if `scopes.enforced` is false',
-        scopes: { enforced: false },
-        shouldBeSelectable: true,
+          'sets `isScopedToUri` to true if `scopes.uri_patterns` is empty',
+        scopes: { uri_patterns: [] },
+        isScopedToUri: true,
         uri: 'https://foo.com/bar',
       },
       {
@@ -119,20 +119,20 @@ describe('sidebar.util.groups', () => {
           enforced: true,
           uri_patterns: ['http://foo.com*', 'https://foo.com*'],
         },
-        shouldBeSelectable: true,
+        isScopedToUri: true,
         uri: 'https://foo.com/bar',
       },
       {
         description:
           'sets `isScopedToUri` to false if `scopes.uri_patterns` do not match the uri',
         scopes: { enforced: true, uri_patterns: ['http://foo.com*'] },
-        shouldBeSelectable: false,
+        isScopedToUri: false,
         uri: 'https://foo.com/bar',
       },
       {
         description: 'it permits multiple *s in the scopes uri pattern',
         scopes: { enforced: true, uri_patterns: ['https://foo.com*bar*'] },
-        shouldBeSelectable: true,
+        isScopedToUri: true,
         uri: 'https://foo.com/boo/bar/baz',
       },
       {
@@ -141,17 +141,17 @@ describe('sidebar.util.groups', () => {
           enforced: true,
           uri_patterns: ['https://foo.com?bar=foo$[^]($){mu}+&boo=*'],
         },
-        shouldBeSelectable: true,
+        isScopedToUri: true,
         uri: 'https://foo.com?bar=foo$[^]($){mu}+&boo=foo',
       },
-    ].forEach(({ description, scopes, shouldBeSelectable, uri }) => {
+    ].forEach(({ description, scopes, isScopedToUri, uri }) => {
       it(description, () => {
         const userGroups = [{ id: 'groupa', name: 'GroupA', scopes: scopes }];
         const featuredGroups = [];
 
         const groups = combineGroups(userGroups, featuredGroups, uri);
 
-        groups.forEach(g => assert.equal(g.isScopedToUri, shouldBeSelectable));
+        groups.forEach(g => assert.equal(g.isScopedToUri, isScopedToUri));
       });
     });
 

--- a/src/sidebar/util/test/groups-test.js
+++ b/src/sidebar/util/test/groups-test.js
@@ -130,6 +130,12 @@ describe('sidebar.util.groups', () => {
         uri: 'https://foo.com/bar',
       },
       {
+        description: 'sets `isScopedToUri` to true if `uri` is null',
+        scopes: { enforced: true, uri_patterns: ['http://foo.com*'] },
+        isScopedToUri: true,
+        uri: null,
+      },
+      {
         description: 'it permits multiple *s in the scopes uri pattern',
         scopes: { enforced: true, uri_patterns: ['https://foo.com*bar*'] },
         isScopedToUri: true,


### PR DESCRIPTION
Remove conditional loading of groups based on the community-groups feature flag. Instead, load all the groups as if the feature flag is enabled, and filter out the groups that shouldn't be shown for the old groups menu in groups.all().
- [x] Remove the feature flag from the group service load function.
- [x] Add getInScopeGroups to group store.
- [x] Call getInScopeGroups to get groups for old groups menu in group service all function.
- [x] Modify the isScopedToUri logic to not be based on scopes.enforced.
- [x] Modify the isSelectable logic inside the GroupListSectionController to be based on scopes.enforced since isScopedToUri no longer takes it into account.
This is a partial fix for https://github.com/hypothesis/product-backlog/issues/975.
This should be merged before .

#1052 with some additional changes:
- [x] Handle uri=null for cases such as viewing a direct annotation without the sidebar 
- [x] Remove disableOosGroupSelection from the group-list-section controller as it's not needed anymore.  