### PR TITLE
Fix extra underlined space in "log in" link

### DIFF
--- a/src/sidebar/components/sidebar-content-error.js
+++ b/src/sidebar/components/sidebar-content-error.js
@@ -26,8 +26,8 @@ function SidebarContentError({
               href=""
               onClick={onLoginRequest}
             >
-              log in{' '}
-            </a>
+              log in
+            </a>{' '}
             to see it.
           </Fragment>
         ) : (


### PR DESCRIPTION
Move the space _after_ the link text.

**Before**

<img width="415" alt="Screenshot 2019-05-13 17 08 36" src="https://user-images.githubusercontent.com/2458/57636937-18a30780-75a2-11e9-8f49-41319dd3dc71.png">

**After**

<img width="216" alt="Screenshot 2019-05-13 17 11 38" src="https://user-images.githubusercontent.com/2458/57636977-2d7f9b00-75a2-11e9-98f3-363fb7be0d93.png">
