### PR TITLE
Enable `strict` option in tsconfig.json

### DIFF
--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -51,7 +51,7 @@ const config = configFrom(window);
 function init() {
   const isPDF = typeof window_.PDFViewerApplication !== 'undefined';
 
-  /** @type {new (e: Element, config: any) => Guest} */
+  /** @type {new (e: HTMLElement, config: any) => Guest} */
   let Klass = isPDF ? PdfSidebar : Sidebar;
 
   if (config.subFrameIdentifier) {

--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -70,7 +70,7 @@ function GroupListItem({
   /**
    * Opens or closes the submenu.
    *
-   * @param {MouseEvent|KeyboardEvent} event
+   * @param {Event} event
    */
   const toggleSubmenu = event => {
     event.stopPropagation();

--- a/src/sidebar/components/hooks/use-element-should-close.js
+++ b/src/sidebar/components/hooks/use-element-should-close.js
@@ -67,10 +67,9 @@ export default function useElementShouldClose(
     }
 
     // Close element when user presses Escape key, regardless of focus.
-    const removeKeyDownListener = listen(document.body, ['keydown'], (
-      /** @type {KeyboardEvent}*/ event
-    ) => {
-      if (normalizeKeyName(event.key) === 'Escape') {
+    const removeKeyDownListener = listen(document.body, ['keydown'], event => {
+      const keyEvent = /** @type {KeyboardEvent} */ (event);
+      if (normalizeKeyName(keyEvent.key) === 'Escape') {
         handleClose();
       }
     });

--- a/src/sidebar/media-embedder.js
+++ b/src/sidebar/media-embedder.js
@@ -396,17 +396,12 @@ function replaceLinkWithEmbed(link) {
  *     the width of the embed.
  */
 export function replaceLinksWithEmbeds(element, { className } = {}) {
-  let links = element.getElementsByTagName('a');
+  // Get a static (non-live) list of <a> children of `element`.
+  // It needs to be static because we may replace these elements as we iterate over them.
+  const links = Array.from(element.getElementsByTagName('a'));
 
-  // `links` is a "live list" of the <a> element children of `element`.
-  // We want to iterate over `links` and replace some of them with embeds,
-  // but we can't modify `links` while looping over it so we need to copy it to
-  // a nice, normal array first.
-  links = Array.prototype.slice.call(links, 0);
-
-  let i;
-  for (i = 0; i < links.length; i++) {
-    const embed = replaceLinkWithEmbed(links[i]);
+  for (let link of links) {
+    const embed = replaceLinkWithEmbed(link);
     if (embed) {
       if (className) {
         embed.className = className;

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -126,7 +126,7 @@ export default function FrameSync(annotationsService, bridge, store) {
       annotationsService.create(annot);
     });
 
-    bridge.on('destroyFrame', destroyFrame.bind(this));
+    bridge.on('destroyFrame', frameIdentifier => destroyFrame(frameIdentifier));
 
     // Map of annotation tag to anchoring status
     // ('anchored'|'orphan'|'timeout').

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -7,7 +7,8 @@
     "jsxFactory": "createElement",
     "module": "commonjs",
     "noEmit": true,
-    "strictNullChecks": true,
+    "strict": true,
+    "noImplicitAny": false,
     "target": "ES2020"
   },
   "include": [


### PR DESCRIPTION
This catches a few minor errors which the previous configuration did
not. See https://www.typescriptlang.org/tsconfig#strict.

`noImplicitAny` is turned off because we still have a lot of
un-annotated variables/parameters in the code.