### PR TITLE
Enable verbose Karma logging to help debug Jenkins CI build failures

### DIFF
--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -151,7 +151,11 @@ module.exports = function(config) {
 
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_INFO,
+
+    // `DEBUG` logging is enabled for CI builds to help track down an issue
+    // on Jenkins where Karma disconnects from Chrome on test startup with
+    // a "No activity in XXX ms" error.
+    logLevel: isCIBuild ? config.LOG_DEBUG : config.LOG_INFO,
 
     browserConsoleLogOptions: {
       level: 'log',


### PR DESCRIPTION
Jenkins builds have been intermittently failing recently (eg. [1]) with an issue
where Chrome fails to connect to Karma after startup. The issue has
proven difficult to reproduce. Add additional logging to provide more
information.

[1] https://jenkins.hypothes.is/job/client/job/dependabot%252Fnpm_and_yarn%252Fwebsocket-1.0.30/1/console