### PR TITLE
Add differentiating link styling to tutorial

### DIFF
--- a/src/styles/sidebar/components/help-panel.scss
+++ b/src/styles/sidebar/components/help-panel.scss
@@ -15,6 +15,10 @@
     border-bottom: 1px solid var.$grey-3;
     line-height: var.$normal-line-height;
     font-size: var.$normal-font-size;
+
+    a {
+      text-decoration: underline;
+    }
   }
 
   &__icon {


### PR DESCRIPTION
I poked around a bit at making non-underlined links the exception, not the rule, but this was a broader design change than is easily done in one quick swoop. So this change fixes the reported issue specifically.

After:

![image](https://user-images.githubusercontent.com/439947/80027690-20597480-84b2-11ea-99e6-d34a18fc2df7.png)


Fixes #2054