### PR TITLE
Fix small UX nit: don't display "only me" icon when editing

### DIFF
--- a/src/sidebar/components/annotation-header.js
+++ b/src/sidebar/components/annotation-header.js
@@ -49,7 +49,7 @@ export default function AnnotationHeader({
   return (
     <header className="annotation-header">
       <div className="annotation-header__row">
-        {annotationIsPrivate && (
+        {annotationIsPrivate && !isEditing && (
           <SvgIcon
             className="annotation-header__icon"
             name="lock"

--- a/src/sidebar/components/test/annotation-header-test.js
+++ b/src/sidebar/components/test/annotation-header-test.js
@@ -61,6 +61,15 @@ describe('AnnotationHeader', () => {
 
       assert.isTrue(wrapper.find('SvgIcon').filter({ name: 'lock' }).exists());
     });
+
+    it('should not render an "Only Me" icon if the annotation is being edited', () => {
+      fakeIsPrivate.returns(true);
+
+      const wrapper = createAnnotationHeader({ isEditing: true });
+
+      assert.isFalse(wrapper.find('SvgIcon').filter({ name: 'lock' }).exists());
+    });
+
     it('should not render an "Only Me" icon if the annotation is not private', () => {
       fakeIsPrivate.returns(false);
 


### PR DESCRIPTION
Do not render the only-me icon while an annotation is being edited, as
the user can switch privacy settings in the editing mode, and those
changes could be at odds with "only me."

Before (watch the icon in the annotation header):

![only-me-before](https://user-images.githubusercontent.com/439947/87792388-d1518000-c811-11ea-802a-60ca416c8f20.gif)

After:

![only-me-after](https://user-images.githubusercontent.com/439947/87792397-d4e50700-c811-11ea-8b84-0151fdc31775.gif)
