### PR TITLE
Fail test suite on uncaught exception

### DIFF
--- a/src/sidebar/services/test/load-annotations-test.js
+++ b/src/sidebar/services/test/load-annotations-test.js
@@ -282,9 +282,15 @@ describe('loadAnnotationsService', () => {
         references: ['parent_annotation_1', 'parent_annotation_2'],
       },
     ];
-    it('clears annotations from the store first', () => {
+    it('clears annotations from the store first', async () => {
+      fakeApi.annotation.get.onFirstCall().resolves({
+        id: 'target_annotation',
+        references: [],
+      });
       const svc = createService();
-      svc.loadThread('target_annotation');
+
+      await svc.loadThread('target_annotation');
+
       assert.calledOnce(fakeStore.clearAnnotations);
     });
 

--- a/src/sidebar/test/bootstrap.js
+++ b/src/sidebar/test/bootstrap.js
@@ -23,3 +23,21 @@ registerIcons({
   ...sidebarIcons,
   ...annotatorIcons,
 });
+
+// Ensure that uncaught exceptions between tests result in the tests failing.
+// This works around an issue with mocha / karma-mocha, see
+// https://github.com/hypothesis/client/issues/2249.
+let pendingError = null;
+window.addEventListener('error', event => {
+  pendingError = event.error;
+});
+window.addEventListener('unhandledrejection', event => {
+  pendingError = event.reason;
+});
+
+afterEach(() => {
+  if (pendingError) {
+    console.error('An uncaught exception was thrown between tests');
+    throw pendingError;
+  }
+});

--- a/src/sidebar/test/bootstrap.js
+++ b/src/sidebar/test/bootstrap.js
@@ -28,16 +28,20 @@ registerIcons({
 // This works around an issue with mocha / karma-mocha, see
 // https://github.com/hypothesis/client/issues/2249.
 let pendingError = null;
+let pendingErrorNotice = null;
+
 window.addEventListener('error', event => {
   pendingError = event.error;
+  pendingErrorNotice = 'An uncaught exception was thrown between tests';
 });
 window.addEventListener('unhandledrejection', event => {
   pendingError = event.reason;
+  pendingErrorNotice = 'An uncaught promise rejection occurred between tests';
 });
 
 afterEach(() => {
   if (pendingError) {
-    console.error('An uncaught exception was thrown between tests');
+    console.error(pendingErrorNotice);
     throw pendingError;
   }
 });


### PR DESCRIPTION
This PR implements a workaround for an issue in the interaction between karma-mocha and mocha which causes uncaught exceptions in between tests to incorrectly result in a "successful" test run. Until the issue is fixed upstream, the workaround is to add our own uncaught exception handler in `src/bootstrap.js` which does cause the test run to fail.

In the process I uncovered a test in `load-annotations-test.js` which was actually failing but where the failure previously went unreported due to this issue.

Once this PR lands I think we should apply the same workaround in the lms project. It is less critical for the other frontend projects because those are smaller and we're not working on them regularly.