### PR TITLE
Refactor clearSelection out of sidebar-content and into the store

### DIFF
--- a/src/sidebar/components/search-status-bar.js
+++ b/src/sidebar/components/search-status-bar.js
@@ -45,13 +45,16 @@ function SearchStatusBarController(store, rootThread) {
   this.filterActive = function() {
     return !!store.getState().filterQuery;
   };
+
+  this.onClearSelection = function() {
+    store.clearSelection();
+  };
 }
 
 module.exports = {
   controller: SearchStatusBarController,
   controllerAs: 'vm',
   bindings: {
-    onClearSelection: '&',
     selectedTab: '<',
     totalAnnotations: '<',
     totalNotes: '<',

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -4,7 +4,6 @@ const SearchClient = require('../search-client');
 const events = require('../events');
 const isThirdPartyService = require('../util/is-third-party-service');
 const tabs = require('../tabs');
-const uiConstants = require('../ui-constants');
 
 /**
  * Returns the group ID of the first annotation in `results` whose
@@ -314,21 +313,6 @@ function SidebarContentController(
     return (
       !this.isLoading() && !!selectedID && store.annotationExists(selectedID)
     );
-  };
-
-  this.clearSelection = function() {
-    let selectedTab = store.getState().selectedTab;
-    if (
-      !store.getState().selectedTab ||
-      store.getState().selectedTab === uiConstants.TAB_ORPHANS
-    ) {
-      selectedTab = uiConstants.TAB_ANNOTATIONS;
-    }
-
-    store.clearSelectedAnnotations();
-    store.selectTab(selectedTab);
-    store.clearDirectLinkedGroupFetchFailed();
-    store.clearDirectLinkedIds();
   };
 }
 

--- a/src/sidebar/components/test/search-status-bar-test.js
+++ b/src/sidebar/components/test/search-status-bar-test.js
@@ -24,6 +24,7 @@ describe('searchStatusBar', () => {
       clearSelectedAnnotations: sinon.stub(),
       clearDirectLinkedGroupFetchFailed: sinon.stub(),
       clearDirectLinkedIds: sinon.stub(),
+      clearSelection: sinon.stub(),
     };
     angular.mock.module('app', {
       store: fakeStore,

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -5,7 +5,6 @@ const EventEmitter = require('tiny-emitter');
 
 const events = require('../../events');
 const sidebarContent = require('../sidebar-content');
-const uiConstants = require('../../ui-constants');
 const util = require('../../directive/test/util');
 
 let searchClients;
@@ -185,47 +184,6 @@ describe('sidebar.components.sidebar-content', function() {
 
   afterEach(function() {
     return sandbox.restore();
-  });
-
-  describe('clearSelection', () => {
-    it('sets selectedTab to Annotations tab if selectedTab is null', () => {
-      store.selectTab(uiConstants.TAB_ORPHANS);
-      $scope.$digest();
-      ctrl.clearSelection();
-
-      assert.equal(store.getState().selectedTab, uiConstants.TAB_ANNOTATIONS);
-    });
-
-    it('sets selectedTab to Annotations tab if selectedTab is set to orphans', () => {
-      store.selectTab(uiConstants.TAB_ORPHANS);
-      $scope.$digest();
-
-      ctrl.clearSelection();
-
-      assert.equal(store.getState().selectedTab, uiConstants.TAB_ANNOTATIONS);
-    });
-
-    it('clears selected annotations', () => {
-      ctrl.clearSelection();
-
-      assert.equal(store.getState().selectedAnnotationMap, null);
-      assert.equal(store.getState().filterQuery, null);
-    });
-
-    it('clears the directLinkedGroupFetchFailed state', () => {
-      store.setDirectLinkedGroupFetchFailed();
-
-      ctrl.clearSelection();
-
-      assert.isFalse(store.getState().directLinkedGroupFetchFailed);
-    });
-
-    it('clears the direct linked IDs in the store', () => {
-      ctrl.clearSelection();
-
-      assert.equal(store.getState().directLinkedAnnotationId, null);
-      assert.equal(store.getState().directLinkedGroupId, null);
-    });
   });
 
   describe('showSelectedTabs', () => {

--- a/src/sidebar/components/test/thread-list-test.js
+++ b/src/sidebar/components/test/thread-list-test.js
@@ -45,6 +45,7 @@ const threadFixtures = immutable({
 });
 
 let fakeVirtualThread;
+let fakeStore;
 const fakeSettings = {};
 
 class FakeVirtualThreadList extends EventEmitter {
@@ -86,7 +87,6 @@ describe('threadList', function() {
   function createThreadList(inputs) {
     const defaultInputs = {
       thread: threadFixtures.thread,
-      onClearSelection: sinon.stub(),
       onForceVisible: sinon.stub(),
       onFocus: sinon.stub(),
       onSelect: sinon.stub(),
@@ -126,6 +126,10 @@ describe('threadList', function() {
   }
 
   before(function() {
+    fakeStore = {
+      clearSelection: sinon.stub(),
+    };
+
     angular.module('app', []).component('threadList', threadList);
   });
 
@@ -133,6 +137,7 @@ describe('threadList', function() {
     angular.mock.module('app', {
       VirtualThreadList: FakeVirtualThreadList,
       settings: fakeSettings,
+      store: fakeStore,
     });
     threadListContainers = [];
   });
@@ -201,13 +206,12 @@ describe('threadList', function() {
     });
 
     it('clears the selection', function() {
-      const inputs = { onClearSelection: sinon.stub() };
-      const element = createThreadList(inputs);
+      const element = createThreadList();
       element.scope.$broadcast(
         events.BEFORE_ANNOTATION_CREATED,
         annotFixtures.annotation
       );
-      assert.called(inputs.onClearSelection);
+      assert.called(fakeStore.clearSelection);
     });
   });
 

--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -49,7 +49,13 @@ const virtualThreadOptions = {
 };
 
 // @ngInject
-function ThreadListController($element, $scope, settings, VirtualThreadList) {
+function ThreadListController(
+  $element,
+  $scope,
+  settings,
+  store,
+  VirtualThreadList
+) {
   // `visibleThreads` keeps track of the subset of all threads matching the
   // current filters which are in or near the viewport and the view then renders
   // only those threads, using placeholders above and below the visible threads
@@ -162,7 +168,7 @@ function ThreadListController($element, $scope, settings, VirtualThreadList) {
     if (annotation.$highlight || metadata.isReply(annotation)) {
       return;
     }
-    self.onClearSelection();
+    store.clearSelection();
     scrollIntoView(annotation.$tag);
   });
 
@@ -191,8 +197,6 @@ module.exports = {
     onSelect: '&',
     /** Called when a user toggles the expansion state of an annotation thread. */
     onChangeCollapsed: '&',
-    /** Called to clear the current selection. */
-    onClearSelection: '&',
   },
   template: require('../templates/thread-list.html'),
 };

