### PR TITLE
Speed up `make dev` and add `make build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ default: help
 help:
 	@echo "make help              Show this help message"
 	@echo "make dev               Run the app in the development server"
+	@echo "make build             Create a production build of the client"
 	@echo "make lint              Run the code linter(s) and print any warnings"
 	@echo "make checkformatting   Check code formatting"
 	@echo "make format            Automatically format code"
@@ -69,7 +70,8 @@ sure: checkformatting lint test
 python:
 	@./bin/install-python
 
-build/manifest.json: node_modules/.uptodate
+.PHONY: build
+build: node_modules/.uptodate
 	yarn run build
 
 node_modules/.uptodate: package.json yarn.lock

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ help:
 	@echo "                       dependencies, etc)"
 
 .PHONY: dev
-dev: build/manifest.json
+dev: node_modules/.uptodate
 	node_modules/.bin/gulp watch
 
 .PHONY: test

--- a/package.json
+++ b/package.json
@@ -123,6 +123,6 @@
     "test": "gulp test",
     "typecheck": "tsc --build src/tsconfig.json",
     "report-coverage": "codecov -f coverage/coverage-final.json",
-    "version": "make clean build/manifest.json"
+    "version": "make clean build"
   }
 }


### PR DESCRIPTION
This PR fixes a couple of issues with the `Makefile` in this repository:

- `make dev` would unnecessarily create production builds of the client before starting the dev server if `node_modules/` was out of date, rather than just running `yarn install`
- The make command to create a production build had a non-obvious form (`make build/manifest.json`) and incomplete dependency information so it would not create a new build if the contents of `src/` had changed since the command was previously run. I've replaced it with `make build` which just always creates a new production build.

The upshot of the first change is that running `make dev` will get a dev server running 20-30 seconds faster on a typical laptop if `node_modules/` needs updating.