### PR TITLE
Refactor groups service's `load` method

### DIFF
--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -270,16 +270,14 @@ function groups(
         return Promise.all([myGroups, allFeaturedGroups, documentUri, token]);
       })
       .then(([myGroups, featuredGroups, documentUri, token]) => {
-        const groups = combineGroups(myGroups, featuredGroups, documentUri);
         const isLoggedIn = token !== null;
-        return filterGroups(
-          groups,
+        const groups = filterGroups(
+          combineGroups(myGroups, featuredGroups, documentUri),
           isLoggedIn,
           directLinkedAnnotationGroupId,
           directLinkedGroupId
         );
-      })
-      .then(groups => {
+
         injectOrganizations(groups);
 
         const isFirstLoad = store.allGroups().length === 0;

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -201,9 +201,10 @@ function groups(
           auth.tokenGetter(),
         ];
 
-        // If there is a directLinkedAnnId, fetch the annotation to see if there needs
-        // to be a second api request to fetch its group since the group may not be in
-        // the results returned by group.list, profile.groups, or the direct-linked group.
+        // If there is a direct-linked annotation, fetch the annotation to see
+        // if there needs to be a second API request to fetch its group since
+        // the group may not be in the results returned by group.list,
+        // profile.groups, or the direct-linked group.
         let directLinkedAnnApi = Promise.resolve(null);
         if (directLinkedAnnId) {
           directLinkedAnnApi = api.annotation
@@ -215,7 +216,7 @@ function groups(
         }
         groupApiRequests = groupApiRequests.concat(directLinkedAnnApi);
 
-        // If there is a directLinkedGroupId, add an api request to get that
+        // If there is a direct-linked group, add an API request to get that
         // particular group since it may not be in the results returned by
         // group.list or profile.groups.
         let directLinkedGroupApi = Promise.resolve(null);
@@ -255,7 +256,7 @@ function groups(
               ? featuredGroups.concat([directLinkedGroup])
               : featuredGroups;
 
-          // If there's a selected annotation it may require an extra api call
+          // If there's a direct-linked annotation it may require an extra API call
           // to fetch its group.
           if (directLinkedAnn) {
             // Set the directLinkedAnnotationGroupId to be used later in
@@ -274,14 +275,9 @@ function groups(
                 id: directLinkedAnn.group,
                 expand: params.expand,
               }).then(directLinkedAnnGroup => {
-                // If the directLinkedAnnotation's group fetch failed, return
-                // the list of groups without it.
                 if (!directLinkedAnnGroup) {
                   return initialFeaturedGroups;
                 }
-
-                // If the directLinkedAnnotation's group fetch was successful,
-                // combine it with the other groups.
                 return initialFeaturedGroups.concat(directLinkedAnnGroup);
               });
             }

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -255,34 +255,27 @@ function groups(
                   // If the directLinkedAnnotation's group fetch failed, return
                   // the list of groups without it.
                   if (!directLinkedAnnGroup) {
-                    return [
-                      combineGroups(myGroups, allFeaturedGroups, documentUri),
-                      token,
-                    ];
+                    return [myGroups, allFeaturedGroups, documentUri, token];
                   }
 
                   // If the directLinkedAnnotation's group fetch was successful,
                   // combine it with the other groups.
                   return [
-                    combineGroups(
-                      myGroups,
-                      allFeaturedGroups.concat(directLinkedAnnGroup),
-                      documentUri
-                    ),
+                    myGroups,
+                    allFeaturedGroups.concat(directLinkedAnnGroup),
+                    documentUri,
                     token,
                   ];
                 });
               }
             }
             // If there is no direct-linked annotation, return the list of groups without it.
-            return [
-              combineGroups(myGroups, allFeaturedGroups, documentUri),
-              token,
-            ];
+            return [myGroups, allFeaturedGroups, documentUri, token];
           }
         );
       })
-      .then(([groups, token]) => {
+      .then(([myGroups, featuredGroups, documentUri, token]) => {
+        const groups = combineGroups(myGroups, featuredGroups, documentUri);
         const isLoggedIn = token !== null;
         return filterGroups(
           groups,

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -230,7 +230,7 @@ function groups(
       })
       .then(([myGroups, featuredGroups, token, selectedAnn, selectedGroup]) => {
         // If there is a direct-linked group, add it to the featured groups list.
-        const allFeaturedGroups =
+        let allFeaturedGroups =
           selectedGroup !== null &&
           !featuredGroups.some(g => g.id === selectedGroup.id)
             ? featuredGroups.concat([selectedGroup])
@@ -250,29 +250,24 @@ function groups(
           // If the direct-linked annotation's group has not already been fetched,
           // fetch it.
           if (!selectedAnnGroup) {
-            return fetchGroup({
+            const initialFeaturedGroups = allFeaturedGroups;
+            allFeaturedGroups = fetchGroup({
               id: selectedAnn.group,
               expand: params.expand,
             }).then(directLinkedAnnGroup => {
               // If the directLinkedAnnotation's group fetch failed, return
               // the list of groups without it.
               if (!directLinkedAnnGroup) {
-                return [myGroups, allFeaturedGroups, documentUri, token];
+                return initialFeaturedGroups;
               }
 
               // If the directLinkedAnnotation's group fetch was successful,
               // combine it with the other groups.
-              return [
-                myGroups,
-                allFeaturedGroups.concat(directLinkedAnnGroup),
-                documentUri,
-                token,
-              ];
+              return initialFeaturedGroups.concat(directLinkedAnnGroup);
             });
           }
         }
-        // If there is no direct-linked annotation, return the list of groups without it.
-        return [myGroups, allFeaturedGroups, documentUri, token];
+        return Promise.all([myGroups, allFeaturedGroups, documentUri, token]);
       })
       .then(([myGroups, featuredGroups, documentUri, token]) => {
         const groups = combineGroups(myGroups, featuredGroups, documentUri);


### PR DESCRIPTION
The `load` method in the groups service that fetches groups from the API, adds them to the store and focuses the appropriate group, was getting difficult to follow.

This PR is a series of incremental refactorings of this method to hopefully make it easier to follow. I've also added some high-level comments to clarify the main steps involved.

A commit-by-commit review will probably be easier than looking at the diff all at once.