### PR TITLE
Don't try to resolve sidebar app URL when booting sidebar app

### DIFF
--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -12,7 +12,14 @@ const commonPolyfills = [
 ];
 
 /**
- * @typedef Config
+ * @typedef SidebarAppConfig
+ * @prop {string} assetRoot - The root URL to which URLs in `manifest` are relative
+ * @prop {Object.<string,string>} manifest -
+ *   A mapping from canonical asset path to cache-busted asset path
+ */
+
+/**
+ * @typedef AnnotatorConfig
  * @prop {string} assetRoot - The root URL to which URLs in `manifest` are relative
  * @prop {string} sidebarAppUrl - The URL of the sidebar's HTML page
  * @prop {Object.<string,string>} manifest -
@@ -48,7 +55,7 @@ function injectScript(doc, src) {
 
 /**
  * @param {Document} doc
- * @param {Config} config
+ * @param {SidebarAppConfig|AnnotatorConfig} config
  * @param {string[]} assets
  */
 function injectAssets(doc, config, assets) {
@@ -74,9 +81,9 @@ function polyfillBundles(needed) {
  * This triggers loading of the necessary resources for the client
  *
  * @param {Document} doc
- * @param {Config} config
+ * @param {AnnotatorConfig} config
  */
-function bootHypothesisClient(doc, config) {
+export function bootHypothesisClient(doc, config) {
   // Detect presence of Hypothesis in the page
   const appLinkEl = doc.querySelector(
     'link[type="application/annotator+html"]'
@@ -120,9 +127,9 @@ function bootHypothesisClient(doc, config) {
  * Bootstrap the sidebar application which displays annotations.
  *
  * @param {Document} doc
- * @param {Config} config
+ * @param {SidebarAppConfig} config
  */
-function bootSidebarApp(doc, config) {
+export function bootSidebarApp(doc, config) {
   const polyfills = polyfillBundles(commonPolyfills);
 
   injectAssets(doc, config, [
@@ -139,19 +146,4 @@ function bootSidebarApp(doc, config) {
     'styles/katex.min.css',
     'styles/sidebar.css',
   ]);
-}
-
-/**
- * Initialize the "sidebar" application if run in the sidebar's stub HTML
- * page or the "annotator" application otherwise.
- *
- * @param {Document} document_
- * @param {Config} config
- */
-export default function boot(document_, config) {
-  if (document_.querySelector('hypothesis-app')) {
-    bootSidebarApp(document_, config);
-  } else {
-    bootHypothesisClient(document_, config);
-  }
 }

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -11,20 +11,26 @@
 
 import { parseJsonConfig } from './parse-json-config';
 
-import boot from './boot';
+import { bootHypothesisClient, bootSidebarApp } from './boot';
 import processUrlTemplate from './url-template';
 import { isBrowserSupported } from './browser-check';
 
 if (isBrowserSupported()) {
   const settings = parseJsonConfig(document);
-  boot(document, {
-    assetRoot: processUrlTemplate(settings.assetRoot || '__ASSET_ROOT__'),
-    // @ts-ignore - `__MANIFEST__` is injected by the build script
-    manifest: __MANIFEST__,
-    sidebarAppUrl: processUrlTemplate(
+  const assetRoot = processUrlTemplate(settings.assetRoot || '__ASSET_ROOT__');
+  // @ts-ignore - `__MANIFEST__` is injected by the build script
+  const manifest = __MANIFEST__;
+
+  // Check whether this is the sidebar app (indicated by the presence of a
+  // `<hypothesis-app>` element) and load the appropriate part of the client.
+  if (document.querySelector('hypothesis-app')) {
+    bootSidebarApp(document, { assetRoot, manifest });
+  } else {
+    const sidebarAppUrl = processUrlTemplate(
       settings.sidebarAppUrl || '__SIDEBAR_APP_URL__'
-    ),
-  });
+    );
+    bootHypothesisClient(document, { assetRoot, manifest, sidebarAppUrl });
+  }
 } else {
   // Show a "quiet" warning to avoid being disruptive on non-Hypothesis sites
   // that embed the client.


### PR DESCRIPTION
When attempting to create a build of the browser extension using the
local dev client and the production h service I encountered an issue where
the client failed to launch because resolving the `sidebarAppUrl` setting in `src/boot/index.js` failed.

This happens because the extension does not set this setting in the
sidebar app so the boot script fell back to trying to resolve the URL
template baked into the development client. This in turn failed
because `document.currentScript` is not set in this context.

The `sidebarAppUrl` setting is not actually needed when booting the sidebar app, so
this commit refactors the boot code to avoid generating it in this
context. This is done by moving the responsibility for determining which
part of the client to load from `boot/boot.js` into `boot/index.js` and
only resolving the necessary settings.

----

The workflow that exposed the problem:

1. Start the client's dev server
2. Install [yalc](https://github.com/whitecolor/yalc) and run `yalc publish` in the client repo
3. In the browser extension repo run `yalc link hypothesis` to use the local build of the client and `make SETTINGS_FILE=settings/chrome-prod.json` to build a production extension using it
4. Uninstall the production extension in Chrome, if you have it installed (or use a separate Chrome profile, which is what I do)
5. Install the development extension in Chrome. Note that it will have a blue badge like the prod extension and will communicate with the prod h service
6. Open a new tab and activate the extension. It should use the production h service (and thus show annotations from prod h) but use your local client