### PR TITLE
Fix a11y attribute issues in MenuItem component

### DIFF
--- a/src/sidebar/components/menu-item.js
+++ b/src/sidebar/components/menu-item.js
@@ -55,13 +55,15 @@ export default function MenuItem({
   }
   const leftIcon = isSubmenuItem ? null : renderedIcon;
   const rightIcon = isSubmenuItem ? renderedIcon : null;
+  // Only add `aria-checked` attribute if `isSubmenuItem` is false. Ensure that the value
+  // is a "true" or "false" string
+  const ariaChecked = !isSubmenuItem
+    ? { 'aria-checked': (!!isSelected).toString() }
+    : {};
 
   return (
     <Fragment>
-      {/* FIXME-A11Y */}
-      {/* eslint-disable-next-line jsx-a11y/role-supports-aria-props */}
       <div
-        aria-checked={isSelected}
         className={classnames('menu-item', {
           'menu-item--submenu': isSubmenuItem,
           'is-disabled': isDisabled,
@@ -69,9 +71,17 @@ export default function MenuItem({
           'is-selected': isSelected,
         })}
         role="menuitem"
-        {...(onClick && onActivate('menuitem', onClick))}
       >
-        <div className="menu-item__action">
+        <div
+          className="menu-item__action"
+          // When `isSubmenuItem` is false, treat these items as "radio" buttons since they can be
+          // "selected". Otherwise this is treated as a "button". Note, If there is no `onClick`
+          // event, then no role will be added in any case.
+          {...ariaChecked}
+          // onActivate will add the `role` attribute
+          {...(onClick &&
+            onActivate(isSubmenuItem ? 'button' : 'radio', onClick))}
+        >
           {hasLeftIcon && (
             <div className="menu-item__icon-container">{leftIcon}</div>
           )}

--- a/src/sidebar/components/test/menu-item-test.js
+++ b/src/sidebar/components/test/menu-item-test.js
@@ -22,7 +22,7 @@ describe('MenuItem', () => {
   it('invokes `onClick` callback when clicked', () => {
     const onClick = sinon.stub();
     const wrapper = createMenuItem({ onClick });
-    wrapper.find('[role="menuitem"]').simulate('click');
+    wrapper.find('.menu-item__action').simulate('click');
     assert.called(onClick);
   });
 
@@ -150,6 +150,71 @@ describe('MenuItem', () => {
         .text(),
       'Submenu content'
     );
+  });
+
+  describe('accessibility attributes', () => {
+    context('when `isSubmenuItem` is truthy', () => {
+      it('sets `role="button"` attribute"', () => {
+        //  submenu button
+        const onClick = sinon.stub();
+        const wrapper = createMenuItem({ onClick, isSubmenuItem: true });
+        assert.equal(wrapper.find('.menu-item__action').prop('role'), 'button');
+      });
+
+      it('does not add the `role` attribute if `onClick` is missing', () => {
+        //  submenu link
+        const wrapper = createMenuItem({ isSubmenuItem: true });
+        assert.equal(
+          wrapper.find('.menu-item__action').prop('role'),
+          undefined
+        );
+      });
+
+      it('does not add the `aria-checked` attribute', () => {
+        //  submenu button
+        const onClick = sinon.stub();
+        const wrapper = createMenuItem({ onClick, isSubmenuItem: true });
+        assert.equal(
+          wrapper.find('.menu-item__action').prop('aria-checked'),
+          undefined
+        );
+      });
+    });
+
+    context('when `isSubmenuItem` is falsey', () => {
+      it('sets `role="radio"` attribute', () => {
+        const onClick = sinon.stub();
+        const wrapper = createMenuItem({ onClick });
+        assert.equal(wrapper.find('.menu-item__action').prop('role'), 'radio');
+      });
+
+      it('sets `aria-checked` to "false" when `isSelected` is missing', () => {
+        const onClick = sinon.stub();
+        const wrapper = createMenuItem({ onClick });
+        assert.equal(
+          wrapper.find('.menu-item__action').prop('aria-checked'),
+          'false'
+        );
+      });
+
+      it('sets `aria-checked` to "false" when `isSelected` is `false`', () => {
+        const onClick = sinon.stub();
+        const wrapper = createMenuItem({ onClick, isSelected: false });
+        assert.equal(
+          wrapper.find('.menu-item__action').prop('aria-checked'),
+          'false'
+        );
+      });
+
+      it('sets `aria-checked` to "true" when `isSelected` is `true`', () => {
+        const onClick = sinon.stub();
+        const wrapper = createMenuItem({ onClick, isSelected: true });
+        assert.equal(
+          wrapper.find('.menu-item__action').prop('aria-checked'),
+          'true'
+        );
+      });
+    });
   });
 
   it(


### PR DESCRIPTION
I addressed the lint issues and assigned the logical aria roles to the items when they needed one. Note, in the case of links, there is no role because we don't use the `<div>` as the "thing" that serves as the link. There is simply a nested <a> that is focusable (as was prior to this PR.)


Fix various a11y lint issues with aria props
 - Topmenu items have role=“radio” since they have a selected state
 - Submenu items that are buttons have role=“button” attribute
 - Submenu items that are links have no role attribute (as there is an <a> tag)
 - Add appropriate aria attribute tests