### PR TITLE
Minor change to tag-editor class names

### DIFF
--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -183,14 +183,14 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
   return (
     <section className="tag-editor">
       <ul
-        className="tag-editor__tag-list"
+        className="tag-editor__tags"
         aria-label="Suggested tags for annotation"
       >
         {tagList.map(tag => {
           return (
             <li
               key={`${tag}`}
-              className="tag-editor__tag-item"
+              className="tag-editor__item"
               aria-label={`Tag: ${tag}`}
             >
               <span className="tag-editor__edit">{tag}</span>

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -60,7 +60,7 @@ describe('TagEditor', function() {
   it('adds appropriate tag values to the elements', () => {
     const wrapper = createComponent();
     wrapper.find('li').forEach((tag, i) => {
-      assert.isTrue(tag.hasClass('tag-editor__tag-item'));
+      assert.isTrue(tag.hasClass('tag-editor__item'));
       assert.equal(tag.text(), fakeTags[i]);
       assert.equal(tag.prop('aria-label'), `Tag: ${fakeTags[i]}`);
     });

--- a/src/styles/sidebar/components/tag-editor.scss
+++ b/src/styles/sidebar/components/tag-editor.scss
@@ -8,12 +8,12 @@
     width: 100%;
   }
 
-  &__tag-list {
+  &__tags {
     display: flex;
     flex-wrap: wrap;
   }
 
-  &__tag-item {
+  &__item {
     display: flex;
     margin-right: 0.5em;
     margin-bottom: 0.5em;


### PR DESCRIPTION
Addressing confusion from slack question. https://hypothes-is.slack.com/archives/C1M8NH76X/p1579618641023500
I think the class names used created confusion and this is an attempt to clean that up.

- rename -“tag-editor__tag-list” to “tag-editor__tags” to avoid confusion between TagList component and TagEditor’s tag list class name
- rename “tag-editor__tag-item” to tag-editor__item” to match style of TagList’s “tag-list__item” class