### PR TITLE
Improve mobile UX of markdown editor and search input

### DIFF
--- a/src/sidebar/components/markdown-editor.js
+++ b/src/sidebar/components/markdown-editor.js
@@ -263,7 +263,7 @@ function MarkdownEditor({ onEditText = () => {}, text = '' }) {
         />
       ) : (
         <textarea
-          className="form-input form-textarea"
+          className="markdown-editor__input form-input form-textarea"
           ref={input}
           onClick={e => e.stopPropagation()}
           onKeydown={handleKeyDown}

--- a/src/sidebar/components/search-input.js
+++ b/src/sidebar/components/search-input.js
@@ -41,7 +41,12 @@ function SearchInput({ alwaysExpanded, query, onSearch }) {
   }
 
   return (
-    <form className="search-input__form" name="searchForm" onSubmit={onSubmit}>
+    <form
+      action="#"
+      className="search-input__form"
+      name="searchForm"
+      onSubmit={onSubmit}
+    >
       <input
         className={classnames('search-input__input', {
           'is-expanded': alwaysExpanded || query,

--- a/src/styles/sidebar/components/markdown-editor.scss
+++ b/src/styles/sidebar/components/markdown-editor.scss
@@ -4,6 +4,10 @@ $toolbar-border: 0.1em solid $grey-3;
   display: flex;
   flex-direction: row;
 
+  // Toolbar buttons wrap on non-touch devices if they don't fit. We don't use
+  // scrolling because that's less convenient to use with a mouse/touchpad.
+  flex-wrap: wrap;
+
   background-color: white;
   border: $toolbar-border;
   border-bottom: none;
@@ -39,4 +43,34 @@ $toolbar-border: 0.1em solid $grey-3;
   border: $toolbar-border;
   background-color: $grey-1;
   padding: 10px;
+}
+
+@media (pointer: coarse) {
+  .markdown-editor__input {
+    font-size: $touch-input-font-size;
+  }
+
+  .markdown-editor__toolbar {
+    // Remove the padding to avoid the toolbar taking up too much space as we
+    // make the buttons larger.
+    padding: 0;
+
+    // Some extra padding at the bottom is needed though as otherwise the
+    // browser is likely to confuse taps on the toolbar buttons and taps on
+    // selection handles, if some text in the first line of the input is
+    // selected.
+    padding-bottom: 10px;
+
+    // Use scrolling rather than wrapping to handle overflow for touch devices.
+    // This saves vertical space.
+    flex-wrap: unset;
+    overflow-x: scroll;
+  }
+
+  // Make the toolbar buttons larger and easier to tap.
+  .markdown-editor__toolbar-button {
+    min-width: $touch-target-size;
+    min-height: $touch-target-size;
+    font-size: 20px;
+  }
 }

--- a/src/styles/sidebar/components/search-input.scss
+++ b/src/styles/sidebar/components/search-input.scss
@@ -45,3 +45,9 @@
     padding-left: 6px;
   }
 }
+
+@media (pointer: coarse) {
+  .search-input__input {
+    font-size: $touch-input-font-size;
+  }
+}

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -121,9 +121,17 @@ $normal-line-height: 17px;
 $small-font-size: 11px;
 $small-line-height: 12px;
 
+// Minimum font size for <input> fields on iOS. If the font size is smaller than
+// this, iOS will zoom into the field when focused.
+$touch-input-font-size: 16px;
+
 // Layout margins
 // -------------------------
 $layout-h-margin: 15px;
+
+// Minimum recommended size for tap targets on mobile.
+// This value originated from Apple's Human Interface Guidelines.
+$touch-target-size: 44px;
 
 // Z-Index Scale
 // -------------------------


### PR DESCRIPTION
- Increase the font size of the markdown editor and search input fields when using touch input. This makes them easier to read on mobile and is especially important on iOS as it prevents Safari from zooming in the input field, which is really annoying when the parent website is mobile optimized. It also sometimes causes the sidebar iframe to move in unexpected ways (see screenshot below).
- Make the toolbar buttons larger when using touch input and add space at the bottom of the toolbar to make it easier for the browser to differentiate taps on the buttons and taps on selection handles in the input field
- Fix an issue where the toolbar overflowed on most phone-sized screens. Depending on the input mode this is handled by making the toolbar scrollable (touch input, easy to scroll by swiping) or by wrapping the icons (non-touch input, possibly harder to scroll).

**Before**

Note toolbar is overflowing:

<img src="https://user-images.githubusercontent.com/2458/67100485-aa4d1b80-f1b7-11e9-9c44-6174055efe62.png" width="400">

Borked sidebar iframe sometimes seen after tapping input field:

<img src="https://user-images.githubusercontent.com/2458/67100523-b933ce00-f1b7-11e9-93cc-87691f52455e.png" width="400">

**After**

Note toolbar does not overflow but is scrollable instead:

<img src="https://user-images.githubusercontent.com/2458/67100540-c18c0900-f1b7-11e9-9064-8da024413aa4.png" width="400">

Search input field showing larger input size without zooming and blue action button in the virtual keyboard:

<img src="https://user-images.githubusercontent.com/2458/67100626-ea140300-f1b7-11e9-982e-b392348289bf.png" width="400">

