### PR TITLE
Add abililty to clear groups in store

### DIFF
--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -55,9 +55,22 @@ const update = {
       groups: action.groups,
     };
   },
+
+  CLEAR_GROUPS() {
+    return {
+      focusedGroupId: null,
+      groups: [],
+    };
+  },
 };
 
 const actions = util.actionTypes(update);
+
+function clearGroups() {
+  return {
+    type: actions.CLEAR_GROUPS,
+  };
+}
 
 /**
  * Set the current focused group.
@@ -184,6 +197,7 @@ module.exports = {
   actions: {
     focusGroup,
     loadGroups,
+    clearGroups,
   },
   selectors: {
     allGroups,

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -127,6 +127,25 @@ describe('sidebar.store.modules.groups', () => {
     });
   });
 
+  describe('clearGroups', () => {
+    it('clears the list of groups', () => {
+      store.loadGroups([publicGroup]);
+
+      store.clearGroups();
+
+      assert.equal(store.getState().groups.length, 0);
+    });
+
+    it('clears the focused group id', () => {
+      store.loadGroups([publicGroup]);
+      store.focusGroup(publicGroup.id);
+
+      store.clearGroups();
+
+      assert.equal(store.getState().focusedGroupId, null);
+    });
+  });
+
   describe('allGroups', () => {
     it('returns all groups', () => {
       store.loadGroups([publicGroup, privateGroup]);


### PR DESCRIPTION
This is needed to be able to clear the group state when logging
out and logging in.

Merge before https://github.com/hypothesis/client/pull/1084.