### PR TITLE
Remove feature-flag switch: Render `AnnotationOmega` in all cases

### DIFF
--- a/src/sidebar/components/annotation-thread.js
+++ b/src/sidebar/components/annotation-thread.js
@@ -86,10 +86,6 @@ function AnnotationThreadController(features, store) {
       store.setCollapsed(thread.parent.id, false);
     }
   };
-
-  this.shouldShowAnnotationOmega = () => {
-    return features.flagEnabled('client_preact_annotation');
-  };
 }
 
 export default {

--- a/src/sidebar/components/test/annotation-thread-test.js
+++ b/src/sidebar/components/test/annotation-thread-test.js
@@ -7,7 +7,7 @@ import moderationBanner from '../moderation-banner';
 
 function PageObject(element) {
   this.annotations = function() {
-    return Array.from(element[0].querySelectorAll('annotation'));
+    return Array.from(element[0].querySelectorAll('annotation-omega'));
   };
   this.visibleReplies = function() {
     return Array.from(
@@ -81,8 +81,7 @@ describe('annotationThread', function() {
       },
     });
     const pageObject = new PageObject(element);
-    assert.equal(pageObject.annotations().length, 1);
-    assert.isTrue(pageObject.isHidden(pageObject.annotations()[0]));
+    assert.equal(pageObject.annotations().length, 0);
   });
 
   describe('onForceVisible', () => {
@@ -241,7 +240,6 @@ describe('annotationThread', function() {
       thread: thread,
     });
     assert.ok(element[0].querySelector('moderation-banner'));
-    assert.ok(element[0].querySelector('annotation'));
   });
 
   it('does not render the annotation or moderation banner if there is no annotation', function() {
@@ -259,11 +257,7 @@ describe('annotationThread', function() {
   });
 
   describe('preact-migrated Annotation component', () => {
-    it('renders `AnnotationOmega` when `client_preact_annotation` feature flag is enabled', () => {
-      fakeFeatures.flagEnabled
-        .withArgs('client_preact_annotation')
-        .returns(true);
-
+    it('renders `AnnotationOmega`', () => {
       const element = util.createDirective(document, 'annotationThread', {
         thread: {
           id: '1',
@@ -282,30 +276,6 @@ describe('annotationThread', function() {
 
       assert.notOk(element[0].querySelector('annotation'));
       assert.ok(element[0].querySelector('annotation-omega'));
-    });
-    it('does not render `AnnotationOmega` if `client_preact_annotation` feature flag is not enabled', () => {
-      fakeFeatures.flagEnabled
-        .withArgs('client_preact_annotation')
-        .returns(false);
-
-      const element = util.createDirective(document, 'annotationThread', {
-        thread: {
-          id: '1',
-          annotation: { id: '1', text: 'text' },
-          children: [
-            {
-              id: '2',
-              annotation: { id: '2', text: 'areply' },
-              children: [],
-              visible: true,
-            },
-          ],
-          visible: true,
-        },
-      });
-
-      assert.ok(element[0].querySelector('annotation'));
-      assert.notOk(element[0].querySelector('annotation-omega'));
     });
   });
 });

--- a/src/sidebar/templates/annotation-thread.html
+++ b/src/sidebar/templates/annotation-thread.html
@@ -14,25 +14,13 @@
       annotation="vm.thread.annotation"
       ng-if="vm.thread.annotation">
     </moderation-banner>
-    <annotation-omega ng-if="vm.shouldShowAnnotationOmega() && vm.thread.annotation"
+    <annotation-omega ng-if="vm.thread.annotation && vm.thread.visible"
       annotation="vm.thread.annotation"
       reply-count="vm.thread.replyCount"
       on-reply-count-click="vm.toggleCollapsed()"
       show-document-info="vm.showDocumentInfo"
       thread-is-collapsed="vm.thread.collapsed">
     </annotation-omega>
-    <annotation ng-class="vm.annotationClasses()"
-             annotation="vm.thread.annotation"
-             is-collapsed="vm.thread.collapsed"
-             name="annotation"
-             ng-mouseenter="vm.annotationHovered = true"
-             ng-mouseleave="vm.annotationHovered = false"
-             ng-if="vm.thread.annotation && !vm.shouldShowAnnotationOmega()"
-             ng-show="vm.thread.visible"
-             show-document-info="vm.showDocumentInfo"
-             on-reply-count-click="vm.toggleCollapsed()"
-             reply-count="vm.thread.replyCount">
-    </annotation>
 
     <div ng-if="!vm.thread.annotation" class="thread-deleted">
       <p><em>Message not available.</em></p>


### PR DESCRIPTION
This PR makes `AnnotationThread` render `AnnotationOmega` in all cases, no longer conditional on feature-flag value. This needs to happen before the feature flag can be removed from `h`.

Part of https://github.com/hypothesis/client/issues/1867
