### PR TITLE
Fix PDF anchoring when annotation refers to last text on a page

### DIFF
--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -342,10 +342,9 @@ function prioritizePages(position) {
  *
  * @param {HTMLElement} root
  * @param {Array} selectors - Selector objects to anchor
- * @param {Object} options - Options to pass to selector anchoring
  * @return {Promise<Range>}
  */
-function anchor(root, selectors, options = {}) {
+function anchor(root, selectors) {
   const position = selectors.find(s => s.type === 'TextPositionSelector');
   const quote = selectors.find(s => s.type === 'TextQuoteSelector');
 

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -188,6 +188,19 @@ describe('annotator/anchoring/pdf', function() {
       });
     });
 
+    // See https://github.com/hypothesis/client/issues/1329
+    it('anchors selectors that match the last text on the page', async () => {
+      viewer.pdfViewer.setCurrentPage(1);
+      const selectors = [
+        {
+          type: 'TextQuoteSelector',
+          exact: 'horde of the living dead.',
+        },
+      ];
+      const anchoredRange = await pdfAnchoring.anchor(container, selectors);
+      assert.equal(anchoredRange.toString(), selectors[0].exact);
+    });
+
     [
       {
         // Position on same page as quote but different text.

--- a/src/annotator/anchoring/test/text-position-test.js
+++ b/src/annotator/anchoring/test/text-position-test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const { toRange } = require('../text-position');
+
+describe('text-position', () => {
+  let container;
+
+  before(() => {
+    container = document.createElement('div');
+    container.innerHTML = `<h1>Test article</h1>
+<p>First paragraph.</p>
+<p>Second paragraph.</p>`;
+  });
+
+  after(() => {
+    container.remove();
+  });
+
+  describe('toRange', () => {
+    const testCase = (description, text) => ({
+      description,
+      text,
+      expected: text,
+    });
+
+    [
+      testCase('start text of root', 'Test article'),
+      testCase('a whole text node', 'First paragraph.'),
+      testCase('end text of root', 'Second paragraph.'),
+      testCase('part of a text node', 'rst paragraph'),
+      {
+        description: 'negative start offset',
+        start: -5,
+        end: 5,
+        expected: new Error('invalid start offset'),
+      },
+      {
+        description: 'invalid start offset',
+        start: 1000,
+        end: 1010,
+        expected: new Error('invalid start offset'),
+      },
+      {
+        description: 'invalid end offset',
+        start: 0,
+        end: 1000,
+        expected: new Error('invalid end offset'),
+      },
+      {
+        description: 'an empty range',
+        start: 0,
+        end: 0,
+        expected: '',
+      },
+      {
+        description: 'a range with end < start',
+        start: 10,
+        end: 5,
+        expected: '',
+      },
+    ].forEach(({ description, start, end, expected, text }) => {
+      it(`returns a range with the correct text (${description})`, () => {
+        if (text) {
+          start = container.textContent.indexOf(text);
+          end = start + text.length;
+        }
+
+        if (expected instanceof Error) {
+          assert.throws(() => {
+            toRange(container, start, end);
+          }, expected.message);
+        } else {
+          const range = toRange(container, start, end);
+          assert.equal(range.toString(), expected);
+        }
+      });
+    });
+  });
+});

--- a/src/annotator/anchoring/text-position.js
+++ b/src/annotator/anchoring/text-position.js
@@ -1,0 +1,84 @@
+'use strict';
+
+/**
+ * Functions to convert between DOM ranges and characters offsets within the
+ * `textContent` of HTML elements.
+ *
+ * These were added to work around issues in `dom-anchor-text-position`'s
+ * `toRange` implementation. When the issue is resolved upstream, we may still
+ * want to keep the test suite for this module.
+ *
+ * See https://github.com/hypothesis/client/issues/1329
+ */
+
+/**
+ * Convert `start` and `end` character offset positions within the `textContent`
+ * of a `root` element into a `Range`.
+ *
+ * Throws if the `start` or `end` offsets are outside of the range `[0,
+ * root.textContent.length]`.
+ *
+ * @param {HTMLElement} root
+ * @param {number} start - Character offset within `root.textContent`
+ * @param {number} end - Character offset within `root.textContent`
+ * @return {Range} Range spanning text from `start` to `end`
+ */
+function toRange(root, start, end) {
+  // The `filter` and `expandEntityReferences` arguments are mandatory in IE
+  // although optional according to the spec.
+  const nodeIter = root.ownerDocument.createNodeIterator(
+    root,
+    NodeFilter.SHOW_TEXT,
+    null, // filter
+    false // expandEntityReferences
+  );
+
+  let startContainer;
+  let startOffset;
+  let endContainer;
+  let endOffset;
+
+  let textLength = 0;
+
+  let node;
+  while ((node = nodeIter.nextNode()) && (!startContainer || !endContainer)) {
+    const nodeText = node.nodeValue;
+
+    if (
+      !startContainer &&
+      start >= textLength &&
+      start <= textLength + nodeText.length
+    ) {
+      startContainer = node;
+      startOffset = start - textLength;
+    }
+
+    if (
+      !endContainer &&
+      end >= textLength &&
+      end <= textLength + nodeText.length
+    ) {
+      endContainer = node;
+      endOffset = end - textLength;
+    }
+
+    textLength += nodeText.length;
+  }
+
+  if (!startContainer) {
+    throw new Error('invalid start offset');
+  }
+  if (!endContainer) {
+    throw new Error('invalid end offset');
+  }
+
+  const range = root.ownerDocument.createRange();
+  range.setStart(startContainer, startOffset);
+  range.setEnd(endContainer, endOffset);
+
+  return range;
+}
+
+module.exports = {
+  toRange,
+};


### PR DESCRIPTION
This PR adds tests for and fixes an issue where annotations that spanned the last text on a PDF page would fail to anchor.

The problem is due to an issue in a function in the dom-anchor-text-position library (see https://github.com/tilgovi/dom-anchor-text-position/pull/7) which converts a pair of `(start, end)` offsets referring to the [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) of an element into a DOM `Range`. Specifically it failed when the `end` offset was equal to `node.textContent.length`.

This PR addresses the issue by:
 - Adding a test case at the level of PDF anchoring
 - Adding a new implementation of `(start, end)` => `Range` conversion in `src/annotator/anchoring/text-position` and an associated set of tests

We may want to revert back to using the dom-anchor-text-position implementation once the above PR (or some functional equivalent) is merged, although I suggest we should keep the tests in that case. I have to say though, the code is not particularly complex so there is value in having fewer dependencies involved in PDF annotation.

HTML anchoring still uses the previous implementation of text position => Range conversion. HTML anchoring is in practice not affected by the issue because it is impossible to select the last text in a document and annotate it. If you select the last _visible_ text in a page, there is always other content after that in `document.body.textContent`.

Fixes #1329 