### PR TITLE
Fix spurious WebSocket disconnection errors

### DIFF
--- a/src/sidebar/test/websocket-test.js
+++ b/src/sidebar/test/websocket-test.js
@@ -32,64 +32,57 @@ describe('websocket wrapper', function() {
     console.warn.restore();
   });
 
-  it('should reconnect after an abnormal disconnection', function() {
-    new Socket('ws://test:1234');
-    assert.ok(fakeSocket);
-    const initialSocket = fakeSocket;
-    fakeSocket.onopen({});
-    fakeSocket.onclose({ code: CLOSE_ABNORMAL });
-    clock.tick(2000);
-    assert.ok(fakeSocket);
-    assert.notEqual(fakeSocket, initialSocket);
-  });
-
-  it('should reconnect if initial connection fails', function() {
-    new Socket('ws://test:1234');
-    assert.ok(fakeSocket);
-    const initialSocket = fakeSocket;
-    fakeSocket.onopen({});
-    fakeSocket.onclose({ code: CLOSE_ABNORMAL });
-    clock.tick(4000);
-    assert.ok(fakeSocket);
-    assert.notEqual(fakeSocket, initialSocket);
-  });
-
-  it('should send queued messages after a reconnect', function() {
-    // simulate WebSocket setup and initial connection
-    const socket = new Socket('ws://test:1234');
-    fakeSocket.onopen({});
-
-    // simulate abnormal disconnection
-    fakeSocket.onclose({ code: CLOSE_ABNORMAL });
-
-    // enqueue a message and check that it is sent after the WS reconnects
-    socket.send({ aKey: 'aValue' });
-    fakeSocket.onopen({});
-    assert.calledWith(fakeSocket.send, '{"aKey":"aValue"}');
-  });
-
-  [CLOSE_NORMAL, CLOSE_GOING_AWAY].forEach(closeCode => {
-    it('should not reconnect after a normal disconnection by the client', function() {
+  context('when the connection is closed by the browser or server', () => {
+    it('should reconnect after an abnormal disconnection', function() {
       new Socket('ws://test:1234');
       assert.ok(fakeSocket);
       const initialSocket = fakeSocket;
-
       fakeSocket.onopen({});
-      fakeSocket.onclose({ code: closeCode });
-      clock.tick(4000);
-
+      fakeSocket.onclose({ code: CLOSE_ABNORMAL });
+      clock.tick(2000);
       assert.ok(fakeSocket);
-      assert.equal(fakeSocket, initialSocket);
+      assert.notEqual(fakeSocket, initialSocket);
     });
-  });
 
-  it('should not reconnect after a normal disconnection by the server', function() {
-    const socket = new Socket('ws://test:1234');
-    socket.close();
-    assert.called(fakeSocket.close);
-    const initialSocket = fakeSocket;
-    clock.tick(2000);
-    assert.equal(fakeSocket, initialSocket);
+    it('should reconnect if initial connection fails', function() {
+      new Socket('ws://test:1234');
+      assert.ok(fakeSocket);
+      const initialSocket = fakeSocket;
+      fakeSocket.onopen({});
+      fakeSocket.onclose({ code: CLOSE_ABNORMAL });
+      clock.tick(4000);
+      assert.ok(fakeSocket);
+      assert.notEqual(fakeSocket, initialSocket);
+    });
+
+    it('should send queued messages after a reconnect', function() {
+      // simulate WebSocket setup and initial connection
+      const socket = new Socket('ws://test:1234');
+      fakeSocket.onopen({});
+
+      // simulate abnormal disconnection
+      fakeSocket.onclose({ code: CLOSE_ABNORMAL });
+
+      // enqueue a message and check that it is sent after the WS reconnects
+      socket.send({ aKey: 'aValue' });
+      fakeSocket.onopen({});
+      assert.calledWith(fakeSocket.send, '{"aKey":"aValue"}');
+    });
+
+    [CLOSE_NORMAL, CLOSE_GOING_AWAY].forEach(closeCode => {
+      it('should not reconnect after a normal disconnection', function() {
+        new Socket('ws://test:1234');
+        assert.ok(fakeSocket);
+        const initialSocket = fakeSocket;
+
+        fakeSocket.onopen({});
+        fakeSocket.onclose({ code: closeCode });
+        clock.tick(4000);
+
+        assert.ok(fakeSocket);
+        assert.equal(fakeSocket, initialSocket);
+      });
+    });
   });
 
   it('should queue messages sent prior to connection', function() {
@@ -105,5 +98,23 @@ describe('websocket wrapper', function() {
     fakeSocket.readyState = FakeWebSocket.OPEN;
     socket.send({ abc: 'foo' });
     assert.calledWith(fakeSocket.send, '{"abc":"foo"}');
+  });
+
+  describe('#close', () => {
+    it('should close the socket with a normal status', () => {
+      const socket = new Socket('ws://test:1234');
+      socket.close();
+      assert.calledWith(fakeSocket.close, CLOSE_NORMAL);
+    });
+
+    it('should not reconnect after closing', () => {
+      const socket = new Socket('ws://test:1234');
+      const initialSocket = fakeSocket;
+
+      socket.close();
+
+      clock.tick(2000);
+      assert.equal(fakeSocket, initialSocket);
+    });
   });
 });

--- a/src/sidebar/websocket.js
+++ b/src/sidebar/websocket.js
@@ -120,7 +120,20 @@ export default class Socket extends EventEmitter {
 
     /** Close the underlying WebSocket connection */
     this.close = function() {
-      socket.close();
+      // nb. h's ws4py-based WebSocket server will currently use whatever
+      // status code we call `close()` with as the status code in its response.
+      //
+      // If no status code is provided, the browser will send a close frame
+      // with no payload, which is allowed by the spec. ws4py however, will
+      // respond by sending back a close frame with a 1005 status code, which
+      // is not allowed by the spec. What ws4py should do in that scenario is
+      // send back a close frame with no payload itself. This invalid close frame
+      // causes browsers to report an abnormal WS termination, even though
+      // nothing really went wrong.
+      //
+      // To avoid the problem, we just explicitly send a "closed normally"
+      // status code here and ws4py will respond with the same status.
+      socket.close(CLOSE_NORMAL);
     };
 
     /**

--- a/src/sidebar/websocket.js
+++ b/src/sidebar/websocket.js
@@ -1,8 +1,19 @@
 import retry from 'retry';
 import EventEmitter from 'tiny-emitter';
 
-// see https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
-const CLOSE_NORMAL = 1000;
+// Status codes indicating the reason why a WebSocket connection closed.
+// See https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent and
+// https://tools.ietf.org/html/rfc6455#section-7.4.
+
+// "Normal" closures.
+export const CLOSE_NORMAL = 1000;
+export const CLOSE_GOING_AWAY = 1001;
+
+// "Abnormal" closures.
+export const CLOSE_ABNORMAL = 1006;
+
+// There are other possible close status codes not listed here. They are all
+// considered abnormal closures.
 
 // Minimum delay, in ms, before reconnecting after an abnormal connection close.
 const RECONNECT_MIN_DELAY = 1000;
@@ -60,7 +71,7 @@ export default class Socket extends EventEmitter {
           self.emit('open', event);
         };
         socket.onclose = function(event) {
-          if (event.code === CLOSE_NORMAL) {
+          if (event.code === CLOSE_NORMAL || event.code === CLOSE_GOING_AWAY) {
             self.emit('close', event);
             return;
           }

--- a/src/sidebar/websocket.js
+++ b/src/sidebar/websocket.js
@@ -120,16 +120,16 @@ export default class Socket extends EventEmitter {
 
     /** Close the underlying WebSocket connection */
     this.close = function() {
-      // nb. h's ws4py-based WebSocket server will currently use whatever
-      // status code we call `close()` with as the status code in its response.
+      // nb. Always sent a status code in the `close()` call to work around
+      // a problem in the backend's ws4py library.
       //
-      // If no status code is provided, the browser will send a close frame
-      // with no payload, which is allowed by the spec. ws4py however, will
-      // respond by sending back a close frame with a 1005 status code, which
-      // is not allowed by the spec. What ws4py should do in that scenario is
-      // send back a close frame with no payload itself. This invalid close frame
-      // causes browsers to report an abnormal WS termination, even though
-      // nothing really went wrong.
+      // If no status code is provided in the `close()` call, the browser will
+      // send a close frame with no payload, which is allowed by the spec.
+      // ws4py however, will respond by sending back a close frame with a 1005
+      // status code, which is not allowed by the spec. What ws4py should do in
+      // that scenario is send back a close frame with no payload itself. This
+      // invalid close frame causes browsers to report an abnormal WS
+      // termination, even though nothing really went wrong.
       //
       // To avoid the problem, we just explicitly send a "closed normally"
       // status code here and ws4py will respond with the same status.


### PR DESCRIPTION
This PR fixes spurious console errors about abnormal WebSocket disconnections when navigating away from the page and when logging in/logging out.

- An error was reported when navigating away from a page if the WS was connected because the status code that indicates this is the reason for a WS connection being closed, 1001, was incorrectly treated as an _abnormal_ disconnection.
- Work around an issue with the WebSocket server (specifically, the `ws4py` package that h uses) will respond to a WS connection being closed with no status code with an invalid response. The fix is to explicitly specify a status code when closing the connection. See comments in the `close()` method for full details.

I also re-organized the tests to make it easier to see which tests relate to what happens when the server or browser closes the connection vs what happens when the client closes the connection.

Related reading: The [Closing Handshake](https://tools.ietf.org/html/rfc6455#section-1.4) section of the WebSocket spec specifies how closing a WebSocket connection works.

----

**Testing:**

On the master branch, go to http://localhost:3000 and log in / out of the client. You'll see messages like this in the console:

<img width="821" alt="Screenshot 2020-03-23 12 10 24" src="https://user-images.githubusercontent.com/2458/77315409-709cb580-6cff-11ea-9bda-973a4b2a9387.png">

On this branch, repeat the same steps and you shouldn't see that message.

The other issue (error when navigating away from page) is a bit harder to reproduce. Locally I can reproduce it sometimes in Firefox by going to http://localhost:3000 and refreshing the page. In Chrome and Safari I haven't found a way to reproduce reliably yet.


