### PR TITLE
Add word-break rule to prevent long-string overflows

### DIFF
--- a/src/styles/sidebar/components/markdown-view.scss
+++ b/src/styles/sidebar/components/markdown-view.scss
@@ -7,6 +7,7 @@
 
   // Prevent long URLs etc. in body causing overflow
   overflow-wrap: break-word;
+  word-break: break-word;
 
   // Margin between bottom of ascent of username and top of
   // x-height of annotation-body should be ~15px.


### PR DESCRIPTION
Add `div.annotation__content` and apply `word-break` and `overflow-wrap`
rules to prevent long strings of characters, e.g. URLs, from breaking
out of the sidebar width in replies.

Fixes https://github.com/hypothesis/support/issues/101

Before:

![image](https://user-images.githubusercontent.com/439947/81002239-e758c280-8e16-11ea-8761-312156049a95.png)

After:

<img width="426" alt="Screen Shot 2020-05-04 at 2 52 13 PM" src="https://user-images.githubusercontent.com/439947/81002256-ecb60d00-8e16-11ea-9a8b-09ea9355d757.png">
