### PR TITLE
Extract `ShareLinks` component

### DIFF
--- a/src/sidebar/components/share-annotations-panel.js
+++ b/src/sidebar/components/share-annotations-panel.js
@@ -7,6 +7,7 @@ const { copyText } = require('../util/copy-to-clipboard');
 const { withServices } = require('../util/service-context');
 const uiConstants = require('../ui-constants');
 
+const ShareLinks = require('./share-links');
 const SidebarPanel = require('./sidebar-panel');
 const SvgIcon = require('./svg-icon');
 
@@ -40,14 +41,6 @@ function ShareAnnotationsPanel({ analytics, flash }) {
       group.id
     }`;
   })(mainFrame, focusedGroup);
-
-  // This is the double-encoded format needed for other services (the entire
-  // URI needs to be encoded because it's used as the value of querystring params)
-  const encodedURI = encodeURIComponent(shareURI);
-
-  const trackShareClick = shareTarget => {
-    analytics.track(analytics.events.DOCUMENT_SHARED, shareTarget);
-  };
 
   const copyShareLink = () => {
     try {
@@ -114,46 +107,10 @@ function ShareAnnotationsPanel({ analytics, flash }) {
               <em>Only Me</em>) annotations are only visible to you.
             </span>
           </p>
-          <ul className="share-annotations-panel-links">
-            <li className="share-annotations-panel-links__link">
-              <a
-                href={`https://twitter.com/intent/tweet?url=${encodedURI}&hashtags=annotated`}
-                title="Tweet share link"
-                onClick={trackShareClick('twitter')}
-              >
-                <SvgIcon
-                  name="twitter"
-                  className="share-annotations-panel-links__icon"
-                />
-              </a>
-            </li>
-            <li className="share-annotations-panel__link">
-              <a
-                href={`https://www.facebook.com/sharer/sharer.php?u=${encodedURI}`}
-                title="Share on Facebook"
-                onClick={trackShareClick('facebook')}
-              >
-                <SvgIcon
-                  name="facebook"
-                  className="share-annotations-panel-links__icon"
-                />
-              </a>
-            </li>
-            <li className="share-annotations-panel__link">
-              <a
-                href={`mailto:?subject=${encodeURIComponent(
-                  "Let's Annotate"
-                )}&body=${encodedURI}`}
-                title="Share via email"
-                onClick={trackShareClick('email')}
-              >
-                <SvgIcon
-                  name="email"
-                  className="share-annotations-panel-links__icon"
-                />
-              </a>
-            </li>
-          </ul>
+          <ShareLinks
+            shareURI={shareURI}
+            analyticsEventName={analytics.events.DOCUMENT_SHARED}
+          />
         </div>
       )}
     </SidebarPanel>

--- a/src/sidebar/components/share-links.js
+++ b/src/sidebar/components/share-links.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const propTypes = require('prop-types');
+const { createElement } = require('preact');
+
+const { withServices } = require('../util/service-context');
+
+const SvgIcon = require('./svg-icon');
+
+/**
+ * A list of share links to social-media platforms.
+ */
+function ShareLinks({ analytics, analyticsEventName, shareURI }) {
+  const trackShareClick = shareTarget => {
+    analytics.track(analyticsEventName, shareTarget);
+  };
+
+  // This is the double-encoded format needed for other services (the entire
+  // URI needs to be encoded because it's used as the value of querystring params)
+  const encodedURI = encodeURIComponent(shareURI);
+
+  return (
+    <ul className="share-links">
+      <li className="share-links__link">
+        <a
+          href={`https://twitter.com/intent/tweet?url=${encodedURI}&hashtags=annotated`}
+          title="Tweet share link"
+          onClick={trackShareClick('twitter')}
+        >
+          <SvgIcon name="twitter" className="share-links__icon" />
+        </a>
+      </li>
+      <li className="share-links__link">
+        <a
+          href={`https://www.facebook.com/sharer/sharer.php?u=${encodedURI}`}
+          title="Share on Facebook"
+          onClick={trackShareClick('facebook')}
+        >
+          <SvgIcon name="facebook" className="share-links__icon" />
+        </a>
+      </li>
+      <li className="share-links__link">
+        <a
+          href={`mailto:?subject=${encodeURIComponent(
+            "Let's Annotate"
+          )}&body=${encodedURI}`}
+          title="Share via email"
+          onClick={trackShareClick('email')}
+        >
+          <SvgIcon name="email" className="share-links__icon" />
+        </a>
+      </li>
+    </ul>
+  );
+}
+
+ShareLinks.propTypes = {
+  /** Analytics event to track when share links are clicked */
+  analyticsEventName: propTypes.string.isRequired,
+  /** URI to shared resource(s), e.g. an annotation or collection of annotations */
+  shareURI: propTypes.string.isRequired,
+
+  // Services/injected
+  analytics: propTypes.object.isRequired,
+};
+
+ShareLinks.injectedProps = ['analytics'];
+
+module.exports = withServices(ShareLinks);

--- a/src/sidebar/components/test/share-annotations-panel-test.js
+++ b/src/sidebar/components/test/share-annotations-panel-test.js
@@ -174,43 +174,4 @@ describe('ShareAnnotationsPanel', () => {
       });
     });
   });
