### PR TITLE
Refactor store state regarding frame fetch status

### DIFF
--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -62,6 +62,8 @@ describe('sidebar/services/frame-sync', function () {
         findIDsForTags: sinon.stub(),
         focusAnnotations: sinon.stub(),
         frames: sinon.stub().returns([fixtures.framesListEntry]),
+        frameFetchStatus: sinon.stub().returns({}),
+        isFrameFetchComplete: sinon.stub().returns(false),
         isLoggedIn: sinon.stub().returns(false),
         openSidebarPanel: sinon.stub(),
         selectAnnotations: sinon.stub(),
@@ -150,6 +152,8 @@ describe('sidebar/services/frame-sync', function () {
 
   context('when annotation count has changed', function () {
     it('sends a "publicAnnotationCountChanged" message to the frame when there are public annotations', function () {
+      fakeStore.frames.returns([{ uri: 'http://example.com' }]);
+      fakeStore.isFrameFetchComplete.returns(true);
       fakeStore.setState({
         annotations: { annotations: [annotationFixtures.publicAnnotation()] },
       });
@@ -164,6 +168,8 @@ describe('sidebar/services/frame-sync', function () {
       const annot = annotationFixtures.defaultAnnotation();
       delete annot.permissions;
 
+      fakeStore.frames.returns([{ uri: 'http://example.com' }]);
+      fakeStore.isFrameFetchComplete.returns(true);
       fakeStore.setState({
         annotations: { annotations: [annot] },
       });

--- a/src/sidebar/store/modules/test/frames-test.js
+++ b/src/sidebar/store/modules/test/frames-test.js
@@ -9,155 +9,183 @@ describe('sidebar/store/modules/frames', function () {
     store = createStore([frames]);
   });
 
-  describe('#connectFrame', function () {
-    it('adds the frame to the list of connected frames', function () {
-      const frame = { uri: 'http://example.com' };
-      store.connectFrame(frame);
-      assert.deepEqual(store.frames(), [frame]);
-    });
-  });
-
-  describe('#destroyFrame', function () {
-    it('removes the frame from the list of connected frames', function () {
-      const frameList = [
-        { uri: 'http://example.com' },
-        { uri: 'http://example.org' },
-      ];
-      store.connectFrame(frameList[0]);
-      store.connectFrame(frameList[1]);
-      store.destroyFrame(frameList[0]);
-      assert.deepEqual(store.frames(), [frameList[1]]);
-    });
-  });
-
-  describe('#updateFrameAnnotationFetchStatus', function () {
-    it('updates the isAnnotationFetchComplete status of the frame', function () {
-      const frame = {
-        uri: 'http://example.com',
-      };
-      const expectedFrame = {
-        uri: 'http://example.com',
-        isAnnotationFetchComplete: true,
-      };
-      store.connectFrame(frame);
-      store.updateFrameAnnotationFetchStatus(frame.uri, true);
-      assert.deepEqual(store.frames(), [expectedFrame]);
+  describe('actions', () => {
+    describe('#connectFrame', () => {
+      it('adds the frame to the list of connected frames', () => {
+        const frame = { uri: 'http://example.com' };
+        store.connectFrame(frame);
+        assert.deepEqual(store.frames(), [frame]);
+      });
     });
 
-    it('does not update the isAnnotationFetchComplete status of the wrong frame', function () {
-      const frame = {
-        uri: 'http://example.com',
-      };
-      store.connectFrame(frame);
-      store.updateFrameAnnotationFetchStatus('http://anotherexample.com', true);
-      assert.deepEqual(store.frames(), [frame]);
+    describe('#destroyFrame', () => {
+      it('removes the frame from the list of connected frames', () => {
+        const frameList = [
+          { uri: 'http://example.com' },
+          { uri: 'http://example.org' },
+        ];
+        store.connectFrame(frameList[0]);
+        store.updateFrameAnnotationFetchStatus(frameList[0].uri, true);
+        store.connectFrame(frameList[1]);
+        store.destroyFrame(frameList[0]);
+        assert.deepEqual(store.frames(), [frameList[1]]);
+        assert.isFalse(store.isFrameFetchComplete(frameList[0].uri));
+      });
     });
-  });
 
-  describe('#mainFrame', () => {
-    it('returns `null` if no frames are connected', () => {
-      assert.isNull(store.mainFrame());
-    });
+    describe('#updateFrameAnnotationFetchStatus', () => {
+      it('updates the annotation-fetch status for the associated URI', () => {
+        const fakeUri = 'http://example.com';
+        store.connectFrame({ uri: fakeUri });
+        store.updateFrameAnnotationFetchStatus(fakeUri, true);
+        assert.isTrue(store.isFrameFetchComplete(fakeUri));
+      });
 
-    [
-      {
-        frames: [{ id: null, uri: 'https://example.org' }],
-        expectedFrame: 0,
-      },
-      {
-        frames: [
-          // An iframe which is also connected.
-          { id: 'iframe1', uri: 'https://foo.com/' },
+      it('does not affect other the annotation-fetch status for other frames', () => {
+        store.connectFrame({ uri: 'http://example.com' });
+        store.connectFrame({ uri: 'http://example.org' });
+        store.updateFrameAnnotationFetchStatus('http://example.com', false);
+        store.updateFrameAnnotationFetchStatus('http://example.org', true);
 
-          // The top-level frame.
-          { id: null, uri: 'https://example.org' },
-        ],
-        expectedFrame: 1,
-      },
-    ].forEach(({ frames, expectedFrame }) => {
-      it('returns the main frame from the frames connected to the sidebar', () => {
-        frames.forEach(frame => store.connectFrame(frame));
-        assert.equal(store.mainFrame(), frames[expectedFrame]);
+        assert.isFalse(store.isFrameFetchComplete('http://example.com'));
       });
     });
   });
 
-  describe('#searchUris', function () {
-    [
-      {
-        when: 'one HTML frame',
-        frames: [
-          {
-            uri: 'https://publisher.org/article.html',
-          },
-        ],
-        searchUris: ['https://publisher.org/article.html'],
-      },
-      {
-        when: 'one PDF frame',
-        frames: [
-          {
-            uri: 'https://publisher.org/article.pdf',
-            metadata: {
-              documentFingerprint: '1234',
-              link: [
-                {
-                  href: 'urn:x-pdf:1234',
-                },
-                {
-                  // When a document fingerprint is provided, we currently rely on the
-                  // host frame to include the original URL of the document in the
-                  // `metadata.link` list.
-                  //
-                  // This may be omitted if the URI is a `file:///` URI.
-                  href: 'https://publisher.org/article.pdf?from_meta_link=1',
-                },
-              ],
-            },
-          },
-        ],
-        searchUris: [
-          'urn:x-pdf:1234',
-          'https://publisher.org/article.pdf?from_meta_link=1',
-        ],
-      },
-      {
-        when: 'multiple HTML frames',
-        frames: [
-          {
-            uri: 'https://publisher.org/article.html',
-          },
-          {
-            uri: 'https://publisher.org/article2.html',
-          },
-        ],
-        searchUris: [
-          'https://publisher.org/article.html',
-          'https://publisher.org/article2.html',
-        ],
-      },
-      {
-        when: 'the document metadata includes a DOI',
-        frames: [
-          {
-            uri: 'https://publisher.org/article.html',
-            metadata: {
-              link: [
-                {
-                  href: 'doi:10.1.1/1234',
-                },
-              ],
-            },
-          },
-        ],
-        searchUris: ['https://publisher.org/article.html', 'doi:10.1.1/1234'],
-      },
-    ].forEach(testCase => {
-      it(testCase.when, () => {
-        testCase.frames.forEach(frame => {
-          store.connectFrame(frame);
+  describe('selectors', () => {
+    describe('#frameFetchStatus', () => {
+      it('should return the annotation-fetch status for all frames that have set status', () => {
+        store.updateFrameAnnotationFetchStatus('http://www.example.com', true);
+        store.updateFrameAnnotationFetchStatus('http://www.example.org', false);
+
+        assert.deepEqual(store.frameFetchStatus(), {
+          'http://www.example.com': true,
+          'http://www.example.org': false,
         });
-        assert.deepEqual(store.searchUris(), testCase.searchUris);
+      });
+    });
+
+    describe('#isFrameFetchComplete', () => {
+      beforeEach(() => {
+        store.updateFrameAnnotationFetchStatus('http://www.example.com', true);
+        store.updateFrameAnnotationFetchStatus('http://www.example.org', false);
+      });
+
+      it('should return the boolean fetch-complete value for a given URI', () => {
+        assert.isTrue(store.isFrameFetchComplete('http://www.example.com'));
+        assert.isFalse(store.isFrameFetchComplete('http://www.example.org'));
+      });
+
+      it('should return `false` if no fetch status available for URI', () => {
+        assert.isFalse(store.isFrameFetchComplete('some rando URI'));
+      });
+    });
+
+    describe('#mainFrame', () => {
+      it('returns `null` if no frames are connected', () => {
+        assert.isNull(store.mainFrame());
+      });
+
+      [
+        {
+          frames: [{ id: null, uri: 'https://example.org' }],
+          expectedFrame: 0,
+        },
+        {
+          frames: [
+            // An iframe which is also connected.
+            { id: 'iframe1', uri: 'https://foo.com/' },
+
+            // The top-level frame.
+            { id: null, uri: 'https://example.org' },
+          ],
+          expectedFrame: 1,
+        },
+      ].forEach(({ frames, expectedFrame }) => {
+        it('returns the main frame from the frames connected to the sidebar', () => {
+          frames.forEach(frame => store.connectFrame(frame));
+          assert.equal(store.mainFrame(), frames[expectedFrame]);
+        });
+      });
+    });
+
+    describe('#searchUris', () => {
+      [
+        {
+          when: 'one HTML frame',
+          frames: [
+            {
+              uri: 'https://publisher.org/article.html',
+            },
+          ],
+          searchUris: ['https://publisher.org/article.html'],
+        },
+        {
+          when: 'one PDF frame',
+          frames: [
+            {
+              uri: 'https://publisher.org/article.pdf',
+              metadata: {
+                documentFingerprint: '1234',
+                link: [
+                  {
+                    href: 'urn:x-pdf:1234',
+                  },
+                  {
+                    // When a document fingerprint is provided, we currently rely on the
+                    // host frame to include the original URL of the document in the
+                    // `metadata.link` list.
+                    //
+                    // This may be omitted if the URI is a `file:///` URI.
+                    href: 'https://publisher.org/article.pdf?from_meta_link=1',
+                  },
+                ],
+              },
+            },
+          ],
+          searchUris: [
+            'urn:x-pdf:1234',
+            'https://publisher.org/article.pdf?from_meta_link=1',
+          ],
+        },
+        {
+          when: 'multiple HTML frames',
+          frames: [
+            {
+              uri: 'https://publisher.org/article.html',
+            },
+            {
+              uri: 'https://publisher.org/article2.html',
+            },
+          ],
+          searchUris: [
+            'https://publisher.org/article.html',
+            'https://publisher.org/article2.html',
+          ],
+        },
+        {
+          when: 'the document metadata includes a DOI',
+          frames: [
+            {
+              uri: 'https://publisher.org/article.html',
+              metadata: {
+                link: [
+                  {
+                    href: 'doi:10.1.1/1234',
+                  },
+                ],
+              },
+            },
+          ],
+          searchUris: ['https://publisher.org/article.html', 'doi:10.1.1/1234'],
+        },
+      ].forEach(testCase => {
+        it(testCase.when, () => {
+          testCase.frames.forEach(frame => {
+            store.connectFrame(frame);
+          });
+          assert.deepEqual(store.searchUris(), testCase.searchUris);
+        });
       });
     });
   });


### PR DESCRIPTION
- Manage status of fetch by URI separately from frame objects in store
- Add and optimize selectors related to frame status and URIs

These changes make the migration of `SidebarContent` much easier/possible by separating the state of `frame` objects themselves versus the status of their annotation-fetching. Thus, part of https://github.com/hypothesis/client/issues/2010