### PR TITLE
Add type-validation module (step 1)

### DIFF
--- a/src/shared/test/type-validation-test.js
+++ b/src/shared/test/type-validation-test.js
@@ -1,0 +1,570 @@
+import validators from '../type-validation';
+
+describe('shared/type-validation', () => {
+  describe('isString', () => {
+    it('does not return an error if the value is a string', () => {
+      assert.equal(validators.isString('string'), true);
+    });
+
+    it('returns an error if the value is not a string', () => {
+      assert.equal(validators.isString(0), 'value is not a string');
+    });
+
+    it('does not return an error if the value is undefined', () => {
+      assert.equal(validators.isString(undefined), true);
+    });
+
+    context('with isRequired', () => {
+      it('does not return an error if the value is not undefined', () => {
+        assert.equal(validators.isString.isRequired('string'), true);
+      });
+
+      it('returns an error if the value is undefined', () => {
+        assert.equal(
+          validators.isString.isRequired(undefined),
+          'value is required but missing'
+        );
+      });
+    });
+
+    context('with onOne', () => {
+      it('does not return an error if the value is allowed', () => {
+        assert.equal(validators.isString.oneOf(['one', 'two'])('one'), true);
+      });
+
+      it('returns an error if the value is not a string', () => {
+        assert.equal(
+          validators.isString.oneOf(['one', 'two'])(0),
+          'value is not a string'
+        );
+      });
+
+      it('returns an error if the value is not allowed', () => {
+        assert.equal(
+          validators.isString.oneOf(['one', 'two'])('three'),
+          'value does not match accepted values: [one,two]'
+        );
+      });
+
+      it('can still be required', () => {
+        assert.equal(
+          validators.isString.oneOf(['one', 'two']).isRequired('one'),
+          true
+        );
+      });
+    });
+  });
+
+  describe('isBoolean', () => {
+    it('does not return an error if the value is a boolean', () => {
+      assert.equal(validators.isBoolean(false), true);
+    });
+
+    it('returns an error if the value is not a boolean', () => {
+      assert.equal(validators.isBoolean(0), 'value is not a boolean');
+    });
+
+    it('does not return an error if the value is undefined', () => {
+      assert.equal(validators.isBoolean(undefined), true);
+    });
+
+    context('with isRequired', () => {
+      it('does not return an error if the value is not undefined', () => {
+        assert.equal(validators.isBoolean.isRequired(false), true);
+      });
+
+      it('returns an error if the value is undefined', () => {
+        assert.equal(
+          validators.isBoolean.isRequired(undefined),
+          'value is required but missing'
+        );
+      });
+    });
+  });
+
+  describe('isNumeric', () => {
+    it('does not return an error if the value is a number', () => {
+      assert.equal(validators.isNumeric(1), true);
+    });
+
+    it('returns an error if the value is not a number', () => {
+      assert.equal(validators.isNumeric('1'), 'value is not a number');
+    });
+
+    it('does not return an error if the value is undefined', () => {
+      assert.equal(validators.isNumeric(undefined), true);
+    });
+
+    context('with isRequired', () => {
+      it('does not return an error if the value is not undefined', () => {
+        assert.equal(validators.isNumeric.isRequired(1), true);
+      });
+
+      it('returns an error if the value is undefined', () => {
+        assert.equal(
+          validators.isNumeric.isRequired(undefined),
+          'value is required but missing'
+        );
+      });
+    });
+
+    context('with limit', () => {
+      it('does not return an error if the value is inside a limit', () => {
+        assert.equal(validators.isNumeric.limit(0, 10)(5), true);
+      });
+
+      it('returns an error if the value is not a number', () => {
+        assert.equal(
+          validators.isNumeric.limit(0, 10)('1'),
+          'value is not a number'
+        );
+      });
+
+      it('returns an error if the value is above a limit', () => {
+        assert.equal(
+          validators.isNumeric.limit(0, 10)(11),
+          'value falls outside of range (0, 10)'
+        );
+      });
+
+      it('returns an error if the value is below a limit', () => {
+        assert.equal(
+          validators.isNumeric.limit(0, 10)(-1),
+          'value falls outside of range (0, 10)'
+        );
+      });
+
+      it('can still can required', () => {
+        assert.equal(validators.isNumeric.limit(0, 10).isRequired(5), true);
+      });
+    });
+  });
+
+  describe('isInteger', () => {
+    it('does not return an error if the value is an integer', () => {
+      assert.equal(validators.isInteger(1), true);
+    });
+
+    it('returns an error if the value is not a integer', () => {
+      assert.equal(validators.isInteger(1.5), 'value is not an integer');
+    });
+
+    it('does not return an error if the value is undefined', () => {
+      assert.equal(validators.isInteger(undefined), true);
+    });
+
+    context('with isRequired', () => {
+      it('does not return an error if the value is not undefined', () => {
+        assert.equal(validators.isInteger.isRequired(1), true);
+      });
+
+      it('returns an error if the value is undefined', () => {
+        assert.equal(
+          validators.isInteger.isRequired(undefined),
+          'value is required but missing'
+        );
+      });
+    });
+
+    context('with limit', () => {
+      it('does not return an error if the value is inside a limit', () => {
+        assert.equal(validators.isInteger.limit(0, 10)(5), true);
+      });
+
+      it('returns an error if the value is not an integer', () => {
+        assert.equal(
+          validators.isInteger.limit(0, 10)(5.5),
+          'value is not an integer'
+        );
+      });
+
+      it('returns an error if the value is above a limit', () => {
+        assert.equal(
+          validators.isInteger.limit(0, 10)(11),
+          'value falls outside of range (0, 10)'
+        );
+      });
+
+      it('returns an error if the value is below a limit', () => {
+        assert.equal(
+          validators.isInteger.limit(0, 10)(-1),
+          'value falls outside of range (0, 10)'
+        );
+      });
+
+      it('can still be required', () => {
+        assert.equal(validators.isInteger.limit(0, 10).isRequired(5), true);
+      });
+    });
+  });
+
+  describe('isFunction', () => {
+    it('does not return an error if the value is a function', () => {
+      assert.equal(
+        validators.isFunction(() => {}),
+        true
+      );
+    });
+
+    it('returns an error if the value is not a function', () => {
+      assert.equal(validators.isFunction(0), 'value is not a function');
+    });
+
+    it('does not return an error if the value is undefined', () => {
+      assert.equal(validators.isFunction(undefined), true);
+    });
+
+    context('with isRequired', () => {
+      it('does not return an error if the value is not undefined', () => {
+        assert.equal(
+          validators.isFunction.isRequired(() => {}),
+          true
+        );
+      });
+
+      it('returns an error if the value is undefined', () => {
+        assert.equal(
+          validators.isFunction.isRequired(undefined),
+          'value is required but missing'
+        );
+      });
+    });
+  });
+
+  describe('isArray', () => {
+    it('does not return an error if the value is an array', () => {
+      assert.equal(validators.isArray([]), true);
+    });
+
+    it('returns an error if the value is not an array', () => {
+      assert.equal(validators.isArray(0), 'value is not an array');
+    });
+
+    it('does not return an error if the value is undefined', () => {
+      assert.equal(validators.isArray(undefined), true);
+    });
+
+    context('with isRequired', () => {
+      it('does not return an error if the value is not undefined', () => {
+        assert.equal(validators.isArray.isRequired([]), true);
+      });
+
+      it('returns an error if the value is undefined', () => {
+        assert.equal(
+          validators.isArray.isRequired(undefined),
+          'value is required but missing'
+        );
+      });
+    });
+
+    context('with ofType', () => {
+      it('does not return an error if the array is of the specified type', () => {
+        assert.equal(
+          validators.isArray.ofType(validators.isNumeric)([1]),
+          true
+        );
+      });
+
+      it('does not return an error if the array is empty', () => {
+        assert.equal(validators.isArray.ofType(validators.isNumeric)([]), true);
+      });
+
+      it('returns an error if the value of the array is not of the specified type', () => {
+        assert.equal(
+          validators.isArray.ofType(validators.isNumeric)([false]),
+          'value is not a number'
+        );
+      });
+
+      it('returns an error if the value is not an array ', () => {
+        assert.equal(
+          validators.isArray.ofType(validators.isNumeric)(false),
+          'value is not an array'
+        );
+      });
+
+      it('can still be required', () => {
+        // Allow empty arrays even with ofType condition.
+        assert.equal(
+          validators.isArray.ofType(validators.isNumeric).isRequired([]),
+          true
+        );
+      });
+    });
+  });
+
+  describe('isObject', () => {
+    it('does not return an error if the value is an array', () => {
+      assert.equal(validators.isObject({}), true);
+    });
+
+    it('returns an error if the value is not an object', () => {
+      assert.equal(validators.isObject(0), 'value is not an object');
+      assert.equal(validators.isObject([]), 'value is not an object');
+      assert.equal(validators.isObject(null), 'value is not an object');
+    });
+
+    it('does not return an error if the value is undefined', () => {
+      assert.equal(validators.isObject(undefined), true);
+    });
+
+    context('with isRequired', () => {
+      it('does not return an error if the value is not undefined', () => {
+        assert.equal(validators.isObject.isRequired({}), true);
+      });
+
+      it('returns an error if the value is undefined', () => {
+        assert.equal(
+          validators.isArray.isRequired(undefined),
+          'value is required but missing'
+        );
+      });
+    });
+
+    context('with ofShape', () => {
+      const shape = {
+        a: validators.isBoolean,
+        b: {
+          c: validators.isString,
+          d: validators.isString.isRequired,
+        },
+      };
+
+      it('does not return an error if the shape matches the schema', () => {
+        const data = {
+          a: true,
+          b: {
+            c: 'string 1',
+            d: 'string 2',
+          },
+        };
+        assert.equal(validators.isObject.ofShape(shape)(data), true);
+      });
+
+      it('returns an error if the shape does not match the schema', () => {
+        const data = {
+          a: true,
+          b: {
+            c: true, // invalid type
+            // d is missing
+          },
+        };
+        assert.deepEqual(validators.isObject.ofShape(shape)(data), [
+          {
+            key: 'b.c',
+            error: 'value is not a string',
+          },
+          {
+            key: 'b.d',
+            error: 'value is required but missing',
+          },
+        ]);
+      });
+
+      it('returns an error if the value is not an object', () => {
+        assert.equal(
+          validators.isObject.ofShape(shape)(0),
+          'value is not an object'
+        );
+      });
+
+      it('can still be required', () => {
+        const data = {
+          a: true,
+          b: {
+            c: 'string 1',
+            d: 'string 2',
+          },
+        };
+        assert.equal(validators.isObject.ofShape(shape).isRequired(data), true);
+      });
+    });
+  });
+
+  describe('oneOfType', () => {
+    it('does not return an error if the value matches an allowed type', () => {
+      assert.equal(
+        validators.oneOfType([validators.isBoolean, validators.isString])(
+          'string'
+        ),
+        true
+      );
+    });
+
+    it('returns an error if the value does not match an allowed type', () => {
+      assert.equal(
+        validators.oneOfType([validators.isBoolean, validators.isString])(1),
+        'value failed to match one of the the allowed types'
+      );
+    });
+
+    it('does not return an error if the value is undefined', () => {
+      assert.equal(
+        validators.oneOfType([validators.isBoolean, validators.isString])(
+          undefined
+        ),
+        true
+      );
+    });
+
+    context('with isRequired', () => {
+      it('does not return an error if the value is not undefined', () => {
+        assert.equal(
+          validators
+            .oneOfType([validators.isBoolean, validators.isString])
+            .isRequired('string'),
+          true
+        );
+      });
+
+      it('returns an error if the value is undefined', () => {
+        assert.equal(
+          validators
+            .oneOfType([validators.isBoolean, validators.isString])
+            .isRequired(undefined),
+          'value is required but missing'
+        );
+      });
+    });
+  });
+
+  describe('validateData', () => {
+    [
+      {
+        data: {},
+        result: true,
+      },
+      {
+        data: {
+          erroneous: 'ignored',
+        },
+        result: true,
+      },
+      {
+        data: { varA: true },
+        result: true,
+      },
+      {
+        data: {
+          varA: true,
+          b: {},
+        },
+        result: true,
+      },
+      {
+        data: {
+          varA: true,
+          b: {
+            varB: true,
+          },
+        },
+        result: true,
+      },
+      {
+        data: {
+          b: {
+            c: {
+              varC: true,
+            },
+          },
+        },
+        result: true,
+      },
+      {
+        data: {
+          b: {
+            c: {
+              varC: 'true',
+            },
+          },
+        },
+        result: [
+          {
+            error: 'value is not a boolean',
+            key: 'b.c.varC',
+          },
+        ],
+      },
+      {
+        data: {
+          varA: 'true',
+          b: {
+            varB: 'true',
+            c: {
+              varC: 'true',
+            },
+          },
+        },
+        result: [
+          {
+            error: 'value is not a boolean',
+            key: 'varA',
+          },
+          {
+            error: 'value is not a boolean',
+            key: 'b.varB',
+          },
+          {
+            error: 'value is not a boolean',
+            key: 'b.c.varC',
+          },
+        ],
+      },
+    ].forEach(test => {
+      it('validates the follow data', () => {
+        let schmea = {
+          varA: validators.isBoolean,
+          b: {
+            varB: validators.isBoolean,
+            c: {
+              varC: validators.isBoolean,
+            },
+          },
+        };
+        assert.deepEqual(
+          validators.validateData(schmea, test.data),
+          test.result
+        );
+      });
+
+      describe('isRequired', () => {
+        const schema = {
+          varA: validators.isBoolean,
+          b: {
+            varB: validators.isBoolean,
+            c: {
+              varC: validators.isBoolean.isRequired,
+            },
+          },
+        };
+
+        it('does not require a value if parent is undefined', () => {
+          const data = {
+            varA: true,
+            b: {
+              varB: true,
+              // c is missing
+            },
+          };
+          assert.deepEqual(validators.validateData(schema, data), true);
+        });
+
+        it('requires a value if its parent is defined', () => {
+          const data = {
+            varA: true,
+            b: {
+              varB: true,
+              c: {}, // varC is missing
+            },
+          };
+          assert.deepEqual(validators.validateData(schema, data), [
+            {
+              error: 'value is required but missing',
+              key: 'b.c.varC',
+            },
+          ]);
+        });
+      });
+    });
+  });
+});

