### PR TITLE
Fix `document.evaluate` feature test in Edge Legacy

### DIFF
--- a/src/annotator/anchoring/xpath.js
+++ b/src/annotator/anchoring/xpath.js
@@ -106,7 +106,10 @@ export function nodeFromXPath(xpath, root = document.body) {
     return document.evaluate(
       '.' + xpath,
       root,
-      null /* nsResolver */,
+
+      // nb. The `namespaceResolver` and `result` arguments are optional in the spec
+      // but required in Edge Legacy.
+      null /* namespaceResolver */,
       XPathResult.FIRST_ORDERED_NODE_TYPE,
       null /* result */
     ).singleNodeValue;

--- a/src/boot/browser-check.js
+++ b/src/boot/browser-check.js
@@ -20,7 +20,17 @@ export function isBrowserSupported() {
 
     // DOM API checks for less frequently-used APIs.
     // These are less likely to have been polyfilled by the host page.
-    () => document.evaluate('/html/body', document), // XPath evaluation.
+    () => {
+      document.evaluate(
+        '/html/body',
+        document,
+
+        // These arguments are optional in the spec but required in Edge Legacy.
+        null /* namespaceResolver */,
+        XPathResult.ANY_TYPE,
+        null /* result */
+      );
+    },
   ];
 
   try {


### PR DESCRIPTION
This API is available in Edge Legacy but with a quirk that arguments
that are optional in the spec (and also in TypeScript's knowledge of the API) are actually required in this browser.

This fixes an issue that the client would incorrectly abort startup in
Edge Legacy with a warning that the browser is unsupported.

This is a follow up to https://github.com/hypothesis/client/pull/2627.