### PR TITLE
Add changeFocusModeUser action

### DIFF
--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -8,6 +8,12 @@
  * - The current filter query
  */
 
+/**
+ * @typedef User
+ * @property {string} username - Unique user's username
+ * @property {string} displayName - User's display name
+ */
+
 'use strict';
 
 const { createSelector } = require('reselect');
@@ -114,7 +120,7 @@ function init(settings) {
     selectedTab: TAB_DEFAULT,
 
     focusMode: {
-      enabled: settings.hasOwnProperty('focus'), // readonly
+      enabled: settings.hasOwnProperty('focus'),
       focused: true,
       // Copy over the focus confg from settings object
       config: { ...(settings.focus ? settings.focus : {}) },
@@ -158,6 +164,19 @@ const update = {
       focusMode: {
         ...state.focusMode,
         focused: action.focused,
+      },
+    };
+  },
+
+  CHANGE_FOCUS_MODE_USER: function(state, action) {
+    return {
+      focusMode: {
+        ...state.focusMode,
+        enabled: true,
+        focused: true,
+        config: {
+          user: { ...action.user },
+        },
       },
     };
   },
@@ -344,6 +363,18 @@ function setFocusModeFocused(focused) {
   };
 }
 
+/**
+ * Changes the focused user and sets focused enabled to `true`.
+ *
+ * @param {User} user - The user to focus on
+ */
+function changeFocusModeUser(user) {
+  return {
+    type: actions.CHANGE_FOCUS_MODE_USER,
+    user,
+  };
+}
+
 /** Sets the sort key for the annotation list. */
 function setSortKey(key) {
   return {
@@ -469,6 +500,7 @@ module.exports = {
     setCollapsed: setCollapsed,
     setFilterQuery: setFilterQuery,
     setFocusModeFocused: setFocusModeFocused,
+    changeFocusModeUser: changeFocusModeUser,
     setForceVisible: setForceVisible,
     setSortKey: setSortKey,
     toggleSelectedAnnotations: toggleSelectedAnnotations,

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -201,6 +201,20 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
+  describe('changeFocusModeUser()', function() {
+    it('sets the focused user and enables focus mode', function() {
+      store.setFocusModeFocused(false);
+      store.changeFocusModeUser({
+        username: 'testuser',
+        displayName: 'Test User',
+      });
+      assert.equal(store.focusModeUsername(), 'testuser');
+      assert.equal(store.focusModeUserPrettyName(), 'Test User');
+      assert.equal(store.focusModeFocused(), true);
+      assert.equal(store.focusModeEnabled(), true);
+    });
+  });
+
   describe('setFocusModeFocused()', function() {
     it('sets the focus mode to enabled', function() {
       store.setFocusModeFocused(true);


### PR DESCRIPTION
We need to make 2 changes to the client to get rpc calls to focus a user.

1. Modify the cross-origin-rpc file (server) to be able to call store actions with a provided list of params. Per RCP spec, this seems like a reasonable, but minimal approach -- as long as the origin is allowed, we call the the method if its found in the store actions.  This no longer returns anything but "ok" because actions are async and we don't hang around for action to finish (but we would I suppose)

2. Added a new action called `changeFocusModeUser` which simply changes the user and forces the `enabled`flag to be true

relates to https://github.com/hypothesis/lms/issues/1136