### PR TITLE
Get getStore in a selector (example)

### DIFF
--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -71,7 +71,7 @@ function createStore(modules, initArgs = [], middleware = []) {
   // Add actions and selectors as methods to the store.
   const actions = Object.assign({}, ...modules.map(m => m.actions));
   const boundActions = redux.bindActionCreators(actions, store.dispatch);
-  const boundSelectors = bindSelectors(allSelectors, store.getState);
+  const boundSelectors = bindSelectors(allSelectors, store.getState, store);
 
   Object.assign(store, boundActions, boundSelectors);
 

--- a/src/sidebar/store/util.js
+++ b/src/sidebar/store/util.js
@@ -41,14 +41,17 @@ function createReducer(actionToUpdateFn) {
  * level. The keys to this object are functions that call the original
  * selectors with the `state` argument set to the current value of `getState()`.
  */
-function bindSelectors(namespaces, getState) {
+function bindSelectors(namespaces, getState, store) {
   const totalSelectors = {};
   Object.keys(namespaces).forEach(namespace => {
     const selectors = namespaces[namespace].selectors;
     Object.keys(selectors).forEach(selector => {
       totalSelectors[selector] = function() {
         const args = [].slice.apply(arguments);
-        args.unshift(getState());
+        args.unshift({
+          ...getState(),
+          getStore: ()=>(store)
+        });
         return selectors[selector].apply(null, args);
       };
     });


### PR DESCRIPTION
An experimental example of how we could access root level selectors  from within other selectors. Then, from within any selector you can call another one simply by calling.

`state.getStore().mySelector()`