### PR TITLE
Validate prop types in tests

### DIFF
--- a/src/sidebar/components/menu-section.js
+++ b/src/sidebar/components/menu-section.js
@@ -38,8 +38,5 @@ MenuSection.propTypes = {
   /**
    * Menu items to display in this section.
    */
-  children: propTypes.oneOfType([
-    propTypes.object,
-    propTypes.arrayOf(propTypes.object),
-  ]).isRequired,
+  children: propTypes.any.isRequired,
 };

--- a/src/sidebar/components/test/markdown-editor-test.js
+++ b/src/sidebar/components/test/markdown-editor-test.js
@@ -6,6 +6,7 @@ import { LinkType } from '../../markdown-commands';
 import MarkdownEditor from '../markdown-editor';
 import { $imports } from '../markdown-editor';
 
+import mockImportedComponents from '../../../test-util/mock-imported-components';
 import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('MarkdownEditor', () => {
@@ -32,6 +33,7 @@ describe('MarkdownEditor', () => {
       return null;
     };
 
+    $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../markdown-commands': fakeMarkdownCommands,
       './markdown-view': MarkdownView,

--- a/src/sidebar/components/test/search-input-test.js
+++ b/src/sidebar/components/test/search-input-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import SearchInput from '../search-input';
 import { $imports } from '../search-input';
 
+import mockImportedComponents from '../../../test-util/mock-imported-components';
 import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('SearchInput', () => {
@@ -22,11 +23,8 @@ describe('SearchInput', () => {
   beforeEach(() => {
     fakeStore = { isLoading: sinon.stub().returns(false) };
 
-    const FakeSpinner = () => null;
-    FakeSpinner.displayName = 'Spinner';
-
+    $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      './spinner': FakeSpinner,
       '../store/use-store': callback => callback(fakeStore),
     });
   });
@@ -84,7 +82,7 @@ describe('SearchInput', () => {
   it('renders search button when app is not in "loading" state', () => {
     fakeStore.isLoading.returns(false);
     const wrapper = createSearchInput();
-    assert.isTrue(wrapper.exists('button'));
+    assert.isTrue(wrapper.exists('Button'));
   });
 
   it(

--- a/src/sidebar/components/test/version-info-test.js
+++ b/src/sidebar/components/test/version-info-test.js
@@ -4,6 +4,7 @@ import { createElement } from 'preact';
 import VersionInfo from '../version-info';
 import { $imports } from '../version-info';
 
+import mockImportedComponents from '../../../test-util/mock-imported-components';
 import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('VersionInfo', function () {
@@ -32,6 +33,7 @@ describe('VersionInfo', function () {
     fakeCopyToClipboard = {
       copyText: sinon.stub(),
     };
+    $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../util/copy-to-clipboard': fakeCopyToClipboard,
     });
@@ -65,7 +67,7 @@ describe('VersionInfo', function () {
     it('copies version info to clipboard when copy button clicked', () => {
       const wrapper = createComponent();
 
-      wrapper.find('button').simulate('click');
+      wrapper.find('Button').props().onClick();
 
       assert.calledWith(fakeCopyToClipboard.copyText, 'fakeString');
     });
@@ -73,7 +75,7 @@ describe('VersionInfo', function () {
     it('confirms info copy when successful', () => {
       const wrapper = createComponent();
 
-      wrapper.find('button').simulate('click');
+      wrapper.find('Button').props().onClick();
 
       assert.calledWith(
         fakeToastMessenger.success,
@@ -85,7 +87,7 @@ describe('VersionInfo', function () {
       fakeCopyToClipboard.copyText.throws();
       const wrapper = createComponent();
 
-      wrapper.find('button').simulate('click');
+      wrapper.find('Button').props().onClick();
 
       assert.calledWith(
         fakeToastMessenger.error,

--- a/src/test-util/mock-imported-components.js
+++ b/src/test-util/mock-imported-components.js
@@ -59,7 +59,13 @@ export default function mockImportedComponents() {
     }
 
     const mock = props => props.children;
+
+    // Make it possible to do `wrapper.find('ComponentName')` where `wrapper`
+    // is an Enzyme wrapper.
     mock.displayName = getDisplayName(value);
+
+    // Mocked components validate props in the same way as the real component.
+    mock.propTypes = value.propTypes;
 
     return mock;
   };


### PR DESCRIPTION
This PR modifies `mockImportedComponents` so that the mocked components has the same `propTypes` property as the original. As a result, prop types are now validated in tests in the same  way as they are in the actual app.

I also added `mockImportedComponents` to a few existing tests which were not using it, making them more unit-y.

I found one issue with `MenuSection` when used by `UserMenu` in the process.

Note that `mockImportedComponents` is duplicated in the lms repo and that needs updating. My plan is that we'll extract this helper into a shared package soon which we can import into that repo.

