### PR TITLE
Convert single annotation page content to Preact

### DIFF
--- a/src/sidebar/components/annotation-viewer-content.js
+++ b/src/sidebar/components/annotation-viewer-content.js
@@ -32,13 +32,20 @@ function AnnotationViewerContent({
     fetchThread(api, annotationId).then(annots => {
       addAnnotations(annots);
 
+      // Find the top-level annotation in the thread that `annotationId` is
+      // part of. This will be different to `annotationId` if `annotationId`
+      // is a reply.
       const topLevelAnnot = annots.filter(
         ann => (ann.references || []).length === 0
       )[0];
 
       if (!topLevelAnnot) {
-        // `annotationId` refers to a reply. We were able to fetch the reply
-        // but not the top-level annotation at the top of the thread.
+        // We were able to fetch annotations in the thread that `annotationId`
+        // is part of (note that `annotationId` may refer to a reply) but
+        // couldn't find a top-level (non-reply) annotation in that thread.
+        //
+        // This might happen if the top-level annotation was deleted or
+        // moderated or had its permissions changed.
         //
         // We need to decide what what be the most useful behavior in this case
         // and implement it.
@@ -46,23 +53,29 @@ function AnnotationViewerContent({
         return;
       }
 
+      // Configure the connection to the real-time update service to send us
+      // updates to any of the annotations in the thread.
       streamFilter
         .addClause('/references', 'one_of', topLevelAnnot.id, true)
         .addClause('/id', 'equals', topLevelAnnot.id, true);
       streamer.setConfig('filter', { filter: streamFilter.getFilter() });
       streamer.connect();
 
+      // Make the full thread of annotations visible. By default replies are
+      // not shown until the user expands the thread.
       annots.forEach(annot => setCollapsed(annot.id, false));
 
+      // FIXME - This should show a visual indication of which reply the
+      // annotation ID in the URL refers to. That isn't currently working.
       if (topLevelAnnot.id !== annotationId) {
-        // FIXME - This should show a visual indication of which reply the
-        // annotation ID in the URL refers to. That isn't working.
         highlightAnnotations([annotationId]);
       }
     });
   }, [
-    addAnnotations,
     annotationId,
+
+    // Static dependencies.
+    addAnnotations,
     api,
     clearAnnotations,
     highlightAnnotations,

--- a/src/sidebar/components/annotation-viewer-content.js
+++ b/src/sidebar/components/annotation-viewer-content.js
@@ -1,77 +1,113 @@
+import { createElement } from 'preact';
+import { useEffect } from 'preact/hooks';
+import propTypes from 'prop-types';
+
+import useStore from '../store/use-store';
+import { withServices } from '../util/service-context';
+
+import ThreadList from './thread-list';
+
+/**
+ * The main content for the single annotation page (aka. https://hypothes.is/a/<annotation ID>)
+ */
+function AnnotationViewerContent({
+  api,
+  rootThread: rootThreadService,
+  streamer,
+  streamFilter,
+}) {
+  const addAnnotations = useStore(store => store.addAnnotations);
+  const annotationId = useStore(store => store.routeParams().id);
+  const clearAnnotations = useStore(store => store.clearAnnotations);
+  const highlightAnnotations = useStore(store => store.highlightAnnotations);
+  const rootThread = useStore(store =>
+    rootThreadService.thread(store.getState())
+  );
+  const setCollapsed = useStore(store => store.setCollapsed);
+
+  useEffect(() => {
+    clearAnnotations();
+
+    // TODO - Handle exceptions during the `fetchThread` call.
+    fetchThread(api, annotationId).then(annots => {
+      addAnnotations(annots);
+
+      const topLevelAnnot = annots.filter(
+        ann => (ann.references || []).length === 0
+      )[0];
+
+      if (!topLevelAnnot) {
+        return;
+      }
+
+      streamFilter
+        .addClause('/references', 'one_of', topLevelAnnot.id, true)
+        .addClause('/id', 'equals', topLevelAnnot.id, true);
+      streamer.setConfig('filter', { filter: streamFilter.getFilter() });
+      streamer.connect();
+
+      annots.forEach(annot => setCollapsed(annot.id, false));
+
+      if (topLevelAnnot.id !== annotationId) {
+        // FIXME - This should show a visual indication of which reply the
+        // annotation ID in the URL refers to. That isn't working.
+        highlightAnnotations([annotationId]);
+      }
+    });
+  }, [
+    addAnnotations,
+    annotationId,
+    api,
+    clearAnnotations,
+    highlightAnnotations,
+    setCollapsed,
+    streamFilter,
+    streamer,
+  ]);
+
+  return <ThreadList thread={rootThread} />;
+}
+
+AnnotationViewerContent.propTypes = {
+  // Injected.
+  api: propTypes.object,
+  rootThread: propTypes.object,
+  streamer: propTypes.object,
+  streamFilter: propTypes.object,
+};
+
+AnnotationViewerContent.injectedProps = [
+  'api',
+  'rootThread',
+  'streamer',
+  'streamFilter',
+];
+
+// NOTE: The function below is intentionally at the bottom of the file.
+//
+// Putting it at the top resulted in an issue where the `createElement` import
+// wasn't correctly referenced in the body of `AnnotationViewerContent` in
+// the compiled JS, causing a runtime error.
+
 /**
  * Fetch all annotations in the same thread as `id`.
  *
- * @return Promise<Array<Annotation>>
+ * @param {Object} api - API client
+ * @param {string} id - Annotation ID. This may be an annotation or a reply.
+ * @return Promise<Annotation[]> - The annotation, followed by any replies.
  */
-function fetchThread(api, id) {
-  let annot;
-  return api.annotation
-    .get({ id: id })
-    .then(function (annot) {
-      if (annot.references && annot.references.length) {
-        // This is a reply, fetch the top-level annotation
-        return api.annotation.get({ id: annot.references[0] });
-      } else {
-        return annot;
-      }
-    })
-    .then(function (annot_) {
-      annot = annot_;
-      return api.search({ references: annot.id });
-    })
-    .then(function (searchResult) {
-      return [annot].concat(searchResult.rows);
-    });
+async function fetchThread(api, id) {
+  let annot = await api.annotation.get({ id });
+
+  if (annot.references && annot.references.length) {
+    // This is a reply, fetch the top-level annotation
+    annot = await api.annotation.get({ id: annot.references[0] });
+  }
+
+  // Fetch all replies to the top-level annotation.
+  const replySearchResult = await api.search({ references: annot.id });
+
+  return [annot, ...replySearchResult.rows];
 }
 
-// @ngInject
-function AnnotationViewerContentController(
-  store,
-  api,
-  rootThread,
-  streamer,
-  streamFilter
-) {
-  store.clearAnnotations();
-
-  const annotationId = store.routeParams().id;
-
-  this.rootThread = () => rootThread.thread(store.getState());
-
-  this.setCollapsed = function (id, collapsed) {
-    store.setCollapsed(id, collapsed);
-  };
-
-  this.ready = fetchThread(api, annotationId).then(function (annots) {
-    store.addAnnotations(annots);
-
-    const topLevelAnnot = annots.filter(function (annot) {
-      return (annot.references || []).length === 0;
-    })[0];
-
-    if (!topLevelAnnot) {
-      return;
-    }
-
-    streamFilter
-      .addClause('/references', 'one_of', topLevelAnnot.id, true)
-      .addClause('/id', 'equals', topLevelAnnot.id, true);
-    streamer.setConfig('filter', { filter: streamFilter.getFilter() });
-    streamer.connect();
-
-    annots.forEach(function (annot) {
-      store.setCollapsed(annot.id, false);
-    });
-
-    if (topLevelAnnot.id !== annotationId) {
-      store.highlightAnnotations([annotationId]);
-    }
-  });
-}
-
-export default {
-  controller: AnnotationViewerContentController,
-  controllerAs: 'vm',
-  bindings: {},
-  template: require('../templates/annotation-viewer-content.html'),
-};
+export default withServices(AnnotationViewerContent);

--- a/src/sidebar/components/annotation-viewer-content.js
+++ b/src/sidebar/components/annotation-viewer-content.js
@@ -37,6 +37,12 @@ function AnnotationViewerContent({
       )[0];
 
       if (!topLevelAnnot) {
+        // `annotationId` refers to a reply. We were able to fetch the reply
+        // but not the top-level annotation at the top of the thread.
+        //
+        // We need to decide what what be the most useful behavior in this case
+        // and implement it.
+        /* istanbul ignore next */
         return;
       }
 

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -119,6 +119,7 @@ registerIcons(iconSet);
 // Preact UI components that are wrapped for use within Angular templates.
 
 import Annotation from './components/annotation';
+import AnnotationViewerContent from './components/annotation-viewer-content';
 import FocusedModeHeader from './components/focused-mode-header';
 import HelpPanel from './components/help-panel';
 import LoggedOutMessage from './components/logged-out-message';
@@ -136,7 +137,6 @@ import TopBar from './components/top-bar';
 
 // Remaining UI components that are still built with Angular.
 
-import annotationViewerContent from './components/annotation-viewer-content';
 import hypothesisApp from './components/hypothesis-app';
 import sidebarContent from './components/sidebar-content';
 import streamContent from './components/stream-content';
@@ -257,7 +257,10 @@ function startAngularApp(config) {
 
     // UI components
     .component('annotation', wrapComponent(Annotation))
-    .component('annotationViewerContent', annotationViewerContent)
+    .component(
+      'annotationViewerContent',
+      wrapComponent(AnnotationViewerContent)
+    )
     .component('helpPanel', wrapComponent(HelpPanel))
     .component('loginPromptPanel', wrapComponent(LoginPromptPanel))
     .component('loggedOutMessage', wrapComponent(LoggedOutMessage))

--- a/src/sidebar/templates/annotation-viewer-content.html
+++ b/src/sidebar/templates/annotation-viewer-content.html
@@ -1,6 +1,0 @@
-<thread-list
-  on-change-collapsed="vm.setCollapsed(id, collapsed)"
-  on-force-visible="vm.forceVisible(thread)"
-  show-document-info="true"
-  thread="vm.rootThread()">
-</thread-list>


### PR DESCRIPTION
This is a pretty direct conversion of the `<annotation-viewer-content>`
component from AngularJS to Preact.

Much of the logic and tests are for non-UI logic, so could potentially
be moved to a service in future.

I encountered an odd issue with the `fetchThread` helper that required
it to be put at the bottom of the file. Putting it at the top resulted
in an error related to the `createElement` import at runtime. I suspect this
may relate to the interaction of various Babel plugins. I haven't completely debugged it
yet.

An issue relating to the highlighting of which reply the ID in the URL
refers to is noted in the code. What should happen is that the reply
that the ID in the URL refers to is visually highlighted. This is an
existing regression from before this commit.

After this initial port lands, there are two items to follow up on:

- Show a helpful error if fetching the annotation thread fails
- Fix the regression around highlighting the reply associated with the annotation/reply ID in the URL