### PR TITLE
Share Annotations Panel 2 of 4: Add base `SidebarPanel` component and store module

### DIFF
--- a/src/sidebar/components/sidebar-panel.js
+++ b/src/sidebar/components/sidebar-panel.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const propTypes = require('prop-types');
+const { createElement } = require('preact');
+const { useEffect, useRef } = require('preact/hooks');
+const scrollIntoView = require('scroll-into-view');
+
+const useStore = require('../store/use-store');
+
+const Slider = require('./slider');
+const SvgIcon = require('./svg-icon');
+
+/**
+ * Base component for a sidebar panel.
+ *
+ * This component provides a basic visual container for sidebar panels, as well
+ * as providing a close button. Only one sidebar panel (as defined by the panel's
+ * `panelName`) is active at one time.
+ */
+function SidebarPanel({ children, panelName, title }) {
+  const panelIsActive = useStore(store => store.isSidebarPanelOpen(panelName));
+  const togglePanelFn = useStore(store => store.toggleSidebarPanel);
+
+  const panelElement = useRef();
+  const panelWasActive = useRef(panelIsActive);
+
+  // Scroll the panel into view if it has just been opened
+  useEffect(() => {
+    if (panelWasActive.current !== panelIsActive) {
+      panelWasActive.current = panelIsActive;
+      if (panelIsActive) {
+        scrollIntoView(panelElement.current);
+      }
+    }
+  }, [panelIsActive]);
+
+  const closePanel = () => {
+    togglePanelFn(panelName, false);
+  };
+
+  return (
+    <Slider visible={panelIsActive}>
+      <div className="sidebar-panel" ref={panelElement}>
+        <div className="sidebar-panel__header">
+          <div className="sidebar-panel__title u-stretch">{title}</div>
+          <div>
+            <button
+              className="sidebar-panel__close-btn"
+              onClick={closePanel}
+              aria-label="close panel"
+            >
+              <SvgIcon
+                name="cancel"
+                className="sidebar-panel__close-btn-icon"
+              />
+              Close
+            </button>
+          </div>
+        </div>
+        <div className="sidebar-panel__content">{children}</div>
+      </div>
+    </Slider>
+  );
+}
+
+SidebarPanel.propTypes = {
+  children: propTypes.any,
+
+  /**
+   * A string identifying this panel. Only one `panelName` may be active at
+   * any time. Multiple panels with the same `panelName` would be "in sync",
+   * opening and closing together.
+   */
+  panelName: propTypes.string.isRequired,
+
+  /** The panel's title: rendered in its containing visual "frame" */
+  title: propTypes.string.isRequired,
+};
+
+module.exports = SidebarPanel;

