### PR TITLE
Update core-js to current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "codecov": "^3.1.0",
     "coffeeify": "^2.1.0",
     "commander": "^4.0.1",
-    "core-js": "^2.5.7",
+    "core-js": "^3.4.1",
     "cross-env": "^6.0.0",
     "custom-event": "^1.0.1",
     "diff": "^4.0.1",

--- a/src/shared/polyfills/es2015.js
+++ b/src/shared/polyfills/es2015.js
@@ -1,16 +1,20 @@
 'use strict';
 
 // ES2015
-require('core-js/es6/promise');
-require('core-js/es6/map');
-require('core-js/es6/number');
-require('core-js/es6/set');
-require('core-js/es6/symbol');
-require('core-js/fn/array/fill');
-require('core-js/fn/array/find');
-require('core-js/fn/array/find-index');
-require('core-js/fn/array/from');
-require('core-js/fn/object/assign');
-require('core-js/fn/string/includes');
-require('core-js/fn/string/ends-with');
-require('core-js/fn/string/starts-with');
+//
+// nb. The imports which add entire classes (Promise, Set etc.) will also add
+// all features for later ES years, so this can result in some duplication with
+// bundles for later ES years.
+require('core-js/es/promise');
+require('core-js/es/map');
+require('core-js/es/number');
+require('core-js/es/set');
+require('core-js/es/symbol');
+require('core-js/es/array/fill');
+require('core-js/es/array/find');
+require('core-js/es/array/find-index');
+require('core-js/es/array/from');
+require('core-js/es/object/assign');
+require('core-js/es/string/includes');
+require('core-js/es/string/ends-with');
+require('core-js/es/string/starts-with');

--- a/src/shared/polyfills/es2016.js
+++ b/src/shared/polyfills/es2016.js
@@ -1,3 +1,3 @@
 'use strict';
 
-require('core-js/fn/array/includes');
+require('core-js/es/array/includes');

--- a/src/shared/polyfills/es2017.js
+++ b/src/shared/polyfills/es2017.js
@@ -1,4 +1,4 @@
 'use strict';
 
-require('core-js/fn/object/entries');
-require('core-js/fn/object/values');
+require('core-js/es/object/entries');
+require('core-js/es/object/values');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,15 +2310,20 @@ core-js-pure@3.1.4:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.4.tgz#5fa17dc77002a169a3566cc48dc774d2e13e3769"
   integrity sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==
 
-core-js@^2.4.0, core-js@^2.5.7:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
-  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+core-js@^2.4.0:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
+  integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
 
 core-js@^3.0.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.1.tgz#76dd6828412900ab27c8ce0b22e6114d7ce21b18"
   integrity sha512-KX/dnuY/J8FtEwbnrzmAjUYgLqtk+cxM86hfG60LGiW3MmltIc2yAmDgBgEkfm0blZhUrdr1Zd84J2Y14mLxzg==
+
+core-js@^3.4.1:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.8.tgz#e0fc0c61f2ef90cbc10c531dbffaa46dfb7152dd"
+  integrity sha512-b+BBmCZmVgho8KnBUOXpvlqEMguko+0P+kXCwD4vIprsXC6ht1qgPxtb1OK6XgSlrySF71wkwBQ0Hv695bk9gQ==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
This package provides polyfills for new ES/DOM APIs for use in IE 11.
This was held back to a v2.x version due to a conflict with fetch-mock
that is now resolved.

This is an attempt to re-land https://github.com/hypothesis/client/pull/1504. This time I have updated the core-js imports in `src/shared/polyfills/es{2015, 2016, 2017}.js`.