### PR TITLE
Fix mobile cursor from jumping to bottom

### DIFF
--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Hypothesis Client Test</title>
 <style>
   body {

--- a/src/styles/annotator/components/adder.scss
+++ b/src/styles/annotator/components/adder.scss
@@ -22,8 +22,9 @@ $adder-transition-duration: 80ms;
   background: var.$color-background;
   border-radius: var.$annotator-border-radius;
 
-  // Prevent the adder from being highlighted during text selection.
-  // This caused an bug that appears on android devices during text selection.
+  // Prevent the browser from selecting text in the adder itself during text
+  // selection.
+  //
   // See https://github.com/hypothesis/product-backlog/issues/878
   user-select: none;
 


### PR DESCRIPTION
When selecting text on the android, it was possible to also highlight the text inside the buttons in the adder. When this happened, the range would grab everything from where you started to highlight to the very end of the dom because the adder is attached as the last node inside body.

The simple fix is to prohibit text selection inside the adder which prevents the selection from getting the adder itself.

-----------

This was a bit tricky to figure out.

1 You need an android
2 Set up remote debugging (see screen shot) https://developers.google.com/web/tools/chrome-devtools/remote-debugging

![Screen Shot 2020-10-09 at 8 59 44 AM](https://user-images.githubusercontent.com/3939074/95639958-4a4a2780-0a4f-11eb-979e-f9904a3566e3.png)

I tracked this down to an issue where in `selection.js`, it was grabbing a much larger range than it should have. I think what was happening it is the adder itself could act as part of the thing you can select/highlight. On mobile, events for selecting text, touching text, etc fire differently than on the desktop.  If you moved you finger too fast or move over a transition from one common ancestor to another, then it grabbed the adder text too.

I was able to totally prevent this by adding 'pointer-events: none; on the adder. While this fully disabled the adder, it fixed this issue. Next I thought that perhaps we should dynamically set that value and we should be good! I was able to pinpoint the problem by adding a simple condition inside `selectedRange`

```
if (range.endContainer.nodeName === 'HYPOTHESIS-ADDER') {
   return null;
}
```

And then in guest.js, we can pass down a flag when range is null to add a css class to the adder. This actually didn't work very well perhaps due to something asynchronous that I didn't have a good understanding of.

The next idea was to just prevent css selection entirely and it didn't need a flag because I don't think we really care about allowing the text to be selected in the first place the adder.

Things to consider.

- [ ] Test this on an iphone
- [ ] What does this mean for accessibility / voice over?

