### PR TITLE
Remove wrapping `<span>` around SVG icons

### DIFF
--- a/src/sidebar/components/svg-icon.js
+++ b/src/sidebar/components/svg-icon.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { createElement } = require('preact');
-const { useLayoutEffect, useRef } = require('preact/hooks');
+const { cloneElement, createElement } = require('preact');
+const { useMemo } = require('preact/hooks');
 const propTypes = require('prop-types');
 
 // The list of supported icons
@@ -17,6 +17,35 @@ const icons = {
 };
 
 /**
+ * Convert a DOM node's attributes to a `props` object for a React element.
+ */
+function propsFromAttrs(domNode) {
+  const attrs = domNode.attributes;
+  const props = {};
+  for (let i = 0; i < attrs.length; i++) {
+    const attr = attrs[i];
+    props[attr.name] = attr.value;
+  }
+  return props;
+}
+
+/**
+ * Convert a DOM element and its children to a React/Preact element that can
+ * be returned from a render function.
+ */
+function reactElementFromNode(domNode) {
+  if (domNode.nodeType !== Node.ELEMENT_NODE) {
+    // Support for non-Element nodes is not implemented.
+    return null;
+  }
+  return createElement(
+    domNode.localName,
+    propsFromAttrs(domNode),
+    Array.from(domNode.childNodes).map(reactElementFromNode)
+  );
+}
+
+/**
  * Component that renders icons using inline `<svg>` elements.
  * This enables their appearance to be customized via CSS.
  *
@@ -27,20 +56,28 @@ function SvgIcon({ name, className = '' }) {
   if (!icons[name]) {
     throw new Error(`Unknown icon ${name}`);
   }
-  const markup = { __html: icons[name] };
 
-  const element = useRef();
-  useLayoutEffect(() => {
-    const svg = element.current.querySelector('svg');
-    svg.setAttribute('class', className);
-  }, [
-    className,
-    // `markup` is a dependency of this effect because the SVG is replaced if
-    // it changes.
-    markup,
-  ]);
+  // Convert the icon's SVG markup into a React element that this component can
+  // return as its rendered output. We do this rather than using
+  // `dangerouslySetInnerHTML` to avoid needing to include a wrapper element in
+  // the output.
+  let svgElement = useMemo(() => {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = icons[name];
+    return reactElementFromNode(tmp.firstElementChild);
+  }, [name]);
 
-  return <span dangerouslySetInnerHTML={markup} ref={element} />;
+  // Add any customized properties. We do this in a separate step to avoid
+  // re-parsing the SVG if `name` has not changed.
+  svgElement = useMemo(() => {
+    if (className) {
+      return cloneElement(svgElement, { className });
+    } else {
+      return svgElement;
+    }
+  }, [className, svgElement]);
+
+  return svgElement;
 }
 
 SvgIcon.propTypes = {

--- a/src/sidebar/components/test/svg-icon-test.js
+++ b/src/sidebar/components/test/svg-icon-test.js
@@ -12,7 +12,9 @@ describe('SvgIcon', () => {
   it("sets the element's content to the content of the SVG", () => {
     const container = document.createElement('div');
     render(<SvgIcon name="refresh" />, container);
-    assert.ok(container.querySelector('svg'));
+    const svg = container.querySelector('svg');
+    assert.ok(svg);
+    assert.isAbove(svg.childElementCount, 0);
   });
 
   it('throws an error if the icon is unknown', () => {
@@ -26,7 +28,7 @@ describe('SvgIcon', () => {
     const container = document.createElement('div');
     render(<SvgIcon name="refresh" />, container);
     const svg = container.querySelector('svg');
-    assert.equal(svg.getAttribute('class'), '');
+    assert.equal(svg.getAttribute('class'), null);
   });
 
   it('sets the class of the SVG if provided', () => {
@@ -42,5 +44,14 @@ describe('SvgIcon', () => {
     render(<SvgIcon name="collapse-menu" className="thing__icon" />, container);
     const svg = container.querySelector('svg');
     assert.equal(svg.getAttribute('class'), 'thing__icon');
+  });
+
+  it('preserves "width", "height" and "viewBox" attributes from the source', () => {
+    const container = document.createElement('div');
+    render(<SvgIcon name="refresh" />, container);
+    const svg = container.querySelector('svg');
+    assert.equal(svg.getAttribute('width'), '16px');
+    assert.equal(svg.getAttribute('height'), '16px');
+    assert.equal(svg.getAttribute('viewBox'), '0 0 16 16');
   });
 });


### PR DESCRIPTION
This makes it easier to get icons positioned correctly because there is one
less element in the hierarchy to deal with and any class passed to
`SvgIcon` is applied to the root element rendered by that component.

Unfortunately React/Preact don't provide a way to trivially return an HTML
or SVG string as the output from a component without a wrapping element.

The implementation therefore works by first using the browser's HTML parser (via
`innerHTML`) to parse the SVG markup and then converting the returned
DOM tree to a Preact element, which the `SvgIcon` component returns as
its render output.