### PR TITLE
Menu key navigation

### DIFF
--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -50,6 +50,11 @@ function GroupListItem({
     }
   };
 
+  /**
+   * Opens or closes the submenu.
+   *
+   * @param {MouseEvent|KeyboardEvent} event
+   */
   const toggleSubmenu = event => {
     event.stopPropagation();
 
@@ -85,9 +90,11 @@ function GroupListItem({
       onToggleSubmenu={toggleSubmenu}
       submenu={
         <Fragment>
-          <ul>
+          {/* Giving the role="menu" allows screen readers to have
+          correct number of subitems */}
+          <ul role="menu">
             {activityUrl && (
-              <li>
+              <li role="none">
                 <MenuItem
                   href={activityUrl}
                   icon="external"
@@ -97,7 +104,7 @@ function GroupListItem({
               </li>
             )}
             {activityUrl && (
-              <li>
+              <li role="none">
                 <MenuItem
                   onClick={copyLink}
                   icon="copy"
@@ -107,7 +114,7 @@ function GroupListItem({
               </li>
             )}
             {canLeaveGroup && (
-              <li>
+              <li role="none">
                 <MenuItem
                   icon="leave"
                   isSubmenuItem={true}

--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -90,11 +90,9 @@ function GroupListItem({
       onToggleSubmenu={toggleSubmenu}
       submenu={
         <Fragment>
-          {/* Giving the role="menu" allows screen readers to have
-          correct number of subitems */}
-          <ul role="menu">
+          <ul>
             {activityUrl && (
-              <li role="none">
+              <li>
                 <MenuItem
                   href={activityUrl}
                   icon="external"
@@ -104,7 +102,7 @@ function GroupListItem({
               </li>
             )}
             {activityUrl && (
-              <li role="none">
+              <li>
                 <MenuItem
                   onClick={copyLink}
                   icon="copy"
@@ -114,7 +112,7 @@ function GroupListItem({
               </li>
             )}
             {canLeaveGroup && (
-              <li role="none">
+              <li>
                 <MenuItem
                   icon="leave"
                   isSubmenuItem={true}

--- a/src/sidebar/components/menu-item.js
+++ b/src/sidebar/components/menu-item.js
@@ -21,6 +21,7 @@ import SvgIcon from '../../shared/components/svg-icon';
  *
  * For items that have submenus, the `MenuItem` will call the `renderSubmenu`
  * prop to render the content of the submenu, when the submenu is visible.
+ * Note that the `submenu` is not supported for link (`href`) items.
  */
 export default function MenuItem({
   href,
@@ -228,7 +229,7 @@ MenuItem.propTypes = {
   /**
    * If present, display a button to toggle the sub-menu associated with this
    * item and indicate the current state; `true` if the submenu is visible.
-   * Note. Omit this prop if there is no `submenu`.
+   * Note. Omit this prop, or set it to null, if there is no `submenu`.
    */
   isSubmenuVisible: propTypes.bool,
 

--- a/src/sidebar/components/menu-item.js
+++ b/src/sidebar/components/menu-item.js
@@ -155,6 +155,10 @@ export default function MenuItem({
 
         {hasSubmenuVisible && (
           <div
+            // We should not have a <button> inside of the menu item itself
+            // but we have a non-standard mechanism with the toggle control
+            // requiring an onClick event nested inside a "menuitemradio|menuitem".
+            // Therefore, a static element with a role="none" is necessary here.
             role="none"
             icon={isSubmenuVisible ? 'collapse-menu' : 'expand-menu'}
             className="menu-item__toggle"

--- a/src/sidebar/components/menu-item.js
+++ b/src/sidebar/components/menu-item.js
@@ -1,9 +1,9 @@
 import classnames from 'classnames';
 import { Fragment, createElement } from 'preact';
+import { useRef } from 'preact/hooks';
 import propTypes from 'prop-types';
 
-import { onActivate } from '../util/on-activate';
-
+import MenuKeyboardNavigation from './menu-keyboard-navigation';
 import Slider from './slider';
 import SvgIcon from '../../shared/components/svg-icon';
 
@@ -38,12 +38,11 @@ export default function MenuItem({
 }) {
   const iconClass = 'menu-item__icon';
   const iconIsUrl = icon && icon.indexOf('/') !== -1;
-  const labelClass = classnames('menu-item__label', {
-    'menu-item__label--submenu': isSubmenuItem,
-  });
 
   const hasLeftIcon = icon || isSubmenuItem;
   const hasRightIcon = icon && isSubmenuItem;
+
+  const menuItemRef = useRef(null);
 
   let renderedIcon = null;
   if (icon !== 'blank') {
@@ -56,49 +55,102 @@ export default function MenuItem({
   const leftIcon = isSubmenuItem ? null : renderedIcon;
   const rightIcon = isSubmenuItem ? renderedIcon : null;
 
-  return (
-    <Fragment>
-      {/* FIXME-A11Y */}
-      {/* eslint-disable-next-line jsx-a11y/role-supports-aria-props */}
-      <div
-        aria-checked={isSelected}
+  // menuItem can be either a link or a button
+  let menuItem;
+  const hasSubmenuVisible = typeof isSubmenuVisible === 'boolean';
+  const isRadioButtonType = typeof isSelected === 'boolean';
+
+  const onCloseSubmenu = event => {
+    if (onToggleSubmenu) {
+      onToggleSubmenu(event);
+    }
+    // The focus won't work without delaying rendering.
+    setTimeout(() => {
+      menuItemRef.current.focus();
+    });
+  };
+
+  const onKeyDown = event => {
+    switch (event.key) {
+      case 'ArrowRight':
+        if (onToggleSubmenu) {
+          event.stopPropagation();
+          event.preventDefault();
+          onToggleSubmenu(event);
+        }
+        break;
+      case 'Enter':
+      case ' ':
+        if (onClick) {
+          // Let event propagate so the menu closes
+          onClick(event);
+        }
+    }
+  };
+  if (href) {
+    // The menu item is a link
+    menuItem = (
+      <a
+        ref={menuItemRef}
         className={classnames('menu-item', {
-          'menu-item--submenu': isSubmenuItem,
+          'is-submenu': isSubmenuItem,
+          'is-disabled': isDisabled,
+        })}
+        href={href}
+        target="_blank"
+        tabIndex="-1"
+        rel="noopener noreferrer"
+        role="menuitem"
+        onKeyDown={onKeyDown}
+      >
+        {hasLeftIcon && (
+          <div className="menu-item__icon-container">{leftIcon}</div>
+        )}
+        <span className="menu-item__label">{label}</span>
+        {hasRightIcon && (
+          <div className="menu-item__icon-container">{rightIcon}</div>
+        )}
+      </a>
+    );
+  } else {
+    // The menu item is a clickable button or radio button.
+    // In either case there may be an optional submenu.
+
+    const expandedProp = {
+      'aria-expanded': hasSubmenuVisible ? isSubmenuVisible : undefined,
+    };
+    menuItem = (
+      <div
+        ref={menuItemRef}
+        className={classnames('menu-item', {
+          'is-submenu': isSubmenuItem,
           'is-disabled': isDisabled,
           'is-expanded': isExpanded,
           'is-selected': isSelected,
         })}
-        role="menuitem"
-        {...(onClick && onActivate('menuitem', onClick))}
+        tabIndex="-1"
+        onKeyDown={onKeyDown}
+        onClick={onClick}
+        role={isRadioButtonType ? 'menuitemradio' : 'menuitem'}
+        aria-checked={isRadioButtonType ? isSelected : undefined}
+        aria-haspopup={hasSubmenuVisible}
+        {...expandedProp}
       >
-        <div className="menu-item__action">
-          {hasLeftIcon && (
-            <div className="menu-item__icon-container">{leftIcon}</div>
-          )}
-          {href && (
-            <a
-              className={labelClass}
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {label}
-            </a>
-          )}
-          {!href && <span className={labelClass}>{label}</span>}
-          {hasRightIcon && (
-            <div className="menu-item__icon-container">{rightIcon}</div>
-          )}
-        </div>
-        {typeof isSubmenuVisible === 'boolean' && (
+        {hasLeftIcon && (
+          <div className="menu-item__icon-container">{leftIcon}</div>
+        )}
+        <span className="menu-item__label">{label}</span>
+        {hasRightIcon && (
+          <div className="menu-item__icon-container">{rightIcon}</div>
+        )}
+
+        {hasSubmenuVisible && (
           <div
+            role="none"
+            icon={isSubmenuVisible ? 'collapse-menu' : 'expand-menu'}
             className="menu-item__toggle"
-            // We need to pass strings here rather than just the boolean attribute
-            // because otherwise the attribute will be omitted entirely when
-            // `isSubmenuVisible` is false.
-            aria-expanded={isSubmenuVisible ? 'true' : 'false'}
-            aria-label={`Show actions for ${label}`}
-            {...onActivate('button', onToggleSubmenu)}
+            onClick={onToggleSubmenu}
+            title={`Show actions for ${label}`}
           >
             <SvgIcon
               name={isSubmenuVisible ? 'collapse-menu' : 'expand-menu'}
@@ -107,9 +159,20 @@ export default function MenuItem({
           </div>
         )}
       </div>
-      {typeof isSubmenuVisible === 'boolean' && (
+    );
+  }
+  return (
+    <Fragment>
+      {menuItem}
+      {hasSubmenuVisible && (
         <Slider visible={isSubmenuVisible}>
-          <div className="menu-item__submenu">{submenu}</div>
+          <MenuKeyboardNavigation
+            closeMenu={onCloseSubmenu}
+            visible={isSubmenuVisible}
+            className="menu-item__submenu"
+          >
+            {submenu}
+          </MenuKeyboardNavigation>
         </Slider>
       )}
     </Fragment>
@@ -165,6 +228,7 @@ MenuItem.propTypes = {
   /**
    * If present, display a button to toggle the sub-menu associated with this
    * item and indicate the current state; `true` if the submenu is visible.
+   * Note. Omit this prop if there is no `submenu`.
    */
   isSubmenuVisible: propTypes.bool,
 

--- a/src/sidebar/components/menu-item.js
+++ b/src/sidebar/components/menu-item.js
@@ -46,7 +46,7 @@ export default function MenuItem({
   const hasRightIcon = icon && isSubmenuItem;
 
   const menuItemRef = useRef(null);
-  const focusTimer = useRef(null);
+  let focusTimer = null;
 
   let renderedIcon = null;
   if (icon !== 'blank') {
@@ -67,8 +67,9 @@ export default function MenuItem({
   useEffect(() => {
     return () => {
       // unmount
-      clearTimeout(focusTimer.current);
+      clearTimeout(focusTimer);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const onCloseSubmenu = event => {
@@ -76,7 +77,7 @@ export default function MenuItem({
       onToggleSubmenu(event);
     }
     // The focus won't work without delaying rendering.
-    focusTimer.current = setTimeout(() => {
+    focusTimer = setTimeout(() => {
       menuItemRef.current.focus();
     });
   };

--- a/src/sidebar/components/menu-keyboard-navigation.js
+++ b/src/sidebar/components/menu-keyboard-navigation.js
@@ -2,6 +2,8 @@ import { createElement } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 import propTypes from 'prop-types';
 
+import { normalizeKeyName } from '../../shared/browser-compatibility-utils';
+
 function isElementVisible(element) {
   return element.offsetParent !== null;
 }
@@ -20,17 +22,22 @@ export default function MenuKeyboardNavigation({
   visible,
 }) {
   const menuRef = useRef(null);
+  const focusTimer = useRef(null);
 
   useEffect(() => {
     if (visible) {
       // The focus won't work without delaying rendering.
-      setTimeout(() => {
+      focusTimer.current = setTimeout(() => {
         const firstItem = menuRef.current.querySelector('[role^="menuitem"]');
         if (firstItem) {
           firstItem.focus();
         }
       });
     }
+    return () => {
+      // unmount
+      clearTimeout(focusTimer.current);
+    };
   }, [visible]);
 
   const onKeyDown = event => {
@@ -44,7 +51,7 @@ export default function MenuKeyboardNavigation({
 
     let handled = false;
 
-    switch (event.key) {
+    switch (normalizeKeyName(event.key)) {
       case 'ArrowLeft':
       case 'Escape':
         if (closeMenu) {

--- a/src/sidebar/components/menu-keyboard-navigation.js
+++ b/src/sidebar/components/menu-keyboard-navigation.js
@@ -10,7 +10,7 @@ function isElementVisible(element) {
  * Helper component used by Menu and MenuItem to facilitate keyboard navigation of a
  * list of <MenuItem> components. This component should not be used directly.
  *
- * Note that `ArrowRight` shall be handled by the <MenuItem> directly and
+ * Note that `ArrowRight` shall be handled by the parent <MenuItem> directly and
  * all other focus() related  navigation is handled here.
  */
 export default function MenuKeyboardNavigation({

--- a/src/sidebar/components/menu-keyboard-navigation.js
+++ b/src/sidebar/components/menu-keyboard-navigation.js
@@ -13,7 +13,7 @@ function isElementVisible(element) {
  * list of <MenuItem> components. This component should not be used directly.
  *
  * Note that `ArrowRight` shall be handled by the parent <MenuItem> directly and
- * all other focus() related  navigation is handled here.
+ * all other focus() related navigation is handled here.
  */
 export default function MenuKeyboardNavigation({
   className,

--- a/src/sidebar/components/menu-keyboard-navigation.js
+++ b/src/sidebar/components/menu-keyboard-navigation.js
@@ -22,12 +22,12 @@ export default function MenuKeyboardNavigation({
   visible,
 }) {
   const menuRef = useRef(null);
-  const focusTimer = useRef(null);
 
   useEffect(() => {
+    let focusTimer = null;
     if (visible) {
-      // The focus won't work without delaying rendering.
-      focusTimer.current = setTimeout(() => {
+      focusTimer = setTimeout(() => {
+        // The focus won't work without delaying rendering.
         const firstItem = menuRef.current.querySelector('[role^="menuitem"]');
         if (firstItem) {
           firstItem.focus();
@@ -36,7 +36,7 @@ export default function MenuKeyboardNavigation({
     }
     return () => {
       // unmount
-      clearTimeout(focusTimer.current);
+      clearTimeout(focusTimer);
     };
   }, [visible]);
 
@@ -91,14 +91,13 @@ export default function MenuKeyboardNavigation({
   };
 
   return (
-    <div
-      role="presentation"
-      className={className}
-      ref={menuRef}
-      onKeyDown={onKeyDown}
-    >
-      {/* role="menu" helps screen readers separate submenu items from parent menu items */}
-      <div role="menu">{children}</div>
+    // This element needs to have role="menu" to facilitate readers
+    // correctly enumerating discrete submenu items, but it also needs
+    // to facilitate keydown events for navigation. Disable the linter
+    // error so it can do both.
+    // eslint-disable-next-line jsx-a11y/interactive-supports-focus
+    <div role="menu" className={className} ref={menuRef} onKeyDown={onKeyDown}>
+      {children}
     </div>
   );
 }

--- a/src/sidebar/components/menu-keyboard-navigation.js
+++ b/src/sidebar/components/menu-keyboard-navigation.js
@@ -84,8 +84,14 @@ export default function MenuKeyboardNavigation({
   };
 
   return (
-    <div role="none" className={className} ref={menuRef} onKeyDown={onKeyDown}>
-      {children}
+    <div
+      role="presentation"
+      className={className}
+      ref={menuRef}
+      onKeyDown={onKeyDown}
+    >
+      {/* role="menu" helps screen readers separate submenu items from parent menu items */}
+      <div role="menu">{children}</div>
     </div>
   );
 }
@@ -100,6 +106,7 @@ MenuKeyboardNavigation.propTypes = {
   // which has a role="menuitem" attribute.
   visible: propTypes.bool,
 
-  // Array of nodes which may contain MenuItems
-  children: propTypes.any,
+  // Array of nodes which may contain <MenuItems> or any nodes
+  // that have role set to 'menuitem', 'menuitemradio', or 'menuitemcheckbox'
+  children: propTypes.any.isRequired,
 };

--- a/src/sidebar/components/menu-keyboard-navigation.js
+++ b/src/sidebar/components/menu-keyboard-navigation.js
@@ -1,0 +1,105 @@
+import { createElement } from 'preact';
+import { useEffect, useRef } from 'preact/hooks';
+import propTypes from 'prop-types';
+
+function isElementVisible(element) {
+  return element.offsetParent !== null;
+}
+
+/**
+ * Helper component used by Menu and MenuItem to facilitate keyboard navigation of a
+ * list of <MenuItem> components. This component should not be used directly.
+ *
+ * Note that `ArrowRight` shall be handled by the <MenuItem> directly and
+ * all other focus() related  navigation is handled here.
+ */
+export default function MenuKeyboardNavigation({
+  className,
+  closeMenu,
+  children,
+  visible,
+}) {
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    if (visible) {
+      // The focus won't work without delaying rendering.
+      setTimeout(() => {
+        const firstItem = menuRef.current.querySelector('[role^="menuitem"]');
+        if (firstItem) {
+          firstItem.focus();
+        }
+      });
+    }
+  }, [visible]);
+
+  const onKeyDown = event => {
+    const menuItems = Array.from(
+      menuRef.current.querySelectorAll('[role^="menuitem"]')
+    ).filter(isElementVisible);
+
+    let focusedIndex = menuItems.findIndex(el =>
+      el.contains(document.activeElement)
+    );
+
+    let handled = false;
+
+    switch (event.key) {
+      case 'ArrowLeft':
+      case 'Escape':
+        if (closeMenu) {
+          closeMenu(event);
+          handled = true;
+        }
+        break;
+      case 'ArrowUp':
+        focusedIndex -= 1;
+        if (focusedIndex < 0) {
+          focusedIndex = menuItems.length - 1;
+        }
+        handled = true;
+        break;
+      case 'ArrowDown':
+        focusedIndex += 1;
+        if (focusedIndex === menuItems.length) {
+          focusedIndex = 0;
+        }
+        handled = true;
+        break;
+      case 'Home':
+        focusedIndex = 0;
+        handled = true;
+        break;
+      case 'End':
+        focusedIndex = menuItems.length - 1;
+        handled = true;
+        break;
+    }
+
+    if (handled && focusedIndex >= 0) {
+      event.stopPropagation();
+      event.preventDefault();
+      menuItems[focusedIndex].focus();
+    }
+  };
+
+  return (
+    <div role="none" className={className} ref={menuRef} onKeyDown={onKeyDown}>
+      {children}
+    </div>
+  );
+}
+
+MenuKeyboardNavigation.propTypes = {
+  className: propTypes.string,
+
+  // Callback when the menu is closed via keyboard input
+  closeMenu: propTypes.func,
+
+  // When  true`, sets focus on the first item in the list
+  // which has a role="menuitem" attribute.
+  visible: propTypes.bool,
+
+  // Array of nodes which may contain MenuItems
+  children: propTypes.any,
+};

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -5,6 +5,7 @@ import propTypes from 'prop-types';
 
 import useElementShouldClose from './hooks/use-element-should-close';
 import SvgIcon from '../../shared/components/svg-icon';
+import MenuKeyboardNavigation from './menu-keyboard-navigation';
 
 // The triangular indicator below the menu toggle button that visually links it
 // to the menu content.
@@ -52,6 +53,7 @@ export default function Menu({
   title,
 }) {
   const [isOpen, setOpen] = useState(defaultOpen);
+  const [openedByKeyboard, setOpenedByKeyboard] = useState(false);
 
   // Notify parent when menu is opened or closed.
   const wasOpen = useRef(isOpen);
@@ -76,6 +78,14 @@ export default function Menu({
       event.preventDefault();
       return;
     }
+    // State variable so we know to set focus() on the first item when opened
+    // via the keyboard.
+    if (!isOpen && event.type === 'click') {
+      setOpenedByKeyboard(true);
+    } else {
+      setOpenedByKeyboard(false);
+    }
+
     setOpen(!isOpen);
   };
   const closeMenu = useCallback(() => setOpen(false), [setOpen]);
@@ -96,7 +106,11 @@ export default function Menu({
   // It should also close if the user presses a key which activates menu items.
   const handleMenuKeyDown = event => {
     if (event.key === 'Enter' || event.key === ' ') {
-      closeMenu();
+      // Don't close the menu right away, the link still needs to be present at least one
+      // more render cycle for them to be followed.
+      setTimeout(() => {
+        closeMenu();
+      });
     }
   };
 
@@ -156,7 +170,9 @@ export default function Menu({
             onClick={closeMenu}
             onKeyDown={handleMenuKeyDown}
           >
-            {children}
+            <MenuKeyboardNavigation visible={openedByKeyboard}>
+              {children}
+            </MenuKeyboardNavigation>
           </div>
         </Fragment>
       )}

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import useElementShouldClose from './hooks/use-element-should-close';
+import { normalizeKeyName } from '../../shared/browser-compatibility-utils';
+
 import SvgIcon from '../../shared/components/svg-icon';
 import MenuKeyboardNavigation from './menu-keyboard-navigation';
 
@@ -73,13 +75,17 @@ export default function Menu({
     if (event.type === 'mousedown') {
       ignoreNextClick = true;
     } else if (event.type === 'click' && ignoreNextClick) {
+      // ignore mouseup event
       ignoreNextClick = false;
       event.stopPropagation();
       event.preventDefault();
       return;
     }
     // State variable so we know to set focus() on the first item when opened
-    // via the keyboard.
+    // via the keyboard. Note, when opening the menu via keyboard by pressing
+    // enter or space, a simulated MouseEvent is created with a type value of
+    // "click". We also know this is not a mouseup event because that condition
+    // is checked above.
     if (!isOpen && event.type === 'click') {
       setOpenedByKeyboard(true);
     } else {
@@ -105,7 +111,8 @@ export default function Menu({
 
   // It should also close if the user presses a key which activates menu items.
   const handleMenuKeyDown = event => {
-    if (event.key === 'Enter' || event.key === ' ') {
+    const key = normalizeKeyName(event.key);
+    if (key === 'Enter' || key === ' ') {
       // The link will not follow if its removed directly from an keypress event.
       // Delay it a little.
       setTimeout(() => {

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -75,7 +75,7 @@ export default function Menu({
     if (event.type === 'mousedown') {
       ignoreNextClick = true;
     } else if (event.type === 'click' && ignoreNextClick) {
-      // ignore mouseup event
+      // Ignore "click" event triggered from the mouse up action.
       ignoreNextClick = false;
       event.stopPropagation();
       event.preventDefault();
@@ -113,8 +113,9 @@ export default function Menu({
   const handleMenuKeyDown = event => {
     const key = normalizeKeyName(event.key);
     if (key === 'Enter' || key === ' ') {
-      // The link will not follow if its removed directly from an keypress event.
-      // Delay it a little.
+      // The browser will not open the link if the link element is removed
+      // from within the keypress event that triggers it. Add a little
+      // delay to work around that.
       setTimeout(() => {
         closeMenu();
       });

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -106,8 +106,8 @@ export default function Menu({
   // It should also close if the user presses a key which activates menu items.
   const handleMenuKeyDown = event => {
     if (event.key === 'Enter' || event.key === ' ') {
-      // Don't close the menu right away, the link still needs to be present at least one
-      // more render cycle for them to be followed.
+      // The link will not follow if its removed directly from an keypress event.
+      // Delay it a little.
       setTimeout(() => {
         closeMenu();
       });

--- a/src/sidebar/components/test/menu-item-test.js
+++ b/src/sidebar/components/test/menu-item-test.js
@@ -1,5 +1,6 @@
 import { mount } from 'enzyme';
 import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
 
 import MenuItem from '../menu-item';
 import { $imports } from '../menu-item';
@@ -8,8 +9,13 @@ import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
 describe('MenuItem', () => {
-  const createMenuItem = props =>
-    mount(<MenuItem label="Test item" {...props} />);
+  const createMenuItem = props => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    return mount(<MenuItem label="Test item" {...props} />, {
+      attachTo: container,
+    });
+  };
 
   beforeEach(() => {
     $imports.$mock(mockImportedComponents());
@@ -19,125 +25,225 @@ describe('MenuItem', () => {
     $imports.$restore();
   });
 
-  it('invokes `onClick` callback when clicked', () => {
-    const onClick = sinon.stub();
-    const wrapper = createMenuItem({ onClick });
-    wrapper.find('[role="menuitem"]').simulate('click');
-    assert.called(onClick);
-  });
-
-  it('renders a link if an `href` is provided', () => {
-    const wrapper = createMenuItem({ href: 'https://example.com' });
-    const link = wrapper.find('a');
-    assert.equal(link.length, 1);
-    assert.equal(link.prop('href'), 'https://example.com');
-    assert.equal(link.prop('rel'), 'noopener noreferrer');
-  });
-
-  it('renders a non-link if an `href` is not provided', () => {
-    const wrapper = createMenuItem();
-    assert.isFalse(wrapper.exists('a'));
-    assert.equal(wrapper.find('.menu-item__label').text(), 'Test item');
-  });
-
-  it('renders an `<img>` icon if an icon URL is provided', () => {
-    const src = 'https://example.com/icon.svg';
-    const wrapper = createMenuItem({ icon: src });
-    const icon = wrapper.find('img');
-    assert.equal(icon.prop('src'), src);
-  });
-
-  it('renders an SVG icon if an icon name is provided', () => {
-    const wrapper = createMenuItem({ icon: 'an-svg-icon' });
-    assert.isTrue(wrapper.exists('SvgIcon[name="an-svg-icon"]'));
-  });
-
-  it('renders a blank space for an icon if `icon` is "blank"', () => {
-    const wrapper = createMenuItem({ icon: 'blank' });
-    const iconSpace = wrapper.find('.menu-item__icon-container');
-    assert.equal(iconSpace.length, 1);
-    assert.equal(iconSpace.children().length, 0);
-  });
-
-  it('does not render a space for an icon if `icon` is missing', () => {
-    const wrapper = createMenuItem();
-    const iconSpace = wrapper.find('.menu-item__icon-container');
-    assert.equal(iconSpace.length, 0);
-  });
-
-  it('shows the submenu indicator if `isSubmenuVisible` is a boolean', () => {
-    const wrapper = createMenuItem({
-      isSubmenuVisible: true,
+  describe('link menu items', () => {
+    it('renders a link if an `href` is provided', () => {
+      const wrapper = createMenuItem({ href: 'https://example.com' });
+      const link = wrapper.find('a');
+      assert.equal(link.length, 1);
+      assert.equal(link.prop('href'), 'https://example.com');
+      assert.equal(link.prop('rel'), 'noopener noreferrer');
     });
-    assert.isTrue(wrapper.exists('SvgIcon[name="collapse-menu"]'));
 
-    wrapper.setProps({ isSubmenuVisible: false });
-    assert.isTrue(wrapper.exists('SvgIcon[name="expand-menu"]'));
-  });
-
-  it('does not show submenu indicator if `isSubmenuVisible` is undefined', () => {
-    const wrapper = createMenuItem();
-    assert.isFalse(wrapper.exists('SvgIcon'));
-  });
-
-  it('calls the `onToggleSubmenu` callback when the submenu toggle is clicked', () => {
-    const onToggleSubmenu = sinon.stub();
-    const wrapper = createMenuItem({
-      isSubmenuVisible: true,
-      onToggleSubmenu,
+    it('renders an `<img>` icon if an icon URL is provided', () => {
+      const src = 'https://example.com/icon.svg';
+      const wrapper = createMenuItem({ icon: src });
+      const icon = wrapper.find('img');
+      assert.equal(icon.prop('src'), src);
     });
-    wrapper.find('.menu-item__toggle').simulate('click');
-    assert.called(onToggleSubmenu);
-  });
 
-  it('renders top-level menu item icons on the left', () => {
-    const wrapper = createMenuItem({ icon: 'an-svg-icon' });
-    const iconSpaces = wrapper.find('.menu-item__icon-container');
-
-    // There should be only one icon space, on the left.
-    assert.equal(iconSpaces.length, 1);
-    assert.equal(iconSpaces.at(0).children().length, 1);
-  });
-
-  it('renders submenu item icons on the right', () => {
-    const wrapper = createMenuItem({
-      icon: 'an-svg-icon',
-      isSubmenuItem: true,
+    it('invokes `onClick` callback when pressing `Enter` or space', () => {
+      const onClick = sinon.stub();
+      const wrapper = createMenuItem({ href: 'https://example.com', onClick });
+      wrapper.find('.menu-item').simulate('keydown', { key: 'Enter' });
+      assert.called(onClick);
+      wrapper.find('.menu-item').simulate('keydown', { key: ' ' });
+      assert.calledTwice(onClick);
     });
-    const iconSpaces = wrapper.find('.menu-item__icon-container');
-    assert.equal(iconSpaces.length, 2);
-
-    // There should be a space for the parent item's icon.
-    assert.equal(iconSpaces.at(0).children().length, 0);
-
-    // The actual icon for the submenu should be shown on the right.
-    assert.equal(iconSpaces.at(1).children().length, 1);
   });
 
-  it('does not render submenu content if `isSubmenuVisible` is undefined', () => {
-    const wrapper = createMenuItem({});
-    assert.isFalse(wrapper.exists('Slider'));
-  });
-
-  it('shows submenu content if `isSubmenuVisible` is true', () => {
-    const wrapper = createMenuItem({
-      isSubmenuVisible: true,
-      submenu: <div>Submenu content</div>,
+  describe('button menu items', () => {
+    it('renders a non-link if an `href` is not provided', () => {
+      const wrapper = createMenuItem();
+      assert.isFalse(wrapper.exists('a'));
+      assert.equal(wrapper.find('.menu-item__label').text(), 'Test item');
     });
-    assert.equal(wrapper.find('Slider').prop('visible'), true);
-    assert.equal(wrapper.find('Slider').children().text(), 'Submenu content');
+
+    it('invokes `onClick` callback when clicked', () => {
+      const onClick = sinon.stub();
+      const wrapper = createMenuItem({ onClick });
+      wrapper.find('.menu-item').simulate('click');
+      assert.called(onClick);
+    });
+
+    it('has proper aria attributes when `isSelected` is a boolean', () => {
+      const wrapper = createMenuItem({ isSelected: true });
+      assert.equal(wrapper.find('.menu-item').prop('role'), 'menuitemradio');
+      assert.equal(wrapper.find('.menu-item').prop('aria-checked'), true);
+      // aria-haspopup should be false without a submenu
+      assert.equal(wrapper.find('.menu-item').prop('aria-haspopup'), false);
+    });
+
+    it('invokes `onClick` callback when pressing `Enter` or space', () => {
+      const onClick = sinon.stub();
+      const wrapper = createMenuItem({ isSelected: true, onClick });
+      wrapper.find('.menu-item').simulate('keydown', { key: 'Enter' });
+      assert.called(onClick);
+      wrapper.find('.menu-item').simulate('keydown', { key: ' ' });
+      assert.calledTwice(onClick);
+    });
   });
 
-  it('hides submenu content if `isSubmenuVisible` is false', () => {
-    const wrapper = createMenuItem({
-      isSubmenuVisible: false,
-      submenu: <div>Submenu content</div>,
+  describe('icons', () => {
+    it('renders an SVG icon if an icon name is provided', () => {
+      const wrapper = createMenuItem({ icon: 'an-svg-icon' });
+      assert.isTrue(wrapper.exists('SvgIcon[name="an-svg-icon"]'));
     });
-    assert.equal(wrapper.find('Slider').prop('visible'), false);
 
-    // The submenu content may still be rendered if the submenu is currently
-    // collapsing.
-    assert.equal(wrapper.find('Slider').children().text(), 'Submenu content');
+    it('renders a blank space for an icon if `icon` is "blank"', () => {
+      const wrapper = createMenuItem({ icon: 'blank' });
+      const iconSpace = wrapper.find('.menu-item__icon-container');
+      assert.equal(iconSpace.length, 1);
+      assert.equal(iconSpace.children().length, 0);
+    });
+
+    it('does not render a space for an icon if `icon` is missing', () => {
+      const wrapper = createMenuItem();
+      const iconSpace = wrapper.find('.menu-item__icon-container');
+      assert.equal(iconSpace.length, 0);
+    });
+
+    it('renders top-level menu item icons on the left', () => {
+      const wrapper = createMenuItem({ icon: 'an-svg-icon' });
+      const iconSpaces = wrapper.find('.menu-item__icon-container');
+
+      // There should be only one icon space, on the left.
+      assert.equal(iconSpaces.length, 1);
+      assert.equal(iconSpaces.at(0).children().length, 1);
+    });
+  });
+
+  describe('submenu', () => {
+    it('shows the submenu indicator if `isSubmenuVisible` is a boolean', () => {
+      const wrapper = createMenuItem({
+        isSubmenuVisible: true,
+      });
+      assert.isTrue(wrapper.exists('SvgIcon[name="collapse-menu"]'));
+      assert.equal(wrapper.find('.menu-item').prop('aria-expanded'), true);
+
+      wrapper.setProps({ isSubmenuVisible: false });
+      assert.isTrue(wrapper.exists('SvgIcon[name="expand-menu"]'));
+      assert.equal(wrapper.find('.menu-item').prop('aria-haspopup'), true);
+      assert.equal(wrapper.find('.menu-item').prop('aria-expanded'), false);
+    });
+
+    it('does not show submenu indicator if `isSubmenuVisible` is undefined', () => {
+      const wrapper = createMenuItem();
+      assert.isFalse(wrapper.exists('SvgIcon'));
+      // aria-expanded should not be present
+      assert.equal(wrapper.find('.menu-item').prop('aria-expanded'), undefined);
+    });
+
+    it('calls the `onToggleSubmenu` callback when the submenu toggle is clicked', () => {
+      const fakeOnToggleSubmenu = sinon.stub();
+      const wrapper = createMenuItem({
+        isSubmenuVisible: true,
+        onToggleSubmenu: fakeOnToggleSubmenu,
+      });
+      wrapper.find('.menu-item__toggle').simulate('click');
+      assert.called(fakeOnToggleSubmenu);
+    });
+
+    it('calls the `onToggleSubmenu` callback when pressing arrow right', () => {
+      const fakeOnToggleSubmenu = sinon.stub();
+      const wrapper = createMenuItem({
+        isSubmenuVisible: true,
+        onToggleSubmenu: fakeOnToggleSubmenu,
+      });
+      wrapper.find('.menu-item').simulate('keydown', { key: 'ArrowRight' });
+    });
+
+    it('renders submenu item icons on the right', () => {
+      const wrapper = createMenuItem({
+        icon: 'an-svg-icon',
+        isSubmenuItem: true,
+      });
+      const iconSpaces = wrapper.find('.menu-item__icon-container');
+      assert.equal(iconSpaces.length, 2);
+
+      // There should be a space for the parent item's icon.
+      assert.equal(iconSpaces.at(0).children().length, 0);
+
+      // The actual icon for the submenu should be shown on the right.
+      assert.equal(iconSpaces.at(1).children().length, 1);
+    });
+
+    it('does not render submenu content if `isSubmenuVisible` is undefined', () => {
+      const wrapper = createMenuItem({});
+      assert.isFalse(wrapper.exists('Slider'));
+    });
+
+    it('shows submenu content if `isSubmenuVisible` is true', () => {
+      const wrapper = createMenuItem({
+        isSubmenuVisible: true,
+        submenu: <div>Submenu content</div>,
+      });
+      assert.equal(wrapper.find('Slider').prop('visible'), true);
+      assert.equal(
+        wrapper.find('MenuKeyboardNavigation').prop('visible'),
+        true
+      );
+      assert.equal(wrapper.find('Slider').children().text(), 'Submenu content');
+    });
+
+    it('hides submenu content if `isSubmenuVisible` is false', () => {
+      const wrapper = createMenuItem({
+        isSubmenuVisible: false,
+        submenu: <div>Submenu content</div>,
+      });
+      assert.equal(wrapper.find('Slider').prop('visible'), false);
+      assert.equal(
+        wrapper.find('MenuKeyboardNavigation').prop('visible'),
+        false
+      );
+
+      // The submenu content may still be rendered if the submenu is currently
+      // collapsing.
+      assert.equal(wrapper.find('Slider').children().text(), 'Submenu content');
+    });
+
+    it('calls `onToggleSubmenu` when the `closeMenu` callback is fired', () => {
+      const fakeOnToggleSubmenu = sinon.stub();
+      const wrapper = createMenuItem({
+        isSubmenuVisible: true,
+        submenu: <div>Submenu content</div>,
+        onToggleSubmenu: fakeOnToggleSubmenu,
+      });
+      act(() => {
+        wrapper
+          .find('MenuKeyboardNavigation')
+          .props()
+          .closeMenu({ key: 'Enter' });
+      });
+      assert.isTrue(fakeOnToggleSubmenu.called);
+    });
+
+    it('calls `onToggleSubmenu` when the right arrow key is pressed', () => {
+      const fakeOnToggleSubmenu = sinon.stub();
+      const wrapper = createMenuItem({
+        isSubmenuVisible: true,
+        submenu: <div>Submenu content</div>,
+        onToggleSubmenu: fakeOnToggleSubmenu,
+      });
+      wrapper.find('.menu-item').simulate('keydown', { key: 'ArrowRight' });
+      assert.isTrue(fakeOnToggleSubmenu.called);
+    });
+
+    it('sets focus to div.menu-item when the submenu is closed via `closeMenu`', () => {
+      const clock = sinon.useFakeTimers();
+      const wrapper = createMenuItem({
+        isSubmenuVisible: true,
+        submenu: <div>Submenu content</div>,
+      });
+      act(() => {
+        wrapper
+          .find('MenuKeyboardNavigation')
+          .props()
+          .closeMenu({ key: 'Enter' });
+      });
+      clock.tick(1);
+      assert.equal(document.activeElement.className, 'menu-item');
+      clock.restore();
+    });
   });
 
   it(
@@ -148,6 +254,15 @@ describe('MenuItem', () => {
         content: () => (
           <div role="menu">
             <MenuItem label="Test item" />
+          </div>
+        ),
+      },
+      {
+        name: 'menu radio button',
+        // eslint-disable-next-line react/display-name
+        content: () => (
+          <div role="menu">
+            <MenuItem label="Test" isSelected={false} />
           </div>
         ),
       },

--- a/src/sidebar/components/test/menu-item-test.js
+++ b/src/sidebar/components/test/menu-item-test.js
@@ -150,6 +150,7 @@ describe('MenuItem', () => {
         onToggleSubmenu: fakeOnToggleSubmenu,
       });
       wrapper.find('.menu-item').simulate('keydown', { key: 'ArrowRight' });
+      assert.called(fakeOnToggleSubmenu);
     });
 
     it('renders submenu item icons on the right', () => {
@@ -217,18 +218,7 @@ describe('MenuItem', () => {
       assert.isTrue(fakeOnToggleSubmenu.called);
     });
 
-    it('calls `onToggleSubmenu` when the right arrow key is pressed', () => {
-      const fakeOnToggleSubmenu = sinon.stub();
-      const wrapper = createMenuItem({
-        isSubmenuVisible: true,
-        submenu: <div>Submenu content</div>,
-        onToggleSubmenu: fakeOnToggleSubmenu,
-      });
-      wrapper.find('.menu-item').simulate('keydown', { key: 'ArrowRight' });
-      assert.isTrue(fakeOnToggleSubmenu.called);
-    });
-
-    it('sets focus to div.menu-item when the submenu is closed via `closeMenu`', () => {
+    it('sets focus to the parent item when the submenu is closed via `closeMenu`', () => {
       const clock = sinon.useFakeTimers();
       const wrapper = createMenuItem({
         isSubmenuVisible: true,

--- a/src/sidebar/components/test/menu-item-test.js
+++ b/src/sidebar/components/test/menu-item-test.js
@@ -119,8 +119,6 @@ describe('MenuItem', () => {
   });
 
   describe('submenu', () => {
-    afterEach(() => {});
-
     it('shows the submenu indicator if `isSubmenuVisible` is a boolean', () => {
       const wrapper = createMenuItem({
         isSubmenuVisible: true,

--- a/src/sidebar/components/test/menu-keyboard-navigation-test.js
+++ b/src/sidebar/components/test/menu-keyboard-navigation-test.js
@@ -15,7 +15,11 @@ describe('MenuKeyboardNavigation', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     return mount(
-      <MenuKeyboardNavigation closeMenu={fakeCloseMenu} {...props}>
+      <MenuKeyboardNavigation
+        closeMenu={fakeCloseMenu}
+        className="test-nav"
+        {...props}
+      >
         <button>Item 0</button>
         <button role="menuitem">Item 1</button>
         <button role="menuitem">Item 2</button>
@@ -42,8 +46,8 @@ describe('MenuKeyboardNavigation', () => {
   });
 
   ['ArrowLeft', 'Escape'].forEach(key => {
-    it(`calls \`closeMenu\` callback when the ${key} is pressed`, () => {
-      const wrapper = createMenuItem({ visible: true }).find('div');
+    it(`calls \`closeMenu\` callback when the '${key}' is pressed`, () => {
+      const wrapper = createMenuItem({ visible: true }).find('div.test-nav');
       wrapper.simulate('keydown', { key });
       assert.called(fakeCloseMenu);
     });
@@ -68,7 +72,7 @@ describe('MenuKeyboardNavigation', () => {
     });
 
     it('changes focus circularly when down arrow is pressed', () => {
-      const wrapper = createMenuItem({ visible: true }).find('div');
+      const wrapper = createMenuItem({ visible: true }).find('div.test-nav');
       clock.tick(1);
       wrapper.simulate('keydown', { key: 'ArrowDown' });
       assert.equal(document.activeElement.innerText, 'Item 2');
@@ -79,7 +83,7 @@ describe('MenuKeyboardNavigation', () => {
     });
 
     it('changes focus circularly when up arrow is pressed', () => {
-      const wrapper = createMenuItem({ visible: true }).find('div');
+      const wrapper = createMenuItem({ visible: true }).find('div.test-nav');
       clock.tick(1);
       wrapper.simulate('keydown', { key: 'ArrowUp' });
       assert.equal(document.activeElement.innerText, 'Item 3');
@@ -90,14 +94,14 @@ describe('MenuKeyboardNavigation', () => {
     });
 
     it('changes focus to the last item when up `End` is pressed', () => {
-      const wrapper = createMenuItem({ visible: true }).find('div');
+      const wrapper = createMenuItem({ visible: true }).find('div.test-nav');
       clock.tick(1);
       wrapper.simulate('keydown', { key: 'End' });
       assert.equal(document.activeElement.innerText, 'Item 3');
     });
 
     it('changes focus to the first item when up `Home` is pressed', () => {
-      const wrapper = createMenuItem({ visible: true }).find('div');
+      const wrapper = createMenuItem({ visible: true }).find('div.test-nav');
       clock.tick(1);
       wrapper.simulate('keydown', { key: 'End' }); // move focus off first item
       wrapper.simulate('keydown', { key: 'Home' });
@@ -111,7 +115,9 @@ describe('MenuKeyboardNavigation', () => {
       // eslint-disable-next-line react/display-name
       content: () => (
         <div>
-          <MenuKeyboardNavigation />
+          <MenuKeyboardNavigation>
+            <button role="menuitem">Item 1</button>
+          </MenuKeyboardNavigation>
         </div>
       ),
     })

--- a/src/sidebar/components/test/menu-keyboard-navigation-test.js
+++ b/src/sidebar/components/test/menu-keyboard-navigation-test.js
@@ -1,0 +1,119 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import MenuKeyboardNavigation from '../menu-keyboard-navigation';
+import { $imports } from '../menu-keyboard-navigation';
+
+import { checkAccessibility } from '../../../test-util/accessibility';
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+
+describe('MenuKeyboardNavigation', () => {
+  let fakeCloseMenu;
+  let clock;
+
+  const createMenuItem = props => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    return mount(
+      <MenuKeyboardNavigation closeMenu={fakeCloseMenu} {...props}>
+        <button>Item 0</button>
+        <button role="menuitem">Item 1</button>
+        <button role="menuitem">Item 2</button>
+        <button role="menuitem">Item 3</button>
+      </MenuKeyboardNavigation>,
+      {
+        attachTo: container,
+      }
+    );
+  };
+
+  beforeEach(() => {
+    fakeCloseMenu = sinon.stub();
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('renders the provided class name', () => {
+    const wrapper = createMenuItem({ className: 'test' });
+    assert.isTrue(wrapper.find('.test').exists());
+  });
+
+  ['ArrowLeft', 'Escape'].forEach(key => {
+    it(`calls \`closeMenu\` callback when the ${key} is pressed`, () => {
+      const wrapper = createMenuItem({ visible: true }).find('div');
+      wrapper.simulate('keydown', { key });
+      assert.called(fakeCloseMenu);
+    });
+  });
+
+  // useFakeTimers does not work with checkAccessibility
+  // so wrap these tests in their own describe block
+  describe('fake timer', () => {
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('sets focus to the first `menuitem` child when `visible` is true', () => {
+      const clock = sinon.useFakeTimers();
+      createMenuItem({ visible: true });
+      clock.tick(1);
+      assert.equal(document.activeElement.innerText, 'Item 1');
+    });
+
+    it('changes focus circularly when down arrow is pressed', () => {
+      const wrapper = createMenuItem({ visible: true }).find('div');
+      clock.tick(1);
+      wrapper.simulate('keydown', { key: 'ArrowDown' });
+      assert.equal(document.activeElement.innerText, 'Item 2');
+      wrapper.simulate('keydown', { key: 'ArrowDown' });
+      assert.equal(document.activeElement.innerText, 'Item 3');
+      wrapper.simulate('keydown', { key: 'ArrowDown' });
+      assert.equal(document.activeElement.innerText, 'Item 1');
+    });
+
+    it('changes focus circularly when up arrow is pressed', () => {
+      const wrapper = createMenuItem({ visible: true }).find('div');
+      clock.tick(1);
+      wrapper.simulate('keydown', { key: 'ArrowUp' });
+      assert.equal(document.activeElement.innerText, 'Item 3');
+      wrapper.simulate('keydown', { key: 'ArrowUp' });
+      assert.equal(document.activeElement.innerText, 'Item 2');
+      wrapper.simulate('keydown', { key: 'ArrowUp' });
+      assert.equal(document.activeElement.innerText, 'Item 1');
+    });
+
+    it('changes focus to the last item when up `End` is pressed', () => {
+      const wrapper = createMenuItem({ visible: true }).find('div');
+      clock.tick(1);
+      wrapper.simulate('keydown', { key: 'End' });
+      assert.equal(document.activeElement.innerText, 'Item 3');
+    });
+
+    it('changes focus to the first item when up `Home` is pressed', () => {
+      const wrapper = createMenuItem({ visible: true }).find('div');
+      clock.tick(1);
+      wrapper.simulate('keydown', { key: 'End' }); // move focus off first item
+      wrapper.simulate('keydown', { key: 'Home' });
+      assert.equal(document.activeElement.innerText, 'Item 1');
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      // eslint-disable-next-line react/display-name
+      content: () => (
+        <div>
+          <MenuKeyboardNavigation />
+        </div>
+      ),
+    })
+  );
+});

--- a/src/sidebar/components/test/menu-keyboard-navigation-test.js
+++ b/src/sidebar/components/test/menu-keyboard-navigation-test.js
@@ -51,7 +51,7 @@ describe('MenuKeyboardNavigation', () => {
 
   // useFakeTimers does not work with checkAccessibility
   // so wrap these tests in their own describe block
-  describe('fake timer', () => {
+  describe('keyboard navigation', () => {
     beforeEach(() => {
       clock = sinon.useFakeTimers();
     });

--- a/src/sidebar/components/test/menu-keyboard-navigation-test.js
+++ b/src/sidebar/components/test/menu-keyboard-navigation-test.js
@@ -10,10 +10,12 @@ import mockImportedComponents from '../../../test-util/mock-imported-components'
 describe('MenuKeyboardNavigation', () => {
   let fakeCloseMenu;
   let clock;
+  let containers = [];
 
   const createMenuItem = props => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
+    let newContainer = document.createElement('div');
+    containers.push(newContainer);
+    document.body.appendChild(newContainer);
     return mount(
       <MenuKeyboardNavigation
         closeMenu={fakeCloseMenu}
@@ -26,7 +28,7 @@ describe('MenuKeyboardNavigation', () => {
         <button role="menuitem">Item 3</button>
       </MenuKeyboardNavigation>,
       {
-        attachTo: container,
+        attachTo: newContainer,
       }
     );
   };
@@ -38,6 +40,10 @@ describe('MenuKeyboardNavigation', () => {
 
   afterEach(() => {
     $imports.$restore();
+    containers.forEach(container => {
+      container.remove();
+    });
+    containers = [];
   });
 
   it('renders the provided class name', () => {
@@ -106,6 +112,13 @@ describe('MenuKeyboardNavigation', () => {
       wrapper.simulate('keydown', { key: 'End' }); // move focus off first item
       wrapper.simulate('keydown', { key: 'Home' });
       assert.equal(document.activeElement.innerText, 'Item 1');
+    });
+
+    it('does not throw an error when unmounting the component before the focus timeout finishes', () => {
+      const wrapper = createMenuItem({ visible: true });
+      wrapper.unmount();
+      clock.tick(1);
+      // no assert needed
     });
   });
 

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -10,6 +10,7 @@ import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('Menu', () => {
   let container;
+  let clock;
 
   const TestLabel = () => 'Test label';
   const TestMenuItem = () => 'Test item';
@@ -39,6 +40,10 @@ describe('Menu', () => {
   afterEach(() => {
     $imports.$restore();
     container.remove();
+    if (clock) {
+      clock.restore();
+      clock = null;
+    }
   });
 
   it('opens and closes when the toggle button is clicked', () => {
@@ -164,13 +169,12 @@ describe('Menu', () => {
     it(`${
       shouldClose ? 'closes' : "doesn't close"
     } when user performs a "${eventType}" (key: "${key}") on menu content`, () => {
-      const clock = sinon.useFakeTimers();
+      clock = sinon.useFakeTimers();
       const wrapper = createMenu({ defaultOpen: true });
       wrapper.find('.menu__content').simulate(eventType, { key });
       clock.tick(1);
       wrapper.update();
       assert.equal(isOpen(wrapper), !shouldClose);
-      clock.restore();
     });
   });
 

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -45,6 +45,7 @@ describe('Menu', () => {
     const wrapper = createMenu();
     assert.isFalse(isOpen(wrapper));
     wrapper.find('button').simulate('click');
+    assert.isTrue(wrapper.find('MenuKeyboardNavigation').prop('visible'));
     assert.isTrue(isOpen(wrapper));
     wrapper.find('button').simulate('click');
     assert.isFalse(isOpen(wrapper));
@@ -54,6 +55,7 @@ describe('Menu', () => {
     const onOpenChanged = sinon.stub();
     const wrapper = createMenu({ onOpenChanged });
     wrapper.find('button').simulate('click');
+    assert.isTrue(wrapper.find('MenuKeyboardNavigation').prop('visible'));
     assert.calledWith(onOpenChanged, true);
     wrapper.find('button').simulate('click');
     assert.calledWith(onOpenChanged, false);
@@ -64,6 +66,7 @@ describe('Menu', () => {
     assert.isFalse(isOpen(wrapper));
 
     wrapper.find('button').simulate('mousedown');
+    assert.isFalse(wrapper.find('MenuKeyboardNavigation').prop('visible'));
     // Make sure the follow-up click doesn't close the menu.
     wrapper.find('button').simulate('click');
 
@@ -161,9 +164,13 @@ describe('Menu', () => {
     it(`${
       shouldClose ? 'closes' : "doesn't close"
     } when user performs a "${eventType}" (key: "${key}") on menu content`, () => {
+      const clock = sinon.useFakeTimers();
       const wrapper = createMenu({ defaultOpen: true });
       wrapper.find('.menu__content').simulate(eventType, { key });
+      clock.tick(1);
+      wrapper.update();
       assert.equal(isOpen(wrapper), !shouldClose);
+      clock.restore();
     });
   });
 

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -172,6 +172,10 @@ describe('Menu', () => {
       clock = sinon.useFakeTimers();
       const wrapper = createMenu({ defaultOpen: true });
       wrapper.find('.menu__content').simulate(eventType, { key });
+      // The close event is delayed by a minimal amount of time in
+      // order to allow links to say in the DOM long enough to be
+      // followed on a click. Therefore, this test must simulate
+      // time passing in order for the menu to close.
       clock.tick(1);
       wrapper.update();
       assert.equal(isOpen(wrapper), !shouldClose);

--- a/src/styles/sidebar/components/menu-item.scss
+++ b/src/styles/sidebar/components/menu-item.scss
@@ -3,96 +3,91 @@
 @use "../../variables" as var;
 
 $menu-item-padding: 10px;
+$item-height: 40px;
+
+// The container for the clickable area of the menu item which triggers an
+// action or link. For menu items without submenus, this covers the full area of
+// the menu item. For menu items with submenus, this covers the full area
+// except for the toggle button that opens the submenu.
+
+a.menu-item:hover {
+  color: var.$link-color-hover;
+}
 
 .menu-item {
   @include focus.outline-on-keyboard-focus;
-
-  $item-height: 40px;
-
-  color: var.$grey-6;
+  align-self: stretch;
   display: flex;
-  flex-direction: row;
   flex-grow: 1;
-  font-weight: 500;
+  appearance: none;
   align-items: center;
+  padding-left: $menu-item-padding;
+  color: var.$grey-6;
+  border: none;
+  padding-right: 0;
+  font-weight: 500;
+  min-height: 40px;
+  width: 100%;
   min-width: 150px;
-  min-height: $item-height;
-
-  // TODO - Make the link fill the full available vertical space.
-  cursor: pointer;
-
+  // Prevent height changes when .is-expanded border is rendered.
+  border-bottom: solid 1px transparent;
   // Prevent menu item text from being selected when user toggles menu.
   user-select: none;
 
-  // An item in a submenu associated with a top-level item.
-  &--submenu {
+  &:hover {
+    background-color: var.$grey-1;
+    .menu-item__toggle {
+      // Make it a bit darker when its a submenu item.
+      background-color: var.$grey-3;
+    }
+  }
+
+  &.is-submenu {
     min-height: $item-height - 10px;
     background: var.$grey-1;
     color: color.mix(var.$grey-5, var.$grey-6, $weight: 50%);
     font-weight: normal;
-  }
-
-  // Animate the background color transition of menu items with expanding submenus.
-  // The timing should match the expansion of the submenu.
-  transition: background 0.15s ease-in;
-
-  &.is-expanded {
-    // Set the background color of menu items with submenus to match the
-    // submenu items.
-    background: var.$grey-1;
-  }
-}
-
-// The container for the clickable area of the menu item which triggers its
-// main action. For menu items without submenus, this covers the full area of
-// the menu item. For menu items with submenus, this covers the full area
-// except for the toggle that opens the submenu.
-.menu-item__action {
-  align-self: stretch;
-  display: flex;
-  flex-grow: 1;
-  align-items: center;
-  padding-left: $menu-item-padding;
-
-  &:hover {
-    background: var.$grey-1;
-
-    .menu-item.is-expanded & {
-      // Since expanded items already have a light grey background, we need to
-      // make the hover state a little darker. This should match submenu items'
-      // hover state.
-      background: var.$grey-3;
-    }
-
-    // Since submenu items already have a light grey background, we need to
-    // use a slightly darker grey as the hover state.
-    .menu-item--submenu & {
-      background: var.$grey-3;
-      color: var.$grey-6;
+    &:hover {
+      background-color: var.$grey-3;
     }
   }
 
-  .menu-item.is-selected & {
+  &.is-selected {
     $border-width: 4px;
     border-left: $border-width solid var.$brand;
     padding-left: $menu-item-padding - $border-width;
   }
-}
 
-.menu-item__icon-container {
-  margin-right: 10px;
-  width: 15px;
-  height: 15px;
+  &.is-expanded {
+    background-color: var.$grey-1;
+    color: var.$grey-6;
+    border-bottom: solid 1px var.$grey-3;
+    &:hover {
+      background-color: var.$grey-3;
+    }
+    .menu-item__toggle {
+      // Make it a bit darker when its expanded. This is needed for
+      // a color darker than hover while expanded.
+      background-color: var.$grey-4;
+    }
+  }
+  &.is-disabled {
+    color: var.$grey-4;
+  }
 }
-
 .menu-item__icon {
   color: inherit;
   display: inline-block;
   margin-right: 4px;
   position: relative;
-
   height: 15px;
   width: 15px;
+
+  &-container {
+    margin-right: 10px;
+    width: 15px;
+    height: 15px;
+  }
 }
 
 .menu-item__label {
@@ -113,24 +108,20 @@ $menu-item-padding: 10px;
   &--submenu {
     font-weight: normal;
   }
-
-  .menu-item.is-disabled & {
-    color: var.$grey-4;
-  }
 }
 
 // Toggle button used to expand or collapse the submenu associated with a menu
 // item.
 .menu-item__toggle {
-  @include focus.outline-on-keyboard-focus;
-
-  color: var.$grey-4;
+  color: var.$grey-5;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   align-self: stretch;
   width: 40px;
+  padding: 0;
+  height: 40px;
 
   // Add a wide transparent border to provide a large-enough hit target (~40px),
   // larger than the visual size of the button (~20px).
@@ -143,11 +134,16 @@ $menu-item-padding: 10px;
   border-radius: 12px;
 
   &:hover {
-    background-color: var.$grey-3;
-    color: var.$grey-5;
+    background-color: var.$grey-4;
+    color: var.$grey-6;
   }
 
   &-icon {
+    width: 12px;
+    height: 12px;
+  }
+
+  svg {
     width: 12px;
     height: 12px;
   }
@@ -155,5 +151,9 @@ $menu-item-padding: 10px;
 
 // The container for open submenus
 .menu-item__submenu {
-  border-bottom: solid 1px var.$grey-2;
+  border-bottom: solid 1px var.$grey-3;
+  &:hover {
+    // Make it a bit darker on hover.
+    background-color: var.$grey-3;
+  }
 }

--- a/src/styles/sidebar/components/menu-item.scss
+++ b/src/styles/sidebar/components/menu-item.scss
@@ -142,11 +142,6 @@ a.menu-item:hover {
     width: 12px;
     height: 12px;
   }
-
-  svg {
-    width: 12px;
-    height: 12px;
-  }
 }
 
 // The container for open submenus


### PR DESCRIPTION
The goal of this PR is to fully finish accessibility requirements for the menu component. The primary goals for that is keyboard navigation of the menu system. This particular PR is not complete, but does move us towards that goal. This is roughtly modeleed after these examples
https://www.w3.org/TR/wai-aria-practices/examples/menubar/menubar-1/menubar-1.html
https://www.w3.org/TR/wai-aria-practices/examples/menubar/menubar-2/menubar-2.html

_With the major change being that an item can both have its own action or toggle a submenu._

I have taken Rob's branch `p-menu-item-arrow-keys` and used that as a basis for this PR with some changes. In short, the component from that branch called `MenuList` has been refactored into a component called `MenuKeyboardNavigation` that can wrap a menu or a submenu and provide some common keyboard functionality.

Along with the accessibility goal I took the time to fix some minor CSS and coding issues I found with the menu (discussed below)

**Mouse Navigation**
All click navigations with the mouse should work exactly as before. There are some minor css differences that I will point out below.

**Keyboard Navigation**
Keyboard navigation works as follows: Click an element next to the menu button with the mouse such as the search bar. Then, using the keyboard, tab back to the menu button so you see the blue focus halo. Press `enter`. Once you do this, then the focus should be moved to the first item with the blue halo. From here, keyboard nav should work and there should always be a blue halo on the items. Every time you drill deeper into a menu, focus should be placed on the first item in that menu. When you back out of a submenu, then focus should be placed back on the parent controlling item.

**Operation:**
- `enter` or `space` or `right arrow` to drill down into a submenu, or click an item
- `up` or `down` to navigate within a menu level
- `home`, `end` to navigate to the first / last items in the menu level
- `left` to ascend up to the parent menu level
- `esc` to close menu

**Other issues or fixes worth pointing out**

- Previous it turns out there was no way to actually click on a link in a menu with the keyboard. I was surprised by that, but I suspect it has to do with preact killing off the a `<a>` before the event makes it to the bowser. I have demonstrated it here: https://jsfiddle.net/ft8z1wux/7/ and there is a hack fix in the code with a timeout. I have added a few hack fixes and commented on them.

- The toggle button is no longer focusable. You can still click on it to active it or when you're on a menu item that owns one, press `right`

- The blue halo gets a little covered up on the submenu. I did spend some time trying to figure out how to force it to render above its siblings but I was unsuccessful. It may mean we live with that for now or change its outline styling. 

- I have not fully tested this with the gauntlet of screen readers yet. I'm going to do that more next week. There may be some extra label(s) to add to inform the user when a toggle button is available on a menu item.

- Moving focus off the menu in my opinion should _close_ the menu, but that is tricky. A simple `onBlur` won't cut is as that only applied to items, not the menu wrapper. The w3 examples actually do this and w/o looking at the code it seems like there is a short delay before the menu hides after focus is removed. I'll look into how that was achieved next week, but I think we can merge this w/o that feature and add it later on.
https://www.w3.org/TR/wai-aria-practices/examples/menubar/menubar-1/menubar-1.html

**CSS changes**

- Toggle buttons get darker when their submenu is expanded and when the menu item they belong to has `:hover`. This helps make them more distinct.

- Links are now red on hover across the entire menu item. Previously, only link text was red, but now the left/right icons turn red too.

- Submenu bottom border is darker and I added a top border to help frame it from its parent. 

**TODO:**
- Minor css issues with sort and post menus. The min width is no longer the same and needs to be fixed.
- Add keyboard navigation ability to the sort and post menus.
- Tests
- A bit of css clean up and comments need to be added here and there

![menu](https://user-images.githubusercontent.com/3939074/78412038-d1ad6e80-75c6-11ea-82d4-d2bd9591be76.gif)
