### PR TITLE
Enable terser workarounds for Safari 10

### DIFF
--- a/scripts/gulp/minify-stream.js
+++ b/scripts/gulp/minify-stream.js
@@ -31,7 +31,10 @@ function minifyStream() {
       const code = Buffer.concat(this.chunks).toString();
 
       // See https://github.com/terser/terser#minify-options-structure
-      const options = {};
+      const options = {
+        // See https://github.com/hypothesis/client/issues/2664.
+        safari10: true,
+      };
 
       // If the code we're minifying has a sourcemap then generate one for the
       // minified output, otherwise skip it.


### PR DESCRIPTION
This fixes an error in production builds of the client in Safari 10:

```
SyntaxError: Cannot declare a let variable twice: 't'.
```

The bundle is the same size with this flag enabled. From a quick look in the terser source code it seems that the effect of this is to prevent variables from being shadowed in certain situations when that would normally be OK (more details here: https://bugs.webkit.org/show_bug.cgi?id=171041).

Fixes #2664

-----

I tested this locally with Safari 10 on macOS 10.12 by making `make dev` build a production build of the client using:

```diff
diff --git a/Makefile b/Makefile
index 2f7b4f97a..0ae45efa9 100644
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 
 .PHONY: dev
 dev: build/manifest.json
-	node_modules/.bin/gulp watch
+	env NODE_ENV=production node_modules/.bin/gulp watch
 
 .PHONY: test
 test: node_modules/.uptodate
```

And then accessing the development server at http://localhost:3000 using Safari 10 via Sauce Labs.