### PR TITLE
Remove Node v14 workaround for Karma

### DIFF
--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -8,14 +8,7 @@ const glob = require('glob');
 
 let chromeFlags = [];
 
-if (process.version.startsWith('v14.')) {
-  // See https://github.com/puppeteer/puppeteer/issues/5719
-  console.warn(
-    'Using system Chrome instead of Puppeteer due to issue with Node 14'
-  );
-} else {
-  process.env.CHROME_BIN = require('puppeteer').executablePath();
-}
+process.env.CHROME_BIN = require('puppeteer').executablePath();
 
 // On Travis and in Docker, the tests run as root, so the sandbox must be
 // disabled.


### PR DESCRIPTION
Run tests under Puppeteer again as the issue with Node v14 has been
resolved.