### PR TITLE
Adjust highlight icon styling for better visibility

### DIFF
--- a/src/styles/sidebar/components/annotation-header.scss
+++ b/src/styles/sidebar/components/annotation-header.scss
@@ -44,7 +44,10 @@
   }
 
   &__highlight-icon {
-    @include utils.icon--xsmall;
-    color: var.$color-text;
+    @include utils.icon--small;
+    color: var.$color-text-light;
+    // Pull the icon down a tad for better vertical alignment with other
+    // items in the same layout row
+    margin-bottom: -1px;
   }
 }


### PR DESCRIPTION
This is a small PR to improve the appearance of the "highlight" icon within annotation cards. The recent CSS consolidation and icon update had it a little too small and a little too dark.

Before:

![image](https://user-images.githubusercontent.com/439947/85567043-88d1e880-b5fe-11ea-9c4d-a99e148f6986.png)


After:

![image](https://user-images.githubusercontent.com/439947/85566985-7ce62680-b5fe-11ea-978e-2a2e9b677109.png)

Overall, this use of an icon here still suffers from usability issues—it's not easy to visually parse, and the only extra disclosure requires a hover. But anyway!