### PR TITLE
Add accessibility unit test using axe-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "autofill-event": "0.0.1",
     "autoprefixer": "^9.4.7",
     "aws-sdk": "^2.345.0",
+    "axe-core": "^3.4.1",
     "babel-plugin-angularjs-annotate": "^0.10.0",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-mockable-imports": "^1.5.1",

--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -88,6 +88,10 @@ module.exports = function(config) {
         // Disable watching because karma-browserify handles this.
         watched: false,
       })),
+
+      // CSS bundles, relied upon by accessibility tests (eg. for color-contrast
+      // checks).
+      { pattern: '../build/styles/{annotator,sidebar}.css', watched: false },
     ],
 
     // list of files to exclude

--- a/src/sidebar/components/logged-out-message.js
+++ b/src/sidebar/components/logged-out-message.js
@@ -32,7 +32,7 @@ function LoggedOutMessage({ onLogin, serviceUrl }) {
         .
       </span>
       <div className="logged-out-message__logo">
-        <a href="https://hypothes.is">
+        <a href="https://hypothes.is" title="Hypothesis homepage">
           <SvgIcon name="logo" className="logged-out-message__logo-icon" />
         </a>
       </div>

--- a/src/sidebar/components/test/.eslintrc
+++ b/src/sidebar/components/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "react/display-name": "off",
+  }
+}

--- a/src/sidebar/components/test/.eslintrc
+++ b/src/sidebar/components/test/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "react/display-name": "off",
-  }
-}

--- a/src/sidebar/components/test/accessibility.js
+++ b/src/sidebar/components/test/accessibility.js
@@ -1,0 +1,87 @@
+import { run } from 'axe-core';
+import { ReactWrapper, mount } from 'enzyme';
+import { isValidElement } from 'preact';
+
+/**
+ * @typedef {Scenario}
+ * @prop {string} [name] -
+ *   A descriptive name for the scenario. Defaults to "default" if not specified.
+ * @prop {() => import('preact').VNode|ReactWrapper} content -
+ *   A function that returns the rendered output to test or an Enzyme wrapper
+ *   created using Enzyme's `mount` function.
+ */
+
+async function testScenario(elementOrWrapper) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  let wrapper;
+  if (elementOrWrapper instanceof ReactWrapper) {
+    wrapper = elementOrWrapper;
+    container.appendChild(elementOrWrapper.getDOMNode());
+  } else {
+    wrapper = mount(elementOrWrapper, { attachTo: container });
+  }
+
+  const results = await run(container, {
+    // Run checks that correspond to the WCAG AA and Section 508 compliance
+    // criteria. These are the standards that we have committed to customers to
+    // meet.
+    runOnly: { type: 'tag', values: ['section508', 'wcag2a', 'wcag2aa'] },
+
+    // Only check for definite failures. The other possible non-pass outcomes for a
+    // given check are "incomplete" (couldn't determine status automatically)
+    // or "inapplicable" (no relevant HTML elements found).
+    resultTypes: ['violations'],
+  });
+  wrapper.unmount();
+  container.remove();
+
+  return results.violations;
+}
+
+/**
+ * Generate an accessibility test function for a component.
+ *
+ * The returned function should be passed as the callback argument to an `it`
+ * call in a Mocha test (eg. `it("should pass a11y checks", checkAccessibility(...))`).
+ *
+ * An accessibility test consists of an array of scenarios describing typical
+ * states of the component.
+ *
+ * @param {Scenario|Scenario[]} scenarios
+ * @return {() => Promise}
+ */
+export function checkAccessibility(scenarios) {
+  if (!Array.isArray(scenarios)) {
+    scenarios = [scenarios];
+  }
+
+  return async () => {
+    for (let { name = 'default', content } of scenarios) {
+      if (typeof content !== 'function') {
+        throw new Error(
+          `"content" key for accessibility scenario "${name}" should be a function but is a ${typeof content}`
+        );
+      }
+
+      const elementOrWrapper = content();
+
+      if (
+        !(elementOrWrapper instanceof ReactWrapper) &&
+        !isValidElement(elementOrWrapper)
+      ) {
+        throw new Error(
+          `Expected "content" function for scenario "${name}" to return a Preact element or an Enzyme wrapper`
+        );
+      }
+
+      const violations = await testScenario(elementOrWrapper);
+      assert.deepEqual(
+        violations,
+        [],
+        `Scenario "${name}" has accessibility violations`
+      );
+    }
+  };
+}

