### PR TITLE
Consolidate `adder` SCSS module

### DIFF
--- a/src/annotator/components/adder-toolbar.js
+++ b/src/annotator/components/adder-toolbar.js
@@ -20,18 +20,16 @@ function ToolbarButton({ badgeCount, icon, label, onClick, shortcut }) {
 
   return (
     <button
-      className="annotator-adder-actions__button"
+      className="annotator-adder-button"
       onClick={onClick}
       aria-label={title}
       title={title}
     >
-      {icon && (
-        <SvgIcon name={icon} className="annotator-adder-actions__icon" />
-      )}
+      {icon && <SvgIcon name={icon} className="annotator-adder-button__icon" />}
       {typeof badgeCount === 'number' && (
-        <span className="annotator-adder-actions__badge">{badgeCount}</span>
+        <span className="annotator-adder-button__badge">{badgeCount}</span>
       )}
-      <span className="annotator-adder-actions__label">{label}</span>
+      <span className="annotator-adder-button__label">{label}</span>
     </button>
   );
 }
@@ -96,8 +94,8 @@ export default function AdderToolbar({
     // @ts-ignore - TS doesn't know about our custom element types.
     <hypothesis-adder-toolbar
       class={classnames('annotator-adder', {
-        'annotator-adder--arrow-down': arrowDirection === 'down',
-        'annotator-adder--arrow-up': arrowDirection === 'up',
+        'annotator-adder--down': arrowDirection === 'up',
+        'annotator-adder--up': arrowDirection === 'down',
         'is-active': isVisible,
       })}
       style={{ visibility: isVisible ? 'visible' : 'hidden' }}
@@ -129,6 +127,14 @@ export default function AdderToolbar({
         )}
         {/* @ts-ignore */}
       </hypothesis-adder-actions>
+      <SvgIcon
+        name="pointer"
+        inline={true}
+        className={classnames('annotator-adder-arrow', {
+          'annotator-adder-arrow--down': arrowDirection === 'down',
+          'annotator-adder-arrow--up': arrowDirection === 'up',
+        })}
+      />
       {/* @ts-ignore */}
     </hypothesis-adder-toolbar>
   );

--- a/src/annotator/icons.js
+++ b/src/annotator/icons.js
@@ -12,5 +12,6 @@ export default {
   hide: require('../images/icons/hide.svg'),
   highlight: require('../images/icons/highlight.svg'),
   note: require('../images/icons/note.svg'),
+  pointer: require('../images/icons/pointer.svg'),
   show: require('../images/icons/show.svg'),
 };

--- a/src/styles/annotator/adder.scss
+++ b/src/styles/annotator/adder.scss
@@ -1,4 +1,7 @@
-@use '../mixins/focus' as focus;
+@use "../mixins/buttons";
+@use "../mixins/layout";
+@use "../mixins/molecules";
+@use "../mixins/utils";
 @use '../variables' as var;
 
 $adder-transition-duration: 80ms;
@@ -11,22 +14,109 @@ $adder-transition-duration: 80ms;
   // Adder, even when using Shadow DOM.
   all: initial;
 
-  // Adder entry animation settings
-  animation-duration: $adder-transition-duration;
-  animation-timing-function: ease-in;
-  animation-fill-mode: forwards;
+  @include utils.border;
 
+  position: absolute;
   box-sizing: border-box;
   direction: ltr;
-  position: absolute;
-  background: var.$white;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-  border-radius: 4px;
+  background: var.$color-background;
+  border-radius: var.$annotator-border-radius;
+
+  // The adder toolbar has a distinctive, broad-spreading drop shadow
   box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.25);
 
   // Give the adder a very low opacity initially.  It will then fade-in when
   // shown.
   opacity: 0.05;
