### PR TITLE
Convert src/shared/{polyfills, test, settings.js} to ES modules

### DIFF
--- a/src/shared/polyfills/document.evaluate.js
+++ b/src/shared/polyfills/document.evaluate.js
@@ -1,2 +1,3 @@
-const wgxpath = require('wicked-good-xpath');
+import * as wgxpath from 'wicked-good-xpath';
+
 wgxpath.install();

--- a/src/shared/polyfills/es2015.js
+++ b/src/shared/polyfills/es2015.js
@@ -3,16 +3,16 @@
 // nb. The imports which add entire classes (Promise, Set etc.) will also add
 // all features for later ES years, so this can result in some duplication with
 // bundles for later ES years.
-require('core-js/es/promise');
-require('core-js/es/map');
-require('core-js/es/number');
-require('core-js/es/set');
-require('core-js/es/symbol');
-require('core-js/es/array/fill');
-require('core-js/es/array/find');
-require('core-js/es/array/find-index');
-require('core-js/es/array/from');
-require('core-js/es/object/assign');
-require('core-js/es/string/includes');
-require('core-js/es/string/ends-with');
-require('core-js/es/string/starts-with');
+import 'core-js/es/promise';
+import 'core-js/es/map';
+import 'core-js/es/number';
+import 'core-js/es/set';
+import 'core-js/es/symbol';
+import 'core-js/es/array/fill';
+import 'core-js/es/array/find';
+import 'core-js/es/array/find-index';
+import 'core-js/es/array/from';
+import 'core-js/es/object/assign';
+import 'core-js/es/string/includes';
+import 'core-js/es/string/ends-with';
+import 'core-js/es/string/starts-with';

--- a/src/shared/polyfills/es2016.js
+++ b/src/shared/polyfills/es2016.js
@@ -1,1 +1,1 @@
-require('core-js/es/array/includes');
+import 'core-js/es/array/includes';

--- a/src/shared/polyfills/es2017.js
+++ b/src/shared/polyfills/es2017.js
@@ -1,2 +1,2 @@
-require('core-js/es/object/entries');
-require('core-js/es/object/values');
+import 'core-js/es/object/entries';
+import 'core-js/es/object/values';

--- a/src/shared/polyfills/fetch.js
+++ b/src/shared/polyfills/fetch.js
@@ -1,1 +1,1 @@
-require('whatwg-fetch');
+import 'whatwg-fetch';

--- a/src/shared/polyfills/index.js
+++ b/src/shared/polyfills/index.js
@@ -95,7 +95,7 @@ const needsPolyfill = {
  * Return the subset of polyfill sets from `needed`  which are needed by the
  * current browser.
  */
-function requiredPolyfillSets(needed) {
+export function requiredPolyfillSets(needed) {
   return needed.filter(set => {
     const checker = needsPolyfill[set];
     if (!checker) {
@@ -104,7 +104,3 @@ function requiredPolyfillSets(needed) {
     return checker();
   });
 }
-
-module.exports = {
-  requiredPolyfillSets,
-};

--- a/src/shared/polyfills/string.prototype.normalize.js
+++ b/src/shared/polyfills/string.prototype.normalize.js
@@ -1,1 +1,1 @@
-require('unorm');
+import 'unorm';

--- a/src/shared/polyfills/test/index-test.js
+++ b/src/shared/polyfills/test/index-test.js
@@ -1,4 +1,4 @@
-const { requiredPolyfillSets } = require('../');
+import { requiredPolyfillSets } from '../';
 
 function stubOut(obj, property, replacement = undefined) {
   const saved = obj[property];

--- a/src/shared/polyfills/url.js
+++ b/src/shared/polyfills/url.js
@@ -1,1 +1,1 @@
-require('js-polyfills/url');
+import 'js-polyfills/url';

--- a/src/shared/settings.js
+++ b/src/shared/settings.js
@@ -25,7 +25,7 @@ function assign(dest, src) {
  *
  * @param {Document|Element} document - The root element to search.
  */
-function jsonConfigsFrom(document) {
+export function jsonConfigsFrom(document) {
   const config = {};
   const settingsElements = document.querySelectorAll(
     'script.js-hypothesis-config'
@@ -47,7 +47,3 @@ function jsonConfigsFrom(document) {
 
   return config;
 }
-
-module.exports = {
-  jsonConfigsFrom: jsonConfigsFrom,
-};

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -1,5 +1,5 @@
-const Bridge = require('../bridge');
-const RPC = require('../frame-rpc');
+import Bridge from '../bridge';
+import RPC from '../frame-rpc';
 
 describe('shared.bridge', function() {
   const sandbox = sinon.createSandbox();

--- a/src/shared/test/discovery-test.js
+++ b/src/shared/test/discovery-test.js
@@ -1,4 +1,4 @@
-const Discovery = require('../discovery');
+import Discovery from '../discovery';
 
 function createWindow() {
   return {

--- a/src/shared/test/promise-util.js
+++ b/src/shared/test/promise-util.js
@@ -8,7 +8,7 @@
  * @param {Promise} promise
  * @param {string} expectedErr - Expected `message` property of error
  */
-function assertPromiseIsRejected(promise, expectedErr) {
+export function assertPromiseIsRejected(promise, expectedErr) {
   const rejectFlag = {};
   return promise
     .catch(err => {
@@ -33,7 +33,7 @@ function assertPromiseIsRejected(promise, expectedErr) {
  *
  * Consider using `assertPromiseIsRejected` instead.
  */
-function toResult(promise) {
+export function toResult(promise) {
   return promise
     .then(function(result) {
       return { result: result };
@@ -42,8 +42,3 @@ function toResult(promise) {
       return { error: err };
     });
 }
-
-module.exports = {
-  assertPromiseIsRejected,
-  toResult,
-};

--- a/src/shared/test/settings-test.js
+++ b/src/shared/test/settings-test.js
@@ -1,4 +1,4 @@
-const settings = require('../settings');
+import * as settings from '../settings';
 
 const sandbox = sinon.createSandbox();
 

--- a/src/shared/test/warn-once-test.js
+++ b/src/shared/test/warn-once-test.js
@@ -1,4 +1,4 @@
-const warnOnce = require('../warn-once');
+import warnOnce from '../warn-once';
 
 describe('warnOnce', () => {
   beforeEach(() => {


### PR DESCRIPTION
Convert all the modules under src/shared to ES modules except for those
which:

 1. Would have a default export if converted to an ES module AND
 2. Are imported by a module still written in CoffeeScript in src/annotator/

For modules which meet these criteria there is some additional work
required to make the tests for the CoffeeScript modules still work after
the conversion.