### PR TITLE
Introduce a new approach to mocking modules in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "aws-sdk": "^2.345.0",
     "babel-plugin-angularjs-annotate": "^0.10.0",
     "babel-plugin-istanbul": "^5.1.0",
+    "babel-plugin-mockable-imports": "^1.1.0",
     "babel-plugin-transform-async-to-promises": "^0.8.6",
     "babel-preset-env": "^1.7.0",
     "babelify": "^10.0.0",

--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -86,6 +86,7 @@ module.exports = function(config) {
             // code coverage instrumentation for Istanbul.
             extensions: ['.js', '.coffee'],
             plugins: [
+              'mockable-imports',
               [
                 'babel-plugin-istanbul',
                 {

--- a/src/sidebar/components/test/group-list-item-out-of-scope-test.js
+++ b/src/sidebar/components/test/group-list-item-out-of-scope-test.js
@@ -1,16 +1,14 @@
 'use strict';
 
 const { mount } = require('enzyme');
-const preact = require('preact');
 const { createElement } = require('preact');
-const proxyquire = require('proxyquire');
 
 const { events } = require('../../services/analytics');
+const GroupListItemOutOfScope = require('../group-list-item-out-of-scope');
 
 describe('GroupListItemOutOfScope', () => {
   let fakeAnalytics;
   let fakeGroupListItemCommon;
-  let GroupListItemOutOfScope;
 
   const fakeGroup = {
     id: 'groupid',
@@ -28,27 +26,23 @@ describe('GroupListItemOutOfScope', () => {
       .first()
       .simulate('click');
 
-  before(() => {
-    fakeGroupListItemCommon = {
-      orgName: sinon.stub(),
-      trackViewGroupActivity: sinon.stub(),
-    };
-
-    GroupListItemOutOfScope = proxyquire('../group-list-item-out-of-scope', {
-      // Use same instance of Preact module in tests and mocked module.
-      // See https://robertknight.me.uk/posts/browserify-dependency-mocking/
-      preact,
-
-      '../util/group-list-item-common': fakeGroupListItemCommon,
-      '@noCallThru': true,
-    });
-  });
-
   beforeEach(() => {
     fakeAnalytics = {
       track: sinon.stub(),
       events,
     };
+    fakeGroupListItemCommon = {
+      orgName: sinon.stub(),
+      trackViewGroupActivity: sinon.stub(),
+    };
+
+    GroupListItemOutOfScope.$imports.$mock({
+      '../util/group-list-item-common': fakeGroupListItemCommon,
+    });
+  });
+
+  afterEach(() => {
+    GroupListItemOutOfScope.$imports.$restore();
   });
 
   const createGroupListItemOutOfScope = fakeGroup => {

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -2,7 +2,7 @@
 
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
-const proxyquire = require('proxyquire');
+const GroupListItem = require('../group-list-item');
 
 const { events } = require('../../services/analytics');
 
@@ -10,19 +10,6 @@ describe('GroupListItem', () => {
   let fakeAnalytics;
   let fakeStore;
   let fakeGroupListItemCommon;
-  let GroupListItem;
-
-  before(() => {
-    fakeGroupListItemCommon = {
-      orgName: sinon.stub(),
-      trackViewGroupActivity: sinon.stub(),
-    };
-
-    GroupListItem = proxyquire('../group-list-item', {
-      '../util/group-list-item-common': fakeGroupListItemCommon,
-      '@noCallThru': true,
-    });
-  });
 
   beforeEach(() => {
     fakeStore = {
@@ -34,6 +21,19 @@ describe('GroupListItem', () => {
       track: sinon.stub(),
       events,
     };
+
+    fakeGroupListItemCommon = {
+      orgName: sinon.stub(),
+      trackViewGroupActivity: sinon.stub(),
+    };
+
+    GroupListItem.$imports.$mock({
+      '../util/group-list-item-common': fakeGroupListItemCommon,
+    });
+  });
+
+  afterEach(() => {
+    GroupListItem.$imports.$restore();
   });
 
   const createGroupListItem = fakeGroup => {

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -1,17 +1,16 @@
 'use strict';
 
 const angular = require('angular');
-const proxyquire = require('proxyquire');
 
 const events = require('../../events');
 const bridgeEvents = require('../../../shared/bridge-events');
-const util = require('../../../shared/test/util');
+
+const hypothesisApp = require('../hypothesis-app');
 
 describe('sidebar.components.hypothesis-app', function() {
   let $componentController = null;
   let $scope = null;
   let $rootScope = null;
-  let fakeAnnotationMetadata = null;
   let fakeStore = null;
   let fakeAnalytics = null;
   let fakeAuth = null;
@@ -44,24 +43,17 @@ describe('sidebar.components.hypothesis-app', function() {
   });
 
   beforeEach(function() {
-    fakeAnnotationMetadata = {
-      location: function() {
-        return 0;
-      },
-    };
-
     fakeServiceConfig = sandbox.stub();
 
-    const component = proxyquire(
-      '../hypothesis-app',
-      util.noCallThru({
-        angular: angular,
-        '../annotation-metadata': fakeAnnotationMetadata,
-        '../service-config': fakeServiceConfig,
-      })
-    );
+    hypothesisApp.$imports.$mock({
+      '../service-config': fakeServiceConfig,
+    });
 
-    angular.module('h', []).component('hypothesisApp', component);
+    angular.module('h', []).component('hypothesisApp', hypothesisApp);
+  });
+
+  afterEach(() => {
+    hypothesisApp.$imports.$restore();
   });
 
   beforeEach(angular.mock.module('h'));

--- a/src/sidebar/components/test/login-control-test.js
+++ b/src/sidebar/components/test/login-control-test.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const angular = require('angular');
-const proxyquire = require('proxyquire');
 
 const bridgeEvents = require('../../../shared/bridge-events');
 const util = require('../../directive/test/util');
+
+const loginControl = require('../login-control');
 
 function pageObject(element) {
   return {
@@ -79,19 +80,15 @@ function thirdPartyUserPage() {
 
 describe('loginControl', function() {
   let fakeBridge;
-  const fakeServiceConfig = sinon.stub();
+  let fakeServiceConfig;
   let fakeWindow;
 
   before(function() {
-    angular.module('app', []).component(
-      'loginControl',
-      proxyquire('../login-control', {
-        '../service-config': fakeServiceConfig,
-      })
-    );
+    angular.module('app', []).component('loginControl', loginControl);
   });
 
   beforeEach(function() {
+    fakeServiceConfig = sinon.stub().returns(null);
     fakeBridge = { call: sinon.stub() };
     const fakeServiceUrl = sinon.stub().returns('someUrl');
     const fakeSettings = {
@@ -106,8 +103,13 @@ describe('loginControl', function() {
       $window: fakeWindow,
     });
 
-    fakeServiceConfig.reset();
-    fakeServiceConfig.returns(null);
+    loginControl.$imports.$mock({
+      '../service-config': fakeServiceConfig,
+    });
+  });
+
+  afterEach(() => {
+    loginControl.$imports.$restore();
   });
 
   describe('the user profile button', function() {

--- a/src/sidebar/components/test/top-bar-test.js
+++ b/src/sidebar/components/test/top-bar-test.js
@@ -1,24 +1,18 @@
 'use strict';
 
 const angular = require('angular');
-const proxyquire = require('proxyquire');
 
+const topBar = require('../top-bar');
 const util = require('../../directive/test/util');
 
 describe('topBar', function() {
   const fakeSettings = {};
-  const fakeIsThirdPartyService = sinon.stub();
+  let fakeIsThirdPartyService;
 
   before(function() {
     angular
       .module('app', [])
-      .component(
-        'topBar',
-        proxyquire('../top-bar', {
-          '../util/is-third-party-service': fakeIsThirdPartyService,
-          '@noCallThru': true,
-        })
-      )
+      .component('topBar', topBar)
       .component('loginControl', {
         bindings: require('../login-control').bindings,
       })
@@ -35,8 +29,15 @@ describe('topBar', function() {
       settings: fakeSettings,
     });
 
-    fakeIsThirdPartyService.reset();
-    fakeIsThirdPartyService.returns(false);
+    fakeIsThirdPartyService = sinon.stub().returns(false);
+
+    topBar.$imports.$mock({
+      '../util/is-third-party-service': fakeIsThirdPartyService,
+    });
+  });
+
+  afterEach(() => {
+    topBar.$imports.$restore();
   });
 
   function applyUpdateBtn(el) {

--- a/src/sidebar/services/test/service-url-test.js
+++ b/src/sidebar/services/test/service-url-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const proxyquire = require('proxyquire');
+const serviceUrlFactory = require('../service-url');
 
 /** Return a fake store object. */
 function fakeStore() {
@@ -20,7 +20,7 @@ function createServiceUrl(linksPromise) {
     .stub()
     .returns({ url: 'EXPANDED_URL', params: {} });
 
-  const serviceUrlFactory = proxyquire('../service-url', {
+  serviceUrlFactory.$imports.$mock({
     '../util/url-util': { replaceURLParams: replaceURLParams },
   });
 
@@ -45,6 +45,7 @@ describe('sidebar.service-url', function() {
 
   afterEach(function() {
     console.warn.restore();
+    serviceUrlFactory.$imports.$restore();
   });
 
   context('before the API response has been received', function() {

--- a/src/sidebar/test/raven-test.js
+++ b/src/sidebar/test/raven-test.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const proxyquire = require('proxyquire');
-const noCallThru = require('../../shared/test/util').noCallThru;
+const raven = require('../raven');
 
 function fakeExceptionData(scriptURL) {
   return {
@@ -28,7 +27,6 @@ describe('raven', function() {
   let fakeAngularTransformer;
   let fakeAngularPlugin;
   let fakeRavenJS;
-  let raven;
 
   beforeEach(function() {
     fakeRavenJS = {
@@ -52,13 +50,14 @@ describe('raven', function() {
       Raven.setDataCallback(fakeAngularTransformer);
     });
 
-    raven = proxyquire(
-      '../raven',
-      noCallThru({
-        'raven-js': fakeRavenJS,
-        'raven-js/plugins/angular': fakeAngularPlugin,
-      })
-    );
+    raven.$imports.$mock({
+      'raven-js': fakeRavenJS,
+      'raven-js/plugins/angular': fakeAngularPlugin,
+    });
+  });
+
+  afterEach(() => {
+    raven.$imports.$restore();
   });
 
   describe('.install()', function() {

--- a/src/sidebar/test/render-markdown-test.js
+++ b/src/sidebar/test/render-markdown-test.js
@@ -1,13 +1,12 @@
 'use strict';
 
-const proxyquire = require('proxyquire');
+const renderMarkdown = require('../render-markdown');
 
 describe('render-markdown', function() {
   let render;
-  let renderMarkdown;
 
   beforeEach(function() {
-    renderMarkdown = proxyquire('../render-markdown', {
+    renderMarkdown.$imports.$mock({
       katex: {
         renderToString: function(input, opts) {
           if (opts && opts.displayMode) {
@@ -21,6 +20,10 @@ describe('render-markdown', function() {
     render = function(markdown) {
       return renderMarkdown(markdown);
     };
+  });
+
+  afterEach(() => {
+    renderMarkdown.$imports.$restore();
   });
 
   describe('autolinking', function() {

--- a/src/sidebar/test/virtual-thread-list-test.js
+++ b/src/sidebar/test/virtual-thread-list-test.js
@@ -1,14 +1,8 @@
 'use strict';
 
-const proxyquire = require('proxyquire');
-
-const VirtualThreadList = proxyquire('../virtual-thread-list', {
-  'lodash.debounce': function(fn) {
-    // Make debounced functions execute immediately
-    return fn;
-  },
-});
 const util = require('../../shared/test/util');
+const VirtualThreadList = require('../virtual-thread-list');
+
 const unroll = util.unroll;
 
 describe('VirtualThreadList', function() {
@@ -44,6 +38,16 @@ describe('VirtualThreadList', function() {
       }),
     };
   }
+
+  beforeEach(() => {
+    VirtualThreadList.$imports.$mock({
+      'lodash.debounce': fn => fn,
+    });
+  });
+
+  afterEach(() => {
+    VirtualThreadList.$imports.$restore();
+  });
 
   beforeEach(function() {
     fakeScope = { $digest: sinon.stub() };

--- a/src/sidebar/util/test/fetch-config-test.js
+++ b/src/sidebar/util/test/fetch-config-test.js
@@ -1,13 +1,12 @@
 'use strict';
 
-const proxyquire = require('proxyquire');
-
 const {
   assertPromiseIsRejected,
 } = require('../../../shared/test/promise-util');
 
+const { fetchConfig, $imports } = require('../fetch-config');
+
 describe('sidebar.util.fetch-config', () => {
-  let fetchConfig;
   let fakeHostConfig;
   let fakeJsonRpc;
   let fakeWindow;
@@ -17,11 +16,10 @@ describe('sidebar.util.fetch-config', () => {
     fakeJsonRpc = {
       call: sinon.stub(),
     };
-    const patched = proxyquire('../fetch-config', {
+    $imports.$mock({
       '../host-config': fakeHostConfig,
       './postmessage-json-rpc': fakeJsonRpc,
     });
-    fetchConfig = patched.fetchConfig;
 
     // By default, embedder provides no custom config.
     fakeHostConfig.returns({});
@@ -37,6 +35,10 @@ describe('sidebar.util.fetch-config', () => {
     const fakeParent = { parent: fakeTopWindow, top: fakeTopWindow };
 
     fakeWindow = { parent: fakeParent, top: fakeTopWindow };
+  });
+
+  afterEach(() => {
+    $imports.$restore();
   });
 
   describe('fetchConfig', () => {

--- a/src/sidebar/util/test/is-third-party-service-test.js
+++ b/src/sidebar/util/test/is-third-party-service-test.js
@@ -1,20 +1,23 @@
 'use strict';
 
-const proxyquire = require('proxyquire');
+const isThirdPartyService = require('../is-third-party-service');
 
 describe('sidebar.util.isThirdPartyService', () => {
   let fakeServiceConfig;
   let fakeSettings;
-  let isThirdPartyService;
 
   beforeEach(() => {
     fakeServiceConfig = sinon.stub();
     fakeSettings = { authDomain: 'hypothes.is' };
 
-    isThirdPartyService = proxyquire('../is-third-party-service', {
+    isThirdPartyService.$imports.$mock({
       '../service-config': fakeServiceConfig,
       '@noCallThru': true,
     });
+  });
+
+  afterEach(() => {
+    isThirdPartyService.$imports.$restore();
   });
 
   it('returns false for first-party services', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1554,6 +1554,11 @@ babel-plugin-istanbul@^5.1.0:
     istanbul-lib-instrument "^3.0.0"
     test-exclude "^5.0.0"
 
+babel-plugin-mockable-imports@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-mockable-imports/-/babel-plugin-mockable-imports-1.2.0.tgz#151db640cf6339a6a878a3b70e336eec4baa1895"
+  integrity sha512-KqKIFsPDQcXf2XZZazAxGa7xUgbGueLfCQb4mD7G16lvLYfz13SakC6IAcRaBueXwNn2O0K6VGlXZzPs0aLL3Q==
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"


### PR DESCRIPTION
This PR introduces a new approach to mocking imports in tests using a [Babel plugin](https://github.com/robertknight/babel-plugin-mockable-imports) to replace proxyquire/proxyquireify. 

### Rationale

There are currently a number of pain points with mocking in our JS code. The main one is that because of the way proxyquire works, it can lead to problems that are [pretty confusing to debug](https://robertknight.me.uk/posts/browserify-dependency-mocking/). It is also inefficient because the module under test gets re-evaluated every time `proxyquire` is called. The Babel plugin here transforms the code in a straightforward way which makes mocking work similarly to how `patch` does in Python, with fewer foot-guns and better performance.

A secondary issue is future-proofing. Proxyquire only understands ES5 directly and is tied to Browserify/Node. The Babel plugin added here understands ES6 `import` syntax directly and works regardless of environment. My intention is that if we use it across all of our projects, this will enable us to make other changes that simplify our tooling overall.

Aside from fixing these problems, there are some additional benefits:

- With this plugin an error will be thrown at runtime you if you provide mocks which do not match what a module actually imports - for example if an unused mock is provided or a typo is made in the module name. This found several problems in the code I've converted so far.
- Tests build and run a few seconds faster. Because this uses a Babel plugin, it can work with the already-parsed code, rather than having to re-parse and process the code a second time as proxyquire does.

To see what this plugin does to a module, you can run Babel locally (with this branch checked out, and having run `yarn install`):

```sh
npm install -g @babel/cli
babel --plugins mockable-imports <path to module you are testing>
```

### Usage

Mocking ES6 (`import foo from "bar"`) or Common JS (`const foo = require("bar")`) imports in tests with this plugin works as follows:

- When this plugin is enabled, every module exports an `$imports` object with `$mock` and `$restore` methods
- In a test suite's `beforeEach` or in the test itself, call `$imports.$mock(mocks)` where `mocks` is a mapping from import path to exports. `$mock` can be called multiple times so you can "layer" mocks - eg. have a default mock for a test suite and then override it in a specific test.
- Add an `afterEach` to the test suite which calls `$imports.$restore` to undo mocks.

### Drawbacks

There is one downside to this approach compared to Proxyquire, which also applies when we patch stuff in Python. Because mocking does not re-evaluate the module being tested, you can't use it to change the result of code that is executed when the module is first imported. For example if a module has:

```js
import helper from './utils/helper';

export const aConstant = helper(someData);

export function usesHelper() {
  return helper(someOtherData);
}
```

You could mock `helper` in `usesHelper` but not the initialization of `aConstant`. Based on my experience converting existing uses of Proxyquire, and also our experience of `unittest.mock` in Python (which has the same limitation) my instinct is that this won't be a significant problem, but it will come up at some point. It might actually be a good thing by encouraging side-effect free modules.

### PR notes

The first commit adds the plugin to the test infrastructure. The subsequent commits change existing uses of proxyquire to verify that it works. To keep the PR smaller, I haven't converted everything in this PR or removed proxyquire. That will come in follow-up PRs.

I'd suggest reading the notes above and then looking through commit by commit. I'm happy to split some of the later commits into separate PRs if that makes things easier for review.