### PR TITLE
Convert new-note-btn to preact

### DIFF
--- a/src/sidebar/components/new-note-btn.js
+++ b/src/sidebar/components/new-note-btn.js
@@ -1,21 +1,43 @@
 'use strict';
 
+const { createElement } = require('preact');
+const propTypes = require('prop-types');
+
 const events = require('../events');
+const useStore = require('../store/use-store');
+const { applyTheme } = require('../util/theme');
+const { withServices } = require('../util/service-context');
 
-module.exports = {
-  controllerAs: 'vm',
-  //@ngInject
-  controller: function($rootScope, store) {
-    this.onNewNoteBtnClick = function() {
-      const topLevelFrame = store.frames().find(f => !f.id);
-      const annot = {
-        target: [],
-        uri: topLevelFrame.uri,
-      };
+function NewNoteButton({ $rootScope, settings }) {
+  const store = useStore(store => ({
+    frames: store.frames(),
+  }));
 
-      $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED, annot);
+  const onNewNoteBtnClick = function() {
+    const topLevelFrame = store.frames.find(f => !f.id);
+    const annot = {
+      target: [],
+      uri: topLevelFrame.uri,
     };
-  },
-  bindings: {},
-  template: require('../templates/new-note-btn.html'),
+    $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED, annot);
+  };
+
+  return (
+    <button
+      style={applyTheme(['ctaBackgroundColor'], settings)}
+      className="new-note__create"
+      onClick={onNewNoteBtnClick}
+    >
+      + New note
+    </button>
+  );
+}
+NewNoteButton.propTypes = {
+  // Injected services.
+  $rootScope: propTypes.object.isRequired,
+  settings: propTypes.object.isRequired,
 };
+
+NewNoteButton.injectedProps = ['$rootScope', 'settings'];
+
+module.exports = withServices(NewNoteButton);

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -180,10 +180,13 @@ function startAngularApp(config) {
       'moderationBanner',
       wrapReactComponent(require('./components/moderation-banner'))
     )
-    .component('newNoteBtn', require('./components/new-note-btn'))
     .component(
       'searchStatusBar',
       wrapReactComponent(require('./components/search-status-bar'))
+    )
+    .component(
+      'newNoteBtn',
+      wrapReactComponent(require('./components/new-note-btn'))
     )
     .component('selectionTabs', require('./components/selection-tabs'))
     .component('sidebarContent', require('./components/sidebar-content'))


### PR DESCRIPTION
Simple conversion of this single button component. I Decided not to remove the `$rootScope`  service. That will require some more discussions.

fixes #1206