### PR TITLE
Convert stream content to Preact

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -129,6 +129,7 @@ import SearchStatusBar from './components/search-status-bar';
 import SelectionTabs from './components/selection-tabs';
 import ShareAnnotationsPanel from './components/share-annotations-panel';
 import SidebarContentError from './components/sidebar-content-error';
+import StreamContent from './components/stream-content';
 import SvgIcon from '../shared/components/svg-icon';
 import Thread from './components/thread';
 import ThreadList from './components/thread-list';
@@ -139,7 +140,6 @@ import TopBar from './components/top-bar';
 
 import hypothesisApp from './components/hypothesis-app';
 import sidebarContent from './components/sidebar-content';
-import streamContent from './components/stream-content';
 
 // Services.
 
@@ -271,7 +271,7 @@ function startAngularApp(config) {
     .component('sidebarContent', sidebarContent)
     .component('sidebarContentError', wrapComponent(SidebarContentError))
     .component('shareAnnotationsPanel', wrapComponent(ShareAnnotationsPanel))
-    .component('streamContent', streamContent)
+    .component('streamContent', wrapComponent(StreamContent))
     .component('svgIcon', wrapComponent(SvgIcon))
     .component('thread', wrapComponent(Thread))
     .component('threadList', wrapComponent(ThreadList))

--- a/src/sidebar/templates/stream-content.html
+++ b/src/sidebar/templates/stream-content.html
@@ -1,5 +1,0 @@
-<thread-list
-  on-change-collapsed="vm.setCollapsed(id, collapsed)"
-  show-document-info="true"
-  thread="vm.rootThread()">
-</thread-list>


### PR DESCRIPTION
This is a fairly direct conversion of the `<stream-content>` component, for the `/stream` route,
from AngularJS to Preact. This is a countepart to https://github.com/hypothesis/client/pull/2074.

There is one minor functional improvement which is to display an error notification
if fetching annotations from the API fails.