### PR TITLE
Don't built the client a second time when running "npm publish"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,13 +157,8 @@ stage('Publish') {
                 // Publish the updated package to the npm registry.
                 // Use `npm` rather than `yarn` for publishing.
                 // See https://github.com/yarnpkg/yarn/pull/3391.
-                //
-                // `npm publish` currently re-builds the client, so `SIDEBAR_APP_URL` must be set.
                 sh "echo '//registry.npmjs.org/:_authToken=${env.NPM_TOKEN}' >> \$HOME/.npmrc"
-                sh """
-                export SIDEBAR_APP_URL=https://hypothes.is/app.html
-                npm publish --tag ${npmTag}
-                """
+                sh "npm publish --tag ${npmTag}"
                 sh "scripts/wait-for-npm-release.sh ${npmTag}"
 
                 // Deploy the client to cdn.hypothes.is, where the embedded

--- a/package.json
+++ b/package.json
@@ -155,7 +155,6 @@
     "format": "prettier --list-different --write '**/*.{js,scss}'",
     "test": "gulp test",
     "report-coverage": "codecov -f coverage/coverage-final.json",
-    "version": "make clean build/manifest.json",
-    "prepublishOnly": "make clean build/manifest.json"
+    "version": "make clean build/manifest.json"
   }
 }


### PR DESCRIPTION
Fix an issue with the CI build where both the `yarn version` and
`npm publish` commands would both build the client's assets.

Since the output of the build process can be affected by environment
variables, this could lead to unexpected results if env vars were set
when running `yarn version` but not when running `npm publish`.

Now only the `yarn version` step will actually build the client.

This resolves some confusion which caused a broken production build, initially worked around in https://github.com/hypothesis/client/pull/1398. See [this Slack thread](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1570450857002300).