### PR TITLE
Rename group-list-v2 => group-list

### DIFF
--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -57,9 +57,9 @@ function GroupList({ serviceUrl, settings }) {
   if (focusedGroup) {
     const icon = focusedGroup.organization.logo;
     label = (
-      <span className="group-list-v2__menu-label">
+      <span className="group-list__menu-label">
         <img
-          className="group-list-v2__menu-icon"
+          className="group-list__menu-icon"
           src={icon || publisherProvidedIcon(settings)}
         />
         {focusedGroup.name}
@@ -82,7 +82,7 @@ function GroupList({ serviceUrl, settings }) {
   return (
     <Menu
       align="left"
-      contentClass="group-list-v2__content"
+      contentClass="group-list__content"
       label={label}
       title="Select group"
     >

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -3,7 +3,7 @@
 const { shallow } = require('enzyme');
 const { createElement } = require('preact');
 
-const GroupList = require('../group-list-v2');
+const GroupList = require('../group-list');
 
 describe('GroupList', () => {
   let fakeServiceConfig;

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -162,7 +162,7 @@ function startAngularApp(config) {
     .component('excerpt', require('./components/excerpt'))
     .component(
       'groupList',
-      wrapReactComponent(require('./components/group-list-v2'))
+      wrapReactComponent(require('./components/group-list'))
     )
     .component(
       'helpLink',

--- a/src/styles/sidebar/components/group-list.scss
+++ b/src/styles/sidebar/components/group-list.scss
@@ -1,8 +1,8 @@
-.group-list-v2__content {
+.group-list__content {
   min-width: 250px;
 }
 
-.group-list-v2__menu-label {
+.group-list__menu-label {
   align-items: center;
   color: $grey-6;
   display: flex;
@@ -10,7 +10,7 @@
   font-weight: bold;
 }
 
-.group-list-v2__menu-icon {
+.group-list__menu-icon {
   width: 15px;
   height: 15px;
   margin-right: 4px;

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -23,7 +23,7 @@ $base-line-height: 20px;
 @import './components/annotation-publish-control';
 @import './components/annotation-thread';
 @import './components/excerpt';
-@import './components/group-list-v2';
+@import './components/group-list';
 @import './components/group-list-item';
 @import './components/help-panel';
 @import './components/loggedout-message';


### PR DESCRIPTION
Now that the old group list/menu has been removed, rename the new
version so that the file name matches the component name.