### PR TITLE
Change anchored range representation to fix overlapping highlight issues

### DIFF
--- a/src/annotator/anchoring/test/text-range-test.js
+++ b/src/annotator/anchoring/test/text-range-test.js
@@ -45,43 +45,35 @@ describe('annotator/anchoring/text-range', () => {
     });
 
     describe('#resolve', () => {
-      [
-        // Position at the start of the element.
-        {
-          getPosition: () => 0,
-          getExpected: () => {
-            const firstNode = textNodes(container)[0];
-            return { node: firstNode, offset: 0 };
-          },
-        },
+      it('resolves text position at start of element to correct node and offset', () => {
+        const pos = new TextPosition(container, 0);
 
-        // Position in the middle of the element.
-        {
-          getPosition: () => container.textContent.indexOf('is a'),
-          getExpected: () => ({
-            node: container.querySelector('p').firstChild,
-            offset: 'This '.length,
-          }),
-        },
+        const { node, offset } = pos.resolve();
 
-        // Position at the end of the element.
-        {
-          getPosition: () => container.textContent.length,
-          getExpected: () => {
-            const lastText = textNodes(container).slice(-1)[0];
-            return { node: lastText, offset: lastText.data.length };
-          },
-        },
-      ].forEach(({ getPosition, getExpected }) => {
-        it('resolves text position to correct node and offset', () => {
-          const pos = new TextPosition(container, getPosition());
+        assertNodesEqual(node, textNodes(container)[0]);
+        assert.equal(offset, 0);
+      });
 
-          const { node, offset } = pos.resolve();
-          const { node: expectedNode, offset: expectedOffset } = getExpected();
+      it('resolves text position in middle of element to correct node and offset', () => {
+        const pos = new TextPosition(
+          container,
+          container.textContent.indexOf('is a')
+        );
 
-          assertNodesEqual(node, expectedNode);
-          assert.equal(offset, expectedOffset);
-        });
+        const { node, offset } = pos.resolve();
+
+        assertNodesEqual(node, container.querySelector('p').firstChild);
+        assert.equal(offset, 'This '.length);
+      });
+
+      it('resolves text position at end of element to correct node and offset', () => {
+        const pos = new TextPosition(container, container.textContent.length);
+
+        const { node, offset } = pos.resolve();
+
+        const lastTextNode = textNodes(container).slice(-1)[0];
+        assertNodesEqual(node, lastTextNode);
+        assert.equal(offset, lastTextNode.data.length);
       });
 
       it('throws if offset exceeds current text content length', () => {

--- a/src/annotator/anchoring/test/text-range-test.js
+++ b/src/annotator/anchoring/test/text-range-test.js
@@ -1,0 +1,205 @@
+import { TextPosition, TextRange } from '../text-range';
+
+import { assertNodesEqual } from '../../../test-util/compare-dom';
+
+const html = `
+<main>
+  <article>
+    <p>This is <b>a</b> <i>test paragraph</i>.</p>
+    <!-- Comment in middle of HTML -->
+    <pre>Some content</pre>
+  </article>
+</main>
+`;
+
+/**
+ * Return all the `Text` descendants of `node`
+ *
+ * @param {Node} node
+ * @return {Text[]}
+ */
+function textNodes(node) {
+  const nodes = [];
+  const iter = document.createNodeIterator(node, NodeFilter.SHOW_TEXT);
+  let current;
+  while ((current = iter.nextNode())) {
+    nodes.push(current);
+  }
+  return nodes;
+}
+
+describe('annotator/anchoring/text-range', () => {
+  describe('TextPosition', () => {
+    let container;
+    before(() => {
+      container = document.createElement('div');
+      container.innerHTML = html;
+    });
+
+    describe('#constructor', () => {
+      it('throws if offset is negative', () => {
+        assert.throws(() => {
+          new TextPosition(container, -1);
+        }, 'Offset is invalid');
+      });
+    });
+
+    describe('#resolve', () => {
+      [
+        // Position at the start of the element.
+        {
+          getPosition: () => 0,
+          getExpected: () => {
+            const firstNode = textNodes(container)[0];
+            return { node: firstNode, offset: 0 };
+          },
+        },
+
+        // Position in the middle of the element.
+        {
+          getPosition: () => container.textContent.indexOf('is a'),
+          getExpected: () => ({
+            node: container.querySelector('p').firstChild,
+            offset: 'This '.length,
+          }),
+        },
+
+        // Position at the end of the element.
+        {
+          getPosition: () => container.textContent.length,
+          getExpected: () => {
+            const lastText = textNodes(container).slice(-1)[0];
+            return { node: lastText, offset: lastText.data.length };
+          },
+        },
+      ].forEach(({ getPosition, getExpected }) => {
+        it('resolves text position to correct node and offset', () => {
+          const pos = new TextPosition(container, getPosition());
+
+          const { node, offset } = pos.resolve();
+          const { node: expectedNode, offset: expectedOffset } = getExpected();
+
+          assertNodesEqual(node, expectedNode);
+          assert.equal(offset, expectedOffset);
+        });
+      });
+
+      it('throws if offset exceeds current text content length', () => {
+        const pos = new TextPosition(
+          container,
+          container.textContent.length + 1
+        );
+
+        assert.throws(() => {
+          pos.resolve();
+        }, 'Offset exceeds text length');
+      });
+    });
+
+    describe('fromPoint', () => {
+      it('returns TextPosition for offset in Text node', () => {
+        const el = document.createElement('div');
+        el.append('One', 'two', 'three');
+
+        const pos = TextPosition.fromPoint(el.childNodes[1], 0);
+
+        assertNodesEqual(pos.element, el);
+        assert.equal(pos.offset, el.textContent.indexOf('two'));
+      });
+
+      it('returns TextPosition for offset in Element node', () => {
+        const el = document.createElement('div');
+        el.innerHTML = '<b>foo</b><i>bar</i><u>baz</u>';
+
+        const pos = TextPosition.fromPoint(el, 1);
+
+        assertNodesEqual(pos.element, el);
+        assert.equal(pos.offset, el.textContent.indexOf('bar'));
+      });
+
+      it('throws if node is not a Text or Element', () => {
+        assert.throws(() => {
+          TextPosition.fromPoint(document, 0);
+        }, 'Point is not in an element or text node');
+      });
+
+      it('throws if Text node has no parent', () => {
+        assert.throws(() => {
+          TextPosition.fromPoint(document.createTextNode('foo'), 0);
+        }, 'Text node has no parent');
+      });
+
+      it('throws if node is a Text node and offset is invalid', () => {
+        const container = document.createElement('div');
+        container.textContent = 'This is a test';
+        assert.throws(() => {
+          TextPosition.fromPoint(container.firstChild, 100);
+        }, 'Text node offset is out of range');
+      });
+
+      it('throws if Node is an Element node and offset is invalid', () => {
+        const container = document.createElement('div');
+        const child = document.createElement('span');
+        container.appendChild(child);
+        assert.throws(() => {
+          TextPosition.fromPoint(container, 2);
+        }, 'Child node offset is out of range');
+      });
+    });
+  });
+
+  describe('TextRange', () => {
+    describe('#toRange', () => {
+      it('resolves start and end points', () => {
+        const el = document.createElement('div');
+        el.textContent = 'one two three';
+
+        const textRange = new TextRange(
+          new TextPosition(el, 4),
+          new TextPosition(el, 7)
+        );
+        const range = textRange.toRange();
+
+        assert.equal(range.toString(), 'two');
+      });
+
+      it('throws if start or end points cannot be resolved', () => {
+        const el = document.createElement('div');
+        el.textContent = 'one two three';
+
+        const textRange = new TextRange(
+          new TextPosition(el, 4),
+          new TextPosition(el, 20)
+        );
+
+        assert.throws(() => {
+          textRange.toRange();
+        }, 'Offset exceeds text length');
+      });
+    });
+
+    describe('fromRange', () => {
+      it('sets `start` and `end` points of range', () => {
+        const el = document.createElement('div');
+        el.textContent = 'one two three';
+
+        const range = new Range();
+        range.selectNodeContents(el);
+
+        const textRange = TextRange.fromRange(range);
+
+        assert.equal(textRange.start.element, el);
+        assert.equal(textRange.start.offset, 0);
+        assert.equal(textRange.end.element, el);
+        assert.equal(textRange.end.offset, el.textContent.length);
+      });
+
+      it('throws if start or end points cannot be converted to a position', () => {
+        const range = new Range();
+        assert.throws(() => {
+          TextRange.fromRange(range);
+        }, 'Point is not in an element or text node');
+      });
+    });
+  });
+});

--- a/src/annotator/anchoring/text-range.js
+++ b/src/annotator/anchoring/text-range.js
@@ -3,7 +3,7 @@
  *
  * @param {Node} node
  */
-function previousSiblingTextLength(node) {
+function previousSiblingsTextLength(node) {
   let sibling = node.previousSibling;
   let length = 0;
   while (sibling) {
@@ -59,6 +59,8 @@ export class TextPosition {
     let textNode;
     let length = 0;
 
+    // Find the text node containing the `this.offset`th character from the start
+    // of `this.element`.
     while ((currentNode = nodeIter.nextNode())) {
       textNode = /** @type {Text} */ (currentNode);
       if (length + textNode.data.length > this.offset) {
@@ -67,6 +69,7 @@ export class TextPosition {
       length += textNode.data.length;
     }
 
+    // Boundary case.
     if (textNode && length === this.offset) {
       return { node: textNode, offset: textNode.data.length };
     }
@@ -92,8 +95,8 @@ export class TextPosition {
           throw new Error('Text node has no parent');
         }
 
-        // Get the offset to the start of the parent element.
-        const textOffset = previousSiblingTextLength(node) + offset;
+        // Get the offset from the start of the parent element.
+        const textOffset = previousSiblingsTextLength(node) + offset;
 
         return new TextPosition(node.parentElement, textOffset);
       }
@@ -153,7 +156,7 @@ export class TextRange {
   }
 
   /**
-   * Convert an exiting DOM `Range` to a `TextRange`
+   * Convert an existing DOM `Range` to a `TextRange`
    *
    * @param {Range} range
    * @return {TextRange}

--- a/src/annotator/anchoring/text-range.js
+++ b/src/annotator/anchoring/text-range.js
@@ -1,0 +1,169 @@
+/**
+ * Return the total length of the text of all previous siblings of `node`.
+ *
+ * @param {Node} node
+ */
+function previousSiblingTextLength(node) {
+  let sibling = node.previousSibling;
+  let length = 0;
+  while (sibling) {
+    length += sibling.textContent?.length ?? 0;
+    sibling = sibling.previousSibling;
+  }
+  return length;
+}
+
+/**
+ * Represents an offset within the text content of an element.
+ *
+ * This position can be resolved to a specific descendant node in the current
+ * DOM subtree of the element using the `resolve` method.
+ */
+export class TextPosition {
+  /**
+   * Construct a `TextPosition` that refers to the text position `offset` within
+   * the text content of `element`.
+   *
+   * @param {Element} element
+   * @param {number} offset
+   */
+  constructor(element, offset) {
+    if (offset < 0) {
+      throw new Error('Offset is invalid');
+    }
+
+    this.element = element;
+
+    /** Character offset from the start of the element's `textContent`. */
+    this.offset = offset;
+  }
+
+  /**
+   * Resolve the position to a specific text node and offset within that node.
+   *
+   * Throws if `this.offset` exceeds the length of the element's text or if
+   * the element has no text. Offsets at the boundary between two nodes are
+   * resolved to the start of the node that begins at the boundary.
+   *
+   * @return {{ node: Text, offset: number }}
+   * @throws {RangeError}
+   */
+  resolve() {
+    const root = this.element;
+    const nodeIter = /** @type {Document} */ (root.ownerDocument).createNodeIterator(
+      root,
+      NodeFilter.SHOW_TEXT
+    );
+
+    let currentNode;
+    let textNode;
+    let length = 0;
+
+    while ((currentNode = nodeIter.nextNode())) {
+      textNode = /** @type {Text} */ (currentNode);
+      if (length + textNode.data.length > this.offset) {
+        return { node: textNode, offset: this.offset - length };
+      }
+      length += textNode.data.length;
+    }
+
+    if (textNode && length === this.offset) {
+      return { node: textNode, offset: textNode.data.length };
+    }
+
+    throw new RangeError('Offset exceeds text length');
+  }
+
+  /**
+   * Construct a `TextPosition` representing the range start or end point (node, offset).
+   *
+   * @param {Node} node
+   * @param {number} offset
+   * @return {TextPosition}
+   */
+  static fromPoint(node, offset) {
+    switch (node.nodeType) {
+      case Node.TEXT_NODE: {
+        if (offset < 0 || offset > /** @type {Text} */ (node).data.length) {
+          throw new Error('Text node offset is out of range');
+        }
+
+        if (!node.parentElement) {
+          throw new Error('Text node has no parent');
+        }
+
+        // Get the offset to the start of the parent element.
+        const textOffset = previousSiblingTextLength(node) + offset;
+
+        return new TextPosition(node.parentElement, textOffset);
+      }
+      case Node.ELEMENT_NODE: {
+        if (offset < 0 || offset > node.childNodes.length) {
+          throw new Error('Child node offset is out of range');
+        }
+
+        // Get the text length before the `offset`th child of element.
+        let textOffset = 0;
+        for (let i = 0; i < offset; i++) {
+          textOffset += node.childNodes[i].textContent?.length ?? 0;
+        }
+
+        return new TextPosition(/** @type {Element} */ (node), textOffset);
+      }
+      default:
+        throw new Error('Point is not in an element or text node');
+    }
+  }
+}
+
+/**
+ * Represents a region of a document as a (start, end) pair of `TextPosition` points.
+ *
+ * Representing a range in this way allows for changes in the DOM content of the
+ * range which don't affect its text content, without affecting the text content
+ * of the range itself.
+ */
+export class TextRange {
+  /**
+   * Construct an immutable `TextRange` from a `start` and `end` point.
+   *
+   * @param {TextPosition} start
+   * @param {TextPosition} end
+   */
+  constructor(start, end) {
+    this.start = start;
+    this.end = end;
+  }
+
+  /**
+   * Resolve the `TextRange` to a DOM range.
+   *
+   * May throw if the `start` or `end` positions cannot be resolved to a range.
+   *
+   * @return {Range}
+   */
+  toRange() {
+    const { node: startNode, offset: startOffset } = this.start.resolve();
+    const { node: endNode, offset: endOffset } = this.end.resolve();
+
+    const range = new Range();
+    range.setStart(startNode, startOffset);
+    range.setEnd(endNode, endOffset);
+    return range;
+  }
+
+  /**
+   * Convert an exiting DOM `Range` to a `TextRange`
+   *
+   * @param {Range} range
+   * @return {TextRange}
+   */
+  static fromRange(range) {
+    const start = TextPosition.fromPoint(
+      range.startContainer,
+      range.startOffset
+    );
+    const end = TextPosition.fromPoint(range.endContainer, range.endOffset);
+    return new TextRange(start, end);
+  }
+}

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -24,6 +24,20 @@ class FakePlugin extends Delegator {
 }
 FakePlugin.instance = null;
 
+class FakeTextRange {
+  constructor(range) {
+    this.range = range;
+  }
+
+  toRange() {
+    return this.range;
+  }
+
+  static fromRange(range) {
+    return new FakeTextRange(range);
+  }
+}
+
 // A little helper which returns a promise that resolves after a timeout
 const timeoutPromise = (millis = 0) =>
   new Promise(resolve => setTimeout(resolve, millis));
@@ -86,6 +100,9 @@ describe('Guest', () => {
     $imports.$mock({
       './adder': { Adder: FakeAdder },
       './anchoring/html': htmlAnchoring,
+      './anchoring/text-range': {
+        TextRange: FakeTextRange,
+      },
       './highlighter': highlighter,
       './range-util': rangeUtil,
       './selection-observer': {
@@ -262,55 +279,82 @@ describe('Guest', () => {
       it('scrolls to the anchor with the matching tag', () => {
         const highlight = document.createElement('span');
         const guest = createGuest();
+        const fakeRange = sinon.stub();
         guest.anchors = [
-          { annotation: { $tag: 'tag1' }, highlights: [highlight] },
+          {
+            annotation: { $tag: 'tag1' },
+            highlights: [highlight],
+            range: new FakeTextRange(fakeRange),
+          },
         ];
+
         emitGuestEvent('scrollToAnnotation', 'tag1');
+
         assert.called(scrollIntoView);
         assert.calledWith(scrollIntoView, highlight);
       });
 
-      context('when dispatching the "scrolltorange" event', () => {
-        it('emits with the range', () => {
-          const highlight = document.createElement('span');
-          const guest = createGuest();
-          const fakeRange = sinon.stub();
-          guest.anchors = [
-            {
-              annotation: { $tag: 'tag1' },
-              highlights: [highlight],
-              range: fakeRange,
-            },
-          ];
+      it('emits a "scrolltorange" DOM event', () => {
+        const highlight = document.createElement('span');
+        const guest = createGuest();
+        const fakeRange = sinon.stub();
+        guest.anchors = [
+          {
+            annotation: { $tag: 'tag1' },
+            highlights: [highlight],
+            range: new FakeTextRange(fakeRange),
+          },
+        ];
 
-          return new Promise(resolve => {
-            guest.element.addEventListener('scrolltorange', event => {
-              assert.equal(event.detail, fakeRange);
-              resolve();
-            });
-
-            emitGuestEvent('scrollToAnnotation', 'tag1');
+        return new Promise(resolve => {
+          guest.element.addEventListener('scrolltorange', event => {
+            assert.equal(event.detail, fakeRange);
+            resolve();
           });
-        });
 
-        it('allows the default scroll behaviour to be prevented', () => {
-          const highlight = document.createElement('span');
-          const guest = createGuest();
-          const fakeRange = sinon.stub();
-          guest.anchors = [
-            {
-              annotation: { $tag: 'tag1' },
-              highlights: [highlight],
-              range: fakeRange,
-            },
-          ];
-
-          guest.element.addEventListener('scrolltorange', event =>
-            event.preventDefault()
-          );
           emitGuestEvent('scrollToAnnotation', 'tag1');
-          assert.notCalled(scrollIntoView);
         });
+      });
+
+      it('allows the default scroll behaviour to be prevented', () => {
+        const highlight = document.createElement('span');
+        const guest = createGuest();
+        const fakeRange = sinon.stub();
+        guest.anchors = [
+          {
+            annotation: { $tag: 'tag1' },
+            highlights: [highlight],
+            range: new FakeTextRange(fakeRange),
+          },
+        ];
+        guest.element.addEventListener('scrolltorange', event =>
+          event.preventDefault()
+        );
+
+        emitGuestEvent('scrollToAnnotation', 'tag1');
+
+        assert.notCalled(scrollIntoView);
+      });
+
+      it("does nothing if the anchor's range cannot be resolved", () => {
+        const highlight = document.createElement('span');
+        const guest = createGuest();
+        guest.anchors = [
+          {
+            annotation: { $tag: 'tag1' },
+            highlights: [highlight],
+            range: {
+              toRange: sinon.stub().throws(new Error('Something went wrong')),
+            },
+          },
+        ];
+        const eventEmitted = sinon.stub();
+        guest.element.addEventListener('scrolltorange', eventEmitted);
+
+        emitGuestEvent('scrollToAnnotation', 'tag1');
+
+        assert.notCalled(eventEmitted);
+        assert.notCalled(scrollIntoView);
       });
     });
 
@@ -763,7 +807,7 @@ describe('Guest', () => {
         assert.equal(guest.anchors.length, 1);
         assert.strictEqual(guest.anchors[0].annotation, annotation);
         assert.strictEqual(guest.anchors[0].target, target);
-        assert.strictEqual(guest.anchors[0].range, range);
+        assert.strictEqual(guest.anchors[0].range.toRange(), range);
         assert.strictEqual(guest.anchors[0].highlights, highlights);
       });
     });

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -74,16 +74,12 @@ describe('anchoring', function () {
       quotes: ["This has not been a scientist's war"],
     },
     {
-      // Known failure with nested annotations that are anchored via quotes
-      // or positions. See https://github.com/hypothesis/h/pull/3313 and
-      // https://github.com/hypothesis/h/issues/3278
       tag: 'nested quotes',
       quotes: [
         "This has not been a scientist's war;" +
           ' it has been a war in which all have had a part',
         "scientist's war",
       ],
-      expectFail: true,
     },
   ].forEach(testCase => {
     it(`should highlight ${testCase.tag} when annotations are loaded`, () => {

--- a/src/test-util/compare-dom.js
+++ b/src/test-util/compare-dom.js
@@ -1,0 +1,48 @@
+/**
+ * Utilities for comparing DOM nodes and trees etc. in tests or producing
+ * representations of them.
+ */
+
+/**
+ * Elide `text` if it exceeds `length`.
+ *
+ * @param {string} text
+ * @param {number} length
+ */
+function elide(text, length) {
+  return text.length < length ? text : text.slice(0, length) + '...';
+}
+
+/**
+ * Return a string representation of a node for use in asserts and debugging.
+ *
+ * @param {Node} node
+ */
+export function nodeToString(node) {
+  switch (node.nodeType) {
+    case Node.TEXT_NODE:
+      return `[Text: ${elide(node.data, 100)}]`;
+    case Node.ELEMENT_NODE:
+      return `[${node.localName} element: ${elide(node.innerHTML, 400)}]`;
+    case Node.DOCUMENT_NODE:
+      return '[Document]';
+    case Node.CDATA_SECTION_NODE:
+      return '[CData Node]';
+    default:
+      return '[Other node]';
+  }
+}
+
+/**
+ * Compare two nodes and throw if not equal.
+ *
+ * This produces more readable output than using `assert.equal(actual, expected)`
+ * if there is a mismatch.
+ */
+export function assertNodesEqual(actual, expected) {
+  if (actual !== expected) {
+    throw new Error(
+      `Expected ${nodeToString(actual)} to equal ${nodeToString(expected)}`
+    );
+  }
+}

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -3,6 +3,22 @@
  */
 
 /**
+ * Object representing a region of a document that an annotation
+ * has been anchored to.
+ *
+ * This representation of anchor ranges allows for certain document mutations
+ * in between anchoring an annotation and later making use of the anchored range,
+ * such as inserting highlights for other anchors. Compared to the initial
+ * anchoring of serialized selectors, resolving these ranges should be a
+ * cheap operation.
+ *
+ * @typedef AbstractRange
+ * @prop {() => Range} toRange -
+ *   Resolve the abstract range to a concrete live `Range`. The implementation
+ *   may or may not return the same `Range` each time.
+ */
+
+/**
  * @typedef {import("./api").Selector} Selector
  * @typedef {import("./api").Target} Target
  */
@@ -30,8 +46,10 @@
  *
  * @typedef Anchor
  * @prop {AnnotationData} annotation
- * @prop {HTMLElement[]} [highlights]
- * @prop {Range} [range]
+ * @prop {HTMLElement[]} [highlights] -
+ *   The HTML elements that create the highlight for this annotation.
+ * @prop {AbstractRange} [range] -
+ *   Region of the document that this annotation's selectors were resolved to.
  * @prop {Target} target
  */
 


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/2719**~~
~~**Depends on https://github.com/hypothesis/client/pull/2724**~~

## Problem overview

This PR fixes some long-standing issues with anchoring and highlighting sets of annotations that refer to overlapping parts of the document. The problem arises from the way that anchoring annotations and inserting highlights works. When annotations are loaded, what happens in the "annotator" part of the code is:

1. Annotator receives a batch of annotations from the sidebar
2. The annotations' selectors are anchored in the document, which produces one or more DOM `Range`s.
3. Once an annotation is anchored, its text is wrapped in `<hypothesis-highlight>` elements to create a highlight effect and enable interactions with the highlights

When annotations overlap, step 3 can invalidate or "corrupt" the ranges produced in step 2. As a result the wrong text or no text gets highlighted.

It is important to note that the interleaving of steps (2) and (3) can vary depending on the document type. In an HTML document step 2 will typically complete for all annotations in a batch before step 3. In a PDF however, some annotations might complete anchoring and be highlighted while others are still being anchored.

## Solution

This PR resolves the problem by introducing a new representation of the anchored region of the document which replaces the `range` property of an anchor. This representation is an "abstract range", which is some object with a `toRange` method that can be called to _resolve_ the region to a real `Range` just before it is needed. In this PR the abstract range is always an instance of a new `TextRange` class which represents a range as a start/end pair of (element, character offset) points.

The first commit adds the `TextRange` and `TextPosition` classes in `src/annotator/text-range.js`. The second commit modifies the `Guest` class in `src/annotator/guest.js` to make use of this when anchoring and inserting highlights as well as altering the definition of an `Anchor` in `src/types/annotator.js`. To understand this I think it will be easiest to start with the changes in `src/types/annotator.js`, then look at the changes in `guest.js` and finally the `TextRange` class and associated tests.

When writing the tests I found that `assert.equal(domNode, otherDomNode)` could produce very verbose output if the check failed. I added some utilities in `src/test-util/compare-dom.js` that do comparisons and produce more readable output if a failure happens.

Fixes https://github.com/hypothesis/h/issues/3278 (already closed, but that's because Jon implemented a workaround outside of the client, the problem still exists in the client itself)
Fixes https://github.com/hypothesis/client/issues/2326
Fixes https://github.com/hypothesis/h/issues/5997
Fixes https://github.com/hypothesis/product-backlog/issues/954 (the original issue described no longer reproduces, but I'm fairly sure it would have been caused by what is fixed here)

## Manual testing

**First test case:**

1. Go to the client's dev server at http://localhost:3000 and remove any existing highlights
2. Highlight the text "Hypothesis client's development server" in the sentence "Welcome to the Hypothesis client's development server" at the top of the page.
3. Highlight the text "development server" within the text highlighted in step 2
4. Reload the page

Expected result: The text "Hypothesis client's development server" is highlighted with "development server" in a darker shade. Hovering over annotation cards should highlight the correct part of the text.
Actual result on master: The text "Hypothesis client's development server" is highlighted in a uniform shade. Hovering over either annotation card highlights the full "Hypothesis client's development server" text.

**Second test case:**

Same as the first test case above, but reverse steps (2) and (3). The expected result should be the same. The actual result in this case will likely be correct on master and should definitely be correct on this branch.

## Alternate solutions

There are a couple of alternative solutions that have been tried in the past that I want to mention, to explain why I'm taking a different approach here:

1. Change the ordering of anchoring steps to enforce that each annotation is anchored and highlighted before moving onto the next. This would avoid the DOM changing in between anchoring and highlighting for a given annotation. The main problem with this is that anchoring involves async steps and in PDFs at least, annotations may not anchor in-order. Forcing annotations to be anchored and highlighted in-order can slow the process down significantly.

2. Sort the annotations by quote length so that the shortest annotations are anchored first. Jon Udell found that this appeared to fix the problem in one of his prototypes a while back, but we haven't carefully proven that it will always work. Also, there is the problem of annotations taking varying amounts of time to anchor mentioned in (1), so sorting PRs by quote length doesn't ensure they will anchor in that order.

## Follow-up work

There is some potential follow-up work that might happen in future:

- There is some duplication between what the `TextRange` class introduced in this PR does and the existing `TextPositionSelector` anchoring. We could try to unify the two later
- There is currently no attempt  to implement any caching in `TextRange.toRange`. That could be added later.