### PR TITLE
Hide the leave group button if allowLeavingGroups is false (1/2)

### DIFF
--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -22,9 +22,8 @@ function GroupListItem({
   onExpand,
   toastMessenger,
 }) {
-  const canLeaveGroup = group.type === 'private';
   const activityUrl = group.links.html;
-  const hasActionMenu = activityUrl || canLeaveGroup;
+  const hasActionMenu = activityUrl || group.canLeave;
   const isSelectable = !group.scopes.enforced || group.isScopedToUri;
 
   const focusedGroupId = useStore(store => store.focusedGroupId());
@@ -111,7 +110,7 @@ function GroupListItem({
                 />
               </li>
             )}
-            {canLeaveGroup && (
+            {group.canLeave && (
               <li>
                 <MenuItem
                   icon="leave"

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -26,6 +26,7 @@ describe('GroupListItem', () => {
         enforced: false,
       },
       type: 'private',
+      canLeave: true,
     };
 
     fakeStore = {
@@ -199,6 +200,7 @@ describe('GroupListItem', () => {
   it('does not show submenu toggle if there are no available actions', () => {
     fakeGroup.links.html = null;
     fakeGroup.type = 'open';
+    fakeGroup.canLeave = false;
     const wrapper = createGroupListItem(fakeGroup);
     assert.isFalse(wrapper.find('MenuItem').prop('isExpanded'));
   });
@@ -227,6 +229,7 @@ describe('GroupListItem', () => {
 
   it('does not show "Leave" action if user cannot leave', () => {
     fakeGroup.type = 'open';
+    fakeGroup.canLeave = false;
     const wrapper = createGroupListItem(fakeGroup, {
       isExpanded: true,
     });

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -342,7 +342,7 @@ export default function groups(
     // metadata on them that will be used elsewhere in the app.
     const isLoggedIn = token !== null;
     const groups = await filterGroups(
-      combineGroups(myGroups, featuredGroups, documentUri),
+      combineGroups(myGroups, featuredGroups, documentUri, settings),
       isLoggedIn,
       directLinkedAnnotationGroupId,
       directLinkedGroupId

--- a/src/sidebar/util/groups.js
+++ b/src/sidebar/util/groups.js
@@ -37,24 +37,19 @@ export function combineGroups(userGroups, featuredGroups, uri, settings) {
   const myGroupIds = userGroups.map(g => g.id);
   featuredGroups = featuredGroups.filter(g => !myGroupIds.includes(g.id));
 
+  // Set the isMember property indicating user membership.
+  featuredGroups.forEach(group => (group.isMember = false));
+  userGroups.forEach(group => (group.isMember = true));
+
+  const groups = userGroups.concat(featuredGroups);
+
   // Set the `canLeave` property. Groups can be left if they are private unless
   // the global `allowLeavingGroups` value is false in the config settings object.
-  const setCanLeave = group => {
+  groups.forEach(group => {
     group.canLeave = !allowLeavingGroups(settings)
       ? false
       : group.type === 'private';
-  };
-  // Set the isMember property indicating user membership.
-  featuredGroups.forEach(group => {
-    group.isMember = false;
-    setCanLeave(group);
   });
-  userGroups.forEach(group => {
-    group.isMember = true;
-    setCanLeave(group);
-  });
-
-  const groups = userGroups.concat(featuredGroups);
 
   // Add isScopedToUri property indicating whether a group is within scope
   // of the given uri. If the scope check cannot be performed, isScopedToUri

--- a/src/sidebar/util/groups.js
+++ b/src/sidebar/util/groups.js
@@ -2,23 +2,19 @@ import escapeStringRegexp from 'escape-string-regexp';
 import serviceConfig from '../service-config';
 
 /**
- * Returns the value for allowLeavingGroups from the service config
- * settings. By default this value is true. In that case, it is
- * intended that groups can be left if they are private. If this
- * value returns false, then the user can not leave any groups.
+ * Should users be able to leave private groups of which they
+ * are a member? Users may leave private groups unless
+ * explicitly disallowed in the service configuration of the
+ * `settings` object.
  *
  * @param {object} settings
  * @return {boolean}
  */
 function allowLeavingGroups(settings) {
-  const serviceConfig_ = serviceConfig(settings);
-  if (serviceConfig_ === null) {
-    return true;
-  }
-  if (typeof serviceConfig_.allowLeavingGroups !== 'boolean') {
-    return true;
-  }
-  return serviceConfig_.allowLeavingGroups;
+  const config = serviceConfig(settings) || {};
+  return typeof config.allowLeavingGroups === 'boolean'
+    ? config.allowLeavingGroups
+    : true;
 }
 
 /**

--- a/src/sidebar/util/test/groups-test.js
+++ b/src/sidebar/util/test/groups-test.js
@@ -9,6 +9,7 @@ describe('sidebar.util.groups', () => {
         '../service-config': fakeServiceConfig,
       });
     });
+
     it('labels groups in both lists as `isMember` true', () => {
       const userGroups = [{ id: 'groupa', name: 'GroupA' }];
       const featuredGroups = [{ id: 'groupa', name: 'GroupA' }];

--- a/src/sidebar/util/test/groups-test.js
+++ b/src/sidebar/util/test/groups-test.js
@@ -1,8 +1,15 @@
-import { combineGroups } from '../groups';
+import { combineGroups, $imports } from '../groups';
 
 describe('sidebar.util.groups', () => {
+  let fakeServiceConfig;
   describe('combineGroups', () => {
-    it('labels groups in both lists as isMember true', () => {
+    beforeEach(() => {
+      fakeServiceConfig = sinon.stub().returns(null);
+      $imports.$mock({
+        '../service-config': fakeServiceConfig,
+      });
+    });
+    it('labels groups in both lists as `isMember` true', () => {
       const userGroups = [{ id: 'groupa', name: 'GroupA' }];
       const featuredGroups = [{ id: 'groupa', name: 'GroupA' }];
       const groups = combineGroups(
@@ -12,6 +19,55 @@ describe('sidebar.util.groups', () => {
       );
       const groupA = groups.find(g => g.id === 'groupa');
       assert.equal(groupA.isMember, true);
+    });
+
+    it('sets `canLeave` to true if a group is private and `allowLeavingGroups` is null', () => {
+      const userGroups = [{ id: 'groupa', name: 'GroupA', type: 'private' }];
+      const featuredGroups = [{ id: 'groupb', name: 'GroupB', type: 'open' }];
+      const groups = combineGroups(
+        userGroups,
+        featuredGroups,
+        'https://foo.com/bar'
+      );
+      const groupA = groups.find(g => g.id === 'groupa');
+      const groupB = groups.find(g => g.id === 'groupb');
+      assert.equal(groupA.canLeave, true);
+      assert.equal(groupB.canLeave, false);
+    });
+
+    it('sets `canLeave` to true if a group is private and `allowLeavingGroups` is not a boolean', () => {
+      fakeServiceConfig.returns({
+        allowLeavingGroups: () => {},
+      });
+      const userGroups = [{ id: 'groupa', name: 'GroupA', type: 'private' }];
+      const featuredGroups = [{ id: 'groupb', name: 'GroupB', type: 'open' }];
+      const groups = combineGroups(
+        userGroups,
+        featuredGroups,
+        'https://foo.com/bar'
+      );
+      const groupA = groups.find(g => g.id === 'groupa');
+      const groupB = groups.find(g => g.id === 'groupb');
+
+      assert.equal(groupA.canLeave, true);
+      assert.equal(groupB.canLeave, false);
+    });
+
+    it('sets `canLeave` to false for all groups if `allowLeavingGroups` is false', () => {
+      fakeServiceConfig.returns({
+        allowLeavingGroups: false,
+      });
+      const userGroups = [{ id: 'groupa', name: 'GroupA', type: 'private' }];
+      const featuredGroups = [{ id: 'groupb', name: 'GroupB', type: 'open' }];
+      const groups = combineGroups(
+        userGroups,
+        featuredGroups,
+        'https://foo.com/bar'
+      );
+      const groupA = groups.find(g => g.id === 'groupa');
+      const groupB = groups.find(g => g.id === 'groupb');
+      assert.equal(groupA.canLeave, false);
+      assert.equal(groupB.canLeave, false);
     });
 
     it('combines groups from both lists uniquely', () => {
@@ -32,7 +88,7 @@ describe('sidebar.util.groups', () => {
       assert.deepEqual(ids, ['__world__', 'groupa', 'groupb']);
     });
 
-    it('adds isMember attribute to each group', () => {
+    it('adds `isMember` attribute to each group', () => {
       const userGroups = [{ id: 'groupa', name: 'GroupA' }];
       const featuredGroups = [
         { id: 'groupb', name: 'GroupB' },


### PR DESCRIPTION
allowLeavingGroups is a new service level config setting that can globally override the the UI to hide the leave button for a group. This is necessary for section groups in LMS where groups are indeed private, but also can’t be left.

---------
This is not entirely testable right now without mocking the service config as we don't actually pass allowLeavingGroups from LMS (yet). Note that second PR to follow this will do that.

Fixes https://github.com/hypothesis/client/issues/2084