### PR TITLE
Improve loading state for LMS, all users

### DIFF
--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -33,9 +33,7 @@ function SidebarContent({
   const focusedGroupId = useStore(store => store.focusedGroupId());
   const hasAppliedFilter = useStore(store => store.hasAppliedFilter());
   const isFocusedMode = useStore(store => store.focusModeEnabled());
-  const annotationsLoading = useStore(store => {
-    return !store.hasFetchedAnnotations() || store.isFetchingAnnotations();
-  });
+  const isLoading = useStore(store => store.isLoading());
   const isLoggedIn = useStore(store => store.isLoggedIn());
   const linkedAnnotationId = useStore(store =>
     store.directLinkedAnnotationId()
@@ -68,7 +66,7 @@ function SidebarContent({
   // If, after loading completes, no `linkedAnnotation` object is present when
   // a `linkedAnnotationId` is set, that indicates an error
   const hasDirectLinkedAnnotationError =
-    !annotationsLoading && linkedAnnotationId ? !linkedAnnotation : false;
+    !isLoading && linkedAnnotationId ? !linkedAnnotation : false;
 
   const hasDirectLinkedGroupError = useStore(store =>
     store.directLinkedGroupFetchFailed()
@@ -78,7 +76,7 @@ function SidebarContent({
     hasDirectLinkedAnnotationError || hasDirectLinkedGroupError;
 
   const showTabs = !hasContentError && !hasAppliedFilter;
-  const showSearchStatus = !hasContentError && !annotationsLoading;
+  const showSearchStatus = !hasContentError && !isLoading;
 
   // Show a CTA to log in if successfully viewing a direct-linked annotation
   // and not logged in
@@ -86,7 +84,7 @@ function SidebarContent({
     linkedAnnotationId &&
     !isLoggedIn &&
     !hasDirectLinkedAnnotationError &&
-    !annotationsLoading;
+    !isLoading;
 
   const prevGroupId = useRef(focusedGroupId);
 
@@ -136,7 +134,7 @@ function SidebarContent({
       {hasDirectLinkedGroupError && (
         <SidebarContentError errorType="group" onLoginRequest={onLogin} />
       )}
-      {showTabs && <SelectionTabs isLoading={annotationsLoading} />}
+      {showTabs && <SelectionTabs isLoading={isLoading} />}
       {showSearchStatus && <SearchStatusBar />}
       <ThreadList thread={rootThread} />
       {showLoggedOutMessage && <LoggedOutMessage onLogin={onLogin} />}

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -56,7 +56,7 @@ describe('SidebarContent', () => {
       hasAppliedFilter: sinon.stub(),
       hasFetchedAnnotations: sinon.stub(),
       hasSidebarOpened: sinon.stub(),
-      isFetchingAnnotations: sinon.stub(),
+      isLoading: sinon.stub().returns(false),
       isLoggedIn: sinon.stub(),
       getState: sinon.stub(),
       profile: sinon.stub().returns({ userid: null }),
@@ -113,8 +113,7 @@ describe('SidebarContent', () => {
   context('when viewing a direct-linked annotation', () => {
     context('successful direct-linked annotation', () => {
       beforeEach(() => {
-        fakeStore.hasFetchedAnnotations.returns(true);
-        fakeStore.isFetchingAnnotations.returns(false);
+        fakeStore.isLoading.returns(false);
         fakeStore.annotationExists.withArgs('someId').returns(true);
         fakeStore.directLinkedAnnotationId.returns('someId');
         fakeStore.findAnnotationByID
@@ -149,8 +148,7 @@ describe('SidebarContent', () => {
     context('error on direct-linked annotation', () => {
       beforeEach(() => {
         // This puts us into a "direct-linked annotation" state
-        fakeStore.hasFetchedAnnotations.returns(true);
-        fakeStore.isFetchingAnnotations.returns(false);
+        fakeStore.isLoading.returns(false);
         fakeStore.directLinkedAnnotationId.returns('someId');
 
         // This puts us into an error state
@@ -179,8 +177,7 @@ describe('SidebarContent', () => {
 
   context('error with direct-linked group', () => {
     beforeEach(() => {
-      fakeStore.hasFetchedAnnotations.returns(true);
-      fakeStore.isFetchingAnnotations.returns(false);
+      fakeStore.isLoading.returns(false);
       fakeStore.directLinkedGroupFetchFailed.returns(true);
     });
 
@@ -229,7 +226,7 @@ describe('SidebarContent', () => {
 
   it('renders search status', () => {
     fakeStore.hasFetchedAnnotations.returns(true);
-    fakeStore.isFetchingAnnotations.returns(false);
+    fakeStore.isLoading.returns(false);
 
     const wrapper = createComponent();
 
@@ -237,7 +234,7 @@ describe('SidebarContent', () => {
   });
 
   it('does not render search status if annotations are loading', () => {
-    fakeStore.hasFetchedAnnotations.returns(false);
+    fakeStore.isLoading.returns(true);
 
     const wrapper = createComponent();
 

--- a/src/sidebar/store/modules/activity.js
+++ b/src/sidebar/store/modules/activity.js
@@ -145,10 +145,13 @@ function isFetchingAnnotations(state) {
 
 /**
  * Return true when any activity is happening in the app that needs to complete
- * before the UI will be idle.
+ * before the UI is ready for interactivity with annotations.
  */
 function isLoading(state) {
-  return state.activity.activeApiRequests > 0;
+  return (
+    state.activity.activeApiRequests > 0 ||
+    !state.activity.hasFetchedAnnotations
+  );
 }
 
 /**

--- a/src/sidebar/store/modules/test/activity-test.js
+++ b/src/sidebar/store/modules/test/activity-test.js
@@ -26,8 +26,8 @@ describe('sidebar/store/modules/activity', () => {
   });
 
   describe('#isLoading', () => {
-    it('returns false with the initial state', () => {
-      assert.equal(store.isLoading(), false);
+    it('returns true when annotations have never been loaded', () => {
+      assert.isTrue(store.isLoading());
     });
 
     it('returns true when API requests are in flight', () => {
@@ -35,14 +35,16 @@ describe('sidebar/store/modules/activity', () => {
       assert.equal(store.isLoading(), true);
     });
 
-    it('returns false when all requests end', () => {
+    it('returns false when all requests end and annotations are fetched', () => {
       store.apiRequestStarted();
       store.apiRequestStarted();
       store.apiRequestFinished();
+      store.annotationFetchStarted();
 
       assert.equal(store.isLoading(), true);
 
       store.apiRequestFinished();
+      store.annotationFetchFinished();
 
       assert.equal(store.isLoading(), false);
     });


### PR DESCRIPTION
This PR makes some logic changes to what the store considers to be a "loading" state for the app and updates components that care about loading states. The net result is a smoother and more consistent loading interface.

There are a few spots in components where it matters if the current state of the application is "loading." What "loading" means in these cases is that we've got the data present to be able to be interactive.

Before these changes, `store.isLoading()` would return `true` only if there is at least one active API request in-flight. After these changes, it will return `true` if there is an active API request OR annotations have never been successfully fetched. This accounts for the new state of waiting for the LMS to provide a list of `groupids` to fetch: while this is the case, there are no API requests in flight, but the application is not "ready" for interactivity.

_In the future,_ we may wish to have more nuance about different loading states in the application, and it may be useful to answer the specific question of "are there any active API requests?" We may also wish to know specifically if _groups_ have ever been loaded successfully (annotations are only loaded after groups are fetched, so by having a successful annotation fetch we currently _de facto_ know that we've also got groups). However, I took the minimal path here that satisfies all of the application's current is-loading needs.

This may all be easier to demonstrate with a GIF.

Before these changes, with an arbitrary 5-second delay introduced while we "wait" for a list of LMS group IDs:

![before-loading-fix](https://user-images.githubusercontent.com/439947/82361332-b82a7f80-99d8-11ea-9d90-e1d08b693bd0.gif)

Note that the search bar allows interactivity. If one actually submits a search during this time, it will _break the app_ and it won't recover. Eep.

After these changes:

![after-loading-fix](https://user-images.githubusercontent.com/439947/82361404-cd071300-99d8-11ea-976b-d9c7d23df29b.gif)

Fixes #2161