### PR TITLE
Add `TagEditor`, `TagList` to `AnnotationOmega` and handle state

### DIFF
--- a/src/sidebar/components/annotation-omega.js
+++ b/src/sidebar/components/annotation-omega.js
@@ -7,6 +7,8 @@ import { quote } from '../util/annotation-metadata';
 import AnnotationBody from './annotation-body';
 import AnnotationHeader from './annotation-header';
 import AnnotationQuote from './annotation-quote';
+import TagEditor from './tag-editor';
+import TagList from './tag-list';
 
 /**
  * The "new", migrated-to-preact annotation component.
@@ -17,25 +19,23 @@ function AnnotationOmega({
   replyCount,
   showDocumentInfo,
 }) {
+  const createDraft = useStore(store => store.createDraft);
+
+  // An annotation will have a draft if it is being edited
   const draft = useStore(store => store.getDraft(annotation));
+  const tags = draft ? draft.tags : annotation.tags;
+  const text = draft ? draft.text : annotation.text;
 
-  // Annotation metadata
   const hasQuote = !!quote(annotation);
+  const isSaving = false;
+  const isEditing = !!draft && !isSaving;
 
-  // Local component state
-  // TODO: `isEditing` will also take into account `isSaving`
-  const isEditing = !!draft;
+  const onEditTags = ({ tags }) => {
+    createDraft(annotation, { ...draft, tags });
+  };
 
-  const annotationState = () =>
-    draft || {
-      text: annotation.text,
-      tags: annotation.tags,
-      annotation,
-    };
-
-  // TODO
-  const fakeOnEditText = () => {
-    alert('TBD');
+  const onEditText = ({ text }) => {
+    createDraft(annotation, { ...draft, text });
   };
 
   return (
@@ -51,9 +51,11 @@ function AnnotationOmega({
       <AnnotationBody
         annotation={annotation}
         isEditing={isEditing}
-        onEditText={fakeOnEditText}
-        text={annotationState().text}
+        onEditText={onEditText}
+        text={text}
       />
+      {isEditing && <TagEditor onEditTags={onEditTags} tagList={tags} />}
+      {!isEditing && <TagList annotation={annotation} tags={tags} />}
     </div>
   );
 }

--- a/src/sidebar/test/annotation-fixtures.js
+++ b/src/sidebar/test/annotation-fixtures.js
@@ -16,12 +16,15 @@ export function defaultAnnotation() {
 }
 
 /**
- * Return a fake annotation created by a third-party user.
+ * Return a fake draft based on a default annotation.
  */
-export function thirdPartyAnnotation() {
-  return Object.assign(defaultAnnotation(), {
-    user: 'acct:ben@publisher.org',
-  });
+export function defaultDraft() {
+  return {
+    annotation: defaultAnnotation(),
+    text: '',
+    tags: [],
+    isPrivate: false,
+  };
 }
 
 /**


### PR DESCRIPTION
This PR adds `TagList` and `TagEditor` to `AnnotationOmega`. It also adds a new action to the `drafts` store module for retrieving the current "state" of an annotation, reproducing logic that was handled within the `Annotation` component itself previously. It also fills in more tests for `AnnotationOmega`.

Changes are confined to `AnnotationOmega`, which is only visible behind a feature flag.

Part of #1650 