### PR TITLE
Help & Tutorial 4/n: Add support for status-change callback to `SidebarPanel`

### DIFF
--- a/src/sidebar/components/sidebar-panel.js
+++ b/src/sidebar/components/sidebar-panel.js
@@ -17,7 +17,7 @@ const SvgIcon = require('./svg-icon');
  * as providing a close button. Only one sidebar panel (as defined by the panel's
  * `panelName`) is active at one time.
  */
-function SidebarPanel({ children, panelName, title }) {
+function SidebarPanel({ children, panelName, title, onActiveChanged }) {
   const panelIsActive = useStore(store => store.isSidebarPanelOpen(panelName));
   const togglePanelFn = useStore(store => store.toggleSidebarPanel);
 
@@ -31,8 +31,11 @@ function SidebarPanel({ children, panelName, title }) {
       if (panelIsActive) {
         scrollIntoView(panelElement.current);
       }
+      if (typeof onActiveChanged === 'function') {
+        onActiveChanged(panelIsActive);
+      }
     }
-  }, [panelIsActive]);
+  }, [panelIsActive, onActiveChanged]);
 
   const closePanel = () => {
     togglePanelFn(panelName, false);
@@ -75,6 +78,9 @@ SidebarPanel.propTypes = {
 
   /** The panel's title: rendered in its containing visual "frame" */
   title: propTypes.string.isRequired,
+
+  /** Optional callback to invoke when this panel's active status changes */
+  onActiveChanged: propTypes.func,
 };
 
 module.exports = SidebarPanel;


### PR DESCRIPTION
This small PR extends the `SidebarPanel` component to be able to provide callback support for when its status changes (i.e. it opens or closes). This will be used by the new help/tutorial panel.

The pattern here is modeled after the `Menu` component's [`onOpenChanged`](https://github.com/hypothesis/client/blob/e9def31d5081f80f0e3658a68c2fb2a7ad63c8b5/src/sidebar/components/menu.js#L53) property.