### PR TITLE
Address tech debt in `selection` pertaining to tabs and sort options

### DIFF
--- a/src/sidebar/components/sort-menu.js
+++ b/src/sidebar/components/sort-menu.js
@@ -17,9 +17,7 @@ export default function SortMenu() {
   const sortKey = useStore(store => store.getState().selection.sortKey);
   // All available sorting options. These change depending on current
   // "tab" or context.
-  const sortKeysAvailable = useStore(
-    store => store.getState().selection.sortKeysAvailable
-  );
+  const sortKeysAvailable = useStore(store => store.sortKeys());
 
   const menuItems = sortKeysAvailable.map(sortOption => {
     return (

--- a/src/sidebar/components/test/sort-menu-test.js
+++ b/src/sidebar/components/test/sort-menu-test.js
@@ -18,12 +18,12 @@ describe('SortMenu', () => {
     fakeState = {
       selection: {
         sortKey: 'Location',
-        sortKeysAvailable: ['Newest', 'Oldest', 'Location'],
       },
     };
     fakeStore = {
       setSortKey: sinon.stub(),
       getState: sinon.stub().returns(fakeState),
+      sortKeys: sinon.stub().returns(['Newest', 'Oldest', 'Location']),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -41,8 +41,8 @@ describe('SortMenu', () => {
 
     const menuItems = wrapper.find('MenuItem');
 
-    assert.lengthOf(menuItems, fakeState.selection.sortKeysAvailable.length);
-    fakeState.selection.sortKeysAvailable.forEach(sortKey => {
+    assert.lengthOf(menuItems, fakeStore.sortKeys().length);
+    fakeStore.sortKeys().forEach(sortKey => {
       assert.lengthOf(
         menuItems.filterWhere(menuItem => menuItem.prop('label') === sortKey),
         1

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -43,8 +43,6 @@ describe('rootThread', function () {
         selection: {
           filterQuery: null,
           highlighted: [],
-          sortKey: 'Location',
-          sortKeysAvailable: ['Location'],
         },
         route: {
           name: 'sidebar',
@@ -214,7 +212,6 @@ describe('rootThread', function () {
       it(`sort order is correct when sorting by ${testCase.order}`, () => {
         fakeBuildThread.reset();
         fakeStore.state.selection.sortKey = testCase.order;
-        fakeStore.state.selection.sortKeysAvailable = [testCase.order];
 
         rootThread.thread(fakeStore.state);
         const sortCompareFn = fakeBuildThread.args[0][1].sortCompareFn;

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -423,28 +423,17 @@ describe('sidebar/store/modules/selection', () => {
 
     it('allows sorting annotations by time and document location', function () {
       store.selectTab(uiConstants.TAB_ANNOTATIONS);
-      assert.deepEqual(getSelectionState().sortKeysAvailable, [
-        'Newest',
-        'Oldest',
-        'Location',
-      ]);
+      assert.deepEqual(store.sortKeys(), ['Newest', 'Oldest', 'Location']);
     });
 
     it('allows sorting page notes by time', function () {
       store.selectTab(uiConstants.TAB_NOTES);
-      assert.deepEqual(getSelectionState().sortKeysAvailable, [
-        'Newest',
-        'Oldest',
-      ]);
+      assert.deepEqual(store.sortKeys(), ['Newest', 'Oldest']);
     });
 
     it('allows sorting orphans by time and document location', function () {
       store.selectTab(uiConstants.TAB_ORPHANS);
-      assert.deepEqual(getSelectionState().sortKeysAvailable, [
-        'Newest',
-        'Oldest',
-        'Location',
-      ]);
+      assert.deepEqual(store.sortKeys(), ['Newest', 'Oldest', 'Location']);
     });
 
     it('sorts annotations by document location by default', function () {

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -87,25 +87,6 @@ describe('store', function () {
       assert.equal(store.getState().selection.sortKey, 'Location');
     });
 
-    it('sets `sortKeysAvailable` to available annotation sort keys if set to Orphans', () => {
-      store.selectTab(uiConstants.TAB_ORPHANS);
-      store.clearSelection();
-      assert.deepEqual(store.getState().selection.sortKeysAvailable, [
-        'Newest',
-        'Oldest',
-        'Location',
-      ]);
-    });
-
-    it('sets `selectedTab` to Annotations if set to Orphans', () => {
-      store.selectTab(uiConstants.TAB_ORPHANS);
-      store.clearSelection();
-      assert.equal(
-        store.getState().selection.selectedTab,
-        uiConstants.TAB_ANNOTATIONS
-      );
-    });
-
     it('does not change `selectedTab` if set to something other than Orphans', () => {
       store.selectTab(uiConstants.TAB_NOTES);
       store.clearSelection();

--- a/src/sidebar/ui-constants.js
+++ b/src/sidebar/ui-constants.js
@@ -6,6 +6,7 @@ export default {
   PANEL_HELP: 'help',
   PANEL_LOGIN_PROMPT: 'loginPrompt',
   PANEL_SHARE_ANNOTATIONS: 'shareGroupAnnotations',
+  TABS: ['annotation', 'note', 'orphan'],
   TAB_ANNOTATIONS: 'annotation',
   TAB_NOTES: 'note',
   TAB_ORPHANS: 'orphan',


### PR DESCRIPTION
Another iteration of `selection` module cleanup. There has been some tech debt here in terms of how tab selection is managed and the sorting options available.

## User-visible changes

There was some logic in place that, when clearing selected annotations, if a user had the `Orphans` tab selected, they would be changed to the `Annotations` tab. While that logic seems to be there on purpose (see https://github.com/hypothesis/client/pull/1186), I can't track down _why_. This doesn't seem helpful: why move the user to another tab at this point? If there is good reason for this behavior, we could put it back.

This PR contains a change which could prevent a bug in which changing tabs resulted in a sorting option not applicable to the new tab was still selected. That should no longer be possible, as all actions/reducers that change the selected tab now use the same logic.

## Other Changes

* `sortKeysAvailable` has been removed from state and there is a selector for this now (this was mentioned in https://github.com/hypothesis/client/pull/1186)
* tab and sorting constants have been simplified
* All actions/reducers use `setTab` when changing the `selectedTab` value