### PR TITLE
Update Babel compilation settings to target newer browsers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,14 +4,17 @@
       "pragma": "createElement"
     }],
     ["@babel/preset-env", {
+       "bugfixes": true,
        "targets": {
-         "browsers": ["> 0.3%"]
+         "chrome": "55",
+         "edge": "17",
+         "firefox": "53",
+         "safari": "10.1",
       }
     }]
   ],
   "plugins": [
-    "angularjs-annotate",
-    "transform-async-to-promises"
+    "angularjs-annotate"
   ],
   "ignore": ["**/vendor/*"],
   "env": {

--- a/src/annotator/plugin/test/pdf-test.js
+++ b/src/annotator/plugin/test/pdf-test.js
@@ -45,7 +45,7 @@ describe('annotator/plugin/pdf', () => {
     };
 
     $imports.$mock({
-      './pdf-metadata': () => fakePDFMetadata,
+      './pdf-metadata': sinon.stub().returns(fakePDFMetadata),
       '../anchoring/pdf': fakePdfAnchoring,
 
       // Disable debouncing of updates.

--- a/src/boot/.babelrc
+++ b/src/boot/.babelrc
@@ -1,0 +1,15 @@
+{
+  "presets": [
+    ["@babel/preset-env", {
+       "targets": {
+         "chrome": "40",
+         "firefox": "38",
+         "safari": "9",
+         "ie": "11"
+      }
+    }]
+  ],
+  "plugins": [
+    "transform-async-to-promises"
+  ]
+}

--- a/src/shared/test/injector-test.js
+++ b/src/shared/test/injector-test.js
@@ -66,7 +66,7 @@ describe('Injector', () => {
 
       container.register('foo', fooFactory);
       container.register('bar', barFactory);
-      container.register('baz', bazFactory);
+      container.register('baz', { factory: bazFactory });
 
       const baz = container.get('baz');
       assert.equal(baz.foo, foo);

--- a/src/sidebar/services/test/oauth-auth-test.js
+++ b/src/sidebar/services/test/oauth-auth-test.js
@@ -78,7 +78,7 @@ describe('sidebar/services/oauth-auth', function () {
       authorize: sinon.stub().returns(Promise.resolve(null)),
     };
 
-    FakeOAuthClient = config => {
+    FakeOAuthClient = function (config) {
       fakeClient.config = config;
       return fakeClient;
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -154,7 +154,7 @@
   dependencies:
     "@babel/types" "^7.12.1"
 
-"@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1":
+"@babel/helper-module-imports@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz#1644c01591a15a2f084dd6d092d9430eb1d1216c"
   integrity sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/2658**~~

Update Babel compilation targets to match the browsers we currently support,
rather than transpiling everything down to ES5.

This reduces the size of our JS bundles and improves performance by using native
implementations of ES2015+ language features. It should also avoid
occassional issues in development caused by interactions of Babel plugins that
compile native features to older syntax (eg. this happened a few times with `transform-async-to-promises`).

The client's boot script has a different configuration than the rest of the
client because it needs to be able to run in older browsers in order to show a
warning when the browser is not supported.

The production bundle size changes resulting from this are approximately:

Sidebar bundle: 398 KB => 329 KB (-17%)
Annotator bundle: 219 KB => 169 KB (-23%)

In the tests I had to fix a few cases where the `new` operator ended up being used with a value created by an arrow function. This works when the value is compiled into a function expression but not with a real/native arrow function.