### PR TITLE
Refactor annotation events

### DIFF
--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -5,7 +5,6 @@ const events = require('../events');
 const memoize = require('../util/memoize');
 const metadata = require('../util/annotation-metadata');
 const tabs = require('../util/tabs');
-const uiConstants = require('../ui-constants');
 
 function truthyKeys(map) {
   return Object.keys(map).filter(function(k) {
@@ -82,18 +81,6 @@ function RootThread($rootScope, store, searchFilter, viewFilter) {
     });
   }
 
-  function deleteNewAndEmptyAnnotations() {
-    store
-      .getState()
-      .annotations.filter(function(ann) {
-        return metadata.isNew(ann) && !store.getDraftIfNotEmpty(ann);
-      })
-      .forEach(function(ann) {
-        store.removeDraft(ann);
-        $rootScope.$broadcast(events.ANNOTATION_DELETED, ann);
-      });
-  }
-
   // Listen for annotations being created or loaded
   // and show them in the UI.
   //
@@ -111,33 +98,14 @@ function RootThread($rootScope, store, searchFilter, viewFilter) {
   });
 
   $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, function(event, ann) {
-    // When a new annotation is created, remove any existing annotations
-    // that are empty.
-    deleteNewAndEmptyAnnotations();
-
-    store.addAnnotations([ann]);
-
-    // If the annotation is of type note or annotation, make sure
-    // the appropriate tab is selected. If it is of type reply, user
-    // stays in the selected tab.
-    if (metadata.isPageNote(ann)) {
-      store.selectTab(uiConstants.TAB_NOTES);
-    } else if (metadata.isAnnotation(ann)) {
-      store.selectTab(uiConstants.TAB_ANNOTATIONS);
-    }
-
-    (ann.references || []).forEach(function(parent) {
-      store.setCollapsed(parent, false);
-    });
+    store.createAnnotation(ann);
   });
 
   // Remove any annotations that are deleted or unloaded
   $rootScope.$on(events.ANNOTATION_DELETED, function(event, annotation) {
     store.removeAnnotations([annotation]);
-    if (annotation.id) {
-      store.removeSelectedAnnotation(annotation.id);
-    }
   });
