### PR TITLE
Search and Select annotation clear one another

### DIFF
--- a/src/sidebar/components/search-input.js
+++ b/src/sidebar/components/search-input.js
@@ -29,7 +29,10 @@ export default function SearchInput({ alwaysExpanded, query, onSearch }) {
 
   const onSubmit = e => {
     e.preventDefault();
-    onSearch(input.current.value);
+    // Don't submit an empty query
+    if (input.current.value.trim()) {
+      onSearch(input.current.value);
+    }
   };
 
   // When the active query changes outside of this component, update the input

--- a/src/sidebar/components/test/search-input-test.js
+++ b/src/sidebar/components/test/search-input-test.js
@@ -61,6 +61,14 @@ describe('SearchInput', () => {
     assert.calledWith(onSearch, 'new-query');
   });
 
+  it('does not call `onSearch` if the input is blank', () => {
+    const onSearch = sinon.stub();
+    const wrapper = createSearchInput({ onSearch });
+    typeQuery(wrapper, ' ');
+    wrapper.find('form').simulate('submit');
+    assert.notCalled(onSearch);
+  });
+
   it('renders loading indicator when app is in a "loading" state', () => {
     fakeStore.isLoading.returns(true);
     const wrapper = createSearchInput();

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -149,7 +149,10 @@ const update = {
   },
 
   SELECT_ANNOTATIONS: function (state, action) {
-    return { selectedAnnotationMap: action.selection };
+    return {
+      selectedAnnotationMap: action.selection,
+      filterQuery: null,
+    };
   },
 
   FOCUS_ANNOTATIONS: function (state, action) {
@@ -247,6 +250,7 @@ const update = {
       filterQuery: action.query,
       forceVisible: {},
       expanded: {},
+      selectedAnnotationMap: {},
     };
   },
 

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -152,6 +152,12 @@ describe('sidebar/store/modules/selection', () => {
       store.selectAnnotations([]);
       assert.isNull(store.getSelectedAnnotationMap());
     });
+
+    it('clears the filter query when selecting an annotation', function () {
+      store.setFilterQuery('a-query');
+      store.selectAnnotations([1]);
+      assert.equal(getSelectionState().filterQuery, null);
+    });
   });
 
   describe('toggleSelectedAnnotations()', function () {
@@ -219,6 +225,12 @@ describe('sidebar/store/modules/selection', () => {
       store.setFilterQuery('some-query');
       assert.deepEqual(getSelectionState().forceVisible, {});
       assert.deepEqual(getSelectionState().expanded, {});
+    });
+
+    it('clears selectedAnnotationMap when setting the filter query', function () {
+      store.selectAnnotations([1, 2, 3]);
+      store.setFilterQuery('a-query');
+      assert.deepEqual(store.getSelectedAnnotationMap(), {});
     });
   });
 


### PR DESCRIPTION
Fix issue where searching and selecting an annotation will be additive and create an unexpected result.

1. When searching for an annotation, it clears the selection.
2. When selecting an annotation, the search is cleared.


fixes https://github.com/hypothesis/client/issues/2270

Testing with LMS: There are a lot of paths to testing this,I tried to mix up a few varieties, but you can see the filters stacking on master but clear eachother out with the fix. The focused user seems to work as intended.

**Master**
![old_filter](https://user-images.githubusercontent.com/3939074/86166662-fe8bf780-bac9-11ea-825f-95074695ce4f.gif)

-----------


**This branch**
![new_filter](https://user-images.githubusercontent.com/3939074/86166689-08155f80-baca-11ea-985d-d487050f35a1.gif)

