### PR TITLE
Stop loading icon font CSS in sidebar app

### DIFF
--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -121,7 +121,6 @@ function bootSidebarApp(doc, config) {
 
     'styles/angular-csp.css',
     'styles/angular-toastr.css',
-    'styles/icomoon.css',
     'styles/katex.min.css',
     'styles/sidebar.css',
   ]);

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -48,7 +48,6 @@ describe('bootstrap', function() {
 
       'styles/angular-csp.css',
       'styles/angular-toastr.css',
-      'styles/icomoon.css',
       'styles/katex.min.css',
       'styles/sidebar.css',
     ];
@@ -155,7 +154,6 @@ describe('bootstrap', function() {
         'scripts/sidebar.bundle.1234.js',
         'styles/angular-csp.1234.css',
         'styles/angular-toastr.1234.css',
-        'styles/icomoon.1234.css',
         'styles/katex.min.1234.css',
         'styles/sidebar.1234.css',
       ].map(assetUrl);


### PR DESCRIPTION
All uses of the icon font in the sidebar app have now been replaced by
`SvgIcon`.