### PR TITLE
Make it easier to interact with the selection 'adder' popup for keyboard users

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -180,8 +180,28 @@ class Adder {
     this._height = () => this.element.getBoundingClientRect().height;
   }
 
+  setupFocusRedirect(elementToFocusNext) {
+    this.element.ownerDocument.addEventListener(
+      'keydown',
+      e => {
+        if (e.key === 'Tab' || e.keyCode === 9) {
+          e.preventDefault();
+          this.focusRedirected = true;
+          elementToFocusNext.focus();
+        }
+      },
+      { capture: true, once: true }
+    );
+  }
+
   /** Hide the adder */
   hide() {
+    if (this.focusRedirected) {
+      // this is a hack.. safari clears selection on focus change,
+      // which triggers hiding
+      this.focusRedirected = false;
+      return;
+    }
     clearTimeout(this._enterTimeout);
     this.element.className = classnames({ 'annotator-adder': true });
     this.element.style.visibility = 'hidden';
@@ -259,6 +279,10 @@ class Adder {
       'annotator-adder--arrow-down': arrowDirection === ARROW_POINTING_DOWN,
       'annotator-adder--arrow-up': arrowDirection === ARROW_POINTING_UP,
     });
+
+    this.setupFocusRedirect(
+      this.element.querySelector(ANNOTATE_BTN_SELECTOR)
+    );
 
     // Some sites make big assumptions about interactive
     // elements on the page. Some want to hide interactive elements


### PR DESCRIPTION
The intended purpose is for [keyboard accessibility](http://www.wuhcag.com/keyboard/).

Here's the working hypothesis as a procedure that's the basis for this change:

1. With only the keyboard, select some text (use caret mode selection if your browser supports it).
2. After the selection is made, the "adder" popup visually prompts.
3. Instinctual interaction with the popup, using the keyboard, is to change focus by tabbing through elements.
4. Next 'Tab' key up should focus away from the selection and move to the first logical element on the adder ("Annotate").
5. The adder having two interactible elements would mean that the next tab hit would focus on the second popup item ("Highlight").
6. When the focus is on the last popup item, the next focusable element would either be:
	a. Cycle back to the first popup item again (focus is trapped)
	b. Bring the focus back to the regular document text flow (next text/element from the selection end boundary)

This commit implements steps 4 and 5, but falls short on steps 6a and 6b.
Instead of step 6, the focus after the adder popup becomes the end of the document.

Other known issues:

Safari and Firefox handle the selection leading to a focus change differently than Chrome.
- Safari clears the selection after focus change, which makes the adder hide since the selection is lost.
	- A flag based check was added as a workaround (hack) for this.
- Firefox behaviour was observed to be different as well, but further investigation is needed.