### PR TITLE
Various fixes for IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "enzyme": "^3.8.0",
     "enzyme-adapter-preact-pure": "^2.0.0",
     "escape-html": "^1.0.3",
-    "escape-string-regexp": "^3.0.0",
+    "escape-string-regexp": "^1.0.5",
     "eslint": "^6.0.1",
     "eslint-config-hypothesis": "^2.0.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",

--- a/src/shared/browser-compatibility-utils.js
+++ b/src/shared/browser-compatibility-utils.js
@@ -1,0 +1,22 @@
+/**
+ * Normalize a keyboard event key name.
+ *
+ * Several old browsers, such as IE11, use alternate key
+ * names for keyboard events. If any abnormal keys are used,
+ * this method returns the normalized name so our UI
+ * components don't require a special case.
+ *
+ * @param {string} key - The keyboard event `key` name
+ * @return {string} - Normalized `key` name
+ */
+export function normalizeKeyName(key) {
+  const mappings = {
+    Left: 'ArrowLeft',
+    Up: 'ArrowUp',
+    Down: 'ArrowDown',
+    Right: 'ArrowRight',
+    Spacebar: ' ',
+    Del: 'Delete',
+  };
+  return mappings[key] ? mappings[key] : key;
+}

--- a/src/shared/polyfills/index.js
+++ b/src/shared/polyfills/index.js
@@ -58,6 +58,10 @@ const needsPolyfill = {
   },
 
   es2018: () => {
+    if (!window.Promise) {
+      // IE11 does not have a Promise object.
+      return true;
+    }
     return !hasMethods(Promise.prototype, 'finally');
   },
 

