### PR TITLE
Fix warning about file type of CoffeeScript test modules

### DIFF
--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -95,6 +95,9 @@ module.exports = function (config) {
 
         // Disable watching because karma-browserify handles this.
         watched: false,
+
+        // Configure `type` explicitly to avoid warning about .coffee files.
+        type: 'js',
       })),
 
       // CSS bundles, relied upon by accessibility tests (eg. for color-contrast


### PR DESCRIPTION
Fix several warnings like this when running tests:

```
22 06 2020 14:01:32.661:WARN [middleware:karma]: Unable to determine
   file type from the file extension, defaulting to js.
     To silence the warning specify a valid type for
     /Users/robert/hypothesis/repos/client/src/annotator/test/sidebar-test.coffee
     in the configuration file.
       See http://karma-runner.github.io/latest/config/files.html
```