### PR TITLE
WIP: Add persisted defaults to store

### DIFF
--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -22,6 +22,7 @@ describe('sidebar.components.sidebar-content', function() {
   let fakeAnalytics;
   let fakeAnnotations;
   let fakeFrameSync;
+  let fakeLocalStorage;
   let fakeRootThread;
   let fakeSettings;
   let fakeStreamer;
@@ -50,6 +51,10 @@ describe('sidebar.components.sidebar-content', function() {
         scrollToAnnotation: sinon.stub(),
       };
 
+      fakeLocalStorage = {
+        getItem: sinon.stub(),
+      };
+
       fakeStreamer = {
         setConfig: sandbox.stub(),
         connect: sandbox.stub(),
@@ -66,6 +71,7 @@ describe('sidebar.components.sidebar-content', function() {
 
       $provide.value('analytics', fakeAnalytics);
       $provide.value('frameSync', fakeFrameSync);
+      $provide.value('localStorage', fakeLocalStorage);
       $provide.value('rootThread', fakeRootThread);
       $provide.value('streamer', fakeStreamer);
       $provide.value('annotations', fakeAnnotations);

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -113,6 +113,11 @@ function sendPageView(analytics) {
   analytics.sendPageView();
 }
 
+// @ngInject
+function persistDefaults(persistedDefaults) {
+  persistedDefaults.persistDefaults();
+}
+
 // Preact UI components that are wrapped for use within Angular templates.
 import AnnotationActionBar from './components/annotation-action-bar';
 import AnnotationBody from './components/annotation-body';
@@ -164,6 +169,7 @@ import frameSyncService from './services/frame-sync';
 import groupsService from './services/groups';
 import localStorageService from './services/local-storage';
 import permissionsService from './services/permissions';
+import persistedDefaultsService from './services/persisted-defaults';
 import rootThreadService from './services/root-thread';
 import searchFilterService from './services/search-filter';
 import serviceUrlService from './services/service-url';
@@ -243,6 +249,7 @@ function startAngularApp(config) {
     .service('groups', groupsService)
     .service('localStorage', localStorageService)
     .service('permissions', permissionsService)
+    .service('persistedDefaults', persistedDefaultsService)
     .service('rootThread', rootThreadService)
     .service('searchFilter', searchFilterService)
     .service('serviceUrl', serviceUrlService)
@@ -271,6 +278,7 @@ function startAngularApp(config) {
     .config(configureRoutes)
     .config(configureToastr)
 
+    .run(persistDefaults)
     .run(sendPageView)
     .run(setupApi)
     .run(crossOriginRPC.server.start);

--- a/src/sidebar/services/permissions.js
+++ b/src/sidebar/services/permissions.js
@@ -1,4 +1,4 @@
-const STORAGE_KEY = 'hypothesis.privacy';
+//const STORAGE_KEY = 'hypothesis.privacy';
 
 /**
  * Object defining which principals can read, update and delete an annotation.
@@ -23,11 +23,11 @@ const STORAGE_KEY = 'hypothesis.privacy';
  * annotations to local storage.
  */
 // @ngInject
-export default function Permissions(localStorage) {
+export default function Permissions(store) {
   const self = this;
 
   function defaultLevel() {
-    const savedLevel = localStorage.getItem(STORAGE_KEY);
+    const savedLevel = store.getDefault('annotationPrivacy');
     switch (savedLevel) {
       case 'private':
       case 'shared':
@@ -97,7 +97,7 @@ export default function Permissions(localStorage) {
    * @param {'private'|'shared'} level
    */
   this.setDefault = function(level) {
-    localStorage.setItem(STORAGE_KEY, level);
+    store.setDefault('annotationPrivacy', level);
   };
 
   /**

--- a/src/sidebar/services/persisted-defaults.js
+++ b/src/sidebar/services/persisted-defaults.js
@@ -1,0 +1,31 @@
+import defaultKeys from '../util/default-keys';
+
+/**
+ * A service for persisting convenient client-side defaults for the (browser)
+ * user.
+ */
+// @ngInject
+export default function persistedDefaults(localStorage, store) {
+  return {
+    /**
+     * `subscribe` to the store to watch for any changes to defaults;
+     * persist any recognized changes to `localStorage`
+     */
+    persistDefaults() {
+      let lastDefaults = store.getDefaults();
+      store.subscribe(() => {
+        const latestDefaults = store.getDefaults();
+        for (let defaultKey in latestDefaults) {
+          if (lastDefaults[defaultKey] !== latestDefaults[defaultKey]) {
+            if (defaultKey in defaultKeys) {
+              // A default has changed (or been added), and it is recognized
+              // as a persist-able default: update it
+              localStorage.setItem(defaultKeys[defaultKey]);
+            }
+          }
+        }
+        lastDefaults = latestDefaults;
+      });
+    },
+  };
+}

--- a/src/sidebar/services/test/annotation-mapper-test.js
+++ b/src/sidebar/services/test/annotation-mapper-test.js
@@ -10,6 +10,7 @@ describe('annotationMapper', function() {
   let $rootScope;
   let store;
   let fakeApi;
+  let fakeLocalStorage;
   let annotationMapper;
 
   beforeEach(function() {
@@ -19,9 +20,13 @@ describe('annotationMapper', function() {
         flag: sinon.stub().returns(Promise.resolve({})),
       },
     };
+
+    fakeLocalStorage = sinon.stub().returns({ getItem: sinon.stub() });
+
     angular
       .module('app', [])
       .service('annotationMapper', annotationMapperFactory)
+      .service('localStorage', fakeLocalStorage)
       .service('store', storeFactory)
       .value('api', fakeApi)
       .value('settings', {});

--- a/src/sidebar/services/test/permissions-test.js
+++ b/src/sidebar/services/test/permissions-test.js
@@ -3,15 +3,15 @@ import Permissions from '../permissions';
 const userid = 'acct:flash@gord.on';
 
 describe('permissions', function() {
-  let fakeLocalStorage;
+  let fakeStore;
   let permissions;
 
   beforeEach(function() {
-    fakeLocalStorage = {
-      getItem: sinon.stub().returns(null),
-      setItem: sinon.stub(),
+    fakeStore = {
+      getDefault: sinon.stub().returns(null),
+      setDefault: sinon.stub(),
     };
-    permissions = new Permissions(fakeLocalStorage);
+    permissions = new Permissions(fakeStore);
   });
 
   describe('#private', function() {
@@ -43,7 +43,7 @@ describe('permissions', function() {
     });
 
     it('returns private permissions if the saved level is "private"', function() {
-      fakeLocalStorage.getItem.returns('private');
+      fakeStore.getDefault.withArgs('annotationPrivacy').returns('private');
       assert.deepEqual(
         permissions.default(userid, 'gid'),
         permissions.private(userid)
@@ -54,7 +54,7 @@ describe('permissions', function() {
       // FIXME: This test is necessary for the patch fix to prevent the "split-null" bug
       // https://github.com/hypothesis/client/issues/1221 but should be removed when the
       // code is refactored.
-      fakeLocalStorage.getItem.returns('private');
+      fakeStore.getDefault.withArgs('annotationPrivacy').returns('private');
       assert.deepEqual(
         permissions.default(undefined, 'gid'),
         permissions.shared(undefined, 'gid')
@@ -62,7 +62,7 @@ describe('permissions', function() {
     });
 
     it('returns shared permissions if the saved level is "shared"', function() {
-      fakeLocalStorage.getItem.returns('shared');
+      fakeStore.getDefault.withArgs('annotationPrivacy').returns('shared');
       assert.deepEqual(
         permissions.default(userid, 'gid'),
         permissions.shared(userid, 'gid')
@@ -71,13 +71,9 @@ describe('permissions', function() {
   });
 
   describe('#setDefault', function() {
-    it('saves the default permissions', function() {
+    it('saves the default permissions in the store', function() {
       permissions.setDefault('private');
-      assert.calledWith(
-        fakeLocalStorage.setItem,
-        'hypothesis.privacy',
-        'private'
-      );
+      assert.calledWith(fakeStore.setDefault, 'annotationPrivacy', 'private');
     });
   });
 

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -29,10 +29,13 @@
  *  3. Checking that the UI correctly presents a given state.
  */
 
+import defaultKeys from '../util/default-keys';
+
 import createStore from './create-store';
 import debugMiddleware from './debug-middleware';
 import activity from './modules/activity';
 import annotations from './modules/annotations';
+import defaults from './modules/defaults';
 import directLinked from './modules/direct-linked';
 import drafts from './modules/drafts';
 import frames from './modules/frames';
@@ -78,15 +81,23 @@ function angularDigestMiddleware($rootScope) {
  * passing the current state of the store.
  */
 // @ngInject
-export default function store($rootScope, settings) {
+export default function store($rootScope, localStorage, settings) {
   const middleware = [
     debugMiddleware,
     angularDigestMiddleware.bind(null, $rootScope),
   ];
 
+  const persistedDefaults = {};
+  Object.keys(defaultKeys).forEach(defaultKey => {
+    persistedDefaults[defaultKey] = localStorage.getItem(
+      defaultKeys[defaultKey]
+    );
+  });
+
   const modules = [
     activity,
     annotations,
+    defaults,
     directLinked,
     drafts,
     frames,
@@ -98,5 +109,5 @@ export default function store($rootScope, settings) {
     sidebarPanels,
     viewer,
   ];
-  return createStore(modules, [settings], middleware);
+  return createStore(modules, [settings, persistedDefaults], middleware);
 }

--- a/src/sidebar/store/modules/defaults.js
+++ b/src/sidebar/store/modules/defaults.js
@@ -1,0 +1,47 @@
+import * as util from '../util';
+
+/**
+ * A store module pertaining to client-side defaults for (browser) users.
+ */
+
+function init(settings, persistedDefaults) {
+  // Initialize state from any available persisted default values
+  return {
+    annotationPrivacy: persistedDefaults.annotationPrivacy || 'shared',
+  };
+}
+
+const update = {
+  SET_DEFAULT: function(state, action) {
+    return { [action.defaultKey]: action.value };
+  },
+};
+
+const actions = util.actionTypes(update);
+
+function setDefault(defaultKey, value) {
+  return { type: actions.SET_DEFAULT, defaultKey: defaultKey, value: value };
+}
+
+/** Selectors */
+function getDefault(state, defaultKey) {
+  return state.defaults[defaultKey];
+}
+
+function getDefaults(state) {
+  return state.defaults;
+}
+
+export default {
+  init: init,
+  namespace: 'defaults',
+  update: update,
+  actions: {
+    setDefault,
+  },
+
+  selectors: {
+    getDefault,
+    getDefaults,
+  },
+};

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -3,6 +3,7 @@ import immutable from 'seamless-immutable';
 import * as annotationFixtures from '../../test/annotation-fixtures';
 import uiConstants from '../../ui-constants';
 import storeFactory from '../index';
+import { $imports } from '../index';
 
 const defaultAnnotation = annotationFixtures.defaultAnnotation;
 const newAnnotation = annotationFixtures.newAnnotation;
@@ -19,172 +20,206 @@ const fixtures = immutable({
 });
 
 describe('store', function() {
-  let store;
+  let fakeDefaultKeys;
+  let fakeLocalStorage;
   let fakeRootScope;
 
-  function tagForID(id) {
-    const storeAnn = store.findAnnotationByID(id);
-    if (!storeAnn) {
-      throw new Error(`No annotation with ID ${id}`);
-    }
-    return storeAnn.$tag;
-  }
-
   beforeEach(function() {
+    fakeDefaultKeys = {};
+    fakeLocalStorage = { getItem: sinon.stub() };
     fakeRootScope = { $applyAsync: sinon.stub() };
-    store = storeFactory(fakeRootScope, {});
+
+    $imports.$mock({
+      '../util/default-keys': fakeDefaultKeys,
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
   });
 
   describe('initialization', function() {
     it('does not set a selection when settings.annotations is null', function() {
+      const store = storeFactory(fakeRootScope, fakeLocalStorage, {});
       assert.isFalse(store.hasSelectedAnnotations());
       assert.equal(Object.keys(store.getState().selection.expanded).length, 0);
     });
 
     it('sets the selection when settings.annotations is set', function() {
-      store = storeFactory(fakeRootScope, { annotations: 'testid' });
+      const store = storeFactory(fakeRootScope, fakeLocalStorage, {
+        annotations: 'testid',
+      });
       assert.deepEqual(store.getState().selection.selectedAnnotationMap, {
         testid: true,
       });
     });
 
     it('expands the selected annotations when settings.annotations is set', function() {
-      store = storeFactory(fakeRootScope, { annotations: 'testid' });
+      const store = storeFactory(fakeRootScope, fakeLocalStorage, {
+        annotations: 'testid',
+      });
       assert.deepEqual(store.getState().selection.expanded, {
         testid: true,
       });
     });
-  });
 
-  describe('clearSelection', () => {
-    // Test clearSelection here over the entire store as it triggers the
-    // CLEAR_SELECTION action in multiple store modules.
-    it('sets `selectedAnnotationMap` to null', () => {
-      store.clearSelection();
-      assert.isNull(store.getState().selection.selectedAnnotationMap);
-    });
+    it('retrieves known defaults from persisted local storage', () => {
+      //fakeDefaultKeys = { foo: 'bar' };
+      storeFactory(fakeRootScope, fakeLocalStorage, {});
 
-    it('sets `filterQuery` to null', () => {
-      store.clearSelection();
-      assert.isNull(store.getState().selection.filterQuery);
-    });
-
-    it('sets `directLinkedGroupFetchFailed` to false', () => {
-      store.clearSelection();
-      assert.isFalse(
-        store.getState().directLinked.directLinkedGroupFetchFailed
-      );
-    });
-
-    it('sets `directLinkedAnnotationId` to null', () => {
-      store.clearSelection();
-      assert.isNull(store.getState().directLinked.directLinkedAnnotationId);
-    });
-
-    it('sets `directLinkedGroupId` to null', () => {
-      store.clearSelection();
-      assert.isNull(store.getState().directLinked.directLinkedGroupId);
-    });
-
-    it('sets `sortKey` to default annotation sort key if set to Orphans', () => {
-      store.selectTab(uiConstants.TAB_ORPHANS);
-      store.clearSelection();
-      assert.equal(store.getState().selection.sortKey, 'Location');
-    });
-
-    it('sets `sortKeysAvailable` to available annotation sort keys if set to Orphans', () => {
-      store.selectTab(uiConstants.TAB_ORPHANS);
-      store.clearSelection();
-      assert.deepEqual(store.getState().selection.sortKeysAvailable, [
-        'Newest',
-        'Oldest',
-        'Location',
-      ]);
-    });
-
-    it('sets `selectedTab` to Annotations if set to Orphans', () => {
-      store.selectTab(uiConstants.TAB_ORPHANS);
-      store.clearSelection();
-      assert.equal(
-        store.getState().selection.selectedTab,
-        uiConstants.TAB_ANNOTATIONS
-      );
-    });
-
-    it('does not change `selectedTab` if set to something other than Orphans', () => {
-      store.selectTab(uiConstants.TAB_NOTES);
-      store.clearSelection();
-      assert.equal(
-        store.getState().selection.selectedTab,
-        uiConstants.TAB_NOTES
-      );
+      assert.calledOnce(fakeLocalStorage.getItem);
+      //assert.calledWith(fakeLocalStorage.getItem, 'bar');
     });
   });
 
-  describe('#removeAnnotations()', function() {
-    it('removes annotations from the current state', function() {
-      const annot = defaultAnnotation();
-      store.addAnnotations([annot]);
-      store.removeAnnotations([annot]);
-      assert.deepEqual(store.getState().annotations.annotations, []);
+  describe('FIXME: move into appropriate store module tests', () => {
+    let store;
+
+    function tagForID(id) {
+      const storeAnn = store.findAnnotationByID(id);
+      if (!storeAnn) {
+        throw new Error(`No annotation with ID ${id}`);
+      }
+      return storeAnn.$tag;
+    }
+
+    beforeEach(() => {
+      store = storeFactory(fakeRootScope, fakeLocalStorage, {});
     });
 
-    it('matches annotations to remove by ID', function() {
-      store.addAnnotations(fixtures.pair);
-      store.removeAnnotations([{ id: fixtures.pair[0].id }]);
-
-      const ids = store.getState().annotations.annotations.map(function(a) {
-        return a.id;
+    describe('clearSelection', () => {
+      // Test clearSelection here over the entire store as it triggers the
+      // CLEAR_SELECTION action in multiple store modules.
+      it('sets `selectedAnnotationMap` to null', () => {
+        store.clearSelection();
+        assert.isNull(store.getState().selection.selectedAnnotationMap);
       });
-      assert.deepEqual(ids, [fixtures.pair[1].id]);
-    });
 
-    it('matches annotations to remove by tag', function() {
-      store.addAnnotations(fixtures.pair);
-      store.removeAnnotations([{ $tag: fixtures.pair[0].$tag }]);
-
-      const tags = store.getState().annotations.annotations.map(function(a) {
-        return a.$tag;
+      it('sets `filterQuery` to null', () => {
+        store.clearSelection();
+        assert.isNull(store.getState().selection.filterQuery);
       });
-      assert.deepEqual(tags, [fixtures.pair[1].$tag]);
-    });
 
-    it('switches back to the Annotations tab when the last orphan is removed', function() {
-      const orphan = Object.assign(defaultAnnotation(), { $orphan: true });
-      store.addAnnotations([orphan]);
-      store.selectTab(uiConstants.TAB_ORPHANS);
-      store.removeAnnotations([orphan]);
-      assert.equal(
-        store.getState().selection.selectedTab,
-        uiConstants.TAB_ANNOTATIONS
-      );
-    });
-  });
+      it('sets `directLinkedGroupFetchFailed` to false', () => {
+        store.clearSelection();
+        assert.isFalse(
+          store.getState().directLinked.directLinkedGroupFetchFailed
+        );
+      });
 
-  describe('#clearAnnotations()', function() {
-    it('removes all annotations', function() {
-      const annot = defaultAnnotation();
-      store.addAnnotations([annot]);
-      store.clearAnnotations();
-      assert.deepEqual(store.getState().annotations.annotations, []);
-    });
-  });
+      it('sets `directLinkedAnnotationId` to null', () => {
+        store.clearSelection();
+        assert.isNull(store.getState().directLinked.directLinkedAnnotationId);
+      });
 
-  describe('#setShowHighlights()', function() {
-    [{ state: true }, { state: false }].forEach(testCase => {
-      it(`sets the visibleHighlights state flag to ${testCase.state}`, () => {
-        store.setShowHighlights(testCase.state);
-        assert.equal(store.getState().viewer.visibleHighlights, testCase.state);
+      it('sets `directLinkedGroupId` to null', () => {
+        store.clearSelection();
+        assert.isNull(store.getState().directLinked.directLinkedGroupId);
+      });
+
+      it('sets `sortKey` to default annotation sort key if set to Orphans', () => {
+        store.selectTab(uiConstants.TAB_ORPHANS);
+        store.clearSelection();
+        assert.equal(store.getState().selection.sortKey, 'Location');
+      });
+
+      it('sets `sortKeysAvailable` to available annotation sort keys if set to Orphans', () => {
+        store.selectTab(uiConstants.TAB_ORPHANS);
+        store.clearSelection();
+        assert.deepEqual(store.getState().selection.sortKeysAvailable, [
+          'Newest',
+          'Oldest',
+          'Location',
+        ]);
+      });
+
+      it('sets `selectedTab` to Annotations if set to Orphans', () => {
+        store.selectTab(uiConstants.TAB_ORPHANS);
+        store.clearSelection();
+        assert.equal(
+          store.getState().selection.selectedTab,
+          uiConstants.TAB_ANNOTATIONS
+        );
+      });
+
+      it('does not change `selectedTab` if set to something other than Orphans', () => {
+        store.selectTab(uiConstants.TAB_NOTES);
+        store.clearSelection();
+        assert.equal(
+          store.getState().selection.selectedTab,
+          uiConstants.TAB_NOTES
+        );
       });
     });
-  });
 
-  describe('#updatingAnchorStatus', function() {
-    it("updates the annotation's orphan flag", function() {
-      const annot = defaultAnnotation();
-      store.addAnnotations([annot]);
-      store.updateAnchorStatus({ [tagForID(annot.id)]: 'orphan' });
-      assert.equal(store.getState().annotations.annotations[0].$orphan, true);
+    describe('#removeAnnotations()', function() {
+      it('removes annotations from the current state', function() {
+        const annot = defaultAnnotation();
+        store.addAnnotations([annot]);
+        store.removeAnnotations([annot]);
+        assert.deepEqual(store.getState().annotations.annotations, []);
+      });
+
+      it('matches annotations to remove by ID', function() {
+        store.addAnnotations(fixtures.pair);
+        store.removeAnnotations([{ id: fixtures.pair[0].id }]);
+
+        const ids = store.getState().annotations.annotations.map(function(a) {
+          return a.id;
+        });
+        assert.deepEqual(ids, [fixtures.pair[1].id]);
+      });
+
+      it('matches annotations to remove by tag', function() {
+        store.addAnnotations(fixtures.pair);
+        store.removeAnnotations([{ $tag: fixtures.pair[0].$tag }]);
+
+        const tags = store.getState().annotations.annotations.map(function(a) {
+          return a.$tag;
+        });
+        assert.deepEqual(tags, [fixtures.pair[1].$tag]);
+      });
+
+      it('switches back to the Annotations tab when the last orphan is removed', function() {
+        const orphan = Object.assign(defaultAnnotation(), { $orphan: true });
+        store.addAnnotations([orphan]);
+        store.selectTab(uiConstants.TAB_ORPHANS);
+        store.removeAnnotations([orphan]);
+        assert.equal(
+          store.getState().selection.selectedTab,
+          uiConstants.TAB_ANNOTATIONS
+        );
+      });
+    });
+
+    describe('#clearAnnotations()', function() {
+      it('removes all annotations', function() {
+        const annot = defaultAnnotation();
+        store.addAnnotations([annot]);
+        store.clearAnnotations();
+        assert.deepEqual(store.getState().annotations.annotations, []);
+      });
+    });
+
+    describe('#setShowHighlights()', function() {
+      [{ state: true }, { state: false }].forEach(testCase => {
+        it(`sets the visibleHighlights state flag to ${testCase.state}`, () => {
+          store.setShowHighlights(testCase.state);
+          assert.equal(
+            store.getState().viewer.visibleHighlights,
+            testCase.state
+          );
+        });
+      });
+    });
+
+    describe('#updatingAnchorStatus', function() {
+      it("updates the annotation's orphan flag", function() {
+        const annot = defaultAnnotation();
+        store.addAnnotations([annot]);
+        store.updateAnchorStatus({ [tagForID(annot.id)]: 'orphan' });
+        assert.equal(store.getState().annotations.annotations[0].$orphan, true);
+      });
     });
   });
 });

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -52,8 +52,11 @@ describe('annotation threading', function() {
       flagEnabled: sinon.stub().returns(true),
     };
 
+    const fakeLocalStorage = sinon.stub().returns({ getItem: sinon.stub() });
+
     angular
       .module('app', [])
+      .service('localStorage', fakeLocalStorage)
       .service('store', storeFactory)
       .service('rootThread', rootThreadFactory)
       .service('searchFilter', searchFilterFactory)

--- a/src/sidebar/util/default-keys.js
+++ b/src/sidebar/util/default-keys.js
@@ -1,0 +1,7 @@
+/**
+ * A map of defaults to their associated (in our case, localStorage) persisted
+ * key
+ */
+export default {
+  annotationPrivacy: 'hypothesis.privacy',
+};


### PR DESCRIPTION
This WIP PR adds a new store module and service for managing client-side defaults that are persisted (in our case, with `localStorage`). It does this by:

* Adding some logic to store initialization that retrieves known persisted defaults (from `localStorage`) and makes those initial values available to store modules
* Adding a new `store` modules, `defaults`, that initializes its state from those retrieved persisted values, and provides a getter and setter (for now) for defaults
* Adding a new `persistedDefaults` service that, on app bootstrap, subscribes to the store and listens for changes to defaults that correspond to known, persist-able defaults. If it detects a change, it tells `localStorage` to persist the updated value(s).

In addition,

* legacy tests have been made to pass—the mocking of the `store` in some of our older tests is Byzantine and feels like it needs revisiting, but I've propped things up as much as possible for now.
* corralled some tests in the store's `index` module tests that really need to be moved out of there
* updated the `permissions` service to get and set the `annotationPrivacy` default via the store instead of `localStorage`


NOT DONE (and why we're in a WIP state here):

* Tests for the new `persistedDefaults` service and `defaults` store module. These should be straightforward enough to write when it's time
* Completed tests for store initialization: I'm having some woes getting mocking working in the store-index tests and the overall mocking setup for those and related tests is making my eyes cross, so I thought I'd reach out for a bit of assistance here.

Remarkably, this is part of https://github.com/hypothesis/client/issues/1650 — it's pursuant to being able to rip out permissions-initialization from the `annotation` controller and get it in the store so that the new `AnnotationOmega` component doesn't have to have that logic in it (which it shouldn't, anyway).