### PR TITLE
Establish `AnnotationOmega` component and add header and quote to it

### DIFF
--- a/src/sidebar/components/annotation-header.js
+++ b/src/sidebar/components/annotation-header.js
@@ -1,6 +1,8 @@
 const propTypes = require('prop-types');
 const { createElement } = require('preact');
 
+const { isHighlight } = require('../util/annotation-metadata');
+
 const AnnotationDocumentInfo = require('./annotation-document-info');
 const AnnotationShareInfo = require('./annotation-share-info');
 const AnnotationUser = require('./annotation-user');
@@ -15,7 +17,6 @@ const Timestamp = require('./timestamp');
 function AnnotationHeader({
   annotation,
   isEditing,
-  isHighlight,
   onReplyCountClick,
   replyCount,
   showDocumentInfo,
@@ -60,7 +61,7 @@ function AnnotationHeader({
 
       <div className="annotation-header__row">
         <AnnotationShareInfo annotation={annotation} />
-        {!isEditing && isHighlight && (
+        {!isEditing && isHighlight(annotation) && (
           <div className="annotation-header__highlight">
             <SvgIcon
               name="highlight"
@@ -81,8 +82,6 @@ AnnotationHeader.propTypes = {
   annotation: propTypes.object.isRequired,
   /* Whether the annotation is actively being edited */
   isEditing: propTypes.bool,
-  /* Whether the annotation is a highlight */
-  isHighlight: propTypes.bool,
   /* Callback for when the toggle-replies element is clicked */
   onReplyCountClick: propTypes.func.isRequired,
   /* How many replies this annotation currently has */

--- a/src/sidebar/components/annotation-omega.js
+++ b/src/sidebar/components/annotation-omega.js
@@ -1,0 +1,70 @@
+const { createElement } = require('preact');
+const propTypes = require('prop-types');
+
+const useStore = require('../store/use-store');
+const { quote } = require('../util/annotation-metadata');
+const { withServices } = require('../util/service-context');
+
+const AnnotationHeader = require('./annotation-header');
+const AnnotationQuote = require('./annotation-quote');
+
+/**
+ * The "new", migrated-to-preact annotation component.
+ */
+function AnnotationOmega({
+  annotation,
+  onReplyCountClick,
+  permissions,
+  replyCount,
+  showDocumentInfo,
+}) {
+  /**
+   * @FIXME: This is TEMPORARY to avoid an error in console when creating new
+   * annotations from the annotator. It does not have long to live.
+   */
+  if (!annotation.permissions) {
+    annotation.permissions = permissions.default(
+      annotation.user,
+      annotation.group
+    );
+  }
+  const draft = useStore(store => store.getDraft(annotation));
+
+  // Annotation metadata
+  const hasQuote = !!quote(annotation);
+
+  // Local component state
+  // TODO: `isEditing` will also take into account `isSaving`
+  const isEditing = !!draft;
+
+  return (
+    <div className="annotation-omega">
+      <AnnotationHeader
+        annotation={annotation}
+        isEditing={isEditing}
+        onReplyCountClick={onReplyCountClick}
+        replyCount={replyCount}
+        showDocumentInfo={showDocumentInfo}
+      />
+      {hasQuote && <AnnotationQuote annotation={annotation} />}
+    </div>
+  );
+}
+
+AnnotationOmega.propTypes = {
+  annotation: propTypes.object.isRequired,
+
+  /** Callback for reply-count clicks */
+  onReplyCountClick: propTypes.func.isRequired,
+  /** Number of replies to this annotation (thread) */
+  replyCount: propTypes.number.isRequired,
+  /** Should extended document info be rendered (e.g. in non-sidebar contexts)? */
+  showDocumentInfo: propTypes.bool.isRequired,
+
+  /** Injected services */
+  permissions: propTypes.object.isRequired,
+};
+
+AnnotationOmega.injectedProps = ['permissions'];
+
+module.exports = withServices(AnnotationOmega);

--- a/src/sidebar/components/annotation-quote.js
+++ b/src/sidebar/components/annotation-quote.js
@@ -2,17 +2,22 @@ const classnames = require('classnames');
 const { createElement } = require('preact');
 const propTypes = require('prop-types');
 
+const { isOrphan, quote } = require('../util/annotation-metadata');
 const { withServices } = require('../util/service-context');
 const { applyTheme } = require('../util/theme');
+
 const Excerpt = require('./excerpt');
 
 /**
  * Display the selected text from the document associated with an annotation.
  */
-function AnnotationQuote({ isOrphan, quote, settings = {} }) {
+function AnnotationQuote({ annotation, settings = {} }) {
   return (
     <section
-      className={classnames('annotation-quote', isOrphan && 'is-orphan')}
+      className={classnames(
+        'annotation-quote',
+        isOrphan(annotation) && 'is-orphan'
+      )}
     >
       <Excerpt
         collapsedHeight={35}
@@ -23,7 +28,7 @@ function AnnotationQuote({ isOrphan, quote, settings = {} }) {
           className="annotation-quote__quote"
           style={applyTheme(['selectionFontFamily'], settings)}
         >
-          {quote}
+          {quote(annotation)}
         </blockquote>
       </Excerpt>
     </section>
@@ -31,17 +36,7 @@ function AnnotationQuote({ isOrphan, quote, settings = {} }) {
 }
 
 AnnotationQuote.propTypes = {
-  /**
-   * If `true`, display an indicator that the annotated text was not found in
-   * the current version of the document.
-   */
-  isOrphan: propTypes.bool,
-
-  /**
-   * The text that the annotation refers to. This is rendered as plain text
-   * (ie. HTML tags are rendered literally).
-   */
-  quote: propTypes.string,
+  annotation: propTypes.object.isRequired,
 
   // Used for theming.
   settings: propTypes.object,

--- a/src/sidebar/components/annotation-thread.js
+++ b/src/sidebar/components/annotation-thread.js
@@ -33,7 +33,7 @@ function showAllParents(thread, showFn) {
 }
 
 // @ngInject
-function AnnotationThreadController(store) {
+function AnnotationThreadController(features, store) {
   // Flag that tracks whether the content of the annotation is hovered,
   // excluding any replies.
   this.annotationHovered = false;
@@ -102,6 +102,10 @@ function AnnotationThreadController(store) {
     if (thread.parent) {
       store.setCollapsed(thread.parent.id, false);
     }
+  };
+
+  this.shouldShowAnnotationOmega = () => {
+    return features.flagEnabled('client_preact_annotation');
   };
 }
 

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -377,13 +377,6 @@ function AnnotationController(
     });
   };
 
-  this.isOrphan = function() {
-    if (typeof self.annotation.$orphan === 'undefined') {
-      return self.annotation.$anchorTimeout;
-    }
-    return self.annotation.$orphan;
-  };
-
   this.user = function() {
     return self.annotation.user;
   };

--- a/src/sidebar/components/test/annotation-header-test.js
+++ b/src/sidebar/components/test/annotation-header-test.js
@@ -8,12 +8,13 @@ const { $imports } = require('../annotation-header');
 const mockImportedComponents = require('./mock-imported-components');
 
 describe('AnnotationHeader', () => {
+  let fakeIsHighlight;
+
   const createAnnotationHeader = props => {
     return mount(
       <AnnotationHeader
         annotation={fixtures.defaultAnnotation()}
         isEditing={false}
-        isHighlight={false}
         onReplyCountClick={sinon.stub()}
         replyCount={0}
         showDocumentInfo={false}
@@ -23,7 +24,14 @@ describe('AnnotationHeader', () => {
   };
 
   beforeEach(() => {
+    fakeIsHighlight = sinon.stub().returns(false);
+
     $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      '../util/annotation-metadata': {
+        isHighlight: fakeIsHighlight,
+      },
+    });
   });
 
   afterEach(() => {
@@ -111,9 +119,9 @@ describe('AnnotationHeader', () => {
 
   describe('annotation is-highlight icon', () => {
     it('should display is-highlight icon if annotation is a highlight', () => {
+      fakeIsHighlight.returns(true);
       const wrapper = createAnnotationHeader({
         isEditing: false,
-        isHighlight: true,
       });
       const highlightIcon = wrapper.find('.annotation-header__highlight');
 
@@ -121,9 +129,9 @@ describe('AnnotationHeader', () => {
     });
 
     it('should not display the is-highlight icon if annotation is not a highlight', () => {
+      fakeIsHighlight.returns(false);
       const wrapper = createAnnotationHeader({
         isEditing: false,
-        isHighlight: false,
       });
       const highlightIcon = wrapper.find('.annotation-header__highlight');
 

--- a/src/sidebar/components/test/annotation-omega-test.js
+++ b/src/sidebar/components/test/annotation-omega-test.js
@@ -1,0 +1,75 @@
+const { createElement } = require('preact');
+const { mount } = require('enzyme');
+
+const mockImportedComponents = require('./mock-imported-components');
+const fixtures = require('../../test/annotation-fixtures');
+
+// @TODO Note this import as `Annotation` for easier updating later
+const Annotation = require('../annotation-omega');
+const { $imports } = require('../annotation-omega');
+
+describe('AnnotationOmega', () => {
+  let fakeOnReplyCountClick;
+
+  // Injected service mocks
+  let fakePermissions;
+
+  // Dependency Mocks
+  let fakeQuote;
+  let fakeStore;
+
+  const createComponent = props => {
+    return mount(
+      <Annotation
+        annotation={fixtures.defaultAnnotation()}
+        onReplyCountClick={fakeOnReplyCountClick}
+        permissions={fakePermissions}
+        replyCount={0}
+        showDocumentInfo={false}
+        {...props}
+      />
+    );
+  };
+
+  beforeEach(() => {
+    fakeOnReplyCountClick = sinon.stub();
+
+    fakeQuote = sinon.stub();
+    fakeStore = {
+      getDraft: sinon.stub(),
+    };
+
+    fakePermissions = {
+      default: sinon.stub(),
+    };
+
+    $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      '../util/annotation-metadata': {
+        quote: fakeQuote,
+      },
+      '../store/use-store': callback => callback(fakeStore),
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('renders quote if annotation has a quote', () => {
+    fakeQuote.returns('quote');
+    const wrapper = createComponent();
+
+    const quote = wrapper.find('AnnotationQuote');
+    assert.isTrue(quote.exists());
+  });
+
+  it('does not render quote if annotation does not have a quote', () => {
+    fakeQuote.returns(null);
+
+    const wrapper = createComponent();
+
+    const quote = wrapper.find('AnnotationQuote');
+    assert.isFalse(quote.exists());
+  });
+});

--- a/src/sidebar/components/test/annotation-quote-test.js
+++ b/src/sidebar/components/test/annotation-quote-test.js
@@ -6,14 +6,31 @@ const { $imports } = require('../annotation-quote');
 const mockImportedComponents = require('./mock-imported-components');
 
 describe('AnnotationQuote', () => {
+  let fakeAnnotation;
+  let fakeIsOrphan;
+  let fakeQuote;
+
   function createQuote(props) {
     return mount(
-      <AnnotationQuote quote="test quote" settings={{}} {...props} />
+      <AnnotationQuote annotation={fakeAnnotation} settings={{}} {...props} />
     );
   }
 
   beforeEach(() => {
+    fakeAnnotation = {
+      target: [],
+    };
+
+    fakeQuote = sinon.stub().returns('test quote');
+    fakeIsOrphan = sinon.stub();
+
     $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      '../util/annotation-metadata': {
+        quote: fakeQuote,
+        isOrphan: fakeIsOrphan,
+      },
+    });
   });
 
   afterEach(() => {

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -137,8 +137,7 @@ describe('annotation', function() {
         })
         .component('annotationQuote', {
           bindings: {
-            isOrphan: '<',
-            quote: '<',
+            annotation: '<',
           },
         });
     });
@@ -679,33 +678,6 @@ describe('annotation', function() {
         const controller = createDirective().controller;
         fakeStore.hasPendingDeletion.returns(false);
         assert.equal(controller.isDeleted(), false);
-      });
-    });
-
-    describe('#isOrphan', function() {
-      it('returns false if the annotation is not an orphan', function() {
-        const controller = createDirective().controller;
-        controller.annotation.$orphan = false;
-        assert.isFalse(controller.isOrphan());
-      });
-
-      it('returns true if the annotation is an orphan', function() {
-        const controller = createDirective().controller;
-        controller.annotation.$orphan = true;
-        assert.isTrue(controller.isOrphan());
-      });
-
-      it('returns true if the anchoring timeout expired', function() {
-        const controller = createDirective().controller;
-        controller.annotation.$anchorTimeout = true;
-        assert.isTrue(controller.isOrphan());
-      });
-
-      it('returns false if the anchoring timeout expired but anchoring did complete', function() {
-        const controller = createDirective().controller;
-        controller.annotation.$orphan = false;
-        controller.annotation.$anchorTimeout = true;
-        assert.isFalse(controller.isOrphan());
       });
     });
 

--- a/src/sidebar/components/test/annotation-thread-test.js
+++ b/src/sidebar/components/test/annotation-thread-test.js
@@ -34,16 +34,20 @@ describe('annotationThread', function() {
       });
   });
 
+  let fakeFeatures;
   let fakeStore;
 
   beforeEach(function() {
+    fakeFeatures = {
+      flagEnabled: sinon.stub().returns(false),
+    };
     fakeStore = {
       setForceVisible: sinon.stub(),
       setCollapsed: sinon.stub(),
       getState: sinon.stub(),
     };
 
-    angular.mock.module('app', { store: fakeStore });
+    angular.mock.module('app', { features: fakeFeatures, store: fakeStore });
   });
 
   it('renders the tree structure of parent and child annotations', function() {
@@ -252,5 +256,56 @@ describe('annotationThread', function() {
     });
     assert.notOk(element[0].querySelector('moderation-banner'));
     assert.notOk(element[0].querySelector('annotation'));
+  });
+
+  describe('preact-migrated Annotation component', () => {
+    it('additionally renders `AnnotationOmega` when `client_preact_annotation` feature flag is enabled', () => {
+      fakeFeatures.flagEnabled
+        .withArgs('client_preact_annotation')
+        .returns(true);
+
+      const element = util.createDirective(document, 'annotationThread', {
+        thread: {
+          id: '1',
+          annotation: { id: '1', text: 'text' },
+          children: [
+            {
+              id: '2',
+              annotation: { id: '2', text: 'areply' },
+              children: [],
+              visible: true,
+            },
+          ],
+          visible: true,
+        },
+      });
+
+      assert.ok(element[0].querySelector('annotation'));
+      assert.ok(element[0].querySelector('annotation-omega'));
+    });
+    it('does not render `AnnotationOmega` if `client_preact_annotation` feature flag is not enabled', () => {
+      fakeFeatures.flagEnabled
+        .withArgs('client_preact_annotation')
+        .returns(false);
+
+      const element = util.createDirective(document, 'annotationThread', {
+        thread: {
+          id: '1',
+          annotation: { id: '1', text: 'text' },
+          children: [
+            {
+              id: '2',
+              annotation: { id: '2', text: 'areply' },
+              children: [],
+              visible: true,
+            },
+          ],
+          visible: true,
+        },
+      });
+
+      assert.ok(element[0].querySelector('annotation'));
+      assert.notOk(element[0].querySelector('annotation-omega'));
+    });
   });
 });

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -125,6 +125,10 @@ function startAngularApp(config) {
     // UI components
     .component('annotation', require('./components/annotation'))
     .component(
+      'annotationOmega',
+      wrapReactComponent(require('./components/annotation-omega'))
+    )
+    .component(
       'annotationBody',
       wrapReactComponent(require('./components/annotation-body'))
     )

--- a/src/sidebar/templates/annotation-thread.html
+++ b/src/sidebar/templates/annotation-thread.html
@@ -14,6 +14,12 @@
       annotation="vm.thread.annotation"
       ng-if="vm.thread.annotation">
     </moderation-banner>
+    <annotation-omega ng-if="vm.shouldShowAnnotationOmega()"
+      annotation="vm.thread.annotation"
+      reply-count="vm.thread.replyCount"
+      on-reply-count-click="vm.toggleCollapsed()"
+      show-document-info="vm.showDocumentInfo">
+    </annotation-omega>
     <annotation ng-class="vm.annotationClasses()"
              annotation="vm.thread.annotation"
              is-collapsed="vm.thread.collapsed"

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -12,10 +12,7 @@
                          show-document-info="vm.showDocumentInfo">
   </annotation-header>
 
-  <annotation-quote
-    quote="vm.quote()"
-    is-orphan="vm.isOrphan()"
-    ng-if="vm.quote()">
+  <annotation-quote annotation="vm.annotation" ng-if="vm.quote()">
   </annotation-quote>
 
   <annotation-body

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -6,7 +6,6 @@
 
   <annotation-header annotation="vm.annotation"
                          is-editing="vm.editing()"
-                         is-highlight="vm.isHighlight()"
                          on-reply-count-click="vm.onReplyCountClick()"
                          reply-count="vm.replyCount"
                          show-document-info="vm.showDocumentInfo">


### PR DESCRIPTION
Part of #1650

This PR establishes an interim `AnnotationOmega` component that represents the "new", preact `Annotation` component. It renders `AnnotationHeader` and `AnnotationQuote` so far.

This component will show up _in addition to_ the main `Annotation` component for now when the `client_preact_annotation` feature flag is enabled. As we progress, the behavior of this feature flag will likely change to "one or the other", but for now, dev ergonomics are better if they are both rendered. It looks like this when the feature flag is active (new `AnnotationOmega` at top):

![image](https://user-images.githubusercontent.com/439947/72078480-30649400-32c7-11ea-8382-327c46993216.png)

This PR also makes some small changes to `AnnotationHeader` and `AnnotationQuote` to make them more "self-sufficient" and not reliant on props passed through by `Annotation[Omega]`.