### PR TITLE
Remove jQuery usage in `Host` and `Sidebar` classes

### DIFF
--- a/src/annotator/host.js
+++ b/src/annotator/host.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 // TODO - Convert this to an ES import once the `Guest` class is converted to JS.
 // @ts-expect-error
 const Guest = require('./guest');
@@ -44,15 +42,15 @@ export default class Host extends Guest {
 
     const sidebarAppSrc = config.sidebarAppUrl + '#' + configParam;
 
-    // Create the iframe
-    const app = $('<iframe></iframe>')
-      .attr('name', 'hyp_sidebar_frame')
-      // enable media in annotations to be shown fullscreen
-      .attr('allowfullscreen', '')
-      .attr('seamless', '')
-      .attr('src', sidebarAppSrc)
-      .attr('title', 'Hypothesis annotation viewer')
-      .addClass('h-sidebar-iframe');
+    // Create the sidebar iframe
+    const sidebarFrame = document.createElement('iframe');
+    sidebarFrame.setAttribute('name', 'hyp_sidebar_frame');
+    // Enable media in annotations to be shown fullscreen
+    sidebarFrame.setAttribute('allowfullscreen', '');
+    sidebarFrame.setAttribute('seamless', '');
+    sidebarFrame.src = sidebarAppSrc;
+    sidebarFrame.title = 'Hypothesis annotation viewer';
+    sidebarFrame.className = 'h-sidebar-iframe';
 
     let externalContainer = null;
 
@@ -67,17 +65,17 @@ export default class Host extends Guest {
     let frame;
 
     if (externalContainer) {
-      externalFrame = $(externalContainer);
+      externalFrame = externalContainer;
     } else {
-      frame = $('<div></div>')
-        .css('display', 'none')
-        .addClass('annotator-frame annotator-outer');
+      frame = document.createElement('div');
+      frame.style.display = 'none';
+      frame.className = 'annotator-frame annotator-outer';
 
       if (config.theme === 'clean') {
-        frame.addClass('annotator-frame--drop-shadow-enabled');
+        frame.classList.add('annotator-frame--drop-shadow-enabled');
       }
 
-      frame.appendTo(element);
+      element.appendChild(frame);
     }
 
     // FIXME: We have to call the parent constructor here instead of at the top
@@ -88,12 +86,13 @@ export default class Host extends Guest {
 
     this.externalFrame = externalFrame;
     this.frame = frame;
-
-    app.appendTo(this.frame || this.externalFrame);
+    (frame || externalFrame).appendChild(sidebarFrame);
 
     this.on('panelReady', () => {
       // Show the UI
-      this.frame?.css('display', '');
+      if (this.frame) {
+        this.frame.style.display = '';
+      }
     });
 
     this.on('beforeAnnotationCreated', annotation => {
@@ -101,7 +100,7 @@ export default class Host extends Guest {
       // the sidebar so that the text editor can be focused as
       // soon as the annotation card appears
       if (!annotation.$highlight) {
-        app[0].contentWindow.focus();
+        /** @type {Window} */ (sidebarFrame.contentWindow).focus();
       }
     });
   }

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -150,12 +150,15 @@ export default class Sidebar extends Host {
     this.renderFrame = requestAnimationFrame(() => {
       this.renderFrame = null;
 
-      if (this._gestureState.final !== this._gestureState.initial) {
+      if (
+        this._gestureState.final !== this._gestureState.initial &&
+        this.frame
+      ) {
         const margin = /** @type {number} */ (this._gestureState.final);
         const width = -margin;
-        this.frame.css('margin-left', `${margin}px`);
+        this.frame.style.marginLeft = `${margin}px`;
         if (width >= MIN_RESIZE) {
-          this.frame.css('width', `${width}px`);
+          this.frame.style.width = `${width}px`;
         }
         this._notifyOfLayoutChange();
       }
@@ -181,8 +184,8 @@ export default class Sidebar extends Host {
 
     const toolbarWidth = (this.frame && this.toolbar.getWidth()) || 0;
     const frame = this.frame || this.externalFrame;
-    const rect = frame[0].getBoundingClientRect();
-    const computedStyle = window.getComputedStyle(frame[0]);
+    const rect = frame.getBoundingClientRect();
+    const computedStyle = window.getComputedStyle(frame);
     const width = parseInt(computedStyle.width);
     const leftMargin = parseInt(computedStyle.marginLeft);
 
@@ -219,7 +222,8 @@ export default class Sidebar extends Host {
   }
 
   _onPan(event) {
-    if (!this.frame) {
+    const frame = this.frame;
+    if (!frame) {
       return;
     }
 
@@ -228,21 +232,21 @@ export default class Sidebar extends Host {
         this._resetGestureState();
 
         // Disable animated transition of sidebar position
-        this.frame.addClass('annotator-no-transition');
+        frame.classList.add('annotator-no-transition');
 
         // Disable pointer events on the iframe.
-        this.frame.css('pointer-events', 'none');
+        frame.style.pointerEvents = 'none';
 
         this._gestureState.initial = parseInt(
-          getComputedStyle(this.frame[0]).marginLeft
+          getComputedStyle(frame).marginLeft
         );
 
         break;
       case 'panend':
-        this.frame.removeClass('annotator-no-transition');
+        frame.classList.remove('annotator-no-transition');
 
         // Re-enable pointer events on the iframe.
-        this.frame.css('pointer-events', '');
+        frame.style.pointerEvents = '';
 
         // Snap open or closed.
         if (
@@ -274,8 +278,9 @@ export default class Sidebar extends Host {
     this.crossframe.call('sidebarOpened');
 
     if (this.frame) {
-      this.frame.css('margin-left', `${-1 * this.frame.width()}px`);
-      this.frame.removeClass('annotator-collapsed');
+      const width = this.frame.getBoundingClientRect().width;
+      this.frame.style.marginLeft = `${-1 * width}px`;
+      this.frame.classList.remove('annotator-collapsed');
     }
 
     this.toolbar.sidebarOpen = true;
@@ -289,8 +294,8 @@ export default class Sidebar extends Host {
 
   hide() {
     if (this.frame) {
-      this.frame.css('margin-left', '');
-      this.frame.addClass('annotator-collapsed');
+      this.frame.style.marginLeft = '';
+      this.frame.classList.add('annotator-collapsed');
     }
 
     this.toolbar.sidebarOpen = false;
@@ -304,7 +309,7 @@ export default class Sidebar extends Host {
 
   isOpen() {
     if (this.frame) {
-      return !this.frame.hasClass('annotator-collapsed');
+      return !this.frame.classList.contains('annotator-collapsed');
     } else {
       // Assume an external frame is always open.
       return true;

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -307,15 +307,6 @@ export default class Sidebar extends Host {
     this._notifyOfLayoutChange(false);
   }
 
-  isOpen() {
-    if (this.frame) {
-      return !this.frame.classList.contains('annotator-collapsed');
-    } else {
-      // Assume an external frame is always open.
-      return true;
-    }
-  }
-
   /**
    * Hide or show highlights associated with annotations in the document.
    *

--- a/src/annotator/test/host-test.js
+++ b/src/annotator/test/host-test.js
@@ -40,13 +40,13 @@ describe('Host', () => {
   describe('widget visibility', () => {
     it('starts hidden', () => {
       const host = createHost();
-      assert.equal(host.frame.css('display'), 'none');
+      assert.equal(host.frame.style.display, 'none');
     });
 
     it('becomes visible when the "panelReady" event fires', () => {
       const host = createHost();
       host.publish('panelReady');
-      assert.equal(host.frame.css('display'), '');
+      assert.equal(host.frame.style.display, '');
     });
   });
 
@@ -98,7 +98,7 @@ describe('Host', () => {
     });
 
     function getConfigString(host) {
-      return host.frame[0].children[0].src;
+      return host.frame.children[0].src;
     }
 
     function configFragment(config) {
@@ -120,7 +120,7 @@ describe('Host', () => {
     it('adds drop shadow if the clean theme is enabled', () => {
       const host = createHost({ theme: 'clean' });
       assert.isTrue(
-        host.frame.hasClass('annotator-frame--drop-shadow-enabled')
+        host.frame.classList.contains('annotator-frame--drop-shadow-enabled')
       );
     });
   });

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -276,8 +276,10 @@ describe('Sidebar', () => {
       it('disables pointer events and transitions on the widget', () => {
         sidebar._onPan({ type: 'panstart' });
 
-        assert.isTrue(sidebar.frame.hasClass('annotator-no-transition'));
-        assert.equal(sidebar.frame.css('pointer-events'), 'none');
+        assert.isTrue(
+          sidebar.frame.classList.contains('annotator-no-transition')
+        );
+        assert.equal(sidebar.frame.style.pointerEvents, 'none');
       });
 
       it('captures the left margin as the gesture initial state', () => {
@@ -293,8 +295,10 @@ describe('Sidebar', () => {
       it('enables pointer events and transitions on the widget', () => {
         sidebar._gestureState = { final: 0 };
         sidebar._onPan({ type: 'panend' });
-        assert.isFalse(sidebar.frame.hasClass('annotator-no-transition'));
-        assert.equal(sidebar.frame.css('pointer-events'), '');
+        assert.isFalse(
+          sidebar.frame.classList.contains('annotator-no-transition')
+        );
+        assert.equal(sidebar.frame.style.pointerEvents, '');
       });
 
       it('calls `show` if the widget is fully visible', () => {
@@ -379,7 +383,7 @@ describe('Sidebar', () => {
     it('the sidebar is destroyed and the frame is detached', () => {
       sidebar.destroy();
       assert.called(fakeCrossFrame.destroy);
-      assert.equal(sidebar.frame[0].parentElement, null);
+      assert.equal(sidebar.frame.parentElement, null);
     });
   });
 
@@ -472,7 +476,7 @@ describe('Sidebar', () => {
         // remove info about call that happens on creation of sidebar
         layoutChangeHandlerSpy.reset();
 
-        frame = sidebar.frame[0];
+        frame = sidebar.frame;
         Object.assign(frame.style, {
           display: 'block',
           width: DEFAULT_WIDTH + 'px',
@@ -603,7 +607,7 @@ describe('Sidebar', () => {
     it('uses the configured external container as the frame', () => {
       assert.equal(sidebar.frame, undefined);
       assert.isDefined(sidebar.externalFrame);
-      assert.equal(sidebar.externalFrame[0], externalFrame);
+      assert.equal(sidebar.externalFrame, externalFrame);
       assert.equal(externalFrame.childNodes.length, 1);
     });
   });


### PR DESCRIPTION
As part of the gradual removal of jQuery from the annotator part of the
app, replace it with DOM APIs in `Host` and `Sidebar`.