### PR TITLE
Enable typechecking for `src/shared/*.js`

### DIFF
--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -75,7 +75,7 @@ export default class Bridge {
    *
    * @param {string} method - Name of remote method to call.
    * @param {any[]} args - Arguments to method.
-   * @param [Function] callback - Called with an array of results.
+   * @return {Promise<any[]>} - Array of results, one per connected frame
    */
   call(method, ...args) {
     let cb;

--- a/src/shared/discovery.js
+++ b/src/shared/discovery.js
@@ -2,7 +2,7 @@
  * Callback invoked when another frame is discovered in this window which runs
  * the Hypothesis sidebar or annotation layer code.
  *
- * @type {Function} DiscoveryCallback
+ * @callback DiscoveryCallback
  * @param {Window} source - The frame that was discovered.
  * @param {string} origin - The origin to use when posting messages to this frame.
  * @param {string} token - A random identifier used by this frame.
@@ -115,7 +115,7 @@ export default class Discovery {
     // window and send messages to them.
     const queue = [this.target.top];
     while (queue.length > 0) {
-      const parent = queue.shift();
+      const parent = /** @type {Window} */ (queue.shift());
       if (parent !== this.target) {
         parent.postMessage(beaconMessage, this.origin);
       }
@@ -176,7 +176,7 @@ export default class Discovery {
 
     // Notify caller of `startDiscovery` in this frame that we found another
     // frame.
-    if (discovered) {
+    if (discovered && this.onDiscovery) {
       this.onDiscovery.call(null, source, origin, token);
     }
   }

--- a/src/shared/injector.js
+++ b/src/shared/injector.js
@@ -96,6 +96,7 @@ export class Injector {
           const resolveErr = new Error(
             `Failed to construct dependency "${dependency}" of "${name}": ${e.message}`
           );
+          // @ts-ignore - `cause` is a custom property
           resolveErr.cause = e;
           throw resolveErr;
         }
@@ -143,7 +144,7 @@ export class Injector {
    * Run a function which uses one or more dependencies provided by the
    * container.
    *
-   * @param {Function} -
+   * @param {Function} callback -
    *   A callback to run, with dependencies annotated in the same way as
    *   functions or classes passed to `register`.
    * @return {any} - Returns the result of running the function.

--- a/src/shared/settings.js
+++ b/src/shared/settings.js
@@ -34,7 +34,7 @@ export function jsonConfigsFrom(document) {
   for (let i = 0; i < settingsElements.length; i++) {
     let settings;
     try {
-      settings = JSON.parse(settingsElements[i].textContent);
+      settings = JSON.parse(settingsElements[i].textContent || '');
     } catch (err) {
       console.warn(
         'Could not parse settings from js-hypothesis-config tags',

--- a/src/shared/shortcut.js
+++ b/src/shared/shortcut.js
@@ -44,10 +44,10 @@ export function matchShortcut(event, shortcut) {
   }
 
   const actualModifiers =
-    (event.ctrlKey && modifiers.ctrl) |
-    (event.metaKey && modifiers.meta) |
-    (event.altKey && modifiers.alt) |
-    (event.shiftKey && modifiers.shift);
+    (event.ctrlKey ? modifiers.ctrl : 0) |
+    (event.metaKey ? modifiers.meta : 0) |
+    (event.altKey ? modifiers.alt : 0) |
+    (event.shiftKey ? modifiers.shift : 0);
 
   return (
     actualModifiers === requiredModifiers &&
@@ -57,7 +57,7 @@ export function matchShortcut(event, shortcut) {
 
 /**
  * @typedef ShortcutOptions
- * @prop {HTMLElement} rootElement -
+ * @prop {HTMLElement} [rootElement] -
  *   Element on which the key event listener should be installed. Defaults to
  *   `document.body`.
  */
@@ -110,7 +110,7 @@ export function useShortcut(
 ) {
   useEffect(() => {
     if (!shortcut) {
-      return null;
+      return undefined;
     }
     return installShortcut(shortcut, onPress, { rootElement });
   }, [shortcut, onPress, rootElement]);

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -11,6 +11,7 @@
     "target": "ES2020"
   },
   "include": [
+    "shared/*.js",
     "sidebar/util/*.js"
   ]
 }


### PR DESCRIPTION
Enable typechecking of annotated functions in src/shared/, excluding
subdirectories for the moment.

This found a few minor mistakes with existing JSDoc usage and a missing null check.