### PR TITLE
Restructure `experimental` config for newly-added experimental features

### DIFF
--- a/dev-server/templates/client-config.js.mustache
+++ b/dev-server/templates/client-config.js.mustache
@@ -2,7 +2,9 @@
   window.hypothesisConfig = function() {
     return {
       // enableExperimentalNewNoteButton: true,
-      enableExperimentalPDFSideBySide: true,
+      experimental: {
+        pdfSideBySide: true,
+      },
       // showHighlights: 'always',
       // theme: 'clean',
 

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -22,13 +22,9 @@ export default function configFrom(window_) {
     enableExperimentalNewNoteButton: settings.hostPageSetting(
       'enableExperimentalNewNoteButton'
     ),
-    enableExperimentalPDFSideBySide: settings.hostPageSetting(
-      'enableExperimentalPDFSideBySide',
-      {
-        coerce: toBoolean,
-        defaultValue: false,
-      }
-    ),
+    experimental: settings.hostPageSetting('experimental', {
+      defaultValue: {},
+    }),
     group: settings.group,
     focus: settings.hostPageSetting('focus'),
     theme: settings.hostPageSetting('theme'),

--- a/src/annotator/pdf-sidebar.js
+++ b/src/annotator/pdf-sidebar.js
@@ -39,7 +39,7 @@ export default class PdfSidebar extends Sidebar {
     // Prefer to lay out the sidebar and the PDF side-by-side (with the sidebar
     // not overlapping the PDF) when space allows
     this.sideBySide = !!(
-      config.enableExperimentalPDFSideBySide &&
+      config.experimental?.pdfSideBySide &&
       this.pdfViewer &&
       this.pdfContainer
     );

--- a/src/annotator/test/pdf-sidebar-test.js
+++ b/src/annotator/test/pdf-sidebar-test.js
@@ -68,7 +68,9 @@ describe('PdfSidebar', () => {
   context('side-by-side mode configured', () => {
     it('enables side-by-side mode if config and PDF js are present', () => {
       const sidebar = createPdfSidebar({
-        enableExperimentalPDFSideBySide: true,
+        experimental: {
+          pdfSideBySide: true,
+        },
       });
       assert.isTrue(sidebar.sideBySide);
     });
@@ -77,7 +79,9 @@ describe('PdfSidebar', () => {
       it('attempts to lay out side-by-side', () => {
         sandbox.stub(window, 'innerWidth').value(1300);
         const sidebar = createPdfSidebar({
-          enableExperimentalPDFSideBySide: true,
+          experimental: {
+            pdfSideBySide: true,
+          },
         });
 
         window.dispatchEvent(new Event('resize'));
@@ -94,7 +98,9 @@ describe('PdfSidebar', () => {
       it('resizes and activates side-by-side mode', () => {
         sandbox.stub(window, 'innerWidth').value(1300);
         const sidebar = createPdfSidebar({
-          enableExperimentalPDFSideBySide: true,
+          experimental: {
+            pdfSideBySide: true,
+          },
         });
         sidebar._lastSidebarLayoutState = {
           expanded: true,
@@ -114,7 +120,9 @@ describe('PdfSidebar', () => {
       it('does not activate side-by-side mode if there is not enough room', () => {
         sandbox.stub(window, 'innerWidth').value(800);
         const sidebar = createPdfSidebar({
-          enableExperimentalPDFSideBySide: true,
+          experimental: {
+            pdfSideBySide: true,
+          },
         });
         sidebar._lastSidebarLayoutState = {
           expanded: true,
@@ -136,7 +144,9 @@ describe('PdfSidebar', () => {
       it('resizes and activates side-by-side mode when sidebar expanded', () => {
         sandbox.stub(window, 'innerWidth').value(1350);
         const sidebar = createPdfSidebar({
-          enableExperimentalPDFSideBySide: true,
+          experimental: {
+            pdfSideBySide: true,
+          },
         });
 
         sidebar.publish('sidebarLayoutChanged', [
@@ -160,7 +170,9 @@ describe('PdfSidebar', () => {
           fakePDFViewerApplication.pdfViewer.currentScaleValue = zoomMode;
           sandbox.stub(window, 'innerWidth').value(1350);
           const sidebar = createPdfSidebar({
-            enableExperimentalPDFSideBySide: true,
+            experimental: {
+              pdfSideBySide: true,
+            },
           });
 
           sidebar.publish('sidebarLayoutChanged', [
@@ -176,7 +188,9 @@ describe('PdfSidebar', () => {
       it('deactivates side-by-side mode when sidebar collapsed', () => {
         sandbox.stub(window, 'innerWidth').value(1350);
         const sidebar = createPdfSidebar({
-          enableExperimentalPDFSideBySide: true,
+          experimental: {
+            pdfSideBySide: true,
+          },
         });
 
         sidebar.publish('sidebarLayoutChanged', [
@@ -190,7 +204,9 @@ describe('PdfSidebar', () => {
       it('does not activate side-by-side mode if there is not enough room', () => {
         sandbox.stub(window, 'innerWidth').value(800);
         const sidebar = createPdfSidebar({
-          enableExperimentalPDFSideBySide: true,
+          experimental: {
+            pdfSideBySide: true,
+          },
         });
 
         sidebar.publish('sidebarLayoutChanged', [


### PR DESCRIPTION
For features going forward, nest in a single `experimental` object so
that `experimental` features can be white-flagged in one go in, e.g.,
via

---

This work is part of getting PDFSideBySide mode whitelisted on `via3` and `via`. It puts `experimental` features in a single object. I've left `enableExperimentalNewNoteButton` alone because it's still used externally.

Part of https://github.com/hypothesis/product-backlog/issues/1046