### PR TITLE
Remove redundant “Select” and “tabs” verbiage

### DIFF
--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -123,7 +123,7 @@ function SelectionTabs({ isLoading, settings }) {
           count={annotationCount}
           isWaitingToAnchor={isWaitingToAnchorAnnotations}
           isSelected={selectedTab === uiConstants.TAB_ANNOTATIONS}
-          label="Select annotations tab"
+          label="Annotations"
           onSelect={() => selectTab(uiConstants.TAB_ANNOTATIONS)}
         >
           Annotations
@@ -132,7 +132,7 @@ function SelectionTabs({ isLoading, settings }) {
           count={noteCount}
           isWaitingToAnchor={isWaitingToAnchorAnnotations}
           isSelected={selectedTab === uiConstants.TAB_NOTES}
-          label="Select page notes tab"
+          label="Page notes"
           onSelect={() => selectTab(uiConstants.TAB_NOTES)}
         >
           Page Notes
@@ -142,7 +142,7 @@ function SelectionTabs({ isLoading, settings }) {
             count={orphanCount}
             isWaitingToAnchor={isWaitingToAnchorAnnotations}
             isSelected={selectedTab === uiConstants.TAB_ORPHANS}
-            label="Select orphans tab"
+            label="Orphans"
             onSelect={() => selectTab(uiConstants.TAB_ORPHANS)}
           >
             Orphans

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -112,12 +112,12 @@ describe('SelectionTabs', function () {
 
       const tabs = wrapper.find('button');
 
-      assert.equal(tabs.at(0).prop('aria-label'), 'Select annotations tab');
-      assert.equal(tabs.at(0).prop('title'), 'Select annotations tab');
-      assert.equal(tabs.at(1).prop('aria-label'), 'Select page notes tab');
-      assert.equal(tabs.at(1).prop('title'), 'Select page notes tab');
-      assert.equal(tabs.at(2).prop('aria-label'), 'Select orphans tab');
-      assert.equal(tabs.at(2).prop('title'), 'Select orphans tab');
+      assert.equal(tabs.at(0).prop('aria-label'), 'Annotations');
+      assert.equal(tabs.at(0).prop('title'), 'Annotations');
+      assert.equal(tabs.at(1).prop('aria-label'), 'Page notes');
+      assert.equal(tabs.at(1).prop('title'), 'Page notes');
+      assert.equal(tabs.at(2).prop('aria-label'), 'Orphans');
+      assert.equal(tabs.at(2).prop('title'), 'Orphans');
     });
 
     it('should show the clean theme when settings contains the clean theme option', function () {


### PR DESCRIPTION
Fixes https://github.com/hypothesis/product-backlog/issues/1107