### PR TITLE
Add individual store types

### DIFF
--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -53,10 +53,37 @@ import viewer from './modules/viewer';
  *
  * // Custom stores
  * @typedef {import("./modules/activity").ActivityStore} ActivityStore
+ * @typedef {import("./modules/annotations").AnnotationsStore} AnnotationsStore
+ * @typedef {import("./modules/defaults").DefaultsStore} DefaultsStore
+ * @typedef {import("./modules/direct-linked").DirectLinkedStore} DirectLinkedStore
+ * @typedef {import("./modules/drafts").DraftsStore} DraftsStore
+ * @typedef {import("./modules/frames").FramesStore} FramesStore
+ * @typedef {import("./modules/groups").GroupsStore} GroupsStore
+ * @typedef {import("./modules/links").LinksStore} LinksStore
+ * @typedef {import("./modules/real-time-updates").RealTimeUpdatesStore} RealTimeUpdatesStore
+ * @typedef {import("./modules/selection").SelectionStore} SelectionStore
+ * @typedef {import("./modules/session").SessionStore} SessionStore
+ * @typedef {import("./modules/sidebar-panels").SidebarPanelsStore} SidebarPanelsStore
+ * @typedef {import("./modules/toast-messages").ToastMessagesStore} ToastMessagesStore
+ * @typedef {import("./modules/viewer").ViewerStore} ViewerStore
  * // TODO: add more stores
  *
  * // Combine all stores
- * @typedef {ReduxStore & ActivityStore} SidebarStore
+ * @typedef {ReduxStore &
+ *  ActivityStore &
+ *  AnnotationsStore &
+ *  DefaultsStore &
+ *  DirectLinkedStore &
+ *  DraftsStore &
+ *  FramesStore &
+ *  GroupsStore &
+ *  LinksStore &
+ *  RealTimeUpdatesStore &
+ *  SelectionStore &
+ *  SessionStore &
+ *  SidebarPanelsStore &
+ *  ToastMessagesStore &
+ *  ViewerStore} SidebarStore
  */
 
 /**

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -3,9 +3,7 @@
  * sidebar.
  */
 
