### PR TITLE
POC: Consolidate filter status UX

### DIFF
--- a/src/sidebar/components/filter-status.js
+++ b/src/sidebar/components/filter-status.js
@@ -1,0 +1,291 @@
+import { createElement } from 'preact';
+
+import Button from './Button';
+
+//import useStore from '../store/use-store';
+
+/**
+ *
+ */
+export default function FilterStatus() {
+  const annotationCount = 45;
+  const resultCount = 4;
+  const filterQuery = 'foo';
+  const selectedCount = 3;
+  const forcedCount = 2;
+  const clearSearchText = 'Clear search';
+  const clearFiltersText = 'Reset filters';
+  const clearSelectionText = 'Show all';
+
+  const studentName = 'Harriet Gorman';
+  const showAllText = 'Show all';
+
+  const filterQueryEl = (
+    <span>
+      <span>for</span>{' '}
+      <span className="filter-status__facet--pre">&#39;{filterQuery}&#39;</span>
+    </span>
+  );
+
+  return (
+    <div>
+      <div className="filter-status__header">2. Filtered by query</div>
+      <div className="filter-status">
+        <div className="u-layout-row--align-center">
+          <div className="filter-status__text">
+            Showing{' '}
+            <span className="filter-status__facet">{resultCount} results</span>{' '}
+            {filterQueryEl}
+          </div>
+          <div>
+            <Button
+              buttonText={clearSearchText}
+              className="button--primary"
+              onClick={() => alert('foo')}
+              icon="cancel"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="filter-status__header">
+        2a. Filtered by query, no results
+      </div>
+      <div className="filter-status">
+        <div className="u-layout-row--align-center">
+          <div className="filter-status__text">
+            <span className="filter-status__facet">No results</span>{' '}
+            {filterQueryEl}
+          </div>
+          <div>
+            <Button
+              buttonText={clearSearchText}
+              className="button--primary"
+              onClick={() => alert('foo')}
+              icon="cancel"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="filter-status__header">
+        3. Filtered by query, force-expanded threads
+      </div>
+      <div className="filter-status">
+        <div className="u-layout-row--align-center">
+          <div className="filter-status__text">
+            Showing{' '}
+            <span className="filter-status__facet">{resultCount} results</span>{' '}
+            {filterQueryEl}{' '}
+            <span className="filter-status__facet--muted">
+              (and {forcedCount} more)
+            </span>
+          </div>
+          <div>
+            <Button
+              buttonText={clearSearchText}
+              className="button--primary"
+              onClick={() => alert('foo')}
+              icon="cancel"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="filter-status__header">4. Annotations selected</div>
+      <div className="filter-status">
+        <div className="u-layout-row--align-center">
+          <div className="filter-status__text">
+            Showing{' '}
+            <span className="filter-status__facet">
+              {selectedCount} annotations
+            </span>
+          </div>
+          <div>
+            <Button
+              buttonText={`${clearSelectionText} (${annotationCount})`}
+              className="button--primary"
+              onClick={() => alert('foo')}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="filter-status__header">5. User-focus active</div>
+      <div className="filter-status">
+        <div className="u-layout-row--align-center">
+          <div className="filter-status__text">
+            Showing{' '}
+            <span className="filter-status__facet">
+              {selectedCount} annotations
+            </span>{' '}
+            by <span className="filter-status__facet">{studentName}</span>
+          </div>
+          <div>
+            <Button
+              buttonText={showAllText}
+              className="button--primary"
+              onClick={() => alert('foo')}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="filter-status__header">
+        5a. User-focus active, no results
+      </div>
+      <div className="filter-status">
+        <div className="u-layout-row--align-center">
+          <div className="filter-status__text">
+            <span className="filter-status__facet">No annotations</span> to show
+            by <span className="filter-status__facet">{studentName}</span>
+          </div>
+          <div>
+            <Button
+              buttonText={showAllText}
+              className="button--primary"
+              onClick={() => alert('foo')}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="filter-status__header">
+        6. User-focus active, filtered by query
+      </div>
+      <div className="filter-status">
+        <div className="u-layout-row--align-center">
+          <div className="filter-status__text">
+            Showing{' '}
+            <span className="filter-status__facet">{resultCount} results</span>{' '}
+            {filterQueryEl} by{' '}
+            <span className="filter-status__facet">{studentName}</span>
+          </div>
+          <div>
+            <Button
+              buttonText={clearSearchText}
+              className="button--primary"
+              onClick={() => alert('foo')}
+              icon="cancel"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="filter-status__header">
+        6a. User-focus active, filtered by query, no results
+      </div>
+      <div className="filter-status">
+        <div className="u-layout-row--align-center">
+          <div className="filter-status__text">
+            <span className="filter-status__facet">No results</span>{' '}
+            {filterQueryEl} by{' '}
+            <span className="filter-status__facet">{studentName}</span>
+          </div>
+          <div>
+            <Button
+              buttonText={clearSearchText}
+              className="button--primary"
+              onClick={() => alert('foo')}
+              icon="cancel"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="filter-status__header">
+        7. User-focus active, filtered by query, force-expanded threads
+      </div>
+      <div className="filter-status">
+        <div className="u-layout-row--align-center">
+          <div className="filter-status__text">
+            Showing{' '}
+            <span className="filter-status__facet">{resultCount} results</span>{' '}
+            {filterQueryEl} by{' '}
+            <span className="filter-status__facet">{studentName}</span>{' '}
+            <span className="filter-status__facet--muted">
+              (and {forcedCount} more)
+            </span>
+          </div>
+          <div>
+            <Button
+              buttonText={clearSearchText}
+              className="button--primary"
+              onClick={() => alert('foo')}
+              icon="cancel"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="filter-status__header">
+        8. User-focus active, selected annotations
+      </div>
+      <div className="filter-status">
+        <div className="u-layout-row--align-center">
+          <div className="filter-status__text">
+            Showing{' '}
+            <span className="filter-status__facet">
+              {selectedCount} annotations
+            </span>
+          </div>
+          <div>
+            <Button
+              buttonText={clearSelectionText}
+              className="button--primary"
+              onClick={() => alert('foo')}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="filter-status__header">
+        9. User-focus active, force-expanded threads
+      </div>
+      <div className="filter-status">
+        <div className="u-layout-row--align-center">
+          <div className="filter-status__text">
+            Showing{' '}
+            <span className="filter-status__facet">
+              {resultCount} annotations
+            </span>{' '}
+            by <span className="filter-status__facet">{studentName}</span>{' '}
+            <span className="filter-status__facet--muted">
+              (and {forcedCount} more)
+            </span>
+          </div>
+          <div>
+            <Button
+              buttonText={clearFiltersText}
+              className="button--primary"
+              onClick={() => alert('foo')}
+              icon="cancel"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="filter-status__header">10. User-focus inactive</div>
+      <div className="filter-status">
+        <div className="u-layout-row--align-center">
+          <div className="filter-status__text">
+            Showing{' '}
+            <span className="filter-status__facet">
+              {selectedCount} annotations
+            </span>{' '}
+            by <span className="filter-status__facet">all</span>
+          </div>
+          <div>
+            <Button
+              buttonText={`Show ${studentName} only`}
+              className="button--primary"
+              onClick={() => alert('foo')}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+FilterStatus.propTypes = {};

--- a/src/sidebar/components/filter-status.js
+++ b/src/sidebar/components/filter-status.js
@@ -1,287 +1,149 @@
 import { createElement } from 'preact';
 
+import { countVisible } from '../util/thread';
+
 import Button from './Button';
 
-//import useStore from '../store/use-store';
+import useRootThread from './hooks/use-root-thread';
+import useStore from '../store/use-store';
 
 /**
+ * Render information about the currently-applied filters and allow the
+ * user to clear filters or toggle user-focus mode on and off
  *
+ * When any filtering is applied, we are in one of 3 mutually-exclusive filtering
+ * "modes". In any mode, we display descriptive text about what the user
+ * is looking at, and present one button to take action on the current filtering
+ * state:
+ * - selection: One or more annotations have been selected in the document by
+ *   the user, or we're looking at a direct-linked annotation. Button clears
+ *   the selection. This mode supersedes all others (i.e. other filters ignored).
+ * - query: There is a user-entered filter query. It can "stack" with user-focus.
+ *    Button clears the selection (query, etc.), but will leave user-focus mode
+ *    intact.
+ * - focus: Neither of the above two modes apply and user-focus mode is
+ *   configured (it may or may not be active). Button toggles activation of
+ *   user-focus mode.
+ *
+ * Descriptive text about the filter status and annotations follows the
+ * pattern:
+ *
+ *   [Showing] (<resultCount>|No) (annotation[s]|result[s]) [for <filterQuery>]
+ *   [by <focusedUser>] [\(and <forcedCount> more\)]`
  */
 export default function FilterStatus() {
-  const annotationCount = 45;
-  const resultCount = 4;
-  const filterQuery = 'foo';
-  const selectedCount = 3;
-  const forcedCount = 2;
-  const clearSearchText = 'Clear search';
-  const clearFiltersText = 'Reset filters';
-  const clearSelectionText = 'Show all';
+  const rootThread = useRootThread();
 
-  const studentName = 'Harriet Gorman';
-  const showAllText = 'Show all';
+  const filterState = useStore(store => store.filterState());
 
-  const filterQueryEl = (
-    <span>
-      <span>for</span>{' '}
-      <span className="filter-status__facet--pre">&#39;{filterQuery}&#39;</span>
-    </span>
-  );
+  // The total count of all of the annotations in the store—may differ from
+  // the number of annotations in the thread and the number of visible annotations
+  const totalCount = useStore(store => store.annotationCount());
+
+  // Actions
+  const clearSelection = useStore(store => store.clearSelection);
+  const toggleFocusMode = useStore(store => store.toggleFocusMode);
+
+  const filterMode = (state => {
+    if (state.selectedCount > 0) {
+      return 'selection';
+    } else if (state.filterQuery) {
+      return 'query';
+    } else if (state.focusConfigured) {
+      return 'focus';
+    }
+    return null;
+  })(filterState);
+
+  if (!filterMode) {
+    // Nothing to do here
+    return null;
+  }
+
+  // Some threads in the `visibleCount` may have been "forced visible" by
+  // the user by clicking "Show x more in conversation" — subtract these
+  // forced-visible threads out to get a correct count of actual filter matches.
+  // In 'selection' mode, rely on the count of selected annotations
+  const visibleCount = countVisible(rootThread);
+  const resultCount =
+    filterMode === 'selection'
+      ? filterState.selectedCount
+      : visibleCount - filterState.forcedVisibleCount;
+
+  let buttonText;
+  switch (filterMode) {
+    case 'selection':
+      // In user-focus mode, displayed counts include annotations AND replies,
+      // while `totalCount` only includes top-level annotations, so that count
+      // doesn't make sense in user-focus mode
+      buttonText = filterState.focusConfigured
+        ? 'Show all'
+        : `Show all (${totalCount})`;
+      break;
+    case 'focus':
+      if (!filterState.forcedVisibleCount) {
+        buttonText = filterState.focusActive
+          ? 'Show all'
+          : `Show only ${filterState.focusDisplayName}`;
+      } else {
+        // When user focus is applied and there are some forced-visible threads,
+        // this special case applies. The button will clear force-visible threads
+        // but leave user focus intact
+        buttonText = 'Reset filters';
+      }
+      break;
+    case 'query':
+    default:
+      buttonText = 'Clear search';
+      break;
+  }
+
+  const buttonProps = {
+    buttonText,
+    onClick: () => clearSelection(),
+    icon: filterMode !== 'focus' ? 'cancel' : null,
+  };
+
+  // In most cases, the action button will clear the current (filter) selection,
+  // but when in 'focus' mode alone, it will toggle activation of the focus
+  if (filterMode === 'focus' && !filterState.forcedVisibleCount) {
+    buttonProps.onClick = () => toggleFocusMode();
+  }
 
   return (
-    <div>
-      <div className="filter-status__header">2. Filtered by query</div>
-      <div className="filter-status">
-        <div className="u-layout-row--align-center">
-          <div className="filter-status__text">
-            Showing{' '}
-            <span className="filter-status__facet">{resultCount} results</span>{' '}
-            {filterQueryEl}
-          </div>
-          <div>
-            <Button
-              buttonText={clearSearchText}
-              className="button--primary"
-              onClick={() => alert('foo')}
-              icon="cancel"
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="filter-status__header">
-        2a. Filtered by query, no results
-      </div>
-      <div className="filter-status">
-        <div className="u-layout-row--align-center">
-          <div className="filter-status__text">
-            <span className="filter-status__facet">No results</span>{' '}
-            {filterQueryEl}
-          </div>
-          <div>
-            <Button
-              buttonText={clearSearchText}
-              className="button--primary"
-              onClick={() => alert('foo')}
-              icon="cancel"
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="filter-status__header">
-        3. Filtered by query, force-expanded threads
-      </div>
-      <div className="filter-status">
-        <div className="u-layout-row--align-center">
-          <div className="filter-status__text">
-            Showing{' '}
-            <span className="filter-status__facet">{resultCount} results</span>{' '}
-            {filterQueryEl}{' '}
-            <span className="filter-status__facet--muted">
-              (and {forcedCount} more)
+    <div className="filter-status">
+      <div className="u-layout-row--align-center">
+        <div className="filter-status__text">
+          {visibleCount > 0 && <span>Showing</span>}{' '}
+          <span className="filter-facet">
+            {resultCount > 0 ? resultCount : 'No'}{' '}
+            {filterMode === 'query' ? 'result' : 'annotation'}
+            {resultCount !== 1 ? 's' : '' /* pluralize */}
+          </span>{' '}
+          {filterMode === 'query' && (
+            <span>
+              for{' '}
+              <span className="filter-facet--pre">
+                &#39;{filterState.filterQuery}&#39;
+              </span>
             </span>
-          </div>
-          <div>
-            <Button
-              buttonText={clearSearchText}
-              className="button--primary"
-              onClick={() => alert('foo')}
-              icon="cancel"
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="filter-status__header">4. Annotations selected</div>
-      <div className="filter-status">
-        <div className="u-layout-row--align-center">
-          <div className="filter-status__text">
-            Showing{' '}
-            <span className="filter-status__facet">
-              {selectedCount} annotations
+          )}{' '}
+          {filterMode !== 'selection' && filterState.focusActive && (
+            <span>
+              by{' '}
+              <span className="filter-facet">
+                {filterState.focusDisplayName}
+              </span>
             </span>
-          </div>
-          <div>
-            <Button
-              buttonText={`${clearSelectionText} (${annotationCount})`}
-              className="button--primary"
-              onClick={() => alert('foo')}
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="filter-status__header">5. User-focus active</div>
-      <div className="filter-status">
-        <div className="u-layout-row--align-center">
-          <div className="filter-status__text">
-            Showing{' '}
-            <span className="filter-status__facet">
-              {selectedCount} annotations
-            </span>{' '}
-            by <span className="filter-status__facet">{studentName}</span>
-          </div>
-          <div>
-            <Button
-              buttonText={showAllText}
-              className="button--primary"
-              onClick={() => alert('foo')}
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="filter-status__header">
-        5a. User-focus active, no results
-      </div>
-      <div className="filter-status">
-        <div className="u-layout-row--align-center">
-          <div className="filter-status__text">
-            <span className="filter-status__facet">No annotations</span> to show
-            by <span className="filter-status__facet">{studentName}</span>
-          </div>
-          <div>
-            <Button
-              buttonText={showAllText}
-              className="button--primary"
-              onClick={() => alert('foo')}
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="filter-status__header">
-        6. User-focus active, filtered by query
-      </div>
-      <div className="filter-status">
-        <div className="u-layout-row--align-center">
-          <div className="filter-status__text">
-            Showing{' '}
-            <span className="filter-status__facet">{resultCount} results</span>{' '}
-            {filterQueryEl} by{' '}
-            <span className="filter-status__facet">{studentName}</span>
-          </div>
-          <div>
-            <Button
-              buttonText={clearSearchText}
-              className="button--primary"
-              onClick={() => alert('foo')}
-              icon="cancel"
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="filter-status__header">
-        6a. User-focus active, filtered by query, no results
-      </div>
-      <div className="filter-status">
-        <div className="u-layout-row--align-center">
-          <div className="filter-status__text">
-            <span className="filter-status__facet">No results</span>{' '}
-            {filterQueryEl} by{' '}
-            <span className="filter-status__facet">{studentName}</span>
-          </div>
-          <div>
-            <Button
-              buttonText={clearSearchText}
-              className="button--primary"
-              onClick={() => alert('foo')}
-              icon="cancel"
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="filter-status__header">
-        7. User-focus active, filtered by query, force-expanded threads
-      </div>
-      <div className="filter-status">
-        <div className="u-layout-row--align-center">
-          <div className="filter-status__text">
-            Showing{' '}
-            <span className="filter-status__facet">{resultCount} results</span>{' '}
-            {filterQueryEl} by{' '}
-            <span className="filter-status__facet">{studentName}</span>{' '}
-            <span className="filter-status__facet--muted">
-              (and {forcedCount} more)
+          )}{' '}
+          {filterState.forcedVisibleCount > 0 && (
+            <span className="filter-facet--muted">
+              (and {filterState.forcedVisibleCount} more)
             </span>
-          </div>
-          <div>
-            <Button
-              buttonText={clearSearchText}
-              className="button--primary"
-              onClick={() => alert('foo')}
-              icon="cancel"
-            />
-          </div>
+          )}
         </div>
-      </div>
-
-      <div className="filter-status__header">
-        8. User-focus active, selected annotations
-      </div>
-      <div className="filter-status">
-        <div className="u-layout-row--align-center">
-          <div className="filter-status__text">
-            Showing{' '}
-            <span className="filter-status__facet">
-              {selectedCount} annotations
-            </span>
-          </div>
-          <div>
-            <Button
-              buttonText={clearSelectionText}
-              className="button--primary"
-              onClick={() => alert('foo')}
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="filter-status__header">
-        9. User-focus active, force-expanded threads
-      </div>
-      <div className="filter-status">
-        <div className="u-layout-row--align-center">
-          <div className="filter-status__text">
-            Showing{' '}
-            <span className="filter-status__facet">
-              {resultCount} annotations
-            </span>{' '}
-            by <span className="filter-status__facet">{studentName}</span>{' '}
-            <span className="filter-status__facet--muted">
-              (and {forcedCount} more)
-            </span>
-          </div>
-          <div>
-            <Button
-              buttonText={clearFiltersText}
-              className="button--primary"
-              onClick={() => alert('foo')}
-              icon="cancel"
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="filter-status__header">10. User-focus inactive</div>
-      <div className="filter-status">
-        <div className="u-layout-row--align-center">
-          <div className="filter-status__text">
-            Showing{' '}
-            <span className="filter-status__facet">
-              {selectedCount} annotations
-            </span>{' '}
-            by <span className="filter-status__facet">all</span>
-          </div>
-          <div>
-            <Button
-              buttonText={`Show ${studentName} only`}
-              className="button--primary"
-              onClick={() => alert('foo')}
-            />
-          </div>
+        <div>
+          <Button className="button--primary" {...buttonProps} />
         </div>
       </div>
     </div>

--- a/src/sidebar/components/search-input.js
+++ b/src/sidebar/components/search-input.js
@@ -29,7 +29,11 @@ export default function SearchInput({ alwaysExpanded, query, onSearch }) {
 
   const onSubmit = e => {
     e.preventDefault();
-    onSearch(input.current.value);
+    if (input.current.value || prevQuery) {
+      // Don't set an initial empty query, but allow a later empty query to
+      // clear `prevQuery`
+      onSearch(input.current.value);
+    }
   };
 
   // When the active query changes outside of this component, update the input

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -77,8 +77,10 @@ function SidebarContent({
 
   const showTabs = !hasContentError && !hasAppliedFilter;
   const showFilterStatus = features.flagEnabled('client_filter_status');
-  const showFocusModeHeader = isFocusedMode; // && !features.flagEnabled('client_filter_status');
-  const showSearchStatus = !hasContentError; // && !features.flagEnabled('client_filter_status');
+  const showFocusModeHeader =
+    isFocusedMode && !features.flagEnabled('client_filter_status');
+  const showSearchStatus =
+    !hasContentError && !features.flagEnabled('client_filter_status');
 
   // Show a CTA to log in if successfully viewing a direct-linked annotation
   // and not logged in
@@ -129,6 +131,7 @@ function SidebarContent({
     <div>
       <h2 className="u-screen-reader-only">Annotations</h2>
       {showFocusModeHeader && <FocusedModeHeader />}
+      {showFilterStatus && <FilterStatus />}
       <LoginPromptPanel onLogin={onLogin} onSignUp={onSignUp} />
       {hasDirectLinkedAnnotationError && (
         <SidebarContentError
@@ -142,7 +145,6 @@ function SidebarContent({
       )}
       {showTabs && <SelectionTabs isLoading={isLoading} />}
       {showSearchStatus && <SearchStatusBar />}
-      {showFilterStatus && <FilterStatus />}
       <ThreadList thread={rootThread} />
       {showLoggedOutMessage && <LoggedOutMessage onLogin={onLogin} />}
     </div>

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -7,6 +7,7 @@ import { withServices } from '../util/service-context';
 import useStore from '../store/use-store';
 import { tabForAnnotation } from '../util/tabs';
 
+import FilterStatus from './filter-status';
 import FocusedModeHeader from './focused-mode-header';
 import LoggedOutMessage from './logged-out-message';
 import LoginPromptPanel from './login-prompt-panel';
@@ -19,6 +20,7 @@ import ThreadList from './thread-list';
  * Render the sidebar and its components
  */
 function SidebarContent({
+  features,
   frameSync,
   onLogin,
   onSignUp,
@@ -74,6 +76,9 @@ function SidebarContent({
     hasDirectLinkedAnnotationError || hasDirectLinkedGroupError;
 
   const showTabs = !hasContentError && !hasAppliedFilter;
+  const showFilterStatus = features.flagEnabled('client_filter_status');
+  const showFocusModeHeader = isFocusedMode; // && !features.flagEnabled('client_filter_status');
+  const showSearchStatus = !hasContentError; // && !features.flagEnabled('client_filter_status');
 
   // Show a CTA to log in if successfully viewing a direct-linked annotation
   // and not logged in
@@ -123,7 +128,7 @@ function SidebarContent({
   return (
     <div>
       <h2 className="u-screen-reader-only">Annotations</h2>
-      {isFocusedMode && <FocusedModeHeader />}
+      {showFocusModeHeader && <FocusedModeHeader />}
       <LoginPromptPanel onLogin={onLogin} onSignUp={onSignUp} />
       {hasDirectLinkedAnnotationError && (
         <SidebarContentError
@@ -136,7 +141,8 @@ function SidebarContent({
         <SidebarContentError errorType="group" onLoginRequest={onLogin} />
       )}
       {showTabs && <SelectionTabs isLoading={isLoading} />}
-      {!hasContentError && <SearchStatusBar />}
+      {showSearchStatus && <SearchStatusBar />}
+      {showFilterStatus && <FilterStatus />}
       <ThreadList thread={rootThread} />
       {showLoggedOutMessage && <LoggedOutMessage onLogin={onLogin} />}
     </div>
@@ -149,12 +155,14 @@ SidebarContent.propTypes = {
   onSignUp: propTypes.func.isRequired,
 
   // Injected
+  features: propTypes.object,
   frameSync: propTypes.object,
   loadAnnotationsService: propTypes.object,
   streamer: propTypes.object,
 };
 
 SidebarContent.injectedProps = [
+  'features',
   'frameSync',
   'loadAnnotationsService',
   'streamer',

--- a/src/sidebar/services/threads.js
+++ b/src/sidebar/services/threads.js
@@ -7,9 +7,13 @@ export default function threadsService(store) {
    */
   function forceVisible(thread) {
     thread.children.forEach(child => {
-      forceVisible(child);
+      if (!child.visible) {
+        forceVisible(child);
+      }
     });
-    store.setForcedVisible(thread.id, true);
+    if (!thread.visible) {
+      store.setForcedVisible(thread.id, true);
+    }
   }
 
   return {

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -163,9 +163,24 @@ const setTab = (newTab, oldTab) => {
   };
 };
 
+/**
+ * Return state object representing a reset selection. This
+ * resets user-set filters (but leaves focus mode intact)
+ *
+ * @return {Object}
+ */
+const resetSelection = () => {
+  return {
+    filterQuery: null,
+    forcedVisible: {},
+    selected: {},
+  };
+};
+
 const update = {
   CHANGE_FOCUS_MODE_USER: function (state, action) {
     return {
+      ...resetSelection(),
       focusMode: setFocus({ user: action.user }),
     };
   },
@@ -175,15 +190,11 @@ const update = {
   },
 
   CLEAR_SELECTION: function () {
-    return {
-      filterQuery: null,
-      forcedVisible: {},
-      selected: {},
-    };
+    return resetSelection();
   },
 
   SELECT_ANNOTATIONS: function (state, action) {
-    return { selected: action.selection };
+    return { ...resetSelection(), selected: action.selection };
   },
 
   SELECT_TAB: function (state, action) {
@@ -197,11 +208,7 @@ const update = {
   },
 
   SET_FILTER_QUERY: function (state, action) {
-    return {
-      filterQuery: action.query,
-      forcedVisible: {},
-      expanded: {},
-    };
+    return { ...resetSelection(), filterQuery: action.query };
   },
 
   SET_FOCUS_MODE: function (state, action) {
@@ -210,6 +217,7 @@ const update = {
         ? action.active
         : !state.focusMode.active;
     return {
+      ...resetSelection(),
       focusMode: {
         ...state.focusMode,
         active,
@@ -287,10 +295,7 @@ const actions = util.actionTypes(update);
  * @param {User} user - The user to focus on
  */
 function changeFocusModeUser(user) {
-  return function (dispatch) {
-    dispatch({ type: actions.CLEAR_SELECTION });
-    dispatch({ type: actions.CHANGE_FOCUS_MODE_USER, user });
-  };
+  return { type: actions.CHANGE_FOCUS_MODE_USER, user };
 }
 
 /** De-select all annotations. */
@@ -311,9 +316,12 @@ function clearSelection() {
  * @param {string[]} ids - Identifiers of annotations to select
  */
 function selectAnnotations(ids) {
-  return {
-    type: actions.SELECT_ANNOTATIONS,
-    selection: toTrueMap(ids),
+  return dispatch => {
+    dispatch({ type: actions.SET_FOCUS_MODE, active: false });
+    dispatch({
+      type: actions.SELECT_ANNOTATIONS,
+      selection: toTrueMap(ids),
+    });
   };
 }
 
@@ -506,10 +514,10 @@ const selectedAnnotations = createSelector(
  */
 const hasAppliedFilter = createSelector(
   filterQuery,
-  focusModeActive,
+  focusModeConfigured,
   hasSelectedAnnotations,
-  (filterQuery, focusModeActive, hasSelectedAnnotations) =>
-    !!filterQuery || focusModeActive || hasSelectedAnnotations
+  (filterQuery, focusModeConfigured, hasSelectedAnnotations) =>
+    !!filterQuery || focusModeConfigured || hasSelectedAnnotations
 );
 
 /**
@@ -525,6 +533,23 @@ function sortKeys(state) {
   }
   return sortKeysForTab;
 }
+
+/**
+ * Summary of applied filters
+ */
+const filterState = createSelector(
+  state => state,
+  selection => {
+    return {
+      filterQuery: filterQuery(selection),
+      focusActive: focusModeActive(selection),
+      focusConfigured: focusModeConfigured(selection),
+      focusDisplayName: focusModeUserPrettyName(selection),
+      forcedVisibleCount: forcedVisibleAnnotations(selection).length,
+      selectedCount: selectedAnnotations(selection).length,
+    };
+  }
+);
 
 /* Selectors that take root state */
 
@@ -598,6 +623,7 @@ export default {
   selectors: {
     expandedMap,
     filterQuery,
+    filterState,
     focusModeActive,
     focusModeConfigured,
     focusModeUserFilter,

--- a/src/styles/mixins/buttons.scss
+++ b/src/styles/mixins/buttons.scss
@@ -73,6 +73,7 @@
 /* A button with displayed text. It may or may not have an icon. */
 @mixin button--labeled {
   @include button;
+  white-space: nowrap; // Keep multi-word button labels from wrapping
   color: var.$grey-mid;
   font-weight: 700;
   background-color: var.$grey-1;

--- a/src/styles/sidebar/components/filter-status.scss
+++ b/src/styles/sidebar/components/filter-status.scss
@@ -1,0 +1,34 @@
+@use "../../mixins/layout";
+@use "../../mixins/molecules";
+@use "../../variables" as var;
+
+.filter-status {
+  @include molecules.card;
+  margin-bottom: 2em;
+  justify-content: space-between;
+
+  &__text {
+    flex-grow: 1;
+    padding-right: var.$layout-space--xsmall;
+  }
+
+  &__facet {
+    white-space: nowrap;
+    font-weight: bold;
+
+    &--muted {
+      color: var.$color-text--light;
+    }
+
+    &--pre {
+      font-weight: normal;
+    }
+  }
+
+  &__header {
+    // Temporary
+    font-size: 16px;
+    font-weight: bold;
+    margin: var.$layout-space 0;
+  }
+}

--- a/src/styles/sidebar/components/filter-status.scss
+++ b/src/styles/sidebar/components/filter-status.scss
@@ -2,27 +2,34 @@
 @use "../../mixins/molecules";
 @use "../../variables" as var;
 
+@mixin facet {
+  white-space: nowrap;
+}
+
+.filter-facet {
+  @include facet;
+  font-weight: bold;
+}
+
+.filter-facet--muted {
+  @include facet;
+  color: var.$color-text--light;
+  font-style: italic;
+}
+
+.filter-facet--pre {
+  @include facet;
+}
+
 .filter-status {
   @include molecules.card;
-  margin-bottom: 2em;
+  margin-bottom: 1em;
+  padding: var.$layout-space--small;
   justify-content: space-between;
 
   &__text {
     flex-grow: 1;
     padding-right: var.$layout-space--xsmall;
-  }
-
-  &__facet {
-    white-space: nowrap;
-    font-weight: bold;
-
-    &--muted {
-      color: var.$color-text--light;
-    }
-
-    &--pre {
-      font-weight: normal;
-    }
   }
 
   &__header {

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -25,6 +25,7 @@
 @use './components/autocomplete-list';
 @use './components/button';
 @use './components/excerpt';
+@use './components/filter-status';
 @use './components/focused-mode-header';
 @use './components/group-list';
 @use './components/group-list-item';

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -40,6 +40,7 @@
     "sidebar/components/annotation-share-info.js",
     "sidebar/components/annotation-viewer-content.js",
     "sidebar/components/annotation.js",
+    "sidebar/components/filter-status.js",
     "sidebar/components/focused-mode-header.js",
     "sidebar/components/group-list-item.js",
     "sidebar/components/group-list-section.js",


### PR DESCRIPTION
This PR consolidates the UX for expressing the status of current filtering into a single new component, `FilterStatus`. It also makes a few behavioral changes to avoid combining selected annotations with other filters.

All of the changes are explained in excruciating detail [in this document](https://docs.google.com/document/d/1I_jT2hVXwWVtMNWqcC1mxQpmckLvu2SD_d2A0Reo0Us/edit#) (requires Hypothesis team access). 

To test, enable the `client_filter_status` feature flag in your local `h`.
To test states 6 - 10 (relevant to user-focus mode), you can edit the `user` config in `dev-server` and restart your local webserver.