### PR TITLE
Convert loading spinner to Preact

### DIFF
--- a/src/sidebar/components/spinner.js
+++ b/src/sidebar/components/spinner.js
@@ -11,6 +11,7 @@ function Spinner() {
   // have been converted to Preact, we should be able to remove this.
   return (
     <div className="spinner__container">
+      {/* See `.spinner` CSS definition for an explanation of the nested spans. */}
       <span className="spinner">
         <span>
           <span />

--- a/src/sidebar/components/spinner.js
+++ b/src/sidebar/components/spinner.js
@@ -1,20 +1,25 @@
 'use strict';
 
-// @ngInject
-function SpinnerController($animate, $element) {
-  // ngAnimate conflicts with the spinners own CSS
-  $animate.enabled(false, $element);
-}
+const { createElement } = require('preact');
 
-module.exports = {
-  controller: SpinnerController,
-  controllerAs: 'vm',
-  template: `
-    <div class="spinner__container">
-      <span class="spinner">
-        <span><span>
-        </span></span>
+/**
+ * Loading indicator.
+ */
+function Spinner() {
+  // The `spinner__container` div only exists to center the spinner within
+  // the `<spinner>` Angular component element. Once consumers of this component
+  // have been converted to Preact, we should be able to remove this.
+  return (
+    <div className="spinner__container">
+      <span className="spinner">
+        <span>
+          <span />
+        </span>
       </span>
     </div>
-  `,
-};
+  );
+}
+
+Spinner.propTypes = {};
+
+module.exports = Spinner;

--- a/src/sidebar/components/test/spinner-test.js
+++ b/src/sidebar/components/test/spinner-test.js
@@ -1,41 +1,16 @@
 'use strict';
 
-const angular = require('angular');
+const { createElement } = require('preact');
+const { mount } = require('enzyme');
 
-const util = require('../../directive/test/util');
+const Spinner = require('../spinner');
 
-const module = angular.mock.module;
-const inject = angular.mock.inject;
+describe('Spinner', function() {
+  const createSpinner = (props = {}) => mount(<Spinner {...props} />);
 
-describe('spinner', function() {
-  let $animate = null;
-  let $element = null;
-  let sandbox = null;
-
-  before(function() {
-    angular.module('h', []).component('spinner', require('../spinner'));
-  });
-
-  beforeEach(module('h'));
-
-  beforeEach(inject(function(_$animate_) {
-    sandbox = sinon.sandbox.create();
-
-    $animate = _$animate_;
-    sandbox.spy($animate, 'enabled');
-
-    $element = util.createDirective(document, 'spinner');
-  }));
-
-  afterEach(function() {
-    sandbox.restore();
-  });
-
-  it('disables ngAnimate animations for itself', function() {
-    assert.calledOnce($animate.enabled);
-
-    const [enabled, jqElement] = $animate.enabled.getCall(0).args;
-    assert.equal(enabled, false);
-    assert.equal(jqElement[0], $element[0]);
+  // A spinner is a trivial component with no props. Just make sure it renders.
+  it('renders', () => {
+    const wrapper = createSpinner();
+    assert.isTrue(wrapper.exists('.spinner'));
   });
 });

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -191,7 +191,7 @@ function startAngularApp(config) {
       'sortMenu',
       wrapReactComponent(require('./components/sort-menu'))
     )
-    .component('spinner', require('./components/spinner'))
+    .component('spinner', wrapReactComponent(require('./components/spinner')))
     .component('streamContent', require('./components/stream-content'))
     .component('svgIcon', wrapReactComponent(require('./components/svg-icon')))
     .component('tagEditor', require('./components/tag-editor'))


### PR DESCRIPTION
This provides the spinning icon that shows in place of the search icon when the client is fetching data.

I kept the HTML structure unchanged to make the conversion simple. Once we have eliminated all the HTML elements that are just used to indicate the boundaries of Angular components (eg. `<spinner>`, `<sort-menu>`), we should be able to simplify this a bit.

Once this component is converted, the search bar can be converted, and then once that is done and the groups menu is shipped, I think we'll be in a place to convert the whole `<top-bar>` over!