### PR TITLE
Do additional consolidation with mixins and remove unused CSS

### DIFF
--- a/src/sidebar/components/annotation-action-bar.js
+++ b/src/sidebar/components/annotation-action-bar.js
@@ -76,7 +76,7 @@ function AnnotationActionBar({
   };
 
   return (
-    <div className="annotation-action-bar">
+    <div className="annotation-action-bar u-layout-row">
       {showEditAction && <Button icon="edit" title="Edit" onClick={onEdit} />}
       {showDeleteAction && (
         <Button icon="trash" title="Delete" onClick={onDelete} />

--- a/src/sidebar/components/annotation-share-control.js
+++ b/src/sidebar/components/annotation-share-control.js
@@ -104,7 +104,7 @@ function AnnotationShareControl({
             <div className="annotation-share-panel__input">
               <input
                 aria-label="Use this URL to share this annotation"
-                className="form-input"
+                className="annotation-share-panel__form-input"
                 type="text"
                 value={shareUri}
                 readOnly

--- a/src/sidebar/components/help-panel.js
+++ b/src/sidebar/components/help-panel.js
@@ -99,15 +99,15 @@ function HelpPanel({ auth, session }) {
       panelName={uiConstants.PANEL_HELP}
       onActiveChanged={onActiveChanged}
     >
-      <div className="help-panel__content">
-        <div className="help-panel__subtitle">
+      <div className="help-panel__content u-vertical-rhythm">
+        <div className="u-layout-row--align-middle">
           <h3 className="help-panel__sub-panel-title">
             {subPanelTitles[activeSubPanel]}
           </h3>
-          <div className="help-panel__navigation">
+          <div>
             {activeSubPanel === 'versionInfo' && (
               <button
-                className="help-panel__sub-panel-link"
+                className="help-panel__sub-panel-navigation-button"
                 onClick={e => openSubPanel(e, 'tutorial')}
                 aria-label="Show tutorial panel"
               >
@@ -120,15 +120,12 @@ function HelpPanel({ auth, session }) {
             )}
             {activeSubPanel === 'tutorial' && (
               <button
-                className="help-panel__sub-panel-link"
+                className="help-panel__sub-panel-navigation-button"
                 onClick={e => openSubPanel(e, 'versionInfo')}
                 aria-label="Show version information panel"
               >
                 About this version
-                <SvgIcon
-                  name="arrow-right"
-                  className="help-panel__sub-panel-link-icon"
-                />
+                <SvgIcon name="arrow-right" />
               </button>
             )}
           </div>

--- a/src/sidebar/components/share-annotations-panel.js
+++ b/src/sidebar/components/share-annotations-panel.js
@@ -71,7 +71,7 @@ function ShareAnnotationsPanel({ analytics, toastMessenger }) {
           <div className="share-annotations-panel__input">
             <input
               aria-label="Use this URL to share these annotations"
-              className="form-input share-annotations-panel__form-input"
+              className="share-annotations-panel__form-input"
               type="text"
               value={shareURI}
               readOnly

--- a/src/sidebar/components/test/help-panel-test.js
+++ b/src/sidebar/components/test/help-panel-test.js
@@ -58,14 +58,16 @@ describe('HelpPanel', function () {
 
     it('should show navigation link to versionInfo sub-panel', () => {
       const wrapper = createComponent();
-      const link = wrapper.find('.help-panel__sub-panel-link');
+      const link = wrapper.find('.help-panel__sub-panel-navigation-button');
 
       assert.equal(link.text(), 'About this version');
     });
 
     it('should switch to versionInfo sub-panel when footer link clicked', () => {
       const wrapper = createComponent();
-      wrapper.find('.help-panel__sub-panel-link').simulate('click');
+      wrapper
+        .find('.help-panel__sub-panel-navigation-button')
+        .simulate('click');
 
       assert.equal(
         wrapper.find('.help-panel__sub-panel-title').text(),
@@ -83,9 +85,11 @@ describe('HelpPanel', function () {
   context('when viewing versionInfo sub-panel', () => {
     it('should show navigation link back to tutorial sub-panel', () => {
       const wrapper = createComponent();
-      wrapper.find('.help-panel__sub-panel-link').simulate('click');
+      wrapper
+        .find('.help-panel__sub-panel-navigation-button')
+        .simulate('click');
 
-      const link = wrapper.find('.help-panel__sub-panel-link');
+      const link = wrapper.find('.help-panel__sub-panel-navigation-button');
 
       assert.isTrue(wrapper.find('VersionInfo').exists());
       assert.isFalse(wrapper.find('Tutorial').exists());
@@ -96,9 +100,11 @@ describe('HelpPanel', function () {
       const wrapper = createComponent();
 
       // Click to get to version-info sub-panel...
-      wrapper.find('.help-panel__sub-panel-link').simulate('click');
+      wrapper
+        .find('.help-panel__sub-panel-navigation-button')
+        .simulate('click');
 
-      const link = wrapper.find('.help-panel__sub-panel-link');
+      const link = wrapper.find('.help-panel__sub-panel-navigation-button');
       // Click again to get back to tutorial sub-panel
       link.simulate('click');
 

--- a/src/styles/mixins/buttons.scss
+++ b/src/styles/mixins/buttons.scss
@@ -133,3 +133,19 @@
     text-decoration: underline;
   }
 }
+
+/**
+ * A button pattern that looks like a link with a small icon on the right
+ * Used, e.g., in the help panel to navigate between sub-panels
+ */
+@mixin button--navigation {
+  @include reset-native-btn-styles;
+  @include layout.row($justify: right, $align: center);
+  color: var.$color-brand;
+
+  svg {
+    margin-left: 2px;
+    width: 12px;
+    height: 12px;
+  }
+}

--- a/src/styles/mixins/forms.scss
+++ b/src/styles/mixins/forms.scss
@@ -49,6 +49,12 @@
   }
 }
 
+@mixin form-input--with-button {
+  @include form-input;
+  width: 100%;
+  border-radius: 0;
+}
+
 @mixin primary-action-btn {
   @include focus.outline-on-keyboard-focus;
   @include utils.font--medium;

--- a/src/styles/sidebar/components/annotation-action-bar.scss
+++ b/src/styles/sidebar/components/annotation-action-bar.scss
@@ -1,3 +1,0 @@
-.annotation-action-bar {
-  display: flex;
-}

--- a/src/styles/sidebar/components/annotation-share-control.scss
+++ b/src/styles/sidebar/components/annotation-share-control.scss
@@ -1,4 +1,5 @@
 @use '../../mixins/buttons';
+@use '../../mixins/forms';
 @use '../../mixins/layout';
 @use '../../mixins/molecules';
 @use "../../mixins/utils";
@@ -25,10 +26,10 @@
     padding: 0.25em 0.5em;
   }
 
-  & .form-input {
+  &__form-input {
+    @include forms.form-input--with-button;
     @include utils.font--small;
     padding: 0.5em;
-    border-radius: 0;
   }
 
   &__permissions {

--- a/src/styles/sidebar/components/annotation-share-control.scss
+++ b/src/styles/sidebar/components/annotation-share-control.scss
@@ -14,7 +14,6 @@
   right: 5px;
   bottom: 32px;
   width: 275px;
-  box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, 0.15);
   cursor: default;
 
   &__input {

--- a/src/styles/sidebar/components/annotation-user.scss
+++ b/src/styles/sidebar/components/annotation-user.scss
@@ -4,13 +4,5 @@
   &__user-name {
     color: var.$color-text;
     font-weight: bold;
-
-    .is-dimmed & {
-      color: var.$color-text-light;
-    }
-
-    .is-highlighted & {
-      color: var.$color-text;
-    }
   }
 }

--- a/src/styles/sidebar/components/annotation.scss
+++ b/src/styles/sidebar/components/annotation.scss
@@ -24,23 +24,6 @@
 .annotation {
   @include layout.vertical-rhythm;
 
-  &.is-highlighted {
-    // Slightly darken the bodies of highlighted annotations to
-    // make them stand out next to others, which will have the `is-dimmed` state
-    // set
-    .annotation-body {
-      color: var.$color-text;
-    }
-  }
-
-  &.is-dimmed {
-    // Lighten the bodies of dimmed annotations to make other
-    // annotations which are not dimmed stand out
-    .annotation-body {
-      color: var.$color-text-light;
-    }
-  }
-
   &__reply-toggle {
     @include buttons.button--link;
   }

--- a/src/styles/sidebar/components/focused-mode-header.scss
+++ b/src/styles/sidebar/components/focused-mode-header.scss
@@ -1,23 +1,27 @@
 @use "../../mixins/focus";
 @use "../../mixins/forms";
 @use "../../mixins/layout";
+@use "../../mixins/molecules";
 @use "../../mixins/utils";
 @use "../../variables" as var;
 
 // A dark grey button used for the primary action
 // in a form
 .focused-mode-header {
+  @include molecules.card-frame;
   @include layout.row($align: center);
-  @include utils.border;
   position: relative;
 
   background-color: var.$color-background;
   border-radius: 2px;
   font-weight: 300;
-  margin-bottom: 0.72em;
-  padding: 0.5em 1em;
+
+  // TODO cleanup
+  padding: 0.5em;
+  margin-bottom: 1em;
 
   &__btn {
+    // TODO use Button component
     @include forms.primary-action-btn;
     @include layout.row($align: center);
     margin-left: auto;

--- a/src/styles/sidebar/components/form-input.scss
+++ b/src/styles/sidebar/components/form-input.scss
@@ -1,8 +1,0 @@
-@use "../../mixins/forms";
-@use "../../variables" as var;
-
-.form-input {
-  @include forms.form-input;
-  width: 100%;
-  display: block;
-}

--- a/src/styles/sidebar/components/help-panel.scss
+++ b/src/styles/sidebar/components/help-panel.scss
@@ -1,17 +1,10 @@
 @use "../../mixins/buttons";
 @use "../../mixins/layout";
+@use "../../mixins/molecules";
 @use "../../mixins/utils";
 @use "../../variables" as var;
 
 .help-panel {
-  &__content {
-    @include layout.vertical_rhythm;
-  }
-
-  &__subtitle {
-    @include layout.row($justify: right, $align: center);
-  }
-
   &__sub-panel-title {
     @include utils.font--large;
     flex-grow: 1;
@@ -20,7 +13,6 @@
   &__subcontent {
     @include utils.border-top;
     @include utils.border-bottom;
-    padding: 0.5em 0;
 
     a {
       text-decoration: underline;
@@ -31,40 +23,11 @@
     @include utils.icon--xsmall;
   }
 
-  &__sub-panel-link {
-    @include buttons.reset-native-btn-styles;
-    @include layout.row($align: center);
-    margin-left: auto;
-    color: var.$color-brand;
-
-    &-icon {
-      margin-left: 2px;
-      width: 12px;
-      height: 12px;
-    }
+  &__sub-panel-navigation-button {
+    @include buttons.button--navigation;
   }
 
   &-tabs {
-    @include layout.row($align: center);
-
-    &__tab {
-      @include utils.font--large;
-      @include utils.border-right;
-      flex: 1 1;
-      text-align: center;
-      color: var.$color-text-light;
-
-      &:last-of-type {
-        border-right: none;
-      }
-    }
-
-    &__link {
-      color: var.$color-text-light;
-    }
-
-    &__icon {
-      @include utils.icon--xsmall;
-    }
+    @include molecules.panel-tabs;
   }
 }

--- a/src/styles/sidebar/components/share-annotations-panel.scss
+++ b/src/styles/sidebar/components/share-annotations-panel.scss
@@ -1,7 +1,8 @@
 @use "../../variables" as var;
 @use "../../mixins/buttons";
-@use "../../mixins/utils";
+@use "../../mixins/forms";
 @use "../../mixins/molecules";
+@use "../../mixins/utils";
 
 .share-annotations-panel {
   color: var.$color-text-light;
@@ -16,7 +17,7 @@
   }
 
   &__form-input {
-    border-radius: 0;
+    @include forms.form-input--with-button;
   }
 
   &__icon--inline {

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -13,7 +13,6 @@
 
 // Components
 // ----------
-@use './components/annotation-action-bar';
 @use './components/annotation';
 @use './components/annotation-body';
 @use './components/annotation-document-info';

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -27,7 +27,6 @@
 @use './components/button';
 @use './components/excerpt';
 @use './components/focused-mode-header';
-@use './components/form-input';
 @use './components/group-list';
 @use './components/group-list-item';
 @use './components/help-panel';

--- a/src/styles/util.scss
+++ b/src/styles/util.scss
@@ -10,6 +10,15 @@
   @include layout.row;
 }
 
+.u-layout-row--align-center,
+.u-layout-row--align-middle {
+  @include layout.row($align: center);
+}
+
+.u-vertical-rhythm {
+  @include layout.vertical-rhythm;
+}
+
 .u-screen-reader-only {
   @include a11y.screen-reader-only;
 }


### PR DESCRIPTION
Part of #2245 

This PR is a slightly grab-bag set of cleanup commits that improve usage of mixins, consolidate some patterns and remove some unneeded or unused CSS.

* Removed `annotation-action-bar` component style module because its only style could be replaced with a utility class
* Removed some classes that are not being used at all
* Make `FocusedModeHeader` use `card-frame` mixin instead of re-defining a card-like pattern
* Refactor `HelpPanel`'s styling — the reason this got a dive here was because I was using it as an exemplar in last week's discussion
* Remove the `form-input` component style module and move those rules into the `forms` mixins — this reflects our move toward having reusable mixins but not component style modules for things that aren't actually components

Following PRs won't be as here-and-there. Thanks for your patience!