### PR TITLE
Change `highlightRange` to accept an ordinary DOM Range

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -4,7 +4,6 @@ import Delegator from './delegator';
 import { Adder } from './adder';
 
 import * as htmlAnchoring from './anchoring/html';
-import { sniff } from './anchoring/range';
 import {
   getHighlightsContainingNode,
   highlightRange,
@@ -414,10 +413,8 @@ export default class Guest extends Delegator {
       if (!anchor.range) {
         return anchor;
       }
-      const range = sniff(anchor.range);
-      const normedRange = range.normalize(root);
       const highlights = /** @type {AnnotationHighlight[]} */ (highlightRange(
-        normedRange
+        anchor.range
       ));
       highlights.forEach(h => {
         h._annotation = anchor.annotation;

--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -154,6 +154,13 @@ function drawHighlightsAbovePdfCanvas(highlightEl) {
  * @return {Text[]}
  */
 function wholeTextNodesInRange(range) {
+  if (range.collapsed) {
+    // Exit early for an empty range to avoid an edge case that breaks the algorithm
+    // below. Splitting a text node at the start of an empty range can leave the
+    // range ending in the left part rather than the right part.
+    return [];
+  }
+
   const textNodes = [];
 
   forEachNodeInRange(range, node => {
@@ -163,10 +170,12 @@ function wholeTextNodesInRange(range) {
     let text = /** @type {Text} */ (node);
 
     if (text === range.startContainer && range.startOffset > 0) {
+      // Split `text` where the range starts, setting it to the part in the range.
       text = text.splitText(range.startOffset);
     }
 
     if (text === range.endContainer && range.endOffset < text.data.length) {
+      // Split `text` where the range ends, leaving it as the part in the range.
       text.splitText(range.endOffset);
     }
 

--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -145,9 +145,9 @@ function drawHighlightsAbovePdfCanvas(highlightEl) {
  */
 
 /**
- * Return the complete text nodes inside `range`.
+ * Return text nodes which are entirely inside `range`.
  *
- * If a range starts or ends part-way through a text node, the nodes are split
+ * If a range starts or ends part-way through a text node, the node is split
  * and the part inside the range is returned.
  *
  * @param {Range} range
@@ -189,7 +189,7 @@ function wholeTextNodesInRange(range) {
  * Wraps the DOM Nodes within the provided range with a highlight
  * element of the specified class and returns the highlight Elements.
  *
- * @param {Range} range - Range to be highlighted.
+ * @param {Range} range - Range to be highlighted
  * @param {string} cssClass - A CSS class to use for the highlight
  * @return {HighlightElement[]} - Elements wrapping text in `normedRange` to add a highlight effect
  */
@@ -223,10 +223,10 @@ export function highlightRange(range, cssClass = 'hypothesis-highlight') {
   // Filter out text node spans that consist only of white space. This avoids
   // inserting highlight elements in places that can only contain a restricted
   // subset of nodes such as table rows and lists.
-  const white = /^\s*$/;
+  const whitespace = /^\s*$/;
   textNodeSpans = textNodeSpans.filter(span =>
     // Check for at least one text node with non-space content.
-    span.some(node => !white.test(node.nodeValue))
+    span.some(node => !whitespace.test(node.nodeValue))
   );
 
   // Wrap each text node span with a `<hypothesis-highlight>` element.

--- a/src/annotator/range-util.js
+++ b/src/annotator/range-util.js
@@ -14,41 +14,36 @@ export function isSelectionBackwards(selection) {
 }
 
 /**
- * Returns true if `node` lies within a range.
- *
- * This is a simplified version of `Range.isPointInRange()` for compatibility
- * with IE.
+ * Returns true if any part of `node` lies within `range`.
  *
  * @param {Range} range
  * @param {Node} node
  */
 export function isNodeInRange(range, node) {
-  if (node === range.startContainer || node === range.endContainer) {
-    return true;
+  try {
+    const length = node.nodeValue?.length ?? node.childNodes.length;
+    return (
+      // Check start of node is before end of range.
+      range.comparePoint(node, 0) <= 0 &&
+      // Check end of node is after start of range.
+      range.comparePoint(node, length) >= 0
+    );
+  } catch (e) {
+    // `comparePoint` may fail if the `range` and `node` do not share a common
+    // ancestor or `node` is a doctype.
+    return false;
   }
-
-  const nodeRange = /** @type {Document} */ (node.ownerDocument).createRange();
-  nodeRange.selectNode(node);
-  const isAtOrBeforeStart =
-    range.compareBoundaryPoints(Range.START_TO_START, nodeRange) <= 0;
-  const isAtOrAfterEnd =
-    range.compareBoundaryPoints(Range.END_TO_END, nodeRange) >= 0;
-  nodeRange.detach();
-  return isAtOrBeforeStart && isAtOrAfterEnd;
 }
 
 /**
- * Iterate over all Node(s) in `range` in document order and invoke `callback`
- * for each of them.
+ * Iterate over all Node(s) which overlap `range` in document order and invoke
+ * `callback` for each of them.
  *
  * @param {Range} range
  * @param {(n: Node) => any} callback
  */
 function forEachNodeInRange(range, callback) {
   const root = range.commonAncestorContainer;
-
-  // The `whatToShow`, `filter` and `expandEntityReferences` arguments are
-  // mandatory in IE although optional according to the spec.
   const nodeIter = /** @type {Document} */ (root.ownerDocument).createNodeIterator(
     root,
     NodeFilter.SHOW_ALL
@@ -56,7 +51,6 @@ function forEachNodeInRange(range, callback) {
 
   let currentNode;
   while ((currentNode = nodeIter.nextNode())) {
-    // eslint-disable-line no-cond-assign
     if (isNodeInRange(range, currentNode)) {
       callback(currentNode);
     }

--- a/src/annotator/range-util.js
+++ b/src/annotator/range-util.js
@@ -42,7 +42,7 @@ export function isNodeInRange(range, node) {
  * @param {Range} range
  * @param {(n: Node) => any} callback
  */
-function forEachNodeInRange(range, callback) {
+export function forEachNodeInRange(range, callback) {
   const root = range.commonAncestorContainer;
   const nodeIter = /** @type {Document} */ (root.ownerDocument).createNodeIterator(
     root,

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -90,6 +90,49 @@ describe('annotator/highlighter', () => {
       assert.isTrue(result[0].classList.contains('hypothesis-highlight'));
     });
 
+    const testText = 'one two three';
+
+    [
+      // Range starting at the start of text node and ending in the middle.
+      [0, 5],
+      // Range starting in the middle of text node and ending in the middle.
+      [4, 7],
+      // Range starting in the middle of text node and ending at the end.
+      [4, testText.length],
+      // Empty ranges.
+      [0, 0],
+      [5, 5],
+      [testText.length, testText.length],
+    ].forEach(([startPos, endPos]) => {
+      it('splits text nodes when only part of one should be highlighted', () => {
+        const el = document.createElement('span');
+        el.append(testText);
+
+        const range = new Range();
+        range.setStart(el.firstChild, startPos);
+        range.setEnd(el.firstChild, endPos);
+        const result = highlightRange(range);
+
+        const highlightedText = result.reduce(
+          (str, el) => str + el.textContent,
+          ''
+        );
+        assert.equal(highlightedText, testText.slice(startPos, endPos));
+        assert.equal(el.textContent, testText);
+      });
+    });
+
+    it('handles a range with no text nodes', () => {
+      const el = document.createElement('span');
+
+      const range = new Range();
+      range.setStart(el, 0);
+      range.setEnd(el, 0);
+      const highlights = highlightRange(range);
+
+      assert.deepEqual(highlights, []);
+    });
+
     it('wraps multiple text nodes which are not adjacent', () => {
       const strings = ['hello', ' Brave ', ' New ', ' World'];
       const textNodes = strings.map(s => document.createTextNode(s));

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -1,7 +1,5 @@
 import { createElement, render } from 'preact';
 
-import { NormalizedRange } from '../anchoring/range';
-
 import {
   getBoundingClientRect,
   getHighlightsContainingNode,
@@ -54,12 +52,10 @@ function PdfPage({ showPlaceholder = false }) {
  */
 function highlightPdfRange(pageContainer) {
   const textSpan = pageContainer.querySelector('.testText');
-  const r = new NormalizedRange({
-    commonAncestor: textSpan,
-    start: textSpan.childNodes[0],
-    end: textSpan.childNodes[0],
-  });
-  return highlightRange(r);
+  const range = new Range();
+  range.setStartBefore(textSpan.childNodes[0]);
+  range.setEndAfter(textSpan.childNodes[0]);
+  return highlightRange(range);
 }
 
 /**
@@ -79,16 +75,14 @@ function createPdfPageWithHighlight() {
 describe('annotator/highlighter', () => {
   describe('highlightRange', () => {
     it('wraps a highlight span around the given range', () => {
-      const txt = document.createTextNode('test highlight span');
+      const text = document.createTextNode('test highlight span');
       const el = document.createElement('span');
-      el.appendChild(txt);
-      const r = new NormalizedRange({
-        commonAncestor: el,
-        start: txt,
-        end: txt,
-      });
+      el.appendChild(text);
+      const range = new Range();
+      range.setStartBefore(text);
+      range.setEndAfter(text);
 
-      const result = highlightRange(r);
+      const result = highlightRange(range);
 
       assert.equal(result.length, 1);
       assert.strictEqual(el.childNodes[0], result[0]);
@@ -107,12 +101,10 @@ describe('annotator/highlighter', () => {
         el.append(childEl);
       });
 
-      const r = new NormalizedRange({
-        commonAncestor: el,
-        start: textNodes[0],
-        end: textNodes[textNodes.length - 1],
-      });
-      const result = highlightRange(r);
+      const range = new Range();
+      range.setStartBefore(textNodes[0]);
+      range.setEndAfter(textNodes[textNodes.length - 1]);
+      const result = highlightRange(range);
 
       assert.equal(result.length, textNodes.length);
       result.forEach((highlight, i) => {
@@ -128,12 +120,10 @@ describe('annotator/highlighter', () => {
       const el = document.createElement('span');
       textNodes.forEach(n => el.append(n));
 
-      const r = new NormalizedRange({
-        commonAncestor: el,
-        start: textNodes[0],
-        end: textNodes[textNodes.length - 1],
-      });
-      const result = highlightRange(r);
+      const range = new Range();
+      range.setStartBefore(textNodes[0]);
+      range.setEndAfter(textNodes[textNodes.length - 1]);
+      const result = highlightRange(range);
 
       assert.equal(result.length, 1);
       assert.equal(el.childNodes.length, 1);
@@ -149,13 +139,11 @@ describe('annotator/highlighter', () => {
       el.appendChild(txt);
       el.appendChild(blank);
       el.appendChild(txt2);
-      const r = new NormalizedRange({
-        commonAncestor: el,
-        start: txt,
-        end: txt2,
-      });
 
-      const result = highlightRange(r);
+      const range = new Range();
+      range.setStartBefore(txt);
+      range.setEndAfter(txt2);
+      const result = highlightRange(range);
 
       assert.equal(result.length, 1);
       assert.equal(result[0].textContent, 'one two');
@@ -166,13 +154,11 @@ describe('annotator/highlighter', () => {
       el.appendChild(document.createTextNode(' '));
       el.appendChild(document.createTextNode(''));
       el.appendChild(document.createTextNode('   '));
-      const r = new NormalizedRange({
-        commonAncestor: el,
-        start: el.childNodes[0],
-        end: el.childNodes[2],
-      });
+      const range = new Range();
+      range.setStartBefore(el.childNodes[0]);
+      range.setEndAfter(el.childNodes[2]);
 
-      const result = highlightRange(r);
+      const result = highlightRange(range);
 
       assert.equal(result.length, 0);
     });
@@ -348,11 +334,9 @@ describe('annotator/highlighter', () => {
     for (let i = 0; i < 3; i++) {
       const span = document.createElement('span');
       span.textContent = 'Test text';
-      const range = new NormalizedRange({
-        commonAncestor: span,
-        start: span.childNodes[0],
-        end: span.childNodes[0],
-      });
+      const range = new Range();
+      range.setStartBefore(span.childNodes[0]);
+      range.setEndAfter(span.childNodes[0]);
       root.appendChild(span);
       highlights.push(...highlightRange(range));
     }
@@ -430,12 +414,12 @@ describe('annotator/highlighter', () => {
   });
 
   describe('getHighlightsContainingNode', () => {
-    const makeRange = (start, end = start) =>
-      new NormalizedRange({
-        commonAncestor: start.parentNode,
-        start,
-        end,
-      });
+    const makeRange = (start, end = start) => {
+      const range = new Range();
+      range.setStartBefore(start);
+      range.setEndAfter(end);
+      return range;
+    };
 
     it('returns all the highlights containing the node', () => {
       const root = document.createElement('div');

--- a/src/annotator/test/range-util-test.js
+++ b/src/annotator/test/range-util-test.js
@@ -44,25 +44,38 @@ describe('annotator.range-util', function () {
     selection.addRange(range);
   }
 
-  describe('#isNodeInRange', function () {
-    it('is true for a node in the range', function () {
-      const rng = createRange(testNode, 0, 1);
-      assert.equal(rangeUtil.isNodeInRange(rng, testNode.firstChild), true);
+  describe('#isNodeInRange', () => {
+    it('returns true for a node in the range', () => {
+      const range = createRange(testNode, 0, 1);
+      assert.isTrue(rangeUtil.isNodeInRange(range, testNode.firstChild));
     });
 
-    it('is false for a node before the range', function () {
+    it('returns false for a node before the range', () => {
       testNode.innerHTML = 'one <b>two</b> three';
-      const rng = createRange(testNode, 1, 2);
-      assert.equal(rangeUtil.isNodeInRange(rng, testNode.firstChild), false);
+      const range = createRange(testNode, 1, 2);
+      assert.isFalse(rangeUtil.isNodeInRange(range, testNode.firstChild));
     });
 
-    it('is false for a node after the range', function () {
+    it('returns false for a node after the range', () => {
       testNode.innerHTML = 'one <b>two</b> three';
-      const rng = createRange(testNode, 1, 2);
-      assert.equal(
-        rangeUtil.isNodeInRange(rng, testNode.childNodes.item(2)),
-        false
+      const range = createRange(testNode, 1, 2);
+      assert.isFalse(
+        rangeUtil.isNodeInRange(range, testNode.childNodes.item(2))
       );
+    });
+
+    it('can test a node with no parent', () => {
+      const node = document.createElement('span');
+      const range = new Range();
+      range.setStart(node, 0);
+      range.setEnd(node, 0);
+      assert.isTrue(rangeUtil.isNodeInRange(range, node));
+    });
+
+    it('can test a node against an empty range', () => {
+      const node = document.createElement('span');
+      const range = new Range();
+      assert.isFalse(rangeUtil.isNodeInRange(range, node));
     });
   });
 


### PR DESCRIPTION
This PR is preparation for some upcoming changes to fix bugs related to overlapping highlights (possibly the original cause of https://github.com/hypothesis/product-backlog/issues/954, but see also https://github.com/hypothesis/client/issues/2326, https://github.com/hypothesis/h/issues/5997). The issue in these cases relates to the fact that the client first anchors annotations to ranges and then adds highlights. The process of inserting the highlights for an anchor modifies the DOM and that can alter the ranges of other anchors. My plan to resolve this is to change the representation of anchored ranges to one which is robust to the kinds of DOM modification made by highlighting [1]. This new representation of an anchor's range will be _resolved_ to a concrete DOM Range just before the highlights are inserted.

As a preliminary step, this PR changes the `highlightRange` function which wraps the contents of an anchor's range with highlights to work with an ordinary DOM `Range` instead of the `NormalizedRange` wrapper class inherited from annotator. In the process I found a bug in one of the helper functions in `range-util.js`, `isNodeInRange`, and rewrote the implementation and added some extra tests to fix that.

----

[1] Specifically, my plan is to represent anchored ranges as a pair of (element, textPosition) points representing the start and end of the range, where `element` refers to the first non-highlight parent element of the range's start/end point and `textPosition` is the character offset in `element`'s text content. If the DOM structure is changed in between anchoring and inserting highlights for a particular annotation, it will still be possible to resolve this representation to the same content, as long as the text content hasn't changed.



