### PR TITLE
Update core-js to current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "codecov": "^3.1.0",
     "coffeeify": "^2.1.0",
     "commander": "^4.0.1",
-    "core-js": "^2.5.7",
+    "core-js": "^3.4.1",
     "cross-env": "^6.0.0",
     "custom-event": "^1.0.1",
     "diff": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2420,12 +2420,12 @@ core-js-pure@3.1.4:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.4.tgz#5fa17dc77002a169a3566cc48dc774d2e13e3769"
   integrity sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==
 
-core-js@^2.4.0, core-js@^2.5.7:
+core-js@^2.4.0:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
   integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
 
-core-js@^3.0.0:
+core-js@^3.0.0, core-js@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.1.tgz#76dd6828412900ab27c8ce0b22e6114d7ce21b18"
   integrity sha512-KX/dnuY/J8FtEwbnrzmAjUYgLqtk+cxM86hfG60LGiW3MmltIc2yAmDgBgEkfm0blZhUrdr1Zd84J2Y14mLxzg==


### PR DESCRIPTION
This package provides polyfills for new ES/DOM APIs for use in IE 11.
This was held back to a v2.x version due to a conflict with fetch-mock
that is now resolved.

- [x] Test this locally with IE 11 (eg. using Sauce Labs) and verify everything still works