### PR TITLE
Reduce test startup time when running a subset of tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,11 @@ endif
 
 .PHONY: servetests
 servetests: node_modules/.uptodate
+ifdef FILTER
+	node_modules/.bin/gulp test-watch --grep $(FILTER)
+else
 	node_modules/.bin/gulp test-watch
+endif
 
 .PHONY: lint
 lint: node_modules/.uptodate

--- a/docs/developers/developing.rst
+++ b/docs/developers/developing.rst
@@ -110,8 +110,7 @@ Hypothesis uses Karma and mocha for testing. To run all the tests once, run:
    make test
 
 You can filter the tests which are run by running ``make test FILTER=<pattern>``.
-See the documentation for Mocha's
-`grep <https://mochajs.org/#g---grep-pattern>`_ option.
+Only test files matching ``<pattern>`` will be executed.
 
 To run tests and automatically re-run them whenever any source files change, run:
 
@@ -121,7 +120,7 @@ To run tests and automatically re-run them whenever any source files change, run
 
 This command will also serve the tests on localhost (typically `http://localhost:9876`)
 so that break points can be set and the browser's console can be used for interactive
-debugging. 
+debugging.
 
 
 Code Style

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,14 +36,11 @@ let liveReloadChangedFiles = [];
 
 function parseCommandLine() {
   commander
-    // Test configuration.
-    // See https://github.com/karma-runner/karma-mocha#configuration
-    .option('--grep [pattern]', 'Run only tests matching a given pattern')
+    .option(
+      '--grep [pattern]',
+      'Run only tests where filename matches a pattern'
+    )
     .parse(process.argv);
-
-  if (commander.grep) {
-    gulpUtil.log(`Running tests matching pattern /${commander.grep}/`);
-  }
 
   return {
     grep: commander.grep,
@@ -384,37 +381,20 @@ gulp.task(
   )
 );
 
-function runKarma(baseConfig, opts, done) {
-  // See https://github.com/karma-runner/karma-mocha#configuration
-  const cliOpts = {
-    client: {
-      mocha: {
-        grep: taskArgs.grep,
-      },
-    },
-  };
-
+function runKarma({ singleRun }, done) {
   const karma = require('karma');
   new karma.Server(
-    Object.assign(
-      {},
-      {
-        configFile: path.resolve(__dirname, baseConfig),
-      },
-      cliOpts,
-      opts
-    ),
+    {
+      configFile: path.resolve(__dirname, './src/karma.config.js'),
+      grep: taskArgs.grep,
+      singleRun,
+    },
     done
   ).start();
 }
 
-gulp.task('test', function(callback) {
-  runKarma('./src/karma.config.js', { singleRun: true }, callback);
-});
-
-gulp.task('test-watch', function(callback) {
-  runKarma('./src/karma.config.js', {}, callback);
-});
+gulp.task('test', done => runKarma({ singleRun: true }, done));
+gulp.task('test-watch', done => runKarma({ singleRun: false }, done));
 
 gulp.task(
   'upload-sourcemaps',


### PR DESCRIPTION
Change the way that the `FILTER` option works in `make test FILTER=<pattern>`
(or equivalently the `--grep` option if using `gulp test --grep
<pattern>`) to control which test files are executed rather than
matching test descriptions.

This enables the test configuration function in `src/karma.config.js` to
limit the test bundle to only the matching files and their dependencies.
This can make the initial bundling much faster and bundle updates (when
using `make servetests`) somewhat faster.

On my system, `make test FILTER=menu-item` takes ~40s on master but only
~7s on this branch.

As before, the filename filter can be combined with the `.only` modifier
on `description` or `it` calls to do more fine-grained filtering of
tests within matching files.

 - Change `--grep` option to gulp to filter test files as part of the
   test bundling process instead of setting the `grep` mocha option

 - Make `make servetests` accept a `FILTER` argument for consistency
   with `make test`

 - Simplify code in gulpfile.js for launching Karma

 - Update documentation for `make test`