### PR TITLE
Make logic for waiting for PDFs to load work in PDF.js >= 2.5.207

### DIFF
--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -75,10 +75,21 @@ async function getPageView(pageIndex) {
     // a "pdfPage" property.
     pageView = await new Promise(resolve => {
       const onPagesLoaded = () => {
-        document.removeEventListener('pagesloaded', onPagesLoaded);
+        if (pdfViewer.eventBus) {
+          pdfViewer.eventBus.off('pagesloaded', onPagesLoaded);
+        } else {
+          document.removeEventListener('pagesloaded', onPagesLoaded);
+        }
+
         resolve(pdfViewer.getPageView(pageIndex));
       };
-      document.addEventListener('pagesloaded', onPagesLoaded);
+
+      if (pdfViewer.eventBus) {
+        pdfViewer.eventBus.on('pagesloaded', onPagesLoaded);
+      } else {
+        // Old PDF.js versions (< 1.6.210) use DOM events.
+        document.addEventListener('pagesloaded', onPagesLoaded);
+      }
     });
   }
 

--- a/src/annotator/plugin/test/pdf-metadata-test.js
+++ b/src/annotator/plugin/test/pdf-metadata-test.js
@@ -42,13 +42,25 @@ class FakePDFViewerApplication {
   /**
    * Initialize the "PDF viewer" as it would be when loading a document or
    * when a document fails to load.
+   *
+   * @param {string} url - Fake PDF URL
+   * @param {Object} options -
+   *   Options to simulate APIs of different versions of PDF.js.
+   *
+   *   @prop {boolean} domEvents - Whether events are emitted on the DOM
+   *   @prop {boolean} eventBusEvents - Whether the `eventBus` API is enabled
+   *   @prop {boolean} initializedPromise - Whether the `initializedPromise` API is enabled
    */
-  constructor(url = '', { domEvents = false, eventBusEvents = true } = {}) {
+  constructor(
+    url = '',
+    { domEvents = false, eventBusEvents = true, initializedPromise = true } = {}
+  ) {
     this.url = url;
     this.documentInfo = undefined;
     this.metadata = undefined;
     this.pdfDocument = null;
     this.dispatchDOMEvents = domEvents;
+    this.initialized = false;
 
     // Use `EventEmitter` as a fake version of PDF.js's `EventBus` class as the
     // API for subscribing to events is the same.
@@ -56,9 +68,16 @@ class FakePDFViewerApplication {
       this.eventBus = new EventEmitter();
     }
 
-    this.initializedPromise = new Promise(resolve => {
-      this._resolveInitializedPromise = resolve;
+    const initPromise = new Promise(resolve => {
+      this._resolveInitializedPromise = () => {
+        this.initialized = true;
+        resolve();
+      };
     });
+
+    if (initializedPromise) {
+      this.initializedPromise = initPromise;
+    }
   }
 
   /**
@@ -110,61 +129,89 @@ function delay(ms) {
 describe('annotator/plugin/pdf-metadata', function () {
   [
     {
-      // Oldest PDF.js versions (pre-2.x)
+      // PDF.js < 1.6.210: `documentload` event dispatched via DOM.
       eventName: 'documentload',
       domEvents: true,
       eventBusEvents: false,
+      initializedPromise: false,
     },
     {
-      // Newer PDF.js versions (~ < 2.5.x)
-      eventName: 'documentloaded',
-      domEvents: true,
-      eventBusEvents: false,
+      // PDF.js >= 1.6.210: Event dispatch moved to internal event bus.
+      eventName: 'documentload',
+      domEvents: false,
+      eventBusEvents: true,
+      initializedPromise: false,
     },
     {
-      // Current PDF.js versions (>= 2.5.x)
+      // PDF.js >= 2.1.266: Deprecated `documentload` event was removed.
       eventName: 'documentloaded',
       domEvents: false,
       eventBusEvents: true,
+      initializedPromise: false,
     },
-  ].forEach(({ eventName, domEvents = false, eventBusEvents = false }, i) => {
-    it(`waits for PDF to load (${i})`, async () => {
-      const fakeApp = new FakePDFViewerApplication('', {
-        domEvents,
-        eventBusEvents,
+    {
+      // PDF.js >= 2.4.456: `initializedPromise` API was introduced.
+      eventName: 'documentloaded',
+      domEvents: false,
+      eventBusEvents: true,
+      initializedPromise: true,
+    },
+  ].forEach(
+    ({ eventName, domEvents, eventBusEvents, initializedPromise }, i) => {
+      it(`waits for PDF to load (${i})`, async () => {
+        const fakeApp = new FakePDFViewerApplication('', {
+          domEvents,
+          eventBusEvents,
+          initializedPromise,
+        });
+        const pdfMetadata = new PDFMetadata(fakeApp);
+
+        fakeApp.completeInit();
+
+        // Request the PDF URL before the document has finished loading.
+        const uriPromise = pdfMetadata.getUri();
+
+        // Simulate a short delay in completing PDF.js initialization and
+        // loading the PDF.
+        //
+        // Note that this delay is longer than the `app.initialized` polling
+        // interval in `pdfViewerInitialized`.
+        await delay(10);
+
+        fakeApp.finishLoading({
+          eventName,
+          url: 'http://fake.com',
+          fingerprint: 'fakeFingerprint',
+        });
+
+        assert.equal(await uriPromise, 'http://fake.com/');
       });
-      const pdfMetadata = new PDFMetadata(fakeApp);
+    }
+  );
 
-      fakeApp.completeInit();
-
-      // Give `PDFMetadata` a chance to register the "documentloaded" event listener.
-      await delay(0);
-
-      fakeApp.finishLoading({
-        eventName,
+  // The `initializedPromise` param simulates different versions of PDF.js with
+  // and without the `PDFViewerApplication.initializedPromise` API.
+  [true, false].forEach(initializedPromise => {
+    it('does not wait for the PDF to load if it has already loaded', function () {
+      const fakePDFViewerApplication = new FakePDFViewerApplication('', {
+        initializedPromise,
+      });
+      fakePDFViewerApplication.completeInit();
+      fakePDFViewerApplication.finishLoading({
         url: 'http://fake.com',
         fingerprint: 'fakeFingerprint',
       });
-
-      assert.equal(await pdfMetadata.getUri(), 'http://fake.com/');
-    });
-  });
-
-  it('does not wait for the PDF to load if it has already loaded', function () {
-    const fakePDFViewerApplication = new FakePDFViewerApplication();
-    fakePDFViewerApplication.finishLoading({
-      url: 'http://fake.com',
-      fingerprint: 'fakeFingerprint',
-    });
-    const pdfMetadata = new PDFMetadata(fakePDFViewerApplication);
-    return pdfMetadata.getUri().then(function (uri) {
-      assert.equal(uri, 'http://fake.com/');
+      const pdfMetadata = new PDFMetadata(fakePDFViewerApplication);
+      return pdfMetadata.getUri().then(function (uri) {
+        assert.equal(uri, 'http://fake.com/');
+      });
     });
   });
 
   describe('metadata sources', function () {
     let pdfMetadata;
     const fakePDFViewerApplication = new FakePDFViewerApplication();
+    fakePDFViewerApplication.completeInit();
     fakePDFViewerApplication.finishLoading({
       fingerprint: 'fakeFingerprint',
       title: 'fakeTitle',
@@ -187,6 +234,7 @@ describe('annotator/plugin/pdf-metadata', function () {
 
       it('returns the fingerprint as a URN when the PDF URL is a local file', function () {
         const fakePDFViewerApplication = new FakePDFViewerApplication();
+        fakePDFViewerApplication.completeInit();
         fakePDFViewerApplication.finishLoading({
           url: 'file:///test.pdf',
           fingerprint: 'fakeFingerprint',
@@ -200,6 +248,7 @@ describe('annotator/plugin/pdf-metadata', function () {
 
       it('resolves relative URLs', () => {
         const fakePDFViewerApplication = new FakePDFViewerApplication();
+        fakePDFViewerApplication.completeInit();
         fakePDFViewerApplication.finishLoading({
           url: 'index.php?action=download&file_id=wibble',
           fingerprint: 'fakeFingerprint',
@@ -258,6 +307,7 @@ describe('annotator/plugin/pdf-metadata', function () {
       it('does not save file:// URLs in document metadata', function () {
         let pdfMetadata;
         const fakePDFViewerApplication = new FakePDFViewerApplication();
+        fakePDFViewerApplication.completeInit();
         fakePDFViewerApplication.finishLoading({
           fingerprint: 'fakeFingerprint',
           url: 'file://fake.pdf',

--- a/src/types/pdfjs.js
+++ b/src/types/pdfjs.js
@@ -62,6 +62,8 @@
  * Defined in `web/pdf_viewer.js` in the PDF.js source.
  *
  * @prop {number} pagesCount
+ * @prop {EventBus} eventBus -
+ *   Reference to the global event bus. Added in PDF.js v1.6.210.
  * @prop {(page: number) => PDFPageView|null} getPageView
  */
 
@@ -80,12 +82,14 @@
  *
  * @typedef PDFViewerApplication
  * @prop {EventBus} [eventBus] -
- *   Global event bus. Since v1.6.210.
+ *   Global event bus. Since v1.6.210. This is not available until the PDF viewer
+ *   has been initialized. See `initialized` and `initializedPromise` properties.
  * @prop {PDFDocument} pdfDocument
  * @prop {PDFViewer} pdfViewer
  * @prop {boolean} downloadComplete
  * @prop {PDFDocumentInfo} documentInfo
  * @prop {Metadata} metadata
+ * @prop {boolean} initialized - Indicates that the PDF viewer is initialized.
  * @prop {Promise<void>} [initializedPromise] -
  *   Promise that resolves when PDF.js is initialized. Since v2.4.456.
  *   See https://github.com/mozilla/pdf.js/wiki/Third-party-viewer-usage#initialization-promise.


### PR DESCRIPTION
f96af43df added support for PDF.js >= v2.5.207 by changing an event
listener to use PDF.js's internal event bus rather than DOM events.
However there was another DOM event listener for the `pagesloaded` event
in `src/annotator/anchoring/pdf.js` that should also have been updated but was
overlooked. This didn't cause a problem in testing with the dev server because
the test documents load quickly enough that they are already loaded by the time
the client's anchoring logic ran.

This commit updates the way that the client listens for events from
PDF.js to use the event bus where available and only fall back to the
DOM in versions of PDF.js that don't support it.

 - Use PDF.js's event bus to listen for `documentload`/`documentloaded`
   and `pagesloaded` events

 - Add a fallback method to wait for event bus to become available in
   versions of PDF.js which support the eventBus but don't have the
   `initializedPromise` API

 - Improve the documentation around which versions of PDF.js support
   different event types and event dispatch methods

 - Add tests to cover the behavior from different releases of PDF.js

For an overview of the different versions of PDF.js that the client
needs to support, see https://github.com/hypothesis/client/issues/2643.

----

**TODO**

- [x] Re-test manually in 1) the version of Hypothesis that ships with the dev server, 2) the version that ships with Via and 3) the v1.1.114 release that shipped with https://github.com/hypothesis/pdf.js-hypothes.is until November 2019
- [x] Add tests to cover fallback paths that wait for PDF viewer to be initialized