### PR TITLE
Tidy/Organize existing SASS color variables

### DIFF
--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -10,7 +10,7 @@
 // of the annotated document when highlights are enabled/disabled.
 .hypothesis-highlights-always-on {
   .hypothesis-svg-highlight {
-    fill: var.$highlight-color;
+    fill: var.$color-highlight;
 
     &.is-opaque {
       fill: yellow;
@@ -18,7 +18,7 @@
   }
 
   .hypothesis-highlight {
-    background-color: var.$highlight-color;
+    background-color: var.$color-highlight;
 
     // For PDFs, we still create highlight elements to wrap the text but the
     // highlight effect is created by another element.
@@ -44,7 +44,7 @@
 
     // Give a highlight inside a larger highlight a different color to stand out.
     & .hypothesis-highlight {
-      background-color: var.$highlight-color-second;
+      background-color: var.$color-highlight-second;
       &.is-transparent {
         background-color: transparent;
       }
@@ -66,7 +66,7 @@
     // When an annotation card is hovered in the sidebar, the corresponding
     // highlights are shown with a "focused" color.
     &.hypothesis-highlight-focused {
-      background-color: var.$highlight-color-focus !important;
+      background-color: var.$color-highlight-focused !important;
 
       .hypothesis-highlight {
         background-color: transparent !important;

--- a/src/styles/mixins/buttons.scss
+++ b/src/styles/mixins/buttons.scss
@@ -29,10 +29,10 @@
   }
 
   &.is-active {
-    color: var.$brand;
+    color: var.$color-brand;
 
     &:hover {
-      color: var.$brand;
+      color: var.$color-brand;
     }
   }
 }

--- a/src/styles/mixins/panel.scss
+++ b/src/styles/mixins/panel.scss
@@ -6,7 +6,7 @@
  * padding, heading and close-button styles.
  */
 @mixin panel {
-  background-color: var.$body-background;
+  background-color: var.$color-background;
   border: solid 1px var.$grey-3;
   border-radius: 2px;
 
@@ -35,7 +35,7 @@
   }
 
   &__title {
-    color: var.$brand;
+    color: var.$color-brand;
     font-size: var.$body2-font-size;
     font-weight: 700;
   }

--- a/src/styles/sidebar/components/annotation-header.scss
+++ b/src/styles/sidebar/components/annotation-header.scss
@@ -23,7 +23,7 @@
     background-color: transparent;
     &:hover {
       background-color: transparent;
-      color: var.$link-color-hover;
+      color: var.$color-link-hover;
     }
   }
 

--- a/src/styles/sidebar/components/annotation-quote.scss
+++ b/src/styles/sidebar/components/annotation-quote.scss
@@ -23,6 +23,6 @@
   }
 
   &.is-focused &__quote {
-    border-left: var.$highlight 3px solid;
+    border-left: var.$color-highlight 3px solid;
   }
 }

--- a/src/styles/sidebar/components/annotation-quote.scss
+++ b/src/styles/sidebar/components/annotation-quote.scss
@@ -23,6 +23,6 @@
   }
 
   &.is-focused &__quote {
-    border-left: var.$color-highlight 3px solid;
+    border-left: var.$color-quote 3px solid;
   }
 }

--- a/src/styles/sidebar/components/annotation.scss
+++ b/src/styles/sidebar/components/annotation.scss
@@ -3,7 +3,7 @@
 // FIXME These hover-related rules should live elsewhere
 // Highlight quote of annotation whenever its thread is hovered
 .thread-list__card:hover .annotation-quote__quote {
-  border-left: var.$color-highlight 3px solid;
+  border-left: var.$color-quote 3px solid;
 }
 
 // When hovering a top-level annotation, show the footer in a hovered state.

--- a/src/styles/sidebar/components/annotation.scss
+++ b/src/styles/sidebar/components/annotation.scss
@@ -3,7 +3,7 @@
 // FIXME These hover-related rules should live elsewhere
 // Highlight quote of annotation whenever its thread is hovered
 .thread-list__card:hover .annotation-quote__quote {
-  border-left: var.$highlight 3px solid;
+  border-left: var.$color-highlight 3px solid;
 }
 
 // When hovering a top-level annotation, show the footer in a hovered state.

