### PR TITLE
Fix compatibility of create-github-release.js with @ocktokit/rest v17

### DIFF
--- a/scripts/create-github-release.js
+++ b/scripts/create-github-release.js
@@ -9,7 +9,7 @@
  * `v<VERSION>` where <VERSION> is the `version` field in package.json.
  */
 
-const Octokit = require('@octokit/rest');
+const { Octokit } = require('@octokit/rest');
 
 const pkg = require('../package.json');
 const { changelistSinceTag } = require('./generate-change-list');

--- a/scripts/generate-change-list.js
+++ b/scripts/generate-change-list.js
@@ -58,7 +58,7 @@ async function* itemsInGitHubAPIResponse(octokit, options) {
 async function getPRsMergedSince(octokit, org, repo, tag) {
   const tagDate = getTagDate(tag);
 
-  const options = await octokit.pullRequests.list.endpoint.merge({
+  const options = await octokit.pulls.list.endpoint.merge({
     owner: org,
     repo,
     state: 'closed',
@@ -136,7 +136,7 @@ async function changelistSinceTag(octokit, tag = getHighestVersionTag()) {
 }
 
 if (require.main === module) {
-  const Octokit = require('@octokit/rest');
+  const { Octokit } = require('@octokit/rest');
   const octokit = new Octokit({ auth: `token ${process.env.GITHUB_TOKEN}` });
   const tag = process.argv[2] || getHighestVersionTag();
 


### PR DESCRIPTION
https://github.com/hypothesis/client/pull/1824 bumped @ocktokit/rest to
v17.0.0 but this contained breaking changes which were not accounted
for.