--- a/src/sidebar/components/test/sidebar-panel-test.js
+++ b/src/sidebar/components/test/sidebar-panel-test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const { createElement } = require('preact');
+const { shallow } = require('enzyme');
+
+const SidebarPanel = require('../sidebar-panel');
+
+describe('SidebarPanel', () => {
+  let fakeStore;
+  let fakeScrollIntoView;
+
+  const createSidebarPanel = props =>
+    shallow(
+      <SidebarPanel panelName="testpanel" title="Test Panel" {...props} />
+    );
+
+  beforeEach(() => {
+    fakeScrollIntoView = sinon.stub();
+
+    fakeStore = {
+      getState: sinon.stub().returns({
+        sidebarPanels: {
+          activePanelName: null,
+        },
+      }),
+      isSidebarPanelOpen: sinon.stub().returns(false),
+      toggleSidebarPanel: sinon.stub(),
+    };
+
+    SidebarPanel.$imports.$mock({
+      '../store/use-store': callback => callback(fakeStore),
+      'scroll-into-view': fakeScrollIntoView,
+    });
+  });
+
+  afterEach(() => {
+    SidebarPanel.$imports.$restore();
+  });
+
+  it('renders the provided title', () => {
+    const wrapper = createSidebarPanel({ title: 'My Panel' });
+    const titleEl = wrapper.find('.sidebar-panel__title');
+    assert.equal(titleEl.text(), 'My Panel');
+  });
+
+  it('closes the panel when close button is clicked', () => {
+    const wrapper = createSidebarPanel({ panelName: 'flibberty' });
+    wrapper.find('button').simulate('click');
+
+    assert.calledWith(fakeStore.toggleSidebarPanel, 'flibberty', false);
+  });
+
+  it('shows content if active', () => {
+    fakeStore.isSidebarPanelOpen.returns(true);
+    const wrapper = createSidebarPanel();
+    assert.isTrue(wrapper.find('Slider').prop('visible'));
+  });
+
+  it('hides content if not active', () => {
+    fakeStore.isSidebarPanelOpen.returns(false);
+    const wrapper = createSidebarPanel();
+    assert.isFalse(wrapper.find('Slider').prop('visible'));
+  });
+
+  it('scrolls panel into view when opened', () => {
+    fakeStore.isSidebarPanelOpen.returns(false);
+    // Initial render will establish in state that the panel is not active
+    const wrapper = createSidebarPanel();
+    // Now, make it so the panel will have an active state
+    fakeStore.isSidebarPanelOpen.returns(true);
+
+    // Trick to make things re-render now with updated state
+    wrapper.setProps({});
+
+    assert.calledOnce(fakeScrollIntoView);
+  });
+
+  it('does not scroll panel if already opened', () => {
+    fakeStore.isSidebarPanelOpen.returns(true);
+    // Initial render will establish in state that the panel is already active
+    const wrapper = createSidebarPanel();
+
+    // Re-rendering should not cause `scrollIntoView` to be invoked
+    wrapper.setProps({});
+
+    assert.isFalse(fakeScrollIntoView.called);
+  });
+});

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -44,6 +44,7 @@ const groups = require('./modules/groups');
 const realTimeUpdates = require('./modules/real-time-updates');
 const selection = require('./modules/selection');
 const session = require('./modules/session');
