### PR TITLE
Add new preact tag editor component

### DIFF
--- a/src/sidebar/components/tag-editor2.js
+++ b/src/sidebar/components/tag-editor2.js
@@ -1,0 +1,226 @@
+'use strict';
+
+const { createElement } = require('preact');
+const propTypes = require('prop-types');
+const { useRef, useState } = require('preact/hooks');
+
+const { withServices } = require('../util/service-context');
+const SvgIcon = require('./svg-icon');
+
+/**
+ * Component to both render and edit annotation tags. Tags may be added or
+ * removed from any given annotation. This component also renders suggested
+ * tags which use  the `tags` service to set or get previously used tags to
+ * local storage.
+ */
+function TagEditor2({
+  id,
+  editMode,
+  isThirdParty,
+  onEditTags,
+  serviceUrl,
+  tags: tagsService,
+  tagList,
+}) {
+  const inputEl = useRef(null);
+  const [suggestions, setSuggestions] = useState([]);
+
+  /**
+   * Builds a uri link for a specific tag name.
+   * @param {string} tag
+   */
+  const createTagSearchURL = tag => {
+    if (isThirdParty) {
+      return null;
+    }
+    return serviceUrl('search.tag', { tag: tag });
+  };
+
+  /**
+   * Passes the tags list to the provided callback `onEditTags` so it may
+   * be saved to the service. Also passes the list to `tagsService.store`
+   * so it may be presented as a future suggestion if its not already
+   * one.
+   *
+   * @param {Array<string>} tagList
+   */
+  const saveTags = tagList => {
+    // save suggested tags
+    tagsService.store(tagList.map(tag => ({ text: tag })));
+    // set the new tag to the annotation
+    onEditTags({ tags: tagList });
+  };
+
+  /**
+   * Remove a tag.
+   *
+   * @param {string} tag
+   */
+  const deleteTag = tag => {
+    const newTagList = [...tagList]; // make a copy
+    const index = newTagList.indexOf(tag);
+    newTagList.splice(index, 1);
+    saveTags(newTagList);
+  };
+
+  /**
+   * Adds a new local tag equal to the value of the input field only
+   * if its not already in the `tagList`.
+   */
+  const addTag = () => {
+    const value = inputEl.current.value.trim();
+    if (value.length === 0) {
+      // don't add an empty tag
+      return;
+    }
+    if (tagList.indexOf(value) >= 0) {
+      // don't add duplicate tag
+      return;
+    }
+    setSuggestions([]);
+    saveTags([...tagList, value]);
+
+    // clear the input field and maintain focus
+    inputEl.current.value = '';
+    inputEl.current.focus();
+  };
+
+  /**
+   *  If the user pressed enter or comma, add a new tag.
+   */
+  const handleKeyPress = e => {
+    if (e.key === 'Enter' || e.key === ',') {
+      addTag();
+      // preventDefault stops the delimiter from being
+      // added to the input field
+      e.preventDefault();
+    }
+  };
+  /**
+   *  As the user types, change the suggestions query
+   *  based on the value of inputEl.
+   */
+  const handleKeyUp = e => {
+    if (e.key) {
+      const queryList = tagsService.filter(inputEl.current.value);
+      const querySet = [];
+      // create a set with no duplicates
+      for (let i = 0; i < queryList.length; i++) {
+        if (tagList.indexOf(queryList[i]) < 0) {
+          querySet.push(queryList[i]);
+        }
+      }
+      setSuggestions(querySet);
+    } else if (e.type === 'keyup') {
+      // assume the user selected an option from datalist
+      addTag();
+    }
+  };
+
+  const buildTagItem = tag => {
+    if (editMode) {
+      return (
+        <li key={`${tag}`} className="tag-editor__tag-item" aria-label={`Tag: ${tag}`}>
+          <span className="tag-editor__edit">{tag}</span>
+          <button
+            onClick={deleteTag.bind(this, tag)}
+            title="Delete tag from this annotation"
+            className="tag-editor__delete"
+          >
+            <SvgIcon name="cancel" />
+          </button>
+        </li>
+      );
+    } else {
+      return (
+        <li 
+        key={`${tag}`} className="tag-editor__tag-item" aria-label={`Tag: ${tag}`}>
+          <a
+            className="tag-editor__link"
+            href={createTagSearchURL(tag)}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {tag}
+          </a>
+        </li>
+      );
+    }
+  };
+
+  const buildTagList = () => {
+    const tagElements = tagList.map(buildTagItem)
+    return (
+      <ul className="tag-editor__tag-list" aria-label="Annotation tags">
+        {tagElements}
+      </ul>
+    );
+  };
+
+  const buildSuggestionsList = () => {
+    const suggestionElements = suggestions.map((suggestion, index) => 
+      (<option key={index} value={suggestion} />)
+    );
+    return (
+      <datalist
+        id={`tag-editor-datalist-${id}`}
+        className="tag-editor__suggestions"
+        aria-label="Annotation suggestions"
+      >
+        {suggestionElements}
+      </datalist>
+    );
+  };
+
+  return (
+    <section className="TagEditor">
+      {buildTagList()}
+      {editMode && (
+        <input
+          list={`tag-editor-datalist-${id}`}
+          onBlur={handleKeyUp}
+          onKeyUp={handleKeyUp}
+          onKeyPress={handleKeyPress}
+          ref={inputEl}
+          placeholder="Add tags..."
+          className="tag-editor__input"
+          type="text"
+        />
+      )}
+      {buildSuggestionsList()}
+    </section>
+  );
+}
+
+/**
+ * @typedef Tag
+ * @param tag {string} - The tag text
+ */
+
+TagEditor2.propTypes = {
+  /* Parent annotation's unique id. */
+  id: propTypes.string,
+
+  /* Is this a hypothesis client or not? */
+  isThirdParty: propTypes.bool,
+
+  /* Either editing the tags, or viewing the tags. */
+  editMode: propTypes.bool,
+  /**
+   *  Callback that saves the tag list.
+   *
+   *  @param {Array<Tag>} - Array of tags to save
+   */
+  onEditTags: propTypes.func,
+
+  /* List of tags as strings. */
+  tagList: propTypes.array,
+
+  /** Services */
+  tags: propTypes.object,
+  serviceUrl: propTypes.func,
+};
+
+TagEditor2.injectedProps = ['serviceUrl', 'tags'];
+
+module.exports = withServices(TagEditor2);

