### PR TITLE
Increase contrast of Button components (a11y)

### DIFF
--- a/src/sidebar/components/test/version-info-test.js
+++ b/src/sidebar/components/test/version-info-test.js
@@ -84,8 +84,7 @@ describe('VersionInfo', function() {
     });
   });
 
-  // FIXME-A11Y
-  it.skip(
+  it(
     'should pass a11y checks',
     checkAccessibility({
       content: () => createComponent(),

--- a/src/styles/mixins/buttons.scss
+++ b/src/styles/mixins/buttons.scss
@@ -16,7 +16,7 @@
 @mixin button-base {
   @include reset-native-btn-styles;
   padding: 0.5em;
-  color: var.$grey-5;
+  color: var.$grey-mid;
 
   &__icon {
     width: 16px;
@@ -47,7 +47,7 @@
   border: none;
   background-color: var.$grey-1;
   font-weight: 700;
-  color: var.$grey-5;
+  color: var.$grey-mid;
 
   padding-right: 0.75em;
   padding-left: 0.75em;

--- a/src/styles/sidebar/components/button.scss
+++ b/src/styles/sidebar/components/button.scss
@@ -29,12 +29,6 @@
   border-radius: 0; // Turn off border-radius to align with <input> edges
   border: 1px solid var.$grey-3;
   border-left: 0px; // Avoid double border with the <input>
-  color: var.$grey-4;
-
-  &:hover {
-    background-color: var.$grey-2;
-    color: var.$grey-5;
-  }
 }
 
 // In a few cases, it's necessary to squeeze buttons into tight spots


### PR DESCRIPTION
The contrast ratio for our icon-label `Button` components is not quite cutting the mustard for WCAG compliance (this doesn’t apply to button usages that have a white/transparent background—those are fine at present).

Before these changes, several buttons only had a contrast ratio of 4.23:1, whereas we need at least 4.5:1 for “normal text” to meet WCAG AA.  This PR changes the text/icon color from `$grey-5` (`#737373`) to `$grey-mid` (`#595959`), which improves the contrast ratio to 6.25:1.

User-visible changes are _relatively_ subtle, but they are visible, so I want to document what's changing in this set of changes.

## Close Buttons

Before:

<img width="95" alt="Screen Shot 2020-02-19 at 1 24 17 PM" src="https://user-images.githubusercontent.com/439947/74863148-66138880-531b-11ea-8064-16f3fed8038a.png">

After:

<img width="94" alt="Screen Shot 2020-02-19 at 1 23 32 PM" src="https://user-images.githubusercontent.com/439947/74863168-6dd32d00-531b-11ea-9444-0490bbbccce1.png">

## Cancel Button in Publish Control

Before:

<img width="433" alt="Screen Shot 2020-02-19 at 1 24 47 PM" src="https://user-images.githubusercontent.com/439947/74863204-7c214900-531b-11ea-9b58-8d753c36a2a1.png">

After:

<img width="324" alt="Screen Shot 2020-02-19 at 1 23 40 PM" src="https://user-images.githubusercontent.com/439947/74863217-82afc080-531b-11ea-840a-c78465d730e9.png">

## Copy-Version-Details Button

Before:

<img width="394" alt="Screen Shot 2020-02-19 at 1 24 12 PM" src="https://user-images.githubusercontent.com/439947/74863250-91967300-531b-11ea-8781-488cd7f56e2f.png">

After:

<img width="406" alt="Screen Shot 2020-02-19 at 1 23 28 PM" src="https://user-images.githubusercontent.com/439947/74863270-98bd8100-531b-11ea-9ed2-087a3305a33e.png">

## Copy URL Buttons

There are two variants of this, one small, one larger. This is the most visible change in this set of changes because the icon color in the "before" variant was lighter than other icons on buttons.

Before:

<img width="297" alt="Screen Shot 2020-02-19 at 1 24 23 PM" src="https://user-images.githubusercontent.com/439947/74863354-c30f3e80-531b-11ea-84fb-fc6019c44898.png">

<img width="432" alt="Screen Shot 2020-02-19 at 1 24 29 PM" src="https://user-images.githubusercontent.com/439947/74863359-c60a2f00-531b-11ea-8c7e-1d569cfc4925.png">

After:

<img width="302" alt="Screen Shot 2020-02-19 at 1 23 48 PM" src="https://user-images.githubusercontent.com/439947/74863321-b68ae600-531b-11ea-9a9e-8674388b75b5.png">

<img width="418" alt="Screen Shot 2020-02-19 at 1 23 55 PM" src="https://user-images.githubusercontent.com/439947/74863330-bc80c700-531b-11ea-9ad2-3fb289242945.png">


Part of https://github.com/hypothesis/product-backlog/issues/1085