### PR TITLE
Re-implement handling of document/highlight events in the annotator

### DIFF
--- a/src/annotator/delegator.coffee
+++ b/src/annotator/delegator.coffee
@@ -16,10 +16,6 @@ $ = require('jquery')
 # from. It provides basic functionality such as instance options, event
 # delegation and pub/sub methods.
 module.exports = class Delegator
-  # Public: Events object. This contains a key/pair hash of events/methods that
-  # should be bound. See Delegator#addEvents() for usage.
-  events: {}
-
 # Public: Options object. Extended on initialisation.
   options: {}
 
@@ -44,116 +40,13 @@ module.exports = class Delegator
     @options = $.extend(true, {}, @options, config)
     @element = $(element)
 
-    # Delegator creates closures for each event it binds. This is a private
-    # registry of created closures, used to enable event unbinding.
-    @_closures = {}
-
     this.on = this.subscribe
-    this.addEvents()
 
 # Public: Destroy the instance, unbinding all events.
 #
 # Returns nothing.
   destroy: ->
-    this.removeEvents()
-
-# Public: binds the function names in the @events Object to their events.
-#
-# The @events Object should be a set of key/value pairs where the key is the
-# event name with optional CSS selector. The value should be a String method
-# name on the current class.
-#
-# This is called by the default Delegator constructor and so shouldn't usually
-# need to be called by the user.
-#
-# Examples
-#
-#   # This will bind the clickedElement() method to the click event on @element.
-#   @options = {"click": "clickedElement"}
-#
-#   # This will delegate the submitForm() method to the submit event on the
-#   # form within the @element.
-#   @options = {"form submit": "submitForm"}
-#
-#   # This will bind the updateAnnotationStore() method to the custom
-#   # annotation:save event. NOTE: Because this is a custom event the
-#   # Delegator#subscribe() method will be used and updateAnnotationStore()
-#   # will not receive an event parameter like the previous two examples.
-#   @options = {"annotation:save": "updateAnnotationStore"}
-#
-# Returns nothing.
-  addEvents: ->
-    for event in Delegator._parseEvents(@events)
-      this._addEvent event.selector, event.event, event.functionName
-
-# Public: unbinds functions previously bound to events by addEvents().
-#
-# The @events Object should be a set of key/value pairs where the key is the
-# event name with optional CSS selector. The value should be a String method
-# name on the current class.
-#
-# Returns nothing.
-  removeEvents: ->
-    for event in Delegator._parseEvents(@events)
-      this._removeEvent event.selector, event.event, event.functionName
-
-# Binds an event to a callback function represented by a String. A selector
-# can be provided in order to watch for events on a child element.
-#
-# The event can be any standard event supported by jQuery or a custom String.
-# If a custom string is used the callback function will not recieve an
-# event object as it's first parameter.
-#
-# selector     - Selector String matching child elements. (default: '')
-# event        - The event to listen for.
-# functionName - A String function name to bind to the event.
-#
-# Examples
-#
-#   # Listens for all click events on instance.element.
-#   instance._addEvent('', 'click', 'onClick')
-#
-#   # Delegates the instance.onInputFocus() method to focus events on all
-#   # form inputs within instance.element.
-#   instance._addEvent('form :input', 'focus', 'onInputFocus')
-#
-# Returns itself.
-  _addEvent: (selector, event, functionName) ->
-    closure = => this[functionName].apply(this, arguments)
-
-    if selector == '' and Delegator._isCustomEvent(event)
-      this.subscribe(event, closure)
-    else
-      @element.delegate(selector, event, closure)
-
-    @_closures["#{selector}/#{event}/#{functionName}"] = closure
-
-    this
-
-# Unbinds a function previously bound to an event by the _addEvent method.
-#
-# Takes the same arguments as _addEvent(), and an event will only be
-# successfully unbound if the arguments to removeEvent() are exactly the same
-# as the original arguments to _addEvent(). This would usually be called by
-# _removeEvents().
-#
-# selector     - Selector String matching child elements. (default: '')
-# event        - The event to listen for.
-# functionName - A String function name to bind to the event.
-#
-# Returns itself.
-  _removeEvent: (selector, event, functionName) ->
-    closure = @_closures["#{selector}/#{event}/#{functionName}"]
-
-    if selector == '' and Delegator._isCustomEvent(event)
-      this.unsubscribe(event, closure)
-    else
-      @element.undelegate(selector, event, closure)
-
-    delete @_closures["#{selector}/#{event}/#{functionName}"]
-
-    this
-
+    # FIXME - This should unbind any event handlers registered via `subscribe`.
 
 # Public: Fires an event and calls all subscribed callbacks with any parameters
 # provided. This is essentially an alias of @element.triggerHandler() but
