### PR TITLE
Revise re-fetching of groups when logged-in user changes

### DIFF
--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -808,8 +808,10 @@ describe('groups', function () {
       fakeApi.groups.list.resetHistory();
       fakeStore.hasFetchedProfile.returns(true);
       fakeStore.profile.returns({ userid: 'acct:firstuser@hypothes.is' });
-      fakeStore.setState({});
+      fakeStore.setState({}); // Notify store subscribers.
 
+      // Wait briefly, as there are a few async steps before the group fetch
+      // from the API starts, if it is going to happen.
       await delay(1);
       assert.notCalled(fakeApi.groups.list);
 
@@ -862,6 +864,8 @@ describe('groups', function () {
           ],
         });
 
+        // Wait briefly, as there are a few async steps before the group fetch
+        // from the API starts, if it is going to happen.
         await delay(1);
         assert.notCalled(fakeApi.groups.list);
       });

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -1,4 +1,3 @@
-import events from '../../events';
 import fakeReduxStore from '../../test/fake-redux-store';
 import groups, { $imports } from '../groups';
 import { waitFor } from '../../../test-util/wait';
@@ -45,7 +44,6 @@ describe('groups', function () {
   let fakeSession;
   let fakeSettings;
   let fakeApi;
-  let fakeRootScope;
   let fakeServiceUrl;
   let fakeMetadata;
   let fakeToastMessenger;
@@ -83,6 +81,7 @@ describe('groups', function () {
         focusedGroupId: sinon.stub(),
         getDefault: sinon.stub(),
         getGroup: sinon.stub(),
+        hasFetchedProfile: sinon.stub().returns(false),
         loadGroups: sinon.stub(),
         newAnnotations: sinon.stub().returns([]),
         allGroups() {
@@ -97,25 +96,11 @@ describe('groups', function () {
         setDefault: sinon.stub(),
         setDirectLinkedGroupFetchFailed: sinon.stub(),
         clearDirectLinkedGroupFetchFailed: sinon.stub(),
+        profile: sinon.stub().returns({ userid: null }),
       }
     );
     fakeSession = sessionWithThreeGroups();
     fakeIsSidebar = true;
-    fakeRootScope = {
-      eventCallbacks: {},
-
-      $apply: function (callback) {
-        callback();
-      },
-
-      $on: function (event, callback) {
-        if (event === events.USER_CHANGED) {
-          this.eventCallbacks[event] = callback;
-        }
-      },
-
-      $broadcast: sinon.stub(),
-    };
     fakeApi = {
       annotation: {
         get: sinon.stub(),
@@ -150,7 +135,6 @@ describe('groups', function () {
 
   function service() {
     return groups(
-      fakeRootScope,
       fakeStore,
       fakeApi,
       fakeIsSidebar,
@@ -810,13 +794,33 @@ describe('groups', function () {
     });
   });
 
-  describe('automatic re-fetching', function () {
-    it('refetches groups when the logged-in user changes', () => {
-      service();
+  const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-      return fakeRootScope.eventCallbacks[events.USER_CHANGED]().then(() => {
-        assert.calledOnce(fakeApi.groups.list);
-      });
+  describe('automatic re-fetching', function () {
+    it('refetches groups when the logged-in user changes', async () => {
+      const svc = service();
+
+      // Load groups before profile fetch has completed.
+      fakeStore.hasFetchedProfile.returns(false);
+      await svc.load();
+
+      // Simulate initial fetch of profile finishing. This should be ignored.
+      fakeApi.groups.list.resetHistory();
+      fakeStore.hasFetchedProfile.returns(true);
+      fakeStore.profile.returns({ userid: 'acct:firstuser@hypothes.is' });
+      fakeStore.setState({});
+
+      await delay(1);
+      assert.notCalled(fakeApi.groups.list);
+
+      // Simulate user logging out (or logging in). This should trigger a re-fetching
+      // of groups.
+      fakeStore.hasFetchedProfile.returns(true);
+      fakeStore.profile.returns({ userid: 'acct:otheruser@hypothes.is' });
+      fakeStore.setState({});
+
+      await waitFor(() => fakeApi.groups.list.callCount > 0);
+      assert.calledOnce(fakeApi.groups.list);
     });
 
     context('when a new frame connects', () => {
@@ -858,7 +862,7 @@ describe('groups', function () {
           ],
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1));
+        await delay(1);
         assert.notCalled(fakeApi.groups.list);
       });
     });

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -4,7 +4,7 @@ import * as util from '../util';
  * A dummy profile returned by the `profile` selector before the real profile
  * is fetched.
  */
-const blankProfile = {
+const initialProfile = {
   /** A map of features that are enabled for the current user. */
   features: {},
   /** A map of preference names and values. */
@@ -20,7 +20,7 @@ function init() {
     /**
      * Profile object fetched from the `/api/profile` endpoint.
      */
-    profile: null,
+    profile: initialProfile,
   };
 }
 
@@ -50,8 +50,7 @@ function updateProfile(profile) {
  * @param {object} state - The application state
  */
 function isLoggedIn(state) {
-  const profile = state.session.profile;
-  return profile !== null && profile.userid !== null;
+  return state.session.profile.userid !== null;
 }
 
 /**
@@ -62,8 +61,7 @@ function isLoggedIn(state) {
  *        name of the feature flag as declared in the Hypothesis service.
  */
 function isFeatureEnabled(state, feature) {
-  const profile = state.session.profile;
-  return profile !== null && !!profile.features[feature];
+  return !!state.session.profile.features[feature];
 }
 
 /**
@@ -72,7 +70,7 @@ function isFeatureEnabled(state, feature) {
  * logged-out user profile returned by the server.
  */
 function hasFetchedProfile(state) {
-  return state.session.profile !== null;
+  return state.session.profile !== initialProfile;
 }
 
 /**
@@ -84,7 +82,7 @@ function hasFetchedProfile(state) {
  * returned. This allows code to skip a null check.
  */
 function profile(state) {
-  return state.session.profile || blankProfile;
+  return state.session.profile;
 }
 
 export default {

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -28,6 +28,17 @@ describe('sidebar/store/modules/session', function () {
     });
   });
 
+  describe('#hasFetchedProfile', () => {
+    it('returns false before profile is updated', () => {
+      assert.isFalse(store.hasFetchedProfile());
+    });
+
+    it('returns true after profile is updated', () => {
+      store.updateProfile({ userid: 'john' });
+      assert.isTrue(store.hasFetchedProfile());
+    });
+  });
+
   describe('#profile', () => {
     it("returns the user's profile", () => {
       store.updateProfile({ userid: 'john' });

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -28,6 +28,27 @@ describe('sidebar/store/modules/session', function () {
     });
   });
 
+  describe('#isFeatureEnabled', () => {
+    it('returns false before features have been fetched', () => {
+      assert.isFalse(store.isFeatureEnabled('some_feature'));
+    });
+
+    it('returns false if feature is unknown', () => {
+      store.updateProfile({ userid: null, features: {} });
+      assert.isFalse(store.isFeatureEnabled('some_feature'));
+    });
+
+    [true, false].forEach(enabled => {
+      it('returns feature flag state if profile is fetched and feature exists', () => {
+        store.updateProfile({
+          userid: null,
+          features: { some_feature: enabled },
+        });
+        assert.equal(store.isFeatureEnabled('some_feature'), enabled);
+      });
+    });
+  });
+
   describe('#hasFetchedProfile', () => {
     it('returns false before profile is updated', () => {
       assert.isFalse(store.hasFetchedProfile());


### PR DESCRIPTION
This PR reimplements re-fetching of groups when the logged-in user changes to address two issues:

1. It removes the use of the `USER_CHANGED` event in the `groups` service, as part of https://github.com/hypothesis/client/issues/1994
2. It fixes an issue where an unnecessary additional API call would be made on startup if the user was logged in from a previous session. This happened because the `USER_CHANGED` event did not distinguish between the user changing after a login/logout action vs. the initial profile being fetched

In order to support (2), the representation of the profile-not-yet-fetched state has been changed in the `session` store module. The `profile` field is now nullable. To avoid a cascade of changes in other parts of the app, the `profile()` selector still returns a blank profile in this case and a separate `hasFetchedProfile()` selector must be used to check if the profile has been fetched or not. I'm not sure yet whether it will be convenient to retain this in future or simply require all code that uses `store.profile()` to account for the null state.