### PR TITLE
Use context API to pass Angular services to React components

### DIFF
--- a/src/sidebar/components/group-list-item-out-of-scope.js
+++ b/src/sidebar/components/group-list-item-out-of-scope.js
@@ -9,6 +9,7 @@ const {
   orgName,
   trackViewGroupActivity,
 } = require('../util/group-list-item-common');
+const { withServices } = require('../util/service-context');
 
 const outOfScopeIcon = (
   <svg
@@ -109,4 +110,4 @@ GroupListItemOutOfScope.propTypes = {
 
 GroupListItemOutOfScope.injectedProps = ['analytics'];
 
-module.exports = GroupListItemOutOfScope;
+module.exports = withServices(GroupListItemOutOfScope);

--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -5,6 +5,7 @@ const propTypes = require('prop-types');
 const { createElement } = require('preact');
 
 const { orgName } = require('../util/group-list-item-common');
+const { withServices } = require('../util/service-context');
 
 function GroupListItem({ analytics, group, store }) {
   const focusGroup = () => {
@@ -61,4 +62,4 @@ GroupListItem.propTypes = {
 
 GroupListItem.injectedProps = ['analytics', 'store'];
 
-module.exports = GroupListItem;
+module.exports = withServices(GroupListItem);

--- a/src/sidebar/components/group-list-section.js
+++ b/src/sidebar/components/group-list-section.js
@@ -9,7 +9,7 @@ const GroupListItemOutOfScope = require('./group-list-item-out-of-scope');
 /**
  * A labeled section of the groups list.
  */
-function GroupListSection({ analytics, groups, heading, store }) {
+function GroupListSection({ groups, heading }) {
   const isSelectable = groupId => {
     const group = groups.find(g => g.id === groupId);
     return !group.scopes.enforced || group.isScopedToUri;
@@ -25,17 +25,11 @@ function GroupListSection({ analytics, groups, heading, store }) {
             key={group.id}
           >
             {isSelectable(group.id) ? (
-              <GroupListItem
-                className="group-list-item"
-                group={group}
-                analytics={analytics}
-                store={store}
-              />
+              <GroupListItem className="group-list-item" group={group} />
             ) : (
               <GroupListItemOutOfScope
                 className="group-list-item-out-of-scope"
                 group={group}
-                analytics={analytics}
               />
             )}
           </li>
@@ -50,13 +44,6 @@ GroupListSection.propTypes = {
   groups: propTypes.arrayOf(propTypes.object),
   /* The string name of the group list section. */
   heading: propTypes.string,
-
-  // TODO - These are only used by child components. It shouldn't be necessary
-  // to pass them down manually.
-  analytics: propTypes.object.isRequired,
-  store: propTypes.object.isRequired,
 };
-
-GroupListSection.injectedProps = ['analytics', 'store'];
 
 module.exports = GroupListSection;

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { createElement } = require('preact');
+
 const { mount } = require('enzyme');
 const GroupListItem = require('../group-list-item');
 

--- a/src/sidebar/components/test/group-list-section-test.js
+++ b/src/sidebar/components/test/group-list-section-test.js
@@ -53,11 +53,9 @@ describe('GroupListSection', () => {
             n =>
               n.type() === GroupListItem || n.type() === GroupListItemOutOfScope
           )
-          .map(item => item.type().name);
+          .map(item => item.type());
         const expectedItemTypes = groups.map(g =>
-          expectedIsSelectable[g.id]
-            ? 'GroupListItem'
-            : 'GroupListItemOutOfScope'
+          expectedIsSelectable[g.id] ? GroupListItem : GroupListItemOutOfScope
         );
         assert.deepEqual(itemTypes, expectedItemTypes);
       });

--- a/src/sidebar/util/service-context.js
+++ b/src/sidebar/util/service-context.js
@@ -1,0 +1,89 @@
+'use strict';
+
+/**
+ * This module provides dependency injection of services into React
+ * components via React's "context" API [1].
+ *
+ * It is initially being used to enable React components to depend on Angular
+ * services/values without having to plumb the services through the tree of
+ * components.
+ *
+ * [1] See https://reactjs.org/docs/context.html#api and
+ *     https://reactjs.org/docs/hooks-reference.html#usecontext
+ */
+
+const { useContext } = require('preact/hooks');
+const { createContext, createElement } = require('preact');
+
+const fallbackInjector = {
+  get(service) {
+    throw new Error(
+      `Missing ServiceContext provider to provide "${service}" prop`
+    );
+  },
+};
+
+/**
+ * Context type for a service dependency injector.
+ *
+ * The value should be an object with a `get(serviceName)` method which returns
+ * the instance of the named value or service.
+ *
+ * Consumers will either use this directly via `useContext` or use the
+ * `withServices` wrapper.
+ */
+const ServiceContext = createContext(fallbackInjector);
+
+/**
+ * Wrap a React component to inject any services it depends upon as props.
+ *
+ * Components declare their service dependencies in an `injectedProps` static
+ * property.
+ *
+ * Any props which are passed directly will override injected props.
+ *
+ * @example
+ *   function MyComponent({ settings }) {
+ *     return ...
+ *   }
+ *
+ *   // Declare services that are injected from context rather than passed by
+ *   // the parent.
+ *   MyComponent.injectedProps = ['settings']
+ *
+ *   // Wrap `MyComponent` to inject any passed props.
+ *   module.exports = withServices(MyComponent);
+ */
+function withServices(Component) {
+  if (!Component.injectedProps) {
+    // This component doesn't depend on any services, so there is no need
+    // to wrap it.
+    return Component;
+  }
+
+  function Wrapper(props) {
+    const $injector = useContext(ServiceContext);
+    const services = {};
+    for (let service of Component.injectedProps) {
+      if (!(service in props)) {
+        services[service] = $injector.get(service);
+      }
+    }
+    return <Component {...services} {...props} />;
+  }
+  const wrappedName = Component.displayName || Component.name;
+  Wrapper.displayName = `withServices(${wrappedName})`;
+
+  // Forward the prop types, except for those expected to be injected via
+  // the `ServiceContext`.
+  Wrapper.propTypes = { ...Component.propTypes };
+  Component.injectedProps.forEach(prop => {
+    delete Wrapper.propTypes[prop];
+  });
+  return Wrapper;
+}
+
+module.exports = {
+  ServiceContext,
+  withServices,
+};

--- a/src/sidebar/util/service-context.js
+++ b/src/sidebar/util/service-context.js
@@ -38,7 +38,7 @@ const ServiceContext = createContext(fallbackInjector);
  * Wrap a React component to inject any services it depends upon as props.
  *
  * Components declare their service dependencies in an `injectedProps` static
- * property.
+ * property. These services also need to be declared in `propTypes`.
  *
  * Any props which are passed directly will override injected props.
  *
@@ -51,7 +51,7 @@ const ServiceContext = createContext(fallbackInjector);
  *   // the parent.
  *   MyComponent.injectedProps = ['settings']
  *
- *   // Wrap `MyComponent` to inject any passed props.
+ *   // Wrap `MyComponent` to inject any services it needs.
  *   module.exports = withServices(MyComponent);
  */
 function withServices(Component) {
@@ -62,7 +62,12 @@ function withServices(Component) {
   }
 
   function Wrapper(props) {
+    // Get the current dependency injector instance that is provided by a
+    // `ServiceContext.Provider` somewhere higher up the component tree.
     const $injector = useContext(ServiceContext);
+
+    // Inject services, unless they have been overridden by props passed from
+    // the parent component.
     const services = {};
     for (let service of Component.injectedProps) {
       if (!(service in props)) {
@@ -71,6 +76,9 @@ function withServices(Component) {
     }
     return <Component {...services} {...props} />;
   }
+
+  // Set the name of the wrapper for use in debug tools and queries in Enzyme
+  // tests.
   const wrappedName = Component.displayName || Component.name;
   Wrapper.displayName = `withServices(${wrappedName})`;
 

--- a/src/sidebar/util/test/service-context-test.js
+++ b/src/sidebar/util/test/service-context-test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const propTypes = require('prop-types');
+const { createElement, render } = require('preact');
+
+const { ServiceContext, withServices } = require('../service-context');
+
+describe('service-context', () => {
+  describe('withServices', () => {
+    let container;
+    let lastProps;
+
+    function TestComponent(props) {
+      lastProps = props;
+    }
+    TestComponent.injectedProps = ['aService'];
+    const WrappedComponent = withServices(TestComponent);
+
+    beforeEach(() => {
+      lastProps = null;
+      container = document.createElement('div');
+    });
+
+    it('returns the input component if there are no service dependencies', () => {
+      function TestComponent() {}
+      assert.equal(withServices(TestComponent), TestComponent);
+    });
+
+    it('looks up services that a Component depends on and injects them as props', () => {
+      const testService = {};
+      const injector = {
+        get: sinon.stub().returns(testService),
+      };
+      render(
+        <ServiceContext.Provider value={injector}>
+          <WrappedComponent />
+        </ServiceContext.Provider>,
+        container
+      );
+      assert.deepEqual(lastProps, { aService: testService });
+      assert.calledWith(injector.get, 'aService');
+    });
+
+    it('copies propTypes except for injected properties to wrapper', () => {
+      function TestComponent() {}
+      TestComponent.propTypes = {
+        notInjected: propTypes.string,
+        injected: propTypes.string,
+      };
+      TestComponent.injectedProps = ['injected'];
+
+      const Wrapped = withServices(TestComponent);
+
+      assert.deepEqual(Wrapped.propTypes, { notInjected: propTypes.string });
+      assert.isUndefined(Wrapped.injectedProps);
+    });
+
+    it('does not look up services if they are passed as props', () => {
+      const testService = {};
+      const injector = {
+        get: sinon.stub(),
+      };
+      render(
+        <ServiceContext.Provider value={injector}>
+          <WrappedComponent aService={testService} />
+        </ServiceContext.Provider>,
+        container
+      );
+      assert.notCalled(injector.get);
+    });
+
+    it('throws if injector is not available', () => {
+      assert.throws(() => {
+        render(<WrappedComponent />, container);
+      }, /Missing ServiceContext/);
+    });
+  });
+});

--- a/src/sidebar/util/wrap-react-component.js
+++ b/src/sidebar/util/wrap-react-component.js
@@ -20,8 +20,7 @@ class ReactController {
     this.domElement = $element[0];
 
     /**
-     * The Angular service injector, used by this component and possibly
-     * children as well.
+     * The Angular service injector, used by this component and its descendants.
      */
     this.$injector = $injector;
 
@@ -119,6 +118,10 @@ function wrapReactComponent(type) {
     );
   }
 
+  /**
+   * Create an AngularJS component controller that renders the specific React
+   * component being wrapped.
+   */
   // @ngInject
   function createController($element, $injector, $scope) {
     return new ReactController($element, $injector, $scope, type);

--- a/src/sidebar/util/wrap-react-component.js
+++ b/src/sidebar/util/wrap-react-component.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { createElement, render } = require('preact');
+const { ServiceContext } = require('./service-context');
 
 function useExpressionBinding(propName) {
   return propName.match(/^on[A-Z]/);
@@ -14,15 +15,21 @@ function useExpressionBinding(propName) {
  * has been created.
  */
 class ReactController {
-  constructor($element, $scope, injectedProps, type) {
+  constructor($element, $injector, $scope, type) {
     /** The DOM element where the React component should be rendered. */
     this.domElement = $element[0];
+
+    /**
+     * The Angular service injector, used by this component and possibly
+     * children as well.
+     */
+    this.$injector = $injector;
 
     /** The React component function or class. */
     this.type = type;
 
     /** The input props to the React component. */
-    this.props = injectedProps;
+    this.props = {};
 
     // Wrap callback properties (eg. `onClick`) with `$scope.$apply` to trigger
     // a digest cycle after the function is called. This ensures that the
@@ -49,11 +56,9 @@ class ReactController {
   $onInit() {
     // Copy properties supplied by the parent Angular component to React props.
     Object.keys(this.type.propTypes).forEach(propName => {
-      if (propName in this.props) {
-        // Skip properties already handled in the constructor.
-        return;
+      if (!useExpressionBinding(propName)) {
+        this.props[propName] = this[propName];
       }
-      this.props[propName] = this[propName];
     });
     this.updateReactComponent();
   }
@@ -77,16 +82,16 @@ class ReactController {
   }
 
   updateReactComponent() {
-    render(createElement(this.type, this.props), this.domElement);
+    // Render component, with a `ServiceContext.Provider` wrapper which
+    // provides access to Angular services via `withServices` or `useContext`
+    // in child components.
+    render(
+      <ServiceContext.Provider value={this.$injector}>
+        <this.type {...this.props} />
+      </ServiceContext.Provider>,
+      this.domElement
+    );
   }
-}
-
-function objectWithKeysAndValues(keys, values) {
-  const obj = {};
-  for (let i = 0; i < keys.length; i++) {
-    obj[keys[i]] = values[i];
-  }
-  return obj;
 }
 
 /**
@@ -98,25 +103,8 @@ function objectWithKeysAndValues(keys, values) {
  * one-way ('<') bindings except for those with names matching /^on[A-Z]/ which
  * are assumed to be callbacks that use expression ('&') bindings.
  *
- * If the React component needs access to an Angular service, the service
- * should be added to `propTypes` and the name listed in an `injectedProps`
- * array:
- *
- * @example
- *   // In `MyComponent.js`:
- *   function MyComponent({ theme }) {
- *     return <div>You are using the {theme} theme</div>
- *   }
- *   MyComponent.propTypes = {
- *     theme: propTypes.string,
- *   }
- *   MyComponent.injectedProps = ['theme'];
- *
- *   // In the Angular bootstrap code:
- *   angular
- *     .module(...)
- *     .component('my-component', wrapReactComponent(MyComponent))
- *     .value('theme', 'dark');
+ * If the React component needs access to an Angular service, it can get at
+ * them using the `withServices` wrapper from service-context.js.
  *
  * @param {Function} type - The React component class or function
  * @return {Object} -
@@ -131,30 +119,19 @@ function wrapReactComponent(type) {
     );
   }
 
-  // Create controller.
-  const injectedPropNames = type.injectedProps || [];
-  class Controller extends ReactController {
-    constructor($element, $scope, ...injectedPropValues) {
-      const injectedProps = objectWithKeysAndValues(
-        injectedPropNames,
-        injectedPropValues
-      );
-      super($element, $scope, injectedProps, type);
-    }
+  // @ngInject
+  function createController($element, $injector, $scope) {
+    return new ReactController($element, $injector, $scope, type);
   }
-  Controller.$inject = ['$element', '$scope', ...injectedPropNames];
 
-  // Create bindings object.
   const bindings = {};
-  Object.keys(type.propTypes)
-    .filter(name => !injectedPropNames.includes(name))
-    .forEach(propName => {
-      bindings[propName] = useExpressionBinding(propName) ? '&' : '<';
-    });
+  Object.keys(type.propTypes).forEach(propName => {
+    bindings[propName] = useExpressionBinding(propName) ? '&' : '<';
+  });
 
   return {
     bindings,
-    controller: Controller,
+    controller: createController,
   };
 }
 


### PR DESCRIPTION
This PR changes the way Angular services (and utilities) are passed to React/Preact components. It addresses two problems:

1. Currently services can only be injected into React components that are directly rendered by `wrapReactComponent`. Children further down in the tree can only get at them if they are passed along by the parent, which requires the parent to know about and forward services that it doesn't use.
2. When we complete the migration, we are still going to have some concept of services, global configuration etc. that React components are going to want to get at, without requiring all parents to pass them along.

The standard pattern to address (2) in a React app is using the [context API](https://reactjs.org/docs/context.html), so with that in mind, I've refactored the way service-passing works to use context. It works as follows:

1. `wrapReactComponent` creates a context "provider" at the root of the React tree it renders, which makes Angular's dependency injector (`$injector`) available to descendants. 
2. React components can get a reference to a service either using 1) `const services = useContext(ServiceContext); services.get(<service name>)` or, more commonly, 2) by using the `withServices` wrapper component which looks up services and passes them along as props. The second method is preferred because it makes writing tests easier - the test can just pass the fake service along as a prop.