### PR TITLE
Refactor buckets to add a11y, convert to preact

### DIFF
--- a/src/annotator/components/buckets.js
+++ b/src/annotator/components/buckets.js
@@ -1,0 +1,140 @@
+import { createElement } from 'preact';
+import classnames from 'classnames';
+import propTypes from 'prop-types';
+import scrollIntoView from 'scroll-into-view';
+
+import { setHighlightsFocused } from '../highlighter';
+import { findClosestOffscreenAnchor } from '../util/buckets';
+
+/**
+ * @typedef {import('../../types/annotator').AnnotationData} AnnotationData
+ * @typedef {import('../util/buckets').Bucket} Bucket
+ */
+
+/**
+ * A left-pointing indicator button that, when hovered or clicked, highlights
+ * or selects associated annotations.
+ *
+ * @param {Object} props
+ *  @param {Bucket} props.bucket
+ *  @param {(annotations: AnnotationData[], toggle: boolean) => any} props.onSelectAnnotations
+ */
+function BucketButton({ bucket, onSelectAnnotations }) {
+  const annotations = bucket.anchors.map(anchor => anchor.annotation);
+  const buttonTitle = `Select nearby annotations (${bucket.anchors.length})`;
+
+  function selectAnnotations(event) {
+    event.stopPropagation();
+    onSelectAnnotations(annotations, event.metaKey || event.ctrlKey);
+  }
+
+  function setFocus(focusState) {
+    bucket.anchors.forEach(anchor => {
+      setHighlightsFocused(anchor.highlights || [], focusState);
+    });
+  }
+
+  return (
+    <button
+      className="bucket-button bucket-button--left"
+      onClick={event => selectAnnotations(event)}
+      onMouseMove={() => setFocus(true)}
+      onMouseOut={() => setFocus(false)}
+      onBlur={() => setFocus(false)}
+      title={buttonTitle}
+      aria-label={buttonTitle}
+    >
+      {bucket.anchors.length}
+    </button>
+  );
+}
+
+BucketButton.propTypes = {
+  bucket: propTypes.object.isRequired,
+  onSelectAnnotations: propTypes.func.isRequired,
+};
+
+/**
+ * An up- or down-pointing button that will scroll to the next closest bucket
+ * of annotations in the given direction.
+ *
+ * @param {Object} props
+ *   @param {Bucket} props.bucket
+ *   @param {'up'|'down'} props.direction
+ */
+function NavigationBucketButton({ bucket, direction }) {
+  const buttonTitle = `Go ${direction} to next annotations (${bucket.anchors.length})`;
+
+  function scrollToClosest(event) {
+    event.stopPropagation();
+    const closest = findClosestOffscreenAnchor(bucket.anchors, direction);
+    if (closest?.highlights?.length) {
+      scrollIntoView(closest.highlights[0]);
+    }
+  }
+  return (
+    <button
+      className={classnames('bucket-button', `bucket-button--${direction}`)}
+      onClick={event => scrollToClosest(event)}
+      title={buttonTitle}
+      aria-label={buttonTitle}
+    >
+      {bucket.anchors.length}
+    </button>
+  );
+}
+
+NavigationBucketButton.propTypes = {
+  bucket: propTypes.object.isRequired,
+  direction: propTypes.string,
+};
+
+/**
+ * A list of buckets, including up and down navigation (when applicable) and
+ * on-screen buckets
+ *
+ * @param {Object} props
+ *   @param {Bucket} props.above
+ *   @param {Bucket} props.below
+ *   @param {Bucket[]} props.buckets
+ *   @param {(annotations: AnnotationData[], toggle: boolean) => any} props.onSelectAnnotations
+ */
+export default function Buckets({
+  above,
+  below,
+  buckets,
+  onSelectAnnotations,
+}) {
+  const showUpNavigation = above.anchors.length > 0;
+  const showDownNavigation = below.anchors.length > 0;
+
+  return (
+    <ul className="buckets">
+      {showUpNavigation && (
+        <li className="bucket" style={{ top: above.position }}>
+          <NavigationBucketButton bucket={above} direction="up" />
+        </li>
+      )}
+      {buckets.map((bucket, index) => (
+        <li className="bucket" style={{ top: bucket.position }} key={index}>
+          <BucketButton
+            bucket={bucket}
+            onSelectAnnotations={onSelectAnnotations}
+          />
+        </li>
+      ))}
+      {showDownNavigation && (
+        <li className="bucket" style={{ top: below.position }}>
+          <NavigationBucketButton bucket={below} direction="down" />
+        </li>
+      )}
+    </ul>
+  );
+}
+
+Buckets.propTypes = {
+  above: propTypes.object.isRequired,
+  below: propTypes.object.isRequired,
+  buckets: propTypes.array.isRequired,
+  onSelectAnnotations: propTypes.func.isRequired,
+};

