### PR TITLE
Fix race condition and error handling when fetching groups in LMS app

### DIFF
--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -190,12 +190,10 @@ loads.
 
    .. option:: groups
 
-      ``String[]|null``. An array of group IDs. If provided, the list of groups
-      fetched from the API will be filtered against this list so that the user
-      can only select from these groups.
-
-      This can be useful in contexts where it is important that annotations
-      are made in a particular group.
+      ``String[]|null``. An array of group IDs. If provided, only these groups
+      will be fetched and displayed in the client. This is used, for example,
+      in the Hypothesis LMS app to show only the groups appropriate for a
+      user looking at a particular assignment.
 
    .. option:: icon
 

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -333,7 +333,7 @@ export default function groups(
   /**
    * Load the specific groups configured by the annotation service.
    *
-   * @param {string[]} groupIds
+   * @param {string[]} groupIds - `id` or `groupid`s of groups to fetch
    */
   async function loadServiceSpecifiedGroups(groupIds) {
     // Fetch the groups that the user is a member of in one request and then

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -30,6 +30,9 @@ export default function groups(
   const svc = serviceConfig(settings);
   const authority = svc ? svc.authority : null;
 
+  // `expand` parameter for various groups API calls.
+  const expandParam = ['organization', 'scopes'];
+
   /**
    * Return the main document URI that is used to fetch groups associated with
    * the site that the user is on.
@@ -111,22 +114,6 @@ export default function groups(
         directLinkedGroupId = null;
       }
     }
-    // If service groups are specified only return those.
-    // If a service group doesn't exist in the list of groups don't return it.
-    if (svc && svc.groups) {
-      try {
-        // The groups may not be immediately available if they are being fetched via RPC.
-        const focusedGroups = await svc.groups;
-        const filteredGroups = groups.filter(
-          g => focusedGroups.includes(g.id) || focusedGroups.includes(g.groupid)
-        );
-        return filteredGroups;
-      } catch (e) {
-        toastMessenger.error(e.message);
-        // Don't show any groups if we catch an error
-        return [];
-      }
-    }
 
     // Logged-in users always see the "Public" group.
     if (isLoggedIn) {
@@ -172,16 +159,13 @@ export default function groups(
   }
 
   /*
-   * Fetch an individual group.
+   * Fetch a specific group.
    *
-   * @param {Object} requestParams
-   * @return {Promise<Group>|undefined}
+   * @param {string} id
+   * @return {Promise<Group>}
    */
-  function fetchGroup(requestParams) {
-    return api.group.read(requestParams).catch(() => {
-      // If the group does not exist or the user doesn't have permission.
-      return null;
-    });
+  async function fetchGroup(id) {
+    return api.group.read({ id, expand: expandParam });
   }
 
   let reloadSetUp = false;
@@ -218,19 +202,12 @@ export default function groups(
   }
 
   /**
-   * Fetch groups from the API, load them into the store and set the focused
-   * group.
-   *
-   * The groups that are fetched depend on the current user, the URI of
-   * the current document, and the direct-linked group and/or annotation.
-   *
-   * On startup, `load()` must be called to trigger the initial groups fetch.
-   * Subsequently groups are automatically reloaded if the logged-in user or
-   * main document URI changes.
+   * Fetch the groups associated with the current user and document, as well
+   * as any groups that have been direct-linked to.
    *
    * @return {Promise<Group[]>}
    */
-  async function load() {
+  async function loadGroupsForUserAndDocument() {
     // Step 1: Get the URI of the active document, so we can fetch groups
     // associated with that document.
     let documentUri;
@@ -243,15 +220,6 @@ export default function groups(
     // Step 2: Concurrently fetch the groups the user is a member of,
     // the groups associated with the current document and the annotation
     // and/or group that was direct-linked (if any).
-    const params = {
-      expand: ['organization', 'scopes'],
-    };
-    if (authority) {
-      params.authority = authority;
-    }
-    if (documentUri) {
-      params.document_uri = documentUri;
-    }
 
     // If there is a direct-linked annotation, fetch the annotation in case
     // the associated group has not already been fetched and we need to make
@@ -273,18 +241,26 @@ export default function groups(
     const directLinkedGroupId = store.directLinkedGroupId();
     let directLinkedGroupApi = null;
     if (directLinkedGroupId) {
-      directLinkedGroupApi = fetchGroup({
-        id: directLinkedGroupId,
-        expand: params.expand,
-      }).then(group => {
-        // If the group does not exist or the user doesn't have permission.
-        if (group === null) {
-          store.setDirectLinkedGroupFetchFailed();
-        } else {
+      directLinkedGroupApi = fetchGroup(directLinkedGroupId)
+        .then(group => {
           store.clearDirectLinkedGroupFetchFailed();
-        }
-        return group;
-      });
+          return group;
+        })
+        .catch(() => {
+          // If the group does not exist or the user doesn't have permission.
+          store.setDirectLinkedGroupFetchFailed();
+          return null;
+        });
+    }
+
+    const listParams = {
+      expand: expandParam,
+    };
+    if (authority) {
+      listParams.authority = authority;
+    }
+    if (documentUri) {
+      listParams.document_uri = documentUri;
     }
 
     const [
@@ -294,8 +270,8 @@ export default function groups(
       directLinkedAnn,
       directLinkedGroup,
     ] = await Promise.all([
-      api.profile.groups.read({ expand: params.expand }),
-      api.groups.list(params),
+      api.profile.groups.read({ expand: expandParam }),
+      api.groups.list(listParams),
       auth.tokenGetter(),
       directLinkedAnnApi,
       directLinkedGroupApi,
@@ -328,12 +304,11 @@ export default function groups(
         .find(g => g.id === directLinkedAnn.group);
 
       if (!directLinkedAnnGroup) {
-        const directLinkedAnnGroup = await fetchGroup({
-          id: directLinkedAnn.group,
-          expand: params.expand,
-        });
-        if (directLinkedAnnGroup) {
+        try {
+          const directLinkedAnnGroup = await fetchGroup(directLinkedAnn.group);
           featuredGroups.push(directLinkedAnnGroup);
+        } catch (e) {
+          toastMessenger.error('Unable to fetch group for linked annotation');
         }
       }
     }
@@ -348,25 +323,103 @@ export default function groups(
       directLinkedGroupId
     );
 
+    addGroupsToStore(groups, [
+      directLinkedAnnotationGroupId,
+      directLinkedGroupId,
+      store.getDefault('focusedGroup'),
+    ]);
+
+    return groups;
+  }
+
+  /**
+   * Load the specific groups configured by the annotation service.
+   *
+   * @param {string[]} groupIds
+   */
+  async function loadServiceSpecifiedGroups(groupIds) {
+    let error;
+    const tryFetchGroup = async id => {
+      try {
+        return await fetchGroup(id);
+      } catch (e) {
+        error = e;
+        return null;
+      }
+    };
+
+    const groups = (
+      await Promise.all(groupIds.map(id => tryFetchGroup(id)))
+    ).filter(g => g !== null);
+
+    addGroupsToStore(groups);
+
+    if (error) {
+      toastMessenger.error(`Unable to fetch groups: ${error.message}`, {
+        autoDismiss: false,
+      });
+    }
+
+    return groups;
+  }
+
+  /**
+   * @param {Group[]} groups
+   * @param {string[]} groupsToFocus - IDs of groups to focus, in preference order
+   */
+  function addGroupsToStore(groups, groupsToFocus = []) {
+    // Add a default organization to groups that don't have one. The organization
+    // provides the logo to display when the group is selected and is also used
+    // to order groups.
     injectOrganizations(groups);
 
-    // Step 5. Load the groups into the store and focus the appropriate
-    // group.
     const isFirstLoad = store.allGroups().length === 0;
-    const prevFocusedGroup = store.getDefault('focusedGroup');
 
     store.loadGroups(groups);
 
     if (isFirstLoad) {
-      if (groups.some(g => g.id === directLinkedAnnotationGroupId)) {
-        focus(directLinkedAnnotationGroupId);
-      } else if (groups.some(g => g.id === directLinkedGroupId)) {
-        focus(directLinkedGroupId);
-      } else if (groups.some(g => g.id === prevFocusedGroup)) {
-        focus(prevFocusedGroup);
+      for (let id of groupsToFocus) {
+        if (groups.some(g => g.id === id)) {
+          focus(id);
+          break;
+        }
       }
     }
+  }
 
+  /**
+   * Fetch groups from the API, load them into the store and set the focused
+   * group.
+   *
+   * There are two main scenarios:
+   *
+   * 1. The groups loaded depend on the current user, current document URI and
+   *    active direct links. This is the default.
+   *
+   *    On startup, `load()` must be called to trigger the initial groups fetch.
+   *    Subsequently groups are automatically reloaded if the logged-in user or
+   *    main document URI changes.
+   *
+   * 2. The annotation service specifies exactly which groups to load via the
+   *    configuration it passes to the client.
+   *
+   * @return {Promise<Group[]>}
+   */
+  async function load() {
+    let groups;
+    if (svc && svc.groups) {
+      try {
+        const groupIds = await svc.groups;
+        groups = await loadServiceSpecifiedGroups(groupIds);
+      } catch (e) {
+        toastMessenger.error(
+          `Unable to fetch group configuration: ${e.message}`
+        );
+        groups = [];
+      }
+    } else {
+      groups = await loadGroupsForUserAndDocument();
+    }
     return groups;
   }
 

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -807,12 +807,13 @@ describe('groups', function () {
         );
 
         const svc = service();
-        await svc.load();
+        const groups = await svc.load();
 
         assert.calledWith(
           fakeToastMessenger.error,
           'Unable to fetch group configuration: Something went wrong'
         );
+        assert.deepEqual(groups, []);
       });
     });
   });


### PR DESCRIPTION
When the LMS app starts it loads Via and the client concurrently with
creating the group(s) for the current course/sections and provides the
groups to the client asynchronously when ready.

Previously when loading groups in this context the client would fetch
groups from h, then wait for the group IDs to be returned from the LMS
app and filter the list of loaded groups by those IDs. There was a race
condition here in that the client may end up fetching groups from h
before they have been created by the LMS backend.

Additionally the error handling was poor if some or all of the group IDs
returned LMS app failed to load. The user could see just a blank state
with no error notice.

This PR resolves these issues by splitting the `groups.load()` method which
is called on startup to load groups into two separate code paths, one
for the case where the annotation service configures the client to load
specific groups and the other for the default case where the client
loads groups associated with the current user, current document and
direct links.

When specific groups are configured, the client will wait for those IDs
to be available before loading only those groups from the API. If some
of the groups fail to load, an error notice will be shown but any other
groups which did load will still be shown.

A potential issue with this new approach is that we are making one HTTP
request per group to load, although all requests happen concurrently and
we are using HTTP/2. This may be slower if there are a large number of groups.

Fixes #2162