### PR TITLE
Increase contrast in annotation cards to meet WCAG AA requirements

### DIFF
--- a/src/styles/sidebar/components/annotation-body.scss
+++ b/src/styles/sidebar/components/annotation-body.scss
@@ -2,7 +2,7 @@
 
 .annotation-body {
   @include var.font-normal;
-  color: var.$grey-6;
+  color: var.$grey-7;
   // Margin between top of ascent of annotation body and
   // bottom of ascent of annotation-quote should be ~15px.
   margin-top: var.$layout-h-margin - 5px;

--- a/src/styles/sidebar/components/annotation-header.scss
+++ b/src/styles/sidebar/components/annotation-header.scss
@@ -6,7 +6,7 @@
   // Margin between top of x-height of username and
   // top of the annotation card should be ~15px
   margin-top: -(var.$layout-h-margin) + 10px;
-  color: var.$grey-5;
+  color: var.$grey-6;
 
   &__row {
     display: flex;
@@ -31,7 +31,7 @@
   &__timestamp-edited {
     @include var.font-small;
     font-style: italic;
-    color: var.$grey-4;
+    color: var.$grey-5;
   }
 
   &__timestamp-created-link {
@@ -41,7 +41,7 @@
   }
 
   &__timestamp-created-link {
-    color: var.$grey-5;
+    color: var.$grey-6;
   }
 
   &__highlight {

--- a/src/styles/sidebar/components/annotation-quote.scss
+++ b/src/styles/sidebar/components/annotation-quote.scss
@@ -17,7 +17,7 @@
   @include var.font-normal;
 
   border-left: 3px solid var.$grey-3;
-  color: var.$grey-4;
+  color: var.$grey-5;
   font-family: sans-serif;
   font-size: 12px;
   font-style: italic;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -20,11 +20,14 @@ $grey-4: #a6a6a6;
 // minus blue tint.
 $grey-semi: #9c9c9c;
 
+// This is the lightest grey admissible on a white, $grey-0 or $grey-1
+// background to meet WCAG-AA text contrast requirements.
 $grey-5: #737373;
 
 // Interim color variable for migration purposes, as the step between `$grey-5`
 // and `$grey-6` is large. Represents `base-mid` in proposed future palette,
 // minus blue tint.
+// This is the lightest grey admissible on $grey-2, $grey-3
 $grey-mid: #595959;
 
 $grey-6: #3f3f3f;


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/1809

This PR increases contrast in several parts of annotation cards. Net effect is that most elements on the card drop one grey-shade to make sure all of them pass muster for contrast ratio.

* Quote: I still have some concern about the readability of all-italic sans serif after these changes, but in terms of contrast ratio, we're OK
* Last-edited timestamp: bumped down a color or two to get contrast ratio to be compliant. To maintain some visual weighting, the timestamp itself was also bumped down one color.
* Annotation body text: to maintain visual hierarchical distinction between the body and the excerpt, I've also dropped the annotation body text one color. 

Before:

<img width="429" alt="Screen Shot 2020-02-20 at 10 25 41 AM" src="https://user-images.githubusercontent.com/439947/74957949-41301b80-53d6-11ea-876c-dc0b56956cdd.png">

After:

<img width="431" alt="Screen Shot 2020-02-20 at 10 25 26 AM" src="https://user-images.githubusercontent.com/439947/74957963-468d6600-53d6-11ea-898f-02dd034f0d27.png">
