### PR TITLE
Avoid effect in tag list

### DIFF
--- a/src/sidebar/components/tag-list.js
+++ b/src/sidebar/components/tag-list.js
@@ -2,7 +2,7 @@
 
 const { createElement } = require('preact');
 const propTypes = require('prop-types');
-const { useEffect, useState } = require('preact/hooks');
+const { useMemo } = require('preact/hooks');
 
 const { isThirdPartyUser } = require('../util/account-id');
 const { withServices } = require('../util/service-context');
@@ -11,13 +11,11 @@ const { withServices } = require('../util/service-context');
  * Component to render an annotation's tags.
  */
 function TagList({ annotation, serviceUrl, settings, tags }) {
-  // Should we show a linked tag or just a text tag?
-  const [renderLink, setRenderLink] = useState(false);
-
-  useEffect(() => {
+  const renderLink = useMemo(
     // Show a link if the authority of the user is not 3rd party
-    setRenderLink(!isThirdPartyUser(annotation.user, settings.authDomain));
-  }, [annotation, settings]);
+    () => !isThirdPartyUser(annotation.user, settings.authDomain),
+    [annotation, settings]
+  );
 
   /**
    * Returns a uri link for a specific tag name.


### PR DESCRIPTION
Simplify and optimize `TagList` a little by determining whether to
render a link directly during the render rather than using an effect.

Effects (if using `useEffect` rather than `useLayoutEffect`) get run after the component is mounted into the DOM and painted. In this context this means that, for first party users, the tags would initially be rendered as spans and then a moment later, they would be switched to links. If the links and spans were styled differently (which I don't think they currently are), the user would see a brief flash of the "wrong" element. Either way, this change avoids a little bit of unnecessary work for the browser.

If there was another reason for using state/an effect here that I overlooked, please let me know.