### PR TITLE
Typecheck `DocumentMetadata` class

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -34,7 +34,6 @@
 
     // Files in `src/annotator` that still have errors to be resolved.
     "annotator/pdf-sidebar.js",
-    "annotator/plugin/document.js",
 
     // Enable this once the rest of `src/sidebar` is checked.
     "sidebar/index.js",

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -17,8 +17,8 @@
  * @typedef DocumentMetadata
  * @prop {string} title
  * @prop {Object[]} link
- *   @prop {string} link.rel
- *   @prop {string} link.type
+ *   @prop {string} [link.rel]
+ *   @prop {string} [link.type]
  *   @prop {string} link.href
  * // html pages
  * @prop {Object.<string, string[]>} [dc]
@@ -27,6 +27,7 @@
  * @prop {Object.<string, string[]>} [highwire]
  * @prop {Object.<string, string[]>} [prism]
  * @prop {Object.<string, string[]>} [twitter]
+ * @prop {string} [favicon]
  * // pdf files
  * @prop {string} [documentFingerprint]
  */


### PR DESCRIPTION
Typecheck the class that reads metadata from HTML documents and attaches
it to annotations as the `annotation.document` property.

This resulted in a few minor corrections to the `DocumentMetadata` type
in `src/types/annotator.js`.