### PR TITLE
Remove IE 11 workarounds or update comments for them

### DIFF
--- a/src/annotator/anchoring/text-position.js
+++ b/src/annotator/anchoring/text-position.js
@@ -26,11 +26,7 @@ export function toRange(root, start, end) {
   // although optional according to the spec.
   const nodeIter = root.ownerDocument.createNodeIterator(
     root,
-    NodeFilter.SHOW_TEXT,
-    null, // filter
-
-    // @ts-ignore - Ignored parameter required for IE 11
-    false // expandEntityReferences
+    NodeFilter.SHOW_TEXT
   );
 
   let startContainer;

--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -102,7 +102,7 @@ function drawHighlightsAbovePdfCanvas(highlightEl) {
       // @ts-ignore - `mixBlendMode` property is missing from type definitions.
       svgStyle.mixBlendMode = 'multiply';
     } else {
-      // For older browsers (IE 11, Edge < 79) we draw all the highlights as
+      // For older browsers (eg. Edge < 79) we draw all the highlights as
       // opaque and then make the entire highlight layer transparent. This means
       // that there is no visual indication of whether text has one or multiple
       // highlights, but it preserves readability.
@@ -232,7 +232,7 @@ export function highlightRange(normedRange, cssClass = 'hypothesis-highlight') {
 /**
  * Replace a child `node` with `replacements`.
  *
- * nb. This is like `ChildNode.replaceWith` but it works in IE 11.
+ * nb. This is like `ChildNode.replaceWith` but it works in older browsers.
  *
  * @param {ChildNode} node
  * @param {Node[]} replacements

--- a/src/annotator/range-util.js
+++ b/src/annotator/range-util.js
@@ -51,11 +51,7 @@ function forEachNodeInRange(range, callback) {
   // mandatory in IE although optional according to the spec.
   const nodeIter = /** @type {Document} */ (root.ownerDocument).createNodeIterator(
     root,
-    NodeFilter.SHOW_ALL,
-    null /* filter */,
-
-    // @ts-ignore - Deprecated last parameter. Required for IE 11.
-    false /* expandEntityReferences */
+    NodeFilter.SHOW_ALL
   );
 
   let currentNode;

--- a/src/boot/test/url-template-test.js
+++ b/src/boot/test/url-template-test.js
@@ -38,12 +38,11 @@ describe('processUrlTemplate', () => {
         .returns([{ src: 'http://test-host:3001/script.js' }]);
     });
 
-    it('falls back to using origin info from the last <script> tag in the document', () => {
-      const url = processUrlTemplate(
-        '{current_scheme}://{current_host}:2000/style.css',
-        fakeDocument
-      );
-      assert.equal(url, 'http://test-host:2000/style.css');
+    it('throws if script origin cannot be determined', () => {
+      assert.throws(() => {
+        const template = '{current_scheme}://{current_host}:2000/style.css';
+        processUrlTemplate(template, fakeDocument);
+      }, 'Could not process URL template because script origin is unknown');
     });
 
     it('does not try to determine the origin if there are no URL template params', () => {

--- a/src/boot/url-template.js
+++ b/src/boot/url-template.js
@@ -14,19 +14,12 @@ function extractOrigin(url) {
 }
 
 function currentScriptOrigin(document_ = document) {
-  try {
-    let scriptEl = /** @type {HTMLScriptElement} */ (document_.currentScript);
-
-    if (!scriptEl) {
-      // Fallback for IE 11.
-      const scripts = document_.querySelectorAll('script');
-      scriptEl = scripts[scripts.length - 1];
-    }
-
-    return extractOrigin(scriptEl.src);
-  } catch (err) {
+  const scriptEl = /** @type {HTMLScriptElement|null} */ (document_.currentScript);
+  if (!scriptEl) {
+    // Function was called outside of initial script execution.
     return null;
   }
+  return extractOrigin(scriptEl.src);
 }
 
 /**
@@ -52,6 +45,10 @@ export default function processUrlTemplate(url, document_ = document) {
   if (origin) {
     url = url.replace('{current_host}', origin.hostname);
     url = url.replace('{current_scheme}', origin.protocol);
+  } else {
+    throw new Error(
+      'Could not process URL template because script origin is unknown'
+    );
   }
 
   return url;

--- a/src/shared/browser-compatibility-utils.js
+++ b/src/shared/browser-compatibility-utils.js
@@ -1,10 +1,11 @@
 /**
  * Normalize a keyboard event key name.
  *
- * Several old browsers, such as IE11, use alternate key
- * names for keyboard events. If any abnormal keys are used,
- * this method returns the normalized name so our UI
- * components don't require a special case.
+ * Some old Microsoft browsers, such as IE 11 and Edge Legacy [1], use non-standard
+ * names for some keys. If any abnormal keys are used, this method returns the
+ * normalized name so our UI components don't require a special case.
+ *
+ * [1] https://caniuse.com/keyboardevent-key
  *
  * @param {string} key - The keyboard event `key` name
  * @return {string} - Normalized `key` name

--- a/src/shared/polyfills/index.js
+++ b/src/shared/polyfills/index.js
@@ -58,11 +58,9 @@ const needsPolyfill = {
   },
 
   es2018: () => {
-    if (!window.Promise) {
-      // IE11 does not have a Promise object.
-      return true;
-    }
-    return !hasMethods(Promise.prototype, 'finally');
+    return (
+      typeof Promise !== 'function' || !hasMethods(Promise.prototype, 'finally')
+    );
   },
 
   // Test for a fully-working URL constructor.

--- a/src/shared/test/user-agent-test.js
+++ b/src/shared/test/user-agent-test.js
@@ -1,22 +1,6 @@
-import { isIE11, isMacOS } from '../user-agent';
+import { isMacOS } from '../user-agent';
 
 describe('shared/user-agent', () => {
-  describe('isIE11', () => {
-    it('returns true when the user agent is IE 11', () => {
-      assert.isTrue(
-        isIE11('Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko')
-      );
-    });
-
-    it('returns false when the user agent is not IE 11', () => {
-      assert.isFalse(
-        isIE11(
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.92 Safari/537.36 Edg/80.0.361.109'
-        )
-      );
-    });
-  });
-
   describe('isMacOS', () => {
     it('returns true when the user agent is a Mac', () => {
       assert.isTrue(

--- a/src/shared/user-agent.js
+++ b/src/shared/user-agent.js
@@ -3,15 +3,6 @@
  */
 
 /**
- * Returns true when the browser is IE11.
- *
- * @param _userAgent {string} - Test seam
- */
-export const isIE11 = (_userAgent = window.navigator.userAgent) => {
-  return _userAgent.indexOf('Trident/7.0') >= 0;
-};
-
-/**
  * Returns true when the OS is Mac OS.
  *
  * @param _userAgent {string} - Test seam

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -3,7 +3,6 @@ import { useEffect, useMemo } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import bridgeEvents from '../../shared/bridge-events';
-import { isIE11 } from '../../shared/user-agent';
 import serviceConfig from '../service-config';
 import useStore from '../store/use-store';
 import uiConstants from '../ui-constants';
@@ -107,20 +106,6 @@ function HypothesisApp({
       openSidebarPanel(uiConstants.PANEL_HELP);
     }
   }, [isSidebar, profile, openSidebarPanel, settings]);
-
-  // Show a deprecation warning if current browser is IE11
-  useEffect(() => {
-    if (isIE11()) {
-      toastMessenger.notice(
-        'Hypothesis is ending support for this browser (Internet Explorer 11) on July 1, 2020.',
-        {
-          autoDismiss: false,
-          moreInfoURL:
-            'https://web.hypothes.is/help/which-browsers-are-supported-by-hypothesis/',
-        }
-      );
-    }
-  }, [toastMessenger]);
 
   const login = async () => {
     if (serviceConfig(settings)) {

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -8,7 +8,6 @@ import HypothesisApp, { $imports } from '../hypothesis-app';
 
 describe('HypothesisApp', () => {
   let fakeApplyTheme;
-  let fakeUserAgent = null;
   let fakeStore = null;
   let fakeAuth = null;
   let fakeBridge = null;
@@ -74,10 +73,6 @@ describe('HypothesisApp', () => {
       call: sinon.stub(),
     };
 
-    fakeUserAgent = {
-      isIE11: sinon.stub().returns(false),
-    };
-
     fakeToastMessenger = {
       error: sinon.stub(),
       notice: sinon.stub(),
@@ -85,7 +80,6 @@ describe('HypothesisApp', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../../shared/user-agent': fakeUserAgent,
       '../service-config': fakeServiceConfig,
       '../store/use-store': callback => callback(fakeStore),
       '../util/session': {
@@ -144,24 +138,6 @@ describe('HypothesisApp', () => {
       fakeShouldAutoDisplayTutorial.returns(false);
       createComponent();
       assert.notCalled(fakeStore.openSidebarPanel);
-    });
-  });
-
-  describe('toast message warning of IE11 deprecation', () => {
-    it('shows notice if user agent is IE11', () => {
-      fakeUserAgent.isIE11.returns(true);
-
-      createComponent();
-
-      assert.called(fakeToastMessenger.notice);
-    });
-
-    it('does not show notice if another user agent', () => {
-      fakeUserAgent.isIE11.returns(false);
-
-      createComponent();
-
-      assert.notCalled(fakeToastMessenger.notice);
     });
   });
 

--- a/src/sidebar/util/random.js
+++ b/src/sidebar/util/random.js
@@ -10,9 +10,7 @@ function byteToHex(val) {
  * @return {string}
  */
 export function generateHexString(len) {
-  // @ts-ignore - TS doesn't know about `msCrypto`.
-  const crypto = window.crypto || window.msCrypto; /* IE 11 */
   const bytes = new Uint8Array(len / 2);
-  crypto.getRandomValues(bytes);
+  window.crypto.getRandomValues(bytes);
   return Array.from(bytes).map(byteToHex).join('');
 }

--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -18,8 +18,7 @@ const maxEventsToSendPerSession = 5;
  */
 function currentScriptOrigin() {
   try {
-    // nb. IE 11 does not support `document.currentScript` and this property
-    // is only available while a `<script>` tag is initially being executed.
+    // This property is only available while a `<script>` tag is initially being executed.
     const script = /** @type {HTMLScriptElement} */ (document.currentScript);
     const scriptUrl = new URL(script.src);
     return scriptUrl.origin;


### PR DESCRIPTION
This PR removes workarounds that were only needed for IE 11 and updates comments for logic was was marked as being for IE 11 only but is still needed in other browsers or situations.

Part of https://github.com/hypothesis/client/issues/2043.

----

**TODO**

- [x] Re-test in Edge 17 and Safari 10 and make sure they still work
- [x] Make sure that startup still fails gracefully in IE 11