### PR TITLE
Add `permissions` util and remove permissions-init logic from components

### DIFF
--- a/src/sidebar/components/annotation-action-bar.js
+++ b/src/sidebar/components/annotation-action-bar.js
@@ -3,6 +3,7 @@ import propTypes from 'prop-types';
 
 import useStore from '../store/use-store';
 import { isShareable, shareURI } from '../util/annotation-sharing';
+import { permits } from '../util/permissions';
 import { withServices } from '../util/service-context';
 
 import AnnotationShareControl from './annotation-share-control';
@@ -18,7 +19,6 @@ function AnnotationActionBar({
   flash,
   onEdit,
   onReply,
-  permissions,
   settings,
 }) {
   const userProfile = useStore(store => store.profile());
@@ -26,11 +26,7 @@ function AnnotationActionBar({
 
   // Is the current user allowed to take the given `action` on this annotation?
   const userIsAuthorizedTo = action => {
-    return permissions.permits(
-      annotation.permissions,
-      action,
-      userProfile.userid
-    );
+    return permits(annotation.permissions, action, userProfile.userid);
   };
 
   const showDeleteAction = userIsAuthorizedTo('delete');
@@ -110,15 +106,9 @@ AnnotationActionBar.propTypes = {
   // Injected services
   annotationMapper: propTypes.object.isRequired,
   flash: propTypes.object.isRequired,
-  permissions: propTypes.object.isRequired,
   settings: propTypes.object.isRequired,
 };
 
-AnnotationActionBar.injectedProps = [
-  'annotationMapper',
-  'flash',
-  'permissions',
-  'settings',
-];
+AnnotationActionBar.injectedProps = ['annotationMapper', 'flash', 'settings'];
 
 export default withServices(AnnotationActionBar);

--- a/src/sidebar/components/annotation-omega.js
+++ b/src/sidebar/components/annotation-omega.js
@@ -3,7 +3,6 @@ import propTypes from 'prop-types';
 
 import useStore from '../store/use-store';
 import { quote } from '../util/annotation-metadata';
-import { withServices } from '../util/service-context';
 
 import AnnotationHeader from './annotation-header';
 import AnnotationQuote from './annotation-quote';
@@ -14,20 +13,9 @@ import AnnotationQuote from './annotation-quote';
 function AnnotationOmega({
   annotation,
   onReplyCountClick,
-  permissions,
   replyCount,
   showDocumentInfo,
 }) {
-  /**
-   * @FIXME: This is TEMPORARY to avoid an error in console when creating new
-   * annotations from the annotator. It does not have long to live.
-   */
-  if (!annotation.permissions) {
-    annotation.permissions = permissions.default(
-      annotation.user,
-      annotation.group
-    );
-  }
   const draft = useStore(store => store.getDraft(annotation));
 
   // Annotation metadata
@@ -60,11 +48,6 @@ AnnotationOmega.propTypes = {
   replyCount: propTypes.number.isRequired,
   /** Should extended document info be rendered (e.g. in non-sidebar contexts)? */
   showDocumentInfo: propTypes.bool.isRequired,
-
-  /** Injected services */
-  permissions: propTypes.object.isRequired,
 };
 
-AnnotationOmega.injectedProps = ['permissions'];
-
-export default withServices(AnnotationOmega);
+export default AnnotationOmega;

--- a/src/sidebar/components/annotation-share-control.js
+++ b/src/sidebar/components/annotation-share-control.js
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import { copyText } from '../util/copy-to-clipboard';
+import { isPrivate } from '../util/permissions';
 import { withServices } from '../util/service-context';
 
 import Button from './button';
@@ -18,10 +19,9 @@ function AnnotationShareControl({
   analytics,
   flash,
   group,
-  permissions,
   shareUri,
 }) {
-  const isPrivate = !permissions.isShared(
+  const annotationIsPrivate = isPrivate(
     annotation.permissions,
     annotation.user
   );
@@ -76,10 +76,10 @@ function AnnotationShareControl({
       <span>Anyone using this link may view this annotation.</span>
     );
 
-  // However, if the annotation is marked as "only me" (`isPrivate` is `true`),
+  // However, if the annotation is marked as "only me" (`annotationIsPrivate` is `true`),
   // then group sharing settings are irrelevant—only the author may view the
   // annotation.
-  const annotationSharingInfo = isPrivate ? (
+  const annotationSharingInfo = annotationIsPrivate ? (
     <span>Only you may view this annotation.</span>
   ) : (
     groupSharingInfo
@@ -144,9 +144,8 @@ AnnotationShareControl.propTypes = {
   /* services */
   analytics: propTypes.object.isRequired,
   flash: propTypes.object.isRequired,
-  permissions: propTypes.object.isRequired,
 };
 
-AnnotationShareControl.injectedProps = ['analytics', 'flash', 'permissions'];
+AnnotationShareControl.injectedProps = ['analytics', 'flash'];
 
 export default withServices(AnnotationShareControl);

--- a/src/sidebar/components/annotation-share-info.js
+++ b/src/sidebar/components/annotation-share-info.js
@@ -2,7 +2,7 @@ import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import useStore from '../store/use-store';
-import { withServices } from '../util/service-context';
+import { isPrivate } from '../util/permissions';
 
 import SvgIcon from './svg-icon';
 
@@ -10,7 +10,7 @@ import SvgIcon from './svg-icon';
  * Render information about what group an annotation is in and
  * whether it is private to the current user (only me)
  */
-function AnnotationShareInfo({ annotation, permissions }) {
+function AnnotationShareInfo({ annotation }) {
   const group = useStore(store => store.getGroup(annotation.group));
 
   // We may not have access to the group object beyond its ID
@@ -20,7 +20,7 @@ function AnnotationShareInfo({ annotation, permissions }) {
   // URL (link) returned by the API for this group. Some groups do not have links
   const linkToGroup = hasGroup && group.links && group.links.html;
 
-  const isPrivate = !permissions.isShared(
+  const annotationIsPrivate = isPrivate(
     annotation.permissions,
     annotation.user
   );
@@ -44,7 +44,7 @@ function AnnotationShareInfo({ annotation, permissions }) {
           </span>
         </a>
       )}
-      {isPrivate && (
+      {annotationIsPrivate && (
         <span className="annotation-share-info__private">
           {/* Show the lock icon in all cases when the annotation is private... */}
           <SvgIcon
@@ -65,11 +65,6 @@ function AnnotationShareInfo({ annotation, permissions }) {
 AnnotationShareInfo.propTypes = {
   /** The current annotation object for which sharing info will be rendered */
   annotation: propTypes.object.isRequired,
-
-  /** injected services */
-  permissions: propTypes.object.isRequired,
 };
 
-AnnotationShareInfo.injectedProps = ['permissions'];
-
-export default withServices(AnnotationShareInfo);
+export default AnnotationShareInfo;

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -92,14 +92,6 @@ function AnnotationController(
      */
     newlyCreatedByHighlightButton = self.annotation.$highlight || false;
 
-    // FIXME: This logic needs to move into the `annotations` store module
-    if (!self.annotation.permissions) {
-      self.annotation.permissions = permissions.default(
-        self.annotation.user,
-        self.annotation.group
-      );
-    }
-
     // Automatically save new highlights to the server when they're created.
     // Note that this line also gets called when the user logs in (since
     // AnnotationController instances are re-created on login) so serves to

--- a/src/sidebar/components/test/annotation-action-bar-test.js
+++ b/src/sidebar/components/test/annotation-action-bar-test.js
@@ -18,7 +18,7 @@ describe('AnnotationActionBar', () => {
   // Fake services
   let fakeAnnotationMapper;
   let fakeFlash;
-  let fakePermissions;
+  let fakePermits;
   let fakeSettings;
   // Fake dependencies
   let fakeIsShareable;
@@ -32,7 +32,6 @@ describe('AnnotationActionBar', () => {
         flash={fakeFlash}
         onEdit={fakeOnEdit}
         onReply={fakeOnReply}
-        permissions={fakePermissions}
         settings={fakeSettings}
         {...props}
       />
@@ -40,14 +39,14 @@ describe('AnnotationActionBar', () => {
   }
 
   const allowOnly = action => {
-    fakePermissions.permits.returns(false);
-    fakePermissions.permits
+    fakePermits.returns(false);
+    fakePermits
       .withArgs(sinon.match.any, action, sinon.match.any)
       .returns(true);
   };
 
   const disallowOnly = action => {
-    fakePermissions.permits
+    fakePermits
       .withArgs(sinon.match.any, action, sinon.match.any)
       .returns(false);
   };
@@ -80,9 +79,7 @@ describe('AnnotationActionBar', () => {
     fakeOnEdit = sinon.stub();
     fakeOnReply = sinon.stub();
 
-    fakePermissions = {
-      permits: sinon.stub().returns(true),
-    };
+    fakePermits = sinon.stub().returns(true);
     fakeSettings = {};
 
     fakeIsShareable = sinon.stub().returns(true);
@@ -99,6 +96,7 @@ describe('AnnotationActionBar', () => {
         isShareable: fakeIsShareable,
         shareURI: sinon.stub().returns('http://share.me'),
       },
+      '../util/permissions': { permits: fakePermits },
       '../store/use-store': callback => callback(fakeStore),
     });
     sinon.stub(window, 'confirm').returns(false);

--- a/src/sidebar/components/test/annotation-omega-test.js
+++ b/src/sidebar/components/test/annotation-omega-test.js
@@ -13,9 +13,6 @@ import { $imports } from '../annotation-omega';
 describe('AnnotationOmega', () => {
   let fakeOnReplyCountClick;
 
-  // Injected service mocks
-  let fakePermissions;
-
   // Dependency Mocks
   let fakeQuote;
   let fakeStore;
@@ -25,7 +22,6 @@ describe('AnnotationOmega', () => {
       <Annotation
         annotation={fixtures.defaultAnnotation()}
         onReplyCountClick={fakeOnReplyCountClick}
-        permissions={fakePermissions}
         replyCount={0}
         showDocumentInfo={false}
         {...props}
@@ -39,10 +35,7 @@ describe('AnnotationOmega', () => {
     fakeQuote = sinon.stub();
     fakeStore = {
       getDraft: sinon.stub(),
-    };
-
-    fakePermissions = {
-      default: sinon.stub(),
+      getDefault: sinon.stub(),
     };
 
     $imports.$mock(mockImportedComponents());

--- a/src/sidebar/components/test/annotation-share-control-test.js
+++ b/src/sidebar/components/test/annotation-share-control-test.js
@@ -13,7 +13,7 @@ describe('AnnotationShareControl', () => {
   let fakeCopyToClipboard;
   let fakeFlash;
   let fakeGroup;
-  let fakePermissions;
+  let fakeIsPrivate;
   let fakeShareUri;
 
   let container;
@@ -29,7 +29,6 @@ describe('AnnotationShareControl', () => {
         analytics={fakeAnalytics}
         flash={fakeFlash}
         group={fakeGroup}
-        permissions={fakePermissions}
         shareUri={fakeShareUri}
         {...props}
       />,
@@ -75,14 +74,13 @@ describe('AnnotationShareControl', () => {
       name: 'My Group',
       type: 'private',
     };
-    fakePermissions = {
-      isShared: sinon.stub().returns(true),
-    };
+    fakeIsPrivate = sinon.stub().returns(false);
     fakeShareUri = 'https://www.example.com';
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../util/copy-to-clipboard': fakeCopyToClipboard,
+      '../util/permissions': { isPrivate: fakeIsPrivate },
       './hooks/use-element-should-close': sinon.stub(),
     });
   });
@@ -166,27 +164,27 @@ describe('AnnotationShareControl', () => {
   [
     {
       groupType: 'private',
-      isShared: true,
+      isPrivate: false,
       expected: 'Only members of the group My Group may view this annotation.',
     },
     {
       groupType: 'open',
-      isShared: true,
+      isPrivate: false,
       expected: 'Anyone using this link may view this annotation.',
     },
     {
       groupType: 'private',
-      isShared: false,
+      isPrivate: true,
       expected: 'Only you may view this annotation.',
     },
     {
       groupType: 'open',
-      isShared: false,
+      isPrivate: true,
       expected: 'Only you may view this annotation.',
     },
   ].forEach(testcase => {
-    it(`renders the correct sharing information for a ${testcase.groupType} group when annotation sharing is ${testcase.isShared}`, () => {
-      fakePermissions.isShared.returns(testcase.isShared);
+    it(`renders the correct sharing information for a ${testcase.groupType} group when annotation privacy is ${testcase.isPrivate}`, () => {
+      fakeIsPrivate.returns(testcase.isPrivate);
       fakeGroup.type = testcase.groupType;
       const wrapper = createComponent({ isPrivate: testcase.isPrivate });
       openElement(wrapper);

--- a/src/sidebar/components/test/annotation-share-info-test.js
+++ b/src/sidebar/components/test/annotation-share-info-test.js
@@ -11,13 +11,12 @@ describe('AnnotationShareInfo', () => {
   let fakeGroup;
   let fakeStore;
   let fakeGetGroup;
-  let fakePermissions;
+  let fakeIsPrivate;
 
   const createAnnotationShareInfo = props => {
     return mount(
       <AnnotationShareInfo
         annotation={fixtures.defaultAnnotation()}
-        permissions={fakePermissions}
         {...props}
       />
     );
@@ -33,13 +32,12 @@ describe('AnnotationShareInfo', () => {
     };
     fakeGetGroup = sinon.stub().returns(fakeGroup);
     fakeStore = { getGroup: fakeGetGroup };
-    fakePermissions = {
-      isShared: sinon.stub().returns(true),
-    };
+    fakeIsPrivate = sinon.stub().returns(false);
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../store/use-store': callback => callback(fakeStore),
+      '../util/permissions': { isPrivate: fakeIsPrivate },
     });
   });
 
@@ -109,7 +107,7 @@ describe('AnnotationShareInfo', () => {
     });
     context('private annotation', () => {
       beforeEach(() => {
-        fakePermissions.isShared.returns(false);
+        fakeIsPrivate.returns(true);
       });
 
       it('should show privacy icon', () => {

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -183,9 +183,6 @@ describe('annotation', function() {
           private: sandbox.stub().returns({
             read: ['justme'],
           }),
-          default: sandbox.stub().returns({
-            read: ['default'],
-          }),
           setDefault: sandbox.stub(),
         };
 
@@ -245,49 +242,6 @@ describe('annotation', function() {
     });
 
     describe('initialization', function() {
-      it('sets the permissions of new annotations', function() {
-        // You can create annotations while logged out and then login.
-        // When you login a new AnnotationController instance is created for
-        // each of your annotations, and on initialization it will set the
-        // annotation's permissions using your username from the session.
-        const annotation = fixtures.newAnnotation();
-        annotation.permissions = undefined;
-        annotation.group = '__world__';
-        fakePermissions.default = function(userid, group) {
-          return {
-            read: [userid, group],
-          };
-        };
-
-        createDirective(annotation);
-
-        assert.deepEqual(
-          annotation.permissions,
-          fakePermissions.default(annotation.user, annotation.group)
-        );
-      });
-
-      it('preserves the permissions of existing annotations', function() {
-        const annotation = fixtures.newAnnotation();
-        annotation.permissions = {
-          permissions: {
-            read: ['foo'],
-            update: ['bar'],
-            delete: ['gar'],
-            admin: ['har'],
-          },
-        };
-        const originalPermissions = JSON.parse(
-          JSON.stringify(annotation.permissions)
-        );
-        fakePermissions.default = function() {
-          return 'new permissions';
-        };
-        fakePermissions.isShared = function() {};
-        createDirective(annotation);
-        assert.deepEqual(annotation.permissions, originalPermissions);
-      });
-
       it('saves new highlights to the server on initialization', function() {
         const annotation = fixtures.newHighlight();
         // The user is logged-in.

--- a/src/sidebar/services/permissions.js
+++ b/src/sidebar/services/permissions.js
@@ -24,17 +24,6 @@
 export default function Permissions(store) {
   const self = this;
 
-  function defaultLevel() {
-    const savedLevel = store.getDefault('annotationPrivacy');
-    switch (savedLevel) {
-      case 'private':
-      case 'shared':
-        return savedLevel;
-      default:
-        return 'shared';
-    }
-  }
-
   /**
    * Return the permissions for a private annotation.
    *
@@ -64,29 +53,6 @@ export default function Permissions(store) {
     return Object.assign(self.private(userid), {
       read: ['group:' + groupId],
     });
-  };
-
-  /**
-   * Return the default permissions for an annotation in a given group.
-   *
-   * @param {string} userid - User ID of the author
-   * @param {string} groupId - ID of the group the annotation is being shared
-   * with
-   * @return {Permissions}
-   */
-  this.default = function(userid, groupId) {
-    // FIXME: The `&& userid` guard was put in place to protect against
-    // https://github.com/hypothesis/client/issues/1221 for the short term
-    // It prevents the setting of permissions to a private level, which
-    // will throw Errors if no `userid` is available (i.e. the annotation was
-    // just created by an anonymous user). Translation: default permissions for
-    // a newly-created (but not saved-to-server) annotation created by a
-    // non-authenticated (anonymous) user will always be shared. For now.
-    if (defaultLevel() === 'private' && userid) {
-      return self.private(userid);
-    } else {
-      return self.shared(userid, groupId);
-    }
   };
 
   /**

--- a/src/sidebar/services/test/permissions-test.js
+++ b/src/sidebar/services/test/permissions-test.js
@@ -34,42 +34,6 @@ describe('permissions', function() {
     });
   });
 
-  describe('#default', function() {
-    it('returns shared permissions by default', function() {
-      assert.deepEqual(
-        permissions.default(userid, 'gid'),
-        permissions.shared(userid, 'gid')
-      );
-    });
-
-    it('returns private permissions if the saved level is "private"', function() {
-      fakeStore.getDefault.withArgs('annotationPrivacy').returns('private');
-      assert.deepEqual(
-        permissions.default(userid, 'gid'),
-        permissions.private(userid)
-      );
-    });
-
-    it('returns shared permissions if the saved level is "private" but no `userid`', function() {
-      // FIXME: This test is necessary for the patch fix to prevent the "split-null" bug
-      // https://github.com/hypothesis/client/issues/1221 but should be removed when the
-      // code is refactored.
-      fakeStore.getDefault.withArgs('annotationPrivacy').returns('private');
-      assert.deepEqual(
-        permissions.default(undefined, 'gid'),
-        permissions.shared(undefined, 'gid')
-      );
-    });
-
-    it('returns shared permissions if the saved level is "shared"', function() {
-      fakeStore.getDefault.withArgs('annotationPrivacy').returns('shared');
-      assert.deepEqual(
-        permissions.default(userid, 'gid'),
-        permissions.shared(userid, 'gid')
-      );
-    });
-  });
-
   describe('#setDefault', function() {
     it('saves the default permissions in the store', function() {
       permissions.setDefault('private');

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -8,6 +8,7 @@ import { createSelector } from 'reselect';
 import uiConstants from '../../ui-constants';
 import * as metadata from '../../util/annotation-metadata';
 import * as arrayUtil from '../../util/array';
+import { defaultPermissions } from '../../util/permissions';
 import * as util from '../util';
 
 import drafts from './drafts';
@@ -334,20 +335,27 @@ function createAnnotation(ann, now = new Date()) {
   return (dispatch, getState) => {
     /**
      * Extend the new, unsaved annotation object with defaults for some
-     * required data fields.
+     * required data fields and default permissions.
      *
      * Note: the `created` and `updated` values will be ignored and superseded
      * by the service when the annotation is persisted, but they are used
      * app-side for annotation card sorting until then.
      */
+    const groupid = getState().groups.focusedGroupId;
+    const userid = getState().session.userid;
     ann = Object.assign(
       {
         created: now.toISOString(),
-        group: getState().groups.focusedGroupId,
+        group: groupid,
+        permissions: defaultPermissions(
+          userid,
+          groupid,
+          getState().defaults.annotationPrivacy
+        ),
         tags: [],
         text: '',
         updated: now.toISOString(),
-        user: getState().session.userid,
+        user: userid,
         user_info: getState().session.user_info,
       },
       ann

--- a/src/sidebar/util/permissions.js
+++ b/src/sidebar/util/permissions.js
@@ -1,0 +1,106 @@
+/**
+ * Utils for working with permissions principals on annotations.
+ *
+ * This is the same as the `permissions` field retrieved on an annotation via
+ * the API.
+ *
+ * Principals are strings of the form `type:id` where `type` is `'acct'` (for a
+ * specific user) or `'group'` (for a group).
+ *
+ * @typedef Permissions
+ * @property {string[]} read - List of principals that can read the annotation
+ * @property {string[]} update - List of principals that can edit the annotation
+ * @property {string[]} delete - List of principals that can delete the
+ * annotation
+ */
+
+function defaultLevel(savedLevel) {
+  switch (savedLevel) {
+    case 'private':
+    case 'shared':
+      return savedLevel;
+    default:
+      return 'shared';
+  }
+}
+
+/**
+ * Return the permissions for a private annotation.
+ *
+ * A private annotation is one which is readable only by its author.
+ *
+ * @param {string} userid - User ID of the author
+ * @return {Permissions}
+ */
+export function privatePermissions(userid) {
+  return {
+    read: [userid],
+    update: [userid],
+    delete: [userid],
+  };
+}
+
+/**
+ * Return the permissions for an annotation that is shared with the given
+ * group.
+ *
+ * @param {string} userid - User ID of the author
+ * @param {string} groupid - ID of the group the annotation is being
+ * shared with
+ * @return {Permissions}
+ */
+export function sharedPermissions(userid, groupid) {
+  return Object.assign(privatePermissions(userid), {
+    read: ['group:' + groupid],
+  });
+}
+/**
+ * Return the default permissions for an annotation in a given group.
+ *
+ * @param {string} userid - User ID of the author
+ * @param {string} groupId - ID of the group the annotation is being shared
+ * with
+ * @return {Permissions}
+ */
+export function defaultPermissions(userid, groupid, savedLevel) {
+  if (defaultLevel(savedLevel) === 'private' && userid) {
+    return privatePermissions(userid);
+  } else {
+    return sharedPermissions(userid, groupid);
+  }
+}
+
+/**
+ * Return true if an annotation with the given permissions is shared with any
+ * group.
+ *
+ * @param {Permissions} perms
+ * @return {boolean}
+ */
+export function isShared(perms) {
+  return perms.read.some(function(principal) {
+    return principal.indexOf('group:') === 0;
+  });
+}
+
+/**
+ * Return true if an annotation with the given permissions is private.
+ *
+ * @param {Permissions} perms
+ * @return {boolean}
+ */
+export function isPrivate(perms) {
+  return !isShared(perms);
+}
+
+/**
+ * Return true if a user can perform the given `action` on an annotation.
+ *
+ * @param {Permissions} perms
+ * @param {'update'|'delete'} action
+ * @param {string} userid
+ * @return {boolean}
+ */
+export function permits(perms, action, userid) {
+  return perms[action].indexOf(userid) !== -1;
+}

--- a/src/sidebar/util/test/permissions-test.js
+++ b/src/sidebar/util/test/permissions-test.js
@@ -1,0 +1,97 @@
+import * as permissions from '../permissions';
+
+const userid = 'acct:flash@gord.on';
+
+describe('sidebar/util/permissions', () => {
+  describe('#privatePermissions', () => {
+    it('only allows the user to read the annotation', () => {
+      assert.deepEqual(permissions.privatePermissions(userid), {
+        read: [userid],
+        update: [userid],
+        delete: [userid],
+      });
+    });
+  });
+
+  describe('#sharedPermissions', () => {
+    it('allows the group to read the annotation', () => {
+      assert.deepEqual(permissions.sharedPermissions(userid, 'gid'), {
+        read: ['group:gid'],
+        update: [userid],
+        delete: [userid],
+      });
+    });
+  });
+
+  describe('#defaultPermissions', () => {
+    it('returns shared permissions by default', () => {
+      assert.deepEqual(
+        permissions.defaultPermissions(userid, 'gid'),
+        permissions.sharedPermissions(userid, 'gid'),
+        null
+      );
+    });
+
+    it('returns private permissions if the saved level is "private"', () => {
+      assert.deepEqual(
+        permissions.defaultPermissions(userid, 'gid', 'private'),
+        permissions.privatePermissions(userid)
+      );
+    });
+
+    it('returns shared permissions if the saved level is "private" but no `userid`', () => {
+      // FIXME: This test is necessary for the patch fix to prevent the "split-null" bug
+      // https://github.com/hypothesis/client/issues/1221 but should be removed when the
+      // code is refactored.
+      assert.deepEqual(
+        permissions.defaultPermissions(undefined, 'gid', 'private'),
+        permissions.sharedPermissions(undefined, 'gid')
+      );
+    });
+
+    it('returns shared permissions if the saved level is "shared"', () => {
+      assert.deepEqual(
+        permissions.defaultPermissions(userid, 'gid', 'shared'),
+        permissions.sharedPermissions(userid, 'gid')
+      );
+    });
+  });
+
+  describe('#isShared', () => {
+    it('returns true if a group can read the annotation', () => {
+      const perms = permissions.sharedPermissions(userid, 'gid');
+      assert.isTrue(permissions.isShared(perms));
+    });
+
+    it('returns false if only specific users can read the annotation', () => {
+      const perms = permissions.privatePermissions(userid);
+      assert.isFalse(permissions.isShared(perms));
+    });
+  });
+
+  describe('#isPrivate', () => {
+    it('returns true if only specific users can read the annotation', () => {
+      const perms = permissions.privatePermissions(userid);
+      assert.isTrue(permissions.isPrivate(perms));
+    });
+
+    it('returns false if a group can read the annotation', () => {
+      const perms = permissions.sharedPermissions(userid, 'gid');
+      assert.isFalse(permissions.isPrivate(perms));
+    });
+  });
+
+  describe('#permits', () => {
+    it('returns true if the user can perform the indicated action', () => {
+      const perms = permissions.privatePermissions(userid);
+      assert.isTrue(permissions.permits(perms, 'update', userid));
+      assert.isTrue(permissions.permits(perms, 'delete', userid));
+    });
+
+    it('returns false if the user cannot perform the action', () => {
+      const perms = permissions.privatePermissions('acct:not.flash@gord.on');
+      assert.isFalse(permissions.permits(perms, 'update', userid));
+      assert.isFalse(permissions.permits(perms, 'delete', userid));
+    });
+  });
+});


### PR DESCRIPTION
This PR follows on from #1685 and removes `permissions` initialization from components and moves it into the `createAnnotation` action in the store, where it finds a better home.

The new `permissions` util is basically a modernized `permissions` service, minus dependencies. I've also added an `isPrivate` function because it seemed useful.

This PR also updates the "modern" (i.e. preact) components to favor the util instead of the service.

The idea here is that the `permissions` service will die as soon as we've migrated remaining uses of it out of the legacy `Annotation` controller—rewriting that code now would be fairly futile as its life expectancy is on the order of days or weeks.

Phew, with this, there is no longer any annotation-object muddling happening in the `annotation` component.

Part of #1650 