### PR TITLE
Convert range classes from coffeescript to js

### DIFF
--- a/src/annotator/anchoring/normalize.js
+++ b/src/annotator/anchoring/normalize.js
@@ -1,0 +1,224 @@
+import $ from 'jquery';
+
+import { BrowserRange } from './range-browser';
+import { NormalizedRange } from './range-normalized';
+import { nodeFromXPath } from './range-js';
+import { SerializedRange } from './range-serialized';
+import {
+  getFirstTextNodeNotBefore,
+  getLastTextNodeUpTo,
+  getTextNodes,
+} from './xpath-util';
+
+/**
+ * Convert a BrowserRange or SerializedRange instance to a new NormalizedRange instance.
+ * Passing a NormalizedRange instance range param will return itself.
+ */
+export function normalize(range, root) {
+  // BrowserRange
+  if (range instanceof BrowserRange) {
+    // Works around the fact that browsers don't generate
+    // ranges/selections in a consistent manner. Some (Safari) will create
+    // ranges that have (say) a textNode startContainer and elementNode
+    // endContainer. Others (Firefox) seem to only ever generate
+    // textNode/textNode or elementNode/elementNode pairs.
+    if (range.tainted) {
+      throw new Error('You may only call normalize() once on a BrowserRange!');
+    } else {
+      range.tainted = true;
+    }
+    const rangeTemp = {};
+    // Look at the start
+    if (range.startContainer.nodeType === Node.ELEMENT_NODE) {
+      // We are dealing with element nodes
+      if (range.startOffset < range.startContainer.childNodes.length) {
+        rangeTemp.start = getFirstTextNodeNotBefore(
+          range.startContainer.childNodes[range.startOffset]
+        );
+      } else {
+        rangeTemp.start = getFirstTextNodeNotBefore(range.startContainer);
+      }
+      rangeTemp.startOffset = 0;
+    } else {
+      // We are dealing with simple text nodes
+      rangeTemp.start = range.startContainer;
+      rangeTemp.startOffset = range.startOffset;
+    }
+
+    // Look at the end
+    if (range.endContainer.nodeType === Node.ELEMENT_NODE) {
+      // Get specified node.
+      let node = range.endContainer.childNodes[range.endOffset];
+      // Does that node exist?
+      if (node) {
+        // Look for a text node either at the immediate beginning of node
+        let n = node;
+        while (n && n.nodeType !== Node.TEXT_NODE) {
+          n = n.firstChild;
+        }
+        // Did we find a text node at the start of this element?
+        if (n) {
+          rangeTemp.end = n;
+          rangeTemp.endOffset = 0;
+        }
+      }
+
+      if (!rangeTemp.end) {
+        // We need to find a text node in the previous sibling of the node at the
+        // given offset, if one exists, or in the previous sibling of its container.
+        if (range.endOffset) {
+          node = range.endContainer.childNodes[range.endOffset - 1];
+        } else {
+          node = range.endContainer.previousSibling;
+        }
+        rangeTemp.end = getLastTextNodeUpTo(node);
+        rangeTemp.endOffset = rangeTemp.end.nodeValue.length;
+      }
+    } else {
+      // We are dealing with simple text nodes
+      rangeTemp.end = range.endContainer;
+      rangeTemp.endOffset = range.endOffset;
+    }
+
+    // We have collected the initial data.
+    // Now let's start to slice & dice the text elements!
+    const normalRange = {};
+    if (rangeTemp.startOffset > 0) {
+      // Do we really have to cut?
+      if (
+        !rangeTemp.start.nextSibling ||
+        rangeTemp.start.nodeValue.length > rangeTemp.startOffset
+      ) {
+        // Yes. Cut.
+        normalRange.start = rangeTemp.start.splitText(rangeTemp.startOffset);
+      } else {
+        // Avoid splitting off zero-length pieces.
+        normalRange.start = getFirstTextNodeNotBefore(
+          rangeTemp.start.nextSibling
+        );
+      }
+    } else {
+      normalRange.start = rangeTemp.start;
+    }
+
+    // Is the whole selection inside one text element ?
+    if (rangeTemp.start === rangeTemp.end) {
+      if (
+        normalRange.start.nodeValue.length >
+        rangeTemp.endOffset - rangeTemp.startOffset
+      ) {
+        normalRange.start.splitText(
+          rangeTemp.endOffset - rangeTemp.startOffset
+        );
+      }
+      normalRange.end = normalRange.start;
+    } else {
+      // No, the end of the selection is in a separate text element
+      // does the end need to be cut?
+      if (rangeTemp.end.nodeValue.length > rangeTemp.endOffset) {
+        rangeTemp.end.splitText(rangeTemp.endOffset);
+      }
+      normalRange.end = rangeTemp.end;
+    }
+
+    // Make sure the common ancestor is an element node.
+    normalRange.commonAncestor = range.commonAncestorContainer;
+    while (normalRange.commonAncestor.nodeType !== Node.ELEMENT_NODE) {
+      normalRange.commonAncestor = normalRange.commonAncestor.parentNode;
+    }
+    return new NormalizedRange(normalRange);
+  }
+
+  // NormalizedRange
+  else if (range instanceof NormalizedRange) {
+    return range;
+  }
+
+  // SerializedRange
+  else if (range instanceof SerializedRange) {
+    const normalRange = {};
+    for (let p of ['start', 'end']) {
+      let node;
+      try {
+        node = nodeFromXPath(range[p], root);
+      } catch (e) {
+        throw new RangeError(
+          `Error while finding ${p} node: ${range[p]}: ` + e
+        );
+      }
+
+      if (!node) {
+        throw new RangeError(`Couldn't find ${p} node: ${range[p]}`);
+      }
+
+      // Unfortunately, we *can't* guarantee only one textNode per
+      // elementNode, so we have to walk along the element's textNodes until
+      // the combined length of the textNodes to that point exceeds or
+      // matches the value of the offset.
+      let length = 0;
+      let targetOffset = range[p + 'Offset'];
+
+      // Range excludes its endpoint because it describes the boundary position.
+      // Target the string index of the last character inside the range.
+      if (p === 'end') {
+        targetOffset--;
+      }
+
+      for (let tn of Array.from(getTextNodes($(node)))) {
+        if (length + tn.nodeValue.length > targetOffset) {
+          normalRange[p + 'Container'] = tn;
+          normalRange[p + 'Offset'] = range[p + 'Offset'] - length;
+          break;
+        } else {
+          length += tn.nodeValue.length;
+        }
+      }
+
+      // If we fall off the end of the for loop without having set
+      // 'startOffset'/'endOffset', the element has shorter content than when
+      // we annotated, so throw an error:
+      if (normalRange[p + 'Offset'] === undefined) {
+        throw new RangeError(
+          `Couldn't find offset ${range[p + 'Offset']} in element ${range[p]}`
+        );
+      }
+    }
+
+    // Here's an elegant next step...
+    //
+    //   normalRange.commonAncestorContainer = $(normalRange.startContainer).parents().has(normalRange.endContainer)[0]
+    //
+    // ...but unfortunately Node.contains() is broken in Safari 5.1.5 (7534.55.3)
+    // and presumably other earlier versions of WebKit. In particular, in a
+    // document like
+    //
+    //   <p>Hello</p>
+    //
+    // the code
+    //
+    //   p = document.getElementsByTagName('p')[0]
+    //   p.contains(p.firstChild)
+    //
+    // returns `false`. Yay.
+    //
+    // So instead, we step through the parents from the bottom up and use
+    // Node.compareDocumentPosition() to decide when to set the
+    // commonAncestorContainer and bail out.
+    const contains = (a, b) => a.compareDocumentPosition(b) & 16;
+    $(normalRange.startContainer)
+      .parents()
+      .each(function () {
+        if (contains(this, normalRange.endContainer)) {
+          normalRange.commonAncestorContainer = this;
+          // bail out of loop
+          return false;
+        }
+        return true;
+      });
+
+    //console.log('calling BrowserRange() on', normalRange);
+    return normalize(new BrowserRange(normalRange), root);
+  } else {
+    throw new Error('Could not normalize unknown range type');
+  }
+}

