### PR TITLE
Add translation map for specific host-config values

### DIFF
--- a/src/shared/test/type-coercions-test.js
+++ b/src/shared/test/type-coercions-test.js
@@ -1,0 +1,151 @@
+import { toBoolean, toInteger, toObject, toString } from '../type-coercions';
+
+describe('shared/type-coercions', () => {
+  describe('toBoolean', () => {
+    [
+      {
+        value: true,
+        result: true,
+      },
+      {
+        value: 'true',
+        result: true,
+      },
+      {
+        value: 'any',
+        result: true,
+      },
+      {
+        value: 'false',
+        result: false,
+      },
+      {
+        value: ' false',
+        result: false,
+      },
+      {
+        value: 'False',
+        result: false,
+      },
+      {
+        value: 'FALSE',
+        result: false,
+      },
+      {
+        value: '',
+        result: false,
+      },
+      {
+        value: '1',
+        result: true,
+      },
+      {
+        value: '0',
+        result: false,
+      },
+      {
+        value: 1,
+        result: true,
+      },
+      {
+        value: null,
+        result: false,
+      },
+      {
+        value: undefined,
+        result: false,
+      },
+    ].forEach(test => {
+      it('coerces the values appropriately', () => {
+        assert.equal(toBoolean(test.value), test.result);
+      });
+    });
+  });
+
+  describe('toInteger', () => {
+    [
+      {
+        value: '1',
+        result: 1,
+      },
+      {
+        value: '0',
+        result: 0,
+      },
+      {
+        value: 1,
+        result: 1,
+      },
+      {
+        value: 1.1,
+        result: 1,
+      },
+      {
+        value: 'a',
+        result: NaN,
+      },
+    ].forEach(test => {
+      it('coerces the values appropriately', () => {
+        assert.deepEqual(toInteger(test.value), test.result);
+      });
+    });
+  });
+
+  describe('toObject', () => {
+    [
+      {
+        value: { a: 'a', b: { c: ['c'] } },
+        result: { a: 'a', b: { c: ['c'] } },
+      },
+      {
+        value: 1,
+        result: {},
+      },
+      {
+        value: null,
+        result: {},
+      },
+      {
+        value: undefined,
+        result: {},
+      },
+    ].forEach(test => {
+      it('coerces the values appropriately', () => {
+        assert.deepEqual(toObject(test.value), test.result);
+      });
+    });
+  });
+
+  describe('toString', () => {
+    [
+      {
+        value: 'a',
+        result: 'a',
+      },
+      {
+        value: 1,
+        result: '1',
+      },
+      {
+        value: null,
+        result: '',
+      },
+      {
+        value: undefined,
+        result: '',
+      },
+      {
+        value: {
+          // In a rare case where its an object with custom
+          // toString value that is not a function.
+          toString: false,
+        },
+        result: '',
+      },
+    ].forEach(test => {
+      it('coerces the values appropriately', () => {
+        assert.equal(toString(test.value), test.result);
+      });
+    });
+  });
+});

--- a/src/shared/type-coercions.js
+++ b/src/shared/type-coercions.js
@@ -1,0 +1,69 @@
+/**
+ * Type conversion methods that coerce incoming configuration values to an
+ * expected type or format that other parts of the UI may make assumptions
+ * on. This is needed for incoming configuration values that are otherwise
+ * not sanitized.
+ *
+ * Note that if the values passed are plain javascript values (such as ones
+ * produced from JSON.parse), then these methods do not throw errors.
+ */
+
+/**
+ * Returns a boolean
+ *
+ * @param {any} value - initial value
+ * @return {boolean}
+ */
+export function toBoolean(value) {
+  if (typeof value === 'string') {
+    if (value.trim().toLocaleLowerCase() === 'false') {
+      // "false", "False", " false", "FALSE" all return false
+      return false;
+    }
+  }
+  const numericalVal = Number(value);
+  if (!isNaN(numericalVal)) {
+    return Boolean(numericalVal);
+  }
+  // Any non numerical or falsely string should return true, otherwise return false
+  return typeof value === 'string';
+}
+
+/**
+ * Returns either an integer or NaN
+ *
+ * @param {any} value - initial value
+ * @return {number}
+ */
+export function toInteger(value) {
+  // Acts as a simple wrapper
+  return parseInt(value);
+}
+
+/**
+ * Returns either the value if its an object or an empty object
+ *
+ * @param {any} value - initial value
+ * @return {object}
+ */
+export function toObject(value) {
+  if (typeof value === 'object' && value !== null) {
+    return value;
+  }
+  // Don't attempt to fix the values, just ensure type correctness
+  return {};
+}
+
+/**
+ * Returns the value as a string or an empty string if the
+ * value undefined, null or otherwise falsely.
+ *
+ * @param {any} value - initial value
+ * @return {string}
+ */
+export function toString(value) {
+  if (value && typeof value.toString === 'function') {
+    return value.toString();
+  }
+  return '';
+}

--- a/src/sidebar/test/host-config-test.js
+++ b/src/sidebar/test/host-config-test.js
@@ -39,6 +39,24 @@ describe('hostPageConfig', function() {
     });
   });
 
+  it('coerces `requestConfigFromFrame` and `openSidebar` values', function() {
+    const window_ = fakeWindow({
+      openSidebar: 'false',
+      requestConfigFromFrame: {
+        origin: 'origin',
+        ancestorLevel: '2',
+      },
+    });
+
+    assert.deepEqual(hostPageConfig(window_), {
+      openSidebar: false,
+      requestConfigFromFrame: {
+        origin: 'origin',
+        ancestorLevel: 2,
+      },
+    });
+  });
+
   it('ignores non-whitelisted config params', function() {
     const window_ = fakeWindow({
       apiUrl: 'https://not-the-hypothesis/api/',


### PR DESCRIPTION
Coerces specific values provided into types that the client assumes it would be in.
This is part of the prep work to support via3 which will eventually only export strings values in the config.

Fixes https://github.com/hypothesis/client/issues/1957