### PR TITLE
Improve document outline and stucture

### DIFF
--- a/src/sidebar/components/annotation-body.js
+++ b/src/sidebar/components/annotation-body.js
@@ -39,7 +39,7 @@ export default function AnnotationBody({
   const showTagList = !isEditing && tags.length > 0;
 
   return (
-    <section className="annotation-body">
+    <div className="annotation-body">
       {showExcerpt && (
         <Excerpt
           collapse={isCollapsed}
@@ -78,7 +78,7 @@ export default function AnnotationBody({
       )}
       {showTagList && <TagList annotation={annotation} tags={tags} />}
       {isEditing && <TagEditor onEditTags={onEditTags} tagList={tags} />}
-    </section>
+    </div>
   );
 }
 

--- a/src/sidebar/components/annotation-quote.js
+++ b/src/sidebar/components/annotation-quote.js
@@ -23,7 +23,7 @@ function AnnotationQuote({ annotation, isFocused, settings = {} }) {
   const documentLanguage = '';
 
   return (
-    <section
+    <div
       className={classnames('annotation-quote', {
         'is-orphan': isOrphan(annotation),
         'is-focused': isFocused,
@@ -43,7 +43,7 @@ function AnnotationQuote({ annotation, isFocused, settings = {} }) {
           {quote(annotation)}
         </blockquote>
       </Excerpt>
-    </section>
+    </div>
   );
 }
 

--- a/src/sidebar/components/annotation-user.js
+++ b/src/sidebar/components/annotation-user.js
@@ -39,7 +39,7 @@ function AnnotationUser({ annotation, features, serviceUrl, settings }) {
           target="_blank"
           rel="noopener noreferrer"
         >
-          <span className="annotation-user__user-name">{displayName}</span>
+          <h3 className="annotation-user__user-name">{displayName}</h3>
         </a>
       </div>
     );
@@ -47,7 +47,7 @@ function AnnotationUser({ annotation, features, serviceUrl, settings }) {
 
   return (
     <div className="annotation-user">
-      <span className="annotation-user__user-name">{displayName}</span>
+      <h3 className="annotation-user__user-name">{displayName}</h3>
     </div>
   );
 }

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -127,6 +127,7 @@ function SidebarContent({
 
   return (
     <div>
+      <h2 className="u-screen-reader-only">Annotations</h2>
       {isFocusedMode && <FocusedModeHeader />}
       <LoginPromptPanel onLogin={onLogin} onSignUp={onSignUp} />
       {hasDirectLinkedAnnotationError && (

--- a/src/sidebar/components/sidebar-panel.js
+++ b/src/sidebar/components/sidebar-panel.js
@@ -55,7 +55,7 @@ export default function SidebarPanel({
               <SvgIcon name={icon} title={title} />
             </div>
           )}
-          <div className="sidebar-panel__title u-stretch">{title}</div>
+          <h2 className="sidebar-panel__title u-stretch">{title}</h2>
           <div>
             <Button
               icon="cancel"

--- a/src/sidebar/components/test/thread-list-test.js
+++ b/src/sidebar/components/test/thread-list-test.js
@@ -214,13 +214,13 @@ describe('ThreadList', () => {
    * Get the blank spacer `<div>` that reserves space for non-rendered threads
    * above the viewport.
    */
-  const getUpperSpacer = wrapper => wrapper.find('div').first();
+  const getUpperSpacer = wrapper => wrapper.find('div > div').first();
 
   /**
    * Get the blank spacer `<div>` that reserves space for non-rendered threads
    * below the viewport.
    */
-  const getLowerSpacer = wrapper => wrapper.find('div').last();
+  const getLowerSpacer = wrapper => wrapper.find('div > div').last();
 
   it('renders dimensional elements above and below visible threads', () => {
     const wrapper = createComponent();

--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -174,7 +174,7 @@ function ThreadList({ thread, $rootScope }) {
   }, [visibleThreads]);
 
   return (
-    <section>
+    <div>
       <div style={{ height: offscreenUpperHeight }} />
       {visibleThreads.map(child => (
         <div className="thread-list__card" id={child.id} key={child.id}>
@@ -182,7 +182,7 @@ function ThreadList({ thread, $rootScope }) {
         </div>
       ))}
       <div style={{ height: offscreenLowerHeight }} />
-    </section>
+    </div>
   );
 }
 

--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -1,21 +1,5 @@
 @use '../variables' as var;
-
-// Hide content from sighted users but make it visible to screen readers.
-//
-// Resources:
-// - https://webaim.org/techniques/css/invisiblecontent/ (see "CSS clip")
-// - https://cloudfour.com/thinks/see-no-evil-hidden-content-and-accessibility/#showing-additional-content-for-screen-readers
-@mixin screen-reader-only {
-  // Take the content out of the normal layout flow.
-  position: absolute;
-
-  // Visually hide the content and prevent it from interfering with mouse/touch
-  // text selection by clipping it to an empty box. Compared to moving content with
-  // `top`/`left` this is less likely to cause the browser to scroll to a
-  // different part of the page when the hidden text has screen-reader focus.
-  clip: rect(0 0 0 0);
-  overflow: hidden;
-}
+@use "../mixins/a11y";
 
 // SVG highlights when the "Show Highlights" toggle is turned off.
 .hypothesis-svg-highlight {
@@ -47,14 +31,14 @@
     // Make highlights visible to screen readers.
     // See also - https://developer.paciellogroup.com/blog/2017/12/short-note-on-making-your-mark-more-accessible/.
     &::before {
-      @include screen-reader-only;
+      @include a11y.screen-reader-only;
 
       // nb. The leading/trailing spaces are intended to ensure the text is treated
       // as separate words by assisitve technologies from the content before/after it.
       content: ' annotation start ';
     }
     &::after {
-      @include screen-reader-only;
+      @include a11y.screen-reader-only;
       content: ' annotation end ';
     }
 

--- a/src/styles/mixins/a11y.scss
+++ b/src/styles/mixins/a11y.scss
@@ -1,0 +1,16 @@
+// Hide content from sighted users but make it visible to screen readers.
+//
+// Resources:
+// - https://webaim.org/techniques/css/invisiblecontent/ (see "CSS clip")
+// - https://cloudfour.com/thinks/see-no-evil-hidden-content-and-accessibility/#showing-additional-content-for-screen-readers
+@mixin screen-reader-only {
+  // Take the content out of the normal layout flow.
+  position: absolute;
+
+  // Visually hide the content and prevent it from interfering with mouse/touch
+  // text selection by clipping it to an empty box. Compared to moving content with
+  // `top`/`left` this is less likely to cause the browser to scroll to a
+  // different part of the page when the hidden text has screen-reader focus.
+  clip: rect(0 0 0 0);
+  overflow: hidden;
+}

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -94,6 +94,22 @@ blockquote {
   margin: 0;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font: inherit;
+  font-size: 100%;
+  font-weight: normal;
+  font-style: normal;
+  vertical-align: baseline;
+}
+
 // Custom elements
 markdown {
   display: block;

--- a/src/styles/util.scss
+++ b/src/styles/util.scss
@@ -1,3 +1,5 @@
+@use "./mixins/a11y";
+
 // Utility classes for layout
 .u-stretch {
   flex-grow: 1;
@@ -10,4 +12,8 @@
 
 .u-strong {
   font-weight: bold;
+}
+
+.u-screen-reader-only {
+  @include a11y.screen-reader-only;
 }


### PR DESCRIPTION
This PR improves document structure and outline by simplifying semantic elements and adding some heading elements.

It's easiest to see the effect by looking at what a document outline for a set of annotations with one expanded thread looks like before these changes:

<img width="584" alt="Screen Shot 2020-05-04 at 2 07 50 PM" src="https://user-images.githubusercontent.com/439947/80998380-e2911000-8e10-11ea-9807-c09ed5c3a73a.png">

And after:

<img width="802" alt="Screen Shot 2020-05-04 at 2 06 50 PM" src="https://user-images.githubusercontent.com/439947/80998389-e58c0080-8e10-11ea-9db0-b84d0429b341.png">

You'll notice a few areas that we could still improve:

* Establishing an `h1`
* Perhaps adding a heading element to thread sections

But I think this is getting us into a better spot.

Fixes #1927