### PR TITLE
Fix race condition when anchoring in a PDF during initial document load

### DIFF
--- a/src/annotator/anchoring/test/fake-pdf-viewer-application.js
+++ b/src/annotator/anchoring/test/fake-pdf-viewer-application.js
@@ -130,6 +130,13 @@ class FakePDFViewer {
     return this._content.length;
   }
 
+  /**
+   * Return the `FakePDFPageView` object representing a rendered page or a
+   * placeholder for one.
+   *
+   * During PDF.js startup when the document is still being loaded, this may
+   * return a nullish value even when the PDF page index is valid.
+   */
   getPageView(index) {
     this._checkBounds(index);
     return this._pages[index];
@@ -160,6 +167,14 @@ class FakePDFViewer {
 
   dispose() {
     this._pages.forEach(page => page.dispose());
+  }
+
+  /**
+   * Dispatch a DOM event to notify observers that some event has occurred
+   * in the PDF viewer.
+   */
+  notify(eventName) {
+    this._container.dispatchEvent(new Event(eventName, { bubbles: true }));
   }
 
   _checkBounds(index) {


### PR DESCRIPTION
Fix a race condition that could occur when the client tried to anchor
annotations in a PDF while the PDF was still loading.

PDF.js' `PDFViewer` class initializes its `PDFPageView` objects, as
returned by `PDFViewer.getPageView`, asynchronously. While the page
views are being initialized, `PDFViewer.pagesCount` returns 0 and
`PDFViewer.getPageView` will return a nullish value. When loading has
progressed further, `getPageView` returns a `PDFPageView` but with no
`pdfPage` property. Once the page views are fully ready, a bubbling
"pagesloaded" event is dispatched at the PDF viewer's container DOM
element.

The PDF anchoring code previously assumed that page views were always
immediately available and they always had a `pdfPage` property. If this
was not the case, anchoring would fail and all/many annotations would
appear as orphans in the client. See the associated issue for ways to
reproduce this locally with Via.

Resolve the issue by making the `getPageView` helper which wraps
`PDFViewer.getPageView` async, and block in that function until the page
views are fully ready.

 - Make `getPageView` helper async and block if necessary until page
   views are ready.
 - Add a test to simulate scenarios where page views are not ready yet
 - Change the `quotePositionCache` cache to store page indexes rather
   than `PDFPageView` objects. This means that less code in the file
   needs to know about `PDFPageView` objects, and deal with the fact
   that they may not be immediately available. It also means it should
   be easier to adapt the code to future PDF.js API changes.

Fixes #1330

----

**Testing**

See [this comment](https://github.com/hypothesis/client/issues/1330#issuecomment-528242209) for a way to reproduce the original issue with any PDF locally in Via (I used https://arxiv.org/pdf/1909.01862.pdf).