### PR TITLE
Add some initial footer components to `AnnotationOmega`

### DIFF
--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -156,8 +156,11 @@ describe('sidebar.frame-sync', function() {
     });
 
     it('sends a "publicAnnotationCountChanged" message to the frame when there are only private annotations', function() {
+      const annot = annotationFixtures.defaultAnnotation();
+      delete annot.permissions;
+
       fakeStore.setState({
-        annotations: { annotations: [annotationFixtures.defaultAnnotation()] },
+        annotations: { annotations: [annot] },
       });
       assert.calledWithMatch(
         fakeBridge.call,

--- a/src/sidebar/test/annotation-fixtures.js
+++ b/src/sidebar/test/annotation-fixtures.js
@@ -8,7 +8,12 @@ export function defaultAnnotation() {
     document: {
       title: 'A special document',
     },
+    permissions: {
+      read: ['group:__world__'],
+    },
+    tags: [],
     target: [{ source: 'source', selector: [] }],
+    text: '',
     uri: 'http://example.com',
     user: 'acct:bill@localhost',
     updated: '2015-05-10T20:18:56.613388+00:00',

--- a/src/sidebar/util/test/annotation-metadata-test.js
+++ b/src/sidebar/util/test/annotation-metadata-test.js
@@ -371,7 +371,9 @@ describe('annotation-metadata', function() {
     });
 
     it('returns false if an annotation is missing permissions', function() {
-      assert.isFalse(annotationMetadata.isPublic(fixtures.defaultAnnotation()));
+      const annot = fixtures.defaultAnnotation();
+      delete annot.permissions;
+      assert.isFalse(annotationMetadata.isPublic(annot));
     });
   });
 


### PR DESCRIPTION
Chug chug chug! It keeps coming, making good progress here overall.

This PR adds some footer components within the `AnnotationOmega` component. I've left some of the callbacks unimplemented for now (those should be obvious from the code).

There are some updates to the "default" annotation fixture here, as well, to better align with what an annotation looks like to components.

No user-visible changes here.

Part of #1650 
