### PR TITLE
Only allow one group's submenu to be expanded at a time

### DIFF
--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -2,7 +2,6 @@
 
 const propTypes = require('prop-types');
 const { Fragment, createElement } = require('preact');
-const { useState } = require('preact/hooks');
 
 const useStore = require('../store/use-store');
 const { orgName } = require('../util/group-list-item-common');
@@ -19,19 +18,17 @@ const MenuItem = require('./menu-item');
  */
 function GroupListItem({
   analytics,
-  defaultSubmenuOpen = false,
+  isExpanded,
   flash,
   group,
   groups: groupsService,
+  onExpand,
 }) {
   const canLeaveGroup = group.type === 'private';
   const activityUrl = group.links.html;
   const hasActionMenu = activityUrl || canLeaveGroup;
   const isSelectable = !group.scopes.enforced || group.isScopedToUri;
 
-  const [isExpanded, setExpanded] = useState(
-    hasActionMenu ? defaultSubmenuOpen : undefined
-  );
   const focusedGroupId = useStore(store => store.focusedGroupId());
   const isSelected = group.id === focusedGroupId;
 
@@ -63,7 +60,7 @@ function GroupListItem({
     // TODO - Fix this more cleanly in `MenuItem`.
     event.preventDefault();
 
-    setExpanded(!isExpanded);
+    onExpand(!isExpanded);
   };
 
   const copyLink = () => {
@@ -79,7 +76,7 @@ function GroupListItem({
     group.type === 'private' ? 'Copy invite link' : 'Copy activity link';
 
   // Close the submenu when any clicks happen which close the top-level menu.
-  const collapseSubmenu = () => setExpanded(false);
+  const collapseSubmenu = () => onExpand(false);
 
   return (
     <Fragment>
@@ -87,7 +84,7 @@ function GroupListItem({
         icon={group.logo || 'blank'}
         iconAlt={orgName(group)}
         isDisabled={!isSelectable}
-        isExpanded={isExpanded}
+        isExpanded={hasActionMenu ? isExpanded : undefined}
         isSelected={isSelected}
         isSubmenuVisible={isExpanded}
         label={group.name}
@@ -142,8 +139,17 @@ function GroupListItem({
 GroupListItem.propTypes = {
   group: propTypes.object.isRequired,
 
-  /** Whether the submenu is open when the item is initially rendered. */
-  defaultSubmenuOpen: propTypes.bool,
+  /**
+   * Whether the submenu for this group is expanded.
+   */
+  isExpanded: propTypes.bool,
+
+  /**
+   * Callback invoked to expand or collapse the current group.
+   *
+   * @type {(expand: boolean) => any}
+   */
+  onExpand: propTypes.func,
 
   // Injected services.
   analytics: propTypes.object.isRequired,

--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -9,6 +9,7 @@ const { withServices } = require('../util/service-context');
 const { copyText } = require('../util/copy-to-clipboard');
 
 const MenuItem = require('./menu-item');
+const Slider = require('./slider');
 
 /**
  * An item in the groups selection menu.
@@ -91,7 +92,7 @@ function GroupListItem({
         onClick={isSelectable ? focusGroup : toggleSubmenu}
         onToggleSubmenu={toggleSubmenu}
       />
-      {isExpanded && (
+      <Slider visible={isExpanded}>
         <div className="group-list-item__submenu">
           <ul onClick={collapseSubmenu}>
             {activityUrl && (
@@ -131,7 +132,7 @@ function GroupListItem({
             </p>
           )}
         </div>
-      )}
+      </Slider>
     </Fragment>
   );
 }

--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -9,7 +9,6 @@ const { withServices } = require('../util/service-context');
 const { copyText } = require('../util/copy-to-clipboard');
 
 const MenuItem = require('./menu-item');
-const Slider = require('./slider');
 
 /**
  * An item in the groups selection menu.
@@ -80,20 +79,18 @@ function GroupListItem({
   const collapseSubmenu = () => onExpand(false);
 
   return (
-    <Fragment>
-      <MenuItem
-        icon={group.logo || 'blank'}
-        iconAlt={orgName(group)}
-        isDisabled={!isSelectable}
-        isExpanded={hasActionMenu ? isExpanded : undefined}
-        isSelected={isSelected}
-        isSubmenuVisible={isExpanded}
-        label={group.name}
-        onClick={isSelectable ? focusGroup : toggleSubmenu}
-        onToggleSubmenu={toggleSubmenu}
-      />
-      <Slider visible={isExpanded}>
-        <div className="group-list-item__submenu">
+    <MenuItem
+      icon={group.logo || 'blank'}
+      iconAlt={orgName(group)}
+      isDisabled={!isSelectable}
+      isExpanded={hasActionMenu ? isExpanded : undefined}
+      isSelected={isSelected}
+      isSubmenuVisible={isExpanded}
+      label={group.name}
+      onClick={isSelectable ? focusGroup : toggleSubmenu}
+      onToggleSubmenu={toggleSubmenu}
+      renderSubmenu={() => (
+        <Fragment>
           <ul onClick={collapseSubmenu}>
             {activityUrl && (
               <li>
@@ -131,9 +128,9 @@ function GroupListItem({
               This group is restricted to specific URLs.
             </p>
           )}
-        </div>
-      </Slider>
-    </Fragment>
+        </Fragment>
+      )}
+    />
   );
 }
 

--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -83,7 +83,7 @@ function GroupListItem({
       icon={group.logo || 'blank'}
       iconAlt={orgName(group)}
       isDisabled={!isSelectable}
-      isExpanded={hasActionMenu ? isExpanded : undefined}
+      isExpanded={hasActionMenu ? isExpanded : false}
       isSelected={isSelected}
       isSubmenuVisible={isExpanded}
       label={group.name}

--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -89,7 +89,7 @@ function GroupListItem({
       label={group.name}
       onClick={isSelectable ? focusGroup : toggleSubmenu}
       onToggleSubmenu={toggleSubmenu}
-      renderSubmenu={() => (
+      submenu={
         <Fragment>
           <ul onClick={collapseSubmenu}>
             {activityUrl && (
@@ -129,7 +129,7 @@ function GroupListItem({
             </p>
           )}
         </Fragment>
-      )}
+      }
     />
   );
 }

--- a/src/sidebar/components/group-list-section.js
+++ b/src/sidebar/components/group-list-section.js
@@ -9,21 +9,39 @@ const MenuSection = require('./menu-section');
 /**
  * A labeled section of the groups list.
  */
-function GroupListSection({ groups, heading }) {
+function GroupListSection({ expandedGroup, onExpandGroup, groups, heading }) {
   return (
     <MenuSection heading={heading}>
       {groups.map(group => (
-        <GroupListItem key={group.id} group={group} />
+        <GroupListItem
+          key={group.id}
+          isExpanded={group === expandedGroup}
+          onExpand={expanded => onExpandGroup(expanded ? group : null)}
+          group={group}
+        />
       ))}
     </MenuSection>
   );
 }
 
 GroupListSection.propTypes = {
+  /**
+   * The group whose submenu is currently expanded, if any.
+   */
+  expandedGroup: propTypes.object,
   /* The list of groups to be displayed in the group list section. */
   groups: propTypes.arrayOf(propTypes.object),
   /* The string name of the group list section. */
   heading: propTypes.string,
+  /**
+   * Callback invoked when a group is expanded or collapsed.
+   *
+   * The argument is the group being expanded, or `null` if the expanded group
+   * is being collapsed.
+   *
+   * @type {(group: Group|null) => any}
+   */
+  onExpandGroup: propTypes.func,
 };
 
 module.exports = GroupListSection;

--- a/src/sidebar/components/group-list-section.js
+++ b/src/sidebar/components/group-list-section.js
@@ -26,7 +26,8 @@ function GroupListSection({ expandedGroup, onExpandGroup, groups, heading }) {
 
 GroupListSection.propTypes = {
   /**
-   * The group whose submenu is currently expanded, if any.
+   * The `Group` whose submenu is currently expanded, or `null` if no group
+   * is currently expanded.
    */
   expandedGroup: propTypes.object,
   /* The list of groups to be displayed in the group list section. */

--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { createElement } = require('preact');
-const { useMemo } = require('preact/hooks');
+const { useMemo, useState } = require('preact/hooks');
 const propTypes = require('prop-types');
 
 const isThirdPartyService = require('../util/is-third-party-service');
@@ -53,6 +53,13 @@ function GroupList({ serviceUrl, settings }) {
   const canCreateNewGroup = userid && !isThirdPartyUser(userid, authDomain);
   const newGroupLink = serviceUrl('groups.new');
 
+  // The group whose submenu is currently open, or `null` if no group item is
+  // currently expanded.
+  //
+  // nb. If we create other menus that behave similarly in future, we may want
+  // to move this state to the `Menu` component.
+  const [expandedGroup, setExpandedGroup] = useState(null);
+
   let label;
   if (focusedGroup) {
     const icon = focusedGroup.organization.logo;
@@ -88,18 +95,27 @@ function GroupList({ serviceUrl, settings }) {
     >
       {currentGroupsSorted.length > 0 && (
         <GroupListSection
+          expandedGroup={expandedGroup}
+          onExpandGroup={setExpandedGroup}
           heading="Currently Viewing"
           groups={currentGroupsSorted}
         />
       )}
       {featuredGroupsSorted.length > 0 && (
         <GroupListSection
+          expandedGroup={expandedGroup}
+          onExpandGroup={setExpandedGroup}
           heading="Featured Groups"
           groups={featuredGroupsSorted}
         />
       )}
       {myGroupsSorted.length > 0 && (
-        <GroupListSection heading="My Groups" groups={myGroupsSorted} />
+        <GroupListSection
+          expandedGroup={expandedGroup}
+          onExpandGroup={setExpandedGroup}
+          heading="My Groups"
+          groups={myGroupsSorted}
+        />
       )}
 
       {canCreateNewGroup && (

--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -91,6 +91,7 @@ function GroupList({ serviceUrl, settings }) {
       align="left"
       contentClass="group-list__content"
       label={label}
+      onOpenChanged={() => setExpandedGroup(null)}
       title="Select group"
     >
       {currentGroupsSorted.length > 0 && (

--- a/src/sidebar/components/menu-item.js
+++ b/src/sidebar/components/menu-item.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const classnames = require('classnames');
-const { Fragment, createElement } = require('preact');
+const { createElement } = require('preact');
 const propTypes = require('prop-types');
 
 const { onActivate } = require('../util/on-activate');
@@ -36,7 +36,7 @@ function MenuItem({
   label,
   onClick,
   onToggleSubmenu,
-  renderSubmenu,
+  submenu,
 }) {
   const iconClass = 'menu-item__icon';
   const iconIsUrl = icon && icon.indexOf('/') !== -1;
@@ -111,7 +111,7 @@ function MenuItem({
       </div>
       {typeof isSubmenuVisible === 'boolean' && (
         <Slider visible={isSubmenuVisible}>
-          <div className="menu-item__submenu">{renderSubmenu()}</div>
+          <div className="menu-item__submenu">{submenu}</div>
         </Slider>
       )}
     </div>
@@ -183,10 +183,13 @@ MenuItem.propTypes = {
   onToggleSubmenu: propTypes.func,
 
   /**
-   * Function called to render the item's submenu when `isSubmenuVisible`
-   * is `true`.
+   * Contents of the submenu for this item.
+   *
+   * This is typically a list of `MenuItem` components with the `isSubmenuItem`
+   * prop set to `true`, but can include other content as well.
+   * The submenu is only rendered if `isSubmenuVisible` is `true`.
    */
-  renderSubmenu: propTypes.func,
+  submenu: propTypes.any,
 };
 
 module.exports = MenuItem;

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -50,10 +50,20 @@ function Menu({
   contentClass,
   defaultOpen = false,
   label,
+  onOpenChanged,
   menuIndicator = true,
   title,
 }) {
   const [isOpen, setOpen] = useState(defaultOpen);
+
+  // Notify parent when menu is opened or closed.
+  const wasOpen = useRef(isOpen);
+  useEffect(() => {
+    if (typeof onOpenChanged === 'function' && wasOpen.current !== isOpen) {
+      wasOpen.current = isOpen;
+      onOpenChanged(isOpen);
+    }
+  }, [isOpen, onOpenChanged]);
 
   // Toggle menu when user presses toggle button. The menu is shown on mouse
   // press for a more responsive/native feel but also handles a click event for
@@ -239,6 +249,14 @@ Menu.propTypes = {
    * Whether the menu is open or closed when initially rendered.
    */
   defaultOpen: propTypes.bool,
+
+  /**
+   * Callback invoked when the menu is opened or closed.
+   *
+   * This can be used, for example, to reset any ephemeral state that the
+   * menu content may have.
+   */
+  onOpenChanged: propTypes.func,
 
   /**
    * A title for the menu. This is important for accessibility if the menu's

--- a/src/sidebar/components/slider.js
+++ b/src/sidebar/components/slider.js
@@ -8,46 +8,66 @@ const { useCallback, useEffect, useRef, useState } = require('preact/hooks');
  * A container which reveals its content when `visible` is `true` using
  * a sliding animation.
  *
+ * When the content is not partially or wholly visible, it is removed from the
+ * DOM using `display: none` so it does not appear in the keyboard navigation
+ * order.
+ *
  * Currently the only reveal/expand direction supported is top-down.
  */
-function Slider({ children, visible, queueTask = setTimeout }) {
+function Slider({ children, visible }) {
   const containerRef = useRef(null);
   const [containerHeight, setContainerHeight] = useState(visible ? 'auto' : 0);
+
+  // Whether the content is currently partially or wholly visible. This is
+  // different from `visible` when collapsing as it is true until the collapse
+  // animation completes.
+  const [contentVisible, setContentVisible] = useState(visible);
 
   // Adjust the container height when the `visible` prop changes.
   useEffect(() => {
     const isVisible = containerHeight !== 0;
     if (visible === isVisible) {
       // Do nothing after the initial mount.
-      return null;
+      return;
     }
 
     const el = containerRef.current;
     if (visible) {
+      // Show the content synchronously so that we can measure it here.
+      el.style.display = '';
+
+      // Make content visible in future renders.
+      setContentVisible(true);
+
       // When expanding, transition the container to the current fixed height
       // of the content. After the transition completes, we'll reset to "auto"
       // height to adapt to future content changes.
       setContainerHeight(el.scrollHeight);
-      return null;
     } else {
       // When collapsing, immediately change the current height to a fixed height
-      // (in case it is currently "auto"), and then one tick later, transition
-      // to 0.
+      // (in case it is currently "auto"), force a synchronous layout,
+      // then transition to 0.
       //
       // These steps are needed because browsers will not animate transitions
       // from "auto" => "0" and may not animate "auto" => fixed height => 0
-      // if the first transition happens in the same tick.
+      // if the layout tree transitions directly from "auto" => 0.
       el.style.height = `${el.scrollHeight}px`;
-      const timer = queueTask(() => {
-        setContainerHeight(0);
-      });
-      return () => clearTimeout(timer);
+
+      // Force a sync layout.
+      el.getBoundingClientRect();
+
+      setContainerHeight(0);
     }
-  }, [containerHeight, queueTask, visible]);
+  }, [containerHeight, visible]);
 
   const handleTransitionEnd = useCallback(() => {
     if (visible) {
       setContainerHeight('auto');
+    } else {
+      // When the collapse animation completes, stop rendering the content so
+      // that the browser has fewer nodes to render and the content is removed
+      // from keyboard navigation.
+      setContentVisible(false);
     }
   }, [setContainerHeight, visible]);
 
@@ -60,9 +80,10 @@ function Slider({ children, visible, queueTask = setTimeout }) {
       ontransitionend={handleTransitionEnd}
       ref={containerRef}
       style={{
+        display: contentVisible ? '' : 'none',
         height: containerHeight,
         overflow: 'hidden',
-        transition: 'height 0.15s ease-in',
+        transition: `height 0.15s ease-in`,
       }}
     >
       {children}
@@ -77,13 +98,6 @@ Slider.propTypes = {
    * Whether the content should be visible or not.
    */
   visible: propTypes.bool,
-
-  /**
-   * Test seam.
-   *
-   * Schedule a callback to run on the next tick.
-   */
-  queueTask: propTypes.func,
 };
 
 module.exports = Slider;

--- a/src/sidebar/components/slider.js
+++ b/src/sidebar/components/slider.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const propTypes = require('prop-types');
+const { createElement } = require('preact');
+const { useCallback, useEffect, useRef, useState } = require('preact/hooks');
+
+/**
+ * A container which reveals its content when `visible` is `true` using
+ * a sliding animation.
+ *
+ * Currently the only reveal/expand direction supported is top-down.
+ */
+function Slider({ children, visible, queueTask = setTimeout }) {
+  const containerRef = useRef(null);
+  const [containerHeight, setContainerHeight] = useState(visible ? 'auto' : 0);
+
+  // Adjust the container height when the `visible` prop changes.
+  useEffect(() => {
+    const isVisible = containerHeight !== 0;
+    if (visible === isVisible) {
+      // Do nothing after the initial mount.
+      return null;
+    }
+
+    const el = containerRef.current;
+    if (visible) {
+      // When expanding, transition the container to the current fixed height
+      // of the content. After the transition completes, we'll reset to "auto"
+      // height to adapt to future content changes.
+      setContainerHeight(el.scrollHeight);
+      return null;
+    } else {
+      // When collapsing, immediately change the current height to a fixed height
+      // (in case it is currently "auto"), and then one tick later, transition
+      // to 0.
+      //
+      // These steps are needed because browsers will not animate transitions
+      // from "auto" => "0" and may not animate "auto" => fixed height => 0
+      // if the first transition happens in the same tick.
+      el.style.height = `${el.scrollHeight}px`;
+      const timer = queueTask(() => {
+        setContainerHeight(0);
+      });
+      return () => clearTimeout(timer);
+    }
+  }, [containerHeight, queueTask, visible]);
+
+  const handleTransitionEnd = useCallback(() => {
+    if (visible) {
+      setContainerHeight('auto');
+    }
+  }, [setContainerHeight, visible]);
+
+  return (
+    <div
+      // nb. Preact uses "ontransitionend" rather than "onTransitionEnd".
+      // See https://bugs.chromium.org/p/chromium/issues/detail?id=961193
+      //
+      // eslint-disable-next-line react/no-unknown-property
+      ontransitionend={handleTransitionEnd}
+      ref={containerRef}
+      style={{
+        height: containerHeight,
+        overflow: 'hidden',
+        transition: 'height 0.15s ease-in',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+Slider.propTypes = {
+  children: propTypes.any,
+
+  /**
+   * Whether the content should be visible or not.
+   */
+  visible: propTypes.bool,
+
+  /**
+   * Test seam.
+   *
+   * Schedule a callback to run on the next tick.
+   */
+  queueTask: propTypes.func,
+};
+
+module.exports = Slider;

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -179,8 +179,29 @@ describe('GroupListItem', () => {
     });
   });
 
+  it('expands submenu if `isExpanded` is `true`', () => {
+    const wrapper = createGroupListItem(fakeGroup, { isExpanded: true });
+    assert.isTrue(
+      wrapper
+        .find('MenuItem')
+        .first()
+        .prop('isExpanded')
+    );
+  });
+
+  it('collapses submenu if `isExpanded` is `false`', () => {
+    const wrapper = createGroupListItem(fakeGroup, { isExpanded: false });
+    assert.isFalse(
+      wrapper
+        .find('MenuItem')
+        .first()
+        .prop('isExpanded')
+    );
+  });
+
   it('toggles submenu when toggle is clicked', () => {
-    const wrapper = createGroupListItem(fakeGroup);
+    const onExpand = sinon.stub();
+    const wrapper = createGroupListItem(fakeGroup, { onExpand });
     const toggleSubmenu = () => {
       const dummyEvent = new Event();
       act(() => {
@@ -194,9 +215,12 @@ describe('GroupListItem', () => {
     };
 
     toggleSubmenu();
-    assert.isTrue(wrapper.exists('ul'));
+    assert.calledWith(onExpand, true);
+    onExpand.resetHistory();
+
+    wrapper.setProps({ isExpanded: true });
     toggleSubmenu();
-    assert.isFalse(wrapper.exists('ul'));
+    assert.calledWith(onExpand, false);
   });
 
   it('does not show submenu toggle if there are no available actions', () => {
@@ -209,14 +233,14 @@ describe('GroupListItem', () => {
   it('does not show link to activity page if not available', () => {
     fakeGroup.links.html = null;
     const wrapper = createGroupListItem(fakeGroup, {
-      defaultSubmenuOpen: true,
+      isExpanded: true,
     });
     assert.isFalse(wrapper.exists('MenuItem[label="View group activity"]'));
   });
 
   it('shows link to activity page if available', () => {
     const wrapper = createGroupListItem(fakeGroup, {
-      defaultSubmenuOpen: true,
+      isExpanded: true,
     });
     assert.isTrue(wrapper.exists('MenuItem[label="View group activity"]'));
   });
@@ -224,7 +248,7 @@ describe('GroupListItem', () => {
   it('does not show "Leave" action if user cannot leave', () => {
     fakeGroup.type = 'open';
     const wrapper = createGroupListItem(fakeGroup, {
-      defaultSubmenuOpen: true,
+      isExpanded: true,
     });
     assert.isFalse(wrapper.exists('MenuItem[label="Leave group"]'));
   });
@@ -232,14 +256,14 @@ describe('GroupListItem', () => {
   it('shows "Leave" action if user can leave', () => {
     fakeGroup.type = 'private';
     const wrapper = createGroupListItem(fakeGroup, {
-      defaultSubmenuOpen: true,
+      isExpanded: true,
     });
     assert.isTrue(wrapper.exists('MenuItem[label="Leave group"]'));
   });
 
   it('prompts to leave group if "Leave" action is clicked', () => {
     const wrapper = createGroupListItem(fakeGroup, {
-      defaultSubmenuOpen: true,
+      isExpanded: true,
     });
     clickMenuItem(wrapper, 'Leave group');
     assert.called(window.confirm);
@@ -248,7 +272,7 @@ describe('GroupListItem', () => {
 
   it('leaves group if "Leave" is clicked and user confirms', () => {
     const wrapper = createGroupListItem(fakeGroup, {
-      defaultSubmenuOpen: true,
+      isExpanded: true,
     });
     window.confirm.returns(true);
     clickMenuItem(wrapper, 'Leave group');
@@ -277,7 +301,7 @@ describe('GroupListItem', () => {
       fakeGroup.scopes.enforced = enforced;
       fakeGroup.isScopedToUri = isScopedToUri;
       const wrapper = createGroupListItem(fakeGroup, {
-        defaultSubmenuOpen: true,
+        isExpanded: true,
       });
       assert.equal(
         wrapper
@@ -316,7 +340,7 @@ describe('GroupListItem', () => {
       fakeGroup.type = groupType;
       fakeGroup.links.html = hasLink ? 'https://anno.co/groups/1' : null;
       const wrapper = createGroupListItem(fakeGroup, {
-        defaultSubmenuOpen: true,
+        isExpanded: true,
       });
       const copyAction = wrapper
         .find('MenuItem')
@@ -332,7 +356,7 @@ describe('GroupListItem', () => {
 
   it('copies activity URL if "Copy link" action is clicked', () => {
     const wrapper = createGroupListItem(fakeGroup, {
-      defaultSubmenuOpen: true,
+      isExpanded: true,
     });
     clickMenuItem(wrapper, 'Copy invite link');
     assert.calledWith(fakeCopyText, 'https://annotate.com/groups/groupid');
@@ -342,7 +366,7 @@ describe('GroupListItem', () => {
   it('reports an error if "Copy link" action fails', () => {
     fakeCopyText.throws(new Error('Something went wrong'));
     const wrapper = createGroupListItem(fakeGroup, {
-      defaultSubmenuOpen: true,
+      isExpanded: true,
     });
     clickMenuItem(wrapper, 'Copy invite link');
     assert.calledWith(fakeCopyText, 'https://annotate.com/groups/groupid');

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -62,8 +62,14 @@ describe('GroupListItem', () => {
     }
     FakeMenuItem.displayName = 'MenuItem';
 
+    function FakeSlider({ children, visible }) {
+      return visible ? children : null;
+    }
+    FakeSlider.displayName = 'Slider';
+
     GroupListItem.$imports.$mock({
       './menu-item': FakeMenuItem,
+      './slider': FakeSlider,
       '../util/copy-to-clipboard': {
         copyText: fakeCopyText,
       },

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -69,7 +69,6 @@ describe('GroupListItem', () => {
 
     GroupListItem.$imports.$mock({
       './menu-item': FakeMenuItem,
-      './slider': FakeSlider,
       '../util/copy-to-clipboard': {
         copyText: fakeCopyText,
       },
@@ -236,19 +235,29 @@ describe('GroupListItem', () => {
     assert.isUndefined(wrapper.find('MenuItem').prop('isExpanded'));
   });
 
+  function getSubmenu(wrapper) {
+    const renderSubmenu = wrapper
+      .find('MenuItem')
+      .first()
+      .prop('renderSubmenu');
+    return mount(<div>{renderSubmenu()}</div>);
+  }
+
   it('does not show link to activity page if not available', () => {
     fakeGroup.links.html = null;
     const wrapper = createGroupListItem(fakeGroup, {
       isExpanded: true,
     });
-    assert.isFalse(wrapper.exists('MenuItem[label="View group activity"]'));
+    const submenu = getSubmenu(wrapper);
+    assert.isFalse(submenu.exists('MenuItem[label="View group activity"]'));
   });
 
   it('shows link to activity page if available', () => {
     const wrapper = createGroupListItem(fakeGroup, {
       isExpanded: true,
     });
-    assert.isTrue(wrapper.exists('MenuItem[label="View group activity"]'));
+    const submenu = getSubmenu(wrapper);
+    assert.isTrue(submenu.exists('MenuItem[label="View group activity"]'));
   });
 
   it('does not show "Leave" action if user cannot leave', () => {
@@ -256,7 +265,8 @@ describe('GroupListItem', () => {
     const wrapper = createGroupListItem(fakeGroup, {
       isExpanded: true,
     });
-    assert.isFalse(wrapper.exists('MenuItem[label="Leave group"]'));
+    const submenu = getSubmenu(wrapper);
+    assert.isFalse(submenu.exists('MenuItem[label="Leave group"]'));
   });
 
   it('shows "Leave" action if user can leave', () => {
@@ -264,14 +274,18 @@ describe('GroupListItem', () => {
     const wrapper = createGroupListItem(fakeGroup, {
       isExpanded: true,
     });
-    assert.isTrue(wrapper.exists('MenuItem[label="Leave group"]'));
+    const submenu = getSubmenu(wrapper);
+    assert.isTrue(submenu.exists('MenuItem[label="Leave group"]'));
   });
 
   it('prompts to leave group if "Leave" action is clicked', () => {
     const wrapper = createGroupListItem(fakeGroup, {
       isExpanded: true,
     });
-    clickMenuItem(wrapper, 'Leave group');
+
+    const submenu = getSubmenu(wrapper);
+    clickMenuItem(submenu, 'Leave group');
+
     assert.called(window.confirm);
     assert.notCalled(fakeGroupsService.leave);
   });
@@ -281,7 +295,10 @@ describe('GroupListItem', () => {
       isExpanded: true,
     });
     window.confirm.returns(true);
-    clickMenuItem(wrapper, 'Leave group');
+
+    const submenu = getSubmenu(wrapper);
+    clickMenuItem(submenu, 'Leave group');
+
     assert.called(window.confirm);
     assert.calledWith(fakeGroupsService.leave, fakeGroup.id);
   });
@@ -316,7 +333,9 @@ describe('GroupListItem', () => {
           .prop('isDisabled'),
         expectDisabled
       );
-      assert.equal(wrapper.exists('.group-list-item__footer'), expectDisabled);
+
+      const submenu = getSubmenu(wrapper);
+      assert.equal(submenu.exists('.group-list-item__footer'), expectDisabled);
     });
   });
 
@@ -348,7 +367,8 @@ describe('GroupListItem', () => {
       const wrapper = createGroupListItem(fakeGroup, {
         isExpanded: true,
       });
-      const copyAction = wrapper
+      const submenu = getSubmenu(wrapper);
+      const copyAction = submenu
         .find('MenuItem')
         .filterWhere(n => n.prop('label').startsWith('Copy'));
 
@@ -364,7 +384,7 @@ describe('GroupListItem', () => {
     const wrapper = createGroupListItem(fakeGroup, {
       isExpanded: true,
     });
-    clickMenuItem(wrapper, 'Copy invite link');
+    clickMenuItem(getSubmenu(wrapper), 'Copy invite link');
     assert.calledWith(fakeCopyText, 'https://annotate.com/groups/groupid');
     assert.calledWith(fakeFlash.info, 'Copied link for "Test"');
   });
@@ -374,7 +394,7 @@ describe('GroupListItem', () => {
     const wrapper = createGroupListItem(fakeGroup, {
       isExpanded: true,
     });
-    clickMenuItem(wrapper, 'Copy invite link');
+    clickMenuItem(getSubmenu(wrapper), 'Copy invite link');
     assert.calledWith(fakeCopyText, 'https://annotate.com/groups/groupid');
     assert.calledWith(fakeFlash.error, 'Unable to copy link');
   });

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -232,7 +232,7 @@ describe('GroupListItem', () => {
     fakeGroup.links.html = null;
     fakeGroup.type = 'open';
     const wrapper = createGroupListItem(fakeGroup);
-    assert.isUndefined(wrapper.find('MenuItem').prop('isExpanded'));
+    assert.isFalse(wrapper.find('MenuItem').prop('isExpanded'));
   });
 
   function getSubmenu(wrapper) {

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -236,11 +236,11 @@ describe('GroupListItem', () => {
   });
 
   function getSubmenu(wrapper) {
-    const renderSubmenu = wrapper
+    const submenu = wrapper
       .find('MenuItem')
       .first()
-      .prop('renderSubmenu');
-    return mount(<div>{renderSubmenu()}</div>);
+      .prop('submenu');
+    return mount(<div>{submenu}</div>);
   }
 
   it('does not show link to activity page if not available', () => {

--- a/src/sidebar/components/test/group-list-section-test.js
+++ b/src/sidebar/components/test/group-list-section-test.js
@@ -22,8 +22,11 @@ describe('GroupListSection', () => {
   const createGroupListSection = ({
     groups = testGroups,
     heading = 'Test section',
+    ...props
   } = {}) => {
-    return shallow(<GroupListSection groups={groups} heading={heading} />);
+    return shallow(
+      <GroupListSection groups={groups} heading={heading} {...props} />
+    );
   };
 
   it('renders heading', () => {
@@ -34,5 +37,40 @@ describe('GroupListSection', () => {
   it('renders groups', () => {
     const wrapper = createGroupListSection();
     assert.equal(wrapper.find(GroupListItem).length, testGroups.length);
+  });
+
+  it('expands group specified by `expandedGroup` prop', () => {
+    const wrapper = createGroupListSection();
+    for (let i = 0; i < testGroups.length; i++) {
+      wrapper.setProps({ expandedGroup: testGroups[i] });
+      wrapper.find(GroupListItem).forEach((n, idx) => {
+        assert.equal(n.prop('isExpanded'), idx === i);
+      });
+    }
+  });
+
+  it("sets expanded group when a group's submenu is expanded", () => {
+    const onExpandGroup = sinon.stub();
+    const wrapper = createGroupListSection({ onExpandGroup });
+    wrapper
+      .find(GroupListItem)
+      .first()
+      .props()
+      .onExpand(true);
+    assert.calledWith(onExpandGroup, testGroups[0]);
+  });
+
+  it("resets expanded group when group's submenu is collapsed", () => {
+    const onExpandGroup = sinon.stub();
+    const wrapper = createGroupListSection({
+      expandedGroup: testGroups[0],
+      onExpandGroup,
+    });
+    wrapper
+      .find(GroupListItem)
+      .first()
+      .props()
+      .onExpand(false);
+    assert.calledWith(onExpandGroup, null);
   });
 });

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -173,16 +173,21 @@ describe('GroupList', () => {
     assert.equal(img.prop('src'), 'test-icon');
   });
 
-  it('sets or resets expanded group item', () => {
+  /**
+   * Assert that the submenu for a particular group is expanded (or none is
+   * if `group` is `null`).
+   */
+  const verifyGroupIsExpanded = (wrapper, group) =>
+    wrapper.find('GroupListSection').forEach(section => {
+      assert.equal(section.prop('expandedGroup'), group);
+    });
+
+  it("sets or resets expanded group item when a group's submenu toggle is clicked", () => {
     const testGroups = populateGroupSections();
 
     // Render group list. Initially no submenu should be expanded.
     const wrapper = createGroupList();
-    const verifyGroupIsExpanded = group =>
-      wrapper.find('GroupListSection').forEach(section => {
-        assert.equal(section.prop('expandedGroup'), group);
-      });
-    verifyGroupIsExpanded(null);
+    verifyGroupIsExpanded(wrapper, null);
 
     // Expand a group in one of the sections.
     act(() => {
@@ -192,7 +197,7 @@ describe('GroupList', () => {
         .prop('onExpandGroup')(testGroups[0]);
     });
     wrapper.update();
-    verifyGroupIsExpanded(testGroups[0]);
+    verifyGroupIsExpanded(wrapper, testGroups[0]);
 
     // Reset expanded group.
     act(() => {
@@ -202,6 +207,28 @@ describe('GroupList', () => {
         .prop('onExpandGroup')(null);
     });
     wrapper.update();
-    verifyGroupIsExpanded(null);
+    verifyGroupIsExpanded(wrapper, null);
+  });
+
+  it('resets expanded group when menu is closed', () => {
+    const testGroups = populateGroupSections();
+    const wrapper = createGroupList();
+
+    // Expand one of the submenus.
+    act(() => {
+      wrapper
+        .find('GroupListSection')
+        .first()
+        .prop('onExpandGroup')(testGroups[0]);
+    });
+    wrapper.update();
+    verifyGroupIsExpanded(wrapper, testGroups[0]);
+
+    // Close the menu
+    act(() => {
+      wrapper.find('Menu').prop('onOpenChanged')(false);
+    });
+    wrapper.update();
+    verifyGroupIsExpanded(wrapper, null);
   });
 });

--- a/src/sidebar/components/test/menu-item-test.js
+++ b/src/sidebar/components/test/menu-item-test.js
@@ -58,8 +58,6 @@ describe('MenuItem', () => {
   it('shows the submenu indicator if `isSubmenuVisible` is a boolean', () => {
     const wrapper = createMenuItem({
       isSubmenuVisible: true,
-      // eslint-disable-next-line react/display-name
-      renderSubmenu: () => <div>Submenu</div>,
     });
     assert.isTrue(wrapper.exists('SvgIcon[name="collapse-menu"]'));
 
@@ -77,8 +75,6 @@ describe('MenuItem', () => {
     const wrapper = createMenuItem({
       isSubmenuVisible: true,
       onToggleSubmenu,
-      // eslint-disable-next-line react/display-name
-      renderSubmenu: () => <div>Submenu</div>,
     });
     wrapper.find('.menu-item__toggle').simulate('click');
     assert.called(onToggleSubmenu);
@@ -116,8 +112,7 @@ describe('MenuItem', () => {
   it('shows submenu content if `isSubmenuVisible` is true', () => {
     const wrapper = createMenuItem({
       isSubmenuVisible: true,
-      // eslint-disable-next-line react/display-name
-      renderSubmenu: () => <div>Submenu content</div>,
+      submenu: <div>Submenu content</div>,
     });
     assert.equal(wrapper.find('Slider').prop('visible'), true);
     assert.equal(
@@ -132,8 +127,7 @@ describe('MenuItem', () => {
   it('hides submenu content if `isSubmenuVisible` is false', () => {
     const wrapper = createMenuItem({
       isSubmenuVisible: false,
-      // eslint-disable-next-line react/display-name
-      renderSubmenu: () => <div>Submenu content</div>,
+      submenu: <div>Submenu content</div>,
     });
     assert.equal(wrapper.find('Slider').prop('visible'), false);
 

--- a/src/sidebar/components/test/menu-item-test.js
+++ b/src/sidebar/components/test/menu-item-test.js
@@ -56,7 +56,11 @@ describe('MenuItem', () => {
   });
 
   it('shows the submenu indicator if `isSubmenuVisible` is a boolean', () => {
-    const wrapper = createMenuItem({ isSubmenuVisible: true });
+    const wrapper = createMenuItem({
+      isSubmenuVisible: true,
+      // eslint-disable-next-line react/display-name
+      renderSubmenu: () => <div>Submenu</div>,
+    });
     assert.isTrue(wrapper.exists('SvgIcon[name="collapse-menu"]'));
 
     wrapper.setProps({ isSubmenuVisible: false });
@@ -70,7 +74,12 @@ describe('MenuItem', () => {
 
   it('calls the `onToggleSubmenu` callback when the submenu toggle is clicked', () => {
     const onToggleSubmenu = sinon.stub();
-    const wrapper = createMenuItem({ isSubmenuVisible: true, onToggleSubmenu });
+    const wrapper = createMenuItem({
+      isSubmenuVisible: true,
+      onToggleSubmenu,
+      // eslint-disable-next-line react/display-name
+      renderSubmenu: () => <div>Submenu</div>,
+    });
     wrapper.find('.menu-item__toggle').simulate('click');
     assert.called(onToggleSubmenu);
   });
@@ -97,5 +106,45 @@ describe('MenuItem', () => {
 
     // The actual icon for the submenu should be shown on the right.
     assert.equal(iconSpaces.at(1).children().length, 1);
+  });
+
+  it('does not render submenu content if `isSubmenuVisible` is undefined', () => {
+    const wrapper = createMenuItem({});
+    assert.isFalse(wrapper.exists('Slider'));
+  });
+
+  it('shows submenu content if `isSubmenuVisible` is true', () => {
+    const wrapper = createMenuItem({
+      isSubmenuVisible: true,
+      // eslint-disable-next-line react/display-name
+      renderSubmenu: () => <div>Submenu content</div>,
+    });
+    assert.equal(wrapper.find('Slider').prop('visible'), true);
+    assert.equal(
+      wrapper
+        .find('Slider')
+        .children()
+        .text(),
+      'Submenu content'
+    );
+  });
+
+  it('hides submenu content if `isSubmenuVisible` is false', () => {
+    const wrapper = createMenuItem({
+      isSubmenuVisible: false,
+      // eslint-disable-next-line react/display-name
+      renderSubmenu: () => <div>Submenu content</div>,
+    });
+    assert.equal(wrapper.find('Slider').prop('visible'), false);
+
+    // The submenu content may still be rendered if the submenu is currently
+    // collapsing.
+    assert.equal(
+      wrapper
+        .find('Slider')
+        .children()
+        .text(),
+      'Submenu content'
+    );
   });
 });

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -51,6 +51,15 @@ describe('Menu', () => {
     assert.isFalse(isOpen(wrapper));
   });
 
+  it('calls `onOpenChanged` prop when menu is opened or closed', () => {
+    const onOpenChanged = sinon.stub();
+    const wrapper = createMenu({ onOpenChanged });
+    wrapper.find('button').simulate('click');
+    assert.calledWith(onOpenChanged, true);
+    wrapper.find('button').simulate('click');
+    assert.calledWith(onOpenChanged, false);
+  });
+
   it('opens and closes when the toggle button is pressed', () => {
     const wrapper = createMenu();
     assert.isFalse(isOpen(wrapper));

--- a/src/sidebar/components/test/slider-test.js
+++ b/src/sidebar/components/test/slider-test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const { mount } = require('enzyme');
+const { createElement } = require('preact');
+
+const Slider = require('../slider');
+
+describe('Slider', () => {
+  let container;
+
+  const createSlider = (props = {}) => {
+    // Use a fake `setTimeout` in tests that runs the callback immediately
+    // to avoid an issue with async state updates
+    // (see https://github.com/preactjs/preact/issues/1794).
+    const fakeSetTimeout = callback => {
+      callback();
+      return null;
+    };
+
+    return mount(
+      <Slider visible={false} queueTask={fakeSetTimeout} {...props}>
+        <div style={{ width: 100, height: 200 }}>Test content</div>
+      </Slider>,
+      { attachTo: container }
+    );
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('should render collapsed if `visible` is false on mount', () => {
+    const wrapper = createSlider({ visible: false });
+    const { height } = wrapper.getDOMNode().getBoundingClientRect();
+    assert.equal(height, 0);
+  });
+
+  it('should render expanded if `visible` is true on mount', () => {
+    const wrapper = createSlider({ visible: true });
+    const { height } = wrapper.getDOMNode().getBoundingClientRect();
+    assert.equal(height, 200);
+  });
+
+  it('should transition to expanded if `visible` changes to `true`', () => {
+    const wrapper = createSlider({ visible: false });
+
+    wrapper.setProps({ visible: true });
+
+    const containerStyle = wrapper.getDOMNode().style;
+    assert.equal(containerStyle.height, '200px');
+  });
+
+  it('should transition to collapsed if `visible` changes to `false`', done => {
+    const wrapper = createSlider({ visible: true });
+
+    wrapper.setProps({ visible: false });
+
+    setTimeout(() => {
+      const { height } = wrapper.getDOMNode().getBoundingClientRect();
+      assert.equal(height, 0);
+      done();
+    }, 1);
+  });
+
+  it('should set the container height to "auto" once the transition finishes', () => {
+    const wrapper = createSlider({ visible: false });
+
+    wrapper.setProps({ visible: true });
+
+    let containerStyle = wrapper.getDOMNode().style;
+    assert.equal(containerStyle.height, '200px');
+
+    wrapper
+      .find('div')
+      .first()
+      .simulate('transitionend');
+
+    containerStyle = wrapper.getDOMNode().style;
+    assert.equal(containerStyle.height, 'auto');
+  });
+
+  [true, false].forEach(visible => {
+    it('should handle unmounting while expanding or collapsing', () => {
+      const wrapper = createSlider({ visible });
+      wrapper.setProps({ visible: !visible });
+      wrapper.unmount();
+    });
+  });
+});

--- a/src/styles/sidebar/components/group-list-item.scss
+++ b/src/styles/sidebar/components/group-list-item.scss
@@ -1,7 +1,3 @@
-.group-list-item__submenu {
-  border-bottom: solid 1px $grey-2;
-}
-
 // Footer to display at the bottom of a menu item.
 .group-list-item__footer {
   background-color: $grey-1;

--- a/src/styles/sidebar/components/menu-item.scss
+++ b/src/styles/sidebar/components/menu-item.scss
@@ -28,7 +28,13 @@ $menu-item-padding: 10px;
     font-weight: normal;
   }
 
+  // Animate the background color transition of menu items with expanding submenus.
+  // The timing should match the expansion of the submenu.
+  transition: background 0.15s ease-in;
+
   &.is-expanded {
+    // Set the background color of menu items with submenus to match the
+    // submenu items.
     background: $grey-1;
   }
 }

--- a/src/styles/sidebar/components/menu-item.scss
+++ b/src/styles/sidebar/components/menu-item.scss
@@ -148,3 +148,8 @@ $menu-item-padding: 10px;
     height: 12px;
   }
 }
+
+// The container for open submenus
+.menu-item__submenu {
+  border-bottom: solid 1px $grey-2;
+}


### PR DESCRIPTION
Per feedback on Slack, change the behaviour of the groups menu so that only one submenu
item can be open at a time.

**User-facing changes**
- Only one groups menu item can be expanded at a time
- Add an animated transition to the expansion collapse of menu items and an animated transition to the background color of menu items when their submenu is expanding or collapsing. This animation avoids menu items "jumping" when expanding a submenu causes one above to collapse

Screencap: https://www.dropbox.com/s/e32441bix46bl1v/Animated%20groups%20menu.mp4?dl=0

**Internal changes**
- Add a `Slider` component which handles animating the reveal / hiding of content with an animation. Doing this correctly in a way that works across Safari/Chrome/Firefox has some details to it which mean that it isn't just a trivial CSS animation
- Move the responsibility for rendering the submenu container for the groups menu from `GroupsListItem` to `MenuItem`. The `GroupsListItem` supplies the content but `MenuItem` handles rendering it inside a container with an expand/collapse animation
- Replace the per-GroupListItem state indicating whether the item's submenu is
open with a per-GroupList state variable indicating which group (or none) has
its submenu currently expanded. This allows `GroupList` to ensure that only one menu item is open at a time