### PR TITLE
Fix incorrect attribute type

### DIFF
--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -156,7 +156,7 @@ function SelectionTabs({ isLoading, settings }) {
               Create one by selecting some text and clicking the{' '}
               <SvgIcon
                 name="annotate"
-                inline="true"
+                inline={true}
                 className="selection-tabs__icon"
               />{' '}
               button.


### PR DESCRIPTION
This is a quick fix for a small bug in https://github.com/hypothesis/client/pull/1612 (merged/deployed yesterday).

There was a property (attribute) on an `SvgIcon` that was being set incorrectly; it should be `boolean`, not `string`