### PR TITLE
Fix browser support check failure if boot script loaded before body

### DIFF
--- a/src/boot/browser-check.js
+++ b/src/boot/browser-check.js
@@ -17,7 +17,7 @@ export function isBrowserSupported() {
     // DOM API checks for frequently-used APIs.
     () => new URL(document.location.href), // URL constructor.
     () => new Request('https://hypothes.is'), // Part of the `fetch` API.
-    () => document.body.prepend.name, // Element.prepend() method.
+    () => Element.prototype.prepend.name,
 
     // DOM API checks for less frequently-used APIs.
     // These are less likely to have been polyfilled by the host page.


### PR DESCRIPTION
Fix a sporadic false negative in the test for whether the current browser is
supported if the Hypothesis boot script is included in the `<head>` of
the page (before the `<body>`). In this case `document.body` is `null`.

I was able to reproduce a failure when visiting https://via.hypothes.is/https://embed.la.utexas.edu/txlatin/2019/03/05/a-trip-to-the-underworld/ in Firefox 82 and Safari 14.