### PR TITLE
Fix a11y for LoggedOutMessage

### DIFF
--- a/src/sidebar/components/logged-out-message.js
+++ b/src/sidebar/components/logged-out-message.js
@@ -3,6 +3,7 @@ import propTypes from 'prop-types';
 
 import { withServices } from '../util/service-context';
 
+import Button from './button';
 import SvgIcon from './svg-icon';
 
 /**
@@ -24,11 +25,12 @@ function LoggedOutMessage({ onLogin, serviceUrl }) {
         >
           create a free account
         </a>{' '}
-        or {/* FIXME-A11Y */}
-        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-        <a className="logged-out-message__link" href="" onClick={onLogin}>
-          log in
-        </a>
+        or{' '}
+        <Button
+          className="logged-out-message__link"
+          onClick={onLogin}
+          buttonText="log in"
+        />
         .
       </span>
       <div className="logged-out-message__logo">

--- a/src/sidebar/components/test/logged-out-message-test.js
+++ b/src/sidebar/components/test/logged-out-message-test.js
@@ -46,7 +46,7 @@ describe('LoggedOutMessage', () => {
   });
 
   // FIXME-A11Y
-  it.skip(
+  it(
     'should pass a11y checks',
     checkAccessibility({
       content: () => createLoggedOutMessage(),

--- a/src/styles/sidebar/components/logged-out-message.scss
+++ b/src/styles/sidebar/components/logged-out-message.scss
@@ -4,17 +4,22 @@
   margin: 25px auto;
   width: 70%;
   text-align: center;
-  color: var.$grey-5;
+  color: var.$grey-mid;
   display: flex;
   flex-direction: column;
 }
 
 .logged-out-message__link {
+  padding: 0;
+  display: inline;
+  color: var.$grey-mid;
+  background-color: transparent;
   text-decoration: underline;
-  color: var.$grey-5;
+  font-weight: 400;
 
   &:hover {
     color: var.$grey-7;
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
Force 4.5:1 contrast on css
Change <a> link to <Button> —since it acts like a button

Before: right
After: left
Diff: bottom.

note: The menu is just forced to show via js override.

![Screen Shot 2020-02-14 at 8 29 53 AM](https://user-images.githubusercontent.com/3939074/74549283-38d26f00-4f04-11ea-8dbf-91e04b6b59ae.png)
