### PR TITLE
Only emit end if searchClient is done searching

### DIFF
--- a/src/sidebar/search-client.js
+++ b/src/sidebar/search-client.js
@@ -74,11 +74,6 @@ class SearchClient extends EventEmitter {
           return;
         }
         self.emit('error', err);
-      })
-      .then(function() {
-        if (self._canceled) {
-          return;
-        }
         self.emit('end');
       });
   }


### PR DESCRIPTION
Previously `end` was emitted after each getBatch call in the
searchClient, now it is emitted once after all batches are
complete.

See [slack thread](https://hypothes-is.slack.com/archives/C1M8NH76X/p1562007159107200) for explanation.