### PR TITLE
Improvements to Button component (0/6)

### DIFF
--- a/src/sidebar/components/button.js
+++ b/src/sidebar/components/button.js
@@ -15,24 +15,40 @@ import SvgIcon from './svg-icon';
  * - `useInputStyle`: for placing an icon-only button next to an input field
  * - `usePrimaryStyle`: for applying "primary action" styling
  * - `className`: arbitrary additional class name(s) to apply
+ *
+ * Buttons have an option `actionType` value that maps the `isActive`
+ * state to the appropriate corresponding aria attribute according to the
+ * `actionType` rules defined in the propTypes def below.
  */
 export default function Button({
   buttonText = '',
   className = '',
   icon = '',
   isActive = false,
-  onClick = () => null,
-  style = {},
   title,
+  actionType,
   useCompactStyle = false,
   useInputStyle = false,
   usePrimaryStyle = false,
+  ...props
 }) {
   // If `buttonText` is provided, the `title` prop is optional and the `button`'s
   // `title` attribute will be set from the `buttonText`
   title = title || buttonText;
 
   const baseClassName = buttonText ? 'button--labeled' : 'button--icon-only';
+
+  // The `actionType` determines which aria attribute is used to
+  // express the `isActive` prop.
+  //
+  // "toggle" for aria-pressed
+  // "group" for aria-expanded
+  const ariaProp = {};
+  if (actionType === 'toggle') {
+    ariaProp['aria-pressed'] = isActive;
+  } else if (actionType === 'group') {
+    ariaProp['aria-expanded'] = isActive;
+  }
 
   return (
     <button
@@ -47,10 +63,9 @@ export default function Button({
         },
         className
       )}
-      onClick={onClick}
-      aria-pressed={isActive}
       title={title}
-      style={style}
+      {...ariaProp}
+      {...props}
     >
       {icon && <SvgIcon name={icon} className="button__icon" />}
       {buttonText}
@@ -105,16 +120,18 @@ Button.propTypes = {
   /** Is this button currently in an "active"/"on" state? */
   isActive: propTypes.bool,
 
-  /** callback for button clicks */
-  onClick: propTypes.func,
-
-  /** optional inline styling  */
-  style: propTypes.object,
-
   /**
    * `title`, used for button `title`, is required unless `buttonText` is present
    */
   title: requiredStringIfButtonTextMissing,
+
+  /**
+   * One of: "toggle", "group".
+   *  "toggle" type uses the `aria-pressed` attribute in conjunction with `isActive`.
+   *  "group" type uses the `aria-expanded` attribute in conjunction with `isActive`.
+   *  If this property is not provided then both aria attributes are undefined.
+   */
+  actionType: propTypes.string,
 
   /** Allows a variant of button that takes up less space */
   useCompactStyle: propTypes.bool,
@@ -127,4 +144,11 @@ Button.propTypes = {
    * differentiating styles will be applied.
    */
   usePrimaryStyle: propTypes.bool,
+
+  /**
+   * Any other provided props will be passed directly to the
+   * <button> tag. Use this for extra event handlers or attributes
+   * not covered by the explicit props above.
+   */
+  props: propTypes.object,
 };

--- a/src/sidebar/components/test/button-test.js
+++ b/src/sidebar/components/test/button-test.js
@@ -7,22 +7,13 @@ import { $imports } from '../button';
 import mockImportedComponents from './mock-imported-components';
 
 describe('Button', () => {
-  let fakeOnClick;
-
   function createComponent(props = {}) {
     return mount(
-      <Button
-        icon="fakeIcon"
-        isActive={false}
-        title="My Action"
-        onClick={fakeOnClick}
-        {...props}
-      />
+      <Button icon="fakeIcon" isActive={false} title="My Action" {...props} />
     );
   }
 
   beforeEach(() => {
-    fakeOnClick = sinon.stub();
     $imports.$mock(mockImportedComponents());
   });
 
@@ -32,7 +23,6 @@ describe('Button', () => {
 
   it('adds active className if `isActive` is `true`', () => {
     const wrapper = createComponent({ isActive: true });
-
     assert.isTrue(wrapper.find('button').hasClass('is-active'));
   });
 
@@ -41,9 +31,22 @@ describe('Button', () => {
     assert.equal(wrapper.find('SvgIcon').prop('name'), 'fakeIcon');
   });
 
-  it('sets ARIA `aria-pressed` attribute if `isActive`', () => {
-    const wrapper = createComponent({ isActive: true });
+  it('sets ARIA `aria-pressed` attribute if `isActive` and `actionType` is "toggle"', () => {
+    const wrapper = createComponent({ isActive: true, actionType: 'toggle' });
     assert.isTrue(wrapper.find('button').prop('aria-pressed'));
+    assert.equal(wrapper.find('button').prop('aria-expanded'), undefined);
+  });
+
+  it('sets ARIA `aria-expanded` attribute if `isActive` and `actionType` is "group"', () => {
+    const wrapper = createComponent({ isActive: true, actionType: 'group' });
+    assert.isTrue(wrapper.find('button').prop('aria-expanded'));
+    assert.equal(wrapper.find('button').prop('aria-pressed'), undefined);
+  });
+
+  it('has no ARIA prop if `actionType` is not provided', () => {
+    const wrapper = createComponent({ isActive: true });
+    assert.equal(wrapper.find('button').prop('aria-expanded'), undefined);
+    assert.equal(wrapper.find('button').prop('aria-pressed'), undefined);
   });
 
   it('sets `title` to provided `title` prop', () => {
@@ -58,12 +61,6 @@ describe('Button', () => {
     });
 
     assert.equal(wrapper.find('button').prop('title'), 'My Label');
-  });
-
-  it('invokes `onClick` callback when pressed', () => {
-    const wrapper = createComponent();
-    wrapper.find('button').simulate('click');
-    assert.calledOnce(fakeOnClick);
   });
 
   it('adds additional class name passed in `className` prop', () => {
@@ -86,7 +83,11 @@ describe('Button', () => {
 
   it('sets primary style if `usePrimaryStyle` is set`', () => {
     const wrapper = createComponent({ usePrimaryStyle: true });
-
     assert.isTrue(wrapper.find('button').hasClass('button--primary'));
+  });
+
+  it('maps any unmapped props to the <button> tag', () => {
+    const wrapper = createComponent({ 'data-testprop': 'test' });
+    assert.equal(wrapper.find('button').prop('data-testprop'), 'test');
   });
 });


### PR DESCRIPTION
In doing the conversion for markdown-editor.js and then menu-item.js I  realized the Button component needed a few more things. I started adding props but it quickly became unwieldy and I think the better approach is to just use a few core props for structure and then allow arbitrary props to be passed down to the <button> tag directly. Things like `style`, `onClick`, `onKeyPress`, `disabled` would otherwise all need to be mapped. It became more complicated with `onActivate` which is a wrapper around `onKeyPress`. The simple solution here is a catch-all!

By doing that, I got rid of `style` and `onClick` because they are now part of the catch all. Additionally, when converting menu-item, I needed to use `aria-expanded` rather than `aria-pressed` because this was a control group. Because `isActive` was already mapped to `aria-pressed` value, it made sense to add a custom `actionType` attribute that could be one of 3 values.

"toggle"
"group"
undefined

This then maps `isActive` to the correct aria attribute for the button's type.  I could use suggestions on a better name. I wanted to use `type` but that is overloaded from HTML on a <button>

I also found it necessary to have the aria attribute be undefined because some buttons don't have a toggle state such as the publish button. In its previous form, the Button component forced `aria-pressed` all the time and I don't believe it allowed it to be undefined which is a third value state and distinguished from `false`. Now it can do all 3 states.

Required for https://github.com/hypothesis/client/issues/1659