### PR TITLE
Bump `eslint-config-hypothesis` and remove redundant `.eslintrc` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,5 @@
 {
   "extends": ["hypothesis", "plugin:jsx-a11y/recommended"],
-  "env": {
-    "es6": true
-  },
-  "globals": {
-    "Set": false
-  },
   "rules": {
     // Suppressed to make ESLint v6 migration easier.
     "no-prototype-builtins": "off",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3162,9 +3162,9 @@ escodegen@~1.1.0:
     source-map "~0.1.30"
 
 eslint-config-hypothesis@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-hypothesis/-/eslint-config-hypothesis-2.0.0.tgz#18c185401d2f9c49cc455861b6a8add7675a1a63"
-  integrity sha512-B1lR2AAmdMixKePtoXDnbOqsdsI+AtNprdsRkN3K82hZvi4vvdAhZMwMCUJlg5EZK64kQV71/TbdqhPd+0ieJw==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-hypothesis/-/eslint-config-hypothesis-2.1.0.tgz#7ad66217dc1eb6c8daaaf390709e1520373f1344"
+  integrity sha512-5qkCCL1jxEDXN5n+C26zNS37w0Oxrv0Lna87riHE558XGMhQZmvKC+JX5j0n8WORKXW4fobS3NPktroBfXl/Zg==
 
 eslint-plugin-jsx-a11y@^6.2.3:
   version "6.2.3"


### PR DESCRIPTION
This PR manually bumps the version of `eslint-config-hypothesis` and removes the now-redundant `env` rule and `Set` allowance in the project's `.eslintrc`.