--- a/src/sidebar/components/tag-editor2.js
+++ b/src/sidebar/components/tag-editor2.js
@@ -120,11 +120,17 @@ function TagEditor2({
   const buildTagItem = tag => {
     if (editMode) {
       return (
-        <li key={`${tag}`} className="tag-editor__tag-item" aria-label={`Tag: ${tag}`}>
+        <li
+          key={`${tag}`}
+          className="tag-editor__tag-item"
+          aria-label={`Tag: ${tag}`}
+        >
           <span className="tag-editor__edit">{tag}</span>
           <button
-            onClick={deleteTag.bind(this, tag)}
-            title="Delete tag from this annotation"
+            onClick={() => {
+              deleteTag(tag);
+            }}
+            title={`Remove Tag: ${tag}`}
             className="tag-editor__delete"
           >
             <SvgIcon name="cancel" />
@@ -133,12 +139,12 @@ function TagEditor2({
       );
     } else {
       return (
-        <li 
-        key={`${tag}`} className="tag-editor__tag-item" aria-label={`Tag: ${tag}`}>
+        <li key={`${tag}`} className="tag-editor__tag-item">
           <a
             className="tag-editor__link"
             href={createTagSearchURL(tag)}
             target="_blank"
+            aria-label={`Tag: ${tag}`}
             rel="noopener noreferrer"
           >
             {tag}
@@ -149,7 +155,7 @@ function TagEditor2({
   };
 
   const buildTagList = () => {
-    const tagElements = tagList.map(buildTagItem)
+    const tagElements = tagList.map(buildTagItem);
     return (
       <ul className="tag-editor__tag-list" aria-label="Annotation tags">
         {tagElements}
@@ -158,9 +164,9 @@ function TagEditor2({
   };
 
   const buildSuggestionsList = () => {
-    const suggestionElements = suggestions.map((suggestion, index) => 
-      (<option key={index} value={suggestion} />)
-    );
+    const suggestionElements = suggestions.map((suggestion, index) => (
+      <option key={index} value={suggestion} />
+    ));
     return (
       <datalist
         id={`tag-editor-datalist-${id}`}
@@ -173,7 +179,7 @@ function TagEditor2({
   };
 
   return (
-    <section className="TagEditor">
+    <section className="tag-editor">
       {buildTagList()}
       {editMode && (
         <input

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -1156,65 +1156,6 @@ describe('annotation', function() {
       });
     });
 
-    describe('tag display', function() {
-      beforeEach('make serviceUrl() return a URL for the tag', function() {
-        fakeServiceUrl
-          .withArgs('search.tag', { tag: 'atag' })
-          .returns('https://hypothes.is/search?q=tag:atag');
-      });
-
-      /**
-       * Return an annotation directive with a single tag.
-       */
-      function annotationWithOneTag() {
-        return createDirective(
-          Object.assign(fixtures.defaultAnnotation(), {
-            tags: ['atag'],
-          })
-        );
-      }
-
-      /**
-       * Return the one tag link element from the given annotation directive.
-       */
-      function tagLinkFrom(directive) {
-        const links = [].slice.apply(
-          directive.element[0].querySelectorAll('a')
-        );
-        const tagLinks = links.filter(function(link) {
-          return link.textContent === 'atag';
-        });
-        assert.equal(tagLinks.length, 1);
-        return tagLinks[0];
-      }
-
-      context('when the annotation is first-party', function() {
-        beforeEach('configure a first-party annotation', function() {
-          fakeAccountID.isThirdPartyUser.returns(false);
-        });
-
-        it('displays links to tag search pages', function() {
-          const tagLink = tagLinkFrom(annotationWithOneTag());
-
-          assert.equal(tagLink.href, 'https://hypothes.is/search?q=tag:atag');
-        });
-      });
-
-      context('when the annotation is third-party', function() {
-        beforeEach('configure a third-party annotation', function() {
-          fakeAccountID.isThirdPartyUser.returns(true);
-        });
-
-        it("doesn't link tags for third-party annotations", function() {
-          // Tag search pages aren't supported for third-party annotations in
-          // h, so we don't link to them in the client.
-          const tagLink = tagLinkFrom(annotationWithOneTag());
-
-          assert.isFalse(tagLink.hasAttribute('href'));
-        });
-      });
-    });
-
     describe('annotation links', function() {
       it('uses the in-context links when available', function() {
         const annotation = Object.assign({}, fixtures.defaultAnnotation(), {

--- a/src/sidebar/components/test/tag-editor2-test.js
+++ b/src/sidebar/components/test/tag-editor2-test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const { mount } = require('enzyme');
+const { createElement } = require('preact');
+
+const events = require('../../events');
+const TagEditor2 = require('../new-note-btn');
+const mockImportedComponents = require('./mock-imported-components');
+
+describe('TagEditor2', function() {
+
+  let fakeTagsService;
+  let fakeServiceUrl;
+  let fakeOnEditTags;
+  
+  function createComponent() {
+    return mount(
+      <TagEditor2
+        // props
+        id={'annotation_id'}
+        editMode={false}
+        isThirdParty={false}
+        onEditTags={fakeOnEditTags}
+        tagList={['tag1', 'tag2']}
+        // service props
+        serviceUrl={fakeServiceUrl}
+        tags={fakeTagsService}
+        
+      />
+    );
+  }
+
+  beforeEach(function() {
+    fakeOnEditTags = sinon.stub();
+    fakeServiceUrl = sinon.stub();
+    fakeTagsService = {
+      filter: sinon.stub(),
+      store: sinon.stub(),
+    };
+    
+
+    TagEditor2.$imports.$mock(mockImportedComponents());
+    /*TagEditor2.$imports.$mock({
+      //'../store/use-store': callback => callback(fakeStore),
+      './SvgIcon': sinon.stub()
+    });*/
+  });
+
+  afterEach(() => {
+    TagEditor2.$imports.$restore();
+  });
+
+  describe('when editMode is false', function() {
+    it('creates the read only component', () => {
+      const wrapper = createComponent();
+      //console.log(wrapper.debug());
+      //assert.include(wrapper.text(), 'New note');
+    });
+  });
+});

--- a/src/sidebar/components/test/tag-editor2-test.js
+++ b/src/sidebar/components/test/tag-editor2-test.js
@@ -1,19 +1,17 @@
 'use strict';
 
-const { mount } = require('enzyme');
 const { createElement } = require('preact');
+const { mount } = require('enzyme');
 
-const events = require('../../events');
-const TagEditor2 = require('../new-note-btn');
 const mockImportedComponents = require('./mock-imported-components');
+const TagEditor2 = require('../tag-editor2');
 
 describe('TagEditor2', function() {
-
   let fakeTagsService;
   let fakeServiceUrl;
   let fakeOnEditTags;
-  
-  function createComponent() {
+
+  function createComponent(props) {
     return mount(
       <TagEditor2
         // props
@@ -25,36 +23,330 @@ describe('TagEditor2', function() {
         // service props
         serviceUrl={fakeServiceUrl}
         tags={fakeTagsService}
-        
+        {...props}
       />
     );
   }
 
   beforeEach(function() {
     fakeOnEditTags = sinon.stub();
-    fakeServiceUrl = sinon.stub();
+    fakeServiceUrl = sinon.stub().returns('http://serviceurl.com');
     fakeTagsService = {
-      filter: sinon.stub(),
+      filter: sinon.stub().returns(['tag3', 'tag4']),
       store: sinon.stub(),
     };
-    
 
     TagEditor2.$imports.$mock(mockImportedComponents());
-    /*TagEditor2.$imports.$mock({
-      //'../store/use-store': callback => callback(fakeStore),
-      './SvgIcon': sinon.stub()
-    });*/
   });
 
   afterEach(() => {
     TagEditor2.$imports.$restore();
   });
 
-  describe('when editMode is false', function() {
-    it('creates the read only component', () => {
+  context('when editMode is false', function() {
+    it('adds appropriate class names and tag values to the elements', () => {
       const wrapper = createComponent();
-      //console.log(wrapper.debug());
-      //assert.include(wrapper.text(), 'New note');
+      assert.equal(
+        wrapper
+          .find('a.tag-editor__link')
+          .at(0)
+          .text(),
+        'tag1'
+      );
+      assert.equal(
+        wrapper
+          .find('a.tag-editor__link')
+          .at(1)
+          .text(),
+        'tag2'
+      );
+    });
+
+    it('adds appropriate aria values to the elements', () => {
+      const wrapper = createComponent();
+      assert.equal(
+        wrapper
+          .find('.tag-editor__tag-item a')
+          .at(0)
+          .prop('aria-label'),
+        'Tag: tag1'
+      );
+      assert.equal(
+        wrapper
+          .find('.tag-editor__tag-item a')
+          .at(1)
+          .prop('aria-label'),
+        'Tag: tag2'
+      );
+    });
+
+    it('renders the href when isThirdParty is false', () => {
+      const wrapper = createComponent();
+      assert.equal(
+        wrapper
+          .find('a.tag-editor__link')
+          .at(0)
+          .prop('href'),
+        'http://serviceurl.com'
+      );
+      assert.equal(
+        wrapper
+          .find('a.tag-editor__link')
+          .at(1)
+          .prop('href'),
+        'http://serviceurl.com'
+      );
+
+      assert.calledWith(fakeServiceUrl, 'search.tag', { tag: 'tag1' });
+      assert.calledWith(fakeServiceUrl, 'search.tag', { tag: 'tag2' });
+
+      it('does not render the href when isThirdParty is true', () => {
+        const wrapper = createComponent({ isThirdParty: true });
+        assert.equal(
+          wrapper
+            .find('a.tag-editor__link')
+            .at(0)
+            .prop('href'),
+          undefined
+        );
+        assert.equal(
+          wrapper
+            .find('a.tag-editor__link')
+            .at(1)
+            .prop('href'),
+          undefined
+        );
+
+        assert.notCalled(fakeServiceUrl);
+      });
+    });
+  });
+
+  context('when editMode is true', function() {
+    it('adds appropriate class names and tag values to the elements', () => {
+      const wrapper = createComponent({ editMode: true });
+      assert.equal(
+        wrapper
+          .find('.tag-editor__edit')
+          .at(0)
+          .text(),
+        'tag1'
+      );
+      assert.equal(
+        wrapper
+          .find('.tag-editor__edit')
+          .at(1)
+          .text(),
+        'tag2'
+      );
+    });
+
+    it('adds appropriate aria values to the elements', () => {
+      const wrapper = createComponent({ editMode: true });
+      assert.equal(
+        wrapper
+          .find('.tag-editor__tag-item')
+          .at(0)
+          .prop('aria-label'),
+        'Tag: tag1'
+      );
+      assert.equal(
+        wrapper
+          .find('.tag-editor__tag-item')
+          .at(1)
+          .prop('aria-label'),
+        'Tag: tag2'
+      );
+    });
+
+    it('creates the component with a unique id', () => {
+      const wrapper = createComponent({ editMode: true });
+      assert.equal(
+        wrapper.find('input').prop('list'),
+        'tag-editor-datalist-annotation_id'
+      );
+    });
+
+    it('calls fakeTagsService.filter with the value from the input field', () => {
+      const wrapper = createComponent({ editMode: true });
+      wrapper.find('input').instance().value = 'tag3';
+      // simulate `keyup` to populate suggestions list
+      wrapper.find('input').simulate('keyup', { key: 'any' });
+      assert.isTrue(fakeTagsService.filter.calledWith('tag3'));
+    });
+
+    it('generates a datalist set equal to the array value returned from fakeTagsService.filter ', () => {
+      const wrapper = createComponent({ editMode: true });
+      // simulate `keyup` to populate suggestions list
+      wrapper.find('input').simulate('keyup', { key: 'any' });
+
+      assert.equal(
+        wrapper
+          .find('datalist option')
+          .at(0)
+          .prop('value'),
+        'tag3'
+      );
+      assert.equal(
+        wrapper
+          .find('datalist option')
+          .at(1)
+          .prop('value'),
+        'tag4'
+      );
+    });
+
+    it('clears the suggestions when adding a new tag', () => {
+      const wrapper = createComponent({ editMode: true });
+      wrapper.find('input').instance().value = 'tag3';
+      // simulate `keyup` to populate suggestions list
+      wrapper.find('input').simulate('keyup', { key: 'any' });
+      assert.equal(wrapper.find('datalist option').length, 2);
+      wrapper.find('input').simulate('keyup'); // no key supplied
+      assert.equal(wrapper.find('datalist option').length, 0);
+
+      assert.isTrue(
+        fakeTagsService.store.calledWith([
+          { text: 'tag1' },
+          { text: 'tag2' },
+          { text: 'tag3' },
+        ])
+      );
+    });
+
+    it('does not render duplicate suggestions', () => {
+      // `tag3` supplied in the `tagList` will be a duplicate value relative
+      // with the fakeTagsService.filter result above.
+      const wrapper = createComponent({
+        editMode: true,
+        tagList: ['tag1', 'tag2', 'tag3'],
+      });
+      // simulate `keyup` to populate suggestions list
+      wrapper.find('input').simulate('keyup', { key: 'any' });
+      assert.equal(wrapper.find('datalist option').length, 1);
+      assert.equal(
+        wrapper
+          .find('datalist option')
+          .at(0)
+          .prop('value'),
+        'tag4'
+      );
+    });
+
+    context('when adding tags', () => {
+      /**
+       * Helper function to assert that a tag was correctly added
+       */
+      const addTagsSavedSuccess = (wrapper, tagList) => {
+        // saves the suggested tags to the service
+        assert.isTrue(
+          fakeTagsService.store.calledWith(tagList.map(tag => ({ text: tag })))
+        );
+        // called the onEditTags callback prop
+        assert.isTrue(fakeOnEditTags.calledWith({ tags: tagList }));
+        // clears out the suggestions
+        assert.equal(wrapper.find('datalist option').length, 0);
+        // assert the input value is cleared out
+        assert.equal(wrapper.find('input').instance().value, '');
+        // note: focus not tested
+      };
+      /**
+       * Helper function to assert that a tag was correctly not added
+       */
+      const addTagsFail = () => {
+        assert.isTrue(fakeTagsService.store.notCalled);
+        assert.isTrue(fakeOnEditTags.notCalled);
+      };
+
+      it('adds a tag from the input field', () => {
+        const wrapper = createComponent({ editMode: true });
+        wrapper.find('input').instance().value = 'tag3';
+
+        wrapper.find('input').simulate('keyup'); // simulates a selection
+        addTagsSavedSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
+      });
+
+      it('populate the datalist, then adds a tag from the input field', () => {
+        const wrapper = createComponent({ editMode: true });
+        wrapper.find('input').instance().value = 'tag3';
+
+        // simulate `keyup` to populate suggestions list
+        wrapper.find('input').simulate('keyup', { key: 'any' });
+        assert.equal(wrapper.find('datalist option').length, 2);
+
+        wrapper.find('input').simulate('keyup'); // simulates a selection
+        addTagsSavedSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
+      });
+
+      it('should not add a tag if the input is empty', () => {
+        const wrapper = createComponent({ editMode: true });
+        wrapper.find('input').instance().value = '';
+
+        wrapper.find('input').simulate('keyup'); // simulates a selection
+        addTagsFail();
+      });
+
+      it('should not add a tag if the input is blank space', () => {
+        const wrapper = createComponent({ editMode: true });
+        wrapper.find('input').instance().value = '  ';
+        wrapper.find('input').simulate('keyup'); // simulates a selection
+        addTagsFail();
+      });
+
+      it('should not add a tag if its a duplicate of one already in the list', () => {
+        const wrapper = createComponent({ editMode: true });
+        wrapper.find('input').instance().value = 'tag1';
+        wrapper.find('input').simulate('keyup'); // simulates a selection
+        addTagsFail();
+      });
+
+      it('adds a tag via keypress `Enter`', () => {
+        const wrapper = createComponent({ editMode: true });
+        wrapper.find('input').instance().value = 'tag3';
+
+        wrapper.find('input').simulate('keypress', { key: 'Enter' });
+        addTagsSavedSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
+      });
+
+      it('adds a tag via keypress `,`', () => {
+        const wrapper = createComponent({ editMode: true });
+        wrapper.find('input').instance().value = 'tag3';
+
+        wrapper.find('input').simulate('keypress', { key: ',' });
+        addTagsSavedSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
+      });
+
+      it('does not add a tag when key is not `,` or  `Enter`', () => {
+        const wrapper = createComponent({ editMode: true });
+        wrapper.find('input').instance().value = 'tag3';
+
+        wrapper.find('input').simulate('keypress', { key: 'e' });
+        addTagsFail();
+      });
+    });
+
+    context('when deleting tags', () => {
+      /**
+       * Helper function to assert that a tag was correctly added
+       */
+      const deleteTagsSavedSuccess = tagList => {
+        // saves the suggested tags to the service
+        assert.isTrue(
+          fakeTagsService.store.calledWith(tagList.map(tag => ({ text: tag })))
+        );
+        // called the onEditTags callback prop
+        assert.isTrue(fakeOnEditTags.calledWith({ tags: tagList }));
+      };
+
+      it('deletes `tag1` when clicking its delete button', () => {
+        const wrapper = createComponent({ editMode: true });
+        assert.equal(wrapper.find('.tag-editor__edit').length, 2);
+        wrapper
+          .find('button')
+          .at(0)
+          .simulate('click');
+        deleteTagsSavedSuccess(['tag2']);
+      });
     });
   });
 });

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -195,6 +195,10 @@ function startAngularApp(config) {
     .component('streamContent', require('./components/stream-content'))
     .component('svgIcon', wrapReactComponent(require('./components/svg-icon')))
     .component('tagEditor', require('./components/tag-editor'))
+    .component(
+      'tagEditor2',
+      wrapReactComponent(require('./components/tag-editor2'))
+    )
     .component('threadList', require('./components/thread-list'))
     .component('topBar', wrapReactComponent(require('./components/top-bar')))
     .directive('hAutofocus', require('./directive/h-autofocus'))

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -38,7 +38,6 @@
       h-branding="accentColor">mire</a>
   </div>
 
-  <!-- Tags-->
   <tag-editor2 
     id="vm.annotation.id"
     edit-mode="vm.editing()"
@@ -47,7 +46,6 @@
     tag-list="vm.state().tags" 
     />
   </tag-editor2>
-  <!-- / Tags-->
 
   <footer class="annotation-footer">
     <div class="annotation-form-actions" ng-if="vm.editing()">

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -30,27 +30,24 @@
     text="vm.state().text">
   </annotation-body>
 
-  <!-- Tags -->
-  <div class="annotation-body form-field" ng-if="vm.editing()">
-    <tag-editor tags="vm.state().tags"
-                on-edit-tags="vm.setTags(tags)"></tag-editor>
-  </div>
-
-  <div class="annotation-body u-layout-row tags tags-read-only"
-       ng-if="(vm.canCollapseBody || vm.state().tags.length) && !vm.editing()">
-    <ul class="tag-list" aria-label="Annotation tags">
-      <li class="tag-item" ng-repeat="tag in vm.state().tags">
-        <a ng-href="{{vm.tagSearchURL(tag)}}" aria-label="Tag: {{tag}}" target="_blank">{{tag}}</a>
-      </li>
-    </ul>
-    <div class="u-stretch"></div>
-    <a class="annotation-link u-strong" ng-show="vm.canCollapseBody"
+  <div class="annotation-link-more">
+    <a class="annotation-link u-strong" ng-show="vm.canCollapseBody && !vm.editing()"
       ng-click="vm.toggleCollapseBody($event)"
       ng-title="vm.collapseBody ? 'Show the full annotation text' : 'Show the first few lines only'"
       ng-bind="vm.collapseBody ? 'More' : 'Less'"
-      h-branding="accentColor"></a>
+      h-branding="accentColor">mire</a>
   </div>
-  <!-- / Tags -->
+
+  <!-- Tags-->
+  <tag-editor2 
+    id="vm.annotation.id"
+    edit-mode="vm.editing()"
+    is-third-party="vm.isThirdParty()"
+    on-edit-tags="vm.setTags(tags)"
+    tag-list="vm.state().tags" 
+    />
+  </tag-editor2>
+  <!-- / Tags-->
 
   <footer class="annotation-footer">
     <div class="annotation-form-actions" ng-if="vm.editing()">

--- a/src/styles/mixins/buttons.scss
+++ b/src/styles/mixins/buttons.scss
@@ -1,4 +1,5 @@
 @use "./focus";
+@use "./selectors";
 @use "../variables" as var;
 
 @mixin reset-native-btn-styles {
@@ -16,6 +17,7 @@
  */
 @mixin action-button($icon-margin: 0 5px) {
   @include reset-native-btn-styles;
+  @include selectors.hover-fade;
   display: flex;
   align-items: center;
   padding: 0.5em;
@@ -24,14 +26,12 @@
   background-color: var.$grey-1;
   color: var.$grey-5;
   font-weight: 700;
-
   &__icon {
     color: var.$grey-5;
     margin: $icon-margin;
   }
 
   &:hover {
-    transition: 0.2s ease-out;
     background-color: var.$grey-2;
     color: var.$grey-6;
   }

--- a/src/styles/mixins/selectors.scss
+++ b/src/styles/mixins/selectors.scss
@@ -1,0 +1,6 @@
+@mixin hover-fade {
+  transition: 0.4s ease-out;
+  &:hover {
+    transition: 0.2s;
+  }
+}

--- a/src/styles/sidebar/components/annotation.scss
+++ b/src/styles/sidebar/components/annotation.scss
@@ -66,6 +66,13 @@
   margin-top: -12px;
 }
 
+.annotation-link-more {
+  display: flex;
+  flex-flow: row-reverse;
+  padding-bottom: 5px;
+  padding-top: 5px;
+}
+
 .annotation-replies:hover {
   .annotation-replies__link {
     text-decoration: underline;

--- a/src/styles/sidebar/components/tag-editor.scss
+++ b/src/styles/sidebar/components/tag-editor.scss
@@ -6,10 +6,10 @@
   color: var.$grey-6;
 
   &__input {
-    @include form-input;
+    @include forms.form-input;
     width: 100%;
     &:focus {
-      @include form-input-focus;
+      @include forms.form-input-focus;
     }
   }
 

--- a/src/styles/sidebar/components/tag-editor.scss
+++ b/src/styles/sidebar/components/tag-editor.scss
@@ -1,0 +1,57 @@
+@use "../../mixins/forms";
+@use "../../variables" as var;
+
+.tag-editor {
+  cursor: default;
+  color: var.$grey-6;
+
+  &__input {
+    @include form-input;
+    width: 100%;
+    &:focus {
+      @include form-input-focus;
+    }
+  }
+
+  &__tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    margin-top: -0.33em; // Absorb the first row of margin-top on the tags.
+  }
+
+  &__tag-item {
+    display: flex;
+    margin-right: 0.5em;
+    margin-bottom: 0.5em;
+  }
+
+  &__edit,
+  &__link {
+    text-decoration: none;
+    border: 1px solid var.$grey-4;
+    border-radius: 2px 0 0 2px;
+    border-right-width: 0;
+    padding: 0.2em 0.5em;
+    color: var.$grey-6;
+    background: var.$grey-2;
+  }
+
+  &__link {
+    border-width: 1px;
+    background: var.$grey-3;
+    &:hover,
+    &:focus {
+      color: var.$link-color-hover;
+    }
+  }
+
+  &__delete {
+    appearance: none;
+    text-decoration: none;
+    border: 1px solid var.$grey-4;
+    border-radius: 0 2px 2px 0;
+    padding: 0.2em 0.5em;
+    color: var.$grey-6;
+    background: var.$grey-3;
+  }
+}

--- a/src/styles/sidebar/components/tag-editor.scss
+++ b/src/styles/sidebar/components/tag-editor.scss
@@ -1,10 +1,8 @@
 @use "../../mixins/forms";
+@use "../../mixins/buttons";
 @use "../../variables" as var;
 
 .tag-editor {
-  cursor: default;
-  color: var.$grey-6;
-
   &__input {
     @include forms.form-input;
     width: 100%;
@@ -16,7 +14,6 @@
   &__tag-list {
     display: flex;
     flex-wrap: wrap;
-    margin-top: -0.33em; // Absorb the first row of margin-top on the tags.
   }
 
   &__tag-item {
@@ -28,30 +25,35 @@
   &__edit,
   &__link {
     text-decoration: none;
-    border: 1px solid var.$grey-4;
-    border-radius: 2px 0 0 2px;
+    border: 1px solid var.$grey-3;
+    border-radius: 4px 0 0 4px;
     border-right-width: 0;
     padding: 0.2em 0.5em;
     color: var.$grey-6;
-    background: var.$grey-2;
+    background: var.$grey-1;
   }
 
   &__link {
     border-width: 1px;
-    background: var.$grey-3;
+    background: var.$grey-1;
+    border-radius: 4px;
     &:hover,
     &:focus {
-      color: var.$link-color-hover;
+      border-color: var.$grey-5;
+      color: var.$brand;
     }
   }
 
   &__delete {
+    @include buttons.action-button;
     appearance: none;
     text-decoration: none;
-    border: 1px solid var.$grey-4;
-    border-radius: 0 2px 2px 0;
+    border: 1px solid var.$grey-3;
+    border-radius: 0 4px 4px 0;
     padding: 0.2em 0.5em;
-    color: var.$grey-6;
-    background: var.$grey-3;
+    &:hover,
+    &:focus {
+      border-color: var.$grey-5;
+    }
   }
 }

--- a/src/styles/sidebar/elements.scss
+++ b/src/styles/sidebar/elements.scss
@@ -1,9 +1,11 @@
+@use "../mixins/selectors";
 @use "../variables" as var;
 
 // basic standard styling for elements
 a {
   color: var.$link-color;
   text-decoration: none;
+  @include selectors.hover-fade;
 }
 
 a:active,

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -55,6 +55,7 @@
 @use './components/sidebar-panel';
 @use './components/svg-icon';
 @use './components/spinner';
+@use './components/tag-editor';
 @use './components/tags-input';
 @use './components/thread-list';
 @use './components/tooltip';


### PR DESCRIPTION
This is a bare bones first pass at this re-write. Its largely the same with just a few css differences to follow the pattern lib. It does not use a custom dropdown/autocomplete component like the ng version, and instead just uses the verbatim `<datalist>` tag -- which seems sufficient for first pass

Todos:
~~- Component name not final.~~
~~- CSS is not final.~~
~~- A11y is not complete, just roughed in.~~
~~- Tests not written.~~
- Old component not ripped out.
- Error with ff and safari when adding tag via `enter`

I mostly want to get some eyes on the first pass to make sure its intuitive in its implementation and functionally meets the requirements of the tag component and more or less matches the existing behavior of the angular component.

