### PR TITLE
POC: Improve filter behavior when creating new annotations or replies

### DIFF
--- a/src/sidebar/components/filter-status.js
+++ b/src/sidebar/components/filter-status.js
@@ -90,10 +90,19 @@ export default function FilterStatus() {
   // forced-visible threads out to get a correct count of actual filter matches.
   // In 'selection' mode, rely on the count of selected annotations
   const visibleCount = countVisible(rootThread);
+  const visibleAnnotationCount = rootThread.children.filter(
+    thread => thread.annotation && thread.visible
+  ).length;
+
   const resultCount =
     filterMode === 'selection'
       ? filterState.selectedCount
       : visibleCount - filterState.forcedVisibleCount;
+
+  const additionalCount =
+    filterMode === 'selection'
+      ? visibleAnnotationCount - resultCount
+      : filterState.forcedVisibleCount;
 
   let buttonText;
   switch (filterMode) {
@@ -133,7 +142,7 @@ export default function FilterStatus() {
 
   // In most cases, the action button will clear the current (filter) selection,
   // but when in 'focusOnly' mode, it will toggle activation of the focus
-  if (filterMode === 'focusOnly' && !filterState.forcedVisibleCount) {
+  if (filterMode === 'focusOnly' && !additionalCount) {
     buttonProps.onClick = () => toggleFocusMode();
   }
 
@@ -144,6 +153,9 @@ export default function FilterStatus() {
           {resultCount > 0 && <span>Showing </span>}
           <span className="filter-facet">
             {resultCount > 0 ? resultCount : 'No'}{' '}
+            {filterMode === 'selection' && additionalCount > 0
+              ? 'selected '
+              : ''}
             {filterMode === 'query' ? 'result' : 'annotation'}
             {resultCount !== 1 ? 's' : '' /* pluralize */}
           </span>
@@ -165,10 +177,10 @@ export default function FilterStatus() {
               </span>
             </span>
           )}
-          {filterState.forcedVisibleCount > 0 && (
+          {additionalCount > 0 && (
             <span className="filter-facet--muted">
               {' '}
-              (and {filterState.forcedVisibleCount} more)
+              (and {additionalCount} more)
             </span>
           )}
         </div>

--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -44,7 +44,7 @@ function getScrollContainer() {
  * @param {ThreadListProps} props
  */
 function ThreadList({ thread }) {
-  const clearSelection = useStore(store => store.clearSelection);
+  const setForcedVisible = useStore(store => store.setForcedVisible);
 
   // Height of the visible area of the scroll container.
   const [scrollContainerHeight, setScrollContainerHeight] = useState(
@@ -105,10 +105,10 @@ function ThreadList({ thread }) {
   // and the thread list will scroll to that.
   useEffect(() => {
     if (newAnnotationTag) {
-      clearSelection();
+      setForcedVisible(newAnnotationTag, true);
       setScrollToId(newAnnotationTag);
     }
-  }, [clearSelection, newAnnotationTag]);
+  }, [setForcedVisible, newAnnotationTag]);
 
   // Effect to scroll a particular thread into view. This is mainly used to
   // scroll a newly created annotation into view.

--- a/src/sidebar/services/threads.js
+++ b/src/sidebar/services/threads.js
@@ -16,8 +16,8 @@ export default function threadsService(store) {
     thread.children.forEach(child => {
       forceVisible(child);
     });
-    if (!thread.visible) {
-      store.setForcedVisible(thread.id, true);
+    if (!thread.visible && thread.annotation) {
+      store.setForcedVisible(thread.annotation.$tag, true);
     }
   }
 

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -266,12 +266,6 @@ const update = {
   },
 
   REMOVE_ANNOTATIONS: function (state, action) {
-    const selection = { ...state.selected };
-    action.annotationsToRemove.forEach(annotation => {
-      if (annotation.id) {
-        delete selection[annotation.id];
-      }
-    });
     let newTab = state.selectedTab;
     // If the orphans tab is selected but no remaining annotations are orphans,
     // switch back to annotations tab
@@ -281,9 +275,23 @@ const update = {
     ) {
       newTab = uiConstants.TAB_ANNOTATIONS;
     }
+
+    const removeAnns = collection => {
+      action.annotationsToRemove.forEach(annotation => {
+        if (annotation.id) {
+          delete collection[annotation.id];
+        }
+        if (annotation.$tag) {
+          delete collection[annotation.$tag];
+        }
+      });
+      return collection;
+    };
     return {
       ...setTab(newTab, state.selectedTab),
-      selected: selection,
+      expanded: removeAnns({ ...state.expanded }),
+      forcedVisible: removeAnns({ ...state.forcedVisible }),
+      selected: removeAnns({ ...state.selected }),
     };
   },
 };

--- a/src/sidebar/util/build-thread.js
+++ b/src/sidebar/util/build-thread.js
@@ -324,9 +324,12 @@ export default function buildThread(annotations, options) {
   let thread = threadAnnotations(annotations);
 
   if (hasSelection) {
-    // Remove threads (annotations) that are not selected
+    // Remove threads (annotations) that are not selected or
+    // are not forced-visible
     thread.children = thread.children.filter(
-      child => opts.selected.indexOf(child.id) !== -1
+      child =>
+        opts.selected.indexOf(child.id) !== -1 ||
+        opts.forcedVisible.indexOf(child.id) !== -1
     );
   }
 

--- a/src/sidebar/util/build-thread.js
+++ b/src/sidebar/util/build-thread.js
@@ -259,7 +259,7 @@ function hasVisibleChildren(thread) {
  * @typedef Options
  * @prop {string[]} [selected] - List of currently-selected annotation ids, from
  *       the data store
- * @prop {string[]} [forcedVisible] - List of ids of annotations that have
+ * @prop {string[]} [forcedVisible] - List of $tags of annotations that have
  *       been explicitly expanded by the user, even if they don't
  *       match current filters
  * @prop {(a: Annotation) => boolean} [filterFn] - Predicate function that
@@ -326,11 +326,12 @@ export default function buildThread(annotations, options) {
   if (hasSelection) {
     // Remove threads (annotations) that are not selected or
     // are not forced-visible
-    thread.children = thread.children.filter(
-      child =>
-        opts.selected.indexOf(child.id) !== -1 ||
-        opts.forcedVisible.indexOf(child.id) !== -1
-    );
+    thread.children = thread.children.filter(child => {
+      const isSelected = opts.selected.includes(child.id);
+      const isForcedVisible =
+        child.annotation && opts.forcedVisible.includes(child.annotation.$tag);
+      return isSelected || isForcedVisible;
+    });
   }
 
   if (threadsFiltered) {
@@ -347,7 +348,7 @@ export default function buildThread(annotations, options) {
     } else if (annotationsFiltered) {
       if (
         hasForcedVisible &&
-        opts.forcedVisible.indexOf(annotationId(thread.annotation)) !== -1
+        opts.forcedVisible.includes(thread.annotation.$tag)
       ) {
         // This annotation may or may not match the filter, but we should
         // make sure it is visible because it has been forced visible by user


### PR DESCRIPTION
This draft PR is a POC implementation of some changes to some behavior when creating new annotations or replies when there is one or more applied filter in the client (selected annotations, query filter, or focused-on-a-user). There is some complexity here, so lots of words.

-----

## Motivation

The main tenets here is that new annotations (or replies) created while filter (s) is/are applied should:

* Be guaranteed to be visible to the user, even after saving to the service
* Not  yank the user out of the filtered mode entirely
* Be explained in the context of the currently-applied filter(s)

A ticket was opened (#2324) recently indicating what I believe to be a not-uncommon use case: a user selects an annotation (or annotations) by clicking on highlighted text in the page and then wants to respond to that annotation. Yanking them fully out of the “selected-filter” mode is jarring and confusing.  Likewise, performing a search that results in a bunch of excluded replies in a nested thread and then replying to one of the visible results: because this yanks you out of the filter entirely, it has the nasty effect of expanding a bunch of hidden reply threads and confusing the user as to the context of the reply.

In the case of user-focus mode, the situation is, I’d argue, _more_ problematic: if a user who is not the focused-upon-user attempts to reply to one of that user’s annotations, their reply is immediately hidden! That’s bad.

**As a result of these changes, creating a new annotation or replying to an annotation when in a filtered mode does not reset filters, and that annotation/reply will stay visible until filters are (eventually) reset.**

Other changes here are in support of that behavior.

I’m looking primarily for feedback on the _behavior_, not the technical implementation, which is messy for the moment.

Out of scope for the moment, but valid needs:

* What happens when **editing** an annotation that matches the current filters, but the edited annotation no longer matches the filters.
* Behavior when creating a new **highlight** in any of these filtered contexts.
* Visual design improvements for delineating which annotations/replies match the current filters and which don't

## Before and After

### When filter query is active

#### Creating a new annotation

Before:

![before-search-annotation](https://user-images.githubusercontent.com/439947/90038791-d203f780-dc93-11ea-8195-2a8623c89cc9.gif)

After:

![after-search-annotation](https://user-images.githubusercontent.com/439947/90038802-d5977e80-dc93-11ea-83e0-969a13c25468.gif)

#### Creating a reply

Before:

![before-search-reply](https://user-images.githubusercontent.com/439947/90038979-0e375800-dc94-11ea-9697-ae0a439cd529.gif)

After:

![after-search-reply](https://user-images.githubusercontent.com/439947/90039005-15f6fc80-dc94-11ea-968c-6b543ebbe3f0.gif)

Screenshot of result, after:

<img width="470" alt="Screen Shot 2020-08-12 at 11 46 51 AM" src="https://user-images.githubusercontent.com/439947/90039030-1d1e0a80-dc94-11ea-8f64-661434819d0a.png">

### When there are selected annotations

#### Creating an annotation

Before:

![before-selection-new-annotation](https://user-images.githubusercontent.com/439947/90039119-38891580-dc94-11ea-822b-078a4fb5d2ec.gif)

After:

![after-selection-new-annotation](https://user-images.githubusercontent.com/439947/90039130-3c1c9c80-dc94-11ea-8893-c5a8cdae3425.gif)

Screen shot, after:

<img width="472" alt="Screen Shot 2020-08-12 at 11 36 55 AM" src="https://user-images.githubusercontent.com/439947/90039229-5b1b2e80-dc94-11ea-99a3-143921d5a96f.png">

#### Creating a reply

Before:

![before-selection-reply](https://user-images.githubusercontent.com/439947/90039253-63736980-dc94-11ea-933b-09d9c1651510.gif)

After:

![after-selection-reply](https://user-images.githubusercontent.com/439947/90039284-6b330e00-dc94-11ea-9541-43b338486533.gif)

### When user focus mode is active

#### Creating an annotation

Before:

![before-user-focus-annotation](https://user-images.githubusercontent.com/439947/90039332-7b4aed80-dc94-11ea-8c8b-4ef82256c3d1.gif)

After:

![after-user-focus-annotation](https://user-images.githubusercontent.com/439947/90039342-7f770b00-dc94-11ea-9448-d4bac0f4b895.gif)

<img width="468" alt="Screen Shot 2020-08-12 at 11 57 04 AM" src="https://user-images.githubusercontent.com/439947/90039427-9a497f80-dc94-11ea-801b-155c223c2a7c.png">

#### Creating a reply

Before:

![before-user-focus-reply](https://user-images.githubusercontent.com/439947/90039359-856cec00-dc94-11ea-9883-7aae35a71f68.gif)

After:

![after-user-focus-reply](https://user-images.githubusercontent.com/439947/90039369-8867dc80-dc94-11ea-952b-49c930f1da8c.gif)

<img width="477" alt="Screen Shot 2020-08-12 at 11 43 39 AM" src="https://user-images.githubusercontent.com/439947/90039400-90c01780-dc94-11ea-8c44-05b54eb0704b.png">



## Technical details

Making newly-created annotations and replies reliably show up without resetting filtering entirely involves updating the  `forcedVisible` collection in the  selection store instead of using  `clearSelection`  on annotation/reply creation, and making sure that `forcedVisible` annotations are respected and presented in the proper contexts (`forcedVisible` collections are reset upon clearing selections/filters).

Some wrinkles:

* New annotations have a locally-set `$tag` property but do not yet have an `id`. This `$tag` needs to be added to the `forcedVisible` collection initially to assure the new annotation/reply remains visible, but after save, that entry needs to be updated to use the server-assigned `id` such that it matches to a real `thread` in the `rootThread`. If this sounds odd (i.e. “can’t we use `$tag` or `id` interchangeably here?”) it’s a little complex to explain the “no” answer in short summary, but I’m happy to elaborate, preferably with voices. These changes implement this updating from `$tag` -> `$id` in the selection module (hastily, without elegance; I’ll refactor).
* There has been an oversight in the selection module’s reducer for `REMOVE_ANNOTATIONS`. It has been correctly removing removed annotation ids from the set of `selected` annotations, but had not been removing references to removed annotations from `forcedVisible` and `expanded`.  This was essentially a bug, but didn’t manifest until some of the other changes on this branch happened.
* Yeah, I can see that `FilterStatus` really needs to be refactored into multiple components. It’s getting too brittle and complex. There will be some duplicated logic, likely, between those components, but, eh.
* These changes introduce a new filter state: “selected annotations with forced-visible threads” (as newly-created annotations/replies are considered forced-visible). This has necessitated a bit of nuance around some wording in the `FilterStatus` component. And it also highlights the difference between how we count “annotations” in different modes (not a new problem). In non-filtered modes and when there are selected annotations, only top-level annotations are “counted”: the counts next to tabs and in the “show all” button when viewing selected annotations exclude replies. Counts when filtering by query or user, however, include both annotations and replies. I’ve been trying to manage juggling this as best I can to this point…

## Next Steps

- [x] Gather feedback on behavior here, if anyone has any
- [x] Clean up implementation
- [x] Refactor `FilterStatus`
- [ ] Update filter-states UX documentation to account for any changes that land
