### PR TITLE
Remove jQuery from annotator initialization

### DIFF
--- a/src/annotator/anchoring/test/range-test.js
+++ b/src/annotator/anchoring/test/range-test.js
@@ -302,7 +302,6 @@ describe('annotator/anchoring/range', () => {
             container.querySelector(test.bound)
           );
           assert.equal(limit.text(), test.textNodes.join(''));
-          // To get a node value from jquery, use ".data".
           assert.deepEqual(
             test.textNodes,
             limit.textNodes().map(n => n.data)

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -4,8 +4,6 @@
  * @typedef {import('../types/annotator').HypothesisWindow} HypothesisWindow
  */
 
-import $ from 'jquery';
-
 // Load polyfill for :focus-visible pseudo-class.
 import 'focus-visible';
 
@@ -50,7 +48,7 @@ const appLinkEl = /** @type {Element} */ (document.querySelector(
 
 const config = configFrom(window);
 
-$.noConflict(true)(function () {
+function init() {
   const isPDF = typeof window_.PDFViewerApplication !== 'undefined';
 
   /** @type {new (e: Element, config: any) => Guest} */
@@ -76,4 +74,21 @@ $.noConflict(true)(function () {
     appLinkEl.remove();
     annotator.destroy();
   });
-});
+}
+
+/**
+ * Returns a Promise that resolves when the document has loaded (but subresources
+ * may still be loading).
+ */
+function documentReady() {
+  return new Promise(resolve => {
+    if (document.readyState !== 'loading') {
+      resolve();
+    }
+    // nb. `readystatechange` may be emitted twice, but `resolve` only resolves
+    // on the first call.
+    document.addEventListener('readystatechange', resolve);
+  });
+}
+
+documentReady().then(init);


### PR DESCRIPTION
Remove jQuery from annotator initialization

As one of the final parts of removing the client's jQuery dependency,
use DOM APIs to defer annotator initialization until the document has
loaded.
