### PR TITLE
Add reply capability to service, `AnnotationOmega`

### DIFF
--- a/src/sidebar/components/annotation-omega.js
+++ b/src/sidebar/components/annotation-omega.js
@@ -40,6 +40,7 @@ function AnnotationOmega({
   // An annotation will have a draft if it is being edited
   const draft = useStore(store => store.getDraft(annotation));
   const group = useStore(store => store.getGroup(annotation.group));
+  const userid = useStore(store => store.profile().userid);
 
   const isPrivate = draft ? draft.isPrivate : !isShared(annotation.permissions);
   const tags = draft ? draft.tags : annotation.tags;
@@ -78,6 +79,15 @@ function AnnotationOmega({
     createDraft(annotation, { ...draft, text });
   };
 
+  const onReply = () => {
+    // TODO: Re-evaluate error handling here
+    if (!userid) {
+      flash.error('Please log in to reply to annotations');
+    } else {
+      annotationsService.reply(annotation, userid);
+    }
+  };
+
   const onSave = async () => {
     setIsSaving(true);
     try {
@@ -90,9 +100,6 @@ function AnnotationOmega({
   };
 
   const onToggleReplies = () => setCollapsed(annotation.id, !threadIsCollapsed);
-
-  // TODO
-  const fakeOnReply = () => alert('Reply: TBD');
 
   return (
     <div className="annotation-omega">
@@ -134,10 +141,7 @@ function AnnotationOmega({
           )}
           {shouldShowActions && (
             <div className="annotation-omega__actions">
-              <AnnotationActionBar
-                annotation={annotation}
-                onReply={fakeOnReply}
-              />
+              <AnnotationActionBar annotation={annotation} onReply={onReply} />
             </div>
           )}
         </div>

--- a/src/sidebar/components/test/annotation-omega-test.js
+++ b/src/sidebar/components/test/annotation-omega-test.js
@@ -52,6 +52,7 @@ describe('AnnotationOmega', () => {
     fakeOnReplyCountClick = sinon.stub();
 
     fakeAnnotationsService = {
+      reply: sinon.stub(),
       save: sinon.stub().resolves(),
     };
 
@@ -75,6 +76,7 @@ describe('AnnotationOmega', () => {
       getGroup: sinon.stub().returns({
         type: 'private',
       }),
+      profile: sinon.stub().returns({ userid: 'acct:foo@bar.com' }),
       setCollapsed: sinon.stub(),
     };
 
@@ -332,6 +334,42 @@ describe('AnnotationOmega', () => {
   });
 
   describe('annotation actions', () => {
+    describe('replying to an annotation', () => {
+      // nb: There's no reason this logic needs to stay within `AnnotationOmega`
+      // once we've migrated to it; it could happily move to `AnnotationActionBar`
+      it('should show a flash alert if user not logged in', () => {
+        // No logged-in user...
+        fakeStore.profile.returns({});
+
+        const wrapper = createComponent();
+
+        wrapper
+          .find('AnnotationActionBar')
+          .props()
+          .onReply();
+
+        assert.calledOnce(fakeFlash.error);
+        assert.notCalled(fakeAnnotationsService.reply);
+      });
+
+      it('should create a reply', () => {
+        const theAnnot = fixtures.defaultAnnotation();
+        const wrapper = createComponent({ annotation: theAnnot });
+
+        wrapper
+          .find('AnnotationActionBar')
+          .props()
+          .onReply();
+
+        assert.calledOnce(fakeAnnotationsService.reply);
+        assert.calledWith(
+          fakeAnnotationsService.reply,
+          theAnnot,
+          'acct:foo@bar.com'
+        );
+      });
+    });
+
     it('should show annotation actions', () => {
       const wrapper = createComponent();
 

--- a/src/sidebar/services/annotations.js
+++ b/src/sidebar/services/annotations.js
@@ -1,5 +1,5 @@
 import SearchClient from '../search-client';
-import { isNew } from '../util/annotation-metadata';
+import { isNew, isPublic } from '../util/annotation-metadata';
 import { privatePermissions, sharedPermissions } from '../util/permissions';
 
 // @ngInject
@@ -82,6 +82,25 @@ export default function annotationsService(
   }
 
   /**
+   * Create a reply to `annotation` by the user `userid` and add to the store.
+   *
+   * @param {Object} annotation
+   * @param {string} userid
+   */
+  function reply(annotation, userid) {
+    const replyAnnotation = {
+      group: annotation.group,
+      permissions: isPublic(annotation)
+        ? sharedPermissions(userid, annotation.group)
+        : privatePermissions(userid),
+      references: (annotation.references || []).concat(annotation.id),
+      target: [{ source: annotation.target[0].source }],
+      uri: annotation.uri,
+    };
+    store.createAnnotation(replyAnnotation);
+  }
+
+  /**
    * Save new (or update existing) annotation. On success,
    * the annotation's `Draft` will be removed and the annotation added
    * to the store.
@@ -118,6 +137,7 @@ export default function annotationsService(
 
   return {
     load,
+    reply,
     save,
   };
 }


### PR DESCRIPTION
~~Depends on #1782~~

This PR adds a `reply` method to the `AnnotationsService`, and makes `AnnotationOmega` use it. No current user-facing changes as this is all feature-flagged and old 'n dusty `Annotation` continues to work as before.

Part of #1650 

~~Adding DO NOT MERGE because of dependency~~