### PR TITLE
Replace references to old groups menu styles in new component

### DIFF
--- a/src/sidebar/components/group-list-v2.js
+++ b/src/sidebar/components/group-list-v2.js
@@ -57,12 +57,12 @@ function GroupList({ serviceUrl, settings }) {
   if (focusedGroup) {
     const icon = focusedGroup.organization.logo;
     label = (
-      <span>
+      <span className="group-list-v2__menu-label">
         <img
-          className="group-list-label__icon group-list-label__icon--organization"
+          className="group-list-v2__menu-icon"
           src={icon || publisherProvidedIcon(settings)}
         />
-        <span className="group-list-label__label">{focusedGroup.name}</span>
+        {focusedGroup.name}
       </span>
     );
   } else {

--- a/src/styles/sidebar/components/group-list-v2.scss
+++ b/src/styles/sidebar/components/group-list-v2.scss
@@ -1,3 +1,22 @@
 .group-list-v2__content {
   min-width: 250px;
 }
+
+.group-list-v2__menu-label {
+  align-items: center;
+  color: $grey-6;
+  display: flex;
+  font-size: $body2-font-size;
+  font-weight: bold;
+}
+
+.group-list-v2__menu-icon {
+  width: 15px;
+  height: 15px;
+  margin-right: 4px;
+
+  // A minor adjustment to make the default icon (the Hypothesis logo) align
+  // better with the text.
+  position: relative;
+  top: 1px;
+}


### PR DESCRIPTION
This replaces some references to the styles for the old groups menu in
the new implementation. The menu label is now slightly darker as it
uses the same grey as the menu items (thanks for the beady-eye @lyzadanger 🙂).
Otherwise there should be no noticeable visual changes.

The CSS itself has been simplified compared to the previous
implementation.

<img width="335" alt="Screenshot 2019-06-18 20 30 47" src="https://user-images.githubusercontent.com/2458/59713745-069f2f00-9208-11e9-9158-53628692c116.png">
