### PR TITLE
Move `delete` and `flag` logic into `AnnotationActionBar` sub-component

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -175,49 +175,6 @@ function AnnotationController(
 
   /**
    * @ngdoc method
-   * @name annotation.AnnotationController#flag
-   * @description Flag the annotation.
-   */
-  this.flag = function() {
-    if (!session.state.userid) {
-      flash.error(
-        'You must be logged in to report an annotation to the moderators.',
-        'Login to flag annotations'
-      );
-      return;
-    }
-
-    const onRejected = function(err) {
-      flash.error(err.message, 'Flagging annotation failed');
-    };
-    annotationMapper.flagAnnotation(self.annotation).then(function() {
-      store.updateFlagStatus(self.annotation.id, true);
-    }, onRejected);
-  };
-
-  /**
-   * @ngdoc method
-   * @name annotation.AnnotationController#delete
-   * @description Deletes the annotation.
-   */
-  this.delete = function() {
-    return $timeout(function() {
-      // Don't use confirm inside the digest cycle.
-      const msg = 'Are you sure you want to delete this annotation?';
-      if ($window.confirm(msg)) {
-        $scope.$apply(function() {
-          annotationMapper
-            .deleteAnnotation(self.annotation)
-            .catch(err =>
-              flash.error(err.message, 'Deleting annotation failed')
-            );
-        });
-      }
-    }, true);
-  };
-
-  /**
-   * @ngdoc method
    * @name annotation.AnnotationController#edit
    * @description Switches the view to an editor.
    */

--- a/src/sidebar/components/test/util.js
+++ b/src/sidebar/components/test/util.js
@@ -1,0 +1,34 @@
+/**
+ * Wait for a condition to evaluate to a truthy value.
+ *
+ * @param {() => any} condition - Function that returns a truthy value when some condition is met
+ * @param {number} timeout - Max delay in milliseconds to wait
+ * @param {string} what - Description of condition that is being waited for
+ * @return {Promise<any>} - Result of the `condition` function
+ */
+export async function waitFor(
+  condition,
+  timeout = 10,
+  what = condition.toString()
+) {
+  const result = condition();
+  if (result) {
+    return result;
+  }
+
+  const start = Date.now();
+
+  return new Promise((resolve, reject) => {
+    const timer = setInterval(() => {
+      const result = condition();
+      if (result) {
+        clearTimeout(timer);
+        resolve(result);
+      }
+      if (Date.now() - start > timeout) {
+        clearTimeout(timer);
+        reject(new Error(`waitFor(${what}) failed after ${timeout} ms`));
+      }
+    });
+  });
+}

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -80,8 +80,6 @@
     <div class="annotation-actions" ng-if="!vm.isSaving && !vm.editing() && vm.id()">
       <annotation-action-bar
         annotation="vm.annotation"
-        on-delete="vm.delete()"
-        on-flag="vm.flag()"
         on-edit="vm.edit()"
         on-reply="vm.reply()"></annotation-action-bar>
     </div>


### PR DESCRIPTION
This PR moves UI-handling logic for deleting and flagging annotations into `AnnotationActionBar`, which is where the buttons that control these behaviors reside.

This has multiple upsides, including:

1. Logic is nearer at hand to where it's needed
2. Fewer props to pass through from `Annotation`
3. Less code in `Annotation`

Given that `edit` and `reply` are in the purview of `Annotation`, that logic has been left in place in `Annotation` and callbacks passed (as before) to `AnnotationActionBar`.

This PR also adds a testing utility to aid with async testing; copied from LMS.

No user-visible changes.

Part of https://github.com/hypothesis/client/issues/1650