### PR TITLE
Remove logic to ignore Hypothesis UI when generating range selectors

### DIFF
--- a/src/annotator/anchoring/range.js
+++ b/src/annotator/anchoring/range.js
@@ -6,17 +6,14 @@ import {
 } from './xpath-util';
 
 /**
- * Return ancestors of `element`, optionally filtered by a CSS `selector`.
+ * Return ancestors of `node`.
  *
  * @param {Node} node
- * @param {string} [selector]
  */
-function parents(node, selector) {
+function parents(node) {
   const parents = [];
   while (node.parentElement) {
-    if (!selector || node.parentElement.matches(selector)) {
-      parents.push(node.parentElement);
-    }
+    parents.push(node.parentElement);
     node = node.parentElement;
   }
   return parents;
@@ -169,13 +166,11 @@ export class BrowserRange {
    * Creates a range suitable for storage.
    *
    * root           - A root Element from which to anchor the serialization.
-   * ignoreSelector - A selector String of elements to ignore. For example
-   *                  elements injected by the annotator.
    *
    * Returns an instance of SerializedRange.
    */
-  serialize(root, ignoreSelector) {
-    return this.normalize().serialize(root, ignoreSelector);
+  serialize(root) {
+    return this.normalize().serialize(root);
   }
 }
 
@@ -250,19 +245,12 @@ export class NormalizedRange {
    * character offset), which can be easily stored in a database.
    *
    * root -           The root Element relative to which XPaths should be calculated
-   * ignoreSelector - A selector String of elements to ignore. For example
-   *                  elements injected by the annotator.
    *
    * Returns an instance of SerializedRange.
    */
-  serialize(root, ignoreSelector) {
+  serialize(root) {
     const serialization = (node, isEnd) => {
-      let origParent;
-      if (ignoreSelector) {
-        origParent = parents(node, `:not(${ignoreSelector})`)[0];
-      } else {
-        origParent = node.parentElement;
-      }
+      const origParent = node.parentElement;
       const xpath = xpathFromNode(origParent, root ?? document);
       const textNodes = getTextNodes(origParent);
       // Calculate real offset as the combined length of all the
@@ -433,13 +421,11 @@ export class SerializedRange {
    * Creates a range suitable for storage.
    *
    * root           - A root Element from which to anchor the serialization.
-   * ignoreSelector - A selector String of elements to ignore. For example
-   *                  elements injected by the annotator.
    *
    * Returns an instance of SerializedRange.
    */
-  serialize(root, ignoreSelector) {
-    return this.normalize(root).serialize(root, ignoreSelector);
+  serialize(root) {
+    return this.normalize(root).serialize(root);
   }
 
   // Returns the range as an Object literal.

--- a/src/annotator/anchoring/test/range-test.js
+++ b/src/annotator/anchoring/test/range-test.js
@@ -271,17 +271,6 @@ describe('annotator/anchoring/range', () => {
           endOffset: 1,
         });
       });
-
-      it('converts BrowserRange to SerializedRange instance with `ignoreSelector` condition', () => {
-        const browserRange = createBrowserRange();
-        const result = browserRange.serialize(container, 'p');
-        assert.deepEqual(result, {
-          start: '/section[1]', // /p[1] selector in xpath ignored
-          startOffset: 0,
-          end: '/section[1]/span[1]', // /p[1] selector in xpath ignored
-          endOffset: 1,
-        });
-      });
     });
   });
 
@@ -373,19 +362,6 @@ describe('annotator/anchoring/range', () => {
         assert.deepEqual(serializedRange, {
           start: '/html[1]/body[1]/div[1]/section[1]/p[1]',
           end: '/html[1]/body[1]/div[1]/section[1]/span[1]/p[1]',
-          startOffset: 0,
-          endOffset: 6,
-        });
-      });
-
-      it('serialize the range with `ignoreSelector` condition', () => {
-        const serializedRange = createNormalizedRange().serialize(
-          container,
-          '#p-3'
-        );
-        assert.deepEqual(serializedRange, {
-          start: '/section[1]/p[1]',
-          end: '/section[1]/span[1]',
           startOffset: 0,
           endOffset: 6,
         });
@@ -510,15 +486,6 @@ describe('annotator/anchoring/range', () => {
         assert.isTrue(result instanceof SerializedRange);
         // The copied instance shall be identical to the initial.
         assert.deepEqual(result, serializedRange);
-      });
-
-      it('converts a SerializedRange to a new SerializedRange instance with `ignoreSelector` condition', () => {
-        const serializedRange = createSerializedRange();
-        const result = serializedRange.serialize(container, '#p-3');
-        // End xpath shall ignore the provided selector and not
-        // be identical to the initial end xpath.
-        assert.notEqual(serializedRange.end, result.end);
-        assert.equal(result.end, '/section[1]/span[1]');
       });
     });
   });

