### PR TITLE
Add custom datalist component

### DIFF
--- a/src/sidebar/components/datalist.js
+++ b/src/sidebar/components/datalist.js
@@ -1,0 +1,73 @@
+const { createElement } = require('preact');
+const classnames = require('classnames');
+const propTypes = require('prop-types');
+const { useMemo } = require('preact/hooks');
+
+/**
+ * Custom datalist component
+ */
+
+function DataList({
+  activeItem = -1,
+  list,
+  listFormatter = item => item,
+  onSelectItem,
+  open = false,
+}) {
+  const items = useMemo(() => {
+    return list.map((item, index) => {
+      return (
+        <li
+          key={`datalist-${index}`}
+          className={classnames({
+            'is-selected': activeItem === index,
+          })}
+          onClick={() => {
+            onSelectItem(item);
+          }}
+        >
+          {listFormatter(item, index)}
+        </li>
+      );
+    });
+  }, [activeItem, list, listFormatter, onSelectItem]);
+
+  return (
+    <div className="datalist">
+      {list.length && open && (
+        <div className="datalist__items">
+          <span className="datalist__arrow-down"/>
+          <ul className="datalist__ul">{items}</ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+DataList.propTypes = {
+  /**
+   * The activeItem is highlighted.
+   */
+  activeItem: propTypes.number,
+  /**
+   * The list of items to render. This can be a simple list of
+   * strings or a list of objects when used with listFormatter.
+   */
+  list: propTypes.array.isRequired,
+  /**
+   * An optional formatter to render each item inside an <li> tag
+   */
+  listFormatter: propTypes.func,
+  /**
+   * Callback when an item is clicked with the mouse.
+   *  (item, index) => {}
+   */
+  onSelectItem: propTypes.func.isRequired,
+  /**
+   * Is the list open or closed?
+   */
+
+  open: propTypes.boolean,
+};
+
+module.exports = DataList;

--- a/src/sidebar/components/datalist.js
+++ b/src/sidebar/components/datalist.js
@@ -4,10 +4,10 @@ const propTypes = require('prop-types');
 const { useMemo } = require('preact/hooks');
 
 /**
- * Custom datalist component
+ * Custom datalist component. Use this in conjunction with an input field.
  */
 
-function DataList({
+function Datalist({
   activeItem = -1,
   list,
   listFormatter = item => item,
@@ -33,10 +33,10 @@ function DataList({
   }, [activeItem, list, listFormatter, onSelectItem]);
 
   return (
-    <div className="datalist">
+    <div className={classnames({}, 'datalist')}>
       {list.length && open && (
         <div className="datalist__items">
-          <span className="datalist__arrow-down"/>
+          <span className="datalist__arrow-down" />
           <ul className="datalist__ul">{items}</ul>
         </div>
       )}
@@ -44,7 +44,7 @@ function DataList({
   );
 }
 
-DataList.propTypes = {
+Datalist.propTypes = {
   /**
    * The activeItem is highlighted.
    */
@@ -56,6 +56,8 @@ DataList.propTypes = {
   list: propTypes.array.isRequired,
   /**
    * An optional formatter to render each item inside an <li> tag
+   * This is useful if the list is an array of objects rather than
+   * just strings.
    */
   listFormatter: propTypes.func,
   /**
@@ -66,8 +68,7 @@ DataList.propTypes = {
   /**
    * Is the list open or closed?
    */
-
-  open: propTypes.boolean,
+  open: propTypes.bool,
 };
 
-module.exports = DataList;
+module.exports = Datalist;

--- a/src/sidebar/components/datalist.js
+++ b/src/sidebar/components/datalist.js
@@ -36,7 +36,6 @@ function Datalist({
     <div className="datalist">
       {list.length > 0 && open && (
         <div className="datalist__items">
-          <span className="datalist__arrow-down" />
           <ul className="datalist__ul">{items}</ul>
         </div>
       )}

--- a/src/sidebar/components/datalist.js
+++ b/src/sidebar/components/datalist.js
@@ -33,8 +33,8 @@ function Datalist({
   }, [activeItem, list, listFormatter, onSelectItem]);
 
   return (
-    <div className={classnames({}, 'datalist')}>
-      {list.length && open && (
+    <div className="datalist">
+      {list.length > 0 && open && (
         <div className="datalist__items">
           <span className="datalist__arrow-down" />
           <ul className="datalist__ul">{items}</ul>

--- a/src/sidebar/components/datalist.js
+++ b/src/sidebar/components/datalist.js
@@ -9,6 +9,8 @@ const { useMemo } = require('preact/hooks');
 
 function Datalist({
   activeItem = -1,
+  id,
+  itemPrefixId,
   list,
   listFormatter = item => item,
   onSelectItem,
@@ -16,27 +18,42 @@ function Datalist({
 }) {
   const items = useMemo(() => {
     return list.map((item, index) => {
+      // only add an id if itemPrefixId is passed
+      const props = itemPrefixId ? { id: `${itemPrefixId}${index}` } : {};
+
       return (
         <li
           key={`datalist-${index}`}
+          role="option"
+          aria-selected={activeItem === index}
           className={classnames({
             'is-selected': activeItem === index,
           })}
           onClick={() => {
             onSelectItem(item);
           }}
+          {...props}
         >
           {listFormatter(item, index)}
         </li>
       );
     });
-  }, [activeItem, list, listFormatter, onSelectItem]);
+  }, [activeItem, itemPrefixId, list, listFormatter, onSelectItem]);
 
+  const props = id ? { id } : {}; // only add the id if its passed
   return (
     <div className="datalist">
       {list.length > 0 && open && (
         <div className="datalist__items">
-          <ul className="datalist__ul">{items}</ul>
+          <ul
+            tabIndex="-1"
+            aria-label="Suggestions"
+            role="listbox"
+            className="datalist__ul"
+            {...props}
+          >
+            {items}
+          </ul>
         </div>
       )}
     </div>
@@ -48,6 +65,16 @@ Datalist.propTypes = {
    * The activeItem is highlighted.
    */
   activeItem: propTypes.number,
+  /**
+   * Optional unique HTML attribute id.
+   */
+  id: propTypes.string,
+  /**
+   * Optional unique HTML attribute id prefix for each item in the list.
+   * The final value of each items' id is `{itemPrefixId}{activeItem}`
+   */
+  itemPrefixId: propTypes.string,
+
   /**
    * The list of items to render. This can be a simple list of
    * strings or a list of objects when used with listFormatter.

--- a/src/sidebar/components/datalist.js
+++ b/src/sidebar/components/datalist.js
@@ -1,7 +1,9 @@
-const { createElement } = require('preact');
-const classnames = require('classnames');
-const propTypes = require('prop-types');
-const { useMemo } = require('preact/hooks');
+import { createElement } from 'preact';
+import classnames from 'classnames';
+import propTypes from 'prop-types';
+import { useMemo } from 'preact/hooks';
+
+const defaultListFormatter = item => item;
 
 /**
  * Custom datalist component. Use this in conjunction with an input field.
@@ -12,7 +14,7 @@ function Datalist({
   id,
   itemPrefixId,
   list,
-  listFormatter = item => item,
+  listFormatter = defaultListFormatter,
   onSelectItem,
   open = false,
 }) {
@@ -26,9 +28,12 @@ function Datalist({
           key={`datalist-${index}`}
           role="option"
           aria-selected={activeItem === index}
-          className={classnames({
-            'is-selected': activeItem === index,
-          })}
+          className={classnames(
+            {
+              'is-selected': activeItem === index,
+            },
+            'datalist__li'
+          )}
           onClick={() => {
             onSelectItem(item);
           }}

--- a/src/sidebar/components/hooks/use-element-should-close.js
+++ b/src/sidebar/components/hooks/use-element-should-close.js
@@ -82,12 +82,8 @@ export default function useElementShouldClose(
       document.body,
       'focus',
       event => {
-<<<<<<< HEAD
         const current = getCurrentNode(closeableEl);
         if (!current.contains(event.target)) {
-=======
-        if (!closeableEl.current.contains(event.target)) {
->>>>>>> Add tests
           handleClose();
         }
       },
@@ -100,12 +96,8 @@ export default function useElementShouldClose(
       document.body,
       ['mousedown', 'click'],
       event => {
-<<<<<<< HEAD
         const current = getCurrentNode(closeableEl);
         if (!current.contains(event.target)) {
-=======
-        if (!closeableEl.current.contains(event.target)) {
->>>>>>> Add tests
           handleClose();
         }
       },

--- a/src/sidebar/components/hooks/use-element-should-close.js
+++ b/src/sidebar/components/hooks/use-element-should-close.js
@@ -82,8 +82,12 @@ export default function useElementShouldClose(
       document.body,
       'focus',
       event => {
+<<<<<<< HEAD
         const current = getCurrentNode(closeableEl);
         if (!current.contains(event.target)) {
+=======
+        if (!closeableEl.current.contains(event.target)) {
+>>>>>>> Add tests
           handleClose();
         }
       },
@@ -96,8 +100,12 @@ export default function useElementShouldClose(
       document.body,
       ['mousedown', 'click'],
       event => {
+<<<<<<< HEAD
         const current = getCurrentNode(closeableEl);
         if (!current.contains(event.target)) {
+=======
+        if (!closeableEl.current.contains(event.target)) {
+>>>>>>> Add tests
           handleClose();
         }
       },

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -14,7 +14,7 @@ let tagEditorIdCounter = 0;
 /**
  * Component to edit annotation's tags.
  *
- * Component accessability is modeled after "Combobox with Listbox Popup Examples" found here:
+ * Component accessibility is modeled after "Combobox with Listbox Popup Examples" found here:
  * https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html
  */
 
@@ -224,21 +224,26 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
           );
         })}
       </ul>
-      <span ref={closeWrapperRef}>
+      <span
+        id={tagEditorId}
+        className="tag-editor__combobox-wrapper"
+        ref={closeWrapperRef}
+        role="combobox"
+        aria-expanded={isOpen.toString()}
+        aria-owns={`${tagEditorId}-datalist`}
+        aria-haspopup="true"
+      >
         <input
-          id={tagEditorId}
           onInput={handleOnInput}
           onKeyDown={handleKeyDown}
+          aria-controls={`${tagEditorId}-datalist`}
           onFocus={handleFocus}
           ref={inputEl}
           placeholder="Add new tags"
           className="tag-editor__input"
           type="text"
           autoComplete="off"
-          role="combobox"
           aria-autocomplete="list"
-          aria-expanded={isOpen}
-          aria-owns={`${tagEditorId}-datalist`}
           aria-activedescendant={activeDescendant}
         />
         <Datalist

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -1,11 +1,12 @@
 import { createElement } from 'preact';
-import { useMemo, useRef, useState } from 'preact/hooks';
+import { useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import { withServices } from '../util/service-context';
 
 import Datalist from './datalist';
 import SvgIcon from './svg-icon';
+import useElementShouldClose from './hooks/use-element-should-close';
 
 /**
  * Component to edit annotation's tags.

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -4,10 +4,8 @@ import propTypes from 'prop-types';
 
 import { withServices } from '../util/service-context';
 
+import Datalist from './datalist';
 import SvgIcon from './svg-icon';
-
-// Global counter used to create a unique id for each instance of a TagEditor
-let datalistIdCounter = 0;
 
 /**
  * Component to edit annotation's tags.
@@ -15,17 +13,15 @@ let datalistIdCounter = 0;
 
 function TagEditor({ onEditTags, tags: tagsService, tagList }) {
   const inputEl = useRef(null);
-  const [showSuggestions, setShowSuggestions] = useState(false);
-  const [suggestionsFiltered, setSuggestionsFiltered] = useState([]); // For Chrome only
-  const [datalistId] = useState(() => {
-    ++datalistIdCounter;
-    return `tag-editor-datalist-${datalistIdCounter}`;
-  });
+  const [suggestions, setSuggestions] = useState([]);
+  const [activeItem, setActiveItem] = useState(-1); // -1 is unselected
+  const [isOpen, setOpen] = useState(false);
 
-  const isChromeUA = !!window.navigator.userAgent.match(/Chrome\/[.0-9]*/);
-  // Suggestion limiter to speed up the performance in Chrome
-  // See https://github.com/hypothesis/client/issues/1606
-  const chromeSuggestionsLimit = 20;
+  // Set up callback to monitor outside click events to lose the Datalist
+  const closeWrapperRef = useRef();
+  useElementShouldClose(closeWrapperRef, isOpen, () => {
+    setOpen(false);
+  });
 
   /**
    * Helper function that returns a list of suggestions less any
@@ -45,12 +41,22 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
     return suggestionsSet.sort();
   };
 
-  // List of suggestions returned from the tagsService
-  const suggestions = useMemo(() => {
+  /**
+   * Get a list of suggestions returned from the tagsService
+   * reset the activeItem and open the Datalist
+   */
+  const updateSuggestions = () => {
     // Remove any repeated suggestions that are already tags.
     // Call filter with an empty string to return all suggestions
-    return removeDuplicates(tagsService.filter(''), tagList);
-  }, [tagsService, tagList]);
+    setSuggestions(
+      removeDuplicates(
+        tagsService.filter(inputEl.current.value.trim()),
+        tagList
+      )
+    );
+    setActiveItem(-1);
+    setOpen(true);
+  };
 
   /**
    * Handle changes to this annotation's tags
@@ -77,8 +83,8 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
    * Adds a tag to the annotation equal to the value of the input field
    * and then clears out the suggestions list and the input field.
    */
-  const addTag = () => {
-    const value = inputEl.current.value.trim();
+  const addTag = newTag => {
+    const value = newTag.trim();
     if (value.length === 0) {
       // don't add an empty tag
       return;
@@ -88,96 +94,90 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
       return;
     }
     updateTags([...tagList, value]);
-    setShowSuggestions(false);
+    setOpen(false);
 
     inputEl.current.value = '';
     inputEl.current.focus();
   };
 
   /**
-   *  If the user pressed enter or comma while focused on
-   *  the <input>, then add a new tag.
+   *  Update the suggestions if the user changes the value of the input
    */
-  const handleKeyPress = e => {
-    if (e.key === 'Enter' || e.key === ',') {
-      addTag();
-      // preventDefault stops the delimiter from being
-      // added to the input field
-      e.preventDefault();
-    }
-  };
-
   const handleOnInput = e => {
     if (
       e.inputType === 'insertText' ||
       e.inputType === 'deleteContentBackward'
     ) {
-      if (inputEl.current.value.length === 0) {
-        // If the user deleted input, hide suggestions. This has
-        // no effect in Safari and the list will stay open.
-        setShowSuggestions(false);
-      } else {
-        if (isChromeUA) {
-          // Filter down the suggestions list for Chrome to subvert a performance
-          // issue. Returning too many suggestions causes a noticeable delay when
-          // rendering the datalist.
-          // See https://github.com/hypothesis/client/issues/1606
-          setSuggestionsFiltered(
-            removeDuplicates(
-              tagsService.filter(inputEl.current.value, chromeSuggestionsLimit),
-              tagList
-            )
-          );
+      updateSuggestions();
+    }
+  };
+
+  /**
+   *  Callback when the user clicked one of the items in the suggestions list.
+   *  This will add a new tag.
+   */
+  const handleSelect = item => {
+    if (item) {
+      addTag(item);
+    }
+  };
+
+  /**
+   * Opens the Datalist on focus if there is a value in the input
+   */
+  const handleFocus = () => {
+    if (inputEl.current.value.trim().length) {
+      setOpen(true);
+    }
+  };
+
+  /**
+   *  Called when the user uses keyboard navigation to move
+   *  up or down the suggestions list creating a highlighted
+   *  item.
+   *
+   *  The first value in the list is an unselected value (-1).
+   *  A user can arrive at this value by pressing the up arrow back to
+   *  the beginning or the down arrow until the end.
+   *
+   * @param {number} direction - Pass 1 for the next item or -1 for the previous
+   */
+  const changeSelectedItem = direction => {
+    let nextActiveItem = activeItem + direction;
+    if (nextActiveItem < -1) {
+      nextActiveItem = suggestions.length - 1;
+    } else if (nextActiveItem >= suggestions.length) {
+      nextActiveItem = -1;
+    }
+    setActiveItem(nextActiveItem);
+  };
+
+  /**
+   * Keydown handler for keyboard navigation of the suggestions list
+   * and when the user presses "Enter" or ","" to add a new typed item not
+   * found in the suggestions list
+   */
+  const handleKeyDown = e => {
+    switch (e.key) {
+      case 'ArrowUp':
+        changeSelectedItem(-1);
+        e.preventDefault();
+        break;
+      case 'ArrowDown':
+        changeSelectedItem(1);
+        e.preventDefault();
+        break;
+      case 'Enter':
+      case ',':
+        if (activeItem === -1) {
+          // nothing selected, just add the typed text
+          addTag(inputEl.current.value);
+        } else {
+          addTag(suggestions[activeItem]);
         }
-        // Show the suggestions if the user types something into the field
-        setShowSuggestions(true);
-      }
-    } else if (
-      e.inputType === undefined ||
-      e.inputType === 'insertReplacementText'
-    ) {
-      // nb. Chrome / Safari reports undefined and Firefox reports 'insertReplacementText'
-      // for the inputTyp value when clicking on an element in the datalist.
-      //
-      // There are two ways to arrive here, either click an item with the mouse
-      // or use keyboard navigation and press 'Enter'.
-      //
-      // If the input value typed already exactly matches the option selected
-      // then this event won't fire and a user would have to press 'Enter' a second
-      // time to trigger the handleKeyPress callback above to add the tag.
-      // Bug: https://github.com/hypothesis/client/issues/1604
-      addTag();
+        e.preventDefault();
+        break;
     }
-  };
-
-  const handleKeyUp = e => {
-    // Safari on macOS and iOS have an issue where pressing "Enter" in an
-    // input when its value exactly matches a suggestion in the associated <datalist>
-    // does not generate a "keypress" event. Therefore we catch the subsequent
-    // "keyup" event instead.
-
-    if (e.key === 'Enter') {
-      // nb. `addTag` will do nothing if the "keypress" event was already handled.
-      addTag();
-    }
-  };
-
-  const suggestionsList = () => {
-    // If this is Chrome, use the filtered list, otherwise use the full list
-    // See https://github.com/hypothesis/client/issues/1606
-    const optionsList = isChromeUA ? suggestionsFiltered : suggestions;
-    return (
-      <datalist
-        id={datalistId}
-        className="tag-editor__suggestions"
-        aria-label="Annotation suggestions"
-      >
-        {showSuggestions &&
-          optionsList.map(suggestion => (
-            <option key={suggestion} value={suggestion} />
-          ))}
-      </datalist>
-    );
   };
 
   return (
@@ -207,17 +207,25 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
           );
         })}
       </ul>
-      <input
-        list={datalistId}
-        onInput={handleOnInput}
-        onKeyPress={handleKeyPress}
-        onKeyUp={handleKeyUp}
-        ref={inputEl}
-        placeholder="Add tags..."
-        className="tag-editor__input"
-        type="text"
-      />
-      {suggestionsList()}
+      <span ref={closeWrapperRef}>
+        <input
+          onInput={handleOnInput}
+          onKeyDown={handleKeyDown}
+          onFocus={handleFocus}
+          ref={inputEl}
+          placeholder="Add new tags"
+          className="tag-editor__input"
+          type="text"
+        />
+        <Datalist
+          list={suggestions}
+          open={isOpen}
+          onSelectItem={item => {
+            handleSelect(item);
+          }}
+          activeItem={activeItem}
+        />
+      </span>
     </section>
   );
 }

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -46,16 +46,17 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
    * reset the activeItem and open the Datalist
    */
   const updateSuggestions = () => {
-    // Remove any repeated suggestions that are already tags.
-    // Call filter with an empty string to return all suggestions
-    setSuggestions(
-      removeDuplicates(
-        tagsService.filter(inputEl.current.value.trim()),
-        tagList
-      )
-    );
+    const value = inputEl.current.value.trim();
+    if (value === '') {
+      // If there is no input, just hide the suggestions
+      setOpen(false);
+    } else {
+      // Remove any repeated suggestions that are already tags.
+      // Call filter with an empty string to return all suggestions
+      setSuggestions(removeDuplicates(tagsService.filter(value), tagList));
+      setOpen(true);
+    }
     setActiveItem(-1);
-    setOpen(true);
   };
 
   /**

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -8,8 +8,14 @@ import Datalist from './datalist';
 import SvgIcon from './svg-icon';
 import useElementShouldClose from './hooks/use-element-should-close';
 
+// Global counter used to create a unique id for each instance of a TagEditor
+let tagEditorIdCounter = 0;
+
 /**
  * Component to edit annotation's tags.
+ *
+ * Component accessability is modeled after "Combobox with Listbox Popup Examples" found here:
+ * https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html
  */
 
 function TagEditor({ onEditTags, tags: tagsService, tagList }) {
@@ -17,6 +23,10 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
   const [suggestions, setSuggestions] = useState([]);
   const [activeItem, setActiveItem] = useState(-1); // -1 is unselected
   const [isOpen, setOpen] = useState(false);
+  const [tagEditorId] = useState(() => {
+    ++tagEditorIdCounter;
+    return `tag-editor-${tagEditorIdCounter}`;
+  });
 
   // Set up callback to monitor outside click events to lose the Datalist
   const closeWrapperRef = useRef();
@@ -182,6 +192,11 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
     }
   };
 
+  // Only add the aria-activedescendant prop when there is an item selected.
+  // -1 value means no item selected.
+  const activeDescendant =
+    activeItem >= 0 ? `${tagEditorId}-datalist-item-${activeItem}` : false;
+
   return (
     <section className="tag-editor">
       <ul
@@ -211,6 +226,7 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
       </ul>
       <span ref={closeWrapperRef}>
         <input
+          id={tagEditorId}
           onInput={handleOnInput}
           onKeyDown={handleKeyDown}
           onFocus={handleFocus}
@@ -218,13 +234,19 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
           placeholder="Add new tags"
           className="tag-editor__input"
           type="text"
+          autoComplete="off"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={isOpen}
+          aria-owns={`${tagEditorId}-datalist`}
+          aria-activedescendant={activeDescendant}
         />
         <Datalist
+          id={`${tagEditorId}-datalist`}
           list={suggestions}
           open={isOpen}
-          onSelectItem={item => {
-            handleSelect(item);
-          }}
+          onSelectItem={handleSelect}
+          itemPrefixId={`${tagEditorId}-datalist-item-`}
           activeItem={activeItem}
         />
       </span>

--- a/src/sidebar/components/test/datalist-test.js
+++ b/src/sidebar/components/test/datalist-test.js
@@ -1,0 +1,116 @@
+const { createElement } = require('preact');
+const { mount } = require('enzyme');
+
+const mockImportedComponents = require('./mock-imported-components');
+const Datalist = require('../datalist');
+const { $imports } = require('../datalist');
+
+describe('TagEditor', function() {
+  let fakeList;
+  let fakeOnSelectItem;
+  let fakeListFormatter;
+  function createComponent(props) {
+    return mount(
+      <Datalist
+        // props
+        list={fakeList}
+        open={true}
+        onSelectItem={fakeOnSelectItem}
+        {...props}
+      />
+    );
+  }
+
+  beforeEach(function() {
+    fakeList = ['tag1', 'tag2'];
+    fakeOnSelectItem = sinon.stub();
+    fakeListFormatter = sinon.stub();
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('does not render the list when open is false', () => {
+    const wrapper = createComponent({ open: false });
+    assert.isFalse(wrapper.find('.datalist__items').exists());
+  });
+
+  it('does not render the list when list is empty', () => {
+    const wrapper = createComponent({ list: [] });
+    assert.isFalse(wrapper.find('.datalist__items').exists());
+  });
+
+  it('sets uniques keys to the <li> items', () => {
+    const wrapper = createComponent();
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(0)
+        .key(),
+      'datalist-0'
+    );
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(1)
+        .key(),
+      'datalist-1'
+    );
+  });
+
+  it('renders the items in order of the list prop', () => {
+    const wrapper = createComponent();
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(0)
+        .text(),
+      'tag1'
+    );
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(1)
+        .text(),
+      'tag2'
+    );
+  });
+
+  it('does not apply the `is-selected` class to items that are not selected', () => {
+    const wrapper = createComponent();
+    assert.isFalse(wrapper.find('li.is-selected').exists());
+  });
+
+  it('applies `is-selected` class only to the <li> at the matching index', () => {
+    const wrapper = createComponent({ activeItem: 0 });
+    assert.isTrue(
+      wrapper
+        .find('li')
+        .at(0)
+        .hasClass('is-selected')
+    );
+    assert.isFalse(
+      wrapper
+        .find('li')
+        .at(1)
+        .hasClass('is-selected')
+    );
+  });
+
+  it('calls onSelect when an <li> is clicked with the corresponding item', () => {
+    const wrapper = createComponent({ activeItem: 0 });
+    wrapper
+      .find('li')
+      .at(0)
+      .simulate('click');
+    assert.calledWith(fakeOnSelectItem, 'tag1');
+  });
+
+  it('calls listFormatter when building the <li> items if present', () => {
+    createComponent({ listFormatter: fakeListFormatter });
+    assert.calledWith(fakeListFormatter, 'tag1', 0);
+    assert.calledWith(fakeListFormatter, 'tag2', 1);
+  });
+});

--- a/src/sidebar/components/test/datalist-test.js
+++ b/src/sidebar/components/test/datalist-test.js
@@ -114,4 +114,52 @@ describe('TagEditor', function() {
     assert.calledWith(fakeListFormatter, 'tag1', 0);
     assert.calledWith(fakeListFormatter, 'tag2', 1);
   });
+
+  it('adds the `id` attribute to <ul> only if its present', () => {
+    let wrapper = createComponent();
+    assert.isNotOk(wrapper.find('ul').prop('id'));
+    wrapper = createComponent({ id: 'datalist-id' });
+    assert.equal(wrapper.find('ul').prop('id'), 'datalist-id');
+  });
+
+  it('creates unique ids on the <li> tags with the `itemPrefixId` only if its present', () => {
+    let wrapper = createComponent();
+    assert.isNotOk(
+      wrapper
+        .find('li')
+        .at(0)
+        .prop('id')
+    );
+    wrapper = createComponent({ itemPrefixId: 'item-prefix-id-' });
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(0)
+        .prop('id'),
+      'item-prefix-id-0'
+    );
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(1)
+        .prop('id'),
+      'item-prefix-id-1'
+    );
+  });
+
+  it('sets the `aria-selected` attribute on the active index ', () => {
+    const wrapper = createComponent({ activeItem: 0 });
+    assert.isTrue(
+      wrapper
+        .find('li')
+        .at(0)
+        .prop('aria-selected')
+    );
+    assert.isFalse(
+      wrapper
+        .find('li')
+        .at(1)
+        .prop('aria-selected')
+    );
+  });
 });

--- a/src/sidebar/components/test/datalist-test.js
+++ b/src/sidebar/components/test/datalist-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const mockImportedComponents = require('./mock-imported-components');
-const Datalist = require('../datalist');
-const { $imports } = require('../datalist');
+import Datalist from '../datalist';
+import { $imports } from '../tag-editor';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('TagEditor', function() {
   let fakeList;

--- a/src/sidebar/components/test/datalist-test.js
+++ b/src/sidebar/components/test/datalist-test.js
@@ -2,18 +2,17 @@ import { mount } from 'enzyme';
 import { createElement } from 'preact';
 
 import Datalist from '../datalist';
-import { $imports } from '../tag-editor';
+import { $imports } from '../datalist';
 
 import mockImportedComponents from './mock-imported-components';
 
-describe('TagEditor', function() {
+describe('Datalist', function() {
   let fakeList;
   let fakeOnSelectItem;
   let fakeListFormatter;
   function createComponent(props) {
     return mount(
       <Datalist
-        // props
         list={fakeList}
         open={true}
         onSelectItem={fakeOnSelectItem}
@@ -43,7 +42,7 @@ describe('TagEditor', function() {
     assert.isFalse(wrapper.find('.datalist__items').exists());
   });
 
-  it('sets uniques keys to the <li> items', () => {
+  it('sets unique keys to the <li> items', () => {
     const wrapper = createComponent();
     assert.equal(
       wrapper

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 import { createElement } from 'preact';
-import { act } = from 'preact/test-utils';
+import { act } from 'preact/test-utils';
 
 import TagEditor from '../tag-editor';
 import { $imports } from '../tag-editor';

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -1,5 +1,6 @@
 import { mount } from 'enzyme';
 import { createElement } from 'preact';
+import { act } = from 'preact/test-utils';
 
 import TagEditor from '../tag-editor';
 import { $imports } from '../tag-editor';
@@ -7,6 +8,7 @@ import { $imports } from '../tag-editor';
 import mockImportedComponents from './mock-imported-components';
 
 describe('TagEditor', function() {
+  let container;
   let fakeTags = ['tag1', 'tag2'];
   let fakeTagsService;
   let fakeServiceUrl;
@@ -22,34 +24,52 @@ describe('TagEditor', function() {
         serviceUrl={fakeServiceUrl}
         tags={fakeTagsService}
         {...props}
-      />
+      />,
+      { attachTo: container }
     );
   }
 
   // Simulates a selection event from datalist
-  function selectOption(wrapper) {
-    wrapper.find('input').simulate('input', { inputType: undefined });
-  }
-  // Simulates a selection event from datalist. This is the
-  // only event that fires in in Safari. In Chrome, both the `keyup`
-  // and `input` events fire, but only the first one adds the tag.
-  function selectOptionViaKeyUp(wrapper) {
-    wrapper.find('input').simulate('keyup', { key: 'Enter' });
+  function selectOption(wrapper, item) {
+    act(() => {
+      wrapper
+        .find('Datalist')
+        .props()
+        .onSelectItem(item);
+    });
   }
 
-  // Simulates a typing input event
+  // Simulates pressing Enter
+  function selectOptionViaEnter(wrapper) {
+    wrapper.find('input').simulate('keydown', { key: 'Enter' });
+  }
+  // Simulates typing ","
+  function selectOptionViaDelimiter(wrapper) {
+    wrapper.find('input').simulate('keydown', { key: ',' });
+  }
+  // Simulates typing the down arrow
+  function navigateDown(wrapper) {
+    wrapper.find('input').simulate('keydown', { key: 'ArrowDown' });
+  }
+  // Simulates typing the up arrow
+  function navigateUp(wrapper) {
+    wrapper.find('input').simulate('keydown', { key: 'ArrowUp' });
+  }
+  // Simulates a typing text
   function typeInput(wrapper) {
     wrapper.find('input').simulate('input', { inputType: 'insertText' });
   }
 
   beforeEach(function() {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
     fakeOnEditTags = sinon.stub();
     fakeServiceUrl = sinon.stub().returns('http://serviceurl.com');
     fakeTagsService = {
       filter: sinon.stub().returns(['tag4', 'tag3']),
       store: sinon.stub(),
     };
-
     $imports.$mock(mockImportedComponents());
   });
 
@@ -66,118 +86,106 @@ describe('TagEditor', function() {
     });
   });
 
-  it("creates a `list` prop on the input that matches the datalist's `id`", () => {
-    const wrapper = createComponent();
-    assert.equal(
-      wrapper.find('input').prop('list'),
-      wrapper.find('datalist').prop('id')
-    );
-  });
-
-  it('creates multiple TagEditors with unique datalist `id`s', () => {
-    const wrapper1 = createComponent();
-    const wrapper2 = createComponent();
-    assert.notEqual(
-      wrapper1.find('datalist').prop('id'),
-      wrapper2.find('datalist').prop('id')
-    );
-  });
-
-  it('generates a ordered datalist containing the array values returned from fakeTagsService.filter ', () => {
+  it('generates an ordered datalist containing the array values returned from fakeTagsService.filter ', () => {
     const wrapper = createComponent();
     wrapper.find('input').instance().value = 'non-empty';
-    wrapper.find('input').simulate('input', { inputType: 'insertText' });
-
-    // fakeTagsService.filter returns ['tag4', 'tag3'], but
-    // datalist shall be ordered as ['tag3', 'tag4']
-    assert.equal(
-      wrapper
-        .find('datalist option')
-        .at(0)
-        .prop('value'),
-      'tag3'
-    );
-    assert.equal(
-      wrapper
-        .find('datalist option')
-        .at(1)
-        .prop('value'),
-      'tag4'
-    );
+    typeInput(wrapper);
+    assert.equal(wrapper.find('Datalist').prop('list')[0], 'tag3');
+    assert.equal(wrapper.find('Datalist').prop('list')[1], 'tag4');
   });
 
-  [
-    {
-      text: ' in Chrome and Safari',
-      eventPayload: { inputType: undefined },
-    },
-    {
-      text: ' in Firefox',
-      eventPayload: { inputType: 'insertReplacementText' },
-    },
-  ].forEach(test => {
-    it(`clears the suggestions when selecting a tag from datalist ${test.text}`, () => {
+  it('passes the text value to filter() after receiving input', () => {
+    const wrapper = createComponent();
+    wrapper.find('input').instance().value = 'tag3';
+    typeInput(wrapper);
+    assert.isTrue(fakeTagsService.filter.calledOnce);
+    assert.isTrue(fakeTagsService.filter.calledWith('tag3'));
+  });
+
+  describe('suggestions open / close', () => {
+    it('close the suggestions when selecting a tag from datalist', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = 'non-empty'; // to open list
+      typeInput(wrapper);
+      assert.equal(wrapper.find('Datalist').prop('open'), true);
+      selectOption(wrapper, 'tag4');
+      wrapper.update();
+      assert.equal(wrapper.find('Datalist').prop('open'), false);
+    });
+
+    it('close the suggestions when deleting input', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = 'tag3';
       typeInput(wrapper);
-      assert.equal(wrapper.find('datalist option').length, 2);
-      wrapper.find('input').simulate('input', test.eventPayload); // simulates a selection
-      assert.equal(wrapper.find('datalist option').length, 0);
-
-      assert.isTrue(
-        fakeTagsService.store.calledWith([
-          { text: 'tag1' },
-          { text: 'tag2' },
-          { text: 'tag3' },
-        ])
-      );
-    });
-  });
-
-  it('clears the suggestions when deleting input', () => {
-    const wrapper = createComponent();
-    wrapper.find('input').instance().value = 'tag3';
-    typeInput(wrapper);
-    assert.equal(wrapper.find('datalist option').length, 2);
-    wrapper.find('input').instance().value = '';
-    wrapper
-      .find('input')
-      .simulate('input', { inputType: 'deleteContentBackward' });
-    assert.equal(wrapper.find('datalist option').length, 0);
-  });
-
-  it('does not clear the suggestions when deleting only part of the input', () => {
-    const wrapper = createComponent();
-    wrapper.find('input').instance().value = 'tag3';
-    typeInput(wrapper);
-    assert.equal(wrapper.find('datalist option').length, 2);
-    wrapper.find('input').instance().value = 't'; // non-empty input remains
-    wrapper
-      .find('input')
-      .simulate('input', { inputType: 'deleteContentBackward' });
-    assert.notEqual(wrapper.find('datalist option').length, 0);
-  });
-
-  it('does not render duplicate suggestions', () => {
-    // `tag3` supplied in the `tagList` will be a duplicate value relative
-    // with the fakeTagsService.filter result above.
-    const wrapper = createComponent({
-      editMode: true,
-      tagList: ['tag1', 'tag2', 'tag3'],
-    });
-    wrapper.find('input').instance().value = 'non-empty';
-    typeInput(wrapper);
-    assert.equal(wrapper.find('datalist option').length, 1);
-    assert.equal(
+      assert.equal(wrapper.find('Datalist').prop('list').length, 2);
+      wrapper.update();
+      assert.equal(wrapper.find('Datalist').prop('open'), true);
+      wrapper.find('input').instance().value = ''; // clear input
       wrapper
-        .find('datalist option')
-        .at(0)
-        .prop('value'),
-      'tag4'
-    );
+        .find('input')
+        .simulate('input', { inputType: 'deleteContentBackward' });
+      assert.equal(wrapper.find('Datalist').prop('open'), false);
+    });
+
+    it('does not close the suggestions when deleting only part of the input', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = 'tag3';
+      typeInput(wrapper);
+      assert.equal(wrapper.find('Datalist').prop('list').length, 2);
+      assert.equal(wrapper.find('Datalist').prop('open'), true);
+      wrapper.find('input').instance().value = 't'; // non-empty input remains
+      wrapper
+        .find('input')
+        .simulate('input', { inputType: 'deleteContentBackward' });
+      assert.equal(wrapper.find('Datalist').prop('open'), true);
+    });
+
+    it('opens the suggestions on focus if input is not empty', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = 'tag3';
+      assert.equal(wrapper.find('Datalist').prop('open'), false);
+      wrapper.find('input').simulate('focus', {});
+      assert.equal(wrapper.find('Datalist').prop('open'), true);
+    });
+
+    it('does not open the suggestions on focus if input is empty', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').simulate('focus', {});
+      assert.equal(wrapper.find('Datalist').prop('open'), false);
+    });
+
+    it('does not open the suggestions on focus if input is only white space', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = ' ';
+      wrapper.find('input').simulate('focus', {});
+      assert.equal(wrapper.find('Datalist').prop('open'), false);
+    });
+
+    it('closes the suggestions when focus is removed from the input', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = 'non-empty';
+      typeInput(wrapper);
+      assert.equal(wrapper.find('Datalist').prop('open'), true);
+      document.body.dispatchEvent(new Event('focus'));
+      wrapper.update();
+      assert.equal(wrapper.find('Datalist').prop('open'), false);
+    });
+
+    it('does not render duplicate suggestions', () => {
+      // `tag3` supplied in the `tagList` will be a duplicate value relative
+      // with the fakeTagsService.filter result above.
+      const wrapper = createComponent({
+        editMode: true,
+        tagList: ['tag1', 'tag2', 'tag3'],
+      });
+      wrapper.find('input').instance().value = 'non-empty';
+      typeInput(wrapper);
+      assert.equal(wrapper.find('Datalist').prop('list').length, 1);
+      assert.equal(wrapper.find('Datalist').prop('list')[0], 'tag4');
+    });
   });
 
-  context('when adding tags', () => {
+  describe('when adding tags', () => {
     /**
      * Helper function to assert that a tag was correctly added
      */
@@ -188,11 +196,12 @@ describe('TagEditor', function() {
       );
       // called the onEditTags callback prop
       assert.isTrue(fakeOnEditTags.calledWith({ tags: tagList }));
-      // clears out the suggestions
-      assert.equal(wrapper.find('datalist option').length, 0);
+      // hides the suggestions
+      assert.equal(wrapper.find('Datalist').prop('open'), false);
       // assert the input value is cleared out
       assert.equal(wrapper.find('input').instance().value, '');
-      // note: focus not tested
+      // input element should have focus
+      assert.equal(document.activeElement.nodeName, 'INPUT');
     };
     /**
      * Helper function to assert that a tag was correctly not added
@@ -204,95 +213,54 @@ describe('TagEditor', function() {
 
     it('adds a tag from the input field', () => {
       const wrapper = createComponent();
-      wrapper.find('input').instance().value = 'tag3';
-      selectOption(wrapper);
+      selectOption(wrapper, 'tag3');
       assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
     });
 
-    it('adds a tag from the input field via keyup event', () => {
+    it('adds a tag from the input field via keydown event', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = 'tag3';
-      selectOptionViaKeyUp(wrapper);
+      selectOptionViaEnter(wrapper);
       assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
     });
 
-    it('populate the datalist, then adds a tag from the input field', () => {
+    it('adds a tag from the input field when typing "," delimiter', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = 'tag3';
-
-      typeInput(wrapper);
-      assert.equal(wrapper.find('datalist option').length, 2);
-
-      selectOption(wrapper);
+      selectOptionViaDelimiter(wrapper);
       assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
-    });
-
-    it('clears out the <option> elements after adding a tag', () => {
-      const wrapper = createComponent();
-      wrapper.find('input').instance().value = 'non-empty';
-
-      typeInput(wrapper);
-      assert.equal(wrapper.find('datalist option').length, 2);
-
-      selectOption(wrapper);
-      assert.equal(wrapper.find('datalist option').length, 0);
     });
 
     it('should not add a tag if the input is empty', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = '';
+      selectOptionViaEnter(wrapper);
+      assertAddTagsFail();
+    });
 
-      selectOption(wrapper);
+    it('should not add a tag if the input is empty', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = '';
+      selectOptionViaEnter(wrapper);
       assertAddTagsFail();
     });
 
     it('should not add a tag if the input is blank space', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = '  ';
-      selectOption(wrapper);
+      selectOptionViaEnter(wrapper);
       assertAddTagsFail();
     });
 
     it('should not add a tag if its a duplicate of one already in the list', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = 'tag1';
-      selectOption(wrapper);
+      selectOptionViaEnter(wrapper);
       assertAddTagsFail();
-    });
-
-    [
-      {
-        key: 'Enter',
-        text: 'adds a tag via keypress `Enter`',
-        run: wrapper => {
-          assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
-        },
-      },
-      {
-        key: ',',
-        text: 'adds a tag via keypress `,`',
-        run: wrapper => {
-          assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
-        },
-      },
-      {
-        key: 'e',
-        text: 'does not add a tag when key is not `,` or  `Enter`',
-        run: () => {
-          assertAddTagsFail();
-        },
-      },
-    ].forEach(test => {
-      it(test.text, () => {
-        const wrapper = createComponent();
-        wrapper.find('input').instance().value = 'tag3';
-        wrapper.find('input').simulate('keypress', { key: test.key });
-        test.run(wrapper);
-      });
     });
   });
 
-  context('when removing tags', () => {
+  describe('when removing tags', () => {
     it('removes `tag1` when clicking its delete button', () => {
       const wrapper = createComponent(); // note: initial tagList is ['tag1', 'tag2']
       assert.equal(wrapper.find('.tag-editor__edit').length, 2);
@@ -308,35 +276,52 @@ describe('TagEditor', function() {
     });
   });
 
-  describe('filter on text input based on user agent', () => {
-    let fakeNavigator;
-    beforeEach(function() {
-      fakeNavigator = sinon.stub(navigator, 'userAgent');
-    });
-
-    afterEach(function() {
-      fakeNavigator.restore();
-    });
-
-    it('calls filter when changing input with a limit of 20 when browser is Chrome', () => {
-      fakeNavigator.get(() => 'Chrome/1.0');
+  describe('navigating suggestions via keyboard', () => {
+    it('should set the initial activeItem value to -1 when opening suggestions', () => {
       const wrapper = createComponent();
-      wrapper.find('input').instance().value = 'tag';
+      wrapper.find('input').instance().value = 'non-empty';
       typeInput(wrapper);
-
-      assert.isTrue(fakeTagsService.filter.calledTwice);
-      assert.isTrue(fakeTagsService.filter.calledWith('tag', 20));
+      assert.equal(wrapper.find('Datalist').prop('open'), true);
+      assert.equal(wrapper.find('Datalist').prop('activeItem'), -1);
+    });
+    it('should increment the activeItem when pressing down circularly', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = 'non-empty';
+      typeInput(wrapper);
+      // 2 suggestions: ['tag3', 'tag4'];
+      navigateDown(wrapper);
+      assert.equal(wrapper.find('Datalist').prop('activeItem'), 0);
+      navigateDown(wrapper);
+      assert.equal(wrapper.find('Datalist').prop('activeItem'), 1);
+      navigateDown(wrapper);
+      // back to unselected
+      assert.equal(wrapper.find('Datalist').prop('activeItem'), -1);
     });
 
-    it('does not call filter when changing input when browser is not Chrome', () => {
-      fakeNavigator.get(() => '');
+    it('should decrement the activeItem when pressing up circularly', () => {
       const wrapper = createComponent();
-
-      wrapper.find('input').instance().value = 'tag';
+      wrapper.find('input').instance().value = 'non-empty';
       typeInput(wrapper);
+      // 2 suggestions: ['tag3', 'tag4'];
+      navigateUp(wrapper);
+      assert.equal(wrapper.find('Datalist').prop('activeItem'), 1);
+      navigateUp(wrapper);
+      assert.equal(wrapper.find('Datalist').prop('activeItem'), 0);
+      navigateUp(wrapper);
+      assert.equal(wrapper.find('Datalist').prop('activeItem'), -1);
+    });
 
-      assert.isTrue(fakeTagsService.filter.calledOnce);
-      assert.isTrue(fakeTagsService.filter.calledWith(''));
+    it('should set activeItem to -1 when clearing the suggestions', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = 'non-empty';
+      typeInput(wrapper);
+      navigateDown(wrapper);
+      // change to non-default value
+      assert.equal(wrapper.find('Datalist').prop('activeItem'), 0);
+      // clear suggestions
+      wrapper.find('input').instance().value = '';
+      typeInput(wrapper);
+      assert.equal(wrapper.find('Datalist').prop('activeItem'), -1);
     });
   });
 });

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -114,8 +114,9 @@ describe('TagEditor', function() {
     it('sets the <Datalist> `id` prop to the same value as the `aria-owns` attribute', () => {
       const wrapper = createComponent();
       wrapper.find('Datalist');
+
       assert.equal(
-        wrapper.find('input').prop('aria-owns'),
+        wrapper.find('.tag-editor__combobox-wrapper').prop('aria-owns'),
         wrapper.find('Datalist').prop('id')
       );
     });
@@ -124,10 +125,16 @@ describe('TagEditor', function() {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = 'non-empty'; // to open list
       typeInput(wrapper);
-      assert.equal(wrapper.find('input').prop('aria-expanded'), true);
+      assert.equal(
+        wrapper.find('.tag-editor__combobox-wrapper').prop('aria-expanded'),
+        'true'
+      );
       selectOption(wrapper, 'tag4');
       wrapper.update();
-      assert.equal(wrapper.find('input').prop('aria-expanded'), false);
+      assert.equal(
+        wrapper.find('.tag-editor__combobox-wrapper').prop('aria-expanded'),
+        'false'
+      );
     });
 
     it('sets the <Datalist> `activeItem` prop to match the selected item index', () => {

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -8,15 +8,18 @@ import { $imports } from '../tag-editor';
 import mockImportedComponents from './mock-imported-components';
 
 describe('TagEditor', function() {
-  let container;
+  let containers = [];
   let fakeTags = ['tag1', 'tag2'];
   let fakeTagsService;
   let fakeServiceUrl;
   let fakeOnEditTags;
 
   function createComponent(props) {
-    container = document.createElement('div');
-    document.body.appendChild(container);
+    // Use an array of containers so we can test more
+    // than one component at a time.
+    let newContainer = document.createElement('div');
+    containers.push(newContainer);
+    document.body.appendChild(newContainer);
     return mount(
       <TagEditor
         // props
@@ -27,9 +30,16 @@ describe('TagEditor', function() {
         tags={fakeTagsService}
         {...props}
       />,
-      { attachTo: container }
+      { attachTo: newContainer }
     );
   }
+
+  afterEach(function() {
+    containers.forEach(container => {
+      container.remove();
+    });
+    containers = [];
+  });
 
   // Simulates a selection event from datalist
   function selectOption(wrapper, item) {
@@ -57,7 +67,7 @@ describe('TagEditor', function() {
   function navigateUp(wrapper) {
     wrapper.find('input').simulate('keydown', { key: 'ArrowUp' });
   }
-  // Simulates a typing text
+  // Simulates typing text
   function typeInput(wrapper) {
     wrapper.find('input').simulate('input', { inputType: 'insertText' });
   }
@@ -101,7 +111,7 @@ describe('TagEditor', function() {
     assert.isTrue(fakeTagsService.filter.calledWith('tag3'));
   });
 
-  describe('accessability attributes and ids', () => {
+  describe('accessibility attributes and ids', () => {
     it('creates multiple TagEditors with unique datalist `id`s', () => {
       const wrapper1 = createComponent();
       const wrapper2 = createComponent();
@@ -162,7 +172,7 @@ describe('TagEditor', function() {
   });
 
   describe('suggestions open / close', () => {
-    it('close the suggestions when selecting a tag from datalist', () => {
+    it('closes the suggestions when selecting a tag from datalist', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = 'non-empty'; // to open list
       typeInput(wrapper);
@@ -172,7 +182,7 @@ describe('TagEditor', function() {
       assert.equal(wrapper.find('Datalist').prop('open'), false);
     });
 
-    it('close the suggestions when deleting input', () => {
+    it('closes the suggestions when deleting input', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = 'tag3';
       typeInput(wrapper);

--- a/src/styles/sidebar/components/datalist.scss
+++ b/src/styles/sidebar/components/datalist.scss
@@ -1,0 +1,41 @@
+@use "../../variables" as var;
+
+.datalist {
+  color: var.$white;
+}
+
+.datalist__items {
+  position: absolute;
+  width: 100%;
+  padding: 0;
+  background-color: var.$grey-mid;
+  z-index: 10;
+}
+
+.datalist__arrow-down {
+  position: absolute;
+  top: -1px;
+  left: 6px;
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 7px solid #fff;
+}
+
+.datalist__ul {
+  list-style: none;
+  padding: 0;
+  > li {
+    padding: 0.25em 2em;
+    white-space: nowrap;
+  }
+  > li.is-selected {
+    background-color: var.$grey-5;
+    color: white;
+  }
+  > li:hover {
+    cursor: pointer;
+    background-color: var.$grey-4;
+  }
+}

--- a/src/styles/sidebar/components/datalist.scss
+++ b/src/styles/sidebar/components/datalist.scss
@@ -1,41 +1,70 @@
 @use "../../variables" as var;
 
 .datalist {
-  color: var.$white;
+  position: relative;
 }
 
 .datalist__items {
   position: absolute;
-  width: 100%;
-  padding: 0;
-  background-color: var.$grey-mid;
+  font-size: var.$body2-font-size;
+  top: 5px;
+  max-width: 100%;
+  min-width: 10em;
+  border: 1px solid var.$grey-3;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
   z-index: 10;
+
+  @media (pointer: coarse) {
+    font-size: var.$touch-input-font-size;
+  }
 }
 
 .datalist__arrow-down {
   position: absolute;
-  top: -1px;
+  top: -6px;
   left: 6px;
   width: 0;
   height: 0;
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
-  border-top: 7px solid #fff;
+  border-bottom: 7px solid var.$grey-4;
+  z-index: -1;
 }
 
 .datalist__ul {
   list-style: none;
+  background-color: var.$white;
   padding: 0;
   > li {
-    padding: 0.25em 2em;
-    white-space: nowrap;
+    padding: 0.25em 1.5em 0.25em 1em;
+    border-left: 4px transparent solid;
   }
   > li.is-selected {
-    background-color: var.$grey-5;
-    color: white;
+    border-left: 4px var.$brand solid;
+    background-color: var.$grey-1;
   }
   > li:hover {
     cursor: pointer;
-    background-color: var.$grey-4;
+    background-color: var.$grey-2;
+  }
+}
+
+/* Dark theme */
+
+@media screen and (prefers-color-scheme: dark) {
+  .datalist__items {
+    color: var.$white;
+  }
+  .datalist__arrow-down {
+    border-bottom: 7px solid var.$grey-6;
+  }
+  .datalist__ul {
+    background-color: var.$grey-6;
+    > li.is-selected {
+      background-color: var.$grey-mid;
+    }
+    > li:hover {
+      background-color: var.$grey-5;
+    }
   }
 }

--- a/src/styles/sidebar/components/datalist.scss
+++ b/src/styles/sidebar/components/datalist.scss
@@ -5,11 +5,27 @@
 }
 
 .datalist__items {
+  &:before {
+    /* creates a small outlined triangle above the drop down menu */
+    background-color: inherit;
+    border: inherit;
+    border-top-left-radius: 0.125rem;
+    clip-path: polygon(0 0, 100% 0, 0% 100%, 0% 100%);
+    content: '';
+    display: inline-block;
+    height: 0.5rem;
+    left: 0.5rem;
+    position: absolute;
+    top: -0.3125rem;
+    transform: rotate(45deg);
+    width: 0.5rem;
+  }
   position: absolute;
   font-size: var.$body2-font-size;
   top: 5px;
   max-width: 100%;
   min-width: 10em;
+  background-color: var.$white;
   border: 1px solid var.$grey-3;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
   z-index: 10;
@@ -19,21 +35,8 @@
   }
 }
 
-.datalist__arrow-down {
-  position: absolute;
-  top: -6px;
-  left: 6px;
-  width: 0;
-  height: 0;
-  border-left: 7px solid transparent;
-  border-right: 7px solid transparent;
-  border-bottom: 7px solid var.$grey-4;
-  z-index: -1;
-}
-
 .datalist__ul {
   list-style: none;
-  background-color: var.$white;
   padding: 0;
   > li {
     padding: 0.25em 1.5em 0.25em 1em;
@@ -54,12 +57,14 @@
 @media screen and (prefers-color-scheme: dark) {
   .datalist__items {
     color: var.$white;
+    background-color: var.$grey-6;
+    &:before {
+    }
   }
   .datalist__arrow-down {
     border-bottom: 7px solid var.$grey-6;
   }
   .datalist__ul {
-    background-color: var.$grey-6;
     > li.is-selected {
       background-color: var.$grey-mid;
     }

--- a/src/styles/sidebar/components/datalist.scss
+++ b/src/styles/sidebar/components/datalist.scss
@@ -31,22 +31,24 @@
   z-index: 10;
 
   @media (pointer: coarse) {
-    font-size: var.$touch-input-font-size;
+    font-size: var.$touch-target-size;
+    line-height: var.$touch-target-size;
   }
 }
 
 .datalist__ul {
   list-style: none;
   padding: 0;
-  > li {
-    padding: 0.25em 1.5em 0.25em 1em;
-    border-left: 4px transparent solid;
-  }
-  > li.is-selected {
+}
+.datalist__li {
+  padding: 0.25em 1.5em 0.25em 1em;
+  border-left: 4px transparent solid;
+
+  &.is-selected {
     border-left: 4px var.$brand solid;
     background-color: var.$grey-1;
   }
-  > li:hover {
+  &:hover {
     cursor: pointer;
     background-color: var.$grey-2;
   }

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -37,6 +37,7 @@
 @use './components/annotation-thread';
 @use './components/annotation-user';
 @use './components/button';
+@use './components/datalist';
 @use './components/excerpt';
 @use './components/focused-mode-header';
 @use './components/group-list';


### PR DESCRIPTION
- Rework tag-editor to use new custom datalist
- Remove tag-editor’s Chrome hack fix to limit datalist to 20
- useElementShouldClose now works on Preact component as well as native components
![datalist](https://user-images.githubusercontent.com/3939074/72045436-ed74d300-326a-11ea-8b88-3707a7b3febb.gif)


Also fixes https://github.com/hypothesis/client/issues/1690