### PR TITLE
Remove `unloadAnnotations` method from `annotation-mapper`

### DIFF
--- a/src/sidebar/events.js
+++ b/src/sidebar/events.js
@@ -43,7 +43,4 @@ export default {
 
   /** A set of annotations were loaded from the server. */
   ANNOTATIONS_LOADED: 'annotationsLoaded',
-
-  /** An annotation is unloaded. */
-  ANNOTATIONS_UNLOADED: 'annotationsUnloaded',
 };

--- a/src/sidebar/services/annotation-mapper.js
+++ b/src/sidebar/services/annotation-mapper.js
@@ -1,5 +1,3 @@
-import angular from 'angular';
-
 import events from '../events';
 
 function getExistingAnnotation(store, id) {
@@ -25,17 +23,6 @@ export default function annotationMapper($rootScope, store, api) {
     });
 
     $rootScope.$broadcast(events.ANNOTATIONS_LOADED, loaded);
-  }
-
-  function unloadAnnotations(annotations) {
-    const unloaded = annotations.map(function(annotation) {
-      const existing = getExistingAnnotation(store, annotation.id);
-      if (existing && annotation !== existing) {
-        annotation = angular.copy(annotation, existing);
-      }
-      return annotation;
-    });
-    $rootScope.$broadcast(events.ANNOTATIONS_UNLOADED, unloaded);
   }
 
   function createAnnotation(annotation) {
@@ -67,7 +54,6 @@ export default function annotationMapper($rootScope, store, api) {
 
   return {
     loadAnnotations: loadAnnotations,
-    unloadAnnotations: unloadAnnotations,
     createAnnotation: createAnnotation,
     deleteAnnotation: deleteAnnotation,
     flagAnnotation: flagAnnotation,

--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -20,7 +20,7 @@ export default function loadAnnotationsService(
    * @param {string} groupId
    */
   function load(uris, groupId) {
-    annotationMapper.unloadAnnotations(store.savedAnnotations());
+    store.removeAnnotations(store.savedAnnotations());
 
     // Cancel previously running search client.
     if (searchClient) {

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -123,10 +123,6 @@ export default function RootThread(
     store.removeAnnotations([annotation]);
   });
 
-  $rootScope.$on(events.ANNOTATIONS_UNLOADED, function(event, annotations) {
-    store.removeAnnotations(annotations);
-  });
-
   // Once the focused group state is moved to the app state store, then the
   // logic in this event handler can be moved to the annotations reducer.
   $rootScope.$on(events.GROUP_FOCUSED, function(event, focusedGroupId) {

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -222,7 +222,7 @@ export default function Streamer(
 
     const deletions = Object.keys(store.pendingDeletions()).map(id => ({ id }));
     if (deletions.length) {
-      annotationMapper.unloadAnnotations(deletions);
+      store.removeAnnotations(deletions);
     }
 
     store.clearPendingUpdates();

--- a/src/sidebar/services/test/annotation-mapper-test.js
+++ b/src/sidebar/services/test/annotation-mapper-test.js
@@ -114,33 +114,6 @@ describe('annotationMapper', function() {
     });
   });
 
-  describe('#unloadAnnotations()', function() {
-    it('triggers the annotationsUnloaded event', function() {
-      sandbox.stub($rootScope, '$broadcast');
-      const annotations = [{ id: 1 }, { id: 2 }, { id: 3 }];
-      annotationMapper.unloadAnnotations(annotations);
-      assert.calledWith(
-        $rootScope.$broadcast,
-        events.ANNOTATIONS_UNLOADED,
-        annotations
-      );
-    });
-
-    it('replaces the properties on the cached annotation with those from the deleted one', function() {
-      sandbox.stub($rootScope, '$broadcast');
-      const annotations = [{ id: 1, url: 'http://example.com' }];
-      store.addAnnotations([{ id: 1, $tag: 'tag1' }]);
-
-      annotationMapper.unloadAnnotations(annotations);
-      assert.calledWith($rootScope.$broadcast, events.ANNOTATIONS_UNLOADED, [
-        {
-          id: 1,
-          url: 'http://example.com',
-        },
-      ]);
-    });
-  });
-
   describe('#flagAnnotation()', function() {
     it('flags an annotation', function() {
       const ann = { id: 'test-id' };

--- a/src/sidebar/services/test/load-annotations-test.js
+++ b/src/sidebar/services/test/load-annotations-test.js
@@ -45,7 +45,6 @@ describe('loadAnnotationsService', () => {
 
     fakeAnnotationMapper = {
       loadAnnotations: sinon.stub(),
-      unloadAnnotations: sinon.stub(),
     };
 
     fakeApi = {
@@ -56,6 +55,7 @@ describe('loadAnnotationsService', () => {
       annotationFetchFinished: sinon.stub(),
       annotationFetchStarted: sinon.stub(),
       frames: sinon.stub(),
+      removeAnnotations: sinon.stub(),
       savedAnnotations: sinon.stub(),
       updateFrameAnnotationFetchStatus: sinon.stub(),
     };
@@ -109,7 +109,7 @@ describe('loadAnnotationsService', () => {
       const svc = createService();
 
       svc.load(fakeUris, fakeGroupId);
-      assert.calledWith(fakeAnnotationMapper.unloadAnnotations, [
+      assert.calledWith(fakeStore.removeAnnotations, [
         sinon.match({ id: fakeUris[0] + '123' }),
         sinon.match({ id: fakeUris[0] + '456' }),
       ]);

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -380,11 +380,6 @@ describe('rootThread', function() {
       assert.calledWith(fakeStore.removeAnnotations, sinon.match([annot]));
     });
 
-    it('removes annotations when ANNOTATIONS_UNLOADED event occurs', function() {
-      $rootScope.$broadcast(events.ANNOTATIONS_UNLOADED, annot);
-      assert.calledWith(fakeStore.removeAnnotations, sinon.match(annot));
-    });
-
     describe('when a new annotation is created', function() {
       let existingNewAnnot;
       let onDelete;

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -113,7 +113,6 @@ describe('Streamer', function() {
 
     fakeAnnotationMapper = {
       loadAnnotations: sinon.stub(),
-      unloadAnnotations: sinon.stub(),
     };
 
     fakeStore = {
@@ -128,6 +127,7 @@ describe('Streamer', function() {
       pendingUpdates: sinon.stub().returns({}),
       pendingDeletions: sinon.stub().returns({}),
       receiveRealTimeUpdates: sinon.stub(),
+      removeAnnotations: sinon.stub(),
     };
 
     fakeGroups = {
@@ -330,7 +330,7 @@ describe('Streamer', function() {
 
         fakeWebSocket.notify(fixtures.deleteNotification);
 
-        assert.notCalled(fakeAnnotationMapper.unloadAnnotations);
+        assert.notCalled(fakeStore.removeAnnotations);
       });
     });
   });
@@ -355,7 +355,7 @@ describe('Streamer', function() {
       activeStreamer.applyPendingUpdates();
 
       assert.calledWithMatch(
-        fakeAnnotationMapper.unloadAnnotations,
+        fakeStore.removeAnnotations,
         sinon.match([{ id: 'an-id' }])
       );
     });

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -12,6 +12,9 @@ import * as util from '../util';
 /**
  * Return a copy of `current` with all matching annotations in `annotations`
  * removed.
+ *
+ * Annotations in `annotations` may be complete annotations or "stubs" with only
+ * the `id` field set.
  */
 function excludeAnnotations(current, annotations) {
   const ids = {};
@@ -272,7 +275,13 @@ function addAnnotations(annotations) {
   };
 }
 
-/** Remove annotations from the currently displayed set. */
+/**
+ * Remove annotations from the currently displayed set.
+ *
+ * @param {Annotation[]} annotations -
+ *   Annotations to remove. These may be complete annotations or stubs which
+ *   only contain an `id` property.
+ */
 function removeAnnotations(annotations) {
   return (dispatch, getState) => {
     const remainingAnnotations = excludeAnnotations(


### PR DESCRIPTION
This method inadvertently (?) mutated annotations in the store which
caused a crash later. Ultimately this method dispatched an event which
was handled only in one place in `root-thread.js` to call
`store.removeAnnotations()`.

This commit removes the method and associated `ANNOTATIONS_UNLOADED`
event and replaces callers with direct calls to
`store.removeAnnotations(...)`.

All uses of Angular events will soon need to be removed as part of the
migration away from Angular JS, but that will happen separately.

Fixes #1879