### PR TITLE
Convert src/sidebar/components to ES modules

### DIFF
--- a/src/sidebar/components/annotation-action-bar.js
+++ b/src/sidebar/components/annotation-action-bar.js
@@ -1,12 +1,12 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const { withServices } = require('../util/service-context');
-const useStore = require('../store/use-store');
-const { isShareable, shareURI } = require('../util/annotation-sharing');
+import useStore from '../store/use-store';
+import { isShareable, shareURI } from '../util/annotation-sharing';
+import { withServices } from '../util/service-context';
 
-const AnnotationShareControl = require('./annotation-share-control');
-const Button = require('./button');
+import AnnotationShareControl from './annotation-share-control';
+import Button from './button';
 
 /**
  * A collection of `Button`s in the footer area of an annotation that take
@@ -121,4 +121,4 @@ AnnotationActionBar.injectedProps = [
   'settings',
 ];
 
-module.exports = withServices(AnnotationActionBar);
+export default withServices(AnnotationActionBar);

--- a/src/sidebar/components/annotation-body.js
+++ b/src/sidebar/components/annotation-body.js
@@ -1,14 +1,14 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const Excerpt = require('./excerpt');
-const MarkdownEditor = require('./markdown-editor');
-const MarkdownView = require('./markdown-view');
+import Excerpt from './excerpt';
+import MarkdownEditor from './markdown-editor';
+import MarkdownView from './markdown-view';
 
 /**
  * Display the rendered content of an annotation.
  */
