### PR TITLE
Refactor `forceVisible` in `selection` state

### DIFF
--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -88,7 +88,7 @@ export default function RootThread(
     // Get the currently loaded annotations and the set of inputs which
     // determines what is visible and build the visible thread structure
     return buildThread(state.annotations.annotations, {
-      forceVisible: truthyKeys(state.selection.forceVisible),
+      forceVisible: store.getForceVisibleAnnotations(),
       expanded: store.expandedThreads(),
       highlighted: state.selection.highlighted,
       selected: truthyKeys(store.getSelectedAnnotationMap() || {}),

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -47,7 +47,6 @@ describe('rootThread', function () {
         drafts: [],
         selection: {
           filterQuery: null,
-          forceVisible: {},
           highlighted: [],
           sortKey: 'Location',
           sortKeysAvailable: ['Location'],
@@ -62,6 +61,7 @@ describe('rootThread', function () {
       },
 
       expandedThreads: sinon.stub().returns({}),
+      getForceVisibleAnnotations: sinon.stub().returns([]),
       getSelectedAnnotationMap: sinon.stub().returns(null),
       subscribe: sinon.stub(),
       removeAnnotations: sinon.stub(),
@@ -155,7 +155,7 @@ describe('rootThread', function () {
     });
 
     it('passes the current force-visible set to buildThread()', function () {
-      fakeStore.state.selection.forceVisible = { id1: true, id2: true };
+      fakeStore.getForceVisibleAnnotations.returns(['id1', 'id2']);
       rootThread.thread(fakeStore.state);
       assert.calledWith(
         fakeBuildThread,

--- a/src/sidebar/services/threads.js
+++ b/src/sidebar/services/threads.js
@@ -9,7 +9,7 @@ export default function threadsService(store) {
     thread.children.forEach(child => {
       forceVisible(child);
     });
-    store.setForceVisible(thread.id, true);
+    store.setForceVisible(thread.id);
   }
 
   return {

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -106,7 +106,7 @@ function init(settings) {
 
     // Set of IDs of annotations that have been explicitly shown
     // by the user even if they do not match the current search filter
-    forceVisible: {},
+    forceVisible: [],
 
     // IDs of annotations that should be highlighted
     highlighted: [],
@@ -138,7 +138,7 @@ const update = {
     const tabSettings = setTab(state.selectedTab, selectedTab);
     return {
       filterQuery: null,
-      forceVisible: {},
+      forceVisible: [],
       selectedAnnotationMap: null,
       ...tabSettings,
     };
@@ -189,7 +189,7 @@ const update = {
   },
 
   SET_FORCE_VISIBLE: function (state, action) {
-    return { forceVisible: action.forceVisible };
+    return { forceVisible: state.forceVisible.concat(action.id) };
   },
 
   SET_EXPANDED: function (state, action) {
@@ -245,7 +245,7 @@ const update = {
   SET_FILTER_QUERY: function (state, action) {
     return {
       filterQuery: action.query,
-      forceVisible: {},
+      forceVisible: [],
       expanded: {},
     };
   },
@@ -291,22 +291,15 @@ function toggleSelectedAnnotations(ids) {
 }
 
 /**
- * Sets whether a given annotation should be visible, even if it does not
- * match the current search query.
+ * Forces an annotation thread to be visible, even if it does not
+ * match the current search query or filters.
  *
  * @param {string} id - Annotation ID
- * @param {boolean} visible
  */
-function setForceVisible(id, visible) {
-  // FIXME: This should be converted to a plain action and accessing the state
-  // should happen in the update() function
-  return function (dispatch, getState) {
-    const forceVisible = Object.assign({}, getState().selection.forceVisible);
-    forceVisible[id] = visible;
-    dispatch({
-      type: actions.SET_FORCE_VISIBLE,
-      forceVisible: forceVisible,
-    });
+function setForceVisible(id) {
+  return {
+    type: actions.SET_FORCE_VISIBLE,
+    id: id,
   };
 }
 
@@ -508,6 +501,10 @@ function focusModeUserPrettyName(state) {
   }
 }
 
+function getForceVisibleAnnotations(state) {
+  return state.selection.forceVisible;
+}
+
 function getSelectedAnnotationMap(state) {
   return state.selection.selectedAnnotationMap;
 }
@@ -544,6 +541,7 @@ export default {
     focusModeUserPrettyName,
     isAnnotationSelected,
     getFirstSelectedAnnotationId,
+    getForceVisibleAnnotations,
     getSelectedAnnotationMap,
   },
 };

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -29,9 +29,10 @@ describe('sidebar/store/modules/selection', () => {
   });
 
   describe('setForceVisible()', function () {
-    it('sets the visibility of the annotation', function () {
-      store.setForceVisible('id1', true);
-      assert.deepEqual(getSelectionState().forceVisible, { id1: true });
+    it('adds the passed id to the `forceVisble` array', function () {
+      store.setForceVisible('id1');
+      store.setForceVisible('id2');
+      assert.deepEqual(store.getForceVisibleAnnotations(), ['id1', 'id2']);
     });
   });
 
@@ -192,10 +193,10 @@ describe('sidebar/store/modules/selection', () => {
     });
 
     it('resets the force-visible and expanded sets', function () {
-      store.setForceVisible('123', true);
+      store.setForceVisible('123');
       store.setCollapsed('456', false);
       store.setFilterQuery('some-query');
-      assert.deepEqual(getSelectionState().forceVisible, {});
+      assert.deepEqual(store.getForceVisibleAnnotations(), []);
       assert.deepEqual(getSelectionState().expanded, {});
     });
   });
@@ -239,7 +240,7 @@ describe('sidebar/store/modules/selection', () => {
         displayName: 'Test User',
       });
 
-      assert.isEmpty(getSelectionState().forceVisible);
+      assert.isEmpty(store.getForceVisibleAnnotations());
       assert.isNull(store.filterQuery());
     });
   });


### PR DESCRIPTION
This is part of ongoing cleanup of the `selection` store module.

* Refactor `forceVisible` to an Array, as entries are always `true`
* Refactor action for setting force-visible annotation threads
* Add selector to avoid usage of `getState()`