### PR TITLE
SCSS consolidation: "Arrow" mixin, better naming, `Excerpt` component

### DIFF
--- a/src/styles/mixins/molecules.scss
+++ b/src/styles/mixins/molecules.scss
@@ -64,6 +64,25 @@
 }
 
 /**
+ * A pattern for styling a little "pointer" (arrow) icon that attaches to
+ * menu content and serves as a visual anchor back to the triggering
+ * button/element. When using, you'll need to provide the appropriate
+ * positioning details to get the pointer to be where you want it in the
+ * given menu.
+ *
+ * @param {string} [$direction] - Which direction the arrow should "point"
+ */
+@mixin menu-arrow($direction: 'up') {
+  position: absolute;
+  z-index: 2;
+  color: var.$color-border;
+  fill: var.$color-background;
+  @if ($direction == 'down') {
+    transform: rotateX(180deg);
+  }
+}
+
+/**
  * A pattern for displaying redacted (moderated) text content
  */
 @mixin redacted-content {

--- a/src/styles/mixins/molecules.scss
+++ b/src/styles/mixins/molecules.scss
@@ -27,7 +27,7 @@
 
   &:hover,
   &.is-focused {
-    @include utils.active-shadow;
+    @include utils.shadow--active;
   }
 
   &--theme-clean {
@@ -48,7 +48,7 @@
  */
 @mixin footer-links {
   @include layout.row(center);
-  @include utils.border-top;
+  @include utils.border--top;
   padding-top: 8px;
 
   &__icon {
@@ -117,7 +117,7 @@
 
   &__header {
     @include layout.row($align: center);
-    @include utils.border-bottom;
+    @include utils.border--bottom;
     padding-bottom: var.$layout-space;
   }
 
@@ -170,7 +170,7 @@
 
   &__tab {
     @include utils.font--large;
-    @include utils.border-right;
+    @include utils.border--right;
     flex: 1 1;
     text-align: center;
     color: var.$color-text--light;

--- a/src/styles/mixins/utils.scss
+++ b/src/styles/mixins/utils.scss
@@ -4,19 +4,19 @@
   border: var.$border-width solid var.$color-border;
 }
 
-@mixin border-top {
+@mixin border--top {
   border-top: var.$border-width solid var.$color-border;
 }
 
-@mixin border-right {
+@mixin border--right {
   border-right: var.$border-width solid var.$color-border;
 }
 
-@mixin border-bottom {
+@mixin border--bottom {
   border-bottom: var.$border-width solid var.$color-border;
 }
 
-@mixin border-left {
+@mixin border--left {
   border-left: var.$border-width solid var.$color-border;
 }
 
@@ -78,6 +78,6 @@
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
 }
 
-@mixin active-shadow {
+@mixin shadow--active {
   box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.15);
 }

--- a/src/styles/sidebar/components/annotation-license.scss
+++ b/src/styles/sidebar/components/annotation-license.scss
@@ -4,7 +4,7 @@
 
 .annotation-license {
   @include utils.font--small;
-  @include utils.border-top;
+  @include utils.border--top;
   // Space between border and text content
   padding-top: var.$layout-space--xsmall;
 

--- a/src/styles/sidebar/components/annotation-share-control.scss
+++ b/src/styles/sidebar/components/annotation-share-control.scss
@@ -42,16 +42,11 @@
   }
 
   // Position the pointer icon absolutely and flip it to make it point at the
-  // share icon. Fill it with background color and give it the same color as
-  // the border to make it look like part of the panel frame.
+  // share icon
   &__arrow {
-    position: absolute;
-    z-index: 100;
+    @include molecules.menu-arrow($direction: 'down');
     right: 0px;
     bottom: -8px;
-    color: var.$color-border;
-    fill: var.$color-background;
-    transform: rotateX(180deg);
   }
 
   .share-links__icon {

--- a/src/styles/sidebar/components/excerpt.scss
+++ b/src/styles/sidebar/components/excerpt.scss
@@ -1,85 +1,79 @@
 @use "../../mixins/buttons";
 @use "../../variables" as var;
 
-// FIXME - Remove the `@at-root` here when SASS modules are used, as local
-// variables will no longer be exposed to other modules.
-@at-root {
-  $expand-duration: 0.15s;
+// the distance by which the shadow indicating a collapsed
+// annotation expands beyond the left/right edges of the card.
+// This value is chosen such that the shadow expands to the full width of
+// the card
+$shadow-h-offset: -12px;
+$expand-duration: 0.15s;
 
-  .excerpt {
-    transition: max-height $expand-duration ease-in;
-    overflow: hidden;
-    position: relative;
-  }
+.excerpt {
+  transition: max-height $expand-duration ease-in;
+  overflow: hidden;
+  position: relative;
+}
 
-  .excerpt__content {
-    // Create a new block-formatting context. This prevents any margins on
-    // elements inside the excerpt from "leaking out" due to margin-collapsing,
-    // which would push this container element away from the top of the excerpt.
-    //
-    // See https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
-    // and https://github.com/hypothesis/client/issues/1518.
-    display: inline-block;
-    width: 100%;
-  }
+.excerpt__content {
+  // Create a new block-formatting context. This prevents any margins on
+  // elements inside the excerpt from "leaking out" due to margin-collapsing,
+  // which would push this container element away from the top of the excerpt.
+  //
+  // See https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
+  // and https://github.com/hypothesis/client/issues/1518.
+  display: inline-block;
+  width: 100%;
+}
 
-  // inline controls for expanding and collapsing
-  // the <excerpt>
-  // -------------
-  .excerpt__inline-controls {
-    display: block;
-    position: absolute;
-    right: 0;
-    bottom: 0;
-  }
+// inline controls for expanding and collapsing
+// the excerpt
+.excerpt__inline-controls {
+  display: block;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+}
 
-  .excerpt__toggle-link {
-    padding-left: 15px;
-    background-image: linear-gradient(to right, transparent 0px, white 12px);
-  }
+.excerpt__toggle-link {
+  padding-left: var.$layout-space;
+  // See https://stackoverflow.com/a/56548711/9788954 regarding
+  // rgba(255, 255, 255, 0) used here instead of `transparent` (for Safari)
+  background-image: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0) 0px,
+    var.$color-background var.$layout-space
+  );
+}
 
-  .excerpt__toggle-button {
-    @include buttons.reset-native-btn-styles;
-    font-style: italic;
-  }
+// TODO the tap target here is quite small
+.excerpt__toggle-button {
+  @include buttons.reset-native-btn-styles;
+  background: transparent;
+  font-style: italic;
+}
 
-  .excerpt__toggle-link > a {
-    color: var.$color-text;
-    font-style: italic;
-    font-weight: normal;
-  }
+// a shadow displayed at the bottom of an <excerpt>s with inline controls
+// disabled, which provides a hint that the excerpt is collapsed
+.excerpt__shadow {
+  position: absolute;
+  left: $shadow-h-offset;
+  right: $shadow-h-offset;
+  bottom: 0;
+  height: var.$touch-target-size;
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0) 50%,
+    rgba(0, 0, 0, 0.08) 95%,
+    rgba(0, 0, 0, 0.13) 100%
+  );
+  transition: opacity $expand-duration linear;
+}
 
-  // a shadow displayed at the bottom of an <excerpt>s with inline controls
-  // disabled, which provides a hint that the excerpt is collapsed
-  // -------------
+.excerpt__shadow--transparent {
+  background-image: none;
+}
 
-  // the distance by which the shadow indicating a collapsed
-  // annotation expands beyond the left/right edges of the card.
-  // This value is chosen such that the shadow expands to the full width of
-  // the card
-  $shadow-h-offset: -12px;
-
-  .excerpt__shadow {
-    position: absolute;
-    left: $shadow-h-offset;
-    right: $shadow-h-offset;
-    bottom: 0;
-    height: 40px;
-    background-image: linear-gradient(
-      to bottom,
-      transparent 50%,
-      rgba(0, 0, 0, 0.08) 95%,
-      rgba(0, 0, 0, 0.13) 100%
-    );
-    transition: opacity $expand-duration linear;
-  }
-
-  .excerpt__shadow--transparent {
-    background-image: none;
-  }
-
-  .excerpt__shadow.is-hidden {
-    opacity: 0;
-    pointer-events: none;
-  }
+.excerpt__shadow.is-hidden {
+  opacity: 0;
+  pointer-events: none;
 }

--- a/src/styles/sidebar/components/help-panel.scss
+++ b/src/styles/sidebar/components/help-panel.scss
@@ -11,8 +11,8 @@
   }
 
   &__subcontent {
-    @include utils.border-top;
-    @include utils.border-bottom;
+    @include utils.border--top;
+    @include utils.border--bottom;
     @include layout.vertical-space;
 
     a {

--- a/src/styles/sidebar/components/menu-item.scss
+++ b/src/styles/sidebar/components/menu-item.scss
@@ -61,7 +61,7 @@ a.menu-item:hover {
   }
 
   &.is-expanded {
-    @include utils.border-bottom;
+    @include utils.border--bottom;
     background-color: var.$grey-1;
     color: var.$color-text;
     &:hover {
@@ -142,7 +142,7 @@ a.menu-item:hover {
 
 // The container for open submenus
 .menu-item__submenu {
-  @include utils.border-bottom;
+  @include utils.border--bottom;
   &:hover {
     // Make it a bit darker on hover.
     background-color: var.$grey-3;

--- a/src/styles/sidebar/components/menu-section.scss
+++ b/src/styles/sidebar/components/menu-section.scss
@@ -2,7 +2,7 @@
 @use "../../mixins/utils";
 
 .menu-section__content {
-  @include utils.border-bottom;
+  @include utils.border--bottom;
 }
 
 .menu-section__heading {

--- a/src/styles/sidebar/components/menu.scss
+++ b/src/styles/sidebar/components/menu.scss
@@ -1,5 +1,6 @@
 @use "../../mixins/focus";
 @use "../../mixins/layout";
+@use "../../mixins/molecules";
 @use "../../mixins/utils";
 @use "../../variables" as var;
 
@@ -56,17 +57,14 @@
 // Triangular indicator at the top of the menu that associates it with the
 // toggle button.
 .menu__arrow {
-  color: var.$grey-3;
-  fill: white;
+  @include molecules.menu-arrow;
 
   // Position the arrow so that it appears flush with the right edge of the
   // content when the menu is right-aligned, and the bottom of the arrow just
   // overlaps the content's border. The effect is that the menu's border is a
   // rounded rect with a notch at the top.
-  position: absolute;
   top: calc(100% - 2px); // nb. Adjust this if changing the <svg> size.
   right: 0;
-  z-index: 2;
 }
 
 // Content area of the menu.

--- a/src/styles/sidebar/components/top-bar.scss
+++ b/src/styles/sidebar/components/top-bar.scss
@@ -5,7 +5,7 @@
 
 .top-bar {
   @include utils.font--large;
-  @include utils.border-bottom;
+  @include utils.border--bottom;
   color: var.$grey-mid;
   background: var.$white;
   height: var.$top-bar-height;


### PR DESCRIPTION
This PR contains three (frankly disparate) commits that continue us toward our Q3 goal of design pattern consolidation. These are:

1. Consolidate a pattern for a menu "arrow" or  that "docks" to the edge of menu content and points back toward the menu's trigger element.
2. Rename the `border*` mixins to use consistent naming conventions
3. Do a pass over the SCSS for the `Excerpt` component

While looking at `Excerpt`, I saw an interesting visual nit in Safari:

![image](https://user-images.githubusercontent.com/439947/90517314-3a8b2280-e133-11ea-9566-cf48b87df045.png)

The odd gradient is a result of Safari's treatment of `transparent`. Technically, `transparent` is `rgba(0, 0, 0, 0)` though most of us intuit it as `rgba(255, 255, 255, 0)`. Something technical about the way other browsers composite it/color spaces/whatever/my-curiosity-does-have-bounds  mean that in practice, `transparent` _behaves like_ `rgba(255, 255, 255, 0)`. But not in Safari's case. Which means that Safari renders a gradient from `transparent` to `white` with shades of grey.

This is fixed by explicitly using `rgba(255, 255, 255, 0)` here.

See https://stackoverflow.com/questions/38391457/linear-gradient-to-transparent-bug-in-latest-safari

(p.s. I don't think it's a bug, per se, despite the SO URL).

Given the focus of these changes, I didn't at this time rectify the fact that the touch target on the inline controls can be tiny; I toyed around with a few options but it wasn't straightforward, so I'll leave that as a separate exercise. User facing changes are negligible.

