### PR TITLE
Update tag-editor suggested-tag list, keyboard behaviors

### DIFF
--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -10,6 +10,8 @@ import { normalizeKeyName } from '../../shared/browser-compatibility-utils';
 import SvgIcon from '../../shared/components/svg-icon';
 import useElementShouldClose from './hooks/use-element-should-close';
 
+/** @typedef {import("preact").JSX.Element} JSXElement */
+
 // Global counter used to create a unique id for each instance of a TagEditor
 let tagEditorIdCounter = 0;
 
@@ -233,6 +235,28 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
     }
   };
 
+  /**
+   * Callback for formatting a suggested tag item. Use selective bolding
+   * to help delineate which part of the entered tag text matches the
+   * suggestion.
+   *
+   * @param {string} item - Suggested tag
+   * @return {JSXElement} - Formatted tag for use in list
+   */
+  const formatSuggestItem = item => {
+    const curVal = inputEl.current.value.trim();
+    const prefix = item.slice(0, item.indexOf(curVal));
+    const suffix = item.slice(item.indexOf(curVal) + curVal.length);
+
+    return (
+      <span>
+        <strong>{prefix}</strong>
+        {curVal}
+        <strong>{suffix}</strong>
+      </span>
+    );
+  };
+
   // The activedescendant prop should match the activeItem's value except
   // when its -1 (no item selected), and in this case set the activeDescendant to "".
   const activeDescendant =
@@ -299,6 +323,7 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
         <AutocompleteList
           id={`${tagEditorId}-autocomplete-list`}
           list={suggestions}
+          listFormatter={formatSuggestItem}
           open={suggestionsListOpen}
           onSelectItem={handleSelect}
           itemPrefixId={`${tagEditorId}-autocomplete-list-item-`}

--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -84,7 +84,6 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
       setSuggestions(removeDuplicates(suggestions, tagList));
       setSuggestionsListOpen(suggestions.length > 0);
     }
-
     setActiveItem(-1);
   };
 
