### PR TITLE
Enable throttling of concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,9 @@
 #!groovy
 
+// Enable concurrent builds of this project to be throttled using the
+// throttle-concurrents Jenkins plugin (https://plugins.jenkins.io/throttle-concurrents)
+
+throttle(['client']) {
 node {
     checkout scm
 
@@ -70,6 +74,7 @@ node {
           sh "make checkformatting lint test"
         }
     }
+}
 }
 
 if (env.BRANCH_NAME != releaseFromBranch) {


### PR DESCRIPTION
Jenkins CI builds of the client project are prone to failing when many
concurrent builds occur. This often happens when many Dependabot PRs are
submitted at once during a weekly dependency update. These builds
succeed most of the time when retried.

Limiting the number of concurrent builds per executor can be done globally,
but it can also be done on a per-project basis using the
throttle-concurrents [1] plugin. Assign a throttling category to client
builds so that this latter approach can be used.

[1] https://plugins.jenkins.io/throttle-concurrents