### PR TITLE
Separate hover areas for main action and submenu toggle

### DIFF
--- a/src/sidebar/components/menu-item.js
+++ b/src/sidebar/components/menu-item.js
@@ -69,23 +69,25 @@ function MenuItem({
       role="menuitem"
       {...(onClick && onActivate('menuitem', onClick))}
     >
-      {hasLeftIcon && (
-        <div className="menu-item__icon-container">{leftIcon}</div>
-      )}
-      {href && (
-        <a
-          className={labelClass}
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {label}
-        </a>
-      )}
-      {!href && <span className={labelClass}>{label}</span>}
-      {hasRightIcon && (
-        <div className="menu-item__icon-container">{rightIcon}</div>
-      )}
+      <div className="menu-item__action">
+        {hasLeftIcon && (
+          <div className="menu-item__icon-container">{leftIcon}</div>
+        )}
+        {href && (
+          <a
+            className={labelClass}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {label}
+          </a>
+        )}
+        {!href && <span className={labelClass}>{label}</span>}
+        {hasRightIcon && (
+          <div className="menu-item__icon-container">{rightIcon}</div>
+        )}
+      </div>
       {typeof isSubmenuVisible === 'boolean' && (
         <div
           className="menu-item__toggle"

--- a/src/styles/sidebar/components/menu-item.scss
+++ b/src/styles/sidebar/components/menu-item.scss
@@ -1,7 +1,6 @@
 $menu-item-padding: 10px;
 
 .menu-item {
-  $item-padding: $menu-item-padding;
   $item-height: 40px;
 
   color: $grey-6;
@@ -12,7 +11,6 @@ $menu-item-padding: 10px;
   align-items: center;
   min-width: 150px;
   min-height: $item-height;
-  padding-left: $item-padding;
 
   // TODO - Make the link fill the full available vertical space.
   cursor: pointer;
@@ -20,45 +18,52 @@ $menu-item-padding: 10px;
   // Prevent menu item text from being selected when user toggles menu.
   user-select: none;
 
-  &:hover {
-    background: $grey-1;
-  }
-
   // An item in a submenu associated with a top-level item.
   &--submenu {
     min-height: $item-height - 10px;
     background: $grey-1;
     color: mix($grey-5, $grey-6, $weight: 50%);
     font-weight: normal;
-    &:hover {
-      // Since submenu items already have a light grey background, we need to
-      // use a slightly darker grey as the hover state.
+  }
+
+  &.is-expanded {
+    background: $grey-1;
+  }
+}
+
+// The container for the clickable area of the menu item which triggers its
+// main action. For menu items without submenus, this covers the full area of
+// the menu item. For menu items with submenus, this covers the full area
+// except for the toggle that opens the submenu.
+.menu-item__action {
+  align-self: stretch;
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+  padding-left: $menu-item-padding;
+
+  &:hover {
+    background: $grey-1;
+
+    .menu-item.is-expanded & {
+      // Since expanded items already have a light grey background, we need to
+      // make the hover state a little darker. This should match submenu items'
+      // hover state.
+      background: $grey-3;
+    }
+
+    // Since submenu items already have a light grey background, we need to
+    // use a slightly darker grey as the hover state.
+    .menu-item--submenu & {
       background: $grey-3;
       color: $grey-6;
     }
   }
 
-  &.is-disabled {
-    .menu-item__label {
-      color: $grey-4;
-    }
-  }
-
-  &.is-expanded {
-    background: $grey-1;
-
-    // Since expanded items already have a light grey background, we need to
-    // make the hover state a little darker. This should match submenu items'
-    // hover state.
-    &:hover {
-      background: $grey-3;
-    }
-  }
-
-  &.is-selected {
+  .menu-item.is-selected & {
     $border-width: 4px;
     border-left: $border-width solid $brand;
-    padding-left: $item-padding - $border-width;
+    padding-left: $menu-item-padding - $border-width;
   }
 }
 
@@ -95,6 +100,10 @@ $menu-item-padding: 10px;
 
   &--submenu {
     font-weight: normal;
+  }
+
+  .menu-item.is-disabled & {
+    color: $grey-4;
   }
 }
 


### PR DESCRIPTION
For menu items that have associated submenus, make it clearer that there
are two separate click zones by highlighting only the clickable area for
the main action when hovering that part of the item.

(See commit message for implementation notes)

_I'm not really sure whether I prefer this change vs the version on master. I'm putting up this PR to solicit feedback._

----

**Before (group name/icon hovered):**

<img width="326" alt="before-main-action" src="https://user-images.githubusercontent.com/2458/60025011-b1906c80-9690-11e9-884d-8b286e458694.png">

**Before (submenu toggle hovered):**

<img width="334" alt="before-submenu-toggle" src="https://user-images.githubusercontent.com/2458/60025028-b5bc8a00-9690-11e9-814e-62f171b4c0bd.png">

**After (group name/icon hovered):**

<img width="343" alt="after-main-action" src="https://user-images.githubusercontent.com/2458/60025034-bb19d480-9690-11e9-8513-c9a9d33f860d.png">

**After (submenu toggle hovered):**

<img width="338" alt="after-submenu-toggle" src="https://user-images.githubusercontent.com/2458/60025049-c0771f00-9690-11e9-9eab-bbd81c2e11d2.png">
