### PR TITLE
Add keyboard shortcuts for the Annotate/Highlight ("adder") toolbar

### DIFF
--- a/src/annotator/components/adder-toolbar.js
+++ b/src/annotator/components/adder-toolbar.js
@@ -2,6 +2,31 @@ import classnames from 'classnames';
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
+import { useShortcut } from '../../shared/shortcut';
+
+function ToolbarButton({ icon, label, onClick, shortcut }) {
+  useShortcut(shortcut, onClick);
+
+  const title = shortcut ? `${label} (${shortcut})` : null;
+
+  return (
+    <button
+      className={classnames('annotator-adder-actions__button', icon)}
+      onClick={onClick}
+      title={title}
+    >
+      <span className="annotator-adder-actions__label">{label}</span>
+    </button>
+  );
+}
+
+ToolbarButton.propTypes = {
+  icon: propTypes.string.isRequired,
+  label: propTypes.string.isRequired,
+  onClick: propTypes.func.isRequired,
+  shortcut: propTypes.string,
+};
+
 /**
  * The toolbar that is displayed above selected text in the document providing
  * options to create annotations or highlights.
@@ -13,6 +38,12 @@ export default function AdderToolbar({ arrowDirection, isVisible, onCommand }) {
 
     onCommand(command);
   };
+
+  // Since the selection toolbar is only shown when there is a selection
+  // of static text, we can use a plain key without any modifier as
+  // the shortcut. This avoids conflicts with browser/OS shortcuts.
+  const annotateShortcut = isVisible ? 'a' : null;
+  const highlightShortcut = isVisible ? 'h' : null;
 
   // nb. The adder is hidden using the `visibility` property rather than `display`
   // so that we can compute its size in order to position it before display.
@@ -26,18 +57,18 @@ export default function AdderToolbar({ arrowDirection, isVisible, onCommand }) {
       style={{ visibility: isVisible ? 'visible' : 'hidden' }}
     >
       <hypothesis-adder-actions className="annotator-adder-actions">
-        <button
-          className="annotator-adder-actions__button h-icon-annotate"
+        <ToolbarButton
+          icon="h-icon-annotate"
           onClick={e => handleCommand(e, 'annotate')}
-        >
-          <span className="annotator-adder-actions__label">Annotate</span>
-        </button>
-        <button
-          className="annotator-adder-actions__button h-icon-highlight"
+          label="Annotate"
+          shortcut={annotateShortcut}
+        />
+        <ToolbarButton
+          icon="h-icon-highlight"
           onClick={e => handleCommand(e, 'highlight')}
-        >
-          <span className="annotator-adder-actions__label">Highlight</span>
-        </button>
+          label="Highlight"
+          shortcut={highlightShortcut}
+        />
       </hypothesis-adder-actions>
     </hypothesis-adder-toolbar>
   );

--- a/src/annotator/components/test/adder-toolbar-test.js
+++ b/src/annotator/components/test/adder-toolbar-test.js
@@ -1,0 +1,4 @@
+describe('AdderToolbar', () => {
+  // nb. Most tests for `AdderToolbar` are currently covered by `adder-test.js`.
+  // This needs refactoring to test the `AdderToolbar` on its own as a unit.
+});

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -1,3 +1,5 @@
+import { act } from 'preact/test-utils';
+
 import { Adder, ARROW_POINTING_UP, ARROW_POINTING_DOWN } from '../adder';
 
 function rect(left, top, width, height) {
@@ -23,7 +25,8 @@ function revertOffsetElement(el) {
 }
 
 // nb. These tests currently cover the `AdderToolbar` Preact component as well
-// as the `Adder` container.
+// as the `Adder` container. The tests for `AdderToolbar` should be moved into
+// `adder-toolbar-test.js`.
 describe('Adder', () => {
   let adderCtrl;
   let adderCallbacks;
@@ -103,6 +106,31 @@ describe('Adder', () => {
       );
       annotateLabel.dispatchEvent(new Event('click', { bubbles: true }));
       assert.called(adderCallbacks.onAnnotate);
+    });
+
+    it('calls onAnnotate callback when shortcut is pressed if adder is visible', () => {
+      // nb. `act` is necessary here to flush effect hooks in `AdderToolbar`.
+      act(() => {
+        adderCtrl.showAt(100, 100, ARROW_POINTING_UP);
+      });
+      document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+      assert.called(adderCallbacks.onAnnotate);
+    });
+
+    it('calls onHighlight callback when shortcut is pressed if adder is visible', () => {
+      // nb. `act` is necessary here to flush effect hooks in `AdderToolbar`.
+      act(() => {
+        adderCtrl.showAt(100, 100, ARROW_POINTING_UP);
+      });
+      document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'h' }));
+      assert.called(adderCallbacks.onHighlight);
+    });
+
+    it('does not call callbacks when adder is hidden', () => {
+      document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+      document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'h' }));
+      assert.notCalled(adderCallbacks.onAnnotate);
+      assert.notCalled(adderCallbacks.onHighlight);
     });
   });
 

--- a/src/shared/shortcut.js
+++ b/src/shared/shortcut.js
@@ -30,8 +30,10 @@ export function matchShortcut(event, shortcut) {
     const modifierFlag = modifiers[part];
     if (modifierFlag) {
       requiredModifiers |= modifierFlag;
-    } else {
+    } else if (requiredKey === null) {
       requiredKey = part;
+    } else {
+      throw new Error('Multiple non-modifier keys specified');
     }
   }
 

--- a/src/shared/shortcut.js
+++ b/src/shared/shortcut.js
@@ -1,0 +1,109 @@
+import { useEffect } from 'preact/hooks';
+
+// Bit flags indicating modifiers required by a shortcut or pressed in a key event.
+const modifiers = {
+  alt: 1,
+  ctrl: 2,
+  meta: 4,
+  shift: 8,
+};
+
+/**
+ * Match a `shortcut` key sequence against a keydown event.
+ *
+ * A shortcut key sequence is a string of "+"-separated keyboard modifiers and
+ * keys. The list may contain zero or more modifiers and must contain exactly
+ * one non-modifier key. The key and modifier names are case-insensitive.
+ * For example "Ctrl+Enter", "shift+a". Key names are matched against `KeyboardEvent.key`.
+ *
+ * @param {KeyboardEvent} event
+ * @param {string} shortcut
+ * @return {boolean}
+ */
+export function matchShortcut(event, shortcut) {
+  const parts = shortcut.split('+').map(p => p.toLowerCase());
+
+  let requiredModifiers = 0;
+  let requiredKey = null;
+
+  for (let part of parts) {
+    const modifierFlag = modifiers[part];
+    if (modifierFlag) {
+      requiredModifiers |= modifierFlag;
+    } else {
+      requiredKey = part;
+    }
+  }
+
+  if (!requiredKey) {
+    throw new Error(`Invalid shortcut: ${shortcut}`);
+  }
+
+  const actualModifiers =
+    (event.ctrlKey && modifiers.ctrl) |
+    (event.metaKey && modifiers.meta) |
+    (event.altKey && modifiers.alt) |
+    (event.shiftKey && modifiers.shift);
+
+  return (
+    actualModifiers === requiredModifiers &&
+    event.key.toLowerCase() === requiredKey
+  );
+}
+
+/**
+ * @typedef ShortcutOptions
+ * @prop {HTMLElement} rootElement -
+ *   Element on which the key event listener should be installed. Defaults to
+ *   `document.body`.
+ */
+
+/**
+ * Install a shortcut key listener on the document.
+ *
+ * This can be used directly outside of a component. To use within a Preact
+ * component, you probably want the `useShortcut` hook.
+ *
+ * @param {string} shortcut - Shortcut key sequence. See `matchShortcut`.
+ * @param {(e: KeyboardEvent) => any} onPress - A function to call when the shortcut matches
+ * @param {ShortcutOptions} [options]
+ * @return {() => void} A function that removes the shortcut
+ */
+export function installShortcut(
+  shortcut,
+  onPress,
+  { rootElement = document.body } = {}
+) {
+  const onKeydown = event => {
+    if (matchShortcut(event, shortcut)) {
+      onPress(event);
+    }
+  };
+  rootElement.addEventListener('keydown', onKeydown);
+  return () => rootElement.removeEventListener('keydown', onKeydown);
+}
+
+/**
+ * An effect hook that installs a shortcut using `installShortcut` and removes
+ * it when the component is unmounted.
+ *
+ * This provides a convenient way to enable a shortcut while a component is
+ * rendered. To conditionally disable the shortcut, set `shortcut` to `null`.
+ *
+ * @param {string|null} shortcut -
+ *   A shortcut key sequence to match or `null` to disable. See `matchShortcut`.
+ * @param {(e: KeyboardEvent) => any} onPress - A function to call when the shortcut matches
+ * @param {ShortcutOptions} [options]
+ */
+export function useShortcut(
+  shortcut,
+  onPress,
+  { rootElement = document.body } = {}
+) {
+  useEffect(() => {
+    if (!shortcut) {
+      return null;
+    }
+    return installShortcut(shortcut, onPress, { rootElement });
+  }, [shortcut, onPress, rootElement]);
+}

