### PR TITLE
Attempt to squelch spurious tiny codecov failures by setting threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        # prevent spurious codecov errors resulting from tiny fluctuations
+        threshold: 0.1%


### PR DESCRIPTION
This PR adds a `codecov` config to the project with a `threshold` value. This is to attempt to squelch spurious `codecov` failures during CI—these failures are not meaningful but result from rounding or precision issues when codecov calculates coverage (typically they manifest as `+/-0.01%`).

This is one approach to help with taming `codecov`. We'll have to see if it helps. 