### PR TITLE
Add custom serialization for `Event` exception values in Sentry reporting

### DIFF
--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -27,6 +27,7 @@ function init(config) {
     environment: config.environment,
     release: '__VERSION__', // replaced by versionify
 
+    // See https://docs.sentry.io/error-reporting/configuration/filtering/?platform=javascript#before-send
     beforeSend: (event, hint) => {
       if (eventsSent >= maxEventsToSendPerSession) {
         // Cap the number of events that any client instance will send, to

--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -27,7 +27,7 @@ function init(config) {
     environment: config.environment,
     release: '__VERSION__', // replaced by versionify
 
-    beforeSend: event => {
+    beforeSend: (event, hint) => {
       if (eventsSent >= maxEventsToSendPerSession) {
         // Cap the number of events that any client instance will send, to
         // reduce the impact on our Sentry event quotas.
@@ -39,8 +39,25 @@ function init(config) {
         );
         return null;
       }
-
       ++eventsSent;
+
+      // Add additional debugging information for non-Error exception types
+      // which Sentry can't serialize to a useful format automatically.
+      //
+      // See https://github.com/getsentry/sentry-javascript/issues/2210
+      try {
+        const originalErr = hint && hint.originalException;
+        if (originalErr instanceof Event) {
+          Object.assign(event.extra, {
+            type: originalErr.type,
+            detail: originalErr.detail,
+            isTrusted: originalErr.isTrusted,
+          });
+        }
+      } catch (e) {
+        // If something went wrong serializing the data, just ignore it.
+      }
+
       return event;
     },
   });


### PR DESCRIPTION
To help debug https://sentry.io/organizations/hypothesis/issues/1190575523
and similar issues, add logic to extract details of uncaught thrown
`Event`s and attach them to Sentry reports.