--- a/src/shared/polyfills/test/index-test.js
+++ b/src/shared/polyfills/test/index-test.js
@@ -41,6 +41,10 @@ describe('shared/polyfills/index', () => {
         providesMethod: [Promise.prototype, 'finally'],
       },
       {
+        set: 'es2018',
+        providesMethod: [window, 'Promise'],
+      },
+      {
         set: 'string.prototype.normalize',
         providesMethod: [String.prototype, 'normalize'],
       },

--- a/src/shared/renderer-options.js
+++ b/src/shared/renderer-options.js
@@ -1,0 +1,27 @@
+import { options } from 'preact';
+
+import { isIE11 } from './user-agent';
+
+/**
+ * Force the dir="auto" attribute to be dir="" as this otherwise causes
+ * an exception in IE11 and breaks subsequent rendering.
+ *
+ * @param {Object} _options - Test seam
+ */
+export function setupIE11Fixes(_options = options) {
+  if (isIE11()) {
+    const prevHook = _options.vnode;
+    _options.vnode = vnode => {
+      if (typeof vnode.type === 'string') {
+        if ('dir' in vnode.props && vnode.props.dir === 'auto') {
+          // Re-assign `vnode.props.dir` if its value is "auto"
+          vnode.props.dir = '';
+        }
+      }
+      // Call previously defined hook if there was any
+      if (prevHook) {
+        prevHook(vnode);
+      }
+    };
+  }
+}

--- a/src/shared/test/browser-compatiblity-utils-test.js
+++ b/src/shared/test/browser-compatiblity-utils-test.js
@@ -1,0 +1,36 @@
+import { normalizeKeyName } from '../browser-compatibility-utils';
+
+describe('shared/browser-compatibility-utils', () => {
+  describe('normalizeKeyName', () => {
+    [
+      {
+        from: 'Left',
+        to: 'ArrowLeft',
+      },
+      {
+        from: 'Up',
+        to: 'ArrowUp',
+      },
+      {
+        from: 'Down',
+        to: 'ArrowDown',
+      },
+      {
+        from: 'Right',
+        to: 'ArrowRight',
+      },
+      {
+        from: 'Spacebar',
+        to: ' ',
+      },
+      {
+        from: 'Del',
+        to: 'Delete',
+      },
+    ].forEach(test => {
+      it(`changes the key value '${test.from}' to '${test.to}'`, () => {
+        assert.equal(normalizeKeyName(test.from), test.to);
+      });
+    });
+  });
+});

--- a/src/shared/test/renderer-options-test.js
+++ b/src/shared/test/renderer-options-test.js
@@ -1,0 +1,77 @@
+import { createElement } from 'preact';
+
+import { setupIE11Fixes } from '../renderer-options';
+import { $imports } from '../renderer-options';
+
+describe('shared/renderer-options', () => {
+  let fakeIsIE11;
+
+  beforeEach(() => {
+    fakeIsIE11 = sinon.stub().returns(true);
+    $imports.$mock({
+      './user-agent': {
+        isIE11: fakeIsIE11,
+      },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  describe('setupIE11Fixes', () => {
+    let fakeOptions;
+    let prevHook;
+
+    beforeEach(() => {
+      prevHook = sinon.stub();
+      fakeOptions = {
+        vnode: undefined,
+      };
+    });
+
+    context('when isIE11 is false', () => {
+      it('does not set a new vnode option if isIE11 is false', () => {
+        fakeIsIE11.returns(false);
+        setupIE11Fixes(fakeOptions);
+        assert.isNotOk(fakeOptions.vnode);
+      });
+    });
+
+    context('when isIE11 is true', () => {
+      it('sets a new vnode option', () => {
+        setupIE11Fixes(fakeOptions);
+        assert.isOk(fakeOptions.vnode);
+      });
+
+      it('does not override an existing option if one exists', () => {
+        fakeOptions.vnode = prevHook;
+        setupIE11Fixes(fakeOptions);
+        fakeOptions.vnode({});
+        assert.called(prevHook);
+      });
+
+      it("alters the `dir` attribute when its equal to 'auto'", () => {
+        setupIE11Fixes(fakeOptions);
+        const vDiv = createElement('div', { dir: 'auto' }, 'text');
+        fakeOptions.vnode(vDiv);
+        assert.equal(vDiv.props.dir, '');
+      });
+
+      it('does not alter the `dir` attribute when vnode.type is not a string', () => {
+        setupIE11Fixes(fakeOptions);
+        const vDiv = createElement('div', { dir: 'auto' }, 'text');
+        vDiv.type = () => {}; // force it to be a function
+        fakeOptions.vnode(vDiv);
+        assert.equal(vDiv.props.dir, 'auto');
+      });
+
+      it("does not alter the `dir` attribute when its value is not 'auto'", () => {
+        setupIE11Fixes(fakeOptions);
+        const vDiv = createElement('function', { dir: 'ltr' }, 'text');
+        fakeOptions.vnode(vDiv);
+        assert.equal(vDiv.props.dir, 'ltr');
+      });
+    });
+  });
+});

--- a/src/shared/test/user-agent-test.js
+++ b/src/shared/test/user-agent-test.js
@@ -1,6 +1,6 @@
 import { isIE11, isMacOS } from '../user-agent';
 
-describe('sidebar/util/user-agent', () => {
+describe('shared/user-agent', () => {
   describe('isIE11', () => {
     it('returns true when the user agent is IE 11', () => {
       assert.isTrue(

--- a/src/shared/test/user-agent-test.js
+++ b/src/shared/test/user-agent-test.js
@@ -1,0 +1,37 @@
+import { isIE11, isMacOS } from '../user-agent';
+
+describe('sidebar/util/user-agent', () => {
+  describe('isIE11', () => {
+    it('returns true when the user agent is IE 11', () => {
+      assert.isTrue(
+        isIE11('Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko')
+      );
+    });
+
+    it('returns false when the user agent is not IE 11', () => {
+      assert.isFalse(
+        isIE11(
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.92 Safari/537.36 Edg/80.0.361.109'
+        )
+      );
+    });
+  });
+
+  describe('isMacOS', () => {
+    it('returns true when the user agent is a Mac', () => {
+      assert.isTrue(
+        isMacOS(
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.163 Safari/537.36'
+        )
+      );
+    });
+
+    it('returns false when the user agent is not a Mac', () => {
+      assert.isFalse(
+        isMacOS(
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.92 Safari/537.36 Edg/80.0.361.109'
+        )
+      );
+    });
+  });
+});

--- a/src/shared/user-agent.js
+++ b/src/shared/user-agent.js
@@ -1,0 +1,21 @@
+/**
+ * Helper methods to identify browser versions and os types
+ */
+
+/**
+ * Returns true when the browser is IE11.
+ *
+ * @param _userAgent {string} - Test seam
+ */
+export const isIE11 = (_userAgent = window.navigator.userAgent) => {
+  return _userAgent.indexOf('Trident/7.0') >= 0;
+};
+
+/**
+ * Returns true when the OS is Mac OS.
+ *
+ * @param _userAgent {string} - Test seam
+ */
+export const isMacOS = (_userAgent = window.navigator.userAgent) => {
+  return _userAgent.indexOf('Mac OS') >= 0;
+};

--- a/src/sidebar/components/markdown-editor.js
+++ b/src/sidebar/components/markdown-editor.js
@@ -9,6 +9,7 @@ import {
   toggleBlockStyle,
   toggleSpanStyle,
 } from '../markdown-commands';
+import { normalizeKeyName } from '../../shared/browser-compatibility-utils';
 import { isMacOS } from '../../shared/user-agent';
 
 import MarkdownView from './markdown-view';
@@ -212,9 +213,8 @@ function Toolbar({ isPreviewing, onCommand, onTogglePreview }) {
       lowerLimit = buttonIds.help;
     }
     let newFocusedElement = null;
-    switch (e.key) {
+    switch (normalizeKeyName(e.key)) {
       case 'ArrowLeft':
-      case 'Left': // IE11
         if (rovingElement <= lowerLimit) {
           newFocusedElement = upperLimit;
         } else {
@@ -222,7 +222,6 @@ function Toolbar({ isPreviewing, onCommand, onTogglePreview }) {
         }
         break;
       case 'ArrowRight':
-      case 'Right': // IE11
         if (rovingElement >= upperLimit) {
           newFocusedElement = lowerLimit;
         } else {

--- a/src/sidebar/components/markdown-editor.js
+++ b/src/sidebar/components/markdown-editor.js
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import { createElement, createRef } from 'preact';
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import {
@@ -9,6 +9,7 @@ import {
   toggleBlockStyle,
   toggleSpanStyle,
 } from '../markdown-commands';
+import { isMacOS } from '../../shared/user-agent';
 
 import MarkdownView from './markdown-view';
 import SvgIcon from '../../shared/components/svg-icon';
@@ -102,10 +103,10 @@ function ToolbarButton({
   tabIndex,
   title = '',
 }) {
+  const modifierKey = useMemo(() => (isMacOS() ? 'Cmd' : 'Ctrl'), []);
+
   let tooltip = title;
   if (shortcutKey) {
-    const modifierKey =
-      window.navigator.userAgent.indexOf('Mac OS') !== -1 ? 'Cmd' : 'Ctrl';
     tooltip += ` (${modifierKey}-${shortcutKey.toUpperCase()})`;
   }
 
@@ -213,6 +214,7 @@ function Toolbar({ isPreviewing, onCommand, onTogglePreview }) {
     let newFocusedElement = null;
     switch (e.key) {
       case 'ArrowLeft':
+      case 'Left': // IE11
         if (rovingElement <= lowerLimit) {
           newFocusedElement = upperLimit;
         } else {
@@ -220,6 +222,7 @@ function Toolbar({ isPreviewing, onCommand, onTogglePreview }) {
         }
         break;
       case 'ArrowRight':
+      case 'Right': // IE11
         if (rovingElement >= upperLimit) {
           newFocusedElement = lowerLimit;
         } else {
@@ -379,10 +382,10 @@ export default function MarkdownEditor({
   onEditText = () => {},
   text = '',
 }) {
-  /** Whether the preview mode is currently active. */
+  // Whether the preview mode is currently active.
   const [preview, setPreview] = useState(false);
 
-  /** The input element where the user inputs their comment. */
+  // The input element where the user inputs their comment.
   const input = useRef(null);
 
   useEffect(() => {

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -1,8 +1,9 @@
 import { createElement } from 'preact';
-import { useRef, useState } from 'preact/hooks';
+import { useMemo, useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import { withServices } from '../util/service-context';
+import { isIE11 } from '../../shared/user-agent';
 
 import AutocompleteList from './autocomplete-list';
 import SvgIcon from '../../shared/components/svg-icon';
@@ -33,6 +34,9 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
   useElementShouldClose(closeWrapperRef, suggestionsListOpen, () => {
     setSuggestionsListOpen(false);
   });
+
+  // Convenient boolean  for ie detection.
+  const ie11 = useMemo(() => isIE11(), []);
 
   /**
    * Helper function that returns a list of suggestions less any
@@ -121,7 +125,8 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
   const handleOnInput = e => {
     if (
       e.inputType === 'insertText' ||
-      e.inputType === 'deleteContentBackward'
+      e.inputType === 'deleteContentBackward' ||
+      ie11 // inputType is not defined in IE 11, so trigger on any input in this case.
     ) {
       updateSuggestions();
     }
@@ -175,10 +180,12 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
   const handleKeyDown = e => {
     switch (e.key) {
       case 'ArrowUp':
+      case 'Up': // IE11
         changeSelectedItem(-1);
         e.preventDefault();
         break;
       case 'ArrowDown':
+      case 'Down': // IE11
         changeSelectedItem(1);
         e.preventDefault();
         break;

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -6,6 +6,7 @@ import { withServices } from '../util/service-context';
 import { isIE11 } from '../../shared/user-agent';
 
 import AutocompleteList from './autocomplete-list';
+import { normalizeKeyName } from '../../shared/browser-compatibility-utils';
 import SvgIcon from '../../shared/components/svg-icon';
 import useElementShouldClose from './hooks/use-element-should-close';
 
@@ -35,7 +36,6 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
     setSuggestionsListOpen(false);
   });
 
-  // Convenient boolean  for ie detection.
   const ie11 = useMemo(() => isIE11(), []);
 
   /**
@@ -178,14 +178,12 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
    * found in the suggestions list
    */
   const handleKeyDown = e => {
-    switch (e.key) {
+    switch (normalizeKeyName(e.key)) {
       case 'ArrowUp':
-      case 'Up': // IE11
         changeSelectedItem(-1);
         e.preventDefault();
         break;
       case 'ArrowDown':
-      case 'Down': // IE11
         changeSelectedItem(1);
         e.preventDefault();
         break;

--- a/src/sidebar/components/test/markdown-editor-test.js
+++ b/src/sidebar/components/test/markdown-editor-test.js
@@ -360,24 +360,18 @@ describe('MarkdownEditor', () => {
     };
 
     context('when `isPreviewing` is false', () => {
-      ['ArrowLeft', 'Left'].forEach(event => {
-        // IE11 uses "Left"
-        it('changes focus circularly to the left', () => {
-          pressKey(event);
-          // preview is the last button
-          matchesFocusedText('Preview');
-          testRovingIndex();
-        });
+      it('changes focus circularly to the left', () => {
+        pressKey('ArrowLeft');
+        // preview is the last button
+        matchesFocusedText('Preview');
+        testRovingIndex();
       });
 
-      ['ArrowRight', 'Right'].forEach(event => {
-        // IE11 uses "Right"
-        it('changes focus circularly to the right', () => {
-          pressKey('ArrowLeft'); // move to the end node
-          pressKey(event); // move back to the start
-          matchesFocusedTitle('Bold');
-          testRovingIndex();
-        });
+      it('changes focus circularly to the right', () => {
+        pressKey('ArrowLeft'); // move to the end node
+        pressKey('ArrowRight'); // move back to the start
+        matchesFocusedTitle('Bold');
+        testRovingIndex();
       });
 
       it('changes focus to the last element when pressing `end`', () => {

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -1,6 +1,7 @@
 /* global process */
 
 import { jsonConfigsFrom } from '../shared/settings';
+import * as rendererOptions from '../shared/renderer-options';
 
 import {
   startServer as startRPCServer,
@@ -55,6 +56,9 @@ const isSidebar = !(
   window.location.pathname.startsWith('/stream') ||
   window.location.pathname.startsWith('/a/')
 );
+
+// Install prect renderer options for IE11 quirks
+rendererOptions.setupIE11Fixes();
 
 // @ngInject
 function configureToastr(toastrConfig) {

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -57,7 +57,7 @@ const isSidebar = !(
   window.location.pathname.startsWith('/a/')
 );
 
-// Install prect renderer options for IE11 quirks
+// Install Preact renderer options to work around IE11 quirks
 rendererOptions.setupIE11Fixes();
 
 // @ngInject

--- a/yarn.lock
+++ b/yarn.lock
@@ -3101,11 +3101,6 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.3, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escape-string-regexp@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-3.0.0.tgz#1dad9cc28aed682be0de197280f79911a5fccd61"
-  integrity sha512-11dXIUC3umvzEViLP117d0KN6LJzZxh5+9F4E/7WLAAw7GrHk8NpUR+g9iJi/pe9C0py4F8rs0hreyRCwlAuZg==
-
 eslint-config-hypothesis@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/eslint-config-hypothesis/-/eslint-config-hypothesis-2.3.0.tgz#846512b19f920597551162eef4003ca1e668c8f5"


### PR DESCRIPTION
- Add es2018 Polyfill check for Promise existence
- Add isIE11() and isMacOS() helper methods
- Fix tag-editor to allow for IE11 specific arrow key events
- Fix markdown-editor to allow for IE11 specific arrow key events
- Add conditional `dir` attribute when IE is detected


There is still one console error remaining and a few self-closing tag warnings, but the sidebar does appear to be working again


![Image4](https://user-images.githubusercontent.com/3939074/79016809-b7bedf00-7b24-11ea-919a-cd11d7d143e2.png)
