### PR TITLE
Assure all `thread` objects are assigned a unique `id`

### DIFF
--- a/src/sidebar/util/build-thread.js
+++ b/src/sidebar/util/build-thread.js
@@ -27,7 +27,6 @@
  * Default state for new threads
  */
 const DEFAULT_THREAD_STATE = {
-  id: '__default__',
   collapsed: false,
   visible: true,
   replyCount: 0,
@@ -88,6 +87,7 @@ function setParent(threads, id, parents = []) {
     threads[parentId] = {
       ...DEFAULT_THREAD_STATE,
       children: [],
+      id: parentId,
     };
     // Link up this new thread to _its_ parent, which should be the original
     // thread's grandparent

--- a/src/sidebar/util/test/build-thread-test.js
+++ b/src/sidebar/util/test/build-thread-test.js
@@ -184,11 +184,14 @@ describe('sidebar/util/build-thread', function () {
           references: ['3'],
         },
       ];
-      const thread = createThread(fixture);
+      // Get the threads with `id` key included
+      const thread = createThread(fixture, {}, ['id']);
+      // It should create a thread with an id of the missing annotation (3)
       assert.deepEqual(thread, [
         {
+          id: '3',
           annotation: undefined,
-          children: [{ annotation: fixture[0], children: [] }],
+          children: [{ id: '1', annotation: fixture[0], children: [] }],
         },
       ]);
     });


### PR DESCRIPTION
I encountered a quiet bug late last week: if there is a nested annotation thread that has two or more deleted (missing) annotations that share a parent (i.e. at the same hierarchical level/siblings), it caused a `key` collision in `preact`. Child threads, rendered in a `ul`, are keyed by `id` in `ThreadList`, and, before these changes, all threads with missing annotations were getting assigned the `id` of `__default__`. (The manifestation of this was a non-crashing error in the console).

These changes make it such that all threads are given a "real" `id`, which corresponds to the `id` (or `$tag`) of the annotation that "should" be present, but is missing.