### PR TITLE
POC: WIP: Add autosave service

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,8 @@
 {
-  "extends": [
-    "hypothesis",
-    "plugin:jsx-a11y/recommended"
-  ],
+  "extends": ["hypothesis", "plugin:jsx-a11y/recommended"],
+  "env": {
+    "es6": true
+  },
   "globals": {
     "Set": false
   },

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -84,13 +84,6 @@ function AnnotationController(
      */
     newlyCreatedByHighlightButton = self.annotation.$highlight || false;
 
-    // Automatically save new highlights to the server when they're created.
-    // Note that this line also gets called when the user logs in (since
-    // AnnotationController instances are re-created on login) so serves to
-    // automatically save highlights that were created while logged out when you
-    // log in.
-    saveNewHighlight();
-
     // If this annotation is not a highlight and if it's new (has just been
     // created by the annotate button) or it has edits not yet saved to the
     // server - then open the editor on AnnotationController instantiation.
@@ -100,45 +93,6 @@ function AnnotationController(
       }
     }
   };
-
-  /** Save this annotation if it's a new highlight.
-   *
-   * The highlight will be saved to the server if the user is logged in,
-   * saved to drafts if they aren't.
-   *
-   * If the annotation is not new (it has already been saved to the server) or
-   * is not a highlight then nothing will happen.
-   *
-   */
-  function saveNewHighlight() {
-    if (!isNew(self.annotation)) {
-      // Already saved.
-      return;
-    }
-
-    if (!self.annotation.user) {
-      // Open sidebar to display error message about needing to login to create highlights.
-      bridge.call('showSidebar');
-    }
-
-    if (!self.isHighlight()) {
-      // Not a highlight,
-      return;
-    }
-
-    if (self.annotation.user) {
-      // User is logged in, save to server.
-      // Highlights are always private.
-      self.annotation.permissions = permissions.private(self.annotation.user);
-      save(self.annotation).then(function(model) {
-        model.$tag = self.annotation.$tag;
-        $rootScope.$broadcast(events.ANNOTATION_CREATED, model);
-      });
-    } else {
-      // User isn't logged in, save to drafts.
-      store.createDraft(self.annotation, self.state());
-    }
-  }
 
   /**
    * @ngdoc method

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -238,38 +238,6 @@ describe('annotation', function() {
     });
 
     describe('initialization', function() {
-      it('saves new highlights to the server on initialization', function() {
-        const annotation = fixtures.newHighlight();
-        // The user is logged-in.
-        annotation.user = fakeSession.state.userid = 'acct:bill@localhost';
-        createDirective(annotation);
-
-        assert.called(fakeApi.annotation.create);
-      });
-
-      it('saves new highlights to drafts if not logged in', function() {
-        const annotation = fixtures.newHighlight();
-        // The user is not logged-in.
-        annotation.user = fakeSession.state.userid = undefined;
-
-        createDirective(annotation);
-
-        assert.notCalled(fakeApi.annotation.create);
-        assert.called(fakeStore.createDraft);
-      });
-
-      it('opens the sidebar when trying to save highlights while logged out', () => {
-        // The sidebar is opened in order to draw the user's attention to
-        // the `You must be logged in to create annotations and highlights` message.
-        const annotation = fixtures.newHighlight();
-        // The user is not logged-in.
-        annotation.user = fakeSession.state.userid = undefined;
-
-        createDirective(annotation);
-
-        assert.calledWith(fakeBridge.call, 'showSidebar');
-      });
-
       it('does not save new annotations on initialization', function() {
         const annotation = fixtures.newAnnotation();
 
@@ -416,24 +384,6 @@ describe('annotation', function() {
         const vm = createDirective(ann).controller;
 
         assert.isFalse(vm.isHighlight());
-      });
-    });
-
-    describe('when the annotation is a highlight', function() {
-      let annotation;
-
-      beforeEach(function() {
-        annotation = fixtures.defaultAnnotation();
-        annotation.$highlight = true;
-      });
-
-      it('is private', function() {
-        delete annotation.id;
-        createDirective(annotation);
-        $scope.$digest();
-        assert.deepEqual(annotation.permissions, {
-          read: ['justme'],
-        });
       });
     });
 

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -123,6 +123,14 @@ function persistDefaults(persistedDefaults) {
   persistedDefaults.init();
 }
 
+/**
+ * Set up autosave-new-highlights service
+ */
+// @ngInject
+function autosave(autosaveService) {
+  autosaveService.init();
+}
+
 // Preact UI components that are wrapped for use within Angular templates.
 
 import AnnotationActionBar from './components/annotation-action-bar';
