### PR TITLE
Simplify groups service `load` method using async/await

### DIFF
--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -222,7 +222,7 @@ function groups(
       });
     }
 
-    let [
+    const [
       myGroups,
       featuredGroups,
       token,
@@ -241,11 +241,12 @@ function groups(
     // don't already have it.
 
     // If there is a direct-linked group, add it to the featured groups list.
-    featuredGroups =
+    if (
       directLinkedGroup &&
       !featuredGroups.some(g => g.id === directLinkedGroup.id)
-        ? featuredGroups.concat([directLinkedGroup])
-        : featuredGroups;
+    ) {
+      featuredGroups.push(directLinkedGroup);
+    }
 
     // If there's a direct-linked annotation it may require an extra API call
     // to fetch its group.

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -171,7 +171,7 @@ function groups(
 
     // Step 2: Concurrently fetch the groups the user is a member of,
     // the groups associated with the current document and the annotation
-    // or group that was direct-linked (if any).
+    // and/or group that was direct-linked (if any).
     const params = {
       expand: ['organization', 'scopes'],
     };

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -290,15 +290,14 @@ function groups(
 
     store.loadGroups(groups);
 
-    if (
-      isFirstLoad &&
-      groups.some(g => g.id === directLinkedAnnotationGroupId)
-    ) {
-      store.focusGroup(directLinkedAnnotationGroupId);
-    } else if (isFirstLoad && groups.some(g => g.id === directLinkedGroupId)) {
-      store.focusGroup(directLinkedGroupId);
-    } else if (isFirstLoad && groups.some(g => g.id === prevFocusedGroup)) {
-      store.focusGroup(prevFocusedGroup);
+    if (isFirstLoad) {
+      if (groups.some(g => g.id === directLinkedAnnotationGroupId)) {
+        store.focusGroup(directLinkedAnnotationGroupId);
+      } else if (groups.some(g => g.id === directLinkedGroupId)) {
+        store.focusGroup(directLinkedGroupId);
+      } else if (groups.some(g => g.id === prevFocusedGroup)) {
+        store.focusGroup(prevFocusedGroup);
+      }
     }
 
     return groups;

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -158,8 +158,7 @@ function groups(
    * group.
    *
    * The groups that are fetched depend on the current user, the URI of
-   * the current document, and whether any direct-links were followed (either
-   * to an annotation or group).
+   * the current document, and the direct-linked group and/or annotation.
    *
    * @return {Promise<Group[]>}
    */

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -170,29 +170,26 @@ function groups(
     if (isSidebar) {
       uri = await getDocumentUriForGroupSearch();
     }
-    const directLinkedGroupId = store.getState().directLinkedGroupId;
-    const directLinkedAnnId = store.getState().directLinkedAnnotationId;
-    const params = {
-      expand: ['organization', 'scopes'],
-    };
-
-    let directLinkedAnnotationGroupId = null;
+    documentUri = uri;
 
     // Step 2: Concurrently fetch the groups the user is a member of,
     // the groups associated with the current document and the annotation
     // or group that was direct-linked (if any).
+    const params = {
+      expand: ['organization', 'scopes'],
+    };
     if (authority) {
       params.authority = authority;
     }
     if (uri) {
       params.document_uri = uri;
     }
-    documentUri = uri;
 
     // If there is a direct-linked annotation, fetch the annotation to see
     // if there needs to be a second API request to fetch its group since
     // the group may not be in the results returned by group.list,
     // profile.groups, or the direct-linked group.
+    const directLinkedAnnId = store.getState().directLinkedAnnotationId;
     let directLinkedAnnApi = null;
     if (directLinkedAnnId) {
       directLinkedAnnApi = api.annotation
@@ -206,6 +203,7 @@ function groups(
     // If there is a direct-linked group, add an API request to get that
     // particular group since it may not be in the results returned by
     // group.list or profile.groups.
+    const directLinkedGroupId = store.getState().directLinkedGroupId;
     let directLinkedGroupApi = null;
     if (directLinkedGroupId) {
       directLinkedGroupApi = fetchGroup({
@@ -250,6 +248,7 @@ function groups(
 
     // If there's a direct-linked annotation it may require an extra API call
     // to fetch its group.
+    let directLinkedAnnotationGroupId = null;
     if (directLinkedAnn) {
       // Set the directLinkedAnnotationGroupId to be used later in
       // the filterGroups method.
@@ -271,6 +270,7 @@ function groups(
         }
       }
     }
+
     // Step 4. Combine all the groups into a single list and set additional
     // metadata on them that will be used elsewhere in the app.
     const isLoggedIn = token !== null;

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -183,10 +183,9 @@ function groups(
       params.document_uri = documentUri;
     }
 
-    // If there is a direct-linked annotation, fetch the annotation to see
-    // if there needs to be a second API request to fetch its group since
-    // the group may not be in the results returned by group.list,
-    // profile.groups, or the direct-linked group.
+    // If there is a direct-linked annotation, fetch the annotation in case
+    // the associated group has not already been fetched and we need to make
+    // an additional request for it.
     const directLinkedAnnId = store.getState().directLinkedAnnotationId;
     let directLinkedAnnApi = null;
     if (directLinkedAnnId) {
@@ -199,8 +198,8 @@ function groups(
     }
 
     // If there is a direct-linked group, add an API request to get that
-    // particular group since it may not be in the results returned by
-    // group.list or profile.groups.
+    // particular group since it may not be in the set of groups that are
+    // fetched by other requests.
     const directLinkedGroupId = store.getState().directLinkedGroupId;
     let directLinkedGroupApi = null;
     if (directLinkedGroupId) {
@@ -252,12 +251,12 @@ function groups(
       // the filterGroups method.
       directLinkedAnnotationGroupId = directLinkedAnn.group;
 
+      // If the direct-linked annotation's group has not already been fetched,
+      // fetch it.
       const directLinkedAnnGroup = myGroups
         .concat(featuredGroups)
         .find(g => g.id === directLinkedAnn.group);
 
-      // If the direct-linked annotation's group has not already been fetched,
-      // fetch it.
       if (!directLinkedAnnGroup) {
         const directLinkedAnnGroup = await fetchGroup({
           id: directLinkedAnn.group,

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -138,7 +138,7 @@ function groups(
   // to include groups associated with this page. This is retained to determine
   // whether we need to re-fetch groups if the URLs of frames connected to the
   // sidebar app changes.
-  let documentUri;
+  let documentUri = null;
 
   /*
    * Fetch an individual group.
@@ -166,11 +166,9 @@ function groups(
   async function load() {
     // Step 1: Get the URI of the active document, so we can fetch groups
     // associated with that document.
-    let uri = null;
     if (isSidebar) {
-      uri = await getDocumentUriForGroupSearch();
+      documentUri = await getDocumentUriForGroupSearch();
     }
-    documentUri = uri;
 
     // Step 2: Concurrently fetch the groups the user is a member of,
     // the groups associated with the current document and the annotation
@@ -181,8 +179,8 @@ function groups(
     if (authority) {
       params.authority = authority;
     }
-    if (uri) {
-      params.document_uri = uri;
+    if (documentUri) {
+      params.document_uri = documentUri;
     }
 
     // If there is a direct-linked annotation, fetch the annotation to see


### PR DESCRIPTION
This is a follow up to https://github.com/hypothesis/client/pull/1122 which removes about 20 lines of code from the `load()` method and reduces the number of scopes and conditionals.

I suggest a commit-by-commit review, but in brief I used async/await syntax to eliminate Promise chains, then removed short-lived variables that were no longer needed and finally moved some variables closer to where they were first used.

This should make it easier to amend this function in future if there are any further changes to the business rules.