@@ -221,45 +114,3 @@ module.exports = class Delegator
   unsubscribe: ->
     @element.unbind.apply @element, arguments
     this
-
-
-# Parse the @events object of a Delegator into an array of objects containing
-# string-valued "selector", "event", and "func" keys.
-Delegator._parseEvents = (eventsObj) ->
-  events = []
-  for sel, functionName of eventsObj
-    [selector..., event] = sel.split ' '
-    events.push({
-      selector: selector.join(' '),
-      event: event,
-      functionName: functionName
-    })
-  return events
-
-
-# Native jQuery events that should recieve an event object. Plugins can
-# add their own methods to this if required.
-Delegator.natives = do ->
-  specials = (key for own key, val of $.event.special)
-  """
-  blur focus focusin focusout load resize scroll unload click dblclick
-  mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave
-  change select submit keydown keypress keyup error touchstart
-  """.split(/[^a-z]+/).concat(specials)
-
-
-# Checks to see if the provided event is a DOM event supported by jQuery or
-# a custom user event.
-#
-# event - String event name.
-#
-# Examples
-#
-#   Delegator._isCustomEvent('click')              # => false
-#   Delegator._isCustomEvent('mousedown')          # => false
-#   Delegator._isCustomEvent('annotation:created') # => true
-#
-# Returns true if event is a custom user event.
-Delegator._isCustomEvent = (event) ->
-  [event] = event.split('.')
-  $.inArray(event, Delegator.natives) == -1

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -248,8 +248,6 @@ module.exports = class Guest extends Delegator
 
   destroy: ->
     this._removeElementEvents()
-    $('#annotator-dynamic-style').remove()
-
     this.selections.unsubscribe()
     @adder.remove()
 

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -26,8 +26,9 @@ annotationsForSelection = () ->
   range = selection.getRangeAt(0)
   return rangeUtil.itemsForRange(range, (node) -> $(node).data('annotation'))
 
-# Return a list of `<hypothesis-highlight>` elements that contain the given node.
-highlightsAt = (node) ->
+# Return the annotations associated with any highlights that contain a given
+# DOM node.
+annotationsAt = (node) ->
   if node.nodeType != Node.ELEMENT_NODE
     node = node.parentElement
 
@@ -38,12 +39,7 @@ highlightsAt = (node) ->
       highlights.push(node)
     node = node.parentElement
 
-  return highlights
-
-# Return the annotations associated with any highlights that contain a given
-# DOM node.
-annotationsAt = (node) ->
-  highlightsAt(event.target).map((h) => $(h).data('annotation'))
+  return highlights.map((h) => $(h).data('annotation'))
 
 # A selector which matches elements added to the DOM by Hypothesis (eg. for
 # highlights and annotation UI).
@@ -151,8 +147,8 @@ module.exports = class Guest extends Delegator
     addListener 'click', (event) =>
       annotations = annotationsAt(event.target)
       if annotations.length and @visibleHighlights
-        xor = event.metaKey or event.ctrlKey
-        this.selectAnnotations(annotations, xor)
+        toggle = event.metaKey or event.ctrlKey
+        this.selectAnnotations(annotations, toggle)
       else maybeHideSidebar(event)
 
     # Allow taps on the document to hide the sidebar as well as clicks, because

