### PR TITLE
Update browser extension after a new prod client release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -178,6 +178,14 @@ stage('Publish') {
     }
 }
 
+milestone()
+stage('Update browser extension') {
+    build(job: 'browser-extension/master',
+          parameters: [
+               string(name: 'BUILD_TYPE', value: 'update-hypothesis-client')
+          ])
+}
+
 // Increment the minor part of a `MAJOR.MINOR.PATCH` semver version.
 String bumpMinorVersion(String version) {
     def parts = version.tokenize('.')


### PR DESCRIPTION
Trigger a build of the "master" branch of the "browser-extension" project after
a new client production release with the `BUILD_TYPE` parameter set to
`update-hypothesis-client` to trigger an update to the Hypothesis client.

In implementing this, I ran into a couple of issues that caught me out
initially:

 - The `build` command must take a job name rather than a project (which
   is essentially a folder of jobs), ie. `browser-extension/master`
   rather than `browser-extension`. See [1].

 - To pass a value for a choice parameter, the easiest option is just to
   pass a string [2]

[1] https://stackoverflow.com/questions/46471467/
[2] https://stackoverflow.com/a/41760715/434243