### PR TITLE
Fix Hammer.JS error on web pages that use Require.JS

### DIFF
--- a/scripts/gulp/create-bundle.js
+++ b/scripts/gulp/create-bundle.js
@@ -87,11 +87,19 @@ module.exports = function createBundle(config, buildOpts) {
     // modules provide the implementations of these.
     builtins: ['console', '_process', 'querystring'],
     externalRequireName,
+
+    // Map of global variable names to functions returning _source code_ for
+    // the values of those globals.
     insertGlobalVars: {
+      // Workaround for Hammer.JS on pages that use RequireJS. Hammer doesn't
+      // set `module.exports` if a global variable called `define` exists.
+      define: () => 'undefined',
+
       // The Browserify polyfill for the `Buffer` global is large and
       // unnecessary, but can get pulled into the bundle by modules that can
       // optionally use it if present.
       Buffer: undefined,
+
       // Override the default stub for the `global` var which defaults to
       // the `global`, `self` and `window` globals in that order.
       //


### PR DESCRIPTION
Fix an error related to Hammer.JS on client startup on pages that define
a global variable called `define`, which is part of [RequireJS](https://requirejs.org). Hammer's
"universal" bundle does not set `module.exports` in this case, so modules that import it
get an empty object back.

Fix the issue by making sure that any reference to `define` inside
bundles evaluates to `undefined` (assuming there is no local variable
within the module with that name).

This fixes an issue where clicking "Annotate" failed to open the sidebar
on BBC News articles (eg. https://www.bbc.co.uk/news/world-52144390).