### PR TITLE
Refactor focus-mode related state in `selection` module

### DIFF
--- a/src/sidebar/components/focused-mode-header.js
+++ b/src/sidebar/components/focused-mode-header.js
@@ -11,12 +11,12 @@ export default function FocusedModeHeader() {
   const toggleFocusMode = useStore(store => store.toggleFocusMode);
   const selectors = useStore(store => ({
     focusModeActive: store.focusModeActive(),
-    focusModeHasUser: store.focusModeHasUser(),
+    focusModeConfigured: store.focusModeConfigured(),
     focusModeUserPrettyName: store.focusModeUserPrettyName(),
   }));
 
   // Nothing to do here for now if we're not focused on a user
-  if (!selectors.focusModeHasUser) {
+  if (!selectors.focusModeConfigured) {
     return null;
   }
 

--- a/src/sidebar/components/focused-mode-header.js
+++ b/src/sidebar/components/focused-mode-header.js
@@ -8,11 +8,9 @@ import useStore from '../store/use-store';
  * and abstracted if needed. Allow user to toggle in and out of the focus "mode."
  */
 export default function FocusedModeHeader() {
-  const actions = useStore(store => ({
-    setFocusModeFocused: store.setFocusModeFocused,
-  }));
+  const toggleFocusMode = useStore(store => store.toggleFocusMode);
   const selectors = useStore(store => ({
-    focusModeFocused: store.focusModeFocused(),
+    focusModeActive: store.focusModeActive(),
     focusModeHasUser: store.focusModeHasUser(),
     focusModeUserPrettyName: store.focusModeUserPrettyName(),
   }));
@@ -22,13 +20,9 @@ export default function FocusedModeHeader() {
     return null;
   }
 
-  const toggleFocusedMode = () => {
-    actions.setFocusModeFocused(!selectors.focusModeFocused);
-  };
-
   const filterStatus = (
     <div className="focused-mode-header__filter-status">
-      {selectors.focusModeFocused ? (
+      {selectors.focusModeActive ? (
         <span>
           Showing <strong>{selectors.focusModeUserPrettyName}</strong> only
         </span>
@@ -41,7 +35,7 @@ export default function FocusedModeHeader() {
   );
 
   const buttonText = (() => {
-    if (selectors.focusModeFocused) {
+    if (selectors.focusModeActive) {
       return 'Show all';
     } else {
       return `Show only ${selectors.focusModeUserPrettyName}`;
@@ -51,7 +45,10 @@ export default function FocusedModeHeader() {
   return (
     <div className="focused-mode-header">
       {filterStatus}
-      <button onClick={toggleFocusedMode} className="focused-mode-header__btn">
+      <button
+        onClick={() => toggleFocusMode()}
+        className="focused-mode-header__btn"
+      >
         {buttonText}
       </button>
     </div>

--- a/src/sidebar/components/search-status-bar.js
+++ b/src/sidebar/components/search-status-bar.js
@@ -39,13 +39,13 @@ function SearchStatusBar({ rootThread }) {
 
   const {
     filterQuery,
-    focusModeFocused,
+    focusModeActive,
     focusModeUserPrettyName,
     hasSelectedAnnotations,
     selectedTab,
   } = useStore(store => ({
     filterQuery: store.getState().selection.filterQuery,
-    focusModeFocused: store.focusModeFocused(),
+    focusModeActive: store.focusModeActive(),
     focusModeUserPrettyName: store.focusModeUserPrettyName(),
     hasSelectedAnnotations: store.hasSelectedAnnotations(),
     selectedTab: store.getState().selection.selectedTab,
@@ -64,7 +64,7 @@ function SearchStatusBar({ rootThread }) {
      * The client has a currently-applied focus on a single user. Superseded by
      * `filtered` mode.
      */
-    focused: focusModeFocused && !filterQuery,
+    focused: focusModeActive && !filterQuery,
     /**
      * @type {Boolean}
      * 0 - n annotations are currently "selected", by, e.g. clicking on highlighted

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -32,7 +32,7 @@ function SidebarContent({
   // Store state values
   const focusedGroupId = useStore(store => store.focusedGroupId());
   const hasAppliedFilter = useStore(store => store.hasAppliedFilter());
-  const isFocusedMode = useStore(store => store.focusModeEnabled());
+  const isFocusedMode = useStore(store => store.focusModeConfigured());
   const isLoading = useStore(store => store.isLoading());
   const isLoggedIn = useStore(store => store.isLoggedIn());
   const linkedAnnotationId = useStore(store =>

--- a/src/sidebar/components/test/focused-mode-header-test.js
+++ b/src/sidebar/components/test/focused-mode-header-test.js
@@ -22,8 +22,8 @@ describe('FocusedModeHeader', function () {
         },
       },
       focusModeActive: sinon.stub().returns(true),
+      focusModeConfigured: sinon.stub().returns(true),
       focusModeUserPrettyName: sinon.stub().returns('Fake User'),
-      focusModeHasUser: sinon.stub().returns(true),
       toggleFocusMode: sinon.stub(),
     };
 
@@ -39,7 +39,7 @@ describe('FocusedModeHeader', function () {
 
   context('not in user-focused mode', () => {
     it('should not render anything if not in user-focused mode', () => {
-      fakeStore.focusModeHasUser = sinon.stub().returns(false);
+      fakeStore.focusModeConfigured.returns(false);
 
       const wrapper = createComponent();
 

--- a/src/sidebar/components/test/focused-mode-header-test.js
+++ b/src/sidebar/components/test/focused-mode-header-test.js
@@ -21,10 +21,10 @@ describe('FocusedModeHeader', function () {
           focused: true,
         },
       },
-      focusModeFocused: sinon.stub().returns(true),
+      focusModeActive: sinon.stub().returns(true),
       focusModeUserPrettyName: sinon.stub().returns('Fake User'),
       focusModeHasUser: sinon.stub().returns(true),
-      setFocusModeFocused: sinon.stub(),
+      toggleFocusMode: sinon.stub(),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -66,7 +66,7 @@ describe('FocusedModeHeader', function () {
 
     context('focus is not applied (unfocused/off)', () => {
       beforeEach(() => {
-        fakeStore.focusModeFocused = sinon.stub().returns(false);
+        fakeStore.focusModeActive = sinon.stub().returns(false);
       });
 
       it("should render status text indicating that all user's annotations are visible", () => {
@@ -86,21 +86,12 @@ describe('FocusedModeHeader', function () {
 
     describe('toggle button', () => {
       it('should toggle focus mode to false if clicked when focused', () => {
-        fakeStore.focusModeFocused = sinon.stub().returns(true);
+        fakeStore.focusModeActive = sinon.stub().returns(true);
         const wrapper = createComponent();
 
         wrapper.find('button').simulate('click');
 
-        assert.calledWith(fakeStore.setFocusModeFocused, false);
-      });
-
-      it('should toggle focus mode to true if clicked when not focused', () => {
-        fakeStore.focusModeFocused = sinon.stub().returns(false);
-        const wrapper = createComponent();
-
-        wrapper.find('button').simulate('click');
-
-        assert.calledWith(fakeStore.setFocusModeFocused, true);
+        assert.calledOnce(fakeStore.toggleFocusMode);
       });
     });
   });

--- a/src/sidebar/components/test/search-status-bar-test.js
+++ b/src/sidebar/components/test/search-status-bar-test.js
@@ -24,7 +24,7 @@ describe('SearchStatusBar', () => {
         selection: {},
       }),
       annotationCount: sinon.stub().returns(1),
-      focusModeFocused: sinon.stub().returns(false),
+      focusModeActive: sinon.stub().returns(false),
       focusModeUserPrettyName: sinon.stub().returns('Fake User'),
       hasSelectedAnnotations: sinon.stub(),
       noteCount: sinon.stub().returns(0),
@@ -122,7 +122,7 @@ describe('SearchStatusBar', () => {
 
   context('user-focused mode applied', () => {
     beforeEach(() => {
-      fakeStore.focusModeFocused = sinon.stub().returns(true);
+      fakeStore.focusModeActive = sinon.stub().returns(true);
     });
 
     it('should not display a clear/show-all-annotations button when user-focused', () => {
@@ -262,7 +262,7 @@ describe('SearchStatusBar', () => {
         { tab: 'note', buttonText: 'Show all notes by Fake User' },
       ].forEach(test => {
         it(`displays correct text for tab '${test.tab}', without count`, () => {
-          fakeStore.focusModeFocused = sinon.stub().returns(true);
+          fakeStore.focusModeActive = sinon.stub().returns(true);
           fakeStore.getState.returns({
             selection: {
               filterQuery: null,
@@ -286,7 +286,7 @@ describe('SearchStatusBar', () => {
     context('combined with applied query filter', () => {
       // Applied-query mode wins out here; no selection UI rendered
       it('does not show selected-mode elements', () => {
-        fakeStore.focusModeFocused = sinon.stub().returns(true);
+        fakeStore.focusModeActive = sinon.stub().returns(true);
         fakeStore.getState.returns({
           selection: {
             filterQuery: 'tag:foo',

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -52,7 +52,7 @@ describe('SidebarContent', () => {
       directLinkedGroupFetchFailed: sinon.stub(),
       findAnnotationByID: sinon.stub(),
       focusedGroupId: sinon.stub(),
-      focusModeEnabled: sinon.stub(),
+      focusModeConfigured: sinon.stub(),
       hasAppliedFilter: sinon.stub(),
       hasFetchedAnnotations: sinon.stub(),
       hasSidebarOpened: sinon.stub(),
@@ -226,7 +226,7 @@ describe('SidebarContent', () => {
   });
 
   it('renders a focused header if in focused mode', () => {
-    fakeStore.focusModeEnabled.returns(true);
+    fakeStore.focusModeConfigured.returns(true);
     const wrapper = createComponent();
 
     assert.isTrue(wrapper.find('FocusedModeHeader').exists());

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -46,7 +46,7 @@ export default function RootThread(
     const sortFn = sortFns[state.selection.sortKey];
     const shouldFilterThread = () => {
       // Is there a search query, or are we in an active (focused) focus mode?
-      return state.selection.filterQuery || store.focusModeFocused();
+      return state.selection.filterQuery || store.focusModeActive();
     };
 
     const options = {
@@ -62,7 +62,7 @@ export default function RootThread(
         state.selection.filterQuery,
         {
           // if a focus mode is applied (focused) and we're focusing on a user
-          user: store.focusModeFocused() && store.focusModeUserId(),
+          user: store.focusModeActive() && store.focusModeUserId(),
         }
       );
 

--- a/src/sidebar/services/root-thread.js
+++ b/src/sidebar/services/root-thread.js
@@ -62,7 +62,7 @@ export default function RootThread(
         state.selection.filterQuery,
         {
           // if a focus mode is applied (focused) and we're focusing on a user
-          user: store.focusModeActive() && store.focusModeUserId(),
+          user: store.focusModeUserFilter(),
         }
       );
 

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -64,7 +64,7 @@ describe('rootThread', function () {
       getDraftIfNotEmpty: sinon.stub().returns(null),
       removeDraft: sinon.stub(),
       createAnnotation: sinon.stub(),
-      focusModeFocused: sinon.stub().returns(false),
+      focusModeActive: sinon.stub().returns(false),
       focusModeUserId: sinon.stub().returns({}),
     };
 
@@ -323,7 +323,7 @@ describe('rootThread', function () {
       const filters = [{ user: { terms: ['acct:bill@localhost'] } }];
       const annotation = annotationFixtures.defaultAnnotation();
       fakeSearchFilter.generateFacetedFilter.returns(filters);
-      fakeStore.focusModeFocused = sinon.stub().returns(true);
+      fakeStore.focusModeActive = sinon.stub().returns(true);
       rootThread.thread(fakeStore.state);
       const filterFn = fakeBuildThread.args[0][1].filterFn;
 

--- a/src/sidebar/services/test/root-thread-test.js
+++ b/src/sidebar/services/test/root-thread-test.js
@@ -65,7 +65,7 @@ describe('rootThread', function () {
       removeDraft: sinon.stub(),
       createAnnotation: sinon.stub(),
       focusModeActive: sinon.stub().returns(false),
-      focusModeUserId: sinon.stub().returns({}),
+      focusModeUserFilter: sinon.stub().returns(null),
     };
 
     fakeBuildThread = sinon.stub().returns(fixtures.emptyThread);

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -60,6 +60,23 @@ function initialSelection(settings) {
   return selection;
 }
 
+// function initialFocus(settings) {
+//   const focusConfig = {
+//     configured: false,
+//     active: false,
+//     user: undefined,
+//   };
+//
+//   if (settings.hasOwnProperty('user')) {
+//     const focusedUser = {...settings.user};
+//     if (focusedUser.username && focusedUser.authority) {
+//       focusConfig.configured = true;
+//       focusConfig.user = focusedUser;
+//     }
+//   }
+//   return focusConfig;
+// }
+
 function init(settings) {
   return {
     /**
@@ -96,7 +113,7 @@ function init(settings) {
 
     filterQuery: settings.query || null,
     focusMode: {
-      enabled: settings.hasOwnProperty('focus'),
+      configured: settings.hasOwnProperty('focus'),
       focused: true,
       // Copy over the focus confg from settings object
       config: { ...(settings.focus ? settings.focus : {}) },
@@ -163,7 +180,7 @@ const update = {
       return {
         focusMode: {
           ...state.focusMode,
-          enabled: false,
+          configured: false,
           focused: false,
         },
       };
@@ -171,7 +188,7 @@ const update = {
       return {
         focusMode: {
           ...state.focusMode,
-          enabled: true,
+          configured: true,
           focused: true,
           config: {
             user: { ...action.user },
@@ -464,21 +481,21 @@ function filterQuery(state) {
 }
 
 /**
- * Do the config settings indicate that the client should be in a focused mode?
+ * Does the configuration used by the app contain valid focus-mode configuration?
  *
  * @return {boolean}
  */
-function focusModeEnabled(state) {
-  return state.selection.focusMode.enabled;
+function focusModeConfigured(state) {
+  return state.selection.focusMode.configured;
 }
 
 /**
- * Is a focus mode enabled, and is it presently applied?
+ * Is a focus mode configured, and is it presently applied?
  *
  * @return {boolean}
  */
 function focusModeFocused(state) {
-  return focusModeEnabled(state) && state.selection.focusMode.focused;
+  return focusModeConfigured(state) && state.selection.focusMode.focused;
 }
 
 /**
@@ -507,7 +524,7 @@ function focusModeUserId(state) {
  * @return {boolean}
  */
 function focusModeHasUser(state) {
-  return focusModeEnabled(state) && !!focusModeUserId(state);
+  return focusModeConfigured(state) && !!focusModeUserId(state);
 }
 
 /**
@@ -592,7 +609,7 @@ export default {
     expandedMap,
     filterQuery,
     focusModeFocused,
-    focusModeEnabled,
+    focusModeConfigured,
     focusModeHasUser,
     focusModeUserId,
     focusModeUserPrettyName,

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -5,24 +5,30 @@
 
 /**
  * @typedef User
- * @property {string} [userid]
- * @property {string} [username]
- * @property {string} displayName - User's display name
+ * @prop {string} [userid]
+ * @prop {string} [username]
+ * @prop {string} displayName - User's display name
  */
 
 /**
  * @typedef FocusedUser
- * @property {string} filter - The identifier to use for filtering annotations
- *           derived from either a userId or a username
- * @property {string} displayName
+ * @prop {string} filter - The identifier to use for filtering annotations
+ *           derived from either a userId or a username. This may take the
+ *           form of a username, e.g. 'oakbucket', or a userid
+ * @prop {string} displayName
  */
 
 /**
  * @typedef FocusState
- * @property {boolean} configured - Focus config contains valid `user` and
+ * @prop {boolean} configured - Focus config contains valid `user` and
  *           is good to go
- * @property {boolean} active - Focus mode is currently applied
- * @property {FocusedUser} [user] - User to focus on (filter annotations for)
+ * @prop {boolean} active - Focus mode is currently applied
+ * @prop {FocusedUser} [user] - User to focus on (filter annotations for)
+ */
+
+/**
+ * @typedef FocusConfig
+ * @prop {User} user
  */
 
 import { createSelector } from 'reselect';
@@ -87,10 +93,10 @@ function initialSelection(settings) {
  * A successfully-configured focus mode will be set to `active` immediately
  * and may be toggled via `toggleFocusMode`.
  *
- * @param {Object} [focusConfig]
+ * @param {FocusConfig} focusConfig
  * @return {FocusState}
  */
-function setFocus(focusConfig = {}) {
+function setFocus(focusConfig) {
   const focusDefaultState = {
     configured: false,
     active: false,
@@ -151,7 +157,7 @@ function init(settings) {
     highlighted: {},
 
     filterQuery: settings.query || null,
-    focusMode: setFocus(settings.focus),
+    focusMode: setFocus(settings.focus || /** @type FocusConfig */ ({})),
 
     selectedTab: uiConstants.TAB_ANNOTATIONS,
     // Key by which annotations are currently sorted.

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -83,9 +83,9 @@ describe('sidebar/store/modules/selection', () => {
       assert.isTrue(store.hasAppliedFilter());
     });
 
-    it('returns true if in user-focused mode', () => {
+    it('returns true if user-focused mode applied', () => {
       store = createStore([selection], [{ focus: { user: {} } }]);
-      store.setFocusModeFocused(true);
+      store.toggleFocusMode(true);
 
       assert.isTrue(store.hasAppliedFilter());
     });
@@ -218,14 +218,14 @@ describe('sidebar/store/modules/selection', () => {
 
   describe('changeFocusModeUser()', function () {
     it('sets the focused user and enables focus mode', function () {
-      store.setFocusModeFocused(false);
+      store.toggleFocusMode(false);
       store.changeFocusModeUser({
         username: 'testuser',
         displayName: 'Test User',
       });
       assert.equal(store.focusModeUserId(), 'testuser');
       assert.equal(store.focusModeUserPrettyName(), 'Test User');
-      assert.equal(store.focusModeFocused(), true);
+      assert.equal(store.focusModeActive(), true);
       assert.equal(store.focusModeConfigured(), true);
     });
 
@@ -237,17 +237,17 @@ describe('sidebar/store/modules/selection', () => {
     //
     // This is the LMS app's way of asking the client to disable focus mode.
     it('disables focus mode if username is undefined', function () {
-      store.setFocusModeFocused(true);
+      store.toggleFocusMode(true);
       store.changeFocusModeUser({
         username: undefined,
         displayName: undefined,
       });
-      assert.equal(store.focusModeFocused(), false);
+      assert.equal(store.focusModeActive(), false);
       assert.equal(store.focusModeConfigured(), false);
     });
 
     it('clears other applied selections', () => {
-      store.setFocusModeFocused(true);
+      store.toggleFocusMode(true);
       store.setForcedVisible('someAnnotationId');
       store.setFilterQuery('somequery');
       store.changeFocusModeUser({
@@ -260,16 +260,17 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('setFocusModeFocused()', function () {
-    it('sets the focus mode to focused', function () {
-      store.setFocusModeFocused(true);
-      assert.equal(getSelectionState().focusMode.focused, true);
+  describe('toggleFocusMode', function () {
+    it('toggles the current active state if called without arguments', function () {
+      store.toggleFocusMode(false);
+      store.toggleFocusMode();
+      assert.equal(getSelectionState().focusMode.active, true);
     });
 
-    it('sets the focus mode to not focused', function () {
-      store = createStore([selection], [{ focus: { user: {} } }]);
-      store.setFocusModeFocused(false);
-      assert.equal(getSelectionState().focusMode.focused, false);
+    it('toggles the current active state to designated state', function () {
+      store.toggleFocusMode(true);
+      store.toggleFocusMode(false);
+      assert.equal(getSelectionState().focusMode.active, false);
     });
   });
 
@@ -283,17 +284,17 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('focusModeFocused', function () {
-    it('should return true by default when focus mode is focused', function () {
+  describe('focusModeActive', function () {
+    it('should return true by default when focus mode is active', function () {
       store = createStore([selection], [{ focus: { user: {} } }]);
       assert.equal(getSelectionState().focusMode.configured, true);
-      assert.equal(getSelectionState().focusMode.focused, true);
-      assert.equal(store.focusModeFocused(), true);
+      assert.equal(getSelectionState().focusMode.active, true);
+      assert.equal(store.focusModeActive(), true);
     });
-    it('should return false by default when focus mode is not focused', function () {
+    it('should return false by default when focus mode is not active', function () {
       assert.equal(getSelectionState().focusMode.configured, false);
-      assert.equal(getSelectionState().focusMode.focused, true);
-      assert.equal(store.focusModeFocused(), false);
+      assert.equal(getSelectionState().focusMode.active, true);
+      assert.equal(store.focusModeActive(), false);
     });
   });
 

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -226,7 +226,7 @@ describe('sidebar/store/modules/selection', () => {
       assert.equal(store.focusModeUserId(), 'testuser');
       assert.equal(store.focusModeUserPrettyName(), 'Test User');
       assert.equal(store.focusModeFocused(), true);
-      assert.equal(store.focusModeEnabled(), true);
+      assert.equal(store.focusModeConfigured(), true);
     });
 
     // When the LMS app wants the client to disable focus mode it sends a
@@ -243,7 +243,7 @@ describe('sidebar/store/modules/selection', () => {
         displayName: undefined,
       });
       assert.equal(store.focusModeFocused(), false);
-      assert.equal(store.focusModeEnabled(), false);
+      assert.equal(store.focusModeConfigured(), false);
     });
 
     it('clears other applied selections', () => {
@@ -261,51 +261,51 @@ describe('sidebar/store/modules/selection', () => {
   });
 
   describe('setFocusModeFocused()', function () {
-    it('sets the focus mode to enabled', function () {
+    it('sets the focus mode to focused', function () {
       store.setFocusModeFocused(true);
       assert.equal(getSelectionState().focusMode.focused, true);
     });
 
-    it('sets the focus mode to not enabled', function () {
+    it('sets the focus mode to not focused', function () {
       store = createStore([selection], [{ focus: { user: {} } }]);
       store.setFocusModeFocused(false);
       assert.equal(getSelectionState().focusMode.focused, false);
     });
   });
 
-  describe('focusModeEnabled()', function () {
+  describe('focusModeConfigured', function () {
     it('should be true when the focus setting is present', function () {
       store = createStore([selection], [{ focus: { user: {} } }]);
-      assert.equal(store.focusModeEnabled(), true);
+      assert.equal(store.focusModeConfigured(), true);
     });
     it('should be false when the focus setting is not present', function () {
-      assert.equal(store.focusModeEnabled(), false);
+      assert.equal(store.focusModeConfigured(), false);
     });
   });
 
-  describe('focusModeFocused()', function () {
-    it('should return true by default when focus mode is enabled', function () {
+  describe('focusModeFocused', function () {
+    it('should return true by default when focus mode is focused', function () {
       store = createStore([selection], [{ focus: { user: {} } }]);
-      assert.equal(getSelectionState().focusMode.enabled, true);
+      assert.equal(getSelectionState().focusMode.configured, true);
       assert.equal(getSelectionState().focusMode.focused, true);
       assert.equal(store.focusModeFocused(), true);
     });
-    it('should return false by default when focus mode is not enabled', function () {
-      assert.equal(getSelectionState().focusMode.enabled, false);
+    it('should return false by default when focus mode is not focused', function () {
+      assert.equal(getSelectionState().focusMode.configured, false);
       assert.equal(getSelectionState().focusMode.focused, true);
       assert.equal(store.focusModeFocused(), false);
     });
   });
 
   describe('focusModeHasUser()', () => {
-    it('should return `true` if focus enabled and valid `user` object present', () => {
+    it('should return `true` if focus configured and valid `user` object present', () => {
       store = createStore(
         [selection],
         [{ focus: { user: { userid: 'acct:userid@authority' } } }]
       );
       assert.isTrue(store.focusModeHasUser());
     });
-    it('should return `false` if focus enabled but `user` object invalid', () => {
+    it('should return `false` if focus configured but `user` object invalid', () => {
       store = createStore(
         [selection],
         [{ focus: { user: { displayName: 'FakeDisplayName' } } }] // `userid` is required
@@ -319,7 +319,7 @@ describe('sidebar/store/modules/selection', () => {
   });
 
   describe('focusModeUserPrettyName()', function () {
-    it('returns false by default when focus mode is not enabled', function () {
+    it('returns false by default when focus mode is not configured', function () {
       store = createStore(
         [selection],
         [{ focus: { user: { displayName: 'FakeDisplayName' } } }]


### PR DESCRIPTION
This PR should be the last significant refactor PR for the `selection` store module.

This PR reduces the API for user-focus related selectors and actions in the `selection` module. Copying one of the commit messages for some clarity:

```
Refactor the way that focus-mode configuration is represented
in state and whittle down the API (selectors and actions) a little
for clarity.

Reduce the object depth for the focus-mode state. Use a single
function to configure focus mode. Concede that user-focus is the
only focus mode for now, and as such valid focus-mode configuration
must contain a (valid) user object.

Note: There is still some lingering inconsistency in the user
identifiers provided by the LMS app. Canvas speedgrader uses app
settings to configure focus mode (`js-config` object) and sets
the `username` property of the `user` object to a username-
formatted value (i.e. a username, no authority indicated). Non-
Canvas graders do not configure focus mode via the settings,
but instead dispatch RPC messages. These pass a `username`
property whose value is formatted like a userId
(`acct:<username>@authority>`) but it still provided via
the `username` property.

AFAIK, nobody/no service sends a `userid` property in the
focus-mode user object, but we document that we do support
it so I've left it extant until we figure this out.
```


This PR should improve the stability and reduce the complexity of user-focus mode.