### PR TITLE
Add Datalist component (Part 1/2)

### DIFF
--- a/src/sidebar/components/datalist.js
+++ b/src/sidebar/components/datalist.js
@@ -1,0 +1,109 @@
+import { createElement } from 'preact';
+import classnames from 'classnames';
+import { useMemo } from 'preact/hooks';
+import propTypes from 'prop-types';
+
+const defaultListFormatter = item => item;
+
+/**
+ * Custom datalist component. Use this in conjunction with an <input> field.
+ * To make this component W3 accessibility compliant, it is is intended to be
+ * coupled to an <input> field or the TagEditor component and can not be
+ * used by itself.
+ *
+ * Modeled after the "ARIA 1.1 Combobox with Listbox Popup"
+ */
+
+export default function Datalist({
+  activeItem = -1,
+  id,
+  itemPrefixId,
+  list,
+  listFormatter = defaultListFormatter,
+  onSelectItem,
+  open = false,
+}) {
+  const items = useMemo(() => {
+    return list.map((item, index) => {
+      // only add an id if itemPrefixId is passed
+      const props = itemPrefixId ? { id: `${itemPrefixId}${index}` } : {};
+
+      return (
+        // The parent <input> field should capture keyboard events
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+        <li
+          key={`datalist-${index}`}
+          role="option"
+          aria-selected={activeItem === index}
+          className={classnames(
+            {
+              'is-selected': activeItem === index,
+            },
+            'datalist__li'
+          )}
+          onClick={() => {
+            onSelectItem(item);
+          }}
+          {...props}
+        >
+          {listFormatter(item, index)}
+        </li>
+      );
+    });
+  }, [activeItem, itemPrefixId, list, listFormatter, onSelectItem]);
+
+  const props = id ? { id } : {}; // only add the id if its passed
+  return (
+    <div className="datalist">
+      {list.length > 0 && open && (
+        <ul
+          className="datalist__items"
+          tabIndex="-1"
+          aria-label="Suggestions"
+          role="listbox"
+          {...props}
+        >
+          {items}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+Datalist.propTypes = {
+  /**
+   * The index of the highlighted item.
+   */
+  activeItem: propTypes.number,
+  /**
+   * Optional unique HTML attribute id. This can be used for
+   * parent `aria-controls` coupling.
+   */
+  id: propTypes.string,
+  /**
+   * Optional unique HTML attribute id prefix for each item in the list.
+   * The final value of each items' id is `{itemPrefixId}{activeItem}`
+   */
+  itemPrefixId: propTypes.string,
+
+  /**
+   * The list of items to render. This can be a simple list of
+   * strings or a list of objects when used with listFormatter.
+   */
+  list: propTypes.array.isRequired,
+  /**
+   * An optional formatter to render each item inside an <li> tag
+   * This is useful if the list is an array of objects rather than
+   * just strings.
+   */
+  listFormatter: propTypes.func,
+  /**
+   * Callback when an item is clicked with the mouse.
+   *  (item, index) => {}
+   */
+  onSelectItem: propTypes.func.isRequired,
+  /**
+   * Is the list open or closed?
+   */
+  open: propTypes.bool,
+};

--- a/src/sidebar/components/test/datalist-test.js
+++ b/src/sidebar/components/test/datalist-test.js
@@ -1,0 +1,159 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import Datalist from '../datalist';
+import { $imports } from '../datalist';
+
+import mockImportedComponents from './mock-imported-components';
+
+describe('Datalist', function() {
+  let fakeList;
+  let fakeOnSelectItem;
+  let fakeListFormatter;
+  function createComponent(props) {
+    return mount(
+      <Datalist list={fakeList} onSelectItem={fakeOnSelectItem} {...props} />
+    );
+  }
+
+  beforeEach(function() {
+    fakeList = ['tag1', 'tag2'];
+    fakeOnSelectItem = sinon.stub();
+    fakeListFormatter = sinon.stub();
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('does not render the list when `open` is false', () => {
+    const wrapper = createComponent();
+    assert.isFalse(wrapper.find('.datalist__items').exists());
+  });
+
+  it('does not render the list when `list` is empty', () => {
+    const wrapper = createComponent({ open: true, list: [] });
+    assert.isFalse(wrapper.find('.datalist__items').exists());
+  });
+
+  it('sets unique keys to the <li> items', () => {
+    const wrapper = createComponent({ open: true });
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(0)
+        .key(),
+      'datalist-0'
+    );
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(1)
+        .key(),
+      'datalist-1'
+    );
+  });
+
+  it('renders the items in order of the list prop', () => {
+    const wrapper = createComponent({ open: true });
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(0)
+        .text(),
+      'tag1'
+    );
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(1)
+        .text(),
+      'tag2'
+    );
+  });
+
+  it('does not apply the `is-selected` class to items that are not selected', () => {
+    const wrapper = createComponent({ open: true });
+    assert.isFalse(wrapper.find('li.is-selected').exists());
+  });
+
+  it('applies `is-selected` class only to the <li> at the matching index', () => {
+    const wrapper = createComponent({ open: true, activeItem: 0 });
+    assert.isTrue(
+      wrapper
+        .find('li')
+        .at(0)
+        .hasClass('is-selected')
+    );
+    assert.isFalse(
+      wrapper
+        .find('li')
+        .at(1)
+        .hasClass('is-selected')
+    );
+  });
+
+  it('calls `onSelect` when an <li> is clicked with the corresponding item', () => {
+    const wrapper = createComponent({ open: true, activeItem: 0 });
+    wrapper
+      .find('li')
+      .at(0)
+      .simulate('click');
+    assert.calledWith(fakeOnSelectItem, 'tag1');
+  });
+
+  it('calls `listFormatter` when building the <li> items if present', () => {
+    createComponent({ open: true, listFormatter: fakeListFormatter });
+    assert.calledWith(fakeListFormatter, 'tag1', 0);
+    assert.calledWith(fakeListFormatter, 'tag2', 1);
+  });
+
+  it('adds the `id` attribute to <ul> only if its present', () => {
+    let wrapper = createComponent({ open: true });
+    assert.isNotOk(wrapper.find('ul').prop('id'));
+    wrapper = createComponent({ open: true, id: 'datalist-id' });
+    assert.equal(wrapper.find('ul').prop('id'), 'datalist-id');
+  });
+
+  it('creates unique ids on the <li> tags with the `itemPrefixId` only if its present', () => {
+    let wrapper = createComponent({ open: true });
+    assert.isNotOk(
+      wrapper
+        .find('li')
+        .at(0)
+        .prop('id')
+    );
+    wrapper = createComponent({ open: true, itemPrefixId: 'item-prefix-id-' });
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(0)
+        .prop('id'),
+      'item-prefix-id-0'
+    );
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(1)
+        .prop('id'),
+      'item-prefix-id-1'
+    );
+  });
+
+  it('sets the `aria-selected` attribute on the active index ', () => {
+    const wrapper = createComponent({ open: true, activeItem: 0 });
+    assert.isTrue(
+      wrapper
+        .find('li')
+        .at(0)
+        .prop('aria-selected')
+    );
+    assert.isFalse(
+      wrapper
+        .find('li')
+        .at(1)
+        .prop('aria-selected')
+    );
+  });
+});

