### PR TITLE
Refactor profile data access in the store

### DIFF
--- a/src/sidebar/components/help-panel.js
+++ b/src/sidebar/components/help-panel.js
@@ -53,7 +53,7 @@ function HelpPanel({ auth, session }) {
   // This reference is such that we know whether we should "dismiss" the tutorial
   // (permanently for this user) when it is closed.
   const hasAutoDisplayPreference = useStore(
-    store => !!store.getState().session.preferences.show_sidebar_tutorial
+    store => !!store.profile().preferences.show_sidebar_tutorial
   );
 
   // The "Tutorial" (getting started) subpanel is the default panel shown

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -69,13 +69,7 @@ function HypothesisAppController(
   // Reload the view when the user switches accounts
   this.onUserChange = profile => {
     self.auth = authStateFromProfile(profile);
-    if (
-      shouldAutoDisplayTutorial(
-        this.isSidebar,
-        store.getState().session,
-        settings
-      )
-    ) {
+    if (shouldAutoDisplayTutorial(this.isSidebar, store.profile(), settings)) {
       // Auto-open the tutorial (help) panel
       store.openSidebarPanel(uiConstants.PANEL_HELP);
     }

--- a/src/sidebar/components/test/help-panel-test.js
+++ b/src/sidebar/components/test/help-panel-test.js
@@ -25,10 +25,10 @@ describe('HelpPanel', function () {
     fakeAuth = {};
     fakeSessionService = { dismissSidebarTutorial: sinon.stub() };
     fakeStore = {
-      getState: sinon
-        .stub()
-        .returns({ session: { preferences: { show_sidebar_tutorial: true } } }),
       mainFrame: sinon.stub().returns(null),
+      profile: sinon.stub().returns({
+        preferences: { show_sidebar_tutorial: true },
+      }),
     };
     fakeVersionDataObject = {
       asEncodedURLString: sinon.stub().returns('fakeURLString'),
@@ -132,8 +132,8 @@ describe('HelpPanel', function () {
   context('dismissing the tutorial and clearing profile setting', () => {
     context('profile preference to auto-show tutorial is truthy', () => {
       beforeEach(() => {
-        fakeStore.getState.returns({
-          session: { preferences: { show_sidebar_tutorial: true } },
+        fakeStore.profile.returns({
+          preferences: { show_sidebar_tutorial: true },
         });
       });
 
@@ -172,8 +172,8 @@ describe('HelpPanel', function () {
 
     context('profile preference to auto-show tutorial is falsy', () => {
       beforeEach(() => {
-        fakeStore.getState.returns({
-          session: { preferences: { show_sidebar_tutorial: false } },
+        fakeStore.profile.returns({
+          preferences: { show_sidebar_tutorial: false },
         });
       });
 

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -65,13 +65,6 @@ describe('sidebar.components.hypothesis-app', function () {
       fakeStore = {
         tool: 'comment',
         clearSelectedAnnotations: sandbox.spy(),
-        getState: sinon.stub().returns({
-          session: {
-            preferences: {
-              show_sidebar_tutorial: false,
-            },
-          },
-        }),
         clearGroups: sinon.stub(),
         closeSidebarPanel: sinon.stub(),
         openSidebarPanel: sinon.stub(),
@@ -80,6 +73,12 @@ describe('sidebar.components.hypothesis-app', function () {
         discardAllDrafts: sandbox.stub(),
         unsavedAnnotations: sandbox.stub().returns([]),
         removeAnnotations: sandbox.stub(),
+
+        profile: sinon.stub().returns({
+          preferences: {
+            show_sidebar_tutorial: false,
+          },
+        }),
       };
 
       fakeAnalytics = {
@@ -305,7 +304,6 @@ describe('sidebar.components.hypothesis-app', function () {
   describe('#login()', function () {
     beforeEach(() => {
       fakeAuth.login = sinon.stub().returns(Promise.resolve());
-      fakeStore.getState.returns({ directLinkedGroupFetchFailed: false });
     });
 
     it('clears groups', () => {

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -199,7 +199,7 @@ describe('sidebar.components.sidebar-content', function () {
         userid: 'different-user@hypothes.is',
       });
 
-      store.updateSession(newProfile);
+      store.updateProfile(newProfile);
       $scope.$digest();
 
       assert.calledWith(
@@ -216,7 +216,7 @@ describe('sidebar.components.sidebar-content', function () {
         },
       });
 
-      store.updateSession(newProfile);
+      store.updateProfile(newProfile);
       $scope.$digest();
 
       assert.notCalled(fakeLoadAnnotationsService.load);

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -104,11 +104,10 @@ export default function session(
    * @return {Profile} The updated profile data
    */
   function update(model) {
-    const prevSession = store.getState().session;
+    const prevSession = store.profile();
     const userChanged = model.userid !== prevSession.userid;
 
-    // Update the session model used by the application
-    store.updateSession(model);
+    store.updateProfile(model);
 
     lastLoad = Promise.resolve(model);
     lastLoadTime = Date.now();
@@ -182,7 +181,7 @@ export default function session(
     // this service. In future, other services which access the session state
     // will do so directly from store or via selector functions
     get state() {
-      return store.getState().session;
+      return store.profile();
     },
 
     update,

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -75,7 +75,7 @@ export default function Streamer(store, auth, groups, session, settings) {
     } else if (message.type === 'session-change') {
       handleSessionChangeNotification(message);
     } else if (message.type === 'whoyouare') {
-      const userid = store.getState().session.userid;
+      const userid = store.profile().userid;
       if (message.userid !== userid) {
         console.warn(
           'WebSocket user ID "%s" does not match logged-in ID "%s"',

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -99,13 +99,11 @@ describe('Streamer', function () {
       addAnnotations: sinon.stub(),
       annotationExists: sinon.stub().returns(false),
       clearPendingUpdates: sinon.stub(),
-      getState: sinon.stub().returns({
-        session: {
-          userid: 'jim@hypothes.is',
-        },
-      }),
       pendingUpdates: sinon.stub().returns({}),
       pendingDeletions: sinon.stub().returns({}),
+      profile: sinon.stub().returns({
+        userid: 'jim@hypothes.is',
+      }),
       receiveRealTimeUpdates: sinon.stub(),
       removeAnnotations: sinon.stub(),
       route: sinon.stub().returns('sidebar'),
@@ -387,10 +385,8 @@ describe('Streamer', function () {
       },
     ].forEach(testCase => {
       it('does nothing if the userid matches the logged-in userid', () => {
-        fakeStore.getState.returns({
-          session: {
-            userid: testCase.userid,
-          },
+        fakeStore.profile.returns({
+          userid: testCase.userid,
         });
         createDefaultStreamer();
         return activeStreamer.connect().then(function () {
@@ -414,10 +410,8 @@ describe('Streamer', function () {
       },
     ].forEach(testCase => {
       it('logs a warning if the userid does not match the logged-in userid', () => {
-        fakeStore.getState.returns({
-          session: {
-            userid: testCase.userid,
-          },
+        fakeStore.profile.returns({
+          userid: testCase.userid,
         });
         createDefaultStreamer();
         return activeStreamer.connect().then(function () {

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -1,25 +1,27 @@
 import * as util from '../util';
 
 function init() {
-  /**
-   * Profile/session information for the active user.
-   */
   return {
-    /** A map of features that are enabled for the current user. */
-    features: {},
-    /** A map of preference names and values. */
-    preferences: {},
     /**
-     * The authenticated user ID or null if the user is not logged in.
+     * Profile object fetched from the `/api/profile` endpoint.
      */
-    userid: null,
+    profile: {
+      /** A map of features that are enabled for the current user. */
+      features: {},
+      /** A map of preference names and values. */
+      preferences: {},
+      /**
+       * The authenticated user ID or null if the user is not logged in.
+       */
+      userid: null,
+    },
   };
 }
 
 const update = {
-  UPDATE_SESSION: function (state, action) {
+  UPDATE_PROFILE: function (state, action) {
     return {
-      ...action.session,
+      profile: { ...action.profile },
     };
   },
 };
@@ -27,12 +29,12 @@ const update = {
 const actions = util.actionTypes(update);
 
 /**
- * Update the session state.
+ * Update the profile information for the current user.
  */
-function updateSession(session) {
+function updateProfile(profile) {
   return {
-    type: actions.UPDATE_SESSION,
-    session: session,
+    type: actions.UPDATE_PROFILE,
+    profile,
   };
 }
 
@@ -42,18 +44,18 @@ function updateSession(session) {
  * @param {object} state - The application state
  */
 function isLoggedIn(state) {
-  return state.session.userid !== null;
+  return state.session.profile.userid !== null;
 }
 
 /**
- * Return true if a given feature flag is enabled.
+ * Return true if a given feature flag is enabled for the current user.
  *
  * @param {object} state - The application state
  * @param {string} feature - The name of the feature flag. This matches the
  *        name of the feature flag as declared in the Hypothesis service.
  */
 function isFeatureEnabled(state, feature) {
-  return !!state.session.features[feature];
+  return !!state.session.profile.features[feature];
 }
 
 /**
@@ -62,7 +64,7 @@ function isFeatureEnabled(state, feature) {
  * Returns the current user's profile fetched from the `/api/profile` endpoint.
  */
 function profile(state) {
-  return state.session;
+  return state.session.profile;
 }
 
 export default {
@@ -71,7 +73,7 @@ export default {
   update,
 
   actions: {
-    updateSession,
+    updateProfile,
   },
 
   selectors: {

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -229,7 +229,7 @@ describe('sidebar/store/modules/groups', () => {
     ].forEach(
       ({ description, isLoggedIn, allGroups, expectedFeaturedGroups }) => {
         it(description, () => {
-          store.updateSession({ userid: isLoggedIn ? '1234' : null });
+          store.updateProfile({ userid: isLoggedIn ? '1234' : null });
           store.loadGroups(allGroups);
           const featuredGroups = getListAssertNoDupes(store, 'featuredGroups');
           assert.deepEqual(featuredGroups, expectedFeaturedGroups);
@@ -269,7 +269,7 @@ describe('sidebar/store/modules/groups', () => {
       },
     ].forEach(({ description, isLoggedIn, allGroups, expectedMyGroups }) => {
       it(description, () => {
-        store.updateSession({ userid: isLoggedIn ? '1234' : null });
+        store.updateProfile({ userid: isLoggedIn ? '1234' : null });
         store.loadGroups(allGroups);
 
         const myGroups = getListAssertNoDupes(store, 'myGroups');
@@ -301,7 +301,7 @@ describe('sidebar/store/modules/groups', () => {
       },
     ].forEach(({ description, isLoggedIn, allGroups }) => {
       it(description, () => {
-        store.updateSession({ userid: isLoggedIn ? '1234' : null });
+        store.updateProfile({ userid: isLoggedIn ? '1234' : null });
         store.loadGroups(allGroups);
 
         const currentlyViewing = getListAssertNoDupes(

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -1,8 +1,6 @@
 import createStore from '../../create-store';
 import session from '../session';
 
-const { init } = session;
-
 describe('sidebar/store/modules/session', function () {
   let store;
 
@@ -10,11 +8,11 @@ describe('sidebar/store/modules/session', function () {
     store = createStore([session]);
   });
 
-  describe('#updateSession', function () {
-    it('updates the session state', function () {
-      const newSession = Object.assign(init(), { userid: 'john' });
-      store.updateSession({ userid: 'john' });
-      assert.deepEqual(store.getState().session, newSession);
+  describe('#updateProfile', function () {
+    it('updates the profile data', function () {
+      const newProfile = Object.assign({ userid: 'john' });
+      store.updateProfile({ userid: 'john' });
+      assert.deepEqual(store.profile(), newProfile);
     });
   });
 
@@ -24,7 +22,7 @@ describe('sidebar/store/modules/session', function () {
       { userid: null, expectedIsLoggedIn: false },
     ].forEach(({ userid, expectedIsLoggedIn }) => {
       it('returns whether the user is logged in', () => {
-        store.updateSession({ userid: userid });
+        store.updateProfile({ userid: userid });
         assert.equal(store.isLoggedIn(), expectedIsLoggedIn);
       });
     });
@@ -32,11 +30,9 @@ describe('sidebar/store/modules/session', function () {
 
   describe('#profile', () => {
     it("returns the user's profile", () => {
-      store.updateSession({ userid: 'john' });
+      store.updateProfile({ userid: 'john' });
       assert.deepEqual(store.profile(), {
         userid: 'john',
-        features: {},
-        preferences: {},
       });
     });
   });

--- a/src/sidebar/util/session.js
+++ b/src/sidebar/util/session.js
@@ -29,10 +29,10 @@ export function shouldShowSidebarTutorial(sessionState) {
  * @param {Object} settings - app configuration/settings
  * @return {boolean} - Tutorial panel should be displayed automatically
  */
-export function shouldAutoDisplayTutorial(isSidebar, sessionState, settings) {
+export function shouldAutoDisplayTutorial(isSidebar, profile, settings) {
   const shouldShowBasedOnProfile =
-    typeof sessionState.preferences === 'object' &&
-    !!sessionState.preferences.show_sidebar_tutorial;
+    typeof profile.preferences === 'object' &&
+    !!profile.preferences.show_sidebar_tutorial;
   const service = serviceConfig(settings) || {};
   return (
     isSidebar && !service.onHelpRequestProvided && shouldShowBasedOnProfile


### PR DESCRIPTION
This PR refactors accessing and updating of profile data from
`/api/profile` in the store:

 - Always access the profile data fetched from `/api/profile` via the
   `store.profile()` selector rather than using
   `store.getState().session...`.

 - Move the profile data from the top level of `state.session` into a
   `profile` field (`state.session.profile`)

 - Rename `store.updateSession()` to `store.updateProfile()` for
   consistency with the `profile()` selector. The previous name is a
   holdover from when "session" meant "the user's cookie session".

These changes make this store module follow our agreed best practices to
avoid accessing state directly, rather than via a selector, and will also
make it easier to add additional session-related state in future which
is not fetched from `/api/profile`.

One subtle but intended change is that `state.session.profile` is now
always _replaced_ when the profile is udpated, rather than it being the
result of merging the previous and current state. The previous behavior
could introduce subtle bugs where state from a previous login remained
after switching the user.