### PR TITLE
Simplify root thread generation in top-level UI components

### DIFF
--- a/src/sidebar/components/annotation-viewer-content.js
+++ b/src/sidebar/components/annotation-viewer-content.js
@@ -36,15 +36,11 @@ function AnnotationViewerContentController(
   streamFilter,
   annotationMapper
 ) {
-  const self = this;
-
   store.setAppIsSidebar(false);
 
   const id = $routeParams.id;
 
-  store.subscribe(function() {
-    self.rootThread = rootThread.thread(store.getState());
-  });
+  this.rootThread = () => rootThread.thread(store.getState());
 
   this.setCollapsed = function(id, collapsed) {
     store.setCollapsed(id, collapsed);

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -17,15 +17,7 @@ function SidebarContentController(
 ) {
   const self = this;
 
-  function thread() {
-    return rootThread.thread(store.getState());
-  }
-
-  const unsubscribeAnnotationUI = store.subscribe(function() {
-    self.rootThread = thread();
-  });
-
-  $scope.$on('$destroy', unsubscribeAnnotationUI);
+  this.rootThread = () => rootThread.thread(store.getState());
 
   function focusAnnotation(annotation) {
     let highlights = [];

--- a/src/sidebar/components/stream-content.js
+++ b/src/sidebar/components/stream-content.js
@@ -62,10 +62,7 @@ function StreamContentController(
   fetch(20);
 
   this.setCollapsed = store.setCollapsed;
-
-  store.subscribe(function() {
-    self.rootThread = rootThread.thread(store.getState());
-  });
+  this.rootThread = () => rootThread.thread(store.getState());
 
   // Sort the stream so that the newest annotations are at the top
   store.setSortKey('Newest');

--- a/src/sidebar/components/stream-content.js
+++ b/src/sidebar/components/stream-content.js
@@ -11,8 +11,6 @@ function StreamContentController(
   rootThread,
   searchFilter
 ) {
-  const self = this;
-
   store.setAppIsSidebar(false);
 
   /** `offset` parameter for the next search API call. */

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -164,6 +164,11 @@ describe('sidebar.components.sidebar-content', function() {
     fakeAnnotations.load.reset();
   }
 
+  it('generates the thread list', () => {
+    const thread = fakeRootThread.thread(store.getState());
+    assert.equal(ctrl.rootThread(), thread);
+  });
+
   context('when the search URIs of connected frames change', () => {
     beforeEach(connectFrameAndPerformInitialFetch);
 

--- a/src/sidebar/templates/annotation-viewer-content.html
+++ b/src/sidebar/templates/annotation-viewer-content.html
@@ -2,5 +2,5 @@
   on-change-collapsed="vm.setCollapsed(id, collapsed)"
   on-force-visible="vm.forceVisible(thread)"
   show-document-info="true"
-  thread="vm.rootThread">
+  thread="vm.rootThread()">
 </thread-list>

--- a/src/sidebar/templates/sidebar-content.html
+++ b/src/sidebar/templates/sidebar-content.html
@@ -35,7 +35,7 @@
   on-select="vm.scrollTo(annotation)"
   show-document-info="false"
   ng-if="!vm.selectedGroupUnavailable()"
-  thread="vm.rootThread">
+  thread="vm.rootThread()">
 </thread-list>
 
 <logged-out-message ng-if="vm.shouldShowLoggedOutMessage()" on-login="vm.onLogin()">

--- a/src/sidebar/templates/stream-content.html
+++ b/src/sidebar/templates/stream-content.html
@@ -2,6 +2,6 @@
   <thread-list
     on-change-collapsed="vm.setCollapsed(id, collapsed)"
     show-document-info="true"
-    thread="vm.rootThread">
+    thread="vm.rootThread()">
   </thread-list>
 </span>


### PR DESCRIPTION
Since an Angular digest cycle is triggered whenever Redux store state
changes, we can simplify the top-level component controllers in the UI
by making `vm.rootThread` a method which generates the top-level thread
when called.

Since `rootThread.thread` memoizes based its input, thread recalculation
won't happen more often than necessary. In fact, it should in theory be more efficient
now since the thread-list is only generated when the UI tries to render it, which may
be less frequently than store subscribers are called.

This change should also make it easier to migrate these components to
Preact/React in future.

----

**Testing**

Test that the thread list appears in:

- The sidebar
- The single annotation view (shown when clicking a timestamp in an annotation car)
- The stream (at http://localhost:5000/stream)