### PR TITLE
Support embedding Flipgrid videos in annotations

### DIFF
--- a/src/sidebar/media-embedder.js
+++ b/src/sidebar/media-embedder.js
@@ -2,8 +2,9 @@ import * as queryString from 'query-string';
 
 /**
  * Return an HTML5 audio player with the given src URL.
+ *
+ * @param {string} src
  */
-
 function audioElement(src) {
   const html5audio = document.createElement('audio');
   html5audio.controls = true;
@@ -93,6 +94,7 @@ function parseTimeString(timeValue) {
  * See https://developers.google.com/youtube/player_parameters for
  * all parameter possibilities.
  *
+ * @param {HTMLAnchorElement} link
  * @returns {string} formatted filtered URL query string, e.g. '?start=90'
  * @example
  * // returns '?end=10&start=5'
@@ -100,6 +102,8 @@ function parseTimeString(timeValue) {
  * // - `t` is translated to `start`
  * // - `baz` is not allowed param
  * // - param keys are sorted
+ *
+ * @param {HTMLAnchorElement} link
  */
 function youTubeQueryParams(link) {
   let query;
@@ -132,6 +136,9 @@ function youTubeQueryParams(link) {
 }
 /**
  * Return a YouTube embed (<iframe>) DOM element for the given video ID.
+ *
+ * @param {string} id
+ * @param {HTMLAnchorElement} link
  */
 function youTubeEmbed(id, link) {
   const query = youTubeQueryParams(link);
@@ -149,6 +156,7 @@ function vimeoEmbed(id) {
  * Each function either returns `undefined` if it can't generate an embed for
  * the link, or a DOM element if it can.
  *
+ * @type {Array<(link: HTMLAnchorElement) => HTMLElement|null>}
  */
 const embedGenerators = [
   // Matches URLs like https://www.youtube.com/watch?v=rw6oWkCojpw
@@ -293,6 +301,8 @@ const embedGenerators = [
  *
  * Otherwise return undefined.
  *
+ * @param {HTMLAnchorElement} link
+ * @return {HTMLElement|null}
  */
 function embedForLink(link) {
   let embed;
@@ -328,6 +338,7 @@ function embedForLink(link) {
  *
  * If the link is not a link to an embeddable media it will be left untouched.
  *
+ * @param {HTMLAnchorElement} link
  * @return {HTMLElement|null}
  */
 function replaceLinkWithEmbed(link) {
@@ -342,7 +353,7 @@ function replaceLinkWithEmbed(link) {
   }
   const embed = embedForLink(link);
   if (embed) {
-    link.parentElement.replaceChild(embed, link);
+    /** @type {Element} */ (link.parentElement).replaceChild(embed, link);
   }
   return embed;
 }

--- a/src/sidebar/test/media-embedder-test.js
+++ b/src/sidebar/test/media-embedder-test.js
@@ -283,6 +283,22 @@ describe('media-embedder', function () {
     });
   });
 
+  it('replaces Flipgrid links with iframes', () => {
+    [
+      ['https://flipgrid.com/s/abc123', 'abc123'],
+      ['https://flipgrid.com/s/def456?foo', 'def456'],
+    ].forEach(([url, id]) => {
+      const element = domElement('<a href="' + url + '">' + url + '</a>');
+
+      mediaEmbedder.replaceLinksWithEmbeds(element);
+
+      assert.equal(
+        embedUrl(element),
+        'https://flipgrid.com/s/' + id + '?embed=true'
+      );
+    });
+  });
+
   it('replaces internet archive links with iframes', function () {
     const urls = [
       // Video details page.


### PR DESCRIPTION
I saw Katelyn filed https://github.com/hypothesis/product-backlog/issues/1125 and I thought it looked fun thing to have and fairly easy to do.

If you paste the Flipgrid video link from that issue (https://flipgrid.com/s/030475b8ceff) into an annotation, it will be turned into an embedded video:

<img width="486" alt="Screenshot 2020-07-22 at 12 24 31" src="https://user-images.githubusercontent.com/2458/88170895-570c6b80-cc16-11ea-9f2f-94afe61c89a6.png">

There is a known issue where the video is rather small and doesn't actually fill the iframe:

<img width="499" alt="Screenshot 2020-07-22 at 12 26 28" src="https://user-images.githubusercontent.com/2458/88171075-a2267e80-cc16-11ea-9d6e-f31eabffa97d.png">

There appears to be an annoying quirk where the video won't fill the _width_ of the iframe unless the _height_ is much taller than required. Video iframes are currently 208px high (I'm not sure where that number came from) but it needs to be 300px or so to make the video fill the frame's width.

On a technical note, I took the opportunity to improve JSDoc annotations in `media-embedder.js` and generalise the code that generates video embeds from URLs containing a video ID in the path.