### PR TITLE
Add ES2015 polyfills required by new Sentry SDK

### DIFF
--- a/src/shared/polyfills/es2015.js
+++ b/src/shared/polyfills/es2015.js
@@ -3,6 +3,7 @@
 // ES2015
 require('core-js/es6/promise');
 require('core-js/es6/map');
+require('core-js/es6/number');
 require('core-js/es6/set');
 require('core-js/es6/symbol');
 require('core-js/fn/array/fill');
@@ -10,5 +11,6 @@ require('core-js/fn/array/find');
 require('core-js/fn/array/find-index');
 require('core-js/fn/array/from');
 require('core-js/fn/object/assign');
+require('core-js/fn/string/includes');
 require('core-js/fn/string/ends-with');
 require('core-js/fn/string/starts-with');


### PR DESCRIPTION
Add missing polyfills required by new Sentry SDK under IE 11 as per the
"Support for <= IE 11" section at
https://docs.sentry.io/platforms/javascript/#browser-table. In
particular the `String.prototype.includes` polyfill was missing and
causing the application to fail to load fully. `Number.isNaN` was also missing.

I haven't gotten exactly to the bottom of where in the Sentry SDK this missing polyfill caused a failure, but since it resolves the issue and is clearly specified as a requirement in the SDK docs, I don't think that's essential.

Fixes #1391