### PR TITLE
Add `watch` utility to streamline reacting to store changes

### DIFF
--- a/src/sidebar/components/stream-content.js
+++ b/src/sidebar/components/stream-content.js
@@ -1,3 +1,5 @@
+import { watch } from '../util/watch';
+
 // @ngInject
 function StreamContentController($scope, store, api, rootThread, searchFilter) {
   /** `offset` parameter for the next search API call. */
@@ -43,13 +45,8 @@ function StreamContentController($scope, store, api, rootThread, searchFilter) {
     fetch(20);
   }
 
-  let lastQuery = currentQuery();
-  const unsubscribe = store.subscribe(() => {
-    const query = currentQuery();
-    if (query !== lastQuery) {
-      lastQuery = query;
-      clearAndFetch();
-    }
+  const unsubscribe = watch(store.subscribe, currentQuery, () => {
+    clearAndFetch();
   });
   $scope.$on('$destroy', unsubscribe);
 

--- a/src/sidebar/services/persisted-defaults.js
+++ b/src/sidebar/services/persisted-defaults.js
@@ -1,3 +1,5 @@
+import { watch } from '../util/watch';
+
 /**
  * A service for reading and persisting convenient client-side defaults for
  * the (browser) user.
@@ -10,14 +12,11 @@ const DEFAULT_KEYS = {
 
 // @ngInject
 export default function persistedDefaults(localStorage, store) {
-  let lastDefaults;
-
   /**
    * Store subscribe callback for persisting changes to defaults. It will only
    * persist defaults that it "knows about" via `DEFAULT_KEYS`.
    */
-  function persistChangedDefaults() {
-    const latestDefaults = store.getDefaults();
+  function persistChangedDefaults(latestDefaults, lastDefaults) {
     for (let defaultKey in latestDefaults) {
       if (
         lastDefaults[defaultKey] !== latestDefaults[defaultKey] &&
@@ -29,7 +28,6 @@ export default function persistedDefaults(localStorage, store) {
         );
       }
     }
-    lastDefaults = latestDefaults;
   }
 
   return {
@@ -45,10 +43,9 @@ export default function persistedDefaults(localStorage, store) {
         const defaultValue = localStorage.getItem(DEFAULT_KEYS[defaultKey]);
         store.setDefault(defaultKey, defaultValue);
       });
-      lastDefaults = store.getDefaults();
 
       // Listen for changes to those defaults from the store and persist them
-      store.subscribe(persistChangedDefaults);
+      watch(store.subscribe, () => store.getDefaults(), persistChangedDefaults);
     },
   };
 }

--- a/src/sidebar/services/persisted-defaults.js
+++ b/src/sidebar/services/persisted-defaults.js
@@ -16,16 +16,13 @@ export default function persistedDefaults(localStorage, store) {
    * Store subscribe callback for persisting changes to defaults. It will only
    * persist defaults that it "knows about" via `DEFAULT_KEYS`.
    */
-  function persistChangedDefaults(latestDefaults, lastDefaults) {
-    for (let defaultKey in latestDefaults) {
+  function persistChangedDefaults(defaults, prevDefaults) {
+    for (let defaultKey in defaults) {
       if (
-        lastDefaults[defaultKey] !== latestDefaults[defaultKey] &&
+        prevDefaults[defaultKey] !== defaults[defaultKey] &&
         defaultKey in DEFAULT_KEYS
       ) {
-        localStorage.setItem(
-          DEFAULT_KEYS[defaultKey],
-          latestDefaults[defaultKey]
-        );
+        localStorage.setItem(DEFAULT_KEYS[defaultKey], defaults[defaultKey]);
       }
     }
   }

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -55,7 +55,7 @@ describe('sidebar/services/frame-sync', function () {
 
   beforeEach(function () {
     fakeStore = createFakeStore(
-      { annotations: [] },
+      { annotations: { annotations: [] } },
       {
         connectFrame: sinon.stub(),
         destroyFrame: sinon.stub(),

--- a/src/sidebar/util/test/watch-test.js
+++ b/src/sidebar/util/test/watch-test.js
@@ -4,9 +4,9 @@ import { watch } from '../watch';
 
 function counterReducer(state = { a: 0, b: 0 }, action) {
   switch (action.type) {
-    case 'increment-a':
+    case 'INCREMENT_A':
       return { ...state, a: state.a + 1 };
-    case 'increment-b':
+    case 'INCREMENT_B':
       return { ...state, b: state.b + 1 };
     default:
       return state;
@@ -28,10 +28,10 @@ describe('sidebar/util/watch', () => {
 
       watch(store.subscribe, () => store.getState().a, callback);
 
-      store.dispatch({ type: 'increment-a' });
+      store.dispatch({ type: 'INCREMENT_A' });
       assert.calledWith(callback, 1, 0);
 
-      store.dispatch({ type: 'increment-a' });
+      store.dispatch({ type: 'INCREMENT_A' });
       assert.calledWith(callback, 2, 1);
     });
 
@@ -40,7 +40,7 @@ describe('sidebar/util/watch', () => {
       const store = counterStore();
 
       watch(store.subscribe, () => store.getState().a, callback);
-      store.dispatch({ type: 'increment-b' });
+      store.dispatch({ type: 'INCREMENT_B' });
 
       assert.notCalled(callback);
     });
@@ -54,7 +54,7 @@ describe('sidebar/util/watch', () => {
         [() => store.getState().a, () => store.getState().b],
         callback
       );
-      store.dispatch({ type: 'increment-a' });
+      store.dispatch({ type: 'INCREMENT_A' });
 
       assert.calledWith(callback, [1, 0], [0, 0]);
     });
@@ -68,13 +68,13 @@ describe('sidebar/util/watch', () => {
         () => store.getState().a,
         callback
       );
-      store.dispatch({ type: 'increment-a' });
+      store.dispatch({ type: 'INCREMENT_A' });
 
       assert.calledWith(callback, 1, 0);
 
       callback.resetHistory();
       unsubscribe();
-      store.dispatch({ type: 'increment-a' });
+      store.dispatch({ type: 'INCREMENT_A' });
 
       assert.notCalled(callback);
     });

--- a/src/sidebar/util/test/watch-test.js
+++ b/src/sidebar/util/test/watch-test.js
@@ -1,0 +1,82 @@
+import { createStore } from 'redux';
+
+import { watch } from '../watch';
+
+function counterReducer(state = { a: 0, b: 0 }, action) {
+  switch (action.type) {
+    case 'increment-a':
+      return { ...state, a: state.a + 1 };
+    case 'increment-b':
+      return { ...state, b: state.b + 1 };
+    default:
+      return state;
+  }
+}
+
+describe('sidebar/util/watch', () => {
+  /**
+   * Create a Redux store as a data source for testing the `watch` function.
+   */
+  function counterStore() {
+    return createStore(counterReducer);
+  }
+
+  describe('watch', () => {
+    it('runs callback when computed value changes', () => {
+      const callback = sinon.stub();
+      const store = counterStore();
+
+      watch(store.subscribe, () => store.getState().a, callback);
+
+      store.dispatch({ type: 'increment-a' });
+      assert.calledWith(callback, 1, 0);
+
+      store.dispatch({ type: 'increment-a' });
+      assert.calledWith(callback, 2, 1);
+    });
+
+    it('does not run callback if computed value did not change', () => {
+      const callback = sinon.stub();
+      const store = counterStore();
+
+      watch(store.subscribe, () => store.getState().a, callback);
+      store.dispatch({ type: 'increment-b' });
+
+      assert.notCalled(callback);
+    });
+
+    it('supports multiple value functions', () => {
+      const callback = sinon.stub();
+      const store = counterStore();
+
+      watch(
+        store.subscribe,
+        [() => store.getState().a, () => store.getState().b],
+        callback
+      );
+      store.dispatch({ type: 'increment-a' });
+
+      assert.calledWith(callback, [1, 0], [0, 0]);
+    });
+
+    it('returns unsubscription function', () => {
+      const callback = sinon.stub();
+      const store = counterStore();
+
+      const unsubscribe = watch(
+        store.subscribe,
+        () => store.getState().a,
+        callback
+      );
+      store.dispatch({ type: 'increment-a' });
+
+      assert.calledWith(callback, 1, 0);
+
+      callback.resetHistory();
+      unsubscribe();
+      store.dispatch({ type: 'increment-a' });
+
+      assert.notCalled(callback);
+    });
+  });
+});

--- a/src/sidebar/util/watch.js
+++ b/src/sidebar/util/watch.js
@@ -51,13 +51,20 @@ import shallowEqual from 'shallowequal';
  *   function that removes the subscription.
  */
 export function watch(subscribe, watchFns, callback) {
+  const isArray = Array.isArray(watchFns);
+
   const getWatchedValues = () =>
-    Array.isArray(watchFns) ? watchFns.map(fn => fn()) : watchFns();
+    isArray ? watchFns.map(fn => fn()) : watchFns();
 
   let prevValues = getWatchedValues();
   const unsubscribe = subscribe(() => {
     const values = getWatchedValues();
-    if (shallowEqual(values, prevValues)) {
+
+    const equal = isArray
+      ? shallowEqual(values, prevValues)
+      : values === prevValues;
+
+    if (equal) {
       return;
     }
 

--- a/src/sidebar/util/watch.js
+++ b/src/sidebar/util/watch.js
@@ -1,0 +1,73 @@
+import shallowEqual from 'shallowequal';
+
+/**
+ * Watch for changes of computed values.
+ *
+ * This utility is a shorthand for a common pattern for reacting to changes in
+ * some data source:
+ *
+ * ```
+ * let prevValue = getCurrentValue();
+ * subscribe(() => {
+ *   const newValue = getCurrentValue();
+ *   if (prevValue !== newValue) {
+ *     // Respond to change of value.
+ *     // ...
+ *
+ *     // Update previous value.
+ *     prevValue = new value;
+ *   }
+ * });
+ * ```
+ *
+ * Where `getCurrentValue` calculates the value of interest and
+ * `subscribe` registers a callback to receive change notifications for
+ * whatever data source (eg. a Redux store) is used by `getCurrentValue`.
+ *
+ * With the `watch` utility this becomes:
+ *
+ * ```
+ * watch(subscribe, getCurrentValue, (newValue, prevValue) => {
+ *   // Respond to change of value
+ * });
+ * ```
+ *
+ * `watch` can watch a single value, if the second argument is a function,
+ * or many if the second argument is an array of functions. In the latter case
+ * the callback will be invoked whenever _any_ of the watched values changes.
+ *
+ * Values are compared using strict equality (`===`).
+ *
+ * @param {(callback: Function) => Function} subscribe - Function used to
+ *   subscribe to notifications of _potential_ changes in the watched values.
+ * @param {Function|Array<Function>} watchFns - A function or array of functions
+ *   which return the current watched values
+ * @param {(current: any, previous: any) => any} callback -
+ *   A callback that is invoked when the watched values changed. It is passed
+ *   the current and previous values respectively. If `watchFns` is an array,
+ *   the `current` and `previous` arguments will be arrays of current and
+ *   previous values.
+ * @return {Function} - Return value of `subscribe`. Typically this is a
+ *   function that removes the subscription.
+ */
+export function watch(subscribe, watchFns, callback) {
+  const getWatchedValues = () =>
+    Array.isArray(watchFns) ? watchFns.map(fn => fn()) : watchFns();
+
+  let prevValues = getWatchedValues();
+  const unsubscribe = subscribe(() => {
+    const values = getWatchedValues();
+    if (shallowEqual(values, prevValues)) {
+      return;
+    }
+
+    // Save and then update `prevValues` before invoking `callback` in case
+    // `callback` triggers another update.
+    const savedPrevValues = prevValues;
+    prevValues = values;
+
+    callback(values, savedPrevValues);
+  });
+
+  return unsubscribe;
+}


### PR DESCRIPTION
There is a common pattern in services for responding to changes in the store:

```js
let prevValue = store.getSomeValue();
store.subscribe(() => {
  const newValue = store.getSomeValue();
  if (prevValue !== newValue) {
    // Respond to change of value.
    // ...
                                      
    // Update previous value.
    prevValue = new value;
  }
});
```

I anticipate that we will want to replace several of the current Angular events (eg. `FRAME_CONNECTED`, `USER_CHANGED`) with some variation of this pattern.

This PR adds a utility function (in `src/sidebar/util/watch`) to simplify implementing that pattern and modifies several existing services to use it. The existing service tests did not require any changes.

With the utility, the pattern above looks like:

```js
import { watch } from '../util/watch';

watch(store.subscribe, () => store.getSomeValue(), (currentValue, prevValue) => {
    // Respond to change
});
```