--- a/src/styles/sidebar/components/datalist.scss
+++ b/src/styles/sidebar/components/datalist.scss
@@ -1,0 +1,78 @@
+@use "../../variables" as var;
+
+.datalist {
+  position: relative;
+}
+
+.datalist__items {
+  @supports (clip-path: polygon(0 0, 100% 0, 0% 100%, 0% 100%)) {
+    &:before {
+      /** 
+       * Creates a small outlined triangle above the drop down menu
+       * that works nicely with a box-shadow and the dark/light themes.
+       */
+      background-color: inherit;
+      border: inherit;
+      border-top-left-radius: 0.125rem;
+      clip-path: polygon(0 0, 100% 0, 0% 100%, 0% 100%);
+      content: '';
+      display: inline-block;
+      height: 0.5rem;
+      left: 0.5rem;
+      position: absolute;
+      top: -0.3125rem;
+      transform: rotate(45deg);
+      width: 0.5rem;
+    }
+  }
+  position: absolute;
+  font-size: var.$body2-font-size;
+  top: 5px;
+  max-width: 100%;
+  min-width: 10em;
+  background-color: var.$white;
+  border: 1px solid var.$grey-3;
+  box-shadow: var.$popup-menu-shadow;
+  z-index: 10;
+
+  @media (pointer: coarse) {
+    font-size: var.$touch-target-size;
+    line-height: var.$touch-target-size;
+  }
+}
+
+.datalist__li {
+  padding: 0.25em 1.5em 0.25em 1em;
+  border-left: 4px transparent solid;
+
+  &.is-selected {
+    border-left: 4px var.$brand solid;
+    background-color: var.$grey-1;
+  }
+  &:hover {
+    cursor: pointer;
+    background-color: var.$grey-2;
+  }
+}
+
+/* Dark theme */
+
+@media screen and (prefers-color-scheme: dark) {
+  .datalist__items {
+    list-style: none;
+    padding: 0;
+    color: var.$white;
+    background-color: var.$grey-6;
+  }
+  .datalist__arrow-down {
+    border-bottom: 7px solid var.$grey-6;
+  }
+  .datalist__li {
+    &.is-selected {
+      background-color: var.$grey-mid;
+    }
+    &:hover {
+      background-color: var.$grey-5;
+    }
+  }
+}

--- a/src/styles/sidebar/components/menu.scss
+++ b/src/styles/sidebar/components/menu.scss
@@ -64,7 +64,7 @@
 .menu__content {
   background-color: white;
   border: 1px solid var.$grey-3;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+  box-shadow: var.$popup-menu-shadow;
   font-size: var.$body2-font-size;
   position: absolute;
   top: calc(100% + 5px);

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -37,6 +37,7 @@
 @use './components/annotation-thread';
 @use './components/annotation-user';
 @use './components/button';
+@use './components/datalist';
 @use './components/excerpt';
 @use './components/focused-mode-header';
 @use './components/group-list';

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -150,6 +150,7 @@ $highlight-color-third: rgba(192, 192, 49, 0.4);
 $highlight-color-focus: rgba(156, 230, 255, 0.5);
 $top-bar-height: 40px;
 $group-list-width: 280px;
+$popup-menu-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
 
 // Mixins
 // ------


### PR DESCRIPTION
Breaking up the previous PR into 2 parts for review. This is a non-visual change only that adds the stand alone Datalist component + tests.

Relevant _Code is pulled from https://github.com/hypothesis/client/pull/1653 verbatim_
