### PR TITLE
Improve handling of text in RTL languages

### DIFF
--- a/src/sidebar/components/annotation-quote.js
+++ b/src/sidebar/components/annotation-quote.js
@@ -26,6 +26,7 @@ function AnnotationQuote({ annotation, settings = {} }) {
       >
         <blockquote
           className="annotation-quote__quote"
+          dir="auto"
           style={applyTheme(['selectionFontFamily'], settings)}
         >
           {quote(annotation)}

--- a/src/sidebar/components/markdown-editor.js
+++ b/src/sidebar/components/markdown-editor.js
@@ -283,6 +283,7 @@ export default function MarkdownEditor({ onEditText = () => {}, text = '' }) {
       ) : (
         <textarea
           className="markdown-editor__input"
+          dir="auto"
           ref={input}
           onClick={e => e.stopPropagation()}
           onKeydown={handleKeyDown}

--- a/src/sidebar/components/markdown-view.js
+++ b/src/sidebar/components/markdown-view.js
@@ -23,6 +23,7 @@ export default function MarkdownView({ markdown = '', textClass = {} }) {
   return (
     <div
       className={classnames('markdown-view', textClass)}
+      dir="auto"
       ref={content}
       dangerouslySetInnerHTML={{ __html: html }}
     />

--- a/src/sidebar/components/search-input.js
+++ b/src/sidebar/components/search-input.js
@@ -50,6 +50,7 @@ export default function SearchInput({ alwaysExpanded, query, onSearch }) {
         className={classnames('search-input__input', {
           'is-expanded': alwaysExpanded || query,
         })}
+        dir="auto"
         type="text"
         name="query"
         placeholder={(isLoading && 'Loading…') || 'Search…'}


### PR DESCRIPTION
In response to #1716, improve display of user-controlled text in Right-To-Left (RTL) languages (eg. Hebrew, Arabic) by applying the `dir="auto"` attribute to:
    
- Input fields (annotation body editor, search bar)
- The rendered annotation body's container element
- The rendered annotation quote (ie. the `<blockquote>` element)
    
This will cause these elements to switch their "base" direction for text layout [1] to RTL or LTR automatically depending on the content [2]. Sequences of characters are rendered in an appropriate order for the specific characters, but the _base_ direction is important when handling text that mixes characters with different directionality amongst other things (see [1] for examples).
    
Fixes https://github.com/hypothesis/client/issues/1716
    
[1] https://www.w3.org/International/articles/inline-bidi-markup/uba-basics
[2] https://www.w3.org/International/questions/qa-html-dir