### PR TITLE
Carry out some post-filter-UX cleanup in `selection` store module

### DIFF
--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -100,14 +100,14 @@ function SelectionTabs({ isLoading, settings }) {
   );
   // actions
   const store = useStore(store => ({
-    clearSelectedAnnotations: store.clearSelectedAnnotations,
+    clearSelection: store.clearSelection,
     selectTab: store.selectTab,
   }));
 
   const isThemeClean = settings.theme === 'clean';
 
   const selectTab = tabId => {
-    store.clearSelectedAnnotations();
+    store.clearSelection();
     store.selectTab(tabId);
   };
 

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -60,9 +60,7 @@ function SidebarContent({
       : null;
 
   // Actions
-  const clearSelectedAnnotations = useStore(
-    store => store.clearSelectedAnnotations
-  );
+  const clearSelection = useStore(store => store.clearSelection);
   const selectTab = useStore(store => store.selectTab);
 
   // If, after loading completes, no `linkedAnnotation` object is present when
@@ -96,14 +94,14 @@ function SidebarContent({
   useEffect(() => {
     if (!prevGroupId.current || prevGroupId.current !== focusedGroupId) {
       // Clear any selected annotations when the group ID changes
-      clearSelectedAnnotations();
+      clearSelection();
       prevGroupId.current = focusedGroupId;
     }
     if (focusedGroupId && searchUris.length) {
       loadAnnotationsService.load(searchUris, focusedGroupId);
     }
   }, [
-    clearSelectedAnnotations,
+    clearSelection,
     loadAnnotationsService,
     focusedGroupId,
     userId,

--- a/src/sidebar/components/sort-menu.js
+++ b/src/sidebar/components/sort-menu.js
@@ -14,7 +14,7 @@ export default function SortMenu() {
     setSortKey: store.setSortKey,
   }));
   // The currently-applied sort order
-  const sortKey = useStore(store => store.getState().selection.sortKey);
+  const sortKey = useStore(store => store.sortKey());
   // All available sorting options. These change depending on current
   // "tab" or context.
   const sortKeysAvailable = useStore(store => store.sortKeys());

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -37,7 +37,6 @@ describe('HypothesisApp', () => {
     fakeShouldAutoDisplayTutorial = sinon.stub().returns(false);
 
     fakeStore = {
-      clearSelectedAnnotations: sinon.spy(),
       clearGroups: sinon.stub(),
       closeSidebarPanel: sinon.stub(),
       openSidebarPanel: sinon.stub(),

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -29,7 +29,7 @@ describe('SelectionTabs', function () {
       enableExperimentalNewNoteButton: false,
     };
     fakeStore = {
-      clearSelectedAnnotations: sinon.stub(),
+      clearSelection: sinon.stub(),
       selectTab: sinon.stub(),
       annotationCount: sinon.stub().returns(123),
       noteCount: sinon.stub().returns(456),
@@ -245,7 +245,7 @@ describe('SelectionTabs', function () {
 
       findButton(wrapper, label).simulate('click');
 
-      assert.calledOnce(fakeStore.clearSelectedAnnotations);
+      assert.calledOnce(fakeStore.clearSelection);
       assert.calledWith(fakeStore.selectTab, tab);
     });
   });
@@ -260,7 +260,7 @@ describe('SelectionTabs', function () {
 
     findButton(wrapper, 'Page Notes').simulate('click');
 
-    assert.notCalled(fakeStore.clearSelectedAnnotations);
+    assert.notCalled(fakeStore.clearSelection);
     assert.notCalled(fakeStore.selectTab);
   });
 

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -41,7 +41,7 @@ describe('SidebarContent', () => {
     };
     fakeStore = {
       // actions
-      clearSelectedAnnotations: sinon.stub(),
+      clearSelection: sinon.stub(),
       selectTab: sinon.stub(),
       // selectors
       annotationExists: sinon.stub(),
@@ -91,21 +91,21 @@ describe('SidebarContent', () => {
       fakeStore.profile.returns({ userid: 'somethingElse' });
       wrapper.setProps({});
       assert.calledOnce(fakeLoadAnnotationsService.load);
-      assert.notCalled(fakeStore.clearSelectedAnnotations);
+      assert.notCalled(fakeStore.clearSelection);
     });
 
     it('clears selected annotations and loads annotations when groupId changes', () => {
       fakeStore.focusedGroupId.returns('affable');
       wrapper.setProps({});
       assert.calledOnce(fakeLoadAnnotationsService.load);
-      assert.calledOnce(fakeStore.clearSelectedAnnotations);
+      assert.calledOnce(fakeStore.clearSelection);
     });
 
     it('loads annotations when searchURIs change', () => {
       fakeStore.searchUris.returns(['abandon-ship']);
       wrapper.setProps({});
       assert.calledOnce(fakeLoadAnnotationsService.load);
-      assert.notCalled(fakeStore.clearSelectedAnnotations);
+      assert.notCalled(fakeStore.clearSelection);
     });
   });
 

--- a/src/sidebar/components/test/sort-menu-test.js
+++ b/src/sidebar/components/test/sort-menu-test.js
@@ -7,7 +7,6 @@ import { $imports } from '../sort-menu';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
 describe('SortMenu', () => {
-  let fakeState;
   let fakeStore;
 
   const createSortMenu = () => {
@@ -15,14 +14,9 @@ describe('SortMenu', () => {
   };
 
   beforeEach(() => {
-    fakeState = {
-      selection: {
-        sortKey: 'Location',
-      },
-    };
     fakeStore = {
       setSortKey: sinon.stub(),
-      getState: sinon.stub().returns(fakeState),
+      sortKey: sinon.stub().returns('Location'),
       sortKeys: sinon.stub().returns(['Newest', 'Oldest', 'Location']),
     };
 
@@ -55,9 +49,7 @@ describe('SortMenu', () => {
 
     const currentSortKeyMenuItem = wrapper
       .find('MenuItem')
-      .filterWhere(
-        menuItem => menuItem.prop('label') === fakeState.selection.sortKey
-      );
+      .filterWhere(menuItem => menuItem.prop('label') === fakeStore.sortKey());
     assert.isTrue(currentSortKeyMenuItem.prop('isSelected'));
   });
 

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -530,6 +530,24 @@ const hasAppliedFilter = createSelector(
 );
 
 /**
+ * Return the currently-selected tab
+ *
+ * @return {'annotation'|'note'|'orphan'}
+ */
+function selectedTab(state) {
+  return state.selectedTab;
+}
+
+/**
+ * Retrieve the current sort option key
+ *
+ * @return {string}
+ */
+function sortKey(state) {
+  return state.sortKey;
+}
+
+/**
  * Retrieve applicable sort options for the currently-selected tab.
  *
  * @return {string[]}
@@ -585,8 +603,8 @@ const threadState = createSelector(
       filters,
       forcedVisible: forcedVisibleAnnotations(selection),
       selected: selectedAnnotations(selection),
-      sortKey: selection.sortKey, // TODO: This should have a selector
-      selectedTab: selection.selectedTab, // TODO: This should have a selector
+      sortKey: sortKey(selection),
+      selectedTab: selectedTab(selection),
     };
     return { annotations, route: routeName, selection: selectionState };
   }
@@ -619,6 +637,8 @@ const threadState = createSelector(
  * @prop {() => boolean} hasAppliedFilter
  * @prop {() => boolean} hasSelectedAnnotations
  * @prop {() => string[]} selectedAnnotations
+ * @prop {() => string} selectedTab
+ * @prop {() => string} sortKey
  * @prop {() => string[]} sortKeys
  *
  * // Root Selectors
@@ -657,6 +677,8 @@ export default {
     hasAppliedFilter,
     hasSelectedAnnotations,
     selectedAnnotations,
+    selectedTab,
+    sortKey,
     sortKeys,
   },
 

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -193,10 +193,6 @@ const update = {
     };
   },
 
-  CLEAR_SELECTED_ANNOTATIONS: function () {
-    return resetSelection();
-  },
-
   CLEAR_SELECTION: function () {
     return resetSelection();
   },
@@ -306,11 +302,10 @@ function changeFocusModeUser(user) {
   return { type: actions.CHANGE_FOCUS_MODE_USER, user };
 }
 
-/** De-select all annotations. */
-function clearSelectedAnnotations() {
-  return { type: actions.CLEAR_SELECTED_ANNOTATIONS };
-}
-
+/**
+ * Clear all selected annotations and filters. This will leave user-focus
+ * alone, however.
+ */
 function clearSelection() {
   return {
     type: actions.CLEAR_SELECTION,
@@ -602,7 +597,6 @@ const threadState = createSelector(
  *
  * // Actions
  * @prop {typeof changeFocusModeUser} changeFocusModeUser
- * @prop {typeof clearSelectedAnnotations} clearSelectedAnnotations
  * @prop {typeof clearSelection} clearSelection
  * @prop {typeof selectAnnotations} selectAnnotations
  * @prop {typeof selectTab} selectTab
@@ -639,7 +633,6 @@ export default {
 
   actions: {
     changeFocusModeUser,
-    clearSelectedAnnotations,
     clearSelection,
     selectAnnotations,
     selectTab,

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -279,20 +279,6 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('clearSelectedAnnotations()', function () {
-    it('removes all annotations from the selection', function () {
-      store.selectAnnotations([1]);
-      store.clearSelectedAnnotations();
-      assert.isEmpty(getSelectionState().selected);
-    });
-
-    it('clears the current search query', function () {
-      store.setFilterQuery('foo');
-      store.clearSelectedAnnotations();
-      assert.isNull(getSelectionState().filterQuery);
-    });
-  });
-
   describe('setFilterQuery()', function () {
     it('sets the filter query', function () {
       store.setFilterQuery('a-query');

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -517,6 +517,21 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
+  describe('selectedTab', () => {
+    it('should return the currently-selected tab', () => {
+      store.selectTab(uiConstants.TAB_NOTES);
+      assert.equal(store.selectedTab(), uiConstants.TAB_NOTES);
+    });
+  });
+
+  describe('sortKey', () => {
+    it('should return the currently-active sort key', () => {
+      store.setSortKey('Newest');
+
+      assert.equal(store.sortKey(), 'Newest');
+    });
+  });
+
   describe('ADD_ANNOTATIONS', () => {
     it('should select the page notes tab if all top-level annotations are page notes', () => {
       store.dispatch({


### PR DESCRIPTION
This PR tackles a few TODOs from the new filter-status UX work:

* `clearSelectedAnnotations` and `clearSelection` did the same thing. These have been consolidated into `clearSelection` for clarity. If a need to clear selected annotations only, without clearing `forcedVisible` and `filterQuery`, arises, we can add another action creator.
* `sortKey` and `selectedTab` didn't have selectors — this has been rectified and the one component (`SortMenu`) that was getting this directly out of state has been updated to use selectors.