### PR TITLE
Make fetch exceptions consistent and filter them from Sentry

### DIFF
--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -136,6 +136,12 @@ function createAPICall(
           body: data ? JSON.stringify(stripInternalProperties(data)) : null,
           headers,
           method: descriptor.method,
+        }).catch(() => {
+          // Re-throw Fetch errors such that they all "look the same" (different
+          // browsers throw different Errors on Fetch failure). This allows
+          // Fetch failures to be either handled in particular ways higher up
+          // or for them to be ignored in error reporting (see `sentry` config).
+          throw new Error(`Fetch operation failed for URL '${url}'`);
         });
       })
       .then(response => {

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -175,7 +175,8 @@ describe('sidebar.services.api', function () {
         // Network error
         status: null,
         body: 'Service unreachable.',
-        expectedMessage: 'Service unreachable.',
+        expectedMessage:
+          "Fetch operation failed for URL 'https://example.com/api/profile'",
       },
       {
         // Request failed with an error given in the JSON body

--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -51,6 +51,8 @@ export function init(config) {
   Sentry.init({
     dsn: config.dsn,
     environment: config.environment,
+    // Do not log Fetch failures to avoid inundating with unhandled fetch exceptions
+    ignoreErrors: ['Fetch operation failed'],
     release: '__VERSION__', // replaced by versionify
     whitelistUrls,
 

--- a/src/sidebar/util/test/sentry-test.js
+++ b/src/sidebar/util/test/sentry-test.js
@@ -75,6 +75,20 @@ describe('sidebar/util/sentry', () => {
       );
     });
 
+    it('configures Sentry to ignore Errors with matching the text "Fetch operation failed"', () => {
+      sentry.init({
+        dsn: 'test-dsn',
+        environment: 'dev',
+      });
+
+      assert.calledWith(
+        fakeSentry.init,
+        sinon.match({
+          ignoreErrors: ['Fetch operation failed'],
+        })
+      );
+    });
+
     it('disables the URL whitelist if `document.currentScript` is inaccessible', () => {
       fakeDocumentCurrentScript.get(() => null);
 


### PR DESCRIPTION
This PR attempts to stanch the massive flow of fetch exceptions into Sentry by doing two things:

1. Re-throw `fetch` errors in the `api` service so that they have a consistent string prefix. This helps because different browsers format fetch failure exceptions in different ways. It also keeps the exception extant should we wish to handle them higher up in the application.
2. Update `sentry` configuration to ignore errors with that string prefix

It's challenging to test the Sentry logging (or not logging) of `fetch` failures locally, _specifically_, but it is possible to test that thrown exceptions with the filtered error text (`Fetch operation failed`) don't get logged by manually throwing an `Error` with that text somewhere in your local codebase.

See https://stackoverflow.com/c/hypothesis/a/282/6 for how to configure Sentry locally

Fixes #2018