--- a/src/shared/type-validation.js
+++ b/src/shared/type-validation.js
@@ -1,0 +1,322 @@
+/**
+ * @typedef {(any)=>any} ValidatorFunction
+ */
+
+/**
+ * @typedef ValidatorProperties
+ * @prop {(any)=>any} [isRequired]
+ * @prop {(any)=>any} [oneOf]
+ * @prop {(any)=>any} [ofType]
+ */
+
+/**
+ * @typedef {ValidatorFunction & ValidatorProperties} Validator
+ */
+
+/**
+ * @typedef ValidationError
+ * @prop {string} key
+ * @prop {string} error
+ */
+
+/**
+ * Validate the following `data` against the following `schema`. Returns true
+ * if the data is valid, otherwise returns an array of ValidationErrors representing
+ * error messages pertaining to the data.
+ *
+ * Note: Erroneous data values not part of the provided schema are ignored, but a
+ * future improvement could be to also check for such values and produce warnings.
+ *
+ * example:
+ *
+ * const schema = {
+ *   a: validation.isString,
+ *   b: validation.isString.isRequired,
+ *   c: {
+ *       d: validation.isInteger,
+ *       e: validation.isArray.ofType(validation.isInteger).isRequired,
+ *       f: validation.oneOf([
+ *            validation.isFunction,
+ *            validation.isString,
+ *          ]).isRequired
+ *   }
+ * }
+ *
+ * let result = validateData(schema, sampleData);
+ *
+ * @param {Object} schema
+ * @param {Object} data
+ * @param {string} [prefix]
+ * @return {true|ValidationError[]}
+ */
+function validateData(schema, data, prefix = '') {
+  const results = [];
+  Object.keys(schema).forEach(key => {
+    const schemaValue = schema[key];
+    const dataValue = data ? data[key] : undefined;
+    const newPrefix = prefix ? `${prefix}.${key}` : key;
+
+    if (typeof schemaValue === 'object') {
+      if (dataValue !== undefined) {
+        // only follow this branch if there is matching data
+        let result = validateData(schemaValue, dataValue, newPrefix);
+        if (result !== true) {
+          results.push(...result);
+        }
+      }
+    } else {
+      const result = schemaValue(dataValue);
+      if (result !== true) {
+        results.push({
+          key: newPrefix,
+          error: result,
+        });
+      }
+    }
+  });
+  return results.length ? results : true;
+}
+
+/**
+ * @type {Validator} shim
+ */
+function baseShim(shim) {
+  return value => {
+    if (value === undefined) {
+      return true;
+    } else {
+      return shim(value);
+    }
+  };
+}
+
+/**
+ * @type {Validator} shim
+ */
+function addRequiredCondition(shim) {
+  shim.isRequired = value => {
+    if (value === undefined) {
+      return 'value is required but missing';
+    }
+    return shim(value);
+  };
+}
+
+/**
+ * @param {Validator[]} types
+ */
+function oneOfTypeShim(types) {
+  const shim = baseShim(value => {
+    for (let i = 0; i < types.length; i++) {
+      if (types[i](value) === true) {
+        return true;
+      }
+    }
+    return 'value failed to match one of the the allowed types';
+  });
+  addRequiredCondition(shim);
+  return shim;
+}
+
+/**
+ * @param {any} value
+ */
+function isStringShim(value) {
+  return baseShim(value => {
+    if (typeof value === 'string') {
+      return true;
+    }
+    return 'value is not a string';
+  })(value);
+}
+
+/**
+ * @type {(list: any[]) => Validator}
+ */
+isStringShim.oneOf = list => {
+  const shim = baseShim(value => {
+    const isString = isStringShim(value);
+    if (isString === true) {
+      if (list.indexOf(value) >= 0) {
+        return true;
+      }
+      return `value does not match accepted values: [${list}]`;
+    }
+    return isString;
+  });
+  addRequiredCondition(shim);
+  return shim;
+};
+
+addRequiredCondition(isStringShim);
+
+/**
+ * @param {any} value
+ */
+const isBooleanShim = baseShim(value => {
+  if (typeof value === 'boolean') {
+    return true;
+  }
+  return 'value is not a boolean';
+});
+
+addRequiredCondition(isBooleanShim);
+
+/**
+ * @param {any} value
+ */
+function isNumericShim(value) {
+  return baseShim(value => {
+    if (typeof value === 'number') {
+      return true;
+    }
+    return 'value is not a number';
+  })(value);
+}
+
+/**
+ * @type {(lower: number ,upper: number) => Validator}
+ */
+isNumericShim.limit = (lower, upper) => {
+  const shim = baseShim(value => {
+    const isNumeric = isNumericShim(value);
+    if (isNumeric === true) {
+      if (value >= lower && value <= upper) {
+        return true;
+      } else {
+        return `value falls outside of range (${lower}, ${upper})`;
+      }
+    }
+    return isNumeric;
+  });
+  addRequiredCondition(shim);
+  return shim;
+};
+
+addRequiredCondition(isNumericShim);
+
+/**
+ * @param {any} value
+ */
+function isIntegerShim(value) {
+  return baseShim(value => {
+    if (Number.isInteger(value)) {
+      return true;
+    }
+    return 'value is not an integer';
+  })(value);
+}
+
+/**
+ * @type {(lower: number ,upper: number) => Validator}
+ */
+isIntegerShim.limit = (lower, upper) => {
+  const shim = baseShim(value => {
+    const isInteger = isIntegerShim(value);
+    if (isInteger === true) {
+      if (value >= lower && value <= upper) {
+        return true;
+      } else {
+        return `value falls outside of range (${lower}, ${upper})`;
+      }
+    }
+    return isInteger;
+  });
+  addRequiredCondition(shim);
+  return shim;
+};
+
+addRequiredCondition(isIntegerShim);
+
+/**
+ * @param {any} value
+ */
+const isFunctionShim = baseShim(value => {
+  if (typeof value === 'function') {
+    return true;
+  }
+  return 'value is not a function';
+});
+
+addRequiredCondition(isFunctionShim);
+
+/**
+ * @param {any} value
+ */
+function isArrayShim(value) {
+  return baseShim(value => {
+    if (Array.isArray(value)) {
+      return true;
+    }
+    return 'value is not an array';
+  })(value);
+}
+
+/**
+ * Restrict the array to a particular type.
+ *  - Only the first element in the array is checked.
+ *  - An empty array is still valid with this condition.
+ * @type {(type: Validator) => Validator}
+ */
+isArrayShim.ofType = type => {
+  const shim = baseShim(value => {
+    const isArray = isArrayShim(value);
+    if (isArray === true) {
+      if (value.length) {
+        return type(value[0]); // just check the first slot
+      }
+    }
+    return isArray;
+  });
+  addRequiredCondition(shim);
+  return shim;
+};
+
+addRequiredCondition(isArrayShim);
+
+/**
+ * @param {any} value
+ */
+function isObjectShim(value) {
+  return baseShim(value => {
+    // ensure null and array types are rejected
+    if (value && value.constructor === {}.constructor) {
+      return true;
+    }
+    return 'value is not an object';
+  })(value);
+}
+
+/**
+ * @type {(shape: Object) => Validator}
+ */
+isObjectShim.ofShape = shape => {
+  const shim = baseShim(value => {
+    const isObject = isObjectShim(value);
+    if (isObject === true) {
+      return validateData(shape, value);
+    }
+    return isObject;
+  });
+  addRequiredCondition(shim);
+  return shim;
+};
+
+addRequiredCondition(isObjectShim);
+
+const validators = {
+  // validators
+  isString: isStringShim,
+  isBoolean: isBooleanShim,
+  isNumeric: isNumericShim,
+  isInteger: isIntegerShim,
+  isFunction: isFunctionShim,
+  isArray: isArrayShim,
+  isObject: isObjectShim,
+  oneOfType: oneOfTypeShim,
+
+  // validation runner
+  validateData: validateData,
+};
+
+export default validators;


