### PR TITLE
Hoist CommonJS imports to top of file

### DIFF
--- a/src/sidebar/components/test/annotation-viewer-content-test.js
+++ b/src/sidebar/components/test/annotation-viewer-content-test.js
@@ -1,5 +1,7 @@
 const angular = require('angular');
 
+const annotationViewerContent = require('../annotation-viewer-content');
+
 // Fake implementation of the API for fetching annotations and replies to
 // annotations.
 function FakeApi(annots) {
@@ -32,10 +34,7 @@ describe('annotationViewerContent', function() {
   before(function() {
     angular
       .module('h', [])
-      .component(
-        'annotationViewerContent',
-        require('../annotation-viewer-content')
-      );
+      .component('annotationViewerContent', annotationViewerContent);
   });
 
   beforeEach(angular.mock.module('h'));

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -1,6 +1,7 @@
 const angular = require('angular');
 
 const events = require('../../events');
+const { events: analyticsEvents } = require('../../services/analytics');
 const bridgeEvents = require('../../../shared/bridge-events');
 
 const hypothesisApp = require('../hypothesis-app');
@@ -84,7 +85,7 @@ describe('sidebar.components.hypothesis-app', function() {
 
       fakeAnalytics = {
         track: sandbox.stub(),
-        events: require('../../services/analytics').events,
+        events: analyticsEvents,
       };
 
       fakeAuth = {};

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -3,6 +3,7 @@ const EventEmitter = require('tiny-emitter');
 
 const events = require('../../events');
 const sidebarContent = require('../sidebar-content');
+const storeFactory = require('../../store');
 
 class FakeRootThread extends EventEmitter {
   constructor() {
@@ -29,7 +30,7 @@ describe('sidebar.components.sidebar-content', function() {
   before(function() {
     angular
       .module('h', [])
-      .service('store', require('../../store'))
+      .service('store', storeFactory)
       .component('sidebarContent', sidebarContent);
   });
 

--- a/src/sidebar/components/test/stream-content-test.js
+++ b/src/sidebar/components/test/stream-content-test.js
@@ -1,6 +1,8 @@
 const angular = require('angular');
 const EventEmitter = require('tiny-emitter');
 
+const streamContent = require('../stream-content');
+
 class FakeRootThread extends EventEmitter {
   constructor() {
     super();
@@ -22,9 +24,7 @@ describe('StreamContentController', function() {
   let fakeStreamFilter;
 
   before(function() {
-    angular
-      .module('h', [])
-      .component('streamContent', require('../stream-content'));
+    angular.module('h', []).component('streamContent', streamContent);
   });
 
   beforeEach(function() {

--- a/src/sidebar/directive/test/h-on-touch-test.js
+++ b/src/sidebar/directive/test/h-on-touch-test.js
@@ -1,5 +1,6 @@
 const angular = require('angular');
 
+const hOnTouch = require('../h-on-touch');
 const util = require('./util');
 
 function testComponent() {
@@ -23,7 +24,7 @@ describe('hOnTouch', function() {
   before(function() {
     angular
       .module('app', [])
-      .directive('hOnTouch', require('../h-on-touch'))
+      .directive('hOnTouch', hOnTouch)
       .directive('test', testComponent);
   });
 

--- a/src/sidebar/directive/test/h-tooltip-test.js
+++ b/src/sidebar/directive/test/h-tooltip-test.js
@@ -1,5 +1,6 @@
 const angular = require('angular');
 
+const hTooltip = require('../h-tooltip');
 const util = require('./util');
 
 function testComponent() {
@@ -17,7 +18,7 @@ describe('h-tooltip', function() {
   before(function() {
     angular
       .module('app', [])
-      .directive('hTooltip', require('../h-tooltip'))
+      .directive('hTooltip', hTooltip)
       .directive('test', testComponent);
   });
 

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -27,6 +27,8 @@ document.body.setAttribute('ng-csp', '');
 disableOpenerForExternalLinks(document.body);
 
 const angular = require('angular');
+const angularRoute = require('angular-route');
+const angularToastr = require('angular-toastr');
 
 // autofill-event relies on the existence of window.angular so
 // it must be require'd after angular is first require'd
@@ -185,8 +187,8 @@ function startAngularApp(config) {
     .module('h', [
       // Angular addons which export the Angular module name
       // via module.exports
-      require('angular-route'),
-      require('angular-toastr'),
+      angularRoute,
+      angularToastr,
     ])
 
     // The root component for the application

--- a/src/sidebar/services/test/annotation-mapper-test.js
+++ b/src/sidebar/services/test/annotation-mapper-test.js
@@ -1,6 +1,8 @@
 const angular = require('angular');
 const immutable = require('seamless-immutable');
 
+const annotationMapperFactory = require('../annotation-mapper');
+const storeFactory = require('../../store');
 const events = require('../../events');
 
 describe('annotationMapper', function() {
@@ -19,8 +21,8 @@ describe('annotationMapper', function() {
     };
     angular
       .module('app', [])
-      .service('annotationMapper', require('../annotation-mapper'))
-      .service('store', require('../../store'))
+      .service('annotationMapper', annotationMapperFactory)
+      .service('store', storeFactory)
       .value('api', fakeApi)
       .value('settings', {});
     angular.mock.module('app');

--- a/src/sidebar/services/test/oauth-auth-test.js
+++ b/src/sidebar/services/test/oauth-auth-test.js
@@ -1,5 +1,6 @@
 const angular = require('angular');
 
+const authFactory = require('../oauth-auth');
 const events = require('../../events');
 
 const FakeWindow = require('../../util/test/fake-window');
@@ -36,7 +37,7 @@ describe('sidebar.oauth-auth', function() {
   }
 
   before(() => {
-    angular.module('app', []).service('auth', require('../oauth-auth'));
+    angular.module('app', []).service('auth', authFactory);
   });
 
   beforeEach(function() {

--- a/src/sidebar/services/test/search-filter-test.js
+++ b/src/sidebar/services/test/search-filter-test.js
@@ -1,4 +1,6 @@
-const searchFilter = require('../search-filter')();
+const searchFilterFactory = require('../search-filter');
+
+const searchFilter = searchFilterFactory();
 
 describe('sidebar.search-filter', () => {
   describe('#toObject', () => {

--- a/src/sidebar/services/test/session-test.js
+++ b/src/sidebar/services/test/session-test.js
@@ -1,6 +1,7 @@
 const angular = require('angular');
 
 const events = require('../../events');
+const { events: analyticsEvents } = require('../analytics');
 const sessionFactory = require('../session');
 const { $imports } = require('../session');
 
@@ -31,7 +32,7 @@ describe('sidebar.session', function() {
     let state = {};
     fakeAnalytics = {
       track: sinon.stub(),
-      events: require('../analytics').events,
+      events: analyticsEvents,
     };
     const fakeStore = {
       getState: function() {

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -1,5 +1,7 @@
 const angular = require('angular');
 
+const tagsFactory = require('../tags');
+
 const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
 const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
 
@@ -22,7 +24,7 @@ describe('sidebar.tags', () => {
   let tags;
 
   before(() => {
-    angular.module('h', []).service('tags', require('../tags'));
+    angular.module('h', []).service('tags', tagsFactory);
   });
 
   beforeEach(() => {

--- a/src/sidebar/services/test/unicode-test.js
+++ b/src/sidebar/services/test/unicode-test.js
@@ -1,4 +1,6 @@
-const unicode = require('../unicode')();
+const unicodeFactory = require('../unicode');
+
+const unicode = unicodeFactory();
 
 describe('unicode', () => {
   describe('#fold', () => {

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -1,6 +1,11 @@
 const angular = require('angular');
 const immutable = require('seamless-immutable');
 
+const storeFactory = require('../../store');
+const rootThreadFactory = require('../../services/root-thread');
+const searchFilterFactory = require('../../services/search-filter');
+const viewFilterFactory = require('../../services/view-filter');
+
 const fixtures = immutable({
   annotations: [
     {
@@ -49,10 +54,10 @@ describe('annotation threading', function() {
 
     angular
       .module('app', [])
-      .service('store', require('../../store'))
-      .service('rootThread', require('../../services/root-thread'))
-      .service('searchFilter', require('../../services/search-filter'))
-      .service('viewFilter', require('../../services/view-filter'))
+      .service('store', storeFactory)
+      .service('rootThread', rootThreadFactory)
+      .service('searchFilter', searchFilterFactory)
+      .service('viewFilter', viewFilterFactory)
       .value('features', fakeFeatures)
       .value('settings', {})
       .value('unicode', fakeUnicode);


### PR DESCRIPTION
In preparation for conversion to ES modules, hoist some remaining
non-top level `require` calls to the top level of the file.