### PR TITLE
AnnotationOmega: Add “Saving…” message

### DIFF
--- a/src/sidebar/components/annotation-omega.js
+++ b/src/sidebar/components/annotation-omega.js
@@ -68,7 +68,7 @@ function AnnotationOmega({
     }
   }, [annotation, draft, createDraft, isSaving]);
 
-  const shouldShowActions = !isEditing && !isNew(annotation);
+  const shouldShowActions = !isSaving && !isEditing && !isNew(annotation);
   const shouldShowLicense = isEditing && !isPrivate && group.type !== 'private';
   const shouldShowReplyToggle = replyCount > 0 && !isReply(annotation);
 
@@ -158,6 +158,9 @@ function AnnotationOmega({
               onClick={onToggleReplies}
               buttonText={toggleText}
             />
+          )}
+          {isSaving && (
+            <div className="annotation-omega__actions">Saving...</div>
           )}
           {shouldShowActions && (
             <div className="annotation-omega__actions">

--- a/src/sidebar/components/test/annotation-omega-test.js
+++ b/src/sidebar/components/test/annotation-omega-test.js
@@ -93,8 +93,6 @@ describe('AnnotationOmega', () => {
     $imports.$restore();
   });
 
-  it('should test `isSaving`');
-
   describe('annotation classnames', () => {
     it('should assign a reply class if the annotation is a reply', () => {
       fakeMetadata.isReply.returns(true);
@@ -235,6 +233,25 @@ describe('AnnotationOmega', () => {
         assert.calledWith(
           fakeAnnotationsService.save,
           wrapper.props().annotation
+        );
+      });
+
+      it('should show a "Saving" message when annotation is saving', () => {
+        setEditingMode(true);
+
+        const wrapper = createComponent();
+        act(() => {
+          wrapper
+            .find('AnnotationPublishControl')
+            .props()
+            .onSave();
+        });
+
+        wrapper.update();
+
+        assert.include(
+          wrapper.find('.annotation-omega__actions').text(),
+          'Saving...'
         );
       });
 


### PR DESCRIPTION
This PR re-implements the “Saving…” message from legacy `Annotation` template when actively saving an annotation.

This is a direct  reimplementation of exactly how this works in the legacy `Annotation` template. Note that this is not the way we should really do this: subsequent work should move the tracking of "saving" state for annotations into the store and make it independent of UI components.

Fixes #1836