### PR TITLE
Remove `onReplyCountClick` prop and use store method instead

### DIFF
--- a/src/sidebar/components/annotation-header.js
+++ b/src/sidebar/components/annotation-header.js
@@ -1,6 +1,7 @@
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
+import useStore from '../store/use-store';
 import { isHighlight, isReply } from '../util/annotation-metadata';
 import { isPrivate } from '../util/permissions';
 
@@ -19,12 +20,13 @@ import Timestamp from './timestamp';
 export default function AnnotationHeader({
   annotation,
   isEditing,
-  onReplyCountClick,
   replyCount,
   showDocumentInfo,
   threadIsCollapsed,
 }) {
   const isCollapsedReply = isReply(annotation) && threadIsCollapsed;
+  const setCollapsed = useStore(store => store.setCollapsed);
+
   const annotationIsPrivate = isPrivate(
     annotation.permissions,
     annotation.user
@@ -34,13 +36,15 @@ export default function AnnotationHeader({
   // NB: `created` and `updated` are strings, not `Date`s
   const hasBeenEdited =
     annotation.updated && annotation.created !== annotation.updated;
-  const showTimestamp = !isEditing;
+  const showTimestamp = !isEditing && annotation.created;
   const showEditedTimestamp = hasBeenEdited && !isCollapsedReply;
 
   const replyPluralized = replyCount > 1 ? 'replies' : 'reply';
   const replyButtonText = `${replyCount} ${replyPluralized}`;
   const showReplyButton = replyCount > 0 && isCollapsedReply;
   const showExtendedInfo = !isReply(annotation);
+
+  const onReplyCountClick = () => setCollapsed(annotation.id, false);
 
   return (
     <header className="annotation-header">
@@ -112,8 +116,6 @@ AnnotationHeader.propTypes = {
   annotation: propTypes.object.isRequired,
   /* Whether the annotation is actively being edited */
   isEditing: propTypes.bool,
-  /* Callback for when the toggle-replies element is clicked */
-  onReplyCountClick: propTypes.func.isRequired,
   /* How many replies this annotation currently has */
   replyCount: propTypes.number,
   /**

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -22,7 +22,6 @@ import Button from './button';
 function Annotation({
   annotation,
   annotationsService,
-  onReplyCountClick,
   replyCount,
   showDocumentInfo,
   threadIsCollapsed,
@@ -101,7 +100,6 @@ function Annotation({
       <AnnotationHeader
         annotation={annotation}
         isEditing={isEditing}
-        onReplyCountClick={onReplyCountClick}
         replyCount={replyCount}
         showDocumentInfo={showDocumentInfo}
         threadIsCollapsed={threadIsCollapsed}
@@ -159,8 +157,6 @@ function Annotation({
 Annotation.propTypes = {
   annotation: propTypes.object.isRequired,
 
-  /** Callback for reply-count clicks */
-  onReplyCountClick: propTypes.func.isRequired,
   /** Number of replies to this annotation (thread) */
   replyCount: propTypes.number.isRequired,
   /** Should extended document info be rendered (e.g. in non-sidebar contexts)? */

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -12,8 +12,6 @@ import Annotation from '../annotation';
 import { $imports } from '../annotation';
 
 describe('Annotation', () => {
-  let fakeOnReplyCountClick;
-
   // Dependency Mocks
   let fakeMetadata;
   let fakePermissions;
@@ -38,7 +36,6 @@ describe('Annotation', () => {
         annotation={fixtures.defaultAnnotation()}
         annotationsService={fakeAnnotationsService}
         toastMessenger={fakeToastMessenger}
-        onReplyCountClick={fakeOnReplyCountClick}
         replyCount={0}
         showDocumentInfo={false}
         threadIsCollapsed={true}
@@ -48,8 +45,6 @@ describe('Annotation', () => {
   };
 
   beforeEach(() => {
-    fakeOnReplyCountClick = sinon.stub();
-
     fakeAnnotationsService = {
       reply: sinon.stub(),
       save: sinon.stub().resolves(),

--- a/src/sidebar/components/thread.js
+++ b/src/sidebar/components/thread.js
@@ -66,7 +66,6 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
             <Annotation
               annotation={thread.annotation}
               replyCount={thread.replyCount}
-              onReplyCountClick={onToggleReplies}
               showDocumentInfo={showDocumentInfo}
               threadIsCollapsed={thread.collapsed}
             />


### PR DESCRIPTION
Let `AnnotationHeader` call `store.setCollapsed` directly instead of
passing a callback down through several layers of components

Part of https://github.com/hypothesis/client/issues/1867