### PR TITLE
Open the sidebar when direct-linked group

### DIFF
--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -34,7 +34,7 @@ module.exports = class Sidebar extends Host
 
     this.hide()
 
-    if config.openSidebar || config.annotations || config.query
+    if config.openSidebar || config.annotations || config.query || config.group
       this.on 'panelReady', => this.show()
 
     if @plugins.BucketBar?

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -233,6 +233,58 @@ describe 'Sidebar', ->
         sidebar.onPan({type: 'panright', deltaX: 100})
         assert.equal(sidebar.gestureState.final, 0)
 
+  describe 'panelReady event', ->
+    it 'opens the sidebar when a direct-linked annotation is present.', ->
+      sidebar = createSidebar(
+        config={
+          annotations: 'ann-id',
+        }
+      )
+      show = sandbox.stub(sidebar, 'show')
+      sidebar.publish('panelReady')
+      assert.calledOnce(show)        
+
+    it 'opens the sidebar when a direct-linked group is present.', ->
+      sidebar = createSidebar(
+        config={
+          group: 'group-id',
+        }
+      )
+      show = sandbox.stub(sidebar, 'show')
+      sidebar.publish('panelReady')
+      assert.calledOnce(show)        
+
+    it 'opens the sidebar when a direct-linked query is present.', ->
+      sidebar = createSidebar(
+        config={
+          query: 'tag:foo',
+        }
+      )
+      show = sandbox.stub(sidebar, 'show')
+      sidebar.publish('panelReady')
+      assert.calledOnce(show)        
+
+    it 'opens the sidebar when openSidebar is set to true.', ->
+      sidebar = createSidebar(
+        config={
+          openSidebar: true,
+        }
+      )
+      show = sandbox.stub(sidebar, 'show')
+      sidebar.publish('panelReady')
+      assert.calledOnce(show)        
+
+    it 'does not show the sidebar if not configured to.', ->
+      sidebar = createSidebar(
+        config={
+        }
+      )
+      show = sandbox.stub(sidebar, 'show')
+      sidebar.publish('panelReady')
+      assert.notCalled(show)        
+
+
+
   describe 'swipe gestures', ->
     sidebar = null
 


### PR DESCRIPTION
- [x] open the sidebar when there is a direct-linked group present
- [x] add missing tests for other config options that should also open the sidebar