### PR TITLE
POC - Alternate fix for menu button layout issue in Safari

### DIFF
--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -25,6 +25,37 @@ const menuArrow = className => (
 let ignoreNextClick = false;
 
 /**
+ * A `<button>` element implemented with `<div role="button">`.
+ *
+ * This exists to work around a rendering issue with `<button>`s in Safari.
+ * See https://github.com/hypothesis/client/issues/2302.
+ */
+function PseudoButton({ children, onClick, ...props }) {
+  const handleKeyUp = event => {
+    // See https://www.w3.org/TR/wai-aria-practices/#keyboard-interaction-3
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.target.click();
+    }
+  };
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onKeyUp={handleKeyUp}
+      onClick={onClick}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+PseudoButton.propTypes = {
+  children: propTypes.any,
+  onClick: propTypes.func,
+};
+
+/**
  * A drop-down menu.
  *
  * Menus consist of a button which toggles whether the menu is open, an
@@ -130,7 +161,7 @@ export default function Menu({
       // except for the toggle button.
       onMouseDown={stopPropagation}
     >
-      <button
+      <PseudoButton
         aria-expanded={isOpen ? 'true' : 'false'}
         aria-haspopup={true}
         className="menu__toggle"
@@ -152,7 +183,7 @@ export default function Menu({
             </span>
           )}
         </span>
-      </button>
+      </PseudoButton>
       {isOpen && (
         <Fragment>
           {menuArrow(arrowClass)}

--- a/src/sidebar/components/menu.js
+++ b/src/sidebar/components/menu.js
@@ -170,19 +170,14 @@ export default function Menu({
         aria-label={title}
         title={title}
       >
-        <span
-          // wrapper is needed to serve as the flex layout for the label and indicator content.
-          className="menu__toggle-wrapper"
-        >
-          {label}
-          {menuIndicator && (
-            <span
-              className={classnames('menu__toggle-arrow', isOpen && 'is-open')}
-            >
-              <SvgIcon name="expand-menu" className="menu__toggle-icon" />
-            </span>
-          )}
-        </span>
+        {label}
+        {menuIndicator && (
+          <span
+            className={classnames('menu__toggle-arrow', isOpen && 'is-open')}
+          >
+            <SvgIcon name="expand-menu" className="menu__toggle-icon" />
+          </span>
+        )}
       </PseudoButton>
       {isOpen && (
         <Fragment>

--- a/src/sidebar/components/test/menu-test.js
+++ b/src/sidebar/components/test/menu-test.js
@@ -46,21 +46,34 @@ describe('Menu', () => {
     }
   });
 
+  function getMenuToggle(wrapper) {
+    return wrapper.find('div.menu__toggle');
+  }
+
   it('opens and closes when the toggle button is clicked', () => {
     const wrapper = createMenu();
     assert.isFalse(isOpen(wrapper));
-    wrapper.find('button').simulate('click');
+    getMenuToggle(wrapper).simulate('click');
     assert.isTrue(isOpen(wrapper));
-    wrapper.find('button').simulate('click');
+    getMenuToggle(wrapper).simulate('click');
+    assert.isFalse(isOpen(wrapper));
+  });
+
+  it('opens and closes when the toggle button is activated by keypress', () => {
+    const wrapper = createMenu();
+    assert.isFalse(isOpen(wrapper));
+    getMenuToggle(wrapper).simulate('keyup', { key: 'Enter' });
+    assert.isTrue(isOpen(wrapper));
+    getMenuToggle(wrapper).simulate('keyup', { key: ' ' });
     assert.isFalse(isOpen(wrapper));
   });
 
   it('calls `onOpenChanged` prop when menu is opened or closed', () => {
     const onOpenChanged = sinon.stub();
     const wrapper = createMenu({ onOpenChanged });
-    wrapper.find('button').simulate('click');
+    getMenuToggle(wrapper).simulate('click');
     assert.calledWith(onOpenChanged, true);
-    wrapper.find('button').simulate('click');
+    getMenuToggle(wrapper).simulate('click');
     assert.calledWith(onOpenChanged, false);
   });
 
@@ -68,9 +81,9 @@ describe('Menu', () => {
     const wrapper = createMenu();
     assert.isFalse(isOpen(wrapper));
 
-    wrapper.find('button').simulate('mousedown');
+    getMenuToggle(wrapper).simulate('mousedown');
     // Make sure the follow-up click doesn't close the menu.
-    wrapper.find('button').simulate('click');
+    getMenuToggle(wrapper).simulate('click');
 
     assert.isTrue(isOpen(wrapper));
   });

--- a/src/styles/sidebar/components/menu.scss
+++ b/src/styles/sidebar/components/menu.scss
@@ -3,6 +3,8 @@
 @use "../../mixins/utils";
 @use "../../variables" as var;
 
+// Container for the menu toggle button and absolutely positioned elements
+// that show the menu content when open.
 .menu {
   position: relative;
 }
@@ -11,16 +13,16 @@
 .menu__toggle {
   @include focus.outline-on-keyboard-focus;
 
+  display: flex;
+  align-items: center;
+  height: 100%;
+
   appearance: none;
   border: none;
   background: none;
   padding: 0;
   color: inherit;
-  // "block" display is needed so it can take up the
-  //  full height of its parent container
-  display: block;
-  height: 100%;
-  align-items: center;
+
   &:hover {
     transition: 0.2s ease-out;
     color: var.$color-text;
@@ -31,10 +33,6 @@
   }
 }
 
-.menu__toggle-wrapper {
-  @include layout.row($align: center);
-  height: 100%;
-}
 .menu__toggle-icon {
   @include utils.icon--xsmall;
 }


### PR DESCRIPTION
I spent some more time debugging https://github.com/hypothesis/client/issues/2302 this morning to try and understand what was going on. The main discovery is that the issue appears to be [specific to the use of a `<button>` element](https://github.com/hypothesis/client/issues/2302#issuecomment-654632234) and the inconsistency disappears when a generic element is used instead.

In #2302, what we are trying to do is ultimately to render the menu dropdown toggle with a custom background color, hover state and border. There are several ways this could be fixed:

1. In https://github.com/hypothesis/client/pull/2303 the problem is fixed by moving the background color and hover state from the `<button>`'s _content_ to the button's _container_. Since the `<button>` itself fills the container, this doesn't reduce the clickable area.
2. A variation on the above would be to move the background color, border and hover state to the button itself
3. Another approach is to replace the `<button>` with a generic element which lays out as expected and consistently between Safari, Firefox and Chrome.

As a proof of concept, this PR implements (3).

1. The first commit replaces the `<button>` for the menu toggle button with a `<div role="button">` that also has appropriate keyboard handling
2. The second commit simplifies the layout of the menu toggle button by removing a wrapper element that vertically centers the button content and instead just setting appropriate flex layout rules on the toggle button itself

The main upside to this fix is that it is localised to the `Menu` component. The downside is that a small amount of extra code is needed to provide affordances (focusability, keyboard activation) that come for free with `<button>`.