### PR TITLE
Remove visible text that denotes when one has `AnnotationOmega` active

### DIFF
--- a/src/sidebar/templates/annotation-thread.html
+++ b/src/sidebar/templates/annotation-thread.html
@@ -14,7 +14,6 @@
       annotation="vm.thread.annotation"
       ng-if="vm.thread.annotation">
     </moderation-banner>
-    <div ng-if="vm.shouldShowAnnotationOmega()"><em>Viewing AnnotationOmega</em></div>
     <annotation-omega ng-if="vm.shouldShowAnnotationOmega() && vm.thread.annotation"
       annotation="vm.thread.annotation"
       reply-count="vm.thread.replyCount"


### PR DESCRIPTION
This will allow us to turn the feature flag on for more users.