### PR TITLE
Refactor annotation publish control styling

### DIFF
--- a/src/sidebar/components/annotation-publish-control.js
+++ b/src/sidebar/components/annotation-publish-control.js
@@ -10,6 +10,7 @@ import { applyTheme } from '../util/theme';
 import Button from './button';
 import Menu from './menu';
 import MenuItem from './menu-item';
+import SvgIcon from '../../shared/components/svg-icon';
 
 /**
  * Render a compound control button for publishing (saving) an annotation:
@@ -53,32 +54,32 @@ function AnnotationPublishControl({
   };
 
   const menuLabel = (
-    <div className="annotation-publish-control__btn-dropdown-arrow">
-      <div className="annotation-publish-control__btn-dropdown-arrow-separator" />
-      <div
-        className="annotation-publish-control__btn-dropdown-arrow-indicator"
-        style={applyTheme(themeProps, settings)}
+    <div
+      className="annotation-publish-button__menu-label"
+      style={applyTheme(themeProps, settings)}
+    >
+      <SvgIcon
+        name="expand-menu"
+        className="annotation-publish-button__menu-icon"
       />
     </div>
   );
 
   return (
     <div className="annotation-publish-control">
-      <div className="annotation-publish-control__btn">
-        <button
-          className="annotation-publish-control__btn-primary"
+      <div className="annotation-publish-button">
+        <Button
+          className="annotation-publish-button__primary"
           style={applyTheme(themeProps, settings)}
           onClick={onSave}
           disabled={isDisabled}
-          aria-label={`Publish this annotation to ${publishDestination}`}
           title={`Publish this annotation to ${publishDestination}`}
-        >
-          Post to {publishDestination}
-        </button>
+          buttonText={`Post to ${publishDestination}`}
+        />
         <Menu
-          arrowClass="annotation-publish-control__btn-menu-arrow"
+          arrowClass="annotation-publish-button__menu-arrow"
           containerPositioned={false}
-          contentClass="annotation-publish-control__btn-menu-content"
+          contentClass="annotation-publish-button__menu-content"
           label={menuLabel}
           menuIndicator={false}
           title="Change annotation sharing setting"
@@ -98,12 +99,14 @@ function AnnotationPublishControl({
           />
         </Menu>
       </div>
-      <Button
-        icon="cancel"
-        buttonText="Cancel"
-        onClick={onCancel}
-        className="annotation-publish-control__btn-cancel"
-      />
+      <div>
+        <Button
+          icon="cancel"
+          className="annotation-publish-control__cancel-button"
+          buttonText="Cancel"
+          onClick={onCancel}
+        />
+      </div>
     </div>
   );
 }

--- a/src/sidebar/components/test/annotation-publish-control-test.js
+++ b/src/sidebar/components/test/annotation-publish-control-test.js
@@ -75,9 +75,7 @@ describe('AnnotationPublishControl', () => {
       const fakeStyle = { foo: 'bar' };
       fakeApplyTheme.returns(fakeStyle);
       const wrapper = createAnnotationPublishControl();
-      const btnPrimary = wrapper.find(
-        '.annotation-publish-control__btn-primary'
-      );
+      const btnPrimary = wrapper.find('.annotation-publish-button__primary');
 
       assert.calledWith(
         fakeApplyTheme,
@@ -89,7 +87,7 @@ describe('AnnotationPublishControl', () => {
   });
 
   describe('dropdown menu button (form submit button)', () => {
-    const btnClass = '.annotation-publish-control__btn-primary';
+    const btnClass = '.annotation-publish-button__primary';
     context('shared annotation', () => {
       it('should label the button with the group name', () => {
         const wrapper = createAnnotationPublishControl();
@@ -99,7 +97,6 @@ describe('AnnotationPublishControl', () => {
           btn.prop('title'),
           `Publish this annotation to ${fakeGroup.name}`
         );
-        assert.equal(btn.text(), `Post to ${fakeGroup.name}`);
       });
     });
 
@@ -112,7 +109,6 @@ describe('AnnotationPublishControl', () => {
 
         const btn = wrapper.find(btnClass);
         assert.equal(btn.prop('title'), 'Publish this annotation to Only Me');
-        assert.equal(btn.text(), 'Post to Only Me');
       });
     });
 
@@ -254,7 +250,7 @@ describe('AnnotationPublishControl', () => {
   describe('cancel button', () => {
     it('should remove the current draft on cancel button click', () => {
       const wrapper = createAnnotationPublishControl({});
-      const cancelBtn = wrapper.find('Button');
+      const cancelBtn = wrapper.find('Button').filter({ buttonText: 'Cancel' });
 
       cancelBtn.props().onClick();
 
@@ -266,7 +262,7 @@ describe('AnnotationPublishControl', () => {
     it('should remove the annotation from the store if it is new/unsaved', () => {
       fakeMetadata.isNew.returns(true);
       const wrapper = createAnnotationPublishControl({});
-      const cancelBtn = wrapper.find('Button');
+      const cancelBtn = wrapper.find('Button').filter({ buttonText: 'Cancel' });
 
       cancelBtn.props().onClick();
 

--- a/src/styles/mixins/buttons.scss
+++ b/src/styles/mixins/buttons.scss
@@ -46,7 +46,7 @@
     @include utils.icon--medium;
   }
 
-  &:hover {
+  &:hover:not([disabled]) {
     transition: 0.2s ease-out;
     color: var.$grey-7;
   }
@@ -64,7 +64,7 @@
   &[aria-pressed='true'] {
     color: var.$color-brand;
 
-    &:hover {
+    &:hover:not([disabled]) {
       color: var.$color-brand;
     }
   }
@@ -77,7 +77,7 @@
   font-weight: 700;
   background-color: var.$grey-1;
 
-  &:hover {
+  &:hover:not([disabled]) {
     background-color: var.$grey-2;
   }
 
@@ -96,9 +96,15 @@
   color: var.$grey-1;
   background-color: var.$grey-mid;
 
-  &:hover {
+  &:hover:not([disabled]) {
     color: var.$grey-1;
     background-color: var.$grey-6;
+  }
+
+  &:disabled {
+    // Note: this color does not meet WCAG contrast requirements,
+    // but is admissable because it is applied to disabled elements
+    color: var.$grey-semi;
   }
 }
 
@@ -116,7 +122,7 @@
   border-radius: 0; // Turn off border-radius to align with <input> edges
   border-left: 0; // Avoid double border with the <input>
 
-  &:hover {
+  &:hover:not([disabled]) {
     background-color: var.$grey-2;
   }
 }
@@ -128,7 +134,7 @@
   @include button;
   color: var.$grey-mid;
   padding: 0;
-  &:hover {
+  &:hover:not([disabled]) {
     color: var.$color-link-hover;
     text-decoration: underline;
   }

--- a/src/styles/sidebar/components/annotation-publish-control.scss
+++ b/src/styles/sidebar/components/annotation-publish-control.scss
@@ -1,118 +1,72 @@
 @use "../../mixins/buttons";
 @use "../../mixins/forms";
 @use "../../mixins/layout";
+@use "../../mixins/utils";
 @use "../../variables" as var;
 
 .annotation-publish-control {
   @include layout.row;
+  @include layout.horizontal-rhythm(var.$layout-space);
 
-  // A split button with a primary submit on the left and a drop-down menu
-  // of related options to the right
-  .annotation-publish-control__btn {
-    @include layout.row;
-    $text-color: var.$color-text-inverted;
-    $default-background-color: var.$grey-mid;
-    $hover-background-color: var.$grey-6;
-    $h-padding: 9px;
-    $height: 35px;
-    $arrow-indicator-width: 26px;
+  &__cancel-button {
+    @include buttons.button--labeled;
+    // TODO: Magic number
+    padding: 0.75em;
+  }
+}
 
-    height: $height;
-    position: relative;
-    margin-right: 1em;
+// A split button with a primary submit on the left and a drop-down menu
+// of related options to the right
+.annotation-publish-button {
+  @include layout.row;
+  // For proper menu alignment
+  position: relative;
 
-    // Align the menu arrow correctly with the ▼ in the toggle
-    &-menu-arrow {
-      right: 5px;
+  // Align the menu (upward) arrow correctly with the ▼ in the menu label icon
+  // Note the extra `&` needed for specificity against `Menu`'s own arrow styling
+  & &__menu-arrow {
+    right: 8px;
+  }
+
+  // Make sure the menu content is wide enough to "reach" to the right-aligned
+  // menu arrow
+  &__menu-content {
+    min-width: 100%;
+  }
+
+  &__primary {
+    @include buttons.button--primary;
+    // TODO magic number
+    padding: 0.75em;
+
+    // Turn off right-side border radius for alignment with menu label/button
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  // dropdown arrow which reveals the button's associated menu
+  // when clicked
+  &__menu-label {
+    @include layout.row(center);
+    color: var.$color-text-inverted;
+    background-color: var.$grey-mid;
+    // Make sure label element takes up full available vertical space
+    height: 100%;
+    // TODO magic number
+    padding: 0 0.75em;
+
+    // Add border radius to the right to match the left side of the primary button
+    border-top-right-radius: var.$border-radius;
+    border-bottom-right-radius: var.$border-radius;
+
+    &:hover {
+      background-color: var.$grey-6;
     }
+  }
 
-    // Make sure the menu content is wide enough to "reach" to the right-aligned
-    // menu arrow
-    &-menu-content {
-      min-width: 100%;
-    }
-
-    &-cancel {
-      @include buttons.button--labeled;
-      padding-right: var.$layout-space--small;
-      padding-left: var.$layout-space--small;
-
-      &__icon {
-        margin: 0;
-      }
-    }
-
-    &-primary {
-      @include forms.primary-action-btn;
-
-      // the label occupies the entire space of the button and
-      // shows a darker state on hover
-      width: 100%;
-      height: 100%;
-      text-align: left;
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-    }
-
-    // dropdown arrow which reveals the button's associated menu
-    // when clicked
-    &-dropdown-arrow {
-      @include layout.row(center);
-      right: 0px;
-      top: 0px;
-
-      height: 100%;
-      width: $arrow-indicator-width;
-
-      border: none;
-      background-color: var.$grey-mid;
-      border-top-right-radius: var.$border-radius;
-      border-bottom-right-radius: var.$border-radius;
-
-      &:hover,
-      button[aria-expanded='true'] & {
-        // Show a hover effect on hover or if associated menu is open
-        background-color: $hover-background-color;
-      }
-
-      &:hover &-separator,
-      button[aria-expanded='true'] &-separator {
-        // hide the 1px vertical separator when the dropdown arrow
-        // is hovered or menu is open
-        background-color: var.$grey-mid;
-      }
-
-      // 1px vertical separator between label and dropdown arrow
-      &-separator {
-        position: absolute;
-        top: 0px;
-        bottom: 0px;
-        margin-top: auto;
-        margin-bottom: auto;
-
-        width: 1px;
-        height: 15px;
-
-        background-color: var.$grey-5;
-      }
-
-      // the ▼ arrow which reveals the dropdown menu when clicked
-      &-indicator {
-        color: $text-color;
-        left: 0px;
-        right: 0px;
-        top: 0px;
-        bottom: 0px;
-        line-height: $height;
-        text-align: center;
-        width: 100%;
-
-        &:after {
-          content: '▼';
-          display: inline-block;
-          transform: scaleY(0.7);
-        }
-      }
-    }
+  &__menu-icon {
+    @include utils.icon--small;
+    // To properly vertically center menu-label icon
+    height: 100%;
   }
 }


### PR DESCRIPTION
Part of #2245 

## Motivation

`AnnotationPublishControl` styling was particularly legacy and complex. It contained unnecessary style rules, had rules nested too deep and was challenging to understand. The UI component was ready for a light refactoring to use `Button` and `SvgIcon` components.

Before these changes, you might be able to spot the odd little vertical artifact in the middle of the menu-icon arrow:

![image](https://user-images.githubusercontent.com/439947/85886562-536efb80-b7b4-11ea-9d72-8774106d0c70.png)

After these changes, the publish button menu uses the more standard menu icon, via `SvgIcon` instead of CSS content:

![image](https://user-images.githubusercontent.com/439947/85886640-74375100-b7b4-11ea-8efc-587e9ecd4d33.png)

This PR simplifies `AnnotationPublishControl` styling and brings it more in line with recent conventions.

## User-visible changes

The aforementioned swap of a CSS-generated arrow in preference of a more standard `SvgIcon` arrow.

## Other changes of note

* Updated `button` mixins to remove hover effects from disabled buttons. The publish control button may be the only time we disable a button in the app. I noticed that having a hover effect on a disabled button makes it feel like it's interactive, when it's not. So I went ahead and updated the base patterns.

## Follow-up

Next steps include readjusting our `space` variables to allow for a size between `0.5em` and `1em` — I missed a tone in the scale, as it were. `0.75em` is hard-coded in the `AnnotationPublishControl` SASS in this set of changes so as to not make this PR too wander-y.

At some point we may decide that the "split button" widget should be a pattern, and we can extract it.