### PR TITLE
Convert markdown-editor to use Button component (1/6)

### DIFF
--- a/src/sidebar/components/button.js
+++ b/src/sidebar/components/button.js
@@ -19,6 +19,7 @@ import SvgIcon from './svg-icon';
 export default function Button({
   buttonText = '',
   className = '',
+  disabled = false,
   icon = '',
   isActive = false,
   onClick = () => null,
@@ -51,6 +52,7 @@ export default function Button({
       aria-pressed={isActive}
       title={title}
       style={style}
+      disabled={disabled}
     >
       {icon && <SvgIcon name={icon} className="button__icon" />}
       {buttonText}
@@ -104,6 +106,9 @@ Button.propTypes = {
 
   /** Is this button currently in an "active"/"on" state? */
   isActive: propTypes.bool,
+
+  /** Is this button disabled? */
+  disabled: propTypes.bool,
 
   /** callback for button clicks */
   onClick: propTypes.func,

--- a/src/sidebar/components/markdown-editor.js
+++ b/src/sidebar/components/markdown-editor.js
@@ -3,6 +3,8 @@ import { createElement } from 'preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
+import Button from './button';
+
 import {
   LinkType,
   convertSelectionToLink,
@@ -105,8 +107,17 @@ function ToolbarButton({
     tooltip += ` (Ctrl+${shortcutKey.toUpperCase()})`;
   }
 
+  const optionalProps = {};
+  if (label) {
+    optionalProps.buttonText = label;
+  }
+  if (iconName) {
+    optionalProps.icon = iconName;
+  }
+
   return (
-    <button
+    <Button
+      useCompactStyle={true}
       className={classnames(
         'markdown-editor__toolbar-button',
         label && 'is-text'
@@ -114,15 +125,8 @@ function ToolbarButton({
       disabled={disabled}
       onClick={onClick}
       title={tooltip}
-    >
-      {iconName && (
-        <SvgIcon
-          name={iconName}
-          className="markdown-editor__toolbar-button-icon"
-        />
-      )}
-      {label}
-    </button>
+      {...optionalProps}
+    />
   );
 }
 

--- a/src/sidebar/components/test/button-test.js
+++ b/src/sidebar/components/test/button-test.js
@@ -89,4 +89,9 @@ describe('Button', () => {
 
     assert.isTrue(wrapper.find('button').hasClass('button--primary'));
   });
+
+  it('disables the button when `disabled` is truthy', () => {
+    const wrapper = createComponent({ disabled: true });
+    assert.isTrue(wrapper.find('button[disabled=true]').exists());
+  });
 });

--- a/src/sidebar/components/test/markdown-editor-test.js
+++ b/src/sidebar/components/test/markdown-editor-test.js
@@ -97,9 +97,7 @@ describe('MarkdownEditor', () => {
         const wrapper = mount(
           <MarkdownEditor text="test" onEditText={onEditText} />
         );
-        const button = wrapper.find(
-          `ToolbarButton[title="${command}"] > button`
-        );
+        const button = wrapper.find(`ToolbarButton[title="${command}"] button`);
         const input = wrapper.find('textarea').getDOMNode();
         input.selectionStart = 0;
         input.selectionEnd = 4;

--- a/src/styles/sidebar/components/markdown-editor.scss
+++ b/src/styles/sidebar/components/markdown-editor.scss
@@ -21,15 +21,7 @@ $toolbar-border: 0.1em solid var.$grey-3;
 }
 
 .markdown-editor__toolbar-button {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  appearance: none;
-  border: none;
-  background: none;
-  min-width: 24px;
-  min-height: 24px;
-
+  flex-shrink: 0;
   color: var.$grey-5;
 
   &:hover,
@@ -45,8 +37,8 @@ $toolbar-border: 0.1em solid var.$grey-3;
     font-size: 13px;
   }
 
-  &-icon {
-    width: 10px;
+  & svg {
+    width: 100%; // Centers the svg in its parent
     height: 10px;
   }
 }
@@ -61,6 +53,7 @@ $toolbar-border: 0.1em solid var.$grey-3;
   display: flex;
   align-items: center;
   margin-bottom: 2px; // Tweak to align help icon better with adjacent buttons
+  z-index: 1; // Makes focus halo renders above preview button
 }
 
 .markdown-editor__input {


### PR DESCRIPTION
More or less a straight conversion to the newer Button component. It was impossible to land the css exactly the same w/o some specialized css to force padding on the svg which I did not feel was warranted. Instead I created a diff to show the difference in padding (see screen shot diff) This just uses the standard `useCompactStyle` padding. I did however need to add the `disabled` prop to Button.

Also note, the "Preview" "Write" toggle button has changed a little. I just allowed the background to be set by the <Button> component. It does look more like a regular button now and I think thats a good thing but this does change the style from before (it had no background color before)

The last little bit of clean up that happens auto-magically is the blue halo no longer is set on mouse clicks on any of these buttons -- but that goes for anything being converting to <Button>

@robertknight I remember you had mentioned in standup today about buttons looking like buttons so I wanted to know if this approach was in line with your thinking or not?

![Screen Shot 2020-01-27 at 3 50 01 PM](https://user-images.githubusercontent.com/3939074/73224434-5343d480-411e-11ea-985e-79ab99a7cf7b.png)


part 1/6 of #1659