### PR TITLE
Fix range selector generation in Chrome and Firefox

### DIFF
--- a/src/annotator/anchoring/range.js
+++ b/src/annotator/anchoring/range.js
@@ -6,15 +6,16 @@ import {
 } from './xpath-util';
 
 /**
- * Return ancestors of `element`, optionally filtered by a CSS `selector`.
+ * Return ancestors of `element`, optionally filtered by a CSS selector.
  *
  * @param {Node} node
- * @param {string} [selector]
+ * @param {string} [ignoreSelector] -
+ *   Any elements that match this CSS selector will be excluded from the result
  */
-function parents(node, selector) {
+function parents(node, ignoreSelector) {
   const parents = [];
   while (node.parentElement) {
-    if (!selector || node.parentElement.matches(selector)) {
+    if (!ignoreSelector || !node.parentElement.matches(ignoreSelector)) {
       parents.push(node.parentElement);
     }
     node = node.parentElement;
@@ -259,7 +260,7 @@ export class NormalizedRange {
     const serialization = (node, isEnd) => {
       let origParent;
       if (ignoreSelector) {
-        origParent = parents(node, `:not(${ignoreSelector})`)[0];
+        origParent = parents(node, ignoreSelector)[0];
       } else {
         origParent = node.parentElement;
       }

--- a/src/annotator/anchoring/test/range-test.js
+++ b/src/annotator/anchoring/test/range-test.js
@@ -272,14 +272,33 @@ describe('annotator/anchoring/range', () => {
         });
       });
 
-      it('converts BrowserRange to SerializedRange instance with `ignoreSelector` condition', () => {
-        const browserRange = createBrowserRange();
-        const result = browserRange.serialize(container, 'p');
-        assert.deepEqual(result, {
-          start: '/section[1]', // /p[1] selector in xpath ignored
-          startOffset: 0,
-          end: '/section[1]/span[1]', // /p[1] selector in xpath ignored
-          endOffset: 1,
+      [
+        // Single selector
+        {
+          ignoreSelector: 'p',
+          expected: {
+            start: '/section[1]', // /p[1] selector in xpath ignored
+            startOffset: 0,
+            end: '/section[1]/span[1]', // /p[1] selector in xpath ignored
+            endOffset: 1,
+          },
+        },
+
+        // Selector list, used to filter out elements using multiple conditions.
+        {
+          ignoreSelector: 'p,p',
+          expected: {
+            start: '/section[1]', // /p[1] selector in xpath ignored
+            startOffset: 0,
+            end: '/section[1]/span[1]', // /p[1] selector in xpath ignored
+            endOffset: 1,
+          },
+        },
+      ].forEach(({ ignoreSelector, expected }) => {
+        it('converts BrowserRange to SerializedRange with `ignoreSelector` filter', () => {
+          const browserRange = createBrowserRange();
+          const result = browserRange.serialize(container, ignoreSelector);
+          assert.deepEqual(result, expected);
         });
       });
     });


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/hypothesis/client/pull/2598 in non-Safari browsers.

----

When generating range selectors the client excludes elements from the
Hypothesis UI by filtering out elements that match the CSS selector
defined by `IGNORE_SELECTOR` in guest.js.

In a554058161 this logic was changed from jQuery's selector matching to
`element.matches(...)`. The selector used in the actual application is a
compount selector which is then inverted with `:not`:

```
:not([class^="annotator-"],[class^="hypothesis-"])
```

It turns out that the `:not(...)` pseudo-class only supports _lists_ of
selectors in Safari, but not in Chrome or Firefox [1]. Therefore the call to
`element.matches(...)` would always fail in these browsers and the
resulting annotation would only have `TextQuoteSelector` and
`TextPositionSelector` selectors but no `RangeSelector`.

This commit fixes the issue by removing the use of `:not` and instead
inverting the `element.matches(...)` test. It also adds a test case for
handling of list selectors.

[1] https://developer.mozilla.org/en-US/docs/Web/CSS/:not#Browser_compatibility