### PR TITLE
Restore document metadata to annotation cards

### DIFF
--- a/src/sidebar/components/test/thread-card-test.js
+++ b/src/sidebar/components/test/thread-card-test.js
@@ -32,6 +32,7 @@ describe('ThreadCard', () => {
     };
     fakeStore = {
       isAnnotationFocused: sinon.stub().returns(false),
+      route: sinon.stub(),
     };
 
     fakeThread = {
@@ -67,6 +68,22 @@ describe('ThreadCard', () => {
     const wrapper = createComponent({ settings: { theme: 'clean' } });
 
     assert(wrapper.find('.thread-card').hasClass('thread-card--theme-clean'));
+  });
+
+  it('shows document info if current route is not sidebar', () => {
+    fakeStore.route.returns('whatever');
+
+    const wrapper = createComponent();
+
+    assert.isTrue(wrapper.find('Thread').props().showDocumentInfo);
+  });
+
+  it('does not show document info if current route is sidebar', () => {
+    fakeStore.route.returns('sidebar');
+
+    const wrapper = createComponent();
+
+    assert.isFalse(wrapper.find('Thread').props().showDocumentInfo);
   });
 
   describe('mouse and click events', () => {

--- a/src/sidebar/components/thread-card.js
+++ b/src/sidebar/components/thread-card.js
@@ -16,6 +16,7 @@ import Thread from './thread';
 function ThreadCard({ frameSync, settings = {}, thread }) {
   const threadTag = thread.annotation && thread.annotation.$tag;
   const isFocused = useStore(store => store.isAnnotationFocused(threadTag));
+  const showDocumentInfo = useStore(store => store.route() !== 'sidebar');
 
   const focusThreadAnnotation = useCallback(
     debounce(tag => {
@@ -44,7 +45,7 @@ function ThreadCard({ frameSync, settings = {}, thread }) {
         'thread-card--theme-clean': settings.theme === 'clean',
       })}
     >
-      <Thread thread={thread} showDocumentInfo={false} />
+      <Thread thread={thread} showDocumentInfo={showDocumentInfo} />
     </div>
   );
 }


### PR DESCRIPTION
Whoops! When migrating, we neglected to make sure that extended document metadata was displayed for annotation cards when not in a sidebar context.

Before (single-annotation view):

![image](https://user-images.githubusercontent.com/439947/82246094-13de0580-9912-11ea-8a95-7d92e3cf4979.png)


After:

![image](https://user-images.githubusercontent.com/439947/82246051-04f75300-9912-11ea-8bed-1f56d3c58182.png)
