### PR TITLE
Freeze store state with `immutable` in development builds

### DIFF
--- a/src/sidebar/store/test/create-store-test.js
+++ b/src/sidebar/store/test/create-store-test.js
@@ -1,3 +1,5 @@
+/* global process */
+
 import createStore from '../create-store';
 
 const A = 0;
@@ -159,4 +161,13 @@ describe('sidebar/store/create-store', () => {
     assert.equal(store.getState().a.count, 0);
     assert.equal(store.getState().b.count, 0);
   });
+
+  if (process.env.NODE_ENV !== 'production') {
+    it('freezes store state in development builds', () => {
+      const store = counterStore();
+      assert.throws(() => {
+        store.getState().a.count = 1;
+      }, /Cannot assign to read only property/);
+    });
+  }
 });


### PR DESCRIPTION
~~**Depends on bug fix in https://github.com/hypothesis/client/pull/1881**. A test will fail on this branch until that fix lands.~~

Deep-freeze the store state after each action in development builds to
catch accidental mutation bugs such as #1879.

We couldn't do this in the past because the `annotation` component used
to mutate newly created annotations. As a result of recent refactoring,
this no longer happens.