### PR TITLE
Improve Adder API and perfomance

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -633,12 +633,8 @@ export default class Guest extends Delegator {
       this.toolbar.newAnnotationType = 'annotation';
     }
 
-    const { left, top, arrowDirection } = this.adderCtrl.target(
-      focusRect,
-      isBackwards
-    );
     this.adderCtrl.annotationsForSelection = annotationsForSelection();
-    this.adderCtrl.showAt(left, top, arrowDirection);
+    this.adderCtrl.show(focusRect, isBackwards);
   }
 
   _onClearSelection() {

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1,4 +1,3 @@
-import * as adder from '../adder';
 import { Observable } from '../util/observable';
 import Delegator from '../delegator';
 import Guest from '../guest';
@@ -11,8 +10,7 @@ class FakeAdder {
     FakeAdder.instance = this;
 
     this.hide = sinon.stub();
-    this.showAt = sinon.stub();
-    this.target = sinon.stub();
+    this.show = sinon.stub();
     this.options = options;
   }
 }
@@ -453,11 +451,6 @@ describe('Guest', () => {
         width: 5,
         height: 5,
       });
-      FakeAdder.instance.target.returns({
-        left: 0,
-        top: 0,
-        arrowDirection: adder.ARROW_POINTING_UP,
-      });
       return selections.next({});
     };
 
@@ -469,7 +462,7 @@ describe('Guest', () => {
     it('shows the adder if the selection contains text', () => {
       createGuest();
       simulateSelectionWithText();
-      assert.called(FakeAdder.instance.showAt);
+      assert.called(FakeAdder.instance.show);
     });
 
     it('sets the annotations associated with the selection', () => {
@@ -490,7 +483,7 @@ describe('Guest', () => {
       simulateSelectionWithoutText();
 
       assert.called(FakeAdder.instance.hide);
-      assert.notCalled(FakeAdder.instance.showAt);
+      assert.notCalled(FakeAdder.instance.show);
     });
 
     it('hides the adder if the selection is empty', () => {


### PR DESCRIPTION
Code reorganisation:
1. `Adder` has a simplified API: added a public method `display` that internally calls private methods `_target` and `_showAt`
2. Performance improvement in `_target` method by removing multiple calls to `this._width()` and `this._height()`
3. More strict type for `arrowDirection` 