### PR TITLE
Remove jQuery dependency from highlighter and add test for multiple text nodes

### DIFF
--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -26,6 +26,27 @@ describe('annotator/highlighter', () => {
       assert.isTrue(result[0].classList.contains('hypothesis-highlight'));
     });
 
+    it('wraps multiple text nodes', () => {
+      const strings = ['hello', ' Brave ', ' New ', ' World'];
+      const textNodes = strings.map(s => document.createTextNode(s));
+
+      const el = document.createElement('span');
+      textNodes.forEach(n => el.append(n));
+
+      const r = new Range.NormalizedRange({
+        commonAncestor: el,
+        start: textNodes[0],
+        end: textNodes[textNodes.length - 1],
+      });
+      const result = highlightRange(r);
+
+      assert.equal(result.length, textNodes.length);
+      result.forEach((highlight, i) => {
+        assert.equal(highlight.nodeName, 'HYPOTHESIS-HIGHLIGHT');
+        assert.deepEqual(Array.from(highlight.childNodes), [textNodes[i]]);
+      });
+    });
+
     it('skips text nodes that are only white space', () => {
       const txt = document.createTextNode('one');
       const blank = document.createTextNode(' ');


### PR DESCRIPTION
As part of an ongoing project to remove the annotator's jQuery
dependency, rewrite the highlighter to avoid it.

This change is also preparation for some upcoming changes to make
highlights more friendly for screen reader users by reducing the
number of `<hypothesis-highlight>` elements created for a run of text in
various situations. Since each `<hypothesis-highlight>` announces its
presence to the screen reader, this gets "noisy" if there are many such
elements.

There are no intended behavior changes here. I added a test for an important case that was missing previously.