### PR TITLE
Fix hidden text for highlights affecting text selection

### DIFF
--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -1,12 +1,20 @@
 @use '../variables' as var;
 
+// Hide content from sighted users but make it visible to screen readers.
+//
+// Resources:
+// - https://webaim.org/techniques/css/invisiblecontent/ (see "CSS clip")
+// - https://cloudfour.com/thinks/see-no-evil-hidden-content-and-accessibility/#showing-additional-content-for-screen-readers
 @mixin screen-reader-only {
-  // Hide this content visually, but without preventing screen readers from
-  // reading it.
-  opacity: 0;
-
-  // Avoid this content affecting the visual layout.
+  // Take the content out of the normal layout flow.
   position: absolute;
+
+  // Visually hide the content and prevent it from interfering with mouse/touch
+  // text selection by clipping it to an empty box. Compared to moving content with
+  // `top`/`left` this is less likely to cause the browser to scroll to a
+  // different part of the page when the hidden text has screen-reader focus.
+  clip: rect(0 0 0 0);
+  overflow: hidden;
 }
 
 // `hypothesis-highlights-always-on` is a class that is toggled on the root


### PR DESCRIPTION
The hidden "annotation start" and "annotation end" text added before and
after highlights was visually hidden using `opacity: 0` but still
interfered with text selection, presumably because the hidden text was
still "visible" to hit testing. Revise the approach to use the CSS
`clip` instead which avoids this problem.

Fixes https://github.com/hypothesis/support/issues/92