### PR TITLE
Consolidate CSS font rules in `annotator` SCSS

### DIFF
--- a/src/styles/annotator/adder.scss
+++ b/src/styles/annotator/adder.scss
@@ -102,8 +102,6 @@ $adder-transition-duration: 80ms;
   @include focus.outline-on-keyboard-focus;
 
   box-shadow: none;
-  font-family: h;
-  font-size: 18px;
   background: transparent;
   color: var.$grey-mid;
   display: flex;
@@ -111,12 +109,12 @@ $adder-transition-duration: 80ms;
   align-items: center;
   border: none;
   cursor: pointer;
+  font-size: 12px;
+  font-family: sans-serif;
+  line-height: 1em;
 
-  padding-top: 10px;
-  padding-bottom: 6px;
-  padding-left: 10px;
-  padding-right: 10px;
-
+  padding: 10px;
+  padding-bottom: 7px;
   transition: color $adder-transition-duration;
 }
 
@@ -141,8 +139,6 @@ $adder-transition-duration: 80ms;
   margin-bottom: 2px;
   margin-top: 4px;
 
-  font-size: 12px;
-  font-family: sans-serif;
   transition: color $adder-transition-duration;
 }
 
@@ -153,8 +149,6 @@ $adder-transition-duration: 80ms;
 
   // The badge should be vertically aligned with icons in other toolbar buttons
   // and the label underneath should also align with labels in other buttons.
-  font-family: sans-serif;
-  font-size: 12px;
   font-weight: bold;
   padding: 2px 4px;
 }

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -12,7 +12,7 @@
 @use './bucket-bar';
 @use './highlights';
 
-var.$base-font-size: 14px;
+$annotator-font-size: 14px;
 $sidebar-collapse-transition-time: 150ms;
 
 // Sidebar
@@ -35,7 +35,7 @@ $sidebar-collapse-transition-time: 150ms;
   user-select: none;
   direction: ltr;
   background: none;
-  font-size: var.$base-font-size;
+  font-size: $annotator-font-size;
   line-height: var.$base-line-height;
   height: 100%;
   position: fixed;


### PR DESCRIPTION
This PR consolidates some font-related (S)CSS in the `annotator` side of the client application.

The intents are:

* Fix an alignment issue with some icons/labels in the annotator toolbar
* Reduce the number of font-related rules in the `annotator` CSS to a minimum as part of an overall audit of the current font styles in the whole application

Alignment issue fixed in annotator toolbar as a nice side effect to the original goals here. Before (note vertical alignment of the "Show" icon/badge:

<img width="296" alt="Screen Shot 2020-05-18 at 10 46 33 AM" src="https://user-images.githubusercontent.com/439947/82235825-3ca9cf00-9901-11ea-9c79-646c601b6706.png">

After:

![image](https://user-images.githubusercontent.com/439947/82235842-45020a00-9901-11ea-8a4f-e94faedc0ce6.png)


Part of #2165