### PR DESCRIPTION
May be used to validate incoming config for the sidebar and annotator, but could also be used for any other JSON like object.

------

Related to feedback from this PR: https://github.com/hypothesis/client/pull/2528
And this slack thread: https://hypothes-is.slack.com/archives/C1M8NH76X/p1602204681233500

This is the first step for adding a robust (non-third party) validation schema to handle our incoming config. This could also be used for any generic config-like JSON object. 

This validation only gathers errors is discovers and returns them in an array of error messages. Each error message has a human readable error text and a dot-path key name to indicate where the error in the json object was discovered. This could also be used to expunge data from a copied config, for example, if we wanted to omit invalid data values down stream. -- That bit of logic is NOT included in this diff, nor is printing the validation errors to the console. A proposed model for this would be as such:

https://hypothes-is.slack.com/archives/C1M8NH76X/p1602204681233500
![config with validation](https://user-images.githubusercontent.com/3939074/96653176-59519500-12ed-11eb-932f-4bffd46c7675.png)

As an example, here is a subset of the config validation schema we could use (note this is not a complete config)

```
showHighlights: validation.isBoolean,
theme: validation.isString.oneOf(['clean', 'classic']),
services: validation.isArray.ofType(validation.isObject.ofShape(
  {
    apiUrl: validation.isString,
    authority: validation.isString,
    grantToken: validation.isString,
    icon: validation.isString,
    groups: validation.isArray.ofType(validation.isString.isRequired)
  }).isRequired
),
groups: validators.oneOfType([
  validators.isString.oneOf(['$rpc:requestGroups']),
  validators.isArray.ofType(validators.isString.isRequired)
]),
onLoginRequest: validators.isFunction,
onLogoutRequest:  validators.isFunction,
branding: {
  appBackgroundColor: validation.isString,
  ctaBackgroundColor: validation.isString,
  ctaTextColor: validation.isString,
  selectionFontFamily: validation.isString,
},
focus: {
  user: {
    username: validation.isString.isRequired,
    userid: validation.isString.isRequired,
    displayName: validation.isString
  }
}
```

This is still imperfect because we don't have a way to say `username` OR `userid` is required, but not both. But apart from that, this gets us very close to a strict validator. Some improvements could be further made by allowing regex strings as part of the `isString.oneOf([...])`. That would help get correct formatting for things like `ctaTextColor` or urls. Another point to consider is this does not allow or check for `null` types. I propose ignoring null is a simpler standard because I don't suspect we don't need a difference between a config value that is `null` or `undefined`. I would prefer to keep it simple.  I also did not add a custom validation handler (for something beyond normal types) and if we can get by w/o one, then that may be best. But it would be trivial to add at this juncture.






