### PR TITLE
Make group selectors more efficient

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "redux": "^4.0.1",
     "redux-thunk": "^2.1.0",
     "request": "^2.76.0",
+    "reselect": "^4.0.0",
     "retry": "^0.12.0",
     "scroll-into-view": "^1.8.2",
     "seamless-immutable": "^7.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8431,6 +8431,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
 resolve-dir@^1.0.0, resolve-dir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"


### PR DESCRIPTION
Ensure that selectors for getting the "My groups", "Currently viewing
groups" and "Featured groups" lists only recompute when the `groups` part of the application state
changes. Previously they would have recomputed when _any_ part of the state changed.
This will reduce how often the groups list needs to update. [1]

This is achieved using `createSelector` from the [reselect](https://github.com/reduxjs/reselect) library which is the standard tool in the Redux ecosystem for writing selectors that memoize (ie. recompute only when relevant inputs change). More generally `createSelector` is the appropriate tool to use when deriving some data from a subset of data in a larger object. There are a bunch of other selectors we could optimize with this as well, but I haven't done that here.

There are no functional changes so no changes to the existing tests.

[1] For background, I noticed while doing some debugging related to upcoming groups list UI changes that the groups list was being re-rendered/updated more frequently than expected.