### PR TITLE
Apply `dir="auto"` fix in Edge Legacy

### DIFF
--- a/src/shared/renderer-options.js
+++ b/src/shared/renderer-options.js
@@ -1,15 +1,23 @@
 import { options } from 'preact';
 
-import { isIE11 } from './user-agent';
-
 /**
- * Force the dir="auto" attribute to be dir="" as this otherwise causes
- * an exception in IE11 and breaks subsequent rendering.
+ * Setup workarounds for setting certain HTML element properties or attributes
+ * in some browsers.
  *
  * @param {Object} _options - Test seam
  */
-export function setupIE11Fixes(_options = options) {
-  if (isIE11()) {
+export function setupBrowserFixes(_options = options) {
+  let needsDirAutoFix = false;
+
+  try {
+    const el = document.createElement('div');
+    // The value "auto" causes an exception in IE 11 and Edge Legacy.
+    el.dir = 'auto';
+  } catch (err) {
+    needsDirAutoFix = true;
+  }
+
+  if (needsDirAutoFix) {
     const prevHook = _options.vnode;
     _options.vnode = vnode => {
       if (typeof vnode.type === 'string') {

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -43,8 +43,8 @@ const isSidebar = !(
   window.location.pathname.startsWith('/a/')
 );
 
-// Install Preact renderer options to work around IE11 quirks
-rendererOptions.setupIE11Fixes();
+// Install Preact renderer options to work around browser quirks
+rendererOptions.setupBrowserFixes();
 
 // @ngInject
 function setupApi(api, streamer) {


### PR DESCRIPTION
The sidebar app failed to start in Edge Legacy due to `element.dir = "auto` assignments causing an exception during Preact component rendering. We already had a fix for this that applied to IE 11, so the fix for this problem is to change the check to test for the bug specifically rather than testing the user agent.

Although we've officially ended support for IE 11, we do still support the latest version of Edge Legacy (v18, before the recent switch to Chrome in January 2020).