### PR TITLE
Remove references to `client_do_not_separate_replies` feature flag

### DIFF
--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -9,7 +9,6 @@ import { isReply } from '../util/annotation-metadata';
 // @ngInject
 export default function loadAnnotationsService(
   api,
-  features,
   store,
   streamer,
   streamFilter
@@ -41,7 +40,7 @@ export default function loadAnnotationsService(
   function searchAndLoad(uris, groupId) {
     searchClient = new SearchClient(api.search, {
       incremental: true,
-      separateReplies: !features.flagEnabled('client_do_not_separate_replies'),
+      separateReplies: false,
     });
     searchClient.on('results', results => {
       if (results.length) {

--- a/src/sidebar/services/test/load-annotations-test.js
+++ b/src/sidebar/services/test/load-annotations-test.js
@@ -31,7 +31,6 @@ class FakeSearchClient extends EventEmitter {
 
 describe('loadAnnotationsService', () => {
   let fakeApi;
-  let fakeFeatures;
   let fakeStore;
   let fakeStreamer;
   let fakeStreamFilter;
@@ -49,10 +48,6 @@ describe('loadAnnotationsService', () => {
       annotation: {
         get: sinon.stub(),
       },
-    };
-
-    fakeFeatures = {
-      flagEnabled: sinon.stub().returns(false),
     };
 
     fakeStore = {
@@ -100,7 +95,6 @@ describe('loadAnnotationsService', () => {
     );
     return loadAnnotationsService(
       fakeApi,
-      fakeFeatures,
       fakeStore,
       fakeStreamer,
       fakeStreamFilter
@@ -224,24 +218,11 @@ describe('loadAnnotationsService', () => {
       assert.ok(searchClients[0].incremental);
     });
 
-    it('loads annotations without separating replies if feature flag is enabled', () => {
-      fakeFeatures.flagEnabled
-        .withArgs('client_do_not_separate_replies')
-        .returns(true);
+    it('loads annotations without separating replies', () => {
       const svc = createService();
 
       svc.load(fakeUris, fakeGroupId);
       assert.isFalse(searchClients[0].separateReplies);
-    });
-
-    it('loads annotations with separated replies if feature flag is not enabled', () => {
-      fakeFeatures.flagEnabled
-        .withArgs('client_do_not_separate_replies')
-        .returns(false);
-      const svc = createService();
-
-      svc.load(fakeUris, fakeGroupId);
-      assert.isTrue(searchClients[0].separateReplies);
     });
 
     it("cancels previously search client if it's still running", () => {


### PR DESCRIPTION
This PR removes references to the `client_do_not_separate_replies` feature flag, now that it has been enabled for everyone for a little while.