### PR TITLE
Refactor `AnnotationBody` and `AnnotationQuote` styles

### DIFF
--- a/src/sidebar/components/annotation-body.js
+++ b/src/sidebar/components/annotation-body.js
@@ -14,7 +14,6 @@ function AnnotationBody({
   collapse,
   isEditing,
   isHiddenByModerator,
-  hasContent,
   onCollapsibleChanged,
   onEditText,
   onToggleCollapsed,
@@ -35,7 +34,7 @@ function AnnotationBody({
             markdown={text}
             textClass={{
               'annotation-body is-hidden': isHiddenByModerator,
-              'has-content': hasContent,
+              'has-content': text.length > 0,
             }}
           />
         </Excerpt>
@@ -55,15 +54,6 @@ AnnotationBody.propTypes = {
   collapse: propTypes.bool,
 
   /**
-   * Whether to show moderated content, if `isHiddenByModerator` is true or
-   * a placeholder otherwise.
-   *
-   * This will be `true` if the current user is a moderator of the annotation's
-   * group. For non-moderators the content is not exposed via the API.
-   */
-  hasContent: propTypes.bool,
-
-  /**
    * Whether to display the body in edit mode (if true) or view mode.
    */
   isEditing: propTypes.bool,
@@ -71,6 +61,10 @@ AnnotationBody.propTypes = {
   /**
    * `true` if the contents of this annotation body have been redacted by
    * a moderator.
+   *
+   * For redacted annotations, the text is shown struck-through (if available)
+   * or replaced by a placeholder indicating redacted content (if `text` is
+   * empty).
    */
   isHiddenByModerator: propTypes.bool,
 

--- a/src/sidebar/components/annotation-body.js
+++ b/src/sidebar/components/annotation-body.js
@@ -33,7 +33,8 @@ function AnnotationBody({
           <MarkdownView
             markdown={text}
             textClass={{
-              'annotation-body is-hidden': isHiddenByModerator,
+              'annotation-body__text': true,
+              'is-hidden': isHiddenByModerator,
               'has-content': text.length > 0,
             }}
           />

--- a/src/sidebar/components/annotation-quote.js
+++ b/src/sidebar/components/annotation-quote.js
@@ -14,7 +14,7 @@ const Excerpt = require('./excerpt');
 function AnnotationQuote({ isOrphan, quote, settings = {} }) {
   return (
     <section
-      className={classnames('annotation-quote-list', isOrphan && 'is-orphan')}
+      className={classnames('annotation-quote', isOrphan && 'is-orphan')}
     >
       <Excerpt
         collapsedHeight={35}
@@ -22,7 +22,7 @@ function AnnotationQuote({ isOrphan, quote, settings = {} }) {
         overflowThreshold={20}
       >
         <blockquote
-          className="annotation-quote"
+          className="annotation-quote__quote"
           style={applyTheme(['selectionFontFamily'], settings)}
         >
           {quote}

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -159,7 +159,6 @@ describe('annotation', function() {
         .component('annotationBody', {
           bindings: {
             collapse: '<',
-            hasContent: '<',
             isEditing: '<',
             isHiddenByModerator: '<',
             onCollapsibleChanged: '&',
@@ -1270,7 +1269,6 @@ describe('annotation', function() {
           text: 'Some offensive content',
         }),
         isHiddenByModerator: true,
-        hasContent: true,
       },
       {
         context: 'for non-moderators',
@@ -1280,16 +1278,14 @@ describe('annotation', function() {
           text: '',
         }),
         isHiddenByModerator: true,
-        hasContent: false,
       },
-    ].forEach(({ ann, context, isHiddenByModerator, hasContent }) => {
+    ].forEach(({ ann, context, isHiddenByModerator }) => {
       it(`passes moderation status to annotation body (${context})`, () => {
         const el = createDirective(ann).element;
         assert.match(
           el.find('annotation-body').controller('annotationBody'),
           sinon.match({
             isHiddenByModerator,
-            hasContent,
           })
         );
       });

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -21,7 +21,6 @@
 
   <annotation-body
     collapse="vm.collapseBody"
-    has-content="vm.hasContent()"
     is-editing="vm.editing()"
     is-hidden-by-moderator="vm.isHiddenByModerator()"
     on-collapsible-changed="vm.setBodyCollapsible(collapsible)"

--- a/src/styles/sidebar/components/annotation-body.scss
+++ b/src/styles/sidebar/components/annotation-body.scss
@@ -1,0 +1,38 @@
+@use '../../variables' as var;
+
+.annotation-body {
+  @include var.font-normal;
+  color: var.$grey-6;
+  // Margin between top of ascent of annotation body and
+  // bottom of ascent of annotation-quote should be ~15px.
+  margin-top: var.$layout-h-margin - 5px;
+  margin-bottom: var.$layout-h-margin;
+  margin-right: 0px;
+  margin-left: 0px;
+}
+
+.annotation-body__text {
+  // Hidden annotations displayed to moderators, where the content is still
+  // present.
+  &.is-hidden.has-content {
+    text-decoration: line-through;
+    filter: grayscale(100%) contrast(65%);
+  }
+
+  // Hidden annotations displayed to non-moderators, where the content has been
+  // filtered out by the service.
+  &.is-hidden:not(.has-content) {
+    // Create a column of horizontal stripes, giving the impression of text
+    // underneath that has been censored.
+    display: block;
+    height: 60px;
+    width: 100vw;
+    background: repeating-linear-gradient(
+      to bottom,
+      var.$grey-2,
+      var.$grey-2 15px,
+      white 15px,
+      white 20px
+    );
+  }
+}

--- a/src/styles/sidebar/components/annotation-quote.scss
+++ b/src/styles/sidebar/components/annotation-quote.scss
@@ -1,0 +1,29 @@
+@use '../../variables' as var;
+
+.annotation-quote {
+  // Margin between top of ascent of annotation quote and
+  // bottom of ascent of username should be ~15px
+  margin-top: var.$layout-h-margin - 5px;
+  // Margin between bottom of ascent of annotation quote and
+  // top of ascent of annotation-body should be ~15px
+  margin-bottom: var.$layout-h-margin - 3px;
+}
+
+.annotation-quote.is-orphan {
+  text-decoration: line-through;
+}
+
+.annotation-quote__quote {
+  @include var.font-normal;
+
+  border-left: 3px solid var.$gray-lighter;
+  color: var.$grey-4;
+  font-family: sans-serif;
+  font-size: 12px;
+  font-style: italic;
+  letter-spacing: 0.1px;
+  padding: 0 1em;
+
+  // Prevent long URLs etc. in quote causing overflow
+  overflow-wrap: break-word;
+}

--- a/src/styles/sidebar/components/annotation.scss
+++ b/src/styles/sidebar/components/annotation.scss
@@ -2,20 +2,8 @@
 @use "../../mixins/icons";
 @use "../../variables" as var;
 
-@mixin quote {
-  @include var.font-normal;
-
-  border-left: 3px solid var.$gray-lighter;
-  color: var.$grey-4;
-  font-family: sans-serif;
-  font-size: 12px;
-  font-style: italic;
-  letter-spacing: 0.1px;
-  padding: 0 1em;
-}
-
 // Highlight quote of annotation whenever its thread is hovered
-.thread-list__card:hover .annotation-quote {
+.thread-list__card:hover .annotation-quote__quote {
   border-left: var.$highlight 3px solid;
 }
 
@@ -72,43 +60,8 @@
   }
 }
 
-.annotation-quote-list,
 .annotation-footer {
   @include forms.pie-clearfix;
-}
-
-.annotation-body {
-  @include var.font-normal;
-  color: var.$grey-6;
-  // Margin between top of ascent of annotation body and
-  // bottom of ascent of annotation-quote should be ~15px.
-  margin-top: var.$layout-h-margin - 5px;
-  margin-bottom: var.$layout-h-margin;
-  margin-right: 0px;
-  margin-left: 0px;
-}
-
-// Hidden annotations displayed to moderators, where the content is still
-// present.
-.annotation-body.is-hidden.has-content {
-  text-decoration: line-through;
-  filter: grayscale(100%) contrast(65%);
-}
-
-// Hidden annotations displayed to non-moderators, where the content has been
-// filtered out by the service.
-.annotation-body.is-hidden:not(.has-content) {
-  // Create a column of horizontal stripes, giving the impression of text
-  // underneath that has been censored.
-  display: block;
-  height: 60px;
-  background: repeating-linear-gradient(
-    to bottom,
-    var.$grey-2,
-    var.$grey-2 15px,
-    white 15px,
-    white 20px
-  );
 }
 
 // the footer at the bottom of an annotation displaying
@@ -121,19 +74,6 @@
 
 .u-flex-spacer {
   flex-grow: 1;
-}
-
-.annotation-quote-list {
-  // Margin between top of ascent of annotation quote and
-  // bottom of ascent of username should be ~15px
-  margin-top: var.$layout-h-margin - 5px;
-  // Margin between bottom of ascent of annotation quote and
-  // top of ascent of annotation-body should be ~15px
-  margin-bottom: var.$layout-h-margin - 3px;
-}
-
-.annotation-quote-list.is-orphan {
-  text-decoration: line-through;
 }
 
 .annotation-media-embed {
@@ -167,13 +107,6 @@
   &[disabled] {
     opacity: 0.2;
   }
-}
-
-.annotation-quote {
-  @include quote;
-
-  // Prevent long URLs etc. in quote causing overflow
-  overflow-wrap: break-word;
 }
 
 .annotation-citation-domain {

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -26,11 +26,13 @@
 // ----------
 @use './components/action-button';
 @use './components/annotation';
+@use './components/annotation-body';
 @use './components/annotation-document-info';
 @use './components/annotation-header';
+@use './components/annotation-publish-control';
+@use './components/annotation-quote';
 @use './components/annotation-share-control';
 @use './components/annotation-share-info';
-@use './components/annotation-publish-control';
 @use './components/annotation-thread';
 @use './components/annotation-user';
 @use './components/excerpt';


### PR DESCRIPTION
This PR includes a couple of pieces of cleanup following the conversion of the `Excerpt` component:

- To follow project conventions, move the annotation body and quote styles out of `annotation.scss` and into their own files and refactor to use BEM-ish naming.
- Remove an unnecessary `hasContent` prop that `AnnotationBody` has. This prop exists to determine whether a moderated annotation is being seen by a moderator, in which case the text will be present and is shown struck-through, or by a non-moderator, in which case it is replaced by a series of grey bars to indicate redacted content. This prop is unnecessary because it can be determined by checking whether the `text` prop is empty or not

After these changes, `annotation.scss` still contains a small number of references to quote and body styles in order to implement custom styling for these elements when annotations are hovered or if they are replies.