### PR TITLE
WIP: Add ability to exclude components from mocking

### DIFF
--- a/src/sidebar/components/test/mock-imported-components.js
+++ b/src/sidebar/components/test/mock-imported-components.js
@@ -39,6 +39,8 @@ function getDisplayName(component) {
  * `Widget`). They will render only their children, as if they were just a
  * `Fragment`.
  *
+ * Components may be excluded (not mocked) by using the `exclude` parameter.
+ *
  * @example
  *   beforeEach(() => {
  *     ComponentUnderTest.$imports.$mock(mockImportedComponents());
@@ -50,9 +52,11 @@ function getDisplayName(component) {
  *     ComponentUnderTest.$imports.$restore();
  *   });
  *
+ * @param {string[]} exclude - An Array of component displayNames that
+ *                             should not be mocked.
  * @return {Function} - A function that can be passed to `$imports.$mock`.
  */
-function mockImportedComponents() {
+function mockImportedComponents(exclude = []) {
   return (source, symbol, value) => {
     if (!isComponent(value)) {
       return null;
@@ -60,6 +64,9 @@ function mockImportedComponents() {
 
     const mock = props => props.children;
     mock.displayName = getDisplayName(value);
+    if (exclude.includes(mock.displayName)) {
+      return null;
+    }
 
     return mock;
   };


### PR DESCRIPTION
I've run into an applied case in which it is necessary to mock some, but not _all_ of a component's imported components.

This PR adds an optional parameter to the `mockImportedComponents` function that takes an Array of component `displayName`s that should be excluded from mocking.

If you need justification, an example follows:

----

In the forthcoming `AnnotationShareControl` component, the toggling open/closed of the element is handled by using an `AnnotationActionButton` within `AnnotationShareControl` itself. A simplified look at its (`AnnotationShareControl`'s) render:

```
    <div className="annotation-share-control" ref={shareRef}>
      <AnnotationActionButton
        icon="h-icon-annotation-share"
        isDisabled={false}
        label="Share"
        onClick={toggleSharePanel}
      />
      {isOpen && (
        <div className="annotation-share-panel">
        { /* ...and so on */ }
 ```

The only way to open the panel—and thus render the whole component, all of the stuff inside `.annotation-share-panel`—is for the `AnnotationActionButton`'s `onClick` to be invoked, which can only be effected externally by simulating a `click` on it.

Thus in this case, in tests, I need `AnnotationActionButton` to be _not_ mocked (for at least some of the tests) so it can be clicked, but the rest of the imported components _do_ need to be mocked still.

I think this situation could also arise if we extracted out (as proposed) an `IconButton` or similar component. Presumably that component would take an `onClick` whose behavior may be relevant to components that use it.