### PR TITLE
Convert mocking to mockable-imports (2/4)

### DIFF
--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -1,23 +1,22 @@
 'use strict';
 
-const proxyquire = require('proxyquire');
-const util = require('../../../shared/test/util');
-
-const fakeSettingsFrom = sinon.stub();
-
-const configFrom = proxyquire(
-  '../index',
-  util.noCallThru({
-    './settings': fakeSettingsFrom,
-  })
-);
+const configFrom = require('../index');
 
 describe('annotator.config.index', function() {
-  beforeEach('reset fakeSettingsFrom', function() {
-    fakeSettingsFrom.reset();
-    fakeSettingsFrom.returns({
+  let fakeSettingsFrom;
+
+  beforeEach(() => {
+    fakeSettingsFrom = sinon.stub().returns({
       hostPageSetting: sinon.stub(),
     });
+
+    configFrom.$imports.$mock({
+      './settings': fakeSettingsFrom,
+    });
+  });
+
+  afterEach(() => {
+    configFrom.$imports.$restore();
   });
 
   it('gets the configuration settings', function() {

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -1,34 +1,28 @@
 'use strict';
 
-const proxyquire = require('proxyquire');
-const util = require('../../../shared/test/util');
-
-const fakeConfigFuncSettingsFrom = sinon.stub();
-const fakeIsBrowserExtension = sinon.stub();
-const fakeSharedSettings = {};
-
-const settingsFrom = proxyquire(
-  '../settings',
-  util.noCallThru({
-    './config-func-settings-from': fakeConfigFuncSettingsFrom,
-    './is-browser-extension': fakeIsBrowserExtension,
-    '../../shared/settings': fakeSharedSettings,
-  })
-);
+const settingsFrom = require('../settings');
 
 describe('annotator.config.settingsFrom', function() {
-  beforeEach('reset fakeConfigFuncSettingsFrom', function() {
-    fakeConfigFuncSettingsFrom.reset();
-    fakeConfigFuncSettingsFrom.returns({});
+  let fakeConfigFuncSettingsFrom;
+  let fakeIsBrowserExtension;
+  let fakeSharedSettings;
+
+  beforeEach(() => {
+    fakeConfigFuncSettingsFrom = sinon.stub().returns({});
+    fakeIsBrowserExtension = sinon.stub().returns(false);
+    fakeSharedSettings = {
+      jsonConfigsFrom: sinon.stub().returns({}),
+    };
+
+    settingsFrom.$imports.$mock({
+      './config-func-settings-from': fakeConfigFuncSettingsFrom,
+      './is-browser-extension': fakeIsBrowserExtension,
+      '../../shared/settings': fakeSharedSettings,
+    });
   });
 
-  beforeEach('reset fakeIsBrowserExtension', function() {
-    fakeIsBrowserExtension.reset();
-    fakeIsBrowserExtension.returns(false);
-  });
-
-  beforeEach('reset fakeSharedSettings', function() {
-    fakeSharedSettings.jsonConfigsFrom = sinon.stub().returns({});
+  afterEach(() => {
+    settingsFrom.$imports.$restore();
   });
 
   describe('#sidebarAppUrl', function() {

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -1,13 +1,12 @@
 'use strict';
 
-const proxyquire = require('proxyquire');
+const boot = require('../boot');
 
 function assetUrl(url) {
   return `https://marginal.ly/client/build/${url}`;
 }
 
 describe('bootstrap', function() {
-  let boot;
   let fakePolyfills;
   let iframe;
 
@@ -19,12 +18,13 @@ describe('bootstrap', function() {
       requiredPolyfillSets: sinon.stub().returns([]),
     };
 
-    boot = proxyquire('../boot', {
+    boot.$imports.$mock({
       '../shared/polyfills': fakePolyfills,
     });
   });
 
   afterEach(function() {
+    boot.$imports.$restore();
     iframe.remove();
   });
 

--- a/src/shared/test/util.js
+++ b/src/shared/test/util.js
@@ -1,28 +1,6 @@
 'use strict';
 
 /**
- * Utility function for use with 'proxyquire' that prevents calls to
- * stubs 'calling through' to the _original_ dependency if a particular
- * function or property is not set on a stub, which is proxyquire's default
- * but usually undesired behavior.
- *
- * See https://github.com/thlorenz/proxyquireify#nocallthru
- *
- * Usage:
- *   var moduleUnderTest = proxyquire('./module-under-test', noCallThru({
- *     './dependency-foo': fakeFoo,
- *   }));
- *
- * @param {Object} stubs - A map of dependency paths to stubs, or a single
- *   stub.
- */
-function noCallThru(stubs) {
-  // This function is trivial but serves as documentation for why
-  // '@noCallThru' is used.
-  return Object.assign(stubs, { '@noCallThru': true });
-}
-
-/**
  * Helper for writing parameterized tests.
  *
  * This is a wrapper around the `it()` function for creating a Mocha test case
@@ -79,6 +57,5 @@ function unroll(description, testFn, fixtures) {
 }
 
 module.exports = {
-  noCallThru: noCallThru,
   unroll: unroll,
 };

--- a/src/sidebar/components/test/annotation-header-test.js
+++ b/src/sidebar/components/test/annotation-header-test.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const angular = require('angular');
-const proxyquire = require('proxyquire');
 
 const fixtures = require('../../test/annotation-fixtures');
+const annotationHeader = require('../annotation-header');
 
 const fakeDocumentMeta = {
   domain: 'docs.io',
@@ -27,7 +27,7 @@ describe('sidebar.components.annotation-header', function() {
   });
 
   beforeEach('Import and register the annotationHeader component', function() {
-    const annotationHeader = proxyquire('../annotation-header', {
+    annotationHeader.$imports.$mock({
       '../annotation-metadata': {
         // eslint-disable-next-line no-unused-vars
         domainAndTitle: function(ann) {
@@ -35,10 +35,12 @@ describe('sidebar.components.annotation-header', function() {
         },
       },
       '../util/account-id': fakeAccountID,
-      '@noCallThru': true,
     });
-
     angular.module('app', []).component('annotationHeader', annotationHeader);
+  });
+
+  afterEach(() => {
+    annotationHeader.$imports.$restore();
   });
 
   beforeEach('Initialize and register fake AngularJS dependencies', function() {

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const angular = require('angular');
-const proxyquire = require('proxyquire');
 
 const events = require('../../events');
 const fixtures = require('../../test/annotation-fixtures');
 const testUtil = require('../../../shared/test/util');
 const util = require('../../directive/test/util');
+
+const annotationComponent = require('../annotation');
 
 const inject = angular.mock.inject;
 const unroll = testUtil.unroll;
@@ -100,9 +101,6 @@ describe('annotation', function() {
     let $scope;
     let $timeout;
     let $window;
-    // Unfortunately fakeAccountID needs to be initialised here because it
-    // gets passed into proxyquire() _before_ the beforeEach() that initializes
-    // the rest of the fakes runs.
     const fakeAccountID = {
       isThirdPartyUser: sinon.stub(),
     };
@@ -120,16 +118,15 @@ describe('annotation', function() {
     let fakeStreamer;
     let sandbox;
 
-    /**
-     * Returns the annotation directive with helpers stubbed out.
-     */
-    function annotationComponent() {
-      return proxyquire('../annotation', {
-        angular: testUtil.noCallThru(angular),
+    beforeEach(() => {
+      annotationComponent.$imports.$mock({
         '../util/account-id': fakeAccountID,
-        '@noCallThru': true,
       });
-    }
+    });
+
+    afterEach(() => {
+      annotationComponent.$imports.$restore();
+    });
 
     function createDirective(annotation) {
       annotation = annotation || fixtures.defaultAnnotation();
@@ -153,7 +150,7 @@ describe('annotation', function() {
     before(function() {
       angular
         .module('h', [])
-        .component('annotation', annotationComponent())
+        .component('annotation', annotationComponent)
         .component('annotationActionButton', {
           bindings: {
             icon: '<',

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -1,11 +1,10 @@
 'use strict';
 
 const angular = require('angular');
-const proxyquire = require('proxyquire');
 const EventEmitter = require('tiny-emitter');
 
 const events = require('../../events');
-const noCallThru = require('../../../shared/test/util').noCallThru;
+const sidebarContent = require('../sidebar-content');
 const uiConstants = require('../../ui-constants');
 
 let searchClients;
@@ -64,21 +63,12 @@ describe('sidebar.components.sidebar-content', function() {
     angular
       .module('h', [])
       .service('store', require('../../store'))
-      .component(
-        'sidebarContent',
-        proxyquire(
-          '../sidebar-content',
-          noCallThru({
-            angular: angular,
-            '../search-client': FakeSearchClient,
-          })
-        )
-      );
+      .component('sidebarContent', sidebarContent);
   });
 
   beforeEach(angular.mock.module('h'));
 
-  beforeEach(
+  beforeEach(() => {
     angular.mock.module(function($provide) {
       searchClients = [];
       sandbox = sinon.sandbox.create();
@@ -142,8 +132,16 @@ describe('sidebar.components.sidebar-content', function() {
       $provide.value('streamFilter', fakeStreamFilter);
       $provide.value('groups', fakeGroups);
       $provide.value('settings', fakeSettings);
-    })
-  );
+    });
+
+    sidebarContent.$imports.$mock({
+      '../search-client': FakeSearchClient,
+    });
+  });
+
+  afterEach(() => {
+    sidebarContent.$imports.$restore();
+  });
 
   function setFrames(frames) {
     frames.forEach(function(frame) {

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -1,13 +1,14 @@
 'use strict';
 
 const angular = require('angular');
-const proxyquire = require('proxyquire');
 const immutable = require('seamless-immutable');
 
 const annotationFixtures = require('../../test/annotation-fixtures');
 const events = require('../../events');
 const uiConstants = require('../../ui-constants');
 const util = require('../../../shared/test/util');
+
+const rootThreadFactory = require('../root-thread');
 
 const unroll = util.unroll;
 
@@ -84,12 +85,7 @@ describe('rootThread', function() {
       .value('drafts', fakeDrafts)
       .value('searchFilter', fakeSearchFilter)
       .value('viewFilter', fakeViewFilter)
-      .service(
-        'rootThread',
-        proxyquire('../root-thread', {
-          '../build-thread': util.noCallThru(fakeBuildThread),
-        })
-      );
+      .service('rootThread', rootThreadFactory);
 
     angular.mock.module('app');
 
@@ -97,6 +93,16 @@ describe('rootThread', function() {
       $rootScope = _$rootScope_;
       rootThread = _rootThread_;
     });
+  });
+
+  beforeEach(() => {
+    rootThreadFactory.$imports.$mock({
+      '../build-thread': fakeBuildThread,
+    });
+  });
+
+  afterEach(() => {
+    rootThreadFactory.$imports.$restore();
   });
 
   describe('#thread', function() {

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const EventEmitter = require('tiny-emitter');
-const proxyquire = require('proxyquire');
 
 const events = require('../../events');
 const unroll = require('../../../shared/test/util').unroll;
+
+const Streamer = require('../streamer');
 
 const fixtures = {
   createNotification: {
@@ -82,7 +83,6 @@ describe('Streamer', function() {
   let fakeSession;
   let fakeSettings;
   let activeStreamer;
-  let Streamer;
 
   function createDefaultStreamer() {
     activeStreamer = new Streamer(
@@ -143,12 +143,13 @@ describe('Streamer', function() {
       websocketUrl: 'ws://example.com/ws',
     };
 
-    Streamer = proxyquire('../streamer', {
+    Streamer.$imports.$mock({
       '../websocket': FakeSocket,
     });
   });
 
   afterEach(function() {
+    Streamer.$imports.$restore();
     activeStreamer = null;
   });
 


### PR DESCRIPTION
This is a follow-up to https://github.com/hypothesis/client/pull/1061 which converts remaining uses of proxyquire in .js files to use `$imports.$mock` instead - see earlier PR for a detailed explanation.

What remains to do after this is convert uses in .coffee files and remove proxyquire as a dependency.