+const sidebarPanels = require('./modules/sidebar-panels');
 const viewer = require('./modules/viewer');
 
 /**
@@ -97,6 +98,7 @@ function store($rootScope, settings) {
     realTimeUpdates,
     selection,
     session,
+    sidebarPanels,
     viewer,
   ];
   return createStore(modules, [settings], middleware);

--- a/src/sidebar/store/modules/sidebar-panels.js
+++ b/src/sidebar/store/modules/sidebar-panels.js
@@ -1,0 +1,130 @@
+/**
+ * This module handles the state for `SidebarPanel` components used in the app.
+ * It keeps track of the "active" `panelName` (simple string) and allows the
+ * opening, closing or toggling of panels via their `panelName`. It merely
+ * retains the `panelName` state as a string: it has no understanding nor
+ * opinions about whether a given `panelName` corresponds to one or more
+ * extant `SidebarPanel` components. Only one panel (as keyed by `panelName`)
+ * may be "active" (open) at one time.
+ */
+
+'use strict';
+
+const util = require('../util');
+
+function init() {
+  return {
+    /*
+     * The `panelName` of the currently-active sidebar panel.
+     * Only one `panelName` may be active at a time, but it is valid (though not
+     * the standard use case) for multiple `SidebarPanel` components to share
+     * the same `panelName`—`panelName` is not intended as a unique ID/key.
+     *
+     * e.g. If `activePanelName` were `foobar`, all `SidebarPanel` components
+     * with `panelName` of `foobar` would be active, and thus visible.
+     *
+     */
+    activePanelName: null,
+  };
+}
+
+const update = {
+  OPEN_SIDEBAR_PANEL: function(state, action) {
+    return { activePanelName: action.panelName };
+  },
+
+  CLOSE_SIDEBAR_PANEL: function(state, action) {
+    let activePanelName = state.activePanelName;
+    if (action.panelName === activePanelName) {
+      // `action.panelName` is indeed the currently-active panel; deactivate
+      activePanelName = null;
+    }
+    // `action.panelName` is not the active panel; nothing to do here
+    return {
+      activePanelName,
+    };
+  },
+
+  TOGGLE_SIDEBAR_PANEL: function(state, action) {
+    let activePanelName;
+    // Is the panel in question currently the active panel?
+    const panelIsActive = state.activePanelName === action.panelName;
+    // What state should the panel in question move to next?
+    const panelShouldBeActive =
+      typeof action.panelState !== 'undefined'
+        ? action.panelState
+        : !panelIsActive;
+
+    if (panelShouldBeActive) {
+      // If the specified panel should be open (active), set it as active
+      activePanelName = action.panelName;
+    } else if (panelIsActive && !panelShouldBeActive) {
+      // If the specified panel is currently open (active), but it shouldn't be anymore
+      activePanelName = null;
+    } else {
+      // This panel is already inactive; do nothing
+      activePanelName = state.activePanelName;
+    }
+
+    return {
+      activePanelName,
+    };
+  },
+};
+
+const actions = util.actionTypes(update);
+
+/**
+ * Designate `panelName` as the currently-active panel name
+ */
+function openSidebarPanel(panelName) {
+  return { type: actions.OPEN_SIDEBAR_PANEL, panelName: panelName };
+}
+
+/**
+ * `panelName` should not be the active panel
+ */
+function closeSidebarPanel(panelName) {
+  return { type: actions.CLOSE_SIDEBAR_PANEL, panelName: panelName };
+}
+
+/**
+ * Toggle a sidebar panel from its current state, or set it to the
+ * designated `panelState`
+ *
+ * @param {String} panelName
+ * @param {Boolean} panelState - Should the panel be active?
+ */
+function toggleSidebarPanel(panelName, panelState) {
+  return {
+    type: actions.TOGGLE_SIDEBAR_PANEL,
+    panelName: panelName,
+    panelState: panelState,
+  };
+}
+
+/**
+ * Is the panel indicated by `panelName` currently active (open)?
+ *
+ * @param {String} panelName
+ * @return {Boolean} - `true` if `panelName` is the currently-active panel
+ */
+function isSidebarPanelOpen(state, panelName) {
+  return state.sidebarPanels.activePanelName === panelName;
+}
+
+module.exports = {
+  namespace: 'sidebarPanels',
+  init: init,
+  update: update,
+
+  actions: {
+    openSidebarPanel,
+    closeSidebarPanel,
+    toggleSidebarPanel,
+  },
+
+  selectors: {
+    isSidebarPanelOpen,
+  },
+};

