### PR TITLE
POC: Move draft creation for new annotations to store

### DIFF
--- a/src/sidebar/components/annotation-omega.js
+++ b/src/sidebar/components/annotation-omega.js
@@ -1,14 +1,9 @@
 import { createElement } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
+import { useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import useStore from '../store/use-store';
-import {
-  isHighlight,
-  isNew,
-  isReply,
-  quote,
-} from '../util/annotation-metadata';
+import { isNew, isReply, quote } from '../util/annotation-metadata';
 import { isShared } from '../util/permissions';
 import { withServices } from '../util/service-context';
 
@@ -55,18 +50,6 @@ function AnnotationOmega({
   const toggleAction = threadIsCollapsed ? 'Show replies' : 'Hide replies';
   const toggleText = `${toggleAction} (${replyCount})`;
 
-  useEffect(() => {
-    // TEMPORARY. Create a new draft for new (non-highlight) annotations
-    // to put the component in "edit mode."
-    if (!isSaving && !draft && isNew(annotation) && !isHighlight(annotation)) {
-      createDraft(annotation, {
-        tags: annotation.tags,
-        text: annotation.text,
-        isPrivate: !isShared(annotation.permissions),
-      });
-    }
-  }, [annotation, draft, createDraft, isSaving]);
-
   const shouldShowActions = !isEditing && !isNew(annotation);
   const shouldShowLicense = isEditing && !isPrivate && group.type !== 'private';
   const shouldShowReplyToggle = replyCount > 0 && !isReply(annotation);
@@ -79,14 +62,7 @@ function AnnotationOmega({
     createDraft(annotation, { ...draft, text });
   };
 
-  const onReply = () => {
-    // TODO: Re-evaluate error handling here
-    if (!userid) {
-      flash.error('Please log in to reply to annotations');
-    } else {
-      annotationsService.reply(annotation, userid);
-    }
-  };
+  const onReply = () => annotationsService.reply(annotation, userid);
 
   const onSave = async () => {
     setIsSaving(true);

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -82,15 +82,6 @@ function AnnotationController(
      * new client-side).
      */
     newlyCreatedByHighlightButton = self.annotation.$highlight || false;
-
-    // If this annotation is not a highlight and if it's new (has just been
-    // created by the annotate button) or it has edits not yet saved to the
-    // server - then open the editor on AnnotationController instantiation.
-    if (!newlyCreatedByHighlightButton) {
-      if (isNew(self.annotation) || store.getDraft(self.annotation)) {
-        self.edit();
-      }
-    }
   };
 
   /**


### PR DESCRIPTION
Until this point, it's been under the `Annotation`'s (and now `AnnotationOmega`'s) purview to look at its annotation object and see if a draft should be created for that annotation (this has the side effect of putting the component in “edit mode”). It felt a little fugly, and this job feels like it would be better done by something that is not directly a UI component.

This is straightforward for the most part but comes with one specific caveat/affordance I'll explain in a moment.

I evaluated a few different approaches to this:

1. **Leave it where it was (in the component)**. The complexity of the current conditional in `AnnotationOmega` (four tests long at present) argued against this, and this operation felt like it applied to the preact app as a whole versus the component specifically. Given that we know that new/unsaved annotations should get a draft (unless they’re highlights) at the time that they’re created and added to the store, that seemed a good place to do it.
2. **Create another service and subscribe to changes and create drafts from there**. There is a certain amount of appeal to this for me, as the `createAnnotation` logic in the `annotations` store module is getting…lengthy. However, it adds a layer of indirection and complexity (another thing to initialize and test, and may seem “magical” to future devs.
3. **Add it to the `createAnnotation` logic in the `annotations` store module**. This is what I ended up doing in this POC. Like I said, the logic in that method is getting longer than I’m totally comfortable with, but this _is_  legitimately part of the set of new-annotation-creation tasks.

### The `$tag` caveat

The [`ann` object reference](https://github.com/hypothesis/client/compare/autosave-highlights...poc-external-draft?expand=1#diff-a63e908ac791de9e976b78bb496bba1fR347) in `createAnnotation` is an object literal representing the annotation object that will get added to the store’s collection of annotations, but the annotation that ultimately gets added to the store’s annotations is a [different object reference](https://github.com/hypothesis/client/compare/autosave-highlights...poc-external-draft?expand=1#diff-a63e908ac791de9e976b78bb496bba1fR71) (i.e. it gets extended and copied), as is the way of things with a redux store.

Thus, at the [point that we want to create a draft within the `createAnnotation` method](https://github.com/hypothesis/client/compare/autosave-highlights...poc-external-draft?expand=1#diff-a63e908ac791de9e976b78bb496bba1fR379), we do not have a reference to annotation object that has been added to the store’s annotations. The `drafts` store module needs to be able to look up the `annotation` passed to `createDraft` in the store’s annotations. In short, we need a unique identifier. This needs to be either an `id` property (which it won’t have yet because it hasn’t been saved) or a local `$tag` property.

In the case of annotations and highlights created on the `annotator` side of the equation, they come pre-populated with a `$tag` that the annotator sets. So a `createDraft` step introduced right after `addAnnotations` works for these cases.

It does not, however, work  for replies or page notes, which are created on the `client` side of the app and won’t have a `$tag` assigned until [within the flow of the `ADD_ANNOTATIONS` action](https://github.com/hypothesis/client/compare/autosave-highlights...poc-external-draft?expand=1#diff-a63e908ac791de9e976b78bb496bba1fR119). That is problematic because from the `createAnnotation` function we have no insight into what that assigned `$tag` ends up being.

What I’ve done here is [reuse the same tag-generating approach as the `annotator` uses to create its `$tag`s](https://github.com/hypothesis/client/compare/autosave-highlights...poc-external-draft?expand=1#diff-a63e908ac791de9e976b78bb496bba1fR361-R364). Assuming this results in something reasonably unique enough, there’s no _meaningful_ problem in assigning a tag here, it’s just a little messy feeling. And maybe there’s some argument for using the sequential simple `$tag` values that this store module uses? Does it matter? Put another way: is there any _meaning_ to the value of `$tag` properties, or do they just need to be reliably unique?

~~_Note_: This branch has a dependency on #1840 so you'll note that the diff is between this branch and that one.~~ Not anymore.

This is pursuant to https://github.com/hypothesis/client/issues/1834