### PR TITLE
Convert additional src/annotator/ modules to ES modules

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -1,6 +1,6 @@
-const classnames = require('classnames');
+import classnames from 'classnames';
 
-const template = require('./adder.html');
+import template from './adder.html';
 
 const ANNOTATE_BTN_SELECTOR = '.js-annotate-btn';
 const HIGHLIGHT_BTN_SELECTOR = '.js-highlight-btn';
@@ -120,7 +120,7 @@ function createAdderDOM(container) {
  * Annotation 'adder' toolbar which appears next to the selection
  * and provides controls for the user to create new annotations.
  */
-class Adder {
+export class Adder {
   /**
    * Construct the toolbar and populate the UI.
    *
@@ -288,9 +288,4 @@ class Adder {
   }
 }
 
-module.exports = {
-  ARROW_POINTING_DOWN: ARROW_POINTING_DOWN,
-  ARROW_POINTING_UP: ARROW_POINTING_UP,
-
-  Adder: Adder,
-};
+export { ARROW_POINTING_DOWN, ARROW_POINTING_UP };

--- a/src/annotator/pdf-sidebar.js
+++ b/src/annotator/pdf-sidebar.js
@@ -1,4 +1,4 @@
-const Sidebar = require('./sidebar');
+import Sidebar from './sidebar';
 
 const DEFAULT_CONFIG = {
   TextSelection: {},
@@ -12,10 +12,8 @@ const DEFAULT_CONFIG = {
   },
 };
 
-class PdfSidebar extends Sidebar {
+export default class PdfSidebar extends Sidebar {
   constructor(element, config) {
     super(element, Object.assign({}, DEFAULT_CONFIG, config));
   }
 }
-
-module.exports = PdfSidebar;

--- a/src/annotator/range-util.js
+++ b/src/annotator/range-util.js
@@ -2,7 +2,7 @@
  * Returns true if the start point of a selection occurs after the end point,
  * in document order.
  */
-function isSelectionBackwards(selection) {
+export function isSelectionBackwards(selection) {
   if (selection.focusNode === selection.anchorNode) {
     return selection.focusOffset < selection.anchorOffset;
   }
@@ -20,7 +20,7 @@ function isSelectionBackwards(selection) {
  * @param {Range} range
  * @param {Node} node
  */
-function isNodeInRange(range, node) {
+export function isNodeInRange(range, node) {
   if (node === range.startContainer || node === range.endContainer) {
     return true;
   }
@@ -69,7 +69,7 @@ function forEachNodeInRange(range, callback) {
  * @param {Range} range
  * @return {Array<Rect>} Array of bounding rects in viewport coordinates.
  */
-function getTextBoundingBoxes(range) {
+export function getTextBoundingBoxes(range) {
   const whitespaceOnly = /^\s*$/;
   const textNodes = [];
   forEachNodeInRange(range, function(node) {
@@ -114,7 +114,7 @@ function getTextBoundingBoxes(range) {
  * @param {Selection} selection
  * @return {Rect|null}
  */
-function selectionFocusRect(selection) {
+export function selectionFocusRect(selection) {
   if (selection.isCollapsed) {
     return null;
   }
@@ -129,10 +129,3 @@ function selectionFocusRect(selection) {
     return textBoxes[textBoxes.length - 1];
   }
 }
-
-module.exports = {
-  getTextBoundingBoxes: getTextBoundingBoxes,
-  isNodeInRange: isNodeInRange,
-  isSelectionBackwards: isSelectionBackwards,
-  selectionFocusRect: selectionFocusRect,
-};

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -1,7 +1,7 @@
 // Tests that the expected parts of the page are highlighted when annotations
 // with various combinations of selector are anchored.
 
-const Guest = require('../../guest');
+import Guest from '../../guest';
 
 function quoteSelector(quote) {
   return {

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -1,8 +1,7 @@
-const { isLoaded } = require('../../util/frame-util');
-
-const FRAME_DEBOUNCE_WAIT = require('../../frame-observer').DEBOUNCE_WAIT + 10;
-const CrossFrame = require('../../plugin/cross-frame');
-const { $imports } = require('../../plugin/cross-frame');
+import { DEBOUNCE_WAIT } from '../../frame-observer';
+import CrossFrame from '../../plugin/cross-frame';
+import { $imports } from '../../plugin/cross-frame';
+import { isLoaded } from '../../util/frame-util';
 
 describe('CrossFrame multi-frame scenario', function() {
   let fakeAnnotationSync;
@@ -16,7 +15,8 @@ describe('CrossFrame multi-frame scenario', function() {
   const sandbox = sinon.createSandbox();
 
   const waitForFrameObserver = function(cb) {
-    return setTimeout(cb, FRAME_DEBOUNCE_WAIT);
+    const wait = DEBOUNCE_WAIT + 10;
+    return setTimeout(cb, wait);
   };
 
   beforeEach(function() {

--- a/src/annotator/util/test/frame-util-test.js
+++ b/src/annotator/util/test/frame-util-test.js
@@ -1,4 +1,4 @@
-const frameUtil = require('../frame-util');
+import * as frameUtil from '../frame-util';
 
 describe('annotator.util.frame-util', function() {
   describe('findFrames', function() {

--- a/src/annotator/util/test/observable-test.js
+++ b/src/annotator/util/test/observable-test.js
@@ -1,4 +1,4 @@
-const observable = require('../observable');
+import * as observable from '../observable';
 
 describe('observable', function() {
   describe('delay()', function() {

--- a/src/annotator/util/test/url-test.js
+++ b/src/annotator/util/test/url-test.js
@@ -1,4 +1,4 @@
-const { normalizeURI } = require('../url');
+import { normalizeURI } from '../url';
 
 describe('annotator.util.url', () => {
   describe('normalizeURI', () => {


### PR DESCRIPTION
This converts all remaining non-ES modules in src/annotator/ except those which:

 1) Are written in CoffeeScript OR

 2) Are written in JS AND have a default export AND are imported from a
    module written in CoffeeScript.

    This last case is a bit more complex to handle and needs a little
    investigation or a decision to punt it to after the CoffeeScript =>
    JS conversion is complete