--- a/src/annotator/components/test/buckets-test.js
+++ b/src/annotator/components/test/buckets-test.js
@@ -1,0 +1,235 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import { checkAccessibility } from '../../../test-util/accessibility';
+
+import Buckets from '../buckets';
+import { $imports } from '../buckets';
+
+describe('Buckets', () => {
+  let fakeBucketsUtil;
+  let fakeHighlighter;
+  let fakeScrollIntoView;
+
+  let fakeAbove;
+  let fakeBelow;
+  let fakeBuckets;
+
+  const createComponent = props =>
+    mount(
+      <Buckets
+        above={fakeAbove}
+        below={fakeBelow}
+        buckets={fakeBuckets}
+        onSelectAnnotations={() => null}
+        {...props}
+      />
+    );
+
+  beforeEach(() => {
+    fakeAbove = { anchors: ['hi', 'there'], position: 150 };
+    fakeBelow = { anchors: ['ho', 'there'], position: 550 };
+    fakeBuckets = [
+      {
+        anchors: [
+          { annotation: { $tag: 't1' }, highlights: ['hi'] },
+          { annotation: { $tag: 't2' }, highlights: ['yay'] },
+        ],
+        position: 250,
+      },
+      { anchors: ['you', 'also', 'are', 'welcome'], position: 350 },
+    ];
+    fakeBucketsUtil = {
+      findClosestOffscreenAnchor: sinon.stub().returns({}),
+    };
+    fakeHighlighter = {
+      setHighlightsFocused: sinon.stub(),
+    };
+    fakeScrollIntoView = sinon.stub();
+
+    $imports.$mock({
+      'scroll-into-view': fakeScrollIntoView,
+      '../highlighter': fakeHighlighter,
+      '../util/buckets': fakeBucketsUtil,
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  describe('up and down navigation', () => {
+    it('renders an up navigation button if there are above-screen anchors', () => {
+      const wrapper = createComponent();
+      const upButton = wrapper.find('.bucket-button--up');
+      // The list item element wrapping the button
+      const bucketItem = wrapper.find('.bucket').first();
+
+      assert.isTrue(upButton.exists());
+      assert.equal(
+        bucketItem.getDOMNode().style.top,
+        `${fakeAbove.position}px`
+      );
+    });
+
+    it('does not render an up navigation button if there are no above-screen anchors', () => {
+      fakeAbove = { anchors: [], position: 150 };
+      const wrapper = createComponent();
+      assert.isFalse(wrapper.find('.bucket-button--up').exists());
+    });
+
+    it('renders a down navigation button if there are below-screen anchors', () => {
+      const wrapper = createComponent();
+
+      const downButton = wrapper.find('.bucket-button--down');
+      // The list item element wrapping the button
+      const bucketItem = wrapper.find('.bucket').last();
+
+      assert.isTrue(downButton.exists());
+      assert.equal(
+        bucketItem.getDOMNode().style.top,
+        `${fakeBelow.position}px`
+      );
+    });
+
+    it('does not render a down navigation button if there are no below-screen anchors', () => {
+      fakeBelow = { anchors: [], position: 550 };
+      const wrapper = createComponent();
+      assert.isFalse(wrapper.find('.bucket-button--down').exists());
+    });
+
+    it('scrolls to anchors above when up navigation button is pressed', () => {
+      const fakeAnchor = { highlights: ['hi'] };
+      fakeBucketsUtil.findClosestOffscreenAnchor.returns(fakeAnchor);
+      const wrapper = createComponent();
+      const upButton = wrapper.find('.bucket-button--up');
+
+      upButton.simulate('click');
+
+      assert.calledWith(
+        fakeBucketsUtil.findClosestOffscreenAnchor,
+        fakeAbove.anchors,
+        'up'
+      );
+      assert.calledWith(fakeScrollIntoView, fakeAnchor.highlights[0]);
+    });
+
+    it('scrolls to anchors below when down navigation button is pressed', () => {
+      const fakeAnchor = { highlights: ['hi'] };
+      fakeBucketsUtil.findClosestOffscreenAnchor.returns(fakeAnchor);
+      const wrapper = createComponent();
+      const downButton = wrapper.find('.bucket-button--down');
+
+      downButton.simulate('click');
+
+      assert.calledWith(
+        fakeBucketsUtil.findClosestOffscreenAnchor,
+        fakeBelow.anchors,
+        'down'
+      );
+      assert.calledWith(fakeScrollIntoView, fakeAnchor.highlights[0]);
+    });
+  });
+
+  describe('on-screen buckets', () => {
+    it('renders a bucket button for each bucket', () => {
+      const wrapper = createComponent();
+
+      assert.equal(wrapper.find('.bucket-button--left').length, 2);
+    });
+
+    it('focuses associated anchors when mouse enters the element', () => {
+      const wrapper = createComponent();
+
+      wrapper.find('.bucket-button--left').first().simulate('mousemove');
+
+      assert.calledTwice(fakeHighlighter.setHighlightsFocused);
+      assert.calledWith(
+        fakeHighlighter.setHighlightsFocused,
+        fakeBuckets[0].anchors[0].highlights,
+        true
+      );
+      assert.calledWith(
+        fakeHighlighter.setHighlightsFocused,
+        fakeBuckets[0].anchors[1].highlights,
+        true
+      );
+    });
+
+    it('removes focus on associated anchors when element is blurred', () => {
+      const wrapper = createComponent();
+
+      wrapper.find('.bucket-button--left').first().simulate('blur');
+
+      assert.calledTwice(fakeHighlighter.setHighlightsFocused);
+      assert.calledWith(
+        fakeHighlighter.setHighlightsFocused,
+        fakeBuckets[0].anchors[0].highlights,
+        false
+      );
+      assert.calledWith(
+        fakeHighlighter.setHighlightsFocused,
+        fakeBuckets[0].anchors[1].highlights,
+        false
+      );
+    });
+
+    it('removes focus on associated anchors when mouse leaves the element', () => {
+      const wrapper = createComponent();
+
+      wrapper.find('.bucket-button--left').first().simulate('mouseout');
+
+      assert.calledTwice(fakeHighlighter.setHighlightsFocused);
+      assert.calledWith(
+        fakeHighlighter.setHighlightsFocused,
+        fakeBuckets[0].anchors[0].highlights,
+        false
+      );
+    });
+
+    it('selects associated annotations when bucket button pressed', () => {
+      const fakeOnSelectAnnotations = sinon.stub();
+      const wrapper = createComponent({
+        onSelectAnnotations: fakeOnSelectAnnotations,
+      });
+
+      wrapper
+        .find('.bucket-button--left')
+        .first()
+        .simulate('click', { metaKey: false, ctrlKey: false });
+
+      assert.calledOnce(fakeOnSelectAnnotations);
+      const call = fakeOnSelectAnnotations.getCall(0);
+      assert.deepEqual(call.args[0], [
+        fakeBuckets[0].anchors[0].annotation,
+        fakeBuckets[0].anchors[1].annotation,
+      ]);
+      assert.equal(call.args[1], false);
+    });
+
+    it('toggles annotation selection if metakey pressed', () => {
+      const fakeOnSelectAnnotations = sinon.stub();
+      const wrapper = createComponent({
+        onSelectAnnotations: fakeOnSelectAnnotations,
+      });
+
+      wrapper
+        .find('.bucket-button--left')
+        .first()
+        .simulate('click', { metaKey: true, ctrlKey: false });
+
+      const call = fakeOnSelectAnnotations.getCall(0);
+
+      assert.equal(call.args[1], true);
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        content: () => createComponent(),
+      },
+    ])
+  );
+});

--- a/src/annotator/plugin/bucket-bar.js
+++ b/src/annotator/plugin/bucket-bar.js
@@ -1,20 +1,9 @@
 import Delegator from '../delegator';
-import scrollIntoView from 'scroll-into-view';
 
-import { setHighlightsFocused } from '../highlighter';
-import { findClosestOffscreenAnchor, anchorBuckets } from '../util/buckets';
+import { createElement, render } from 'preact';
+import Buckets from '../components/buckets';
 
-/**
- * @typedef {import('../util/buckets').Bucket} Bucket
- */
-
-// Scroll to the next closest anchor off screen in the given direction.
-function scrollToClosest(anchors, direction) {
-  const closest = findClosestOffscreenAnchor(anchors, direction);
-  if (closest && closest.highlights?.length) {
-    scrollIntoView(closest.highlights[0]);
-  }
-}
+import { anchorBuckets } from '../util/buckets';
 
 export default class BucketBar extends Delegator {
   constructor(element, options, annotator) {
@@ -30,11 +19,6 @@ export default class BucketBar extends Delegator {
     super(el, opts);
 
     this.annotator = annotator;
-
-    /** @type {Bucket[]} */
-    this.buckets = [];
-    /** @type {HTMLElement[]} - Elements created in the bucket bar for each bucket */
-    this.tabs = [];
 
     // The element to append this plugin's element to; defaults to the provided
     // `element` unless a `container` option was provided
@@ -80,22 +64,6 @@ export default class BucketBar extends Delegator {
     });
   }
 
-  /**
-   * Focus or unfocus the anchor highlights in the bucket indicated by `index`
-   *
-   * @param {number} index - The bucket's index in the `this.buckets` array
-   * @param {boolean} toggle - Should this set of highlights be focused (or
-   *   un-focused)?
-   */
-  updateHighlightFocus(index, toggle) {
-    if (index > 0 && this.buckets[index] && !this.isNavigationBucket(index)) {
-      const bucket = this.buckets[index];
-      bucket.anchors.forEach(anchor => {
-        setHighlightsFocused(anchor.highlights || [], toggle);
-      });
-    }
-  }
-
   update() {
     if (this._updatePending) {
       return;
@@ -108,101 +76,17 @@ export default class BucketBar extends Delegator {
   }
 
   _update() {
-    this.buckets = anchorBuckets(this.annotator.anchors);
-
-    // The following affordances attempt to reuse existing DOM elements
-    // when reconstructing bucket "tabs" to cut down on the number of elements
-    // created and added to the DOM
-
-    // Only leave as many "tab" elements attached to the DOM as there are
-    // buckets
-    this.tabs.slice(this.buckets.length).forEach(tabEl => tabEl.remove());
-
-    // And cut the "tabs" collection down to the size of buckets, too
-    /** @type {HTMLElement[]} */
-    this.tabs = this.tabs.slice(0, this.buckets.length);
-
-    // If the number of "tabs" currently in the DOM is too small (fewer than
-    // buckets), fill that gap by creating new elements (and adding event
-    // listeners to them)
-    this.buckets.slice(this.tabs.length).forEach(() => {
-      const tabEl = document.createElement('div');
-      this.tabs.push(tabEl);
-
-      // Note that these elements are reused as buckets change, meaning that
-      // any given tab element will correspond to a different bucket over time.
-      // However, we know that we have one "tab" per bucket, in order,
-      // so we can look up the correct bucket for a tab at event time.
-
-      // Focus and unfocus highlights on mouse events
-      tabEl.addEventListener('mousemove', () => {
-        this.updateHighlightFocus(this.tabs.indexOf(tabEl), true);
-      });
-
-      tabEl.addEventListener('mouseout', () => {
-        this.updateHighlightFocus(this.tabs.indexOf(tabEl), false);
-      });
-
-      // Select the annotations (in the sidebar)
-      // that have anchors within the clicked bucket
-      tabEl.addEventListener('click', event => {
-        event.stopPropagation();
-        const index = this.tabs.indexOf(tabEl);
-        const bucket = this.buckets[index];
-        if (!bucket) {
-          return;
+    const buckets = anchorBuckets(this.annotator.anchors);
+    render(
+      <Buckets
+        above={buckets.above}
+        below={buckets.below}
+        buckets={buckets.buckets}
+        onSelectAnnotations={(annotations, toggle) =>
+          this.annotator.selectAnnotations(annotations, toggle)
         }
-        if (this.isLower(index)) {
-          scrollToClosest(bucket.anchors, 'down');
-        } else if (this.isUpper(index)) {
-          scrollToClosest(bucket.anchors, 'up');
-        } else {
-          const annotations = bucket.anchors.map(anchor => anchor.annotation);
-          this.annotator.selectAnnotations(
-            annotations,
-            event.ctrlKey || event.metaKey
-          );
-        }
-      });
-
-      this.element.appendChild(tabEl);
-    });
-
-    this._buildTabs();
-  }
-
-  _buildTabs() {
-    this.tabs.forEach((tabEl, index) => {
-      const anchorCount = this.buckets[index].anchors.length;
-      tabEl.className = 'annotator-bucket-indicator';
-      tabEl.style.top = `${this.buckets[index].position}px`;
-      tabEl.style.display = '';
-
-      if (anchorCount) {
-        tabEl.innerHTML = `<div class="label">${this.buckets[index].anchors.length}</div>`;
-        if (anchorCount === 1) {
-          tabEl.setAttribute('title', 'Show one annotation');
-        } else {
-          tabEl.setAttribute('title', `Show ${anchorCount} annotations`);
-        }
-      } else {
-        tabEl.style.display = 'none';
-      }
-
-      tabEl.classList.toggle('upper', this.isUpper(index));
-      tabEl.classList.toggle('lower', this.isLower(index));
-    });
-  }
-
-  isUpper(i) {
-    return i === 0;
-  }
-
-  isLower(i) {
-    return i === this.buckets.length - 1;
-  }
-
-  isNavigationBucket(i) {
-    return this.isUpper(i) || this.isLower(i);
+      />,
+      this.element
+    );
   }
 }

--- a/src/annotator/util/buckets.js
+++ b/src/annotator/util/buckets.js
@@ -12,6 +12,15 @@ import { getBoundingClientRect } from '../highlighter';
  */
 
 /**
+ * @typedef BucketSet
+ * @prop {Bucket} above - A single bucket containing all of the anchors that
+ *                        are offscreen upwards
+ * @prop {Bucket} below - A single bucket containing all of the anchors that are
+ *                        offscreen downwards
+ * @prop {Bucket[]} buckets - On-screen buckets
+ */
+
+/**
  * @typedef WorkingBucket
  * @prop {Anchor[]} anchors - The anchors in this bucket
  * @prop {number} position - The computed position (offset) for this bucket,
@@ -131,7 +140,7 @@ function getAnchorPositions(anchors) {
  * Compute buckets
  *
  * @param {Anchor[]} anchors
- * @return {Bucket[]}
+ * @return {BucketSet}
  */
 export function anchorBuckets(anchors) {
   const anchorPositions = getAnchorPositions(anchors);
@@ -214,15 +223,20 @@ export function anchorBuckets(anchors) {
   }
 
   // Add an upper "navigation" bucket with offscreen-above anchors
-  buckets.unshift({
+  const above = {
     anchors: Array.from(aboveScreen),
     position: BUCKET_TOP_THRESHOLD,
-  });
+  };
 
   // Add a lower "navigation" bucket with offscreen-below anchors
-  buckets.push({
+  const below = {
     anchors: Array.from(belowScreen),
     position: window.innerHeight - BUCKET_BOTTOM_THRESHOLD,
-  });
-  return buckets;
+  };
+
+  return {
+    above,
+    below,
+    buckets,
+  };
 }

--- a/src/styles/annotator/bucket-bar.scss
+++ b/src/styles/annotator/bucket-bar.scss
@@ -1,3 +1,4 @@
+@use "../mixins/buttons";
 @use "../mixins/reset";
 @use "../mixins/utils";
 @use "../variables" as var;
@@ -20,126 +21,31 @@
     background: rgba(0, 0, 0, 0.08);
   }
 
-  .annotator-bucket-indicator {
-    box-sizing: border-box;
-    background: var.$white;
-    border: solid 1px var.$grey-3;
-    border-radius: 2px 4px 4px 2px;
-    right: 0;
-    pointer-events: all;
+  .buckets,
+  .bucket {
     position: absolute;
-    line-height: 1;
-    height: 16px;
-    width: 26px;
-    -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
-    text-align: center;
-    cursor: pointer;
-    // Vertically center the element, which is 16px high
+    right: 0;
+  }
+
+  .bucket-button {
+    // Need pointer events again. Necessary because of `pointer-events` rule
+    // in `.annotator-bucket-bar`
+    pointer-events: all;
+  }
+
+  .bucket-button--left {
+    // Center the indicator vertically (the element is 16px tall)
     margin-top: -8px;
+    @include buttons.indicator--left;
+  }
 
-    .label {
-      @include reset.reset-box-model;
-      @include reset.reset-font;
-      background: none;
-      color: var.$color-text--light;
-      font-weight: bold;
-      font-family: var.$sans-font-family;
-      font-size: var.$annotator-bucket-bar-font-size;
-      line-height: var.$annotator-bucket-bar-line-height;
-      margin: 0 auto;
-    }
+  .bucket-button--up {
+    @include buttons.indicator--up;
+    // Vertically center the element (which is 22px high)
+    margin-top: -11px;
+  }
 
-    &:before,
-    &:after {
-      content: '';
-      right: 100%;
-      top: 50%;
-      position: absolute;
-      // NB: use of 'inset' here fixes jagged diagonals in FF
-      // https://github.com/zurb/foundation/issues/2230
-      border: inset transparent;
-      height: 0;
-      width: 0;
-    }
-
-    &:before {
-      border-width: 8px;
-      border-right: 5px solid var.$grey-3;
-      margin-top: -8px;
-    }
-
-    &:after {
-      border-width: 7px;
-      border-right: 4px solid var.$white;
-      margin-top: -7px;
-    }
-
-    &.lower,
-    &.upper {
-      @include utils.shadow;
-      z-index: 1;
-
-      &:before,
-      &:after {
-        left: 50%;
-        bottom: 100%;
-        right: auto;
-        border-right: solid transparent;
-        margin-top: 0;
-      }
-      & .label {
-        // Vertical alignment tweak to better center the label in the indicator
-        margin-top: -1px;
-      }
-    }
-
-    &.upper {
-      border-radius: 2px 2px 4px 4px;
-      // Vertically center the element (which is 22px high) by adding a negative
-      // top margin in conjunction with an inline style `top` position (set
-      // in code)
-      margin-top: -11px;
-
-      &:before,
-      &:after {
-        top: auto;
-        bottom: 100%;
-      }
-
-      &:before {
-        border-width: 13px;
-        border-bottom: 6px solid var.$grey-3;
-        margin-left: -13px;
-      }
-
-      &:after {
-        border-width: 12px;
-        border-bottom: 5px solid var.$white;
-        margin-left: -12px;
-      }
-    }
-
-    &.lower {
-      margin-top: 0;
-      border-radius: 4px 4px 2px 2px;
-
-      &:before,
-      &:after {
-        bottom: auto;
-        top: 100%;
-      }
-
-      &:before {
-        border-width: 13px;
-        border-top: 6px solid var.$grey-3;
-        margin-left: -13px;
-      }
-
-      &:after {
-        border-width: 12px;
-        border-top: 5px solid var.$white;
-        margin-left: -12px;
-      }
-    }
+  .bucket-button--down {
+    @include buttons.indicator--down;
   }
 }

--- a/src/styles/mixins/buttons.scss
+++ b/src/styles/mixins/buttons.scss
@@ -175,3 +175,142 @@
     height: 12px;
   }
 }
+
+/**
+ * Mixins that style buttons to appear as lozenges with an integrated arrow
+ * pointing left, up or down (right doesn't exist yet but could easily be added).
+ * These indicators are used, e.g., in the bucket bar.
+ *
+ * These button or button-like elements consist of styles applied to the
+ * element itself, which create a rounded-rectangle lozenge with small-sized
+ * label text, as well as composited ::before and ::after pseudo-elements to
+ * create an arrow-pointer effect.
+ *
+ * The arrow-points are created by the combination of borders and positioning.
+ * See https://css-tricks.com/snippets/css/css-triangle/ for a few examples
+ *
+ */
+$indicator-width: 26px;
+$indicator-height: 16px;
+
+// How far the arrow-pointer "sticks out" from the main body of the lozenge
+$indicator-horizontal-offset: 5px;
+$indicator-vertical-offset: 6px;
+
+@mixin indicator-base {
+  @include reset-native-btn-styles;
+  @include utils.border;
+  position: absolute;
+  right: 0;
+
+  background-color: var.$color-background;
+
+  width: $indicator-width;
+  height: $indicator-height;
+
+  // Font/text
+  text-align: center;
+  color: var.$color-text--light;
+  font-weight: bold;
+  font-family: var.$sans-font-family;
+  font-size: var.$annotator-bucket-bar-font-size;
+  line-height: 1;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    // NB: use of 'inset' here fixes jagged diagonals in FF
+    // https://github.com/zurb/foundation/issues/2230
+    border: inset transparent;
+  }
+}
+
+@mixin indicator-vertical-base {
+  @include indicator-base;
+  @include utils.shadow;
+  z-index: 1;
+
+  &::before,
+  &::after {
+    left: 50%;
+  }
+}
+
+@mixin indicator--left {
+  @include indicator-base;
+  border-radius: 2px 4px 4px 2px;
+
+  &::before,
+  &::after {
+    right: 100%;
+    top: 50%;
+  }
+
+  // This creates a left-pointing "wedge" in grey
+  // offset to the left of the element
+  &::before {
+    border-width: $indicator-height / 2;
+    border-right: $indicator-horizontal-offset solid var.$grey-3;
+    margin-top: -1 * ($indicator-height / 2);
+  }
+
+  // This creates a left-pointing "wedge" in white, on top
+  // of the grey wedge and one pixel narrower so that the
+  // grey wedge appears as a border around it
+  &::after {
+    border-width: $indicator-height / 2 - 1;
+    border-right: ($indicator-horizontal-offset - 1) solid var.$color-background;
+    margin-top: -1 * ($indicator-height / 2 - 1);
+  }
+}
+
+@mixin indicator--up {
+  @include indicator-vertical-base;
+  border-radius: 2px 2px 4px 4px;
+
+  &::before,
+  &::after {
+    top: auto;
+    bottom: 100%;
+  }
+
+  // Grey (border) arrow pointing up
+  &::before {
+    border-width: $indicator-width / 2;
+    border-bottom: $indicator-vertical-offset solid var.$grey-3;
+    margin-left: -1 * ($indicator-width / 2);
+  }
+
+  // White (fill) arrow pointing up
+  &::after {
+    border-width: $indicator-width / 2 - 1;
+    border-bottom: ($indicator-vertical-offset - 1) solid var.$color-background;
+    margin-left: -1 * ($indicator-width / 2 - 1);
+  }
+}
+
+@mixin indicator--down {
+  @include indicator-vertical-base;
+  margin-top: 0;
+  border-radius: 4px 4px 2px 2px;
+
+  &::before,
+  &::after {
+    top: 100%;
+  }
+
+  // Grey (border) arrow, pointing down
+  &::before {
+    border-width: $indicator-width / 2;
+    border-top: $indicator-vertical-offset solid var.$grey-3;
+    margin-left: -1 * ($indicator-width / 2);
+  }
+
+  // White (fill) arrow, pointing down
+  &::after {
+    border-width: $indicator-width / 2 - 1;
+    border-top: ($indicator-vertical-offset - 1) solid var.$color-background;
+    margin-left: -1 * ($indicator-width / 2 - 1);
+  }
+}


### PR DESCRIPTION
This is a ready-for-primetime variant of https://github.com/hypothesis/client/pull/2687

Fixes https://github.com/hypothesis/client/issues/2139

Convert anchor buckets to preact, clean up, and add some HTML semantics and a11y affordances.