### PR TITLE
Revert "Fix overflow on Thread contents"

### DIFF
--- a/src/styles/sidebar/components/thread.scss
+++ b/src/styles/sidebar/components/thread.scss
@@ -53,8 +53,7 @@
 
   &__content {
     flex-grow: 1;
-    // Prevent long, non-wrapping content (typically URLs) from exceeding
-    // the width of the annotation card
-    overflow: hidden;
+    // Prevent annotation content from overflowing the container
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
Reverts hypothesis/client#2075

This broke the Post annotation by hidden it when it was longer than the bottom of the .thread container. Reverting for now 

![Screen Shot 2020-04-23 at 10 02 05 AM](https://user-images.githubusercontent.com/3939074/80128025-fc497200-8549-11ea-8c6d-be3b15ad9efa.png)
  menu