### PR TITLE
WIP: POC configuration for Notebook

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -230,7 +230,7 @@ function generateBootScript(manifest, { usingDevServer = false } = {}) {
 
   const defaultNotebookAppUrl = process.env.NOTEBOOK_APP_URL
     ? `${process.env.NOTEBOOK_APP_URL}`
-    : '{current_scheme}://{current_host}:5000/notebook.html';
+    : '{current_scheme}://{current_host}:5000/notebook';
   let defaultAssetRoot;
 
   if (process.env.NODE_ENV === 'production' && !usingDevServer) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -228,6 +228,9 @@ function generateBootScript(manifest, { usingDevServer = false } = {}) {
     ? `${process.env.SIDEBAR_APP_URL}`
     : '{current_scheme}://{current_host}:5000/app.html';
 
+  const defaultNotebookAppUrl = process.env.SIDEBAR_APP_URL
+    ? `${process.env.NOTEBOOK_APP_URL}`
+    : '{current_scheme}://{current_host}:5000/notebook.html';
   let defaultAssetRoot;
 
   if (process.env.NODE_ENV === 'production' && !usingDevServer) {
@@ -239,6 +242,7 @@ function generateBootScript(manifest, { usingDevServer = false } = {}) {
 
   if (isFirstBuild) {
     log(`Sidebar app URL: ${defaultSidebarAppUrl}`);
+    log(`Notebook app URL: ${defaultNotebookAppUrl}`);
     log(`Client asset root URL: ${defaultAssetRoot}`);
     isFirstBuild = false;
   }
@@ -248,6 +252,7 @@ function generateBootScript(manifest, { usingDevServer = false } = {}) {
     .pipe(replace('__MANIFEST__', JSON.stringify(manifest)))
     .pipe(replace('__ASSET_ROOT__', defaultAssetRoot))
     .pipe(replace('__SIDEBAR_APP_URL__', defaultSidebarAppUrl))
+    .pipe(replace('__NOTEBOOK_APP_URL__', defaultNotebookAppUrl))
     // Strip sourcemap link. It will have been invalidated by the previous
     // replacements and the bundle is so small that it isn't really valuable.
     .pipe(replace(/^\/\/# sourceMappingURL=\S+$/m, ''))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -228,7 +228,7 @@ function generateBootScript(manifest, { usingDevServer = false } = {}) {
     ? `${process.env.SIDEBAR_APP_URL}`
     : '{current_scheme}://{current_host}:5000/app.html';
 
-  const defaultNotebookAppUrl = process.env.SIDEBAR_APP_URL
+  const defaultNotebookAppUrl = process.env.NOTEBOOK_APP_URL
     ? `${process.env.NOTEBOOK_APP_URL}`
     : '{current_scheme}://{current_host}:5000/notebook.html';
   let defaultAssetRoot;

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -39,6 +39,7 @@ export default function configFrom(window_) {
     requestConfigFromFrame: settings.hostPageSetting('requestConfigFromFrame'),
     services: settings.hostPageSetting('services'),
     showHighlights: settings.showHighlights,
+    notebookAppUrl: settings.notebookAppUrl,
     sidebarAppUrl: settings.sidebarAppUrl,
     // Subframe identifier given when a frame is being embedded into
     // by a top level client

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -8,6 +8,39 @@ export default function settingsFrom(window_) {
   const configFuncSettings = configFuncSettingsFrom(window_);
 
   /**
+   * Return the href URL of the first notebook link in the given document.
+   *
+   * Return the value of the href attribute of the first
+   * `<link type="application/annotator+html" rel="notebook">` element in the given document.
+   *
+   * This URL is used as the src of the notebook's iframe.
+   *
+   * @return {string} - The URL to use for the notebook's iframe.
+   *
+   * @throws {Error} - If there's no notebook link or the first notebook has
+   *   no href.
+   *
+   */
+  function notebookAppUrl() {
+    const link = window_.document.querySelector(
+      'link[type="application/annotator+html"][rel="notebook"]'
+    );
+
+    if (!link) {
+      throw new Error(
+        'No application/annotator+html (rel="notebook") link in the document'
+      );
+    }
+
+    if (!link.href) {
+      throw new Error(
+        'application/annotator+html (rel="notebook") link has no href'
+      );
+    }
+    return link.href;
+  }
+
+  /**
    * Return the href URL of the first annotator sidebar link in the given document.
    *
    * Return the value of the href attribute of the first
@@ -37,7 +70,6 @@ export default function settingsFrom(window_) {
         'application/annotator+html (rel="sidebar") link has no href'
       );
     }
-
     return link.href;
   }
 
@@ -208,6 +240,9 @@ export default function settingsFrom(window_) {
     },
     get showHighlights() {
       return showHighlights();
+    },
+    get notebookAppUrl() {
+      return notebookAppUrl();
     },
     get sidebarAppUrl() {
       return sidebarAppUrl();

--- a/src/annotator/config/sidebar.js
+++ b/src/annotator/config/sidebar.js
@@ -1,0 +1,41 @@
+/**
+ * Create the JSON-serializable subset of annotator configuration that should
+ * be passed to the sidebar application.
+ */
+export function createSidebarConfig(config) {
+  const sidebarConfig = { ...config };
+
+  // Some config settings are not JSON-stringifiable (e.g. JavaScript
+  // functions) and will be omitted when the config is JSON-stringified.
+  // Add a JSON-stringifiable option for each of these so that the sidebar can
+  // at least know whether the callback functions were provided or not.
+  if (sidebarConfig.services?.length > 0) {
+    const service = sidebarConfig.services[0];
+    if (service.onLoginRequest) {
+      service.onLoginRequestProvided = true;
+    }
+    if (service.onLogoutRequest) {
+      service.onLogoutRequestProvided = true;
+    }
+    if (service.onSignupRequest) {
+      service.onSignupRequestProvided = true;
+    }
+    if (service.onProfileRequest) {
+      service.onProfileRequestProvided = true;
+    }
+    if (service.onHelpRequest) {
+      service.onHelpRequestProvided = true;
+    }
+  }
+
+  // Remove several annotator-only properties.
+  //
+  // nb. We don't currently strip all the annotator-only properties here.
+  // That's OK because validation / filtering happens in the sidebar app itself.
+  // It just results in unnecessary content in the sidebar iframe's URL string.
+  ['notebookAppUrl', 'sidebarAppUrl', 'pluginClasses'].forEach(
+    key => delete sidebarConfig[key]
+  );
+
+  return sidebarConfig;
+}

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -22,6 +22,7 @@ import BucketBarPlugin from './plugin/bucket-bar';
 import CrossFramePlugin from './plugin/cross-frame';
 import DocumentPlugin from './plugin/document';
 import Guest from './guest';
+import Notebook from './notebook';
 import PDFPlugin from './plugin/pdf';
 import PdfSidebar from './pdf-sidebar';
 import Sidebar from './sidebar';
@@ -70,9 +71,11 @@ function init() {
   config.pluginClasses = pluginClasses;
 
   const annotator = new Klass(document.body, config);
+  const notebook = new Notebook(document.body, config);
   appLinkEl.addEventListener('destroy', function () {
     appLinkEl.remove();
     annotator.destroy();
+    notebook.destroy();
   });
 }
 

--- a/src/annotator/notebook.js
+++ b/src/annotator/notebook.js
@@ -1,8 +1,33 @@
 import Delegator from './delegator';
+import { createSidebarConfig } from './config/sidebar';
+
+/**
+ * Create the iframe that will load the sidebar application.
+ *
+ * @return {HTMLIFrameElement}
+ */
+function createNotebookFrame(config) {
+  const sidebarConfig = createSidebarConfig(config);
+  const configParam =
+    'config=' + encodeURIComponent(JSON.stringify(sidebarConfig));
+  const notebookAppSrc = config.notebookAppUrl + '#' + configParam;
+
+  const notebookFrame = document.createElement('iframe');
+
+  // Enable media in annotations to be shown fullscreen
+  notebookFrame.setAttribute('allowfullscreen', '');
+
+  notebookFrame.src = notebookAppSrc;
+  notebookFrame.title = 'Hypothesis annotation notebook';
+  notebookFrame.className = 'notebook-inner';
+
+  return notebookFrame;
+}
 
 export default class Notebook extends Delegator {
   constructor(element, config) {
     super(element, config);
+    this.frame = null;
     // TODO?: handle external container?
 
     this.container = document.createElement('div');
@@ -10,26 +35,22 @@ export default class Notebook extends Delegator {
     // TODO?: Is there any necessity to handle theme-clean?
     this.container.className = 'notebook-outer';
 
-    // TODO: this.inner will become this.frame (likely) and will be an iframe
-    this.inner = document.createElement('div');
-    this.inner.className = 'notebook-inner';
-    // TODO: entirely temporary
-    this.inner.onclick = event => {
-      event.stopPropagation();
-      this.publish('hideNotebook');
-    };
-
-    this.container.appendChild(this.inner);
-    this.element.appendChild(this.container);
-
     this.subscribe('showNotebook', () => this.show());
     this.subscribe('hideNotebook', () => this.hide());
     // If the sidebar has opened, get out of the way
     this.subscribe('sidebarOpened', () => this.hide());
   }
 
+  init() {
+    if (!this.frame) {
+      this.frame = createNotebookFrame(this.options);
+      this.container.appendChild(this.frame);
+      this.element.appendChild(this.container);
+    }
+  }
+
   show() {
-    // TODO check for iframe initialization
+    this.init();
     this.container.style.display = '';
   }
 

--- a/src/annotator/notebook.js
+++ b/src/annotator/notebook.js
@@ -1,0 +1,44 @@
+import Delegator from './delegator';
+
+export default class Notebook extends Delegator {
+  constructor(element, config) {
+    super(element, config);
+    // TODO?: handle external container?
+
+    this.container = document.createElement('div');
+    this.container.style.display = 'none';
+    // TODO?: Is there any necessity to handle theme-clean?
+    this.container.className = 'notebook-outer';
+
+    // TODO: this.inner will become this.frame (likely) and will be an iframe
+    this.inner = document.createElement('div');
+    this.inner.className = 'notebook-inner';
+    // TODO: entirely temporary
+    this.inner.onclick = event => {
+      event.stopPropagation();
+      this.publish('hideNotebook');
+    };
+
+    this.container.appendChild(this.inner);
+    this.element.appendChild(this.container);
+
+    this.subscribe('showNotebook', () => this.show());
+    this.subscribe('hideNotebook', () => this.hide());
+    // If the sidebar has opened, get out of the way
+    this.subscribe('sidebarOpened', () => this.hide());
+  }
+
+  show() {
+    // TODO check for iframe initialization
+    this.container.style.display = '';
+  }
+
+  hide() {
+    this.container.style.display = 'none';
+  }
+
+  destroy() {
+    // TBD
+    return;
+  }
+}

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -221,6 +221,14 @@ export default class Sidebar extends Guest {
     this.crossframe.on('showSidebar', () => this.show());
     this.crossframe.on('hideSidebar', () => this.hide());
 
+    // Re-publish the crossframe event so that anything extending Delegator
+    // can subscribe to it (without need for crossframe)
+    this.crossframe.on('showNotebook', () => this.publish('showNotebook'));
+    this.crossframe.on('hideNotebook', () => this.publish('hideNotebook'));
+
+    this.subscribe('showNotebook', () => this.hide());
+    this.subscribe('hideNotebook', () => this.show());
+
     const eventHandlers = [
       [events.LOGIN_REQUESTED, this.onLoginRequest],
       [events.LOGOUT_REQUESTED, this.onLogoutRequest],
@@ -391,6 +399,7 @@ export default class Sidebar extends Guest {
 
   show() {
     this.crossframe.call('sidebarOpened');
+    this.publish('sidebarOpened');
 
     if (this.frame) {
       const width = this.frame.getBoundingClientRect().width;

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -2,6 +2,7 @@ import Hammer from 'hammerjs';
 
 import annotationCounts from './annotation-counts';
 import sidebarTrigger from './sidebar-trigger';
+import { createSidebarConfig } from './config/sidebar';
 import events from '../shared/bridge-events';
 import features from './features';
 
@@ -23,46 +24,6 @@ const defaultConfig = {
     container: '.annotator-frame',
   },
 };
-
-/**
- * Create the JSON-serializable subset of annotator configuration that should
- * be passed to the sidebar application.
- */
-function createSidebarConfig(config) {
-  const sidebarConfig = { ...config };
-
-  // Some config settings are not JSON-stringifiable (e.g. JavaScript
-  // functions) and will be omitted when the config is JSON-stringified.
-  // Add a JSON-stringifiable option for each of these so that the sidebar can
-  // at least know whether the callback functions were provided or not.
-  if (sidebarConfig.services?.length > 0) {
-    const service = sidebarConfig.services[0];
-    if (service.onLoginRequest) {
-      service.onLoginRequestProvided = true;
-    }
-    if (service.onLogoutRequest) {
-      service.onLogoutRequestProvided = true;
-    }
-    if (service.onSignupRequest) {
-      service.onSignupRequestProvided = true;
-    }
-    if (service.onProfileRequest) {
-      service.onProfileRequestProvided = true;
-    }
-    if (service.onHelpRequest) {
-      service.onHelpRequestProvided = true;
-    }
-  }
-
-  // Remove several annotator-only properties.
-  //
-  // nb. We don't currently strip all the annotator-only properties here.
-  // That's OK because validation / filtering happens in the sidebar app itself.
-  // It just results in unnecessary content in the sidebar iframe's URL string.
-  ['sidebarAppUrl', 'pluginClasses'].forEach(key => delete sidebarConfig[key]);
-
-  return sidebarConfig;
-}
 
 /**
  * Create the iframe that will load the sidebar application.

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -578,19 +578,20 @@ describe('Sidebar', () => {
         sinon.stub(sidebar, 'publish');
         sidebar.show();
         assert.calledOnce(layoutChangeHandlerSpy);
-        assert.calledOnce(sidebar.publish);
         assert.calledWith(
           sidebar.publish,
           'sidebarLayoutChanged',
           sinon.match.any
         );
+        assert.calledWith(sidebar.publish, 'sidebarOpened');
+        assert.calledTwice(sidebar.publish);
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
           expanded: true,
         });
 
         sidebar.hide();
         assert.calledTwice(layoutChangeHandlerSpy);
-        assert.calledTwice(sidebar.publish);
+        assert.calledThrice(sidebar.publish);
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
           expanded: false,
           width: fakeToolbar.getWidth(),

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -14,6 +14,7 @@ const commonPolyfills = [
 /**
  * @typedef Config
  * @prop {string} assetRoot - The root URL to which URLs in `manifest` are relative
+ * @prop {string} notebookAppUrl - The URL of the notebook's HTML page
  * @prop {string} sidebarAppUrl - The URL of the sidebar's HTML page
  * @prop {Object.<string,string>} manifest -
  *   A mapping from canonical asset path to cache-busted asset path
@@ -93,6 +94,15 @@ function bootHypothesisClient(doc, config) {
   sidebarUrl.href = config.sidebarAppUrl;
   sidebarUrl.type = 'application/annotator+html';
   doc.head.appendChild(sidebarUrl);
+
+  // Register the URL of the notebook app which the Hypothesis client should load.
+  // The <link> tag is also used by browser extensions etc. to detect the
+  // presence of the Hypothesis notebook on the page.
+  const notebookUrl = doc.createElement('link');
+  notebookUrl.rel = 'notebook';
+  notebookUrl.href = config.notebookAppUrl;
+  notebookUrl.type = 'application/annotator+html';
+  doc.head.appendChild(notebookUrl);
 
   // Register the URL of the annotation client which is currently being used to drive
   // annotation interactions.

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -21,6 +21,9 @@ if (isBrowserSupported()) {
     assetRoot: processUrlTemplate(settings.assetRoot || '__ASSET_ROOT__'),
     // @ts-ignore - `__MANIFEST__` is injected by the build script
     manifest: __MANIFEST__,
+    notebookAppUrl: processUrlTemplate(
+      settings.notebookAppUrl || '__NOTEBOOK_APP_URL__'
+    ),
     sidebarAppUrl: processUrlTemplate(
       settings.sidebarAppUrl || '__SIDEBAR_APP_URL__'
     ),

--- a/src/shared/bridge-events.js
+++ b/src/shared/bridge-events.js
@@ -12,6 +12,11 @@ export default {
   FEATURE_FLAGS_UPDATED: 'featureFlagsUpdated',
 
   /**
+   * Focus the annotations indicated by the passed array of $tags
+   */
+  FOCUS_ANNOTATIONS: 'focusAnnotations',
+
+  /**
    * The sidebar is asking the annotator to open the partner site help page.
    */
   HELP_REQUESTED: 'helpRequested',
@@ -37,6 +42,11 @@ export default {
    * The set of annotations was updated.
    */
   PUBLIC_ANNOTATION_COUNT_CHANGED: 'publicAnnotationCountChanged',
+
+  /**
+   * The annotator should scroll to a particular annotation defined by $tag.
+   */
+  SCROLL_TO_ANNOTATION: 'scrollToAnnotation',
 
   /**
    * The sidebar is asking the annotator to do a partner site sign-up.

--- a/src/sidebar/components/test/sidebar-content-test.js
+++ b/src/sidebar/components/test/sidebar-content-test.js
@@ -8,7 +8,7 @@ import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
 describe('SidebarContent', () => {
-  let fakeFrameSync;
+  let fakeBridge;
   let fakeLoadAnnotationsService;
   let fakeUseRootThread;
   let fakeStore;
@@ -20,7 +20,7 @@ describe('SidebarContent', () => {
       <SidebarContent
         onLogin={() => null}
         onSignUp={() => null}
-        frameSync={fakeFrameSync}
+        bridge={fakeBridge}
         loadAnnotationsService={fakeLoadAnnotationsService}
         streamer={fakeStreamer}
         {...props}
@@ -28,9 +28,8 @@ describe('SidebarContent', () => {
     );
 
   beforeEach(() => {
-    fakeFrameSync = {
-      focusAnnotations: sinon.stub(),
-      scrollToAnnotation: sinon.stub(),
+    fakeBridge = {
+      call: sinon.stub(),
     };
     fakeLoadAnnotationsService = {
       load: sinon.stub(),
@@ -41,6 +40,7 @@ describe('SidebarContent', () => {
     };
     fakeStore = {
       // actions
+      focusAnnotations: sinon.stub(),
       clearSelection: sinon.stub(),
       selectTab: sinon.stub(),
       // selectors
@@ -119,13 +119,13 @@ describe('SidebarContent', () => {
 
       it('focuses and scrolls to direct-linked annotations once anchored', () => {
         createComponent();
-        assert.calledOnce(fakeFrameSync.scrollToAnnotation);
-        assert.calledWith(fakeFrameSync.scrollToAnnotation, 'myTag');
-        assert.calledOnce(fakeFrameSync.focusAnnotations);
+        assert.calledWith(fakeBridge.call, 'scrollToAnnotation', 'myTag');
         assert.calledWith(
-          fakeFrameSync.focusAnnotations,
+          fakeBridge.call,
+          'focusAnnotations',
           sinon.match(['myTag'])
         );
+        assert.calledWith(fakeStore.focusAnnotations, sinon.match(['myTag']));
       });
 
       it('selects the correct tab for direct-linked annotations once anchored', () => {

--- a/src/sidebar/components/test/thread-card-test.js
+++ b/src/sidebar/components/test/thread-card-test.js
@@ -9,23 +9,23 @@ import mockImportedComponents from '../../../test-util/mock-imported-components'
 
 describe('ThreadCard', () => {
   let fakeDebounce;
-  let fakeFrameSync;
+  let fakeBridge;
   let fakeStore;
   let fakeThread;
 
   function createComponent(props) {
     return mount(
-      <ThreadCard frameSync={fakeFrameSync} thread={fakeThread} {...props} />
+      <ThreadCard bridge={fakeBridge} thread={fakeThread} {...props} />
     );
   }
 
   beforeEach(() => {
     fakeDebounce = sinon.stub().returnsArg(0);
-    fakeFrameSync = {
-      focusAnnotations: sinon.stub(),
-      scrollToAnnotation: sinon.stub(),
+    fakeBridge = {
+      call: sinon.stub(),
     };
     fakeStore = {
+      focusAnnotations: sinon.stub(),
       isAnnotationFocused: sinon.stub().returns(false),
       route: sinon.stub(),
     };
@@ -81,7 +81,7 @@ describe('ThreadCard', () => {
 
       wrapper.find('.thread-card').simulate('click');
 
-      assert.calledWith(fakeFrameSync.scrollToAnnotation, 'myTag');
+      assert.calledWith(fakeBridge.call, 'scrollToAnnotation', 'myTag');
     });
 
     it('focuses the annotation thread when mouse enters', () => {
@@ -89,7 +89,7 @@ describe('ThreadCard', () => {
 
       wrapper.find('.thread-card').simulate('mouseenter');
 
-      assert.calledWith(fakeFrameSync.focusAnnotations, sinon.match(['myTag']));
+      assert.calledWith(fakeStore.focusAnnotations, sinon.match(['myTag']));
     });
 
     it('unfocuses the annotation thread when mouse exits', () => {
@@ -97,7 +97,7 @@ describe('ThreadCard', () => {
 
       wrapper.find('.thread-card').simulate('mouseleave');
 
-      assert.calledWith(fakeFrameSync.focusAnnotations, sinon.match([]));
+      assert.calledWith(fakeStore.focusAnnotations, sinon.match([]));
     });
 
     ['button', 'a'].forEach(tag => {
@@ -113,7 +113,7 @@ describe('ThreadCard', () => {
         wrapper.find('.thread-card').props().onClick({
           target: nodeChild,
         });
-        assert.notCalled(fakeFrameSync.scrollToAnnotation);
+        assert.notCalled(fakeBridge.call);
       });
     });
   });

--- a/src/sidebar/components/test/user-menu-test.js
+++ b/src/sidebar/components/test/user-menu-test.js
@@ -10,6 +10,7 @@ import mockImportedComponents from '../../../test-util/mock-imported-components'
 describe('UserMenu', () => {
   let fakeAuth;
   let fakeBridge;
+  let fakeFeatures;
   let fakeIsThirdPartyUser;
   let fakeOnLogout;
   let fakeServiceConfig;
@@ -21,6 +22,7 @@ describe('UserMenu', () => {
       <UserMenu
         auth={fakeAuth}
         bridge={fakeBridge}
+        features={fakeFeatures}
         onLogout={fakeOnLogout}
         serviceUrl={fakeServiceUrl}
         settings={fakeSettings}
@@ -42,6 +44,7 @@ describe('UserMenu', () => {
       username: 'eleanorFishy',
     };
     fakeBridge = { call: sinon.stub() };
+    fakeFeatures = { flagEnabled: sinon.stub().returns(false) };
     fakeIsThirdPartyUser = sinon.stub();
     fakeOnLogout = sinon.stub();
     fakeServiceConfig = sinon.stub();
@@ -179,6 +182,38 @@ describe('UserMenu', () => {
 
       const accountMenuItem = findMenuItem(wrapper, 'Account settings');
       assert.isFalse(accountMenuItem.exists());
+    });
+  });
+
+  describe('open notebook item', () => {
+    context('notebook feature is enabled', () => {
+      it('includes the open notebook item', () => {
+        fakeFeatures.flagEnabled.withArgs('notebook_launch').returns(true);
+        const wrapper = createUserMenu();
+
+        const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
+        assert.isTrue(openNotebookItem.exists());
+      });
+
+      it('triggers a message when open-notebook item is clicked', () => {
+        fakeFeatures.flagEnabled.withArgs('notebook_launch').returns(true);
+        const wrapper = createUserMenu();
+
+        const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
+        openNotebookItem.props().onClick();
+        assert.calledOnce(fakeBridge.call);
+        assert.calledWith(fakeBridge.call, 'showNotebook');
+      });
+    });
+
+    context('notebook feature is not enabled', () => {
+      it('does not include the open notebook item', () => {
+        fakeFeatures.flagEnabled.withArgs('notebook_launch').returns(false);
+        const wrapper = createUserMenu();
+
+        const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
+        assert.isFalse(openNotebookItem.exists());
+      });
     });
   });
 

--- a/src/sidebar/components/user-menu.js
+++ b/src/sidebar/components/user-menu.js
@@ -27,6 +27,7 @@ import SvgIcon from '../../shared/components/svg-icon';
  * @typedef UserMenuProps
  * @prop {AuthState} auth - object representing authenticated user and auth status
  * @prop {() => any} onLogout - onClick callback for the "log out" button
+ * @prop {Object} features - injected service
  * @prop {Object} bridge
  * @prop {ServiceUrlGetter} serviceUrl
  * @prop {MergedConfig} settings
@@ -40,7 +41,7 @@ import SvgIcon from '../../shared/components/svg-icon';
  *
  * @param {UserMenuProps} props
  */
-function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
+function UserMenu({ auth, bridge, features, onLogout, serviceUrl, settings }) {
   const isThirdParty = isThirdPartyUser(auth.userid, settings.authDomain);
   const service = serviceConfig(settings);
 
@@ -50,6 +51,11 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
     !isThirdParty || serviceSupports('onProfileRequestProvided');
   const isLogoutEnabled =
     !isThirdParty || serviceSupports('onLogoutRequestProvided');
+  const isNotebookEnabled = features.flagEnabled('notebook_launch');
+
+  const onSelectNotebook = () => {
+    bridge.call('showNotebook');
+  };
 
   const onProfileSelected = () =>
     isThirdParty && bridge.call(bridgeEvents.PROFILE_REQUESTED);
@@ -86,6 +92,12 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
               href={serviceUrl('account.settings')}
             />
           )}
+          {isNotebookEnabled && (
+            <MenuItem
+              label="Open notebook"
+              onClick={() => onSelectNotebook()}
+            />
+          )}
         </MenuSection>
         {isLogoutEnabled && (
           <MenuSection>
@@ -101,10 +113,11 @@ UserMenu.propTypes = {
   auth: propTypes.object.isRequired,
   onLogout: propTypes.func.isRequired,
   bridge: propTypes.object.isRequired,
+  features: propTypes.object.isRequired,
   serviceUrl: propTypes.func.isRequired,
   settings: propTypes.object.isRequired,
 };
 
-UserMenu.injectedProps = ['bridge', 'serviceUrl', 'settings'];
+UserMenu.injectedProps = ['bridge', 'features', 'serviceUrl', 'settings'];
 
 export default withServices(UserMenu);

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -38,11 +38,6 @@ if (appConfig.googleAnalytics) {
   addAnalytics(appConfig.googleAnalytics);
 }
 
-const isSidebar = !(
-  window.location.pathname.startsWith('/stream') ||
-  window.location.pathname.startsWith('/a/')
-);
-
 // Install Preact renderer options to work around browser quirks
 rendererOptions.setupBrowserFixes();
 
@@ -91,9 +86,9 @@ function autosave(autosaveService) {
 }
 
 // @inject
-function setupFrameSync(frameSync) {
+function setupFrameSync(frameSync, isSidebar) {
   if (isSidebar) {
-    frameSync.connect();
+    frameSync.connect(true);
   }
 }
 
@@ -139,6 +134,12 @@ import { Injector } from '../shared/injector';
 
 function startApp(config) {
   const container = new Injector();
+
+  const isSidebar = !(
+    window.location.pathname.startsWith('/stream') ||
+    window.location.pathname.startsWith('/a/') ||
+    window.location.pathname.startsWith('/notebook')
+  );
 
   // Register services.
   container

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -220,26 +220,4 @@ export default function FrameSync(annotationsService, bridge, store) {
     setupSyncToFrame();
     setupSyncFromFrame();
   };
-
-  /**
-   * Focus annotations with the given $tags.
-   *
-   * This is used to indicate the highlight in the document that corresponds to
-   * a given annotation in the sidebar.
-   *
-   * @param {string[]} tags - annotation $tags
-   */
-  this.focusAnnotations = function (tags) {
-    store.focusAnnotations(tags);
-    bridge.call('focusAnnotations', tags);
-  };
-
-  /**
-   * Scroll the frame to the highlight for an annotation with a given tag.
-   *
-   * @param {string} tag
-   */
-  this.scrollToAnnotation = function (tag) {
-    bridge.call('scrollToAnnotation', tag);
-  };
 }

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -15,10 +15,14 @@ export default function router($window, store) {
     const params = queryString.parse($window.location.search);
 
     let route;
+
     switch (pathSegments[0]) {
       case 'a':
         route = 'annotation';
         params.id = pathSegments[1] || '';
+        break;
+      case 'notebook.html':
+        route = 'stream';
         break;
       case 'stream':
         route = 'stream';

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -21,7 +21,7 @@ export default function router($window, store) {
         route = 'annotation';
         params.id = pathSegments[1] || '';
         break;
-      case 'notebook.html':
+      case 'notebook':
         route = 'stream';
         break;
       case 'stream':

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -390,22 +390,4 @@ describe('sidebar/services/frame-sync', function () {
       assert.calledWith(fakeBridge.call, 'setVisibleHighlights');
     });
   });
-
-  describe('when annotations are focused in the sidebar', () => {
-    it('should update the focused annotations in the store', () => {
-      frameSync.focusAnnotations(['a1', 'a2']);
-      assert.calledWith(
-        fakeStore.focusAnnotations,
-        sinon.match.array.deepEquals(['a1', 'a2'])
-      );
-    });
-    it('notify the host page', () => {
-      frameSync.focusAnnotations([1, 2]);
-      assert.calledWith(
-        fakeBridge.call,
-        'focusAnnotations',
-        sinon.match.array.deepEquals([1, 2])
-      );
-    });
-  });
 });

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -15,6 +15,7 @@
 @use './components/toolbar';
 @use './bucket-bar';
 @use './highlights';
+@use './notebook';
 
 // Sidebar
 .annotator-frame {

--- a/src/styles/annotator/notebook.scss
+++ b/src/styles/annotator/notebook.scss
@@ -16,6 +16,7 @@
   .notebook-inner {
     box-sizing: border-box;
     @include molecules.panel;
+    width: 100%;
     height: 100%;
   }
 }

--- a/src/styles/annotator/notebook.scss
+++ b/src/styles/annotator/notebook.scss
@@ -1,0 +1,21 @@
+@use '../variables' as var;
+@use '../mixins/molecules';
+
+.notebook-outer {
+  // TODO: CSS namespace conflicts?
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  padding: var.$layout-space;
+  // Leave explicitly the right amount of room for closed-sidebar affordances
+  padding-right: var.$annotator-toolbar-width + 5px;
+
+  .notebook-inner {
+    box-sizing: border-box;
+    @include molecules.panel;
+    height: 100%;
+  }
+}


### PR DESCRIPTION
This chunk of work makes it possible to open a "notebook" view that contains a stream view via a menu item in the user menu.

This WIP PR depends on:

* https://github.com/hypothesis/h/pull/6393 to make the app available at `/notebook.html` on `h`
* https://github.com/hypothesis/client/pull/2706 (although it doesn't really _have_ to in the current direction we're going here)

This PR adds a bunch of configuration incantations to make it possible to populate a Notebook iFrame with the source of `/notebook.html` on `h`, similar to how it is done for the sidebar application (at `/app.html`). It adds the needed support for ENV vars to the build scripts and support in `annotator/config`. 

If we decide to use this kind of approach, we'd also need to update a couple of docs in the `developer/docs` directory and update the `Jenkinsfile` to set this appropriately in QA and prod. As such, this feature would only work locally as it's implemented in this branch.

To try it out:

* Make sure you have the new route available on `h` by either pulling the PR branch from https://github.com/hypothesis/h/pull/6393 or updating your `h` `master` once that has landed
* Enable the `notebook_launch` feature flag in your local `h`
* You should see an "Open notebook" item in the user menu

What to expect:

* You should see a full-sized modal pop up and load the contents of the sidebar stream view.
* You should see the closed-sidebar affordances at the right
* Re-opening the sidebar should cause the Notebook view to go away

What not to expect (yet):

* A more friendly way to close the Notebook view
* Robust styling of the Notebook panel (e.g. if you scroll down, it will be off-screen)
* While you can interact with the annotations shown in the stream view, changes to an annotation in the stream view that also shows up in the sidebar may be out of sync (i.e. the sidebar won't show the changes until a reload for now). This is expected for now.

I think there are some opportunities here to DRY things out a little more, but wanted to get eyes on the general approach first.

Once we get this (or some variant of it) landed, I think it satisfies the intent of the basic, high-level prototype by giving us a "canvas" on which to build the actual Notebook view/component, so I'll go ahead and say:

Fixes https://github.com/hypothesis/product-backlog/issues/1153