### PR TITLE
Add basic expand/collapse for reply threads to `AnnotationOmega`

### DIFF
--- a/src/sidebar/components/test/annotation-omega-test.js
+++ b/src/sidebar/components/test/annotation-omega-test.js
@@ -35,6 +35,7 @@ describe('AnnotationOmega', () => {
         onReplyCountClick={fakeOnReplyCountClick}
         replyCount={0}
         showDocumentInfo={false}
+        threadIsCollapsed={true}
         {...props}
       />
     );
@@ -45,6 +46,7 @@ describe('AnnotationOmega', () => {
 
     fakeMetadata = {
       isNew: sinon.stub(),
+      isReply: sinon.stub(),
       quote: sinon.stub(),
     };
 
@@ -58,6 +60,7 @@ describe('AnnotationOmega', () => {
       getGroup: sinon.stub().returns({
         type: 'private',
       }),
+      setCollapsed: sinon.stub(),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -218,6 +221,67 @@ describe('AnnotationOmega', () => {
       const wrapper = createComponent();
 
       assert.isFalse(wrapper.find('AnnotationLicense').exists());
+    });
+  });
+
+  describe('reply thread toggle button', () => {
+    const findRepliesButton = wrapper =>
+      wrapper.find('Button').filter('.annotation-omega__reply-toggle');
+
+    it('should render a toggle button if the annotation has replies', () => {
+      fakeMetadata.isReply.returns(false);
+      const wrapper = createComponent({
+        replyCount: 5,
+        threadIsCollapsed: true,
+      });
+
+      assert.isTrue(findRepliesButton(wrapper).exists());
+      assert.equal(
+        wrapper.find('Button').props().buttonText,
+        'Show replies (5)'
+      );
+    });
+
+    it('should not render a toggle button if the annotation has no replies', () => {
+      fakeMetadata.isReply.returns(false);
+      const wrapper = createComponent({
+        replyCount: 0,
+        threadIsCollapsed: true,
+      });
+
+      assert.isFalse(findRepliesButton(wrapper).exists());
+    });
+
+    it('should not render a toggle button if the annotation itself is a reply', () => {
+      fakeMetadata.isReply.returns(true);
+      const wrapper = createComponent({
+        replyCount: 5,
+        threadIsCollapsed: true,
+      });
+
+      assert.isFalse(findRepliesButton(wrapper).exists());
+    });
+
+    it('should toggle the collapsed state of the thread on click', () => {
+      fakeMetadata.isReply.returns(false);
+      const wrapper = createComponent({
+        replyCount: 5,
+        threadIsCollapsed: true,
+      });
+
+      act(() => {
+        wrapper
+          .find('Button')
+          .props()
+          .onClick();
+      });
+      wrapper.setProps({ threadIsCollapsed: false });
+
+      assert.calledOnce(fakeStore.setCollapsed);
+      assert.equal(
+        findRepliesButton(wrapper).props().buttonText,
+        'Hide replies (5)'
+      );
     });
   });
 

--- a/src/sidebar/templates/annotation-thread.html
+++ b/src/sidebar/templates/annotation-thread.html
@@ -14,13 +14,12 @@
       annotation="vm.thread.annotation"
       ng-if="vm.thread.annotation">
     </moderation-banner>
-    <div ng-if="vm.shouldShowAnnotationOmega()"><em>Viewing AnnotationOmega</em></div>
     <annotation-omega ng-if="vm.thread.annotation && vm.shouldShowAnnotationOmega()"
       annotation="vm.thread.annotation"
       reply-count="vm.thread.replyCount"
       on-reply-count-click="vm.toggleCollapsed()"
       show-document-info="vm.showDocumentInfo"
-      thread="vm.thread">
+      thread-is-collapsed="vm.thread.collapsed">
     </annotation-omega>
     <annotation ng-class="vm.annotationClasses()"
              annotation="vm.thread.annotation"
@@ -34,6 +33,7 @@
              on-reply-count-click="vm.toggleCollapsed()"
              reply-count="vm.thread.replyCount">
     </annotation>
+    <div ng-if="vm.shouldShowAnnotationOmega()"><em>Viewing AnnotationOmega</em></div>
 
     <div ng-if="!vm.thread.annotation" class="thread-deleted">
       <p><em>Message not available.</em></p>

--- a/src/sidebar/templates/annotation-thread.html
+++ b/src/sidebar/templates/annotation-thread.html
@@ -15,11 +15,12 @@
       ng-if="vm.thread.annotation">
     </moderation-banner>
     <div ng-if="vm.shouldShowAnnotationOmega()"><em>Viewing AnnotationOmega</em></div>
-    <annotation-omega ng-if="vm.shouldShowAnnotationOmega()"
+    <annotation-omega ng-if="vm.thread.annotation && vm.shouldShowAnnotationOmega()"
       annotation="vm.thread.annotation"
       reply-count="vm.thread.replyCount"
       on-reply-count-click="vm.toggleCollapsed()"
-      show-document-info="vm.showDocumentInfo">
+      show-document-info="vm.showDocumentInfo"
+      thread="vm.thread">
     </annotation-omega>
     <annotation ng-class="vm.annotationClasses()"
              annotation="vm.thread.annotation"

--- a/src/styles/sidebar/components/annotation-omega.scss
+++ b/src/styles/sidebar/components/annotation-omega.scss
@@ -1,0 +1,20 @@
+// TEMPORARY styles for use during annotation migration
+.annotation-omega {
+  &__controls {
+    display: flex;
+  }
+
+  &__reply-toggle.button {
+    padding: 0;
+    background-color: transparent;
+    font-weight: 400;
+    &:hover {
+      background-color: transparent;
+      text-decoration: underline;
+    }
+  }
+}
+
+.annotation-omega-actions {
+  margin-left: auto;
+}

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -26,6 +26,7 @@
 // ----------
 @use './components/annotation-action-bar';
 @use './components/annotation';
+@use './components/annotation-omega';
 @use './components/annotation-body';
 @use './components/annotation-document-info';
 @use './components/annotation-header';


### PR DESCRIPTION
This PR adds the ability to show/hide the reply threads within `AnnotationOmega` components. It removes the long chain of passed bindings and instead contacts the store directly about collapsing/expanding the threads.

The expand/collapse control has been refactored as a `Button`, but still looks the same. To accomplish this, this PR introduces some interim `AnnotationOmega`-specific SCSS; these will be merged into `Annotation` styles eventually.

Note that there is still CSS class-work to be done to make nested reply threads correctly hide all the way when their carets are closed; that will happen subsequently.

For reference, it looks like this currently:

![image](https://user-images.githubusercontent.com/439947/73104478-73785700-3ec4-11ea-989e-6877a7a6fcd2.png)

![image](https://user-images.githubusercontent.com/439947/73104504-812ddc80-3ec4-11ea-9f80-b7850f9cbd20.png)


Part of #1650 