### PR TITLE
Remove jQuery usage from range.js

### DIFF
--- a/src/annotator/anchoring/range.js
+++ b/src/annotator/anchoring/range.js
@@ -416,32 +416,8 @@ export class SerializedRange {
       }
     }
 
-    // Here's an elegant next step...
-    //
-    //   range.commonAncestorContainer = $(range.startContainer).parents().has(range.endContainer)[0]
-    //
-    // ...but unfortunately Node.contains() is broken in Safari 5.1.5 (7534.55.3)
-    // and presumably other earlier versions of WebKit. In particular, in a
-    // document like
-    //
-    //   <p>Hello</p>
-    //
-    // the code
-    //
-    //   p = document.getElementsByTagName('p')[0]
-    //   p.contains(p.firstChild)
-    //
-    // returns `false`. Yay.
-    //
-    // So instead, we step through the parents from the bottom up and use
-    // Node.compareDocumentPosition() to decide when to set the
-    // commonAncestorContainer and bail out.
-
-    const contains = (a, b) =>
-      a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_CONTAINED_BY;
-
     for (let parent of parents(range.startContainer)) {
-      if (contains(parent, range.endContainer)) {
+      if (parent.contains(range.endContainer)) {
         range.commonAncestorContainer = parent;
         break;
       }

--- a/src/annotator/anchoring/range.js
+++ b/src/annotator/anchoring/range.js
@@ -271,7 +271,7 @@ export class NormalizedRange {
       const nodes = textNodes.slice(0, textNodes.indexOf(node));
       let offset = 0;
       for (let n of nodes) {
-        offset += n.nodeValue?.length ?? 0;
+        offset += n.data.length ?? 0;
       }
 
       if (isEnd) {
@@ -397,15 +397,12 @@ export class SerializedRange {
       }
 
       for (let tn of getTextNodes(node)) {
-        if (tn.nodeValue === null) {
-          continue;
-        }
-        if (length + tn.nodeValue.length > targetOffset) {
+        if (length + tn.data.length > targetOffset) {
           range[p + 'Container'] = tn;
           range[p + 'Offset'] = this[p + 'Offset'] - length;
           break;
         } else {
-          length += tn.nodeValue.length;
+          length += tn.data.length;
         }
       }
 

--- a/src/annotator/anchoring/test/xpath-util-test.js
+++ b/src/annotator/anchoring/test/xpath-util-test.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import {
   findChild,
   getTextNodes,
@@ -61,8 +59,7 @@ describe('annotator/anchoring/xpath-util', () => {
   describe('getTextNodes', () => {
     let container;
 
-    // Helper (expects a jquery array)
-    const nodeValues = nodes => nodes.map((i, n) => n.nodeValue);
+    const nodeValues = nodes => nodes.map(n => n.nodeValue);
 
     beforeEach(() => {
       container = document.createElement('div');
@@ -75,26 +72,22 @@ describe('annotator/anchoring/xpath-util', () => {
 
     it('finds basic text nodes', () => {
       container.innerHTML = `<span>text 1</span><span>text 2</span>`;
-      const result = getTextNodes($(container));
-      assert.deepEqual(nodeValues(result).toArray(), ['text 1', 'text 2']);
+      const result = getTextNodes(container);
+      assert.deepEqual(nodeValues(result), ['text 1', 'text 2']);
     });
 
     it('finds basic text nodes and whitespace', () => {
       container.innerHTML = `<span>text 1</span>
         <span>text 2</span>`;
-      const result = getTextNodes($(container));
-      assert.deepEqual(nodeValues(result).toArray(), [
-        'text 1',
-        '\n        ',
-        'text 2',
-      ]);
+      const result = getTextNodes(container);
+      assert.deepEqual(nodeValues(result), ['text 1', '\n        ', 'text 2']);
     });
 
     it('finds basic text nodes and whitespace but ignores comments', () => {
       container.innerHTML = `<span>text 1</span>
         <!--span>text 2</span-->`;
-      const result = getTextNodes($(container));
-      assert.deepEqual(nodeValues(result).toArray(), ['text 1', '\n        ']);
+      const result = getTextNodes(container);
+      assert.deepEqual(nodeValues(result), ['text 1', '\n        ']);
     });
   });
 

--- a/src/annotator/anchoring/xpath-util.js
+++ b/src/annotator/anchoring/xpath-util.js
@@ -85,45 +85,21 @@ export function xpathFromNode(node, root) {
 }
 
 /**
- * Flatten a nested array structure.
- * TODO: use Array.prototype.flat and polyfill
+ * Return all text node descendants of `element`.
+ *
+ * @param {Element} element
+ * @return {Text[]}
  */
-function flatten(array) {
-  const flatten = ary => {
-    let flat = [];
-    ary.forEach(el => {
-      if (el && Array.isArray(el)) {
-        flat = flat.concat(flatten(el));
-      } else {
-        flat = flat.concat(el);
-      }
-    });
-    return flat;
-  };
-  return flatten(array);
-}
-
-/**
- * Finds all text nodes within the elements in the current collection.
- * Returns a new jQuery collection of text nodes.
- */
-export function getTextNodes(jq) {
-  const getTextNodes = node => {
-    if (node && node.nodeType !== Node.TEXT_NODE) {
-      const nodes = [];
-      if (node.nodeType !== Node.COMMENT_NODE) {
-        [...node.childNodes].forEach(child => {
-          nodes.push(getTextNodes(child));
-        });
-      }
-      return nodes;
-    } else {
-      return node;
+export function getTextNodes(element) {
+  const nodes = [];
+  for (let node of Array.from(element.childNodes)) {
+    if (node instanceof Text) {
+      nodes.push(node);
+    } else if (node instanceof Element) {
+      nodes.push(...getTextNodes(node));
     }
-  };
-  return jq.map((index, node) => {
-    return flatten(getTextNodes(node));
-  });
+  }
+  return nodes;
 }
 
 /**


### PR DESCRIPTION
As part of the removal of jQuery from the annotator, remove usage from
`range.js`:

 - Replace `parents()` method with a small helper function

 - Rewrite `getTextNodes` function to accept and return DOM nodes rather
   than jQuery collections

 - Use `Node.contains` instead of jQuery's `contains` method. Note that there
   is a semantic difference that `contains(node, node)` returns
   `false` whereas `node.contains(node)` returns `true`. In other words, in the DOM API a node "contains" itself, but not in jQuery. It was possible to leverage this to simplify a condition.