### PR TITLE
Fix top bar failing to display in /stream route

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -252,9 +252,10 @@ function startAngularApp(config) {
   // constructed them.
   //
   // @ngInject
-  function registerAngularServices($rootScope, toastr) {
+  function registerAngularServices($location, $rootScope, toastr) {
     container
       .register('toastr', { value: toastr })
+      .register('$location', { value: $location })
       .register('$rootScope', { value: $rootScope });
   }
 


### PR DESCRIPTION
This broke in dff1f428a634c380ee35728fa4dedede441c5288 because the
`$location` Angular service became unavailable to the
`StreamSearchInput` component as it was not registered in the new
dependency injection container.

Test: Go to http://localhost:5000/stream and you should see the top bar and be able to login and search.