### PR TITLE
Fix press `Tab` to add a tag

### DIFF
--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -67,7 +67,7 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
       // Remove any repeated suggestions that are already tags
       // and set those to state.
       setSuggestions(removeDuplicates(suggestions, tagList));
-      setSuggestionsListOpen(true);
+      setSuggestionsListOpen(suggestions.length > 0);
     }
     setActiveItem(-1);
   };
@@ -193,13 +193,16 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
         e.preventDefault();
         break;
       case 'Tab':
-        if (activeItem === -1) {
-          // allow tab key to add tag, but only if the <input> value
-          // matches a suggestion from the list
-          if (suggestions.indexOf(inputEl.current.value) > -1) {
-            addTag(inputEl.current.value);
-            e.preventDefault();
-          }
+        if (activeItem !== -1) {
+          // If there is a selected item, then allow `Tab` to behave exactly
+          // like `Enter` or `,`.
+          addTag(suggestions[activeItem]);
+          e.preventDefault();
+        } else if (suggestionsListOpen) {
+          // If there is no selected item, then allow `Tab` to add the first
+          // item in the list if the list is open.
+          addTag(suggestions[0]);
+          e.preventDefault();
         }
     }
   };

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -226,47 +226,39 @@ describe('TagEditor', function () {
       assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
     });
 
-    it('adds a tag from the <input> field via keydown event', () => {
-      const wrapper = createComponent();
-      wrapper.find('input').instance().value = 'tag3';
-      selectOptionViaEnter(wrapper);
-      assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
-      // ensure focus is still on the input field
-      assert.equal(document.activeElement.nodeName, 'INPUT');
+    [
+      [selectOptionViaEnter, 'Enter'],
+      [selectOptionViaDelimiter, ','],
+      [selectOptionViaTab, 'Tab'],
+    ].forEach(keyAction => {
+      it(`adds a tag from the <input> field when typing "${keyAction[1]}"`, () => {
+        const wrapper = createComponent();
+        wrapper.find('input').instance().value = 'tag3';
+        typeInput(wrapper); // opens suggestion list
+        keyAction[0](wrapper);
+        assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
+        // ensure focus is still on the input field
+        assert.equal(document.activeElement.nodeName, 'INPUT');
+      });
     });
 
-    it('adds a tag from the <input> field when typing "," delimiter', () => {
-      const wrapper = createComponent();
-      wrapper.find('input').instance().value = 'tag3';
-      selectOptionViaDelimiter(wrapper);
-      assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
-      // ensure focus is still on the input field
-      assert.equal(document.activeElement.nodeName, 'INPUT');
+    [
+      [selectOptionViaEnter, 'Enter'],
+      [selectOptionViaDelimiter, ','],
+      [selectOptionViaTab, 'Tab'],
+    ].forEach(keyAction => {
+      it(`adds a tag from the suggestions list when typing "${keyAction[1]}"`, () => {
+        const wrapper = createComponent();
+        wrapper.find('input').instance().value = 't';
+        typeInput(wrapper);
+        // suggestions: [tag3, tag4]
+        navigateDown(wrapper);
+        keyAction[0](wrapper);
+        assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
+        // ensure focus is still on the input field
+        assert.equal(document.activeElement.nodeName, 'INPUT');
+      });
     });
-
-    it('adds a tag when the <input> value is a match for a suggestion and "Tab" is pressed', () => {
-      const wrapper = createComponent();
-      wrapper.find('input').instance().value = 'tag3';
-      typeInput(wrapper);
-      // suggestions: [tag3, tag4]
-      selectOptionViaTab(wrapper);
-      assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
-      // ensure focus is still on the input field
-      assert.equal(document.activeElement.nodeName, 'INPUT');
-    });
-
-    it('adds a tag from the suggestions list', () => {
-      const wrapper = createComponent();
-      wrapper.find('input').instance().value = 'non-empty';
-      typeInput(wrapper);
-      // suggestions: [tag3, tag4]
-      navigateDown(wrapper);
-      selectOptionViaEnter(wrapper);
-      assertAddTagsSuccess(wrapper, ['tag1', 'tag2', 'tag3']);
-      // ensure focus is still on the input field
-      assert.equal(document.activeElement.nodeName, 'INPUT');
-    });
-
     it('should not add a tag if the <input> is empty', () => {
       const wrapper = createComponent();
       wrapper.find('input').instance().value = '';
@@ -295,8 +287,9 @@ describe('TagEditor', function () {
       assertAddTagsFail();
     });
 
-    it('should not a tag when pressing "Tab" and input typed is not a suggestion', () => {
+    it('should not add a tag when pressing "Tab" and there are no suggestions', () => {
       const wrapper = createComponent();
+      fakeTagsService.filter.returns([]);
       wrapper.find('input').instance().value = 'tag33';
       typeInput(wrapper);
       selectOptionViaTab(wrapper);


### PR DESCRIPTION
- Tab will add the first suggestion in the autocomplete list if the list is not empty and `Tab` is pressed without any suggestion being selected.
- Tab can act as `Enter` or `,` and add a selected tag from a list when pressed.

-----

A bit of background with this PR. I initially made an attempt to fix this a few weeks ago, but it was incomplete and did not meet the expectations. This PR addresses those issues and cuts right to the meet of the problem and now makes tab mostly work the way the older angular component did (to the best of my knowledge). I originally suspected this was going to be more difficult to fix due to some refactoring with selected Index, but that was not the case.

**2 things change.**

1. if you use the keyboard navigation to select an item from the suggested list, pressing `Tab` will now work exactly like `Enter` or `,` to select an item from the list.

2. Tab can work as a autocomplete. If you type part of a suggestion, then `Tab` will automatically pick the first suggestion in the list and add that new tag.  So for example, if you typed `dinos` and `Tab` and `dinosaur` was the first suggestion, then that is added.

Note, that it should also fail to work when, for example, you type `dinosaurs` and that word is not a suggestion. In that case you have to press `Enter` or `,` to create the new tag/suggestion combo.

This does not address ticket  #1954 as that will likely require some linkage between the submit button and the tag editor perhaps by some sort of dirty state keep in the store. I think we can address that in a separate PR.

Fixes https://github.com/hypothesis/client/issues/1736