### PR TITLE
Simplify XPath generation code

### DIFF
--- a/src/annotator/anchoring/range.js
+++ b/src/annotator/anchoring/range.js
@@ -249,7 +249,7 @@ export class NormalizedRange {
       } else {
         origParent = $(node).parent();
       }
-      const xpath = xpathFromNode(origParent, root)[0];
+      const xpath = xpathFromNode(origParent[0], root ?? document);
       const textNodes = getTextNodes(origParent);
       // Calculate real offset as the combined length of all the
       // preceding textNode siblings. We include the length of the

--- a/src/annotator/anchoring/test/xpath-test.js
+++ b/src/annotator/anchoring/test/xpath-test.js
@@ -1,55 +1,6 @@
-import $ from 'jquery';
-
-import { nodeFromXPath, xpathFromNode, $imports } from '../xpath';
+import { nodeFromXPath } from '../xpath';
 
 describe('annotator/anchoring/xpath', () => {
-  describe('xpathFromNode', () => {
-    let container;
-    let fakeSimpleXPathJQuery;
-    let fakeSimpleXPathPure;
-
-    beforeEach(() => {
-      container = document.createElement('div');
-      document.body.appendChild(container);
-      fakeSimpleXPathJQuery = sinon.stub().returns('/div[1]');
-      fakeSimpleXPathPure = sinon.stub().returns('/div[1]');
-
-      $imports.$mock({
-        './xpath-util': {
-          simpleXPathJQuery: fakeSimpleXPathJQuery,
-          simpleXPathPure: fakeSimpleXPathPure,
-        },
-      });
-    });
-
-    afterEach(() => {
-      container.remove();
-      $imports.$restore();
-    });
-
-    it('calls `simpleXPathJQuery`', () => {
-      const xpath = xpathFromNode($(container), document.body);
-      assert.called(fakeSimpleXPathJQuery);
-      assert.equal(xpath, '/div[1]');
-    });
-
-    it('calls `simpleXPathPure` if `simpleXPathJQuery` throws an exception', () => {
-      sinon.stub(console, 'log');
-      fakeSimpleXPathJQuery.throws(new Error());
-      const xpath = xpathFromNode($(container), document.body);
-      assert.called(fakeSimpleXPathPure);
-      assert.equal(xpath, '/div[1]');
-      assert.isTrue(
-        // eslint-disable-next-line no-console
-        console.log.calledWith(
-          'jQuery-based XPath construction failed! Falling back to manual.'
-        )
-      );
-      // eslint-disable-next-line no-console
-      console.log.restore();
-    });
-  });
-
   describe('nodeFromXPath', () => {
     let container;
     const html = `

--- a/src/annotator/anchoring/xpath-util.js
+++ b/src/annotator/anchoring/xpath-util.js
@@ -60,7 +60,7 @@ function getPathSegment(node) {
 }
 
 /**
- * A simple XPath generator using which can generate XPaths of the form
+ * A simple XPath generator which can generate XPaths of the form
  * /tag[index]/tag[index].
  *
  * @param {Node} node - The node to generate a path to
@@ -79,7 +79,7 @@ export function xpathFromNode(node, root) {
     elem = elem.parentNode;
   }
   xpath = '/' + xpath;
-  xpath = xpath.replace(/\/$/, '');
+  xpath = xpath.replace(/\/$/, ''); // Remove trailing slash
 
   return xpath;
 }

--- a/src/annotator/anchoring/xpath.js
+++ b/src/annotator/anchoring/xpath.js
@@ -1,23 +1,6 @@
-import { findChild, simpleXPathJQuery, simpleXPathPure } from './xpath-util';
+import { findChild } from './xpath-util';
 
-/**
- * Wrapper for simpleXPath. Attempts to call the jquery
- * version, and if that excepts, then falls back to pure js
- * version.
- */
-export function xpathFromNode(el, relativeRoot) {
-  let result;
-  try {
-    result = simpleXPathJQuery(el, relativeRoot);
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.log(
-      'jQuery-based XPath construction failed! Falling back to manual.'
-    );
-    result = simpleXPathPure(el, relativeRoot);
-  }
-  return result;
-}
+export { xpathFromNode } from './xpath-util';
 
 /**
  * Finds an element node using an XPath relative to the document root.


### PR DESCRIPTION
For reasons that AFAIK are no longer relevant, there were two
implementations of XPath generation for use in serializing range
selectors. Since we're removing jQuery from the Hypothesis client, this
removes the jQuery implementation and simplifies the remaining DOM-only
one.

 - Remove jQuery XPath generation

 - Change the non-jQuery implementation to take DOM Nodes as input
   rather than jQuery collections

 - Simplify and add type documentation for the remaining implementation

 - Correct the documentation for `xpathFromNode`. The previous comments
   said that it _evaluated_ XPaths but actually it _generates_ them.