### PR TITLE
Remove checks for IE 11 in `TagEditor` component

### DIFF
--- a/src/sidebar/components/tag-editor.js
+++ b/src/sidebar/components/tag-editor.js
@@ -1,9 +1,8 @@
 import { createElement } from 'preact';
-import { useMemo, useRef, useState } from 'preact/hooks';
+import { useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import { withServices } from '../util/service-context';
-import { isIE11 } from '../../shared/user-agent';
 
 import AutocompleteList from './autocomplete-list';
 import { normalizeKeyName } from '../../shared/browser-compatibility-utils';
@@ -54,8 +53,6 @@ function TagEditor({
   useElementShouldClose(closeWrapperRef, suggestionsListOpen, () => {
     setSuggestionsListOpen(false);
   });
-
-  const ie11 = useMemo(() => isIE11(), []);
 
   /**
    * Retrieve the current trimmed text value of the tag <input>
@@ -120,20 +117,9 @@ function TagEditor({
     }
   };
 
-  /**
-   *  Update the suggestions if the user changes the value of the input
-   *
-   * @param {import("preact").JSX.TargetedEvent<HTMLInputElement, InputEvent>} e
-   */
-  const handleOnInput = e => {
+  const handleOnInput = () => {
     onTagInput?.(pendingTag());
-    if (
-      e.inputType === 'insertText' ||
-      e.inputType === 'deleteContentBackward' ||
-      ie11 // inputType is not defined in IE 11, so trigger on any input in this case.
-    ) {
-      updateSuggestions();
-    }
+    updateSuggestions();
   };
 
   /**

--- a/src/sidebar/components/test/tag-editor-test.js
+++ b/src/sidebar/components/test/tag-editor-test.js
@@ -17,7 +17,6 @@ describe('TagEditor', function () {
   let fakeOnAddTag;
   let fakeOnRemoveTag;
   let fakeOnTagInput;
-  let fakeIsIE11;
 
   function createComponent(props) {
     // Use an array of containers so we can test more
@@ -46,16 +45,10 @@ describe('TagEditor', function () {
     fakeOnRemoveTag = sinon.stub();
     fakeOnTagInput = sinon.stub();
     fakeServiceUrl = sinon.stub().returns('http://serviceurl.com');
-    fakeIsIE11 = sinon.stub().returns(false);
     fakeTagsService = {
       filter: sinon.stub().returns(['tag4', 'tag3']),
     };
     $imports.$mock(mockImportedComponents());
-    $imports.$mock({
-      '../../shared/user-agent': {
-        isIE11: fakeIsIE11,
-      },
-    });
   });
 
   afterEach(function () {
@@ -91,12 +84,7 @@ describe('TagEditor', function () {
   }
   // Simulates typing text
   function typeInput(wrapper) {
-    if (!fakeIsIE11()) {
-      wrapper.find('input').simulate('input', { inputType: 'insertText' });
-    } else {
-      // IE11 does not have an inputType key.
-      wrapper.find('input').simulate('input', {});
-    }
+    wrapper.find('input').simulate('input', { inputType: 'insertText' });
   }
 
   it('adds appropriate tag values to the elements', () => {
@@ -417,58 +405,52 @@ describe('TagEditor', function () {
     });
 
     describe('navigating suggestions via keyboard', () => {
-      [true, false].forEach(ie11 => {
-        it('should set the initial `activeItem` value to -1 when opening suggestions', () => {
-          fakeIsIE11.returns(ie11);
-          const wrapper = createComponent();
-          wrapper.find('input').instance().value = 'non-empty';
-          typeInput(wrapper);
-          assert.equal(wrapper.find('AutocompleteList').prop('open'), true);
-          assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), -1);
-        });
+      it('should set the initial `activeItem` value to -1 when opening suggestions', () => {
+        const wrapper = createComponent();
+        wrapper.find('input').instance().value = 'non-empty';
+        typeInput(wrapper);
+        assert.equal(wrapper.find('AutocompleteList').prop('open'), true);
+        assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), -1);
+      });
 
-        it('should increment the `activeItem` when pressing down circularly', () => {
-          fakeIsIE11.returns(ie11);
-          const wrapper = createComponent();
-          wrapper.find('input').instance().value = 'non-empty';
-          typeInput(wrapper);
-          // 2 suggestions: ['tag3', 'tag4'];
-          navigateDown(wrapper);
-          assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 0);
-          navigateDown(wrapper);
-          assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 1);
-          navigateDown(wrapper);
-          // back to unselected
-          assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), -1);
-        });
+      it('should increment the `activeItem` when pressing down circularly', () => {
+        const wrapper = createComponent();
+        wrapper.find('input').instance().value = 'non-empty';
+        typeInput(wrapper);
+        // 2 suggestions: ['tag3', 'tag4'];
+        navigateDown(wrapper);
+        assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 0);
+        navigateDown(wrapper);
+        assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 1);
+        navigateDown(wrapper);
+        // back to unselected
+        assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), -1);
+      });
 
-        it('should decrement the `activeItem` when pressing up circularly', () => {
-          fakeIsIE11.returns(ie11);
-          const wrapper = createComponent();
-          wrapper.find('input').instance().value = 'non-empty';
-          typeInput(wrapper);
-          // 2 suggestions: ['tag3', 'tag4'];
-          navigateUp(wrapper);
-          assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 1);
-          navigateUp(wrapper);
-          assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 0);
-          navigateUp(wrapper);
-          assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), -1);
-        });
+      it('should decrement the `activeItem` when pressing up circularly', () => {
+        const wrapper = createComponent();
+        wrapper.find('input').instance().value = 'non-empty';
+        typeInput(wrapper);
+        // 2 suggestions: ['tag3', 'tag4'];
+        navigateUp(wrapper);
+        assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 1);
+        navigateUp(wrapper);
+        assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 0);
+        navigateUp(wrapper);
+        assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), -1);
+      });
 
-        it('should set `activeItem` to -1 when clearing the suggestions', () => {
-          fakeIsIE11.returns(ie11);
-          const wrapper = createComponent();
-          wrapper.find('input').instance().value = 'non-empty';
-          typeInput(wrapper);
-          navigateDown(wrapper);
-          // change to non-default value
-          assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 0);
-          // clear suggestions
-          wrapper.find('input').instance().value = '';
-          typeInput(wrapper);
-          assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), -1);
-        });
+      it('should set `activeItem` to -1 when clearing the suggestions', () => {
+        const wrapper = createComponent();
+        wrapper.find('input').instance().value = 'non-empty';
+        typeInput(wrapper);
+        navigateDown(wrapper);
+        // change to non-default value
+        assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), 0);
+        // clear suggestions
+        wrapper.find('input').instance().value = '';
+        typeInput(wrapper);
+        assert.equal(wrapper.find('AutocompleteList').prop('activeItem'), -1);
       });
     });
   });


### PR DESCRIPTION
`TagEditor` tested if the browser was IE 11 to determine whether to
check the `inputType` property of `InputEvent`. However it is not only
IE 11 that did not support this property.

From reading the comments in https://github.com/hypothesis/client/pull/1558 it
appears that the `inputType` checks was originally added to resolve an
issue with accepting suggestions by pressing Enter in an earlier version
of `TagEditor` that used the `<datalist>` element. As far as I can tell
this is no longer applicable. `<datalist>` was replaced by a custom UI
and accepting suggestions by pressing Enter works without this logic.
Therefore this commit removes it entirely.

@LMS007 - Please let me know if you can think of something I've overlooked here.