### PR TITLE
Improve typechecking on annotation-metatdata

### DIFF
--- a/src/sidebar/util/annotation-metadata.js
+++ b/src/sidebar/util/annotation-metadata.js
@@ -8,9 +8,7 @@
 
 /** Extract a URI, domain and title from the given domain model object.
  *
- * @param {object} annotation
- * @returns {object} An object with three properties extracted from the model:
- *   uri, domain and title.
+ * @param {Annotation} annotation
  *
  */
 export function documentMetadata(annotation) {
@@ -267,9 +265,9 @@ export function location(annotation) {
     const targets = annotation.target || [];
     for (let i = 0; i < targets.length; i++) {
       const selectors = targets[i].selector || [];
-      for (let k = 0; k < selectors.length; k++) {
-        if (selectors[k].type === 'TextPositionSelector') {
-          return /** @type {TextPositionSelector} */ (selectors[k]).start;
+      for (const selector of selectors) {
+        if (selector.type === 'TextPositionSelector') {
+          return selector.start;
         }
       }
     }

--- a/src/sidebar/util/annotation-metadata.js
+++ b/src/sidebar/util/annotation-metadata.js
@@ -3,11 +3,12 @@
  */
 
 /** @typedef {import('../../types/api').Annotation} Annotation */
+/** @typedef {import('../../types/api').TextPositionSelector} TextPositionSelector */
+/** @typedef {import('../../types/api').TextQuoteSelector} TextQuoteSelector */
 
 /** Extract a URI, domain and title from the given domain model object.
  *
- * @param {object} annotation An annotation domain model object as received
- *   from the server-side API.
+ * @param {object} annotation
  * @returns {object} An object with three properties extracted from the model:
  *   uri, domain and title.
  *
@@ -36,7 +37,7 @@ export function documentMetadata(annotation) {
 /**
  * Return the domain and title of an annotation for display on an annotation
  * card.
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  */
 export function domainAndTitle(annotation) {
   return {
@@ -47,10 +48,7 @@ export function domainAndTitle(annotation) {
 }
 
 /**
- * Returns the uri or the incontext link from an annotation,
- * or null if the protocol is not http(s).
- *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  */
 function titleLinkFromAnnotation(annotation) {
   let titleLink = /** @type {string|null} */ (annotation.uri);
@@ -72,7 +70,7 @@ function titleLinkFromAnnotation(annotation) {
 /**
  * Returns the domain text from an annotation.
  *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  */
 function domainTextFromAnnotation(annotation) {
   const document = documentMetadata(annotation);
@@ -95,7 +93,7 @@ function domainTextFromAnnotation(annotation) {
  * Returns the title text from an annotation and crops it to 30 chars
  * if needed.
  *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  */
 function titleTextFromAnnotation(annotation) {
   const document = documentMetadata(annotation);
@@ -122,7 +120,7 @@ export function isReply(annotation) {
  * "New" means this annotation has been newly created client-side and not
  * saved to the server yet.
  *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  */
 export function isNew(annotation) {
   return !annotation.id;
@@ -131,7 +129,7 @@ export function isNew(annotation) {
 /**
  * Return `true` if the given annotation is public, `false` otherwise.
  *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  */
 export function isPublic(annotation) {
   let isPublic = false;
@@ -157,7 +155,7 @@ export function isPublic(annotation) {
  * as opposed to a Page Note which refers to the whole document or a reply,
  * which refers to another annotation.
  *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  */
 function hasSelector(annotation) {
   return !!(
@@ -173,7 +171,7 @@ function hasSelector(annotation) {
  * Returns false if anchoring is still in process but the flag indicating that
  * the initial timeout allowed for anchoring has expired.
  *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  */
 export function isWaitingToAnchor(annotation) {
   return (
@@ -186,7 +184,7 @@ export function isWaitingToAnchor(annotation) {
 /**
  * Has this annotation hidden by moderators?
  *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  * @return {boolean}
  */
 export function isHidden(annotation) {
@@ -199,7 +197,7 @@ export function isHidden(annotation) {
  * Highlights are generally identifiable by having no text content AND no tags,
  * but there is some nuance.
  *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  * @return {boolean}
  */
 export function isHighlight(annotation) {
@@ -233,7 +231,7 @@ export function isHighlight(annotation) {
 /**
  * Return `true` if the given annotation is an orphan.
  *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  */
 export function isOrphan(annotation) {
   return hasSelector(annotation) && annotation.$orphan;
@@ -242,7 +240,7 @@ export function isOrphan(annotation) {
 /**
  * Return `true` if the given annotation is a page note.
  *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  */
 export function isPageNote(annotation) {
   return !hasSelector(annotation) && !isReply(annotation);
@@ -251,7 +249,7 @@ export function isPageNote(annotation) {
 /**
  * Return `true` if the given annotation is a top level annotation, `false` otherwise.
  *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  */
 export function isAnnotation(annotation) {
   return !!(hasSelector(annotation) && !isOrphan(annotation));
@@ -259,7 +257,7 @@ export function isAnnotation(annotation) {
 
 /** Return a numeric key that can be used to sort annotations by location.
  *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  * @return {number} - A key representing the location of the annotation in
  *                    the document, where lower numbers mean closer to the
  *                    start.
@@ -271,7 +269,7 @@ export function location(annotation) {
       const selectors = targets[i].selector || [];
       for (let k = 0; k < selectors.length; k++) {
         if (selectors[k].type === 'TextPositionSelector') {
-          return selectors[k].start;
+          return /** @type {TextPositionSelector} */ (selectors[k]).start;
         }
       }
     }
@@ -283,7 +281,7 @@ export function location(annotation) {
  * Return the number of times the annotation has been flagged
  * by other users. If moderation metadata is not present, returns `null`.
  *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  * @return {number|null}
  */
 export function flagCount(annotation) {
@@ -296,7 +294,7 @@ export function flagCount(annotation) {
 /**
  * Return the text quote that an annotation refers to.
  *
- * @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  * @return {string|null}
  */
 export function quote(annotation) {
@@ -308,5 +306,5 @@ export function quote(annotation) {
     return null;
   }
   const quoteSel = target.selector.find(s => s.type === 'TextQuoteSelector');
-  return quoteSel ? quoteSel.exact : null;
+  return quoteSel ? /** @type {TextQuoteSelector}*/ (quoteSel).exact : null;
 }

--- a/src/sidebar/util/annotation-metadata.js
+++ b/src/sidebar/util/annotation-metadata.js
@@ -2,6 +2,8 @@
  * Utility functions for querying annotation metadata.
  */
 
+/** @typedef {import('../../types/api').Annotation} Annotation */
+
 /** Extract a URI, domain and title from the given domain model object.
  *
  * @param {object} annotation An annotation domain model object as received
@@ -12,7 +14,8 @@
  */
 export function documentMetadata(annotation) {
   const uri = annotation.uri;
-  let domain = new URL(uri).hostname;
+
+  let domain = new URL(/** @type {string} */ (uri)).hostname;
   let title = domain;
 
   if (annotation.document && annotation.document.title) {
@@ -33,6 +36,7 @@ export function documentMetadata(annotation) {
 /**
  * Return the domain and title of an annotation for display on an annotation
  * card.
+ * @param {Annotation} annotation - An annotation domain model object.
  */
 export function domainAndTitle(annotation) {
   return {
@@ -42,6 +46,12 @@ export function domainAndTitle(annotation) {
   };
 }
 
+/**
+ * Returns the uri or the incontext link from an annotation,
+ * or null if the protocol is not http(s).
+ *
+ * @param {Annotation} annotation - An annotation domain model object.
+ */
 function titleLinkFromAnnotation(annotation) {
   let titleLink = annotation.uri;
 
@@ -59,7 +69,11 @@ function titleLinkFromAnnotation(annotation) {
 
   return titleLink;
 }
-
+/**
+ * Returns the domain text from an annotation.
+ *
+ * @param {Annotation} annotation - An annotation domain model object.
+ */
 function domainTextFromAnnotation(annotation) {
   const document = documentMetadata(annotation);
 
@@ -77,6 +91,12 @@ function domainTextFromAnnotation(annotation) {
   return domainText;
 }
 
+/**
+ * Returns the title text from an annotation and crops it to 30 chars
+ * if needed.
+ *
+ * @param {Annotation} annotation - An annotation domain model object.
+ */
 function titleTextFromAnnotation(annotation) {
   const document = documentMetadata(annotation);
 
@@ -88,7 +108,11 @@ function titleTextFromAnnotation(annotation) {
   return titleText;
 }
 
-/** Return `true` if the given annotation is a reply, `false` otherwise. */
+/**
+ * Return `true` if the given annotation is a reply, `false` otherwise.
+ *
+ *  @param {Annotation} annotation - An annotation domain model object.
+ */
 export function isReply(annotation) {
   return (annotation.references || []).length > 0;
 }
@@ -97,12 +121,18 @@ export function isReply(annotation) {
  *
  * "New" means this annotation has been newly created client-side and not
  * saved to the server yet.
+ *
+ * @param {Annotation} annotation - An annotation domain model object.
  */
 export function isNew(annotation) {
   return !annotation.id;
 }
 
-/** Return `true` if the given annotation is public, `false` otherwise. */
+/**
+ * Return `true` if the given annotation is public, `false` otherwise.
+ *
+ * @param {Annotation} annotation - An annotation domain model object.
+ */
 export function isPublic(annotation) {
   let isPublic = false;
 
@@ -126,6 +156,8 @@ export function isPublic(annotation) {
  * An annotation which has a selector refers to a specific part of a document,
  * as opposed to a Page Note which refers to the whole document or a reply,
  * which refers to another annotation.
+ *
+ * @param {Annotation} annotation - An annotation domain model object.
  */
 function hasSelector(annotation) {
   return !!(
@@ -140,6 +172,8 @@ function hasSelector(annotation) {
  *
  * Returns false if anchoring is still in process but the flag indicating that
  * the initial timeout allowed for anchoring has expired.
+ *
+ * @param {Annotation} annotation - An annotation domain model object.
  */
 export function isWaitingToAnchor(annotation) {
   return (
@@ -152,7 +186,7 @@ export function isWaitingToAnchor(annotation) {
 /**
  * Has this annotation hidden by moderators?
  *
- * @param {Object} annotation
+ * @param {Annotation} annotation - An annotation domain model object.
  * @return {boolean}
  */
 export function isHidden(annotation) {
@@ -165,7 +199,7 @@ export function isHidden(annotation) {
  * Highlights are generally identifiable by having no text content AND no tags,
  * but there is some nuance.
  *
- * @param {Object} annotation
+ * @param {Annotation} annotation - An annotation domain model object.
  * @return {boolean}
  */
 export function isHighlight(annotation) {
@@ -196,23 +230,36 @@ export function isHighlight(annotation) {
   );
 }
 
-/** Return `true` if the given annotation is an orphan. */
+/**
+ * Return `true` if the given annotation is an orphan.
+ *
+ * @param {Annotation} annotation - An annotation domain model object.
+ */
 export function isOrphan(annotation) {
   return hasSelector(annotation) && annotation.$orphan;
 }
 
-/** Return `true` if the given annotation is a page note. */
+/**
+ * Return `true` if the given annotation is a page note.
+ *
+ * @param {Annotation} annotation - An annotation domain model object.
+ */
 export function isPageNote(annotation) {
   return !hasSelector(annotation) && !isReply(annotation);
 }
 
-/** Return `true` if the given annotation is a top level annotation, `false` otherwise. */
+/**
+ * Return `true` if the given annotation is a top level annotation, `false` otherwise.
+ *
+ * @param {Annotation} annotation - An annotation domain model object.
+ */
 export function isAnnotation(annotation) {
   return !!(hasSelector(annotation) && !isOrphan(annotation));
 }
 
 /** Return a numeric key that can be used to sort annotations by location.
  *
+ * @param {Annotation} annotation - An annotation domain model object.
  * @return {number} - A key representing the location of the annotation in
  *                    the document, where lower numbers mean closer to the
  *                    start.
@@ -236,25 +283,27 @@ export function location(annotation) {
  * Return the number of times the annotation has been flagged
  * by other users. If moderation metadata is not present, returns `null`.
  *
+ * @param {Annotation} annotation - An annotation domain model object.
  * @return {number|null}
  */
-export function flagCount(ann) {
-  if (!ann.moderation) {
+export function flagCount(annotation) {
+  if (!annotation.moderation) {
     return null;
   }
-  return ann.moderation.flagCount;
+  return annotation.moderation.flagCount;
 }
 
 /**
  * Return the text quote that an annotation refers to.
  *
+ * @param {Annotation} annotation - An annotation domain model object.
  * @return {string|null}
  */
-export function quote(ann) {
-  if (ann.target.length === 0) {
+export function quote(annotation) {
+  if (annotation.target.length === 0) {
     return null;
   }
-  const target = ann.target[0];
+  const target = annotation.target[0];
   if (!target.selector) {
     return null;
   }

--- a/src/sidebar/util/annotation-metadata.js
+++ b/src/sidebar/util/annotation-metadata.js
@@ -15,7 +15,7 @@
 export function documentMetadata(annotation) {
   const uri = annotation.uri;
 
-  let domain = new URL(/** @type {string} */ (uri)).hostname;
+  let domain = new URL(uri).hostname;
   let title = domain;
 
   if (annotation.document && annotation.document.title) {
@@ -53,7 +53,7 @@ export function domainAndTitle(annotation) {
  * @param {Annotation} annotation - An annotation domain model object.
  */
 function titleLinkFromAnnotation(annotation) {
-  let titleLink = annotation.uri;
+  let titleLink = /** @type {string|null} */ (annotation.uri);
 
   if (
     titleLink &&

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -15,7 +15,7 @@
  * @prop {string} updated
  * @prop {string[]} tags
  * @prop {string} text
- * @prop {string|null} uri
+ * @prop {string} uri
  * @prop {string} user
  * @prop {boolean} hidden
  * @prop {boolean} [$highlight]

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -6,6 +6,25 @@
  */
 
 /**
+ * @typedef TextQuoteSelector
+ * @prop {'TextQuoteSelector'} type
+ * @prop {string} exact
+ * @prop {string} [prefix]
+ * @prop {string} [suffix]
+ */
+
+/**
+ * @typedef TextPositionSelector
+ * @prop {'TextPositionSelector'} type
+ * @prop {number} start
+ * @prop {number} end
+ */
+
+/**
+ * @typedef {TextQuoteSelector | TextPositionSelector} Selector
+ */
+
+/**
  * TODO - Fill out remaining properties
  *
  * @typedef Annotation
@@ -18,9 +37,6 @@
  * @prop {string} uri
  * @prop {string} user
  * @prop {boolean} hidden
- * @prop {boolean} [$highlight]
- * @prop {boolean} [$orphan]
- * @prop {boolean} [$anchorTimeout]
  *
  * @prop {Object} document
  *   @prop {string} document.title
@@ -32,17 +48,19 @@
  *
  * @prop {Object[]} target
  *   @prop {string} target.source
- *   @prop {Object[]} target.selector
- *     @prop {string} target.selector.type
- *     @prop {string} target.selector.exact
- *     @prop {number} target.selector.start
+ *   @prop {Selector[]} [target.selector]
  *
- * @prop {Object} moderation
+ * @prop {Object} [moderation]
  *   @prop {number} moderation.flagCount
  *
  * @prop {Object} links
- *   @prop {string} links.incontext
- *   @prop {string} links.html
+ *   @prop {string} [links.incontext]
+ *   @prop {string} [links.html]
+ *
+ * // Properties not present on API objects, but added by utilities in the client.
+ * @prop {boolean} [$highlight]
+ * @prop {boolean} [$orphan]
+ * @prop {boolean} [$anchorTimeout]
  */
 
 /**

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -15,8 +15,34 @@
  * @prop {string} updated
  * @prop {string[]} tags
  * @prop {string} text
- * @prop {string} uri
+ * @prop {string|null} uri
  * @prop {string} user
+ * @prop {boolean} hidden
+ * @prop {boolean} [$highlight]
+ * @prop {boolean} [$orphan]
+ * @prop {boolean} [$anchorTimeout]
+ *
+ * @prop {Object} document
+ *   @prop {string} document.title
+ *
+ * @prop {Object} permissions
+ *   @prop {string[]} permissions.read
+ *   @prop {string[]} permissions.update
+ *   @prop {string[]} permissions.delete
+ *
+ * @prop {Object[]} target
+ *   @prop {string} target.source
+ *   @prop {Object[]} target.selector
+ *     @prop {string} target.selector.type
+ *     @prop {string} target.selector.exact
+ *     @prop {number} target.selector.start
+ *
+ * @prop {Object} moderation
+ *   @prop {number} moderation.flagCount
+ *
+ * @prop {Object} links
+ *   @prop {string} links.incontext
+ *   @prop {string} links.html
  */
 
 /**

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -21,7 +21,16 @@
  */
 
 /**
- * @typedef {TextQuoteSelector | TextPositionSelector} Selector
+ * @typedef RangeSelector
+ * @prop {'RangeSelector'} type
+ * @prop {string} startContainer
+ * @prop {string} endContainer
+ * @prop {number} startOffset
+ * @prop {number} endOffset
+ */
+
+/**
+ * @typedef {TextQuoteSelector | TextPositionSelector | RangeSelector} Selector
  */
 
 /**


### PR DESCRIPTION
Further fill in the {Annotation} typedef

----

pretty straightforward PR, I made a choice to nest objects all under the `Annotation` type rather than make custom `@typdefs` for the sub-objects that really wouldn't stand on their own or have much meaning by themselves. 