### PR TITLE
Disable `_separate_replies` for annotation loading in sidebar (behind feature flag)

### DIFF
--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -1,6 +1,7 @@
 /**
  * A service for fetching annotations, filtered by document URIs and group.
  */
+
 import SearchClient from '../search-client';
 
 import { isReply } from '../util/annotation-metadata';
@@ -8,6 +9,7 @@ import { isReply } from '../util/annotation-metadata';
 // @ngInject
 export default function loadAnnotationsService(
   api,
+  features,
   store,
   streamer,
   streamFilter
@@ -39,6 +41,7 @@ export default function loadAnnotationsService(
   function searchAndLoad(uris, groupId) {
     searchClient = new SearchClient(api.search, {
       incremental: true,
+      separateReplies: !features.flagEnabled('client_do_not_separate_replies'),
     });
     searchClient.on('results', results => {
       if (results.length) {


### PR DESCRIPTION
Fixes https://github.com/hypothesis/private-issues/issues/41

This PR makes a change to the `LoadAnnotationsService` (and `SearchClient`) such that, if the corresponding `client_do_not_separate_replies` feature flag is enabled in `h`, `_separate_replies` (an API parameter for the annotations-search endpoint) is set to _false_ when fetching annotations and their replies in the sidebar view (it was previously set to `true` and will remain as such if the feature flag is not enabled).

Setting this parameter to _false_ assures that _all_ annotations and replies are retrieved, and that replies don't get left behind if there are a lot of them. 

Because the issue that this fixes is in a private repository, I'm going to attempt an explanation of it here.

## Explaining the Issue

The issue this PR attempts to fix was reported by users who reported that not all expected annotation replies were showing up in the sidebar. This problem appears to happen when a top-level annotation (or multiple top-level annotations) has a lot of replies.

When the `_separate_replies` parameter for the annotation-search API is `false` or not set, all matching annotations are returned in a single list (Array): top-level annotations and all replies are mingled in a single collection. One gets a response that looks roughly like so:

```
{
  total: 376; // Total number of all annotations—top-level AND replies combined—that match the current search
  rows: [ /* one "page" worth of annotations and replies */ ]
}
```

The client requests annotations in chunks ("pages") of 200 per request. Thus `rows` can only accommodate up to 200 annotations (and replies, mixed in) at a time. But after the first request the client can see that there is a total of 376 that should match, so it knows to make another request to get the other 176 annotations and replies.

When `_separate_replies` is set to `true`, however, the service will peel out annotations that are replies and return them in a separate list from the "main", top-level annotation results in the response. That ends up looking like the following in our example case:

```
{
  total: 53; // Total number of TOP-LEVEL annotations ONLY
  rows: [ /* up to 200 matching TOP-LEVEL annotations; in this case contains 53 annotations */],
  replies: [ /* up to 200 matching REPLIES */ ],
}
```

The crux of the issue here is that the service reports a total of 53 matches, but it's only counting top-level annotations. The response in this example will contain 53 top-level annotations and 200 replies. That's because there are only 53 top-level annotations to fetch. `replies` contains 200 replies because that's the size of the batch (page size).

Now the client will look and say, ah, the total number I'm after is 53 and I already have 253, so I'm done here! Even though there are still 123 replies that are missing (376 total matches - 53 top-level annotations - 200 replies fetched = 123 missing).

-----

A straightforward way to prevent this behavior is set the `_separate_replies` API parameter to `false` when fetching annotations in the sidebar. However, this change _could_ have side effects and as such is being released behind a feature flag initially for caution. Note that the `stream` view will still use `_separate_replies` when fetching its annotations. 

This PR ~~is~~ *was* in draft status because:

* General feedback solicited on approach
* It's a right PITA to test the feature-flag logic in `LoadAnnotationsService` as, at present in tests, `SearchClient` is implemented as a `FakeSearchClient` _object_ instead of mocking. ~~Thus, tests are not present~~ Fixed.
* ~~I'm not sure how far to flail around with improving JSDoc/getting type-checking ideal for the affected modules here and would like to consult.~~ (Resolved).

In testing this work, I also uncovered some (presumably orthogonal) issues of client performance when loading, rendering and interacting with large amounts of replies. 

## Before

Before these changes, on a page that has a large number of replies on a few top-level annotations, or with the feature flag disabled: 

![replies-before](https://user-images.githubusercontent.com/439947/86285954-91ed2780-bbb3-11ea-81c6-0e3b02797d03.gif)

It loads _relatively_ quickly, but is missing nearly _two-thirds_ of the replies—it's getting the wrong answer entirely! The first annotation should have 263 replies. It has zero here.

## After

After these changes, with feature flag enabled:
![replies-after](https://user-images.githubusercontent.com/439947/86286254-23f53000-bbb4-11ea-8139-0551a22b5d1d.gif)


The loading is slower, but it is loading nearly 600 annotations + replies, in three batches. It's getting the correct answer. You can also see that the replies kind of "stream" in and, as they do, counts increment and change.