### PR TITLE
Remove `FRAME_CONNECTED` event

### DIFF
--- a/src/sidebar/events.js
+++ b/src/sidebar/events.js
@@ -3,9 +3,6 @@
  * on $rootScope
  */
 export default {
-  // Internal state changes
-  FRAME_CONNECTED: 'frameConnected',
-
   // Session state changes
 
   /** The logged-in user changed */

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -203,7 +203,6 @@ export default function FrameSync($rootScope, $window, store, bridge) {
         return;
       }
 
-      $rootScope.$broadcast(events.FRAME_CONNECTED);
       store.connectFrame({
         id: info.frameIdentifier,
         metadata: info.metadata,


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/2037**~~

This PR replaces the use of the `FRAME_CONNECTED` event in the `features` and `groups` services to respond to changes in the documents connected to the sidebar. The last commit removes the `FRAME_CONNECTED` event which is no longer used.

Both of these are replaced by logic that watches the relevant store state using the `watch` utility introduced in  https://github.com/hypothesis/client/pull/2037.

Part of https://github.com/hypothesis/client/issues/1994.


