### PR TITLE
Fix typo `bnt` -> `btn` in `SelectionTabs` component

### DIFF
--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -5,7 +5,7 @@ const propTypes = require('prop-types');
 const { createElement } = require('preact');
 const { Fragment } = require('preact');
 
-const NewNoteBnt = require('./new-note-btn');
+const NewNoteBtn = require('./new-note-btn');
 const sessionUtil = require('../util/session-util');
 const uiConstants = require('../ui-constants');
 const useStore = require('../store/use-store');
@@ -140,7 +140,7 @@ function SelectionTabs({ isLoading, settings, session }) {
         )}
       </div>
       {selectedTab === uiConstants.TAB_NOTES &&
-        settings.enableExperimentalNewNoteButton && <NewNoteBnt />}
+        settings.enableExperimentalNewNoteButton && <NewNoteBtn />}
       {!isLoading && (
         <div className="selection-tabs__empty-message">
           {showNotesUnavailableMessage && (

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -133,7 +133,7 @@ describe('SelectionTabs', function() {
       assert.isFalse(wrapper.exists('.selection-tabs--theme-clean'));
     });
 
-    it('should not display the new-note-bnt when the annotations tab is active', function() {
+    it('should not display the new-note-btn when the annotations tab is active', function() {
       const wrapper = createComponent();
       assert.equal(wrapper.find(NewNoteBtn).length, 0);
     });


### PR DESCRIPTION
Was looking at the new `SelectionTabs` component this morning and noticed a typo in `NewNoteBtn`.

Changing the source code did not break tests, which suggests perhaps `NewNoteBtn` should be mocked in the tests?