### PR TITLE
Use fragment instead of query to pass config to sidebar app

### DIFF
--- a/src/annotator/host.coffee
+++ b/src/annotator/host.coffee
@@ -27,10 +27,8 @@ module.exports = class Host extends Guest
     configParam = 'config=' + encodeURIComponent(
       JSON.stringify(Object.assign({}, config, {sidebarAppUrl: undefined, pluginClasses: undefined }))
     )
-    if config.sidebarAppUrl and '?' in config.sidebarAppUrl
-      sidebarAppSrc = config.sidebarAppUrl + '&' + configParam
-    else
-      sidebarAppSrc = config.sidebarAppUrl + '?' + configParam
+
+    sidebarAppSrc = config.sidebarAppUrl + '#' + configParam
 
     # Create the iframe
     app = $('<iframe></iframe>')

--- a/src/annotator/test/host-test.coffee
+++ b/src/annotator/test/host-test.coffee
@@ -78,7 +78,7 @@ describe 'Host', ->
       appURL = new URL('/base/annotator/test/empty.html', window.location.href)
       host = createHost({annotations: '1234'})
       configStr = encodeURIComponent(JSON.stringify({annotations: '1234'}))
-      assert.equal(host.frame[0].children[0].src, appURL + '?config=' + configStr)
+      assert.equal(host.frame[0].children[0].src, appURL + '#config=' + configStr)
 
     it 'adds drop shadow if the clean theme is enabled', ->
       host = createHost({theme: 'clean'})

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -7,7 +7,8 @@ const queryString = require('query-string');
  * client.
  */
 function hostPageConfig(window) {
-  const configJSON = queryString.parse(window.location.search).config;
+  const configStr = window.location.hash.slice(1);
+  const configJSON = queryString.parse(configStr).config;
   const config = JSON.parse(configJSON || '{}');
 
   // Known configuration parameters which we will import from the host page.

--- a/src/sidebar/test/host-config-test.js
+++ b/src/sidebar/test/host-config-test.js
@@ -5,7 +5,7 @@ const hostPageConfig = require('../host-config');
 function fakeWindow(config) {
   return {
     location: {
-      search: '?config=' + JSON.stringify(config),
+      hash: '#config=' + JSON.stringify(config),
     },
   };
 }


### PR DESCRIPTION
Use a URL fragment rather than query string to pass configuration from
the host page to the sidebar app.

This means that the `src` attribute for the sidebar iframe will be `https://hypothes.is/app.html#config=...` rather than `https://hypothes.is/app.html?config=...`.

Only the client, not h, needs access to this configuration, but passing
it in a query string causes this information to act as a cache-buster
for what should be a highly-cacheable resource
(https://hypothes.is/app.html). The long query string also ends up
polluting reports in tools like Google Analytics and h access logs.

The content and format of the config string remains the same, only the
delivery method has changed.

Relevant context: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1575447372326000