--- a/src/sidebar/components/test/annotation-action-bar-test.js
+++ b/src/sidebar/components/test/annotation-action-bar-test.js
@@ -316,7 +316,6 @@ describe('AnnotationActionBar', () => {
   it(
     'should pass a11y checks',
     checkAccessibility({
-      name: 'default',
       content: () => createComponent(),
     })
   );

--- a/src/sidebar/components/test/annotation-action-bar-test.js
+++ b/src/sidebar/components/test/annotation-action-bar-test.js
@@ -6,6 +6,7 @@ import AnnotationActionBar from '../annotation-action-bar';
 import { $imports } from '../annotation-action-bar';
 import * as fixtures from '../../test/annotation-fixtures';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 import { waitFor } from './util';
 
@@ -311,4 +312,12 @@ describe('AnnotationActionBar', () => {
       });
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      name: 'default',
+      content: () => createComponent(),
+    })
+  );
 });

--- a/src/sidebar/components/test/annotation-body-test.js
+++ b/src/sidebar/components/test/annotation-body-test.js
@@ -7,6 +7,7 @@ import * as fixtures from '../../test/annotation-fixtures';
 import AnnotationBody from '../annotation-body';
 import { $imports } from '../annotation-body';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationBody', () => {
@@ -89,4 +90,11 @@ describe('AnnotationBody', () => {
     assert.equal(buttonProps.buttonText, 'Less');
     assert.equal(buttonProps.title, 'Show the first few lines only');
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createBody(),
+    })
+  );
 });

--- a/src/sidebar/components/test/annotation-document-info-test.js
+++ b/src/sidebar/components/test/annotation-document-info-test.js
@@ -5,6 +5,7 @@ import * as fixtures from '../../test/annotation-fixtures';
 import AnnotationDocumentInfo from '../annotation-document-info';
 import { $imports } from '../annotation-document-info';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationDocumentInfo', () => {
@@ -75,4 +76,17 @@ describe('AnnotationDocumentInfo', () => {
 
     assert.equal(domain.text(), '(www.example.com)');
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => {
+        fakeDomainAndTitle.returns({
+          titleText: 'I have a title',
+          domain: 'www.example.com',
+        });
+        return createAnnotationDocumentInfo();
+      },
+    })
+  );
 });

--- a/src/sidebar/components/test/annotation-document-info-test.js
+++ b/src/sidebar/components/test/annotation-document-info-test.js
@@ -77,7 +77,8 @@ describe('AnnotationDocumentInfo', () => {
     assert.equal(domain.text(), '(www.example.com)');
   });
 
-  it(
+  // FIXME-A11Y
+  it.skip(
     'should pass a11y checks',
     checkAccessibility({
       content: () => {

--- a/src/sidebar/components/test/annotation-header-test.js
+++ b/src/sidebar/components/test/annotation-header-test.js
@@ -5,6 +5,7 @@ import * as fixtures from '../../test/annotation-fixtures';
 import AnnotationHeader from '../annotation-header';
 import { $imports } from '../annotation-header';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationHeader', () => {
@@ -180,4 +181,26 @@ describe('AnnotationHeader', () => {
       assert.isFalse(highlight.exists());
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        name: 'not editing',
+        content: () =>
+          createAnnotationHeader({
+            annotation: fixtures.defaultAnnotation(),
+            isEditing: false,
+          }),
+      },
+      {
+        name: 'editing',
+        content: () =>
+          createAnnotationHeader({
+            annotation: fixtures.defaultAnnotation(),
+            isEditing: true,
+          }),
+      },
+    ])
+  );
 });

--- a/src/sidebar/components/test/annotation-publish-control-test.js
+++ b/src/sidebar/components/test/annotation-publish-control-test.js
@@ -5,6 +5,7 @@ import * as fixtures from '../../test/annotation-fixtures';
 import AnnotationPublishControl from '../annotation-publish-control';
 import { $imports } from '../annotation-publish-control';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationPublishControl', () => {
@@ -272,4 +273,11 @@ describe('AnnotationPublishControl', () => {
       assert.calledOnce(fakeStore.removeAnnotations);
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createAnnotationPublishControl(),
+    })
+  );
 });

