### PR TITLE
Add sendReadyToReceive method to fetch-config.js

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -5,7 +5,7 @@ import { jsonConfigsFrom } from '../shared/settings';
 import crossOriginRPC from './cross-origin-rpc.js';
 import addAnalytics from './ga';
 import disableOpenerForExternalLinks from './util/disable-opener-for-external-links';
-import { fetchConfig } from './util/fetch-config';
+import { fetchConfig, sendReadyToReceive } from './util/fetch-config';
 import * as sentry from './util/sentry';
 
 // Read settings rendered into sidebar app HTML by service/extension.
@@ -359,6 +359,7 @@ function startAngularApp(config) {
 fetchConfig(appConfig)
   .then(config => {
     startAngularApp(config);
+    sendReadyToReceive();
   })
   .catch(err => {
     // Report error. This will be the only notice that the user gets because the

--- a/src/sidebar/util/fetch-config.js
+++ b/src/sidebar/util/fetch-config.js
@@ -180,3 +180,33 @@ export async function fetchConfig(appConfig, window_ = window) {
     );
   }
 }
+
+/**
+ * Makes an RPC request `readyToReceive` to the ancestor window to
+ * inform that it is ready to receive incoming RPC requests. This
+ * function must only be called after the RPC server is started.
+ *
+ * e.g.
+ * crossOriginRPC.server.start
+ *
+ * @param {Window} window_ - Test seam.
+ */
+export function sendReadyToReceive(window_ = window) {
+  const requestConfigFromFrame = hostConfig(window).requestConfigFromFrame;
+  // Does it get the config from an ancestor frame?
+  if (
+    requestConfigFromFrame &&
+    typeof requestConfigFromFrame.ancestorLevel === 'number' &&
+    typeof requestConfigFromFrame.origin === 'string'
+  ) {
+    const parentFrame = getAncestorFrame(
+      requestConfigFromFrame.ancestorLevel,
+      window_
+    );
+    postMessageJsonRpc.call(
+      parentFrame,
+      requestConfigFromFrame.origin,
+      'readyToReceive'
+    );
+  }
+}

--- a/src/sidebar/util/test/fetch-config-test.js
+++ b/src/sidebar/util/test/fetch-config-test.js
@@ -1,5 +1,5 @@
 import { assertPromiseIsRejected } from '../../../shared/test/promise-util';
-import { fetchConfig, $imports } from '../fetch-config';
+import { fetchConfig, sendReadyToReceive, $imports } from '../fetch-config';
 
 describe('sidebar.util.fetch-config', () => {
   let fakeHostConfig;
@@ -279,6 +279,40 @@ describe('sidebar.util.fetch-config', () => {
           );
         }
       });
+    });
+  });
+
+  describe('sendReadyToReceive', () => {
+    beforeEach(() => {
+      fakeJsonRpc.call.resolves({});
+    });
+
+    it('does not send RCP if there is no requestConfigFromFrame', () => {
+      sendReadyToReceive(fakeWindow);
+      assert.notCalled(fakeJsonRpc.call);
+    });
+
+    it('does not send RPC if requestConfigFromFrame is not an object', () => {
+      fakeHostConfig.returns({
+        requestConfigFromFrame: 'https://embedder.com',
+      });
+      sendReadyToReceive(fakeWindow);
+      assert.notCalled(fakeJsonRpc.call);
+    });
+
+    it('sends RPC when requestConfigFromFrame has origin and ancestorLevel keys', () => {
+      fakeHostConfig.returns({
+        requestConfigFromFrame: {
+          origin: 'https://embedder.com',
+          ancestorLevel: 2,
+        },
+      });
+      sendReadyToReceive(fakeWindow);
+      fakeJsonRpc.call.calledWithExactly(
+        fakeTopWindow,
+        'https://embedder.com',
+        'readyToReceive'
+      );
     });
   });
 });


### PR DESCRIPTION
This is a necessary request back to the parent app to tell it that the client’s RCP server is ready to receive incoming RCP requests. Without message, the parent APP does not know when to start sending RPC requests down from to the client. If they are sent too soon, they risk timeout. _I noticed the timeout happened after making some of the requests async._

![Screen Shot 2020-03-13 at 10 04 53 AM](https://user-images.githubusercontent.com/3939074/76643396-2c94fe00-6512-11ea-91c1-a641db1657e9.png)

The thing we need to do is send this RPC request after `startAngularApp` is called (which in turn starts the RCP server)

I was not initially sure how to fit this request in with the current structure but decided on just adding a stand alone method that takes care of everything. The downside is this is a bit redundant with `fetchConfig` in that it also has to call `getAncestorFrame` and also check the `requestConfigFromFrame` variable -- both of which are done already with `fetchConfig`, but this is a minor bit of overhead to making the api clean.

The other thing I was not sure about is where this method should live. fetch-config is not really the right name anymore of everything in that file, but I didn't really want to make a new file. We could rename fetch-confg to rcp-config-requests or something similar? Open to ideas.

If this does get checked in right now, it won't "hurt" anything, but it will mean that there will be an error in the console due to unknown method. The changes on LMS side are not straightforward and will break the client without this PR (we're at another cat vs mouse junction), so I propose we stub out `readyToReceive` as a no-op registered method in LMS first if we want to avoid the error.


PR's on the LMS side:
https://github.com/hypothesis/lms/pull/1539
https://github.com/hypothesis/lms/pull/1540
