### PR TITLE
Make it easier to test client from a different device

### DIFF
--- a/docs/developers/envvars.rst
+++ b/docs/developers/envvars.rst
@@ -10,7 +10,3 @@ build tasks.
    the sidebar app's iframe), used when the host page does not contain a
    :option:`sidebarAppUrl` setting.
    ``https://hypothes.is/app.html`` by default.
-
-.. envvar:: PACKAGE_SERVER_HOSTNAME
-
-   The hostname that is used to generate URLs to the package content server.

--- a/docs/developers/mobile.rst
+++ b/docs/developers/mobile.rst
@@ -15,9 +15,11 @@ tested with at least current versions of iOS Safari and Chrome for Android.
    by editing ``conf/development-app.ini`` and changing the ``host`` setting from
    ``localhost`` to ``0.0.0.0``.
 
-#. Get the IP address or hostname of your development system (``<HOSTNAME>``
+#. Get the hostname of your development system (``<HOSTNAME>``
    in the steps below). You can do this using the ``hostname`` terminal command on
-   Mac/Linux.
+   macOS/Linux.
+
+   On macOS, this will typically be something like "Bobs-MacBookPro.local".
 
    .. tip::
 
@@ -39,26 +41,11 @@ tested with at least current versions of iOS Safari and Chrome for Android.
 
       make dev
 
-#. Set the :envvar:`SIDEBAR_APP_URL` and :envvar:`PACKAGE_SERVER_HOSTNAME`
-   environment variables to load assets from this hostname and start the dev
-   server:
+#. Make sure the "Redirect URL" of the OAuth client associated with your
+   development client matches `<HOSTNAME>`. You can configure the OAuth clients
+   registered with h at http://localhost:5000/admin/oauthclients.
 
-   .. code-block:: sh
-
-      # In the client repository
-
-      # Set URL which sidebar app ("app.html") is loaded from
-      export SIDEBAR_APP_URL=http://<HOSTNAME>:5000/app.html
-      # Set hostname used when generating client asset URLs
-      export PACKAGE_SERVER_HOSTNAME=<HOSTNAME>
-
-      make dev
-
-   .. tip::
-
-      When ``make dev`` runs, it will print out the URLs used for h
-      and client assets. These should include ``<HOSTNAME>`` instead of
-      ``localhost``.
+   This step is necessary to make logging into the client work.
 
 #. On your mobile device, go to a page which has the client embedded such as
    ``http://<HOSTNAME>:3000`` or ``http://<HOSTNAME>:5000/docs/help``.

--- a/scripts/gulp/live-reload-server.js
+++ b/scripts/gulp/live-reload-server.js
@@ -120,7 +120,9 @@ function LiveReloadServer(port, config) {
             });
 
             var embedScript = document.createElement('script');
-            embedScript.src = '${config.clientUrl}';
+            embedScript.src = '${
+              config.clientUrl
+            }'.replace('{current_host}', document.location.hostname);
             document.body.appendChild(embedScript);
 
             var iframeIsAdded = false;

--- a/scripts/gulp/serve-package.js
+++ b/scripts/gulp/serve-package.js
@@ -19,7 +19,7 @@ const { version } = require('../../package.json');
  * returned by the service's '/embed.js' route and included in the '/app.html'
  * app.
  */
