### PR TITLE
Update Preact

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "npm-packlist": "^2.0.1",
     "postcss": "^7.0.13",
     "postcss-url": "^8.0.0",
-    "preact": "^10.0.4",
+    "preact": "^10.4.0",
     "prettier": "2.0.4",
     "puppeteer": "^2.0.0",
     "query-string": "^3.0.1",

--- a/src/sidebar/util/test/wrap-react-component-test.js
+++ b/src/sidebar/util/test/wrap-react-component-test.js
@@ -184,7 +184,7 @@ describe('wrapReactComponent', () => {
 
     assert.calledWithMatch(
       consoleError,
-      /Invalid Button `label` of type `number`/
+      /Invalid prop `label` of type `number`/
     );
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6133,10 +6133,10 @@ preact-render-to-string@^4.1.0:
   dependencies:
     pretty-format "^3.8.0"
 
-preact@^10.0.4:
-  version "10.3.4"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.3.4.tgz#e1542a4d3eba3e7a37f312a2c331231b97052024"
-  integrity sha512-wMgzs/RGYf0I1PZf8ZFJdyU/3kCcwepJyVYe+N9FGajyQWarMoPrPfrQajcG0psPj6ySYv2cSuLYFCihvV/Qrw==
+preact@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.4.0.tgz#90e10264a221690484a56344437a353ffac08600"
+  integrity sha512-34iqY2qPWKAmsi+tNNwYCstta93P+zF1f4DLtsOUPh32uYImNzJY7h7EymCva+6RoJL01v3W3phSRD8jE0sFLg==
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This fixes an issue where an uncaught error thrown inside an `act` callback would
stop any `useEffect` effects from running for the rest of the test
session, which was pretty confusing to debug.

See https://github.com/preactjs/preact/releases/tag/10.4.0