### PR TITLE
Typecheck PDF anchoring code

### DIFF
--- a/src/annotator/plugin/pdf-metadata.js
+++ b/src/annotator/plugin/pdf-metadata.js
@@ -1,6 +1,10 @@
 import { normalizeURI } from '../util/url';
 
 /**
+ * @typedef {import('../../types/pdfjs').PDFViewerApplication} PDFViewerApplication
+ */
+
+/**
  * @typedef Link
  * @prop {string} href
  */
@@ -30,9 +34,10 @@ export default class PDFMetadata {
    * Construct a `PDFMetadata` that returns URIs/metadata associated with a
    * given PDF viewer.
    *
-   * @param {Object} app - The `PDFViewerApplication` global from PDF.js
+   * @param {PDFViewerApplication} app - The `PDFViewerApplication` global from PDF.js
    */
   constructor(app) {
+    /** @type {Promise<PDFViewerApplication>} */
     this._loaded = new Promise(resolve => {
       const finish = () => {
         window.removeEventListener('documentload', finish);
@@ -89,7 +94,7 @@ export default class PDFMetadata {
         app.metadata.has('dc:title') &&
         app.metadata.get('dc:title') !== 'Untitled'
       ) {
-        title = app.metadata.get('dc:title');
+        title = /** @type {string} */ (app.metadata.get('dc:title'));
       } else if (app.documentInfo && app.documentInfo.Title) {
         title = app.documentInfo.Title;
       }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -34,7 +34,6 @@
 
     // Files in `src/annotator` that still have errors to be resolved.
     "annotator/pdf-sidebar.js",
-    "annotator/anchoring/pdf.js",
     "annotator/plugin/document.js",
 
     // Enable this once the rest of `src/sidebar` is checked.

--- a/src/types/pdfjs.js
+++ b/src/types/pdfjs.js
@@ -1,0 +1,89 @@
+/**
+ * This module defines the subset of the PDF.js interface that the client relies
+ * on.
+ *
+ * PDF.js doesn't provide its own types. There are partial definitions available
+ * from DefinitelyTyped but these don't include everything we use. The source of
+ * truth is the pdf.js repo (https://github.com/mozilla/pdf.js/) on GitHub.
+ * See in particular `src/display/api.js` in that repo.
+ *
+ * Note that the definitions here are not complete, they only include properties
+ * that the client uses. The names of types should match the corresponding
+ * JSDoc types or classes in the PDF.js source where possible.
+ */
+
+/**
+ * @typedef Metadata
+ * @prop {(name: string) => string} get
+ * @prop {(name: string) => boolean} has
+ */
+
+/**
+ * @typedef PDFDocument
+ * @prop {string} fingerprint
+ */
+
+/**
+ * @typedef PDFDocumentInfo
+ * @prop {string} [Title]
+ */
+
+/**
+ * @typedef GetTextContentParameters
+ * @prop {boolean} normalizeWhitespace
+ */
+
+/**
+ * @typedef TextContentItem
+ * @prop {string} str
+ */
+
+/**
+ * @typedef TextContent
+ * @prop {TextContentItem[]} items
+ */
+
+/**
+ * @typedef PDFPageProxy
+ * @prop {(o?: GetTextContentParameters) => Promise<TextContent>} getTextContent
+ */
+
+/**
+ * @typedef PDFPageView
+ * @prop {HTMLElement} div - Container element for the PDF page
+ * @prop {HTMLElement} el -
+ *   Obsolete alias for `div`?. TODO: Remove this and stop checking for it.
+ * @prop {PDFPageProxy} pdfPage
+ * @prop {TextLayer|null} textLayer
+ * @prop {number} renderingState - See `src/annotator/pdfjs-rendering-states.js`
+ */
+
+/**
+ * @typedef PDFViewer
+ *
+ * Defined in `web/pdf_viewer.js` in the PDF.js source.
+ *
+ * @prop {number} pagesCount
+ * @prop {(page: number) => PDFPageView|null} getPageView
+ */
+
+/**
+ * The `PDFViewerApplication` global which is the entry-point for accessing PDF.js.
+ *
+ * Defined in `web/app.js` in the PDF.js source.
+ *
+ * @typedef PDFViewerApplication
+ * @prop {PDFDocument} pdfDocument
+ * @prop {PDFViewer} pdfViewer
+ * @prop {boolean} downloadComplete
+ * @prop {PDFDocumentInfo} documentInfo
+ * @prop {Metadata} metadata
+ */
+
+/**
+ * @typedef TextLayer
+ * @prop {boolean} renderingDone
+ * @prop {HTMLElement} textLayerDiv
+ */
+
+export {};


### PR DESCRIPTION
Add a `src/types/pdfjs.js` module which defines the subset of the PDF.js
viewer API that the client actually uses and make use of it in
`src/annotator/anchoring/pdf.js` and `src/annotator/plugin/pdf-metadata.js`
to typecheck these files.

As well as helping to catch errors and JSDoc mistakes in these files,
this should also make future PDF.js upgrades easier because we can see
what PDF.js APIs the client actually relies on.

*TODO:*

- [x] Check that the names given to types in `types/pdfjs.js` actually matches the PDF.js source code
- [x] Have a look at whether it would be beneficial to make use of the community-written types from DefinitelyTyped (see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/pdfjs-dist/index.d.ts) (_Update: No, they are missing some important types and properties. I did mention them in a comment though._)