### PR TITLE
Remove unused iframe attributes

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -76,12 +76,10 @@ function createSidebarIframe(config) {
   const sidebarAppSrc = config.sidebarAppUrl + '#' + configParam;
 
   const sidebarFrame = document.createElement('iframe');
-  sidebarFrame.setAttribute('name', 'hyp_sidebar_frame');
 
   // Enable media in annotations to be shown fullscreen
   sidebarFrame.setAttribute('allowfullscreen', '');
 
-  sidebarFrame.setAttribute('seamless', '');
   sidebarFrame.src = sidebarAppSrc;
   sidebarFrame.title = 'Hypothesis annotation viewer';
   sidebarFrame.className = 'h-sidebar-iframe';


### PR DESCRIPTION
 - Remove `seamless` attribute which has not been supported by major
   browsers for years [1]
 - Remove the `name="hyp_sidebar_frame"` attribute which is not
   referenced anywhere else in the code. I did find a couple of
   references to it in Google, but only in scripts written by Hypothesis
   team members which are not run regularly.

[1] https://caniuse.com/iframe-seamless