### PR TITLE
Improved tag editor (Part 2/2)

### DIFF
--- a/src/sidebar/components/datalist.js
+++ b/src/sidebar/components/datalist.js
@@ -1,0 +1,105 @@
+import { createElement } from 'preact';
+import classnames from 'classnames';
+import propTypes from 'prop-types';
+import { useMemo } from 'preact/hooks';
+
+const defaultListFormatter = item => item;
+
+/**
+ * Custom datalist component. Use this in conjunction with an input field.
+ */
+
+function Datalist({
+  activeItem = -1,
+  id,
+  itemPrefixId,
+  list,
+  listFormatter = defaultListFormatter,
+  onSelectItem,
+  open = false,
+}) {
+  const items = useMemo(() => {
+    return list.map((item, index) => {
+      // only add an id if itemPrefixId is passed
+      const props = itemPrefixId ? { id: `${itemPrefixId}${index}` } : {};
+
+      return (
+        <li
+          key={`datalist-${index}`}
+          role="option"
+          aria-selected={activeItem === index}
+          className={classnames(
+            {
+              'is-selected': activeItem === index,
+            },
+            'datalist__li'
+          )}
+          onClick={() => {
+            onSelectItem(item);
+          }}
+          {...props}
+        >
+          {listFormatter(item, index)}
+        </li>
+      );
+    });
+  }, [activeItem, itemPrefixId, list, listFormatter, onSelectItem]);
+
+  const props = id ? { id } : {}; // only add the id if its passed
+  return (
+    <div className="datalist">
+      {list.length > 0 && open && (
+        <div className="datalist__items">
+          <ul
+            tabIndex="-1"
+            aria-label="Suggestions"
+            role="listbox"
+            className="datalist__ul"
+            {...props}
+          >
+            {items}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+Datalist.propTypes = {
+  /**
+   * The activeItem is highlighted.
+   */
+  activeItem: propTypes.number,
+  /**
+   * Optional unique HTML attribute id.
+   */
+  id: propTypes.string,
+  /**
+   * Optional unique HTML attribute id prefix for each item in the list.
+   * The final value of each items' id is `{itemPrefixId}{activeItem}`
+   */
+  itemPrefixId: propTypes.string,
+
+  /**
+   * The list of items to render. This can be a simple list of
+   * strings or a list of objects when used with listFormatter.
+   */
+  list: propTypes.array.isRequired,
+  /**
+   * An optional formatter to render each item inside an <li> tag
+   * This is useful if the list is an array of objects rather than
+   * just strings.
+   */
+  listFormatter: propTypes.func,
+  /**
+   * Callback when an item is clicked with the mouse.
+   *  (item, index) => {}
+   */
+  onSelectItem: propTypes.func.isRequired,
+  /**
+   * Is the list open or closed?
+   */
+  open: propTypes.bool,
+};
+
+module.exports = Datalist;

--- a/src/sidebar/components/test/datalist-test.js
+++ b/src/sidebar/components/test/datalist-test.js
@@ -1,0 +1,164 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import Datalist from '../datalist';
+import { $imports } from '../datalist';
+
+import mockImportedComponents from './mock-imported-components';
+
+describe('Datalist', function() {
+  let fakeList;
+  let fakeOnSelectItem;
+  let fakeListFormatter;
+  function createComponent(props) {
+    return mount(
+      <Datalist
+        list={fakeList}
+        open={true}
+        onSelectItem={fakeOnSelectItem}
+        {...props}
+      />
+    );
+  }
+
+  beforeEach(function() {
+    fakeList = ['tag1', 'tag2'];
+    fakeOnSelectItem = sinon.stub();
+    fakeListFormatter = sinon.stub();
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('does not render the list when open is false', () => {
+    const wrapper = createComponent({ open: false });
+    assert.isFalse(wrapper.find('.datalist__items').exists());
+  });
+
+  it('does not render the list when list is empty', () => {
+    const wrapper = createComponent({ list: [] });
+    assert.isFalse(wrapper.find('.datalist__items').exists());
+  });
+
+  it('sets unique keys to the <li> items', () => {
+    const wrapper = createComponent();
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(0)
+        .key(),
+      'datalist-0'
+    );
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(1)
+        .key(),
+      'datalist-1'
+    );
+  });
+
+  it('renders the items in order of the list prop', () => {
+    const wrapper = createComponent();
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(0)
+        .text(),
+      'tag1'
+    );
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(1)
+        .text(),
+      'tag2'
+    );
+  });
+
+  it('does not apply the `is-selected` class to items that are not selected', () => {
+    const wrapper = createComponent();
+    assert.isFalse(wrapper.find('li.is-selected').exists());
+  });
+
+  it('applies `is-selected` class only to the <li> at the matching index', () => {
+    const wrapper = createComponent({ activeItem: 0 });
+    assert.isTrue(
+      wrapper
+        .find('li')
+        .at(0)
+        .hasClass('is-selected')
+    );
+    assert.isFalse(
+      wrapper
+        .find('li')
+        .at(1)
+        .hasClass('is-selected')
+    );
+  });
+
+  it('calls onSelect when an <li> is clicked with the corresponding item', () => {
+    const wrapper = createComponent({ activeItem: 0 });
+    wrapper
+      .find('li')
+      .at(0)
+      .simulate('click');
+    assert.calledWith(fakeOnSelectItem, 'tag1');
+  });
+
+  it('calls listFormatter when building the <li> items if present', () => {
+    createComponent({ listFormatter: fakeListFormatter });
+    assert.calledWith(fakeListFormatter, 'tag1', 0);
+    assert.calledWith(fakeListFormatter, 'tag2', 1);
+  });
+
+  it('adds the `id` attribute to <ul> only if its present', () => {
+    let wrapper = createComponent();
+    assert.isNotOk(wrapper.find('ul').prop('id'));
+    wrapper = createComponent({ id: 'datalist-id' });
+    assert.equal(wrapper.find('ul').prop('id'), 'datalist-id');
+  });
+
+  it('creates unique ids on the <li> tags with the `itemPrefixId` only if its present', () => {
+    let wrapper = createComponent();
+    assert.isNotOk(
+      wrapper
+        .find('li')
+        .at(0)
+        .prop('id')
+    );
+    wrapper = createComponent({ itemPrefixId: 'item-prefix-id-' });
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(0)
+        .prop('id'),
+      'item-prefix-id-0'
+    );
+    assert.equal(
+      wrapper
+        .find('li')
+        .at(1)
+        .prop('id'),
+      'item-prefix-id-1'
+    );
+  });
+
+  it('sets the `aria-selected` attribute on the active index ', () => {
+    const wrapper = createComponent({ activeItem: 0 });
+    assert.isTrue(
+      wrapper
+        .find('li')
+        .at(0)
+        .prop('aria-selected')
+    );
+    assert.isFalse(
+      wrapper
+        .find('li')
+        .at(1)
+        .prop('aria-selected')
+    );
+  });
+});

--- a/src/styles/sidebar/components/datalist.scss
+++ b/src/styles/sidebar/components/datalist.scss
@@ -1,0 +1,77 @@
+@use "../../variables" as var;
+
+.datalist {
+  position: relative;
+}
+
+.datalist__items {
+  &:before {
+    /* creates a small outlined triangle above the drop down menu */
+    background-color: inherit;
+    border: inherit;
+    border-top-left-radius: 0.125rem;
+    clip-path: polygon(0 0, 100% 0, 0% 100%, 0% 100%);
+    content: '';
+    display: inline-block;
+    height: 0.5rem;
+    left: 0.5rem;
+    position: absolute;
+    top: -0.3125rem;
+    transform: rotate(45deg);
+    width: 0.5rem;
+  }
+  position: absolute;
+  font-size: var.$body2-font-size;
+  top: 5px;
+  max-width: 100%;
+  min-width: 10em;
+  background-color: var.$white;
+  border: 1px solid var.$grey-3;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+  z-index: 10;
+
+  @media (pointer: coarse) {
+    font-size: var.$touch-target-size;
+    line-height: var.$touch-target-size;
+  }
+}
+
+.datalist__ul {
+  list-style: none;
+  padding: 0;
+}
+.datalist__li {
+  padding: 0.25em 1.5em 0.25em 1em;
+  border-left: 4px transparent solid;
+
+  &.is-selected {
+    border-left: 4px var.$brand solid;
+    background-color: var.$grey-1;
+  }
+  &:hover {
+    cursor: pointer;
+    background-color: var.$grey-2;
+  }
+}
+
+/* Dark theme */
+
+@media screen and (prefers-color-scheme: dark) {
+  .datalist__items {
+    color: var.$white;
+    background-color: var.$grey-6;
+    &:before {
+    }
+  }
+  .datalist__arrow-down {
+    border-bottom: 7px solid var.$grey-6;
+  }
+  .datalist__ul {
+    > li.is-selected {
+      background-color: var.$grey-mid;
+    }
+    > li:hover {
+      background-color: var.$grey-5;
+    }
+  }
+}

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -37,6 +37,7 @@
 @use './components/annotation-thread';
 @use './components/annotation-user';
 @use './components/button';
+@use './components/datalist';
 @use './components/excerpt';
 @use './components/focused-mode-header';
 @use './components/group-list';


### PR DESCRIPTION
**For some reason the diff is not working right, I'm not sure how to just get the diff between these two branches.**

- This updates the TagEditor to use the new Datalist component and also adds the a11y combobox model found here https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html
- Also fixes https://github.com/hypothesis/client/issues/1690 (Can't add new tags in Edge v44)
