### PR TITLE
Implement experimental PDF Side-by-Side feature

### DIFF
--- a/dev-server/templates/client-config.js.mustache
+++ b/dev-server/templates/client-config.js.mustache
@@ -2,6 +2,7 @@
   window.hypothesisConfig = function() {
     return {
       // enableExperimentalNewNoteButton: true,
+      enableExperimentalPDFSideBySide: true,
       // showHighlights: 'always',
       // theme: 'clean',
 

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -22,6 +22,13 @@ export default function configFrom(window_) {
     enableExperimentalNewNoteButton: settings.hostPageSetting(
       'enableExperimentalNewNoteButton'
     ),
+    enableExperimentalPDFSideBySide: settings.hostPageSetting(
+      'enableExperimentalPDFSideBySide',
+      {
+        coerce: toBoolean,
+        defaultValue: false,
+      }
+    ),
     group: settings.group,
     focus: settings.hostPageSetting('focus'),
     theme: settings.hostPageSetting('theme'),

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -104,6 +104,9 @@ module.exports = class Guest extends Delegator
     @crossframe = this.plugins.CrossFrame
 
     @crossframe.onConnect(=> this._setupInitialState(config))
+
+    # Whether clicks on non-highlighted text should close the sidebar
+    this.closeSidebarOnDocumentClick = true
     this._connectAnnotationSync(@crossframe)
     this._connectAnnotationUISync(@crossframe)
 
@@ -445,14 +448,15 @@ module.exports = class Guest extends Delegator
 
   # Did an event originate from an element in the annotator UI? (eg. the sidebar
   # frame, or its toolbar)
-  _isEventInAnnotator: (event) ->
+  isEventInAnnotator: (event) ->
     return closest(event.target, '.annotator-frame') != null
 
   # Event handlers to close the sidebar when the user clicks in the document.
   # These really ought to live with the sidebar code.
   onElementClick: (event) ->
-    if !this._isEventInAnnotator(event) and !@selectedTargets?.length
-      @crossframe?.call('hideSidebar')
+    if this.closeSidebarOnDocumentClick
+      if !this.isEventInAnnotator(event) and !@selectedTargets?.length and not event.annotations?.length
+        @crossframe?.call('hideSidebar')
 
   onElementTouchStart: (event) ->
     # Mobile browsers do not register click events on
@@ -460,8 +464,9 @@ module.exports = class Guest extends Delegator
     # adding that to every element, we can add the initial
     # touchstart event which is always registered to
     # make up for the lack of click support for all elements.
-    if !this._isEventInAnnotator(event) and !@selectedTargets?.length
-      @crossframe?.call('hideSidebar')
+    if this.closeSidebarOnDocumentClick
+      if !this.isEventInAnnotator(event) and !@selectedTargets?.length and not event.annotations?.length
+        @crossframe?.call('hideSidebar')
 
   onHighlightMouseover: (event) ->
     return unless @visibleHighlights

--- a/src/annotator/pdf-sidebar.js
+++ b/src/annotator/pdf-sidebar.js
@@ -1,5 +1,10 @@
 import Sidebar from './sidebar';
 
+/**
+ * @typedef {import('../types/annotator').HypothesisWindow} HypothesisWindow
+ * @typedef {import('./sidebar').LayoutState} LayoutState
+ */
+
 const defaultConfig = {
   TextSelection: {},
   PDF: {},
@@ -12,8 +17,103 @@ const defaultConfig = {
   },
 };
 
+// The viewport and controls for PDF.js start breaking down below about 670px
+// of available space, so only render PDF and sidebar side-by-side if there
+// is enough room. Otherwise, allow sidebar to overlap PDF
+const MIN_PDF_WIDTH = 680;
+
 export default class PdfSidebar extends Sidebar {
   constructor(element, config) {
     super(element, { ...defaultConfig, ...config });
+
+    this._lastSidebarLayoutState = {
+      expanded: false,
+      width: 0,
+      height: 0,
+    };
+
+    this.window = /** @type {HypothesisWindow} */ (window);
+    this.pdfViewer = this.window.PDFViewerApplication?.pdfViewer;
+    this.pdfContainer = this.window.PDFViewerApplication?.appConfig?.appContainer;
+
+    // Prefer to lay out the sidebar and the PDF side-by-side (with the sidebar
+    // not overlapping the PDF) when space allows
+    this.sideBySide = !!(
+      config.enableExperimentalPDFSideBySide &&
+      this.pdfViewer &&
+      this.pdfContainer
+    );
+
+    // Is the current state of the layout side-by-side?
+    this.sideBySideActive = false;
+
+    if (this.sideBySide) {
+      this.subscribe('sidebarLayoutChanged', state =>
+        this.fitSideBySide(state)
+      );
+      this.window.addEventListener('resize', () => this.fitSideBySide());
+    }
+  }
+
+  /**
+   * Set the PDF.js container element to the designated `width` and
+   * activate side-by-side mode.
+   *
+   * @param {number} width - in pixels
+   */
+  activateSideBySide(width) {
+    this.sideBySideActive = true;
+    this.closeSidebarOnDocumentClick = false;
+    this.pdfContainer.style.width = width + 'px';
+    this.pdfContainer.classList.add('hypothesis-side-by-side');
+  }
+
+  /**
+   * Deactivate side-by-side mode and allow PDF.js pages to render at
+   * whatever width the current full-page viewport allows.
+   */
+  deactivateSideBySide() {
+    this.sideBySideActive = false;
+    this.closeSidebarOnDocumentClick = true;
+    this.pdfContainer.style.width = 'auto';
+    this.pdfContainer.classList.remove('hypothesis-side-by-side');
+  }
+
+  /**
+   * Attempt to make the PDF viewer and the sidebar fit side-by-side without
+   * overlap if there is enough room in the viewport to do so reasonably.
+   * Resize the PDF viewer container element to leave the right amount of room
+   * for the sidebar, and prompt PDF.js to re-render the PDF pages to scale
+   * within that resized container.
+   *
+   * @param {LayoutState} [sidebarLayoutState]
+   */
+  fitSideBySide(sidebarLayoutState) {
+    if (!sidebarLayoutState) {
+      sidebarLayoutState = /** @type {LayoutState} */ (this
+        ._lastSidebarLayoutState);
+    }
+    const maximumWidthToFit = this.window.innerWidth - sidebarLayoutState.width;
+    if (sidebarLayoutState.expanded && maximumWidthToFit >= MIN_PDF_WIDTH) {
+      this.activateSideBySide(maximumWidthToFit);
+    } else {
+      this.deactivateSideBySide();
+    }
+
+    // The following logic is pulled from PDF.js `webViewerResize`
+    const currentScaleValue = this.pdfViewer.currentScaleValue;
+    if (
+      currentScaleValue === 'auto' ||
+      currentScaleValue === 'page-fit' ||
+      currentScaleValue === 'page-width'
+    ) {
+      // NB: There is logic within the setter for `currentScaleValue`
+      // Setting this scale value will prompt PDF.js to recalculate viewport
+      this.pdfViewer.currentScaleValue = currentScaleValue;
+    }
+    // This will cause PDF pages to re-render if their scaling has changed
+    this.pdfViewer.update();
+
+    this._lastSidebarLayoutState = sidebarLayoutState;
   }
 }

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -172,10 +172,6 @@ export default class Sidebar extends Host {
    *   opposed to being resized via the sidebar's drag handles
    */
   _notifyOfLayoutChange(expanded) {
-    if (!this.onLayoutChange) {
-      return;
-    }
-
     // The sidebar structure is:
     //
     // [ Toolbar    ][                                   ]
@@ -185,7 +181,7 @@ export default class Sidebar extends Host {
     // The sidebar iframe is hidden or shown by adjusting the left margin of
     // its container.
 
-    const toolbarWidth = this.toolbarWidth || 0;
+    const toolbarWidth = (this.frame && this.toolbar.getWidth()) || 0;
     const frame = this.frame || this.externalFrame;
     const rect = frame[0].getBoundingClientRect();
     const computedStyle = window.getComputedStyle(frame[0]);
@@ -212,11 +208,16 @@ export default class Sidebar extends Host {
       expanded = frameVisibleWidth > toolbarWidth;
     }
 
-    this.onLayoutChange({
+    const layoutState = {
       expanded,
       width: expanded ? frameVisibleWidth : toolbarWidth,
       height: rect.height,
-    });
+    };
+
+    if (this.onLayoutChange) {
+      this.onLayoutChange(layoutState);
+    }
+    this.publish('sidebarLayoutChanged', [layoutState]);
   }
 
   _onPan(event) {

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -8,6 +8,13 @@ import features from './features';
 
 import { ToolbarController } from './toolbar';
 
+/**
+ * @typedef LayoutState
+ * @prop {boolean} expanded
+ * @prop {number} width
+ * @prop {number} height
+ */
+
 // Minimum width to which the frame can be resized.
 const MIN_RESIZE = 280;
 
@@ -208,11 +215,11 @@ export default class Sidebar extends Host {
       expanded = frameVisibleWidth > toolbarWidth;
     }
 
-    const layoutState = {
+    const layoutState = /** @type LayoutState */ ({
       expanded,
       width: expanded ? frameVisibleWidth : toolbarWidth,
       height: rect.height,
-    };
+    });
 
     if (this.onLayoutChange) {
       this.onLayoutChange(layoutState);

--- a/src/annotator/test/guest-test.coffee
+++ b/src/annotator/test/guest-test.coffee
@@ -346,6 +346,17 @@ describe 'Guest', ->
         assert.called(guest[methods[event]])
         assert.calledWith(guest.plugins.CrossFrame.call, 'hideSidebar')
 
+    it 'does not hide sidebar if configured not to close sidebar on document click', ->
+
+      for event in ['click', 'touchstart']
+        sandbox.spy(guest, methods[event])
+        guest.closeSidebarOnDocumentClick = false
+
+        rootElement.dispatchEvent(new Event(event))
+
+        assert.called(guest[methods[event]])
+        assert.notCalled(guest.plugins.CrossFrame.call)
+
     it 'does not hide sidebar if event occurs inside annotator UI', ->
       fakeSidebarFrame = document.createElement('div')
       fakeSidebarFrame.className = 'annotator-frame'

--- a/src/annotator/test/pdf-sidebar-test.js
+++ b/src/annotator/test/pdf-sidebar-test.js
@@ -1,0 +1,234 @@
+import $ from 'jquery';
+
+import PdfSidebar from '../pdf-sidebar';
+import { $imports } from '../pdf-sidebar';
+
+describe('PdfSidebar', () => {
+  const sandbox = sinon.createSandbox();
+  let CrossFrame;
+  let fakeCrossFrame;
+
+  let fakePDFViewerApplication;
+  let fakePDFContainer;
+  let fakePDFViewerUpdate;
+  const sidebarConfig = { pluginClasses: {} };
+
+  const createPdfSidebar = config => {
+    config = { ...sidebarConfig, ...config };
+
+    const element = document.createElement('div');
+    return new PdfSidebar(element, config);
+  };
+
+  beforeEach(() => {
+    sandbox.stub(PdfSidebar.prototype, '_setupGestures');
+    fakePDFContainer = document.createElement('div');
+    fakePDFViewerUpdate = sinon.stub();
+
+    fakePDFViewerApplication = {
+      appConfig: {
+        appContainer: fakePDFContainer,
+      },
+      pdfViewer: {
+        currentScaleValue: 'auto',
+        update: fakePDFViewerUpdate,
+      },
+    };
+    // See https://github.com/sinonjs/sinon/issues/1537
+    // Can't stub an undefined property in a sandbox
+    window.PDFViewerApplication = fakePDFViewerApplication;
+
+    // From `Sidebar.js` tests
+    fakeCrossFrame = {};
+    fakeCrossFrame.onConnect = sandbox.stub().returns(fakeCrossFrame);
+    fakeCrossFrame.on = sandbox.stub().returns(fakeCrossFrame);
+    fakeCrossFrame.call = sandbox.spy();
+    fakeCrossFrame.destroy = sandbox.stub();
+
+    const fakeBucketBar = {};
+    fakeBucketBar.element = $('<div></div>');
+    fakeBucketBar.destroy = sandbox.stub();
+
+    CrossFrame = sandbox.stub();
+    CrossFrame.returns(fakeCrossFrame);
+
+    const BucketBar = sandbox.stub();
+    BucketBar.returns(fakeBucketBar);
+
+    sidebarConfig.pluginClasses.CrossFrame = CrossFrame;
+    sidebarConfig.pluginClasses.BucketBar = BucketBar;
+  });
+
+  afterEach(() => {
+    delete window.PDFViewerApplication;
+    sandbox.restore();
+    $imports.$restore();
+  });
+
+  context('side-by-side mode configured', () => {
+    it('enables side-by-side mode if config and PDF js are present', () => {
+      const sidebar = createPdfSidebar({
+        enableExperimentalPDFSideBySide: true,
+      });
+      assert.isTrue(sidebar.sideBySide);
+    });
+
+    describe('when window is resized', () => {
+      it('attempts to lay out side-by-side', () => {
+        sandbox.stub(window, 'innerWidth').value(1300);
+        const sidebar = createPdfSidebar({
+          enableExperimentalPDFSideBySide: true,
+        });
+
+        window.dispatchEvent(new Event('resize'));
+
+        // PDFSidebar.fitSideBySide is invoked with no argument, so
+        // `sidebar.lastSidebarLayoutState` is used. By default, the sidebar
+        // is not `expanded`, so side-by-side will not activate here (it only
+        // activates if sidebar is `expanded` in its layout state)
+        assert.isFalse(sidebar.sideBySideActive);
+        // However, the PDF container is always updated on a resize
+        assert.calledOnce(fakePDFViewerUpdate);
+      });
+
+      it('resizes and activates side-by-side mode', () => {
+        sandbox.stub(window, 'innerWidth').value(1300);
+        const sidebar = createPdfSidebar({
+          enableExperimentalPDFSideBySide: true,
+        });
+        sidebar._lastSidebarLayoutState = {
+          expanded: true,
+          width: 428,
+          height: 800,
+        };
+
+        window.dispatchEvent(new Event('resize'));
+
+        // Since `sidebar._lastSidebarLayoutState` has `expanded: true`,
+        // side-by-side mode can be activated if there is enough room...
+        assert.isTrue(sidebar.sideBySideActive);
+        assert.calledOnce(fakePDFViewerUpdate);
+        assert.equal(fakePDFContainer.style.width, 1300 - 428 + 'px');
+      });
+
+      it('does not activate side-by-side mode if there is not enough room', () => {
+        sandbox.stub(window, 'innerWidth').value(800);
+        const sidebar = createPdfSidebar({
+          enableExperimentalPDFSideBySide: true,
+        });
+        sidebar._lastSidebarLayoutState = {
+          expanded: true,
+          width: 428,
+          height: 800,
+        };
+
+        window.dispatchEvent(new Event('resize'));
+
+        // Since `sidebar._lastSidebarLayoutState` has `expanded: true`,
+        // side-by-side mode can be activated if there is enough room...
+        assert.isFalse(sidebar.sideBySideActive);
+        assert.calledOnce(fakePDFViewerUpdate);
+        assert.equal(fakePDFContainer.style.width, 'auto');
+      });
+    });
+
+    describe('when sidebar layout state changes', () => {
+      it('resizes and activates side-by-side mode when sidebar expanded', () => {
+        sandbox.stub(window, 'innerWidth').value(1350);
+        const sidebar = createPdfSidebar({
+          enableExperimentalPDFSideBySide: true,
+        });
+
+        sidebar.publish('sidebarLayoutChanged', [
+          { expanded: true, width: 428, height: 728 },
+        ]);
+
+        assert.isTrue(sidebar.sideBySideActive);
+        assert.calledOnce(fakePDFViewerUpdate);
+        assert.equal(fakePDFContainer.style.width, 1350 - 428 + 'px');
+      });
+
+      /**
+       * For each of the relative zoom modes supported by PDF.js, PDFSidebar
+       * should re-set the `currentScale` value, which will prompt PDF.js
+       * to re-calculate the zoom/viewport. Then, `pdfViewer.update()` will
+       * re-render the PDF pages as needed for the dirtied viewport/scaling.
+       * These tests are primarily for test coverage of these zoom modes.
+       */
+      ['auto', 'page-fit', 'page-width'].forEach(zoomMode => {
+        it('activates side-by-side mode for each relative zoom mode', () => {
+          fakePDFViewerApplication.pdfViewer.currentScaleValue = zoomMode;
+          sandbox.stub(window, 'innerWidth').value(1350);
+          const sidebar = createPdfSidebar({
+            enableExperimentalPDFSideBySide: true,
+          });
+
+          sidebar.publish('sidebarLayoutChanged', [
+            { expanded: true, width: 428, height: 728 },
+          ]);
+
+          assert.isTrue(sidebar.sideBySideActive);
+          assert.calledOnce(fakePDFViewerUpdate);
+          assert.equal(fakePDFContainer.style.width, 1350 - 428 + 'px');
+        });
+      });
+
+      it('deactivates side-by-side mode when sidebar collapsed', () => {
+        sandbox.stub(window, 'innerWidth').value(1350);
+        const sidebar = createPdfSidebar({
+          enableExperimentalPDFSideBySide: true,
+        });
+
+        sidebar.publish('sidebarLayoutChanged', [
+          { expanded: false, width: 428, height: 728 },
+        ]);
+
+        assert.isFalse(sidebar.sideBySideActive);
+        assert.equal(fakePDFContainer.style.width, 'auto');
+      });
+
+      it('does not activate side-by-side mode if there is not enough room', () => {
+        sandbox.stub(window, 'innerWidth').value(800);
+        const sidebar = createPdfSidebar({
+          enableExperimentalPDFSideBySide: true,
+        });
+
+        sidebar.publish('sidebarLayoutChanged', [
+          { expanded: true, width: 428, height: 728 },
+        ]);
+
+        assert.isFalse(sidebar.sideBySideActive);
+        assert.calledOnce(fakePDFViewerUpdate);
+        assert.equal(fakePDFContainer.style.width, 'auto');
+      });
+    });
+  });
+
+  context('side-by-side mode not configured', () => {
+    it('does not enable side-by-side mode', () => {
+      const sidebar = createPdfSidebar({});
+
+      assert.isFalse(sidebar.sideBySide);
+    });
+
+    it('does not attempt to resize PDF container on window resize', () => {
+      const sidebar = createPdfSidebar({});
+
+      window.dispatchEvent(new Event('resize'));
+
+      assert.isFalse(sidebar.sideBySideActive);
+      assert.notCalled(fakePDFViewerUpdate);
+    });
+
+    it('does not attempt to resize PDF container on sidebar layout change', () => {
+      const sidebar = createPdfSidebar({});
+
+      sidebar.publish('sidebarLayoutChanged', [
+        { expanded: true, width: 428, height: 728 },
+      ]);
+
+      assert.isFalse(sidebar.sideBySideActive);
+      assert.notCalled(fakePDFViewerUpdate);
+    });
+  });
+});

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -506,14 +506,22 @@ describe('Sidebar', () => {
       });
 
       it('notifies when sidebar changes expanded state', () => {
+        sinon.stub(sidebar, 'publish');
         sidebar.show();
         assert.calledOnce(layoutChangeHandlerSpy);
+        assert.calledOnce(sidebar.publish);
+        assert.calledWith(
+          sidebar.publish,
+          'sidebarLayoutChanged',
+          sinon.match.any
+        );
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
           expanded: true,
         });
 
         sidebar.hide();
         assert.calledTwice(layoutChangeHandlerSpy);
+        assert.calledTwice(sidebar.publish);
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
           expanded: false,
           width: fakeToolbar.getWidth(),

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -78,6 +78,7 @@ $sidebar-collapse-transition-time: 150ms;
     z-index: 2;
   }
 
+  // FIXME:  Use variables for sizing here
   .annotator-frame-button {
     @include focus.outline-on-keyboard-focus;
 

--- a/src/styles/annotator/pdfjs-overrides.scss
+++ b/src/styles/annotator/pdfjs-overrides.scss
@@ -15,3 +15,15 @@
 .textLayer .highlight.selected {
   background-color: rgba(0, 100, 0, 0.5);
 }
+
+// Make sure sidebar bucket bar/toolbar don't obscure PDF JS tools menu
+// This gives enough room for `.annotator-frame-button` which uses a hard-coded
+// width of 30px
+#toolbarViewer {
+  margin-right: 30px;
+}
+
+// The affordance is not needed in side-by-side mode
+.hypothesis-side-by-side #toolbarViewer {
+  margin-right: 0;
+}


### PR DESCRIPTION
This PR is an implementation of the [requested PDF "pagefit" feature](https://github.com/hypothesis/product-backlog/issues/1046), which I'm calling "side-by-side" here for a bit more clarity.

This implementation:

* Builds off of the second sketched approach, putting all of the PDF-side-by-side logic within `PDFSidebar`
* Adds a config setting for activating this side-by-side mode (defaults to `false` at present, but I've set it explicitly to `true` in the devserver client-config defaults for easier testing)
* When configured to do so, the PDF will resize to not be overlapped by the sidebar whenever the sidebar is opened, sidebar is resized, or the window is resized
* Does not apply side-by-side mode if viewport is too small (currently 680px minimum for PDF pages, because PDF.js control layout starts breaking when narrower)
* Does not hide the sidebar on document interactions when side-by-side mode is applied
* Fixes #2372 because the code involved was right in front of me (`Guest` will no longer try to hide the sidebar before showing it when highlighted-text is clicked, eliminating a judder)
* Fixes #2463 because the code was right there...


Fixes #2477