### PR TITLE
Normalize module imports to an ES module-friendly format

### DIFF
--- a/src/annotator/anchoring/test/html-test.js
+++ b/src/annotator/anchoring/test/html-test.js
@@ -1,6 +1,6 @@
 const html = require('../html');
 
-const toResult = require('../../../shared/test/promise-util').toResult;
+const { toResult } = require('../../../shared/test/promise-util');
 const fixture = require('./html-anchoring-fixture.html');
 
 /** Return all text node children of `container`. */

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -1,4 +1,4 @@
-const isLoaded = require('../../util/frame-util').isLoaded;
+const { isLoaded } = require('../../util/frame-util');
 
 const FRAME_DEBOUNCE_WAIT = require('../../frame-observer').DEBOUNCE_WAIT + 10;
 const CrossFrame = require('../../plugin/cross-frame');

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -10,8 +10,10 @@
 /* global __MANIFEST__ */
 
 const boot = require('./boot');
-const settings = require('../shared/settings').jsonConfigsFrom(document);
+const { jsonConfigsFrom } = require('../shared/settings');
 const processUrlTemplate = require('./url-template');
+
+const settings = jsonConfigsFrom(document);
 
 boot(document, {
   assetRoot: processUrlTemplate(settings.assetRoot || '__ASSET_ROOT__'),

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -5,7 +5,7 @@ const fixtures = require('../../test/annotation-fixtures');
 const util = require('../../directive/test/util');
 
 const annotationComponent = require('../annotation');
-const { $imports } = require('../annotation');
+const { $imports, updateModel } = require('../annotation');
 
 const inject = angular.mock.inject;
 
@@ -34,8 +34,6 @@ const groupFixtures = {
 
 describe('annotation', function() {
   describe('updateModel()', function() {
-    const updateModel = require('../annotation').updateModel;
-
     function fakePermissions() {
       return {
         shared: function() {},

--- a/src/sidebar/directive/test/h-branding-test.js
+++ b/src/sidebar/directive/test/h-branding-test.js
@@ -1,5 +1,8 @@
 const angular = require('angular');
 
+const hBranding = require('../h-branding');
+const fixtures = require('./h-branding-fixtures');
+
 describe('BrandingDirective', function() {
   let $compile;
   let $rootScope;
@@ -10,7 +13,7 @@ describe('BrandingDirective', function() {
   // with desired settings. Note, needs to be called for angular
   // to be initialized for the test
   const setSettingsAndBootApp = function() {
-    angular.module('app', []).directive('hBranding', require('../h-branding'));
+    angular.module('app', []).directive('hBranding', hBranding);
 
     angular.mock.module('app', {
       settings: customSettings || {},
@@ -59,7 +62,7 @@ describe('BrandingDirective', function() {
     assert.equal(el[0].style.backgroundColor, '');
   });
 
-  require('./h-branding-fixtures').forEach(testCase => {
+  fixtures.forEach(testCase => {
     it('applies branding to elements', () => {
       applyBrandingSettings(testCase.settings);
 

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -2,12 +2,13 @@ const addAnalytics = require('./ga');
 const disableOpenerForExternalLinks = require('./util/disable-opener-for-external-links');
 const { fetchConfig } = require('./util/fetch-config');
 const serviceConfig = require('./service-config');
+const { jsonConfigsFrom } = require('../shared/settings');
 const crossOriginRPC = require('./cross-origin-rpc.js');
 
 let sentry;
 
 // Read settings rendered into sidebar app HTML by service/extension.
-const appConfig = require('../shared/settings').jsonConfigsFrom(document);
+const appConfig = jsonConfigsFrom(document);
 
 if (appConfig.sentry) {
   // Initialize Sentry. This is required at the top of this file

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -22,7 +22,7 @@ const uiConstants = require('../ui-constants');
  * JavaScript, it includes only the information needed to uniquely identify it
  * within the current session and anchor it in the document.
  */
-function formatAnnot(ann) {
+export function formatAnnot(ann) {
   return {
     tag: ann.$tag,
     msg: {
@@ -39,7 +39,13 @@ function formatAnnot(ann) {
  * sidebar.
  */
 // @ngInject
-function FrameSync($rootScope, $window, Discovery, store, bridge) {
+export default function FrameSync(
+  $rootScope,
+  $window,
+  Discovery,
+  store,
+  bridge
+) {
   // Set of tags of annotations that are currently loaded into the frame
   const inFrame = new Set();
 
@@ -253,8 +259,3 @@ function FrameSync($rootScope, $window, Discovery, store, bridge) {
     bridge.call('scrollToAnnotation', tag);
   };
 }
-
-module.exports = {
-  default: FrameSync,
-  formatAnnot: formatAnnot,
-};

--- a/src/sidebar/services/oauth-auth.js
+++ b/src/sidebar/services/oauth-auth.js
@@ -1,5 +1,5 @@
 const events = require('../events');
-const resolve = require('../util/url').resolve;
+const { resolve } = require('../util/url');
 const serviceConfig = require('../service-config');
 
 /**

--- a/src/sidebar/services/oauth-auth.js
+++ b/src/sidebar/services/oauth-auth.js
@@ -21,7 +21,6 @@ const serviceConfig = require('../service-config');
  * Interaction with OAuth endpoints in the annotation service is delegated to
  * the `OAuthClient` class.
  */
-// @ngInject
 function auth(
   $rootScope,
   $window,
@@ -299,5 +298,18 @@ function auth(
     tokenGetter,
   };
 }
+
+// `$inject` is added manually rather than using `@ngInject` to work around
+// a conflict between the transform-async-to-promises and angularjs-annotate
+// Babel plugins.
+auth.$inject = [
+  '$rootScope',
+  '$window',
+  'OAuthClient',
+  'apiRoutes',
+  'flash',
+  'localStorage',
+  'settings',
+];
 
 module.exports = auth;

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -3,9 +3,8 @@ const EventEmitter = require('tiny-emitter');
 
 const annotationFixtures = require('../../test/annotation-fixtures');
 const events = require('../../events');
-const FrameSync = require('../frame-sync').default;
 const createFakeStore = require('../../test/fake-redux-store');
-const formatAnnot = require('../frame-sync').formatAnnot;
+const { default: FrameSync, formatAnnot } = require('../frame-sync');
 const uiConstants = require('../../ui-constants');
 
 const fixtures = {

--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -1,6 +1,5 @@
 const redux = require('redux');
-// `.default` is needed because 'redux-thunk' is built as an ES2015 module
-const thunk = require('redux-thunk').default;
+const { default: thunk } = require('redux-thunk');
 
 const { createReducer, bindSelectors } = require('./util');
 

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -1,8 +1,7 @@
 const { createSelector } = require('reselect');
 
 const util = require('../util');
-const { selectors: sessionSelectors } = require('./session');
-const { isLoggedIn } = sessionSelectors;
+const session = require('./session');
 
 function init() {
   return {
@@ -141,7 +140,7 @@ function getGroup(state, id) {
  */
 const getMyGroups = createSelector(
   state => state.groups.groups,
-  isLoggedIn,
+  session.selectors.isLoggedIn,
   (groups, loggedIn) => {
     // If logged out, the Public group still has isMember set to true so only
     // return groups with membership in logged in state.

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -7,9 +7,9 @@ const { createSelector } = require('reselect');
 
 const { actionTypes } = require('../util');
 
-const { selectors: annotationSelectors } = require('./annotations');
-const { selectors: groupSelectors } = require('./groups');
-const { selectors: viewerSelectors } = require('./viewer');
+const annotations = require('./annotations');
+const groups = require('./groups');
+const viewer = require('./viewer');
 
 function init() {
   return {
@@ -95,8 +95,8 @@ function receiveRealTimeUpdates({
       // group and reload all annotations and discard pending updates
       // when switching groups.
       if (
-        ann.group === groupSelectors.focusedGroupId(getState()) ||
-        !viewerSelectors.isSidebar(getState())
+        ann.group === groups.selectors.focusedGroupId(getState()) ||
+        !viewer.selectors.isSidebar(getState())
       ) {
         pendingUpdates[ann.id] = ann;
       }
@@ -111,7 +111,7 @@ function receiveRealTimeUpdates({
       // even if the annotation is from the current group, it might be for a
       // new annotation (saved in pendingUpdates and removed above), that has
       // not yet been loaded.
-      if (annotationSelectors.annotationExists(getState(), ann.id)) {
+      if (annotations.selectors.annotationExists(getState(), ann.id)) {
         pendingDeletions[ann.id] = true;
       }
     });

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -19,7 +19,7 @@ const immutable = require('seamless-immutable');
 
 const arrayUtil = require('../../util/array');
 const metadata = require('../../util/annotation-metadata');
-const toSet = require('../../util/array').toSet;
+const { toSet } = require('../../util/array');
 const uiConstants = require('../../ui-constants');
 
 const util = require('../util');

--- a/src/sidebar/test/bootstrap.js
+++ b/src/sidebar/test/bootstrap.js
@@ -8,9 +8,11 @@ sinon.assert.expose(assert, { prefix: null });
 // the directive tests rely on angular.element() returning
 // a full version of jQuery.
 //
-window.jQuery = window.$ = require('jquery');
+const jQuery = require('jquery');
 require('angular');
 require('angular-mocks');
+
+window.jQuery = window.$ = jQuery;
 
 // Configure Enzyme for UI tests.
 require('preact/debug');

--- a/src/sidebar/util/test/retry-test.js
+++ b/src/sidebar/util/test/retry-test.js
@@ -1,5 +1,5 @@
 const retryUtil = require('../retry');
-const toResult = require('../../../shared/test/promise-util').toResult;
+const { toResult } = require('../../../shared/test/promise-util');
 
 describe('sidebar.util.retry', function() {
   describe('.retryPromiseOperation', function() {


### PR DESCRIPTION
This PR prepares for converting the client to ES module syntax by normalizing some of our existing imports into a form that is easier to map to ES module imports.

1. Modify several imports to conform to one of two forms that easily maps to ES imports:

```js
// Maps to `import foo from "foo"` or `import * as foo from "foo"` depending
// on what module `./foo` exports.
const foo = require('./foo'); 
// Maps to `import { bar, baz } from "foo"`
const { bar, baz } = require('./foo'); 
```

2. Move some imports to the top level of the file (eg. not in a conditional or function) because ES module imports must appear at the top level. This change mostly affects `src/sidebar/index.js`.
3. I changed the way that some store modules import functions from other store modules to a version that will work after the conversion. My plan is that store modules will default-export a single object rather than having multiple exports
4. When testing out ES modules locally I ran into a conflict between the Babel plugin that handles `async` functions and the Babel plugin that handles `// @ngInject` comments in `src/sidebar/services/oauth-auth.js`. I haven't yet determined exactly why the conflict only happens after converting to ES imports, but since it only happened with this one module I've worked around it for now by replacing the `// @ngInject` comment with the code that would normally be generated for it (`auth.$inject = ...`)
