### PR TITLE
Very rough POC: PDF Pagefit

### DIFF
--- a/src/annotator/plugin/pdf.coffee
+++ b/src/annotator/plugin/pdf.coffee
@@ -24,8 +24,37 @@ module.exports = class PDF extends Plugin
       subtree: true
     })
 
+    @lastLayoutInfo = {
+      expanded: false
+      width: 0
+      height: 0
+    }
+
+    @boundResizeHandler = @onResize.bind(this)
+
+    window.addEventListener 'resize', @boundResizeHandler
+
+  onResize: ->
+    this.pageFit(@lastLayoutInfo)
+
+  pageFit: (layoutInfo) ->
+    document.getElementById('outerContainer').style.width = window.innerWidth - layoutInfo.width + 'px'
+
+    if @pdfViewer
+      # The code in this block is copied from `webViewerResize` in PDFJS
+      currentScaleValue = @pdfViewer.currentScaleValue
+
+      if (currentScaleValue == "auto" || currentScaleValue == "page-fit" || currentScaleValue == "page-width")
+        @pdfViewer.currentScaleValue = currentScaleValue
+
+      @pdfViewer.update()
+
+    @lastLayoutInfo = layoutInfo
+
+
   destroy: ->
     @pdfViewer.viewer.classList.remove('has-transparent-text-layer')
+    window.removeEventListener 'resize', @boundResizeHandler
     @observer.disconnect()
 
   uri: ->


### PR DESCRIPTION
This is a rough sketch PR to show one general possible approach to implementing PDF page fitting.

This approach dovetails in to some existing "layout-change" logic in the annotator (sidebar) code. It addresses multiple needs:

* Resizing the PDF container when the sidebar layout changes (e.g. the sidebar is opened, closed, or resized)
* Resizing the PDF container when the window size changes

If you try this out and see `TypeError: Cannot read property 'nodeValue' of null` in the console when resizing the window: this is not a regression; it also happens on `master` (i.e. unrelated to these changes).

These changes are small in terms of code changes, but raise several discussion questions that we can talk about together.