### PR TITLE
Add loading of annotations state to store

### DIFF
--- a/src/sidebar/store/modules/activity.js
+++ b/src/sidebar/store/modules/activity.js
@@ -14,6 +14,10 @@ function init() {
        * The number of API requests that have started and not yet completed.
        */
       activeApiRequests: 0,
+      /**
+       * The number of annotation fetches that have started and not yet completed.
+       */
+      activeAnnotationFetches: 0,
     },
   };
 }
@@ -44,6 +48,32 @@ const update = {
       },
     };
   },
+
+  ANNOTATION_FETCH_STARTED(state) {
+    const { activity } = state;
+    return {
+      activity: {
+        ...activity,
+        activeAnnotationFetches: activity.activeAnnotationFetches + 1,
+      },
+    };
+  },
+
+  ANNOTATION_FETCH_FINISHED(state) {
+    const { activity } = state;
+    if (activity.activeAnnotationFetches === 0) {
+      throw new Error(
+        'ANNOTATION_FETCH_FINISHED action when no annotation fetches were active'
+      );
+    }
+
+    return {
+      activity: {
+        ...activity,
+        activeAnnotationFetches: activity.activeAnnotationFetches - 1,
+      },
+    };
+  },
 };
 
 const actions = actionTypes(update);
@@ -56,12 +86,27 @@ function apiRequestFinished() {
   return { type: actions.API_REQUEST_FINISHED };
 }
 
+function annotationFetchStarted() {
+  return { type: actions.ANNOTATION_FETCH_STARTED };
+}
+
+function annotationFetchFinished() {
+  return { type: actions.ANNOTATION_FETCH_FINISHED };
+}
+
 /**
  * Return true when any activity is happening in the app that needs to complete
  * before the UI will be idle.
  */
 function isLoading(state) {
   return state.activity.activeApiRequests > 0;
+}
+
+/**
+ * Return true when annotations are actively being fetched.
+ */
+function isFetchingAnnotations(state) {
+  return state.activity.activeAnnotationFetches > 0;
 }
 
 module.exports = {
@@ -71,9 +116,12 @@ module.exports = {
   actions: {
     apiRequestStarted,
     apiRequestFinished,
+    annotationFetchStarted,
+    annotationFetchFinished,
   },
 
   selectors: {
     isLoading,
+    isFetchingAnnotations,
   },
 };

--- a/src/sidebar/store/modules/test/activity-test.js
+++ b/src/sidebar/store/modules/test/activity-test.js
@@ -33,6 +33,63 @@ describe('sidebar/store/modules/activity', () => {
     });
   });
 
+  describe('isFetchingAnnotations', () => {
+    it('returns false with the initial state', () => {
+      assert.equal(store.isFetchingAnnotations(), false);
+    });
+
+    it('returns true when API requests are in flight', () => {
+      store.annotationFetchStarted();
+      assert.equal(store.isFetchingAnnotations(), true);
+    });
+
+    it('returns false when all requests end', () => {
+      store.annotationFetchStarted();
+      store.annotationFetchStarted();
+      store.annotationFetchFinished();
+
+      assert.equal(store.isFetchingAnnotations(), true);
+
+      store.annotationFetchFinished();
+
+      assert.equal(store.isFetchingAnnotations(), false);
+    });
+  });
+
+  it('defaults `activeAnnotationFetches` counter to zero', () => {
+    assert.equal(store.getState().activity.activeAnnotationFetches, 0);
+  });
+
+  describe('annotationFetchFinished', () => {
+    it('triggers an error if no requests are in flight', () => {
+      assert.throws(() => {
+        store.annotationFetchFinished();
+      });
+    });
+
+    it('increments `activeAnnotationFetches` counter when a new annotation fetch is started', () => {
+      store.annotationFetchStarted();
+
+      assert.equal(store.getState().activity.activeAnnotationFetches, 1);
+    });
+  });
+
+  describe('annotationFetchStarted', () => {
+    it('triggers an error if no requests are in flight', () => {
+      assert.throws(() => {
+        store.annotationFetchFinished();
+      });
+    });
+
+    it('decrements `activeAnnotationFetches` counter when an annotation fetch is finished', () => {
+      store.annotationFetchStarted();
+
+      store.annotationFetchFinished();
+
+      assert.equal(store.getState().activity.activeAnnotationFetches, 0);
+    });
+  });
+
   describe('#apiRequestFinished', () => {
     it('triggers an error if no requests are in flight', () => {
       assert.throws(() => {


### PR DESCRIPTION
Track annotation loads in the store by keeping a counter of currently active annotation loads.