### PR TITLE
Fix bug with asynchronous range highlighting

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -33,17 +33,6 @@ import { normalizeURI } from './util/url';
  * @typedef {Element & { _annotation?: AnnotationData }} AnnotationHighlight
  */
 
-const animationPromise = fn =>
-  new Promise((resolve, reject) =>
-    requestAnimationFrame(() => {
-      try {
-        resolve(fn());
-      } catch (error) {
-        reject(error);
-      }
-    })
-  );
-
 /**
  * Return all the annotations associated with the selected text.
  *
@@ -391,18 +380,16 @@ export default class Guest extends Delegator {
       if (!anchor.range) {
         return anchor;
       }
-      return animationPromise(() => {
-        const range = xpathRange.sniff(anchor.range);
-        const normedRange = range.normalize(root);
-        const highlights = /** @type {AnnotationHighlight[]} */ (highlightRange(
-          normedRange
-        ));
-        highlights.forEach(h => {
-          h._annotation = anchor.annotation;
-        });
-        anchor.highlights = highlights;
-        return anchor;
+      const range = xpathRange.sniff(anchor.range);
+      const normedRange = range.normalize(root);
+      const highlights = /** @type {AnnotationHighlight[]} */ (highlightRange(
+        normedRange
+      ));
+      highlights.forEach(h => {
+        h._annotation = anchor.annotation;
       });
+      anchor.highlights = highlights;
+      return anchor;
     };
 
     // Store the results of anchoring.

--- a/src/annotator/plugin/pdf.coffee
+++ b/src/annotator/plugin/pdf.coffee
@@ -1,4 +1,5 @@
 Plugin = require('../plugin')
+debounce = require('lodash.debounce')
 
 { default: RenderingStates } = require('../pdfjs-rendering-states')
 
@@ -16,7 +17,7 @@ module.exports = class PDF extends Plugin
 
     @pdfMetadata = new PDFMetadata(PDFViewerApplication)
 
-    @observer = new MutationObserver((mutations) => this._update())
+    @observer = new MutationObserver(debounce(this._update.bind(this), 100))
     @observer.observe(@pdfViewer.viewer, {
       attributes: true
       attributeFilter: ['data-loaded']


### PR DESCRIPTION
This PR attempts to fix a bug manifesting as a thrown Error and the disappearance of highlights from PDF documents after multiple resizes or other DOM-structure changes that fire the `MutationObserver` callback in the `PDF` plugin.

I shall elaborate on all things: explanation, motivation of approach, etc. after we verify that this approach is feasible.

(Edited: commit messages are now elaborated).

Fixes #2502 
