### PR TITLE
Range coffee to js (1/3)

### DIFF
--- a/src/annotator/anchoring/range-browser.js
+++ b/src/annotator/anchoring/range-browser.js
@@ -1,0 +1,24 @@
+/**
+ * Public: Creates a wrapper around a range object obtained from a DOMSelection.
+ */
+export class BrowserRange {
+  /**
+   * Public: Creates an instance of BrowserRange.
+   *
+   * object - A range object obtained via DOMSelection#getRangeAt().
+   *
+   * Examples
+   *
+   *   selection = window.getSelection()
+   *   range = new Range.BrowserRange(selection.getRangeAt(0))
+   *
+   * Returns an instance of BrowserRange.
+   */
+  constructor(obj) {
+    this.commonAncestorContainer = obj.commonAncestorContainer;
+    this.startContainer = obj.startContainer;
+    this.startOffset = obj.startOffset;
+    this.endContainer = obj.endContainer;
+    this.endOffset = obj.endOffset;
+  }
+}

--- a/src/annotator/anchoring/range-browser.js
+++ b/src/annotator/anchoring/range-browser.js
@@ -1,5 +1,5 @@
 /**
- * Public: Creates a wrapper around a range object obtained from a DOMSelection.
+ * Creates a wrapper around a range object obtained from a DOMSelection.
  */
 export class BrowserRange {
   /**

--- a/src/annotator/anchoring/range-normalized.js
+++ b/src/annotator/anchoring/range-normalized.js
@@ -1,0 +1,170 @@
+import $ from 'jquery';
+
+import { xpathFromNode } from './range-js';
+import { SerializedRange } from './range-serialized';
+import { getTextNodes } from './xpath-util';
+
+/**
+ * Public: A normalized range is most commonly used throughout the annotator.
+ * its the result of a deserialized SerializedRange or a BrowserRange with
+ * out browser inconsistencies.
+ */
+export default class NormalizedRange {
+  /**
+   * Public: Creates an instance of a NormalizedRange.
+   *
+   * This is usually created by calling the .normalize() method on one of the
+   * other Range classes rather than manually.
+   *
+   * obj - An Object literal. Should have the following properties.
+   *       commonAncestor: A Element that encompasses both the start and end nodes
+   *       start:          The first TextNode in the range.
+   *       end             The last TextNode in the range.
+   *
+   * Returns an instance of NormalizedRange.
+   */
+  constructor(obj) {
+    this.commonAncestor = obj.commonAncestor;
+    this.start = obj.start;
+    this.end = obj.end;
+  }
+
+  /**
+   * Public: For API consistency.
+   *
+   * Returns itself.
+   */
+  normalize() {
+    return this;
+  }
+
+  /**
+   * Public: Limits the nodes within the NormalizedRange to those contained
+   * withing the bounds parameter. It returns an updated range with all
+   * properties updated. NOTE: Method returns null if all nodes fall outside
+   * of the bounds.
+   *
+   * bounds - An Element to limit the range to.
+   *
+   * Returns updated self or null.
+   */
+  limit(bounds) {
+    const nodes = $.grep(
+      this.textNodes(),
+      node => node.parentNode === bounds || $.contains(bounds, node.parentNode)
+    );
+    if (!nodes.length) {
+      return null;
+    }
+
+    this.start = nodes[0];
+    this.end = nodes[nodes.length - 1];
+
+    const startParents = $(this.start).parents();
+
+    for (let parent of Array.from($(this.end).parents())) {
+      if (startParents.index(parent) !== -1) {
+        this.commonAncestor = parent;
+        break;
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Convert this range into an object consisting of two pairs of (xpath,
+   * character offset), which can be easily stored in a database.
+   *
+   * root -           The root Element relative to which XPaths should be calculated
+   * ignoreSelector - A selector String of elements to ignore. For example
+   *                  elements injected by the annotator.
+   *
+   * Returns an instance of SerializedRange.
+   */
+  serialize(root, ignoreSelector) {
+    const serialization = function (node, isEnd) {
+      let origParent;
+      if (ignoreSelector) {
+        origParent = $(node).parents(`:not(${ignoreSelector})`).eq(0);
+      } else {
+        origParent = $(node).parent();
+      }
+      const xpath = xpathFromNode(origParent, root)[0];
+      const textNodes = getTextNodes(origParent);
+      //console.log('3')
+      // Calculate real offset as the combined length of all the
+      // preceding textNode siblings. We include the length of the
+      // node if it's the end node.
+      const nodes = textNodes.slice(0, textNodes.index(node));
+      let offset = 0;
+      for (let n of Array.from(nodes)) {
+        offset += n.nodeValue.length;
+      }
+
+      if (isEnd) {
+        return [xpath, offset + node.nodeValue.length];
+      } else {
+        return [xpath, offset];
+      }
+    };
+
+    const start = serialization(this.start);
+    const end = serialization(this.end, true);
+
+    return new SerializedRange({
+      // XPath strings
+      start: start[0],
+      end: end[0],
+      // Character offsets (integer)
+      startOffset: start[1],
+      endOffset: end[1],
+    });
+  }
+
+  /**
+   * Public: Creates a concatenated String of the contents of all the text nodes
+   * within the range.
+   *
+   * Returns a String.
+   */
+  text() {
+    return Array.from(this.textNodes())
+      .map(node => node.nodeValue)
+      .join('');
+  }
+
+  /**
+   * Public: Fetches only the text nodes within the range.
+   *
+   * Returns an Array of TextNode instances.
+   */
+  textNodes() {
+    const textNodes = getTextNodes($(this.commonAncestor));
+    const [start, end] = Array.from([
+      textNodes.index(this.start),
+      textNodes.index(this.end),
+    ]);
+    // Return the textNodes that fall between the start and end indexes.
+    return $.makeArray(textNodes.slice(start, +end + 1 || undefined));
+  }
+
+  /**
+   * Public: Converts the Normalized range to a native browser range.
+   *
+   * See: https://developer.mozilla.org/en/DOM/range
+   *
+   * Examples
+   *
+   *   selection = window.getSelection()
+   *   selection.removeAllRanges()
+   *   selection.addRange(normedRange.toRange())
+   *
+   * Returns a Range object.
+   */
+  toRange() {
+    const range = document.createRange();
+    range.setStartBefore(this.start);
+    range.setEndAfter(this.end);
+    return range;
+  }
+}

--- a/src/annotator/anchoring/range-serialized.js
+++ b/src/annotator/anchoring/range-serialized.js
@@ -1,0 +1,25 @@
+/**
+ * Public: A range suitable for storing in local storage or serializing to JSON.
+ */
+
+export class SerializedRange {
+  /**
+   * Public: Creates a SerializedRange
+   *
+   * obj - The stored object. It should have the following properties.
+   *       start:       An xpath to the Element containing the first TextNode
+   *                    relative to the root Element.
+   *       startOffset: The offset to the start of the selection from obj.start.
+   *       end:         An xpath to the Element containing the last TextNode
+   *                    relative to the root Element.
+   *       startOffset: The offset to the end of the selection from obj.end.
+   *
+   * Returns an instance of SerializedRange
+   */
+  constructor(obj) {
+    this.start = obj.start;
+    this.startOffset = obj.startOffset;
+    this.end = obj.end;
+    this.endOffset = obj.endOffset;
+  }
+}

--- a/src/annotator/anchoring/test/range-browser-test.js
+++ b/src/annotator/anchoring/test/range-browser-test.js
@@ -1,0 +1,41 @@
+import { BrowserRange } from '../range-browser';
+
+describe('annotator/anchoring/range-browser', () => {
+  let container;
+  const html = `
+      <section id="section-1">
+        <p id="p-1">text 1</p>
+        <p id="p-2">text 2</p>
+        <span id="span-1">
+          <p id="p-3">text 3</p>
+        </span>
+      </section>
+      <span id="span-2"></span>`;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    container.innerHTML = html;
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  function createRange(props) {
+    return new BrowserRange({
+      commonAncestorContainer: container,
+      startContainer: container.querySelector('#p-1').firstChild,
+      startOffset: 0,
+      endContainer: container.querySelector('#p-3').firstChild,
+      endOffset: 0,
+      ...props,
+    });
+  }
+
+  describe('BrowserRange', () => {
+    it('creates a BrowserRange instance', () => {
+      createRange();
+    });
+  });
+});

--- a/src/annotator/anchoring/test/range-normalized-test.js
+++ b/src/annotator/anchoring/test/range-normalized-test.js
@@ -1,0 +1,157 @@
+import NormalizedRange, { $imports } from '../range-normalized';
+
+describe('annotator/anchoring/range-normalized', () => {
+  describe('NormalizedRange', () => {
+    let container;
+    const html = `
+        <section id="section-1">
+          <p id="p-1">text 1</p>
+          <p id="p-2">text 2</p>
+          <span id="span-1">
+            <p id="p-3">text 3</p>
+          </span>
+        </section>
+        <span id="span-2"></span>`;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+      container.innerHTML = html;
+    });
+
+    afterEach(() => {
+      container.remove();
+    });
+
+    function createRange(props) {
+      return new NormalizedRange({
+        commonAncestor: container,
+        start: container.querySelector('#p-1').firstChild,
+        end: container.querySelector('#p-3').firstChild,
+        ...props,
+      });
+    }
+
+    describe('#normalize', () => {
+      it('return an instance of itself', () => {
+        const range = createRange();
+        assert.deepEqual(range, range.normalize());
+      });
+    });
+
+    describe('#limit', () => {
+      it('does not limit range if the limit node resides outside of bounds', () => {
+        const limit = createRange().limit(container.querySelector('#span-2'));
+        assert.isNull(limit);
+      });
+
+      [
+        {
+          bound: '#p-1',
+          textNodes: ['text 1'],
+        },
+        {
+          bound: '#p-2',
+          textNodes: ['text 2'],
+        },
+        {
+          bound: '#section-1',
+          textNodes: [
+            'text 1',
+            '\n          ',
+            'text 2',
+            '\n          ',
+            '\n            ',
+            'text 3',
+          ],
+        },
+      ].forEach(test => {
+        it('limits range to the bounding node', () => {
+          let limit = createRange().limit(container.querySelector(test.bound));
+          assert.equal(limit.text(), test.textNodes.join(''));
+          // To get a node value from jquery, use ".data".
+          assert.deepEqual(
+            test.textNodes,
+            limit.textNodes().map(n => n.data)
+          );
+        });
+      });
+    });
+
+    describe('#toRange', () => {
+      let fakeSetStartBefore;
+      let fakeSetEndAfter;
+
+      beforeEach(() => {
+        sinon.stub(document, 'createRange');
+        fakeSetStartBefore = sinon.stub();
+        fakeSetEndAfter = sinon.stub();
+        document.createRange.returns({
+          setStartBefore: fakeSetStartBefore,
+          setEndAfter: fakeSetEndAfter,
+        });
+      });
+      afterEach(() => {
+        document.createRange.restore();
+      });
+
+      it('converts normalized range to native range', () => {
+        const range = createRange();
+        const nativeRange = range.toRange();
+        assert.deepEqual(nativeRange, document.createRange());
+        assert.calledWith(fakeSetStartBefore, range.start);
+        assert.calledWith(fakeSetEndAfter, range.end);
+      });
+    });
+
+    describe('#serialize', () => {
+      let fakeSerializedRange;
+
+      beforeEach(() => {
+        fakeSerializedRange = sinon.stub();
+        $imports.$mock({
+          './range-serialized': {
+            SerializedRange: fakeSerializedRange,
+          },
+        });
+      });
+
+      afterEach(() => {
+        $imports.$restore();
+      });
+
+      it('serialize the range with a relative parent', () => {
+        const range = createRange();
+        range.serialize(container);
+        assert.calledWith(fakeSerializedRange, {
+          start: '/section[1]/p[1]',
+          end: '/section[1]/span[1]/p[1]',
+          startOffset: 0,
+          endOffset: 6,
+        });
+      });
+
+      it('serialize the range with no relative parent', () => {
+        const range = createRange();
+        range.serialize();
+        assert.calledWith(fakeSerializedRange, {
+          start: '/html[1]/body[1]/div[1]/section[1]/p[1]',
+          end: '/html[1]/body[1]/div[1]/section[1]/span[1]/p[1]',
+          startOffset: 0,
+          endOffset: 6,
+        });
+      });
+
+      it('serialize the range with an `ignoreSelector`', () => {
+        const range = createRange();
+        range.serialize(container, '#p-3');
+        assert.calledWith(fakeSerializedRange, {
+          start: '/section[1]/p[1]',
+          end: '/section[1]/span[1]',
+          startOffset: 0,
+          endOffset: 19,
+        });
+      });
+    });
+  });
+});

--- a/src/annotator/anchoring/test/range-serialized-test.js
+++ b/src/annotator/anchoring/test/range-serialized-test.js
@@ -1,0 +1,40 @@
+import { SerializedRange } from '../range-serialized';
+
+describe('annotator/anchoring/range-serialized', () => {
+  let container;
+  const html = `
+      <section id="section-1">
+        <p id="p-1">text 1</p>
+        <p id="p-2">text 2</p>
+        <span id="span-1">
+          <p id="p-3">text 3</p>
+        </span>
+      </section>
+      <span id="span-2"></span>`;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    container.innerHTML = html;
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  function createRange(props) {
+    return new SerializedRange({
+      start: container.querySelector('#p-1').firstChild,
+      startOffset: 0,
+      end: container.querySelector('#p-3').firstChild,
+      endOffset: 0,
+      ...props,
+    });
+  }
+
+  describe('SerializedRange', () => {
+    it('creates a SerializedRange instance', () => {
+      createRange();
+    });
+  });
+});


### PR DESCRIPTION
- Separate each range class into its own module. There is a circular dependency among the 3 range modules which is handled with an inline require() statement in range-browser.
- Eliminate the custom RangeError class from coffeescript and just use native RangeError
- Add unit tests for range-normalized

--------

This is phase 1/3, The `range-browser` and range-serialized are minimally stubbed out. The next two PRs will fill those modules in & their new unit tests. Note that none of these modules are actually hooked up to any code that runs and only the units tests run. After `range.coffee` is totally converted, I'll create a final PR to hook up this block of work in code. I do have a temporary branch that is indeed hooked up to simply ensure the app does appear to build, run and all tests work (most importantly the `html-test` and `pdf-test` files. So I know this conversion is at least in theory working. But for this PR, only the unit tests matter at this point. Don't worry about totally integration.

**Notes**
- The module names are prefixed with `range-` so they appear in order in the file view. Note that the classes names are inverted for legacy reasons. We could change that I kept it the same for the conversion.
- The code is largely directly ported from coffeescript as are the comments.
- Type checking will be done in a later pass
