### PR TITLE
Fix click callback in `ShareLinks` to not track analytics events until clicked

### DIFF
--- a/src/sidebar/components/share-links.js
+++ b/src/sidebar/components/share-links.js
@@ -12,7 +12,9 @@ const SvgIcon = require('./svg-icon');
  */
 function ShareLinks({ analytics, analyticsEventName, shareURI }) {
   const trackShareClick = shareTarget => {
-    analytics.track(analyticsEventName, shareTarget);
+    return () => {
+      analytics.track(analyticsEventName, shareTarget);
+    };
   };
 
   // This is the double-encoded format needed for other services (the entire

--- a/src/sidebar/components/test/share-links-test.js
+++ b/src/sidebar/components/test/share-links-test.js
@@ -57,9 +57,16 @@ describe('ShareLinks', () => {
       const wrapper = createComponent({ shareURI: shareLink });
 
       const link = wrapper.find(`a[title="${testCase.title}"]`);
-      link.simulate('click');
 
       assert.equal(link.prop('href'), testCase.expectedURI);
+
+      // Assure tracking doesn't happen until clicked
+      // See https://github.com/hypothesis/client/issues/1566
+      assert.notCalled(fakeAnalytics.track);
+
+      // Now click...
+      link.simulate('click');
+
       assert.calledWith(
         fakeAnalytics.track,
         'potato-peeling',


### PR DESCRIPTION
Faulty construction of a click callback in each `ShareLinks` link was
causing analytics tracking of associated events when the component loads,
not on click.

Fixes https://github.com/hypothesis/client/issues/1566