### PR TITLE
Fix a11y lint on SelectionTabs component

### DIFF
--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -30,7 +30,7 @@ function Tab({
       onTouchStart={onChangeTab.bind(this, type)}
       role="tab"
       tabIndex="0"
-      aria-selected={selected}
+      aria-selected={selected.toString()}
     >
       {children}
       {count > 0 && !isWaitingToAnchor && (

--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -22,9 +22,7 @@ function Tab({
   type,
 }) {
   return (
-    // FIXME-A11Y
-    // eslint-disable-next-line jsx-a11y/anchor-is-valid
-    <a
+    <button
       className={classnames('selection-tabs__type', {
         'is-selected': selected,
       })}
@@ -38,7 +36,7 @@ function Tab({
       {count > 0 && !isWaitingToAnchor && (
         <span className="selection-tabs__count"> {count}</span>
       )}
-    </a>
+    </button>
   );
 }
 Tab.propTypes = {

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -81,6 +81,8 @@ describe('SelectionTabs', function() {
       const wrapper = createComponent();
       const tabs = wrapper.find('button');
       assert.isTrue(tabs.at(0).hasClass('is-selected'));
+      assert.equal(tabs.at(0).prop('aria-selected'), 'true');
+      assert.equal(tabs.at(1).prop('aria-selected'), 'false');
     });
 
     it('should display notes tab as selected', function() {
@@ -90,6 +92,8 @@ describe('SelectionTabs', function() {
       const wrapper = createComponent({});
       const tabs = wrapper.find('button');
       assert.isTrue(tabs.at(1).hasClass('is-selected'));
+      assert.equal(tabs.at(1).prop('aria-selected'), 'true');
+      assert.equal(tabs.at(0).prop('aria-selected'), 'false');
     });
 
     it('should display orphans tab as selected if there is 1 or more orphans', function() {
@@ -100,6 +104,9 @@ describe('SelectionTabs', function() {
       const wrapper = createComponent({});
       const tabs = wrapper.find('button');
       assert.isTrue(tabs.at(2).hasClass('is-selected'));
+      assert.equal(tabs.at(2).prop('aria-selected'), 'true');
+      assert.equal(tabs.at(1).prop('aria-selected'), 'false');
+      assert.equal(tabs.at(0).prop('aria-selected'), 'false');
     });
 
     it('should not display orphans tab if there are 0 orphans', function() {

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -58,7 +58,7 @@ describe('SelectionTabs', function() {
   context('displays selection tabs and counts', function() {
     it('should display the tabs and counts of annotations and notes', function() {
       const wrapper = createComponent();
-      const tabs = wrapper.find('a');
+      const tabs = wrapper.find('button');
       assert.isTrue(tabs.at(0).contains('Annotations'));
       assert.equal(
         tabs
@@ -79,8 +79,8 @@ describe('SelectionTabs', function() {
 
     it('should display annotations tab as selected', function() {
       const wrapper = createComponent();
-      const aTags = wrapper.find('a');
-      assert.isTrue(aTags.at(0).hasClass('is-selected'));
+      const tabs = wrapper.find('button');
+      assert.isTrue(tabs.at(0).hasClass('is-selected'));
     });
 
     it('should display notes tab as selected', function() {
@@ -88,7 +88,7 @@ describe('SelectionTabs', function() {
         selection: { selectedTab: uiConstants.TAB_NOTES },
       });
       const wrapper = createComponent({});
-      const tabs = wrapper.find('a');
+      const tabs = wrapper.find('button');
       assert.isTrue(tabs.at(1).hasClass('is-selected'));
     });
 
@@ -98,7 +98,7 @@ describe('SelectionTabs', function() {
       });
       fakeStore.orphanCount.returns(1);
       const wrapper = createComponent({});
-      const tabs = wrapper.find('a');
+      const tabs = wrapper.find('button');
       assert.isTrue(tabs.at(2).hasClass('is-selected'));
     });
 
@@ -107,7 +107,7 @@ describe('SelectionTabs', function() {
         selection: { selectedTab: uiConstants.TAB_ORPHANS },
       });
       const wrapper = createComponent({});
-      const tabs = wrapper.find('a');
+      const tabs = wrapper.find('button');
       assert.equal(tabs.length, 2);
     });
 

--- a/src/styles/sidebar/components/selection-tabs.scss
+++ b/src/styles/sidebar/components/selection-tabs.scss
@@ -1,4 +1,5 @@
 @use "../../mixins/focus";
+@use "../../mixins/buttons";
 @use "../../variables" as var;
 
 .selection-tabs {
@@ -19,6 +20,7 @@
 }
 
 .selection-tabs__type {
+  @include buttons.reset-native-btn-styles;
   @include focus.outline-on-keyboard-focus;
 
   color: var.$grey-6;
@@ -28,6 +30,10 @@
   min-height: 18px;
 
   user-select: none;
+
+  &:hover {
+    color: var.$link-color-hover;
+  }
 }
 
 .selection-tabs__type.is-selected {


### PR DESCRIPTION
Straight forward conversion. I would like to get opinion on using the <Button> component here, but again, the css was a bit easier to match without it.
