### PR TITLE
Replace angular-mocks in service tests

### DIFF
--- a/src/sidebar/services/test/local-storage-test.js
+++ b/src/sidebar/services/test/local-storage-test.js
@@ -1,5 +1,3 @@
-import angular from 'angular';
-
 import service from '../local-storage';
 
 function windowWithLocalStoragePropertyThatThrows() {
@@ -27,8 +25,6 @@ function windowWithLocalStorageMethodsThatThrow() {
 describe('sidebar.localStorage', () => {
   let fakeWindow;
 
-  before(() => angular.module('h', []).service('localStorage', service));
-
   [
     windowWithLocalStorageMethodsThatThrow(),
     windowWithLocalStoragePropertyThatThrows(),
@@ -38,17 +34,9 @@ describe('sidebar.localStorage', () => {
       let key = null;
 
       beforeEach(() => {
-        angular.mock.module('h', {
-          $window,
-        });
+        localStorage = service($window);
+        key = 'test.memory.key';
       });
-
-      beforeEach(
-        angular.mock.inject(_localStorage_ => {
-          localStorage = _localStorage_;
-          key = 'test.memory.key';
-        })
-      );
 
       it('sets/gets Item', () => {
         const value = 'What shall we do with a drunken sailor?';
@@ -87,14 +75,10 @@ describe('sidebar.localStorage', () => {
           removeItem: sinon.stub(),
         },
       };
-
-      angular.mock.module('h', {
-        $window: fakeWindow,
-      });
     });
 
     beforeEach(() => {
-      angular.mock.inject(_localStorage_ => (localStorage = _localStorage_));
+      localStorage = service(fakeWindow);
     });
 
     it('uses window.localStorage functions to handle data', () => {

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -1,6 +1,7 @@
-import angular from 'angular';
+import EventEmitter from 'tiny-emitter';
 
 import events from '../../events';
+import { Injector } from '../../../shared/injector';
 import * as annotationFixtures from '../../test/annotation-fixtures';
 import uiConstants from '../../ui-constants';
 import rootThreadFactory from '../root-thread';
@@ -88,21 +89,21 @@ describe('rootThread', function () {
       filter: sinon.stub(),
     };
 
-    angular
-      .module('app', [])
-      .value('annotationsService', fakeAnnotationsService)
-      .value('store', fakeStore)
-      .value('searchFilter', fakeSearchFilter)
-      .value('settings', fakeSettings)
-      .value('viewFilter', fakeViewFilter)
-      .service('rootThread', rootThreadFactory);
+    const emitter = new EventEmitter();
+    $rootScope = {
+      $on: (event, cb) => emitter.on(event, data => cb(null, data)),
+      $broadcast: (event, data) => emitter.emit(event, data),
+    };
 
-    angular.mock.module('app');
-
-    angular.mock.inject(function (_$rootScope_, _rootThread_) {
-      $rootScope = _$rootScope_;
-      rootThread = _rootThread_;
-    });
+    rootThread = new Injector()
+      .register('$rootScope', { value: $rootScope })
+      .register('annotationsService', { value: fakeAnnotationsService })
+      .register('store', { value: fakeStore })
+      .register('searchFilter', { value: fakeSearchFilter })
+      .register('settings', { value: fakeSettings })
+      .register('viewFilter', { value: fakeViewFilter })
+      .register('rootThread', rootThreadFactory)
+      .get('rootThread');
   });
 
   beforeEach(() => {

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -1,5 +1,3 @@
-import angular from 'angular';
-
 import tagsFactory from '../tags';
 
 const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
@@ -22,10 +20,6 @@ class FakeStorage {
 describe('sidebar.tags', () => {
   let fakeLocalStorage;
   let tags;
-
-  before(() => {
-    angular.module('h', []).service('tags', tagsFactory);
-  });
 
   beforeEach(() => {
     fakeLocalStorage = new FakeStorage();
@@ -58,12 +52,7 @@ describe('sidebar.tags', () => {
     fakeLocalStorage.setObject(TAGS_MAP_KEY, savedTagsMap);
     fakeLocalStorage.setObject(TAGS_LIST_KEY, savedTagsList);
 
-    angular.mock.module('h', {
-      localStorage: fakeLocalStorage,
-    });
-    angular.mock.inject(_tags_ => {
-      tags = _tags_;
-    });
+    tags = tagsFactory(fakeLocalStorage);
   });
 
   describe('#filter', () => {


### PR DESCRIPTION
As part of the migration away from Angular, replace the use of
angular-mocks for constructing service instances in tests.

 - For tests that only have one or two dependencies, call the service
   constructor directly
 - For tests that have many dependencies, enough that the order could be
   easily mixed up if calling the constructor directly, re-use the
   `Injector` class which is used to wire up services in the real
   application

Several of these tests relied on Angular's built-in `$rootScope`
service. Use of this should go away entirely soon, but for this commit,
just replace it with a minimal mock - either an object with stubs or an
`EventEmitter`.

The remaining use of `angular-mocks` following these changes is in modules which
are going to be replaced or removed as part of the UI component conversion, with the
exception of `src/sidebar/test/integration/threading-test.js` which I decided to tackle
separately.