### PR TITLE
Add `flex-shrink` rule to login links

### DIFF
--- a/src/styles/sidebar/components/top-bar.scss
+++ b/src/styles/sidebar/components/top-bar.scss
@@ -54,6 +54,7 @@
 
 .top-bar__login-links {
   display: flex;
+  flex-shrink: 0;
 }
 
 .top-bar__inner {


### PR DESCRIPTION
https://github.com/hypothesis/client/pull/1784 caused a visual regression in the top bar when a search is active. Before this fix, opening the search interface looks like:

<img width="480" alt="Screen Shot 2020-02-13 at 2 24 20 PM" src="https://user-images.githubusercontent.com/439947/74470586-d9755000-4e6c-11ea-816a-398d3de1e541.png">

and after (back to what it looked like before #1784, which, as we know, still isn't ideal...):

<img width="479" alt="Screen Shot 2020-02-13 at 2 24 33 PM" src="https://user-images.githubusercontent.com/439947/74470604-de3a0400-4e6c-11ea-8a41-1e6996382493.png">
