### PR TITLE
Avoid video embeds being cut off in narrow viewports

### DIFF
--- a/src/sidebar/components/markdown-view.js
+++ b/src/sidebar/components/markdown-view.js
@@ -14,10 +14,12 @@ export default function MarkdownView({ markdown = '', textClass = {} }) {
   const html = useMemo(() => (markdown ? renderMarkdown(markdown) : ''), [
     markdown,
   ]);
-  const content = useRef(null);
+  const content = useRef(/** @type {HTMLDivElement|null} */ (null));
 
   useEffect(() => {
-    replaceLinksWithEmbeds(content.current);
+    replaceLinksWithEmbeds(content.current, {
+      className: 'markdown-view__embed',
+    });
   }, [markdown]);
 
   // Use a blank string to indicate that the content language is unknown and may be

--- a/src/sidebar/components/test/markdown-view-test.js
+++ b/src/sidebar/components/test/markdown-view-test.js
@@ -13,10 +13,7 @@ describe('MarkdownView', () => {
   beforeEach(() => {
     fakeRenderMarkdown = markdown => `rendered:${markdown}`;
     fakeMediaEmbedder = {
-      replaceLinksWithEmbeds: el => {
-        // Tag the element as having been processed
-        el.dataset.replacedLinksWithEmbeds = 'yes';
-      },
+      replaceLinksWithEmbeds: sinon.stub(),
     };
 
     $imports.$mock({
@@ -50,7 +47,9 @@ describe('MarkdownView', () => {
   it('replaces links with embeds in rendered output', () => {
     const wrapper = mount(<MarkdownView markdown="**test**" />);
     const rendered = wrapper.find('.markdown-view').getDOMNode();
-    assert.equal(rendered.dataset.replacedLinksWithEmbeds, 'yes');
+    assert.calledWith(fakeMediaEmbedder.replaceLinksWithEmbeds, rendered, {
+      className: 'markdown-view__embed',
+    });
   });
 
   it('applies `textClass` class to container', () => {

--- a/src/sidebar/test/media-embedder-test.js
+++ b/src/sidebar/test/media-embedder-test.js
@@ -17,6 +17,28 @@ describe('media-embedder', function () {
     clock.restore();
   });
 
+  /**
+   * Find all the media embed elements in a container.
+   */
+  function findEmbeds(element) {
+    return [...element.querySelectorAll('iframe,audio')];
+  }
+
+  /**
+   * Return the URL of the single media embed in `element`.
+   */
+  function embedUrl(element) {
+    const embeds = findEmbeds(element);
+    assert.equal(embeds.length, 1);
+    return embeds[0].src;
+  }
+
+  function assertStyle(element, expectedProperties) {
+    Object.entries(expectedProperties).forEach(([prop, value]) => {
+      assert.equal(element.style[prop], value);
+    });
+  }
+
   it('replaces YouTube watch links with iframes', function () {
     const urls = [
       'https://www.youtube.com/watch?v=QCkm0lL-6lc',
@@ -30,10 +52,8 @@ describe('media-embedder', function () {
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
 
-      assert.equal(element.childElementCount, 1);
-      assert.equal(element.children[0].tagName, 'IFRAME', url);
       assert.equal(
-        element.children[0].src,
+        embedUrl(element),
         'https://www.youtube.com/embed/QCkm0lL-6lc'
       );
     });
@@ -50,14 +70,12 @@ describe('media-embedder', function () {
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
 
-      assert.equal(element.childElementCount, 1);
-      assert.equal(element.children[0].tagName, 'IFRAME', url);
-      // queryString's #stringify sorts keys, so resulting query string
-      // will be reliably as follows, regardless of original ordering
-      // Note also `v` param is handled elsewhere and is not "allowed" in
-      // queryString.
       assert.equal(
-        element.children[0].src,
+        embedUrl(element),
+        // queryString's #stringify sorts keys, so resulting query string
+        // will be reliably as follows, regardless of original ordering
+        // Note also `v` param is handled elsewhere and is not "allowed" in
+        // queryString.
         'https://www.youtube.com/embed/QCkm0lL-6lc?end=10&start=5'
       );
     });
@@ -74,10 +92,8 @@ describe('media-embedder', function () {
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
 
-      assert.equal(element.childElementCount, 1);
-      assert.equal(element.children[0].tagName, 'IFRAME', url);
       assert.equal(
-        element.children[0].src,
+        embedUrl(element),
         'https://www.youtube.com/embed/QCkm0lL-6lc?end=10&start=5'
       );
     });
@@ -131,9 +147,7 @@ describe('media-embedder', function () {
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
 
-      assert.equal(element.childElementCount, 1);
-      assert.equal(element.children[0].tagName, 'IFRAME', url[0]);
-      assert.equal(element.children[0].src, url[1]);
+      assert.equal(embedUrl(element), url[1]);
     });
   });
 
@@ -147,12 +161,10 @@ describe('media-embedder', function () {
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
 
-      assert.equal(element.childElementCount, 1);
-      assert.equal(element.children[0].tagName, 'IFRAME');
-      // queryString's #stringify sorts keys, so resulting query string
-      // will be reliably as follows, regardless of original ordering
       assert.equal(
-        element.children[0].src,
+        embedUrl(element),
+        // queryString's #stringify sorts keys, so resulting query string
+        // will be reliably as follows, regardless of original ordering
         'https://www.youtube.com/embed/QCkm0lL-6lc?end=10&start=5'
       );
     });
@@ -168,10 +180,8 @@ describe('media-embedder', function () {
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
 
-      assert.equal(element.childElementCount, 1);
-      assert.equal(element.children[0].tagName, 'IFRAME');
       assert.equal(
-        element.children[0].src,
+        embedUrl(element),
         'https://www.youtube.com/embed/QCkm0lL-6lc'
       );
     });
@@ -187,12 +197,10 @@ describe('media-embedder', function () {
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
 
-      assert.equal(element.childElementCount, 1);
-      assert.equal(element.children[0].tagName, 'IFRAME');
-      // queryString's #stringify sorts keys, so resulting query string
-      // will be reliably as follows, regardless of original ordering
       assert.equal(
-        element.children[0].src,
+        embedUrl(element),
+        // queryString's #stringify sorts keys, so resulting query string
+        // will be reliably as follows, regardless of original ordering
         'https://www.youtube.com/embed/QCkm0lL-6lc?end=10&start=5'
       );
     });
@@ -208,10 +216,8 @@ describe('media-embedder', function () {
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
 
-      assert.equal(element.childElementCount, 1);
-      assert.equal(element.children[0].tagName, 'IFRAME', url);
       assert.equal(
-        element.children[0].src,
+        embedUrl(element),
         'https://www.youtube.com/embed/QCkm0lL-6lc?end=10&start=5'
       );
     });
@@ -227,12 +233,8 @@ describe('media-embedder', function () {
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
 
-      assert.equal(element.childElementCount, 1);
-      assert.equal(element.children[0].tagName, 'IFRAME');
-      // queryString's #stringify sorts keys, so resulting query string
-      // will be reliably as follows, regardless of original ordering
       assert.equal(
-        element.children[0].src,
+        embedUrl(element),
         'https://www.youtube.com/embed/QCkm0lL-6lc?end=10&start=5'
       );
     });
@@ -252,10 +254,8 @@ describe('media-embedder', function () {
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
 
-      assert.equal(element.childElementCount, 1);
-      assert.equal(element.children[0].tagName, 'IFRAME');
       assert.equal(
-        element.children[0].src,
+        embedUrl(element),
         'https://player.vimeo.com/video/149000090'
       );
     });
@@ -276,10 +276,8 @@ describe('media-embedder', function () {
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
 
-      assert.equal(element.childElementCount, 1);
-      assert.equal(element.children[0].tagName, 'IFRAME');
       assert.equal(
-        element.children[0].src,
+        embedUrl(element),
         'https://player.vimeo.com/video/148845534'
       );
     });
@@ -304,9 +302,7 @@ describe('media-embedder', function () {
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
 
-      assert.equal(element.children[0].tagName, 'IFRAME');
-
-      const actual = element.children[0].src;
+      const actual = embedUrl(element);
       const expected =
         url.indexOf('start') !== -1
           ? 'https://archive.org/embed/PATH?start=360&end=420.3'
@@ -406,16 +402,59 @@ describe('media-embedder', function () {
 
     mediaEmbedder.replaceLinksWithEmbeds(element);
 
-    assert.equal(element.childElementCount, 2);
-    assert.equal(element.children[0].tagName, 'IFRAME');
-    assert.equal(
-      element.children[0].src,
-      'https://www.youtube.com/embed/QCkm0lL-6lc'
-    );
-    assert.equal(element.children[1].tagName, 'IFRAME');
-    assert.equal(
-      element.children[1].src,
-      'https://www.youtube.com/embed/abcdefg'
-    );
+    const embeds = findEmbeds(element);
+
+    assert.equal(embeds.length, 2);
+    assert.equal(embeds[0].src, 'https://www.youtube.com/embed/QCkm0lL-6lc');
+    assert.equal(embeds[1].src, 'https://www.youtube.com/embed/abcdefg');
+  });
+
+  it('applies `className` option to video embeds', () => {
+    const url = 'https://www.youtube.com/watch?v=QCkm0lL-6lc';
+    const element = domElement('<a href="' + url + '">' + url + '</a>');
+
+    mediaEmbedder.replaceLinksWithEmbeds(element, {
+      className: 'widget__video',
+    });
+
+    assert.equal(element.childElementCount, 1);
+    assert.equal(element.children[0].className, 'widget__video');
+  });
+
+  it('sets a default width on video embeds if no `className` if provided', () => {
+    const url = 'https://www.youtube.com/watch?v=QCkm0lL-6lc';
+    const element = domElement('<a href="' + url + '">' + url + '</a>');
+
+    mediaEmbedder.replaceLinksWithEmbeds(element);
+
+    assert.equal(element.childElementCount, 1);
+    assert.equal(element.children[0].style.width, '350px');
+  });
+
+  it('wraps video embeds in an aspect-ratio box', () => {
+    const url = 'https://www.youtube.com/watch?v=QCkm0lL-6lc';
+    const element = domElement('<a href="' + url + '">' + url + '</a>');
+
+    mediaEmbedder.replaceLinksWithEmbeds(element);
+
+    assert.equal(element.childElementCount, 1);
+    assert.equal(element.children[0].tagName, 'DIV');
+
+    const aspectRatioBox = element.children[0];
+    assertStyle(aspectRatioBox, {
+      position: 'relative',
+      paddingBottom: '56.25%' /* 9/16 as a percentage */,
+    });
+    assert.equal(aspectRatioBox.childElementCount, 1);
+
+    const embed = aspectRatioBox.children[0];
+    assert.equal(embed.tagName, 'IFRAME');
+    assertStyle(embed, {
+      position: 'absolute',
+      top: '0px',
+      left: '0px',
+      width: '100%',
+      height: '100%',
+    });
   });
 });

--- a/src/styles/sidebar/components/annotation.scss
+++ b/src/styles/sidebar/components/annotation.scss
@@ -32,9 +32,3 @@
     margin-left: auto;
   }
 }
-
-// FIXME move me
-.annotation-media-embed {
-  width: 369px;
-  height: 208px;
-}

--- a/src/styles/sidebar/components/excerpt.scss
+++ b/src/styles/sidebar/components/excerpt.scss
@@ -20,6 +20,7 @@
     // See https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
     // and https://github.com/hypothesis/client/issues/1518.
     display: inline-block;
+    width: 100%;
   }
 
   // inline controls for expanding and collapsing

--- a/src/styles/sidebar/components/markdown-view.scss
+++ b/src/styles/sidebar/components/markdown-view.scss
@@ -29,5 +29,14 @@
 
   &__embed {
     width: 100%;
+
+    // Avoid embeds becoming too large when the annotation card is very wide.
+    // We can't just use `max-width` because the embed height is set using
+    // a CSS hack that sets `height` based on `width`.
+    //
+    // Therefore we cap the `width` based on the viewport size.
+    @media (min-width: 450px) {
+      width: 380px;
+    }
   }
 }

--- a/src/styles/sidebar/components/markdown-view.scss
+++ b/src/styles/sidebar/components/markdown-view.scss
@@ -1,6 +1,8 @@
 @use "../styled-text";
 
 .markdown-view {
+  width: 100%;
+
   @include styled-text.styled-text;
 
   cursor: text;
@@ -23,5 +25,9 @@
   // the annotation-body
   p:last-child {
     margin-bottom: 1px;
+  }
+
+  &__embed {
+    width: 100%;
   }
 }


### PR DESCRIPTION
_This PR addresses a [change request](https://github.com/hypothesis/client/pull/2369#pullrequestreview-453307173) in #2369. The original request was to move a CSS class that was in the wrong place and resolve a question about where a hard-coded pixel value came from. Investigating this led me to overhaul how video embeds are sized._

----

Previously video embeds were given a fixed with of 369px, which is close
to the width available to annotation content at the sidebar's default width
(~380px). On narrower viewports the video would get cut off and in larger
viewports the embed would not take advantage of the available space.

Fix this by setting the width of video embeds to `100%` and using a CSS
hack [1] to set the height of the video such that the embed has a 16:9
aspect ratio, which is what YouTube optimizes for.

 - Set `width: 100%` on `excerpt__content` and `markdown-view` so that
   the annotation content always fills the available width.

 - Add support for specifying a class name for embed containers when
   calling `replaceLinksWithEmbeds` and use that to give embeds rendered
   in `MarkdownView` a `width` of 100%.

 - Change `replaceLinksWithEmbeds` to wrap iframes with an aspect-ratio
   box (see [1]) which causes the iframe's height to be adjusted as the
   width changes to have a 16:9 aspect ratio.

   Adding this container required changes in `media-embedder-test` to
   allow the `<iframe>` to be wrapped in a container element.

[1] https://css-tricks.com/aspect-ratio-boxes/

----

**Before (Narrow viewport):**

<img width="400" alt="Cut off video" src="https://user-images.githubusercontent.com/2458/88283718-e3389480-cce3-11ea-9ca9-68d579d8dfc3.png">

**After (Narrow viewport):**

<img width="400" alt="Resized video 2" src="https://user-images.githubusercontent.com/2458/88283779-05caad80-cce4-11ea-8ad4-a56471bb3d9b.png">

**Before (Wide viewport):**

<img width="400" alt="Not resized - wide" src="https://user-images.githubusercontent.com/2458/88283926-517d5700-cce4-11ea-8147-1a6b5c2cb226.png">

**After (Wide viewport):**

<img width="400" alt="Resized video - wide" src="https://user-images.githubusercontent.com/2458/88283840-285cc680-cce4-11ea-986b-19a74ae14978.png">
