### PR TITLE
Refactor `SidebarContentError` for a11y, usability

### DIFF
--- a/src/images/icons/restricted.svg
+++ b/src/images/icons/restricted.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><g fill-rule="evenodd"><rect fill="none" stroke="none" x="0" y="0" width="16" height="16"></rect><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 1C4.5 1 1 4.5 1 8s3.5 7 7 7 7-3.5 7-7-3.5-7-7-7zm0 7l-4 4 4-4 4-4-4 4z"></path></g></svg>

--- a/src/sidebar/components/search-status-bar.js
+++ b/src/sidebar/components/search-status-bar.js
@@ -38,15 +38,12 @@ function SearchStatusBar({ rootThread }) {
   }));
 
   const {
-    directLinkedGroupFetchFailed,
     filterQuery,
     focusModeFocused,
     focusModeUserPrettyName,
     selectionMap,
     selectedTab,
   } = useStore(store => ({
-    directLinkedGroupFetchFailed: store.getState().directLinked
-      .directLinkedGroupFetchFailed,
     filterQuery: store.getState().selection.filterQuery,
     focusModeFocused: store.focusModeFocused(),
     focusModeUserPrettyName: store.focusModeUserPrettyName(),
@@ -75,9 +72,6 @@ function SearchStatusBar({ rootThread }) {
      * `filtered` mode.
      */
     selected: (() => {
-      if (directLinkedGroupFetchFailed) {
-        return true;
-      }
       return (
         !!selectionMap && Object.keys(selectionMap).length > 0 && !filterQuery
       );

--- a/src/sidebar/components/svg-icon.js
+++ b/src/sidebar/components/svg-icon.js
@@ -41,6 +41,7 @@ const icons = {
   profile: require('../../images/icons/profile.svg'),
   public: require('../../images/icons/public.svg'),
   refresh: require('../../images/icons/refresh.svg'),
+  restricted: require('../../images/icons/restricted.svg'),
   reply: require('../../images/icons/reply.svg'),
   search: require('../../images/icons/search.svg'),
   share: require('../../images/icons/share.svg'),

--- a/src/sidebar/components/test/search-status-bar-test.js
+++ b/src/sidebar/components/test/search-status-bar-test.js
@@ -22,7 +22,6 @@ describe('SearchStatusBar', () => {
     fakeStore = {
       getState: sinon.stub().returns({
         selection: {},
-        directLinked: {},
       }),
       annotationCount: sinon.stub().returns(1),
       focusModeFocused: sinon.stub().returns(false),
@@ -46,9 +45,6 @@ describe('SearchStatusBar', () => {
         selection: {
           filterQuery: 'tag:foo',
           selectedTab: 'annotation',
-        },
-        directLinked: {
-          directLinkedGroupFetchFailed: false,
         },
       });
       fakeStore.annotationCount.returns(3);
@@ -184,7 +180,6 @@ describe('SearchStatusBar', () => {
           filterQuery: 'tag:foo',
           selectedTab: 'annotation',
         },
-        directLinked: {},
       });
 
       const wrapper = createComponent({});
@@ -245,7 +240,6 @@ describe('SearchStatusBar', () => {
               selectedAnnotationMap: { annId: true },
               selectedTab: test.tab,
             },
-            directLinked: {},
           });
           fakeStore.annotationCount.returns(test.annotationCount);
           fakeStore.noteCount.returns(test.noteCount);
@@ -272,9 +266,7 @@ describe('SearchStatusBar', () => {
             selection: {
               filterQuery: null,
               selectedTab: test.tab,
-            },
-            directLinked: {
-              directLinkedGroupFetchFailed: true,
+              selectedAnnotationMap: { annId: true },
             },
           });
           fakeStore.annotationCount.returns(5);
@@ -298,9 +290,6 @@ describe('SearchStatusBar', () => {
           selection: {
             filterQuery: 'tag:foo',
             selectedTab: 'annotation',
-          },
-          directLinked: {
-            directLinkedGroupFetchFailed: false,
           },
         });
         fakeStore.annotationCount.returns(5);

--- a/src/sidebar/templates/sidebar-content.html
+++ b/src/sidebar/templates/sidebar-content.html
@@ -8,27 +8,21 @@
 </selection-tabs>
 
 <search-status-bar
-  ng-if="!vm.isLoading()">
+  ng-if="!vm.isLoading() && !(vm.selectedAnnotationUnavailable() || vm.selectedGroupUnavailable())">
 </search-status-bar>
 
 <!-- Display error message if direct-linked annotation fetch failed. -->
 <sidebar-content-error
-  class="sidebar-content-error"
-  logged-out-error-message="'This annotation is not available.'"
-  logged-in-error-message="'You do not have permission to view this annotation.'"
+  error-type="'annotation'"
   on-login-request="vm.onLogin()"
-  is-logged-in="vm.auth.status === 'logged-in'"
   ng-if="vm.selectedAnnotationUnavailable()"
 >
 </sidebar-content-error>
 
 <!-- Display error message if direct-linked group fetch failed. -->
 <sidebar-content-error
-  class="sidebar-content-error"
-  logged-out-error-message="'This group is not available.'"
-  logged-in-error-message="'This group is not available.'"
+  error-type="'group'"
   on-login-request="vm.onLogin()"
-  is-logged-in="vm.auth.status === 'logged-in'"
   ng-if="vm.selectedGroupUnavailable()"
 >
 </sidebar-content-error>

--- a/src/styles/mixins/panel.scss
+++ b/src/styles/mixins/panel.scss
@@ -20,6 +20,10 @@
     border-bottom-style: solid;
   }
 
+  &__header-icon {
+    margin-right: 0.5em;
+  }
+
   &__subheader {
     width: 100%;
     text-align: center;

--- a/src/styles/sidebar/components/sidebar-content-error.scss
+++ b/src/styles/sidebar/components/sidebar-content-error.scss
@@ -1,0 +1,17 @@
+@use "../../mixins/panel";
+@use "../../variables" as var;
+
+.sidebar-content-error {
+  @include panel.panel;
+  position: relative;
+  margin-bottom: 0.75em;
+
+  &__button {
+    margin-left: 1em;
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+}

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -57,6 +57,7 @@
 @use './components/share-annotations-panel';
 @use './components/search-input';
 @use './components/share-links';
+@use './components/sidebar-content-error';
 @use './components/sidebar-panel';
 @use './components/svg-icon';
 @use './components/spinner';


### PR DESCRIPTION
This PR refactors `SidebarContentError` to fix a11y lint issues as well as make the component consistent with our design patterns and more helpful to users.

This work was discussed in a (warning: lengthy!) [Slack thread (accessible to Hypothesis staff)](https://hypothes-is.slack.com/archives/C07NXBDNW/p1581538293019100).

This component renders an error message if a user has followed a direct link (URL) to an annotation or group, but that annotation or group is non-existent or the user does not have permission to access it.

There are four possible states for this error (mutually exclusive).

### State 1. Direct-linked annotation unavailable, user not logged in

Before these changes:

<img width="473" alt="Screen Shot 2020-02-13 at 10 17 38 AM" src="https://user-images.githubusercontent.com/439947/74477475-5c9ca300-4e79-11ea-9636-61bdf708396b.png">

After these changes:

<img width="471" alt="Screen Shot 2020-02-13 at 3 52 33 PM" src="https://user-images.githubusercontent.com/439947/74477495-632b1a80-4e79-11ea-82e1-48aa67e6e9d3.png">

### State 2. Direct-linked annotation unavailable, user logged in

Before:

<img width="468" alt="Screen Shot 2020-02-13 at 10 17 49 AM" src="https://user-images.githubusercontent.com/439947/74477505-67573800-4e79-11ea-98a0-90bbd0860eb2.png">

After: 

<img width="472" alt="Screen Shot 2020-02-13 at 3 52 43 PM" src="https://user-images.githubusercontent.com/439947/74477523-70e0a000-4e79-11ea-89e7-416a2b7b6dd4.png">

### State 3. Direct-linked group unavailable, user not logged in

Before: 

<img width="470" alt="Screen Shot 2020-02-13 at 10 18 05 AM" src="https://user-images.githubusercontent.com/439947/74477533-75a55400-4e79-11ea-911c-58b09c3bfcf6.png">

After:

<img width="472" alt="Screen Shot 2020-02-13 at 3 52 54 PM" src="https://user-images.githubusercontent.com/439947/74477545-7c33cb80-4e79-11ea-838f-b08028b0d36f.png">

### State 4. Direct-linked group unavailable, user logged in

Before:

<img width="478" alt="Screen Shot 2020-02-13 at 10 18 12 AM" src="https://user-images.githubusercontent.com/439947/74477558-81911600-4e79-11ea-9604-55c8b6d33732.png">

After:

<img width="473" alt="Screen Shot 2020-02-13 at 3 53 04 PM" src="https://user-images.githubusercontent.com/439947/74477565-85249d00-4e79-11ea-8c39-a0f92b4c7e97.png">
