### PR TITLE
Help & Tutorial 2/n: Add `isSidebar`, `versionData` utilities

### DIFF
--- a/src/sidebar/util/is-sidebar.js
+++ b/src/sidebar/util/is-sidebar.js
@@ -1,0 +1,14 @@
+'use strict';
+
+/**
+ * Is the instance of the application in the current `window_` within a
+ * sidebar (vs. single-annotation or stream view)?
+ */
+const isSidebar = (window_ = window) => {
+  return !(
+    window_.location.pathname.startsWith('/stream') ||
+    window_.location.pathname.startsWith('/a/')
+  );
+};
+
+module.exports = isSidebar;

--- a/src/sidebar/util/test/is-sidebar-test.js
+++ b/src/sidebar/util/test/is-sidebar-test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const isSidebar = require('../is-sidebar');
+
+describe('sidebar.utils.is-sidebar', () => {
+  [
+    '/a/random-annotation-id',
+    '/stream/',
+    '/stream',
+    '/a/',
+    '/a/foo.html',
+  ].forEach(fakePath => {
+    it(`returns false if window.location is in stream or single-annotation view (${fakePath})`, () => {
+      const window_ = {};
+      window_.location = new URL(`http://www.example.com${fakePath}`);
+      assert.isFalse(isSidebar(window_));
+    });
+  });
+
+  ['/whatever', '/anything-else', '/a', '/apples/', '/app.html'].forEach(
+    fakePath => {
+      it(`returns true if window.location is not in stream or single-annotation view (${fakePath})`, () => {
+        const window_ = {};
+        window_.location = new URL(`http://www.example.com${fakePath}`);
+        assert.isTrue(isSidebar(window_));
+      });
+    }
+  );
+});

--- a/src/sidebar/util/test/version-data-test.js
+++ b/src/sidebar/util/test/version-data-test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const VersionData = require('../version-data');
+
+describe('VersionData', () => {
+  let clock;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  describe('constructor', () => {
+    it('sets `timestamp` to string of current date', () => {
+      const versionData = new VersionData({}, {});
+      assert.equal(versionData.timestamp, new Date().toString());
+    });
+
+    it('sets `version`', () => {
+      const versionData = new VersionData({}, {});
+      assert.equal(versionData.version, '1.0.0-dummy-version');
+    });
+
+    it('sets `userAgent`', () => {
+      const versionData = new VersionData(
+        {},
+        {},
+        { navigator: { userAgent: 'fakeUserAgent' } }
+      );
+      assert.equal(versionData.userAgent, 'fakeUserAgent');
+    });
+
+    context('empty `userInfo` and `documentInfo` objects', () => {
+      // This can happen early in app lifecycle
+      it('sets properties to "N/A" for missing values', () => {
+        const versionData = new VersionData({}, {});
+        ['url', 'fingerprint', 'account'].forEach(prop => {
+          assert.equal(versionData[prop], 'N/A');
+        });
+      });
+    });
+
+    describe('account information', () => {
+      it('includes display name if available', () => {
+        const versionData = new VersionData(
+          {
+            userid: 'acct:foo@bar.com',
+            displayName: 'Fred Hubert',
+          },
+          {}
+        );
+        assert.equal(versionData.account, 'Fred Hubert (acct:foo@bar.com)');
+      });
+
+      it('only includes userid if no display name', () => {
+        const versionData = new VersionData({ userid: 'acct:foo@bar.com' }, {});
+        assert.equal(versionData.account, 'acct:foo@bar.com');
+      });
+    });
+
+    describe('document information', () => {
+      it('sets `url`', () => {
+        const versionData = new VersionData(
+          {},
+          { uri: 'https://www.whatbadgerseat.com' }
+        );
+        assert.equal(versionData.url, 'https://www.whatbadgerseat.com');
+      });
+
+      it('sets `fingerprint`', () => {
+        const versionData = new VersionData(
+          {},
+          { metadata: { documentFingerprint: 'DEADBEEF' } }
+        );
+        assert.equal(versionData.fingerprint, 'DEADBEEF');
+      });
+    });
+  });
+
+  describe('#asEncodedURLString', () => {
+    ['timestamp', 'account'].forEach(prop => {
+      it(`includes encoded value for ${prop} in URL string`, () => {
+        const versionData = new VersionData({}, {});
+        const encoded = versionData.asEncodedURLString();
+        const subStr = encodeURIComponent(`${prop}: ${versionData[prop]}\r\n`);
+        assert.include(encoded, subStr);
+      });
+    });
+  });
+});

--- a/src/sidebar/util/version-data.js
+++ b/src/sidebar/util/version-data.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * An object representing user info
+ *
+ * @typedef {Object} UserInfo
+ * @property {string=} userid
+ * @property {string=} displayName
+ */
+
+/**
+ * An object representing document metadata
+ *
+ * @typedef {Object} DocMetadata
+ * @property {string=} documentFingerprint - optional PDF fingerprint for
+ *                     current document
+ */
+
+/**
+ * An object representing document info
+ *
+ * @typedef {Object} DocumentInfo
+ * @property {string=} url - current document URL
+ * @property {DocMetadata} metadata - document metadata
+ */
+
+class VersionData {
+  /**
+   * @param {UserInfo} userInfo
+   * @param {DocumentInfo} documentInfo
+   * @param {Window} window_ - test seam
+   * @return {VersionData}
+   */
+  constructor(userInfo, documentInfo, window_ = window) {
+    const noValueString = 'N/A';
+    const docMeta = documentInfo.metadata;
+
+    let accountString = noValueString;
+    if (userInfo.userid) {
+      accountString = userInfo.userid;
+      if (userInfo.displayName) {
+        accountString = `${userInfo.displayName} (${accountString})`;
+      }
+    }
+
+    this.timestamp = new Date().toString();
+    this.url = documentInfo.uri || noValueString;
+    this.fingerprint =
+      docMeta && docMeta.documentFingerprint
+        ? docMeta.documentFingerprint
+        : noValueString;
+    this.account = accountString;
+    this.userAgent = window_.navigator.userAgent;
+    this.version = '__VERSION__';
+  }
+
+  /**
+   * Return a single, encoded URL string of version data suitable for use in
+   * a querystring (as the value of a single parameter)
+   *
+   * @return {string} - URI-encoded string
+   */
+  asEncodedURLString() {
+    let versionString = '';
+    for (let prop in this) {
+      if (Object.prototype.hasOwnProperty.call(this, prop)) {
+        versionString += `${prop}: ${this[prop]}\r\n`;
+      }
+    }
+    return encodeURIComponent(versionString);
+  }
+}
+
+module.exports = VersionData;


### PR DESCRIPTION
Part of hypothesis/product-backlog#1031

This PR adds two utility modules needed by the new `HelpPanel` component (forthcoming):

* `isSidebar`: This simple utility attempts to centralize and deify what the logic is for "whether the app is running in a sidebar". Further follow-up required to transition the whole app codebase to use this, but it will be used in the immediate term by the `HelpPanel` and `hypothesis-app` components.
* `VersionData`: This utility helps to organize user, session and version data for presentation and use in the client app. It has been converted to a `class` since its first WIP implementation as a convenience for encapsulating  `asEncodedURLString` as an instance method.