--- a/src/styles/sidebar/components/autocomplete-list.scss
+++ b/src/styles/sidebar/components/autocomplete-list.scss
@@ -10,7 +10,7 @@
 .autocomplete-list__items {
   @supports (clip-path: polygon(0 0, 100% 0, 0% 100%, 0% 100%)) {
     &:before {
-      /** 
+      /**
        * Creates a small outlined triangle above the drop down menu
        * that works nicely with a box-shadow and the dark/light themes.
        */
@@ -49,7 +49,7 @@
   border-left: 4px transparent solid;
 
   &.is-selected {
-    border-left: 4px var.$brand solid;
+    border-left: 4px var.$color-brand solid;
     background-color: var.$grey-1;
   }
   &:hover {

--- a/src/styles/sidebar/components/focused-mode-header.scss
+++ b/src/styles/sidebar/components/focused-mode-header.scss
@@ -9,7 +9,7 @@
   align-items: center;
   position: relative;
 
-  background-color: var.$body-background;
+  background-color: var.$color-background;
   border-radius: 2px;
   border: solid 1px var.$grey-3;
   font-family: var.$sans-font-family;

--- a/src/styles/sidebar/components/help-panel.scss
+++ b/src/styles/sidebar/components/help-panel.scss
@@ -38,7 +38,7 @@
     display: flex;
     align-items: center;
     margin-left: auto;
-    color: var.$brand;
+    color: var.$color-brand;
 
     &-icon {
       margin-left: 2px;

--- a/src/styles/sidebar/components/menu-item.scss
+++ b/src/styles/sidebar/components/menu-item.scss
@@ -11,7 +11,7 @@ $item-height: 40px;
 // except for the toggle button that opens the submenu.
 
 a.menu-item:hover {
-  color: var.$link-color-hover;
+  color: var.$color-link-hover;
 }
 
 .menu-item {
@@ -54,7 +54,7 @@ a.menu-item:hover {
 
   &.is-selected {
     $border-width: 4px;
-    border-left: $border-width solid var.$brand;
+    border-left: $border-width solid var.$color-brand;
     padding-left: $menu-item-padding - $border-width;
   }
 

--- a/src/styles/sidebar/components/moderation-banner.scss
+++ b/src/styles/sidebar/components/moderation-banner.scss
@@ -48,7 +48,7 @@
   }
 
   .moderation-banner.is-flagged:not(.is-hidden) {
-    background-color: var.$brand;
+    background-color: var.$color-brand;
   }
 
   .moderation-banner.is-hidden {

--- a/src/styles/sidebar/components/selection-tabs.scss
+++ b/src/styles/sidebar/components/selection-tabs.scss
@@ -37,7 +37,7 @@
   user-select: none;
 
   &:hover {
-    color: var.$link-color-hover;
+    color: var.$color-link-hover;
   }
 }
 

--- a/src/styles/sidebar/components/tag-list.scss
+++ b/src/styles/sidebar/components/tag-list.scss
@@ -23,7 +23,7 @@
   &__link {
     &:hover,
     &:focus {
-      color: var.$brand;
+      color: var.$color-brand;
       border-color: var.$grey-4;
     }
   }

--- a/src/styles/sidebar/components/top-bar.scss
+++ b/src/styles/sidebar/components/top-bar.scss
@@ -32,10 +32,10 @@
   }
 
   &__icon-button--refresh {
-    color: var.$brand;
+    color: var.$color-brand;
 
     &:hover {
-      color: var.$brand;
+      color: var.$color-brand;
     }
   }
 
@@ -51,12 +51,12 @@
 .top-bar__login-button.button {
   padding: 0 0.25em;
   background-color: transparent;
-  color: var.$brand;
+  color: var.$color-brand;
   font-size: var.$body2-font-size;
   font-weight: 400;
 
   &:hover {
-    color: var.$link-color-hover;
+    color: var.$color-link-hover;
   }
 }
 

--- a/src/styles/sidebar/elements.scss
+++ b/src/styles/sidebar/elements.scss
@@ -2,7 +2,7 @@
 
 // basic standard styling for elements
 a {
-  color: var.$link-color;
+  color: var.$color-link;
   text-decoration: none;
 }
 
@@ -13,7 +13,7 @@ a:focus {
 
 a:hover {
   text-decoration: none;
-  color: var.$link-color-hover;
+  color: var.$color-link-hover;
 }
 
 p {

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -68,7 +68,7 @@
 body {
   height: 100%;
 
-  background-color: var.$body-background;
+  background-color: var.$color-background;
   color: var.$color-text;
   font-family: var.$sans-font-family;
   font-size: var.$base-font-size;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -50,49 +50,6 @@ $highlight: #58cef4;
 $color-focus-outline: #51a7e8;
 $color-focus-shadow: color.scale($color-focus-outline, $alpha: -50%);
 
-// Tint and shade functions from
-// https://css-tricks.com/snippets/sass/tint-shade-functions
-@function tint($color, $percent) {
-  @return color.mix(white, $color, $percent);
-}
-
-@function shade($color, $percent) {
-  @return color.mix(black, $color, $percent);
-}
-
-@function color-weight($c, $n: 500) {
-  @if $n == 50 {
-    @return tint($c, 85%);
-  }
-  @if $n == 100 {
-    @return tint($c, 70%);
-  }
-  @if $n == 200 {
-    @return tint($c, 50%);
-  }
-  @if $n == 300 {
-    @return tint($c, 30%);
-  }
-  @if $n == 400 {
-    @return tint($c, 15%);
-  }
-  @if $n == 500 {
-    @return $c;
-  }
-  @if $n == 600 {
-    @return shade($c, 15%);
-  }
-  @if $n == 700 {
-    @return shade($c, 30%);
-  }
-  @if $n == 800 {
-    @return shade($c, 50%);
-  }
-  @if $n == 900 {
-    @return shade($c, 85%);
-  }
-}
-
 // Scaffolding
 // -------------------------
 $body-background: $white !default;
@@ -100,7 +57,7 @@ $body-background: $white !default;
 // Links
 // -------------------------
 $link-color: $brand !default;
-$link-color-hover: color-weight($brand, 700) !default;
+$link-color-hover: #84141e !default;
 
 // Typography
 // -------------------------

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -45,10 +45,14 @@ $color-notice: #fbc168;
 $color-error: #d93c3f;
 
 $color-brand: #bd1c2b;
-$color-highlight: #58cef4;
+$color-quote: #58cef4;
 
 $color-focus-outline: #51a7e8;
 $color-focus-shadow: color.scale($color-focus-outline, $alpha: -50%);
+
+$color-highlight: rgba(255, 255, 60, 0.4);
+$color-highlight-second: rgba(206, 206, 60, 0.4);
+$color-highlight-focused: rgba(156, 230, 255, 0.5);
 
 // Scaffolding
 // -------------------------
@@ -98,9 +102,6 @@ $zindex-tooltip: 20;
 // Other Variables
 // -------------------------
 $bucket-bar-width: 22px;
-$highlight-color: rgba(255, 255, 60, 0.4);
-$highlight-color-second: rgba(206, 206, 60, 0.4);
-$highlight-color-focus: rgba(156, 230, 255, 0.5);
 $top-bar-height: 40px;
 $popup-menu-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
 

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,7 +1,7 @@
 @use "sass:color";
 
-// Greys
-
+// Greys (layout colors)
+// These may be used for non-textual styling of components and elements
 $white: #fff !default;
 
 // Interim color variable for migration purposes.
@@ -34,12 +34,13 @@ $grey-6: #3f3f3f;
 
 $grey-7: #202020;
 
-// Colors
+// Text colors
 $color-text: $grey-7;
 $color-text-light: $grey-5;
 // Text color when used on a dark background
 $color-text-inverted: $grey-1;
 
+// Other colors
 $color-success: #00a36d;
 $color-notice: #fbc168;
 $color-error: #d93c3f;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -44,20 +44,20 @@ $color-success: #00a36d;
 $color-notice: #fbc168;
 $color-error: #d93c3f;
 
-$brand: #bd1c2b;
-$highlight: #58cef4;
+$color-brand: #bd1c2b;
+$color-highlight: #58cef4;
 
 $color-focus-outline: #51a7e8;
 $color-focus-shadow: color.scale($color-focus-outline, $alpha: -50%);
 
 // Scaffolding
 // -------------------------
-$body-background: $white !default;
+$color-background: $white;
 
 // Links
 // -------------------------
-$link-color: $brand !default;
-$link-color-hover: #84141e !default;
+$color-link: $color-brand !default;
+$color-link-hover: #84141e !default;
 
 // Typography
 // -------------------------


### PR DESCRIPTION
This PR is a continuation of housework to tidy up our existing SASS reality. It's meant to be descriptive, not prescriptive—just tidying up what we already have to make it easier to evaluate where we're going.

* Removes some unused (or so lightly used as to be easily replaceable) color functions
* Renames color variables to be consistently prefixed with `$color-` (with the exception of the `$grey-`s). This is nice for clarity and for grepping.
* Renames `$highlight` to `$color-quote` to distinguish it from `$color-highlight` (formerly `$highlight-color`)
* Tidies up the `variables` module a bit

There should be no user-visible changes here.