### PR TITLE
Move more annotation-related state logic into sub-components, store

### DIFF
--- a/src/sidebar/components/annotation-action-bar.js
+++ b/src/sidebar/components/annotation-action-bar.js
@@ -3,7 +3,7 @@ import propTypes from 'prop-types';
 
 import useStore from '../store/use-store';
 import { isShareable, shareURI } from '../util/annotation-sharing';
-import { permits } from '../util/permissions';
+import { isPrivate, permits } from '../util/permissions';
 import { withServices } from '../util/service-context';
 
 import AnnotationShareControl from './annotation-share-control';
@@ -17,7 +17,6 @@ function AnnotationActionBar({
   annotation,
   annotationMapper,
   flash,
-  onEdit,
   onReply,
   settings,
 }) {
@@ -37,6 +36,7 @@ function AnnotationActionBar({
   const showFlagAction = userProfile.userid !== annotation.user;
   const showShareAction = isShareable(annotation, settings);
 
+  const createDraft = useStore(store => store.createDraft);
   const updateFlagFn = useStore(store => store.updateFlagStatus);
 
   const updateFlag = () => {
@@ -49,6 +49,14 @@ function AnnotationActionBar({
         flash.error(err.message, 'Deleting annotation failed');
       });
     }
+  };
+
+  const onEdit = () => {
+    createDraft(annotation, {
+      tags: annotation.tags,
+      text: annotation.text,
+      isPrivate: isPrivate(annotation.permissions),
+    });
   };
 
   const onFlag = () => {
@@ -100,7 +108,6 @@ function AnnotationActionBar({
 AnnotationActionBar.propTypes = {
   annotation: propTypes.object.isRequired,
   /** Callbacks for when action buttons are clicked/tapped */
-  onEdit: propTypes.func.isRequired,
   onReply: propTypes.func.isRequired,
 
   // Injected services

--- a/src/sidebar/components/annotation-omega.js
+++ b/src/sidebar/components/annotation-omega.js
@@ -2,7 +2,7 @@ import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import useStore from '../store/use-store';
-import { isNew, isReply, quote } from '../util/annotation-metadata';
+import { isNew, quote } from '../util/annotation-metadata';
 import { isShared } from '../util/permissions';
 
 import AnnotationActionBar from './annotation-action-bar';
@@ -24,7 +24,6 @@ function AnnotationOmega({
   showDocumentInfo,
 }) {
   const createDraft = useStore(store => store.createDraft);
-  const setDefault = useStore(store => store.setDefault);
 
   // An annotation will have a draft if it is being edited
   const draft = useStore(store => store.getDraft(annotation));
@@ -50,17 +49,8 @@ function AnnotationOmega({
     createDraft(annotation, { ...draft, text });
   };
 
-  const onSetPrivacy = ({ level }) => {
-    createDraft(annotation, { ...draft, isPrivate: level === 'private' });
-    // Persist this as privacy default for future annotations unless this is a reply
-    if (!isReply(annotation)) {
-      setDefault('annotationPrivacy', level);
-    }
-  };
-
   // TODO
   const fakeOnReply = () => alert('Reply: TBD');
-  const fakeOnRevert = () => alert('Revert changes: TBD');
   const fakeOnSave = () => alert('Save changes: TBD');
 
   return (
@@ -84,12 +74,9 @@ function AnnotationOmega({
       <footer className="annotation-footer">
         {isEditing && (
           <AnnotationPublishControl
-            group={group}
+            annotation={annotation}
             isDisabled={isEmpty}
-            isShared={!isPrivate}
-            onCancel={fakeOnRevert}
             onSave={fakeOnSave}
-            onSetPrivacy={onSetPrivacy}
           />
         )}
         {shouldShowLicense && <AnnotationLicense />}

--- a/src/sidebar/components/annotation-omega.js
+++ b/src/sidebar/components/annotation-omega.js
@@ -59,7 +59,6 @@ function AnnotationOmega({
   };
 
   // TODO
-  const fakeOnEdit = () => alert('Enter edit mode: TBD');
   const fakeOnReply = () => alert('Reply: TBD');
   const fakeOnRevert = () => alert('Revert changes: TBD');
   const fakeOnSave = () => alert('Save changes: TBD');
@@ -98,7 +97,6 @@ function AnnotationOmega({
           <div className="annotation-actions">
             <AnnotationActionBar
               annotation={annotation}
-              onEdit={fakeOnEdit}
               onReply={fakeOnReply}
             />
           </div>

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -261,18 +261,6 @@ function AnnotationController(
     });
   };
 
-  /**
-   * @ngdoc method
-   * @name annotation.AnnotationController#revert
-   * @description Reverts an edit in progress and returns to the viewer.
-   */
-  this.revert = function() {
-    store.removeDraft(self.annotation);
-    if (isNew(self.annotation)) {
-      $rootScope.$broadcast(events.ANNOTATION_DELETED, self.annotation);
-    }
-  };
-
   this.save = function() {
     if (!self.annotation.user) {
       flash.info('Please log in to save your annotations.');
@@ -311,32 +299,6 @@ function AnnotationController(
         self.edit();
         flash.error(err.message, 'Saving annotation failed');
       });
-  };
-
-  /**
-   * @ngdoc method
-   * @name annotation.AnnotationController#setPrivacy
-   *
-   * Set the privacy settings on the annotation to a predefined
-   * level. The supported levels are 'private' which makes the annotation
-   * visible only to its creator and 'shared' which makes the annotation
-   * visible to everyone in the group.
-   *
-   * The changes take effect when the annotation is saved
-   */
-  this.setPrivacy = function(privacy) {
-    // When the user changes the privacy level of an annotation they're
-    // creating or editing, we cache that and use the same privacy level the
-    // next time they create an annotation.
-    // But _don't_ cache it when they change the privacy level of a reply.
-    if (!isReply(self.annotation)) {
-      permissions.setDefault(privacy);
-    }
-    store.createDraft(self.annotation, {
-      tags: self.state().tags,
-      text: self.state().text,
-      isPrivate: privacy === 'private',
-    });
   };
 
   this.user = function() {

--- a/src/sidebar/components/test/annotation-omega-test.js
+++ b/src/sidebar/components/test/annotation-omega-test.js
@@ -45,7 +45,6 @@ describe('AnnotationOmega', () => {
 
     fakeMetadata = {
       isNew: sinon.stub(),
-      isReply: sinon.stub().returns(false),
       quote: sinon.stub(),
     };
 
@@ -59,7 +58,6 @@ describe('AnnotationOmega', () => {
       getGroup: sinon.stub().returns({
         type: 'private',
       }),
-      setDefault: sinon.stub(),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -157,6 +155,18 @@ describe('AnnotationOmega', () => {
       assert.isFalse(wrapper.find('AnnotationPublishControl').exists());
     });
 
+    it('should enable the publish control if the annotation is not empty', () => {
+      const draft = fixtures.defaultDraft();
+      draft.text = 'bananas';
+      fakeStore.getDraft.returns(draft);
+
+      const wrapper = createComponent();
+
+      assert.isFalse(
+        wrapper.find('AnnotationPublishControl').props().isDisabled
+      );
+    });
+
     it('should set the publish control to disabled if annotation is empty', () => {
       const draft = fixtures.defaultDraft();
       draft.tags = [];
@@ -168,78 +178,6 @@ describe('AnnotationOmega', () => {
       assert.isTrue(
         wrapper.find('AnnotationPublishControl').props().isDisabled
       );
-    });
-
-    it('should set `isShared` to `false` if annotation is private', () => {
-      const draft = fixtures.defaultDraft();
-      draft.isPrivate = true;
-
-      fakeStore.getDraft.returns(draft);
-
-      const wrapper = createComponent();
-
-      assert.isFalse(wrapper.find('AnnotationPublishControl').props().isShared);
-    });
-
-    it('should set `isShared` to `true` if annotation is shared', () => {
-      const draft = fixtures.defaultDraft();
-      draft.isPrivate = false;
-      fakeStore.getDraft.returns(draft);
-
-      const wrapper = createComponent();
-
-      assert.isTrue(wrapper.find('AnnotationPublishControl').props().isShared);
-    });
-
-    it('should update annotation privacy when changed by publish control', () => {
-      setEditingMode(true);
-
-      const wrapper = createComponent();
-
-      act(() => {
-        wrapper
-          .find('AnnotationPublishControl')
-          .props()
-          .onSetPrivacy({ level: 'private' });
-      });
-
-      const call = fakeStore.createDraft.getCall(0);
-
-      assert.calledOnce(fakeStore.createDraft);
-      assert.isTrue(call.args[1].isPrivate);
-    });
-
-    it('should update annotation privacy default on change', () => {
-      setEditingMode(true);
-
-      const wrapper = createComponent();
-
-      act(() => {
-        wrapper
-          .find('AnnotationPublishControl')
-          .props()
-          .onSetPrivacy({ level: 'private' });
-      });
-
-      assert.calledOnce(fakeStore.setDefault);
-      assert.calledWith(fakeStore.setDefault, 'annotationPrivacy', 'private');
-    });
-
-    it('should not update annotation privacy default on change if annotation is reply', () => {
-      fakeMetadata.isReply.returns(true);
-
-      setEditingMode(true);
-
-      const wrapper = createComponent();
-
-      act(() => {
-        wrapper
-          .find('AnnotationPublishControl')
-          .props()
-          .onSetPrivacy({ level: 'private' });
-      });
-
-      assert.equal(fakeStore.setDefault.callCount, 0);
     });
   });
 

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -499,52 +499,6 @@ describe('annotation', function() {
       });
     });
 
-    describe('#setPrivacy', function() {
-      it('makes the annotation private when level is "private"', function() {
-        const parts = createDirective();
-        parts.controller.setPrivacy('private');
-        assert.calledWith(
-          fakeStore.createDraft,
-          parts.controller.annotation,
-          sinon.match({
-            isPrivate: true,
-          })
-        );
-      });
-
-      it('makes the annotation shared when level is "shared"', function() {
-        const parts = createDirective();
-        parts.controller.setPrivacy('shared');
-        assert.calledWith(
-          fakeStore.createDraft,
-          parts.controller.annotation,
-          sinon.match({
-            isPrivate: false,
-          })
-        );
-      });
-
-      it('sets the default visibility level if "shared"', function() {
-        const parts = createDirective();
-        parts.controller.edit();
-        parts.controller.setPrivacy('shared');
-        assert.calledWith(fakePermissions.setDefault, 'shared');
-      });
-
-      it('sets the default visibility if "private"', function() {
-        const parts = createDirective();
-        parts.controller.edit();
-        parts.controller.setPrivacy('private');
-        assert.calledWith(fakePermissions.setDefault, 'private');
-      });
-
-      it("doesn't save the visibility if the annotation is a reply", function() {
-        const parts = createDirective(fixtures.oldReply());
-        parts.controller.setPrivacy('private');
-        assert.notCalled(fakePermissions.setDefault);
-      });
-    });
-
     describe('#hasContent', function() {
       it('returns false if the annotation has no tags or text', function() {
         const controller = createDirective(fixtures.oldHighlight()).controller;
@@ -770,13 +724,6 @@ describe('annotation', function() {
         assert.equal(controller.state().text, 'unsaved-text');
       });
 
-      it('removes the draft when changes are discarded', function() {
-        const parts = createDirective();
-        parts.controller.edit();
-        parts.controller.revert();
-        assert.calledWith(fakeStore.removeDraft, parts.annotation);
-      });
-
       it('removes the draft when changes are saved', function() {
         const annotation = fixtures.defaultAnnotation();
         const controller = createDirective(annotation).controller;
@@ -784,23 +731,6 @@ describe('annotation', function() {
         return controller.save().then(function() {
           assert.calledWith(fakeStore.removeDraft, annotation);
         });
-      });
-    });
-
-    describe('reverting edits', function() {
-      it('removes the current draft', function() {
-        const controller = createDirective(fixtures.defaultAnnotation())
-          .controller;
-        controller.edit();
-        controller.revert();
-        assert.calledWith(fakeStore.removeDraft, controller.annotation);
-      });
-
-      it('deletes the annotation if it was new', function() {
-        const controller = createDirective(fixtures.newAnnotation()).controller;
-        sandbox.spy($rootScope, '$broadcast');
-        controller.revert();
-        assert.calledWith($rootScope.$broadcast, events.ANNOTATION_DELETED);
       });
     });
   });

--- a/src/sidebar/components/test/annotation-thread-test.js
+++ b/src/sidebar/components/test/annotation-thread-test.js
@@ -259,7 +259,7 @@ describe('annotationThread', function() {
   });
 
   describe('preact-migrated Annotation component', () => {
-    it('additionally renders `AnnotationOmega` when `client_preact_annotation` feature flag is enabled', () => {
+    it('renders `AnnotationOmega` when `client_preact_annotation` feature flag is enabled', () => {
       fakeFeatures.flagEnabled
         .withArgs('client_preact_annotation')
         .returns(true);
@@ -280,7 +280,7 @@ describe('annotationThread', function() {
         },
       });
 
-      assert.ok(element[0].querySelector('annotation'));
+      assert.notOk(element[0].querySelector('annotation'));
       assert.ok(element[0].querySelector('annotation-omega'));
     });
     it('does not render `AnnotationOmega` if `client_preact_annotation` feature flag is not enabled', () => {

--- a/src/sidebar/templates/annotation-thread.html
+++ b/src/sidebar/templates/annotation-thread.html
@@ -14,6 +14,7 @@
       annotation="vm.thread.annotation"
       ng-if="vm.thread.annotation">
     </moderation-banner>
+    <div ng-if="vm.shouldShowAnnotationOmega()"><em>Viewing AnnotationOmega</em></div>
     <annotation-omega ng-if="vm.shouldShowAnnotationOmega()"
       annotation="vm.thread.annotation"
       reply-count="vm.thread.replyCount"
@@ -26,7 +27,7 @@
              name="annotation"
              ng-mouseenter="vm.annotationHovered = true"
              ng-mouseleave="vm.annotationHovered = false"
-             ng-if="vm.thread.annotation"
+             ng-if="vm.thread.annotation && !vm.shouldShowAnnotationOmega()"
              ng-show="vm.thread.visible"
              show-document-info="vm.showDocumentInfo"
              on-reply-count-click="vm.toggleCollapsed()"

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -66,7 +66,6 @@
     <div class="annotation-actions" ng-if="!vm.isSaving && !vm.editing() && vm.id()">
       <annotation-action-bar
         annotation="vm.annotation"
-        on-edit="vm.edit()"
         on-reply="vm.reply()"></annotation-action-bar>
     </div>
   </footer>

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -41,12 +41,9 @@
 
     <div class="annotation-form-actions" ng-if="vm.editing()">
       <annotation-publish-control
-        group="vm.group()"
+        annotation="vm.annotation"
         is-disabled="!vm.hasContent()"
-        is-shared="vm.isShared()"
-        on-cancel="vm.revert()"
-        on-save="vm.save()"
-        on-set-privacy="vm.setPrivacy(level)"></annotation-publish-control>
+        on-save="vm.save()"></annotation-publish-control>
     </div>
 
     <annotation-license ng-if="vm.shouldShowLicense()"></annotation-license>


### PR DESCRIPTION
This PR continues migration of `Annotation` with some refactors to move some component state logic out of `Annotation` and into relevant components.

In addition, as of this PR, enabling the `client_preact_annotation` feature flag will show _only_ `AnnotationOmega` (NB: Not all features are implemented yet) and will disable `annotation`. This is to prevent potential contention and confusion between these two components. There is also a rendered string when viewing the `AnnotationOmega` variant to help prevent confusion (trust me, it happens easily when developing on this!)

Further details:

* ~~Auto-creation of drafts for new/unsaved annotations (except highlights) has been moved into the `createAnnotation` action in the `store` and out of the `annotation` component~~ (Removed from this PR because of a race condition in the (legacy) `annotation` controller. Will be re-addressed when implementing reply logic (which is coming up soon).
* `AnnotationPublishControl` handles its own privacy-level setting and change reversion (i.e. cancel)
* `AnnotationActionBar` handles "entering into edit mode" via creating a new draft versus a callback provided by `Annotation`

Part of #1650