### PR TITLE
Remove IE 11 polyfills

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,7 +112,6 @@ const appBundles = [
 //    the client that need it in `src/boot/boot.js`
 //  - Add the polyfill to the test environment if necessary in `src/karma.config.js`
 const polyfillBundles = [
-  'document.evaluate',
   'es2015',
   'es2016',
   'es2017',

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "diff": "^4.0.1",
     "dom-anchor-text-position": "^5.0.0",
     "dom-anchor-text-quote": "^4.0.2",
-    "dom-node-iterator": "^5.0.0",
     "dom-seek": "^5.0.1",
     "dompurify": "^2.0.1",
     "enzyme": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "core-js": "^3.4.1",
     "cross-env": "^7.0.0",
     "diff": "^4.0.1",
-    "document-base-uri": "^1.0.0",
     "dom-anchor-text-position": "^5.0.0",
     "dom-anchor-text-quote": "^4.0.2",
     "dom-node-iterator": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "vinyl": "^2.2.0",
     "watchify": "^3.7.0",
     "whatwg-fetch": "^3.0.0",
-    "wicked-good-xpath": "^1.3.0",
     "wrap-text": "^1.0.7",
     "zen-observable": "^0.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "commander": "^6.0.0",
     "core-js": "^3.4.1",
     "cross-env": "^7.0.0",
-    "custom-event": "^1.0.1",
     "diff": "^4.0.1",
     "document-base-uri": "^1.0.0",
     "dom-anchor-text-position": "^5.0.0",

--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -2,10 +2,6 @@
 
 import seek from 'dom-seek';
 
-// `dom-node-iterator` polyfills optional arguments of `createNodeIterator`
-// and properties of the returned `NodeIterator` for IE 11 compatibility.
-const createNodeIterator = require('dom-node-iterator/polyfill')();
-
 import RenderingStates from '../pdfjs-rendering-states';
 
 import { BrowserRange } from './range';
@@ -446,8 +442,7 @@ export function describe(root, range) {
 
   const startPageIndex = getSiblingIndex(startTextLayer.parentNode);
 
-  const iter = createNodeIterator.call(
-    document,
+  const iter = root.ownerDocument.createNodeIterator(
     startTextLayer,
     NodeFilter.SHOW_TEXT
   );

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -1,4 +1,3 @@
-import CustomEvent from 'custom-event';
 import scrollIntoView from 'scroll-into-view';
 
 import Delegator from './delegator';

--- a/src/annotator/plugin/document.js
+++ b/src/annotator/plugin/document.js
@@ -17,8 +17,6 @@
  * @typedef {import('../../types/annotator').DocumentMetadata} Metadata
  */
 
-import baseURI from 'document-base-uri';
-
 import Delegator from '../delegator';
 
 import { normalizeURI } from '../util/url';
@@ -70,7 +68,7 @@ export default class DocumentMeta extends Delegator {
 
     this.metadata = createMetadata();
 
-    this.baseURI = options.baseURI || baseURI;
+    this.baseURI = options.baseURI || document.baseURI;
     this.document = options.document || document;
     this.normalizeURI = options.normalizeURI || normalizeURI;
 

--- a/src/annotator/util/url.js
+++ b/src/annotator/util/url.js
@@ -1,5 +1,3 @@
-import baseURI from 'document-base-uri';
-
 /**
  * Return a normalized version of a URI.
  *
@@ -9,7 +7,7 @@ import baseURI from 'document-base-uri';
  * @param {string} [base] - Base URL to resolve relative to. Defaults to
  *   the document's base URL.
  */
-export function normalizeURI(uri, base = baseURI) {
+export function normalizeURI(uri, base = document.baseURI) {
   const absUrl = new URL(uri, base).href;
 
   // Remove the fragment identifier.

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -92,7 +92,6 @@ function bootHypothesisClient(doc, config) {
   doc.head.appendChild(clientUrl);
 
   const polyfills = polyfillBundles([
-    'document.evaluate',
     'es2015',
     'es2016',
     'es2017',

--- a/src/shared/polyfills/document.evaluate.js
+++ b/src/shared/polyfills/document.evaluate.js
@@ -1,3 +1,0 @@
-import * as wgxpath from 'wicked-good-xpath';
-
-wgxpath.install();

--- a/src/shared/polyfills/index.js
+++ b/src/shared/polyfills/index.js
@@ -81,13 +81,6 @@ const needsPolyfill = {
     }
   },
 
-  // Test for XPath evaluation.
-  'document.evaluate': () => {
-    // Depending on the browser the `evaluate` property may be on the prototype
-    // or just the object itself.
-    return typeof document.evaluate !== 'function';
-  },
-
   // Test for Unicode normalization. This depends on a large polyfill so it
   // is separated out into its own bundle.
   'string.prototype.normalize': () => {

--- a/src/shared/polyfills/test/index-test.js
+++ b/src/shared/polyfills/test/index-test.js
@@ -49,10 +49,6 @@ describe('shared/polyfills/index', () => {
         providesMethod: [String.prototype, 'normalize'],
       },
       {
-        set: 'document.evaluate',
-        providesMethod: [Document.prototype, 'evaluate'],
-      },
-      {
         // Missing URL constructor.
         set: 'url',
         providesMethod: [window, 'URL'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8324,11 +8324,6 @@ which@^1.2.1, which@^1.2.14, which@^1.2.9:
   dependencies:
     isexe "^2.0.0"
 
-wicked-good-xpath@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz#81b0e95e8650e49c94b22298fff8686b5553cf6c"
-  integrity sha1-gbDpXoZQ5JyUsiKY//hoa1VTz2w=
-
 wide-align@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,11 +2881,6 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-document-base-uri@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/document-base-uri/-/document-base-uri-1.0.0.tgz#88013e6ee6aa210f1a991953149f3a1698e1e661"
-  integrity sha1-iAE+buaqIQ8amRlTFJ86Fpjh5mE=
-
 dom-anchor-text-position@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dom-anchor-text-position/-/dom-anchor-text-position-4.0.0.tgz#4c839b3bded94f0cab0f06a0189468f3f1ec2bb2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2909,11 +2909,6 @@ dom-node-iterator@^3.5.0:
   resolved "https://registry.yarnpkg.com/dom-node-iterator/-/dom-node-iterator-3.5.3.tgz#32b68aa440962f1734487029f544a3db704637b7"
   integrity sha1-MraKpECWLxc0SHAp9USj23BGN7c=
 
-dom-node-iterator@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/dom-node-iterator/-/dom-node-iterator-5.0.0.tgz#630315338734a814a95455c5a88293f6a9a735ac"
-  integrity sha512-SYApJtqUMs8HRAzTnst9ROFsCVMiDM41kG6PcYfkIVnt2yb3BG68/wetDfqCdtlkNBRzUiX1D5JSpJCYcNtY3Q==
-
 dom-seek@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/dom-seek/-/dom-seek-4.0.3.tgz#f14dddf04b3fb062d901c7b00b0c142a06e0a94b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2657,7 +2657,7 @@ cuint@^0.2.2:
   resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
   integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
 
-custom-event@^1.0.1, custom-event@~1.0.0:
+custom-event@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425"
   integrity sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/2627**

Since IE 11 is no longer supported, this PR removes polyfills that were only used to support that browser:

- [Node.baseURI](https://developer.mozilla.org/en-US/docs/Web/API/Node/baseURI#Browser_compatibility)
- [CustomEvent constructor](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent#Browser_compatibility)
- [document.evaluate](https://developer.mozilla.org/en-US/docs/Web/API/Document/evaluate#Browser_compatibility)
- Optional-ness of certain arguments to `document.createNodeIterator`

One polyfill I didn't remove in this PR is one for the [URL constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#Browser_compatibility). Although that is available in all the browsers we support, there are comments in the code that it may not work as expected in some browsers and I need to remind myself which ones those are.

Part of https://github.com/hypothesis/client/issues/2043.