### PR TITLE
Enable Chrome tracing during startup

### DIFF
--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -28,6 +28,16 @@ if (process.env.TRAVIS || process.env.RUNNING_IN_DOCKER) {
     __dirname + '/../',
     'chrome_debug.log'
   );
+
+  // Enable even more debug logging from Chrome to help track down build
+  // failures in Jenkins. This generates a large (~40MB+) JSON file detailing
+  // events that happen during browser startup.
+  //
+  // See https://www.chromium.org/developers/how-tos/trace-event-profiling-tool/recording-tracing-runs#TOC-Capturing-chrome-desktop-startup
+  const traceFile = path.resolve(__dirname + '/../', 'chrome_trace.json');
+  chromeFlags.push('--trace-startup');
+  chromeFlags.push('--trace-startup-duration=7');
+  chromeFlags.push(`--trace-startup-file=${traceFile}`);
 }
 
 if (process.env.RUNNING_IN_DOCKER) {


### PR DESCRIPTION
Jenkins CI builds are failing frequently but not always. It seems to be especially prone to happening during the weekly batch of dependency updates from Dependabot.

From Karma's debug logging and Chrome's verbose logging I can see that the test files are _fetched_ from Karma's web server by the iframe which runs the tests, but it seems as though the scripts are not parsed or not executed.

This PR turns on Chrome tracing during startup, which captures extremely detailed logs about network activity, script execution etc. for 7 seconds after startup. The logs are written to `chrome_trace.json` in the build's workspace directory. See https://www.chromium.org/developers/how-tos/trace-event-profiling-tool/recording-tracing-runs#TOC-Capturing-chrome-desktop-startup for more details.

The trace file is large (~30MB) so we'll need to turn this off once the issue is resolved.