### PR TITLE
Move `export` keyword to declaration site

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -16,13 +16,13 @@ const HIGHLIGHT_BTN_SELECTOR = '.js-highlight-btn';
  * Show the adder above the selection with an arrow pointing down at the
  * selected text.
  */
-const ARROW_POINTING_DOWN = 1;
+export const ARROW_POINTING_DOWN = 1;
 
 /**
  * Show the adder above the selection with an arrow pointing up at the
  * selected text.
  */
-const ARROW_POINTING_UP = 2;
+export const ARROW_POINTING_UP = 2;
 
 function toPx(pixels) {
   return pixels.toString() + 'px';
@@ -287,5 +287,3 @@ export class Adder {
     }, 1);
   }
 }
-
-export { ARROW_POINTING_DOWN, ARROW_POINTING_UP };

--- a/src/sidebar/markdown-commands.js
+++ b/src/sidebar/markdown-commands.js
@@ -21,7 +21,7 @@
  * Types of Markdown link that can be inserted with
  * convertSelectionToLink()
  */
-const LinkType = {
+export const LinkType = {
   ANCHOR_LINK: 0,
   IMAGE_LINK: 1,
 };
@@ -264,5 +264,3 @@ export function toggleBlockStyle(state, prefix) {
     });
   }
 }
-
-export { LinkType };

--- a/src/sidebar/util/service-context.js
+++ b/src/sidebar/util/service-context.js
@@ -32,7 +32,7 @@ const fallbackInjector = {
  * Consumers will either use this directly via `useContext` or use the
  * `withServices` wrapper.
  */
-const ServiceContext = createContext(fallbackInjector);
+export const ServiceContext = createContext(fallbackInjector);
 
 /**
  * Wrap a React component to inject any services it depends upon as props.
@@ -112,5 +112,3 @@ export function useService(service) {
   const injector = useContext(ServiceContext);
   return injector.get(service);
 }
-
-export { ServiceContext };


### PR DESCRIPTION
Improve code style consistency by always putting the `export` keyword
at the site of the var/function/class declaration where possible.