### PR TITLE
Namespace cleanup

### DIFF
--- a/src/sidebar/components/annotation-viewer-content.js
+++ b/src/sidebar/components/annotation-viewer-content.js
@@ -40,7 +40,7 @@ function AnnotationViewerContentController(
 
   const id = $routeParams.id;
 
-  this.rootThread = () => rootThread.thread(store.getRootState());
+  this.rootThread = () => rootThread.thread(store.getState());
 
   this.setCollapsed = function(id, collapsed) {
     store.setCollapsed(id, collapsed);

--- a/src/sidebar/components/search-status-bar.js
+++ b/src/sidebar/components/search-status-bar.js
@@ -26,7 +26,7 @@ const countVisibleAnns = annThread => {
  * annotations, and, in some cases, a mechanism for clearing the filter(s).
  * */
 function SearchStatusBar({ rootThread }) {
-  const thread = useStore(store => rootThread.thread(store.getRootState()));
+  const thread = useStore(store => rootThread.thread(store.getState()));
 
   const actions = useStore(store => ({
     clearSelection: store.clearSelection,
@@ -45,13 +45,13 @@ function SearchStatusBar({ rootThread }) {
     selectionMap,
     selectedTab,
   } = useStore(store => ({
-    directLinkedGroupFetchFailed: store.getRootState().directLinked
+    directLinkedGroupFetchFailed: store.getState().directLinked
       .directLinkedGroupFetchFailed,
-    filterQuery: store.getRootState().selection.filterQuery,
+    filterQuery: store.getState().selection.filterQuery,
     focusModeFocused: store.focusModeFocused(),
     focusModeUserPrettyName: store.focusModeUserPrettyName(),
-    selectionMap: store.getRootState().selection.selectedAnnotationMap,
-    selectedTab: store.getRootState().selection.selectedTab,
+    selectionMap: store.getState().selection.selectedAnnotationMap,
+    selectedTab: store.getState().selection.selectedTab,
   }));
 
   // The search status bar UI represents multiple "modes" of filtering

--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -70,9 +70,7 @@ Tab.propTypes = {
  */
 
 function SelectionTabs({ isLoading, settings, session }) {
-  const selectedTab = useStore(
-    store => store.getRootState().selection.selectedTab
-  );
+  const selectedTab = useStore(store => store.getState().selection.selectedTab);
   const noteCount = useStore(store => store.noteCount());
   const annotationCount = useStore(store => store.annotationCount());
   const orphanCount = useStore(store => store.orphanCount());

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -17,7 +17,7 @@ function SidebarContentController(
 ) {
   const self = this;
 
-  this.rootThread = () => rootThread.thread(store.getRootState());
+  this.rootThread = () => rootThread.thread(store.getState());
 
   function focusAnnotation(annotation) {
     let highlights = [];
@@ -41,11 +41,11 @@ function SidebarContentController(
    * not the order in which they appear in the document.
    */
   function firstSelectedAnnotation() {
-    if (store.getRootState().selection.selectedAnnotationMap) {
+    if (store.getState().selection.selectedAnnotationMap) {
       const id = Object.keys(
-        store.getRootState().selection.selectedAnnotationMap
+        store.getState().selection.selectedAnnotationMap
       )[0];
-      return store.getRootState().annotations.annotations.find(function(annot) {
+      return store.getState().annotations.annotations.find(function(annot) {
         return annot.id === id;
       });
     } else {
@@ -135,7 +135,7 @@ function SidebarContentController(
     if (
       this.selectedAnnotationUnavailable() ||
       this.selectedGroupUnavailable() ||
-      store.getRootState().selection.filterQuery
+      store.getState().selection.filterQuery
     ) {
       return false;
     } else if (store.focusModeFocused()) {
@@ -153,7 +153,7 @@ function SidebarContentController(
   this.scrollTo = scrollToAnnotation;
 
   this.selectedGroupUnavailable = function() {
-    return store.getRootState().directLinked.directLinkedGroupFetchFailed;
+    return store.getState().directLinked.directLinkedGroupFetchFailed;
   };
 
   this.selectedAnnotationUnavailable = function() {
@@ -171,7 +171,7 @@ function SidebarContentController(
 
     // If user has not landed on a direct linked annotation
     // don't show the CTA.
-    if (!store.getRootState().directLinked.directLinkedAnnotationId) {
+    if (!store.getState().directLinked.directLinkedAnnotationId) {
       return false;
     }
 

--- a/src/sidebar/components/sort-menu.js
+++ b/src/sidebar/components/sort-menu.js
@@ -15,11 +15,11 @@ function SortMenu() {
     setSortKey: store.setSortKey,
   }));
   // The currently-applied sort order
-  const sortKey = useStore(store => store.getRootState().selection.sortKey);
+  const sortKey = useStore(store => store.getState().selection.sortKey);
   // All available sorting options. These change depending on current
   // "tab" or context.
   const sortKeysAvailable = useStore(
-    store => store.getRootState().selection.sortKeysAvailable
+    store => store.getState().selection.sortKeysAvailable
   );
 
   const menuItems = sortKeysAvailable.map(sortOption => {

--- a/src/sidebar/components/stream-content.js
+++ b/src/sidebar/components/stream-content.js
@@ -60,7 +60,7 @@ function StreamContentController(
   fetch(20);
 
   this.setCollapsed = store.setCollapsed;
-  this.rootThread = () => rootThread.thread(store.getRootState());
+  this.rootThread = () => rootThread.thread(store.getState());
 
   // Sort the stream so that the newest annotations are at the top
   store.setSortKey('Newest');

--- a/src/sidebar/components/test/search-status-bar-test.js
+++ b/src/sidebar/components/test/search-status-bar-test.js
@@ -20,8 +20,7 @@ describe('SearchStatusBar', () => {
       thread: sinon.stub().returns({ children: [] }),
     };
     fakeStore = {
-      getState: sinon.stub(),
-      getRootState: sinon.stub().returns({
+      getState: sinon.stub().returns({
         selection: {},
         directLinked: {},
       }),
@@ -42,7 +41,7 @@ describe('SearchStatusBar', () => {
 
   context('user search query is applied', () => {
     beforeEach(() => {
-      fakeStore.getRootState.returns({
+      fakeStore.getState.returns({
         selection: {
           filterQuery: 'tag:foo',
           selectedTab: 'annotation',
@@ -179,7 +178,7 @@ describe('SearchStatusBar', () => {
         ],
       });
 
-      fakeStore.getRootState.returns({
+      fakeStore.getState.returns({
         selection: {
           filterQuery: 'tag:foo',
           selectedTab: 'annotation',
@@ -239,7 +238,7 @@ describe('SearchStatusBar', () => {
         },
       ].forEach(test => {
         it(test.description, () => {
-          fakeStore.getRootState.returns({
+          fakeStore.getState.returns({
             selection: {
               filterQuery: null,
               selectedAnnotationMap: { annId: true },
@@ -272,7 +271,7 @@ describe('SearchStatusBar', () => {
       ].forEach(test => {
         it(`displays correct text for tab '${test.tab}', without count`, () => {
           fakeStore.focusModeFocused = sinon.stub().returns(true);
-          fakeStore.getRootState.returns({
+          fakeStore.getState.returns({
             selection: {
               filterQuery: null,
               selectedTab: test.tab,
@@ -302,7 +301,7 @@ describe('SearchStatusBar', () => {
       // Applied-query mode wins out here; no selection UI rendered
       it('does not show selected-mode elements', () => {
         fakeStore.focusModeFocused = sinon.stub().returns(true);
-        fakeStore.getRootState.returns({
+        fakeStore.getState.returns({
           selection: {
             filterQuery: 'tag:foo',
             selectedTab: 'annotation',

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -63,7 +63,7 @@ describe('SelectionTabs', function() {
       noteCount: sinon.stub().returns(456),
       orphanCount: sinon.stub().returns(0),
       isWaitingToAnchorAnnotations: sinon.stub().returns(false),
-      getRootState: sinon.stub().returns({
+      getState: sinon.stub().returns({
         selection: {
           selectedTab: uiConstants.TAB_ANNOTATIONS,
         },
@@ -103,7 +103,7 @@ describe('SelectionTabs', function() {
     });
 
     it('should display notes tab as selected', function() {
-      fakeStore.getRootState.returns({
+      fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_NOTES },
       });
       const wrapper = createDeepComponent({});
@@ -112,7 +112,7 @@ describe('SelectionTabs', function() {
     });
 
     it('should display orphans tab as selected if there is 1 or more orphans', function() {
-      fakeStore.getRootState.returns({
+      fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_ORPHANS },
       });
       fakeStore.orphanCount.returns(1);
@@ -122,7 +122,7 @@ describe('SelectionTabs', function() {
     });
 
     it('should not display orphans tab if there are 0 orphans', function() {
-      fakeStore.getRootState.returns({
+      fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_ORPHANS },
       });
       const wrapper = createDeepComponent({});
@@ -147,7 +147,7 @@ describe('SelectionTabs', function() {
     });
 
     it('should not display the new-note-btn when the notes tab is active and the new-note-btn is disabled', function() {
-      fakeStore.getRootState.returns({
+      fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_NOTES },
       });
       const wrapper = createComponent({});
@@ -156,7 +156,7 @@ describe('SelectionTabs', function() {
 
     it('should display the new-note-btn when the notes tab is active and the new-note-btn is enabled', function() {
       fakeSettings.enableExperimentalNewNoteButton = true;
-      fakeStore.getRootState.returns({
+      fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_NOTES },
       });
       const wrapper = createComponent({});
@@ -172,7 +172,7 @@ describe('SelectionTabs', function() {
     });
 
     it('should not display a message when its loading notes count is 0', function() {
-      fakeStore.getRootState.returns({
+      fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_NOTES },
       });
       fakeStore.noteCount.returns(0);
@@ -192,7 +192,7 @@ describe('SelectionTabs', function() {
     });
 
     it('should display the longer version of the no notes message when there are no notes', function() {
-      fakeStore.getRootState.returns({
+      fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_NOTES },
       });
       fakeStore.noteCount.returns(0);
@@ -205,7 +205,7 @@ describe('SelectionTabs', function() {
 
     it('should display the prompt to create a note when there are no notes and enableExperimentalNewNoteButton is true', function() {
       fakeSettings.enableExperimentalNewNoteButton = true;
-      fakeStore.getRootState.returns({
+      fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_NOTES },
       });
       fakeStore.noteCount.returns(0);
@@ -242,7 +242,7 @@ describe('SelectionTabs', function() {
     context('when the sidebar tutorial is displayed', function() {
       it('should display the shorter version of the no notes message when there are no notes', function() {
         fakeSession.state.preferences.show_sidebar_tutorial = true;
-        fakeStore.getRootState.returns({
+        fakeStore.getState.returns({
           selection: { selectedTab: uiConstants.TAB_NOTES },
         });
         fakeStore.noteCount.returns(0);

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -176,7 +176,7 @@ describe('sidebar.components.sidebar-content', function() {
   }
 
   it('generates the thread list', () => {
-    const thread = fakeRootThread.thread(store.getRootState());
+    const thread = fakeRootThread.thread(store.getState());
     assert.equal(ctrl.rootThread(), thread);
   });
 

--- a/src/sidebar/components/test/sort-menu-test.js
+++ b/src/sidebar/components/test/sort-menu-test.js
@@ -23,7 +23,7 @@ describe('SortMenu', () => {
     };
     fakeStore = {
       setSortKey: sinon.stub(),
-      getRootState: sinon.stub().returns(fakeState),
+      getState: sinon.stub().returns(fakeState),
     };
 
     SortMenu.$imports.$mock({

--- a/src/sidebar/services/annotation-mapper.js
+++ b/src/sidebar/services/annotation-mapper.js
@@ -5,7 +5,7 @@ const angular = require('angular');
 const events = require('../events');
 
 function getExistingAnnotation(store, id) {
-  return store.getRootState().annotations.annotations.find(function(annot) {
+  return store.getState().annotations.annotations.find(function(annot) {
     return annot.id === id;
   });
 }

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -56,7 +56,7 @@ function FrameSync($rootScope, $window, Discovery, store, bridge) {
     let prevPublicAnns = 0;
 
     store.subscribe(function() {
-      const state = store.getRootState();
+      const state = store.getState();
       if (
         state.annotations.annotations === prevAnnotations &&
         state.frames === prevFrames

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -179,7 +179,7 @@ function groups(
     // If there is a direct-linked annotation, fetch the annotation in case
     // the associated group has not already been fetched and we need to make
     // an additional request for it.
-    const directLinkedAnnId = store.getRootState().directLinked
+    const directLinkedAnnId = store.getState().directLinked
       .directLinkedAnnotationId;
     let directLinkedAnnApi = null;
     if (directLinkedAnnId) {
@@ -194,7 +194,7 @@ function groups(
     // If there is a direct-linked group, add an API request to get that
     // particular group since it may not be in the set of groups that are
     // fetched by other requests.
-    const directLinkedGroupId = store.getRootState().directLinked
+    const directLinkedGroupId = store.getState().directLinked
       .directLinkedGroupId;
     let directLinkedGroupApi = null;
     if (directLinkedGroupId) {

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -127,7 +127,7 @@ function RootThread($rootScope, store, searchFilter, viewFilter) {
   // logic in this event handler can be moved to the annotations reducer.
   $rootScope.$on(events.GROUP_FOCUSED, function(event, focusedGroupId) {
     const updatedAnnots = store
-      .getRootState()
+      .getState()
       .annotations.annotations.filter(function(ann) {
         return metadata.isNew(ann) && !metadata.isReply(ann);
       })

--- a/src/sidebar/services/service-url.js
+++ b/src/sidebar/services/service-url.js
@@ -42,7 +42,7 @@ function serviceUrl(store, apiRoutes) {
     });
 
   return function(linkName, params) {
-    const links = store.getRootState().links;
+    const links = store.getState().links;
 
     if (links === null) {
       return '';

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -106,7 +106,7 @@ function session(
    * @return {Profile} The updated profile data
    */
   function update(model) {
-    const prevSession = store.getRootState().session;
+    const prevSession = store.getState().session;
     const userChanged = model.userid !== prevSession.userid;
 
     // Update the session model used by the application
@@ -184,7 +184,7 @@ function session(
     // this service. In future, other services which access the session state
     // will do so directly from store or via selector functions
     get state() {
-      return store.getRootState().session;
+      return store.getState().session;
     },
 
     update,

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -98,7 +98,7 @@ function Streamer(
       } else if (message.type === 'session-change') {
         handleSessionChangeNotification(message);
       } else if (message.type === 'whoyouare') {
-        const userid = store.getRootState().session.userid;
+        const userid = store.getState().session.userid;
         if (message.userid !== userid) {
           console.warn(
             'WebSocket user ID "%s" does not match logged-in ID "%s"',

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -72,16 +72,16 @@ describe('groups', function() {
         getGroup: sinon.stub(),
         loadGroups: sinon.stub(),
         allGroups() {
-          return this.getRootState().groups.groups;
+          return this.getState().groups.groups;
         },
         focusedGroup() {
-          return this.getRootState().groups.focusedGroup;
+          return this.getState().groups.focusedGroup;
         },
         mainFrame() {
-          return this.getRootState().frames[0];
+          return this.getState().frames[0];
         },
         focusedGroupId() {
-          const group = this.getRootState().groups.focusedGroup;
+          const group = this.getState().groups.focusedGroup;
           return group ? group.id : null;
         },
         setDirectLinkedGroupFetchFailed: sinon.stub(),

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -53,7 +53,7 @@ describe('rootThread', function() {
           sortKeysAvailable: ['Location'],
         },
       },
-      getRootState: function() {
+      getState: function() {
         return this.state;
       },
 

--- a/src/sidebar/services/test/service-url-test.js
+++ b/src/sidebar/services/test/service-url-test.js
@@ -12,9 +12,6 @@ function fakeStore() {
     getState: function() {
       return { links: links };
     },
-    getRootState: function() {
-      return { links: links };
-    },
   };
 }
 

--- a/src/sidebar/services/test/session-test.js
+++ b/src/sidebar/services/test/session-test.js
@@ -35,7 +35,7 @@ describe('sidebar.session', function() {
       events: require('../analytics').events,
     };
     const fakeStore = {
-      getRootState: function() {
+      getState: function() {
         return { session: state };
       },
       updateSession: function(session) {

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -119,7 +119,7 @@ describe('Streamer', function() {
     fakeStore = {
       annotationExists: sinon.stub().returns(false),
       clearPendingUpdates: sinon.stub(),
-      getRootState: sinon.stub().returns({
+      getState: sinon.stub().returns({
         session: {
           userid: 'jim@hypothes.is',
         },
@@ -408,7 +408,7 @@ describe('Streamer', function() {
       },
     ].forEach(testCase => {
       it('does nothing if the userid matches the logged-in userid', () => {
-        fakeStore.getRootState.returns({
+        fakeStore.getState.returns({
           session: {
             userid: testCase.userid,
           },
@@ -435,7 +435,7 @@ describe('Streamer', function() {
       },
     ].forEach(testCase => {
       it('logs a warning if the userid does not match the logged-in userid', () => {
-        fakeStore.getRootState.returns({
+        fakeStore.getState.returns({
           session: {
             userid: testCase.userid,
           },

--- a/src/sidebar/store/modules/test/activity-test.js
+++ b/src/sidebar/store/modules/test/activity-test.js
@@ -57,7 +57,7 @@ describe('sidebar/store/modules/activity', () => {
   });
 
   it('defaults `activeAnnotationFetches` counter to zero', () => {
-    assert.equal(store.getRootState().activity.activeAnnotationFetches, 0);
+    assert.equal(store.getState().activity.activeAnnotationFetches, 0);
   });
 
   describe('annotationFetchFinished', () => {
@@ -70,7 +70,7 @@ describe('sidebar/store/modules/activity', () => {
     it('increments `activeAnnotationFetches` counter when a new annotation fetch is started', () => {
       store.annotationFetchStarted();
 
-      assert.equal(store.getRootState().activity.activeAnnotationFetches, 1);
+      assert.equal(store.getState().activity.activeAnnotationFetches, 1);
     });
   });
 
@@ -86,7 +86,7 @@ describe('sidebar/store/modules/activity', () => {
 
       store.annotationFetchFinished();
 
-      assert.equal(store.getRootState().activity.activeAnnotationFetches, 0);
+      assert.equal(store.getState().activity.activeAnnotationFetches, 0);
     });
   });
 

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -138,10 +138,7 @@ describe('sidebar/store/modules/annotations', function() {
       store.dispatch(actions.addAnnotations([ann]));
       store.dispatch(actions.hideAnnotation(ann.id));
 
-      const storeAnn = selectors.findAnnotationByID(
-        store.getRootState(),
-        ann.id
-      );
+      const storeAnn = selectors.findAnnotationByID(store.getState(), ann.id);
       assert.equal(storeAnn.hidden, true);
     });
   });
@@ -154,10 +151,7 @@ describe('sidebar/store/modules/annotations', function() {
       store.dispatch(actions.addAnnotations([ann]));
       store.dispatch(actions.unhideAnnotation(ann.id));
 
-      const storeAnn = selectors.findAnnotationByID(
-        store.getRootState(),
-        ann.id
-      );
+      const storeAnn = selectors.findAnnotationByID(store.getState(), ann.id);
       assert.equal(storeAnn.hidden, false);
     });
   });
@@ -168,7 +162,7 @@ describe('sidebar/store/modules/annotations', function() {
       const ann = fixtures.defaultAnnotation();
       store.dispatch(actions.addAnnotations([ann]));
       store.dispatch(actions.removeAnnotations([ann]));
-      assert.equal(store.getRootState().annotations.annotations.length, 0);
+      assert.equal(store.getState().annotations.annotations.length, 0);
     });
   });
 
@@ -226,10 +220,7 @@ describe('sidebar/store/modules/annotations', function() {
         store.dispatch(actions.addAnnotations([ann]));
         store.dispatch(actions.updateFlagStatus(ann.id, testCase.nowFlagged));
 
-        const storeAnn = selectors.findAnnotationByID(
-          store.getRootState(),
-          ann.id
-        );
+        const storeAnn = selectors.findAnnotationByID(store.getState(), ann.id);
         assert.equal(storeAnn.flagged, testCase.nowFlagged);
         assert.deepEqual(storeAnn.moderation, testCase.newModeration);
       });
@@ -242,7 +233,7 @@ describe('sidebar/store/modules/annotations', function() {
       const ann = fixtures.oldAnnotation();
       store.dispatch(actions.createAnnotation(ann));
       assert.equal(
-        selectors.findAnnotationByID(store.getRootState(), ann.id).id,
+        selectors.findAnnotationByID(store.getState(), ann.id).id,
         ann.id
       );
     });
@@ -251,7 +242,7 @@ describe('sidebar/store/modules/annotations', function() {
       const store = createStore();
       store.dispatch(actions.createAnnotation(fixtures.oldAnnotation()));
       assert.equal(
-        store.getRootState().selection.selectedTab,
+        store.getState().selection.selectedTab,
         uiConstants.TAB_ANNOTATIONS
       );
     });
@@ -260,7 +251,7 @@ describe('sidebar/store/modules/annotations', function() {
       const store = createStore();
       store.dispatch(actions.createAnnotation(fixtures.oldPageNote()));
       assert.equal(
-        store.getRootState().selection.selectedTab,
+        store.getState().selection.selectedTab,
         uiConstants.TAB_NOTES
       );
     });
@@ -291,7 +282,7 @@ describe('sidebar/store/modules/annotations', function() {
           tags: [],
         })
       );
-      assert.isTrue(store.getRootState().selection.expanded.annotation_id);
+      assert.isTrue(store.getState().selection.expanded.annotation_id);
     });
   });
 });

--- a/src/sidebar/store/modules/test/direct-linked-test.js
+++ b/src/sidebar/store/modules/test/direct-linked-test.js
@@ -8,7 +8,7 @@ describe('sidebar/store/modules/direct-linked', () => {
   let fakeSettings = {};
 
   const getDirectLinkedState = () => {
-    return store.getRootState().directLinked;
+    return store.getState().directLinked;
   };
 
   beforeEach(() => {

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -91,7 +91,7 @@ describe('sidebar/store/modules/groups', () => {
 
       store.focusGroup(publicGroup.id);
 
-      assert.equal(store.getRootState().groups.focusedGroupId, publicGroup.id);
+      assert.equal(store.getState().groups.focusedGroupId, publicGroup.id);
       assert.notCalled(console.error);
     });
 
@@ -100,7 +100,7 @@ describe('sidebar/store/modules/groups', () => {
 
       store.focusGroup(privateGroup.id);
 
-      assert.equal(store.getRootState().groups.focusedGroupId, publicGroup.id);
+      assert.equal(store.getState().groups.focusedGroupId, publicGroup.id);
       assert.called(console.error);
     });
   });
@@ -108,7 +108,7 @@ describe('sidebar/store/modules/groups', () => {
   describe('loadGroups', () => {
     it('updates the set of groups', () => {
       store.loadGroups([publicGroup]);
-      assert.deepEqual(store.getRootState().groups.groups, [publicGroup]);
+      assert.deepEqual(store.getState().groups.groups, [publicGroup]);
     });
 
     it('resets the focused group if not in new set of groups', () => {
@@ -116,7 +116,7 @@ describe('sidebar/store/modules/groups', () => {
       store.focusGroup(publicGroup.id);
       store.loadGroups([]);
 
-      assert.equal(store.getRootState().groups.focusedGroupId, null);
+      assert.equal(store.getState().groups.focusedGroupId, null);
     });
 
     it('leaves focused group unchanged if in new set of groups', () => {
@@ -124,7 +124,7 @@ describe('sidebar/store/modules/groups', () => {
       store.focusGroup(publicGroup.id);
       store.loadGroups([publicGroup, privateGroup]);
 
-      assert.equal(store.getRootState().groups.focusedGroupId, publicGroup.id);
+      assert.equal(store.getState().groups.focusedGroupId, publicGroup.id);
     });
   });
 
@@ -134,7 +134,7 @@ describe('sidebar/store/modules/groups', () => {
 
       store.clearGroups();
 
-      assert.equal(store.getRootState().groups.groups.length, 0);
+      assert.equal(store.getState().groups.groups.length, 0);
     });
 
     it('clears the focused group id', () => {
@@ -143,7 +143,7 @@ describe('sidebar/store/modules/groups', () => {
 
       store.clearGroups();
 
-      assert.equal(store.getRootState().groups.focusedGroupId, null);
+      assert.equal(store.getState().groups.focusedGroupId, null);
     });
   });
 

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -10,7 +10,7 @@ describe('sidebar/store/modules/selection', () => {
   let fakeSettings = [{}, {}];
 
   const getSelectionState = () => {
-    return store.getRootState().selection;
+    return store.getState().selection;
   };
 
   beforeEach(() => {

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -16,7 +16,7 @@ describe('sidebar/store/modules/session', function() {
     it('updates the session state', function() {
       const newSession = Object.assign(init(), { userid: 'john' });
       store.updateSession({ userid: 'john' });
-      assert.deepEqual(store.getRootState().session, newSession);
+      assert.deepEqual(store.getState().session, newSession);
     });
   });
 

--- a/src/sidebar/store/modules/test/viewer-test.js
+++ b/src/sidebar/store/modules/test/viewer-test.js
@@ -22,12 +22,12 @@ describe('store/modules/viewer', function() {
 
     it('sets a flag indicating that highlights are visible', function() {
       store.setShowHighlights(true);
-      assert.isTrue(store.getRootState().viewer.visibleHighlights);
+      assert.isTrue(store.getState().viewer.visibleHighlights);
     });
 
     it('sets a flag indicating that highlights are not visible', function() {
       store.setShowHighlights(false);
-      assert.isFalse(store.getRootState().viewer.visibleHighlights);
+      assert.isFalse(store.getState().viewer.visibleHighlights);
     });
   });
 });

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -43,22 +43,19 @@ describe('store', function() {
   describe('initialization', function() {
     it('does not set a selection when settings.annotations is null', function() {
       assert.isFalse(store.hasSelectedAnnotations());
-      assert.equal(
-        Object.keys(store.getRootState().selection.expanded).length,
-        0
-      );
+      assert.equal(Object.keys(store.getState().selection.expanded).length, 0);
     });
 
     it('sets the selection when settings.annotations is set', function() {
       store = storeFactory(fakeRootScope, { annotations: 'testid' });
-      assert.deepEqual(store.getRootState().selection.selectedAnnotationMap, {
+      assert.deepEqual(store.getState().selection.selectedAnnotationMap, {
         testid: true,
       });
     });
 
     it('expands the selected annotations when settings.annotations is set', function() {
       store = storeFactory(fakeRootScope, { annotations: 'testid' });
-      assert.deepEqual(store.getRootState().selection.expanded, {
+      assert.deepEqual(store.getState().selection.expanded, {
         testid: true,
       });
     });
@@ -69,41 +66,41 @@ describe('store', function() {
     // CLEAR_SELECTION action in multiple store modules.
     it('sets `selectedAnnotationMap` to null', () => {
       store.clearSelection();
-      assert.isNull(store.getRootState().selection.selectedAnnotationMap);
+      assert.isNull(store.getState().selection.selectedAnnotationMap);
     });
 
     it('sets `filterQuery` to null', () => {
       store.clearSelection();
-      assert.isNull(store.getRootState().selection.filterQuery);
+      assert.isNull(store.getState().selection.filterQuery);
     });
 
     it('sets `directLinkedGroupFetchFailed` to false', () => {
       store.clearSelection();
       assert.isFalse(
-        store.getRootState().directLinked.directLinkedGroupFetchFailed
+        store.getState().directLinked.directLinkedGroupFetchFailed
       );
     });
 
     it('sets `directLinkedAnnotationId` to null', () => {
       store.clearSelection();
-      assert.isNull(store.getRootState().directLinked.directLinkedAnnotationId);
+      assert.isNull(store.getState().directLinked.directLinkedAnnotationId);
     });
 
     it('sets `directLinkedGroupId` to null', () => {
       store.clearSelection();
-      assert.isNull(store.getRootState().directLinked.directLinkedGroupId);
+      assert.isNull(store.getState().directLinked.directLinkedGroupId);
     });
 
     it('sets `sortKey` to default annotation sort key if set to Orphans', () => {
       store.selectTab(uiConstants.TAB_ORPHANS);
       store.clearSelection();
-      assert.equal(store.getRootState().selection.sortKey, 'Location');
+      assert.equal(store.getState().selection.sortKey, 'Location');
     });
 
     it('sets `sortKeysAvailable` to available annotation sort keys if set to Orphans', () => {
       store.selectTab(uiConstants.TAB_ORPHANS);
       store.clearSelection();
-      assert.deepEqual(store.getRootState().selection.sortKeysAvailable, [
+      assert.deepEqual(store.getState().selection.sortKeysAvailable, [
         'Newest',
         'Oldest',
         'Location',
@@ -114,7 +111,7 @@ describe('store', function() {
       store.selectTab(uiConstants.TAB_ORPHANS);
       store.clearSelection();
       assert.equal(
-        store.getRootState().selection.selectedTab,
+        store.getState().selection.selectedTab,
         uiConstants.TAB_ANNOTATIONS
       );
     });
@@ -123,7 +120,7 @@ describe('store', function() {
       store.selectTab(uiConstants.TAB_NOTES);
       store.clearSelection();
       assert.equal(
-        store.getRootState().selection.selectedTab,
+        store.getState().selection.selectedTab,
         uiConstants.TAB_NOTES
       );
     });
@@ -144,7 +141,7 @@ describe('store', function() {
     it('adds annotations not in the store', function() {
       const annot = defaultAnnotation();
       store.addAnnotations([annot]);
-      assert.match(store.getRootState().annotations.annotations, [
+      assert.match(store.getState().annotations.annotations, [
         sinon.match(annot),
       ]);
     });
@@ -155,7 +152,7 @@ describe('store', function() {
       const page = oldPageNote();
       store.addAnnotations([page]);
       assert.equal(
-        store.getRootState().selection.selectedTab,
+        store.getState().selection.selectedTab,
         uiConstants.TAB_ANNOTATIONS
       );
     });
@@ -164,7 +161,7 @@ describe('store', function() {
       const page = oldPageNote();
       store.addAnnotations([page]);
       assert.equal(
-        store.getRootState().selection.selectedTab,
+        store.getState().selection.selectedTab,
         uiConstants.TAB_NOTES
       );
     });
@@ -174,7 +171,7 @@ describe('store', function() {
       const annot = defaultAnnotation();
       store.addAnnotations([annot, page]);
       assert.equal(
-        store.getRootState().selection.selectedTab,
+        store.getState().selection.selectedTab,
         uiConstants.TAB_ANNOTATIONS
       );
     });
@@ -185,11 +182,9 @@ describe('store', function() {
 
       store.addAnnotations([annotA, annotB]);
 
-      const tags = store
-        .getRootState()
-        .annotations.annotations.map(function(a) {
-          return a.$tag;
-        });
+      const tags = store.getState().annotations.annotations.map(function(a) {
+        return a.$tag;
+      });
 
       assert.deepEqual(tags, ['t1', 't2']);
     });
@@ -200,7 +195,7 @@ describe('store', function() {
       const update = Object.assign({}, defaultAnnotation(), { text: 'update' });
       store.addAnnotations([update]);
 
-      const updatedAnnot = store.getRootState().annotations.annotations[0];
+      const updatedAnnot = store.getState().annotations.annotations[0];
       assert.equal(updatedAnnot.text, 'update');
     });
 
@@ -212,7 +207,7 @@ describe('store', function() {
       const saved = Object.assign({}, annot, { id: 'server-id' });
       store.addAnnotations([saved]);
 
-      const annots = store.getRootState().annotations.annotations;
+      const annots = store.getState().annotations.annotations;
       assert.equal(annots.length, 1);
       assert.equal(annots[0].id, 'server-id');
     });
@@ -225,7 +220,7 @@ describe('store', function() {
       const nowStr = now.toISOString();
 
       store.addAnnotations([newAnnotation()], now);
-      const annot = store.getRootState().annotations.annotations[0];
+      const annot = store.getState().annotations.annotations[0];
 
       assert.equal(annot.created, nowStr);
       assert.equal(annot.updated, nowStr);
@@ -238,7 +233,7 @@ describe('store', function() {
       annot.updated = '2000-01-01T04:05:06Z';
 
       store.addAnnotations([annot], now);
-      const result = store.getRootState().annotations.annotations[0];
+      const result = store.getState().annotations.annotations[0];
 
       assert.equal(result.created, annot.created);
       assert.equal(result.updated, annot.updated);
@@ -252,7 +247,7 @@ describe('store', function() {
       const update = Object.assign({}, defaultAnnotation(), { text: 'update' });
       store.addAnnotations([update]);
 
-      const updatedAnnot = store.getRootState().annotations.annotations[0];
+      const updatedAnnot = store.getState().annotations.annotations[0];
       assert.isFalse(updatedAnnot.$orphan);
     });
 
@@ -262,9 +257,7 @@ describe('store', function() {
 
       clock.tick(ANCHOR_TIME_LIMIT);
 
-      assert.isTrue(
-        store.getRootState().annotations.annotations[0].$anchorTimeout
-      );
+      assert.isTrue(store.getState().annotations.annotations[0].$anchorTimeout);
     });
 
     it('does not set the timeout flag on annotations that do anchor within a time limit', function() {
@@ -275,7 +268,7 @@ describe('store', function() {
       clock.tick(ANCHOR_TIME_LIMIT);
 
       assert.isFalse(
-        store.getRootState().annotations.annotations[0].$anchorTimeout
+        store.getState().annotations.annotations[0].$anchorTimeout
       );
     });
 
@@ -292,9 +285,7 @@ describe('store', function() {
 
     it('does not expect annotations to anchor on the stream', function() {
       const isOrphan = function() {
-        return !!metadata.isOrphan(
-          store.getRootState().annotations.annotations[0]
-        );
+        return !!metadata.isOrphan(store.getState().annotations.annotations[0]);
       };
 
       const annot = defaultAnnotation();
@@ -308,14 +299,14 @@ describe('store', function() {
 
     it('initializes the $orphan field for new annotations', function() {
       store.addAnnotations([newAnnotation()]);
-      assert.isFalse(store.getRootState().annotations.annotations[0].$orphan);
+      assert.isFalse(store.getState().annotations.annotations[0].$orphan);
     });
 
     it('adds multiple new annotations', function() {
       store.addAnnotations([fixtures.newPair[0]]);
       store.addAnnotations([fixtures.newPair[1]]);
 
-      assert.equal(store.getRootState().annotations.annotations.length, 2);
+      assert.equal(store.getState().annotations.annotations.length, 2);
     });
   });
 
@@ -324,14 +315,14 @@ describe('store', function() {
       const annot = defaultAnnotation();
       store.addAnnotations([annot]);
       store.removeAnnotations([annot]);
-      assert.deepEqual(store.getRootState().annotations.annotations, []);
+      assert.deepEqual(store.getState().annotations.annotations, []);
     });
 
     it('matches annotations to remove by ID', function() {
       store.addAnnotations(fixtures.pair);
       store.removeAnnotations([{ id: fixtures.pair[0].id }]);
 
-      const ids = store.getRootState().annotations.annotations.map(function(a) {
+      const ids = store.getState().annotations.annotations.map(function(a) {
         return a.id;
       });
       assert.deepEqual(ids, [fixtures.pair[1].id]);
@@ -341,11 +332,9 @@ describe('store', function() {
       store.addAnnotations(fixtures.pair);
       store.removeAnnotations([{ $tag: fixtures.pair[0].$tag }]);
 
-      const tags = store
-        .getRootState()
-        .annotations.annotations.map(function(a) {
-          return a.$tag;
-        });
+      const tags = store.getState().annotations.annotations.map(function(a) {
+        return a.$tag;
+      });
       assert.deepEqual(tags, [fixtures.pair[1].$tag]);
     });
 
@@ -355,7 +344,7 @@ describe('store', function() {
       store.selectTab(uiConstants.TAB_ORPHANS);
       store.removeAnnotations([orphan]);
       assert.equal(
-        store.getRootState().selection.selectedTab,
+        store.getState().selection.selectedTab,
         uiConstants.TAB_ANNOTATIONS
       );
     });
@@ -366,7 +355,7 @@ describe('store', function() {
       const annot = defaultAnnotation();
       store.addAnnotations([annot]);
       store.clearAnnotations();
-      assert.deepEqual(store.getRootState().annotations.annotations, []);
+      assert.deepEqual(store.getState().annotations.annotations, []);
     });
   });
 
@@ -375,10 +364,7 @@ describe('store', function() {
       'sets the visibleHighlights state flag to #state',
       function(testCase) {
         store.setShowHighlights(testCase.state);
-        assert.equal(
-          store.getRootState().viewer.visibleHighlights,
-          testCase.state
-        );
+        assert.equal(store.getState().viewer.visibleHighlights, testCase.state);
       },
       [{ state: true }, { state: false }]
     );
@@ -389,10 +375,7 @@ describe('store', function() {
       const annot = defaultAnnotation();
       store.addAnnotations([annot]);
       store.updateAnchorStatus({ [tagForID(annot.id)]: 'orphan' });
-      assert.equal(
-        store.getRootState().annotations.annotations[0].$orphan,
-        true
-      );
+      assert.equal(store.getState().annotations.annotations[0].$orphan, true);
     });
   });
 });

--- a/src/sidebar/store/test/util-test.js
+++ b/src/sidebar/store/test/util-test.js
@@ -23,11 +23,9 @@ const fixtures = {
       },
     },
     namespace2: {
-      useLocalState: true,
       selectors: {
         countAnnotations2: function(state) {
-          // useLocalState does not need namespaced path.
-          return state.annotations.length;
+          return state.namespace2.annotations.length;
         },
       },
     },
@@ -107,29 +105,6 @@ describe('reducer utils', function() {
       });
     });
 
-    it('applies update functions from each input object', () => {
-      const firstCounterActions = {
-        INCREMENT_COUNTER(state) {
-          return { firstCounter: state.firstCounter + 1 };
-        },
-      };
-      const secondCounterActions = {
-        INCREMENT_COUNTER(state) {
-          return { secondCounter: state.secondCounter + 1 };
-        },
-      };
-      const reducer = util.createReducer(
-        firstCounterActions,
-        secondCounterActions
-      );
-
-      const state = { firstCounter: 5, secondCounter: 10 };
-      const action = { type: 'INCREMENT_COUNTER' };
-      const newState = reducer(state, action);
-
-      assert.deepEqual(newState, { firstCounter: 6, secondCounter: 11 });
-    });
-
     it('supports reducer functions that return an array', function() {
       const action = {
         type: 'FIRST_ITEM',
@@ -154,13 +129,11 @@ describe('reducer utils', function() {
           annotations: [{ id: 1 }],
         },
         namespace2: {
-          annotations: [{ id: 1 }],
+          annotations: [{ id: 2 }],
         },
       });
       const bound = util.bindSelectors(fixtures.selectors, getState);
-      // Test non-namespaced selector (useLocalState=true)
       assert.equal(bound.countAnnotations1(), 1);
-      // Test the namespaced selector
       assert.equal(bound.countAnnotations2(), 1);
     });
   });

--- a/src/sidebar/store/util.js
+++ b/src/sidebar/store/util.js
@@ -14,34 +14,24 @@ function actionTypes(updateFns) {
  * Given objects which map action names to update functions, this returns a
  * reducer function that can be passed to the redux `createStore` function.
  *
- * @param {Object[]} actionToUpdateFn - Objects mapping action names to update
+ * @param {Object} actionToUpdateFn - Object mapping action names to update
  *                                      functions.
  */
-function createReducer(...actionToUpdateFn) {
-  // Combine the (action name => update function) maps together into a single
-  // (action name => update functions) map.
-  //
-  // After namespace migration, remove the requirement for actionToUpdateFns
-  // to use arrays. Why? createReducer will be called once for each module rather
-  // than once for all modules.
-  const actionToUpdateFns = {};
-  actionToUpdateFn.forEach(map => {
-    Object.keys(map).forEach(k => {
-      actionToUpdateFns[k] = (actionToUpdateFns[k] || []).concat(map[k]);
-    });
-  });
-
+function createReducer(actionToUpdateFn) {
   return (state = {}, action) => {
-    const fns = actionToUpdateFns[action.type];
-    if (!fns) {
+    const fn = actionToUpdateFn[action.type];
+    if (!fn) {
       return state;
     }
     // Some modules return an array rather than an object. They need to be
     // handled differently so we don't cast them to an object.
     if (Array.isArray(state)) {
-      return [...fns[0](state, action)];
+      return [...fn(state, action)];
     }
-    return Object.assign({}, state, ...fns.map(f => f(state, action)));
+    return {
+      ...state,
+      ...fn(state, action),
+    };
   };
 }
 
@@ -49,24 +39,16 @@ function createReducer(...actionToUpdateFn) {
  * Takes a mapping of namespaced modules and the store's `getState()` function
  * and returns an aggregated flat object with all the selectors at the root
  * level. The keys to this object are functions that call the original
- * selectors with the `state` argument set to the current value of `getState()`
- * for namespaced modules or `getState().base` for non-namespaced modules.
+ * selectors with the `state` argument set to the current value of `getState()`.
  */
 function bindSelectors(namespaces, getState) {
   const totalSelectors = {};
   Object.keys(namespaces).forEach(namespace => {
     const selectors = namespaces[namespace].selectors;
-    const useLocalState = namespaces[namespace].useLocalState;
     Object.keys(selectors).forEach(selector => {
       totalSelectors[selector] = function() {
         const args = [].slice.apply(arguments);
-        if (useLocalState) {
-          // Temporary scaffold until all selectors use namespaces.
-          args.unshift(getState()[namespace]);
-        } else {
-          // Namespace modules get root scope
-          args.unshift(getState());
-        }
+        args.unshift(getState());
         return selectors[selector].apply(null, args);
       };
     });

--- a/src/sidebar/test/fake-redux-store.js
+++ b/src/sidebar/test/fake-redux-store.js
@@ -24,10 +24,6 @@ function fakeStore(initialState, methods) {
 
   const store = redux.createStore(update, initialState);
 
-  store.getRootState = () => {
-    return store.getState();
-  };
-
   store.setState = function(state) {
     store.dispatch({ type: 'SET_STATE', state: state });
   };

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -71,20 +71,20 @@ describe('annotation threading', function() {
 
   it('should display newly loaded annotations', function() {
     store.addAnnotations(fixtures.annotations);
-    assert.equal(rootThread.thread(store.getRootState()).children.length, 2);
+    assert.equal(rootThread.thread(store.getState()).children.length, 2);
   });
 
   it('should not display unloaded annotations', function() {
     store.addAnnotations(fixtures.annotations);
     store.removeAnnotations(fixtures.annotations);
-    assert.equal(rootThread.thread(store.getRootState()).children.length, 0);
+    assert.equal(rootThread.thread(store.getState()).children.length, 0);
   });
 
   it('should filter annotations when a search is set', function() {
     store.addAnnotations(fixtures.annotations);
     store.setFilterQuery('second');
-    assert.equal(rootThread.thread(store.getRootState()).children.length, 1);
-    assert.equal(rootThread.thread(store.getRootState()).children[0].id, '2');
+    assert.equal(rootThread.thread(store.getState()).children.length, 1);
+    assert.equal(rootThread.thread(store.getState()).children[0].id, '2');
   });
 
   unroll(
@@ -93,7 +93,7 @@ describe('annotation threading', function() {
       store.addAnnotations(fixtures.annotations);
       store.setSortKey(testCase.sortKey);
       const actualOrder = rootThread
-        .thread(store.getRootState())
+        .thread(store.getState())
         .children.map(function(thread) {
           return thread.annotation.id;
         });

--- a/src/sidebar/util/test/state-util-test.js
+++ b/src/sidebar/util/test/state-util-test.js
@@ -7,7 +7,9 @@ describe('state-util', function() {
   let store;
 
   beforeEach(function() {
-    store = fakeStore({ val: 0 });
+    store = fakeStore({
+      fake: { val: 0 },
+    });
   });
 
   describe('awaitStateChange()', function() {
@@ -20,9 +22,7 @@ describe('state-util', function() {
 
     it('should return promise that resolves to a non-null value', function() {
       const expected = 5;
-
       store.setState({ val: 5 });
-
       return stateUtil
         .awaitStateChange(store, getValWhenGreaterThanTwo)
         .then(function(actual) {


### PR DESCRIPTION
* Branched from `namespace-annotations-module`

- By in large, this is mostly a search and replace with `getRootState` ->  `getState`

- This also removes the logic for lumping the non-namespaced modules into "base" and now any module not having a namespace shows a console warning and it won't be added to the store.

- I also refactored `createReducer` because its no longer ever the case it will need an array of reducers since each duplicate reducer ID is fully namespaced. In other words we call `createReducer` multiple times now rather than taking an array.

- I remove some test logic that dealt with an array parm for createReducer 

- Added a test to specifically test multiple reducers across 2 different modules triggered by a single action.

