### PR TITLE
Remove redundant CSS rules

### DIFF
--- a/src/styles/sidebar/components/annotation-body.scss
+++ b/src/styles/sidebar/components/annotation-body.scss
@@ -2,8 +2,6 @@
 @use "../../mixins/buttons";
 
 .annotation-body {
-  @include var.font-normal;
-  color: var.$color-text;
   margin: 1em 0;
 }
 
@@ -40,7 +38,6 @@
 
   .annotation-body__collapse-toggle-button {
     @include buttons.button--labeled;
-    padding: 0.5em;
     background-color: transparent;
   }
 }

--- a/src/styles/sidebar/components/annotation-document-info.scss
+++ b/src/styles/sidebar/components/annotation-document-info.scss
@@ -1,7 +1,6 @@
 @use "../../variables" as var;
 
 .annotation-document-info {
-  @include var.font-normal;
   color: var.$color-text-light;
   display: flex;
 

--- a/src/styles/sidebar/components/annotation-header.scss
+++ b/src/styles/sidebar/components/annotation-header.scss
@@ -3,8 +3,6 @@
 @use "../../variables" as var;
 
 .annotation-header {
-  color: var.$color-text;
-
   &__row {
     display: flex;
     flex-wrap: wrap-reverse;

--- a/src/styles/sidebar/components/annotation-quote.scss
+++ b/src/styles/sidebar/components/annotation-quote.scss
@@ -8,7 +8,6 @@
   }
 
   &__quote {
-    @include var.font-normal;
     border-left: 3px solid var.$grey-3;
     color: var.$color-text-light;
     font-style: italic;

--- a/src/styles/sidebar/components/annotation-share-control.scss
+++ b/src/styles/sidebar/components/annotation-share-control.scss
@@ -23,10 +23,6 @@
   &__icon-button {
     @include buttons.button--input;
     padding: 0.25em 0.5em;
-
-    &__icon {
-      margin: 0;
-    }
   }
 
   & .form-input {

--- a/src/styles/sidebar/components/annotation-share-info.scss
+++ b/src/styles/sidebar/components/annotation-share-info.scss
@@ -6,7 +6,6 @@
 
   &__group,
   &__private {
-    @include var.font-normal;
     display: flex;
     align-items: baseline;
     color: var.$color-text-light;

--- a/src/styles/sidebar/components/annotation-user.scss
+++ b/src/styles/sidebar/components/annotation-user.scss
@@ -2,7 +2,6 @@
 
 .annotation-user {
   &__user-name {
-    @include var.font-normal;
     color: var.$color-text;
     font-weight: bold;
 

--- a/src/styles/sidebar/components/annotation.scss
+++ b/src/styles/sidebar/components/annotation.scss
@@ -57,7 +57,6 @@
   }
 
   &__footer {
-    @include var.font-normal;
     color: var.$color-text-light;
     margin-top: 1em;
   }

--- a/src/styles/sidebar/components/autocomplete-list.scss
+++ b/src/styles/sidebar/components/autocomplete-list.scss
@@ -8,7 +8,6 @@
 }
 
 .autocomplete-list__items {
-  @include var.font-normal;
   @supports (clip-path: polygon(0 0, 100% 0, 0% 100%, 0% 100%)) {
     &:before {
       /**

--- a/src/styles/sidebar/components/focused-mode-header.scss
+++ b/src/styles/sidebar/components/focused-mode-header.scss
@@ -12,7 +12,6 @@
   background-color: var.$color-background;
   border-radius: 2px;
   border: solid 1px var.$grey-3;
-  font-family: var.$sans-font-family;
   font-weight: 300;
   margin-bottom: 0.72em;
   padding: 0.5em 1em;

--- a/src/styles/sidebar/components/help-panel.scss
+++ b/src/styles/sidebar/components/help-panel.scss
@@ -10,7 +10,6 @@
   }
 
   &__content {
-    @include var.font-normal;
     padding: 0.5em;
     border-top: 1px solid var.$grey-3;
     border-bottom: 1px solid var.$grey-3;

--- a/src/styles/sidebar/components/markdown-editor.scss
+++ b/src/styles/sidebar/components/markdown-editor.scss
@@ -41,10 +41,6 @@ $toolbar-border: 0.1em solid var.$grey-3;
     color: var.$grey-3;
   }
 
-  &.is-text {
-    @include var.font-normal;
-  }
-
   &-icon {
     width: 10px;
     height: 10px;

--- a/src/styles/sidebar/components/menu-section.scss
+++ b/src/styles/sidebar/components/menu-section.scss
@@ -5,7 +5,6 @@
 }
 
 .menu-section__heading {
-  @include var.font-normal;
   color: var.$color-text-light;
   line-height: 1;
   margin: 1px 1px 0;

--- a/src/styles/sidebar/components/moderation-banner.scss
+++ b/src/styles/sidebar/components/moderation-banner.scss
@@ -5,7 +5,6 @@
   $h-padding: 15px;
 
   .moderation-banner {
-    @include var.font-normal;
     position: relative;
 
     color: white;

--- a/src/styles/sidebar/components/selection-tabs.scss
+++ b/src/styles/sidebar/components/selection-tabs.scss
@@ -5,8 +5,6 @@
 .selection-tabs {
   display: flex;
   flex-direction: row;
-  @include var.font-normal;
-  color: var.$color-text-light;
 
   &:hover {
     color: var.$color-text;


### PR DESCRIPTION
* Remove CSS rules that “are the case already” via inheritance.
* Remove rules that are subsequently overridden and never apply.

Part of #2245 