### PR TITLE
Re-factor props for `AnnotationBody` and add `AnnotationBody` to `AnnotationOmega`

### DIFF
--- a/src/sidebar/components/annotation-body.js
+++ b/src/sidebar/components/annotation-body.js
@@ -1,4 +1,4 @@
-import { createElement } from 'preact';
+import { Fragment, createElement } from 'preact';
 import { useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
@@ -32,27 +32,29 @@ export default function AnnotationBody({
     : 'Show the first few lines only';
 
   return (
-    <section className="annotation-body">
-      {!isEditing && (
-        <Excerpt
-          collapse={isCollapsed}
-          collapsedHeight={400}
-          inlineControls={false}
-          onCollapsibleChanged={setIsCollapsible}
-          onToggleCollapsed={setIsCollapsed}
-          overflowThreshold={20}
-        >
-          <MarkdownView
-            markdown={text}
-            textClass={{
-              'annotation-body__text': true,
-              'is-hidden': isHidden(annotation),
-              'has-content': text.length > 0,
-            }}
-          />
-        </Excerpt>
-      )}
-      {isEditing && <MarkdownEditor text={text} onEditText={onEditText} />}
+    <Fragment>
+      <section className="annotation-body">
+        {!isEditing && (
+          <Excerpt
+            collapse={isCollapsed}
+            collapsedHeight={400}
+            inlineControls={false}
+            onCollapsibleChanged={setIsCollapsible}
+            onToggleCollapsed={setIsCollapsed}
+            overflowThreshold={20}
+          >
+            <MarkdownView
+              markdown={text}
+              textClass={{
+                'annotation-body__text': true,
+                'is-hidden': isHidden(annotation),
+                'has-content': text.length > 0,
+              }}
+            />
+          </Excerpt>
+        )}
+        {isEditing && <MarkdownEditor text={text} onEditText={onEditText} />}
+      </section>
       {isCollapsible && !isEditing && (
         <div className="annotation-body__collapse-toggle">
           <Button
@@ -63,7 +65,7 @@ export default function AnnotationBody({
           />
         </div>
       )}
-    </section>
+    </Fragment>
   );
 }
 

--- a/src/sidebar/components/annotation-omega.js
+++ b/src/sidebar/components/annotation-omega.js
@@ -4,6 +4,7 @@ import propTypes from 'prop-types';
 import useStore from '../store/use-store';
 import { quote } from '../util/annotation-metadata';
 
+import AnnotationBody from './annotation-body';
 import AnnotationHeader from './annotation-header';
 import AnnotationQuote from './annotation-quote';
 
@@ -25,6 +26,18 @@ function AnnotationOmega({
   // TODO: `isEditing` will also take into account `isSaving`
   const isEditing = !!draft;
 
+  const annotationState = () =>
+    draft || {
+      text: annotation.text,
+      tags: annotation.tags,
+      annotation,
+    };
+
+  // TODO
+  const fakeOnEditText = () => {
+    alert('TBD');
+  };
+
   return (
     <div className="annotation-omega">
       <AnnotationHeader
@@ -35,6 +48,12 @@ function AnnotationOmega({
         showDocumentInfo={showDocumentInfo}
       />
       {hasQuote && <AnnotationQuote annotation={annotation} />}
+      <AnnotationBody
+        annotation={annotation}
+        isEditing={isEditing}
+        onEditText={fakeOnEditText}
+        text={annotationState().text}
+      />
     </div>
   );
 }

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -71,14 +71,6 @@ function AnnotationController(
    * methods goes here.
    */
   this.$onInit = () => {
-    /** Determines whether controls to expand/collapse the annotation body
-     * are displayed adjacent to the tags field.
-     */
-    self.canCollapseBody = false;
-
-    /** Determines whether the annotation body should be collapsed. */
-    self.collapseBody = true;
-
     /** True if the annotation is currently being saved. */
     self.isSaving = false;
 
@@ -242,11 +234,6 @@ function AnnotationController(
     }
   };
 
-  this.toggleCollapseBody = function(event) {
-    event.stopPropagation();
-    self.collapseBody = !self.collapseBody;
-  };
-
   /**
    * @ngdoc method
    * @name annotation.AnnotationController#reply
@@ -364,23 +351,8 @@ function AnnotationController(
     return store.hasPendingDeletion(self.annotation.id);
   };
 
-  this.isHiddenByModerator = function() {
-    return self.annotation.hidden;
-  };
-
   this.isReply = function() {
     return isReply(self.annotation);
-  };
-
-  /**
-   * Sets whether or not the controls for expanding/collapsing the body of
-   * lengthy annotations should be shown.
-   */
-  this.setBodyCollapsible = function(canCollapse) {
-    if (canCollapse === self.canCollapseBody) {
-      return;
-    }
-    self.canCollapseBody = canCollapse;
   };
 
   this.setText = function(text) {

--- a/src/sidebar/components/excerpt.js
+++ b/src/sidebar/components/excerpt.js
@@ -77,7 +77,7 @@ function Excerpt({
     // prettier-ignore
     const isCollapsible =
       newContentHeight > (collapsedHeight + overflowThreshold);
-    onCollapsibleChanged({ collapsible: isCollapsible });
+    onCollapsibleChanged(isCollapsible);
   }, [collapsedHeight, onCollapsibleChanged, overflowThreshold]);
 
   useLayoutEffect(() => {

--- a/src/sidebar/components/test/annotation-body-test.js
+++ b/src/sidebar/components/test/annotation-body-test.js
@@ -1,5 +1,8 @@
 import { mount } from 'enzyme';
 import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
+
+import * as fixtures from '../../test/annotation-fixtures';
 
 import AnnotationBody from '../annotation-body';
 import { $imports } from '../annotation-body';
@@ -8,7 +11,14 @@ import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationBody', () => {
   function createBody(props = {}) {
-    return mount(<AnnotationBody text="test comment" {...props} />);
+    return mount(
+      <AnnotationBody
+        annotation={fixtures.defaultAnnotation()}
+        isEditing={false}
+        text="test comment"
+        {...props}
+      />
+    );
   }
 
   beforeEach(() => {
@@ -29,5 +39,54 @@ describe('AnnotationBody', () => {
     const wrapper = createBody({ isEditing: true });
     assert.isTrue(wrapper.exists('MarkdownEditor'));
     assert.isFalse(wrapper.exists('MarkdownView'));
+  });
+
+  it('does not render controls to expand/collapse the excerpt if it is not collapsible', () => {
+    const wrapper = createBody();
+
+    // By default, `isCollapsible` is `false` until changed by `Excerpt`,
+    // so the expand/collapse button will not render
+    assert.notOk(wrapper.find('Button').exists());
+  });
+
+  it('renders controls to expand/collapse the excerpt if it is collapsible', () => {
+    const wrapper = createBody();
+    const excerpt = wrapper.find('Excerpt');
+
+    act(() => {
+      // change the `isCollapsible` state to `true` via the `Excerpt`
+      excerpt.props().onCollapsibleChanged(true);
+    });
+    wrapper.update();
+
+    const button = wrapper.find('Button');
+    assert.isOk(button.exists());
+    assert.equal(button.props().buttonText, 'More');
+    assert.equal(button.props().title, 'Show full annotation text');
+  });
+
+  it('shows appropriate button text to collapse the Excerpt if expanded', () => {
+    const wrapper = createBody();
+    const excerpt = wrapper.find('Excerpt');
+
+    act(() => {
+      // Get the `isCollapsible` state to `true`
+      excerpt.props().onCollapsibleChanged(true);
+      // Force a re-render so the button shows up
+    });
+    wrapper.update();
+
+    act(() => {
+      wrapper
+        .find('Button')
+        .props()
+        .onClick();
+    });
+    wrapper.update();
+
+    const buttonProps = wrapper.find('Button').props();
+
+    assert.equal(buttonProps.buttonText, 'Less');
+    assert.equal(buttonProps.title, 'Show the first few lines only');
   });
 });

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -123,12 +123,8 @@ describe('annotation', function() {
         .component('annotation', annotationComponent)
         .component('annotationBody', {
           bindings: {
-            collapse: '<',
             isEditing: '<',
-            isHiddenByModerator: '<',
-            onCollapsibleChanged: '&',
             onEditText: '&',
-            onToggleCollapsed: '&',
             text: '<',
           },
         })
@@ -805,36 +801,6 @@ describe('annotation', function() {
         sandbox.spy($rootScope, '$broadcast');
         controller.revert();
         assert.calledWith($rootScope.$broadcast, events.ANNOTATION_DELETED);
-      });
-    });
-
-    [
-      {
-        context: 'for moderators',
-        ann: Object.assign(fixtures.moderatedAnnotation({ hidden: true }), {
-          // Content still present.
-          text: 'Some offensive content',
-        }),
-        isHiddenByModerator: true,
-      },
-      {
-        context: 'for non-moderators',
-        ann: Object.assign(fixtures.moderatedAnnotation({ hidden: true }), {
-          // Content filtered out by service.
-          tags: [],
-          text: '',
-        }),
-        isHiddenByModerator: true,
-      },
-    ].forEach(({ ann, context, isHiddenByModerator }) => {
-      it(`passes moderation status to annotation body (${context})`, () => {
-        const el = createDirective(ann).element;
-        assert.match(
-          el.find('annotation-body').controller('annotationBody'),
-          sinon.match({
-            isHiddenByModerator,
-          })
-        );
       });
     });
   });

--- a/src/sidebar/components/test/excerpt-test.js
+++ b/src/sidebar/components/test/excerpt-test.js
@@ -101,7 +101,7 @@ describe('Excerpt', () => {
       sizeChangedCallback();
     });
 
-    assert.calledWith(onCollapsibleChanged, { collapsible: true });
+    assert.calledWith(onCollapsibleChanged, true);
   });
 
   it('calls `onToggleCollapsed` when user clicks in bottom area to expand excerpt', () => {

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -15,22 +15,12 @@
   </annotation-quote>
 
   <annotation-body
-    collapse="vm.collapseBody"
+    annotation="vm.annotation"
     is-editing="vm.editing()"
-    is-hidden-by-moderator="vm.isHiddenByModerator()"
-    on-collapsible-changed="vm.setBodyCollapsible(collapsible)"
     on-edit-text="vm.setText(text)"
-    on-toggle-collapsed="vm.collapseBody = collapsed"
     text="vm.state().text">
   </annotation-body>
 
-  <div class="annotation-link-more">
-    <a class="annotation-link u-strong" ng-show="vm.canCollapseBody && !vm.editing()"
-      ng-click="vm.toggleCollapseBody($event)"
-      ng-title="vm.collapseBody ? 'Show the full annotation text' : 'Show the first few lines only'"
-      ng-bind="vm.collapseBody ? 'More' : 'Less'"
-      h-branding="accentColor">more</a>
-  </div>
   <!-- Tags -->
   <tag-editor
     ng-if="vm.editing()"

--- a/src/sidebar/util/annotation-metadata.js
+++ b/src/sidebar/util/annotation-metadata.js
@@ -150,6 +150,16 @@ export function isWaitingToAnchor(annotation) {
 }
 
 /**
+ * Has this annotation hidden by moderators?
+ *
+ * @param {Object} annotation
+ * @return {boolean}
+ */
+export function isHidden(annotation) {
+  return !!annotation.hidden;
+}
+
+/**
  * Is this annotation a highlight?
  *
  * Highlights are generally identifiable by having no text content AND no tags,

--- a/src/sidebar/util/test/annotation-metadata-test.js
+++ b/src/sidebar/util/test/annotation-metadata-test.js
@@ -234,6 +234,24 @@ describe('annotation-metadata', function() {
     });
   });
 
+  describe('.isHidden', () => {
+    it('returns `true` if annotation has been hidden', () => {
+      const annotation = fixtures.moderatedAnnotation({ hidden: true });
+      assert.isTrue(annotationMetadata.isHidden(annotation));
+    });
+
+    [
+      fixtures.newEmptyAnnotation(),
+      fixtures.newReply(),
+      fixtures.newHighlight(),
+      fixtures.oldAnnotation(),
+    ].forEach(nonHiddenAnnotation => {
+      it('returns `false` if annotation is not hidden', () => {
+        assert.isFalse(annotationMetadata.isHidden(nonHiddenAnnotation));
+      });
+    });
+  });
+
   describe('.isHighlight', () => {
     [
       {

--- a/src/styles/sidebar/components/annotation-body.scss
+++ b/src/styles/sidebar/components/annotation-body.scss
@@ -6,9 +6,11 @@
   // Margin between top of ascent of annotation body and
   // bottom of ascent of annotation-quote should be ~15px.
   margin-top: var.$layout-h-margin - 5px;
-  margin-bottom: var.$layout-h-margin;
   margin-right: 0px;
   margin-left: 0px;
+  .annotation-body__collapse-toggle-button {
+    background-color: transparent;
+  }
 }
 
 .annotation-body__text {
@@ -35,4 +37,10 @@
       white 20px
     );
   }
+}
+
+.annotation-body__collapse-toggle {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.5em 0;
 }

--- a/src/styles/sidebar/components/annotation-body.scss
+++ b/src/styles/sidebar/components/annotation-body.scss
@@ -6,11 +6,9 @@
   // Margin between top of ascent of annotation body and
   // bottom of ascent of annotation-quote should be ~15px.
   margin-top: var.$layout-h-margin - 5px;
+  margin-bottom: var.$layout-h-margin;
   margin-right: 0px;
   margin-left: 0px;
-  .annotation-body__collapse-toggle-button {
-    background-color: transparent;
-  }
 }
 
 .annotation-body__text {
@@ -40,7 +38,12 @@
 }
 
 .annotation-body__collapse-toggle {
+  // Negative top margin to bring this up tight under `.annotation-body`
+  margin-top: -(var.$layout-h-margin - 5px);
   display: flex;
   justify-content: flex-end;
-  padding: 0.5em 0;
+
+  .annotation-body__collapse-toggle-button {
+    background-color: transparent;
+  }
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -20,7 +20,7 @@ $grey-4: #a6a6a6;
 // minus blue tint.
 $grey-semi: #9c9c9c;
 
-$grey-5: #7a7a7a;
+$grey-5: #767676;
 
 // Interim color variable for migration purposes, as the step between `$grey-5`
 // and `$grey-6` is large. Represents `base-mid` in proposed future palette,


### PR DESCRIPTION
This PR primarily moves some props around vis-a-vis `AnnotationBody` such that `Annotation` doesn't have to manage `Excerpt`'s state (its grandchild) via `AnnotationBody`. This allows for a simpler integration of `AnnotationBody` into `Annotation`.

This PR also makes a global change to `$grey-5`, making it a few ticks darker to be compliant with WCAG contrast-ratio requirements.

The new `More/Less` controls for expanding/collapsing excerpts in this PR are WCAG-compliant for contrast ratio.

Screen shot of new/more contrasty controls as of this PR:

![image](https://user-images.githubusercontent.com/439947/72738294-4566e000-3b6f-11ea-98ea-89892e12bf6a.png)


Part of #1650
Related to https://github.com/hypothesis/product-backlog/issues/1085