### PR TITLE
Highlight quote when hovering on an annotation in the main text

### DIFF
--- a/src/sidebar/components/annotation-quote.js
+++ b/src/sidebar/components/annotation-quote.js
@@ -40,7 +40,6 @@ function AnnotationQuote({ annotation, isFocused, settings = {} }) {
     <div
       className={classnames('annotation-quote', {
         'is-orphan': isOrphan(annotation),
-        'is-focused': isFocused,
       })}
     >
       <Excerpt
@@ -49,7 +48,9 @@ function AnnotationQuote({ annotation, isFocused, settings = {} }) {
         overflowThreshold={20}
       >
         <blockquote
-          className="annotation-quote__quote"
+          className={classnames('annotation-quote__quote', {
+            'is-focused': isFocused,
+          })}
           dir="auto"
           lang={documentLanguage}
           style={applyTheme(['selectionFontFamily'], settings)}

--- a/src/styles/sidebar/components/annotation.scss
+++ b/src/styles/sidebar/components/annotation.scss
@@ -2,12 +2,6 @@
 @use "../../mixins/layout";
 @use "../../variables" as var;
 
-// FIXME These hover-related rules should live elsewhere
-// Highlight quote of annotation whenever its thread is hovered
-.thread-list__card:hover .annotation-quote__quote {
-  border-left: var.$color-quote 3px solid;
-}
-
 // When hovering a top-level annotation, show the footer in a hovered state.
 // When hovering a reply (at any level), show the reply's own footer in
 // a hovered state and also the footer of the top-level annotation.


### PR DESCRIPTION
This fixes #2527 