### PR TITLE
Added `document.elementsFromPoint` polyfill

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -248,17 +248,27 @@ export class Adder {
     // Find the Z index of all the elements in the screen for five positions
     // around the adder (left-top, left-bottom, middle-center, right-top,
     // right-bottom) and use the greatest.
+    // In old implementations elementsFromPoint return null.
+    const leftTopElements = document.elementsFromPoint(left, top) ?? [];
+    const leftBottomElements =
+      document.elementsFromPoint(left, top + adderHeight) ?? [];
+    const middleCenterElements =
+      document.elementsFromPoint(
+        left + adderWidth / 2,
+        top + adderHeight / 2
+      ) ?? [];
+    const rightTopElements =
+      document.elementsFromPoint(left + adderWidth, top) ?? [];
+    const rightBottomElements =
+      document.elementsFromPoint(left + adderWidth, top + adderHeight) ?? [];
 
     // Unique elements so `getComputedStyle` is called the minimum amount of times.
     const elements = new Set([
-      ...document.elementsFromPoint(left, top),
-      ...document.elementsFromPoint(left, top + adderHeight),
-      ...document.elementsFromPoint(
-        left + adderWidth / 2,
-        top + adderHeight / 2
-      ),
-      ...document.elementsFromPoint(left + adderWidth, top),
-      ...document.elementsFromPoint(left + adderWidth, top + adderHeight),
+      ...leftTopElements,
+      ...leftBottomElements,
+      ...middleCenterElements,
+      ...rightTopElements,
+      ...rightBottomElements,
     ]);
 
     const zIndexes = [...elements]

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -1,6 +1,5 @@
 import { act } from 'preact/test-utils';
-import { createElement } from 'preact';
-import { mount } from 'enzyme';
+import { createElement, render } from 'preact';
 
 import { Adder, ARROW_POINTING_UP, ARROW_POINTING_DOWN } from '../adder';
 
@@ -231,6 +230,22 @@ describe('Adder', () => {
       return parseInt(adderEl.style.zIndex);
     }
 
+    function createComponent(left, top, zIndex, attachTo) {
+      render(
+        <div
+          style={{
+            position: 'absolute',
+            width: 1,
+            height: 1,
+            left,
+            top,
+            zIndex,
+          }}
+        />,
+        attachTo
+      );
+    }
+
     beforeEach(() => {
       container = document.createElement('div');
       document.body.appendChild(container);
@@ -240,13 +255,6 @@ describe('Adder', () => {
       container.remove();
     });
 
-    it('returns default hard coded value if `document.elementsFromPoint` is not available', () => {
-      const elementsFromPointBackup = document.elementsFromPoint;
-      document.elementsFromPoint = undefined;
-      assert.strictEqual(getAdderZIndex(0, 0), 32768);
-      document.elementsFromPoint = elementsFromPointBackup;
-    });
-
     it('returns default value of 1', () => {
       // Even if not elements are found, it returns 1
       assert.strictEqual(getAdderZIndex(-100000, -100000), 1);
@@ -254,36 +262,20 @@ describe('Adder', () => {
     });
 
     it('returns the greatest zIndex', () => {
-      const createComponent = (left, top, zIndex, attachTo) =>
-        mount(
-          <div
-            style={{
-              position: 'absolute',
-              width: 1,
-              height: 1,
-              left,
-              top,
-              zIndex,
-            }}
-          />,
-          { attachTo }
-        );
-
-      const wrapper = createComponent(0, 0, 2, container);
+      createComponent(0, 0, 2, container);
       assert.strictEqual(getAdderZIndex(0, 0), 3);
 
       const initLeft = 10;
       const initTop = 10;
       const adderWidth = adderCtrl._width();
       const adderHeight = adderCtrl._height();
-      const wrapperDOMNode = wrapper.getDOMNode();
 
       // Create first element (left-top)
-      createComponent(initLeft, initTop, 3, wrapperDOMNode);
+      createComponent(initLeft, initTop, 3, container);
       assert.strictEqual(getAdderZIndex(initLeft, initTop), 4);
 
       // Create second element (left-bottom)
-      createComponent(initLeft, initTop + adderHeight, 5, wrapperDOMNode);
+      createComponent(initLeft, initTop + adderHeight, 5, container);
       assert.strictEqual(getAdderZIndex(initLeft, initTop), 6);
 
       // Create third element (middle-center)
@@ -291,12 +283,12 @@ describe('Adder', () => {
         initLeft + adderWidth / 2,
         initTop + adderHeight / 2,
         6,
-        wrapperDOMNode
+        container
       );
       assert.strictEqual(getAdderZIndex(initLeft, initTop), 7);
 
       // Create fourth element (right-top)
-      createComponent(initLeft + adderWidth, initTop, 7, wrapperDOMNode);
+      createComponent(initLeft + adderWidth, initTop, 7, container);
       assert.strictEqual(getAdderZIndex(initLeft, initTop), 8);
 
       // Create third element (right-bottom)
@@ -304,11 +296,9 @@ describe('Adder', () => {
         initLeft + adderWidth,
         initTop + adderHeight,
         8,
-        wrapperDOMNode
+        container
       );
       assert.strictEqual(getAdderZIndex(initLeft, initTop), 9);
-
-      wrapper.unmount();
     });
   });
 

--- a/src/shared/polyfills/document.elementsFromPoint.js
+++ b/src/shared/polyfills/document.elementsFromPoint.js
@@ -1,0 +1,47 @@
+if (
+  typeof document !== 'undefined' &&
+  typeof document.elementsFromPoint === 'undefined'
+) {
+  if (
+    // @ts-ignore
+    typeof document.msElementsFromPoint !== 'undefined'
+  ) {
+    document.elementsFromPoint = (x, y) =>
+      // @ts-ignore
+      Array.from(document.msElementsFromPoint(x, y) ?? []);
+  } else {
+    document.elementsFromPoint = elementsFromPointPolyfill;
+  }
+}
+
+/**
+ * @param {number} x
+ * @param {number} y
+ */
+function elementsFromPointPolyfill(x, y) {
+  const elements = [];
+  const pointerEvents = [];
+  let el;
+
+  do {
+    const newElement = document.elementFromPoint(x, y);
+    if (newElement && el !== newElement) {
+      el = newElement;
+      elements.push(el);
+      // @ts-ignore Element does not have style property
+      pointerEvents.push(el.style.pointerEvents);
+      // @ts-ignore Element does not have style property
+      el.style.pointerEvents = 'none';
+    } else {
+      el = null;
+    }
+  } while (el);
+
+  for (let i = 0; i < elements.length; i++) {
+    const el = elements[i];
+    // @ts-ignore Element does not have style property
+    el.style.pointerEvents = pointerEvents[i];
+  }
+
+  return elements;
+}

--- a/src/shared/polyfills/index.js
+++ b/src/shared/polyfills/index.js
@@ -88,6 +88,10 @@ const needsPolyfill = {
     return typeof document.evaluate !== 'function';
   },
 
+  'document.elementsFromPoint': () => {
+    return typeof document.elementsFromPoint !== 'function';
+  },
+
   // Test for Unicode normalization. This depends on a large polyfill so it
   // is separated out into its own bundle.
   'string.prototype.normalize': () => {


### PR DESCRIPTION
I added a polyfill for `document.elementsFromPoint` to support old browsers.

The polyfill is based on these two npm packages:
* https://www.npmjs.com/package/polyfill-elements-from-point
* https://www.npmjs.com/package/elementsfrompoint-polyfill

When using the non-standard `msElementsFromPoint` the return value is modified to a standard `Element[]` (instead of `NodeList`)

My concern is that the polyfill assumes all the elements return by `elementFromPoint` have `style` property. 
