### PR TITLE
Add utility class for primary-styled button

### DIFF
--- a/src/styles/sidebar/components/button.scss
+++ b/src/styles/sidebar/components/button.scss
@@ -22,3 +22,7 @@
 .button--labeled {
   @include buttons.button--labeled;
 }
+
+.button--primary {
+  @include buttons.button--primary;
+}


### PR DESCRIPTION
Noticed a small CSS regression from the Button improvements a few days ago: need to provide a util class for primary-styled buttons for use by the obscure "Experimental New Note Button" component.