-function AnnotationBody({
+export default function AnnotationBody({
   collapse,
   isEditing,
   isHiddenByModerator,
@@ -91,5 +91,3 @@ AnnotationBody.propTypes = {
    */
   text: propTypes.string,
 };
-
-module.exports = AnnotationBody;

--- a/src/sidebar/components/annotation-document-info.js
+++ b/src/sidebar/components/annotation-document-info.js
@@ -1,13 +1,13 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const annotationMetadata = require('../util/annotation-metadata');
+import * as annotationMetadata from '../util/annotation-metadata';
 
 /**
  * Render some metadata about an annotation's document and link to it
  * if a link is available.
  */
-function AnnotationDocumentInfo({ annotation }) {
+export default function AnnotationDocumentInfo({ annotation }) {
   const documentInfo = annotationMetadata.domainAndTitle(annotation);
   // If there's no document title, nothing to do here
   if (!documentInfo.titleText) {
@@ -38,5 +38,3 @@ AnnotationDocumentInfo.propTypes = {
   /* Annotation for which the document metadata will be rendered */
   annotation: propTypes.object.isRequired,
 };
-
-module.exports = AnnotationDocumentInfo;

--- a/src/sidebar/components/annotation-header.js
+++ b/src/sidebar/components/annotation-header.js
@@ -1,20 +1,20 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const { isHighlight } = require('../util/annotation-metadata');
+import { isHighlight } from '../util/annotation-metadata';
 
-const AnnotationDocumentInfo = require('./annotation-document-info');
-const AnnotationShareInfo = require('./annotation-share-info');
-const AnnotationUser = require('./annotation-user');
-const SvgIcon = require('./svg-icon');
-const Timestamp = require('./timestamp');
+import AnnotationDocumentInfo from './annotation-document-info';
+import AnnotationShareInfo from './annotation-share-info';
+import AnnotationUser from './annotation-user';
+import SvgIcon from './svg-icon';
+import Timestamp from './timestamp';
 
 /**
  * Render an annotation's header summary, including metadata about its user,
  * sharing status, document and timestamp. It also allows the user to
  * toggle sub-threads/replies in certain cases.
  */
-function AnnotationHeader({
+export default function AnnotationHeader({
   annotation,
   isEditing,
   onReplyCountClick,
@@ -92,5 +92,3 @@ AnnotationHeader.propTypes = {
    */
   showDocumentInfo: propTypes.bool,
 };
-
-module.exports = AnnotationHeader;

--- a/src/sidebar/components/annotation-license.js
+++ b/src/sidebar/components/annotation-license.js
@@ -1,11 +1,11 @@
-const { createElement } = require('preact');
+import { createElement } from 'preact';
 
-const SvgIcon = require('./svg-icon');
+import SvgIcon from './svg-icon';
 
 /**
  * Render information about CC licensing
  */
-function AnnotationLicense() {
+export default function AnnotationLicense() {
   return (
     <div className="annotation-license">
       <a
@@ -34,5 +34,3 @@ function AnnotationLicense() {
 }
 
 AnnotationLicense.propTypes = {};
-
-module.exports = AnnotationLicense;

--- a/src/sidebar/components/annotation-omega.js
+++ b/src/sidebar/components/annotation-omega.js
@@ -1,12 +1,12 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const useStore = require('../store/use-store');
-const { quote } = require('../util/annotation-metadata');
-const { withServices } = require('../util/service-context');
+import useStore from '../store/use-store';
+import { quote } from '../util/annotation-metadata';
+import { withServices } from '../util/service-context';
 
-const AnnotationHeader = require('./annotation-header');
-const AnnotationQuote = require('./annotation-quote');
+import AnnotationHeader from './annotation-header';
+import AnnotationQuote from './annotation-quote';
 
 /**
  * The "new", migrated-to-preact annotation component.
@@ -67,4 +67,4 @@ AnnotationOmega.propTypes = {
 
 AnnotationOmega.injectedProps = ['permissions'];
 
-module.exports = withServices(AnnotationOmega);
+export default withServices(AnnotationOmega);

--- a/src/sidebar/components/annotation-publish-control.js
+++ b/src/sidebar/components/annotation-publish-control.js
@@ -1,12 +1,12 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const { applyTheme } = require('../util/theme');
-const { withServices } = require('../util/service-context');
+import { withServices } from '../util/service-context';
+import { applyTheme } from '../util/theme';
 
-const Button = require('./button');
-const Menu = require('./menu');
-const MenuItem = require('./menu-item');
+import Button from './button';
+import Menu from './menu';
+import MenuItem from './menu-item';
 
 /**
  * Render a compound control button for publishing (saving) an annotation:
@@ -111,4 +111,4 @@ AnnotationPublishControl.propTypes = {
 
 AnnotationPublishControl.injectedProps = ['settings'];
 
-module.exports = withServices(AnnotationPublishControl);
+export default withServices(AnnotationPublishControl);

--- a/src/sidebar/components/annotation-quote.js
+++ b/src/sidebar/components/annotation-quote.js
@@ -1,12 +1,12 @@
-const classnames = require('classnames');
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const { isOrphan, quote } = require('../util/annotation-metadata');
-const { withServices } = require('../util/service-context');
-const { applyTheme } = require('../util/theme');
+import { isOrphan, quote } from '../util/annotation-metadata';
+import { withServices } from '../util/service-context';
+import { applyTheme } from '../util/theme';
 
-const Excerpt = require('./excerpt');
+import Excerpt from './excerpt';
 
 /**
  * Display the selected text from the document associated with an annotation.
@@ -44,4 +44,4 @@ AnnotationQuote.propTypes = {
 
 AnnotationQuote.injectedProps = ['settings'];
 
-module.exports = withServices(AnnotationQuote);
+export default withServices(AnnotationQuote);

--- a/src/sidebar/components/annotation-share-control.js
+++ b/src/sidebar/components/annotation-share-control.js
@@ -1,14 +1,14 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
-const { useEffect, useRef, useState } = require('preact/hooks');
+import { createElement } from 'preact';
+import { useEffect, useRef, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const useElementShouldClose = require('./hooks/use-element-should-close');
-const { copyText } = require('../util/copy-to-clipboard');
-const { withServices } = require('../util/service-context');
+import { copyText } from '../util/copy-to-clipboard';
+import { withServices } from '../util/service-context';
 
-const Button = require('./button');
-const ShareLinks = require('./share-links');
-const SvgIcon = require('./svg-icon');
+import Button from './button';
+import useElementShouldClose from './hooks/use-element-should-close';
+import ShareLinks from './share-links';
+import SvgIcon from './svg-icon';
 
 /**
  * "Popup"-style component for sharing a single annotation.
@@ -149,4 +149,4 @@ AnnotationShareControl.propTypes = {
 
 AnnotationShareControl.injectedProps = ['analytics', 'flash', 'permissions'];
 
-module.exports = withServices(AnnotationShareControl);
+export default withServices(AnnotationShareControl);

--- a/src/sidebar/components/annotation-share-info.js
+++ b/src/sidebar/components/annotation-share-info.js
@@ -1,10 +1,10 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const { withServices } = require('../util/service-context');
-const useStore = require('../store/use-store');
+import useStore from '../store/use-store';
+import { withServices } from '../util/service-context';
 
-const SvgIcon = require('./svg-icon');
+import SvgIcon from './svg-icon';
 
 /**
  * Render information about what group an annotation is in and
@@ -72,4 +72,4 @@ AnnotationShareInfo.propTypes = {
 
 AnnotationShareInfo.injectedProps = ['permissions'];
 
-module.exports = withServices(AnnotationShareInfo);
+export default withServices(AnnotationShareInfo);

--- a/src/sidebar/components/annotation-thread.js
+++ b/src/sidebar/components/annotation-thread.js
@@ -109,10 +109,7 @@ function AnnotationThreadController(features, store) {
   };
 }
 
-/**
- * Renders a thread of annotations.
- */
-module.exports = {
+export default {
   controllerAs: 'vm',
   controller: AnnotationThreadController,
   bindings: {

--- a/src/sidebar/components/annotation-user.js
+++ b/src/sidebar/components/annotation-user.js
@@ -1,8 +1,8 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const { isThirdPartyUser, username } = require('../util/account-id');
-const { withServices } = require('../util/service-context');
+import { isThirdPartyUser, username } from '../util/account-id';
+import { withServices } from '../util/service-context';
 
 /**
  * Display information about an annotation's user. Link to the user's
@@ -63,4 +63,4 @@ AnnotationUser.propTypes = {
 };
 
 AnnotationUser.injectedProps = ['features', 'serviceUrl', 'settings'];
-module.exports = withServices(AnnotationUser);
+export default withServices(AnnotationUser);

--- a/src/sidebar/components/annotation-viewer-content.js
+++ b/src/sidebar/components/annotation-viewer-content.js
@@ -71,7 +71,7 @@ function AnnotationViewerContentController(
   });
 }
 
-module.exports = {
+export default {
   controller: AnnotationViewerContentController,
   controllerAs: 'vm',
   bindings: {},

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -1,11 +1,6 @@
-const {
-  isNew,
-  isReply,
-  isPageNote,
-  quote,
-} = require('../util/annotation-metadata');
-const events = require('../events');
-const { isThirdPartyUser } = require('../util/account-id');
+import events from '../events';
+import { isThirdPartyUser } from '../util/account-id';
+import { isNew, isReply, isPageNote, quote } from '../util/annotation-metadata';
 
 /**
  * Return a copy of `annotation` with changes made in the editor applied.
@@ -451,7 +446,7 @@ function AnnotationController(
   };
 }
 
-module.exports = {
+export default {
   controller: AnnotationController,
   controllerAs: 'vm',
   bindings: {

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -5,7 +5,7 @@ import { isNew, isReply, isPageNote, quote } from '../util/annotation-metadata';
 /**
  * Return a copy of `annotation` with changes made in the editor applied.
  */
-function updateModel(annotation, changes, permissions) {
+export function updateModel(annotation, changes, permissions) {
   const userid = annotation.user;
 
   return Object.assign({}, annotation, {
@@ -457,7 +457,4 @@ export default {
     isCollapsed: '<',
   },
   template: require('../templates/annotation.html'),
-
-  // Private helper exposed for use in unit tests.
-  updateModel: updateModel,
 };

--- a/src/sidebar/components/button.js
+++ b/src/sidebar/components/button.js
@@ -1,8 +1,8 @@
-const classnames = require('classnames');
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const SvgIcon = require('./svg-icon');
+import SvgIcon from './svg-icon';
 
 /**
  * A button, one of three base types depending on provided props:
@@ -16,7 +16,7 @@ const SvgIcon = require('./svg-icon');
  * - `usePrimaryStyle`: for applying "primary action" styling
  * - `className`: arbitrary additional class name(s) to apply
  */
-function Button({
+export default function Button({
   buttonText = '',
   className = '',
   icon = '',
@@ -128,5 +128,3 @@ Button.propTypes = {
    */
   usePrimaryStyle: propTypes.bool,
 };
-
-module.exports = Button;

--- a/src/sidebar/components/excerpt.js
+++ b/src/sidebar/components/excerpt.js
@@ -1,16 +1,11 @@
-const classnames = require('classnames');
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
-const {
-  useCallback,
-  useLayoutEffect,
-  useRef,
-  useState,
-} = require('preact/hooks');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import { useCallback, useLayoutEffect, useRef, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const { applyTheme } = require('../util/theme');
-const { withServices } = require('../util/service-context');
-const observeElementSize = require('../util/observe-element-size');
+import observeElementSize from '../util/observe-element-size';
+import { withServices } from '../util/service-context';
+import { applyTheme } from '../util/theme';
 
 /**
  * An optional toggle link at the bottom of an excerpt which controls whether
@@ -185,4 +180,4 @@ Excerpt.propTypes = {
 
 Excerpt.injectedProps = ['settings'];
 
-module.exports = withServices(Excerpt);
+export default withServices(Excerpt);

--- a/src/sidebar/components/focused-mode-header.js
+++ b/src/sidebar/components/focused-mode-header.js
@@ -1,13 +1,13 @@
-const { createElement } = require('preact');
+import { createElement } from 'preact';
 
-const useStore = require('../store/use-store');
+import useStore from '../store/use-store';
 
 /**
  * Render a control to interact with any focused "mode" in the sidebar.
  * Currently only a user-focus mode is supported but this could be broadened
  * and abstracted if needed. Allow user to toggle in and out of the focus "mode."
  */
-function FocusedModeHeader() {
+export default function FocusedModeHeader() {
   const actions = useStore(store => ({
     setFocusModeFocused: store.setFocusModeFocused,
   }));
@@ -59,5 +59,3 @@ function FocusedModeHeader() {
 }
 
 FocusedModeHeader.propTypes = {};
-
-module.exports = FocusedModeHeader;

--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -1,12 +1,12 @@
-const propTypes = require('prop-types');
-const { Fragment, createElement } = require('preact');
+import { Fragment, createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const useStore = require('../store/use-store');
-const { orgName } = require('../util/group-list-item-common');
-const { withServices } = require('../util/service-context');
-const { copyText } = require('../util/copy-to-clipboard');
+import useStore from '../store/use-store';
+import { copyText } from '../util/copy-to-clipboard';
+import { orgName } from '../util/group-list-item-common';
+import { withServices } from '../util/service-context';
 
-const MenuItem = require('./menu-item');
+import MenuItem from './menu-item';
 
 /**
  * An item in the groups selection menu.
@@ -155,4 +155,4 @@ GroupListItem.propTypes = {
 
 GroupListItem.injectedProps = ['analytics', 'flash', 'groups'];
 
-module.exports = withServices(GroupListItem);
+export default withServices(GroupListItem);

--- a/src/sidebar/components/group-list-section.js
+++ b/src/sidebar/components/group-list-section.js
@@ -1,13 +1,18 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const GroupListItem = require('./group-list-item');
-const MenuSection = require('./menu-section');
+import GroupListItem from './group-list-item';
+import MenuSection from './menu-section';
 
 /**
  * A labeled section of the groups list.
  */
-function GroupListSection({ expandedGroup, onExpandGroup, groups, heading }) {
+export default function GroupListSection({
+  expandedGroup,
+  onExpandGroup,
+  groups,
+  heading,
+}) {
   return (
     <MenuSection heading={heading}>
       {groups.map(group => (
@@ -42,5 +47,3 @@ GroupListSection.propTypes = {
    */
   onExpandGroup: propTypes.func,
 };
-
-module.exports = GroupListSection;

--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -1,17 +1,17 @@
-const { createElement } = require('preact');
-const { useMemo, useState } = require('preact/hooks');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import { useMemo, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const isThirdPartyService = require('../util/is-third-party-service');
-const { isThirdPartyUser } = require('../util/account-id');
-const groupsByOrganization = require('../util/group-organizations');
-const useStore = require('../store/use-store');
-const { withServices } = require('../util/service-context');
-const serviceConfig = require('../service-config');
+import serviceConfig from '../service-config';
+import useStore from '../store/use-store';
+import { isThirdPartyUser } from '../util/account-id';
+import groupsByOrganization from '../util/group-organizations';
+import isThirdPartyService from '../util/is-third-party-service';
+import { withServices } from '../util/service-context';
 
-const Menu = require('./menu');
-const MenuItem = require('./menu-item');
-const GroupListSection = require('./group-list-section');
+import GroupListSection from './group-list-section';
+import Menu from './menu';
+import MenuItem from './menu-item';
 
 /**
  * Return the custom icon for the top bar configured by the publisher in
@@ -136,4 +136,4 @@ GroupList.propTypes = {
 
 GroupList.injectedProps = ['serviceUrl', 'settings'];
 
-module.exports = withServices(GroupList);
+export default withServices(GroupList);

--- a/src/sidebar/components/help-panel.js
+++ b/src/sidebar/components/help-panel.js
@@ -1,16 +1,16 @@
-const { createElement } = require('preact');
-const { useCallback, useMemo, useState } = require('preact/hooks');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import { useCallback, useMemo, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const uiConstants = require('../ui-constants');
-const useStore = require('../store/use-store');
-const VersionData = require('../util/version-data');
-const { withServices } = require('../util/service-context');
+import useStore from '../store/use-store';
+import uiConstants from '../ui-constants';
+import { withServices } from '../util/service-context';
+import VersionData from '../util/version-data';
 
-const SidebarPanel = require('./sidebar-panel');
-const SvgIcon = require('./svg-icon');
-const Tutorial = require('./tutorial');
-const VersionInfo = require('./version-info');
+import SidebarPanel from './sidebar-panel';
+import SvgIcon from './svg-icon';
+import Tutorial from './tutorial';
+import VersionInfo from './version-info';
 
 /**
  * External link "tabs" inside of the help panel.
@@ -156,4 +156,4 @@ HelpPanel.propTypes = {
 };
 
 HelpPanel.injectedProps = ['session'];
-module.exports = withServices(HelpPanel);
+export default withServices(HelpPanel);

--- a/src/sidebar/components/hooks/test/use-element-should-close-test.js
+++ b/src/sidebar/components/hooks/test/use-element-should-close-test.js
@@ -1,11 +1,10 @@
-const { createElement } = require('preact');
-const { useRef } = require('preact/hooks');
-const propTypes = require('prop-types');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { useRef } from 'preact/hooks';
+import { act } from 'preact/test-utils';
+import propTypes from 'prop-types';
 
-const { act } = require('preact/test-utils');
-const { mount } = require('enzyme');
-
-const useElementShouldClose = require('../use-element-should-close');
+import useElementShouldClose from '../use-element-should-close';
 
 describe('hooks.useElementShouldClose', () => {
   let handleClose;

--- a/src/sidebar/components/hooks/use-element-should-close.js
+++ b/src/sidebar/components/hooks/use-element-should-close.js
@@ -1,6 +1,6 @@
-const { useEffect } = require('preact/hooks');
+import { useEffect } from 'preact/hooks';
 
-const { listen } = require('../../util/dom');
+import { listen } from '../../util/dom';
 
 /**
  * This hook adds appropriate `eventListener`s to the document when a target
@@ -19,7 +19,11 @@ const { listen } = require('../../util/dom');
  * @param {() => void} handleClose - A function that will do the actual closing
  *                                   of `closeableEl`
  */
-function useElementShouldClose(closeableEl, isOpen, handleClose) {
+export default function useElementShouldClose(
+  closeableEl,
+  isOpen,
+  handleClose
+) {
   useEffect(() => {
     if (!isOpen) {
       return () => {};
@@ -69,5 +73,3 @@ function useElementShouldClose(closeableEl, isOpen, handleClose) {
     };
   }, [closeableEl, isOpen, handleClose]);
 }
-
-module.exports = useElementShouldClose;

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -1,10 +1,10 @@
-const events = require('../events');
-const { parseAccountID } = require('../util/account-id');
-const serviceConfig = require('../service-config');
-const bridgeEvents = require('../../shared/bridge-events');
-const uiConstants = require('../ui-constants');
-const isSidebar = require('../util/is-sidebar');
-const { shouldAutoDisplayTutorial } = require('../util/session');
+import bridgeEvents from '../../shared/bridge-events';
+import events from '../events';
+import serviceConfig from '../service-config';
+import uiConstants from '../ui-constants';
+import { parseAccountID } from '../util/account-id';
+import isSidebar from '../util/is-sidebar';
+import { shouldAutoDisplayTutorial } from '../util/session';
 
 /**
  * Return the user's authentication status from their profile.
@@ -163,7 +163,7 @@ function HypothesisAppController(
   };
 }
 
-module.exports = {
+export default {
   controller: HypothesisAppController,
   controllerAs: 'vm',
   template: require('../templates/hypothesis-app.html'),

--- a/src/sidebar/components/logged-out-message.js
+++ b/src/sidebar/components/logged-out-message.js
@@ -1,9 +1,9 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const { withServices } = require('../util/service-context');
+import { withServices } from '../util/service-context';
 
-const SvgIcon = require('./svg-icon');
+import SvgIcon from './svg-icon';
 
 /**
  * Render a call-to-action to log in or sign up. This message is intended to be
@@ -46,4 +46,4 @@ LoggedOutMessage.propTypes = {
 
 LoggedOutMessage.injectedProps = ['serviceUrl'];
 
-module.exports = withServices(LoggedOutMessage);
+export default withServices(LoggedOutMessage);

--- a/src/sidebar/components/markdown-editor.js
+++ b/src/sidebar/components/markdown-editor.js
@@ -1,16 +1,17 @@
-const classnames = require('classnames');
-const { createElement } = require('preact');
-const { useEffect, useRef, useState } = require('preact/hooks');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import { useEffect, useRef, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const MarkdownView = require('./markdown-view');
-const {
+import {
   LinkType,
   convertSelectionToLink,
   toggleBlockStyle,
   toggleSpanStyle,
-} = require('../markdown-commands');
-const SvgIcon = require('./svg-icon');
+} from '../markdown-commands';
+
+import MarkdownView from './markdown-view';
+import SvgIcon from './svg-icon';
 
 // Mapping of toolbar command name to key for Ctrl+<key> keyboard shortcuts.
 // The shortcuts are taken from Stack Overflow's editor.
@@ -233,7 +234,7 @@ Toolbar.propTypes = {
 /**
  * Viewer/editor for the body of an annotation in markdown format.
  */
-function MarkdownEditor({ onEditText = () => {}, text = '' }) {
+export default function MarkdownEditor({ onEditText = () => {}, text = '' }) {
   /** Whether the preview mode is currently active. */
   const [preview, setPreview] = useState(false);
 
@@ -305,5 +306,3 @@ MarkdownEditor.propTypes = {
    */
   onEditText: propTypes.func,
 };
-
-module.exports = MarkdownEditor;

--- a/src/sidebar/components/markdown-view.js
+++ b/src/sidebar/components/markdown-view.js
@@ -1,16 +1,16 @@
-const classnames = require('classnames');
-const { createElement } = require('preact');
-const { useEffect, useMemo, useRef } = require('preact/hooks');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import { useEffect, useMemo, useRef } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const { replaceLinksWithEmbeds } = require('../media-embedder');
-const renderMarkdown = require('../render-markdown');
+import { replaceLinksWithEmbeds } from '../media-embedder';
+import renderMarkdown from '../render-markdown';
 
 /**
  * A component which renders markdown as HTML and replaces recognized links
  * with embedded video/audio.
  */
-function MarkdownView({ markdown = '', textClass = {} }) {
+export default function MarkdownView({ markdown = '', textClass = {} }) {
   const html = useMemo(() => (markdown ? renderMarkdown(markdown) : ''), [
     markdown,
   ]);
@@ -39,5 +39,3 @@ MarkdownView.propTypes = {
    */
   textClass: propTypes.object,
 };
-
-module.exports = MarkdownView;

--- a/src/sidebar/components/menu-item.js
+++ b/src/sidebar/components/menu-item.js
@@ -1,11 +1,11 @@
-const classnames = require('classnames');
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const { onActivate } = require('../util/on-activate');
+import { onActivate } from '../util/on-activate';
 
-const Slider = require('./slider');
-const SvgIcon = require('./svg-icon');
+import Slider from './slider';
+import SvgIcon from './svg-icon';
 
 /**
  * An item in a dropdown menu.
@@ -22,7 +22,7 @@ const SvgIcon = require('./svg-icon');
  * For items that have submenus, the `MenuItem` will call the `renderSubmenu`
  * prop to render the content of the submenu, when the submenu is visible.
  */
-function MenuItem({
+export default function MenuItem({
   href,
   icon,
   iconAlt,
@@ -189,5 +189,3 @@ MenuItem.propTypes = {
    */
   submenu: propTypes.any,
 };
-
-module.exports = MenuItem;

--- a/src/sidebar/components/menu-section.js
+++ b/src/sidebar/components/menu-section.js
@@ -1,5 +1,5 @@
-const { Fragment, createElement, toChildArray } = require('preact');
-const propTypes = require('prop-types');
+import { Fragment, createElement, toChildArray } from 'preact';
+import propTypes from 'prop-types';
 
 /**
  * Group a set of menu items together visually, with an optional header.
@@ -16,7 +16,7 @@ const propTypes = require('prop-types');
  *     </MenuSection>
  *   </Menu>
  */
-function MenuSection({ heading, children }) {
+export default function MenuSection({ heading, children }) {
   return (
     <Fragment>
       {heading && <h2 className="menu-section__heading">{heading}</h2>}
@@ -43,5 +43,3 @@ MenuSection.propTypes = {
     propTypes.arrayOf(propTypes.object),
   ]).isRequired,
 };
-
-module.exports = MenuSection;

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -1,11 +1,10 @@
-const classnames = require('classnames');
-const { Fragment, createElement } = require('preact');
-const { useCallback, useEffect, useRef, useState } = require('preact/hooks');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { Fragment, createElement } from 'preact';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const useElementShouldClose = require('./hooks/use-element-should-close');
-
-const SvgIcon = require('./svg-icon');
+import useElementShouldClose from './hooks/use-element-should-close';
+import SvgIcon from './svg-icon';
 
 // The triangular indicator below the menu toggle button that visually links it
 // to the menu content.
@@ -40,7 +39,7 @@ let ignoreNextClick = false;
  *     </MenuSection>
  *   </Menu>
  */
-function Menu({
+export default function Menu({
   align = 'left',
   arrowClass = '',
   children,
@@ -223,5 +222,3 @@ Menu.propTypes = {
    */
   menuIndicator: propTypes.bool,
 };
-
-module.exports = Menu;

--- a/src/sidebar/components/moderation-banner.js
+++ b/src/sidebar/components/moderation-banner.js
@@ -1,10 +1,10 @@
-const { createElement } = require('preact');
-const classnames = require('classnames');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const annotationMetadata = require('../util/annotation-metadata');
-const useStore = require('../store/use-store');
-const { withServices } = require('../util/service-context');
+import useStore from '../store/use-store';
+import * as annotationMetadata from '../util/annotation-metadata';
+import { withServices } from '../util/service-context';
 
 /**
  * Banner allows moderators to hide/unhide the flagged
@@ -101,4 +101,4 @@ ModerationBanner.propTypes = {
 
 ModerationBanner.injectedProps = ['api', 'flash'];
 
-module.exports = withServices(ModerationBanner);
+export default withServices(ModerationBanner);

--- a/src/sidebar/components/new-note-btn.js
+++ b/src/sidebar/components/new-note-btn.js
@@ -1,12 +1,12 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const events = require('../events');
-const useStore = require('../store/use-store');
-const { applyTheme } = require('../util/theme');
-const { withServices } = require('../util/service-context');
+import events from '../events';
+import useStore from '../store/use-store';
+import { withServices } from '../util/service-context';
+import { applyTheme } from '../util/theme';
 
-const Button = require('./button');
+import Button from './button';
 
 function NewNoteButton({ $rootScope, settings }) {
   const store = useStore(store => ({
@@ -43,4 +43,4 @@ NewNoteButton.propTypes = {
 
 NewNoteButton.injectedProps = ['$rootScope', 'settings'];
 
-module.exports = withServices(NewNoteButton);
+export default withServices(NewNoteButton);

--- a/src/sidebar/components/search-input.js
+++ b/src/sidebar/components/search-input.js
@@ -1,12 +1,12 @@
-const classnames = require('classnames');
-const { createElement } = require('preact');
-const { useRef, useState } = require('preact/hooks');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import { useRef, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const useStore = require('../store/use-store');
+import useStore from '../store/use-store';
 
-const Button = require('./button');
-const Spinner = require('./spinner');
+import Button from './button';
+import Spinner from './spinner';
 
 /**
  * An input field in the top bar for entering a query that filters annotations
@@ -17,7 +17,7 @@ const Spinner = require('./spinner');
  * is fetching for data from the API or in a "loading" state for any other
  * reason.
  */
-function SearchInput({ alwaysExpanded, query, onSearch }) {
+export default function SearchInput({ alwaysExpanded, query, onSearch }) {
   const isLoading = useStore(store => store.isLoading());
   const input = useRef();
 
@@ -89,5 +89,3 @@ SearchInput.propTypes = {
    */
   onSearch: propTypes.func,
 };
-
-module.exports = SearchInput;

--- a/src/sidebar/components/search-status-bar.js
+++ b/src/sidebar/components/search-status-bar.js
@@ -1,12 +1,12 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
-const { useMemo } = require('preact/hooks');
+import { createElement } from 'preact';
+import { useMemo } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const { withServices } = require('../util/service-context');
-const uiConstants = require('../ui-constants');
-const useStore = require('../store/use-store');
+import useStore from '../store/use-store';
+import uiConstants from '../ui-constants';
+import { withServices } from '../util/service-context';
 
-const Button = require('./button');
+import Button from './button';
 
 /**
  * Of the annotations in the thread `annThread`, how many
@@ -187,4 +187,4 @@ SearchStatusBar.propTypes = {
 
 SearchStatusBar.injectedProps = ['rootThread'];
 
-module.exports = withServices(SearchStatusBar);
+export default withServices(SearchStatusBar);

--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -1,14 +1,14 @@
-const classnames = require('classnames');
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
-const { Fragment } = require('preact');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import { Fragment } from 'preact';
+import propTypes from 'prop-types';
 
-const NewNoteBtn = require('./new-note-btn');
-const uiConstants = require('../ui-constants');
-const useStore = require('../store/use-store');
-const { withServices } = require('../util/service-context');
+import useStore from '../store/use-store';
+import uiConstants from '../ui-constants';
+import { withServices } from '../util/service-context';
 
-const SvgIcon = require('./svg-icon');
+import NewNoteBtn from './new-note-btn';
+import SvgIcon from './svg-icon';
 
 /**
  *  Display name of the tab and annotation count.
@@ -177,4 +177,4 @@ SelectionTabs.propTypes = {
 
 SelectionTabs.injectedProps = ['settings'];
 
-module.exports = withServices(SelectionTabs);
+export default withServices(SelectionTabs);

--- a/src/sidebar/components/share-annotations-panel.js
+++ b/src/sidebar/components/share-annotations-panel.js
@@ -1,14 +1,15 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
-const useStore = require('../store/use-store');
-const { copyText } = require('../util/copy-to-clipboard');
-const { withServices } = require('../util/service-context');
-const uiConstants = require('../ui-constants');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const Button = require('./button');
-const ShareLinks = require('./share-links');
-const SidebarPanel = require('./sidebar-panel');
-const SvgIcon = require('./svg-icon');
+import useStore from '../store/use-store';
+import uiConstants from '../ui-constants';
+import { copyText } from '../util/copy-to-clipboard';
+import { withServices } from '../util/service-context';
+
+import Button from './button';
+import ShareLinks from './share-links';
+import SidebarPanel from './sidebar-panel';
+import SvgIcon from './svg-icon';
 
 /**
  * A panel for sharing the current group's annotations.
@@ -122,4 +123,4 @@ ShareAnnotationsPanel.propTypes = {
 
 ShareAnnotationsPanel.injectedProps = ['analytics', 'flash'];
 
-module.exports = withServices(ShareAnnotationsPanel);
+export default withServices(ShareAnnotationsPanel);

--- a/src/sidebar/components/share-links.js
+++ b/src/sidebar/components/share-links.js
@@ -1,9 +1,9 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const { withServices } = require('../util/service-context');
+import { withServices } from '../util/service-context';
 
-const SvgIcon = require('./svg-icon');
+import SvgIcon from './svg-icon';
 
 /**
  * A single sharing link as a list item
@@ -91,4 +91,4 @@ ShareLinks.propTypes = {
 
 ShareLinks.injectedProps = ['analytics'];
 
-module.exports = withServices(ShareLinks);
+export default withServices(ShareLinks);

--- a/src/sidebar/components/sidebar-content-error.js
+++ b/src/sidebar/components/sidebar-content-error.js
@@ -1,10 +1,10 @@
-const { Fragment, createElement } = require('preact');
-const propTypes = require('prop-types');
+import { Fragment, createElement } from 'preact';
+import propTypes from 'prop-types';
 
 /**
  * An error message to display in the sidebar.
  */
-function SidebarContentError({
+export default function SidebarContentError({
   loggedOutErrorMessage,
   loggedInErrorMessage,
   onLoginRequest,
@@ -46,5 +46,3 @@ SidebarContentError.propTypes = {
   /* A boolean indicating whether the user is logged in or not. */
   isLoggedIn: propTypes.bool,
 };
-
-module.exports = SidebarContentError;

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -1,6 +1,6 @@
-const events = require('../events');
-const isThirdPartyService = require('../util/is-third-party-service');
-const tabs = require('../util/tabs');
+import events from '../events';
+import isThirdPartyService from '../util/is-third-party-service';
+import * as tabs from '../util/tabs';
 
 // @ngInject
 function SidebarContentController(
@@ -191,7 +191,7 @@ function SidebarContentController(
   };
 }
 
-module.exports = {
+export default {
   controller: SidebarContentController,
   controllerAs: 'vm',
   bindings: {

--- a/src/sidebar/components/sidebar-panel.js
+++ b/src/sidebar/components/sidebar-panel.js
@@ -1,12 +1,12 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
-const { useEffect, useRef } = require('preact/hooks');
-const scrollIntoView = require('scroll-into-view');
+import { createElement } from 'preact';
+import { useEffect, useRef } from 'preact/hooks';
+import propTypes from 'prop-types';
+import scrollIntoView from 'scroll-into-view';
 
-const useStore = require('../store/use-store');
+import useStore from '../store/use-store';
 
-const Button = require('./button');
-const Slider = require('./slider');
+import Button from './button';
+import Slider from './slider';
 
 /**
  * Base component for a sidebar panel.
@@ -15,7 +15,12 @@ const Slider = require('./slider');
  * as providing a close button. Only one sidebar panel (as defined by the panel's
  * `panelName`) is active at one time.
  */
-function SidebarPanel({ children, panelName, title, onActiveChanged }) {
+export default function SidebarPanel({
+  children,
+  panelName,
+  title,
+  onActiveChanged,
+}) {
   const panelIsActive = useStore(store => store.isSidebarPanelOpen(panelName));
   const togglePanelFn = useStore(store => store.toggleSidebarPanel);
 
@@ -75,5 +80,3 @@ SidebarPanel.propTypes = {
   /** Optional callback to invoke when this panel's active status changes */
   onActiveChanged: propTypes.func,
 };
-
-module.exports = SidebarPanel;

--- a/src/sidebar/components/slider.js
+++ b/src/sidebar/components/slider.js
@@ -1,6 +1,6 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
-const { useCallback, useEffect, useRef, useState } = require('preact/hooks');
+import { createElement } from 'preact';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
 /**
  * A container which reveals its content when `visible` is `true` using
@@ -12,7 +12,7 @@ const { useCallback, useEffect, useRef, useState } = require('preact/hooks');
  *
  * Currently the only reveal/expand direction supported is top-down.
  */
-function Slider({ children, visible }) {
+export default function Slider({ children, visible }) {
   const containerRef = useRef(null);
   const [containerHeight, setContainerHeight] = useState(visible ? 'auto' : 0);
 
@@ -97,5 +97,3 @@ Slider.propTypes = {
    */
   visible: propTypes.bool,
 };
-
-module.exports = Slider;

--- a/src/sidebar/components/sort-menu.js
+++ b/src/sidebar/components/sort-menu.js
@@ -1,15 +1,15 @@
-const { createElement } = require('preact');
+import { createElement } from 'preact';
 
-const useStore = require('../store/use-store');
+import useStore from '../store/use-store';
 
-const Button = require('./button');
-const Menu = require('./menu');
-const MenuItem = require('./menu-item');
+import Button from './button';
+import Menu from './menu';
+import MenuItem from './menu-item';
 
 /**
  * A drop-down menu of sorting options for a collection of annotations.
  */
-function SortMenu() {
+export default function SortMenu() {
   const actions = useStore(store => ({
     setSortKey: store.setSortKey,
   }));
@@ -58,5 +58,3 @@ function SortMenu() {
 }
 
 SortMenu.propTypes = {};
-
-module.exports = SortMenu;

--- a/src/sidebar/components/spinner.js
+++ b/src/sidebar/components/spinner.js
@@ -1,9 +1,9 @@
-const { createElement } = require('preact');
+import { createElement } from 'preact';
 
 /**
  * Loading indicator.
  */
-function Spinner() {
+export default function Spinner() {
   // The `spinner__container` div only exists to center the spinner within
   // the `<spinner>` Angular component element. Once consumers of this component
   // have been converted to Preact, we should be able to remove this.
@@ -20,5 +20,3 @@ function Spinner() {
 }
 
 Spinner.propTypes = {};
-
-module.exports = Spinner;

--- a/src/sidebar/components/stream-content.js
+++ b/src/sidebar/components/stream-content.js
@@ -66,7 +66,7 @@ function StreamContentController(
   this.loadMore = fetch;
 }
 
-module.exports = {
+export default {
   controller: StreamContentController,
   controllerAs: 'vm',
   bindings: {},

--- a/src/sidebar/components/stream-search-input.js
+++ b/src/sidebar/components/stream-search-input.js
@@ -1,10 +1,10 @@
-const { createElement } = require('preact');
-const { useEffect, useState } = require('preact/hooks');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const { withServices } = require('../util/service-context');
+import { withServices } from '../util/service-context';
 
-const SearchInput = require('./search-input');
+import SearchInput from './search-input';
 
 /**
  * Search input for the single annotation view and stream.
@@ -37,4 +37,4 @@ StreamSearchInput.propTypes = {
 
 StreamSearchInput.injectedProps = ['$location', '$rootScope'];
 
-module.exports = withServices(StreamSearchInput);
+export default withServices(StreamSearchInput);

--- a/src/sidebar/components/svg-icon.js
+++ b/src/sidebar/components/svg-icon.js
@@ -1,7 +1,7 @@
-const classnames = require('classnames');
-const { createElement } = require('preact');
-const { useLayoutEffect, useRef } = require('preact/hooks');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import { useLayoutEffect, useRef } from 'preact/hooks';
+import propTypes from 'prop-types';
 
 // The list of supported icons
 const icons = {
@@ -56,7 +56,12 @@ const icons = {
  * This matches the way we do icons on the website, see
  * https://github.com/hypothesis/h/pull/3675
  */
-function SvgIcon({ name, className = '', inline = false, title = '' }) {
+export default function SvgIcon({
+  name,
+  className = '',
+  inline = false,
+  title = '',
+}) {
   if (!icons[name]) {
     throw new Error(`Unknown icon ${name}`);
   }
@@ -101,5 +106,3 @@ SvgIcon.propTypes = {
   /** Optional title attribute to apply to the SVG's containing `span` */
   title: propTypes.string,
 };
-
-module.exports = SvgIcon;

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
-const { useMemo, useRef, useState } = require('preact/hooks');
+import { createElement } from 'preact';
+import { useMemo, useRef, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const { withServices } = require('../util/service-context');
-const SvgIcon = require('./svg-icon');
+import { withServices } from '../util/service-context';
+
+import SvgIcon from './svg-icon';
 
 // Global counter used to create a unique id for each instance of a TagEditor
 let datalistIdCounter = 0;
@@ -244,4 +245,4 @@ TagEditor.propTypes = {
 
 TagEditor.injectedProps = ['serviceUrl', 'tags'];
 
-module.exports = withServices(TagEditor);
+export default withServices(TagEditor);

--- a/src/sidebar/components/tag-list.js
+++ b/src/sidebar/components/tag-list.js
@@ -1,9 +1,9 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
-const { useMemo } = require('preact/hooks');
+import { createElement } from 'preact';
+import { useMemo } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const { isThirdPartyUser } = require('../util/account-id');
-const { withServices } = require('../util/service-context');
+import { isThirdPartyUser } from '../util/account-id';
+import { withServices } from '../util/service-context';
 
 /**
  * Component to render an annotation's tags.
@@ -70,4 +70,4 @@ TagList.propTypes = {
 
 TagList.injectedProps = ['serviceUrl', 'settings'];
 
-module.exports = withServices(TagList);
+export default withServices(TagList);

--- a/src/sidebar/components/test/annotation-action-bar-test.js
+++ b/src/sidebar/components/test/annotation-action-bar-test.js
@@ -1,12 +1,12 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
-const { act } = require('preact/test-utils');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const { waitFor } = require('./util');
+import AnnotationActionBar from '../annotation-action-bar';
+import { $imports } from '../annotation-action-bar';
 
-const AnnotationActionBar = require('../annotation-action-bar');
-const { $imports } = require('../annotation-action-bar');
-const mockImportedComponents = require('./mock-imported-components');
+import mockImportedComponents from './mock-imported-components';
+import { waitFor } from './util';
 
 describe('AnnotationActionBar', () => {
   let fakeAnnotation;

--- a/src/sidebar/components/test/annotation-body-test.js
+++ b/src/sidebar/components/test/annotation-body-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const AnnotationBody = require('../annotation-body');
-const { $imports } = require('../annotation-body');
-const mockImportedComponents = require('./mock-imported-components');
+import AnnotationBody from '../annotation-body';
+import { $imports } from '../annotation-body';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationBody', () => {
   function createBody(props = {}) {

--- a/src/sidebar/components/test/annotation-document-info-test.js
+++ b/src/sidebar/components/test/annotation-document-info-test.js
@@ -1,11 +1,11 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const fixtures = require('../../test/annotation-fixtures');
+import * as fixtures from '../../test/annotation-fixtures';
+import AnnotationDocumentInfo from '../annotation-document-info';
+import { $imports } from '../annotation-document-info';
 
-const AnnotationDocumentInfo = require('../annotation-document-info');
-const { $imports } = require('../annotation-document-info');
-const mockImportedComponents = require('./mock-imported-components');
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationDocumentInfo', () => {
   let fakeDomainAndTitle;

--- a/src/sidebar/components/test/annotation-header-test.js
+++ b/src/sidebar/components/test/annotation-header-test.js
@@ -1,11 +1,11 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const fixtures = require('../../test/annotation-fixtures');
+import * as fixtures from '../../test/annotation-fixtures';
+import AnnotationHeader from '../annotation-header';
+import { $imports } from '../annotation-header';
 
-const AnnotationHeader = require('../annotation-header');
-const { $imports } = require('../annotation-header');
-const mockImportedComponents = require('./mock-imported-components');
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationHeader', () => {
   let fakeIsHighlight;

--- a/src/sidebar/components/test/annotation-omega-test.js
+++ b/src/sidebar/components/test/annotation-omega-test.js
@@ -1,12 +1,14 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const mockImportedComponents = require('./mock-imported-components');
-const fixtures = require('../../test/annotation-fixtures');
+import * as fixtures from '../../test/annotation-fixtures';
+
+import mockImportedComponents from './mock-imported-components';
 
 // @TODO Note this import as `Annotation` for easier updating later
-const Annotation = require('../annotation-omega');
-const { $imports } = require('../annotation-omega');
+
+import Annotation from '../annotation-omega';
+import { $imports } from '../annotation-omega';
 
 describe('AnnotationOmega', () => {
   let fakeOnReplyCountClick;

--- a/src/sidebar/components/test/annotation-publish-control-test.js
+++ b/src/sidebar/components/test/annotation-publish-control-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const AnnotationPublishControl = require('../annotation-publish-control');
-const { $imports } = require('../annotation-publish-control');
-const mockImportedComponents = require('./mock-imported-components');
+import AnnotationPublishControl from '../annotation-publish-control';
+import { $imports } from '../annotation-publish-control';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationPublishControl', () => {
   let fakeGroup;

--- a/src/sidebar/components/test/annotation-quote-test.js
+++ b/src/sidebar/components/test/annotation-quote-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const AnnotationQuote = require('../annotation-quote');
-const { $imports } = require('../annotation-quote');
-const mockImportedComponents = require('./mock-imported-components');
+import AnnotationQuote from '../annotation-quote';
+import { $imports } from '../annotation-quote';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationQuote', () => {
   let fakeAnnotation;

--- a/src/sidebar/components/test/annotation-share-control-test.js
+++ b/src/sidebar/components/test/annotation-share-control-test.js
@@ -1,10 +1,11 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
-const { act } = require('preact/test-utils');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const AnnotationShareControl = require('../annotation-share-control');
-const { $imports } = require('../annotation-share-control');
-const mockImportedComponents = require('./mock-imported-components');
+import AnnotationShareControl from '../annotation-share-control';
+import { $imports } from '../annotation-share-control';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationShareControl', () => {
   let fakeAnnotation;

--- a/src/sidebar/components/test/annotation-share-info-test.js
+++ b/src/sidebar/components/test/annotation-share-info-test.js
@@ -1,11 +1,11 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const fixtures = require('../../test/annotation-fixtures');
+import * as fixtures from '../../test/annotation-fixtures';
+import AnnotationShareInfo from '../annotation-share-info';
+import { $imports } from '../annotation-share-info';
 
-const AnnotationShareInfo = require('../annotation-share-info');
-const { $imports } = require('../annotation-share-info');
-const mockImportedComponents = require('./mock-imported-components');
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationShareInfo', () => {
   let fakeGroup;

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -1,11 +1,10 @@
-const angular = require('angular');
+import angular from 'angular';
 
-const events = require('../../events');
-const fixtures = require('../../test/annotation-fixtures');
-const util = require('../../directive/test/util');
-
-const annotationComponent = require('../annotation');
-const { $imports, updateModel } = require('../annotation');
+import * as util from '../../directive/test/util';
+import events from '../../events';
+import * as fixtures from '../../test/annotation-fixtures';
+import annotationComponent from '../annotation';
+import { $imports, updateModel } from '../annotation';
 
 const inject = angular.mock.inject;
 

--- a/src/sidebar/components/test/annotation-thread-test.js
+++ b/src/sidebar/components/test/annotation-thread-test.js
@@ -1,9 +1,9 @@
-const angular = require('angular');
+import angular from 'angular';
 
-const annotationThread = require('../annotation-thread');
-const moderationBanner = require('../moderation-banner');
-const fixtures = require('../../test/annotation-fixtures');
-const util = require('../../directive/test/util');
+import * as util from '../../directive/test/util';
+import * as fixtures from '../../test/annotation-fixtures';
+import annotationThread from '../annotation-thread';
+import moderationBanner from '../moderation-banner';
 
 function PageObject(element) {
   this.annotations = function() {

--- a/src/sidebar/components/test/annotation-user-test.js
+++ b/src/sidebar/components/test/annotation-user-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const AnnotationUser = require('../annotation-user');
-const { $imports } = require('../annotation-user');
-const mockImportedComponents = require('./mock-imported-components');
+import AnnotationUser from '../annotation-user';
+import { $imports } from '../annotation-user';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationUser', () => {
   let fakeAnnotation;

--- a/src/sidebar/components/test/annotation-viewer-content-test.js
+++ b/src/sidebar/components/test/annotation-viewer-content-test.js
@@ -1,6 +1,6 @@
-const angular = require('angular');
+import angular from 'angular';
 
-const annotationViewerContent = require('../annotation-viewer-content');
+import annotationViewerContent from '../annotation-viewer-content';
 
 // Fake implementation of the API for fetching annotations and replies to
 // annotations.

--- a/src/sidebar/components/test/button-test.js
+++ b/src/sidebar/components/test/button-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const Button = require('../button');
-const { $imports } = require('../button');
-const mockImportedComponents = require('./mock-imported-components');
+import Button from '../button';
+import { $imports } from '../button';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('Button', () => {
   let fakeOnClick;

--- a/src/sidebar/components/test/excerpt-test.js
+++ b/src/sidebar/components/test/excerpt-test.js
@@ -1,9 +1,9 @@
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const Excerpt = require('../excerpt');
-const { $imports } = require('../excerpt');
+import Excerpt from '../excerpt';
+import { $imports } from '../excerpt';
 
 describe('Excerpt', () => {
   const SHORT_DIV = <div id="foo" style="height: 5px;" />;

--- a/src/sidebar/components/test/focused-mode-header-test.js
+++ b/src/sidebar/components/test/focused-mode-header-test.js
@@ -1,9 +1,10 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const FocusedModeHeader = require('../focused-mode-header');
-const { $imports } = require('../focused-mode-header');
-const mockImportedComponents = require('./mock-imported-components');
+import FocusedModeHeader from '../focused-mode-header';
+import { $imports } from '../focused-mode-header';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('FocusedModeHeader', function() {
   let fakeStore;

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -1,11 +1,10 @@
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const { mount } = require('enzyme');
-const GroupListItem = require('../group-list-item');
-const { $imports } = require('../group-list-item');
-
-const { events } = require('../../services/analytics');
+import { events } from '../../services/analytics';
+import GroupListItem from '../group-list-item';
+import { $imports } from '../group-list-item';
 
 describe('GroupListItem', () => {
   let fakeAnalytics;

--- a/src/sidebar/components/test/group-list-section-test.js
+++ b/src/sidebar/components/test/group-list-section-test.js
@@ -1,9 +1,10 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const GroupListSection = require('../group-list-section');
-const { $imports } = require('../group-list-section');
-const mockImportedComponents = require('./mock-imported-components');
+import GroupListSection from '../group-list-section';
+import { $imports } from '../group-list-section';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('GroupListSection', () => {
   const testGroups = [

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -1,10 +1,11 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const GroupList = require('../group-list');
-const { $imports } = require('../group-list');
-const mockImportedComponents = require('./mock-imported-components');
+import GroupList from '../group-list';
+import { $imports } from '../group-list';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('GroupList', () => {
   let fakeServiceConfig;

--- a/src/sidebar/components/test/help-panel-test.js
+++ b/src/sidebar/components/test/help-panel-test.js
@@ -1,10 +1,11 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const HelpPanel = require('../help-panel');
-const { $imports } = require('../help-panel');
-const mockImportedComponents = require('./mock-imported-components');
+import HelpPanel from '../help-panel';
+import { $imports } from '../help-panel';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('HelpPanel', function() {
   let fakeAuth;

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -1,11 +1,10 @@
-const angular = require('angular');
+import angular from 'angular';
 
-const events = require('../../events');
-const { events: analyticsEvents } = require('../../services/analytics');
-const bridgeEvents = require('../../../shared/bridge-events');
-
-const hypothesisApp = require('../hypothesis-app');
-const { $imports } = require('../hypothesis-app');
+import bridgeEvents from '../../../shared/bridge-events';
+import events from '../../events';
+import { events as analyticsEvents } from '../../services/analytics';
+import hypothesisApp from '../hypothesis-app';
+import { $imports } from '../hypothesis-app';
 
 describe('sidebar.components.hypothesis-app', function() {
   let $componentController = null;

--- a/src/sidebar/components/test/logged-out-message-test.js
+++ b/src/sidebar/components/test/logged-out-message-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const LoggedOutMessage = require('../logged-out-message');
-const { $imports } = require('../logged-out-message');
-const mockImportedComponents = require('./mock-imported-components');
+import LoggedOutMessage from '../logged-out-message';
+import { $imports } from '../logged-out-message';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('LoggedOutMessage', () => {
   const createLoggedOutMessage = props => {

--- a/src/sidebar/components/test/markdown-editor-test.js
+++ b/src/sidebar/components/test/markdown-editor-test.js
@@ -1,10 +1,10 @@
-const { createElement, render } = require('preact');
-const { act } = require('preact/test-utils');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement, render } from 'preact';
+import { act } from 'preact/test-utils';
 
-const { LinkType } = require('../../markdown-commands');
-const MarkdownEditor = require('../markdown-editor');
-const { $imports } = require('../markdown-editor');
+import { LinkType } from '../../markdown-commands';
+import MarkdownEditor from '../markdown-editor';
+import { $imports } from '../markdown-editor';
 
 describe('MarkdownEditor', () => {
   const formatResult = {

--- a/src/sidebar/components/test/markdown-view-test.js
+++ b/src/sidebar/components/test/markdown-view-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const MarkdownView = require('../markdown-view');
-const { $imports } = require('../markdown-view');
+import MarkdownView from '../markdown-view';
+import { $imports } from '../markdown-view';
 
 describe('MarkdownView', () => {
   let fakeMediaEmbedder;

--- a/src/sidebar/components/test/menu-item-test.js
+++ b/src/sidebar/components/test/menu-item-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const MenuItem = require('../menu-item');
-const { $imports } = require('../menu-item');
-const mockImportedComponents = require('./mock-imported-components');
+import MenuItem from '../menu-item';
+import { $imports } from '../menu-item';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('MenuItem', () => {
   const createMenuItem = props =>

--- a/src/sidebar/components/test/menu-section-test.js
+++ b/src/sidebar/components/test/menu-section-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const MenuSection = require('../menu-section');
-const { $imports } = require('../menu-section');
-const mockImportedComponents = require('./mock-imported-components');
+import MenuSection from '../menu-section';
+import { $imports } from '../menu-section';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('MenuSection', () => {
   const createMenuSection = props =>

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -1,9 +1,9 @@
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const Menu = require('../menu');
-const { $imports } = require('../menu');
+import Menu from '../menu';
+import { $imports } from '../menu';
 
 describe('Menu', () => {
   let container;

--- a/src/sidebar/components/test/mock-imported-components.js
+++ b/src/sidebar/components/test/mock-imported-components.js
@@ -52,7 +52,7 @@ function getDisplayName(component) {
  *
  * @return {Function} - A function that can be passed to `$imports.$mock`.
  */
-function mockImportedComponents() {
+export default function mockImportedComponents() {
   return (source, symbol, value) => {
     if (!isComponent(value)) {
       return null;
@@ -64,5 +64,3 @@ function mockImportedComponents() {
     return mock;
   };
 }
-
-module.exports = mockImportedComponents;

--- a/src/sidebar/components/test/moderation-banner-test.js
+++ b/src/sidebar/components/test/moderation-banner-test.js
@@ -1,10 +1,11 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const ModerationBanner = require('../moderation-banner');
-const { $imports } = require('../moderation-banner');
-const fixtures = require('../../test/annotation-fixtures');
-const mockImportedComponents = require('./mock-imported-components');
+import * as fixtures from '../../test/annotation-fixtures';
+import ModerationBanner from '../moderation-banner';
+import { $imports } from '../moderation-banner';
+
+import mockImportedComponents from './mock-imported-components';
 
 const moderatedAnnotation = fixtures.moderatedAnnotation;
 

--- a/src/sidebar/components/test/new-note-btn-test.js
+++ b/src/sidebar/components/test/new-note-btn-test.js
@@ -1,11 +1,12 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const events = require('../../events');
-const NewNoteButton = require('../new-note-btn');
-const { $imports } = require('../new-note-btn');
-const mockImportedComponents = require('./mock-imported-components');
+import events from '../../events';
+import NewNoteButton from '../new-note-btn';
+import { $imports } from '../new-note-btn';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('NewNoteButton', function() {
   let fakeStore;

--- a/src/sidebar/components/test/search-input-test.js
+++ b/src/sidebar/components/test/search-input-test.js
@@ -1,8 +1,8 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const SearchInput = require('../search-input');
-const { $imports } = require('../search-input');
+import SearchInput from '../search-input';
+import { $imports } from '../search-input';
 
 describe('SearchInput', () => {
   let fakeStore;

--- a/src/sidebar/components/test/search-status-bar-test.js
+++ b/src/sidebar/components/test/search-status-bar-test.js
@@ -1,9 +1,10 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const SearchStatusBar = require('../search-status-bar');
-const { $imports } = require('../search-status-bar');
-const mockImportedComponents = require('./mock-imported-components');
+import SearchStatusBar from '../search-status-bar';
+import { $imports } from '../search-status-bar';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('SearchStatusBar', () => {
   let fakeRootThread;

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -1,10 +1,11 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const uiConstants = require('../../ui-constants');
-const SelectionTabs = require('../selection-tabs');
-const { $imports } = require('../selection-tabs');
-const mockImportedComponents = require('./mock-imported-components');
+import uiConstants from '../../ui-constants';
+import SelectionTabs from '../selection-tabs';
+import { $imports } from '../selection-tabs';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('SelectionTabs', function() {
   // mock services

--- a/src/sidebar/components/test/share-annotations-panel-test.js
+++ b/src/sidebar/components/test/share-annotations-panel-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const ShareAnnotationsPanel = require('../share-annotations-panel');
-const { $imports } = require('../share-annotations-panel');
-const mockImportedComponents = require('./mock-imported-components');
+import ShareAnnotationsPanel from '../share-annotations-panel';
+import { $imports } from '../share-annotations-panel';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('ShareAnnotationsPanel', () => {
   let fakeStore;

--- a/src/sidebar/components/test/share-links-test.js
+++ b/src/sidebar/components/test/share-links-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const ShareLinks = require('../share-links');
-const { $imports } = require('../share-links');
-const mockImportedComponents = require('./mock-imported-components');
+import ShareLinks from '../share-links';
+import { $imports } from '../share-links';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('ShareLinks', () => {
   let fakeAnalytics;

--- a/src/sidebar/components/test/sidebar-content-error-test.js
+++ b/src/sidebar/components/test/sidebar-content-error-test.js
@@ -1,9 +1,10 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const SidebarContentError = require('../sidebar-content-error');
-const { $imports } = require('../sidebar-content-error');
-const mockImportedComponents = require('./mock-imported-components');
+import SidebarContentError from '../sidebar-content-error';
+import { $imports } from '../sidebar-content-error';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('SidebarContentError', () => {
   const createSidebarContentError = (

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -1,9 +1,9 @@
-const angular = require('angular');
-const EventEmitter = require('tiny-emitter');
+import angular from 'angular';
+import EventEmitter from 'tiny-emitter';
 
-const events = require('../../events');
-const sidebarContent = require('../sidebar-content');
-const storeFactory = require('../../store');
+import events from '../../events';
+import storeFactory from '../../store';
+import sidebarContent from '../sidebar-content';
 
 class FakeRootThread extends EventEmitter {
   constructor() {

--- a/src/sidebar/components/test/sidebar-panel-test.js
+++ b/src/sidebar/components/test/sidebar-panel-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const SidebarPanel = require('../sidebar-panel');
-const { $imports } = require('../sidebar-panel');
-const mockImportedComponents = require('./mock-imported-components');
+import SidebarPanel from '../sidebar-panel';
+import { $imports } from '../sidebar-panel';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('SidebarPanel', () => {
   let fakeStore;

--- a/src/sidebar/components/test/slider-test.js
+++ b/src/sidebar/components/test/slider-test.js
@@ -1,7 +1,7 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const Slider = require('../slider');
+import Slider from '../slider';
 
 describe('Slider', () => {
   let container;

--- a/src/sidebar/components/test/sort-menu-test.js
+++ b/src/sidebar/components/test/sort-menu-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const SortMenu = require('../sort-menu');
-const { $imports } = require('../sort-menu');
-const mockImportedComponents = require('./mock-imported-components');
+import SortMenu from '../sort-menu';
+import { $imports } from '../sort-menu';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('SortMenu', () => {
   let fakeState;

--- a/src/sidebar/components/test/spinner-test.js
+++ b/src/sidebar/components/test/spinner-test.js
@@ -1,7 +1,7 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const Spinner = require('../spinner');
+import Spinner from '../spinner';
 
 describe('Spinner', function() {
   const createSpinner = (props = {}) => mount(<Spinner {...props} />);

--- a/src/sidebar/components/test/stream-content-test.js
+++ b/src/sidebar/components/test/stream-content-test.js
@@ -1,7 +1,7 @@
-const angular = require('angular');
-const EventEmitter = require('tiny-emitter');
+import angular from 'angular';
+import EventEmitter from 'tiny-emitter';
 
-const streamContent = require('../stream-content');
+import streamContent from '../stream-content';
 
 class FakeRootThread extends EventEmitter {
   constructor() {

--- a/src/sidebar/components/test/stream-search-input-test.js
+++ b/src/sidebar/components/test/stream-search-input-test.js
@@ -1,10 +1,11 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const StreamSearchInput = require('../stream-search-input');
-const { $imports } = require('../stream-search-input');
-const mockImportedComponents = require('./mock-imported-components');
+import StreamSearchInput from '../stream-search-input';
+import { $imports } from '../stream-search-input';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('StreamSearchInput', () => {
   let fakeLocation;

--- a/src/sidebar/components/test/svg-icon-test.js
+++ b/src/sidebar/components/test/svg-icon-test.js
@@ -1,6 +1,6 @@
-const { createElement, render } = require('preact');
+import { createElement, render } from 'preact';
 
-const SvgIcon = require('../svg-icon');
+import SvgIcon from '../svg-icon';
 
 describe('SvgIcon', () => {
   // Tests here use DOM APIs rather than Enzyme because SvgIcon uses

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const mockImportedComponents = require('./mock-imported-components');
-const TagEditor = require('../tag-editor');
-const { $imports } = require('../tag-editor');
+import TagEditor from '../tag-editor';
+import { $imports } from '../tag-editor';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('TagEditor', function() {
   let fakeTags = ['tag1', 'tag2'];

--- a/src/sidebar/components/test/tag-list-test.js
+++ b/src/sidebar/components/test/tag-list-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const mockImportedComponents = require('./mock-imported-components');
-const TagList = require('../tag-list');
-const { $imports } = require('../tag-list');
+import TagList from '../tag-list';
+import { $imports } from '../tag-list';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('TagList', function() {
   let fakeServiceUrl;

--- a/src/sidebar/components/test/thread-list-test.js
+++ b/src/sidebar/components/test/thread-list-test.js
@@ -1,11 +1,10 @@
-const angular = require('angular');
+import angular from 'angular';
+import immutable from 'seamless-immutable';
+import EventEmitter from 'tiny-emitter';
 
-const EventEmitter = require('tiny-emitter');
-const immutable = require('seamless-immutable');
-
-const events = require('../../events');
-const threadList = require('../thread-list');
-const util = require('../../directive/test/util');
+import * as util from '../../directive/test/util';
+import events from '../../events';
+import threadList from '../thread-list';
 
 const annotFixtures = immutable({
   annotation: { $tag: 't1', id: '1', text: 'text' },

--- a/src/sidebar/components/test/timestamp-test.js
+++ b/src/sidebar/components/test/timestamp-test.js
@@ -1,9 +1,9 @@
-const { createElement } = require('preact');
-const { act } = require('preact/test-utils');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
-const Timestamp = require('../timestamp');
-const { $imports } = require('../timestamp');
+import Timestamp from '../timestamp';
+import { $imports } from '../timestamp';
 
 describe('Timestamp', () => {
   let clock;

--- a/src/sidebar/components/test/top-bar-test.js
+++ b/src/sidebar/components/test/top-bar-test.js
@@ -1,12 +1,12 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const uiConstants = require('../../ui-constants');
-const bridgeEvents = require('../../../shared/bridge-events');
+import bridgeEvents from '../../../shared/bridge-events';
+import uiConstants from '../../ui-constants';
+import TopBar from '../top-bar';
+import { $imports } from '../top-bar';
 
-const TopBar = require('../top-bar');
-const { $imports } = require('../top-bar');
-const mockImportedComponents = require('./mock-imported-components');
+import mockImportedComponents from './mock-imported-components';
 
 describe('TopBar', () => {
   const fakeSettings = {};

--- a/src/sidebar/components/test/tutorial-test.js
+++ b/src/sidebar/components/test/tutorial-test.js
@@ -1,9 +1,10 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const Tutorial = require('../tutorial');
-const { $imports } = require('../tutorial');
-const mockImportedComponents = require('./mock-imported-components');
+import Tutorial from '../tutorial';
+import { $imports } from '../tutorial';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('Tutorial', function() {
   let fakeIsThirdPartyService;

--- a/src/sidebar/components/test/user-menu-test.js
+++ b/src/sidebar/components/test/user-menu-test.js
@@ -1,9 +1,10 @@
-const { createElement } = require('preact');
-const { mount } = require('enzyme');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const UserMenu = require('../user-menu');
-const { $imports } = require('../user-menu');
-const mockImportedComponents = require('./mock-imported-components');
+import UserMenu from '../user-menu';
+import { $imports } from '../user-menu';
+
+import mockImportedComponents from './mock-imported-components';
 
 describe('UserMenu', () => {
   let fakeAuth;

--- a/src/sidebar/components/test/user-menu-test.js
+++ b/src/sidebar/components/test/user-menu-test.js
@@ -1,6 +1,7 @@
 import { mount } from 'enzyme';
 import { createElement } from 'preact';
 
+import bridgeEvents from '../../../shared/bridge-events';
 import UserMenu from '../user-menu';
 import { $imports } from '../user-menu';
 
@@ -11,7 +12,6 @@ describe('UserMenu', () => {
   let fakeBridge;
   let fakeIsThirdPartyUser;
   let fakeOnLogout;
-  let fakeProfileBridgeEvent;
   let fakeServiceConfig;
   let fakeServiceUrl;
   let fakeSettings;
@@ -44,7 +44,6 @@ describe('UserMenu', () => {
     fakeBridge = { call: sinon.stub() };
     fakeIsThirdPartyUser = sinon.stub();
     fakeOnLogout = sinon.stub();
-    fakeProfileBridgeEvent = 'profile-requested';
     fakeServiceConfig = sinon.stub();
     fakeServiceUrl = sinon.stub();
     fakeSettings = {
@@ -57,9 +56,6 @@ describe('UserMenu', () => {
         isThirdPartyUser: fakeIsThirdPartyUser,
       },
       '../service-config': fakeServiceConfig,
-      '../../shared/bridge-events': {
-        PROFILE_REQUESTED: fakeProfileBridgeEvent,
-      },
     });
   });
 
@@ -149,7 +145,7 @@ describe('UserMenu', () => {
         onProfileSelected();
 
         assert.equal(fakeBridge.call.callCount, 1);
-        assert.calledWith(fakeBridge.call, fakeProfileBridgeEvent);
+        assert.calledWith(fakeBridge.call, bridgeEvents.PROFILE_REQUESTED);
       });
 
       it('should not fire profile event for first-party user', () => {

--- a/src/sidebar/components/test/version-info-test.js
+++ b/src/sidebar/components/test/version-info-test.js
@@ -1,8 +1,8 @@
-const { mount } = require('enzyme');
-const { createElement } = require('preact');
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
 
-const VersionInfo = require('../version-info');
-const { $imports } = require('../version-info');
+import VersionInfo from '../version-info';
+import { $imports } from '../version-info';
 
 describe('VersionInfo', function() {
   let fakeVersionData;

--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -1,11 +1,11 @@
-const events = require('../events');
-const metadata = require('../util/annotation-metadata');
+import events from '../events';
+import * as metadata from '../util/annotation-metadata';
 
 /**
  * Component which displays a virtualized list of annotation threads.
  */
 
-const scopeTimeout = require('../util/scope-timeout');
+import scopeTimeout from '../util/scope-timeout';
 
 /**
  * Returns the height of the thread for an annotation if it exists in the view
@@ -181,7 +181,7 @@ function ThreadListController(
   };
 }
 
-module.exports = {
+export default {
   controller: ThreadListController,
   controllerAs: 'vm',
   bindings: {

--- a/src/sidebar/components/timestamp.js
+++ b/src/sidebar/components/timestamp.js
@@ -1,16 +1,16 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
-const { useEffect, useMemo, useState } = require('preact/hooks');
+import { createElement } from 'preact';
+import { useEffect, useMemo, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
 
-const { format: formatDate } = require('../util/date');
-const { decayingInterval, toFuzzyString } = require('../util/time');
+import { format as formatDate } from '../util/date';
+import { decayingInterval, toFuzzyString } from '../util/time';
 
 /**
  * Display a relative timestamp (eg. '6 minutes ago') as static text or a link.
  *
  * The timestamp automatically refreshes at an appropriate frequency.
  */
-function Timestamp({ className, href, timestamp }) {
+export default function Timestamp({ className, href, timestamp }) {
   // "Current" time, used when calculating the relative age of `timestamp`.
   const [now, setNow] = useState(new Date());
 
@@ -60,5 +60,3 @@ Timestamp.propTypes = {
    */
   timestamp: propTypes.string.isRequired,
 };
-
-module.exports = Timestamp;

--- a/src/sidebar/components/top-bar.js
+++ b/src/sidebar/components/top-bar.js
@@ -1,21 +1,21 @@
-const { Fragment, createElement } = require('preact');
-const classnames = require('classnames');
-const propTypes = require('prop-types');
+import classnames from 'classnames';
+import { Fragment, createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const bridgeEvents = require('../../shared/bridge-events');
-const useStore = require('../store/use-store');
-const { applyTheme } = require('../util/theme');
-const isThirdPartyService = require('../util/is-third-party-service');
-const serviceConfig = require('../service-config');
-const { withServices } = require('../util/service-context');
-const uiConstants = require('../ui-constants');
+import bridgeEvents from '../../shared/bridge-events';
+import serviceConfig from '../service-config';
+import useStore from '../store/use-store';
+import uiConstants from '../ui-constants';
+import isThirdPartyService from '../util/is-third-party-service';
+import { withServices } from '../util/service-context';
+import { applyTheme } from '../util/theme';
 
-const Button = require('./button');
-const GroupList = require('./group-list');
-const SearchInput = require('./search-input');
-const StreamSearchInput = require('./stream-search-input');
-const SortMenu = require('./sort-menu');
-const UserMenu = require('./user-menu');
+import Button from './button';
+import GroupList from './group-list';
+import SearchInput from './search-input';
+import SortMenu from './sort-menu';
+import StreamSearchInput from './stream-search-input';
+import UserMenu from './user-menu';
 
 /**
  * The toolbar which appears at the top of the sidebar providing actions
@@ -190,4 +190,4 @@ TopBar.propTypes = {
 
 TopBar.injectedProps = ['bridge', 'settings', 'streamer'];
 
-module.exports = withServices(TopBar);
+export default withServices(TopBar);

--- a/src/sidebar/components/tutorial.js
+++ b/src/sidebar/components/tutorial.js
@@ -1,10 +1,10 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const { withServices } = require('../util/service-context');
-const isThirdPartyService = require('../util/is-third-party-service');
+import isThirdPartyService from '../util/is-third-party-service';
+import { withServices } from '../util/service-context';
 
-const SvgIcon = require('./svg-icon');
+import SvgIcon from './svg-icon';
 
 /**
  * Subcomponent: an "instruction" within the tutorial step that includes an
@@ -80,4 +80,4 @@ Tutorial.propTypes = {
 
 Tutorial.injectedProps = ['settings'];
 
-module.exports = withServices(Tutorial);
+export default withServices(Tutorial);

--- a/src/sidebar/components/user-menu.js
+++ b/src/sidebar/components/user-menu.js
@@ -1,15 +1,15 @@
-const { createElement } = require('preact');
-const propTypes = require('prop-types');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const bridgeEvents = require('../../shared/bridge-events');
-const { isThirdPartyUser } = require('../util/account-id');
-const serviceConfig = require('../service-config');
-const { withServices } = require('../util/service-context');
+import bridgeEvents from '../../shared/bridge-events';
+import serviceConfig from '../service-config';
+import { isThirdPartyUser } from '../util/account-id';
+import { withServices } from '../util/service-context';
 
-const Button = require('./button');
-const Menu = require('./menu');
-const MenuSection = require('./menu-section');
-const MenuItem = require('./menu-item');
+import Button from './button';
+import Menu from './menu';
+import MenuItem from './menu-item';
+import MenuSection from './menu-section';
 
 /**
  * A menu with user and account links.
@@ -91,4 +91,4 @@ UserMenu.propTypes = {
 
 UserMenu.injectedProps = ['bridge', 'serviceUrl', 'settings'];
 
-module.exports = withServices(UserMenu);
+export default withServices(UserMenu);

--- a/src/sidebar/components/version-info.js
+++ b/src/sidebar/components/version-info.js
@@ -1,10 +1,10 @@
-const propTypes = require('prop-types');
-const { createElement } = require('preact');
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
 
-const { copyText } = require('../util/copy-to-clipboard');
-const { withServices } = require('../util/service-context');
+import { copyText } from '../util/copy-to-clipboard';
+import { withServices } from '../util/service-context';
 
-const Button = require('./button');
+import Button from './button';
 
 /**
  * Display current client version info
@@ -60,4 +60,4 @@ VersionInfo.propTypes = {
 
 VersionInfo.injectedProps = ['flash'];
 
-module.exports = withServices(VersionInfo);
+export default withServices(VersionInfo);


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/1660**

Use the convert-to-es-modules package from the frontend-toolkit repo to convert CommonJS/Node require syntax to ES modules.

As well as the module syntax conversion, this script also has the effect of normalizing the sorting and grouping of imports according to the following convention, which fairly closely matches the existing organization.

- Imports are grouped into 3 categories: Vendor, same package but other directory (as calling module), same directory as calling module
- Imports are sorted by module path

Import specifiers on the same line are not re-ordered.