### PR TITLE
Show full test output in CI

### DIFF
--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -10,9 +10,13 @@ const envify = require('loose-envify/custom');
 let chromeFlags = [];
 process.env.CHROME_BIN = require('puppeteer').executablePath();
 
+// `true` if this build is running in a continuous integration environment.
+let isCIBuild = false;
+
 // On Travis and in Docker, the tests run as root, so the sandbox must be
 // disabled.
 if (process.env.TRAVIS || process.env.RUNNING_IN_DOCKER) {
+  isCIBuild = true;
   chromeFlags.push('--no-sandbox');
 }
 
@@ -117,8 +121,14 @@ module.exports = function(config) {
       // Display a helpful diff when comparing complex objects
       // See https://www.npmjs.com/package/karma-mocha-reporter#showdiff
       showDiff: true,
-      // Only show the total test counts and details for failed tests
-      output: 'minimal',
+
+      // Output only summary and errors in development to make output easier
+      // to parse.
+      //
+      // In CI enable full output to help track down an issue where CI builds
+      // have been failing frequently on Jenkins with "Disconnected, because
+      // no message in XXX ms" errors.
+      output: isCIBuild ? 'full' : 'minimal',
     },
 
     coverageIstanbulReporter: {


### PR DESCRIPTION
This may help to track down some frequent build failures seen on Jenkins
where Karma disconnects from the browser after 20 seconds by showing us
which tests, if any, have just run when the disconnect happens.

See eg. https://jenkins.hypothes.is/job/client/job/dependabot%252Fnpm_and_yarn%252Fpuppeteer-1.20.0/2/console