### PR TITLE
Add `aria-label` to annotation tags

### DIFF
--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -56,7 +56,7 @@
 
   <div class="annotation-body u-layout-row tags tags-read-only"
        ng-if="(vm.canCollapseBody || vm.state().tags.length) && !vm.editing()">
-    <ul class="tag-list">
+    <ul class="tag-list" aria-label="Annotation tags">
       <li class="tag-item" ng-repeat="tag in vm.state().tags">
         <a ng-href="{{vm.tagSearchURL(tag)}}" target="_blank">{{tag}}</a>
       </li>


### PR DESCRIPTION
Add an `aria-label` as a first-stop step to better a11y on annotation tags.

There's still more to do in this area to make annotation tags more accessible, but adding an `aria-label` on the containing list won't hurt.

Fixes  https://github.com/hypothesis/product-backlog/issues/781 as currently written