### PR TITLE
Typecheck most remaining JS files in src/annotator

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -41,7 +41,7 @@ const ARROW_H_MARGIN = 20;
  * @return {Element}
  */
 function nearestPositionedAncestor(el) {
-  let parentEl = el.parentElement;
+  let parentEl = /** @type {Element} */ (el.parentElement);
   while (parentEl.parentElement) {
     if (getComputedStyle(parentEl).position !== 'static') {
       break;
@@ -95,15 +95,23 @@ export class Adder {
       zIndex: 999,
     });
 
-    this._view = container.ownerDocument.defaultView;
+    this._view = /** @type {Window} */ (container.ownerDocument.defaultView);
 
-    this._width = () =>
-      this._shadowRoot.firstChild.getBoundingClientRect().width;
-    this._height = () =>
-      this._shadowRoot.firstChild.getBoundingClientRect().height;
+    this._width = () => {
+      const firstChild = /** @type {Element} */ (this._shadowRoot.firstChild);
+      return firstChild.getBoundingClientRect().width;
+    };
+
+    this._height = () => {
+      const firstChild = /** @type {Element} */ (this._shadowRoot.firstChild);
+      return firstChild.getBoundingClientRect().height;
+    };
 
     this._isVisible = false;
+
+    /** @type {'up'|'down'} */
     this._arrowDirection = 'up';
+
     this._onAnnotate = options.onAnnotate;
     this._onHighlight = options.onHighlight;
     this._onShowAnnotations = options.onShowAnnotations;
@@ -130,7 +138,7 @@ export class Adder {
    * Return the best position to show the adder in order to target the
    * selected text in `targetRect`.
    *
-   * @param {Rect} targetRect - The rect of text to target, in viewport
+   * @param {DOMRect} targetRect - The rect of text to target, in viewport
    *        coordinates.
    * @param {boolean} isSelectionBackwards - True if the selection was made
    *        backwards, such that the focus point is mosty likely at the top-left

--- a/src/annotator/anchoring/text-position.js
+++ b/src/annotator/anchoring/text-position.js
@@ -28,19 +28,21 @@ export function toRange(root, start, end) {
     root,
     NodeFilter.SHOW_TEXT,
     null, // filter
+
+    // @ts-ignore - Ignored parameter required for IE 11
     false // expandEntityReferences
   );
 
   let startContainer;
-  let startOffset;
+  let startOffset = 0;
   let endContainer;
-  let endOffset;
+  let endOffset = 0;
 
   let textLength = 0;
 
   let node;
   while ((node = nodeIter.nextNode()) && (!startContainer || !endContainer)) {
-    const nodeText = node.nodeValue;
+    const nodeText = /** @type {string} */ (node.nodeValue);
 
     if (
       !startContainer &&

--- a/src/annotator/annotation-sync.js
+++ b/src/annotator/annotation-sync.js
@@ -152,7 +152,7 @@ AnnotationSync.prototype._tag = function (ann, tag) {
   if (ann.$tag) {
     return ann;
   }
-  tag = tag || window.btoa(Math.random());
+  tag = tag || window.btoa(Math.random().toString());
   Object.defineProperty(ann, '$tag', {
     value: tag,
   });

--- a/src/annotator/components/toolbar.js
+++ b/src/annotator/components/toolbar.js
@@ -6,7 +6,7 @@ import SvgIcon from '../../shared/components/svg-icon';
 
 /**
  * @param {Object} props
- *  @param {import("preact/hooks").Ref<HTMLButtonElement>} [props.buttonRef]
+ *  @param {import("preact").Ref<HTMLButtonElement>} [props.buttonRef]
  *  @param {boolean} [props.expanded]
  *  @param {string} [props.extraClasses]
  *  @param {string} props.label
@@ -74,7 +74,7 @@ ToolbarButton.propTypes = {
  *   Callback to toggle visibility of highlights in the document.
  * @prop {() => any} toggleSidebar -
  *   Callback to toggle the visibility of the sidebar.
- * @prop {import("preact/hooks").Ref<HTMLButtonElement>} [toggleSidebarRef] -
+ * @prop {import("preact").Ref<HTMLButtonElement>} [toggleSidebarRef] -
  *   Ref that gets set to the toolbar button for toggling the sidebar.
  *   This is exposed to enable the drag-to-resize functionality of this
  *   button.

--- a/src/annotator/icons.js
+++ b/src/annotator/icons.js
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 /**
  * Set of icons used by the annotator part of the application via the `SvgIcon`
  * component.

--- a/src/annotator/plugin/pdf-metadata.js
+++ b/src/annotator/plugin/pdf-metadata.js
@@ -30,7 +30,7 @@ export default class PDFMetadata {
    * Construct a `PDFMetadata` that returns URIs/metadata associated with a
    * given PDF viewer.
    *
-   * @param {PDFViewerApplication} app
+   * @param {Object} app - The `PDFViewerApplication` global from PDF.js
    */
   constructor(app) {
     this._loaded = new Promise(resolve => {

--- a/src/annotator/range-util.js
+++ b/src/annotator/range-util.js
@@ -1,6 +1,8 @@
 /**
  * Returns true if the start point of a selection occurs after the end point,
  * in document order.
+ *
+ * @param {Selection} selection
  */
 export function isSelectionBackwards(selection) {
   if (selection.focusNode === selection.anchorNode) {
@@ -25,7 +27,7 @@ export function isNodeInRange(range, node) {
     return true;
   }
 
-  const nodeRange = node.ownerDocument.createRange();
+  const nodeRange = /** @type {Document} */ (node.ownerDocument).createRange();
   nodeRange.selectNode(node);
   const isAtOrBeforeStart =
     range.compareBoundaryPoints(Range.START_TO_START, nodeRange) <= 0;
@@ -40,17 +42,19 @@ export function isNodeInRange(range, node) {
  * for each of them.
  *
  * @param {Range} range
- * @param {Function} callback
+ * @param {(n: Node) => any} callback
  */
 function forEachNodeInRange(range, callback) {
   const root = range.commonAncestorContainer;
 
   // The `whatToShow`, `filter` and `expandEntityReferences` arguments are
   // mandatory in IE although optional according to the spec.
-  const nodeIter = root.ownerDocument.createNodeIterator(
+  const nodeIter = /** @type {Document} */ (root.ownerDocument).createNodeIterator(
     root,
     NodeFilter.SHOW_ALL,
     null /* filter */,
+
+    // @ts-ignore - Deprecated last parameter. Required for IE 11.
     false /* expandEntityReferences */
   );
 
@@ -67,7 +71,7 @@ function forEachNodeInRange(range, callback) {
  * Returns the bounding rectangles of non-whitespace text nodes in `range`.
  *
  * @param {Range} range
- * @return {Array<Rect>} Array of bounding rects in viewport coordinates.
+ * @return {Array<DOMRect>} Array of bounding rects in viewport coordinates.
  */
 export function getTextBoundingBoxes(range) {
   const whitespaceOnly = /^\s*$/;
@@ -75,7 +79,7 @@ export function getTextBoundingBoxes(range) {
   forEachNodeInRange(range, function (node) {
     if (
       node.nodeType === Node.TEXT_NODE &&
-      !node.textContent.match(whitespaceOnly)
+      !(/** @type {string} */ (node.textContent).match(whitespaceOnly))
     ) {
       textNodes.push(node);
     }
@@ -112,7 +116,7 @@ export function getTextBoundingBoxes(range) {
  * Returns null if the selection is empty.
  *
  * @param {Selection} selection
- * @return {Rect|null}
+ * @return {DOMRect|null}
  */
 export function selectionFocusRect(selection) {
   if (selection.isCollapsed) {
@@ -146,6 +150,7 @@ export function itemsForRange(range, itemForNode) {
   const items = new Set();
 
   forEachNodeInRange(range, node => {
+    /** @type {Node|null} */
     let current = node;
     while (current) {
       if (checkedNodes.has(current)) {

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -11,8 +11,11 @@
     "target": "ES2020"
   },
   "include": [
+    "annotator/*.js",
+    "annotator/anchoring/*.js",
     "annotator/config/*.js",
     "annotator/components/*.js",
+    "annotator/plugin/*.js",
     "annotator/util/*.js",
     "boot/*.js",
     "shared/*.js",
@@ -26,6 +29,14 @@
     "sidebar/store/*.js"
   ],
   "exclude": [
+    // Enable this once the rest of `src/annotator` is checked.
+    "annotator/index.js",
+
+    // Files in `src/annotator` that still have errors to be resolved.
+    "annotator/pdf-sidebar.js",
+    "annotator/anchoring/pdf.js",
+    "annotator/plugin/document.js",
+
     // Enable this once the rest of `src/sidebar` is checked.
     "sidebar/index.js",
 


### PR DESCRIPTION
This PR enables typechecking for most of the remaining JS files in `src/annotator`, fixing errors along the way, with a few exceptions for modules that will require more work. The entry-point `index.js` file is also excluded since that imports many CoffeeScript files that cannot be checked.

There are a few common kinds of change here:

- Casting a generic possibly-null DOM type to a specific subtype (eg. `Node` => `Element`) because we know this is safe but TS doesn't
- Changing implicit int/float => string conversions to explicit ones (eg. when calling `Element.setAttribute`)
- Telling TS to ignore a few uses of deprecated parameters which we needed to set for IE 11 compatibility but which no longer exist according to MDN or TS's DOM type definitions. We could go ahead and remove these now since we've dropped IE 11 support, but I wanted to avoid making any functional changes in this PR