### PR TITLE
Fix datalist performance in Chrome

### DIFF
--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -17,23 +17,38 @@ let datalistIdCounter = 0;
 function TagEditor({ onEditTags, tags: tagsService, tagList }) {
   const inputEl = useRef(null);
   const [showSuggestions, setShowSuggestions] = useState(false);
+  const [suggestionsFiltered, setSuggestionsFiltered] = useState([]); // For Chrome only
   const [datalistId] = useState(() => {
     ++datalistIdCounter;
     return `tag-editor-datalist-${datalistIdCounter}`;
   });
 
+  const isChromeUA = !!window.navigator.userAgent.match(/Chrome\/[.0-9]*/);
+  // Suggestion limiter to speed up the performance in Chrome
+  // See https://github.com/hypothesis/client/issues/1606
+  const chromeSuggestionsLimit = 20;
+
+  /**
+   * Helper function that returns a list of suggestions less any
+   * results also found from the duplicates list.
+   *
+   * @param {Array<string>} suggestions - Original list of suggestions
+   * @param {Array<string>} duplicates - Items to be removed from the result
+   * @return {Array<string>}
+   */
+  const removeDuplicates = (suggestions, duplicates) => {
+    const suggestionsSet = [];
+    suggestions.forEach(suggestion => {
+      if (duplicates.indexOf(suggestion) < 0) {
+        suggestionsSet.push(suggestion);
+      }
+    });
+    return suggestionsSet.sort();
+  };
+
   // List of suggestions returned from the tagsService
   const suggestions = useMemo(() => {
     // Remove any repeated suggestions that are already tags.
-    const removeDuplicates = (suggestions, tags) => {
-      const suggestionsSet = [];
-      suggestions.forEach(suggestion => {
-        if (tags.indexOf(suggestion) < 0) {
-          suggestionsSet.push(suggestion);
-        }
-      });
-      return suggestionsSet.sort();
-    };
     // Call filter with an empty string to return all suggestions
     return removeDuplicates(tagsService.filter(''), tagList);
   }, [tagsService, tagList]);
@@ -94,9 +109,30 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
   };
 
   const handleOnInput = e => {
-    if (e.inputType === 'insertText') {
-      // Show the suggestions if the user types something into the field
-      setShowSuggestions(true);
+    if (
+      e.inputType === 'insertText' ||
+      e.inputType === 'deleteContentBackward'
+    ) {
+      if (inputEl.current.value.length === 0) {
+        // If the user deleted input, hide suggestions. This has
+        // no effect in Safari and the list will stay open.
+        setShowSuggestions(false);
+      } else {
+        if (isChromeUA) {
+          // Filter down the suggestions list for Chrome to subvert a performance
+          // issue. Returning too many suggestions causes a noticeable delay when
+          // rendering the datalist.
+          // See https://github.com/hypothesis/client/issues/1606
+          setSuggestionsFiltered(
+            removeDuplicates(
+              tagsService.filter(inputEl.current.value, chromeSuggestionsLimit),
+              tagList
+            )
+          );
+        }
+        // Show the suggestions if the user types something into the field
+        setShowSuggestions(true);
+      }
     } else if (
       e.inputType === undefined ||
       e.inputType === 'insertReplacementText'
@@ -112,10 +148,6 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
       // time to trigger the handleKeyPress callback above to add the tag.
       // Bug: https://github.com/hypothesis/client/issues/1604
       addTag();
-    } else if (inputEl.current.value.length === 0) {
-      // If the user deleted input, hide suggestions. This has
-      // no effect in Safari and the list will stay open.
-      setShowSuggestions(false);
     }
   };
 
@@ -132,6 +164,9 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
   };
 
   const suggestionsList = () => {
+    // If this is Chrome, use the filtered list, otherwise use the full list
+    // See https://github.com/hypothesis/client/issues/1606
+    const optionsList = isChromeUA ? suggestionsFiltered : suggestions;
     return (
       <datalist
         id={datalistId}
@@ -139,7 +174,7 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
         aria-label="Annotation suggestions"
       >
         {showSuggestions &&
-          suggestions.map(suggestion => (
+          optionsList.map(suggestion => (
             <option key={suggestion} value={suggestion} />
           ))}
       </datalist>

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -307,4 +307,34 @@ describe('TagEditor', function() {
       assert.isTrue(fakeOnEditTags.calledWith({ tags: ['tag2'] }));
     });
   });
+
+  describe('filter on text input based on user agent', () => {
+    let stub = sinon.stub(navigator, 'userAgent');
+
+    afterEach(function() {
+      stub.restore();
+    });
+
+    it('calls filter when changing input with a limit of 20 when browser is Chrome', () => {
+      const wrapper = createComponent();
+      stub.get(() => 'Chrome/1.0');
+      wrapper.find('input').instance().value = 'tag';
+      typeInput(wrapper);
+
+      assert.isTrue(fakeTagsService.filter.calledTwice);
+      assert.isTrue(fakeTagsService.filter.calledWith('tag', 20));
+    });
+
+    it('does not call filter when changing input when browser is not Chrome', () => {
+      let stub = sinon.stub(navigator, 'userAgent');
+      stub.get(() => '');
+      const wrapper = createComponent();
+
+      wrapper.find('input').instance().value = 'tag';
+      typeInput(wrapper);
+
+      assert.isTrue(fakeTagsService.filter.calledOnce);
+      assert.isTrue(fakeTagsService.filter.calledWith(''));
+    });
+  });
 });

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -309,15 +309,18 @@ describe('TagEditor', function() {
   });
 
   describe('filter on text input based on user agent', () => {
-    let stub = sinon.stub(navigator, 'userAgent');
+    let fakeNavigator;
+    beforeEach(function() {
+      fakeNavigator = sinon.stub(navigator, 'userAgent');
+    });
 
     afterEach(function() {
-      stub.restore();
+      fakeNavigator.restore();
     });
 
     it('calls filter when changing input with a limit of 20 when browser is Chrome', () => {
+      fakeNavigator.get(() => 'Chrome/1.0');
       const wrapper = createComponent();
-      stub.get(() => 'Chrome/1.0');
       wrapper.find('input').instance().value = 'tag';
       typeInput(wrapper);
 
@@ -326,8 +329,7 @@ describe('TagEditor', function() {
     });
 
     it('does not call filter when changing input when browser is not Chrome', () => {
-      let stub = sinon.stub(navigator, 'userAgent');
-      stub.get(() => '');
+      fakeNavigator.get(() => '');
       const wrapper = createComponent();
 
       wrapper.find('input').instance().value = 'tag';

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -26,12 +26,13 @@ function tags(localStorage) {
    * @param {number} limit - Optional limit of the results.
    * @return {Tag[]} List of matching tags
    */
-  function filter(query, limit = null) {
+  function filter(query, limit = 0) {
+    const limitNumber = Number(limit); // ensures we are dealing with a number
     const savedTags = localStorage.getObject(TAGS_LIST_KEY) || [];
     let resultCount = 0;
     return savedTags.filter(e => {
       if (e.toLowerCase().indexOf(query.toLowerCase()) !== -1) {
-        if (Number(limit) === 0 || resultCount < limit) {
+        if (limitNumber === 0 || resultCount < limitNumber) {
           // limit allows a subset of the results
           // See https://github.com/hypothesis/client/issues/1606
           ++resultCount;

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -26,13 +26,12 @@ function tags(localStorage) {
    * @param {number} limit - Optional limit of the results.
    * @return {Tag[]} List of matching tags
    */
-  function filter(query, limit = 0) {
-    const limitNumber = Number(limit); // ensures we are dealing with a number
+  function filter(query, limit = null) {
     const savedTags = localStorage.getObject(TAGS_LIST_KEY) || [];
     let resultCount = 0;
     return savedTags.filter(e => {
       if (e.toLowerCase().indexOf(query.toLowerCase()) !== -1) {
-        if (limitNumber === 0 || resultCount < limitNumber) {
+        if (limit === null || resultCount < limit) {
           // limit allows a subset of the results
           // See https://github.com/hypothesis/client/issues/1606
           ++resultCount;

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -23,13 +23,22 @@ function tags(localStorage) {
    * Return a list of tag suggestions matching `query`.
    *
    * @param {string} query
+   * @param {number} limit - Optional limit of the results.
    * @return {Tag[]} List of matching tags
    */
-  function filter(query) {
+  function filter(query, limit = null) {
     const savedTags = localStorage.getObject(TAGS_LIST_KEY) || [];
-
+    let resultCount = 0;
     return savedTags.filter(e => {
-      return e.toLowerCase().indexOf(query.toLowerCase()) !== -1;
+      if (e.toLowerCase().indexOf(query.toLowerCase()) !== -1) {
+        if (Number(limit) === 0 || resultCount < limit) {
+          // limit allows a subset of the results
+          // See https://github.com/hypothesis/client/issues/1606
+          ++resultCount;
+          return true;
+        }
+      }
+      return false;
     });
   }
 

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -80,10 +80,6 @@ describe('sidebar.tags', () => {
       assert.deepEqual(tags.filter('r', 2), ['bar', 'future']);
       assert.deepEqual(tags.filter('r', 3), ['bar', 'future', 'argon']);
     });
-
-    it('does not limit tags when limit is 0', () => {
-      assert.deepEqual(tags.filter('r', 0), ['bar', 'future', 'argon']);
-    });
   });
 
   describe('#store', () => {

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -74,6 +74,16 @@ describe('sidebar.tags', () => {
     it('is case insensitive', () => {
       assert.deepEqual(tags.filter('Ar'), ['bar', 'argon']);
     });
+
+    it('limits tags when provided a limit value', () => {
+      assert.deepEqual(tags.filter('r', 1), ['bar']);
+      assert.deepEqual(tags.filter('r', 2), ['bar', 'future']);
+      assert.deepEqual(tags.filter('r', 3), ['bar', 'future', 'argon']);
+    });
+
+    it('does not limit tags when limit is 0', () => {
+      assert.deepEqual(tags.filter('r', 0), ['bar', 'future', 'argon']);
+    });
   });
 
   describe('#store', () => {


### PR DESCRIPTION
When tag suggestions exceeds just a few hundred results, a noticeable performance is observed in Chrome. 

I arbitrarily selected 20 results as a reasonable limit, but it may be best to match firefox / safari which window the result to 6 or so at a time?

I left some test code in so you can easily test 1000 suggestions. this should be fast in every browser now.

fixed https://github.com/hypothesis/client/issues/1606