### PR TITLE
Fix error in angular callback by providing `event` object

### DIFF
--- a/src/sidebar/components/annotation-action-bar.js
+++ b/src/sidebar/components/annotation-action-bar.js
@@ -76,12 +76,12 @@ function AnnotationActionBar({
       .catch(err => flash.error(err.message, 'Flagging annotation failed'));
   };
 
-  const onReplyClick = () => {
+  const onReplyClick = event => {
     if (!isLoggedIn) {
       openSidebarPanel(uiConstants.PANEL_LOGIN_PROMPT);
       return;
     }
-    onReply();
+    onReply(event);
   };
 
   return (


### PR DESCRIPTION
The reply click handler was failing because it was not passing the `event` along to angular. This caused a regression in replying.

This is the error that this fixes:

![image](https://user-images.githubusercontent.com/439947/75071918-5daa8180-54c4-11ea-841e-a1168a22cbb6.png)
