### PR TITLE
Add self-closing ESlint enforcement

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,5 @@
 {
-  "extends": [
-    "hypothesis",
-    "plugin:react/recommended"
-  ],
+  "extends": ["hypothesis", "plugin:react/recommended"],
   "globals": {
     "Set": false
   },
@@ -10,6 +7,7 @@
     "mocha/no-exclusive-tests": "error",
     "no-var": "error",
     "indent": "off",
+    "react/self-closing-comp": "error",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "error"
   },
@@ -19,11 +17,7 @@
       "jsx": true
     }
   },
-  "plugins": [
-    "mocha",
-    "react",
-    "react-hooks"
-  ],
+  "plugins": ["mocha", "react", "react-hooks"],
   "settings": {
     "react": {
       "pragma": "createElement",

--- a/src/sidebar/components/moderation-banner.js
+++ b/src/sidebar/components/moderation-banner.js
@@ -81,7 +81,7 @@ function ModerationBanner({ annotation, api, flash }) {
       {annotation.hidden && (
         <span>Hidden from users. Flagged x{flagCount}</span>
       )}
-      <span className="u-stretch"></span>
+      <span className="u-stretch" />
       <button {...toggleButtonProps}>
         {annotation.hidden ? 'Unhide' : 'Hide'}
       </button>

--- a/src/sidebar/components/search-input.js
+++ b/src/sidebar/components/search-input.js
@@ -63,7 +63,7 @@ function SearchInput({ alwaysExpanded, query, onSearch }) {
           className="search-input__icon top-bar__btn"
           onClick={() => input.current.focus()}
         >
-          <i className="h-icon-search"></i>
+          <i className="h-icon-search" />
         </button>
       )}
       {isLoading && <Spinner className="top-bar__btn" title="Loading…" />}


### PR DESCRIPTION
We sometimes neglect to use self-closing tags in our components; let's enforce it so we don't overlook it.