### PR TITLE
Add keyboard navigation to MarkdownEditor to improve a11y

### DIFF
--- a/src/styles/sidebar/components/markdown-editor.scss
+++ b/src/styles/sidebar/components/markdown-editor.scss
@@ -1,3 +1,4 @@
+@use "../../mixins/buttons";
 @use "../../mixins/forms";
 @use "../../variables" as var;
 
@@ -21,12 +22,11 @@ $toolbar-border: 0.1em solid var.$grey-3;
 }
 
 .markdown-editor__toolbar-button {
+  @include buttons.reset-native-btn-styles;
   display: flex;
   justify-content: center;
   align-items: center;
   appearance: none;
-  border: none;
-  background: none;
   min-width: 24px;
   min-height: 24px;
 


### PR DESCRIPTION
- `arrow left`, `arrow right`, `home` and `end` keys are all supported and modeled after https://www.w3.org/TR/wai-aria-practices/examples/toolbar/toolbar.html

- Add roving tabIndex value for all toolbar elements.

![mark](https://user-images.githubusercontent.com/3939074/76692776-3acd4200-6618-11ea-850e-e020f36e5eaf.gif)

fixes: https://github.com/hypothesis/client/issues/1854