### PR TITLE
Remove unused `USER_CHANGED` event

### DIFF
--- a/src/sidebar/events.js
+++ b/src/sidebar/events.js
@@ -5,8 +5,6 @@
 export default {
   // Session state changes
 
-  /** The logged-in user changed */
-  USER_CHANGED: 'userChanged',
   /**
    * API tokens were fetched and saved to local storage by another client
    * instance.

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -113,10 +113,6 @@ export default function session(
     lastLoadTime = Date.now();
 
     if (userChanged) {
-      $rootScope.$broadcast(events.USER_CHANGED, {
-        profile: model,
-      });
-
       // Associate error reports with the current user in Sentry.
       if (model.userid) {
         sentry.setUserInfo({

--- a/src/sidebar/services/test/session-test.js
+++ b/src/sidebar/services/test/session-test.js
@@ -198,15 +198,6 @@ describe('sidebar/services/session', function () {
   });
 
   describe('#update()', function () {
-    it('broadcasts USER_CHANGED when the user changes', function () {
-      const userChangeCallback = sinon.stub();
-      $rootScope.$on(events.USER_CHANGED, userChangeCallback);
-      session.update({
-        userid: 'fred',
-      });
-      assert.calledOnce(userChangeCallback);
-    });
-
     it('updates the user ID for Sentry error reports', function () {
       session.update({
         userid: 'anne',


### PR DESCRIPTION
All consumers of this event have now been migrated to watch
`store.profile()` and/or `store.hasFetchedProfile()` instead.

Part of https://github.com/hypothesis/client/issues/1994.