### PR TITLE
Fix <SearchStatusBar> flicker

### DIFF
--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -138,7 +138,7 @@ function SidebarContent({
         <SidebarContentError errorType="group" onLoginRequest={onLogin} />
       )}
       {showTabs && <SelectionTabs isLoading={isLoading} />}
-      <SearchStatusBar />
+      {!hasContentError && <SearchStatusBar />}
       <ThreadList thread={rootThread} />
       {showLoggedOutMessage && <LoggedOutMessage onLogin={onLogin} />}
     </div>

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -76,7 +76,6 @@ function SidebarContent({
     hasDirectLinkedAnnotationError || hasDirectLinkedGroupError;
 
   const showTabs = !hasContentError && !hasAppliedFilter;
-  const showSearchStatus = !hasContentError && !isLoading;
 
   // Show a CTA to log in if successfully viewing a direct-linked annotation
   // and not logged in
@@ -139,7 +138,7 @@ function SidebarContent({
         <SidebarContentError errorType="group" onLoginRequest={onLogin} />
       )}
       {showTabs && <SelectionTabs isLoading={isLoading} />}
-      {showSearchStatus && <SearchStatusBar />}
+      <SearchStatusBar />
       <ThreadList thread={rootThread} />
       {showLoggedOutMessage && <LoggedOutMessage onLogin={onLogin} />}
     </div>

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -224,23 +224,6 @@ describe('SidebarContent', () => {
     assert.isTrue(wrapper.find('FocusedModeHeader').exists());
   });
 
-  it('renders search status', () => {
-    fakeStore.hasFetchedAnnotations.returns(true);
-    fakeStore.isLoading.returns(false);
-
-    const wrapper = createComponent();
-
-    assert.isTrue(wrapper.find('SearchStatusBar').exists());
-  });
-
-  it('does not render search status if annotations are loading', () => {
-    fakeStore.isLoading.returns(true);
-
-    const wrapper = createComponent();
-
-    assert.isFalse(wrapper.find('SearchStatusBar').exists());
-  });
-
   describe('selection tabs', () => {
     it('renders tabs', () => {
       const wrapper = createComponent();

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -169,8 +169,12 @@ describe('SidebarContent', () => {
 
       it('does not render tabs', () => {
         const wrapper = createComponent();
-
         assert.isFalse(wrapper.find('SelectionTabs').exists());
+      });
+
+      it('does not render search status', () => {
+        const wrapper = createComponent();
+        assert.isFalse(wrapper.find('SearchStatusBar').exists());
       });
     });
   });
@@ -194,8 +198,12 @@ describe('SidebarContent', () => {
 
     it('does not render tabs', () => {
       const wrapper = createComponent();
-
       assert.isFalse(wrapper.find('SelectionTabs').exists());
+    });
+
+    it('does not render search status', () => {
+      const wrapper = createComponent();
+      assert.isFalse(wrapper.find('SearchStatusBar').exists());
     });
   });
 
@@ -222,6 +230,11 @@ describe('SidebarContent', () => {
     const wrapper = createComponent();
 
     assert.isTrue(wrapper.find('FocusedModeHeader').exists());
+  });
+
+  it('renders the search status', () => {
+    const wrapper = createComponent();
+    assert.isTrue(wrapper.find('SearchStatusBar').exists());
   });
 
   describe('selection tabs', () => {


### PR DESCRIPTION
Don’t hide the component when `store.isLoading()` is true. This only causes a re-render of that component and momentarily removes it from the DOM. Its not actually invalid to show the filter buttons while loading because the filter is still being applied.


![no_flicker](https://user-images.githubusercontent.com/3939074/85628436-ff81dc80-b624-11ea-8375-4566bbbdd6c3.gif)

fixes https://github.com/hypothesis/client/issues/2194