### PR TITLE
Remove remaining implicit jQuery imports

### DIFF
--- a/src/annotator/plugin/test/bucket-bar-test.coffee
+++ b/src/annotator/plugin/test/bucket-bar-test.coffee
@@ -1,3 +1,5 @@
+$ = require('jquery')
+
 BucketBar = require('../bucket-bar')
 
 # Return DOM elements for non-empty bucket indicators in a `BucketBar`.

--- a/src/annotator/plugin/test/cross-frame-test.coffee
+++ b/src/annotator/plugin/test/cross-frame-test.coffee
@@ -1,3 +1,5 @@
+$ = require('jquery')
+
 Plugin = require('../../plugin')
 CrossFrame = require('../cross-frame')
 { $imports } = require('../cross-frame')

--- a/src/annotator/test/sidebar-test.coffee
+++ b/src/annotator/test/sidebar-test.coffee
@@ -1,3 +1,5 @@
+$ = require('jquery')
+
 { default: events } = require('../../shared/bridge-events')
 
 Sidebar = require('../sidebar')

--- a/src/sidebar/test/bootstrap.js
+++ b/src/sidebar/test/bootstrap.js
@@ -1,20 +1,8 @@
 // Expose the sinon assertions.
 sinon.assert.expose(assert, { prefix: null });
 
-// Load Angular libraries required by tests.
-//
-// The tests for Client currently rely on having
-// a full version of jQuery available and several of
-// the directive tests rely on angular.element() returning
-// a full version of jQuery.
-//
-
-import jQuery from 'jquery';
-
 import 'angular';
 import 'angular-mocks';
-
-window.jQuery = window.$ = jQuery;
 
 // Configure Enzyme for UI tests.
 import 'preact/debug';


### PR DESCRIPTION
This is a bit of clean up following on from 6717bac55d24bf33ffc6376c3ec7c6ab0994686a and contributing to the gradual removal of jQuery from the app (it has been fully gone from the sidebar for a while, but is still used in the "annotator" part of the code).

- Remove obsolete comments in `src/sidebar/test/bootstrap.js` about
  Angular using the full version of jQuery. This no longer applies.

- Remove the last few uses of the `$` global variable to reference
  jQuery and replace it with an explicit import. This will make it
  easier to identify the remaining parts of the app that are still using
  it.