### PR TITLE
Remove obsolete workaround for a Babel plugin conflict

### DIFF
--- a/src/sidebar/services/oauth-auth.js
+++ b/src/sidebar/services/oauth-auth.js
@@ -24,6 +24,8 @@ import { resolve } from '../util/url';
  *
  * Interaction with OAuth endpoints in the annotation service is delegated to
  * the `OAuthClient` class.
+ *
+ * @ngInject
  */
 export default function auth(
   $window,
@@ -307,14 +309,3 @@ export default function auth(
     tokenGetter,
   });
 }
-
-// `$inject` is added manually rather than using `@ngInject` to work around
-// a conflict between the transform-async-to-promises and angularjs-annotate
-// Babel plugins.
-auth.$inject = [
-  '$window',
-  'apiRoutes',
-  'localStorage',
-  'settings',
-  'toastMessenger',
-];


### PR DESCRIPTION
Remove a workaround in `oauth-auth.js` associated with the transform-async-to-promises Babel plugin that is no longer needed following https://github.com/hypothesis/client/pull/2659.

The plugin itself is still needed because it is used when building the boot script, although we could just ban use of async/await in that module instead.