### PR TITLE
Refactor "maps" of annotations/threads within the `selection` store module

### DIFF
--- a/src/sidebar/build-thread.js
+++ b/src/sidebar/build-thread.js
@@ -263,7 +263,7 @@ function hasVisibleChildren(thread) {
  * @typedef Options
  * @prop {string[]} [selected] - List of currently-selected annotation ids, from
  *       the data store
- * @prop {string[]} [forceVisible] - List of ids of annotations that have
+ * @prop {string[]} [forcedVisible] - List of ids of annotations that have
  *       been explicitly expanded by the user, even if they don't
  *       match current filters
  * @prop {(a: Annotation) => boolean} [filterFn] - Predicate function that
@@ -326,7 +326,7 @@ export default function buildThread(annotations, options) {
 
   const hasHighlights = opts.highlighted.length > 0;
   const hasSelection = opts.selected.length > 0;
-  const hasForcedVisible = opts.forceVisible && opts.forceVisible.length;
+  const hasForcedVisible = opts.forcedVisible && opts.forcedVisible.length;
 
   let thread = threadAnnotations(annotations);
 
@@ -351,7 +351,7 @@ export default function buildThread(annotations, options) {
     } else if (annotationsFiltered) {
       if (
         hasForcedVisible &&
-        opts.forceVisible.indexOf(annotationId(thread.annotation)) !== -1
+        opts.forcedVisible.indexOf(annotationId(thread.annotation)) !== -1
       ) {
         // This annotation may or may not match the filter, but we should
         // make sure it is visible because it has been forced visible by user

--- a/src/sidebar/components/annotation-header.js
+++ b/src/sidebar/components/annotation-header.js
@@ -25,7 +25,7 @@ export default function AnnotationHeader({
   threadIsCollapsed,
 }) {
   const isCollapsedReply = isReply(annotation) && threadIsCollapsed;
-  const setCollapsed = useStore(store => store.setCollapsed);
+  const setExpanded = useStore(store => store.setExpanded);
 
   const annotationIsPrivate = isPrivate(
     annotation.permissions,
@@ -44,7 +44,7 @@ export default function AnnotationHeader({
   const showReplyButton = replyCount > 0 && isCollapsedReply;
   const showExtendedInfo = !isReply(annotation);
 
-  const onReplyCountClick = () => setCollapsed(annotation.id, false);
+  const onReplyCountClick = () => setExpanded(annotation.id, true);
 
   return (
     <header className="annotation-header">

--- a/src/sidebar/components/annotation-viewer-content.js
+++ b/src/sidebar/components/annotation-viewer-content.js
@@ -22,7 +22,7 @@ function AnnotationViewerContent({
   const rootThread = useStore(store =>
     rootThreadService.thread(store.getState())
   );
-  const setCollapsed = useStore(store => store.setCollapsed);
+  const setExpanded = useStore(store => store.setExpanded);
   const userid = useStore(store => store.profile().userid);
 
   const [fetchError, setFetchError] = useState(false);
@@ -57,7 +57,7 @@ function AnnotationViewerContent({
 
         // Make the full thread of annotations visible. By default replies are
         // not shown until the user expands the thread.
-        annots.forEach(annot => setCollapsed(annot.id, false));
+        annots.forEach(annot => setExpanded(annot.id, true));
 
         // FIXME - This should show a visual indication of which reply the
         // annotation ID in the URL refers to. That isn't currently working.
@@ -79,7 +79,7 @@ function AnnotationViewerContent({
     clearAnnotations,
     highlightAnnotations,
     loadAnnotationsService,
-    setCollapsed,
+    setExpanded,
   ]);
 
   return (

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -31,7 +31,7 @@ function Annotation({
   const isFocused = useStore(store =>
     store.isAnnotationFocused(annotation.$tag)
   );
-  const setCollapsed = useStore(store => store.setCollapsed);
+  const setExpanded = useStore(store => store.setExpanded);
 
   // An annotation will have a draft if it is being edited
   const draft = useStore(store => store.getDraft(annotation));
@@ -87,7 +87,7 @@ function Annotation({
     }
   };
 
-  const onToggleReplies = () => setCollapsed(annotation.id, !threadIsCollapsed);
+  const onToggleReplies = () => setExpanded(annotation.id, !!threadIsCollapsed);
 
   return (
     /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */

--- a/src/sidebar/components/search-status-bar.js
+++ b/src/sidebar/components/search-status-bar.js
@@ -41,13 +41,13 @@ function SearchStatusBar({ rootThread }) {
     filterQuery,
     focusModeFocused,
     focusModeUserPrettyName,
-    selectionMap,
+    hasSelectedAnnotations,
     selectedTab,
   } = useStore(store => ({
     filterQuery: store.getState().selection.filterQuery,
     focusModeFocused: store.focusModeFocused(),
     focusModeUserPrettyName: store.focusModeUserPrettyName(),
-    selectionMap: store.getSelectedAnnotationMap(),
+    hasSelectedAnnotations: store.hasSelectedAnnotations(),
     selectedTab: store.getState().selection.selectedTab,
   }));
 
@@ -72,9 +72,7 @@ function SearchStatusBar({ rootThread }) {
      * `filtered` mode.
      */
     selected: (() => {
-      return (
-        !!selectionMap && Object.keys(selectionMap).length > 0 && !filterQuery
-      );
+      return hasSelectedAnnotations && !filterQuery;
     })(),
   };
 

--- a/src/sidebar/components/test/annotation-header-test.js
+++ b/src/sidebar/components/test/annotation-header-test.js
@@ -33,7 +33,7 @@ describe('AnnotationHeader', () => {
     fakeIsPrivate = sinon.stub();
 
     fakeStore = {
-      setCollapsed: sinon.stub(),
+      setExpanded: sinon.stub(),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -97,8 +97,8 @@ describe('AnnotationHeader', () => {
       const btn = findReplyButton(wrapper);
       btn.props().onClick();
 
-      assert.calledOnce(fakeStore.setCollapsed);
-      assert.calledWith(fakeStore.setCollapsed, fakeAnnotation.id, false);
+      assert.calledOnce(fakeStore.setExpanded);
+      assert.calledWith(fakeStore.setExpanded, fakeAnnotation.id, true);
     });
 
     it('should not render if there are no replies to show', () => {

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -72,7 +72,7 @@ describe('Annotation', () => {
       isAnnotationFocused: sinon.stub().returns(false),
       isSavingAnnotation: sinon.stub().returns(false),
       profile: sinon.stub().returns({ userid: 'acct:foo@bar.com' }),
-      setCollapsed: sinon.stub(),
+      setExpanded: sinon.stub(),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -398,7 +398,7 @@ describe('Annotation', () => {
       });
       wrapper.setProps({ threadIsCollapsed: false });
 
-      assert.calledOnce(fakeStore.setCollapsed);
+      assert.calledOnce(fakeStore.setExpanded);
       assert.equal(
         findRepliesButton(wrapper).props().buttonText,
         'Hide replies (5)'

--- a/src/sidebar/components/test/annotation-viewer-content-test.js
+++ b/src/sidebar/components/test/annotation-viewer-content-test.js
@@ -21,7 +21,7 @@ describe('AnnotationViewerContent', () => {
       highlightAnnotations: sinon.stub(),
       routeParams: sinon.stub().returns({ id: 'test_annotation_id' }),
       profile: sinon.stub().returns({ userid: null }),
-      setCollapsed: sinon.stub(),
+      setExpanded: sinon.stub(),
     };
 
     fakeLoadAnnotationsService = {
@@ -81,8 +81,8 @@ describe('AnnotationViewerContent', () => {
 
         await new Promise(resolve => setTimeout(resolve, 0));
 
-        assert.calledWith(fakeStore.setCollapsed, 'test_annotation_id', false);
-        assert.calledWith(fakeStore.setCollapsed, 'test_reply_id', false);
+        assert.calledWith(fakeStore.setExpanded, 'test_annotation_id', true);
+        assert.calledWith(fakeStore.setExpanded, 'test_reply_id', true);
       });
     });
 

--- a/src/sidebar/components/test/search-status-bar-test.js
+++ b/src/sidebar/components/test/search-status-bar-test.js
@@ -26,7 +26,7 @@ describe('SearchStatusBar', () => {
       annotationCount: sinon.stub().returns(1),
       focusModeFocused: sinon.stub().returns(false),
       focusModeUserPrettyName: sinon.stub().returns('Fake User'),
-      getSelectedAnnotationMap: sinon.stub(),
+      hasSelectedAnnotations: sinon.stub(),
       noteCount: sinon.stub().returns(0),
     };
 
@@ -243,7 +243,7 @@ describe('SearchStatusBar', () => {
           });
           fakeStore.annotationCount.returns(test.annotationCount);
           fakeStore.noteCount.returns(test.noteCount);
-          fakeStore.getSelectedAnnotationMap.returns({ annId: true });
+          fakeStore.hasSelectedAnnotations.returns(true);
 
           const wrapper = createComponent({});
 
@@ -270,7 +270,7 @@ describe('SearchStatusBar', () => {
             },
           });
           fakeStore.annotationCount.returns(5);
-          fakeStore.getSelectedAnnotationMap.returns({ annId: true });
+          fakeStore.hasSelectedAnnotations.returns(true);
           fakeStore.noteCount.returns(3);
 
           const wrapper = createComponent({});

--- a/src/sidebar/components/test/thread-test.js
+++ b/src/sidebar/components/test/thread-test.js
@@ -81,7 +81,7 @@ describe('Thread', () => {
 
   beforeEach(() => {
     fakeStore = {
-      setCollapsed: sinon.stub(),
+      setExpanded: sinon.stub(),
     };
 
     fakeThreadsService = {
@@ -134,8 +134,8 @@ describe('Thread', () => {
         getToggleButton(wrapper).props().onClick();
       });
 
-      assert.calledOnce(fakeStore.setCollapsed);
-      assert.calledWith(fakeStore.setCollapsed, replyThread.id, true);
+      assert.calledOnce(fakeStore.setExpanded);
+      assert.calledWith(fakeStore.setExpanded, replyThread.id, false);
     });
 
     it('assigns an appropriate CSS class to the element', () => {

--- a/src/sidebar/components/thread.js
+++ b/src/sidebar/components/thread.js
@@ -16,7 +16,7 @@ import ModerationBanner from './moderation-banner';
  * and at any given time it may be `collapsed`.
  */
 function Thread({ showDocumentInfo = false, thread, threadsService }) {
-  const setCollapsed = useStore(store => store.setCollapsed);
+  const setExpanded = useStore(store => store.setExpanded);
 
   // Only render this thread's annotation if it exists and the thread is `visible`
   const showAnnotation = thread.annotation && thread.visible;
@@ -40,7 +40,7 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
     child => countVisible(child) > 0
   );
 
-  const onToggleReplies = () => setCollapsed(thread.id, !thread.collapsed);
+  const onToggleReplies = () => setExpanded(thread.id, !!thread.collapsed);
   return (
     <section
       className={classnames('thread', {

--- a/src/sidebar/services/annotations.js
+++ b/src/sidebar/services/annotations.js
@@ -123,7 +123,7 @@ export default function annotationsService(api, store) {
 
     (annotation.references || []).forEach(parent => {
       // Expand any parents of this annotation.
-      store.setCollapsed(parent, false);
+      store.setExpanded(parent, true);
     });
   }
 

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -59,7 +59,7 @@ export default function RootThread(
       forceVisible: truthyKeys(state.selection.forceVisible),
       expanded: store.expandedThreads(),
       highlighted: state.selection.highlighted,
-      selected: truthyKeys(store.getSelectedAnnotationMap() || {}),
+      selected: store.selectedAnnotations(),
       sortCompareFn: sortFn,
     };
 

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -3,12 +3,6 @@ import * as metadata from '../util/annotation-metadata';
 import memoize from '../util/memoize';
 import * as tabs from '../util/tabs';
 
-function truthyKeys(map) {
-  return Object.keys(map).filter(function (k) {
-    return !!map[k];
-  });
-}
-
 // Mapping from sort order name to a less-than predicate
 // function for comparing annotations to determine their sort order.
 const sortFns = {
@@ -56,7 +50,7 @@ export default function RootThread(
     };
 
     const options = {
-      forceVisible: truthyKeys(state.selection.forceVisible),
+      forcedVisible: store.forcedVisibleAnnotations(),
       expanded: store.expandedThreads(),
       highlighted: state.selection.highlighted,
       selected: store.selectedAnnotations(),

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -51,7 +51,7 @@ export default function RootThread(
 
     const options = {
       forcedVisible: store.forcedVisibleAnnotations(),
-      expanded: store.expandedThreads(),
+      expanded: store.expandedMap(),
       highlighted: state.selection.highlighted,
       selected: store.selectedAnnotations(),
       sortCompareFn: sortFn,

--- a/src/sidebar/services/test/annotations-test.js
+++ b/src/sidebar/services/test/annotations-test.js
@@ -49,7 +49,7 @@ describe('annotationsService', () => {
       removeAnnotations: sinon.stub(),
       removeDraft: sinon.stub(),
       selectTab: sinon.stub(),
-      setCollapsed: sinon.stub(),
+      setExpanded: sinon.stub(),
       updateFlagStatus: sinon.stub(),
     };
 
@@ -220,10 +220,10 @@ describe('annotationsService', () => {
 
       svc.create(annot, now);
 
-      assert.equal(fakeStore.setCollapsed.callCount, 3);
-      assert.calledWith(fakeStore.setCollapsed, 'aparent', false);
-      assert.calledWith(fakeStore.setCollapsed, 'anotherparent', false);
-      assert.calledWith(fakeStore.setCollapsed, 'yetanotherancestor', false);
+      assert.equal(fakeStore.setExpanded.callCount, 3);
+      assert.calledWith(fakeStore.setExpanded, 'aparent', true);
+      assert.calledWith(fakeStore.setExpanded, 'anotherparent', true);
+      assert.calledWith(fakeStore.setExpanded, 'yetanotherancestor', true);
     });
   });
 

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -55,13 +55,12 @@ describe('rootThread', function () {
         return this.state;
       },
 
-      expandedThreads: sinon.stub().returns({}),
+      expandedMap: sinon.stub().returns({}),
       forcedVisibleAnnotations: sinon.stub().returns([]),
       subscribe: sinon.stub(),
       removeAnnotations: sinon.stub(),
       removeSelectedAnnotation: sinon.stub(),
       addAnnotations: sinon.stub(),
-      setCollapsed: sinon.stub(),
       selectedAnnotations: sinon.stub().returns([]),
       selectTab: sinon.stub(),
       getDraftIfNotEmpty: sinon.stub().returns(null),
@@ -128,7 +127,7 @@ describe('rootThread', function () {
     });
 
     it('passes the current expanded set to buildThread()', function () {
-      fakeStore.expandedThreads.returns({ id1: true, id2: true });
+      fakeStore.expandedMap.returns({ id1: true, id2: true });
       rootThread.thread(fakeStore.state);
       assert.calledWith(
         fakeBuildThread,

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -57,12 +57,12 @@ describe('rootThread', function () {
       },
 
       expandedThreads: sinon.stub().returns({}),
-      getSelectedAnnotationMap: sinon.stub().returns(null),
       subscribe: sinon.stub(),
       removeAnnotations: sinon.stub(),
       removeSelectedAnnotation: sinon.stub(),
       addAnnotations: sinon.stub(),
       setCollapsed: sinon.stub(),
+      selectedAnnotations: sinon.stub().returns([]),
       selectTab: sinon.stub(),
       getDraftIfNotEmpty: sinon.stub().returns(null),
       removeDraft: sinon.stub(),
@@ -116,10 +116,7 @@ describe('rootThread', function () {
     });
 
     it('passes the current selection to buildThread()', function () {
-      fakeStore.getSelectedAnnotationMap.returns({
-        id1: true,
-        id2: true,
-      });
+      fakeStore.selectedAnnotations.returns(['id1', 'id2']);
       rootThread.thread(fakeStore.state);
       assert.calledWith(
         fakeBuildThread,

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -42,7 +42,6 @@ describe('rootThread', function () {
         drafts: [],
         selection: {
           filterQuery: null,
-          forceVisible: {},
           highlighted: [],
           sortKey: 'Location',
           sortKeysAvailable: ['Location'],
@@ -57,6 +56,7 @@ describe('rootThread', function () {
       },
 
       expandedThreads: sinon.stub().returns({}),
+      forcedVisibleAnnotations: sinon.stub().returns([]),
       subscribe: sinon.stub(),
       removeAnnotations: sinon.stub(),
       removeSelectedAnnotation: sinon.stub(),
@@ -140,13 +140,13 @@ describe('rootThread', function () {
     });
 
     it('passes the current force-visible set to buildThread()', function () {
-      fakeStore.state.selection.forceVisible = { id1: true, id2: true };
+      fakeStore.forcedVisibleAnnotations.returns(['id1', 'id2']);
       rootThread.thread(fakeStore.state);
       assert.calledWith(
         fakeBuildThread,
         [],
         sinon.match({
-          forceVisible: ['id1', 'id2'],
+          forcedVisible: ['id1', 'id2'],
         })
       );
     });

--- a/src/sidebar/services/test/threads-test.js
+++ b/src/sidebar/services/test/threads-test.js
@@ -40,7 +40,7 @@ describe('threadsService', function () {
 
   beforeEach(() => {
     fakeStore = {
-      setForceVisible: sinon.stub(),
+      setForcedVisible: sinon.stub(),
     };
     service = threadsService(fakeStore);
   });
@@ -64,7 +64,7 @@ describe('threadsService', function () {
         '2bi',
         '2bii',
       ].forEach(threadId =>
-        assert.calledWith(fakeStore.setForceVisible, threadId)
+        assert.calledWith(fakeStore.setForcedVisible, threadId)
       );
     });
 
@@ -73,8 +73,8 @@ describe('threadsService', function () {
       service.forceVisible(NESTED_THREADS.children[0]);
 
       const calledWithThreadIds = [];
-      for (let i = 0; i < fakeStore.setForceVisible.callCount; i++) {
-        calledWithThreadIds.push(fakeStore.setForceVisible.getCall(i).args[0]);
+      for (let i = 0; i < fakeStore.setForcedVisible.callCount; i++) {
+        calledWithThreadIds.push(fakeStore.setForcedVisible.getCall(i).args[0]);
       }
       assert.deepEqual(calledWithThreadIds, [
         '1ai',

--- a/src/sidebar/services/threads.js
+++ b/src/sidebar/services/threads.js
@@ -9,7 +9,7 @@ export default function threadsService(store) {
     thread.children.forEach(child => {
       forceVisible(child);
     });
-    store.setForceVisible(thread.id, true);
+    store.setForcedVisible(thread.id, true);
   }
 
   return {

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -117,8 +117,9 @@ function init(settings) {
     // by the user even if they do not match the current search filter
     forcedVisible: {},
 
-    // IDs of annotations that should be highlighted
-    highlighted: [],
+    // A map of annotations that should appear as "highlighted", e.g. the
+    // target of a single-annotation view
+    highlighted: {},
 
     filterQuery: settings.query || null,
 
@@ -355,12 +356,16 @@ function setExpanded(id, expanded) {
  * Highlight annotations with the given `ids`.
  *
  * This is used to indicate the specific annotation in a thread that was
- * linked to for example.
+ * linked to for example. Replaces the current map of highlighted annotations.
+ *
+ * @param {string[ids]} - ids of annotations to highlight
  */
 function highlightAnnotations(ids) {
+  const highlighted = {};
+  ids.forEach(id => (highlighted[id] = true));
   return {
     type: actions.HIGHLIGHT_ANNOTATIONS,
-    highlighted: ids,
+    highlighted,
   };
 }
 

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -45,6 +45,17 @@ TAB_SORTKEYS_AVAILABLE[uiConstants.TAB_ORPHANS] = [
   'Location',
 ];
 
+/**
+ * Utility function that returns all of the properties of an object whose
+ * value is `true`.
+ *
+ * @param {Object} obj
+ * @return {any[]}
+ */
+function truthyKeys(obj) {
+  return Object.keys(obj).filter(key => obj[key] === true);
+}
+
 function initialSelection(settings) {
   const selection = {};
   // TODO: Do not take into account existence of `settings.query` here
@@ -402,9 +413,7 @@ function setSortKey(key) {
 /* Selectors */
 
 function focusedAnnotations(state) {
-  return Object.keys(state.selection.focused).filter(
-    id => state.selection.focused[id] === true
-  );
+  return truthyKeys(state.selection.focused);
 }
 
 /** Is the annotation referenced by `$tag` currently focused? */
@@ -417,8 +426,7 @@ function isAnnotationFocused(state, $tag) {
  */
 const hasSelectedAnnotations = createSelector(
   state => state.selection.selected,
-  selection =>
-    Object.keys(selection).filter(id => selection[id] === true).length > 0
+  selection => truthyKeys(selection).length > 0
 );
 
 /** De-select all annotations. */
@@ -441,9 +449,7 @@ function clearSelection() {
 const getFirstSelectedAnnotationId = createSelector(
   state => state.selection.selected,
   selection => {
-    const selectedIds = Object.keys(selection).filter(
-      id => selection[id] === true
-    );
+    const selectedIds = truthyKeys(selection);
     return selectedIds.length ? selectedIds[0] : null;
   }
 );
@@ -543,7 +549,7 @@ const hasAppliedFilter = createSelector(
 
 const selectedAnnotations = createSelector(
   state => state.selection.selected,
-  selection => Object.keys(selection).filter(id => selection[id] === true)
+  selection => truthyKeys(selection)
 );
 
 export default {

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -214,7 +214,7 @@ const update = {
   },
 
   SET_EXPANDED: function (state, action) {
-    return { expanded: action.expanded };
+    return { expanded: { ...state.expanded, [action.id]: action.expanded } };
   },
 
   HIGHLIGHT_ANNOTATIONS: function (state, action) {
@@ -336,16 +336,18 @@ function focusAnnotations(tags) {
   };
 }
 
-function setCollapsed(id, collapsed) {
-  // FIXME: This should be converted to a plain action and accessing the state
-  // should happen in the update() function
-  return function (dispatch, getState) {
-    const expanded = Object.assign({}, getState().selection.expanded);
-    expanded[id] = !collapsed;
-    dispatch({
-      type: actions.SET_EXPANDED,
-      expanded: expanded,
-    });
+/**
+ * Set the expanded state for a single annotation/thread, affecting whether or not
+ * an annotation's replies are visible.
+ *
+ * @param {string} id - annotation (or thread) id
+ * @param {boolean} expanded - `true` for expanded replies, `false` to collapse
+ */
+function setExpanded(id, expanded) {
+  return {
+    type: actions.SET_EXPANDED,
+    id,
+    expanded,
   };
 }
 
@@ -457,7 +459,10 @@ const getFirstSelectedAnnotationId = createSelector(
   }
 );
 
-function expandedThreads(state) {
+/**
+ * Retrieve map of expanded/collapsed annotations (threads)
+ */
+function expandedMap(state) {
   return state.selection.expanded;
 }
 
@@ -567,7 +572,7 @@ export default {
     highlightAnnotations,
     selectAnnotations,
     selectTab,
-    setCollapsed,
+    setExpanded,
     setFilterQuery,
     setFocusModeFocused,
     changeFocusModeUser,
@@ -577,7 +582,7 @@ export default {
   },
 
   selectors: {
-    expandedThreads,
+    expandedMap,
     filterQuery,
     focusModeFocused,
     focusModeEnabled,

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -52,8 +52,21 @@ TAB_SORTKEYS_AVAILABLE[uiConstants.TAB_ORPHANS] = [
  * @param {Object} obj
  * @return {string[]}
  */
-function truthyKeys(obj) {
+function trueKeys(obj) {
   return Object.keys(obj).filter(key => obj[key] === true);
+}
+
+/**
+ * Convert an array of strings into an object mapping each array entry (string)
+ * to `true`.
+ *
+ * @param {string[]} arr
+ * @return {Object<string,true>}
+ */
+function toTrueMap(arr) {
+  const obj = /** @type {Object<string,true>} */ ({});
+  arr.forEach(key => (obj[key] = true));
+  return obj;
 }
 
 function initialSelection(settings) {
@@ -172,9 +185,7 @@ const update = {
   },
 
   FOCUS_ANNOTATIONS: function (state, action) {
-    const focused = {};
-    action.focusedTags.forEach(tag => (focused[tag] = true));
-    return { focused };
+    return { focused: toTrueMap(action.focusedTags) };
   },
 
   SET_FOCUS_MODE_FOCUSED: function (state, action) {
@@ -287,11 +298,9 @@ const actions = util.actionTypes(update);
  * @param {string[]} ids - Identifiers of annotations to select
  */
 function selectAnnotations(ids) {
-  const selection = {};
-  ids.forEach(id => (selection[id] = true));
   return {
     type: actions.SELECT_ANNOTATIONS,
-    selection,
+    selection: toTrueMap(ids),
   };
 }
 
@@ -364,11 +373,9 @@ function setExpanded(id, expanded) {
  * @param {string[]} ids - annotations to highlight
  */
 function highlightAnnotations(ids) {
-  const highlighted = {};
-  ids.forEach(id => (highlighted[id] = true));
   return {
     type: actions.HIGHLIGHT_ANNOTATIONS,
-    highlighted,
+    highlighted: toTrueMap(ids),
   };
 }
 
@@ -421,13 +428,15 @@ function setSortKey(key) {
 
 /* Selectors */
 
-function focusedAnnotations(state) {
-  return truthyKeys(state.selection.focused);
-}
+const focusedAnnotations = createSelector(
+  state => state.selection.focused,
+  focused => trueKeys(focused)
+);
 
-function forcedVisibleAnnotations(state) {
-  return truthyKeys(state.selection.forcedVisible);
-}
+const forcedVisibleAnnotations = createSelector(
+  state => state.selection.forcedVisible,
+  forcedVisible => trueKeys(forcedVisible)
+);
 
 /**
  * Is the annotation referenced by `$tag` currently focused?
@@ -446,7 +455,7 @@ function isAnnotationFocused(state, $tag) {
  */
 const hasSelectedAnnotations = createSelector(
   state => state.selection.selected,
-  selection => truthyKeys(selection).length > 0
+  selection => trueKeys(selection).length > 0
 );
 
 /** De-select all annotations. */
@@ -469,7 +478,7 @@ function clearSelection() {
 const getFirstSelectedAnnotationId = createSelector(
   state => state.selection.selected,
   selection => {
-    const selectedIds = truthyKeys(selection);
+    const selectedIds = trueKeys(selection);
     return selectedIds.length ? selectedIds[0] : null;
   }
 );
@@ -574,7 +583,7 @@ const hasAppliedFilter = createSelector(
 
 const selectedAnnotations = createSelector(
   state => state.selection.selected,
-  selection => truthyKeys(selection)
+  selection => trueKeys(selection)
 );
 
 export default {

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -44,21 +44,21 @@ describe('sidebar/store/modules/selection', () => {
 
   describe('focusAnnotations()', function () {
     it('adds the provided annotation IDs to the focused annotations', function () {
-      store.focusAnnotations([1, 2, 3]);
-      assert.deepEqual(getSelectionState().focusedAnnotations, [1, 2, 3]);
+      store.focusAnnotations(['1', '2', '3']);
+      assert.deepEqual(store.focusedAnnotations(), ['1', '2', '3']);
     });
 
     it('replaces any other focused annotation IDs', function () {
-      store.focusAnnotations([1]);
-      store.focusAnnotations([2, 3]);
-      assert.deepEqual(getSelectionState().focusedAnnotations, [2, 3]);
+      store.focusAnnotations(['1']);
+      store.focusAnnotations(['2', '3']);
+      assert.deepEqual(store.focusedAnnotations(), ['2', '3']);
     });
 
-    it('sets focused annotations to an empty array if no IDs provided', function () {
-      store.focusAnnotations([1]);
+    it('sets focused annotations to an empty object if no IDs provided', function () {
+      store.focusAnnotations(['1']);
       store.focusAnnotations([]);
-      assert.isArray(getSelectionState().focusedAnnotations);
-      assert.isEmpty(getSelectionState().focusedAnnotations);
+      assert.isObject(getSelectionState().focused);
+      assert.isEmpty(getSelectionState().focused);
     });
   });
 

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -45,10 +45,14 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('setCollapsed()', function () {
+  describe('setExpanded()', function () {
     it('sets the expanded state of the annotation', function () {
-      store.setCollapsed('parent_id', false);
-      assert.deepEqual(store.expandedThreads(), { parent_id: true });
+      store.setExpanded('parent_id', true);
+      store.setExpanded('whatnot', false);
+      assert.deepEqual(store.expandedMap(), {
+        parent_id: true,
+        whatnot: false,
+      });
     });
   });
 
@@ -205,7 +209,7 @@ describe('sidebar/store/modules/selection', () => {
 
     it('resets the force-visible and expanded sets', function () {
       store.setForcedVisible('123', true);
-      store.setCollapsed('456', false);
+      store.setExpanded('456', true);
       store.setFilterQuery('some-query');
       assert.deepEqual(getSelectionState().forcedVisible, {});
       assert.deepEqual(getSelectionState().expanded, {});

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -112,53 +112,38 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('isAnnotationSelected', function () {
-    it('returns true if the id provided is selected', function () {
-      store.selectAnnotations([1]);
-      assert.isTrue(store.isAnnotationSelected(1));
-    });
-
-    it('returns false if the id provided is not selected', function () {
-      store.selectAnnotations([1]);
-      assert.isFalse(store.isAnnotationSelected(2));
-    });
-
-    it('returns false if there are no selected annotations', function () {
-      assert.isFalse(store.isAnnotationSelected(1));
-    });
-  });
-
   describe('selectAnnotations()', function () {
-    it('adds the passed annotations to the selectedAnnotationMap', function () {
+    it('adds the passed annotations to the selectedAnnotations', function () {
       store.selectAnnotations([1, 2, 3]);
-      assert.deepEqual(store.getSelectedAnnotationMap(), {
+      assert.deepEqual(getSelectionState().selected, {
         1: true,
         2: true,
         3: true,
       });
     });
 
-    it('replaces any annotations originally in the map', function () {
+    it('replaces any annotations originally in the selection', function () {
       store.selectAnnotations([1]);
       store.selectAnnotations([2, 3]);
-      assert.deepEqual(store.getSelectedAnnotationMap(), {
+      assert.deepEqual(getSelectionState().selected, {
         2: true,
         3: true,
       });
     });
 
-    it('nulls the map if no annotations are selected', function () {
+    it('empties the selection object if no annotations are selected', function () {
       store.selectAnnotations([1]);
       store.selectAnnotations([]);
-      assert.isNull(store.getSelectedAnnotationMap());
+      assert.isObject(getSelectionState().selected);
+      assert.isEmpty(getSelectionState().selected);
     });
   });
 
   describe('toggleSelectedAnnotations()', function () {
-    it('adds annotations missing from the selectedAnnotationMap', function () {
+    it('adds annotations missing from the selectedAnnotations', function () {
       store.selectAnnotations([1, 2]);
       store.toggleSelectedAnnotations([3, 4]);
-      assert.deepEqual(store.getSelectedAnnotationMap(), {
+      assert.deepEqual(getSelectionState().selected, {
         1: true,
         2: true,
         3: true,
@@ -166,27 +151,22 @@ describe('sidebar/store/modules/selection', () => {
       });
     });
 
-    it('removes annotations already in the selectedAnnotationMap', function () {
+    it('removes annotations already in the selection', function () {
       store.selectAnnotations([1, 3]);
       store.toggleSelectedAnnotations([1, 2]);
-      assert.deepEqual(store.getSelectedAnnotationMap(), {
+      assert.deepEqual(getSelectionState().selected, {
+        1: false,
         2: true,
         3: true,
       });
     });
-
-    it('nulls the map if no annotations are selected', function () {
-      store.selectAnnotations([1]);
-      store.toggleSelectedAnnotations([1]);
-      assert.isNull(store.getSelectedAnnotationMap());
-    });
   });
 
   describe('#REMOVE_ANNOTATIONS', function () {
-    it('removing an annotation should also remove it from selectedAnnotationMap', function () {
+    it('removing an annotation should also remove it from the selection', function () {
       store.selectAnnotations([1, 2, 3]);
       store.removeAnnotations([{ id: 2 }]);
-      assert.deepEqual(store.getSelectedAnnotationMap(), {
+      assert.deepEqual(getSelectionState().selected, {
         1: true,
         3: true,
       });
@@ -197,7 +177,7 @@ describe('sidebar/store/modules/selection', () => {
     it('removes all annotations from the selection', function () {
       store.selectAnnotations([1]);
       store.clearSelectedAnnotations();
-      assert.isNull(store.getSelectedAnnotationMap());
+      assert.isEmpty(getSelectionState().selected);
     });
 
     it('clears the current search query', function () {

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -380,7 +380,16 @@ describe('sidebar/store/modules/selection', () => {
   describe('highlightAnnotations()', function () {
     it('sets the highlighted annotations', function () {
       store.highlightAnnotations(['id1', 'id2']);
-      assert.deepEqual(getSelectionState().highlighted, ['id1', 'id2']);
+      assert.deepEqual(getSelectionState().highlighted, {
+        id1: true,
+        id2: true,
+      });
+    });
+
+    it('replaces the current set of highlighted annotations', () => {
+      store.highlightAnnotations(['id1', 'id2']);
+      store.highlightAnnotations(['id3']);
+      assert.deepEqual(getSelectionState().highlighted, { id3: true });
     });
   });
 

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -28,10 +28,20 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('setForceVisible()', function () {
+  describe('setForcedVisible', function () {
     it('sets the visibility of the annotation', function () {
-      store.setForceVisible('id1', true);
-      assert.deepEqual(getSelectionState().forceVisible, { id1: true });
+      store.setForcedVisible('id1', true);
+      assert.deepEqual(getSelectionState().forcedVisible, { id1: true });
+    });
+
+    it('does not affect the visibility of other annotations', () => {
+      store.setForcedVisible('id1', true);
+      store.setForcedVisible('id2', false);
+      assert.deepEqual(getSelectionState().forcedVisible, {
+        id1: true,
+        id2: false,
+      });
+      assert.deepEqual(store.forcedVisibleAnnotations(), ['id1']);
     });
   });
 
@@ -194,10 +204,10 @@ describe('sidebar/store/modules/selection', () => {
     });
 
     it('resets the force-visible and expanded sets', function () {
-      store.setForceVisible('123', true);
+      store.setForcedVisible('123', true);
       store.setCollapsed('456', false);
       store.setFilterQuery('some-query');
-      assert.deepEqual(getSelectionState().forceVisible, {});
+      assert.deepEqual(getSelectionState().forcedVisible, {});
       assert.deepEqual(getSelectionState().expanded, {});
     });
   });
@@ -234,14 +244,14 @@ describe('sidebar/store/modules/selection', () => {
 
     it('clears other applied selections', () => {
       store.setFocusModeFocused(true);
-      store.setForceVisible('someAnnotationId');
+      store.setForcedVisible('someAnnotationId');
       store.setFilterQuery('somequery');
       store.changeFocusModeUser({
         username: 'testuser',
         displayName: 'Test User',
       });
 
-      assert.isEmpty(getSelectionState().forceVisible);
+      assert.isEmpty(getSelectionState().forcedVisible);
       assert.isNull(store.filterQuery());
     });
   });

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -40,9 +40,7 @@ describe('store', function () {
 
     it('sets the selection when settings.annotations is set', function () {
       store = storeFactory({ annotations: 'testid' });
-      assert.deepEqual(store.getSelectedAnnotationMap(), {
-        testid: true,
-      });
+      assert.deepEqual(store.selectedAnnotations(), ['testid']);
     });
 
     it('expands the selected annotations when settings.annotations is set', function () {
@@ -56,9 +54,9 @@ describe('store', function () {
   describe('clearSelection', () => {
     // Test clearSelection here over the entire store as it triggers the
     // CLEAR_SELECTION action in multiple store modules.
-    it('sets `selectedAnnotationMap` to null', () => {
+    it('empties selected annotation map', () => {
       store.clearSelection();
-      assert.isNull(store.getSelectedAnnotationMap());
+      assert.isEmpty(store.selectedAnnotations());
     });
 
     it('sets `filterQuery` to null', () => {

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -35,7 +35,7 @@ describe('store', function () {
   describe('initialization', function () {
     it('does not set a selection when settings.annotations is null', function () {
       assert.isFalse(store.hasSelectedAnnotations());
-      assert.equal(Object.keys(store.expandedThreads()).length, 0);
+      assert.equal(Object.keys(store.expandedMap()).length, 0);
     });
 
     it('sets the selection when settings.annotations is set', function () {
@@ -45,7 +45,7 @@ describe('store', function () {
 
     it('expands the selected annotations when settings.annotations is set', function () {
       store = storeFactory({ annotations: 'testid' });
-      assert.deepEqual(store.expandedThreads(), {
+      assert.deepEqual(store.expandedMap(), {
         testid: true,
       });
     });

--- a/src/sidebar/test/build-thread-test.js
+++ b/src/sidebar/test/build-thread-test.js
@@ -290,7 +290,7 @@ describe('build-thread', function () {
         filterFn: function (annot) {
           return annot.text.match(/first/);
         },
-        forceVisible: ['3'],
+        forcedVisible: ['3'],
       });
       assert.isFalse(thread.children[0].collapsed);
     });


### PR DESCRIPTION
There are several properties in the `selection` store state that are kind of map-like, kind of Set-like. These include the currently-selected annotations, the currently-highlighted annotations, a map of expanded/collapsed threads, etc. There has been some inconsistency both in their internal representation and external representation (via selectors).

This PR aims to make consistent the maplike collections in the `selection` state such that they are predictable and conventionalized. For each of the affected collections, the internal structure is represented as `{Object<string,boolean>}` where the string key is an identifier (id or tag) of an annotation or thread. In several of these maps, entries are always `true`, making them feel like Arrays, but for now I've opted to make them all Objects, because:

* As in a Set, you'll end up with only one entry per annotation ID (protects from dupes)
* It may be useful, now or ever, to be able to set an entry to `false` — this is already useful for the `expanded` collection, e.g. Even if not, it's nice to have these all consistent.

The selector conventions are:

* `<nameOfProperty>Annotations`, e.g. `forcedVisibleAnnotations`, `selectedAnnotations`: Returns an `Array` of all annotation identifiers in the map object with a `true` value.
* `<nameOfProperty>Map`, e.g. `expandedMap`: Retrieves the map object itself, with all entries

And for actions:

* `set<nameOfProperty>`, e.g. `setExpanded`, `setForcedVisible`. takes single `id` and boolean: _updates_ current map
* `<verbFormOfProperty>Annotations`, e.g. `highlightAnnotations`, `selectAnnotations`. _replaces_ current map. Takes Array of `id`s and sets them all to `true` in the new map.

I've only added actions and selectors for these where they're actively needed. Figure we can add them just in time as we go.

More work to do in this module, but this is plenty chunky for a PR.