### PR TITLE
Fix module load error on pages defining `require`

### DIFF
--- a/scripts/gulp/create-bundle.js
+++ b/scripts/gulp/create-bundle.js
@@ -135,8 +135,8 @@ module.exports = function createBundle(config, buildOpts) {
     .readFileSync(defaultPreludePath)
     .toString()
     .replace(
-      'var previousRequire = typeof require == "function" && require;',
-      `var previousRequire = typeof ${externalRequireName} == "function" && ${externalRequireName};`
+      /typeof require == "function" && require/g,
+      `typeof ${externalRequireName} == "function" && ${externalRequireName};`
     );
   if (!prelude.includes(externalRequireName)) {
     throw new Error(


### PR DESCRIPTION
There are two expressions which reference a global `require` function in
the Browserify prelude. Both of them need to be rewritten to use
`hypothesisRequire` instead. Previously only the first use was
rewritten, which worked as long as the page didn't define its own
`require` function. On https://qa.hypothes.is/search for example, h's
JavaScript bundles do.