### PR TITLE
Standardize the module test descriptions

### DIFF
--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -6,7 +6,7 @@ const createStore = require('../../create-store');
 const groups = require('../groups');
 const session = require('../session');
 
-describe('sidebar.store.modules.groups', () => {
+describe('sidebar/store/modules/groups', () => {
   const publicGroup = immutable({
     id: '__world__',
     name: 'Public',

--- a/src/sidebar/store/modules/test/links-test.js
+++ b/src/sidebar/store/modules/test/links-test.js
@@ -6,7 +6,7 @@ const init = links.init;
 const update = links.update.UPDATE_LINKS;
 const action = links.actions.updateLinks;
 
-describe('sidebar.reducers.links', function() {
+describe('sidebar/store/modules/links', function() {
   describe('#init()', function() {
     it('returns a null links object', function() {
       assert.deepEqual(init(), null);

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -5,7 +5,7 @@ const createStore = require('../../create-store');
 const selection = require('../selection');
 const uiConstants = require('../../../ui-constants');
 
-describe('store/modules/selection', () => {
+describe('sidebar/store/modules/selection', () => {
   let store;
   let fakeSettings = [{}, {}];
 

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -5,7 +5,7 @@ const session = require('../session');
 
 const { init } = session;
 
-describe('sidebar.reducers.session', function() {
+describe('sidebar/store/modules/session', function() {
   let store;
 
   beforeEach(() => {


### PR DESCRIPTION
note: annotations and viewer will be done in different PRs. This just cleans up the rest of the module test names.

