### PR TITLE
Add negative top margin to “show x more in conversation” buttons

### DIFF
--- a/src/sidebar/components/thread.js
+++ b/src/sidebar/components/thread.js
@@ -81,6 +81,7 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
         {showHiddenToggle && (
           <Button
             buttonText={`Show ${countHidden(thread)} more in conversation`}
+            className="thread__hidden-toggle-button"
             onClick={() => threadsService.forceVisible(thread)}
           />
         )}

--- a/src/styles/sidebar/components/thread.scss
+++ b/src/styles/sidebar/components/thread.scss
@@ -50,6 +50,11 @@
       }
     }
   }
+  &__hidden-toggle-button {
+    // This makes the vertical alignment with thread-collapse chevrons
+    // more precise
+    margin-top: -0.25em;
+  }
 
   &__content {
     flex-grow: 1;


### PR DESCRIPTION
Fine-tune the vertical alignment of the “Show x more in conversation”
hidden-thread toggling buttons so that they better align with thread
toggle chevrons.

It's fairly subtle, but the vertical alignment was a bit off.

Before:

![image](https://user-images.githubusercontent.com/439947/81602504-bdfde080-939a-11ea-9df7-a5ac7027006c.png)

After:

<img width="406" alt="Screen Shot 2020-05-11 at 3 16 51 PM" src="https://user-images.githubusercontent.com/439947/81602538-cb1acf80-939a-11ea-9630-a1ebf4aace36.png">


Fixes #2097