### PR TITLE
Change Flipgrid embed aspect ratio from 4:3 to 16:9

### DIFF
--- a/src/sidebar/media-embedder.js
+++ b/src/sidebar/media-embedder.js
@@ -238,13 +238,7 @@ const embedGenerators = [
   createEmbedGenerator(
     'flipgrid.com',
     /^\/s\/([^/]+)$/,
-    id => `https://flipgrid.com/s/${id}?embed=true`,
-    {
-      // Flipgrid renders the video with a very small size if using the default
-      // 16:9 aspect ratio, so change to 4:3 instead. This does create empty
-      // vertical space, but this is better than a tiny video.
-      aspectRatio: 4 / 3,
-    }
+    id => `https://flipgrid.com/s/${id}?embed=true`
   ),
 
   /**


### PR DESCRIPTION
Flipgrid fixed an issue on their end that required us to make the iframe
for Flipgrid embeds taller than the actual content. This commit removes
the custom aspect ratio so that these videos will use the 16:9 default.

Tested by pasting this link into an annotation: https://flipgrid.com/s/030475b8ceff

Slack thread: https://hypothes-is.slack.com/archives/C1M8NH76X/p1596723935386100