### PR TITLE
Make sidebar buttons transparent

### DIFF
--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -108,7 +108,7 @@ $base-font-size: 14px;
   .annotator-frame-button {
     transition: background-color .25s .25s;
     @include smallshadow;
-    background: $white;
+    background: rgba(255, 255, 255, 0.7);
     border: solid 1px $gray-lighter;
     border-radius: 4px;
     color: $gray-light;

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -119,15 +119,15 @@ $base-font-size: 14px;
     font-size: 16px;
     margin-bottom: 5px;
 
-    &:active {
-      transition: background-color .25s;
-      background-color: $gray-light;
-    }
-
     &:focus, &:hover {
       background: $white;
       outline: 0;
       color: $text-color;
+    }
+
+    &:active {
+      transition: background-color .25s;
+      background-color: $gray-light;
     }
   }
 

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -108,7 +108,7 @@ $base-font-size: 14px;
   .annotator-frame-button {
     transition: background-color .25s .25s;
     @include smallshadow;
-    background: rgba(255, 255, 255, 0.7);
+    background: $toolbar-button-background;
     border: solid 1px $gray-lighter;
     border-radius: 4px;
     color: $gray-light;

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -106,7 +106,7 @@ $base-font-size: 14px;
   }
 
   .annotator-frame-button {
-    transition: background-color .25s .25s;
+    transition: background-color .25s .25s, color .25s .25s;
     @include smallshadow;
     background: $toolbar-button-background;
     border: solid 1px $gray-lighter;

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -120,7 +120,7 @@ $base-font-size: 14px;
     margin-bottom: 5px;
 
     &:focus, &:hover {
-      background: $white;
+      background-color: $white;
       outline: 0;
       color: $text-color;
     }

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -125,6 +125,7 @@ $base-font-size: 14px;
     }
 
     &:focus, &:hover {
+      background: $white;
       outline: 0;
       color: $text-color;
     }

--- a/src/styles/annotator/bucket-bar.scss
+++ b/src/styles/annotator/bucket-bar.scss
@@ -10,8 +10,9 @@
 }
 
 .annotator-bucket-indicator {
+  transition: background-color .25s .25s;
   box-sizing: border-box;
-  background: $white;
+  background: $toolbar-button-background;
   border: solid 1px $gray-lighter;
   border-radius: 2px 4px 4px 2px;
   right: 0;
@@ -59,6 +60,10 @@
     border-width: 7px;
     border-right: 4px solid $white;
     margin-top: -7px;
+  }
+
+  &:focus, &:hover {
+    background-color: $white;
   }
 
   &.lower, &.upper {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -127,6 +127,7 @@ $highlight-color-third: rgba(192, 192, 49, 0.4);
 $highlight-color-focus: rgba(156, 230, 255, 0.5);
 $top-bar-height: 40px;
 $group-list-width: 280px;
+$toolbar-button-background: rgba(255, 255, 255, 0.7);
 
 // Mixins
 // ------


### PR DESCRIPTION
The three buttons protruding from the sidebar sometimes cover content from the underlying webpages (e.g. https://en.wikipedia.org/wiki/Hypothes.is, covering part of the "Log in" link at the top-right corner). Making these buttons transparent (though still solid on hover) may help seeing the underlying content.
I wasn't sure what the transparency should be (I set it to 0.7), or whether I had to file an issue/feature request first.

Previously:
![image](https://user-images.githubusercontent.com/30059933/59450163-73a46600-8dbd-11e9-8da7-541ad55b212f.png)


Now:
![image](https://user-images.githubusercontent.com/30059933/59450025-2fb16100-8dbd-11e9-8779-ea57ae361bb5.png)