--- a/src/annotator/plugin/document.js
+++ b/src/annotator/plugin/document.js
@@ -69,15 +69,26 @@ export default class DocumentMeta extends Plugin {
   constructor(element, options) {
     super(element, options);
 
-    this.events = {
-      beforeAnnotationCreated: 'beforeAnnotationCreated',
-    };
-
     this.metadata = createMetadata();
 
     this.baseURI = options.baseURI || baseURI;
     this.document = options.document || document;
     this.normalizeURI = options.normalizeURI || normalizeURI;
+
+    /**
+     * Event handler that adds document metadata to new annotations.
+     */
+    this.beforeAnnotationCreated = annotation => {
+      annotation.document = this.metadata;
+    };
+
+    // @ts-expect-error - Method comes from CoffeeScript base class.
+    this.subscribe('beforeAnnotationCreated', this.beforeAnnotationCreated);
+  }
+
+  destroy() {
+    // @ts-expect-error - Method comes from CoffeeScript base class.
+    this.unsubscribe('beforeAnnotationCreated', this.beforeAnnotationCreated);
   }
 
   pluginInit() {
@@ -112,14 +123,6 @@ export default class DocumentMeta extends Plugin {
       }
     }
     return Object.keys(uniqueUrls);
-  }
-
-  /**
-   * Hook that augments new annotations with metadata about the document they
-   * came from.
-   */
-  beforeAnnotationCreated(annotation) {
-    annotation.document = this.metadata;
   }
 
   /**

--- a/src/annotator/plugin/test/document-test.js
+++ b/src/annotator/plugin/test/document-test.js
@@ -31,14 +31,27 @@ describe('DocumentMeta', function () {
       return normalizeURI(url, base);
     });
 
-    testDocument = new DocumentMeta(tempDocument, {
+    // Root element to use for the `Delegator` event bus. This can be different
+    // than the document from which metadata is gathered.
+    const rootElement = document.body;
+
+    testDocument = new DocumentMeta(rootElement, {
       document: tempDocument,
       normalizeURI: fakeNormalizeURI,
     });
     testDocument.pluginInit();
   });
 
-  afterEach(() => $(document).unbind());
+  afterEach(() => {
+    testDocument.destroy();
+    $(document).unbind();
+  });
+
+  it('attaches document metadata to new annotations', () => {
+    const annotation = {};
+    testDocument.publish('beforeAnnotationCreated', [annotation]);
+    assert.equal(annotation.document, testDocument.metadata);
+  });
 
   describe('annotation should have some metadata', function () {
     let metadata = null;

--- a/src/annotator/test/guest-test.coffee
+++ b/src/annotator/test/guest-test.coffee
@@ -337,24 +337,14 @@ describe 'Guest', ->
       fakeSidebarFrame?.remove()
 
     it 'hides sidebar when the user taps or clicks in the page', ->
-
       for event in ['click', 'touchstart']
-        sandbox.spy(guest, methods[event])
-
         rootElement.dispatchEvent(new Event(event))
-
-        assert.called(guest[methods[event]])
         assert.calledWith(guest.plugins.CrossFrame.call, 'hideSidebar')
 
     it 'does not hide sidebar if configured not to close sidebar on document click', ->
-
       for event in ['click', 'touchstart']
-        sandbox.spy(guest, methods[event])
         guest.closeSidebarOnDocumentClick = false
-
         rootElement.dispatchEvent(new Event(event))
-
-        assert.called(guest[methods[event]])
         assert.notCalled(guest.plugins.CrossFrame.call)
 
     it 'does not hide sidebar if event occurs inside annotator UI', ->
@@ -363,11 +353,7 @@ describe 'Guest', ->
       rootElement.appendChild(fakeSidebarFrame)
 
       for event in ['click', 'touchstart']
-        sandbox.spy(guest, methods[event])
-
         fakeSidebarFrame.dispatchEvent(new Event(event, { bubbles: true }))
-
-        assert.called(guest[methods[event]])
         assert.notCalled(guest.plugins.CrossFrame.call)
 
 

--- a/src/annotator/test/guest-test.coffee
+++ b/src/annotator/test/guest-test.coffee
@@ -25,15 +25,12 @@ class FakeAdder
 
 class FakePlugin extends Plugin
   instance: null
-  events:
-    'customEvent': 'customEventHandler'
 
   constructor: ->
     FakePlugin::instance = this
     super
 
   pluginInit: sinon.stub()
-  customEventHandler: sinon.stub()
 
 # A little helper which returns a promise that resolves after a timeout
 timeoutPromise = (millis = 0) ->
@@ -120,10 +117,6 @@ describe 'Guest', ->
 
     it 'hold reference to instance', ->
       assert.equal(fakePlugin.annotator, guest)
-
-    it 'subscribe to events', ->
-      guest.publish('customEvent', ['1', '2'])
-      assert.calledWith(fakePlugin.customEventHandler, '1', '2')
 
     it 'destroy when instance is destroyed', ->
       sandbox.spy(fakePlugin, 'destroy')


### PR DESCRIPTION
This PR reworks event handling in the annotator code to remove a bunch of indirection in the `Guest` class and also to simplify the `Delegator` class by removing the `events` property and associated logic. The changes affect handling of:

 1. Clicks, hovers and taps on highlights and document elements (handled in `guest.coffee`)
 2. Attaching document metadata to new annotations (handled in `document.js`)

The events in (1) are now handled by ordinary DOM event listeners in the `Guest` class.
The events in (2) are now handled by a call to the `subscribe` method.

Aside from removing indirection in handling of clicks/taps/hovers on the document/highlights, this will also simplify future work to convert the remaining CoffeeScript to JS, remove jQuery and refactor the architecture of the annotator.

**Testing:**

The main thing to check when testing this is that clicks on highlights work the same as on `master`, including:

 - When clicking on a lone highlight
 - When clicking inside a nested highlight
 - When hovering / un-hovering a highlight
 - When clicking multiple highlights in succession with the control key held to select multiple annotations
