### PR TITLE
Move management of “isSaving” state for annotations into the store

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { createElement } from 'preact';
-import { useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import useStore from '../store/use-store';
@@ -35,6 +34,7 @@ function Annotation({
   const draft = useStore(store => store.getDraft(annotation));
   const group = useStore(store => store.getGroup(annotation.group));
   const userid = useStore(store => store.profile().userid);
+  const isSaving = useStore(store => store.isSavingAnnotation(annotation));
 
   const isCollapsedReply = isReply(annotation) && threadIsCollapsed;
   const isPrivate = draft ? draft.isPrivate : !isShared(annotation.permissions);
@@ -44,7 +44,6 @@ function Annotation({
   const hasQuote = !!quote(annotation);
   const isEmpty = !text && !tags.length;
 
-  const [isSaving, setIsSaving] = useState(false);
   const isEditing = !!draft && !isSaving;
 
   const toggleAction = threadIsCollapsed ? 'Show replies' : 'Hide replies';
@@ -65,13 +64,10 @@ function Annotation({
   const onReply = () => annotationsService.reply(annotation, userid);
 
   const onSave = async () => {
-    setIsSaving(true);
     try {
       await annotationsService.save(annotation);
     } catch (err) {
       toastMessenger.error('Saving annotation failed');
-    } finally {
-      setIsSaving(false);
     }
   };
 

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -74,6 +74,7 @@ describe('Annotation', () => {
       getGroup: sinon.stub().returns({
         type: 'private',
       }),
+      isSavingAnnotation: sinon.stub().returns(false),
       profile: sinon.stub().returns({ userid: 'acct:foo@bar.com' }),
       setCollapsed: sinon.stub(),
     };
@@ -200,13 +201,9 @@ describe('Annotation', () => {
 
       it('should show a "Saving" message when annotation is saving', () => {
         setEditingMode(true);
+        fakeStore.isSavingAnnotation.returns(true);
 
         const wrapper = createComponent();
-        act(() => {
-          wrapper.find('AnnotationPublishControl').props().onSave();
-        });
-
-        wrapper.update();
 
         assert.include(
           wrapper.find('.annotation__actions').text(),

--- a/src/sidebar/services/annotations.js
+++ b/src/sidebar/services/annotations.js
@@ -154,7 +154,13 @@ export default function annotationsService(api, store) {
       );
     }
 
-    const savedAnnotation = await saved;
+    let savedAnnotation;
+    store.annotationSaveStarted(annotation);
+    try {
+      savedAnnotation = await saved;
+    } finally {
+      store.annotationSaveFinished(annotation);
+    }
 
     Object.keys(annotation).forEach(key => {
       if (key[0] === '$') {

--- a/src/sidebar/services/test/annotations-test.js
+++ b/src/sidebar/services/test/annotations-test.js
@@ -36,6 +36,8 @@ describe('annotationsService', () => {
 
     fakeStore = {
       addAnnotations: sinon.stub(),
+      annotationSaveFinished: sinon.stub(),
+      annotationSaveStarted: sinon.stub(),
       createDraft: sinon.stub(),
       deleteNewAndEmptyDrafts: sinon.stub(),
       focusedGroupId: sinon.stub(),
@@ -289,6 +291,8 @@ describe('annotationsService', () => {
       return svc.save(annotation).then(() => {
         assert.calledOnce(fakeApi.annotation.create);
         assert.notCalled(fakeApi.annotation.update);
+        assert.calledOnce(fakeStore.annotationSaveStarted);
+        assert.calledOnce(fakeStore.annotationSaveFinished);
       });
     });
 
@@ -299,6 +303,8 @@ describe('annotationsService', () => {
       return svc.save(annotation).then(() => {
         assert.calledOnce(fakeApi.annotation.update);
         assert.notCalled(fakeApi.annotation.create);
+        assert.calledOnce(fakeStore.annotationSaveStarted);
+        assert.calledOnce(fakeStore.annotationSaveFinished);
       });
     });
 
@@ -367,6 +373,16 @@ describe('annotationsService', () => {
     });
 
     context('error on save', () => {
+      it('removes the active save request from the store', () => {
+        fakeApi.annotation.update.rejects();
+        fakeMetadata.isNew.returns(false);
+
+        return svc.save(fixtures.defaultAnnotation()).catch(() => {
+          assert.notCalled(fakeStore.removeDraft);
+          assert.calledOnce(fakeStore.annotationSaveFinished);
+        });
+      });
+
       it('does not remove the annotation draft', () => {
         fakeApi.annotation.update.rejects();
         fakeMetadata.isNew.returns(false);


### PR DESCRIPTION
This PR moves the management of whether a given annotation is being saved into the store, via the `AnnotationsService.save` method.

This is a lightweight and unsophisticated implementation. As a group, we discussed on a call last week whether I should take the trouble to be more granular about this (e.g. counting individual inflight requests and then decrementing), but we decided that, since the I won't allow multiple inflight requests for a single annotation, that we could make do with a simple Array that tracks annotations being saved. So here you have it.

This change will allow other components to be aware of annotation-save state, which can relieve some of the burden on the `Annotation` component.

Part of https://github.com/hypothesis/client/issues/1867