### PR TITLE
Improved tag editor (Part 2/2)

### DIFF
--- a/src/sidebar/components/autocomplete-list.js
+++ b/src/sidebar/components/autocomplete-list.js
@@ -6,7 +6,7 @@ import propTypes from 'prop-types';
 const defaultListFormatter = item => item;
 
 /**
- * Custom datalist component. Use this in conjunction with an <input> field.
+ * Custom autocomplete component. Use this in conjunction with an <input> field.
  * To make this component W3 accessibility compliant, it is is intended to be
  * coupled to an <input> field or the TagEditor component and can not be
  * used by itself.
@@ -14,7 +14,7 @@ const defaultListFormatter = item => item;
  * Modeled after the "ARIA 1.1 Combobox with Listbox Popup"
  */
 
-export default function Datalist({
+export default function AutocompleteList({
   activeItem = -1,
   id,
   itemPrefixId,
@@ -32,14 +32,14 @@ export default function Datalist({
         // The parent <input> field should capture keyboard events
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events
         <li
-          key={`datalist-${index}`}
+          key={`autocomplete-list-${index}`}
           role="option"
           aria-selected={activeItem === index}
           className={classnames(
             {
               'is-selected': activeItem === index,
             },
-            'datalist__li'
+            'autocomplete-list__li'
           )}
           onClick={() => {
             onSelectItem(item);
@@ -54,10 +54,10 @@ export default function Datalist({
 
   const props = id ? { id } : {}; // only add the id if its passed
   return (
-    <div className="datalist">
+    <div className="autocomplete-list">
       {list.length > 0 && open && (
         <ul
-          className="datalist__items"
+          className="autocomplete-list__items"
           tabIndex="-1"
           aria-label="Suggestions"
           role="listbox"
@@ -70,7 +70,7 @@ export default function Datalist({
   );
 }
 
-Datalist.propTypes = {
+AutocompleteList.propTypes = {
   /**
    * The index of the highlighted item.
    */

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -1,31 +1,38 @@
 import { createElement } from 'preact';
-import { useMemo, useRef, useState } from 'preact/hooks';
+import { useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import { withServices } from '../util/service-context';
 
+import AutocompleteList from './autocomplete-list';
 import SvgIcon from './svg-icon';
+import useElementShouldClose from './hooks/use-element-should-close';
 
 // Global counter used to create a unique id for each instance of a TagEditor
-let datalistIdCounter = 0;
+let tagEditorIdCounter = 0;
 
 /**
  * Component to edit annotation's tags.
+ *
+ * Component accessibility is modeled after "Combobox with Listbox Popup Examples" found here:
+ * https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html
  */
 
 function TagEditor({ onEditTags, tags: tagsService, tagList }) {
   const inputEl = useRef(null);
-  const [showSuggestions, setShowSuggestions] = useState(false);
-  const [suggestionsFiltered, setSuggestionsFiltered] = useState([]); // For Chrome only
-  const [datalistId] = useState(() => {
-    ++datalistIdCounter;
-    return `tag-editor-datalist-${datalistIdCounter}`;
+  const [suggestions, setSuggestions] = useState([]);
+  const [activeItem, setActiveItem] = useState(-1); // -1 is unselected
+  const [suggestionsListOpen, setSuggestionsListOpen] = useState(false);
+  const [tagEditorId] = useState(() => {
+    ++tagEditorIdCounter;
+    return `tag-editor-${tagEditorIdCounter}`;
   });
 
-  const isChromeUA = !!window.navigator.userAgent.match(/Chrome\/[.0-9]*/);
-  // Suggestion limiter to speed up the performance in Chrome
-  // See https://github.com/hypothesis/client/issues/1606
-  const chromeSuggestionsLimit = 20;
+  // Set up callback to monitor outside click events to close the AutocompleteList
+  const closeWrapperRef = useRef();
+  useElementShouldClose(closeWrapperRef, suggestionsListOpen, () => {
+    setSuggestionsListOpen(false);
+  });
 
   /**
    * Helper function that returns a list of suggestions less any
@@ -45,12 +52,25 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
     return suggestionsSet.sort();
   };
 
-  // List of suggestions returned from the tagsService
-  const suggestions = useMemo(() => {
-    // Remove any repeated suggestions that are already tags.
-    // Call filter with an empty string to return all suggestions
-    return removeDuplicates(tagsService.filter(''), tagList);
-  }, [tagsService, tagList]);
+  /**
+   * Get a list of suggestions returned from the tagsService
+   * reset the activeItem and open the AutocompleteList
+   */
+  const updateSuggestions = () => {
+    const value = inputEl.current.value.trim();
+    if (value === '') {
+      // If there is no input, just hide the suggestions
+      setSuggestionsListOpen(false);
+    } else {
+      // Call filter() with a query value to return all matching suggestions.
+      const suggestions = tagsService.filter(value);
+      // Remove any repeated suggestions that are already tags
+      // and set those to state.
+      setSuggestions(removeDuplicates(suggestions, tagList));
+      setSuggestionsListOpen(true);
+    }
+    setActiveItem(-1);
+  };
 
   /**
    * Handle changes to this annotation's tags
@@ -77,8 +97,8 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
    * Adds a tag to the annotation equal to the value of the input field
    * and then clears out the suggestions list and the input field.
    */
-  const addTag = () => {
-    const value = inputEl.current.value.trim();
+  const addTag = newTag => {
+    const value = newTag.trim();
     if (value.length === 0) {
       // don't add an empty tag
       return;
@@ -88,97 +108,98 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
       return;
     }
     updateTags([...tagList, value]);
-    setShowSuggestions(false);
+    setSuggestionsListOpen(false);
 
     inputEl.current.value = '';
     inputEl.current.focus();
   };
 
   /**
-   *  If the user pressed enter or comma while focused on
-   *  the <input>, then add a new tag.
+   *  Update the suggestions if the user changes the value of the input
    */
-  const handleKeyPress = e => {
-    if (e.key === 'Enter' || e.key === ',') {
-      addTag();
-      // preventDefault stops the delimiter from being
-      // added to the input field
-      e.preventDefault();
-    }
-  };
-
   const handleOnInput = e => {
     if (
       e.inputType === 'insertText' ||
       e.inputType === 'deleteContentBackward'
     ) {
-      if (inputEl.current.value.length === 0) {
-        // If the user deleted input, hide suggestions. This has
-        // no effect in Safari and the list will stay open.
-        setShowSuggestions(false);
-      } else {
-        if (isChromeUA) {
-          // Filter down the suggestions list for Chrome to subvert a performance
-          // issue. Returning too many suggestions causes a noticeable delay when
-          // rendering the datalist.
-          // See https://github.com/hypothesis/client/issues/1606
-          setSuggestionsFiltered(
-            removeDuplicates(
-              tagsService.filter(inputEl.current.value, chromeSuggestionsLimit),
-              tagList
-            )
-          );
+      updateSuggestions();
+    }
+  };
+
+  /**
+   *  Callback when the user clicked one of the items in the suggestions list.
+   *  This will add a new tag.
+   */
+  const handleSelect = item => {
+    if (item) {
+      addTag(item);
+    }
+  };
+
+  /**
+   * Opens the AutocompleteList on focus if there is a value in the input
+   */
+  const handleFocus = () => {
+    if (inputEl.current.value.trim().length) {
+      setSuggestionsListOpen(true);
+    }
+  };
+
+  /**
+   *  Called when the user uses keyboard navigation to move
+   *  up or down the suggestions list creating a highlighted
+   *  item.
+   *
+   *  The first value in the list is an unselected value (-1).
+   *  A user can arrive at this value by pressing the up arrow back to
+   *  the beginning or the down arrow until the end.
+   *
+   * @param {number} direction - Pass 1 for the next item or -1 for the previous
+   */
+  const changeSelectedItem = direction => {
+    let nextActiveItem = activeItem + direction;
+    if (nextActiveItem < -1) {
+      nextActiveItem = suggestions.length - 1;
+    } else if (nextActiveItem >= suggestions.length) {
+      nextActiveItem = -1;
+    }
+    setActiveItem(nextActiveItem);
+  };
+
+  /**
+   * Keydown handler for keyboard navigation of the suggestions list
+   * and when the user presses "Enter" or ","" to add a new typed item not
+   * found in the suggestions list
+   */
+  const handleKeyDown = e => {
+    switch (e.key) {
+      case 'ArrowUp':
+        changeSelectedItem(-1);
+        e.preventDefault();
+        break;
+      case 'ArrowDown':
+        changeSelectedItem(1);
+        e.preventDefault();
+        break;
+      case 'Enter':
+      case ',':
+        if (activeItem === -1) {
+          // nothing selected, just add the typed text
+          addTag(inputEl.current.value);
+        } else {
+          addTag(suggestions[activeItem]);
         }
-        // Show the suggestions if the user types something into the field
-        setShowSuggestions(true);
-      }
-    } else if (
-      e.inputType === undefined ||
-      e.inputType === 'insertReplacementText'
-    ) {
-      // nb. Chrome / Safari reports undefined and Firefox reports 'insertReplacementText'
-      // for the inputTyp value when clicking on an element in the datalist.
-      //
-      // There are two ways to arrive here, either click an item with the mouse
-      // or use keyboard navigation and press 'Enter'.
-      //
-      // If the input value typed already exactly matches the option selected
-      // then this event won't fire and a user would have to press 'Enter' a second
-      // time to trigger the handleKeyPress callback above to add the tag.
-      // Bug: https://github.com/hypothesis/client/issues/1604
-      addTag();
+        e.preventDefault();
+        break;
     }
   };
 
-  const handleKeyUp = e => {
-    // Safari on macOS and iOS have an issue where pressing "Enter" in an
-    // input when its value exactly matches a suggestion in the associated <datalist>
-    // does not generate a "keypress" event. Therefore we catch the subsequent
-    // "keyup" event instead.
-
-    if (e.key === 'Enter') {
-      // nb. `addTag` will do nothing if the "keypress" event was already handled.
-      addTag();
-    }
-  };
-
-  const suggestionsList = () => {
-    // If this is Chrome, use the filtered list, otherwise use the full list
-    // See https://github.com/hypothesis/client/issues/1606
-    const optionsList = isChromeUA ? suggestionsFiltered : suggestions;
-    return (
-      <datalist
-        id={datalistId}
-        className="tag-editor__suggestions"
-        aria-label="Annotation suggestions"
-      >
-        {showSuggestions &&
-          optionsList.map(suggestion => (
-            <option key={suggestion} value={suggestion} />
-          ))}
-      </datalist>
-    );
-  };
+  // The activedescendant prop should match the activeItem's value except
+  // when its -1 (no item selected), and in this case set the activeDescendant to "".
+  const activeDescendant =
+    activeItem >= 0
+      ? `${tagEditorId}-autocomplete-list-item-${activeItem}`
+      : '';
 
   return (
     <section className="tag-editor">
@@ -207,17 +228,40 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
           );
         })}
       </ul>
-      <input
-        list={datalistId}
-        onInput={handleOnInput}
-        onKeyPress={handleKeyPress}
-        onKeyUp={handleKeyUp}
-        ref={inputEl}
-        placeholder="Add tags..."
-        className="tag-editor__input"
-        type="text"
-      />
-      {suggestionsList()}
+      <span
+        id={tagEditorId}
+        className="tag-editor__combobox-wrapper"
+        ref={closeWrapperRef}
+        // Disabled because aria-controls must be attached to the <input> field
+        // eslint-disable-next-line jsx-a11y/role-has-required-aria-props
+        role="combobox"
+        aria-expanded={suggestionsListOpen.toString()}
+        aria-owns={`${tagEditorId}-autocomplete-list`}
+        aria-haspopup="listbox"
+      >
+        <input
+          onInput={handleOnInput}
+          onKeyDown={handleKeyDown}
+          onFocus={handleFocus}
+          ref={inputEl}
+          placeholder="Add new tags"
+          className="tag-editor__input"
+          type="text"
+          autoComplete="off"
+          aria-autocomplete="list"
+          aria-activedescendant={activeDescendant}
+          aria-controls={`${tagEditorId}-autocomplete-list`}
+          dir="auto"
+        />
+        <AutocompleteList
+          id={`${tagEditorId}-autocomplete-list`}
+          list={suggestions}
+          open={suggestionsListOpen}
+          onSelectItem={handleSelect}
+          itemPrefixId={`${tagEditorId}-autocomplete-list-item-`}
+          activeItem={activeItem}
+        />
+      </span>
     </section>
   );
 }

--- a/src/sidebar/components/test/autocomplete-list-test.js
+++ b/src/sidebar/components/test/autocomplete-list-test.js
@@ -12,7 +12,11 @@ describe('AutocompleteList', function() {
   let fakeListFormatter;
   function createComponent(props) {
     return mount(
-      <AutocompleteList list={fakeList} onSelectItem={fakeOnSelectItem} {...props} />
+      <AutocompleteList
+        list={fakeList}
+        onSelectItem={fakeOnSelectItem}
+        {...props}
+      />
     );
   }
 

--- a/src/sidebar/components/test/autocomplete-list-test.js
+++ b/src/sidebar/components/test/autocomplete-list-test.js
@@ -1,18 +1,18 @@
 import { mount } from 'enzyme';
 import { createElement } from 'preact';
 
-import Datalist from '../datalist';
-import { $imports } from '../datalist';
+import AutocompleteList from '../autocomplete-list';
+import { $imports } from '../autocomplete-list';
 
 import mockImportedComponents from './mock-imported-components';
 
-describe('Datalist', function() {
+describe('AutocompleteList', function() {
   let fakeList;
   let fakeOnSelectItem;
   let fakeListFormatter;
   function createComponent(props) {
     return mount(
-      <Datalist list={fakeList} onSelectItem={fakeOnSelectItem} {...props} />
+      <AutocompleteList list={fakeList} onSelectItem={fakeOnSelectItem} {...props} />
     );
   }
 
@@ -29,12 +29,12 @@ describe('Datalist', function() {
 
   it('does not render the list when `open` is false', () => {
     const wrapper = createComponent();
-    assert.isFalse(wrapper.find('.datalist__items').exists());
+    assert.isFalse(wrapper.find('.autocomplete-list__items').exists());
   });
 
   it('does not render the list when `list` is empty', () => {
     const wrapper = createComponent({ open: true, list: [] });
-    assert.isFalse(wrapper.find('.datalist__items').exists());
+    assert.isFalse(wrapper.find('.autocomplete-list__items').exists());
   });
 
   it('sets unique keys to the <li> items', () => {
@@ -44,14 +44,14 @@ describe('Datalist', function() {
         .find('li')
         .at(0)
         .key(),
-      'datalist-0'
+      'autocomplete-list-0'
     );
     assert.equal(
       wrapper
         .find('li')
         .at(1)
         .key(),
-      'datalist-1'
+      'autocomplete-list-1'
     );
   });
 
@@ -112,8 +112,8 @@ describe('Datalist', function() {
   it('adds the `id` attribute to <ul> only if its present', () => {
     let wrapper = createComponent({ open: true });
     assert.isNotOk(wrapper.find('ul').prop('id'));
-    wrapper = createComponent({ open: true, id: 'datalist-id' });
-    assert.equal(wrapper.find('ul').prop('id'), 'datalist-id');
+    wrapper = createComponent({ open: true, id: 'autocomplete-list-id' });
+    assert.equal(wrapper.find('ul').prop('id'), 'autocomplete-list-id');
   });
 
   it('creates unique ids on the <li> tags with the `itemPrefixId` only if its present', () => {

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -1,5 +1,6 @@
 import { mount } from 'enzyme';
 import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
 import TagEditor from '../tag-editor';
 import { $imports } from '../tag-editor';
@@ -7,12 +8,18 @@ import { $imports } from '../tag-editor';
 import mockImportedComponents from './mock-imported-components';
 
 describe('TagEditor', function() {
+  let containers = [];
   let fakeTags = ['tag1', 'tag2'];
   let fakeTagsService;
   let fakeServiceUrl;
   let fakeOnEditTags;
 
   function createComponent(props) {
+    // Use an array of containers so we can test more
+    // than one component at a time.
+    let newContainer = document.createElement('div');
+    containers.push(newContainer);
+    document.body.appendChild(newContainer);
     return mount(
       <TagEditor
         // props
@@ -22,22 +29,45 @@ describe('TagEditor', function() {
         serviceUrl={fakeServiceUrl}
         tags={fakeTagsService}
         {...props}
-      />
+      />,
+      { attachTo: newContainer }
     );
   }
 
-  // Simulates a selection event from datalist
-  function selectOption(wrapper) {
-    wrapper.find('input').simulate('input', { inputType: undefined });
-  }
-  // Simulates a selection event from datalist. This is the
-  // only event that fires in in Safari. In Chrome, both the `keyup`
-  // and `input` events fire, but only the first one adds the tag.
-  function selectOptionViaKeyUp(wrapper) {
-    wrapper.find('input').simulate('keyup', { key: 'Enter' });
+  afterEach(function() {
+    containers.forEach(container => {
+      container.remove();
+    });
+    containers = [];
+  });
+
+  // Simulates a selection event from autocomplete-list
+  function selectOption(wrapper, item) {
+    act(() => {
+      wrapper
+        .find('AutocompleteList')
+        .props()
+        .onSelectItem(item);
+    });
   }
 
-  // Simulates a typing input event
+  // Simulates pressing Enter
+  function selectOptionViaEnter(wrapper) {
+    wrapper.find('input').simulate('keydown', { key: 'Enter' });
+  }
+  // Simulates typing ","
+  function selectOptionViaDelimiter(wrapper) {
+    wrapper.find('input').simulate('keydown', { key: ',' });
+  }
+  // Simulates typing the down arrow
+  function navigateDown(wrapper) {
+    wrapper.find('input').simulate('keydown', { key: 'ArrowDown' });
+  }
+  // Simulates typing the up arrow
+  function navigateUp(wrapper) {
+    wrapper.find('input').simulate('keydown', { key: 'ArrowUp' });
+  }
+  // Simulates typing text
   function typeInput(wrapper) {
     wrapper.find('input').simulate('input', { inputType: 'insertText' });
   }
@@ -49,7 +79,6 @@ describe('TagEditor', function() {
       filter: sinon.stub().returns(['tag4', 'tag3']),
       store: sinon.stub(),
     };
-
     $imports.$mock(mockImportedComponents());
   });
 
@@ -66,118 +95,169 @@ describe('TagEditor', function() {
     });
   });
 
-  it("creates a `list` prop on the input that matches the datalist's `id`", () => {
-    const wrapper = createComponent();
-    assert.equal(
-      wrapper.find('input').prop('list'),
-      wrapper.find('datalist').prop('id')
-    );
-  });
-
-  it('creates multiple TagEditors with unique datalist `id`s', () => {
-    const wrapper1 = createComponent();
-    const wrapper2 = createComponent();
-    assert.notEqual(
-      wrapper1.find('datalist').prop('id'),
-      wrapper2.find('datalist').prop('id')
-    );
-  });
-
-  it('generates a ordered datalist containing the array values returned from fakeTagsService.filter ', () => {
+  it('generates an ordered autocomplete-list containing the array values returned from filter()', () => {
     const wrapper = createComponent();
     wrapper.find('input').instance().value = 'non-empty';
-    wrapper.find('input').simulate('input', { inputType: 'insertText' });
-
-    // fakeTagsService.filter returns ['tag4', 'tag3'], but
-    // datalist shall be ordered as ['tag3', 'tag4']
-    assert.equal(
-      wrapper
-        .find('datalist option')
-        .at(0)
-        .prop('value'),
-      'tag3'
-    );
-    assert.equal(
-      wrapper
-        .find('datalist option')
-        .at(1)
-        .prop('value'),
-      'tag4'
-    );
+    typeInput(wrapper);
+    assert.equal(wrapper.find('AutocompleteList').prop('list')[0], 'tag3');
+    assert.equal(wrapper.find('AutocompleteList').prop('list')[1], 'tag4');
   });
 
-  [
-    {
-      text: ' in Chrome and Safari',
-      eventPayload: { inputType: undefined },
-    },
-    {
-      text: ' in Firefox',
-      eventPayload: { inputType: 'insertReplacementText' },
-    },
-  ].forEach(test => {
-    it(`clears the suggestions when selecting a tag from datalist ${test.text}`, () => {
+  it('passes the text value to filter() after receiving input', () => {
+    const wrapper = createComponent();
+    wrapper.find('input').instance().value = 'tag3';
+    typeInput(wrapper);
+    assert.isTrue(fakeTagsService.filter.calledOnce);
+    assert.isTrue(fakeTagsService.filter.calledWith('tag3'));
+  });
+
+  describe('accessibility attributes and ids', () => {
+    it('creates multiple <TagEditor> components with unique autocomplete-list `id` props', () => {
+      const wrapper1 = createComponent();
+      const wrapper2 = createComponent();
+      assert.notEqual(
+        wrapper1.find('AutocompleteList').prop('id'),
+        wrapper2.find('AutocompleteList').prop('id')
+      );
+    });
+
+    it('sets the <AutocompleteList> `id` prop to the same value as the `aria-owns` attribute', () => {
+      const wrapper = createComponent();
+      wrapper.find('AutocompleteList');
+
+      assert.equal(
+        wrapper.find('.tag-editor__combobox-wrapper').prop('aria-owns'),
+        wrapper.find('AutocompleteList').prop('id')
+      );
+    });
+
+    it('sets `aria-expanded` value to match open state', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = 'non-empty'; // to open list
+      typeInput(wrapper);
+      assert.equal(
+        wrapper.find('.tag-editor__combobox-wrapper').prop('aria-expanded'),
+        'true'
+      );
+      selectOption(wrapper, 'tag4');
+      wrapper.update();
+      assert.equal(
+        wrapper.find('.tag-editor__combobox-wrapper').prop('aria-expanded'),
+        'false'
+      );
+    });
+
+    it('sets the <AutocompleteList> `activeItem` prop to match the selected item index', () => {
+      function checkAttributes(wrapper) {
+        const activeDescendant = wrapper
+          .find('input')
+          .prop('aria-activedescendant');
+        const itemPrefixId = wrapper
+          .find('AutocompleteList')
+          .prop('itemPrefixId');
+        const activeDescendantIndex = activeDescendant.split(itemPrefixId);
+        assert.equal(
+          activeDescendantIndex[1],
+          wrapper.find('AutocompleteList').prop('activeItem')
+        );
+      }
+
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = 'non-empty';
+      typeInput(wrapper);
+      // initial aria-activedescendant value is "" when index is -1
+      assert.equal(wrapper.find('input').prop('aria-activedescendant'), '');
+      // 2 suggestions: ['tag3', 'tag4'];
+      navigateDown(wrapper); // press down once
+      checkAttributes(wrapper);
+      navigateDown(wrapper); // press down again once
+      checkAttributes(wrapper);
+    });
+  });
+
+  describe('suggestions open / close', () => {
+    it('closes the suggestions when selecting a tag from autocomplete-list', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = 'non-empty'; // to open list
+      typeInput(wrapper);
+      assert.equal(wrapper.find('AutocompleteList').prop('open'), true);
+      selectOption(wrapper, 'tag4');
+      wrapper.update();
+      assert.equal(wrapper.find('AutocompleteList').prop('open'), false);
+    });
+
+    it('closes the suggestions when deleting <input> value', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = 'tag3';
       typeInput(wrapper);
-      assert.equal(wrapper.find('datalist option').length, 2);
-      wrapper.find('input').simulate('input', test.eventPayload); // simulates a selection
-      assert.equal(wrapper.find('datalist option').length, 0);
-
-      assert.isTrue(
-        fakeTagsService.store.calledWith([
-          { text: 'tag1' },
-          { text: 'tag2' },
-          { text: 'tag3' },
-        ])
-      );
-    });
-  });
-
-  it('clears the suggestions when deleting input', () => {
-    const wrapper = createComponent();
-    wrapper.find('input').instance().value = 'tag3';
-    typeInput(wrapper);
-    assert.equal(wrapper.find('datalist option').length, 2);
-    wrapper.find('input').instance().value = '';
-    wrapper
-      .find('input')
-      .simulate('input', { inputType: 'deleteContentBackward' });
-    assert.equal(wrapper.find('datalist option').length, 0);
-  });
-
-  it('does not clear the suggestions when deleting only part of the input', () => {
-    const wrapper = createComponent();
-    wrapper.find('input').instance().value = 'tag3';
-    typeInput(wrapper);
-    assert.equal(wrapper.find('datalist option').length, 2);
-    wrapper.find('input').instance().value = 't'; // non-empty input remains
-    wrapper
-      .find('input')
-      .simulate('input', { inputType: 'deleteContentBackward' });
-    assert.notEqual(wrapper.find('datalist option').length, 0);
-  });
-
-  it('does not render duplicate suggestions', () => {
-    // `tag3` supplied in the `tagList` will be a duplicate value relative
-    // with the fakeTagsService.filter result above.
-    const wrapper = createComponent({
-      editMode: true,
-      tagList: ['tag1', 'tag2', 'tag3'],
-    });
-    wrapper.find('input').instance().value = 'non-empty';
-    typeInput(wrapper);
-    assert.equal(wrapper.find('datalist option').length, 1);
-    assert.equal(
+      assert.equal(wrapper.find('AutocompleteList').prop('list').length, 2);
+      wrapper.update();
+      assert.equal(wrapper.find('AutocompleteList').prop('open'), true);
+      wrapper.find('input').instance().value = ''; // clear input
       wrapper
-        .find('datalist option')
-        .at(0)
-        .prop('value'),
-      'tag4'
-    );
+        .find('input')
+        .simulate('input', { inputType: 'deleteContentBackward' });
+      assert.equal(wrapper.find('AutocompleteList').prop('open'), false);
+    });
+
+    it('does not close the suggestions when deleting only part of the <input> value', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = 'tag3';
+      typeInput(wrapper);
+      assert.equal(wrapper.find('AutocompleteList').prop('list').length, 2);
+      assert.equal(wrapper.find('AutocompleteList').prop('open'), true);
+      wrapper.find('input').instance().value = 't'; // non-empty input remains
+      wrapper
+        .find('input')
+        .simulate('input', { inputType: 'deleteContentBackward' });
+      assert.equal(wrapper.find('AutocompleteList').prop('open'), true);
+    });
+
+    it('opens the suggestions on focus if <input> is not empty', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = 'tag3';
+      assert.equal(wrapper.find('AutocompleteList').prop('open'), false);
+      wrapper.find('input').simulate('focus', {});
+      assert.equal(wrapper.find('AutocompleteList').prop('open'), true);
+    });
+
+    it('does not open the suggestions on focus if <input> is empty', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').simulate('focus', {});
+      assert.equal(wrapper.find('AutocompleteList').prop('open'), false);
+    });
+
+    it('does not open the suggestions on focus if <input> value is only white space', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = ' ';
+      wrapper.find('input').simulate('focus', {});
+      assert.equal(wrapper.find('AutocompleteList').prop('open'), false);
+    });
+
+    it('closes the suggestions when focus is removed from the <input> field', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = 'non-empty';
+      typeInput(wrapper);
+      assert.equal(wrapper.find('AutocompleteList').prop('open'), true);
+      document.body.dispatchEvent(new Event('focus'));
+      wrapper.update();
+      assert.equal(wrapper.find('AutocompleteList').prop('open'), false);
+    });
+
+    it('does not render duplicate suggestions', () => {
+      // `tag3` supplied in the `tagList` will be a duplicate value relative
+      // with the fakeTagsService.filter result above.
+      const wrapper = createComponent({
+        editMode: true,
+        tagList: ['tag1', 'tag2', 'tag3'],
+      });
+      wrapper.find('input').instance().value = 'non-empty';
+      typeInput(wrapper);
+      assert.deepEqual(wrapper.find('AutocompleteList').prop('list'), ['tag4']);
+    });
   });
 
-  context('when adding tags', () => {
+  describe('when adding tags', () => {
     /**
      * Helper function to assert that a tag was correctly added
      */
@@ -188,11 +268,12 @@ describe('TagEditor', function() {
       );
       // called the onEditTags callback prop
       assert.isTrue(fakeOnEditTags.calledWith({ tags: tagList }));
-      // clears out the suggestions
-      assert.equal(wrapper.find('datalist option').length, 0);
+      // hides the suggestions
+      assert.equal(wrapper.find('AutocompleteList').prop('open'), false);
       // assert the input value is cleared out
       assert.equal(wrapper.find('input').instance().value, '');
-      // note: focus not tested
+      // input element should have focus
+      assert.equal(document.activeElement.nodeName, 'INPUT');
     };
     /**
      * Helper function to assert that a tag was correctly not added
@@ -202,97 +283,66 @@ describe('TagEditor', function() {
       assert.isTrue(fakeOnEditTags.notCalled);
     };
 
-    it('adds a tag from the input field', () => {
+    it('adds a tag from the <input> field', () => {
       const wrapper = createComponent();
-      wrapper.find('input').instance().value = 'tag3';
-      selectOption(wrapper);
+      selectOption(wrapper, 'tag3');
       assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
     });
 
-    it('adds a tag from the input field via keyup event', () => {
+    it('adds a tag from the <input> field via keydown event', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = 'tag3';
-      selectOptionViaKeyUp(wrapper);
+      selectOptionViaEnter(wrapper);
       assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
     });
 
-    it('populate the datalist, then adds a tag from the input field', () => {
+    it('adds a tag from the <input> field when typing "," delimiter', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = 'tag3';
-
-      typeInput(wrapper);
-      assert.equal(wrapper.find('datalist option').length, 2);
-
-      selectOption(wrapper);
+      selectOptionViaDelimiter(wrapper);
       assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
     });
 
-    it('clears out the <option> elements after adding a tag', () => {
+    it('adds a tag from the suggestions list', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = 'non-empty';
-
       typeInput(wrapper);
-      assert.equal(wrapper.find('datalist option').length, 2);
+      // suggestions: [tag3, tag4]
+      navigateDown(wrapper);
+      selectOptionViaEnter(wrapper);
+      assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
+    });
 
-      selectOption(wrapper);
-      assert.equal(wrapper.find('datalist option').length, 0);
+    it('should not add a tag if the <input> is empty', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = '';
+      selectOptionViaEnter(wrapper);
+      assertAddTagsFail();
     });
 
     it('should not add a tag if the input is empty', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = '';
-
-      selectOption(wrapper);
+      selectOptionViaEnter(wrapper);
       assertAddTagsFail();
     });
 
-    it('should not add a tag if the input is blank space', () => {
+    it('should not add a tag if the <input> value is only white space', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = '  ';
-      selectOption(wrapper);
+      selectOptionViaEnter(wrapper);
       assertAddTagsFail();
     });
 
     it('should not add a tag if its a duplicate of one already in the list', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = 'tag1';
-      selectOption(wrapper);
+      selectOptionViaEnter(wrapper);
       assertAddTagsFail();
-    });
-
-    [
-      {
-        key: 'Enter',
-        text: 'adds a tag via keypress `Enter`',
-        run: wrapper => {
-          assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
-        },
-      },
-      {
-        key: ',',
-        text: 'adds a tag via keypress `,`',
-        run: wrapper => {
-          assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
-        },
-      },
-      {
-        key: 'e',
-        text: 'does not add a tag when key is not `,` or  `Enter`',
-        run: () => {
-          assertAddTagsFail();
-        },
-      },
-    ].forEach(test => {
-      it(test.text, () => {
-        const wrapper = createComponent();
-        wrapper.find('input').instance().value = 'tag3';
-        wrapper.find('input').simulate('keypress', { key: test.key });
-        test.run(wrapper);
-      });
     });
   });
 
-  context('when removing tags', () => {
+  describe('when removing tags', () => {
     it('removes `tag1` when clicking its delete button', () => {
       const wrapper = createComponent(); // note: initial tagList is ['tag1', 'tag2']
       assert.equal(wrapper.find('.tag-editor__edit').length, 2);
@@ -308,35 +358,52 @@ describe('TagEditor', function() {
     });
   });
 
-  describe('filter on text input based on user agent', () => {
-    let fakeNavigator;
-    beforeEach(function() {
-      fakeNavigator = sinon.stub(navigator, 'userAgent');
-    });
-
-    afterEach(function() {
-      fakeNavigator.restore();
-    });
-
-    it('calls filter when changing input with a limit of 20 when browser is Chrome', () => {
-      fakeNavigator.get(() => 'Chrome/1.0');
+  describe('navigating suggestions via keyboard', () => {
+    it('should set the initial `activeItem` value to -1 when opening suggestions', () => {
       const wrapper = createComponent();
-      wrapper.find('input').instance().value = 'tag';
+      wrapper.find('input').instance().value = 'non-empty';
       typeInput(wrapper);
-
-      assert.isTrue(fakeTagsService.filter.calledTwice);
-      assert.isTrue(fakeTagsService.filter.calledWith('tag', 20));
+      assert.equal(wrapper.find('AutocompleteList').prop('open'), true);
+      assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), -1);
+    });
+    it('should increment the `activeItem` when pressing down circularly', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = 'non-empty';
+      typeInput(wrapper);
+      // 2 suggestions: ['tag3', 'tag4'];
+      navigateDown(wrapper);
+      assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 0);
+      navigateDown(wrapper);
+      assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 1);
+      navigateDown(wrapper);
+      // back to unselected
+      assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), -1);
     });
 
-    it('does not call filter when changing input when browser is not Chrome', () => {
-      fakeNavigator.get(() => '');
+    it('should decrement the `activeItem` when pressing up circularly', () => {
       const wrapper = createComponent();
-
-      wrapper.find('input').instance().value = 'tag';
+      wrapper.find('input').instance().value = 'non-empty';
       typeInput(wrapper);
+      // 2 suggestions: ['tag3', 'tag4'];
+      navigateUp(wrapper);
+      assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 1);
+      navigateUp(wrapper);
+      assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 0);
+      navigateUp(wrapper);
+      assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), -1);
+    });
 
-      assert.isTrue(fakeTagsService.filter.calledOnce);
-      assert.isTrue(fakeTagsService.filter.calledWith(''));
+    it('should set `activeItem` to -1 when clearing the suggestions', () => {
+      const wrapper = createComponent();
+      wrapper.find('input').instance().value = 'non-empty';
+      typeInput(wrapper);
+      navigateDown(wrapper);
+      // change to non-default value
+      assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 0);
+      // clear suggestions
+      wrapper.find('input').instance().value = '';
+      typeInput(wrapper);
+      assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), -1);
     });
   });
 });

--- a/src/styles/sidebar/components/autocomplete-list.scss
+++ b/src/styles/sidebar/components/autocomplete-list.scss
@@ -1,10 +1,10 @@
 @use "../../variables" as var;
 
-.datalist {
+.autocomplete-list {
   position: relative;
 }
 
-.datalist__items {
+.autocomplete-list__items {
   @supports (clip-path: polygon(0 0, 100% 0, 0% 100%, 0% 100%)) {
     &:before {
       /** 
@@ -41,7 +41,7 @@
   }
 }
 
-.datalist__li {
+.autocomplete-list__li {
   padding: 0.25em 1.5em 0.25em 1em;
   border-left: 4px transparent solid;
 
@@ -58,16 +58,16 @@
 /* Dark theme */
 
 @media screen and (prefers-color-scheme: dark) {
-  .datalist__items {
+  .autocomplete-list__items {
     list-style: none;
     padding: 0;
     color: var.$white;
     background-color: var.$grey-6;
   }
-  .datalist__arrow-down {
+  .autocomplete-list__arrow-down {
     border-bottom: 7px solid var.$grey-6;
   }
-  .datalist__li {
+  .autocomplete-list__li {
     &.is-selected {
       background-color: var.$grey-mid;
     }

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -37,7 +37,7 @@
 @use './components/annotation-thread';
 @use './components/annotation-user';
 @use './components/button';
-@use './components/datalist';
+@use './components/autocomplete-list';
 @use './components/excerpt';
 @use './components/focused-mode-header';
 @use './components/group-list';

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -36,8 +36,8 @@
 @use './components/annotation-share-info';
 @use './components/annotation-thread';
 @use './components/annotation-user';
-@use './components/button';
 @use './components/autocomplete-list';
+@use './components/button';
 @use './components/excerpt';
 @use './components/focused-mode-header';
 @use './components/group-list';


### PR DESCRIPTION
- This updates the TagEditor to use the new Datalist component and also adds the a11y combobox model found here https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html
- Also fixes https://github.com/hypothesis/client/issues/1690 (Can't add new tags in Edge v44)

Relevant code is pulled from https://github.com/hypothesis/client/pull/1653 verbatim