### PR TITLE
Disable unauthenticated annotating and highlighting

### DIFF
--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -103,6 +103,8 @@ function HypothesisAppController(
     return auth
       .login()
       .then(() => {
+        // If the prompt-to-log-in sidebar panel is open, close it
+        store.closeSidebarPanel(uiConstants.PANEL_LOGIN_PROMPT);
         store.clearGroups();
         session.reload();
       })

--- a/src/sidebar/components/login-prompt-panel.js
+++ b/src/sidebar/components/login-prompt-panel.js
@@ -1,0 +1,45 @@
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
+
+import useStore from '../store/use-store';
+import uiConstants from '../ui-constants';
+
+import Button from './button';
+import SidebarPanel from './sidebar-panel';
+
+/**
+ * A sidebar panel that prompts a user to log in (or sign up) to annotate.
+ */
+export default function LoginPromptPanel({ onLogin, onSignUp }) {
+  const isLoggedIn = useStore(store => store.isLoggedIn());
+  if (isLoggedIn) {
+    return null;
+  }
+  return (
+    <SidebarPanel
+      icon="restricted"
+      title="Login needed"
+      panelName={uiConstants.PANEL_LOGIN_PROMPT}
+    >
+      <p>Please log in to create annotations or highlights.</p>
+      <div className="sidebar-panel__actions">
+        <Button
+          buttonText="Sign up"
+          className="sidebar-panel__button"
+          onClick={onSignUp}
+        />
+        <Button
+          buttonText="Log in"
+          className="sidebar-panel__button"
+          onClick={onLogin}
+          usePrimaryStyle
+        />
+      </div>
+    </SidebarPanel>
+  );
+}
+
+LoginPromptPanel.propTypes = {
+  onLogin: propTypes.func.isRequired,
+  onSignUp: propTypes.func.isRequired,
+};

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -197,6 +197,7 @@ export default {
   bindings: {
     auth: '<',
     onLogin: '&',
+    onSignUp: '&',
   },
   template: require('../templates/sidebar-content.html'),
 };

--- a/src/sidebar/components/sidebar-panel.js
+++ b/src/sidebar/components/sidebar-panel.js
@@ -7,6 +7,7 @@ import useStore from '../store/use-store';
 
 import Button from './button';
 import Slider from './slider';
+import SvgIcon from './svg-icon';
 
 /**
  * Base component for a sidebar panel.
@@ -17,6 +18,7 @@ import Slider from './slider';
  */
 export default function SidebarPanel({
   children,
+  icon = '',
   panelName,
   title,
   onActiveChanged,
@@ -48,6 +50,11 @@ export default function SidebarPanel({
     <Slider visible={panelIsActive}>
       <div className="sidebar-panel" ref={panelElement}>
         <div className="sidebar-panel__header">
+          {icon && (
+            <div className="sidebar-panel__header-icon">
+              <SvgIcon name={icon} title={title} />
+            </div>
+          )}
           <div className="sidebar-panel__title u-stretch">{title}</div>
           <div>
             <Button
@@ -66,6 +73,11 @@ export default function SidebarPanel({
 
 SidebarPanel.propTypes = {
   children: propTypes.any,
+
+  /**
+   * An optional icon name for display next to the panel's title
+   */
+  icon: propTypes.string,
 
   /**
    * A string identifying this panel. Only one `panelName` may be active at

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -75,6 +75,7 @@ describe('sidebar.components.hypothesis-app', function() {
           },
         }),
         clearGroups: sinon.stub(),
+        closeSidebarPanel: sinon.stub(),
         openSidebarPanel: sinon.stub(),
         // draft store
         countDrafts: sandbox.stub().returns(0),
@@ -332,6 +333,13 @@ describe('sidebar.components.hypothesis-app', function() {
       const ctrl = createController();
       return ctrl.login().then(() => {
         assert.called(fakeSession.reload);
+      });
+    });
+
+    it('closes the login prompt panel', () => {
+      const ctrl = createController();
+      return ctrl.login().then(() => {
+        assert.called(fakeStore.closeSidebarPanel);
       });
     });
 

--- a/src/sidebar/components/test/login-prompt-panel-test.js
+++ b/src/sidebar/components/test/login-prompt-panel-test.js
@@ -1,0 +1,64 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import LoginPromptPanel from '../login-prompt-panel';
+import { $imports } from '../login-prompt-panel';
+
+import { checkAccessibility } from '../../../test-util/accessibility';
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+
+describe('LoginPromptPanel', function() {
+  let fakeOnLogin;
+  let fakeOnSignUp;
+
+  let fakeStore;
+
+  function createComponent(props) {
+    return mount(
+      <LoginPromptPanel
+        onLogin={fakeOnLogin}
+        onSignUp={fakeOnSignUp}
+        {...props}
+      />
+    );
+  }
+
+  beforeEach(() => {
+    fakeStore = {
+      isLoggedIn: sinon.stub().returns(false),
+    };
+
+    fakeOnLogin = sinon.stub();
+    fakeOnSignUp = sinon.stub();
+
+    $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      '../store/use-store': callback => callback(fakeStore),
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('should render if user not logged in', () => {
+    fakeStore.isLoggedIn.returns(false);
+    const wrapper = createComponent();
+
+    assert.isTrue(wrapper.find('SidebarPanel').exists());
+  });
+
+  it('should not render if user is logged in', () => {
+    fakeStore.isLoggedIn.returns(true);
+    const wrapper = createComponent();
+
+    assert.isFalse(wrapper.find('SidebarPanel').exists());
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    })
+  );
+});

--- a/src/sidebar/components/test/sidebar-panel-test.js
+++ b/src/sidebar/components/test/sidebar-panel-test.js
@@ -44,6 +44,14 @@ describe('SidebarPanel', () => {
     assert.equal(titleEl.text(), 'My Panel');
   });
 
+  it('renders an icon if provided', () => {
+    const wrapper = createSidebarPanel({ icon: 'restricted' });
+
+    const icon = wrapper.find('SvgIcon').filter({ name: 'restricted' });
+
+    assert.isTrue(icon.exists());
+  });
+
   it('closes the panel when close button is clicked', () => {
     const wrapper = createSidebarPanel({ panelName: 'flibberty' });
 

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -85,7 +85,7 @@ function configureRoutes($routeProvider) {
   });
   $routeProvider.otherwise({
     template:
-      '<sidebar-content auth="vm.auth" on-login="vm.login()"></sidebar-content>',
+      '<sidebar-content auth="vm.auth" on-login="vm.login()" on-sign-up="vm.signUp()"></sidebar-content>',
     reloadOnSearch: false,
     resolve: resolve,
   });
@@ -135,6 +135,7 @@ import AnnotationQuote from './components/annotation-quote';
 import FocusedModeHeader from './components/focused-mode-header';
 import HelpPanel from './components/help-panel';
 import LoggedOutMessage from './components/logged-out-message';
+import LoginPromptPanel from './components/login-prompt-panel';
 import ModerationBanner from './components/moderation-banner';
 import SearchStatusBar from './components/search-status-bar';
 import SelectionTabs from './components/selection-tabs';
@@ -274,6 +275,7 @@ function startAngularApp(config) {
     .component('annotationThread', annotationThread)
     .component('annotationViewerContent', annotationViewerContent)
     .component('helpPanel', wrapComponent(HelpPanel))
+    .component('loginPromptPanel', wrapComponent(LoginPromptPanel))
     .component('loggedOutMessage', wrapComponent(LoggedOutMessage))
     .component('moderationBanner', wrapComponent(ModerationBanner))
     .component('searchStatusBar', wrapComponent(SearchStatusBar))

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -40,7 +40,7 @@ export function formatAnnot(ann) {
  * sidebar.
  */
 // @ngInject
-export default function FrameSync($rootScope, $window, flash, store, bridge) {
+export default function FrameSync($rootScope, $window, store, bridge) {
   // Set of tags of annotations that are currently loaded into the frame
   const inFrame = new Set();
 
@@ -135,7 +135,7 @@ export default function FrameSync($rootScope, $window, flash, store, bridge) {
       // target document
       if (!store.isLoggedIn()) {
         bridge.call('showSidebar');
-        flash.error('Please log in to create annotations or highlights');
+        store.openSidebarPanel(uiConstants.PANEL_LOGIN_PROMPT);
         bridge.call('deleteAnnotation', formatAnnot(annot));
         return;
       }

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -40,7 +40,7 @@ export function formatAnnot(ann) {
  * sidebar.
  */
 // @ngInject
-export default function FrameSync($rootScope, $window, store, bridge) {
+export default function FrameSync($rootScope, $window, flash, store, bridge) {
   // Set of tags of annotations that are currently loaded into the frame
   const inFrame = new Set();
 
@@ -128,8 +128,18 @@ export default function FrameSync($rootScope, $window, store, bridge) {
   function setupSyncFromFrame() {
     // A new annotation, note or highlight was created in the frame
     bridge.on('beforeCreateAnnotation', function(event) {
-      inFrame.add(event.tag);
       const annot = Object.assign({}, event.msg, { $tag: event.tag });
+      // If user is not logged in, we can't really create a meaningful highlight
+      // or annotation. Instead, we need to open the sidebar, show an error,
+      // and delete the (unsaved) annotation so it gets un-selected in the
+      // target document
+      if (!store.isLoggedIn()) {
+        bridge.call('showSidebar');
+        flash.error('Please log in to create annotations or highlights');
+        bridge.call('deleteAnnotation', formatAnnot(annot));
+        return;
+      }
+      inFrame.add(event.tag);
       $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED, annot);
     });
 

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -50,7 +50,6 @@ const fixtures = {
 describe('sidebar.frame-sync', function() {
   let fakeStore;
   let fakeBridge;
-  let fakeFlash;
   let frameSync;
   let $rootScope;
 
@@ -59,10 +58,6 @@ describe('sidebar.frame-sync', function() {
   });
 
   beforeEach(function() {
-    fakeFlash = {
-      error: sinon.stub(),
-    };
-
     fakeStore = createFakeStore(
       { annotations: [] },
       {
@@ -72,6 +67,7 @@ describe('sidebar.frame-sync', function() {
         focusAnnotations: sinon.stub(),
         frames: sinon.stub().returns([fixtures.framesListEntry]),
         isLoggedIn: sinon.stub().returns(false),
+        openSidebarPanel: sinon.stub(),
         selectAnnotations: sinon.stub(),
         selectTab: sinon.stub(),
         toggleSelectedAnnotations: sinon.stub(),
@@ -96,7 +92,6 @@ describe('sidebar.frame-sync', function() {
     }
 
     angular.mock.module('app', {
-      flash: fakeFlash,
       store: fakeStore,
       bridge: fakeBridge,
     });
@@ -260,13 +255,13 @@ describe('sidebar.frame-sync', function() {
         assert.calledWith(fakeBridge.call, 'showSidebar');
       });
 
-      it('should flash an error message', () => {
+      it('should open the login prompt panel', () => {
         const ann = { target: [] };
         fakeBridge.emit('beforeCreateAnnotation', { tag: 't1', msg: ann });
 
         assert.calledWith(
-          fakeFlash.error,
-          'Please log in to create annotations or highlights'
+          fakeStore.openSidebarPanel,
+          uiConstants.PANEL_LOGIN_PROMPT
         );
       });
 

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -50,6 +50,7 @@ const fixtures = {
 describe('sidebar.frame-sync', function() {
   let fakeStore;
   let fakeBridge;
+  let fakeFlash;
   let frameSync;
   let $rootScope;
 
@@ -58,6 +59,10 @@ describe('sidebar.frame-sync', function() {
   });
 
   beforeEach(function() {
+    fakeFlash = {
+      error: sinon.stub(),
+    };
+
     fakeStore = createFakeStore(
       { annotations: [] },
       {
@@ -66,6 +71,7 @@ describe('sidebar.frame-sync', function() {
         findIDsForTags: sinon.stub(),
         focusAnnotations: sinon.stub(),
         frames: sinon.stub().returns([fixtures.framesListEntry]),
+        isLoggedIn: sinon.stub().returns(false),
         selectAnnotations: sinon.stub(),
         selectTab: sinon.stub(),
         toggleSelectedAnnotations: sinon.stub(),
@@ -90,6 +96,7 @@ describe('sidebar.frame-sync', function() {
     }
 
     angular.mock.module('app', {
+      flash: fakeFlash,
       store: fakeStore,
       bridge: fakeBridge,
     });
@@ -211,21 +218,64 @@ describe('sidebar.frame-sync', function() {
   });
 
   context('when a new annotation is created in the frame', function() {
-    it('emits a BEFORE_ANNOTATION_CREATED event', function() {
-      const onCreated = sinon.stub();
-      const ann = { target: [] };
-      $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, onCreated);
+    context('when an authenticated user is present', () => {
+      it('emits a BEFORE_ANNOTATION_CREATED event', function() {
+        fakeStore.isLoggedIn.returns(true);
+        const onCreated = sinon.stub();
+        const ann = { target: [] };
+        $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, onCreated);
 
-      fakeBridge.emit('beforeCreateAnnotation', { tag: 't1', msg: ann });
+        fakeBridge.emit('beforeCreateAnnotation', { tag: 't1', msg: ann });
 
-      assert.calledWithMatch(
-        onCreated,
-        sinon.match.any,
-        sinon.match({
-          $tag: 't1',
-          target: [],
-        })
-      );
+        assert.calledWithMatch(
+          onCreated,
+          sinon.match.any,
+          sinon.match({
+            $tag: 't1',
+            target: [],
+          })
+        );
+      });
+    });
+
+    context('when no authenticated user is present', () => {
+      beforeEach(() => {
+        fakeStore.isLoggedIn.returns(false);
+      });
+
+      it('should not emit BEFORE_ANNOTATION_CREATED event', () => {
+        const onCreated = sinon.stub();
+        const ann = { target: [] };
+        $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, onCreated);
+
+        fakeBridge.emit('beforeCreateAnnotation', { tag: 't1', msg: ann });
+
+        assert.notCalled(onCreated);
+      });
+
+      it('should open the sidebar', () => {
+        const ann = { target: [] };
+        fakeBridge.emit('beforeCreateAnnotation', { tag: 't1', msg: ann });
+
+        assert.calledWith(fakeBridge.call, 'showSidebar');
+      });
+
+      it('should flash an error message', () => {
+        const ann = { target: [] };
+        fakeBridge.emit('beforeCreateAnnotation', { tag: 't1', msg: ann });
+
+        assert.calledWith(
+          fakeFlash.error,
+          'Please log in to create annotations or highlights'
+        );
+      });
+
+      it('should send a "deleteAnnotation" message to the frame', () => {
+        const ann = { target: [] };
+        fakeBridge.emit('beforeCreateAnnotation', { tag: 't1', msg: ann });
+
+        assert.calledWith(fakeBridge.call, 'deleteAnnotation');
+      });
     });
   });
 

--- a/src/sidebar/templates/sidebar-content.html
+++ b/src/sidebar/templates/sidebar-content.html
@@ -2,6 +2,8 @@
   ng-if="vm.showFocusedHeader()">
 </focused-mode-header>
 
+<login-prompt-panel on-login="vm.onLogin()" on-sign-up="vm.onSignUp()"></login-prompt-panel>
+
 <selection-tabs
   ng-if="vm.showSelectedTabs()"
   is-loading="vm.isLoading()">
@@ -26,6 +28,7 @@
   ng-if="vm.selectedGroupUnavailable()"
 >
 </sidebar-content-error>
+
 
 <thread-list
   on-change-collapsed="vm.setCollapsed(id, collapsed)"

--- a/src/sidebar/ui-constants.js
+++ b/src/sidebar/ui-constants.js
@@ -4,6 +4,7 @@
 
 export default {
   PANEL_HELP: 'help',
+  PANEL_LOGIN_PROMPT: 'loginPrompt',
   PANEL_SHARE_ANNOTATIONS: 'shareGroupAnnotations',
   TAB_ANNOTATIONS: 'annotation',
   TAB_NOTES: 'note',

--- a/src/styles/mixins/panel.scss
+++ b/src/styles/mixins/panel.scss
@@ -44,6 +44,15 @@
     margin: 1em;
     margin-top: 0;
   }
+
+  &__button {
+    margin-left: 1em;
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+  }
 }
 
 /**

--- a/src/styles/sidebar/components/sidebar-content-error.scss
+++ b/src/styles/sidebar/components/sidebar-content-error.scss
@@ -5,13 +5,4 @@
   @include panel.panel;
   position: relative;
   margin-bottom: 0.75em;
-
-  &__button {
-    margin-left: 1em;
-  }
-
-  &__actions {
-    display: flex;
-    justify-content: flex-end;
-  }
 }


### PR DESCRIPTION
Updated: **Feedback is to go with the panel direction, so I've rounded out that approach and added tests to the second commit.**

This PR builds on the POC in [this branch](https://github.com/hypothesis/client/tree/poc-no-unauthed-annots).

The intent of this PR is to prevent the creation of wonky/incomplete annotations and highlights in the client sidebar interface. The current problem set is discussed at length in [this Slack thread, accessible to Hypothesis staff](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1582209101481900). I'll add a few "before" screenshots to the end of this description, as well, for the purpose of background/documentation.

The [first commit](https://github.com/hypothesis/client/commit/1dd1dbca7f8c39b9f5bd1e43169136a3a2f34962) on this branch is short and sweet: it disables the creation of anonymous highlights and annotations at the `frame-sync` service level, before they are added to the store. In these cases, it opens the sidebar and flashes and error message about needing to log in:

<img width="476" alt="Screen Shot 2020-02-20 at 3 15 23 PM" src="https://user-images.githubusercontent.com/439947/74975099-751a3980-53f4-11ea-8881-4dc8b34ca698.png">

I wish we could just ship the above because it is so self-contained and simple and prevents so many problems. That first commit has tests and is shipshape.

_However_, the positioning of the flash element is obnoxiously right on top of the _Log in_ link we're asking users to use! This is probably a deal-killer?

Thus, the [second commit](https://github.com/hypothesis/client/commit/8fee1be037f398a88e2c4c9e1203d793632dc2ab) builds on the first to use a `SidebarPanel`-derived component to display the error message. It looks like so:

<img width="487" alt="Screen Shot 2020-02-20 at 3 15 43 PM" src="https://user-images.githubusercontent.com/439947/74975205-b1e63080-53f4-11ea-8f21-456b4c01bbf3.png">

On the plus side, that treatment gets the CTA buttons right in front of the user, and is smart enough to close itself when login is successful. It is also consistent with other panel patterns we're using in the client. On the down side, I don't feel like it is crystal-clear, visually.

----

## Before

<img width="451" alt="Screen Shot 2020-02-14 at 3 01 26 PM" src="https://user-images.githubusercontent.com/439947/74975575-45b7fc80-53f5-11ea-91cc-3693dfa19e6a.png">

<img width="541" alt="Screen Shot 2020-02-14 at 3 03 12 PM" src="https://user-images.githubusercontent.com/439947/74975588-48b2ed00-53f5-11ea-93a8-1e1d8b6206ec.png">

<img width="495" alt="Screen Shot 2020-02-14 at 3 04 15 PM" src="https://user-images.githubusercontent.com/439947/74975596-4baddd80-53f5-11ea-9f6c-56dfe5a36c54.png">

<img width="869" alt="Screen Shot 2020-02-14 at 3 05 52 PM" src="https://user-images.githubusercontent.com/439947/74975610-50729180-53f5-11ea-977a-04670225010e.png">
