### PR TITLE
Remove (some) deprecated SCSS color variables

### DIFF
--- a/src/styles/forms.scss
+++ b/src/styles/forms.scss
@@ -201,14 +201,6 @@
   padding: 2px;
 }
 
-// a light grey cancel/remove button which darkens on hover
-.btn--cancel {
-  color: $color-silver;
-  &:hover {
-    color: darken($color-silver, 15%);
-  }
-}
-
 // Handles state transitions from "default" -> "loading" -> "success"
 [status-button-state] .btn-message {
   top: -999em;

--- a/src/styles/mixins/forms.scss
+++ b/src/styles/mixins/forms.scss
@@ -82,7 +82,7 @@
 }
 
 @mixin primary-action-btn {
-  color: $color-seashell;
+  color: $grey-1;
   background-color: $color-dove-gray;
   height: 35px;
   border: none;

--- a/src/styles/sidebar/components/annotation-publish-control.scss
+++ b/src/styles/sidebar/components/annotation-publish-control.scss
@@ -2,10 +2,13 @@
   display: flex;
 
   &__cancel-btn {
-    @extend .btn--cancel;
-
     margin-left: 5px;
     font-weight: normal;
+    color: $grey-4;
+
+    &:hover {
+      color: $grey-5;
+    }
 
     &__icon {
       margin-right: 3px;

--- a/src/styles/sidebar/components/annotation-publish-control.scss
+++ b/src/styles/sidebar/components/annotation-publish-control.scss
@@ -16,7 +16,7 @@
   // A split button with a primary submit on the left and a drop-down menu
   // of related options to the right
   .annotation-publish-control__btn {
-    $text-color: $color-seashell;
+    $text-color: $grey-1;
     $default-background-color: $color-dove-gray;
     $hover-background-color: $color-mine-shaft;
     $h-padding: 9px;

--- a/src/styles/sidebar/components/primary-action-btn.scss
+++ b/src/styles/sidebar/components/primary-action-btn.scss
@@ -9,7 +9,7 @@
 }
 
 .primary-action-btn__icon {
-  color: $color-silver-chalice;
+  color: $grey-4;
   display: inline-block;
   font-weight: bold;
   margin-left: -3px;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -15,7 +15,6 @@ $gray-lightest: #f9f9f9 !default;
 $color-mine-shaft: #3a3a3a;
 $color-dove-gray: #626262;
 $color-gray: #818181;
-$color-silver-chalice: #a6a6a6;
 $color-silver: #bbb;
 
 // Colors

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -17,7 +17,6 @@ $color-dove-gray: #626262;
 $color-gray: #818181;
 $color-silver-chalice: #a6a6a6;
 $color-silver: #bbb;
-$color-seashell: #f1f1f1;
 
 // Colors
 // ---------------------

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -10,14 +10,12 @@ $gray: #777 !default;
 $gray-dark: #585858;
 $gray-light: #969696 !default;
 $gray-lighter: #d3d3d3 !default;
-$gray-lightest: #f9f9f9 !default;
 
 $color-mine-shaft: #3a3a3a;
 $color-dove-gray: #626262;
 $color-gray: #818181;
 // Colors
 // ---------------------
-$color-cardinal: #bd1c2b;
 $brand-color: #bd1c2b !default;
 
 $button-text-color: $gray-dark !default;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -15,8 +15,6 @@ $gray-lightest: #f9f9f9 !default;
 $color-mine-shaft: #3a3a3a;
 $color-dove-gray: #626262;
 $color-gray: #818181;
-$color-silver: #bbb;
-
 // Colors
 // ---------------------
 $color-cardinal: #bd1c2b;


### PR DESCRIPTION
This small housekeeping PR removes some lesser-used, deprecated SCSS color variables. There should only be the most negligible user-visible difference in the removal of `$color-seashell` and replacement with `$grey-1`: `#f1f1f1` to `#f2f2f2`, respectively, in one or two tiny elements. If anyone can actually spot that change with the naked eye, you should take up a career in color theory!

More to come here, but this works towards a Q4 objective of normalizing color palette use.