### PR TITLE
Open sidebar when highlighting while logged-out

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -53,6 +53,7 @@ function AnnotationController(
   store,
   annotationMapper,
   api,
+  bridge,
   drafts,
   flash,
   groups,
@@ -195,6 +196,11 @@ function AnnotationController(
     if (!isNew(self.annotation)) {
       // Already saved.
       return;
+    }
+
+    if (!self.annotation.user) {
+      // Open sidebar to display error message about needing to login to create highlights.
+      bridge.call('showSidebar');
     }
 
     if (!self.isHighlight()) {

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -115,6 +115,7 @@ describe('annotation', function() {
     let fakeSession;
     let fakeSettings;
     let fakeApi;
+    let fakeBridge;
     let fakeStreamer;
     let sandbox;
 
@@ -248,6 +249,10 @@ describe('annotation', function() {
           },
         };
 
+        fakeBridge = {
+          call: sinon.stub(),
+        };
+
         fakeStreamer = {
           hasPendingDeletion: sinon.stub(),
         };
@@ -256,6 +261,7 @@ describe('annotation', function() {
         $provide.value('annotationMapper', fakeAnnotationMapper);
         $provide.value('store', fakeStore);
         $provide.value('api', fakeApi);
+        $provide.value('bridge', fakeBridge);
         $provide.value('drafts', fakeDrafts);
         $provide.value('flash', fakeFlash);
         $provide.value('groups', fakeGroups);

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -379,6 +379,18 @@ describe('annotation', function() {
         assert.called(fakeDrafts.update);
       });
 
+      it('opens the sidebar when trying to save highlights while logged out', () => {
+        // The sidebar is opened in order to draw the user's attention to
+        // the `You must be logged in to create annotations and highlights` message.
+        const annotation = fixtures.newHighlight();
+        // The user is not logged-in.
+        annotation.user = fakeSession.state.userid = undefined;
+
+        createDirective(annotation);
+
+        assert.calledWith(fakeBridge.call, 'showSidebar');
+      });
+
       it('does not save new annotations on initialization', function() {
         const annotation = fixtures.newAnnotation();
 

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -1,5 +1,5 @@
 <header class="annotation-header" ng-if="!vm.user()">
-  <strong>You must be logged in to create annotations.</strong>
+  <strong>You must be logged in to create annotations and highlights.</strong>
 </header>
 
 <div ng-keydown="vm.onKeydown($event)" ng-if="vm.user()">


### PR DESCRIPTION
When the user creates a highlight while logged out, they appear to
work however, they silently do not get saved. An error message
does pop up in the sidebar informing them they cannot create annotations
when not logged in but they don't see it because the sidebar does not
open when creating a highlight. This makes the error message more
apparent to the user by popping open the sidebar.

Previously the error message only mentioned annotations now it says,
"You must be logged in to create annotations **and highlights**.".

This is a slight adjustment from https://github.com/hypothesis/client/pull/967 but the same concept.