### PR TITLE
WIP: Migrate `ThreadList` component

### DIFF
--- a/src/sidebar/components/annotation-quote.js
+++ b/src/sidebar/components/annotation-quote.js
@@ -11,7 +11,7 @@ import Excerpt from './excerpt';
 /**
  * Display the selected text from the document associated with an annotation.
  */
-function AnnotationQuote({ annotation, settings = {} }) {
+function AnnotationQuote({ annotation, isFocused, settings = {} }) {
   // The language for the quote may be different than the client's UI (set by
   // `<html lang="...">`).
   //
@@ -24,10 +24,10 @@ function AnnotationQuote({ annotation, settings = {} }) {
 
   return (
     <section
-      className={classnames(
-        'annotation-quote',
-        isOrphan(annotation) && 'is-orphan'
-      )}
+      className={classnames('annotation-quote', {
+        'is-orphan': isOrphan(annotation),
+        'is-focused': isFocused,
+      })}
     >
       <Excerpt
         collapsedHeight={35}
@@ -49,7 +49,8 @@ function AnnotationQuote({ annotation, settings = {} }) {
 
 AnnotationQuote.propTypes = {
   annotation: propTypes.object.isRequired,
-
+  /** Is this annotation currently focused? */
+  isFocused: propTypes.bool,
   // Used for theming.
   settings: propTypes.object,
 };

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -27,6 +27,9 @@ function Annotation({
   toastMessenger,
 }) {
   const createDraft = useStore(store => store.createDraft);
+  const isFocused = useStore(store =>
+    store.isAnnotationFocused(annotation.$tag)
+  );
   const setCollapsed = useStore(store => store.setCollapsed);
 
   // An annotation will have a draft if it is being edited
@@ -90,6 +93,7 @@ function Annotation({
       className={classnames('annotation', {
         'annotation--reply': isReply(annotation),
         'is-collapsed': threadIsCollapsed,
+        'is-focused': isFocused,
       })}
       onKeyDown={onKeyDown}
     >
@@ -101,7 +105,9 @@ function Annotation({
         threadIsCollapsed={threadIsCollapsed}
       />
 
-      {hasQuote && <AnnotationQuote annotation={annotation} />}
+      {hasQuote && (
+        <AnnotationQuote annotation={annotation} isFocused={isFocused} />
+      )}
 
       {!isCollapsedReply && (
         <AnnotationBody

--- a/src/sidebar/components/thread-card.js
+++ b/src/sidebar/components/thread-card.js
@@ -1,0 +1,65 @@
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import { useCallback, useMemo } from 'preact/hooks';
+
+import debounce from 'lodash.debounce';
+import propTypes from 'prop-types';
+import useStore from '../store/use-store';
+import { withServices } from '../util/service-context';
+
+import Thread from './thread';
+
+/**
+ * A "top-level" `Thread`, rendered as a "card" in the sidebar. A `Thread`
+ * renders its own child `Thread`s within itself.
+ */
+function ThreadCard({ frameSync, settings, thread }) {
+  const threadTag = useMemo(() => {
+    return thread.annotation && thread.annotation.$tag;
+  }, [thread]);
+
+  const isFocused = useStore(store => store.isAnnotationFocused(threadTag));
+
+  const focusThreadAnnotation = useCallback(
+    debounce(tag => {
+      const focusTags = tag ? [tag] : [];
+      frameSync.focusAnnotations(focusTags);
+    }, 10),
+    [frameSync]
+  );
+
+  const scrollToAnnotation = useCallback(
+    tag => {
+      frameSync.scrollToAnnotation(tag);
+    },
+    [frameSync]
+  );
+
+  return (
+    /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+    <div
+      onClick={() => scrollToAnnotation(threadTag)}
+      onMouseEnter={() => focusThreadAnnotation(threadTag)}
+      onMouseLeave={() => focusThreadAnnotation(null)}
+      key={thread.id}
+      className={classnames('thread-card', {
+        'is-focused': isFocused,
+        'thread-card--theme-clean': settings && settings.theme === 'clean',
+      })}
+    >
+      <Thread thread={thread} showDocumentInfo={false} />
+    </div>
+  );
+}
+
+ThreadCard.propTypes = {
+  thread: propTypes.object.isRequired,
+
+  /** injected */
+  frameSync: propTypes.object.isRequired,
+  settings: propTypes.object,
+};
+
+ThreadCard.injectedProps = ['frameSync', 'settings'];
+
+export default withServices(ThreadCard);

--- a/src/sidebar/components/thread-list-omega.js
+++ b/src/sidebar/components/thread-list-omega.js
@@ -1,0 +1,240 @@
+import { createElement } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+import propTypes from 'prop-types';
+import debounce from 'lodash.debounce';
+import shallowEqual from 'shallowequal';
+
+import events from '../events';
+import useStore from '../store/use-store';
+import { isHighlight, isReply } from '../util/annotation-metadata';
+import { getElementHeightWithMargins } from '../util/dom';
+import { withServices } from '../util/service-context';
+
+import ThreadCard from './thread-card';
+
+// When we don't have a real measurement of a thread card's height (yet)
+// from the browser, use this as an approximate value, in pixels.
+const THREAD_DEFAULT_HEIGHT = 200;
+
+/**
+ * Calculate the set of `thread`s that should be rendered by estimating which
+ * of the threads are within or near the viewport.
+ *
+ * @param {Thread[]} threads - List of threads in the order they appear
+ * @param {Object} threadHeights - Map of thread ID to measured height
+ * @param {number} scrollPos - Vertical scroll offset of scrollable container
+ * @param {number} windowHeight -
+ *   Height of the visible area of the scrollable container.
+ */
+function calculateVisibleThreads(
+  threads,
+  threadHeights,
+  scrollPos,
+  windowHeight
+) {
+  // Space above the viewport in pixels which should be considered 'on-screen'
+  // when calculating the set of visible threads
+  const MARGIN_ABOVE = 800;
+  // Same as MARGIN_ABOVE but for the space below the viewport
+  const MARGIN_BELOW = 800;
+  // List of threads which are in or near the viewport and need to
+  // actually be rendered.
+  const visibleThreads = [];
+
+  const calculatedHeights = {
+    offscreenLower: 0,
+    offscreenUpper: 0,
+    total: 0,
+  };
+
+  const threadIsAboveViewport = (threadHeight, heights) =>
+    heights.total + threadHeight < scrollPos - MARGIN_ABOVE;
+  const threadIsVisible = (threadHeight, heights) =>
+    heights.total < scrollPos + windowHeight + MARGIN_BELOW;
+
+  threads.forEach(thread => {
+    const threadHeight = threadHeights[thread.id] || THREAD_DEFAULT_HEIGHT;
+    if (threadIsAboveViewport(threadHeight, calculatedHeights)) {
+      calculatedHeights.offscreenUpper += threadHeight;
+    } else if (threadIsVisible(threadHeight, calculatedHeights)) {
+      visibleThreads.push(thread);
+    } else {
+      // thread is below visible viewport
+      calculatedHeights.offscreenLower += threadHeight;
+    }
+    calculatedHeights.total += threadHeight;
+  });
+
+  return {
+    visibleThreads,
+    offscreenUpperHeight: calculatedHeights.offscreenUpper,
+    offscreenLowerHeight: calculatedHeights.offscreenLower,
+  };
+}
+
+function getScrollContainer() {
+  return document.querySelector('.js-thread-list-scroll-root');
+}
+
+/**
+ * Render a list of threads, but only render those that are in or near the
+ * current browser viewport.
+ */
+function ThreadListOmega({ thread, $rootScope }) {
+  const clearSelection = useStore(store => store.clearSelection);
+  // Height of the scrollable container. For the moment, this is the same as
+  // the window height.
+  const [windowHeight, setWindowHeight] = useState(window.innerHeight);
+
+  // Scroll offset of scroll container. This is updated after the scroll
+  // container is scrolled, with debouncing to limit update frequency.
+  const [scrollPosition, setScrollPosition] = useState(
+    getScrollContainer().scrollTop
+  );
+
+  // Map of thread ID to measured height of thread.
+  const [threadHeights, setThreadHeights] = useState({});
+
+  // ID of thread to scroll to after the next render. If the thread is not
+  // present, the value persists until it can be "consumed".
+  const [scrollToId, setScrollToId] = useState(null);
+
+  const topLevelThreads = thread.children;
+  const topLevelThreadIds = topLevelThreads.map(t => t.id);
+
+  const {
+    offscreenLowerHeight,
+    offscreenUpperHeight,
+    visibleThreads,
+  } = calculateVisibleThreads(
+    topLevelThreads,
+    threadHeights,
+    scrollPosition,
+    windowHeight
+  );
+
+  // Listen for when a new annotation is created in the application, and trigger
+  // a scroll to that annotation's thread card (unless highlight or reply)
+  useEffect(() => {
+    const removeListener = $rootScope.$on(
+      events.BEFORE_ANNOTATION_CREATED,
+      (event, annotation) => {
+        if (!isHighlight(annotation) && !isReply(annotation)) {
+          clearSelection();
+          setScrollToId(annotation.$tag);
+        }
+      }
+    );
+    return removeListener;
+  }, [$rootScope, clearSelection]);
+
+  // Effect to scroll a particular thread into view. This is mainly used to
+  // scroll a newly created annotation into view (as triggered by the
+  // listener for `BEFORE_ANNOTATION_CREATED`)
+  useEffect(() => {
+    if (!scrollToId) {
+      return;
+    }
+
+    const threadIndex = topLevelThreads.findIndex(t => t.id === scrollToId);
+    if (threadIndex === -1) {
+      // Thread is not currently present.
+      //
+      // When `scrollToId` is set as a result of a `BEFORE_ANNOTATION_CREATED`
+      // event, the annotation is not always present in the _next_ render after
+      // that event is received, but in another render after that. Therefore
+      // we wait until the annotation appears before "consuming" the scroll-to-id.
+      return;
+    }
+
+    // Clear `scrollToId` so we don't scroll again after the next render.
+    setScrollToId(null);
+
+    const getThreadHeight = thread =>
+      threadHeights[thread.id] || THREAD_DEFAULT_HEIGHT;
+
+    const yOffset = topLevelThreads
+      .slice(0, threadIndex)
+      .reduce((total, thread) => total + getThreadHeight(thread), 0);
+
+    const scrollContainer = getScrollContainer();
+    scrollContainer.scrollTop = yOffset;
+  }, [scrollToId, topLevelThreads, threadHeights]);
+
+  // Attach listeners such that Whenever the scroll container is scrolled or the
+  // window resized, a recalculation of visible threads is triggered
+  useEffect(() => {
+    const scrollContainer = getScrollContainer();
+
+    const updateScrollPosition = debounce(
+      () => {
+        setWindowHeight(window.innerHeight);
+        setScrollPosition(scrollContainer.scrollTop);
+      },
+      10,
+      { maxWait: 100 }
+    );
+
+    scrollContainer.addEventListener('scroll', updateScrollPosition);
+    window.addEventListener('resize', updateScrollPosition);
+
+    return () => {
+      scrollContainer.removeEventListener('scroll', updateScrollPosition);
+      window.removeEventListener('resize', updateScrollPosition);
+    };
+  }, []);
+
+  // When the set of top-level threads changes, recalculate the real rendered
+  // heights of thread cards and update `threadHeights` state if there are changes.
+  useEffect(() => {
+    let newHeights = {};
+
+    for (let id of topLevelThreadIds) {
+      const threadElement = document.getElementById(id);
+      if (!threadElement) {
+        // Thread is currently off screen.
+        continue;
+      }
+      const height = getElementHeightWithMargins(threadElement);
+      if (height !== null) {
+        newHeights[id] = height;
+      }
+    }
+
+    // Functional update of `threadHeights` state: `heights` is previous state
+    setThreadHeights(heights => {
+      // Merge existing and new heights.
+      newHeights = Object.assign({}, heights, newHeights);
+
+      // Skip update if no heights actually changed.
+      if (shallowEqual(heights, newHeights)) {
+        return heights;
+      }
+      return newHeights;
+    });
+  }, [topLevelThreadIds]);
+
+  return (
+    <section>
+      <div style={{ height: offscreenUpperHeight }} />
+      {visibleThreads.map(child => (
+        <div id={child.id} key={child.id}>
+          <ThreadCard thread={child} />
+        </div>
+      ))}
+      <div style={{ height: offscreenLowerHeight }} />
+    </section>
+  );
+}
+
+ThreadListOmega.propTypes = {
+  /** Should annotations render extra document metadata? */
+  thread: propTypes.object.isRequired,
+
+  /** injected */
+  $rootScope: propTypes.object.isRequired,
+};
+
+ThreadListOmega.injectedProps = ['$rootScope', 'settings'];
+
+export default withServices(ThreadListOmega);

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -136,6 +136,7 @@ import hypothesisApp from './components/hypothesis-app';
 import sidebarContent from './components/sidebar-content';
 import streamContent from './components/stream-content';
 import threadList from './components/thread-list';
+import threadListOmega from './components/thread-list-omega';
 
 // Services.
 
@@ -268,6 +269,7 @@ function startAngularApp(config) {
     .component('svgIcon', wrapComponent(SvgIcon))
     .component('thread', wrapComponent(Thread))
     .component('threadList', threadList)
+    .component('threadListOmega', wrapComponent(threadListOmega))
     .component('toastMessages', wrapComponent(ToastMessages))
     .component('topBar', wrapComponent(TopBar))
 

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -252,6 +252,7 @@ export default function FrameSync($rootScope, $window, store, bridge) {
    * @param {string[]} tags
    */
   this.focusAnnotations = function (tags) {
+    store.focusAnnotations(tags);
     bridge.call('focusAnnotations', tags);
   };
 

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -92,8 +92,8 @@ const setTab = (selectedTab, newTab) => {
 
 function init(settings) {
   return {
-    // Contains a map of annotation tag:true pairs.
-    focusedAnnotationMap: null,
+    // An array of annotation `$tag`s representing annotations that are focused
+    focusedAnnotations: [],
 
     // Contains a map of annotation id:true pairs.
     selectedAnnotationMap: initialSelection(settings),
@@ -153,7 +153,7 @@ const update = {
   },
 
   FOCUS_ANNOTATIONS: function (state, action) {
-    return { focusedAnnotationMap: action.focused };
+    return { focusedAnnotations: [...action.focusedTags] };
   },
 
   SET_FOCUS_MODE_FOCUSED: function (state, action) {
@@ -318,7 +318,7 @@ function setForceVisible(id, visible) {
 function focusAnnotations(tags) {
   return {
     type: actions.FOCUS_ANNOTATIONS,
-    focused: freeze(toSet(tags)),
+    focusedTags: tags,
   };
 }
 
@@ -393,6 +393,13 @@ function setSortKey(key) {
     type: actions.SET_SORT_KEY,
     key: key,
   };
+}
+
+/** Is the annotation referenced by `$tag` currently focused? */
+function isAnnotationFocused(state, $tag) {
+  return (state.selection.focusedAnnotations || []).some(
+    focusedAnn => $tag && focusedAnn === $tag
+  );
 }
 
 /**
@@ -542,6 +549,7 @@ export default {
     focusModeHasUser,
     focusModeUserId,
     focusModeUserPrettyName,
+    isAnnotationFocused,
     isAnnotationSelected,
     getFirstSelectedAnnotationId,
     getSelectedAnnotationMap,

--- a/src/sidebar/templates/sidebar-content.html
+++ b/src/sidebar/templates/sidebar-content.html
@@ -34,14 +34,16 @@
 </search-status-bar>
 
 
-<thread-list
+<!-- <thread-list
   on-change-collapsed="vm.setCollapsed(id, collapsed)"
   on-focus="vm.focus(annotation)"
   on-select="vm.scrollTo(annotation)"
   show-document-info="false"
   ng-if="!vm.selectedGroupUnavailable()"
   thread="vm.rootThread()">
-</thread-list>
+</thread-list> -->
+
+<thread-list-omega thread="vm.rootThread()"></thread-list-omega>
 
 <logged-out-message ng-if="vm.shouldShowLoggedOutMessage()" on-login="vm.onLogin()">
 </logged-out-message>

--- a/src/sidebar/util/dom.js
+++ b/src/sidebar/util/dom.js
@@ -21,3 +21,29 @@ export function listen(element, events, listener, { useCapture = false } = {}) {
     );
   };
 }
+
+/**
+ * Obtain the pixel height of the element with id `elementId`, including
+ * top and bottom margins.
+ *
+ * @param {string} elementId - The DOM element's id attribute
+ * @return {number|null} - The element's height in pixels or `null` if no
+ *                         element with id `elementId` exists
+ */
+export function getElementHeightWithMargins(elementId) {
+  const threadElement = document.getElementById(elementId);
+  if (!threadElement) {
+    return null;
+  }
+  const style = window.getComputedStyle(threadElement);
+  // Get the height of the element inside the border-box, excluding
+  // top and bottom margins.
+  const elementHeight = threadElement.getBoundingClientRect().height;
+
+  // Get the bottom margin of the element. style.margin{Side} will return
+  // values of the form 'Npx', from which we extract 'N'.
+  const marginHeight =
+    parseFloat(style.marginTop) + parseFloat(style.marginBottom);
+
+  return elementHeight + marginHeight;
+}

--- a/src/styles/sidebar/components/annotation-quote.scss
+++ b/src/styles/sidebar/components/annotation-quote.scss
@@ -2,23 +2,27 @@
 
 .annotation-quote {
   margin: 1em 0;
-}
 
-.annotation-quote.is-orphan {
-  text-decoration: line-through;
-}
+  &.is-orphan {
+    text-decoration: line-through;
+  }
 
-.annotation-quote__quote {
-  @include var.font-normal;
+  &__quote {
+    @include var.font-normal;
 
-  border-left: 3px solid var.$grey-3;
-  color: var.$grey-5;
-  font-family: sans-serif;
-  font-size: 12px;
-  font-style: italic;
-  letter-spacing: 0.1px;
-  padding: 0 1em;
+    border-left: 3px solid var.$grey-3;
+    color: var.$grey-5;
+    font-family: sans-serif;
+    font-size: 12px;
+    font-style: italic;
+    letter-spacing: 0.1px;
+    padding: 0 1em;
 
-  // Prevent long URLs etc. in quote causing overflow
-  overflow-wrap: break-word;
+    // Prevent long URLs etc. in quote causing overflow
+    overflow-wrap: break-word;
+  }
+
+  &.is-focused &__quote {
+    border-left: var.$highlight 3px solid;
+  }
 }

--- a/src/styles/sidebar/components/thread-card.scss
+++ b/src/styles/sidebar/components/thread-card.scss
@@ -1,0 +1,26 @@
+@use "../../variables" as var;
+
+.thread-card {
+  margin-bottom: 1em;
+  padding: 1em;
+  border-radius: 2px;
+  box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  background-color: var.$white;
+
+  &.is-focused {
+    box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.15);
+  }
+
+  &--theme-clean {
+    // Give a little more space so that the border appears centered
+    // between cards
+    padding-bottom: 1.5em;
+    border-bottom: 1px solid var.$grey-2;
+    box-shadow: none;
+
+    &:hover {
+      box-shadow: none;
+    }
+  }
+}

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -62,6 +62,7 @@
 @use './components/tag-editor';
 @use './components/tag-list';
 @use './components/thread';
+@use './components/thread-card';
 @use './components/thread-list';
 @use './components/toast-messages';
 @use './components/tooltip';


### PR DESCRIPTION
I'd like to get eyes on this work one more time before I sew up final details and write tests, as there are some more structural changes that have happened as I have worked through migrating more of the `ThreadList` component's responsibilities.

* `ThreadListOmega` is settled down from the last set of proposed changes. I've done just a bit of cleanup and reorg.
* I've done work to reintroduce `focused` annotations back to the app—these are the "hovered" annotations from either side of the app, annotator or sidebar, that are then communicated as hovered to the other side of the app so that they can be visually noted. I've refactored the handling of this some in the `selection` module and made its usage more consistent. I've also updated some visual styling in a few affected components. 
* I've introduced a new component, `ThreadCard`. This felt natural, as state management for these top-level threads was starting to feel a little cumbersome inside of `ThreadListOmega`.

Next steps: I'm looking for a yea/nay on this structure, then I'll be able to clean up, write tests, and open a real PR to land this—this should be the last WIP step.