### PR TITLE
Wrap MenuItem icons with link if `href` provided

### DIFF
--- a/src/sidebar/components/menu-item.js
+++ b/src/sidebar/components/menu-item.js
@@ -47,14 +47,33 @@ function MenuItem({
   const hasLeftIcon = icon || isSubmenuItem;
   const hasRightIcon = icon && isSubmenuItem;
 
-  let renderedIcon = null;
-  if (icon !== 'blank') {
-    renderedIcon = iconIsUrl ? (
+  let renderedIcon = (() => {
+    if (!icon || icon === 'blank') {
+      return null;
+    }
+    let iconEl = iconIsUrl ? (
       <img className={iconClass} alt={iconAlt} src={icon} />
     ) : (
       <SvgIcon name={icon} className="menu-item__icon" />
     );
-  }
+    // MenuItems with a `click` property will have that applied to the
+    // entirety of  `div.menu-item`, but those with `href` need to have
+    // the icon wrapped in an `a` element
+    if (href) {
+      iconEl = (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="menu-item__icon-link"
+        >
+          {iconEl}
+        </a>
+      );
+    }
+    return iconEl;
+  })();
+
   const leftIcon = isSubmenuItem ? null : renderedIcon;
   const rightIcon = isSubmenuItem ? renderedIcon : null;
 

--- a/src/sidebar/components/test/menu-item-test.js
+++ b/src/sidebar/components/test/menu-item-test.js
@@ -42,6 +42,14 @@ describe('MenuItem', () => {
     assert.isTrue(wrapper.exists('SvgIcon[name="an-svg-icon"]'));
   });
 
+  it('links icon to `href` if `href` is provided', () => {
+    const wrapper = createMenuItem({
+      icon: 'an-svg-icon',
+      href: 'http://www.example.com',
+    });
+    assert.isTrue(wrapper.exists('.menu-item__icon-link'));
+  });
+
   it('renders a blank space for an icon if `icon` is "blank"', () => {
     const wrapper = createMenuItem({ icon: 'blank' });
     const iconSpace = wrapper.find('.menu-item__icon-container');

--- a/src/styles/sidebar/components/menu-item.scss
+++ b/src/styles/sidebar/components/menu-item.scss
@@ -79,6 +79,10 @@ $menu-item-padding: 10px;
   margin-right: 10px;
   width: 15px;
   height: 15px;
+
+  & a {
+    color: inherit;
+  }
 }
 
 .menu-item__icon {


### PR DESCRIPTION
`MenuItem` components that have `click` properties defined will apply that click handler to the entire menu item container div, meaning that clicking anywhere on the menu item—including on its icon—would cause something to happen. However, with `MenuItem`s that are linked to something (i.e. have an `href` property instead), the link was only getting applied to the menu item's label, such that clicking on the icon did nothing.

This PR fixes that.

Fixes #1213