### PR TITLE
Improve type coercions for paramWhiteList

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -1,5 +1,5 @@
 import settingsFrom from './settings';
-import { toBoolean } from '../../shared/type-coercions';
+import coercions from '../../shared/type-coercions';
 
 /**
  * Reads the Hypothesis configuration from the environment.
@@ -33,7 +33,7 @@ export default function configFrom(window_) {
     openSidebar: settings.hostPageSetting('openSidebar', {
       allowInBrowserExt: true,
       // Coerce value to a boolean because it may come from via as a string
-      coerce: toBoolean,
+      coerce: coercions.toBoolean,
     }),
     query: settings.query,
     requestConfigFromFrame: settings.hostPageSetting('requestConfigFromFrame'),

--- a/src/sidebar/test/host-config-test.js
+++ b/src/sidebar/test/host-config-test.js
@@ -65,9 +65,9 @@ describe('hostPageConfig', function () {
     assert.deepEqual(hostPageConfig(window_), {});
   });
 
-  it('ignores `null` values in config', function () {
+  it('ignores `undefined` values in config', function () {
     const window_ = fakeWindow({
-      openSidebar: null,
+      openSidebar: undefined,
     });
 
     assert.deepEqual(hostPageConfig(window_), {});


### PR DESCRIPTION
- Rework coercions so they work more like react props rather than function calls
- Improve type-coercion capability to allow for nullish values. This is similar to propTypes `.isRequired`
- Add coercions to remaining config settings host-config.

partially fixes: #1968

-----------

Example usage..

```
  const paramWhiteList = {
    annotations: coercions.toString.orNull,
    group: coercions.toString.orNull,
    query: coercions.toString.orNull,
    appType: coercions.toString.orNull,
    openSidebar: coercions.toBoolean,
    ...
```
When reviewing this, the diff is hard to follow and makes little sense because the `type-coercions.js` is totally restructured. 

Image diff (master is on the right, this branch on the left) --it's a screenshot of the host-config after its run through the  `paramWhiteList`. They are identical.

![Screen Shot 2020-09-12 at 2 49 55 PM](https://user-images.githubusercontent.com/3939074/93005595-3fab7980-f507-11ea-9b8a-89e4c7d32bad.png)



