### PR TITLE
Use same direct-linked group error when logged-in

### DIFF
--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -6,6 +6,7 @@ const EventEmitter = require('tiny-emitter');
 const events = require('../../events');
 const sidebarContent = require('../sidebar-content');
 const uiConstants = require('../../ui-constants');
+const util = require('../../directive/test/util');
 
 let searchClients;
 
@@ -146,6 +147,19 @@ describe('sidebar.components.sidebar-content', function() {
   function setFrames(frames) {
     frames.forEach(function(frame) {
       store.connectFrame(frame);
+    });
+  }
+
+  function createSidebarContent(
+    { userid } = { userid: 'acct:person@example.com' }
+  ) {
+    return util.createDirective(document, 'sidebarContent', {
+      auth: {
+        status: userid ? 'logged-in' : 'logged-out',
+        userid: userid,
+      },
+      search: sinon.stub().returns({ query: sinon.stub() }),
+      onLogin: sinon.stub(),
     });
   }
 
@@ -335,6 +349,19 @@ describe('sidebar.components.sidebar-content', function() {
         $scope.$digest();
         // Re-construct the controller after the environment setup.
         makeSidebarContentController();
+      });
+
+      [null, 'acct:person@example.com'].forEach(userid => {
+        it('displays same group error message regardless of login state', () => {
+          const element = createSidebarContent({ userid });
+
+          const sidebarContentError = element.find('.sidebar-content-error');
+          const errorMessage = sidebarContentError.attr(
+            'logged-in-error-message'
+          );
+
+          assert.equal(errorMessage, "'This group is not available.'");
+        });
       });
 
       it('sets directLinkedGroupFetchFailed to true', () => {

--- a/src/sidebar/templates/sidebar-content.html
+++ b/src/sidebar/templates/sidebar-content.html
@@ -36,7 +36,7 @@
 <sidebar-content-error
   class="sidebar-content-error"
   logged-out-error-message="'This group is not available.'"
-  logged-in-error-message="'You either do not have permission to view this group, the group does not exist, or the group is not visible at this URL.'"
+  logged-in-error-message="'This group is not available.'"
   on-login-request="vm.onLogin()"
   is-logged-in="vm.auth.status === 'logged-in'"
   ng-if="vm.selectedGroupUnavailable()"


### PR DESCRIPTION
Use the same short error message for notifying the user that the direct-linked group in unavailable regardless of login state.