### PR TITLE
Override `<button>` padding from page styles in toolbar

### DIFF
--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -111,6 +111,7 @@ $sidebar-collapse-transition-time: 150ms;
     text-decoration: none;
     height: 30px;
     width: 30px;
+    padding: 1px 6px;
     margin-bottom: 5px;
 
     &:active {


### PR DESCRIPTION
Revert to hard-coded padding for the toolbar buttons to override any
default padding the page may have for `<button>` elements. This affects
PDF.js amongst other apps/sites. Instead of setting the padding to 0 as
before, set it to `1px 6px` which matches Chrome's defaults that looked
reasonable.

A better solution will be to use Shadow DOM for the whole sidebar UI,
but that is a larger change.