### PR TITLE
Add `defaults` store module and `persistedDefaults` service

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -115,6 +115,15 @@ function sendPageView(analytics) {
   analytics.sendPageView();
 }
 
+/**
+ * Fetch any persisted client-side defaults, and persist any app-state changes to
+ * those defaults
+ */
+// @ngInject
+function persistDefaults(persistedDefaults) {
+  persistedDefaults.init();
+}
+
 // Preact UI components that are wrapped for use within Angular templates.
 
 import AnnotationActionBar from './components/annotation-action-bar';
@@ -171,6 +180,7 @@ import groupsService from './services/groups';
 import localStorageService from './services/local-storage';
 import authService from './services/oauth-auth';
 import permissionsService from './services/permissions';
+import persistedDefaultsService from './services/persisted-defaults';
 import rootThreadService from './services/root-thread';
 import searchFilterService from './services/search-filter';
 import serviceUrlService from './services/service-url';
@@ -253,6 +263,7 @@ function startAngularApp(config) {
     .service('groups', groupsService)
     .service('localStorage', localStorageService)
     .service('permissions', permissionsService)
+    .service('persistedDefaults', persistedDefaultsService)
     .service('rootThread', rootThreadService)
     .service('searchFilter', searchFilterService)
     .service('serviceUrl', serviceUrlService)
@@ -281,6 +292,7 @@ function startAngularApp(config) {
     .config(configureRoutes)
     .config(configureToastr)
 
+    .run(persistDefaults)
     .run(sendPageView)
     .run(setupApi)
     .run(crossOriginRPC.server.start);

--- a/src/sidebar/services/permissions.js
+++ b/src/sidebar/services/permissions.js
@@ -1,5 +1,3 @@
-const STORAGE_KEY = 'hypothesis.privacy';
-
 /**
  * Object defining which principals can read, update and delete an annotation.
  *
@@ -23,11 +21,11 @@ const STORAGE_KEY = 'hypothesis.privacy';
  * annotations to local storage.
  */
 // @ngInject
-export default function Permissions(localStorage) {
+export default function Permissions(store) {
   const self = this;
 
   function defaultLevel() {
-    const savedLevel = localStorage.getItem(STORAGE_KEY);
+    const savedLevel = store.getDefault('annotationPrivacy');
     switch (savedLevel) {
       case 'private':
       case 'shared':
@@ -97,7 +95,7 @@ export default function Permissions(localStorage) {
    * @param {'private'|'shared'} level
    */
   this.setDefault = function(level) {
-    localStorage.setItem(STORAGE_KEY, level);
+    store.setDefault('annotationPrivacy', level);
   };
 
   /**

--- a/src/sidebar/services/persisted-defaults.js
+++ b/src/sidebar/services/persisted-defaults.js
@@ -1,0 +1,53 @@
+/**
+ * A service for reading and persisting convenient client-side defaults for
+ * the (browser) user.
+ */
+
+const DEFAULT_KEYS = {
+  annotationPrivacy: 'hypothesis.privacy',
+};
+
+// @ngInject
+export default function persistedDefaults(localStorage, store) {
+  let lastDefaults;
+
+  /**
+   * Store subscribe callback for persisting changes to defaults. It will only
+   * persist defaults that it "knows about" via `DEFAULT_KEYS`.
+   */
+  function persistChangedDefaults() {
+    const latestDefaults = store.getDefaults();
+    for (let defaultKey in latestDefaults) {
+      if (
+        lastDefaults[defaultKey] !== latestDefaults[defaultKey] &&
+        defaultKey in DEFAULT_KEYS
+      ) {
+        localStorage.setItem(
+          DEFAULT_KEYS[defaultKey],
+          latestDefaults[defaultKey]
+        );
+      }
+    }
+    lastDefaults = latestDefaults;
+  }
+
+  return {
+    /**
+     * Initially populate the store with any available persisted defaults,
+     * then subscribe to the store in order to persist any changes to
+     * those defaults.
+     */
+    init() {
+      // Read persisted defaults into the store
+      Object.keys(DEFAULT_KEYS).forEach(defaultKey => {
+        // `localStorage.getItem` will return `null` for a non-existent key
+        const defaultValue = localStorage.getItem(DEFAULT_KEYS[defaultKey]);
+        store.setDefault(defaultKey, defaultValue);
+      });
+      lastDefaults = store.getDefaults();
+
+      // Listen for changes to those defaults from the store and persist them
+      store.subscribe(persistChangedDefaults);
+    },
+  };
+}

--- a/src/sidebar/services/test/permissions-test.js
+++ b/src/sidebar/services/test/permissions-test.js
@@ -3,15 +3,15 @@ import Permissions from '../permissions';
 const userid = 'acct:flash@gord.on';
 
 describe('permissions', function() {
-  let fakeLocalStorage;
+  let fakeStore;
   let permissions;
 
   beforeEach(function() {
-    fakeLocalStorage = {
-      getItem: sinon.stub().returns(null),
-      setItem: sinon.stub(),
+    fakeStore = {
+      getDefault: sinon.stub().returns(null),
+      setDefault: sinon.stub(),
     };
-    permissions = new Permissions(fakeLocalStorage);
+    permissions = new Permissions(fakeStore);
   });
 
   describe('#private', function() {
@@ -43,7 +43,7 @@ describe('permissions', function() {
     });
 
     it('returns private permissions if the saved level is "private"', function() {
-      fakeLocalStorage.getItem.returns('private');
+      fakeStore.getDefault.withArgs('annotationPrivacy').returns('private');
       assert.deepEqual(
         permissions.default(userid, 'gid'),
         permissions.private(userid)
@@ -54,7 +54,7 @@ describe('permissions', function() {
       // FIXME: This test is necessary for the patch fix to prevent the "split-null" bug
       // https://github.com/hypothesis/client/issues/1221 but should be removed when the
       // code is refactored.
-      fakeLocalStorage.getItem.returns('private');
+      fakeStore.getDefault.withArgs('annotationPrivacy').returns('private');
       assert.deepEqual(
         permissions.default(undefined, 'gid'),
         permissions.shared(undefined, 'gid')
@@ -62,7 +62,7 @@ describe('permissions', function() {
     });
 
     it('returns shared permissions if the saved level is "shared"', function() {
-      fakeLocalStorage.getItem.returns('shared');
+      fakeStore.getDefault.withArgs('annotationPrivacy').returns('shared');
       assert.deepEqual(
         permissions.default(userid, 'gid'),
         permissions.shared(userid, 'gid')
@@ -71,13 +71,9 @@ describe('permissions', function() {
   });
 
   describe('#setDefault', function() {
-    it('saves the default permissions', function() {
+    it('saves the default permissions in the store', function() {
       permissions.setDefault('private');
-      assert.calledWith(
-        fakeLocalStorage.setItem,
-        'hypothesis.privacy',
-        'private'
-      );
+      assert.calledWith(fakeStore.setDefault, 'annotationPrivacy', 'private');
     });
   });
 

--- a/src/sidebar/services/test/persisted-defaults-test.js
+++ b/src/sidebar/services/test/persisted-defaults-test.js
@@ -1,0 +1,141 @@
+import fakeReduxStore from '../../test/fake-redux-store';
+
+import persistedDefaults from '../persisted-defaults';
+
+const DEFAULT_KEYS = {
+  annotationPrivacy: 'hypothesis.privacy',
+};
+
+describe('sidebar/services/persisted-defaults', function() {
+  let fakeLocalStorage;
+  let fakeGetItem;
+  let fakeSetItem;
+
+  let fakeStore;
+
+  beforeEach(() => {
+    fakeStore = fakeReduxStore(
+      {
+        defaults: {
+          annotationPrivacy: null,
+        },
+      },
+      {
+        setDefault: sinon.stub(),
+        getDefault: sinon.stub(),
+        getDefaults: sinon.stub().returns({ annotationPrivacy: 'earmuffs' }),
+      }
+    );
+
+    fakeGetItem = sinon.stub();
+    fakeSetItem = sinon.stub();
+
+    fakeLocalStorage = {
+      getItem: fakeGetItem,
+      setItem: fakeSetItem,
+    };
+  });
+
+  describe('#init', () => {
+    it('should retrieve persisted defaults from `localStorage`', () => {
+      const svc = persistedDefaults(fakeLocalStorage, fakeStore);
+
+      svc.init();
+
+      // Retrieving the one default from localStorage
+      assert.calledOnce(fakeLocalStorage.getItem);
+      assert.calledWith(
+        fakeLocalStorage.getItem,
+        DEFAULT_KEYS.annotationPrivacy
+      );
+      // Setting the one default in the store
+      assert.calledOnce(fakeStore.setDefault);
+    });
+
+    it('should set defaults on the store with the values returned by `localStorage`', () => {
+      fakeLocalStorage.getItem.returns('bananas');
+      const svc = persistedDefaults(fakeLocalStorage, fakeStore);
+
+      svc.init();
+
+      assert.calledWith(fakeStore.setDefault, 'annotationPrivacy', 'bananas');
+    });
+
+    it('should set default to `null` if key non-existent in storage', () => {
+      fakeLocalStorage.getItem.returns(null);
+      const svc = persistedDefaults(fakeLocalStorage, fakeStore);
+
+      svc.init();
+
+      assert.calledWith(fakeStore.setDefault, 'annotationPrivacy', null);
+    });
+
+    context('when defaults change in the store', () => {
+      it('should persist changes to a known default', () => {
+        const svc = persistedDefaults(fakeLocalStorage, fakeStore);
+        svc.init();
+
+        const updatedDefaults = { annotationPrivacy: 'carrots' };
+
+        fakeStore.getDefaults.returns(updatedDefaults);
+        fakeStore.setState({ defaults: updatedDefaults });
+
+        assert.calledOnce(fakeLocalStorage.setItem);
+        assert.calledWith(
+          fakeLocalStorage.setItem,
+          DEFAULT_KEYS.annotationPrivacy,
+          'carrots'
+        );
+      });
+
+      it('should persist subsequent changes to known defaults', () => {
+        const svc = persistedDefaults(fakeLocalStorage, fakeStore);
+        svc.init();
+
+        const updatedDefaults = { annotationPrivacy: 'carrots' };
+        const reupdatedDefaults = { annotationPrivacy: 'potatoes' };
+
+        fakeStore.getDefaults.returns(updatedDefaults);
+        fakeStore.setState({ defaults: updatedDefaults });
+        fakeStore.getDefaults.returns(reupdatedDefaults);
+        fakeStore.setState({ defaults: reupdatedDefaults });
+
+        assert.calledTwice(fakeLocalStorage.setItem);
+        assert.calledWith(
+          fakeLocalStorage.setItem,
+          DEFAULT_KEYS.annotationPrivacy,
+          'carrots'
+        );
+        assert.calledWith(
+          fakeLocalStorage.setItem,
+          DEFAULT_KEYS.annotationPrivacy,
+          'potatoes'
+        );
+      });
+
+      it('should not update local storage if default has not changed', () => {
+        const defaults = { annotationPrivacy: 'carrots' };
+        fakeLocalStorage.getItem.returns('carrots');
+        fakeStore.getDefaults.returns(defaults);
+        fakeStore.setState({ defaults: defaults });
+        const svc = persistedDefaults(fakeLocalStorage, fakeStore);
+        svc.init();
+
+        fakeStore.getDefaults.returns(defaults);
+        fakeStore.setState({ defaults: defaults });
+
+        assert.notCalled(fakeLocalStorage.setItem);
+      });
+
+      it('should not persist changes for default keys it is unaware of', () => {
+        const svc = persistedDefaults(fakeLocalStorage, fakeStore);
+        svc.init();
+
+        fakeStore.getDefaults.returns({ foople: 'grapefruit' });
+        fakeStore.setState({ defaults: { foople: 'grapefruit' } });
+
+        assert.notCalled(fakeLocalStorage.setItem);
+      });
+    });
+  });
+});

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -33,6 +33,7 @@ import createStore from './create-store';
 import debugMiddleware from './debug-middleware';
 import activity from './modules/activity';
 import annotations from './modules/annotations';
+import defaults from './modules/defaults';
 import directLinked from './modules/direct-linked';
 import drafts from './modules/drafts';
 import frames from './modules/frames';
@@ -87,6 +88,7 @@ export default function store($rootScope, settings) {
   const modules = [
     activity,
     annotations,
+    defaults,
     directLinked,
     drafts,
     frames,

--- a/src/sidebar/store/modules/defaults.js
+++ b/src/sidebar/store/modules/defaults.js
@@ -1,0 +1,68 @@
+import * as util from '../util';
+
+/**
+ * A store module for managing client-side user-convenience defaults.
+ *
+ * Example: the default privacy level for newly-created annotations
+ * (`private` or `shared`). This default is updated when a user selects a
+ * different publishing destination (e.g. `Post to [group name]` versus
+ * `Post to Only Me`) from the menu rendered by the `AnnotationPublishControl`
+ * component.
+ *
+ * At present, these defaults are persisted between app sessions in `localStorage`,
+ * and their retrieval and re-persistence on change is handled in the
+ * `persistedDefaults` service.
+ */
+
+function init() {
+  /**
+   * Note that the persisted presence of any of these defaults cannot be
+   * guaranteed, so consumers of said defaults should be prepared to handle
+   * missing (i.e. `null`) values. As `null` is a sentinal value indicating
+   * "not set/unavailable", a `null` value for a default is otherwise invalid.
+   */
+  return {
+    annotationPrivacy: null,
+  };
+}
+
+const update = {
+  SET_DEFAULT: function(state, action) {
+    return { [action.defaultKey]: action.value };
+  },
+};
+
+const actions = util.actionTypes(update);
+
+function setDefault(defaultKey, value) {
+  return { type: actions.SET_DEFAULT, defaultKey: defaultKey, value: value };
+}
+
+/** Selectors */
+
+/**
+ * Retrieve the state's current value for `defaultKey`.
+ *
+ * @return {*} - The current value for `defaultKey` or `undefined` if it is not
+ *               present
+ */
+function getDefault(state, defaultKey) {
+  return state.defaults[defaultKey];
+}
+
+function getDefaults(state) {
+  return state.defaults;
+}
+
+export default {
+  init,
+  namespace: 'defaults',
+  update,
+  actions: {
+    setDefault,
+  },
+  selectors: {
+    getDefault,
+    getDefaults,
+  },
+};

--- a/src/sidebar/store/modules/test/defaults-test.js
+++ b/src/sidebar/store/modules/test/defaults-test.js
@@ -1,0 +1,57 @@
+import createStore from '../../create-store';
+import defaults from '../defaults';
+
+describe('store/modules/defaults', function() {
+  let store;
+
+  beforeEach(() => {
+    store = createStore([defaults]);
+  });
+
+  describe('actions', () => {
+    describe('#setDefault', function() {
+      it('should update the indicated default with the new value', () => {
+        const beforePrivacy = store.getDefault('annotationPrivacy');
+        store.setDefault('annotationPrivacy', 'private');
+
+        assert.isNull(beforePrivacy);
+        assert.equal(store.getDefault('annotationPrivacy'), 'private');
+      });
+
+      it('should add a new property to the `defaults` state if non-existent', () => {
+        store.setDefault('foo', 'bar');
+
+        const latestDefaults = store.getDefaults();
+        assert.include(latestDefaults, { foo: 'bar' });
+      });
+    });
+  });
+
+  describe('selectors', () => {
+    describe('#getDefault', () => {
+      it('should return the current value for the given default', () => {
+        store.setDefault('annotationPrivacy', 'shared');
+        assert.equal(store.getDefault('annotationPrivacy'), 'shared');
+      });
+
+      it('should return `null` for default keys that have no value (yet)', () => {
+        assert.isNull(store.getDefault('annotationPrivacy'));
+      });
+
+      it('should return `undefined` if default key (property) is unrecognized', () => {
+        // This differentiates from `null`, which is a known property but not set
+        assert.isUndefined(store.getDefault('someRandomKey'));
+      });
+    });
+
+    describe('#getDefaults', () => {
+      it('should return all defined defaults', () => {
+        store.setDefault('foo', 'bar');
+
+        const latestDefaults = store.getDefaults();
+
+        assert.hasAllKeys(latestDefaults, ['foo', 'annotationPrivacy']);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add a new store module for managing state of client-side defaults
and a new service for a) retrieving those values from where they
were persisted on initialization and b) subscribing to the store
to watch for changes on those defaults—and persisting those changes.

Update the `permissions` service to get/set its default annotation
privacy level through the store instead of directly through
`localStorage`.

Part of #1650