### PR TITLE
Decouple `wrapReactComponent` from Angular `$injector`

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -251,6 +251,8 @@ function startAngularApp(config) {
       .register('$rootScope', { value: $rootScope });
   }
 
+  const wrapComponent = component => wrapReactComponent(component, container);
+
   angular
     .module('h', [angularRoute, angularToastr])
 
@@ -259,36 +261,33 @@ function startAngularApp(config) {
 
     // UI components
     .component('annotation', annotation)
-    .component('annotationBody', wrapReactComponent(AnnotationBody))
-    .component('annotationHeader', wrapReactComponent(AnnotationHeader))
-    .component('annotationActionBar', wrapReactComponent(AnnotationActionBar))
-    .component('annotationLicense', wrapReactComponent(AnnotationLicense))
-    .component('annotationOmega', wrapReactComponent(AnnotationOmega))
+    .component('annotationBody', wrapComponent(AnnotationBody))
+    .component('annotationHeader', wrapComponent(AnnotationHeader))
+    .component('annotationActionBar', wrapComponent(AnnotationActionBar))
+    .component('annotationLicense', wrapComponent(AnnotationLicense))
+    .component('annotationOmega', wrapComponent(AnnotationOmega))
     .component(
       'annotationPublishControl',
-      wrapReactComponent(AnnotationPublishControl)
+      wrapComponent(AnnotationPublishControl)
     )
-    .component('annotationQuote', wrapReactComponent(AnnotationQuote))
+    .component('annotationQuote', wrapComponent(AnnotationQuote))
     .component('annotationThread', annotationThread)
     .component('annotationViewerContent', annotationViewerContent)
-    .component('helpPanel', wrapReactComponent(HelpPanel))
-    .component('loggedOutMessage', wrapReactComponent(LoggedOutMessage))
-    .component('moderationBanner', wrapReactComponent(ModerationBanner))
-    .component('searchStatusBar', wrapReactComponent(SearchStatusBar))
-    .component('focusedModeHeader', wrapReactComponent(FocusedModeHeader))
-    .component('selectionTabs', wrapReactComponent(SelectionTabs))
+    .component('helpPanel', wrapComponent(HelpPanel))
+    .component('loggedOutMessage', wrapComponent(LoggedOutMessage))
+    .component('moderationBanner', wrapComponent(ModerationBanner))
+    .component('searchStatusBar', wrapComponent(SearchStatusBar))
+    .component('focusedModeHeader', wrapComponent(FocusedModeHeader))
+    .component('selectionTabs', wrapComponent(SelectionTabs))
     .component('sidebarContent', sidebarContent)
-    .component('sidebarContentError', wrapReactComponent(SidebarContentError))
-    .component(
-      'shareAnnotationsPanel',
-      wrapReactComponent(ShareAnnotationsPanel)
-    )
+    .component('sidebarContentError', wrapComponent(SidebarContentError))
+    .component('shareAnnotationsPanel', wrapComponent(ShareAnnotationsPanel))
     .component('streamContent', streamContent)
-    .component('svgIcon', wrapReactComponent(SvgIcon))
-    .component('tagEditor', wrapReactComponent(TagEditor))
-    .component('tagList', wrapReactComponent(TagList))
+    .component('svgIcon', wrapComponent(SvgIcon))
+    .component('tagEditor', wrapComponent(TagEditor))
+    .component('tagList', wrapComponent(TagList))
     .component('threadList', threadList)
-    .component('topBar', wrapReactComponent(TopBar))
+    .component('topBar', wrapComponent(TopBar))
     .directive('hAutofocus', hAutofocusDirective)
     .directive('hBranding', hBrandingDirective)
     .directive('hOnTouch', hOnTouchDirective)
@@ -315,7 +314,6 @@ function startAngularApp(config) {
     .service('session', () => container.get('session'))
     .service('streamer', () => container.get('streamer'))
     .service('streamFilter', () => container.get('streamFilter'))
-    .service('tags', () => container.get('tags'))
 
     // Redux store
     .service('store', () => container.get('store'))

--- a/src/sidebar/util/service-context.js
+++ b/src/sidebar/util/service-context.js
@@ -64,7 +64,7 @@ export function withServices(Component) {
   function Wrapper(props) {
     // Get the current dependency injector instance that is provided by a
     // `ServiceContext.Provider` somewhere higher up the component tree.
-    const $injector = useContext(ServiceContext);
+    const injector = useContext(ServiceContext);
 
     // Inject services, unless they have been overridden by props passed from
     // the parent component.
@@ -80,7 +80,7 @@ export function withServices(Component) {
       }
 
       if (!(service in props)) {
-        services[service] = $injector.get(service);
+        services[service] = injector.get(service);
       }
     }
     return <Component {...services} {...props} />;

--- a/src/sidebar/util/test/wrap-react-component-test.js
+++ b/src/sidebar/util/test/wrap-react-component-test.js
@@ -3,6 +3,7 @@ import { Component, createElement } from 'preact';
 import { useContext } from 'preact/hooks';
 import propTypes from 'prop-types';
 
+import { Injector } from '../../../shared/injector';
 import { createDirective } from '../../directive/test/util';
 import { ServiceContext } from '../service-context';
 import wrapReactComponent from '../wrap-react-component';
@@ -58,11 +59,15 @@ describe('wrapReactComponent', () => {
     return { element, onClick, onDblClick };
   }
 
+  let servicesInjector;
+
   beforeEach(() => {
+    const servicesInjector = new Injector();
+    servicesInjector.register('theme', { value: 'dark' });
+
     angular
       .module('app', [])
-      .component('btn', wrapReactComponent(Button))
-      .value('theme', 'dark');
+      .component('btn', wrapReactComponent(Button, servicesInjector));
     angular.mock.module('app');
   });
 
@@ -73,7 +78,7 @@ describe('wrapReactComponent', () => {
   });
 
   it('derives Angular component "bindings" from React "propTypes"', () => {
-    const ngComponent = wrapReactComponent(Button);
+    const ngComponent = wrapReactComponent(Button, servicesInjector);
     assert.deepEqual(ngComponent.bindings, {
       label: '<',
       isDisabled: '<',
@@ -141,7 +146,7 @@ describe('wrapReactComponent', () => {
     angular
       .module('app', [])
       .component('parent', parentComponent)
-      .component('child', wrapReactComponent(ChildComponent));
+      .component('child', wrapReactComponent(ChildComponent, servicesInjector));
     angular.mock.module('app');
 
     // Render the component with the child initially visible.
@@ -160,7 +165,7 @@ describe('wrapReactComponent', () => {
       return <div>Hello world</div>;
     }
     assert.throws(
-      () => wrapReactComponent(TestComponent),
+      () => wrapReactComponent(TestComponent, servicesInjector),
       'React component TestComponent does not specify its inputs using "propTypes"'
     );
   });
@@ -231,7 +236,7 @@ describe('wrapReactComponent', () => {
     angular
       .module('app', [])
       .component('parent', parentComponent)
-      .component('child', wrapReactComponent(Child));
+      .component('child', wrapReactComponent(Child, servicesInjector));
     angular.mock.module('app');
 
     const element = createDirective(document, 'parent');


### PR DESCRIPTION
Pass the `Injector` service container directly to `wrapReactComponent` instead of
looking up services via Angular's `$injector` service.

This removes the need to register services with Angular if only other
services or Preact components use them. This will enable us to
incrementally remove these service registrations as the migration
continues.

Even though `wrapReactComponent` will go away entirely at the end of the migration,
removing this dependency now ensures that the non-Angular parts of the UI don't
indirectly depend on the `$injector` Angular service's behavior.

As a starting point, also remove the "tags" service registration, as all the
UI components and services that use it have been migrated.