--- a/src/sidebar/store/modules/test/sidebar-panels-test.js
+++ b/src/sidebar/store/modules/test/sidebar-panels-test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const createStore = require('../../create-store');
+const sidebarPanels = require('../sidebar-panels');
+
+describe('sidebar/store/modules/sidebar-panels', () => {
+  let store;
+
+  const getSidebarPanelsState = () => {
+    return store.getState().sidebarPanels;
+  };
+
+  beforeEach(() => {
+    store = createStore([sidebarPanels]);
+  });
+
+  describe('#init', () => {
+    it('sets initial `activePanelName` to `null`', () => {
+      assert.equal(getSidebarPanelsState().activePanelName, null);
+    });
+  });
+
+  describe('reducers', () => {
+    describe('#OPEN_SIDEBAR_PANEL', () => {
+      it('replaces `activePanelName` with passed `panelName`', () => {
+        store.openSidebarPanel('foobar');
+
+        assert.equal(getSidebarPanelsState().activePanelName, 'foobar');
+      });
+    });
+
+    describe('#CLOSE_SIDEBAR_PANEL', () => {
+      it('sets the active panel `null` if passed `panelName` is active panel', () => {
+        store.openSidebarPanel('dingdong');
+        store.closeSidebarPanel('dingdong');
+        assert.equal(getSidebarPanelsState().activePanelName, null);
+      });
+      it('does not change the active panel if passed `panelName` is not the active panel', () => {
+        store.openSidebarPanel('dingdong');
+        store.closeSidebarPanel('somethingelse');
+        assert.equal(getSidebarPanelsState().activePanelName, 'dingdong');
+      });
+    });
+
+    describe('#TOGGLE_SIDEBAR_PANEL', () => {
+      it('sets active panel to passed `panelName` if that panel is not the active panel already', () => {
+        store.toggleSidebarPanel('dingdong');
+        assert.equal(getSidebarPanelsState().activePanelName, 'dingdong');
+      });
+
+      it('sets active panel to `null` if passed `panelName` is the active panel already', () => {
+        store.openSidebarPanel('dingdong');
+        store.toggleSidebarPanel('dingdong');
+        assert.equal(getSidebarPanelsState().activePanelName, null);
+      });
+
+      it('activates the given `panelName` if `activeState` is `true`', () => {
+        store.openSidebarPanel('dingdong');
+        store.toggleSidebarPanel('dingdong', true);
+        assert.equal(getSidebarPanelsState().activePanelName, 'dingdong');
+      });
+
+      it('deactivates the given `panelName` if `activeState` is `false` and panel is active', () => {
+        store.openSidebarPanel('dingdong');
+        store.toggleSidebarPanel('dingdong', false);
+        assert.equal(getSidebarPanelsState().activePanelName, null);
+      });
+
+      it('does not change active panel if `panelName` is not active and `activeState` is false', () => {
+        store.openSidebarPanel('doodledoo');
+        store.toggleSidebarPanel('dingdong', false);
+        assert.equal(getSidebarPanelsState().activePanelName, 'doodledoo');
+      });
+    });
+  });
+
+  describe('selectors', () => {
+    describe('#isSidebarPanelOpen', () => {
+      it('returns `true` if `panelName` is the current active panel', () => {
+        store.openSidebarPanel('dingdong');
+        assert.isTrue(store.isSidebarPanelOpen('dingdong'));
+      });
+
+      it('returns `false` if `panelName` is not the current active panel', () => {
+        store.openSidebarPanel('dingdong');
+        assert.isFalse(store.isSidebarPanelOpen('broomstick'));
+      });
+    });
+  });
+});

--- a/src/styles/sidebar/components/sidebar-panel.scss
+++ b/src/styles/sidebar/components/sidebar-panel.scss
@@ -1,0 +1,50 @@
+.sidebar-panel {
+  border: solid 1px $grey-3;
+  border-radius: 2px;
+  font-family: $sans-font-family;
+  margin-bottom: 0.75em;
+  position: relative;
+  background-color: $body-background;
+
+  &__header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    border: 1px none $grey-3;
+    border-bottom-style: solid;
+    padding: 1em 0;
+    margin: 0 1em;
+  }
+
+  &__title {
+    color: $brand;
+    font-size: $body2-font-size;
+    font-weight: 700;
+  }
+
+  &__close-btn {
+    display: flex;
+    align-items: center;
+    border-radius: 2px;
+    border: none;
+    padding: 0.5em;
+    background-color: $grey-1;
+    color: $grey-5;
+    font-weight: 700;
+
+    &-icon {
+      color: $grey-5;
+    }
+
+    &:hover {
+      transition: 0.2s ease-out;
+      background-color: $grey-2;
+      color: $grey-6;
+    }
+  }
+
+  &__content {
+    padding: 0.75em;
+    padding-top: 0;
+  }
+}

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -43,6 +43,7 @@ $base-line-height: 20px;
 @import './components/selection-tabs';
 @import './components/share-link';
 @import './components/search-input';
+@import './components/sidebar-panel';
 @import './components/sidebar-tutorial';
 @import './components/svg-icon';
 @import './components/spinner';


### PR DESCRIPTION
This PR adds a new base component, `SidebarPanel`, and a similarly-named store module for managing panels.

No user-visible changes in this PR. Base component only.

Part of https://github.com/hypothesis/client/issues/1201