### PR TITLE
Update Cancel UI for `AnnotationPublishControl`

### DIFF
--- a/src/sidebar/components/annotation-publish-control.js
+++ b/src/sidebar/components/annotation-publish-control.js
@@ -8,6 +8,7 @@ const { withServices } = require('../util/service-context');
 
 const Menu = require('./menu');
 const MenuItem = require('./menu-item');
+const SvgIcon = require('./svg-icon');
 
 /**
  * Render a compound control button for publishing (saving) an annotation:
@@ -75,11 +76,11 @@ function AnnotationPublishControl({
         </Menu>
       </div>
       <button
-        className="annotation-publish-control__cancel-btn btn-clean"
+        className="action-button"
         onClick={onCancel}
         title="Cancel changes to this annotation"
       >
-        <i className="h-icon-cancel-outline publish-annotation-cancel-btn__icon btn-icon" />{' '}
+        <SvgIcon name="cancel" className="action-button__icon--compact" />
         Cancel
       </button>
     </div>

--- a/src/sidebar/components/test/annotation-publish-control-test.js
+++ b/src/sidebar/components/test/annotation-publish-control-test.js
@@ -191,7 +191,9 @@ describe('AnnotationPublishControl', () => {
       const wrapper = createAnnotationPublishControl({
         onCancel: fakeOnCancel,
       });
-      const cancelBtn = wrapper.find('.annotation-publish-control__cancel-btn');
+      const cancelBtn = wrapper.find(
+        '[title="Cancel changes to this annotation"]'
+      );
       cancelBtn.prop('onClick')();
 
       assert.calledOnce(fakeOnCancel);

--- a/src/styles/sidebar/components/annotation-publish-control.scss
+++ b/src/styles/sidebar/components/annotation-publish-control.scss
@@ -1,23 +1,9 @@
+@use "../../mixins/buttons";
 @use "../../mixins/forms";
 @use "../../variables" as var;
 
 .annotation-publish-control {
   display: flex;
-
-  &__cancel-btn {
-    margin-left: 5px;
-    font-weight: normal;
-    color: var.$grey-4;
-
-    &:hover {
-      color: var.$grey-5;
-    }
-
-    &__icon {
-      margin-right: 3px;
-      transform: translateY(10%);
-    }
-  }
 
   // A split button with a primary submit on the left and a drop-down menu
   // of related options to the right
@@ -32,6 +18,7 @@
 
     height: $height;
     position: relative;
+    margin-right: 1em;
 
     // Align the menu arrow correctly with the ▼ in the toggle
     &-menu-arrow {


### PR DESCRIPTION
This PR replaces the icon-font icon for the cancel button in the `AnnotationPublishControl` with an SVG variant, tidies some styling, fixes alignment, and boosts contrast.

The existing control for “cancel” has long been both really low contrast and misaligned vertically. It looks like this in the current client/extension:

<img width="411" alt="Screen Shot 2019-12-10 at 4 22 24 PM" src="https://user-images.githubusercontent.com/439947/70570823-a65fc900-1b6a-11ea-820d-895e557405fb.png">

After these changes:

<img width="406" alt="Screen Shot 2019-12-10 at 4 24 09 PM" src="https://user-images.githubusercontent.com/439947/70570834-ab247d00-1b6a-11ea-99c7-f227be36c2c5.png">

A couple of points to note:
* This is a one-off pattern. We don’t have any other button-y interface elements that behave or look like this in the app.
* The updated variant uses a shared button-styling SASS mixin, so it inherits some (consistent) padding and hover-timing effects (the hover is just a darker color, FWIW, that hasn’t changed overall).

Part of https://github.com/hypothesis/client/issues/1561
