### PR TITLE
Remove debug code from production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "retry": "^0.12.0",
     "sass": "^1.23.0",
     "scroll-into-view": "^1.8.2",
-    "seamless-immutable": "^7.1.4",
     "shallowequal": "^1.1.0",
     "showdown": "^1.6.4",
     "sinon": "^9.0.0",

--- a/src/sidebar/components/test/thread-list-test.js
+++ b/src/sidebar/components/test/thread-list-test.js
@@ -1,10 +1,10 @@
 import angular from 'angular';
-import immutable from 'seamless-immutable';
 import EventEmitter from 'tiny-emitter';
 
 import * as util from './angular-util';
 import events from '../../events';
 import threadList, { $imports } from '../thread-list';
+import immutable from '../../util/immutable';
 
 const annotFixtures = immutable({
   annotation: { $tag: 't1', id: '1', text: 'text' },

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -1,3 +1,5 @@
+/* global process */
+
 import { jsonConfigsFrom } from '../shared/settings';
 
 import crossOriginRPC from './cross-origin-rpc.js';
@@ -37,7 +39,9 @@ import angularToastr from 'angular-toastr';
 import 'focus-visible';
 
 // Enable debugging checks for Preact.
-import 'preact/debug';
+if (process.env.NODE_ENV !== 'production') {
+  require('preact/debug');
+}
 
 import wrapReactComponent from './util/wrap-react-component';
 

--- a/src/sidebar/services/test/annotation-mapper-test.js
+++ b/src/sidebar/services/test/annotation-mapper-test.js
@@ -1,9 +1,9 @@
 import angular from 'angular';
-import immutable from 'seamless-immutable';
 
 import events from '../../events';
 import storeFactory from '../../store';
 import annotationMapperFactory from '../annotation-mapper';
+import immutable from '../../util/immutable';
 
 describe('annotationMapper', function() {
   const sandbox = sinon.createSandbox();

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -1,11 +1,11 @@
 import angular from 'angular';
-import immutable from 'seamless-immutable';
 
 import events from '../../events';
 import * as annotationFixtures from '../../test/annotation-fixtures';
 import uiConstants from '../../ui-constants';
 import rootThreadFactory from '../root-thread';
 import { $imports } from '../root-thread';
+import immutable from '../../util/immutable';
 
 const fixtures = immutable({
   emptyThread: {

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -15,11 +15,11 @@
  */
 
 import { createSelector } from 'reselect';
-import immutable from 'seamless-immutable';
 
 import uiConstants from '../../ui-constants';
 import * as metadata from '../../util/annotation-metadata';
 import { countIf, toSet } from '../../util/array';
+import immutable from '../../util/immutable';
 import * as util from '../util';
 
 /**

--- a/src/sidebar/store/modules/test/drafts-test.js
+++ b/src/sidebar/store/modules/test/drafts-test.js
@@ -1,10 +1,9 @@
-import immutable from 'seamless-immutable';
-
 import createStore from '../../create-store';
 import annotations from '../annotations';
 import drafts from '../drafts';
 import { Draft } from '../drafts';
 import selection from '../selection';
+import immutable from '../../../util/immutable';
 
 const fixtures = immutable({
   draftWithText: {

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -1,8 +1,7 @@
-import immutable from 'seamless-immutable';
-
 import createStore from '../../create-store';
 import groups from '../groups';
 import session from '../session';
+import immutable from '../../../util/immutable';
 
 describe('sidebar/store/modules/groups', () => {
   const publicGroup = immutable({

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -1,8 +1,7 @@
-import immutable from 'seamless-immutable';
-
 import * as annotationFixtures from '../../test/annotation-fixtures';
 import uiConstants from '../../ui-constants';
 import storeFactory from '../index';
+import immutable from '../../util/immutable';
 
 const defaultAnnotation = annotationFixtures.defaultAnnotation;
 const newAnnotation = annotationFixtures.newAnnotation;

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -1,10 +1,10 @@
 import angular from 'angular';
-import immutable from 'seamless-immutable';
 
 import rootThreadFactory from '../../services/root-thread';
 import searchFilterFactory from '../../services/search-filter';
 import viewFilterFactory from '../../services/view-filter';
 import storeFactory from '../../store';
+import immutable from '../../util/immutable';
 
 const fixtures = immutable({
   annotations: [

--- a/src/sidebar/util/group-organizations.js
+++ b/src/sidebar/util/group-organizations.js
@@ -1,4 +1,4 @@
-import immutable from 'seamless-immutable';
+import immutable from './immutable';
 
 // TODO: Update when this is a property available on the API response
 const DEFAULT_ORG_ID = '__default__';

--- a/src/sidebar/util/immutable.js
+++ b/src/sidebar/util/immutable.js
@@ -1,0 +1,33 @@
+/* global process */
+
+/**
+ * Freeze an object recursively.
+ *
+ * This only works for plain objects, arrays and objects where data is stored
+ * in enumerable fields.
+ */
+function deepFreeze(object) {
+  Object.freeze(object);
+
+  Object.values(object).forEach(val => {
+    if (typeof val === 'object' && val !== null) {
+      deepFreeze(val);
+    }
+  });
+
+  return object;
+}
+
+/**
+ * Prevent accidental mutations to `object` or any of its fields in debug builds.
+ *
+ * @param {Object} object
+ * @return {Object} Returns the input object
+ */
+export default function immutable(object) {
+  if (process.env.NODE_ENV === 'production') {
+    return object;
+  } else {
+    return deepFreeze(object);
+  }
+}

--- a/src/sidebar/util/test/immutable-test.js
+++ b/src/sidebar/util/test/immutable-test.js
@@ -1,0 +1,20 @@
+import immutable from '../immutable';
+
+describe('immutable', () => {
+  it('deeply freezes objects', () => {
+    const obj = {
+      plainValue: 'plain',
+      objectValue: {
+        leafValue: 'leaf',
+      },
+      arrayValue: [1],
+    };
+
+    const result = immutable(obj);
+
+    assert.equal(result, obj);
+    assert.isTrue(Object.isFrozen(obj));
+    assert.isTrue(Object.isFrozen(obj.objectValue));
+    assert.isTrue(Object.isFrozen(obj.arrayValue));
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7015,11 +7015,6 @@ scroll-into-view@^1.8.2:
   resolved "https://registry.yarnpkg.com/scroll-into-view/-/scroll-into-view-1.14.1.tgz#ca8e152228088d50fca7a266d3757141ba917fa2"
   integrity sha512-50Ynbg3igEFY2bCa5Iv4H+t9dqCmG+Y10LnaaSIjPR13+KFtvFRr+Wmq0foGoyJmn8K+8My+ZFbEIZ2JUorxcA==
 
-seamless-immutable@^7.1.4:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/seamless-immutable/-/seamless-immutable-7.1.4.tgz#6e9536def083ddc4dea0207d722e0e80d0f372f8"
-  integrity sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A==
-
 semver-greatest-satisfied-range@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz#13e8c2658ab9691cb0cd71093240280d36f77a5b"


### PR DESCRIPTION
Looking at the contents of `build/scripts/sidebar.bundle.js` using [source-map-explorer](https://www.npmjs.com/package/source-map-explorer) [1] I noticed that we were including some unnecessary debug code in our production builds, which has a download + runtime cost. This PR removes that code:

1. Only load `preact/debug` in non-production builds.
2. Replace the `seamless-immutable` package which is used to guard against accidental mutation of state in the store with a tiny helper which uses `Object.freeze` recursively. `seamless-immutable` provides other APIs, but we don't use them

----

[1] Output from `source-map-explorer build/scripts/sidebar.bundle.js build/scripts/sidebar.bundle.js.map` before and then after (open full image in new tab and look at `node_modules/` section):

Before:

<img width="500" alt="sidebar-bundle-content-before" src="https://user-images.githubusercontent.com/2458/75884232-57999680-5e1c-11ea-85cf-9b1644ed5679.png">

After:

<img width="500" alt="sidebar-bundle-content-after" src="https://user-images.githubusercontent.com/2458/75884238-5bc5b400-5e1c-11ea-804e-248a5ab0a988.png">
