### PR TITLE
Add `aria-label` and/or `title` to `<button>` elements

### DIFF
--- a/src/annotator/components/adder-toolbar.js
+++ b/src/annotator/components/adder-toolbar.js
@@ -14,6 +14,7 @@ function ToolbarButton({ badgeCount, icon, label, onClick, shortcut }) {
     <button
       className="annotator-adder-actions__button"
       onClick={onClick}
+      aria-label={title}
       title={title}
     >
       {icon && <SvgIcon name={icon} />}

--- a/src/sidebar/components/annotation-body.js
+++ b/src/sidebar/components/annotation-body.js
@@ -31,10 +31,6 @@ export default function AnnotationBody({
   const [isCollapsible, setIsCollapsible] = useState(false);
 
   const toggleText = isCollapsed ? 'More' : 'Less';
-  const toggleTitle = isCollapsed
-    ? 'Show full annotation text'
-    : 'Show the first few lines only';
-
   const showExcerpt = !isEditing && text.length > 0;
   const showTagList = !isEditing && tags.length > 0;
 
@@ -69,10 +65,11 @@ export default function AnnotationBody({
       {isCollapsible && !isEditing && (
         <div className="annotation-body__collapse-toggle">
           <Button
-            className="annotation-body__collapse-toggle-button"
-            onClick={() => setIsCollapsed(!isCollapsed)}
             buttonText={toggleText}
-            title={toggleTitle}
+            className="annotation-body__collapse-toggle-button"
+            isExpanded={!isCollapsed}
+            onClick={() => setIsCollapsed(!isCollapsed)}
+            title="Toggle to show full annotation text"
           />
         </div>
       )}

--- a/src/sidebar/components/annotation-publish-control.js
+++ b/src/sidebar/components/annotation-publish-control.js
@@ -70,6 +70,7 @@ function AnnotationPublishControl({
           style={applyTheme(themeProps, settings)}
           onClick={onSave}
           disabled={isDisabled}
+          aria-label={`Publish this annotation to ${publishDestination}`}
           title={`Publish this annotation to ${publishDestination}`}
         >
           Post to {publishDestination}

--- a/src/sidebar/components/button.js
+++ b/src/sidebar/components/button.js
@@ -21,6 +21,7 @@ export default function Button({
   className = '',
   disabled = false,
   icon = '',
+  isExpanded,
   isPressed,
   onClick = () => null,
   style = {},
@@ -39,6 +40,9 @@ export default function Button({
   if (typeof isPressed === 'boolean') {
     // Indicate that this is a toggle button.
     extraProps['aria-pressed'] = isPressed;
+  }
+  if (typeof isExpanded === 'boolean') {
+    extraProps['aria-expanded'] = isExpanded;
   }
 
   return (
@@ -109,6 +113,11 @@ Button.propTypes = {
    * provided.
    */
   icon: requiredStringIfButtonTextMissing,
+
+  /**
+   * Is the expandable element controlled by this button currently expanded?
+   */
+  isExpanded: propTypes.bool,
 
   /**
    * Indicate that this is a toggle button (if `isPressed` is a boolean) and

--- a/src/sidebar/components/button.js
+++ b/src/sidebar/components/button.js
@@ -37,6 +37,13 @@ export default function Button({
   const baseClassName = buttonText ? 'button--labeled' : 'button--icon-only';
 
   const extraProps = {};
+
+  // If there is no displayed text in the button, or if the provided `title`
+  // differs from the displayed text, add `aria-label` and `title` attributes
+  if (!buttonText || title !== buttonText) {
+    extraProps.title = title;
+    extraProps['aria-label'] = title;
+  }
   if (typeof isPressed === 'boolean') {
     // Indicate that this is a toggle button.
     extraProps['aria-pressed'] = isPressed;
@@ -59,7 +66,6 @@ export default function Button({
         className
       )}
       onClick={onClick}
-      title={title}
       style={style}
       disabled={disabled}
       {...extraProps}

--- a/src/sidebar/components/excerpt.js
+++ b/src/sidebar/components/excerpt.js
@@ -20,7 +20,8 @@ function InlineControls({ isCollapsed, setCollapsed, linkStyle = {} }) {
         <button
           className="excerpt__toggle-button"
           onClick={() => setCollapsed(!isCollapsed)}
-          aria-label="Toggle to show the full excerpt or first few lines only"
+          aria-expanded={!isCollapsed}
+          aria-label="Toggle to show the full excerpt"
           aria-pressed={(!isCollapsed).toString()}
           style={linkStyle}
         >

--- a/src/sidebar/components/markdown-editor.js
+++ b/src/sidebar/components/markdown-editor.js
@@ -119,6 +119,7 @@ function ToolbarButton({
       )}
       disabled={disabled}
       onClick={onClick}
+      aria-label={tooltip}
       title={tooltip}
       tabIndex={tabIndex}
       ref={buttonRef}

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -148,6 +148,7 @@ export default function Menu({
         className="menu__toggle"
         onMouseDown={toggleMenu}
         onClick={toggleMenu}
+        aria-label={title}
         title={title}
       >
         <span

--- a/src/sidebar/components/moderation-banner.js
+++ b/src/sidebar/components/moderation-banner.js
@@ -51,15 +51,16 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
   };
 
   const toggleButtonProps = (() => {
-    const props = {};
+    const buttonProps = {};
     if (annotation.hidden) {
-      props.onClick = unhideAnnotation;
-      props.title = 'Make this annotation visible to everyone';
+      buttonProps.onClick = unhideAnnotation;
+      buttonProps.title = 'Make this annotation visible to everyone';
     } else {
-      props.onClick = hideAnnotation;
-      props.title = 'Hide this annotation from non-moderators';
+      buttonProps.onClick = hideAnnotation;
+      buttonProps.title = 'Hide this annotation from non-moderators';
     }
-    return props;
+    buttonProps['aria-label'] = buttonProps.title;
+    return buttonProps;
   })();
 
   const bannerClasses = classnames('moderation-banner', {

--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -13,7 +13,14 @@ import SvgIcon from '../../shared/components/svg-icon';
 /**
  *  Display name of the tab and annotation count.
  */
-function Tab({ children, count, isWaitingToAnchor, isSelected, onSelect }) {
+function Tab({
+  children,
+  count,
+  isWaitingToAnchor,
+  isSelected,
+  label,
+  onSelect,
+}) {
   const selectTab = () => {
     if (!isSelected) {
       onSelect();
@@ -32,6 +39,8 @@ function Tab({ children, count, isWaitingToAnchor, isSelected, onSelect }) {
       onMouseDown={selectTab}
       role="tab"
       tabIndex="0"
+      title={label}
+      aria-label={label}
       aria-selected={isSelected.toString()}
     >
       {children}
@@ -59,6 +68,10 @@ Tab.propTypes = {
    * Are there any annotations still waiting to anchor?
    */
   isWaitingToAnchor: propTypes.bool.isRequired,
+  /**
+   * A string label to use for `aria-label` and `title`
+   */
+  label: propTypes.string.isRequired,
   /**
    * Callback to invoke when this tab is selected.
    */
@@ -110,6 +123,7 @@ function SelectionTabs({ isLoading, settings }) {
           count={annotationCount}
           isWaitingToAnchor={isWaitingToAnchorAnnotations}
           isSelected={selectedTab === uiConstants.TAB_ANNOTATIONS}
+          label="Select annotations tab"
           onSelect={() => selectTab(uiConstants.TAB_ANNOTATIONS)}
         >
           Annotations
@@ -118,6 +132,7 @@ function SelectionTabs({ isLoading, settings }) {
           count={noteCount}
           isWaitingToAnchor={isWaitingToAnchorAnnotations}
           isSelected={selectedTab === uiConstants.TAB_NOTES}
+          label="Select page notes tab"
           onSelect={() => selectTab(uiConstants.TAB_NOTES)}
         >
           Page Notes
@@ -127,6 +142,7 @@ function SelectionTabs({ isLoading, settings }) {
             count={orphanCount}
             isWaitingToAnchor={isWaitingToAnchorAnnotations}
             isSelected={selectedTab === uiConstants.TAB_ORPHANS}
+            label="Select orphans tab"
             onSelect={() => selectTab(uiConstants.TAB_ORPHANS)}
           >
             Orphans

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -239,6 +239,7 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
                 onClick={() => {
                   removeTag(tag);
                 }}
+                aria-label={`Remove Tag: ${tag}`}
                 title={`Remove Tag: ${tag}`}
                 className="tag-editor__delete"
               >

--- a/src/sidebar/components/test/annotation-body-test.js
+++ b/src/sidebar/components/test/annotation-body-test.js
@@ -65,7 +65,8 @@ describe('AnnotationBody', () => {
     const button = wrapper.find('Button');
     assert.isOk(button.exists());
     assert.equal(button.props().buttonText, 'More');
-    assert.equal(button.props().title, 'Show full annotation text');
+    assert.equal(button.props().title, 'Toggle to show full annotation text');
+    assert.isFalse(button.props().isExpanded);
   });
 
   it('shows appropriate button text to collapse the Excerpt if expanded', () => {
@@ -87,7 +88,8 @@ describe('AnnotationBody', () => {
     const buttonProps = wrapper.find('Button').props();
 
     assert.equal(buttonProps.buttonText, 'Less');
-    assert.equal(buttonProps.title, 'Show the first few lines only');
+    assert.equal(buttonProps.title, 'Toggle to show full annotation text');
+    assert.isTrue(buttonProps.isExpanded);
   });
 
   describe('tag list and editor', () => {

--- a/src/sidebar/components/test/button-test.js
+++ b/src/sidebar/components/test/button-test.js
@@ -65,18 +65,48 @@ describe('Button', () => {
     assert.notProperty(wrapper.find('button').props(), 'aria-pressed');
   });
 
-  it('sets `title` to provided `title` prop', () => {
-    const wrapper = createComponent({});
-    assert.equal(wrapper.find('button').prop('title'), 'My Action');
-  });
-
-  it('uses `buttonText` to set `title` attr if `title` missing', () => {
-    const wrapper = createComponent({
-      buttonText: 'My Label',
-      title: undefined,
+  describe('`title` and `aria-label` attributes', () => {
+    it('sets attrs to provided `title` prop', () => {
+      const wrapper = createComponent({});
+      assert.equal(wrapper.find('button').prop('title'), 'My Action');
+      assert.equal(wrapper.find('button').prop('aria-label'), 'My Action');
     });
 
-    assert.equal(wrapper.find('button').prop('title'), 'My Label');
+    it('sets attrs if `title` is different than `buttonText`', () => {
+      const wrapper = createComponent({
+        buttonText: 'My Label',
+        title: 'Click here to do something',
+      });
+
+      assert.equal(
+        wrapper.find('button').prop('title'),
+        'Click here to do something'
+      );
+      assert.equal(
+        wrapper.find('button').prop('aria-label'),
+        'Click here to do something'
+      );
+    });
+
+    it('does not set attrs if no `title` provided and `buttonText` present', () => {
+      const wrapper = createComponent({
+        buttonText: 'My Label',
+        title: undefined,
+      });
+
+      assert.notProperty(wrapper.find('button').props(), 'title');
+      assert.notProperty(wrapper.find('button').props(), 'aria-label');
+    });
+
+    it('does not set attrs if `title` is the same as `buttonText`', () => {
+      const wrapper = createComponent({
+        buttonText: 'My Label',
+        title: 'My Label',
+      });
+
+      assert.notProperty(wrapper.find('button').props(), 'title');
+      assert.notProperty(wrapper.find('button').props(), 'aria-label');
+    });
   });
 
   it('invokes `onClick` callback when pressed', () => {

--- a/src/sidebar/components/test/button-test.js
+++ b/src/sidebar/components/test/button-test.js
@@ -41,6 +41,18 @@ describe('Button', () => {
     assert.equal(wrapper.find('SvgIcon').prop('name'), 'fakeIcon');
   });
 
+  [true, false].forEach(isExpanded => {
+    it('sets `aria-expanded` attribute if `isExpanded` is a boolean', () => {
+      const wrapper = createComponent({ isExpanded });
+      assert.equal(wrapper.find('button').prop('aria-expanded'), isExpanded);
+    });
+  });
+
+  it('does not set `aria-expanded` attribute if `isExpanded` is omitted', () => {
+    const wrapper = createComponent();
+    assert.notProperty(wrapper.find('button').props(), 'aria-expanded');
+  });
+
   [true, false].forEach(isPressed => {
     it('sets `aria-pressed` attribute if `isPressed` is a boolean', () => {
       const wrapper = createComponent({ isPressed });

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -106,6 +106,20 @@ describe('SelectionTabs', function () {
       assert.equal(tabs.length, 2);
     });
 
+    it('should render `title` and `aria-label` attributes for tab buttons', () => {
+      fakeStore.orphanCount.returns(1);
+      const wrapper = createComponent({});
+
+      const tabs = wrapper.find('button');
+
+      assert.equal(tabs.at(0).prop('aria-label'), 'Select annotations tab');
+      assert.equal(tabs.at(0).prop('title'), 'Select annotations tab');
+      assert.equal(tabs.at(1).prop('aria-label'), 'Select page notes tab');
+      assert.equal(tabs.at(1).prop('title'), 'Select page notes tab');
+      assert.equal(tabs.at(2).prop('aria-label'), 'Select orphans tab');
+      assert.equal(tabs.at(2).prop('title'), 'Select orphans tab');
+    });
+
     it('should show the clean theme when settings contains the clean theme option', function () {
       fakeSettings.theme = 'clean';
       const wrapper = createComponent();


### PR DESCRIPTION
Hopefully, third time's the charm here, and with luck:

Fixes: https://github.com/hypothesis/client/issues/2056

This PR adds `aria-label` attributes to `<button>` elements when their title/label differs from the displayed button text or if there is no button text.

Depends on #2130  