### PR TITLE
Fix eslint issues in HelpPanel component

### DIFF
--- a/src/sidebar/components/help-panel.js
+++ b/src/sidebar/components/help-panel.js
@@ -105,34 +105,30 @@ function HelpPanel({ auth, session }) {
         </h3>
         <div className="help-panel__footer">
           {activeSubPanel === 'versionInfo' && (
-            // FIXME-A11Y
-            // eslint-disable-next-line jsx-a11y/anchor-is-valid
-            <a
-              href="#"
+            <button
               className="help-panel__sub-panel-link"
               onClick={e => openSubPanel(e, 'tutorial')}
+              aria-label="Show tutorial panel"
             >
-              <div>Getting started</div>
+              Getting started
               <SvgIcon
                 name="arrow-right"
                 className="help-panel__sub-panel-link-icon"
               />
-            </a>
+            </button>
           )}
           {activeSubPanel === 'tutorial' && (
-            // FIXME-A11Y
-            // eslint-disable-next-line jsx-a11y/anchor-is-valid
-            <a
-              href="#"
+            <button
               className="help-panel__sub-panel-link"
               onClick={e => openSubPanel(e, 'versionInfo')}
+              aria-label="Show version information panel"
             >
-              <div>About this version</div>
+              About this version
               <SvgIcon
                 name="arrow-right"
                 className="help-panel__sub-panel-link-icon"
               />
-            </a>
+            </button>
           )}
         </div>
       </div>

--- a/src/styles/sidebar/components/help-panel.scss
+++ b/src/styles/sidebar/components/help-panel.scss
@@ -1,3 +1,4 @@
+@use "../../mixins/buttons";
 @use "../../variables" as var;
 
 .help-panel {
@@ -29,6 +30,7 @@
   }
 
   &__sub-panel-link {
+    @include buttons.reset-native-btn-styles;
     display: flex;
     align-items: center;
     margin-left: auto;


### PR DESCRIPTION
This is kind of one of those "if it walks like a duck" lint issues

Motivations for changing `<a>` to `<button>` is here
https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md#case-i-want-to-perform-an-action-and-need-a-clickable-ui-element

I did not use our button component in this instance because we don’t have control over the icon position relative to the text. _This is something we may need to think on when doing some Button refactoring._ 