### PR TITLE
Highlights a11y (2/2) - Make highlights "visible" to screen readers

### DIFF
--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -1,11 +1,34 @@
 @use '../variables' as var;
 
+@mixin screen-reader-only {
+  // Hide this content visually, but without preventing screen readers from
+  // reading it.
+  opacity: 0;
+
+  // Avoid this content affecting the visual layout.
+  position: absolute;
+}
+
 // `hypothesis-highlights-always-on` is a class that is toggled on the root
 // of the annotated document when highlights are enabled/disabled.
 .hypothesis-highlights-always-on {
   .hypothesis-highlight {
     background-color: var.$highlight-color;
     cursor: pointer;
+
+    // Make highlights visible to screen readers.
+    // See also - https://developer.paciellogroup.com/blog/2017/12/short-note-on-making-your-mark-more-accessible/.
+    &::before {
+      @include screen-reader-only;
+
+      // nb. The leading/trailing spaces are intended to ensure the text is treated
+      // as separate words by assisitve technologies from the content before/after it.
+      content: ' comment start ';
+    }
+    &::after {
+      @include screen-reader-only;
+      content: ' comment end ';
+    }
   }
 
   .hypothesis-highlight .hypothesis-highlight {


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/1775**

Use CSS `::before` and `::after` to add "comment start" and "commend. end" notices around highlighted text which screen readers will read but which are not visible.

This pattern follows the example of how highlights are presented in Google Docs and also [this blog post](https://developer.paciellogroup.com/blog/2017/12/short-note-on-making-your-mark-more-accessible/).

This will get quite audibly "noisy" if there are a lot of overlapping highlights, but I think it is better than not having the highlights be visible to screen reader users at all.

This change doesn't fix the problem of being able to activate highlighted text and navigate to the corresponding annotation in the sidebar, that will come separately.