### PR TITLE
Fix bug where direct linked group is duplicated

### DIFF
--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -213,9 +213,11 @@ function groups(
         }
         return Promise.all(groupApiRequests).then(
           ([myGroups, featuredGroups, token, selectedGroup]) => [
+            // Don't add the selectedGroup if it's already in the featuredGroups.
             combineGroups(
               myGroups,
-              selectedGroup !== undefined
+              selectedGroup !== undefined &&
+                !featuredGroups.some(g => g.id === selectedGroup.id)
                 ? featuredGroups.concat([selectedGroup])
                 : featuredGroups,
               documentUri

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -230,6 +230,25 @@ describe('groups', function() {
       });
     });
 
+    // TODO: Add a de-dup test for the direct-linked annotation.
+
+    it('does not duplicate groups if the direct-linked group is also a featured group', () => {
+      const svc = service();
+
+      // Set the direct-linked group to dummyGroups[0].
+      fakeSettings.group = dummyGroups[0].id;
+      fakeApi.group.read.returns(Promise.resolve(dummyGroups[0]));
+
+      // Include the dummyGroups[0] in the featured groups.
+      fakeApi.profile.groups.read.returns(Promise.resolve([]));
+      fakeApi.groups.list.returns(Promise.resolve([dummyGroups[0]]));
+
+      return svc.load().then(groups => {
+        const groupIds = groups.map(g => g.id);
+        assert.deepEqual(groupIds, [fakeSettings.group]);
+      });
+    });
+
     it('combines groups from all 3 endpoints if there is a selectedGroup', () => {
       const svc = service();
 

--- a/src/sidebar/util/groups.js
+++ b/src/sidebar/util/groups.js
@@ -5,11 +5,11 @@ const escapeStringRegexp = require('escape-string-regexp');
 /**
  * Combine groups from multiple api calls together to form a unique list of groups.
  * Add an isMember property to each group indicating whether the logged in user is a member.
- * Add an isScopedToUri property to each group indicating whether the group can be annotated
- *   in based on group scoping and the uri of the current page.
+ * Add an isScopedToUri property to each group indicating whether the uri matches the group's
+ *   uri patterns. If no uri patterns are specified, defaults to True.
  *
  * @param {Group[]} userGroups - groups the user is a member of
- * @param {Group[]} featuredGroups - groups scoped to the particular uri, authority, and user
+ * @param {Group[]} featuredGroups - all other groups, may include some duplicates from the userGroups
  * @param {string} uri - uri of the current page
  */
 function combineGroups(userGroups, featuredGroups, uri) {


### PR DESCRIPTION
Do not add the direct-linked group to featuredGroups if it is already
present. This happens when a group is direct-linked to but the group
is already scoped to the page so the direct-linked group shows up twice.