### PR TITLE
WIP: Open/close basic notebook prototype container

### DIFF
--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -22,6 +22,7 @@ import BucketBarPlugin from './plugin/bucket-bar';
 import CrossFramePlugin from './plugin/cross-frame';
 import DocumentPlugin from './plugin/document';
 import Guest from './guest';
+import Notebook from './notebook';
 import PDFPlugin from './plugin/pdf';
 import PdfSidebar from './pdf-sidebar';
 import Sidebar from './sidebar';
@@ -70,9 +71,11 @@ function init() {
   config.pluginClasses = pluginClasses;
 
   const annotator = new Klass(document.body, config);
+  const notebook = new Notebook(document.body, config);
   appLinkEl.addEventListener('destroy', function () {
     appLinkEl.remove();
     annotator.destroy();
+    notebook.destroy();
   });
 }
 

--- a/src/annotator/notebook.js
+++ b/src/annotator/notebook.js
@@ -1,0 +1,44 @@
+import Delegator from './delegator';
+
+export default class Notebook extends Delegator {
+  constructor(element, config) {
+    super(element, config);
+    // TODO?: handle external container?
+
+    this.container = document.createElement('div');
+    this.container.style.display = 'none';
+    // TODO?: Is there any necessity to handle theme-clean?
+    this.container.className = 'notebook-outer';
+
+    // TODO: this.inner will become this.frame (likely) and will be an iframe
+    this.inner = document.createElement('div');
+    this.inner.className = 'notebook-inner';
+    // TODO: entirely temporary
+    this.inner.onclick = event => {
+      event.stopPropagation();
+      this.publish('hideNotebook');
+    };
+
+    this.container.appendChild(this.inner);
+    this.element.appendChild(this.container);
+
+    this.subscribe('showNotebook', () => this.show());
+    this.subscribe('hideNotebook', () => this.hide());
+    // If the sidebar has opened, get out of the way
+    this.subscribe('sidebarOpened', () => this.hide());
+  }
+
+  show() {
+    // TODO check for iframe initialization
+    this.container.style.display = '';
+  }
+
+  hide() {
+    this.container.style.display = 'none';
+  }
+
+  destroy() {
+    // TBD
+    return;
+  }
+}

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -221,6 +221,14 @@ export default class Sidebar extends Guest {
     this.crossframe.on('showSidebar', () => this.show());
     this.crossframe.on('hideSidebar', () => this.hide());
 
+    // Re-publish the crossframe event so that anything extending Delegator
+    // can subscribe to it (without need for crossframe)
+    this.crossframe.on('showNotebook', () => this.publish('showNotebook'));
+    this.crossframe.on('hideNotebook', () => this.publish('hideNotebook'));
+
+    this.subscribe('showNotebook', () => this.hide());
+    this.subscribe('hideNotebook', () => this.show());
+
     const eventHandlers = [
       [events.LOGIN_REQUESTED, this.onLoginRequest],
       [events.LOGOUT_REQUESTED, this.onLogoutRequest],
@@ -391,6 +399,7 @@ export default class Sidebar extends Guest {
 
   show() {
     this.crossframe.call('sidebarOpened');
+    this.publish('sidebarOpened');
 
     if (this.frame) {
       const width = this.frame.getBoundingClientRect().width;

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -578,19 +578,20 @@ describe('Sidebar', () => {
         sinon.stub(sidebar, 'publish');
         sidebar.show();
         assert.calledOnce(layoutChangeHandlerSpy);
-        assert.calledOnce(sidebar.publish);
         assert.calledWith(
           sidebar.publish,
           'sidebarLayoutChanged',
           sinon.match.any
         );
+        assert.calledWith(sidebar.publish, 'sidebarOpened');
+        assert.calledTwice(sidebar.publish);
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
           expanded: true,
         });
 
         sidebar.hide();
         assert.calledTwice(layoutChangeHandlerSpy);
-        assert.calledTwice(sidebar.publish);
+        assert.calledThrice(sidebar.publish);
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
           expanded: false,
           width: fakeToolbar.getWidth(),

--- a/src/sidebar/components/test/user-menu-test.js
+++ b/src/sidebar/components/test/user-menu-test.js
@@ -10,6 +10,7 @@ import mockImportedComponents from '../../../test-util/mock-imported-components'
 describe('UserMenu', () => {
   let fakeAuth;
   let fakeBridge;
+  let fakeFeatures;
   let fakeIsThirdPartyUser;
   let fakeOnLogout;
   let fakeServiceConfig;
@@ -21,6 +22,7 @@ describe('UserMenu', () => {
       <UserMenu
         auth={fakeAuth}
         bridge={fakeBridge}
+        features={fakeFeatures}
         onLogout={fakeOnLogout}
         serviceUrl={fakeServiceUrl}
         settings={fakeSettings}
@@ -42,6 +44,7 @@ describe('UserMenu', () => {
       username: 'eleanorFishy',
     };
     fakeBridge = { call: sinon.stub() };
+    fakeFeatures = { flagEnabled: sinon.stub().returns(false) };
     fakeIsThirdPartyUser = sinon.stub();
     fakeOnLogout = sinon.stub();
     fakeServiceConfig = sinon.stub();
@@ -179,6 +182,38 @@ describe('UserMenu', () => {
 
       const accountMenuItem = findMenuItem(wrapper, 'Account settings');
       assert.isFalse(accountMenuItem.exists());
+    });
+  });
+
+  describe('open notebook item', () => {
+    context('notebook feature is enabled', () => {
+      it('includes the open notebook item', () => {
+        fakeFeatures.flagEnabled.withArgs('notebook_launch').returns(true);
+        const wrapper = createUserMenu();
+
+        const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
+        assert.isTrue(openNotebookItem.exists());
+      });
+
+      it('triggers a message when open-notebook item is clicked', () => {
+        fakeFeatures.flagEnabled.withArgs('notebook_launch').returns(true);
+        const wrapper = createUserMenu();
+
+        const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
+        openNotebookItem.props().onClick();
+        assert.calledOnce(fakeBridge.call);
+        assert.calledWith(fakeBridge.call, 'showNotebook');
+      });
+    });
+
+    context('notebook feature is not enabled', () => {
+      it('does not include the open notebook item', () => {
+        fakeFeatures.flagEnabled.withArgs('notebook_launch').returns(false);
+        const wrapper = createUserMenu();
+
+        const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
+        assert.isFalse(openNotebookItem.exists());
+      });
     });
   });
 

--- a/src/sidebar/components/user-menu.js
+++ b/src/sidebar/components/user-menu.js
@@ -27,6 +27,7 @@ import SvgIcon from '../../shared/components/svg-icon';
  * @typedef UserMenuProps
  * @prop {AuthState} auth - object representing authenticated user and auth status
  * @prop {() => any} onLogout - onClick callback for the "log out" button
+ * @prop {Object} features - injected service
  * @prop {Object} bridge
  * @prop {ServiceUrlGetter} serviceUrl
  * @prop {MergedConfig} settings
@@ -40,7 +41,7 @@ import SvgIcon from '../../shared/components/svg-icon';
  *
  * @param {UserMenuProps} props
  */
-function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
+function UserMenu({ auth, bridge, features, onLogout, serviceUrl, settings }) {
   const isThirdParty = isThirdPartyUser(auth.userid, settings.authDomain);
   const service = serviceConfig(settings);
 
@@ -50,6 +51,11 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
     !isThirdParty || serviceSupports('onProfileRequestProvided');
   const isLogoutEnabled =
     !isThirdParty || serviceSupports('onLogoutRequestProvided');
+  const isNotebookEnabled = features.flagEnabled('notebook_launch');
+
+  const onSelectNotebook = () => {
+    bridge.call('showNotebook');
+  };
 
   const onProfileSelected = () =>
     isThirdParty && bridge.call(bridgeEvents.PROFILE_REQUESTED);
@@ -86,6 +92,12 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
               href={serviceUrl('account.settings')}
             />
           )}
+          {isNotebookEnabled && (
+            <MenuItem
+              label="Open notebook"
+              onClick={() => onSelectNotebook()}
+            />
+          )}
         </MenuSection>
         {isLogoutEnabled && (
           <MenuSection>
@@ -101,10 +113,11 @@ UserMenu.propTypes = {
   auth: propTypes.object.isRequired,
   onLogout: propTypes.func.isRequired,
   bridge: propTypes.object.isRequired,
+  features: propTypes.object.isRequired,
   serviceUrl: propTypes.func.isRequired,
   settings: propTypes.object.isRequired,
 };
 
-UserMenu.injectedProps = ['bridge', 'serviceUrl', 'settings'];
+UserMenu.injectedProps = ['bridge', 'features', 'serviceUrl', 'settings'];
 
 export default withServices(UserMenu);

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -15,6 +15,7 @@
 @use './components/toolbar';
 @use './bucket-bar';
 @use './highlights';
+@use './notebook';
 
 // Sidebar
 .annotator-frame {

--- a/src/styles/annotator/notebook.scss
+++ b/src/styles/annotator/notebook.scss
@@ -1,0 +1,21 @@
+@use '../variables' as var;
+@use '../mixins/molecules';
+
+.notebook-outer {
+  // TODO: CSS namespace conflicts?
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  padding: var.$layout-space;
+  // Leave explicitly the right amount of room for closed-sidebar affordances
+  padding-right: var.$annotator-toolbar-width + 5px;
+
+  .notebook-inner {
+    box-sizing: border-box;
+    @include molecules.panel;
+    height: 100%;
+  }
+}


### PR DESCRIPTION
This PR adds functionality (behind a feature flag) to open and dismiss the container that will hold the Notebook UI.

To test, make sure you have recent `h` `master` and enabled the `notebook_launch` feature-flag locally.

There should be an additional item in the UserMenu in the client sidebar:

![image](https://user-images.githubusercontent.com/439947/98288132-61a80200-1f74-11eb-862b-f313144d7038.png)

Clicking on that should cause the sidebar to collapse and a full-screen modal-style panel to appear. Click anywhere on that panel to "dismiss the notebook." The sidebar will re-open. Opening the sidebar via the caret icon while the notebook panel is open should also dismiss the notebook panel (for now, anyway; these are all very provisional affordances).
