### PR TITLE
Replace all keypress events with the keydown event

### DIFF
--- a/src/sidebar/components/hooks/use-element-should-close.js
+++ b/src/sidebar/components/hooks/use-element-should-close.js
@@ -66,7 +66,7 @@ export default function useElementShouldClose(
     }
 
     // Close element when user presses Escape key, regardless of focus.
-    const removeKeypressListener = listen(document.body, ['keydown'], event => {
+    const removeKeyDownListener = listen(document.body, ['keydown'], event => {
       if (event.key === 'Escape') {
         handleClose();
       }
@@ -101,7 +101,7 @@ export default function useElementShouldClose(
     );
 
     return () => {
-      removeKeypressListener();
+      removeKeyDownListener();
       removeClickListener();
       removeFocusListener();
     };

--- a/src/sidebar/components/markdown-editor.js
+++ b/src/sidebar/components/markdown-editor.js
@@ -293,7 +293,7 @@ export default function MarkdownEditor({
           dir="auto"
           ref={input}
           onClick={e => e.stopPropagation()}
-          onKeydown={handleKeyDown}
+          onKeyDown={handleKeyDown}
           onInput={e => onEditText({ text: e.target.value })}
           value={text}
         />

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -94,7 +94,7 @@ export default function Menu({
   const stopPropagation = e => e.stopPropagation();
 
   // It should also close if the user presses a key which activates menu items.
-  const handleMenuKeyPress = event => {
+  const handleMenuKeyDown = event => {
     if (event.key === 'Enter' || event.key === ' ') {
       closeMenu();
     }
@@ -154,7 +154,7 @@ export default function Menu({
             role="menu"
             tabIndex="-1"
             onClick={closeMenu}
-            onKeyPress={handleMenuKeyPress}
+            onKeyDown={handleMenuKeyDown}
           >
             {children}
           </div>

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -111,7 +111,7 @@ describe('Menu', () => {
     const wrapper = createMenu({ defaultOpen: true });
 
     act(() => {
-      const event = new Event('keypress');
+      const event = new Event('keydown');
       event.key = 'a';
       document.body.dispatchEvent(event);
     });
@@ -140,17 +140,17 @@ describe('Menu', () => {
       shouldClose: true,
     },
     {
-      eventType: 'keypress',
+      eventType: 'keydown',
       key: 'Enter',
       shouldClose: true,
     },
     {
-      eventType: 'keypress',
+      eventType: 'keydown',
       key: ' ',
       shouldClose: true,
     },
     {
-      eventType: 'keypress',
+      eventType: 'keydown',
       key: 'a',
       shouldClose: false,
     },

--- a/src/sidebar/util/on-activate.js
+++ b/src/sidebar/util/on-activate.js
@@ -15,7 +15,7 @@ export function onActivate(role, handler) {
     onClick: handler,
 
     // Support keyboard activation.
-    onKeypress: event => {
+    onKeyDown: event => {
       if (event.key === 'Enter' || event.key === ' ') {
         handler(event);
       }


### PR DESCRIPTION
keypress is deprecated
https://developer.mozilla.org/en-US/docs/Web/API/Document/keypress_event

I have manually tested each event to make sure it still fires
fixes https://github.com/hypothesis/client/issues/1899

