### PR TITLE
Typecheck SvgIcon

### DIFF
--- a/src/shared/components/svg-icon.js
+++ b/src/shared/components/svg-icon.js
@@ -54,6 +54,9 @@ export default function SvgIcon({
   const element = /** @type {Ref<HTMLElement>} */ (useRef());
   useLayoutEffect(() => {
     const svg = element.current.querySelector('svg');
+
+    // The icon should always contain an `<svg>` element, but check here as we
+    // don't validate the markup when it is registered.
     if (svg) {
       svg.setAttribute('class', className);
     }
@@ -89,7 +92,7 @@ SvgIcon.propTypes = {
 /**
  * Register icons for use with the `SvgIcon` component.
  *
- * @param {IconMap} icons - Object mapping icon names to SVG data.
+ * @param {IconMap} icons
  * @param {Object} options
  *  @param {boolean} [options.reset] - If `true`, remove existing registered icons.
  */

--- a/src/shared/components/svg-icon.js
+++ b/src/shared/components/svg-icon.js
@@ -6,7 +6,12 @@ import propTypes from 'prop-types';
 /**
  * Object mapping icon names to SVG markup.
  *
- * @typedef {{[name: string]: string}} IconMap
+ * @typedef {Object.<string,string>} IconMap
+ */
+
+/**
+ * @template T
+ * @typedef {import("preact/hooks").Ref<T>} Ref
  */
 
 /**
@@ -17,11 +22,23 @@ import propTypes from 'prop-types';
 let iconRegistry = {};
 
 /**
+ * @typedef SvgIconProps
+ * @prop {string} name - The name of the icon to display.
+ *   The name must match a name that has already been registered using the
+ *   `registerIcons` function.
+ * @prop {string} [className] - A CSS class to apply to the `<svg>` element.
+ * @prop {boolean} [inline] - Apply a style allowing for inline display of icon wrapper.
+ * @prop {string} [title] - Optional title attribute to apply to the SVG's containing `span`.
+ */
+
+/**
  * Component that renders icons using inline `<svg>` elements.
  * This enables their appearance to be customized via CSS.
  *
  * This matches the way we do icons on the website, see
  * https://github.com/hypothesis/h/pull/3675
+ *
+ * @param {SvgIconProps} props
  */
 export default function SvgIcon({
   name,
@@ -34,10 +51,12 @@ export default function SvgIcon({
   }
   const markup = { __html: iconRegistry[name] };
 
-  const element = useRef();
+  const element = /** @type {Ref<HTMLElement>} */ (useRef());
   useLayoutEffect(() => {
     const svg = element.current.querySelector('svg');
-    svg.setAttribute('class', className);
+    if (svg) {
+      svg.setAttribute('class', className);
+    }
   }, [
     className,
     // `markup` is a dependency of this effect because the SVG is replaced if
@@ -61,21 +80,9 @@ export default function SvgIcon({
 }
 
 SvgIcon.propTypes = {
-  /**
-   * The name of the icon to display.
-   *
-   * The name must match a name that has already been registered using the
-   * `registerIcons` function.
-   */
-  name: propTypes.string,
-
-  /** A CSS class to apply to the `<svg>` element. */
+  name: propTypes.string.isRequired,
   className: propTypes.string,
-
-  /** Apply a style allowing for inline display of icon wrapper */
   inline: propTypes.bool,
-
-  /** Optional title attribute to apply to the SVG's containing `span` */
   title: propTypes.string,
 };
 
@@ -83,7 +90,8 @@ SvgIcon.propTypes = {
  * Register icons for use with the `SvgIcon` component.
  *
  * @param {IconMap} icons - Object mapping icon names to SVG data.
- * @param {boolean} [options.reset] - If `true`, remove existing registered icons.
+ * @param {Object} options
+ *  @param {boolean} [options.reset] - If `true`, remove existing registered icons.
  */
 export function registerIcons(icons, { reset = false } = {}) {
   if (reset) {

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -15,6 +15,7 @@
     "annotator/util/*.js",
     "boot/*.js",
     "shared/*.js",
+    "shared/components/*.js",
     "sidebar/*.js",
     "sidebar/services/*.js",
     "sidebar/util/*.js"


### PR DESCRIPTION
Typecheck `shared/components/svg-icon.js`. This enables edit-time rather than
runtime detection of incorrect usage, as well as enabling UI component
props to reference types (eg. API objects) defined elsewhere with JSDoc.

Props are currently declared with both JSDoc and via
`SvgIcon.propTypes`. The intent is that the JSDoc is the canonical
definition, but `SvgIcon.propTypes` is still useful to catch incorrect
usage from other parts of the code which are currently not typechecked.

We might be able to auto-generate `propTypes` in future from the JSDoc, but I haven't found or built
a suitable tool for that yet.