### PR TITLE
Replace Angular router

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@sentry/browser": "^5.6.2",
     "angular": "^1.7.5",
     "angular-mocks": "^1.7.5",
-    "angular-route": "^1.7.5",
     "angular-toastr": "^2.1.1",
     "autoprefixer": "^9.4.7",
     "aws-sdk": "^2.345.0",

--- a/scripts/gulp/vendor-bundles.js
+++ b/scripts/gulp/vendor-bundles.js
@@ -9,7 +9,7 @@
 module.exports = {
   bundles: {
     jquery: ['jquery'],
-    angular: ['angular', 'angular-route', 'angular-toastr'],
+    angular: ['angular', 'angular-toastr'],
     katex: ['katex'],
     sentry: ['@sentry/browser'],
     showdown: ['showdown'],

--- a/src/sidebar/components/annotation-viewer-content.js
+++ b/src/sidebar/components/annotation-viewer-content.js
@@ -35,7 +35,7 @@ function AnnotationViewerContentController(
 ) {
   store.clearAnnotations();
 
-  const id = store.routeParams().id;
+  const annotationId = store.routeParams().id;
 
   this.rootThread = () => rootThread.thread(store.getState());
 
@@ -43,7 +43,7 @@ function AnnotationViewerContentController(
     store.setCollapsed(id, collapsed);
   };
 
-  this.ready = fetchThread(api, id).then(function(annots) {
+  this.ready = fetchThread(api, annotationId).then(function(annots) {
     annotationMapper.loadAnnotations(annots);
 
     const topLevelAnnot = annots.filter(function(annot) {
@@ -64,8 +64,8 @@ function AnnotationViewerContentController(
       store.setCollapsed(annot.id, false);
     });
 
-    if (topLevelAnnot.id !== id) {
-      store.highlightAnnotations([id]);
+    if (topLevelAnnot.id !== annotationId) {
+      store.highlightAnnotations([annotationId]);
     }
   });
 }

--- a/src/sidebar/components/annotation-viewer-content.js
+++ b/src/sidebar/components/annotation-viewer-content.js
@@ -26,7 +26,6 @@ function fetchThread(api, id) {
 
 // @ngInject
 function AnnotationViewerContentController(
-  $routeParams,
   store,
   api,
   rootThread,
@@ -34,9 +33,9 @@ function AnnotationViewerContentController(
   streamFilter,
   annotationMapper
 ) {
-  store.setAppIsSidebar(false);
+  store.clearAnnotations();
 
-  const id = $routeParams.id;
+  const id = store.routeParams().id;
 
   this.rootThread = () => rootThread.thread(store.getState());
 

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -35,7 +35,6 @@ function authStateFromProfile(profile) {
 function HypothesisAppController(
   $document,
   $rootScope,
-  $route,
   $scope,
   $window,
   analytics,
@@ -81,6 +80,8 @@ function HypothesisAppController(
       store.openSidebarPanel(uiConstants.PANEL_HELP);
     }
   };
+
+  this.route = () => store.route();
 
   $scope.$on(events.USER_CHANGED, function(event, data) {
     self.onUserChange(data.profile);

--- a/src/sidebar/components/stream-search-input.js
+++ b/src/sidebar/components/stream-search-input.js
@@ -1,7 +1,7 @@
 import { createElement } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
+import useStore from '../store/use-store';
 import { withServices } from '../util/service-context';
 
 import SearchInput from './search-input';
@@ -11,30 +11,23 @@ import SearchInput from './search-input';
  *
  * This displays and updates the "q" query param in the URL.
  */
-function StreamSearchInput({ $location, $rootScope }) {
-  const [query, setQuery] = useState($location.search().q);
-  const search = query => {
-    $rootScope.$apply(() => {
-      // Re-route the user to `/stream` if they are on `/a/:id` and then set
-      // the search query.
-      $location.path('/stream').search({ q: query });
-    });
+function StreamSearchInput({ router }) {
+  const query = useStore(store => store.routeParams().q);
+  const setQuery = query => {
+    // Re-route the user to `/stream` if they are on `/a/:id` and then set
+    // the search query.
+    router.navigate('stream', { q: query });
   };
 
-  useEffect(() => {
-    $rootScope.$on('$locationChangeSuccess', () => {
-      setQuery($location.search().q);
-    });
-  }, [$location, $rootScope]);
-
-  return <SearchInput query={query} onSearch={search} alwaysExpanded={true} />;
+  return (
+    <SearchInput query={query} onSearch={setQuery} alwaysExpanded={true} />
+  );
 }
 
 StreamSearchInput.propTypes = {
-  $location: propTypes.object,
-  $rootScope: propTypes.object,
+  router: propTypes.object,
 };
 
-StreamSearchInput.injectedProps = ['$location', '$rootScope'];
+StreamSearchInput.injectedProps = ['router'];
 
 export default withServices(StreamSearchInput);

--- a/src/sidebar/components/test/annotation-viewer-content-test.js
+++ b/src/sidebar/components/test/annotation-viewer-content-test.js
@@ -41,12 +41,11 @@ describe('annotationViewerContent', function() {
 
   function createController(opts) {
     const locals = {
-      $location: {},
-      $routeParams: { id: 'test_annotation_id' },
       store: {
-        setAppIsSidebar: sinon.stub(),
+        clearAnnotations: sinon.stub(),
         setCollapsed: sinon.stub(),
         highlightAnnotations: sinon.stub(),
+        routeParams: sinon.stub().returns({ id: 'test_annotation_id' }),
         subscribe: sinon.stub(),
       },
       api: opts.api,

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -18,12 +18,10 @@ describe('sidebar.components.hypothesis-app', function() {
   let fakeFlash = null;
   let fakeFrameSync = null;
   let fakeIsSidebar = null;
-  let fakeParams = null;
   let fakeServiceConfig = null;
   let fakeSession = null;
   let fakeShouldAutoDisplayTutorial = null;
   let fakeGroups = null;
-  let fakeRoute = null;
   let fakeServiceUrl = null;
   let fakeSettings = null;
   let fakeWindow = null;
@@ -103,8 +101,6 @@ describe('sidebar.components.hypothesis-app', function() {
         connect: sandbox.spy(),
       };
 
-      fakeParams = { id: 'test' };
-
       fakeSession = {
         load: sandbox.stub().returns(Promise.resolve({ userid: null })),
         logout: sandbox.stub(),
@@ -114,8 +110,6 @@ describe('sidebar.components.hypothesis-app', function() {
       fakeGroups = {
         focus: sandbox.spy(),
       };
-
-      fakeRoute = { reload: sandbox.spy() };
 
       fakeWindow = {
         top: {},
@@ -140,8 +134,6 @@ describe('sidebar.components.hypothesis-app', function() {
       $provide.value('settings', fakeSettings);
       $provide.value('bridge', fakeBridge);
       $provide.value('groups', fakeGroups);
-      $provide.value('$route', fakeRoute);
-      $provide.value('$routeParams', fakeParams);
       $provide.value('$window', fakeWindow);
     })
   );

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -76,7 +76,7 @@ function setupApi(api, streamer) {
  * route to match the current URL.
  */
 // @ngInject
-function setupRoute(api, groups, session, router) {
+function setupRoute(groups, session, router) {
   Promise.all([groups.load(), session.load()]).finally(() => {
     router.sync();
   });

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -72,7 +72,7 @@ export default function RootThread(
     }
 
     let threadFilterFn;
-    if (state.viewer.isSidebar && !shouldFilterThread()) {
+    if (state.route.name === 'sidebar' && !shouldFilterThread()) {
       threadFilterFn = function(thread) {
         if (!thread.annotation) {
           return false;

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -1,0 +1,85 @@
+import * as queryString from 'query-string';
+
+/**
+ * A service that manages the association between the route and route parameters
+ * implied by the URL and the corresponding route state in the store.
+ */
+// @ngInject
+export default function router($window, store) {
+  /**
+   * Return the name and parameters of the current route.
+   */
+  function currentRoute() {
+    const path = $window.location.pathname;
+    const pathSegments = path.slice(1).split('/');
+    const params = queryString.parse($window.location.search);
+
+    let route;
+    if (pathSegments[0] === 'a') {
+      route = 'annotation';
+      params.id = pathSegments[1] || '';
+    } else if (pathSegments[0] === 'stream') {
+      route = 'stream';
+    } else {
+      route = 'sidebar';
+    }
+
+    return { route, params };
+  }
+
+  /**
+   * Generate a URL for a given route.
+   */
+  function routeUrl(name, params = {}) {
+    let url;
+    const queryParams = { ...params };
+
+    if (name === 'annotation') {
+      const id = params.id;
+      delete queryParams.id;
+
+      url = `/a/${id}`;
+    } else if (name === 'stream') {
+      url = '/stream';
+    } else {
+      throw new Error(`Cannot generate URL for route "${name}"`);
+    }
+
+    const query = queryString.stringify(queryParams);
+    if (query.length > 0) {
+      url += '?' + query;
+    }
+
+    return url;
+  }
+
+  /**
+   * Synchronize the route name and parameters in the store with the current
+   * URL.
+   */
+  function sync() {
+    const { route, params } = currentRoute();
+    store.changeRoute(route, params);
+  }
+
+  /**
+   * Navigate to a given route.
+   *
+   * @param {string} name
+   * @param {Object} params
+   */
+  function navigate(name, params) {
+    $window.history.pushState({}, '', routeUrl(name, params));
+    sync();
+  }
+
+  // Handle back/forward navigation.
+  $window.addEventListener('popstate', () => {
+    // All the state we need to update the route is contained in the URL, which
+    // has already been updated at this point, so just sync the store route
+    // to match the URL.
+    sync();
+  });
+
+  return { sync, navigate };
+}

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -15,13 +15,17 @@ export default function router($window, store) {
     const params = queryString.parse($window.location.search);
 
     let route;
-    if (pathSegments[0] === 'a') {
-      route = 'annotation';
-      params.id = pathSegments[1] || '';
-    } else if (pathSegments[0] === 'stream') {
-      route = 'stream';
-    } else {
-      route = 'sidebar';
+    switch (pathSegments[0]) {
+      case 'a':
+        route = 'annotation';
+        params.id = pathSegments[1] || '';
+        break;
+      case 'stream':
+        route = 'stream';
+        break;
+      default:
+        route = 'sidebar';
+        break;
     }
 
     return { route, params };
@@ -34,15 +38,19 @@ export default function router($window, store) {
     let url;
     const queryParams = { ...params };
 
-    if (name === 'annotation') {
-      const id = params.id;
-      delete queryParams.id;
-
-      url = `/a/${id}`;
-    } else if (name === 'stream') {
-      url = '/stream';
-    } else {
-      throw new Error(`Cannot generate URL for route "${name}"`);
+    switch (name) {
+      case 'annotation':
+        {
+          const id = params.id;
+          delete queryParams.id;
+          url = `/a/${id}`;
+        }
+        break;
+      case 'stream':
+        url = '/stream';
+        break;
+      default:
+        throw new Error(`Cannot generate URL for route "${name}"`);
     }
 
     const query = queryString.stringify(queryParams);

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -74,8 +74,8 @@ export default function router($window, store) {
     const { route, params } = currentRoute();
     store.changeRoute(route, params);
 
-    // Setup listener for back/forward navigation. We do this in `sync()` to avoid
-    // the route being changed by eg. a "popstate" emitted by the browser on
+    // Set up listener for back/forward navigation. We do this in `sync()` to
+    // avoid the route being changed by a "popstate" emitted by the browser on
     // document load (which Safari and Chrome do).
     if (!didRegisterPopstateListener) {
       $window.addEventListener('popstate', () => {

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -61,13 +61,31 @@ export default function router($window, store) {
     return url;
   }
 
+  let didRegisterPopstateListener = false;
+
   /**
    * Synchronize the route name and parameters in the store with the current
    * URL.
+   *
+   * The first call to this method also registers a listener for future back/forwards
+   * navigation in the browser.
    */
   function sync() {
     const { route, params } = currentRoute();
     store.changeRoute(route, params);
+
+    // Setup listener for back/forward navigation. We do this in `sync()` to avoid
+    // the route being changed by eg. a "popstate" emitted by the browser on
+    // document load (which Safari and Chrome do).
+    if (!didRegisterPopstateListener) {
+      $window.addEventListener('popstate', () => {
+        // All the state we need to update the route is contained in the URL, which
+        // has already been updated at this point, so just sync the store route
+        // to match the URL.
+        sync();
+      });
+      didRegisterPopstateListener = true;
+    }
   }
 
   /**
@@ -80,14 +98,6 @@ export default function router($window, store) {
     $window.history.pushState({}, '', routeUrl(name, params));
     sync();
   }
-
-  // Handle back/forward navigation.
-  $window.addEventListener('popstate', () => {
-    // All the state we need to update the route is contained in the URL, which
-    // has already been updated at this point, so just sync the store route
-    // to match the URL.
-    sync();
-  });
 
   return { sync, navigate };
 }

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -52,7 +52,7 @@ export default function Streamer(
         break;
     }
 
-    if (!store.isSidebar()) {
+    if (store.route() !== 'sidebar') {
       applyPendingUpdates();
     }
   }

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -41,7 +41,6 @@ describe('rootThread', function() {
           annotations: [],
         },
         viewer: {
-          isSidebar: true,
           visibleHighlights: false,
         },
         drafts: [],
@@ -54,6 +53,10 @@ describe('rootThread', function() {
           selectedAnnotationMap: null,
           sortKey: 'Location',
           sortKeysAvailable: ['Location'],
+        },
+        route: {
+          name: 'sidebar',
+          params: {},
         },
       },
       getState: function() {
@@ -294,7 +297,7 @@ describe('rootThread', function() {
 
     it('does not filter annotations when not in the sidebar', function() {
       fakeBuildThread.reset();
-      fakeStore.state.viewer.isSidebar = false;
+      fakeStore.state.route.name = 'stream';
 
       rootThread.thread(fakeStore.state);
       const threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;

--- a/src/sidebar/services/test/router-test.js
+++ b/src/sidebar/services/test/router-test.js
@@ -1,0 +1,113 @@
+import EventEmitter from 'tiny-emitter';
+import router from '../router';
+
+const fixtures = [
+  {
+    path: '/app.html',
+    route: 'sidebar',
+    params: {},
+  },
+  {
+    path: '/a/foo',
+    route: 'annotation',
+    params: { id: 'foo' },
+  },
+  {
+    path: '/stream',
+    search: 'q=foobar',
+    route: 'stream',
+    params: { q: 'foobar' },
+  },
+];
+
+describe('router', () => {
+  let fakeWindow;
+  let fakeStore;
+
+  function createService() {
+    return router(fakeWindow, fakeStore);
+  }
+
+  function updateUrl(path, search) {
+    fakeWindow.location.pathname = path;
+    fakeWindow.location.search = search;
+  }
+
+  beforeEach(() => {
+    const emitter = new EventEmitter();
+    fakeWindow = {
+      location: {
+        pathname: '',
+        search: '',
+      },
+      history: {
+        pushState: sinon.stub(),
+      },
+      addEventListener: emitter.on.bind(emitter),
+      emit: emitter.emit.bind(emitter),
+    };
+    fakeStore = {
+      changeRoute: sinon.stub(),
+    };
+  });
+
+  describe('#sync', () => {
+    fixtures.forEach(({ path, search, route, params }) => {
+      it('updates the active route in the store', () => {
+        updateUrl(path, search);
+
+        const svc = createService();
+        svc.sync();
+
+        assert.calledWith(fakeStore.changeRoute, route, params);
+      });
+    });
+  });
+
+  describe('#navigate', () => {
+    fixtures.forEach(({ path, search, route, params }) => {
+      if (route === 'sidebar') {
+        // You can't navigate _to_ the sidebar from another route.
+        return;
+      }
+
+      it('updates the URL', () => {
+        const svc = createService();
+
+        svc.navigate(route, params);
+
+        const expectedUrl = path + (search ? `?${search}` : '');
+        assert.calledWith(fakeWindow.history.pushState, {}, '', expectedUrl);
+      });
+    });
+
+    it('throws an error if route does not have a fixed URL', () => {
+      const svc = createService();
+      assert.throws(() => {
+        svc.navigate('sidebar');
+      }, 'Cannot generate URL for route "sidebar"');
+    });
+
+    it('updates the active route in the store', () => {
+      const svc = createService();
+
+      updateUrl('/stream', 'q=foobar');
+      svc.navigate('stream', { q: 'foobar' });
+
+      assert.calledWith(fakeStore.changeRoute, 'stream', { q: 'foobar' });
+    });
+  });
+
+  context('when a browser history navigation happens', () => {
+    fixtures.forEach(({ path, search, route, params }) => {
+      it('updates the active route in the store', () => {
+        createService();
+
+        updateUrl(path, search);
+        fakeWindow.emit('popstate');
+
+        assert.calledWith(fakeStore.changeRoute, route, params);
+      });
+    });
+  });
+});

--- a/src/sidebar/services/test/router-test.js
+++ b/src/sidebar/services/test/router-test.js
@@ -101,13 +101,27 @@ describe('router', () => {
   context('when a browser history navigation happens', () => {
     fixtures.forEach(({ path, search, route, params }) => {
       it('updates the active route in the store', () => {
-        createService();
+        const svc = createService();
+        svc.sync();
+        fakeStore.changeRoute.resetHistory();
 
         updateUrl(path, search);
         fakeWindow.emit('popstate');
 
         assert.calledWith(fakeStore.changeRoute, route, params);
       });
+    });
+
+    it('does nothing if the initial call to `sync()` has not happened', () => {
+      createService();
+
+      // Simulate a "popstate" event being triggered by the browser before
+      // the app is ready to initialize the router by calling `sync()`.
+      //
+      // Safari and Chrome do this when the page loads. Firefox does not.
+      fakeWindow.emit('popstate');
+
+      assert.notCalled(fakeStore.changeRoute);
     });
   });
 });

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -123,11 +123,11 @@ describe('Streamer', function() {
           userid: 'jim@hypothes.is',
         },
       }),
-      isSidebar: sinon.stub().returns(true),
       pendingUpdates: sinon.stub().returns({}),
       pendingDeletions: sinon.stub().returns({}),
       receiveRealTimeUpdates: sinon.stub(),
       removeAnnotations: sinon.stub(),
+      route: sinon.stub().returns('sidebar'),
     };
 
     fakeGroups = {
@@ -275,7 +275,7 @@ describe('Streamer', function() {
 
     context('when the app is the stream', function() {
       beforeEach(function() {
-        fakeStore.isSidebar.returns(false);
+        fakeStore.route.returns('stream');
       });
 
       it('applies updates immediately', function() {

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -40,6 +40,7 @@ import frames from './modules/frames';
 import groups from './modules/groups';
 import links from './modules/links';
 import realTimeUpdates from './modules/real-time-updates';
+import route from './modules/route';
 import selection from './modules/selection';
 import session from './modules/session';
 import sidebarPanels from './modules/sidebar-panels';
@@ -95,6 +96,7 @@ export default function store($rootScope, settings) {
     links,
     groups,
     realTimeUpdates,
+    route,
     selection,
     session,
     sidebarPanels,

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -9,6 +9,8 @@ import * as metadata from '../../util/annotation-metadata';
 import * as arrayUtil from '../../util/array';
 import * as util from '../util';
 
+import route from './route';
+
 /**
  * Return a copy of `current` with all matching annotations in `annotations`
  * removed.
@@ -241,7 +243,7 @@ function addAnnotations(annotations) {
     // If we're not in the sidebar, we're done here.
     // FIXME Split the annotation-adding from the anchoring code; possibly
     // move into service
-    if (!getState().viewer.isSidebar) {
+    if (route.selectors.route(getState()) !== 'sidebar') {
       return;
     }
 

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -9,7 +9,7 @@ import { actionTypes } from '../util';
 
 import annotations from './annotations';
 import groups from './groups';
-import viewer from './viewer';
+import route from './route';
 
 function init() {
   return {
@@ -96,7 +96,7 @@ function receiveRealTimeUpdates({
       // when switching groups.
       if (
         ann.group === groups.selectors.focusedGroupId(getState()) ||
-        !viewer.selectors.isSidebar(getState())
+        route.selectors.route(getState()) !== 'sidebar'
       ) {
         pendingUpdates[ann.id] = ann;
       }

--- a/src/sidebar/store/modules/route.js
+++ b/src/sidebar/store/modules/route.js
@@ -1,0 +1,70 @@
+import { actionTypes } from '../util';
+
+function init() {
+  return {
+    /**
+     * The current route.
+     * One of null (if no route active yet), "sidebar", "annotation" or "stream".
+     */
+    name: null,
+
+    /**
+     * Parameters of the current route.
+     *
+     * - The "annotation" route has an "id" (annotation ID) parameter.
+     * - The "stream" route has a "q" (query) parameter.
+     * - The "sidebar" route has no parameters.
+     */
+    params: {},
+  };
+}
+
+const update = {
+  CHANGE_ROUTE(state, { name, params }) {
+    return { name, params };
+  },
+};
+
+const actions = actionTypes(update);
+
+/**
+ * Change the active route.
+ *
+ * @param {string} name - Name of the route to activate. See `init` for possible values
+ * @param {Object} params - Parameters associated with the route
+ */
+function changeRoute(name, params = {}) {
+  return {
+    type: actions.CHANGE_ROUTE,
+    name,
+    params,
+  };
+}
+
+/**
+ * Return the name of the current route.
+ */
+function route(state) {
+  return state.route.name;
+}
+
+/**
+ * Return any parameters for the current route, extracted from the path and
+ * query string.
+ */
+function routeParams(state) {
+  return state.route.params;
+}
+
+export default {
+  init,
+  namespace: 'route',
+  update,
+  actions: {
+    changeRoute,
+  },
+  selectors: {
+    route,
+    routeParams,
+  },
+};

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -2,12 +2,12 @@ import * as fixtures from '../../../test/annotation-fixtures';
 import * as metadata from '../../../util/annotation-metadata';
 import createStore from '../../create-store';
 import annotations from '../annotations';
-import viewer from '../viewer';
+import route from '../route';
 
 const { actions, selectors } = annotations;
 
 function createTestStore() {
-  return createStore([annotations, viewer], [{}]);
+  return createStore([annotations, route], [{}]);
 }
 
 // Tests for most of the functionality in reducers/annotations.js are currently
@@ -30,6 +30,7 @@ describe('sidebar/store/modules/annotations', function() {
     beforeEach(function() {
       clock = sinon.useFakeTimers();
       store = createTestStore();
+      store.changeRoute('sidebar', {});
     });
 
     afterEach(function() {
@@ -134,7 +135,7 @@ describe('sidebar/store/modules/annotations', function() {
       };
 
       const annot = fixtures.defaultAnnotation();
-      store.setAppIsSidebar(false);
+      store.changeRoute('stream', { q: 'a-query' });
       store.addAnnotations([annot]);
 
       clock.tick(ANCHOR_TIME_LIMIT);

--- a/src/sidebar/store/modules/test/real-time-updates-test.js
+++ b/src/sidebar/store/modules/test/real-time-updates-test.js
@@ -11,14 +11,14 @@ const { focusGroup } = groups.actions;
 describe('sidebar/store/modules/real-time-updates', () => {
   let fakeAnnotationExists;
   let fakeFocusedGroupId;
-  let fakeIsSidebar;
+  let fakeRoute;
   let fakeSettings = {};
   let store;
 
   beforeEach(() => {
     fakeAnnotationExists = sinon.stub().returns(true);
     fakeFocusedGroupId = sinon.stub().returns('group-1');
-    fakeIsSidebar = sinon.stub().returns(true);
+    fakeRoute = sinon.stub().returns('sidebar');
 
     store = createStore(
       [realTimeUpdates, annotations, selection],
@@ -36,9 +36,9 @@ describe('sidebar/store/modules/real-time-updates', () => {
           selectors: { focusedGroupId: fakeFocusedGroupId },
         },
       },
-      './viewer': {
+      './route': {
         default: {
-          selectors: { isSidebar: fakeIsSidebar },
+          selectors: { route: fakeRoute },
         },
       },
     });
@@ -84,7 +84,7 @@ describe('sidebar/store/modules/real-time-updates', () => {
 
     it('always adds pending updates in the stream where there is no focused group', () => {
       fakeFocusedGroupId.returns(null);
-      fakeIsSidebar.returns(false);
+      fakeRoute.returns('stream');
 
       addPendingUpdates(store);
 

--- a/src/sidebar/store/modules/test/viewer-test.js
+++ b/src/sidebar/store/modules/test/viewer-test.js
@@ -7,17 +7,8 @@ describe('store/modules/viewer', function() {
   beforeEach(() => {
     store = createStore([viewer]);
   });
-  describe('#setAppIsSidebar', function() {
-    it('sets a flag indicating that the app is not the sidebar', function() {
-      store.setAppIsSidebar(false);
-      assert.isFalse(store.isSidebar());
-    });
 
-    it('sets a flag indicating that the app is the sidebar', function() {
-      store.setAppIsSidebar(true);
-      assert.isTrue(store.isSidebar());
-    });
-
+  describe('#setShowHighlights', function() {
     it('sets a flag indicating that highlights are visible', function() {
       store.setShowHighlights(true);
       assert.isTrue(store.getState().viewer.visibleHighlights);

--- a/src/sidebar/store/modules/viewer.js
+++ b/src/sidebar/store/modules/viewer.js
@@ -7,32 +7,17 @@ import * as util from '../util';
 
 function init() {
   return {
-    // Flag that indicates whether the app is the sidebar and connected to
-    // a page where annotations are being shown in context.
-    //
-    // Note that this flag is not available early in the lifecycle of the
-    // application.
-    isSidebar: true,
-
     visibleHighlights: false,
   };
 }
 
 const update = {
-  SET_SIDEBAR: function(state, action) {
-    return { isSidebar: action.isSidebar };
-  },
   SET_HIGHLIGHTS_VISIBLE: function(state, action) {
     return { visibleHighlights: action.visible };
   },
 };
 
 const actions = util.actionTypes(update);
-
-/** Set whether the app is the sidebar */
-function setAppIsSidebar(isSidebar) {
-  return { type: actions.SET_SIDEBAR, isSidebar: isSidebar };
-}
 
 /**
  * Sets whether annotation highlights in connected documents are shown
@@ -42,24 +27,12 @@ function setShowHighlights(show) {
   return { type: actions.SET_HIGHLIGHTS_VISIBLE, visible: show };
 }
 
-/**
- * Returns true if the app is being used as the sidebar in the annotation
- * client, as opposed to the standalone annotation page or stream views.
- */
-function isSidebar(state) {
-  return state.viewer.isSidebar;
-}
-
 export default {
   init: init,
   namespace: 'viewer',
   update: update,
   actions: {
-    setAppIsSidebar: setAppIsSidebar,
     setShowHighlights: setShowHighlights,
   },
-
-  selectors: {
-    isSidebar,
-  },
+  selectors: {},
 };

--- a/src/sidebar/templates/hypothesis-app.html
+++ b/src/sidebar/templates/hypothesis-app.html
@@ -10,6 +10,15 @@
   <div class="content">
     <help-panel auth="vm.auth"></help-panel>
     <share-annotations-panel></share-annotations-panel>
-    <main ng-view=""></main>
+
+    <main ng-if="vm.route()">
+      <annotation-viewer-content ng-if="vm.route() == 'annotation'"></annotation-viewer-content>
+      <stream-content ng-if="vm.route() == 'stream'"></stream-content>
+      <sidebar-content
+        ng-if="vm.route() == 'sidebar'"
+        auth="vm.auth"
+        on-login="vm.login()"
+        on-sign-up="vm.signUp()"></sidebar-content>
+    </main>
   </div>
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,11 +1140,6 @@ angular-mocks@^1.7.5:
   resolved "https://registry.yarnpkg.com/angular-mocks/-/angular-mocks-1.7.9.tgz#0a3b7e28b9a493b4e3010ed2b0f69a68e9b4f79b"
   integrity sha512-LQRqqiV3sZ7NTHBnNmLT0bXtE5e81t97+hkJ56oU0k3dqKv1s6F+nBWRlOVzqHWPGFOiPS8ZJVdrS8DFzHyNIA==
 
-angular-route@^1.7.5:
-  version "1.7.9"
-  resolved "https://registry.yarnpkg.com/angular-route/-/angular-route-1.7.9.tgz#f9910a2af0ba3ad7a969c5dd369b8360d0d5e4ef"
-  integrity sha512-vRoj5hzdQtWbODhWJqDzD1iNOEfCKshO6GFBuPVV7RHlPjzIc4R2dHCc7Qiv/8F3LDxJDohc6vSnTDMLHuaqeA==
-
 angular-toastr@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/angular-toastr/-/angular-toastr-2.1.1.tgz#9f8350ca482145a44d011a755b8fb3623d60544c"


### PR DESCRIPTION
Implement a replacement for the Angular JS router which will enable the
root components of the app to be more easily migrated to Preact in future.
Since the app only has three routes with very simple parameters, we
don't yet need a fully-fledged router implementation but can get by with
some pretty basic URL parsing.

 - Introduce a store module which holds the currently active route
   (`null`, "sidebar", "annotation" or "stream") and any parameters of
   that route.

   This state replaces the `isSidebar` boolean in the `viewer` module,
   since whether the app is the sidebar can be determined by checking
   the active route name.

 - Add a `router` service which handles synchronizing the store route
   with the current URL (via the `sync` method or in response to a
   `popstate` DOM event) or updating the URL and active route in the
   store (via the `navigate` method).

 - Modify the `<hypothesis-app>` component to fetch the active route
   from the store and use it to conditionally render the appropriate
   content component. This replaces the Angular router configuration
   that used to be in `src/sidebar/index.js`

 - Change the places that used to read or update the current route to
   read the active route and route params from the store (`store.{route,
   routeParams}`) and switch the current route by using the `router` service
   (`router.navigate`)

 - Remove the unused angular-route package

Fixes #1878

----

**Testing**

1. Check that the sidebar loads as before on a page with the client embedded
2. Check that links to the HTML page for a single annotation (the timestamps on annotation cards) still work.
3. Check that entering a search query on the single annotation page and pressing Enter navigates to `/stream?q=<query>` and updates the content accordingly
4. Check that http://localhost:5000/stream works (this view has many problems, but check that it at least does the same as before) and that it updates when changing the search query and pressing Enter
5. Check that the content and URL update when pressing the Back/Forward buttons after a navigation in steps 3/4