### PR TITLE
Improve typechecking in several shared modules

### DIFF
--- a/src/shared/dom-element.js
+++ b/src/shared/dom-element.js
@@ -7,6 +7,9 @@
 /**
  * Implementation of `element.closest(selector)`. This is used to support browsers
  * (IE 11) that don't have a native implementation.
+ *
+ * @param {Element|null} element
+ * @param {string} selector
  */
 export function closest(element, selector) {
   while (element) {

--- a/src/shared/frame-rpc.js
+++ b/src/shared/frame-rpc.js
@@ -29,6 +29,13 @@
 
 const VERSION = '1.0.0';
 
+/**
+ *  @constructor
+ *  @param {Window} src
+ *  @param {Window} dst
+ *  @param {string} origin
+ *  @param {(Object<string, ((any) => any)>) | ((any) => any)} methods
+ */
 export default function RPC(src, dst, origin, methods) {
   if (!(this instanceof RPC)) return new RPC(src, dst, origin, methods);
   const self = this;
@@ -64,11 +71,18 @@ RPC.prototype.destroy = function () {
   this.src.removeEventListener('message', this._onmessage);
 };
 
+/**
+ * @param {string} method
+ */
 RPC.prototype.call = function (method) {
   const args = [].slice.call(arguments, 1);
   return this.apply(method, args);
 };
 
+/**
+ * @param {string} method
+ * @param {any[]} args
+ */
 RPC.prototype.apply = function (method, args) {
   if (this._destroyed) return;
   const seq = this._sequence++;

--- a/src/shared/type-coercions.js
+++ b/src/shared/type-coercions.js
@@ -44,7 +44,7 @@ export function toInteger(value) {
  * Returns either the value if its an object or an empty object
  *
  * @param {any} value - initial value
- * @return {object}
+ * @return {Object}
  */
 export function toObject(value) {
   if (typeof value === 'object' && value !== null) {


### PR DESCRIPTION
I'm not sure if this is our standard or not, but I'm ignoring all private methods in a class or (class-like) thing. Seems like overkill to add typechecking to those; however, the effort could still catch bugs. We could discuss further in slack.