--- a/src/annotator/anchoring/range-browser.js
+++ b/src/annotator/anchoring/range-browser.js
@@ -1,0 +1,25 @@
+/**
+ * Public: Creates a wrapper around a range object obtained from a DOMSelection.
+ */
+export class BrowserRange {
+  /**
+   * Public: Creates an instance of BrowserRange.
+   *
+   * object - A range object obtained via DOMSelection#getRangeAt().
+   *
+   * Examples
+   *
+   *   selection = window.getSelection()
+   *   range = new Range.BrowserRange(selection.getRangeAt(0))
+   *
+   * Returns an instance of BrowserRange.
+   */
+  constructor(obj) {
+    this.commonAncestorContainer = obj.commonAncestorContainer;
+    this.startContainer = obj.startContainer;
+    this.startOffset = obj.startOffset;
+    this.endContainer = obj.endContainer;
+    this.endOffset = obj.endOffset;
+    this.tainted = false;
+  }
+}

--- a/src/annotator/anchoring/range-normalized.js
+++ b/src/annotator/anchoring/range-normalized.js
@@ -1,0 +1,109 @@
+import $ from 'jquery';
+
+import { getTextNodes } from './xpath-util';
+
+/**
+ * Public: A normalized range is most commonly used throughout the annotator.
+ * its the result of a deserialized SerializedRange or a BrowserRange with
+ * out browser inconsistencies.
+ */
+export class NormalizedRange {
+  /**
+   * Public: Creates an instance of a NormalizedRange.
+   *
+   * This is usually created by calling the .normalize() method on one of the
+   * other Range classes rather than manually.
+   *
+   * obj - An Object literal. Should have the following properties.
+   *       commonAncestor: A Element that encompasses both the start and end nodes
+   *       start:          The first TextNode in the range.
+   *       end             The last TextNode in the range.
+   *
+   * Returns an instance of NormalizedRange.
+   */
+  constructor(obj) {
+    this.commonAncestor = obj.commonAncestor;
+    this.start = obj.start;
+    this.end = obj.end;
+  }
+
+  /**
+   * Public: Limits the nodes within the NormalizedRange to those contained
+   * withing the bounds parameter. It returns an updated range with all
+   * properties updated. NOTE: Method returns null if all nodes fall outside
+   * of the bounds.
+   *
+   * bounds - An Element to limit the range to.
+   *
+   * Returns updated self or null.
+   */
+  limit(bounds) {
+    const nodes = $.grep(
+      this.textNodes(),
+      node => node.parentNode === bounds || $.contains(bounds, node.parentNode)
+    );
+    if (!nodes.length) {
+      return null;
+    }
+
+    this.start = nodes[0];
+    this.end = nodes[nodes.length - 1];
+
+    const startParents = $(this.start).parents();
+
+    for (let parent of Array.from($(this.end).parents())) {
+      if (startParents.index(parent) !== -1) {
+        this.commonAncestor = parent;
+        break;
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Public: Creates a concatenated String of the contents of all the text nodes
+   * within the range.
+   *
+   * Returns a String.
+   */
+  text() {
+    return Array.from(this.textNodes())
+      .map(node => node.nodeValue)
+      .join('');
+  }
+
+  /**
+   * Public: Fetches only the text nodes within the range.
+   *
+   * Returns an Array of TextNode instances.
+   */
+  textNodes() {
+    const textNodes = getTextNodes($(this.commonAncestor));
+    const [start, end] = Array.from([
+      textNodes.index(this.start),
+      textNodes.index(this.end),
+    ]);
+    // Return the textNodes that fall between the start and end indexes.
+    return $.makeArray(textNodes.slice(start, +end + 1 || undefined));
+  }
+
+  /**
+   * Public: Converts the Normalized range to a native browser range.
+   *
+   * See: https://developer.mozilla.org/en/DOM/range
+   *
+   * Examples
+   *
+   *   selection = window.getSelection()
+   *   selection.removeAllRanges()
+   *   selection.addRange(normedRange.toRange())
+   *
+   * Returns a Range object.
+   */
+  toRange() {
+    const range = document.createRange();
+    range.setStartBefore(this.start);
+    range.setEndAfter(this.end);
+    return range;
+  }
+}

--- a/src/annotator/anchoring/range-serialized.js
+++ b/src/annotator/anchoring/range-serialized.js
@@ -1,0 +1,34 @@
+/**
+ * Public: A range suitable for storing in local storage or serializing to JSON.
+ */
+export class SerializedRange {
+  /**
+   * Public: Creates a SerializedRange
+   *
+   * obj - The stored object. It should have the following properties.
+   *       start:       An xpath to the Element containing the first TextNode
+   *                    relative to the root Element.
+   *       startOffset: The offset to the start of the selection from obj.start.
+   *       end:         An xpath to the Element containing the last TextNode
+   *                    relative to the root Element.
+   *       startOffset: The offset to the end of the selection from obj.end.
+   *
+   * Returns an instance of SerializedRange
+   */
+  constructor(obj) {
+    this.start = obj.start;
+    this.startOffset = obj.startOffset;
+    this.end = obj.end;
+    this.endOffset = obj.endOffset;
+  }
+
+  // Public: Returns the range as an Object literal.
+  toObject() {
+    return {
+      start: this.start,
+      startOffset: this.startOffset,
+      end: this.end,
+      endOffset: this.endOffset,
+    };
+  }
+}

--- a/src/annotator/anchoring/serialize.js
+++ b/src/annotator/anchoring/serialize.js
@@ -1,0 +1,70 @@
+import $ from 'jquery';
+
+import { normalize } from './normalize';
+import { BrowserRange } from './range-browser';
+import { xpathFromNode } from './range-js';
+import { NormalizedRange } from './range-normalized';
+import { SerializedRange } from './range-serialized';
+import { getTextNodes } from './xpath-util';
+
+/**
+ * Convert a BrowserRange or NormalizedRange instance to a new SerializedRange instance,
+ * or a SerializedRange instance can be re-serialized to a new SerializedRange instance
+ * augmented with a with a provided `ignoreSelector`
+ */
+export function serialize(range, root, ignoreSelector) {
+  // BrowserRange
+  if (range instanceof BrowserRange) {
+    return serialize(normalize(range, root), root, ignoreSelector);
+  }
+
+  // NormalizedRange
+  else if (range instanceof NormalizedRange) {
+    // Convert this range into an object consisting of two pairs of (xpath,
+    // character offset), which can be easily stored in a database.
+    const serialization = function (node, isEnd) {
+      let origParent;
+      if (ignoreSelector) {
+        origParent = $(node).parents(`:not(${ignoreSelector})`).eq(0);
+      } else {
+        origParent = $(node).parent();
+      }
+      const xpath = xpathFromNode(origParent, root)[0];
+      const textNodes = getTextNodes(origParent);
+
+      // Calculate real offset as the combined length of all the
+      // preceding textNode siblings. We include the length of the
+      // node if it's the end node.
+      const nodes = textNodes.slice(0, textNodes.index(node));
+      let offset = 0;
+      nodes.each((index, n) => {
+        offset += n.nodeValue.length;
+      });
+
+      if (isEnd) {
+        return [xpath, offset + node.nodeValue.length];
+      } else {
+        return [xpath, offset];
+      }
+    };
+
+    const start = serialization(range.start);
+    const end = serialization(range.end, true);
+
+    return new SerializedRange({
+      // XPath strings
+      start: start[0],
+      end: end[0],
+      // Character offsets (integer)
+      startOffset: start[1],
+      endOffset: end[1],
+    });
+  }
+
+  // SerializedRange
+  else if (range instanceof SerializedRange) {
+    return serialize(normalize(range, root), root, ignoreSelector);
+  } else {
+    throw new Error('Could not serialize unknown range type');
+  }
+}

--- a/src/annotator/anchoring/test/normalize-test.js
+++ b/src/annotator/anchoring/test/normalize-test.js
@@ -1,0 +1,302 @@
+import { normalize, $imports } from '../normalize';
+import { BrowserRange } from '../range-browser';
+import { NormalizedRange } from '../range-normalized';
+import { SerializedRange } from '../range-serialized';
+
+describe('annotator/anchoring/range-types', () => {
+  let container;
+  const html = `
+      <section id="section-1">
+        <p id="p-1">text 1</p>
+        <p id="p-2">text 2a<br/>text 2b</p>
+        <span id="span-1">
+          <p id="p-3">text 3</p>
+          <p id="p-4"></p>
+          <p id="p-5"><br/></p>
+        </span>
+      </section>
+      <span id="span-2"></span>`;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    // Remove extraneous white space which can affect offsets in tests.
+    // 1. Two or more spaces in a row
+    // 2. New lines
+    container.innerHTML = html.replace(/[\s+]{2,}|\n+/g, '');
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  function createBrowserRange(props) {
+    return new BrowserRange({
+      commonAncestorContainer: container,
+      startContainer: container.querySelector('#p-1').firstChild,
+      startOffset: 0,
+      endContainer: container.querySelector('#p-3').firstChild,
+      endOffset: 1,
+      tainted: false,
+      ...props,
+    });
+  }
+
+  function createNormalizedRange(props) {
+    return new NormalizedRange({
+      commonAncestor: container,
+      start: container.querySelector('#p-1').firstChild,
+      end: container.querySelector('#p-3').firstChild,
+      ...props,
+    });
+  }
+
+  function createSerializedRange(props) {
+    return new SerializedRange({
+      start: '/section[1]/p[1]',
+      startOffset: 0,
+      end: '/section[1]/span[1]/p[1]',
+      endOffset: 6,
+      ...props,
+    });
+  }
+
+  describe('normalize', () => {
+    describe('BrowserRange type', () => {
+      it('throws an error BrowserRange instance is normalized more than once', () => {
+        const browserRange = createBrowserRange();
+        assert.throws(() => {
+          normalize(browserRange, container);
+          normalize(browserRange, container);
+        }, 'You may only call normalize() once on a BrowserRange!');
+      });
+
+      it('converts BrowserRange instance to NormalizedRange instance', () => {
+        const browserRange = createBrowserRange();
+        const normalizedRange = normalize(browserRange, container);
+        assert.isTrue(normalizedRange instanceof NormalizedRange);
+        assert.deepEqual(normalizedRange, createNormalizedRange());
+      });
+
+      context('`startContainer` is ELEMENT_NODE', () => {
+        it('handles ELEMENT_NODE start node', () => {
+          const browserRange = createBrowserRange({
+            startContainer: container.querySelector('#p-1'),
+          });
+          const normalizedRange = normalize(browserRange, container);
+          assert.deepEqual(normalizedRange, createNormalizedRange());
+        });
+
+        it('handles ELEMENT_NODE start node when `startOffset` > than number of child nodes', () => {
+          const browserRange = createBrowserRange({
+            startContainer: container.querySelector('#p-1'),
+            startOffset: 1,
+          });
+          const normalizedRange = normalize(browserRange, container);
+          assert.deepEqual(normalizedRange, createNormalizedRange());
+        });
+      });
+
+      context('endContainer is ELEMENT_NODE', () => {
+        it('handles ELEMENT_NODE end node', () => {
+          const browserRange = createBrowserRange({
+            endContainer: container.querySelector('#p-3'),
+          });
+          const normalizedRange = normalize(browserRange, container);
+          assert.deepEqual(normalizedRange, createNormalizedRange());
+        });
+
+        it('handles ELEMENT_NODE end node with no `endOffset` and no children', () => {
+          const browserRange = createBrowserRange({
+            endContainer: container.querySelector('#p-4'),
+            endOffset: 0,
+          });
+          const normalizedRange = normalize(browserRange, container);
+          assert.deepEqual(normalizedRange, createNormalizedRange());
+        });
+
+        it('handles ELEMENT_NODE end nodes with no `endOffset` and children', () => {
+          const browserRange = createBrowserRange({
+            endContainer: container.querySelector('#p-3'),
+            endOffset: 0,
+          });
+          const normalizedRange = normalize(browserRange, container);
+          assert.deepEqual(normalizedRange, createNormalizedRange());
+        });
+
+        it('handles ELEMENT_NODE end nodes with no `endOffset` and non-TEXT_NODE children', () => {
+          const browserRange = createBrowserRange({
+            endContainer: container.querySelector('#p-5'),
+            endOffset: 0,
+          });
+          const normalizedRange = normalize(browserRange, container);
+          assert.deepEqual(normalizedRange, createNormalizedRange());
+        });
+      });
+
+      context('slices the text elements', () => {
+        it('cuts the text node if there is no sibling', () => {
+          const browserRange = createBrowserRange({
+            startOffset: 1,
+          });
+          const normalizedRange = normalize(browserRange, container);
+          assert.equal(normalizedRange.start.data, 'ext 1');
+        });
+
+        it('cuts the text node if there is a sibling but text node length > `startOffset`', () => {
+          const browserRange = createBrowserRange({
+            startContainer: container.querySelector('#p-2').firstChild,
+            startOffset: 1,
+          });
+          const normalizedRange = normalize(browserRange, container);
+          assert.equal(normalizedRange.start.data, 'ext 2a');
+        });
+
+        it('does not cut the text node', () => {
+          const browserRange = createBrowserRange({
+            startContainer: container.querySelector('#p-2').firstChild,
+            startOffset: 7,
+            endOffset: 14,
+          });
+          const normalizedRange = normalize(browserRange, container);
+          assert.equal(normalizedRange.start.data, 'text 2b');
+        });
+      });
+
+      context('the whole selection is inside one text element', () => {
+        [
+          {
+            startOffset: 1,
+            endOffset: 3,
+            result: 'ex',
+          },
+          {
+            startOffset: 0,
+            endOffset: 7,
+            result: 'text 1',
+          },
+        ].forEach(test => {
+          it('crops the text node appropriately', () => {
+            const browserRange = createBrowserRange({
+              startContainer: container.querySelector('#p-1').firstChild,
+              endContainer: container.querySelector('#p-1').firstChild,
+              startOffset: test.startOffset,
+              endOffset: test.endOffset,
+            });
+            const normalizedRange = normalize(browserRange, container);
+            assert.equal(normalizedRange.start.data, test.result);
+          });
+        });
+      });
+      context('common ancestor is not ELEMENT_NODE', () => {
+        it('corrects the commons ancestor to the first non text node', () => {
+          const browserRange = createBrowserRange({
+            commonAncestorContainer: container.querySelector('#p-1').firstChild,
+          });
+          const normalizedRange = normalize(browserRange, container);
+          assert.deepEqual(
+            normalizedRange.commonAncestor,
+            container.querySelector('#p-1')
+          );
+        });
+      });
+    });
+
+    describe('NormalizedRange type', () => {
+      it('returns an instance of itself', () => {
+        const initialRange = createNormalizedRange();
+        const normalizedRange = normalize(initialRange, container);
+        assert.deepEqual(initialRange, normalizedRange);
+      });
+    });
+
+    describe('SerializedRange type', () => {
+      it('converts a SerializedRange instance to a NormalizedRange instance', () => {
+        const serializedRange = createSerializedRange({
+          startOffset: 0,
+          endOffset: 6,
+        });
+        const normalizedRange = normalize(serializedRange, container);
+        assert.isTrue(normalizedRange instanceof NormalizedRange);
+        assert.equal(normalizedRange.start.data, 'text 1');
+        assert.equal(normalizedRange.end.data, 'text 3');
+      });
+
+      it('adjusts starting offset to second text node', () => {
+        const serializedRange = createSerializedRange({
+          start: '/section[1]/p[2]',
+          end: '/section[1]/p[2]',
+          startOffset: 7,
+          endOffset: 14,
+        });
+        const normalizedRange = normalize(serializedRange, container);
+        assert.isTrue(normalizedRange instanceof NormalizedRange);
+        assert.equal(normalizedRange.start.data, 'text 2b');
+        assert.equal(normalizedRange.end.data, 'text 2b');
+      });
+
+      context('when offsets are invalid', () => {
+        it("throws an error if it can't find a valid start offset", () => {
+          const serializedRange = createSerializedRange({
+            startOffset: 99,
+          });
+          assert.throws(() => {
+            normalize(serializedRange, container);
+          }, "Couldn't find offset 99 in element /section[1]/p[1]");
+        });
+
+        it("throws an error if it can't find a valid start offset", () => {
+          const serializedRange = createSerializedRange({
+            startOffset: 1,
+            endOffset: 99,
+          });
+          assert.throws(() => {
+            normalize(serializedRange, container);
+          }, "Couldn't find offset 99 in element /section[1]/span[1]/p[1]");
+        });
+      });
+
+      context('nodeFromXPath() does not return a valid node', () => {
+        let fakeNodeFromXPath;
+
+        beforeEach(() => {
+          fakeNodeFromXPath = sinon.stub();
+          $imports.$mock({
+            './range-js': {
+              nodeFromXPath: fakeNodeFromXPath,
+            },
+          });
+        });
+
+        afterEach(() => {
+          $imports.$restore();
+        });
+
+        it('throws a range error if nodeFromXPath() throws an error', () => {
+          fakeNodeFromXPath.throws(new Error('error message'));
+          const serializedRange = createSerializedRange();
+          assert.throws(() => {
+            normalize(serializedRange, container);
+          }, 'Error while finding start node: /section[1]/p[1]: Error: error message');
+        });
+
+        it('throws a range error if nodeFromXPath() does not return a node', () => {
+          fakeNodeFromXPath.returns(null);
+          const serializedRange = createSerializedRange();
+          assert.throws(() => {
+            normalize(serializedRange, container);
+          }, "Couldn't find start node: /section[1]/p[1]");
+        });
+      });
+    });
+
+    describe('invalid type', () => {
+      it('throws an error when attempting to serialize an unknown range instance', () => {
+        const invalidRangeObject = {};
+        assert.throws(() => {
+          normalize(invalidRangeObject, container);
+        }, 'Could not normalize unknown range type');
+      });
+    });
+  });
+});

--- a/src/annotator/anchoring/test/range-browser-test.js
+++ b/src/annotator/anchoring/test/range-browser-test.js
@@ -1,0 +1,52 @@
+import { BrowserRange } from '../range-browser';
+
+describe('annotator/anchoring/range-browser', () => {
+  describe('BrowserRange', () => {
+    let container;
+    const html = `
+        <section id="section-1">
+          <p id="p-1">text 1</p>
+          <p id="p-2">text 2</p>
+          <span id="span-1">
+            <p id="p-3">text 3</p>
+          </span>
+        </section>
+        <span id="span-2"></span>`;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+      // Remove extraneous white space which can affect textNodes in tests.
+      // 1. two or more spaces in a row
+      // 2. new lines
+      container.innerHTML = html.replace(/[\s+]{2,}|\n+/g, '');
+    });
+
+    afterEach(() => {
+      container.remove();
+    });
+
+    function createRange() {
+      return new BrowserRange({
+        commonAncestorContainer: container,
+        startContainer: container.querySelector('#p-1').firstChild,
+        startOffset: 0,
+        endContainer: container.querySelector('#p-3').firstChild,
+        endOffset: 0,
+      });
+    }
+    describe('#constructor', () => {
+      it('creates a BrowserRange instance', () => {
+        const range = createRange();
+        assert.deepEqual(range, {
+          commonAncestorContainer: container,
+          startContainer: container.querySelector('#p-1').firstChild,
+          startOffset: 0,
+          endContainer: container.querySelector('#p-3').firstChild,
+          endOffset: 0,
+          tainted: false,
+        });
+      });
+    });
+  });
+});

--- a/src/annotator/anchoring/test/range-normalized-test.js
+++ b/src/annotator/anchoring/test/range-normalized-test.js
@@ -1,0 +1,97 @@
+import { NormalizedRange } from '../range-normalized';
+
+describe('annotator/anchoring/range-normalized', () => {
+  describe('NormalizedRange', () => {
+    let container;
+    const html = `
+        <section id="section-1">
+          <p id="p-1">text 1</p>
+          <p id="p-2">text 2</p>
+          <span id="span-1">
+            <p id="p-3">text 3</p>
+          </span>
+        </section>
+        <span id="span-2"></span>`;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+      // Remove extraneous white space which can affect textNodes in tests.
+      // 1. two or more spaces in a row
+      // 2. new lines
+      container.innerHTML = html.replace(/[\s+]{2,}|\n+/g, '');
+    });
+
+    afterEach(() => {
+      container.remove();
+    });
+
+    function createRange(props) {
+      return new NormalizedRange({
+        commonAncestor: container,
+        start: container.querySelector('#p-1').firstChild,
+        end: container.querySelector('#p-3').firstChild,
+        ...props,
+      });
+    }
+
+    describe('#limit, #text and #textNodes methods', () => {
+      it('does not limit range if the limit node resides outside of bounds', () => {
+        const limit = createRange().limit(container.querySelector('#span-2'));
+        assert.isNull(limit);
+      });
+
+      [
+        {
+          bound: '#p-1',
+          textNodes: ['text 1'],
+        },
+        {
+          bound: '#p-2',
+          textNodes: ['text 2'],
+        },
+        {
+          bound: '#section-1',
+          textNodes: ['text 1', 'text 2', 'text 3'],
+        },
+      ].forEach(test => {
+        it('limits range to the bounding node', () => {
+          let limit = createRange().limit(container.querySelector(test.bound));
+          assert.equal(limit.text(), test.textNodes.join(''));
+          // To get a node value from jquery, use ".data".
+          assert.deepEqual(
+            test.textNodes,
+            limit.textNodes().map(n => n.data)
+          );
+        });
+      });
+    });
+
+    describe('#toRange', () => {
+      let fakeSetStartBefore;
+      let fakeSetEndAfter;
+
+      beforeEach(() => {
+        sinon.stub(document, 'createRange');
+        fakeSetStartBefore = sinon.stub();
+        fakeSetEndAfter = sinon.stub();
+        document.createRange.returns({
+          setStartBefore: fakeSetStartBefore,
+          setEndAfter: fakeSetEndAfter,
+        });
+      });
+
+      afterEach(() => {
+        document.createRange.restore();
+      });
+
+      it('converts normalized range to native range', () => {
+        const range = createRange();
+        const nativeRange = range.toRange();
+        assert.deepEqual(nativeRange, document.createRange());
+        assert.calledWith(fakeSetStartBefore, range.start);
+        assert.calledWith(fakeSetEndAfter, range.end);
+      });
+    });
+  });
+});

