### PR TITLE
Add accessible label to search input field

### DIFF
--- a/src/sidebar/components/search-input.js
+++ b/src/sidebar/components/search-input.js
@@ -47,6 +47,7 @@ export default function SearchInput({ alwaysExpanded, query, onSearch }) {
       onSubmit={onSubmit}
     >
       <input
+        aria-label="Search"
         className={classnames('search-input__input', {
           'is-expanded': alwaysExpanded || query,
         })}

--- a/src/sidebar/components/test/search-input-test.js
+++ b/src/sidebar/components/test/search-input-test.js
@@ -87,8 +87,7 @@ describe('SearchInput', () => {
     assert.isTrue(wrapper.exists('button'));
   });
 
-  // FIXME-A11Y
-  it.skip(
+  it(
     'should pass a11y checks',
     checkAccessibility([
       {


### PR DESCRIPTION
In my testing with screen readers the meaning was reasonably clear from
the fact that you had to click on a button labeled "Search annotations"
to focus the field and there is a "Search..." placeholder. Nevertheless,
this keeps automated checking tools happy.

A better solution would probably be to re-design the search UI so that there is
enough space for a visible label and information about the search
syntax, as well as enough space for the search field on smaller screens.