### PR TITLE
Fix mutation violation when changing focused group

### DIFF
--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -33,14 +33,13 @@ function GroupListItem({
   const actions = useStore(store => ({
     clearDirectLinkedGroupFetchFailed: store.clearDirectLinkedGroupFetchFailed,
     clearDirectLinkedIds: store.clearDirectLinkedIds,
-    focusGroup: store.focusGroup,
   }));
 
   const focusGroup = () => {
     analytics.track(analytics.events.GROUP_SWITCH);
     actions.clearDirectLinkedGroupFetchFailed();
     actions.clearDirectLinkedIds();
-    actions.focusGroup(group.id);
+    groupsService.focus(group.id);
   };
 
   const leaveGroup = () => {

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -29,7 +29,6 @@ describe('GroupListItem', () => {
     };
 
     fakeStore = {
-      focusGroup: sinon.stub(),
       focusedGroupId: sinon.stub().returns('groupid'),
       clearDirectLinkedIds: sinon.stub(),
       clearDirectLinkedGroupFetchFailed: sinon.stub(),
@@ -50,6 +49,7 @@ describe('GroupListItem', () => {
     };
 
     fakeGroupsService = {
+      focus: sinon.stub(),
       leave: sinon.stub(),
     };
 
@@ -111,7 +111,7 @@ describe('GroupListItem', () => {
       .props()
       .onClick();
 
-    assert.calledWith(fakeStore.focusGroup, fakeGroup.id);
+    assert.calledWith(fakeGroupsService.focus, fakeGroup.id);
     assert.calledWith(fakeAnalytics.track, fakeAnalytics.events.GROUP_SWITCH);
   });
 

--- a/src/sidebar/events.js
+++ b/src/sidebar/events.js
@@ -18,9 +18,6 @@ export default {
 
   // UI state changes
 
-  /** The currently selected group changed */
-  GROUP_FOCUSED: 'groupFocused',
-
   // Annotation events
 
   /** A new annotation has been created locally. */

--- a/src/sidebar/services/persisted-defaults.js
+++ b/src/sidebar/services/persisted-defaults.js
@@ -5,6 +5,7 @@
 
 const DEFAULT_KEYS = {
   annotationPrivacy: 'hypothesis.privacy',
+  focusedGroup: 'hypothesis.groups.focus',
 };
 
 // @ngInject

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -123,24 +123,6 @@ export default function RootThread(
     store.removeAnnotations([annotation]);
   });
 
-  // Once the focused group state is moved to the app state store, then the
-  // logic in this event handler can be moved to the annotations reducer.
-  $rootScope.$on(events.GROUP_FOCUSED, function(event, focusedGroupId) {
-    const updatedAnnots = store
-      .getState()
-      .annotations.annotations.filter(function(ann) {
-        return metadata.isNew(ann) && !metadata.isReply(ann);
-      })
-      .map(function(ann) {
-        return Object.assign(ann, {
-          group: focusedGroupId,
-        });
-      });
-    if (updatedAnnots.length > 0) {
-      store.addAnnotations(updatedAnnots);
-    }
-  });
-
   /**
    * Build the root conversation thread from the given UI state.
    * @return {Thread}

--- a/src/sidebar/services/test/persisted-defaults-test.js
+++ b/src/sidebar/services/test/persisted-defaults-test.js
@@ -3,6 +3,7 @@ import persistedDefaults from '../persisted-defaults';
 
 const DEFAULT_KEYS = {
   annotationPrivacy: 'hypothesis.privacy',
+  focusedGroup: 'hypothesis.groups.focus',
 };
 
 describe('sidebar/services/persisted-defaults', function() {
@@ -41,14 +42,15 @@ describe('sidebar/services/persisted-defaults', function() {
 
       svc.init();
 
-      // Retrieving the one default from localStorage
-      assert.calledOnce(fakeLocalStorage.getItem);
-      assert.calledWith(
-        fakeLocalStorage.getItem,
-        DEFAULT_KEYS.annotationPrivacy
+      // Retrieving each known default from localStorage...
+      assert.equal(
+        fakeLocalStorage.getItem.callCount,
+        Object.keys(DEFAULT_KEYS).length
       );
-      // Setting the one default in the store
-      assert.calledOnce(fakeStore.setDefault);
+
+      Object.keys(DEFAULT_KEYS).forEach(defaultKey => {
+        assert.calledWith(fakeLocalStorage.getItem, DEFAULT_KEYS[defaultKey]);
+      });
     });
 
     it('should set defaults on the store with the values returned by `localStorage`', () => {
@@ -57,7 +59,9 @@ describe('sidebar/services/persisted-defaults', function() {
 
       svc.init();
 
-      assert.calledWith(fakeStore.setDefault, 'annotationPrivacy', 'bananas');
+      Object.keys(DEFAULT_KEYS).forEach(defaultKey => {
+        assert.calledWith(fakeStore.setDefault, defaultKey, 'bananas');
+      });
     });
 
     it('should set default to `null` if key non-existent in storage', () => {
@@ -66,7 +70,9 @@ describe('sidebar/services/persisted-defaults', function() {
 
       svc.init();
 
-      assert.calledWith(fakeStore.setDefault, 'annotationPrivacy', null);
+      Object.keys(DEFAULT_KEYS).forEach(defaultKey => {
+        assert.calledWith(fakeStore.setDefault, defaultKey, null);
+      });
     });
 
     context('when defaults change in the store', () => {
@@ -113,7 +119,7 @@ describe('sidebar/services/persisted-defaults', function() {
       });
 
       it('should not update local storage if default has not changed', () => {
-        const defaults = { annotationPrivacy: 'carrots' };
+        const defaults = { focusedGroup: 'carrots' };
         fakeLocalStorage.getItem.returns('carrots');
         fakeStore.getDefaults.returns(defaults);
         fakeStore.setState({ defaults: defaults });

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -416,40 +416,4 @@ describe('rootThread', function() {
       });
     });
   });
-
-  describe('when the focused group changes', function() {
-    it('moves new annotations to the focused group', function() {
-      fakeStore.state.annotations.annotations = [{ $tag: 'a-tag' }];
-
-      $rootScope.$broadcast(events.GROUP_FOCUSED, 'private-group');
-
-      assert.calledWith(
-        fakeStore.addAnnotations,
-        sinon.match([
-          {
-            $tag: 'a-tag',
-            group: 'private-group',
-          },
-        ])
-      );
-    });
-
-    it('does not move replies to the new group', function() {
-      fakeStore.state.annotations.annotations = [annotationFixtures.newReply()];
-
-      $rootScope.$broadcast(events.GROUP_FOCUSED, 'private-group');
-
-      assert.notCalled(fakeStore.addAnnotations);
-    });
-
-    it('does not move saved annotations to the new group', function() {
-      fakeStore.state.annotations.annotations = [
-        annotationFixtures.defaultAnnotation(),
-      ];
-
-      $rootScope.$broadcast(events.GROUP_FOCUSED, 'private-group');
-
-      assert.notCalled(fakeStore.addAnnotations);
-    });
-  });
 });

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -384,6 +384,16 @@ function findAnnotationByID(state, id) {
 }
 
 /**
+ * Return all loaded annotations that are not highlights and have not been saved
+ * to the server.
+ */
+const newAnnotations = createSelector(
+  state => state.annotations.annotations,
+  annotations =>
+    annotations.filter(ann => metadata.isNew(ann) && !metadata.isHighlight(ann))
+);
+
+/**
  * Return all loaded annotations that are highlights and have not been saved
  * to the server.
  */
@@ -445,6 +455,7 @@ export default {
     findAnnotationByID,
     findIDsForTags,
     isWaitingToAnchorAnnotations,
+    newAnnotations,
     newHighlights,
     noteCount,
     orphanCount,

--- a/src/sidebar/store/modules/defaults.js
+++ b/src/sidebar/store/modules/defaults.js
@@ -23,6 +23,7 @@ function init() {
    */
   return {
     annotationPrivacy: null,
+    focusedGroup: null,
   };
 }
 

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -174,6 +174,41 @@ describe('sidebar/store/modules/annotations', function() {
     });
   });
 
+  describe('newAnnotations', () => {
+    [
+      {
+        annotations: [
+          fixtures.oldAnnotation(), // no
+          fixtures.newAnnotation(), // yes
+          fixtures.newAnnotation(), // yes
+          fixtures.newReply(), // yes
+        ],
+        expectedLength: 3,
+      },
+      {
+        annotations: [fixtures.oldAnnotation(), fixtures.newHighlight()],
+        expectedLength: 0,
+      },
+      {
+        annotations: [
+          fixtures.newHighlight(), // no
+          fixtures.newReply(), // yes
+          fixtures.oldAnnotation(), // no
+          fixtures.newPageNote(), // yes
+        ],
+        expectedLength: 2,
+      },
+    ].forEach(testCase => {
+      it('returns number of unsaved, new annotations', () => {
+        const state = { annotations: { annotations: testCase.annotations } };
+        assert.lengthOf(
+          selectors.newAnnotations(state),
+          testCase.expectedLength
+        );
+      });
+    });
+  });
+
   describe('newHighlights', () => {
     [
       {

--- a/src/sidebar/store/modules/test/defaults-test.js
+++ b/src/sidebar/store/modules/test/defaults-test.js
@@ -50,7 +50,11 @@ describe('store/modules/defaults', function() {
 
         const latestDefaults = store.getDefaults();
 
-        assert.hasAllKeys(latestDefaults, ['foo', 'annotationPrivacy']);
+        assert.hasAllKeys(latestDefaults, [
+          'foo',
+          'annotationPrivacy',
+          'focusedGroup',
+        ]);
       });
     });
   });

--- a/src/sidebar/test/annotation-fixtures.js
+++ b/src/sidebar/test/annotation-fixtures.js
@@ -104,6 +104,18 @@ export function newHighlight() {
   };
 }
 
+/** Return an annotation domain model object for a new page note.
+ */
+export function newPageNote() {
+  return {
+    $highlight: undefined,
+    target: [{ source: 'http://example.org' }],
+    references: [],
+    text: '',
+    tags: [],
+  };
+}
+
 /** Return an annotation domain model object for an existing annotation
  *  received from the server.
  */
@@ -137,7 +149,8 @@ export function oldHighlight() {
  */
 export function oldPageNote() {
   return {
-    highlight: undefined,
+    id: 'note_id',
+    $highlight: undefined,
     target: [{ source: 'http://example.org' }],
     references: [],
     text: '',


### PR DESCRIPTION
This WIP PR fixes several birds with one stone.

At the core: the recent no-mutation-enforcement in non-production environments introduced in #1882 kicked up a violation in my local environment today, so I wanted to chase it down and fix it. After several wrong starts, I think I have a plausible solution here, and, while it's a little rough around the edges (and no tests yet), I think it's worth getting up here before I end my week.

Before this fix:

* Launch the client
* Create a new annotation, but don't save it
* Change groups with the groups menu

You'll get:

![image](https://user-images.githubusercontent.com/439947/76125010-e7307800-5fc9-11ea-8dd0-5664827b1b34.png)

This is a result of code in the `root-thread` service using `Object.assign` improperly and mutating `annotation` objects.

This PR consolidates some flung-about logic for handling change-of-focused-group state into a single `groups` service method, `focus`. This method:

* handles setting the updated focused group in the store
* Looks for any new annotations, creates copies with updated `group` references, and re-adds those to the store.
* Takes care of persisting the last-focused-group pref using the more newfangled `persisted-defaults` mechanism.

This allows us to:

* Remove the `GROUP_FOCUSED` event (yay!)
* Remove the dependency on `localStorage` from `groups` service
* Consolidate focused-group-changing logic into an easier-to-find place—removing it from `root-thread`, especially