### PR TITLE
Menu usability improvements

### DIFF
--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -82,18 +82,32 @@ function Menu({
       return () => {};
     }
 
-    const removeListeners = listen(
+    const removeKeypressListener = listen(
       document.body,
-      ['keypress', 'click', 'mousedown'],
+      ['keypress'],
       event => {
-        if (event.type === 'keypress' && event.key !== 'Escape') {
-          return;
+        if (event.key === 'Escape') {
+          closeMenu();
         }
-        closeMenu();
       }
     );
 
-    return removeListeners;
+    const removeClickListener = listen(
+      document.body,
+      ['mousedown', 'click'],
+      event => {
+        // nb. Mouse events inside the current menu are handled elsewhere.
+        if (!menuRef.current.contains(event.target)) {
+          closeMenu();
+        }
+      },
+      { useCapture: true }
+    );
+
+    return () => {
+      removeKeypressListener();
+      removeClickListener();
+    };
   }, [closeMenu, isOpen]);
 
   const stopPropagation = e => e.stopPropagation();

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -82,6 +82,7 @@ function Menu({
       return () => {};
     }
 
+    // Close menu when user presses Escape key, regardless of focus.
     const removeKeypressListener = listen(
       document.body,
       ['keypress'],
@@ -92,6 +93,21 @@ function Menu({
       }
     );
 
+    // Close menu if user focuses an element outside the menu via any means
+    // (key press, programmatic focus change).
+    const removeFocusListener = listen(
+      document.body,
+      'focus',
+      event => {
+        if (!menuRef.current.contains(event.target)) {
+          closeMenu();
+        }
+      },
+      { useCapture: true }
+    );
+
+    // Close menu if user clicks outside menu, even if on an element which
+    // does not accept focus.
     const removeClickListener = listen(
       document.body,
       ['mousedown', 'click'],
@@ -107,6 +123,7 @@ function Menu({
     return () => {
       removeKeypressListener();
       removeClickListener();
+      removeFocusListener();
     };
   }, [closeMenu, isOpen]);
 

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -89,16 +89,6 @@ function Menu({
         if (event.type === 'keypress' && event.key !== 'Escape') {
           return;
         }
-        if (
-          event.type === 'mousedown' &&
-          menuRef.current &&
-          menuRef.current.contains(event.target)
-        ) {
-          // Close the menu as soon as the user _presses_ the mouse outside the
-          // menu, but only when they _release_ the mouse if they click inside
-          // the menu.
-          return;
-        }
         closeMenu();
       }
     );
@@ -106,8 +96,27 @@ function Menu({
     return removeListeners;
   }, [closeMenu, isOpen]);
 
+  const stopPropagation = e => e.stopPropagation();
+
+  // Close menu if user presses a key which activates menu items.
+  const handleMenuKeyPress = event => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      closeMenu();
+    }
+  };
+
   return (
-    <div className="menu" ref={menuRef}>
+    <div
+      className="menu"
+      ref={menuRef}
+      // Don't close the menu if the mouse is released over one of the menu
+      // elements outside the content area (eg. the arrow at the top of the
+      // content).
+      onClick={stopPropagation}
+      // Don't close the menu if the user presses the mouse down on menu elements
+      // except for the toggle button.
+      onMouseDown={stopPropagation}
+    >
       <button
         aria-expanded={isOpen ? 'true' : 'false'}
         aria-haspopup={true}
@@ -135,6 +144,8 @@ function Menu({
               contentClass
             )}
             role="menu"
+            onClick={closeMenu}
+            onKeyPress={handleMenuKeyPress}
           >
             {children}
           </div>

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -122,6 +122,46 @@ describe('Menu', () => {
     assert.isTrue(isOpen(wrapper));
   });
 
+  [
+    {
+      eventType: 'click',
+      key: null,
+      shouldClose: true,
+    },
+    {
+      eventType: 'keypress',
+      key: 'Enter',
+      shouldClose: true,
+    },
+    {
+      eventType: 'keypress',
+      key: ' ',
+      shouldClose: true,
+    },
+    {
+      eventType: 'keypress',
+      key: 'a',
+      shouldClose: false,
+    },
+  ].forEach(({ eventType, key, shouldClose }) => {
+    it(`${
+      shouldClose ? 'closes' : "doesn't close"
+    } when user performs a "${eventType}" (key: "${key}") on menu content`, () => {
+      const wrapper = createMenu({ defaultOpen: true });
+      wrapper.find('.menu__content').simulate(eventType, { key });
+      assert.equal(isOpen(wrapper), !shouldClose);
+    });
+  });
+
+  it("doesn't close when user presses on a menu element outside the toggle button or content", () => {
+    const wrapper = createMenu({ defaultOpen: true });
+
+    // The event may be received either by the top `<div>` or the arrow element
+    // itself.
+    wrapper.find('.menu').simulate('mousedown');
+    wrapper.find('.menu__arrow').simulate('mousedown');
+  });
+
   it('aligns menu content depending on `align` prop', () => {
     const wrapper = createMenu({ defaultOpen: true });
     assert.isTrue(wrapper.exists('.menu__content--align-left'));

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -83,6 +83,7 @@ describe('Menu', () => {
     new Event('mousedown'),
     new Event('click'),
     ((e = new Event('keypress')), (e.key = 'Escape'), e),
+    new Event('focus'),
   ].forEach(event => {
     it(`closes when the user clicks or presses the mouse outside (${event.type})`, () => {
       const wrapper = createMenu({ defaultOpen: true });
@@ -141,6 +142,11 @@ describe('Menu', () => {
     {
       eventType: 'keypress',
       key: 'a',
+      shouldClose: false,
+    },
+    {
+      eventType: 'focus',
+      key: null,
       shouldClose: false,
     },
   ].forEach(({ eventType, key, shouldClose }) => {

--- a/src/sidebar/util/dom.js
+++ b/src/sidebar/util/dom.js
@@ -1,17 +1,26 @@
 'use strict';
 
 /**
- * Attach `handler` as an event listener for `events` on `element`.
+ * Attach listeners for one or multiple events to an element and return a
+ * function that removes the listeners.
  *
+ * @param {Element}
+ * @param {string[]} events
+ * @param {(event: Event) => any} listener
+ * @param {boolean} [options.useCapture]
  * @return {function} Function which removes the event listeners.
  */
-function listen(element, events, handler) {
+function listen(element, events, listener, { useCapture = false } = {}) {
   if (!Array.isArray(events)) {
     events = [events];
   }
-  events.forEach(event => element.addEventListener(event, handler));
+  events.forEach(event =>
+    element.addEventListener(event, listener, useCapture)
+  );
   return () => {
-    events.forEach(event => element.removeEventListener(event, handler));
+    events.forEach(event =>
+      element.removeEventListener(event, listener, useCapture)
+    );
   };
 }
 

--- a/src/sidebar/util/test/dom-test.js
+++ b/src/sidebar/util/test/dom-test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const { listen } = require('../dom');
+
+describe('sidebar/util/dom', () => {
+  const createElement = () => ({
+    addEventListener: sinon.stub(),
+    removeEventListener: sinon.stub(),
+  });
+
+  describe('listen', () => {
+    [true, false].forEach(useCapture => {
+      it('adds listeners for specified events', () => {
+        const element = createElement();
+        const handler = sinon.stub();
+
+        listen(element, ['click', 'mousedown'], handler, { useCapture });
+
+        assert.calledWith(
+          element.addEventListener,
+          'click',
+          handler,
+          useCapture
+        );
+        assert.calledWith(
+          element.addEventListener,
+          'mousedown',
+          handler,
+          useCapture
+        );
+      });
+    });
+
+    [true, false].forEach(useCapture => {
+      it('removes listeners when returned function is invoked', () => {
+        const element = createElement();
+        const handler = sinon.stub();
+
+        const removeListeners = listen(
+          element,
+          ['click', 'mousedown'],
+          handler,
+          { useCapture }
+        );
+        removeListeners();
+
+        assert.calledWith(
+          element.removeEventListener,
+          'click',
+          handler,
+          useCapture
+        );
+        assert.calledWith(
+          element.removeEventListener,
+          'mousedown',
+          handler,
+          useCapture
+        );
+      });
+    });
+  });
+});

--- a/src/styles/sidebar/components/menu-item.scss
+++ b/src/styles/sidebar/components/menu-item.scss
@@ -1,6 +1,8 @@
 $menu-item-padding: 10px;
 
 .menu-item {
+  @include outline-on-keyboard-focus;
+
   $item-padding: $menu-item-padding;
   $item-height: 40px;
 


### PR DESCRIPTION
This PR implements several general usability fixes for menus:

- Hide the menu if focus is moved outside of the menu via a non-click/tap method (eg. a key combination which activates other element, or a programmatic focus change)
- Do not display an outline when pressing on a menu item. An outline is still shown when a menu item has keyboard focus
- Fix an annoying issue where it was possible for the menu to close immediately after opening if you clicked _juuust_ in the right place in the lower-right corner of the menu toggle button, in the location where the menu content '^' arrow appears
- Close the menu when a menu item is activated via the keyboard rather than the mouse

Things **not** yet addressed in this PR:

- The tab key doesn't cycle around menu items (behaviour here is inconsistent across well-known products that I tested and native menus, but it seems to be the majority convention)
- Changing focused menu items via up and down arrows
- Menu items that are buttons can be activated via Space or Enter. Menu items that are links can only be activated by pressing Enter. The latter behaviour just comes from the way HTML anchor elements behave normally.