### PR TITLE
Add command to typecheck code and enable it for src/sidebar/util/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ endif
 .PHONY: lint
 lint: node_modules/.uptodate
 	yarn run lint
+	yarn run typecheck
 
 .PHONY: docs
 docs: python

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "terser": "^4.4.0",
     "through2": "^3.0.0",
     "tiny-emitter": "^2.0.2",
+    "typescript": "^3.9.5",
     "unorm": "^1.3.3",
     "vinyl": "^2.2.0",
     "watchify": "^3.7.0",
@@ -127,6 +128,7 @@
     "checkformatting": "prettier --check '**/*.{js,scss}'",
     "format": "prettier --list-different --write '**/*.{js,scss}'",
     "test": "gulp test",
+    "typecheck": "tsc --build src/tsconfig.json",
     "report-coverage": "codecov -f coverage/coverage-final.json",
     "version": "make clean build/manifest.json"
   }

--- a/src/sidebar/build-thread.js
+++ b/src/sidebar/build-thread.js
@@ -1,4 +1,22 @@
-/** Default state for new threads, before applying filters etc. */
+/**
+ * @typedef {import('../types/api').Annotation} Annotation
+ *
+ * @typedef Thread
+ * @prop {string} id
+ * @prop {Annotation} [annotation]
+ * @prop {Thread} [parent]
+ * @prop {boolean} visible
+ * @prop {boolean} collapsed
+ * @prop {Thread[]} children
+ * @prop {number} totalChildren
+ * @prop {'dim'|'highlight'} [highlightState]
+ */
+
+/**
+ * Default state for new threads, before applying filters etc.
+ *
+ * @type {Thread}
+ */
 const DEFAULT_THREAD_STATE = {
   /**
    * The ID of this thread. This will be the same as the annotation ID for
@@ -128,6 +146,7 @@ function threadAnnotations(annotations) {
   });
 
   const root = {
+    id: 'root',
     annotation: undefined,
     children: roots,
     visible: true,
@@ -157,7 +176,7 @@ function mapThread(thread, mapFn) {
  * Return a sorted copy of an array of threads.
  *
  * @param {Array<Thread>} threads - The list of threads to sort
- * @param {(Annotation,Annotation) => boolean} compareFn
+ * @param {(a: Annotation, b: Annotation) => boolean} compareFn
  * @return {Array<Thread>} Sorted list of threads
  */
 function sort(threads, compareFn) {
@@ -220,7 +239,21 @@ function hasVisibleChildren(thread) {
 }
 
 /**
+ * @typedef Options
+ * @prop {string[]} [selected]
+ * @prop {string[]} [forceVisible]
+ * @prop {(a: Annotation) => boolean} [filterFn]
+ * @prop {(t: Thread) => boolean} [threadFilterFn]
+ * @prop {Object} [expanded]
+ * @prop {Object} [highlighted]
+ * @prop {(a: Annotation, b: Annotation) => boolean} [sortCompareFn]
+ * @prop {(a: Annotation, b: Annotation) => boolean} [replySortCompareFn]
+ */
+
+/**
  * Default options for buildThread()
+ *
+ * @type {Options}
  */
 const defaultOpts = {
   /** List of currently selected annotation IDs */

--- a/src/sidebar/build-thread.js
+++ b/src/sidebar/build-thread.js
@@ -3,13 +3,13 @@
  *
  * @typedef Thread
  * @prop {string} id
- * @prop {Annotation} [annotation]
- * @prop {Thread} [parent]
+ * @prop {Annotation|undefined} annotation
+ * @prop {Thread|undefined} parent
  * @prop {boolean} visible
  * @prop {boolean} collapsed
  * @prop {Thread[]} children
  * @prop {number} totalChildren
- * @prop {'dim'|'highlight'} [highlightState]
+ * @prop {'dim'|'highlight'|undefined} highlightState
  */
 
 /**
@@ -22,7 +22,7 @@ const DEFAULT_THREAD_STATE = {
    * The ID of this thread. This will be the same as the annotation ID for
    * created annotations or the `$tag` property for new annotations.
    */
-  id: undefined,
+  id: '__default__',
   /**
    * The Annotation which is displayed by this thread.
    *
@@ -152,6 +152,8 @@ function threadAnnotations(annotations) {
     visible: true,
     collapsed: false,
     totalChildren: roots.length,
+    parent: undefined,
+    highlightState: undefined,
   };
 
   return root;
@@ -253,7 +255,7 @@ function hasVisibleChildren(thread) {
 /**
  * Default options for buildThread()
  *
- * @type {Options}
+ * @type {Partial<Options>}
  */
 const defaultOpts = {
   /** List of currently selected annotation IDs */

--- a/src/sidebar/host-config.js
+++ b/src/sidebar/host-config.js
@@ -7,8 +7,43 @@ import {
 } from '../shared/type-coercions';
 
 /**
+ * @typedef RequestConfigFromFrameOptions
+ * @prop {number} ancestorLevel
+ * @prop {string} origin
+ */
+
+/**
+ * Configuration for the client provided by the frame embedding it.
+ *
+ * User-facing documentation exists at
+ * https://h.readthedocs.io/projects/client/en/latest/publishers/config/
+ *
+ * @typedef Config
+ * @prop {string} [annotations] - Direct-linked annotation ID
+ * @prop {string} [group] - Direct-linked group ID
+ * @prop {string} [query] - Initial filter query
+ * @prop {string} [appType] - Method used to load the client
+ * @prop {boolean} [openSidebar] - Whether to open the sidebar on the initial load
+ * @prop {boolean} [showHighlights] - Whether to show highlights
+ * @prop {Object[]} [services] -
+ *   Configuration for the annotation services that the client connects to
+ * @prop {Object} [branding] -
+ *   Theme properties (fonts, colors etc.)
+ * @prop {boolean} [enableExperimentalNewNoteButton] -
+ *   Whether to show the "New note" button on the "Page Notes" tab
+ * @prop {RequestConfigFromFrameOptions|string} [requestConfigFromFrame]
+ *   Origin of the ancestor frame to request configuration from
+ * @prop {string} [theme]
+ *   Name of the base theme to use.
+ * @prop {string} [usernameUrl]
+ *   URL template for username links
+ */
+
+/**
  * Return the app configuration specified by the frame embedding the Hypothesis
  * client.
+ *
+ * @return {Config}
  */
 export default function hostPageConfig(window) {
   const configStr = window.location.hash.slice(1);

--- a/src/sidebar/util/account-id.js
+++ b/src/sidebar/util/account-id.js
@@ -19,6 +19,8 @@ export function parseAccountID(user) {
 
 /**
  * Returns the username part of an account ID or an empty string.
+ *
+ * @param {string} user
  */
 export function username(user) {
   const account = parseAccountID(user);
@@ -30,6 +32,9 @@ export function username(user) {
 
 /**
  * Returns true if the authority is of a 3rd party user.
+ *
+ * @param {string} user
+ * @param {string} authDomain
  */
 export function isThirdPartyUser(user, authDomain) {
   const account = parseAccountID(user);

--- a/src/sidebar/util/copy-to-clipboard.js
+++ b/src/sidebar/util/copy-to-clipboard.js
@@ -16,7 +16,7 @@ export function copyText(text) {
 
   try {
     const range = document.createRange();
-    const selection = document.getSelection();
+    const selection = /** @type {Selection} */ (document.getSelection());
 
     selection.removeAllRanges();
     range.selectNodeContents(temp);

--- a/src/sidebar/util/date.js
+++ b/src/sidebar/util/date.js
@@ -5,6 +5,8 @@ let formatter;
 /**
  * Returns a standard human-readable representation
  * of a date and time.
+ *
+ * @param {Date} date
  */
 export function format(date) {
   if (typeof Intl !== 'undefined' && Intl.DateTimeFormat) {

--- a/src/sidebar/util/disable-opener-for-external-links.js
+++ b/src/sidebar/util/disable-opener-for-external-links.js
@@ -17,8 +17,10 @@
  */
 export default function disableOpenerForExternalLinks(root) {
   root.addEventListener('click', event => {
-    if (event.target.tagName === 'A') {
-      const linkEl = event.target;
+    const target = /** @type {HTMLElement} */ (event.target);
+
+    if (target.tagName === 'A') {
+      const linkEl = /** @type {HTMLAnchorElement} */ (target);
       if (linkEl.target === '_blank') {
         linkEl.rel = 'noopener';
       }

--- a/src/sidebar/util/dom.js
+++ b/src/sidebar/util/dom.js
@@ -27,9 +27,10 @@ export function getElementHeightWithMargins(element) {
  * Attach listeners for one or multiple events to an element and return a
  * function that removes the listeners.
  *
- * @param {Element}
+ * @param {HTMLElement} element
  * @param {string[]} events
- * @param {(event: Event) => any} listener
+ * @param {EventListener} listener
+ * @param {Object} options
  * @param {boolean} [options.useCapture]
  * @return {function} Function which removes the event listeners.
  */

--- a/src/sidebar/util/fetch-config.js
+++ b/src/sidebar/util/fetch-config.js
@@ -24,7 +24,7 @@ function ancestors(window_) {
  * Returns the global embedder ancestor frame.
  *
  * @param {number} levels - Number of ancestors levels to ascend.
- * @param {Window=} window
+ * @param {Window=} window_
  * @return {Window}
  */
 function getAncestorFrame(levels, window_ = window) {
@@ -57,6 +57,7 @@ function fetchConfigFromAncestorFrame(origin, window_ = window) {
       ancestor,
       origin,
       'requestConfig',
+      [],
       timeout
     );
     configResponses.push(result);
@@ -86,7 +87,7 @@ function fetchConfigLegacy(appConfig, window_ = window) {
   const hostPageConfig = hostConfig(window_);
 
   let embedderConfig;
-  const origin = hostPageConfig.requestConfigFromFrame;
+  const origin = /** @type string */ (hostPageConfig.requestConfigFromFrame);
   embedderConfig = fetchConfigFromAncestorFrame(origin, window_);
 
   return embedderConfig.then(embedderConfig => {
@@ -154,7 +155,7 @@ async function fetchConfigRpc(appConfig, parentFrame, origin) {
  *  already have the `services` value
  * @param {function} rpcCall - RPC method
  *  (method, args, timeout) => Promise
- * @return {Object} - The mutated settings
+ * @return {Promise<Object>} - The mutated settings
  */
 async function fetchGroupsAsync(config, rpcCall) {
   if (Array.isArray(config.services)) {
@@ -170,6 +171,7 @@ async function fetchGroupsAsync(config, rpcCall) {
   }
   return config;
 }
+
 /**
  * Fetch the host configuration and merge it with the app configuration from h.
  *
@@ -180,10 +182,11 @@ async function fetchGroupsAsync(config, rpcCall) {
  *
  * @param {Object} appConfig - Settings rendered into `app.html` by the h service.
  * @param {Window} window_ - Test seam.
- * @return {Object} - The merged settings.
+ * @return {Promise<Object>} - The merged settings.
  */
 export async function fetchConfig(appConfig, window_ = window) {
   const hostPageConfig = hostConfig(window);
+
   const requestConfigFromFrame = hostPageConfig.requestConfigFromFrame;
 
   if (!requestConfigFromFrame) {

--- a/src/sidebar/util/group-list-item-common.js
+++ b/src/sidebar/util/group-list-item-common.js
@@ -1,3 +1,11 @@
+/**
+ * @typedef {import('../../types/api').Group} Group
+ */
+
+/**
+ * @param {Group} group
+ * @return {string}
+ */
 export function orgName(group) {
   return group.organization && group.organization.name;
 }

--- a/src/sidebar/util/group-organizations.js
+++ b/src/sidebar/util/group-organizations.js
@@ -1,5 +1,9 @@
 import immutable from './immutable';
 
+/**
+ * @typedef {import('../../types/api').Group} Group
+ */
+
 // TODO: Update when this is a property available on the API response
 const DEFAULT_ORG_ID = '__default__';
 

--- a/src/sidebar/util/groups.js
+++ b/src/sidebar/util/groups.js
@@ -1,3 +1,5 @@
+/** @typedef {import('../../types/api').Group} Group */
+
 import escapeStringRegexp from 'escape-string-regexp';
 import serviceConfig from '../service-config';
 

--- a/src/sidebar/util/is-third-party-service.js
+++ b/src/sidebar/util/is-third-party-service.js
@@ -9,7 +9,7 @@ import serviceConfig from '../service-config';
  * If no custom annotation services are configured then return `false`.
  *
  * @param {Object} settings - the sidebar settings object
- *
+ * @return {boolean}
  */
 export default function isThirdPartyService(settings) {
   const service = serviceConfig(settings);

--- a/src/sidebar/util/memoize.js
+++ b/src/sidebar/util/memoize.js
@@ -4,6 +4,11 @@
  *
  * The argument to the input function may be of any type and is compared
  * using reference equality.
+ *
+ * @template Arg
+ * @template Result
+ * @param {(arg: Arg) => Result} fn
+ * @return {(arg: Arg) => Result}
  */
 export default function memoize(fn) {
   if (fn.length !== 1) {

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -192,6 +192,8 @@ export default class OAuthClient {
         response_type: 'code',
         state: state,
       });
+
+    // @ts-ignore
     authWindow.location = authUrl;
 
     return authResponse.then(rsp => rsp.code);

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -193,7 +193,7 @@ export default class OAuthClient {
         state: state,
       });
 
-    // @ts-ignore
+    // @ts-ignore - TS doesn't know about `location = <string>`.
     authWindow.location = authUrl;
 
     return authResponse.then(rsp => rsp.code);
@@ -255,10 +255,10 @@ export default class OAuthClient {
       })
       .replace(/&/g, ',');
 
-    return $window.open(
+    return /** @type {Window} */ ($window.open(
       'about:blank',
       'Log in to Hypothesis',
       authWindowSettings
-    );
+    ));
   }
 }

--- a/src/sidebar/util/observe-element-size.js
+++ b/src/sidebar/util/observe-element-size.js
@@ -12,7 +12,9 @@
  * @return {() => void}
  */
 export default function observeElementSize(element, onSizeChanged) {
+  // @ts-ignore - TS is missing `ResizeObserver` type definition
   if (typeof ResizeObserver !== 'undefined') {
+    // @ts-ignore
     const observer = new ResizeObserver(() =>
       onSizeChanged(element.clientWidth, element.clientHeight)
     );

--- a/src/sidebar/util/permissions.js
+++ b/src/sidebar/util/permissions.js
@@ -58,7 +58,7 @@ export function sharedPermissions(userid, groupid) {
  * Return the default permissions for an annotation in a given group.
  *
  * @param {string} userid - User ID of the author
- * @param {string} groupId - ID of the group the annotation is being shared
+ * @param {string} groupid - ID of the group the annotation is being shared
  * with
  * @return {Permissions}
  */

--- a/src/sidebar/util/postmessage-json-rpc.js
+++ b/src/sidebar/util/postmessage-json-rpc.js
@@ -21,10 +21,9 @@ function createTimeout(delay, message) {
  * @param {string} origin - Origin filter for `window.postMessage` call
  * @param {string} method - Name of the JSON-RPC method
  * @param {any[]} params - Parameters of the JSON-RPC method
- * @param {number|null} [number=2000] timeout - Maximum time to wait in
- *  ms or null or 0 to ignore timeout.
- * @param [Window] window_ - Test seam.
- * @param [id] id - Test seam.
+ * @param {number} [timeout] - Maximum time to wait in ms
+ * @param {Window} [window_] - Test seam.
+ * @param {string} [id] - Test seam.
  * @return {Promise<any>} - A Promise for the response to the call
  */
 export function call(

--- a/src/sidebar/util/random.js
+++ b/src/sidebar/util/random.js
@@ -6,10 +6,11 @@ function byteToHex(val) {
 /**
  * Generate a random hex string of `len` chars.
  *
- * @param {number} - An even-numbered length string to generate.
+ * @param {number} len - An even-numbered length string to generate.
  * @return {string}
  */
 export function generateHexString(len) {
+  // @ts-ignore
   const crypto = window.crypto || window.msCrypto; /* IE 11 */
   const bytes = new Uint8Array(len / 2);
   crypto.getRandomValues(bytes);

--- a/src/sidebar/util/random.js
+++ b/src/sidebar/util/random.js
@@ -10,7 +10,7 @@ function byteToHex(val) {
  * @return {string}
  */
 export function generateHexString(len) {
-  // @ts-ignore
+  // @ts-ignore - TS doesn't know about `msCrypto`.
   const crypto = window.crypto || window.msCrypto; /* IE 11 */
   const bytes = new Uint8Array(len / 2);
   crypto.getRandomValues(bytes);

--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -47,7 +47,7 @@ export function init(config) {
   // If we can't determine the current script's origin, just disable the
   // whitelist and report all errors.
   const scriptOrigin = currentScriptOrigin();
-  const whitelistUrls = scriptOrigin ? [scriptOrigin] : null;
+  const whitelistUrls = scriptOrigin ? [scriptOrigin] : undefined;
 
   Sentry.init({
     dsn: config.dsn,

--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -20,7 +20,8 @@ function currentScriptOrigin() {
   try {
     // nb. IE 11 does not support `document.currentScript` and this property
     // is only available while a `<script>` tag is initially being executed.
-    const scriptUrl = new URL(document.currentScript.src);
+    const script = /** @type {HTMLScriptElement} */ (document.currentScript);
+    const scriptUrl = new URL(script.src);
     return scriptUrl.origin;
   } catch (e) {
     return null;
@@ -80,6 +81,7 @@ export function init(config) {
         if (originalErr instanceof Event) {
           Object.assign(event.extra, {
             type: originalErr.type,
+            // @ts-ignore - `detail` is a property of certain event types.
             detail: originalErr.detail,
             isTrusted: originalErr.isTrusted,
           });

--- a/src/sidebar/util/session.js
+++ b/src/sidebar/util/session.js
@@ -1,5 +1,7 @@
 import serviceConfig from '../service-config';
 
+/** @typedef {import('../../types/api').Profile} Profile */
+
 /**
  * Returns true if the sidebar tutorial has to be shown to a user for a given session.
  * @deprecated To be removed once preact help/tutorial panel is in place
@@ -25,7 +27,7 @@ export function shouldShowSidebarTutorial(sessionState) {
  *   in turn implies that there is an authenticated user.
  *
  * @param {boolean} isSidebar - is the app currently displayed in a sidebar?
- * @param {Object} sessionState - `session` state from the store
+ * @param {Profile} profile - User profile returned from the API
  * @param {Object} settings - app configuration/settings
  * @return {boolean} - Tutorial panel should be displayed automatically
  */

--- a/src/sidebar/util/state.js
+++ b/src/sidebar/util/state.js
@@ -1,11 +1,14 @@
+/** @typedef {import('redux').Store} Store */
+
 /**
  * Return a value from app state when it meets certain criteria.
  *
  * `await` returns a Promise which resolves when a selector function,
  * which reads values from a Redux store, returns non-null.
  *
+ * @template T
  * @param {Object} store - Redux store
- * @param {Function<T|null>} selector - Function which returns a value from the
+ * @param {(s: Store) => T|null} selector - Function which returns a value from the
  *   store if the criteria is met or `null` otherwise.
  * @return {Promise<T>}
  */

--- a/src/sidebar/util/tabs.js
+++ b/src/sidebar/util/tabs.js
@@ -1,21 +1,26 @@
 // Functions that determine which tab an annotation should be displayed in.
 
-import uiConstants from '../ui-constants';
-
 import * as metadata from './annotation-metadata';
+
+/**
+ * @typedef {import('../../types/api').Annotation} Annotation
+ *
+ * @typedef {'annotation'|'note'|'orphan'} Tab
+ */
 
 /**
  * Return the tab in which an annotation should be displayed.
  *
  * @param {Annotation} ann
+ * @return {Tab}
  */
 export function tabForAnnotation(ann) {
   if (metadata.isOrphan(ann)) {
-    return uiConstants.TAB_ORPHANS;
+    return 'orphan';
   } else if (metadata.isPageNote(ann)) {
-    return uiConstants.TAB_NOTES;
+    return 'note';
   } else {
-    return uiConstants.TAB_ANNOTATIONS;
+    return 'annotation';
   }
 }
 
@@ -23,7 +28,7 @@ export function tabForAnnotation(ann) {
  * Return true if an annotation should be displayed in a given tab.
  *
  * @param {Annotation} ann
- * @param {number} tab - The TAB_* value indicating the tab
+ * @param {Tab} tab
  */
 export function shouldShowInTab(ann, tab) {
   if (metadata.isWaitingToAnchor(ann)) {

--- a/src/sidebar/util/test/fetch-config-test.js
+++ b/src/sidebar/util/test/fetch-config-test.js
@@ -102,6 +102,7 @@ describe('sidebar.util.fetch-config', () => {
             frame,
             'https://embedder.com',
             'requestConfig',
+            [],
             expectedTimeout
           );
         });
@@ -130,6 +131,7 @@ describe('sidebar.util.fetch-config', () => {
             fakeWindow.parent.parent,
             'https://embedder.com',
             'requestConfig',
+            [],
             expectedTimeout
           )
           .returns(

--- a/src/sidebar/util/test/sentry-test.js
+++ b/src/sidebar/util/test/sentry-test.js
@@ -100,7 +100,7 @@ describe('sidebar/util/sentry', () => {
       assert.calledWith(
         fakeSentry.init,
         sinon.match({
-          whitelistUrls: null,
+          whitelistUrls: undefined,
         })
       );
     });

--- a/src/sidebar/util/thread.js
+++ b/src/sidebar/util/thread.js
@@ -1,3 +1,5 @@
+/** @typedef {import('../build-thread').Thread} Thread */
+
 /**
  * Count the number of annotations/replies in the `thread` whose `visible`
  * property matches `visibility`.

--- a/src/sidebar/util/time.js
+++ b/src/sidebar/util/time.js
@@ -101,6 +101,14 @@ function dayAndMonthAndYear(date, now, Intl) {
   );
 }
 
+/**
+ * @typedef Breakpoint
+ * @prop {(date: Date, now: Date) => boolean} test
+ * @prop {(date: Date, now: Date, Intl: typeof window.Intl) => string} formatFn
+ * @prop {number|null} nextUpdate
+ */
+
+/** @type {Breakpoint[]} */
 const BREAKPOINTS = [
   {
     // Less than 30 seconds
@@ -132,13 +140,14 @@ const BREAKPOINTS = [
     formatFn: dayAndMonth,
     nextUpdate: null,
   },
-  {
-    // everything else (default case)
-    test: () => true,
-    formatFn: dayAndMonthAndYear,
-    nextUpdate: null,
-  },
 ];
+
+/** @type {Breakpoint} */
+const DEFAULT_BREAKPOINT = {
+  test: () => true,
+  formatFn: dayAndMonthAndYear,
+  nextUpdate: null,
+};
 
 /**
  * Returns a dict that describes how to format the date based on the delta
@@ -146,8 +155,7 @@ const BREAKPOINTS = [
  *
  * @param {Date} date - The date to consider as the timestamp to format.
  * @param {Date} now - The date to consider as the current time.
- * @return {Object} An object that describes how to format the date or
- *                           null if no breakpoint matches.
+ * @return {Breakpoint} An object that describes how to format the date.
  */
 function getBreakpoint(date, now) {
   for (let breakpoint of BREAKPOINTS) {
@@ -155,7 +163,7 @@ function getBreakpoint(date, now) {
       return breakpoint;
     }
   }
-  return null;
+  return DEFAULT_BREAKPOINT;
 }
 
 /**

--- a/src/sidebar/util/time.js
+++ b/src/sidebar/util/time.js
@@ -43,13 +43,7 @@ function delta(date, now) {
  *                      param is present for dependency injection during test.
  * @returns {string}
  */
-function formatIntl(date, options, Intl) {
-  // If the tests have passed in a mock Intl then use it, otherwise use the
-  // real one.
-  if (typeof Intl === 'undefined') {
-    Intl = window.Intl;
-  }
-
+function formatIntl(date, options, Intl = window.Intl) {
   if (Intl && Intl.DateTimeFormat) {
     const key = JSON.stringify(options);
     let formatter = formatters[key];
@@ -144,7 +138,7 @@ const BREAKPOINTS = [
 
 /** @type {Breakpoint} */
 const DEFAULT_BREAKPOINT = {
-  test: () => true,
+  test: /* istanbul ignore next */ () => true,
   formatFn: dayAndMonthAndYear,
   nextUpdate: null,
 };

--- a/src/sidebar/util/time.js
+++ b/src/sidebar/util/time.js
@@ -162,7 +162,7 @@ function getBreakpoint(date, now) {
  * Return the number of milliseconds until the next update for a given date
  * should be handled, based on the delta between `date` and `now`.
  *
- * @param {Date} date
+ * @param {Date|null} date
  * @param {Date} now
  * @return {Number|null} - ms until next update or `null` if no update
  *                         should occur

--- a/src/sidebar/util/time.js
+++ b/src/sidebar/util/time.js
@@ -25,6 +25,7 @@ export function clearFormatters() {
  * @param {Date} now
  */
 function delta(date, now) {
+  // @ts-ignore
   return now - date;
 }
 
@@ -145,7 +146,7 @@ const BREAKPOINTS = [
  *
  * @param {Date} date - The date to consider as the timestamp to format.
  * @param {Date} now - The date to consider as the current time.
- * @return {breakpoint|null} An object that describes how to format the date or
+ * @return {Object} An object that describes how to format the date or
  *                           null if no breakpoint matches.
  */
 function getBreakpoint(date, now) {
@@ -195,7 +196,7 @@ export function nextFuzzyUpdate(date, now) {
  * This can be used to refresh parts of a UI whose
  * update frequency depends on the age of a timestamp.
  *
- * @param {String} date - An ISO 8601 date string timestamp to format.
+ * @param {string} date - An ISO 8601 date string timestamp to format.
  * @param {UpdateCallback} callback - A callback function to call when the timestamp changes.
  * @return {Function} A function that cancels the automatic refresh.
  */
@@ -223,7 +224,7 @@ export function decayingInterval(date, callback) {
 /**
  * This callback is a param for the `decayingInterval` function.
  * @callback UpdateCallback
- * @param {Date} - The date associated with the current interval/timeout
+ * @param {string} date - The date associated with the current interval/timeout
  */
 
 /**

--- a/src/sidebar/util/url.js
+++ b/src/sidebar/util/url.js
@@ -6,6 +6,10 @@
  *
  *   replaceURLParams('/things/:id', {id: 'foo', q: 'bar'}) =>
  *     {url: '/things/foo', params: {q: 'bar'}}
+ *
+ * @param {string} url
+ * @param {Object} params
+ * @return {{ url: string, params: Object }}
  */
 export function replaceURLParams(url, params) {
   const unusedParams = {};

--- a/src/sidebar/util/version-data.js
+++ b/src/sidebar/util/version-data.js
@@ -18,7 +18,7 @@
  * An object representing document info
  *
  * @typedef {Object} DocumentInfo
- * @property {string=} url - current document URL
+ * @property {string=} uri - current document URL
  * @property {DocMetadata} metadata - document metadata
  */
 
@@ -27,7 +27,6 @@ export default class VersionData {
    * @param {UserInfo} userInfo
    * @param {DocumentInfo} documentInfo
    * @param {Window} window_ - test seam
-   * @return {VersionData}
    */
   constructor(userInfo, documentInfo, window_ = window) {
     const noValueString = 'N/A';

--- a/src/sidebar/util/visible-threads.js
+++ b/src/sidebar/util/visible-threads.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('../build-thread').Thread} Thread
+ */
+
 export const THREAD_DIMENSION_DEFAULTS = {
   // When we don't have a real measurement of a thread card's height (yet)
   // from the browser, use this as an approximate value, in pixels.

--- a/src/sidebar/util/watch.js
+++ b/src/sidebar/util/watch.js
@@ -54,7 +54,9 @@ export function watch(subscribe, watchFns, callback) {
   const isArray = Array.isArray(watchFns);
 
   const getWatchedValues = () =>
-    isArray ? watchFns.map(fn => fn()) : watchFns();
+    isArray
+      ? /** @type {Function[]} */ (watchFns).map(fn => fn())
+      : /** @type {Function} */ (watchFns)();
 
   let prevValues = getWatchedValues();
   const unsubscribe = subscribe(() => {

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,7 +1,14 @@
 {
   "compilerOptions": {
-    "target": "ES5",
+    "allowJs": true,
+    "checkJs": true,
+    "lib": ["es2018", "dom"],
+    "jsx": "react",
+    "jsxFactory": "createElement",
     "module": "commonjs",
-    "allowJs": true
-  }
+    "noEmit": true
+  },
+  "include": [
+    "sidebar/util/*.js"
+  ]
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -6,7 +6,9 @@
     "jsx": "react",
     "jsxFactory": "createElement",
     "module": "commonjs",
-    "noEmit": true
+    "noEmit": true,
+    "strictNullChecks": true,
+    "target": "ES2020"
   },
   "include": [
     "sidebar/util/*.js"

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -36,7 +36,8 @@
  * @typedef Group
  * @prop {string} id
  * @prop {'private'|'open'} type
- * @prop {Organization|null} organization
+ * @prop {Organization} organization - nb. This field is nullable in the API, but
+ *   we assign a default organization on the client.
  *
  * // Properties not present on API objects, but added by utilities in the client.
  * @prop {string} logo

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -1,0 +1,49 @@
+/**
+ * Type definitions for objects returned from the Hypothesis API.
+ *
+ * The canonical reference is the API documentation at
+ * https://h.readthedocs.io/en/latest/api-reference/
+ */
+
+/**
+ * TODO - Fill out remaining properties
+ *
+ * @typedef Annotation
+ * @prop {string} [id]
+ * @prop {string[]} [references]
+ * @prop {string} created
+ */
+
+/**
+ * TODO - Fill out remaining properties
+ *
+ * @typedef Profile
+ * @prop {Object} preferences
+ * @prop {boolean} preferences.show_sidebar_tutorial
+ */
+
+/**
+ * TODO - Fill out remaining properties
+ *
+ * @typedef Organization
+ * @prop {string} name
+ * @prop {string} logo
+ */
+
+/**
+ * TODO - Fill out remaining properties
+ *
+ * @typedef Group
+ * @prop {string} id
+ * @prop {'private'|'open'} type
+ * @prop {Organization|null} organization
+ *
+ * // Properties not present on API objects, but added by utilities in the client.
+ * @prop {string} logo
+ * @prop {boolean} isMember
+ * @prop {boolean} isScopedToUri
+ * @prop {boolean} canLeave
+ */
+
+// Make TypeScript treat this file as a module.
+export const unused = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7743,6 +7743,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^3.9.5:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
+
 ua-parser-js@0.7.21:
   version "0.7.21"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"


### PR DESCRIPTION
This PR adds the initial infrastructure to typecheck JavaScript code based on JSDoc comments. It also augments/fixes up the existing JSDoc in `src/sidebar/util` so that this directory typechecks successfully (nb. this doesn't include the `test` subdirectory), along with a couple of other modules (`build-thread.js` and `host-config.js`).

To run both linting and type checking locally, you can run `make lint`. To run typechecking alone, run `yarn typecheck`. For better productivity, you can install an editor plugin which will give you live feedback as you code. I use [ALE](https://github.com/dense-analysis/ale) in Vim. VSCode supports it out of the box. I've used [atom-typescript](https://github.com/TypeStrong/atom-typescript) for Atom, although I'm not sure if it is the preferred packaged nowadays.

In the process I found several examples of the kind of improvement that typechecking is intended to help us make:

- In `fetch-config.js` there was a place where the `call` function from `postmessage-json-rpc.js` was called passing the wrong parameters. A timeout value was passed where the function expected an array of method params. The code _happened_ to still work, but not as intended.
- In several places the existing JSDoc specified the wrong type for a parameter or had the wrong name, which would be confusing for a reader. We were also using the wrong syntax for optional parameters/properties in several places.
- There is now a file, `src/types/api.js`, which provides a central place to document the types of objects returned from the API which we pass around our code and occasionally augment with locally added properties. At the moment this is mostly a stub.
- In `build-thread.js` and `host-config.js` I added typedefs which document the core objects (`Thread`, `Config`) that these files work with. These files are outside the `util/` directory but there are several utility modules in `src/sidebar/util` that work with these objects.

This PR doesn't add types to all of the functions/classes in `src/sidebar/util`. For functions that don't have `@param` documentation, TypeScript will assume that the parameters could be of any type.  We can expand typechecking to more functions incrementally over time, and also to additional directories by modifying `src/tsconfig.json`.

For reference when reviewing this, the [here is the reference for the JSDoc syntax we use](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html). There are a few things I'll call out in particular:

- If a function's parameter types are documented, then the return type will be automatically inferred if not explicitly specified via `@return`.
- `@typedef Foo` and `@typedef {Object} Foo` are basically equivalent if followed by a list of property (`@prop`) declarations. I preferred `@typedef Foo` here as it is shorter.
- `// @ts-ignore` is a way to tell TypeScript to ignore any errors on the next line, for cases where typechecking is difficult
- It is possible to make the type of an expression more specific using `/** @type {Type} */ (expression)`. eg. `/** @type {HTMLAnchorElement} */ (element)` would tell TS that `element` is specifically an `<a>` element rather than any HTML element.
- In many cases TS can follow the logic of code and figure out when a conditional check changes the type. For example given:
   ```js
   const thing = getThing(); // Suppose this returns a `Thing` or `null`
   if (!thing) {
     return;
   }
   thing.doStuff(); // `thing` must be a `Thing` rather than `null` here.
   ```
  In some cases though it is necessary to simplify the code or use `@type` to help it.