--- a/src/sidebar/components/test/annotation-quote-test.js
+++ b/src/sidebar/components/test/annotation-quote-test.js
@@ -45,7 +45,8 @@ describe('AnnotationQuote', () => {
     assert.equal(quote.text(), 'test quote');
   });
 
-  it(
+  // FIXME-A11Y
+  it.skip(
     'should pass a11y checks',
     checkAccessibility({
       content: () => createQuote(),

--- a/src/sidebar/components/test/annotation-quote-test.js
+++ b/src/sidebar/components/test/annotation-quote-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import AnnotationQuote from '../annotation-quote';
 import { $imports } from '../annotation-quote';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationQuote', () => {
@@ -43,4 +44,11 @@ describe('AnnotationQuote', () => {
     const quote = wrapper.find('blockquote');
     assert.equal(quote.text(), 'test quote');
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createQuote(),
+    })
+  );
 });

--- a/src/sidebar/components/test/annotation-share-control-test.js
+++ b/src/sidebar/components/test/annotation-share-control-test.js
@@ -5,6 +5,7 @@ import { act } from 'preact/test-utils';
 import AnnotationShareControl from '../annotation-share-control';
 import { $imports } from '../annotation-share-control';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationShareControl', () => {
@@ -208,4 +209,23 @@ describe('AnnotationShareControl', () => {
       'Use this URL to share this annotation'
     );
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility(
+      {
+        name: 'when closed',
+        content: () => createComponent(),
+      },
+      {
+        name: 'when open',
+        content: () => {
+          const wrapper = createComponent();
+          openElement(wrapper);
+          wrapper.update();
+          return wrapper;
+        },
+      }
+    )
+  );
 });

--- a/src/sidebar/components/test/annotation-share-info-test.js
+++ b/src/sidebar/components/test/annotation-share-info-test.js
@@ -5,6 +5,7 @@ import * as fixtures from '../../test/annotation-fixtures';
 import AnnotationShareInfo from '../annotation-share-info';
 import { $imports } from '../annotation-share-info';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationShareInfo', () => {
@@ -142,4 +143,11 @@ describe('AnnotationShareInfo', () => {
       });
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createAnnotationShareInfo(),
+    })
+  );
 });

--- a/src/sidebar/components/test/annotation-share-info-test.js
+++ b/src/sidebar/components/test/annotation-share-info-test.js
@@ -144,7 +144,8 @@ describe('AnnotationShareInfo', () => {
     });
   });
 
-  it(
+  // FIXME-A11Y
+  it.skip(
     'should pass a11y checks',
     checkAccessibility({
       content: () => createAnnotationShareInfo(),

--- a/src/sidebar/components/test/annotation-user-test.js
+++ b/src/sidebar/components/test/annotation-user-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import AnnotationUser from '../annotation-user';
 import { $imports } from '../annotation-user';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('AnnotationUser', () => {
@@ -143,4 +144,11 @@ describe('AnnotationUser', () => {
       });
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createAnnotationUser(),
+    })
+  );
 });

--- a/src/sidebar/components/test/button-test.js
+++ b/src/sidebar/components/test/button-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import Button from '../button';
 import { $imports } from '../button';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('Button', () => {
@@ -89,4 +90,11 @@ describe('Button', () => {
 
     assert.isTrue(wrapper.find('button').hasClass('button--primary'));
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    })
+  );
 });

--- a/src/sidebar/components/test/excerpt-test.js
+++ b/src/sidebar/components/test/excerpt-test.js
@@ -5,6 +5,8 @@ import { act } from 'preact/test-utils';
 import Excerpt from '../excerpt';
 import { $imports } from '../excerpt';
 
+import { checkAccessibility } from './accessibility';
+
 describe('Excerpt', () => {
   const SHORT_DIV = <div id="foo" style="height: 5px;" />;
   const TALL_DIV = (
@@ -132,4 +134,18 @@ describe('Excerpt', () => {
       assert.equal(getExcerptHeight(wrapper), 200);
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        name: 'external controls',
+        content: () => createExcerpt({}, TALL_DIV),
+      },
+      {
+        name: 'internal controls',
+        content: () => createExcerpt({ inlineControls: true }, TALL_DIV),
+      },
+    ])
+  );
 });

