### PR TITLE
Replace the `BEFORE_ANNOTATION_CREATED` event

### DIFF
--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -71,11 +71,20 @@ function ThreadList({ thread }) {
   );
 
   // Scroll to newly created annotations and replies.
+  //
+  // A side effect of the approach here is that if there are multiple unsaved
+  // annotations and the newest one is saved or removed, the thread list will
+  // scroll to the next unsaved one.
   const newAnnotationTag = useStore(store => {
-    const ann = store
+    // If multiple unsaved annotations exist, assume that the last one in the
+    // list is the most recently created one.
+    const newAnnotations = store
       .unsavedAnnotations()
-      .find(ann => !ann.id && !isHighlight(ann));
-    return ann ? ann.$tag : null;
+      .filter(ann => !ann.id && !isHighlight(ann));
+    if (!newAnnotations.length) {
+      return null;
+    }
+    return newAnnotations[newAnnotations.length - 1].$tag;
   });
 
   useEffect(() => {

--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -70,11 +70,7 @@ function ThreadList({ thread }) {
     [topLevelThreads, threadHeights, scrollPosition, scrollContainerHeight]
   );
 
-  // Scroll to newly created annotations and replies.
-  //
-  // A side effect of the approach here is that if there are multiple unsaved
-  // annotations and the newest one is saved or removed, the thread list will
-  // scroll to the next unsaved one.
+  // Get the `$tag` of the most recently created unsaved annotation.
   const newAnnotationTag = useStore(store => {
     // If multiple unsaved annotations exist, assume that the last one in the
     // list is the most recently created one.
@@ -87,6 +83,11 @@ function ThreadList({ thread }) {
     return newAnnotations[newAnnotations.length - 1].$tag;
   });
 
+  // Scroll to newly created annotations and replies.
+  //
+  // nb. If there are multiple unsaved annotations and the newest one is saved
+  // or removed, `newAnnotationTag` will revert to the previous unsaved annotation
+  // and the thread list will scroll to that.
   useEffect(() => {
     if (newAnnotationTag) {
       clearSelection();

--- a/src/sidebar/events.js
+++ b/src/sidebar/events.js
@@ -10,11 +10,4 @@ export default {
    * instance.
    */
   OAUTH_TOKENS_CHANGED: 'oauthTokensChanged',
-
-  // UI state changes
-
-  // Annotation events
-
-  /** A new annotation has been created locally. */
-  BEFORE_ANNOTATION_CREATED: 'beforeAnnotationCreated',
 };

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -1,7 +1,6 @@
 import debounce from 'lodash.debounce';
 
 import bridgeEvents from '../../shared/bridge-events';
-import events from '../events';
 import Discovery from '../../shared/discovery';
 import uiConstants from '../ui-constants';
 import * as metadata from '../util/annotation-metadata';
@@ -41,7 +40,7 @@ export function formatAnnot(ann) {
  * sidebar.
  */
 // @ngInject
-export default function FrameSync($rootScope, $window, store, bridge) {
+export default function FrameSync(annotationsService, bridge, store) {
   // Set of tags of annotations that are currently loaded into the frame
   const inFrame = new Set();
 
@@ -131,7 +130,9 @@ export default function FrameSync($rootScope, $window, store, bridge) {
         return;
       }
       inFrame.add(event.tag);
-      $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED, annot);
+
+      // Create the new annotation in the sidebar.
+      annotationsService.create(annot);
     });
 
     bridge.on('destroyFrame', destroyFrame.bind(this));

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -1,5 +1,4 @@
 import buildThread from '../build-thread';
-import events from '../events';
 import * as metadata from '../util/annotation-metadata';
 import memoize from '../util/memoize';
 import * as tabs from '../util/tabs';
@@ -38,7 +37,6 @@ const sortFns = {
  */
 // @ngInject
 export default function RootThread(
-  $rootScope,
   annotationsService,
   store,
   searchFilter,
@@ -97,10 +95,6 @@ export default function RootThread(
       threadFilterFn: threadFilterFn,
     });
   }
-
-  $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, function (event, ann) {
-    annotationsService.create(ann);
-  });
 
   /**
    * Build the root conversation thread from the given UI state.

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -1,6 +1,3 @@
-import EventEmitter from 'tiny-emitter';
-
-import events from '../../events';
 import { Injector } from '../../../shared/injector';
 import * as annotationFixtures from '../../test/annotation-fixtures';
 import uiConstants from '../../ui-constants';
@@ -22,13 +19,11 @@ const fixtures = immutable({
 
 describe('rootThread', function () {
   let fakeAnnotationsService;
-  let fakeStore;
   let fakeBuildThread;
   let fakeSearchFilter;
   let fakeSettings;
+  let fakeStore;
   let fakeViewFilter;
-
-  let $rootScope;
 
   let rootThread;
 
@@ -88,14 +83,7 @@ describe('rootThread', function () {
       filter: sinon.stub(),
     };
 
-    const emitter = new EventEmitter();
-    $rootScope = {
-      $on: (event, cb) => emitter.on(event, data => cb(null, data)),
-      $broadcast: (event, data) => emitter.emit(event, data),
-    };
-
     rootThread = new Injector()
-      .register('$rootScope', { value: $rootScope })
       .register('annotationsService', { value: fakeAnnotationsService })
       .register('store', { value: fakeStore })
       .register('searchFilter', { value: fakeSearchFilter })
@@ -353,46 +341,6 @@ describe('rootThread', function () {
         sinon.match([annotation]),
         filters
       );
-    });
-  });
-
-  context('when annotation events occur', function () {
-    const annot = annotationFixtures.defaultAnnotation();
-
-    it('creates a new annotation when BEFORE_ANNOTATION_CREATED event occurs', function () {
-      $rootScope.$broadcast(events.BEFORE_ANNOTATION_CREATED, annot);
-      assert.notCalled(fakeStore.removeAnnotations);
-      assert.calledWith(fakeAnnotationsService.create, sinon.match(annot));
-    });
-
-    describe('when a new annotation is created', function () {
-      let existingNewAnnot;
-      beforeEach(function () {
-        existingNewAnnot = { $tag: 'a-new-tag' };
-        fakeStore.state.annotations.annotations.push(existingNewAnnot);
-      });
-
-      it('does not remove annotations that have non-empty drafts', function () {
-        fakeStore.getDraftIfNotEmpty.returns(fixtures.nonEmptyDraft);
-        $rootScope.$broadcast(
-          events.BEFORE_ANNOTATION_CREATED,
-          annotationFixtures.newAnnotation()
-        );
-
-        assert.notCalled(fakeStore.removeDraft);
-      });
-
-      it('does not remove saved annotations', function () {
-        const ann = annotationFixtures.defaultAnnotation();
-        fakeStore.state.annotations.annotations = [ann];
-
-        $rootScope.$broadcast(
-          events.BEFORE_ANNOTATION_CREATED,
-          annotationFixtures.newAnnotation()
-        );
-
-        assert.notCalled(fakeStore.removeDraft);
-      });
     });
   });
 });

--- a/src/sidebar/store/modules/drafts.js
+++ b/src/sidebar/store/modules/drafts.js
@@ -1,3 +1,5 @@
+import { createSelector } from 'reselect';
+
 import * as metadata from '../../util/annotation-metadata';
 import * as util from '../util';
 
@@ -178,11 +180,10 @@ function getDraftIfNotEmpty(state, annotation) {
  *
  * @return {Object[]}
  */
-function unsavedAnnotations(state) {
-  return state.drafts
-    .filter(draft => !draft.annotation.id)
-    .map(draft => draft.annotation);
-}
+const unsavedAnnotations = createSelector(
+  state => state.drafts,
+  drafts => drafts.filter(d => !d.annotation.id).map(d => d.annotation)
+);
 
 export default {
   init,

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -52,13 +52,7 @@ describe('annotation threading', function () {
       flagEnabled: sinon.stub().returns(true),
     };
 
-    const fakeRootScope = {
-      $applyAsync: sinon.stub(),
-      $on: sinon.stub(),
-    };
-
     const container = new Injector()
-      .register('$rootScope', { value: fakeRootScope })
       .register('store', storeFactory)
       .register('rootThread', rootThreadFactory)
       .register('searchFilter', searchFilterFactory)


### PR DESCRIPTION
The `BEFORE_ANNOTATION_CREATED` event was used for two purposes:

 1. Invoke `annotationsService.create(...)` to create the annotation in
    the sidebar.
 2. Scroll the newly created annotation into view

Resolve (1) by calling `annotationsService.create` directly from the
`frameSync` service and resolve (2) by watching for changes to
`unsavedAnnotations()` in the store and scrolling to the new annotation
when it appears.

There is one functional change which is that replies will be scrolled
into view, as this seems like a useful behavior if the user clicks the
"Reply" button for a thread and the input field appears below the bottom
of the screen.

Part of https://github.com/hypothesis/client/issues/1994.