### PR TITLE
Change show/hide sidebar button label depending on state

### DIFF
--- a/src/annotator/components/test/toolbar-test.js
+++ b/src/annotator/components/test/toolbar-test.js
@@ -66,7 +66,7 @@ describe('Toolbar', () => {
     assert.calledWith(toggleSidebar);
 
     wrapper.setProps({ isSidebarOpen: true });
-    findButton(wrapper, 'Show annotation sidebar').simulate('click');
+    findButton(wrapper, 'Hide annotation sidebar').simulate('click');
     assert.calledWith(toggleSidebar);
   });
 

--- a/src/annotator/components/toolbar.js
+++ b/src/annotator/components/toolbar.js
@@ -69,9 +69,12 @@ export default function Toolbar({
         <ToolbarButton
           extraClasses="annotator-frame-button--sidebar_toggle"
           buttonRef={toggleSidebarRef}
-          label="Show annotation sidebar"
+          label={
+            isSidebarOpen
+              ? 'Hide annotation sidebar'
+              : 'Show annotation sidebar'
+          }
           icon={isSidebarOpen ? 'h-icon-chevron-right' : 'h-icon-chevron-left'}
-          selected={isSidebarOpen}
           onClick={toggleSidebar}
         />
       )}


### PR DESCRIPTION
Change the sidebar toggle button from being a toggle button with the
label "Show annotation sidebar" to a normal button that changes between "Show
annotation sidebar" and "Hide annotation sidebar" labels.

WAI-ARIA guidelines [1] suggest that both are valid ways of implementing
toggle actions and looking around web and native apps on macOS one can
find plenty of both for similar actions. The one clear
requirement is to use a label change OR aria-pressed, but not both.

We think [2] a label change will make the state slightly easier to quickly
discern and it provides a more useful tooltip for sighted desktop users.

[1] https://www.w3.org/TR/wai-aria-practices-1.1/#button
[2] https://github.com/hypothesis/client/issues/2055#issuecomment-622512247

Fixes https://github.com/hypothesis/client/issues/2055