### PR TITLE
Prepare for transition to ES modules

### DIFF
--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const classnames = require('classnames');
 
 const template = require('./adder.html');

--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* global PDFViewerApplication */
 
 const seek = require('dom-seek');

--- a/src/annotator/anchoring/test/fake-pdf-viewer-application.js
+++ b/src/annotator/anchoring/test/fake-pdf-viewer-application.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Fake implementation of the parts of PDF.js that the Hypothesis client's
  * anchoring interacts with.

--- a/src/annotator/anchoring/test/html-baselines/index.js
+++ b/src/annotator/anchoring/test/html-baselines/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Fixtures for anchoring baseline tests. The goals of these tests are to:
 //
 // 1) Check for unexpected changes in the selectors captured when describing

--- a/src/annotator/anchoring/test/html-test.js
+++ b/src/annotator/anchoring/test/html-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const html = require('../html');
 
 const toResult = require('../../../shared/test/promise-util').toResult;

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const domAnchorTextQuote = require('dom-anchor-text-quote');
 
 const FakePDFViewerApplication = require('./fake-pdf-viewer-application');

--- a/src/annotator/anchoring/test/text-position-test.js
+++ b/src/annotator/anchoring/test/text-position-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { toRange } = require('../text-position');
 
 describe('text-position', () => {

--- a/src/annotator/anchoring/test/types-test.js
+++ b/src/annotator/anchoring/test/types-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const types = require('../types');
 
 const TextQuoteAnchor = types.TextQuoteAnchor;

--- a/src/annotator/anchoring/text-position.js
+++ b/src/annotator/anchoring/text-position.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Functions to convert between DOM ranges and characters offsets within the
  * `textContent` of HTML elements.

--- a/src/annotator/annotation-counts.js
+++ b/src/annotator/annotation-counts.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const events = require('../shared/bridge-events');
 
 const ANNOTATION_COUNT_ATTR = 'data-hypothesis-annotation-count';

--- a/src/annotator/annotation-sync.js
+++ b/src/annotator/annotation-sync.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // AnnotationSync listens for messages from the sidebar app indicating that
 // annotations have been added or removed and relays them to Guest.
 //

--- a/src/annotator/config/config-func-settings-from.js
+++ b/src/annotator/config/config-func-settings-from.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Return an object containing config settings from window.hypothesisConfig().
  *

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const settingsFrom = require('./settings');
 
 /**

--- a/src/annotator/config/is-browser-extension.js
+++ b/src/annotator/config/is-browser-extension.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Return true if the client is from a browser extension.
  *

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const configFuncSettingsFrom = require('./config-func-settings-from');
 const isBrowserExtension = require('./is-browser-extension');
 const sharedSettings = require('../../shared/settings');

--- a/src/annotator/config/test/config-func-settings-from-test.js
+++ b/src/annotator/config/test/config-func-settings-from-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const configFuncSettingsFrom = require('../config-func-settings-from');
 
 describe('annotator.config.configFuncSettingsFrom', function() {

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const configFrom = require('../index');
 
 describe('annotator.config.index', function() {

--- a/src/annotator/config/test/is-browser-extension-test.js
+++ b/src/annotator/config/test/is-browser-extension-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const isBrowserExtension = require('../is-browser-extension');
 
 describe('annotator.config.isBrowserExtension', function() {

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const settingsFrom = require('../settings');
 
 describe('annotator.config.settingsFrom', function() {

--- a/src/annotator/features.js
+++ b/src/annotator/features.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const events = require('../shared/bridge-events');
 const warnOnce = require('../shared/warn-once');
 

--- a/src/annotator/frame-observer.js
+++ b/src/annotator/frame-observer.js
@@ -1,5 +1,3 @@
-'use strict';
-
 let FrameUtil = require('./util/frame-util');
 let debounce = require('lodash.debounce');
 

--- a/src/annotator/highlighter/index.js
+++ b/src/annotator/highlighter/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const domWrapHighlighter = require('./dom-wrap-highlighter');
 const overlayHighlighter = require('./overlay-highlighter');
 const features = require('../features');

--- a/src/annotator/highlighter/overlay-highlighter/index.js
+++ b/src/annotator/highlighter/overlay-highlighter/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = {
   highlightRange: () => {
     // eslint-disable-next-line no-console

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const $ = require('jquery');
 
 // Load polyfill for :focus-visible pseudo-class.

--- a/src/annotator/pdf-sidebar.js
+++ b/src/annotator/pdf-sidebar.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const Sidebar = require('./sidebar');
 
 const DEFAULT_CONFIG = {

--- a/src/annotator/pdfjs-rendering-states.js
+++ b/src/annotator/pdfjs-rendering-states.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Enum values for page rendering states (IRenderableView#renderingState)
  * in PDF.js. Taken from web/pdf_rendering_queue.js in the PDF.js library.

--- a/src/annotator/plugin/document.js
+++ b/src/annotator/plugin/document.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*
  ** Adapted from:
  ** https://github.com/openannotation/annotator/blob/v1.2.x/src/plugin/document.coffee

--- a/src/annotator/plugin/pdf-metadata.js
+++ b/src/annotator/plugin/pdf-metadata.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { normalizeURI } = require('../util/url');
 
 /**

--- a/src/annotator/plugin/test/document-test.js
+++ b/src/annotator/plugin/test/document-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*
  ** Adapted from:
  ** https://github.com/openannotation/annotator/blob/v1.2.x/test/spec/plugin/document_spec.coffee

--- a/src/annotator/plugin/test/pdf-metadata-test.js
+++ b/src/annotator/plugin/test/pdf-metadata-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const PDFMetadata = require('../pdf-metadata');
 
 /**

--- a/src/annotator/plugin/test/toolbar-test.js
+++ b/src/annotator/plugin/test/toolbar-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const $ = require('jquery');
 
 const Toolbar = require('../toolbar');

--- a/src/annotator/range-util.js
+++ b/src/annotator/range-util.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Returns true if the start point of a selection occurs after the end point,
  * in document order.

--- a/src/annotator/selections.js
+++ b/src/annotator/selections.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const observable = require('./util/observable');
 
 /** Returns the selected `DOMRange` in `document`. */

--- a/src/annotator/sidebar-trigger.js
+++ b/src/annotator/sidebar-trigger.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const SIDEBAR_TRIGGER_BTN_ATTR = 'data-hypothesis-trigger';
 
 /**

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const adder = require('../adder');
 
 function rect(left, top, width, height) {

--- a/src/annotator/test/annotation-counts-test.js
+++ b/src/annotator/test/annotation-counts-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const annotationCounts = require('../annotation-counts');
 
 describe('annotationCounts', function() {

--- a/src/annotator/test/annotation-sync-test.js
+++ b/src/annotator/test/annotation-sync-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const EventEmitter = require('tiny-emitter');
 
 const AnnotationSync = require('../annotation-sync');

--- a/src/annotator/test/features-test.js
+++ b/src/annotator/test/features-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const events = require('../../shared/bridge-events');
 const features = require('../features');
 

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -1,8 +1,6 @@
 // Tests that the expected parts of the page are highlighted when annotations
 // with various combinations of selector are anchored.
 
-'use strict';
-
 const Guest = require('../../guest');
 
 function quoteSelector(quote) {

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const isLoaded = require('../../util/frame-util').isLoaded;
 
 const FRAME_DEBOUNCE_WAIT = require('../../frame-observer').DEBOUNCE_WAIT + 10;

--- a/src/annotator/test/range-util-test.js
+++ b/src/annotator/test/range-util-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const rangeUtil = require('../range-util');
 
 function createRange(node, start, end) {

--- a/src/annotator/test/selections-test.js
+++ b/src/annotator/test/selections-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const observable = require('../util/observable');
 const selections = require('../selections');
 

--- a/src/annotator/test/sidebar-trigger-test.js
+++ b/src/annotator/test/sidebar-trigger-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const sidebarTrigger = require('../sidebar-trigger');
 
 describe('sidebarTrigger', function() {

--- a/src/annotator/util/frame-util.js
+++ b/src/annotator/util/frame-util.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Return all `<iframe>` elements under `container` which are annotate-able.
  *

--- a/src/annotator/util/observable.js
+++ b/src/annotator/util/observable.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Functions (aka. 'operators') for generating and manipulating streams of
  * values using the Observable API.

--- a/src/annotator/util/test/frame-util-test.js
+++ b/src/annotator/util/test/frame-util-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const frameUtil = require('../frame-util');
 
 describe('annotator.util.frame-util', function() {

--- a/src/annotator/util/test/observable-test.js
+++ b/src/annotator/util/test/observable-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const observable = require('../observable');
 
 describe('observable', function() {

--- a/src/annotator/util/test/url-test.js
+++ b/src/annotator/util/test/url-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { normalizeURI } = require('../url');
 
 describe('annotator.util.url', () => {

--- a/src/annotator/util/url.js
+++ b/src/annotator/util/url.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const baseURI = require('document-base-uri');
 
 /**

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { requiredPolyfillSets } = require('../shared/polyfills');
 
 function injectStylesheet(doc, href) {

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // This is the main entry point for the Hypothesis client in the host page
 // and the sidebar application.
 //

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const boot = require('../boot');
 
 function assetUrl(url) {

--- a/src/boot/test/url-template-test.js
+++ b/src/boot/test/url-template-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const processUrlTemplate = require('../url-template');
 
 describe('processUrlTemplate', () => {

--- a/src/boot/url-template.js
+++ b/src/boot/url-template.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Extract the protocol and hostname (ie. host without port) from the URL.
  *

--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -1,7 +1,5 @@
 /* global process */
 
-'use strict';
-
 /* global __dirname */
 
 const path = require('path');

--- a/src/shared/bridge-events.js
+++ b/src/shared/bridge-events.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * This module defines the set of global events that are dispatched
  * across the bridge between the sidebar and annotator

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const extend = require('extend');
 
 const RPC = require('./frame-rpc');

--- a/src/shared/discovery.js
+++ b/src/shared/discovery.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Callback invoked when another frame is discovered in this window which runs
  * the Hypothesis sidebar or annotation layer code.

--- a/src/shared/frame-rpc.js
+++ b/src/shared/frame-rpc.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* eslint-disable */
 
 /** This software is released under the MIT license:

--- a/src/shared/polyfills/document.evaluate.js
+++ b/src/shared/polyfills/document.evaluate.js
@@ -1,4 +1,2 @@
-'use strict';
-
 const wgxpath = require('wicked-good-xpath');
 wgxpath.install();

--- a/src/shared/polyfills/es2015.js
+++ b/src/shared/polyfills/es2015.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // ES2015
 //
 // nb. The imports which add entire classes (Promise, Set etc.) will also add

--- a/src/shared/polyfills/es2016.js
+++ b/src/shared/polyfills/es2016.js
@@ -1,3 +1,1 @@
-'use strict';
-
 require('core-js/es/array/includes');

--- a/src/shared/polyfills/es2017.js
+++ b/src/shared/polyfills/es2017.js
@@ -1,4 +1,2 @@
-'use strict';
-
 require('core-js/es/object/entries');
 require('core-js/es/object/values');

--- a/src/shared/polyfills/fetch.js
+++ b/src/shared/polyfills/fetch.js
@@ -1,3 +1,1 @@
-'use strict';
-
 require('whatwg-fetch');

--- a/src/shared/polyfills/index.js
+++ b/src/shared/polyfills/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Checkers to test which polyfills are required by the current browser.
  *

--- a/src/shared/polyfills/string.prototype.normalize.js
+++ b/src/shared/polyfills/string.prototype.normalize.js
@@ -1,3 +1,1 @@
-'use strict';
-
 require('unorm');

--- a/src/shared/polyfills/test/index-test.js
+++ b/src/shared/polyfills/test/index-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { requiredPolyfillSets } = require('../');
 
 function stubOut(obj, property, replacement = undefined) {

--- a/src/shared/polyfills/url.js
+++ b/src/shared/polyfills/url.js
@@ -1,3 +1,1 @@
-'use strict';
-
 require('js-polyfills/url');

--- a/src/shared/settings.js
+++ b/src/shared/settings.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // `Object.assign()`-like helper. Used because this script needs to work
 // in IE 10/11 without polyfills.
 function assign(dest, src) {

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const Bridge = require('../bridge');
 const RPC = require('../frame-rpc');
 

--- a/src/shared/test/discovery-test.js
+++ b/src/shared/test/discovery-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const Discovery = require('../discovery');
 
 function createWindow() {

--- a/src/shared/test/promise-util.js
+++ b/src/shared/test/promise-util.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Helper to assert a promise is rejected.
  *

--- a/src/shared/test/settings-test.js
+++ b/src/shared/test/settings-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const settings = require('../settings');
 
 const sandbox = sinon.createSandbox();

--- a/src/shared/test/warn-once-test.js
+++ b/src/shared/test/warn-once-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const warnOnce = require('../warn-once');
 
 describe('warnOnce', () => {

--- a/src/shared/warn-once.js
+++ b/src/shared/warn-once.js
@@ -1,5 +1,3 @@
-'use strict';
-
 let shownWarnings = {};
 
 /**

--- a/src/sidebar/build-thread.js
+++ b/src/sidebar/build-thread.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /** Default state for new threads, before applying filters etc. */
 const DEFAULT_THREAD_STATE = {
   /**

--- a/src/sidebar/components/annotation-action-bar.js
+++ b/src/sidebar/components/annotation-action-bar.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/annotation-body.js
+++ b/src/sidebar/components/annotation-body.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const propTypes = require('prop-types');
 

--- a/src/sidebar/components/annotation-document-info.js
+++ b/src/sidebar/components/annotation-document-info.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/annotation-header.js
+++ b/src/sidebar/components/annotation-header.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/annotation-license.js
+++ b/src/sidebar/components/annotation-license.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 
 const SvgIcon = require('./svg-icon');

--- a/src/sidebar/components/annotation-publish-control.js
+++ b/src/sidebar/components/annotation-publish-control.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/annotation-quote.js
+++ b/src/sidebar/components/annotation-quote.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const classnames = require('classnames');
 const { createElement } = require('preact');
 const propTypes = require('prop-types');

--- a/src/sidebar/components/annotation-share-control.js
+++ b/src/sidebar/components/annotation-share-control.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 const { useEffect, useRef, useState } = require('preact/hooks');

--- a/src/sidebar/components/annotation-share-info.js
+++ b/src/sidebar/components/annotation-share-info.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/annotation-thread.js
+++ b/src/sidebar/components/annotation-thread.js
@@ -1,5 +1,3 @@
-'use strict';
-
 function hiddenCount(thread) {
   const isHidden = thread.annotation && !thread.visible;
   return thread.children.reduce(

--- a/src/sidebar/components/annotation-user.js
+++ b/src/sidebar/components/annotation-user.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/annotation-viewer-content.js
+++ b/src/sidebar/components/annotation-viewer-content.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Fetch all annotations in the same thread as `id`.
  *

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const {
   isNew,
   isReply,

--- a/src/sidebar/components/button.js
+++ b/src/sidebar/components/button.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const classnames = require('classnames');
 const propTypes = require('prop-types');
 const { createElement } = require('preact');

--- a/src/sidebar/components/excerpt.js
+++ b/src/sidebar/components/excerpt.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const classnames = require('classnames');
 const propTypes = require('prop-types');
 const { createElement } = require('preact');

--- a/src/sidebar/components/focused-mode-header.js
+++ b/src/sidebar/components/focused-mode-header.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 
 const useStore = require('../store/use-store');

--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { Fragment, createElement } = require('preact');
 

--- a/src/sidebar/components/group-list-section.js
+++ b/src/sidebar/components/group-list-section.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const propTypes = require('prop-types');
 

--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { useMemo, useState } = require('preact/hooks');
 const propTypes = require('prop-types');

--- a/src/sidebar/components/help-panel.js
+++ b/src/sidebar/components/help-panel.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { useCallback, useMemo, useState } = require('preact/hooks');
 const propTypes = require('prop-types');

--- a/src/sidebar/components/hooks/test/use-element-should-close-test.js
+++ b/src/sidebar/components/hooks/test/use-element-should-close-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { useRef } = require('preact/hooks');
 const propTypes = require('prop-types');

--- a/src/sidebar/components/hooks/use-element-should-close.js
+++ b/src/sidebar/components/hooks/use-element-should-close.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { useEffect } = require('preact/hooks');
 
 const { listen } = require('../../util/dom');

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const events = require('../events');
 const { parseAccountID } = require('../util/account-id');
 const serviceConfig = require('../service-config');

--- a/src/sidebar/components/logged-out-message.js
+++ b/src/sidebar/components/logged-out-message.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/markdown-editor.js
+++ b/src/sidebar/components/markdown-editor.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const classnames = require('classnames');
 const { createElement } = require('preact');
 const { useEffect, useRef, useState } = require('preact/hooks');

--- a/src/sidebar/components/markdown-view.js
+++ b/src/sidebar/components/markdown-view.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const classnames = require('classnames');
 const { createElement } = require('preact');
 const { useEffect, useMemo, useRef } = require('preact/hooks');

--- a/src/sidebar/components/menu-item.js
+++ b/src/sidebar/components/menu-item.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const classnames = require('classnames');
 const { createElement } = require('preact');
 const propTypes = require('prop-types');

--- a/src/sidebar/components/menu-section.js
+++ b/src/sidebar/components/menu-section.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { Fragment, createElement, toChildArray } = require('preact');
 const propTypes = require('prop-types');
 

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const classnames = require('classnames');
 const { Fragment, createElement } = require('preact');
 const { useCallback, useEffect, useRef, useState } = require('preact/hooks');

--- a/src/sidebar/components/moderation-banner.js
+++ b/src/sidebar/components/moderation-banner.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const classnames = require('classnames');
 const propTypes = require('prop-types');

--- a/src/sidebar/components/new-note-btn.js
+++ b/src/sidebar/components/new-note-btn.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const propTypes = require('prop-types');
 

--- a/src/sidebar/components/search-input.js
+++ b/src/sidebar/components/search-input.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const classnames = require('classnames');
 const { createElement } = require('preact');
 const { useRef, useState } = require('preact/hooks');

--- a/src/sidebar/components/search-status-bar.js
+++ b/src/sidebar/components/search-status-bar.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const propTypes = require('prop-types');
 const { useMemo } = require('preact/hooks');

--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const classnames = require('classnames');
 const propTypes = require('prop-types');
 const { createElement } = require('preact');

--- a/src/sidebar/components/share-annotations-panel.js
+++ b/src/sidebar/components/share-annotations-panel.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 const useStore = require('../store/use-store');

--- a/src/sidebar/components/share-links.js
+++ b/src/sidebar/components/share-links.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/sidebar-content-error.js
+++ b/src/sidebar/components/sidebar-content-error.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { Fragment, createElement } = require('preact');
 const propTypes = require('prop-types');
 

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const events = require('../events');
 const isThirdPartyService = require('../util/is-third-party-service');
 const tabs = require('../util/tabs');

--- a/src/sidebar/components/sidebar-panel.js
+++ b/src/sidebar/components/sidebar-panel.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 const { useEffect, useRef } = require('preact/hooks');

--- a/src/sidebar/components/slider.js
+++ b/src/sidebar/components/slider.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 const { useCallback, useEffect, useRef, useState } = require('preact/hooks');

--- a/src/sidebar/components/sort-menu.js
+++ b/src/sidebar/components/sort-menu.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 
 const useStore = require('../store/use-store');

--- a/src/sidebar/components/spinner.js
+++ b/src/sidebar/components/spinner.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 
 /**

--- a/src/sidebar/components/stream-content.js
+++ b/src/sidebar/components/stream-content.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // @ngInject
 function StreamContentController(
   $scope,

--- a/src/sidebar/components/stream-search-input.js
+++ b/src/sidebar/components/stream-search-input.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { useEffect, useState } = require('preact/hooks');
 const propTypes = require('prop-types');

--- a/src/sidebar/components/svg-icon.js
+++ b/src/sidebar/components/svg-icon.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const classnames = require('classnames');
 const { createElement } = require('preact');
 const { useLayoutEffect, useRef } = require('preact/hooks');

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const propTypes = require('prop-types');
 const { useMemo, useRef, useState } = require('preact/hooks');

--- a/src/sidebar/components/tag-list.js
+++ b/src/sidebar/components/tag-list.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const propTypes = require('prop-types');
 const { useMemo } = require('preact/hooks');

--- a/src/sidebar/components/test/annotation-action-bar-test.js
+++ b/src/sidebar/components/test/annotation-action-bar-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/annotation-body-test.js
+++ b/src/sidebar/components/test/annotation-body-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/annotation-document-info-test.js
+++ b/src/sidebar/components/test/annotation-document-info-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/annotation-header-test.js
+++ b/src/sidebar/components/test/annotation-header-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/annotation-publish-control-test.js
+++ b/src/sidebar/components/test/annotation-publish-control-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/annotation-quote-test.js
+++ b/src/sidebar/components/test/annotation-quote-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/annotation-share-control-test.js
+++ b/src/sidebar/components/test/annotation-share-control-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 const { act } = require('preact/test-utils');

--- a/src/sidebar/components/test/annotation-share-info-test.js
+++ b/src/sidebar/components/test/annotation-share-info-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 
 const events = require('../../events');

--- a/src/sidebar/components/test/annotation-thread-test.js
+++ b/src/sidebar/components/test/annotation-thread-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 
 const annotationThread = require('../annotation-thread');

--- a/src/sidebar/components/test/annotation-user-test.js
+++ b/src/sidebar/components/test/annotation-user-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/annotation-viewer-content-test.js
+++ b/src/sidebar/components/test/annotation-viewer-content-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 
 // Fake implementation of the API for fetching annotations and replies to

--- a/src/sidebar/components/test/button-test.js
+++ b/src/sidebar/components/test/button-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/excerpt-test.js
+++ b/src/sidebar/components/test/excerpt-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { act } = require('preact/test-utils');
 const { mount } = require('enzyme');

--- a/src/sidebar/components/test/focused-mode-header-test.js
+++ b/src/sidebar/components/test/focused-mode-header-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { act } = require('preact/test-utils');
 

--- a/src/sidebar/components/test/group-list-section-test.js
+++ b/src/sidebar/components/test/group-list-section-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const { createElement } = require('preact');
 const { act } = require('preact/test-utils');

--- a/src/sidebar/components/test/help-panel-test.js
+++ b/src/sidebar/components/test/help-panel-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const { createElement } = require('preact');
 const { act } = require('preact/test-utils');

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 
 const events = require('../../events');

--- a/src/sidebar/components/test/logged-out-message-test.js
+++ b/src/sidebar/components/test/logged-out-message-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/markdown-editor-test.js
+++ b/src/sidebar/components/test/markdown-editor-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement, render } = require('preact');
 const { act } = require('preact/test-utils');
 const { mount } = require('enzyme');

--- a/src/sidebar/components/test/markdown-view-test.js
+++ b/src/sidebar/components/test/markdown-view-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/menu-item-test.js
+++ b/src/sidebar/components/test/menu-item-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/menu-section-test.js
+++ b/src/sidebar/components/test/menu-section-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { act } = require('preact/test-utils');
 const { mount } = require('enzyme');

--- a/src/sidebar/components/test/mock-imported-components.js
+++ b/src/sidebar/components/test/mock-imported-components.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Return true if `value` "looks like" a React/Preact component.
  */

--- a/src/sidebar/components/test/moderation-banner-test.js
+++ b/src/sidebar/components/test/moderation-banner-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/test/new-note-btn-test.js
+++ b/src/sidebar/components/test/new-note-btn-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const { createElement } = require('preact');
 const { act } = require('preact/test-utils');

--- a/src/sidebar/components/test/search-input-test.js
+++ b/src/sidebar/components/test/search-input-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/search-status-bar-test.js
+++ b/src/sidebar/components/test/search-status-bar-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/test/share-annotations-panel-test.js
+++ b/src/sidebar/components/test/share-annotations-panel-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/share-links-test.js
+++ b/src/sidebar/components/test/share-links-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/sidebar-content-error-test.js
+++ b/src/sidebar/components/test/sidebar-content-error-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 const EventEmitter = require('tiny-emitter');
 

--- a/src/sidebar/components/test/sidebar-panel-test.js
+++ b/src/sidebar/components/test/sidebar-panel-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/slider-test.js
+++ b/src/sidebar/components/test/slider-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/test/sort-menu-test.js
+++ b/src/sidebar/components/test/sort-menu-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/spinner-test.js
+++ b/src/sidebar/components/test/spinner-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/stream-content-test.js
+++ b/src/sidebar/components/test/stream-content-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 const EventEmitter = require('tiny-emitter');
 

--- a/src/sidebar/components/test/stream-search-input-test.js
+++ b/src/sidebar/components/test/stream-search-input-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const { createElement } = require('preact');
 const { act } = require('preact/test-utils');

--- a/src/sidebar/components/test/svg-icon-test.js
+++ b/src/sidebar/components/test/svg-icon-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement, render } = require('preact');
 
 const SvgIcon = require('../svg-icon');

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/tag-list-test.js
+++ b/src/sidebar/components/test/tag-list-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/thread-list-test.js
+++ b/src/sidebar/components/test/thread-list-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 
 const EventEmitter = require('tiny-emitter');

--- a/src/sidebar/components/test/timestamp-test.js
+++ b/src/sidebar/components/test/timestamp-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { act } = require('preact/test-utils');
 const { mount } = require('enzyme');

--- a/src/sidebar/components/test/top-bar-test.js
+++ b/src/sidebar/components/test/top-bar-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/tutorial-test.js
+++ b/src/sidebar/components/test/tutorial-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/test/user-menu-test.js
+++ b/src/sidebar/components/test/user-menu-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const { mount } = require('enzyme');
 

--- a/src/sidebar/components/test/version-info-test.js
+++ b/src/sidebar/components/test/version-info-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const { createElement } = require('preact');
 

--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const events = require('../events');
 const metadata = require('../util/annotation-metadata');
 

--- a/src/sidebar/components/timestamp.js
+++ b/src/sidebar/components/timestamp.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 const { useEffect, useMemo, useState } = require('preact/hooks');

--- a/src/sidebar/components/top-bar.js
+++ b/src/sidebar/components/top-bar.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { Fragment, createElement } = require('preact');
 const classnames = require('classnames');
 const propTypes = require('prop-types');

--- a/src/sidebar/components/tutorial.js
+++ b/src/sidebar/components/tutorial.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const propTypes = require('prop-types');
 

--- a/src/sidebar/components/user-menu.js
+++ b/src/sidebar/components/user-menu.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement } = require('preact');
 const propTypes = require('prop-types');
 

--- a/src/sidebar/components/version-info.js
+++ b/src/sidebar/components/version-info.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 

--- a/src/sidebar/cross-origin-rpc.js
+++ b/src/sidebar/cross-origin-rpc.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const warnOnce = require('../shared/warn-once');
 
 /**

--- a/src/sidebar/directive/h-autofocus.js
+++ b/src/sidebar/directive/h-autofocus.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /** An attribute directive that focuses an <input> when it's linked by Angular.
  *
  * The HTML5 autofocus attribute automatically puts the keyboard focus in an

--- a/src/sidebar/directive/h-branding.js
+++ b/src/sidebar/directive/h-branding.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * The BrandingDirective brings theming configuration to our sidebar
  * by allowing the branding hypothesis settings to be reflected on items

--- a/src/sidebar/directive/h-on-touch.js
+++ b/src/sidebar/directive/h-on-touch.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Install an event handler on an element.
  *

--- a/src/sidebar/directive/h-tooltip.js
+++ b/src/sidebar/directive/h-tooltip.js
@@ -1,5 +1,3 @@
-'use strict';
-
 let theTooltip;
 
 /**

--- a/src/sidebar/directive/test/h-branding-fixtures.js
+++ b/src/sidebar/directive/test/h-branding-fixtures.js
@@ -1,5 +1,3 @@
-'use strict';
-// Test data for the firehose of branding combinations
 module.exports = [
   // ALL SUPPORTED PROPERTIES
   {

--- a/src/sidebar/directive/test/h-branding-test.js
+++ b/src/sidebar/directive/test/h-branding-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 
 describe('BrandingDirective', function() {

--- a/src/sidebar/directive/test/h-on-touch-test.js
+++ b/src/sidebar/directive/test/h-on-touch-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 
 const util = require('./util');

--- a/src/sidebar/directive/test/h-tooltip-test.js
+++ b/src/sidebar/directive/test/h-tooltip-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 
 const util = require('./util');

--- a/src/sidebar/directive/test/util.js
+++ b/src/sidebar/directive/test/util.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* global angular */
 
 /**

--- a/src/sidebar/directive/test/window-scroll-test.js
+++ b/src/sidebar/directive/test/window-scroll-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 
 const inject = angular.mock.inject;

--- a/src/sidebar/directive/window-scroll.js
+++ b/src/sidebar/directive/window-scroll.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = function() {
   return {
     link: function(scope, elem, attr) {

--- a/src/sidebar/events.js
+++ b/src/sidebar/events.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * This module defines the set of global events that are dispatched
  * on $rootScope

--- a/src/sidebar/filter/test/url-test.js
+++ b/src/sidebar/filter/test/url-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const url = require('../url');
 
 describe('url.encode', function() {

--- a/src/sidebar/filter/url.js
+++ b/src/sidebar/filter/url.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * URL encode a string, dealing appropriately with null values.
  */

--- a/src/sidebar/ga.js
+++ b/src/sidebar/ga.js
@@ -1,5 +1,3 @@
-'use strict';
-
 let loaded = false;
 
 module.exports = function(trackingId) {

--- a/src/sidebar/get-api-url.js
+++ b/src/sidebar/get-api-url.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const serviceConfig = require('./service-config');
 
 /**

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const queryString = require('query-string');
 
 /**

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const addAnalytics = require('./ga');
 const disableOpenerForExternalLinks = require('./util/disable-opener-for-external-links');
 const { fetchConfig } = require('./util/fetch-config');

--- a/src/sidebar/live-reload-client.js
+++ b/src/sidebar/live-reload-client.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* eslint no-console: "off" */
 
 const queryString = require('query-string');

--- a/src/sidebar/markdown-commands.js
+++ b/src/sidebar/markdown-commands.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Commands for toggling markdown formatting of a selection
  * in an input field.

--- a/src/sidebar/media-embedder.js
+++ b/src/sidebar/media-embedder.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const queryString = require('query-string');
 
 /**

--- a/src/sidebar/render-markdown.js
+++ b/src/sidebar/render-markdown.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const createDOMPurify = require('dompurify');
 const escapeHtml = require('escape-html');
 const katex = require('katex');

--- a/src/sidebar/search-client.js
+++ b/src/sidebar/search-client.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const EventEmitter = require('tiny-emitter');
 
 /**

--- a/src/sidebar/service-config.js
+++ b/src/sidebar/service-config.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Return the configuration for the annotation service which the client would retrieve
  * annotations from which may contain the authority, grantToken and icon.

--- a/src/sidebar/services/analytics.js
+++ b/src/sidebar/services/analytics.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const VIA_REFERRER = /^https:\/\/(qa-)?via.hypothes.is\//;
 
 const events = {

--- a/src/sidebar/services/annotation-mapper.js
+++ b/src/sidebar/services/annotation-mapper.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 
 const events = require('../events');

--- a/src/sidebar/services/annotations.js
+++ b/src/sidebar/services/annotations.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const SearchClient = require('../search-client');
 
 // @ngInject

--- a/src/sidebar/services/api-routes.js
+++ b/src/sidebar/services/api-routes.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { retryPromiseOperation } = require('../util/retry');
 
 /**

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const get = require('lodash.get');
 const queryString = require('query-string');
 

--- a/src/sidebar/services/features.js
+++ b/src/sidebar/services/features.js
@@ -9,8 +9,6 @@
  * change at any time and should write code accordingly. Feature flags should
  * not be cached, and should not be interrogated only at setup time.
  */
-'use strict';
-
 const events = require('../events');
 const bridgeEvents = require('../../shared/bridge-events');
 const warnOnce = require('../../shared/warn-once');

--- a/src/sidebar/services/flash.js
+++ b/src/sidebar/services/flash.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * A service for displaying "flash" notification messages.
  */

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const debounce = require('lodash.debounce');
 
 const events = require('../events');

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const STORAGE_KEY = 'hypothesis.groups.focus';
 const DEFAULT_ORG_ID = '__default__';
 

--- a/src/sidebar/services/local-storage.js
+++ b/src/sidebar/services/local-storage.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Fallback in-memory store if `localStorage` is not read/writable.
  */

--- a/src/sidebar/services/oauth-auth.js
+++ b/src/sidebar/services/oauth-auth.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const events = require('../events');
 const resolve = require('../util/url').resolve;
 const serviceConfig = require('../service-config');

--- a/src/sidebar/services/permissions.js
+++ b/src/sidebar/services/permissions.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const STORAGE_KEY = 'hypothesis.privacy';
 
 /**

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const buildThread = require('../build-thread');
 const events = require('../events');
 const memoize = require('../util/memoize');

--- a/src/sidebar/services/search-filter.js
+++ b/src/sidebar/services/search-filter.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Splits a search term into filter and data.
  *

--- a/src/sidebar/services/service-url.js
+++ b/src/sidebar/services/service-url.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const urlUtil = require('../util/url');
 
 /**

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const events = require('../events');
 const retryUtil = require('../util/retry');
 const sentry = require('../util/sentry');

--- a/src/sidebar/services/stream-filter.js
+++ b/src/sidebar/services/stream-filter.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * StreamFilter generates JSON-serializable configuration objects that
  * control which real-time updates are received from the annotation service.

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const queryString = require('query-string');
 const uuid = require('node-uuid');
 

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * @typedef Tag
  * @property {string} text - The label of the tag

--- a/src/sidebar/services/test/analytics-test.js
+++ b/src/sidebar/services/test/analytics-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const analyticsService = require('../analytics');
 
 describe('analytics', function() {

--- a/src/sidebar/services/test/annotation-mapper-test.js
+++ b/src/sidebar/services/test/annotation-mapper-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 const immutable = require('seamless-immutable');
 

--- a/src/sidebar/services/test/annotations-test.js
+++ b/src/sidebar/services/test/annotations-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const annotations = require('../annotations');
 const EventEmitter = require('tiny-emitter');
 

--- a/src/sidebar/services/test/api-routes-test.js
+++ b/src/sidebar/services/test/api-routes-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const apiRoutesFactory = require('../api-routes');
 
 // Abridged version of the response returned by https://hypothes.is/api,

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const fetchMock = require('fetch-mock');
 
 const apiFactory = require('../api');

--- a/src/sidebar/services/test/features-test.js
+++ b/src/sidebar/services/test/features-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const features = require('../features');
 const events = require('../../events');
 const bridgeEvents = require('../../../shared/bridge-events');

--- a/src/sidebar/services/test/flash-test.js
+++ b/src/sidebar/services/test/flash-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const flash = require('../flash');
 
 describe('sidebar.flash', () => {

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 const EventEmitter = require('tiny-emitter');
 

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const events = require('../../events');
 const fakeReduxStore = require('../../test/fake-redux-store');
 const groups = require('../groups');

--- a/src/sidebar/services/test/local-storage-test.js
+++ b/src/sidebar/services/test/local-storage-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 const service = require('../local-storage');
 

--- a/src/sidebar/services/test/oauth-auth-test.js
+++ b/src/sidebar/services/test/oauth-auth-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 
 const events = require('../../events');

--- a/src/sidebar/services/test/permissions-test.js
+++ b/src/sidebar/services/test/permissions-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const Permissions = require('../permissions');
 
 const userid = 'acct:flash@gord.on';

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 const immutable = require('seamless-immutable');
 

--- a/src/sidebar/services/test/search-filter-test.js
+++ b/src/sidebar/services/test/search-filter-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const searchFilter = require('../search-filter')();
 
 describe('sidebar.search-filter', () => {

--- a/src/sidebar/services/test/service-url-test.js
+++ b/src/sidebar/services/test/service-url-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const serviceUrlFactory = require('../service-url');
 
 /** Return a fake store object. */

--- a/src/sidebar/services/test/session-test.js
+++ b/src/sidebar/services/test/session-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 
 const events = require('../../events');

--- a/src/sidebar/services/test/stream-filter-test.js
+++ b/src/sidebar/services/test/stream-filter-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const StreamFilter = require('../stream-filter');
 
 describe('sidebar/services/stream-filter', () => {

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const EventEmitter = require('tiny-emitter');
 const Streamer = require('../streamer');
 

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 
 const TAGS_LIST_KEY = 'hypothesis.user.tags.list';

--- a/src/sidebar/services/test/unicode-test.js
+++ b/src/sidebar/services/test/unicode-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const unicode = require('../unicode')();
 
 describe('unicode', () => {

--- a/src/sidebar/services/test/view-filter-test.js
+++ b/src/sidebar/services/test/view-filter-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const ViewFilter = require('../view-filter');
 
 function isoDateWithAge(age) {

--- a/src/sidebar/services/unicode.js
+++ b/src/sidebar/services/unicode.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Unicode combining characters
  * from http://xregexp.com/addons/unicode/unicode-categories.js line:30

--- a/src/sidebar/services/view-filter.js
+++ b/src/sidebar/services/view-filter.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { quote } = require('../util/annotation-metadata');
 
 // Prevent Babel inserting helper code after `@ngInject` comment below which

--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const redux = require('redux');
 // `.default` is needed because 'redux-thunk' is built as an ES2015 module
 const thunk = require('redux-thunk').default;

--- a/src/sidebar/store/debug-middleware.js
+++ b/src/sidebar/store/debug-middleware.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * A debug utility that prints information about internal application state
  * changes to the console.

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Central store of state for the sidebar application, managed using
  * [Redux](http://redux.js.org/).

--- a/src/sidebar/store/modules/activity.js
+++ b/src/sidebar/store/modules/activity.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Store module which tracks activity happening in the application that may
  * need to be reflected in the UI.

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -3,8 +3,6 @@
  * sidebar.
  */
 
-'use strict';
-
 const { createSelector } = require('reselect');
 
 const arrayUtil = require('../../util/array');

--- a/src/sidebar/store/modules/direct-linked.js
+++ b/src/sidebar/store/modules/direct-linked.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const util = require('../util');
 
 function init(settings) {

--- a/src/sidebar/store/modules/drafts.js
+++ b/src/sidebar/store/modules/drafts.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const metadata = require('../../util/annotation-metadata');
 const util = require('../util');
 

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createSelector } = require('reselect');
 
 const util = require('../util');

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createSelector } = require('reselect');
 
 const util = require('../util');

--- a/src/sidebar/store/modules/links.js
+++ b/src/sidebar/store/modules/links.js
@@ -7,8 +7,6 @@
  * Used by serviceUrl.
  */
 
-'use strict';
-
 /** Return the initial links. */
 function init() {
   return null;

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * This module contains state related to real-time updates received via the
  * WebSocket connection to h's real-time API.

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -14,8 +14,6 @@
  * @property {string} displayName - User's display name
  */
 
-'use strict';
-
 const { createSelector } = require('reselect');
 const immutable = require('seamless-immutable');
 

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const util = require('../util');
 
 function init() {

--- a/src/sidebar/store/modules/sidebar-panels.js
+++ b/src/sidebar/store/modules/sidebar-panels.js
@@ -8,8 +8,6 @@
  * may be "active" (open) at one time.
  */
 
-'use strict';
-
 const util = require('../util');
 
 function init() {

--- a/src/sidebar/store/modules/test/activity-test.js
+++ b/src/sidebar/store/modules/test/activity-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const createStore = require('../../create-store');
 const activity = require('../activity');
 

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const annotations = require('../annotations');
 const createStoreFromModules = require('../../create-store');
 const drafts = require('../drafts');

--- a/src/sidebar/store/modules/test/direct-linked-test.js
+++ b/src/sidebar/store/modules/test/direct-linked-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const createStore = require('../../create-store');
 const directLinked = require('../direct-linked');
 

--- a/src/sidebar/store/modules/test/drafts-test.js
+++ b/src/sidebar/store/modules/test/drafts-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const immutable = require('seamless-immutable');
 
 const drafts = require('../drafts');

--- a/src/sidebar/store/modules/test/frames-test.js
+++ b/src/sidebar/store/modules/test/frames-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const frames = require('../frames');
 const createStore = require('../../create-store');
 

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const immutable = require('seamless-immutable');
 
 const createStore = require('../../create-store');

--- a/src/sidebar/store/modules/test/links-test.js
+++ b/src/sidebar/store/modules/test/links-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const links = require('../links');
 
 const init = links.init;

--- a/src/sidebar/store/modules/test/real-time-updates-test.js
+++ b/src/sidebar/store/modules/test/real-time-updates-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const createStore = require('../../create-store');
 
 const annotations = require('../annotations');

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const annotations = require('../annotations');
 const createStore = require('../../create-store');
 const selection = require('../selection');

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const createStore = require('../../create-store');
 const session = require('../session');
 

--- a/src/sidebar/store/modules/test/sidebar-panels-test.js
+++ b/src/sidebar/store/modules/test/sidebar-panels-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const createStore = require('../../create-store');
 const sidebarPanels = require('../sidebar-panels');
 

--- a/src/sidebar/store/modules/test/viewer-test.js
+++ b/src/sidebar/store/modules/test/viewer-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const viewer = require('../viewer');
 const createStore = require('../../create-store');
 

--- a/src/sidebar/store/modules/viewer.js
+++ b/src/sidebar/store/modules/viewer.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const util = require('../util');
 
 /**

--- a/src/sidebar/store/test/create-store-test.js
+++ b/src/sidebar/store/test/create-store-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const createStore = require('../create-store');
 
 const A = 0;

--- a/src/sidebar/store/test/debug-middleware-test.js
+++ b/src/sidebar/store/test/debug-middleware-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* eslint-disable no-console */
 
 const redux = require('redux');

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const immutable = require('seamless-immutable');
 
 const storeFactory = require('../index');

--- a/src/sidebar/store/test/use-store-test.js
+++ b/src/sidebar/store/test/use-store-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const { createStore } = require('redux');
 const { createElement } = require('preact');

--- a/src/sidebar/store/test/util-test.js
+++ b/src/sidebar/store/test/util-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const util = require('../util');
 
 const fixtures = {

--- a/src/sidebar/store/use-store.js
+++ b/src/sidebar/store/use-store.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* global process */
 
 const shallowEqual = require('shallowequal');

--- a/src/sidebar/store/util.js
+++ b/src/sidebar/store/util.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Return an object where each key in `updateFns` is mapped to the key itself.
  */

--- a/src/sidebar/test/annotation-fixtures.js
+++ b/src/sidebar/test/annotation-fixtures.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Return a fake annotation with the basic properties filled in.
  */

--- a/src/sidebar/test/bootstrap.js
+++ b/src/sidebar/test/bootstrap.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Expose the sinon assertions.
 sinon.assert.expose(assert, { prefix: null });
 

--- a/src/sidebar/test/build-thread-test.js
+++ b/src/sidebar/test/build-thread-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const buildThread = require('../build-thread');
 const metadata = require('../util/annotation-metadata');
 

--- a/src/sidebar/test/cross-origin-rpc-test.js
+++ b/src/sidebar/test/cross-origin-rpc-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const crossOriginRPC = require('../cross-origin-rpc');
 
 describe('crossOriginRPC', function() {

--- a/src/sidebar/test/fake-redux-store.js
+++ b/src/sidebar/test/fake-redux-store.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const redux = require('redux');
 
 /**

--- a/src/sidebar/test/get-api-url-test.js
+++ b/src/sidebar/test/get-api-url-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const getApiUrl = require('../get-api-url');
 
 describe('sidebar.getApiUrl', function() {

--- a/src/sidebar/test/group-fixtures.js
+++ b/src/sidebar/test/group-fixtures.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const Chance = require('chance');
 const chance = new Chance();
 

--- a/src/sidebar/test/host-config-test.js
+++ b/src/sidebar/test/host-config-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const hostPageConfig = require('../host-config');
 
 function fakeWindow(config) {

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 const immutable = require('seamless-immutable');
 

--- a/src/sidebar/test/markdown-commands-test.js
+++ b/src/sidebar/test/markdown-commands-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const commands = require('../markdown-commands');
 
 /**

--- a/src/sidebar/test/media-embedder-test.js
+++ b/src/sidebar/test/media-embedder-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const mediaEmbedder = require('../media-embedder.js');
 
 describe('media-embedder', function() {

--- a/src/sidebar/test/render-markdown-test.js
+++ b/src/sidebar/test/render-markdown-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const renderMarkdown = require('../render-markdown');
 
 describe('render-markdown', function() {

--- a/src/sidebar/test/search-client-test.js
+++ b/src/sidebar/test/search-client-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const SearchClient = require('../search-client');
 
 function awaitEvent(emitter, event) {

--- a/src/sidebar/test/service-config-test.js
+++ b/src/sidebar/test/service-config-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const serviceConfig = require('../service-config');
 
 describe('serviceConfig', function() {

--- a/src/sidebar/test/virtual-thread-list-test.js
+++ b/src/sidebar/test/virtual-thread-list-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const VirtualThreadList = require('../virtual-thread-list');
 
 describe('VirtualThreadList', function() {

--- a/src/sidebar/test/websocket-test.js
+++ b/src/sidebar/test/websocket-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const Socket = require('../websocket');
 
 describe('websocket wrapper', function() {

--- a/src/sidebar/ui-constants.js
+++ b/src/sidebar/ui-constants.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * uiConstants is a set of globally used constants across the application.
  */

--- a/src/sidebar/util/account-id.js
+++ b/src/sidebar/util/account-id.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Parses H account names of the form 'acct:<username>@<provider>'
  * into a {username, provider} object or null if the input does not

--- a/src/sidebar/util/annotation-metadata.js
+++ b/src/sidebar/util/annotation-metadata.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Utility functions for querying annotation metadata.
  */

--- a/src/sidebar/util/annotation-sharing.js
+++ b/src/sidebar/util/annotation-sharing.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const serviceConfig = require('../service-config');
 
 /**

--- a/src/sidebar/util/array.js
+++ b/src/sidebar/util/array.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Return the number of elements in `ary` for which `predicate` returns true.
  *

--- a/src/sidebar/util/copy-to-clipboard.js
+++ b/src/sidebar/util/copy-to-clipboard.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Copy the string `text` to the clipboard.
  *

--- a/src/sidebar/util/date.js
+++ b/src/sidebar/util/date.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // cached date formatting instance.
 // See https://github.com/hypothesis/h/issues/2820#issuecomment-166285361
 let formatter;

--- a/src/sidebar/util/disable-opener-for-external-links.js
+++ b/src/sidebar/util/disable-opener-for-external-links.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Prevent windows or tabs opened via links under `root` from accessing their
  * opening `Window`.

--- a/src/sidebar/util/dom.js
+++ b/src/sidebar/util/dom.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Attach listeners for one or multiple events to an element and return a
  * function that removes the listeners.

--- a/src/sidebar/util/fetch-config.js
+++ b/src/sidebar/util/fetch-config.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const getApiUrl = require('../get-api-url');
 const hostConfig = require('../host-config');
 const postMessageJsonRpc = require('./postmessage-json-rpc');

--- a/src/sidebar/util/group-list-item-common.js
+++ b/src/sidebar/util/group-list-item-common.js
@@ -1,5 +1,3 @@
-'use strict';
-
 function orgName(group) {
   return group.organization && group.organization.name;
 }

--- a/src/sidebar/util/group-organizations.js
+++ b/src/sidebar/util/group-organizations.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const immutable = require('seamless-immutable');
 
 // TODO: Update when this is a property available on the API response

--- a/src/sidebar/util/groups.js
+++ b/src/sidebar/util/groups.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const escapeStringRegexp = require('escape-string-regexp');
 
 /**

--- a/src/sidebar/util/is-sidebar.js
+++ b/src/sidebar/util/is-sidebar.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Is the instance of the application in the current `window_` within a
  * sidebar (vs. single-annotation or stream view)?

--- a/src/sidebar/util/is-third-party-service.js
+++ b/src/sidebar/util/is-third-party-service.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const serviceConfig = require('../service-config');
 
 /**

--- a/src/sidebar/util/memoize.js
+++ b/src/sidebar/util/memoize.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * A simple memoization function which caches the last result of
  * a single-argument function.

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const queryString = require('query-string');
 
 const random = require('./random');

--- a/src/sidebar/util/observe-element-size.js
+++ b/src/sidebar/util/observe-element-size.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Watch for changes in the size (`clientWidth` and `clientHeight`) of
  * an element.

--- a/src/sidebar/util/on-activate.js
+++ b/src/sidebar/util/on-activate.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Return a set of props that can be applied to a React DOM element to make
  * it activateable like a button.

--- a/src/sidebar/util/postmessage-json-rpc.js
+++ b/src/sidebar/util/postmessage-json-rpc.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { generateHexString } = require('./random');
 
 /** Generate a random ID to associate RPC requests and responses. */

--- a/src/sidebar/util/random.js
+++ b/src/sidebar/util/random.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* global Uint8Array */
 
 function byteToHex(val) {

--- a/src/sidebar/util/retry.js
+++ b/src/sidebar/util/retry.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const retry = require('retry');
 
 /**

--- a/src/sidebar/util/scope-timeout.js
+++ b/src/sidebar/util/scope-timeout.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Sets a timeout which is linked to the lifetime of an Angular scope.
  *

--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const Sentry = require('@sentry/browser');
 
 const warnOnce = require('../../shared/warn-once');

--- a/src/sidebar/util/service-context.js
+++ b/src/sidebar/util/service-context.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* global process */
 
 /**

--- a/src/sidebar/util/session.js
+++ b/src/sidebar/util/session.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const serviceConfig = require('../service-config');
 
 /**

--- a/src/sidebar/util/state.js
+++ b/src/sidebar/util/state.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Return a value from app state when it meets certain criteria.
  *

--- a/src/sidebar/util/tabs.js
+++ b/src/sidebar/util/tabs.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Functions that determine which tab an annotation should be displayed in.
 
 const metadata = require('./annotation-metadata');

--- a/src/sidebar/util/test/account-id-test.js
+++ b/src/sidebar/util/test/account-id-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { parseAccountID, username, isThirdPartyUser } = require('../account-id');
 
 describe('sidebar.util.account-id', function() {

--- a/src/sidebar/util/test/annotation-metadata-test.js
+++ b/src/sidebar/util/test/annotation-metadata-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const annotationMetadata = require('../annotation-metadata');
 const fixtures = require('../../test/annotation-fixtures');
 

--- a/src/sidebar/util/test/annotation-sharing-test.js
+++ b/src/sidebar/util/test/annotation-sharing-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const sharingUtil = require('../annotation-sharing');
 
 describe('sidebar.util.annotation-sharing', () => {

--- a/src/sidebar/util/test/copy-to-clipboard-test.js
+++ b/src/sidebar/util/test/copy-to-clipboard-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { copyText } = require('../copy-to-clipboard');
 
 describe('copy-to-clipboard', () => {

--- a/src/sidebar/util/test/disable-opener-for-external-links-test.js
+++ b/src/sidebar/util/test/disable-opener-for-external-links-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const disableOpenerForExternalLinks = require('../disable-opener-for-external-links');
 
 describe('sidebar.util.disable-opener-for-external-links', () => {

--- a/src/sidebar/util/test/dom-test.js
+++ b/src/sidebar/util/test/dom-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { listen } = require('../dom');
 
 describe('sidebar/util/dom', () => {

--- a/src/sidebar/util/test/fake-window.js
+++ b/src/sidebar/util/test/fake-window.js
@@ -1,5 +1,3 @@
-'use strict';
-
 class FakeWindow {
   constructor() {
     this.callbacks = [];

--- a/src/sidebar/util/test/fetch-config-test.js
+++ b/src/sidebar/util/test/fetch-config-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const {
   assertPromiseIsRejected,
 } = require('../../../shared/test/promise-util');

--- a/src/sidebar/util/test/group-list-item-common-test.js
+++ b/src/sidebar/util/test/group-list-item-common-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const groupListItemCommon = require('../group-list-item-common');
 
 const { events } = require('../../services/analytics');

--- a/src/sidebar/util/test/group-organizations-test.js
+++ b/src/sidebar/util/test/group-organizations-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const groupsByOrganization = require('../group-organizations');
 const orgFixtures = require('../../test/group-fixtures');
 

--- a/src/sidebar/util/test/groups-test.js
+++ b/src/sidebar/util/test/groups-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { combineGroups } = require('../groups');
 
 describe('sidebar.util.groups', () => {

--- a/src/sidebar/util/test/is-sidebar-test.js
+++ b/src/sidebar/util/test/is-sidebar-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const isSidebar = require('../is-sidebar');
 
 describe('sidebar.utils.is-sidebar', () => {

--- a/src/sidebar/util/test/is-third-party-service-test.js
+++ b/src/sidebar/util/test/is-third-party-service-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const isThirdPartyService = require('../is-third-party-service');
 
 describe('sidebar.util.isThirdPartyService', () => {

--- a/src/sidebar/util/test/memoize-test.js
+++ b/src/sidebar/util/test/memoize-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const memoize = require('../memoize');
 
 describe('memoize', function() {

--- a/src/sidebar/util/test/oauth-client-test.js
+++ b/src/sidebar/util/test/oauth-client-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const fetchMock = require('fetch-mock');
 const { stringify } = require('query-string');
 const sinon = require('sinon');

--- a/src/sidebar/util/test/observe-element-size-test.js
+++ b/src/sidebar/util/test/observe-element-size-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const observeElementSize = require('../observe-element-size');
 
 /**

--- a/src/sidebar/util/test/postmessage-json-rpc-test.js
+++ b/src/sidebar/util/test/postmessage-json-rpc-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const EventEmitter = require('tiny-emitter');
 
 const {

--- a/src/sidebar/util/test/random-test.js
+++ b/src/sidebar/util/test/random-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const random = require('../random');
 
 describe('sidebar.util.random', () => {

--- a/src/sidebar/util/test/retry-test.js
+++ b/src/sidebar/util/test/retry-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const retryUtil = require('../retry');
 const toResult = require('../../../shared/test/promise-util').toResult;
 

--- a/src/sidebar/util/test/scope-timeout-test.js
+++ b/src/sidebar/util/test/scope-timeout-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const scopeTimeout = require('../scope-timeout');
 
 function FakeScope() {

--- a/src/sidebar/util/test/sentry-test.js
+++ b/src/sidebar/util/test/sentry-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const sentry = require('../sentry');
 
 describe('sidebar/util/sentry', () => {

--- a/src/sidebar/util/test/service-context-test.js
+++ b/src/sidebar/util/test/service-context-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { mount } = require('enzyme');
 const propTypes = require('prop-types');
 const { createElement, render } = require('preact');

--- a/src/sidebar/util/test/session-test.js
+++ b/src/sidebar/util/test/session-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const sessionUtil = require('../session');
 
 describe('sidebar/util/session', () => {

--- a/src/sidebar/util/test/state-test.js
+++ b/src/sidebar/util/test/state-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const fakeStore = require('../../test/fake-redux-store');
 const stateUtil = require('../state');
 

--- a/src/sidebar/util/test/tabs-test.js
+++ b/src/sidebar/util/test/tabs-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const fixtures = require('../../test/annotation-fixtures');
 const uiConstants = require('../../ui-constants');
 const tabs = require('../tabs');

--- a/src/sidebar/util/test/theme-test.js
+++ b/src/sidebar/util/test/theme-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { applyTheme } = require('../theme');
 
 describe('sidebar/util/theme/applyTheme', () => {

--- a/src/sidebar/util/test/time-test.js
+++ b/src/sidebar/util/test/time-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const time = require('../time');
 
 const second = 1000;

--- a/src/sidebar/util/test/url-test.js
+++ b/src/sidebar/util/test/url-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const urlUtil = require('../url');
 
 describe('sidebar/util/url', function() {

--- a/src/sidebar/util/test/version-data-test.js
+++ b/src/sidebar/util/test/version-data-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const VersionData = require('../version-data');
 
 describe('VersionData', () => {

--- a/src/sidebar/util/test/wrap-react-component-test.js
+++ b/src/sidebar/util/test/wrap-react-component-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const angular = require('angular');
 const { Component, createElement } = require('preact');
 const { useContext } = require('preact/hooks');

--- a/src/sidebar/util/theme.js
+++ b/src/sidebar/util/theme.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * @const {Object} All supported options for theming and their corresponding
  *                 CSS property names (JS-style)

--- a/src/sidebar/util/time.js
+++ b/src/sidebar/util/time.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Utility functions for generating formatted "fuzzy" date strings and
  * computing decaying intervals for updating those dates in a UI.

--- a/src/sidebar/util/url.js
+++ b/src/sidebar/util/url.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Replace parameters in a URL template with values from a `params` object.
  *

--- a/src/sidebar/util/version-data.js
+++ b/src/sidebar/util/version-data.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * An object representing user info
  *

--- a/src/sidebar/util/wrap-react-component.js
+++ b/src/sidebar/util/wrap-react-component.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { createElement, render } = require('preact');
 const { ServiceContext } = require('./service-context');
 

--- a/src/sidebar/virtual-thread-list.js
+++ b/src/sidebar/virtual-thread-list.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const EventEmitter = require('tiny-emitter');
 const debounce = require('lodash.debounce');
 

--- a/src/sidebar/websocket.js
+++ b/src/sidebar/websocket.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const retry = require('retry');
 const EventEmitter = require('tiny-emitter');
 


### PR DESCRIPTION
In preparation for converting the client source to ES modules, in order
that the pattern library and other frontend apps all use the same module
system, change the source type for ESLint to "module" and remove the
"use strict" declarations at the top of each source file.

Babel already inserts "use strict" at the top of every module it
processes and support for transpiling ES modules is already enabled by
@babel/preset-env.

The change is only applied to modules in `src/` as build scripts
(gulpfile.js, `scripts/**.js`) are not treated as modules.

----

With theses changes `import` and `export` can be used in modules inside `src/` and use of `"use strict";` in those modules will produce a lint error.