### PR TITLE
Add userid key to config docs for focus mode

### DIFF
--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -406,8 +406,9 @@ loads.
       return {
         focus: {
           user: {
-            // required
+            // required (username or userid)
             username: "foobar1234",
+            userid: 'acct:foobar1234@domain',
             // optional
             displayName: "Foo Bar",
           }


### PR DESCRIPTION
The original ticket was to remove the ability to operate on username for focused mode, but this was more work than expected and perhaps not the best choice considering that SpeedGrader does indeed pass around the username, not the userid and we can't change that.

Relates to https://github.com/hypothesis/lms/issues/1199. 

The client already operates on either value and so the simple fix is to reflect that in does so in the docs so there is no confusion.
https://h.readthedocs.io/projects/client/en/latest/publishers/config/#cmdoption-arg-focus

Note: The `focus` config relating to the docs is only used for SpeedGrader, and all other LMS apps so far use RPC requests to set focus which does in fact pass the `userid`, not the user name (though either would work even in that case)

Change proposed:

![Screen Shot 2019-12-20 at 1 07 27 PM](https://user-images.githubusercontent.com/3939074/71293578-baee4f00-232a-11ea-9f96-58e66ed2103a.png)

fixes https://github.com/hypothesis/client/issues/1516

