### PR TITLE
Dumb fix for `nzz.ch` site

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -92,7 +92,7 @@ export class Adder {
 
       // Assign a high Z-index so that the adder shows above any content on the
       // page
-      zIndex: 999,
+      zIndex: 10000,
     });
 
     this._view = /** @type {Window} */ (container.ownerDocument.defaultView);


### PR DESCRIPTION
I will take a look later at the smart solution (get the compute z-index value of all the parent elements).