### PR TITLE
Refactor `RootThread` for conventions, clarity

### DIFF
--- a/src/sidebar/components/annotation-viewer-content.js
+++ b/src/sidebar/components/annotation-viewer-content.js
@@ -14,7 +14,7 @@ import SidebarContentError from './sidebar-content-error';
 function AnnotationViewerContent({
   loadAnnotationsService,
   onLogin,
-  rootThread: rootThreadService,
+  rootThreadService,
 }) {
   const annotationId = useStore(store => store.routeParams().id);
   const clearAnnotations = useStore(store => store.clearAnnotations);
@@ -100,12 +100,12 @@ AnnotationViewerContent.propTypes = {
 
   // Injected.
   loadAnnotationsService: propTypes.object,
-  rootThread: propTypes.object,
+  rootThreadService: propTypes.object,
 };
 
 AnnotationViewerContent.injectedProps = [
   'loadAnnotationsService',
-  'rootThread',
+  'rootThreadService',
 ];
 
 export default withServices(AnnotationViewerContent);

--- a/src/sidebar/components/search-status-bar.js
+++ b/src/sidebar/components/search-status-bar.js
@@ -25,8 +25,8 @@ const countVisibleAnns = annThread => {
  * UI for displaying information about the currently-applied filtering of
  * annotations, and, in some cases, a mechanism for clearing the filter(s).
  * */
-function SearchStatusBar({ rootThread }) {
-  const thread = useStore(store => rootThread.thread(store.getState()));
+function SearchStatusBar({ rootThreadService }) {
+  const thread = useStore(store => rootThreadService.thread(store.getState()));
 
   const actions = useStore(store => ({
     clearSelection: store.clearSelection,
@@ -174,9 +174,9 @@ function SearchStatusBar({ rootThread }) {
 
 SearchStatusBar.propTypes = {
   // Injected services.
-  rootThread: propTypes.object.isRequired,
+  rootThreadService: propTypes.object.isRequired,
 };
 
-SearchStatusBar.injectedProps = ['rootThread'];
+SearchStatusBar.injectedProps = ['rootThreadService'];
 
 export default withServices(SearchStatusBar);

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -22,7 +22,7 @@ function SidebarContent({
   onLogin,
   onSignUp,
   loadAnnotationsService,
-  rootThread: rootThreadService,
+  rootThreadService,
   streamer,
 }) {
   const rootThread = useStore(store =>
@@ -153,14 +153,14 @@ SidebarContent.propTypes = {
   // Injected
   frameSync: propTypes.object,
   loadAnnotationsService: propTypes.object,
-  rootThread: propTypes.object,
+  rootThreadService: propTypes.object,
   streamer: propTypes.object,
 };
 
 SidebarContent.injectedProps = [
   'frameSync',
   'loadAnnotationsService',
-  'rootThread',
+  'rootThreadService',
   'streamer',
 ];
 

--- a/src/sidebar/components/stream-content.js
+++ b/src/sidebar/components/stream-content.js
@@ -12,7 +12,7 @@ import ThreadList from './thread-list';
  */
 function StreamContent({
   api,
-  rootThread: rootThreadService,
+  rootThreadService,
   searchFilter,
   toastMessenger,
 }) {
@@ -88,14 +88,14 @@ function StreamContent({
 StreamContent.propTypes = {
   // Injected services.
   api: propTypes.object,
-  rootThread: propTypes.object,
+  rootThreadService: propTypes.object,
   searchFilter: propTypes.object,
   toastMessenger: propTypes.object,
 };
 
 StreamContent.injectedProps = [
   'api',
-  'rootThread',
+  'rootThreadService',
   'searchFilter',
   'toastMessenger',
 ];

--- a/src/sidebar/components/test/annotation-viewer-content-test.js
+++ b/src/sidebar/components/test/annotation-viewer-content-test.js
@@ -11,7 +11,7 @@ import AnnotationViewerContent, {
 describe('AnnotationViewerContent', () => {
   let fakeStore;
   let fakeOnLogin;
-  let fakeRootThread;
+  let fakeRootThreadService;
   let fakeLoadAnnotationsService;
 
   beforeEach(() => {
@@ -30,7 +30,7 @@ describe('AnnotationViewerContent', () => {
 
     fakeOnLogin = sinon.stub();
 
-    fakeRootThread = { thread: sinon.stub().returns({}) };
+    fakeRootThreadService = { thread: sinon.stub().returns({}) };
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
@@ -47,7 +47,7 @@ describe('AnnotationViewerContent', () => {
       <AnnotationViewerContent
         loadAnnotationsService={fakeLoadAnnotationsService}
         onLogin={fakeOnLogin}
-        rootThread={fakeRootThread}
+        rootThreadService={fakeRootThreadService}
         {...props}
       />
     );

--- a/src/sidebar/components/test/search-status-bar-test.js
+++ b/src/sidebar/components/test/search-status-bar-test.js
@@ -8,15 +8,17 @@ import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
 describe('SearchStatusBar', () => {
-  let fakeRootThread;
+  let fakeRootThreadService;
   let fakeStore;
 
   function createComponent(props) {
-    return mount(<SearchStatusBar rootThread={fakeRootThread} {...props} />);
+    return mount(
+      <SearchStatusBar rootThreadService={fakeRootThreadService} {...props} />
+    );
   }
 
   beforeEach(() => {
-    fakeRootThread = {
+    fakeRootThreadService = {
       thread: sinon.stub().returns({ children: [] }),
     };
     fakeStore = {
@@ -105,7 +107,7 @@ describe('SearchStatusBar', () => {
       },
     ].forEach(test => {
       it(test.description, () => {
-        fakeRootThread.thread.returns({
+        fakeRootThreadService.thread.returns({
           children: test.children,
         });
 
@@ -156,7 +158,7 @@ describe('SearchStatusBar', () => {
       },
     ].forEach(test => {
       it(test.description, () => {
-        fakeRootThread.thread.returns({
+        fakeRootThreadService.thread.returns({
           children: test.children,
         });
         const wrapper = createComponent({});
@@ -169,7 +171,7 @@ describe('SearchStatusBar', () => {
     });
 
     it('should not display user-focused mode text if filtered mode is (also) applied', () => {
-      fakeRootThread.thread.returns({
+      fakeRootThreadService.thread.returns({
         children: [
           { id: '1', visible: true, children: [] },
           { id: '2', visible: true, children: [] },

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -22,7 +22,7 @@ describe('SidebarContent', () => {
         onSignUp={() => null}
         frameSync={fakeFrameSync}
         loadAnnotationsService={fakeLoadAnnotationsService}
-        rootThread={fakeRootThreadService}
+        rootThreadService={fakeRootThreadService}
         streamer={fakeStreamer}
         {...props}
       />

--- a/src/sidebar/components/test/stream-content-test.js
+++ b/src/sidebar/components/test/stream-content-test.js
@@ -8,7 +8,7 @@ import StreamContent, { $imports } from '../stream-content';
 
 describe('StreamContent', () => {
   let fakeApi;
-  let fakeRootThread;
+  let fakeRootThreadService;
   let fakeSearchFilter;
   let fakeStore;
   let fakeToastMessenger;
@@ -18,7 +18,7 @@ describe('StreamContent', () => {
       search: sinon.stub().resolves({ rows: [], replies: [], total: 0 }),
     };
 
-    fakeRootThread = {
+    fakeRootThreadService = {
       thread: sinon.stub().returns({}),
     };
 
@@ -54,7 +54,7 @@ describe('StreamContent', () => {
     return mount(
       <StreamContent
         api={fakeApi}
-        rootThread={fakeRootThread}
+        rootThreadService={fakeRootThreadService}
         searchFilter={fakeSearchFilter}
         toastMessenger={fakeToastMessenger}
       />

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -157,7 +157,7 @@ function startApp(config) {
     .register('loadAnnotationsService', loadAnnotationsService)
     .register('localStorage', localStorageService)
     .register('persistedDefaults', persistedDefaultsService)
-    .register('rootThread', rootThreadService)
+    .register('rootThreadService', rootThreadService)
     .register('router', routerService)
     .register('searchFilter', searchFilterService)
     .register('serviceUrl', serviceUrlService)

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -36,7 +36,7 @@ const sortFns = {
  * The root thread is then displayed by viewer.html
  */
 // @ngInject
-export default function RootThread(
+export default function RootThreadService(
   annotationsService,
   store,
   searchFilter,

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -17,7 +17,7 @@ const fixtures = immutable({
   },
 });
 
-describe('rootThread', function () {
+describe('rootThreadService', function () {
   let fakeAnnotationsService;
   let fakeBuildThread;
   let fakeSearchFilter;
@@ -25,7 +25,7 @@ describe('rootThread', function () {
   let fakeStore;
   let fakeViewFilter;
 
-  let rootThread;
+  let rootThreadService;
 
   beforeEach(function () {
     fakeAnnotationsService = {
@@ -83,14 +83,14 @@ describe('rootThread', function () {
       filter: sinon.stub(),
     };
 
-    rootThread = new Injector()
+    rootThreadService = new Injector()
       .register('annotationsService', { value: fakeAnnotationsService })
       .register('store', { value: fakeStore })
       .register('searchFilter', { value: fakeSearchFilter })
       .register('settings', { value: fakeSettings })
       .register('viewFilter', { value: fakeViewFilter })
-      .register('rootThread', rootThreadFactory)
-      .get('rootThread');
+      .register('rootThreadService', rootThreadFactory)
+      .get('rootThreadService');
   });
 
   beforeEach(() => {
@@ -105,13 +105,16 @@ describe('rootThread', function () {
 
   describe('#thread', function () {
     it('returns the result of buildThread()', function () {
-      assert.equal(rootThread.thread(fakeStore.state), fixtures.emptyThread);
+      assert.equal(
+        rootThreadService.thread(fakeStore.state),
+        fixtures.emptyThread
+      );
     });
 
     it('passes loaded annotations to buildThread()', function () {
       const annotation = annotationFixtures.defaultAnnotation();
       fakeStore.state.annotations.annotations = [annotation];
-      rootThread.thread(fakeStore.state);
+      rootThreadService.thread(fakeStore.state);
       assert.calledWith(fakeBuildThread, sinon.match([annotation]));
     });
 
@@ -120,7 +123,7 @@ describe('rootThread', function () {
         id1: true,
         id2: true,
       });
-      rootThread.thread(fakeStore.state);
+      rootThreadService.thread(fakeStore.state);
       assert.calledWith(
         fakeBuildThread,
         [],
@@ -132,7 +135,7 @@ describe('rootThread', function () {
 
     it('passes the current expanded set to buildThread()', function () {
       fakeStore.expandedThreads.returns({ id1: true, id2: true });
-      rootThread.thread(fakeStore.state);
+      rootThreadService.thread(fakeStore.state);
       assert.calledWith(
         fakeBuildThread,
         [],
@@ -144,7 +147,7 @@ describe('rootThread', function () {
 
     it('passes the current force-visible set to buildThread()', function () {
       fakeStore.state.selection.forceVisible = { id1: true, id2: true };
-      rootThread.thread(fakeStore.state);
+      rootThreadService.thread(fakeStore.state);
       assert.calledWith(
         fakeBuildThread,
         [],
@@ -156,7 +159,7 @@ describe('rootThread', function () {
 
     it('passes the highlighted set to buildThread()', function () {
       fakeStore.state.selection.highlighted = ['id1', 'id2'];
-      rootThread.thread(fakeStore.state);
+      rootThreadService.thread(fakeStore.state);
       assert.calledWith(
         fakeBuildThread,
         [],
@@ -220,7 +223,7 @@ describe('rootThread', function () {
         fakeStore.state.selection.sortKey = testCase.order;
         fakeStore.state.selection.sortKeysAvailable = [testCase.order];
 
-        rootThread.thread(fakeStore.state);
+        rootThreadService.thread(fakeStore.state);
         const sortCompareFn = fakeBuildThread.args[0][1].sortCompareFn;
         const actualOrder = sortBy(annotations, sortCompareFn).map(function (
           annot
@@ -236,7 +239,7 @@ describe('rootThread', function () {
     it('filter matches only annotations when Annotations tab is selected', function () {
       fakeBuildThread.reset();
       fakeStore.state.selection.selectedTab = uiConstants.TAB_ANNOTATIONS;
-      rootThread.thread(fakeStore.state);
+      rootThreadService.thread(fakeStore.state);
       const threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
 
       const annotation = { target: [{ selector: {} }] };
@@ -246,7 +249,7 @@ describe('rootThread', function () {
     it('filter matches only notes when Notes tab is selected', function () {
       fakeBuildThread.reset();
       fakeStore.state.selection.selectedTab = uiConstants.TAB_NOTES;
-      rootThread.thread(fakeStore.state);
+      rootThreadService.thread(fakeStore.state);
       const threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
 
       assert.isTrue(threadFilterFn({ annotation: { target: [{}] } }));
@@ -255,7 +258,7 @@ describe('rootThread', function () {
     it('filter matches only orphans when Orphans tab is selected', function () {
       fakeBuildThread.reset();
       fakeStore.state.selection.selectedTab = uiConstants.TAB_ORPHANS;
-      rootThread.thread(fakeStore.state);
+      rootThreadService.thread(fakeStore.state);
       const threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
 
       const orphan = Object.assign(annotationFixtures.defaultAnnotation(), {
@@ -268,7 +271,7 @@ describe('rootThread', function () {
     it('filter does not match notes when Annotations tab is selected', function () {
       fakeBuildThread.reset();
       fakeStore.state.selection.selectedTab = uiConstants.TAB_ANNOTATIONS;
-      rootThread.thread(fakeStore.state);
+      rootThreadService.thread(fakeStore.state);
       const threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
 
       assert.isFalse(threadFilterFn({ annotation: { target: [{}] } }));
@@ -277,7 +280,7 @@ describe('rootThread', function () {
     it('filter does not match orphans when Annotations tab is selected', function () {
       fakeBuildThread.reset();
       fakeStore.state.selection.selectedTab = uiConstants.TAB_ANNOTATIONS;
-      rootThread.thread(fakeStore.state);
+      rootThreadService.thread(fakeStore.state);
       const threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
 
       assert.isFalse(threadFilterFn({ annotation: { $orphan: true } }));
@@ -287,7 +290,7 @@ describe('rootThread', function () {
       fakeBuildThread.reset();
       fakeStore.state.route.name = 'stream';
 
-      rootThread.thread(fakeStore.state);
+      rootThreadService.thread(fakeStore.state);
       const threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
 
       // There should be no thread filter function on the stream and standalone
@@ -297,7 +300,7 @@ describe('rootThread', function () {
 
     it('filter returns false when no annotations are provided', function () {
       fakeBuildThread.reset();
-      rootThread.thread(fakeStore.state);
+      rootThreadService.thread(fakeStore.state);
       const threadFilterFn = fakeBuildThread.args[0][1].threadFilterFn;
       assert.isFalse(threadFilterFn({}));
     });
@@ -311,7 +314,7 @@ describe('rootThread', function () {
       fakeSearchFilter.generateFacetedFilter.returns(filters);
       fakeStore.state.selection.filterQuery = 'queryterm';
 
-      rootThread.thread(fakeStore.state);
+      rootThreadService.thread(fakeStore.state);
       const filterFn = fakeBuildThread.args[0][1].filterFn;
 
       fakeViewFilter.filter.returns([annotation]);
@@ -331,7 +334,7 @@ describe('rootThread', function () {
       const annotation = annotationFixtures.defaultAnnotation();
       fakeSearchFilter.generateFacetedFilter.returns(filters);
       fakeStore.focusModeFocused = sinon.stub().returns(true);
-      rootThread.thread(fakeStore.state);
+      rootThreadService.thread(fakeStore.state);
       const filterFn = fakeBuildThread.args[0][1].filterFn;
 
       fakeViewFilter.filter.returns([annotation]);

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -390,6 +390,15 @@ function findAnnotationByID(state, id) {
 }
 
 /**
+ * Return all annotations currently in the store
+ *
+ * @return {Array<Annotation>}
+ */
+function annotations(state) {
+  return state.annotations.annotations;
+}
+
+/**
  * Return all loaded annotations that are not highlights and have not been saved
  * to the server.
  */
@@ -456,6 +465,7 @@ export default {
   },
 
   selectors: {
+    annotations,
     annotationCount,
     annotationExists,
     findAnnotationByID,

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -515,8 +515,55 @@ function focusModeUserPrettyName(state) {
   }
 }
 
+/**
+ * Return an array of annotation ids that have been forced visible by the
+ * user—i.e. return the "truthy keys" of `forceVisible`
+ *
+ * @return {Array<string>}
+ */
+const forcedVisibleAnnotations = createSelector(
+  state => state.selection.forceVisible,
+  forcedVisible =>
+    Object.keys(forcedVisible).filter(forceKey => !!forcedVisible[forceKey])
+);
+
 function getSelectedAnnotationMap(state) {
   return state.selection.selectedAnnotationMap;
+}
+
+/**
+ * @return {Array<string>} - ids of highlighted annotations
+ */
+function highlightedAnnotations(state) {
+  return state.selection.highlighted;
+}
+
+/**
+ * Return an array of currently-selected annotation ids
+ *
+ * @return {Array<string>}
+ */
+const selectedAnnotations = createSelector(
+  state => state.selection.selectedAnnotationMap,
+  selectedMap =>
+    Object.keys(selectedMap || {}).filter(
+      selectedKey => !!selectedMap[selectedKey]
+    )
+);
+
+/**
+ * @return {string} - The currently-selected tab
+ */
+function selectedTab(state) {
+  return state.selection.selectedTab;
+}
+
+/**
+ * Retrieve current sorting order for annotations
+ * @return {string}
+ */
+function sortKey(state) {
+  return state.selection.sortKey;
 }
 
 /**
@@ -563,11 +610,16 @@ export default {
     focusModeHasUser,
     focusModeUserId,
     focusModeUserPrettyName,
+    forcedVisibleAnnotations,
+    highlightedAnnotations,
     isAnnotationFocused,
     isAnnotationSelected,
     getFirstSelectedAnnotationId,
     getSelectedAnnotationMap,
     hasAppliedFilter,
     hasSelectedAnnotations,
+    selectedAnnotations,
+    selectedTab,
+    sortKey,
   },
 };

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -32,6 +32,7 @@ describe('sidebar/store/modules/selection', () => {
     it('sets the visibility of the annotation', function () {
       store.setForceVisible('id1', true);
       assert.deepEqual(getSelectionState().forceVisible, { id1: true });
+      assert.deepEqual(store.forcedVisibleAnnotations(), ['id1']);
     });
   });
 
@@ -218,6 +219,7 @@ describe('sidebar/store/modules/selection', () => {
       store.setCollapsed('456', false);
       store.setFilterQuery('some-query');
       assert.deepEqual(getSelectionState().forceVisible, {});
+      assert.deepEqual(store.forcedVisibleAnnotations(), []);
       assert.deepEqual(getSelectionState().expanded, {});
     });
   });
@@ -262,6 +264,7 @@ describe('sidebar/store/modules/selection', () => {
       });
 
       assert.isEmpty(getSelectionState().forceVisible);
+      assert.isEmpty(store.forcedVisibleAnnotations());
       assert.isNull(store.filterQuery());
     });
   });
@@ -386,7 +389,7 @@ describe('sidebar/store/modules/selection', () => {
   describe('highlightAnnotations()', function () {
     it('sets the highlighted annotations', function () {
       store.highlightAnnotations(['id1', 'id2']);
-      assert.deepEqual(getSelectionState().highlighted, ['id1', 'id2']);
+      assert.deepEqual(store.highlightedAnnotations(), ['id1', 'id2']);
     });
   });
 
@@ -404,18 +407,12 @@ describe('sidebar/store/modules/selection', () => {
   describe('selectTab()', function () {
     it('sets the selected tab', function () {
       store.selectTab(uiConstants.TAB_ANNOTATIONS);
-      assert.equal(
-        getSelectionState().selectedTab,
-        uiConstants.TAB_ANNOTATIONS
-      );
+      assert.equal(store.selectedTab(), uiConstants.TAB_ANNOTATIONS);
     });
 
     it('ignores junk tag names', function () {
       store.selectTab('flibbertigibbert');
-      assert.equal(
-        getSelectionState().selectedTab,
-        uiConstants.TAB_ANNOTATIONS
-      );
+      assert.equal(store.selectedTab(), uiConstants.TAB_ANNOTATIONS);
     });
 
     it('allows sorting annotations by time and document location', function () {
@@ -467,7 +464,7 @@ describe('sidebar/store/modules/selection', () => {
 
       store.selectTab(uiConstants.TAB_NOTES);
 
-      assert.equal(getSelectionState().sortKey, 'Newest');
+      assert.equal(store.sortKey(), 'Newest');
     });
   });
 
@@ -479,7 +476,7 @@ describe('sidebar/store/modules/selection', () => {
         currentAnnotationCount: 0,
       });
 
-      assert.equal(getSelectionState().selectedTab, uiConstants.TAB_NOTES);
+      assert.equal(store.selectedTab(), uiConstants.TAB_NOTES);
     });
 
     it('should select the page notes tab if page notes have replies', () => {
@@ -492,7 +489,7 @@ describe('sidebar/store/modules/selection', () => {
         currentAnnotationCount: 0,
       });
 
-      assert.equal(getSelectionState().selectedTab, uiConstants.TAB_NOTES);
+      assert.equal(store.selectedTab(), uiConstants.TAB_NOTES);
     });
 
     it('should not select the page notes tab if there were previously annotations in the store', () => {
@@ -502,10 +499,7 @@ describe('sidebar/store/modules/selection', () => {
         currentAnnotationCount: 4,
       });
 
-      assert.equal(
-        getSelectionState().selectedTab,
-        uiConstants.TAB_ANNOTATIONS
-      );
+      assert.equal(store.selectedTab(), uiConstants.TAB_ANNOTATIONS);
     });
 
     it('should not select the page notes tab if there are non-page-note annotations at the top level', () => {
@@ -519,10 +513,7 @@ describe('sidebar/store/modules/selection', () => {
         currentAnnotationCount: 0,
       });
 
-      assert.equal(
-        getSelectionState().selectedTab,
-        uiConstants.TAB_ANNOTATIONS
-      );
+      assert.equal(store.selectedTab(), uiConstants.TAB_ANNOTATIONS);
     });
   });
 });

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -36,7 +36,7 @@ const fixtures = immutable({
 
 describe('annotation threading', function () {
   let store;
-  let rootThread;
+  let rootThreadService;
 
   beforeEach(function () {
     const fakeUnicode = {
@@ -54,7 +54,7 @@ describe('annotation threading', function () {
 
     const container = new Injector()
       .register('store', storeFactory)
-      .register('rootThread', rootThreadFactory)
+      .register('rootThreadService', rootThreadFactory)
       .register('searchFilter', searchFilterFactory)
       .register('annotationsService', () => {})
       .register('viewFilter', viewFilterFactory)
@@ -63,25 +63,28 @@ describe('annotation threading', function () {
       .register('unicode', { value: fakeUnicode });
 
     store = container.get('store');
-    rootThread = container.get('rootThread');
+    rootThreadService = container.get('rootThreadService');
   });
 
   it('should display newly loaded annotations', function () {
     store.addAnnotations(fixtures.annotations);
-    assert.equal(rootThread.thread(store.getState()).children.length, 2);
+    assert.equal(rootThreadService.thread(store.getState()).children.length, 2);
   });
 
   it('should not display unloaded annotations', function () {
     store.addAnnotations(fixtures.annotations);
     store.removeAnnotations(fixtures.annotations);
-    assert.equal(rootThread.thread(store.getState()).children.length, 0);
+    assert.equal(rootThreadService.thread(store.getState()).children.length, 0);
   });
 
   it('should filter annotations when a search is set', function () {
     store.addAnnotations(fixtures.annotations);
     store.setFilterQuery('second');
-    assert.equal(rootThread.thread(store.getState()).children.length, 1);
-    assert.equal(rootThread.thread(store.getState()).children[0].id, '2');
+    assert.equal(rootThreadService.thread(store.getState()).children.length, 1);
+    assert.equal(
+      rootThreadService.thread(store.getState()).children[0].id,
+      '2'
+    );
   });
 
   [
@@ -97,7 +100,7 @@ describe('annotation threading', function () {
     it(`should sort annotations by ${testCase.mode}`, () => {
       store.addAnnotations(fixtures.annotations);
       store.setSortKey(testCase.sortKey);
-      const actualOrder = rootThread
+      const actualOrder = rootThreadService
         .thread(store.getState())
         .children.map(function (thread) {
           return thread.annotation.id;


### PR DESCRIPTION
This PR is a draft/WIP of refactoring `RootThread`:

* Rename to `RootThreadService` to avoid confusion
* Add a bunch of store selectors so that `buildRootThread` doesn't access store state directly
* Remove a bunch of cruft from tests

This is in draft because I'd like input on a situation that arose when I removed all direct references to store state in `buildRootThread`. Currently, that function is memoized on `state`, but the function no longer does anything with `state`, which will cause a linting error (unused-vars). However, `state` does seem like an appropriate thing to memoize on. We could write a new memoizer for this function, but...dunno. Right now I've told the linter to shut up, but I'd like some input.