### PR TITLE
Remove unused annotator CSS

### DIFF
--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -17,15 +17,19 @@ $sidebar-collapse-transition-time: 150ms;
 
 // Sidebar
 .annotator-frame {
-  // a CSS reset which attempts to prevent the host page's styles
-  // from affecting the styles of the sidebar.
-  //
-  // FIXME - This component and other annotator components which currently
-  // live on the page could be isolated from the host page's CSS/JS via
-  // transparent same-origin iframes
+  // CSS reset which attempts to isolate this element and its children from
+  // host page styles.
   @include meta.load-css('../reset');
   @include reset.nested-reset;
   @include reset.reset-box-model;
+
+  * {
+    background: none;
+    font-size: 100%;
+    text-indent: 0;
+    height: initial;
+    width: initial;
+  }
 
   // frame styles
   user-select: none;
@@ -52,14 +56,6 @@ $sidebar-collapse-transition-time: 150ms;
     }
   }
 
-  * {
-    background: none;
-    font-size: 100%;
-    text-indent: 0;
-    height: initial;
-    width: initial;
-  }
-
   .h-sidebar-iframe {
     border: none;
     height: 100%;
@@ -81,17 +77,6 @@ $sidebar-collapse-transition-time: 150ms;
     left: -(var.$bucket-bar-width + 18px - 7px);
     width: 37px;
     z-index: 2;
-
-    ul {
-      height: 100%;
-    }
-
-    ul,
-    li {
-      box-sizing: border-box;
-      list-style: none;
-      @include reset.reset-box-model;
-    }
   }
 
   .annotator-frame-button {
@@ -158,11 +143,6 @@ $sidebar-collapse-transition-time: 150ms;
   transition: none !important;
 }
 
-.annotator-hide {
-  display: none;
-  visibility: hidden;
-}
-
 /*
   Mobile layout
   240-479 px
@@ -202,22 +182,4 @@ $sidebar-collapse-transition-time: 150ms;
     width: 428px;
     margin-left: -428px;
   }
-}
-
-/*
-  Widescreen layout
-  912-1887 px
-  Zoomed in above 912 px
-*/
-
-@media screen and (min-width: 57em) {
-}
-
-/*
-  Huge-screen layout
-  1888-2520 px
-  Zoomed in above 1920 px
-*/
-
-@media screen and (min-width: 118em) {
 }


### PR DESCRIPTION
Remove several unused classes and styles and group all the CSS reset style rules for `.annotator-frame` together.