--- a/src/annotator/anchoring/types.js
+++ b/src/annotator/anchoring/types.js
@@ -75,12 +75,10 @@ export class RangeAnchor {
   }
 
   /**
-   * @param {Object} [options]
-   *   @param {string} [options.ignoreSelector]
    * @return {RangeSelector}
    */
-  toSelector(options = {}) {
-    const range = this.range.serialize(this.root, options.ignoreSelector);
+  toSelector() {
+    const range = this.range.serialize(this.root);
     return {
       type: 'RangeSelector',
       startContainer: range.start,

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -63,13 +63,6 @@ function annotationsAt(node) {
   return /** @type {AnnotationData[]} */ (items);
 }
 
-// A selector which matches elements added to the DOM by Hypothesis (eg. for
-// highlights and annotation UI).
-//
-// We can simplify this once all classes are converted from an "annotator-"
-// prefix to a "hypothesis-" prefix.
-const IGNORE_SELECTOR = '[class^="annotator-"],[class^="hypothesis-"]';
-
 export default class Guest extends Delegator {
   constructor(element, config, anchoring = htmlAnchoring) {
     const defaultConfig = {
@@ -355,11 +348,8 @@ export default class Guest extends Delegator {
       }
 
       // Find a target using the anchoring module.
-      const options = {
-        ignoreSelector: IGNORE_SELECTOR,
-      };
       return this.anchoring
-        .anchor(root, target.selector, options)
+        .anchor(root, target.selector)
         .then(range => ({
           annotation,
           target,
@@ -477,11 +467,8 @@ export default class Guest extends Delegator {
     this.selectedRanges = null;
 
     const getSelectors = range => {
-      const options = {
-        ignoreSelector: IGNORE_SELECTOR,
-      };
       // Returns an array of selectors for the passed range.
-      return this.anchoring.describe(root, range, options);
+      return this.anchoring.describe(root, range);
     };
 
     const setDocumentInfo = info => {


### PR DESCRIPTION
Remove the logic that was intended to ignore Hypothesis UI when
generating range selectors.

We don't need this any more because all Hypothesis UI elements in the
host page which contain text have `user-select` set to prevent text
selection. This affects the bucket bar, vertical toolbar and adder.

In addition, the logic did not serve its intended purpose as it only applied to
range selector generation. If the user did somehow succeed in selecting text in
the bucket bar for example the client would still generate quote and position
selectors that referred to that content. What the client would need to
do instead is modify the range from which the annotation's selectors
were generated.

As a side effect this fixes a regression introduced in a554058 which caused
range selector generation to fail in Chrome and Firefox due to use of
`Element.matches` with a `:not(<inner selector>)` selector where `<inner selector>` is a
list of selectors (the `IGNORE_SELECTOR` value from `guest.js`). Such selectors are
[not supported](https://developer.mozilla.org/en-US/docs/Web/CSS/:not#Browser_compatibility) in
Chrome and Firefox.

----

**Testing:**

In Chrome or Firefox, open the developer tools and then create an annotation. In the Network tab look at the payload for the request to the server to create the new annotation. The `selector` array should have a `RangeSelector`:

<img width="444" alt="range-selector" src="https://user-images.githubusercontent.com/2458/95197145-0f3ac080-07d1-11eb-94fc-9ede44203a80.png">
