### PR TITLE
Add charset token to Content-Type header for client files deployed to S3

### DIFF
--- a/scripts/deploy-to-s3.js
+++ b/scripts/deploy-to-s3.js
@@ -17,7 +17,7 @@ const TEXT_MIME_TYPES = {
   '.md': 'text/markdown',
   '.js': 'application/javascript',
   '.json': 'application/json',
-  '.map': 'application/octet-stream',
+  '.map': 'application/json',
   '.svg': 'image/svg+xml',
 };
 

--- a/scripts/deploy-to-s3.js
+++ b/scripts/deploy-to-s3.js
@@ -12,13 +12,16 @@ const AWS = require('aws-sdk');
 /**
  * File extension / mime type associations for file types we actually use.
  */
-const MIME_TYPES = {
+const TEXT_MIME_TYPES = {
   '.css': 'text/css',
   '.md': 'text/markdown',
   '.js': 'application/javascript',
   '.json': 'application/json',
   '.map': 'application/octet-stream',
   '.svg': 'image/svg+xml',
+};
+
+const BINARY_MIME_TYPES = {
   '.woff': 'font/woff',
   '.woff2': 'font/woff2',
 };
@@ -33,9 +36,16 @@ function contentTypeFromFilename(path) {
     return 'text/plain';
   }
 
-  if (MIME_TYPES[extension]) {
-    return MIME_TYPES[extension];
+  let mimeType = TEXT_MIME_TYPES[extension];
+  if (mimeType) {
+    return mimeType + '; charset=UTF-8';
   }
+
+  mimeType = BINARY_MIME_TYPES[extension];
+  if (mimeType) {
+    return mimeType;
+  }
+
   throw new Error(`Unable to look up Content-Type for ${path}`);
 }
 


### PR DESCRIPTION
Add a `charset=UTF-8` token to the `Content-Type` header of client files
deployed to S3. This ensures that characters in JS / CSS / SVG files used in
the host page are interpreted correctly if the host page does not set a
charset itself or sets a non-UTF-8 charset.

Fixes #1547

----

I have tested this locally as follows (note the "1.0.0-dummy-version" string comes from `package.json` and is overridden for normal releases):

```shellsession
$ export AWS_ACCESS_KEY_ID=<credentials for cdn.hypothes.is>
$ export AWS_SECRET_ACCESS_KEY=<credentials for cdn.hypothes.is>
$ env NODE_ENV=production gulp build
$ ./scripts/deploy-to-s3.js --bucket cdn.hypothes.is --tag testing

$ curl -I 'https://cdn.hypothes.is/hypothesis/1.0.0-dummy-version/build/styles/annotator.css'
HTTP/2 200
date: Thu, 05 Dec 2019 15:15:05 GMT
content-type: text/css; charset=UTF-8
...

$ curl -I 'https://cdn.hypothes.is/hypothesis/1.0.0-dummy-version/build/fonts/h.woff'
HTTP/2 200
date: Thu, 05 Dec 2019 15:15:47 GMT
content-type: font/woff
...
```

