### PR TITLE
Exclude src/test-util from code coverage metrics

### DIFF
--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -126,7 +126,7 @@ module.exports = function(config) {
               [
                 'babel-plugin-istanbul',
                 {
-                  exclude: ['**/test/**/*.{coffee,js}'],
+                  exclude: ['**/test/**/*.{coffee,js}', '**/test-util/**'],
                 },
               ],
             ],


### PR DESCRIPTION
Our current policy (in JS code at least, I think some of the Python projects differ) is not to include test-only code in coverage metrics.

This also addresses an issue that some of the code in `src/test-util/` contains branches, eg. timeout conditions, that will only be reached in some test runs.