### PR TITLE
Remove autofill-event dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "angular-mocks": "^1.7.5",
     "angular-route": "^1.7.5",
     "angular-toastr": "^2.1.1",
-    "autofill-event": "0.0.1",
     "autoprefixer": "^9.4.7",
     "aws-sdk": "^2.345.0",
     "axe-core": "^3.4.1",

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -33,10 +33,6 @@ import angular from 'angular';
 import angularRoute from 'angular-route';
 import angularToastr from 'angular-toastr';
 
-// autofill-event relies on the existence of window.angular so
-// it must be require'd after angular is first require'd
-import 'autofill-event';
-
 // Load polyfill for :focus-visible pseudo-class.
 import 'focus-visible';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1466,11 +1466,6 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autofill-event@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/autofill-event/-/autofill-event-0.0.1.tgz#c382cf989b21b61ff4a12b3597e1943471d3cf7a"
-  integrity sha1-w4LPmJshth/0oSs1l+GUNHHTz3o=
-
 autoprefixer@^9.4.7:
   version "9.7.4"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.7.4.tgz#f8bf3e06707d047f0641d87aee8cfb174b2a5378"


### PR DESCRIPTION
This is an Angular/jQuery-specific package which AFAICS is no longer
useful for us. Every component in the sidebar app that displays an input
field of some kind is now built with Preact.