### PR TITLE
Change focus mode button label

### DIFF
--- a/src/sidebar/components/focused-mode-header.js
+++ b/src/sidebar/components/focused-mode-header.js
@@ -45,7 +45,7 @@ function FocusedModeHeader() {
     if (selectors.focusModeFocused) {
       return 'Show all';
     } else {
-      return `Only ${selectors.focusModeUserPrettyName}`;
+      return `Show only ${selectors.focusModeUserPrettyName}`;
     }
   })();
 

--- a/src/sidebar/components/test/focused-mode-header-test.js
+++ b/src/sidebar/components/test/focused-mode-header-test.js
@@ -76,7 +76,7 @@ describe('FocusedModeHeader', function() {
 
         const button = wrapper.find('button');
 
-        assert.include(button.text(), 'Only Fake User');
+        assert.include(button.text(), 'Show only Fake User');
       });
     });
 


### PR DESCRIPTION
Change the label when showing everyone's annotations from "Only <name>"
to "Show only <name>". Having the label always start with a verb is more
consistent and hopefully a bit clearer.