### PR TITLE
Fail more gracefully in unsupported versions of Edge Legacy

### DIFF
--- a/src/boot/browser-check.js
+++ b/src/boot/browser-check.js
@@ -17,6 +17,7 @@ export function isBrowserSupported() {
     // DOM API checks for frequently-used APIs.
     () => new URL(document.location.href), // URL constructor.
     () => new Request('https://hypothes.is'), // Part of the `fetch` API.
+    () => document.body.prepend.name, // Element.prepend() method.
 
     // DOM API checks for less frequently-used APIs.
     // These are less likely to have been polyfilled by the host page.


### PR DESCRIPTION
Add a test for the [`Element.prepend()` method](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/prepend) so that startup fails more
gracefully in older, unsupported versions of Edge Legacy (<= 16). This
API was chosen as a representative test because it's Chrome/Edge Legacy
support closely matches our minimum versions.

The same change was made for the LMS app in https://github.com/hypothesis/lms/pull/2209.