### PR TITLE
Improve a11y testing for AutocompleteList and TagEditor

### DIFF
--- a/src/sidebar/components/autocomplete-list.js
+++ b/src/sidebar/components/autocomplete-list.js
@@ -53,19 +53,25 @@ export default function AutocompleteList({
   }, [activeItem, itemPrefixId, list, listFormatter, onSelectItem]);
 
   const props = id ? { id } : {}; // only add the id if its passed
+  const isHidden = list.length === 0 || !open;
   return (
-    <div className="autocomplete-list">
-      {list.length > 0 && open && (
-        <ul
-          className="autocomplete-list__items"
-          tabIndex="-1"
-          aria-label="Suggestions"
-          role="listbox"
-          {...props}
-        >
-          {items}
-        </ul>
+    <div
+      className={classnames(
+        {
+          'is-hidden': isHidden,
+        },
+        'autocomplete-list'
       )}
+    >
+      <ul
+        className="autocomplete-list__items"
+        tabIndex="-1"
+        aria-label="Suggestions"
+        role="listbox"
+        {...props}
+      >
+        {items}
+      </ul>
     </div>
   );
 }

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -109,6 +109,7 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
     }
     updateTags([...tagList, value]);
     setSuggestionsListOpen(false);
+    setActiveItem(-1);
 
     inputEl.current.value = '';
     inputEl.current.focus();
@@ -248,6 +249,7 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
           className="tag-editor__input"
           type="text"
           autoComplete="off"
+          aria-label="Add tag field"
           aria-autocomplete="list"
           aria-activedescendant={activeDescendant}
           aria-controls={`${tagEditorId}-autocomplete-list`}

--- a/src/sidebar/components/test/autocomplete-list-test.js
+++ b/src/sidebar/components/test/autocomplete-list-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import AutocompleteList from '../autocomplete-list';
 import { $imports } from '../autocomplete-list';
 
+import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
 describe('AutocompleteList', function() {
@@ -33,12 +34,12 @@ describe('AutocompleteList', function() {
 
   it('does not render the list when `open` is false', () => {
     const wrapper = createComponent();
-    assert.isFalse(wrapper.find('.autocomplete-list__items').exists());
+    assert.isTrue(wrapper.find('.autocomplete-list').hasClass('is-hidden'));
   });
 
   it('does not render the list when `list` is empty', () => {
     const wrapper = createComponent({ open: true, list: [] });
-    assert.isFalse(wrapper.find('.autocomplete-list__items').exists());
+    assert.isTrue(wrapper.find('.autocomplete-list').hasClass('is-hidden'));
   });
 
   it('sets unique keys to the <li> items', () => {
@@ -160,4 +161,22 @@ describe('AutocompleteList', function() {
         .prop('aria-selected')
     );
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        name: 'list open',
+        content: () => {
+          return createComponent({ open: true });
+        },
+      },
+      {
+        name: 'list open, first item selected',
+        content: () => {
+          return createComponent({ open: true, activeItem: 1 });
+        },
+      },
+    ])
+  );
 });

--- a/src/styles/sidebar/components/autocomplete-list.scss
+++ b/src/styles/sidebar/components/autocomplete-list.scss
@@ -2,6 +2,9 @@
 
 .autocomplete-list {
   position: relative;
+  &.is-hidden {
+    display: none;
+  }
 }
 
 .autocomplete-list__items {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -20,7 +20,7 @@ $grey-4: #a6a6a6;
 // minus blue tint.
 $grey-semi: #9c9c9c;
 
-$grey-5: #767676;
+$grey-5: #737373;
 
 // Interim color variable for migration purposes, as the step between `$grey-5`
 // and `$grey-6` is large. Represents `base-mid` in proposed future palette,


### PR DESCRIPTION
This diff is a bit ugly because I moved some of the tests around, but there are far less changes in the test file than what the diff indicates, sorry about that. I wanted to move all the a11y tests and related a11y things to the end of the test file.

**Here is what this covers**

- Adds axe tests for both TagEditor and AutocompleteList
- I reset activeItem to -1 after adding a tag. This was not being done before, but I'm now seeing a problem with the screen reader because it still thinks the active index is set. This was not an issue previously because of how the AutocompleteList was being shown/hidden via DOM, where as now, its via `display:none` (read below for explanation)
- Some minor fixes ups to get those tests to pass (as follows)
  - grey-5 is very very slightly darker, I decided to make this across the whole app because we use that against the grey-0 background often enough. This meets the 4.5:1 contrast req.
  - Needed to add `aria-label` - I was allowing placeholder to be the label, but a11y lint didn't like that, probably best to just add the label. I decided to call it "Add tag field" but I'm open to other suggestions. I liked the idea of adding the "field" suffix to reinforce to the user what the thing is.
  - Needed to do full DOM testing of the suggestions list in tests. This is one of those components where you can't just allow the mockImportedComponents to mock everything so I'm importing AutocompleteList in the TagEditor test and its getting fully rendered, otherwise it won't pass axe tests. I suspect we may encounter this again.
AutocompleteList can't be done with an if condition on the items anymore. This is one of those sad moments where react/preact is too good for its own good. I really like the idea of hiding DOM elements but it breaks the a11y tests when the id counterparts of the aria tags are not in the DOM! So, I followed what they did on w3.org and added a hidden style with `display:none`

@jaredpdesigns I would use some feedback on the grey-5, the change is so small its not even worth a screen shot, but I wanted to make sure it fits with the rest of our grays and / or do we want to approach this contrast thing more methodically?
```
// Interim color variable for migration purposes.
// Used as very-subtle background color for form fields. $grey-1 is too dark.
$grey-0: #fafafa;
$grey-1: #f2f2f2;
$grey-2: #ececec;
$grey-3: #dbdbdb;
$grey-4: #a6a6a6;
// Interim color variable for migration purposes, as the step between `$grey-4`
// and `$grey-5` is large. Represents `base-semi` in proposed future palette,
// minus blue tint.
$grey-semi: #9c9c9c;
$grey-5: #737373;
// Interim color variable for migration purposes, as the step between `$grey-5`
// and `$grey-6` is large. Represents `base-mid` in proposed future palette,
// minus blue tint.
$grey-mid: #595959;
$grey-6: #3f3f3f;
$grey-7: #202020;
$black: #000 !default;``` 
