### PR TITLE
Add `isHighlight` util function to `annotation-metadata`

### DIFF
--- a/src/sidebar/test/annotation-fixtures.js
+++ b/src/sidebar/test/annotation-fixtures.js
@@ -113,7 +113,7 @@ function oldHighlight() {
   return {
     id: 'annotation_id',
     $highlight: undefined,
-    target: ['foo', 'bar'],
+    target: [{ source: 'source', selector: [] }],
     references: [],
     text: '',
     tags: [],

--- a/src/sidebar/util/annotation-metadata.js
+++ b/src/sidebar/util/annotation-metadata.js
@@ -149,6 +149,43 @@ function isWaitingToAnchor(annotation) {
   );
 }
 
+/**
+ * Is this annotation a highlight?
+ *
+ * Highlights are generally identifiable by having no text content AND no tags,
+ * but there is some nuance.
+ *
+ * @param {Object} annotation
+ * @return {boolean}
+ */
+function isHighlight(annotation) {
+  // `$highlight` is an ephemeral attribute set by the `annotator` on new
+  // annotation objects (created by clicking the "highlight" button).
+  // It is not persisted and cannot be relied upon, but if it IS present,
+  // this is definitely a highlight (one which is not yet saved).
+  if (annotation.$highlight) {
+    return true;
+  }
+
+  if (isNew(annotation)) {
+    // For new (unsaved-to-service) annotations, unless they have a truthy
+    // `$highlight` attribute, we don't know yet if they are a highlight.
+    return false;
+  }
+
+  // Note that it is possible to end up with an empty (no `text`) annotation
+  // that is not a highlight by adding at least one tag—thus, it is necessary
+  // to check for the existence of tags as well as text content.
+
+  return (
+    !isPageNote(annotation) &&
+    !isReply(annotation) &&
+    !annotation.hidden && // A hidden annotation has some form of objectionable content
+    !annotation.text &&
+    !(annotation.tags && annotation.tags.length)
+  );
+}
+
 /** Return `true` if the given annotation is an orphan. */
 function isOrphan(annotation) {
   return hasSelector(annotation) && annotation.$orphan;
@@ -220,6 +257,7 @@ module.exports = {
   domainAndTitle: domainAndTitle,
   flagCount: flagCount,
   isAnnotation: isAnnotation,
+  isHighlight: isHighlight,
   isNew: isNew,
   isOrphan: isOrphan,
   isPageNote: isPageNote,

--- a/src/sidebar/util/test/annotation-metadata-test.js
+++ b/src/sidebar/util/test/annotation-metadata-test.js
@@ -234,6 +234,58 @@ describe('annotation-metadata', function() {
     });
   });
 
+  describe('.isHighlight', () => {
+    [
+      {
+        annotation: fixtures.newEmptyAnnotation(),
+        expect: false,
+        desc: 'new, empty annotation',
+      },
+      {
+        annotation: fixtures.newReply(),
+        expect: false,
+        desc: 'new, reply annotation',
+      },
+      {
+        annotation: fixtures.newAnnotation(),
+        expect: false,
+        desc: 'new, with some text',
+      },
+      {
+        annotation: fixtures.newHighlight(),
+        expect: true,
+        desc: 'new, marked as $highlight',
+      },
+      {
+        annotation: fixtures.oldAnnotation(),
+        expect: false,
+        desc: 'pre-existing annotation',
+      },
+      {
+        annotation: fixtures.oldHighlight(),
+        expect: true,
+        desc: 'pre-existing higlight',
+      },
+      {
+        annotation: fixtures.oldPageNote(),
+        expect: false,
+        desc: 'pre-existing page note',
+      },
+      {
+        annotation: fixtures.oldReply(),
+        expect: false,
+        desc: 'pre-existing reply',
+      },
+    ].forEach(testcase => {
+      it(`returns ${testcase.expect} for isHighlight when annotation is: ${testcase.desc}`, () => {
+        assert.equal(
+          annotationMetadata.isHighlight(testcase.annotation),
+          testcase.expect
+        );
+      });
+    });
+  });
+
   describe('.isPageNote', function() {
     it('returns true for an annotation with an empty target', function() {
       assert.isTrue(


### PR DESCRIPTION
Related to https://github.com/hypothesis/client/issues/1650

This PR introduces an `isHighlight` function into the `annotation-metadata` utility module.

Background: As part of working on #1650, I'm looking at the way that the `Annotation` component and sub-components need to evaluate whether a given annotation is a highlight (or not). At present, that logic is held captive within the ng `annotation` controller. (See code here: https://github.com/hypothesis/client/blob/34d63c815669595e9feb20f9abd7fc523d4edca2/src/sidebar/components/annotation.js#L268-L293 ).

Instead of migrating this logic into the new `Annotation` controller, I'd like to analyze it and make it re-usable as a metadata utility.

I'm breaking this work out as a separate chunk because I want to get careful eyes on the logic I presumed and not have this get lost amongst other `Annotation` concerns.

To get tests to pass using the logic ported, I had to make a change to the `oldHighlight` annotation fixture. I want to get eyes on that, too, to make sure that I'm not doing something daft.
