### PR TITLE
WIP - RPC refactor

### DIFF
--- a/src/sidebar/util/ancestor-frame-rpc.js
+++ b/src/sidebar/util/ancestor-frame-rpc.js
@@ -1,0 +1,78 @@
+import hostConfig from '../host-config';
+import * as postMessageJsonRpc from './postmessage-json-rpc';
+
+// Global embedder ancestor frame handle that is capable 
+// of sending and receiving RPC requests.
+let _ancestor = null;
+
+/** 
+ *  Returns the global embedder ancestor frame
+ *  @return {Promise<Window>}
+ */
+export async function ancestor() {
+  if (_ancestor) {
+    return Promise.resolve(_ancestor);
+  }
+  _ancestor = await findTrueAncestor();
+  return _ancestor;
+}
+
+/** 
+ * Iteratively discoverers all parent iframes and 
+ * returns them in a list.
+ * @return {Window[]}
+ */
+function getAncestors(window_) {
+  if (window_ === window_.top) {
+    return [];
+  }
+
+  // nb. The top window's `parent` is itself!
+  const ancestors = [];
+  do {
+    window_ = window_.parent;
+    ancestors.push(window_);
+  } while (window_ !== window_.top);
+
+  return ancestors;
+}
+/** 
+ * Sends out an RPC request to every parent iframe. The
+ * first one to respond back with an acknowledgement is
+ * assumed to be the controlling embedder frame that will
+ * later be used to send along its config and communicate
+ * with the client.
+ * 
+ * @param {Window=} - The current window frame of this sidebar.
+ * @return {Window} - The discovered ancestor frame.
+ */
+async function findTrueAncestor(window_ = window) {
+  const configResponses = [];
+  const hostPageConfig = hostConfig(window_);
+  const origin = hostPageConfig.requestConfigFromFrame;
+
+  const ancestors = getAncestors(window_);
+  for (let i = 0; i <  ancestors.length; i++) {
+    const ancestor = ancestors[i];
+    const timeout = 3000;
+    const result = postMessageJsonRpc.call(
+      ancestor,
+      origin,
+      'requestFrame',
+      // Round trip a unique index so we can match up 
+      // the result to a local frame.
+      [{index: i}], 
+      timeout,
+    );
+    configResponses.push(result);
+  }
+
+  if (configResponses.length === 0) {
+    configResponses.push(Promise.reject(new Error('Client is top frame')));
+  }
+  const result = await Promise.race(configResponses);
+  // result.index will match the index into the ancestors array 
+  // that we sent the winning request to.
+  return ancestors[result.index];
+}
+


### PR DESCRIPTION
**Goals of this PR.**

- Pull out the logic for finding the parent frame from the config request and make that its own request called`requestFrame`. This is encapsulated in an async function called `ancestor()` that either  or gets parent frame if its the first time or returns the frame if it already has it from a previous call.

- Stub out a new request for telling the parent LMS app that the client RPC server is actually ready.  `readyToReceive` and ensure this gets called only after `crossOriginRPC.server.start` is run.

- Refactor `fetchConfig` into `fetchConfigRpc` and `fetchConfig` to make the code easier to read. These methods also do not need to guess which parent frame they send to because we have it from the frame from `ancestor()` call

- Fix the timeout bug discovered when changing things around in LMS. In setting up async methods for RPC request on the lms rcp server, I came across an underlying bug in our client's rpc server. We currently don't enforce order on the client. That is to say only by chance the rpc requests from the lms down to the client arrived after the client service is ready. 

**Bug details**
Previously when `fetchConfig()` was called, it sent out an rpc request (`requestConfig`) to the client. When that request landed, it told the LMS app that the client was ready. But only after that rpc response came back, did the client then actually set up the RPC server on the client via. `startAngularApp(config)` (index.js line 360) which then kicked off `.run(crossOriginRPC.server.start);`. It was only by chance this worked and when changes were made on LMS, this stopped working. I refactored index.js so everything is run in the correct order.

_Note. this can not be tested until some changes on the LMS are made, I'm looking for structural feedback on the code and making sure everything makes sense with what I'm intending to change._