### PR TITLE
Improve filter behavior when creating new annotations or replies

### DIFF
--- a/src/sidebar/components/test/filter-status-test.js
+++ b/src/sidebar/components/test/filter-status-test.js
@@ -150,6 +150,32 @@ describe('FilterStatus', () => {
       assertFilterText(createComponent(), 'Showing 4 annotations');
     });
 
+    it('should show the count of additionally-shown top-level annotations', () => {
+      // In selection mode, "forced visible" count is computed by subtracting
+      // the selectedCount from the count of all visible top-level threads
+      // (children/replies are ignored in this count)
+      fakeUseRootThread.returns({
+        id: '__default__',
+        children: [
+          { id: '1', annotation: { $tag: '1' }, visible: true, children: [] },
+          {
+            id: '2',
+            annotation: { $tag: '2' },
+            visible: true,
+            children: [
+              {
+                id: '2a',
+                annotation: { $tag: '2a' },
+                visible: true,
+                children: [],
+              },
+            ],
+          },
+        ],
+      });
+      assertFilterText(createComponent(), 'Showing 1 annotation (and 1 more)');
+    });
+
     it('should provide a "Show all" button that shows a count of all annotations', () => {
       fakeStore.annotationCount.returns(5);
       assertButton(createComponent(), {

--- a/src/sidebar/components/test/thread-list-test.js
+++ b/src/sidebar/components/test/thread-list-test.js
@@ -40,7 +40,7 @@ describe('ThreadList', () => {
     document.body.appendChild(fakeScrollContainer);
 
     fakeStore = {
-      clearSelection: sinon.stub(),
+      setForcedVisible: sinon.stub(),
       unsavedAnnotations: sinon.stub().returns([]),
     };
 
@@ -113,19 +113,11 @@ describe('ThreadList', () => {
   });
 
   context('new annotation created in application', () => {
-    it('clears the current selection in the store', () => {
+    it('sets the new annotation to forced-visible', () => {
       const wrapper = createComponent();
       addNewAnnotation(wrapper);
-      assert.calledOnce(fakeStore.clearSelection);
-    });
-
-    it('does not clear the selection in the store if new annotation is a highlight', () => {
-      fakeMetadata.isHighlight.returns(true);
-      const wrapper = createComponent();
-
-      addNewAnnotation(wrapper);
-
-      assert.notCalled(fakeStore.clearSelection);
+      assert.calledOnce(fakeStore.setForcedVisible);
+      assert.calledWith(fakeStore.setForcedVisible, 'foobar', true);
     });
   });
 

--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -44,7 +44,7 @@ function getScrollContainer() {
  * @param {ThreadListProps} props
  */
 function ThreadList({ thread }) {
-  const clearSelection = useStore(store => store.clearSelection);
+  const setForcedVisible = useStore(store => store.setForcedVisible);
 
   // Height of the visible area of the scroll container.
   const [scrollContainerHeight, setScrollContainerHeight] = useState(
@@ -105,10 +105,10 @@ function ThreadList({ thread }) {
   // and the thread list will scroll to that.
   useEffect(() => {
     if (newAnnotationTag) {
-      clearSelection();
+      setForcedVisible(newAnnotationTag, true);
       setScrollToId(newAnnotationTag);
     }
-  }, [clearSelection, newAnnotationTag]);
+  }, [setForcedVisible, newAnnotationTag]);
 
   // Effect to scroll a particular thread into view. This is mainly used to
   // scroll a newly created annotation into view.

--- a/src/sidebar/services/test/threads-test.js
+++ b/src/sidebar/services/test/threads-test.js
@@ -2,33 +2,61 @@ import threadsService from '../threads';
 
 const NESTED_THREADS = {
   id: 'top',
+  annotation: { $tag: 'top-tag' },
   children: [
     {
       id: '1',
+      annotation: { $tag: '1-tag' },
       children: [
-        { id: '1a', children: [{ id: '1ai', children: [] }] },
-        { id: '1b', children: [], visible: true },
+        {
+          id: '1a',
+          annotation: { $tag: '1a-tag' },
+          children: [
+            { annotation: { $tag: '1ai-tag' }, id: '1ai', children: [] },
+          ],
+        },
+        {
+          id: '1b',
+          annotation: { $tag: '1b-tag' },
+          children: [],
+          visible: true,
+        },
         {
           id: '1c',
-          children: [{ id: '1ci', children: [], visible: false }],
+          annotation: { $tag: '1c-tag' },
+          children: [
+            {
+              id: '1ci',
+              annotation: { $tag: '1ci-tag' },
+              children: [],
+              visible: false,
+            },
+          ],
         },
       ],
     },
     {
       id: '2',
+      annotation: { $tag: '2-tag' },
       children: [
-        { id: '2a', children: [] },
+        { id: '2a', annotation: { $tag: '2a-tag' }, children: [] },
         {
           id: '2b',
           children: [
-            { id: '2bi', children: [], visible: true },
-            { id: '2bii', children: [] },
+            {
+              id: '2bi',
+              annotation: { $tag: '2bi-tag' },
+              children: [],
+              visible: true,
+            },
+            { id: '2bii', annotation: { $tag: '2bii-tag' }, children: [] },
           ],
         },
       ],
     },
     {
       id: '3',
+      annotation: { $tag: '3-tag' },
       children: [],
     },
   ],
@@ -49,17 +77,17 @@ describe('threadsService', function () {
     let nonVisibleThreadIds;
     beforeEach(() => {
       nonVisibleThreadIds = [
-        'top',
-        '1',
-        '2',
-        '3',
-        '1a',
-        '1c',
-        '2a',
-        '2b',
-        '1ai',
-        '1ci',
-        '2bii',
+        'top-tag',
+        '1-tag',
+        '2-tag',
+        '3-tag',
+        '1a-tag',
+        '1c-tag',
+        '2a-tag',
+        //'2b-tag',  Not visible, but also does not have an annotation
+        '1ai-tag',
+        '1ci-tag',
+        '2bii-tag',
       ];
     });
     it('should set the thread and its children force-visible in the store', () => {
@@ -81,7 +109,13 @@ describe('threadsService', function () {
       for (let i = 0; i < fakeStore.setForcedVisible.callCount; i++) {
         calledWithThreadIds.push(fakeStore.setForcedVisible.getCall(i).args[0]);
       }
-      assert.deepEqual(calledWithThreadIds, ['1ai', '1a', '1ci', '1c', '1']);
+      assert.deepEqual(calledWithThreadIds, [
+        '1ai-tag',
+        '1a-tag',
+        '1ci-tag',
+        '1c-tag',
+        '1-tag',
+      ]);
     });
   });
 });

--- a/src/sidebar/services/threads.js
+++ b/src/sidebar/services/threads.js
@@ -16,8 +16,8 @@ export default function threadsService(store) {
     thread.children.forEach(child => {
       forceVisible(child);
     });
-    if (!thread.visible) {
-      store.setForcedVisible(thread.id, true);
+    if (!thread.visible && thread.annotation) {
+      store.setForcedVisible(thread.annotation.$tag, true);
     }
   }
 

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -266,12 +266,6 @@ const update = {
   },
 
   REMOVE_ANNOTATIONS: function (state, action) {
-    const selection = { ...state.selected };
-    action.annotationsToRemove.forEach(annotation => {
-      if (annotation.id) {
-        delete selection[annotation.id];
-      }
-    });
     let newTab = state.selectedTab;
     // If the orphans tab is selected but no remaining annotations are orphans,
     // switch back to annotations tab
@@ -281,9 +275,23 @@ const update = {
     ) {
       newTab = uiConstants.TAB_ANNOTATIONS;
     }
+
+    const removeAnns = collection => {
+      action.annotationsToRemove.forEach(annotation => {
+        if (annotation.id) {
+          delete collection[annotation.id];
+        }
+        if (annotation.$tag) {
+          delete collection[annotation.$tag];
+        }
+      });
+      return collection;
+    };
     return {
       ...setTab(newTab, state.selectedTab),
-      selected: selection,
+      expanded: removeAnns({ ...state.expanded }),
+      forcedVisible: removeAnns({ ...state.forcedVisible }),
+      selected: removeAnns({ ...state.selected }),
     };
   },
 };

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -271,11 +271,17 @@ describe('sidebar/store/modules/selection', () => {
   describe('#REMOVE_ANNOTATIONS', function () {
     it('removing an annotation should also remove it from the selection', function () {
       store.selectAnnotations([1, 2, 3]);
+      store.setForcedVisible(2, true);
+      store.setForcedVisible(1, true);
+      store.setExpanded(1, true);
+      store.setExpanded(2, true);
       store.removeAnnotations([{ id: 2 }]);
       assert.deepEqual(getSelectionState().selected, {
         1: true,
         3: true,
       });
+      assert.deepEqual(store.forcedVisibleAnnotations(), ['1']);
+      assert.deepEqual(store.expandedMap(), { 1: true });
     });
   });
 

--- a/src/sidebar/util/build-thread.js
+++ b/src/sidebar/util/build-thread.js
@@ -259,7 +259,7 @@ function hasVisibleChildren(thread) {
  * @typedef Options
  * @prop {string[]} [selected] - List of currently-selected annotation ids, from
  *       the data store
- * @prop {string[]} [forcedVisible] - List of ids of annotations that have
+ * @prop {string[]} [forcedVisible] - List of $tags of annotations that have
  *       been explicitly expanded by the user, even if they don't
  *       match current filters
  * @prop {(a: Annotation) => boolean} [filterFn] - Predicate function that
@@ -326,11 +326,14 @@ export default function buildThread(annotations, options) {
   if (hasSelection) {
     // Remove threads (annotations) that are not selected or
     // are not forced-visible
-    thread.children = thread.children.filter(
-      child =>
-        opts.selected.indexOf(child.id) !== -1 ||
-        opts.forcedVisible.indexOf(child.id) !== -1
-    );
+    thread.children = thread.children.filter(child => {
+      const isSelected = opts.selected.includes(child.id);
+      const isForcedVisible =
+        hasForcedVisible &&
+        child.annotation &&
+        opts.forcedVisible.includes(child.annotation.$tag);
+      return isSelected || isForcedVisible;
+    });
   }
 
   if (threadsFiltered) {
@@ -347,7 +350,7 @@ export default function buildThread(annotations, options) {
     } else if (annotationsFiltered) {
       if (
         hasForcedVisible &&
-        opts.forcedVisible.indexOf(annotationId(thread.annotation)) !== -1
+        opts.forcedVisible.includes(thread.annotation.$tag)
       ) {
         // This annotation may or may not match the filter, but we should
         // make sure it is visible because it has been forced visible by user

--- a/src/sidebar/util/build-thread.js
+++ b/src/sidebar/util/build-thread.js
@@ -324,9 +324,12 @@ export default function buildThread(annotations, options) {
   let thread = threadAnnotations(annotations);
 
   if (hasSelection) {
-    // Remove threads (annotations) that are not selected
+    // Remove threads (annotations) that are not selected or
+    // are not forced-visible
     thread.children = thread.children.filter(
-      child => opts.selected.indexOf(child.id) !== -1
+      child =>
+        opts.selected.indexOf(child.id) !== -1 ||
+        opts.forcedVisible.indexOf(child.id) !== -1
     );
   }
 

--- a/src/sidebar/util/test/build-thread-test.js
+++ b/src/sidebar/util/test/build-thread-test.js
@@ -6,15 +6,18 @@ const SIMPLE_FIXTURE = [
   {
     id: '1',
     text: 'first annotation',
+    $tag: '1',
     references: [],
   },
   {
     id: '2',
+    $tag: '2',
     text: 'second annotation',
     references: [],
   },
   {
     id: '3',
+    $tag: '3',
     text: 'third annotation',
     references: [1],
   },
@@ -363,6 +366,28 @@ describe('sidebar/util/build-thread', function () {
                 children: [],
               },
             ],
+          },
+        ]);
+      });
+
+      it('shows forced-visible annotations, also', function () {
+        const thread = createThread(SIMPLE_FIXTURE, {
+          selected: ['1'],
+          forcedVisible: ['2'],
+        });
+        assert.deepEqual(thread, [
+          {
+            annotation: SIMPLE_FIXTURE[0],
+            children: [
+              {
+                annotation: SIMPLE_FIXTURE[2],
+                children: [],
+              },
+            ],
+          },
+          {
+            annotation: SIMPLE_FIXTURE[1],
+            children: [],
           },
         ]);
       });


### PR DESCRIPTION
This is a review-ready variant of https://github.com/hypothesis/client/pull/2434

This PR improves the UX behavior of filters when users create new annotations or replies, as exhaustively described in https://github.com/hypothesis/client/pull/2434

This ready-for-review PR also adds a refactor of the `FilterStatus` component, breaking it down into:

* `FilterStatus`: Determine which kind of filter status to display (or none, if no filters are applied)
* `SelectionFilterStatus`, `QueryFilterStatus`, `FocusFilterStatus`: These components are responsible for putting together the state details and the `Button` for their status information
* `FilterStatusPanel`: Actually renders the panel, message and `Button` as provided by `SelectionFilterStatus`, `QueryFilterStatus` or `FocusFilterStatus`

I'm hoping this breakdown makes all of the possible message formatting variants, etc., a little less confounding and brittle. 

I didn't have to re-write/update a single test for `FilterStatus`, which is pretty cool and reassuring.