### PR TITLE
Typecheck annotator/{index, pdf-sidebar} and simplify tsconfig.json

### DIFF
--- a/src/annotator/pdf-sidebar.js
+++ b/src/annotator/pdf-sidebar.js
@@ -1,3 +1,4 @@
+// @ts-expect-error - './sidebar' needs to be converted from JS.
 import Sidebar from './sidebar';
 
 const DEFAULT_CONFIG = {

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -11,29 +11,13 @@
     "target": "ES2020"
   },
   "include": [
-    "annotator/*.js",
-    "annotator/anchoring/*.js",
-    "annotator/config/*.js",
-    "annotator/components/*.js",
-    "annotator/plugin/*.js",
-    "annotator/util/*.js",
-    "boot/*.js",
-    "shared/*.js",
-    "shared/components/*.js",
-    "sidebar/*.js",
-    "sidebar/components/*.js",
-    "sidebar/components/hooks/*.js",
-    "sidebar/store/modules/*.js",
-    "sidebar/services/*.js",
-    "sidebar/util/*.js",
-    "sidebar/store/*.js"
+    "**/*.js"
   ],
   "exclude": [
-    // Enable this once the rest of `src/annotator` is checked.
-    "annotator/index.js",
-
-    // Files in `src/annotator` that still have errors to be resolved.
-    "annotator/pdf-sidebar.js",
+    // Tests are not checked.
+    "**/test/**/*.js",
+    "test-util/**/*.js",
+    "karma.config.js",
 
     // Enable this once the rest of `src/sidebar` is checked.
     "sidebar/index.js",

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -38,9 +38,10 @@
  *
  * @typedef Globals
  * @prop {Object} [PDFViewerApplication] -
- *   PDF.js entry point. If set triggers loading of PDF rather than HTML integration.
+ *   PDF.js entry point. If set, triggers loading of PDF rather than HTML integration.
  * @prop {boolean} [__hypothesis_frame] -
- *   Flag used to indicate that Hypothesis is loaded in the current frame.
+ *   Flag used to indicate that the "annotator" part of Hypothesis is loaded in
+ *   the current frame.
  */
 
 /**

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -32,5 +32,20 @@
  * @prop {string} [documentFingerprint]
  */
 
+/**
+ * Global variables which the Hypothesis client looks for on the `window` object
+ * when loaded in a frame that influence how it behaves.
+ *
+ * @typedef Globals
+ * @prop {Object} [PDFViewerApplication] -
+ *   PDF.js entry point. If set triggers loading of PDF rather than HTML integration.
+ * @prop {boolean} [__hypothesis_frame] -
+ *   Flag used to indicate that Hypothesis is loaded in the current frame.
+ */
+
+/**
+ * @typedef {Window & Globals} HypothesisWindow
+ */
+
 // Make TypeScript treat this file as a module.
 export const unused = {};


### PR DESCRIPTION
This PR fixes or ignores remaining typechecking errors in `annotator/{index.js, pdf-sidebar.js}`. With that done, the `tsconfig.json` file can be simplified by switching it from listing files to include to only listing files to exclude. This means that any new files that are not explicitly excluded will be checked, other than tests which are currently not checked at all.

As part of this, I added types to `src/types/annotator.js` to document the non-native global variables on the `Window` object which are either set by the client or may influence how the client behaves.