### PR TITLE
Increase highlight opacity

### DIFF
--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -150,7 +150,7 @@ $zindex-tooltip: 20;
 // Other Variables
 // -------------------------
 $bucket-bar-width: 22px;
-$highlight-color: rgba(255, 255, 60, 0.3);
+$highlight-color: rgba(255, 255, 60, 0.4);
 $highlight-color-second: rgba(206, 206, 60, 0.4);
 $highlight-color-focus: rgba(156, 230, 255, 0.5);
 $top-bar-height: 40px;


### PR DESCRIPTION
Increase the opacity of highlights from 30% to 40% to improve the visibility of highlights, especially on very light/white backgrounds. Following https://github.com/hypothesis/client/pull/2017, we can do this without reducing contrast of highlighted text in PDFs.

Only the color of "first level" (non-nested) highlights was increased,
as nested highlights already had the higher level of contrast.

This PR is a modest adjustment intended to improve visibility for most users without highlights looking too harsh/vibrant. From experimenting with the various vision loss modes in Firefox and Chrome, I think to accommodate some users we will need to provide a user preference to increase contrast to much higher levels (say, 100% opacity) or change the color that is used. We might be able to do this automatically in future using the [`prefers-contrast` media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast).

---

**HTML (before):**

<img width="740" alt="Highlight 30% opacity HTML" src="https://user-images.githubusercontent.com/2458/79304786-ff10eb00-7ee9-11ea-9e78-2979e654f7ed.png">

**HTML (after):**

<img width="747" alt="Highlight 40% opacity HTML" src="https://user-images.githubusercontent.com/2458/79304796-046e3580-7eea-11ea-918e-88309bb812da.png">

**PDF (before):**

<img width="900" alt="Highlight 30% opacity" src="https://user-images.githubusercontent.com/2458/79304807-09cb8000-7eea-11ea-9eff-68cdc79f2402.png">

**PDF (after):**

<img width="874" alt="Highlight 40% opacity" src="https://user-images.githubusercontent.com/2458/79304821-1059f780-7eea-11ea-953f-f1396911200a.png">
