### PR TITLE
Show focus ring on annotator toolbar buttons when using keyboard focus

### DIFF
--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -1,10 +1,11 @@
 'use strict';
 
-const configFrom = require('./config/index');
-
 const $ = require('jquery');
 
-// Applications
+// Load polyfill for :focus-visible pseudo-class.
+require('focus-visible');
+
+const configFrom = require('./config/index');
 const Guest = require('./guest');
 const Sidebar = require('./sidebar');
 const PdfSidebar = require('./pdf-sidebar');

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -1,5 +1,6 @@
 @import '../base';
 @import '../mixins/icons';
+@import '../mixins/focus';
 
 @import './adder';
 
@@ -107,6 +108,8 @@ $base-font-size: 14px;
   }
 
   .annotator-frame-button {
+    @include outline-on-keyboard-focus;
+
     transition: background-color 0.25s;
     @include smallshadow;
     background: $white;
@@ -126,7 +129,6 @@ $base-font-size: 14px;
 
     &:focus,
     &:hover {
-      outline: 0;
       color: $text-color;
     }
   }


### PR DESCRIPTION
Apply the pattern used by the sidebar's horizontal toolbar and menus of
showing a focus ring around tab-focused items, but only when they
have been given focus via the keyboard.

**Testing:**

Go to http://localhost:3000 and click on the buttons in the vertical toolbar. They should work the same as before. Now use the keyboard to focus them, you should see a focus ring whereas on master you won't.

<img width="584" alt="Screenshot 2019-11-08 11 23 51" src="https://user-images.githubusercontent.com/2458/68473376-bd816300-021a-11ea-9bfa-7793c26e9e55.png">