--- a/src/sidebar/components/test/focused-mode-header-test.js
+++ b/src/sidebar/components/test/focused-mode-header-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import FocusedModeHeader from '../focused-mode-header';
 import { $imports } from '../focused-mode-header';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('FocusedModeHeader', function() {
@@ -103,4 +104,11 @@ describe('FocusedModeHeader', function() {
       });
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    })
+  );
 });

--- a/src/sidebar/components/test/help-panel-test.js
+++ b/src/sidebar/components/test/help-panel-test.js
@@ -5,6 +5,7 @@ import { act } from 'preact/test-utils';
 import HelpPanel from '../help-panel';
 import { $imports } from '../help-panel';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('HelpPanel', function() {
@@ -194,4 +195,11 @@ describe('HelpPanel', function() {
       });
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    })
+  );
 });

--- a/src/sidebar/components/test/logged-out-message-test.js
+++ b/src/sidebar/components/test/logged-out-message-test.js
@@ -45,7 +45,8 @@ describe('LoggedOutMessage', () => {
     assert.equal(loginLink.prop('onClick'), fakeOnLogin);
   });
 
-  it(
+  // FIXME-A11Y
+  it.skip(
     'should pass a11y checks',
     checkAccessibility({
       content: () => createLoggedOutMessage(),

--- a/src/sidebar/components/test/logged-out-message-test.js
+++ b/src/sidebar/components/test/logged-out-message-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import LoggedOutMessage from '../logged-out-message';
 import { $imports } from '../logged-out-message';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('LoggedOutMessage', () => {
@@ -43,4 +44,11 @@ describe('LoggedOutMessage', () => {
 
     assert.equal(loginLink.prop('onClick'), fakeOnLogin);
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createLoggedOutMessage(),
+    })
+  );
 });

--- a/src/sidebar/components/test/markdown-editor-test.js
+++ b/src/sidebar/components/test/markdown-editor-test.js
@@ -6,6 +6,8 @@ import { LinkType } from '../../markdown-commands';
 import MarkdownEditor from '../markdown-editor';
 import { $imports } from '../markdown-editor';
 
+import { checkAccessibility } from './accessibility';
+
 describe('MarkdownEditor', () => {
   const formatResult = {
     text: 'formatted text',
@@ -240,4 +242,27 @@ describe('MarkdownEditor', () => {
       container.remove();
     }
   });
+
+  // FIXME-A11Y
+  it.skip(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        content: () => <MarkdownEditor text="test" />,
+      },
+      {
+        name: 'Preview mode',
+        content: () => {
+          const wrapper = mount(<MarkdownEditor text="test" />);
+
+          const previewButton = wrapper
+            .find('button')
+            .filterWhere(el => el.text() === 'Preview');
+          previewButton.simulate('click');
+
+          return wrapper;
+        },
+      },
+    ])
+  );
 });

