### PR TITLE
Remove "extend" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "eslint-plugin-react-hooks": "^2.4.0",
     "exorcist": "^1.0.1",
     "express": "^4.14.1",
-    "extend": "^3.0.2",
     "fancy-log": "^1.3.3",
     "fetch-mock": "9",
     "focus-visible": "^5.0.0",

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -1,4 +1,3 @@
-extend = require('extend')
 raf = require('raf')
 scrollIntoView = require('scroll-into-view')
 CustomEvent = require('custom-event')

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -1,4 +1,3 @@
-extend = require('extend')
 raf = require('raf')
 Hammer = require('hammerjs')
 

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -1,5 +1,3 @@
-import extend from 'extend';
-
 import RPC from './frame-rpc';
 
 /**
@@ -54,7 +52,7 @@ export default class Bridge {
       }
     };
 
-    const listeners = extend({ connect }, this.channelListeners);
+    const listeners = { connect, ...this.channelListeners };
 
     // Set up a channel
     channel = new RPC(window, source, origin, listeners);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3430,7 +3430,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@^3.0.2:
+extend@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==


### PR DESCRIPTION
This has been replaced with object spread or `Object.assign` apart from in one instance.