### PR TITLE
Move browser support list to `browserslist` key in package.json

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,13 +4,7 @@
       "pragma": "createElement"
     }],
     ["@babel/preset-env", {
-       "bugfixes": true,
-       "targets": {
-         "chrome": "55",
-         "edge": "17",
-         "firefox": "53",
-         "safari": "10.1",
-      }
+       "bugfixes": true
     }]
   ],
   "plugins": [

--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,8 @@
     ["@babel/preset-react", {
       "pragma": "createElement"
     }],
+
+    // Compile JS for browser targets set by `browserslist` key in package.json.
     ["@babel/preset-env", {
        "bugfixes": true
     }]

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "wrap-text": "^1.0.7",
     "zen-observable": "^0.3.0"
   },
+  "browserslist": "chrome 55, edge 17, firefox 53, safari 10.1",
   "browserify": {
     "transform": [
       "browserify-versionify",


### PR DESCRIPTION
Move the list of supported browsers from `.babelrc` to the
`browserslist` key in `package.json`. This enables other
browserslist-enabled tools such as autoprefixer to adapt their output to
the target browsers.

This reduces the size of the production CSS bundles slightly by reducing
the number of unnecessary vendor prefixed rules that are generated. There should
be no change in the generated JS bundles.

See https://github.com/postcss/autoprefixer#browsers,
https://github.com/browserslist/browserslist#queries and
https://babeljs.io/docs/en/babel-preset-env#browserslist-integration.