### PR TITLE
Refactor fetch-config.js and allow requestConfigFromFrame to be an object

### DIFF
--- a/src/sidebar/util/fetch-config.js
+++ b/src/sidebar/util/fetch-config.js
@@ -1,8 +1,10 @@
 import getApiUrl from '../get-api-url';
 import hostConfig from '../host-config';
-
 import * as postMessageJsonRpc from './postmessage-json-rpc';
 
+/**
+ * @deprecated
+ */
 function ancestors(window_) {
   if (window_ === window_.top) {
     return [];
@@ -19,6 +21,27 @@ function ancestors(window_) {
 }
 
 /**
+ * Returns the global embedder ancestor frame.
+ *
+ * @param {number} levels - Number of ancestors levels to ascend.
+ * @param {Window=} window
+ * @return {Window}
+ */
+function getAncestorFrame(levels, window_ = window) {
+  let ancestorWindow = window_;
+  for (let i = 0; i < levels; i++) {
+    if (ancestorWindow === ancestorWindow.top) {
+      throw new Error(
+        'The target parent frame has exceeded the ancestor tree. Try reducing the `requestConfigFromFrame.ancestorLevel` value in the `hypothesisConfig`'
+      );
+    }
+    ancestorWindow = ancestorWindow.parent;
+  }
+  return ancestorWindow;
+}
+
+/**
+ * @deprecated
  * Fetch client configuration from an ancestor frame.
  *
  * @param {string} origin - The origin of the frame to fetch config from.
@@ -47,6 +70,7 @@ function fetchConfigFromAncestorFrame(origin, window_ = window) {
 }
 
 /**
+ * @deprecated
  * Merge client configuration from h service with config fetched from
  * embedding frame.
  *
@@ -58,20 +82,101 @@ function fetchConfigFromAncestorFrame(origin, window_ = window) {
  * @param {Window} window_ - Test seam.
  * @return {Promise<Object>} - The merged settings.
  */
-export function fetchConfig(appConfig, window_ = window) {
+function fetchConfigLegacy(appConfig, window_ = window) {
   const hostPageConfig = hostConfig(window_);
 
   let embedderConfig;
-  if (hostPageConfig.requestConfigFromFrame) {
-    const origin = hostPageConfig.requestConfigFromFrame;
-    embedderConfig = fetchConfigFromAncestorFrame(origin, window_);
-  } else {
-    embedderConfig = Promise.resolve(hostPageConfig);
-  }
+  const origin = hostPageConfig.requestConfigFromFrame;
+  embedderConfig = fetchConfigFromAncestorFrame(origin, window_);
 
   return embedderConfig.then(embedderConfig => {
     const mergedConfig = Object.assign({}, appConfig, embedderConfig);
     mergedConfig.apiUrl = getApiUrl(mergedConfig);
     return mergedConfig;
   });
+}
+
+/**
+ * Merge client configuration from h service with config from the hash fragment.
+ *
+ * @param {Object} appConfig - App config settings rendered into `app.html` by the h service.
+ * @param {Object} hostPageConfig - App configuration specified by the embedding  frame.
+ * @return {Object} - The merged settings.
+ */
+function fetchConfigEmbed(appConfig, hostPageConfig) {
+  const mergedConfig = {
+    ...appConfig,
+    ...hostPageConfig,
+  };
+  mergedConfig.apiUrl = getApiUrl(mergedConfig);
+  return mergedConfig;
+}
+
+/**
+ * Merge client configuration from h service with config fetched from
+ * a parent frame asynchronously.
+ *
+ * Use this method to retrieve the config asynchronously from a parent
+ * frame via RPC. See tests for more details.
+ *
+ * @param {Object} appConfig - Settings rendered into `app.html` by the h service.
+ * @param {Window} parentFrame - Frame to send call to.
+ * @param {string} origin - Origin filter for `window.postMessage` call.
+ * @return {Promise<Object>} - The merged settings.
+ */
+async function fetchConfigRpc(appConfig, parentFrame, origin) {
+  const remoteConfig = await postMessageJsonRpc.call(
+    parentFrame,
+    origin,
+    'requestConfig',
+    [],
+    3000
+  );
+  return fetchConfigEmbed(appConfig, remoteConfig);
+}
+
+/**
+ * Fetch the host configuration and merge it with the app configuration from h.
+ *
+ * There are 3 ways to get the host config:
+ *  Direct embed - From the hash string of the embedder frame.
+ *  Legacy RPC with unknown parent - From a ancestor parent frame that passes it down via RPC. (deprecated)
+ *  RPC with known parent - From a ancestor parent frame that passes it down via RPC.
+ *
+ * @param {Object} appConfig - Settings rendered into `app.html` by the h service.
+ * @param {Window} window_ - Test seam.
+ * @return {Object} - The merged settings.
+ */
+export async function fetchConfig(appConfig, window_ = window) {
+  const hostPageConfig = hostConfig(window);
+  const requestConfigFromFrame = hostPageConfig.requestConfigFromFrame;
+
+  if (!requestConfigFromFrame) {
+    // Directly embed: just get the config.
+    return fetchConfigEmbed(appConfig, hostPageConfig);
+  }
+  if (typeof requestConfigFromFrame === 'string') {
+    // Legacy: send RPC to all parents to find config. (deprecated)
+    // nb. Browsers may display errors in the console when messages are sent to frames
+    // that don't match the origin filter".
+    return await fetchConfigLegacy(appConfig, window_);
+  } else if (
+    typeof requestConfigFromFrame.ancestorLevel === 'number' &&
+    typeof requestConfigFromFrame.origin === 'string'
+  ) {
+    // Know parent frame: send RPC directly to the parent.
+    const parentFrame = getAncestorFrame(
+      requestConfigFromFrame.ancestorLevel,
+      window_
+    );
+    return await fetchConfigRpc(
+      appConfig,
+      parentFrame,
+      requestConfigFromFrame.origin
+    );
+  } else {
+    throw new Error(
+      'Improper `requestConfigFromFrame` object. Both `ancestorLevel` and `origin` need to be specified'
+    );
+  }
 }

--- a/src/sidebar/util/test/fetch-config-test.js
+++ b/src/sidebar/util/test/fetch-config-test.js
@@ -5,15 +5,19 @@ describe('sidebar.util.fetch-config', () => {
   let fakeHostConfig;
   let fakeJsonRpc;
   let fakeWindow;
+  let fakeApiUrl;
+  let fakeTopWindow;
 
   beforeEach(() => {
     fakeHostConfig = sinon.stub();
     fakeJsonRpc = {
       call: sinon.stub(),
     };
+    fakeApiUrl = sinon.stub().returns('https://dev.hypothes.is/api/');
     $imports.$mock({
       '../host-config': fakeHostConfig,
       './postmessage-json-rpc': fakeJsonRpc,
+      '../get-api-url': fakeApiUrl,
     });
 
     // By default, embedder provides no custom config.
@@ -23,13 +27,13 @@ describe('sidebar.util.fetch-config', () => {
     fakeJsonRpc.call.throws(new Error('call() response not set'));
 
     // Setup fake window hierarchy.
-    const fakeTopWindow = { parent: null, top: null };
+    fakeTopWindow = { parent: null, top: null, testId: 2 };
     fakeTopWindow.parent = fakeTopWindow; // Yep, the DOM really works like this.
     fakeTopWindow.top = fakeTopWindow;
 
-    const fakeParent = { parent: fakeTopWindow, top: fakeTopWindow };
+    const fakeParent = { parent: fakeTopWindow, top: fakeTopWindow, testId: 1 };
 
-    fakeWindow = { parent: fakeParent, top: fakeTopWindow };
+    fakeWindow = { parent: fakeParent, top: fakeTopWindow, testId: 0 };
   });
 
   afterEach(() => {
@@ -37,47 +41,44 @@ describe('sidebar.util.fetch-config', () => {
   });
 
   describe('fetchConfig', () => {
-    // By default, combine the settings rendered into the sidebar's HTML page
-    // by h with the settings from `window.hypothesisConfig` in the parent
-    // window.
-    it('reads config from sidebar URL query string', () => {
-      fakeHostConfig
-        .withArgs(fakeWindow)
-        .returns({ apiUrl: 'https://dev.hypothes.is/api/' });
-
-      return fetchConfig({}, fakeWindow).then(config => {
-        assert.deepEqual(config, { apiUrl: 'https://dev.hypothes.is/api/' });
-      });
-    });
-
-    it('merges config from sidebar HTML app and embedder', () => {
-      const apiUrl = 'https://dev.hypothes.is/api/';
-      fakeHostConfig.returns({
-        appType: 'via',
+    context('direct embed', () => {
+      // no `requestConfigFromFrame` variable
+      //
+      // Combine the settings rendered into the sidebar's HTML page
+      // by h with the settings from `window.hypothesisConfig` in the parent
+      // window.
+      it('adds the apiUrl to the merged result', async () => {
+        const mergedConfig = await fetchConfig({});
+        assert.deepEqual(mergedConfig, { apiUrl: fakeApiUrl() });
       });
 
-      return fetchConfig({ apiUrl }, fakeWindow).then(config => {
-        assert.deepEqual(config, { apiUrl, appType: 'via' });
-      });
-    });
-
-    // By default, don't try to fetch settings from parent frames via
-    // `postMessage` requests.
-    it('does not fetch settings from ancestor frames by default', () => {
-      return fetchConfig({}, fakeWindow).then(() => {
+      it('does not fetch settings from ancestor frames', async () => {
+        await fetchConfig({});
         assert.notCalled(fakeJsonRpc.call);
       });
+
+      it('merges the hostPageConfig onto appConfig and returns the result', async () => {
+        // hostPageConfig shall take precedent over appConfig
+        const appConfig = { foo: 'bar', appType: 'via' };
+        fakeHostConfig.returns({ foo: 'baz' });
+        const mergedConfig = await fetchConfig(appConfig);
+        assert.deepEqual(mergedConfig, {
+          foo: 'baz',
+          appType: 'via',
+          apiUrl: fakeApiUrl(),
+        });
+      });
     });
 
-    // In scenarios like LMS integrations, the client is annotating a document
-    // inside an iframe and the client needs to retrieve configuration securely
-    // from the top-level window without that configuration being exposed to the
-    // document itself.
-    //
-    // This config fetching is enabled by a setting in the host page.
-    context('when fetching config from an ancestor frame is enabled', () => {
+    context('from an RPC parent of unknown ancestry', () => {
+      // @deprecated
+      // `requestConfigFromFrame` is a string containing an origin
+      //
+      // In scenarios like LMS integrations, the client is annotating a document
+      // inside an iframe and the client needs to retrieve configuration
+      // securely from the top-level window without  that configuration being
+      // exposed to the document itself.
       const expectedTimeout = 3000;
-
       beforeEach(() => {
         fakeHostConfig.returns({
           requestConfigFromFrame: 'https://embedder.com',
@@ -89,23 +90,21 @@ describe('sidebar.util.fetch-config', () => {
         console.warn.restore();
       });
 
-      it('fetches config from ancestor frames', () => {
+      it('fetches config from ancestor frames', async () => {
         fakeJsonRpc.call.returns(Promise.resolve({}));
-
-        return fetchConfig({}, fakeWindow).then(() => {
-          // The client will send a message to each ancestor asking for
-          // configuration. Only those with the expected origin will be able to
-          // respond.
-          const ancestors = [fakeWindow.parent, fakeWindow.parent.parent];
-          ancestors.forEach(frame => {
-            assert.calledWith(
-              fakeJsonRpc.call,
-              frame,
-              'https://embedder.com',
-              'requestConfig',
-              expectedTimeout
-            );
-          });
+        await fetchConfig({}, fakeWindow);
+        // The client will send a message to each ancestor asking for
+        // configuration. Only those with the expected origin will be able to
+        // respond.
+        const ancestors = [fakeWindow.parent, fakeWindow.parent.parent];
+        ancestors.forEach(frame => {
+          assert.calledWith(
+            fakeJsonRpc.call,
+            frame,
+            'https://embedder.com',
+            'requestConfig',
+            expectedTimeout
+          );
         });
       });
 
@@ -123,7 +122,7 @@ describe('sidebar.util.fetch-config', () => {
         return assertPromiseIsRejected(config, 'Nope');
       });
 
-      it('returns config from ancestor frame', () => {
+      it('returns config from ancestor frame', async () => {
         // When the embedder responds with configuration, that should be
         // returned by `fetchConfig`.
         fakeJsonRpc.call.returns(new Promise(() => {}));
@@ -147,17 +146,138 @@ describe('sidebar.util.fetch-config', () => {
             })
           );
 
-        return fetchConfig({}, fakeWindow).then(config => {
-          assert.deepEqual(config, {
-            apiUrl: 'https://servi.ce/api/',
-            services: [
-              {
-                apiUrl: 'https://servi.ce/api/',
-                grantToken: 'secret-token',
-              },
-            ],
-          });
+        const config = await fetchConfig({}, fakeWindow);
+        assert.deepEqual(config, {
+          apiUrl: fakeApiUrl(),
+          services: [
+            {
+              apiUrl: 'https://servi.ce/api/',
+              grantToken: 'secret-token',
+            },
+          ],
         });
+      });
+    });
+
+    context('from an RPC parent of known ancestry', () => {
+      // `requestConfigFromFrame` is an object containing an `origin` and `ancestorLevel`
+      //
+      // In scenarios like LMS integrations, the client is annotating a document
+      // inside an iframe and the client needs to retrieve configuration
+      // securely from the top-level window without  that configuration being
+      // exposed to the document itself.
+      beforeEach(() => {
+        fakeJsonRpc.call.resolves({});
+        fakeHostConfig.returns({
+          requestConfigFromFrame: {
+            origin: 'https://embedder.com',
+            ancestorLevel: 2,
+          },
+        });
+      });
+
+      it('makes an RCP request to `requestConfig` ', async () => {
+        await fetchConfig({}, fakeWindow);
+        fakeJsonRpc.call.calledWithExactly(
+          fakeTopWindow,
+          'https://embedder.com',
+          'requestConfig',
+          [],
+          3000
+        );
+      });
+
+      [0, 1, 2].forEach(level => {
+        it(`finds ${level}'th ancestor window according to how high the level is`, async () => {
+          fakeHostConfig.returns({
+            requestConfigFromFrame: {
+              origin: 'https://embedder.com',
+              ancestorLevel: level,
+            },
+          });
+          await fetchConfig({}, fakeWindow);
+          // testId is a fake property used to assert the level of the fake window
+          assert.equal(fakeJsonRpc.call.getCall(0).args[0].testId, level);
+        });
+      });
+
+      it('throws an error when target ancestor exceeds top window', async () => {
+        fakeHostConfig.returns({
+          requestConfigFromFrame: {
+            origin: 'https://embedder.com',
+            ancestorLevel: 10, // The top window is only 2 levels high
+          },
+        });
+        try {
+          await fetchConfig({}, fakeWindow);
+          throw new Error('Failed to catch error');
+        } catch (e) {
+          assert.equal(
+            e.message,
+            'The target parent frame has exceeded the ancestor tree. Try reducing the `requestConfigFromFrame.ancestorLevel` value in the `hypothesisConfig`'
+          );
+        }
+      });
+
+      it('creates a merged config when the rpc requests returns the host config` ', async () => {
+        const appConfig = { foo: 'bar', appType: 'via' };
+        fakeJsonRpc.call.resolves({ foo: 'baz' }); // host config
+        const result = await fetchConfig(appConfig, fakeWindow);
+        assert.deepEqual(result, {
+          foo: 'baz',
+          appType: 'via',
+          apiUrl: fakeApiUrl(),
+        });
+      });
+
+      it('rejects if fetching config fails` ', async () => {
+        fakeJsonRpc.call.rejects(new Error('Nope'));
+        const appConfig = { foo: 'bar', appType: 'via' };
+
+        const result = fetchConfig(appConfig, fakeWindow);
+        return assertPromiseIsRejected(result, 'Nope');
+      });
+    });
+
+    context('incorrect requestConfigFromFrame object', () => {
+      beforeEach(() => {
+        fakeJsonRpc.call.resolves({});
+      });
+
+      it('missing ancestorLevel', async () => {
+        fakeHostConfig.returns({
+          requestConfigFromFrame: {
+            origin: 'https://embedder.com',
+            // missing ancestorLevel
+          },
+        });
+        try {
+          await fetchConfig({}, fakeWindow);
+          throw new Error('Failed to catch error');
+        } catch (e) {
+          assert.equal(
+            e.message,
+            'Improper `requestConfigFromFrame` object. Both `ancestorLevel` and `origin` need to be specified'
+          );
+        }
+      });
+
+      it('missing origin', async () => {
+        fakeHostConfig.returns({
+          requestConfigFromFrame: {
+            // missing origin
+            ancestorLevel: 2,
+          },
+        });
+        try {
+          await fetchConfig({}, fakeWindow);
+          throw new Error('Failed to catch error');
+        } catch (e) {
+          assert.equal(
+            e.message,
+            'Improper `requestConfigFromFrame` object. Both `ancestorLevel` and `origin` need to be specified'
+          );
+        }
       });
     });
   });


### PR DESCRIPTION
- Rename fetchConfig to fetchConfigLegacy
- Allow the requestConfigFromFrame variable from hypothesisConfig to be either a string containing the origin url (legacy),
or an object containing the origin url + the ancestor level value of the parent frame. This is used to directly find the
frame which to send RPC requests too so we don't have to guess and create erroneous console errors.
- Rename fetchConfig to fetchConfigLegacy (now deprecated)
- Add fetchConfigRpc to replace fetchConfigLegacy
- Add fetchConfigEmbed for the simple hash fragment case
- Refactor fetchConfig to decide how it will fetch the host config (one of 3-ways)
 1. simple case from url hash fragment
 2. legacy RPC call from (depreciated)
 3. RPC call directly to parent frame.
-------------

Effectively this diff should have no visible change to the client. In order to see it working with the new config var, changes to via and lms need to be made. I have locally shimmed in those changes and verified that it does work and the console error is gone. Expect more PR's to follow this one, then the plan is to circle back to the client and remove some of the @depricated code in this diff.

