### PR TITLE
Fix `Promise.prototype.finally` polyfill loading in older browsers

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const { mkdirSync } = require('fs');
+const { mkdirSync, readdirSync } = require('fs');
 const path = require('path');
 
 const changed = require('gulp-changed');
@@ -107,22 +107,16 @@ const appBundles = [
 //  - Add the relevant dependencies to the project
 //  - Create an entry point in `src/shared/polyfills/{set}` and a feature
 //    detection function in `src/shared/polyfills/index.js`
-//  - Add an entry to the list below to generate the polyfill bundle
 //  - Add the polyfill set name to the required dependencies for the parts of
 //    the client that need it in `src/boot/boot.js`
-//  - Add the polyfill to the test environment if necessary in `src/karma.config.js`
-const polyfillBundles = [
-  'es2015',
-  'es2016',
-  'es2017',
-  'fetch',
-  'string.prototype.normalize',
-  'url',
-].map(set => ({
-  name: `polyfills-${set}`,
-  entry: `./src/shared/polyfills/${set}`,
-  transforms: ['babel'],
-}));
+const polyfillBundles = readdirSync('./src/shared/polyfills/')
+  .filter(name => name.endsWith('.js') && name !== 'index.js')
+  .map(name => name.replace(/\.js$/, ''))
+  .map(set => ({
+    name: `polyfills-${set}`,
+    entry: `./src/shared/polyfills/${set}`,
+    transforms: ['babel'],
+  }));
 
 const appBundleConfigs = appBundles.concat(polyfillBundles).map(config => {
   return Object.assign({}, appBundleBaseConfig, config);

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -1,6 +1,21 @@
 import { requiredPolyfillSets } from '../shared/polyfills';
 
 /**
+ * Polyfills used by both the annotator and sidebar app.
+ */
+const commonPolyfills = [
+  // ES APIs
+  'es2015',
+  'es2016',
+  'es2017',
+  'es2018',
+
+  // DOM APIs. These may rely on certain ES APIs so they should be loaded after
+  // the above polyfills.
+  'url',
+];
+
+/**
  * @typedef Config
  * @prop {string} assetRoot - The root URL to which URLs in `manifest` are relative
  * @prop {string} sidebarAppUrl - The URL of the sidebar's HTML page
@@ -91,13 +106,7 @@ function bootHypothesisClient(doc, config) {
   clientUrl.type = 'application/annotator+javascript';
   doc.head.appendChild(clientUrl);
 
-  const polyfills = polyfillBundles([
-    'es2015',
-    'es2016',
-    'es2017',
-    'es2018',
-    'url',
-  ]);
+  const polyfills = polyfillBundles(commonPolyfills);
 
   injectAssets(doc, config, [
     // Vendor code and polyfills
@@ -120,16 +129,9 @@ function bootHypothesisClient(doc, config) {
  */
 function bootSidebarApp(doc, config) {
   const polyfills = polyfillBundles([
-    // JS polyfills.
-    'es2015',
-    'es2016',
-    'es2017',
+    ...commonPolyfills,
     'string.prototype.normalize',
-
-    // DOM polyfills. These are loaded after the JS polyfills as they may
-    // depend upon them, eg. for Promises.
     'fetch',
-    'url',
   ]);
 
   injectAssets(doc, config, [


### PR DESCRIPTION
The sidebar application failed to load in Safari 10 due to the ES 2018
polyfill bundle, which contains a polyfill for
`Promise.prototype.finally`, not being loaded in that browser.

The issue was that 'es2018' was not listed in the polyfill bundles to
build in `gulpfile.js` or in the list of bundles required by the sidebar
app in `boot.js`.

This commit fixes these issues and makes the issue less likely to occur
in future by:

 - Removing the need to manually list each polyfill bundle in
   `gulpfile.js`. Instead the `src/shared/polyfills` dir is listed and
   every non-`index.js` file is used as the root of a bundle.
 - Factoring out the polyfills common to the sidebar and annotator app
   into a variable and including "es2018" there