### PR TITLE
Remove jQuery from `BucketBar` and increase test coverage

### DIFF
--- a/src/annotator/plugin/test/bucket-bar-test.js
+++ b/src/annotator/plugin/test/bucket-bar-test.js
@@ -1,15 +1,15 @@
-import $ from 'jquery';
 import BucketBar from '../bucket-bar';
 import { $imports } from '../bucket-bar';
 
-// Return DOM elements for non-empty bucket indicators in a `BucketBar`.
+// Return DOM elements for non-empty bucket indicators in a `BucketBar`
+// (i.e. bucket tab elements containing 1 or more anchors)
 const nonEmptyBuckets = function (bucketBar) {
-  const buckets = bucketBar.element[0].querySelectorAll(
+  const buckets = bucketBar.element.querySelectorAll(
     '.annotator-bucket-indicator'
   );
   return Array.from(buckets).filter(bucket => {
     const label = bucket.querySelector('.label');
-    return parseInt(label.textContent) > 0;
+    return !!label;
   });
 };
 
@@ -17,9 +17,27 @@ const createMouseEvent = function (type, { ctrlKey, metaKey } = {}) {
   return new MouseEvent(type, { ctrlKey, metaKey });
 };
 
+// Create a fake anchor, which is a combination of annotation object and
+// associated highlight elements.
+const createAnchor = () => {
+  return {
+    annotation: { $tag: 'ann1' },
+    highlights: [document.createElement('span')],
+  };
+};
+
 describe('BucketBar', () => {
+  const sandbox = sinon.createSandbox();
   let fakeAnnotator;
   let fakeBucketUtil;
+  let fakeHighlighter;
+  let fakeScrollIntoView;
+  let bucketBar;
+
+  const createBucketBar = function (options) {
+    const element = document.createElement('div');
+    return new BucketBar(element, options || {}, fakeAnnotator);
+  };
 
   beforeEach(() => {
     fakeAnnotator = {
@@ -35,32 +53,113 @@ describe('BucketBar', () => {
       buildBuckets: sinon.stub().returns([]),
     };
 
+    fakeHighlighter = {
+      setHighlightsFocused: sinon.stub(),
+    };
+
+    fakeScrollIntoView = sinon.stub();
+
     $imports.$mock({
+      'scroll-into-view': fakeScrollIntoView,
+      '../highlighter': fakeHighlighter,
       '../util/buckets': fakeBucketUtil,
     });
+
+    sandbox.stub(window, 'requestAnimationFrame').yields();
   });
 
   afterEach(() => {
+    bucketBar?.destroy();
     $imports.$restore();
+    sandbox.restore();
   });
 
-  const createBucketBar = function (options) {
-    const element = document.createElement('div');
-    return new BucketBar(element, options || {}, fakeAnnotator);
-  };
+  describe('initializing and attaching to the DOM', () => {
+    let containerEl;
 
-  // Create a fake anchor, which is a combination of annotation object and
-  // associated highlight elements.
-  const createAnchor = () => {
-    return {
-      annotation: { $tag: 'ann1' },
-      highlights: [document.createElement('span')],
-    };
-  };
+    beforeEach(() => {
+      // Any element referenced by `options.container` selector needs to be
+      // present on the `document` before initialization
+      containerEl = document.createElement('div');
+      containerEl.className = 'bucket-bar-container';
+      document.body.appendChild(containerEl);
+      sandbox.stub(console, 'warn'); // Restored in test-global `afterEach`
+    });
 
-  context('when a bucket is clicked', () => {
-    let bucketBar;
+    afterEach(() => {
+      containerEl.remove();
+    });
 
+    it('will append its element to any supplied `options.container` selector', () => {
+      bucketBar = createBucketBar({ container: '.bucket-bar-container' });
+      assert.exists(containerEl.querySelector('.annotator-bucket-bar'));
+    });
+
+    it('will append itself to the element passed to constructor if `options.container` non-existent', () => {
+      bucketBar = createBucketBar({ container: '.bucket-bar-nope' });
+      assert.notExists(containerEl.querySelector('.annotator-bucket-bar'));
+      assert.calledOnce(console.warn);
+    });
+  });
+
+  describe('updating buckets', () => {
+    it('should update buckets when the window is resized', () => {
+      bucketBar = createBucketBar();
+      assert.notCalled(fakeBucketUtil.buildBuckets);
+      window.dispatchEvent(new Event('resize'));
+      assert.calledOnce(fakeBucketUtil.buildBuckets);
+    });
+
+    it('should update buckets when the window is scrolled', () => {
+      bucketBar = createBucketBar();
+      assert.notCalled(fakeBucketUtil.buildBuckets);
+      window.dispatchEvent(new Event('scroll'));
+      assert.calledOnce(fakeBucketUtil.buildBuckets);
+    });
+
+    context('when scrollables provided', () => {
+      let scrollableEls = [];
+
+      beforeEach(() => {
+        const scrollableEls1 = document.createElement('div');
+        scrollableEls1.className = 'scrollable-1';
+        const scrollableEls2 = document.createElement('div');
+        scrollableEls2.className = 'scrollable-2';
+        scrollableEls.push(scrollableEls1, scrollableEls2);
+        document.body.appendChild(scrollableEls1);
+        document.body.appendChild(scrollableEls2);
+      });
+
+      afterEach(() => {
+        // Explicitly call `destroy` before removing scrollable elements
+        // from document to test the scrollable-remove-events path of
+        // the `destroy` method. Otherwise, this afterEach will execute
+        // before the test-global one that calls `destroy`, and there will
+        // be no scrollable elements left in the document.
+        bucketBar.destroy();
+        scrollableEls.forEach(el => el.remove());
+      });
+
+      it('should update buckets when any scrollable scrolls', () => {
+        bucketBar = createBucketBar({
+          scrollables: ['.scrollable-1', '.scrollable-2'],
+        });
+        assert.notCalled(fakeBucketUtil.buildBuckets);
+        scrollableEls[0].dispatchEvent(new Event('scroll'));
+        assert.calledOnce(fakeBucketUtil.buildBuckets);
+        scrollableEls[1].dispatchEvent(new Event('scroll'));
+        assert.calledTwice(fakeBucketUtil.buildBuckets);
+      });
+    });
+
+    it('should not update if another update is pending', () => {
+      bucketBar._updatePending = true;
+      bucketBar.update();
+      assert.notCalled(window.requestAnimationFrame);
+    });
+  });
+
+  describe('user interactions with buckets', () => {
     beforeEach(() => {
       bucketBar = createBucketBar();
       // Create fake anchors and render buckets.
@@ -71,11 +170,34 @@ describe('BucketBar', () => {
       ]);
 
       bucketBar.annotator.anchors = anchors;
-      bucketBar._update();
+      bucketBar.update();
     });
 
-    it('selects the annotations', () => {
-      // Click on the indicator for the non-empty bucket.
+    it('highlights the bucket anchors when pointer device moved into bucket', () => {
+      const bucketEls = nonEmptyBuckets(bucketBar);
+      bucketEls[0].dispatchEvent(createMouseEvent('mousemove'));
+      assert.calledOnce(fakeHighlighter.setHighlightsFocused);
+      assert.calledWith(
+        fakeHighlighter.setHighlightsFocused,
+        bucketBar.annotator.anchors[0].highlights,
+        true
+      );
+    });
+
+    it('un-highlights the bucket anchors when pointer device moved out of bucket', () => {
+      const bucketEls = nonEmptyBuckets(bucketBar);
+      bucketEls[0].dispatchEvent(createMouseEvent('mousemove'));
+      bucketEls[0].dispatchEvent(createMouseEvent('mouseout'));
+      assert.calledTwice(fakeHighlighter.setHighlightsFocused);
+      const secondCall = fakeHighlighter.setHighlightsFocused.getCall(1);
+      assert.equal(
+        secondCall.args[0],
+        bucketBar.annotator.anchors[0].highlights
+      );
+      assert.equal(secondCall.args[1], false);
+    });
+
+    it('selects the annotations corresponding to the anchors in a bucket when bucket is clicked', () => {
       const bucketEls = nonEmptyBuckets(bucketBar);
       assert.equal(bucketEls.length, 1);
       bucketEls[0].dispatchEvent(createMouseEvent('click'));
@@ -84,12 +206,24 @@ describe('BucketBar', () => {
       assert.calledWith(bucketBar.annotator.selectAnnotations, anns, false);
     });
 
+    it('handles missing buckets gracefully on click', () => {
+      // FIXME - refactor and remove necessity for this test
+      // There is a coupling between `BucketBar.prototype.tabs` and
+      // `BucketBar.prototype.buckets` — they're "expected" to be the same
+      // length and correspond to each other. This very much should be the case,
+      // but, just in case...
+      const bucketEls = nonEmptyBuckets(bucketBar);
+      assert.equal(bucketEls.length, 1);
+      bucketBar.tabs = [];
+      bucketEls[0].dispatchEvent(createMouseEvent('click'));
+      assert.notCalled(bucketBar.annotator.selectAnnotations);
+    });
+
     [
       { ctrlKey: true, metaKey: false },
       { ctrlKey: false, metaKey: true },
     ].forEach(({ ctrlKey, metaKey }) =>
       it('toggles selection of the annotations if Ctrl or Alt is pressed', () => {
-        // Click on the indicator for the non-empty bucket.
         const bucketEls = nonEmptyBuckets(bucketBar);
         assert.equal(bucketEls.length, 1);
         bucketEls[0].dispatchEvent(
@@ -104,112 +238,154 @@ describe('BucketBar', () => {
     );
   });
 
-  // Yes this is testing a private method. Yes this is bad practice, but I'd
-  // rather test this functionality in a private method than not test it at all.
-  //
-  // Note: This could be tested using only the public APIs of the `BucketBar`
-  // class using the approach of the "when a bucket is clicked" tests above.
-  describe.skip('_buildTabs', () => {
-    const setup = function (tabs) {
-      const bucketBar = createBucketBar();
-      bucketBar.tabs = tabs;
-      bucketBar.buckets = [
-        { anchors: [], position: 0 },
-        {
-          anchors: ['AN ANNOTATION?'],
-          position: BucketBar.BUCKET_TOP_THRESHOLD - 1,
-        },
-        { anchors: [], position: BucketBar.BUCKET_TOP_THRESHOLD },
+  describe('rendered bucket "tabs"', () => {
+    let fakeAnchors;
+    let fakeAbove;
+    let fakeBelow;
+    let fakeBuckets;
+
+    beforeEach(() => {
+      bucketBar = createBucketBar();
+      fakeAnchors = [
+        createAnchor(),
+        createAnchor(),
+        createAnchor(),
+        createAnchor(),
+        createAnchor(),
+        createAnchor(),
       ];
-      return bucketBar;
-    };
+      // These two anchors are considered to be offscreen upwards
+      fakeAbove = [fakeAnchors[0], fakeAnchors[1]];
+      // These buckets are on-screen
+      fakeBuckets = [
+        { anchors: [fakeAnchors[2], fakeAnchors[3]], position: 350 },
+        { anchors: [], position: 450 }, // This is an empty bucket
+        { anchors: [fakeAnchors[4]], position: 550 },
+      ];
+      // This anchor is offscreen below
+      fakeBelow = [fakeAnchors[5]];
 
-    it('creates a tab with a title', () => {
-      const tab = $('<div />');
-      const bucketBar = setup(tab);
-
-      bucketBar._buildTabs();
-      assert.equal(tab.attr('title'), 'Show one annotation');
+      fakeBucketUtil.constructPositionPoints.returns({
+        above: fakeAbove,
+        below: fakeBelow,
+        points: [],
+      });
+      fakeBucketUtil.buildBuckets.returns(fakeBuckets.slice());
     });
 
-    it('creates a tab with a pluralized title', () => {
-      const tab = $('<div />');
-      const bucketBar = setup(tab);
-      bucketBar.buckets[0].anchors.push('Another Annotation?');
+    describe('navigation bucket tabs', () => {
+      it('adds navigation tabs to scroll up and down to nearest anchors offscreen', () => {
+        bucketBar.update();
+        const validBuckets = nonEmptyBuckets(bucketBar);
+        assert.equal(
+          validBuckets[0].getAttribute('title'),
+          'Show 2 annotations'
+        );
+        assert.equal(
+          validBuckets[validBuckets.length - 1].getAttribute('title'),
+          'Show one annotation'
+        );
 
-      bucketBar._buildTabs();
-      assert.equal(tab.attr('title'), 'Show 2 annotations');
+        assert.isTrue(validBuckets[0].classList.contains('upper'));
+        assert.isTrue(
+          validBuckets[validBuckets.length - 1].classList.contains('lower')
+        );
+      });
+
+      it('removes unneeded tab elements from the document', () => {
+        bucketBar.update();
+        const extraEl = document.createElement('div');
+        extraEl.className = 'extraTab';
+        bucketBar.element.append(extraEl);
+        bucketBar.tabs.push(extraEl);
+        assert.equal(bucketBar.tabs.length, bucketBar.buckets.length + 1);
+
+        // Resetting this return is necessary to return a fresh array reference
+        // on next update
+        fakeBucketUtil.buildBuckets.returns(fakeBuckets.slice());
+        bucketBar.update();
+        assert.equal(bucketBar.tabs.length, bucketBar.buckets.length);
+        assert.notExists(bucketBar.element.querySelector('.extraTab'));
+      });
+
+      it('scrolls up to nearest anchor above when upper navigation tab clicked', () => {
+        fakeBucketUtil.findClosestOffscreenAnchor.returns(fakeAnchors[1]);
+        bucketBar.update();
+        const visibleBuckets = nonEmptyBuckets(bucketBar);
+        visibleBuckets[0].dispatchEvent(createMouseEvent('click'));
+        assert.calledOnce(fakeBucketUtil.findClosestOffscreenAnchor);
+        assert.calledWith(
+          fakeBucketUtil.findClosestOffscreenAnchor,
+          sinon.match([fakeAnchors[0], fakeAnchors[1]]),
+          'up'
+        );
+        assert.calledOnce(fakeScrollIntoView);
+        assert.calledWith(fakeScrollIntoView, fakeAnchors[1].highlights[0]);
+      });
+
+      it('scrolls down to nearest anchor below when lower navigation tab clicked', () => {
+        fakeBucketUtil.findClosestOffscreenAnchor.returns(fakeAnchors[5]);
+        bucketBar.update();
+        const visibleBuckets = nonEmptyBuckets(bucketBar);
+        visibleBuckets[visibleBuckets.length - 1].dispatchEvent(
+          createMouseEvent('click')
+        );
+        assert.calledOnce(fakeBucketUtil.findClosestOffscreenAnchor);
+        assert.calledWith(
+          fakeBucketUtil.findClosestOffscreenAnchor,
+          sinon.match([fakeAnchors[5]]),
+          'down'
+        );
+        assert.calledOnce(fakeScrollIntoView);
+        assert.calledWith(fakeScrollIntoView, fakeAnchors[5].highlights[0]);
+      });
     });
 
-    it('sets the tab text to the number of annotations', () => {
-      const tab = $('<div />');
-      const bucketBar = setup(tab);
-      bucketBar.buckets[0].push('Another Annotation?');
-
-      bucketBar._buildTabs();
-      assert.equal(tab.text(), '2');
+    it('displays bucket tabs that have at least one anchor', () => {
+      bucketBar.update();
+      const visibleBuckets = nonEmptyBuckets(bucketBar);
+      // Visible buckets include: upper navigation tab, two on-screen buckets,
+      // lower navigation tab = 4
+      assert.equal(visibleBuckets.length, 4);
+      visibleBuckets.forEach(visibleEl => {
+        assert.equal(visibleEl.style.display, '');
+      });
     });
 
-    it('sets the tab text to the number of annotations', () => {
-      const tab = $('<div />');
-      const bucketBar = setup(tab);
-      bucketBar.buckets[0].push('Another Annotation?');
-
-      bucketBar._buildTabs();
-      assert.equal(tab.text(), '2');
+    it('sets bucket-tab label text and title based on number of anchors', () => {
+      bucketBar.update();
+      const visibleBuckets = nonEmptyBuckets(bucketBar);
+      // Upper navigation bucket tab
+      assert.equal(visibleBuckets[0].title, 'Show 2 annotations');
+      assert.equal(visibleBuckets[0].querySelector('.label').innerHTML, '2');
+      // First on-screen visible bucket
+      assert.equal(visibleBuckets[1].title, 'Show 2 annotations');
+      assert.equal(visibleBuckets[1].querySelector('.label').innerHTML, '2');
+      // Second on-screen visible bucket
+      assert.equal(visibleBuckets[2].title, 'Show one annotation');
+      assert.equal(visibleBuckets[2].querySelector('.label').innerHTML, '1');
+      // Lower navigation bucket tab
+      assert.equal(visibleBuckets[3].title, 'Show one annotation');
+      assert.equal(visibleBuckets[3].querySelector('.label').innerHTML, '1');
     });
 
-    it('adds the class "upper" if the annotation is at the top', () => {
-      const tab = $('<div />');
-      const bucketBar = setup(tab);
-      sinon.stub(bucketBar, 'isUpper').returns(true);
+    it('does not display empty bucket tabs', () => {
+      fakeBucketUtil.buildBuckets.returns([]);
+      fakeBucketUtil.constructPositionPoints.returns({
+        above: [],
+        below: [],
+        points: [],
+      });
+      bucketBar.update();
 
-      bucketBar._buildTabs();
-      assert.equal(tab.hasClass('upper'), true);
-    });
+      const allBuckets = bucketBar.element.querySelectorAll(
+        '.annotator-bucket-indicator'
+      );
 
-    it('removes the class "upper" if the annotation is not at the top', () => {
-      const tab = $('<div />').addClass('upper');
-      const bucketBar = setup(tab);
-      sinon.stub(bucketBar, 'isUpper').returns(false);
-
-      bucketBar._buildTabs();
-      assert.equal(tab.hasClass('upper'), false);
-    });
-
-    it('adds the class "lower" if the annotation is at the top', () => {
-      const tab = $('<div />');
-      const bucketBar = setup(tab);
-      sinon.stub(bucketBar, 'isLower').returns(true);
-
-      bucketBar._buildTabs();
-      assert.equal(tab.hasClass('lower'), true);
-    });
-
-    it('removes the class "lower" if the annotation is not at the top', () => {
-      const tab = $('<div />').addClass('lower');
-      const bucketBar = setup(tab);
-      sinon.stub(bucketBar, 'isLower').returns(false);
-
-      bucketBar._buildTabs();
-      assert.equal(tab.hasClass('lower'), false);
-    });
-
-    it('reveals the tab if there are annotations in the bucket', () => {
-      const tab = $('<div />');
-      const bucketBar = setup(tab);
-
-      bucketBar._buildTabs();
-      assert.equal(tab.css('display'), '');
-    });
-
-    it('hides the tab if there are no annotations in the bucket', () => {
-      const tab = $('<div />');
-      const bucketBar = setup(tab);
-      bucketBar.buckets = [];
-
-      bucketBar._buildTabs();
-      assert.equal(tab.css('display'), 'none');
+      // All of the buckets are empty...
+      allBuckets.forEach(bucketEl => {
+        assert.equal(bucketEl.style.display, 'none');
+      });
     });
   });
 });

--- a/src/annotator/plugin/test/bucket-bar-test.js
+++ b/src/annotator/plugin/test/bucket-bar-test.js
@@ -66,10 +66,9 @@ describe('BucketBar', () => {
       // Create fake anchors and render buckets.
       const anchors = [createAnchor()];
 
-      fakeBucketUtil.buildBuckets.returns({
-        index: [250],
-        buckets: [[anchors[0]]],
-      });
+      fakeBucketUtil.buildBuckets.returns([
+        { anchors: [anchors[0]], position: 250 },
+      ]);
 
       bucketBar.annotator.anchors = anchors;
       bucketBar._update();
@@ -110,15 +109,17 @@ describe('BucketBar', () => {
   //
   // Note: This could be tested using only the public APIs of the `BucketBar`
   // class using the approach of the "when a bucket is clicked" tests above.
-  describe('_buildTabs', () => {
+  describe.skip('_buildTabs', () => {
     const setup = function (tabs) {
       const bucketBar = createBucketBar();
       bucketBar.tabs = tabs;
-      bucketBar.buckets = [['AN ANNOTATION?']];
-      bucketBar.index = [
-        0,
-        BucketBar.BUCKET_TOP_THRESHOLD - 1,
-        BucketBar.BUCKET_TOP_THRESHOLD,
+      bucketBar.buckets = [
+        { anchors: [], position: 0 },
+        {
+          anchors: ['AN ANNOTATION?'],
+          position: BucketBar.BUCKET_TOP_THRESHOLD - 1,
+        },
+        { anchors: [], position: BucketBar.BUCKET_TOP_THRESHOLD },
       ];
       return bucketBar;
     };
@@ -134,7 +135,7 @@ describe('BucketBar', () => {
     it('creates a tab with a pluralized title', () => {
       const tab = $('<div />');
       const bucketBar = setup(tab);
-      bucketBar.buckets[0].push('Another Annotation?');
+      bucketBar.buckets[0].anchors.push('Another Annotation?');
 
       bucketBar._buildTabs();
       assert.equal(tab.attr('title'), 'Show 2 annotations');

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -42,7 +42,9 @@ export default class Sidebar extends Host {
     }
 
     if (this.plugins.BucketBar) {
-      this.plugins.BucketBar.element.on('click', () => this.show());
+      this.plugins.BucketBar.element.addEventListener('click', () =>
+        this.show()
+      );
     }
 
     // Set up the toolbar on the left edge of the sidebar.

--- a/src/annotator/test/pdf-sidebar-test.js
+++ b/src/annotator/test/pdf-sidebar-test.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import PdfSidebar from '../pdf-sidebar';
 import { $imports } from '../pdf-sidebar';
 
@@ -46,7 +44,7 @@ describe('PdfSidebar', () => {
     fakeCrossFrame.destroy = sandbox.stub();
 
     const fakeBucketBar = {};
-    fakeBucketBar.element = $('<div></div>');
+    fakeBucketBar.element = document.createElement('div');
     fakeBucketBar.destroy = sandbox.stub();
 
     CrossFrame = sandbox.stub();

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import events from '../../shared/bridge-events';
 
 import Sidebar from '../sidebar';
@@ -68,7 +66,7 @@ describe('Sidebar', () => {
     FakeToolbarController = sinon.stub().returns(fakeToolbar);
 
     const fakeBucketBar = {};
-    fakeBucketBar.element = $('<div></div>');
+    fakeBucketBar.element = document.createElement('div');
     fakeBucketBar.destroy = sandbox.stub();
 
     CrossFrame = sandbox.stub();

--- a/src/annotator/util/test/buckets-test.js
+++ b/src/annotator/util/test/buckets-test.js
@@ -203,10 +203,9 @@ describe('annotator/util/buckets', () => {
 
   describe('buildBuckets', () => {
     it('should return empty buckets if points array is empty', () => {
-      const bucketInfo = buildBuckets([]);
-      assert.isArray(bucketInfo.buckets);
-      assert.isEmpty(bucketInfo.buckets);
-      assert.isEmpty(bucketInfo.index);
+      const buckets = buildBuckets([]);
+      assert.isArray(buckets);
+      assert.isEmpty(buckets);
     });
 
     it('should group overlapping anchor highlights into shared buckets', () => {
@@ -220,12 +219,12 @@ describe('annotator/util/buckets', () => {
       });
 
       const buckets = buildBuckets(points);
-      assert.equal(buckets.buckets.length, 2);
-      assert.isEmpty(buckets.buckets[1]);
+      assert.equal(buckets.length, 2);
+      assert.isEmpty(buckets[1].anchors);
       // All anchors are in a single bucket
-      assert.deepEqual(buckets.buckets[0], anchors);
+      assert.deepEqual(buckets[0].anchors, anchors);
       // Because this is the first bucket, it will be aligned top
-      assert.equal(buckets.index[0], 150);
+      assert.equal(buckets[0].position, 150);
     });
 
     it('should group nearby anchor highlights into shared buckets', () => {
@@ -241,12 +240,12 @@ describe('annotator/util/buckets', () => {
       });
 
       const buckets = buildBuckets(points);
-      assert.equal(buckets.buckets.length, 2);
-      assert.isEmpty(buckets.buckets[1]);
+      assert.equal(buckets.length, 2);
+      assert.isEmpty(buckets[1].anchors);
       // All anchors are in a single bucket
-      assert.deepEqual(buckets.buckets[0], anchors);
+      assert.deepEqual(buckets[0].anchors, anchors);
       // Because this is the first bucket, it will be aligned top
-      assert.equal(buckets.index[0], 175);
+      assert.equal(buckets[0].position, 175);
     });
 
     it('should put anchors that are not near each other in separate buckets', () => {
@@ -261,16 +260,16 @@ describe('annotator/util/buckets', () => {
         position += 100;
       });
       const buckets = buildBuckets(points);
-      assert.equal(buckets.buckets.length, 8);
+      assert.equal(buckets.length, 8);
       // Legacy of previous implementation, shrug?
-      assert.isEmpty(buckets.buckets[1]);
-      assert.isEmpty(buckets.buckets[3]);
-      assert.isEmpty(buckets.buckets[5]);
-      assert.isEmpty(buckets.buckets[7]);
-      assert.deepEqual(buckets.buckets[0], [anchors[0]]);
-      assert.deepEqual(buckets.buckets[2], [anchors[1]]);
-      assert.deepEqual(buckets.buckets[4], [anchors[2]]);
-      assert.deepEqual(buckets.buckets[6], [anchors[3]]);
+      assert.isEmpty(buckets[1].anchors);
+      assert.isEmpty(buckets[3].anchors);
+      assert.isEmpty(buckets[5].anchors);
+      assert.isEmpty(buckets[7].anchors);
+      assert.deepEqual(buckets[0].anchors, [anchors[0]]);
+      assert.deepEqual(buckets[2].anchors, [anchors[1]]);
+      assert.deepEqual(buckets[4].anchors, [anchors[2]]);
+      assert.deepEqual(buckets[6].anchors, [anchors[3]]);
     });
   });
 });


### PR DESCRIPTION
This PR does these things:

* Removes the `jQuery` dependency from `BucketBar` and reimplements as vanilla DOM JS
* Refactors the `buckets.buildBuckets` util function to return an array of objects instead of two Arrays (made refactoring `BucketBar` in this area more straightforward)
* Brings test coverage for `BucketBar` to 100% (whew)
* Adds `typedef`s, comments, refactors for clarity where possible

There's still work to do here, but, whew.

Fixes https://github.com/hypothesis/client/issues/2616

I'm going to put this in `draft` because there are a few things I'd like to get scrutiny on before merging.