### PR TITLE
Simplify `since:<time>` filter query parsing and remove `result:<term>` parsing

### DIFF
--- a/src/sidebar/services/search-filter.js
+++ b/src/sidebar/services/search-filter.js
@@ -15,16 +15,7 @@ function splitTerm(term) {
   }
 
   if (
-    [
-      'group',
-      'quote',
-      'result',
-      'since',
-      'tag',
-      'text',
-      'uri',
-      'user',
-    ].includes(filter)
+    ['group', 'quote', 'since', 'tag', 'text', 'uri', 'user'].includes(filter)
   ) {
     const data = term.slice(filter.length + 1);
     return [filter, data];
@@ -118,7 +109,7 @@ function toObject(searchText) {
 
 /**
  * @typedef Facet
- * @property {'and'|'or'|'min'} operator
+ * @property {'and'|'or'} operator
  * @property {string[]|number[]} terms
  */
 
@@ -143,7 +134,6 @@ function generateFacetedFilter(searchText, focusFilters = {}) {
   let terms;
   const any = [];
   const quote = [];
-  const result = [];
   const since = [];
   const tag = [];
   const text = [];
@@ -158,9 +148,6 @@ function generateFacetedFilter(searchText, focusFilters = {}) {
       switch (filter) {
         case 'quote':
           quote.push(fieldValue);
-          break;
-        case 'result':
-          result.push(fieldValue);
           break;
         case 'since':
           {
@@ -211,10 +198,6 @@ function generateFacetedFilter(searchText, focusFilters = {}) {
     quote: {
       terms: quote,
       operator: 'and',
-    },
-    result: {
-      terms: result,
-      operator: 'min',
     },
     since: {
       terms: since,


### PR DESCRIPTION
Simplify code in `search-filter.js` in preparation for enabling
typechecking of `src/sidebar/services`.

 - Use a single regex to parse the `<time><unit>` expression in `since:<time>` filter queries rather than
   two expressions per time unit.
 - Replace the use of manual offsets to get the `<value>` part of a `<field>:<value>` expression which is
   error prone.
 - Update JSDoc of various functions
 - Provide a fallback in case a tokenizing regex fails to match. I
   haven't verified that this fallback ever gets used, but it keeps both
   TS and the human reader happier
 - Remove `result:<term>` parsing. There were no tests for this and the code that filters annotations doesn't reference this field