### PR TITLE
Rectify infinite load on single-annotation, stream views

### DIFF
--- a/src/sidebar/components/stream-content.js
+++ b/src/sidebar/components/stream-content.js
@@ -17,6 +17,12 @@ function StreamContent({
   toastMessenger,
 }) {
   const addAnnotations = useStore(store => store.addAnnotations);
+  const annotationFetchStarted = useStore(
+    store => store.annotationFetchStarted
+  );
+  const annotationFetchFinished = useStore(
+    store => store.annotationFetchFinished
+  );
   const clearAnnotations = useStore(store => store.clearAnnotations);
   const currentQuery = useStore(store => store.routeParams().q);
   const setSortKey = useStore(store => store.setSortKey);
@@ -38,10 +44,21 @@ function StreamContent({
 
         ...searchFilter.toObject(query),
       };
-      const results = await api.search(queryParams);
-      addAnnotations([...results.rows, ...results.replies]);
+      try {
+        annotationFetchStarted();
+        const results = await api.search(queryParams);
+        addAnnotations([...results.rows, ...results.replies]);
+      } finally {
+        annotationFetchFinished();
+      }
     },
-    [addAnnotations, api, searchFilter]
+    [
+      addAnnotations,
+      annotationFetchStarted,
+      annotationFetchFinished,
+      api,
+      searchFilter,
+    ]
   );
 
   // Update the stream when this route is initially displayed and whenever

--- a/src/sidebar/components/test/stream-content-test.js
+++ b/src/sidebar/components/test/stream-content-test.js
@@ -28,6 +28,8 @@ describe('StreamContent', () => {
 
     fakeStore = {
       addAnnotations: sinon.stub(),
+      annotationFetchStarted: sinon.stub(),
+      annotationFetchFinished: sinon.stub(),
       clearAnnotations: sinon.spy(),
       getState: sinon.stub().returns({}),
       routeParams: sinon.stub().returns({ id: 'test' }),
@@ -67,6 +69,21 @@ describe('StreamContent', () => {
   it('calls the search API with `_separate_replies: true`', () => {
     createComponent();
     assert.equal(fakeApi.search.firstCall.args[0]._separate_replies, true);
+  });
+
+  it('records the start and finish of the fetch request in the store', async () => {
+    createComponent();
+
+    await waitFor(() => fakeStore.annotationFetchStarted.calledOnce);
+    await waitFor(() => fakeStore.annotationFetchFinished.calledOnce);
+  });
+
+  it('records the finish of the fetch request on error', async () => {
+    fakeApi.search.throws();
+    createComponent();
+
+    await waitFor(() => fakeStore.annotationFetchStarted.calledOnce);
+    await waitFor(() => fakeStore.annotationFetchFinished.calledOnce);
   });
 
   it('loads the annotations and replies into the store', async () => {


### PR DESCRIPTION
This PR fixes the regression https://github.com/hypothesis/client/issues/2207, making the loading state "resolve" in the single-annotation and stream views.

It does this by:

* Refactoring the retrieval of thread annotations, removing it from the `AnnotationViewerContent` component and putting it into the `loadAnnotationsService`
* Making the new `loadAnnotationsService.loadThread` method register the start and finish of its fetch with the store—this will resolve the loading state for the `AnnotationViewerContent` component
* Making the `StreamContent` component register the start and end of its search-annotations operation to resolve the loading state there, as well. In future, we could factor this logic out of `StreamContent`, but it doesn't seem particularly urgent to me.

Fixes #2207