### PR TITLE
Record document URL as "extra" metadata rather than a tag

### DIFF
--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -50,7 +50,7 @@ function init(config) {
   // via `document.referrer`. More information about the document is available
   // later when frames where the "annotator" code has loaded have connected to
   // the sidebar via `postMessage` RPC messages.
-  Sentry.setTag('document_url', document.referrer);
+  Sentry.setExtra('document_url', document.referrer);
 }
 
 /**

--- a/src/sidebar/util/test/sentry-test.js
+++ b/src/sidebar/util/test/sentry-test.js
@@ -10,7 +10,7 @@ describe('sidebar/util/sentry', () => {
   beforeEach(() => {
     fakeSentry = {
       init: sinon.stub(),
-      setTag: sinon.stub(),
+      setExtra: sinon.stub(),
       setUser: sinon.stub(),
     };
 
@@ -55,7 +55,7 @@ describe('sidebar/util/sentry', () => {
     it('adds extra context to reports', () => {
       sentry.init({ dsn: 'test-dsn', environment: 'dev' });
       assert.calledWith(
-        fakeSentry.setTag,
+        fakeSentry.setExtra,
         'document_url',
         'https://example.com'
       );


### PR DESCRIPTION
https://github.com/hypothesis/client/pull/1328 added the URL of the page in which the client was embedded as metadata in crash reports. It was added as a Sentry "tag" which is an indexed key/value pair. It turns out that Sentry has various constraints on the characters that can appear in tags as well as their length. Any tags which don't match these constraints are simply dropped so we lose the information. This turned out to happen quite often for document URLs.

For debugging purposes we want to capture the full document URL unmodified. Therefore capture this as un-indexed "extra" metadata, which has fewer constraints, rather than
an indexed "tag".

In Sentry error reports, the metadata will now show up in the "Additional data" section:

<img width="669" alt="Screenshot 2019-08-28 08 33 48" src="https://user-images.githubusercontent.com/2458/63835065-9e3e9d80-c96e-11e9-979a-9e78a560350c.png">
