### PR TITLE
Support PDF.js >= 2.5.207

### DIFF
--- a/src/types/pdfjs.js
+++ b/src/types/pdfjs.js
@@ -68,16 +68,29 @@
  */
 
 /**
+ * Defined in `web/ui_utils.js` in the PDF.js source.
+ *
+ * @typedef EventBus
+ * @prop {(event: string, listener: Function) => void} on
+ * @prop {(event: string, listener: Function) => void} off
+ */
+
+/**
  * The `PDFViewerApplication` global which is the entry-point for accessing PDF.js.
  *
  * Defined in `web/app.js` in the PDF.js source.
  *
  * @typedef PDFViewerApplication
+ * @prop {EventBus} [eventBus] -
+ *   Global event bus. Since v1.6.210.
  * @prop {PDFDocument} pdfDocument
  * @prop {PDFViewer} pdfViewer
  * @prop {boolean} downloadComplete
  * @prop {PDFDocumentInfo} documentInfo
  * @prop {Metadata} metadata
+ * @prop {Promise<void>} [initializedPromise] -
+ *   Promise that resolves when PDF.js is initialized. Since v2.4.456.
+ *   See https://github.com/mozilla/pdf.js/wiki/Third-party-viewer-usage#initialization-promise.
  */
 
 /**


### PR DESCRIPTION
Since [1] PDF.js does not dispatch events to the DOM any more. Therefore
the client needs to listen for the `documentloaded` event from
`PDFApplicationViewer.eventBus`. The `eventBus` property is only
available once the viewer is initialized, so the client needs to wait
for `initializedPromise` to resolve before checking it.

[1] https://github.com/mozilla/pdf.js/pull/11655

----

Related to this PR, we should decide on a compatibility policy for PDF.js. At a minimum, we always need to support:

- The version of PDF.js that is currently used by Via and the Chrome extension
- The version of PDF.js that is shipped with https://github.com/hypothesis/pdf.js-hypothes.is

In addition, we should also support:

- Versions of PDF.js that shipped with older versions of https://github.com/hypothesis/pdf.js-hypothes.is and are still in widespread usage. We need to get some statistics on this.
- The version of PDF.js that ships as Firefox's built in viewer in the current version of Firefox
