### PR TITLE
Show focus indicator on various UI elements if they have keyboard focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "express": "^4.14.1",
     "extend": "^3.0.2",
     "fetch-mock": "6",
+    "focus-visible": "^4.1.5",
     "gulp": "^4.0.0",
     "gulp-changed": "^3.2.0",
     "gulp-if": "^2.0.0",

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -35,6 +35,9 @@ const angular = require('angular');
 // it must be require'd after angular is first require'd
 require('autofill-event');
 
+// Load polyfill for :focus-visible pseudo-class.
+require('focus-visible');
+
 // Enable debugging checks for Preact.
 require('preact/debug');
 

--- a/src/styles/mixins/focus.scss
+++ b/src/styles/mixins/focus.scss
@@ -1,0 +1,23 @@
+/**
+ * Display an outline on an element only when it has keyboard focus.
+ *
+ * This requires the browser to support the :focus-visible pseudo-selector [1]
+ * or for the JS polyfill [2] to be loaded.
+ *
+ * [1] https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
+ * [2] https://github.com/WICG/focus-visible
+ */
+@mixin outline-on-keyboard-focus {
+  // Selector for browsers using JS polyfill, which adds the "focus-visible"
+  // class to a keyboard-focused element.
+  &:focus:not(.focus-visible) {
+    outline: none;
+  }
+
+  // Selector for browsers with native :focus-visible support.
+  // (Do not combine with above, as an unsupported pseudo-class disables the
+  // entire selector)
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+}

--- a/src/styles/sidebar/common.scss
+++ b/src/styles/sidebar/common.scss
@@ -1,6 +1,5 @@
 @import '../base';
 @import '../forms';
-@import '../mixins/responsive';
 
 @import './styled-text';
 

--- a/src/styles/sidebar/components/selection-tabs.scss
+++ b/src/styles/sidebar/components/selection-tabs.scss
@@ -17,14 +17,13 @@
 }
 
 .selection-tabs__type {
+  @include outline-on-keyboard-focus;
+
   color: $grey-6;
   margin-right: 20px;
   cursor: pointer;
   min-width: 85px;
   min-height: 18px;
-
-  // Disable focus ring for selected tab
-  outline: none;
 
   user-select: none;
 }

--- a/src/styles/sidebar/components/simple-search.scss
+++ b/src/styles/sidebar/components/simple-search.scss
@@ -21,6 +21,8 @@
   $expanded-max-width: 150px;
 
   .simple-search-input {
+    @include outline-on-keyboard-focus;
+
     flex-grow: 1;
     order: 1;
 
@@ -28,7 +30,6 @@
 
     // disable the default browser styling for the input
     border: none;
-    outline: none;
     padding: 0px;
     width: 100%;
 

--- a/src/styles/sidebar/components/top-bar.scss
+++ b/src/styles/sidebar/components/top-bar.scss
@@ -51,11 +51,12 @@
 
 // Removes the native styling from a <button> element
 @mixin reset-native-btn-styles {
+  @include outline-on-keyboard-focus;
+
   padding: 0px;
   margin: 0px;
   background-color: transparent;
   border-style: none;
-  outline: none;
 }
 
 .top-bar__btn {

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -1,10 +1,19 @@
 $base-font-size: 12px;
 $base-line-height: 20px;
 
+// Variables and mixins
+// --------------------
 @import '../variables';
-@import '../reset';
+@import '../mixins/focus';
+@import '../mixins/responsive';
 
+// Base styles
+// -----------
+@import '../reset';
 @import './elements';
+
+// Misc. legacy :(
+// ---------------
 @import './common';
 
 // Components

--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,6 +3699,11 @@ flush-write-stream@^1.0.2:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
+focus-visible@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-4.1.5.tgz#50b44e2e84c24b831ceca3cce84d57c2b311c855"
+  integrity sha512-yo/njtk/BB4Z2euzaZe3CZrg4u5s5uEi7ZwbHBJS2quHx51N0mmcx9nTIiImUGlgy+vf26d0CcQluahBBBL/Fw==
+
 follow-redirects@^1.0.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.4.1.tgz#d8120f4518190f55aac65bb6fc7b85fcd666d6aa"


### PR DESCRIPTION
A few UI elements, such as buttons at the top of the sidebar, currently always disable the focus outline. This hides a distracting/unwanted outline for mouse/touch users but makes keyboard navigation more difficult.

This is being addressed at the web platform level by adding a [`:focus-visible` CSS pseudo-class](https://github.com/WICG/focus-visible) which applies if an element has focus and the browser deems that the focus should always be indicated. Currently only Chrome supports it natively but there is an "official" polyfill.

This PR adds the polyfill and makes use of it to enable focus outline for buttons in the top bar and selected tabs in the UI when using keyboard navigation. I also intend to make use of this in the new menus.

<img width="493" alt="Screenshot 2019-05-17 12 00 45" src="https://user-images.githubusercontent.com/2458/57924754-e2b19c00-789d-11e9-870b-2b8bbf92adf1.png">

There is a slight risk that the specs might change, but the behaviour is definitely better than what we have on master in any case.