### PR TITLE
Flush timers after each test

### DIFF
--- a/scripts/run-test-loop.py
+++ b/scripts/run-test-loop.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import re
+import subprocess
+import sys
+
+max_iterations = 100
+for i in range(0, max_iterations):
+    print(f"Running test iteration {i+1} of {max_iterations}")
+
+    try:
+        stdout = None
+        proc = subprocess.run(
+            "node_modules/.bin/gulp test",
+            shell=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        )
+        stdout = proc.stdout.decode()
+
+        tests_run_match = re.search("TOTAL: ([0-9]+) SUCCESS", stdout)
+
+        if not tests_run_match:
+            print(f"Tests failed on run {i}")
+            print(stdout)
+
+        expected_tests = 2439
+        tests_run = int(tests_run_match.group(1))
+        if tests_run < expected_tests:
+            print(f"Only ran {tests_run} instead of {expected_tests}")
+            print(stdout)
+
+    except Exception as ex:
+        print("Test process failed", ex)
+        print(stdout)
+        continue

--- a/src/sidebar/test/bootstrap.js
+++ b/src/sidebar/test/bootstrap.js
@@ -23,3 +23,6 @@ registerIcons({
   ...sidebarIcons,
   ...annotatorIcons,
 });
+
+import { flushTimersAfterEachTest } from '../../test-util/flush-timers';
+flushTimersAfterEachTest();

--- a/src/test-util/flush-timers.js
+++ b/src/test-util/flush-timers.js
@@ -1,0 +1,74 @@
+/**
+ * Wrap a pair of browser functions for starting and clearing a timer in order
+ * to enable flushing pending timers after each test.
+ */
+class TimerWrapper {
+  /**
+   * @param {(callback: () => void, delay?: ms) => number} setTimerMethod -
+   *   Method used to start the timer (eg. `setTimeout`)
+   * @param {(id: number) => void} clearTimeout - Method used to clear the timer
+   */
+  constructor(setTimerMethod, clearTimerMethod) {
+    this.pendingCallbacks = new Map();
+    this.setTimerMethod = setTimerMethod;
+    this.clearTimerMethod = clearTimerMethod;
+    this.nativeSetTimer = window[this.setTimerMethod];
+    this.nativeClearTimer = window[this.clearTimerMethod];
+  }
+
+  install() {
+    window[this.setTimerMethod] = (callback, delay) => {
+      const id = this.nativeSetTimer.call(
+        window,
+        () => {
+          this.pendingCallbacks.delete(id);
+          callback();
+        },
+        // Some timer functions don't take a `delay` argument, but it
+        // doesn't cause errors if `undefined` is passed.
+        delay
+      );
+      this.pendingCallbacks.set(id, callback);
+      return id;
+    };
+
+    window[this.clearTimerMethod] = id => {
+      this.nativeClearTimer.call(window, id);
+      this.pendingCallbacks.delete(id);
+    };
+  }
+
+  flush() {
+    for (let [, callback] of this.pendingCallbacks) {
+      callback();
+    }
+    this.pendingCallbacks.clear();
+  }
+}
+
+/**
+ * Set up a mocha `afterEach` hook which flushes any pending timers after each
+ * test ends.
+ *
+ * This prevents problems where a test starts a timer, finishes before the
+ * timer has expired and the timer firing at some later point causes a confusing
+ * test failure.
+ *
+ * Timers are flushed rather than canceled because this more closely matches the
+ * behavior in the real application where the timers will eventually expire.
+ */
+export function flushTimersAfterEachTest() {
+  const setTimeoutWrapper = new TimerWrapper('setTimeout', 'clearTimeout');
+  const rafWrapper = new TimerWrapper(
+    'requestAnimationFrame',
+    'clearAnimationFrame'
+  );
+
+  setTimeoutWrapper.install();
+  rafWrapper.install();
+
+  afterEach(() => {
+    setTimeoutWrapper.flush();
+    rafWrapper.flush();
+  });
+}


### PR DESCRIPTION
This is a work-in-progress fix for one aspect of https://github.com/hypothesis/client/issues/2249, which is that confusing test failures can occur if a test starts a timer and then the timer doesn't expire until after the test completes. These timers may be scheduled directly by us or implicitly by third-party libraries. In most cases tests should clean up their own timers before they exit, but this may be tricky in some cases (eg. when the timer lives in a third-party library).

If one of these timers expires during another test, Mocha will attribute the error to _that_ test instead of the test that actually started the timer. If the timer expiry occurs "between" tests then there is currently a separate issue in the `mocha`/`karma-mocha` libraries where the test suite aborts with no indication of an error, except for the completed test count being smaller than expected.

This PR ensures that any timers started during the execution of a test are executed before the test completes. It does this by wrapping the `setTimeout` and `requestAnimationFrame` functions and then flushing any not-yet-executed timers in an `afterEach` hook. I'm not sure that this is going to be the best fix long-term, but the code here is set up in such a way that we can easily remove it later.

I also added a Python script in `scripts/run-test-loop.py` which executes the test suite in a loop, to make it easier to flush out flakey test failures.

The issue in the test runner with errors that occur at certain times not being reported needs to be addressed upstream in either the mocha or karma-mocha libraries.