### PR TITLE
Make local-ID ($tag) generation consistent

### DIFF
--- a/src/sidebar/services/annotations.js
+++ b/src/sidebar/services/annotations.js
@@ -9,7 +9,7 @@ import {
   privatePermissions,
   sharedPermissions,
 } from '../util/permissions';
-import { generateHexString } from '../util/random';
+import { generateLocalId } from '../util/random';
 import uiConstants from '../ui-constants';
 
 // @ngInject
@@ -48,7 +48,7 @@ export default function annotationsService(api, store) {
     // We need a unique local/app identifier for this new annotation such
     // that we might look it up later in the store. It won't have an ID yet,
     // as it has not been persisted to the service.
-    const $tag = generateHexString(8);
+    const $tag = generateLocalId();
 
     let permissions = defaultPermissions(userid, groupid, defaultPrivacy);
 

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -8,6 +8,7 @@ import { createSelector } from 'reselect';
 import * as metadata from '../../util/annotation-metadata';
 import * as arrayUtil from '../../util/array';
 import * as util from '../util';
+import { generateLocalId } from '../../util/random';
 
 import route from './route';
 
@@ -56,11 +57,9 @@ function findByTag(annotations, tag) {
  * from the service.
  *
  * @param {Object} annotation
- * @param {Number} tag - The `$tag` value that should be used for this
- *                       if it doesn't have a `$tag` already
  * @return {Object} - annotation with local (`$*`) fields set
  */
-function initializeAnnotation(annotation, tag) {
+function initializeAnnotation(annotation) {
   let orphan = annotation.$orphan;
 
   if (!annotation.id) {
@@ -71,7 +70,7 @@ function initializeAnnotation(annotation, tag) {
   return Object.assign({}, annotation, {
     // Flag indicating whether waiting for the annotation to anchor timed out.
     $anchorTimeout: false,
-    $tag: annotation.$tag || tag,
+    $tag: annotation.$tag || generateLocalId(),
     $orphan: orphan,
   });
 }
@@ -79,10 +78,6 @@ function initializeAnnotation(annotation, tag) {
 function init() {
   return {
     annotations: [],
-
-    // The local tag to assign to the next annotation that is loaded into the
-    // app
-    nextTag: 1,
   };
 }
 
@@ -94,7 +89,6 @@ const update = {
     const added = [];
     const unchanged = [];
     const updated = [];
-    let nextTag = state.nextTag;
 
     action.annotations.forEach(annot => {
       let existing;
@@ -116,8 +110,7 @@ const update = {
           updatedTags[existing.$tag] = true;
         }
       } else {
-        added.push(initializeAnnotation(annot, 't' + nextTag));
-        ++nextTag;
+        added.push(initializeAnnotation(annot));
       }
     });
 
@@ -129,7 +122,6 @@ const update = {
 
     return {
       annotations: added.concat(updated).concat(unchanged),
-      nextTag: nextTag,
     };
   },
 

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -51,11 +51,10 @@ describe('sidebar/store/modules/annotations', function () {
 
       store.addAnnotations([annotA, annotB]);
 
-      const tags = store.getState().annotations.annotations.map(function (a) {
-        return a.$tag;
+      store.getState().annotations.annotations.forEach(annot => {
+        assert.isString(annot.$tag);
+        assert.lengthOf(annot.$tag, 8);
       });
-
-      assert.deepEqual(tags, ['t1', 't2']);
     });
 
     it('updates annotations with matching IDs in the store', function () {

--- a/src/sidebar/util/random.js
+++ b/src/sidebar/util/random.js
@@ -15,3 +15,13 @@ export function generateHexString(len) {
   crypto.getRandomValues(bytes);
   return Array.from(bytes).map(byteToHex).join('');
 }
+
+/**
+ * Generate a random hex string of 8 characters for use as a client-side
+ * local identifier.
+ *
+ * @return {string}
+ */
+export function generateLocalId() {
+  return generateHexString(8);
+}


### PR DESCRIPTION
This PR is a small move toward making `annotation.$tag` values—local identifiers for annotation objects—more consistent. Yes, likely we should rename the property, too, but as a step in the overall direction, these changes remove the managed `nextTag` state property in the `annotations` store module and make all places in the app that generate local IDs use the same utility function.

Yeah, the utility function is just a wrapper, but makes itself a single source of truth for what local IDs look like for now.