--- a/src/sidebar/components/test/markdown-editor-test.js
+++ b/src/sidebar/components/test/markdown-editor-test.js
@@ -248,6 +248,7 @@ describe('MarkdownEditor', () => {
     'should pass a11y checks',
     checkAccessibility([
       {
+        // eslint-disable-next-line react/display-name
         content: () => <MarkdownEditor text="test" />,
       },
       {

--- a/src/sidebar/components/test/markdown-view-test.js
+++ b/src/sidebar/components/test/markdown-view-test.js
@@ -63,6 +63,7 @@ describe('MarkdownView', () => {
   it(
     'should pass a11y checks',
     checkAccessibility({
+      // eslint-disable-next-line react/display-name
       content: () => <MarkdownView markdown="foo" />,
     })
   );

--- a/src/sidebar/components/test/markdown-view-test.js
+++ b/src/sidebar/components/test/markdown-view-test.js
@@ -4,6 +4,8 @@ import { createElement } from 'preact';
 import MarkdownView from '../markdown-view';
 import { $imports } from '../markdown-view';
 
+import { checkAccessibility } from './accessibility';
+
 describe('MarkdownView', () => {
   let fakeMediaEmbedder;
   let fakeRenderMarkdown;
@@ -57,4 +59,11 @@ describe('MarkdownView', () => {
     );
     assert.isTrue(wrapper.find('.markdown-view.fancy-effect').exists());
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => <MarkdownView markdown="foo" />,
+    })
+  );
 });

--- a/src/sidebar/components/test/menu-item-test.js
+++ b/src/sidebar/components/test/menu-item-test.js
@@ -157,6 +157,7 @@ describe('MenuItem', () => {
     checkAccessibility([
       {
         name: 'default',
+        // eslint-disable-next-line react/display-name
         content: () => (
           <div role="menu">
             <MenuItem label="Test item" />
@@ -165,6 +166,7 @@ describe('MenuItem', () => {
       },
       {
         name: 'with link',
+        // eslint-disable-next-line react/display-name
         content: () => (
           <div role="menu">
             <MenuItem label="Test" href="https://foobar.com" />
@@ -173,6 +175,7 @@ describe('MenuItem', () => {
       },
       {
         name: 'with icon',
+        // eslint-disable-next-line react/display-name
         content: () => (
           <div role="menu">
             <MenuItem label="Test" icon="an-svg-icon" />
@@ -181,6 +184,7 @@ describe('MenuItem', () => {
       },
       {
         name: 'with submenu',
+        // eslint-disable-next-line react/display-name
         content: () => (
           <div role="menu">
             <MenuItem

--- a/src/sidebar/components/test/menu-item-test.js
+++ b/src/sidebar/components/test/menu-item-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import MenuItem from '../menu-item';
 import { $imports } from '../menu-item';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('MenuItem', () => {
@@ -150,4 +151,46 @@ describe('MenuItem', () => {
       'Submenu content'
     );
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        name: 'default',
+        content: () => (
+          <div role="menu">
+            <MenuItem label="Test item" />
+          </div>
+        ),
+      },
+      {
+        name: 'with link',
+        content: () => (
+          <div role="menu">
+            <MenuItem label="Test" href="https://foobar.com" />
+          </div>
+        ),
+      },
+      {
+        name: 'with icon',
+        content: () => (
+          <div role="menu">
+            <MenuItem label="Test" icon="an-svg-icon" />
+          </div>
+        ),
+      },
+      {
+        name: 'with submenu',
+        content: () => (
+          <div role="menu">
+            <MenuItem
+              label="Test"
+              isSubmenuVisible={true}
+              submenu={<div>Submenu content</div>}
+            />
+          </div>
+        ),
+      },
+    ])
+  );
 });

--- a/src/sidebar/components/test/menu-item-test.js
+++ b/src/sidebar/components/test/menu-item-test.js
@@ -156,7 +156,6 @@ describe('MenuItem', () => {
     'should pass a11y checks',
     checkAccessibility([
       {
-        name: 'default',
         // eslint-disable-next-line react/display-name
         content: () => (
           <div role="menu">

--- a/src/sidebar/components/test/menu-section-test.js
+++ b/src/sidebar/components/test/menu-section-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import MenuSection from '../menu-section';
 import { $imports } from '../menu-section';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('MenuSection', () => {
@@ -36,4 +37,11 @@ describe('MenuSection', () => {
     const wrapper = createMenuSection();
     assert.isTrue(wrapper.exists('li > .menu-item'));
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createMenuSection(),
+    })
+  );
 });

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -5,6 +5,8 @@ import { act } from 'preact/test-utils';
 import Menu from '../menu';
 import { $imports } from '../menu';
 
+import { checkAccessibility } from './accessibility';
+
 describe('Menu', () => {
   let container;
 
@@ -223,4 +225,18 @@ describe('Menu', () => {
 
     assert.include({ position: 'static' }, menuContainer.prop('style'));
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        name: 'default',
+        content: () => (
+          <Menu label={<TestLabel />} title="Test menu">
+            <TestMenuItem />
+          </Menu>
+        ),
+      },
+    ])
+  );
 });

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -231,6 +231,7 @@ describe('Menu', () => {
     checkAccessibility([
       {
         name: 'default',
+        // eslint-disable-next-line react/display-name
         content: () => (
           <Menu label={<TestLabel />} title="Test menu">
             <TestMenuItem />

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -230,7 +230,6 @@ describe('Menu', () => {
     'should pass a11y checks',
     checkAccessibility([
       {
-        name: 'default',
         // eslint-disable-next-line react/display-name
         content: () => (
           <Menu label={<TestLabel />} title="Test menu">

--- a/src/sidebar/components/test/moderation-banner-test.js
+++ b/src/sidebar/components/test/moderation-banner-test.js
@@ -5,6 +5,7 @@ import * as fixtures from '../../test/annotation-fixtures';
 import ModerationBanner from '../moderation-banner';
 import { $imports } from '../moderation-banner';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 const moderatedAnnotation = fixtures.moderatedAnnotation;
@@ -182,4 +183,16 @@ describe('ModerationBanner', () => {
       done();
     }, 0);
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () =>
+        createComponent({
+          annotation: moderatedAnnotation({
+            flagCount: 10,
+          }),
+        }),
+    })
+  );
 });

--- a/src/sidebar/components/test/new-note-btn-test.js
+++ b/src/sidebar/components/test/new-note-btn-test.js
@@ -6,6 +6,7 @@ import events from '../../events';
 import NewNoteButton from '../new-note-btn';
 import { $imports } from '../new-note-btn';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('NewNoteButton', function() {
@@ -76,4 +77,11 @@ describe('NewNoteButton', function() {
       }
     );
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    })
+  );
 });

--- a/src/sidebar/components/test/search-input-test.js
+++ b/src/sidebar/components/test/search-input-test.js
@@ -4,6 +4,8 @@ import { createElement } from 'preact';
 import SearchInput from '../search-input';
 import { $imports } from '../search-input';
 
+import { checkAccessibility } from './accessibility';
+
 describe('SearchInput', () => {
   let fakeStore;
 
@@ -84,4 +86,21 @@ describe('SearchInput', () => {
     const wrapper = createSearchInput();
     assert.isTrue(wrapper.exists('button'));
   });
+
+  // FIXME-A11Y
+  it.skip(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        content: () => createSearchInput(),
+      },
+      {
+        name: 'loading state',
+        content: () => {
+          fakeStore.isLoading.returns(true);
+          return createSearchInput();
+        },
+      },
+    ])
+  );
 });

--- a/src/sidebar/components/test/search-status-bar-test.js
+++ b/src/sidebar/components/test/search-status-bar-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import SearchStatusBar from '../search-status-bar';
 import { $imports } from '../search-status-bar';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('SearchStatusBar', () => {
@@ -314,4 +315,11 @@ describe('SearchStatusBar', () => {
       });
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent({}),
+    })
+  );
 });

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -5,6 +5,7 @@ import uiConstants from '../../ui-constants';
 import SelectionTabs from '../selection-tabs';
 import { $imports } from '../selection-tabs';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('SelectionTabs', function() {
@@ -196,4 +197,16 @@ describe('SelectionTabs', function() {
       );
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => {
+        fakeStore.annotationCount.returns(1);
+        fakeStore.noteCount.returns(2);
+        fakeStore.orphanCount.returns(3);
+        return createComponent({});
+      },
+    })
+  );
 });

--- a/src/sidebar/components/test/share-annotations-panel-test.js
+++ b/src/sidebar/components/test/share-annotations-panel-test.js
@@ -185,7 +185,8 @@ describe('ShareAnnotationsPanel', () => {
     });
   });
 
-  it(
+  // FIXME-A11Y
+  it.skip(
     'should pass a11y checks',
     checkAccessibility({
       content: () => createShareAnnotationsPanel(),

--- a/src/sidebar/components/test/share-annotations-panel-test.js
+++ b/src/sidebar/components/test/share-annotations-panel-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import ShareAnnotationsPanel from '../share-annotations-panel';
 import { $imports } from '../share-annotations-panel';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('ShareAnnotationsPanel', () => {
@@ -183,4 +184,11 @@ describe('ShareAnnotationsPanel', () => {
       });
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createShareAnnotationsPanel(),
+    })
+  );
 });

--- a/src/sidebar/components/test/share-links-test.js
+++ b/src/sidebar/components/test/share-links-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import ShareLinks from '../share-links';
 import { $imports } from '../share-links';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('ShareLinks', () => {
@@ -74,4 +75,11 @@ describe('ShareLinks', () => {
       );
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    })
+  );
 });

--- a/src/sidebar/components/test/sidebar-content-error-test.js
+++ b/src/sidebar/components/test/sidebar-content-error-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import SidebarContentError from '../sidebar-content-error';
 import { $imports } from '../sidebar-content-error';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('SidebarContentError', () => {
@@ -71,4 +72,38 @@ describe('SidebarContentError', () => {
 
     assert.equal(errorText, loggedInErrorMessage);
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        name: 'logged out',
+        content: () => {
+          const isLoggedIn = false;
+          const loggedOutErrorMessage = 'This annotation is not available.';
+          const loggedInErrorMessage =
+            'You do not have permission to view this annotation.';
+          return createSidebarContentError(
+            loggedOutErrorMessage,
+            loggedInErrorMessage,
+            isLoggedIn
+          );
+        },
+      },
+      {
+        name: 'logged in',
+        content: () => {
+          const isLoggedIn = true;
+          const loggedOutErrorMessage = 'This annotation is not available.';
+          const loggedInErrorMessage =
+            'You do not have permission to view this annotation.';
+          return createSidebarContentError(
+            loggedOutErrorMessage,
+            loggedInErrorMessage,
+            isLoggedIn
+          );
+        },
+      },
+    ])
+  );
 });

--- a/src/sidebar/components/test/sidebar-panel-test.js
+++ b/src/sidebar/components/test/sidebar-panel-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import SidebarPanel from '../sidebar-panel';
 import { $imports } from '../sidebar-panel';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('SidebarPanel', () => {
@@ -117,4 +118,11 @@ describe('SidebarPanel', () => {
       assert.isFalse(fakeScrollIntoView.called);
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createSidebarPanel(),
+    })
+  );
 });

--- a/src/sidebar/components/test/slider-test.js
+++ b/src/sidebar/components/test/slider-test.js
@@ -3,6 +3,8 @@ import { createElement } from 'preact';
 
 import Slider from '../slider';
 
+import { checkAccessibility } from './accessibility';
+
 describe('Slider', () => {
   let container;
 
@@ -99,4 +101,18 @@ describe('Slider', () => {
       wrapper.unmount();
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        name: 'visible',
+        content: () => createSlider({ visible: true }),
+      },
+      {
+        name: 'hidden',
+        content: () => createSlider({ visible: false }),
+      },
+    ])
+  );
 });

--- a/src/sidebar/components/test/spinner-test.js
+++ b/src/sidebar/components/test/spinner-test.js
@@ -3,6 +3,8 @@ import { createElement } from 'preact';
 
 import Spinner from '../spinner';
 
+import { checkAccessibility } from './accessibility';
+
 describe('Spinner', function() {
   const createSpinner = (props = {}) => mount(<Spinner {...props} />);
 
@@ -11,4 +13,11 @@ describe('Spinner', function() {
     const wrapper = createSpinner();
     assert.isTrue(wrapper.exists('.spinner'));
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createSpinner(),
+    })
+  );
 });

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import TagEditor from '../tag-editor';
 import { $imports } from '../tag-editor';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('TagEditor', function() {
@@ -339,4 +340,12 @@ describe('TagEditor', function() {
       assert.isTrue(fakeTagsService.filter.calledWith(''));
     });
   });
+
+  // FIXME-A11Y
+  it.skip(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    })
+  );
 });

--- a/src/sidebar/components/test/tag-list-test.js
+++ b/src/sidebar/components/test/tag-list-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import TagList from '../tag-list';
 import { $imports } from '../tag-list';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('TagList', function() {
@@ -87,4 +88,21 @@ describe('TagList', function() {
       assert.notCalled(fakeServiceUrl);
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        name: 'first-party user',
+        content: () => createComponent({ tags: ['tag1', 'tag2'] }),
+      },
+      {
+        name: 'third-party user',
+        content: () => {
+          fakeIsThirdPartyUser.returns(true);
+          return createComponent({ tags: ['tag1', 'tag2'] });
+        },
+      },
+    ])
+  );
 });

--- a/src/sidebar/components/test/timestamp-test.js
+++ b/src/sidebar/components/test/timestamp-test.js
@@ -5,6 +5,8 @@ import { act } from 'preact/test-utils';
 import Timestamp from '../timestamp';
 import { $imports } from '../timestamp';
 
+import { checkAccessibility } from './accessibility';
+
 describe('Timestamp', () => {
   let clock;
   let fakeTime;
@@ -125,4 +127,19 @@ describe('Timestamp', () => {
       });
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => {
+        // Fake timers break axe-core.
+        clock.restore();
+
+        return createTimestamp({
+          timestamp: '2016-06-10T10:04:04.939Z',
+          href: 'https://annotate.com/a/1234',
+        });
+      },
+    })
+  );
 });

