### PR TITLE
Make it easier to create custom builds of the client

### DIFF
--- a/scripts/build-app
+++ b/scripts/build-app
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Create a production build of the client with a given OAuth client ID
+#
+# Usage:
+#
+# ./build <oauth_client_id> [<api_url>]
+#
+# oauth_client_id - The OAuth client ID registered with the "h" service.
+# api_url - The root URL of the h service's REST API. Must have trailing
+#           slash (eg. https://hypothes.is/api/)
+#
+# After running this script, you will need to upload the contents of the "build"
+# dir to the location that the client will be served from.
+
+set -eu
+
+export NODE_ENV=production
+export OAUTH_CLIENT_ID=$1
+export API_URL=${2:-https://hypothes.is/api/}
+
+# Remove any outputs from previous builds.
+rm -rf build/
+
+gulp build

--- a/scripts/build-app
+++ b/scripts/build-app
@@ -15,6 +15,11 @@
 
 set -eu
 
+if [ $# -eq 0 ]; then
+  echo "Usage: $0 <oauth_client_id> [<api_url>]"
+  exit 0
+fi
+
 export NODE_ENV=production
 export OAUTH_CLIENT_ID=$1
 export API_URL=${2:-https://hypothes.is/api/}

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -57,7 +57,7 @@ function injectScript(doc, src) {
  */
 function injectAssets(doc, config, assets) {
   assets.forEach(function (path) {
-    const url = config.assetRoot + 'build/' + config.manifest[path];
+    const url = config.assetRoot + config.manifest[path];
     if (url.match(/\.css/)) {
       injectStylesheet(doc, url);
     } else {
@@ -102,7 +102,7 @@ function bootHypothesisClient(doc, config) {
   // annotation interactions.
   const clientUrl = doc.createElement('link');
   clientUrl.rel = 'hypothesis-client';
-  clientUrl.href = config.assetRoot + 'build/boot.js';
+  clientUrl.href = config.assetRoot + 'boot.js';
   clientUrl.type = 'application/annotator+javascript';
   doc.head.appendChild(clientUrl);
 

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -17,13 +17,44 @@ import { isBrowserSupported } from './browser-check';
 
 if (isBrowserSupported()) {
   const settings = parseJsonConfig(document);
+  // Use the asset root and sidebar app locations specified in the host page,
+  // if present. This is used by the Hypothesis browser extensions to make the
+  // boot script load assets bundled with the extension.
+  let assetRoot;
+  if (settings.assetRoot) {
+    // The `assetRoot` setting is assumed to point at the root of the contents of
+    // the npm package.
+    assetRoot = settings.assetRoot + 'build/';
+  }
+  let sidebarAppUrl = settings.sidebarAppUrl;
+
+  // Otherwise, try to determine the default root URL for assets and the sidebar
+  // application from the location where the boot script is hosted.
+  try {
+    const script = /** @type {HTMLScriptElement} */ (document.currentScript);
+    let scriptUrl = new URL(script.src);
+
+    // We only use the bundled sidebar HTML and assets if the boot script has
+    // its original name. If the `<script>` tag references a custom name
+    // (eg. as in "https://hypothes.is/embed.js") then we skip this and fall
+    // back to the URLs embedded in the boot script.
+    if (scriptUrl.pathname.endsWith('/boot.js')) {
+      assetRoot = assetRoot || new URL('./', scriptUrl).href;
+      sidebarAppUrl = sidebarAppUrl || new URL('app.html', scriptUrl).href;
+    }
+  } catch (e) {
+    // IE does not support `document.currentScript` or the URL constructor.
+  }
+
+  // Otherwise, fall back to hardcoded default URLs.
+  assetRoot = processUrlTemplate(assetRoot || '__ASSET_ROOT__');
+  sidebarAppUrl = processUrlTemplate(sidebarAppUrl || '__SIDEBAR_APP_URL__');
+
   boot(document, {
-    assetRoot: processUrlTemplate(settings.assetRoot || '__ASSET_ROOT__'),
+    assetRoot,
     // @ts-ignore - `__MANIFEST__` is injected by the build script
     manifest: __MANIFEST__,
-    sidebarAppUrl: processUrlTemplate(
-      settings.sidebarAppUrl || '__SIDEBAR_APP_URL__'
-    ),
+    sidebarAppUrl,
   });
 } else {
   // Show a "quiet" warning to avoid being disruptive on non-Hypothesis sites

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -5,7 +5,7 @@ function assetUrl(url) {
   return `https://marginal.ly/client/build/${url}`;
 }
 
-describe('bootstrap', function () {
+describe('boot/boot', function () {
   let fakePolyfills;
   let iframe;
 
@@ -55,7 +55,7 @@ describe('bootstrap', function () {
 
     boot(iframe.contentDocument, {
       sidebarAppUrl: 'https://marginal.ly/app.html',
-      assetRoot: 'https://marginal.ly/client/',
+      assetRoot: 'https://marginal.ly/client/build/',
       manifest: manifest,
     });
   }

--- a/src/sidebar/app.html
+++ b/src/sidebar/app.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <hypothesis-app></hypothesis-app>
+
+    <script class="js-hypothesis-config" type="application/json">
+      __CONFIG__
+    </script>
+
+    <script src="boot.js"></script>
+  </body>
+</html>
+


### PR DESCRIPTION
Add a script `./scripts/build-app <OAuth client ID> [<h API URL>]` which will create a production build of the client using a given OAuth client ID which can then be served from the pre-registered URL associated with that OAuth client. This is useful for early-stage experiments or third-parties wanting to customize the client in ways that are not suitable for inclusion in the main codebase.

More generally, I think it makes sense that the client repo should document what a minimal version of the sidebar app's HTML should look like, even if we may need to generate a custom version in h or the browser extension in order to set the OAuth client ID.

 - Add a template for a minimal version of "app.html", the sidebar app's
   HTML file which is normally hosted by h. At build time, this template
   is processed and emitted into the "build" directory by the
   "build-html" task

 - Make it possible to serve the client from a URL without having to
   bake the URL into the client at build time by using
   `document.currentScript` to resolve the location of the client's
   assets. This avoids the need to rebuild the client if it is moved to
   a different URL.

I wrote this tool originally for creating an experimental fork of the client that supports embedded H5P activities (https://hypothesis-h5p.s3.us-east-2.amazonaws.com/index.html), but I think it is more generally useful.

**Testing**

1. Check that the embedded client at http://localhost:3000 still works
2. Check that a dev browser extension which bundles the client from this branch still works
3. Create and host a custom build of the client as follows:
   1. Register an OAuth client at http://localhost:5000/admin/oauthclients with the Redirect URL set to http://localhost:4040
   2. In the client repo on this branch run `scripts/build-app <OAuth client ID> http://localhost:5000/api`
   3. In the client repo run ``python3 -m http.server 4040``
   4. Create an HTML file ``test.html`` with the following content in the root of the client repo:
        ```html
        <h1>Hello World</h1>
        <script src="http://localhost:4040/build/boot.js"></script>
        ```
   5. Navigate to http://localhost:4040/test.html and check that the custom build of the client loads and that you can log in

With Step 3, you can also register a custom client that works with the production Hypothesis service at https://hypothes.is/admin/oauthclients. The custom client build can then be hosted in any static hosting site -  for example GitHub Pages, S3 etc.