### PR TITLE
Replace `module.exports` with ES exports

### DIFF
--- a/src/sidebar/cross-origin-rpc.js
+++ b/src/sidebar/cross-origin-rpc.js
@@ -48,7 +48,7 @@ function isJsonRpcMessage(data) {
  * All methods called upon must be mapped in the `registeredMethods` function.
  */
 // @ngInject
-function start(store, settings, $window) {
+export function startServer(store, settings, $window) {
   const methods = registeredMethods(store);
 
   // Process the pre-start incoming RPC requests
@@ -128,11 +128,6 @@ function preStartMessageListener(event) {
  *
  * @param {Window} window_ - Test seam
  */
-function preStart(window_ = window) {
+export function preStartServer(window_ = window) {
   window_.addEventListener('message', preStartMessageListener);
 }
-
-module.exports = {
-  preStartServer: preStart,
-  startServer: start,
-};

--- a/src/sidebar/util/service-context.js
+++ b/src/sidebar/util/service-context.js
@@ -52,7 +52,7 @@ export const ServiceContext = createContext(fallbackInjector);
  *   MyComponent.injectedProps = ['settings']
  *
  *   // Wrap `MyComponent` to inject any services it needs.
- *   module.exports = withServices(MyComponent);
+ *   export default withServices(MyComponent);
  */
 export function withServices(Component) {
   if (!Component.injectedProps) {


### PR DESCRIPTION
Change `cross-origin-rpc.js` to use ES exports instead of `module.exports`
for consistency with other modules.

Also update documentation in `service-context.js` to use ES exports.