### PR TITLE
Add accessible label to annotation body markdown editor

### DIFF
--- a/src/sidebar/components/annotation-body.js
+++ b/src/sidebar/components/annotation-body.js
@@ -53,7 +53,13 @@ export default function AnnotationBody({
             />
           </Excerpt>
         )}
-        {isEditing && <MarkdownEditor text={text} onEditText={onEditText} />}
+        {isEditing && (
+          <MarkdownEditor
+            label="Annotation body"
+            text={text}
+            onEditText={onEditText}
+          />
+        )}
       </section>
       {isCollapsible && !isEditing && (
         <div className="annotation-body__collapse-toggle">

--- a/src/sidebar/components/markdown-editor.js
+++ b/src/sidebar/components/markdown-editor.js
@@ -234,7 +234,11 @@ Toolbar.propTypes = {
 /**
  * Viewer/editor for the body of an annotation in markdown format.
  */
-export default function MarkdownEditor({ onEditText = () => {}, text = '' }) {
+export default function MarkdownEditor({
+  label = '',
+  onEditText = () => {},
+  text = '',
+}) {
   /** Whether the preview mode is currently active. */
   const [preview, setPreview] = useState(false);
 
@@ -282,6 +286,7 @@ export default function MarkdownEditor({ onEditText = () => {}, text = '' }) {
         />
       ) : (
         <textarea
+          aria-label={label}
           className="markdown-editor__input"
           dir="auto"
           ref={input}
@@ -296,6 +301,11 @@ export default function MarkdownEditor({ onEditText = () => {}, text = '' }) {
 }
 
 MarkdownEditor.propTypes = {
+  /**
+   * An accessible label for the input field.
+   */
+  label: propTypes.string.isRequired,
+
   /** The markdown text to edit. */
   text: propTypes.string,
 

--- a/src/sidebar/components/test/markdown-editor-test.js
+++ b/src/sidebar/components/test/markdown-editor-test.js
@@ -100,13 +100,14 @@ describe('MarkdownEditor', () => {
     describe(`"${command}" toolbar command`, () => {
       it('applies formatting when toolbar button is clicked', () => {
         const onEditText = sinon.stub();
-        const wrapper = createComponent({ text: 'test', onEditText });
+        const text = 'toolbar command test';
+        const wrapper = createComponent({ text, onEditText });
         const button = wrapper.find(
           `ToolbarButton[title="${command}"] > button`
         );
         const input = wrapper.find('textarea').getDOMNode();
         input.selectionStart = 0;
-        input.selectionEnd = 4;
+        input.selectionEnd = text.length;
 
         button.simulate('click');
 
@@ -116,7 +117,7 @@ describe('MarkdownEditor', () => {
         const [formatFunction, ...args] = effect;
         assert.calledWith(
           formatFunction,
-          sinon.match({ text: 'test', selectionStart: 0, selectionEnd: 4 }),
+          sinon.match({ text, selectionStart: 0, selectionEnd: text.length }),
           ...args
         );
       });
@@ -124,10 +125,11 @@ describe('MarkdownEditor', () => {
       if (key) {
         it('applies formatting when shortcut key is pressed', () => {
           const onEditText = sinon.stub();
-          const wrapper = createComponent({ text: 'test', onEditText });
+          const text = 'toolbar shortcut test';
+          const wrapper = createComponent({ text, onEditText });
           const input = wrapper.find('textarea');
           input.getDOMNode().selectionStart = 0;
-          input.getDOMNode().selectionEnd = 4;
+          input.getDOMNode().selectionEnd = text.length;
 
           input.simulate('keydown', {
             ctrlKey: true,
@@ -140,7 +142,7 @@ describe('MarkdownEditor', () => {
           const [formatFunction, ...args] = effect;
           assert.calledWith(
             formatFunction,
-            sinon.match({ text: 'test', selectionStart: 0, selectionEnd: 4 }),
+            sinon.match({ text, selectionStart: 0, selectionEnd: text.length }),
             ...args
           );
         });

--- a/src/sidebar/components/test/markdown-editor-test.js
+++ b/src/sidebar/components/test/markdown-editor-test.js
@@ -42,6 +42,10 @@ describe('MarkdownEditor', () => {
     $imports.$restore();
   });
 
+  function createComponent(props = {}) {
+    return mount(<MarkdownEditor label="Test editor" text="test" {...props} />);
+  }
+
   const commands = [
     {
       command: 'Bold',
@@ -96,9 +100,7 @@ describe('MarkdownEditor', () => {
     describe(`"${command}" toolbar command`, () => {
       it('applies formatting when toolbar button is clicked', () => {
         const onEditText = sinon.stub();
-        const wrapper = mount(
-          <MarkdownEditor text="test" onEditText={onEditText} />
-        );
+        const wrapper = createComponent({ text: 'test', onEditText });
         const button = wrapper.find(
           `ToolbarButton[title="${command}"] > button`
         );
@@ -122,9 +124,7 @@ describe('MarkdownEditor', () => {
       if (key) {
         it('applies formatting when shortcut key is pressed', () => {
           const onEditText = sinon.stub();
-          const wrapper = mount(
-            <MarkdownEditor text="test" onEditText={onEditText} />
-          );
+          const wrapper = createComponent({ text: 'test', onEditText });
           const input = wrapper.find('textarea');
           input.getDOMNode().selectionStart = 0;
           input.getDOMNode().selectionEnd = 4;
@@ -162,9 +162,7 @@ describe('MarkdownEditor', () => {
   ].forEach(({ ctrlKey, key }) => {
     it('does not apply formatting when a non-shortcut key is pressed', () => {
       const onEditText = sinon.stub();
-      const wrapper = mount(
-        <MarkdownEditor text="test" onEditText={onEditText} />
-      );
+      const wrapper = createComponent({ onEditText });
       const input = wrapper.find('textarea');
 
       input.simulate('keydown', {
@@ -178,9 +176,7 @@ describe('MarkdownEditor', () => {
 
   it('calls `onEditText` callback when text is changed', () => {
     const onEditText = sinon.stub();
-    const wrapper = mount(
-      <MarkdownEditor text="test" onEditText={onEditText} />
-    );
+    const wrapper = createComponent({ onEditText });
     const input = wrapper.find('textarea').getDOMNode();
     input.value = 'changed';
     wrapper.find('textarea').simulate('input');
@@ -190,7 +186,7 @@ describe('MarkdownEditor', () => {
   });
 
   it('enters preview mode when Preview button is clicked', () => {
-    const wrapper = mount(<MarkdownEditor text="test" />);
+    const wrapper = createComponent();
 
     const previewButton = wrapper
       .find('button')
@@ -206,7 +202,7 @@ describe('MarkdownEditor', () => {
   });
 
   it('exits preview mode when Write button is clicked', () => {
-    const wrapper = mount(<MarkdownEditor text="test" />);
+    const wrapper = createComponent();
 
     // Switch to "Preview" mode.
     const previewButton = wrapper
@@ -234,7 +230,7 @@ describe('MarkdownEditor', () => {
       document.body.focus();
       document.body.appendChild(container);
       act(() => {
-        render(<MarkdownEditor text="test" />, container);
+        render(<MarkdownEditor label="An editor" text="test" />, container);
       });
 
       assert.equal(document.activeElement.nodeName, 'TEXTAREA');
@@ -243,18 +239,23 @@ describe('MarkdownEditor', () => {
     }
   });
 
-  // FIXME-A11Y
-  it.skip(
+  it('sets accessible label for input field', () => {
+    const wrapper = createComponent({ label: 'Annotation body' });
+    const inputField = wrapper.find('textarea');
+    assert.equal(inputField.prop('aria-label'), 'Annotation body');
+  });
+
+  it(
     'should pass a11y checks',
     checkAccessibility([
       {
         // eslint-disable-next-line react/display-name
-        content: () => <MarkdownEditor text="test" />,
+        content: () => createComponent(),
       },
       {
         name: 'Preview mode',
         content: () => {
-          const wrapper = mount(<MarkdownEditor text="test" />);
+          const wrapper = createComponent();
 
           const previewButton = wrapper
             .find('button')


### PR DESCRIPTION
Visually I think the purpose of this field is obvious without an explicit label
but it may not be clear to assistive tech users.