### PR TITLE
WIP (very): Prototype hook to handle “close” interactions on document

### DIFF
--- a/src/sidebar/components/hooks/use-component-should-close.js
+++ b/src/sidebar/components/hooks/use-component-should-close.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const { useEffect } = require('preact/hooks');
+
+const { listen } = require('../../util/dom');
+
+function useComponentShouldClose(componentRef, isOpen, handleClose) {
+  useEffect(() => {
+    if (!isOpen) {
+      return () => {};
+    }
+
+    // Close component when user presses Escape key, regardless of focus.
+    const removeKeypressListener = listen(
+      document.body,
+      ['keypress'],
+      event => {
+        if (event.key === 'Escape') {
+          handleClose();
+        }
+      }
+    );
+
+    // Close menu if user focuses an element outside the component via any means
+    // (key press, programmatic focus change).
+    const removeFocusListener = listen(
+      document.body,
+      'focus',
+      event => {
+        if (!componentRef.current.contains(event.target)) {
+          handleClose();
+        }
+      },
+      { useCapture: true }
+    );
+
+    // Close menu if user clicks outside component, even if on an element which
+    // does not accept focus.
+    const removeClickListener = listen(
+      document.body,
+      ['mousedown', 'click'],
+      event => {
+        // nb. Mouse events inside the current menu are handled elsewhere.
+        if (!componentRef.current.contains(event.target)) {
+          handleClose();
+        }
+      },
+      { useCapture: true }
+    );
+
+    return () => {
+      removeKeypressListener();
+      removeClickListener();
+      removeFocusListener();
+    };
+  }, [componentRef, isOpen, handleClose]);
+}
+
+module.exports = useComponentShouldClose;

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -5,7 +5,7 @@ const { Fragment, createElement } = require('preact');
 const { useCallback, useEffect, useRef, useState } = require('preact/hooks');
 const propTypes = require('prop-types');
 
-const { listen } = require('../util/dom');
+const useComponentShouldClose = require('./hooks/use-component-should-close');
 
 const SvgIcon = require('./svg-icon');
 
@@ -89,56 +89,7 @@ function Menu({
   // These handlers close the menu when the user taps or clicks outside the
   // menu or presses Escape.
   const menuRef = useRef();
-  useEffect(() => {
-    if (!isOpen) {
-      return () => {};
-    }
-
-    // Close menu when user presses Escape key, regardless of focus.
-    const removeKeypressListener = listen(
-      document.body,
-      ['keypress'],
-      event => {
-        if (event.key === 'Escape') {
-          closeMenu();
-        }
-      }
-    );
-
-    // Close menu if user focuses an element outside the menu via any means
-    // (key press, programmatic focus change).
-    const removeFocusListener = listen(
-      document.body,
-      'focus',
-      event => {
-        if (!menuRef.current.contains(event.target)) {
-          closeMenu();
-        }
-      },
-      { useCapture: true }
-    );
-
-    // Close menu if user clicks outside menu, even if on an element which
-    // does not accept focus.
-    const removeClickListener = listen(
-      document.body,
-      ['mousedown', 'click'],
-      event => {
-        // nb. Mouse events inside the current menu are handled elsewhere.
-        if (!menuRef.current.contains(event.target)) {
-          closeMenu();
-        }
-      },
-      { useCapture: true }
-    );
-
-    return () => {
-      removeKeypressListener();
-      removeClickListener();
-      removeFocusListener();
-    };
-  }, [closeMenu, isOpen]);
-
+  useComponentShouldClose(menuRef, isOpen, closeMenu);
   const stopPropagation = e => e.stopPropagation();
 
   // Close menu if user presses a key which activates menu items.


### PR DESCRIPTION
This is a quick-and-dirty hack of a possible approach for a hook to make some logic in the `Menu` component reusable—handle `document` interactions that indicate that a user wants to exit/close a component.

I'm looking for a sanity check that I'm not going about this totally wrong: violating some rule of hook authoring, or doing something silly with state that's going to cause problems.

Right now the hook wholesale wraps a `useEffect` hook—is this all wrong?

Also, naming was hard. Let me know if any better ideas.