### PR TITLE
Add direct linked group to store

### DIFF
--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -49,8 +49,6 @@ function SidebarContentController(
   streamFilter
 ) {
   const self = this;
-  this.directLinkedGroupFetchFailed =
-    !!settings.group && settings.group !== store.focusedGroup().id;
 
   function thread() {
     return rootThread.thread(store.getState());
@@ -311,7 +309,7 @@ function SidebarContentController(
   this.scrollTo = scrollToAnnotation;
 
   this.areAllAnnotationsVisible = function() {
-    if (this.directLinkedGroupFetchFailed) {
+    if (store.getState().directLinkedGroupFetchFailed) {
       return true;
     }
     const selection = store.getState().selectedAnnotationMap;
@@ -322,7 +320,7 @@ function SidebarContentController(
   };
 
   this.selectedGroupUnavailable = function() {
-    return !this.isLoading() && this.directLinkedGroupFetchFailed;
+    return !this.isLoading() && store.getState().directLinkedGroupFetchFailed;
   };
 
   this.selectedAnnotationUnavailable = function() {
@@ -387,8 +385,7 @@ function SidebarContentController(
 
     store.clearSelectedAnnotations();
     store.selectTab(selectedTab);
-    // Clear direct-linked group fetch failed state.
-    this.directLinkedGroupFetchFailed = false;
+    store.clearDirectLinkedGroupFetchFailed();
   };
 }
 

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -213,11 +213,11 @@ describe('sidebar.components.sidebar-content', function() {
     });
 
     it('clears the directLinkedGroupFetchFailed state', () => {
-      ctrl.directLinkedGroupFetchFailed = true;
+      store.setDirectLinkedGroupFetchFailed();
 
       ctrl.clearSelection();
 
-      assert.isFalse(ctrl.directLinkedGroupFetchFailed);
+      assert.isFalse(store.getState().directLinkedGroupFetchFailed);
     });
   });
 
@@ -234,12 +234,8 @@ describe('sidebar.components.sidebar-content', function() {
 
     it('returns false if selected group is unavailable', () => {
       fakeSettings.group = 'group-id';
-      store.loadGroups([{ id: 'default-id' }]);
-      store.focusGroup('default-id');
-      fakeGroups.focused.returns({ id: 'default-id' });
+      store.setDirectLinkedGroupFetchFailed();
       $scope.$digest();
-      // Re-construct the controller after the environment setup.
-      makeSidebarContentController();
       assert.isFalse(ctrl.showSelectedTabs());
     });
 
@@ -343,12 +339,8 @@ describe('sidebar.components.sidebar-content', function() {
       beforeEach(() => {
         setFrames([{ uri: 'http://www.example.com' }]);
         fakeSettings.group = 'group-id';
-        store.loadGroups([{ id: 'default-id' }]);
-        store.focusGroup('default-id');
-        fakeGroups.focused.returns({ id: 'default-id' });
+        store.setDirectLinkedGroupFetchFailed();
         $scope.$digest();
-        // Re-construct the controller after the environment setup.
-        makeSidebarContentController();
       });
 
       [null, 'acct:person@example.com'].forEach(userid => {
@@ -362,10 +354,6 @@ describe('sidebar.components.sidebar-content', function() {
 
           assert.equal(errorMessage, "'This group is not available.'");
         });
-      });
-
-      it('sets directLinkedGroupFetchFailed to true', () => {
-        assert.isTrue(ctrl.directLinkedGroupFetchFailed);
       });
 
       it('areAllAnnotationsVisible returns true since there is an error message', () => {
@@ -385,10 +373,6 @@ describe('sidebar.components.sidebar-content', function() {
         store.focusGroup(fakeSettings.group);
         fakeGroups.focused.returns({ id: fakeSettings.group });
         $scope.$digest();
-      });
-
-      it('sets directLinkedGroupFetchFailed to false', () => {
-        assert.isFalse(ctrl.directLinkedGroupFetchFailed);
       });
 
       it('areAllAnnotationsVisible returns false since group has no annotations', () => {

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -77,7 +77,8 @@ function groups(
         directLinkedGroup.scopes.enforced
       ) {
         groups = groups.filter(g => g.id !== directLinkedGroupId);
-        directLinkedGroupId = undefined;
+        store.setDirectLinkedGroupFetchFailed();
+        directLinkedGroupId = null;
       }
     }
 
@@ -213,6 +214,14 @@ function groups(
           selectedGroupApi = fetchGroup({
             id: directLinkedGroupId,
             expand: params.expand,
+          }).then(group => {
+            // If the group does not exist or the user doesn't have permission.
+            if (group === null) {
+              store.setDirectLinkedGroupFetchFailed();
+            } else {
+              store.clearDirectLinkedGroupFetchFailed();
+            }
+            return group;
           });
         }
         groupApiRequests = groupApiRequests.concat(selectedGroupApi);

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -85,6 +85,8 @@ describe('groups', function() {
           const group = this.getState().focusedGroup;
           return group ? group.id : null;
         },
+        setDirectLinkedGroupFetchFailed: sinon.stub(),
+        clearDirectLinkedGroupFetchFailed: sinon.stub(),
       }
     );
     fakeSession = sessionWithThreeGroups();
@@ -191,6 +193,8 @@ describe('groups', function() {
       fakeSettings.group = outOfScopeEnforcedGroup.id;
       fakeApi.group.read.returns(Promise.resolve(outOfScopeEnforcedGroup));
       return svc.load().then(groups => {
+        // The failure state is captured in the store.
+        assert.called(fakeStore.setDirectLinkedGroupFetchFailed);
         // The focus group is not set to the direct-linked group.
         assert.calledWith(fakeStore.focusGroup, dummyGroups[0].id);
         // The direct-linked group is not in the list of groups.
@@ -211,6 +215,8 @@ describe('groups', function() {
         )
       );
       return svc.load().then(() => {
+        // The failure state is captured in the store.
+        assert.called(fakeStore.setDirectLinkedGroupFetchFailed);
         // The focus group is not set to the direct-linked group.
         assert.calledWith(fakeStore.focusGroup, dummyGroups[0].id);
       });
@@ -378,6 +384,16 @@ describe('groups', function() {
       fakeApi.groups.list.returns(Promise.resolve(dummyGroups));
       return svc.load().then(() => {
         assert.calledWith(fakeStore.focusGroup, fakeSettings.group);
+      });
+    });
+
+    it('clears the directLinkedGroupFetchFailed state if loading a direct-linked group', () => {
+      const svc = service();
+      fakeSettings.group = dummyGroups[1].id;
+      fakeApi.groups.list.returns(Promise.resolve(dummyGroups));
+      return svc.load().then(() => {
+        assert.called(fakeStore.clearDirectLinkedGroupFetchFailed);
+        assert.notCalled(fakeStore.setDirectLinkedGroupFetchFailed);
       });
     });
 

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -36,6 +36,7 @@ const debugMiddleware = require('./debug-middleware');
 
 const activity = require('./modules/activity');
 const annotations = require('./modules/annotations');
+const directLinkedGroup = require('./modules/direct-linked-group');
 const frames = require('./modules/frames');
 const links = require('./modules/links');
 const groups = require('./modules/groups');
@@ -86,6 +87,7 @@ function store($rootScope, settings) {
   const modules = [
     activity,
     annotations,
+    directLinkedGroup,
     frames,
     links,
     groups,

--- a/src/sidebar/store/modules/direct-linked-group.js
+++ b/src/sidebar/store/modules/direct-linked-group.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const util = require('../util');
+
+function init() {
+  return {
+    /**
+     * Indicates that an error occured in retrieving/showing the direct linked group.
+     * This could be because:
+     * - the group does not exist
+     * - the user does not have permission
+     * - the group is out of scope for the given page
+     * @type {boolean}
+     */
+    directLinkedGroupFetchFailed: false,
+  };
+}
+
+const update = {
+  UPDATE_DIRECT_LINKED_GROUP_FETCH_FAILED(state, action) {
+    return {
+      directLinkedGroupFetchFailed: action.directLinkedGroupFetchFailed,
+    };
+  },
+};
+
+const actions = util.actionTypes(update);
+
+/**
+ * Set the direct linked group fetch failure to true.
+ */
+function setDirectLinkedGroupFetchFailed() {
+  return {
+    type: actions.UPDATE_DIRECT_LINKED_GROUP_FETCH_FAILED,
+    directLinkedGroupFetchFailed: true,
+  };
+}
+
+/**
+ * Clear the direct linked group fetch failure.
+ */
+function clearDirectLinkedGroupFetchFailed() {
+  return {
+    type: actions.UPDATE_DIRECT_LINKED_GROUP_FETCH_FAILED,
+    directLinkedGroupFetchFailed: false,
+  };
+}
+
+module.exports = {
+  init,
+  update,
+  actions: {
+    setDirectLinkedGroupFetchFailed,
+    clearDirectLinkedGroupFetchFailed,
+  },
+  selectors: {},
+};

--- a/src/sidebar/store/modules/test/direct-linked-group-test.js
+++ b/src/sidebar/store/modules/test/direct-linked-group-test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const createStore = require('../../create-store');
+const directLinkedGroup = require('../direct-linked-group');
+
+describe('sidebar/store/modules/direct-linked-group', () => {
+  let store;
+
+  beforeEach(() => {
+    store = createStore([directLinkedGroup]);
+  });
+
+  it('sets directLinkedGroupFetchFailed to true', () => {
+    store.setDirectLinkedGroupFetchFailed();
+
+    assert.isTrue(store.getState().directLinkedGroupFetchFailed);
+  });
+
+  it('sets directLinkedGroupFetchFailed to false', () => {
+    store.setDirectLinkedGroupFetchFailed();
+
+    store.clearDirectLinkedGroupFetchFailed();
+
+    assert.isFalse(store.getState().directLinkedGroupFetchFailed);
+  });
+});


### PR DESCRIPTION
Add direct-linked group error to the store and use it to set/get the state instead of storing the state on the content-sidebar controller. 

This should be merged before https://github.com/hypothesis/client/pull/1084.