### PR TITLE
Add namespace capability to store modules

### DIFF
--- a/src/sidebar/services/service-url.js
+++ b/src/sidebar/services/service-url.js
@@ -42,7 +42,7 @@ function serviceUrl(store, apiRoutes) {
     });
 
   return function(linkName, params) {
-    const links = store.getState().links;
+    const links = store.getRootState().links;
 
     if (links === null) {
       return '';

--- a/src/sidebar/services/test/service-url-test.js
+++ b/src/sidebar/services/test/service-url-test.js
@@ -12,6 +12,9 @@ function fakeStore() {
     getState: function() {
       return { links: links };
     },
+    getRootState: function() {
+      return { links: links };
+    },
   };
 }
 

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -254,7 +254,7 @@ function addAnnotations(annotations, now) {
 
   return function(dispatch, getState) {
     const added = annotations.filter(function(annot) {
-      return !findByID(getState().annotations, annot.id);
+      return !findByID(getState().base.annotations, annot.id);
     });
 
     dispatch({
@@ -262,7 +262,7 @@ function addAnnotations(annotations, now) {
       annotations: annotations,
     });
 
-    if (!getState().isSidebar) {
+    if (!getState().base.isSidebar) {
       return;
     }
 
@@ -277,7 +277,7 @@ function addAnnotations(annotations, now) {
     if (anchoringIDs.length > 0) {
       setTimeout(() => {
         // Find annotations which haven't yet been anchored in the document.
-        const anns = getState().annotations;
+        const anns = getState().base.annotations;
         const annsStillAnchoring = anchoringIDs
           .map(id => findByID(anns, id))
           .filter(ann => ann && metadata.isWaitingToAnchor(ann));

--- a/src/sidebar/store/modules/drafts.js
+++ b/src/sidebar/store/modules/drafts.js
@@ -106,10 +106,10 @@ function createDraft(annotation, changes) {
 function deleteNewAndEmptyDrafts() {
   const annotations = require('./annotations');
   return (dispatch, getState) => {
-    const newDrafts = getState().drafts.filter(draft => {
+    const newDrafts = getState().base.drafts.filter(draft => {
       return (
         metadata.isNew(draft.annotation) &&
-        !getDraftIfNotEmpty(getState(), draft.annotation)
+        !getDraftIfNotEmpty(getState().base, draft.annotation)
       );
     });
     const removedAnnotations = newDrafts.map(draft => {

--- a/src/sidebar/store/modules/links.js
+++ b/src/sidebar/store/modules/links.js
@@ -11,12 +11,12 @@
 
 /** Return the initial links. */
 function init() {
-  return { links: null };
+  return null;
 }
 
 /** Return updated links based on the given current state and action object. */
 function updateLinks(state, action) {
-  return { links: action.newLinks };
+  return { ...action.newLinks };
 }
 
 /** Return an action object for updating the links to the given newLinks. */
@@ -26,6 +26,7 @@ function updateLinksAction(newLinks) {
 
 module.exports = {
   init: init,
+  namespace: 'links',
   update: { UPDATE_LINKS: updateLinks },
   actions: { updateLinks: updateLinksAction },
   selectors: {},

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -236,7 +236,7 @@ function selectAnnotations(ids) {
 /** Toggle whether annotations are selected or not. */
 function toggleSelectedAnnotations(ids) {
   return function(dispatch, getState) {
-    const selection = Object.assign({}, getState().selectedAnnotationMap);
+    const selection = Object.assign({}, getState().base.selectedAnnotationMap);
     for (let i = 0; i < ids.length; i++) {
       const id = ids[i];
       if (selection[id]) {
@@ -260,7 +260,7 @@ function setForceVisible(id, visible) {
   // FIXME: This should be converted to a plain action and accessing the state
   // should happen in the update() function
   return function(dispatch, getState) {
-    const forceVisible = Object.assign({}, getState().forceVisible);
+    const forceVisible = Object.assign({}, getState().base.forceVisible);
     forceVisible[id] = visible;
     dispatch({
       type: actions.SET_FORCE_VISIBLE,
@@ -285,7 +285,7 @@ function setCollapsed(id, collapsed) {
   // FIXME: This should be converted to a plain action and accessing the state
   // should happen in the update() function
   return function(dispatch, getState) {
-    const expanded = Object.assign({}, getState().expanded);
+    const expanded = Object.assign({}, getState().base.expanded);
     expanded[id] = !collapsed;
     dispatch({
       type: actions.SET_EXPANDED,

--- a/src/sidebar/store/modules/test/links-test.js
+++ b/src/sidebar/store/modules/test/links-test.js
@@ -9,23 +9,24 @@ const action = links.actions.updateLinks;
 describe('sidebar.reducers.links', function() {
   describe('#init()', function() {
     it('returns a null links object', function() {
-      assert.deepEqual(init(), { links: null });
+      assert.deepEqual(init(), null);
     });
   });
 
   describe('#update.UPDATE_LINKS()', function() {
     it('returns the given newLinks as the links object', function() {
-      assert.deepEqual(update('CURRENT_STATE', { newLinks: 'NEW_LINKS' }), {
-        links: 'NEW_LINKS',
-      });
+      assert.deepEqual(
+        update('CURRENT_STATE', { newLinks: { NEW_LINK: 'http://new_link' } }),
+        { NEW_LINK: 'http://new_link' }
+      );
     });
   });
 
   describe('#actions.updateLinks()', function() {
     it('returns an UPDATE_LINKS action object for the given newLinks', function() {
-      assert.deepEqual(action('NEW_LINKS'), {
+      assert.deepEqual(action({ NEW_LINK: 'http://new_link' }), {
         type: 'UPDATE_LINKS',
-        newLinks: 'NEW_LINKS',
+        newLinks: { NEW_LINK: 'http://new_link' },
       });
     });
   });


### PR DESCRIPTION
Each module can now opt into being namespaced by exporting the value for "namespace". The `links` module  is the only module that has been namespaced.

**When using a namespace a few things change:**

- Reducers need not be aware of the namespace. The scope will be set when they are called.
- Namespaced selectors of the module will need to use the namespace because they will be given the root of the store.
- A namespaced module's state keys no longer need to be unique since it can't collide with other state keys.
- A namespaced module's state can return an array rather than an object if the state is a simple list of thing.
- There is a new helper method called getRootState which returns the root of the store which has access to both "base" and all other new namespaces.
- getRootState returns the root of the store, 

**Some behavior changes for Legacy (non-namespaced) modules:**

- Legacy modules are nested in a pseudo namespace called "base" which will be depreciated once all module are namespaced. 
- getState returns the "base" state
- Selectors of legacy modules will not need to use the namespace because they will be given a scoped state of the "base" namespace

The long term plan is to export a namespace for each module at which point we'll do a little deprecation work inside of create-store. 

_Note, this work does not namespace actions or selectors functions themselves -- that work may come later._

#1235 