### PR TITLE
Enable debugging info for JSX elements in dev builds and tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,5 +13,15 @@
     "angularjs-annotate",
     "transform-async-to-promises"
   ],
-  "ignore": ["**/vendor/*"]
+  "ignore": ["**/vendor/*"],
+  "env": {
+    "development": {
+      "presets": [
+        ["@babel/preset-react", {
+          "development": true,
+          "pragma": "createElement"
+        }]
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Enable the "development" [1] option for the `@babel/preset-react` preset
to enable more helpful warnings/errors from Preact in development
builds. For example, see the stack trace in this warning I triggered by removing an effect's dependency list:

<img width="703" alt="Screenshot 2020-02-12 15 29 25" src="https://user-images.githubusercontent.com/2458/74351188-b2f0df80-4dae-11ea-95ee-342224b5c70d.png">

Note that the configuration added here _replaces_ rather than _augments_
the `@babel/preset-react` config for other builds (ie. when `NODE_ENV` !== "development"), so other keys like
"createElement" also need to be specified in both places.

See https://babeljs.io/docs/en/babel-preset-react#development and https://babeljs.io/docs/en/6.26.3/babelrc#env-option.

Footnote: On a technical level, what this change does is cause some additional metadata about the _location_ in the source code of JSX expressions to be passed in the `createElement(...)` calls that the JSX expressions are converted into.