### PR TITLE
Fix AutocompleteList aria-selecterd prop

### DIFF
--- a/src/sidebar/components/autocomplete-list.js
+++ b/src/sidebar/components/autocomplete-list.js
@@ -34,7 +34,7 @@ export default function AutocompleteList({
         <li
           key={`autocomplete-list-${index}`}
           role="option"
-          aria-selected={activeItem === index}
+          aria-selected={(activeItem === index).toString()}
           className={classnames(
             {
               'is-selected': activeItem === index,

--- a/src/sidebar/components/test/autocomplete-list-test.js
+++ b/src/sidebar/components/test/autocomplete-list-test.js
@@ -146,19 +146,22 @@ describe('AutocompleteList', function() {
     );
   });
 
-  it('sets the `aria-selected` attribute on the active index ', () => {
+  it('sets the `aria-selected` attribute to "true" on the active item and "false" for all others', () => {
     const wrapper = createComponent({ open: true, activeItem: 0 });
-    assert.isTrue(
+    assert.equal(
       wrapper
         .find('li')
         .at(0)
-        .prop('aria-selected')
+        .prop('aria-selected'),
+      'true'
     );
-    assert.isFalse(
+
+    assert.equal(
       wrapper
         .find('li')
         .at(1)
-        .prop('aria-selected')
+        .prop('aria-selected'),
+      'false'
     );
   });
 


### PR DESCRIPTION
Minor fix here. The `aria-selected` prop shall be “true” or “false” on items in the list. Previously this was truthy so it was omitted from the DOM when false.  Undefined has a different meaning than aria-selected=“false”. I don't think this has any visible changes, even for the screen readers that I tested, but I wanted to get the semantics correct so we have proper examples in our code base.

