### PR TITLE
Enable Chrome debug logging

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -427,14 +427,6 @@ function runKarma(baseConfig, opts, done) {
     },
   };
 
-  // Work around a bug in Karma 1.10 which causes console log messages not to
-  // be displayed when using a non-default reporter.
-  // See https://github.com/karma-runner/karma/pull/2220
-  const BaseReporter = require('karma/lib/reporters/base');
-  BaseReporter.decoratorFactory.$inject = BaseReporter.decoratorFactory.$inject.map(
-    dep => dep.replace('browserLogOptions', 'browserConsoleLogOptions')
-  );
-
   const karma = require('karma');
   new karma.Server(
     Object.assign(

--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -18,6 +18,16 @@ let isCIBuild = false;
 if (process.env.TRAVIS || process.env.RUNNING_IN_DOCKER) {
   isCIBuild = true;
   chromeFlags.push('--no-sandbox');
+
+  // Enable debug logging from Chrome to help track down a cause of frequent
+  // build failures in Jenkins. The log files are written to `chrome_debug.log`
+  // in the workspace for the current build.
+  chromeFlags.push('--enable-logging');
+  chromeFlags.push('--v=1');
+  process.env.CHROME_LOG_FILE = path.resolve(
+    __dirname + '/../',
+    'chrome_debug.log'
+  );
 }
 
 if (process.env.RUNNING_IN_DOCKER) {


### PR DESCRIPTION
This PR [enables logging](https://www.chromium.org/for-testers/enable-logging) for Chrome in Jenkins so that it writes logs to `chrome_debug.log` in the workspace directory.

After a build completes, the files in the workspace can be browsed via the "Workspaces" link on the left hand side in Jenkins. For example https://jenkins.hypothes.is/job/client/job/chrome-debug-logging/2/ws/.

This should help us in tracking down a cause of frequent test execution failures in Jenkins where Chrome disconnects during the configuration process before it starts running any tests.