### PR TITLE
Add standardized hover transition

### DIFF
--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -4,6 +4,7 @@
 @use '../mixins/focus';
 @use '../mixins/reset';
 @use '../mixins/shadow';
+@use '../mixins/effects';
 
 @use './adder';
 @use './bucket-bar';
@@ -110,9 +111,9 @@ var.$base-font-size: 14px;
   }
 
   .annotator-frame-button {
+    @include effects.hover-fade;
     @include focus.outline-on-keyboard-focus;
 
-    transition: background-color 0.25s;
     @include shadow.smallshadow;
     background: var.$white;
     border: solid 1px var.$gray-lighter;

--- a/src/styles/mixins/buttons.scss
+++ b/src/styles/mixins/buttons.scss
@@ -1,4 +1,5 @@
 @use "./focus";
+@use "./effects";
 @use "../variables" as var;
 
 @mixin reset-native-btn-styles {
@@ -15,6 +16,7 @@
  */
 @mixin button-base {
   @include reset-native-btn-styles;
+  @include effects.hover-fade;
   padding: 0.5em;
   color: var.$grey-5;
 

--- a/src/styles/mixins/effects.scss
+++ b/src/styles/mixins/effects.scss
@@ -1,0 +1,9 @@
+/**
+ * Standard hover fade in/out effect for anything clickable
+ */
+@mixin hover-fade {
+  transition: 0.25s ease-out;
+  &:hover {
+    transition: 0.1s;
+  }
+}

--- a/src/styles/mixins/forms.scss
+++ b/src/styles/mixins/forms.scss
@@ -1,3 +1,4 @@
+@use "./effects";
 @use "../variables" as var;
 
 /* Style input placeholders */
@@ -59,6 +60,7 @@
 }
 
 @mixin btn {
+  @include effects.hover-fade;
   box-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
 
   background: linear-gradient(var.$button-background-gradient);
@@ -95,6 +97,7 @@
 }
 
 @mixin primary-action-btn {
+  @include effects.hover-fade;
   color: var.$grey-1;
   background-color: var.$color-dove-gray;
   height: 35px;

--- a/src/styles/sidebar/components/annotation-publish-control.scss
+++ b/src/styles/sidebar/components/annotation-publish-control.scss
@@ -1,10 +1,12 @@
 @use "../../mixins/forms";
+@use "../../mixins/effects";
 @use "../../variables" as var;
 
 .annotation-publish-control {
   display: flex;
 
   &__cancel-btn {
+    @include effects.hover-fade;
     margin-left: 5px;
     font-weight: normal;
     color: var.$grey-4;
@@ -59,6 +61,7 @@
     // dropdown arrow which reveals the button's associated menu
     // when clicked
     &-dropdown-arrow {
+      @include effects.hover-fade;
       position: absolute;
       right: 0px;
       top: 0px;

--- a/src/styles/sidebar/components/markdown-editor.scss
+++ b/src/styles/sidebar/components/markdown-editor.scss
@@ -1,3 +1,4 @@
+@use '../mixins/effects';
 @use "../../variables" as var;
 
 $toolbar-border: 0.1em solid var.$grey-3;
@@ -20,6 +21,7 @@ $toolbar-border: 0.1em solid var.$grey-3;
 }
 
 .markdown-editor__toolbar-button {
+  @include effects.hover-fade;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -51,12 +53,14 @@ $toolbar-border: 0.1em solid var.$grey-3;
 }
 
 .markdown-editor__preview {
+  @include effects.hover-fade;
   border: $toolbar-border;
   background-color: var.$grey-1;
   padding: 10px;
 }
 
 .markdown-editor__toolbar-help-link {
+  @include effects.hover-fade;
   display: flex;
   align-items: center;
   margin-bottom: 2px; // Tweak to align help icon better with adjacent buttons

--- a/src/styles/sidebar/components/tag-list.scss
+++ b/src/styles/sidebar/components/tag-list.scss
@@ -24,7 +24,6 @@
     &:hover,
     &:focus {
       color: var.$brand;
-      border-color: var.$grey-4;
     }
   }
 }

--- a/src/styles/sidebar/components/top-bar.scss
+++ b/src/styles/sidebar/components/top-bar.scss
@@ -1,4 +1,5 @@
 @use "../../mixins/buttons";
+@use "../../mixins/effects";
 @use "../../variables" as var;
 
 .top-bar {
@@ -58,7 +59,7 @@
 
 .top-bar__btn {
   @include buttons.reset-native-btn-styles;
-
+  @include effects.hover-fade;
   height: 100%;
   color: var.$gray-light;
   display: inline-block;

--- a/src/styles/sidebar/elements.scss
+++ b/src/styles/sidebar/elements.scss
@@ -1,7 +1,9 @@
+@use "../mixins/effects";
 @use "../variables" as var;
 
 // basic standard styling for elements
 a {
+  @include effects.hover-fade;
   color: var.$link-color;
   text-decoration: none;
 }


### PR DESCRIPTION
- Use effects.hover-fade where appropriate for clickable things
- Remove dark border hover color from tag item

There is no point in making a GIF of this change because it's too fast to be captured that way so you'll need to pull and run locally to see changes.

**The purpose of this diff is 2 fold.**
1. Add a standardized way to set transition timing across all clickable things.
2. Apply that standardization to many of the clickable things. (I don't except to cover them all with one pass)

This does more of a heavy handed transition where it does not specifically call out `color` or `background-color` or `opacity` or anything, but rather asserts that any css property change will be transitioned in 100ms when the mouse is hovering over the element and then revert in 250ms there after. I wanted to keep these somewhat fast because this is a major UI change and I don't want it to feel too much different or slow, but mostly just more polished.

Also removed that dark border on TagList items which didn't match anything. I realize this diverges from the new design but we can circle back to this on a second pass when we do more uniform changes across the UI. It just felt like it stood out too much right now.