--- a/src/annotator/anchoring/test/range-serialized-test.js
+++ b/src/annotator/anchoring/test/range-serialized-test.js
@@ -1,0 +1,62 @@
+import { SerializedRange } from '../range-serialized';
+
+describe('annotator/anchoring/range-serialized', () => {
+  describe('SerializedRange', () => {
+    let container;
+    const html = `
+        <section id="section-1">
+          <p id="p-1">text 1</p>
+          <p id="p-2">text 2</p>
+          <span id="span-1">
+            <p id="p-3">text 3</p>
+          </span>
+        </section>
+        <span id="span-2"></span>`;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+      // Remove extraneous white space which can affect textNodes in tests.
+      // 1. two or more spaces in a row
+      // 2. new lines
+      container.innerHTML = html.replace(/[\s+]{2,}|\n+/g, '');
+    });
+
+    afterEach(() => {
+      container.remove();
+    });
+
+    function createRange() {
+      return new SerializedRange({
+        start: container.querySelector('#p-1').firstChild,
+        startOffset: 0,
+        end: container.querySelector('#p-3').firstChild,
+        endOffset: 0,
+      });
+    }
+
+    describe('#constructor', () => {
+      it('creates a SerializedRange instance', () => {
+        const range = createRange();
+        assert.deepEqual(range, {
+          start: container.querySelector('#p-1').firstChild,
+          startOffset: 0,
+          end: container.querySelector('#p-3').firstChild,
+          endOffset: 0,
+        });
+      });
+    });
+
+    describe('#toObject', () => {
+      it('returns an object literal', () => {
+        const range = createRange();
+        assert.deepEqual(range.toObject(), {
+          start: container.querySelector('#p-1').firstChild,
+          startOffset: 0,
+          end: container.querySelector('#p-3').firstChild,
+          endOffset: 0,
+        });
+      });
+    });
+  });
+});

