### PR TITLE
Improve a11y lint

### DIFF
--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -73,9 +73,6 @@ function GroupListItem({
   const copyLinkLabel =
     group.type === 'private' ? 'Copy invite link' : 'Copy activity link';
 
-  // Close the submenu when any clicks happen which close the top-level menu.
-  const collapseSubmenu = () => onExpand(false);
-
   return (
     <MenuItem
       icon={group.logo || 'blank'}
@@ -89,9 +86,7 @@ function GroupListItem({
       onToggleSubmenu={toggleSubmenu}
       submenu={
         <Fragment>
-          {/* FIXME-A11Y */}
-          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */}
-          <ul onClick={collapseSubmenu}>
+          <ul>
             {activityUrl && (
               <li>
                 <MenuItem

--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -5,6 +5,7 @@ import propTypes from 'prop-types';
 import serviceConfig from '../service-config';
 import useStore from '../store/use-store';
 import { isThirdPartyUser } from '../util/account-id';
+import { orgName } from '../util/group-list-item-common';
 import groupsByOrganization from '../util/group-organizations';
 import isThirdPartyService from '../util/is-third-party-service';
 import { withServices } from '../util/service-context';
@@ -61,13 +62,15 @@ function GroupList({ serviceUrl, settings }) {
   let label;
   if (focusedGroup) {
     const icon = focusedGroup.organization.logo;
+    // If org name is missing, then treat this icon like decoration
+    // and pass an empty string.
+    const altName = orgName(focusedGroup) ? orgName(focusedGroup) : '';
     label = (
       <span className="group-list__menu-label">
-        {/* FIXME-A11Y */}
-        {/* eslint-disable-next-line jsx-a11y/alt-text */}
         <img
           className="group-list__menu-icon"
           src={icon || publisherProvidedIcon(settings)}
+          alt={altName}
         />
         {focusedGroup.name}
       </span>

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -12,12 +12,7 @@ describe('GroupList', () => {
   let fakeServiceUrl;
   let fakeSettings;
   let fakeStore;
-
-  const testGroup = {
-    id: 'testgroup',
-    name: 'Test group',
-    organization: { id: 'testorg', name: 'Test Org' },
-  };
+  let testGroup;
 
   function createGroupList() {
     return mount(
@@ -47,6 +42,12 @@ describe('GroupList', () => {
   }
 
   beforeEach(() => {
+    testGroup = {
+      id: 'testgroup',
+      name: 'Test group',
+      organization: { id: 'testorg', name: 'Test Org' },
+    };
+
     fakeServiceUrl = sinon.stub();
     fakeSettings = {
       authDomain: 'hypothes.is',
@@ -152,12 +153,28 @@ describe('GroupList', () => {
     assert.equal(newGroupButton.props().href, 'https://example.com/groups/new');
   });
 
-  it('displays the group name and icon as static text if there is only one group and no actions available', () => {
-    $imports.$mock({
-      '../util/is-third-party-service': () => true,
+  context('when `isThirdPartyService` is true', () => {
+    beforeEach(() => {
+      $imports.$mock({
+        '../util/is-third-party-service': () => true,
+      });
     });
-    const wrapper = createGroupList();
-    assert.equal(wrapper.text(), 'Test group');
+
+    it('displays the group name and icon as static text if there is only one group and no actions available', () => {
+      const wrapper = createGroupList();
+      assert.equal(wrapper.text(), 'Test group');
+    });
+
+    it('uses the organization name for the `alt` attribute', () => {
+      const wrapper = createGroupList();
+      assert.equal(wrapper.find('img').prop('alt'), 'Test Org');
+    });
+
+    it('uses a blank string for the `alt` attribute if the organization name is missing', () => {
+      testGroup.organization = {};
+      const wrapper = createGroupList();
+      assert.equal(wrapper.find('img').prop('alt'), '');
+    });
   });
 
   it('renders a placeholder if groups have not loaded yet', () => {


### PR DESCRIPTION
Small PR to land some of the ease fixes.

- We can't have click handlers on non-interactive elements, but turns out, I don't think we even need this click handler at all because `<Menu>` a distant relative of `<GroupListItem>` has a useElementShouldClose(). Once the Menu opens again, the `isExpanded` prop is reset to `false` so it works just the same. I also tested the screen readers and they don't change as a result of removing the collapseSubmenu method.

- The icon in group-list.js did have not any value in being read out and just made it more confusing so I treat it like a decorative alt tag (blank string)

Fixes some of https://github.com/hypothesis/client/issues/1727