### PR TITLE
SvgIcon changes

### DIFF
--- a/src/shared/components/svg-icon.js
+++ b/src/shared/components/svg-icon.js
@@ -20,6 +20,10 @@ let iconRegistry = {};
  * Component that renders icons using inline `<svg>` elements.
  * This enables their appearance to be customized via CSS.
  *
+ * Supply either a registerer icon `name` or a trusted SVG object
+ * to the `src` prop.
+ * a
+ *
  * This matches the way we do icons on the website, see
  * https://github.com/hypothesis/h/pull/3675
  */
@@ -27,12 +31,29 @@ export default function SvgIcon({
   name,
   className = '',
   inline = false,
+  src,
   title = '',
 }) {
-  if (!iconRegistry[name]) {
-    throw new Error(`Icon name "${name}" is not registered`);
+  let markup;
+
+  // Registered icon
+  if (name) {
+    if (!iconRegistry[name]) {
+      throw new Error(`Icon name "${name}" is not registered`);
+    }
+    markup = { __html: iconRegistry[name] };
   }
-  const markup = { __html: iconRegistry[name] };
+  // Trusted icon
+  else if (src) {
+    if (!src.trustedHTML) {
+      throw new Error(
+        'Un-trusted resource passed to SvgIcon. If this is a valid SVG, use the `trustMarkup` wrapper.'
+      );
+    }
+    markup = { __html: src.trustedHTML };
+  } else {
+    throw new Error('Either `svg` or `name` must be supplied');
+  }
 
   const element = useRef();
   useLayoutEffect(() => {
@@ -74,6 +95,11 @@ SvgIcon.propTypes = {
 
   /** Apply a style allowing for inline display of icon wrapper */
   inline: propTypes.bool,
+
+  /** Imported SVG resource with a trusted wrapper. */
+  src: propTypes.shape({
+    trustedHTML: propTypes.string,
+  }),
 
   /** Optional title attribute to apply to the SVG's containing `span` */
   title: propTypes.string,

--- a/src/shared/components/test/svg-icon-test.js
+++ b/src/shared/components/test/svg-icon-test.js
@@ -1,6 +1,9 @@
 import { createElement, render } from 'preact';
 
 import SvgIcon, { availableIcons, registerIcons } from '../svg-icon';
+import { trustMarkup } from '../../trusted';
+
+import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('SvgIcon', () => {
   // Tests here use DOM APIs rather than Enzyme because SvgIcon uses
@@ -9,6 +12,12 @@ describe('SvgIcon', () => {
 
   // Global icon set that is registered with `SvgIcon` outside of these tests.
   let savedIconSet;
+  const unTrustedSvg = {
+    untrusted: require('../../../images/icons/collapse-menu.svg'),
+  };
+  const trustedSvg = trustMarkup(
+    require('../../../images/icons/collapse-menu.svg')
+  );
 
   beforeEach(() => {
     savedIconSet = availableIcons();
@@ -27,68 +36,103 @@ describe('SvgIcon', () => {
     registerIcons(savedIconSet, { reset: true });
   });
 
-  it("sets the element's content to the content of the SVG", () => {
-    const container = document.createElement('div');
-    render(<SvgIcon name="refresh" />, container);
-    assert.ok(container.querySelector('svg'));
-  });
-
-  it('throws an error if the icon name is not registered', () => {
-    assert.throws(() => {
+  describe('registered icons', () => {
+    it("sets the element's content to the content of the SVG", () => {
       const container = document.createElement('div');
-      render(<SvgIcon name="unknown" />, container);
-    }, 'Icon name "unknown" is not registered');
+      render(<SvgIcon name="refresh" />, container);
+      assert.ok(container.querySelector('svg'));
+    });
+
+    it('throws an error if the icon name is not registered', () => {
+      assert.throws(() => {
+        const container = document.createElement('div');
+        render(<SvgIcon name="unknown" />, container);
+      }, 'Icon name "unknown" is not registered');
+    });
+
+    it('does not set the class of the SVG by default', () => {
+      const container = document.createElement('div');
+      render(<SvgIcon name="refresh" />, container);
+      const svg = container.querySelector('svg');
+      assert.equal(svg.getAttribute('class'), '');
+    });
+
+    it('sets the class of the SVG if provided', () => {
+      const container = document.createElement('div');
+      render(<SvgIcon name="refresh" className="thing__icon" />, container);
+      const svg = container.querySelector('svg');
+      assert.equal(svg.getAttribute('class'), 'thing__icon');
+    });
+
+    it('retains the CSS class if the icon changes', () => {
+      const container = document.createElement('div');
+      render(<SvgIcon name="expand-menu" className="thing__icon" />, container);
+      render(
+        <SvgIcon name="collapse-menu" className="thing__icon" />,
+        container
+      );
+      const svg = container.querySelector('svg');
+      assert.equal(svg.getAttribute('class'), 'thing__icon');
+    });
+
+    it('sets a default class on the wrapper element', () => {
+      const container = document.createElement('div');
+      render(<SvgIcon name="expand-menu" />, container);
+      const wrapper = container.querySelector('span');
+      assert.isTrue(wrapper.classList.contains('svg-icon'));
+      assert.isFalse(wrapper.classList.contains('svg-icon--inline'));
+    });
+
+    it('appends an inline class to wrapper if `inline` prop is `true`', () => {
+      const container = document.createElement('div');
+      render(<SvgIcon name="expand-menu" inline={true} />, container);
+      const wrapper = container.querySelector('span');
+      assert.isTrue(wrapper.classList.contains('svg-icon'));
+      assert.isTrue(wrapper.classList.contains('svg-icon--inline'));
+    });
+
+    it('sets a title to the containing `span` element if `title` is present', () => {
+      const container = document.createElement('div');
+      render(<SvgIcon name="expand-menu" title="Open menu" />, container);
+      const wrapper = container.querySelector('span');
+      assert.equal(wrapper.getAttribute('title'), 'Open menu');
+    });
+
+    it('sets does not set a title on the containing `span` element if `title` not present', () => {
+      const container = document.createElement('div');
+      render(<SvgIcon name="expand-menu" />, container);
+      const wrapper = container.querySelector('span');
+      assert.notOk(wrapper.getAttribute('title'));
+    });
   });
 
-  it('does not set the class of the SVG by default', () => {
-    const container = document.createElement('div');
-    render(<SvgIcon name="refresh" />, container);
-    const svg = container.querySelector('svg');
-    assert.equal(svg.getAttribute('class'), '');
+  describe('trusted icon objects', () => {
+    it("sets the element's content to the content of the trusted SVG", () => {
+      const container = document.createElement('div');
+      render(<SvgIcon src={trustedSvg} />, container);
+      assert.ok(container.querySelector('svg'));
+    });
+
+    it('throws an error if the icon is unknown', () => {
+      assert.throws(() => {
+        const container = document.createElement('div');
+        render(<SvgIcon />, container);
+      });
+    });
+
+    it('throws an error if the icon is un-trusted svg', () => {
+      assert.throws(() => {
+        const container = document.createElement('div');
+        render(<SvgIcon src={unTrustedSvg} />, container);
+      });
+    });
   });
 
-  it('sets the class of the SVG if provided', () => {
-    const container = document.createElement('div');
-    render(<SvgIcon name="refresh" className="thing__icon" />, container);
-    const svg = container.querySelector('svg');
-    assert.equal(svg.getAttribute('class'), 'thing__icon');
-  });
-
-  it('retains the CSS class if the icon changes', () => {
-    const container = document.createElement('div');
-    render(<SvgIcon name="expand-menu" className="thing__icon" />, container);
-    render(<SvgIcon name="collapse-menu" className="thing__icon" />, container);
-    const svg = container.querySelector('svg');
-    assert.equal(svg.getAttribute('class'), 'thing__icon');
-  });
-
-  it('sets a default class on the wrapper element', () => {
-    const container = document.createElement('div');
-    render(<SvgIcon name="expand-menu" />, container);
-    const wrapper = container.querySelector('span');
-    assert.isTrue(wrapper.classList.contains('svg-icon'));
-    assert.isFalse(wrapper.classList.contains('svg-icon--inline'));
-  });
-
-  it('appends an inline class to wrapper if `inline` prop is `true`', () => {
-    const container = document.createElement('div');
-    render(<SvgIcon name="expand-menu" inline={true} />, container);
-    const wrapper = container.querySelector('span');
-    assert.isTrue(wrapper.classList.contains('svg-icon'));
-    assert.isTrue(wrapper.classList.contains('svg-icon--inline'));
-  });
-
-  it('sets a title to the containing `span` element if `title` is present', () => {
-    const container = document.createElement('div');
-    render(<SvgIcon name="expand-menu" title="Open menu" />, container);
-    const wrapper = container.querySelector('span');
-    assert.equal(wrapper.getAttribute('title'), 'Open menu');
-  });
-
-  it('sets does not set a title on the containing `span` element if `title` not present', () => {
-    const container = document.createElement('div');
-    render(<SvgIcon name="expand-menu" />, container);
-    const wrapper = container.querySelector('span');
-    assert.notOk(wrapper.getAttribute('title'));
-  });
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      // eslint-disable-next-line react/display-name
+      content: () => <SvgIcon src={trustedSvg} />,
+    })
+  );
 });

--- a/src/shared/components/test/svg-icon-test.js
+++ b/src/shared/components/test/svg-icon-test.js
@@ -120,7 +120,7 @@ describe('SvgIcon', () => {
       });
     });
 
-    it('throws an error if the icon is un-trusted svg', () => {
+    it('throws an error if the icon is an un-trusted svg', () => {
       assert.throws(() => {
         const container = document.createElement('div');
         render(<SvgIcon src={unTrustedSvg} />, container);

--- a/src/shared/test/trusted-test.js
+++ b/src/shared/test/trusted-test.js
@@ -1,0 +1,9 @@
+import { trustMarkup } from '../trusted';
+
+describe('trustMarkup', () => {
+  it('returns the provided object wrapped in a key called `trustedHTML`', () => {
+    assert.match(trustMarkup('some object'), {
+      trustedHTML: 'some object',
+    });
+  });
+});

--- a/src/shared/trusted.js
+++ b/src/shared/trusted.js
@@ -1,0 +1,12 @@
+/**
+ * Wrap `markup` to indicate that it came from a trusted source
+ * (ie. not unsanitized user input)
+ *
+ * @param  {string} markup - Resource object to wrap
+ * @return {object} - An object with a  `trustedHTML` property whose value is `markup`.
+ */
+function trustMarkup(markup) {
+  return { trustedHTML: markup };
+}
+
+export { trustMarkup };


### PR DESCRIPTION
- Add ability for SvgIcon to use a trusted icon directly. This serves 2 purposes along with being aligned with LMS.

- 1. It is more readable to have the icon path used in place rather than a level of indirection from a registered name in another file.
- 2. Keeping track of abandoned icons should be easier because searching for a path and ".svg" suffix is a lot easier than a name that could be very common such as "groups" -- which is a real icon.

See https://github.com/hypothesis/lms/blob/master/lms/static/scripts/frontend_apps/components/SvgIcon.js

To the best of my knowledge, `require` will cache the file so even through we may call it more than once on the same SVG, there should not be a significate performance hit for doing that relative to a single registered icon file.

If we like this, then going forward, we can convert to using trustMarkup and remove `icon.js` when finished. 


**current**

icons.js
```
export default {
...
spinner: require('../images/icons/spinner.svg'),
}
```
component
```
<SvgIcon
    name="spinner"
    />
```


**changed**

component
```
import { trustMarkup } from '../utils/trusted';

<SvgIcon
      src={trustMarkup(require('../../../images/spinner.svg'))}
    />
```

fixes https://github.com/hypothesis/client/issues/2053