### PR TITLE
Fix page note initial tab selection when there are replies in the mix

### DIFF
--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -2,6 +2,7 @@ import uiConstants from '../../../ui-constants';
 import createStore from '../../create-store';
 import annotations from '../annotations';
 import selection from '../selection';
+import * as fixtures from '../../../test/annotation-fixtures';
 
 describe('sidebar/store/modules/selection', () => {
   let store;
@@ -421,6 +422,61 @@ describe('sidebar/store/modules/selection', () => {
       store.selectTab(uiConstants.TAB_NOTES);
 
       assert.equal(getSelectionState().sortKey, 'Newest');
+    });
+  });
+
+  describe('ADD_ANNOTATIONS', () => {
+    it('should select the page notes tab if all top-level annotations are page notes', () => {
+      store.dispatch({
+        type: 'ADD_ANNOTATIONS',
+        annotations: [fixtures.oldPageNote(), fixtures.oldPageNote()],
+        currentAnnotationCount: 0,
+      });
+
+      assert.equal(getSelectionState().selectedTab, uiConstants.TAB_NOTES);
+    });
+
+    it('should select the page notes tab if page notes have replies', () => {
+      const pageNote = fixtures.oldPageNote();
+      const reply = fixtures.newReply();
+      reply.references = [pageNote.id];
+      store.dispatch({
+        type: 'ADD_ANNOTATIONS',
+        annotations: [pageNote, reply],
+        currentAnnotationCount: 0,
+      });
+
+      assert.equal(getSelectionState().selectedTab, uiConstants.TAB_NOTES);
+    });
+
+    it('should not select the page notes tab if there were previously annotations in the store', () => {
+      store.dispatch({
+        type: 'ADD_ANNOTATIONS',
+        annotations: [fixtures.oldPageNote(), fixtures.oldPageNote()],
+        currentAnnotationCount: 4,
+      });
+
+      assert.equal(
+        getSelectionState().selectedTab,
+        uiConstants.TAB_ANNOTATIONS
+      );
+    });
+
+    it('should not select the page notes tab if there are non-page-note annotations at the top level', () => {
+      store.dispatch({
+        type: 'ADD_ANNOTATIONS',
+        annotations: [
+          fixtures.oldPageNote(),
+          fixtures.oldPageNote(),
+          fixtures.oldHighlight(),
+        ],
+        currentAnnotationCount: 0,
+      });
+
+      assert.equal(
+        getSelectionState().selectedTab,
+        uiConstants.TAB_ANNOTATIONS
+      );
     });
   });
 });


### PR DESCRIPTION
I've found a fix for https://github.com/hypothesis/client/issues/1827, and this code change will make the client correctly select the "Page Notes" tab automatically when all _top level_ annotations are Page Notes—this change disregards replies when making that calculation.

Caveat, however: the chunk of code this modifies (originally added https://github.com/hypothesis/client/commit/cca9dabd4e8a4182e4ea4745ad55f325ee68ad92 ) is untested. This pattern is new to me—an action name here `ADD_ANNOTATIONS` appears to be adding another reducer for the `ADD_ANNOTATIONS` action originally defined in the `annotations` store module (https://github.com/hypothesis/client/blob/599e25e57355ec0b46f22787adfebf41dc1e5a12/src/sidebar/store/modules/annotations.js#L477). How _would_ we write tests for this? Note that the `real-time-updates` module also appears to define an `ADD_ANNOTATIONS` reducer. Apologies if my terminology is off.

Fixes https://github.com/hypothesis/client/issues/1827