### PR TITLE
Improve typechecking on several store util modules

### DIFF
--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -23,15 +23,19 @@ import { createReducer, bindSelectors } from './util';
  * the store.
  *
  * @param {Object[]} modules
- * @param {any[]} initArgs - Arguments to pass to each state module's `init` function
- * @param [any[]] middleware - List of additional Redux middlewares to use.
+ * @param {any[]} [initArgs] - Arguments to pass to each state module's `init` function
+ * @param {any[]} [middleware] - List of additional Redux middlewares to use.
  */
 export default function createStore(modules, initArgs = [], middleware = []) {
   // Create the initial state and state update function.
 
   // Namespaced objects for initial states.
   const initialState = {};
-  // Namespaced reducers from each module.
+
+  /**
+   * Namespaced reducers from each module.
+   * @type {import("redux").ReducersMapObject} allReducers
+   */
   const allReducers = {};
   // Namespaced selectors from each module.
   const allSelectors = {};

--- a/src/sidebar/store/debug-middleware.js
+++ b/src/sidebar/store/debug-middleware.js
@@ -22,7 +22,7 @@ export default function debugMiddleware(store) {
   return function (next) {
     return function (action) {
       // @ts-ignore The window interface needs to be expanded to include this property
-      if (/** @type {Window & HypothesisGlobals} */ (!window).debug) {
+      if (!(/** @type {Window & HypothesisGlobals} */ (window).debug)) {
         next(action);
         return;
       }

--- a/src/sidebar/store/debug-middleware.js
+++ b/src/sidebar/store/debug-middleware.js
@@ -1,4 +1,9 @@
 /**
+ * @typedef HypothesisGlobals
+ * @prop {boolean} debug
+ */
+
+/**
  * A debug utility that prints information about internal application state
  * changes to the console.
  *
@@ -7,6 +12,8 @@
  * When enabled, every action that changes application state will be printed
  * to the console, along with the application state before and after the action
  * was handled.
+ *
+ * @param {import("redux").Store} store
  */
 export default function debugMiddleware(store) {
   /* eslint-disable no-console */
@@ -14,7 +21,8 @@ export default function debugMiddleware(store) {
 
   return function (next) {
     return function (action) {
-      if (!window.debug) {
+      // @ts-ignore The window interface needs to be expanded to include this property
+      if (/** @type {Window & HypothesisGlobals} */ (!window).debug) {
         next(action);
         return;
       }
@@ -29,7 +37,7 @@ export default function debugMiddleware(store) {
       next(action);
 
       console.log('Next State:', store.getState());
-      console.groupEnd(groupTitle);
+      console.groupEnd();
     };
   };
   /* eslint-enable no-console */

--- a/src/sidebar/store/debug-middleware.js
+++ b/src/sidebar/store/debug-middleware.js
@@ -1,9 +1,4 @@
 /**
- * @typedef HypothesisGlobals
- * @prop {boolean} debug
- */
-
-/**
  * A debug utility that prints information about internal application state
  * changes to the console.
  *
@@ -22,7 +17,7 @@ export default function debugMiddleware(store) {
   return function (next) {
     return function (action) {
       // @ts-ignore The window interface needs to be expanded to include this property
-      if (!(/** @type {Window & HypothesisGlobals} */ (window).debug)) {
+      if (!window.debug) {
         next(action);
         return;
       }

--- a/src/sidebar/store/use-store.js
+++ b/src/sidebar/store/use-store.js
@@ -50,7 +50,7 @@ export default function useStore(callback) {
 
   // Store the last-used callback in a ref so we can access it in the effect
   // below without having to re-subscribe to the store when it changes.
-  const lastCallback = /** @type {Ref<HTMLElement>} */ useRef();
+  const lastCallback = useRef();
   lastCallback.current = callback;
 
   const lastResult = useRef();

--- a/src/sidebar/store/use-store.js
+++ b/src/sidebar/store/use-store.js
@@ -51,7 +51,7 @@ export default function useStore(callback) {
 
   // Store the last-used callback in a ref so we can access it in the effect
   // below without having to re-subscribe to the store when it changes.
-  const lastCallback = useRef(/** @type {typeof callback|null} */ (null));
+  const lastCallback = useRef(/** @type {StoreCallback<T>|null} */ (null));
   lastCallback.current = callback;
 
   const lastResult = useRef(/** @type {T|undefined} */ (undefined));

--- a/src/sidebar/store/use-store.js
+++ b/src/sidebar/store/use-store.js
@@ -11,9 +11,10 @@ import { useService } from '../util/service-context';
  */
 
 /**
+ * @template T
  * @callback StoreCallback
  * @param {Store} store
- * @return {any}
+ * @return {T}
  */
 
 /**
@@ -40,7 +41,7 @@ import { useService } from '../util/service-context';
  *   }
  *
  * @template T
- * @param {StoreCallback} callback -
+ * @param {StoreCallback<T>} callback -
  *   Callback that receives the store as an argument and returns some state
  *   and/or actions extracted from the store.
  * @return {T} - The result of `callback(store)`
@@ -50,10 +51,10 @@ export default function useStore(callback) {
 
   // Store the last-used callback in a ref so we can access it in the effect
   // below without having to re-subscribe to the store when it changes.
-  const lastCallback = useRef();
+  const lastCallback = useRef(/** @type {typeof callback|null} */ (null));
   lastCallback.current = callback;
 
-  const lastResult = useRef();
+  const lastResult = useRef(/** @type {T|undefined} */ (undefined));
   lastResult.current = callback(store);
 
   // Check for a performance issue caused by `callback` returning a different
@@ -75,7 +76,7 @@ export default function useStore(callback) {
   // and re-render the component if the result changed.
   useEffect(() => {
     function checkForUpdate() {
-      const result = /** @type {StoreCallback} */ (lastCallback.current)(store);
+      const result = lastCallback.current(store);
       if (shallowEqual(result, lastResult.current)) {
         return;
       }
@@ -94,5 +95,5 @@ export default function useStore(callback) {
     return unsubscribe;
   }, [forceUpdate, store]);
 
-  return /** @type {T} */ (lastResult.current);
+  return lastResult.current;
 }

--- a/src/sidebar/util/service-context.js
+++ b/src/sidebar/util/service-context.js
@@ -8,6 +8,10 @@
  *     https://reactjs.org/docs/hooks-reference.html#usecontext
  */
 
+/**
+ * @typedef {import("redux").Store} Store
+ */
+
 import { createContext, createElement } from 'preact';
 import { useContext } from 'preact/hooks';
 
@@ -103,6 +107,7 @@ export function withServices(Component) {
  * context of custom hooks.
  *
  * @param {string} service - Name of the service to look up
+ * @return {Store}
  */
 export function useService(service) {
   const injector = useContext(ServiceContext);

--- a/src/sidebar/util/service-context.js
+++ b/src/sidebar/util/service-context.js
@@ -107,7 +107,7 @@ export function withServices(Component) {
  * context of custom hooks.
  *
  * @param {string} service - Name of the service to look up
- * @return {Store}
+ * @return {Object}
  */
 export function useService(service) {
   const injector = useContext(ServiceContext);

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -20,7 +20,13 @@
     "sidebar/*.js",
     "sidebar/store/modules/*.js",
     "sidebar/services/*.js",
-    "sidebar/util/*.js"
+    "sidebar/util/*.js",
+
+    // TODO replace these with sidebar/store/* when all modules are converted
+    "sidebar/store/create-store.js",
+    "sidebar/store/debug-middleware.js",
+    "sidebar/store/use-store.js",
+    
   ],
   "exclude": [
     // Enable this once the rest of `src/sidebar` is checked.


### PR DESCRIPTION
This is sort of a first attempt at getting some of the store utility modules converted over. I don't have a great sense of what level of complexity this is for TS because I have not got very far with many conversions. I'll learn more as I go.

Note. `create-store.js` could be improved by flushing out the `createReducer` function in `util.js` but the return types are very complex at first glance. Its getting into the weeds with redux ts and I can't make too much sense of that today just looking at the redux ts file.  It may very well involve small modifications to our code or some heavy handed casting. But for now, I'm just avoiding adding a return type to `createReducer` and just casting variables that use it -- I'm not entirely sure that's the best way to go about this either but TS is happy for now.


