### PR TITLE
Attempt to fix prod deploy failure after concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,6 +155,8 @@ stage('Publish') {
     node {
         checkout scm
 
+        workspace = pwd()
+
         echo "Publishing ${pkgName} v${newPkgVersion} from ${releaseFromBranch} branch."
         postSlack 'good', "Starting prod deployment of v${newPkgVersion} (${lastCommitHash})"
 


### PR DESCRIPTION
Attempt to fix a prod deployment failure when initial build step happens
in a different workspace directory than the prod deploy step.

This typically happens when two or more builds are in progress concurrently
and then all of the earlier builds finish before the last one is
deployed. In this scenario the initial build step happens in a directory
such as `master@2` whereas the prod deploy step will happen in a
directory named `master`. The prod deploy step assumed that the
workspace was still `master@2` and git commands would fail because the
directory no longer existed.