-/**
- * @typedef {import('../../../types/api').Annotation} Annotation
- */
+/** @typedef {import('../../../types/api').Annotation} Annotation */
 
 /**
  * @typedef AnnotationStub
@@ -544,6 +542,35 @@ function savedAnnotations(state) {
     return !metadata.isNew(ann);
   });
 }
+
+/**
+ * @typedef AnnotationsStore
+ *
+ * // Actions
+ * @prop {typeof addAnnotations} addAnnotations
+ * @prop {typeof clearAnnotations} clearAnnotations
+ * @prop {typeof focusAnnotations} focusAnnotations
+ * @prop {typeof hideAnnotation} hideAnnotation
+ * @prop {typeof removeAnnotations} removeAnnotations
+ * @prop {typeof unhideAnnotation} unhideAnnotation
+ * @prop {typeof updateAnchorStatus} updateAnchorStatus
+ * @prop {typeof updateFlagStatus} updateFlagStatus
+ 
+ *
+ * // Selectors
+ * @prop {() => number} annotationCount
+ * @prop {(id: string) => boolean} annotationExists
+ * @prop {(id: string) => Annotation} findAnnotationByID
+ * @prop {(tags: string[]) => string[]} findIDsForTags
+ * @prop {() => string[]} focusedAnnotations
+ * @prop {() => string[]} highlightedAnnotations
+ * @prop {() => boolean} isWaitingToAnchorAnnotations
+ * @prop {() => Annotation[]} newAnnotations
+ * @prop {() => Annotation[]} newHighlights
+ * @prop {() => number} noteCount
+ * @prop {() => number} orphanCount
+ * @prop {() => Annotation[]} savedAnnotations
+ */
 
 export default {
   init: init,

--- a/src/sidebar/store/modules/defaults.js
+++ b/src/sidebar/store/modules/defaults.js
@@ -44,7 +44,7 @@ function setDefault(defaultKey, value) {
 /**
  * Retrieve the state's current value for `defaultKey`.
  *
- * @return {*} - The current value for `defaultKey` or `undefined` if it is not
+ * @return {string|null} - The current value for `defaultKey` or `undefined` if it is not
  *               present
  */
 function getDefault(state, defaultKey) {
@@ -54,6 +54,17 @@ function getDefault(state, defaultKey) {
 function getDefaults(state) {
   return state;
 }
+
+/**
+ * @typedef DefaultsStore
+ *
+ * // Actions
+ * @prop {typeof setDefault} setDefault
+ *
+ * // Selectors
+ * @prop {(key: string) => string|null} getDefault
+ * @prop {() => Object.<string,string|null>} getDefaults
+ */
 
 export default {
   init,

--- a/src/sidebar/store/modules/direct-linked.js
+++ b/src/sidebar/store/modules/direct-linked.js
@@ -29,7 +29,7 @@ function init(settings) {
     directLinkedAnnotationId: settings.annotations || null,
 
     /**
-     * Indicates that an error occured in retrieving/showing the direct linked group.
+     * Indicates that an error occurred in retrieving/showing the direct linked group.
      * This could be because:
      * - the group does not exist
      * - the user does not have permission
@@ -139,6 +139,22 @@ function directLinkedGroupId(state) {
 function directLinkedGroupFetchFailed(state) {
   return state.directLinkedGroupFetchFailed;
 }
+
+/**
+ * @typedef DirectLinkedStore
+ *
+ * // Actions
+ * @prop {typeof setDirectLinkedGroupFetchFailed} setDirectLinkedGroupFetchFailed
+ * @prop {typeof setDirectLinkedGroupId} setDirectLinkedGroupId
+ * @prop {typeof setDirectLinkedAnnotationId} setDirectLinkedAnnotationId
+ * @prop {typeof clearDirectLinkedGroupFetchFailed} clearDirectLinkedGroupFetchFailed
+ * @prop {typeof clearDirectLinkedIds} clearDirectLinkedIds
+ *
+ * // Selectors
+ * @prop {() => string|null} directLinkedAnnotationId
+ * @prop {() => boolean} directLinkedGroupFetchFailed
+ * @prop {() => string|null} directLinkedGroupId
+ */
 
 export default {
   init,

--- a/src/sidebar/store/modules/drafts.js
+++ b/src/sidebar/store/modules/drafts.js
@@ -3,6 +3,8 @@ import { createSelector } from 'reselect';
 import * as metadata from '../../util/annotation-metadata';
 import * as util from '../util';
 
+/** @typedef {import('../../../types/api').Annotation} Annotation */
+
 /**
  * The drafts store provides temporary storage for unsaved edits to new or
  * existing annotations.
@@ -178,12 +180,28 @@ function getDraftIfNotEmpty(state, annotation) {
 /**
  * Returns a list of draft annotations which have no id.
  *
- * @return {Object[]}
+ * @return {Draft[]}
  */
 const unsavedAnnotations = createSelector(
   state => state,
   drafts => drafts.filter(d => !d.annotation.id).map(d => d.annotation)
 );
+
+/**
+ * @typedef DraftsStore
+ *
+ * // Actions
+ * @prop {typeof createDraft} createDraft
+ * @prop {typeof deleteNewAndEmptyDrafts} deleteNewAndEmptyDrafts
+ * @prop {typeof discardAllDrafts} discardAllDrafts
+ * @prop {typeof removeDraft} removeDraft
+ *
+ * // Selectors
+ * @prop {() => number} countDrafts
+ * @prop {(a: Annotation) => Draft|null} getDraft
+ * @prop {(a: Annotation) => Draft|null} getDraftIfNotEmpty
+ * @prop {() => Draft[]} unsavedAnnotations
+ */
 
 export default {
   init,

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -126,15 +126,27 @@ const searchUris = createShallowEqualSelector(
   uris => uris
 );
 
+/**
+ * @typedef FramesStore
+ *
+ * // Actions
+ * @prop {typeof connectFrame} connectFrame
+ * @prop {typeof destroyFrame} destroyFrame
+ * @prop {typeof updateFrameAnnotationFetchStatus} updateFrameAnnotationFetchStatus
+ *
+ * // Selectors
+ * // TODO add rest ...
+ */
+
 export default {
   init: init,
   namespace: 'frames',
   update: update,
 
   actions: {
-    connectFrame: connectFrame,
-    destroyFrame: destroyFrame,
-    updateFrameAnnotationFetchStatus: updateFrameAnnotationFetchStatus,
+    connectFrame,
+    destroyFrame,
+    updateFrameAnnotationFetchStatus,
   },
 
   selectors: {

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -196,6 +196,19 @@ const getCurrentlyViewingGroups = createSelector(
   }
 );
 
+/**
+ * @typedef GroupsStore
+ *
+ * // Actions
+ * @prop {typeof focusGroup} focusGroup
+ * @prop {typeof loadGroups} loadGroups
+ * @prop {typeof clearGroups} clearGroups
+ *
+ * // Selectors
+ * @prop {() => Group[]} allGroups
+ * // TODO: add rest ...
+ */
+
 export default {
   init,
   namespace: 'groups',

--- a/src/sidebar/store/modules/links.js
+++ b/src/sidebar/store/modules/links.js
@@ -1,3 +1,5 @@
+import { actionTypes } from '../util';
+
 /**
  * Reducer for storing a "links" object in the Redux state store.
  *
@@ -12,20 +14,37 @@ function init() {
   return null;
 }
 
+const update = {
+  UPDATE_LINKS(state, action) {
+    return {
+      ...action.newLinks,
+    };
+  },
+};
+
+const actions = actionTypes(update);
+
 /** Return updated links based on the given current state and action object. */
-function updateLinks(state, action) {
-  return { ...action.newLinks };
+function updateLinks(newLinks) {
+  return {
+    type: actions.UPDATE_LINKS,
+    newLinks,
+  };
 }
 
-/** Return an action object for updating the links to the given newLinks. */
-function updateLinksAction(newLinks) {
-  return { type: 'UPDATE_LINKS', newLinks: newLinks };
-}
+/**
+ * @typedef LinksStore
+ *
+ * // Actions
+ * @prop {typeof updateLinks} updateLinks
+ */
 
 export default {
   init: init,
   namespace: 'links',
-  update: { UPDATE_LINKS: updateLinks },
-  actions: { updateLinks: updateLinksAction },
+  update,
+  actions: {
+    updateLinks,
+  },
   selectors: {},
 };

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -140,7 +140,7 @@ function clearPendingUpdates() {
  * Return added or updated annotations received via the WebSocket
  * which have not been applied to the local state.
  *
- * @return {{[id: string]: Annotation}}
+ * @return {Object.<string, Annotation>}
  */
 function pendingUpdates(state) {
   return state.pendingUpdates;
@@ -150,7 +150,7 @@ function pendingUpdates(state) {
  * Return IDs of annotations which have been deleted on the server but not
  * yet removed from the local state.
  *
- * @return {{[id: string]: boolean}}
+ * @return {Object.<string, Annotation>}
  */
 function pendingDeletions(state) {
   return state.pendingDeletions;
@@ -172,6 +172,20 @@ const pendingUpdateCount = createSelector(
 function hasPendingDeletion(state, id) {
   return state.pendingDeletions.hasOwnProperty(id);
 }
+
+/**
+ * @typedef RealTimeUpdatesStore
+ *
+ * // Actions
+ * @prop {typeof receiveRealTimeUpdates} receiveRealTimeUpdates
+ * @prop {typeof clearPendingUpdates} clearPendingUpdates
+ *
+ * // Selectors
+ * @prop {() => boolean} hasPendingDeletion
+ * @prop {() => Object.<string, boolean>} pendingDeletions
+ * @prop {() => Object.<string, Annotation>} pendingUpdates
+ * @prop {() => number} pendingUpdateCount
+ */
 
 export default {
   init,

--- a/src/sidebar/store/modules/route.js
+++ b/src/sidebar/store/modules/route.js
@@ -31,7 +31,7 @@ const actions = actionTypes(update);
  * Change the active route.
  *
  * @param {string} name - Name of the route to activate. See `init` for possible values
- * @param {Object} params - Parameters associated with the route
+ * @param {Object.<string,string>} params - Parameters associated with the route
  */
 function changeRoute(name, params = {}) {
   return {
@@ -55,6 +55,17 @@ function route(state) {
 function routeParams(state) {
   return state.params;
 }
+
+/**
+ * @typedef RouteStore
+ *
+ * // Actions
+ * @prop {typeof changeRoute} changeRoute
+ *
+ * // Selectors
+ * @prop {() => string|null} route
+ * @prop {() => Object.<string,string>} routeParams
+ */
 
 export default {
   init,

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -556,6 +556,26 @@ const threadState = createSelector(
   }
 );
 
+/**
+ * @typedef SelectionStore
+ *
+ * // Actions
+ * @prop {typeof changeFocusModeUser} changeFocusModeUser
+ * @prop {typeof clearSelectedAnnotations} clearSelectedAnnotations
+ * @prop {typeof clearSelection} clearSelection
+ * @prop {typeof selectAnnotations} selectAnnotations
+ * @prop {typeof selectTab} selectTab
+ * @prop {typeof setExpanded} setExpanded
+ * @prop {typeof setFilterQuery} setFilterQuery
+ * @prop {typeof setForcedVisible} setForcedVisible
+ * @prop {typeof setSortKey} setSortKey
+ * @prop {typeof toggleFocusMode} toggleFocusMode
+ * @prop {typeof toggleSelectedAnnotations} toggleSelectedAnnotations
+ *
+ * // Selectors
+ * // TODO: add the rest
+ */
+
 export default {
   init: init,
   namespace: 'selection',

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -1,8 +1,14 @@
 import * as util from '../util';
 
 /**
+ * @typedef {import('../../../types/api').Profile} Profile
+ */
+
+/**
  * A dummy profile returned by the `profile` selector before the real profile
  * is fetched.
+ *
+ * @type Profile
  */
 const initialProfile = {
   /** A map of features that are enabled for the current user. */
@@ -84,6 +90,19 @@ function hasFetchedProfile(state) {
 function profile(state) {
   return state.profile;
 }
+
+/**
+ * @typedef SessionStore
+ *
+ * // Actions
+ * @prop {typeof hasFetchedProfile} hasFetchedProfile
+ *
+ * // Selectors
+ * @prop {() => boolean} hasFetchedProfile
+ * @prop {(feature: string) => boolean} isFeatureEnabled
+ * @prop {() => boolean} isLoggedIn
+ * @prop {() => Profile} profile
+ */
 
 export default {
   init,

--- a/src/sidebar/store/modules/sidebar-panels.js
+++ b/src/sidebar/store/modules/sidebar-panels.js
@@ -90,8 +90,8 @@ function closeSidebarPanel(panelName) {
  * Toggle a sidebar panel from its current state, or set it to the
  * designated `panelState`
  *
- * @param {String} panelName
- * @param {Boolean} panelState - Should the panel be active?
+ * @param {string} panelName
+ * @param {boolean} panelState - Should the panel be active?
  */
 function toggleSidebarPanel(panelName, panelState) {
   return {
@@ -104,12 +104,24 @@ function toggleSidebarPanel(panelName, panelState) {
 /**
  * Is the panel indicated by `panelName` currently active (open)?
  *
- * @param {String} panelName
- * @return {Boolean} - `true` if `panelName` is the currently-active panel
+ * @param {string} panelName
+ * @return {boolean} - `true` if `panelName` is the currently-active panel
  */
 function isSidebarPanelOpen(state, panelName) {
   return state.activePanelName === panelName;
 }
+
+/**
+ * @typedef SidebarPanelsStore
+ *
+ * // Actions
+ * @prop {typeof openSidebarPanel} openSidebarPanel
+ * @prop {typeof closeSidebarPanel} closeSidebarPanel
+ * @prop {typeof toggleSidebarPanel} toggleSidebarPanel
+ *
+ * // Selectors
+ * @prop {(name: string) => boolean} isSidebarPanelOpen
+ */
 
 export default {
   namespace: 'sidebarPanels',

--- a/src/sidebar/store/modules/toast-messages.js
+++ b/src/sidebar/store/modules/toast-messages.js
@@ -1,6 +1,14 @@
 import * as util from '../util';
 
 /**
+ * @typedef ToastMessage
+ * @prop {('error'|'success'|'notice')} type
+ * @prop {string} id
+ * @prop {string} message
+ * @prop {string} moreInfoURL
+ */
+
+/**
  * A store module for managing a collection of toast messages. This module
  * maintains state only; it's up to other layers to handle the management
  * and interactions with these messages.
@@ -40,6 +48,9 @@ const actions = util.actionTypes(update);
 
 /** Actions */
 
+/**
+ * @param {ToastMessage} message
+ */
 function addMessage(message) {
   return { type: actions.ADD_MESSAGE, message };
 }
@@ -56,7 +67,7 @@ function removeMessage(id) {
 /**
  * Update the `message` object (lookup is by `id`).
  *
- * @param {Object} message
+ * @param {ToastMessage} message
  */
 function updateMessage(message) {
   return { type: actions.UPDATE_MESSAGE, message };
@@ -97,6 +108,20 @@ function hasMessage(state, type, text) {
     return message.type === type && message.message === text;
   });
 }
+
+/**
+ * @typedef ToastMessagesStore
+ *
+ * // Actions
+ * @prop {typeof addMessage} addToastMessage
+ * @prop {typeof removeMessage} removeToastMessage
+ * @prop {typeof updateMessage} updateToastMessage
+ *
+ * // Selectors
+ * @prop {(id: string) => (ToastMessage|undefined)} getToastMessage
+ * @prop {() => ToastMessage[]} getToastMessages
+ * @prop {(type: string, text: string) => boolean} hasToastMessage
+ */
 
 export default {
   init,

--- a/src/sidebar/store/modules/viewer.js
+++ b/src/sidebar/store/modules/viewer.js
@@ -53,6 +53,17 @@ function hasSidebarOpened(state) {
   return state.sidebarHasOpened;
 }
 
+/**
+ * @typedef ViewerStore
+ *
+ * // Actions
+ * @prop {typeof setShowHighlights} setShowHighlights
+ * @prop {typeof setSidebarOpened} setSidebarOpened
+ *
+ * // Selectors
+ * @prop {() => boolean} hasSidebarOpened
+ */
+
 export default {
   init: init,
   namespace: 'viewer',

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -83,9 +83,10 @@
  * TODO - Fill out remaining properties
  *
  * @typedef Profile
- * @prop {string} userid
+ * @prop {string|null} userid
  * @prop {Object} preferences
- * @prop {boolean} preferences.show_sidebar_tutorial
+ * @prop {boolean} [preferences.show_sidebar_tutorial]
+ * @prop {Object.<string, boolean>} features
  */
 
 /**


### PR DESCRIPTION
- Add types for each store including most of their selectors and actions.
- Not every selector and action is completed, but this covers most of them and serves as a first step to typing all the selectors / actions