### PR TITLE
Tune virtual thread list debouncing

### DIFF
--- a/src/sidebar/test/virtual-thread-list-test.js
+++ b/src/sidebar/test/virtual-thread-list-test.js
@@ -36,8 +36,17 @@ describe('VirtualThreadList', function() {
   }
 
   beforeEach(() => {
+    const fakeDebounce = callback => {
+      const debounced = () => {
+        // Update synchronously instead of really debouncing.
+        callback();
+      };
+      debounced.cancel = sinon.stub();
+      return debounced;
+    };
+
     $imports.$mock({
-      'lodash.debounce': fn => fn,
+      'lodash.debounce': fakeDebounce,
     });
   });
 

--- a/src/sidebar/virtual-thread-list.js
+++ b/src/sidebar/virtual-thread-list.js
@@ -34,8 +34,6 @@ export default class VirtualThreadList extends EventEmitter {
   constructor($scope, window_, rootThread, options) {
     super();
 
-    const self = this;
-
     this._rootThread = rootThread;
 
     this._options = Object.assign({}, options);
@@ -46,16 +44,22 @@ export default class VirtualThreadList extends EventEmitter {
     this.window = window_;
     this.scrollRoot = options.scrollRoot || document.body;
 
-    const debouncedUpdate = debounce(function() {
-      self.calculateVisibleThreads();
-      $scope.$digest();
-    }, 20);
+    const debouncedUpdate = debounce(
+      () => {
+        this.calculateVisibleThreads();
+        $scope.$digest();
+      },
+      10,
+      { maxWait: 100 }
+    );
+
     this.scrollRoot.addEventListener('scroll', debouncedUpdate);
     this.window.addEventListener('resize', debouncedUpdate);
 
     this._detach = function() {
       this.scrollRoot.removeEventListener('scroll', debouncedUpdate);
       this.window.removeEventListener('resize', debouncedUpdate);
+      debouncedUpdate.cancel();
     };
   }
 


### PR DESCRIPTION
When scrolling through a long list of annotations quickly, the sidebar could display blank space for a long period of time. This was happening because the debounced update function waited for a period of at least 20ms with no "scroll" events, and a gap of that length could take some time to appear if there was a queue of scroll events being delivered.

Fix the issue by adding an upper bound of 100ms (via a `maxWait` parameter to `debounce`) after a scroll event before recalculating the list of visible threads.

Also make sure to cancel any pending updates after the `detach` method is called.

**Master:**

![scrolling-master](https://user-images.githubusercontent.com/2458/77063521-bdb61a00-69d5-11ea-964c-46c941ba3f94.gif)

**This branch:**

![scrolling-tuned](https://user-images.githubusercontent.com/2458/77063567-d292ad80-69d5-11ea-95e9-c2b22824e9d2.gif)
