### PR TITLE
Replace link with `Button` in `AnnotationHeader` (A11y)

### DIFF
--- a/src/sidebar/components/annotation-header.js
+++ b/src/sidebar/components/annotation-header.js
@@ -1,11 +1,12 @@
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
-import { isHighlight } from '../util/annotation-metadata';
+import { isHighlight, isReply } from '../util/annotation-metadata';
 
 import AnnotationDocumentInfo from './annotation-document-info';
 import AnnotationShareInfo from './annotation-share-info';
 import AnnotationUser from './annotation-user';
+import Button from './button';
 import SvgIcon from './svg-icon';
 import Timestamp from './timestamp';
 
@@ -20,6 +21,7 @@ export default function AnnotationHeader({
   onReplyCountClick,
   replyCount,
   showDocumentInfo,
+  threadIsCollapsed,
 }) {
   const annotationLink = annotation.links ? annotation.links.html : '';
   const replyPluralized = !replyCount || replyCount > 1 ? 'replies' : 'reply';
@@ -27,17 +29,21 @@ export default function AnnotationHeader({
   const hasBeenEdited =
     annotation.updated && annotation.created !== annotation.updated;
 
+  const showReplyButton = threadIsCollapsed && isReply(annotation);
+  const replyButtonText = `${replyCount} ${replyPluralized}`;
+
   return (
     <header className="annotation-header">
       <div className="annotation-header__row">
         <AnnotationUser annotation={annotation} />
-        <div className="annotation-collapsed-replies">
-          {/* FIXME-A11Y */}
-          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events, jsx-a11y/anchor-is-valid */}
-          <a className="annotation-link" onClick={onReplyCountClick}>
-            {replyCount} {replyPluralized}
-          </a>
-        </div>
+        {showReplyButton && (
+          <Button
+            className="annotation-header__reply-toggle"
+            buttonText={replyButtonText}
+            onClick={onReplyCountClick}
+            title="Expand replies"
+          />
+        )}
         {!isEditing && annotation.created && (
           <div className="annotation-header__timestamp">
             {hasBeenEdited && (
@@ -93,4 +99,8 @@ AnnotationHeader.propTypes = {
    * annotation and stream views
    */
   showDocumentInfo: propTypes.bool,
+  /**
+   * Is this thread currently collapsed?
+   */
+  threadIsCollapsed: propTypes.bool.isRequired,
 };

--- a/src/sidebar/components/annotation-omega.js
+++ b/src/sidebar/components/annotation-omega.js
@@ -102,6 +102,7 @@ function AnnotationOmega({
         onReplyCountClick={onReplyCountClick}
         replyCount={replyCount}
         showDocumentInfo={showDocumentInfo}
+        threadIsCollapsed={threadIsCollapsed}
       />
       {hasQuote && <AnnotationQuote annotation={annotation} />}
       <AnnotationBody

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -8,7 +8,8 @@
                          is-editing="vm.editing()"
                          on-reply-count-click="vm.onReplyCountClick()"
                          reply-count="vm.replyCount"
-                         show-document-info="vm.showDocumentInfo">
+                         show-document-info="vm.showDocumentInfo"
+                         thread-is-collapsed="vm.isCollapsed">
   </annotation-header>
 
   <annotation-quote annotation="vm.annotation" ng-if="vm.quote()">

--- a/src/styles/sidebar/components/annotation-header.scss
+++ b/src/styles/sidebar/components/annotation-header.scss
@@ -13,6 +13,16 @@
     align-items: baseline;
   }
 
+  &__reply-toggle.button {
+    padding: 0 0.5em;
+    font-weight: 400;
+    background-color: transparent;
+    &:hover {
+      background-color: transparent;
+      color: var.$link-color-hover;
+    }
+  }
+
   // Timestamps are right aligned in a flex row
   &__timestamp {
     margin-left: auto;


### PR DESCRIPTION
Depends on #1780 

This PR replaces a link element with a Button in AnnotationHeader and makes it more clear what the intent is in the code. The previous code rendered a link here no matter what, and it was unclear that, in some states, classes are applied that make this link "show up." Instead, use some comprehensible logic in the element here. It also removes a dependency on annotation SCSS.

Yep, this is another example of overriding Button styling, but I'd like to collect these for later scrutiny.

Fixes a11y-linting issue.

Part of #1727