### PR TITLE
Remove unused `children` prop from `MenuItem`

### DIFF
--- a/src/sidebar/components/menu-item.js
+++ b/src/sidebar/components/menu-item.js
@@ -45,7 +45,6 @@ import Slider from './slider';
  *   Contents of the submenu for this item.  This is typically a list of `MenuItem` components
  *    with the `isSubmenuItem` prop set to `true`, but can include other content as well.
  *    The submenu is only rendered if `isSubmenuVisible` is `true`.
- * @prop {Object} [children] -  The content of the menu item.
  */
 
 /**
@@ -248,5 +247,4 @@ MenuItem.propTypes = {
   onClick: propTypes.func,
   onToggleSubmenu: propTypes.func,
   submenu: propTypes.any,
-  children: propTypes.object,
 };

--- a/src/sidebar/components/sort-menu.js
+++ b/src/sidebar/components/sort-menu.js
@@ -26,9 +26,7 @@ export default function SortMenu() {
         label={sortOption}
         onClick={() => actions.setSortKey(sortOption)}
         isSelected={sortOption === sortKey}
-      >
-        {sortOption}
-      </MenuItem>
+      />
     );
   });
 


### PR DESCRIPTION
The `MenuItem` component never used this prop. It was passed by mistake
in `SortMenu` as a duplicate of the `label` prop.