### PR TITLE
Call requestGroups to get groups filter

### DIFF
--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -111,8 +111,7 @@ export default function groups(
     // If a service group doesn't exist in the list of groups don't return it.
     if (svc && svc.groups) {
       try {
-        // The groups may not be available if they are being fetched via RPC.
-        // See mutateAsyncGroups in fetch-config.js
+        // The groups may not be immediately available if they are being fetched via RPC.
         const focusedGroups = await svc.groups;
         const filteredGroups = groups.filter(
           g => focusedGroups.includes(g.id) || focusedGroups.includes(g.groupid)
@@ -120,6 +119,8 @@ export default function groups(
         return filteredGroups;
       } catch (e) {
         toastMessenger.error(e.message);
+        // Don't show any groups if we catch an error
+        return [];
       }
     }
 

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -47,6 +47,7 @@ describe('groups', function () {
   let fakeRootScope;
   let fakeServiceUrl;
   let fakeMetadata;
+  let fakeToastMessenger;
 
   beforeEach(function () {
     fakeAuth = {
@@ -151,6 +152,7 @@ describe('groups', function () {
       fakeServiceUrl,
       fakeSession,
       fakeSettings,
+      fakeToastMessenger,
       fakeAuth
     );
   }

--- a/src/sidebar/test/cross-origin-rpc-test.js
+++ b/src/sidebar/test/cross-origin-rpc-test.js
@@ -10,7 +10,7 @@ class FakeWindow {
   }
 }
 
-describe('sidebar/cross-origin-rcp', function () {
+describe('sidebar/cross-origin-rpc', function () {
   let fakeStore;
   let fakeWarnOnce;
   let fakeWindow;

--- a/src/sidebar/util/fetch-config.js
+++ b/src/sidebar/util/fetch-config.js
@@ -132,12 +132,11 @@ async function fetchConfigRpc(appConfig, parentFrame, origin) {
     [],
     3000
   );
-  // Closure for the RPC call for mutateAsyncGroups to scope parentFrame
-  // and origin variables.
+  // Closure for the RPC call to scope parentFrame and origin variables.
   const rpcCall = (method, args = [], timeout = 3000) =>
     postMessageJsonRpc.call(parentFrame, origin, method, args, timeout);
   const mergedConfig = fetchConfigEmbed(appConfig, remoteConfig);
-  return mutateAsyncGroups(mergedConfig, rpcCall);
+  return fetchGroupsAsync(mergedConfig, rpcCall);
 }
 
 /**
@@ -147,9 +146,9 @@ async function fetchConfigRpc(appConfig, parentFrame, origin) {
  * call to `requestGroups` when the `groups` value is '$rpc:requestGroups'
  * If the `groups` value is missing or falsely then it won't be mutated.
  *
- * This allows the app to start with an incomplete config and then.
- * lazily fill in the `groups` value(s) later when its ready. This helps
- * speed up the loading process.
+ * This allows the app to start with an incomplete config and then lazily
+ * fill in the `groups` value(s) later when its ready. This helps speed
+ * up the loading process.
  *
  * @param {Object} config - The configuration object to mutate. This should
  *  already have the `services` value
@@ -157,8 +156,7 @@ async function fetchConfigRpc(appConfig, parentFrame, origin) {
  *  (method, args, timeout) => Promise
  * @return {Object} - The mutated settings
  */
-
-async function mutateAsyncGroups(config, rpcCall) {
+async function fetchGroupsAsync(config, rpcCall) {
   if (Array.isArray(config.services)) {
     config.services.forEach((service, index) => {
       if (service.groups === '$rpc:requestGroups') {

--- a/src/sidebar/util/test/fetch-config-test.js
+++ b/src/sidebar/util/test/fetch-config-test.js
@@ -247,10 +247,10 @@ describe('sidebar.util.fetch-config', () => {
         };
         fakeJsonRpc.call.onFirstCall().resolves({ foo: 'baz' }); // host config
         const result = await fetchConfig(appConfig, fakeWindow);
-        assert.deepEqual(await result.services[0].groups, ['group1', 'group2']);
+        assert.deepEqual(result.services[0].groups, ['group1', 'group2']);
       });
 
-      it("creates a merged config where `groups` returns a promise when its initial value is '$rpc:requestGroups'", async () => {
+      it("creates a merged config where `groups` is a promise when its initial value is '$rpc:requestGroups'", async () => {
         const appConfig = {
           services: [{ groups: '$rpc:requestGroups' }],
           appType: 'via',


### PR DESCRIPTION
Proposal for fetching groups async. 

**Update**
Added a function called `mutateAsyncGroups`  which may mutate the config object if groups filter exists. I considered making this function not mutate the object but that seemed more difficult to later merge back into the config because its a deep confg value. I see no side effects here to mutating the config object because its all internal to the fetch-config process anyway.

`mutateAsyncGroups` has 3 cases for a `groups` value:

1.  Missing or falsely `groups`: _Don't do anything_
2. `groups` exist: _Return a resolved promise_
3. `groups` is equal to '$rcp:requestGroups': _return a promise that fetches the filter array via RPC_

The gist here is that if there is a `groups` filter, the groups service can treat it as a promise in that case so we don't have to have a condition in the groups service to see if it's an instanceof Promise.  Its just always undefined or a Promise

**Array of services**
Because services is an array, I just send the service index back as a parameter of the `requestGroups` call. The method in LMS does not accept params nor does the RPC server so that would have to be filled in later if we wanted to handle more than one service, but the idea is this would work if there was more than 1 service later one.

fixes #1908