+
+  // Adder entry animation settings
+  animation-duration: $adder-transition-duration;
+  animation-timing-function: ease-in;
+  animation-fill-mode: forwards;
+
+  &--down.is-active {
+    animation-name: adder-fade-in, adder-pop-down;
+  }
+
+  &--up.is-active {
+    animation-name: adder-fade-in, adder-pop-up;
+  }
+}
+
+.annotator-adder-arrow {
+  @include molecules.menu-arrow;
+  // Horizontal centering, part 1
+  left: 50%;
+
+  &--down {
+    // These transforms:
+    // 1) Reimplement the "down" variant of the menu-arrow mixin,
+    //    rotating the arrow pointer SVG.
+    //    Having this here is necessary because all transforms for an element
+    //    must be in a single rule, and we also need to:
+    // 2) Translate -50% (left) on the X axis to complete horizontal centering
+    // 3) Translate up (Y) by 1px to eliminate a faint border line visible in Safari
+    transform: rotateX(180deg) translateX(-50%) translateY(1px);
+  }
+
+  &--up {
+    // Align at top edge of parent element...
+    top: 0;
+    // Translate on X axis -50% (left) to complete horizontal centering
+    // Translate -100% on Y axis (up) to position arrow above parent
+    transform: translate(-50%, -100%);
+  }
+}
+
+.annotator-adder-actions {
+  @include layout.row;
+}
+
+.annotator-adder-button {
+  @include layout.column($align: center);
+  @include buttons.reset-native-btn-styles;
+
+  cursor: pointer;
+  color: var.$grey-mid;
+  font-size: var.$annotator-adder-font-size;
+  line-height: var.$annotator-adder-line-height;
+  padding: var.$layout-space--small;
+  transition: color $adder-transition-duration;
+
+  &__label {
+    margin-top: var.$layout-space--xxsmall;
+    transition: color $adder-transition-duration;
+  }
+
+  &__badge {
+    // The badge should be vertically aligned with icons in other toolbar buttons
+    // and the label underneath should also align with labels in other buttons.
+    background-color: var.$grey-mid;
+    border-radius: var.$annotator-border-radius;
+    color: var.$color-text--inverted;
+    font-weight: bold;
+    // For positioning the number appropriately withint the badge background
+    padding: 2px 4px;
+  }
+}
+
+.annotator-adder-actions__separator {
+  margin: var.$layout-space--xxsmall;
+  @include utils.border--right;
+  // Override border color to be a little darker
+  border-color: var.$grey-4;
+}
+
+// The toolbar has full contrast when not hovered. When the toolbar is hovered,
+// the buttons are dimmed except for the one which is currently hovered.
+.annotator-adder-actions:hover {
+  .annotator-adder-button:not(:hover) {
+    color: var.$grey-semi;
+
+    .annotator-adder-button__badge {
+      background-color: var.$grey-semi;
+    }
+  }
 }
 
 @keyframes adder-fade-in {
@@ -57,102 +147,4 @@ $adder-transition-duration: 80ms;
   to {
     transform: scale(1) translateY(0px);
   }
-}
-
-@mixin adder-arrow($rotation) {
-  transform: rotate($rotation);
-  background: var.$white;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.2);
-  border-right: 1px solid rgba(0, 0, 0, 0.2);
-  content: '';
-  display: block;
-  height: 6px;
-  left: 0;
-  margin-left: auto;
-  margin-right: auto;
-  position: absolute;
-  right: 0;
-  width: 6px;
-}
-
-.annotator-adder--arrow-down.is-active {
-  animation-name: adder-fade-in, adder-pop-up;
-}
-
-.annotator-adder--arrow-down:before {
-  @include adder-arrow(45deg);
-  bottom: -5px;
-}
-
-.annotator-adder--arrow-up.is-active {
-  animation-name: adder-fade-in, adder-pop-down;
-}
-
-.annotator-adder--arrow-up:before {
-  @include adder-arrow(225deg);
-  top: -5px;
-}
-
-.annotator-adder-actions {
-  display: flex;
-  flex-direction: row;
-}
-
-.annotator-adder-actions__button {
-  @include focus.outline-on-keyboard-focus;
-
-  box-shadow: none;
-  background: transparent;
-  color: var.$color-text;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  border: none;
-  cursor: pointer;
-  font-size: var.$annotator-adder-font-size;
-  font-family: sans-serif;
-  line-height: var.$annotator-adder-line-height;
-
-  padding: 10px;
-  padding-bottom: 7px;
-  transition: color $adder-transition-duration;
-}
-
-.annotator-adder-actions__button {
-  color: var.$grey-mid;
-}
-
-.annotator-adder-actions__separator {
-  margin: 5px 5px;
-  border-right: 1px solid var.$grey-4;
-}
-
-// The toolbar has full contrast when not hovered. When the toolbar is hovered,
-// the buttons are dimmed except for the one which is currently hovered.
-.annotator-adder-actions:hover {
-  .annotator-adder-actions__button:not(:hover) {
-    color: var.$grey-semi;
-
-    .annotator-adder-actions__badge {
-      background-color: var.$grey-semi;
-    }
-  }
-}
-
-.annotator-adder-actions__label {
-  margin-bottom: 2px;
-  margin-top: 4px;
-
-  transition: color $adder-transition-duration;
-}
-
-.annotator-adder-actions__badge {
-  background-color: var.$grey-mid;
-  border-radius: 3px;
-  color: white;
-
-  // The badge should be vertically aligned with icons in other toolbar buttons
-  // and the label underneath should also align with labels in other buttons.
-  font-weight: bold;
-  padding: 2px 4px;
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -111,7 +111,7 @@ $icon-size--small: 12px;
 $icon-size--medium: 16px;
 $icon-size--large: 24px;
 
-// Transitional Typography (Temporary)
+// Annotator-specific values
 // -----------------------------------
 
 $annotator-base-font-size: 14px;
@@ -122,3 +122,5 @@ $annotator-adder-line-height: 1em;
 
 $annotator-bucket-bar-font-size: 10px;
 $annotator-bucket-bar-line-height: 14px;
+
+$annotator-border-radius: 4px;


### PR DESCRIPTION
Part of #2520
Depends on #2518 

This PR consolidates the SCSS for the `AdderToolbar`.

* Use mixins or variables where possible
* Replace custom arrow CSS with `Svg` icon, `menu-arrow` mixin
* Increase commenting

User-visible changes are subtle; there are slight adjustments to proportions, and the arrow/pointer is consistent with other pointers in our app now.

Before:

<img width="212" alt="Screen Shot 2020-09-10 at 12 31 55 PM" src="https://user-images.githubusercontent.com/439947/92764402-667c7b00-f362-11ea-80dd-07377e71a18a.png">

After:

<img width="212" alt="Screen Shot 2020-09-10 at 12 32 29 PM" src="https://user-images.githubusercontent.com/439947/92764418-6a100200-f362-11ea-8bef-79ee1c0b8b6e.png">

