### PR TITLE
Remove references to obsolete `page.el` property

### DIFF
--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -246,13 +246,12 @@ async function anchorByPosition(pageIndex, anchor) {
 
   // The page has not been rendered yet. Create a placeholder element and
   // anchor to that instead.
-  const div = /** @type {HTMLElement} */ (page.div || page.el);
-  let placeholder = div.getElementsByClassName('annotator-placeholder')[0];
+  let placeholder = page.div.querySelector('.annotator-placeholder');
   if (!placeholder) {
     placeholder = document.createElement('span');
     placeholder.classList.add('annotator-placeholder');
     placeholder.textContent = 'Loading annotations…';
-    div.appendChild(placeholder);
+    page.div.appendChild(placeholder);
   }
   const range = document.createRange();
   range.setStartBefore(placeholder);

--- a/src/annotator/plugin/pdf.js
+++ b/src/annotator/plugin/pdf.js
@@ -62,21 +62,12 @@ export default class PDF extends Plugin {
     // A list of annotations that need to be refreshed.
     const refreshAnnotations = [];
 
-    // Check all the pages with text layers that have finished rendering.
-    for (
-      let pageIndex = 0, end = this.pdfViewer.pagesCount, asc = 0 <= end;
-      asc ? pageIndex < end : pageIndex > end;
-      asc ? pageIndex++ : pageIndex--
-    ) {
+    const pageCount = this.pdfViewer.pagesCount;
+    for (let pageIndex = 0; pageIndex < pageCount; pageIndex++) {
       const page = this.pdfViewer.getPageView(pageIndex);
       if (!page.textLayer?.renderingDone) {
         continue;
       }
-
-      const div = page.div ?? page.el;
-      const placeholder = div.getElementsByClassName(
-        'annotator-placeholder'
-      )[0];
 
       // Detect what needs to be done by checking the rendering state.
       switch (page.renderingState) {
@@ -90,7 +81,12 @@ export default class PDF extends Plugin {
           // means the PDF anchoring module anchored annotations before it was
           // rendered. Remove this, which will cause the annotations to anchor
           // again, below.
-          placeholder?.parentNode.removeChild(placeholder);
+          {
+            const placeholder = page.div.querySelector(
+              '.annotator-placeholder'
+            );
+            placeholder?.parentNode.removeChild(placeholder);
+          }
           break;
       }
     }

--- a/src/types/pdfjs.js
+++ b/src/types/pdfjs.js
@@ -51,8 +51,6 @@
 /**
  * @typedef PDFPageView
  * @prop {HTMLElement} div - Container element for the PDF page
- * @prop {HTMLElement} el -
- *   Obsolete alias for `div`?. TODO: Remove this and stop checking for it.
  * @prop {PDFPageProxy} pdfPage
  * @prop {TextLayer|null} textLayer
  * @prop {number} renderingState - See `src/annotator/pdfjs-rendering-states.js`


### PR DESCRIPTION
The `el` property of PDF pages was removed from PDF.js in February 2015
in [eed67ea8](https://github.com/mozilla/pdf.js/commit/eed67ea8bbba61a05877a99dc2f03b5adad5a288) so we can remove this check while still supporting older versions of PDF.js that we care about.

Also rewrite an unnecessarily complex loop header. The `pagesCount`
property cannot be negative, so there is no need to check for this.