### PR TITLE
Convert mocking to mockable imports (3/4)

### DIFF
--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -7,6 +7,7 @@ Delegator = require('./delegator')
 $ = require('jquery')
 
 adder = require('./adder')
+htmlAnchoring = require('./anchoring/html')
 highlighter = require('./highlighter')
 rangeUtil = require('./range-util')
 selections = require('./selections')
@@ -37,7 +38,7 @@ module.exports = class Guest extends Delegator
     TextSelection: {}
 
   # Anchoring module
-  anchoring: require('./anchoring/html')
+  anchoring: htmlAnchoring
 
   # Internal state
   plugins: null

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -38,7 +38,7 @@ module.exports = class Guest extends Delegator
     TextSelection: {}
 
   # Anchoring module
-  anchoring: htmlAnchoring
+  anchoring: null
 
   # Internal state
   plugins: null
@@ -49,7 +49,7 @@ module.exports = class Guest extends Delegator
   html:
     adder: '<hypothesis-adder></hypothesis-adder>'
 
-  constructor: (element, config) ->
+  constructor: (element, config, anchoring = htmlAnchoring) ->
     super
 
     this.adder = $(this.html.adder).appendTo(@element).hide()
@@ -77,6 +77,8 @@ module.exports = class Guest extends Delegator
     # Set the frame identifier if it's available.
     # The "top" guest instance will have this as null since it's in a top frame not a sub frame
     this.frameIdentifier = config.subFrameIdentifier || null
+
+    this.anchoring = anchoring
 
     cfOptions =
       config: config

--- a/src/annotator/plugin/test/cross-frame-test.coffee
+++ b/src/annotator/plugin/test/cross-frame-test.coffee
@@ -1,7 +1,5 @@
-proxyquire = require('proxyquire')
-
 Plugin = require('../../plugin')
-CrossFrame = null
+CrossFrame = require('../cross-frame')
 
 describe 'CrossFrame', ->
   fakeDiscovery = null
@@ -41,16 +39,16 @@ describe 'CrossFrame', ->
     proxyDiscovery = sandbox.stub().returns(fakeDiscovery)
     proxyBridge = sandbox.stub().returns(fakeBridge)
 
-    CrossFrame = proxyquire('../cross-frame', {
+    CrossFrame.$imports.$mock({
       '../plugin': Plugin,
       '../annotation-sync': proxyAnnotationSync,
       '../../shared/bridge': proxyBridge,
       '../../shared/discovery': proxyDiscovery
     })
 
-
   afterEach ->
     sandbox.restore()
+    CrossFrame.$imports.$restore()
 
   describe 'CrossFrame constructor', ->
     it 'instantiates the Discovery component', ->

--- a/src/annotator/test/guest-test.coffee
+++ b/src/annotator/test/guest-test.coffee
@@ -54,7 +54,6 @@ describe 'Guest', ->
     config = Object.assign({}, guestConfig, config)
     element = document.createElement('div')
     guest = new Guest(element, config)
-    guest.anchoring = htmlAnchoring
     return guest
 
   beforeEach ->
@@ -77,6 +76,7 @@ describe 'Guest', ->
 
     Guest.$imports.$mock({
       './adder': {Adder: FakeAdder},
+      './anchoring/html': htmlAnchoring,
       './highlighter': highlighter,
       './range-util': rangeUtil,
       './selections': (document) ->

--- a/src/annotator/test/host-test.coffee
+++ b/src/annotator/test/host-test.coffee
@@ -1,5 +1,4 @@
-proxyquire = require('proxyquire')
-Host = proxyquire('../host', {})
+Host = require('../host')
 
 describe 'Host', ->
   sandbox = sinon.sandbox.create()

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const proxyquire = require('proxyquire');
 const isLoaded = require('../../util/frame-util').isLoaded;
 
 const FRAME_DEBOUNCE_WAIT = require('../../frame-observer').DEBOUNCE_WAIT + 10;
+const CrossFrame = require('../../plugin/cross-frame');
 
 describe('CrossFrame multi-frame scenario', function() {
   let fakeAnnotationSync;
@@ -30,7 +30,7 @@ describe('CrossFrame multi-frame scenario', function() {
     proxyAnnotationSync = sandbox.stub().returns(fakeAnnotationSync);
     proxyBridge = sandbox.stub().returns(fakeBridge);
 
-    const CrossFrame = proxyquire('../../plugin/cross-frame', {
+    CrossFrame.$imports.$mock({
       '../annotation-sync': proxyAnnotationSync,
       '../../shared/bridge': proxyBridge,
     });
@@ -53,6 +53,8 @@ describe('CrossFrame multi-frame scenario', function() {
     sandbox.restore();
     crossFrame.destroy();
     container.parentNode.removeChild(container);
+
+    CrossFrame.$imports.$restore();
   });
 
   it('detects frames on page', function() {

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -1,11 +1,6 @@
 events = require('../../shared/bridge-events')
 
-proxyquire = require('proxyquire')
-
-rafStub = (fn) ->
-  fn()
-
-Sidebar = proxyquire('../sidebar', { raf: rafStub })
+Sidebar = require('../sidebar')
 
 DEFAULT_WIDTH = 350
 DEFAULT_HEIGHT = 600
@@ -16,6 +11,14 @@ describe 'Sidebar', ->
   CrossFrame = null
   fakeCrossFrame = null
   sidebarConfig = {pluginClasses: {}}
+
+  before ->
+    rafStub = (fn) ->
+      fn()
+    Sidebar.$imports.$mock({ raf: rafStub })
+
+  after ->
+    Sidebar.$imports.$restore()
 
   createSidebar = (config={}) ->
     config = Object.assign({}, sidebarConfig, config)


### PR DESCRIPTION
This is a follow-up to #1061 which converts remaining uses of proxyquire in .coffee files to use $imports.$mock instead - see earlier PR for a detailed explanation.

After this PR and https://github.com/hypothesis/client/pull/1085 are merged, the final PR will remove proxyquire as a dependency.