### PR TITLE
Make simple fix to `AnnotationShareControl` to suppress errors on logout

### DIFF
--- a/src/sidebar/components/annotation-share-control.js
+++ b/src/sidebar/components/annotation-share-control.js
@@ -45,6 +45,11 @@ function AnnotationShareControl({
     }
   }, [isOpen]);
 
+  // FIXME: See https://github.com/hypothesis/client/issues/1542
+  if (!group) {
+    return null;
+  }
+
   const copyShareLink = () => {
     try {
       copyText(shareUri);
@@ -127,8 +132,12 @@ function AnnotationShareControl({
 }
 
 AnnotationShareControl.propTypes = {
-  /** group that the annotation is in */
-  group: propTypes.object.isRequired,
+  /** group that the annotation is in
+   *  If missing, this component will not render
+   *  FIXME: Refactor after root cause is addressed
+   *  See https://github.com/hypothesis/client/issues/1542
+   */
+  group: propTypes.object,
   /** Is this annotation set to "only me"/private? */
   isPrivate: propTypes.bool.isRequired,
   /** The URI to view the annotation on its own */

--- a/src/sidebar/components/test/annotation-share-control-test.js
+++ b/src/sidebar/components/test/annotation-share-control-test.js
@@ -75,6 +75,11 @@ describe('AnnotationShareControl', () => {
     AnnotationShareControl.$imports.$restore();
   });
 
+  it('does not render component if `group` prop not OK', () => {
+    const wrapper = createComponent({ group: undefined });
+    assert.equal(wrapper.html(), '');
+  });
+
   it('does not render content when not open', () => {
     const wrapper = createComponent();
 


### PR DESCRIPTION
Add a quick fix so that users will not see an error on logout when there
is a temporary state of the app during which the `group` prop may be
undefined.

Part of https://github.com/hypothesis/client/issues/1542