### PR TITLE
Remove Hypothesis-Client-Version header from "trivial" API requests

### DIFF
--- a/src/sidebar/services/api-routes.js
+++ b/src/sidebar/services/api-routes.js
@@ -14,12 +14,11 @@ function apiRoutes(settings) {
   let linkCache;
 
   function getJSON(url) {
-    const config = {
-      headers: {
-        'Hypothesis-Client-Version': '__VERSION__', // replaced by versionify
-      },
-    };
-    return fetch(url, config).then(response => {
+    // nb. The `/api/` and `/api/links` routes are fetched without specifying
+    // any additional headers/config so that we can use `<link rel="preload">` in
+    // the `/app.html` response to fetch them early, while the client JS app
+    // is loading.
+    return fetch(url).then(response => {
       if (response.status !== 200) {
         throw new Error(`Fetching ${url} failed`);
       }

--- a/src/sidebar/services/test/api-routes-test.js
+++ b/src/sidebar/services/test/api-routes-test.js
@@ -91,14 +91,6 @@ describe('sidebar.api-routes', () => {
         assert.deepEqual(routes, apiIndexResponse.links);
       });
     });
-
-    it('sends client version custom request header', () => {
-      return apiRoutes.routes().then(() => {
-        assert.calledWith(window.fetch, fakeSettings.apiUrl, {
-          headers: { 'Hypothesis-Client-Version': '__VERSION__' },
-        });
-      });
-    });
   });
 
   describe('#links', () => {


### PR DESCRIPTION
Remove the custom headers from the `/api/` and `/api/links` API requests
so that we can preload these routes very early in the sidebar app's
startup process using `<link rel="preload">` (which can't set custom headers, see https://github.com/hypothesis/h/pull/5862), thus reducing the number
of roundtrips required before showing annotations.

My understanding is that the original motivations for adding this header (see [1]) were mostly concerned with requests which trigger real work on the backend, whereas these requests don't, and should in most cases be able to be served from a short-term cache by Cloudflare.

For context, this was prompted by the analysis in https://hypothes-is.slack.com/archives/C4K6M7P5E/p1575447372326000.

[1] See https://github.com/hypothesis/client/pull/930.