### PR TITLE
Consolidate all grey colors across client application

### DIFF
--- a/src/styles/annotator/adder.scss
+++ b/src/styles/annotator/adder.scss
@@ -110,7 +110,7 @@ $adder-transition-duration: 80ms;
   font-family: h;
   font-size: 18px;
   background: transparent !important;
-  color: var.$gray-dark !important;
+  color: var.$grey-mid !important;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -126,10 +126,10 @@ $adder-transition-duration: 80ms;
 }
 
 .annotator-adder-actions .annotator-adder-actions__button:hover {
-  color: var.$gray-dark !important;
+  color: var.$grey-mid !important;
 
   .annotator-adder-actions__label {
-    color: var.$gray-dark !important;
+    color: var.$grey-mid !important;
   }
 }
 
@@ -137,6 +137,6 @@ $adder-transition-duration: 80ms;
   font-size: 11px;
   margin: 2px 0px;
   font-family: sans-serif;
-  color: var.$gray-dark !important;
+  color: var.$grey-mid !important;
   transition: color $adder-transition-duration;
 }

--- a/src/styles/annotator/adder.scss
+++ b/src/styles/annotator/adder.scss
@@ -98,11 +98,11 @@ $adder-transition-duration: 80ms;
 }
 
 .annotator-adder-actions:hover .annotator-adder-actions__button {
-  color: var.$gray-light !important;
+  color: var.$grey-semi !important;
 }
 
 .annotator-adder-actions:hover .annotator-adder-actions__label {
-  color: var.$gray-light !important;
+  color: var.$grey-semi !important;
 }
 
 .annotator-adder-actions__button {

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -117,7 +117,7 @@ var.$base-font-size: 14px;
     background: var.$white;
     border: solid 1px var.$grey-3;
     border-radius: 4px;
-    color: var.$gray-light;
+    color: var.$grey-semi;
     text-decoration: none;
     height: 30px;
     width: 30px;
@@ -126,7 +126,7 @@ var.$base-font-size: 14px;
     margin-bottom: 5px;
 
     &:active {
-      background-color: var.$gray-light;
+      background-color: var.$grey-semi;
     }
 
     &:focus,

--- a/src/styles/mixins/forms.scss
+++ b/src/styles/mixins/forms.scss
@@ -67,7 +67,7 @@
   color: var.$button-text-color;
   text-shadow: 0 1px 0 #fff;
   border-radius: 2px;
-  border: 1px solid var.$gray-light;
+  border: 1px solid var.$grey-semi;
   padding: 0.5em 0.9em;
 }
 
@@ -91,7 +91,7 @@
   cursor: default;
   background: #f0f0f0;
   border-color: #cecece;
-  color: var.$gray-light;
+  color: var.$grey-semi;
 }
 
 @mixin primary-action-btn {
@@ -108,7 +108,7 @@
   padding-right: 12px;
 
   &:disabled {
-    color: var.$gray-light;
+    color: var.$grey-semi;
   }
 
   &:hover:enabled {

--- a/src/styles/mixins/forms.scss
+++ b/src/styles/mixins/forms.scss
@@ -112,6 +112,6 @@
   }
 
   &:hover:enabled {
-    background-color: var.$color-mine-shaft;
+    background-color: var.$grey-6;
   }
 }

--- a/src/styles/mixins/forms.scss
+++ b/src/styles/mixins/forms.scss
@@ -34,7 +34,7 @@
   border-radius: 2px;
   padding: 0.5em 0.75em;
   font-weight: normal;
-  color: var.$gray;
+  color: var.$grey-5;
   background-color: #fafafa;
 }
 
@@ -44,7 +44,7 @@
 
   @include focus-outline;
   @include placeholder {
-    color: var.$gray;
+    color: var.$grey-5;
   }
 }
 

--- a/src/styles/mixins/forms.scss
+++ b/src/styles/mixins/forms.scss
@@ -96,7 +96,7 @@
 
 @mixin primary-action-btn {
   color: var.$grey-1;
-  background-color: var.$color-dove-gray;
+  background-color: var.$grey-mid;
   height: 35px;
   border: none;
   border-radius: 2px;

--- a/src/styles/sidebar/components/annotation-publish-control.scss
+++ b/src/styles/sidebar/components/annotation-publish-control.scss
@@ -98,7 +98,7 @@
         width: 1px;
         height: 15px;
 
-        background-color: var.$color-gray;
+        background-color: var.$grey-5;
       }
 
       // the ▼ arrow which reveals the dropdown menu when clicked

