### PR TITLE
Improve readability of PDF highlights

### DIFF
--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -156,6 +156,12 @@ export function highlightRange(normedRange, cssClass = 'hypothesis-highlight') {
   // Find text nodes within the range to highlight.
   const textNodes = normedRange.textNodes();
 
+  // Check if this range refers to a placeholder for not-yet-rendered text in
+  // a PDF. These highlights should be invisible.
+  const isPlaceholder =
+    textNodes.length > 0 &&
+    closest(textNodes[0].parentNode, '.annotator-placeholder') !== null;
+
   // Group text nodes into spans of adjacent nodes. If a group of text nodes are
   // adjacent, we only need to create one highlight element for the group.
   let textNodeSpans = [];
@@ -191,16 +197,18 @@ export function highlightRange(normedRange, cssClass = 'hypothesis-highlight') {
     nodes[0].parentNode.replaceChild(highlightEl, nodes[0]);
     nodes.forEach(node => highlightEl.appendChild(node));
 
-    // For PDF highlights, create the highlight effect by using an SVG placed
-    // above the page's canvas rather than CSS `background-color` on the
-    // highlight element. This enables more control over blending of the
-    // highlight with the content below.
-    const svgHighlight = drawHighlightsAbovePdfCanvas(highlightEl);
-    if (svgHighlight) {
-      highlightEl.className += ' is-transparent';
+    if (!isPlaceholder) {
+      // For PDF highlights, create the highlight effect by using an SVG placed
+      // above the page's canvas rather than CSS `background-color` on the
+      // highlight element. This enables more control over blending of the
+      // highlight with the content below.
+      const svgHighlight = drawHighlightsAbovePdfCanvas(highlightEl);
+      if (svgHighlight) {
+        highlightEl.className += ' is-transparent';
 
-      // Associate SVG element with highlight for use by `removeHighlights`.
-      highlightEl.svgHighlight = svgHighlight;
+        // Associate SVG element with highlight for use by `removeHighlights`.
+        highlightEl.svgHighlight = svgHighlight;
+      }
     }
 
     highlights.push(highlightEl);

--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -9,7 +9,8 @@ function isCSSPropertySupported(property, value) {
 }
 
 /**
- * Polyfill for `element.closest(selector)`, only needed for IE 11.
+ * Implementation of `element.closest(selector)`. This is used to support browsers
+ * (IE 11) that don't have a native implementation.
  */
 function closest(element, selector) {
   while (element) {

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -1,3 +1,5 @@
+import { createElement, render } from 'preact';
+
 import Range from '../anchoring/range';
 
 import {
@@ -5,6 +7,60 @@ import {
   removeHighlights,
   getBoundingClientRect,
 } from '../highlighter';
+
+/**
+ * Preact component that renders a simplified version of the DOM structure
+ * of PDF.js pages.
+ *
+ * This is used to test PDF-specific highlighting behavior.
+ */
+function PdfPage() {
+  return (
+    <div className="page">
+      <div className="canvasWrapper">
+        {/* Canvas where PDF.js renders the visual PDF output. */}
+        <canvas />
+      </div>
+      {/* Transparent text layer created by PDF.js to enable text selection */}
+      <div className="textLayer">
+        {/* Text span created to correspond to some text rendered into the canvas.
+            Hypothesis creates `<hypothesis-highlight>` elements here. */}
+        <span className="testText">Text to highlight</span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Highlight the text in a fake PDF page.
+ *
+ * @param {HTMLElement} - HTML element into which `PdfPage` component has been
+ *   rendered
+ * @return {HTMLElement} - `<hypothesis-highlight>` element
+ */
+function highlightPdfRange(pdfPage) {
+  const textSpan = pdfPage.querySelector('.testText');
+  const r = new Range.NormalizedRange({
+    commonAncestor: textSpan,
+    start: textSpan.childNodes[0],
+    end: textSpan.childNodes[0],
+  });
+  return highlightRange(r);
+}
+
+/**
+ * Render a fake PDF.js page (`PdfPage`) and return its container.
+ *
+ * @return {HTMLElement}
+ */
+function createPdfPageWithHighlight() {
+  const container = document.createElement('div');
+  render(<PdfPage />, container);
+
+  highlightPdfRange(container);
+
+  return container;
+}
 
 describe('annotator/highlighter', () => {
   describe('highlightRange', () => {
@@ -106,6 +162,66 @@ describe('annotator/highlighter', () => {
 
       assert.equal(result.length, 0);
     });
+
+    context('when the highlighted text is part of a PDF.js text layer', () => {
+      it("removes the highlight element's background color", () => {
+        const page = createPdfPageWithHighlight();
+        const highlight = page.querySelector('hypothesis-highlight');
+        assert.isTrue(highlight.classList.contains('is-transparent'));
+      });
+
+      it('creates an SVG layer above the PDF canvas and draws a highlight in that', () => {
+        const page = createPdfPageWithHighlight();
+        const canvas = page.querySelector('canvas');
+        const svgLayer = page.querySelector('svg');
+
+        // Verify SVG layer was created.
+        assert.ok(svgLayer);
+        assert.equal(svgLayer.previousElementSibling, canvas);
+
+        // Check that an SVG graphic element was created for the highlight.
+        const highlight = page.querySelector('hypothesis-highlight');
+        const svgRect = page.querySelector('rect');
+        assert.ok(svgRect);
+        assert.equal(highlight.svgHighlight, svgRect);
+      });
+
+      it('re-uses the existing SVG layer for the page if present', () => {
+        // Create a PDF page with a single highlight.
+        const page = createPdfPageWithHighlight();
+
+        // Create a second highlight on the same page.
+        highlightPdfRange(page);
+
+        // There should be multiple highlights.
+        assert.equal(page.querySelectorAll('hypothesis-highlight').length, 2);
+
+        // ... but only one SVG layer.
+        assert.equal(page.querySelectorAll('svg').length, 1);
+        // ... with multiple <rect>s
+        assert.equal(
+          page.querySelector('svg').querySelectorAll('rect').length,
+          2
+        );
+      });
+
+      it('does not create an SVG highlight if the canvas is not found', () => {
+        const container = document.createElement('div');
+        render(<PdfPage />, container);
+
+        // Remove canvas. This might be missing if the DOM structure looks like
+        // PDF.js but isn't, or perhaps a future PDF.js update or fork changes
+        // the DOM structure significantly. In that case, we'll fall back to
+        // regular CSS-based highlighting.
+        container.querySelector('canvas').remove();
+
+        const [highlight] = highlightPdfRange(container);
+
+        assert.isFalse(highlight.classList.contains('is-transparent'));
+        assert.isNull(container.querySelector('rect'));
+        assert.notOk(highlight.svgHighlight);
+      });
+    });
   });
 
   describe('removeHighlights', () => {
@@ -130,6 +246,18 @@ describe('annotator/highlighter', () => {
       hl.appendChild(txt);
 
       removeHighlights([hl]);
+    });
+
+    it('removes any associated SVG elements external to the highlight element', () => {
+      const page = createPdfPageWithHighlight();
+      const highlight = page.querySelector('hypothesis-highlight');
+
+      assert.instanceOf(highlight.svgHighlight, SVGElement);
+      assert.equal(page.querySelectorAll('rect').length, 1);
+
+      removeHighlights([highlight]);
+
+      assert.equal(page.querySelectorAll('rect').length, 0);
     });
   });
 

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -34,12 +34,12 @@ function PdfPage() {
 /**
  * Highlight the text in a fake PDF page.
  *
- * @param {HTMLElement} - HTML element into which `PdfPage` component has been
- *   rendered
+ * @param {HTMLElement} pageContainer - HTML element into which `PdfPage`
+ *   component has been rendered
  * @return {HTMLElement} - `<hypothesis-highlight>` element
  */
-function highlightPdfRange(pdfPage) {
-  const textSpan = pdfPage.querySelector('.testText');
+function highlightPdfRange(pageContainer) {
+  const textSpan = pageContainer.querySelector('.testText');
   const r = new Range.NormalizedRange({
     commonAncestor: textSpan,
     start: textSpan.childNodes[0],

--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -17,11 +17,27 @@
   overflow: hidden;
 }
 
+// SVG highlights when the "Show Highlights" toggle is turned off.
+.hypothesis-svg-highlight {
+  fill: transparent;
+}
+
 // `hypothesis-highlights-always-on` is a class that is toggled on the root
 // of the annotated document when highlights are enabled/disabled.
 .hypothesis-highlights-always-on {
+  .hypothesis-svg-highlight {
+    fill: var.$highlight-color;
+  }
+
   .hypothesis-highlight {
     background-color: var.$highlight-color;
+
+    // For PDFs, we still create highlight elements to wrap the text but the
+    // highlight effect is created by another element.
+    &.is-transparent {
+      background-color: transparent;
+    }
+
     cursor: pointer;
 
     // Make highlights visible to screen readers.
@@ -41,6 +57,9 @@
     // Give a highlight inside a larger highlight a different color to stand out.
     & .hypothesis-highlight {
       background-color: var.$highlight-color-second;
+      &.is-transparent {
+        background-color: transparent;
+      }
 
       // In document viewers where the highlight is drawn _on top of_ the text
       // (eg. PDF.js) too many nested highlights can make the underlying text unreadable.

--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -27,6 +27,10 @@
 .hypothesis-highlights-always-on {
   .hypothesis-svg-highlight {
     fill: var.$highlight-color;
+
+    &.is-opaque {
+      fill: yellow;
+    }
   }
 
   .hypothesis-highlight {


### PR DESCRIPTION
Improve the readability of highlights on PDFs by creating the highlights
using SVG elements positioned just above the page's canvas instead of
using the CSS `background-color` property on the
`<hypothesis-highlight>` elements in the page's text layer.

Using SVG elements placed in the DOM like this allows us to control how
the highlight is blended with the content underneath using CSS
`mix-blend-mode`. Using the `multiply` blend mode [2] means that highlights
will darken the content below rather than making dark text in the
canvas appear lighter and muddier. Additionally this approach gives us
more control over the appearance of overlapping highlights. Note that
for the custom blending to work, it is important that the SVG is in the
same stacking context as the canvas [1]

We still need to keep the `<hypothesis-highlight>` elements in the text layer
for interactive functionality (eg. interacting with highlights using the
keyboard or pointer). The SVG highlight is associated with the
`<hypothesis-highlight>` via an `svgHighlight` property so that the SVG
can be removed when the highlight itself is removed.

An additional benefit of this approach is that it will allow us to bump up the contrast used
for highlights on web pages, as some users have reported they are too feint (eg. https://github.com/hypothesis/product-backlog/issues/1099),
without negatively affecting readability of highlighted text in PDFs.

[1] https://drafts.fxtf.org/compositing-1/#csscompositingrules_CSS
[2] https://drafts.fxtf.org/compositing-1/#valdef-blend-mode-multiply

Fixes https://github.com/hypothesis/client/issues/408
Fixes https://github.com/hypothesis/client/issues/1995

----

Example: https://docdrop.org/static/drop-pdf/The-Pedagogy-of-Listening_Retyped-WZ1Tv.pdf

(Note that the kerning issues in this PDF are an issue with either PDF.js or the PDF itself) 

**Master:**

<img width="1048" alt="pdf-highlighting-master" src="https://user-images.githubusercontent.com/2458/78908778-825db700-7a7a-11ea-987c-7f9a7085e3ce.png">

**This branch:**

<img width="1013" alt="pdf-highlighting-with-svgs" src="https://user-images.githubusercontent.com/2458/78908806-8c7fb580-7a7a-11ea-85a8-a52596e07e35.png">

----

- [x] Investigate highlight creation and scrolling performance compared with master
- [x] Test with more PDFs
- [x] Write tests
- [x] Test behavior in browsers that don't support `mix-blend-mode` (IE 11, Edge < 79) (Can still use SVG, but may need to use an `feBlend` or fall back to "normal" blending with lower opacity)
- [x] Make highlight visibility toggle button work with SVG-based highlights
