### PR TITLE
Work around issue with Node v14 and Puppeteer

### DIFF
--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -7,7 +7,15 @@ const envify = require('loose-envify/custom');
 const glob = require('glob');
 
 let chromeFlags = [];
-process.env.CHROME_BIN = require('puppeteer').executablePath();
+
+if (process.version.startsWith('v14.')) {
+  // See https://github.com/puppeteer/puppeteer/issues/5719
+  console.warn(
+    'Using system Chrome instead of Puppeteer due to issue with Node 14'
+  );
+} else {
+  process.env.CHROME_BIN = require('puppeteer').executablePath();
+}
 
 // On Travis and in Docker, the tests run as root, so the sandbox must be
 // disabled.


### PR DESCRIPTION
Use the system version of Chrome if the developer has Node v14
installed, to work around an upstream issue with Puppeteer (see code
comment).

The observed behavior under Node 14 is that running `make test` fails with an error about Chrome not being captured (ie. Karma failed to launch Chrome)

Further details: https://github.com/puppeteer/puppeteer/issues/5719