### PR TITLE
Use `bridge.call` directly instead of injecting `frameSync`

### DIFF
--- a/src/shared/bridge-events.js
+++ b/src/shared/bridge-events.js
@@ -12,6 +12,11 @@ export default {
   FEATURE_FLAGS_UPDATED: 'featureFlagsUpdated',
 
   /**
+   * Focus the annotations indicated by the passed array of $tags
+   */
+  FOCUS_ANNOTATIONS: 'focusAnnotations',
+
+  /**
    * The sidebar is asking the annotator to open the partner site help page.
    */
   HELP_REQUESTED: 'helpRequested',
@@ -37,6 +42,11 @@ export default {
    * The set of annotations was updated.
    */
   PUBLIC_ANNOTATION_COUNT_CHANGED: 'publicAnnotationCountChanged',
+
+  /**
+   * The annotator should scroll to a particular annotation defined by $tag.
+   */
+  SCROLL_TO_ANNOTATION: 'scrollToAnnotation',
 
   /**
    * The sidebar is asking the annotator to do a partner site sign-up.

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -8,7 +8,7 @@ import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
 describe('SidebarContent', () => {
-  let fakeFrameSync;
+  let fakeBridge;
   let fakeLoadAnnotationsService;
   let fakeUseRootThread;
   let fakeStore;
@@ -20,7 +20,7 @@ describe('SidebarContent', () => {
       <SidebarContent
         onLogin={() => null}
         onSignUp={() => null}
-        frameSync={fakeFrameSync}
+        bridge={fakeBridge}
         loadAnnotationsService={fakeLoadAnnotationsService}
         streamer={fakeStreamer}
         {...props}
@@ -28,9 +28,8 @@ describe('SidebarContent', () => {
     );
 
   beforeEach(() => {
-    fakeFrameSync = {
-      focusAnnotations: sinon.stub(),
-      scrollToAnnotation: sinon.stub(),
+    fakeBridge = {
+      call: sinon.stub(),
     };
     fakeLoadAnnotationsService = {
       load: sinon.stub(),
@@ -41,6 +40,7 @@ describe('SidebarContent', () => {
     };
     fakeStore = {
       // actions
+      focusAnnotations: sinon.stub(),
       clearSelection: sinon.stub(),
       selectTab: sinon.stub(),
       // selectors
@@ -119,13 +119,13 @@ describe('SidebarContent', () => {
 
       it('focuses and scrolls to direct-linked annotations once anchored', () => {
         createComponent();
-        assert.calledOnce(fakeFrameSync.scrollToAnnotation);
-        assert.calledWith(fakeFrameSync.scrollToAnnotation, 'myTag');
-        assert.calledOnce(fakeFrameSync.focusAnnotations);
+        assert.calledWith(fakeBridge.call, 'scrollToAnnotation', 'myTag');
         assert.calledWith(
-          fakeFrameSync.focusAnnotations,
+          fakeBridge.call,
+          'focusAnnotations',
           sinon.match(['myTag'])
         );
+        assert.calledWith(fakeStore.focusAnnotations, sinon.match(['myTag']));
       });
 
       it('selects the correct tab for direct-linked annotations once anchored', () => {

--- a/src/sidebar/components/test/thread-card-test.js
+++ b/src/sidebar/components/test/thread-card-test.js
@@ -9,23 +9,23 @@ import mockImportedComponents from '../../../test-util/mock-imported-components'
 
 describe('ThreadCard', () => {
   let fakeDebounce;
-  let fakeFrameSync;
+  let fakeBridge;
   let fakeStore;
   let fakeThread;
 
   function createComponent(props) {
     return mount(
-      <ThreadCard frameSync={fakeFrameSync} thread={fakeThread} {...props} />
+      <ThreadCard bridge={fakeBridge} thread={fakeThread} {...props} />
     );
   }
 
   beforeEach(() => {
     fakeDebounce = sinon.stub().returnsArg(0);
-    fakeFrameSync = {
-      focusAnnotations: sinon.stub(),
-      scrollToAnnotation: sinon.stub(),
+    fakeBridge = {
+      call: sinon.stub(),
     };
     fakeStore = {
+      focusAnnotations: sinon.stub(),
       isAnnotationFocused: sinon.stub().returns(false),
       route: sinon.stub(),
     };
@@ -81,7 +81,7 @@ describe('ThreadCard', () => {
 
       wrapper.find('.thread-card').simulate('click');
 
-      assert.calledWith(fakeFrameSync.scrollToAnnotation, 'myTag');
+      assert.calledWith(fakeBridge.call, 'scrollToAnnotation', 'myTag');
     });
 
     it('focuses the annotation thread when mouse enters', () => {
@@ -89,7 +89,7 @@ describe('ThreadCard', () => {
 
       wrapper.find('.thread-card').simulate('mouseenter');
 
-      assert.calledWith(fakeFrameSync.focusAnnotations, sinon.match(['myTag']));
+      assert.calledWith(fakeStore.focusAnnotations, sinon.match(['myTag']));
     });
 
     it('unfocuses the annotation thread when mouse exits', () => {
@@ -97,7 +97,7 @@ describe('ThreadCard', () => {
 
       wrapper.find('.thread-card').simulate('mouseleave');
 
-      assert.calledWith(fakeFrameSync.focusAnnotations, sinon.match([]));
+      assert.calledWith(fakeStore.focusAnnotations, sinon.match([]));
     });
 
     ['button', 'a'].forEach(tag => {
@@ -113,7 +113,7 @@ describe('ThreadCard', () => {
         wrapper.find('.thread-card').props().onClick({
           target: nodeChild,
         });
-        assert.notCalled(fakeFrameSync.scrollToAnnotation);
+        assert.notCalled(fakeBridge.call);
       });
     });
   });

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -220,26 +220,4 @@ export default function FrameSync(annotationsService, bridge, store) {
     setupSyncToFrame();
     setupSyncFromFrame();
   };
-
-  /**
-   * Focus annotations with the given $tags.
-   *
-   * This is used to indicate the highlight in the document that corresponds to
-   * a given annotation in the sidebar.
-   *
-   * @param {string[]} tags - annotation $tags
-   */
-  this.focusAnnotations = function (tags) {
-    store.focusAnnotations(tags);
-    bridge.call('focusAnnotations', tags);
-  };
-
-  /**
-   * Scroll the frame to the highlight for an annotation with a given tag.
-   *
-   * @param {string} tag
-   */
-  this.scrollToAnnotation = function (tag) {
-    bridge.call('scrollToAnnotation', tag);
-  };
 }

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -390,22 +390,4 @@ describe('sidebar/services/frame-sync', function () {
       assert.calledWith(fakeBridge.call, 'setVisibleHighlights');
     });
   });
-
-  describe('when annotations are focused in the sidebar', () => {
-    it('should update the focused annotations in the store', () => {
-      frameSync.focusAnnotations(['a1', 'a2']);
-      assert.calledWith(
-        fakeStore.focusAnnotations,
-        sinon.match.array.deepEquals(['a1', 'a2'])
-      );
-    });
-    it('notify the host page', () => {
-      frameSync.focusAnnotations([1, 2]);
-      assert.calledWith(
-        fakeBridge.call,
-        'focusAnnotations',
-        sinon.match.array.deepEquals([1, 2])
-      );
-    });
-  });
 });


### PR DESCRIPTION
Clarify `frameSync`'s purpose better by pulling out a couple of methods that were thin wrappers around `bridge.call`.

Note that `frameSync` is not used as an injected service anymore by any components.