### PR TITLE
requestGroups RPC call should not timeout

### DIFF
--- a/src/sidebar/util/fetch-config.js
+++ b/src/sidebar/util/fetch-config.js
@@ -160,8 +160,9 @@ async function fetchGroupsAsync(config, rpcCall) {
   if (Array.isArray(config.services)) {
     config.services.forEach((service, index) => {
       if (service.groups === '$rpc:requestGroups') {
-        // The `groups` need to be fetched from a secondary RPC call
-        service.groups = rpcCall('requestGroups', [index], 5000).catch(() => {
+        // The `groups` need to be fetched from a secondary RPC call and
+        // there should be no timeout as it may be waiting for user input.
+        service.groups = rpcCall('requestGroups', [index], null).catch(() => {
           throw new Error('Unable to fetch groups');
         });
       }

--- a/src/sidebar/util/postmessage-json-rpc.js
+++ b/src/sidebar/util/postmessage-json-rpc.js
@@ -80,16 +80,16 @@ export function call(
     window_.addEventListener('message', listener);
   });
 
-  const raceConditions = [response];
+  const responseOrTimeout = [response];
   if (timeout) {
-    raceConditions.push(
+    responseOrTimeout.push(
       createTimeout(timeout, `Request to ${origin} timed out`)
     );
   }
 
   // Cleanup and return.
   // FIXME: If we added a `Promise.finally` polyfill we could simplify this.
-  return Promise.race(raceConditions)
+  return Promise.race(responseOrTimeout)
     .then(result => {
       window_.removeEventListener('message', listener);
       return result;

--- a/src/sidebar/util/test/fetch-config-test.js
+++ b/src/sidebar/util/test/fetch-config-test.js
@@ -257,7 +257,7 @@ describe('sidebar.util.fetch-config', () => {
             'https://embedder.com',
             'requestGroups',
             [0], // passes service index to requestGroups
-            5000
+            null // no timeout
           )
         );
       });

--- a/src/sidebar/util/test/postmessage-json-rpc-test.js
+++ b/src/sidebar/util/test/postmessage-json-rpc-test.js
@@ -18,14 +18,14 @@ describe('sidebar.util.postmessage-json-rpc', () => {
     let frame;
     let fakeWindow;
 
-    function doCall() {
-      const timeout = 1;
+    function doCall(timeout = 1) {
+      const _timeout = timeout;
       return call(
         frame,
         origin,
         'testMethod',
         [1, 2, 3],
-        timeout,
+        _timeout,
         fakeWindow,
         messageId
       );
@@ -145,6 +145,22 @@ describe('sidebar.util.postmessage-json-rpc', () => {
         doCall(),
         'Request to https://embedder.com timed out'
       );
+    });
+
+    it('if timeout is null, then it does not timeout', async () => {
+      const clock = sinon.useFakeTimers();
+      const result = doCall(null);
+      clock.tick(100000); // wait a long time
+      fakeWindow.emitter.emit('message', {
+        origin,
+        data: {
+          jsonrpc: '2.0',
+          id: messageId,
+          result: {},
+        },
+      });
+      await result;
+      clock.restore();
     });
   });
 });

--- a/src/sidebar/util/test/postmessage-json-rpc-test.js
+++ b/src/sidebar/util/test/postmessage-json-rpc-test.js
@@ -19,13 +19,12 @@ describe('sidebar.util.postmessage-json-rpc', () => {
     let fakeWindow;
 
     function doCall(timeout = 1) {
-      const _timeout = timeout;
       return call(
         frame,
         origin,
         'testMethod',
         [1, 2, 3],
-        _timeout,
+        timeout,
         fakeWindow,
         messageId
       );


### PR DESCRIPTION
Change the client RPC request to optionally bypass the timeout. There could be a case where its waiting for user input to proceed with authorization and could take any number of seconds.

----

Later on we'll need to converge this with the RPC module in LMS.

fixes https://github.com/hypothesis/client/issues/2158