### PR TITLE
Convert remaining CommonJS modules to ES modules

### DIFF
--- a/src/annotator/annotation-counts.js
+++ b/src/annotator/annotation-counts.js
@@ -1,4 +1,4 @@
-const events = require('../shared/bridge-events');
+import events from '../shared/bridge-events';
 
 const ANNOTATION_COUNT_ATTR = 'data-hypothesis-annotation-count';
 
@@ -10,7 +10,7 @@ const ANNOTATION_COUNT_ATTR = 'data-hypothesis-annotation-count';
  * display annotation count.
  */
 
-function annotationCounts(rootEl, crossframe) {
+export default function annotationCounts(rootEl, crossframe) {
   crossframe.on(
     events.PUBLIC_ANNOTATION_COUNT_CHANGED,
     updateAnnotationCountElems
@@ -23,5 +23,3 @@ function annotationCounts(rootEl, crossframe) {
     });
   }
 }
-
-module.exports = annotationCounts;

--- a/src/annotator/annotation-sync.js
+++ b/src/annotator/annotation-sync.js
@@ -3,7 +3,7 @@
 //
 // It also listens for events from Guest when new annotations are created or
 // annotations successfully anchor and relays these to the sidebar app.
-function AnnotationSync(bridge, options) {
+export default function AnnotationSync(bridge, options) {
   const self = this;
 
   this.bridge = bridge;
@@ -174,5 +174,3 @@ AnnotationSync.prototype._format = function(ann) {
     msg: ann,
   };
 };
-
-module.exports = AnnotationSync;

--- a/src/annotator/features.js
+++ b/src/annotator/features.js
@@ -1,5 +1,5 @@
-const events = require('../shared/bridge-events');
-const warnOnce = require('../shared/warn-once');
+import events from '../shared/bridge-events';
+import warnOnce from '../shared/warn-once';
 
 let _features = {};
 
@@ -7,7 +7,7 @@ const _set = features => {
   _features = features || {};
 };
 
-module.exports = {
+export default {
   init: function(crossframe) {
     crossframe.on(events.FEATURE_FLAGS_UPDATED, _set);
   },

--- a/src/annotator/frame-observer.js
+++ b/src/annotator/frame-observer.js
@@ -7,7 +7,7 @@ let difference = (arrayA, arrayB) => {
   return arrayA.filter(x => !arrayB.includes(x));
 };
 
-const DEBOUNCE_WAIT = 40;
+export const DEBOUNCE_WAIT = 40;
 
 export default class FrameObserver {
   constructor(target) {
@@ -71,5 +71,3 @@ export default class FrameObserver {
     }
   }
 }
-
-FrameObserver.DEBOUNCE_WAIT = DEBOUNCE_WAIT;

--- a/src/annotator/frame-observer.js
+++ b/src/annotator/frame-observer.js
@@ -1,5 +1,6 @@
-let FrameUtil = require('./util/frame-util');
-let debounce = require('lodash.debounce');
+import debounce from 'lodash.debounce';
+
+import * as FrameUtil from './util/frame-util';
 
 // Find difference of two arrays
 let difference = (arrayA, arrayB) => {
@@ -8,7 +9,7 @@ let difference = (arrayA, arrayB) => {
 
 const DEBOUNCE_WAIT = 40;
 
-class FrameObserver {
+export default class FrameObserver {
   constructor(target) {
     this._target = target;
     this._handledFrames = [];
@@ -70,6 +71,5 @@ class FrameObserver {
     }
   }
 }
-FrameObserver.DEBOUNCE_WAIT = DEBOUNCE_WAIT;
 
-module.exports = FrameObserver;
+FrameObserver.DEBOUNCE_WAIT = DEBOUNCE_WAIT;

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -10,7 +10,7 @@ adder = require('./adder')
 htmlAnchoring = require('./anchoring/html')
 highlighter = require('./highlighter')
 rangeUtil = require('./range-util')
-selections = require('./selections')
+{ default: selections } = require('./selections')
 xpathRange = require('./anchoring/range')
 { normalizeURI } = require('./util/url')
 

--- a/src/annotator/pdfjs-rendering-states.js
+++ b/src/annotator/pdfjs-rendering-states.js
@@ -12,4 +12,4 @@ const RenderingStates = {
   FINISHED: 3,
 };
 
-module.exports = RenderingStates;
+export default RenderingStates;

--- a/src/annotator/plugin/cross-frame.coffee
+++ b/src/annotator/plugin/cross-frame.coffee
@@ -1,10 +1,10 @@
 Plugin = require('../plugin')
 
-AnnotationSync = require('../annotation-sync')
-Bridge = require('../../shared/bridge')
-Discovery = require('../../shared/discovery')
+{ default: AnnotationSync } = require('../annotation-sync')
+{ default: Bridge } = require('../../shared/bridge')
+{ default: Discovery } = require('../../shared/discovery')
 FrameUtil = require('../util/frame-util')
-FrameObserver = require('../frame-observer')
+{ default: FrameObserver } = require('../frame-observer')
 
 # Extracts individual keys from an object and returns a new one.
 extract = extract = (obj, keys...) ->

--- a/src/annotator/plugin/pdf.coffee
+++ b/src/annotator/plugin/pdf.coffee
@@ -1,6 +1,6 @@
 Plugin = require('../plugin')
 
-RenderingStates = require('../pdfjs-rendering-states')
+{ default: RenderingStates } = require('../pdfjs-rendering-states')
 
 module.exports = class PDF extends Plugin
   documentLoaded: null

--- a/src/annotator/selections.js
+++ b/src/annotator/selections.js
@@ -1,4 +1,4 @@
-const observable = require('./util/observable');
+import * as observable from './util/observable';
 
 /** Returns the selected `DOMRange` in `document`. */
 function selectedRange(document) {
@@ -21,7 +21,7 @@ function selectedRange(document) {
  *
  * @return Observable<DOMRange|null>
  */
-function selections(document) {
+export default function selections(document) {
   // Get a stream of selection changes that occur whilst the user is not
   // making a selection with the mouse.
   let isMouseDown;
@@ -54,5 +54,3 @@ function selections(document) {
     return selectedRange(document);
   });
 }
-
-module.exports = selections;

--- a/src/annotator/sidebar-trigger.js
+++ b/src/annotator/sidebar-trigger.js
@@ -8,7 +8,7 @@ const SIDEBAR_TRIGGER_BTN_ATTR = 'data-hypothesis-trigger';
  * @param {Object} showFn - Function which shows the sidebar.
  */
 
-function trigger(rootEl, showFn) {
+export default function trigger(rootEl, showFn) {
   const triggerElems = rootEl.querySelectorAll(
     '[' + SIDEBAR_TRIGGER_BTN_ATTR + ']'
   );
@@ -22,5 +22,3 @@ function trigger(rootEl, showFn) {
     event.stopPropagation();
   }
 }
-
-module.exports = trigger;

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -3,10 +3,10 @@ raf = require('raf')
 Hammer = require('hammerjs')
 
 Host = require('./host')
-annotationCounts = require('./annotation-counts')
-sidebarTrigger = require('./sidebar-trigger')
-events = require('../shared/bridge-events')
-features = require('./features')
+{ default: annotationCounts } = require('./annotation-counts')
+{ default: sidebarTrigger } = require('./sidebar-trigger')
+{ default: events } = require('../shared/bridge-events')
+{ default: features } = require('./features')
 
 # Minimum width to which the frame can be resized.
 MIN_RESIZE = 280

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -1,4 +1,4 @@
-events = require('../../shared/bridge-events')
+{ default: events } = require('../../shared/bridge-events')
 
 Sidebar = require('../sidebar')
 { $imports } = require('../sidebar')

--- a/src/shared/bridge-events.js
+++ b/src/shared/bridge-events.js
@@ -2,7 +2,7 @@
  * This module defines the set of global events that are dispatched
  * across the bridge between the sidebar and annotator
  */
-module.exports = {
+export default {
   // Events that the sidebar sends to the annotator
   // ----------------------------------------------
 

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -1,12 +1,12 @@
-const extend = require('extend');
+import extend from 'extend';
 
-const RPC = require('./frame-rpc');
+import RPC from './frame-rpc';
 
 /**
  * The Bridge service sets up a channel between frames and provides an events
  * API on top of it.
  */
-class Bridge {
+export default class Bridge {
   constructor() {
     this.links = [];
     this.channelListeners = {};
@@ -167,5 +167,3 @@ class Bridge {
     return this;
   }
 }
-
-module.exports = Bridge;

--- a/src/shared/discovery.js
+++ b/src/shared/discovery.js
@@ -30,7 +30,7 @@
  * 5. Clients listen for "ack" messages. When they receive one from a server
  *    they call the callback to `startDiscovery`.
  */
-class Discovery {
+export default class Discovery {
   /**
    * @param {Window} target
    * @param {Object} options
@@ -227,5 +227,3 @@ class Discovery {
       .replace(/\D/g, '');
   }
 }
-
-module.exports = Discovery;

--- a/src/shared/frame-rpc.js
+++ b/src/shared/frame-rpc.js
@@ -29,9 +29,7 @@
 
 const VERSION = '1.0.0';
 
-module.exports = RPC;
-
-function RPC(src, dst, origin, methods) {
+export default function RPC(src, dst, origin, methods) {
   if (!(this instanceof RPC)) return new RPC(src, dst, origin, methods);
   const self = this;
   this.src = src;

--- a/src/shared/warn-once.js
+++ b/src/shared/warn-once.js
@@ -11,7 +11,7 @@ let shownWarnings = {};
  *   are concatenated into a string key which is used to determine if the warning
  *   has been logged before.
  */
-function warnOnce(...args) {
+export default function warnOnce(...args) {
   const key = args.join();
   if (key in shownWarnings) {
     return;
@@ -23,5 +23,3 @@ function warnOnce(...args) {
 warnOnce.reset = () => {
   shownWarnings = {};
 };
-
-module.exports = warnOnce;

--- a/src/sidebar/services/test/persisted-defaults-test.js
+++ b/src/sidebar/services/test/persisted-defaults-test.js
@@ -1,5 +1,4 @@
 import fakeReduxStore from '../../test/fake-redux-store';
-
 import persistedDefaults from '../persisted-defaults';
 
 const DEFAULT_KEYS = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,9 +1443,9 @@ babel-plugin-istanbul@^6.0.0:
     test-exclude "^6.0.0"
 
 babel-plugin-mockable-imports@^1.5.1:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-mockable-imports/-/babel-plugin-mockable-imports-1.5.2.tgz#bd2095f0c10496ca74de236a7ee096b0062abb74"
-  integrity sha512-R2UdySrsMaOr/6Jrj27V5Ryy6Gpt7d398fggqtZ3fd1/OF2rpJcb9ymjbGx2NLm4P9NQyvqAU570YtgWmA71RA==
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-mockable-imports/-/babel-plugin-mockable-imports-1.6.0.tgz#ae8c817327bc84a6258915456934d7d8d5a67999"
+  integrity sha512-+CpQXtdmLBT/AaU4lM2EFwE5DnYVtHprpmzSrQls0Zd0FaHcGKJPdN10PQMachMNVh38rADXTd5TwGNMvHW85g==
 
 babel-plugin-transform-async-to-promises@^0.8.6:
   version "0.8.15"


### PR DESCRIPTION
This converts the remaining CommonJS modules under `src/` to ES modules. These modules have default exports and are imported by modules still written in CoffeeScript, so some extra changes were required:

1. The imports in CoffeeScript modules had to be changed from `foo = require("foo")` to `{ default: foo } = require("foo")`
2. The mockable-imports Babel plugin had to be updated to support the JavaScript code generated by (1)

There are still a few `require(...)` expressions in the codebase after this change. These relate to imports of HTML templates and SVG icons. The HTML templates will go away anyway as part of the Angular => Preact migration. The SVG icons we can do at a later point.