### PR TITLE
Remove unnecessary registration of several classes / functions with Angular

### DIFF
--- a/src/sidebar/components/test/thread-list-test.js
+++ b/src/sidebar/components/test/thread-list-test.js
@@ -4,7 +4,7 @@ import EventEmitter from 'tiny-emitter';
 
 import * as util from '../../directive/test/util';
 import events from '../../events';
-import threadList from '../thread-list';
+import threadList, { $imports } from '../thread-list';
 
 const annotFixtures = immutable({
   annotation: { $tag: 't1', id: '1', text: 'text' },
@@ -132,14 +132,19 @@ describe('threadList', function() {
 
   beforeEach(function() {
     angular.mock.module('app', {
-      VirtualThreadList: FakeVirtualThreadList,
       settings: fakeSettings,
       store: fakeStore,
     });
     threadListContainers = [];
+
+    $imports.$mock({
+      '../virtual-thread-list': FakeVirtualThreadList,
+    });
   });
 
   afterEach(function() {
+    $imports.$restore();
+
     threadListContainers.forEach(function(el) {
       el.remove();
     });

--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -1,5 +1,6 @@
 import events from '../events';
 import * as metadata from '../util/annotation-metadata';
+import VirtualThreadList from '../virtual-thread-list';
 
 /**
  * Component which displays a virtualized list of annotation threads.
@@ -47,13 +48,7 @@ const virtualThreadOptions = {
 };
 
 // @ngInject
-function ThreadListController(
-  $element,
-  $scope,
-  settings,
-  store,
-  VirtualThreadList
-) {
+function ThreadListController($element, $scope, settings, store) {
   // `visibleThreads` keeps track of the subset of all threads matching the
   // current filters which are in or near the viewport and the view then renders
   // only those threads, using placeholders above and below the visible threads

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -199,7 +199,6 @@ import store from './store';
 
 import Discovery from '../shared/discovery';
 
-import { encode as urlEncodeFilter } from './filter/url';
 import OAuthClient from './util/oauth-client';
 import * as random from './util/random';
 import * as time from './util/time';
@@ -255,7 +254,6 @@ function startAngularApp(config) {
     .register('serviceConfig', { value: serviceConfig })
     .register('settings', { value: config })
     .register('time', { value: time })
-    .register('urlEncodeFilter', { value: urlEncodeFilter });
 
   // Register services which only Angular can construct, once Angular has
   // constructed them.
@@ -345,7 +343,6 @@ function startAngularApp(config) {
     .value('serviceConfig', container.get('serviceConfig'))
     .value('settings', container.get('settings'))
     .value('time', container.get('time'))
-    .value('urlEncodeFilter', container.get('urlEncodeFilter'))
 
     .config(configureLocation)
     .config(configureRoutes)

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -317,14 +317,12 @@ function startAngularApp(config) {
     .service('annotationMapper', () => container.get('annotationMapper'))
     .service('annotationsService', () => container.get('annotationsService'))
     .service('api', () => container.get('api'))
-    .service('apiRoutes', () => container.get('apiRoutes'))
     .service('auth', () => container.get('auth'))
     .service('bridge', () => container.get('bridge'))
     .service('features', () => container.get('features'))
     .service('flash', () => container.get('flash'))
     .service('frameSync', () => container.get('frameSync'))
     .service('groups', () => container.get('groups'))
-    .service('localStorage', () => container.get('localStorage'))
     .service('permissions', () => container.get('permissions'))
     .service('persistedDefaults', () => container.get('persistedDefaults'))
     .service('rootThread', () => container.get('rootThread'))
@@ -334,8 +332,6 @@ function startAngularApp(config) {
     .service('streamer', () => container.get('streamer'))
     .service('streamFilter', () => container.get('streamFilter'))
     .service('tags', () => container.get('tags'))
-    .service('unicode', () => container.get('unicode'))
-    .service('viewFilter', () => container.get('viewFilter'))
 
     // Redux store
     .service('store', () => container.get('store'))

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -2,7 +2,6 @@ import { jsonConfigsFrom } from '../shared/settings';
 
 import crossOriginRPC from './cross-origin-rpc.js';
 import addAnalytics from './ga';
-import serviceConfig from './service-config';
 import disableOpenerForExternalLinks from './util/disable-opener-for-external-links';
 import { fetchConfig } from './util/fetch-config';
 import * as sentry from './util/sentry';
@@ -197,13 +196,6 @@ import store from './store';
 
 // Utilities.
 
-import Discovery from '../shared/discovery';
-
-import OAuthClient from './util/oauth-client';
-import * as random from './util/random';
-import * as time from './util/time';
-import VirtualThreadList from './virtual-thread-list';
-
 import { Injector } from '../shared/injector';
 
 function startAngularApp(config) {
@@ -246,14 +238,8 @@ function startAngularApp(config) {
   // that use them, since they don't depend on instances of other services.
   container
     .register('$window', { value: window })
-    .register('Discovery', { value: Discovery })
-    .register('OAuthClient', { value: OAuthClient })
-    .register('VirtualThreadList', { value: VirtualThreadList })
     .register('isSidebar', { value: isSidebar })
-    .register('random', { value: random })
-    .register('serviceConfig', { value: serviceConfig })
-    .register('settings', { value: config })
-    .register('time', { value: time })
+    .register('settings', { value: config });
 
   // Register services which only Angular can construct, once Angular has
   // constructed them.
@@ -335,14 +321,8 @@ function startAngularApp(config) {
     .service('store', () => container.get('store'))
 
     // Utilities
-    .value('Discovery', container.get('Discovery'))
-    .value('OAuthClient', container.get('OAuthClient'))
-    .value('VirtualThreadList', container.get('VirtualThreadList'))
     .value('isSidebar', container.get('isSidebar'))
-    .value('random', container.get('random'))
-    .value('serviceConfig', container.get('serviceConfig'))
     .value('settings', container.get('settings'))
-    .value('time', container.get('time'))
 
     .config(configureLocation)
     .config(configureRoutes)

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -2,6 +2,7 @@ import debounce from 'lodash.debounce';
 
 import bridgeEvents from '../../shared/bridge-events';
 import events from '../events';
+import Discovery from '../../shared/discovery';
 import uiConstants from '../ui-constants';
 import * as metadata from '../util/annotation-metadata';
 
@@ -39,13 +40,7 @@ export function formatAnnot(ann) {
  * sidebar.
  */
 // @ngInject
-export default function FrameSync(
-  $rootScope,
-  $window,
-  Discovery,
-  store,
-  bridge
-) {
+export default function FrameSync($rootScope, $window, store, bridge) {
   // Set of tags of annotations that are currently loaded into the frame
   const inFrame = new Set();
 

--- a/src/sidebar/services/oauth-auth.js
+++ b/src/sidebar/services/oauth-auth.js
@@ -1,5 +1,6 @@
 import events from '../events';
 import serviceConfig from '../service-config';
+import OAuthClient from '../util/oauth-client';
 import { resolve } from '../util/url';
 
 /**
@@ -24,7 +25,6 @@ import { resolve } from '../util/url';
 export default function auth(
   $rootScope,
   $window,
-  OAuthClient,
   apiRoutes,
   flash,
   localStorage,
@@ -305,7 +305,6 @@ export default function auth(
 auth.$inject = [
   '$rootScope',
   '$window',
-  'OAuthClient',
   'apiRoutes',
   'flash',
   'localStorage',

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -1,4 +1,5 @@
 import events from '../events';
+import serviceConfig from '../service-config';
 import * as retryUtil from '../util/retry';
 import * as sentry from '../util/sentry';
 
@@ -26,8 +27,7 @@ export default function session(
   api,
   auth,
   flash,
-  settings,
-  serviceConfig
+  settings
 ) {
   // Cache the result of load()
   let lastLoad;

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -5,7 +5,7 @@ import events from '../../events';
 import * as annotationFixtures from '../../test/annotation-fixtures';
 import createFakeStore from '../../test/fake-redux-store';
 import uiConstants from '../../ui-constants';
-import FrameSync, { formatAnnot } from '../frame-sync';
+import FrameSync, { $imports, formatAnnot } from '../frame-sync';
 
 const fixtures = {
   ann: Object.assign({ $tag: 't1' }, annotationFixtures.defaultAnnotation()),
@@ -90,7 +90,6 @@ describe('sidebar.frame-sync', function() {
     }
 
     angular.mock.module('app', {
-      Discovery: FakeDiscovery,
       store: fakeStore,
       bridge: fakeBridge,
     });
@@ -99,9 +98,14 @@ describe('sidebar.frame-sync', function() {
       $rootScope = _$rootScope_;
       frameSync = _frameSync_;
     });
+
+    $imports.$mock({
+      '../../shared/discovery': FakeDiscovery,
+    });
   });
 
   beforeEach(function() {
+    $imports.$restore();
     frameSync.connect();
   });
 

--- a/src/sidebar/services/test/oauth-auth-test.js
+++ b/src/sidebar/services/test/oauth-auth-test.js
@@ -2,7 +2,7 @@ import angular from 'angular';
 
 import events from '../../events';
 import FakeWindow from '../../util/test/fake-window';
-import authFactory from '../oauth-auth';
+import authFactory, { $imports } from '../oauth-auth';
 
 const DEFAULT_TOKEN_EXPIRES_IN_SECS = 1000;
 const TOKEN_KEY = 'hypothesis.oauth.hypothes%2Eis.token';
@@ -99,16 +99,21 @@ describe('sidebar.oauth-auth', function() {
       flash: fakeFlash,
       localStorage: fakeLocalStorage,
       settings: fakeSettings,
-      OAuthClient: FakeOAuthClient,
     });
 
     angular.mock.inject((_auth_, _$rootScope_) => {
       auth = _auth_;
       $rootScope = _$rootScope_;
     });
+
+    $imports.$mock({
+      '../util/oauth-client': FakeOAuthClient,
+    });
   });
 
   afterEach(function() {
+    $imports.$restore();
+
     performance.now.restore();
     clock.restore();
   });

--- a/src/sidebar/services/test/session-test.js
+++ b/src/sidebar/services/test/session-test.js
@@ -67,10 +67,10 @@ describe('sidebar.session', function() {
       auth: fakeAuth,
       flash: fakeFlash,
       settings: fakeSettings,
-      serviceConfig: fakeServiceConfig,
     });
 
     $imports.$mock({
+      '../service-config': fakeServiceConfig,
       '../util/sentry': fakeSentry,
     });
   });


### PR DESCRIPTION
This PR removes the registration of several things with Angular in `src/sidebar/index.js` that no longer need to be registered with Angular:

- Remove several calls to `.service(...)` to register services which are only used by other services. Since the new DI container handles wiring these services together, Angular doesn't need to know about them.
- Remove several calls to `.value(...)` to register classes or functions with Angular so that they could be mocked using `angular.mock` in tests. We can simplify the code and improve consistency here by just importing the class/function directly where needed and mocking it in tests using `$imports.$mock`. In some cases the code had already been changed/re-written to import the things it needed directly (eg. the `random` and `time` modules) and the `value(...)` call was unused.