### PR TITLE
Handle missing organization logo  

### DIFF
--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -61,17 +61,21 @@ function GroupList({ serviceUrl, settings }) {
 
   let label;
   if (focusedGroup) {
-    const icon = focusedGroup.organization.logo;
+    const icon =
+      focusedGroup.organization.logo || publisherProvidedIcon(settings);
+
     // If org name is missing, then treat this icon like decoration
     // and pass an empty string.
     const altName = orgName(focusedGroup) ? orgName(focusedGroup) : '';
     label = (
       <span className="group-list__menu-label">
-        <img
-          className="group-list__menu-icon"
-          src={icon || publisherProvidedIcon(settings)}
-          alt={altName}
-        />
+        {icon && (
+          <img
+            className="group-list__menu-icon"
+            src={icon || publisherProvidedIcon(settings)}
+            alt={altName}
+          />
+        )}
         {focusedGroup.name}
       </span>
     );

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -181,11 +181,13 @@ describe('GroupList', () => {
     });
 
     it('uses the organization name for the `alt` attribute', () => {
+      fakeServiceConfig.returns({ icon: 'test-icon' });
       const wrapper = createGroupList();
       assert.equal(wrapper.find('img').prop('alt'), 'Test Org');
     });
 
     it('uses a blank string for the `alt` attribute if the organization name is missing', () => {
+      fakeServiceConfig.returns({ icon: 'test-icon' });
       testGroup.organization = {};
       const wrapper = createGroupList();
       assert.equal(wrapper.find('img').prop('alt'), '');
@@ -205,6 +207,12 @@ describe('GroupList', () => {
     const label = wrapper.find('Menu').prop('label');
     const img = mount(label).find('img');
     assert.equal(img.prop('src'), 'test-icon');
+  });
+
+  it('does not render an icon if the the publisher-provided icon is missing', () => {
+    const wrapper = createGroupList();
+    const label = wrapper.find('Menu').prop('label');
+    assert.isFalse(mount(label).find('img').exists());
   });
 
   /**


### PR DESCRIPTION
Fix rendering issue when the org logo is missing by omitting the <img> entirely 

fixes: https://github.com/hypothesis/client/issues/2212

![missing_org](https://user-images.githubusercontent.com/3939074/84209907-33c59c80-aa6c-11ea-8ab8-54db7fe72c01.gif)