--- a/src/sidebar/store/modules/direct-linked.js
+++ b/src/sidebar/store/modules/direct-linked.js
@@ -64,6 +64,13 @@ const update = {
       directLinkedGroupId: null,
     };
   },
+  CLEAR_SELECTION: function() {
+    return {
+      directLinkedAnnotationId: null,
+      directLinkedGroupId: null,
+      directLinkedGroupFetchFailed: false,
+    };
+  },
 };
 
 const actions = util.actionTypes(update);

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -64,6 +64,29 @@ function freeze(selection) {
   }
 }
 
+const setTab = (selectedTab, newTab) => {
+  // Do nothing if the "new tab" is not a valid tab.
+  if (
+    [
+      uiConstants.TAB_ANNOTATIONS,
+      uiConstants.TAB_NOTES,
+      uiConstants.TAB_ORPHANS,
+    ].indexOf(newTab) === -1
+  ) {
+    return {};
+  }
+  // Shortcut if the tab is already correct, to avoid resetting the sortKey
+  // unnecessarily.
+  if (selectedTab === newTab) {
+    return {};
+  }
+  return {
+    selectedTab: newTab,
+    sortKey: TAB_SORTKEY_DEFAULT[newTab],
+    sortKeysAvailable: TAB_SORTKEYS_AVAILABLE[newTab],
+  };
+};
+
 function init(settings) {
   return {
     // Contains a map of annotation tag:true pairs.
@@ -97,7 +120,20 @@ function init(settings) {
 }
 
 const update = {
-  CLEAR_SELECTION: function() {
+  CLEAR_SELECTION: function(state) {
+    let selectedTab = state.selectedTab;
+    if (selectedTab === uiConstants.TAB_ORPHANS) {
+      selectedTab = uiConstants.TAB_ANNOTATIONS;
+    }
+    const tabSettings = setTab(state.selectedTab, selectedTab);
+    return {
+      filterQuery: null,
+      selectedAnnotationMap: null,
+      ...tabSettings,
+    };
+  },
+
+  CLEAR_SELECTED_ANNOTATIONS: function() {
     return { filterQuery: null, selectedAnnotationMap: null };
   },
 
@@ -122,26 +158,7 @@ const update = {
   },
 
   SELECT_TAB: function(state, action) {
-    // Do nothing if the "new tab" is not a valid tab.
-    if (
-      [
-        uiConstants.TAB_ANNOTATIONS,
-        uiConstants.TAB_NOTES,
-        uiConstants.TAB_ORPHANS,
-      ].indexOf(action.tab) === -1
-    ) {
-      return {};
-    }
-    // Shortcut if the tab is already correct, to avoid resetting the sortKey
-    // unnecessarily.
-    if (state.selectedTab === action.tab) {
-      return {};
-    }
-    return {
-      selectedTab: action.tab,
-      sortKey: TAB_SORTKEY_DEFAULT[action.tab],
-      sortKeysAvailable: TAB_SORTKEYS_AVAILABLE[action.tab],
-    };
+    return setTab(state.selectedTab, action.tab);
   },
 
   ADD_ANNOTATIONS(state, action) {
@@ -312,7 +329,13 @@ function removeSelectedAnnotation(id) {
 
 /** De-select all annotations. */
 function clearSelectedAnnotations() {
-  return { type: actions.CLEAR_SELECTION };
+  return { type: actions.CLEAR_SELECTED_ANNOTATIONS };
+}
+
+function clearSelection() {
+  return {
+    type: actions.CLEAR_SELECTION,
+  };
 }
 
 /**
@@ -331,6 +354,7 @@ module.exports = {
 
   actions: {
     clearSelectedAnnotations: clearSelectedAnnotations,
+    clearSelection: clearSelection,
     focusAnnotations: focusAnnotations,
     highlightAnnotations: highlightAnnotations,
     removeSelectedAnnotation: removeSelectedAnnotation,

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -61,6 +61,63 @@ describe('store', function() {
     });
   });
 
+  describe('clearSelection', () => {
+    // Test clearSelection here over the entire store as it triggers the
+    // CLEAR_SELECTION action in multiple store modules.
+    it('sets `selectedAnnotationMap` to null', () => {
+      store.clearSelection();
+      assert.isNull(store.getState().selectedAnnotationMap);
+    });
+
+    it('sets `filterQuery` to null', () => {
+      store.clearSelection();
+      assert.isNull(store.getState().filterQuery);
+    });
+
+    it('sets `directLinkedGroupFetchFailed` to false', () => {
+      store.clearSelection();
+      assert.isFalse(store.getState().directLinkedGroupFetchFailed);
+    });
+
+    it('sets `directLinkedAnnotationId` to null', () => {
+      store.clearSelection();
+      assert.isNull(store.getState().directLinkedAnnotationId);
+    });
+
+    it('sets `directLinkedGroupId` to null', () => {
+      store.clearSelection();
+      assert.isNull(store.getState().directLinkedGroupId);
+    });
+
+    it('sets `sortKey` to default annotation sort key if set to Orphans', () => {
+      store.selectTab(uiConstants.TAB_ORPHANS);
+      store.clearSelection();
+      assert.equal(store.getState().sortKey, 'Location');
+    });
+
+    it('sets `sortKeysAvailable` to available annotation sort keys if set to Orphans', () => {
+      store.selectTab(uiConstants.TAB_ORPHANS);
+      store.clearSelection();
+      assert.deepEqual(store.getState().sortKeysAvailable, [
+        'Newest',
+        'Oldest',
+        'Location',
+      ]);
+    });
+
+    it('sets `selectedTab` to Annotations if set to Orphans', () => {
+      store.selectTab(uiConstants.TAB_ORPHANS);
+      store.clearSelection();
+      assert.equal(store.getState().selectedTab, uiConstants.TAB_ANNOTATIONS);
+    });
+
+    it('does not change `selectedTab` if set to something other than Orphans', () => {
+      store.selectTab(uiConstants.TAB_NOTES);
+      store.clearSelection();
+      assert.equal(store.getState().selectedTab, uiConstants.TAB_NOTES);
+    });
+  });
+
   describe('#addAnnotations()', function() {
     const ANCHOR_TIME_LIMIT = 1000;
     let clock;

--- a/src/sidebar/templates/sidebar-content.html
+++ b/src/sidebar/templates/sidebar-content.html
@@ -10,7 +10,6 @@
 
 <search-status-bar
   ng-show="!vm.isLoading()"
-  on-clear-selection="vm.clearSelection()"
   selected-tab="vm.selectedTab"
   total-annotations="vm.totalAnnotations"
   total-notes="vm.totalNotes">
@@ -40,7 +39,6 @@
 
 <thread-list
   on-change-collapsed="vm.setCollapsed(id, collapsed)"
-  on-clear-selection="vm.clearSelection()"
   on-focus="vm.focus(annotation)"
   on-select="vm.scrollTo(annotation)"
   show-document-info="false"


### PR DESCRIPTION
Move clearSelection out of the sidebar-content and into the store so that it's not getting passed around from the sidebar-content to child components. 

This is a partial fix for https://github.com/hypothesis/product-backlog/issues/1028.