### PR TITLE
Update user-focus store, rootThread intergration for clarity

### DIFF
--- a/src/sidebar/components/focused-mode-header.js
+++ b/src/sidebar/components/focused-mode-header.js
@@ -4,6 +4,11 @@ const { createElement } = require('preact');
 
 const useStore = require('../store/use-store');
 
+/**
+ * Render a control to interact with any focused "mode" in the sidebar.
+ * Currently only a user-focus mode is supported but this could be broadened
+ * and abstracted if needed. Allow user to toggle in and out of the focus "mode."
+ */
 function FocusedModeHeader() {
   const store = useStore(store => ({
     actions: {

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -49,22 +49,14 @@ function RootThread($rootScope, store, searchFilter, viewFilter) {
   function buildRootThread(state) {
     const sortFn = sortFns[state.sortKey];
     const shouldFilterThread = () => {
-      // is there a query or focused truthy value from the config?
+      // Is there a search query, or are we in an active (focused) focus mode?
       return state.filterQuery || store.focusModeFocused();
     };
     let filterFn;
     if (shouldFilterThread()) {
-      const userFilter = {}; // optional user filter object for focused mode
-      // look for a unique username, if present, add it to the user filter
-      const focusedUsername = store.focusModeUsername(); // may be null if no focused user
-      if (focusedUsername) {
-        // focused user found, add it to the filter object
-        userFilter.user = focusedUsername;
-      }
-      const filters = searchFilter.generateFacetedFilter(
-        state.filterQuery,
-        userFilter
-      );
+      const filters = searchFilter.generateFacetedFilter(state.filterQuery, {
+        user: store.focusModeUsername(), // `null` if no focused user
+      });
 
       filterFn = function(annot) {
         return viewFilter.filter([annot], filters).length > 0;

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -324,7 +324,7 @@ function setFilterQuery(query) {
 }
 
 /**
- * Set the focused to only show annotations by the focused user.
+ * Set the focused to only show annotations matching the current focus mode.
  */
 function setFocusModeFocused(focused) {
   return {
@@ -379,17 +379,9 @@ const getFirstSelectedAnnotationId = createSelector(
 function filterQuery(state) {
   return state.filterQuery;
 }
+
 /**
- * Returns the on/off state of the focus mode. This can be toggled on or off to
- * filter to the focused user.
- *
- * @return {boolean}
- */
-function focusModeFocused(state) {
-  return state.focusMode.enabled && state.focusMode.focused;
-}
-/**
- * Returns the value of the focus mode from the config.
+ * Do the config settings indicate that the client should be in a focused mode?
  *
  * @return {boolean}
  */
@@ -398,15 +390,34 @@ function focusModeEnabled(state) {
 }
 
 /**
- * Returns the username of the focused mode or null if none is found.
+ * Is a focus mode enabled, and is it presently applied?
  *
- * @return {object}
+ * @return {boolean}
+ */
+function focusModeFocused(state) {
+  return focusModeEnabled(state) && state.focusMode.focused;
+}
+
+/**
+ * Returns the username for a focused user or `null` if no focused user.
+ *
+ * @return {object|null}
  */
 function focusModeUsername(state) {
   if (state.focusMode.config.user && state.focusMode.config.user.username) {
     return state.focusMode.config.user.username;
   }
   return null;
+}
+
+/**
+ * Does the configured focus mode include user info, i.e. are we focusing on a
+ * user?
+ *
+ * @return {boolean}
+ */
+function focusModeHasUser(state) {
+  return focusModeEnabled(state) && !!focusModeUsername(state);
 }
 
 /**
@@ -453,6 +464,7 @@ module.exports = {
     filterQuery,
     focusModeFocused,
     focusModeEnabled,
+    focusModeHasUser,
     focusModeUsername,
     focusModeUserPrettyName,
     isAnnotationSelected,

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -223,6 +223,27 @@ describe('store/modules/selection', () => {
     });
   });
 
+  describe('focusModeHasUser()', () => {
+    it('should return `true` if focus enabled and valid `user` object present', () => {
+      store = createStore(
+        [selection],
+        [{ focus: { user: { username: 'whatever' } } }]
+      );
+      assert.isTrue(store.focusModeHasUser());
+    });
+    it('should return `false` if focus enabled but `user` object invalid', () => {
+      store = createStore(
+        [selection],
+        [{ focus: { user: { displayName: 'whatever' } } }] // `username` is required
+      );
+      assert.isFalse(store.focusModeHasUser());
+    });
+    it('should return `false` if `user` object missing', () => {
+      store = createStore([selection], [{ focus: {} }]);
+      assert.isFalse(store.focusModeHasUser());
+    });
+  });
+
   describe('focusModeUserPrettyName()', function() {
     it('should return false by default when focus mode is not enabled', function() {
       store = createStore(


### PR DESCRIPTION
This small PR puts a bit of polish (comments, minor structure) on some of the user-focus underpinnings.

It adds an additional store selector for asking "is there a focused user right now?"