### PR TITLE
Fix overlapping text in headings in annotation bodies

### DIFF
--- a/src/styles/sidebar/styled-text.scss
+++ b/src/styles/sidebar/styled-text.scss
@@ -1,4 +1,7 @@
 @mixin styled-text() {
+  // Reset the line-height in case any parent elements have set it.
+  line-height: normal;
+
   h1, h2, h3, h4, h5, h6, p, ol, ul, img, pre, blockquote {
     margin: .618em 0;
   }


### PR DESCRIPTION
Parent elements of annotation cards set line heights to absolute pixel
values. Annotation card headings then inherit this and as a result,
their line height is too small for the font size.

We ought to reconsider the way line heights are set elsewhere in the
app, but resetting the line height in the `styled-text` mixin ensures
that annotation body styles are protected from whatever the parent
elements do with it.

**Master:**

<img width="432" alt="Screenshot 2019-05-10 17 12 05" src="https://user-images.githubusercontent.com/2458/57541400-d0d47400-7346-11e9-8602-581ecf1cedd1.png">

**This branch:**

<img width="471" alt="Screenshot 2019-05-10 17 08 49" src="https://user-images.githubusercontent.com/2458/57541404-d467fb00-7346-11e9-8d1e-67453370e296.png">

Fixes https://github.com/hypothesis/product-backlog/issues/162

This same fix can also be applied in h.