### PR TITLE
Revert "Bump prettier from 1.19.1 to 2.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "postcss": "^7.0.13",
     "postcss-url": "^8.0.0",
     "preact": "^10.0.4",
-    "prettier": "2.0.1",
+    "prettier": "1.19.1",
     "puppeteer": "^2.0.0",
     "query-string": "^3.0.1",
     "redux": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6278,10 +6278,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.1.tgz#3f00ac71263be34684b2b2c8d7e7f63737592dac"
-  integrity sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==
+prettier@1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-format@^3.8.0:
   version "3.8.0"


### PR DESCRIPTION
This was merged by mistake before all CI checks had run.

Reverts hypothesis/client#1950