### PR TITLE
Don't show edited timestamps if annotations haven't been updated

### DIFF
--- a/src/sidebar/components/annotation-header.js
+++ b/src/sidebar/components/annotation-header.js
@@ -1,8 +1,13 @@
 import { createElement } from 'preact';
+import { useMemo } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import useStore from '../store/use-store';
-import { isHighlight, isReply } from '../util/annotation-metadata';
+import {
+  hasBeenEdited,
+  isHighlight,
+  isReply,
+} from '../util/annotation-metadata';
 import { isPrivate } from '../util/permissions';
 
 import AnnotationDocumentInfo from './annotation-document-info';
@@ -47,11 +52,10 @@ export default function AnnotationHeader({
   const annotationIsPrivate = isPrivate(annotation.permissions);
   const annotationLink = annotation.links ? annotation.links.html : '';
 
-  // NB: `created` and `updated` are strings, not `Date`s
-  const hasBeenEdited =
-    annotation.updated && annotation.created !== annotation.updated;
   const showTimestamp = !isEditing && annotation.created;
-  const showEditedTimestamp = hasBeenEdited && !isCollapsedReply;
+  const showEditedTimestamp = useMemo(() => {
+    return hasBeenEdited(annotation) && !isCollapsedReply;
+  }, [annotation, isCollapsedReply]);
 
   const replyPluralized = replyCount > 1 ? 'replies' : 'reply';
   const replyButtonText = `${replyCount} ${replyPluralized}`;

--- a/src/sidebar/components/test/annotation-header-test.js
+++ b/src/sidebar/components/test/annotation-header-test.js
@@ -11,6 +11,7 @@ import mockImportedComponents from '../../../test-util/mock-imported-components'
 describe('AnnotationHeader', () => {
   let fakeIsHighlight;
   let fakeIsReply;
+  let fakeHasBeenEdited;
   let fakeIsPrivate;
   let fakeStore;
 
@@ -30,6 +31,7 @@ describe('AnnotationHeader', () => {
   beforeEach(() => {
     fakeIsHighlight = sinon.stub().returns(false);
     fakeIsReply = sinon.stub().returns(false);
+    fakeHasBeenEdited = sinon.stub().returns(false);
     fakeIsPrivate = sinon.stub();
 
     fakeStore = {
@@ -42,6 +44,7 @@ describe('AnnotationHeader', () => {
       '../util/annotation-metadata': {
         isHighlight: fakeIsHighlight,
         isReply: fakeIsReply,
+        hasBeenEdited: fakeHasBeenEdited,
       },
       '../util/permissions': {
         isPrivate: fakeIsPrivate,
@@ -170,7 +173,7 @@ describe('AnnotationHeader', () => {
 
     it('should render edited timestamp if annotation has been edited', () => {
       const annotation = fixtures.defaultAnnotation();
-      annotation.updated = '2018-05-10T20:18:56.613388+00:00';
+      fakeHasBeenEdited.returns(true);
 
       const wrapper = createAnnotationHeader({
         annotation: annotation,
@@ -185,6 +188,7 @@ describe('AnnotationHeader', () => {
     it('should not render edited timestamp if annotation has not been edited', () => {
       // Default annotation's created value is same as updated; as if the annotation
       // has not been edited before
+      fakeHasBeenEdited.returns(false);
       const wrapper = createAnnotationHeader({
         annotation: fixtures.newAnnotation(),
       });
@@ -196,6 +200,7 @@ describe('AnnotationHeader', () => {
     });
 
     it('should not render edited timestamp if annotation is collapsed reply', () => {
+      fakeHasBeenEdited.returns(true);
       const annotation = fixtures.defaultAnnotation();
       annotation.updated = '2018-05-10T20:18:56.613388+00:00';
       fakeIsReply.returns(true);

--- a/src/sidebar/util/test/annotation-metadata-test.js
+++ b/src/sidebar/util/test/annotation-metadata-test.js
@@ -4,205 +4,215 @@ import * as annotationMetadata from '../annotation-metadata';
 const documentMetadata = annotationMetadata.documentMetadata;
 const domainAndTitle = annotationMetadata.domainAndTitle;
 
-describe('annotation-metadata', function () {
-  describe('.documentMetadata', function () {
-    context('when the model has a document property', function () {
-      it('returns the hostname from model.uri as the domain', function () {
-        const model = {
-          document: {},
-          uri: 'http://example.com/',
-        };
+describe('sidebar/util/annotation-metadata', () => {
+  const fakeAnnotation = (props = {}) => {
+    return {
+      document: {},
+      uri: 'http://example.com/a/page',
+      ...props,
+    };
+  };
 
-        assert.equal(documentMetadata(model).domain, 'example.com');
+  describe('documentMetadata', () => {
+    context('when the annotation has a document property', () => {
+      it('returns the hostname from annotation.uri as the domain', () => {
+        const annotation = fakeAnnotation();
+        assert.equal(documentMetadata(annotation).domain, 'example.com');
       });
 
-      context('when model.uri does not start with "urn"', function () {
-        it('uses model.uri as the uri', function () {
-          const model = {
-            document: {},
-            uri: 'http://example.com/',
-          };
-
-          assert.equal(documentMetadata(model).uri, 'http://example.com/');
+      context('when annotation.uri does not start with "urn"', () => {
+        it('uses annotation.uri as the uri', () => {
+          const annotation = fakeAnnotation();
+          assert.equal(
+            documentMetadata(annotation).uri,
+            'http://example.com/a/page'
+          );
         });
       });
 
-      context('when document.title is an available', function () {
-        it('uses the first document title as the title', function () {
-          const model = {
-            uri: 'http://example.com/',
+      context('when document.title is an available', () => {
+        it('uses the first document title as the title', () => {
+          const annotation = fakeAnnotation({
             document: {
               title: ['My Document', 'My Other Document'],
             },
-          };
+          });
 
-          assert.equal(documentMetadata(model).title, model.document.title[0]);
+          assert.equal(
+            documentMetadata(annotation).title,
+            annotation.document.title[0]
+          );
         });
       });
 
-      context('when there is no document.title', function () {
-        it('returns the domain as the title', function () {
-          const model = {
-            document: {},
-            uri: 'http://example.com/',
-          };
-
-          assert.equal(documentMetadata(model).title, 'example.com');
+      context('when there is no document.title', () => {
+        it('returns the domain as the title', () => {
+          const annotation = fakeAnnotation();
+          assert.equal(documentMetadata(annotation).title, 'example.com');
         });
       });
     });
 
-    context('when the model does not have a document property', function () {
-      it('returns model.uri for the uri', function () {
-        const model = { uri: 'http://example.com/' };
+    context('when the annotation does not have a document property', () => {
+      let annotationNoDocument;
 
-        assert.equal(documentMetadata(model).uri, model.uri);
+      beforeEach(() => {
+        annotationNoDocument = fakeAnnotation();
+        delete annotationNoDocument.document;
       });
 
-      it('returns the hostname of model.uri for the domain', function () {
-        const model = { uri: 'http://example.com/' };
-
-        assert.equal(documentMetadata(model).domain, 'example.com');
+      it('returns annotation.uri for the uri', () => {
+        assert.equal(
+          documentMetadata(annotationNoDocument).uri,
+          annotationNoDocument.uri
+        );
       });
 
-      it('returns the hostname of model.uri for the title', function () {
-        const model = { uri: 'http://example.com/' };
+      it('returns the hostname of annotation.uri for the domain', () => {
+        assert.equal(
+          documentMetadata(annotationNoDocument).domain,
+          'example.com'
+        );
+      });
 
-        assert.equal(documentMetadata(model).title, 'example.com');
+      it('returns the hostname of annotation.uri for the title', () => {
+        assert.equal(
+          documentMetadata(annotationNoDocument).title,
+          'example.com'
+        );
       });
     });
   });
 
-  describe('.domainAndTitle', function () {
-    context('when an annotation has a non-http(s) uri', function () {
-      it('returns no title link', function () {
-        const model = {
+  describe('domainAndTitle', () => {
+    context('when an annotation has a non-http(s) uri', () => {
+      it('returns no title link', () => {
+        const annotation = fakeAnnotation({
           uri: 'file:///example.pdf',
-        };
+        });
 
-        assert.equal(domainAndTitle(model).titleLink, null);
+        assert.equal(domainAndTitle(annotation).titleLink, null);
       });
     });
 
-    context('when an annotation has a direct link', function () {
-      it('returns the direct link as a title link', function () {
-        const model = {
+    context('when an annotation has a direct link', () => {
+      it('returns the direct link as a title link', () => {
+        const annotation = {
           uri: 'https://annotatedsite.com/',
           links: {
             incontext: 'https://example.com',
           },
         };
 
-        assert.equal(domainAndTitle(model).titleLink, 'https://example.com');
+        assert.equal(
+          domainAndTitle(annotation).titleLink,
+          'https://example.com'
+        );
       });
     });
 
     context(
       'when an annotation has no direct link but has a http(s) uri',
-      function () {
-        it('returns the uri as title link', function () {
-          const model = {
+      () => {
+        it('returns the uri as title link', () => {
+          const annotation = fakeAnnotation({
             uri: 'https://example.com',
-          };
-
-          assert.equal(domainAndTitle(model).titleLink, 'https://example.com');
-        });
-      }
-    );
-
-    context(
-      'when the annotation title is shorter than 30 characters',
-      function () {
-        it('returns the annotation title as title text', function () {
-          const model = {
-            uri: 'https://annotatedsite.com/',
-            document: {
-              title: ['A Short Document Title'],
-            },
-          };
+          });
 
           assert.equal(
-            domainAndTitle(model).titleText,
-            'A Short Document Title'
+            domainAndTitle(annotation).titleLink,
+            'https://example.com'
           );
         });
       }
     );
 
-    context(
-      'when the annotation title is longer than 30 characters',
-      function () {
-        it('truncates the title text with "…"', function () {
-          const model = {
-            uri: 'http://example.com/',
-            document: {
-              title: ['My Really Really Long Document Title'],
-            },
-          };
-
-          assert.equal(
-            domainAndTitle(model).titleText,
-            'My Really Really Long Document…'
-          );
+    context('when the annotation title is shorter than 30 characters', () => {
+      it('returns the annotation title as title text', () => {
+        const annotation = fakeAnnotation({
+          uri: 'https://annotatedsite.com/',
+          document: {
+            title: ['A Short Document Title'],
+          },
         });
-      }
-    );
 
-    context('when the document uri refers to a filename', function () {
-      it('returns the filename as domain text', function () {
-        const model = {
+        assert.equal(
+          domainAndTitle(annotation).titleText,
+          'A Short Document Title'
+        );
+      });
+    });
+
+    context('when the annotation title is longer than 30 characters', () => {
+      it('truncates the title text with ellipsis character "…"', () => {
+        const annotation = fakeAnnotation({
+          document: {
+            title: ['My Really Really Long Document Title'],
+          },
+        });
+
+        assert.equal(
+          domainAndTitle(annotation).titleText,
+          'My Really Really Long Document…'
+        );
+      });
+    });
+
+    context('when the document uri refers to a filename', () => {
+      it('returns the filename as domain text', () => {
+        const annotation = fakeAnnotation({
           uri: 'file:///path/to/example.pdf',
           document: {
             title: ['Document Title'],
           },
-        };
+        });
 
-        assert.equal(domainAndTitle(model).domain, 'example.pdf');
+        assert.equal(domainAndTitle(annotation).domain, 'example.pdf');
       });
     });
 
-    context('when domain and title are the same', function () {
-      it('returns an empty domain text string', function () {
-        const model = {
+    context('when domain and title are the same', () => {
+      it('returns an empty domain text string', () => {
+        const annotation = fakeAnnotation({
           uri: 'https://example.com',
           document: {
             title: ['example.com'],
           },
-        };
+        });
 
-        assert.equal(domainAndTitle(model).domain, '');
+        assert.equal(domainAndTitle(annotation).domain, '');
       });
     });
 
-    context('when the document has no domain', function () {
-      it('returns an empty domain text string', function () {
-        const model = {
+    context('when the document has no domain', () => {
+      it('returns an empty domain text string', () => {
+        const annotation = fakeAnnotation({
           uri: 'doi:10.1234/5678',
           document: {
             title: ['example.com'],
           },
-        };
+        });
 
-        assert.equal(domainAndTitle(model).domain, '');
+        assert.equal(domainAndTitle(annotation).domain, '');
       });
     });
 
-    context('when the document is a local file with a title', function () {
-      it('returns the filename', function () {
-        const model = {
+    context('when the document is a local file with a title', () => {
+      it('returns the filename', () => {
+        const annotation = fakeAnnotation({
           uri: 'file:///home/seanh/MyFile.pdf',
           document: {
             title: ['example.com'],
           },
-        };
+        });
 
-        assert.equal(domainAndTitle(model).domain, 'MyFile.pdf');
+        assert.equal(domainAndTitle(annotation).domain, 'MyFile.pdf');
       });
     });
   });
 
-  describe('.location', function () {
-    it('returns the position for annotations with a text position', function () {
+  describe('location', () => {
+    it('returns the position for annotations with a text position', () => {
       assert.equal(
         annotationMetadata.location({
           target: [
@@ -220,7 +230,7 @@ describe('annotation-metadata', function () {
       );
     });
 
-    it('returns +ve infinity for annotations without a text position', function () {
+    it('returns +ve infinity for annotations without a text position', () => {
       assert.equal(
         annotationMetadata.location({
           target: [
@@ -234,7 +244,7 @@ describe('annotation-metadata', function () {
     });
   });
 
-  describe('.isHidden', () => {
+  describe('isHidden', () => {
     it('returns `true` if annotation has been hidden', () => {
       const annotation = fixtures.moderatedAnnotation({ hidden: true });
       assert.isTrue(annotationMetadata.isHidden(annotation));
@@ -304,29 +314,32 @@ describe('annotation-metadata', function () {
     });
   });
 
-  describe('.isPageNote', function () {
-    it('returns true for an annotation with an empty target', function () {
+  describe('isPageNote', () => {
+    it('returns true for an annotation with an empty target', () => {
       assert.isTrue(
         annotationMetadata.isPageNote({
           target: [],
         })
       );
     });
-    it('returns true for an annotation without selectors', function () {
+
+    it('returns true for an annotation without selectors', () => {
       assert.isTrue(
         annotationMetadata.isPageNote({
           target: [{ selector: undefined }],
         })
       );
     });
-    it('returns true for an annotation without a target', function () {
+
+    it('returns true for an annotation without a target', () => {
       assert.isTrue(
         annotationMetadata.isPageNote({
           target: undefined,
         })
       );
     });
-    it('returns false for an annotation which is a reply', function () {
+
+    it('returns false for an annotation which is a reply', () => {
       assert.isFalse(
         annotationMetadata.isPageNote({
           target: [],
@@ -336,21 +349,22 @@ describe('annotation-metadata', function () {
     });
   });
 
-  describe('.isAnnotation', function () {
-    it('returns true if an annotation is a top level annotation', function () {
+  describe('isAnnotation', () => {
+    it('returns true if an annotation is a top level annotation', () => {
       assert.isTrue(
         annotationMetadata.isAnnotation({
           target: [{ selector: [] }],
         })
       );
     });
-    it('returns false if an annotation has no target', function () {
+
+    it('returns false if an annotation has no target', () => {
       assert.isFalse(annotationMetadata.isAnnotation({}));
     });
   });
 
-  describe('.isPublic', function () {
-    it('returns true if an annotation is shared within a group', function () {
+  describe('isPublic', () => {
+    it('returns true if an annotation is shared within a group', () => {
       assert.isTrue(annotationMetadata.isPublic(fixtures.publicAnnotation()));
     });
 
@@ -370,22 +384,22 @@ describe('annotation-metadata', function () {
       });
     });
 
-    it('returns false if an annotation is missing permissions', function () {
+    it('returns false if an annotation is missing permissions', () => {
       const annot = fixtures.defaultAnnotation();
       delete annot.permissions;
       assert.isFalse(annotationMetadata.isPublic(annot));
     });
   });
 
-  describe('.isOrphan', function () {
-    it('returns true if an annotation failed to anchor', function () {
+  describe('isOrphan', () => {
+    it('returns true if an annotation failed to anchor', () => {
       const annotation = Object.assign(fixtures.defaultAnnotation(), {
         $orphan: true,
       });
       assert.isTrue(annotationMetadata.isOrphan(annotation));
     });
 
-    it('returns false if an annotation successfully anchored', function () {
+    it('returns false if an annotation successfully anchored', () => {
       const orphan = Object.assign(fixtures.defaultAnnotation(), {
         $orphan: false,
       });
@@ -393,36 +407,36 @@ describe('annotation-metadata', function () {
     });
   });
 
-  describe('.isWaitingToAnchor', function () {
+  describe('isWaitingToAnchor', () => {
     const isWaitingToAnchor = annotationMetadata.isWaitingToAnchor;
 
-    it('returns true for annotations that are not yet anchored', function () {
+    it('returns true for annotations that are not yet anchored', () => {
       assert.isTrue(isWaitingToAnchor(fixtures.defaultAnnotation()));
     });
 
-    it('returns false for annotations that are anchored', function () {
+    it('returns false for annotations that are anchored', () => {
       const anchored = Object.assign({}, fixtures.defaultAnnotation(), {
         $orphan: false,
       });
       assert.isFalse(isWaitingToAnchor(anchored));
     });
 
-    it('returns false for annotations that failed to anchor', function () {
+    it('returns false for annotations that failed to anchor', () => {
       const anchored = Object.assign({}, fixtures.defaultAnnotation(), {
         $orphan: true,
       });
       assert.isFalse(isWaitingToAnchor(anchored));
     });
 
-    it('returns false for replies', function () {
+    it('returns false for replies', () => {
       assert.isFalse(isWaitingToAnchor(fixtures.oldReply()));
     });
 
-    it('returns false for page notes', function () {
+    it('returns false for page notes', () => {
       assert.isFalse(isWaitingToAnchor(fixtures.oldPageNote()));
     });
 
-    it('returns false if the anchoring timeout flag was set', function () {
+    it('returns false if the anchoring timeout flag was set', () => {
       const pending = Object.assign({}, fixtures.defaultAnnotation(), {
         $anchorTimeout: true,
       });
@@ -430,14 +444,14 @@ describe('annotation-metadata', function () {
     });
   });
 
-  describe('.flagCount', function () {
+  describe('flagCount', () => {
     const flagCount = annotationMetadata.flagCount;
 
-    it('returns `null` if the user is not a moderator', function () {
+    it('returns `null` if the user is not a moderator', () => {
       assert.equal(flagCount(fixtures.defaultAnnotation()), null);
     });
 
-    it('returns the flag count if present', function () {
+    it('returns the flag count if present', () => {
       const ann = fixtures.moderatedAnnotation({ flagCount: 10 });
       assert.equal(flagCount(ann), 10);
     });
@@ -486,6 +500,71 @@ describe('annotation-metadata', function () {
         ],
       };
       assert.equal(annotationMetadata.quote(ann), null);
+    });
+  });
+
+  describe('hasBeenEdited', () => {
+    it('should return false if created and updated timestamps are equal', () => {
+      const annotation = fakeAnnotation({
+        created: '2020-10-28T15:35:26.822151+00:00',
+        updated: '2020-10-28T15:35:26.822151+00:00',
+      });
+      assert.isFalse(annotationMetadata.hasBeenEdited(annotation));
+    });
+
+    it('should return false if created and updated timestamps are very close', () => {
+      // Sub-second difference
+      const annotation1 = fakeAnnotation({
+        created: '2020-10-28T15:35:26.822151+00:00',
+        updated: '2020-10-28T15:35:26.822450+00:00',
+      });
+      // Slightly more than one-second difference
+      const annotation2 = fakeAnnotation({
+        created: '2020-10-28T15:35:26.822151+00:00',
+        updated: '2020-10-28T15:35:27.822450+00:00',
+      });
+      assert.isFalse(annotationMetadata.hasBeenEdited(annotation1));
+      assert.isFalse(annotationMetadata.hasBeenEdited(annotation2));
+    });
+
+    it('should return true if created and updated timestamps are meaningfully different', () => {
+      // Few seconds difference
+      const annotation1 = fakeAnnotation({
+        created: '2020-10-28T15:35:26.822151+00:00',
+        updated: '2020-10-28T15:35:29.555555+00:00',
+      });
+      // A few days
+      const annotation2 = fakeAnnotation({
+        created: '2020-10-28T15:35:26.822151+00:00',
+        updated: '2020-10-30T15:35:27.822450+00:00',
+      });
+      assert.isTrue(annotationMetadata.hasBeenEdited(annotation1));
+      assert.isTrue(annotationMetadata.hasBeenEdited(annotation2));
+    });
+
+    context('invalid created or updated dates', () => {
+      it('should return false if created and updated are equal', () => {
+        const annotation = fakeAnnotation({
+          created: 'nope',
+          updated: 'nope',
+        });
+        assert.isFalse(annotationMetadata.hasBeenEdited(annotation));
+      });
+
+      it('should return false if updated is not present', () => {
+        const annotation = fakeAnnotation({
+          created: '2020-10-28T15:35:26.822151+00:00',
+        });
+        assert.isFalse(annotationMetadata.hasBeenEdited(annotation));
+      });
+
+      it('should return false if created and updated are different but problematic', () => {
+        const annotation = fakeAnnotation({
+          created: 'nope',
+          updated: 'nope!',
+        });
+        assert.isFalse(annotationMetadata.hasBeenEdited(annotation));
+      });
     });
   });
 });


### PR DESCRIPTION
Previously, the `AnnotationHeader` component checked the equivalency
of `annotation.created` and `annotation.updated` to determine if an
annotation had been updated subsequent to its creation. This is
problematic if an annotation has a very small difference between its
`created` and `updated` dates.

`created` and `updated` are returned by the API as ISO-8601 date strings
with microsecond resolution. These days, annotations created by the `h`
service will have exactly equivalent `created` and `updated` timestamps
(assuming they haven't actually been edited subsequently, of course). In
the past, however, annotations often had negligible (sub-second)
differences in their `created` and `updated` dates. This resulted in
an edited timestamp misleadingly appearing in the UI for older
annotations.

These changes add a `hasBeenEdited` function to the
`annotation-metadata` util module that considers an annotation edited
only if `created` and `updated` differ by at least 2 seconds.

Tests for `annotation-metadata` have also been modernized somewhat here. (This makes the diff look way bigger than it "is").

Fixes #2684