### PR TITLE
Fix useElementShouldClose to work with Escape key

### DIFF
--- a/src/sidebar/components/hooks/test/use-element-should-close-test.js
+++ b/src/sidebar/components/hooks/test/use-element-should-close-test.js
@@ -12,7 +12,7 @@ describe('hooks.useElementShouldClose', () => {
   const events = [
     new Event('mousedown'),
     new Event('click'),
-    ((e = new Event('keypress')), (e.key = 'Escape'), e),
+    ((e = new Event('keydown')), (e.key = 'Escape'), e),
     new Event('focus'),
   ];
 

--- a/src/sidebar/components/hooks/use-element-should-close.js
+++ b/src/sidebar/components/hooks/use-element-should-close.js
@@ -19,7 +19,7 @@ import { listen } from '../../util/dom';
 /**
  * This hook adds appropriate `eventListener`s to the document when a target
  * element (`closeableEl`) is open. Events such as `click` and `focus` on
- * elements that fall outside of `closeableEl` in the document, or keypress
+ * elements that fall outside of `closeableEl` in the document, or keydown
  * events for the `esc` key, will invoke the provided `handleClose` function
  * to indicate that `closeableEl` should be closed. This hook also performs
  * cleanup to remove `eventListener`s when appropriate.
@@ -66,15 +66,11 @@ export default function useElementShouldClose(
     }
 
     // Close element when user presses Escape key, regardless of focus.
-    const removeKeypressListener = listen(
-      document.body,
-      ['keypress'],
-      event => {
-        if (event.key === 'Escape') {
-          handleClose();
-        }
+    const removeKeypressListener = listen(document.body, ['keydown'], event => {
+      if (event.key === 'Escape') {
+        handleClose();
       }
-    );
+    });
 
     // Close element if user focuses an element outside of it via any means
     // (key press, programmatic focus change).

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -92,7 +92,7 @@ describe('Menu', () => {
   [
     new Event('mousedown'),
     new Event('click'),
-    ((e = new Event('keypress')), (e.key = 'Escape'), e),
+    ((e = new Event('keydown')), (e.key = 'Escape'), e),
     new Event('focus'),
   ].forEach(event => {
     it(`closes when the user clicks or presses the mouse outside (${event.type})`, () => {


### PR DESCRIPTION
‘keypress’ is not fired for “Escape” key, so we need to listen for ‘keydown’. 

This is needed for a number of a11y components such as dialogs. So its good to fix this sooner than later. I specifically need this now because I'm porting `useElementShouldClose` to LMS for an a11y dialog change but I need `useElementShouldClose` for the Escape feature --which is actually broken, hence, this PR :)

fixed https://github.com/hypothesis/client/issues/1710