--- a/src/annotator/anchoring/test/serialize-test.js
+++ b/src/annotator/anchoring/test/serialize-test.js
@@ -1,0 +1,220 @@
+import { serialize, $imports } from '../serialize';
+import { BrowserRange } from '../range-browser';
+import { NormalizedRange } from '../range-normalized';
+import { SerializedRange } from '../range-serialized';
+
+describe('annotator/anchoring/serialize', () => {
+  let container;
+  const html = `
+      <section id="section-1">
+        <p id="p-1">text 1</p>
+        <p id="p-2">text 2a<br>text 2b</p>
+        <span id="span-1">
+          <p id="p-3">text 3</p>
+        </span>
+      </section>
+      <span id="span-2"></span>`;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    // Remove extraneous white space which can affect offsets in tests.
+    // 1. Two or more spaces in a row
+    // 2. New lines
+    container.innerHTML = html.replace(/[\s+]{2,}|\n+/g, '');
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  function createBrowserRange(props) {
+    return new BrowserRange({
+      commonAncestorContainer: container,
+      startContainer: container.querySelector('#p-1').firstChild,
+      startOffset: 0,
+      endContainer: container.querySelector('#p-3').firstChild,
+      endOffset: 6,
+      ...props,
+    });
+  }
+
+  function createNormalizedRange(props) {
+    return new NormalizedRange({
+      commonAncestor: container,
+      start: container.querySelector('#p-1').firstChild,
+      end: container.querySelector('#p-3').firstChild,
+      ...props,
+    });
+  }
+
+  function createSerializedRange(props) {
+    return new SerializedRange({
+      start: '/section[1]/p[1]',
+      startOffset: 0,
+      end: '/section[1]/span[1]/p[1]',
+      endOffset: 6,
+      ...props,
+    });
+  }
+
+  describe('serialize', () => {
+    describe('BrowserRange type', () => {
+      let fakeNormalize;
+
+      beforeEach(() => {
+        fakeNormalize = sinon.stub();
+        $imports.$mock({
+          './normalize': {
+            normalize: fakeNormalize,
+          },
+        });
+      });
+
+      afterEach(() => {
+        $imports.$restore();
+      });
+
+      it('converts BrowserRange to SerializedRange instance', () => {
+        const browserRange = createBrowserRange();
+        const normalizedRange = createNormalizedRange();
+        fakeNormalize
+          .withArgs(browserRange, container)
+          .returns(normalizedRange); // mock the normalized return value
+        const result = serialize(browserRange, container);
+        assert.isTrue(result instanceof SerializedRange);
+        assert.equal(result.end, '/section[1]/span[1]/p[1]');
+      });
+
+      it('converts BrowserRange to SerializedRange instance with `ignoreSelector` condition', () => {
+        const browserRange = createBrowserRange();
+        const normalizedRange = createNormalizedRange();
+        // Mock the normalized return value
+        fakeNormalize
+          .withArgs(browserRange, container)
+          .returns(normalizedRange);
+        const result = serialize(browserRange, container, '#p-3');
+        // End xpath shall ignore the provided selector.
+        assert.equal(result.end, '/section[1]/span[1]');
+      });
+    });
+
+    describe('NormalizedRange type', () => {
+      let fakeSerializedRange;
+
+      beforeEach(() => {
+        fakeSerializedRange = sinon.stub();
+        $imports.$mock({
+          './range-serialized': {
+            SerializedRange: fakeSerializedRange,
+          },
+        });
+      });
+
+      afterEach(() => {
+        $imports.$restore();
+      });
+
+      it('serialize the range with relative parent', () => {
+        serialize(createNormalizedRange(), container);
+        assert.calledWith(fakeSerializedRange, {
+          start: '/section[1]/p[1]',
+          end: '/section[1]/span[1]/p[1]',
+          startOffset: 0,
+          endOffset: 6,
+        });
+      });
+
+      it('serialize the range with no relative parent', () => {
+        serialize(createNormalizedRange());
+        assert.calledWith(fakeSerializedRange, {
+          start: '/html[1]/body[1]/div[1]/section[1]/p[1]',
+          end: '/html[1]/body[1]/div[1]/section[1]/span[1]/p[1]',
+          startOffset: 0,
+          endOffset: 6,
+        });
+      });
+
+      it('serialize the range with `ignoreSelector` condition', () => {
+        serialize(createNormalizedRange(), container, '#p-3');
+        assert.calledWith(fakeSerializedRange, {
+          start: '/section[1]/p[1]',
+          end: '/section[1]/span[1]',
+          startOffset: 0,
+          endOffset: 6,
+        });
+      });
+
+      it('serialize the range with multiple text nodes', () => {
+        serialize(
+          createNormalizedRange({
+            start: container.querySelector('#p-2').firstChild.nextSibling
+              .nextSibling,
+            end: container.querySelector('#p-3').firstChild,
+            startOffset: 7,
+            endOffset: 6,
+          })
+        );
+        assert.calledWith(fakeSerializedRange, {
+          start: '/html[1]/body[1]/div[1]/section[1]/p[2]',
+          end: '/html[1]/body[1]/div[1]/section[1]/span[1]/p[1]',
+          startOffset: 7,
+          endOffset: 6,
+        });
+      });
+    });
+
+    describe('SerializedRange type', () => {
+      let fakeNormalize;
+
+      beforeEach(() => {
+        fakeNormalize = sinon.stub();
+        $imports.$mock({
+          './normalize': {
+            normalize: fakeNormalize,
+          },
+        });
+      });
+
+      afterEach(() => {
+        $imports.$restore();
+      });
+
+      it('converts a SerializedRange to a new SerializedRange instance', () => {
+        const serializedRange = createSerializedRange();
+        const normalizedRange = createNormalizedRange();
+        // mock the normalized return value
+        fakeNormalize
+          .withArgs(serializedRange, container)
+          .returns(normalizedRange);
+        const result = serialize(serializedRange, container);
+        assert.isTrue(result instanceof SerializedRange);
+        // the copied instance shall be identical to the initial
+        assert.deepEqual(result, serializedRange);
+      });
+
+      it('converts a SerializedRange to a new SerializedRange instance with `ignoreSelector` condition', () => {
+        const serializedRange = createSerializedRange();
+        const normalizedRange = createNormalizedRange();
+        // mock the normalized return value
+        fakeNormalize
+          .withArgs(serializedRange, container)
+          .returns(normalizedRange);
+        const result = serialize(serializedRange, container, '#p-3');
+        // end xpath shall ignore the provided selector and not
+        // be identical to the initial end xpath
+        assert.notEqual(serializedRange.end, result.end);
+        assert.equal(result.end, '/section[1]/span[1]');
+      });
+    });
+
+    describe('invalid type', () => {
+      it('throws an error when attempting to serialize an unknown range instance', () => {
+        const invalidRangeObject = {};
+        assert.throws(() => {
+          serialize(invalidRangeObject, container);
+        }, 'Could not serialize unknown range type');
+      });
+    });
+  });
+});