-
-  describe('other share links', () => {
-    const shareLink =
-      'https://hyp.is/go?url=https%3A%2F%2Fwww.example.com&group=testprivate';
-    const encodedLink = encodeURIComponent(shareLink);
-    const encodedSubject = encodeURIComponent("Let's Annotate");
-
-    [
-      {
-        service: 'facebook',
-        expectedURI: `https://www.facebook.com/sharer/sharer.php?u=${encodedLink}`,
-        title: 'Share on Facebook',
-      },
-      {
-        service: 'twitter',
-        expectedURI: `https://twitter.com/intent/tweet?url=${encodedLink}&hashtags=annotated`,
-        title: 'Tweet share link',
-      },
-      {
-        service: 'email',
-        expectedURI: `mailto:?subject=${encodedSubject}&body=${encodedLink}`,
-        title: 'Share via email',
-      },
-    ].forEach(testCase => {
-      it(`creates a share link for ${testCase.service} and tracks clicks`, () => {
-        const wrapper = createShareAnnotationsPanel();
-
-        const link = wrapper.find(`a[title="${testCase.title}"]`);
-        link.simulate('click');
-
-        assert.equal(link.prop('href'), testCase.expectedURI);
-        assert.calledWith(
-          fakeAnalytics.track,
-          fakeAnalytics.events.DOCUMENT_SHARED,
-          testCase.service
-        );
-      });
-    });
-  });
 });

--- a/src/sidebar/components/test/share-links-test.js
+++ b/src/sidebar/components/test/share-links-test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const { createElement } = require('preact');
+const { mount } = require('enzyme');
+
+const ShareLinks = require('../share-links');
+const mockImportedComponents = require('./mock-imported-components');
+
+describe('ShareLinks', () => {
+  let fakeAnalytics;
+  const shareLink =
+    'https://hyp.is/go?url=https%3A%2F%2Fwww.example.com&group=testprivate';
+
+  const createComponent = props =>
+    mount(
+      <ShareLinks
+        analyticsEventName="potato-peeling"
+        analytics={fakeAnalytics}
+        shareURI={shareLink}
+        {...props}
+      />
+    );
+
+  beforeEach(() => {
+    fakeAnalytics = {
+      track: sinon.stub(),
+    };
+
+    ShareLinks.$imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    ShareLinks.$imports.$restore();
+  });
+
+  const encodedLink = encodeURIComponent(shareLink);
+  const encodedSubject = encodeURIComponent("Let's Annotate");
+
+  [
+    {
+      service: 'facebook',
+      expectedURI: `https://www.facebook.com/sharer/sharer.php?u=${encodedLink}`,
+      title: 'Share on Facebook',
+    },
+    {
+      service: 'twitter',
+      expectedURI: `https://twitter.com/intent/tweet?url=${encodedLink}&hashtags=annotated`,
+      title: 'Tweet share link',
+    },
+    {
+      service: 'email',
+      expectedURI: `mailto:?subject=${encodedSubject}&body=${encodedLink}`,
+      title: 'Share via email',
+    },
+  ].forEach(testCase => {
+    it(`creates a share link for ${testCase.service} and tracks clicks`, () => {
+      const wrapper = createComponent({ shareURI: shareLink });
+
+      const link = wrapper.find(`a[title="${testCase.title}"]`);
+      link.simulate('click');
+
+      assert.equal(link.prop('href'), testCase.expectedURI);
+      assert.calledWith(
+        fakeAnalytics.track,
+        'potato-peeling',
+        testCase.service
+      );
+    });
+  });
+});

--- a/src/styles/sidebar/components/share-links.scss
+++ b/src/styles/sidebar/components/share-links.scss
@@ -1,0 +1,10 @@
+@use '../../mixins/links';
+
+.share-links {
+  @include links.footer-links;
+
+  &__icon {
+    width: 24px;
+    height: 24px;
+  }
+}

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -45,6 +45,7 @@ $base-line-height: 20px;
 @import './components/selection-tabs';
 @import './components/share-annotations-panel';
 @import './components/search-input';
+@import './components/share-links';
 @import './components/sidebar-panel';
 @import './components/svg-icon';
 @import './components/spinner';


### PR DESCRIPTION
~~Depends on https://github.com/hypothesis/client/pull/1505~~

Part of https://github.com/hypothesis/client/issues/1201

This second rearranging-deck-chairs PR toward https://github.com/hypothesis/client/issues/1201 extracts a new `ShareLinks` component from the existing `ShareAnnotationsPanel` component.

It turns out that the functionality for sharing a single annotation vs. multiple annotations on social media and email isn't just similar, it's identical (shown here in the recently-updated `ShareAnnotationsPanel`—which is affected in this PR—and the in-progress prototyped `AnnotationShareControl` component, which is WIP):

<img width="469" alt="Screen Shot 2019-11-18 at 4 08 43 PM" src="https://user-images.githubusercontent.com/439947/69094483-6cdde700-0a1e-11ea-8c3b-05d4fee0cdd8.png">

Thus, this PR extracts those sharing links as a reusable component.
