### PR TITLE
Satisfy a11y audit for `aria-label`, `aria-expanded` on <button> elements

### DIFF
--- a/src/annotator/components/adder-toolbar.js
+++ b/src/annotator/components/adder-toolbar.js
@@ -14,6 +14,7 @@ function ToolbarButton({ badgeCount, icon, label, onClick, shortcut }) {
     <button
       className="annotator-adder-actions__button"
       onClick={onClick}
+      aria-label={title}
       title={title}
     >
       {icon && <SvgIcon name={icon} />}

--- a/src/sidebar/components/annotation-body.js
+++ b/src/sidebar/components/annotation-body.js
@@ -31,10 +31,6 @@ export default function AnnotationBody({
   const [isCollapsible, setIsCollapsible] = useState(false);
 
   const toggleText = isCollapsed ? 'More' : 'Less';
-  const toggleTitle = isCollapsed
-    ? 'Show full annotation text'
-    : 'Show the first few lines only';
-
   const showExcerpt = !isEditing && text.length > 0;
   const showTagList = !isEditing && tags.length > 0;
 
@@ -69,10 +65,11 @@ export default function AnnotationBody({
       {isCollapsible && !isEditing && (
         <div className="annotation-body__collapse-toggle">
           <Button
-            className="annotation-body__collapse-toggle-button"
-            onClick={() => setIsCollapsed(!isCollapsed)}
             buttonText={toggleText}
-            title={toggleTitle}
+            className="annotation-body__collapse-toggle-button"
+            isExpanded={!isCollapsed}
+            onClick={() => setIsCollapsed(!isCollapsed)}
+            title="Toggle to show full annotation text"
           />
         </div>
       )}

--- a/src/sidebar/components/annotation-publish-control.js
+++ b/src/sidebar/components/annotation-publish-control.js
@@ -70,7 +70,6 @@ function AnnotationPublishControl({
           style={applyTheme(themeProps, settings)}
           onClick={onSave}
           disabled={isDisabled}
-          title={`Publish this annotation to ${publishDestination}`}
         >
           Post to {publishDestination}
         </button>

--- a/src/sidebar/components/button.js
+++ b/src/sidebar/components/button.js
@@ -21,6 +21,7 @@ export default function Button({
   className = '',
   disabled = false,
   icon = '',
+  isExpanded,
   isPressed,
   onClick = () => null,
   style = {},
@@ -39,6 +40,9 @@ export default function Button({
   if (typeof isPressed === 'boolean') {
     // Indicate that this is a toggle button.
     extraProps['aria-pressed'] = isPressed;
+  }
+  if (typeof isExpanded === 'boolean') {
+    extraProps['aria-expanded'] = isExpanded;
   }
 
   return (
@@ -109,6 +113,11 @@ Button.propTypes = {
    * provided.
    */
   icon: requiredStringIfButtonTextMissing,
+
+  /**
+   * Is the expandable element controlled by this button currently expanded?
+   */
+  isExpanded: propTypes.bool,
 
   /**
    * Indicate that this is a toggle button (if `isPressed` is a boolean) and

--- a/src/sidebar/components/button.js
+++ b/src/sidebar/components/button.js
@@ -59,6 +59,7 @@ export default function Button({
         className
       )}
       onClick={onClick}
+      aria-label={title}
       title={title}
       style={style}
       disabled={disabled}

--- a/src/sidebar/components/excerpt.js
+++ b/src/sidebar/components/excerpt.js
@@ -20,7 +20,8 @@ function InlineControls({ isCollapsed, setCollapsed, linkStyle = {} }) {
         <button
           className="excerpt__toggle-button"
           onClick={() => setCollapsed(!isCollapsed)}
-          aria-label="Toggle to show the full excerpt or first few lines only"
+          aria-expanded={!isCollapsed}
+          aria-label="Toggle to show the full excerpt"
           aria-pressed={(!isCollapsed).toString()}
           style={linkStyle}
         >

--- a/src/sidebar/components/markdown-editor.js
+++ b/src/sidebar/components/markdown-editor.js
@@ -119,6 +119,7 @@ function ToolbarButton({
       )}
       disabled={disabled}
       onClick={onClick}
+      aria-label={tooltip}
       title={tooltip}
       tabIndex={tabIndex}
       ref={buttonRef}

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -145,6 +145,7 @@ export default function Menu({
       <button
         aria-expanded={isOpen ? 'true' : 'false'}
         aria-haspopup={true}
+        aria-label={title}
         className="menu__toggle"
         onMouseDown={toggleMenu}
         onClick={toggleMenu}

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -239,6 +239,7 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
                 onClick={() => {
                   removeTag(tag);
                 }}
+                aria-label={`Remove Tag: ${tag}`}
                 title={`Remove Tag: ${tag}`}
                 className="tag-editor__delete"
               >

--- a/src/sidebar/components/test/annotation-body-test.js
+++ b/src/sidebar/components/test/annotation-body-test.js
@@ -65,7 +65,8 @@ describe('AnnotationBody', () => {
     const button = wrapper.find('Button');
     assert.isOk(button.exists());
     assert.equal(button.props().buttonText, 'More');
-    assert.equal(button.props().title, 'Show full annotation text');
+    assert.equal(button.props().title, 'Toggle to show full annotation text');
+    assert.isFalse(button.props().isExpanded);
   });
 
   it('shows appropriate button text to collapse the Excerpt if expanded', () => {
@@ -87,7 +88,8 @@ describe('AnnotationBody', () => {
     const buttonProps = wrapper.find('Button').props();
 
     assert.equal(buttonProps.buttonText, 'Less');
-    assert.equal(buttonProps.title, 'Show the first few lines only');
+    assert.equal(buttonProps.title, 'Toggle to show full annotation text');
+    assert.isTrue(buttonProps.isExpanded);
   });
 
   describe('tag list and editor', () => {

--- a/src/sidebar/components/test/annotation-publish-control-test.js
+++ b/src/sidebar/components/test/annotation-publish-control-test.js
@@ -95,10 +95,6 @@ describe('AnnotationPublishControl', () => {
         const wrapper = createAnnotationPublishControl();
 
         const btn = wrapper.find(btnClass);
-        assert.equal(
-          btn.prop('title'),
-          `Publish this annotation to ${fakeGroup.name}`
-        );
         assert.equal(btn.text(), `Post to ${fakeGroup.name}`);
       });
     });
@@ -111,7 +107,6 @@ describe('AnnotationPublishControl', () => {
         const wrapper = createAnnotationPublishControl();
 
         const btn = wrapper.find(btnClass);
-        assert.equal(btn.prop('title'), 'Publish this annotation to Only Me');
         assert.equal(btn.text(), 'Post to Only Me');
       });
     });

--- a/src/sidebar/components/test/button-test.js
+++ b/src/sidebar/components/test/button-test.js
@@ -41,6 +41,18 @@ describe('Button', () => {
     assert.equal(wrapper.find('SvgIcon').prop('name'), 'fakeIcon');
   });
 
+  [true, false].forEach(isExpanded => {
+    it('sets `aria-expanded` attribute if `isExpanded` is a boolean', () => {
+      const wrapper = createComponent({ isExpanded });
+      assert.equal(wrapper.find('button').prop('aria-expanded'), isExpanded);
+    });
+  });
+
+  it('does not set `aria-expanded` attribute if `isExpanded` is omitted', () => {
+    const wrapper = createComponent();
+    assert.notProperty(wrapper.find('button').props(), 'aria-expanded');
+  });
+
   [true, false].forEach(isPressed => {
     it('sets `aria-pressed` attribute if `isPressed` is a boolean', () => {
       const wrapper = createComponent({ isPressed });

--- a/src/sidebar/components/test/button-test.js
+++ b/src/sidebar/components/test/button-test.js
@@ -70,6 +70,11 @@ describe('Button', () => {
     assert.equal(wrapper.find('button').prop('title'), 'My Action');
   });
 
+  it('sets `aria-label` to provided `title` prop', () => {
+    const wrapper = createComponent({});
+    assert.equal(wrapper.find('button').prop('aria-label'), 'My Action');
+  });
+
   it('uses `buttonText` to set `title` attr if `title` missing', () => {
     const wrapper = createComponent({
       buttonText: 'My Label',


### PR DESCRIPTION
This PR gamely attempts to satisfy https://github.com/hypothesis/client/issues/2057 and https://github.com/hypothesis/client/issues/2056 in one go, as they both concern buttons.

* It makes the `title`/`aria-label` values for the buttons that control expanding/collapsing annotation quotes and body content static (`Toggle to show full content`) and adds an `aria-expanded` attribute to them. I've always found `aria-expanded` to be a confusing attribute as it can be applied to the control (e.g. button) _or_ the content being expanded. I chose the former in this case because the DOM relationship between the button and the expanded target is not simple (i.e. the expandable content doesn't directly follow the button in the DOM structure). In theory, one could use `aria-controls` to create a relationship between the button control and its target expandable element or element group, but this is [fraught with problems, per Heydon Pickering](https://heydonworks.com/article/aria-controls-is-poop/). I am, however, kind of exhausted and indifferent to `aria-*` attributes at this point, so will take feedback happily.
* To accomplish this (having an `aria-expanded` attribute on these buttons), I had to add an `isExpanded` prop to the `Button` component. I can already hear the groaning. _Yes_, `Button` and uses of `<button>` throughout the whole app desperately need review and refactor. But I didn't see a more expedient way to handle this right now.
* I duplicated `title` attributes on `<button>` elements (those not generated via  the `Button` component—yes, we are inconsistent) into `aria-label` in most places where such a change was easy. There are a couple of odd buttons not accounted for, for example the annotation-moderation buttons, which are just weird.

Fixes #2057 
Fixes #2056 

...I hope