### PR TITLE
Add reply and collapsed classnames to `AnnotationOmega`

### DIFF
--- a/src/sidebar/components/annotation-omega.js
+++ b/src/sidebar/components/annotation-omega.js
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import { createElement } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
@@ -115,7 +116,13 @@ function AnnotationOmega({
 
   return (
     /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
-    <div className="annotation-omega" onKeyDown={onKeyDown}>
+    <div
+      className={classnames('annotation-omega', {
+        'annotation--reply': isReply(annotation),
+        'is-collapsed': threadIsCollapsed,
+      })}
+      onKeyDown={onKeyDown}
+    >
       <AnnotationHeader
         annotation={annotation}
         isEditing={isEditing}

--- a/src/sidebar/components/test/annotation-omega-test.js
+++ b/src/sidebar/components/test/annotation-omega-test.js
@@ -95,6 +95,25 @@ describe('AnnotationOmega', () => {
 
   it('should test `isSaving`');
 
+  describe('annotation classnames', () => {
+    it('should assign a reply class if the annotation is a reply', () => {
+      fakeMetadata.isReply.returns(true);
+
+      const wrapper = createComponent({ threadIsCollapsed: false });
+      const annot = wrapper.find('.annotation-omega');
+
+      assert.isTrue(annot.hasClass('annotation--reply'));
+      assert.isFalse(annot.hasClass('is-collapsed'));
+    });
+
+    it('should assign a collapsed class if the annotation thread is collapsed', () => {
+      const wrapper = createComponent({ threadIsCollapsed: true });
+      const annot = wrapper.find('.annotation-omega');
+
+      assert.isTrue(annot.hasClass('is-collapsed'));
+    });
+  });
+
   describe('annotation quote', () => {
     it('renders quote if annotation has a quote', () => {
       fakeMetadata.quote.returns('quote');


### PR DESCRIPTION
Make collapsed reply threads appear identical to legacy `Annotation` controller.

Mirror the current implementation in `Annotation` and `AnnotationThread`
for applying stateful CSS classes to `AnnotationOmega` elements. This
approach should be reviewed after migration is complete.

Fixes #1837

This is a somewhat Band-Aid(TM) fix for making sure that collapsed replies in threads look like the legacy `Annotation` controller. There is still an outstanding issue in which the group name shows still for collapsed threads. I considered fixing that in the same batch of changes but decided to wait and do it more cleanly after the migration.

## Before

Before this change, a collapsed reply thread still had its body content showing ("Reply 1-A" in this example):

![image](https://user-images.githubusercontent.com/439947/75687660-1e222900-5c6c-11ea-8a23-166f4b5b1b80.png)

## After

After this change, a collapsed reply thread's body content is no longer shown:

![image](https://user-images.githubusercontent.com/439947/75687713-2f6b3580-5c6c-11ea-9af4-098881094852.png)