### PR DESCRIPTION
**WIP**

In short, no unit tests for any of these modules existed. All tests are new and may not all make sense. I did the best I could trying to figure out how all this stuff worked. The goal was make as much sense as possible with 100% code coverage.

**_Note that this code is not hooked up yet so it won't run even if commited._**

It's also possible that once we hook this up to the full integration tests (html-test.js) that something might show up. I don't have 100% confidence this is perfect, but it may not matter because Its close and we should see any issues come up at that time -- I expect them to be minor.

**What is not done yet:**
1. typing.
2. major reworking of comments.
3. various bugs relating to range.
4. remove jquery

Because of the size of this PR, I don't want to complicate it with any of the above issues. They can be done with better confidence in later passes.

TODO:

- [ ] give this a fresh look in the morning. I'm tired right now
- [ ] decide if we should spend the extra time to make 100% of the tests in serialize() and normalize() pure unit tests or continue allow them to use BrowserRange, NormalizedRange, SerializedRange without stubbing the responses entirely.

**(2) Commits:**
---------------

Convert range classes from coffeescript to js.

 1. BrowserRange
 2. NormalizedRange
 3. SerializedRange

Converted classes no longer contain serialize() and normalize() methods. This is done to remove circular dependencies from the classes and break up complex serialization and normalization logic into separate modules and functions which is easier to read and test.

----------------

Add normalize and serialize converted modules

These modules contain only 1 function each and replace the 3 serialize() and normalize() functions previously found in each of the 3 coffeescript range classes. The fundamental difference is that these functions are not bound to a specific range class type and instead take a range instance param and then decided which conversion algorithm to run based on the type of instance.

This removes the circular dependencies each of the 3 range classes had and additionally groups all complex serialize and normalize logic into discrete modules.