### PR TITLE
Add more properties to sample config in `dev-server`

### DIFF
--- a/scripts/gulp/dev-server.js
+++ b/scripts/gulp/dev-server.js
@@ -86,8 +86,11 @@ function DevServer(port, config) {
             var appHost = document.location.hostname;
 
             window.hypothesisConfig = function () {
+              // See https://h.readthedocs.io/projects/client/en/latest/publishers/config/
               return {
-                // Force into focused user mode
+                // enableExperimentalNewNoteButton: true,
+                // showHighlights: 'always',
+                // theme: 'clean',
 
                 // Example focused user mode
                 // focus: {
@@ -97,6 +100,13 @@ function DevServer(port, config) {
                 //     displayName: 'Foo Bar',
                 //   }
                 // },
+                // Example services config
+                // services: [{
+                //   apiUrl: 'http://localhost:5000/api',
+                //   authority: 'partner.org',
+                //   allowLeavingGroups: false,
+                //   groups: ['a-group-id', 'another-group-id'],
+                // }],
 
                 // Open the sidebar when the page loads
                 openSidebar: true,


### PR DESCRIPTION
For developer convenience, add a few more (commented-out) properties
to the config used by the local devserver, and link to more documentation.

This isn't exhaustive, but captures some properties that I find myself tinkering with from time to time.