### PR TITLE
Improve typechecking for Stores

### DIFF
--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -8,19 +8,6 @@ import immutable from '../util/immutable';
 import { createReducer, bindSelectors } from './util';
 
 /**
- * // Base redux store
- * @typedef {import("redux").Store} ReduxStore
- *
- * // Custom stores
- * @typedef {import("./modules/activity").ActivityStore} ActivityStore
- * // TODO: add more stores
- *
- * // Combine all stores
- * @typedef {ReduxStore &
- *  ActivityStore} SidebarStore
- */
-
-/**
  * Create a Redux store from a set of _modules_.
  *
  * Each module defines the logic related to a particular piece of the application
@@ -37,8 +24,7 @@ import { createReducer, bindSelectors } from './util';
  *
  * @param {Object[]} modules
  * @param {any[]} [initArgs] - Arguments to pass to each state module's `init` function
- * @param {any[]} [middleware] - List of additional Redux middlewares to use.
- * @return {SidebarStore}
+ * @param {any[]} [middleware] - List of additional Redux middlewares to use
  */
 export default function createStore(modules, initArgs = [], middleware = []) {
   // Create the initial state and state update function.
@@ -102,5 +88,5 @@ export default function createStore(modules, initArgs = [], middleware = []) {
 
   Object.assign(store, boundActions, boundSelectors);
 
-  return /** @type {SidebarStore} */ (store);
+  return store;
 }

--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -93,11 +93,7 @@ export default function createStore(modules, initArgs = [], middleware = []) {
   }
 
   // Create the store.
-  const store = /** @type {SidebarStore} */ (redux.createStore(
-    reducer,
-    initialState,
-    enhancer
-  ));
+  const store = redux.createStore(reducer, initialState, enhancer);
 
   // Add actions and selectors as methods to the store.
   const actions = Object.assign({}, ...modules.map(m => m.actions));
@@ -106,5 +102,5 @@ export default function createStore(modules, initArgs = [], middleware = []) {
 
   Object.assign(store, boundActions, boundSelectors);
 
-  return store;
+  return /** @type {SidebarStore} */ (store);
 }

--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -8,6 +8,19 @@ import immutable from '../util/immutable';
 import { createReducer, bindSelectors } from './util';
 
 /**
+ * // Base redux store
+ * @typedef {import("redux").Store} ReduxStore
+ *
+ * // Custom stores
+ * @typedef {import("./modules/activity").ActivityStore} ActivityStore
+ * // TODO: add more stores
+ *
+ * // Combine all stores
+ * @typedef {ReduxStore &
+ *  ActivityStore} SidebarStore
+ */
+
+/**
  * Create a Redux store from a set of _modules_.
  *
  * Each module defines the logic related to a particular piece of the application
@@ -25,6 +38,7 @@ import { createReducer, bindSelectors } from './util';
  * @param {Object[]} modules
  * @param {any[]} [initArgs] - Arguments to pass to each state module's `init` function
  * @param {any[]} [middleware] - List of additional Redux middlewares to use.
+ * @return {SidebarStore}
  */
 export default function createStore(modules, initArgs = [], middleware = []) {
   // Create the initial state and state update function.
@@ -79,7 +93,11 @@ export default function createStore(modules, initArgs = [], middleware = []) {
   }
 
   // Create the store.
-  const store = redux.createStore(reducer, initialState, enhancer);
+  const store = /** @type {SidebarStore} */ (redux.createStore(
+    reducer,
+    initialState,
+    enhancer
+  ));
 
   // Add actions and selectors as methods to the store.
   const actions = Object.assign({}, ...modules.map(m => m.actions));

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -54,6 +54,9 @@ import viewer from './modules/viewer';
  * the individual state modules. ie. `store.actionName(args)` dispatches an
  * action through the store and `store.selectorName(args)` invokes a selector
  * passing the current state of the store.
+ *
+ * @param {import('../../types/config').SidebarConfig} settings
+ * @return {import('.create-store').HypothesisStore}
  */
 // @ngInject
 export default function store(settings) {

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -56,7 +56,7 @@ import viewer from './modules/viewer';
  * passing the current state of the store.
  *
  * @param {import('../../types/config').SidebarConfig} settings
- * @return {import('.create-store').HypothesisStore}
+ * @return {import('./create-store').SidebarStore}
  */
 // @ngInject
 export default function store(settings) {

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -48,6 +48,18 @@ import toastMessages from './modules/toast-messages';
 import viewer from './modules/viewer';
 
 /**
+ * // Base redux store
+ * @typedef {import("redux").Store} ReduxStore
+ *
+ * // Custom stores
+ * @typedef {import("./modules/activity").ActivityStore} ActivityStore
+ * // TODO: add more stores
+ *
+ * // Combine all stores
+ * @typedef {ReduxStore & ActivityStore} SidebarStore
+ */
+
+/**
  * Factory which creates the sidebar app's state store.
  *
  * Returns a Redux store augmented with methods for each action and selector in
@@ -56,7 +68,7 @@ import viewer from './modules/viewer';
  * passing the current state of the store.
  *
  * @param {import('../../types/config').SidebarConfig} settings
- * @return {import('./create-store').SidebarStore}
+ * @return {SidebarStore}
  */
 // @ngInject
 export default function store(settings) {
@@ -79,5 +91,9 @@ export default function store(settings) {
     toastMessages,
     viewer,
   ];
-  return createStore(modules, [settings], middleware);
+  return /** @type {SidebarStore} */ (createStore(
+    modules,
+    [settings],
+    middleware
+  ));
 }

--- a/src/sidebar/store/modules/activity.js
+++ b/src/sidebar/store/modules/activity.js
@@ -167,6 +167,26 @@ function isSavingAnnotation(state, annotation) {
   return state.activeAnnotationSaveRequests.includes(annotation.$tag);
 }
 
+/** @typedef {import('../../../types/api').Annotation} Annotation */
+
+/**
+ * @typedef ActivityStore
+ *
+ * // Actions
+ * @prop {typeof annotationFetchStarted} annotationFetchStarted
+ * @prop {typeof annotationFetchFinished} annotationFetchFinished
+ * @prop {typeof annotationSaveStarted} annotationSaveStarted
+ * @prop {typeof annotationSaveFinished} annotationSaveFinished
+ * @prop {typeof apiRequestStarted} apiRequestStarted
+ * @prop {typeof apiRequestFinished} apiRequestFinished
+ *
+ * // Selectors
+ * @prop {() => boolean} hasFetchedAnnotations
+ * @prop {() => boolean} isLoading
+ * @prop {() => boolean} isFetchingAnnotations
+ * @prop {(a: Annotation) => boolean} isSavingAnnotation
+ */
+
 export default {
   init,
   update,

--- a/src/sidebar/store/use-store.js
+++ b/src/sidebar/store/use-store.js
@@ -6,14 +6,13 @@ import shallowEqual from 'shallowequal';
 import warnOnce from '../../shared/warn-once';
 import { useService } from '../util/service-context';
 
-/**
- * @typedef {import("redux").Store} Store
- */
+/** @typedef {import("redux").Store} Store */
+/** @typedef {import("./create-store").SidebarStore} SidebarStore */
 
 /**
  * @template T
  * @callback StoreCallback
- * @param {Store} store
+ * @param {SidebarStore} store
  * @return {T}
  */
 

--- a/src/sidebar/store/use-store.js
+++ b/src/sidebar/store/use-store.js
@@ -7,7 +7,8 @@ import warnOnce from '../../shared/warn-once';
 import { useService } from '../util/service-context';
 
 /** @typedef {import("redux").Store} Store */
-/** @typedef {import("./create-store").SidebarStore} SidebarStore */
+
+/** @typedef {import("./index").SidebarStore} SidebarStore */
 
 /**
  * @template T

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -22,13 +22,7 @@
     "sidebar/store/modules/*.js",
     "sidebar/services/*.js",
     "sidebar/util/*.js",
-
-    // TODO replace these with sidebar/store/* when all modules are converted
-    "sidebar/store/create-store.js",
-    "sidebar/store/debug-middleware.js",
-    "sidebar/store/use-store.js",
-    "sidebar/store/utils.js",
-    
+    "sidebar/store/*.js",
   ],
   "exclude": [
     // Enable this once the rest of `src/sidebar` is checked.


### PR DESCRIPTION
Add SidebarStore type. This is an aggregation of the base ReduxStore + each one of our stores baked in. The fist store added here is simply the Activity store (as a first example)

There are some assumptions when making store types:

1. It is assumed they are transformed in `createStore` where the selectors and actions are flattened.

2. Some meta data (namely, the init method, namespace and update method) are refactored or removed.

These transformations are implied through the typing which explicitly ignores these methods and structure of the raw store before the transformation in create-store.

--------------


This is just a subset of the larger PR (no changes)
https://github.com/hypothesis/client/pull/2318