+
   $rootScope.$on(events.ANNOTATIONS_UNLOADED, function(event, annotations) {
     store.removeAnnotations(annotations);
   });

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -39,6 +39,7 @@ describe('rootThread', function() {
       state: {
         annotations: [],
         expanded: {},
+        drafts: [],
         filterQuery: null,
         focusedAnnotationMap: null,
         forceVisible: {},
@@ -63,6 +64,7 @@ describe('rootThread', function() {
       selectTab: sinon.stub(),
       getDraftIfNotEmpty: sinon.stub().returns(null),
       removeDraft: sinon.stub(),
+      createAnnotation: sinon.stub(),
     };
 
     fakeBuildThread = sinon.stub().returns(fixtures.emptyThread);
@@ -341,6 +343,12 @@ describe('rootThread', function() {
   context('when annotation events occur', function() {
     const annot = annotationFixtures.defaultAnnotation();
 
+    it('creates a new annotation in the store when BEFORE_ANNOTATION_CREATED event occurs', function() {
+      $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED, annot);
+      assert.notCalled(fakeStore.removeAnnotations);
+      assert.calledWith(fakeStore.createAnnotation, sinon.match(annot));
+    });
+
     unroll(
       'adds or updates annotations when #event event occurs',
       function(testCase) {
@@ -350,38 +358,20 @@ describe('rootThread', function() {
         assert.calledWith(fakeStore.addAnnotations, sinon.match(annotations));
       },
       [
-        { event: events.BEFORE_ANNOTATION_CREATED, annotations: annot },
         { event: events.ANNOTATION_CREATED, annotations: annot },
         { event: events.ANNOTATION_UPDATED, annotations: annot },
         { event: events.ANNOTATIONS_LOADED, annotations: [annot] },
       ]
     );
 
-    it('expands the parents of new annotations', function() {
-      const reply = annotationFixtures.oldReply();
-      $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED, reply);
-      assert.calledWith(fakeStore.setCollapsed, reply.references[0], false);
+    it('removes annotations when ANNOTATION_DELETED event occurs', function() {
+      $rootScope.$broadcast(events.ANNOTATION_DELETED, annot);
+      assert.calledWith(fakeStore.removeAnnotations, sinon.match([annot]));
     });
 
-    unroll(
-      'removes annotations when #event event occurs',
-      function(testCase) {
-        $rootScope.$broadcast(testCase.event, testCase.annotations);
-        const annotations = [].concat(testCase.annotations);
-        assert.calledWith(
-          fakeStore.removeAnnotations,
-          sinon.match(annotations)
-        );
-      },
-      [
-        { event: events.ANNOTATION_DELETED, annotations: annot },
-        { event: events.ANNOTATIONS_UNLOADED, annotations: [annot] },
-      ]
-    );
-
-    it('deselects deleted annotations', function() {
-      $rootScope.$broadcast(events.ANNOTATION_DELETED, annot);
-      assert.calledWith(fakeStore.removeSelectedAnnotation, annot.id);
+    it('removes annotations when ANNOTATIONS_UNLOADED event occurs', function() {
+      $rootScope.$broadcast(events.ANNOTATIONS_UNLOADED, annot);
+      assert.calledWith(fakeStore.removeAnnotations, sinon.match(annot));
     });
 
     describe('when a new annotation is created', function() {
@@ -393,24 +383,6 @@ describe('rootThread', function() {
 
         existingNewAnnot = { $tag: 'a-new-tag' };
         fakeStore.state.annotations.push(existingNewAnnot);
-      });
-
-      it('removes drafts for new and empty annotations', function() {
-        fakeStore.getDraftIfNotEmpty.returns(null);
-        const annotation = annotationFixtures.newEmptyAnnotation();
-
-        $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED, annotation);
-
-        assert.calledWith(fakeStore.removeDraft, existingNewAnnot);
-      });
-
-      it('deletes new and empty annotations', function() {
-        fakeStore.getDraftIfNotEmpty.returns(null);
-        const annotation = annotationFixtures.newEmptyAnnotation();
-
-        $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED, annotation);
-
-        assert.calledWithMatch(onDelete, sinon.match.any, existingNewAnnot);
       });
 
       it('does not remove annotations that have non-empty drafts', function() {

--- a/src/sidebar/store/modules/drafts.js
+++ b/src/sidebar/store/modules/drafts.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const metadata = require('../../util/annotation-metadata');
 const util = require('../util');
 
 /**
@@ -96,14 +97,41 @@ function createDraft(annotation, changes) {
   };
 }
 
-/** Remove all drafts. */
+/**
+ * Remove any drafts that are empty.
+ *
+ * An empty draft has no text and no reference tags.
+ */
+
+function deleteNewAndEmptyDrafts() {
+  const annotations = require('./annotations');
+  return (dispatch, getState) => {
+    const newDrafts = getState().drafts.filter(draft => {
+      return (
+        metadata.isNew(draft.annotation) &&
+        !getDraftIfNotEmpty(getState(), draft.annotation)
+      );
+    });
+    const removedAnnotations = newDrafts.map(draft => {
+      dispatch(removeDraft(draft.annotation));
+      return draft.annotation;
+    });
+    dispatch(annotations.actions.removeAnnotations(removedAnnotations));
+  };
+}
+
+/**
+ * Remove all drafts.
+ * */
 function discardAllDrafts() {
   return {
     type: actions.DISCARD_ALL_DRAFTS,
   };
 }
 
-/** Remove the draft version of an annotation. */
+/**
+ * Remove the draft version of an annotation.
+ */
 function removeDraft(annotation) {
   return {
     type: actions.REMOVE_DRAFT,
@@ -169,6 +197,7 @@ module.exports = {
   update,
   actions: {
     createDraft,
+    deleteNewAndEmptyDrafts,
     discardAllDrafts,
     removeDraft,
   },

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -176,6 +176,18 @@ const update = {
     return {};
   },
 
+  REMOVE_ANNOTATIONS: function(state, action) {
+    const selection = Object.assign({}, state.selectedAnnotationMap);
+    action.annotations.forEach(annotation => {
+      if (annotation.id) {
+        delete selection[annotation.id];
+      }
+    });
+    return {
+      selectedAnnotationMap: freeze(selection),
+    };
+  },
+
   SET_FILTER_QUERY: function(state, action) {
     return {
       filterQuery: action.query,
@@ -317,20 +329,6 @@ function hasSelectedAnnotations(state) {
   return !!state.selectedAnnotationMap;
 }
 
-/** De-select an annotation. */
-function removeSelectedAnnotation(id) {
-  // FIXME: This should be converted to a plain action and accessing the state
-  // should happen in the update() function
-  return function(dispatch, getState) {
-    const selection = Object.assign({}, getState().selectedAnnotationMap);
-    if (!selection || !id) {
-      return;
-    }
-    delete selection[id];
-    dispatch(select(selection));
-  };
-}
-
 /** De-select all annotations. */
 function clearSelectedAnnotations() {
   return { type: actions.CLEAR_SELECTED_ANNOTATIONS };
@@ -365,7 +363,6 @@ module.exports = {
     clearSelection: clearSelection,
     focusAnnotations: focusAnnotations,
     highlightAnnotations: highlightAnnotations,
-    removeSelectedAnnotation: removeSelectedAnnotation,
     selectAnnotations: selectAnnotations,
     selectTab: selectTab,
     setCollapsed: setCollapsed,

--- a/src/sidebar/store/modules/test/drafts-test.js
+++ b/src/sidebar/store/modules/test/drafts-test.js
@@ -28,7 +28,7 @@ const fixtures = immutable({
   },
 });
 
-describe('Drafts Store', () => {
+describe('store/modules/drafts', () => {
   let store;
 
   beforeEach(() => {
@@ -223,6 +223,48 @@ describe('Drafts Store', () => {
     it('should not return saved annotations which have drafts', () => {
       store.createDraft(fixtures.annotation, fixtures.draftWithText);
       assert.deepEqual(store.unsavedAnnotations(), []);
+    });
+  });
+
+  describe('#deleteNewAndEmptyDrafts', () => {
+    [
+      {
+        key: 'should remove new and empty drafts',
+        annotation: {
+          id: undefined,
+          $tag: 'my_annotation_tag',
+        },
+        draft: fixtures.emptyDraft,
+        shouldRemove: true,
+      },
+      {
+        key: 'should not remove drafts with an id',
+        annotation: {
+          id: 'my_id',
+          $tag: 'my_annotation_tag',
+        },
+        draft: fixtures.emptyDraft,
+        shouldRemove: false,
+      },
+      {
+        key: 'should not remove drafts with text',
+        annotation: {
+          id: undefined,
+          $tag: 'my_annotation_tag',
+        },
+        draft: fixtures.draftWithText,
+        shouldRemove: false,
+      },
+    ].forEach(test => {
+      it(test.key, () => {
+        store.createDraft(test.annotation, test.draft);
+        store.deleteNewAndEmptyDrafts([test.annotation]);
+        if (test.shouldRemove) {
+          assert.isNotOk(store.getDraft(test.annotation));
+        } else {
+          assert.isOk(store.getDraft(test.annotation));
+        }
+      });
     });
   });
 });

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -1,15 +1,16 @@
 'use strict';
 
+const annotations = require('../annotations');
 const createStore = require('../../create-store');
 const selection = require('../selection');
 const uiConstants = require('../../../ui-constants');
 
-describe('selection', () => {
+describe('store/modules/selection', () => {
   let store;
-  let fakeSettings = {};
+  let fakeSettings = [{}, {}];
 
   beforeEach(() => {
-    store = createStore([selection], [fakeSettings]);
+    store = createStore([annotations, selection], fakeSettings);
   });
 
   describe('getFirstSelectedAnnotationId', function() {
@@ -145,20 +146,14 @@ describe('selection', () => {
     });
   });
 
-  describe('removeSelectedAnnotation()', function() {
-    it('removes an annotation from the selectedAnnotationMap', function() {
+  describe('#REMOVE_ANNOTATIONS', function() {
+    it('removing an annotation should also remove it from selectedAnnotationMap', function() {
       store.selectAnnotations([1, 2, 3]);
-      store.removeSelectedAnnotation(2);
+      store.removeAnnotations([{ id: 2 }]);
       assert.deepEqual(store.getState().selectedAnnotationMap, {
         1: true,
         3: true,
       });
-    });
-
-    it('nulls the map if no annotations are selected', function() {
-      store.selectAnnotations([1]);
-      store.removeSelectedAnnotation(1);
-      assert.isNull(store.getState().selectedAnnotationMap);
     });
   });
 


### PR DESCRIPTION
This is mostly just moves 3 parts of functionality from root-thread out into appropriate stores and improves the test cases.

fixes #1236
