### PR TITLE
Revert "Remove unused `permissions` service"

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -181,6 +181,7 @@ import frameSyncService from './services/frame-sync';
 import groupsService from './services/groups';
 import loadAnnotationsService from './services/load-annotations';
 import localStorageService from './services/local-storage';
+import permissionsService from './services/permissions';
 import persistedDefaultsService from './services/persisted-defaults';
 import rootThreadService from './services/root-thread';
 import searchFilterService from './services/search-filter';
@@ -223,6 +224,7 @@ function startAngularApp(config) {
     .register('groups', groupsService)
     .register('loadAnnotationsService', loadAnnotationsService)
     .register('localStorage', localStorageService)
+    .register('permissions', permissionsService)
     .register('persistedDefaults', persistedDefaultsService)
     .register('rootThread', rootThreadService)
     .register('searchFilter', searchFilterService)
@@ -310,6 +312,7 @@ function startAngularApp(config) {
     .service('loadAnnotationsService', () =>
       container.get('loadAnnotationsService')
     )
+    .service('permissions', () => container.get('permissions'))
     .service('persistedDefaults', () => container.get('persistedDefaults'))
     .service('rootThread', () => container.get('rootThread'))
     .service('searchFilter', () => container.get('searchFilter'))

--- a/src/sidebar/services/permissions.js
+++ b/src/sidebar/services/permissions.js
@@ -1,0 +1,91 @@
+/**
+ * Object defining which principals can read, update and delete an annotation.
+ *
+ * This is the same as the `permissions` field retrieved on an annotation via
+ * the API.
+ *
+ * Principals are strings of the form `type:id` where `type` is `'acct'` (for a
+ * specific user) or `'group'` (for a group).
+ *
+ * @typedef Permissions
+ * @property {string[]} read - List of principals that can read the annotation
+ * @property {string[]} update - List of principals that can edit the annotation
+ * @property {string[]} delete - List of principals that can delete the
+ * annotation
+ */
+
+/**
+ * A service for generating and querying `Permissions` objects for annotations.
+ *
+ * It also provides methods to save and restore permissions preferences for new
+ * annotations to local storage.
+ */
+// @ngInject
+export default function Permissions(store) {
+  const self = this;
+
+  /**
+   * Return the permissions for a private annotation.
+   *
+   * A private annotation is one which is readable only by its author.
+   *
+   * @param {string} userid - User ID of the author
+   * @return {Permissions}
+   */
+  this.private = function(userid) {
+    return {
+      read: [userid],
+      update: [userid],
+      delete: [userid],
+    };
+  };
+
+  /**
+   * Return the permissions for an annotation that is shared with the given
+   * group.
+   *
+   * @param {string} userid - User ID of the author
+   * @param {string} groupId - ID of the group the annotation is being
+   * shared with
+   * @return {Permissions}
+   */
+  this.shared = function(userid, groupId) {
+    return Object.assign(self.private(userid), {
+      read: ['group:' + groupId],
+    });
+  };
+
+  /**
+   * Set the default permissions for new annotations.
+   *
+   * @param {'private'|'shared'} level
+   */
+  this.setDefault = function(level) {
+    store.setDefault('annotationPrivacy', level);
+  };
+
+  /**
+   * Return true if an annotation with the given permissions is shared with any
+   * group.
+   *
+   * @param {Permissions} perms
+   * @return {boolean}
+   */
+  this.isShared = function(perms) {
+    return perms.read.some(function(principal) {
+      return principal.indexOf('group:') === 0;
+    });
+  };
+
+  /**
+   * Return true if a user can perform the given `action` on an annotation.
+   *
+   * @param {Permissions} perms
+   * @param {'update'|'delete'} action
+   * @param {string} userid
+   * @return {boolean}
+   */
+  this.permits = function(perms, action, userid) {
+    return perms[action].indexOf(userid) !== -1;
+  };
+}

--- a/src/sidebar/services/test/permissions-test.js
+++ b/src/sidebar/services/test/permissions-test.js
@@ -1,0 +1,69 @@
+import Permissions from '../permissions';
+
+const userid = 'acct:flash@gord.on';
+
+describe('permissions', function() {
+  let fakeStore;
+  let permissions;
+
+  beforeEach(function() {
+    fakeStore = {
+      getDefault: sinon.stub().returns(null),
+      setDefault: sinon.stub(),
+    };
+    permissions = new Permissions(fakeStore);
+  });
+
+  describe('#private', function() {
+    it('only allows the user to read the annotation', function() {
+      assert.deepEqual(permissions.private(userid), {
+        read: [userid],
+        update: [userid],
+        delete: [userid],
+      });
+    });
+  });
+
+  describe('#shared', function() {
+    it('allows the group to read the annotation', function() {
+      assert.deepEqual(permissions.shared(userid, 'gid'), {
+        read: ['group:gid'],
+        update: [userid],
+        delete: [userid],
+      });
+    });
+  });
+
+  describe('#setDefault', function() {
+    it('saves the default permissions in the store', function() {
+      permissions.setDefault('private');
+      assert.calledWith(fakeStore.setDefault, 'annotationPrivacy', 'private');
+    });
+  });
+
+  describe('#isShared', function() {
+    it('returns true if a group can read the annotation', function() {
+      const perms = permissions.shared(userid, 'gid');
+      assert.isTrue(permissions.isShared(perms));
+    });
+
+    it('returns false if only specific users can read the annotation', function() {
+      const perms = permissions.private(userid);
+      assert.isFalse(permissions.isShared(perms));
+    });
+  });
+
+  describe('#permits', function() {
+    it('returns true if the user can perform the action', function() {
+      const perms = permissions.private(userid);
+      assert.isTrue(permissions.permits(perms, 'update', userid));
+      assert.isTrue(permissions.permits(perms, 'delete', userid));
+    });
+
+    it('returns false if the user cannot perform the action', function() {
+      const perms = permissions.private('acct:not.flash@gord.on');
+      assert.isFalse(permissions.permits(perms, 'update', userid));
+      assert.isFalse(permissions.permits(perms, 'delete', userid));
+    });
+  });
+});


### PR DESCRIPTION
Reverts hypothesis/client#1903

This set of changes is causing console errors on QA and and needs to be re-reviewed.