### PR TITLE
Move coverage reporting from Travis to Jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,3 @@ matrix:
         - make lint
     - env: ACTION=test
       node_js: '10'
-      after_success:
-        yarn run report-coverage

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,15 @@ node {
 
     stage('Test') {
         nodeEnv.inside("-e HOME=${workspace}") {
-          sh "make checkformatting lint test"
+            withCredentials([
+                string(credentialsId: 'codecov-token', variable: 'CODECOV_TOKEN')
+            ]) {
+              sh "make checkformatting lint test"
+              sh """
+              export CODECOV_TOKEN=${env.CODECOV_TOKEN}
+              yarn run report-coverage
+              """
+            }
         }
     }
 }


### PR DESCRIPTION
Jenkins is the primary CI system and the source of truth for test
status, so it makes sense to generate coverage reports here too.

This also paves the way for potentially replacing codecov for coverage
status reporting with an alternative system in future which produces
output that devs find easier to work with.

For future reference, the `CODECOV_TOKEN` credential is configured at https://jenkins.hypothes.is/job/client/credentials/store/folder/domain/_/.