### PR TITLE
Hide excerpt and body expand toggles from assistive technology

### DIFF
--- a/src/sidebar/components/annotation-body.js
+++ b/src/sidebar/components/annotation-body.js
@@ -67,7 +67,10 @@ export default function AnnotationBody({
         />
       )}
       {isCollapsible && !isEditing && (
-        <div className="annotation-body__collapse-toggle">
+        <div className="annotation-body__collapse-toggle" aria-hidden="true">
+          {/* This is hidden from screen readers because the toggle
+              is only a visual toggle: the content is all present
+           */}
           <Button
             className="annotation-body__collapse-toggle-button"
             onClick={() => setIsCollapsed(!isCollapsed)}

--- a/src/sidebar/components/excerpt.js
+++ b/src/sidebar/components/excerpt.js
@@ -14,8 +14,11 @@ import { applyTheme } from '../util/theme';
 function InlineControls({ isCollapsed, setCollapsed, linkStyle = {} }) {
   const toggleLabel = isCollapsed ? 'More' : 'Less';
 
+  // These controls are hidden from assistive technology using the
+  // `aria-hidden` attribute because the entire excerpt is present, it's
+  // just visually hidden, making these controls meaningless for screen readers
   return (
-    <div className="excerpt__inline-controls">
+    <div className="excerpt__inline-controls" aria-hidden="true">
       <span className="excerpt__toggle-link">
         <button
           className="excerpt__toggle-button"
@@ -110,6 +113,7 @@ function Excerpt({
         {children}
       </div>
       <div
+        aria-hidden="true"
         role="presentation"
         onClick={() => setCollapsed(false)}
         className={classnames({


### PR DESCRIPTION
We visually truncate long excerpts and annotation bodies, and provide
expand controls so that users can view the entire contents. However,
this is just a visual truncation: the content is all present in the
document at all times—this makes these controls meaningless to screen
readers. Hide using the `aria-hidden` attribute.

Fixes https://github.com/hypothesis/client/issues/2057