### PR TITLE
Do not link last-edited timestamp to annotation single view

### DIFF
--- a/src/sidebar/components/annotation-header.js
+++ b/src/sidebar/components/annotation-header.js
@@ -44,7 +44,6 @@ function AnnotationHeader({
                 (edited{' '}
                 <Timestamp
                   className="annotation-header__timestamp-edited-link"
-                  href={annotationLink}
                   timestamp={annotation.updated}
                 />
                 ){' '}

--- a/src/styles/sidebar/components/annotation-header.scss
+++ b/src/styles/sidebar/components/annotation-header.scss
@@ -21,8 +21,7 @@
     color: $grey-4;
   }
 
-  &__timestamp-created-link,
-  &__timestamp-edited-link {
+  &__timestamp-created-link {
     &:hover {
       text-decoration: underline;
     }
@@ -30,10 +29,6 @@
 
   &__timestamp-created-link {
     color: $grey-5;
-  }
-
-  &__timestamp-edited-link {
-    color: $grey-4;
   }
 
   &__highlight {


### PR DESCRIPTION
Render, but do not link, the last-edited timestamp. Having both this
and the created timestamp linked to the single-annotation view can lead
to confusion, as it might seem like they link to two different places
if they’re both linked.

Before (both timestamps are linked):

![linked-edited-timestamp](https://user-images.githubusercontent.com/439947/63797810-cb3f7180-c8d6-11e9-8c88-ff85f85c7b83.gif)

After (only created timestamp is linked):

![unlinked-edited-timestamp](https://user-images.githubusercontent.com/439947/63797824-d1cde900-c8d6-11e9-9b6c-dae74ce733ff.gif)

Note that in the after case, the cursor is remaining as a `pointer`, which I find a little confusing, but it's an inherited thing because the entire annotation card is "clickable" (to scroll to the corresponding annotation in the host page).

Fixes https://github.com/hypothesis/client/issues/1295