@@ -169,6 +177,7 @@ import windowScrollDirective from './directive/window-scroll';
 import bridgeService from '../shared/bridge';
 
 import analyticsService from './services/analytics';
+import autosaveService from './services/autosave';
 import annotationMapperService from './services/annotation-mapper';
 import annotationsService from './services/annotations';
 import apiService from './services/api';
@@ -211,6 +220,7 @@ function startAngularApp(config) {
     .register('analytics', analyticsService)
     .register('annotationMapper', annotationMapperService)
     .register('annotationsService', annotationsService)
+    .register('autosaveService', autosaveService)
     .register('api', apiService)
     .register('apiRoutes', apiRoutesService)
     .register('auth', authService)
@@ -301,6 +311,7 @@ function startAngularApp(config) {
     .service('analytics', () => container.get('analytics'))
     .service('annotationMapper', () => container.get('annotationMapper'))
     .service('annotationsService', () => container.get('annotationsService'))
+    .service('autosaveService', () => container.get('autosaveService'))
     .service('api', () => container.get('api'))
     .service('auth', () => container.get('auth'))
     .service('bridge', () => container.get('bridge'))
@@ -332,6 +343,7 @@ function startAngularApp(config) {
     .run(registerAngularServices)
 
     .run(persistDefaults)
+    .run(autosave)
     .run(sendPageView)
     .run(setupApi)
     .run(crossOriginRPC.server.start);

--- a/src/sidebar/services/autosave.js
+++ b/src/sidebar/services/autosave.js
@@ -1,0 +1,59 @@
+/**
+ * A service for automatically saving new highlights.
+ */
+import { retryPromiseOperation } from '../util/retry';
+
+// @ngInject
+export default function autosaveService(annotationsService, store) {
+  // A Set of annotation $tags that have save requests in-flight
+  const saving = new Set();
+
+  // A Set of annotation $tags that have failed to save after retries
+  const failed = new Set();
+
+  /**
+   * Determine whether we should try to send a save request for the highlight
+   * indicated by `htag`
+   *
+   * @param {string} htag - The local unique identifier for the unsaved highlight
+   * @return {boolean}
+   */
+  const shouldSaveHighlight = htag => {
+    return !saving.has(htag) && !failed.has(htag);
+  };
+
+  /**
+   * Store-subscribed call back. Automatically save new highlights.
+   */
+  const autosaveNewHighlights = () => {
+    const newHighlights = store.newHighlights() || [];
+
+    newHighlights.forEach(highlight => {
+      // Because this is a new annotation object, it does not yet have an `id`
+      // property. Use the local `$tag` for uniqueness instead.
+      const htag = highlight.$tag;
+
+      if (!shouldSaveHighlight(htag)) {
+        return;
+      }
+
+      saving.add(htag);
+
+      retryPromiseOperation(() => annotationsService.save(highlight))
+        .catch(() => {
+          // save failed after retries
+          failed.add(htag);
+        })
+        .finally(() => {
+          // Request is complete, no longer attempting to save
+          saving.delete(htag);
+        });
+    });
+  };
+
+  return {
+    init() {
+      store.subscribe(autosaveNewHighlights);
+    },
+  };
+}

--- a/src/sidebar/services/test/autosave-test.js
+++ b/src/sidebar/services/test/autosave-test.js
@@ -1,0 +1,62 @@
+import * as annotationFixtures from '../../test/annotation-fixtures';
+import createFakeStore from '../../test/fake-redux-store';
+
+import autosaveService from '../autosave';
+import { $imports } from '../autosave';
+
+describe('autosaveService', () => {
+  let fakeAnnotationsService;
+  let fakeNewHighlights;
+  let fakeRetryPromiseOperation;
+  let fakeStore;
+
+  beforeEach(() => {
+    fakeAnnotationsService = { save: sinon.stub().resolves() };
+    fakeNewHighlights = sinon.stub().returns([]);
+    fakeRetryPromiseOperation = sinon.stub().resolves();
+    fakeStore = createFakeStore(
+      { annotations: [] },
+      { newHighlights: fakeNewHighlights }
+    );
+
+    $imports.$mock({
+      '../util/retry': {
+        retryPromiseOperation: fakeRetryPromiseOperation,
+      },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('should subscribe to store updates and check for new highlights', () => {
+    const svc = autosaveService(fakeAnnotationsService, fakeStore);
+    svc.init();
+
+    fakeStore.setState({
+      annotations: ['foo'],
+    });
+
+    assert.calledOnce(fakeStore.newHighlights);
+  });
+
+  it('should save new highlights', () => {
+    const svc = autosaveService(fakeAnnotationsService, fakeStore);
+    const newHighlight = annotationFixtures.newHighlight();
+    svc.init();
+    newHighlight.$tag = 'deadbeef';
+    fakeStore.newHighlights.returns([newHighlight]);
+
+    fakeStore.setState({
+      annotations: ['foo'],
+    });
+
+    assert.calledOnce(fakeRetryPromiseOperation);
+  });
+
+  describe('retries and failures', () => {
+    it('should not try to save a highlight that is already being saved');
+    it('should not try to save a highlight that has failed to save');
+  });
+});

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -8,7 +8,7 @@ import { createSelector } from 'reselect';
 import uiConstants from '../../ui-constants';
 import * as metadata from '../../util/annotation-metadata';
 import * as arrayUtil from '../../util/array';
-import { defaultPermissions } from '../../util/permissions';
+import { defaultPermissions, privatePermissions } from '../../util/permissions';
 import * as util from '../util';
 
 import drafts from './drafts';
@@ -360,6 +360,11 @@ function createAnnotation(ann, now = new Date()) {
       },
       ann
     );
+    // Highlights are peculiar in that they always have private permissions
+    if (metadata.isHighlight(ann)) {
+      ann.permissions = privatePermissions(userid);
+    }
+
     // When a new annotation is created, remove any existing annotations
     // that are empty.
     dispatch(drafts.actions.deleteNewAndEmptyDrafts([ann]));
@@ -438,6 +443,25 @@ function findAnnotationByID(state, id) {
 }
 
 /**
+ * Return all loaded annotations that are highlights and have not been saved
+ * to the server.
+ */
+const newAnnotations = createSelector(
+  state => state.annotations.annotations,
+  annotations => annotations.filter(ann => metadata.isNew(ann))
+);
+
+/**
+ * Return all loaded annotations that are highlights and have not been saved
+ * to the server.
+ */
+const newHighlights = createSelector(
+  state => state.annotations.annotations,
+  annotations =>
+    annotations.filter(ann => metadata.isNew(ann) && metadata.isHighlight(ann))
+);
+
+/**
  * Return the number of page notes.
  */
 const noteCount = createSelector(
@@ -485,13 +509,15 @@ export default {
   },
 
   selectors: {
-    annotationExists,
-    noteCount,
     annotationCount,
-    orphanCount,
-    isWaitingToAnchorAnnotations,
+    annotationExists,
     findAnnotationByID,
     findIDsForTags,
+    isWaitingToAnchorAnnotations,
+    newAnnotations,
+    newHighlights,
+    noteCount,
+    orphanCount,
     savedAnnotations,
   },
 };


### PR DESCRIPTION
Part of #1650 

This PR is a POC of refactoring the auto-save of new highlights into a service that subscribes to the store and auto-saves new highlights.

Is this approach sensible? Is the retries thing silly? And I'm not sure whether the change necessitated in the `.eslintrc` for the use of `Set` should be here or in the upstream `hypothesis` lint config...