### PR TITLE
Fix real-time update action processing

### DIFF
--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -98,9 +98,12 @@ function receiveRealTimeUpdates({
       // focused group, since we only display annotations from the focused
       // group and reload all annotations and discard pending updates
       // when switching groups.
+      const groupState = getState().groups;
+      const routeState = getState().route;
+
       if (
-        ann.group === groups.selectors.focusedGroupId(getState()) ||
-        route.selectors.route(getState()) !== 'sidebar'
+        ann.group === groups.selectors.focusedGroupId(groupState) ||
+        route.selectors.route(routeState) !== 'sidebar'
       ) {
         pendingUpdates[/** @type {string} */ (ann.id)] = ann;
       }
@@ -116,7 +119,8 @@ function receiveRealTimeUpdates({
       // even if the annotation is from the current group, it might be for a
       // new annotation (saved in pendingUpdates and removed above), that has
       // not yet been loaded.
-      if (annotations.selectors.annotationExists(getState(), id)) {
+      const annotationsState = getState().annotations;
+      if (annotations.selectors.annotationExists(annotationsState, id)) {
         pendingDeletions[id] = true;
       }
     });

--- a/src/sidebar/store/modules/test/real-time-updates-test.js
+++ b/src/sidebar/store/modules/test/real-time-updates-test.js
@@ -16,9 +16,20 @@ describe('sidebar/store/modules/real-time-updates', () => {
   let store;
 
   beforeEach(() => {
-    fakeAnnotationExists = sinon.stub().returns(true);
-    fakeFocusedGroupId = sinon.stub().returns('group-1');
-    fakeRoute = sinon.stub().returns('sidebar');
+    fakeAnnotationExists = sinon.stub().callsFake(state => {
+      assert.equal(state, store.getState().annotations);
+      return true;
+    });
+
+    fakeFocusedGroupId = sinon.stub().callsFake(state => {
+      assert.equal(state, store.getState().groups);
+      return 'group-1';
+    });
+
+    fakeRoute = sinon.stub().callsFake(state => {
+      assert.equal(state, store.getState().route);
+      return 'sidebar';
+    });
 
     store = createStore(
       [realTimeUpdates, annotations, selection],


### PR DESCRIPTION
When store modules were refactored to only receive their local state in
selectors, the code in `store/modules/real-time-updates` which directly
uses selectors from other modules rather than calling
`store.<selectorMethod>(...)` was not updated to pass in the appropriate
part of the state.

Fixing this resolves two problems:

 - An error when processing notifications of deleted annotations from
   the server. These notifications are currently not getting delivered
   due to a server-side issue (see https://github.com/hypothesis/h/pull/6214).

 - Filtering notifications of new or updated annotations not excluding
   annotations from groups that are not currently focused.

   Fixing this second issue has the side effect that it _appears_ to fix
   https://github.com/hypothesis/support/issues/137 from the user's
   point of view. I say _appears to_ because the backend is still
   incorrectly delivering notifications that the user shouldn't be able
   to see. That is fixed by https://github.com/hypothesis/h/pull/6202