@@ -194,44 +193,63 @@ function TagEditor({ onEditTags, tags: tagsService, tagList }) {
   };
 
   /**
-   * Keydown handler for keyboard navigation of the suggestions list
-   * and when the user presses "Enter" or ","" to add a new typed item not
-   * found in the suggestions list
+   * Keydown handler for keyboard navigation of the tag editor field and the
+   * suggested-tags list.
    *
    * @param {KeyboardEvent} e
    */
   const handleKeyDown = e => {
     switch (normalizeKeyName(e.key)) {
       case 'ArrowUp':
+        // Select the previous item in the suggestion list
         changeSelectedItem(-1);
         e.preventDefault();
         break;
       case 'ArrowDown':
+        // Select the next item in the suggestion list
         changeSelectedItem(1);
+        e.preventDefault();
+        break;
+      case 'Escape':
+        // Clear any entered text, but retain focus
+        inputEl.current.value = '';
         e.preventDefault();
         break;
       case 'Enter':
       case ',':
+        // Commit a tag
         if (activeItem === -1) {
           // nothing selected, just add the typed text
           addTag(/** @type {HTMLInputElement} */ (inputEl.current).value);
         } else {
+          // Add the selected tag
           addTag(suggestions[activeItem]);
         }
         e.preventDefault();
         break;
       case 'Tab':
-        if (activeItem !== -1) {
-          // If there is a selected item, then allow `Tab` to behave exactly
-          // like `Enter` or `,`.
-          addTag(suggestions[activeItem]);
-          e.preventDefault();
-        } else if (suggestionsListOpen) {
-          // If there is no selected item, then allow `Tab` to add the first
-          // item in the list if the list is open.
-          addTag(suggestions[0]);
-          e.preventDefault();
+        // Commit a tag, or tab out of the field if it is empty (default browser
+        // behavior)
+        if (inputEl.current.value.trim() === '') {
+          // If the tag field is empty, allow `Tab` to have its default
+          // behavior: continue to the next element in tab order
+          break;
         }
+        if (activeItem !== -1) {
+          // If there is a selected item in the suggested tag list,
+          // commit that tag (just like `Enter` and `,` in this case)
+          addTag(suggestions[activeItem]);
+        } else if (suggestions.length === 1) {
+          // If there is exactly one suggested tag match, commit that tag
+          // This emulates a "tab-complete" behavior
+          addTag(suggestions[0]);
+        } else {
+          // Commit the tag as typed in the field
+          addTag(/** @type {HTMLInputElement} */ (inputEl.current).value);
+        }
+        // Retain focus
+        e.preventDefault();
+        break;
     }
   };
 

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -27,8 +27,15 @@ export default function tags(localStorage) {
   function filter(query, limit = null) {
     const savedTags = localStorage.getObject(TAGS_LIST_KEY) || [];
     let resultCount = 0;
-    return savedTags.filter(e => {
-      if (e.toLowerCase().indexOf(query.toLowerCase()) !== -1) {
+    // query will match tag if:
+    // * tag starts with query (e.g. tag "banana" matches query "ban"), OR
+    // * any word in the tag starts with query
+    //   (e.g. tag "pink banana" matches query "ban"), OR
+    // * tag has substring query occurring after a non-word character
+    //   (e.g. tag "pink!banana" matches query "ban")
+    let regex = new RegExp('(\\W|\\b)' + query, 'i');
+    return savedTags.filter(tag => {
+      if (tag.match(regex)) {
         if (limit === null || resultCount < limit) {
           // limit allows a subset of the results
           // See https://github.com/hypothesis/client/issues/1606

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -17,7 +17,7 @@ class FakeStorage {
   }
 }
 
-describe('sidebar.tags', () => {
+describe('sidebar/services/tags', () => {
   let fakeLocalStorage;
   let tags;
 
@@ -34,6 +34,16 @@ describe('sidebar.tags', () => {
       bar: {
         text: 'bar',
         count: 5,
+        updated: stamp,
+      },
+      'bar argon': {
+        text: 'bar argon',
+        count: 2,
+        updated: stamp,
+      },
+      banana: {
+        text: 'banana',
+        count: 2,
         updated: stamp,
       },
       future: {
@@ -56,18 +66,22 @@ describe('sidebar.tags', () => {
   });
 
   describe('#filter', () => {
-    it('returns tags having the query as a substring', () => {
-      assert.deepEqual(tags.filter('a'), ['bar', 'argon']);
+    it('returns tags that start with the query string', () => {
+      assert.deepEqual(tags.filter('b'), ['bar', 'bar argon', 'banana']);
+    });
+
+    it('returns tags that have any word starting with the query string', () => {
+      assert.deepEqual(tags.filter('ar'), ['bar argon', 'argon']);
     });
 
     it('is case insensitive', () => {
-      assert.deepEqual(tags.filter('Ar'), ['bar', 'argon']);
+      assert.deepEqual(tags.filter('Ar'), ['bar argon', 'argon']);
     });
 
     it('limits tags when provided a limit value', () => {
-      assert.deepEqual(tags.filter('r', 1), ['bar']);
-      assert.deepEqual(tags.filter('r', 2), ['bar', 'future']);
-      assert.deepEqual(tags.filter('r', 3), ['bar', 'future', 'argon']);
+      assert.deepEqual(tags.filter('b', 1), ['bar']);
+      assert.deepEqual(tags.filter('b', 2), ['bar', 'bar argon']);
+      assert.deepEqual(tags.filter('b', 3), ['bar', 'bar argon', 'banana']);
     });
   });
 
@@ -101,7 +115,14 @@ describe('sidebar.tags', () => {
       }
 
       const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
-      assert.deepEqual(storedTagsList, ['foo', 'bar', 'future', 'argon']);
+      assert.deepEqual(storedTagsList, [
+        'foo',
+        'bar',
+        'banana',
+        'bar argon',
+        'future',
+        'argon',
+      ]);
     });
   });
 });


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/1122

This PR adjusts some details of the way that suggested tags are filtered and presented in the tag editor, and adjusts some keyboard behaviors to improve overall UX feel. I'm opening this as a separate PR from the remaining (main) item in https://github.com/hypothesis/product-backlog/issues/1122, which is adding any uncommitted tag remaining in the tag-editor text field when the annotation is saved. Alas, that turns out to be hard, or at least fiddly, requiring some refactor across multiple components. So I'll corral it into its own branch/PR.

## Changes to suggested tag list filtering

I'll paste from the commit message here: 

```
Suggested tag matching should not use lookback

Change the matching logic for determining whether a given suggested tag
(`tag`) matches the currently-typed tag field text (`query`).

Formerly, `tag` would match `query` if `tag` were a substring of `query` in any position. However, this creates a lot of noise in the matches and is not commonly what folks are after.

Now, `tag` will match `query` if:

* `tag` starts with `query` OR
* `query` occurs within `tag` after a word boundary or a non-word
   character

Thus, a `query` of "app":

* Would match the `tag` "apple"
* Would match the `tag` "crab apple" ("app" occurs after a word boundary)
* Would match the `tag` "crab.apple" ("app" occurs after non-word char)
* Would NOT match the `tag` "crabapple"
```

### Before

![before-tag-suggestion](https://user-images.githubusercontent.com/439947/92023635-02870080-ed2b-11ea-8f37-eb9d57904fbc.gif)

### After

![after-tag-suggestion](https://user-images.githubusercontent.com/439947/92023646-09ae0e80-ed2b-11ea-892a-75545fbf6c5f.gif)

## Changes to suggested tag list formatting

Shamelessly cribbed from some of the bigger web properties out there: selective bolding to help users see what part of their entered text matches suggested tags. You can see it in the after video above, and also in this still screenshot:

<img width="419" alt="after-tag-suggestion-2" src="https://user-images.githubusercontent.com/439947/92023768-38c48000-ed2b-11ea-9934-d5f4e419b621.png">

## Keyboard interaction changes

| Key        | Additional Context                               | Behavior Before                           | Behavior After                                    | Change    |
| ---------- | ------------------------------------------------ | ----------------------------------------- | ------------------------------------------------- | --------- |
| Down Arrow | When suggested tags available                    | Select next tag in suggested tag list     | Select next tag in suggested tag list             | UNCHANGED |
| Up Arrow   | When suggested tags available                    | Select previous tag in suggested tag list | Select previous tag in suggested tag list         | UNCHANGED |
| `Escape`   | --                                               | --                                        | Clears content of field but retains focus         | NEW       |
| `Enter`    | Tag has been selected in the suggested tags list | Commit suggested tag                      | Commit suggested tag                              | UNCHANGED |
| `Enter`    | No tag selected from suggested tags list         | Commit typed contents of field as tag     | Commit typed contents of field as tag             | UNCHANGED |
| `,`        | Tag has been selected in the suggested tags list | Commit suggested tag                      | Commit suggested tag                              | UNCHANGED |
| `,`        | No tag selected from suggested tags list         | Commit typed contents of field as tag     | Commit typed contents of field as tag             | UNCHANGED |
| `Tab`      | field empty                                      | --                                        | Allow default browser behavior (tab out of field) | NEW       |
| `Tab`      | Tag has been selected in the suggested tags list | Commit suggested tag                      | Commit suggested tag                              | UNCHANGED |
| `Tab`      | Exactly one suggested tag                        | Commit suggested tag                      | Commit suggested tag                              | UNCHANGED |
| `Tab`      | Multiple suggested tags, none selected           | Commit first suggested tag                | Commit typed contents of field as tag             | CHANGED   |
