### PR TITLE
Extract thread-count functions into utility

### DIFF
--- a/src/sidebar/components/annotation-thread.js
+++ b/src/sidebar/components/annotation-thread.js
@@ -1,22 +1,4 @@
-function hiddenCount(thread) {
-  const isHidden = thread.annotation && !thread.visible;
-  return thread.children.reduce(
-    function(count, reply) {
-      return count + hiddenCount(reply);
-    },
-    isHidden ? 1 : 0
-  );
-}
-
-function visibleCount(thread) {
-  const isVisible = thread.annotation && thread.visible;
-  return thread.children.reduce(
-    function(count, reply) {
-      return count + visibleCount(reply);
-    },
-    isVisible ? 1 : 0
-  );
-}
+import { countVisible, countHidden } from '../util/thread';
 
 function showAllChildren(thread, showFn) {
   thread.children.forEach(child => {
@@ -72,7 +54,8 @@ function AnnotationThreadController(features, store) {
   };
 
   /**
-   * Show this thread and any of its children
+   * Show this thread and any of its children. This is available if filtering
+   * is applied that hides items in the thread.
    */
   this.showThreadAndReplies = function() {
     showAllParents(this.thread, this.onForceVisible);
@@ -90,11 +73,11 @@ function AnnotationThreadController(features, store) {
    * search filter.
    */
   this.hiddenCount = function() {
-    return hiddenCount(this.thread);
+    return countHidden(this.thread);
   };
 
   this.shouldShowReply = function(child) {
-    return visibleCount(child) > 0;
+    return countVisible(child) > 0;
   };
 
   this.onForceVisible = function(thread) {

--- a/src/sidebar/util/test/thread-test.js
+++ b/src/sidebar/util/test/thread-test.js
@@ -1,0 +1,54 @@
+import * as threadUtil from '../thread';
+
+describe('sidebar/util/thread', () => {
+  const fakeThread = () => {
+    return {
+      annotation: {},
+      visible: true,
+      children: [
+        {
+          annotation: {},
+          visible: true,
+          children: [
+            { annotation: {}, visible: true, children: [] },
+            { annotation: {}, visible: false, children: [] },
+          ],
+        },
+        {
+          annotation: {},
+          visible: false,
+          children: [{ annotation: {}, visible: true, children: [] }],
+        },
+        { annotation: {}, visible: true, children: [] },
+      ],
+    };
+  };
+
+  describe('countVisible', () => {
+    it('should count the number of visible entries in the thread', () => {
+      const thread = fakeThread();
+      assert.equal(threadUtil.countVisible(thread), 5);
+    });
+
+    it('should calculate visible entries when top-level thread is hidden', () => {
+      const thread = fakeThread();
+      thread.visible = false;
+
+      assert.equal(threadUtil.countVisible(thread), 4);
+    });
+  });
+
+  describe('countHidden', () => {
+    it('should count the number of hidden entries in the thread', () => {
+      const thread = fakeThread();
+      assert.equal(threadUtil.countHidden(thread), 2);
+    });
+
+    it('should calculate visible entries when top-level thread is hidden', () => {
+      const thread = fakeThread();
+      thread.visible = false;
+
+      assert.equal(threadUtil.countHidden(thread), 3);
+    });
+  });
+});

--- a/src/sidebar/util/thread.js
+++ b/src/sidebar/util/thread.js
@@ -1,0 +1,31 @@
+/**
+ * Count the number of annotations/replies in the `thread` whose `visible`
+ * property matches `visibility`.
+ *
+ * @param {Thread} thread
+ * @param {boolean} visibility — `true`: count visible annotations
+ *                               `false`: count hidden annotations
+ * @return {number}
+ */
+function countByVisibility(thread, visibility) {
+  const matchesVisibility =
+    !!thread.annotation && thread.visible === visibility;
+  return thread.children.reduce(
+    (count, reply) => count + countByVisibility(reply, visibility),
+    matchesVisibility ? 1 : 0
+  );
+}
+
+/**
+ * Count the hidden annotations/replies in the `thread`
+ */
+export function countHidden(thread) {
+  return countByVisibility(thread, false);
+}
+
+/**
+ * Count the visible annotations/replies in the `thread`
+ */
+export function countVisible(thread) {
+  return countByVisibility(thread, true);
+}


### PR DESCRIPTION
This small PR extracts a couple of counting functions into a `thread` utility. Extracting logic makes it easier to migrate the `AnnotationThread` component (https://github.com/hypothesis/client/issues/1845) when it's time to do that.