--- a/src/styles/sidebar/components/annotation-publish-control.scss
+++ b/src/styles/sidebar/components/annotation-publish-control.scss
@@ -24,7 +24,7 @@
   .annotation-publish-control__btn {
     $text-color: var.$grey-1;
     $default-background-color: var.$color-dove-gray;
-    $hover-background-color: var.$color-mine-shaft;
+    $hover-background-color: var.$grey-6;
     $h-padding: 9px;
     $height: 35px;
     $border-radius: 2px;

--- a/src/styles/sidebar/components/annotation-publish-control.scss
+++ b/src/styles/sidebar/components/annotation-publish-control.scss
@@ -23,7 +23,7 @@
   // of related options to the right
   .annotation-publish-control__btn {
     $text-color: var.$grey-1;
-    $default-background-color: var.$color-dove-gray;
+    $default-background-color: var.$grey-mid;
     $hover-background-color: var.$grey-6;
     $h-padding: 9px;
     $height: 35px;
@@ -70,7 +70,7 @@
       margin-left: 8px;
 
       border: none;
-      background-color: var.$color-dove-gray;
+      background-color: var.$grey-mid;
       border-top-right-radius: $border-radius;
       border-bottom-right-radius: $border-radius;
 
@@ -84,7 +84,7 @@
       button[aria-expanded='true'] &-separator {
         // hide the 1px vertical separator when the dropdown arrow
         // is hovered or menu is open
-        background-color: var.$color-dove-gray;
+        background-color: var.$grey-mid;
       }
 
       // 1px vertical separator between label and dropdown arrow

--- a/src/styles/sidebar/components/annotation.scss
+++ b/src/styles/sidebar/components/annotation.scss
@@ -117,7 +117,7 @@
 }
 
 .annotation-citation-domain {
-  color: var.$gray-light;
+  color: var.$grey-semi;
   font-size: var.$body1-font-size;
 }
 

--- a/src/styles/sidebar/components/menu-section.scss
+++ b/src/styles/sidebar/components/menu-section.scss
@@ -5,7 +5,7 @@
 }
 
 .menu-section__heading {
-  color: var.$gray-light;
+  color: var.$grey-semi;
   font-size: var.$body1-font-size;
   line-height: 1;
   margin: 1px 1px 0;

--- a/src/styles/sidebar/components/new-note.scss
+++ b/src/styles/sidebar/components/new-note.scss
@@ -1,7 +1,7 @@
 @use "../../variables" as var;
 
 .new-note__create {
-  background-color: var.$color-dove-gray;
+  background-color: var.$grey-mid;
   border: none;
   border-radius: 3px;
   color: #fff;

--- a/src/styles/sidebar/components/search-input.scss
+++ b/src/styles/sidebar/components/search-input.scss
@@ -6,7 +6,7 @@
   flex-flow: row nowrap;
 
   position: relative;
-  color: var.$gray-dark;
+  color: var.$grey-mid;
 }
 
 .search-input__icon {

--- a/src/styles/sidebar/components/search-input.scss
+++ b/src/styles/sidebar/components/search-input.scss
@@ -37,7 +37,7 @@
 
   &:disabled {
     background: none;
-    color: var.$gray-light;
+    color: var.$grey-semi;
   }
 
   // Expand the search input when focused (triggered by clicking

--- a/src/styles/sidebar/components/tags-input.scss
+++ b/src/styles/sidebar/components/tags-input.scss
@@ -24,7 +24,7 @@ tags-input {
       outline: none;
       border: none !important;
       background: none;
-      color: var.$gray;
+      color: var.$grey-5;
 
       // Firefox and Webkit render input boxes at different heights. This
       // causes issues when the tags (which render consistentely) are inserted

--- a/src/styles/sidebar/components/top-bar.scss
+++ b/src/styles/sidebar/components/top-bar.scss
@@ -66,11 +66,11 @@
   padding: 1px 3px 0 3px;
 
   &:hover {
-    color: var.$gray-dark;
+    color: var.$grey-mid;
   }
 
   &.is-active {
-    color: var.$gray-dark;
+    color: var.$grey-mid;
   }
 
   &--refresh {

--- a/src/styles/sidebar/components/top-bar.scss
+++ b/src/styles/sidebar/components/top-bar.scss
@@ -60,7 +60,7 @@
   @include buttons.reset-native-btn-styles;
 
   height: 100%;
-  color: var.$gray-light;
+  color: var.$grey-semi;
   display: inline-block;
   cursor: pointer;
   padding: 1px 3px 0 3px;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -12,7 +12,6 @@ $grey-3: #dbdbdb;
 $grey-4: #a6a6a6;
 
 $gray-light: #969696 !default;
-$color-gray: #818181;
 
 $grey-5: #7a7a7a;
 $gray: #777 !default;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -14,7 +14,6 @@ $grey-4: #a6a6a6;
 $gray-light: #969696 !default;
 
 $grey-5: #7a7a7a;
-$gray: #777 !default;
 
 // Interim color variable for migration purposes, as the step between `$grey-5`
 // and `$grey-6` is large. Represents `base-mid` in proposed future palette,

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -11,7 +11,10 @@ $grey-3: #dbdbdb;
 
 $grey-4: #a6a6a6;
 
-$gray-light: #969696 !default;
+// Interim color variable for migration purposes, as the step between `$grey-4`
+// and `$grey-5` is large. Represents `base-semi` in proposed future palette,
+// minus blue tint.
+$grey-semi: #9c9c9c;
 
 $grey-5: #7a7a7a;
 

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -16,8 +16,10 @@ $gray-light: #969696 !default;
 $grey-5: #7a7a7a;
 $gray: #777 !default;
 
-$color-dove-gray: #626262;
-$gray-dark: #585858;
+// Interim color variable for migration purposes, as the step between `$grey-5`
+// and `$grey-6` is large. Represents `base-mid` in proposed future palette,
+// minus blue tint.
+$grey-mid: #595959;
 
 $grey-6: #3f3f3f;
 
@@ -30,7 +32,7 @@ $black: #000 !default;
 $brand: #bd1c2b;
 $highlight: #58cef4;
 
-$button-text-color: $gray-dark !default;
+$button-text-color: $grey-mid !default;
 $button-background-start: $white !default;
 $button-background-end: #f0f0f0 !default;
 $button-background-gradient: to bottom, $button-background-start,
@@ -85,7 +87,7 @@ $success-color: #1cbd41 !default;
 // Scaffolding
 // -------------------------
 $body-background: $white !default;
-$text-color: $gray-dark !default;
+$text-color: $grey-mid !default;
 
 // Links
 // -------------------------

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -21,7 +21,6 @@ $color-dove-gray: #626262;
 $gray-dark: #585858;
 
 $grey-6: #3f3f3f;
-$color-mine-shaft: #3a3a3a;
 
 $grey-7: #202020;
 


### PR DESCRIPTION
After organizing with a spreadsheet, I was able to find a straightforward approach to get our grey colors cleaned up across the application. This PR updates all SASS color-variable references to use one of the following defined greys:

* `$white`
* `$black`
* `$grey-1` through `$grey-7`
* `$grey-semi` (NEW)
* `$grey-mid` (NEW)

It does not address non-grey colors nor non-variable colors in CSS.

The color-value gap between `$grey-4` and `$grey-5`, and the gap between `$grey-5` and `$grey-6` are quite wide, and some of the deprecated color values fell awkwardly between them. Trying to adjust these midway colors up or down to the nearest numbered grey caused a cascade of effects and imbalances.

Instead, what I've done is introduce two new/interim named color variables, `$grey-semi` and `$grey-mid`, which correspond to the proposed colors in the pattern library `base-semi` and `base-mid`, respectively, with their blue tints removed. These fit well into the gaps between `$grey-4`, `$grey-5` and `$grey-6`.

The overall effect for the human user is minimal. I encourage comparing before and after—there are small differences, but I believe them subtle enough to be negligible. See what you think!

Part of https://github.com/hypothesis/client/issues/1560