### PR TITLE
WIP: Create new `Thread` preact component to replace `AnnotationThread`

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -117,15 +117,15 @@ function Annotation({
       {isEditing && <TagEditor onEditTags={onEditTags} tagList={tags} />}
       {!isEditing && <TagList annotation={annotation} tags={tags} />}
       <footer className="annotation__footer">
-        <div className="annotation__form-actions">
-          {isEditing && (
+        {isEditing && (
+          <div className="annotation__form-actions">
             <AnnotationPublishControl
               annotation={annotation}
               isDisabled={isEmpty}
               onSave={onSave}
             />
-          )}
-        </div>
+          </div>
+        )}
         {shouldShowLicense && <AnnotationLicense />}
         <div className="annotation__controls">
           {shouldShowReplyToggle && (

--- a/src/sidebar/components/thread.js
+++ b/src/sidebar/components/thread.js
@@ -1,0 +1,116 @@
+import classnames from 'classnames';
+import { createElement, Fragment } from 'preact';
+
+import propTypes from 'prop-types';
+import useStore from '../store/use-store';
+import { withServices } from '../util/service-context';
+import { countHidden, countVisible } from '../util/thread';
+
+import Annotation from './annotation';
+import Button from './button';
+import ModerationBanner from './moderation-banner';
+
+/**
+ * A thread, which contains a single annotation at its top level, and its
+ * recursively-rendered children (i.e. replies). A thread may have a parent,
+ * and at any given time it may be `collapsed`.
+ */
+function Thread({ showDocumentInfo = false, thread, threadsService }) {
+  const setCollapsed = useStore(store => store.setCollapsed);
+
+  // Only render this thread's annotation if it exists and the thread is `visible`
+  const showAnnotation = thread.annotation && thread.visible;
+
+  // Render this thread's replies only if the thread is expanded
+  const showChildren = !thread.collapsed;
+
+  // Applied search filters will "hide" non-matching threads. If there are
+  // hidden items within this thread, provide a control to un-hide them.
+  const showHiddenToggle = countHidden(thread) > 0;
+
+  // Render a control to expand/collapse the current thread if this thread has
+  // a parent (i.e. is a reply thread)
+  const showThreadToggle = !!thread.parent;
+  const toggleIcon = thread.collapsed ? 'caret-right' : 'expand-menu';
+  const toggleTitle = thread.collapsed ? 'Expand replies' : 'Collapse replies';
+
+  // If rendering child threads, only render those that have at least one
+  // visible item within them—i.e. don't render empty/totally-hidden threads.
+  const visibleChildren = thread.children.filter(
+    child => countVisible(child) > 0
+  );
+
+  const onToggleReplies = () => setCollapsed(thread.id, !thread.collapsed);
+  return (
+    <div
+      className={classnames('thread', {
+        'thread--reply': thread.depth > 0,
+        'thread--top-reply': thread.depth === 1,
+        'is-collapsed': thread.collapsed,
+      })}
+    >
+      {showThreadToggle && (
+        <div className="thread__collapse">
+          <Button
+            className="thread__collapse-button"
+            icon={toggleIcon}
+            title={toggleTitle}
+            onClick={onToggleReplies}
+          />
+        </div>
+      )}
+
+      <div className="thread__content">
+        {showAnnotation && (
+          <Fragment>
+            <ModerationBanner annotation={thread.annotation} />
+            <Annotation
+              annotation={thread.annotation}
+              replyCount={thread.replyCount}
+              onReplyCountClick={onToggleReplies}
+              showDocumentInfo={showDocumentInfo}
+              threadIsCollapsed={thread.collapsed}
+            />
+          </Fragment>
+        )}
+
+        {!thread.annotation && (
+          <div>
+            <p>
+              <em>Message not available.</em>
+            </p>
+          </div>
+        )}
+
+        {showHiddenToggle && (
+          <Button
+            buttonText={`Show ${countHidden(thread)} more in conversation`}
+            onClick={() => threadsService.forceVisible(thread)}
+          />
+        )}
+
+        {showChildren && (
+          <ul>
+            {visibleChildren.map(child => (
+              <li key={child.annotation.$tag}>
+                <Thread thread={child} threadsService={threadsService} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+Thread.propTypes = {
+  showDocumentInfo: propTypes.bool,
+  thread: propTypes.object.isRequired,
+
+  // Injected
+  threadsService: propTypes.object.isRequired,
+};
+
+Thread.injectedProps = ['threadsService'];
+
+export default withServices(Thread);

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -117,6 +117,7 @@ import SelectionTabs from './components/selection-tabs';
 import ShareAnnotationsPanel from './components/share-annotations-panel';
 import SidebarContentError from './components/sidebar-content-error';
 import SvgIcon from './components/svg-icon';
+import Thread from './components/thread';
 import ToastMessages from './components/toast-messages';
 import TopBar from './components/top-bar';
 
@@ -155,6 +156,7 @@ import sessionService from './services/session';
 import streamFilterService from './services/stream-filter';
 import streamerService from './services/streamer';
 import tagsService from './services/tags';
+import threadsService from './services/threads';
 import toastMessenger from './services/toast-messenger';
 import unicodeService from './services/unicode';
 import viewFilterService from './services/view-filter';
@@ -199,6 +201,7 @@ function startAngularApp(config) {
     .register('streamer', streamerService)
     .register('streamFilter', streamFilterService)
     .register('tags', tagsService)
+    .register('threadsService', threadsService)
     .register('toastMessenger', toastMessenger)
     .register('unicode', unicodeService)
     .register('viewFilter', viewFilterService)
@@ -247,6 +250,7 @@ function startAngularApp(config) {
     .component('shareAnnotationsPanel', wrapComponent(ShareAnnotationsPanel))
     .component('streamContent', streamContent)
     .component('svgIcon', wrapComponent(SvgIcon))
+    .component('thread', wrapComponent(Thread))
     .component('threadList', threadList)
     .component('toastMessages', wrapComponent(ToastMessages))
     .component('topBar', wrapComponent(TopBar))
@@ -275,6 +279,7 @@ function startAngularApp(config) {
     .service('session', () => container.get('session'))
     .service('streamer', () => container.get('streamer'))
     .service('streamFilter', () => container.get('streamFilter'))
+    .service('threadsService', () => container.get('threadsService'))
     .service('toastMessenger', () => container.get('toastMessenger'))
 
     // Redux store

--- a/src/sidebar/services/threads.js
+++ b/src/sidebar/services/threads.js
@@ -1,0 +1,18 @@
+// @ngInject
+export default function threadsService(store) {
+  /**
+   * Make this thread and all of its children "visible". This has the effect of
+   * "unhiding" a thread which is currently hidden by an applied search filter
+   * (as well as its child threads).
+   */
+  function forceVisible(thread) {
+    thread.children.forEach(child => {
+      forceVisible(child);
+    });
+    store.setForceVisible(thread.id, true);
+  }
+
+  return {
+    forceVisible,
+  };
+}

--- a/src/sidebar/templates/thread-list.html
+++ b/src/sidebar/templates/thread-list.html
@@ -12,7 +12,16 @@
           thread="child"
           show-document-info="vm.showDocumentInfo"
           on-change-collapsed="vm.onChangeCollapsed({id: id, collapsed: collapsed})">
-        </annotation-thread>
+    </div>
+  </li>
+  <li ng-repeat="child in vm.virtualThreadList.visibleThreads track by child.id">
+    <div id="{{child.id}}"
+        class="thread-list__card"
+        ng-mouseenter="vm.onFocus({annotation: child.annotation})"
+        ng-class="{'thread-list__card--theme-clean' : vm.isThemeClean }"
+        ng-click="vm.onSelect({annotation: child.annotation})"
+        ng-mouseleave="vm.onFocus({annotation: null})">
+        <thread thread="child" show-document-info="vm.showDocumentInfo"></thread>
     </div>
     <hr ng-if="vm.isThemeClean"
         class="thread-list__separator--theme-clean" />

--- a/src/styles/sidebar/components/annotation-header.scss
+++ b/src/styles/sidebar/components/annotation-header.scss
@@ -10,6 +10,7 @@
 
   &__row {
     display: flex;
+    flex-wrap: wrap-reverse;
     align-items: baseline;
   }
 

--- a/src/styles/sidebar/components/thread.scss
+++ b/src/styles/sidebar/components/thread.scss
@@ -1,0 +1,50 @@
+@use "../../variables" as var;
+
+.thread {
+  &--reply {
+    margin-top: 0.5em;
+    padding-top: 0.5em;
+  }
+  display: flex;
+
+  &__collapse {
+    border-left: 1px dashed var.$grey-3;
+    margin: 0.25em;
+    margin-top: 0;
+    cursor: auto;
+
+    &:hover {
+      border-left: 1px dashed var.$grey-4;
+    }
+  }
+
+  .is-collapsed &__collapse {
+    border-left: none;
+  }
+
+  &__collapse-button {
+    margin-left: -1.25em;
+    padding: 0.75em;
+    padding-top: 0.25em;
+    padding-bottom: 1em;
+    background-color: var.$white;
+
+    .button__icon {
+      color: var.$grey-4;
+      width: 12px;
+      height: 12px;
+    }
+
+    &:hover {
+      .button__icon {
+        color: var.$grey-6;
+      }
+    }
+  }
+
+  &__content {
+    flex-grow: 1;
+    // Prevent annotation content from overflowing the container
+    max-width: 100%;
+  }
+}

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -62,6 +62,7 @@
 @use './components/spinner';
 @use './components/tag-editor';
 @use './components/tag-list';
+@use './components/thread';
 @use './components/thread-list';
 @use './components/toast-messages';
 @use './components/tooltip';


### PR DESCRIPTION
This PR presents the proposed structure for a new preact `Thread` component to replace `AnnotationThread`.

Right now, `thread-list` renders _both_ `AnnotationThread`s and `Thread`s, so that a reviewer can compare and contrast.

I suggest pulling this branch and playing around with it, adding some nested replies, etc., and experimenting with expanding, collapsing threads as well as applying search filters. The general design approach for the threads and expand/collapse controls have been discussed and verbally approved in a [Slack conversation accessible to Hypothesis staff](https://hypothes-is.slack.com/archives/C07NXBDNW/p1585144768001900).

There is an additional design change in this set of changes for the appearance of the control to show threads hidden by applied search filters. I haven't had a chance to discuss the design of this with anyone yet. It's not meant as an end point, but it's a tad bit better than what's extant, I think.

Part of https://github.com/hypothesis/client/issues/1845

Amendment: I should point out that if you create a thread that spans more than the vertical viewport of your screen (i.e. a whole bunch of nested replies), you might end up in a state of crazy flicker and re-render as the two thread components fight with each other. This can be rectified by either removing a couple of replies from your long thread, or by commenting out the old `annotation-thread` rendering in the `thread-list` template.