### PR TITLE
Reformat with Prettier v2

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
 {
-  "singleQuote": true,
-  "trailingComma": "es5"
+  "arrowParens": "avoid",
+  "singleQuote": true
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,7 +41,7 @@ function parseCommandLine() {
 const taskArgs = parseCommandLine();
 
 /** A list of all modules included in vendor bundles. */
-const vendorModules = Object.keys(vendorBundles.bundles).reduce(function(
+const vendorModules = Object.keys(vendorBundles.bundles).reduce(function (
   deps,
   key
 ) {
@@ -50,9 +50,9 @@ const vendorModules = Object.keys(vendorBundles.bundles).reduce(function(
 []);
 
 // Builds the bundles containing vendor JS code
-gulp.task('build-vendor-js', function() {
+gulp.task('build-vendor-js', function () {
   const finished = [];
-  Object.keys(vendorBundles.bundles).forEach(function(name) {
+  Object.keys(vendorBundles.bundles).forEach(function (name) {
     finished.push(
       createBundle({
         name: name,
@@ -130,9 +130,9 @@ const appBundleConfigs = appBundles.concat(polyfillBundles).map(config => {
 
 gulp.task(
   'build-js',
-  gulp.parallel('build-vendor-js', function() {
+  gulp.parallel('build-vendor-js', function () {
     return Promise.all(
-      appBundleConfigs.map(function(config) {
+      appBundleConfigs.map(function (config) {
         return createBundle(config);
       })
     );
@@ -142,7 +142,7 @@ gulp.task(
 gulp.task(
   'watch-js',
   gulp.series('build-vendor-js', function watchJS() {
-    appBundleConfigs.forEach(function(config) {
+    appBundleConfigs.forEach(function (config) {
       createBundle(config, { watch: true });
     });
   })
@@ -161,7 +161,7 @@ const cssBundles = [
   './node_modules/angular-toastr/dist/angular-toastr.css',
 ];
 
-gulp.task('build-css', function() {
+gulp.task('build-css', function () {
   mkdirSync(STYLE_DIR, { recursive: true });
   const bundles = cssBundles.map(entry =>
     createStyleBundle({
@@ -189,7 +189,7 @@ const fontFiles = [
   'node_modules/katex/dist/fonts/*.woff2',
 ];
 
-gulp.task('build-fonts', function() {
+gulp.task('build-fonts', function () {
   return gulp
     .src(fontFiles)
     .pipe(changed(FONTS_DIR))
@@ -204,7 +204,7 @@ gulp.task(
 );
 
 const imageFiles = 'src/images/**/*';
-gulp.task('build-images', function() {
+gulp.task('build-images', function () {
   return gulp
     .src(imageFiles)
     .pipe(changed(IMAGES_DIR))
@@ -273,7 +273,7 @@ function generateManifest(opts) {
     .src(MANIFEST_SOURCE_FILES)
     .pipe(manifest({ name: 'manifest.json' }))
     .pipe(
-      through.obj(function(file, enc, callback) {
+      through.obj(function (file, enc, callback) {
         const newManifest = JSON.parse(file.contents.toString());
 
         // Expand template vars in boot script bundle
@@ -286,17 +286,17 @@ function generateManifest(opts) {
     .pipe(gulp.dest('build/'));
 }
 
-gulp.task('watch-manifest', function() {
+gulp.task('watch-manifest', function () {
   gulp.watch(MANIFEST_SOURCE_FILES, { delay: 500 }, function updateManifest() {
     return generateManifest({ usingDevServer: true });
   });
 });
 
-gulp.task('serve-package', function() {
+gulp.task('serve-package', function () {
   servePackage(3001);
 });
 
-gulp.task('serve-test-pages', function() {
+gulp.task('serve-test-pages', function () {
   const DevServer = require('./scripts/gulp/dev-server');
   new DevServer(3000, {
     // The scheme is omitted here as the client asset server will use the same

--- a/scripts/decaf/decaf.js
+++ b/scripts/decaf/decaf.js
@@ -193,7 +193,7 @@ process.argv.slice(2).forEach(filePath => {
   const inFile = path.resolve(filePath);
   const outFile = inFile.replace(/\.coffee$/, '.js');
   conversions.push(
-    toResultOrError(convertFile(inFile, outFile)).then(function(result) {
+    toResultOrError(convertFile(inFile, outFile)).then(function (result) {
       result.fileName = inFile;
       return result;
     })

--- a/scripts/gulp/create-bundle.js
+++ b/scripts/gulp/create-bundle.js
@@ -17,14 +17,14 @@ const watchify = require('watchify');
 const minifyStream = require('./minify-stream');
 
 function streamFinished(stream) {
-  return new Promise(function(resolve, reject) {
+  return new Promise(function (resolve, reject) {
     stream.on('finish', resolve);
     stream.on('error', reject);
   });
 }
 
 function waitForever() {
-  return new Promise(function() {});
+  return new Promise(function () {});
 }
 
 /**
@@ -99,7 +99,7 @@ module.exports = function createBundle(config, buildOpts) {
       // `global` or `self` that is not an alias for `window`. See
       // https://github.com/hypothesis/h/issues/2723 and
       // https://github.com/hypothesis/client/issues/277
-      global: function() {
+      global: function () {
         return 'window';
       },
     },
@@ -113,7 +113,7 @@ module.exports = function createBundle(config, buildOpts) {
   // Specify modules that Browserify should not parse.
   // The 'noParse' array must contain full file paths,
   // not module names.
-  bundleOpts.noParse = (config.noParse || []).map(function(id) {
+  bundleOpts.noParse = (config.noParse || []).map(function (id) {
     // If package.json specifies a custom entry point for the module for
     // use in the browser, resolve that.
     const packageConfig = require('../../package.json');
@@ -150,7 +150,7 @@ module.exports = function createBundle(config, buildOpts) {
 
   const bundle = browserify([], bundleOpts);
 
-  (config.require || []).forEach(function(req) {
+  (config.require || []).forEach(function (req) {
     // When another bundle uses 'bundle.external(<module path>)',
     // the module path is rewritten relative to the
     // base directory and a '/' prefix is added, so
@@ -181,7 +181,7 @@ module.exports = function createBundle(config, buildOpts) {
   bundle.add(config.entry || []);
   bundle.external(config.external || []);
 
-  (config.transforms || []).forEach(function(transform) {
+  (config.transforms || []).forEach(function (transform) {
     if (transform === 'coffee') {
       bundle.transform(coffeeify);
     }
@@ -210,7 +210,7 @@ module.exports = function createBundle(config, buildOpts) {
   function build() {
     const output = fs.createWriteStream(bundlePath);
     let stream = bundle.bundle();
-    stream.on('error', function(err) {
+    stream.on('error', function (err) {
       log('Build error', err.toString());
     });
 
@@ -224,23 +224,23 @@ module.exports = function createBundle(config, buildOpts) {
 
   if (buildOpts.watch) {
     bundle.plugin(watchify);
-    bundle.on('update', function(ids) {
+    bundle.on('update', function (ids) {
       const start = Date.now();
 
       log('Source files changed', ids);
       build()
-        .then(function() {
+        .then(function () {
           log('Updated %s (%d ms)', bundleFileName, Date.now() - start);
         })
-        .catch(function(err) {
+        .catch(function (err) {
           console.error('Building updated bundle failed:', err);
         });
     });
     build()
-      .then(function() {
+      .then(function () {
         log('Built ' + bundleFileName);
       })
-      .catch(function(err) {
+      .catch(function (err) {
         console.error('Error building bundle:', err);
       });
 

--- a/scripts/gulp/dev-server.js
+++ b/scripts/gulp/dev-server.js
@@ -33,7 +33,7 @@ function codeOfConductText() {
  */
 function DevServer(port, config) {
   function listen() {
-    const app = function(req, response) {
+    const app = function (req, response) {
       const url = urlParser.parse(req.url);
       let content;
 
@@ -136,7 +136,7 @@ function DevServer(port, config) {
     };
 
     const server = createServer(app);
-    server.listen(port, function(err) {
+    server.listen(port, function (err) {
       if (err) {
         log('Setting up dev server failed', err);
       }

--- a/scripts/gulp/manifest.js
+++ b/scripts/gulp/manifest.js
@@ -14,11 +14,11 @@ const VinylFile = require('vinyl');
  * manifest mapping input paths (eg. "scripts/foo.js")
  * to URLs with cache-busting query parameters (eg. "scripts/foo.js?af95bd").
  */
-module.exports = function(opts) {
+module.exports = function (opts) {
   const manifest = {};
 
   return through.obj(
-    function(file, enc, callback) {
+    function (file, enc, callback) {
       const hash = crypto.createHash('sha1');
       hash.update(file.contents);
 
@@ -28,7 +28,7 @@ module.exports = function(opts) {
 
       callback();
     },
-    function(callback) {
+    function (callback) {
       const manifestFile = new VinylFile({
         path: opts.name,
         contents: Buffer.from(JSON.stringify(manifest, null, 2), 'utf-8'),

--- a/scripts/gulp/serve-package.js
+++ b/scripts/gulp/serve-package.js
@@ -23,13 +23,13 @@ function servePackage(port) {
   const app = express();
 
   // Enable CORS for assets so that cross-origin font loading works.
-  app.use(function(req, res, next) {
+  app.use(function (req, res, next) {
     res.append('Access-Control-Allow-Origin', '*');
     res.append('Access-Control-Allow-Methods', 'GET');
     next();
   });
 
-  const serveBootScript = function(req, res) {
+  const serveBootScript = function (req, res) {
     const entryPath = require.resolve('../..');
     const entryScript = readFileSync(entryPath).toString('utf-8');
     res.send(entryScript);

--- a/src/annotator/anchoring/test/html-test.js
+++ b/src/annotator/anchoring/test/html-test.js
@@ -63,7 +63,7 @@ function toRange(root, descriptor) {
 }
 
 function findByType(selectors, type) {
-  return selectors.find(function(s) {
+  return selectors.find(function (s) {
     return s.type === type;
   });
 }
@@ -72,7 +72,7 @@ function findByType(selectors, type) {
  * Return a copy of a list of selectors sorted by type.
  */
 function sortByType(selectors) {
-  return selectors.slice().sort(function(a, b) {
+  return selectors.slice().sort(function (a, b) {
     return a.type.localeCompare(b.type);
   });
 }
@@ -305,16 +305,16 @@ const expectedFailures = [
   // Currently empty.
 ];
 
-describe('HTML anchoring', function() {
+describe('HTML anchoring', function () {
   let container;
 
-  beforeEach(function() {
+  beforeEach(function () {
     container = document.createElement('section');
     container.innerHTML = fixture;
     document.body.appendChild(container);
   });
 
-  afterEach(function() {
+  afterEach(function () {
     container.remove();
   });
 
@@ -346,7 +346,7 @@ describe('HTML anchoring', function() {
       const positionSel = findByType(selectors, 'TextPositionSelector');
       const quoteSel = findByType(selectors, 'TextQuoteSelector');
 
-      const failInfo = expectedFailures.find(function(f) {
+      const failInfo = expectedFailures.find(function (f) {
         return f[0] === testCase.description;
       });
       let failTypes = {};
@@ -364,8 +364,8 @@ describe('HTML anchoring', function() {
 
       // Map each selector back to a Range and check that it refers to the same
       // text. We test each selector in turn to make sure they are all valid.
-      const anchored = selectors.map(function(sel) {
-        return html.anchor(container, [sel]).then(function(anchoredRange) {
+      const anchored = selectors.map(function (sel) {
+        return html.anchor(container, [sel]).then(function (anchoredRange) {
           assert.equal(range.toString(), anchoredRange.toString());
         });
       });
@@ -373,26 +373,26 @@ describe('HTML anchoring', function() {
     });
   });
 
-  describe('When anchoring fails', function() {
+  describe('When anchoring fails', function () {
     const validQuoteSelector = {
       type: 'TextQuoteSelector',
       exact: 'Lorem ipsum',
     };
 
-    it('throws an error if anchoring using a quote fails', function() {
+    it('throws an error if anchoring using a quote fails', function () {
       const quoteSelector = {
         type: 'TextQuoteSelector',
         exact: 'This text does not appear in the web page',
       };
 
-      return toResult(html.anchor(container, [quoteSelector])).then(function(
+      return toResult(html.anchor(container, [quoteSelector])).then(function (
         result
       ) {
         assert.equal(result.error.message, 'Quote not found');
       });
     });
 
-    it('does not throw an error if anchoring using a position fails', function() {
+    it('does not throw an error if anchoring using a position fails', function () {
       const positionSelector = {
         type: 'TextPositionSelector',
         start: 1000,
@@ -404,7 +404,7 @@ describe('HTML anchoring', function() {
       return html.anchor(container, [positionSelector, validQuoteSelector]);
     });
 
-    it('does not throw an error if anchoring using a range fails', function() {
+    it('does not throw an error if anchoring using a range fails', function () {
       const rangeSelector = {
         type: 'RangeSelector',
         startContainer: '/main',
@@ -419,15 +419,15 @@ describe('HTML anchoring', function() {
     });
   });
 
-  describe('Web page baselines', function() {
+  describe('Web page baselines', function () {
     let frame;
 
-    before(function() {
+    before(function () {
       frame = document.createElement('iframe');
       document.body.appendChild(frame);
     });
 
-    after(function() {
+    after(function () {
       frame.remove();
     });
 
@@ -449,18 +449,18 @@ describe('HTML anchoring', function() {
 
         frame.contentWindow.document.documentElement.innerHTML = fixtureHtml;
 
-        const annotationsChecked = annotations.map(function(ann) {
+        const annotationsChecked = annotations.map(function (ann) {
           // Anchor the existing selectors
           const root = frame.contentWindow.document.body;
           const selectors = ann.target[0].selector;
           const result = html.anchor(root, selectors);
           return result
-            .then(function(range) {
+            .then(function (range) {
               // Re-anchor the selectors and check that the new and existing
               // selectors match.
               return html.describe(root, range);
             })
-            .then(function(newSelectors) {
+            .then(function (newSelectors) {
               assert.deepEqual(sortByType(selectors), sortByType(newSelectors));
             });
         });

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -37,11 +37,11 @@ const fixtures = {
   ],
 };
 
-describe('annotator/anchoring/pdf', function() {
+describe('annotator/anchoring/pdf', function () {
   let container;
   let viewer;
 
-  beforeEach(function() {
+  beforeEach(function () {
     // The rendered text for each page is cached during anchoring.
     // Clear this here so that each test starts from the same state.
     pdfAnchoring.purgeCache();
@@ -56,42 +56,42 @@ describe('annotator/anchoring/pdf', function() {
     viewer.pdfViewer.setCurrentPage(0);
   });
 
-  afterEach(function() {
+  afterEach(function () {
     window.PDFViewerApplication.dispose();
     window.PDFViewerApplication = null;
     container.remove();
   });
 
-  describe('#describe', function() {
-    it('returns position and quote selectors', function() {
+  describe('#describe', function () {
+    it('returns position and quote selectors', function () {
       viewer.pdfViewer.setCurrentPage(2);
       const range = findText(container, 'Netherfield Park');
-      return pdfAnchoring.describe(container, range).then(function(selectors) {
-        const types = selectors.map(function(s) {
+      return pdfAnchoring.describe(container, range).then(function (selectors) {
+        const types = selectors.map(function (s) {
           return s.type;
         });
         assert.deepEqual(types, ['TextPositionSelector', 'TextQuoteSelector']);
       });
     });
 
-    it('returns a position selector with correct start/end offsets', function() {
+    it('returns a position selector with correct start/end offsets', function () {
       viewer.pdfViewer.setCurrentPage(2);
       const quote = 'Netherfield Park';
       const range = findText(container, quote);
       const contentStr = fixtures.pdfPages.join('');
       const expectedPos = contentStr.replace(/\n/g, '').lastIndexOf(quote);
 
-      return pdfAnchoring.describe(container, range).then(function(selectors) {
+      return pdfAnchoring.describe(container, range).then(function (selectors) {
         const position = selectors[0];
         assert.equal(position.start, expectedPos);
         assert.equal(position.end, expectedPos + quote.length);
       });
     });
 
-    it('returns a quote selector with the correct quote', function() {
+    it('returns a quote selector with the correct quote', function () {
       viewer.pdfViewer.setCurrentPage(2);
       const range = findText(container, 'Netherfield Park');
-      return pdfAnchoring.describe(container, range).then(function(selectors) {
+      return pdfAnchoring.describe(container, range).then(function (selectors) {
         const quote = selectors[1];
 
         assert.deepEqual(quote, {
@@ -103,7 +103,7 @@ describe('annotator/anchoring/pdf', function() {
       });
     });
 
-    it('returns selector when range starts at end of text node with no next siblings', function() {
+    it('returns selector when range starts at end of text node with no next siblings', function () {
       // this problem is referenced in client issue #122
       // But what is happening is the startContainer is referencing a text
       // elment inside of a node. The logic in pdf#describe() was assuming if the
@@ -132,7 +132,7 @@ describe('annotator/anchoring/pdf', function() {
       const contentStr = fixtures.pdfPages.join('');
       const expectedPos = contentStr.replace(/\n/g, '').lastIndexOf(quote);
 
-      return pdfAnchoring.describe(container, range).then(function(selectors) {
+      return pdfAnchoring.describe(container, range).then(function (selectors) {
         const position = selectors[0];
         assert.equal(position.start, expectedPos);
         assert.equal(position.end, expectedPos + quote.length);
@@ -152,33 +152,33 @@ describe('annotator/anchoring/pdf', function() {
     });
   });
 
-  describe('#anchor', function() {
-    it('anchors previously created selectors if the page is rendered', function() {
+  describe('#anchor', function () {
+    it('anchors previously created selectors if the page is rendered', function () {
       viewer.pdfViewer.setCurrentPage(2);
       const range = findText(container, 'My dear Mr. Bennet');
-      return pdfAnchoring.describe(container, range).then(function(selectors) {
+      return pdfAnchoring.describe(container, range).then(function (selectors) {
         const position = selectors[0];
         const quote = selectors[1];
 
         // Test that all of the selectors anchor and that each selector individually
         // anchors correctly as well
         const subsets = [[position, quote], [position], [quote]];
-        const subsetsAnchored = subsets.map(function(subset) {
-          const types = subset.map(function(s) {
+        const subsetsAnchored = subsets.map(function (subset) {
+          const types = subset.map(function (s) {
             return s.type;
           });
           const description = 'anchoring failed with ' + types.join(', ');
 
           return pdfAnchoring
             .anchor(container, subset)
-            .then(function(anchoredRange) {
+            .then(function (anchoredRange) {
               assert.equal(
                 anchoredRange.toString(),
                 range.toString(),
                 description
               );
             })
-            .catch(function(err) {
+            .catch(function (err) {
               console.warn(description);
               throw err;
             });
@@ -214,12 +214,12 @@ describe('annotator/anchoring/pdf', function() {
         offset: 100000,
       },
     ].forEach(({ offset }) => {
-      it('anchors using a quote if the position selector fails', function() {
+      it('anchors using a quote if the position selector fails', function () {
         viewer.pdfViewer.setCurrentPage(0);
         const range = findText(container, 'Pride And Prejudice');
         return pdfAnchoring
           .describe(container, range)
-          .then(function(selectors) {
+          .then(function (selectors) {
             const position = selectors[0];
             const quote = selectors[1];
 
@@ -234,16 +234,16 @@ describe('annotator/anchoring/pdf', function() {
       });
     });
 
-    it('anchors to a placeholder element if the page is not rendered', function() {
+    it('anchors to a placeholder element if the page is not rendered', function () {
       viewer.pdfViewer.setCurrentPage(2);
       const range = findText(container, 'Netherfield Park');
       return pdfAnchoring
         .describe(container, range)
-        .then(function(selectors) {
+        .then(function (selectors) {
           viewer.pdfViewer.setCurrentPage(0);
           return pdfAnchoring.anchor(container, selectors);
         })
-        .then(function(anchoredRange) {
+        .then(function (anchoredRange) {
           assert.equal(anchoredRange.toString(), 'Loading annotations…');
         });
     });

--- a/src/annotator/anchoring/test/types-test.js
+++ b/src/annotator/anchoring/test/types-test.js
@@ -6,10 +6,10 @@ const TextPositionAnchor = types.TextPositionAnchor;
 // These are primarily basic API tests for the anchoring classes. Tests for
 // anchoring a variety of HTML and PDF content exist in `html-test` and
 // `pdf-test`.
-describe('types', function() {
+describe('types', function () {
   let container;
 
-  before(function() {
+  before(function () {
     container = document.createElement('div');
     container.innerHTML = [
       'Four score and seven years ago our fathers brought forth on this continent,',
@@ -19,43 +19,43 @@ describe('types', function() {
     document.body.appendChild(container);
   });
 
-  after(function() {
+  after(function () {
     container.remove();
   });
 
-  describe('TextQuoteAnchor', function() {
-    describe('#toRange', function() {
-      it('returns a valid DOM Range', function() {
+  describe('TextQuoteAnchor', function () {
+    describe('#toRange', function () {
+      it('returns a valid DOM Range', function () {
         const quoteAnchor = new TextQuoteAnchor(container, 'Liberty');
         const range = quoteAnchor.toRange();
         assert.instanceOf(range, Range);
         assert.equal(range.toString(), 'Liberty');
       });
 
-      it('throws if the quote is not found', function() {
+      it('throws if the quote is not found', function () {
         const quoteAnchor = new TextQuoteAnchor(
           container,
           'five score and nine years ago'
         );
-        assert.throws(function() {
+        assert.throws(function () {
           quoteAnchor.toRange();
         });
       });
     });
 
-    describe('#toPositionAnchor', function() {
-      it('returns a TextPositionAnchor', function() {
+    describe('#toPositionAnchor', function () {
+      it('returns a TextPositionAnchor', function () {
         const quoteAnchor = new TextQuoteAnchor(container, 'Liberty');
         const pos = quoteAnchor.toPositionAnchor();
         assert.instanceOf(pos, TextPositionAnchor);
       });
 
-      it('throws if the quote is not found', function() {
+      it('throws if the quote is not found', function () {
         const quoteAnchor = new TextQuoteAnchor(
           container,
           'some are more equal than others'
         );
-        assert.throws(function() {
+        assert.throws(function () {
           quoteAnchor.toPositionAnchor();
         });
       });

--- a/src/annotator/annotation-counts.js
+++ b/src/annotator/annotation-counts.js
@@ -18,7 +18,7 @@ export default function annotationCounts(rootEl, crossframe) {
 
   function updateAnnotationCountElems(newCount) {
     const elems = rootEl.querySelectorAll('[' + ANNOTATION_COUNT_ATTR + ']');
-    Array.from(elems).forEach(function(elem) {
+    Array.from(elems).forEach(function (elem) {
       elem.textContent = newCount;
     });
   }

--- a/src/annotator/annotation-sync.js
+++ b/src/annotator/annotation-sync.js
@@ -22,16 +22,16 @@ export default function AnnotationSync(bridge, options) {
   this._emit = options.emit;
 
   // Listen locally for interesting events
-  Object.keys(this._eventListeners).forEach(function(eventName) {
+  Object.keys(this._eventListeners).forEach(function (eventName) {
     const listener = self._eventListeners[eventName];
-    self._on(eventName, function(annotation) {
+    self._on(eventName, function (annotation) {
       listener.apply(self, [annotation]);
     });
   });
 
   // Register remotely invokable methods
-  Object.keys(this._channelListeners).forEach(function(eventName) {
-    self.bridge.on(eventName, function(data, callbackFunction) {
+  Object.keys(this._channelListeners).forEach(function (eventName) {
+    self.bridge.on(eventName, function (data, callbackFunction) {
       const listener = self._channelListeners[eventName];
       listener.apply(self, [data, callbackFunction]);
     });
@@ -42,8 +42,8 @@ export default function AnnotationSync(bridge, options) {
 // association of annotations received in arguments to window-local copies.
 AnnotationSync.prototype.cache = null;
 
-AnnotationSync.prototype.sync = function(annotations) {
-  annotations = function() {
+AnnotationSync.prototype.sync = function (annotations) {
+  annotations = function () {
     let i;
     const formattedAnnotations = [];
 
@@ -55,8 +55,8 @@ AnnotationSync.prototype.sync = function(annotations) {
   this.bridge.call(
     'sync',
     annotations,
-    (function(_this) {
-      return function(err, annotations) {
+    (function (_this) {
+      return function (err, annotations) {
         let i;
         const parsedAnnotations = [];
         annotations = annotations || [];
@@ -73,14 +73,14 @@ AnnotationSync.prototype.sync = function(annotations) {
 
 // Handlers for messages arriving through a channel
 AnnotationSync.prototype._channelListeners = {
-  deleteAnnotation: function(body, cb) {
+  deleteAnnotation: function (body, cb) {
     const annotation = this._parse(body);
     delete this.cache[annotation.$tag];
     this._emit('annotationDeleted', annotation);
     cb(null, this._format(annotation));
   },
-  loadAnnotations: function(bodies, cb) {
-    const annotations = function() {
+  loadAnnotations: function (bodies, cb) {
+    const annotations = function () {
       let i;
       const parsedAnnotations = [];
 
@@ -96,7 +96,7 @@ AnnotationSync.prototype._channelListeners = {
 
 // Handlers for events coming from this frame, to send them across the channel
 AnnotationSync.prototype._eventListeners = {
-  beforeAnnotationCreated: function(annotation) {
+  beforeAnnotationCreated: function (annotation) {
     if (annotation.$tag) {
       return undefined;
     }
@@ -106,14 +106,14 @@ AnnotationSync.prototype._eventListeners = {
   },
 };
 
-AnnotationSync.prototype._mkCallRemotelyAndParseResults = function(
+AnnotationSync.prototype._mkCallRemotelyAndParseResults = function (
   method,
   callBack
 ) {
-  return (function(_this) {
-    return function(annotation) {
+  return (function (_this) {
+    return function (annotation) {
       // Wrap the callback function to first parse returned items
-      const wrappedCallback = function(failure, results) {
+      const wrappedCallback = function (failure, results) {
         if (failure === null) {
           _this._parseResults(results);
         }
@@ -128,7 +128,7 @@ AnnotationSync.prototype._mkCallRemotelyAndParseResults = function(
 };
 
 // Parse returned message bodies to update cache with any changes made remotely
-AnnotationSync.prototype._parseResults = function(results) {
+AnnotationSync.prototype._parseResults = function (results) {
   let bodies;
   let body;
   let i;
@@ -148,7 +148,7 @@ AnnotationSync.prototype._parseResults = function(results) {
 
 // Assign a non-enumerable tag to objects which cross the bridge.
 // This tag is used to identify the objects between message.
-AnnotationSync.prototype._tag = function(ann, tag) {
+AnnotationSync.prototype._tag = function (ann, tag) {
   if (ann.$tag) {
     return ann;
   }
@@ -161,13 +161,13 @@ AnnotationSync.prototype._tag = function(ann, tag) {
 };
 
 // Parse a message body from a RPC call with the provided parser.
-AnnotationSync.prototype._parse = function(body) {
+AnnotationSync.prototype._parse = function (body) {
   const merged = Object.assign(this.cache[body.tag] || {}, body.msg);
   return this._tag(merged, body.tag);
 };
 
 // Format an annotation into an RPC message body with the provided formatter.
-AnnotationSync.prototype._format = function(ann) {
+AnnotationSync.prototype._format = function (ann) {
   this._tag(ann);
   return {
     tag: ann.$tag,

--- a/src/annotator/config/test/config-func-settings-from-test.js
+++ b/src/annotator/config/test/config-func-settings-from-test.js
@@ -1,22 +1,22 @@
 import configFuncSettingsFrom from '../config-func-settings-from';
 
-describe('annotator.config.configFuncSettingsFrom', function() {
+describe('annotator.config.configFuncSettingsFrom', function () {
   const sandbox = sinon.createSandbox();
 
-  afterEach('reset the sandbox', function() {
+  afterEach('reset the sandbox', function () {
     sandbox.restore();
   });
 
-  context("when there's no window.hypothesisConfig() function", function() {
-    it('returns {}', function() {
+  context("when there's no window.hypothesisConfig() function", function () {
+    it('returns {}', function () {
       const fakeWindow = {};
 
       assert.deepEqual(configFuncSettingsFrom(fakeWindow), {});
     });
   });
 
-  context("when window.hypothesisConfig() isn't a function", function() {
-    beforeEach('stub console.warn()', function() {
+  context("when window.hypothesisConfig() isn't a function", function () {
+    beforeEach('stub console.warn()', function () {
       sandbox.stub(console, 'warn');
     });
 
@@ -24,11 +24,11 @@ describe('annotator.config.configFuncSettingsFrom', function() {
       return { hypothesisConfig: 42 };
     }
 
-    it('returns {}', function() {
+    it('returns {}', function () {
       assert.deepEqual(configFuncSettingsFrom(fakeWindow()), {});
     });
 
-    it('logs a warning', function() {
+    it('logs a warning', function () {
       configFuncSettingsFrom(fakeWindow());
 
       assert.calledOnce(console.warn);
@@ -40,8 +40,8 @@ describe('annotator.config.configFuncSettingsFrom', function() {
     });
   });
 
-  context('when window.hypothesisConfig() is a function', function() {
-    it('returns whatever window.hypothesisConfig() returns', function() {
+  context('when window.hypothesisConfig() is a function', function () {
+    it('returns whatever window.hypothesisConfig() returns', function () {
       // It just blindly returns whatever hypothesisConfig() returns
       // (even if it's not an object).
       const fakeWindow = { hypothesisConfig: sinon.stub().returns(42) };

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -1,7 +1,7 @@
 import configFrom from '../index';
 import { $imports } from '../index';
 
-describe('annotator.config.index', function() {
+describe('annotator.config.index', function () {
   let fakeSettingsFrom;
 
   beforeEach(() => {
@@ -18,7 +18,7 @@ describe('annotator.config.index', function() {
     $imports.$restore();
   });
 
-  it('gets the configuration settings', function() {
+  it('gets the configuration settings', function () {
     configFrom('WINDOW');
 
     assert.calledOnce(fakeSettingsFrom);
@@ -37,28 +37,28 @@ describe('annotator.config.index', function() {
     }
   );
 
-  context("when there's no application/annotator+html <link>", function() {
-    beforeEach('remove the application/annotator+html <link>', function() {
+  context("when there's no application/annotator+html <link>", function () {
+    beforeEach('remove the application/annotator+html <link>', function () {
       Object.defineProperty(fakeSettingsFrom(), 'sidebarAppUrl', {
         get: sinon.stub().throws(new Error("there's no link")),
       });
     });
 
-    it('throws an error', function() {
-      assert.throws(function() {
+    it('throws an error', function () {
+      assert.throws(function () {
         configFrom('WINDOW');
       }, "there's no link");
     });
   });
 
-  ['assetRoot', 'subFrameIdentifier', 'openSidebar'].forEach(function(
+  ['assetRoot', 'subFrameIdentifier', 'openSidebar'].forEach(function (
     settingName
   ) {
     it(
       'reads ' +
         settingName +
         ' from the host page, even when in a browser extension',
-      function() {
+      function () {
         configFrom('WINDOW');
 
         assert.calledWithExactly(
@@ -70,12 +70,12 @@ describe('annotator.config.index', function() {
     );
   });
 
-  ['branding', 'services'].forEach(function(settingName) {
+  ['branding', 'services'].forEach(function (settingName) {
     it(
       'reads ' +
         settingName +
         ' from the host page only when in an embedded client',
-      function() {
+      function () {
         configFrom('WINDOW');
 
         assert.calledWithExactly(
@@ -92,8 +92,8 @@ describe('annotator.config.index', function() {
     'openSidebar',
     'requestConfigFromFrame',
     'services',
-  ].forEach(function(settingName) {
-    it('returns the ' + settingName + ' value from the host page', function() {
+  ].forEach(function (settingName) {
+    it('returns the ' + settingName + ' value from the host page', function () {
       const settings = {
         assetRoot: 'chrome-extension://1234/client/',
         branding: 'BRANDING_SETTING',
@@ -101,7 +101,7 @@ describe('annotator.config.index', function() {
         requestConfigFromFrame: 'https://embedder.com',
         services: 'SERVICES_SETTING',
       };
-      fakeSettingsFrom().hostPageSetting = function(settingName) {
+      fakeSettingsFrom().hostPageSetting = function (settingName) {
         return settings[settingName];
       };
 

--- a/src/annotator/config/test/is-browser-extension-test.js
+++ b/src/annotator/config/test/is-browser-extension-test.js
@@ -1,6 +1,6 @@
 import isBrowserExtension from '../is-browser-extension';
 
-describe('annotator.config.isBrowserExtension', function() {
+describe('annotator.config.isBrowserExtension', function () {
   [
     {
       url: 'chrome-extension://abcxyz',
@@ -27,8 +27,8 @@ describe('annotator.config.isBrowserExtension', function() {
       url: 'ftp://partner.org',
       returns: true,
     },
-  ].forEach(function(test) {
-    it('returns ' + test.returns + ' for ' + test.url, function() {
+  ].forEach(function (test) {
+    it('returns ' + test.returns + ' for ' + test.url, function () {
       assert.equal(isBrowserExtension(test.url), test.returns);
     });
   });

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -1,7 +1,7 @@
 import settingsFrom from '../settings';
 import { $imports } from '../settings';
 
-describe('annotator.config.settingsFrom', function() {
+describe('annotator.config.settingsFrom', function () {
   let fakeConfigFuncSettingsFrom;
   let fakeIsBrowserExtension;
   let fakeSharedSettings;
@@ -24,7 +24,7 @@ describe('annotator.config.settingsFrom', function() {
     $imports.$restore();
   });
 
-  describe('#sidebarAppUrl', function() {
+  describe('#sidebarAppUrl', function () {
     function appendSidebarLinkToDocument(href) {
       const link = document.createElement('link');
       link.type = 'application/annotator+html';
@@ -36,18 +36,18 @@ describe('annotator.config.settingsFrom', function() {
       return link;
     }
 
-    context("when there's an application/annotator+html link", function() {
+    context("when there's an application/annotator+html link", function () {
       let link;
 
-      beforeEach('add an application/annotator+html <link>', function() {
+      beforeEach('add an application/annotator+html <link>', function () {
         link = appendSidebarLinkToDocument('http://example.com/app.html');
       });
 
-      afterEach('tidy up the link', function() {
+      afterEach('tidy up the link', function () {
         document.head.removeChild(link);
       });
 
-      it('returns the href from the link', function() {
+      it('returns the href from the link', function () {
         assert.equal(
           settingsFrom(window).sidebarAppUrl,
           'http://example.com/app.html'
@@ -55,21 +55,21 @@ describe('annotator.config.settingsFrom', function() {
       });
     });
 
-    context('when there are multiple annotator+html links', function() {
+    context('when there are multiple annotator+html links', function () {
       let link1;
       let link2;
 
-      beforeEach('add two links to the document', function() {
+      beforeEach('add two links to the document', function () {
         link1 = appendSidebarLinkToDocument('http://example.com/app1');
         link2 = appendSidebarLinkToDocument('http://example.com/app2');
       });
 
-      afterEach('tidy up the links', function() {
+      afterEach('tidy up the links', function () {
         document.head.removeChild(link1);
         document.head.removeChild(link2);
       });
 
-      it('returns the href from the first one', function() {
+      it('returns the href from the first one', function () {
         assert.equal(
           settingsFrom(window).sidebarAppUrl,
           'http://example.com/app1'
@@ -77,37 +77,37 @@ describe('annotator.config.settingsFrom', function() {
       });
     });
 
-    context('when the annotator+html link has no href', function() {
+    context('when the annotator+html link has no href', function () {
       let link;
 
       beforeEach(
         'add an application/annotator+html <link> with no href',
-        function() {
+        function () {
           link = appendSidebarLinkToDocument();
         }
       );
 
-      afterEach('tidy up the link', function() {
+      afterEach('tidy up the link', function () {
         document.head.removeChild(link);
       });
 
-      it('throws an error', function() {
-        assert.throws(function() {
+      it('throws an error', function () {
+        assert.throws(function () {
           settingsFrom(window).sidebarAppUrl; // eslint-disable-line no-unused-expressions
         }, 'application/annotator+html (rel="sidebar") link has no href');
       });
     });
 
-    context("when there's no annotator+html link", function() {
-      it('throws an error', function() {
-        assert.throws(function() {
+    context("when there's no annotator+html link", function () {
+      it('throws an error', function () {
+        assert.throws(function () {
           settingsFrom(window).sidebarAppUrl; // eslint-disable-line no-unused-expressions
         }, 'No application/annotator+html (rel="sidebar") link in the document');
       });
     });
   });
 
-  describe('#clientUrl', function() {
+  describe('#clientUrl', function () {
     function appendClientUrlLinkToDocument(href) {
       const link = document.createElement('link');
       link.type = 'application/annotator+javascript';
@@ -121,21 +121,21 @@ describe('annotator.config.settingsFrom', function() {
 
     context(
       "when there's an application/annotator+javascript link",
-      function() {
+      function () {
         let link;
 
         beforeEach(
           'add an application/annotator+javascript <link>',
-          function() {
+          function () {
             link = appendClientUrlLinkToDocument('http://example.com/app.html');
           }
         );
 
-        afterEach('tidy up the link', function() {
+        afterEach('tidy up the link', function () {
           document.head.removeChild(link);
         });
 
-        it('returns the href from the link', function() {
+        it('returns the href from the link', function () {
           assert.equal(
             settingsFrom(window).clientUrl,
             'http://example.com/app.html'
@@ -144,49 +144,49 @@ describe('annotator.config.settingsFrom', function() {
       }
     );
 
-    context('when there are multiple annotator+javascript links', function() {
+    context('when there are multiple annotator+javascript links', function () {
       let link1;
       let link2;
 
-      beforeEach('add two links to the document', function() {
+      beforeEach('add two links to the document', function () {
         link1 = appendClientUrlLinkToDocument('http://example.com/app1');
         link2 = appendClientUrlLinkToDocument('http://example.com/app2');
       });
 
-      afterEach('tidy up the links', function() {
+      afterEach('tidy up the links', function () {
         document.head.removeChild(link1);
         document.head.removeChild(link2);
       });
 
-      it('returns the href from the first one', function() {
+      it('returns the href from the first one', function () {
         assert.equal(settingsFrom(window).clientUrl, 'http://example.com/app1');
       });
     });
 
-    context('when the annotator+javascript link has no href', function() {
+    context('when the annotator+javascript link has no href', function () {
       let link;
 
       beforeEach(
         'add an application/annotator+javascript <link> with no href',
-        function() {
+        function () {
           link = appendClientUrlLinkToDocument();
         }
       );
 
-      afterEach('tidy up the link', function() {
+      afterEach('tidy up the link', function () {
         document.head.removeChild(link);
       });
 
-      it('throws an error', function() {
-        assert.throws(function() {
+      it('throws an error', function () {
+        assert.throws(function () {
           settingsFrom(window).clientUrl; // eslint-disable-line no-unused-expressions
         }, 'application/annotator+javascript (rel="hypothesis-client") link has no href');
       });
     });
 
-    context("when there's no annotator+javascript link", function() {
-      it('throws an error', function() {
-        assert.throws(function() {
+    context("when there's no annotator+javascript link", function () {
+      it('throws an error', function () {
+        assert.throws(function () {
           settingsFrom(window).clientUrl; // eslint-disable-line no-unused-expressions
         }, 'No application/annotator+javascript (rel="hypothesis-client") link in the document');
       });
@@ -204,20 +204,20 @@ describe('annotator.config.settingsFrom', function() {
     };
   }
 
-  describe('#annotations', function() {
+  describe('#annotations', function () {
     context(
       'when the host page has a js-hypothesis-config with an annotations setting',
-      function() {
+      function () {
         beforeEach(
           'add a js-hypothesis-config annotations setting',
-          function() {
+          function () {
             fakeSharedSettings.jsonConfigsFrom.returns({
               annotations: 'annotationsFromJSON',
             });
           }
         );
 
-        it('returns the annotations from the js-hypothesis-config script', function() {
+        it('returns the annotations from the js-hypothesis-config script', function () {
           assert.equal(
             settingsFrom(fakeWindow()).annotations,
             'annotationsFromJSON'
@@ -226,10 +226,10 @@ describe('annotator.config.settingsFrom', function() {
 
         context(
           "when there's also an annotations in the URL fragment",
-          function() {
+          function () {
             specify(
               'js-hypothesis-config annotations override URL ones',
-              function() {
+              function () {
                 const window_ = fakeWindow(
                   'http://localhost:3000#annotations:annotationsFromURL'
                 );
@@ -270,9 +270,9 @@ describe('annotator.config.settingsFrom', function() {
         url: 'http://localhost:3000',
         returns: null,
       },
-    ].forEach(function(test) {
-      describe(test.describe, function() {
-        it(test.it, function() {
+    ].forEach(function (test) {
+      describe(test.describe, function () {
+        it(test.it, function () {
           assert.deepEqual(
             settingsFrom(fakeWindow(test.url)).annotations,
             test.returns
@@ -305,28 +305,31 @@ describe('annotator.config.settingsFrom', function() {
     });
   });
 
-  describe('#query', function() {
+  describe('#query', function () {
     context(
       'when the host page has a js-hypothesis-config with a query setting',
-      function() {
-        beforeEach('add a js-hypothesis-config query setting', function() {
+      function () {
+        beforeEach('add a js-hypothesis-config query setting', function () {
           fakeSharedSettings.jsonConfigsFrom.returns({
             query: 'queryFromJSON',
           });
         });
 
-        it('returns the query from the js-hypothesis-config script', function() {
+        it('returns the query from the js-hypothesis-config script', function () {
           assert.equal(settingsFrom(fakeWindow()).query, 'queryFromJSON');
         });
 
-        context("when there's also a query in the URL fragment", function() {
-          specify('js-hypothesis-config queries override URL ones', function() {
-            const window_ = fakeWindow(
-              'http://localhost:3000#annotations:query:queryFromUrl'
-            );
+        context("when there's also a query in the URL fragment", function () {
+          specify(
+            'js-hypothesis-config queries override URL ones',
+            function () {
+              const window_ = fakeWindow(
+                'http://localhost:3000#annotations:query:queryFromUrl'
+              );
 
-            assert.equal(settingsFrom(window_).query, 'queryFromJSON');
-          });
+              assert.equal(settingsFrom(window_).query, 'queryFromJSON');
+            }
+          );
         });
       }
     );
@@ -374,9 +377,9 @@ describe('annotator.config.settingsFrom', function() {
         url: 'http://localhost:3000',
         returns: null,
       },
-    ].forEach(function(test) {
-      describe(test.describe, function() {
-        it(test.it, function() {
+    ].forEach(function (test) {
+      describe(test.describe, function () {
+        it(test.it, function () {
           assert.deepEqual(
             settingsFrom(fakeWindow(test.url)).query,
             test.returns
@@ -385,8 +388,8 @@ describe('annotator.config.settingsFrom', function() {
       });
     });
 
-    describe('when the URL contains an invalid fragment', function() {
-      it('returns null', function() {
+    describe('when the URL contains an invalid fragment', function () {
+      it('returns null', function () {
         // An invalid escape sequence which will cause decodeURIComponent() to
         // throw a URIError.
         const invalidFrag = '%aaaaa';
@@ -398,7 +401,7 @@ describe('annotator.config.settingsFrom', function() {
     });
   });
 
-  describe('#showHighlights', function() {
+  describe('#showHighlights', function () {
     [
       {
         it: 'returns an "always" setting from the host page unmodified',
@@ -463,8 +466,8 @@ describe('annotator.config.settingsFrom', function() {
         input: /regex/,
         output: /regex/,
       },
-    ].forEach(function(test) {
-      it(test.it, function() {
+    ].forEach(function (test) {
+      it(test.it, function () {
         fakeSharedSettings.jsonConfigsFrom.returns({
           showHighlights: test.input,
         });
@@ -473,7 +476,7 @@ describe('annotator.config.settingsFrom', function() {
         assert.deepEqual(settings.showHighlights, test.output);
       });
 
-      it(test.it, function() {
+      it(test.it, function () {
         fakeConfigFuncSettingsFrom.returns({
           showHighlights: test.input,
         });
@@ -483,16 +486,16 @@ describe('annotator.config.settingsFrom', function() {
       });
     });
 
-    it("defaults to 'always' if there's no showHighlights setting in the host page", function() {
+    it("defaults to 'always' if there's no showHighlights setting in the host page", function () {
       assert.equal(settingsFrom(fakeWindow()).showHighlights, 'always');
     });
 
-    context('when the client is in a browser extension', function() {
-      beforeEach('configure a browser extension client', function() {
+    context('when the client is in a browser extension', function () {
+      beforeEach('configure a browser extension client', function () {
         fakeIsBrowserExtension.returns(true);
       });
 
-      it("doesn't read the setting from the host page, defaults to 'always'", function() {
+      it("doesn't read the setting from the host page, defaults to 'always'", function () {
         fakeSharedSettings.jsonConfigsFrom.returns({
           showHighlights: 'never',
         });
@@ -505,7 +508,7 @@ describe('annotator.config.settingsFrom', function() {
     });
   });
 
-  describe('#hostPageSetting', function() {
+  describe('#hostPageSetting', function () {
     [
       {
         when: 'the client is embedded in a web page',
@@ -619,9 +622,9 @@ describe('annotator.config.settingsFrom', function() {
         defaultValue: 'the default value',
         expected: 'the default value',
       },
-    ].forEach(function(test) {
-      context(test.when, function() {
-        specify(test.specify, function() {
+    ].forEach(function (test) {
+      context(test.when, function () {
+        specify(test.specify, function () {
           fakeIsBrowserExtension.returns(test.isBrowserExtension);
           fakeConfigFuncSettingsFrom.returns(test.configFuncSettings);
           fakeSharedSettings.jsonConfigsFrom.returns(test.jsonSettings);

--- a/src/annotator/features.js
+++ b/src/annotator/features.js
@@ -8,15 +8,15 @@ const _set = features => {
 };
 
 export default {
-  init: function(crossframe) {
+  init: function (crossframe) {
     crossframe.on(events.FEATURE_FLAGS_UPDATED, _set);
   },
 
-  reset: function() {
+  reset: function () {
     _set({});
   },
 
-  flagEnabled: function(flag) {
+  flagEnabled: function (flag) {
     if (!(flag in _features)) {
       warnOnce('looked up unknown feature', flag);
       return false;

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -38,7 +38,7 @@ const appLinkEl = document.querySelector(
 );
 const config = configFrom(window);
 
-$.noConflict(true)(function() {
+$.noConflict(true)(function () {
   let Klass = window.PDFViewerApplication ? PdfSidebar : Sidebar;
 
   if (config.hasOwnProperty('constructor')) {
@@ -62,7 +62,7 @@ $.noConflict(true)(function() {
   config.pluginClasses = pluginClasses;
 
   const annotator = new Klass(document.body, config);
-  appLinkEl.addEventListener('destroy', function() {
+  appLinkEl.addEventListener('destroy', function () {
     appLinkEl.parentElement.removeChild(appLinkEl);
     annotator.destroy();
   });

--- a/src/annotator/plugin/test/document-test.js
+++ b/src/annotator/plugin/test/document-test.js
@@ -15,13 +15,13 @@ import $ from 'jquery';
 import { normalizeURI } from '../../util/url';
 import DocumentMeta from '../document';
 
-describe('DocumentMeta', function() {
+describe('DocumentMeta', function () {
   let fakeNormalizeURI;
   let tempDocument;
   let tempDocumentHead;
   let testDocument = null;
 
-  beforeEach(function() {
+  beforeEach(function () {
     tempDocument = document.createDocumentFragment();
     tempDocument.location = { href: 'https://example.com' };
     tempDocumentHead = document.createElement('head');
@@ -40,7 +40,7 @@ describe('DocumentMeta', function() {
 
   afterEach(() => $(document).unbind());
 
-  describe('annotation should have some metadata', function() {
+  describe('annotation should have some metadata', function () {
     let metadata = null;
 
     beforeEach(() => {
@@ -77,7 +77,7 @@ describe('DocumentMeta', function() {
       assert.equal(metadata.title, 'Foo');
     });
 
-    it('should have links with absolute hrefs and types', function() {
+    it('should have links with absolute hrefs and types', function () {
       assert.ok(metadata.link);
       assert.equal(metadata.link.length, 10);
       assert.equal(metadata.link[1].rel, 'alternate');
@@ -110,14 +110,14 @@ describe('DocumentMeta', function() {
       assert.equal(metadata.link.length, 10);
     });
 
-    it('should have highwire metadata', function() {
+    it('should have highwire metadata', function () {
       assert.ok(metadata.highwire);
       assert.deepEqual(metadata.highwire.pdf_url, ['foo.pdf']);
       assert.deepEqual(metadata.highwire.doi, ['10.1175/JCLI-D-11-00015.1']);
       assert.deepEqual(metadata.highwire.title, ['Foo']);
     });
 
-    it('should have dublincore metadata', function() {
+    it('should have dublincore metadata', function () {
       assert.ok(metadata.dc);
       assert.deepEqual(metadata.dc.identifier, [
         'doi:10.1175/JCLI-D-11-00015.1',
@@ -127,34 +127,34 @@ describe('DocumentMeta', function() {
       assert.deepEqual(metadata.dc.type, ['Article']);
     });
 
-    it('should have facebook metadata', function() {
+    it('should have facebook metadata', function () {
       assert.ok(metadata.facebook);
       assert.deepEqual(metadata.facebook.url, ['http://example.com']);
     });
 
-    it('should have eprints metadata', function() {
+    it('should have eprints metadata', function () {
       assert.ok(metadata.eprints);
       assert.deepEqual(metadata.eprints.title, [
         'Computer Lib / Dream Machines',
       ]);
     });
 
-    it('should have prism metadata', function() {
+    it('should have prism metadata', function () {
       assert.ok(metadata.prism);
       assert.deepEqual(metadata.prism.title, ['Literary Machines']);
 
-      it('should have twitter card metadata', function() {
+      it('should have twitter card metadata', function () {
         assert.ok(metadata.twitter);
         assert.deepEqual(metadata.twitter.site, ['@okfn']);
       });
     });
 
-    it('should have unique uris', function() {
+    it('should have unique uris', function () {
       const uris = testDocument.uris();
       assert.equal(uris.length, 8);
     });
 
-    it('uri() returns the canonical uri', function() {
+    it('uri() returns the canonical uri', function () {
       const uri = testDocument.uri();
       assert.equal(uri, metadata.link[5].href);
     });
@@ -204,19 +204,19 @@ describe('DocumentMeta', function() {
     });
   });
 
-  describe('#_absoluteUrl', function() {
-    it('should add the protocol when the url starts with two slashes', function() {
+  describe('#_absoluteUrl', function () {
+    it('should add the protocol when the url starts with two slashes', function () {
       const result = testDocument._absoluteUrl('//example.com/');
       const expected = `${document.location.protocol}//example.com/`;
       assert.equal(result, expected);
     });
 
-    it('should add a trailing slash when given an empty path', function() {
+    it('should add a trailing slash when given an empty path', function () {
       const result = testDocument._absoluteUrl('http://example.com');
       assert.equal(result, 'http://example.com/');
     });
 
-    it('should make a relative path into an absolute url', function() {
+    it('should make a relative path into an absolute url', function () {
       const result = testDocument._absoluteUrl('path');
       const expected =
         document.location.protocol +
@@ -227,7 +227,7 @@ describe('DocumentMeta', function() {
       assert.equal(result, expected);
     });
 
-    it('should make an absolute path into an absolute url', function() {
+    it('should make an absolute path into an absolute url', function () {
       const result = testDocument._absoluteUrl('/path');
       const expected =
         document.location.protocol + '//' + document.location.host + '/path';
@@ -235,8 +235,8 @@ describe('DocumentMeta', function() {
     });
   });
 
-  describe('#uri', function() {
-    beforeEach(function() {
+  describe('#uri', function () {
+    beforeEach(function () {
       // Remove any existing canonical links which would otherwise override the
       // document's own location.
       const canonicalLink = document.querySelector('link[rel="canonical"]');
@@ -247,7 +247,7 @@ describe('DocumentMeta', function() {
 
     // Create a blank HTML document with a faked `href` and `baseURI` and
     // return a `DocumentMeta` instance which reads metadata from it.
-    const createDoc = function(href, baseURI, htmlDoc) {
+    const createDoc = function (href, baseURI, htmlDoc) {
       if (!htmlDoc) {
         // Create a blank DOM DocumentMeta
         htmlDoc = document.implementation.createHTMLDocument();
@@ -276,14 +276,14 @@ describe('DocumentMeta', function() {
       'https://publisher.org/book',
       'file:///Users/jim/book',
     ].forEach(href =>
-      it("should return the document's URL if it has an allowed scheme", function() {
+      it("should return the document's URL if it has an allowed scheme", function () {
         const baseURI = 'https://publisher.org/';
         const doc = createDoc(href, baseURI);
         assert.equal(doc.uri(), href);
       })
     );
 
-    it("should return the baseURI if the document's URL does not have an allowed scheme", function() {
+    it("should return the baseURI if the document's URL does not have an allowed scheme", function () {
       const href = 'blob:1234-5678';
       const baseURI = 'https://publisher.org/book';
       const doc = createDoc(href, baseURI);
@@ -298,15 +298,15 @@ describe('DocumentMeta', function() {
       // created by a `<base>` tag.
       ['blob:1234', 'doi:foo'],
       ['chrome://foo', 'chrome://blah'],
-    ].forEach(function(...args) {
+    ].forEach(function (...args) {
       const [href, baseURI] = Array.from(args[0]);
-      it("should return the document's URL if it and the baseURI do not have an allowed scheme", function() {
+      it("should return the document's URL if it and the baseURI do not have an allowed scheme", function () {
         const doc = createDoc(href, baseURI);
         assert.equal(doc.uri(), href);
       });
     });
 
-    it('returns the canonical URI if present', function() {
+    it('returns the canonical URI if present', function () {
       const htmlDoc = document.implementation.createHTMLDocument();
       const canonicalLink = htmlDoc.createElement('link');
       canonicalLink.rel = 'canonical';

--- a/src/annotator/plugin/test/pdf-metadata-test.js
+++ b/src/annotator/plugin/test/pdf-metadata-test.js
@@ -78,14 +78,14 @@ class FakePDFViewerApplication {
   }
 }
 
-describe('annotator/plugin/pdf-metadata', function() {
+describe('annotator/plugin/pdf-metadata', function () {
   [
     // Event dispatched in older PDF.js versions (pre-7bc4bfcc).
     'documentload',
     // Event dispatched in newer PDF.js versions (post-7bc4bfcc).
     'documentloaded',
   ].forEach(eventName => {
-    it('waits for the PDF to load before returning metadata', function() {
+    it('waits for the PDF to load before returning metadata', function () {
       const fakeApp = new FakePDFViewerApplication();
       const pdfMetadata = new PDFMetadata(fakeApp);
 
@@ -95,25 +95,25 @@ describe('annotator/plugin/pdf-metadata', function() {
         fingerprint: 'fakeFingerprint',
       });
 
-      return pdfMetadata.getUri().then(function(uri) {
+      return pdfMetadata.getUri().then(function (uri) {
         assert.equal(uri, 'http://fake.com/');
       });
     });
   });
 
-  it('does not wait for the PDF to load if it has already loaded', function() {
+  it('does not wait for the PDF to load if it has already loaded', function () {
     const fakePDFViewerApplication = new FakePDFViewerApplication();
     fakePDFViewerApplication.finishLoading({
       url: 'http://fake.com',
       fingerprint: 'fakeFingerprint',
     });
     const pdfMetadata = new PDFMetadata(fakePDFViewerApplication);
-    return pdfMetadata.getUri().then(function(uri) {
+    return pdfMetadata.getUri().then(function (uri) {
       assert.equal(uri, 'http://fake.com/');
     });
   });
 
-  describe('metadata sources', function() {
+  describe('metadata sources', function () {
     let pdfMetadata;
     const fakePDFViewerApplication = new FakePDFViewerApplication();
     fakePDFViewerApplication.finishLoading({
@@ -125,18 +125,18 @@ describe('annotator/plugin/pdf-metadata', function() {
       url: 'http://fake.com/',
     });
 
-    beforeEach(function() {
+    beforeEach(function () {
       pdfMetadata = new PDFMetadata(fakePDFViewerApplication);
     });
 
-    describe('#getUri', function() {
-      it('returns the non-file URI', function() {
-        return pdfMetadata.getUri().then(function(uri) {
+    describe('#getUri', function () {
+      it('returns the non-file URI', function () {
+        return pdfMetadata.getUri().then(function (uri) {
           assert.equal(uri, 'http://fake.com/');
         });
       });
 
-      it('returns the fingerprint as a URN when the PDF URL is a local file', function() {
+      it('returns the fingerprint as a URN when the PDF URL is a local file', function () {
         const fakePDFViewerApplication = new FakePDFViewerApplication();
         fakePDFViewerApplication.finishLoading({
           url: 'file:///test.pdf',
@@ -144,7 +144,7 @@ describe('annotator/plugin/pdf-metadata', function() {
         });
         const pdfMetadata = new PDFMetadata(fakePDFViewerApplication);
 
-        return pdfMetadata.getUri().then(function(uri) {
+        return pdfMetadata.getUri().then(function (uri) {
           assert.equal(uri, 'urn:x-pdf:fakeFingerprint');
         });
       });
@@ -167,8 +167,8 @@ describe('annotator/plugin/pdf-metadata', function() {
       });
     });
 
-    describe('#getMetadata', function() {
-      it('gets the title from the dc:title field', function() {
+    describe('#getMetadata', function () {
+      it('gets the title from the dc:title field', function () {
         const expectedMetadata = {
           title: 'dcFakeTitle',
           link: [
@@ -181,12 +181,12 @@ describe('annotator/plugin/pdf-metadata', function() {
           documentFingerprint: fakePDFViewerApplication.pdfDocument.fingerprint,
         };
 
-        return pdfMetadata.getMetadata().then(function(actualMetadata) {
+        return pdfMetadata.getMetadata().then(function (actualMetadata) {
           assert.deepEqual(actualMetadata, expectedMetadata);
         });
       });
 
-      it('gets the title from the documentInfo.Title field', function() {
+      it('gets the title from the documentInfo.Title field', function () {
         const expectedMetadata = {
           title: fakePDFViewerApplication.documentInfo.Title,
           link: [
@@ -201,12 +201,12 @@ describe('annotator/plugin/pdf-metadata', function() {
 
         fakePDFViewerApplication.metadata.has = sinon.stub().returns(false);
 
-        return pdfMetadata.getMetadata().then(function(actualMetadata) {
+        return pdfMetadata.getMetadata().then(function (actualMetadata) {
           assert.deepEqual(actualMetadata, expectedMetadata);
         });
       });
 
-      it('does not save file:// URLs in document metadata', function() {
+      it('does not save file:// URLs in document metadata', function () {
         let pdfMetadata;
         const fakePDFViewerApplication = new FakePDFViewerApplication();
         fakePDFViewerApplication.finishLoading({
@@ -224,7 +224,7 @@ describe('annotator/plugin/pdf-metadata', function() {
 
         pdfMetadata = new PDFMetadata(fakePDFViewerApplication);
 
-        return pdfMetadata.getMetadata().then(function(actualMetadata) {
+        return pdfMetadata.getMetadata().then(function (actualMetadata) {
           assert.equal(actualMetadata.link.length, 1);
           assert.equal(
             actualMetadata.link[0].href,

--- a/src/annotator/range-util.js
+++ b/src/annotator/range-util.js
@@ -72,7 +72,7 @@ function forEachNodeInRange(range, callback) {
 export function getTextBoundingBoxes(range) {
   const whitespaceOnly = /^\s*$/;
   const textNodes = [];
-  forEachNodeInRange(range, function(node) {
+  forEachNodeInRange(range, function (node) {
     if (
       node.nodeType === Node.TEXT_NODE &&
       !node.textContent.match(whitespaceOnly)
@@ -82,7 +82,7 @@ export function getTextBoundingBoxes(range) {
   });
 
   let rects = [];
-  textNodes.forEach(function(node) {
+  textNodes.forEach(function (node) {
     const nodeRange = node.ownerDocument.createRange();
     nodeRange.selectNodeContents(node);
     if (node === range.startContainer) {

--- a/src/annotator/selections.js
+++ b/src/annotator/selections.js
@@ -27,7 +27,7 @@ export default function selections(document) {
   let isMouseDown;
   const selectionEvents = observable
     .listen(document, ['mousedown', 'mouseup', 'selectionchange'])
-    .filter(function(event) {
+    .filter(function (event) {
       if (event.type === 'mousedown' || event.type === 'mouseup') {
         isMouseDown = event.type === 'mousedown';
         return false;
@@ -50,7 +50,7 @@ export default function selections(document) {
     observable.delay(0, observable.Observable.of({})),
   ]);
 
-  return events.map(function() {
+  return events.map(function () {
     return selectedRange(document);
   });
 }

--- a/src/annotator/sidebar-trigger.js
+++ b/src/annotator/sidebar-trigger.js
@@ -13,7 +13,7 @@ export default function trigger(rootEl, showFn) {
     '[' + SIDEBAR_TRIGGER_BTN_ATTR + ']'
   );
 
-  Array.from(triggerElems).forEach(function(triggerElem) {
+  Array.from(triggerElems).forEach(function (triggerElem) {
     triggerElem.addEventListener('click', handleCommand);
   });
 

--- a/src/annotator/test/annotation-counts-test.js
+++ b/src/annotator/test/annotation-counts-test.js
@@ -1,13 +1,13 @@
 import annotationCounts from '../annotation-counts';
 
-describe('annotationCounts', function() {
+describe('annotationCounts', function () {
   let countEl1;
   let countEl2;
   let CrossFrame;
   let fakeCrossFrame;
   let sandbox;
 
-  beforeEach(function() {
+  beforeEach(function () {
     CrossFrame = null;
     fakeCrossFrame = {};
     sandbox = sinon.createSandbox();
@@ -26,14 +26,14 @@ describe('annotationCounts', function() {
     CrossFrame.returns(fakeCrossFrame);
   });
 
-  afterEach(function() {
+  afterEach(function () {
     sandbox.restore();
     countEl1.remove();
     countEl2.remove();
   });
 
-  describe('listen for "publicAnnotationCountChanged" event', function() {
-    const emitEvent = function() {
+  describe('listen for "publicAnnotationCountChanged" event', function () {
+    const emitEvent = function () {
       let crossFrameArgs;
       let evt;
       let fn;
@@ -53,7 +53,7 @@ describe('annotationCounts', function() {
       }
     };
 
-    it('displays the updated annotation count on the appropriate elements', function() {
+    it('displays the updated annotation count on the appropriate elements', function () {
       const newCount = 10;
       annotationCounts(document.body, fakeCrossFrame);
 

--- a/src/annotator/test/annotation-sync-test.js
+++ b/src/annotator/test/annotation-sync-test.js
@@ -2,23 +2,23 @@ import EventEmitter from 'tiny-emitter';
 
 import AnnotationSync from '../annotation-sync';
 
-describe('AnnotationSync', function() {
+describe('AnnotationSync', function () {
   let createAnnotationSync;
   let fakeBridge;
   let options;
   let publish;
   const sandbox = sinon.createSandbox();
 
-  beforeEach(function() {
+  beforeEach(function () {
     const emitter = new EventEmitter();
     const listeners = {};
 
-    createAnnotationSync = function() {
+    createAnnotationSync = function () {
       return new AnnotationSync(fakeBridge, options);
     };
 
     fakeBridge = {
-      on: sandbox.spy(function(method, fn) {
+      on: sandbox.spy(function (method, fn) {
         listeners[method] = fn;
       }),
       call: sandbox.stub(),
@@ -31,7 +31,7 @@ describe('AnnotationSync', function() {
       emit: emitter.emit.bind(emitter), // eslint-disable-line no-restricted-properties
     };
 
-    publish = function() {
+    publish = function () {
       const method = arguments[0];
       const args = [].slice.call(arguments, 1);
 
@@ -39,26 +39,26 @@ describe('AnnotationSync', function() {
     };
   });
 
-  afterEach(function() {
+  afterEach(function () {
     sandbox.restore();
   });
 
-  describe('#constructor', function() {
-    context('when "deleteAnnotation" is published', function() {
-      it('calls emit("annotationDeleted")', function() {
+  describe('#constructor', function () {
+    context('when "deleteAnnotation" is published', function () {
+      it('calls emit("annotationDeleted")', function () {
         const ann = { id: 1, $tag: 'tag1' };
         const eventStub = sinon.stub();
         options.on('annotationDeleted', eventStub);
         createAnnotationSync();
 
-        publish('deleteAnnotation', { msg: ann }, function() {});
+        publish('deleteAnnotation', { msg: ann }, function () {});
 
         assert.calledWith(eventStub, ann);
       });
 
-      it("calls the 'deleteAnnotation' event's callback function", function(done) {
+      it("calls the 'deleteAnnotation' event's callback function", function (done) {
         const ann = { id: 1, $tag: 'tag1' };
-        const callback = function(err, ret) {
+        const callback = function (err, ret) {
           assert.isNull(err);
           assert.deepEqual(ret, { tag: 'tag1', msg: ann });
           done();
@@ -68,30 +68,30 @@ describe('AnnotationSync', function() {
         publish('deleteAnnotation', { msg: ann }, callback);
       });
 
-      it('deletes any existing annotation from its cache before calling emit', function() {
+      it('deletes any existing annotation from its cache before calling emit', function () {
         const ann = { id: 1, $tag: 'tag1' };
         const annSync = createAnnotationSync();
         annSync.cache.tag1 = ann;
-        options.emit = function() {
+        options.emit = function () {
           assert(!annSync.cache.tag1);
         };
 
-        publish('deleteAnnotation', { msg: ann }, function() {});
+        publish('deleteAnnotation', { msg: ann }, function () {});
       });
 
-      it('deletes any existing annotation from its cache', function() {
+      it('deletes any existing annotation from its cache', function () {
         const ann = { id: 1, $tag: 'tag1' };
         const annSync = createAnnotationSync();
         annSync.cache.tag1 = ann;
 
-        publish('deleteAnnotation', { msg: ann }, function() {});
+        publish('deleteAnnotation', { msg: ann }, function () {});
 
         assert(!annSync.cache.tag1);
       });
     });
 
-    context('when "loadAnnotations" is published', function() {
-      it('calls emit("annotationsLoaded")', function() {
+    context('when "loadAnnotations" is published', function () {
+      it('calls emit("annotationsLoaded")', function () {
         const annotations = [
           { id: 1, $tag: 'tag1' },
           { id: 2, $tag: 'tag2' },
@@ -106,14 +106,14 @@ describe('AnnotationSync', function() {
         options.on('annotationsLoaded', loadedStub);
         createAnnotationSync();
 
-        publish('loadAnnotations', bodies, function() {});
+        publish('loadAnnotations', bodies, function () {});
 
         assert.calledWith(loadedStub, annotations);
       });
     });
 
-    context('when "beforeAnnotationCreated" is emitted', function() {
-      it('calls bridge.call() passing the event', function() {
+    context('when "beforeAnnotationCreated" is emitted', function () {
+      it('calls bridge.call() passing the event', function () {
         const ann = { id: 1 };
         createAnnotationSync();
 
@@ -128,8 +128,8 @@ describe('AnnotationSync', function() {
         );
       });
 
-      context('if the annotation has a $tag', function() {
-        it('does not call bridge.call()', function() {
+      context('if the annotation has a $tag', function () {
+        it('does not call bridge.call()', function () {
           const ann = { id: 1, $tag: 'tag1' };
           createAnnotationSync();
 

--- a/src/annotator/test/features-test.js
+++ b/src/annotator/test/features-test.js
@@ -2,7 +2,7 @@ import events from '../../shared/bridge-events';
 import features from '../features';
 import { $imports } from '../features';
 
-describe('features - annotation layer', function() {
+describe('features - annotation layer', function () {
   let featureFlagsUpdateHandler;
   let fakeWarnOnce;
 
@@ -11,18 +11,18 @@ describe('features - annotation layer', function() {
     feature_off: false,
   };
 
-  const setFeatures = function(features) {
+  const setFeatures = function (features) {
     featureFlagsUpdateHandler(features || initialFeatures);
   };
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeWarnOnce = sinon.stub();
     $imports.$mock({
       '../shared/warn-once': fakeWarnOnce,
     });
 
     features.init({
-      on: function(topic, handler) {
+      on: function (topic, handler) {
         if (topic === events.FEATURE_FLAGS_UPDATED) {
           featureFlagsUpdateHandler = handler;
         }
@@ -33,28 +33,28 @@ describe('features - annotation layer', function() {
     setFeatures();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     features.reset();
     $imports.$restore();
   });
 
-  describe('flagEnabled', function() {
-    it('should retrieve features data', function() {
+  describe('flagEnabled', function () {
+    it('should retrieve features data', function () {
       assert.equal(features.flagEnabled('feature_on'), true);
       assert.equal(features.flagEnabled('feature_off'), false);
     });
 
-    it('should return false if features have not been loaded', function() {
+    it('should return false if features have not been loaded', function () {
       // simulate feature data not having been loaded yet
       features.reset();
       assert.equal(features.flagEnabled('feature_on'), false);
     });
 
-    it('should return false for unknown flags', function() {
+    it('should return false for unknown flags', function () {
       assert.isFalse(features.flagEnabled('unknown_feature'));
     });
 
-    it('should warn when accessing unknown flags', function() {
+    it('should warn when accessing unknown flags', function () {
       assert.isFalse(features.flagEnabled('unknown_feature'));
       assert.calledOnce(fakeWarnOnce);
       assert.calledWith(fakeWarnOnce, 'looked up unknown feature');

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -28,7 +28,7 @@ function annotateQuote(quote) {
  */
 function highlightedPhrases(container) {
   return Array.from(container.querySelectorAll('.hypothesis-highlight')).map(
-    function(el) {
+    function (el) {
       return el.textContent;
     }
   );
@@ -45,16 +45,16 @@ function FakeCrossFrame() {
   this.sync = sinon.stub();
 }
 
-describe('anchoring', function() {
+describe('anchoring', function () {
   let guest;
   let guestConfig;
   let container;
 
-  before(function() {
+  before(function () {
     guestConfig = { pluginClasses: { CrossFrame: FakeCrossFrame } };
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     sinon.stub(console, 'warn');
     container = document.createElement('div');
     container.innerHTML = require('./test-page.html');
@@ -62,7 +62,7 @@ describe('anchoring', function() {
     guest = new Guest(container, guestConfig);
   });
 
-  afterEach(function() {
+  afterEach(function () {
     guest.destroy();
     container.parentNode.removeChild(container);
     console.warn.restore();
@@ -87,21 +87,21 @@ describe('anchoring', function() {
     },
   ].forEach(testCase => {
     it(`should highlight ${testCase.tag} when annotations are loaded`, () => {
-      const normalize = function(quotes) {
-        return quotes.map(function(q) {
+      const normalize = function (quotes) {
+        return quotes.map(function (q) {
           return simplifyWhitespace(q);
         });
       };
 
-      const annotations = testCase.quotes.map(function(q) {
+      const annotations = testCase.quotes.map(function (q) {
         return annotateQuote(q);
       });
 
-      const anchored = annotations.map(function(ann) {
+      const anchored = annotations.map(function (ann) {
         return guest.anchor(ann);
       });
 
-      return Promise.all(anchored).then(function() {
+      return Promise.all(anchored).then(function () {
         const assertFn = testCase.expectFail
           ? assert.notDeepEqual
           : assert.deepEqual;

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -3,7 +3,7 @@ import CrossFrame from '../../plugin/cross-frame';
 import { $imports } from '../../plugin/cross-frame';
 import { isLoaded } from '../../util/frame-util';
 
-describe('CrossFrame multi-frame scenario', function() {
+describe('CrossFrame multi-frame scenario', function () {
   let fakeAnnotationSync;
   let fakeBridge;
   let proxyAnnotationSync;
@@ -14,12 +14,12 @@ describe('CrossFrame multi-frame scenario', function() {
 
   const sandbox = sinon.createSandbox();
 
-  const waitForFrameObserver = function(cb) {
+  const waitForFrameObserver = function (cb) {
     const wait = DEBOUNCE_WAIT + 10;
     return setTimeout(cb, wait);
   };
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeBridge = {
       createChannel: sandbox.stub(),
       call: sandbox.stub(),
@@ -48,7 +48,7 @@ describe('CrossFrame multi-frame scenario', function() {
     crossFrame = new CrossFrame(container, options);
   });
 
-  afterEach(function() {
+  afterEach(function () {
     sandbox.restore();
     crossFrame.destroy();
     container.parentNode.removeChild(container);
@@ -56,7 +56,7 @@ describe('CrossFrame multi-frame scenario', function() {
     $imports.$restore();
   });
 
-  it('detects frames on page', function() {
+  it('detects frames on page', function () {
     // Create a frame before initializing
     const validFrame = document.createElement('iframe');
     validFrame.setAttribute('enable-annotation', '');
@@ -71,8 +71,8 @@ describe('CrossFrame multi-frame scenario', function() {
     // Now initialize
     crossFrame.pluginInit();
 
-    const validFramePromise = new Promise(function(resolve) {
-      isLoaded(validFrame, function() {
+    const validFramePromise = new Promise(function (resolve) {
+      isLoaded(validFrame, function () {
         assert(
           validFrame.contentDocument.body.hasChildNodes(),
           'expected valid frame to be modified'
@@ -80,8 +80,8 @@ describe('CrossFrame multi-frame scenario', function() {
         resolve();
       });
     });
-    const invalidFramePromise = new Promise(function(resolve) {
-      isLoaded(invalidFrame, function() {
+    const invalidFramePromise = new Promise(function (resolve) {
+      isLoaded(invalidFrame, function () {
         assert(
           !invalidFrame.contentDocument.body.hasChildNodes(),
           'expected invalid frame to not be modified'
@@ -93,7 +93,7 @@ describe('CrossFrame multi-frame scenario', function() {
     return Promise.all([validFramePromise, invalidFramePromise]);
   });
 
-  it('detects removed frames', function() {
+  it('detects removed frames', function () {
     // Create a frame before initializing
     const frame = document.createElement('iframe');
     frame.setAttribute('enable-annotation', '');
@@ -108,15 +108,15 @@ describe('CrossFrame multi-frame scenario', function() {
     assert.calledWith(fakeBridge.call, 'destroyFrame');
   });
 
-  it('injects embed script in frame', function() {
+  it('injects embed script in frame', function () {
     const frame = document.createElement('iframe');
     frame.setAttribute('enable-annotation', '');
     container.appendChild(frame);
 
     crossFrame.pluginInit();
 
-    return new Promise(function(resolve) {
-      isLoaded(frame, function() {
+    return new Promise(function (resolve) {
+      isLoaded(frame, function () {
         const scriptElement = frame.contentDocument.querySelector(
           'script[src]'
         );
@@ -131,7 +131,7 @@ describe('CrossFrame multi-frame scenario', function() {
     });
   });
 
-  it('excludes injection from already injected frames', function() {
+  it('excludes injection from already injected frames', function () {
     const frame = document.createElement('iframe');
     frame.setAttribute('enable-annotation', '');
     container.appendChild(frame);
@@ -139,8 +139,8 @@ describe('CrossFrame multi-frame scenario', function() {
 
     crossFrame.pluginInit();
 
-    return new Promise(function(resolve) {
-      isLoaded(frame, function() {
+    return new Promise(function (resolve) {
+      isLoaded(frame, function () {
         const scriptElement = frame.contentDocument.querySelector(
           'script[src]'
         );
@@ -153,7 +153,7 @@ describe('CrossFrame multi-frame scenario', function() {
     });
   });
 
-  it('detects dynamically added frames', function() {
+  it('detects dynamically added frames', function () {
     // Initialize with no initial frame, unlike before
     crossFrame.pluginInit();
 
@@ -162,10 +162,10 @@ describe('CrossFrame multi-frame scenario', function() {
     frame.setAttribute('enable-annotation', '');
     container.appendChild(frame);
 
-    return new Promise(function(resolve) {
+    return new Promise(function (resolve) {
       // Yield to let the DOM and CrossFrame catch up
-      waitForFrameObserver(function() {
-        isLoaded(frame, function() {
+      waitForFrameObserver(function () {
+        isLoaded(frame, function () {
           assert(
             frame.contentDocument.body.hasChildNodes(),
             'expected dynamically added frame to be modified'
@@ -176,7 +176,7 @@ describe('CrossFrame multi-frame scenario', function() {
     });
   });
 
-  it('detects dynamically removed frames', function() {
+  it('detects dynamically removed frames', function () {
     // Create a frame before initializing
     const frame = document.createElement('iframe');
     frame.setAttribute('enable-annotation', '');
@@ -185,13 +185,13 @@ describe('CrossFrame multi-frame scenario', function() {
     // Now initialize
     crossFrame.pluginInit();
 
-    return new Promise(function(resolve) {
+    return new Promise(function (resolve) {
       // Yield to let the DOM and CrossFrame catch up
-      waitForFrameObserver(function() {
+      waitForFrameObserver(function () {
         frame.remove();
 
         // Yield again
-        waitForFrameObserver(function() {
+        waitForFrameObserver(function () {
           assert.calledWith(fakeBridge.call, 'destroyFrame');
           resolve();
         });
@@ -199,7 +199,7 @@ describe('CrossFrame multi-frame scenario', function() {
     });
   });
 
-  it('detects a frame dynamically removed, and added again', function() {
+  it('detects a frame dynamically removed, and added again', function () {
     // Create a frame before initializing
     const frame = document.createElement('iframe');
     frame.setAttribute('enable-annotation', '');
@@ -208,8 +208,8 @@ describe('CrossFrame multi-frame scenario', function() {
     // Now initialize
     crossFrame.pluginInit();
 
-    return new Promise(function(resolve) {
-      isLoaded(frame, function() {
+    return new Promise(function (resolve) {
+      isLoaded(frame, function () {
         assert(
           frame.contentDocument.body.hasChildNodes(),
           'expected initial frame to be modified'
@@ -218,13 +218,13 @@ describe('CrossFrame multi-frame scenario', function() {
         frame.remove();
 
         // Yield to let the DOM and CrossFrame catch up
-        waitForFrameObserver(function() {
+        waitForFrameObserver(function () {
           // Add the frame again
           container.appendChild(frame);
 
           // Yield again
-          waitForFrameObserver(function() {
-            isLoaded(frame, function() {
+          waitForFrameObserver(function () {
+            isLoaded(frame, function () {
               assert(
                 frame.contentDocument.body.hasChildNodes(),
                 'expected dynamically added frame to be modified'
@@ -237,7 +237,7 @@ describe('CrossFrame multi-frame scenario', function() {
     });
   });
 
-  it('detects a frame dynamically added, removed, and added again', function() {
+  it('detects a frame dynamically added, removed, and added again', function () {
     // Initialize with no initial frame
     crossFrame.pluginInit();
 
@@ -246,10 +246,10 @@ describe('CrossFrame multi-frame scenario', function() {
     frame.setAttribute('enable-annotation', '');
     container.appendChild(frame);
 
-    return new Promise(function(resolve) {
+    return new Promise(function (resolve) {
       // Yield to let the DOM and CrossFrame catch up
-      waitForFrameObserver(function() {
-        isLoaded(frame, function() {
+      waitForFrameObserver(function () {
+        isLoaded(frame, function () {
           assert(
             frame.contentDocument.body.hasChildNodes(),
             'expected dynamically added frame to be modified'
@@ -258,13 +258,13 @@ describe('CrossFrame multi-frame scenario', function() {
           frame.remove();
 
           // Yield again
-          waitForFrameObserver(function() {
+          waitForFrameObserver(function () {
             // Add the frame again
             container.appendChild(frame);
 
             // Yield
-            waitForFrameObserver(function() {
-              isLoaded(frame, function() {
+            waitForFrameObserver(function () {
+              isLoaded(frame, function () {
                 assert(
                   frame.contentDocument.body.hasChildNodes(),
                   'expected dynamically added frame to be modified'

--- a/src/annotator/test/range-util-test.js
+++ b/src/annotator/test/range-util-test.js
@@ -21,11 +21,11 @@ function roundCoords(rect) {
   };
 }
 
-describe('annotator.range-util', function() {
+describe('annotator.range-util', function () {
   let selection;
   let testNode;
 
-  beforeEach(function() {
+  beforeEach(function () {
     selection = window.getSelection();
     selection.collapse(null);
 
@@ -34,7 +34,7 @@ describe('annotator.range-util', function() {
     document.body.appendChild(testNode);
   });
 
-  afterEach(function() {
+  afterEach(function () {
     testNode.parentElement.removeChild(testNode);
   });
 
@@ -44,19 +44,19 @@ describe('annotator.range-util', function() {
     selection.addRange(range);
   }
 
-  describe('#isNodeInRange', function() {
-    it('is true for a node in the range', function() {
+  describe('#isNodeInRange', function () {
+    it('is true for a node in the range', function () {
       const rng = createRange(testNode, 0, 1);
       assert.equal(rangeUtil.isNodeInRange(rng, testNode.firstChild), true);
     });
 
-    it('is false for a node before the range', function() {
+    it('is false for a node before the range', function () {
       testNode.innerHTML = 'one <b>two</b> three';
       const rng = createRange(testNode, 1, 2);
       assert.equal(rangeUtil.isNodeInRange(rng, testNode.firstChild), false);
     });
 
-    it('is false for a node after the range', function() {
+    it('is false for a node after the range', function () {
       testNode.innerHTML = 'one <b>two</b> three';
       const rng = createRange(testNode, 1, 2);
       assert.equal(
@@ -66,15 +66,15 @@ describe('annotator.range-util', function() {
     });
   });
 
-  describe('#getTextBoundingBoxes', function() {
-    it('gets the bounding box of a range in a text node', function() {
+  describe('#getTextBoundingBoxes', function () {
+    it('gets the bounding box of a range in a text node', function () {
       testNode.innerHTML = 'plain text';
       const rng = createRange(testNode.firstChild, 0, 5);
       const boxes = rangeUtil.getTextBoundingBoxes(rng);
       assert.ok(boxes.length);
     });
 
-    it('gets the bounding box of a range containing a text node', function() {
+    it('gets the bounding box of a range containing a text node', function () {
       testNode.innerHTML = 'plain text';
       const rng = createRange(testNode, 0, 1);
 
@@ -92,7 +92,7 @@ describe('annotator.range-util', function() {
       ]);
     });
 
-    it('returns the bounding box in viewport coordinates', function() {
+    it('returns the bounding box in viewport coordinates', function () {
       testNode.innerHTML = 'plain text';
       const rng = createRange(testNode, 0, 1);
 
@@ -105,17 +105,17 @@ describe('annotator.range-util', function() {
     });
   });
 
-  describe('#selectionFocusRect', function() {
-    it('returns null if the selection is empty', function() {
+  describe('#selectionFocusRect', function () {
+    it('returns null if the selection is empty', function () {
       assert.isNull(rangeUtil.selectionFocusRect(selection));
     });
 
-    it('returns a point if the selection is not empty', function() {
+    it('returns a point if the selection is not empty', function () {
       selectNode(testNode);
       assert.ok(rangeUtil.selectionFocusRect(selection));
     });
 
-    it("returns the first line's rect if the selection is backwards", function() {
+    it("returns the first line's rect if the selection is backwards", function () {
       selectNode(testNode);
       selection.collapseToEnd();
       selection.extend(testNode, 0);
@@ -124,7 +124,7 @@ describe('annotator.range-util', function() {
       assert.equal(rect.top, testNode.offsetTop);
     });
 
-    it("returns the last line's rect if the selection is forwards", function() {
+    it("returns the last line's rect if the selection is forwards", function () {
       selectNode(testNode);
       const rect = rangeUtil.selectionFocusRect(selection);
       assert.equal(rect.left, testNode.offsetLeft);

--- a/src/annotator/test/selections-test.js
+++ b/src/annotator/test/selections-test.js
@@ -5,36 +5,36 @@ function FakeDocument() {
   const listeners = {};
 
   return {
-    getSelection: function() {
+    getSelection: function () {
       return this.selection;
     },
 
-    addEventListener: function(name, listener) {
+    addEventListener: function (name, listener) {
       listeners[name] = (listeners[name] || []).concat(listener);
     },
 
-    removeEventListener: function(name, listener) {
-      listeners[name] = listeners[name].filter(function(lis) {
+    removeEventListener: function (name, listener) {
+      listeners[name] = listeners[name].filter(function (lis) {
         return lis !== listener;
       });
     },
 
-    dispatchEvent: function(event) {
-      listeners[event.type].forEach(function(fn) {
+    dispatchEvent: function (event) {
+      listeners[event.type].forEach(function (fn) {
         fn(event);
       });
     },
   };
 }
 
-describe('selections', function() {
+describe('selections', function () {
   let clock;
   let fakeDocument;
   let range;
   let rangeSub;
   let onSelectionChanged;
 
-  beforeEach(function() {
+  beforeEach(function () {
     clock = sinon.useFakeTimers();
     fakeDocument = new FakeDocument();
     onSelectionChanged = sinon.stub();
@@ -46,24 +46,24 @@ describe('selections', function() {
     range = {};
     fakeDocument.selection = {
       rangeCount: 1,
-      getRangeAt: function(index) {
+      getRangeAt: function (index) {
         return index === 0 ? range : null;
       },
     };
   });
 
-  afterEach(function() {
+  afterEach(function () {
     rangeSub.unsubscribe();
     clock.restore();
   });
 
-  it('emits the selected range when mouseup occurs', function() {
+  it('emits the selected range when mouseup occurs', function () {
     fakeDocument.dispatchEvent({ type: 'mouseup' });
     clock.tick(20);
     assert.calledWith(onSelectionChanged, range);
   });
 
-  it('emits an event if there is a selection at the initial subscription', function() {
+  it('emits an event if there is a selection at the initial subscription', function () {
     const onInitialSelection = sinon.stub();
     const ranges = selections(fakeDocument);
     const sub = ranges.subscribe({ next: onInitialSelection });
@@ -72,21 +72,21 @@ describe('selections', function() {
     sub.unsubscribe();
   });
 
-  describe('when the selection changes', function() {
-    it('emits a selection if the mouse is not down', function() {
+  describe('when the selection changes', function () {
+    it('emits a selection if the mouse is not down', function () {
       fakeDocument.dispatchEvent({ type: 'selectionchange' });
       clock.tick(200);
       assert.calledWith(onSelectionChanged, range);
     });
 
-    it('does not emit a selection if the mouse is down', function() {
+    it('does not emit a selection if the mouse is down', function () {
       fakeDocument.dispatchEvent({ type: 'mousedown' });
       fakeDocument.dispatchEvent({ type: 'selectionchange' });
       clock.tick(200);
       assert.notCalled(onSelectionChanged);
     });
 
-    it('does not emit a selection until there is a pause since the last change', function() {
+    it('does not emit a selection until there is a pause since the last change', function () {
       fakeDocument.dispatchEvent({ type: 'selectionchange' });
       clock.tick(90);
       fakeDocument.dispatchEvent({ type: 'selectionchange' });

--- a/src/annotator/test/sidebar-trigger-test.js
+++ b/src/annotator/test/sidebar-trigger-test.js
@@ -1,10 +1,10 @@
 import sidebarTrigger from '../sidebar-trigger';
 
-describe('sidebarTrigger', function() {
+describe('sidebarTrigger', function () {
   let triggerEl1;
   let triggerEl2;
 
-  beforeEach(function() {
+  beforeEach(function () {
     triggerEl1 = document.createElement('button');
     triggerEl1.setAttribute('data-hypothesis-trigger', '');
     document.body.appendChild(triggerEl1);
@@ -14,7 +14,7 @@ describe('sidebarTrigger', function() {
     document.body.appendChild(triggerEl2);
   });
 
-  it('calls the show callback which a trigger button is clicked', function() {
+  it('calls the show callback which a trigger button is clicked', function () {
     const fakeShowFn = sinon.stub();
     sidebarTrigger(document, fakeShowFn);
 

--- a/src/annotator/util/frame-util.js
+++ b/src/annotator/util/frame-util.js
@@ -65,7 +65,7 @@ function shouldEnableAnnotation(iframe) {
 
 export function isDocumentReady(iframe, callback) {
   if (iframe.contentDocument.readyState === 'loading') {
-    iframe.contentDocument.addEventListener('DOMContentLoaded', function() {
+    iframe.contentDocument.addEventListener('DOMContentLoaded', function () {
       callback();
     });
   } else {
@@ -75,7 +75,7 @@ export function isDocumentReady(iframe, callback) {
 
 export function isLoaded(iframe, callback) {
   if (iframe.contentDocument.readyState !== 'complete') {
-    iframe.addEventListener('load', function() {
+    iframe.addEventListener('load', function () {
       callback();
     });
   } else {

--- a/src/annotator/util/observable.js
+++ b/src/annotator/util/observable.js
@@ -13,17 +13,17 @@ import Observable from 'zen-observable';
  * @param {Array<string>} eventNames - List of events to subscribe to
  */
 export function listen(src, eventNames) {
-  return new Observable(function(observer) {
-    const onNext = function(event) {
+  return new Observable(function (observer) {
+    const onNext = function (event) {
       observer.next(event);
     };
 
-    eventNames.forEach(function(event) {
+    eventNames.forEach(function (event) {
       src.addEventListener(event, onNext);
     });
 
-    return function() {
-      eventNames.forEach(function(event) {
+    return function () {
+      eventNames.forEach(function (event) {
         src.removeEventListener(event, onNext);
       });
     };
@@ -34,12 +34,12 @@ export function listen(src, eventNames) {
  * Delay events from a source Observable by `delay` ms.
  */
 export function delay(delay, src) {
-  return new Observable(function(obs) {
+  return new Observable(function (obs) {
     let timeouts = [];
     const sub = src.subscribe({
-      next: function(value) {
-        const t = setTimeout(function() {
-          timeouts = timeouts.filter(function(other) {
+      next: function (value) {
+        const t = setTimeout(function () {
+          timeouts = timeouts.filter(function (other) {
             return other !== t;
           });
           obs.next(value);
@@ -47,7 +47,7 @@ export function delay(delay, src) {
         timeouts.push(t);
       },
     });
-    return function() {
+    return function () {
       timeouts.forEach(clearTimeout);
       sub.unsubscribe();
     };
@@ -63,7 +63,7 @@ export function delay(delay, src) {
  * @return {Observable<T>}
  */
 export function buffer(delay, src) {
-  return new Observable(function(obs) {
+  return new Observable(function (obs) {
     let lastValue;
     let timeout;
 
@@ -72,14 +72,14 @@ export function buffer(delay, src) {
     }
 
     const sub = src.subscribe({
-      next: function(value) {
+      next: function (value) {
         lastValue = value;
         clearTimeout(timeout);
         timeout = setTimeout(onNext, delay);
       },
     });
 
-    return function() {
+    return function () {
       sub.unsubscribe();
       clearTimeout(timeout);
     };
@@ -93,17 +93,17 @@ export function buffer(delay, src) {
  * @return Observable
  */
 export function merge(sources) {
-  return new Observable(function(obs) {
-    const subs = sources.map(function(src) {
+  return new Observable(function (obs) {
+    const subs = sources.map(function (src) {
       return src.subscribe({
-        next: function(value) {
+        next: function (value) {
           obs.next(value);
         },
       });
     });
 
-    return function() {
-      subs.forEach(function(sub) {
+    return function () {
+      subs.forEach(function (sub) {
         sub.unsubscribe();
       });
     };
@@ -113,7 +113,7 @@ export function merge(sources) {
 /** Drop the first `n` events from the `src` Observable. */
 export function drop(src, n) {
   let count = 0;
-  return src.filter(function() {
+  return src.filter(function () {
     ++count;
     return count > n;
   });

--- a/src/annotator/util/test/frame-util-test.js
+++ b/src/annotator/util/test/frame-util-test.js
@@ -1,7 +1,7 @@
 import * as frameUtil from '../frame-util';
 
-describe('annotator.util.frame-util', function() {
-  describe('findFrames', function() {
+describe('annotator.util.frame-util', function () {
+  describe('findFrames', function () {
     let container;
 
     const _addFrameToContainer = (options = {}) => {
@@ -14,16 +14,16 @@ describe('annotator.util.frame-util', function() {
       return frame;
     };
 
-    beforeEach(function() {
+    beforeEach(function () {
       container = document.createElement('div');
       document.body.appendChild(container);
     });
 
-    afterEach(function() {
+    afterEach(function () {
       container.remove();
     });
 
-    it('should return valid frames', function() {
+    it('should return valid frames', function () {
       let foundFrames = frameUtil.findFrames(container);
 
       assert.lengthOf(
@@ -53,7 +53,7 @@ describe('annotator.util.frame-util', function() {
       assert.lengthOf(foundFrames, 0);
     });
 
-    it('should not return the Hypothesis sidebar', function() {
+    it('should not return the Hypothesis sidebar', function () {
       _addFrameToContainer({ className: 'h-sidebar-iframe other-class-too' });
 
       const foundFrames = frameUtil.findFrames(container);

--- a/src/annotator/util/test/observable-test.js
+++ b/src/annotator/util/test/observable-test.js
@@ -1,21 +1,21 @@
 import * as observable from '../observable';
 
-describe('observable', function() {
-  describe('delay()', function() {
+describe('observable', function () {
+  describe('delay()', function () {
     let clock;
 
-    beforeEach(function() {
+    beforeEach(function () {
       clock = sinon.useFakeTimers();
     });
 
-    afterEach(function() {
+    afterEach(function () {
       clock.restore();
     });
 
-    it('defers events', function() {
+    it('defers events', function () {
       const received = [];
       const obs = observable.delay(50, observable.Observable.of('foo'));
-      obs.forEach(function(v) {
+      obs.forEach(function (v) {
         received.push(v);
       });
       assert.deepEqual(received, []);
@@ -23,10 +23,10 @@ describe('observable', function() {
       assert.deepEqual(received, ['foo']);
     });
 
-    it('delivers events in sequence', function() {
+    it('delivers events in sequence', function () {
       const received = [];
       const obs = observable.delay(10, observable.Observable.of(1, 2));
-      obs.forEach(function(v) {
+      obs.forEach(function (v) {
         received.push(v);
       });
       clock.tick(20);

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -20,7 +20,7 @@ function injectScript(doc, src) {
 }
 
 function injectAssets(doc, config, assets) {
-  assets.forEach(function(path) {
+  assets.forEach(function (path) {
     const url = config.assetRoot + 'build/' + config.manifest[path];
     if (url.match(/\.css/)) {
       injectStylesheet(doc, url);

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -5,11 +5,11 @@ function assetUrl(url) {
   return `https://marginal.ly/client/build/${url}`;
 }
 
-describe('bootstrap', function() {
+describe('bootstrap', function () {
   let fakePolyfills;
   let iframe;
 
-  beforeEach(function() {
+  beforeEach(function () {
     iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
 
@@ -22,7 +22,7 @@ describe('bootstrap', function() {
     });
   });
 
-  afterEach(function() {
+  afterEach(function () {
     $imports.$restore();
     iframe.remove();
   });
@@ -52,7 +52,7 @@ describe('bootstrap', function() {
       'styles/sidebar.css',
     ];
 
-    const manifest = assetNames.reduce(function(manifest, path) {
+    const manifest = assetNames.reduce(function (manifest, path) {
       const url = path.replace(/\.([a-z]+)$/, '.1234.$1');
       manifest[path] = url;
       return manifest;
@@ -66,7 +66,7 @@ describe('bootstrap', function() {
   }
 
   function findAssets(doc_) {
-    const scripts = Array.from(doc_.querySelectorAll('script')).map(function(
+    const scripts = Array.from(doc_.querySelectorAll('script')).map(function (
       el
     ) {
       return el.src;
@@ -74,15 +74,15 @@ describe('bootstrap', function() {
 
     const styles = Array.from(
       doc_.querySelectorAll('link[rel="stylesheet"]')
-    ).map(function(el) {
+    ).map(function (el) {
       return el.href;
     });
 
     return scripts.concat(styles).sort();
   }
 
-  context('in the host page', function() {
-    it('loads assets for the annotation layer', function() {
+  context('in the host page', function () {
+    it('loads assets for the annotation layer', function () {
       runBoot();
       const expectedAssets = [
         'scripts/annotator.bundle.1234.js',
@@ -95,7 +95,7 @@ describe('bootstrap', function() {
       assert.deepEqual(findAssets(iframe.contentDocument), expectedAssets);
     });
 
-    it('creates the link to the sidebar iframe', function() {
+    it('creates the link to the sidebar iframe', function () {
       runBoot();
 
       const sidebarAppLink = iframe.contentDocument.querySelector(
@@ -105,7 +105,7 @@ describe('bootstrap', function() {
       assert.equal(sidebarAppLink.href, 'https://marginal.ly/app.html');
     });
 
-    it('does nothing if Hypothesis is already loaded in the document', function() {
+    it('does nothing if Hypothesis is already loaded in the document', function () {
       const link = iframe.contentDocument.createElement('link');
       link.type = 'application/annotator+html';
       iframe.contentDocument.head.appendChild(link);
@@ -132,19 +132,19 @@ describe('bootstrap', function() {
     });
   });
 
-  context('in the sidebar application', function() {
+  context('in the sidebar application', function () {
     let appRootElement;
 
-    beforeEach(function() {
+    beforeEach(function () {
       appRootElement = iframe.contentDocument.createElement('hypothesis-app');
       iframe.contentDocument.body.appendChild(appRootElement);
     });
 
-    afterEach(function() {
+    afterEach(function () {
       appRootElement.remove();
     });
 
-    it('loads assets for the sidebar application', function() {
+    it('loads assets for the sidebar application', function () {
       runBoot();
       const expectedAssets = [
         'scripts/angular.bundle.1234.js',

--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -48,7 +48,7 @@ if (process.env.RUNNING_IN_DOCKER) {
   process.env.CHROME_BIN = 'chromium-browser';
 }
 
-module.exports = function(config) {
+module.exports = function (config) {
   let testFiles = [
     'annotator/**/*-test.coffee',
     '**/test/*-test.js',

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -94,11 +94,11 @@ export default class Bridge {
       };
     };
 
-    const promises = this.links.map(function(l) {
-      const p = new Promise(function(resolve, reject) {
+    const promises = this.links.map(function (l) {
+      const p = new Promise(function (resolve, reject) {
         const timeout = setTimeout(() => resolve(null), 1000);
         try {
-          return l.channel.call(method, ...Array.from(args), function(
+          return l.channel.call(method, ...Array.from(args), function (
             err,
             result
           ) {

--- a/src/shared/discovery.js
+++ b/src/shared/discovery.js
@@ -222,8 +222,6 @@ export default class Discovery {
    * and a server.
    */
   generateToken() {
-    return Math.random()
-      .toString()
-      .replace(/\D/g, '');
+    return Math.random().toString().replace(/\D/g, '');
   }
 }

--- a/src/shared/frame-rpc.js
+++ b/src/shared/frame-rpc.js
@@ -45,7 +45,7 @@ export default function RPC(src, dst, origin, methods) {
   this._sequence = 0;
   this._callbacks = {};
 
-  this._onmessage = function(ev) {
+  this._onmessage = function (ev) {
     if (self._destroyed) return;
     if (self.dst !== ev.source) return;
     if (self.origin !== '*' && ev.origin !== self.origin) return;
@@ -59,17 +59,17 @@ export default function RPC(src, dst, origin, methods) {
     (typeof methods === 'function' ? methods(this) : methods) || {};
 }
 
-RPC.prototype.destroy = function() {
+RPC.prototype.destroy = function () {
   this._destroyed = true;
   this.src.removeEventListener('message', this._onmessage);
 };
 
-RPC.prototype.call = function(method) {
+RPC.prototype.call = function (method) {
   const args = [].slice.call(arguments, 1);
   return this.apply(method, args);
 };
 
-RPC.prototype.apply = function(method, args) {
+RPC.prototype.apply = function (method, args) {
   if (this._destroyed) return;
   const seq = this._sequence++;
   if (typeof args[args.length - 1] === 'function') {
@@ -88,12 +88,12 @@ RPC.prototype.apply = function(method, args) {
   );
 };
 
-RPC.prototype._handle = function(msg) {
+RPC.prototype._handle = function (msg) {
   const self = this;
   if (self._destroyed) return;
   if (msg.hasOwnProperty('method')) {
     if (!this._methods.hasOwnProperty(msg.method)) return;
-    const args = msg.arguments.concat(function() {
+    const args = msg.arguments.concat(function () {
       self.dst.postMessage(
         {
           protocol: 'frame-rpc',

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -1,7 +1,7 @@
 import Bridge from '../bridge';
 import RPC from '../frame-rpc';
 
-describe('shared.bridge', function() {
+describe('shared.bridge', function () {
   const sandbox = sinon.createSandbox();
   let bridge;
   let createChannel;
@@ -23,15 +23,15 @@ describe('shared.bridge', function() {
 
   afterEach(() => sandbox.restore());
 
-  describe('#createChannel', function() {
-    it('creates a new channel with the provided options', function() {
+  describe('#createChannel', function () {
+    it('creates a new channel with the provided options', function () {
       const channel = createChannel();
       assert.equal(channel.src, window);
       assert.equal(channel.dst, fakeWindow);
       assert.equal(channel.origin, 'http://example.com');
     });
 
-    it('adds the channel to the .links property', function() {
+    it('adds the channel to the .links property', function () {
       const channel = createChannel();
       assert.isTrue(
         bridge.links.some(
@@ -40,7 +40,7 @@ describe('shared.bridge', function() {
       );
     });
 
-    it('registers any existing listeners on the channel', function() {
+    it('registers any existing listeners on the channel', function () {
       const message1 = sandbox.spy();
       const message2 = sandbox.spy();
       bridge.on('message1', message1);
@@ -50,14 +50,14 @@ describe('shared.bridge', function() {
       assert.propertyVal(channel._methods, 'message2', message2);
     });
 
-    it('returns the newly created channel', function() {
+    it('returns the newly created channel', function () {
       const channel = createChannel();
       assert.instanceOf(channel, RPC);
     });
   });
 
-  describe('#call', function() {
-    it('forwards the call to every created channel', function() {
+  describe('#call', function () {
+    it('forwards the call to every created channel', function () {
       const channel = createChannel();
       sandbox.stub(channel, 'call');
       bridge.call('method1', 'params1');
@@ -65,14 +65,14 @@ describe('shared.bridge', function() {
       assert.calledWith(channel.call, 'method1', 'params1');
     });
 
-    it('provides a timeout', function(done) {
+    it('provides a timeout', function (done) {
       const channel = createChannel();
       sandbox.stub(channel, 'call');
       sandbox.stub(window, 'setTimeout').yields();
       bridge.call('method1', 'params1', done);
     });
 
-    it('calls a callback when all channels return successfully', function(done) {
+    it('calls a callback when all channels return successfully', function (done) {
       const channel1 = createChannel();
       const channel2 = bridge.createChannel(
         fakeWindow,
@@ -82,7 +82,7 @@ describe('shared.bridge', function() {
       sandbox.stub(channel1, 'call').yields(null, 'result1');
       sandbox.stub(channel2, 'call').yields(null, 'result2');
 
-      const callback = function(err, results) {
+      const callback = function (err, results) {
         assert.isNull(err);
         assert.deepEqual(results, ['result1', 'result2']);
         done();
@@ -91,7 +91,7 @@ describe('shared.bridge', function() {
       bridge.call('method1', 'params1', callback);
     });
 
-    it('calls a callback with an error when a channels fails', function(done) {
+    it('calls a callback with an error when a channels fails', function (done) {
       const error = new Error('Uh oh');
       const channel1 = createChannel();
       const channel2 = bridge.createChannel(
@@ -102,7 +102,7 @@ describe('shared.bridge', function() {
       sandbox.stub(channel1, 'call').throws(error);
       sandbox.stub(channel2, 'call').yields(null, 'result2');
 
-      const callback = function(err) {
+      const callback = function (err) {
         assert.equal(err, error);
         done();
       };
@@ -110,12 +110,12 @@ describe('shared.bridge', function() {
       bridge.call('method1', 'params1', callback);
     });
 
-    it('destroys the channel when a call fails', function(done) {
+    it('destroys the channel when a call fails', function (done) {
       const channel = createChannel();
       sandbox.stub(channel, 'call').throws(new Error(''));
       sandbox.stub(channel, 'destroy');
 
-      const callback = function() {
+      const callback = function () {
         assert.called(channel.destroy);
         done();
       };
@@ -123,61 +123,61 @@ describe('shared.bridge', function() {
       bridge.call('method1', 'params1', callback);
     });
 
-    it('no longer publishes to a channel that has had an error', function(done) {
+    it('no longer publishes to a channel that has had an error', function (done) {
       const channel = createChannel();
       sandbox.stub(channel, 'call').throws(new Error('oeunth'));
-      bridge.call('method1', 'params1', function() {
+      bridge.call('method1', 'params1', function () {
         assert.calledOnce(channel.call);
-        bridge.call('method1', 'params1', function() {
+        bridge.call('method1', 'params1', function () {
           assert.calledOnce(channel.call);
           done();
         });
       });
     });
 
-    it('treats a timeout as a success with no result', function(done) {
+    it('treats a timeout as a success with no result', function (done) {
       const channel = createChannel();
       sandbox.stub(channel, 'call');
       sandbox.stub(window, 'setTimeout').yields();
-      bridge.call('method1', 'params1', function(err, res) {
+      bridge.call('method1', 'params1', function (err, res) {
         assert.isNull(err);
         assert.deepEqual(res, [null]);
         done();
       });
     });
 
-    it('returns a promise object', function() {
+    it('returns a promise object', function () {
       createChannel();
       const ret = bridge.call('method1', 'params1');
       assert.instanceOf(ret, Promise);
     });
   });
 
-  describe('#on', function() {
-    it('adds a method to the method registry', function() {
+  describe('#on', function () {
+    it('adds a method to the method registry', function () {
       createChannel();
       bridge.on('message1', sandbox.spy());
       assert.isFunction(bridge.channelListeners.message1);
     });
 
-    it('only allows registering a method once', function() {
+    it('only allows registering a method once', function () {
       bridge.on('message1', sandbox.spy());
       assert.throws(() => bridge.on('message1', sandbox.spy()));
     });
   });
 
   describe('#off', () =>
-    it('removes the method from the method registry', function() {
+    it('removes the method from the method registry', function () {
       createChannel();
       bridge.on('message1', sandbox.spy());
       bridge.off('message1');
       assert.isUndefined(bridge.channelListeners.message1);
     }));
 
-  describe('#onConnect', function() {
-    it('adds a callback that is called when a channel is connected', function(done) {
+  describe('#onConnect', function () {
+    it('adds a callback that is called when a channel is connected', function (done) {
       let channel;
-      const callback = function(c, s) {
+      const callback = function (c, s) {
         assert.strictEqual(c, channel);
         assert.strictEqual(s, fakeWindow);
         done();
@@ -200,7 +200,7 @@ describe('shared.bridge', function() {
       channel = createChannel();
     });
 
-    it('allows multiple callbacks to be registered', function(done) {
+    it('allows multiple callbacks to be registered', function (done) {
       let channel;
       let callbackCount = 0;
       const callback = (c, s) => {
@@ -231,7 +231,7 @@ describe('shared.bridge', function() {
   });
 
   describe('#destroy', () =>
-    it('destroys all opened channels', function() {
+    it('destroys all opened channels', function () {
       const channel1 = bridge.createChannel(
         fakeWindow,
         'http://example.com',

--- a/src/shared/test/injector-test.js
+++ b/src/shared/test/injector-test.js
@@ -4,7 +4,7 @@ describe('Injector', () => {
   describe('#get', () => {
     it('calls a "factory" provider as a function to create the object', () => {
       const instance = 'aValue';
-      const factory = sinon.stub().callsFake(function() {
+      const factory = sinon.stub().callsFake(function () {
         assert.isUndefined(this);
         return instance;
       });

--- a/src/shared/test/promise-util.js
+++ b/src/shared/test/promise-util.js
@@ -35,10 +35,10 @@ export function assertPromiseIsRejected(promise, expectedErr) {
  */
 export function toResult(promise) {
   return promise
-    .then(function(result) {
+    .then(function (result) {
       return { result: result };
     })
-    .catch(function(err) {
+    .catch(function (err) {
       return { error: err };
     });
 }

--- a/src/shared/test/settings-test.js
+++ b/src/shared/test/settings-test.js
@@ -2,12 +2,12 @@ import * as settings from '../settings';
 
 const sandbox = sinon.createSandbox();
 
-describe('settings', function() {
-  afterEach('reset the sandbox', function() {
+describe('settings', function () {
+  afterEach('reset the sandbox', function () {
     sandbox.restore();
   });
 
-  describe('#jsonConfigsFrom', function() {
+  describe('#jsonConfigsFrom', function () {
     const jsonConfigsFrom = settings.jsonConfigsFrom;
 
     function appendJSHypothesisConfig(document_, jsonString) {
@@ -19,105 +19,105 @@ describe('settings', function() {
       document_.body.appendChild(el);
     }
 
-    afterEach('remove js-hypothesis-config tags', function() {
+    afterEach('remove js-hypothesis-config tags', function () {
       const elements = document.querySelectorAll('.js-settings-test');
       for (let i = 0; i < elements.length; i++) {
         elements[i].remove();
       }
     });
 
-    context('when there are no JSON scripts', function() {
-      it('returns {}', function() {
+    context('when there are no JSON scripts', function () {
+      it('returns {}', function () {
         assert.deepEqual(jsonConfigsFrom(document), {});
       });
     });
 
-    context("when there's JSON scripts with no top-level objects", function() {
-      beforeEach('add JSON scripts with no top-level objects', function() {
+    context("when there's JSON scripts with no top-level objects", function () {
+      beforeEach('add JSON scripts with no top-level objects', function () {
         appendJSHypothesisConfig(document, 'null');
         appendJSHypothesisConfig(document, '23');
         appendJSHypothesisConfig(document, 'true');
       });
 
-      it('ignores them', function() {
+      it('ignores them', function () {
         assert.deepEqual(jsonConfigsFrom(document), {});
       });
     });
 
-    context("when there's a JSON script with a top-level array", function() {
-      beforeEach('add a JSON script containing a top-level array', function() {
+    context("when there's a JSON script with a top-level array", function () {
+      beforeEach('add a JSON script containing a top-level array', function () {
         appendJSHypothesisConfig(document, '["a", "b", "c"]');
       });
 
-      it('returns the array, parsed into an object', function() {
+      it('returns the array, parsed into an object', function () {
         assert.deepEqual(jsonConfigsFrom(document), { 0: 'a', 1: 'b', 2: 'c' });
       });
     });
 
-    context("when there's a JSON script with a top-level string", function() {
-      beforeEach('add a JSON script with a top-level string', function() {
+    context("when there's a JSON script with a top-level string", function () {
+      beforeEach('add a JSON script with a top-level string', function () {
         appendJSHypothesisConfig(document, '"hi"');
       });
 
-      it('returns the string, parsed into an object', function() {
+      it('returns the string, parsed into an object', function () {
         assert.deepEqual(jsonConfigsFrom(document), { 0: 'h', 1: 'i' });
       });
     });
 
-    context("when there's a JSON script containing invalid JSON", function() {
-      beforeEach('stub console.warn()', function() {
+    context("when there's a JSON script containing invalid JSON", function () {
+      beforeEach('stub console.warn()', function () {
         sandbox.stub(console, 'warn');
       });
 
-      beforeEach('add a JSON script containing invalid JSON', function() {
+      beforeEach('add a JSON script containing invalid JSON', function () {
         appendJSHypothesisConfig(document, 'this is not valid json');
       });
 
-      it('logs a warning', function() {
+      it('logs a warning', function () {
         jsonConfigsFrom(document);
 
         assert.called(console.warn);
       });
 
-      it('returns {}', function() {
+      it('returns {}', function () {
         assert.deepEqual(jsonConfigsFrom(document), {});
       });
 
-      it('still returns settings from other JSON scripts', function() {
+      it('still returns settings from other JSON scripts', function () {
         appendJSHypothesisConfig(document, '{"foo": "FOO", "bar": "BAR"}');
 
         assert.deepEqual(jsonConfigsFrom(document), { foo: 'FOO', bar: 'BAR' });
       });
     });
 
-    context("when there's a JSON script with an empty object", function() {
-      beforeEach('add a JSON script containing an empty object', function() {
+    context("when there's a JSON script with an empty object", function () {
+      beforeEach('add a JSON script containing an empty object', function () {
         appendJSHypothesisConfig(document, '{}');
       });
 
-      it('ignores it', function() {
+      it('ignores it', function () {
         assert.deepEqual(jsonConfigsFrom(document), {});
       });
     });
 
-    context("when there's a JSON script containing some settings", function() {
-      beforeEach('add a JSON script containing some settings', function() {
+    context("when there's a JSON script containing some settings", function () {
+      beforeEach('add a JSON script containing some settings', function () {
         appendJSHypothesisConfig(document, '{"foo": "FOO", "bar": "BAR"}');
       });
 
-      it('returns the settings', function() {
+      it('returns the settings', function () {
         assert.deepEqual(jsonConfigsFrom(document), { foo: 'FOO', bar: 'BAR' });
       });
     });
 
-    context('when there are JSON scripts with different settings', function() {
-      beforeEach('add some JSON scripts with different settings', function() {
+    context('when there are JSON scripts with different settings', function () {
+      beforeEach('add some JSON scripts with different settings', function () {
         appendJSHypothesisConfig(document, '{"foo": "FOO"}');
         appendJSHypothesisConfig(document, '{"bar": "BAR"}');
         appendJSHypothesisConfig(document, '{"gar": "GAR"}');
       });
 
-      it('merges them all into one returned object', function() {
+      it('merges them all into one returned object', function () {
         assert.deepEqual(jsonConfigsFrom(document), {
           foo: 'FOO',
           bar: 'BAR',
@@ -126,8 +126,8 @@ describe('settings', function() {
       });
     });
 
-    context('when multiple JSON scripts contain the same setting', function() {
-      beforeEach('add some JSON scripts with different settings', function() {
+    context('when multiple JSON scripts contain the same setting', function () {
+      beforeEach('add some JSON scripts with different settings', function () {
         appendJSHypothesisConfig(document, '{"foo": "first"}');
         appendJSHypothesisConfig(document, '{"foo": "second"}');
         appendJSHypothesisConfig(document, '{"foo": "third"}');
@@ -135,7 +135,7 @@ describe('settings', function() {
 
       specify(
         'settings from later in the page override ones from earlier',
-        function() {
+        function () {
           assert.equal(jsonConfigsFrom(document).foo, 'third');
         }
       );

--- a/src/sidebar/build-thread.js
+++ b/src/sidebar/build-thread.js
@@ -100,7 +100,7 @@ function threadAnnotations(annotations) {
   const threads = {};
 
   // Build mapping of annotation ID -> thread
-  annotations.forEach(function(annotation) {
+  annotations.forEach(function (annotation) {
     threads[id(annotation)] = Object.assign({}, DEFAULT_THREAD_STATE, {
       id: id(annotation),
       annotation: annotation,
@@ -109,7 +109,7 @@ function threadAnnotations(annotations) {
   });
 
   // Set each thread's parent based on the references field
-  annotations.forEach(function(annotation) {
+  annotations.forEach(function (annotation) {
     if (!annotation.references) {
       return;
     }
@@ -119,7 +119,7 @@ function threadAnnotations(annotations) {
   // Collect the set of threads which have no parent as
   // children of the thread root
   const roots = [];
-  Object.keys(threads).forEach(function(id) {
+  Object.keys(threads).forEach(function (id) {
     if (!threads[id].parent) {
       // Top-level threads are collapsed by default
       threads[id].collapsed = true;
@@ -147,7 +147,7 @@ function threadAnnotations(annotations) {
  */
 function mapThread(thread, mapFn) {
   return Object.assign({}, mapFn(thread), {
-    children: thread.children.map(function(child) {
+    children: thread.children.map(function (child) {
       return mapThread(child, mapFn);
     }),
   });
@@ -161,7 +161,7 @@ function mapThread(thread, mapFn) {
  * @return {Array<Thread>} Sorted list of threads
  */
 function sort(threads, compareFn) {
-  return threads.slice().sort(function(a, b) {
+  return threads.slice().sort(function (a, b) {
     // Threads with no annotation always sort to the top
     if (!a.annotation || !b.annotation) {
       if (!a.annotation && !b.annotation) {
@@ -186,7 +186,7 @@ function sort(threads, compareFn) {
  * to `compareFn` and replies sorted by `replyCompareFn`.
  */
 function sortThread(thread, compareFn, replyCompareFn) {
-  const children = thread.children.map(function(child) {
+  const children = thread.children.map(function (child) {
     return sortThread(child, replyCompareFn, replyCompareFn);
   });
 
@@ -200,13 +200,13 @@ function sortThread(thread, compareFn, replyCompareFn) {
  * updated.
  */
 function countRepliesAndDepth(thread, depth) {
-  const children = thread.children.map(function(c) {
+  const children = thread.children.map(function (c) {
     return countRepliesAndDepth(c, depth + 1);
   });
   return Object.assign({}, thread, {
     children: children,
     depth: depth,
-    replyCount: children.reduce(function(total, child) {
+    replyCount: children.reduce(function (total, child) {
       return total + 1 + child.replyCount;
     }, 0),
   });
@@ -214,7 +214,7 @@ function countRepliesAndDepth(thread, depth) {
 
 /** Return true if a thread has any visible children. */
 function hasVisibleChildren(thread) {
-  return thread.children.some(function(child) {
+  return thread.children.some(function (child) {
     return child.visible || hasVisibleChildren(child);
   });
 }
@@ -250,14 +250,14 @@ const defaultOpts = {
    * Less-than comparison function used to compare annotations in order to sort
    * the top-level thread.
    */
-  sortCompareFn: function(a, b) {
+  sortCompareFn: function (a, b) {
     return a.id < b.id;
   },
   /**
    * Less-than comparison function used to compare annotations in order to sort
    * replies.
    */
-  replySortCompareFn: function(a, b) {
+  replySortCompareFn: function (a, b) {
     return a.created < b.created;
   },
 };
@@ -283,7 +283,7 @@ export default function buildThread(annotations, opts) {
   // Mark annotations as visible or hidden depending on whether
   // they are being edited and whether they match the current filter
   // criteria
-  const shouldShowThread = function(annotation) {
+  const shouldShowThread = function (annotation) {
     if (opts.forceVisible && opts.forceVisible.indexOf(id(annotation)) !== -1) {
       return true;
     }
@@ -297,14 +297,14 @@ export default function buildThread(annotations, opts) {
   // that are selected
   if (opts.selected.length > 0) {
     thread = Object.assign({}, thread, {
-      children: thread.children.filter(function(child) {
+      children: thread.children.filter(function (child) {
         return opts.selected.indexOf(child.id) !== -1;
       }),
     });
   }
 
   // Set the visibility and highlight states of threads
-  thread = mapThread(thread, function(thread) {
+  thread = mapThread(thread, function (thread) {
     let highlightState;
     if (opts.highlighted.length > 0) {
       const isHighlighted =
@@ -324,7 +324,7 @@ export default function buildThread(annotations, opts) {
   // Expand any threads which:
   // 1) Have been explicitly expanded OR
   // 2) Have children matching the filter
-  thread = mapThread(thread, function(thread) {
+  thread = mapThread(thread, function (thread) {
     const id = thread.id;
 
     // If the thread was explicitly expanded or collapsed, respect that option
@@ -340,7 +340,7 @@ export default function buildThread(annotations, opts) {
   });
 
   // Remove top-level threads which contain no visible annotations
-  thread.children = thread.children.filter(function(child) {
+  thread.children = thread.children.filter(function (child) {
     return child.visible || hasVisibleChildren(child);
   });
 

--- a/src/sidebar/components/annotation-viewer-content.js
+++ b/src/sidebar/components/annotation-viewer-content.js
@@ -7,7 +7,7 @@ function fetchThread(api, id) {
   let annot;
   return api.annotation
     .get({ id: id })
-    .then(function(annot) {
+    .then(function (annot) {
       if (annot.references && annot.references.length) {
         // This is a reply, fetch the top-level annotation
         return api.annotation.get({ id: annot.references[0] });
@@ -15,11 +15,11 @@ function fetchThread(api, id) {
         return annot;
       }
     })
-    .then(function(annot_) {
+    .then(function (annot_) {
       annot = annot_;
       return api.search({ references: annot.id });
     })
-    .then(function(searchResult) {
+    .then(function (searchResult) {
       return [annot].concat(searchResult.rows);
     });
 }
@@ -39,14 +39,14 @@ function AnnotationViewerContentController(
 
   this.rootThread = () => rootThread.thread(store.getState());
 
-  this.setCollapsed = function(id, collapsed) {
+  this.setCollapsed = function (id, collapsed) {
     store.setCollapsed(id, collapsed);
   };
 
-  this.ready = fetchThread(api, annotationId).then(function(annots) {
+  this.ready = fetchThread(api, annotationId).then(function (annots) {
     annotationMapper.loadAnnotations(annots);
 
-    const topLevelAnnot = annots.filter(function(annot) {
+    const topLevelAnnot = annots.filter(function (annot) {
       return (annot.references || []).length === 0;
     })[0];
 
@@ -60,7 +60,7 @@ function AnnotationViewerContentController(
     streamer.setConfig('filter', { filter: streamFilter.getFilter() });
     streamer.connect();
 
-    annots.forEach(function(annot) {
+    annots.forEach(function (annot) {
       store.setCollapsed(annot.id, false);
     });
 

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -83,7 +83,7 @@ function HypothesisAppController(
 
   this.route = () => store.route();
 
-  $scope.$on(events.USER_CHANGED, function(event, data) {
+  $scope.$on(events.USER_CHANGED, function (event, data) {
     self.onUserChange(data.profile);
   });
 
@@ -97,7 +97,7 @@ function HypothesisAppController(
    * @return {Promise<void>} - A Promise that resolves when the login flow
    *   completes. For non-OAuth logins, always resolves immediately.
    */
-  this.login = function() {
+  this.login = function () {
     if (serviceConfig(settings)) {
       // Let the host page handle the login request
       bridge.call(bridgeEvents.LOGIN_REQUESTED);
@@ -117,7 +117,7 @@ function HypothesisAppController(
       });
   };
 
-  this.signUp = function() {
+  this.signUp = function () {
     analytics.track(analytics.events.SIGN_UP_REQUESTED);
 
     if (serviceConfig(settings)) {
@@ -129,7 +129,7 @@ function HypothesisAppController(
   };
 
   // Prompt to discard any unsaved drafts.
-  const promptToLogout = function() {
+  const promptToLogout = function () {
     // TODO - Replace this with a UI which doesn't look terrible.
     let text = '';
     const drafts = store.countDrafts();
@@ -148,13 +148,13 @@ function HypothesisAppController(
   };
 
   // Log the user out.
-  this.logout = function() {
+  this.logout = function () {
     if (!promptToLogout()) {
       return;
     }
 
     store.clearGroups();
-    store.unsavedAnnotations().forEach(function(annotation) {
+    store.unsavedAnnotations().forEach(function (annotation) {
       $rootScope.$emit(events.ANNOTATION_DELETED, annotation);
     });
     store.discardAllDrafts();

--- a/src/sidebar/components/new-note-btn.js
+++ b/src/sidebar/components/new-note-btn.js
@@ -14,7 +14,7 @@ function NewNoteButton({ annotationsService, settings }) {
 
   const openSidebarPanel = useStore(store => store.openSidebarPanel);
 
-  const onNewNoteBtnClick = function() {
+  const onNewNoteBtnClick = function () {
     if (!isLoggedIn) {
       openSidebarPanel(uiConstants.PANEL_LOGIN_PROMPT);
       return;

--- a/src/sidebar/components/search-status-bar.js
+++ b/src/sidebar/components/search-status-bar.js
@@ -14,7 +14,7 @@ import Button from './button';
  */
 const countVisibleAnns = annThread => {
   return annThread.children.reduce(
-    function(count, child) {
+    function (count, child) {
       return count + countVisibleAnns(child);
     },
     annThread.visible ? 1 : 0

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -43,7 +43,7 @@ function SidebarContentController(
       const id = Object.keys(
         store.getState().selection.selectedAnnotationMap
       )[0];
-      return store.getState().annotations.annotations.find(function(annot) {
+      return store.getState().annotations.annotations.find(function (annot) {
         return annot.id === id;
       });
     } else {
@@ -53,7 +53,7 @@ function SidebarContentController(
 
   this.isLoading = () => {
     if (
-      !store.frames().some(function(frame) {
+      !store.frames().some(function (frame) {
         return frame.uri;
       })
     ) {
@@ -63,7 +63,7 @@ function SidebarContentController(
     return store.isFetchingAnnotations();
   };
 
-  $scope.$on('sidebarOpened', function() {
+  $scope.$on('sidebarOpened', function () {
     analytics.track(analytics.events.SIDEBAR_OPENED);
 
     streamer.connect();
@@ -76,18 +76,18 @@ function SidebarContentController(
     }
   };
 
-  $scope.$on(events.USER_CHANGED, function() {
+  $scope.$on(events.USER_CHANGED, function () {
     streamer.reconnect();
   });
 
-  $scope.$on(events.ANNOTATIONS_SYNCED, function(event, tags) {
+  $scope.$on(events.ANNOTATIONS_SYNCED, function (event, tags) {
     // When a direct-linked annotation is successfully anchored in the page,
     // focus and scroll to it
     const selectedAnnot = firstSelectedAnnotation();
     if (!selectedAnnot) {
       return;
     }
-    const matchesSelection = tags.some(function(tag) {
+    const matchesSelection = tags.some(function (tag) {
       return tag === selectedAnnot.$tag;
     });
     if (!matchesSelection) {
@@ -129,7 +129,7 @@ function SidebarContentController(
     return store.focusModeEnabled();
   };
 
-  this.showSelectedTabs = function() {
+  this.showSelectedTabs = function () {
     if (
       this.selectedAnnotationUnavailable() ||
       this.selectedGroupUnavailable() ||
@@ -143,25 +143,25 @@ function SidebarContentController(
     }
   };
 
-  this.setCollapsed = function(id, collapsed) {
+  this.setCollapsed = function (id, collapsed) {
     store.setCollapsed(id, collapsed);
   };
 
   this.focus = focusAnnotation;
   this.scrollTo = scrollToAnnotation;
 
-  this.selectedGroupUnavailable = function() {
+  this.selectedGroupUnavailable = function () {
     return store.getState().directLinked.directLinkedGroupFetchFailed;
   };
 
-  this.selectedAnnotationUnavailable = function() {
+  this.selectedAnnotationUnavailable = function () {
     const selectedID = store.getFirstSelectedAnnotationId();
     return (
       !this.isLoading() && !!selectedID && !store.annotationExists(selectedID)
     );
   };
 
-  this.shouldShowLoggedOutMessage = function() {
+  this.shouldShowLoggedOutMessage = function () {
     // If user is not logged out, don't show CTA.
     if (self.auth.status !== 'logged-out') {
       return false;

--- a/src/sidebar/components/stream-content.js
+++ b/src/sidebar/components/stream-content.js
@@ -11,7 +11,7 @@ function StreamContentController(
   let offset = 0;
 
   /** Load annotations fetched from the API into the app. */
-  const load = function(result) {
+  const load = function (result) {
     offset += result.rows.length;
     annotationMapper.loadAnnotations(result.rows, result.replies);
   };
@@ -21,7 +21,7 @@ function StreamContentController(
   /**
    * Fetch the next `limit` annotations starting from `offset` from the API.
    */
-  const fetch = function(limit) {
+  const fetch = function (limit) {
     const query = Object.assign(
       {
         _separate_replies: true,
@@ -34,7 +34,7 @@ function StreamContentController(
     api
       .search(query)
       .then(load)
-      .catch(function(err) {
+      .catch(function (err) {
         console.error(err);
       });
   };

--- a/src/sidebar/components/test/angular-util.js
+++ b/src/sidebar/components/test/angular-util.js
@@ -81,12 +81,12 @@ export function createDirective(
   // we want to create and compile it.
   let $compile;
   let $scope;
-  angular.mock.inject(function(_$compile_, _$rootScope_) {
+  angular.mock.inject(function (_$compile_, _$rootScope_) {
     $compile = _$compile_;
     $scope = _$rootScope_.$new();
   });
   const templateElement = document.createElement(hyphenate(name));
-  Object.keys(attrs).forEach(function(key) {
+  Object.keys(attrs).forEach(function (key) {
     const attrName = hyphenate(key);
     let attrKey = key;
     if (typeof attrs[key] === 'function') {
@@ -109,7 +109,7 @@ export function createDirective(
   opts.parentElement.appendChild(templateElement);
 
   // setup initial scope
-  Object.keys(attrs).forEach(function(key) {
+  Object.keys(attrs).forEach(function (key) {
     if (attrs[key].callback) {
       $scope[key] = attrs[key].callback;
     } else {
@@ -124,7 +124,7 @@ export function createDirective(
   // scope values. The caller can then re-render/link
   // the template passing in different properties
   // and verify the output
-  const linkDirective = function(props) {
+  const linkDirective = function (props) {
     const childScope = $scope.$new();
     angular.extend(childScope, props);
     const element = linkFn(childScope);

--- a/src/sidebar/components/test/annotation-body-test.js
+++ b/src/sidebar/components/test/annotation-body-test.js
@@ -78,10 +78,7 @@ describe('AnnotationBody', () => {
     wrapper.update();
 
     act(() => {
-      wrapper
-        .find('Button')
-        .props()
-        .onClick();
+      wrapper.find('Button').props().onClick();
     });
     wrapper.update();
 

--- a/src/sidebar/components/test/annotation-share-control-test.js
+++ b/src/sidebar/components/test/annotation-share-control-test.js
@@ -39,10 +39,7 @@ describe('AnnotationShareControl', () => {
 
   function openElement(wrapper) {
     act(() => {
-      wrapper
-        .find('Button')
-        .props()
-        .onClick();
+      wrapper.find('Button').props().onClick();
     });
     wrapper.update();
   }
@@ -128,9 +125,7 @@ describe('AnnotationShareControl', () => {
       const wrapper = createComponent();
       openElement(wrapper);
 
-      getButton(wrapper, 'copy')
-        .props()
-        .onClick();
+      getButton(wrapper, 'copy').props().onClick();
 
       assert.calledWith(
         fakeCopyToClipboard.copyText,
@@ -142,9 +137,7 @@ describe('AnnotationShareControl', () => {
       const wrapper = createComponent();
       openElement(wrapper);
 
-      getButton(wrapper, 'copy')
-        .props()
-        .onClick();
+      getButton(wrapper, 'copy').props().onClick();
 
       assert.calledWith(
         fakeToastMessenger.success,
@@ -157,9 +150,7 @@ describe('AnnotationShareControl', () => {
       const wrapper = createComponent();
       openElement(wrapper);
 
-      getButton(wrapper, 'copy')
-        .props()
-        .onClick();
+      getButton(wrapper, 'copy').props().onClick();
 
       assert.calledWith(fakeToastMessenger.error, 'Unable to copy link');
     });

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -225,10 +225,7 @@ describe('Annotation', () => {
         setEditingMode(true);
 
         const wrapper = createComponent();
-        wrapper
-          .find('AnnotationPublishControl')
-          .props()
-          .onSave();
+        wrapper.find('AnnotationPublishControl').props().onSave();
 
         assert.calledWith(
           fakeAnnotationsService.save,
@@ -241,10 +238,7 @@ describe('Annotation', () => {
 
         const wrapper = createComponent();
         act(() => {
-          wrapper
-            .find('AnnotationPublishControl')
-            .props()
-            .onSave();
+          wrapper.find('AnnotationPublishControl').props().onSave();
         });
 
         wrapper.update();
@@ -260,10 +254,7 @@ describe('Annotation', () => {
         fakeAnnotationsService.save.rejects();
 
         const wrapper = createComponent();
-        wrapper
-          .find('AnnotationPublishControl')
-          .props()
-          .onSave();
+        wrapper.find('AnnotationPublishControl').props().onSave();
 
         await waitFor(() => fakeToastMessenger.error.called);
       });
@@ -429,9 +420,7 @@ describe('Annotation', () => {
       });
 
       act(() => {
-        findRepliesButton(wrapper)
-          .props()
-          .onClick();
+        findRepliesButton(wrapper).props().onClick();
       });
       wrapper.setProps({ threadIsCollapsed: false });
 
@@ -449,10 +438,7 @@ describe('Annotation', () => {
         const theAnnot = fixtures.defaultAnnotation();
         const wrapper = createComponent({ annotation: theAnnot });
 
-        wrapper
-          .find('AnnotationActionBar')
-          .props()
-          .onReply();
+        wrapper.find('AnnotationActionBar').props().onReply();
 
         assert.calledOnce(fakeAnnotationsService.reply);
         assert.calledWith(

--- a/src/sidebar/components/test/annotation-viewer-content-test.js
+++ b/src/sidebar/components/test/annotation-viewer-content-test.js
@@ -8,10 +8,10 @@ function FakeApi(annots) {
   this.annots = annots;
 
   this.annotation = {
-    get: function(query) {
+    get: function (query) {
       let result;
       if (query.id) {
-        result = annots.find(function(a) {
+        result = annots.find(function (a) {
           return a.id === query.id;
         });
       }
@@ -19,10 +19,10 @@ function FakeApi(annots) {
     },
   };
 
-  this.search = function(query) {
+  this.search = function (query) {
     let result;
     if (query.references) {
-      result = annots.filter(function(a) {
+      result = annots.filter(function (a) {
         return a.references && a.references.indexOf(query.references) !== -1;
       });
     }
@@ -30,8 +30,8 @@ function FakeApi(annots) {
   };
 }
 
-describe('annotationViewerContent', function() {
-  before(function() {
+describe('annotationViewerContent', function () {
+  before(function () {
     angular
       .module('h', [])
       .component('annotationViewerContent', annotationViewerContent);
@@ -51,16 +51,16 @@ describe('annotationViewerContent', function() {
       api: opts.api,
       rootThread: { thread: sinon.stub() },
       streamer: {
-        setConfig: function() {},
-        connect: function() {},
+        setConfig: function () {},
+        connect: function () {},
       },
       streamFilter: {
-        addClause: function() {
+        addClause: function () {
           return {
-            addClause: function() {},
+            addClause: function () {},
           };
         },
-        getFilter: function() {},
+        getFilter: function () {},
       },
       annotationMapper: {
         loadAnnotations: sinon.spy(),
@@ -68,7 +68,7 @@ describe('annotationViewerContent', function() {
     };
 
     let $componentController;
-    angular.mock.inject(function(_$componentController_) {
+    angular.mock.inject(function (_$componentController_) {
       $componentController = _$componentController_;
     });
     locals.ctrl = $componentController('annotationViewerContent', locals, {
@@ -77,14 +77,14 @@ describe('annotationViewerContent', function() {
     return locals;
   }
 
-  describe('the standalone view for a top-level annotation', function() {
-    it('loads the annotation and all replies', function() {
+  describe('the standalone view for a top-level annotation', function () {
+    it('loads the annotation and all replies', function () {
       const fakeApi = new FakeApi([
         { id: 'test_annotation_id' },
         { id: 'test_reply_id', references: ['test_annotation_id'] },
       ]);
       const controller = createController({ api: fakeApi });
-      return controller.ctrl.ready.then(function() {
+      return controller.ctrl.ready.then(function () {
         assert.calledOnce(controller.annotationMapper.loadAnnotations);
         assert.calledWith(
           controller.annotationMapper.loadAnnotations,
@@ -93,26 +93,26 @@ describe('annotationViewerContent', function() {
       });
     });
 
-    it('does not highlight any annotations', function() {
+    it('does not highlight any annotations', function () {
       const fakeApi = new FakeApi([
         { id: 'test_annotation_id' },
         { id: 'test_reply_id', references: ['test_annotation_id'] },
       ]);
       const controller = createController({ api: fakeApi });
-      return controller.ctrl.ready.then(function() {
+      return controller.ctrl.ready.then(function () {
         assert.notCalled(controller.store.highlightAnnotations);
       });
     });
   });
 
-  describe('the standalone view for a reply', function() {
-    it('loads the top-level annotation and all replies', function() {
+  describe('the standalone view for a reply', function () {
+    it('loads the top-level annotation and all replies', function () {
       const fakeApi = new FakeApi([
         { id: 'parent_id' },
         { id: 'test_annotation_id', references: ['parent_id'] },
       ]);
       const controller = createController({ api: fakeApi });
-      return controller.ctrl.ready.then(function() {
+      return controller.ctrl.ready.then(function () {
         assert.calledWith(
           controller.annotationMapper.loadAnnotations,
           sinon.match(fakeApi.annots)
@@ -120,13 +120,13 @@ describe('annotationViewerContent', function() {
       });
     });
 
-    it('expands the thread', function() {
+    it('expands the thread', function () {
       const fakeApi = new FakeApi([
         { id: 'parent_id' },
         { id: 'test_annotation_id', references: ['parent_id'] },
       ]);
       const controller = createController({ api: fakeApi });
-      return controller.ctrl.ready.then(function() {
+      return controller.ctrl.ready.then(function () {
         assert.calledWith(controller.store.setCollapsed, 'parent_id', false);
         assert.calledWith(
           controller.store.setCollapsed,
@@ -136,13 +136,13 @@ describe('annotationViewerContent', function() {
       });
     });
 
-    it('highlights the reply', function() {
+    it('highlights the reply', function () {
       const fakeApi = new FakeApi([
         { id: 'parent_id' },
         { id: 'test_annotation_id', references: ['parent_id'] },
       ]);
       const controller = createController({ api: fakeApi });
-      return controller.ctrl.ready.then(function() {
+      return controller.ctrl.ready.then(function () {
         assert.calledWith(
           controller.store.highlightAnnotations,
           sinon.match(['test_annotation_id'])

--- a/src/sidebar/components/test/autocomplete-list-test.js
+++ b/src/sidebar/components/test/autocomplete-list-test.js
@@ -7,7 +7,7 @@ import { $imports } from '../autocomplete-list';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('AutocompleteList', function() {
+describe('AutocompleteList', function () {
   let fakeList;
   let fakeOnSelectItem;
   let fakeListFormatter;
@@ -21,7 +21,7 @@ describe('AutocompleteList', function() {
     );
   }
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeList = ['tag1', 'tag2'];
     fakeOnSelectItem = sinon.stub();
     fakeListFormatter = sinon.stub();
@@ -44,38 +44,14 @@ describe('AutocompleteList', function() {
 
   it('sets unique keys to the <li> items', () => {
     const wrapper = createComponent({ open: true });
-    assert.equal(
-      wrapper
-        .find('li')
-        .at(0)
-        .key(),
-      'autocomplete-list-0'
-    );
-    assert.equal(
-      wrapper
-        .find('li')
-        .at(1)
-        .key(),
-      'autocomplete-list-1'
-    );
+    assert.equal(wrapper.find('li').at(0).key(), 'autocomplete-list-0');
+    assert.equal(wrapper.find('li').at(1).key(), 'autocomplete-list-1');
   });
 
   it('renders the items in order of the list prop', () => {
     const wrapper = createComponent({ open: true });
-    assert.equal(
-      wrapper
-        .find('li')
-        .at(0)
-        .text(),
-      'tag1'
-    );
-    assert.equal(
-      wrapper
-        .find('li')
-        .at(1)
-        .text(),
-      'tag2'
-    );
+    assert.equal(wrapper.find('li').at(0).text(), 'tag1');
+    assert.equal(wrapper.find('li').at(1).text(), 'tag2');
   });
 
   it('does not apply the `is-selected` class to items that are not selected', () => {
@@ -85,26 +61,13 @@ describe('AutocompleteList', function() {
 
   it('applies `is-selected` class only to the <li> at the matching index', () => {
     const wrapper = createComponent({ open: true, activeItem: 0 });
-    assert.isTrue(
-      wrapper
-        .find('li')
-        .at(0)
-        .hasClass('is-selected')
-    );
-    assert.isFalse(
-      wrapper
-        .find('li')
-        .at(1)
-        .hasClass('is-selected')
-    );
+    assert.isTrue(wrapper.find('li').at(0).hasClass('is-selected'));
+    assert.isFalse(wrapper.find('li').at(1).hasClass('is-selected'));
   });
 
   it('calls `onSelect` when an <li> is clicked with the corresponding item', () => {
     const wrapper = createComponent({ open: true, activeItem: 0 });
-    wrapper
-      .find('li')
-      .at(0)
-      .simulate('click');
+    wrapper.find('li').at(0).simulate('click');
     assert.calledWith(fakeOnSelectItem, 'tag1');
   });
 
@@ -123,46 +86,17 @@ describe('AutocompleteList', function() {
 
   it('creates unique ids on the <li> tags with the `itemPrefixId` only if its present', () => {
     let wrapper = createComponent({ open: true });
-    assert.isNotOk(
-      wrapper
-        .find('li')
-        .at(0)
-        .prop('id')
-    );
+    assert.isNotOk(wrapper.find('li').at(0).prop('id'));
     wrapper = createComponent({ open: true, itemPrefixId: 'item-prefix-id-' });
-    assert.equal(
-      wrapper
-        .find('li')
-        .at(0)
-        .prop('id'),
-      'item-prefix-id-0'
-    );
-    assert.equal(
-      wrapper
-        .find('li')
-        .at(1)
-        .prop('id'),
-      'item-prefix-id-1'
-    );
+    assert.equal(wrapper.find('li').at(0).prop('id'), 'item-prefix-id-0');
+    assert.equal(wrapper.find('li').at(1).prop('id'), 'item-prefix-id-1');
   });
 
   it('sets the `aria-selected` attribute to "true" on the active item and "false" for all others', () => {
     const wrapper = createComponent({ open: true, activeItem: 0 });
-    assert.equal(
-      wrapper
-        .find('li')
-        .at(0)
-        .prop('aria-selected'),
-      'true'
-    );
+    assert.equal(wrapper.find('li').at(0).prop('aria-selected'), 'true');
 
-    assert.equal(
-      wrapper
-        .find('li')
-        .at(1)
-        .prop('aria-selected'),
-      'false'
-    );
+    assert.equal(wrapper.find('li').at(1).prop('aria-selected'), 'false');
   });
 
   it(

--- a/src/sidebar/components/test/focused-mode-header-test.js
+++ b/src/sidebar/components/test/focused-mode-header-test.js
@@ -7,13 +7,13 @@ import { $imports } from '../focused-mode-header';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('FocusedModeHeader', function() {
+describe('FocusedModeHeader', function () {
   let fakeStore;
   function createComponent() {
     return mount(<FocusedModeHeader />);
   }
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeStore = {
       selection: {
         focusMode: {

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -96,20 +96,14 @@ describe('GroupListItem', () => {
 
   function clickMenuItem(wrapper, label) {
     act(() => {
-      wrapper
-        .find(`MenuItem[label="${label}"]`)
-        .props()
-        .onClick();
+      wrapper.find(`MenuItem[label="${label}"]`).props().onClick();
     });
     wrapper.update();
   }
 
   it('changes the focused group when group is clicked', () => {
     const wrapper = createGroupListItem(fakeGroup);
-    wrapper
-      .find('MenuItem')
-      .props()
-      .onClick();
+    wrapper.find('MenuItem').props().onClick();
 
     assert.calledWith(fakeGroupsService.focus, fakeGroup.id);
     assert.calledWith(fakeAnalytics.track, fakeAnalytics.events.GROUP_SWITCH);
@@ -117,20 +111,14 @@ describe('GroupListItem', () => {
 
   it('clears the direct linked ids from the store when the group is clicked', () => {
     const wrapper = createGroupListItem(fakeGroup);
-    wrapper
-      .find('MenuItem')
-      .props()
-      .onClick();
+    wrapper.find('MenuItem').props().onClick();
 
     assert.calledOnce(fakeStore.clearDirectLinkedIds);
   });
 
   it('clears the direct-linked group fetch failed from the store when the group is clicked', () => {
     const wrapper = createGroupListItem(fakeGroup);
-    wrapper
-      .find('MenuItem')
-      .props()
-      .onClick();
+    wrapper.find('MenuItem').props().onClick();
 
     assert.calledOnce(fakeStore.clearDirectLinkedGroupFetchFailed);
   });
@@ -180,22 +168,12 @@ describe('GroupListItem', () => {
 
   it('expands submenu if `isExpanded` is `true`', () => {
     const wrapper = createGroupListItem(fakeGroup, { isExpanded: true });
-    assert.isTrue(
-      wrapper
-        .find('MenuItem')
-        .first()
-        .prop('isExpanded')
-    );
+    assert.isTrue(wrapper.find('MenuItem').first().prop('isExpanded'));
   });
 
   it('collapses submenu if `isExpanded` is `false`', () => {
     const wrapper = createGroupListItem(fakeGroup, { isExpanded: false });
-    assert.isFalse(
-      wrapper
-        .find('MenuItem')
-        .first()
-        .prop('isExpanded')
-    );
+    assert.isFalse(wrapper.find('MenuItem').first().prop('isExpanded'));
   });
 
   it('toggles submenu when toggle is clicked', () => {
@@ -204,11 +182,7 @@ describe('GroupListItem', () => {
     const toggleSubmenu = () => {
       const dummyEvent = new Event('dummy');
       act(() => {
-        wrapper
-          .find('MenuItem')
-          .first()
-          .props()
-          .onToggleSubmenu(dummyEvent);
+        wrapper.find('MenuItem').first().props().onToggleSubmenu(dummyEvent);
       });
       wrapper.update();
     };
@@ -230,10 +204,7 @@ describe('GroupListItem', () => {
   });
 
   function getSubmenu(wrapper) {
-    const submenu = wrapper
-      .find('MenuItem')
-      .first()
-      .prop('submenu');
+    const submenu = wrapper.find('MenuItem').first().prop('submenu');
     return mount(<div>{submenu}</div>);
   }
 
@@ -321,10 +292,7 @@ describe('GroupListItem', () => {
         isExpanded: true,
       });
       assert.equal(
-        wrapper
-          .find('MenuItem')
-          .first()
-          .prop('isDisabled'),
+        wrapper.find('MenuItem').first().prop('isDisabled'),
         expectDisabled
       );
 

--- a/src/sidebar/components/test/group-list-section-test.js
+++ b/src/sidebar/components/test/group-list-section-test.js
@@ -59,11 +59,7 @@ describe('GroupListSection', () => {
   it("sets expanded group when a group's submenu is expanded", () => {
     const onExpandGroup = sinon.stub();
     const wrapper = createGroupListSection({ onExpandGroup });
-    wrapper
-      .find('GroupListItem')
-      .first()
-      .props()
-      .onExpand(true);
+    wrapper.find('GroupListItem').first().props().onExpand(true);
     assert.calledWith(onExpandGroup, testGroups[0]);
   });
 
@@ -73,11 +69,7 @@ describe('GroupListSection', () => {
       expandedGroup: testGroups[0],
       onExpandGroup,
     });
-    wrapper
-      .find('GroupListItem')
-      .first()
-      .props()
-      .onExpand(false);
+    wrapper.find('GroupListItem').first().props().onExpand(false);
     assert.calledWith(onExpandGroup, null);
   });
 });

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -210,20 +210,16 @@ describe('GroupList', () => {
 
     // Expand a group in one of the sections.
     act(() => {
-      wrapper
-        .find('GroupListSection')
-        .first()
-        .prop('onExpandGroup')(testGroups[0]);
+      wrapper.find('GroupListSection').first().prop('onExpandGroup')(
+        testGroups[0]
+      );
     });
     wrapper.update();
     verifyGroupIsExpanded(wrapper, testGroups[0]);
 
     // Reset expanded group.
     act(() => {
-      wrapper
-        .find('GroupListSection')
-        .first()
-        .prop('onExpandGroup')(null);
+      wrapper.find('GroupListSection').first().prop('onExpandGroup')(null);
     });
     wrapper.update();
     verifyGroupIsExpanded(wrapper, null);
@@ -235,10 +231,9 @@ describe('GroupList', () => {
 
     // Expand one of the submenus.
     act(() => {
-      wrapper
-        .find('GroupListSection')
-        .first()
-        .prop('onExpandGroup')(testGroups[0]);
+      wrapper.find('GroupListSection').first().prop('onExpandGroup')(
+        testGroups[0]
+      );
     });
     wrapper.update();
     verifyGroupIsExpanded(wrapper, testGroups[0]);

--- a/src/sidebar/components/test/help-panel-test.js
+++ b/src/sidebar/components/test/help-panel-test.js
@@ -8,7 +8,7 @@ import { $imports } from '../help-panel';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('HelpPanel', function() {
+describe('HelpPanel', function () {
   let fakeAuth;
   let fakeSessionService;
   let fakeStore;

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -6,7 +6,7 @@ import { events as analyticsEvents } from '../../services/analytics';
 import hypothesisApp from '../hypothesis-app';
 import { $imports } from '../hypothesis-app';
 
-describe('sidebar.components.hypothesis-app', function() {
+describe('sidebar.components.hypothesis-app', function () {
   let $componentController = null;
   let $scope = null;
   let $rootScope = null;
@@ -28,17 +28,17 @@ describe('sidebar.components.hypothesis-app', function() {
 
   let sandbox = null;
 
-  const createController = function(locals) {
+  const createController = function (locals) {
     locals = locals || {};
     locals.$scope = $scope;
     return $componentController('hypothesisApp', locals);
   };
 
-  beforeEach(function() {
+  beforeEach(function () {
     sandbox = sinon.createSandbox();
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeIsSidebar = sandbox.stub().returns(true);
     fakeServiceConfig = sandbox.stub();
     fakeShouldAutoDisplayTutorial = sinon.stub().returns(false);
@@ -61,7 +61,7 @@ describe('sidebar.components.hypothesis-app', function() {
   beforeEach(angular.mock.module('h'));
 
   beforeEach(
-    angular.mock.module(function($provide) {
+    angular.mock.module(function ($provide) {
       fakeStore = {
         tool: 'comment',
         clearSelectedAnnotations: sandbox.spy(),
@@ -139,24 +139,24 @@ describe('sidebar.components.hypothesis-app', function() {
   );
 
   beforeEach(
-    angular.mock.inject(function(_$componentController_, _$rootScope_) {
+    angular.mock.inject(function (_$componentController_, _$rootScope_) {
       $componentController = _$componentController_;
       $rootScope = _$rootScope_;
       $scope = $rootScope.$new();
     })
   );
 
-  afterEach(function() {
+  afterEach(function () {
     sandbox.restore();
   });
 
-  it('connects to host frame in the sidebar app', function() {
+  it('connects to host frame in the sidebar app', function () {
     fakeIsSidebar.returns(true);
     createController();
     assert.called(fakeFrameSync.connect);
   });
 
-  it('does not connect to the host frame in the stream', function() {
+  it('does not connect to the host frame in the stream', function () {
     fakeIsSidebar.returns(false);
     createController();
     assert.notCalled(fakeFrameSync.connect);
@@ -180,24 +180,24 @@ describe('sidebar.components.hypothesis-app', function() {
     });
   });
 
-  it('auth.status is "unknown" on startup', function() {
+  it('auth.status is "unknown" on startup', function () {
     const ctrl = createController();
     assert.equal(ctrl.auth.status, 'unknown');
   });
 
-  it('sets auth.status to "logged-out" if userid is null', function() {
+  it('sets auth.status to "logged-out" if userid is null', function () {
     const ctrl = createController();
-    return fakeSession.load().then(function() {
+    return fakeSession.load().then(function () {
       assert.equal(ctrl.auth.status, 'logged-out');
     });
   });
 
-  it('sets auth.status to "logged-in" if userid is non-null', function() {
-    fakeSession.load = function() {
+  it('sets auth.status to "logged-in" if userid is non-null', function () {
+    fakeSession.load = function () {
       return Promise.resolve({ userid: 'acct:jim@hypothes.is' });
     };
     const ctrl = createController();
-    return fakeSession.load().then(function() {
+    return fakeSession.load().then(function () {
       assert.equal(ctrl.auth.status, 'logged-in');
     });
   });
@@ -245,9 +245,9 @@ describe('sidebar.components.hypothesis-app', function() {
     });
   });
 
-  it('updates auth when the logged-in user changes', function() {
+  it('updates auth when the logged-in user changes', function () {
     const ctrl = createController();
-    return fakeSession.load().then(function() {
+    return fakeSession.load().then(function () {
       $scope.$broadcast(events.USER_CHANGED, {
         profile: {
           userid: 'acct:john@hypothes.is',
@@ -263,8 +263,8 @@ describe('sidebar.components.hypothesis-app', function() {
     });
   });
 
-  describe('#signUp', function() {
-    it('tracks sign up requests in analytics', function() {
+  describe('#signUp', function () {
+    it('tracks sign up requests in analytics', function () {
       const ctrl = createController();
       ctrl.signUp();
       assert.calledWith(
@@ -273,26 +273,26 @@ describe('sidebar.components.hypothesis-app', function() {
       );
     });
 
-    context('when using a third-party service', function() {
-      beforeEach(function() {
+    context('when using a third-party service', function () {
+      beforeEach(function () {
         fakeServiceConfig.returns({});
       });
 
-      it('sends SIGNUP_REQUESTED event', function() {
+      it('sends SIGNUP_REQUESTED event', function () {
         const ctrl = createController();
         ctrl.signUp();
         assert.calledWith(fakeBridge.call, bridgeEvents.SIGNUP_REQUESTED);
       });
 
-      it('does not open a URL directly', function() {
+      it('does not open a URL directly', function () {
         const ctrl = createController();
         ctrl.signUp();
         assert.notCalled(fakeWindow.open);
       });
     });
 
-    context('when not using a third-party service', function() {
-      it('opens the signup URL in a new tab', function() {
+    context('when not using a third-party service', function () {
+      it('opens the signup URL in a new tab', function () {
         fakeServiceUrl.withArgs('signup').returns('https://ann.service/signup');
         const ctrl = createController();
         ctrl.signUp();
@@ -301,7 +301,7 @@ describe('sidebar.components.hypothesis-app', function() {
     });
   });
 
-  describe('#login()', function() {
+  describe('#login()', function () {
     beforeEach(() => {
       fakeAuth.login = sinon.stub().returns(Promise.resolve());
       fakeStore.getState.returns({ directLinkedGroupFetchFailed: false });
@@ -345,7 +345,7 @@ describe('sidebar.components.hypothesis-app', function() {
       });
     });
 
-    it('sends LOGIN_REQUESTED if a third-party service is in use', function() {
+    it('sends LOGIN_REQUESTED if a third-party service is in use', function () {
       // If the client is using a third-party annotation service then clicking
       // on a login button should send the LOGIN_REQUESTED event over the bridge
       // (so that the partner site we're embedded in can do its own login
@@ -362,10 +362,10 @@ describe('sidebar.components.hypothesis-app', function() {
     });
   });
 
-  describe('#logout()', function() {
+  describe('#logout()', function () {
     // Tests shared by both of the contexts below.
     function doSharedTests() {
-      it('prompts the user if there are drafts', function() {
+      it('prompts the user if there are drafts', function () {
         fakeStore.countDrafts.returns(1);
         const ctrl = createController();
 
@@ -382,7 +382,7 @@ describe('sidebar.components.hypothesis-app', function() {
         assert.called(fakeStore.clearGroups);
       });
 
-      it('emits "annotationDeleted" for each unsaved draft annotation', function() {
+      it('emits "annotationDeleted" for each unsaved draft annotation', function () {
         fakeStore.unsavedAnnotations = sandbox
           .stub()
           .returns(['draftOne', 'draftTwo', 'draftThree']);
@@ -406,7 +406,7 @@ describe('sidebar.components.hypothesis-app', function() {
         ]);
       });
 
-      it('discards draft annotations', function() {
+      it('discards draft annotations', function () {
         const ctrl = createController();
 
         ctrl.logout();
@@ -414,7 +414,7 @@ describe('sidebar.components.hypothesis-app', function() {
         assert(fakeStore.discardAllDrafts.calledOnce);
       });
 
-      it('does not emit "annotationDeleted" if the user cancels the prompt', function() {
+      it('does not emit "annotationDeleted" if the user cancels the prompt', function () {
         const ctrl = createController();
         fakeStore.countDrafts.returns(1);
         $rootScope.$emit = sandbox.stub();
@@ -425,7 +425,7 @@ describe('sidebar.components.hypothesis-app', function() {
         assert($rootScope.$emit.notCalled);
       });
 
-      it('does not discard drafts if the user cancels the prompt', function() {
+      it('does not discard drafts if the user cancels the prompt', function () {
         const ctrl = createController();
         fakeStore.countDrafts.returns(1);
         fakeWindow.confirm.returns(false);
@@ -435,7 +435,7 @@ describe('sidebar.components.hypothesis-app', function() {
         assert(fakeStore.discardAllDrafts.notCalled);
       });
 
-      it('does not prompt if there are no drafts', function() {
+      it('does not prompt if there are no drafts', function () {
         const ctrl = createController();
         fakeStore.countDrafts.returns(0);
 
@@ -445,24 +445,24 @@ describe('sidebar.components.hypothesis-app', function() {
       });
     }
 
-    context('when no third-party service is in use', function() {
+    context('when no third-party service is in use', function () {
       doSharedTests();
 
-      it('calls session.logout()', function() {
+      it('calls session.logout()', function () {
         const ctrl = createController();
         ctrl.logout();
         assert.called(fakeSession.logout);
       });
     });
 
-    context('when a third-party service is in use', function() {
-      beforeEach('configure a third-party service to be in use', function() {
+    context('when a third-party service is in use', function () {
+      beforeEach('configure a third-party service to be in use', function () {
         fakeServiceConfig.returns({});
       });
 
       doSharedTests();
 
-      it('sends LOGOUT_REQUESTED', function() {
+      it('sends LOGOUT_REQUESTED', function () {
         createController().logout();
 
         assert.calledOnce(fakeBridge.call);
@@ -472,7 +472,7 @@ describe('sidebar.components.hypothesis-app', function() {
         );
       });
 
-      it('does not send LOGOUT_REQUESTED if the user cancels the prompt', function() {
+      it('does not send LOGOUT_REQUESTED if the user cancels the prompt', function () {
         fakeStore.countDrafts.returns(1);
         fakeWindow.confirm.returns(false);
 
@@ -481,7 +481,7 @@ describe('sidebar.components.hypothesis-app', function() {
         assert.notCalled(fakeBridge.call);
       });
 
-      it('does not call session.logout()', function() {
+      it('does not call session.logout()', function () {
         createController().logout();
 
         assert.notCalled(fakeSession.logout);

--- a/src/sidebar/components/test/login-prompt-panel-test.js
+++ b/src/sidebar/components/test/login-prompt-panel-test.js
@@ -7,7 +7,7 @@ import { $imports } from '../login-prompt-panel';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('LoginPromptPanel', function() {
+describe('LoginPromptPanel', function () {
   let fakeOnLogin;
   let fakeOnSignUp;
 

--- a/src/sidebar/components/test/markdown-editor-test.js
+++ b/src/sidebar/components/test/markdown-editor-test.js
@@ -440,10 +440,7 @@ describe('MarkdownEditor', () => {
       beforeEach(() => {
         // turn on Preview mode
         act(() => {
-          wrapper
-            .find('Toolbar')
-            .props()
-            .onTogglePreview();
+          wrapper.find('Toolbar').props().onTogglePreview();
         });
         const previewButton = wrapper
           .find('button')

--- a/src/sidebar/components/test/menu-item-test.js
+++ b/src/sidebar/components/test/menu-item-test.js
@@ -125,13 +125,7 @@ describe('MenuItem', () => {
       submenu: <div>Submenu content</div>,
     });
     assert.equal(wrapper.find('Slider').prop('visible'), true);
-    assert.equal(
-      wrapper
-        .find('Slider')
-        .children()
-        .text(),
-      'Submenu content'
-    );
+    assert.equal(wrapper.find('Slider').children().text(), 'Submenu content');
   });
 
   it('hides submenu content if `isSubmenuVisible` is false', () => {
@@ -143,13 +137,7 @@ describe('MenuItem', () => {
 
     // The submenu content may still be rendered if the submenu is currently
     // collapsing.
-    assert.equal(
-      wrapper
-        .find('Slider')
-        .children()
-        .text(),
-      'Submenu content'
-    );
+    assert.equal(wrapper.find('Slider').children().text(), 'Submenu content');
   });
 
   it(

--- a/src/sidebar/components/test/moderation-banner-test.js
+++ b/src/sidebar/components/test/moderation-banner-test.js
@@ -95,13 +95,13 @@ describe('ModerationBanner', () => {
     });
   });
 
-  it('displays the number of flags the annotation has received', function() {
+  it('displays the number of flags the annotation has received', function () {
     const ann = fixtures.moderatedAnnotation({ flagCount: 10 });
     const wrapper = createComponent({ annotation: ann });
     assert.include(wrapper.text(), 'Flagged for review x10');
   });
 
-  it('displays in a more compact form if the annotation is a reply', function() {
+  it('displays in a more compact form if the annotation is a reply', function () {
     const wrapper = createComponent({
       annotation: {
         ...fixtures.oldReply(),
@@ -113,7 +113,7 @@ describe('ModerationBanner', () => {
     wrapper.exists('.is-reply');
   });
 
-  it('does not display in a more compact form if the annotation is not a reply', function() {
+  it('does not display in a more compact form if the annotation is not a reply', function () {
     const wrapper = createComponent({
       annotation: {
         ...fixtures.moderatedAnnotation({}),
@@ -125,7 +125,7 @@ describe('ModerationBanner', () => {
     assert.isFalse(wrapper.exists('.is-reply'));
   });
 
-  it('reports if the annotation was hidden', function() {
+  it('reports if the annotation was hidden', function () {
     const wrapper = createComponent({
       annotation: fixtures.moderatedAnnotation({
         flagCount: 1,
@@ -135,7 +135,7 @@ describe('ModerationBanner', () => {
     assert.include(wrapper.text(), 'Hidden from users');
   });
 
-  it('hides the annotation if "Hide" is clicked', function() {
+  it('hides the annotation if "Hide" is clicked', function () {
     const wrapper = createComponent({
       annotation: fixtures.moderatedAnnotation({
         flagCount: 10,
@@ -145,7 +145,7 @@ describe('ModerationBanner', () => {
     assert.calledWith(fakeApi.annotation.hide, { id: 'ann-id' });
   });
 
-  it('reports an error if hiding the annotation fails', function(done) {
+  it('reports an error if hiding the annotation fails', function (done) {
     const wrapper = createComponent({
       annotation: moderatedAnnotation({
         flagCount: 10,
@@ -154,13 +154,13 @@ describe('ModerationBanner', () => {
     fakeApi.annotation.hide.returns(Promise.reject(new Error('Network Error')));
     wrapper.find('button').simulate('click');
 
-    setTimeout(function() {
+    setTimeout(function () {
       assert.calledWith(fakeToastMessenger.error, 'Failed to hide annotation');
       done();
     }, 0);
   });
 
-  it('unhides the annotation if "Unhide" is clicked', function() {
+  it('unhides the annotation if "Unhide" is clicked', function () {
     const wrapper = createComponent({
       annotation: moderatedAnnotation({
         flagCount: 1,
@@ -171,7 +171,7 @@ describe('ModerationBanner', () => {
     assert.calledWith(fakeApi.annotation.unhide, { id: 'ann-id' });
   });
 
-  it('reports an error if unhiding the annotation fails', function(done) {
+  it('reports an error if unhiding the annotation fails', function (done) {
     const wrapper = createComponent({
       annotation: moderatedAnnotation({
         flagCount: 1,
@@ -182,7 +182,7 @@ describe('ModerationBanner', () => {
       Promise.reject(new Error('Network Error'))
     );
     wrapper.find('button').simulate('click');
-    setTimeout(function() {
+    setTimeout(function () {
       assert.calledWith(
         fakeToastMessenger.error,
         'Failed to unhide annotation'

--- a/src/sidebar/components/test/new-note-btn-test.js
+++ b/src/sidebar/components/test/new-note-btn-test.js
@@ -9,7 +9,7 @@ import uiConstants from '../../ui-constants';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('NewNoteButton', function() {
+describe('NewNoteButton', function () {
   let fakeStore;
   let fakeAnnotationsService;
   let fakeSettings;
@@ -23,7 +23,7 @@ describe('NewNoteButton', function() {
     );
   }
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeAnnotationsService = {
       create: sinon.stub(),
     };
@@ -62,10 +62,7 @@ describe('NewNoteButton', function() {
     const wrapper = createComponent();
 
     act(() => {
-      wrapper
-        .find('Button')
-        .props()
-        .onClick();
+      wrapper.find('Button').props().onClick();
     });
 
     assert.calledWith(
@@ -80,10 +77,7 @@ describe('NewNoteButton', function() {
     const wrapper = createComponent();
 
     act(() => {
-      wrapper
-        .find('Button')
-        .props()
-        .onClick();
+      wrapper.find('Button').props().onClick();
     });
 
     assert.calledWith(fakeAnnotationsService.create, {

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -8,7 +8,7 @@ import { $imports } from '../selection-tabs';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('SelectionTabs', function() {
+describe('SelectionTabs', function () {
   // mock services
   let fakeSettings;
   let fakeStore;
@@ -55,29 +55,17 @@ describe('SelectionTabs', function() {
   const unavailableMessage = wrapper =>
     wrapper.find('.selection-tabs__message').text();
 
-  context('displays selection tabs and counts', function() {
-    it('should display the tabs and counts of annotations and notes', function() {
+  context('displays selection tabs and counts', function () {
+    it('should display the tabs and counts of annotations and notes', function () {
       const wrapper = createComponent();
       const tabs = wrapper.find('button');
       assert.isTrue(tabs.at(0).contains('Annotations'));
-      assert.equal(
-        tabs
-          .at(0)
-          .find('.selection-tabs__count')
-          .text(),
-        123
-      );
+      assert.equal(tabs.at(0).find('.selection-tabs__count').text(), 123);
       assert.isTrue(tabs.at(1).contains('Page Notes'));
-      assert.equal(
-        tabs
-          .at(1)
-          .find('.selection-tabs__count')
-          .text(),
-        456
-      );
+      assert.equal(tabs.at(1).find('.selection-tabs__count').text(), 456);
     });
 
-    it('should display annotations tab as selected', function() {
+    it('should display annotations tab as selected', function () {
       const wrapper = createComponent();
       const tabs = wrapper.find('button');
       assert.isTrue(tabs.at(0).hasClass('is-selected'));
@@ -85,7 +73,7 @@ describe('SelectionTabs', function() {
       assert.equal(tabs.at(1).prop('aria-selected'), 'false');
     });
 
-    it('should display notes tab as selected', function() {
+    it('should display notes tab as selected', function () {
       fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_NOTES },
       });
@@ -96,7 +84,7 @@ describe('SelectionTabs', function() {
       assert.equal(tabs.at(0).prop('aria-selected'), 'false');
     });
 
-    it('should display orphans tab as selected if there is 1 or more orphans', function() {
+    it('should display orphans tab as selected if there is 1 or more orphans', function () {
       fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_ORPHANS },
       });
@@ -109,7 +97,7 @@ describe('SelectionTabs', function() {
       assert.equal(tabs.at(0).prop('aria-selected'), 'false');
     });
 
-    it('should not display orphans tab if there are 0 orphans', function() {
+    it('should not display orphans tab if there are 0 orphans', function () {
       fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_ORPHANS },
       });
@@ -118,23 +106,23 @@ describe('SelectionTabs', function() {
       assert.equal(tabs.length, 2);
     });
 
-    it('should show the clean theme when settings contains the clean theme option', function() {
+    it('should show the clean theme when settings contains the clean theme option', function () {
       fakeSettings.theme = 'clean';
       const wrapper = createComponent();
       assert.isTrue(wrapper.exists('.selection-tabs--theme-clean'));
     });
 
-    it('should not show the clean theme when settings does not contain the clean theme option', function() {
+    it('should not show the clean theme when settings does not contain the clean theme option', function () {
       const wrapper = createComponent();
       assert.isFalse(wrapper.exists('.selection-tabs--theme-clean'));
     });
 
-    it('should not display the new-note-btn when the annotations tab is active', function() {
+    it('should not display the new-note-btn when the annotations tab is active', function () {
       const wrapper = createComponent();
       assert.equal(wrapper.find('NewNoteButton').length, 0);
     });
 
-    it('should not display the new-note-btn when the notes tab is active and the new-note-btn is disabled', function() {
+    it('should not display the new-note-btn when the notes tab is active and the new-note-btn is disabled', function () {
       fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_NOTES },
       });
@@ -142,7 +130,7 @@ describe('SelectionTabs', function() {
       assert.equal(wrapper.find('NewNoteButton').length, 0);
     });
 
-    it('should display the new-note-btn when the notes tab is active and the new-note-btn is enabled', function() {
+    it('should display the new-note-btn when the notes tab is active and the new-note-btn is enabled', function () {
       fakeSettings.enableExperimentalNewNoteButton = true;
       fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_NOTES },
@@ -151,7 +139,7 @@ describe('SelectionTabs', function() {
       assert.equal(wrapper.find('NewNoteButton').length, 1);
     });
 
-    it('should not display a message when its loading annotation count is 0', function() {
+    it('should not display a message when its loading annotation count is 0', function () {
       fakeStore.annotationCount.returns(0);
       const wrapper = createComponent({
         isLoading: true,
@@ -159,7 +147,7 @@ describe('SelectionTabs', function() {
       assert.isFalse(wrapper.exists('.annotation-unavailable-message__label'));
     });
 
-    it('should not display a message when its loading notes count is 0', function() {
+    it('should not display a message when its loading notes count is 0', function () {
       fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_NOTES },
       });
@@ -170,7 +158,7 @@ describe('SelectionTabs', function() {
       assert.isFalse(wrapper.exists('.selection-tabs__message'));
     });
 
-    it('should not display the longer version of the no annotations message when there are no annotations and isWaitingToAnchorAnnotations is true', function() {
+    it('should not display the longer version of the no annotations message when there are no annotations and isWaitingToAnchorAnnotations is true', function () {
       fakeStore.annotationCount.returns(0);
       fakeStore.isWaitingToAnchorAnnotations.returns(true);
       const wrapper = createComponent({
@@ -179,7 +167,7 @@ describe('SelectionTabs', function() {
       assert.isFalse(wrapper.exists('.selection-tabs__message'));
     });
 
-    it('should display the longer version of the no notes message when there are no notes', function() {
+    it('should display the longer version of the no notes message when there are no notes', function () {
       fakeStore.getState.returns({
         selection: { selectedTab: uiConstants.TAB_NOTES },
       });
@@ -191,7 +179,7 @@ describe('SelectionTabs', function() {
       );
     });
 
-    it('should display the longer version of the no annotations message when there are no annotations', function() {
+    it('should display the longer version of the no annotations message when there are no annotations', function () {
       fakeStore.annotationCount.returns(0);
       const wrapper = createComponent({});
       assert.include(

--- a/src/sidebar/components/test/share-annotations-panel-test.js
+++ b/src/sidebar/components/test/share-annotations-panel-test.js
@@ -150,10 +150,7 @@ describe('ShareAnnotationsPanel', () => {
       it('copies link to clipboard when copy button clicked', () => {
         const wrapper = createShareAnnotationsPanel();
 
-        wrapper
-          .find('Button')
-          .props()
-          .onClick();
+        wrapper.find('Button').props().onClick();
 
         assert.calledWith(
           fakeCopyToClipboard.copyText,
@@ -164,10 +161,7 @@ describe('ShareAnnotationsPanel', () => {
       it('confirms link copy when successful', () => {
         const wrapper = createShareAnnotationsPanel();
 
-        wrapper
-          .find('Button')
-          .props()
-          .onClick();
+        wrapper.find('Button').props().onClick();
 
         assert.calledWith(
           fakeToastMessenger.success,
@@ -178,10 +172,7 @@ describe('ShareAnnotationsPanel', () => {
         fakeCopyToClipboard.copyText.throws();
         const wrapper = createShareAnnotationsPanel();
 
-        wrapper
-          .find('Button')
-          .props()
-          .onClick();
+        wrapper.find('Button').props().onClick();
 
         assert.calledWith(fakeToastMessenger.error, 'Unable to copy link');
       });

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -14,7 +14,7 @@ class FakeRootThread extends EventEmitter {
   }
 }
 
-describe('sidebar.components.sidebar-content', function() {
+describe('sidebar.components.sidebar-content', function () {
   let $rootScope;
   let $scope;
   let store;
@@ -27,7 +27,7 @@ describe('sidebar.components.sidebar-content', function() {
   let fakeStreamer;
   let sandbox;
 
-  before(function() {
+  before(function () {
     angular
       .module('h', [])
       .service('store', storeFactory)
@@ -37,7 +37,7 @@ describe('sidebar.components.sidebar-content', function() {
   beforeEach(angular.mock.module('h'));
 
   beforeEach(() => {
-    angular.mock.module(function($provide) {
+    angular.mock.module(function ($provide) {
       sandbox = sinon.createSandbox();
 
       fakeAnalytics = {
@@ -74,13 +74,13 @@ describe('sidebar.components.sidebar-content', function() {
   });
 
   function setFrames(frames) {
-    frames.forEach(function(frame) {
+    frames.forEach(function (frame) {
       store.connectFrame(frame);
     });
   }
 
   const makeSidebarContentController = () => {
-    angular.mock.inject(function($componentController, _store_, _$rootScope_) {
+    angular.mock.inject(function ($componentController, _store_, _$rootScope_) {
       $rootScope = _$rootScope_;
       $scope = $rootScope.$new();
 
@@ -104,7 +104,7 @@ describe('sidebar.components.sidebar-content', function() {
     makeSidebarContentController();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     return sandbox.restore();
   });
 
@@ -223,8 +223,8 @@ describe('sidebar.components.sidebar-content', function() {
     });
   });
 
-  describe('when an annotation is anchored', function() {
-    it('focuses and scrolls to the annotation if already selected', function() {
+  describe('when an annotation is anchored', function () {
+    it('focuses and scrolls to the annotation if already selected', function () {
       const uri = 'http://example.com';
       store.selectAnnotations(['123']);
       setFrames([{ uri: uri }]);
@@ -277,7 +277,7 @@ describe('sidebar.components.sidebar-content', function() {
     });
   });
 
-  describe('direct linking messages', function() {
+  describe('direct linking messages', function () {
     /**
      * Connect a frame, indicating that the document has finished initial
      * loading.
@@ -294,18 +294,18 @@ describe('sidebar.components.sidebar-content', function() {
       ]);
     }
 
-    beforeEach(function() {
+    beforeEach(function () {
       store.setDirectLinkedAnnotationId('test');
     });
 
-    it('displays a message if the selection is unavailable', function() {
+    it('displays a message if the selection is unavailable', function () {
       addFrame();
       store.selectAnnotations(['missing']);
       $scope.$digest();
       assert.isTrue(ctrl.selectedAnnotationUnavailable());
     });
 
-    it('does not show a message if the selection is available', function() {
+    it('does not show a message if the selection is available', function () {
       addFrame();
       store.addAnnotations([{ id: '123' }]);
       store.selectAnnotations(['123']);
@@ -313,14 +313,14 @@ describe('sidebar.components.sidebar-content', function() {
       assert.isFalse(ctrl.selectedAnnotationUnavailable());
     });
 
-    it('does not a show a message if there is no selection', function() {
+    it('does not a show a message if there is no selection', function () {
       addFrame();
       store.selectAnnotations([]);
       $scope.$digest();
       assert.isFalse(ctrl.selectedAnnotationUnavailable());
     });
 
-    it("doesn't show a message if the document isn't loaded yet", function() {
+    it("doesn't show a message if the document isn't loaded yet", function () {
       // There is a selection but the selected annotation isn't available.
       store.selectAnnotations(['missing']);
       store.annotationFetchStarted();
@@ -329,7 +329,7 @@ describe('sidebar.components.sidebar-content', function() {
       assert.isFalse(ctrl.selectedAnnotationUnavailable());
     });
 
-    it('shows logged out message if selection is available', function() {
+    it('shows logged out message if selection is available', function () {
       addFrame();
       ctrl.auth = {
         status: 'logged-out',
@@ -340,7 +340,7 @@ describe('sidebar.components.sidebar-content', function() {
       assert.isTrue(ctrl.shouldShowLoggedOutMessage());
     });
 
-    it('does not show loggedout message if selection is unavailable', function() {
+    it('does not show loggedout message if selection is unavailable', function () {
       addFrame();
       ctrl.auth = {
         status: 'logged-out',
@@ -350,7 +350,7 @@ describe('sidebar.components.sidebar-content', function() {
       assert.isFalse(ctrl.shouldShowLoggedOutMessage());
     });
 
-    it('does not show loggedout message if there is no selection', function() {
+    it('does not show loggedout message if there is no selection', function () {
       addFrame();
       ctrl.auth = {
         status: 'logged-out',
@@ -360,7 +360,7 @@ describe('sidebar.components.sidebar-content', function() {
       assert.isFalse(ctrl.shouldShowLoggedOutMessage());
     });
 
-    it('does not show loggedout message if user is not logged out', function() {
+    it('does not show loggedout message if user is not logged out', function () {
       addFrame();
       ctrl.auth = {
         status: 'logged-in',
@@ -371,7 +371,7 @@ describe('sidebar.components.sidebar-content', function() {
       assert.isFalse(ctrl.shouldShowLoggedOutMessage());
     });
 
-    it('does not show loggedout message if not a direct link', function() {
+    it('does not show loggedout message if not a direct link', function () {
       addFrame();
       ctrl.auth = {
         status: 'logged-out',
@@ -383,7 +383,7 @@ describe('sidebar.components.sidebar-content', function() {
       assert.isFalse(ctrl.shouldShowLoggedOutMessage());
     });
 
-    it('does not show loggedout message if using third-party accounts', function() {
+    it('does not show loggedout message if using third-party accounts', function () {
       fakeSettings.services = [{ authority: 'publisher.com' }];
       addFrame();
       ctrl.auth = { status: 'logged-out' };
@@ -395,19 +395,19 @@ describe('sidebar.components.sidebar-content', function() {
     });
   });
 
-  describe('deferred websocket connection', function() {
-    it('should connect the websocket the first time the sidebar opens', function() {
+  describe('deferred websocket connection', function () {
+    it('should connect the websocket the first time the sidebar opens', function () {
       $rootScope.$broadcast('sidebarOpened');
       assert.called(fakeStreamer.connect);
     });
 
-    describe('when logged in user changes', function() {
-      it('should not reconnect if the sidebar is closed', function() {
+    describe('when logged in user changes', function () {
+      it('should not reconnect if the sidebar is closed', function () {
         $rootScope.$broadcast(events.USER_CHANGED);
         assert.calledOnce(fakeStreamer.reconnect);
       });
 
-      it('should reconnect if the sidebar is open', function() {
+      it('should reconnect if the sidebar is open', function () {
         $rootScope.$broadcast('sidebarOpened');
         fakeStreamer.connect.reset();
         $rootScope.$broadcast(events.USER_CHANGED);

--- a/src/sidebar/components/test/sidebar-panel-test.js
+++ b/src/sidebar/components/test/sidebar-panel-test.js
@@ -55,10 +55,7 @@ describe('SidebarPanel', () => {
   it('closes the panel when close button is clicked', () => {
     const wrapper = createSidebarPanel({ panelName: 'flibberty' });
 
-    wrapper
-      .find('Button')
-      .props()
-      .onClick();
+    wrapper.find('Button').props().onClick();
 
     assert.calledWith(fakeStore.toggleSidebarPanel, 'flibberty', false);
   });

--- a/src/sidebar/components/test/slider-test.js
+++ b/src/sidebar/components/test/slider-test.js
@@ -71,10 +71,7 @@ describe('Slider', () => {
     let containerStyle = wrapper.getDOMNode().style;
     assert.equal(containerStyle.height, '200px');
 
-    wrapper
-      .find('div')
-      .first()
-      .simulate('transitionend');
+    wrapper.find('div').first().simulate('transitionend');
 
     containerStyle = wrapper.getDOMNode().style;
     assert.equal(containerStyle.height, 'auto');
@@ -85,10 +82,7 @@ describe('Slider', () => {
 
     wrapper.setProps({ visible: false });
 
-    wrapper
-      .find('div')
-      .first()
-      .simulate('transitionend');
+    wrapper.find('div').first().simulate('transitionend');
 
     const containerStyle = wrapper.getDOMNode().style;
     assert.equal(containerStyle.display, 'none');

--- a/src/sidebar/components/test/spinner-test.js
+++ b/src/sidebar/components/test/spinner-test.js
@@ -5,7 +5,7 @@ import Spinner from '../spinner';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 
-describe('Spinner', function() {
+describe('Spinner', function () {
   const createSpinner = (props = {}) => mount(<Spinner {...props} />);
 
   // A spinner is a trivial component with no props. Just make sure it renders.

--- a/src/sidebar/components/test/stream-content-test.js
+++ b/src/sidebar/components/test/stream-content-test.js
@@ -10,7 +10,7 @@ class FakeRootThread extends EventEmitter {
   }
 }
 
-describe('StreamContentController', function() {
+describe('StreamContentController', function () {
   let $componentController;
   let fakeAnnotationMapper;
   let fakeStore;
@@ -20,11 +20,11 @@ describe('StreamContentController', function() {
   let fakeStreamer;
   let fakeStreamFilter;
 
-  before(function() {
+  before(function () {
     angular.module('h', []).component('streamContent', streamContent);
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeAnnotationMapper = {
       loadAnnotations: sinon.spy(),
     };
@@ -44,7 +44,7 @@ describe('StreamContentController', function() {
     };
 
     fakeApi = {
-      search: sinon.spy(function() {
+      search: sinon.spy(function () {
         return Promise.resolve({ rows: [], total: 0 });
       }),
     };
@@ -74,7 +74,7 @@ describe('StreamContentController', function() {
       streamer: fakeStreamer,
     });
 
-    angular.mock.inject(function(_$componentController_) {
+    angular.mock.inject(function (_$componentController_) {
       $componentController = _$componentController_;
     });
   });
@@ -88,13 +88,13 @@ describe('StreamContentController', function() {
     assert.calledOnce(fakeStore.clearAnnotations);
   });
 
-  it('calls the search API with `_separate_replies: true`', function() {
+  it('calls the search API with `_separate_replies: true`', function () {
     createController();
     assert.equal(fakeApi.search.firstCall.args[0]._separate_replies, true);
   });
 
-  it('passes the annotations and replies from search to loadAnnotations()', function() {
-    fakeApi.search = function() {
+  it('passes the annotations and replies from search to loadAnnotations()', function () {
+    fakeApi.search = function () {
       return Promise.resolve({
         rows: ['annotation_1', 'annotation_2'],
         replies: ['reply_1', 'reply_2', 'reply_3'],
@@ -103,7 +103,7 @@ describe('StreamContentController', function() {
 
     createController();
 
-    return Promise.resolve().then(function() {
+    return Promise.resolve().then(function () {
       assert.calledOnce(fakeAnnotationMapper.loadAnnotations);
       assert.calledWith(
         fakeAnnotationMapper.loadAnnotations,
@@ -113,8 +113,8 @@ describe('StreamContentController', function() {
     });
   });
 
-  context('when route parameters change', function() {
-    it('updates annotations if the query changed', function() {
+  context('when route parameters change', function () {
+    it('updates annotations if the query changed', function () {
       fakeStore.routeParams.returns({ q: 'test query' });
       createController();
       fakeStore.clearAnnotations.resetHistory();
@@ -127,7 +127,7 @@ describe('StreamContentController', function() {
       assert.called(fakeApi.search);
     });
 
-    it('does not clear annotations if the query did not change', function() {
+    it('does not clear annotations if the query did not change', function () {
       fakeStore.routeParams.returns({ q: 'test query' });
       createController();
       fakeApi.search.resetHistory();

--- a/src/sidebar/components/test/stream-search-input-test.js
+++ b/src/sidebar/components/test/stream-search-input-test.js
@@ -41,10 +41,7 @@ describe('StreamSearchInput', () => {
   it('sets path and query when user searches', () => {
     const wrapper = createSearchInput();
     act(() => {
-      wrapper
-        .find('SearchInput')
-        .props()
-        .onSearch('new-query');
+      wrapper.find('SearchInput').props().onSearch('new-query');
     });
     assert.calledWith(fakeRouter.navigate, 'stream', { q: 'new-query' });
   });

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -9,7 +9,7 @@ import { $imports } from '../tag-editor';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('TagEditor', function() {
+describe('TagEditor', function () {
   let containers = [];
   let fakeTags = ['tag1', 'tag2'];
   let fakeTagsService;
@@ -36,7 +36,7 @@ describe('TagEditor', function() {
     );
   }
 
-  afterEach(function() {
+  afterEach(function () {
     containers.forEach(container => {
       container.remove();
     });
@@ -46,10 +46,7 @@ describe('TagEditor', function() {
   // Simulates a selection event from autocomplete-list
   function selectOption(wrapper, item) {
     act(() => {
-      wrapper
-        .find('AutocompleteList')
-        .props()
-        .onSelectItem(item);
+      wrapper.find('AutocompleteList').props().onSelectItem(item);
     });
   }
 
@@ -74,7 +71,7 @@ describe('TagEditor', function() {
     wrapper.find('input').simulate('input', { inputType: 'insertText' });
   }
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeOnEditTags = sinon.stub();
     fakeServiceUrl = sinon.stub().returns('http://serviceurl.com');
     fakeTagsService = {
@@ -445,7 +442,7 @@ describe('TagEditor', function() {
   });
 
   describe('accessibility validation', () => {
-    beforeEach(function() {
+    beforeEach(function () {
       // create a full dom tree for a11y testing
       $imports.$mock({
         './autocomplete-list': AutocompleteList,

--- a/src/sidebar/components/test/tag-list-test.js
+++ b/src/sidebar/components/test/tag-list-test.js
@@ -7,7 +7,7 @@ import { $imports } from '../tag-list';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('TagList', function() {
+describe('TagList', function () {
   let fakeServiceUrl;
   let fakeIsThirdPartyUser;
   const fakeTags = ['tag1', 'tag2'];
@@ -26,7 +26,7 @@ describe('TagList', function() {
     );
   }
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeServiceUrl = sinon.stub().returns('http://serviceurl.com');
     fakeIsThirdPartyUser = sinon.stub().returns(false);
 
@@ -70,7 +70,7 @@ describe('TagList', function() {
   });
 
   context('when `isThirdPartyUser` returns true', () => {
-    beforeEach(function() {
+    beforeEach(function () {
       fakeIsThirdPartyUser.returns(true);
     });
 

--- a/src/sidebar/components/test/thread-list-test.js
+++ b/src/sidebar/components/test/thread-list-test.js
@@ -54,10 +54,10 @@ class FakeVirtualThreadList extends EventEmitter {
     let thread = rootThread;
 
     this.options = options;
-    this.setRootThread = function(_thread) {
+    this.setRootThread = function (_thread) {
       thread = _thread;
     };
-    this.notify = function() {
+    this.notify = function () {
       this.emit('changed', {
         offscreenLowerHeight: 10,
         offscreenUpperHeight: 20,
@@ -65,7 +65,7 @@ class FakeVirtualThreadList extends EventEmitter {
       });
     };
     this.detach = sinon.stub();
-    this.yOffsetOf = function() {
+    this.yOffsetOf = function () {
       return 42;
     };
     this.calculateVisibleThreads = () => {
@@ -78,7 +78,7 @@ class FakeVirtualThreadList extends EventEmitter {
   }
 }
 
-describe('threadList', function() {
+describe('threadList', function () {
   let threadListContainers;
 
   function createThreadList(inputs) {
@@ -122,7 +122,7 @@ describe('threadList', function() {
     return element;
   }
 
-  before(function() {
+  before(function () {
     fakeStore = {
       clearSelection: sinon.stub(),
     };
@@ -130,7 +130,7 @@ describe('threadList', function() {
     angular.module('app', []).component('threadList', threadList);
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     angular.mock.module('app', {
       settings: fakeSettings,
       store: fakeStore,
@@ -142,15 +142,15 @@ describe('threadList', function() {
     });
   });
 
-  afterEach(function() {
+  afterEach(function () {
     $imports.$restore();
 
-    threadListContainers.forEach(function(el) {
+    threadListContainers.forEach(function (el) {
       el.remove();
     });
   });
 
-  it('shows the clean theme when settings contains the clean theme option', function() {
+  it('shows the clean theme when settings contains the clean theme option', function () {
     angular.mock.module('app', {
       VirtualThreadList: FakeVirtualThreadList,
       settings: { theme: 'clean' },
@@ -164,7 +164,7 @@ describe('threadList', function() {
     );
   });
 
-  it('displays the children of the root thread', function() {
+  it('displays the children of the root thread', function () {
     const element = createThreadList();
     fakeVirtualThread.notify();
     element.scope.$digest();
@@ -172,8 +172,8 @@ describe('threadList', function() {
     assert.equal(children.length, 2);
   });
 
-  describe('when a new annotation is created', function() {
-    it('scrolls the annotation into view', function() {
+  describe('when a new annotation is created', function () {
+    it('scrolls the annotation into view', function () {
       const element = createThreadList();
       element.parentEl.scrollTop = 500;
 
@@ -185,7 +185,7 @@ describe('threadList', function() {
       assert.isBelow(element.parentEl.scrollTop, 100);
     });
 
-    it('does not scroll the annotation into view if it is a reply', function() {
+    it('does not scroll the annotation into view if it is a reply', function () {
       const element = createThreadList();
       element.parentEl.scrollTop = 500;
 
@@ -196,7 +196,7 @@ describe('threadList', function() {
       assert.equal(element.parentEl.scrollTop, 500);
     });
 
-    it('does not scroll the annotation into view if it is a highlight', function() {
+    it('does not scroll the annotation into view if it is a highlight', function () {
       const element = createThreadList();
       element.parentEl.scrollTop = 500;
 
@@ -207,7 +207,7 @@ describe('threadList', function() {
       assert.equal(element.parentEl.scrollTop, 500);
     });
 
-    it('clears the selection', function() {
+    it('clears the selection', function () {
       const element = createThreadList();
       element.scope.$broadcast(
         events.BEFORE_ANNOTATION_CREATED,
@@ -217,7 +217,7 @@ describe('threadList', function() {
     });
   });
 
-  it('calls onFocus() when the user hovers an annotation', function() {
+  it('calls onFocus() when the user hovers an annotation', function () {
     const inputs = {
       onFocus: {
         args: ['annotation'],
@@ -237,7 +237,7 @@ describe('threadList', function() {
     );
   });
 
-  it('calls onSelect() when a user clicks an annotation', function() {
+  it('calls onSelect() when a user clicks an annotation', function () {
     const inputs = {
       onSelect: {
         args: ['annotation'],
@@ -257,7 +257,7 @@ describe('threadList', function() {
     );
   });
 
-  it('uses the correct scroll root', function() {
+  it('uses the correct scroll root', function () {
     createThreadList();
     const scrollRoot = fakeVirtualThread.options.scrollRoot;
     assert.isTrue(scrollRoot.classList.contains('js-thread-list-scroll-root'));

--- a/src/sidebar/components/test/thread-test.js
+++ b/src/sidebar/components/test/thread-test.js
@@ -131,9 +131,7 @@ describe('Thread', () => {
       const wrapper = createComponent({ thread: replyThread });
 
       act(() => {
-        getToggleButton(wrapper)
-          .props()
-          .onClick();
+        getToggleButton(wrapper).props().onClick();
       });
 
       assert.calledOnce(fakeStore.setCollapsed);

--- a/src/sidebar/components/test/tutorial-test.js
+++ b/src/sidebar/components/test/tutorial-test.js
@@ -7,7 +7,7 @@ import { $imports } from '../tutorial';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('Tutorial', function() {
+describe('Tutorial', function () {
   let fakeIsThirdPartyService;
 
   function createComponent(props) {

--- a/src/sidebar/components/test/version-info-test.js
+++ b/src/sidebar/components/test/version-info-test.js
@@ -6,7 +6,7 @@ import { $imports } from '../version-info';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 
-describe('VersionInfo', function() {
+describe('VersionInfo', function () {
   let fakeVersionData;
   // Services
   let fakeToastMessenger;

--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -89,8 +89,8 @@ function ThreadListController($element, $scope, settings, store) {
 
     scopeTimeout(
       $scope,
-      function() {
-        state.visibleThreads.forEach(function(thread) {
+      function () {
+        state.visibleThreads.forEach(function (thread) {
           const height = getThreadHeight(thread.id);
           if (!height) {
             return;
@@ -131,7 +131,7 @@ function ThreadListController($element, $scope, settings, store) {
     // estimated Y offset changed and if so, trigger scrolling again.
     scopeTimeout(
       $scope,
-      function() {
+      function () {
         const newYOffset = scrollOffset(id);
         if (newYOffset !== estimatedYOffset) {
           scrollIntoView(id);
@@ -141,7 +141,7 @@ function ThreadListController($element, $scope, settings, store) {
     );
   }
 
-  $scope.$on(events.BEFORE_ANNOTATION_CREATED, function(event, annotation) {
+  $scope.$on(events.BEFORE_ANNOTATION_CREATED, function (event, annotation) {
     if (annotation.$highlight || metadata.isReply(annotation)) {
       return;
     }
@@ -149,13 +149,13 @@ function ThreadListController($element, $scope, settings, store) {
     scrollIntoView(annotation.$tag);
   });
 
-  this.$onChanges = function(changes) {
+  this.$onChanges = function (changes) {
     if (changes.thread && visibleThreads) {
       visibleThreads.setRootThread(changes.thread.currentValue);
     }
   };
 
-  this.$onDestroy = function() {
+  this.$onDestroy = function () {
     visibleThreads.detach();
   };
 }

--- a/src/sidebar/ga.js
+++ b/src/sidebar/ga.js
@@ -12,11 +12,11 @@ export default function loadGoogleAnalytics(trackingId) {
   /* eslint-disable */
 
   // Google Analytics snippet to load the analytics script
-  (function(i, s, o, g, r, a, m) {
+  (function (i, s, o, g, r, a, m) {
     i['GoogleAnalyticsObject'] = r;
     (i[r] =
       i[r] ||
-      function() {
+      function () {
         (i[r].q = i[r].q || []).push(arguments);
       }),
       (i[r].l = 1 * new Date());

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -90,7 +90,7 @@ export default function hostPageConfig(window) {
     },
   };
 
-  return Object.keys(config).reduce(function(result, key) {
+  return Object.keys(config).reduce(function (result, key) {
     if (paramWhiteList.indexOf(key) !== -1) {
       // Ignore `null` values as these indicate a default value.
       // In this case the config value set in the sidebar app HTML config is

--- a/src/sidebar/markdown-commands.js
+++ b/src/sidebar/markdown-commands.js
@@ -241,7 +241,7 @@ export function toggleBlockStyle(state, prefix) {
   // Test whether all lines in the selected range already have the style
   // applied
   let blockHasStyle = true;
-  transformLines(state, start, end, function(state, lineStart) {
+  transformLines(state, start, end, function (state, lineStart) {
     if (state.text.slice(lineStart, lineStart + prefix.length) !== prefix) {
       blockHasStyle = false;
     }
@@ -250,12 +250,12 @@ export function toggleBlockStyle(state, prefix) {
 
   if (blockHasStyle) {
     // Remove the formatting.
-    return transformLines(state, start, end, function(state, lineStart) {
+    return transformLines(state, start, end, function (state, lineStart) {
       return replaceText(state, lineStart, prefix.length, '');
     });
   } else {
     // Add the block style to any lines which do not already have it applied
-    return transformLines(state, start, end, function(state, lineStart) {
+    return transformLines(state, start, end, function (state, lineStart) {
       if (state.text.slice(lineStart, lineStart + prefix.length) === prefix) {
         return state;
       } else {

--- a/src/sidebar/render-markdown.js
+++ b/src/sidebar/render-markdown.js
@@ -112,7 +112,7 @@ function extractMath(content) {
 }
 
 function insertMath(html, mathBlocks) {
-  return mathBlocks.reduce(function(html, block) {
+  return mathBlocks.reduce(function (html, block) {
     let renderedMath;
     try {
       if (block.inline) {

--- a/src/sidebar/search-client.js
+++ b/src/sidebar/search-client.js
@@ -39,7 +39,7 @@ export default class SearchClient extends EventEmitter {
 
     const self = this;
     this._searchFn(searchQuery)
-      .then(function(results) {
+      .then(function (results) {
         if (self._canceled) {
           return;
         }
@@ -67,7 +67,7 @@ export default class SearchClient extends EventEmitter {
           self.emit('end');
         }
       })
-      .catch(function(err) {
+      .catch(function (err) {
         if (self._canceled) {
           return;
         }

--- a/src/sidebar/services/annotation-mapper.js
+++ b/src/sidebar/services/annotation-mapper.js
@@ -1,7 +1,7 @@
 import events from '../events';
 
 function getExistingAnnotation(store, id) {
-  return store.getState().annotations.annotations.find(function(annot) {
+  return store.getState().annotations.annotations.find(function (annot) {
     return annot.id === id;
   });
 }
@@ -13,7 +13,7 @@ export default function annotationMapper($rootScope, store, api) {
     annotations = annotations.concat(replies || []);
 
     const loaded = [];
-    annotations.forEach(function(annotation) {
+    annotations.forEach(function (annotation) {
       const existing = getExistingAnnotation(store, annotation.id);
       if (existing) {
         $rootScope.$broadcast(events.ANNOTATION_UPDATED, annotation);
@@ -35,7 +35,7 @@ export default function annotationMapper($rootScope, store, api) {
       .delete({
         id: annotation.id,
       })
-      .then(function() {
+      .then(function () {
         $rootScope.$broadcast(events.ANNOTATION_DELETED, annotation);
         return annotation;
       });
@@ -46,7 +46,7 @@ export default function annotationMapper($rootScope, store, api) {
       .flag({
         id: annot.id,
       })
-      .then(function() {
+      .then(function () {
         $rootScope.$broadcast(events.ANNOTATION_FLAGGED, annot);
         return annot;
       });

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -103,7 +103,7 @@ function createAPICall(
     onRequestFinished = noop,
   } = {}
 ) {
-  return function(params, data, options = {}) {
+  return function (params, data, options = {}) {
     onRequestStarted();
 
     let accessToken;

--- a/src/sidebar/services/features.js
+++ b/src/sidebar/services/features.js
@@ -16,7 +16,7 @@ import events from '../events';
 
 // @ngInject
 export default function features($rootScope, bridge, session) {
-  const _sendFeatureFlags = function() {
+  const _sendFeatureFlags = function () {
     const userFeatures = session.state.features;
     bridge.call(bridgeEvents.FEATURE_FLAGS_UPDATED, userFeatures || {});
   };

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -54,7 +54,7 @@ export default function FrameSync($rootScope, $window, store, bridge) {
     let prevFrames = [];
     let prevPublicAnns = 0;
 
-    store.subscribe(function() {
+    store.subscribe(function () {
       const state = store.getState();
       if (
         state.annotations.annotations === prevAnnotations &&
@@ -67,7 +67,7 @@ export default function FrameSync($rootScope, $window, store, bridge) {
       const inSidebar = new Set();
       const added = [];
 
-      state.annotations.annotations.forEach(function(annot) {
+      state.annotations.annotations.forEach(function (annot) {
         if (metadata.isReply(annot)) {
           // The frame does not need to know about replies
           return;
@@ -82,7 +82,7 @@ export default function FrameSync($rootScope, $window, store, bridge) {
           added.push(annot);
         }
       });
-      const deleted = prevAnnotations.filter(function(annot) {
+      const deleted = prevAnnotations.filter(function (annot) {
         return !inSidebar.has(annot.$tag);
       });
       prevAnnotations = state.annotations.annotations;
@@ -93,11 +93,11 @@ export default function FrameSync($rootScope, $window, store, bridge) {
       // annotations if their selectors are updated.
       if (added.length > 0) {
         bridge.call('loadAnnotations', added.map(formatAnnot));
-        added.forEach(function(annot) {
+        added.forEach(function (annot) {
           inFrame.add(annot.$tag);
         });
       }
-      deleted.forEach(function(annot) {
+      deleted.forEach(function (annot) {
         bridge.call('deleteAnnotation', formatAnnot(annot));
         inFrame.delete(annot.$tag);
       });
@@ -105,7 +105,7 @@ export default function FrameSync($rootScope, $window, store, bridge) {
       const frames = store.frames();
       if (frames.length > 0) {
         if (
-          frames.every(function(frame) {
+          frames.every(function (frame) {
             return frame.isAnnotationFetchComplete;
           })
         ) {
@@ -127,7 +127,7 @@ export default function FrameSync($rootScope, $window, store, bridge) {
    */
   function setupSyncFromFrame() {
     // A new annotation, note or highlight was created in the frame
-    bridge.on('beforeCreateAnnotation', function(event) {
+    bridge.on('beforeCreateAnnotation', function (event) {
       const annot = Object.assign({}, event.msg, { $tag: event.tag });
       // If user is not logged in, we can't really create a meaningful highlight
       // or annotation. Instead, we need to open the sidebar, show an error,
@@ -161,8 +161,8 @@ export default function FrameSync($rootScope, $window, store, bridge) {
     }, 10);
 
     // Anchoring an annotation in the frame completed
-    bridge.on('sync', function(events_) {
-      events_.forEach(function(event) {
+    bridge.on('sync', function (events_) {
+      events_.forEach(function (event) {
         inFrame.add(event.tag);
         anchoringStatusUpdates[event.tag] = event.msg.$orphan
           ? 'orphan'
@@ -171,31 +171,31 @@ export default function FrameSync($rootScope, $window, store, bridge) {
       });
     });
 
-    bridge.on('showAnnotations', function(tags) {
+    bridge.on('showAnnotations', function (tags) {
       store.selectAnnotations(store.findIDsForTags(tags));
       store.selectTab(uiConstants.TAB_ANNOTATIONS);
     });
 
-    bridge.on('focusAnnotations', function(tags) {
+    bridge.on('focusAnnotations', function (tags) {
       store.focusAnnotations(tags || []);
     });
 
-    bridge.on('toggleAnnotationSelection', function(tags) {
+    bridge.on('toggleAnnotationSelection', function (tags) {
       store.toggleSelectedAnnotations(store.findIDsForTags(tags));
     });
 
-    bridge.on('sidebarOpened', function() {
+    bridge.on('sidebarOpened', function () {
       $rootScope.$broadcast('sidebarOpened');
     });
 
     // These invoke the matching methods by name on the Guests
-    bridge.on('showSidebar', function() {
+    bridge.on('showSidebar', function () {
       bridge.call('showSidebar');
     });
-    bridge.on('hideSidebar', function() {
+    bridge.on('hideSidebar', function () {
       bridge.call('hideSidebar');
     });
-    bridge.on('setVisibleHighlights', function(state) {
+    bridge.on('setVisibleHighlights', function (state) {
       bridge.call('setVisibleHighlights', state);
     });
   }
@@ -206,7 +206,7 @@ export default function FrameSync($rootScope, $window, store, bridge) {
    * connected frames.
    */
   function addFrame(channel) {
-    channel.call('getDocumentInfo', function(err, info) {
+    channel.call('getDocumentInfo', function (err, info) {
       if (err) {
         channel.destroy();
         return;
@@ -223,7 +223,7 @@ export default function FrameSync($rootScope, $window, store, bridge) {
 
   function destroyFrame(frameIdentifier) {
     const frames = store.frames();
-    const frameToDestroy = frames.find(function(frame) {
+    const frameToDestroy = frames.find(function (frame) {
       return frame.id === frameIdentifier;
     });
     if (frameToDestroy) {
@@ -234,7 +234,7 @@ export default function FrameSync($rootScope, $window, store, bridge) {
   /**
    * Find and connect to Hypothesis clients in the current window.
    */
-  this.connect = function() {
+  this.connect = function () {
     const discovery = new Discovery(window, { server: true });
     discovery.startDiscovery(bridge.createChannel.bind(bridge));
     bridge.onConnect(addFrame);
@@ -251,7 +251,7 @@ export default function FrameSync($rootScope, $window, store, bridge) {
    *
    * @param {string[]} tags
    */
-  this.focusAnnotations = function(tags) {
+  this.focusAnnotations = function (tags) {
     bridge.call('focusAnnotations', tags);
   };
 
@@ -260,7 +260,7 @@ export default function FrameSync($rootScope, $window, store, bridge) {
    *
    * @param {string} tag
    */
-  this.scrollToAnnotation = function(tag) {
+  this.scrollToAnnotation = function (tag) {
     bridge.call('scrollToAnnotation', tag);
   };
 }

--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -51,7 +51,7 @@ export default function loadAnnotationsService(
       // Remove client as it's no longer active.
       searchClient = null;
 
-      store.frames().forEach(function(frame) {
+      store.frames().forEach(function (frame) {
         if (0 <= uris.indexOf(frame.uri)) {
           store.updateFrameAnnotationFetchStatus(frame.uri, true);
         }

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -5,7 +5,7 @@ import memoize from '../util/memoize';
 import * as tabs from '../util/tabs';
 
 function truthyKeys(map) {
-  return Object.keys(map).filter(function(k) {
+  return Object.keys(map).filter(function (k) {
     return !!map[k];
   });
 }
@@ -13,13 +13,13 @@ function truthyKeys(map) {
 // Mapping from sort order name to a less-than predicate
 // function for comparing annotations to determine their sort order.
 const sortFns = {
-  Newest: function(a, b) {
+  Newest: function (a, b) {
     return a.updated > b.updated;
   },
-  Oldest: function(a, b) {
+  Oldest: function (a, b) {
     return a.updated < b.updated;
   },
-  Location: function(a, b) {
+  Location: function (a, b) {
     return metadata.location(a) < metadata.location(b);
   },
 };
@@ -66,14 +66,14 @@ export default function RootThread(
         }
       );
 
-      filterFn = function(annot) {
+      filterFn = function (annot) {
         return viewFilter.filter([annot], filters).length > 0;
       };
     }
 
     let threadFilterFn;
     if (state.route.name === 'sidebar' && !shouldFilterThread()) {
-      threadFilterFn = function(thread) {
+      threadFilterFn = function (thread) {
         if (!thread.annotation) {
           return false;
         }
@@ -108,18 +108,18 @@ export default function RootThread(
     events.ANNOTATION_UPDATED,
     events.ANNOTATIONS_LOADED,
   ];
-  loadEvents.forEach(function(event) {
-    $rootScope.$on(event, function(event, annotation) {
+  loadEvents.forEach(function (event) {
+    $rootScope.$on(event, function (event, annotation) {
       store.addAnnotations([].concat(annotation));
     });
   });
 
-  $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, function(event, ann) {
+  $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, function (event, ann) {
     annotationsService.create(ann);
   });
 
   // Remove any annotations that are deleted or unloaded
-  $rootScope.$on(events.ANNOTATION_DELETED, function(event, annotation) {
+  $rootScope.$on(events.ANNOTATION_DELETED, function (event, annotation) {
     store.removeAnnotations([annotation]);
   });
 

--- a/src/sidebar/services/search-filter.js
+++ b/src/sidebar/services/search-filter.js
@@ -50,7 +50,7 @@ function tokenize(searchtext) {
   //   "bar" -> bar
   //   'foo" -> 'foo"
   //   bar"  -> bar"
-  const _removeQuoteCharacter = function(text) {
+  const _removeQuoteCharacter = function (text) {
     const start = text.slice(0, 1);
     const end = text.slice(-1);
     if ((start === '"' || start === "'") && start === end) {
@@ -87,7 +87,7 @@ function toObject(searchtext) {
   const obj = {};
   const backendFilter = f => (f === 'tag' ? 'tags' : f);
 
-  const addToObj = function(key, data) {
+  const addToObj = function (key, data) {
     if (obj[key]) {
       return obj[key].push(data);
     } else {

--- a/src/sidebar/services/service-url.js
+++ b/src/sidebar/services/service-url.js
@@ -35,11 +35,11 @@ export default function serviceUrl(store, apiRoutes) {
   apiRoutes
     .links()
     .then(store.updateLinks)
-    .catch(function(error) {
+    .catch(function (error) {
       console.warn('The links API request was rejected: ' + error.message);
     });
 
-  return function(linkName, params) {
+  return function (linkName, params) {
     const links = store.getState().links;
 
     if (links === null) {

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -63,7 +63,7 @@ export default function session(
       // the /app endpoint.
       lastLoadTime = Date.now();
       lastLoad = retryUtil
-        .retryPromiseOperation(function() {
+        .retryPromiseOperation(function () {
           const authority = getAuthority();
           const opts = {};
           if (authority) {
@@ -71,12 +71,12 @@ export default function session(
           }
           return api.profile.read(opts);
         }, profileFetchRetryOpts)
-        .then(function(session) {
+        .then(function (session) {
           update(session);
           lastLoadTime = Date.now();
           return session;
         })
-        .catch(function(err) {
+        .catch(function (err) {
           lastLoadTime = null;
           throw err;
         });
@@ -142,12 +142,12 @@ export default function session(
     });
 
     return loggedOut
-      .catch(function(err) {
+      .catch(function (err) {
         flash.error('Log out failed');
         analytics.track(analytics.events.LOGOUT_FAILURE);
         throw new Error(err);
       })
-      .then(function() {
+      .then(function () {
         analytics.track(analytics.events.LOGOUT_SUCCESS);
       });
   }

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -84,7 +84,7 @@ export default function Streamer(
     // Wrap message dispatches in $rootScope.$apply() so that
     // scope watches on app state affected by the received message
     // are updated
-    $rootScope.$apply(function() {
+    $rootScope.$apply(function () {
       const message = JSON.parse(event.data);
       if (!message) {
         return;
@@ -110,7 +110,7 @@ export default function Streamer(
   }
 
   function sendClientConfig() {
-    Object.keys(configMessages).forEach(function(key) {
+    Object.keys(configMessages).forEach(function (key) {
       if (configMessages[key]) {
         socket.send(configMessages[key]);
       }
@@ -129,7 +129,7 @@ export default function Streamer(
     }
   }
 
-  const _connect = function() {
+  const _connect = function () {
     // If we have no URL configured, don't do anything.
     if (!settings.websocketUrl) {
       return Promise.resolve();
@@ -137,7 +137,7 @@ export default function Streamer(
 
     return auth
       .tokenGetter()
-      .then(function(token) {
+      .then(function (token) {
         let url;
         if (token) {
           // Include the access token in the URL via a query param. This method
@@ -173,7 +173,7 @@ export default function Streamer(
           id: 1,
         });
       })
-      .catch(function(err) {
+      .catch(function (err) {
         console.error(
           'Failed to fetch token for WebSocket authentication',
           err

--- a/src/sidebar/services/test/analytics-test.js
+++ b/src/sidebar/services/test/analytics-test.js
@@ -1,10 +1,10 @@
 import analyticsService from '../analytics';
 
-describe('analytics', function() {
+describe('analytics', function () {
   let $windowStub;
   let svc;
 
-  beforeEach(function() {
+  beforeEach(function () {
     $windowStub = {
       ga: sinon.stub(),
       location: {
@@ -36,10 +36,10 @@ describe('analytics', function() {
     );
   }
 
-  describe('applying global category based on environment contexts', function() {
-    it('sets the category to match the appType setting value', function() {
+  describe('applying global category based on environment contexts', function () {
+    it('sets the category to match the appType setting value', function () {
       const validTypes = ['chrome-extension', 'embed', 'bookmarklet', 'via'];
-      validTypes.forEach(function(appType, index) {
+      validTypes.forEach(function (appType, index) {
         analyticsService($windowStub, { appType: appType }).track(
           'event' + index
         );
@@ -47,12 +47,12 @@ describe('analytics', function() {
       });
     });
 
-    it('sets category as embed if no other matches can be made', function() {
+    it('sets category as embed if no other matches can be made', function () {
       analyticsService($windowStub).track('eventA');
       checkEventSent('embed', 'eventA');
     });
 
-    it('sets category as via if url matches the via uri pattern', function() {
+    it('sets category as via if url matches the via uri pattern', function () {
       $windowStub.document.referrer = 'https://via.hypothes.is/';
       analyticsService($windowStub).track('eventA');
       checkEventSent('via', 'eventA');
@@ -63,7 +63,7 @@ describe('analytics', function() {
       checkEventSent('via', 'eventB');
     });
 
-    it('sets category as chrome-extension if protocol matches chrome-extension:', function() {
+    it('sets category as chrome-extension if protocol matches chrome-extension:', function () {
       $windowStub.location.protocol = 'chrome-extension:';
       analyticsService($windowStub).track('eventA');
       checkEventSent('chrome-extension', 'eventA');
@@ -71,17 +71,17 @@ describe('analytics', function() {
   });
 
   describe('#track', () => {
-    it('allows custom labels to be sent for an event', function() {
+    it('allows custom labels to be sent for an event', function () {
       svc.track('eventA', 'labelA');
       checkEventSent('embed', 'eventA', 'labelA');
     });
 
-    it('allows custom metricValues to be sent for an event', function() {
+    it('allows custom metricValues to be sent for an event', function () {
       svc.track('eventA', null, 242.2);
       checkEventSent('embed', 'eventA', null, 242.2);
     });
 
-    it('allows custom metricValues and labels to be sent for an event', function() {
+    it('allows custom metricValues and labels to be sent for an event', function () {
       svc.track('eventA', 'labelabc', 242.2);
       checkEventSent('embed', 'eventA', 'labelabc', 242.2);
     });

--- a/src/sidebar/services/test/annotation-mapper-test.js
+++ b/src/sidebar/services/test/annotation-mapper-test.js
@@ -5,14 +5,14 @@ import storeFactory from '../../store';
 import annotationMapperFactory from '../annotation-mapper';
 import immutable from '../../util/immutable';
 
-describe('annotationMapper', function() {
+describe('annotationMapper', function () {
   const sandbox = sinon.createSandbox();
   let $rootScope;
   let store;
   let fakeApi;
   let annotationMapper;
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeApi = {
       annotation: {
         delete: sinon.stub().returns(Promise.resolve({})),
@@ -27,19 +27,19 @@ describe('annotationMapper', function() {
       .value('settings', {});
     angular.mock.module('app');
 
-    angular.mock.inject(function(_$rootScope_, _store_, _annotationMapper_) {
+    angular.mock.inject(function (_$rootScope_, _store_, _annotationMapper_) {
       $rootScope = _$rootScope_;
       annotationMapper = _annotationMapper_;
       store = _store_;
     });
   });
 
-  afterEach(function() {
+  afterEach(function () {
     sandbox.restore();
   });
 
-  describe('#loadAnnotations()', function() {
-    it('triggers the annotationLoaded event', function() {
+  describe('#loadAnnotations()', function () {
+    it('triggers the annotationLoaded event', function () {
       sandbox.stub($rootScope, '$broadcast');
       const annotations = [{ id: 1 }, { id: 2 }, { id: 3 }];
       annotationMapper.loadAnnotations(annotations);
@@ -51,7 +51,7 @@ describe('annotationMapper', function() {
       ]);
     });
 
-    it('also includes replies in the annotationLoaded event', function() {
+    it('also includes replies in the annotationLoaded event', function () {
       sandbox.stub($rootScope, '$broadcast');
       const annotations = [{ id: 1 }];
       const replies = [{ id: 2 }, { id: 3 }];
@@ -64,7 +64,7 @@ describe('annotationMapper', function() {
       ]);
     });
 
-    it('triggers the annotationUpdated event for each loaded annotation', function() {
+    it('triggers the annotationUpdated event for each loaded annotation', function () {
       sandbox.stub($rootScope, '$broadcast');
       const annotations = immutable([{ id: 1 }, { id: 2 }, { id: 3 }]);
       store.addAnnotations(angular.copy(annotations));
@@ -78,7 +78,7 @@ describe('annotationMapper', function() {
       );
     });
 
-    it('also triggers annotationUpdated for cached replies', function() {
+    it('also triggers annotationUpdated for cached replies', function () {
       sandbox.stub($rootScope, '$broadcast');
       const annotations = [{ id: 1 }];
       const replies = [{ id: 2 }, { id: 3 }, { id: 4 }];
@@ -90,7 +90,7 @@ describe('annotationMapper', function() {
       );
     });
 
-    it('replaces the properties on the cached annotation with those from the loaded one', function() {
+    it('replaces the properties on the cached annotation with those from the loaded one', function () {
       sandbox.stub($rootScope, '$broadcast');
       const annotations = [{ id: 1, url: 'http://example.com' }];
       store.addAnnotations([{ id: 1, $tag: 'tag1' }]);
@@ -103,7 +103,7 @@ describe('annotationMapper', function() {
       });
     });
 
-    it('excludes cached annotations from the annotationLoaded event', function() {
+    it('excludes cached annotations from the annotationLoaded event', function () {
       sandbox.stub($rootScope, '$broadcast');
       const annotations = [{ id: 1, url: 'http://example.com' }];
       store.addAnnotations([{ id: 1, $tag: 'tag1' }]);
@@ -114,20 +114,20 @@ describe('annotationMapper', function() {
     });
   });
 
-  describe('#flagAnnotation()', function() {
-    it('flags an annotation', function() {
+  describe('#flagAnnotation()', function () {
+    it('flags an annotation', function () {
       const ann = { id: 'test-id' };
       annotationMapper.flagAnnotation(ann);
       assert.calledOnce(fakeApi.annotation.flag);
       assert.calledWith(fakeApi.annotation.flag, { id: ann.id });
     });
 
-    it('emits the "annotationFlagged" event', function(done) {
+    it('emits the "annotationFlagged" event', function (done) {
       sandbox.stub($rootScope, '$broadcast');
       const ann = { id: 'test-id' };
       annotationMapper
         .flagAnnotation(ann)
-        .then(function() {
+        .then(function () {
           assert.calledWith(
             $rootScope.$broadcast,
             events.ANNOTATION_FLAGGED,
@@ -138,14 +138,14 @@ describe('annotationMapper', function() {
     });
   });
 
-  describe('#createAnnotation()', function() {
-    it('creates a new annotation resource', function() {
+  describe('#createAnnotation()', function () {
+    it('creates a new annotation resource', function () {
       const ann = {};
       const ret = annotationMapper.createAnnotation(ann);
       assert.equal(ret, ann);
     });
 
-    it('emits the "beforeAnnotationCreated" event', function() {
+    it('emits the "beforeAnnotationCreated" event', function () {
       sandbox.stub($rootScope, '$broadcast');
       const ann = {};
       annotationMapper.createAnnotation(ann);
@@ -157,19 +157,19 @@ describe('annotationMapper', function() {
     });
   });
 
-  describe('#deleteAnnotation()', function() {
-    it('deletes the annotation on the server', function() {
+  describe('#deleteAnnotation()', function () {
+    it('deletes the annotation on the server', function () {
       const ann = { id: 'test-id' };
       annotationMapper.deleteAnnotation(ann);
       assert.calledWith(fakeApi.annotation.delete, { id: 'test-id' });
     });
 
-    it('triggers the "annotationDeleted" event on success', function(done) {
+    it('triggers the "annotationDeleted" event on success', function (done) {
       sandbox.stub($rootScope, '$broadcast');
       const ann = {};
       annotationMapper
         .deleteAnnotation(ann)
-        .then(function() {
+        .then(function () {
           assert.calledWith(
             $rootScope.$broadcast,
             events.ANNOTATION_DELETED,
@@ -180,13 +180,13 @@ describe('annotationMapper', function() {
       $rootScope.$apply();
     });
 
-    it('does not emit an event on error', function(done) {
+    it('does not emit an event on error', function (done) {
       sandbox.stub($rootScope, '$broadcast');
       fakeApi.annotation.delete.returns(Promise.reject());
       const ann = { id: 'test-id' };
       annotationMapper
         .deleteAnnotation(ann)
-        .catch(function() {
+        .catch(function () {
           assert.notCalled($rootScope.$broadcast);
         })
         .then(done, done);

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -13,7 +13,7 @@ import apiFactory from '../api';
 //
 const routes = require('./api-index.json').links;
 
-describe('sidebar.services.api', function() {
+describe('sidebar.services.api', function () {
   let fakeAuth;
   let fakeStore;
   let api;

--- a/src/sidebar/services/test/features-test.js
+++ b/src/sidebar/services/test/features-test.js
@@ -3,14 +3,14 @@ import events from '../../events';
 import features from '../features';
 import { $imports } from '../features';
 
-describe('h:features - sidebar layer', function() {
+describe('h:features - sidebar layer', function () {
   let fakeBridge;
   let fakeWarnOnce;
   let fakeRootScope;
   let fakeSession;
   let sandbox;
 
-  beforeEach(function() {
+  beforeEach(function () {
     sandbox = sinon.createSandbox();
 
     fakeBridge = {
@@ -24,7 +24,7 @@ describe('h:features - sidebar layer', function() {
 
       $broadcast: sandbox.stub(),
 
-      $on: function(event, callback) {
+      $on: function (event, callback) {
         this.eventCallbacks[event] = callback;
       },
     };
@@ -44,38 +44,38 @@ describe('h:features - sidebar layer', function() {
     });
   });
 
-  afterEach(function() {
+  afterEach(function () {
     $imports.$restore();
     sandbox.restore();
   });
 
-  describe('flagEnabled', function() {
-    it('should retrieve features data', function() {
+  describe('flagEnabled', function () {
+    it('should retrieve features data', function () {
       const features_ = features(fakeRootScope, fakeBridge, fakeSession);
       assert.equal(features_.flagEnabled('feature_on'), true);
       assert.equal(features_.flagEnabled('feature_off'), false);
     });
 
-    it('should return false if features have not been loaded', function() {
+    it('should return false if features have not been loaded', function () {
       const features_ = features(fakeRootScope, fakeBridge, fakeSession);
       // simulate feature data not having been loaded yet
       fakeSession.state = {};
       assert.equal(features_.flagEnabled('feature_on'), false);
     });
 
-    it('should trigger a refresh of session data', function() {
+    it('should trigger a refresh of session data', function () {
       const features_ = features(fakeRootScope, fakeBridge, fakeSession);
       features_.flagEnabled('feature_on');
       assert.calledOnce(fakeSession.load);
     });
 
-    it('should return false for unknown flags', function() {
+    it('should return false for unknown flags', function () {
       const features_ = features(fakeRootScope, fakeBridge, fakeSession);
       assert.isFalse(features_.flagEnabled('unknown_feature'));
     });
   });
 
-  it('should broadcast feature flags to annotation layer based on load/user changes', function() {
+  it('should broadcast feature flags to annotation layer based on load/user changes', function () {
     assert.notProperty(fakeRootScope.eventCallbacks, events.USER_CHANGED);
     assert.notProperty(fakeRootScope.eventCallbacks, events.FRAME_CONNECTED);
 

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -47,17 +47,17 @@ const fixtures = {
   },
 };
 
-describe('sidebar.frame-sync', function() {
+describe('sidebar.frame-sync', function () {
   let fakeStore;
   let fakeBridge;
   let frameSync;
   let $rootScope;
 
-  before(function() {
+  before(function () {
     angular.module('app', []).service('frameSync', FrameSync);
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeStore = createFakeStore(
       { annotations: [] },
       {
@@ -80,7 +80,7 @@ describe('sidebar.frame-sync', function() {
       call: sinon.stub(),
       createChannel: sinon.stub(),
       on: emitter.on.bind(emitter),
-      onConnect: function(listener) {
+      onConnect: function (listener) {
         emitter.on('connect', listener);
       },
 
@@ -96,7 +96,7 @@ describe('sidebar.frame-sync', function() {
       bridge: fakeBridge,
     });
 
-    angular.mock.inject(function(_$rootScope_, _frameSync_) {
+    angular.mock.inject(function (_$rootScope_, _frameSync_) {
       $rootScope = _$rootScope_;
       frameSync = _frameSync_;
     });
@@ -106,13 +106,13 @@ describe('sidebar.frame-sync', function() {
     });
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     $imports.$restore();
     frameSync.connect();
   });
 
-  context('when annotations are loaded into the sidebar', function() {
-    it('sends a "loadAnnotations" message to the frame', function() {
+  context('when annotations are loaded into the sidebar', function () {
+    it('sends a "loadAnnotations" message to the frame', function () {
       fakeStore.setState({
         annotations: { annotations: [fixtures.ann] },
       });
@@ -123,7 +123,7 @@ describe('sidebar.frame-sync', function() {
       );
     });
 
-    it('sends a "loadAnnotations" message only for new annotations', function() {
+    it('sends a "loadAnnotations" message only for new annotations', function () {
       const ann2 = Object.assign({}, fixtures.ann, { $tag: 't2', id: 'a2' });
       fakeStore.setState({
         annotations: { annotations: [fixtures.ann] },
@@ -141,7 +141,7 @@ describe('sidebar.frame-sync', function() {
       );
     });
 
-    it('does not send a "loadAnnotations" message for replies', function() {
+    it('does not send a "loadAnnotations" message for replies', function () {
       fakeStore.setState({
         annotations: { annotations: [annotationFixtures.newReply()] },
       });
@@ -149,8 +149,8 @@ describe('sidebar.frame-sync', function() {
     });
   });
 
-  context('when annotation count has changed', function() {
-    it('sends a "publicAnnotationCountChanged" message to the frame when there are public annotations', function() {
+  context('when annotation count has changed', function () {
+    it('sends a "publicAnnotationCountChanged" message to the frame when there are public annotations', function () {
       fakeStore.setState({
         annotations: { annotations: [annotationFixtures.publicAnnotation()] },
       });
@@ -161,7 +161,7 @@ describe('sidebar.frame-sync', function() {
       );
     });
 
-    it('sends a "publicAnnotationCountChanged" message to the frame when there are only private annotations', function() {
+    it('sends a "publicAnnotationCountChanged" message to the frame when there are only private annotations', function () {
       const annot = annotationFixtures.defaultAnnotation();
       delete annot.permissions;
 
@@ -175,7 +175,7 @@ describe('sidebar.frame-sync', function() {
       );
     });
 
-    it('does not send a "publicAnnotationCountChanged" message to the frame if annotation fetch is not complete', function() {
+    it('does not send a "publicAnnotationCountChanged" message to the frame if annotation fetch is not complete', function () {
       fakeStore.frames.returns([{ uri: 'http://example.com' }]);
       fakeStore.setState({
         annotations: { annotations: [annotationFixtures.publicAnnotation()] },
@@ -185,7 +185,7 @@ describe('sidebar.frame-sync', function() {
       );
     });
 
-    it('does not send a "publicAnnotationCountChanged" message if there are no connected frames', function() {
+    it('does not send a "publicAnnotationCountChanged" message if there are no connected frames', function () {
       fakeStore.frames.returns([]);
       fakeStore.setState({
         annotations: { annotations: [annotationFixtures.publicAnnotation()] },
@@ -196,8 +196,8 @@ describe('sidebar.frame-sync', function() {
     });
   });
 
-  context('when annotations are removed from the sidebar', function() {
-    it('sends a "deleteAnnotation" message to the frame', function() {
+  context('when annotations are removed from the sidebar', function () {
+    it('sends a "deleteAnnotation" message to the frame', function () {
       fakeStore.setState({
         annotations: { annotations: [fixtures.ann] },
       });
@@ -212,9 +212,9 @@ describe('sidebar.frame-sync', function() {
     });
   });
 
-  context('when a new annotation is created in the frame', function() {
+  context('when a new annotation is created in the frame', function () {
     context('when an authenticated user is present', () => {
-      it('emits a BEFORE_ANNOTATION_CREATED event', function() {
+      it('emits a BEFORE_ANNOTATION_CREATED event', function () {
         fakeStore.isLoggedIn.returns(true);
         const onCreated = sinon.stub();
         const ann = { target: [] };
@@ -274,7 +274,7 @@ describe('sidebar.frame-sync', function() {
     });
   });
 
-  context('when anchoring completes', function() {
+  context('when anchoring completes', function () {
     let clock = sinon.stub();
 
     beforeEach(() => {
@@ -291,7 +291,7 @@ describe('sidebar.frame-sync', function() {
       clock.tick(20);
     }
 
-    it('updates the anchoring status for the annotation', function() {
+    it('updates the anchoring status for the annotation', function () {
       fakeBridge.emit('sync', [{ tag: 't1', msg: { $orphan: false } }]);
 
       expireDebounceTimeout();
@@ -311,7 +311,7 @@ describe('sidebar.frame-sync', function() {
       });
     });
 
-    it('emits an ANNOTATIONS_SYNCED event', function() {
+    it('emits an ANNOTATIONS_SYNCED event', function () {
       const onSync = sinon.stub();
       $rootScope.$on(events.ANNOTATIONS_SYNCED, onSync);
 
@@ -322,15 +322,15 @@ describe('sidebar.frame-sync', function() {
     });
   });
 
-  context('when a new frame connects', function() {
+  context('when a new frame connects', function () {
     let frameInfo;
     const fakeChannel = {
-      call: function(name, callback) {
+      call: function (name, callback) {
         callback(null, frameInfo);
       },
     };
 
-    it("adds the page's metadata to the frames list", function() {
+    it("adds the page's metadata to the frames list", function () {
       frameInfo = fixtures.htmlDocumentInfo;
 
       fakeBridge.emit('connect', fakeChannel);
@@ -343,18 +343,18 @@ describe('sidebar.frame-sync', function() {
     });
   });
 
-  context('when a frame is destroyed', function() {
+  context('when a frame is destroyed', function () {
     const frameId = fixtures.framesListEntry.id;
 
-    it('removes the frame from the frames list', function() {
+    it('removes the frame from the frames list', function () {
       fakeBridge.emit('destroyFrame', frameId);
 
       assert.calledWith(fakeStore.destroyFrame, fixtures.framesListEntry);
     });
   });
 
-  describe('on "showAnnotations" message', function() {
-    it('selects annotations which have an ID', function() {
+  describe('on "showAnnotations" message', function () {
+    it('selects annotations which have an ID', function () {
       fakeStore.findIDsForTags.returns(['id1', 'id2', 'id3']);
       fakeBridge.emit('showAnnotations', ['tag1', 'tag2', 'tag3']);
 
@@ -363,15 +363,15 @@ describe('sidebar.frame-sync', function() {
     });
   });
 
-  describe('on "focusAnnotations" message', function() {
-    it('focuses the annotations', function() {
+  describe('on "focusAnnotations" message', function () {
+    it('focuses the annotations', function () {
       fakeBridge.emit('focusAnnotations', ['tag1', 'tag2', 'tag3']);
       assert.calledWith(fakeStore.focusAnnotations, ['tag1', 'tag2', 'tag3']);
     });
   });
 
-  describe('on "toggleAnnotationSelection" message', function() {
-    it('toggles the selected state of the annotations', function() {
+  describe('on "toggleAnnotationSelection" message', function () {
+    it('toggles the selected state of the annotations', function () {
       fakeStore.findIDsForTags.returns(['id1', 'id2', 'id3']);
       fakeBridge.emit('toggleAnnotationSelection', ['tag1', 'tag2', 'tag3']);
       assert.calledWith(fakeStore.toggleSelectedAnnotations, [
@@ -382,8 +382,8 @@ describe('sidebar.frame-sync', function() {
     });
   });
 
-  describe('on "sidebarOpened" message', function() {
-    it('broadcasts a sidebarOpened event', function() {
+  describe('on "sidebarOpened" message', function () {
+    it('broadcasts a sidebarOpened event', function () {
       const onSidebarOpened = sinon.stub();
       $rootScope.$on('sidebarOpened', onSidebarOpened);
 
@@ -393,20 +393,20 @@ describe('sidebar.frame-sync', function() {
     });
   });
 
-  describe('on a relayed bridge call', function() {
-    it('calls "showSidebar"', function() {
+  describe('on a relayed bridge call', function () {
+    it('calls "showSidebar"', function () {
       fakeBridge.emit('showSidebar');
 
       assert.calledWith(fakeBridge.call, 'showSidebar');
     });
 
-    it('calls "hideSidebar"', function() {
+    it('calls "hideSidebar"', function () {
       fakeBridge.emit('hideSidebar');
 
       assert.calledWith(fakeBridge.call, 'hideSidebar');
     });
 
-    it('calls "setVisibleHighlights"', function() {
+    it('calls "setVisibleHighlights"', function () {
       fakeBridge.emit('setVisibleHighlights');
 
       assert.calledWith(fakeBridge.call, 'setVisibleHighlights');

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -21,7 +21,7 @@ function truthTable(columns) {
 }
 
 // Return a mock session service containing three groups.
-const sessionWithThreeGroups = function() {
+const sessionWithThreeGroups = function () {
   return {
     state: {},
   };
@@ -37,7 +37,7 @@ const dummyGroups = [
   { name: 'Group 3', id: 'id3' },
 ];
 
-describe('groups', function() {
+describe('groups', function () {
   let fakeAuth;
   let fakeStore;
   let fakeIsSidebar;
@@ -48,7 +48,7 @@ describe('groups', function() {
   let fakeServiceUrl;
   let fakeMetadata;
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeAuth = {
       tokenGetter: sinon.stub().returns('1234'),
     };
@@ -98,11 +98,11 @@ describe('groups', function() {
     fakeRootScope = {
       eventCallbacks: {},
 
-      $apply: function(callback) {
+      $apply: function (callback) {
         callback();
       },
 
-      $on: function(event, callback) {
+      $on: function (event, callback) {
         if (event === events.USER_CHANGED || event === events.FRAME_CONNECTED) {
           this.eventCallbacks[event] = callback;
         }
@@ -230,7 +230,7 @@ describe('groups', function() {
     });
   });
 
-  describe('#all', function() {
+  describe('#all', function () {
     it('returns all groups from store.allGroups', () => {
       const svc = service();
       fakeStore.allGroups = sinon.stub().returns(dummyGroups);
@@ -239,7 +239,7 @@ describe('groups', function() {
     });
   });
 
-  describe('#load', function() {
+  describe('#load', function () {
     it('filters out direct-linked groups that are out of scope and scope enforced', () => {
       const svc = service();
       fakeStore.getDefault.returns(dummyGroups[0].id);
@@ -281,7 +281,7 @@ describe('groups', function() {
       });
     });
 
-    it('combines groups from both endpoints', function() {
+    it('combines groups from both endpoints', function () {
       const svc = service();
 
       const groups = [
@@ -356,7 +356,7 @@ describe('groups', function() {
       });
     });
 
-    it('loads all available groups', function() {
+    it('loads all available groups', function () {
       const svc = service();
 
       return svc.load().then(() => {
@@ -364,7 +364,7 @@ describe('groups', function() {
       });
     });
 
-    it('sends `expand` parameter', function() {
+    it('sends `expand` parameter', function () {
       const svc = service();
       fakeApi.groups.list.returns(
         Promise.resolve([{ id: 'groupa', name: 'GroupA' }])
@@ -516,7 +516,7 @@ describe('groups', function() {
       });
     });
 
-    it('injects a defalt organization if group is missing an organization', function() {
+    it('injects a defalt organization if group is missing an organization', function () {
       const svc = service();
       const groups = [{ id: '39r39f', name: 'Ding Dong!' }];
       fakeApi.groups.list.returns(Promise.resolve(groups));
@@ -769,8 +769,8 @@ describe('groups', function() {
     });
   });
 
-  describe('#get', function() {
-    it('returns the requested group', function() {
+  describe('#get', function () {
+    it('returns the requested group', function () {
       const svc = service();
       fakeStore.getGroup.withArgs('foo').returns(dummyGroups[1]);
 
@@ -778,8 +778,8 @@ describe('groups', function() {
     });
   });
 
-  describe('#leave', function() {
-    it('should call the group leave API', function() {
+  describe('#leave', function () {
+    it('should call the group leave API', function () {
       const s = service();
       return s.leave('id2').then(() => {
         assert.calledWithMatch(fakeApi.group.member.delete, {
@@ -790,7 +790,7 @@ describe('groups', function() {
     });
   });
 
-  describe('calls load on various events', function() {
+  describe('calls load on various events', function () {
     it('refetches groups when the logged-in user changes', () => {
       service();
 

--- a/src/sidebar/services/test/oauth-auth-test.js
+++ b/src/sidebar/services/test/oauth-auth-test.js
@@ -7,7 +7,7 @@ import authFactory, { $imports } from '../oauth-auth';
 const DEFAULT_TOKEN_EXPIRES_IN_SECS = 1000;
 const TOKEN_KEY = 'hypothesis.oauth.hypothes%2Eis.token';
 
-describe('sidebar.oauth-auth', function() {
+describe('sidebar.oauth-auth', function () {
   let $rootScope;
   let FakeOAuthClient;
   let auth;
@@ -39,7 +39,7 @@ describe('sidebar.oauth-auth', function() {
     angular.module('app', []).service('auth', authFactory);
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     // Setup fake clock. This has to be done before setting up the `window`
     // fake which makes use of timers.
     clock = sinon.useFakeTimers();
@@ -111,7 +111,7 @@ describe('sidebar.oauth-auth', function() {
     });
   });
 
-  afterEach(function() {
+  afterEach(function () {
     $imports.$restore();
 
     performance.now.restore();
@@ -130,14 +130,14 @@ describe('sidebar.oauth-auth', function() {
     });
   });
 
-  describe('#tokenGetter', function() {
+  describe('#tokenGetter', function () {
     const successfulTokenResponse = Promise.resolve({
       accessToken: 'firstAccessToken',
       refreshToken: 'firstRefreshToken',
       expiresAt: 100,
     });
 
-    it('exchanges the grant token for an access token if provided', function() {
+    it('exchanges the grant token for an access token if provided', function () {
       fakeClient.exchangeGrantToken.returns(successfulTokenResponse);
 
       return auth.tokenGetter().then(token => {
@@ -146,9 +146,9 @@ describe('sidebar.oauth-auth', function() {
       });
     });
 
-    context('when the access token request fails', function() {
+    context('when the access token request fails', function () {
       const expectedErr = new Error('Grant token exchange failed');
-      beforeEach('make access token requests fail', function() {
+      beforeEach('make access token requests fail', function () {
         fakeClient.exchangeGrantToken.returns(Promise.reject(expectedErr));
       });
 
@@ -158,8 +158,8 @@ describe('sidebar.oauth-auth', function() {
         }, func);
       }
 
-      it('shows an error message to the user', function() {
-        return assertThatAccessTokenPromiseWasRejectedAnd(function() {
+      it('shows an error message to the user', function () {
+        return assertThatAccessTokenPromiseWasRejectedAnd(function () {
           assert.calledOnce(fakeFlash.error);
           assert.equal(
             fakeFlash.error.firstCall.args[0],
@@ -168,22 +168,22 @@ describe('sidebar.oauth-auth', function() {
         });
       });
 
-      it('returns a rejected promise', function() {
+      it('returns a rejected promise', function () {
         return assertThatAccessTokenPromiseWasRejectedAnd(err => {
           assert.equal(err.message, expectedErr.message);
         });
       });
     });
 
-    it('should cache tokens for future use', function() {
+    it('should cache tokens for future use', function () {
       fakeClient.exchangeGrantToken.returns(successfulTokenResponse);
       return auth
         .tokenGetter()
-        .then(function() {
+        .then(function () {
           fakeClient.exchangeGrantToken.reset();
           return auth.tokenGetter();
         })
-        .then(function(token) {
+        .then(function (token) {
           assert.equal(token, 'firstAccessToken');
           assert.notCalled(fakeClient.exchangeGrantToken);
         });
@@ -193,7 +193,7 @@ describe('sidebar.oauth-auth', function() {
     // flight when tokenGetter() is called again, then it should just return
     // the pending Promise for the first request again (and not send a second
     // concurrent HTTP request).
-    it('should not make two concurrent access token requests', function() {
+    it('should not make two concurrent access token requests', function () {
       let respond;
       fakeClient.exchangeGrantToken.returns(
         new Promise(resolve => {
@@ -216,15 +216,15 @@ describe('sidebar.oauth-auth', function() {
       });
     });
 
-    it('should not attempt to exchange a grant token if none was provided', function() {
+    it('should not attempt to exchange a grant token if none was provided', function () {
       fakeSettings.services = [{ authority: 'publisher.org' }];
-      return auth.tokenGetter().then(function(token) {
+      return auth.tokenGetter().then(function (token) {
         assert.notCalled(fakeClient.exchangeGrantToken);
         assert.equal(token, null);
       });
     });
 
-    it('should refresh the access token if it expired', function() {
+    it('should refresh the access token if it expired', function () {
       fakeClient.exchangeGrantToken.returns(
         Promise.resolve(successfulTokenResponse)
       );
@@ -258,7 +258,7 @@ describe('sidebar.oauth-auth', function() {
 
     // It only sends one refresh request, even if tokenGetter() is called
     // multiple times and the refresh response hasn't come back yet.
-    it('does not send more than one refresh request', function() {
+    it('does not send more than one refresh request', function () {
       fakeClient.exchangeGrantToken.returns(
         Promise.resolve(successfulTokenResponse)
       );
@@ -296,13 +296,13 @@ describe('sidebar.oauth-auth', function() {
         });
     });
 
-    context('when a refresh request fails', function() {
-      beforeEach('make refresh token requests fail', function() {
+    context('when a refresh request fails', function () {
+      beforeEach('make refresh token requests fail', function () {
         fakeClient.refreshToken.returns(Promise.reject(new Error('failed')));
         fakeClient.exchangeGrantToken.returns(successfulTokenResponse);
       });
 
-      it('logs the user out', function() {
+      it('logs the user out', function () {
         expireAccessToken();
 
         return auth.tokenGetter(token => {

--- a/src/sidebar/services/test/persisted-defaults-test.js
+++ b/src/sidebar/services/test/persisted-defaults-test.js
@@ -6,7 +6,7 @@ const DEFAULT_KEYS = {
   focusedGroup: 'hypothesis.groups.focus',
 };
 
-describe('sidebar/services/persisted-defaults', function() {
+describe('sidebar/services/persisted-defaults', function () {
   let fakeLocalStorage;
   let fakeGetItem;
   let fakeSetItem;

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -19,7 +19,7 @@ const fixtures = immutable({
   },
 });
 
-describe('rootThread', function() {
+describe('rootThread', function () {
   let fakeAnnotationsService;
   let fakeStore;
   let fakeBuildThread;
@@ -31,7 +31,7 @@ describe('rootThread', function() {
 
   let rootThread;
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeAnnotationsService = {
       create: sinon.stub(),
     };
@@ -59,7 +59,7 @@ describe('rootThread', function() {
           params: {},
         },
       },
-      getState: function() {
+      getState: function () {
         return this.state;
       },
 
@@ -99,7 +99,7 @@ describe('rootThread', function() {
 
     angular.mock.module('app');
 
-    angular.mock.inject(function(_$rootScope_, _rootThread_) {
+    angular.mock.inject(function (_$rootScope_, _rootThread_) {
       $rootScope = _$rootScope_;
       rootThread = _rootThread_;
     });
@@ -115,19 +115,19 @@ describe('rootThread', function() {
     $imports.$restore();
   });
 
-  describe('#thread', function() {
-    it('returns the result of buildThread()', function() {
+  describe('#thread', function () {
+    it('returns the result of buildThread()', function () {
       assert.equal(rootThread.thread(fakeStore.state), fixtures.emptyThread);
     });
 
-    it('passes loaded annotations to buildThread()', function() {
+    it('passes loaded annotations to buildThread()', function () {
       const annotation = annotationFixtures.defaultAnnotation();
       fakeStore.state.annotations.annotations = [annotation];
       rootThread.thread(fakeStore.state);
       assert.calledWith(fakeBuildThread, sinon.match([annotation]));
     });
 
-    it('passes the current selection to buildThread()', function() {
+    it('passes the current selection to buildThread()', function () {
       fakeStore.state.selection.selectedAnnotationMap = {
         id1: true,
         id2: true,
@@ -142,7 +142,7 @@ describe('rootThread', function() {
       );
     });
 
-    it('passes the current expanded set to buildThread()', function() {
+    it('passes the current expanded set to buildThread()', function () {
       fakeStore.state.selection.expanded = { id1: true, id2: true };
       rootThread.thread(fakeStore.state);
       assert.calledWith(
@@ -154,7 +154,7 @@ describe('rootThread', function() {
       );
     });
 
-    it('passes the current force-visible set to buildThread()', function() {
+    it('passes the current force-visible set to buildThread()', function () {
       fakeStore.state.selection.forceVisible = { id1: true, id2: true };
       rootThread.thread(fakeStore.state);
       assert.calledWith(
@@ -166,7 +166,7 @@ describe('rootThread', function() {
       );
     });
 
-    it('passes the highlighted set to buildThread()', function() {
+    it('passes the highlighted set to buildThread()', function () {
       fakeStore.state.selection.highlighted = ['id1', 'id2'];
       rootThread.thread(fakeStore.state);
       assert.calledWith(
@@ -179,9 +179,9 @@ describe('rootThread', function() {
     });
   });
 
-  describe('when the sort order changes', function() {
+  describe('when the sort order changes', function () {
     function sortBy(annotations, sortCompareFn) {
-      return annotations.slice().sort(function(a, b) {
+      return annotations.slice().sort(function (a, b) {
         return sortCompareFn(a, b) ? -1 : sortCompareFn(b, a) ? 1 : 0;
       });
     }
@@ -234,7 +234,7 @@ describe('rootThread', function() {
 
         rootThread.thread(fakeStore.state);
         const sortCompareFn = fakeBuildThread.args[0][1].sortCompareFn;
-        const actualOrder = sortBy(annotations, sortCompareFn).map(function(
+        const actualOrder = sortBy(annotations, sortCompareFn).map(function (
           annot
         ) {
           return annotations.indexOf(annot);
@@ -244,8 +244,8 @@ describe('rootThread', function() {
     });
   });
 
-  describe('when no filter query is set', function() {
-    it('filter matches only annotations when Annotations tab is selected', function() {
+  describe('when no filter query is set', function () {
+    it('filter matches only annotations when Annotations tab is selected', function () {
       fakeBuildThread.reset();
       fakeStore.state.selection.selectedTab = uiConstants.TAB_ANNOTATIONS;
       rootThread.thread(fakeStore.state);
@@ -255,7 +255,7 @@ describe('rootThread', function() {
       assert.isDefined(threadFilterFn({ annotation: annotation }));
     });
 
-    it('filter matches only notes when Notes tab is selected', function() {
+    it('filter matches only notes when Notes tab is selected', function () {
       fakeBuildThread.reset();
       fakeStore.state.selection.selectedTab = uiConstants.TAB_NOTES;
       rootThread.thread(fakeStore.state);
@@ -264,7 +264,7 @@ describe('rootThread', function() {
       assert.isTrue(threadFilterFn({ annotation: { target: [{}] } }));
     });
 
-    it('filter matches only orphans when Orphans tab is selected', function() {
+    it('filter matches only orphans when Orphans tab is selected', function () {
       fakeBuildThread.reset();
       fakeStore.state.selection.selectedTab = uiConstants.TAB_ORPHANS;
       rootThread.thread(fakeStore.state);
@@ -277,7 +277,7 @@ describe('rootThread', function() {
       assert.isTrue(threadFilterFn({ annotation: orphan }));
     });
 
-    it('filter does not match notes when Annotations tab is selected', function() {
+    it('filter does not match notes when Annotations tab is selected', function () {
       fakeBuildThread.reset();
       fakeStore.state.selection.selectedTab = uiConstants.TAB_ANNOTATIONS;
       rootThread.thread(fakeStore.state);
@@ -286,7 +286,7 @@ describe('rootThread', function() {
       assert.isFalse(threadFilterFn({ annotation: { target: [{}] } }));
     });
 
-    it('filter does not match orphans when Annotations tab is selected', function() {
+    it('filter does not match orphans when Annotations tab is selected', function () {
       fakeBuildThread.reset();
       fakeStore.state.selection.selectedTab = uiConstants.TAB_ANNOTATIONS;
       rootThread.thread(fakeStore.state);
@@ -295,7 +295,7 @@ describe('rootThread', function() {
       assert.isFalse(threadFilterFn({ annotation: { $orphan: true } }));
     });
 
-    it('does not filter annotations when not in the sidebar', function() {
+    it('does not filter annotations when not in the sidebar', function () {
       fakeBuildThread.reset();
       fakeStore.state.route.name = 'stream';
 
@@ -307,7 +307,7 @@ describe('rootThread', function() {
       assert.notOk(threadFilterFn);
     });
 
-    it('filter returns false when no annotations are provided', function() {
+    it('filter returns false when no annotations are provided', function () {
       fakeBuildThread.reset();
       rootThread.thread(fakeStore.state);
       const threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
@@ -315,8 +315,8 @@ describe('rootThread', function() {
     });
   });
 
-  describe('when the filter query changes', function() {
-    it('generates a thread filter function from the query', function() {
+  describe('when the filter query changes', function () {
+    it('generates a thread filter function from the query', function () {
       fakeBuildThread.reset();
       const filters = [{ any: { terms: ['queryterm'] } }];
       const annotation = annotationFixtures.defaultAnnotation();
@@ -356,10 +356,10 @@ describe('rootThread', function() {
     });
   });
 
-  context('when annotation events occur', function() {
+  context('when annotation events occur', function () {
     const annot = annotationFixtures.defaultAnnotation();
 
-    it('creates a new annotation when BEFORE_ANNOTATION_CREATED event occurs', function() {
+    it('creates a new annotation when BEFORE_ANNOTATION_CREATED event occurs', function () {
       $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED, annot);
       assert.notCalled(fakeStore.removeAnnotations);
       assert.calledWith(fakeAnnotationsService.create, sinon.match(annot));
@@ -378,15 +378,15 @@ describe('rootThread', function() {
       });
     });
 
-    it('removes annotations when ANNOTATION_DELETED event occurs', function() {
+    it('removes annotations when ANNOTATION_DELETED event occurs', function () {
       $rootScope.$broadcast(events.ANNOTATION_DELETED, annot);
       assert.calledWith(fakeStore.removeAnnotations, sinon.match([annot]));
     });
 
-    describe('when a new annotation is created', function() {
+    describe('when a new annotation is created', function () {
       let existingNewAnnot;
       let onDelete;
-      beforeEach(function() {
+      beforeEach(function () {
         onDelete = sinon.stub();
         $rootScope.$on(events.ANNOTATION_DELETED, onDelete);
 
@@ -394,7 +394,7 @@ describe('rootThread', function() {
         fakeStore.state.annotations.annotations.push(existingNewAnnot);
       });
 
-      it('does not remove annotations that have non-empty drafts', function() {
+      it('does not remove annotations that have non-empty drafts', function () {
         fakeStore.getDraftIfNotEmpty.returns(fixtures.nonEmptyDraft);
         $rootScope.$broadcast(
           events.BEFORE_ANNOTATION_CREATED,
@@ -405,7 +405,7 @@ describe('rootThread', function() {
         assert.notCalled(onDelete);
       });
 
-      it('does not remove saved annotations', function() {
+      it('does not remove saved annotations', function () {
         const ann = annotationFixtures.defaultAnnotation();
         fakeStore.state.annotations.annotations = [ann];
 

--- a/src/sidebar/services/test/service-url-test.js
+++ b/src/sidebar/services/test/service-url-test.js
@@ -5,10 +5,10 @@ import { $imports } from '../service-url';
 function fakeStore() {
   let links = null;
   return {
-    updateLinks: function(newLinks) {
+    updateLinks: function (newLinks) {
       links = newLinks;
     },
-    getState: function() {
+    getState: function () {
       return { links: links };
     },
   };
@@ -37,50 +37,50 @@ function createServiceUrl(linksPromise) {
   };
 }
 
-describe('sidebar.service-url', function() {
-  beforeEach(function() {
+describe('sidebar.service-url', function () {
+  beforeEach(function () {
     sinon.stub(console, 'warn');
   });
 
-  afterEach(function() {
+  afterEach(function () {
     console.warn.restore();
     $imports.$restore();
   });
 
-  context('before the API response has been received', function() {
+  context('before the API response has been received', function () {
     let serviceUrl;
     let apiRoutes;
 
-    beforeEach(function() {
+    beforeEach(function () {
       // Create a serviceUrl function with an unresolved Promise that will
       // never be resolved - it never receives the links from store.links().
-      const parts = createServiceUrl(new Promise(function() {}));
+      const parts = createServiceUrl(new Promise(function () {}));
 
       serviceUrl = parts.serviceUrl;
       apiRoutes = parts.apiRoutes;
     });
 
-    it('sends one API request for the links at boot time', function() {
+    it('sends one API request for the links at boot time', function () {
       assert.calledOnce(apiRoutes.links);
       assert.isTrue(apiRoutes.links.calledWithExactly());
     });
 
-    it('returns an empty string for any link', function() {
+    it('returns an empty string for any link', function () {
       assert.equal(serviceUrl('foo'), '');
     });
 
-    it('returns an empty string even if link params are given', function() {
+    it('returns an empty string even if link params are given', function () {
       assert.equal(serviceUrl('foo', { bar: 'bar' }), '');
     });
   });
 
-  context('after the API response has been received', function() {
+  context('after the API response has been received', function () {
     let store;
     let linksPromise;
     let replaceURLParams;
     let serviceUrl;
 
-    beforeEach(function() {
+    beforeEach(function () {
       // The links Promise that store.links() will return.
       linksPromise = Promise.resolve({
         first_link: 'http://example.com/first_page/:foo',
@@ -94,14 +94,14 @@ describe('sidebar.service-url', function() {
       replaceURLParams = parts.replaceURLParams;
     });
 
-    it('updates store with the real links', function() {
-      return linksPromise.then(function(links) {
+    it('updates store with the real links', function () {
+      return linksPromise.then(function (links) {
         assert.deepEqual(store.getState(), { links: links });
       });
     });
 
-    it('calls replaceURLParams with the path and given params', function() {
-      return linksPromise.then(function() {
+    it('calls replaceURLParams with the path and given params', function () {
+      return linksPromise.then(function () {
         const params = { foo: 'bar' };
 
         serviceUrl('first_link', params);
@@ -114,8 +114,8 @@ describe('sidebar.service-url', function() {
       });
     });
 
-    it('passes an empty params object to replaceURLParams if no params are given', function() {
-      return linksPromise.then(function() {
+    it('passes an empty params object to replaceURLParams if no params are given', function () {
+      return linksPromise.then(function () {
         serviceUrl('first_link');
 
         assert.calledOnce(replaceURLParams);
@@ -123,18 +123,18 @@ describe('sidebar.service-url', function() {
       });
     });
 
-    it('returns the expanded URL from replaceURLParams', function() {
-      return linksPromise.then(function() {
+    it('returns the expanded URL from replaceURLParams', function () {
+      return linksPromise.then(function () {
         const renderedUrl = serviceUrl('first_link');
 
         assert.equal(renderedUrl, 'EXPANDED_URL');
       });
     });
 
-    it("throws an error if it doesn't have the requested link", function() {
-      return linksPromise.then(function() {
+    it("throws an error if it doesn't have the requested link", function () {
+      return linksPromise.then(function () {
         assert.throws(
-          function() {
+          function () {
             serviceUrl('madeUpLinkName');
           },
           Error,
@@ -143,16 +143,16 @@ describe('sidebar.service-url', function() {
       });
     });
 
-    it('throws an error if replaceURLParams returns unused params', function() {
+    it('throws an error if replaceURLParams returns unused params', function () {
       const params = { unused_param_1: 'foo', unused_param_2: 'bar' };
       replaceURLParams.returns({
         url: 'EXPANDED_URL',
         params: params,
       });
 
-      return linksPromise.then(function() {
+      return linksPromise.then(function () {
         assert.throws(
-          function() {
+          function () {
             serviceUrl('first_link', params);
           },
           Error,

--- a/src/sidebar/services/test/session-test.js
+++ b/src/sidebar/services/test/session-test.js
@@ -7,7 +7,7 @@ import { $imports } from '../session';
 
 const mock = angular.mock;
 
-describe('sidebar.session', function() {
+describe('sidebar.session', function () {
   let $rootScope;
 
   let fakeAnalytics;
@@ -22,11 +22,11 @@ describe('sidebar.session', function() {
   // The instance of the `session` service.
   let session;
 
-  before(function() {
+  before(function () {
     angular.module('h', []).service('session', sessionFactory);
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     sandbox = sinon.createSandbox();
 
     let state = {};
@@ -35,10 +35,10 @@ describe('sidebar.session', function() {
       events: analyticsEvents,
     };
     const fakeStore = {
-      getState: function() {
+      getState: function () {
         return { session: state };
       },
-      updateSession: function(session) {
+      updateSession: function (session) {
         state = session;
       },
     };
@@ -76,20 +76,20 @@ describe('sidebar.session', function() {
   });
 
   beforeEach(
-    mock.inject(function(_$rootScope_, _session_) {
+    mock.inject(function (_$rootScope_, _session_) {
       session = _session_;
       $rootScope = _$rootScope_;
     })
   );
 
-  afterEach(function() {
+  afterEach(function () {
     $imports.$restore();
     sandbox.restore();
   });
 
-  describe('#load()', function() {
-    context('when the host page provides an OAuth grant token', function() {
-      beforeEach(function() {
+  describe('#load()', function () {
+    context('when the host page provides an OAuth grant token', function () {
+      beforeEach(function () {
         fakeServiceConfig.returns({
           authority: 'publisher.org',
           grantToken: 'a.jwt.token',
@@ -101,16 +101,16 @@ describe('sidebar.session', function() {
         );
       });
 
-      it('should pass the "authority" param when fetching the profile', function() {
-        return session.load().then(function() {
+      it('should pass the "authority" param when fetching the profile', function () {
+        return session.load().then(function () {
           assert.calledWith(fakeApi.profile.read, {
             authority: 'publisher.org',
           });
         });
       });
 
-      it('should update the session with the profile data from the API', function() {
-        return session.load().then(function() {
+      it('should update the session with the profile data from the API', function () {
+        return session.load().then(function () {
           assert.equal(session.state.userid, 'acct:user@publisher.org');
         });
       });
@@ -158,7 +158,7 @@ describe('sidebar.session', function() {
       });
 
       it('should update the session with the profile data from the API', () => {
-        return session.load().then(function() {
+        return session.load().then(function () {
           assert.equal(session.state.userid, 'acct:user@hypothes.is');
         });
       });
@@ -191,8 +191,8 @@ describe('sidebar.session', function() {
     });
   });
 
-  describe('#update()', function() {
-    it('broadcasts USER_CHANGED when the user changes', function() {
+  describe('#update()', function () {
+    it('broadcasts USER_CHANGED when the user changes', function () {
       const userChangeCallback = sinon.stub();
       $rootScope.$on(events.USER_CHANGED, userChangeCallback);
       session.update({
@@ -201,7 +201,7 @@ describe('sidebar.session', function() {
       assert.calledOnce(userChangeCallback);
     });
 
-    it('updates the user ID for Sentry error reports', function() {
+    it('updates the user ID for Sentry error reports', function () {
       session.update({
         userid: 'anne',
       });
@@ -211,8 +211,8 @@ describe('sidebar.session', function() {
     });
   });
 
-  describe('#dismissSidebarTutorial()', function() {
-    beforeEach(function() {
+  describe('#dismissSidebarTutorial()', function () {
+    beforeEach(function () {
       fakeApi.profile.update.returns(
         Promise.resolve({
           preferences: {},
@@ -220,7 +220,7 @@ describe('sidebar.session', function() {
       );
     });
 
-    it('disables the tutorial for the user', function() {
+    it('disables the tutorial for the user', function () {
       session.dismissSidebarTutorial();
       assert.calledWith(
         fakeApi.profile.update,
@@ -229,8 +229,8 @@ describe('sidebar.session', function() {
       );
     });
 
-    it('should update the session with the response from the API', function() {
-      return session.dismissSidebarTutorial().then(function() {
+    it('should update the session with the response from the API', function () {
+      return session.dismissSidebarTutorial().then(function () {
         assert.isNotOk(session.state.preferences.show_sidebar_tutorial);
       });
     });
@@ -260,7 +260,7 @@ describe('sidebar.session', function() {
     });
   });
 
-  describe('#logout', function() {
+  describe('#logout', function () {
     beforeEach(() => {
       let loggedIn = true;
 

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -56,21 +56,21 @@ class FakeSocket extends EventEmitter {
 
     this.isConnected = sinon.stub().returns(true);
 
-    this.send = function(message) {
+    this.send = function (message) {
       this.messages.push(message);
     };
 
-    this.notify = function(message) {
+    this.notify = function (message) {
       this.emit('message', { data: JSON.stringify(message) });
     };
 
-    this.close = function() {
+    this.close = function () {
       this.didClose = true;
     };
   }
 }
 
-describe('Streamer', function() {
+describe('Streamer', function () {
   let fakeAnnotationMapper;
   let fakeStore;
   let fakeAuth;
@@ -92,21 +92,21 @@ describe('Streamer', function() {
     );
   }
 
-  beforeEach(function() {
+  beforeEach(function () {
     const emitter = new EventEmitter();
 
     fakeAuth = {
-      tokenGetter: function() {
+      tokenGetter: function () {
         return Promise.resolve('dummy-access-token');
       },
     };
 
     fakeRootScope = {
-      $apply: function(callback) {
+      $apply: function (callback) {
         callback();
       },
       $on: emitter.on.bind(emitter),
-      $broadcast: function(event, data) {
+      $broadcast: function (event, data) {
         emitter.emit(event, { event: event }, data);
       },
     };
@@ -148,34 +148,34 @@ describe('Streamer', function() {
     });
   });
 
-  afterEach(function() {
+  afterEach(function () {
     $imports.$restore();
     activeStreamer = null;
   });
 
-  it('should not create a websocket connection if websocketUrl is not provided', function() {
+  it('should not create a websocket connection if websocketUrl is not provided', function () {
     fakeSettings = {};
     createDefaultStreamer();
 
-    return activeStreamer.connect().then(function() {
+    return activeStreamer.connect().then(function () {
       assert.isNull(fakeWebSocket);
     });
   });
 
-  it('should not create a websocket connection', function() {
+  it('should not create a websocket connection', function () {
     createDefaultStreamer();
     assert.isNull(fakeWebSocket);
   });
 
-  it('should have a non-null client ID', function() {
+  it('should have a non-null client ID', function () {
     createDefaultStreamer();
     assert.ok(activeStreamer.clientId);
   });
 
-  it('should send the client ID after connecting', function() {
+  it('should send the client ID after connecting', function () {
     createDefaultStreamer();
-    return activeStreamer.connect().then(function() {
-      const clientIdMsg = fakeWebSocket.messages.find(function(msg) {
+    return activeStreamer.connect().then(function () {
+      const clientIdMsg = fakeWebSocket.messages.find(function (msg) {
         return msg.messageType === 'client_id';
       });
       assert.ok(clientIdMsg);
@@ -183,27 +183,27 @@ describe('Streamer', function() {
     });
   });
 
-  it('should request the logged-in user ID after connecting', function() {
+  it('should request the logged-in user ID after connecting', function () {
     createDefaultStreamer();
-    return activeStreamer.connect().then(function() {
-      const whoamiMsg = fakeWebSocket.messages.find(function(msg) {
+    return activeStreamer.connect().then(function () {
+      const whoamiMsg = fakeWebSocket.messages.find(function (msg) {
         return msg.type === 'whoami';
       });
       assert.ok(whoamiMsg);
     });
   });
 
-  describe('#connect()', function() {
-    it('should create a websocket connection', function() {
+  describe('#connect()', function () {
+    it('should create a websocket connection', function () {
       createDefaultStreamer();
-      return activeStreamer.connect().then(function() {
+      return activeStreamer.connect().then(function () {
         assert.ok(fakeWebSocket);
       });
     });
 
-    it('should include credentials in the URL if the client has an access token', function() {
+    it('should include credentials in the URL if the client has an access token', function () {
       createDefaultStreamer();
-      return activeStreamer.connect().then(function() {
+      return activeStreamer.connect().then(function () {
         assert.equal(
           fakeWebSocket.url,
           'ws://example.com/ws?access_token=dummy-access-token'
@@ -211,10 +211,10 @@ describe('Streamer', function() {
       });
     });
 
-    it('should preserve query params when adding access token to URL', function() {
+    it('should preserve query params when adding access token to URL', function () {
       fakeSettings.websocketUrl = 'ws://example.com/ws?foo=bar';
       createDefaultStreamer();
-      return activeStreamer.connect().then(function() {
+      return activeStreamer.connect().then(function () {
         assert.equal(
           fakeWebSocket.url,
           'ws://example.com/ws?access_token=dummy-access-token&foo=bar'
@@ -222,63 +222,63 @@ describe('Streamer', function() {
       });
     });
 
-    it('should not include credentials in the URL if the client has no access token', function() {
-      fakeAuth.tokenGetter = function() {
+    it('should not include credentials in the URL if the client has no access token', function () {
+      fakeAuth.tokenGetter = function () {
         return Promise.resolve(null);
       };
 
       createDefaultStreamer();
-      return activeStreamer.connect().then(function() {
+      return activeStreamer.connect().then(function () {
         assert.equal(fakeWebSocket.url, 'ws://example.com/ws');
       });
     });
 
-    it('should not close any existing socket', function() {
+    it('should not close any existing socket', function () {
       let oldWebSocket;
       createDefaultStreamer();
       return activeStreamer
         .connect()
-        .then(function() {
+        .then(function () {
           oldWebSocket = fakeWebSocket;
           return activeStreamer.connect();
         })
-        .then(function() {
+        .then(function () {
           assert.ok(!oldWebSocket.didClose);
           assert.ok(!fakeWebSocket.didClose);
         });
     });
   });
 
-  describe('#reconnect()', function() {
-    it('should close the existing socket', function() {
+  describe('#reconnect()', function () {
+    it('should close the existing socket', function () {
       let oldWebSocket;
       createDefaultStreamer();
 
       return activeStreamer
         .connect()
-        .then(function() {
+        .then(function () {
           oldWebSocket = fakeWebSocket;
           return activeStreamer.reconnect();
         })
-        .then(function() {
+        .then(function () {
           assert.ok(oldWebSocket.didClose);
           assert.ok(!fakeWebSocket.didClose);
         });
     });
   });
 
-  describe('annotation notifications', function() {
-    beforeEach(function() {
+  describe('annotation notifications', function () {
+    beforeEach(function () {
       createDefaultStreamer();
       return activeStreamer.connect();
     });
 
-    context('when the app is the stream', function() {
-      beforeEach(function() {
+    context('when the app is the stream', function () {
+      beforeEach(function () {
         fakeStore.route.returns('stream');
       });
 
-      it('applies updates immediately', function() {
+      it('applies updates immediately', function () {
         const [ann] = fixtures.createNotification.payload;
         fakeStore.pendingUpdates.returns({
           [ann.id]: ann,
@@ -296,22 +296,22 @@ describe('Streamer', function() {
       });
     });
 
-    context('when the app is the sidebar', function() {
-      it('saves pending updates', function() {
+    context('when the app is the sidebar', function () {
+      it('saves pending updates', function () {
         fakeWebSocket.notify(fixtures.createNotification);
         assert.calledWith(fakeStore.receiveRealTimeUpdates, {
           updatedAnnotations: fixtures.createNotification.payload,
         });
       });
 
-      it('saves pending deletions', function() {
+      it('saves pending deletions', function () {
         fakeWebSocket.notify(fixtures.deleteNotification);
         assert.calledWith(fakeStore.receiveRealTimeUpdates, {
           deletedAnnotations: fixtures.deleteNotification.payload,
         });
       });
 
-      it('does not apply updates immediately', function() {
+      it('does not apply updates immediately', function () {
         const ann = fixtures.createNotification.payload;
         fakeStore.pendingUpdates.returns({
           [ann.id]: ann,
@@ -322,7 +322,7 @@ describe('Streamer', function() {
         assert.notCalled(fakeAnnotationMapper.loadAnnotations);
       });
 
-      it('does not apply deletions immediately', function() {
+      it('does not apply deletions immediately', function () {
         const ann = fixtures.deleteNotification.payload;
         fakeStore.pendingDeletions.returns({
           [ann.id]: true,
@@ -335,13 +335,13 @@ describe('Streamer', function() {
     });
   });
 
-  describe('#applyPendingUpdates', function() {
-    beforeEach(function() {
+  describe('#applyPendingUpdates', function () {
+    beforeEach(function () {
       createDefaultStreamer();
       return activeStreamer.connect();
     });
 
-    it('applies pending updates', function() {
+    it('applies pending updates', function () {
       fakeStore.pendingUpdates.returns({ 'an-id': { id: 'an-id' } });
       activeStreamer.applyPendingUpdates();
       assert.calledWith(fakeAnnotationMapper.loadAnnotations, [
@@ -349,7 +349,7 @@ describe('Streamer', function() {
       ]);
     });
 
-    it('applies pending deletions', function() {
+    it('applies pending deletions', function () {
       fakeStore.pendingDeletions.returns({ 'an-id': true });
 
       activeStreamer.applyPendingUpdates();
@@ -360,17 +360,17 @@ describe('Streamer', function() {
       );
     });
 
-    it('clears the set of pending updates', function() {
+    it('clears the set of pending updates', function () {
       fakeWebSocket.notify(fixtures.createNotification);
       activeStreamer.applyPendingUpdates();
       assert.calledWith(fakeStore.clearPendingUpdates);
     });
   });
 
-  describe('session change notifications', function() {
-    it('updates the session when a notification is received', function() {
+  describe('session change notifications', function () {
+    it('updates the session when a notification is received', function () {
       createDefaultStreamer();
-      return activeStreamer.connect().then(function() {
+      return activeStreamer.connect().then(function () {
         const model = {
           groups: [
             {
@@ -388,12 +388,12 @@ describe('Streamer', function() {
     });
   });
 
-  describe('whoyouare notifications', function() {
-    beforeEach(function() {
+  describe('whoyouare notifications', function () {
+    beforeEach(function () {
       sinon.stub(console, 'warn');
     });
 
-    afterEach(function() {
+    afterEach(function () {
       console.warn.restore();
     });
 
@@ -414,7 +414,7 @@ describe('Streamer', function() {
           },
         });
         createDefaultStreamer();
-        return activeStreamer.connect().then(function() {
+        return activeStreamer.connect().then(function () {
           fakeWebSocket.notify({
             type: 'whoyouare',
             userid: testCase.websocketUserid,
@@ -441,7 +441,7 @@ describe('Streamer', function() {
           },
         });
         createDefaultStreamer();
-        return activeStreamer.connect().then(function() {
+        return activeStreamer.connect().then(function () {
           fakeWebSocket.notify({
             type: 'whoyouare',
             userid: testCase.websocketUserid,
@@ -452,14 +452,14 @@ describe('Streamer', function() {
     });
   });
 
-  describe('reconnections', function() {
-    it('resends configuration messages when a reconnection occurs', function() {
+  describe('reconnections', function () {
+    it('resends configuration messages when a reconnection occurs', function () {
       createDefaultStreamer();
-      return activeStreamer.connect().then(function() {
+      return activeStreamer.connect().then(function () {
         fakeWebSocket.messages = [];
         fakeWebSocket.emit('open');
 
-        const configMsgTypes = fakeWebSocket.messages.map(function(msg) {
+        const configMsgTypes = fakeWebSocket.messages.map(function (msg) {
           return msg.type || msg.messageType;
         });
         assert.deepEqual(configMsgTypes, ['client_id', 'whoami']);

--- a/src/sidebar/services/test/threads-test.js
+++ b/src/sidebar/services/test/threads-test.js
@@ -34,7 +34,7 @@ const NESTED_THREADS = {
   ],
 };
 
-describe('threadsService', function() {
+describe('threadsService', function () {
   let fakeStore;
   let service;
 

--- a/src/sidebar/services/test/toast-messenger-test.js
+++ b/src/sidebar/services/test/toast-messenger-test.js
@@ -1,6 +1,6 @@
 import toastMessenger from '../toast-messenger';
 
-describe('toastMessenger', function() {
+describe('toastMessenger', function () {
   let clock;
   let fakeStore;
   let service;

--- a/src/sidebar/store/debug-middleware.js
+++ b/src/sidebar/store/debug-middleware.js
@@ -12,8 +12,8 @@ export default function debugMiddleware(store) {
   /* eslint-disable no-console */
   let serial = 0;
 
-  return function(next) {
-    return function(action) {
+  return function (next) {
+    return function (action) {
       if (!window.debug) {
         next(action);
         return;

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -58,15 +58,15 @@ import viewer from './modules/viewer';
  * See http://redux.js.org/docs/advanced/Middleware.html
  */
 function angularDigestMiddleware($rootScope) {
-  return function(next) {
-    return function(action) {
+  return function (next) {
+    return function (action) {
       next(action);
 
       // '$$phase' is set if Angular is in the middle of a digest cycle already
       if (!$rootScope.$$phase) {
         // $applyAsync() is similar to $apply() but provides debouncing.
         // See http://stackoverflow.com/questions/30789177
-        $rootScope.$applyAsync(function() {});
+        $rootScope.$applyAsync(function () {});
       }
     };
   };

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -21,7 +21,7 @@ import route from './route';
 function excludeAnnotations(current, annotations) {
   const ids = {};
   const tags = {};
-  annotations.forEach(function(annot) {
+  annotations.forEach(function (annot) {
     if (annot.id) {
       ids[annot.id] = true;
     }
@@ -29,7 +29,7 @@ function excludeAnnotations(current, annotations) {
       tags[annot.$tag] = true;
     }
   });
-  return current.filter(function(annot) {
+  return current.filter(function (annot) {
     const shouldRemove =
       (annot.id && annot.id in ids) || (annot.$tag && annot.$tag in tags);
     return !shouldRemove;
@@ -37,13 +37,13 @@ function excludeAnnotations(current, annotations) {
 }
 
 function findByID(annotations, id) {
-  return annotations.find(function(annot) {
+  return annotations.find(function (annot) {
     return annot.id === id;
   });
 }
 
 function findByTag(annotations, tag) {
-  return annotations.find(function(annot) {
+  return annotations.find(function (annot) {
     return annot.$tag === tag;
   });
 }
@@ -87,7 +87,7 @@ function init() {
 }
 
 const update = {
-  ADD_ANNOTATIONS: function(state, action) {
+  ADD_ANNOTATIONS: function (state, action) {
     const updatedIDs = {};
     const updatedTags = {};
 
@@ -133,18 +133,18 @@ const update = {
     };
   },
 
-  REMOVE_ANNOTATIONS: function(state, action) {
+  REMOVE_ANNOTATIONS: function (state, action) {
     return {
       annotations: [...action.remainingAnnotations],
     };
   },
 
-  CLEAR_ANNOTATIONS: function() {
+  CLEAR_ANNOTATIONS: function () {
     return { annotations: [] };
   },
 
-  UPDATE_FLAG_STATUS: function(state, action) {
-    const annotations = state.annotations.map(function(annot) {
+  UPDATE_FLAG_STATUS: function (state, action) {
+    const annotations = state.annotations.map(function (annot) {
       const match = annot.id && annot.id === action.id;
       if (match) {
         if (annot.flagged === action.isFlagged) {
@@ -168,8 +168,8 @@ const update = {
     return { annotations: annotations };
   },
 
-  UPDATE_ANCHOR_STATUS: function(state, action) {
-    const annotations = state.annotations.map(function(annot) {
+  UPDATE_ANCHOR_STATUS: function (state, action) {
+    const annotations = state.annotations.map(function (annot) {
       if (!action.statusUpdates.hasOwnProperty(annot.$tag)) {
         return annot;
       }
@@ -184,8 +184,8 @@ const update = {
     return { annotations: annotations };
   },
 
-  HIDE_ANNOTATION: function(state, action) {
-    const anns = state.annotations.map(function(ann) {
+  HIDE_ANNOTATION: function (state, action) {
+    const anns = state.annotations.map(function (ann) {
       if (ann.id !== action.id) {
         return ann;
       }
@@ -194,8 +194,8 @@ const update = {
     return { annotations: anns };
   },
 
-  UNHIDE_ANNOTATION: function(state, action) {
-    const anns = state.annotations.map(function(ann) {
+  UNHIDE_ANNOTATION: function (state, action) {
+    const anns = state.annotations.map(function (ann) {
       if (ann.id !== action.id) {
         return ann;
       }
@@ -229,7 +229,7 @@ function updateFlagStatus(id, isFlagged) {
  * @param {Object}[] annotations - Array of annotation objects to add.
  */
 function addAnnotations(annotations) {
-  return function(dispatch, getState) {
+  return function (dispatch, getState) {
     const added = annotations.filter(annot => {
       return !findByID(getState().annotations.annotations, annot.id);
     });
@@ -347,14 +347,14 @@ function unhideAnnotation(id) {
  * @param {state} - The global app state
  */
 function savedAnnotations(state) {
-  return state.annotations.annotations.filter(function(ann) {
+  return state.annotations.annotations.filter(function (ann) {
     return !metadata.isNew(ann);
   });
 }
 
 /** Return true if the annotation with a given ID is currently loaded. */
 function annotationExists(state, id) {
-  return state.annotations.annotations.some(function(annot) {
+  return state.annotations.annotations.some(function (annot) {
     return annot.id === id;
   });
 }
@@ -369,7 +369,7 @@ function annotationExists(state, id) {
  */
 function findIDsForTags(state, tags) {
   const ids = [];
-  tags.forEach(function(tag) {
+  tags.forEach(function (tag) {
     const annot = findByTag(state.annotations.annotations, tag);
     if (annot && annot.id) {
       ids.push(annot.id);

--- a/src/sidebar/store/modules/defaults.js
+++ b/src/sidebar/store/modules/defaults.js
@@ -28,7 +28,7 @@ function init() {
 }
 
 const update = {
-  SET_DEFAULT: function(state, action) {
+  SET_DEFAULT: function (state, action) {
     return { [action.defaultKey]: action.value };
   },
 };

--- a/src/sidebar/store/modules/direct-linked.js
+++ b/src/sidebar/store/modules/direct-linked.js
@@ -62,7 +62,7 @@ const update = {
       directLinkedGroupId: null,
     };
   },
-  CLEAR_SELECTION: function() {
+  CLEAR_SELECTION: function () {
     return {
       directLinkedAnnotationId: null,
       directLinkedGroupId: null,

--- a/src/sidebar/store/modules/drafts.js
+++ b/src/sidebar/store/modules/drafts.js
@@ -53,16 +53,16 @@ export class Draft {
 /* Reducer */
 
 const update = {
-  DISCARD_ALL_DRAFTS: function() {
+  DISCARD_ALL_DRAFTS: function () {
     return [];
   },
-  REMOVE_DRAFT: function(state, action) {
+  REMOVE_DRAFT: function (state, action) {
     const drafts = state.filter(draft => {
       return !draft.match(action.annotation);
     });
     return drafts;
   },
-  UPDATE_DRAFT: function(state, action) {
+  UPDATE_DRAFT: function (state, action) {
     // removes a matching existing draft, then adds
     const drafts = state.filter(draft => {
       return !draft.match(action.draft.annotation);

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -8,16 +8,16 @@ function init() {
 }
 
 const update = {
-  CONNECT_FRAME: function(state, action) {
+  CONNECT_FRAME: function (state, action) {
     return [...state, action.frame];
   },
 
-  DESTROY_FRAME: function(state, action) {
+  DESTROY_FRAME: function (state, action) {
     return state.filter(f => f !== action.frame);
   },
 
-  UPDATE_FRAME_ANNOTATION_FETCH_STATUS: function(state, action) {
-    const frames = state.map(function(frame) {
+  UPDATE_FRAME_ANNOTATION_FETCH_STATUS: function (state, action) {
+    const frames = state.map(function (frame) {
       const match = frame.uri && frame.uri === action.uri;
       if (match) {
         return Object.assign({}, frame, {
@@ -87,13 +87,13 @@ function searchUrisForFrame(frame) {
   let uris = [frame.uri];
 
   if (frame.metadata && frame.metadata.documentFingerprint) {
-    uris = frame.metadata.link.map(function(link) {
+    uris = frame.metadata.link.map(function (link) {
       return link.href;
     });
   }
 
   if (frame.metadata && frame.metadata.link) {
-    frame.metadata.link.forEach(function(link) {
+    frame.metadata.link.forEach(function (link) {
       if (link.href.startsWith('doi:')) {
         uris.push(link.href);
       }
@@ -108,7 +108,7 @@ function searchUrisForFrame(frame) {
  * current page.
  */
 function searchUris(state) {
-  return state.frames.reduce(function(uris, frame) {
+  return state.frames.reduce(function (uris, frame) {
     return uris.concat(searchUrisForFrame(frame));
   }, []);
 }

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -130,7 +130,7 @@ function init(settings) {
 }
 
 const update = {
-  CLEAR_SELECTION: function(state) {
+  CLEAR_SELECTION: function (state) {
     let selectedTab = state.selectedTab;
     if (selectedTab === uiConstants.TAB_ORPHANS) {
       selectedTab = uiConstants.TAB_ANNOTATIONS;
@@ -143,19 +143,19 @@ const update = {
     };
   },
 
-  CLEAR_SELECTED_ANNOTATIONS: function() {
+  CLEAR_SELECTED_ANNOTATIONS: function () {
     return { filterQuery: null, selectedAnnotationMap: null };
   },
 
-  SELECT_ANNOTATIONS: function(state, action) {
+  SELECT_ANNOTATIONS: function (state, action) {
     return { selectedAnnotationMap: action.selection };
   },
 
-  FOCUS_ANNOTATIONS: function(state, action) {
+  FOCUS_ANNOTATIONS: function (state, action) {
     return { focusedAnnotationMap: action.focused };
   },
 
-  SET_FOCUS_MODE_FOCUSED: function(state, action) {
+  SET_FOCUS_MODE_FOCUSED: function (state, action) {
     return {
       focusMode: {
         ...state.focusMode,
@@ -164,7 +164,7 @@ const update = {
     };
   },
 
-  CHANGE_FOCUS_MODE_USER: function(state, action) {
+  CHANGE_FOCUS_MODE_USER: function (state, action) {
     if (action.user.username === undefined) {
       return {
         focusMode: {
@@ -187,19 +187,19 @@ const update = {
     }
   },
 
-  SET_FORCE_VISIBLE: function(state, action) {
+  SET_FORCE_VISIBLE: function (state, action) {
     return { forceVisible: action.forceVisible };
   },
 
-  SET_EXPANDED: function(state, action) {
+  SET_EXPANDED: function (state, action) {
     return { expanded: action.expanded };
   },
 
-  HIGHLIGHT_ANNOTATIONS: function(state, action) {
+  HIGHLIGHT_ANNOTATIONS: function (state, action) {
     return { highlighted: action.highlighted };
   },
 
-  SELECT_TAB: function(state, action) {
+  SELECT_TAB: function (state, action) {
     return setTab(state.selectedTab, action.tab);
   },
 
@@ -221,7 +221,7 @@ const update = {
     return {};
   },
 
-  REMOVE_ANNOTATIONS: function(state, action) {
+  REMOVE_ANNOTATIONS: function (state, action) {
     const selection = Object.assign({}, state.selectedAnnotationMap);
     action.annotationsToRemove.forEach(annotation => {
       if (annotation.id) {
@@ -241,7 +241,7 @@ const update = {
     };
   },
 
-  SET_FILTER_QUERY: function(state, action) {
+  SET_FILTER_QUERY: function (state, action) {
     return {
       filterQuery: action.query,
       forceVisible: {},
@@ -249,7 +249,7 @@ const update = {
     };
   },
 
-  SET_SORT_KEY: function(state, action) {
+  SET_SORT_KEY: function (state, action) {
     return { sortKey: action.key };
   },
 };
@@ -272,7 +272,7 @@ function selectAnnotations(ids) {
 
 /** Toggle whether annotations are selected or not. */
 function toggleSelectedAnnotations(ids) {
-  return function(dispatch, getState) {
+  return function (dispatch, getState) {
     const selection = Object.assign(
       {},
       getState().selection.selectedAnnotationMap
@@ -299,7 +299,7 @@ function toggleSelectedAnnotations(ids) {
 function setForceVisible(id, visible) {
   // FIXME: This should be converted to a plain action and accessing the state
   // should happen in the update() function
-  return function(dispatch, getState) {
+  return function (dispatch, getState) {
     const forceVisible = Object.assign({}, getState().selection.forceVisible);
     forceVisible[id] = visible;
     dispatch({
@@ -324,7 +324,7 @@ function focusAnnotations(tags) {
 function setCollapsed(id, collapsed) {
   // FIXME: This should be converted to a plain action and accessing the state
   // should happen in the update() function
-  return function(dispatch, getState) {
+  return function (dispatch, getState) {
     const expanded = Object.assign({}, getState().selection.expanded);
     expanded[id] = !collapsed;
     dispatch({

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -17,7 +17,7 @@ function init() {
 }
 
 const update = {
-  UPDATE_SESSION: function(state, action) {
+  UPDATE_SESSION: function (state, action) {
     return {
       ...action.session,
     };

--- a/src/sidebar/store/modules/sidebar-panels.js
+++ b/src/sidebar/store/modules/sidebar-panels.js
@@ -27,11 +27,11 @@ function init() {
 }
 
 const update = {
-  OPEN_SIDEBAR_PANEL: function(state, action) {
+  OPEN_SIDEBAR_PANEL: function (state, action) {
     return { activePanelName: action.panelName };
   },
 
-  CLOSE_SIDEBAR_PANEL: function(state, action) {
+  CLOSE_SIDEBAR_PANEL: function (state, action) {
     let activePanelName = state.activePanelName;
     if (action.panelName === activePanelName) {
       // `action.panelName` is indeed the currently-active panel; deactivate
@@ -43,7 +43,7 @@ const update = {
     };
   },
 
-  TOGGLE_SIDEBAR_PANEL: function(state, action) {
+  TOGGLE_SIDEBAR_PANEL: function (state, action) {
     let activePanelName;
     // Is the panel in question currently the active panel?
     const panelIsActive = state.activePanelName === action.panelName;

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -13,8 +13,8 @@ function createTestStore() {
 // Tests for most of the functionality in reducers/annotations.js are currently
 // in the tests for the whole Redux store
 
-describe('sidebar/store/modules/annotations', function() {
-  describe('#addAnnotations()', function() {
+describe('sidebar/store/modules/annotations', function () {
+  describe('#addAnnotations()', function () {
     const ANCHOR_TIME_LIMIT = 1000;
     let clock;
     let store;
@@ -27,17 +27,17 @@ describe('sidebar/store/modules/annotations', function() {
       return storeAnn.$tag;
     }
 
-    beforeEach(function() {
+    beforeEach(function () {
       clock = sinon.useFakeTimers();
       store = createTestStore();
       store.changeRoute('sidebar', {});
     });
 
-    afterEach(function() {
+    afterEach(function () {
       clock.restore();
     });
 
-    it('adds annotations not in the store', function() {
+    it('adds annotations not in the store', function () {
       const annot = fixtures.defaultAnnotation();
       store.addAnnotations([annot]);
       assert.match(store.getState().annotations.annotations, [
@@ -45,20 +45,20 @@ describe('sidebar/store/modules/annotations', function() {
       ]);
     });
 
-    it('assigns a local tag to annotations', function() {
+    it('assigns a local tag to annotations', function () {
       const annotA = Object.assign(fixtures.defaultAnnotation(), { id: 'a1' });
       const annotB = Object.assign(fixtures.defaultAnnotation(), { id: 'a2' });
 
       store.addAnnotations([annotA, annotB]);
 
-      const tags = store.getState().annotations.annotations.map(function(a) {
+      const tags = store.getState().annotations.annotations.map(function (a) {
         return a.$tag;
       });
 
       assert.deepEqual(tags, ['t1', 't2']);
     });
 
-    it('updates annotations with matching IDs in the store', function() {
+    it('updates annotations with matching IDs in the store', function () {
       const annot = fixtures.defaultAnnotation();
       store.addAnnotations([annot]);
       const update = Object.assign({}, fixtures.defaultAnnotation(), {
@@ -70,7 +70,7 @@ describe('sidebar/store/modules/annotations', function() {
       assert.equal(updatedAnnot.text, 'update');
     });
 
-    it('updates annotations with matching tags in the store', function() {
+    it('updates annotations with matching tags in the store', function () {
       const annot = fixtures.newAnnotation();
       annot.$tag = 'local-tag';
       store.addAnnotations([annot]);
@@ -83,7 +83,7 @@ describe('sidebar/store/modules/annotations', function() {
       assert.equal(annots[0].id, 'server-id');
     });
 
-    it('preserves anchoring status of updated annotations', function() {
+    it('preserves anchoring status of updated annotations', function () {
       const annot = fixtures.defaultAnnotation();
       store.addAnnotations([annot]);
       store.updateAnchorStatus({ [tagForID(annot.id)]: 'anchored' });
@@ -97,7 +97,7 @@ describe('sidebar/store/modules/annotations', function() {
       assert.isFalse(updatedAnnot.$orphan);
     });
 
-    it('sets the timeout flag on annotations that fail to anchor within a time limit', function() {
+    it('sets the timeout flag on annotations that fail to anchor within a time limit', function () {
       const annot = fixtures.defaultAnnotation();
       store.addAnnotations([annot]);
 
@@ -106,7 +106,7 @@ describe('sidebar/store/modules/annotations', function() {
       assert.isTrue(store.getState().annotations.annotations[0].$anchorTimeout);
     });
 
-    it('does not set the timeout flag on annotations that do anchor within a time limit', function() {
+    it('does not set the timeout flag on annotations that do anchor within a time limit', function () {
       const annot = fixtures.defaultAnnotation();
       store.addAnnotations([annot]);
       store.updateAnchorStatus({ [tagForID(annot.id)]: 'anchored' });
@@ -118,19 +118,19 @@ describe('sidebar/store/modules/annotations', function() {
       );
     });
 
-    it('does not attempt to modify orphan status if annotations are removed before anchoring timeout expires', function() {
+    it('does not attempt to modify orphan status if annotations are removed before anchoring timeout expires', function () {
       const annot = fixtures.defaultAnnotation();
       store.addAnnotations([annot]);
       store.updateAnchorStatus({ [tagForID(annot.id)]: 'anchored' });
       store.removeAnnotations([annot]);
 
-      assert.doesNotThrow(function() {
+      assert.doesNotThrow(function () {
         clock.tick(ANCHOR_TIME_LIMIT);
       });
     });
 
-    it('does not expect annotations to anchor on the stream', function() {
-      const isOrphan = function() {
+    it('does not expect annotations to anchor on the stream', function () {
+      const isOrphan = function () {
         return !!metadata.isOrphan(store.getState().annotations.annotations[0]);
       };
 
@@ -143,7 +143,7 @@ describe('sidebar/store/modules/annotations', function() {
       assert.isFalse(isOrphan());
     });
 
-    it('initializes the $orphan field for new annotations', function() {
+    it('initializes the $orphan field for new annotations', function () {
       store.addAnnotations([fixtures.newAnnotation()]);
       assert.isFalse(store.getState().annotations.annotations[0].$orphan);
     });
@@ -289,10 +289,10 @@ describe('sidebar/store/modules/annotations', function() {
     });
   });
 
-  describe('#savedAnnotations', function() {
+  describe('#savedAnnotations', function () {
     const savedAnnotations = selectors.savedAnnotations;
 
-    it('returns annotations which are saved', function() {
+    it('returns annotations which are saved', function () {
       const state = {
         annotations: {
           annotations: [fixtures.newAnnotation(), fixtures.defaultAnnotation()],
@@ -302,10 +302,10 @@ describe('sidebar/store/modules/annotations', function() {
     });
   });
 
-  describe('#findIDsForTags', function() {
+  describe('#findIDsForTags', function () {
     const findIDsForTags = selectors.findIDsForTags;
 
-    it('returns the IDs corresponding to the provided local tags', function() {
+    it('returns the IDs corresponding to the provided local tags', function () {
       const ann = fixtures.defaultAnnotation();
       const state = {
         annotations: {
@@ -315,7 +315,7 @@ describe('sidebar/store/modules/annotations', function() {
       assert.deepEqual(findIDsForTags(state, ['t1']), [ann.id]);
     });
 
-    it('does not return IDs for annotations that do not have an ID', function() {
+    it('does not return IDs for annotations that do not have an ID', function () {
       const ann = fixtures.newAnnotation();
       const state = {
         annotations: {
@@ -326,8 +326,8 @@ describe('sidebar/store/modules/annotations', function() {
     });
   });
 
-  describe('#hideAnnotation', function() {
-    it('sets the `hidden` state to `true`', function() {
+  describe('#hideAnnotation', function () {
+    it('sets the `hidden` state to `true`', function () {
       const store = createTestStore();
       const ann = fixtures.moderatedAnnotation({ hidden: false });
 
@@ -339,8 +339,8 @@ describe('sidebar/store/modules/annotations', function() {
     });
   });
 
-  describe('#unhideAnnotation', function() {
-    it('sets the `hidden` state to `false`', function() {
+  describe('#unhideAnnotation', function () {
+    it('sets the `hidden` state to `false`', function () {
       const store = createTestStore();
       const ann = fixtures.moderatedAnnotation({ hidden: true });
 
@@ -352,8 +352,8 @@ describe('sidebar/store/modules/annotations', function() {
     });
   });
 
-  describe('#removeAnnotations', function() {
-    it('removes the annotation', function() {
+  describe('#removeAnnotations', function () {
+    it('removes the annotation', function () {
       const store = createTestStore();
       const ann = fixtures.defaultAnnotation();
       store.dispatch(actions.addAnnotations([ann]));
@@ -362,7 +362,7 @@ describe('sidebar/store/modules/annotations', function() {
     });
   });
 
-  describe('#updateFlagStatus', function() {
+  describe('#updateFlagStatus', function () {
     [
       {
         description: 'non-moderator flags annotation',

--- a/src/sidebar/store/modules/test/defaults-test.js
+++ b/src/sidebar/store/modules/test/defaults-test.js
@@ -1,7 +1,7 @@
 import createStore from '../../create-store';
 import defaults from '../defaults';
 
-describe('store/modules/defaults', function() {
+describe('store/modules/defaults', function () {
   let store;
 
   beforeEach(() => {
@@ -9,7 +9,7 @@ describe('store/modules/defaults', function() {
   });
 
   describe('actions', () => {
-    describe('#setDefault', function() {
+    describe('#setDefault', function () {
       it('should update the indicated default with the new value', () => {
         const beforePrivacy = store.getDefault('annotationPrivacy');
         store.setDefault('annotationPrivacy', 'private');

--- a/src/sidebar/store/modules/test/frames-test.js
+++ b/src/sidebar/store/modules/test/frames-test.js
@@ -1,7 +1,7 @@
 import createStore from '../../create-store';
 import frames from '../frames';
 
-describe('sidebar/store/modules/frames', function() {
+describe('sidebar/store/modules/frames', function () {
   let store;
 
   beforeEach(() => {
@@ -9,16 +9,16 @@ describe('sidebar/store/modules/frames', function() {
     store = createStore([frames]);
   });
 
-  describe('#connectFrame', function() {
-    it('adds the frame to the list of connected frames', function() {
+  describe('#connectFrame', function () {
+    it('adds the frame to the list of connected frames', function () {
       const frame = { uri: 'http://example.com' };
       store.connectFrame(frame);
       assert.deepEqual(store.frames(), [frame]);
     });
   });
 
-  describe('#destroyFrame', function() {
-    it('removes the frame from the list of connected frames', function() {
+  describe('#destroyFrame', function () {
+    it('removes the frame from the list of connected frames', function () {
       const frameList = [
         { uri: 'http://example.com' },
         { uri: 'http://example.org' },
@@ -30,8 +30,8 @@ describe('sidebar/store/modules/frames', function() {
     });
   });
 
-  describe('#updateFrameAnnotationFetchStatus', function() {
-    it('updates the isAnnotationFetchComplete status of the frame', function() {
+  describe('#updateFrameAnnotationFetchStatus', function () {
+    it('updates the isAnnotationFetchComplete status of the frame', function () {
       const frame = {
         uri: 'http://example.com',
       };
@@ -44,7 +44,7 @@ describe('sidebar/store/modules/frames', function() {
       assert.deepEqual(store.frames(), [expectedFrame]);
     });
 
-    it('does not update the isAnnotationFetchComplete status of the wrong frame', function() {
+    it('does not update the isAnnotationFetchComplete status of the wrong frame', function () {
       const frame = {
         uri: 'http://example.com',
       };
@@ -82,7 +82,7 @@ describe('sidebar/store/modules/frames', function() {
     });
   });
 
-  describe('#searchUris', function() {
+  describe('#searchUris', function () {
     [
       {
         when: 'one HTML frame',

--- a/src/sidebar/store/modules/test/links-test.js
+++ b/src/sidebar/store/modules/test/links-test.js
@@ -4,15 +4,15 @@ const init = links.init;
 const update = links.update.UPDATE_LINKS;
 const action = links.actions.updateLinks;
 
-describe('sidebar/store/modules/links', function() {
-  describe('#init()', function() {
-    it('returns a null links object', function() {
+describe('sidebar/store/modules/links', function () {
+  describe('#init()', function () {
+    it('returns a null links object', function () {
       assert.deepEqual(init(), null);
     });
   });
 
-  describe('#update.UPDATE_LINKS()', function() {
-    it('returns the given newLinks as the links object', function() {
+  describe('#update.UPDATE_LINKS()', function () {
+    it('returns the given newLinks as the links object', function () {
       assert.deepEqual(
         update('CURRENT_STATE', { newLinks: { NEW_LINK: 'http://new_link' } }),
         { NEW_LINK: 'http://new_link' }
@@ -20,8 +20,8 @@ describe('sidebar/store/modules/links', function() {
     });
   });
 
-  describe('#actions.updateLinks()', function() {
-    it('returns an UPDATE_LINKS action object for the given newLinks', function() {
+  describe('#actions.updateLinks()', function () {
+    it('returns an UPDATE_LINKS action object for the given newLinks', function () {
       assert.deepEqual(action({ NEW_LINK: 'http://new_link' }), {
         type: 'UPDATE_LINKS',
         newLinks: { NEW_LINK: 'http://new_link' },

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -16,34 +16,34 @@ describe('sidebar/store/modules/selection', () => {
     store = createStore([annotations, selection], fakeSettings);
   });
 
-  describe('getFirstSelectedAnnotationId', function() {
-    it('returns the first selected annotation id it finds', function() {
+  describe('getFirstSelectedAnnotationId', function () {
+    it('returns the first selected annotation id it finds', function () {
       store.selectAnnotations([1, 2]);
       assert.equal(store.getFirstSelectedAnnotationId(), 1);
     });
 
-    it('returns null if no selected annotation ids are found', function() {
+    it('returns null if no selected annotation ids are found', function () {
       store.selectAnnotations([]);
       assert.isNull(store.getFirstSelectedAnnotationId());
     });
   });
 
-  describe('setForceVisible()', function() {
-    it('sets the visibility of the annotation', function() {
+  describe('setForceVisible()', function () {
+    it('sets the visibility of the annotation', function () {
       store.setForceVisible('id1', true);
       assert.deepEqual(getSelectionState().forceVisible, { id1: true });
     });
   });
 
-  describe('setCollapsed()', function() {
-    it('sets the expanded state of the annotation', function() {
+  describe('setCollapsed()', function () {
+    it('sets the expanded state of the annotation', function () {
       store.setCollapsed('parent_id', false);
       assert.deepEqual(getSelectionState().expanded, { parent_id: true });
     });
   });
 
-  describe('focusAnnotations()', function() {
-    it('adds the passed annotations to the focusedAnnotationMap', function() {
+  describe('focusAnnotations()', function () {
+    it('adds the passed annotations to the focusedAnnotationMap', function () {
       store.focusAnnotations([1, 2, 3]);
       assert.deepEqual(getSelectionState().focusedAnnotationMap, {
         1: true,
@@ -52,7 +52,7 @@ describe('sidebar/store/modules/selection', () => {
       });
     });
 
-    it('replaces any annotations originally in the map', function() {
+    it('replaces any annotations originally in the map', function () {
       store.focusAnnotations([1]);
       store.focusAnnotations([2, 3]);
       assert.deepEqual(getSelectionState().focusedAnnotationMap, {
@@ -61,53 +61,53 @@ describe('sidebar/store/modules/selection', () => {
       });
     });
 
-    it('nulls the map if no annotations are focused', function() {
+    it('nulls the map if no annotations are focused', function () {
       store.focusAnnotations([1]);
       store.focusAnnotations([]);
       assert.isNull(getSelectionState().focusedAnnotationMap);
     });
   });
 
-  describe('hasSelectedAnnotations', function() {
-    it('returns true if there are any selected annotations', function() {
+  describe('hasSelectedAnnotations', function () {
+    it('returns true if there are any selected annotations', function () {
       store.selectAnnotations([1]);
       assert.isTrue(store.hasSelectedAnnotations());
     });
 
-    it('returns false if there are no selected annotations', function() {
+    it('returns false if there are no selected annotations', function () {
       assert.isFalse(store.hasSelectedAnnotations());
     });
   });
 
-  describe('filterQuery', function() {
-    it('returns the filterQuery value when provided', function() {
+  describe('filterQuery', function () {
+    it('returns the filterQuery value when provided', function () {
       store.setFilterQuery('tag:foo');
       assert.equal(store.filterQuery(), 'tag:foo');
     });
 
-    it('returns null when no filterQuery is present', function() {
+    it('returns null when no filterQuery is present', function () {
       assert.isNull(store.filterQuery());
     });
   });
 
-  describe('isAnnotationSelected', function() {
-    it('returns true if the id provided is selected', function() {
+  describe('isAnnotationSelected', function () {
+    it('returns true if the id provided is selected', function () {
       store.selectAnnotations([1]);
       assert.isTrue(store.isAnnotationSelected(1));
     });
 
-    it('returns false if the id provided is not selected', function() {
+    it('returns false if the id provided is not selected', function () {
       store.selectAnnotations([1]);
       assert.isFalse(store.isAnnotationSelected(2));
     });
 
-    it('returns false if there are no selected annotations', function() {
+    it('returns false if there are no selected annotations', function () {
       assert.isFalse(store.isAnnotationSelected(1));
     });
   });
 
-  describe('selectAnnotations()', function() {
-    it('adds the passed annotations to the selectedAnnotationMap', function() {
+  describe('selectAnnotations()', function () {
+    it('adds the passed annotations to the selectedAnnotationMap', function () {
       store.selectAnnotations([1, 2, 3]);
       assert.deepEqual(getSelectionState().selectedAnnotationMap, {
         1: true,
@@ -116,7 +116,7 @@ describe('sidebar/store/modules/selection', () => {
       });
     });
 
-    it('replaces any annotations originally in the map', function() {
+    it('replaces any annotations originally in the map', function () {
       store.selectAnnotations([1]);
       store.selectAnnotations([2, 3]);
       assert.deepEqual(getSelectionState().selectedAnnotationMap, {
@@ -125,15 +125,15 @@ describe('sidebar/store/modules/selection', () => {
       });
     });
 
-    it('nulls the map if no annotations are selected', function() {
+    it('nulls the map if no annotations are selected', function () {
       store.selectAnnotations([1]);
       store.selectAnnotations([]);
       assert.isNull(getSelectionState().selectedAnnotationMap);
     });
   });
 
-  describe('toggleSelectedAnnotations()', function() {
-    it('adds annotations missing from the selectedAnnotationMap', function() {
+  describe('toggleSelectedAnnotations()', function () {
+    it('adds annotations missing from the selectedAnnotationMap', function () {
       store.selectAnnotations([1, 2]);
       store.toggleSelectedAnnotations([3, 4]);
       assert.deepEqual(getSelectionState().selectedAnnotationMap, {
@@ -144,7 +144,7 @@ describe('sidebar/store/modules/selection', () => {
       });
     });
 
-    it('removes annotations already in the selectedAnnotationMap', function() {
+    it('removes annotations already in the selectedAnnotationMap', function () {
       store.selectAnnotations([1, 3]);
       store.toggleSelectedAnnotations([1, 2]);
       assert.deepEqual(getSelectionState().selectedAnnotationMap, {
@@ -153,15 +153,15 @@ describe('sidebar/store/modules/selection', () => {
       });
     });
 
-    it('nulls the map if no annotations are selected', function() {
+    it('nulls the map if no annotations are selected', function () {
       store.selectAnnotations([1]);
       store.toggleSelectedAnnotations([1]);
       assert.isNull(getSelectionState().selectedAnnotationMap);
     });
   });
 
-  describe('#REMOVE_ANNOTATIONS', function() {
-    it('removing an annotation should also remove it from selectedAnnotationMap', function() {
+  describe('#REMOVE_ANNOTATIONS', function () {
+    it('removing an annotation should also remove it from selectedAnnotationMap', function () {
       store.selectAnnotations([1, 2, 3]);
       store.removeAnnotations([{ id: 2 }]);
       assert.deepEqual(getSelectionState().selectedAnnotationMap, {
@@ -171,27 +171,27 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('clearSelectedAnnotations()', function() {
-    it('removes all annotations from the selection', function() {
+  describe('clearSelectedAnnotations()', function () {
+    it('removes all annotations from the selection', function () {
       store.selectAnnotations([1]);
       store.clearSelectedAnnotations();
       assert.isNull(getSelectionState().selectedAnnotationMap);
     });
 
-    it('clears the current search query', function() {
+    it('clears the current search query', function () {
       store.setFilterQuery('foo');
       store.clearSelectedAnnotations();
       assert.isNull(getSelectionState().filterQuery);
     });
   });
 
-  describe('setFilterQuery()', function() {
-    it('sets the filter query', function() {
+  describe('setFilterQuery()', function () {
+    it('sets the filter query', function () {
       store.setFilterQuery('a-query');
       assert.equal(getSelectionState().filterQuery, 'a-query');
     });
 
-    it('resets the force-visible and expanded sets', function() {
+    it('resets the force-visible and expanded sets', function () {
       store.setForceVisible('123', true);
       store.setCollapsed('456', false);
       store.setFilterQuery('some-query');
@@ -200,8 +200,8 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('changeFocusModeUser()', function() {
-    it('sets the focused user and enables focus mode', function() {
+  describe('changeFocusModeUser()', function () {
+    it('sets the focused user and enables focus mode', function () {
       store.setFocusModeFocused(false);
       store.changeFocusModeUser({
         username: 'testuser',
@@ -220,7 +220,7 @@ describe('sidebar/store/modules/selection', () => {
     // https://github.com/hypothesis/lms/blob/d6b88fd7e375a4b23899117556b3e39cfe18986b/lms/static/scripts/frontend_apps/components/LMSGrader.js#L46
     //
     // This is the LMS app's way of asking the client to disable focus mode.
-    it('disables focus mode if username is undefined', function() {
+    it('disables focus mode if username is undefined', function () {
       store.setFocusModeFocused(true);
       store.changeFocusModeUser({
         username: undefined,
@@ -231,37 +231,37 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('setFocusModeFocused()', function() {
-    it('sets the focus mode to enabled', function() {
+  describe('setFocusModeFocused()', function () {
+    it('sets the focus mode to enabled', function () {
       store.setFocusModeFocused(true);
       assert.equal(getSelectionState().focusMode.focused, true);
     });
 
-    it('sets the focus mode to not enabled', function() {
+    it('sets the focus mode to not enabled', function () {
       store = createStore([selection], [{ focus: { user: {} } }]);
       store.setFocusModeFocused(false);
       assert.equal(getSelectionState().focusMode.focused, false);
     });
   });
 
-  describe('focusModeEnabled()', function() {
-    it('should be true when the focus setting is present', function() {
+  describe('focusModeEnabled()', function () {
+    it('should be true when the focus setting is present', function () {
       store = createStore([selection], [{ focus: { user: {} } }]);
       assert.equal(store.focusModeEnabled(), true);
     });
-    it('should be false when the focus setting is not present', function() {
+    it('should be false when the focus setting is not present', function () {
       assert.equal(store.focusModeEnabled(), false);
     });
   });
 
-  describe('focusModeFocused()', function() {
-    it('should return true by default when focus mode is enabled', function() {
+  describe('focusModeFocused()', function () {
+    it('should return true by default when focus mode is enabled', function () {
       store = createStore([selection], [{ focus: { user: {} } }]);
       assert.equal(getSelectionState().focusMode.enabled, true);
       assert.equal(getSelectionState().focusMode.focused, true);
       assert.equal(store.focusModeFocused(), true);
     });
-    it('should return false by default when focus mode is not enabled', function() {
+    it('should return false by default when focus mode is not enabled', function () {
       assert.equal(getSelectionState().focusMode.enabled, false);
       assert.equal(getSelectionState().focusMode.focused, true);
       assert.equal(store.focusModeFocused(), false);
@@ -289,29 +289,29 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('focusModeUserPrettyName()', function() {
-    it('returns false by default when focus mode is not enabled', function() {
+  describe('focusModeUserPrettyName()', function () {
+    it('returns false by default when focus mode is not enabled', function () {
       store = createStore(
         [selection],
         [{ focus: { user: { displayName: 'FakeDisplayName' } } }]
       );
       assert.equal(store.focusModeUserPrettyName(), 'FakeDisplayName');
     });
-    it('returns the userid when displayName is missing', function() {
+    it('returns the userid when displayName is missing', function () {
       store = createStore(
         [selection],
         [{ focus: { user: { userid: 'acct:userid@authority' } } }]
       );
       assert.equal(store.focusModeUserPrettyName(), 'acct:userid@authority');
     });
-    it('returns an empty string when user object has is empty', function() {
+    it('returns an empty string when user object has is empty', function () {
       store = createStore([selection], [{ focus: { user: {} } }]);
       assert.equal(store.focusModeUserPrettyName(), '');
     });
-    it('return an empty string when there is no focus object', function() {
+    it('return an empty string when there is no focus object', function () {
       assert.equal(store.focusModeUserPrettyName(), '');
     });
-    it('returns the username when displayName and userid is missing', function() {
+    it('returns the username when displayName and userid is missing', function () {
       // remove once LMS no longer sends username in RPC or config
       // https://github.com/hypothesis/client/issues/1516
       store = createStore(
@@ -322,22 +322,22 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('focusModeUserId()', function() {
-    it('should return the userid when present', function() {
+  describe('focusModeUserId()', function () {
+    it('should return the userid when present', function () {
       store = createStore(
         [selection],
         [{ focus: { user: { userid: 'acct:userid@authority' } } }]
       );
       assert.equal(store.focusModeUserId(), 'acct:userid@authority');
     });
-    it('should return null when the userid is not present', function() {
+    it('should return null when the userid is not present', function () {
       store = createStore([selection], [{ focus: { user: {} } }]);
       assert.isNull(store.focusModeUserId());
     });
-    it('should return null when the user object is not present', function() {
+    it('should return null when the user object is not present', function () {
       assert.isNull(store.focusModeUserId());
     });
-    it('should return the username when present but no userid', function() {
+    it('should return the username when present but no userid', function () {
       // remove once LMS no longer sends username in RPC or config
       // https://github.com/hypothesis/client/issues/1516
       store = createStore(
@@ -348,15 +348,15 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('highlightAnnotations()', function() {
-    it('sets the highlighted annotations', function() {
+  describe('highlightAnnotations()', function () {
+    it('sets the highlighted annotations', function () {
       store.highlightAnnotations(['id1', 'id2']);
       assert.deepEqual(getSelectionState().highlighted, ['id1', 'id2']);
     });
   });
 
-  describe('selectTab()', function() {
-    it('sets the selected tab', function() {
+  describe('selectTab()', function () {
+    it('sets the selected tab', function () {
       store.selectTab(uiConstants.TAB_ANNOTATIONS);
       assert.equal(
         getSelectionState().selectedTab,
@@ -364,7 +364,7 @@ describe('sidebar/store/modules/selection', () => {
       );
     });
 
-    it('ignores junk tag names', function() {
+    it('ignores junk tag names', function () {
       store.selectTab('flibbertigibbert');
       assert.equal(
         getSelectionState().selectedTab,
@@ -372,7 +372,7 @@ describe('sidebar/store/modules/selection', () => {
       );
     });
 
-    it('allows sorting annotations by time and document location', function() {
+    it('allows sorting annotations by time and document location', function () {
       store.selectTab(uiConstants.TAB_ANNOTATIONS);
       assert.deepEqual(getSelectionState().sortKeysAvailable, [
         'Newest',
@@ -381,7 +381,7 @@ describe('sidebar/store/modules/selection', () => {
       ]);
     });
 
-    it('allows sorting page notes by time', function() {
+    it('allows sorting page notes by time', function () {
       store.selectTab(uiConstants.TAB_NOTES);
       assert.deepEqual(getSelectionState().sortKeysAvailable, [
         'Newest',
@@ -389,7 +389,7 @@ describe('sidebar/store/modules/selection', () => {
       ]);
     });
 
-    it('allows sorting orphans by time and document location', function() {
+    it('allows sorting orphans by time and document location', function () {
       store.selectTab(uiConstants.TAB_ORPHANS);
       assert.deepEqual(getSelectionState().sortKeysAvailable, [
         'Newest',
@@ -398,22 +398,22 @@ describe('sidebar/store/modules/selection', () => {
       ]);
     });
 
-    it('sorts annotations by document location by default', function() {
+    it('sorts annotations by document location by default', function () {
       store.selectTab(uiConstants.TAB_ANNOTATIONS);
       assert.deepEqual(getSelectionState().sortKey, 'Location');
     });
 
-    it('sorts page notes from oldest to newest by default', function() {
+    it('sorts page notes from oldest to newest by default', function () {
       store.selectTab(uiConstants.TAB_NOTES);
       assert.deepEqual(getSelectionState().sortKey, 'Oldest');
     });
 
-    it('sorts orphans by document location by default', function() {
+    it('sorts orphans by document location by default', function () {
       store.selectTab(uiConstants.TAB_ORPHANS);
       assert.deepEqual(getSelectionState().sortKey, 'Location');
     });
 
-    it('does not reset the sort key unless necessary', function() {
+    it('does not reset the sort key unless necessary', function () {
       // Select the tab, setting sort key to 'Oldest', and then manually
       // override the sort key.
       store.selectTab(uiConstants.TAB_NOTES);

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -3,15 +3,15 @@ import session from '../session';
 
 const { init } = session;
 
-describe('sidebar/store/modules/session', function() {
+describe('sidebar/store/modules/session', function () {
   let store;
 
   beforeEach(() => {
     store = createStore([session]);
   });
 
-  describe('#updateSession', function() {
-    it('updates the session state', function() {
+  describe('#updateSession', function () {
+    it('updates the session state', function () {
       const newSession = Object.assign(init(), { userid: 'john' });
       store.updateSession({ userid: 'john' });
       assert.deepEqual(store.getState().session, newSession);

--- a/src/sidebar/store/modules/test/toast-messages-test.js
+++ b/src/sidebar/store/modules/test/toast-messages-test.js
@@ -1,7 +1,7 @@
 import createStore from '../../create-store';
 import toastMessages from '../toast-messages';
 
-describe('store/modules/toast-messages', function() {
+describe('store/modules/toast-messages', function () {
   let store;
   let fakeToastMessage;
 

--- a/src/sidebar/store/modules/test/viewer-test.js
+++ b/src/sidebar/store/modules/test/viewer-test.js
@@ -1,20 +1,20 @@
 import createStore from '../../create-store';
 import viewer from '../viewer';
 
-describe('store/modules/viewer', function() {
+describe('store/modules/viewer', function () {
   let store;
 
   beforeEach(() => {
     store = createStore([viewer]);
   });
 
-  describe('#setShowHighlights', function() {
-    it('sets a flag indicating that highlights are visible', function() {
+  describe('#setShowHighlights', function () {
+    it('sets a flag indicating that highlights are visible', function () {
       store.setShowHighlights(true);
       assert.isTrue(store.getState().viewer.visibleHighlights);
     });
 
-    it('sets a flag indicating that highlights are not visible', function() {
+    it('sets a flag indicating that highlights are not visible', function () {
       store.setShowHighlights(false);
       assert.isFalse(store.getState().viewer.visibleHighlights);
     });

--- a/src/sidebar/store/modules/toast-messages.js
+++ b/src/sidebar/store/modules/toast-messages.js
@@ -12,20 +12,20 @@ function init() {
 }
 
 const update = {
-  ADD_MESSAGE: function(state, action) {
+  ADD_MESSAGE: function (state, action) {
     return {
       messages: state.messages.concat({ ...action.message }),
     };
   },
 
-  REMOVE_MESSAGE: function(state, action) {
+  REMOVE_MESSAGE: function (state, action) {
     const updatedMessages = state.messages.filter(
       message => message.id !== action.id
     );
     return { messages: updatedMessages };
   },
 
-  UPDATE_MESSAGE: function(state, action) {
+  UPDATE_MESSAGE: function (state, action) {
     const updatedMessages = state.messages.map(message => {
       if (message.id && message.id === action.message.id) {
         return { ...action.message };

--- a/src/sidebar/store/modules/viewer.js
+++ b/src/sidebar/store/modules/viewer.js
@@ -12,7 +12,7 @@ function init() {
 }
 
 const update = {
-  SET_HIGHLIGHTS_VISIBLE: function(state, action) {
+  SET_HIGHLIGHTS_VISIBLE: function (state, action) {
     return { visibleHighlights: action.visible };
   },
 };

--- a/src/sidebar/store/test/debug-middleware-test.js
+++ b/src/sidebar/store/test/debug-middleware-test.js
@@ -8,10 +8,10 @@ function id(state) {
   return state;
 }
 
-describe('debug middleware', function() {
+describe('debug middleware', function () {
   let store;
 
-  beforeEach(function() {
+  beforeEach(function () {
     sinon.stub(console, 'log');
     sinon.stub(console, 'group');
     sinon.stub(console, 'groupEnd');
@@ -20,7 +20,7 @@ describe('debug middleware', function() {
     store = redux.createStore(id, {}, enhancer);
   });
 
-  afterEach(function() {
+  afterEach(function () {
     console.log.restore();
     console.group.restore();
     console.groupEnd.restore();
@@ -28,13 +28,13 @@ describe('debug middleware', function() {
     delete window.debug;
   });
 
-  it('logs app state changes when "window.debug" is truthy', function() {
+  it('logs app state changes when "window.debug" is truthy', function () {
     window.debug = true;
     store.dispatch({ type: 'SOMETHING_HAPPENED' });
     assert.called(console.log);
   });
 
-  it('logs nothing when "window.debug" is falsey', function() {
+  it('logs nothing when "window.debug" is falsey', function () {
     store.dispatch({ type: 'SOMETHING_HAPPENED' });
     assert.notCalled(console.log);
   });

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -17,7 +17,7 @@ const fixtures = immutable({
   ],
 });
 
-describe('store', function() {
+describe('store', function () {
   let store;
   let fakeRootScope;
 
@@ -29,25 +29,25 @@ describe('store', function() {
     return storeAnn.$tag;
   }
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeRootScope = { $applyAsync: sinon.stub() };
     store = storeFactory(fakeRootScope, {});
   });
 
-  describe('initialization', function() {
-    it('does not set a selection when settings.annotations is null', function() {
+  describe('initialization', function () {
+    it('does not set a selection when settings.annotations is null', function () {
       assert.isFalse(store.hasSelectedAnnotations());
       assert.equal(Object.keys(store.getState().selection.expanded).length, 0);
     });
 
-    it('sets the selection when settings.annotations is set', function() {
+    it('sets the selection when settings.annotations is set', function () {
       store = storeFactory(fakeRootScope, { annotations: 'testid' });
       assert.deepEqual(store.getState().selection.selectedAnnotationMap, {
         testid: true,
       });
     });
 
-    it('expands the selected annotations when settings.annotations is set', function() {
+    it('expands the selected annotations when settings.annotations is set', function () {
       store = storeFactory(fakeRootScope, { annotations: 'testid' });
       assert.deepEqual(store.getState().selection.expanded, {
         testid: true,
@@ -120,35 +120,35 @@ describe('store', function() {
     });
   });
 
-  describe('#removeAnnotations()', function() {
-    it('removes annotations from the current state', function() {
+  describe('#removeAnnotations()', function () {
+    it('removes annotations from the current state', function () {
       const annot = defaultAnnotation();
       store.addAnnotations([annot]);
       store.removeAnnotations([annot]);
       assert.deepEqual(store.getState().annotations.annotations, []);
     });
 
-    it('matches annotations to remove by ID', function() {
+    it('matches annotations to remove by ID', function () {
       store.addAnnotations(fixtures.pair);
       store.removeAnnotations([{ id: fixtures.pair[0].id }]);
 
-      const ids = store.getState().annotations.annotations.map(function(a) {
+      const ids = store.getState().annotations.annotations.map(function (a) {
         return a.id;
       });
       assert.deepEqual(ids, [fixtures.pair[1].id]);
     });
 
-    it('matches annotations to remove by tag', function() {
+    it('matches annotations to remove by tag', function () {
       store.addAnnotations(fixtures.pair);
       store.removeAnnotations([{ $tag: fixtures.pair[0].$tag }]);
 
-      const tags = store.getState().annotations.annotations.map(function(a) {
+      const tags = store.getState().annotations.annotations.map(function (a) {
         return a.$tag;
       });
       assert.deepEqual(tags, [fixtures.pair[1].$tag]);
     });
 
-    it('switches back to the Annotations tab when the last orphan is removed', function() {
+    it('switches back to the Annotations tab when the last orphan is removed', function () {
       const orphan = Object.assign(defaultAnnotation(), { $orphan: true });
       store.addAnnotations([orphan]);
       store.selectTab(uiConstants.TAB_ORPHANS);
@@ -160,8 +160,8 @@ describe('store', function() {
     });
   });
 
-  describe('#clearAnnotations()', function() {
-    it('removes all annotations', function() {
+  describe('#clearAnnotations()', function () {
+    it('removes all annotations', function () {
       const annot = defaultAnnotation();
       store.addAnnotations([annot]);
       store.clearAnnotations();
@@ -169,7 +169,7 @@ describe('store', function() {
     });
   });
 
-  describe('#setShowHighlights()', function() {
+  describe('#setShowHighlights()', function () {
     [{ state: true }, { state: false }].forEach(testCase => {
       it(`sets the visibleHighlights state flag to ${testCase.state}`, () => {
         store.setShowHighlights(testCase.state);
@@ -178,8 +178,8 @@ describe('store', function() {
     });
   });
 
-  describe('#updatingAnchorStatus', function() {
-    it("updates the annotation's orphan flag", function() {
+  describe('#updatingAnchorStatus', function () {
+    it("updates the annotation's orphan flag", function () {
       const annot = defaultAnnotation();
       store.addAnnotations([annot]);
       store.updateAnchorStatus({ [tagForID(annot.id)]: 'orphan' });

--- a/src/sidebar/store/test/util-test.js
+++ b/src/sidebar/store/test/util-test.js
@@ -2,27 +2,27 @@ import * as util from '../util';
 
 const fixtures = {
   update: {
-    ADD_ANNOTATIONS: function(state, action) {
+    ADD_ANNOTATIONS: function (state, action) {
       if (!state.annotations) {
         return { annotations: action.annotations };
       }
       return { annotations: state.annotations.concat(action.annotations) };
     },
-    SELECT_TAB: function(state, action) {
+    SELECT_TAB: function (state, action) {
       return { tab: action.tab };
     },
   },
   selectors: {
     namespace1: {
       selectors: {
-        countAnnotations1: function(state) {
+        countAnnotations1: function (state) {
           return state.namespace1.annotations.length;
         },
       },
     },
     namespace2: {
       selectors: {
-        countAnnotations2: function(state) {
+        countAnnotations2: function (state) {
           return state.namespace2.annotations.length;
         },
       },
@@ -30,9 +30,9 @@ const fixtures = {
   },
 };
 
-describe('reducer utils', function() {
-  describe('#actionTypes', function() {
-    it('returns an object with values equal to keys', function() {
+describe('reducer utils', function () {
+  describe('#actionTypes', function () {
+    it('returns an object with values equal to keys', function () {
       assert.deepEqual(
         util.actionTypes({
           SOME_ACTION: sinon.stub(),
@@ -46,8 +46,8 @@ describe('reducer utils', function() {
     });
   });
 
-  describe('#createReducer', function() {
-    it('returns an object if input state is undefined', function() {
+  describe('#createReducer', function () {
+    it('returns an object if input state is undefined', function () {
       // See redux.js:assertReducerShape in the "redux" package.
       const reducer = util.createReducer(fixtures.update);
       const initialState = reducer(undefined, {
@@ -56,7 +56,7 @@ describe('reducer utils', function() {
       assert.isOk(initialState);
     });
 
-    it('returns a reducer that combines each update function from the input object', function() {
+    it('returns a reducer that combines each update function from the input object', function () {
       const reducer = util.createReducer(fixtures.update);
       const newState = reducer(
         {},
@@ -70,7 +70,7 @@ describe('reducer utils', function() {
       });
     });
 
-    it('returns a new object if the action was handled', function() {
+    it('returns a new object if the action was handled', function () {
       const reducer = util.createReducer(fixtures.update);
       const originalState = { someFlag: false };
       assert.notEqual(
@@ -79,7 +79,7 @@ describe('reducer utils', function() {
       );
     });
 
-    it('returns the original object if the action was not handled', function() {
+    it('returns the original object if the action was not handled', function () {
       const reducer = util.createReducer(fixtures.update);
       const originalState = { someFlag: false };
       assert.equal(
@@ -88,7 +88,7 @@ describe('reducer utils', function() {
       );
     });
 
-    it('preserves state not modified by the update function', function() {
+    it('preserves state not modified by the update function', function () {
       const reducer = util.createReducer(fixtures.update);
       const newState = reducer(
         { otherFlag: false },
@@ -103,7 +103,7 @@ describe('reducer utils', function() {
       });
     });
 
-    it('supports reducer functions that return an array', function() {
+    it('supports reducer functions that return an array', function () {
       const action = {
         type: 'FIRST_ITEM',
         item: 'bar',
@@ -120,8 +120,8 @@ describe('reducer utils', function() {
     });
   });
 
-  describe('#bindSelectors', function() {
-    it('bound functions call original functions with current value of getState()', function() {
+  describe('#bindSelectors', function () {
+    it('bound functions call original functions with current value of getState()', function () {
       const getState = sinon.stub().returns({
         namespace1: {
           annotations: [{ id: 1 }],

--- a/src/sidebar/store/util.js
+++ b/src/sidebar/store/util.js
@@ -2,7 +2,7 @@
  * Return an object where each key in `updateFns` is mapped to the key itself.
  */
 export function actionTypes(updateFns) {
-  return Object.keys(updateFns).reduce(function(types, key) {
+  return Object.keys(updateFns).reduce(function (types, key) {
     types[key] = key;
     return types;
   }, {});
@@ -44,7 +44,7 @@ export function bindSelectors(namespaces, getState) {
   Object.keys(namespaces).forEach(namespace => {
     const selectors = namespaces[namespace].selectors;
     Object.keys(selectors).forEach(selector => {
-      totalSelectors[selector] = function() {
+      totalSelectors[selector] = function () {
         const args = [].slice.apply(arguments);
         args.unshift(getState());
         return selectors[selector].apply(null, args);

--- a/src/sidebar/test/build-thread-test.js
+++ b/src/sidebar/test/build-thread-test.js
@@ -28,9 +28,9 @@ const SIMPLE_FIXTURE = [
  */
 function filter(thread, keys) {
   const result = {};
-  keys.forEach(function(key) {
+  keys.forEach(function (key) {
     if (key === 'children') {
-      result[key] = thread[key].map(function(child) {
+      result[key] = thread[key].map(function (child) {
         return filter(child, keys);
       });
     } else {
@@ -59,9 +59,9 @@ function createThread(fixture, opts, keys) {
   return rootThread.children;
 }
 
-describe('build-thread', function() {
-  describe('threading', function() {
-    it('arranges parents and children as a thread', function() {
+describe('build-thread', function () {
+  describe('threading', function () {
+    it('arranges parents and children as a thread', function () {
       const thread = createThread(SIMPLE_FIXTURE);
       assert.deepEqual(thread, [
         {
@@ -80,7 +80,7 @@ describe('build-thread', function() {
       ]);
     });
 
-    it('threads nested replies', function() {
+    it('threads nested replies', function () {
       const NESTED_FIXTURE = [
         {
           id: '1',
@@ -115,7 +115,7 @@ describe('build-thread', function() {
       ]);
     });
 
-    it('handles loops implied by the reply field', function() {
+    it('handles loops implied by the reply field', function () {
       const LOOPED_FIXTURE = [
         {
           id: '1',
@@ -141,7 +141,7 @@ describe('build-thread', function() {
       ]);
     });
 
-    it('handles missing parent annotations', function() {
+    it('handles missing parent annotations', function () {
       const fixture = [
         {
           id: '1',
@@ -157,7 +157,7 @@ describe('build-thread', function() {
       ]);
     });
 
-    it('handles missing replies', function() {
+    it('handles missing replies', function () {
       const fixture = [
         {
           id: '1',
@@ -186,7 +186,7 @@ describe('build-thread', function() {
       ]);
     });
 
-    it('threads new annotations which have tags but not IDs', function() {
+    it('threads new annotations which have tags but not IDs', function () {
       const fixture = [
         {
           $tag: 't1',
@@ -196,7 +196,7 @@ describe('build-thread', function() {
       assert.deepEqual(thread, [{ annotation: fixture[0], children: [] }]);
     });
 
-    it('threads new replies which have tags but not IDs', function() {
+    it('threads new replies which have tags but not IDs', function () {
       const fixture = [
         {
           id: '1',
@@ -224,37 +224,37 @@ describe('build-thread', function() {
     });
   });
 
-  describe('collapsed state', function() {
-    it('collapses top-level annotations by default', function() {
+  describe('collapsed state', function () {
+    it('collapses top-level annotations by default', function () {
       const thread = buildThread(SIMPLE_FIXTURE, {});
       assert.isTrue(thread.children[0].collapsed);
     });
 
-    it('expands replies by default', function() {
+    it('expands replies by default', function () {
       const thread = buildThread(SIMPLE_FIXTURE, {});
       assert.isFalse(thread.children[0].children[0].collapsed);
     });
 
-    it('expands threads which have been explicitly expanded', function() {
+    it('expands threads which have been explicitly expanded', function () {
       const thread = buildThread(SIMPLE_FIXTURE, {
         expanded: { '1': true },
       });
       assert.isFalse(thread.children[0].collapsed);
     });
 
-    it('collapses replies which have been explicitly collapsed', function() {
+    it('collapses replies which have been explicitly collapsed', function () {
       const thread = buildThread(SIMPLE_FIXTURE, {
         expanded: { '3': false },
       });
       assert.isTrue(thread.children[0].children[0].collapsed);
     });
 
-    it('expands threads with visible children', function() {
+    it('expands threads with visible children', function () {
       // Simulate performing a search which only matches the top-level
       // annotation, not its reply, and then clicking
       // 'View N more in conversation' to show the complete discussion thread
       const thread = buildThread(SIMPLE_FIXTURE, {
-        filterFn: function(annot) {
+        filterFn: function (annot) {
           return annot.text.match(/first/);
         },
         forceVisible: ['3'],
@@ -263,13 +263,13 @@ describe('build-thread', function() {
     });
   });
 
-  describe('filtering', function() {
-    context('when there is an active filter', function() {
-      it('shows only annotations that match the filter', function() {
+  describe('filtering', function () {
+    context('when there is an active filter', function () {
+      it('shows only annotations that match the filter', function () {
         const threads = createThread(
           SIMPLE_FIXTURE,
           {
-            filterFn: function(annot) {
+            filterFn: function (annot) {
               return annot.text.match(/first/);
             },
           },
@@ -290,11 +290,11 @@ describe('build-thread', function() {
         ]);
       });
 
-      it('shows threads containing replies that match the filter', function() {
+      it('shows threads containing replies that match the filter', function () {
         const threads = createThread(
           SIMPLE_FIXTURE,
           {
-            filterFn: function(annot) {
+            filterFn: function (annot) {
               return annot.text.match(/third/);
             },
           },
@@ -316,8 +316,8 @@ describe('build-thread', function() {
       });
     });
 
-    context('when there is a selection', function() {
-      it('shows only selected annotations', function() {
+    context('when there is a selection', function () {
+      it('shows only selected annotations', function () {
         const thread = createThread(SIMPLE_FIXTURE, {
           selected: ['1'],
         });
@@ -335,7 +335,7 @@ describe('build-thread', function() {
       });
     });
 
-    describe('thread filtering', function() {
+    describe('thread filtering', function () {
       const fixture = [
         {
           id: '1',
@@ -349,9 +349,9 @@ describe('build-thread', function() {
         },
       ];
 
-      it('shows only annotations matching the thread filter', function() {
+      it('shows only annotations matching the thread filter', function () {
         const thread = createThread(fixture, {
-          threadFilterFn: function(thread) {
+          threadFilterFn: function (thread) {
             return metadata.isPageNote(thread.annotation);
           },
         });
@@ -366,14 +366,14 @@ describe('build-thread', function() {
     });
   });
 
-  describe('sort order', function() {
-    const annots = function(threads) {
-      return threads.map(function(thread) {
+  describe('sort order', function () {
+    const annots = function (threads) {
+      return threads.map(function (thread) {
         return thread.annotation;
       });
     };
 
-    it('sorts top-level annotations using the comparison function', function() {
+    it('sorts top-level annotations using the comparison function', function () {
       const fixture = [
         {
           id: '1',
@@ -388,14 +388,14 @@ describe('build-thread', function() {
       ];
 
       const thread = createThread(fixture, {
-        sortCompareFn: function(a, b) {
+        sortCompareFn: function (a, b) {
           return a.updated > b.updated;
         },
       });
       assert.deepEqual(annots(thread), [fixture[1], fixture[0]]);
     });
 
-    it('sorts replies by creation date', function() {
+    it('sorts replies by creation date', function () {
       const fixture = [
         {
           id: '1',
@@ -414,7 +414,7 @@ describe('build-thread', function() {
         },
       ];
       const thread = createThread(fixture, {
-        sortCompareFn: function(a, b) {
+        sortCompareFn: function (a, b) {
           return a.id < b.id;
         },
       });
@@ -422,8 +422,8 @@ describe('build-thread', function() {
     });
   });
 
-  describe('reply counts', function() {
-    it('populates the reply count field', function() {
+  describe('reply counts', function () {
+    it('populates the reply count field', function () {
       assert.deepEqual(createThread(SIMPLE_FIXTURE, {}, ['replyCount']), [
         {
           annotation: SIMPLE_FIXTURE[0],
@@ -445,34 +445,34 @@ describe('build-thread', function() {
     });
   });
 
-  describe('depth', function() {
-    it('is 0 for annotations', function() {
+  describe('depth', function () {
+    it('is 0 for annotations', function () {
       const thread = createThread(SIMPLE_FIXTURE, {}, ['depth']);
       assert.deepEqual(thread[0].depth, 0);
     });
 
-    it('is 1 for top-level replies', function() {
+    it('is 1 for top-level replies', function () {
       const thread = createThread(SIMPLE_FIXTURE, {}, ['depth']);
       assert.deepEqual(thread[0].children[0].depth, 1);
     });
   });
 
-  describe('highlighting', function() {
-    it('does not set highlight state when none are highlighted', function() {
+  describe('highlighting', function () {
+    it('does not set highlight state when none are highlighted', function () {
       const thread = createThread(SIMPLE_FIXTURE, {}, ['dimmed']);
-      thread.forEach(function(child) {
+      thread.forEach(function (child) {
         assert.equal(child.highlightState, undefined);
       });
     });
 
-    it('highlights annotations', function() {
+    it('highlights annotations', function () {
       const thread = createThread(SIMPLE_FIXTURE, { highlighted: ['1'] }, [
         'highlightState',
       ]);
       assert.equal(thread[0].highlightState, 'highlight');
     });
 
-    it('dims annotations which are not highlighted', function() {
+    it('dims annotations which are not highlighted', function () {
       const thread = createThread(SIMPLE_FIXTURE, { highlighted: ['1'] }, [
         'highlightState',
       ]);

--- a/src/sidebar/test/cross-origin-rpc-test.js
+++ b/src/sidebar/test/cross-origin-rpc-test.js
@@ -10,14 +10,14 @@ class FakeWindow {
   }
 }
 
-describe('sidebar/cross-origin-rcp', function() {
+describe('sidebar/cross-origin-rcp', function () {
   let fakeStore;
   let fakeWarnOnce;
   let fakeWindow;
   let settings;
   let frame;
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeStore = {
       changeFocusModeUser: sinon.stub(),
     };
@@ -40,8 +40,8 @@ describe('sidebar/cross-origin-rcp', function() {
     $imports.$restore();
   });
 
-  describe('#startServer', function() {
-    it('sends a response with the "ok" result', function() {
+  describe('#startServer', function () {
+    it('sends a response with the "ok" result', function () {
       startServer(fakeStore, settings, fakeWindow);
 
       fakeWindow.emitter.emit('message', {
@@ -64,7 +64,7 @@ describe('sidebar/cross-origin-rcp', function() {
       );
     });
 
-    it('calls the registered method with the provided params', function() {
+    it('calls the registered method with the provided params', function () {
       startServer(fakeStore, settings, fakeWindow);
 
       fakeWindow.emitter.emit('message', {
@@ -83,7 +83,7 @@ describe('sidebar/cross-origin-rcp', function() {
       );
     });
 
-    it('calls the registered method with no params', function() {
+    it('calls the registered method with no params', function () {
       startServer(fakeStore, settings, fakeWindow);
 
       fakeWindow.emitter.emit('message', {
@@ -98,7 +98,7 @@ describe('sidebar/cross-origin-rcp', function() {
       assert.isTrue(fakeStore.changeFocusModeUser.calledWithExactly());
     });
 
-    it('does not call the unregistered method', function() {
+    it('does not call the unregistered method', function () {
       startServer(fakeStore, settings, fakeWindow);
 
       fakeWindow.emitter.emit('message', {
@@ -132,8 +132,8 @@ describe('sidebar/cross-origin-rcp', function() {
       {},
       { rpcAllowedOrigins: [] },
       { rpcAllowedOrigins: ['https://allowed1.com', 'https://allowed2.com'] },
-    ].forEach(function(settings) {
-      it("doesn't respond if the origin isn't allowed", function() {
+    ].forEach(function (settings) {
+      it("doesn't respond if the origin isn't allowed", function () {
         startServer(fakeStore, settings, fakeWindow);
 
         fakeWindow.emitter.emit('message', {
@@ -150,7 +150,7 @@ describe('sidebar/cross-origin-rcp', function() {
       });
     });
 
-    it("responds with an error if there's no method", function() {
+    it("responds with an error if there's no method", function () {
       startServer(fakeStore, settings, fakeWindow);
       let jsonRpcRequest = { jsonrpc: '2.0', id: 42 }; // No "method" member.
 
@@ -176,8 +176,8 @@ describe('sidebar/cross-origin-rcp', function() {
       );
     });
 
-    ['unknownMethod', null].forEach(function(method) {
-      it('responds with an error if the method is unknown', function() {
+    ['unknownMethod', null].forEach(function (method) {
+      it('responds with an error if the method is unknown', function () {
         startServer(fakeStore, settings, fakeWindow);
 
         fakeWindow.emitter.emit('message', {
@@ -204,12 +204,12 @@ describe('sidebar/cross-origin-rcp', function() {
     });
   });
 
-  describe('#preStartServer', function() {
-    beforeEach(function() {
+  describe('#preStartServer', function () {
+    beforeEach(function () {
       preStartServer(fakeWindow);
     });
 
-    it('responds to an incoming request that arrives before the server starts', function() {
+    it('responds to an incoming request that arrives before the server starts', function () {
       fakeWindow.emitter.emit('message', {
         data: { jsonrpc: '2.0', method: 'changeFocusModeUser', id: 42 },
         origin: 'https://allowed1.com',
@@ -228,7 +228,7 @@ describe('sidebar/cross-origin-rcp', function() {
       );
     });
 
-    it('responds to multiple incoming requests that arrive before the server starts', function() {
+    it('responds to multiple incoming requests that arrive before the server starts', function () {
       const messageEvent = id => ({
         data: { jsonrpc: '2.0', method: 'changeFocusModeUser', id },
         origin: 'https://allowed1.com',
@@ -255,7 +255,7 @@ describe('sidebar/cross-origin-rcp', function() {
       assert.isTrue(frame.postMessage.calledWithExactly(...response(44)));
     });
 
-    it("does not respond to pre-start incoming requests if the origin isn't allowed", function() {
+    it("does not respond to pre-start incoming requests if the origin isn't allowed", function () {
       fakeWindow.emitter.emit('message', {
         data: { jsonrpc: '2.0', method: 'changeFocusModeUser', id: 42 },
         origin: 'https://fake.com',

--- a/src/sidebar/test/fake-redux-store.js
+++ b/src/sidebar/test/fake-redux-store.js
@@ -22,7 +22,7 @@ export default function fakeStore(initialState, methods) {
 
   const store = redux.createStore(update, initialState);
 
-  store.setState = function(state) {
+  store.setState = function (state) {
     store.dispatch({ type: 'SET_STATE', state: state });
   };
 

--- a/src/sidebar/test/get-api-url-test.js
+++ b/src/sidebar/test/get-api-url-test.js
@@ -1,8 +1,8 @@
 import getApiUrl from '../get-api-url';
 
-describe('sidebar.getApiUrl', function() {
-  context('when there is a service object in settings', function() {
-    it('returns apiUrl from the service object', function() {
+describe('sidebar.getApiUrl', function () {
+  context('when there is a service object in settings', function () {
+    it('returns apiUrl from the service object', function () {
       const settings = {
         apiUrl: 'someApiUrl',
         services: [
@@ -15,8 +15,8 @@ describe('sidebar.getApiUrl', function() {
     });
   });
 
-  context('when there is no service object in settings', function() {
-    it('returns apiUrl from the settings object', function() {
+  context('when there is no service object in settings', function () {
+    it('returns apiUrl from the settings object', function () {
       const settings = {
         apiUrl: 'someApiUrl',
       };
@@ -26,14 +26,14 @@ describe('sidebar.getApiUrl', function() {
 
   context(
     'when there is a service object in settings but does not contain an apiUrl key',
-    function() {
-      it('throws error', function() {
+    function () {
+      it('throws error', function () {
         const settings = {
           apiUrl: 'someApiUrl',
           services: [{}],
         };
         assert.throws(
-          function() {
+          function () {
             getApiUrl(settings);
           },
           Error,

--- a/src/sidebar/test/host-config-test.js
+++ b/src/sidebar/test/host-config-test.js
@@ -8,8 +8,8 @@ function fakeWindow(config) {
   };
 }
 
-describe('hostPageConfig', function() {
-  it('parses config from location string and returns whitelisted params', function() {
+describe('hostPageConfig', function () {
+  it('parses config from location string and returns whitelisted params', function () {
     const window_ = fakeWindow({
       annotations: '1234',
       group: 'abc12',
@@ -39,7 +39,7 @@ describe('hostPageConfig', function() {
     });
   });
 
-  it('coerces `requestConfigFromFrame` and `openSidebar` values', function() {
+  it('coerces `requestConfigFromFrame` and `openSidebar` values', function () {
     const window_ = fakeWindow({
       openSidebar: 'false',
       requestConfigFromFrame: {
@@ -57,7 +57,7 @@ describe('hostPageConfig', function() {
     });
   });
 
-  it('ignores non-whitelisted config params', function() {
+  it('ignores non-whitelisted config params', function () {
     const window_ = fakeWindow({
       apiUrl: 'https://not-the-hypothesis/api/',
     });
@@ -65,7 +65,7 @@ describe('hostPageConfig', function() {
     assert.deepEqual(hostPageConfig(window_), {});
   });
 
-  it('ignores `null` values in config', function() {
+  it('ignores `null` values in config', function () {
     const window_ = fakeWindow({
       openSidebar: null,
     });

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -34,16 +34,16 @@ const fixtures = immutable({
   ],
 });
 
-describe('annotation threading', function() {
+describe('annotation threading', function () {
   let store;
   let rootThread;
 
-  beforeEach(function() {
+  beforeEach(function () {
     const fakeUnicode = {
-      normalize: function(s) {
+      normalize: function (s) {
         return s;
       },
-      fold: function(s) {
+      fold: function (s) {
         return s;
       },
     };
@@ -65,24 +65,24 @@ describe('annotation threading', function() {
 
     angular.mock.module('app');
 
-    angular.mock.inject(function(_store_, _rootThread_) {
+    angular.mock.inject(function (_store_, _rootThread_) {
       store = _store_;
       rootThread = _rootThread_;
     });
   });
 
-  it('should display newly loaded annotations', function() {
+  it('should display newly loaded annotations', function () {
     store.addAnnotations(fixtures.annotations);
     assert.equal(rootThread.thread(store.getState()).children.length, 2);
   });
 
-  it('should not display unloaded annotations', function() {
+  it('should not display unloaded annotations', function () {
     store.addAnnotations(fixtures.annotations);
     store.removeAnnotations(fixtures.annotations);
     assert.equal(rootThread.thread(store.getState()).children.length, 0);
   });
 
-  it('should filter annotations when a search is set', function() {
+  it('should filter annotations when a search is set', function () {
     store.addAnnotations(fixtures.annotations);
     store.setFilterQuery('second');
     assert.equal(rootThread.thread(store.getState()).children.length, 1);
@@ -104,7 +104,7 @@ describe('annotation threading', function() {
       store.setSortKey(testCase.sortKey);
       const actualOrder = rootThread
         .thread(store.getState())
-        .children.map(function(thread) {
+        .children.map(function (thread) {
           return thread.annotation.id;
         });
       assert.deepEqual(actualOrder, testCase.expectedOrder);

--- a/src/sidebar/test/markdown-commands-test.js
+++ b/src/sidebar/test/markdown-commands-test.js
@@ -42,25 +42,25 @@ function formatState(state) {
   );
 }
 
-describe('markdown commands', function() {
-  describe('span formatting', function() {
+describe('markdown commands', function () {
+  describe('span formatting', function () {
     function toggle(state, prefix, suffix, placeholder) {
       prefix = prefix || '**';
       suffix = suffix || '**';
       return commands.toggleSpanStyle(state, prefix, suffix, placeholder);
     }
 
-    it('adds formatting to spans', function() {
+    it('adds formatting to spans', function () {
       const output = toggle(parseState('make <sel>text</sel> bold'));
       assert.equal(formatState(output), 'make **<sel>text</sel>** bold');
     });
 
-    it('removes formatting from spans', function() {
+    it('removes formatting from spans', function () {
       const output = toggle(parseState('make **<sel>text</sel>** bold'));
       assert.equal(formatState(output), 'make <sel>text</sel> bold');
     });
 
-    it('adds formatting to spans when the prefix and suffix differ', function() {
+    it('adds formatting to spans when the prefix and suffix differ', function () {
       const output = toggle(
         parseState('make <sel>math</sel> mathy'),
         '\\(',
@@ -69,7 +69,7 @@ describe('markdown commands', function() {
       assert.equal(formatState(output), 'make \\(<sel>math</sel>\\) mathy');
     });
 
-    it('inserts placeholders if the selection is empty', function() {
+    it('inserts placeholders if the selection is empty', function () {
       const output = toggle(
         parseState('make <sel></sel> bold'),
         '**',
@@ -80,7 +80,7 @@ describe('markdown commands', function() {
     });
   });
 
-  describe('block formatting', function() {
+  describe('block formatting', function () {
     [
       {
         tag: 'adds formatting to blocks',
@@ -113,8 +113,8 @@ describe('markdown commands', function() {
     });
   });
 
-  describe('link formatting', function() {
-    const linkify = function(text, linkType) {
+  describe('link formatting', function () {
+    const linkify = function (text, linkType) {
       return commands.convertSelectionToLink(parseState(text), linkType);
     };
 
@@ -144,7 +144,7 @@ describe('markdown commands', function() {
       });
     });
 
-    it('converts URLs to image links', function() {
+    it('converts URLs to image links', function () {
       const output = linkify(
         'one <sel>http://foobar.com</sel> three',
         commands.LinkType.IMAGE_LINK

--- a/src/sidebar/test/media-embedder-test.js
+++ b/src/sidebar/test/media-embedder-test.js
@@ -1,6 +1,6 @@
 import * as mediaEmbedder from '../media-embedder.js';
 
-describe('media-embedder', function() {
+describe('media-embedder', function () {
   function domElement(html) {
     const element = document.createElement('div');
     element.innerHTML = html;
@@ -17,7 +17,7 @@ describe('media-embedder', function() {
     clock.restore();
   });
 
-  it('replaces YouTube watch links with iframes', function() {
+  it('replaces YouTube watch links with iframes', function () {
     const urls = [
       'https://www.youtube.com/watch?v=QCkm0lL-6lc',
       'https://www.youtube.com/watch/?v=QCkm0lL-6lc',
@@ -25,7 +25,7 @@ describe('media-embedder', function() {
       'https://www.youtube.com/watch?foo=bar&v=QCkm0lL-6lc&h=j',
       'https://www.youtube.com/watch?v=QCkm0lL-6lc&foo=bar',
     ];
-    urls.forEach(function(url) {
+    urls.forEach(function (url) {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -39,13 +39,13 @@ describe('media-embedder', function() {
     });
   });
 
-  it('allows whitelisted parameters in YouTube watch URLs', function() {
+  it('allows whitelisted parameters in YouTube watch URLs', function () {
     const urls = [
       'https://www.youtube.com/watch?v=QCkm0lL-6lc&start=5&end=10',
       'https://www.youtube.com/watch?v=QCkm0lL-6lc&end=10&start=5',
       'https://www.youtube.com/watch/?v=QCkm0lL-6lc&end=10&start=5',
     ];
-    urls.forEach(function(url) {
+    urls.forEach(function (url) {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -63,13 +63,13 @@ describe('media-embedder', function() {
     });
   });
 
-  it('translates YouTube watch `t` param to `start` for embed', function() {
+  it('translates YouTube watch `t` param to `start` for embed', function () {
     const urls = [
       'https://www.youtube.com/watch?v=QCkm0lL-6lc&t=5&end=10',
       'https://www.youtube.com/watch?v=QCkm0lL-6lc&end=10&t=5',
       'https://www.youtube.com/watch/?v=QCkm0lL-6lc&end=10&t=5',
     ];
-    urls.forEach(function(url) {
+    urls.forEach(function (url) {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -83,7 +83,7 @@ describe('media-embedder', function() {
     });
   });
 
-  it('parses YouTube `t` param values into seconds', function() {
+  it('parses YouTube `t` param values into seconds', function () {
     const cases = [
       [
         'https://www.youtube.com/watch?v=QCkm0lL-6lc&t=5m',
@@ -126,7 +126,7 @@ describe('media-embedder', function() {
         'https://www.youtube.com/embed/QCkm0lL-6lc?start=10',
       ],
     ];
-    cases.forEach(function(url) {
+    cases.forEach(function (url) {
       const element = domElement('<a href="' + url[0] + '">' + url[0] + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -137,12 +137,12 @@ describe('media-embedder', function() {
     });
   });
 
-  it('excludes non-whitelisted params in YouTube watch links', function() {
+  it('excludes non-whitelisted params in YouTube watch links', function () {
     const urls = [
       'https://www.youtube.com/watch?v=QCkm0lL-6lc&start=5&end=10&baz=dingdong',
       'https://www.youtube.com/watch/?v=QCkm0lL-6lc&autoplay=1&end=10&start=5',
     ];
-    urls.forEach(function(url) {
+    urls.forEach(function (url) {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -158,12 +158,12 @@ describe('media-embedder', function() {
     });
   });
 
-  it('replaces YouTube share links with iframes', function() {
+  it('replaces YouTube share links with iframes', function () {
     const urls = [
       'https://youtu.be/QCkm0lL-6lc',
       'https://youtu.be/QCkm0lL-6lc/',
     ];
-    urls.forEach(function(url) {
+    urls.forEach(function (url) {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -177,12 +177,12 @@ describe('media-embedder', function() {
     });
   });
 
-  it('allows whitelisted parameters in YouTube share links', function() {
+  it('allows whitelisted parameters in YouTube share links', function () {
     const urls = [
       'https://youtu.be/QCkm0lL-6lc?start=5&end=10',
       'https://youtu.be/QCkm0lL-6lc/?end=10&start=5',
     ];
-    urls.forEach(function(url) {
+    urls.forEach(function (url) {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -198,12 +198,12 @@ describe('media-embedder', function() {
     });
   });
 
-  it('translates YouTube share URL `t` param to `start` for embed', function() {
+  it('translates YouTube share URL `t` param to `start` for embed', function () {
     const urls = [
       'https://youtu.be/QCkm0lL-6lc?t=5&end=10',
       'https://youtu.be/QCkm0lL-6lc/?end=10&t=5',
     ];
-    urls.forEach(function(url) {
+    urls.forEach(function (url) {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -217,12 +217,12 @@ describe('media-embedder', function() {
     });
   });
 
-  it('excludes non-whitelisted params in YouTube share links', function() {
+  it('excludes non-whitelisted params in YouTube share links', function () {
     const urls = [
       'https://youtu.be/QCkm0lL-6lc?foo=bar&t=5&end=10&baz=dingdong',
       'https://youtu.be/QCkm0lL-6lc/?autoplay=1&end=10&t=5',
     ];
-    urls.forEach(function(url) {
+    urls.forEach(function (url) {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -238,7 +238,7 @@ describe('media-embedder', function() {
     });
   });
 
-  it('replaces Vimeo links with iframes', function() {
+  it('replaces Vimeo links with iframes', function () {
     const urls = [
       'https://vimeo.com/149000090',
       'https://vimeo.com/149000090/',
@@ -247,7 +247,7 @@ describe('media-embedder', function() {
       'https://vimeo.com/149000090?foo=bar&a=b',
       'https://vimeo.com/149000090/?foo=bar&a=b',
     ];
-    urls.forEach(function(url) {
+    urls.forEach(function (url) {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -261,7 +261,7 @@ describe('media-embedder', function() {
     });
   });
 
-  it('replaces Vimeo channel links with iframes', function() {
+  it('replaces Vimeo channel links with iframes', function () {
     const urls = [
       'https://vimeo.com/channels/staffpicks/148845534',
       'https://vimeo.com/channels/staffpicks/148845534/',
@@ -271,7 +271,7 @@ describe('media-embedder', function() {
       'https://vimeo.com/channels/staffpicks/148845534?foo=bar&id=1',
       'https://vimeo.com/channels/otherchannel/148845534',
     ];
-    urls.forEach(function(url) {
+    urls.forEach(function (url) {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -285,7 +285,7 @@ describe('media-embedder', function() {
     });
   });
 
-  it('replaces internet archive links with iframes', function() {
+  it('replaces internet archive links with iframes', function () {
     const urls = [
       // Video details page.
       'https://archive.org/details/PATH',
@@ -299,7 +299,7 @@ describe('media-embedder', function() {
       // Embed link generated by the "Share" links on the details pages.
       'https://archive.org/embed/PATH?start=360&end=420.3',
     ];
-    urls.forEach(function(url) {
+    urls.forEach(function (url) {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -315,7 +315,7 @@ describe('media-embedder', function() {
     });
   });
 
-  it('replaces audio links with html5 audio elements', function() {
+  it('replaces audio links with html5 audio elements', function () {
     const urls = [
       'https://archive.org/download/testmp3testfile/mpthreetest.mp3',
       'https://archive.org/download/testmp3testfile/mpthreetest.mp3#fragment',
@@ -329,7 +329,7 @@ describe('media-embedder', function() {
       'https://wisc.pb.unizin.org/frenchcscr/wp-content/uploads/sites/208/2018/03/6Léry_Conclusion.mp3',
       'https://wisc.pb.unizin.org/frenchcscr/wp-content/uploads/sites/208/2018/03/6L%25C3%25A9ry_Conclusion.mp3',
     ];
-    urls.forEach(function(url) {
+    urls.forEach(function (url) {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -349,7 +349,7 @@ describe('media-embedder', function() {
     });
   });
 
-  it('does not replace links if the link text is different', function() {
+  it('does not replace links if the link text is different', function () {
     const url = 'https://youtu.be/QCkm0lL-6lc';
     const element = domElement('<a href="' + url + '">different label</a>');
 
@@ -359,7 +359,7 @@ describe('media-embedder', function() {
     assert.equal(element.children[0].tagName, 'A');
   });
 
-  it('does not replace non-media links', function() {
+  it('does not replace non-media links', function () {
     const url = 'https://example.com/example.html';
     const element = domElement('<a href="' + url + '">' + url + '</a>');
 
@@ -369,7 +369,7 @@ describe('media-embedder', function() {
     assert.equal(element.children[0].tagName, 'A');
   });
 
-  it('does not mess with the rest of the HTML', function() {
+  it('does not mess with the rest of the HTML', function () {
     const url = 'https://www.youtube.com/watch?v=QCkm0lL-6lc';
     const element = domElement(
       '<p>Look at this video:</p>\n\n' +
@@ -388,7 +388,7 @@ describe('media-embedder', function() {
     assert.equal(element.children[2].outerHTML, "<p>Isn't it cool!</p>");
   });
 
-  it('replaces multiple links with multiple embeds', function() {
+  it('replaces multiple links with multiple embeds', function () {
     const url1 = 'https://www.youtube.com/watch?v=QCkm0lL-6lc';
     const url2 = 'https://youtu.be/abcdefg';
     const element = domElement(

--- a/src/sidebar/test/render-markdown-test.js
+++ b/src/sidebar/test/render-markdown-test.js
@@ -1,13 +1,13 @@
 import renderMarkdown from '../render-markdown';
 import { $imports } from '../render-markdown';
 
-describe('render-markdown', function() {
+describe('render-markdown', function () {
   let render;
 
-  beforeEach(function() {
+  beforeEach(function () {
     $imports.$mock({
       katex: {
-        renderToString: function(input, opts) {
+        renderToString: function (input, opts) {
           if (opts && opts.displayMode) {
             return 'math+display:' + input;
           } else {
@@ -16,7 +16,7 @@ describe('render-markdown', function() {
         },
       },
     });
-    render = function(markdown) {
+    render = function (markdown) {
       return renderMarkdown(markdown);
     };
   });
@@ -25,8 +25,8 @@ describe('render-markdown', function() {
     $imports.$restore();
   });
 
-  describe('autolinking', function() {
-    it('should autolink URLs', function() {
+  describe('autolinking', function () {
+    it('should autolink URLs', function () {
       assert.equal(
         render('See this link - http://arxiv.org/article'),
         '<p>See this link - <a href="http://arxiv.org/article" target="_blank">' +
@@ -34,7 +34,7 @@ describe('render-markdown', function() {
       );
     });
 
-    it("should autolink URLs with _'s in them correctly", function() {
+    it("should autolink URLs with _'s in them correctly", function () {
       assert.equal(
         render(
           'See this https://hypothes.is/stream?q=tag:group_test_needs_card'
@@ -47,15 +47,15 @@ describe('render-markdown', function() {
     });
   });
 
-  describe('markdown rendering', function() {
-    it('should render markdown', function() {
+  describe('markdown rendering', function () {
+    it('should render markdown', function () {
       assert.equal(
         render('one **two** three'),
         '<p>one <strong>two</strong> three</p>'
       );
     });
 
-    it('should sanitize the result', function() {
+    it('should sanitize the result', function () {
       // Check that the rendered HTML is fed through the HTML sanitization
       // library. This is not an extensive test of sanitization behavior, that
       // is left to DOMPurify's tests.
@@ -73,12 +73,12 @@ describe('render-markdown', function() {
     });
   });
 
-  describe('math blocks', function() {
-    it('should render LaTeX blocks', function() {
+  describe('math blocks', function () {
+    it('should render LaTeX blocks', function () {
       assert.equal(render('$$x*2$$'), '<p>math+display:x*2</p>');
     });
 
-    it('should render mixed blocks', function() {
+    it('should render mixed blocks', function () {
       assert.equal(
         render('one $$x*2$$ two $$x*3$$ three'),
         '<p>one </p>\n<p>math+display:x*2</p>\n' +
@@ -86,14 +86,14 @@ describe('render-markdown', function() {
       );
     });
 
-    it('should not sanitize math renderer output', function() {
+    it('should not sanitize math renderer output', function () {
       // Check that KaTeX's rendered output is not corrupted in any way by
       // sanitization.
       const html = render('$$ <unknown-tag>foo</unknown-tag> $$');
       assert.include(html, '<unknown-tag>foo</unknown-tag>');
     });
 
-    it('should render mixed inline and block math', function() {
+    it('should render mixed inline and block math', function () {
       assert.equal(
         render('one \\(x*2\\) three $$x*3$$'),
         '<p>one math:x*2 three </p>\n<p>math+display:x*3</p>'
@@ -101,12 +101,12 @@ describe('render-markdown', function() {
     });
   });
 
-  describe('inline math', function() {
-    it('should render inline LaTeX', function() {
+  describe('inline math', function () {
+    it('should render inline LaTeX', function () {
       assert.equal(render('\\(x*2\\)'), '<p>math:x*2</p>');
     });
 
-    it('should render mixed inline LaTeX blocks', function() {
+    it('should render mixed inline LaTeX blocks', function () {
       assert.equal(
         render('one \\(x+2\\) two \\(x+3\\) four'),
         '<p>one math:x+2 two math:x+3 four</p>'

--- a/src/sidebar/test/search-client-test.js
+++ b/src/sidebar/test/search-client-test.js
@@ -1,7 +1,7 @@
 import SearchClient from '../search-client';
 
 function awaitEvent(emitter, event) {
-  return new Promise(function(resolve) {
+  return new Promise(function (resolve) {
     emitter.on(event, resolve);
   });
 }
@@ -17,7 +17,7 @@ describe('SearchClient', () => {
   let fakeSearchFn;
 
   beforeEach(() => {
-    fakeSearchFn = sinon.spy(function(params) {
+    fakeSearchFn = sinon.spy(function (params) {
       return Promise.resolve({
         rows: RESULTS.slice(params.offset, params.offset + params.limit),
         total: RESULTS.length,

--- a/src/sidebar/test/service-config-test.js
+++ b/src/sidebar/test/service-config-test.js
@@ -1,7 +1,7 @@
 import serviceConfig from '../service-config';
 
-describe('serviceConfig', function() {
-  it('returns null if services is not an array', function() {
+describe('serviceConfig', function () {
+  it('returns null if services is not an array', function () {
     const settings = {
       services: 'someString',
     };
@@ -9,7 +9,7 @@ describe('serviceConfig', function() {
     assert.isNull(serviceConfig(settings));
   });
 
-  it('returns null if the settings object has no services', function() {
+  it('returns null if the settings object has no services', function () {
     const settings = {
       services: [],
     };
@@ -17,7 +17,7 @@ describe('serviceConfig', function() {
     assert.isNull(serviceConfig(settings));
   });
 
-  it('returns the first service in the settings object', function() {
+  it('returns the first service in the settings object', function () {
     const settings = {
       services: [
         {

--- a/src/sidebar/test/virtual-thread-list-test.js
+++ b/src/sidebar/test/virtual-thread-list-test.js
@@ -1,7 +1,7 @@
 import VirtualThreadList from '../virtual-thread-list';
 import { $imports } from '../virtual-thread-list';
 
-describe('VirtualThreadList', function() {
+describe('VirtualThreadList', function () {
   let lastState;
   let threadList;
   const threadOptions = {};
@@ -19,7 +19,7 @@ describe('VirtualThreadList', function() {
   }
 
   function threadIDs(threads) {
-    return threads.map(function(thread) {
+    return threads.map(function (thread) {
       return thread.id;
     });
   }
@@ -27,7 +27,7 @@ describe('VirtualThreadList', function() {
   function generateRootThread(count) {
     return {
       annotation: undefined,
-      children: idRange(0, count - 1).map(function(id) {
+      children: idRange(0, count - 1).map(function (id) {
         return { id: id, annotation: undefined, children: [] };
       }),
     };
@@ -52,23 +52,23 @@ describe('VirtualThreadList', function() {
     $imports.$restore();
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeScope = { $digest: sinon.stub() };
 
     fakeScrollRoot = {
       scrollTop: 0,
       listeners: {},
-      addEventListener: function(event, listener) {
+      addEventListener: function (event, listener) {
         this.listeners[event] = this.listeners[event] || [];
         this.listeners[event].push(listener);
       },
-      removeEventListener: function(event, listener) {
-        this.listeners[event] = this.listeners[event].filter(function(fn) {
+      removeEventListener: function (event, listener) {
+        this.listeners[event] = this.listeners[event].filter(function (fn) {
           return fn !== listener;
         });
       },
-      trigger: function(event) {
-        (this.listeners[event] || []).forEach(function(cb) {
+      trigger: function (event) {
+        (this.listeners[event] || []).forEach(function (cb) {
           cb();
         });
       },
@@ -76,17 +76,17 @@ describe('VirtualThreadList', function() {
 
     fakeWindow = {
       listeners: {},
-      addEventListener: function(event, listener) {
+      addEventListener: function (event, listener) {
         this.listeners[event] = this.listeners[event] || [];
         this.listeners[event].push(listener);
       },
-      removeEventListener: function(event, listener) {
-        this.listeners[event] = this.listeners[event].filter(function(fn) {
+      removeEventListener: function (event, listener) {
+        this.listeners[event] = this.listeners[event].filter(function (fn) {
           return fn !== listener;
         });
       },
-      trigger: function(event) {
-        (this.listeners[event] || []).forEach(function(cb) {
+      trigger: function (event) {
+        (this.listeners[event] || []).forEach(function (cb) {
           cb();
         });
       },
@@ -102,7 +102,7 @@ describe('VirtualThreadList', function() {
       rootThread,
       threadOptions
     );
-    threadList.on('changed', function(state) {
+    threadList.on('changed', function (state) {
       lastState = state;
     });
   });
@@ -157,24 +157,24 @@ describe('VirtualThreadList', function() {
     });
   });
 
-  it('recalculates when a window.resize occurs', function() {
+  it('recalculates when a window.resize occurs', function () {
     lastState = null;
     fakeWindow.trigger('resize');
     assert.ok(lastState);
   });
 
-  it('recalculates when a scrollRoot.scroll occurs', function() {
+  it('recalculates when a scrollRoot.scroll occurs', function () {
     lastState = null;
     fakeScrollRoot.trigger('scroll');
     assert.ok(lastState);
   });
 
-  it('recalculates when root thread changes', function() {
+  it('recalculates when root thread changes', function () {
     threadList.setRootThread({ annotation: undefined, children: [] });
     assert.ok(lastState);
   });
 
-  describe('#setThreadHeight', function() {
+  describe('#setThreadHeight', function () {
     [
       {
         threadHeight: 1000,
@@ -189,7 +189,7 @@ describe('VirtualThreadList', function() {
         const thread = generateRootThread(10);
         fakeWindow.innerHeight = 500;
         fakeScrollRoot.scrollTop = 0;
-        idRange(0, 10).forEach(function(id) {
+        idRange(0, 10).forEach(function (id) {
           threadList.setThreadHeight(id, testCase.threadHeight);
         });
         threadList.setRootThread(thread);
@@ -201,14 +201,14 @@ describe('VirtualThreadList', function() {
     });
   });
 
-  describe('#detach', function() {
-    it('stops listening to window.resize events', function() {
+  describe('#detach', function () {
+    it('stops listening to window.resize events', function () {
       threadList.detach();
       lastState = null;
       fakeWindow.trigger('resize');
       assert.isNull(lastState);
     });
-    it('stops listening to scrollRoot.scroll events', function() {
+    it('stops listening to scrollRoot.scroll events', function () {
       threadList.detach();
       lastState = null;
       fakeScrollRoot.trigger('scroll');
@@ -216,7 +216,7 @@ describe('VirtualThreadList', function() {
     });
   });
 
-  describe('#yOffsetOf', function() {
+  describe('#yOffsetOf', function () {
     [
       {
         nth: 'first',
@@ -237,7 +237,7 @@ describe('VirtualThreadList', function() {
       it(`returns ${testCase.offset} as the Y offset of the ${testCase.nth} thread`, () => {
         const thread = generateRootThread(10);
         threadList.setRootThread(thread);
-        idRange(0, 10).forEach(function(id) {
+        idRange(0, 10).forEach(function (id) {
           threadList.setThreadHeight(id, 100);
         });
         const id = idRange(testCase.index, testCase.index)[0];

--- a/src/sidebar/test/websocket-test.js
+++ b/src/sidebar/test/websocket-test.js
@@ -4,7 +4,7 @@ import Socket, {
   CLOSE_ABNORMAL,
 } from '../websocket';
 
-describe('websocket wrapper', function() {
+describe('websocket wrapper', function () {
   let fakeSocket;
   let clock;
 
@@ -17,7 +17,7 @@ describe('websocket wrapper', function() {
 
   const WebSocket = window.WebSocket;
 
-  beforeEach(function() {
+  beforeEach(function () {
     global.WebSocket = FakeWebSocket;
     clock = sinon.useFakeTimers();
 
@@ -26,14 +26,14 @@ describe('websocket wrapper', function() {
     sinon.stub(console, 'warn');
   });
 
-  afterEach(function() {
+  afterEach(function () {
     global.WebSocket = WebSocket;
     clock.restore();
     console.warn.restore();
   });
 
   context('when the connection is closed by the browser or server', () => {
-    it('should reconnect after an abnormal disconnection', function() {
+    it('should reconnect after an abnormal disconnection', function () {
       new Socket('ws://test:1234');
       assert.ok(fakeSocket);
       const initialSocket = fakeSocket;
@@ -44,7 +44,7 @@ describe('websocket wrapper', function() {
       assert.notEqual(fakeSocket, initialSocket);
     });
 
-    it('should reconnect if initial connection fails', function() {
+    it('should reconnect if initial connection fails', function () {
       new Socket('ws://test:1234');
       assert.ok(fakeSocket);
       const initialSocket = fakeSocket;
@@ -55,7 +55,7 @@ describe('websocket wrapper', function() {
       assert.notEqual(fakeSocket, initialSocket);
     });
 
-    it('should send queued messages after a reconnect', function() {
+    it('should send queued messages after a reconnect', function () {
       // simulate WebSocket setup and initial connection
       const socket = new Socket('ws://test:1234');
       fakeSocket.onopen({});
@@ -70,7 +70,7 @@ describe('websocket wrapper', function() {
     });
 
     [CLOSE_NORMAL, CLOSE_GOING_AWAY].forEach(closeCode => {
-      it('should not reconnect after a normal disconnection', function() {
+      it('should not reconnect after a normal disconnection', function () {
         new Socket('ws://test:1234');
         assert.ok(fakeSocket);
         const initialSocket = fakeSocket;
@@ -85,7 +85,7 @@ describe('websocket wrapper', function() {
     });
   });
 
-  it('should queue messages sent prior to connection', function() {
+  it('should queue messages sent prior to connection', function () {
     const socket = new Socket('ws://test:1234');
     socket.send({ abc: 'foo' });
     assert.notCalled(fakeSocket.send);
@@ -93,7 +93,7 @@ describe('websocket wrapper', function() {
     assert.calledWith(fakeSocket.send, '{"abc":"foo"}');
   });
 
-  it('should send messages immediately when connected', function() {
+  it('should send messages immediately when connected', function () {
     const socket = new Socket('ws://test:1234');
     fakeSocket.readyState = FakeWebSocket.OPEN;
     socket.send({ abc: 'foo' });

--- a/src/sidebar/util/annotation-metadata.js
+++ b/src/sidebar/util/annotation-metadata.js
@@ -110,7 +110,7 @@ export function isPublic(annotation) {
     return isPublic;
   }
 
-  annotation.permissions.read.forEach(function(perm) {
+  annotation.permissions.read.forEach(function (perm) {
     const readPermArr = perm.split(':');
     if (readPermArr.length === 2 && readPermArr[0] === 'group') {
       isPublic = true;

--- a/src/sidebar/util/array.js
+++ b/src/sidebar/util/array.js
@@ -5,7 +5,7 @@
  * @param {Function} predicate
  */
 export function countIf(ary, predicate) {
-  return ary.reduce(function(count, item) {
+  return ary.reduce(function (count, item) {
     return predicate(item) ? count + 1 : count;
   }, 0);
 }
@@ -16,7 +16,7 @@ export function countIf(ary, predicate) {
  * @param {string[]} list - List of keys for the set.
  */
 export function toSet(list) {
-  return list.reduce(function(set, key) {
+  return list.reduce(function (set, key) {
     set[key] = true;
     return set;
   }, {});

--- a/src/sidebar/util/groups.js
+++ b/src/sidebar/util/groups.js
@@ -51,10 +51,7 @@ function uriMatchesScopes(uri, scopes) {
     scopes.find(uriRegex =>
       uri.match(
         // Convert *'s to .*'s for regex matching and escape all other special characters.
-        uriRegex
-          .split('*')
-          .map(escapeStringRegexp)
-          .join('.*')
+        uriRegex.split('*').map(escapeStringRegexp).join('.*')
       )
     ) !== undefined
   );

--- a/src/sidebar/util/memoize.js
+++ b/src/sidebar/util/memoize.js
@@ -13,7 +13,7 @@ export default function memoize(fn) {
   let lastArg;
   let lastResult;
 
-  return function(arg) {
+  return function (arg) {
     if (arg === lastArg) {
       return lastResult;
     }

--- a/src/sidebar/util/permissions.js
+++ b/src/sidebar/util/permissions.js
@@ -78,7 +78,7 @@ export function defaultPermissions(userid, groupid, savedLevel) {
  * @return {boolean}
  */
 export function isShared(perms) {
-  return perms.read.some(function(principal) {
+  return perms.read.some(function (principal) {
     return principal.indexOf('group:') === 0;
   });
 }

--- a/src/sidebar/util/random.js
+++ b/src/sidebar/util/random.js
@@ -13,7 +13,5 @@ export function generateHexString(len) {
   const crypto = window.crypto || window.msCrypto; /* IE 11 */
   const bytes = new Uint8Array(len / 2);
   crypto.getRandomValues(bytes);
-  return Array.from(bytes)
-    .map(byteToHex)
-    .join('');
+  return Array.from(bytes).map(byteToHex).join('');
 }

--- a/src/sidebar/util/retry.js
+++ b/src/sidebar/util/retry.js
@@ -11,15 +11,15 @@ import retry from 'retry';
  *         it succeeds within the allowed number of attempts.
  */
 export function retryPromiseOperation(opFn, options) {
-  return new Promise(function(resolve, reject) {
+  return new Promise(function (resolve, reject) {
     const operation = retry.operation(options);
-    operation.attempt(function() {
+    operation.attempt(function () {
       opFn()
-        .then(function(result) {
+        .then(function (result) {
           operation.retry();
           resolve(result);
         })
-        .catch(function(err) {
+        .catch(function (err) {
           if (!operation.retry(err)) {
             reject(err);
           }

--- a/src/sidebar/util/scope-timeout.js
+++ b/src/sidebar/util/scope-timeout.js
@@ -22,11 +22,11 @@ export default function scopeTimeout(
   clearTimeoutFn = clearTimeoutFn || clearTimeout;
 
   let removeDestroyHandler;
-  const id = setTimeoutFn(function() {
+  const id = setTimeoutFn(function () {
     removeDestroyHandler();
     fn();
   }, delay);
-  removeDestroyHandler = $scope.$on('$destroy', function() {
+  removeDestroyHandler = $scope.$on('$destroy', function () {
     clearTimeoutFn(id);
   });
 }

--- a/src/sidebar/util/test/account-id-test.js
+++ b/src/sidebar/util/test/account-id-test.js
@@ -1,43 +1,43 @@
 import { parseAccountID, username, isThirdPartyUser } from '../account-id';
 
-describe('sidebar.util.account-id', function() {
+describe('sidebar.util.account-id', function () {
   const term = 'acct:hacker@example.com';
 
-  describe('parseAccountID', function() {
-    it('should extract the username and provider', function() {
+  describe('parseAccountID', function () {
+    it('should extract the username and provider', function () {
       assert.deepEqual(parseAccountID(term), {
         username: 'hacker',
         provider: 'example.com',
       });
     });
 
-    it('should return null if the ID is invalid', function() {
+    it('should return null if the ID is invalid', function () {
       assert.equal(parseAccountID('bogus'), null);
     });
   });
 
-  describe('username', function() {
-    it('should return the username from the account ID', function() {
+  describe('username', function () {
+    it('should return the username from the account ID', function () {
       assert.equal(username(term), 'hacker');
     });
 
-    it('should return an empty string if the ID is invalid', function() {
+    it('should return an empty string if the ID is invalid', function () {
       assert.equal(username('bogus'), '');
     });
   });
 
-  describe('isThirdPartyUser', function() {
-    it('should return true if user is a third party user', function() {
+  describe('isThirdPartyUser', function () {
+    it('should return true if user is a third party user', function () {
       assert.isTrue(isThirdPartyUser('acct:someone@example.com', 'ex.com'));
     });
 
-    it('should return false if user is not a third party user', function() {
+    it('should return false if user is not a third party user', function () {
       assert.isFalse(
         isThirdPartyUser('acct:someone@example.com', 'example.com')
       );
     });
 
-    it('should return false if the user is invalid', function() {
+    it('should return false if the user is invalid', function () {
       assert.isFalse(isThirdPartyUser('bogus', 'example.com'));
     });
   });

--- a/src/sidebar/util/test/annotation-metadata-test.js
+++ b/src/sidebar/util/test/annotation-metadata-test.js
@@ -4,10 +4,10 @@ import * as annotationMetadata from '../annotation-metadata';
 const documentMetadata = annotationMetadata.documentMetadata;
 const domainAndTitle = annotationMetadata.domainAndTitle;
 
-describe('annotation-metadata', function() {
-  describe('.documentMetadata', function() {
-    context('when the model has a document property', function() {
-      it('returns the hostname from model.uri as the domain', function() {
+describe('annotation-metadata', function () {
+  describe('.documentMetadata', function () {
+    context('when the model has a document property', function () {
+      it('returns the hostname from model.uri as the domain', function () {
         const model = {
           document: {},
           uri: 'http://example.com/',
@@ -16,8 +16,8 @@ describe('annotation-metadata', function() {
         assert.equal(documentMetadata(model).domain, 'example.com');
       });
 
-      context('when model.uri does not start with "urn"', function() {
-        it('uses model.uri as the uri', function() {
+      context('when model.uri does not start with "urn"', function () {
+        it('uses model.uri as the uri', function () {
           const model = {
             document: {},
             uri: 'http://example.com/',
@@ -27,8 +27,8 @@ describe('annotation-metadata', function() {
         });
       });
 
-      context('when document.title is an available', function() {
-        it('uses the first document title as the title', function() {
+      context('when document.title is an available', function () {
+        it('uses the first document title as the title', function () {
           const model = {
             uri: 'http://example.com/',
             document: {
@@ -40,8 +40,8 @@ describe('annotation-metadata', function() {
         });
       });
 
-      context('when there is no document.title', function() {
-        it('returns the domain as the title', function() {
+      context('when there is no document.title', function () {
+        it('returns the domain as the title', function () {
           const model = {
             document: {},
             uri: 'http://example.com/',
@@ -52,20 +52,20 @@ describe('annotation-metadata', function() {
       });
     });
 
-    context('when the model does not have a document property', function() {
-      it('returns model.uri for the uri', function() {
+    context('when the model does not have a document property', function () {
+      it('returns model.uri for the uri', function () {
         const model = { uri: 'http://example.com/' };
 
         assert.equal(documentMetadata(model).uri, model.uri);
       });
 
-      it('returns the hostname of model.uri for the domain', function() {
+      it('returns the hostname of model.uri for the domain', function () {
         const model = { uri: 'http://example.com/' };
 
         assert.equal(documentMetadata(model).domain, 'example.com');
       });
 
-      it('returns the hostname of model.uri for the title', function() {
+      it('returns the hostname of model.uri for the title', function () {
         const model = { uri: 'http://example.com/' };
 
         assert.equal(documentMetadata(model).title, 'example.com');
@@ -73,9 +73,9 @@ describe('annotation-metadata', function() {
     });
   });
 
-  describe('.domainAndTitle', function() {
-    context('when an annotation has a non-http(s) uri', function() {
-      it('returns no title link', function() {
+  describe('.domainAndTitle', function () {
+    context('when an annotation has a non-http(s) uri', function () {
+      it('returns no title link', function () {
         const model = {
           uri: 'file:///example.pdf',
         };
@@ -84,8 +84,8 @@ describe('annotation-metadata', function() {
       });
     });
 
-    context('when an annotation has a direct link', function() {
-      it('returns the direct link as a title link', function() {
+    context('when an annotation has a direct link', function () {
+      it('returns the direct link as a title link', function () {
         const model = {
           uri: 'https://annotatedsite.com/',
           links: {
@@ -99,8 +99,8 @@ describe('annotation-metadata', function() {
 
     context(
       'when an annotation has no direct link but has a http(s) uri',
-      function() {
-        it('returns the uri as title link', function() {
+      function () {
+        it('returns the uri as title link', function () {
           const model = {
             uri: 'https://example.com',
           };
@@ -112,8 +112,8 @@ describe('annotation-metadata', function() {
 
     context(
       'when the annotation title is shorter than 30 characters',
-      function() {
-        it('returns the annotation title as title text', function() {
+      function () {
+        it('returns the annotation title as title text', function () {
           const model = {
             uri: 'https://annotatedsite.com/',
             document: {
@@ -131,8 +131,8 @@ describe('annotation-metadata', function() {
 
     context(
       'when the annotation title is longer than 30 characters',
-      function() {
-        it('truncates the title text with "…"', function() {
+      function () {
+        it('truncates the title text with "…"', function () {
           const model = {
             uri: 'http://example.com/',
             document: {
@@ -148,8 +148,8 @@ describe('annotation-metadata', function() {
       }
     );
 
-    context('when the document uri refers to a filename', function() {
-      it('returns the filename as domain text', function() {
+    context('when the document uri refers to a filename', function () {
+      it('returns the filename as domain text', function () {
         const model = {
           uri: 'file:///path/to/example.pdf',
           document: {
@@ -161,8 +161,8 @@ describe('annotation-metadata', function() {
       });
     });
 
-    context('when domain and title are the same', function() {
-      it('returns an empty domain text string', function() {
+    context('when domain and title are the same', function () {
+      it('returns an empty domain text string', function () {
         const model = {
           uri: 'https://example.com',
           document: {
@@ -174,8 +174,8 @@ describe('annotation-metadata', function() {
       });
     });
 
-    context('when the document has no domain', function() {
-      it('returns an empty domain text string', function() {
+    context('when the document has no domain', function () {
+      it('returns an empty domain text string', function () {
         const model = {
           uri: 'doi:10.1234/5678',
           document: {
@@ -187,8 +187,8 @@ describe('annotation-metadata', function() {
       });
     });
 
-    context('when the document is a local file with a title', function() {
-      it('returns the filename', function() {
+    context('when the document is a local file with a title', function () {
+      it('returns the filename', function () {
         const model = {
           uri: 'file:///home/seanh/MyFile.pdf',
           document: {
@@ -201,8 +201,8 @@ describe('annotation-metadata', function() {
     });
   });
 
-  describe('.location', function() {
-    it('returns the position for annotations with a text position', function() {
+  describe('.location', function () {
+    it('returns the position for annotations with a text position', function () {
       assert.equal(
         annotationMetadata.location({
           target: [
@@ -220,7 +220,7 @@ describe('annotation-metadata', function() {
       );
     });
 
-    it('returns +ve infinity for annotations without a text position', function() {
+    it('returns +ve infinity for annotations without a text position', function () {
       assert.equal(
         annotationMetadata.location({
           target: [
@@ -304,29 +304,29 @@ describe('annotation-metadata', function() {
     });
   });
 
-  describe('.isPageNote', function() {
-    it('returns true for an annotation with an empty target', function() {
+  describe('.isPageNote', function () {
+    it('returns true for an annotation with an empty target', function () {
       assert.isTrue(
         annotationMetadata.isPageNote({
           target: [],
         })
       );
     });
-    it('returns true for an annotation without selectors', function() {
+    it('returns true for an annotation without selectors', function () {
       assert.isTrue(
         annotationMetadata.isPageNote({
           target: [{ selector: undefined }],
         })
       );
     });
-    it('returns true for an annotation without a target', function() {
+    it('returns true for an annotation without a target', function () {
       assert.isTrue(
         annotationMetadata.isPageNote({
           target: undefined,
         })
       );
     });
-    it('returns false for an annotation which is a reply', function() {
+    it('returns false for an annotation which is a reply', function () {
       assert.isFalse(
         annotationMetadata.isPageNote({
           target: [],
@@ -336,21 +336,21 @@ describe('annotation-metadata', function() {
     });
   });
 
-  describe('.isAnnotation', function() {
-    it('returns true if an annotation is a top level annotation', function() {
+  describe('.isAnnotation', function () {
+    it('returns true if an annotation is a top level annotation', function () {
       assert.isTrue(
         annotationMetadata.isAnnotation({
           target: [{ selector: [] }],
         })
       );
     });
-    it('returns false if an annotation has no target', function() {
+    it('returns false if an annotation has no target', function () {
       assert.isFalse(annotationMetadata.isAnnotation({}));
     });
   });
 
-  describe('.isPublic', function() {
-    it('returns true if an annotation is shared within a group', function() {
+  describe('.isPublic', function () {
+    it('returns true if an annotation is shared within a group', function () {
       assert.isTrue(annotationMetadata.isPublic(fixtures.publicAnnotation()));
     });
 
@@ -370,22 +370,22 @@ describe('annotation-metadata', function() {
       });
     });
 
-    it('returns false if an annotation is missing permissions', function() {
+    it('returns false if an annotation is missing permissions', function () {
       const annot = fixtures.defaultAnnotation();
       delete annot.permissions;
       assert.isFalse(annotationMetadata.isPublic(annot));
     });
   });
 
-  describe('.isOrphan', function() {
-    it('returns true if an annotation failed to anchor', function() {
+  describe('.isOrphan', function () {
+    it('returns true if an annotation failed to anchor', function () {
       const annotation = Object.assign(fixtures.defaultAnnotation(), {
         $orphan: true,
       });
       assert.isTrue(annotationMetadata.isOrphan(annotation));
     });
 
-    it('returns false if an annotation successfully anchored', function() {
+    it('returns false if an annotation successfully anchored', function () {
       const orphan = Object.assign(fixtures.defaultAnnotation(), {
         $orphan: false,
       });
@@ -393,36 +393,36 @@ describe('annotation-metadata', function() {
     });
   });
 
-  describe('.isWaitingToAnchor', function() {
+  describe('.isWaitingToAnchor', function () {
     const isWaitingToAnchor = annotationMetadata.isWaitingToAnchor;
 
-    it('returns true for annotations that are not yet anchored', function() {
+    it('returns true for annotations that are not yet anchored', function () {
       assert.isTrue(isWaitingToAnchor(fixtures.defaultAnnotation()));
     });
 
-    it('returns false for annotations that are anchored', function() {
+    it('returns false for annotations that are anchored', function () {
       const anchored = Object.assign({}, fixtures.defaultAnnotation(), {
         $orphan: false,
       });
       assert.isFalse(isWaitingToAnchor(anchored));
     });
 
-    it('returns false for annotations that failed to anchor', function() {
+    it('returns false for annotations that failed to anchor', function () {
       const anchored = Object.assign({}, fixtures.defaultAnnotation(), {
         $orphan: true,
       });
       assert.isFalse(isWaitingToAnchor(anchored));
     });
 
-    it('returns false for replies', function() {
+    it('returns false for replies', function () {
       assert.isFalse(isWaitingToAnchor(fixtures.oldReply()));
     });
 
-    it('returns false for page notes', function() {
+    it('returns false for page notes', function () {
       assert.isFalse(isWaitingToAnchor(fixtures.oldPageNote()));
     });
 
-    it('returns false if the anchoring timeout flag was set', function() {
+    it('returns false if the anchoring timeout flag was set', function () {
       const pending = Object.assign({}, fixtures.defaultAnnotation(), {
         $anchorTimeout: true,
       });
@@ -430,14 +430,14 @@ describe('annotation-metadata', function() {
     });
   });
 
-  describe('.flagCount', function() {
+  describe('.flagCount', function () {
     const flagCount = annotationMetadata.flagCount;
 
-    it('returns `null` if the user is not a moderator', function() {
+    it('returns `null` if the user is not a moderator', function () {
       assert.equal(flagCount(fixtures.defaultAnnotation()), null);
     });
 
-    it('returns the flag count if present', function() {
+    it('returns the flag count if present', function () {
       const ann = fixtures.moderatedAnnotation({ flagCount: 10 });
       assert.equal(flagCount(ann), 10);
     });

--- a/src/sidebar/util/test/group-organizations-test.js
+++ b/src/sidebar/util/test/group-organizations-test.js
@@ -1,9 +1,9 @@
 import * as orgFixtures from '../../test/group-fixtures';
 import groupsByOrganization from '../group-organizations';
 
-describe('group-organizations', function() {
-  context('when sorting organizations and their contained groups', function() {
-    it('should put the default organization groups last', function() {
+describe('group-organizations', function () {
+  context('when sorting organizations and their contained groups', function () {
+    it('should put the default organization groups last', function () {
       const defaultOrg = orgFixtures.defaultOrganization();
       const groups = [
         orgFixtures.expandedGroup({ organization: defaultOrg }),
@@ -16,7 +16,7 @@ describe('group-organizations', function() {
       assert.equal(sortedGroups[2].organization.id, defaultOrg.id);
     });
 
-    it('should sort organizations by name', function() {
+    it('should sort organizations by name', function () {
       const org1 = orgFixtures.organization({ name: 'zzzzz' });
       const org2 = orgFixtures.organization({ name: 'aaaaa' });
       const org3 = orgFixtures.organization({ name: 'yyyyy' });
@@ -33,7 +33,7 @@ describe('group-organizations', function() {
       assert.equal(sortedGroups[2].organization.name, 'zzzzz');
     });
 
-    it('should sort organizations secondarily by id', function() {
+    it('should sort organizations secondarily by id', function () {
       const org1 = orgFixtures.organization({ name: 'zzzzz', id: 'zzzzz' });
       const org2 = orgFixtures.organization({ name: 'zzzzz', id: 'aaaaa' });
       const org3 = orgFixtures.organization({ name: 'zzzzz', id: 'yyyyy' });
@@ -50,7 +50,7 @@ describe('group-organizations', function() {
       assert.equal(sortedGroups[2].organization.id, 'zzzzz');
     });
 
-    it('should only include logo for first group in each organization', function() {
+    it('should only include logo for first group in each organization', function () {
       const org = orgFixtures.organization({ name: 'Aluminum' });
       const org2 = orgFixtures.organization({ name: 'Zirconium' });
       const groups = [
@@ -69,8 +69,8 @@ describe('group-organizations', function() {
     });
   });
 
-  context('when encountering missing data', function() {
-    it('should be able to sort without any groups in the default org', function() {
+  context('when encountering missing data', function () {
+    it('should be able to sort without any groups in the default org', function () {
       const org = orgFixtures.organization({ name: 'Aluminum' });
       const groups = [
         { name: 'Aluminum', organization: org },
@@ -85,7 +85,7 @@ describe('group-organizations', function() {
       });
     });
 
-    it('should omit any groups without an organization', function() {
+    it('should omit any groups without an organization', function () {
       const org = orgFixtures.organization({ name: 'Europium' });
       const groups = [
         { name: 'Aluminum', organization: org },
@@ -102,7 +102,7 @@ describe('group-organizations', function() {
       });
     });
 
-    it('should omit any groups with unexpanded organizations', function() {
+    it('should omit any groups with unexpanded organizations', function () {
       const org = orgFixtures.organization({ name: 'Europium' });
       const groups = [
         { name: 'Aluminum', organization: org },
@@ -119,7 +119,7 @@ describe('group-organizations', function() {
       });
     });
 
-    it('should omit logo property if not present on organization', function() {
+    it('should omit logo property if not present on organization', function () {
       const org = orgFixtures.organization({ logo: undefined });
       const org2 = orgFixtures.organization({ logo: null });
       const groups = [
@@ -137,8 +137,8 @@ describe('group-organizations', function() {
     });
   });
 
-  context('when building data structures', function() {
-    it('returned group objects should be immutable', function() {
+  context('when building data structures', function () {
+    it('returned group objects should be immutable', function () {
       const group = orgFixtures.expandedGroup({ name: 'Halfnium' });
       const groups = [group];
 

--- a/src/sidebar/util/test/memoize-test.js
+++ b/src/sidebar/util/test/memoize-test.js
@@ -1,6 +1,6 @@
 import memoize from '../memoize';
 
-describe('memoize', function() {
+describe('memoize', function () {
   let count = 0;
   let memoized;
 
@@ -9,22 +9,22 @@ describe('memoize', function() {
     return arg * arg;
   }
 
-  beforeEach(function() {
+  beforeEach(function () {
     count = 0;
     memoized = memoize(square);
   });
 
-  it('computes the result of the function', function() {
+  it('computes the result of the function', function () {
     assert.equal(memoized(12), 144);
   });
 
-  it('does not recompute if the input is unchanged', function() {
+  it('does not recompute if the input is unchanged', function () {
     memoized(42);
     memoized(42);
     assert.equal(count, 1);
   });
 
-  it('recomputes if the input changes', function() {
+  it('recomputes if the input changes', function () {
     memoized(42);
     memoized(39);
     assert.equal(count, 2);

--- a/src/sidebar/util/test/observe-element-size-test.js
+++ b/src/sidebar/util/test/observe-element-size-test.js
@@ -48,7 +48,7 @@ describe('observeElementSize', () => {
     stopObserving = observeElementSize(content, sizeChanged);
   }
 
-  context('when `ResizeObserver` is available', function() {
+  context('when `ResizeObserver` is available', function () {
     if (typeof ResizeObserver === 'undefined') {
       this.skip();
     }

--- a/src/sidebar/util/test/retry-test.js
+++ b/src/sidebar/util/test/retry-test.js
@@ -1,19 +1,19 @@
 import { toResult } from '../../../shared/test/promise-util';
 import * as retryUtil from '../retry';
 
-describe('sidebar.util.retry', function() {
-  describe('.retryPromiseOperation', function() {
-    it('should return the result of the operation function', function() {
+describe('sidebar.util.retry', function () {
+  describe('.retryPromiseOperation', function () {
+    it('should return the result of the operation function', function () {
       const operation = sinon.stub().returns(Promise.resolve(42));
       const wrappedOperation = retryUtil.retryPromiseOperation(operation);
-      return wrappedOperation.then(function(result) {
+      return wrappedOperation.then(function (result) {
         assert.equal(result, 42);
       });
     });
 
-    it('should retry the operation if it fails', function() {
+    it('should retry the operation if it fails', function () {
       const results = [new Error('fail'), 'ok'];
-      const operation = sinon.spy(function() {
+      const operation = sinon.spy(function () {
         const nextResult = results.shift();
         if (nextResult instanceof Error) {
           return Promise.reject(nextResult);
@@ -24,21 +24,21 @@ describe('sidebar.util.retry', function() {
       const wrappedOperation = retryUtil.retryPromiseOperation(operation, {
         minTimeout: 1,
       });
-      return wrappedOperation.then(function(result) {
+      return wrappedOperation.then(function (result) {
         assert.equal(result, 'ok');
       });
     });
 
-    it('should return the error if it repeatedly fails', function() {
+    it('should return the error if it repeatedly fails', function () {
       const error = new Error('error');
-      const operation = sinon.spy(function() {
+      const operation = sinon.spy(function () {
         return Promise.reject(error);
       });
       const wrappedOperation = retryUtil.retryPromiseOperation(operation, {
         minTimeout: 3,
         retries: 2,
       });
-      return toResult(wrappedOperation).then(function(result) {
+      return toResult(wrappedOperation).then(function (result) {
         assert.equal(result.error, error);
       });
     });

--- a/src/sidebar/util/test/scope-timeout-test.js
+++ b/src/sidebar/util/test/scope-timeout-test.js
@@ -2,27 +2,27 @@ import scopeTimeout from '../scope-timeout';
 
 function FakeScope() {
   this.listeners = {};
-  this.$on = function(event, fn) {
+  this.$on = function (event, fn) {
     this.listeners[event] = this.listeners[event] || [];
     this.listeners[event].push(fn);
-    return function() {
-      this.listeners[event] = this.listeners[event].filter(function(otherFn) {
+    return function () {
+      this.listeners[event] = this.listeners[event].filter(function (otherFn) {
         return otherFn !== fn;
       });
     }.bind(this);
   };
 }
 
-describe('scope-timeout', function() {
+describe('scope-timeout', function () {
   let fakeSetTimeout;
   let fakeClearTimeout;
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeSetTimeout = sinon.stub().returns(42);
     fakeClearTimeout = sinon.stub();
   });
 
-  it('schedules a timeout', function() {
+  it('schedules a timeout', function () {
     const $scope = new FakeScope();
     const callback = sinon.stub();
     scopeTimeout($scope, callback, 0, fakeSetTimeout, fakeClearTimeout);
@@ -32,7 +32,7 @@ describe('scope-timeout', function() {
     assert.called(callback);
   });
 
-  it('removes the scope listener when the timeout fires', function() {
+  it('removes the scope listener when the timeout fires', function () {
     const $scope = new FakeScope();
     const callback = sinon.stub();
     scopeTimeout($scope, callback, 0, fakeSetTimeout, fakeClearTimeout);
@@ -42,7 +42,7 @@ describe('scope-timeout', function() {
     assert.equal($scope.listeners.$destroy.length, 0);
   });
 
-  it('clears the timeout when the scope is destroyed', function() {
+  it('clears the timeout when the scope is destroyed', function () {
     const $scope = new FakeScope();
     const callback = sinon.stub();
     scopeTimeout($scope, callback, 0, fakeSetTimeout, fakeClearTimeout);

--- a/src/sidebar/util/test/service-context-test.js
+++ b/src/sidebar/util/test/service-context-test.js
@@ -78,10 +78,7 @@ describe('service-context', () => {
   describe('useService', () => {
     it('returns the named service', () => {
       const injector = {
-        get: sinon
-          .stub()
-          .withArgs('aService')
-          .returns('aValue'),
+        get: sinon.stub().withArgs('aService').returns('aValue'),
       };
       function TestComponent() {
         const value = useService('aService');

--- a/src/sidebar/util/test/session-test.js
+++ b/src/sidebar/util/test/session-test.js
@@ -2,7 +2,7 @@ import * as sessionUtil from '../session';
 
 describe('sidebar/util/session', () => {
   describe('#shouldShowSidebarTutorial', () => {
-    it('shows sidebar tutorial if the settings object has the show_sidebar_tutorial key set', function() {
+    it('shows sidebar tutorial if the settings object has the show_sidebar_tutorial key set', function () {
       const sessionState = {
         preferences: {
           show_sidebar_tutorial: true,
@@ -12,7 +12,7 @@ describe('sidebar/util/session', () => {
       assert.isTrue(sessionUtil.shouldShowSidebarTutorial(sessionState));
     });
 
-    it('hides sidebar tutorial if the settings object does not have the show_sidebar_tutorial key set', function() {
+    it('hides sidebar tutorial if the settings object does not have the show_sidebar_tutorial key set', function () {
       const sessionState = {
         preferences: {
           show_sidebar_tutorial: false,

--- a/src/sidebar/util/test/state-test.js
+++ b/src/sidebar/util/test/state-test.js
@@ -1,16 +1,16 @@
 import fakeStore from '../../test/fake-redux-store';
 import * as stateUtil from '../state';
 
-describe('sidebar/util/state', function() {
+describe('sidebar/util/state', function () {
   let store;
 
-  beforeEach(function() {
+  beforeEach(function () {
     store = fakeStore({
       fake: { val: 0 },
     });
   });
 
-  describe('awaitStateChange()', function() {
+  describe('awaitStateChange()', function () {
     function getValWhenGreaterThanTwo(store) {
       if (store.getState().val < 3) {
         return null;
@@ -18,17 +18,17 @@ describe('sidebar/util/state', function() {
       return store.getState().val;
     }
 
-    it('should return promise that resolves to a non-null value', function() {
+    it('should return promise that resolves to a non-null value', function () {
       const expected = 5;
       store.setState({ val: 5 });
       return stateUtil
         .awaitStateChange(store, getValWhenGreaterThanTwo)
-        .then(function(actual) {
+        .then(function (actual) {
           assert.equal(actual, expected);
         });
     });
 
-    it('should wait for awaitStateChange to return a non-null value', function() {
+    it('should wait for awaitStateChange to return a non-null value', function () {
       let valPromise;
       const expected = 5;
 
@@ -36,7 +36,7 @@ describe('sidebar/util/state', function() {
       valPromise = stateUtil.awaitStateChange(store, getValWhenGreaterThanTwo);
       store.setState({ val: 5 });
 
-      return valPromise.then(function(actual) {
+      return valPromise.then(function (actual) {
         assert.equal(actual, expected);
       });
     });

--- a/src/sidebar/util/test/tabs-test.js
+++ b/src/sidebar/util/test/tabs-test.js
@@ -2,8 +2,8 @@ import * as fixtures from '../../test/annotation-fixtures';
 import uiConstants from '../../ui-constants';
 import * as tabs from '../tabs';
 
-describe('tabs', function() {
-  describe('tabForAnnotation', function() {
+describe('tabs', function () {
+  describe('tabForAnnotation', function () {
     [
       {
         ann: fixtures.defaultAnnotation(),
@@ -26,7 +26,7 @@ describe('tabs', function() {
     });
   });
 
-  describe('shouldShowInTab', function() {
+  describe('shouldShowInTab', function () {
     [
       {
         // Anchoring in progress.

--- a/src/sidebar/util/test/time-test.js
+++ b/src/sidebar/util/test/time-test.js
@@ -5,11 +5,11 @@ const minute = second * 60;
 const hour = minute * 60;
 const day = hour * 24;
 
-describe('sidebar.util.time', function() {
+describe('sidebar.util.time', function () {
   let sandbox;
   let fakeIntl;
 
-  beforeEach(function() {
+  beforeEach(function () {
     sandbox = sinon.createSandbox();
     sandbox.useFakeTimers();
 
@@ -23,7 +23,7 @@ describe('sidebar.util.time', function() {
     time.clearFormatters();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     sandbox.restore();
   });
 
@@ -46,8 +46,8 @@ describe('sidebar.util.time', function() {
     return date;
   };
 
-  describe('.toFuzzyString', function() {
-    it('Handles empty dates', function() {
+  describe('.toFuzzyString', function () {
+    it('Handles empty dates', function () {
       const date = null;
       const expect = '';
       assert.equal(time.toFuzzyString(date, undefined), expect);
@@ -121,7 +121,7 @@ describe('sidebar.util.time', function() {
       );
     });
 
-    it('falls back to simple strings for >24hrs ago', function() {
+    it('falls back to simple strings for >24hrs ago', function () {
       // If window.Intl is not available then the date formatting for dates
       // more than one day ago falls back to a simple date string.
       const timeStamp = fakeDate('1970-01-01T00:00:00.000Z');
@@ -133,7 +133,7 @@ describe('sidebar.util.time', function() {
       assert.equal(formattedDate, 'Thu Jan 01 1970');
     });
 
-    it('falls back to simple strings for >1yr ago', function() {
+    it('falls back to simple strings for >1yr ago', function () {
       // If window.Intl is not available then the date formatting for dates
       // more than one year ago falls back to a simple date string.
       const timeStamp = fakeDate('1970-01-01T00:00:00.000Z');
@@ -146,13 +146,13 @@ describe('sidebar.util.time', function() {
     });
   });
 
-  describe('.decayingInterval', function() {
-    it('Handles empty dates', function() {
+  describe('.decayingInterval', function () {
+    it('Handles empty dates', function () {
       const date = null;
       time.decayingInterval(date, undefined);
     });
 
-    it('uses a short delay for recent timestamps', function() {
+    it('uses a short delay for recent timestamps', function () {
       const date = new Date().toISOString();
       const callback = sandbox.stub();
       time.decayingInterval(date, callback);
@@ -162,7 +162,7 @@ describe('sidebar.util.time', function() {
       assert.calledTwice(callback);
     });
 
-    it('uses a longer delay for older timestamps', function() {
+    it('uses a longer delay for older timestamps', function () {
       const date = new Date().toISOString();
       const ONE_MINUTE = minute;
       sandbox.clock.tick(10 * ONE_MINUTE);
@@ -176,7 +176,7 @@ describe('sidebar.util.time', function() {
       assert.calledTwice(callback);
     });
 
-    it('returned function cancels the timer', function() {
+    it('returned function cancels the timer', function () {
       const date = new Date().toISOString();
       const callback = sandbox.stub();
       const cancel = time.decayingInterval(date, callback);
@@ -185,7 +185,7 @@ describe('sidebar.util.time', function() {
       assert.notCalled(callback);
     });
 
-    it('does not set a timeout for dates > 24hrs ago', function() {
+    it('does not set a timeout for dates > 24hrs ago', function () {
       const date = new Date().toISOString();
       const ONE_DAY = day;
       sandbox.clock.tick(10 * ONE_DAY);
@@ -198,8 +198,8 @@ describe('sidebar.util.time', function() {
     });
   });
 
-  describe('.nextFuzzyUpdate', function() {
-    it('Handles empty dates', function() {
+  describe('.nextFuzzyUpdate', function () {
+    it('Handles empty dates', function () {
       const date = null;
       const expect = null;
       assert.equal(time.nextFuzzyUpdate(date, undefined), expect);

--- a/src/sidebar/util/test/url-test.js
+++ b/src/sidebar/util/test/url-test.js
@@ -1,22 +1,22 @@
 import * as urlUtil from '../url';
 
-describe('sidebar/util/url', function() {
-  describe('replaceURLParams()', function() {
-    it('should replace params in URLs', function() {
+describe('sidebar/util/url', function () {
+  describe('replaceURLParams()', function () {
+    it('should replace params in URLs', function () {
       const replaced = urlUtil.replaceURLParams('http://foo.com/things/:id', {
         id: 'test',
       });
       assert.equal(replaced.url, 'http://foo.com/things/test');
     });
 
-    it('should URL encode params in URLs', function() {
+    it('should URL encode params in URLs', function () {
       const replaced = urlUtil.replaceURLParams('http://foo.com/things/:id', {
         id: 'foo=bar',
       });
       assert.equal(replaced.url, 'http://foo.com/things/foo%3Dbar');
     });
 
-    it('should return unused params', function() {
+    it('should return unused params', function () {
       const replaced = urlUtil.replaceURLParams('http://foo.com/:id', {
         id: 'test',
         q: 'unused',

--- a/src/sidebar/virtual-thread-list.js
+++ b/src/sidebar/virtual-thread-list.js
@@ -51,7 +51,7 @@ export default class VirtualThreadList extends EventEmitter {
     this.scrollRoot.addEventListener('scroll', debouncedUpdate);
     this.window.addEventListener('resize', debouncedUpdate);
 
-    this._detach = function() {
+    this._detach = function () {
       this.scrollRoot.removeEventListener('scroll', debouncedUpdate);
       this.window.removeEventListener('resize', debouncedUpdate);
       debouncedUpdate.cancel();
@@ -111,13 +111,13 @@ export default class VirtualThreadList extends EventEmitter {
   yOffsetOf(id) {
     const self = this;
     const allThreads = this._rootThread.children;
-    const matchIndex = allThreads.findIndex(function(thread) {
+    const matchIndex = allThreads.findIndex(function (thread) {
       return thread.id === id;
     });
     if (matchIndex === -1) {
       return 0;
     }
-    return allThreads.slice(0, matchIndex).reduce(function(offset, thread) {
+    return allThreads.slice(0, matchIndex).reduce(function (offset, thread) {
       return offset + self._height(thread.id);
     }, 0);
   }

--- a/src/sidebar/websocket.js
+++ b/src/sidebar/websocket.js
@@ -64,13 +64,13 @@ export default class Socket extends EventEmitter {
         randomize: true,
       });
 
-      operation.attempt(function() {
+      operation.attempt(function () {
         socket = new WebSocket(url);
-        socket.onopen = function(event) {
+        socket.onopen = function (event) {
           onOpen();
           self.emit('open', event);
         };
-        socket.onclose = function(event) {
+        socket.onclose = function (event) {
           if (event.code === CLOSE_NORMAL || event.code === CLOSE_GOING_AWAY) {
             self.emit('close', event);
             return;
@@ -81,10 +81,10 @@ export default class Socket extends EventEmitter {
           console.warn(err);
           onAbnormalClose(err);
         };
-        socket.onerror = function(event) {
+        socket.onerror = function (event) {
           self.emit('error', event);
         };
-        socket.onmessage = function(event) {
+        socket.onmessage = function (event) {
           self.emit('message', event);
         };
       });
@@ -112,14 +112,14 @@ export default class Socket extends EventEmitter {
       // ...otherwise reconnect the websocket after a short delay.
       let delay = RECONNECT_MIN_DELAY;
       delay += Math.floor(Math.random() * delay);
-      operation = setTimeout(function() {
+      operation = setTimeout(function () {
         operation = null;
         connect();
       }, delay);
     }
 
     /** Close the underlying WebSocket connection */
-    this.close = function() {
+    this.close = function () {
       // nb. Always sent a status code in the `close()` call to work around
       // a problem in the backend's ws4py library.
       //
@@ -140,7 +140,7 @@ export default class Socket extends EventEmitter {
      * Send a JSON object via the WebSocket connection, or queue it
      * for later delivery if not currently connected.
      */
-    this.send = function(message) {
+    this.send = function (message) {
       messageQueue.push(message);
       if (this.isConnected()) {
         sendMessages();
@@ -148,7 +148,7 @@ export default class Socket extends EventEmitter {
     };
 
     /** Returns true if the WebSocket is currently connected. */
-    this.isConnected = function() {
+    this.isConnected = function () {
       return socket.readyState === WebSocket.OPEN;
     };
 


### PR DESCRIPTION
Update `.prettierrc` to match other projects (lms, browser-extension) which have already been updated to Prettier v2 and reformat code using `make format`.

Most of the changes in the diff are one of:

- Adding a space between `function` keyword and `(` for anonymous functions
- Several chained property accesses (`foo(...).bar(...).baz()`) which used to be wrapped onto multiple lines are not put on one line.