-function servePackage(port, hostname) {
+function servePackage(port) {
   const app = express();
 
   // Enable CORS for assets so that cross-origin font loading works.
@@ -43,7 +43,7 @@ function servePackage(port, hostname) {
 
   createServer(app).listen(port, () => {
     const scheme = useSsl ? 'https' : 'http';
-    log(`Package served at ${scheme}://${hostname}:${port}/hypothesis`);
+    log(`Package served at ${scheme}://localhost:${port}/hypothesis`);
   });
 }
 

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -13,9 +13,12 @@
 
 const boot = require('./boot');
 const settings = require('../shared/settings').jsonConfigsFrom(document);
+const processUrlTemplate = require('./url-template');
 
 boot(document, {
-  assetRoot: settings.assetRoot || '__ASSET_ROOT__',
+  assetRoot: processUrlTemplate(settings.assetRoot || '__ASSET_ROOT__'),
   manifest: __MANIFEST__,
-  sidebarAppUrl: settings.sidebarAppUrl || '__SIDEBAR_APP_URL__',
+  sidebarAppUrl: processUrlTemplate(
+    settings.sidebarAppUrl || '__SIDEBAR_APP_URL__'
+  ),
 });

--- a/src/boot/test/url-template-test.js
+++ b/src/boot/test/url-template-test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const processUrlTemplate = require('../url-template');
+
+describe('processUrlTemplate', () => {
+  let fakeDocument;
+
+  beforeEach(() => {
+    fakeDocument = { currentScript: null };
+  });
+
+  context('when `document.currentScript` is set', () => {
+    beforeEach(() => {
+      fakeDocument.currentScript = {
+        src: 'https://john-smith-mbp.local/hypothesis',
+      };
+    });
+
+    it('replaces {current_host} in template', () => {
+      const url = processUrlTemplate(
+        'https://{current_host}:3000/script.js',
+        fakeDocument
+      );
+      assert.equal(url, 'https://john-smith-mbp.local:3000/script.js');
+    });
+
+    it('replaces {current_scheme} in template', () => {
+      const url = processUrlTemplate(
+        '{current_scheme}://localhost/script.js',
+        fakeDocument
+      );
+      assert.equal(url, 'https://localhost/script.js');
+    });
+  });
+
+  context('when `document.currentScript` is not set', () => {
+    it('does not replace parameters', () => {
+      const url = processUrlTemplate(
+        '{current_scheme}://{current_host}:2000/style.css',
+        fakeDocument
+      );
+      assert.equal(url, '{current_scheme}://{current_host}:2000/style.css');
+    });
+  });
+});

--- a/src/boot/url-template.js
+++ b/src/boot/url-template.js
@@ -1,0 +1,30 @@
+'use strict';
+
+function currentScriptUrl(document_ = document) {
+  try {
+    const scriptEl = document_.currentScript;
+    return new URL(scriptEl.src);
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * Replace references to `current_host` and `current_scheme` URL template
+ * parameters with the corresponding elements of the current script URL.
+ *
+ * During local development, there are cases when the client/h needs to be accessed
+ * from a device or VM that is not the system where the development server is
+ * running. In that case, all references to `localhost` need to be replaced
+ * with the IP/hostname of the dev server.
+ */
+function processUrlTemplate(url, document_ = document) {
+  const scriptUrl = currentScriptUrl(document_);
+  if (scriptUrl) {
+    url = url.replace('{current_host}', scriptUrl.hostname);
+    url = url.replace('{current_scheme}', scriptUrl.protocol.slice(0, -1));
+  }
+  return url;
+}
+
+module.exports = processUrlTemplate;


### PR DESCRIPTION
Make it easier to test the development client from a different device by removing
the need to customize the `SIDEBAR_APP_URL` and `PACKAGE_SERVER_HOSTNAME`
environment variables first.

Instead of hardcoding the client/h dev server hostname and scheme in the client's
boot script, support a very simple URL templating scheme where
references to `{current_host}` and `{current_scheme}` are replaced by
the corresponding elements of the boot script's URL.

This means that for example, if the embed script is accessed as
`https://Roberts-MacBook-Pro.local:5000/embed.js` then the boot script
will use asset URLs such as
`https://Roberts-MacBook-Pro.local:3001/assets/sidebar.bundle.js`. If
the boot script is accessed as `http://localhost:5000/embed.js` then
it will generate `http://localhost:3001/assets/sidebar.bundle.js`
instead.

A [related change in h](https://github.com/hypothesis/h/pull/5758) will remove the need to set the `CLIENT_URL` env
var and modify the OAuth client's redirect URL. At present, those steps
are still required.