### PR TITLE
Fix `appBackgroundColor` theme property handling

### DIFF
--- a/src/sidebar/components/annotation-publish-control.js
+++ b/src/sidebar/components/annotation-publish-control.js
@@ -58,9 +58,6 @@ function AnnotationPublishControl({
 
   const publishDestination = isPrivate ? 'Only Me' : group.name;
 
-  /** @type {ThemeProperty[]} */
-  const themeProps = ['ctaTextColor', 'ctaBackgroundColor'];
-
   // Revert changes to this annotation
   const onCancel = () => {
     removeDraft(annotation);
@@ -77,11 +74,13 @@ function AnnotationPublishControl({
     }
   };
 
+  const buttonStyle = applyTheme(
+    ['ctaTextColor', 'ctaBackgroundColor'],
+    settings
+  );
+
   const menuLabel = (
-    <div
-      className="annotation-publish-button__menu-label"
-      style={applyTheme(themeProps, settings)}
-    >
+    <div className="annotation-publish-button__menu-label" style={buttonStyle}>
       <SvgIcon name="expand-menu" className="u-icon--small" />
     </div>
   );
@@ -91,7 +90,7 @@ function AnnotationPublishControl({
       <div className="annotation-publish-button">
         <Button
           className="annotation-publish-button__primary"
-          style={applyTheme(themeProps, settings)}
+          style={buttonStyle}
           onClick={onSave}
           disabled={isDisabled}
           title={`Publish this annotation to ${publishDestination}`}
@@ -99,7 +98,10 @@ function AnnotationPublishControl({
         />
         {/* This wrapper div is necessary because of peculiarities with
              Safari: see https://github.com/hypothesis/client/issues/2302 */}
-        <div className="annotation-publish-button__menu-wrapper">
+        <div
+          className="annotation-publish-button__menu-wrapper"
+          style={buttonStyle}
+        >
           <Menu
             arrowClass="annotation-publish-button__menu-arrow"
             containerPositioned={false}

--- a/src/sidebar/components/annotation-publish-control.js
+++ b/src/sidebar/components/annotation-publish-control.js
@@ -15,7 +15,6 @@ import SvgIcon from '../../shared/components/svg-icon';
 /**
  * @typedef {import('../../types/api').Annotation} Annotation
  * @typedef {import('../../types/config').MergedConfig} MergedConfig
- * @typedef {import('../util/theme').ThemeProperty} ThemeProperty
  */
 
 /**

--- a/src/sidebar/components/annotation-publish-control.js
+++ b/src/sidebar/components/annotation-publish-control.js
@@ -15,6 +15,7 @@ import SvgIcon from '../../shared/components/svg-icon';
 /**
  * @typedef {import('../../types/api').Annotation} Annotation
  * @typedef {import('../../types/config').MergedConfig} MergedConfig
+ * @typedef {import('../util/theme').ThemeProperty} ThemeProperty
  */
 
 /**
@@ -56,6 +57,8 @@ function AnnotationPublishControl({
   const isPrivate = draft ? draft.isPrivate : !isShared(annotation.permissions);
 
   const publishDestination = isPrivate ? 'Only Me' : group.name;
+
+  /** @type {ThemeProperty[]} */
   const themeProps = ['ctaTextColor', 'ctaBackgroundColor'];
 
   // Revert changes to this annotation

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -77,7 +77,7 @@ function HypothesisApp({
   }, [hasFetchedProfile, profile]);
 
   const backgroundStyle = useMemo(
-    () => applyTheme(['backgroundColor'], settings),
+    () => applyTheme(['appBackgroundColor'], settings),
     [settings]
   );
 

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -7,6 +7,7 @@ import mockImportedComponents from '../../../test-util/mock-imported-components'
 import HypothesisApp, { $imports } from '../hypothesis-app';
 
 describe('HypothesisApp', () => {
+  let fakeApplyTheme;
   let fakeUserAgent = null;
   let fakeStore = null;
   let fakeAuth = null;
@@ -33,6 +34,7 @@ describe('HypothesisApp', () => {
   };
 
   beforeEach(() => {
+    fakeApplyTheme = sinon.stub().returns({});
     fakeServiceConfig = sinon.stub();
     fakeShouldAutoDisplayTutorial = sinon.stub().returns(false);
 
@@ -89,6 +91,7 @@ describe('HypothesisApp', () => {
       '../util/session': {
         shouldAutoDisplayTutorial: fakeShouldAutoDisplayTutorial,
       },
+      '../util/theme': { applyTheme: fakeApplyTheme },
     });
   });
 
@@ -448,5 +451,16 @@ describe('HypothesisApp', () => {
         assert.notCalled(fakeSession.logout);
       });
     });
+  });
+
+  it('applies theme config', () => {
+    const style = { backgroundColor: 'red' };
+    fakeApplyTheme.returns({ backgroundColor: 'red' });
+
+    const wrapper = createComponent();
+    const background = wrapper.find('.hypothesis-app');
+
+    assert.calledWith(fakeApplyTheme, ['appBackgroundColor'], fakeSettings);
+    assert.deepEqual(background.prop('style'), style);
   });
 });

--- a/src/sidebar/util/theme.js
+++ b/src/sidebar/util/theme.js
@@ -1,7 +1,3 @@
-/**
- * @const {Object} All supported options for theming and their corresponding
- *                 CSS property names (JS-style)
- */
 const supportedThemeProperties = {
   accentColor: 'color',
   appBackgroundColor: 'backgroundColor',
@@ -10,6 +6,19 @@ const supportedThemeProperties = {
   selectionFontFamily: 'fontFamily',
   annotationFontFamily: 'fontFamily',
 };
+
+/**
+ * Name of a theme element which can be configured.
+ *
+ * @typedef {keyof supportedThemeProperties} ThemeProperty
+ */
+
+/**
+ * Subset of the config from the host page which includes theme configuration.
+ *
+ * @typedef Settings
+ * @prop {Object.<ThemeProperty,string>} [branding]
+ */
 
 /**
  * Return a React `style` object suitable for use as the value of the `style`
@@ -27,12 +36,11 @@ const supportedThemeProperties = {
  *
  * See https://reactjs.org/docs/dom-elements.html#style
  *
- * @param {String[]} themeProperties    Which of the supported theme properties
- *                                      should have applied rules in the `style`
- *                                      object
- * @param {Object} settings             A settings object, in which any `branding`
- *                                      property values are set
- * @return {Object}                     An React-style style object
+ * @param {ThemeProperty[]} themeProperties -
+ *   Which of the supported theme properties should have applied rules in the `style`
+ *   object
+ * @param {Settings} settings
+ * @return {Object.<string,string>} - Object that can be passed as the `style` prop
  *
  * @example
  * let themeProperties = ['accentColor', 'ctaTextColor', 'foo'];
@@ -46,6 +54,7 @@ const supportedThemeProperties = {
  * applyTheme(themeProperties, settings); // -> { color: '#ffc '}
  */
 export function applyTheme(themeProperties, settings) {
+  /** @type {Object.<string,string>} */
   const style = {};
   if (!settings.branding) {
     return style;


### PR DESCRIPTION
This fixes the regressions in #2143.

- Fix an incorrect call to `applyTheme` which passed an invalid theme
property name (`backgroundColor` instead of `appBackgroundColor`). This is a regression from when this component was converted from AngularJS to Preact in 7bbb8a6.
- Improve the type definitions of `applyTheme` and add a test to help catch
such mistakes in future.
- Fix `ctaBackgroundColor` not being applied correctly to the right-hand side of the "Post to <group name>" button

Tested manually with this diff to the dev server config:

```diff
diff --git a/dev-server/templates/client-config.js.mustache b/dev-server/templates/client-config.js.mustache
index 080d8657d..dde7b0ce3 100644
--- a/dev-server/templates/client-config.js.mustache
+++ b/dev-server/templates/client-config.js.mustache
@@ -2,6 +2,11 @@
   var appHost = document.location.hostname;
   window.hypothesisConfig = function() {
     return {
+      branding: {
+        appBackgroundColor: 'white',
+        ctaBackgroundColor: 'red',
+        ctaTextColor: 'yellow',
+      },
       // enableExperimentalNewNoteButton: true,
       // showHighlights: 'always',
       // theme: 'clean',
@@ -29,4 +34,4 @@
   var embedScript = document.createElement('script');
   embedScript.src = '{{{clientUrl}}}'.replace('{current_host}', document.location.hostname);
   document.body.appendChild(embedScript);
-</script>
\ No newline at end of file
+</script>
```
Fixes #2439