### PR TITLE
Update and Simplify `SelectionTabs`, `NewNoteButton` icons, styling

### DIFF
--- a/src/sidebar/components/button.js
+++ b/src/sidebar/components/button.js
@@ -24,6 +24,7 @@ function Button({
   icon = '',
   isActive = false,
   onClick = () => null,
+  style = {},
   title,
   useCompactStyle = false,
   useInputStyle = false,
@@ -51,6 +52,7 @@ function Button({
       onClick={onClick}
       aria-pressed={isActive}
       title={title}
+      style={style}
     >
       {icon && <SvgIcon name={icon} className="button__icon" />}
       {buttonText}
@@ -107,6 +109,9 @@ Button.propTypes = {
 
   /** callback for button clicks */
   onClick: propTypes.func,
+
+  /** optional inline styling  */
+  style: propTypes.object,
 
   /**
    * `title`, used for button `title`, is required unless `buttonText` is present

--- a/src/sidebar/components/new-note-btn.js
+++ b/src/sidebar/components/new-note-btn.js
@@ -8,6 +8,8 @@ const useStore = require('../store/use-store');
 const { applyTheme } = require('../util/theme');
 const { withServices } = require('../util/service-context');
 
+const Button = require('./button');
+
 function NewNoteButton({ $rootScope, settings }) {
   const store = useStore(store => ({
     frames: store.frames(),
@@ -23,13 +25,16 @@ function NewNoteButton({ $rootScope, settings }) {
   };
 
   return (
-    <button
-      style={applyTheme(['ctaBackgroundColor'], settings)}
-      className="new-note__create"
-      onClick={onNewNoteBtnClick}
-    >
-      + New note
-    </button>
+    <div className="new-note-button">
+      <Button
+        buttonText="New note"
+        icon="add"
+        onClick={onNewNoteBtnClick}
+        style={applyTheme(['ctaBackgroundColor'], settings)}
+        useCompactStyle
+        usePrimaryStyle
+      />
+    </div>
   );
 }
 NewNoteButton.propTypes = {

--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -6,10 +6,11 @@ const { createElement } = require('preact');
 const { Fragment } = require('preact');
 
 const NewNoteBtn = require('./new-note-btn');
-const sessionUtil = require('../util/session');
 const uiConstants = require('../ui-constants');
 const useStore = require('../store/use-store');
 const { withServices } = require('../util/service-context');
+
+const SvgIcon = require('./svg-icon');
 
 /**
  *  Display name of the tab and annotation count.
@@ -72,7 +73,7 @@ Tab.propTypes = {
  *  Tabbed display of annotations and notes.
  */
 
-function SelectionTabs({ isLoading, settings, session }) {
+function SelectionTabs({ isLoading, settings }) {
   const selectedTab = useStore(store => store.getState().selection.selectedTab);
   const noteCount = useStore(store => store.noteCount());
   const annotationCount = useStore(store => store.annotationCount());
@@ -100,10 +101,6 @@ function SelectionTabs({ isLoading, settings, session }) {
 
   const showNotesUnavailableMessage =
     selectedTab === uiConstants.TAB_NOTES && noteCount === 0;
-
-  const showSidebarTutorial = sessionUtil.shouldShowSidebarTutorial(
-    session.state
-  );
 
   return (
     <Fragment>
@@ -146,32 +143,23 @@ function SelectionTabs({ isLoading, settings, session }) {
       {selectedTab === uiConstants.TAB_NOTES &&
         settings.enableExperimentalNewNoteButton && <NewNoteBtn />}
       {!isLoading && (
-        <div className="selection-tabs__empty-message">
+        <div>
           {showNotesUnavailableMessage && (
-            <div className="annotation-unavailable-message">
-              <p className="annotation-unavailable-message__label">
-                There are no page notes in this group.
-                {settings.enableExperimentalNewNoteButton &&
-                  !showSidebarTutorial && (
-                    <div className="annotation-unavailable-message__tutorial">
-                      Create one by clicking the{' '}
-                      <i className="help-icon h-icon-note" /> button.
-                    </div>
-                  )}
-              </p>
+            <div className="selection-tabs__message">
+              There are no page notes in this group.
             </div>
           )}
           {showAnnotationsUnavailableMessage && (
-            <div className="annotation-unavailable-message">
-              <p className="annotation-unavailable-message__label">
-                There are no annotations in this group.
-                {!showSidebarTutorial && (
-                  <div className="annotation-unavailable-message__tutorial">
-                    Create one by selecting some text and clicking the{' '}
-                    <i className="help-icon h-icon-annotate" /> button.
-                  </div>
-                )}
-              </p>
+            <div className="selection-tabs__message">
+              There are no annotations in this group.
+              <br />
+              Create one by selecting some text and clicking the{' '}
+              <SvgIcon
+                name="annotate"
+                inline="true"
+                className="selection-tabs__icon"
+              />{' '}
+              button.
             </div>
           )}
         </div>
@@ -187,9 +175,8 @@ SelectionTabs.propTypes = {
 
   // Injected services.
   settings: propTypes.object.isRequired,
-  session: propTypes.object.isRequired,
 };
 
-SelectionTabs.injectedProps = ['session', 'settings'];
+SelectionTabs.injectedProps = ['settings'];
 
 module.exports = withServices(SelectionTabs);

--- a/src/sidebar/components/test/new-note-btn-test.js
+++ b/src/sidebar/components/test/new-note-btn-test.js
@@ -2,6 +2,7 @@
 
 const { mount } = require('enzyme');
 const { createElement } = require('preact');
+const { act } = require('preact/test-utils');
 
 const events = require('../../events');
 const NewNoteButton = require('../new-note-btn');
@@ -49,22 +50,22 @@ describe('NewNoteButton', function() {
     NewNoteButton.$imports.$restore();
   });
 
-  it('creates the component', () => {
+  it("sets a backgroundColor equal to the setting's ctaBackgroundColor color", () => {
     const wrapper = createComponent();
-    assert.include(wrapper.text(), 'New note');
-  });
-
-  it("has a backgroundColor equal to the setting's ctaBackgroundColor color", () => {
-    const wrapper = createComponent().find('button');
     assert.equal(
-      wrapper.prop('style').backgroundColor,
+      wrapper.find('Button').prop('style').backgroundColor,
       fakeSettings.branding.ctaBackgroundColor
     );
   });
 
   it('should broadcast BEFORE_ANNOTATION_CREATED event when the new note button is clicked', () => {
     const wrapper = createComponent();
-    wrapper.find('button').simulate('click');
+    act(() => {
+      wrapper
+        .find('Button')
+        .props()
+        .onClick();
+    });
     const topLevelFrame = fakeStore.frames().find(f => !f.id);
     assert.calledWith(
       fakeRootScope.$broadcast,

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -9,7 +9,6 @@ const mockImportedComponents = require('./mock-imported-components');
 
 describe('SelectionTabs', function() {
   // mock services
-  let fakeSession;
   let fakeSettings;
   let fakeStore;
 
@@ -20,23 +19,11 @@ describe('SelectionTabs', function() {
 
   function createComponent(props) {
     return mount(
-      <SelectionTabs
-        session={fakeSession}
-        settings={fakeSettings}
-        {...defaultProps}
-        {...props}
-      />
+      <SelectionTabs settings={fakeSettings} {...defaultProps} {...props} />
     );
   }
 
   beforeEach(() => {
-    fakeSession = {
-      state: {
-        preferences: {
-          show_sidebar_tutorial: false,
-        },
-      },
-    };
     fakeSettings = {
       enableExperimentalNewNoteButton: false,
     };
@@ -65,7 +52,7 @@ describe('SelectionTabs', function() {
   });
 
   const unavailableMessage = wrapper =>
-    wrapper.find('.annotation-unavailable-message__label').text();
+    wrapper.find('.selection-tabs__message').text();
 
   context('displays selection tabs and counts', function() {
     it('should display the tabs and counts of annotations and notes', function() {
@@ -172,7 +159,7 @@ describe('SelectionTabs', function() {
       const wrapper = createComponent({
         isLoading: true,
       });
-      assert.isFalse(wrapper.exists('.annotation-unavailable-message__label'));
+      assert.isFalse(wrapper.exists('.selection-tabs__message'));
     });
 
     it('should not display the longer version of the no annotations message when there are no annotations and isWaitingToAnchorAnnotations is true', function() {
@@ -181,7 +168,7 @@ describe('SelectionTabs', function() {
       const wrapper = createComponent({
         isLoading: false,
       });
-      assert.isFalse(wrapper.exists('.annotation-unavailable-message__label'));
+      assert.isFalse(wrapper.exists('.selection-tabs__message'));
     });
 
     it('should display the longer version of the no notes message when there are no notes', function() {
@@ -196,24 +183,6 @@ describe('SelectionTabs', function() {
       );
     });
 
-    it('should display the prompt to create a note when there are no notes and enableExperimentalNewNoteButton is true', function() {
-      fakeSettings.enableExperimentalNewNoteButton = true;
-      fakeStore.getState.returns({
-        selection: { selectedTab: uiConstants.TAB_NOTES },
-      });
-      fakeStore.noteCount.returns(0);
-      const wrapper = createComponent({});
-      assert.include(
-        wrapper.find('.annotation-unavailable-message__tutorial').text(),
-        'Create one by clicking the'
-      );
-      assert.isTrue(
-        wrapper
-          .find('.annotation-unavailable-message__tutorial i')
-          .hasClass('h-icon-note')
-      );
-    });
-
     it('should display the longer version of the no annotations message when there are no annotations', function() {
       fakeStore.annotationCount.returns(0);
       const wrapper = createComponent({});
@@ -222,49 +191,9 @@ describe('SelectionTabs', function() {
         'There are no annotations in this group.'
       );
       assert.include(
-        wrapper.find('.annotation-unavailable-message__tutorial').text(),
+        unavailableMessage(wrapper),
         'Create one by selecting some text and clicking the'
       );
-      assert.isTrue(
-        wrapper
-          .find('.annotation-unavailable-message__tutorial i')
-          .hasClass('h-icon-annotate')
-      );
-    });
-
-    context('when the sidebar tutorial is displayed', function() {
-      it('should display the shorter version of the no notes message when there are no notes', function() {
-        fakeSession.state.preferences.show_sidebar_tutorial = true;
-        fakeStore.getState.returns({
-          selection: { selectedTab: uiConstants.TAB_NOTES },
-        });
-        fakeStore.noteCount.returns(0);
-        const wrapper = createComponent({});
-
-        const msg = unavailableMessage(wrapper);
-
-        assert.include(msg, 'There are no page notes in this group.');
-        assert.notInclude(msg, 'Create one by clicking the');
-        assert.notInclude(
-          msg,
-          'Create one by selecting some text and clicking the'
-        );
-      });
-
-      it('should display the shorter version of the no annotations message when there are no annotations', function() {
-        fakeSession.state.preferences.show_sidebar_tutorial = true;
-        fakeStore.annotationCount.returns(0);
-        const wrapper = createComponent({});
-
-        const msg = unavailableMessage(wrapper);
-
-        assert.include(msg, 'There are no annotations in this group.');
-        assert.notInclude(msg, 'Create one by clicking the');
-        assert.notInclude(
-          msg,
-          'Create one by selecting some text and clicking the'
-        );
-      });
     });
   });
 });

--- a/src/styles/sidebar/components/new-note.scss
+++ b/src/styles/sidebar/components/new-note.scss
@@ -1,14 +1,7 @@
 @use "../../variables" as var;
 
-.new-note__create {
-  background-color: var.$grey-mid;
-  border: none;
-  border-radius: 3px;
-  color: #fff;
+.new-note-button {
   display: flex;
-  font-weight: 500;
-  margin-left: auto;
-  margin-right: 14px;
-  margin-bottom: 10px;
-  text-align: center;
+  justify-content: flex-end;
+  margin: 0 1em 1em 0;
 }

--- a/src/styles/sidebar/components/selection-tabs.scss
+++ b/src/styles/sidebar/components/selection-tabs.scss
@@ -48,3 +48,17 @@
 .selection-tabs__type--orphan {
   margin-left: -5px;
 }
+
+.selection-tabs__message {
+  border: 1px solid var.$grey-3;
+  padding: 3em;
+  text-align: center;
+}
+
+.selection-tabs__icon {
+  width: 12px;
+  height: 12px;
+  margin-right: 1px;
+  margin-bottom: -1px; // Pull the icon a little toward the baseline
+  color: var.$grey-5;
+}


### PR DESCRIPTION
This PR addresses several issues with the `SelectionTabs` and the `NewNoteBtn` components:

* Icons are swapped out for SVGs
* Conditional around showing certain parts of messaging based on tutorial display removed from `SelectionTabs`
* Extraneous markup and styling removed from `SelectionTabs`
* `NewNoteBtn` converted to use `Button` component and styled consistently
* Extend `Button` to accept a custom `style` object prop

### Fixing the "No notes" messaging to make sense

As far as I can divine, the existence of `NewNoteBtn` is for satisfying a customer theming/design requirement, see https://github.com/hypothesis/client/pull/555 and https://github.com/hypothesis/client/pull/576 . This button is only ever rendered if a particular client configuration (`enableExperimentalNewNoteButton`) is set. We do not enable this for our client embed or extension. Only a small subset of H users ever see this button. My assumption is that this button exists to allow note creation if the "standard" bucket-bar create-note icon is disabled.

`SelectionTabs` before this set of changes had some (IMO) over-heavy logic for determining what kind of messaging to show users if no annotations or notes were available in the group selected, including what I believe to be a non-sensical code path for users in contexts where the "experimental new note button" _is_ enabled.

For example, before this change, eLife users see the following when the Notes tab is selected and there are no available page notes:

<img width="474" alt="Screen Shot 2019-12-20 at 9 23 08 AM" src="https://user-images.githubusercontent.com/439947/71263764-8ff70180-2310-11ea-84be-0c7ff2c4fe70.png">

The instructions in the rendered messaging involve an icon for a button that doesn't exist in this interface (the bucket-bar notes icon). And that messaging-with-icon _only_ shows up if the experimental button is enabled. So, AFAICT, it's nonsense and I've removed that sentence entirely.

The proximity of the "New Note" button itself to the messaging makes any sort of tutorial text here seem redundant to me, anyway. The button is _right there_.

### Removing the conditional branch regarding tutorial display

`SelectionTabs` also had a set of conditionals that would alter the messaging displayed depending on whether the help/tutorial panel was also open. While I can understand the thinking behind this, there were some problems with the existing implementation:

* It was broken. It used a method of checking for whether the tutorial was open that didn't return the correct results.
* I don't believe it provides a lot of value. Making a dynamic change to some of the displayed text in messaging when a panel is toggled doesn't seem like a lot of help to users to me.
* It introduces extra complexity to the component. Removing this branching allows for the removal of a service dependency and a chunk of code overall.

## After this change

### No Annotations messaging

![image](https://user-images.githubusercontent.com/439947/71264198-8ae68200-2311-11ea-93b7-910987f83c85.png)

Minimal changes, but SVG icon is used here.

#### No Notes messaging

![image](https://user-images.githubusercontent.com/439947/71264224-9d60bb80-2311-11ea-906d-ba4bfa85f6b1.png)

No change if experimental-new-note-button is not enabled. ^

<img width="463" alt="Screen Shot 2019-12-20 at 9 57 51 AM" src="https://user-images.githubusercontent.com/439947/71264310-d0a34a80-2311-11ea-81d7-cc8bb4e4bf3d.png">

^ In places where new-note-button is enabled, the button is now styled consistently with other buttons (it _will_ pick up a custom themed background color, as it did before). The nonsensical extra directions have been removed.

*Note*: I haven't made any user-visible changes to styling in this PR to avoid bogging us down further (except for making the new-note button use consistent styling with other buttons), but I do believe the design pattern here could use a rethink at some point.