### PR TITLE
Use mobile-friendly font size for all input fields

### DIFF
--- a/src/sidebar/components/markdown-editor.js
+++ b/src/sidebar/components/markdown-editor.js
@@ -283,7 +283,7 @@ function MarkdownEditor({ onEditText = () => {}, text = '' }) {
         />
       ) : (
         <textarea
-          className="markdown-editor__input form-input form-textarea"
+          className="markdown-editor__input"
           ref={input}
           onClick={e => e.stopPropagation()}
           onKeydown={handleKeyDown}

--- a/src/styles/forms.scss
+++ b/src/styles/forms.scss
@@ -5,15 +5,4 @@
   @include forms.form-input;
   width: 100%;
   display: block;
-
-  &:focus,
-  &.js-focus {
-    @include forms.form-input-focus;
-  }
-}
-
-.form-textarea {
-  min-height: 8em;
-  max-width: 100%;
-  resize: vertical;
 }

--- a/src/styles/mixins/forms.scss
+++ b/src/styles/mixins/forms.scss
@@ -28,6 +28,16 @@
     0px 0px 5px var.$color-focus-shadow;
 }
 
+@mixin form-input-focus {
+  outline: none;
+  background-color: var.$white;
+
+  @include focus-outline;
+  @include placeholder {
+    color: var.$grey-5;
+  }
+}
+
 @mixin form-input {
   @include var.font-normal;
   border: 1px solid var.$grey-3;
@@ -36,15 +46,13 @@
   font-weight: normal;
   color: var.$grey-5;
   background-color: var.$grey-0;
-}
 
-@mixin form-input-focus {
-  outline: none;
-  background-color: var.$white;
+  &:focus {
+    @include form-input-focus;
+  }
 
-  @include focus-outline;
-  @include placeholder {
-    color: var.$grey-5;
+  @media (pointer: coarse) {
+    font-size: var.$touch-input-font-size;
   }
 }
 

--- a/src/styles/sidebar/components/markdown-editor.scss
+++ b/src/styles/sidebar/components/markdown-editor.scss
@@ -1,3 +1,4 @@
+@use "../../mixins/forms";
 @use "../../variables" as var;
 
 $toolbar-border: 0.1em solid var.$grey-3;
@@ -62,11 +63,15 @@ $toolbar-border: 0.1em solid var.$grey-3;
   margin-bottom: 2px; // Tweak to align help icon better with adjacent buttons
 }
 
-@media (pointer: coarse) {
-  .markdown-editor__input {
-    font-size: var.$touch-input-font-size;
-  }
+.markdown-editor__input {
+  @include forms.form-input;
 
+  min-height: 8em;
+  resize: vertical;
+  width: 100%;
+}
+
+@media (pointer: coarse) {
   .markdown-editor__toolbar {
     // Remove the padding to avoid the toolbar taking up too much space as we
     // make the buttons larger.

--- a/src/styles/sidebar/components/search-input.scss
+++ b/src/styles/sidebar/components/search-input.scss
@@ -1,4 +1,4 @@
-@use "../../mixins/focus";
+@use "../../mixins/forms";
 @use "../../variables" as var;
 
 .search-input__form {
@@ -14,17 +14,16 @@
 }
 
 .search-input__input {
-  @include focus.outline-on-keyboard-focus;
+  @include forms.form-input;
 
   flex-grow: 1;
   order: 1;
 
-  color: var.$text-color;
-
   // Disable default browser styling for the input.
-  border: none;
-  padding: 0px;
-  width: 100%;
+  &:not(:focus) {
+    border: none;
+    padding: 0px;
+  }
 
   // The search box expands when focused, via a change in the
   // `max-width` property.
@@ -43,11 +42,5 @@
   &.is-expanded {
     max-width: 150px;
     padding-left: 6px;
-  }
-}
-
-@media (pointer: coarse) {
-  .search-input__input {
-    font-size: var.$touch-input-font-size;
   }
 }

--- a/src/styles/sidebar/components/tag-editor.scss
+++ b/src/styles/sidebar/components/tag-editor.scss
@@ -6,13 +6,6 @@
   &__input {
     @include forms.form-input;
     width: 100%;
-    &:focus {
-      @include forms.form-input-focus;
-    }
-
-    @media (pointer: coarse) {
-      font-size: var.$touch-input-font-size;
-    }
   }
 
   &__tag-list {

--- a/src/styles/sidebar/components/tag-editor.scss
+++ b/src/styles/sidebar/components/tag-editor.scss
@@ -9,6 +9,10 @@
     &:focus {
       @include forms.form-input-focus;
     }
+
+    @media (pointer: coarse) {
+      font-size: var.$touch-input-font-size;
+    }
   }
 
   &__tag-list {


### PR DESCRIPTION
Match other input fields in the sidebar in using a larger font size for
the tag editor input on mobile/touch inputs. This also prevents iOS
Safari from zooming into the input when focused.

**Update:** In response to a [suggestion](https://github.com/hypothesis/client/pull/1605#discussion_r359425564) I did some refactoring of our input styles to make all input fields use the `form-input` mixin for their styles and moved the font-size and focus outline adjustments into the `form-input` mixin. The end result is that all input fields in the sidebar now have the same focus outline and use the same larger font size when using touch input. The one visual change on desktop is that the search input's focus ring is consistent with other input fields in the app:

<img width="326" alt="Screenshot 2019-12-19 12 18 49" src="https://user-images.githubusercontent.com/2458/71173707-50baa900-225b-11ea-9e97-ec88b34d0baa.png">
