### PR TITLE
Typecheck src/sidebar/services

### DIFF
--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -45,7 +45,7 @@ function stripInternalProperties(obj) {
  * Options controlling how an API call is made or processed.
  *
  * @typedef APICallOptions
- * @prop [boolean] includeMetadata - If false (the default), the response is
+ * @prop {boolean} [includeMetadata] - If false (the default), the response is
  *   just the JSON response from the API. If true, the response is an `APIResponse`
  *   containing additional metadata about the request and response.
  */
@@ -53,10 +53,10 @@ function stripInternalProperties(obj) {
 /**
  * Function which makes an API request.
  *
- * @typedef {function} APICallFunction
- * @param [any] params - A map of URL and query string parameters to include with the request.
- * @param [any] data - The body of the request.
- * @param [APICallOptions] options
+ * @callback APICallFunction
+ * @param {any} [params] - A map of URL and query string parameters to include with the request.
+ * @param {any} [data] - The body of the request.
+ * @param {APICallOptions} options
  * @return {Promise<any|APIResponse>}
  */
 
@@ -66,11 +66,11 @@ function stripInternalProperties(obj) {
  * @typedef {Object} APIMethodOptions
  * @prop {() => Promise<string>} getAccessToken -
  *   Function which acquires a valid access token for making an API request.
- * @prop [() => string|null] getClientId -
+ * @prop {() => string|null} getClientId -
  *   Function that returns a per-session client ID to include with the request
  *   or `null`.
- * @prop [() => any] onRequestStarted - Callback invoked when the API request starts.
- * @prop [() => any] onRequestFinished - Callback invoked when the API request finishes.
+ * @prop {() => any} onRequestStarted - Callback invoked when the API request starts.
+ * @prop {() => any} onRequestFinished - Callback invoked when the API request finishes.
  */
 
 // istanbul ignore next

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -4,6 +4,8 @@ import { combineGroups } from '../util/groups';
 import { awaitStateChange } from '../util/state';
 import { watch } from '../util/watch';
 
+/** @typedef {import('../../types/api').Group} Group */
+
 const DEFAULT_ORG_ID = '__default__';
 
 /**
@@ -11,8 +13,10 @@ const DEFAULT_ORG_ID = '__default__';
  */
 const DEFAULT_ORGANIZATION = {
   id: DEFAULT_ORG_ID,
+  name: '__DEFAULT__',
   logo:
     'data:image/svg+xml;utf8,' +
+    // @ts-ignore - TS doesn't know about .svg files.
     encodeURIComponent(require('../../images/icons/logo.svg')),
 };
 
@@ -93,7 +97,7 @@ export default function groups(
    * @param {boolean} isLoggedIn
    * @param {string|null} directLinkedAnnotationGroupId
    * @param {string|null} directLinkedGroupId
-   * @return {Group[]}
+   * @return {Promise<Group[]>}
    */
   async function filterGroups(
     groups,
@@ -107,6 +111,7 @@ export default function groups(
       if (
         directLinkedGroup &&
         !directLinkedGroup.isScopedToUri &&
+        directLinkedGroup.scopes &&
         directLinkedGroup.scopes.enforced
       ) {
         groups = groups.filter(g => g.id !== directLinkedGroupId);
@@ -365,6 +370,7 @@ export default function groups(
     addGroupsToStore(groups);
 
     if (error) {
+      // @ts-ignore - TS can't track the type of `error` here.
       toastMessenger.error(`Unable to fetch groups: ${error.message}`, {
         autoDismiss: false,
       });

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -54,7 +54,15 @@ export default function RootThread(
       // Is there a search query, or are we in an active (focused) focus mode?
       return state.selection.filterQuery || store.focusModeFocused();
     };
-    let filterFn;
+
+    const options = {
+      forceVisible: truthyKeys(state.selection.forceVisible),
+      expanded: store.expandedThreads(),
+      highlighted: state.selection.highlighted,
+      selected: truthyKeys(store.getSelectedAnnotationMap() || {}),
+      sortCompareFn: sortFn,
+    };
+
     if (shouldFilterThread()) {
       const filters = searchFilter.generateFacetedFilter(
         state.selection.filterQuery,
@@ -64,14 +72,13 @@ export default function RootThread(
         }
       );
 
-      filterFn = function (annot) {
+      options.filterFn = function (annot) {
         return viewFilter.filter([annot], filters).length > 0;
       };
     }
 
-    let threadFilterFn;
     if (state.route.name === 'sidebar' && !shouldFilterThread()) {
-      threadFilterFn = function (thread) {
+      options.threadFilterFn = function (thread) {
         if (!thread.annotation) {
           return false;
         }
@@ -85,15 +92,7 @@ export default function RootThread(
 
     // Get the currently loaded annotations and the set of inputs which
     // determines what is visible and build the visible thread structure
-    return buildThread(state.annotations.annotations, {
-      forceVisible: truthyKeys(state.selection.forceVisible),
-      expanded: store.expandedThreads(),
-      highlighted: state.selection.highlighted,
-      selected: truthyKeys(store.getSelectedAnnotationMap() || {}),
-      sortCompareFn: sortFn,
-      filterFn: filterFn,
-      threadFilterFn: threadFilterFn,
-    });
+    return buildThread(state.annotations.annotations, options);
   }
 
   /**

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -42,6 +42,7 @@ export default function router($window, store) {
       case 'annotation':
         {
           const id = params.id;
+          // @ts-ignore - TS doesn't know what properties `queryParams` has.
           delete queryParams.id;
           url = `/a/${id}`;
         }

--- a/src/sidebar/services/service-url.js
+++ b/src/sidebar/services/service-url.js
@@ -20,6 +20,7 @@ import * as urlUtil from '../util/url';
  * always returns empty strings as the URLs. After the links object has been
  * received from the API this function starts returning the real URLs.
  *
+ * @callback ServiceUrlGetter
  * @param {string} linkName - The name of the link to expand
  * @param {object} params - The params with which to expand the link
  * @returns {string} The expanded absolute URL, or an empty string if the
@@ -28,7 +29,10 @@ import * as urlUtil from '../util/url';
  *                 linkName is unknown
  * @throws {Error} If one or more of the params given isn't used in the URL
  *                 template
- *
+ */
+
+/**
+ * @return {ServiceUrlGetter}
  * @ngInject
  */
 export default function serviceUrl(store, apiRoutes) {

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -4,12 +4,7 @@ import * as sentry from '../util/sentry';
 
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
-/**
- * @typedef Profile
- *
- * An object returned by the API (`GET /api/profile`) containing profile data
- * for the current user.
- */
+/** @typedef {import('../../types/api').Profile} Profile */
 
 /**
  * This service handles fetching the user's profile, updating profile settings

--- a/src/sidebar/services/stream-filter.js
+++ b/src/sidebar/services/stream-filter.js
@@ -19,9 +19,9 @@
  * @prop {string} match_policy - TODO: Remove this, the backend doesn't use it any more.
  * @prop {FilterClause[]} clauses
  * @prop {Object} actions - TODO: Remove this, the backend doesn't use it any more.
- * @prop {boolean} [actions.create]
- * @prop {boolean} [actions.update]
- * @prop {boolean} [actions.delete]
+ *  @prop {boolean} [actions.create]
+ *  @prop {boolean} [actions.update]
+ *  @prop {boolean} [actions.delete]
  */
 
 /**

--- a/src/sidebar/services/stream-filter.js
+++ b/src/sidebar/services/stream-filter.js
@@ -1,4 +1,47 @@
 /**
+ * @typedef {'equals'|'one_of'} Operator
+ */
+
+/**
+ * Filter clause against which annotation updates are tested before being
+ * sent to the client.
+ *
+ * @typedef FilterClause
+ * @prop {string} field
+ * @prop {Operator} operator
+ * @prop {any} value
+ * @prop {boolean} case_sensitive - TODO: Backend doesn't use this at present,
+ *   but it seems important for certain fields (eg. ID).
+ */
+
+/**
+ * @typedef Filter
+ * @prop {string} match_policy - TODO: Remove this, the backend doesn't use it any more.
+ * @prop {FilterClause[]} clauses
+ * @prop {Object} actions - TODO: Remove this, the backend doesn't use it any more.
+ * @prop {boolean} [actions.create]
+ * @prop {boolean} [actions.update]
+ * @prop {boolean} [actions.delete]
+ */
+
+/**
+ * Return a filter which matches every update that is visible to the current user.
+ *
+ * @return {Filter}
+ */
+function defaultFilter() {
+  return {
+    match_policy: 'include_any',
+    clauses: [],
+    actions: {
+      create: true,
+      update: true,
+      delete: true,
+    },
+  };
+}
+
+/**
  * StreamFilter generates JSON-serializable configuration objects that
  * control which real-time updates are received from the annotation service.
  *
@@ -7,16 +50,16 @@
  */
 export default class StreamFilter {
   constructor() {
-    this.resetFilter();
+    this.filter = defaultFilter();
   }
 
   /**
    * Add a matching clause to the configuration.
    *
-   * @param field - Field to filter by
-   * @param operator - How to filter
-   * @param value - Value to match
-   * @param caseSensitive - Whether matching should be case sensitive
+   * @param {string} field - Field to filter by
+   * @param {Operator} operator - How to filter
+   * @param {any} value - Value to match
+   * @param {boolean} caseSensitive - Whether matching should be case sensitive
    */
   addClause(field, operator, value, caseSensitive = false) {
     this.filter.clauses.push({
@@ -35,15 +78,7 @@ export default class StreamFilter {
 
   /** Reset the configuration to return all updates. */
   resetFilter() {
-    this.filter = {
-      match_policy: 'include_any',
-      clauses: [],
-      actions: {
-        create: true,
-        update: true,
-        delete: true,
-      },
-    };
+    this.filter = defaultFilter();
     return this;
   }
 }

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -21,7 +21,7 @@ export default function tags(localStorage) {
    * Return a list of tag suggestions matching `query`.
    *
    * @param {string} query
-   * @param {number} limit - Optional limit of the results.
+   * @param {number|null} limit - Optional limit of the results.
    * @return {Tag[]} List of matching tags
    */
   function filter(query, limit = null) {
@@ -44,7 +44,7 @@ export default function tags(localStorage) {
    * Update the list of stored tag suggestions based on the tags that a user has
    * entered for a given annotation.
    *
-   * @param {Tag} tags - List of tags.
+   * @param {Tag[]} tags - List of tags.
    */
   function store(tags) {
     // Update the stored (tag, frequency) map.

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -507,13 +507,13 @@ describe('groups', function () {
       });
     });
 
-    it('injects a defalt organization if group is missing an organization', function () {
+    it('injects a default organization if group is missing an organization', function () {
       const svc = service();
       const groups = [{ id: '39r39f', name: 'Ding Dong!' }];
       fakeApi.groups.list.returns(Promise.resolve(groups));
       return svc.load().then(groups => {
         assert.isObject(groups[0].organization);
-        assert.hasAllKeys(groups[0].organization, ['id', 'logo']);
+        assert.hasAllKeys(groups[0].organization, ['id', 'name', 'logo']);
       });
     });
 

--- a/src/sidebar/services/toast-messenger.js
+++ b/src/sidebar/services/toast-messenger.js
@@ -44,8 +44,8 @@ export default function toastMessenger(store) {
    * extant in the store's collection of toast messages (i.e. has the same
    * `type` and `message` text of an existing message).
    *
-   * @param {('error'|'success')} type
-   * @param {string} message - The message to be rendered
+   * @param {('error'|'success'|'notice')} type
+   * @param {string} messageText - The message to be rendered
    * @param {MessageOptions} [options]
    */
   const addMessage = (

--- a/src/sidebar/services/view-filter.js
+++ b/src/sidebar/services/view-filter.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('../../types/api').Annotation} Annotation
+ */
+
 import { quote } from '../util/annotation-metadata';
 
 // Prevent Babel inserting helper code after `@ngInject` comment below which
@@ -10,6 +14,18 @@ function displayName(ann) {
   }
   return ann.user_info.display_name || '';
 }
+
+/**
+ * @typedef Filter
+ * @prop {(ann: Annotation) => boolean} matches
+ */
+
+/**
+ * @typedef Checker
+ * @prop {(ann: Annotation) => boolean} autofalse
+ * @prop {(ann: Annotation) => any|any[]} value
+ * @prop {(term: any, value: any) => boolean} match
+ */
 
 /**
  * Filter annotations against parsed search queries.
@@ -35,6 +51,8 @@ export default function ViewFilter(unicode) {
    * Filter that matches annotations against a single field & term.
    *
    * eg. "quote:foo" or "text:bar"
+   *
+   * @implements {Filter}
    */
   class TermFilter {
     /**
@@ -67,11 +85,13 @@ export default function ViewFilter(unicode) {
 
   /**
    * Filter that combines other filters using AND or OR combinators.
+   *
+   * @implements {Filter}
    */
   class BinaryOpFilter {
     /**
      * @param {'and'|'or'} op - Binary operator
-     * @param {Filter[]} - Array of filters to test against
+     * @param {Filter[]} filters - Array of filters to test against
      */
     constructor(op, filters) {
       this.operator = op;
@@ -95,6 +115,8 @@ export default function ViewFilter(unicode) {
    *   autofalse: a function for a preliminary false match result
    *   value: a function to extract to facet value for the annotation.
    *   match: a function to check if the extracted value matches the facet value
+   *
+   * @type {Object.<string,Checker>}
    */
   const fieldMatchers = {
     quote: {

--- a/src/sidebar/util/groups.js
+++ b/src/sidebar/util/groups.js
@@ -65,6 +65,10 @@ export function combineGroups(userGroups, featuredGroups, uri, settings) {
   return groups;
 }
 
+/**
+ * @param {Group} group
+ * @param {string} uri
+ */
 function isScopedToUri(group, uri) {
   /* If a scope check cannot be performed, meaning:
    * - the group doesn't have a scopes attribute

--- a/src/sidebar/util/retry.js
+++ b/src/sidebar/util/retry.js
@@ -5,7 +5,7 @@ import retry from 'retry';
  * fails after a set number of attempts.
  *
  * @param {Function} opFn - The operation to retry
- * @param {Object} options - The options object to pass to retry.operation()
+ * @param {Object} [options] - The options object to pass to retry.operation()
  *
  * @return A promise for the first successful result of the operation, if
  *         it succeeds within the allowed number of attempts.

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -16,6 +16,7 @@
     "boot/*.js",
     "shared/*.js",
     "sidebar/*.js",
+    "sidebar/services/*.js",
     "sidebar/util/*.js"
   ],
   "exclude": [

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -12,12 +12,18 @@
  * @prop {string} [id]
  * @prop {string[]} [references]
  * @prop {string} created
+ * @prop {string} updated
+ * @prop {string[]} tags
+ * @prop {string} text
+ * @prop {string} uri
+ * @prop {string} user
  */
 
 /**
  * TODO - Fill out remaining properties
  *
  * @typedef Profile
+ * @prop {string} userid
  * @prop {Object} preferences
  * @prop {boolean} preferences.show_sidebar_tutorial
  */
@@ -31,6 +37,12 @@
  */
 
 /**
+ * @typedef GroupScopes
+ * @prop {boolean} enforced
+ * @prop {string[]} uri_patterns;
+ */
+
+/**
  * TODO - Fill out remaining properties
  *
  * @typedef Group
@@ -38,6 +50,7 @@
  * @prop {'private'|'open'} type
  * @prop {Organization} organization - nb. This field is nullable in the API, but
  *   we assign a default organization on the client.
+ * @prop {GroupScopes|null} scopes
  *
  * // Properties not present on API objects, but added by utilities in the client.
  * @prop {string} logo

--- a/src/types/config.js
+++ b/src/types/config.js
@@ -11,6 +11,9 @@
  * @prop {string} apiUrl
  * @prop {string} authority
  * @prop {string} grantToken
+ * @prop {string[]|Promise<string[]>} [groups] -
+ *   List of groups to show. The embedder can specify an array. In the sidebar
+ *   this may be converted to a Promise if this information is fetched asynchronously.
  * @prop {boolean} [allowLeavingGroups]
  * @prop {boolean} [enableShareLinks]
  * @prop {Function} [onLoginRequest]


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/2273**~~

This PR enables initial typechecking of modules in src/sidebar/services and fixes up many issues/incompleteness with the existing JSDoc annotations.

Aside from finding some over-complex and error-prone code in [filter query parsing](https://github.com/hypothesis/client/pull/2273) this also turned up a potential issue in `src/sidebar/services/stream-filter.js` where we set a `case_sensitive` flag on the client for certain fields but nothing explicitly uses it on the backend. I haven't altered the code in this commit but have just flagged the issue. We also continue to set some fields which are still parsed on the backend but [comments in the source](https://github.com/hypothesis/h/blob/master/h/streamer/filter.py) indicate are ignored.