### PR TITLE
Move remaining highlighting logic from `Guest` class to `highlighter.js`

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -10,6 +10,7 @@ import * as htmlAnchoring from './anchoring/html';
 import * as xpathRange from './anchoring/range';
 
 import {
+  getHighlightsContainingNode,
   highlightRange,
   removeAllHighlights,
   removeHighlights,
@@ -57,20 +58,9 @@ function annotationsForSelection() {
  * DOM node.
  */
 function annotationsAt(node) {
-  if (node.nodeType !== Node.ELEMENT_NODE) {
-    node = node.parentElement;
-  }
-
-  const highlights = [];
-
-  while (node) {
-    if (node.classList.contains('hypothesis-highlight')) {
-      highlights.push(node);
-    }
-    node = node.parentElement;
-  }
-
-  return highlights.map(h => h._annotation);
+  return getHighlightsContainingNode(node).map(
+    h => /** @type {AnnotationHighlight} */ (h)._annotation
+  );
 }
 
 // A selector which matches elements added to the DOM by Hypothesis (eg. for

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -44,23 +44,35 @@ const animationPromise = fn =>
     })
   );
 
+/**
+ * Return all the annotations associated with the selected text.
+ *
+ * @return {AnnotationData[]}
+ */
 function annotationsForSelection() {
   const selection = /** @type {Selection} */ (window.getSelection());
   const range = selection.getRangeAt(0);
-  return rangeUtil.itemsForRange(
+  const items = rangeUtil.itemsForRange(
     range,
+
+    // nb. Only non-nullish items are returned by `itemsForRange`.
     node => /** @type {AnnotationHighlight} */ (node)._annotation
   );
+  return /** @type {AnnotationData[]} */ (items);
 }
 
 /**
  * Return the annotations associated with any highlights that contain a given
  * DOM node.
+ *
+ * @param {Node} node
+ * @return {AnnotationData[]}
  */
 function annotationsAt(node) {
-  return getHighlightsContainingNode(node).map(
-    h => /** @type {AnnotationHighlight} */ (h)._annotation
-  );
+  const items = getHighlightsContainingNode(node)
+    .map(h => /** @type {AnnotationHighlight} */ (h)._annotation)
+    .filter(ann => ann !== undefined);
+  return /** @type {AnnotationData[]} */ (items);
 }
 
 // A selector which matches elements added to the DOM by Hypothesis (eg. for

--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -302,6 +302,30 @@ export function setHighlightsVisible(root, visible) {
 }
 
 /**
+ * Get the highlight elements that contain the given node.
+ *
+ * @param {Node} node
+ * @return {HighlightElement[]}
+ */
+export function getHighlightsContainingNode(node) {
+  let el =
+    node.nodeType === Node.ELEMENT_NODE
+      ? /** @type {Element} */ (node)
+      : node.parentElement;
+
+  const highlights = [];
+
+  while (el) {
+    if (el.classList.contains('hypothesis-highlight')) {
+      highlights.push(/** @type {HighlightElement} */ (el));
+    }
+    el = el.parentElement;
+  }
+
+  return highlights;
+}
+
+/**
  * Subset of `DOMRect` interface.
  *
  * @typedef Rect

--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -247,6 +247,16 @@ function replaceWith(node, replacements) {
 }
 
 /**
+ * Remove all highlights under a given root element.
+ *
+ * @param {HTMLElement} root
+ */
+export function removeAllHighlights(root) {
+  const highlights = Array.from(root.querySelectorAll('hypothesis-highlight'));
+  removeHighlights(/** @type {HighlightElement[]} */ (highlights));
+}
+
+/**
  * Remove highlights from a range previously highlighted with `highlightRange`.
  *
  * @param {HighlightElement[]} highlights - The highlight elements returned by `highlightRange`
@@ -262,6 +272,33 @@ export function removeHighlights(highlights) {
       h.svgHighlight.remove();
     }
   }
+}
+
+/**
+ * Set whether the given highlight elements should appear "focused".
+ *
+ * A highlight can be displayed in a different ("focused") style to indicate
+ * that it is current in some other context - for example the user has selected
+ * the corresponding annotation in the sidebar.
+ *
+ * @param {HighlightElement[]} highlights
+ * @param {boolean} focused
+ */
+export function setHighlightsFocused(highlights, focused) {
+  highlights.forEach(h =>
+    h.classList.toggle('hypothesis-highlight-focused', focused)
+  );
+}
+
+/**
+ * Set whether highlights under the given root element should be visible.
+ *
+ * @param {HTMLElement} root
+ * @param {boolean} visible
+ */
+export function setHighlightsVisible(root, visible) {
+  const showHighlightsClass = 'hypothesis-highlights-always-on';
+  root.classList.toggle(showHighlightsClass, visible);
 }
 
 /**

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -4,6 +4,7 @@ import Range from '../anchoring/range';
 
 import {
   getBoundingClientRect,
+  getHighlightsContainingNode,
   highlightRange,
   removeHighlights,
   removeAllHighlights,
@@ -420,6 +421,41 @@ describe('annotator/highlighter', () => {
       assert.isFalse(
         root.classList.contains('hypothesis-highlights-always-on')
       );
+    });
+  });
+
+  describe('getHighlightsContainingNode', () => {
+    const makeRange = (start, end = start) =>
+      new Range.NormalizedRange({
+        commonAncestor: start.parentNode,
+        start,
+        end,
+      });
+
+    it('returns all the highlights containing the node', () => {
+      const root = document.createElement('div');
+      const text0 = document.createTextNode('One');
+      const text1 = document.createTextNode('Two');
+      root.appendChild(text0);
+      root.appendChild(text1);
+
+      const [highlight0] = highlightRange(makeRange(text0, text1));
+      const [highlight1] = highlightRange(makeRange(text0));
+
+      const highlights = getHighlightsContainingNode(text0);
+
+      assert.deepEqual(highlights, [highlight1, highlight0]);
+    });
+
+    it('returns an empty array if the node is not contained in a highlight', () => {
+      const root = document.createElement('div');
+      root.textContent = 'Test text';
+      assert.deepEqual(getHighlightsContainingNode(root.childNodes[0]), []);
+    });
+
+    it('returns an empty array if node has no parent element', () => {
+      const text = document.createTextNode('foobar');
+      assert.deepEqual(getHighlightsContainingNode(text), []);
     });
   });
 

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -337,6 +337,11 @@ describe('annotator/highlighter', () => {
     });
   });
 
+  /**
+   * Add some text nodes to `root` and highlight them with `highlightRange`.
+   *
+   * Returns all the highlight elements.
+   */
   function createHighlights(root) {
     let highlights = [];
 


### PR DESCRIPTION
This is some follow-up refactoring to the recent conversion of the `Guest` class to JS.

The `Guest` class currently does some manipulation of highlights directly and some through functions in `highlighter.js`. For a better separation of responsibilities, this PR extracts the remaining direct manipulation of highlights out of the `Guest` class and into functions in `highlighter.js`. In the process the logic has been changed to use plain DOM APIs rather than jQuery and the tests have been improved.

With these changes it was a very small step to remove the remaining direct usage of jQuery from the `Guest` class, so I have also done that as well.