### PR TITLE
Remove analytics tracking from annotation component

### DIFF
--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -83,7 +83,6 @@ describe('annotation', function() {
     const fakeAccountID = {
       isThirdPartyUser: sinon.stub(),
     };
-    let fakeAnalytics;
     let fakeAnnotationMapper;
     let fakeStore;
     let fakeFlash;
@@ -160,11 +159,6 @@ describe('annotation', function() {
     beforeEach(
       angular.mock.module(function($provide) {
         sandbox = sinon.sandbox.create();
-
-        fakeAnalytics = {
-          track: sandbox.stub(),
-          events: {},
-        };
 
         fakeAnnotationMapper = {
           createAnnotation: sandbox.stub().returns({
@@ -246,7 +240,6 @@ describe('annotation', function() {
           call: sinon.stub(),
         };
 
-        $provide.value('analytics', fakeAnalytics);
         $provide.value('annotationMapper', fakeAnnotationMapper);
         $provide.value('store', fakeStore);
         $provide.value('api', fakeApi);


### PR DESCRIPTION
We are not actively doing anything with this data, so we can save
ourselves some Angular => Preact porting effort by removing the tracking
code for the time being.