--- a/src/sidebar/components/test/top-bar-test.js
+++ b/src/sidebar/components/test/top-bar-test.js
@@ -6,6 +6,7 @@ import uiConstants from '../../ui-constants';
 import TopBar from '../top-bar';
 import { $imports } from '../top-bar';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('TopBar', () => {
@@ -264,4 +265,18 @@ describe('TopBar', () => {
       assert.isFalse(wrapper.exists('button[title="Share this page"]'));
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        name: 'in sidebar',
+        content: () => createTopBar({ isSidebar: true }),
+      },
+      {
+        name: 'in stream / single annotation view',
+        content: () => createTopBar({ isSidebar: false }),
+      },
+    ])
+  );
 });

--- a/src/sidebar/components/test/tutorial-test.js
+++ b/src/sidebar/components/test/tutorial-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import Tutorial from '../tutorial';
 import { $imports } from '../tutorial';
 
+import { checkAccessibility } from './accessibility';
 import mockImportedComponents from './mock-imported-components';
 
 describe('Tutorial', function() {
@@ -55,4 +56,11 @@ describe('Tutorial', function() {
       assert.isTrue(instruction.exists());
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    })
+  );
 });

--- a/src/sidebar/components/test/version-info-test.js
+++ b/src/sidebar/components/test/version-info-test.js
@@ -4,6 +4,8 @@ import { createElement } from 'preact';
 import VersionInfo from '../version-info';
 import { $imports } from '../version-info';
 
