### PR TITLE
Add an `align-items` rule to the focused-mode button

### DIFF
--- a/src/styles/sidebar/components/focused-mode-header.scss
+++ b/src/styles/sidebar/components/focused-mode-header.scss
@@ -10,6 +10,7 @@
   &__btn {
     @include forms.primary-action-btn;
     display: flex;
+    align-items: center;
     margin-left: auto;
     height: 30px;
     padding-left: 10px;


### PR DESCRIPTION
Add an alignment rule to CSS so that button text aligns vertical
center in Firefox.

Before:

<img width="420" alt="Screen Shot 2020-01-16 at 2 45 44 PM" src="https://user-images.githubusercontent.com/439947/72557534-f3704280-386e-11ea-97ef-03484112914e.png">

After:

<img width="415" alt="Screen Shot 2020-01-16 at 2 44 26 PM" src="https://user-images.githubusercontent.com/439947/72557542-f79c6000-386e-11ea-8524-33b54e11d912.png">

Glad this was a quick fix because this is about to be converted over to the `<Button>` component soon, anyway, which should prevent inconsistencies like this.

To test locally: Update `scripts/gulp/live-reload-server.js` to put the client in "focused-user mode". Let me know if you need more details.