### PR TITLE
Fix single annotation page

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -274,6 +274,7 @@ function startAngularApp(config) {
     // Register services, the store and utilities with Angular, so that
     // Angular components can use them.
     .service('analytics', () => container.get('analytics'))
+    .service('api', () => container.get('api'))
     .service('auth', () => container.get('auth'))
     .service('bridge', () => container.get('bridge'))
     .service('features', () => container.get('features'))


### PR DESCRIPTION
4d210869005684f5b7a20ea86a95a8cc4fd9c71e removed registration of the
`api` service from Angular, but the component for the single annotation
page still needs it.

Fixes https://github.com/hypothesis/support/issues/102