### PR TITLE
Convert most `require`s to ES `import` syntax

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -1,6 +1,6 @@
-const classnames = require('classnames');
+import classnames from 'classnames';
 
-const template = require('./adder.html');
+import template from './adder.html';
 
 const ANNOTATE_BTN_SELECTOR = '.js-annotate-btn';
 const HIGHLIGHT_BTN_SELECTOR = '.js-highlight-btn';

--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -1,15 +1,15 @@
 /* global PDFViewerApplication */
 
-const seek = require('dom-seek');
+import seek from 'dom-seek';
 
 // `dom-node-iterator` polyfills optional arguments of `createNodeIterator`
 // and properties of the returned `NodeIterator` for IE 11 compatibility.
 const createNodeIterator = require('dom-node-iterator/polyfill')();
 
-const xpathRange = require('./range');
-const RenderingStates = require('../pdfjs-rendering-states');
-const { TextPositionAnchor, TextQuoteAnchor } = require('./types');
-const { toRange: textPositionToRange } = require('./text-position');
+import xpathRange from './range';
+import RenderingStates from '../pdfjs-rendering-states';
+import { TextPositionAnchor, TextQuoteAnchor } from './types';
+import { toRange as textPositionToRange } from './text-position';
 
 // Caches for performance.
 

--- a/src/annotator/anchoring/test/fake-pdf-viewer-application.js
+++ b/src/annotator/anchoring/test/fake-pdf-viewer-application.js
@@ -9,7 +9,7 @@
  * each of the relevant classes in PDF.js.
  */
 
-const RenderingStates = require('../../pdfjs-rendering-states');
+import RenderingStates from '../../pdfjs-rendering-states';
 
 /**
  * Create the DOM structure for a page which matches the structure produced by

--- a/src/annotator/anchoring/test/html-test.js
+++ b/src/annotator/anchoring/test/html-test.js
@@ -1,6 +1,6 @@
 const html = require('../html');
 
-const toResult = require('../../../shared/test/promise-util').toResult;
+const { toResult } = require('../../../shared/test/promise-util');
 const fixture = require('./html-anchoring-fixture.html');
 
 /** Return all text node children of `container`. */

