### PR TITLE
Improve `aria-label` on annotation tags

### DIFF
--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -58,7 +58,7 @@
        ng-if="(vm.canCollapseBody || vm.state().tags.length) && !vm.editing()">
     <ul class="tag-list" aria-label="Annotation tags">
       <li class="tag-item" ng-repeat="tag in vm.state().tags">
-        <a ng-href="{{vm.tagSearchURL(tag)}}" target="_blank">{{tag}}</a>
+        <a ng-href="{{vm.tagSearchURL(tag)}}" aria-label="Tag: {{tag}}" target="_blank">{{tag}}</a>
       </li>
     </ul>
     <div class="u-stretch"></div>

--- a/src/styles/mixins/forms.scss
+++ b/src/styles/mixins/forms.scss
@@ -102,13 +102,3 @@
     background-color: $color-mine-shaft;
   }
 }
-
-// Tint and shade functions from
-// https://css-tricks.com/snippets/sass/tint-shade-functions
-@function tint($color, $percent) {
-  @return mix(white, $color, $percent);
-}
-
-@function shade($color, $percent) {
-  @return mix(black, $color, $percent);
-}

--- a/src/styles/sidebar/components/tags-input.scss
+++ b/src/styles/sidebar/components/tags-input.scss
@@ -10,8 +10,9 @@ tags-input {
   }
 
   .tags {
+    display: flex;
+    flex-wrap: wrap;
     @include form-input;
-    @include pie-clearfix;
 
     &.focused {
       @include form-input-focus;
@@ -19,7 +20,6 @@ tags-input {
 
     // Input
     .input {
-      float: left;
       padding: 0.1333em 0;
       outline: none;
       border: none !important;
@@ -35,18 +35,19 @@ tags-input {
 
   .tag-list {
     margin-top: -0.33em; // Absorb the first row of margin-top on the tags.
-    float: left;
+    display: flex;
+    flex-wrap: wrap;
   }
 
   .tag-item {
-    float: left;
     position: relative;
     padding: 0.0769em 1.307em 0.0769em 0.538em;
     margin-top: 0.384em;
     margin-right: 0.384em;
     font-size: 0.866em;
-    color: $button-text-color;
-    border: 1px solid $gray-lighter;
+    color: $grey-6;
+    border: 1px solid $grey-4;
+    background-color: $grey-3;
     border-radius: 2px;
 
     &.selected {
@@ -73,11 +74,12 @@ tags-input {
 }
 
 .tags-read-only {
-  font-size: 0.8461em;
+  font-size: $normal-font-size;
   margin: 0.4545em 0;
 
   .tag-list {
-    @include pie-clearfix;
+    display: flex;
+    flex-wrap: wrap;
     // Margin between bottom of ascent of annotation body and
     // top of tags list should be ~15px
     margin-top: -$layout-h-margin + 10px;
@@ -86,16 +88,15 @@ tags-input {
     margin-bottom: $layout-h-margin - 10px;
 
     .tag-item {
-      float: left;
-      margin-right: 0.4545em;
+      margin: 0 0.4545em 0.4545em 0;
 
       a {
         text-decoration: none;
-        border: 1px solid $gray-lighter;
+        border: 1px solid $grey-3;
         border-radius: 2px;
         padding: 0 0.4545em 0.1818em;
-        color: $gray-light;
-        background: $gray-lightest;
+        color: $grey-6;
+        background: $grey-2;
 
         &:hover,
         &:focus {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -46,6 +46,16 @@ $grey-7: #202020;
 $brand: #bd1c2b;
 $highlight: #58cef4;
 
+// Tint and shade functions from
+// https://css-tricks.com/snippets/sass/tint-shade-functions
+@function tint($color, $percent) {
+  @return mix(white, $color, $percent);
+}
+
+@function shade($color, $percent) {
+  @return mix(black, $color, $percent);
+}
+
 @function color-weight($c, $n: 500) {
   @if $n == 50 {
     @return tint($c, 85%);


### PR DESCRIPTION
**Bug fix**
I also discovered a bug where `shade()` was not correctly being called so the hover effect in 3 places in the css was not working. I fixed that, so that happened to make tags have a hover effect (text turns red)  which they never did before, so if this is not what we want, I can remove it :)

**Why was this broken?**
Turns out that `$link-color-hover` in `variables.sass` called a function called `color-weight` which in turn called `shade()`, but `shade()` was not defined but somehow silently or perhaps magically failed? The simple fix is to move `shade` and `tint` to `variables.sass`

**tags accessibility**
Furthermore, I added the `roll` attributes to the tags' list parent and list elements. This allows the screen reader to read from the `aria-label` rather than just the text itself. I tested this with ChromeVox and it seems to read better.

**css clean up**
I also removed all the `float` css from the tag sass file and went with flexbox. It's a lot more clean.

**Accessibility while editing tags**
I didn't add the accessibility attributes when editing tags because they are limited due to the ng directive. Upon exploring this a bit more, it appeared to required some complex changes to the tags directive by making use of custom templates we pass to the tag directive. I think the effort should be spent on rebuilding the tag component in preact or using an off the shelf one. I'm in favor of building our own.

**Font-size** 
I asked some questions about this in slack, but I'm a bit perplexed by the extremely high precision after the decimal place with the ems. Our app is not even responsive in the first place -- and perhaps it should but I'm curious why the 4 digit level of precision here. 

**Affordance of tags** 
I decide after some tinkers with UX that the best solution was to slightly bump up the size of the tags. After all, doing some sort of zoom or font size scale of hover is going to look weird and also has no precedent in our UI. I also think that the standard way browsers now scale is the perfect solution:

```
Mac: CMD + 
Win: CTR + 

```

Works perfect and our users should know this. Having said that, a small bump form 0.8461em to 0.94em feels reasonable to me given the size of everything else.  I also adjusted the contrast of the tags so they render darker and are easier to see. 

fixes https://github.com/hypothesis/product-backlog/issues/1057

![Screen Shot 2019-09-19 at 10 45 05 PM](https://user-images.githubusercontent.com/3939074/65302180-2c054700-db2f-11e9-88a5-d62a6a938d96.png)
