### PR TITLE
Fix a silently failing test

### DIFF
--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -383,7 +383,7 @@ describe('sidebar.components.hypothesis-app', function() {
     it('clears groups', () => {
       const ctrl = createController();
 
-      ctrl.login().then(() => {
+      return ctrl.login().then(() => {
         assert.called(fakeStore.clearGroups);
       });
     });


### PR DESCRIPTION
The `HypothesisAppController#login()` method returns a Promise and calls
`fakeStore.clearGroups` asynchronously. This means we need to wait for
the result before checking the spy, and return the result in the test
case so Mocha knows when the test has finished.