### PR TITLE
Tighten up display of headers for collapsed replies in threads

### DIFF
--- a/src/sidebar/components/annotation-share-info.js
+++ b/src/sidebar/components/annotation-share-info.js
@@ -44,18 +44,9 @@ function AnnotationShareInfo({ annotation }) {
           </span>
         </a>
       )}
-      {annotationIsPrivate && (
+      {annotationIsPrivate && !linkToGroup && (
         <span className="annotation-share-info__private">
-          {/* Show the lock icon in all cases when the annotation is private... */}
-          <SvgIcon
-            className="annotation-share-info__icon"
-            name="lock"
-            title="This annotation is visible only to you"
-          />
-          {/* but only render the "Only Me" text if we're not showing/linking a group name */}
-          {!linkToGroup && (
-            <span className="annotation-share-info__private-info">Only me</span>
-          )}
+          <span className="annotation-share-info__private-info">Only me</span>
         </span>
       )}
     </div>

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -4,7 +4,7 @@ import { useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import useStore from '../store/use-store';
-import { isNew, isReply, quote } from '../util/annotation-metadata';
+import { isReply, quote } from '../util/annotation-metadata';
 import { isShared } from '../util/permissions';
 import { withServices } from '../util/service-context';
 
@@ -38,6 +38,7 @@ function Annotation({
   const group = useStore(store => store.getGroup(annotation.group));
   const userid = useStore(store => store.profile().userid);
 
+  const isCollapsedReply = isReply(annotation) && threadIsCollapsed;
   const isPrivate = draft ? draft.isPrivate : !isShared(annotation.permissions);
   const tags = draft ? draft.tags : annotation.tags;
   const text = draft ? draft.text : annotation.text;
@@ -51,7 +52,7 @@ function Annotation({
   const toggleAction = threadIsCollapsed ? 'Show replies' : 'Hide replies';
   const toggleText = `${toggleAction} (${replyCount})`;
 
-  const shouldShowActions = !isSaving && !isEditing && !isNew(annotation);
+  const shouldShowActions = !isSaving && !isEditing && !isCollapsedReply;
   const shouldShowLicense = isEditing && !isPrivate && group.type !== 'private';
   const shouldShowReplyToggle = replyCount > 0 && !isReply(annotation);
 

--- a/src/sidebar/components/test/annotation-share-info-test.js
+++ b/src/sidebar/components/test/annotation-share-info-test.js
@@ -106,30 +106,12 @@ describe('AnnotationShareInfo', () => {
 
       assert.notOk(privacy.exists());
     });
+
     context('private annotation', () => {
       beforeEach(() => {
         fakeIsPrivate.returns(true);
       });
 
-      it('should show privacy icon', () => {
-        const wrapper = createAnnotationShareInfo();
-
-        const privacyIcon = wrapper.find(
-          '.annotation-share-info__private .annotation-share-info__icon'
-        );
-
-        assert.isOk(privacyIcon.exists());
-        assert.equal(privacyIcon.prop('name'), 'lock');
-      });
-      it('should not show "only me" text for first-party group', () => {
-        const wrapper = createAnnotationShareInfo();
-
-        const privacyText = wrapper.find(
-          '.annotation-share-info__private-info'
-        );
-
-        assert.notOk(privacyText.exists());
-      });
       it('should show "only me" text for annotation in third-party group', () => {
         fakeGetGroup.returns({ name: 'Some Name' });
         const wrapper = createAnnotationShareInfo();

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -62,7 +62,6 @@ describe('Annotation', () => {
     };
 
     fakeMetadata = {
-      isNew: sinon.stub(),
       isReply: sinon.stub(),
       quote: sinon.stub(),
     };
@@ -463,10 +462,9 @@ describe('Annotation', () => {
       assert.isFalse(wrapper.find('AnnotationActionBar').exists());
     });
 
-    it('should not show annotation actions for new annotation', () => {
-      fakeMetadata.isNew.returns(true);
-
-      const wrapper = createComponent();
+    it('should not show annotations if the annotation is a collapsed reply', () => {
+      fakeMetadata.isReply.returns(true);
+      const wrapper = createComponent({ threadIsCollapsed: true });
 
       assert.isFalse(wrapper.find('AnnotationActionBar').exists());
     });

--- a/src/styles/sidebar/components/annotation-header.scss
+++ b/src/styles/sidebar/components/annotation-header.scss
@@ -14,6 +14,13 @@
     align-items: baseline;
   }
 
+  &__icon {
+    margin-right: 5px;
+    width: 10px;
+    height: 10px;
+    color: var.$grey-6;
+  }
+
   &__reply-toggle.button {
     padding: 0 0.5em;
     font-weight: 400;


### PR DESCRIPTION
This PR builds on some design tuning for threaded annotation replies. It makes some tweaks to optimize the flow of collapsed reply threads, primarily. Net result: collapsed replies only take up "one line" visually now.

These changes are based on a [Slack design discussion accessible to Hypothesis team members](https://hypothes-is.slack.com/archives/C07NXBDNW/p1585144768001900).

Before these changes, a complex thread with some expanded, some collapsed replies looked like:

<img width="429" alt="Screen Shot 2020-03-31 at 1 15 43 PM" src="https://user-images.githubusercontent.com/439947/78055857-285e4280-7352-11ea-9f46-07f87b4df47e.png">

After these changes, the same threads and state:

<img width="431" alt="Screen Shot 2020-03-31 at 1 16 21 PM" src="https://user-images.githubusercontent.com/439947/78055872-2eecba00-7352-11ea-9de2-8f46857790de.png">

Changes:

* "Only me" icon is moved up next to user display name and is always rendered (when applicable)
* Group name is only rendered for top-level annotations. It is not rendered at all for replies, whether they are expanded or not. All replies belong to the same group as their topmost anontation.
* Collapsed annotation replies do not render the edited timestamp, if any.
* Annotation controls are not rendered for collapsed replies
* "0 replies" will not render next to collapsed threads anymore—there has to be at least one reply that is hidden for this control to show up now.

Fixes https://github.com/hypothesis/client/issues/1845
