### PR TITLE
Remove unnecessary jQuery usage in several tests

### DIFF
--- a/src/annotator/plugin/test/document-test.js
+++ b/src/annotator/plugin/test/document-test.js
@@ -10,8 +10,6 @@
  ** https://github.com/openannotation/annotator/blob/master/LICENSE
  */
 
-import $ from 'jquery';
-
 import { normalizeURI } from '../../util/url';
 import DocumentMeta from '../document';
 
@@ -44,7 +42,6 @@ describe('DocumentMeta', function () {
 
   afterEach(() => {
     testDocument.destroy();
-    $(document).unbind();
   });
 
   it('attaches document metadata to new annotations', () => {
@@ -276,7 +273,8 @@ describe('DocumentMeta', function () {
           href,
         },
       };
-      const doc = new DocumentMeta($('<div></div>')[0], {
+      const divEl = document.createElement('div');
+      const doc = new DocumentMeta(divEl, {
         document: fakeDocument,
         baseURI,
       });

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import * as adder from '../adder';
 import { Observable } from '../util/observable';
 import Delegator from '../delegator';
@@ -225,12 +223,12 @@ describe('Guest', () => {
 
     describe('on "focusAnnotations" event', () => {
       it('focuses any annotations with a matching tag', () => {
-        const highlight0 = $('<span></span>');
-        const highlight1 = $('<span></span>');
+        const highlight0 = document.createElement('span');
+        const highlight1 = document.createElement('span');
         const guest = createGuest();
         guest.anchors = [
-          { annotation: { $tag: 'tag1' }, highlights: highlight0.toArray() },
-          { annotation: { $tag: 'tag2' }, highlights: highlight1.toArray() },
+          { annotation: { $tag: 'tag1' }, highlights: [highlight0] },
+          { annotation: { $tag: 'tag2' }, highlights: [highlight1] },
         ];
 
         emitGuestEvent('focusAnnotations', ['tag1']);
@@ -243,12 +241,12 @@ describe('Guest', () => {
       });
 
       it('unfocuses any annotations without a matching tag', () => {
-        const highlight0 = $('<span></span>');
-        const highlight1 = $('<span></span>');
+        const highlight0 = document.createElement('span');
+        const highlight1 = document.createElement('span');
         const guest = createGuest();
         guest.anchors = [
-          { annotation: { $tag: 'tag1' }, highlights: highlight0.toArray() },
-          { annotation: { $tag: 'tag2' }, highlights: highlight1.toArray() },
+          { annotation: { $tag: 'tag1' }, highlights: [highlight0] },
+          { annotation: { $tag: 'tag2' }, highlights: [highlight1] },
         ];
 
         emitGuestEvent('focusAnnotations', ['tag1']);
@@ -267,25 +265,25 @@ describe('Guest', () => {
       });
 
       it('scrolls to the anchor with the matching tag', () => {
-        const highlight = $('<span></span>');
+        const highlight = document.createElement('span');
         const guest = createGuest();
         guest.anchors = [
-          { annotation: { $tag: 'tag1' }, highlights: highlight.toArray() },
+          { annotation: { $tag: 'tag1' }, highlights: [highlight] },
         ];
         emitGuestEvent('scrollToAnnotation', 'tag1');
         assert.called(scrollIntoView);
-        assert.calledWith(scrollIntoView, highlight[0]);
+        assert.calledWith(scrollIntoView, highlight);
       });
 
       context('when dispatching the "scrolltorange" event', () => {
         it('emits with the range', () => {
-          const highlight = $('<span></span>');
+          const highlight = document.createElement('span');
           const guest = createGuest();
           const fakeRange = sinon.stub();
           guest.anchors = [
             {
               annotation: { $tag: 'tag1' },
-              highlights: highlight.toArray(),
+              highlights: [highlight],
               range: fakeRange,
             },
           ];
@@ -301,13 +299,13 @@ describe('Guest', () => {
         });
 
         it('allows the default scroll behaviour to be prevented', () => {
-          const highlight = $('<span></span>');
+          const highlight = document.createElement('span');
           const guest = createGuest();
           const fakeRange = sinon.stub();
           guest.anchors = [
             {
               annotation: { $tag: 'tag1' },
-              highlights: highlight.toArray(),
+              highlights: [highlight],
               range: fakeRange,
             },
           ];

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -43,11 +43,11 @@ describe('Sidebar', () => {
   };
 
   const createExternalContainer = () => {
-    const externalFrame = $(
-      '<div class="' + EXTERNAL_CONTAINER_SELECTOR + '"></div>'
-    );
-    externalFrame.width(DEFAULT_WIDTH).height(DEFAULT_HEIGHT);
-    return externalFrame[0];
+    const externalFrame = document.createElement('div');
+    externalFrame.className = EXTERNAL_CONTAINER_SELECTOR;
+    externalFrame.style.width = DEFAULT_WIDTH + 'px';
+    externalFrame.style.height = DEFAULT_HEIGHT + 'px';
+    return externalFrame;
   };
 
   beforeEach(() => {


### PR DESCRIPTION
Remove jQuery in places where it can easily be replaced with DOM APIs.

@lyzadanger recently asked me whether there was a general plan to remove jQuery from tests as there is to remove it from the annotator code that ships to users. I suggest the answer to that is "yes", but for different reasons. For end users this will reduce bundle size, which in turn helps startup time. For developers there is a modest consistency benefit in not needing to work with two different APIs for DOM manipulation.