### PR TITLE
Add missing effect dependencies in StreamSearchInput

### DIFF
--- a/src/sidebar/components/stream-search-input.js
+++ b/src/sidebar/components/stream-search-input.js
@@ -25,7 +25,7 @@ function StreamSearchInput({ $location, $rootScope }) {
     $rootScope.$on('$locationChangeSuccess', () => {
       setQuery($location.search().q);
     });
-  });
+  }, [$location, $rootScope]);
 
   return <SearchInput query={query} onSearch={search} alwaysExpanded={true} />;
 }


### PR DESCRIPTION
This fixes an issue, and corresponding warning in tests, where an effect
would unnecessarily run on every render.

There is a related warning about needing to enable the `@babel/plugin-transform-jsx-source` Babel plugin to get more helpful warnings for this kind of issue in tests. I will address that separately.

See https://hypothes-is.slack.com/archives/C1M8NH76X/p1581517940185900