### PR TITLE
Remove fragment anchoring support

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "diff": "^4.0.1",
     "diff-match-patch": "^1.0.0",
     "document-base-uri": "^1.0.0",
-    "dom-anchor-fragment": "^1.0.1",
     "dom-anchor-text-position": "^4.0.0",
     "dom-anchor-text-quote": "^4.0.2",
     "dom-node-iterator": "^3.5.3",
@@ -138,7 +137,6 @@
     ]
   },
   "browser": {
-    "dom-anchor-fragment": "./node_modules/dom-anchor-fragment/dist/FragmentAnchor.js",
     "hammerjs": "./node_modules/hammerjs/hammer.js",
     "jquery": "./node_modules/jquery/dist/jquery.slim.js"
   },

--- a/src/annotator/anchoring/html.coffee
+++ b/src/annotator/anchoring/html.coffee
@@ -1,5 +1,4 @@
 {
-  FragmentAnchor
   RangeAnchor
   TextPositionAnchor
   TextQuoteAnchor
@@ -40,8 +39,6 @@ exports.anchor = (root, selectors, options = {}) ->
   # Collect all the selectors
   for selector in selectors ? []
     switch selector.type
-      when 'FragmentSelector'
-        fragment = selector
       when 'TextPositionSelector'
         position = selector
         options.hint = position.start  # TextQuoteAnchor hint
@@ -60,11 +57,6 @@ exports.anchor = (root, selectors, options = {}) ->
   # From a default of failure, we build up catch clauses to try selectors in
   # order, from simple to complex.
   promise = Promise.reject('unable to anchor')
-
-  if fragment?
-    promise = promise.catch ->
-      return querySelector(FragmentAnchor, root, fragment, options)
-      .then(maybeAssertQuote)
 
   if range?
     promise = promise.catch ->
@@ -85,7 +77,7 @@ exports.anchor = (root, selectors, options = {}) ->
 
 
 exports.describe = (root, range, options = {}) ->
-  types = [FragmentAnchor, RangeAnchor, TextPositionAnchor, TextQuoteAnchor]
+  types = [RangeAnchor, TextPositionAnchor, TextQuoteAnchor]
 
   selectors = for type in types
     try

--- a/src/annotator/anchoring/test/html-baselines/wikipedia-regression-testing.json
+++ b/src/annotator/anchoring/test/html-baselines/wikipedia-regression-testing.json
@@ -13,11 +13,6 @@
                "source" : "https://en.wikipedia.org/wiki/Regression_testing",
                "selector" : [
                   {
-                     "conformsTo" : "https://tools.ietf.org/html/rfc3236",
-                     "value" : "footer-info-lastmod",
-                     "type" : "FragmentSelector"
-                  },
-                  {
                      "endOffset" : 48,
                      "endContainer" : "/div[5]/ul[1]/li[1]",
                      "startOffset" : 32,
@@ -96,11 +91,6 @@
                "source" : "https://en.wikipedia.org/wiki/Regression_testing",
                "selector" : [
                   {
-                     "type" : "FragmentSelector",
-                     "conformsTo" : "https://tools.ietf.org/html/rfc3236",
-                     "value" : "mw-content-text"
-                  },
-                  {
                      "endContainer" : "/div[3]/div[3]/div[4]/p[8]",
                      "startContainer" : "/div[3]/div[3]/div[4]/p[8]",
                      "startOffset" : 0,
@@ -162,11 +152,6 @@
             {
                "selector" : [
                   {
-                     "value" : "mw-content-text",
-                     "conformsTo" : "https://tools.ietf.org/html/rfc3236",
-                     "type" : "FragmentSelector"
-                  },
-                  {
                      "endOffset" : 156,
                      "endContainer" : "/div[3]/div[3]/div[4]/blockquote[1]/p[1]",
                      "type" : "RangeSelector",
@@ -199,11 +184,6 @@
          "target" : [
             {
                "selector" : [
-                  {
-                     "value" : "mw-content-text",
-                     "conformsTo" : "https://tools.ietf.org/html/rfc3236",
-                     "type" : "FragmentSelector"
-                  },
                   {
                      "endOffset" : 120,
                      "startContainer" : "/div[3]/div[3]/div[4]/p[2]",
@@ -259,11 +239,6 @@
          "target" : [
             {
                "selector" : [
-                  {
-                     "type" : "FragmentSelector",
-                     "value" : "firstHeading",
-                     "conformsTo" : "https://tools.ietf.org/html/rfc3236"
-                  },
                   {
                      "endOffset" : 18,
                      "endContainer" : "/div[3]/h1[1]",

--- a/src/annotator/anchoring/types.coffee
+++ b/src/annotator/anchoring/types.coffee
@@ -122,6 +122,5 @@ class TextQuoteAnchor
 
 
 exports.RangeAnchor = RangeAnchor
-exports.FragmentAnchor = require('dom-anchor-fragment')
 exports.TextPositionAnchor = TextPositionAnchor
 exports.TextQuoteAnchor = TextQuoteAnchor

--- a/yarn.lock
+++ b/yarn.lock
@@ -3308,11 +3308,6 @@ document-base-uri@^1.0.0:
   resolved "https://registry.yarnpkg.com/document-base-uri/-/document-base-uri-1.0.0.tgz#88013e6ee6aa210f1a991953149f3a1698e1e661"
   integrity sha1-iAE+buaqIQ8amRlTFJ86Fpjh5mE=
 
-dom-anchor-fragment@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/dom-anchor-fragment/-/dom-anchor-fragment-1.0.4.tgz#43c9d0596e29dcfda520f4b1d1c1702efc9cdf06"
-  integrity sha1-Q8nQWW4p3P2lIPSx0cFwLvyc3wY=
-
 dom-anchor-text-position@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dom-anchor-text-position/-/dom-anchor-text-position-4.0.0.tgz#4c839b3bded94f0cab0f06a0189468f3f1ec2bb2"


### PR DESCRIPTION
_(For context on why this issue came up now, see this [Slack support issue](https://hypothes-is.slack.com/archives/C1EQELNMS/p1555520595003600))_

dom-anchor-fragment is shipped as a UMD module which causes problems on
pages that declare a global function called `define` (see #479).

While we could fix the module, fragment anchoring is not very useful at
the moment. The client primarily anchors to the quote and uses other
anchors only as an optimization. The Wikipedia baseline tests changed in
this PR show how little value a fragment has on real websites.
Therefore, just remove support for generating and using fragment selectors.

This change should not cause anchoring regressions, as anchoring would
only have succeeded previously if the quote selector matched. Now it will just
fall through to anchoring using the range, position or quote selectors instead.

Fixes #479

----

**Testing**

1. Go to https://www.fulcrum.org/concern/monographs/dj52w5765?locale=en and try to activate the prod boomarklet or extension. It should fail to load.
2. Go to https://www.fulcrum.org/concern/monographs/dj52w5765?locale=en and activate a bookmarklet / extension from this branch. It should load. Note that you will either need to serve the dev client over HTTPS or disable your browser's mixed-content blocking.