### PR TITLE
Add `save` method to `AnnotationsService`; use it in `AnnotationOmega`

### DIFF
--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -72,6 +72,7 @@ function bootHypothesisClient(doc, config) {
     'es2015',
     'es2016',
     'es2017',
+    'es2018',
     'url',
   ]);
 

--- a/src/shared/polyfills/es2018.js
+++ b/src/shared/polyfills/es2018.js
@@ -1,0 +1,1 @@
+import 'core-js/es/promise/finally';

--- a/src/shared/polyfills/index.js
+++ b/src/shared/polyfills/index.js
@@ -57,6 +57,10 @@ const needsPolyfill = {
     return !hasMethods(Object, 'entries', 'values');
   },
 
+  es2018: () => {
+    return !hasMethods(Promise.prototype, 'finally');
+  },
+
   // Test for a fully-working URL constructor.
   url: () => {
     try {

--- a/src/shared/polyfills/test/index-test.js
+++ b/src/shared/polyfills/test/index-test.js
@@ -37,6 +37,10 @@ describe('shared/polyfills/index', () => {
         providesMethod: [Object, 'entries'],
       },
       {
+        set: 'es2018',
+        providesMethod: [Promise.prototype, 'finally'],
+      },
+      {
         set: 'string.prototype.normalize',
         providesMethod: [String.prototype, 'normalize'],
       },


### PR DESCRIPTION
This PR is contains a re-implementation of annotation-save functionality in the `annotationsService`, as well as an update to `AnnotationOmega` to make it use the new service method for saving annotations.

Part of #1650

This PR started out as a WIP/prototype. Discussion of that follows below:

-----

~~This PR is an annotated set of changes representing a re-implementation of annotation-save functionality in the `annotationsService` (as such this depends on #1755, but it doesn't matter much, as it is not meant for merge anyway).~~

Given that saving an annotation (or updating one, same general operation) is critical biz logic, I want to get the prototype of a newly-factored way of doing this in front of folks and reviewed with good scrutiny (to this effect, I'd like to schedule a synchronous code review for this, with this PR as a helping hand).

The new `save` method in `annotationsService` implements logic currently spread around the `Annotation` component controller, in its `save` member method: https://github.com/hypothesis/client/blob/ec63961a743dc15e7112290816e19b38ac5d73e5/src/sidebar/components/annotation.js#L264-L302 , its `save` function: https://github.com/hypothesis/client/blob/ec63961a743dc15e7112290816e19b38ac5d73e5/src/sidebar/components/annotation.js#L42-L65 and its `updateModel` function: https://github.com/hypothesis/client/blob/ec63961a743dc15e7112290816e19b38ac5d73e5/src/sidebar/components/annotation.js#L5-L19

This PR also shows how `AnnotationOmega` could use this service method within the publish button (i.e. save) click callback.

This "works," as in, it appears to work with the most straightforward use cases in-(a single)browser and is totally untested. There are miles to go here before sleep. But! I wanted to get eyes on this in its current state before going further.