### PR TITLE
Support selecting tabs with the keyboard

### DIFF
--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -13,9 +13,9 @@ import SvgIcon from './svg-icon';
 /**
  *  Display name of the tab and annotation count.
  */
-function Tab({ children, count, isWaitingToAnchor, onSelect, selected }) {
+function Tab({ children, count, isWaitingToAnchor, isSelected, onSelect }) {
   const selectTab = () => {
-    if (!selected) {
+    if (!isSelected) {
       onSelect();
     }
   };
@@ -23,7 +23,7 @@ function Tab({ children, count, isWaitingToAnchor, onSelect, selected }) {
   return (
     <button
       className={classnames('selection-tabs__type', {
-        'is-selected': selected,
+        'is-selected': isSelected,
       })}
       // Listen for `onMouseDown` so that the tab is selected when _pressed_
       // as this makes the UI feel faster. Also listen for `onClick` as a fallback
@@ -32,7 +32,7 @@ function Tab({ children, count, isWaitingToAnchor, onSelect, selected }) {
       onMouseDown={selectTab}
       role="tab"
       tabIndex="0"
-      aria-selected={selected.toString()}
+      aria-selected={isSelected.toString()}
     >
       {children}
       {count > 0 && !isWaitingToAnchor && (
@@ -52,6 +52,10 @@ Tab.propTypes = {
    */
   count: propTypes.number.isRequired,
   /**
+   * Is this tab currently selected?
+   */
+  isSelected: propTypes.bool.isRequired,
+  /**
    * Are there any annotations still waiting to anchor?
    */
   isWaitingToAnchor: propTypes.bool.isRequired,
@@ -59,10 +63,6 @@ Tab.propTypes = {
    * Callback to invoke when this tab is selected.
    */
   onSelect: propTypes.func.isRequired,
-  /**
-   * Is this tab currently selected?
-   */
-  selected: propTypes.bool.isRequired,
 };
 
 /**
@@ -85,9 +85,9 @@ function SelectionTabs({ isLoading, settings }) {
 
   const isThemeClean = settings.theme === 'clean';
 
-  const selectTab = type => {
+  const selectTab = tabId => {
     store.clearSelectedAnnotations();
-    store.selectTab(type);
+    store.selectTab(tabId);
   };
 
   const showAnnotationsUnavailableMessage =
@@ -109,7 +109,7 @@ function SelectionTabs({ isLoading, settings }) {
         <Tab
           count={annotationCount}
           isWaitingToAnchor={isWaitingToAnchorAnnotations}
-          selected={selectedTab === uiConstants.TAB_ANNOTATIONS}
+          isSelected={selectedTab === uiConstants.TAB_ANNOTATIONS}
           onSelect={() => selectTab(uiConstants.TAB_ANNOTATIONS)}
         >
           Annotations
@@ -117,7 +117,7 @@ function SelectionTabs({ isLoading, settings }) {
         <Tab
           count={noteCount}
           isWaitingToAnchor={isWaitingToAnchorAnnotations}
-          selected={selectedTab === uiConstants.TAB_NOTES}
+          isSelected={selectedTab === uiConstants.TAB_NOTES}
           onSelect={() => selectTab(uiConstants.TAB_NOTES)}
         >
           Page Notes
@@ -126,7 +126,7 @@ function SelectionTabs({ isLoading, settings }) {
           <Tab
             count={orphanCount}
             isWaitingToAnchor={isWaitingToAnchorAnnotations}
-            selected={selectedTab === uiConstants.TAB_ORPHANS}
+            isSelected={selectedTab === uiConstants.TAB_ORPHANS}
             onSelect={() => selectTab(uiConstants.TAB_ORPHANS)}
           >
             Orphans

--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -13,21 +13,23 @@ import SvgIcon from './svg-icon';
 /**
  *  Display name of the tab and annotation count.
  */
-function Tab({
-  children,
-  count,
-  isWaitingToAnchor,
-  onChangeTab,
-  selected,
-  type,
-}) {
+function Tab({ children, count, isWaitingToAnchor, onSelect, selected }) {
+  const selectTab = () => {
+    if (!selected) {
+      onSelect();
+    }
+  };
+
   return (
     <button
       className={classnames('selection-tabs__type', {
         'is-selected': selected,
       })}
-      onMouseDown={onChangeTab.bind(this, type)}
-      onTouchStart={onChangeTab.bind(this, type)}
+      // Listen for `onMouseDown` so that the tab is selected when _pressed_
+      // as this makes the UI feel faster. Also listen for `onClick` as a fallback
+      // to enable selecting the tab via other input methods.
+      onClick={selectTab}
+      onMouseDown={selectTab}
       role="tab"
       tabIndex="0"
       aria-selected={selected.toString()}
@@ -39,6 +41,7 @@ function Tab({
     </button>
   );
 }
+
 Tab.propTypes = {
   /**
    * Child components.
@@ -53,18 +56,13 @@ Tab.propTypes = {
    */
   isWaitingToAnchor: propTypes.bool.isRequired,
   /**
-   * Callback when this tab is active with type as a parameter.
+   * Callback to invoke when this tab is selected.
    */
-  onChangeTab: propTypes.func.isRequired,
+  onSelect: propTypes.func.isRequired,
   /**
    * Is this tab currently selected?
    */
   selected: propTypes.bool.isRequired,
-  /**
-   * The type value for this tab. One of
-   * 'annotation', 'note', or 'orphan'.
-   */
-  type: propTypes.oneOf(['annotation', 'note', 'orphan']).isRequired,
 };
 
 /**
@@ -87,7 +85,7 @@ function SelectionTabs({ isLoading, settings }) {
 
   const isThemeClean = settings.theme === 'clean';
 
-  const selectTab = function(type) {
+  const selectTab = type => {
     store.clearSelectedAnnotations();
     store.selectTab(type);
   };
@@ -112,8 +110,7 @@ function SelectionTabs({ isLoading, settings }) {
           count={annotationCount}
           isWaitingToAnchor={isWaitingToAnchorAnnotations}
           selected={selectedTab === uiConstants.TAB_ANNOTATIONS}
-          type={uiConstants.TAB_ANNOTATIONS}
-          onChangeTab={selectTab}
+          onSelect={() => selectTab(uiConstants.TAB_ANNOTATIONS)}
         >
           Annotations
         </Tab>
@@ -121,8 +118,7 @@ function SelectionTabs({ isLoading, settings }) {
           count={noteCount}
           isWaitingToAnchor={isWaitingToAnchorAnnotations}
           selected={selectedTab === uiConstants.TAB_NOTES}
-          type={uiConstants.TAB_NOTES}
-          onChangeTab={selectTab}
+          onSelect={() => selectTab(uiConstants.TAB_NOTES)}
         >
           Page Notes
         </Tab>
@@ -131,8 +127,7 @@ function SelectionTabs({ isLoading, settings }) {
             count={orphanCount}
             isWaitingToAnchor={isWaitingToAnchorAnnotations}
             selected={selectedTab === uiConstants.TAB_ORPHANS}
-            type={uiConstants.TAB_ORPHANS}
-            onChangeTab={selectTab}
+            onSelect={() => selectTab(uiConstants.TAB_ORPHANS)}
           >
             Orphans
           </Tab>

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -205,6 +205,49 @@ describe('SelectionTabs', function() {
     });
   });
 
+  const findButton = (wrapper, label) =>
+    wrapper.findWhere(
+      el => el.type() === 'button' && el.text().includes(label)
+    );
+
+  [
+    { label: 'Annotations', tab: uiConstants.TAB_ANNOTATIONS },
+    { label: 'Page Notes', tab: uiConstants.TAB_NOTES },
+    { label: 'Orphans', tab: uiConstants.TAB_ORPHANS },
+  ].forEach(({ label, tab }) => {
+    it(`should change the selected tab when "${label}" tab is clicked`, () => {
+      // Pre-select a different tab than the one we are about to click.
+      fakeStore.getState.returns({
+        selection: {
+          selectedTab: 'other-tab',
+        },
+      });
+
+      // Make the "Orphans" tab appear.
+      fakeStore.orphanCount.returns(1);
+      const wrapper = createComponent({});
+
+      findButton(wrapper, label).simulate('click');
+
+      assert.calledOnce(fakeStore.clearSelectedAnnotations);
+      assert.calledWith(fakeStore.selectTab, tab);
+    });
+  });
+
+  it('does not change the selected tab if it is already selected', () => {
+    fakeStore.getState.returns({
+      selection: {
+        selectedTab: uiConstants.TAB_NOTES,
+      },
+    });
+    const wrapper = createComponent({});
+
+    findButton(wrapper, 'Page Notes').simulate('click');
+
+    assert.notCalled(fakeStore.clearSelectedAnnotations);
+    assert.notCalled(fakeStore.selectTab);
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({


### PR DESCRIPTION
Tab bar buttons responded to mouse/touch press events to make tab
switching feel fast and match how eg. browser tabs behave. However these were not
triggered when activating the buttons using the keyboard. Resolve the
issue by adding the standard click event handler and keeping the
mousedown handler as an optimization.

Also add a missing test for tab selection behavior.