### PR TITLE
Add button to adder toolbar to show annotations for selection

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -52,6 +52,14 @@ function nearestPositionedAncestor(el) {
 }
 
 /**
+ * @typedef AdderOptions
+ * @prop {() => any} onAnnotate - Callback invoked when "Annotate" button is clicked
+ * @prop {() => any} onHighlight - Callback invoked when "Highlight" button is clicked
+ * @prop {(annotations: Object[]) => any} onShowAnnotations -
+ *   Callback invoked when  "Show" button is clicked
+ */
+
+/**
  * Container for the 'adder' toolbar which provides controls for the user to
  * annotate and highlight the selected text.
  *
@@ -66,8 +74,8 @@ export class Adder {
    *
    * The adder is initially hidden.
    *
-   * @param {Element} container - The DOM element into which the adder will be created
-   * @param {Object} options - Options object specifying `onAnnotate` and `onHighlight`
+   * @param {HTMLElement} container - The DOM element into which the adder will be created
+   * @param {AdderOptions} options - Options object specifying `onAnnotate` and `onHighlight`
    *        event handlers.
    */
   constructor(container, options) {
@@ -98,6 +106,17 @@ export class Adder {
     this._arrowDirection = 'up';
     this._onAnnotate = options.onAnnotate;
     this._onHighlight = options.onHighlight;
+    this._onShowAnnotations = options.onShowAnnotations;
+
+    /**
+     * Annotation objects associated with the current selection. If non-empty,
+     * a "Show" button appears in the toolbar. Clicking the button calls the
+     * `onShowAnnotations` callback with the current value of `annotationsForSelection`.
+     *
+     * @type {Object[]}
+     */
+    this.annotationsForSelection = [];
+
     this._render();
   }
 
@@ -198,15 +217,18 @@ export class Adder {
       switch (command) {
         case 'annotate':
           this._onAnnotate();
+          this.hide();
           break;
         case 'highlight':
           this._onHighlight();
+          this.hide();
+          break;
+        case 'show':
+          this._onShowAnnotations(this.annotationsForSelection);
           break;
         default:
           break;
       }
-
-      this.hide();
     };
 
     render(
@@ -214,6 +236,7 @@ export class Adder {
         isVisible={this._isVisible}
         arrowDirection={this._arrowDirection}
         onCommand={handleCommand}
+        annotationCount={this.annotationsForSelection.length}
       />,
       this._shadowRoot
     );

--- a/src/annotator/components/adder-toolbar.js
+++ b/src/annotator/components/adder-toolbar.js
@@ -5,7 +5,7 @@ import propTypes from 'prop-types';
 import { useShortcut } from '../../shared/shortcut';
 import SvgIcon from '../../shared/components/svg-icon';
 
-function ToolbarButton({ icon, label, onClick, shortcut }) {
+function ToolbarButton({ badgeCount, icon, label, onClick, shortcut }) {
   useShortcut(shortcut, onClick);
 
   const title = shortcut ? `${label} (${shortcut})` : label;
@@ -16,14 +16,18 @@ function ToolbarButton({ icon, label, onClick, shortcut }) {
       onClick={onClick}
       title={title}
     >
-      <SvgIcon name={icon} />
+      {icon && <SvgIcon name={icon} />}
+      {typeof badgeCount === 'number' && (
+        <span className="annotator-adder-actions__badge">{badgeCount}</span>
+      )}
       <span className="annotator-adder-actions__label">{label}</span>
     </button>
   );
 }
 
 ToolbarButton.propTypes = {
-  icon: propTypes.string.isRequired,
+  badgeCount: propTypes.number,
+  icon: propTypes.string,
   label: propTypes.string.isRequired,
   onClick: propTypes.func.isRequired,
   shortcut: propTypes.string,
@@ -33,7 +37,12 @@ ToolbarButton.propTypes = {
  * The toolbar that is displayed above selected text in the document providing
  * options to create annotations or highlights.
  */
-export default function AdderToolbar({ arrowDirection, isVisible, onCommand }) {
+export default function AdderToolbar({
+  arrowDirection,
+  isVisible,
+  onCommand,
+  annotationCount = 0,
+}) {
   const handleCommand = (event, command) => {
     event.preventDefault();
     event.stopPropagation();
@@ -46,6 +55,7 @@ export default function AdderToolbar({ arrowDirection, isVisible, onCommand }) {
   // the shortcut. This avoids conflicts with browser/OS shortcuts.
   const annotateShortcut = isVisible ? 'a' : null;
   const highlightShortcut = isVisible ? 'h' : null;
+  const showShortcut = isVisible ? 's' : null;
 
   // nb. The adder is hidden using the `visibility` property rather than `display`
   // so that we can compute its size in order to position it before display.
@@ -71,6 +81,17 @@ export default function AdderToolbar({ arrowDirection, isVisible, onCommand }) {
           label="Highlight"
           shortcut={highlightShortcut}
         />
+        {annotationCount > 0 && (
+          <div className="annotator-adder-actions__separator" />
+        )}
+        {annotationCount > 0 && (
+          <ToolbarButton
+            badgeCount={annotationCount}
+            onClick={e => handleCommand(e, 'show')}
+            label="Show"
+            shortcut={showShortcut}
+          />
+        )}
       </hypothesis-adder-actions>
     </hypothesis-adder-toolbar>
   );
@@ -90,8 +111,16 @@ AdderToolbar.propTypes = {
   isVisible: propTypes.bool.isRequired,
 
   /**
-   * Callback invoked with the name ("annotate", "highlight") of the selected
-   * command when a toolbar command is clicked.
+   * Callback invoked with the name ("annotate", "highlight", "show") of the
+   * selected command when a toolbar command is clicked.
    */
   onCommand: propTypes.func.isRequired,
+
+  /**
+   * Number of annotations associated with the selected text.
+   *
+   * If non-zero, a "Show" button is displayed to allow the user to see the
+   * annotations that correspond to the selection.
+   */
+  annotationCount: propTypes.number,
 };

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -20,6 +20,11 @@ animationPromise = (fn) ->
       catch error
         reject(error)
 
+annotationsForSelection = () ->
+  selection = window.getSelection()
+  range = selection.getRangeAt(0)
+  return rangeUtil.itemsForRange(range, (node) -> $(node).data('annotation'))
+
 # A selector which matches elements added to the DOM by Hypothesis (eg. for
 # highlights and annotation UI).
 #
@@ -68,6 +73,8 @@ module.exports = class Guest extends Delegator
         self.setVisibleHighlights(true)
         self.createHighlight()
         document.getSelection().removeAllRanges()
+      onShowAnnotations: (anns) ->
+        self.selectAnnotations(anns)
     })
     this.selections = selections(document).subscribe
       next: (range) ->
@@ -425,6 +432,7 @@ module.exports = class Guest extends Delegator
       .addClass('h-icon-annotate');
 
     {left, top, arrowDirection} = this.adderCtrl.target(focusRect, isBackwards)
+    this.adderCtrl.annotationsForSelection = annotationsForSelection()
     this.adderCtrl.showAt(left, top, arrowDirection)
 
   _onClearSelection: () ->

--- a/src/annotator/range-util.js
+++ b/src/annotator/range-util.js
@@ -133,6 +133,9 @@ export function selectionFocusRect(selection) {
 /**
  * Retrieve a set of items associated with nodes in a given range.
  *
+ * An `item` can be any data that the caller wishes to compute from or associate
+ * with a node. Only unique items, as determined by `Object.is`, are returned.
+ *
  * @template T
  * @param {Range} range
  * @param {(n: Node) => T} itemForNode - Callback returning the item for a given node

--- a/src/annotator/range-util.js
+++ b/src/annotator/range-util.js
@@ -129,3 +129,35 @@ export function selectionFocusRect(selection) {
     return textBoxes[textBoxes.length - 1];
   }
 }
+
+/**
+ * Retrieve a set of items associated with nodes in a given range.
+ *
+ * @template T
+ * @param {Range} range
+ * @param {(n: Node) => T} itemForNode - Callback returning the item for a given node
+ * @return {T[]} items
+ */
+export function itemsForRange(range, itemForNode) {
+  const checkedNodes = new Set();
+  const items = new Set();
+
+  forEachNodeInRange(range, node => {
+    let current = node;
+    while (current) {
+      if (checkedNodes.has(current)) {
+        break;
+      }
+      checkedNodes.add(current);
+
+      const item = itemForNode(current);
+      if (item) {
+        items.add(item);
+      }
+
+      current = current.parentNode;
+    }
+  });
+
+  return [...items];
+}

--- a/src/annotator/test/range-util-test.js
+++ b/src/annotator/test/range-util-test.js
@@ -134,4 +134,21 @@ describe('annotator.range-util', function () {
       );
     });
   });
+
+  describe('itemsForRange', () => {
+    it('returns unique items for range', () => {
+      const range = document.createRange();
+      range.setStart(testNode, 0);
+      range.setEnd(testNode, testNode.childNodes.length);
+
+      const data = new Map();
+      data.set(testNode, 'itemA');
+      data.set(testNode.childNodes[0], 'itemB');
+      data.set(testNode.childNodes[1], 'itemB'); // Intentional duplicate.
+      data.set(testNode.childNodes[2], 'itemC');
+      const items = rangeUtil.itemsForRange(range, item => data.get(item));
+
+      assert.deepEqual(items, ['itemA', 'itemB', 'itemC']);
+    });
+  });
 });

--- a/src/styles/annotator/adder.scss
+++ b/src/styles/annotator/adder.scss
@@ -97,20 +97,12 @@ $adder-transition-duration: 80ms;
   flex-direction: row;
 }
 
-.annotator-adder-actions:hover .annotator-adder-actions__button {
-  color: var.$grey-semi !important;
-}
-
-.annotator-adder-actions:hover .annotator-adder-actions__label {
-  color: var.$grey-semi !important;
-}
-
 .annotator-adder-actions__button {
   box-shadow: none;
   font-family: h;
   font-size: 18px;
-  background: transparent !important;
-  color: var.$grey-mid !important;
+  background: transparent;
+  color: var.$grey-mid;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -125,11 +117,20 @@ $adder-transition-duration: 80ms;
   transition: color $adder-transition-duration;
 }
 
-.annotator-adder-actions .annotator-adder-actions__button:hover {
-  color: var.$grey-mid !important;
+.annotator-adder-actions__separator {
+  margin: 5px 5px;
+  border-right: 1px solid var.$grey-4;
+}
 
-  .annotator-adder-actions__label {
-    color: var.$grey-mid !important;
+// The toolbar has full contrast when not hovered. When the toolbar is hovered,
+// the buttons are dimmed except for the one which is currently hovered.
+.annotator-adder-actions:hover {
+  .annotator-adder-actions__button:not(:hover) {
+    color: var.$grey-semi;
+
+    .annotator-adder-actions__badge {
+      background-color: var.$grey-semi;
+    }
   }
 }
 
@@ -137,8 +138,20 @@ $adder-transition-duration: 80ms;
   margin-bottom: 2px;
   margin-top: 4px;
 
-  font-size: 11px;
+  font-size: 12px;
   font-family: sans-serif;
-  color: var.$grey-mid !important;
   transition: color $adder-transition-duration;
+}
+
+.annotator-adder-actions__badge {
+  background-color: var.$grey-mid;
+  border-radius: 3px;
+  color: white;
+
+  // The badge should be vertically aligned with icons in other toolbar buttons
+  // and the label underneath should also align with labels in other buttons.
+  font-family: sans-serif;
+  font-size: 12px;
+  font-weight: bold;
+  padding: 2px 4px;
 }

--- a/src/styles/annotator/adder.scss
+++ b/src/styles/annotator/adder.scss
@@ -1,3 +1,4 @@
+@use '../mixins/focus' as focus;
 @use '../variables' as var;
 
 $adder-transition-duration: 80ms;
@@ -98,6 +99,8 @@ $adder-transition-duration: 80ms;
 }
 
 .annotator-adder-actions__button {
+  @include focus.outline-on-keyboard-focus;
+
   box-shadow: none;
   font-family: h;
   font-size: 18px;


### PR DESCRIPTION
Add a button to the adder toolbar to show the existing annotations that
relate to the selected text, along with a keyboard shortcut (the "s"
key) to trigger it. This button only appears if the selected text overlaps at least one highlight.

This provides a way to filter annotations in the sidebar to those that
correspond to a particular highlight or region of text using only the
keyboard (we assume that the user already has some method of making the text selection in the first place). It might also be useful for other users in case the highlight is hard to click (eg. if the highlight has a small target area due to font size, text length etc.)

_Edit: Final design implementing Lyza's suggestions:_

<img width="611" alt="adder-show-button-revised" src="https://user-images.githubusercontent.com/2458/78358454-2216d300-75ab-11ea-8f31-d6db3139fc4a.png">

----

_Edit: Notes on initial prototype:_

**Note: The layout, icon and label here are not polished. They are just meant to illustrate the idea.**

<img width="696" alt="Screenshot 2020-03-18 09 19 00" src="https://user-images.githubusercontent.com/2458/76945040-e49f1e00-68f9-11ea-8540-8d5a32f5662b.png">

At this point I'm looking for feedback on the design:

- Is this the right approach to providing a keyboard-accessible way to filter annotations to those that correspond to a particular highlight?
- Should this have an icon in the toolbar or just a keyboard shortcut?
- If there is an icon, what should the icon be?
- If there is an icon, what should the label be?
- A specific query I have with screen reader usage is how the user will navigate back from the sidebar to the page once they have read and maybe replied to the annotations.  Maybe it will suffice to rely on the screen reader's existing shortcuts and navigation facilities?