### PR TITLE
Make menu section heading slightly darker

### DIFF
--- a/src/styles/sidebar/components/menu-section.scss
+++ b/src/styles/sidebar/components/menu-section.scss
@@ -5,7 +5,7 @@
 }
 
 .menu-section__heading {
-  color: var.$grey-semi;
+  color: var.$grey-5;
   font-size: var.$body1-font-size;
   line-height: 1;
   margin: 1px 1px 0;


### PR DESCRIPTION
Per the useful notes in `variables.scss`, $grey-5 is the lightest grey
that can be used on a white background for the text to meet WCAG
contrast requirements. This change also makes menu section headings more
consistent with other text in the sidebar.