### PR TITLE
Remove "X" icon from toggle button in focus mode

### DIFF
--- a/src/sidebar/components/focused-mode-header.js
+++ b/src/sidebar/components/focused-mode-header.js
@@ -4,8 +4,6 @@ const { createElement } = require('preact');
 
 const useStore = require('../store/use-store');
 
-const SvgIcon = require('./svg-icon');
-
 /**
  * Render a control to interact with any focused "mode" in the sidebar.
  * Currently only a user-focus mode is supported but this could be broadened
@@ -55,7 +53,6 @@ function FocusedModeHeader() {
     <div className="focused-mode-header sheet">
       {filterStatus}
       <button onClick={toggleFocusedMode} className="focused-mode-header__btn">
-        <SvgIcon name="cancel" className="focused-mode-header__btn-icon" />
         {buttonText}
       </button>
     </div>

--- a/src/styles/sidebar/components/focused-mode-header.scss
+++ b/src/styles/sidebar/components/focused-mode-header.scss
@@ -10,17 +10,13 @@
     display: flex;
     margin-left: auto;
     height: 30px;
-    padding-left: 6px;
+    padding-left: 10px;
     padding-right: 10px;
     background-color: $grey-2;
     color: $grey-5;
     &:hover:enabled {
       background-color: $grey-3;
     }
-  }
-
-  &__btn-icon {
-    margin-right: 3px;
   }
 
   &__filter-status {


### PR DESCRIPTION
Since clicking the button toggles between two states rather than
dismissing the "focus mode" header, the "X" icon doesn't feel
appropriate, so remove it.

The button's padding has been adjusted to center align the content
following the removal of the icon.

Fixes #1294