### PR TITLE
Adjust some HTML semantic structural elements

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -92,8 +92,8 @@ function Annotation({
   const onToggleReplies = () => setCollapsed(annotation.id, !threadIsCollapsed);
 
   return (
-    /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
-    <div
+    /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
+    <article
       className={classnames('annotation', {
         'annotation--reply': isReply(annotation),
         'is-collapsed': threadIsCollapsed,
@@ -144,7 +144,7 @@ function Annotation({
           )}
         </div>
       </footer>
-    </div>
+    </article>
   );
 }
 

--- a/src/sidebar/components/thread.js
+++ b/src/sidebar/components/thread.js
@@ -42,7 +42,7 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
 
   const onToggleReplies = () => setCollapsed(thread.id, !thread.collapsed);
   return (
-    <div
+    <section
       className={classnames('thread', {
         'thread--reply': thread.depth > 0,
         'is-collapsed': thread.collapsed,
@@ -96,7 +96,7 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
           </ul>
         )}
       </div>
-    </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
This tiny PR makes a few simple semantic adjustments to content sections:

* `Thread`s are `section`s instead of `div`s
* `Annotation`s are `article`s instead of `div`s
* `AnnotationQuote` has been wrapped in an `aside` versus a `section`. I'm not fiercely wedded to this but it seems generally consistent.

Part of https://github.com/hypothesis/client/issues/1927