### PR TITLE
Tune tutorial text to eliminate input-modality-specific instructions.

### DIFF
--- a/src/sidebar/components/tutorial.js
+++ b/src/sidebar/components/tutorial.js
@@ -35,7 +35,7 @@ function Tutorial({ settings }) {
   return (
     <ol className="tutorial__list">
       <li className="tutorial__item">
-        To create an annotation, select text and click the{' '}
+        To create an annotation, select text and then select the{' '}
         <TutorialInstruction iconName="annotate" commandName="Annotate" />{' '}
         button.
       </li>
@@ -48,7 +48,7 @@ function Tutorial({ settings }) {
         >
           visible only to you
         </a>
-        ), select text and click the{' '}
+        ), select text and then select the{' '}
         <TutorialInstruction iconName="highlight" commandName="Highlight" />{' '}
         button.
       </li>
@@ -67,7 +67,7 @@ function Tutorial({ settings }) {
         </li>
       )}
       <li className="tutorial__item">
-        To reply to an annotation, click the{' '}
+        To reply to an annotation, select the{' '}
         <TutorialInstruction iconName="reply" commandName="Reply" /> button.
       </li>
     </ol>


### PR DESCRIPTION
During our accessibility audit, the mouse-specific "click" text in our tutorial was called out:

I've tuned the text in this tutorial panel to remove references to "clicking". This leaves a fair amount of "selecting" in the text.

I started down the path of perhaps trying to improve the text overall (step 3, especially, feels cumbersome), but Stopped Myself, as that is a larger task.

Before:

![image](https://user-images.githubusercontent.com/439947/80805952-5b7d3700-8b87-11ea-90fe-2c909ba1212a.png)

After:

![image](https://user-images.githubusercontent.com/439947/80806182-f37b2080-8b87-11ea-9965-a68045dadce8.png)


Fixes https://github.com/hypothesis/client/issues/2062