### PR TITLE
Remove some unused CSS classes and separate `annotation` styling

### DIFF
--- a/src/sidebar/components/annotation-omega.js
+++ b/src/sidebar/components/annotation-omega.js
@@ -94,7 +94,7 @@ function AnnotationOmega({
     /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
     <div
       className={classnames('annotation-omega', {
-        'annotation--reply': isReply(annotation),
+        'annotation-omega--reply': isReply(annotation),
         'is-collapsed': threadIsCollapsed,
       })}
       onKeyDown={onKeyDown}
@@ -116,8 +116,8 @@ function AnnotationOmega({
       />
       {isEditing && <TagEditor onEditTags={onEditTags} tagList={tags} />}
       {!isEditing && <TagList annotation={annotation} tags={tags} />}
-      <footer className="annotation-footer">
-        <div className="annotation-form-actions">
+      <footer className="annotation-omega__footer">
+        <div className="annotation-omega__form-actions">
           {isEditing && (
             <AnnotationPublishControl
               annotation={annotation}

--- a/src/sidebar/components/test/annotation-omega-test.js
+++ b/src/sidebar/components/test/annotation-omega-test.js
@@ -100,7 +100,7 @@ describe('AnnotationOmega', () => {
       const wrapper = createComponent({ threadIsCollapsed: false });
       const annot = wrapper.find('.annotation-omega');
 
-      assert.isTrue(annot.hasClass('annotation--reply'));
+      assert.isTrue(annot.hasClass('annotation-omega--reply'));
       assert.isFalse(annot.hasClass('is-collapsed'));
     });
 

--- a/src/styles/sidebar/components/annotation-license.scss
+++ b/src/styles/sidebar/components/annotation-license.scss
@@ -3,7 +3,8 @@
 .annotation-license {
   @include var.font-small;
   border-top: 1px solid var.$grey-3;
-  padding-top: 0.75em;
+  padding-top: 0.5em;
+  margin: 0.5em 0;
 
   &__link {
     display: flex;

--- a/src/styles/sidebar/components/annotation-omega.scss
+++ b/src/styles/sidebar/components/annotation-omega.scss
@@ -1,3 +1,5 @@
+@use "../../variables" as var;
+
 .annotation-omega {
   &__reply-toggle.button {
     background-color: transparent;
@@ -16,5 +18,52 @@
 
   &__actions {
     margin-left: auto;
+  }
+
+  &__form-actions {
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 10px;
+  }
+
+  &__footer {
+    @include var.font-normal;
+    color: var.$grey-5;
+    margin-top: var.$layout-h-margin;
+  }
+
+  &--reply &__footer {
+    margin-top: var.$layout-h-margin - 8px;
+  }
+}
+
+// FIXME vertical rhythm here should be refactored
+.annotation-omega--reply {
+  .annotation-header {
+    // Margin between bottom of ascent of annotation card footer labels
+    // and top of ascent of username should be ~20px
+    margin-top: 0px;
+  }
+
+  .annotation-body {
+    // Margin between top of ascent of annotation body and
+    // bottom of ascent of username should be ~15px
+    margin-top: var.$layout-h-margin - 8px;
+    // Margin between bottom of ascent of annotation body and
+    // top of annotation footer labels should be ~15px
+    margin-bottom: var.$layout-h-margin - 3px;
+  }
+}
+
+.annotation-omega--reply.is-collapsed {
+  margin-bottom: 0;
+
+  .annotation-header {
+    margin: 0;
+  }
+
+  .annotation-body,
+  .annotation-footer {
+    display: none;
   }
 }

--- a/src/styles/sidebar/components/annotation.scss
+++ b/src/styles/sidebar/components/annotation.scss
@@ -17,24 +17,6 @@
   .annotation-action-btn {
     color: var.$grey-6;
   }
-
-  .annotation-header__timestamp-link {
-    color: var.$grey-5;
-  }
-}
-
-.annotation {
-  display: block;
-  font-family: var.$sans-font-family;
-  position: relative;
-}
-
-.annotation.is-dimmed {
-  // Lighten the bodies of dimmed annotations to make other
-  // annotations which are not dimmed stand out
-  .annotation-body {
-    color: var.$grey-5;
-  }
 }
 
 .annotation.is-highlighted {
@@ -46,19 +28,12 @@
   }
 }
 
-.annotation-link-more {
-  display: flex;
-  flex-flow: row-reverse;
-}
-
-.annotation-link {
-  @include var.font-small;
-  color: var.$grey-4;
-  // Decrease the margin between the more/less link
-  // and the annotation body.
-  margin-top: -1em;
-  padding-bottom: 0.5em;
-  padding-top: 0.5em;
+.annotation.is-dimmed {
+  // Lighten the bodies of dimmed annotations to make other
+  // annotations which are not dimmed stand out
+  .annotation-body {
+    color: var.$grey-5;
+  }
 }
 
 .annotation-replies:hover {
@@ -69,18 +44,9 @@
 
 .annotation-footer {
   @include forms.pie-clearfix;
-}
-
-// the footer at the bottom of an annotation displaying
-// the annotation actions and reply counts
-.annotation-footer {
   @include var.font-normal;
   color: var.$grey-5;
   margin-top: var.$layout-h-margin;
-}
-
-.u-flex-spacer {
-  flex-grow: 1;
 }
 
 .annotation-media-embed {
@@ -105,22 +71,6 @@
   display: flex;
 }
 
-.annotation-action-btn {
-  color: var.$grey-5;
-  font-weight: normal;
-  padding: 0;
-  margin: 0px 0px 0px 12px;
-
-  &[disabled] {
-    opacity: 0.2;
-  }
-}
-
-.annotation-citation-domain {
-  color: var.$grey-semi;
-  font-size: var.$body1-font-size;
-}
-
 .annotation-collapsed-replies {
   display: none;
 }
@@ -143,10 +93,6 @@
   }
 }
 
-.annotation-share-dialog-wrapper {
-  position: relative;
-}
-
 // the actions for publishing annotations and reverting changes
 // at the bottom of an annotation card
 .annotation-form-actions {
@@ -157,10 +103,6 @@
 
 // Style adjustments for annotation cards that are replies
 .annotation--reply {
-  .annotation-action-btn {
-    color: var.$grey-4;
-  }
-
   .annotation-footer {
     // Margin between bottom of ascent of annotation body and
     // top of annotation footer should be ~15px
@@ -181,9 +123,4 @@
     // top of annotation footer labels should be ~15px
     margin-bottom: var.$layout-h-margin - 3px;
   }
-}
-
-.annotation--flagged {
-  color: var.$brand;
-  cursor: default;
 }


### PR DESCRIPTION
I started trying to accomplish https://github.com/hypothesis/client/issues/1921 and ran into some extra noise in the (S)CSS for the legacy annotation component. These changes are aimed at making it easier to fix #1921 and to make it easier to see what CSS needs to be retained (though likely refactored in part) for `AnnotationOmega` (which will ultimately be renamed to `Annotation` once the old `Annotation` goes away).

This PR does two major and one minor thing:

1. Removes unused CSS classes from the `annotation` SCSS. This shouldn't need much argument.
1. Makes the SCSS for `AnnotationOmega` wholly independent of `Annotation`. This helps us see what styling is left in the purview of the component (and help us to refactor what's left).
1. (Small thing) adjusts the annotation-license vertical layout 

That last thing was just a nit I noticed while I was cleaning things up (only affects `AnnotationOmega`) — vertical rhythm was too tight when there are replies to show and the annotation license is visible (O! The combination of states!).

Before:

<img width="432" alt="Screen Shot 2020-03-16 at 4 28 07 PM" src="https://user-images.githubusercontent.com/439947/76797168-50bb3e00-67a3-11ea-832b-dad2d43a3c0b.png">

After:

<img width="444" alt="Screen Shot 2020-03-16 at 4 28 25 PM" src="https://user-images.githubusercontent.com/439947/76797180-544ec500-67a3-11ea-9013-0d3388f808af.png">

As to satisfying #1921, it is likely easier to wait until after we've switched over to `AnnotationOmega` for everyone before trying to sort that out; otherwise we'll have to solve the problem twice over (once for both implementations of the component).

