### PR TITLE
Fix erroneous page scrolling when clicking share / delete buttons

### DIFF
--- a/src/sidebar/components/annotation-action-bar.js
+++ b/src/sidebar/components/annotation-action-bar.js
@@ -41,12 +41,13 @@ function AnnotationActionBar({
 
   const createDraft = useStore(store => store.createDraft);
 
-  const onDelete = () => {
+  const onDelete = e => {
     if (window.confirm('Are you sure you want to delete this annotation?')) {
       annotationsService.delete(annotation).catch(err => {
         toastMessenger.error(err.message);
       });
     }
+    e.stopPropagation();
   };
 
   const onEdit = () => {

--- a/src/sidebar/components/annotation-share-control.js
+++ b/src/sidebar/components/annotation-share-control.js
@@ -31,7 +31,10 @@ function AnnotationShareControl({
   const [isOpen, setOpen] = useState(false);
   const wasOpen = useRef(isOpen);
 
-  const toggleSharePanel = () => setOpen(!isOpen);
+  const toggleSharePanel = e => {
+    setOpen(!isOpen);
+    e.stopPropagation();
+  };
   const closePanel = () => setOpen(false);
 
   // Interactions outside of the component when it is open should close it

--- a/src/sidebar/components/test/annotation-action-bar-test.js
+++ b/src/sidebar/components/test/annotation-action-bar-test.js
@@ -14,6 +14,7 @@ import { waitFor } from '../../../test-util/wait';
 describe('AnnotationActionBar', () => {
   let fakeAnnotation;
   let fakeOnReply;
+  let fakeStopPropagation;
 
   let fakeUserProfile;
 
@@ -61,6 +62,7 @@ describe('AnnotationActionBar', () => {
     fakeUserProfile = {
       userid: 'account:foo@bar.com',
     };
+    fakeStopPropagation = sinon.stub();
 
     fakeAnnotationsService = {
       delete: sinon.stub().resolves(),
@@ -147,11 +149,9 @@ describe('AnnotationActionBar', () => {
     it('asks for confirmation before deletion', () => {
       allowOnly('delete');
       const button = getButton(createComponent(), 'trash');
-
       act(() => {
-        button.props().onClick();
+        button.props().onClick({ stopPropagation: fakeStopPropagation });
       });
-
       assert.calledOnce(confirm);
       assert.notCalled(fakeAnnotationsService.delete);
     });
@@ -162,7 +162,7 @@ describe('AnnotationActionBar', () => {
       const button = getButton(createComponent(), 'trash');
 
       act(() => {
-        button.props().onClick();
+        button.props().onClick({ stopPropagation: fakeStopPropagation });
       });
 
       assert.calledWith(fakeAnnotationsService.delete, fakeAnnotation);
@@ -175,10 +175,19 @@ describe('AnnotationActionBar', () => {
 
       const button = getButton(createComponent(), 'trash');
       act(() => {
-        button.props().onClick();
+        button.props().onClick({ stopPropagation: fakeStopPropagation });
       });
 
       await waitFor(() => fakeToastMessenger.error.called);
+    });
+
+    it('calls stopPropagation when delete button is clicked', () => {
+      allowOnly('delete');
+      const button = getButton(createComponent(), 'trash');
+      act(() => {
+        button.props().onClick({ stopPropagation: fakeStopPropagation });
+      });
+      assert.isTrue(fakeStopPropagation.called);
     });
   });
 

--- a/src/sidebar/components/test/annotation-share-control-test.js
+++ b/src/sidebar/components/test/annotation-share-control-test.js
@@ -16,6 +16,7 @@ describe('AnnotationShareControl', () => {
   let fakeGroup;
   let fakeIsPrivate;
   let fakeShareUri;
+  let fakeStopPropagation;
 
   let container;
 
@@ -39,7 +40,10 @@ describe('AnnotationShareControl', () => {
 
   function openElement(wrapper) {
     act(() => {
-      wrapper.find('Button').props().onClick();
+      wrapper
+        .find('Button')
+        .props()
+        .onClick({ stopPropagation: fakeStopPropagation });
     });
     wrapper.update();
   }
@@ -74,6 +78,7 @@ describe('AnnotationShareControl', () => {
     };
     fakeIsPrivate = sinon.stub().returns(false);
     fakeShareUri = 'https://www.example.com';
+    fakeStopPropagation = sinon.stub();
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
@@ -104,7 +109,7 @@ describe('AnnotationShareControl', () => {
     const button = getButton(wrapper, 'share');
 
     act(() => {
-      button.props().onClick();
+      button.props().onClick({ stopPropagation: fakeStopPropagation });
     });
     wrapper.update();
 
@@ -202,6 +207,13 @@ describe('AnnotationShareControl', () => {
       document.activeElement.getAttribute('aria-label'),
       'Use this URL to share this annotation'
     );
+  });
+
+  it('calls stopPropagation when button is clicked', () => {
+    const wrapper = createComponent();
+    openElement(wrapper);
+    wrapper.update();
+    assert.isTrue(fakeStopPropagation.called);
   });
 
   it(


### PR DESCRIPTION
Clicking delete or share annotation buttons causes the page to scroll because it propagates the event to thread-card which calls an RPC to the annotator and eventually calls scrollIntoView.

-------

There remains one small bug with the share annotation card (but also would happen on any popup that used use-elemet-should-close. Because it listens to click events directly on the body, it can't `stopPropagation` on events that should be consumed by the dialog or its buttons. The original bug did not mention this, but I'll need to file a new low priority ticket to address this. It may be a bit more tricky to solve.

fixes https://github.com/hypothesis/client/issues/2035