### PR TITLE
Change `flex` alignment to fix one-pixel gap in toast message containers

### DIFF
--- a/src/styles/sidebar/components/toast-messages.scss
+++ b/src/styles/sidebar/components/toast-messages.scss
@@ -37,7 +37,7 @@
 
 .toast-message {
   @include molecules.card-frame;
-  @include layout.row($align: center);
+  @include layout.row($align: stretch);
   position: relative;
   width: 100%;
   margin-bottom: 0.75em;


### PR DESCRIPTION
Fixes #2561