### PR TITLE
Add parent frame URL as context to Sentry error reports

### DIFF
--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -44,6 +44,13 @@ function init(config) {
       return event;
     },
   });
+
+  // In the sidebar application, it is often useful to know the URL which the
+  // client was loaded into. This information is usually available in an iframe
+  // via `document.referrer`. More information about the document is available
+  // later when frames where the "annotator" code has loaded have connected to
+  // the sidebar via `postMessage` RPC messages.
+  Sentry.setTag('document_url', document.referrer);
 }
 
 /**

--- a/src/sidebar/util/test/sentry-test.js
+++ b/src/sidebar/util/test/sentry-test.js
@@ -3,12 +3,14 @@
 const sentry = require('../sentry');
 
 describe('sidebar/util/sentry', () => {
+  let fakeDocumentReferrer;
   let fakeSentry;
   let fakeWarnOnce;
 
   beforeEach(() => {
     fakeSentry = {
       init: sinon.stub(),
+      setTag: sinon.stub(),
       setUser: sinon.stub(),
     };
 
@@ -25,6 +27,15 @@ describe('sidebar/util/sentry', () => {
   });
 
   describe('init', () => {
+    beforeEach(() => {
+      fakeDocumentReferrer = sinon.stub(document, 'referrer');
+      fakeDocumentReferrer.get(() => 'https://example.com');
+    });
+
+    afterEach(() => {
+      fakeDocumentReferrer.restore();
+    });
+
     it('configures Sentry', () => {
       sentry.init({
         dsn: 'test-dsn',
@@ -38,6 +49,15 @@ describe('sidebar/util/sentry', () => {
           environment: 'dev',
           release: '1.0.0-dummy-version',
         })
+      );
+    });
+
+    it('adds extra context to reports', () => {
+      sentry.init({ dsn: 'test-dsn', environment: 'dev' });
+      assert.calledWith(
+        fakeSentry.setTag,
+        'document_url',
+        'https://example.com'
       );
     });
 


### PR DESCRIPTION
Add a `document_url` tag to error reports whose value is the URL of the
sidebar's parent frame.

This is useful when reproducing issues that only occur on certain sites.

The value is added as a "tag" so that it shows up at the top of reports in Sentry ([see example](https://sentry.io/organizations/hypothesis/issues/1189810152/?project=69811&query=is%3Aunresolved&statsPeriod=14d)) and is indexed for searching and grouping:

<img width="661" alt="Screenshot 2019-08-27 12 09 49" src="https://user-images.githubusercontent.com/2458/63766915-1f8d2600-c8c4-11e9-86e5-764c530e800a.png">
