### PR TITLE
Fix manifest not rebuilding after source file changes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -346,7 +346,7 @@ function generateManifest(opts) {
 
 gulp.task('watch-manifest', function() {
   gulp.watch(MANIFEST_SOURCE_FILES, { delay: 500 }, function updateManifest() {
-    generateManifest({ usingDevServer: true });
+    return generateManifest({ usingDevServer: true });
   });
 });
 


### PR DESCRIPTION
Fix an issue where `build/boot.js` and `build/manifest.json` were not
rebuilt after script/style bundles were updated or other resources were
updated in the `build/` directory.

The `updateManifest` gulp task function was not returning a value so
gulp silently treated the task as never completing. I thought this
generated a warning at some point in the past, but it looks like that
was not happening.

This fixes an issue in development where `build/boot.js` would sometimes
be generated before `build/scripts/boot.bundle.js` had been fully
written and then not regenerated after that file was written. This
resulted in an empty or incomplete `build/boot.js` file and as a result
the dev client would fail to start.