### PR TITLE
Fix sidebar app URL in production

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,8 +157,13 @@ stage('Publish') {
                 // Publish the updated package to the npm registry.
                 // Use `npm` rather than `yarn` for publishing.
                 // See https://github.com/yarnpkg/yarn/pull/3391.
+                //
+                // `npm publish` currently re-builds the client, so `SIDEBAR_APP_URL` must be set.
                 sh "echo '//registry.npmjs.org/:_authToken=${env.NPM_TOKEN}' >> \$HOME/.npmrc"
-                sh "npm publish --tag ${npmTag}"
+                sh """
+                export SIDEBAR_APP_URL=https://hypothes.is/app.html
+                npm publish --tag ${npmTag}
+                """
                 sh "scripts/wait-for-npm-release.sh ${npmTag}"
 
                 // Deploy the client to cdn.hypothes.is, where the embedded


### PR DESCRIPTION
The `npm publish` step currently rebuilds the client. Since the `SIDEBAR_APP_URL`
env var was not set in the shell used to do this, the default value of
http://localhost:5000/app.html got used instead of
https://hypothes.is/app.html.