--- a/src/annotator/anchoring/test/html-test.js
+++ b/src/annotator/anchoring/test/html-test.js
@@ -1,7 +1,6 @@
-const html = require('../html');
-
-const { toResult } = require('../../../shared/test/promise-util');
-const fixture = require('./html-anchoring-fixture.html');
+import * as html from '../html';
+import { toResult } from '../../../shared/test/promise-util';
+import fixture from './html-anchoring-fixture.html';
 
 /** Return all text node children of `container`. */
 function textNodes(container) {

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -1,7 +1,7 @@
-const domAnchorTextQuote = require('dom-anchor-text-quote');
+import * as domAnchorTextQuote from 'dom-anchor-text-quote';
 
-const FakePDFViewerApplication = require('./fake-pdf-viewer-application');
-const pdfAnchoring = require('../pdf');
+import FakePDFViewerApplication from './fake-pdf-viewer-application';
+import * as pdfAnchoring from '../pdf';
 
 /**
  * Return a DOM Range which refers to the specified `text` in `container`.

--- a/src/annotator/anchoring/test/text-position-test.js
+++ b/src/annotator/anchoring/test/text-position-test.js
@@ -1,4 +1,4 @@
-const { toRange } = require('../text-position');
+import { toRange } from '../text-position';
 
 describe('text-position', () => {
   let container;

--- a/src/annotator/anchoring/test/types-test.js
+++ b/src/annotator/anchoring/test/types-test.js
@@ -1,4 +1,4 @@
-const types = require('../types');
+import * as types from '../types';
 
 const TextQuoteAnchor = types.TextQuoteAnchor;
 const TextPositionAnchor = types.TextPositionAnchor;

--- a/src/annotator/annotation-counts.js
+++ b/src/annotator/annotation-counts.js
@@ -1,4 +1,4 @@
-const events = require('../shared/bridge-events');
+import * as events from '../shared/bridge-events';
 
 const ANNOTATION_COUNT_ATTR = 'data-hypothesis-annotation-count';
 

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -1,4 +1,4 @@
-const settingsFrom = require('./settings');
+import settingsFrom from './settings';
 
 /**
  * Reads the Hypothesis configuration from the environment.

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -1,6 +1,6 @@
-const configFuncSettingsFrom = require('./config-func-settings-from');
-const isBrowserExtension = require('./is-browser-extension');
-const sharedSettings = require('../../shared/settings');
+import configFuncSettingsFrom from './config-func-settings-from';
+import isBrowserExtension from './is-browser-extension';
+import * as sharedSettings from '../../shared/settings';
 
 function settingsFrom(window_) {
   const jsonConfigs = sharedSettings.jsonConfigsFrom(window_.document);

--- a/src/annotator/config/test/config-func-settings-from-test.js
+++ b/src/annotator/config/test/config-func-settings-from-test.js
@@ -1,4 +1,4 @@
-const configFuncSettingsFrom = require('../config-func-settings-from');
+import configFuncSettingsFrom from '../config-func-settings-from';
 
 describe('annotator.config.configFuncSettingsFrom', function() {
   const sandbox = sinon.createSandbox();

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -1,4 +1,4 @@
-const configFrom = require('../index');
+import configFrom from '../index';
 
 describe('annotator.config.index', function() {
   let fakeSettingsFrom;

--- a/src/annotator/config/test/is-browser-extension-test.js
+++ b/src/annotator/config/test/is-browser-extension-test.js
@@ -1,4 +1,4 @@
-const isBrowserExtension = require('../is-browser-extension');
+import isBrowserExtension from '../is-browser-extension';
 
 describe('annotator.config.isBrowserExtension', function() {
   [

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -1,4 +1,4 @@
-const settingsFrom = require('../settings');
+import settingsFrom from '../settings';
 
 describe('annotator.config.settingsFrom', function() {
   let fakeConfigFuncSettingsFrom;

--- a/src/annotator/features.js
+++ b/src/annotator/features.js
@@ -1,5 +1,5 @@
-const events = require('../shared/bridge-events');
-const warnOnce = require('../shared/warn-once');
+import * as events from '../shared/bridge-events';
+import warnOnce from '../shared/warn-once';
 
 let _features = {};
 

--- a/src/annotator/frame-observer.js
+++ b/src/annotator/frame-observer.js
@@ -1,5 +1,6 @@
-let FrameUtil = require('./util/frame-util');
-let debounce = require('lodash.debounce');
+import * as FrameUtil from './util/frame-util';
+
+import debounce from 'lodash.debounce';
 
 // Find difference of two arrays
 let difference = (arrayA, arrayB) => {

--- a/src/annotator/highlighter/index.js
+++ b/src/annotator/highlighter/index.js
@@ -1,6 +1,6 @@
-const domWrapHighlighter = require('./dom-wrap-highlighter');
-const overlayHighlighter = require('./overlay-highlighter');
-const features = require('../features');
+import * as domWrapHighlighter from './dom-wrap-highlighter';
+import * as overlayHighlighter from './overlay-highlighter';
+import * as features from '../features';
 
 // we need a facade for the highlighter interface
 // that will let us lazy check the overlay_highlighter feature

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -1,12 +1,12 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
 // Load polyfill for :focus-visible pseudo-class.
-require('focus-visible');
+import 'focus-visible';
 
-const configFrom = require('./config/index');
-const Guest = require('./guest');
-const Sidebar = require('./sidebar');
-const PdfSidebar = require('./pdf-sidebar');
+import configFrom from './config/index';
+import Guest from './guest';
+import Sidebar from './sidebar';
+import PdfSidebar from './pdf-sidebar';
 
 const pluginClasses = {
   // UI plugins

--- a/src/annotator/pdf-sidebar.js
+++ b/src/annotator/pdf-sidebar.js
@@ -1,4 +1,4 @@
-const Sidebar = require('./sidebar');
+import Sidebar from './sidebar';
 
 const DEFAULT_CONFIG = {
   TextSelection: {},

--- a/src/annotator/plugin/document.js
+++ b/src/annotator/plugin/document.js
@@ -10,10 +10,10 @@
  ** https://github.com/openannotation/annotator/blob/master/LICENSE
  */
 
-const baseURI = require('document-base-uri');
+import baseURI from 'document-base-uri';
 
-const Plugin = require('../plugin');
-const { normalizeURI } = require('../util/url');
+import Plugin from '../plugin';
+import { normalizeURI } from '../util/url';
 
 /**
  * DocumentMeta reads metadata/links from the current HTML document and

--- a/src/annotator/plugin/pdf-metadata.js
+++ b/src/annotator/plugin/pdf-metadata.js
@@ -1,4 +1,4 @@
-const { normalizeURI } = require('../util/url');
+import { normalizeURI } from '../util/url';
 
 /**
  * @typedef Link

--- a/src/annotator/plugin/test/document-test.js
+++ b/src/annotator/plugin/test/document-test.js
@@ -10,10 +10,10 @@
  ** https://github.com/openannotation/annotator/blob/master/LICENSE
  */
 
-const $ = require('jquery');
+import $ from 'jquery';
 
-const DocumentMeta = require('../document');
-const { normalizeURI } = require('../../util/url');
+import DocumentMeta from '../document';
+import { normalizeURI } from '../../util/url';
 
 describe('DocumentMeta', function() {
   let fakeNormalizeURI;

--- a/src/annotator/plugin/test/pdf-metadata-test.js
+++ b/src/annotator/plugin/test/pdf-metadata-test.js
@@ -1,4 +1,4 @@
-const PDFMetadata = require('../pdf-metadata');
+import PDFMetadata from '../pdf-metadata';
 
 /**
  * Fake implementation of PDF.js `window.PDFViewerApplication.metadata`.

--- a/src/annotator/plugin/test/toolbar-test.js
+++ b/src/annotator/plugin/test/toolbar-test.js
@@ -1,6 +1,6 @@
-const $ = require('jquery');
+import $ from 'jquery';
 
-const Toolbar = require('../toolbar');
+import Toolbar from '../toolbar';
 
 describe('Toolbar', () => {
   let container;

--- a/src/annotator/selections.js
+++ b/src/annotator/selections.js
@@ -1,4 +1,4 @@
-const observable = require('./util/observable');
+import * as observable from './util/observable';
 
 /** Returns the selected `DOMRange` in `document`. */
 function selectedRange(document) {

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -1,4 +1,4 @@
-const adder = require('../adder');
+import * as adder from '../adder';
 
 function rect(left, top, width, height) {
   return { left: left, top: top, width: width, height: height };

--- a/src/annotator/test/annotation-counts-test.js
+++ b/src/annotator/test/annotation-counts-test.js
@@ -1,4 +1,4 @@
-const annotationCounts = require('../annotation-counts');
+import annotationCounts from '../annotation-counts';
 
 describe('annotationCounts', function() {
   let countEl1;

--- a/src/annotator/test/annotation-sync-test.js
+++ b/src/annotator/test/annotation-sync-test.js
@@ -1,6 +1,6 @@
-const EventEmitter = require('tiny-emitter');
+import EventEmitter from 'tiny-emitter';
 
-const AnnotationSync = require('../annotation-sync');
+import AnnotationSync from '../annotation-sync';
 
 describe('AnnotationSync', function() {
   let createAnnotationSync;

--- a/src/annotator/test/features-test.js
+++ b/src/annotator/test/features-test.js
@@ -1,5 +1,5 @@
-const events = require('../../shared/bridge-events');
-const features = require('../features');
+import * as events from '../../shared/bridge-events';
+import * as features from '../features';
 
 describe('features - annotation layer', function() {
   let featureFlagsUpdateHandler;

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -1,7 +1,7 @@
 // Tests that the expected parts of the page are highlighted when annotations
 // with various combinations of selector are anchored.
 
-const Guest = require('../../guest');
+import Guest from '../../guest';
 
 function quoteSelector(quote) {
   return {

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -1,7 +1,7 @@
-const { isLoaded } = require('../../util/frame-util');
+import { isLoaded } from '../../util/frame-util';
 
 const FRAME_DEBOUNCE_WAIT = require('../../frame-observer').DEBOUNCE_WAIT + 10;
-const CrossFrame = require('../../plugin/cross-frame');
+import CrossFrame from '../../plugin/cross-frame';
 
 describe('CrossFrame multi-frame scenario', function() {
   let fakeAnnotationSync;

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -1,4 +1,4 @@
-const isLoaded = require('../../util/frame-util').isLoaded;
+const { isLoaded } = require('../../util/frame-util');
 
 const FRAME_DEBOUNCE_WAIT = require('../../frame-observer').DEBOUNCE_WAIT + 10;
 const CrossFrame = require('../../plugin/cross-frame');

--- a/src/annotator/test/range-util-test.js
+++ b/src/annotator/test/range-util-test.js
@@ -1,4 +1,4 @@
-const rangeUtil = require('../range-util');
+import * as rangeUtil from '../range-util';
 
 function createRange(node, start, end) {
   const range = node.ownerDocument.createRange();

--- a/src/annotator/test/selections-test.js
+++ b/src/annotator/test/selections-test.js
@@ -1,5 +1,5 @@
-const observable = require('../util/observable');
-const selections = require('../selections');
+import * as observable from '../util/observable';
+import selections from '../selections';
 
 function FakeDocument() {
   const listeners = {};

--- a/src/annotator/test/sidebar-trigger-test.js
+++ b/src/annotator/test/sidebar-trigger-test.js
@@ -1,4 +1,4 @@
-const sidebarTrigger = require('../sidebar-trigger');
+import sidebarTrigger from '../sidebar-trigger';
 
 describe('sidebarTrigger', function() {
   let triggerEl1;

--- a/src/annotator/util/observable.js
+++ b/src/annotator/util/observable.js
@@ -3,7 +3,7 @@
  * values using the Observable API.
  */
 
-const Observable = require('zen-observable');
+import Observable from 'zen-observable';
 
 /**
  * Returns an observable of events emitted by a DOM event source

--- a/src/annotator/util/test/frame-util-test.js
+++ b/src/annotator/util/test/frame-util-test.js
@@ -1,4 +1,4 @@
-const frameUtil = require('../frame-util');
+import * as frameUtil from '../frame-util';
 
 describe('annotator.util.frame-util', function() {
   describe('findFrames', function() {

--- a/src/annotator/util/test/observable-test.js
+++ b/src/annotator/util/test/observable-test.js
@@ -1,4 +1,4 @@
-const observable = require('../observable');
+import * as observable from '../observable';
 
 describe('observable', function() {
   describe('delay()', function() {

--- a/src/annotator/util/test/url-test.js
+++ b/src/annotator/util/test/url-test.js
@@ -1,4 +1,4 @@
-const { normalizeURI } = require('../url');
+import { normalizeURI } from '../url';
 
 describe('annotator.util.url', () => {
   describe('normalizeURI', () => {

--- a/src/annotator/util/url.js
+++ b/src/annotator/util/url.js
@@ -1,4 +1,4 @@
-const baseURI = require('document-base-uri');
+import baseURI from 'document-base-uri';
 
 /**
  * Return a normalized version of a URI.

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -1,4 +1,4 @@
-const { requiredPolyfillSets } = require('../shared/polyfills');
+import { requiredPolyfillSets } from '../shared/polyfills';
 
 function injectStylesheet(doc, href) {
   const link = doc.createElement('link');

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -9,9 +9,10 @@
 
 /* global __MANIFEST__ */
 
-const boot = require('./boot');
-const { jsonConfigsFrom } = require('../shared/settings');
-const processUrlTemplate = require('./url-template');
+import boot from './boot';
+
+import { jsonConfigsFrom } from '../shared/settings';
+import processUrlTemplate from './url-template';
 
 const settings = jsonConfigsFrom(document);
 

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -10,8 +10,10 @@
 /* global __MANIFEST__ */
 
 const boot = require('./boot');
-const settings = require('../shared/settings').jsonConfigsFrom(document);
+const { jsonConfigsFrom } = require('../shared/settings');
 const processUrlTemplate = require('./url-template');
+
+const settings = jsonConfigsFrom(document);
 
 boot(document, {
   assetRoot: processUrlTemplate(settings.assetRoot || '__ASSET_ROOT__'),

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -1,4 +1,4 @@
-const boot = require('../boot');
+import boot from '../boot';
 
 function assetUrl(url) {
   return `https://marginal.ly/client/build/${url}`;

--- a/src/boot/test/url-template-test.js
+++ b/src/boot/test/url-template-test.js
@@ -1,4 +1,4 @@
-const processUrlTemplate = require('../url-template');
+import processUrlTemplate from '../url-template';
 
 describe('processUrlTemplate', () => {
   let fakeDocument;

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -1,6 +1,6 @@
-const extend = require('extend');
+import extend from 'extend';
 
-const RPC = require('./frame-rpc');
+import RPC from './frame-rpc';
 
 /**
  * The Bridge service sets up a channel between frames and provides an events

--- a/src/shared/polyfills/document.evaluate.js
+++ b/src/shared/polyfills/document.evaluate.js
@@ -1,2 +1,2 @@
-const wgxpath = require('wicked-good-xpath');
+import * as wgxpath from 'wicked-good-xpath';
 wgxpath.install();

--- a/src/shared/polyfills/es2015.js
+++ b/src/shared/polyfills/es2015.js
@@ -3,16 +3,17 @@
 // nb. The imports which add entire classes (Promise, Set etc.) will also add
 // all features for later ES years, so this can result in some duplication with
 // bundles for later ES years.
-require('core-js/es/promise');
-require('core-js/es/map');
-require('core-js/es/number');
-require('core-js/es/set');
-require('core-js/es/symbol');
-require('core-js/es/array/fill');
-require('core-js/es/array/find');
-require('core-js/es/array/find-index');
-require('core-js/es/array/from');
-require('core-js/es/object/assign');
-require('core-js/es/string/includes');
-require('core-js/es/string/ends-with');
-require('core-js/es/string/starts-with');
+import 'core-js/es/promise';
+
+import 'core-js/es/map';
+import 'core-js/es/number';
+import 'core-js/es/set';
+import 'core-js/es/symbol';
+import 'core-js/es/array/fill';
+import 'core-js/es/array/find';
+import 'core-js/es/array/find-index';
+import 'core-js/es/array/from';
+import 'core-js/es/object/assign';
+import 'core-js/es/string/includes';
+import 'core-js/es/string/ends-with';
+import 'core-js/es/string/starts-with';

--- a/src/shared/polyfills/es2016.js
+++ b/src/shared/polyfills/es2016.js
@@ -1,1 +1,1 @@
-require('core-js/es/array/includes');
+import 'core-js/es/array/includes';

--- a/src/shared/polyfills/es2017.js
+++ b/src/shared/polyfills/es2017.js
@@ -1,2 +1,2 @@
-require('core-js/es/object/entries');
-require('core-js/es/object/values');
+import 'core-js/es/object/entries';
+import 'core-js/es/object/values';

--- a/src/shared/polyfills/fetch.js
+++ b/src/shared/polyfills/fetch.js
@@ -1,1 +1,1 @@
-require('whatwg-fetch');
+import 'whatwg-fetch';

--- a/src/shared/polyfills/string.prototype.normalize.js
+++ b/src/shared/polyfills/string.prototype.normalize.js
@@ -1,1 +1,1 @@
-require('unorm');
+import 'unorm';

--- a/src/shared/polyfills/test/index-test.js
+++ b/src/shared/polyfills/test/index-test.js
@@ -1,4 +1,4 @@
-const { requiredPolyfillSets } = require('../');
+import { requiredPolyfillSets } from '../';
 
 function stubOut(obj, property, replacement = undefined) {
   const saved = obj[property];

--- a/src/shared/polyfills/url.js
+++ b/src/shared/polyfills/url.js
@@ -1,1 +1,1 @@
-require('js-polyfills/url');
+import 'js-polyfills/url';

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -1,5 +1,5 @@
-const Bridge = require('../bridge');
-const RPC = require('../frame-rpc');
+import Bridge from '../bridge';
+import RPC from '../frame-rpc';
 
 describe('shared.bridge', function() {
   const sandbox = sinon.createSandbox();

--- a/src/shared/test/discovery-test.js
+++ b/src/shared/test/discovery-test.js
@@ -1,4 +1,4 @@
-const Discovery = require('../discovery');
+import Discovery from '../discovery';
 
 function createWindow() {
   return {

--- a/src/shared/test/settings-test.js
+++ b/src/shared/test/settings-test.js
@@ -1,4 +1,4 @@
-const settings = require('../settings');
+import * as settings from '../settings';
 
 const sandbox = sinon.createSandbox();
 

--- a/src/shared/test/warn-once-test.js
+++ b/src/shared/test/warn-once-test.js
@@ -1,4 +1,4 @@
-const warnOnce = require('../warn-once');
+import warnOnce from '../warn-once';
 
 describe('warnOnce', () => {
   beforeEach(() => {

--- a/src/sidebar/components/annotation-action-bar.js
+++ b/src/sidebar/components/annotation-action-bar.js
@@ -1,11 +1,10 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
 
-const { withServices } = require('../util/service-context');
-const { isShareable, shareURI } = require('../util/annotation-sharing');
-
-const AnnotationShareControl = require('./annotation-share-control');
-const Button = require('./button');
+import { withServices } from '../util/service-context';
+import { isShareable, shareURI } from '../util/annotation-sharing';
+import AnnotationShareControl from './annotation-share-control';
+import Button from './button';
 
 /**
  * A collection of `Button`s in the footer area of an annotation.

--- a/src/sidebar/components/annotation-body.js
+++ b/src/sidebar/components/annotation-body.js
@@ -1,9 +1,9 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const Excerpt = require('./excerpt');
-const MarkdownEditor = require('./markdown-editor');
-const MarkdownView = require('./markdown-view');
+import Excerpt from './excerpt';
+import MarkdownEditor from './markdown-editor';
+import MarkdownView from './markdown-view';
 
 /**
  * Display the rendered content of an annotation.

--- a/src/sidebar/components/annotation-document-info.js
+++ b/src/sidebar/components/annotation-document-info.js
@@ -1,7 +1,7 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
 
-const annotationMetadata = require('../util/annotation-metadata');
+import * as annotationMetadata from '../util/annotation-metadata';
 
 /**
  * Render some metadata about an annotation's document and link to it

--- a/src/sidebar/components/annotation-header.js
+++ b/src/sidebar/components/annotation-header.js
@@ -1,11 +1,11 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
 
-const AnnotationDocumentInfo = require('./annotation-document-info');
-const AnnotationShareInfo = require('./annotation-share-info');
-const AnnotationUser = require('./annotation-user');
-const SvgIcon = require('./svg-icon');
-const Timestamp = require('./timestamp');
+import AnnotationDocumentInfo from './annotation-document-info';
+import AnnotationShareInfo from './annotation-share-info';
+import AnnotationUser from './annotation-user';
+import SvgIcon from './svg-icon';
+import Timestamp from './timestamp';
 
 /**
  * Render an annotation's header summary, including metadata about its user,

--- a/src/sidebar/components/annotation-license.js
+++ b/src/sidebar/components/annotation-license.js
@@ -1,6 +1,6 @@
-const { createElement } = require('preact');
+import { createElement } from 'preact';
 
-const SvgIcon = require('./svg-icon');
+import SvgIcon from './svg-icon';
 
 /**
  * Render information about CC licensing

--- a/src/sidebar/components/annotation-publish-control.js
+++ b/src/sidebar/components/annotation-publish-control.js
@@ -1,12 +1,11 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
 
-const { applyTheme } = require('../util/theme');
-const { withServices } = require('../util/service-context');
-
-const Button = require('./button');
-const Menu = require('./menu');
-const MenuItem = require('./menu-item');
+import { applyTheme } from '../util/theme';
+import { withServices } from '../util/service-context';
+import Button from './button';
+import Menu from './menu';
+import MenuItem from './menu-item';
 
 /**
  * Render a compound control button for publishing (saving) an annotation:

--- a/src/sidebar/components/annotation-quote.js
+++ b/src/sidebar/components/annotation-quote.js
@@ -1,10 +1,10 @@
-const classnames = require('classnames');
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const { withServices } = require('../util/service-context');
-const { applyTheme } = require('../util/theme');
-const Excerpt = require('./excerpt');
+import { withServices } from '../util/service-context';
+import { applyTheme } from '../util/theme';
+import Excerpt from './excerpt';
 
 /**
  * Display the selected text from the document associated with an annotation.

--- a/src/sidebar/components/annotation-share-control.js
+++ b/src/sidebar/components/annotation-share-control.js
@@ -1,14 +1,13 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
-const { useEffect, useRef, useState } = require('preact/hooks');
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
+import { useEffect, useRef, useState } from 'preact/hooks';
 
-const useElementShouldClose = require('./hooks/use-element-should-close');
-const { copyText } = require('../util/copy-to-clipboard');
-const { withServices } = require('../util/service-context');
-
-const Button = require('./button');
-const ShareLinks = require('./share-links');
-const SvgIcon = require('./svg-icon');
+import useElementShouldClose from './hooks/use-element-should-close';
+import { copyText } from '../util/copy-to-clipboard';
+import { withServices } from '../util/service-context';
+import Button from './button';
+import ShareLinks from './share-links';
+import SvgIcon from './svg-icon';
 
 /**
  * "Popup"-style component for sharing a single annotation.

--- a/src/sidebar/components/annotation-share-info.js
+++ b/src/sidebar/components/annotation-share-info.js
@@ -1,10 +1,9 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
 
-const { withServices } = require('../util/service-context');
-const useStore = require('../store/use-store');
-
-const SvgIcon = require('./svg-icon');
+import { withServices } from '../util/service-context';
+import useStore from '../store/use-store';
+import SvgIcon from './svg-icon';
 
 /**
  * Render information about what group an annotation is in and

--- a/src/sidebar/components/annotation-user.js
+++ b/src/sidebar/components/annotation-user.js
@@ -1,8 +1,8 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
 
-const { isThirdPartyUser, username } = require('../util/account-id');
-const { withServices } = require('../util/service-context');
+import { isThirdPartyUser, username } from '../util/account-id';
+import { withServices } from '../util/service-context';
 
 /**
  * Display information about an annotation's user. Link to the user's

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -1,11 +1,6 @@
-const {
-  isNew,
-  isReply,
-  isPageNote,
-  quote,
-} = require('../util/annotation-metadata');
-const events = require('../events');
-const { isThirdPartyUser } = require('../util/account-id');
+import { isNew, isReply, isPageNote, quote } from '../util/annotation-metadata';
+import * as events from '../events';
+import { isThirdPartyUser } from '../util/account-id';
 
 /**
  * Return a copy of `annotation` with changes made in the editor applied.

--- a/src/sidebar/components/button.js
+++ b/src/sidebar/components/button.js
@@ -1,8 +1,8 @@
-const classnames = require('classnames');
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import classnames from 'classnames';
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
 
-const SvgIcon = require('./svg-icon');
+import SvgIcon from './svg-icon';
 
 /**
  * A button, one of three base types depending on provided props:

--- a/src/sidebar/components/excerpt.js
+++ b/src/sidebar/components/excerpt.js
@@ -1,16 +1,11 @@
-const classnames = require('classnames');
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
-const {
-  useCallback,
-  useLayoutEffect,
-  useRef,
-  useState,
-} = require('preact/hooks');
+import classnames from 'classnames';
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
+import { useCallback, useLayoutEffect, useRef, useState } from 'preact/hooks';
 
-const { applyTheme } = require('../util/theme');
-const { withServices } = require('../util/service-context');
-const observeElementSize = require('../util/observe-element-size');
+import { applyTheme } from '../util/theme';
+import { withServices } from '../util/service-context';
+import observeElementSize from '../util/observe-element-size';
 
 /**
  * An optional toggle link at the bottom of an excerpt which controls whether

--- a/src/sidebar/components/focused-mode-header.js
+++ b/src/sidebar/components/focused-mode-header.js
@@ -1,6 +1,6 @@
-const { createElement } = require('preact');
+import { createElement } from 'preact';
 
-const useStore = require('../store/use-store');
+import useStore from '../store/use-store';
 
 /**
  * Render a control to interact with any focused "mode" in the sidebar.

--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -1,12 +1,11 @@
-const propTypes = require('prop-types');
-const { Fragment, createElement } = require('preact');
+import propTypes from 'prop-types';
+import { Fragment, createElement } from 'preact';
 
-const useStore = require('../store/use-store');
-const { orgName } = require('../util/group-list-item-common');
-const { withServices } = require('../util/service-context');
-const { copyText } = require('../util/copy-to-clipboard');
-
-const MenuItem = require('./menu-item');
+import useStore from '../store/use-store';
+import { orgName } from '../util/group-list-item-common';
+import { withServices } from '../util/service-context';
+import { copyText } from '../util/copy-to-clipboard';
+import MenuItem from './menu-item';
 
 /**
  * An item in the groups selection menu.

--- a/src/sidebar/components/group-list-section.js
+++ b/src/sidebar/components/group-list-section.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const GroupListItem = require('./group-list-item');
-const MenuSection = require('./menu-section');
+import GroupListItem from './group-list-item';
+import MenuSection from './menu-section';
 
 /**
  * A labeled section of the groups list.

--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -1,17 +1,16 @@
-const { createElement } = require('preact');
-const { useMemo, useState } = require('preact/hooks');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import { useMemo, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const isThirdPartyService = require('../util/is-third-party-service');
-const { isThirdPartyUser } = require('../util/account-id');
-const groupsByOrganization = require('../util/group-organizations');
-const useStore = require('../store/use-store');
-const { withServices } = require('../util/service-context');
-const serviceConfig = require('../service-config');
-
-const Menu = require('./menu');
-const MenuItem = require('./menu-item');
-const GroupListSection = require('./group-list-section');
+import isThirdPartyService from '../util/is-third-party-service';
+import { isThirdPartyUser } from '../util/account-id';
+import groupsByOrganization from '../util/group-organizations';
+import useStore from '../store/use-store';
+import { withServices } from '../util/service-context';
+import serviceConfig from '../service-config';
+import Menu from './menu';
+import MenuItem from './menu-item';
+import GroupListSection from './group-list-section';
 
 /**
  * Return the custom icon for the top bar configured by the publisher in

--- a/src/sidebar/components/help-panel.js
+++ b/src/sidebar/components/help-panel.js
@@ -1,16 +1,15 @@
-const { createElement } = require('preact');
-const { useCallback, useMemo, useState } = require('preact/hooks');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import { useCallback, useMemo, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const uiConstants = require('../ui-constants');
-const useStore = require('../store/use-store');
-const VersionData = require('../util/version-data');
-const { withServices } = require('../util/service-context');
-
-const SidebarPanel = require('./sidebar-panel');
-const SvgIcon = require('./svg-icon');
-const Tutorial = require('./tutorial');
-const VersionInfo = require('./version-info');
+import * as uiConstants from '../ui-constants';
+import useStore from '../store/use-store';
+import VersionData from '../util/version-data';
+import { withServices } from '../util/service-context';
+import SidebarPanel from './sidebar-panel';
+import SvgIcon from './svg-icon';
+import Tutorial from './tutorial';
+import VersionInfo from './version-info';
 
 /**
  * External link "tabs" inside of the help panel.

--- a/src/sidebar/components/hooks/test/use-element-should-close-test.js
+++ b/src/sidebar/components/hooks/test/use-element-should-close-test.js
@@ -1,11 +1,10 @@
-const { createElement } = require('preact');
-const { useRef } = require('preact/hooks');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import { useRef } from 'preact/hooks';
+import propTypes from 'prop-types';
+import { act } from 'preact/test-utils';
+import { mount } from 'enzyme';
 
-const { act } = require('preact/test-utils');
-const { mount } = require('enzyme');
-
-const useElementShouldClose = require('../use-element-should-close');
+import useElementShouldClose from '../use-element-should-close';
 
 describe('hooks.useElementShouldClose', () => {
   let handleClose;

--- a/src/sidebar/components/hooks/use-element-should-close.js
+++ b/src/sidebar/components/hooks/use-element-should-close.js
@@ -1,6 +1,6 @@
-const { useEffect } = require('preact/hooks');
+import { useEffect } from 'preact/hooks';
 
-const { listen } = require('../../util/dom');
+import { listen } from '../../util/dom';
 
 /**
  * This hook adds appropriate `eventListener`s to the document when a target

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -1,10 +1,10 @@
-const events = require('../events');
-const { parseAccountID } = require('../util/account-id');
-const serviceConfig = require('../service-config');
-const bridgeEvents = require('../../shared/bridge-events');
-const uiConstants = require('../ui-constants');
-const isSidebar = require('../util/is-sidebar');
-const { shouldAutoDisplayTutorial } = require('../util/session');
+import * as events from '../events';
+import { parseAccountID } from '../util/account-id';
+import serviceConfig from '../service-config';
+import * as bridgeEvents from '../../shared/bridge-events';
+import * as uiConstants from '../ui-constants';
+import isSidebar from '../util/is-sidebar';
+import { shouldAutoDisplayTutorial } from '../util/session';
 
 /**
  * Return the user's authentication status from their profile.

--- a/src/sidebar/components/logged-out-message.js
+++ b/src/sidebar/components/logged-out-message.js
@@ -1,9 +1,8 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
 
-const { withServices } = require('../util/service-context');
-
-const SvgIcon = require('./svg-icon');
+import { withServices } from '../util/service-context';
+import SvgIcon from './svg-icon';
 
 /**
  * Render a call-to-action to log in or sign up. This message is intended to be

--- a/src/sidebar/components/markdown-editor.js
+++ b/src/sidebar/components/markdown-editor.js
@@ -1,16 +1,11 @@
-const classnames = require('classnames');
-const { createElement } = require('preact');
-const { useEffect, useRef, useState } = require('preact/hooks');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import { useEffect, useRef, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const MarkdownView = require('./markdown-view');
-const {
-  LinkType,
-  convertSelectionToLink,
-  toggleBlockStyle,
-  toggleSpanStyle,
-} = require('../markdown-commands');
-const SvgIcon = require('./svg-icon');
+import MarkdownView from './markdown-view';
+import { LinkType, convertSelectionToLink, toggleBlockStyle, toggleSpanStyle } from '../markdown-commands';
+import SvgIcon from './svg-icon';
 
 // Mapping of toolbar command name to key for Ctrl+<key> keyboard shortcuts.
 // The shortcuts are taken from Stack Overflow's editor.

--- a/src/sidebar/components/markdown-view.js
+++ b/src/sidebar/components/markdown-view.js
@@ -1,10 +1,10 @@
-const classnames = require('classnames');
-const { createElement } = require('preact');
-const { useEffect, useMemo, useRef } = require('preact/hooks');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import { useEffect, useMemo, useRef } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const { replaceLinksWithEmbeds } = require('../media-embedder');
-const renderMarkdown = require('../render-markdown');
+import { replaceLinksWithEmbeds } from '../media-embedder';
+import renderMarkdown from '../render-markdown';
 
 /**
  * A component which renders markdown as HTML and replaces recognized links

--- a/src/sidebar/components/menu-item.js
+++ b/src/sidebar/components/menu-item.js
@@ -1,11 +1,10 @@
-const classnames = require('classnames');
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const { onActivate } = require('../util/on-activate');
-
-const Slider = require('./slider');
-const SvgIcon = require('./svg-icon');
+import { onActivate } from '../util/on-activate';
+import Slider from './slider';
+import SvgIcon from './svg-icon';
 
 /**
  * An item in a dropdown menu.

--- a/src/sidebar/components/menu-section.js
+++ b/src/sidebar/components/menu-section.js
@@ -1,5 +1,5 @@
-const { Fragment, createElement, toChildArray } = require('preact');
-const propTypes = require('prop-types');
+import { Fragment, createElement, toChildArray } from 'preact';
+import propTypes from 'prop-types';
 
 /**
  * Group a set of menu items together visually, with an optional header.

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -1,11 +1,10 @@
-const classnames = require('classnames');
-const { Fragment, createElement } = require('preact');
-const { useCallback, useEffect, useRef, useState } = require('preact/hooks');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { Fragment, createElement } from 'preact';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const useElementShouldClose = require('./hooks/use-element-should-close');
-
-const SvgIcon = require('./svg-icon');
+import useElementShouldClose from './hooks/use-element-should-close';
+import SvgIcon from './svg-icon';
 
 // The triangular indicator below the menu toggle button that visually links it
 // to the menu content.

--- a/src/sidebar/components/moderation-banner.js
+++ b/src/sidebar/components/moderation-banner.js
@@ -1,10 +1,10 @@
-const { createElement } = require('preact');
-const classnames = require('classnames');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import classnames from 'classnames';
+import propTypes from 'prop-types';
 
-const annotationMetadata = require('../util/annotation-metadata');
-const useStore = require('../store/use-store');
-const { withServices } = require('../util/service-context');
+import * as annotationMetadata from '../util/annotation-metadata';
+import useStore from '../store/use-store';
+import { withServices } from '../util/service-context';
 
 /**
  * Banner allows moderators to hide/unhide the flagged

--- a/src/sidebar/components/new-note-btn.js
+++ b/src/sidebar/components/new-note-btn.js
@@ -1,12 +1,11 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const events = require('../events');
-const useStore = require('../store/use-store');
-const { applyTheme } = require('../util/theme');
-const { withServices } = require('../util/service-context');
-
-const Button = require('./button');
+import * as events from '../events';
+import useStore from '../store/use-store';
+import { applyTheme } from '../util/theme';
+import { withServices } from '../util/service-context';
+import Button from './button';
 
 function NewNoteButton({ $rootScope, settings }) {
   const store = useStore(store => ({

--- a/src/sidebar/components/search-input.js
+++ b/src/sidebar/components/search-input.js
@@ -1,12 +1,11 @@
-const classnames = require('classnames');
-const { createElement } = require('preact');
-const { useRef, useState } = require('preact/hooks');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import { useRef, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const useStore = require('../store/use-store');
-
-const Button = require('./button');
-const Spinner = require('./spinner');
+import useStore from '../store/use-store';
+import Button from './button';
+import Spinner from './spinner';
 
 /**
  * An input field in the top bar for entering a query that filters annotations

--- a/src/sidebar/components/search-status-bar.js
+++ b/src/sidebar/components/search-status-bar.js
@@ -1,12 +1,11 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
-const { useMemo } = require('preact/hooks');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
+import { useMemo } from 'preact/hooks';
 
-const { withServices } = require('../util/service-context');
-const uiConstants = require('../ui-constants');
-const useStore = require('../store/use-store');
-
-const Button = require('./button');
+import { withServices } from '../util/service-context';
+import * as uiConstants from '../ui-constants';
+import useStore from '../store/use-store';
+import Button from './button';
 
 /**
  * Of the annotations in the thread `annThread`, how many

--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -1,14 +1,13 @@
-const classnames = require('classnames');
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
-const { Fragment } = require('preact');
+import classnames from 'classnames';
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
+import { Fragment } from 'preact';
 
-const NewNoteBtn = require('./new-note-btn');
-const uiConstants = require('../ui-constants');
-const useStore = require('../store/use-store');
-const { withServices } = require('../util/service-context');
-
-const SvgIcon = require('./svg-icon');
+import NewNoteBtn from './new-note-btn';
+import * as uiConstants from '../ui-constants';
+import useStore from '../store/use-store';
+import { withServices } from '../util/service-context';
+import SvgIcon from './svg-icon';
 
 /**
  *  Display name of the tab and annotation count.

--- a/src/sidebar/components/share-annotations-panel.js
+++ b/src/sidebar/components/share-annotations-panel.js
@@ -1,14 +1,14 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
-const useStore = require('../store/use-store');
-const { copyText } = require('../util/copy-to-clipboard');
-const { withServices } = require('../util/service-context');
-const uiConstants = require('../ui-constants');
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
 
-const Button = require('./button');
-const ShareLinks = require('./share-links');
-const SidebarPanel = require('./sidebar-panel');
-const SvgIcon = require('./svg-icon');
+import useStore from '../store/use-store';
+import { copyText } from '../util/copy-to-clipboard';
+import { withServices } from '../util/service-context';
+import * as uiConstants from '../ui-constants';
+import Button from './button';
+import ShareLinks from './share-links';
+import SidebarPanel from './sidebar-panel';
+import SvgIcon from './svg-icon';
 
 /**
  * A panel for sharing the current group's annotations.

--- a/src/sidebar/components/share-links.js
+++ b/src/sidebar/components/share-links.js
@@ -1,9 +1,8 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
 
-const { withServices } = require('../util/service-context');
-
-const SvgIcon = require('./svg-icon');
+import { withServices } from '../util/service-context';
+import SvgIcon from './svg-icon';
 
 /**
  * A single sharing link as a list item

--- a/src/sidebar/components/sidebar-content-error.js
+++ b/src/sidebar/components/sidebar-content-error.js
@@ -1,5 +1,5 @@
-const { Fragment, createElement } = require('preact');
-const propTypes = require('prop-types');
+import { Fragment, createElement } from 'preact';
+import propTypes from 'prop-types';
 
 /**
  * An error message to display in the sidebar.

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -1,6 +1,6 @@
-const events = require('../events');
-const isThirdPartyService = require('../util/is-third-party-service');
-const tabs = require('../util/tabs');
+import * as events from '../events';
+import isThirdPartyService from '../util/is-third-party-service';
+import * as tabs from '../util/tabs';
 
 // @ngInject
 function SidebarContentController(

--- a/src/sidebar/components/sidebar-panel.js
+++ b/src/sidebar/components/sidebar-panel.js
@@ -1,12 +1,11 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
-const { useEffect, useRef } = require('preact/hooks');
-const scrollIntoView = require('scroll-into-view');
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
+import { useEffect, useRef } from 'preact/hooks';
+import scrollIntoView from 'scroll-into-view';
 
-const useStore = require('../store/use-store');
-
-const Button = require('./button');
-const Slider = require('./slider');
+import useStore from '../store/use-store';
+import Button from './button';
+import Slider from './slider';
 
 /**
  * Base component for a sidebar panel.

--- a/src/sidebar/components/slider.js
+++ b/src/sidebar/components/slider.js
@@ -1,6 +1,6 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
-const { useCallback, useEffect, useRef, useState } = require('preact/hooks');
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 
 /**
  * A container which reveals its content when `visible` is `true` using

--- a/src/sidebar/components/sort-menu.js
+++ b/src/sidebar/components/sort-menu.js
@@ -1,10 +1,9 @@
-const { createElement } = require('preact');
+import { createElement } from 'preact';
 
-const useStore = require('../store/use-store');
-
-const Button = require('./button');
-const Menu = require('./menu');
-const MenuItem = require('./menu-item');
+import useStore from '../store/use-store';
+import Button from './button';
+import Menu from './menu';
+import MenuItem from './menu-item';
 
 /**
  * A drop-down menu of sorting options for a collection of annotations.

--- a/src/sidebar/components/spinner.js
+++ b/src/sidebar/components/spinner.js
@@ -1,4 +1,4 @@
-const { createElement } = require('preact');
+import { createElement } from 'preact';
 
 /**
  * Loading indicator.

--- a/src/sidebar/components/stream-search-input.js
+++ b/src/sidebar/components/stream-search-input.js
@@ -1,10 +1,9 @@
-const { createElement } = require('preact');
-const { useEffect, useState } = require('preact/hooks');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const { withServices } = require('../util/service-context');
-
-const SearchInput = require('./search-input');
+import { withServices } from '../util/service-context';
+import SearchInput from './search-input';
 
 /**
  * Search input for the single annotation view and stream.

--- a/src/sidebar/components/svg-icon.js
+++ b/src/sidebar/components/svg-icon.js
@@ -1,7 +1,7 @@
-const classnames = require('classnames');
-const { createElement } = require('preact');
-const { useLayoutEffect, useRef } = require('preact/hooks');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import { useLayoutEffect, useRef } from 'preact/hooks';
+import propTypes from 'prop-types';
 
 // The list of supported icons
 const icons = {

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -1,9 +1,9 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
-const { useMemo, useRef, useState } = require('preact/hooks');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
+import { useMemo, useRef, useState } from 'preact/hooks';
 
-const { withServices } = require('../util/service-context');
-const SvgIcon = require('./svg-icon');
+import { withServices } from '../util/service-context';
+import SvgIcon from './svg-icon';
 
 // Global counter used to create a unique id for each instance of a TagEditor
 let datalistIdCounter = 0;

--- a/src/sidebar/components/tag-list.js
+++ b/src/sidebar/components/tag-list.js
@@ -1,9 +1,9 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
-const { useMemo } = require('preact/hooks');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
+import { useMemo } from 'preact/hooks';
 
-const { isThirdPartyUser } = require('../util/account-id');
-const { withServices } = require('../util/service-context');
+import { isThirdPartyUser } from '../util/account-id';
+import { withServices } from '../util/service-context';
 
 /**
  * Component to render an annotation's tags.

--- a/src/sidebar/components/test/annotation-action-bar-test.js
+++ b/src/sidebar/components/test/annotation-action-bar-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const AnnotationActionBar = require('../annotation-action-bar');
-const mockImportedComponents = require('./mock-imported-components');
+import AnnotationActionBar from '../annotation-action-bar';
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationActionBar', () => {
   let fakeAnnotation;

--- a/src/sidebar/components/test/annotation-body-test.js
+++ b/src/sidebar/components/test/annotation-body-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const AnnotationBody = require('../annotation-body');
-const mockImportedComponents = require('./mock-imported-components');
+import AnnotationBody from '../annotation-body';
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationBody', () => {
   function createBody(props = {}) {

--- a/src/sidebar/components/test/annotation-document-info-test.js
+++ b/src/sidebar/components/test/annotation-document-info-test.js
@@ -1,10 +1,9 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const fixtures = require('../../test/annotation-fixtures');
-
-const AnnotationDocumentInfo = require('../annotation-document-info');
-const mockImportedComponents = require('./mock-imported-components');
+import * as fixtures from '../../test/annotation-fixtures';
+import AnnotationDocumentInfo from '../annotation-document-info';
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationDocumentInfo', () => {
   let fakeDomainAndTitle;

--- a/src/sidebar/components/test/annotation-header-test.js
+++ b/src/sidebar/components/test/annotation-header-test.js
@@ -1,10 +1,9 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const fixtures = require('../../test/annotation-fixtures');
-
-const AnnotationHeader = require('../annotation-header');
-const mockImportedComponents = require('./mock-imported-components');
+import * as fixtures from '../../test/annotation-fixtures';
+import AnnotationHeader from '../annotation-header';
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationHeader', () => {
   const createAnnotationHeader = props => {

--- a/src/sidebar/components/test/annotation-publish-control-test.js
+++ b/src/sidebar/components/test/annotation-publish-control-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const AnnotationPublishControl = require('../annotation-publish-control');
-const mockImportedComponents = require('./mock-imported-components');
+import AnnotationPublishControl from '../annotation-publish-control';
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationPublishControl', () => {
   let fakeGroup;

--- a/src/sidebar/components/test/annotation-quote-test.js
+++ b/src/sidebar/components/test/annotation-quote-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const AnnotationQuote = require('../annotation-quote');
-const mockImportedComponents = require('./mock-imported-components');
+import AnnotationQuote from '../annotation-quote';
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationQuote', () => {
   function createQuote(props) {

--- a/src/sidebar/components/test/annotation-share-control-test.js
+++ b/src/sidebar/components/test/annotation-share-control-test.js
@@ -1,9 +1,9 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
-const { act } = require('preact/test-utils');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
 
-const AnnotationShareControl = require('../annotation-share-control');
-const mockImportedComponents = require('./mock-imported-components');
+import AnnotationShareControl from '../annotation-share-control';
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationShareControl', () => {
   let fakeAnnotation;

--- a/src/sidebar/components/test/annotation-share-info-test.js
+++ b/src/sidebar/components/test/annotation-share-info-test.js
@@ -1,10 +1,9 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const fixtures = require('../../test/annotation-fixtures');
-
-const AnnotationShareInfo = require('../annotation-share-info');
-const mockImportedComponents = require('./mock-imported-components');
+import * as fixtures from '../../test/annotation-fixtures';
+import AnnotationShareInfo from '../annotation-share-info';
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationShareInfo', () => {
   let fakeGroup;

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -5,6 +5,7 @@ const fixtures = require('../../test/annotation-fixtures');
 const util = require('../../directive/test/util');
 
 const annotationComponent = require('../annotation');
+const { updateModel } = require('../annotation');
 
 const inject = angular.mock.inject;
 
@@ -33,8 +34,6 @@ const groupFixtures = {
 
 describe('annotation', function() {
   describe('updateModel()', function() {
-    const updateModel = require('../annotation').updateModel;
-
     function fakePermissions() {
       return {
         shared: function() {},

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -1,11 +1,10 @@
-const angular = require('angular');
+import angular from 'angular';
 
-const events = require('../../events');
-const fixtures = require('../../test/annotation-fixtures');
-const util = require('../../directive/test/util');
-
-const annotationComponent = require('../annotation');
-const { updateModel } = require('../annotation');
+import * as events from '../../events';
+import * as fixtures from '../../test/annotation-fixtures';
+import * as util from '../../directive/test/util';
+import * as annotationComponent from '../annotation';
+import { updateModel } from '../annotation';
 
 const inject = angular.mock.inject;
 

--- a/src/sidebar/components/test/annotation-thread-test.js
+++ b/src/sidebar/components/test/annotation-thread-test.js
@@ -1,9 +1,9 @@
-const angular = require('angular');
+import angular from 'angular';
 
-const annotationThread = require('../annotation-thread');
-const moderationBanner = require('../moderation-banner');
-const fixtures = require('../../test/annotation-fixtures');
-const util = require('../../directive/test/util');
+import * as annotationThread from '../annotation-thread';
+import moderationBanner from '../moderation-banner';
+import * as fixtures from '../../test/annotation-fixtures';
+import * as util from '../../directive/test/util';
 
 function PageObject(element) {
   this.annotations = function() {

--- a/src/sidebar/components/test/annotation-user-test.js
+++ b/src/sidebar/components/test/annotation-user-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const AnnotationUser = require('../annotation-user');
-const mockImportedComponents = require('./mock-imported-components');
+import AnnotationUser from '../annotation-user';
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationUser', () => {
   let fakeAnnotation;

--- a/src/sidebar/components/test/annotation-viewer-content-test.js
+++ b/src/sidebar/components/test/annotation-viewer-content-test.js
@@ -1,4 +1,4 @@
-const angular = require('angular');
+import angular from 'angular';
 
 // Fake implementation of the API for fetching annotations and replies to
 // annotations.

--- a/src/sidebar/components/test/button-test.js
+++ b/src/sidebar/components/test/button-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const Button = require('../button');
-const mockImportedComponents = require('./mock-imported-components');
+import Button from '../button';
+import mockImportedComponents from './mock-imported-components';
 
 describe('Button', () => {
   let fakeOnClick;

--- a/src/sidebar/components/test/excerpt-test.js
+++ b/src/sidebar/components/test/excerpt-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
+import { mount } from 'enzyme';
 
-const Excerpt = require('../excerpt');
+import Excerpt from '../excerpt';
 
 describe('Excerpt', () => {
   const SHORT_DIV = <div id="foo" style="height: 5px;" />;

--- a/src/sidebar/components/test/focused-mode-header-test.js
+++ b/src/sidebar/components/test/focused-mode-header-test.js
@@ -1,8 +1,8 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const FocusedModeHeader = require('../focused-mode-header');
-const mockImportedComponents = require('./mock-imported-components');
+import FocusedModeHeader from '../focused-mode-header';
+import mockImportedComponents from './mock-imported-components';
 
 describe('FocusedModeHeader', function() {
   let fakeStore;

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -1,10 +1,9 @@
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
+import { mount } from 'enzyme';
 
-const { mount } = require('enzyme');
-const GroupListItem = require('../group-list-item');
-
-const { events } = require('../../services/analytics');
+import GroupListItem from '../group-list-item';
+import { events } from '../../services/analytics';
 
 describe('GroupListItem', () => {
   let fakeAnalytics;

--- a/src/sidebar/components/test/group-list-section-test.js
+++ b/src/sidebar/components/test/group-list-section-test.js
@@ -1,8 +1,8 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const GroupListSection = require('../group-list-section');
-const mockImportedComponents = require('./mock-imported-components');
+import GroupListSection from '../group-list-section';
+import mockImportedComponents from './mock-imported-components';
 
 describe('GroupListSection', () => {
   const testGroups = [

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -1,9 +1,9 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const GroupList = require('../group-list');
-const mockImportedComponents = require('./mock-imported-components');
+import GroupList from '../group-list';
+import mockImportedComponents from './mock-imported-components';
 
 describe('GroupList', () => {
   let fakeServiceConfig;

--- a/src/sidebar/components/test/help-panel-test.js
+++ b/src/sidebar/components/test/help-panel-test.js
@@ -1,9 +1,9 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const HelpPanel = require('../help-panel');
-const mockImportedComponents = require('./mock-imported-components');
+import HelpPanel from '../help-panel';
+import mockImportedComponents from './mock-imported-components';
 
 describe('HelpPanel', function() {
   let fakeAuth;

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -1,9 +1,8 @@
-const angular = require('angular');
+import angular from 'angular';
 
-const events = require('../../events');
-const bridgeEvents = require('../../../shared/bridge-events');
-
-const hypothesisApp = require('../hypothesis-app');
+import * as events from '../../events';
+import * as bridgeEvents from '../../../shared/bridge-events';
+import * as hypothesisApp from '../hypothesis-app';
 
 describe('sidebar.components.hypothesis-app', function() {
   let $componentController = null;

--- a/src/sidebar/components/test/logged-out-message-test.js
+++ b/src/sidebar/components/test/logged-out-message-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const LoggedOutMessage = require('../logged-out-message');
-const mockImportedComponents = require('./mock-imported-components');
+import LoggedOutMessage from '../logged-out-message';
+import mockImportedComponents from './mock-imported-components';
 
 describe('LoggedOutMessage', () => {
   const createLoggedOutMessage = props => {

--- a/src/sidebar/components/test/markdown-editor-test.js
+++ b/src/sidebar/components/test/markdown-editor-test.js
@@ -1,9 +1,9 @@
-const { createElement, render } = require('preact');
-const { act } = require('preact/test-utils');
-const { mount } = require('enzyme');
+import { createElement, render } from 'preact';
+import { act } from 'preact/test-utils';
+import { mount } from 'enzyme';
 
-const { LinkType } = require('../../markdown-commands');
-const MarkdownEditor = require('../markdown-editor');
+import { LinkType } from '../../markdown-commands';
+import MarkdownEditor from '../markdown-editor';
 
 describe('MarkdownEditor', () => {
   const formatResult = {

--- a/src/sidebar/components/test/markdown-view-test.js
+++ b/src/sidebar/components/test/markdown-view-test.js
@@ -1,7 +1,7 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const MarkdownView = require('../markdown-view');
+import MarkdownView from '../markdown-view';
 
 describe('MarkdownView', () => {
   let fakeMediaEmbedder;

--- a/src/sidebar/components/test/menu-item-test.js
+++ b/src/sidebar/components/test/menu-item-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const MenuItem = require('../menu-item');
-const mockImportedComponents = require('./mock-imported-components');
+import MenuItem from '../menu-item';
+import mockImportedComponents from './mock-imported-components';
 
 describe('MenuItem', () => {
   const createMenuItem = props =>

--- a/src/sidebar/components/test/menu-section-test.js
+++ b/src/sidebar/components/test/menu-section-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const MenuSection = require('../menu-section');
-const mockImportedComponents = require('./mock-imported-components');
+import MenuSection from '../menu-section';
+import mockImportedComponents from './mock-imported-components';
 
 describe('MenuSection', () => {
   const createMenuSection = props =>

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
+import { mount } from 'enzyme';
 
-const Menu = require('../menu');
+import Menu from '../menu';
 
 describe('Menu', () => {
   let container;

--- a/src/sidebar/components/test/mock-imported-components.js
+++ b/src/sidebar/components/test/mock-imported-components.js
@@ -2,11 +2,9 @@
  * Return true if `value` "looks like" a React/Preact component.
  */
 function isComponent(value) {
-  return (
-    typeof value === 'function' &&
-    value.hasOwnProperty('propTypes') &&
-    value.name.match(/^[A-Z]/)
-  );
+  return typeof value === 'function' &&
+  value.hasOwnProperty('propTypes') &&
+  value.name.match(/^[A-Z]/);
 }
 
 /**

--- a/src/sidebar/components/test/moderation-banner-test.js
+++ b/src/sidebar/components/test/moderation-banner-test.js
@@ -1,9 +1,9 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const ModerationBanner = require('../moderation-banner');
-const fixtures = require('../../test/annotation-fixtures');
-const mockImportedComponents = require('./mock-imported-components');
+import ModerationBanner from '../moderation-banner';
+import * as fixtures from '../../test/annotation-fixtures';
+import mockImportedComponents from './mock-imported-components';
 
 const moderatedAnnotation = fixtures.moderatedAnnotation;
 

--- a/src/sidebar/components/test/new-note-btn-test.js
+++ b/src/sidebar/components/test/new-note-btn-test.js
@@ -1,10 +1,10 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const events = require('../../events');
-const NewNoteButton = require('../new-note-btn');
-const mockImportedComponents = require('./mock-imported-components');
+import * as events from '../../events';
+import NewNoteButton from '../new-note-btn';
+import mockImportedComponents from './mock-imported-components';
 
 describe('NewNoteButton', function() {
   let fakeStore;

--- a/src/sidebar/components/test/search-input-test.js
+++ b/src/sidebar/components/test/search-input-test.js
@@ -1,7 +1,7 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const SearchInput = require('../search-input');
+import SearchInput from '../search-input';
 
 describe('SearchInput', () => {
   let fakeStore;

--- a/src/sidebar/components/test/search-status-bar-test.js
+++ b/src/sidebar/components/test/search-status-bar-test.js
@@ -1,8 +1,8 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const SearchStatusBar = require('../search-status-bar');
-const mockImportedComponents = require('./mock-imported-components');
+import SearchStatusBar from '../search-status-bar';
+import mockImportedComponents from './mock-imported-components';
 
 describe('SearchStatusBar', () => {
   let fakeRootThread;

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -1,9 +1,9 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const uiConstants = require('../../ui-constants');
-const SelectionTabs = require('../selection-tabs');
-const mockImportedComponents = require('./mock-imported-components');
+import * as uiConstants from '../../ui-constants';
+import SelectionTabs from '../selection-tabs';
+import mockImportedComponents from './mock-imported-components';
 
 describe('SelectionTabs', function() {
   // mock services

--- a/src/sidebar/components/test/share-annotations-panel-test.js
+++ b/src/sidebar/components/test/share-annotations-panel-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const ShareAnnotationsPanel = require('../share-annotations-panel');
-const mockImportedComponents = require('./mock-imported-components');
+import ShareAnnotationsPanel from '../share-annotations-panel';
+import mockImportedComponents from './mock-imported-components';
 
 describe('ShareAnnotationsPanel', () => {
   let fakeStore;

--- a/src/sidebar/components/test/share-links-test.js
+++ b/src/sidebar/components/test/share-links-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const ShareLinks = require('../share-links');
-const mockImportedComponents = require('./mock-imported-components');
+import ShareLinks from '../share-links';
+import mockImportedComponents from './mock-imported-components';
 
 describe('ShareLinks', () => {
   let fakeAnalytics;

--- a/src/sidebar/components/test/sidebar-content-error-test.js
+++ b/src/sidebar/components/test/sidebar-content-error-test.js
@@ -1,8 +1,8 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const SidebarContentError = require('../sidebar-content-error');
-const mockImportedComponents = require('./mock-imported-components');
+import SidebarContentError from '../sidebar-content-error';
+import mockImportedComponents from './mock-imported-components';
 
 describe('SidebarContentError', () => {
   const createSidebarContentError = (

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -1,8 +1,8 @@
-const angular = require('angular');
-const EventEmitter = require('tiny-emitter');
+import angular from 'angular';
+import EventEmitter from 'tiny-emitter';
 
-const events = require('../../events');
-const sidebarContent = require('../sidebar-content');
+import * as events from '../../events';
+import * as sidebarContent from '../sidebar-content';
 
 class FakeRootThread extends EventEmitter {
   constructor() {

--- a/src/sidebar/components/test/sidebar-panel-test.js
+++ b/src/sidebar/components/test/sidebar-panel-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const SidebarPanel = require('../sidebar-panel');
-const mockImportedComponents = require('./mock-imported-components');
+import SidebarPanel from '../sidebar-panel';
+import mockImportedComponents from './mock-imported-components';
 
 describe('SidebarPanel', () => {
   let fakeStore;

--- a/src/sidebar/components/test/slider-test.js
+++ b/src/sidebar/components/test/slider-test.js
@@ -1,7 +1,7 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const Slider = require('../slider');
+import Slider from '../slider';
 
 describe('Slider', () => {
   let container;

--- a/src/sidebar/components/test/sort-menu-test.js
+++ b/src/sidebar/components/test/sort-menu-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const SortMenu = require('../sort-menu');
-const mockImportedComponents = require('./mock-imported-components');
+import SortMenu from '../sort-menu';
+import mockImportedComponents from './mock-imported-components';
 
 describe('SortMenu', () => {
   let fakeState;

--- a/src/sidebar/components/test/spinner-test.js
+++ b/src/sidebar/components/test/spinner-test.js
@@ -1,7 +1,7 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const Spinner = require('../spinner');
+import Spinner from '../spinner';
 
 describe('Spinner', function() {
   const createSpinner = (props = {}) => mount(<Spinner {...props} />);

--- a/src/sidebar/components/test/stream-content-test.js
+++ b/src/sidebar/components/test/stream-content-test.js
@@ -1,5 +1,5 @@
-const angular = require('angular');
-const EventEmitter = require('tiny-emitter');
+import angular from 'angular';
+import EventEmitter from 'tiny-emitter';
 
 class FakeRootThread extends EventEmitter {
   constructor() {

--- a/src/sidebar/components/test/stream-search-input-test.js
+++ b/src/sidebar/components/test/stream-search-input-test.js
@@ -1,9 +1,9 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const StreamSearchInput = require('../stream-search-input');
-const mockImportedComponents = require('./mock-imported-components');
+import StreamSearchInput from '../stream-search-input';
+import mockImportedComponents from './mock-imported-components';
 
 describe('StreamSearchInput', () => {
   let fakeLocation;

--- a/src/sidebar/components/test/svg-icon-test.js
+++ b/src/sidebar/components/test/svg-icon-test.js
@@ -1,6 +1,6 @@
-const { createElement, render } = require('preact');
+import { createElement, render } from 'preact';
 
-const SvgIcon = require('../svg-icon');
+import SvgIcon from '../svg-icon';
 
 describe('SvgIcon', () => {
   // Tests here use DOM APIs rather than Enzyme because SvgIcon uses

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const mockImportedComponents = require('./mock-imported-components');
-const TagEditor = require('../tag-editor');
+import mockImportedComponents from './mock-imported-components';
+import TagEditor from '../tag-editor';
 
 describe('TagEditor', function() {
   let fakeTags = ['tag1', 'tag2'];

--- a/src/sidebar/components/test/tag-list-test.js
+++ b/src/sidebar/components/test/tag-list-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const mockImportedComponents = require('./mock-imported-components');
-const TagList = require('../tag-list');
+import mockImportedComponents from './mock-imported-components';
+import TagList from '../tag-list';
 
 describe('TagList', function() {
   let fakeServiceUrl;

--- a/src/sidebar/components/test/thread-list-test.js
+++ b/src/sidebar/components/test/thread-list-test.js
@@ -1,11 +1,10 @@
-const angular = require('angular');
+import angular from 'angular';
+import EventEmitter from 'tiny-emitter';
+import immutable from 'seamless-immutable';
 
-const EventEmitter = require('tiny-emitter');
-const immutable = require('seamless-immutable');
-
-const events = require('../../events');
-const threadList = require('../thread-list');
-const util = require('../../directive/test/util');
+import * as events from '../../events';
+import * as threadList from '../thread-list';
+import * as util from '../../directive/test/util';
 
 const annotFixtures = immutable({
   annotation: { $tag: 't1', id: '1', text: 'text' },

--- a/src/sidebar/components/test/timestamp-test.js
+++ b/src/sidebar/components/test/timestamp-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
+import { mount } from 'enzyme';
 
-const Timestamp = require('../timestamp');
+import Timestamp from '../timestamp';
 
 describe('Timestamp', () => {
   let clock;

--- a/src/sidebar/components/test/top-bar-test.js
+++ b/src/sidebar/components/test/top-bar-test.js
@@ -1,11 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const uiConstants = require('../../ui-constants');
-const bridgeEvents = require('../../../shared/bridge-events');
-
-const TopBar = require('../top-bar');
-const mockImportedComponents = require('./mock-imported-components');
+import * as uiConstants from '../../ui-constants';
+import * as bridgeEvents from '../../../shared/bridge-events';
+import TopBar from '../top-bar';
+import mockImportedComponents from './mock-imported-components';
 
 describe('TopBar', () => {
   const fakeSettings = {};

--- a/src/sidebar/components/test/tutorial-test.js
+++ b/src/sidebar/components/test/tutorial-test.js
@@ -1,8 +1,8 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const Tutorial = require('../tutorial');
-const mockImportedComponents = require('./mock-imported-components');
+import Tutorial from '../tutorial';
+import mockImportedComponents from './mock-imported-components';
 
 describe('Tutorial', function() {
   let fakeIsThirdPartyService;

--- a/src/sidebar/components/test/user-menu-test.js
+++ b/src/sidebar/components/test/user-menu-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
-const UserMenu = require('../user-menu');
-const mockImportedComponents = require('./mock-imported-components');
+import UserMenu from '../user-menu';
+import mockImportedComponents from './mock-imported-components';
 
 describe('UserMenu', () => {
   let fakeAuth;

--- a/src/sidebar/components/test/version-info-test.js
+++ b/src/sidebar/components/test/version-info-test.js
@@ -1,7 +1,7 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const VersionInfo = require('../version-info');
+import VersionInfo from '../version-info';
 
 describe('VersionInfo', function() {
   let fakeVersionData;

--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -1,11 +1,11 @@
-const events = require('../events');
-const metadata = require('../util/annotation-metadata');
+import * as events from '../events';
+import * as metadata from '../util/annotation-metadata';
 
 /**
  * Component which displays a virtualized list of annotation threads.
  */
 
-const scopeTimeout = require('../util/scope-timeout');
+import scopeTimeout from '../util/scope-timeout';
 
 /**
  * Returns the height of the thread for an annotation if it exists in the view

--- a/src/sidebar/components/timestamp.js
+++ b/src/sidebar/components/timestamp.js
@@ -1,9 +1,9 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
-const { useEffect, useMemo, useState } = require('preact/hooks');
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 
-const { format: formatDate } = require('../util/date');
-const { decayingInterval, toFuzzyString } = require('../util/time');
+import { format as formatDate } from '../util/date';
+import { decayingInterval, toFuzzyString } from '../util/time';
 
 /**
  * Display a relative timestamp (eg. '6 minutes ago') as static text or a link.

--- a/src/sidebar/components/top-bar.js
+++ b/src/sidebar/components/top-bar.js
@@ -1,21 +1,20 @@
-const { Fragment, createElement } = require('preact');
-const classnames = require('classnames');
-const propTypes = require('prop-types');
+import { Fragment, createElement } from 'preact';
+import classnames from 'classnames';
+import propTypes from 'prop-types';
 
-const bridgeEvents = require('../../shared/bridge-events');
-const useStore = require('../store/use-store');
-const { applyTheme } = require('../util/theme');
-const isThirdPartyService = require('../util/is-third-party-service');
-const serviceConfig = require('../service-config');
-const { withServices } = require('../util/service-context');
-const uiConstants = require('../ui-constants');
-
-const Button = require('./button');
-const GroupList = require('./group-list');
-const SearchInput = require('./search-input');
-const StreamSearchInput = require('./stream-search-input');
-const SortMenu = require('./sort-menu');
-const UserMenu = require('./user-menu');
+import * as bridgeEvents from '../../shared/bridge-events';
+import useStore from '../store/use-store';
+import { applyTheme } from '../util/theme';
+import isThirdPartyService from '../util/is-third-party-service';
+import serviceConfig from '../service-config';
+import { withServices } from '../util/service-context';
+import * as uiConstants from '../ui-constants';
+import Button from './button';
+import GroupList from './group-list';
+import SearchInput from './search-input';
+import StreamSearchInput from './stream-search-input';
+import SortMenu from './sort-menu';
+import UserMenu from './user-menu';
 
 /**
  * The toolbar which appears at the top of the sidebar providing actions

--- a/src/sidebar/components/tutorial.js
+++ b/src/sidebar/components/tutorial.js
@@ -1,10 +1,9 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const { withServices } = require('../util/service-context');
-const isThirdPartyService = require('../util/is-third-party-service');
-
-const SvgIcon = require('./svg-icon');
+import { withServices } from '../util/service-context';
+import isThirdPartyService from '../util/is-third-party-service';
+import SvgIcon from './svg-icon';
 
 /**
  * Subcomponent: an "instruction" within the tutorial step that includes an

--- a/src/sidebar/components/user-menu.js
+++ b/src/sidebar/components/user-menu.js
@@ -1,15 +1,14 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const bridgeEvents = require('../../shared/bridge-events');
-const { isThirdPartyUser } = require('../util/account-id');
-const serviceConfig = require('../service-config');
-const { withServices } = require('../util/service-context');
-
-const Button = require('./button');
-const Menu = require('./menu');
-const MenuSection = require('./menu-section');
-const MenuItem = require('./menu-item');
+import * as bridgeEvents from '../../shared/bridge-events';
+import { isThirdPartyUser } from '../util/account-id';
+import serviceConfig from '../service-config';
+import { withServices } from '../util/service-context';
+import Button from './button';
+import Menu from './menu';
+import MenuSection from './menu-section';
+import MenuItem from './menu-item';
 
 /**
  * A menu with user and account links.

--- a/src/sidebar/components/version-info.js
+++ b/src/sidebar/components/version-info.js
@@ -1,10 +1,9 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import propTypes from 'prop-types';
+import { createElement } from 'preact';
 
-const { copyText } = require('../util/copy-to-clipboard');
-const { withServices } = require('../util/service-context');
-
-const Button = require('./button');
+import { copyText } from '../util/copy-to-clipboard';
+import { withServices } from '../util/service-context';
+import Button from './button';
 
 /**
  * Display current client version info

--- a/src/sidebar/cross-origin-rpc.js
+++ b/src/sidebar/cross-origin-rpc.js
@@ -1,4 +1,4 @@
-const warnOnce = require('../shared/warn-once');
+import warnOnce from '../shared/warn-once';
 
 /**
  * Return the mapped methods that can be called remotely via this server.

--- a/src/sidebar/directive/test/h-branding-test.js
+++ b/src/sidebar/directive/test/h-branding-test.js
@@ -1,4 +1,4 @@
-const angular = require('angular');
+import angular from 'angular';
 
 describe('BrandingDirective', function() {
   let $compile;

--- a/src/sidebar/directive/test/h-on-touch-test.js
+++ b/src/sidebar/directive/test/h-on-touch-test.js
@@ -1,6 +1,6 @@
-const angular = require('angular');
+import angular from 'angular';
 
-const util = require('./util');
+import * as util from './util';
 
 function testComponent() {
   return {

--- a/src/sidebar/directive/test/h-tooltip-test.js
+++ b/src/sidebar/directive/test/h-tooltip-test.js
@@ -1,6 +1,6 @@
-const angular = require('angular');
+import angular from 'angular';
 
-const util = require('./util');
+import * as util from './util';
 
 function testComponent() {
   return {

--- a/src/sidebar/directive/test/window-scroll-test.js
+++ b/src/sidebar/directive/test/window-scroll-test.js
@@ -1,8 +1,8 @@
-const angular = require('angular');
+import angular from 'angular';
 
 const inject = angular.mock.inject;
 
-const windowScroll = require('../window-scroll');
+import windowScroll from '../window-scroll';
 
 describe('windowScroll', function() {
   let directive = null;

--- a/src/sidebar/filter/test/url-test.js
+++ b/src/sidebar/filter/test/url-test.js
@@ -1,4 +1,4 @@
-const url = require('../url');
+import * as url from '../url';
 
 describe('url.encode', function() {
   it('urlencodes its input', function() {

--- a/src/sidebar/get-api-url.js
+++ b/src/sidebar/get-api-url.js
@@ -1,4 +1,4 @@
-const serviceConfig = require('./service-config');
+import serviceConfig from './service-config';
 
 /**
  * Function that returns apiUrl from the settings object.

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -1,4 +1,4 @@
-const queryString = require('query-string');
+import * as queryString from 'query-string';
 
 /**
  * Return the app configuration specified by the frame embedding the Hypothesis

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -2,12 +2,13 @@ const addAnalytics = require('./ga');
 const disableOpenerForExternalLinks = require('./util/disable-opener-for-external-links');
 const { fetchConfig } = require('./util/fetch-config');
 const serviceConfig = require('./service-config');
+const { jsonConfigsFrom } = require('../shared/settings');
 const crossOriginRPC = require('./cross-origin-rpc.js');
 
 let sentry;
 
 // Read settings rendered into sidebar app HTML by service/extension.
-const appConfig = require('../shared/settings').jsonConfigsFrom(document);
+const appConfig = jsonConfigsFrom(document);
 
 if (appConfig.sentry) {
   // Initialize Sentry. This is required at the top of this file

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -1,9 +1,9 @@
-const addAnalytics = require('./ga');
-const disableOpenerForExternalLinks = require('./util/disable-opener-for-external-links');
-const { fetchConfig } = require('./util/fetch-config');
-const serviceConfig = require('./service-config');
-const { jsonConfigsFrom } = require('../shared/settings');
-const crossOriginRPC = require('./cross-origin-rpc.js');
+import addAnalytics from './ga';
+import disableOpenerForExternalLinks from './util/disable-opener-for-external-links';
+import { fetchConfig } from './util/fetch-config';
+import serviceConfig from './service-config';
+import { jsonConfigsFrom } from '../shared/settings';
+import * as crossOriginRPC from './cross-origin-rpc.js';
 
 let sentry;
 
@@ -28,19 +28,19 @@ document.body.setAttribute('ng-csp', '');
 // Prevent tab-jacking.
 disableOpenerForExternalLinks(document.body);
 
-const angular = require('angular');
+import angular from 'angular';
 
 // autofill-event relies on the existence of window.angular so
 // it must be require'd after angular is first require'd
-require('autofill-event');
+import 'autofill-event';
 
 // Load polyfill for :focus-visible pseudo-class.
-require('focus-visible');
+import 'focus-visible';
 
 // Enable debugging checks for Preact.
-require('preact/debug');
+import 'preact/debug';
 
-const wrapReactComponent = require('./util/wrap-react-component');
+import wrapReactComponent from './util/wrap-react-component';
 
 if (appConfig.googleAnalytics) {
   addAnalytics(appConfig.googleAnalytics);

--- a/src/sidebar/live-reload-client.js
+++ b/src/sidebar/live-reload-client.js
@@ -1,8 +1,8 @@
 /* eslint no-console: "off" */
 
-const queryString = require('query-string');
+import * as queryString from 'query-string';
 
-const Socket = require('./websocket');
+import Socket from './websocket';
 
 /**
  * Return a URL with a cache-busting query string parameter added.

--- a/src/sidebar/media-embedder.js
+++ b/src/sidebar/media-embedder.js
@@ -1,4 +1,4 @@
-const queryString = require('query-string');
+import * as queryString from 'query-string';
 
 /**
  * Return an HTML5 audio player with the given src URL.

--- a/src/sidebar/render-markdown.js
+++ b/src/sidebar/render-markdown.js
@@ -1,7 +1,7 @@
-const createDOMPurify = require('dompurify');
-const escapeHtml = require('escape-html');
-const katex = require('katex');
-const showdown = require('showdown');
+import createDOMPurify from 'dompurify';
+import escapeHtml from 'escape-html';
+import * as katex from 'katex';
+import showdown from 'showdown';
 
 const DOMPurify = createDOMPurify(window);
 

--- a/src/sidebar/search-client.js
+++ b/src/sidebar/search-client.js
@@ -1,4 +1,4 @@
-const EventEmitter = require('tiny-emitter');
+import EventEmitter from 'tiny-emitter';
 
 /**
  * Client for the Hypothesis search API.

--- a/src/sidebar/services/annotation-mapper.js
+++ b/src/sidebar/services/annotation-mapper.js
@@ -1,6 +1,6 @@
-const angular = require('angular');
+import angular from 'angular';
 
-const events = require('../events');
+import * as events from '../events';
 
 function getExistingAnnotation(store, id) {
   return store.getState().annotations.annotations.find(function(annot) {

--- a/src/sidebar/services/annotations.js
+++ b/src/sidebar/services/annotations.js
@@ -1,4 +1,4 @@
-const SearchClient = require('../search-client');
+import SearchClient from '../search-client';
 
 // @ngInject
 function annotations(annotationMapper, api, store, streamer, streamFilter) {

--- a/src/sidebar/services/api-routes.js
+++ b/src/sidebar/services/api-routes.js
@@ -1,4 +1,4 @@
-const { retryPromiseOperation } = require('../util/retry');
+import { retryPromiseOperation } from '../util/retry';
 
 /**
  * A service which fetches and caches API route metadata.

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -1,7 +1,7 @@
-const get = require('lodash.get');
-const queryString = require('query-string');
+import get from 'lodash.get';
+import * as queryString from 'query-string';
 
-const { replaceURLParams } = require('../util/url');
+import { replaceURLParams } from '../util/url';
 
 /**
  * Translate the response from a failed API call into an Error-like object.

--- a/src/sidebar/services/features.js
+++ b/src/sidebar/services/features.js
@@ -9,9 +9,10 @@
  * change at any time and should write code accordingly. Feature flags should
  * not be cached, and should not be interrogated only at setup time.
  */
-const events = require('../events');
-const bridgeEvents = require('../../shared/bridge-events');
-const warnOnce = require('../../shared/warn-once');
+import * as events from '../events';
+
+import * as bridgeEvents from '../../shared/bridge-events';
+import warnOnce from '../../shared/warn-once';
 
 // @ngInject
 function features($rootScope, bridge, session) {

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -1,9 +1,9 @@
-const debounce = require('lodash.debounce');
+import debounce from 'lodash.debounce';
 
-const events = require('../events');
-const bridgeEvents = require('../../shared/bridge-events');
-const metadata = require('../util/annotation-metadata');
-const uiConstants = require('../ui-constants');
+import * as events from '../events';
+import * as bridgeEvents from '../../shared/bridge-events';
+import * as metadata from '../util/annotation-metadata';
+import * as uiConstants from '../ui-constants';
 
 /**
  * @typedef FrameInfo

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -22,7 +22,7 @@ const uiConstants = require('../ui-constants');
  * JavaScript, it includes only the information needed to uniquely identify it
  * within the current session and anchor it in the document.
  */
-function formatAnnot(ann) {
+export function formatAnnot(ann) {
   return {
     tag: ann.$tag,
     msg: {
@@ -39,7 +39,13 @@ function formatAnnot(ann) {
  * sidebar.
  */
 // @ngInject
-function FrameSync($rootScope, $window, Discovery, store, bridge) {
+export default function FrameSync(
+  $rootScope,
+  $window,
+  Discovery,
+  store,
+  bridge
+) {
   // Set of tags of annotations that are currently loaded into the frame
   const inFrame = new Set();
 
@@ -253,8 +259,3 @@ function FrameSync($rootScope, $window, Discovery, store, bridge) {
     bridge.call('scrollToAnnotation', tag);
   };
 }
-
-module.exports = {
-  default: FrameSync,
-  formatAnnot: formatAnnot,
-};

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -11,10 +11,10 @@ const DEFAULT_ORGANIZATION = {
     encodeURIComponent(require('../../images/icons/logo.svg')),
 };
 
-const events = require('../events');
-const { awaitStateChange } = require('../util/state');
-const { combineGroups } = require('../util/groups');
-const serviceConfig = require('../service-config');
+import * as events from '../events';
+import { awaitStateChange } from '../util/state';
+import { combineGroups } from '../util/groups';
+import serviceConfig from '../service-config';
 
 // @ngInject
 function groups(

--- a/src/sidebar/services/oauth-auth.js
+++ b/src/sidebar/services/oauth-auth.js
@@ -1,6 +1,6 @@
-const events = require('../events');
-const { resolve } = require('../util/url');
-const serviceConfig = require('../service-config');
+import * as events from '../events';
+import { resolve } from '../util/url';
+import serviceConfig from '../service-config';
 
 /**
  * @typedef RefreshOptions

--- a/src/sidebar/services/oauth-auth.js
+++ b/src/sidebar/services/oauth-auth.js
@@ -1,5 +1,5 @@
 const events = require('../events');
-const resolve = require('../util/url').resolve;
+const { resolve } = require('../util/url');
 const serviceConfig = require('../service-config');
 
 /**

--- a/src/sidebar/services/oauth-auth.js
+++ b/src/sidebar/services/oauth-auth.js
@@ -21,7 +21,6 @@ const serviceConfig = require('../service-config');
  * Interaction with OAuth endpoints in the annotation service is delegated to
  * the `OAuthClient` class.
  */
-// @ngInject
 function auth(
   $rootScope,
   $window,
@@ -299,5 +298,18 @@ function auth(
     tokenGetter,
   };
 }
+
+// `$inject` is added manually rather than using `@ngInject` to work around
+// a conflict between the transform-async-to-promises and angularjs-annotate
+// Babel plugins.
+auth.$inject = [
+  '$rootScope',
+  '$window',
+  'OAuthClient',
+  'apiRoutes',
+  'flash',
+  'localStorage',
+  'settings',
+];
 
 module.exports = auth;

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -1,8 +1,8 @@
-const buildThread = require('../build-thread');
-const events = require('../events');
-const memoize = require('../util/memoize');
-const metadata = require('../util/annotation-metadata');
-const tabs = require('../util/tabs');
+import buildThread from '../build-thread';
+import * as events from '../events';
+import memoize from '../util/memoize';
+import * as metadata from '../util/annotation-metadata';
+import * as tabs from '../util/tabs';
 
 function truthyKeys(map) {
   return Object.keys(map).filter(function(k) {

--- a/src/sidebar/services/service-url.js
+++ b/src/sidebar/services/service-url.js
@@ -1,4 +1,4 @@
-const urlUtil = require('../util/url');
+import * as urlUtil from '../util/url';
 
 /**
  * A function that returns an absolute URL given a link name and params, by

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -1,6 +1,6 @@
-const events = require('../events');
-const retryUtil = require('../util/retry');
-const sentry = require('../util/sentry');
+import * as events from '../events';
+import * as retryUtil from '../util/retry';
+import * as sentry from '../util/sentry';
 
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -1,9 +1,8 @@
-const queryString = require('query-string');
-const uuid = require('node-uuid');
+import * as queryString from 'query-string';
+import uuid from 'node-uuid';
 
-const warnOnce = require('../../shared/warn-once');
-
-const Socket = require('../websocket');
+import warnOnce from '../../shared/warn-once';
+import Socket from '../websocket';
 
 /**
  * Open a new WebSocket connection to the Hypothesis push notification service.

--- a/src/sidebar/services/test/analytics-test.js
+++ b/src/sidebar/services/test/analytics-test.js
@@ -1,4 +1,4 @@
-const analyticsService = require('../analytics');
+import analyticsService from '../analytics';
 
 describe('analytics', function() {
   let $windowStub;

--- a/src/sidebar/services/test/annotation-mapper-test.js
+++ b/src/sidebar/services/test/annotation-mapper-test.js
@@ -1,7 +1,7 @@
-const angular = require('angular');
-const immutable = require('seamless-immutable');
+import angular from 'angular';
+import immutable from 'seamless-immutable';
 
-const events = require('../../events');
+import * as events from '../../events';
 
 describe('annotationMapper', function() {
   const sandbox = sinon.createSandbox();

--- a/src/sidebar/services/test/annotations-test.js
+++ b/src/sidebar/services/test/annotations-test.js
@@ -1,5 +1,6 @@
-const annotations = require('../annotations');
-const EventEmitter = require('tiny-emitter');
+import annotations from '../annotations';
+
+import EventEmitter from 'tiny-emitter';
 
 let searchClients;
 let longRunningSearchClient = false;

--- a/src/sidebar/services/test/api-routes-test.js
+++ b/src/sidebar/services/test/api-routes-test.js
@@ -1,4 +1,4 @@
-const apiRoutesFactory = require('../api-routes');
+import apiRoutesFactory from '../api-routes';
 
 // Abridged version of the response returned by https://hypothes.is/api,
 // with the domain name changed.

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -1,6 +1,6 @@
-const fetchMock = require('fetch-mock');
+import fetchMock from 'fetch-mock';
 
-const apiFactory = require('../api');
+import apiFactory from '../api';
 
 // API route directory.
 //

--- a/src/sidebar/services/test/features-test.js
+++ b/src/sidebar/services/test/features-test.js
@@ -1,6 +1,6 @@
-const features = require('../features');
-const events = require('../../events');
-const bridgeEvents = require('../../../shared/bridge-events');
+import features from '../features';
+import * as events from '../../events';
+import * as bridgeEvents from '../../../shared/bridge-events';
 
 describe('h:features - sidebar layer', function() {
   let fakeBridge;

--- a/src/sidebar/services/test/flash-test.js
+++ b/src/sidebar/services/test/flash-test.js
@@ -1,4 +1,4 @@
-const flash = require('../flash');
+import flash from '../flash';
 
 describe('sidebar.flash', () => {
   ['info', 'success', 'warning', 'error'].forEach(method => {

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -3,9 +3,8 @@ const EventEmitter = require('tiny-emitter');
 
 const annotationFixtures = require('../../test/annotation-fixtures');
 const events = require('../../events');
-const FrameSync = require('../frame-sync').default;
 const createFakeStore = require('../../test/fake-redux-store');
-const formatAnnot = require('../frame-sync').formatAnnot;
+const { default: FrameSync, formatAnnot } = require('../frame-sync');
 const uiConstants = require('../../ui-constants');
 
 const fixtures = {

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -1,11 +1,11 @@
-const angular = require('angular');
-const EventEmitter = require('tiny-emitter');
+import angular from 'angular';
+import EventEmitter from 'tiny-emitter';
 
-const annotationFixtures = require('../../test/annotation-fixtures');
-const events = require('../../events');
-const createFakeStore = require('../../test/fake-redux-store');
-const { default: FrameSync, formatAnnot } = require('../frame-sync');
-const uiConstants = require('../../ui-constants');
+import * as annotationFixtures from '../../test/annotation-fixtures';
+import * as events from '../../events';
+import createFakeStore from '../../test/fake-redux-store';
+import FrameSync, { formatAnnot } from '../frame-sync';
+import * as uiConstants from '../../ui-constants';
 
 const fixtures = {
   ann: Object.assign({ $tag: 't1' }, annotationFixtures.defaultAnnotation()),

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -1,6 +1,6 @@
-const events = require('../../events');
-const fakeReduxStore = require('../../test/fake-redux-store');
-const groups = require('../groups');
+import * as events from '../../events';
+import fakeReduxStore from '../../test/fake-redux-store';
+import groups from '../groups';
 
 /**
  * Generate a truth table containing every possible combination of a set of

--- a/src/sidebar/services/test/local-storage-test.js
+++ b/src/sidebar/services/test/local-storage-test.js
@@ -1,5 +1,6 @@
-const angular = require('angular');
-const service = require('../local-storage');
+import angular from 'angular';
+
+import service from '../local-storage';
 
 function windowWithLocalStoragePropertyThatThrows() {
   const win = {};

--- a/src/sidebar/services/test/oauth-auth-test.js
+++ b/src/sidebar/services/test/oauth-auth-test.js
@@ -1,8 +1,7 @@
-const angular = require('angular');
+import angular from 'angular';
 
-const events = require('../../events');
-
-const FakeWindow = require('../../util/test/fake-window');
+import * as events from '../../events';
+import FakeWindow from '../../util/test/fake-window';
 
 const DEFAULT_TOKEN_EXPIRES_IN_SECS = 1000;
 const TOKEN_KEY = 'hypothesis.oauth.hypothes%2Eis.token';

--- a/src/sidebar/services/test/permissions-test.js
+++ b/src/sidebar/services/test/permissions-test.js
@@ -1,4 +1,4 @@
-const Permissions = require('../permissions');
+import Permissions from '../permissions';
 
 const userid = 'acct:flash@gord.on';
 

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -1,10 +1,10 @@
-const angular = require('angular');
-const immutable = require('seamless-immutable');
+import angular from 'angular';
+import immutable from 'seamless-immutable';
 
-const annotationFixtures = require('../../test/annotation-fixtures');
-const events = require('../../events');
-const uiConstants = require('../../ui-constants');
-const rootThreadFactory = require('../root-thread');
+import * as annotationFixtures from '../../test/annotation-fixtures';
+import * as events from '../../events';
+import * as uiConstants from '../../ui-constants';
+import rootThreadFactory from '../root-thread';
 
 const fixtures = immutable({
   emptyThread: {

--- a/src/sidebar/services/test/service-url-test.js
+++ b/src/sidebar/services/test/service-url-test.js
@@ -1,4 +1,4 @@
-const serviceUrlFactory = require('../service-url');
+import serviceUrlFactory from '../service-url';
 
 /** Return a fake store object. */
 function fakeStore() {

--- a/src/sidebar/services/test/session-test.js
+++ b/src/sidebar/services/test/session-test.js
@@ -1,7 +1,7 @@
-const angular = require('angular');
+import angular from 'angular';
 
-const events = require('../../events');
-const sessionFactory = require('../session');
+import * as events from '../../events';
+import sessionFactory from '../session';
 
 const mock = angular.mock;
 

--- a/src/sidebar/services/test/stream-filter-test.js
+++ b/src/sidebar/services/test/stream-filter-test.js
@@ -1,4 +1,4 @@
-const StreamFilter = require('../stream-filter');
+import StreamFilter from '../stream-filter';
 
 describe('sidebar/services/stream-filter', () => {
   describe('#addClause', () => {

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -1,5 +1,6 @@
-const EventEmitter = require('tiny-emitter');
-const Streamer = require('../streamer');
+import EventEmitter from 'tiny-emitter';
+
+import Streamer from '../streamer';
 
 const fixtures = {
   createNotification: {

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -1,4 +1,4 @@
-const angular = require('angular');
+import angular from 'angular';
 
 const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
 const TAGS_MAP_KEY = 'hypothesis.user.tags.map';

--- a/src/sidebar/services/test/view-filter-test.js
+++ b/src/sidebar/services/test/view-filter-test.js
@@ -1,4 +1,4 @@
-const ViewFilter = require('../view-filter');
+import ViewFilter from '../view-filter';
 
 function isoDateWithAge(age) {
   return new Date(Date.now() - age * 1000).toISOString();

--- a/src/sidebar/services/view-filter.js
+++ b/src/sidebar/services/view-filter.js
@@ -1,4 +1,4 @@
-const { quote } = require('../util/annotation-metadata');
+import { quote } from '../util/annotation-metadata';
 
 // Prevent Babel inserting helper code after `@ngInject` comment below which
 // breaks browserify-ngannotate.

--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -1,6 +1,5 @@
 const redux = require('redux');
-// `.default` is needed because 'redux-thunk' is built as an ES2015 module
-const thunk = require('redux-thunk').default;
+const { default: thunk } = require('redux-thunk');
 
 const { createReducer, bindSelectors } = require('./util');
 

--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -1,7 +1,7 @@
-const redux = require('redux');
-const { default: thunk } = require('redux-thunk');
+import * as redux from 'redux';
+import thunk from 'redux-thunk';
 
-const { createReducer, bindSelectors } = require('./util');
+import { createReducer, bindSelectors } from './util';
 
 /**
  * Create a Redux store from a set of _modules_.

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -29,21 +29,21 @@
  *  3. Checking that the UI correctly presents a given state.
  */
 
-const createStore = require('./create-store');
-const debugMiddleware = require('./debug-middleware');
+import createStore from './create-store';
 
-const activity = require('./modules/activity');
-const annotations = require('./modules/annotations');
-const directLinked = require('./modules/direct-linked');
-const drafts = require('./modules/drafts');
-const frames = require('./modules/frames');
-const links = require('./modules/links');
-const groups = require('./modules/groups');
-const realTimeUpdates = require('./modules/real-time-updates');
-const selection = require('./modules/selection');
-const session = require('./modules/session');
-const sidebarPanels = require('./modules/sidebar-panels');
-const viewer = require('./modules/viewer');
+import debugMiddleware from './debug-middleware';
+import * as activity from './modules/activity';
+import * as annotations from './modules/annotations';
+import * as directLinked from './modules/direct-linked';
+import * as drafts from './modules/drafts';
+import * as frames from './modules/frames';
+import * as links from './modules/links';
+import * as groups from './modules/groups';
+import * as realTimeUpdates from './modules/real-time-updates';
+import * as selection from './modules/selection';
+import * as session from './modules/session';
+import * as sidebarPanels from './modules/sidebar-panels';
+import * as viewer from './modules/viewer';
 
 /**
  * Redux middleware which triggers an Angular change-detection cycle

--- a/src/sidebar/store/modules/activity.js
+++ b/src/sidebar/store/modules/activity.js
@@ -3,7 +3,7 @@
  * need to be reflected in the UI.
  */
 
-const { actionTypes } = require('../util');
+import { actionTypes } from '../util';
 
 function init() {
   return {

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -3,15 +3,14 @@
  * sidebar.
  */
 
-const { createSelector } = require('reselect');
+import { createSelector } from 'reselect';
 
-const arrayUtil = require('../../util/array');
-const metadata = require('../../util/annotation-metadata');
-const uiConstants = require('../../ui-constants');
-
-const selection = require('./selection');
-const drafts = require('./drafts');
-const util = require('../util');
+import * as arrayUtil from '../../util/array';
+import * as metadata from '../../util/annotation-metadata';
+import * as uiConstants from '../../ui-constants';
+import * as selection from './selection';
+import * as drafts from './drafts';
+import * as util from '../util';
 
 /**
  * Return a copy of `current` with all matching annotations in `annotations`

--- a/src/sidebar/store/modules/direct-linked.js
+++ b/src/sidebar/store/modules/direct-linked.js
@@ -1,4 +1,4 @@
-const util = require('../util');
+import * as util from '../util';
 
 function init(settings) {
   return {

--- a/src/sidebar/store/modules/drafts.js
+++ b/src/sidebar/store/modules/drafts.js
@@ -1,5 +1,5 @@
-const metadata = require('../../util/annotation-metadata');
-const util = require('../util');
+import * as metadata from '../../util/annotation-metadata';
+import * as util from '../util';
 
 /**
  * The drafts store provides temporary storage for unsaved edits to new or

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -1,6 +1,6 @@
-const { createSelector } = require('reselect');
+import { createSelector } from 'reselect';
 
-const util = require('../util');
+import * as util from '../util';
 
 function init() {
   // The list of frames connected to the sidebar app

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -1,7 +1,7 @@
-const { createSelector } = require('reselect');
+import { createSelector } from 'reselect';
 
-const util = require('../util');
-const { selectors: sessionSelectors } = require('./session');
+import * as util from '../util';
+import { selectors as sessionSelectors } from './session';
 const { isLoggedIn } = sessionSelectors;
 
 function init() {

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -3,13 +3,12 @@
  * WebSocket connection to h's real-time API.
  */
 
-const { createSelector } = require('reselect');
+import { createSelector } from 'reselect';
 
-const { actionTypes } = require('../util');
-
-const { selectors: annotationSelectors } = require('./annotations');
-const { selectors: groupSelectors } = require('./groups');
-const { selectors: viewerSelectors } = require('./viewer');
+import { actionTypes } from '../util';
+import { selectors as annotationSelectors } from './annotations';
+import { selectors as groupSelectors } from './groups';
+import { selectors as viewerSelectors } from './viewer';
 
 function init() {
   return {

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -14,15 +14,15 @@
  * @property {string} displayName - User's display name
  */
 
-const { createSelector } = require('reselect');
-const immutable = require('seamless-immutable');
+import { createSelector } from 'reselect';
 
-const arrayUtil = require('../../util/array');
-const metadata = require('../../util/annotation-metadata');
-const { toSet } = require('../../util/array');
-const uiConstants = require('../../ui-constants');
+import immutable from 'seamless-immutable';
 
-const util = require('../util');
+import * as arrayUtil from '../../util/array';
+import * as metadata from '../../util/annotation-metadata';
+import { toSet } from '../../util/array';
+import * as uiConstants from '../../ui-constants';
+import * as util from '../util';
 
 /**
  * Default starting tab.

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -19,7 +19,7 @@ const immutable = require('seamless-immutable');
 
 const arrayUtil = require('../../util/array');
 const metadata = require('../../util/annotation-metadata');
-const toSet = require('../../util/array').toSet;
+const { toSet } = require('../../util/array');
 const uiConstants = require('../../ui-constants');
 
 const util = require('../util');

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -1,4 +1,4 @@
-const util = require('../util');
+import * as util from '../util';
 
 function init() {
   /**

--- a/src/sidebar/store/modules/sidebar-panels.js
+++ b/src/sidebar/store/modules/sidebar-panels.js
@@ -8,7 +8,7 @@
  * may be "active" (open) at one time.
  */
 
-const util = require('../util');
+import * as util from '../util';
 
 function init() {
   return {

--- a/src/sidebar/store/modules/test/activity-test.js
+++ b/src/sidebar/store/modules/test/activity-test.js
@@ -1,5 +1,5 @@
-const createStore = require('../../create-store');
-const activity = require('../activity');
+import createStore from '../../create-store';
+import * as activity from '../activity';
 
 describe('sidebar/store/modules/activity', () => {
   let store;

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -1,10 +1,10 @@
-const annotations = require('../annotations');
-const createStoreFromModules = require('../../create-store');
-const drafts = require('../drafts');
-const fixtures = require('../../../test/annotation-fixtures');
-const selection = require('../selection');
-const viewer = require('../viewer');
-const uiConstants = require('../../../ui-constants');
+import * as annotations from '../annotations';
+import createStoreFromModules from '../../create-store';
+import * as drafts from '../drafts';
+import * as fixtures from '../../../test/annotation-fixtures';
+import * as selection from '../selection';
+import * as viewer from '../viewer';
+import * as uiConstants from '../../../ui-constants';
 
 const { actions, selectors } = annotations;
 

--- a/src/sidebar/store/modules/test/direct-linked-test.js
+++ b/src/sidebar/store/modules/test/direct-linked-test.js
@@ -1,5 +1,5 @@
-const createStore = require('../../create-store');
-const directLinked = require('../direct-linked');
+import createStore from '../../create-store';
+import * as directLinked from '../direct-linked';
 
 describe('sidebar/store/modules/direct-linked', () => {
   let store;

--- a/src/sidebar/store/modules/test/drafts-test.js
+++ b/src/sidebar/store/modules/test/drafts-test.js
@@ -1,10 +1,10 @@
-const immutable = require('seamless-immutable');
+import immutable from 'seamless-immutable';
 
-const drafts = require('../drafts');
-const annotations = require('../annotations');
-const selection = require('../selection');
-const { Draft } = require('../drafts');
-const createStore = require('../../create-store');
+import * as drafts from '../drafts';
+import * as annotations from '../annotations';
+import * as selection from '../selection';
+import { Draft } from '../drafts';
+import createStore from '../../create-store';
 
 const fixtures = immutable({
   draftWithText: {

--- a/src/sidebar/store/modules/test/frames-test.js
+++ b/src/sidebar/store/modules/test/frames-test.js
@@ -1,5 +1,5 @@
-const frames = require('../frames');
-const createStore = require('../../create-store');
+import * as frames from '../frames';
+import createStore from '../../create-store';
 
 describe('sidebar/store/modules/frames', function() {
   let store;

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -1,8 +1,8 @@
-const immutable = require('seamless-immutable');
+import immutable from 'seamless-immutable';
 
-const createStore = require('../../create-store');
-const groups = require('../groups');
-const session = require('../session');
+import createStore from '../../create-store';
+import * as groups from '../groups';
+import * as session from '../session';
 
 describe('sidebar/store/modules/groups', () => {
   const publicGroup = immutable({

--- a/src/sidebar/store/modules/test/links-test.js
+++ b/src/sidebar/store/modules/test/links-test.js
@@ -1,4 +1,4 @@
-const links = require('../links');
+import * as links from '../links';
 
 const init = links.init;
 const update = links.update.UPDATE_LINKS;

--- a/src/sidebar/store/modules/test/real-time-updates-test.js
+++ b/src/sidebar/store/modules/test/real-time-updates-test.js
@@ -1,9 +1,8 @@
-const createStore = require('../../create-store');
-
-const annotations = require('../annotations');
-const groups = require('../groups');
-const realTimeUpdates = require('../real-time-updates');
-const selection = require('../selection');
+import createStore from '../../create-store';
+import * as annotations from '../annotations';
+import * as groups from '../groups';
+import * as realTimeUpdates from '../real-time-updates';
+import * as selection from '../selection';
 
 const { removeAnnotations } = annotations.actions;
 const { focusGroup } = groups.actions;

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -1,7 +1,7 @@
-const annotations = require('../annotations');
-const createStore = require('../../create-store');
-const selection = require('../selection');
-const uiConstants = require('../../../ui-constants');
+import * as annotations from '../annotations';
+import createStore from '../../create-store';
+import * as selection from '../selection';
+import * as uiConstants from '../../../ui-constants';
 
 describe('sidebar/store/modules/selection', () => {
   let store;

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -1,5 +1,5 @@
-const createStore = require('../../create-store');
-const session = require('../session');
+import createStore from '../../create-store';
+import * as session from '../session';
 
 const { init } = session;
 

--- a/src/sidebar/store/modules/test/sidebar-panels-test.js
+++ b/src/sidebar/store/modules/test/sidebar-panels-test.js
@@ -1,5 +1,5 @@
-const createStore = require('../../create-store');
-const sidebarPanels = require('../sidebar-panels');
+import createStore from '../../create-store';
+import * as sidebarPanels from '../sidebar-panels';
 
 describe('sidebar/store/modules/sidebar-panels', () => {
   let store;

--- a/src/sidebar/store/modules/test/viewer-test.js
+++ b/src/sidebar/store/modules/test/viewer-test.js
@@ -1,5 +1,5 @@
-const viewer = require('../viewer');
-const createStore = require('../../create-store');
+import * as viewer from '../viewer';
+import createStore from '../../create-store';
 
 describe('store/modules/viewer', function() {
   let store;

--- a/src/sidebar/store/modules/viewer.js
+++ b/src/sidebar/store/modules/viewer.js
@@ -1,4 +1,4 @@
-const util = require('../util');
+import * as util from '../util';
 
 /**
  * This module defines actions and state related to the display mode of the

--- a/src/sidebar/store/test/create-store-test.js
+++ b/src/sidebar/store/test/create-store-test.js
@@ -1,4 +1,4 @@
-const createStore = require('../create-store');
+import createStore from '../create-store';
 
 const A = 0;
 

--- a/src/sidebar/store/test/debug-middleware-test.js
+++ b/src/sidebar/store/test/debug-middleware-test.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 
-const redux = require('redux');
+import * as redux from 'redux';
 
-const debugMiddleware = require('../debug-middleware');
+import debugMiddleware from '../debug-middleware';
 
 function id(state) {
   return state;

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -1,9 +1,9 @@
-const immutable = require('seamless-immutable');
+import immutable from 'seamless-immutable';
 
-const storeFactory = require('../index');
-const annotationFixtures = require('../../test/annotation-fixtures');
-const metadata = require('../../util/annotation-metadata');
-const uiConstants = require('../../ui-constants');
+import storeFactory from '../index';
+import * as annotationFixtures from '../../test/annotation-fixtures';
+import * as metadata from '../../util/annotation-metadata';
+import * as uiConstants from '../../ui-constants';
 
 const defaultAnnotation = annotationFixtures.defaultAnnotation;
 const newAnnotation = annotationFixtures.newAnnotation;

--- a/src/sidebar/store/test/use-store-test.js
+++ b/src/sidebar/store/test/use-store-test.js
@@ -1,9 +1,9 @@
-const { mount } = require('enzyme');
-const { createStore } = require('redux');
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
+import { mount } from 'enzyme';
+import { createStore } from 'redux';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const useStore = require('../use-store');
+import useStore from '../use-store';
 const { $imports } = useStore;
 
 const initialState = { value: 10, otherValue: 20 };

--- a/src/sidebar/store/test/util-test.js
+++ b/src/sidebar/store/test/util-test.js
@@ -1,4 +1,4 @@
-const util = require('../util');
+import * as util from '../util';
 
 const fixtures = {
   update: {

--- a/src/sidebar/store/use-store.js
+++ b/src/sidebar/store/use-store.js
@@ -1,10 +1,11 @@
 /* global process */
 
-const shallowEqual = require('shallowequal');
-const { useEffect, useRef, useReducer } = require('preact/hooks');
+import shallowEqual from 'shallowequal';
 
-const { useService } = require('../util/service-context');
-const warnOnce = require('../../shared/warn-once');
+import { useEffect, useRef, useReducer } from 'preact/hooks';
+
+import { useService } from '../util/service-context';
+import warnOnce from '../../shared/warn-once';
 
 /**
  * Hook for accessing state or actions from the store inside a component.

--- a/src/sidebar/test/bootstrap.js
+++ b/src/sidebar/test/bootstrap.js
@@ -8,9 +8,11 @@ sinon.assert.expose(assert, { prefix: null });
 // the directive tests rely on angular.element() returning
 // a full version of jQuery.
 //
-window.jQuery = window.$ = require('jquery');
+const jQuery = require('jquery');
 require('angular');
 require('angular-mocks');
+
+window.jQuery = window.$ = jQuery;
 
 // Configure Enzyme for UI tests.
 require('preact/debug');

--- a/src/sidebar/test/bootstrap.js
+++ b/src/sidebar/test/bootstrap.js
@@ -8,14 +8,16 @@ sinon.assert.expose(assert, { prefix: null });
 // the directive tests rely on angular.element() returning
 // a full version of jQuery.
 //
-const jQuery = require('jquery');
-require('angular');
-require('angular-mocks');
+import jQuery from 'jquery';
+
+import 'angular';
+import 'angular-mocks';
 
 window.jQuery = window.$ = jQuery;
 
 // Configure Enzyme for UI tests.
-require('preact/debug');
-const { configure } = require('enzyme');
-const { Adapter } = require('enzyme-adapter-preact-pure');
+import 'preact/debug';
+
+import { configure } from 'enzyme';
+import { Adapter } from 'enzyme-adapter-preact-pure';
 configure({ adapter: new Adapter() });

--- a/src/sidebar/test/build-thread-test.js
+++ b/src/sidebar/test/build-thread-test.js
@@ -1,5 +1,5 @@
-const buildThread = require('../build-thread');
-const metadata = require('../util/annotation-metadata');
+import buildThread from '../build-thread';
+import * as metadata from '../util/annotation-metadata';
 
 // Fixture with two top level annotations, one note and one reply
 const SIMPLE_FIXTURE = [

--- a/src/sidebar/test/cross-origin-rpc-test.js
+++ b/src/sidebar/test/cross-origin-rpc-test.js
@@ -1,4 +1,4 @@
-const crossOriginRPC = require('../cross-origin-rpc');
+import * as crossOriginRPC from '../cross-origin-rpc';
 
 describe('crossOriginRPC', function() {
   describe('server', function() {

--- a/src/sidebar/test/fake-redux-store.js
+++ b/src/sidebar/test/fake-redux-store.js
@@ -1,4 +1,4 @@
-const redux = require('redux');
+import * as redux from 'redux';
 
 /**
  * Utility function that creates a fake Redux store for use in tests.

--- a/src/sidebar/test/get-api-url-test.js
+++ b/src/sidebar/test/get-api-url-test.js
@@ -1,4 +1,4 @@
-const getApiUrl = require('../get-api-url');
+import getApiUrl from '../get-api-url';
 
 describe('sidebar.getApiUrl', function() {
   context('when there is a service object in settings', function() {

--- a/src/sidebar/test/group-fixtures.js
+++ b/src/sidebar/test/group-fixtures.js
@@ -1,4 +1,4 @@
-const Chance = require('chance');
+import Chance from 'chance';
 const chance = new Chance();
 
 function group() {

--- a/src/sidebar/test/host-config-test.js
+++ b/src/sidebar/test/host-config-test.js
@@ -1,4 +1,4 @@
-const hostPageConfig = require('../host-config');
+import hostPageConfig from '../host-config';
 
 function fakeWindow(config) {
   return {

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -1,5 +1,5 @@
-const angular = require('angular');
-const immutable = require('seamless-immutable');
+import angular from 'angular';
+import immutable from 'seamless-immutable';
 
 const fixtures = immutable({
   annotations: [

--- a/src/sidebar/test/markdown-commands-test.js
+++ b/src/sidebar/test/markdown-commands-test.js
@@ -1,4 +1,4 @@
-const commands = require('../markdown-commands');
+import * as commands from '../markdown-commands';
 
 /**
  * Convert a string containing '<sel>' and '</sel>' markers

--- a/src/sidebar/test/media-embedder-test.js
+++ b/src/sidebar/test/media-embedder-test.js
@@ -1,4 +1,4 @@
-const mediaEmbedder = require('../media-embedder.js');
+import * as mediaEmbedder from '../media-embedder.js';
 
 describe('media-embedder', function() {
   function domElement(html) {

--- a/src/sidebar/test/render-markdown-test.js
+++ b/src/sidebar/test/render-markdown-test.js
@@ -1,4 +1,4 @@
-const renderMarkdown = require('../render-markdown');
+import renderMarkdown from '../render-markdown';
 
 describe('render-markdown', function() {
   let render;

--- a/src/sidebar/test/search-client-test.js
+++ b/src/sidebar/test/search-client-test.js
@@ -1,4 +1,4 @@
-const SearchClient = require('../search-client');
+import SearchClient from '../search-client';
 
 function awaitEvent(emitter, event) {
   return new Promise(function(resolve) {

--- a/src/sidebar/test/service-config-test.js
+++ b/src/sidebar/test/service-config-test.js
@@ -1,4 +1,4 @@
-const serviceConfig = require('../service-config');
+import serviceConfig from '../service-config';
 
 describe('serviceConfig', function() {
   it('returns null if services is not an array', function() {

--- a/src/sidebar/test/virtual-thread-list-test.js
+++ b/src/sidebar/test/virtual-thread-list-test.js
@@ -1,4 +1,4 @@
-const VirtualThreadList = require('../virtual-thread-list');
+import VirtualThreadList from '../virtual-thread-list';
 
 describe('VirtualThreadList', function() {
   let lastState;

--- a/src/sidebar/test/websocket-test.js
+++ b/src/sidebar/test/websocket-test.js
@@ -1,4 +1,4 @@
-const Socket = require('../websocket');
+import Socket from '../websocket';
 
 describe('websocket wrapper', function() {
   let fakeSocket;

--- a/src/sidebar/util/annotation-sharing.js
+++ b/src/sidebar/util/annotation-sharing.js
@@ -1,4 +1,4 @@
-const serviceConfig = require('../service-config');
+import serviceConfig from '../service-config';
 
 /**
  * Is the sharing of annotations enabled? Check for any defined `serviceConfig`,

--- a/src/sidebar/util/fetch-config.js
+++ b/src/sidebar/util/fetch-config.js
@@ -1,6 +1,6 @@
-const getApiUrl = require('../get-api-url');
-const hostConfig = require('../host-config');
-const postMessageJsonRpc = require('./postmessage-json-rpc');
+import getApiUrl from '../get-api-url';
+import hostConfig from '../host-config';
+import * as postMessageJsonRpc from './postmessage-json-rpc';
 
 function ancestors(window_) {
   if (window_ === window_.top) {

--- a/src/sidebar/util/group-organizations.js
+++ b/src/sidebar/util/group-organizations.js
@@ -1,4 +1,4 @@
-const immutable = require('seamless-immutable');
+import immutable from 'seamless-immutable';
 
 // TODO: Update when this is a property available on the API response
 const DEFAULT_ORG_ID = '__default__';

--- a/src/sidebar/util/groups.js
+++ b/src/sidebar/util/groups.js
@@ -1,4 +1,4 @@
-const escapeStringRegexp = require('escape-string-regexp');
+import escapeStringRegexp from 'escape-string-regexp';
 
 /**
  * Combine groups from multiple api calls together to form a unique list of groups.

--- a/src/sidebar/util/is-third-party-service.js
+++ b/src/sidebar/util/is-third-party-service.js
@@ -1,4 +1,4 @@
-const serviceConfig = require('../service-config');
+import serviceConfig from '../service-config';
 
 /**
  * Return `true` if the first configured service is a "third-party" service.

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -1,6 +1,6 @@
-const queryString = require('query-string');
+import * as queryString from 'query-string';
 
-const random = require('./random');
+import * as random from './random';
 
 /**
  * An object holding the details of an access token from the tokenUrl endpoint.

--- a/src/sidebar/util/postmessage-json-rpc.js
+++ b/src/sidebar/util/postmessage-json-rpc.js
@@ -1,4 +1,4 @@
-const { generateHexString } = require('./random');
+import { generateHexString } from './random';
 
 /** Generate a random ID to associate RPC requests and responses. */
 function generateId() {

--- a/src/sidebar/util/retry.js
+++ b/src/sidebar/util/retry.js
@@ -1,4 +1,4 @@
-const retry = require('retry');
+import retry from 'retry';
 
 /**
  * Retry a Promise-returning operation until it succeeds or

--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -1,6 +1,6 @@
-const Sentry = require('@sentry/browser');
+import * as Sentry from '@sentry/browser';
 
-const warnOnce = require('../../shared/warn-once');
+import warnOnce from '../../shared/warn-once';
 
 /**
  * @typedef SentryConfig

--- a/src/sidebar/util/service-context.js
+++ b/src/sidebar/util/service-context.js
@@ -12,8 +12,9 @@
  *     https://reactjs.org/docs/hooks-reference.html#usecontext
  */
 
-const { useContext } = require('preact/hooks');
-const { createContext, createElement } = require('preact');
+import { useContext } from 'preact/hooks';
+
+import { createContext, createElement } from 'preact';
 
 const fallbackInjector = {
   get(service) {

--- a/src/sidebar/util/session.js
+++ b/src/sidebar/util/session.js
@@ -1,4 +1,4 @@
-const serviceConfig = require('../service-config');
+import serviceConfig from '../service-config';
 
 /**
  * Returns true if the sidebar tutorial has to be shown to a user for a given session.

--- a/src/sidebar/util/tabs.js
+++ b/src/sidebar/util/tabs.js
@@ -1,7 +1,8 @@
 // Functions that determine which tab an annotation should be displayed in.
 
-const metadata = require('./annotation-metadata');
-const uiConstants = require('../ui-constants');
+import * as metadata from './annotation-metadata';
+
+import * as uiConstants from '../ui-constants';
 
 /**
  * Return the tab in which an annotation should be displayed.

--- a/src/sidebar/util/test/account-id-test.js
+++ b/src/sidebar/util/test/account-id-test.js
@@ -1,4 +1,4 @@
-const { parseAccountID, username, isThirdPartyUser } = require('../account-id');
+import { parseAccountID, username, isThirdPartyUser } from '../account-id';
 
 describe('sidebar.util.account-id', function() {
   const term = 'acct:hacker@example.com';

--- a/src/sidebar/util/test/annotation-metadata-test.js
+++ b/src/sidebar/util/test/annotation-metadata-test.js
@@ -1,5 +1,5 @@
-const annotationMetadata = require('../annotation-metadata');
-const fixtures = require('../../test/annotation-fixtures');
+import * as annotationMetadata from '../annotation-metadata';
+import * as fixtures from '../../test/annotation-fixtures';
 
 const documentMetadata = annotationMetadata.documentMetadata;
 const domainAndTitle = annotationMetadata.domainAndTitle;

--- a/src/sidebar/util/test/annotation-sharing-test.js
+++ b/src/sidebar/util/test/annotation-sharing-test.js
@@ -1,4 +1,4 @@
-const sharingUtil = require('../annotation-sharing');
+import * as sharingUtil from '../annotation-sharing';
 
 describe('sidebar.util.annotation-sharing', () => {
   let fakeAnnotation;

--- a/src/sidebar/util/test/copy-to-clipboard-test.js
+++ b/src/sidebar/util/test/copy-to-clipboard-test.js
@@ -1,4 +1,4 @@
-const { copyText } = require('../copy-to-clipboard');
+import { copyText } from '../copy-to-clipboard';
 
 describe('copy-to-clipboard', () => {
   beforeEach(() => {

--- a/src/sidebar/util/test/disable-opener-for-external-links-test.js
+++ b/src/sidebar/util/test/disable-opener-for-external-links-test.js
@@ -1,4 +1,4 @@
-const disableOpenerForExternalLinks = require('../disable-opener-for-external-links');
+import disableOpenerForExternalLinks from '../disable-opener-for-external-links';
 
 describe('sidebar.util.disable-opener-for-external-links', () => {
   let containerEl;

--- a/src/sidebar/util/test/dom-test.js
+++ b/src/sidebar/util/test/dom-test.js
@@ -1,4 +1,4 @@
-const { listen } = require('../dom');
+import { listen } from '../dom';
 
 describe('sidebar/util/dom', () => {
   const createElement = () => ({

--- a/src/sidebar/util/test/fetch-config-test.js
+++ b/src/sidebar/util/test/fetch-config-test.js
@@ -1,8 +1,5 @@
-const {
-  assertPromiseIsRejected,
-} = require('../../../shared/test/promise-util');
-
-const { fetchConfig, $imports } = require('../fetch-config');
+import { assertPromiseIsRejected } from '../../../shared/test/promise-util';
+import { fetchConfig, $imports } from '../fetch-config';
 
 describe('sidebar.util.fetch-config', () => {
   let fakeHostConfig;

--- a/src/sidebar/util/test/group-list-item-common-test.js
+++ b/src/sidebar/util/test/group-list-item-common-test.js
@@ -1,6 +1,5 @@
-const groupListItemCommon = require('../group-list-item-common');
-
-const { events } = require('../../services/analytics');
+import * as groupListItemCommon from '../group-list-item-common';
+import { events } from '../../services/analytics';
 
 describe('sidebar/util/groupListItemCommon', () => {
   describe('trackViewGroupActivity', () => {

--- a/src/sidebar/util/test/group-organizations-test.js
+++ b/src/sidebar/util/test/group-organizations-test.js
@@ -1,5 +1,5 @@
-const groupsByOrganization = require('../group-organizations');
-const orgFixtures = require('../../test/group-fixtures');
+import groupsByOrganization from '../group-organizations';
+import * as orgFixtures from '../../test/group-fixtures';
 
 describe('group-organizations', function() {
   context('when sorting organizations and their contained groups', function() {

--- a/src/sidebar/util/test/groups-test.js
+++ b/src/sidebar/util/test/groups-test.js
@@ -1,4 +1,4 @@
-const { combineGroups } = require('../groups');
+import { combineGroups } from '../groups';
 
 describe('sidebar.util.groups', () => {
   describe('combineGroups', () => {

--- a/src/sidebar/util/test/is-sidebar-test.js
+++ b/src/sidebar/util/test/is-sidebar-test.js
@@ -1,4 +1,4 @@
-const isSidebar = require('../is-sidebar');
+import isSidebar from '../is-sidebar';
 
 describe('sidebar.utils.is-sidebar', () => {
   [

--- a/src/sidebar/util/test/is-third-party-service-test.js
+++ b/src/sidebar/util/test/is-third-party-service-test.js
@@ -1,4 +1,4 @@
-const isThirdPartyService = require('../is-third-party-service');
+import isThirdPartyService from '../is-third-party-service';
 
 describe('sidebar.util.isThirdPartyService', () => {
   let fakeServiceConfig;

--- a/src/sidebar/util/test/memoize-test.js
+++ b/src/sidebar/util/test/memoize-test.js
@@ -1,4 +1,4 @@
-const memoize = require('../memoize');
+import memoize from '../memoize';
 
 describe('memoize', function() {
   let count = 0;

--- a/src/sidebar/util/test/oauth-client-test.js
+++ b/src/sidebar/util/test/oauth-client-test.js
@@ -1,9 +1,9 @@
-const fetchMock = require('fetch-mock');
-const { stringify } = require('query-string');
-const sinon = require('sinon');
+import fetchMock from 'fetch-mock';
+import { stringify } from 'query-string';
+import sinon from 'sinon';
 
-const OAuthClient = require('../oauth-client');
-const FakeWindow = require('./fake-window');
+import OAuthClient from '../oauth-client';
+import FakeWindow from './fake-window';
 
 const fixtures = {
   tokenResponse: {

--- a/src/sidebar/util/test/observe-element-size-test.js
+++ b/src/sidebar/util/test/observe-element-size-test.js
@@ -1,4 +1,4 @@
-const observeElementSize = require('../observe-element-size');
+import observeElementSize from '../observe-element-size';
 
 /**
  * Wait for a condition to become true.

--- a/src/sidebar/util/test/postmessage-json-rpc-test.js
+++ b/src/sidebar/util/test/postmessage-json-rpc-test.js
@@ -1,9 +1,7 @@
-const EventEmitter = require('tiny-emitter');
+import EventEmitter from 'tiny-emitter';
 
-const {
-  assertPromiseIsRejected,
-} = require('../../../shared/test/promise-util');
-const { call } = require('../postmessage-json-rpc');
+import { assertPromiseIsRejected } from '../../../shared/test/promise-util';
+import { call } from '../postmessage-json-rpc';
 
 class FakeWindow {
   constructor() {

--- a/src/sidebar/util/test/random-test.js
+++ b/src/sidebar/util/test/random-test.js
@@ -1,4 +1,4 @@
-const random = require('../random');
+import * as random from '../random';
 
 describe('sidebar.util.random', () => {
   describe('#generateHexString', () => {

--- a/src/sidebar/util/test/retry-test.js
+++ b/src/sidebar/util/test/retry-test.js
@@ -1,5 +1,5 @@
-const retryUtil = require('../retry');
-const { toResult } = require('../../../shared/test/promise-util');
+import * as retryUtil from '../retry';
+import { toResult } from '../../../shared/test/promise-util';
 
 describe('sidebar.util.retry', function() {
   describe('.retryPromiseOperation', function() {

--- a/src/sidebar/util/test/retry-test.js
+++ b/src/sidebar/util/test/retry-test.js
@@ -1,5 +1,5 @@
 const retryUtil = require('../retry');
-const toResult = require('../../../shared/test/promise-util').toResult;
+const { toResult } = require('../../../shared/test/promise-util');
 
 describe('sidebar.util.retry', function() {
   describe('.retryPromiseOperation', function() {

--- a/src/sidebar/util/test/scope-timeout-test.js
+++ b/src/sidebar/util/test/scope-timeout-test.js
@@ -1,4 +1,4 @@
-const scopeTimeout = require('../scope-timeout');
+import scopeTimeout from '../scope-timeout';
 
 function FakeScope() {
   this.listeners = {};

--- a/src/sidebar/util/test/sentry-test.js
+++ b/src/sidebar/util/test/sentry-test.js
@@ -1,4 +1,4 @@
-const sentry = require('../sentry');
+import * as sentry from '../sentry';
 
 describe('sidebar/util/sentry', () => {
   let fakeDocumentReferrer;

--- a/src/sidebar/util/test/service-context-test.js
+++ b/src/sidebar/util/test/service-context-test.js
@@ -1,12 +1,8 @@
-const { mount } = require('enzyme');
-const propTypes = require('prop-types');
-const { createElement, render } = require('preact');
+import { mount } from 'enzyme';
+import propTypes from 'prop-types';
+import { createElement, render } from 'preact';
 
-const {
-  ServiceContext,
-  withServices,
-  useService,
-} = require('../service-context');
+import { ServiceContext, withServices, useService } from '../service-context';
 
 describe('service-context', () => {
   describe('withServices', () => {

--- a/src/sidebar/util/test/session-test.js
+++ b/src/sidebar/util/test/session-test.js
@@ -1,4 +1,4 @@
-const sessionUtil = require('../session');
+import * as sessionUtil from '../session';
 
 describe('sidebar/util/session', () => {
   describe('#shouldShowSidebarTutorial', () => {

--- a/src/sidebar/util/test/state-test.js
+++ b/src/sidebar/util/test/state-test.js
@@ -1,5 +1,5 @@
-const fakeStore = require('../../test/fake-redux-store');
-const stateUtil = require('../state');
+import fakeStore from '../../test/fake-redux-store';
+import * as stateUtil from '../state';
 
 describe('sidebar/util/state', function() {
   let store;

--- a/src/sidebar/util/test/tabs-test.js
+++ b/src/sidebar/util/test/tabs-test.js
@@ -1,6 +1,6 @@
-const fixtures = require('../../test/annotation-fixtures');
-const uiConstants = require('../../ui-constants');
-const tabs = require('../tabs');
+import * as fixtures from '../../test/annotation-fixtures';
+import * as uiConstants from '../../ui-constants';
+import * as tabs from '../tabs';
 
 describe('tabs', function() {
   describe('tabForAnnotation', function() {

--- a/src/sidebar/util/test/theme-test.js
+++ b/src/sidebar/util/test/theme-test.js
@@ -1,4 +1,4 @@
-const { applyTheme } = require('../theme');
+import { applyTheme } from '../theme';
 
 describe('sidebar/util/theme/applyTheme', () => {
   let fakeSettings;

--- a/src/sidebar/util/test/time-test.js
+++ b/src/sidebar/util/test/time-test.js
@@ -1,4 +1,4 @@
-const time = require('../time');
+import * as time from '../time';
 
 const second = 1000;
 const minute = second * 60;

--- a/src/sidebar/util/test/url-test.js
+++ b/src/sidebar/util/test/url-test.js
@@ -1,4 +1,4 @@
-const urlUtil = require('../url');
+import * as urlUtil from '../url';
 
 describe('sidebar/util/url', function() {
   describe('replaceURLParams()', function() {

--- a/src/sidebar/util/test/version-data-test.js
+++ b/src/sidebar/util/test/version-data-test.js
@@ -1,4 +1,4 @@
-const VersionData = require('../version-data');
+import VersionData from '../version-data';
 
 describe('VersionData', () => {
   let clock;

--- a/src/sidebar/util/test/wrap-react-component-test.js
+++ b/src/sidebar/util/test/wrap-react-component-test.js
@@ -1,11 +1,11 @@
-const angular = require('angular');
-const { Component, createElement } = require('preact');
-const { useContext } = require('preact/hooks');
-const propTypes = require('prop-types');
+import angular from 'angular';
+import { Component, createElement } from 'preact';
+import { useContext } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const { ServiceContext } = require('../service-context');
-const wrapReactComponent = require('../wrap-react-component');
-const { createDirective } = require('../../directive/test/util');
+import { ServiceContext } from '../service-context';
+import wrapReactComponent from '../wrap-react-component';
+import { createDirective } from '../../directive/test/util';
 
 // Saved `onDblClick` prop from last render of `Button`.
 // This makes it easy to call it with different arguments.

--- a/src/sidebar/util/wrap-react-component.js
+++ b/src/sidebar/util/wrap-react-component.js
@@ -1,5 +1,6 @@
-const { createElement, render } = require('preact');
-const { ServiceContext } = require('./service-context');
+import { createElement, render } from 'preact';
+
+import { ServiceContext } from './service-context';
 
 function useExpressionBinding(propName) {
   return propName.match(/^on[A-Z]/);

--- a/src/sidebar/virtual-thread-list.js
+++ b/src/sidebar/virtual-thread-list.js
@@ -1,5 +1,5 @@
-const EventEmitter = require('tiny-emitter');
-const debounce = require('lodash.debounce');
+import EventEmitter from 'tiny-emitter';
+import debounce from 'lodash.debounce';
 
 /**
  * @typedef Options

--- a/src/sidebar/websocket.js
+++ b/src/sidebar/websocket.js
@@ -1,5 +1,5 @@
-const retry = require('retry');
-const EventEmitter = require('tiny-emitter');
+import retry from 'retry';
+import EventEmitter from 'tiny-emitter';
 
 // see https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
 const CLOSE_NORMAL = 1000;


### PR DESCRIPTION
This PR converts most CommonJS/Node `require` imports to ES module `import` syntax using the [convert-to-es-modules](https://github.com/hypothesis/frontend-toolkit/tree/master/packages/convert-to-es-modules) script from the frontend-toolkit repo. The immediate motivation is that it means we'll be using the same module system across the client and lms projects, which will be convenient when sharing UI components and utilities between them.

There will be other benefits now and in the future in that ES imports are more amenable to static analysis. For example "Go to definition"/"Find references" using the ALE plugin in Vim (and I would guess VS Code or Atom, since they all use the same language server) works better.

The first few commits make some small changes that make it easier for the automated script to do its work. The last commit is the result of running the code on all files in `src/` except for `src/karma.config.js`.

The script only processes `require` calls which appear as top-level statements or variable initializers. This means that there are still some `require` calls which are invoked conditionally inside functions that are not touched by this PR.

The script preserves the existing sort order of imports, although it only has two categories for grouping (local imports vs imports from node_modules). We might use automated formatting to standardize the ordering/grouping in future as was recently done for the backend projects.

After this PR lands, I will move to the next step which is migrating `module.exports` to ES `export` syntax.