### PR TITLE
Remove unused ng component wrappers

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -158,10 +158,6 @@ function startAngularApp(config) {
     )
     .component('annotationThread', require('./components/annotation-thread'))
     .component(
-      'annotationUser',
-      wrapReactComponent(require('./components/annotation-user'))
-    )
-    .component(
       'annotationViewerContent',
       require('./components/annotation-viewer-content')
     )
@@ -185,10 +181,6 @@ function startAngularApp(config) {
       wrapReactComponent(require('./components/search-status-bar'))
     )
     .component(
-      'newNoteBtn',
-      wrapReactComponent(require('./components/new-note-btn'))
-    )
-    .component(
       'selectionTabs',
       wrapReactComponent(require('./components/selection-tabs'))
     )
@@ -203,10 +195,6 @@ function startAngularApp(config) {
     .component('svgIcon', wrapReactComponent(require('./components/svg-icon')))
     .component('tagEditor', require('./components/tag-editor'))
     .component('threadList', require('./components/thread-list'))
-    .component(
-      'timestamp',
-      wrapReactComponent(require('./components/timestamp'))
-    )
     .component('topBar', wrapReactComponent(require('./components/top-bar')))
     .directive('hAutofocus', require('./directive/h-autofocus'))
     .directive('hBranding', require('./directive/h-branding'))

--- a/src/sidebar/templates/new-note-btn.html
+++ b/src/sidebar/templates/new-note-btn.html
@@ -1,3 +1,0 @@
-<button class="new-note__create" ng-click="vm.onNewNoteBtnClick()" h-branding="ctaBackgroundColor">
-  + New note
-</button>


### PR DESCRIPTION
- Remove unused `new-note-btn.html` Angular template
- Remove Angular component wrappers for Preact components which are no longer used from within any Angular templates, because all the components that use them have also been converted