### PR TITLE
Help & Tutorial 3/n: Refactor how auto-display of tutorial is determined

### DIFF
--- a/src/sidebar/util/session-util.js
+++ b/src/sidebar/util/session-util.js
@@ -1,7 +1,10 @@
 'use strict';
 
+const serviceConfig = require('../service-config');
+
 /**
  * Returns true if the sidebar tutorial has to be shown to a user for a given session.
+ * @deprecated To be removed once preact help/tutorial panel is in place
  */
 function shouldShowSidebarTutorial(sessionState) {
   if (sessionState.preferences.show_sidebar_tutorial) {
@@ -10,6 +13,35 @@ function shouldShowSidebarTutorial(sessionState) {
   return false;
 }
 
+/**
+ * The following things must all be true for the tutorial component to auto-display
+ * on app launch:
+ * - The app must be operating within the "sidebar" (i.e. not single-annotation
+ *   or stream mode); AND
+ * - No configuration is present in `settings.services` indicating
+ *   that the host wants to handle its own help requests (i.e. no event handler
+ *   is provided to intercept the default help panel), AND
+ * - A user profile is loaded in the current state that indicates a `true` value
+ *   for the `show_sidebar_tutorial` preference (i.e. the tutorial has not been
+ *   dismissed by this user yet). This implies the presence of a profile, which
+ *   in turn implies that there is an authenticated user.
+ *
+ * @param {boolean} isSidebar - is the app currently displayed in a sidebar?
+ * @param {Object} sessionState - `session` state from the store
+ * @param {Object} settings - app configuration/settings
+ * @return {boolean} - Tutorial panel should be displayed automatically
+ */
+function shouldAutoDisplayTutorial(isSidebar, sessionState, settings) {
+  const shouldShowBasedOnProfile =
+    typeof sessionState.preferences === 'object' &&
+    !!sessionState.preferences.show_sidebar_tutorial;
+  const service = serviceConfig(settings) || {};
+  return (
+    isSidebar && !service.onHelpRequestProvided && shouldShowBasedOnProfile
+  );
+}
+
 module.exports = {
   shouldShowSidebarTutorial: shouldShowSidebarTutorial,
+  shouldAutoDisplayTutorial: shouldAutoDisplayTutorial,
 };

--- a/src/sidebar/util/test/session-util-test.js
+++ b/src/sidebar/util/test/session-util-test.js
@@ -2,24 +2,94 @@
 
 const sessionUtil = require('../session-util');
 
-describe('sessionUtil.shouldShowSidebarTutorial', function() {
-  it('shows sidebar tutorial if the settings object has the show_sidebar_tutorial key set', function() {
-    const sessionState = {
-      preferences: {
-        show_sidebar_tutorial: true,
-      },
-    };
+describe('sidebar.util.session-util', () => {
+  describe('#shouldShowSidebarTutorial', () => {
+    it('shows sidebar tutorial if the settings object has the show_sidebar_tutorial key set', function() {
+      const sessionState = {
+        preferences: {
+          show_sidebar_tutorial: true,
+        },
+      };
 
-    assert.isTrue(sessionUtil.shouldShowSidebarTutorial(sessionState));
+      assert.isTrue(sessionUtil.shouldShowSidebarTutorial(sessionState));
+    });
+
+    it('hides sidebar tutorial if the settings object does not have the show_sidebar_tutorial key set', function() {
+      const sessionState = {
+        preferences: {
+          show_sidebar_tutorial: false,
+        },
+      };
+
+      assert.isFalse(sessionUtil.shouldShowSidebarTutorial(sessionState));
+    });
   });
 
-  it('hides sidebar tutorial if the settings object does not have the show_sidebar_tutorial key set', function() {
-    const sessionState = {
-      preferences: {
-        show_sidebar_tutorial: false,
+  describe('#shouldAutoDisplayTutorial', () => {
+    [
+      {
+        // The only "true" state
+        description: 'in sidebar with loaded user preference to show tutorial',
+        isSidebar: true,
+        sessionState: { preferences: { show_sidebar_tutorial: true } },
+        settings: {},
+        expected: true,
       },
-    };
-
-    assert.isFalse(sessionUtil.shouldShowSidebarTutorial(sessionState));
+      {
+        description: 'in sidebar with no loaded user profile',
+        isSidebar: true,
+        sessionState: {},
+        settings: {},
+        expected: false,
+      },
+      {
+        description: 'not in sidebar with no loaded user profile',
+        isSidebar: false,
+        sessionState: {},
+        settings: {},
+        expected: false,
+      },
+      {
+        description:
+          'in sidebar with loaded user preference not to show tutorial',
+        isSidebar: true,
+        sessionState: { preferences: { show_sidebar_tutorial: false } },
+        settings: {},
+        expected: false,
+      },
+      {
+        description:
+          'in sidebar with loaded user preference to show tutorial and configured help service',
+        isSidebar: true,
+        sessionState: { preferences: { show_sidebar_tutorial: true } },
+        settings: { services: [{ onHelpRequestProvided: true }] },
+        expected: false,
+      },
+      {
+        description:
+          'not in sidebar with loaded user preference to show tutorial and configured help service',
+        isSidebar: false,
+        sessionState: { preferences: { show_sidebar_tutorial: true } },
+        settings: { services: [{ onHelpRequestProvided: true }] },
+        expected: false,
+      },
+      {
+        description:
+          'not in sidebar with no loaded user profile and configured help service',
+        isSidebar: false,
+        sessionState: {},
+        settings: { services: [{ onHelpRequestProvided: true }] },
+        expected: false,
+      },
+    ].forEach(fixture => {
+      it(`should calculate auto-display to be ${fixture.expected} when ${fixture.description}`, () => {
+        const shouldDisplay = sessionUtil.shouldAutoDisplayTutorial(
+          fixture.isSidebar,
+          fixture.sessionState,
+          fixture.settings
+        );
+        assert.equal(shouldDisplay, fixture.expected);
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR is the end result of several implementation attempts that were each problematic in turn. I want to keep this bit of logic out of the big help-panel diff coming up as it is already quite large enough.

This PR refines the logic that answers the question "should the client automatically display the tutorial component at this time?" There is an incomplete attempt to answer this question in an existing util: https://github.com/hypothesis/client/blob/1c80ed665b635b09cae66551d2cb9e0b4ca09590/src/sidebar/util/session-util.js#L6

However, that variant only addresses one of the three questions that need to be answered to determine if the application _should_ automatically display the tutorial (and doesn't actually answer the question of whether the tutorial _is_ visible, but instead only partially answers whether it _should_ be).

The new method `shouldAutoDisplayTutorial` determines whether the tutorial should be auto-displayed (duh). It will be imminently used by the `hypothesis-app` component to, well, determine whether to auto-open the new tutorial/help panel.

The existing/deprecated `shouldShowSidebarTutorial` is only used by one component, https://github.com/hypothesis/client/blob/1c80ed665b635b09cae66551d2cb9e0b4ca09590/src/sidebar/components/selection-tabs.js . What that component really wants to know is whether the tutorial actually _is_ showing presently, which, once the new help panel has been merged, can be obtained via a selector in the `sidebar_panels` store module (i.e. "Is the HELP panel currently active?").

OK, so, the plan here is, after merging this:

1. Use this new util method from the `hypothesis-app` component to determine when to auto-open the tutorial (already done in local branch)
2. Replace uses of `shouldShowSidebarTutorial` in `SelectionTabs` with checking directly to see if the help panel is open (I can't do this just yet as the help panel doesn't exist yet)
3. Remove `shouldShowSidebarTutorial`

Sorry, this is getting awfully long for such a small diff, but I wanted to mention that I did try alternate implementations of this as both a service and a selector in a store module. Both had some challenges that I could elaborate on if needed. Boy, this has been a lot of thrash for a relatively simple bit of logic!