+import { checkAccessibility } from './accessibility';
+
 describe('VersionInfo', function() {
   let fakeVersionData;
   // Services
@@ -81,4 +83,11 @@ describe('VersionInfo', function() {
       assert.calledWith(fakeFlash.error, 'Unable to copy version info');
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    })
+  );
 });

--- a/src/sidebar/components/test/version-info-test.js
+++ b/src/sidebar/components/test/version-info-test.js
@@ -84,7 +84,8 @@ describe('VersionInfo', function() {
     });
   });
 
-  it(
+  // FIXME-A11Y
+  it.skip(
     'should pass a11y checks',
     checkAccessibility({
       content: () => createComponent(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1464,6 +1464,11 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axe-core@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.4.1.tgz#e42623918bb85b5ef674633852cb9029db0309c5"
+  integrity sha512-+EhIdwR0hF6aeMx46gFDUy6qyCfsL0DmBrV3Z+LxYbsOd8e1zBaPHa3f9Rbjsz2dEwSBkLw6TwML/CAIIAqRpw==
+
 axobject-query@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.1.1.tgz#2a3b1271ec722d48a4cd4b3fcc20c853326a49a7"


### PR DESCRIPTION
This PR adds runtime accessibility checks at the unit-test level using [axe-core](https://github.com/dequelabs/axe-core). This complements the static analysis done by the jsx-a11y ESLint plugin.

It works as follows:

1. axe-core has been added to the project as a dependency
2. A new utility function, `checkAccessibility`, has been implemented in `src/sidebar/components/test/accessibility.js`. It takes a list of "scenarios" which are objects describing different major states of the component ("open", "closed" etc.) along with a function to produce an example of the component in that state. The DOM output of the rendered example is passed to axe-core which runs a set of accessibility checks based on the WCAG level A and AA criteria.
3. Each component (with some exceptions) unit test adds a new test case `it("should pass a11y checks", ...)` which uses `checkAccessibility` to render the component in its key states and run checks against the resulting DOM. Any violations will cause the test to fail.

The exceptions are for components which don't render any DOM nodes directly, but delegate all of their output to other components. The assumption is that each component which does render output will always produce accessible results, providing that its input checks (prop types), pass.

- [x] Add axe-core dependency to project and implement a utility (`src/sidebar/components/test/accessibility.js`) that can be used to run the WCAG rules on a component
- [x] Add basic a11y tests to each component using axe-core. Skip any failures.
- [x] File a follow-up issue to fix skipped tests (https://github.com/hypothesis/client/issues/1734)
- [x] Check whether we can check for color contrast issues as well. This will require loading the CSS into the tests. (_Yes, we can_)
- [x] ~Compare the output to testing with the axe browser extension. Does it pick up anything the unit tests don't? If so, what issues are those and how can we guard against them in future?~ (I will do this as part of follow-up work)
