### PR TITLE
Fix Menu tab focus on keyboard navigation

### DIFF
--- a/src/sidebar/components/annotation-publish-control.js
+++ b/src/sidebar/components/annotation-publish-control.js
@@ -58,9 +58,7 @@ function AnnotationPublishControl({
       <div
         className="annotation-publish-control__btn-dropdown-arrow-indicator"
         style={applyTheme(themeProps, settings)}
-      >
-        <div>▼</div>
-      </div>
+      />
     </div>
   );
 

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -126,14 +126,19 @@ export default function Menu({
         onClick={toggleMenu}
         title={title}
       >
-        {label}
-        {menuIndicator && (
-          <span
-            className={classnames('menu__toggle-arrow', isOpen && 'is-open')}
-          >
-            <SvgIcon name="expand-menu" className="menu__toggle-icon" />
-          </span>
-        )}
+        <span
+          // wrapper is needed to serve as the flex layout for the label and indicator content.
+          className="menu__toggle-wrapper"
+        >
+          {label}
+          {menuIndicator && (
+            <span
+              className={classnames('menu__toggle-arrow', isOpen && 'is-open')}
+            >
+              <SvgIcon name="expand-menu" className="menu__toggle-icon" />
+            </span>
+          )}
+        </span>
       </button>
       {isOpen && (
         <Fragment>

--- a/src/styles/sidebar/components/annotation-publish-control.scss
+++ b/src/styles/sidebar/components/annotation-publish-control.scss
@@ -16,6 +16,7 @@
     $arrow-indicator-width: 26px;
 
     height: $height;
+    display: flex;
     position: relative;
     margin-right: 1em;
 
@@ -38,22 +39,20 @@
       width: 100%;
       height: 100%;
       text-align: left;
-      padding-left: $h-padding;
-      padding-right: $arrow-indicator-width + 8px;
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
     }
 
     // dropdown arrow which reveals the button's associated menu
     // when clicked
     &-dropdown-arrow {
-      position: absolute;
+      display: flex;
+      align-items: center;
       right: 0px;
       top: 0px;
 
       height: 100%;
       width: $arrow-indicator-width;
-      padding-left: 0px;
-      padding-right: $h-padding;
-      margin-left: 8px;
 
       border: none;
       background-color: var.$grey-mid;
@@ -90,15 +89,17 @@
       // the ▼ arrow which reveals the dropdown menu when clicked
       &-indicator {
         color: $text-color;
-        position: absolute;
         left: 0px;
         right: 0px;
         top: 0px;
         bottom: 0px;
         line-height: $height;
         text-align: center;
+        width: 100%;
 
-        & > div {
+        &:after {
+          content: '▼';
+          display: inline-block;
           transform: scaleY(0.7);
         }
       }

--- a/src/styles/sidebar/components/menu.scss
+++ b/src/styles/sidebar/components/menu.scss
@@ -14,10 +14,18 @@
   background: none;
   padding: 0;
   color: inherit;
-  display: flex;
+  // "block" display is needed so it can take up the
+  //  full height of its parent container
+  display: block;
+  height: 100%;
   align-items: center;
 }
 
+.menu__toggle-wrapper {
+  display: flex;
+  align-items: center;
+  height: 100%;
+}
 .menu__toggle-icon {
   width: 10px;
   height: 10px;


### PR DESCRIPTION
This fix was a bit tricky land. My goal was to be non-invasive and make what we had work so it did not require large changes to other parts of the code that used <Menu>. In short, the keyboard navigation now correctly shows the focus state of the open menu button for publishing an annotation.

fixes https://github.com/hypothesis/client/issues/1629
![halo](https://user-images.githubusercontent.com/3939074/73090542-68560480-3e8d-11ea-9846-60695a677114.gif)
