### PR TITLE
Remove mkdirp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "lodash.debounce": "^4.0.3",
     "lodash.get": "^4.3.0",
     "loose-envify": "^1.4.0",
-    "mkdirp": "^0.5.1",
     "mocha": "^7.0.0",
     "node-uuid": "^1.4.3",
     "npm-packlist": "^2.0.1",

--- a/scripts/gulp/create-bundle.js
+++ b/scripts/gulp/create-bundle.js
@@ -12,7 +12,6 @@ const coffeeify = require('coffeeify');
 const exorcist = require('exorcist');
 const log = require('fancy-log');
 const envify = require('loose-envify/custom');
-const mkdirp = require('mkdirp');
 const watchify = require('watchify');
 
 const minifyStream = require('./minify-stream');
@@ -61,7 +60,7 @@ function waitForever() {
  *                   waits forever otherwise.
  */
 module.exports = function createBundle(config, buildOpts) {
-  mkdirp.sync(config.path);
+  fs.mkdirSync(config.path, { recursive: true });
 
   buildOpts = buildOpts || { watch: false };
 


### PR DESCRIPTION
Remove a dependency that is no longer needed with current versions of
Node as the built-in `fs.mkdirSync` function has a `recursive` option.

To test, remove your `build` directory and then trigger a rebuild of JS bundles (eg. with `make dev` or `gulp build-js`).