### PR TITLE
Build CSS bundles before running Karma

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -397,8 +397,16 @@ function runKarma({ singleRun }, done) {
   ).start();
 }
 
-gulp.task('test', done => runKarma({ singleRun: true }, done));
-gulp.task('test-watch', done => runKarma({ singleRun: false }, done));
+// Unit and integration testing tasks.
+// Some (eg. a11y) tests rely on CSS bundles, so build these first.
+gulp.task(
+  'test',
+  gulp.series('build-css', done => runKarma({ singleRun: true }, done))
+);
+gulp.task(
+  'test-watch',
+  gulp.series('build-css', done => runKarma({ singleRun: false }, done))
+);
 
 gulp.task(
   'upload-sourcemaps',


### PR DESCRIPTION
This is important for a11y tests which rely on having styles present.

This takes about ~1.2s on my machine currently. We can reclaim that time
in future by adding some caching to speed up the JS bundle build.