### PR TITLE
Add preStart method to cross-origin-rcp module

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -2,7 +2,10 @@
 
 import { jsonConfigsFrom } from '../shared/settings';
 
-import crossOriginRPC from './cross-origin-rpc.js';
+import {
+  startServer as startRPCServer,
+  preStartServer as preStartRPCServer,
+} from './cross-origin-rpc.js';
 import addAnalytics from './ga';
 import disableOpenerForExternalLinks from './util/disable-opener-for-external-links';
 import { fetchConfig } from './util/fetch-config';
@@ -294,7 +297,7 @@ function startAngularApp(config) {
     .run(sendPageView)
     .run(setupApi)
     .run(setupRoute)
-    .run(crossOriginRPC.server.start);
+    .run(startRPCServer);
 
   // Work around a check in Angular's $sniffer service that causes it to
   // incorrectly determine that Firefox extensions are Chrome Packaged Apps which
@@ -310,6 +313,9 @@ function startAngularApp(config) {
   const appEl = document.querySelector('hypothesis-app');
   angular.bootstrap(appEl, ['h'], { strictDi: true });
 }
+
+// Start capturing RPC requests before we start the RPC server (startRPCServer)
+preStartRPCServer();
 
 fetchConfig(appConfig)
   .then(config => {

--- a/src/sidebar/util/test/fetch-config-test.js
+++ b/src/sidebar/util/test/fetch-config-test.js
@@ -176,7 +176,7 @@ describe('sidebar.util.fetch-config', () => {
         });
       });
 
-      it('makes an RCP request to `requestConfig` ', async () => {
+      it('makes an RPC request to `requestConfig` ', async () => {
         await fetchConfig({}, fakeWindow);
         fakeJsonRpc.call.calledWithExactly(
           fakeTopWindow,


### PR DESCRIPTION
When called, allows any incoming rpc request to wait in a queue and be proceeded a short time later when the actual start() method is called. This prevents potential timeouts from incoming RPC requests from LMS (or similar) that arrive after we tipped off the parent frame with a fetchConfig outgoing request but before start() is called.

After refactoring to remove the self-executing function (yesterday's attempt), testing got much more simple.  I also refactored a bit use a fake `emitter` as was done in postmessage-json-rpc-test so its a bit more consistent and less boiler plate code.

![no_errors](https://user-images.githubusercontent.com/3939074/77586477-80ed9580-6ea3-11ea-8b55-9bb656e21389.gif)


fixes https://github.com/hypothesis/client/pull/1885
