### PR TITLE
Fix menu arrow alignment and overlap with content

### DIFF
--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -9,6 +9,14 @@ const { listen } = require('../util/dom');
 
 const SvgIcon = require('./svg-icon');
 
+// The triangular indicator below the menu toggle button that visually links it
+// to the menu content.
+const menuArrow = (
+  <svg className="menu__arrow" width={15} height={8}>
+    <path d="M0 8 L7 0 L15 8" stroke="currentColor" strokeWidth="2" />
+  </svg>
+);
+
 /**
  * Flag indicating whether the next click event on the menu's toggle button
  * should be ignored, because the action it would trigger has already been
@@ -116,7 +124,7 @@ function Menu({
       </button>
       {isOpen && (
         <Fragment>
-          <div className="menu__arrow" />
+          {menuArrow}
           <div
             className={classnames(
               'menu__content',

--- a/src/styles/sidebar/components/menu.scss
+++ b/src/styles/sidebar/components/menu.scss
@@ -28,18 +28,17 @@
 // Triangular indicator at the top of the menu that associates it with the
 // toggle button.
 .menu__arrow {
-  $size: 10px;
+  color: $grey-3;
+  fill: white;
 
-  background-color: white;
-  border-left: 1px solid $grey-3;
-  border-top: 1px solid $grey-3;
-  height: $size;
+  // Position the arrow so that it appears flush with the right edge of the
+  // content when the menu is right-aligned, and the bottom of the arrow just
+  // overlaps the content's border. The effect is that the menu's border is a
+  // rounded rect with a notch at the top.
   position: absolute;
+  top: calc(100% - 2px);  // nb. Adjust this if changing the <svg> size.
   right: 0;
-  top: 100%;
-  transform: rotate(45deg);
-  width: $size;
-  z-index: 3;
+  z-index: 1;
 }
 
 // Content area of the menu.


### PR DESCRIPTION
This fixes a misalignment between the arrow indicator below the menu toggle button and the menu content below when the content is right-aligned.

Changes can be seen by merging this branch into #1154.

**Before:**

<img width="197" alt="Screenshot 2019-06-07 09 55 23" src="https://user-images.githubusercontent.com/2458/59092919-92f94a00-890a-11e9-860c-2a584e240126.png">

**After:**

<img width="213" alt="Screenshot 2019-06-07 09 55 48" src="https://user-images.githubusercontent.com/2458/59092888-7fe67a00-890a-11e9-935f-546487e35dfc.png">

<img width="211" alt="Screenshot 2019-06-07 09 55 54" src="https://user-images.githubusercontent.com/2458/59092895-837a0100-890a-11e9-9083-230db3635994.png">

