### PR TITLE
Rename `annotations` -> `annotationsService` (establish service-naming pattern)

### DIFF
--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -6,7 +6,7 @@ import * as tabs from '../util/tabs';
 function SidebarContentController(
   $scope,
   analytics,
-  annotations,
+  annotationsService,
   store,
   frameSync,
   rootThread,
@@ -120,7 +120,7 @@ function SidebarContentController(
       }
 
       const searchUris = store.searchUris();
-      annotations.load(searchUris, currentGroupId);
+      annotationsService.load(searchUris, currentGroupId);
     },
     true
   );

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -68,7 +68,7 @@ describe('sidebar.components.sidebar-content', function() {
       $provide.value('frameSync', fakeFrameSync);
       $provide.value('rootThread', fakeRootThread);
       $provide.value('streamer', fakeStreamer);
-      $provide.value('annotations', fakeAnnotations);
+      $provide.value('annotationsService', fakeAnnotations);
       $provide.value('settings', fakeSettings);
     });
   });

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -252,7 +252,7 @@ function startAngularApp(config) {
 
     .service('analytics', analyticsService)
     .service('annotationMapper', annotationMapperService)
-    .service('annotations', annotationsService)
+    .service('annotationsService', annotationsService)
     .service('api', apiService)
     .service('apiRoutes', apiRoutesService)
     .service('auth', authService)

--- a/src/sidebar/services/annotations.js
+++ b/src/sidebar/services/annotations.js
@@ -1,7 +1,7 @@
 import SearchClient from '../search-client';
 
 // @ngInject
-export default function annotations(
+export default function annotationsService(
   annotationMapper,
   api,
   store,

--- a/src/sidebar/services/test/annotations-test.js
+++ b/src/sidebar/services/test/annotations-test.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'tiny-emitter';
 
-import annotations from '../annotations';
+import annotationsService from '../annotations';
 import { $imports } from '../annotations';
 
 let searchClients;
@@ -29,7 +29,7 @@ class FakeSearchClient extends EventEmitter {
   }
 }
 
-describe('annotations', () => {
+describe('annotationService', () => {
   let fakeStore;
   let fakeApi;
   let fakeAnnotationMapper;
@@ -90,7 +90,7 @@ describe('annotations', () => {
         return { uri: uri };
       })
     );
-    return annotations(
+    return annotationsService(
       fakeAnnotationMapper,
       fakeApi,
       fakeStore,


### PR DESCRIPTION
This PR proposes the renaming of the `annotations` service module to `annotationService` as a possible pattern, or at least a discussion starter, for a naming convention for client sidebar services.

## Motivation

1. Injected services become available arguments to function components, and their naming can be ambiguous—e.g. does the `groups` prop for a given component refer to an array of `group` objects, or to the service?
1. Within the service modules themselves, ambiguity can arise if the default export is, say, called `annotations` and methods within it take `annotations` as a parameter.
1. Ambiguous naming makes for challenging code grepping for uses of services.
1. We have been discussing the idea of having a single service to correspond to both a single object ("model"-ish thing) and a collection of same, e.g. a single service to handle a single annotation and a collection of annotations. Should naming of said service be singular or plural?

## Proposed Conventions (DISCUSS!)

* Names should be singular. This notion I came to for two reasons. First, the fatuous: it's easier to pronounce `annotationService` than `annotationsService`. But more materially, services in our `python` apps, as well as table and model names, are singular. So I'm leaning toward consistency across our stack.
* The default export of service modules should use the `*Service` naming but the filenames should not. i.e. `annotation.js`, not `annotation-service.js`. This one @LMS007 may have some comments on, as he leans towards the `*-service.js` naming, but I feel it's redundant as they are already in a `services` directory and we don't use suffixes like this for our other app entities.
* A nod to @robertknight 's opinion: one service module for any given entity, e.g. `annotation`, `group`, which includes operations on single objects and collections of objects.

## Now What?

* Discuss.
* Once we land on a naming convention, discuss whether we want to try to migrate service names over quickly or take it apace?
* The service touched in this PR, whatever it's called in the end, will have some CRUD biz logic for (single) annotations added to it as part of the `Annotation` migration...

As such, this is distantly part of #1650 