### PR TITLE
Upgrade TypeScript and fix various issues related to optional properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "terser": "^5.0.0",
     "through2": "^4.0.1",
     "tiny-emitter": "^2.0.2",
-    "typescript": "^3.9.5",
+    "typescript": "^4.0.2",
     "unorm": "^1.3.3",
     "vinyl": "^2.2.0",
     "watchify": "^3.7.0",

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -63,11 +63,6 @@ $.noConflict(true)(function () {
 
   let Klass = isPDF ? PdfSidebar : Sidebar;
 
-  if (config.hasOwnProperty('constructor')) {
-    Klass = config.constructor;
-    delete config.constructor;
-  }
-
   if (config.subFrameIdentifier) {
     // Make sure the PDF plugin is loaded if the subframe contains the PDF.js viewer.
     if (isPDF) {

--- a/src/annotator/plugin/document.js
+++ b/src/annotator/plugin/document.js
@@ -25,6 +25,43 @@ import Plugin from '../plugin';
 import { normalizeURI } from '../util/url';
 
 /**
+ * Extension of the `Metadata` type with non-optional fields for `dc`, `eprints` etc.
+ *
+ * @typedef HTMLDocumentMetadata
+ * @prop {string} title
+ * @prop {Object[]} link
+ *   @prop {string} [link.rel]
+ *   @prop {string} [link.type]
+ *   @prop {string} link.href
+ * @prop {Object.<string, string[]>} dc
+ * @prop {Object.<string, string[]>} eprints
+ * @prop {Object.<string, string[]>} facebook
+ * @prop {Object.<string, string[]>} highwire
+ * @prop {Object.<string, string[]>} prism
+ * @prop {Object.<string, string[]>} twitter
+ * @prop {string} [favicon]
+ * @prop {string} [documentFingerprint]
+ */
+
+/**
+ * Create an empty `HTMLDocumentMetadata` object.
+ *
+ * @return {HTMLDocumentMetadata}
+ */
+function createMetadata() {
+  return {
+    title: document.title,
+    link: [],
+    dc: {},
+    eprints: {},
+    facebook: {},
+    highwire: {},
+    prism: {},
+    twitter: {},
+  };
+}
+
+/**
  * DocumentMeta reads metadata/links from the current HTML document and
  * populates the `document` property of new annotations.
  */
@@ -36,8 +73,7 @@ export default class DocumentMeta extends Plugin {
       beforeAnnotationCreated: 'beforeAnnotationCreated',
     };
 
-    /** @type {Metadata} */
-    this.metadata = { title: document.title, link: [] };
+    this.metadata = createMetadata();
 
     this.baseURI = options.baseURI || baseURI;
     this.document = options.document || document;
@@ -90,7 +126,7 @@ export default class DocumentMeta extends Plugin {
    * Return metadata for the current page.
    */
   getDocumentMetadata() {
-    this.metadata = { title: document.title, link: [] };
+    this.metadata = createMetadata();
 
     // first look for some common metadata types
     // TODO: look for microdata/rdfa?

--- a/src/annotator/toolbar.js
+++ b/src/annotator/toolbar.js
@@ -27,7 +27,10 @@ export class ToolbarController {
     this._container.className = 'annotator-toolbar';
 
     this._useMinimalControls = false;
+
+    /** @type {'annotation'|'note'} */
     this._newAnnotationType = 'note';
+
     this._highlightsVisible = false;
     this._sidebarOpen = false;
 

--- a/src/shared/frame-rpc.js
+++ b/src/shared/frame-rpc.js
@@ -37,7 +37,6 @@ const VERSION = '1.0.0';
  *  @param {(Object<string, ((any) => any)>) | ((any) => any)} methods
  */
 export default function RPC(src, dst, origin, methods) {
-  if (!(this instanceof RPC)) return new RPC(src, dst, origin, methods);
   const self = this;
   this.src = src;
   this.dst = dst;

--- a/src/sidebar/components/annotation-body.js
+++ b/src/sidebar/components/annotation-body.js
@@ -28,7 +28,7 @@ import TagList from './tag-list';
  * @prop {string} text -
  *     The markdown annotation body, which is either rendered as HTML (if `isEditing`
  *     is false) or displayed in a text area otherwise.
- * @prop {MergedConfig} [settings]
+ * @prop {MergedConfig} settings
  */
 
 /**

--- a/src/sidebar/components/annotation-header.js
+++ b/src/sidebar/components/annotation-header.js
@@ -20,7 +20,7 @@ import Timestamp from './timestamp';
  * @typedef AnnotationHeaderProps
  * @prop {Annotation} annotation
  * @prop {boolean} [isEditing] - Whether the annotation is actively being edited
- * @prop {number} [replyCount] - How many replies this annotation currently has
+ * @prop {number} replyCount - How many replies this annotation currently has
  * @prop {boolean} [showDocumentInfo] -
  *   Should document metadata be rendered? Hint: this is enabled for single annotation
  *   and stream views.

--- a/src/sidebar/components/annotation-header.js
+++ b/src/sidebar/components/annotation-header.js
@@ -58,7 +58,10 @@ export default function AnnotationHeader({
   const showReplyButton = replyCount > 0 && isCollapsedReply;
   const showExtendedInfo = !isReply(annotation);
 
-  const onReplyCountClick = () => setExpanded(annotation.id, true);
+  const onReplyCountClick = () =>
+    // If an annotation has replies it must have been saved and therefore have
+    // an ID.
+    setExpanded(/** @type {string} */ (annotation.id), true);
 
   return (
     <header className="annotation-header">

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -105,7 +105,10 @@ function Annotation({
     }
   };
 
-  const onToggleReplies = () => setExpanded(annotation.id, !!threadIsCollapsed);
+  const onToggleReplies = () =>
+    // nb. We assume the annotation has an ID here because it is not possible
+    // to create replies until the annotation has been saved.
+    setExpanded(/** @type {string} */ (annotation.id), !!threadIsCollapsed);
 
   return (
     /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */

--- a/src/sidebar/components/excerpt.js
+++ b/src/sidebar/components/excerpt.js
@@ -9,8 +9,8 @@ import { applyTheme } from '../util/theme';
 
 /**
  * @typedef InlineControlsProps
- * @prop {boolean} [isCollapsed]
- * @prop {(collapsed: boolean) => any} [setCollapsed]
+ * @prop {boolean} isCollapsed
+ * @prop {(collapsed: boolean) => any} setCollapsed
  * @prop {Object} [linkStyle]
  */
 

--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -82,9 +82,12 @@ function GroupListItem({
     onExpand(!isExpanded);
   };
 
-  const copyLink = () => {
+  /**
+   * @param {string} url
+   */
+  const copyLink = url => {
     try {
-      copyText(activityUrl);
+      copyText(url);
       toastMessenger.success(`Copied link for "${group.name}"`);
     } catch (err) {
       toastMessenger.error('Unable to copy link');
@@ -121,7 +124,7 @@ function GroupListItem({
             {activityUrl && (
               <li>
                 <MenuItem
-                  onClick={copyLink}
+                  onClick={() => copyLink(activityUrl)}
                   icon="copy"
                   isSubmenuItem={true}
                   label={copyLinkLabel}

--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -16,7 +16,7 @@ import MenuItem from './menu-item';
  * @typedef GroupListItemProps
  * @prop {Group} group
  * @prop {boolean} [isExpanded] - Whether the submenu for this group is expanded
- * @prop {(expand: boolean) => any} [onExpand] -
+ * @prop {(expand: boolean) => any} onExpand -
  *   Callback invoked to expand or collapse the current group
  * @prop {Object} analytics - Injected service
  * @prop {Object} groups - Injected service

--- a/src/sidebar/components/group-list-section.js
+++ b/src/sidebar/components/group-list-section.js
@@ -12,9 +12,9 @@ import MenuSection from './menu-section';
  * @typedef GroupListSectionProps
  * @prop {Group|null} [expandedGroup]
  *  - The `Group` whose submenu is currently expanded, or `null` if no group is currently expanded
- * @prop {Group[]} [groups] - The list of groups to be displayed in the group list section
+ * @prop {Group[]} groups - The list of groups to be displayed in the group list section
  * @prop {string} [heading] - The string name of the group list section
- * @prop {(group: Group|null) => any} [onExpandGroup] -
+ * @prop {(group: Group|null) => any} onExpandGroup -
  *   Callback invoked when a group is expanded or collapsed.  The argument is the group being
  *   expanded, or `null` if the expanded group is being collapsed.
  */

--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -31,8 +31,8 @@ function publisherProvidedIcon(settings) {
 
 /**
  * @typedef GroupListProps
- * @prop {ServiceUrlGetter} [serviceUrl]
- * @prop {MergedConfig} [settings]
+ * @prop {ServiceUrlGetter} serviceUrl
+ * @prop {MergedConfig} settings
  */
 
 /**

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -53,12 +53,12 @@ function authStateFromProfile(profile) {
 
 /**
  * @typedef HypothesisAppProps
- * @prop {Object} [auth]
- * @prop {Bridge} [bridge]
- * @prop {ServiceUrlGetter} [serviceUrl]
- * @prop {MergedConfig} [settings]
- * @prop {Object} [session]
- * @prop {Object} [toastMessenger]
+ * @prop {Object} auth
+ * @prop {Bridge} bridge
+ * @prop {ServiceUrlGetter} serviceUrl
+ * @prop {MergedConfig} settings
+ * @prop {Object} session
+ * @prop {Object} toastMessenger
  */
 
 /**

--- a/src/sidebar/components/markdown-editor.js
+++ b/src/sidebar/components/markdown-editor.js
@@ -165,9 +165,9 @@ ToolbarButton.propTypes = {
 
 /**
  * @typedef ToolbarProps
- * @prop {boolean} [isPreviewing] - `true` if the editor's "Preview" mode is active.
- * @prop {(a: ButtonID) => any} [onCommand] - Callback invoked with the selected command when a toolbar button is clicked.
- * @prop {() => any} [onTogglePreview] - Callback invoked when the "Preview" toggle button is clicked.
+ * @prop {boolean} isPreviewing - `true` if the editor's "Preview" mode is active.
+ * @prop {(a: ButtonID) => any} onCommand - Callback invoked with the selected command when a toolbar button is clicked.
+ * @prop {() => any} onTogglePreview - Callback invoked when the "Preview" toggle button is clicked.
  */
 
 /**

--- a/src/sidebar/components/menu-item.js
+++ b/src/sidebar/components/menu-item.js
@@ -91,7 +91,7 @@ export default function MenuItem({
   let focusTimer = null;
 
   let renderedIcon = null;
-  if (icon !== 'blank') {
+  if (icon && icon !== 'blank') {
     renderedIcon = iconIsUrl ? (
       <img className={iconClass} alt={iconAlt} src={icon} />
     ) : (

--- a/src/sidebar/components/search-input.js
+++ b/src/sidebar/components/search-input.js
@@ -14,7 +14,7 @@ import Spinner from './spinner';
  *   If true, the input field is always shown. If false, the input field is only shown
  *   if the query is non-empty.
  * @prop {string|null} query - The currently active filter query
- * @prop {(value: string) => any} [onSearch] -
+ * @prop {(value: string) => any} onSearch -
  *   Callback to invoke when the current filter query changes
  */
 

--- a/src/sidebar/components/tag-list.js
+++ b/src/sidebar/components/tag-list.js
@@ -11,8 +11,8 @@ import { withServices } from '../util/service-context';
  * @typedef TagListProps
  * @prop {Annotation} annotation - Annotation that owns the tags.
  * @prop {string[]} tags - List of tags as strings.
- * @prop {(a: string, b: Object<'tag', string>) => any} [serviceUrl] - Services
- * @prop {Object} [settings]
+ * @prop {(a: string, b: Object<'tag', string>) => any} serviceUrl - Services
+ * @prop {{ authDomain: string }} settings
  */
 
 /**

--- a/src/sidebar/components/thread-card.js
+++ b/src/sidebar/components/thread-card.js
@@ -18,7 +18,7 @@ import Thread from './thread';
  * @typedef ThreadCardProps
  * @prop {Thread} thread
  * @prop {Object} frameSync - Injected service
- * @prop {MergedConfig} [settings] - Injected service
+ * @prop {MergedConfig} settings - Injected service
  */
 
 /**

--- a/src/sidebar/components/user-menu.js
+++ b/src/sidebar/components/user-menu.js
@@ -18,11 +18,9 @@ import SvgIcon from '../../shared/components/svg-icon';
 
 /**
  * @typedef AuthState
- * @prop {'logged-in'|'logged-out'} status
- * @prop {string} [displayName]
- * @prop {string} [userid]
- * @prop {string} [username]
- * @prop {string} [provider]
+ * @prop {string} displayName
+ * @prop {string} userid
+ * @prop {string} username
  */
 
 /**

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -102,12 +102,13 @@ function receiveRealTimeUpdates({
         ann.group === groups.selectors.focusedGroupId(getState()) ||
         route.selectors.route(getState()) !== 'sidebar'
       ) {
-        pendingUpdates[ann.id] = ann;
+        pendingUpdates[/** @type {string} */ (ann.id)] = ann;
       }
     });
     deletedAnnotations.forEach(ann => {
+      const id = /** @type {string} */ (ann.id);
       // Discard any pending but not-yet-applied updates for this annotation
-      delete pendingUpdates[ann.id];
+      delete pendingUpdates[id];
 
       // If we already have this annotation loaded, then record a pending
       // deletion. We do not check the group of the annotation here because a)
@@ -115,8 +116,8 @@ function receiveRealTimeUpdates({
       // even if the annotation is from the current group, it might be for a
       // new annotation (saved in pendingUpdates and removed above), that has
       // not yet been loaded.
-      if (annotations.selectors.annotationExists(getState(), ann.id)) {
-        pendingDeletions[ann.id] = true;
+      if (annotations.selectors.annotationExists(getState(), id)) {
+        pendingDeletions[id] = true;
       }
     });
     dispatch({

--- a/src/sidebar/util/annotation-metadata.js
+++ b/src/sidebar/util/annotation-metadata.js
@@ -232,7 +232,7 @@ export function isHighlight(annotation) {
  * @param {Annotation} annotation
  */
 export function isOrphan(annotation) {
-  return hasSelector(annotation) && annotation.$orphan;
+  return hasSelector(annotation) && annotation.$orphan === true;
 }
 
 /**

--- a/src/sidebar/util/thread-annotations.js
+++ b/src/sidebar/util/thread-annotations.js
@@ -32,7 +32,7 @@ const sortFns = {
 function buildRootThread(threadState) {
   const selection = threadState.selection;
 
-  /** @type {BuildThreadOptions} */
+  /** @type {Partial<BuildThreadOptions>} */
   const options = {
     expanded: selection.expanded,
     forcedVisible: selection.forcedVisible,

--- a/src/sidebar/util/view-filter.js
+++ b/src/sidebar/util/view-filter.js
@@ -191,5 +191,5 @@ export default function filterAnnotations(annotations, filters) {
     .filter(ann => {
       return ann.id && rootFilter.matches(ann);
     })
-    .map(ann => ann.id);
+    .map(ann => /** @type {string} */ (ann.id));
 }

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -20,7 +20,8 @@
  *   @prop {string} [link.rel]
  *   @prop {string} [link.type]
  *   @prop {string} link.href
- * // html pages
+ *
+ * // HTML only.
  * @prop {Object.<string, string[]>} [dc]
  * @prop {Object.<string, string[]>} [eprints]
  * @prop {Object.<string, string[]>} [facebook]
@@ -28,7 +29,8 @@
  * @prop {Object.<string, string[]>} [prism]
  * @prop {Object.<string, string[]>} [twitter]
  * @prop {string} [favicon]
- * // pdf files
+ *
+ * // HTML + PDF.
  * @prop {string} [documentFingerprint]
  */
 

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -43,9 +43,12 @@
  * TODO - Fill out remaining properties
  *
  * @typedef Annotation
- * @prop {string} [id]
- * @prop {string} [$tag] - A locally-generated unique identifier for annotations
- *       that have not been saved to the service yet (and thus do not have an id)
+ * @prop {string} [id] -
+ *   The server-assigned ID for the annotation. This is only set once the
+ *   annotation has been saved to the backend
+ * @prop {string} $tag - A locally-generated unique identifier for annotations.
+ *   This is set for all annotations, whether they have been saved to the backend
+ *   or not.
  * @prop {string[]} [references]
  * @prop {string} created
  * @prop {boolean} [flagged]

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -45,7 +45,7 @@
  * @typedef Annotation
  * @prop {string} [id] -
  *   The server-assigned ID for the annotation. This is only set once the
- *   annotation has been saved to the backend
+ *   annotation has been saved to the backend.
  * @prop {string} $tag - A locally-generated unique identifier for annotations.
  *   This is set for all annotations, whether they have been saved to the backend
  *   or not.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7795,10 +7795,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.5:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 ua-parser-js@0.7.21:
   version "0.7.21"


### PR DESCRIPTION
This PR upgrades TypeScript to v4.0 and fixes issues that the new version complains about.

The major change is that optional properties (ie. `@prop {Thing} [aThing]`) are now treated as being `Thing|undefined` rather than just `Thing`, which means code must check that the property exists before trying to use it. This surfaced various issues such as:

- Properties which were incorrectly marked as optional in JSDoc comments
- Places where a missing optional property was not handled correctly
- Cases where we know an optional property must exist, but for non-trivial reasons that TS isn't aware of (eg. we know that we're dealing with an annotation that has been saved to the server, so the `id` field must be set)

There were also a small number of unrelated changes. See individual commits for more details.

In general I expect that most TS updates will require far fewer changes than this.