### PR TITLE
Remove obsolete references to shallow rendering

### DIFF
--- a/src/sidebar/components/menu-item.js
+++ b/src/sidebar/components/menu-item.js
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { createElement } from 'preact';
+import { Fragment, createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { onActivate } from '../util/on-activate';
@@ -57,9 +57,7 @@ export default function MenuItem({
   const rightIcon = isSubmenuItem ? renderedIcon : null;
 
   return (
-    // Wrapper element is a `<div>` rather than a `Fragment` to work around
-    // limitations of Enzyme's shallow rendering.
-    <div>
+    <Fragment>
       {/* FIXME-A11Y */}
       {/* eslint-disable-next-line jsx-a11y/role-supports-aria-props */}
       <div
@@ -114,7 +112,7 @@ export default function MenuItem({
           <div className="menu-item__submenu">{submenu}</div>
         </Slider>
       )}
-    </div>
+    </Fragment>
   );
 }
 

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -83,10 +83,6 @@ describe('GroupListItem', () => {
   });
 
   const createGroupListItem = (fakeGroup, props = {}) => {
-    // nb. Mount rendering is used here with a manually mocked `MenuItem`
-    // because `GroupListItem` renders multiple top-level elements (wrapped in
-    // a fragment) and `wrapper.update()` cannot be used in that case when using
-    // shallow rendering.
     return mount(
       <GroupListItem
         flash={fakeFlash}


### PR DESCRIPTION
We replaced use of Enzyme's shallow rendering for component unit tests
some time ago in https://github.com/hypothesis/client/pull/1470.