### PR TITLE
Revert "Improve accessability for toggle buttons"

### DIFF
--- a/src/annotator/plugin/toolbar.coffee
+++ b/src/annotator/plugin/toolbar.coffee
@@ -6,7 +6,6 @@ makeButton = (item) ->
   .attr('href', '')
   .attr('title', item.title)
   .attr('name', item.name)
-  .attr('aria-pressed', item.ariaPressed)
   .on(item.on)
   .addClass('annotator-frame-button')
   .addClass(item.class)
@@ -27,15 +26,6 @@ module.exports = class Toolbar extends Plugin
       $(@options.container).append @toolbar
     else
       $(@element).append @toolbar
-    
-    # https://h.readthedocs.io/projects/client/en/latest/publishers/config/?highlight=onLoginRequest#cmdoption-arg-showhighlights
-    highlightsAreVisible = true; # default to on
-    showHighlightsConfig = window.hypothesisConfig().showHighlights;
-    
-    if showHighlightsConfig == 'always' || showHighlightsConfig == true 
-      highlightsAreVisible = true
-    else if showHighlightsConfig == false || showHighlightsConfig == 'never'
-      highlightsAreVisible = false
 
     items = [
       "title": "Close Sidebar"
@@ -49,7 +39,6 @@ module.exports = class Toolbar extends Plugin
           @toolbar.find('[name=sidebar-close]').hide();
     ,
       "title": "Toggle or Resize Sidebar"
-      "ariaPressed": !!window.hypothesisConfig().openSidebar
       "class": "annotator-frame-button--sidebar_toggle h-icon-chevron-left"
       "name": "sidebar-toggle"
       "on":
@@ -59,15 +48,12 @@ module.exports = class Toolbar extends Plugin
           collapsed = @annotator.frame.hasClass('annotator-collapsed')
           if collapsed
             @annotator.show()
-            event.target.setAttribute('aria-pressed', true);
           else
             @annotator.hide()
-            event.target.setAttribute('aria-pressed', false);
     ,
-      "title": "Toggle Highlights Visibility"
-      "class": if highlightsAreVisible then 'h-icon-visibility' else 'h-icon-visibility-off'
+      "title": "Hide Highlights"
+      "class": "h-icon-visibility"
       "name": "highlight-visibility"
-      "ariaPressed": highlightsAreVisible
       "on":
         "click": (event) =>
           event.preventDefault()
@@ -101,12 +87,12 @@ module.exports = class Toolbar extends Plugin
       $('[name=highlight-visibility]')
       .removeClass('h-icon-visibility-off')
       .addClass('h-icon-visibility')
-      .attr('aria-pressed', 'true')
+      .prop('title', 'Hide Highlights');
     else
       $('[name=highlight-visibility]')
       .removeClass('h-icon-visibility')
       .addClass('h-icon-visibility-off')
-      .attr('aria-pressed', 'false')
+      .prop('title', 'Show Highlights');
 
   disableMinimizeBtn: () ->
     $('[name=sidebar-toggle]').remove();

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -107,7 +107,7 @@ $base-font-size: 14px;
   }
 
   .annotator-frame-button {
-    transition: background-color 0.25s;
+    transition: background-color 0.25s 0.25s;
     @include smallshadow;
     background: $white;
     border: solid 1px $gray-lighter;
@@ -121,6 +121,7 @@ $base-font-size: 14px;
     margin-bottom: 5px;
 
     &:active {
+      transition: background-color 0.25s;
       background-color: $gray-light;
     }
 


### PR DESCRIPTION
This reverts commit ab3d902ff465063e70431e6744b1de5a6b0a01f0.

This change caused the client to fail to load on pages where
`window.hypothesisConfig` is not defined, which means all pages that do not embed Hypothesis directly and some that do, if use JSON configuration rather than defining `window.hypothesisConfig`.

Original PR: https://github.com/hypothesis/client/pull/1382