### PR TITLE
Fix annotation and thread vertical rhythm and layout

### DIFF
--- a/src/sidebar/components/annotation-body.js
+++ b/src/sidebar/components/annotation-body.js
@@ -1,4 +1,4 @@
-import { Fragment, createElement } from 'preact';
+import { createElement } from 'preact';
 import { useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
@@ -8,6 +8,8 @@ import Button from './button';
 import Excerpt from './excerpt';
 import MarkdownEditor from './markdown-editor';
 import MarkdownView from './markdown-view';
+import TagEditor from './tag-editor';
+import TagList from './tag-list';
 
 /**
  * Display the rendered content of an annotation.
@@ -15,7 +17,9 @@ import MarkdownView from './markdown-view';
 export default function AnnotationBody({
   annotation,
   isEditing,
+  onEditTags,
   onEditText,
+  tags,
   text,
 }) {
   // Should the text content of `Excerpt` be rendered in a collapsed state,
@@ -31,36 +35,37 @@ export default function AnnotationBody({
     ? 'Show full annotation text'
     : 'Show the first few lines only';
 
+  const showExcerpt = !isEditing && text.length > 0;
+  const showTagList = !isEditing && tags.length > 0;
+
   return (
-    <Fragment>
-      <section className="annotation-body">
-        {!isEditing && (
-          <Excerpt
-            collapse={isCollapsed}
-            collapsedHeight={400}
-            inlineControls={false}
-            onCollapsibleChanged={setIsCollapsible}
-            onToggleCollapsed={setIsCollapsed}
-            overflowThreshold={20}
-          >
-            <MarkdownView
-              markdown={text}
-              textClass={{
-                'annotation-body__text': true,
-                'is-hidden': isHidden(annotation),
-                'has-content': text.length > 0,
-              }}
-            />
-          </Excerpt>
-        )}
-        {isEditing && (
-          <MarkdownEditor
-            label="Annotation body"
-            text={text}
-            onEditText={onEditText}
+    <section className="annotation-body">
+      {showExcerpt && (
+        <Excerpt
+          collapse={isCollapsed}
+          collapsedHeight={400}
+          inlineControls={false}
+          onCollapsibleChanged={setIsCollapsible}
+          onToggleCollapsed={setIsCollapsed}
+          overflowThreshold={20}
+        >
+          <MarkdownView
+            markdown={text}
+            textClass={{
+              'annotation-body__text': true,
+              'is-hidden': isHidden(annotation),
+              'has-content': text.length > 0,
+            }}
           />
-        )}
-      </section>
+        </Excerpt>
+      )}
+      {isEditing && (
+        <MarkdownEditor
+          label="Annotation body"
+          text={text}
+          onEditText={onEditText}
+        />
+      )}
       {isCollapsible && !isEditing && (
         <div className="annotation-body__collapse-toggle">
           <Button
@@ -71,7 +76,9 @@ export default function AnnotationBody({
           />
         </div>
       )}
-    </Fragment>
+      {showTagList && <TagList annotation={annotation} tags={tags} />}
+      {isEditing && <TagEditor onEditTags={onEditTags} tagList={tags} />}
+    </section>
   );
 }
 
@@ -87,9 +94,16 @@ AnnotationBody.propTypes = {
   isEditing: propTypes.bool,
 
   /**
+   * Callback invoked when the user edits tags.
+   */
+  onEditTags: propTypes.func,
+
+  /**
    * Callback invoked when the user edits the content of the annotation body.
    */
   onEditText: propTypes.func,
+
+  tags: propTypes.array.isRequired,
 
   /**
    * The markdown annotation body, which is either rendered as HTML (if `isEditing`

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -15,8 +15,6 @@ import AnnotationLicense from './annotation-license';
 import AnnotationPublishControl from './annotation-publish-control';
 import AnnotationQuote from './annotation-quote';
 import Button from './button';
-import TagEditor from './tag-editor';
-import TagList from './tag-list';
 
 /**
  * A single annotation.
@@ -52,7 +50,7 @@ function Annotation({
   const toggleAction = threadIsCollapsed ? 'Show replies' : 'Hide replies';
   const toggleText = `${toggleAction} (${replyCount})`;
 
-  const shouldShowActions = !isSaving && !isEditing && !isCollapsedReply;
+  const shouldShowActions = !isSaving && !isEditing;
   const shouldShowLicense = isEditing && !isPrivate && group.type !== 'private';
   const shouldShowReplyToggle = replyCount > 0 && !isReply(annotation);
 
@@ -108,42 +106,52 @@ function Annotation({
         showDocumentInfo={showDocumentInfo}
         threadIsCollapsed={threadIsCollapsed}
       />
+
       {hasQuote && <AnnotationQuote annotation={annotation} />}
-      <AnnotationBody
-        annotation={annotation}
-        isEditing={isEditing}
-        onEditText={onEditText}
-        text={text}
-      />
-      {isEditing && <TagEditor onEditTags={onEditTags} tagList={tags} />}
-      {!isEditing && <TagList annotation={annotation} tags={tags} />}
-      <footer className="annotation__footer">
-        {isEditing && (
-          <div className="annotation__form-actions">
-            <AnnotationPublishControl
-              annotation={annotation}
-              isDisabled={isEmpty}
-              onSave={onSave}
-            />
-          </div>
-        )}
-        {shouldShowLicense && <AnnotationLicense />}
-        <div className="annotation__controls">
-          {shouldShowReplyToggle && (
-            <Button
-              className="annotation__reply-toggle"
-              onClick={onToggleReplies}
-              buttonText={toggleText}
-            />
-          )}
-          {isSaving && <div className="annotation__actions">Saving...</div>}
-          {shouldShowActions && (
-            <div className="annotation__actions">
-              <AnnotationActionBar annotation={annotation} onReply={onReply} />
+
+      {!isCollapsedReply && (
+        <AnnotationBody
+          annotation={annotation}
+          isEditing={isEditing}
+          onEditTags={onEditTags}
+          onEditText={onEditText}
+          tags={tags}
+          text={text}
+        />
+      )}
+
+      {!isCollapsedReply && (
+        <footer className="annotation__footer">
+          {isEditing && (
+            <div className="annotation__form-actions">
+              <AnnotationPublishControl
+                annotation={annotation}
+                isDisabled={isEmpty}
+                onSave={onSave}
+              />
             </div>
           )}
-        </div>
-      </footer>
+          {shouldShowLicense && <AnnotationLicense />}
+          <div className="annotation__controls">
+            {shouldShowReplyToggle && (
+              <Button
+                className="annotation__reply-toggle"
+                onClick={onToggleReplies}
+                buttonText={toggleText}
+              />
+            )}
+            {isSaving && <div className="annotation__actions">Saving...</div>}
+            {shouldShowActions && (
+              <div className="annotation__actions">
+                <AnnotationActionBar
+                  annotation={annotation}
+                  onReply={onReply}
+                />
+              </div>
+            )}
+          </div>
+        </footer>
+      )}
     </article>
   );
 }

--- a/src/sidebar/components/test/annotation-body-test.js
+++ b/src/sidebar/components/test/annotation-body-test.js
@@ -16,6 +16,8 @@ describe('AnnotationBody', () => {
       <AnnotationBody
         annotation={fixtures.defaultAnnotation()}
         isEditing={false}
+        onEditTags={() => null}
+        tags={[]}
         text="test comment"
         {...props}
       />
@@ -88,10 +90,41 @@ describe('AnnotationBody', () => {
     assert.equal(buttonProps.title, 'Show the first few lines only');
   });
 
+  describe('tag list and editor', () => {
+    it('renders a list of tags if not editing and annotation has tags', () => {
+      const wrapper = createBody({ isEditing: false, tags: ['foo', 'bar'] });
+
+      assert.isTrue(wrapper.find('TagList').exists());
+    });
+
+    it('does not render a tag list if annotation has no tags', () => {
+      const wrapper = createBody({ isEditing: false, tags: [] });
+
+      assert.isFalse(wrapper.find('TagList').exists());
+    });
+
+    it('renders a tag editor if annotation is being edited', () => {
+      const wrapper = createBody({ isEditing: true, tags: ['foo', 'bar'] });
+
+      assert.isTrue(wrapper.find('TagEditor').exists());
+      assert.isFalse(wrapper.find('TagList').exists());
+    });
+  });
+
   it(
     'should pass a11y checks',
-    checkAccessibility({
-      content: () => createBody(),
-    })
+    checkAccessibility([
+      {
+        content: () => createBody(),
+      },
+      {
+        name: 'when annotation has tags (tag list)',
+        content: () => createBody({ isEditing: false, tags: ['foo', 'bar'] }),
+      },
+      {
+        name: 'when annotation is being edited and has tags',
+        content: () => createBody({ isEditing: true, tags: ['foo', 'bar'] }),
+      },
+    ])
   );
 });

--- a/src/styles/sidebar/components/annotation-body.scss
+++ b/src/styles/sidebar/components/annotation-body.scss
@@ -3,12 +3,7 @@
 .annotation-body {
   @include var.font-normal;
   color: var.$grey-7;
-  // Margin between top of ascent of annotation body and
-  // bottom of ascent of annotation-quote should be ~15px.
-  margin-top: var.$layout-h-margin - 5px;
-  margin-bottom: var.$layout-h-margin;
-  margin-right: 0px;
-  margin-left: 0px;
+  margin: 1em 0;
 }
 
 .annotation-body__text {
@@ -38,12 +33,12 @@
 }
 
 .annotation-body__collapse-toggle {
-  // Negative top margin to bring this up tight under `.annotation-body`
-  margin-top: -(var.$layout-h-margin - 5px);
+  margin: 0.5em 0;
   display: flex;
   justify-content: flex-end;
 
   .annotation-body__collapse-toggle-button {
+    padding: 0.5em;
     background-color: transparent;
   }
 }

--- a/src/styles/sidebar/components/annotation-header.scss
+++ b/src/styles/sidebar/components/annotation-header.scss
@@ -3,9 +3,6 @@
 
 .annotation-header {
   @include forms.pie-clearfix;
-  // Margin between top of x-height of username and
-  // top of the annotation card should be ~15px
-  margin-top: -(var.$layout-h-margin) + 10px;
   color: var.$grey-6;
 
   &__row {

--- a/src/styles/sidebar/components/annotation-license.scss
+++ b/src/styles/sidebar/components/annotation-license.scss
@@ -4,7 +4,7 @@
   @include var.font-small;
   border-top: 1px solid var.$grey-3;
   padding-top: 0.5em;
-  margin: 0.5em 0;
+  margin: 1em 0;
 
   &__link {
     display: flex;

--- a/src/styles/sidebar/components/annotation-quote.scss
+++ b/src/styles/sidebar/components/annotation-quote.scss
@@ -1,12 +1,7 @@
 @use '../../variables' as var;
 
 .annotation-quote {
-  // Margin between top of ascent of annotation quote and
-  // bottom of ascent of username should be ~15px
-  margin-top: var.$layout-h-margin - 5px;
-  // Margin between bottom of ascent of annotation quote and
-  // top of ascent of annotation-body should be ~15px
-  margin-bottom: var.$layout-h-margin - 3px;
+  margin: 1em 0;
 }
 
 .annotation-quote.is-orphan {

--- a/src/styles/sidebar/components/annotation.scss
+++ b/src/styles/sidebar/components/annotation.scss
@@ -66,42 +66,7 @@
   &__footer {
     @include var.font-normal;
     color: var.$grey-5;
-    margin-top: var.$layout-h-margin;
-  }
-
-  &--reply &__footer {
-    margin-top: var.$layout-h-margin - 8px;
-  }
-}
-
-// FIXME vertical rhythm here should be refactored
-.annotation--reply {
-  .annotation-header {
-    // Margin between bottom of ascent of annotation card footer labels
-    // and top of ascent of username should be ~20px
-    margin-top: 0px;
-  }
-
-  .annotation-body {
-    // Margin between top of ascent of annotation body and
-    // bottom of ascent of username should be ~15px
-    margin-top: var.$layout-h-margin - 8px;
-    // Margin between bottom of ascent of annotation body and
-    // top of annotation footer labels should be ~15px
-    margin-bottom: var.$layout-h-margin - 3px;
-  }
-}
-
-.annotation--reply.is-collapsed {
-  margin-bottom: 0;
-
-  .annotation-header {
-    margin: 0;
-  }
-
-  .annotation-body,
-  .annotation-footer {
-    display: none;
+    margin-top: 1em;
   }
 }
 

--- a/src/styles/sidebar/components/tag-editor.scss
+++ b/src/styles/sidebar/components/tag-editor.scss
@@ -3,6 +3,8 @@
 @use "../../variables" as var;
 
 .tag-editor {
+  margin: 0.5em 0;
+
   &__input {
     @include forms.form-input;
     width: 100%;
@@ -11,12 +13,13 @@
   &__tags {
     display: flex;
     flex-wrap: wrap;
+    margin: 0.5em 0;
   }
 
   &__item {
     display: flex;
-    margin-right: 0.5em;
-    margin-bottom: 0.5em;
+    margin: 0.25em 0.5em 0.25em 0;
+    line-height: var.$base-line-height;
   }
 
   &__edit {

--- a/src/styles/sidebar/components/tag-list.scss
+++ b/src/styles/sidebar/components/tag-list.scss
@@ -1,23 +1,23 @@
 @use "../../variables" as var;
 
 .tag-list {
+  margin: 1em 0;
   display: flex;
   flex-wrap: wrap;
 
   &__item {
-    display: flex;
-    margin-right: 0.5em;
-    margin-bottom: 0.5em;
+    margin: 0.25em 0.5em 0.25em 0;
+    padding: 0 0.5em;
+    line-height: var.$base-line-height;
+    background: var.$grey-1;
+    border: 1px solid var.$grey-3;
+    border-radius: 2px;
   }
 
   &__link,
   &__text {
     text-decoration: none;
     color: var.$grey-6;
-    background: var.$grey-1;
-    border: 1px solid var.$grey-3;
-    border-radius: 2px;
-    padding: 0 0.5em;
   }
 
   &__link {

--- a/src/styles/sidebar/components/thread-list.scss
+++ b/src/styles/sidebar/components/thread-list.scss
@@ -11,7 +11,7 @@
   box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.1);
   border-radius: 2px;
   cursor: pointer;
-  padding: var.$layout-h-margin;
+  padding: 1em;
   background-color: var.$white;
 
   &:hover {

--- a/src/styles/sidebar/components/thread.scss
+++ b/src/styles/sidebar/components/thread.scss
@@ -5,28 +5,35 @@
 
   &--reply {
     margin-top: 0.5em;
-    padding-top: 0.5em;
   }
 
-  &__collapse {
-    margin: 0.25em;
-    margin-top: 0;
-    cursor: auto;
-    border-left: 1px dashed var.$grey-3;
+  // Conserve space for deeper usable nesting
+  &__children {
+    margin-left: -0.75em;
+  }
 
+  // Left "channel" of thread
+  &__collapse {
+    margin-right: 1em;
+    border-right: 1px dashed var.$grey-3;
+    // The entire channel is NOT clickable so don't make it look like it is
+    // (overrides `pointer` cursor applied to entire card)
+    cursor: auto;
+
+    // Darken thread line on hover as a visual cue to show related thread items
     &:hover {
-      border-left: 1px dashed var.$grey-4;
+      border-right: 1px dashed var.$grey-4;
     }
 
     .is-collapsed & {
-      border-left: none;
+      border-right: none;
     }
   }
 
   // TODO These styles should be consolidated with other `Button` styles
   &__collapse-button {
-    margin-left: -1.25em;
-    padding: 0.25em 0.75em 1em 0.75em;
+    margin-right: -1.25em;
+    padding: 0.25em 0.75em 0.75em 0.75em;
     // Need a non-transparent background so that the dashed border line
     // does not show through the button
     background-color: var.$white;


### PR DESCRIPTION
~~Depends on #1985 for the moment~~ (no longer; rebased)

This PR adjusts the structure of annotation components and vertical CSS margins to make vertical rhythm more consistent and eliminate some extra vertical blank space in annotations and threads.

## Before and After

### Annotation

Before:

<img width="421" alt="before-annotation" src="https://user-images.githubusercontent.com/439947/78253973-37183700-74c3-11ea-87cc-970c3ebb6d26.png">

After:

<img width="422" alt="after-annotation" src="https://user-images.githubusercontent.com/439947/78253983-397a9100-74c3-11ea-8130-d741f9027084.png">

### Highlight

Before:

<img width="426" alt="before-highlight" src="https://user-images.githubusercontent.com/439947/78254006-4303f900-74c3-11ea-926b-e4467bd5b639.png">

After:

<img width="428" alt="after-highlight" src="https://user-images.githubusercontent.com/439947/78254019-48f9da00-74c3-11ea-831e-52b48400e50a.png">

### Highlight with Tags

Before:

<img width="419" alt="before-highlight-with-tags" src="https://user-images.githubusercontent.com/439947/78254038-531bd880-74c3-11ea-94e1-4a486dca2fb1.png">

After:

<img width="423" alt="after-highlight-with-tags" src="https://user-images.githubusercontent.com/439947/78254047-557e3280-74c3-11ea-8b4d-78473e8f8db4.png">

### Collapsed Threads

Before:

<img width="414" alt="before-collapsed-threads" src="https://user-images.githubusercontent.com/439947/78254067-5adb7d00-74c3-11ea-92ce-f1c779b105c4.png">

After:

<img width="429" alt="after-collapsed-threads" src="https://user-images.githubusercontent.com/439947/78254077-5dd66d80-74c3-11ea-9584-db25c4e9dc0d.png">

### Annotation with Empty Body and No Excerpt (e.g. page note)

Before:

<img width="422" alt="before-empty-annotation" src="https://user-images.githubusercontent.com/439947/78254095-67f86c00-74c3-11ea-8c3d-dd3f7daa7b33.png">

After:

<img width="423" alt="after-empty-annotation" src="https://user-images.githubusercontent.com/439947/78254110-6c248980-74c3-11ea-82e7-53705d9cf34b.png">


The most substantive change is that the rendering of `TagList` and `TagEditor` is now handled by `AnnotationBody`, such that the basic structure of an `Annotation` is:

* `article.annotation`
    * `header.annotation-header`
    * `aside.annotation-quote`
    * `section.annotation-body`
    * `footer.annotation-footer`

Having an expected DOM hierarchy helps make margins collapse as expected, etc.

This PR introduces a consistency in vertical margins: `1em` for significant margins and `0.5em` for inter-section (smaller) margins. These are not yet managed as SASS variables, but I imagine they will be as we iterate.

There's certainly several follow-up tasks here (e.g. the margins as SASS variables), but I feel that this is moving in a good direction, as I hope before/after screenshots will support. I'll call out some other spots that need follow up in code comments.

Fixes https://github.com/hypothesis/client/issues/1705
Fixes https://github.com/hypothesis/client/issues/1921