### PR TITLE
Rewrite the `AnnotationSync` class in the annotator

### DIFF
--- a/src/annotator/annotation-sync.js
+++ b/src/annotator/annotation-sync.js
@@ -82,23 +82,24 @@ export default class AnnotationSync {
   }
 
   /**
-   * Assign a non-enumerable tag to objects which cross the bridge.
-   * This tag is used to identify the objects between messages.
+   * Assign a non-enumerable "tag" to identify annotations exchanged between
+   * the sidebar and annotator and associate the tag with the `annotation` instance
+   * in the local cache.
    *
-   * @param {AnnotationData} ann
-   * @param {string} [tag]
+   * @param {AnnotationData} annotation
+   * @param {string} [tag] - The tag to assign
    * @return {AnnotationData}
    */
-  _tag(ann, tag) {
-    if (ann.$tag) {
-      return ann;
+  _tag(annotation, tag) {
+    if (annotation.$tag) {
+      return annotation;
     }
     tag = tag || window.btoa(Math.random().toString());
-    Object.defineProperty(ann, '$tag', {
+    Object.defineProperty(annotation, '$tag', {
       value: tag,
     });
-    this.cache[tag] = ann;
-    return ann;
+    this.cache[tag] = annotation;
+    return annotation;
   }
 
   /**
@@ -116,15 +117,15 @@ export default class AnnotationSync {
   /**
    * Format an annotation into an RPC message body.
    *
-   * @param {AnnotationData} ann
+   * @param {AnnotationData} annotation
    * @return {RpcMessage}
    */
-  _format(ann) {
-    this._tag(ann);
+  _format(annotation) {
+    this._tag(annotation);
 
     return {
-      tag: ann.$tag,
-      msg: ann,
+      tag: annotation.$tag,
+      msg: annotation,
     };
   }
 }

--- a/src/annotator/test/annotation-sync-test.js
+++ b/src/annotator/test/annotation-sync-test.js
@@ -120,12 +120,10 @@ describe('AnnotationSync', function () {
         options.emit('beforeAnnotationCreated', ann);
 
         assert.called(fakeBridge.call);
-        assert.calledWith(
-          fakeBridge.call,
-          'beforeCreateAnnotation',
-          { msg: ann, tag: ann.$tag },
-          sinon.match.func
-        );
+        assert.calledWith(fakeBridge.call, 'beforeCreateAnnotation', {
+          msg: ann,
+          tag: ann.$tag,
+        });
       });
 
       context('if the annotation has a $tag', function () {
@@ -138,6 +136,17 @@ describe('AnnotationSync', function () {
           assert.notCalled(fakeBridge.call);
         });
       });
+    });
+  });
+
+  describe('#sync', () => {
+    it('calls "sync" method of the bridge', () => {
+      const ann = { id: 1 };
+      const annotationSync = createAnnotationSync();
+
+      annotationSync.sync([ann]);
+
+      assert.calledWith(fakeBridge.call, 'sync', [{ msg: ann, tag: ann.$tag }]);
     });
   });
 });


### PR DESCRIPTION
While looking into https://github.com/hypothesis/client/issues/1071 I found that the
`AnnotationSync` class in the annotator was in a sorry state and it was hard to figure
out what it was doing.

The `AnnotationSync` class was an ES5-style class that had a ton of
ES5-isms, odd constructions probably resulting from a historical
conversion from CoffeeScript, unused code and unnecessary abstractions. It was also
lacking in documentation.

This commit rewrites the class using modern syntax and removing unused
code and unnecessary abstractions (eg. the `_eventListeners` and
`_channelListeners` properties).

The API and behavior should be unchanged. An additional test was added
for the `sync` method.