### PR TITLE
Consolidate filter status information into a new component, `FilterStatus`

### DIFF
--- a/src/sidebar/components/filter-status.js
+++ b/src/sidebar/components/filter-status.js
@@ -1,0 +1,180 @@
+import { createElement } from 'preact';
+
+import { countVisible } from '../util/thread';
+
+import Button from './button';
+
+import useRootThread from './hooks/use-root-thread';
+import useStore from '../store/use-store';
+
+/**
+ * Render information about the currently-applied filters and allow the
+ * user to clear filters or toggle user-focus mode on and off
+ *
+ * When any filtering is applied, we are in one of 3 mutually-exclusive filtering
+ * "modes". In any mode, we display descriptive text about what the user
+ * is looking at, and present one button to take action on the current filtering
+ * state.
+ *
+ * Descriptive text about the filter status and annotations follows the
+ * pattern:
+ *
+ *   [Showing] (<resultCount>|No) (annotation[s]|result[s]) [for <filterQuery>]
+ *   [by <focusedUser>] [\(and <forcedCount> more\)]`
+ *
+ * Modes are as follows:
+ *
+ * - selection: One of more annotations have been selected in the document by
+ *   the user, or there is a direct-linked annotation active. Other filters
+ *   will be ignored and it supersedes other modes.
+ *    - Text:
+ *      "Showing <selectedCount> annotation[s]"
+ *    - Button:
+ *      "<cancelIcon> Show all [\(<totalCount>\)]"
+ *      Action: clears selection
+ *      (`totalCount` is not displayed if user focus is configured)
+ *
+ * - query: There is a user-entered filter query, and potentially other filters
+ *   (e.g. user-focus).
+ *    - Text:
+ *    "[Showing] (No|<resultCount>) result[s] for '<filterQuery>'
+ *    [by <focusDisplayName>] [\(and <forcedVisibleCount> more\)]"
+ *    - Button:
+ *      "<cancelIcon> Clear search"
+ *      Action: clears selection/filters (leaves user focus state intact)
+ *
+ * - focusOnly: Neither of the above two modes apply and user-focus is
+ *   configured.
+ *   - Text:
+ *     "[Showing] (No|<resultCount>) annotation[s]
+ *     by <focusDisplayName> [\(and <forcedVisibleCount> more\)]"
+ *   - Button:
+ *     "Show only <focusDisplayName>" (when user-focus mode not active)
+ *     "Show all" (when user-focus mode active)
+ *     "Reset filters" (When user-focus mode is active
+ *                      and threads are force-expanded)
+ *     Action: Toggle user focus
+ *
+ */
+export default function FilterStatus() {
+  const rootThread = useRootThread();
+
+  const filterState = useStore(store => store.filterState());
+
+  // The total count of all of the annotations in the store—may differ from
+  // the number of annotations in the thread and the number of visible annotations
+  const totalCount = useStore(store => store.annotationCount());
+
+  // Actions
+  const clearSelection = useStore(store => store.clearSelection);
+  const toggleFocusMode = useStore(store => store.toggleFocusMode);
+
+  const filterMode = (() => {
+    if (filterState.selectedCount > 0) {
+      return 'selection';
+    } else if (filterState.filterQuery) {
+      return 'query';
+    } else if (filterState.focusConfigured) {
+      return 'focusOnly';
+    }
+    return null;
+  })();
+
+  if (!filterMode) {
+    // Nothing to do here
+    return null;
+  }
+
+  // Some threads in the `visibleCount` may have been "forced visible" by
+  // the user by clicking "Show x more in conversation" — subtract these
+  // forced-visible threads out to get a correct count of actual filter matches.
+  // In 'selection' mode, rely on the count of selected annotations
+  const visibleCount = countVisible(rootThread);
+  const resultCount =
+    filterMode === 'selection'
+      ? filterState.selectedCount
+      : visibleCount - filterState.forcedVisibleCount;
+
+  let buttonText;
+  switch (filterMode) {
+    case 'selection':
+      // If user focus is configured, displayed counts include annotations AND replies,
+      // while `totalCount` only includes top-level annotations, so that count
+      // doesn't make sense when user focus is involved in the mix
+      buttonText = filterState.focusConfigured
+        ? 'Show all'
+        : `Show all (${totalCount})`;
+      break;
+    case 'focusOnly':
+      if (!filterState.forcedVisibleCount) {
+        buttonText = filterState.focusActive
+          ? 'Show all'
+          : `Show only ${filterState.focusDisplayName}`;
+      } else {
+        // When user focus is applied and there are some forced-visible threads,
+        // this special case applies. The button will clear force-visible threads
+        // but leave user focus intact
+        buttonText = 'Reset filters';
+      }
+      break;
+    case 'query':
+      buttonText = 'Clear search';
+      break;
+  }
+
+  const buttonProps = {
+    buttonText,
+    onClick: () => clearSelection(),
+    icon: filterMode !== 'focusOnly' ? 'cancel' : null,
+  };
+
+  // In most cases, the action button will clear the current (filter) selection,
+  // but when in 'focusOnly' mode, it will toggle activation of the focus
+  if (filterMode === 'focusOnly' && !filterState.forcedVisibleCount) {
+    buttonProps.onClick = () => toggleFocusMode();
+  }
+
+  return (
+    <div className="filter-status">
+      <div className="u-layout-row--align-center">
+        <div className="filter-status__text">
+          {resultCount > 0 && <span>Showing </span>}
+          <span className="filter-facet">
+            {resultCount > 0 ? resultCount : 'No'}{' '}
+            {filterMode === 'query' ? 'result' : 'annotation'}
+            {resultCount !== 1 ? 's' : '' /* pluralize */}
+          </span>
+          {filterMode === 'query' && (
+            <span>
+              {' '}
+              for{' '}
+              <span className="filter-facet--pre">
+                &#39;{filterState.filterQuery}&#39;
+              </span>
+            </span>
+          )}
+          {filterMode !== 'selection' && filterState.focusActive && (
+            <span>
+              {' '}
+              by{' '}
+              <span className="filter-facet">
+                {filterState.focusDisplayName}
+              </span>
+            </span>
+          )}
+          {filterState.forcedVisibleCount > 0 && (
+            <span className="filter-facet--muted">
+              {' '}
+              (and {filterState.forcedVisibleCount} more)
+            </span>
+          )}
+        </div>
+        <div>
+          <Button className="button--primary" {...buttonProps} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+FilterStatus.propTypes = {};

--- a/src/sidebar/components/search-input.js
+++ b/src/sidebar/components/search-input.js
@@ -29,7 +29,11 @@ export default function SearchInput({ alwaysExpanded, query, onSearch }) {
 
   const onSubmit = e => {
     e.preventDefault();
-    onSearch(input.current.value);
+    if (input.current.value || prevQuery) {
+      // Don't set an initial empty query, but allow a later empty query to
+      // clear `prevQuery`
+      onSearch(input.current.value);
+    }
   };
 
   // When the active query changes outside of this component, update the input

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -7,6 +7,7 @@ import { withServices } from '../util/service-context';
 import useStore from '../store/use-store';
 import { tabForAnnotation } from '../util/tabs';
 
+import FilterStatus from './filter-status';
 import FocusedModeHeader from './focused-mode-header';
 import LoggedOutMessage from './logged-out-message';
 import LoginPromptPanel from './login-prompt-panel';
@@ -45,6 +46,9 @@ function SidebarContent({
     ? tabForAnnotation(linkedAnnotation)
     : null;
   const searchUris = useStore(store => store.searchUris());
+  const filterStatusEnabled = useStore(store =>
+    store.isFeatureEnabled('client_filter_status')
+  );
   const sidebarHasOpened = useStore(store => store.hasSidebarOpened());
   const userId = useStore(store => store.profile().userid);
 
@@ -73,7 +77,10 @@ function SidebarContent({
   const hasContentError =
     hasDirectLinkedAnnotationError || hasDirectLinkedGroupError;
 
+  const showFilterStatus = filterStatusEnabled && !hasContentError;
   const showTabs = !hasContentError && !hasAppliedFilter;
+  const showFocusModeHeader = isFocusedMode && !showFilterStatus;
+  const showSearchStatus = !hasContentError && !showFilterStatus;
 
   // Show a CTA to log in if successfully viewing a direct-linked annotation
   // and not logged in
@@ -123,7 +130,8 @@ function SidebarContent({
   return (
     <div>
       <h2 className="u-screen-reader-only">Annotations</h2>
-      {isFocusedMode && <FocusedModeHeader />}
+      {showFocusModeHeader && <FocusedModeHeader />}
+      {showFilterStatus && <FilterStatus />}
       <LoginPromptPanel onLogin={onLogin} onSignUp={onSignUp} />
       {hasDirectLinkedAnnotationError && (
         <SidebarContentError
@@ -136,7 +144,7 @@ function SidebarContent({
         <SidebarContentError errorType="group" onLoginRequest={onLogin} />
       )}
       {showTabs && <SelectionTabs isLoading={isLoading} />}
-      {!hasContentError && <SearchStatusBar />}
+      {showSearchStatus && <SearchStatusBar />}
       <ThreadList thread={rootThread} />
       {showLoggedOutMessage && <LoggedOutMessage onLogin={onLogin} />}
     </div>

--- a/src/sidebar/components/test/filter-status-test.js
+++ b/src/sidebar/components/test/filter-status-test.js
@@ -1,0 +1,376 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import FilterStatus, { $imports } from '../filter-status';
+
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+
+function getFilterState() {
+  return {
+    filterQuery: null,
+    focusActive: false,
+    focusConfigured: false,
+    focusDisplayName: null,
+    forcedVisibleCount: 0,
+    selectedCount: 0,
+  };
+}
+
+describe('FilterStatus', () => {
+  let fakeStore;
+  let fakeUseRootThread;
+  let fakeThreadUtil;
+
+  const createComponent = () => {
+    return mount(<FilterStatus />);
+  };
+
+  beforeEach(() => {
+    fakeThreadUtil = {
+      countVisible: sinon.stub().returns(0),
+    };
+    fakeStore = {
+      annotationCount: sinon.stub(),
+      clearSelection: sinon.stub(),
+      filterState: sinon.stub().returns(getFilterState()),
+      toggleFocusMode: sinon.stub(),
+    };
+
+    fakeUseRootThread = sinon.stub().returns({});
+
+    $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      './hooks/use-root-thread': fakeUseRootThread,
+      '../store/use-store': callback => callback(fakeStore),
+      '../util/thread': fakeThreadUtil,
+    });
+  });
+
+  function assertFilterText(wrapper, text) {
+    const filterText = wrapper.find('.filter-status__text').text();
+    assert.equal(filterText, text);
+  }
+
+  function assertButton(wrapper, expected) {
+    const buttonProps = wrapper.find('Button').props();
+
+    assert.equal(buttonProps.buttonText, expected.text);
+    assert.equal(buttonProps.icon, expected.icon);
+    buttonProps.onClick();
+    assert.calledOnce(expected.callback);
+  }
+
+  function assertClearButton(wrapper) {
+    assertButton(wrapper, {
+      text: 'Clear search',
+      icon: 'cancel',
+      callback: fakeStore.clearSelection,
+    });
+  }
+
+  context('(State 1): no search filters active', () => {
+    it('should return null if filter state indicates no active filters', () => {
+      const wrapper = createComponent();
+      assert.isEmpty(wrapper);
+    });
+  });
+
+  context('(State 2): filtered by query', () => {
+    let filterState;
+
+    beforeEach(() => {
+      filterState = { ...getFilterState(), filterQuery: 'foobar' };
+      fakeStore.filterState.returns(filterState);
+      fakeThreadUtil.countVisible.returns(1);
+    });
+
+    it('should provide a "Clear search" button that clears the selection', () => {
+      assertClearButton(createComponent());
+    });
+
+    it('should show the count of matching results', () => {
+      assertFilterText(createComponent(), "Showing 1 result for 'foobar'");
+    });
+
+    it('should show pluralized count of results when appropriate', () => {
+      fakeThreadUtil.countVisible.returns(5);
+      assertFilterText(createComponent(), "Showing 5 results for 'foobar'");
+    });
+
+    it('should show a no results message when no matches', () => {
+      fakeThreadUtil.countVisible.returns(0);
+      assertFilterText(createComponent(), "No results for 'foobar'");
+    });
+  });
+
+  context('(State 3): filtered by query with force-expanded threads', () => {
+    let filterState;
+
+    beforeEach(() => {
+      filterState = {
+        ...getFilterState(),
+        filterQuery: 'foobar',
+        forcedVisibleCount: 3,
+      };
+      fakeStore.filterState.returns(filterState);
+      fakeThreadUtil.countVisible.returns(5);
+    });
+
+    it('should show a separate count for results versus forced visible', () => {
+      assertFilterText(
+        createComponent(),
+        "Showing 2 results for 'foobar' (and 3 more)"
+      );
+    });
+
+    it('should provide a "Clear search" button that clears the selection', () => {
+      assertClearButton(createComponent());
+    });
+  });
+
+  context('(State 4): selected annotations', () => {
+    let filterState;
+
+    beforeEach(() => {
+      filterState = {
+        ...getFilterState(),
+        selectedCount: 1,
+      };
+      fakeStore.filterState.returns(filterState);
+    });
+
+    it('should show the count of annotations', () => {
+      assertFilterText(createComponent(), 'Showing 1 annotation');
+    });
+
+    it('should pluralize annotations when necessary', () => {
+      filterState.selectedCount = 4;
+      fakeStore.filterState.returns(filterState);
+
+      assertFilterText(createComponent(), 'Showing 4 annotations');
+    });
+
+    it('should provide a "Show all" button that shows a count of all annotations', () => {
+      fakeStore.annotationCount.returns(5);
+      assertButton(createComponent(), {
+        text: 'Show all (5)',
+        icon: 'cancel',
+        callback: fakeStore.clearSelection,
+      });
+    });
+  });
+
+  context('(State 5): user-focus mode active', () => {
+    let filterState;
+
+    beforeEach(() => {
+      filterState = {
+        ...getFilterState(),
+        focusActive: true,
+        focusConfigured: true,
+        focusDisplayName: 'Ebenezer Studentolog',
+      };
+      fakeStore.filterState.returns(filterState);
+      fakeThreadUtil.countVisible.returns(1);
+    });
+
+    it('should show a count of annotations by the focused user', () => {
+      assertFilterText(
+        createComponent(),
+        'Showing 1 annotation by Ebenezer Studentolog'
+      );
+    });
+
+    it('should pluralize annotations when needed', () => {
+      fakeThreadUtil.countVisible.returns(3);
+      assertFilterText(
+        createComponent(),
+        'Showing 3 annotations by Ebenezer Studentolog'
+      );
+    });
+
+    it('should show a no results message when user has no annotations', () => {
+      fakeThreadUtil.countVisible.returns(0);
+      assertFilterText(
+        createComponent(),
+        'No annotations by Ebenezer Studentolog'
+      );
+    });
+
+    it('should provide a "Show all" button that toggles user focus mode', () => {
+      assertButton(createComponent(), {
+        text: 'Show all',
+        icon: null,
+        callback: fakeStore.toggleFocusMode,
+      });
+    });
+  });
+
+  context('(State 6): user-focus mode active, filtered by query', () => {
+    let filterState;
+
+    beforeEach(() => {
+      filterState = {
+        ...getFilterState(),
+        focusActive: true,
+        focusConfigured: true,
+        focusDisplayName: 'Ebenezer Studentolog',
+        filterQuery: 'biscuits',
+      };
+      fakeStore.filterState.returns(filterState);
+      fakeThreadUtil.countVisible.returns(1);
+    });
+
+    it('should show a count of annotations by the focused user', () => {
+      assertFilterText(
+        createComponent(),
+        "Showing 1 result for 'biscuits' by Ebenezer Studentolog"
+      );
+    });
+
+    it('should pluralize annotations when needed', () => {
+      fakeThreadUtil.countVisible.returns(3);
+      assertFilterText(
+        createComponent(),
+        "Showing 3 results for 'biscuits' by Ebenezer Studentolog"
+      );
+    });
+
+    it('should show a no results message when user has no annotations', () => {
+      fakeThreadUtil.countVisible.returns(0);
+      assertFilterText(
+        createComponent(),
+        "No results for 'biscuits' by Ebenezer Studentolog"
+      );
+    });
+
+    it('should provide a "Clear search" button', () => {
+      assertClearButton(createComponent());
+    });
+  });
+
+  context(
+    '(State 7): user-focus mode active, filtered by query, force-expanded threads',
+    () => {
+      let filterState;
+
+      beforeEach(() => {
+        filterState = {
+          ...getFilterState(),
+          focusActive: true,
+          focusConfigured: true,
+          focusDisplayName: 'Ebenezer Studentolog',
+          filterQuery: 'biscuits',
+          forcedVisibleCount: 2,
+        };
+        fakeStore.filterState.returns(filterState);
+        fakeThreadUtil.countVisible.returns(3);
+      });
+
+      it('should show a count of annotations by the focused user', () => {
+        assertFilterText(
+          createComponent(),
+          "Showing 1 result for 'biscuits' by Ebenezer Studentolog (and 2 more)"
+        );
+      });
+
+      it('should provide a "Clear search" button', () => {
+        assertClearButton(createComponent());
+      });
+    }
+  );
+
+  context('(State 8): user-focus mode active, selected annotations', () => {
+    let filterState;
+
+    beforeEach(() => {
+      filterState = {
+        ...getFilterState(),
+        focusActive: true,
+        focusConfigured: true,
+        focusDisplayName: 'Ebenezer Studentolog',
+        selectedCount: 2,
+      };
+      fakeStore.filterState.returns(filterState);
+    });
+
+    it('should ignore user and display selected annotations', () => {
+      assertFilterText(createComponent(), 'Showing 2 annotations');
+    });
+
+    it('should provide a "Show all" button', () => {
+      assertButton(createComponent(), {
+        text: 'Show all',
+        icon: 'cancel',
+        callback: fakeStore.clearSelection,
+      });
+    });
+  });
+
+  context('(State 9): user-focus mode active, force-expanded threads', () => {
+    let filterState;
+
+    beforeEach(() => {
+      filterState = {
+        ...getFilterState(),
+        focusActive: true,
+        focusConfigured: true,
+        focusDisplayName: 'Ebenezer Studentolog',
+        forcedVisibleCount: 3,
+      };
+      fakeStore.filterState.returns(filterState);
+      fakeThreadUtil.countVisible.returns(7);
+    });
+
+    it('should show count of user results separately from forced-visible threads', () => {
+      assertFilterText(
+        createComponent(),
+        'Showing 4 annotations by Ebenezer Studentolog (and 3 more)'
+      );
+    });
+
+    it('should handle cases when there are no focused-user annotations', () => {
+      filterState = { ...filterState, forcedVisibleCount: 7 };
+      fakeStore.filterState.returns(filterState);
+      assertFilterText(
+        createComponent(),
+        'No annotations by Ebenezer Studentolog (and 7 more)'
+      );
+    });
+
+    it('should provide a "Reset filters" button', () => {
+      assertButton(createComponent(), {
+        text: 'Reset filters',
+        icon: null,
+        callback: fakeStore.clearSelection,
+      });
+    });
+  });
+
+  context('(State 10): user-focus mode configured but inactive', () => {
+    let filterState;
+
+    beforeEach(() => {
+      filterState = {
+        ...getFilterState(),
+        focusActive: false,
+        focusConfigured: true,
+        focusDisplayName: 'Ebenezer Studentolog',
+      };
+      fakeStore.filterState.returns(filterState);
+      fakeThreadUtil.countVisible.returns(7);
+    });
+
+    it("should show a count of everyone's annotations", () => {
+      assertFilterText(createComponent(), 'Showing 7 annotations');
+    });
+
+    it('should provide a button to activate user-focused mode', () => {
+      assertButton(createComponent(), {
+        text: 'Show only Ebenezer Studentolog',
+        icon: null,
+        callback: fakeStore.toggleFocusMode,
+      });
+    });
+  });
+});

--- a/src/sidebar/components/test/search-input-test.js
+++ b/src/sidebar/components/test/search-input-test.js
@@ -61,6 +61,25 @@ describe('SearchInput', () => {
     assert.calledWith(onSearch, 'new-query');
   });
 
+  it('does not set an initial empty query when form is submitted', () => {
+    // If the first query entered is empty, it will be ignored
+    const onSearch = sinon.stub();
+    const wrapper = createSearchInput({ onSearch });
+    typeQuery(wrapper, '');
+    wrapper.find('form').simulate('submit');
+    assert.notCalled(onSearch);
+  });
+
+  it('sets subsequent empty queries if entered', () => {
+    // If there has already been at least one query set, subsequent
+    // empty queries will be honored
+    const onSearch = sinon.stub();
+    const wrapper = createSearchInput({ query: 'foo', onSearch });
+    typeQuery(wrapper, '');
+    wrapper.find('form').simulate('submit');
+    assert.calledWith(onSearch, '');
+  });
+
   it('renders loading indicator when app is in a "loading" state', () => {
     fakeStore.isLoading.returns(true);
     const wrapper = createSearchInput();

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -53,6 +53,7 @@ describe('SidebarContent', () => {
       hasAppliedFilter: sinon.stub(),
       hasFetchedAnnotations: sinon.stub(),
       hasSidebarOpened: sinon.stub(),
+      isFeatureEnabled: sinon.stub().returns(false),
       isLoading: sinon.stub().returns(false),
       isLoggedIn: sinon.stub(),
       getState: sinon.stub(),
@@ -174,6 +175,14 @@ describe('SidebarContent', () => {
         const wrapper = createComponent();
         assert.isFalse(wrapper.find('SearchStatusBar').exists());
       });
+
+      it('does not render filter status', () => {
+        fakeStore.isFeatureEnabled
+          .withArgs('client_filter_status')
+          .returns(true);
+        const wrapper = createComponent();
+        assert.isFalse(wrapper.find('FilterStatus').exists());
+      });
     });
   });
 
@@ -202,6 +211,42 @@ describe('SidebarContent', () => {
     it('does not render search status', () => {
       const wrapper = createComponent();
       assert.isFalse(wrapper.find('SearchStatusBar').exists());
+    });
+  });
+
+  context('user-focus mode', () => {
+    it('shows focus mode header when focus mode is configured', () => {
+      fakeStore.focusModeConfigured.returns(true);
+
+      const wrapper = createComponent();
+
+      assert.isTrue(wrapper.find('FocusedModeHeader').exists());
+    });
+
+    it('shows filter status when focus mode and feature flag enabled', () => {
+      fakeStore.isFeatureEnabled.withArgs('client_filter_status').returns(true);
+
+      const wrapper = createComponent();
+
+      assert.isFalse(wrapper.find('FocusedModeHeader').exists());
+      assert.isTrue(wrapper.find('FilterStatus').exists());
+    });
+  });
+
+  describe('search status', () => {
+    it('shows the search status bar', () => {
+      const wrapper = createComponent();
+
+      assert.isTrue(wrapper.find('SearchStatusBar').exists());
+    });
+
+    it('shows filter status instead of search status when feature flag enabled', () => {
+      fakeStore.isFeatureEnabled.withArgs('client_filter_status').returns(true);
+
+      const wrapper = createComponent();
+
+      assert.isFalse(wrapper.find('SearchStatusBar').exists());
+      assert.isTrue(wrapper.find('FilterStatus').exists());
     });
   });
 

--- a/src/sidebar/services/test/threads-test.js
+++ b/src/sidebar/services/test/threads-test.js
@@ -7,10 +7,10 @@ const NESTED_THREADS = {
       id: '1',
       children: [
         { id: '1a', children: [{ id: '1ai', children: [] }] },
-        { id: '1b', children: [] },
+        { id: '1b', children: [], visible: true },
         {
           id: '1c',
-          children: [{ id: '1ci', children: [] }],
+          children: [{ id: '1ci', children: [], visible: false }],
         },
       ],
     },
@@ -21,7 +21,7 @@ const NESTED_THREADS = {
         {
           id: '2b',
           children: [
-            { id: '2bi', children: [] },
+            { id: '2bi', children: [], visible: true },
             { id: '2bii', children: [] },
           ],
         },
@@ -46,26 +46,31 @@ describe('threadsService', function () {
   });
 
   describe('#forceVisible', () => {
-    it('should set the thread and its children force-visible in the store', () => {
-      service.forceVisible(NESTED_THREADS);
-
-      [
+    let nonVisibleThreadIds;
+    beforeEach(() => {
+      nonVisibleThreadIds = [
         'top',
         '1',
         '2',
         '3',
         '1a',
-        '1b',
         '1c',
         '2a',
         '2b',
         '1ai',
         '1ci',
-        '2bi',
         '2bii',
-      ].forEach(threadId =>
-        assert.calledWith(fakeStore.setForcedVisible, threadId)
-      );
+      ];
+    });
+    it('should set the thread and its children force-visible in the store', () => {
+      service.forceVisible(NESTED_THREADS);
+      nonVisibleThreadIds.forEach(threadId => {
+        assert.calledWith(fakeStore.setForcedVisible, threadId);
+        assert.callCount(
+          fakeStore.setForcedVisible,
+          nonVisibleThreadIds.length
+        );
+      });
     });
 
     it('should not set the visibility on thread ancestors', () => {
@@ -76,14 +81,7 @@ describe('threadsService', function () {
       for (let i = 0; i < fakeStore.setForcedVisible.callCount; i++) {
         calledWithThreadIds.push(fakeStore.setForcedVisible.getCall(i).args[0]);
       }
-      assert.deepEqual(calledWithThreadIds, [
-        '1ai',
-        '1a',
-        '1b',
-        '1ci',
-        '1c',
-        '1',
-      ]);
+      assert.deepEqual(calledWithThreadIds, ['1ai', '1a', '1ci', '1c', '1']);
     });
   });
 });

--- a/src/sidebar/services/threads.js
+++ b/src/sidebar/services/threads.js
@@ -1,15 +1,24 @@
+/**
+ * @typedef {import('../util/build-thread').Thread} Thread
+ */
+
 // @ngInject
 export default function threadsService(store) {
   /**
    * Make this thread and all of its children "visible". This has the effect of
    * "unhiding" a thread which is currently hidden by an applied search filter
-   * (as well as its child threads).
+   * (as well as its child threads). Only threads that are not currently visible
+   * will be forced visible.
+   *
+   * @param {Thread} thread
    */
   function forceVisible(thread) {
     thread.children.forEach(child => {
       forceVisible(child);
     });
-    store.setForcedVisible(thread.id, true);
+    if (!thread.visible) {
+      store.setForcedVisible(thread.id, true);
+    }
   }
 
   return {

--- a/src/styles/mixins/buttons.scss
+++ b/src/styles/mixins/buttons.scss
@@ -73,6 +73,7 @@
 /* A button with displayed text. It may or may not have an icon. */
 @mixin button--labeled {
   @include button;
+  white-space: nowrap; // Keep multi-word button labels from wrapping
   color: var.$grey-mid;
   font-weight: 700;
   background-color: var.$grey-1;

--- a/src/styles/sidebar/components/filter-status.scss
+++ b/src/styles/sidebar/components/filter-status.scss
@@ -1,0 +1,34 @@
+@use "../../mixins/layout";
+@use "../../mixins/molecules";
+@use "../../variables" as var;
+
+@mixin facet {
+  white-space: nowrap;
+}
+
+.filter-facet {
+  @include facet;
+  font-weight: bold;
+}
+
+.filter-facet--muted {
+  @include facet;
+  color: var.$color-text--light;
+  font-style: italic;
+}
+
+.filter-facet--pre {
+  @include facet;
+}
+
+.filter-status {
+  @include molecules.card;
+  margin-bottom: var.$layout-space;
+  padding: var.$layout-space--small;
+  justify-content: space-between;
+
+  &__text {
+    flex-grow: 1;
+    padding-right: var.$layout-space--xsmall;
+  }
+}

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -25,6 +25,7 @@
 @use './components/autocomplete-list';
 @use './components/button';
 @use './components/excerpt';
+@use './components/filter-status';
 @use './components/focused-mode-header';
 @use './components/group-list';
 @use './components/group-list-item';

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -39,6 +39,7 @@
     "sidebar/components/annotation-share-info.js",
     "sidebar/components/annotation-viewer-content.js",
     "sidebar/components/annotation.js",
+    "sidebar/components/filter-status.js",
     "sidebar/components/focused-mode-header.js",
     "sidebar/components/group-list-item.js",
     "sidebar/components/group-list-section.js",


### PR DESCRIPTION
This PR consolidates filter status information in the client into a single component, `FilterStatus` (behind feature flag) and fixes confusing behavior arising from combining selected annotations and queries (not behind feature flag).

This PR takes over where https://github.com/hypothesis/client/pull/2383 left off, and makes the changes outlined [in this document](https://docs.google.com/document/d/1I_jT2hVXwWVtMNWqcC1mxQpmckLvu2SD_d2A0Reo0Us/edit#) (requires Hypothesis team access). 

Fixes https://github.com/hypothesis/client/issues/2270
Fixes https://github.com/hypothesis/client/issues/1383 (behind feature flag)

Putting into draft until I have a chance to integrate initial feedback from @robertknight on #2383  — this PR is cleaned up and has tests, however.
