### PR TITLE
Remove "raf" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "prettier": "1.19.1",
     "puppeteer": "^2.0.0",
     "query-string": "^3.0.1",
-    "raf": "^3.1.0",
     "redux": "^4.0.1",
     "redux-thunk": "^2.1.0",
     "reselect": "^4.0.0",

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -1,4 +1,3 @@
-raf = require('raf')
 scrollIntoView = require('scroll-into-view')
 CustomEvent = require('custom-event')
 
@@ -15,7 +14,7 @@ xpathRange = require('./anchoring/range')
 
 animationPromise = (fn) ->
   return new Promise (resolve, reject) ->
-    raf ->
+    requestAnimationFrame ->
       try
         resolve(fn())
       catch error
@@ -295,7 +294,7 @@ module.exports = class Guest extends Delegator
         self.anchors.push(anchor)
 
     # Remove all the highlights that have no corresponding target anymore.
-    raf -> highlighter.removeHighlights(deadHighlights)
+    requestAnimationFrame -> highlighter.removeHighlights(deadHighlights)
 
     # Anchor any targets of this annotation that are not anchored already.
     for target in annotation.target when target not in anchoredTargets
@@ -318,7 +317,7 @@ module.exports = class Guest extends Delegator
     this.anchors = anchors
 
     unhighlight = Array::concat(unhighlight...)
-    raf =>
+    requestAnimationFrame =>
       highlighter.removeHighlights(unhighlight)
       this.plugins.BucketBar?.update()
 

--- a/src/annotator/plugin/bucket-bar.coffee
+++ b/src/annotator/plugin/bucket-bar.coffee
@@ -1,5 +1,3 @@
-raf = require('raf')
-
 $ = require('jquery')
 Plugin = require('../plugin')
 
@@ -101,7 +99,7 @@ module.exports = class BucketBar extends Plugin
   # Update sometime soon
   update: =>
     return if @_updatePending?
-    @_updatePending = raf =>
+    @_updatePending = requestAnimationFrame =>
       delete @_updatePending
       @_update()
 

--- a/src/annotator/sidebar.coffee
+++ b/src/annotator/sidebar.coffee
@@ -1,4 +1,3 @@
-raf = require('raf')
 Hammer = require('hammerjs')
 
 Host = require('./host')
@@ -130,7 +129,7 @@ module.exports = class Sidebar extends Host
     return if @renderFrame
 
     # Schedule a frame
-    @renderFrame = raf =>
+    @renderFrame = requestAnimationFrame =>
       @renderFrame = null  # Clear the schedule
 
       # Process the resize gesture

--- a/src/annotator/test/guest-test.coffee
+++ b/src/annotator/test/guest-test.coffee
@@ -11,9 +11,6 @@ Guest = require('../guest')
 rangeUtil = null
 selections = null
 
-raf = sinon.stub().yields()
-raf['@noCallThru'] = true
-
 scrollIntoView = sinon.stub()
 scrollIntoView['@noCallThru'] = true
 
@@ -75,6 +72,8 @@ describe 'Guest', ->
       anchor: sinon.stub()
     }
 
+    sinon.stub(window, 'requestAnimationFrame').yields()
+
     $imports.$mock({
       './adder': {Adder: FakeAdder},
       './anchoring/html': htmlAnchoring,
@@ -86,7 +85,6 @@ describe 'Guest', ->
           return () ->
         )
       './delegator': Delegator,
-      'raf': raf,
       'scroll-into-view': scrollIntoView,
     })
 
@@ -102,6 +100,7 @@ describe 'Guest', ->
     guestConfig.pluginClasses['CrossFrame'] = CrossFrame
 
   afterEach ->
+    window.requestAnimationFrame.restore()
     sandbox.restore()
     console.warn.restore()
     $imports.$restore()

--- a/src/annotator/test/guest-test.coffee
+++ b/src/annotator/test/guest-test.coffee
@@ -4,7 +4,6 @@ Plugin = require('../plugin')
 
 Delegator = require('../delegator')
 $ = require('jquery')
-Delegator['@noCallThru'] = true
 
 Guest = require('../guest')
 { $imports } = require('../guest')
@@ -12,7 +11,6 @@ rangeUtil = null
 selections = null
 
 scrollIntoView = sinon.stub()
-scrollIntoView['@noCallThru'] = true
 
 class FakeAdder
   instance: null

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -14,11 +14,10 @@ describe 'Sidebar', ->
   sidebarConfig = {pluginClasses: {}}
 
   before ->
-    rafStub = (fn) ->
-      fn()
-    $imports.$mock({ raf: rafStub })
+    sinon.stub(window, 'requestAnimationFrame').yields()
 
   after ->
+    window.requestAnimationFrame.restore();
     $imports.$restore()
 
   createSidebar = (config={}) ->

--- a/src/sidebar/util/test/is-third-party-service-test.js
+++ b/src/sidebar/util/test/is-third-party-service-test.js
@@ -11,7 +11,6 @@ describe('sidebar.util.isThirdPartyService', () => {
 
     $imports.$mock({
       '../service-config': fakeServiceConfig,
-      '@noCallThru': true,
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6380,7 +6380,7 @@ querystring@0.2.0, querystring@^0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-raf@^3.1.0, raf@^3.4.1:
+raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==


### PR DESCRIPTION
This is a polyfill for `requestAnimationFrame`, which is [natively supported](https://caniuse.com/#search=requestanimationframe) by all browsers we support.

The client was already broken if `requestAnimationFrame` was not available for any reason because some other dependencies (eg. Preact) already make use of it directly in the sidebar.