### PR TITLE
Remove polyfills for features supported by all target browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "gulp-rename": "^2.0.0",
     "gulp-replace": "^1.0.0",
     "hammerjs": "^2.0.4",
-    "js-polyfills": "^0.1.16",
     "karma": "^5.0.1",
     "karma-browserify": "^7.0.0",
     "karma-chai": "^0.1.0",
@@ -90,10 +89,8 @@
     "through2": "^4.0.1",
     "tiny-emitter": "^2.0.2",
     "typescript": "^4.0.2",
-    "unorm": "^1.3.3",
     "vinyl": "^2.2.0",
     "watchify": "^3.7.0",
-    "whatwg-fetch": "^3.0.0",
     "wrap-text": "^1.0.7",
     "zen-observable": "^0.3.0"
   },

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -10,9 +10,7 @@ const commonPolyfills = [
   'es2017',
   'es2018',
 
-  // DOM APIs. These may rely on certain ES APIs so they should be loaded after
-  // the above polyfills.
-  'url',
+  // Any other polyfills which may rely on certain ES APIs should be listed here.
 ];
 
 /**
@@ -127,11 +125,7 @@ function bootHypothesisClient(doc, config) {
  * @param {Config} config
  */
 function bootSidebarApp(doc, config) {
-  const polyfills = polyfillBundles([
-    ...commonPolyfills,
-    'string.prototype.normalize',
-    'fetch',
-  ]);
+  const polyfills = polyfillBundles(commonPolyfills);
 
   injectAssets(doc, config, [
     ...polyfills,

--- a/src/boot/polyfills/fetch.js
+++ b/src/boot/polyfills/fetch.js
@@ -1,1 +1,0 @@
-import 'whatwg-fetch';

--- a/src/boot/polyfills/index.js
+++ b/src/boot/polyfills/index.js
@@ -62,32 +62,6 @@ const needsPolyfill = {
       typeof Promise !== 'function' || !hasMethods(Promise.prototype, 'finally')
     );
   },
-
-  // Test for a fully-working URL constructor.
-  url: () => {
-    try {
-      // Some browsers do not have a URL constructor at all.
-      const url = new window.URL('https://hypothes.is');
-
-      // Other browsers have a broken URL constructor.
-      if (url.hostname !== 'hypothes.is') {
-        throw new Error('Broken URL constructor');
-      }
-      return false;
-    } catch (e) {
-      return true;
-    }
-  },
-
-  // Test for Unicode normalization. This depends on a large polyfill so it
-  // is separated out into its own bundle.
-  'string.prototype.normalize': () => {
-    return !hasMethods(String.prototype, 'normalize');
-  },
-
-  fetch: () => {
-    return typeof window.fetch !== 'function';
-  },
 };
 
 /**

--- a/src/boot/polyfills/string.prototype.normalize.js
+++ b/src/boot/polyfills/string.prototype.normalize.js
@@ -1,1 +1,0 @@
-import 'unorm';

--- a/src/boot/polyfills/test/index-test.js
+++ b/src/boot/polyfills/test/index-test.js
@@ -44,24 +44,6 @@ describe('boot/polyfills/index', () => {
         set: 'es2018',
         providesMethod: [window, 'Promise'],
       },
-      {
-        set: 'string.prototype.normalize',
-        providesMethod: [String.prototype, 'normalize'],
-      },
-      {
-        // Missing URL constructor.
-        set: 'url',
-        providesMethod: [window, 'URL'],
-      },
-      {
-        // Broken URL constructor.
-        set: 'url',
-        providesMethod: [window, 'URL', () => {}],
-      },
-      {
-        set: 'fetch',
-        providesMethod: [window, 'fetch'],
-      },
     ].forEach(({ set, providesMethod }) => {
       it(`includes "${set}" if required`, () => {
         const [obj, method, replacement] = providesMethod;

--- a/src/boot/polyfills/url.js
+++ b/src/boot/polyfills/url.js
@@ -1,1 +1,0 @@
-import 'js-polyfills/url';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4748,11 +4748,6 @@ jmespath@0.15.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
-js-polyfills@^0.1.16:
-  version "0.1.43"
-  resolved "https://registry.yarnpkg.com/js-polyfills/-/js-polyfills-0.1.43.tgz#6ec32030b05dc71a4257a950d1c4eaf301bb8035"
-  integrity sha512-wWCJcw7uMA12uk7qcqZlIQy9nj+Evh1wVUmn5MOlJ7GPC8HT5PLjB9Uiqjw9ldAbbOuNOWJ6ENb7NwU6qqf48g==
-
 js-string-escape@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
@@ -7727,11 +7722,6 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
-unorm@^1.3.3:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.6.0.tgz#029b289661fba714f1a9af439eb51d9b16c205af"
-  integrity sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==
-
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -7932,11 +7922,6 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
-
-whatwg-fetch@^3.0.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
-  integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==
 
 whatwg-url@^6.5.0:
   version "6.5.0"


### PR DESCRIPTION
Remove polyfills for features that are supported by all of our target
browsers:

 - `fetch` (https://caniuse.com/fetch)
 - The `URL` constructor (https://caniuse.com/url)
 - `String.prototype.normalize` (https://caniuse.com/mdn-javascript_builtins_string_normalize)