### PR TITLE
Rewrite bucket-generating logic

### DIFF
--- a/src/styles/annotator/bucket-bar.scss
+++ b/src/styles/annotator/bucket-bar.scss
@@ -28,13 +28,14 @@
     right: 0;
     pointer-events: all;
     position: absolute;
-    margin-top: -8px;
     line-height: 1;
     height: 16px;
     width: 26px;
     -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
     text-align: center;
     cursor: pointer;
+    // Vertically center the element, which is 16px high
+    margin-top: -8px;
 
     .label {
       @include reset.reset-box-model;
@@ -86,10 +87,18 @@
         border-right: solid transparent;
         margin-top: 0;
       }
+      & .label {
+        // Vertical alignment tweak to better center the label in the indicator
+        margin-top: -1px;
+      }
     }
 
     &.upper {
       border-radius: 2px 2px 4px 4px;
+      // Vertically center the element (which is 22px high) by adding a negative
+      // top margin in conjunction with an inline style `top` position (set
+      // in code)
+      margin-top: -11px;
 
       &:before,
       &:after {
@@ -111,6 +120,7 @@
     }
 
     &.lower {
+      margin-top: 0;
       border-radius: 4px 4px 2px 2px;
 
       &:before,


### PR DESCRIPTION
This ~~draft PR demonstrates an approach to refactoring~~ reimplements the logic used to compute and position anchor buckets in the bucket bar. ~~It does not yet have tests.~~

It is my hope that this re-implementation will be more comprehensible to future devs, provide a clearer separation of concerns and more clearly express the desired outcome of the bucketing logic.

It:

* Removes the weird empty extra buckets
* Redefines types in `buckets` util in a way that feels more intuitive
* Moves some positioning "logic" into CSS
* Removes the need for `BucketBar` to maintain (and export) constants
* Fixes [this bug](https://github.com/hypothesis/client/issues/397)

The resulting buckets are very close to what the previous algorithm created, minus the knack for sometimes putting anchors into multiple buckets (bug #397). 

There's probably one more follow-up pass to rectify a few lingering...interesting features of the code...but this is feeling better...

Fixes https://github.com/hypothesis/client/issues/2618
Fixes #397