### PR TITLE
Find suitable z-index for the adder

### DIFF
--- a/dev-server/documents/html/z-index.mustache
+++ b/dev-server/documents/html/z-index.mustache
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Hypothesis Client Test</title>
+<style>
+  body {
+    font-family: sans-serif;
+  }
+</style>
+</head>
+<body>
+  <h2>z-index test page</h2>
+  <p>This has a z-index of 0</p>
+  <ol style="z-index: 20000; position: relative">
+    <li style="z-index: 25000; position: relative">This has a z-index of 25000</li>
+    <li style="z-index: 30000; position: relative">This has a z-index of 30000</li>
+    <li>This has a z-index of 20000 (from parent)</li>
+    <li>This has a z-index of 20000 (from parent)</li>
+    <li>This has a z-index of 20000 (from parent)</li>
+  </ol>
+  <p>This has a z-index of 0</p>
+
+   {{{hypothesisScript}}}
+  </body>
+</html>

--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -18,6 +18,7 @@
     <li><a href="/document/burns">Poems and Songs of Robert Burns</a></li>
     <li><a href="/document/doyle">The Disappearance of Lady Carfax, by Arthur Conan Doyle</a></li>
     <li><a href="/document/tolstoy">Anna Karenina, by Leo Tolstoy</a></li>
+    <li><a href="/document/z-index">z-index page</a></li>
   </ul>
 
   <h2>Test PDF documents</h2>

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -1,4 +1,6 @@
 import { act } from 'preact/test-utils';
+import { createElement } from 'preact';
+import { mount } from 'enzyme';
 
 import { Adder, ARROW_POINTING_UP, ARROW_POINTING_DOWN } from '../adder';
 
@@ -214,6 +216,95 @@ describe('Adder', () => {
     it('does not positon the adder beyond the left edge of the viewport', () => {
       const target = adderCtrl.target(rect(-100, 100, 10, 10), false);
       assert.isAtLeast(target.left, 0);
+    });
+  });
+
+  describe('adder Z index', () => {
+    let container;
+
+    function getAdderZIndex(left, top) {
+      adderCtrl.showAt(left, top);
+      return parseInt(adderEl.style.zIndex);
+    }
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+      container.remove();
+    });
+
+    it('returns default hard coded value if `document.elementsFromPoint` is not available', () => {
+      const elementsFromPointBackup = document.elementsFromPoint;
+      document.elementsFromPoint = undefined;
+      assert.strictEqual(getAdderZIndex(0, 0), 32768);
+      document.elementsFromPoint = elementsFromPointBackup;
+    });
+
+    it('returns default value of 1', () => {
+      // Even if not elements are found, it returns 1
+      assert.strictEqual(getAdderZIndex(-100000, -100000), 1);
+      assert.strictEqual(getAdderZIndex(100000, 100000), 1);
+    });
+
+    it('returns the greatest zIndex', () => {
+      const createComponent = (left, top, zIndex, attachTo) =>
+        mount(
+          <div
+            style={{
+              position: 'absolute',
+              width: 1,
+              height: 1,
+              left,
+              top,
+              zIndex,
+            }}
+          />,
+          { attachTo }
+        );
+
+      const wrapper = createComponent(0, 0, 2, container);
+      assert.strictEqual(getAdderZIndex(0, 0), 3);
+
+      const initLeft = 10;
+      const initTop = 10;
+      const adderWidth = adderCtrl._width();
+      const adderHeight = adderCtrl._height();
+      const wrapperDOMNode = wrapper.getDOMNode();
+
+      // Create first element (left-top)
+      createComponent(initLeft, initTop, 3, wrapperDOMNode);
+      assert.strictEqual(getAdderZIndex(initLeft, initTop), 4);
+
+      // Create second element (left-bottom)
+      createComponent(initLeft, initTop + adderHeight, 5, wrapperDOMNode);
+      assert.strictEqual(getAdderZIndex(initLeft, initTop), 6);
+
+      // Create third element (middle-center)
+      createComponent(
+        initLeft + adderWidth / 2,
+        initTop + adderHeight / 2,
+        6,
+        wrapperDOMNode
+      );
+      assert.strictEqual(getAdderZIndex(initLeft, initTop), 7);
+
+      // Create fourth element (right-top)
+      createComponent(initLeft + adderWidth, initTop, 7, wrapperDOMNode);
+      assert.strictEqual(getAdderZIndex(initLeft, initTop), 8);
+
+      // Create third element (right-bottom)
+      createComponent(
+        initLeft + adderWidth,
+        initTop + adderHeight,
+        8,
+        wrapperDOMNode
+      );
+      assert.strictEqual(getAdderZIndex(initLeft, initTop), 9);
+
+      wrapper.unmount();
     });
   });
 


### PR DESCRIPTION
This PR incorporates a solution to programatically find a z-index for the adder. Before this, the z-index of the adder was a hard-coded value, which didn't work for some websites (see for example #2009).

We evaluated the option of finding the greatest z-index in the page. However, this takes too long for heavy pages.

This solution in this PR is not bulletproof, but probably works for the most part of the websites. It uses the greatest z-index of five nearby elements: left-top, left-bottom, middle-center, right-top, right-bottom elements around the adder.
  
Resolves #2009