--- a/src/shared/shortcut.js
+++ b/src/shared/shortcut.js
@@ -87,8 +87,12 @@ export function installShortcut(
  * An effect hook that installs a shortcut using `installShortcut` and removes
  * it when the component is unmounted.
  *
- * This provides a convenient way to enable a shortcut while a component is
- * rendered. To conditionally disable the shortcut, set `shortcut` to `null`.
+ * This provides a convenient way to enable a document-level shortcut while
+ * a component is mounted. This differs from adding an `onKeyDown` handler to
+ * one of the component's DOM elements in that it doesn't require the component
+ * to have focus.
+ *
+ * To conditionally disable the shortcut, set `shortcut` to `null`.
  *
  * @param {string|null} shortcut -
  *   A shortcut key sequence to match or `null` to disable. See `matchShortcut`.

--- a/src/shared/test/shortcut-test.js
+++ b/src/shared/test/shortcut-test.js
@@ -62,12 +62,24 @@ describe('shared/shortcut', () => {
   });
 
   describe('installShortcut', () => {
-    it('should install a shortcut listener on the root element', () => {
+    it('should install a shortcut listener on the document body', () => {
       const onPress = sinon.stub();
       const removeShortcut = installShortcut('a', onPress);
       const event = new KeyboardEvent('keydown', { key: 'a' });
 
       document.body.dispatchEvent(event);
+      removeShortcut();
+
+      assert.calledWith(onPress, event);
+    });
+
+    it('should install a shortcut listener on a custom root element', () => {
+      const onPress = sinon.stub();
+      const el = document.createElement('div');
+      const removeShortcut = installShortcut('a', onPress, { rootElement: el });
+      const event = new KeyboardEvent('keydown', { key: 'a' });
+
+      el.dispatchEvent(event);
       removeShortcut();
 
       assert.calledWith(onPress, event);

--- a/src/shared/test/shortcut-test.js
+++ b/src/shared/test/shortcut-test.js
@@ -16,10 +16,23 @@ function createEvent(key, { ctrl, alt, shift, meta } = {}) {
 describe('shared/shortcut', () => {
   describe('matchShortcut', () => {
     [
+      // Single modifier.
       { shortcut: 'ctrl+a', event: createEvent('a', { ctrl: true }) },
       { shortcut: 'meta+a', event: createEvent('a', { meta: true }) },
       { shortcut: 'shift+a', event: createEvent('a', { shift: true }) },
       { shortcut: 'alt+a', event: createEvent('a', { alt: true }) },
+
+      // Multiple modifiers.
+      {
+        shortcut: 'ctrl+shift+a',
+        event: createEvent('a', { ctrl: true, shift: true }),
+      },
+      {
+        shortcut: 'alt+meta+a',
+        event: createEvent('a', { alt: true, meta: true }),
+      },
+
+      // No modifier.
       { shortcut: 'a', event: createEvent('a') },
     ].forEach(({ shortcut, event }) => {
       it('should match if modifiers match', () => {
@@ -27,13 +40,17 @@ describe('shared/shortcut', () => {
       });
     });
 
-    [{ shortcut: 'ctrl+a', event: createEvent('a', { ctrl: false }) }].forEach(
-      ({ shortcut, event }) => {
-        it('should not match if modifiers do not match', () => {
-          assert.isFalse(matchShortcut(event, shortcut));
-        });
-      }
-    );
+    [
+      { shortcut: 'ctrl+a', event: createEvent('a', { ctrl: false }) },
+      {
+        shortcut: 'ctrl+shift+a',
+        event: createEvent('a', { ctrl: true, shift: false }),
+      },
+    ].forEach(({ shortcut, event }) => {
+      it('should not match if modifiers do not match', () => {
+        assert.isFalse(matchShortcut(event, shortcut));
+      });
+    });
 
     [
       { shortcut: 'a', event: createEvent('a') },
@@ -169,6 +186,8 @@ describe('shared/shortcut', () => {
       });
 
       triggerShortcut({ key: 'a' });
+
+      assert.notCalled(onClick);
     });
   });
 });

--- a/src/shared/test/shortcut-test.js
+++ b/src/shared/test/shortcut-test.js
@@ -1,0 +1,156 @@
+import { createElement, render } from 'preact';
+import { act } from 'preact/test-utils';
+
+import { matchShortcut, installShortcut, useShortcut } from '../shortcut';
+
+function createEvent(key, { ctrl, alt, shift, meta } = {}) {
+  return {
+    key,
+    ctrlKey: !!ctrl,
+    altKey: !!alt,
+    shiftKey: !!shift,
+    metaKey: !!meta,
+  };
+}
+
+describe('shared/shortcut', () => {
+  describe('matchShortcut', () => {
+    [
+      { shortcut: 'ctrl+a', event: createEvent('a', { ctrl: true }) },
+      { shortcut: 'meta+a', event: createEvent('a', { meta: true }) },
+      { shortcut: 'shift+a', event: createEvent('a', { shift: true }) },
+      { shortcut: 'alt+a', event: createEvent('a', { alt: true }) },
+      { shortcut: 'a', event: createEvent('a') },
+    ].forEach(({ shortcut, event }) => {
+      it('should match if modifiers match', () => {
+        assert.isTrue(matchShortcut(event, shortcut));
+      });
+    });
+
+    [{ shortcut: 'ctrl+a', event: createEvent('a', { ctrl: false }) }].forEach(
+      ({ shortcut, event }) => {
+        it('should not match if modifiers do not match', () => {
+          assert.isFalse(matchShortcut(event, shortcut));
+        });
+      }
+    );
+
+    [
+      { shortcut: 'a', event: createEvent('a') },
+      { shortcut: 'enter', event: createEvent('Enter') },
+    ].forEach(({ shortcut, event }) => {
+      it('should match if non-modifier key matches', () => {
+        assert.isTrue(matchShortcut(event, shortcut));
+      });
+    });
+
+    [{ shortcut: 'a', event: createEvent('b') }].forEach(
+      ({ shortcut, event }) => {
+        it('should not match if non-modifier key does not match', () => {
+          assert.isFalse(matchShortcut(event, shortcut));
+        });
+      }
+    );
+
+    ['ctrl', 'META'].forEach(shortcut => {
+      it('should throw an error if no non-modifier key is specified', () => {
+        assert.throws(() => {
+          matchShortcut(createEvent('a'), shortcut);
+        });
+      });
+    });
+  });
+
+  describe('installShortcut', () => {
+    it('should install a shortcut listener on the root element', () => {
+      const onPress = sinon.stub();
+      const removeShortcut = installShortcut('a', onPress);
+      const event = new KeyboardEvent('keydown', { key: 'a' });
+
+      document.body.dispatchEvent(event);
+      removeShortcut();
+
+      assert.calledWith(onPress, event);
+    });
+
+    it('should not trigger if not-matching key is pressed', () => {
+      const onPress = sinon.stub();
+      const removeShortcut = installShortcut('a', onPress);
+      const event = new KeyboardEvent('keydown', { key: 'b' });
+
+      document.body.dispatchEvent(event);
+      removeShortcut();
+
+      assert.notCalled(onPress);
+    });
+
+    it('should remove shortcut listener when returned callback is called', () => {
+      const onPress = sinon.stub();
+      const removeShortcut = installShortcut('a', onPress);
+      const event = new KeyboardEvent('keydown', { key: 'a' });
+
+      removeShortcut();
+      document.body.dispatchEvent(event);
+
+      assert.notCalled(onPress);
+    });
+  });
+
+  describe('useShortcut', () => {
+    // eslint-disable-next-line react/prop-types
+    function Button({ shortcut = null, onClick }) {
+      useShortcut(shortcut, onClick);
+      return <button onClick={onClick}>Shortcut test</button>;
+    }
+
+    function triggerShortcut(keyEventArgs) {
+      const event = new KeyboardEvent('keydown', keyEventArgs);
+      document.body.dispatchEvent(event);
+    }
+
+    let container;
+    beforeEach(() => {
+      container = document.createElement('div');
+    });
+
+    afterEach(() => {
+      // Unmount component to remove any shortcut handlers.
+      act(() => {
+        render(null, container);
+      });
+    });
+
+    it('should install a shortcut when component is mounted', () => {
+      const onClick = sinon.stub();
+
+      act(() => {
+        render(<Button shortcut="a" onClick={onClick} />, container);
+      });
+      triggerShortcut({ key: 'a' });
+
+      assert.called(onClick);
+    });
+
+    it('should not install a shortcut if `shortcut` is null', () => {
+      const onClick = sinon.stub();
+
+      act(() => {
+        render(<Button onClick={onClick} />, container);
+      });
+      triggerShortcut({ key: 'a' });
+
+      assert.notCalled(onClick);
+    });
+
+    it('should remove the shortcut when component is unmounted', () => {
+      const onClick = sinon.stub();
+
+      act(() => {
+        render(<Button onClick={onClick} />, container);
+        render(null, container);
+      });
+
+      triggerShortcut({ key: 'a' });
+    });
+  });
+});

--- a/src/shared/test/shortcut-test.js
+++ b/src/shared/test/shortcut-test.js
@@ -59,6 +59,12 @@ describe('shared/shortcut', () => {
         });
       });
     });
+
+    it('should throw an error if multiple non-modifier keys are specified', () => {
+      assert.throws(() => {
+        matchShortcut(createEvent('a'), 'a+b');
+      }, 'Multiple non-modifier keys specified');
+    });
   });
 
   describe('installShortcut', () => {


### PR DESCRIPTION
This PR makes it easier to create annotations and highlights using the keyboard. It adds keyboard shortcuts for the "Annotate" and "Highlight" buttons which are "a" and "h" respectively. My thinking is that since the toolbar is only shown when there is a non-empty selection of static text (ie. not in an input field), we can use plain keys, with no modifiers, as the shortcut keys. I've left open the possibility to change this in future.

I plan to extend this in future by adding an additional toolbar action which selects the annotations associated with the selected text, ie. as if you had clicked on the highlighted text, and a corresponding shortcut. This will provide a solution to the problem of how to view annotations associated with a highlighted piece of text using only keyboard interaction.

The PR is split into two commits. The first adds a set of utilities in `src/shared/shortcut.js` that make it easy to create document-level shortcuts that are associated with a component. The second modifies `src/annotator/components/adder-toolbar.js` to use this to register shortcuts for the "Annotate" and "Highlight" buttons. When reviewing this, it will probably be easier to start by looking at the changes to `adder-toolbar.js`.

To make the shortcuts discoverable, I added titles to these buttons. I expect we'll also need to write up a document in the knowledge base.