### PR TITLE
Improve tab bar accessibility

### DIFF
--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -29,6 +29,9 @@ function Tab({
       })}
       onMouseDown={onChangeTab.bind(this, type)}
       onTouchStart={onChangeTab.bind(this, type)}
+      role="tab"
+      tabIndex="0"
+      ariaSelected={selected}
     >
       {children}
       {count > 0 && !isWaitingToAnchor && (
@@ -108,6 +111,7 @@ function SelectionTabs({ isLoading, settings, session }) {
         className={classnames('selection-tabs', {
           'selection-tabs--theme-clean': isThemeClean,
         })}
+        role="tablist"
       >
         <Tab
           count={annotationCount}

--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -31,7 +31,7 @@ function Tab({
       onTouchStart={onChangeTab.bind(this, type)}
       role="tab"
       tabIndex="0"
-      ariaSelected={selected}
+      aria-selected={selected}
     >
       {children}
       {count > 0 && !isWaitingToAnchor && (


### PR DESCRIPTION
 - Add ARIA roles to the tab bar and individual tabs
 - Make the tab items tab-focusable
 - Indicate the selected tab using `aria-selected`

With these changes, VoiceOver announces, for example "Annotations <count>, selected, tab 1 of 2" when focusing the annotations tab.

Previously tab focus skipped over the tab headings entirely and if focused using VoiceOver keys it would just say "Annotations <count>, pressable".