### PR TITLE
Set SIDEBAR_APP_URL to a sensible default value in dev

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -148,7 +148,10 @@ stage('Publish') {
                 sh "sleep 2" // Give GitHub a moment to realize the tag exists.
 
                 // Bump the package version and create the GitHub release.
-                sh "yarn version --no-git-tag-version --new-version ${newPkgVersion}"
+                sh """
+                export SIDEBAR_APP_URL=https://hypothes.is/app.html
+                yarn version --no-git-tag-version --new-version ${newPkgVersion}
+                """
                 sh "scripts/create-github-release.js"
 
                 // Publish the updated package to the npm registry.

--- a/docs/developers/developing.rst
+++ b/docs/developers/developing.rst
@@ -83,27 +83,12 @@ run:
 
 .. code-block:: sh
 
-   export SIDEBAR_APP_URL=http://localhost:5000/app.html
    make dev
 
-Next, you'll need to create an OAuth client which enables the Hypothesis client
-to request an access token from the service in order to make API calls.
-
-1. Go to http://localhost:5000/admin/oauthclients (you'll need to be logged
-   in to h as an admin user)
-2. Select "Register a new OAuth client"
-3. Choose a name (eg. "Client") and set the redirect URL to
-   http://localhost:5000/app.html. Leave the other settings at their default values.
-4. After creating the client, make a note of the randomly generated client ID.
-
-**In the `hypothesis/h` repository**, set the :envvar:`CLIENT_URL` and
-:envvar:`CLIENT_OAUTH_ID` env vars to tell h where to load the client from and
-what OAuth client to use, before running ``make dev``:
+**In the `hypothesis/h` repository** run:
 
 .. code-block:: sh
 
-   export CLIENT_OAUTH_ID={ OAuth client ID from step above }
-   export CLIENT_URL=http://localhost:3001/hypothesis
    make dev
 
 Once the client and h are running, you can test it out by visiting:

--- a/docs/developers/developing.rst
+++ b/docs/developers/developing.rst
@@ -75,17 +75,15 @@ This takes longer to setup than :ref:`running-from-browser-ext`.
 You should follow these steps if you want to make changes to h as well as to
 the client.
 
-First follow the
-`instructions for setting up a development install of h <http://h.readthedocs.io/en/latest/developing/>`_.
-Once you have a development install of h set up, you can
-configure it to use a local build of the client. **In the client repository**,
-run:
+First follow the `instructions for setting up a development install of h
+<http://h.readthedocs.io/en/latest/developing/>`_. Then run both h and the
+client at the same time in different shells. **In the client repository**, run:
 
 .. code-block:: sh
 
    make dev
 
-**In the `hypothesis/h` repository** run:
+Then in a different shell, **in the h repository**, run:
 
 .. code-block:: sh
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -324,7 +324,7 @@ function generateBootScript(manifest) {
 
   const defaultSidebarAppUrl = process.env.SIDEBAR_APP_URL
     ? `${process.env.SIDEBAR_APP_URL}`
-    : 'https://hypothes.is/app.html';
+    : 'http://localhost:5000/app.html';
 
   let defaultAssetRoot;
 


### PR DESCRIPTION
Set SIDEBAR_APP_URL to work with your local dev instance of h by default
in dev.

This is in line with the rest of our apps (h, lms, bouncer, via): when
run in dev they default to working with the dev instances of the others
app, not the production ones.

The idea is that, when setting up all the apps in a dev env, you just
have to install each app and run `make dev` and it will work correctly
with the other dev apps. Some apps also require a `make devdata` command
if they need sensitive DB contents and/or envvars.

Don't require developers to have to set lots and lots of envvars in each
individual project.

I also deleted some docs that instructed people to create authclients,
and set envvars, that are already automated in h.