### PR TITLE
Replace two dependencies that are only used once

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "lodash.debounce": "^4.0.3",
     "loose-envify": "^1.4.0",
     "mocha": "^7.0.0",
-    "node-uuid": "^1.4.3",
     "npm-packlist": "^2.0.1",
     "postcss": "^7.0.13",
     "postcss-url": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "karma-sinon": "^1.0.5",
     "katex": "^0.11.0",
     "lodash.debounce": "^4.0.3",
-    "lodash.get": "^4.3.0",
     "loose-envify": "^1.4.0",
     "mocha": "^7.0.0",
     "node-uuid": "^1.4.3",

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -1,4 +1,3 @@
-import get from 'lodash.get';
 import * as queryString from 'query-string';
 
 import { replaceURLParams } from '../util/url';
@@ -76,6 +75,14 @@ function stripInternalProperties(obj) {
 
 // istanbul ignore next
 const noop = () => null;
+
+function get(object, path) {
+  let cursor = object;
+  path.split('.').forEach(segment => {
+    cursor = cursor[segment];
+  });
+  return cursor;
+}
 
 /**
  * Creates a function that will make an API call to a named route.

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -1,7 +1,7 @@
-import uuid from 'node-uuid';
 import * as queryString from 'query-string';
 
 import warnOnce from '../../shared/warn-once';
+import { generateHexString } from '../util/random';
 import Socket from '../websocket';
 
 /**
@@ -27,8 +27,8 @@ export default function Streamer(
   session,
   settings
 ) {
-  // The randomly generated session UUID
-  const clientId = uuid.v4();
+  // The randomly generated session ID
+  const clientId = generateHexString(32);
 
   // The socket instance for this Streamer instance
   let socket;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5680,11 +5680,6 @@ node-releases@^1.1.47:
   dependencies:
     semver "^6.3.0"
 
-node-uuid@^1.4.3:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
-  integrity sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=
-
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5186,7 +5186,7 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash.get@^4.3.0, lodash.get@^4.4.2:
+lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=


### PR DESCRIPTION
Following on from https://github.com/hypothesis/client/pull/1872, this PR reduces the size of the sidebar bundle a bit more by removing a couple of dependencies that we can easily do without.

- Use of `lodash.get` to take a dotted API method path (`annotations.search`) and extract the relevant value from a nested object (`{ annotations: { ..., search: { ... }, ... }`)
- Use of `node-uuid` to generate a random identifier when setting up the WebSocket connection (note I've verified that h doesn't care whether the identifier is a UUID or not)