### PR TITLE
Use `aria-expanded` instead of `aria-pressed` per a11y audit

### DIFF
--- a/src/sidebar/components/test/top-bar-test.js
+++ b/src/sidebar/components/test/top-bar-test.js
@@ -119,7 +119,7 @@ describe('TopBar', () => {
 
         wrapper.update();
 
-        assert.isTrue(helpButton.props().isPressed);
+        assert.isTrue(helpButton.props().isExpanded);
       });
 
       context('help service handler configured in services', () => {
@@ -228,7 +228,7 @@ describe('TopBar', () => {
     const wrapper = createTopBar();
     const shareButton = getButton(wrapper, 'share');
 
-    assert.isTrue(shareButton.prop('isPressed'));
+    assert.isTrue(shareButton.prop('isExpanded'));
   });
 
   it('displays search input in the sidebar', () => {

--- a/src/sidebar/components/top-bar.js
+++ b/src/sidebar/components/top-bar.js
@@ -105,7 +105,7 @@ function TopBar({
           <Button
             className="top-bar__icon-button"
             icon="help"
-            isPressed={currentActivePanel === uiConstants.PANEL_HELP}
+            isExpanded={currentActivePanel === uiConstants.PANEL_HELP}
             onClick={requestHelp}
             title="Help"
             useCompactStyle
@@ -135,7 +135,7 @@ function TopBar({
             <Button
               className="top-bar__icon-button"
               icon="share"
-              isPressed={
+              isExpanded={
                 currentActivePanel === uiConstants.PANEL_SHARE_ANNOTATIONS
               }
               onClick={toggleSharePanel}
@@ -146,7 +146,7 @@ function TopBar({
           <Button
             className="top-bar__icon-button"
             icon="help"
-            isPressed={currentActivePanel === uiConstants.PANEL_HELP}
+            isExpanded={currentActivePanel === uiConstants.PANEL_HELP}
             onClick={requestHelp}
             title="Help"
             useCompactStyle


### PR DESCRIPTION
This addresses part of https://github.com/hypothesis/product-backlog/issues/1110

I'm unsure of how to address the show/hide sidebar toggle at present. It follows a different pattern than these buttons.