### PR TITLE
POC for launching notebook in iframe

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -224,6 +224,10 @@ let isFirstBuild = true;
 function generateBootScript(manifest, { usingDevServer = false } = {}) {
   const { version } = require('./package.json');
 
+  const defaultNotebookAppUrl = process.env.NOTEBOOK_APP_URL
+    ? `${process.env.NOTEBOOK_APP_URL}`
+    : '{current_scheme}://{current_host}:5000/notebook';
+
   const defaultSidebarAppUrl = process.env.SIDEBAR_APP_URL
     ? `${process.env.SIDEBAR_APP_URL}`
     : '{current_scheme}://{current_host}:5000/app.html';
@@ -239,6 +243,7 @@ function generateBootScript(manifest, { usingDevServer = false } = {}) {
 
   if (isFirstBuild) {
     log(`Sidebar app URL: ${defaultSidebarAppUrl}`);
+    log(`Notebook app URL: ${defaultNotebookAppUrl}`);
     log(`Client asset root URL: ${defaultAssetRoot}`);
     isFirstBuild = false;
   }
@@ -247,6 +252,7 @@ function generateBootScript(manifest, { usingDevServer = false } = {}) {
     .src('build/scripts/boot.bundle.js')
     .pipe(replace('__MANIFEST__', JSON.stringify(manifest)))
     .pipe(replace('__ASSET_ROOT__', defaultAssetRoot))
+    .pipe(replace('__NOTEBOOK_APP_URL__', defaultNotebookAppUrl))
     .pipe(replace('__SIDEBAR_APP_URL__', defaultSidebarAppUrl))
     // Strip sourcemap link. It will have been invalidated by the previous
     // replacements and the bundle is so small that it isn't really valuable.

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -39,6 +39,7 @@ export default function configFrom(window_) {
     requestConfigFromFrame: settings.hostPageSetting('requestConfigFromFrame'),
     services: settings.hostPageSetting('services'),
     showHighlights: settings.showHighlights,
+    notebookAppUrl: settings.notebookAppUrl,
     sidebarAppUrl: settings.sidebarAppUrl,
     // Subframe identifier given when a frame is being embedded into
     // by a top level client

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -8,33 +8,33 @@ export default function settingsFrom(window_) {
   const configFuncSettings = configFuncSettingsFrom(window_);
 
   /**
-   * Return the href URL of the first annotator sidebar link in the given document.
+   * Return the href of the first annotator link in the given
+   * document with this `rel` attribute.
    *
    * Return the value of the href attribute of the first
-   * `<link type="application/annotator+html" rel="sidebar">` element in the given document.
+   * `<link type="application/annotator+html" rel="${rel}">`
+   * element in the given document. This URL is used as the `src` for sidebar
+   * or notebook iframes.
    *
-   * This URL is used as the src of the sidebar's iframe.
-   *
-   * @return {string} - The URL to use for the sidebar's iframe.
-   *
-   * @throws {Error} - If there's no annotator link or the first annotator has
-   *   no href.
-   *
+   * @param {string} rel - The `rel` attribute to match
+   * @return {string} - The URL to use for the iframe
+   * @throws {Error} - If there's no link with the `rel` indicated, or the first
+   *   matching link has no `href`
    */
-  function sidebarAppUrl() {
+  function urlFromLinkTag(rel) {
     const link = window_.document.querySelector(
-      'link[type="application/annotator+html"][rel="sidebar"]'
+      `link[type="application/annotator+html"][rel="${rel}"]`
     );
 
     if (!link) {
       throw new Error(
-        'No application/annotator+html (rel="sidebar") link in the document'
+        `No application/annotator+html (rel="${rel}") link in the document`
       );
     }
 
     if (!link.href) {
       throw new Error(
-        'application/annotator+html (rel="sidebar") link has no href'
+        `application/annotator+html (rel="${rel}") link has no href`
       );
     }
 
@@ -45,13 +45,13 @@ export default function settingsFrom(window_) {
    * Return the href URL of the first annotator client link in the given document.
    *
    * Return the value of the href attribute of the first
-   * `<link type="application/annotator+html" rel="hypothesis-client">` element in the given document.
+   * `<link type="application/annotator+javascript" rel="hypothesis-client">`
+   * element in the given document.
    *
-   * This URL is used to identify where the client is from and what url should be
-   *    used inside of subframes
+   * This URL is used to identify where the client is from and what url should
+   * be used inside of subframes.
    *
    * @return {string} - The URL that the client is hosted from
-   *
    * @throws {Error} - If there's no annotator link or the first annotator has
    *   no href.
    *
@@ -177,7 +177,7 @@ export default function settingsFrom(window_) {
     const coerceValue =
       typeof options.coerce === 'function' ? options.coerce : name => name;
 
-    if (!allowInBrowserExt && isBrowserExtension(sidebarAppUrl())) {
+    if (!allowInBrowserExt && isBrowserExtension(urlFromLinkTag('sidebar'))) {
       return hasDefaultValue ? options.defaultValue : null;
     }
 
@@ -206,11 +206,14 @@ export default function settingsFrom(window_) {
     get group() {
       return group();
     },
+    get notebookAppUrl() {
+      return urlFromLinkTag('notebook');
+    },
     get showHighlights() {
       return showHighlights();
     },
     get sidebarAppUrl() {
-      return sidebarAppUrl();
+      return urlFromLinkTag('sidebar');
     },
     get query() {
       return query();

--- a/src/annotator/config/sidebar.js
+++ b/src/annotator/config/sidebar.js
@@ -1,0 +1,41 @@
+/**
+ * Create the JSON-serializable subset of annotator configuration that should
+ * be passed to the sidebar application.
+ */
+export function createSidebarConfig(config) {
+  const sidebarConfig = { ...config };
+
+  // Some config settings are not JSON-stringifiable (e.g. JavaScript
+  // functions) and will be omitted when the config is JSON-stringified.
+  // Add a JSON-stringifiable option for each of these so that the sidebar can
+  // at least know whether the callback functions were provided or not.
+  if (sidebarConfig.services?.length > 0) {
+    const service = sidebarConfig.services[0];
+    if (service.onLoginRequest) {
+      service.onLoginRequestProvided = true;
+    }
+    if (service.onLogoutRequest) {
+      service.onLogoutRequestProvided = true;
+    }
+    if (service.onSignupRequest) {
+      service.onSignupRequestProvided = true;
+    }
+    if (service.onProfileRequest) {
+      service.onProfileRequestProvided = true;
+    }
+    if (service.onHelpRequest) {
+      service.onHelpRequestProvided = true;
+    }
+  }
+
+  // Remove several annotator-only properties.
+  //
+  // nb. We don't currently strip all the annotator-only properties here.
+  // That's OK because validation / filtering happens in the sidebar app itself.
+  // It just results in unnecessary content in the sidebar iframe's URL string.
+  ['notebookAppUrl', 'sidebarAppUrl', 'pluginClasses'].forEach(
+    key => delete sidebarConfig[key]
+  );
+
+  return sidebarConfig;
+}

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -1,7 +1,7 @@
 import settingsFrom from '../settings';
 import { $imports } from '../settings';
 
-describe('annotator.config.settingsFrom', function () {
+describe('annotator/config/settingsFrom', () => {
   let fakeConfigFuncSettingsFrom;
   let fakeIsBrowserExtension;
   let fakeParseJsonConfig;
@@ -22,90 +22,169 @@ describe('annotator.config.settingsFrom', function () {
     $imports.$restore();
   });
 
-  describe('#sidebarAppUrl', function () {
-    function appendSidebarLinkToDocument(href) {
+  describe('app frame URLs from link tags', () => {
+    function appendLink(href, rel) {
       const link = document.createElement('link');
       link.type = 'application/annotator+html';
-      link.rel = 'sidebar';
+      link.rel = rel;
       if (href) {
         link.href = href;
       }
       document.head.appendChild(link);
       return link;
     }
+    describe('#notebookAppUrl', () => {
+      context(
+        "when there's an application/annotator+html notebook link",
+        () => {
+          let link;
 
-    context("when there's an application/annotator+html link", function () {
-      let link;
+          beforeEach(
+            'add an application/annotator+html notebook <link>',
+            () => {
+              link = appendLink('http://example.com/app.html', 'notebook');
+            }
+          );
 
-      beforeEach('add an application/annotator+html <link>', function () {
-        link = appendSidebarLinkToDocument('http://example.com/app.html');
-      });
+          afterEach('tidy up the notebook link', () => {
+            link.remove();
+          });
 
-      afterEach('tidy up the link', function () {
-        document.head.removeChild(link);
-      });
-
-      it('returns the href from the link', function () {
-        assert.equal(
-          settingsFrom(window).sidebarAppUrl,
-          'http://example.com/app.html'
-        );
-      });
-    });
-
-    context('when there are multiple annotator+html links', function () {
-      let link1;
-      let link2;
-
-      beforeEach('add two links to the document', function () {
-        link1 = appendSidebarLinkToDocument('http://example.com/app1');
-        link2 = appendSidebarLinkToDocument('http://example.com/app2');
-      });
-
-      afterEach('tidy up the links', function () {
-        document.head.removeChild(link1);
-        document.head.removeChild(link2);
-      });
-
-      it('returns the href from the first one', function () {
-        assert.equal(
-          settingsFrom(window).sidebarAppUrl,
-          'http://example.com/app1'
-        );
-      });
-    });
-
-    context('when the annotator+html link has no href', function () {
-      let link;
-
-      beforeEach(
-        'add an application/annotator+html <link> with no href',
-        function () {
-          link = appendSidebarLinkToDocument();
+          it('returns the href from the notebook link', () => {
+            assert.equal(
+              settingsFrom(window).notebookAppUrl,
+              'http://example.com/app.html'
+            );
+          });
         }
       );
 
-      afterEach('tidy up the link', function () {
-        document.head.removeChild(link);
+      context('when there are multiple annotator+html notebook links', () => {
+        let link1;
+        let link2;
+
+        beforeEach('add two notebook links to the document', () => {
+          link1 = appendLink('http://example.com/app1', 'notebook');
+          link2 = appendLink('http://example.com/app2', 'notebook');
+        });
+
+        afterEach('tidy up the notebook links', () => {
+          link1.remove();
+          link2.remove();
+        });
+
+        it('returns the href from the first notebook link found', () => {
+          assert.equal(
+            settingsFrom(window).notebookAppUrl,
+            'http://example.com/app1'
+          );
+        });
       });
 
-      it('throws an error', function () {
-        assert.throws(function () {
-          settingsFrom(window).sidebarAppUrl; // eslint-disable-line no-unused-expressions
-        }, 'application/annotator+html (rel="sidebar") link has no href');
+      context('when the annotator+html notebook link has no href', () => {
+        let link;
+
+        beforeEach(
+          'add an application/annotator+html notebook <link> with no href',
+          () => {
+            link = appendLink(undefined, 'notebook');
+          }
+        );
+
+        afterEach('tidy up the notebook link', () => {
+          link.remove();
+        });
+
+        it('throws an error', () => {
+          assert.throws(() => {
+            settingsFrom(window).notebookAppUrl; // eslint-disable-line no-unused-expressions
+          }, 'application/annotator+html (rel="notebook") link has no href');
+        });
+      });
+
+      context("when there's no annotator+html notebook link", () => {
+        it('throws an error', () => {
+          assert.throws(() => {
+            settingsFrom(window).notebookAppUrl; // eslint-disable-line no-unused-expressions
+          }, 'No application/annotator+html (rel="notebook") link in the document');
+        });
       });
     });
 
-    context("when there's no annotator+html link", function () {
-      it('throws an error', function () {
-        assert.throws(function () {
-          settingsFrom(window).sidebarAppUrl; // eslint-disable-line no-unused-expressions
-        }, 'No application/annotator+html (rel="sidebar") link in the document');
+    describe('#sidebarAppUrl', () => {
+      context("when there's an application/annotator+html sidebar link", () => {
+        let link;
+
+        beforeEach('add an application/annotator+html sidebar <link>', () => {
+          link = appendLink('http://example.com/app.html', 'sidebar');
+        });
+
+        afterEach('tidy up the sidebar link', () => {
+          link.remove();
+        });
+
+        it('returns the href from the sidebar link', () => {
+          assert.equal(
+            settingsFrom(window).sidebarAppUrl,
+            'http://example.com/app.html'
+          );
+        });
+      });
+
+      context('when there are multiple annotator+html sidebar links', () => {
+        let link1;
+        let link2;
+
+        beforeEach('add two sidebar links to the document', () => {
+          link1 = appendLink('http://example.com/app1', 'sidebar');
+          link2 = appendLink('http://example.com/app2', 'sidebar');
+        });
+
+        afterEach('tidy up the sidebar links', () => {
+          link1.remove();
+          link2.remove();
+        });
+
+        it('returns the href from the first one', () => {
+          assert.equal(
+            settingsFrom(window).sidebarAppUrl,
+            'http://example.com/app1'
+          );
+        });
+      });
+
+      context('when the annotator+html sidebar link has no href', () => {
+        let link;
+
+        beforeEach(
+          'add an application/annotator+html sidebar <link> with no href',
+          () => {
+            link = appendLink(null, 'sidebar');
+          }
+        );
+
+        afterEach('tidy up the sidebar link', () => {
+          link.remove();
+        });
+
+        it('throws an error', () => {
+          assert.throws(() => {
+            settingsFrom(window).sidebarAppUrl; // eslint-disable-line no-unused-expressions
+          }, 'application/annotator+html (rel="sidebar") link has no href');
+        });
+      });
+
+      context("when there's no annotator+html sidebar link", () => {
+        it('throws an error', () => {
+          assert.throws(() => {
+            settingsFrom(window).sidebarAppUrl; // eslint-disable-line no-unused-expressions
+          }, 'No application/annotator+html (rel="sidebar") link in the document');
+        });
       });
     });
   });
 
-  describe('#clientUrl', function () {
+  describe('#clientUrl', () => {
     function appendClientUrlLinkToDocument(href) {
       const link = document.createElement('link');
       link.type = 'application/annotator+javascript';
@@ -117,74 +196,68 @@ describe('annotator.config.settingsFrom', function () {
       return link;
     }
 
-    context(
-      "when there's an application/annotator+javascript link",
-      function () {
-        let link;
+    context("when there's an application/annotator+javascript link", () => {
+      let link;
 
-        beforeEach(
-          'add an application/annotator+javascript <link>',
-          function () {
-            link = appendClientUrlLinkToDocument('http://example.com/app.html');
-          }
+      beforeEach('add an application/annotator+javascript <link>', () => {
+        link = appendClientUrlLinkToDocument('http://example.com/app.html');
+      });
+
+      afterEach('tidy up the link', () => {
+        link.remove();
+      });
+
+      it('returns the href from the link', () => {
+        assert.equal(
+          settingsFrom(window).clientUrl,
+          'http://example.com/app.html'
         );
+      });
+    });
 
-        afterEach('tidy up the link', function () {
-          document.head.removeChild(link);
-        });
-
-        it('returns the href from the link', function () {
-          assert.equal(
-            settingsFrom(window).clientUrl,
-            'http://example.com/app.html'
-          );
-        });
-      }
-    );
-
-    context('when there are multiple annotator+javascript links', function () {
+    context('when there are multiple annotator+javascript links', () => {
       let link1;
       let link2;
 
-      beforeEach('add two links to the document', function () {
+      beforeEach('add two links to the document', () => {
         link1 = appendClientUrlLinkToDocument('http://example.com/app1');
         link2 = appendClientUrlLinkToDocument('http://example.com/app2');
       });
 
-      afterEach('tidy up the links', function () {
-        document.head.removeChild(link1);
-        document.head.removeChild(link2);
+      afterEach('tidy up the links', () => {
+        link1.remove();
+        link2.remove();
       });
 
-      it('returns the href from the first one', function () {
+      it('returns the href from the first one', () => {
         assert.equal(settingsFrom(window).clientUrl, 'http://example.com/app1');
       });
     });
 
-    context('when the annotator+javascript link has no href', function () {
+    context('when the annotator+javascript link has no href', () => {
       let link;
 
       beforeEach(
         'add an application/annotator+javascript <link> with no href',
-        function () {
+        () => {
           link = appendClientUrlLinkToDocument();
         }
       );
 
-      afterEach('tidy up the link', function () {
-        document.head.removeChild(link);
+      afterEach('tidy up the link', () => {
+        link.remove();
       });
 
-      it('throws an error', function () {
-        assert.throws(function () {
+      it('throws an error', () => {
+        assert.throws(() => {
           settingsFrom(window).clientUrl; // eslint-disable-line no-unused-expressions
         }, 'application/annotator+javascript (rel="hypothesis-client") link has no href');
       });
     });
 
-    context("when there's no annotator+javascript link", function () {
-      it('throws an error', function () {
-        assert.throws(function () {
+    context("when there's no annotator+javascript link", () => {
+      it('throws an error', () => {
+        assert.throws(() => {
           settingsFrom(window).clientUrl; // eslint-disable-line no-unused-expressions
         }, 'No application/annotator+javascript (rel="hypothesis-client") link in the document');
       });
@@ -202,20 +275,17 @@ describe('annotator.config.settingsFrom', function () {
     };
   }
 
-  describe('#annotations', function () {
+  describe('#annotations', () => {
     context(
       'when the host page has a js-hypothesis-config with an annotations setting',
-      function () {
-        beforeEach(
-          'add a js-hypothesis-config annotations setting',
-          function () {
-            fakeParseJsonConfig.returns({
-              annotations: 'annotationsFromJSON',
-            });
-          }
-        );
+      () => {
+        beforeEach('add a js-hypothesis-config annotations setting', () => {
+          fakeParseJsonConfig.returns({
+            annotations: 'annotationsFromJSON',
+          });
+        });
 
-        it('returns the annotations from the js-hypothesis-config script', function () {
+        it('returns the annotations from the js-hypothesis-config script', () => {
           assert.equal(
             settingsFrom(fakeWindow()).annotations,
             'annotationsFromJSON'
@@ -223,11 +293,11 @@ describe('annotator.config.settingsFrom', function () {
         });
 
         context(
-          "when there's also an annotations in the URL fragment",
-          function () {
+          "when there's also an `annotations` in the URL fragment",
+          () => {
             specify(
               'js-hypothesis-config annotations override URL ones',
-              function () {
+              () => {
                 const window_ = fakeWindow(
                   'http://localhost:3000#annotations:annotationsFromURL'
                 );
@@ -269,8 +339,8 @@ describe('annotator.config.settingsFrom', function () {
         returns: null,
       },
     ].forEach(function (test) {
-      describe(test.describe, function () {
-        it(test.it, function () {
+      describe(test.describe, () => {
+        it(test.it, () => {
           assert.deepEqual(
             settingsFrom(fakeWindow(test.url)).annotations,
             test.returns
@@ -303,31 +373,28 @@ describe('annotator.config.settingsFrom', function () {
     });
   });
 
-  describe('#query', function () {
+  describe('#query', () => {
     context(
       'when the host page has a js-hypothesis-config with a query setting',
-      function () {
-        beforeEach('add a js-hypothesis-config query setting', function () {
+      () => {
+        beforeEach('add a js-hypothesis-config query setting', () => {
           fakeParseJsonConfig.returns({
             query: 'queryFromJSON',
           });
         });
 
-        it('returns the query from the js-hypothesis-config script', function () {
+        it('returns the query from the js-hypothesis-config script', () => {
           assert.equal(settingsFrom(fakeWindow()).query, 'queryFromJSON');
         });
 
-        context("when there's also a query in the URL fragment", function () {
-          specify(
-            'js-hypothesis-config queries override URL ones',
-            function () {
-              const window_ = fakeWindow(
-                'http://localhost:3000#annotations:query:queryFromUrl'
-              );
+        context("when there's also a query in the URL fragment", () => {
+          specify('js-hypothesis-config queries override URL ones', () => {
+            const window_ = fakeWindow(
+              'http://localhost:3000#annotations:query:queryFromUrl'
+            );
 
-              assert.equal(settingsFrom(window_).query, 'queryFromJSON');
-            }
-          );
+            assert.equal(settingsFrom(window_).query, 'queryFromJSON');
+          });
         });
       }
     );
@@ -376,8 +443,8 @@ describe('annotator.config.settingsFrom', function () {
         returns: null,
       },
     ].forEach(function (test) {
-      describe(test.describe, function () {
-        it(test.it, function () {
+      describe(test.describe, () => {
+        it(test.it, () => {
           assert.deepEqual(
             settingsFrom(fakeWindow(test.url)).query,
             test.returns
@@ -386,8 +453,8 @@ describe('annotator.config.settingsFrom', function () {
       });
     });
 
-    describe('when the URL contains an invalid fragment', function () {
-      it('returns null', function () {
+    describe('when the URL contains an invalid fragment', () => {
+      it('returns null', () => {
         // An invalid escape sequence which will cause decodeURIComponent() to
         // throw a URIError.
         const invalidFrag = '%aaaaa';
@@ -399,7 +466,7 @@ describe('annotator.config.settingsFrom', function () {
     });
   });
 
-  describe('#showHighlights', function () {
+  describe('#showHighlights', () => {
     [
       {
         it: 'returns an "always" setting from the host page unmodified',
@@ -465,7 +532,7 @@ describe('annotator.config.settingsFrom', function () {
         output: /regex/,
       },
     ].forEach(function (test) {
-      it(test.it, function () {
+      it(test.it, () => {
         fakeParseJsonConfig.returns({
           showHighlights: test.input,
         });
@@ -474,7 +541,7 @@ describe('annotator.config.settingsFrom', function () {
         assert.deepEqual(settings.showHighlights, test.output);
       });
 
-      it(test.it, function () {
+      it(test.it, () => {
         fakeConfigFuncSettingsFrom.returns({
           showHighlights: test.input,
         });
@@ -484,16 +551,16 @@ describe('annotator.config.settingsFrom', function () {
       });
     });
 
-    it("defaults to 'always' if there's no showHighlights setting in the host page", function () {
+    it("defaults to 'always' if there's no showHighlights setting in the host page", () => {
       assert.equal(settingsFrom(fakeWindow()).showHighlights, 'always');
     });
 
-    context('when the client is in a browser extension', function () {
-      beforeEach('configure a browser extension client', function () {
+    context('when the client is in a browser extension', () => {
+      beforeEach('configure a browser extension client', () => {
         fakeIsBrowserExtension.returns(true);
       });
 
-      it("doesn't read the setting from the host page, defaults to 'always'", function () {
+      it("doesn't read the setting from the host page, defaults to 'always'", () => {
         fakeParseJsonConfig.returns({
           showHighlights: 'never',
         });
@@ -506,7 +573,7 @@ describe('annotator.config.settingsFrom', function () {
     });
   });
 
-  describe('#hostPageSetting', function () {
+  describe('#hostPageSetting', () => {
     [
       {
         when: 'the client is embedded in a web page',
@@ -621,8 +688,8 @@ describe('annotator.config.settingsFrom', function () {
         expected: 'the default value',
       },
     ].forEach(function (test) {
-      context(test.when, function () {
-        specify(test.specify, function () {
+      context(test.when, () => {
+        specify(test.specify, () => {
           fakeIsBrowserExtension.returns(test.isBrowserExtension);
           fakeConfigFuncSettingsFrom.returns(test.configFuncSettings);
           fakeParseJsonConfig.returns(test.jsonSettings);

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -22,6 +22,7 @@ import BucketBarPlugin from './plugin/bucket-bar';
 import CrossFramePlugin from './plugin/cross-frame';
 import DocumentPlugin from './plugin/document';
 import Guest from './guest';
+import Notebook from './notebook';
 import PDFPlugin from './plugin/pdf';
 import PdfSidebar from './pdf-sidebar';
 import Sidebar from './sidebar';
@@ -70,9 +71,11 @@ function init() {
   config.pluginClasses = pluginClasses;
 
   const annotator = new Klass(document.body, config);
+  const notebook = new Notebook(document.body, config);
   appLinkEl.addEventListener('destroy', function () {
     appLinkEl.remove();
     annotator.destroy();
+    notebook.destroy();
   });
 }
 

--- a/src/annotator/notebook.js
+++ b/src/annotator/notebook.js
@@ -1,0 +1,64 @@
+import Delegator from './delegator';
+import { createSidebarConfig } from './config/sidebar';
+
+/**
+ * Create the iframe that will load the notebook application.
+ *
+ * @return {HTMLIFrameElement}
+ */
+function createNotebookFrame(config) {
+  const sidebarConfig = createSidebarConfig(config);
+  const configParam =
+    'config=' + encodeURIComponent(JSON.stringify(sidebarConfig));
+  const notebookAppSrc = config.notebookAppUrl + '#' + configParam;
+
+  const notebookFrame = document.createElement('iframe');
+
+  // Enable media in annotations to be shown fullscreen
+  notebookFrame.setAttribute('allowfullscreen', '');
+
+  notebookFrame.src = notebookAppSrc;
+  notebookFrame.title = 'Hypothesis annotation notebook';
+  notebookFrame.className = 'notebook-inner';
+
+  return notebookFrame;
+}
+
+export default class Notebook extends Delegator {
+  constructor(element, config) {
+    super(element, config);
+    this.frame = null;
+
+    this.container = document.createElement('div');
+    this.container.style.display = 'none';
+    this.container.className = 'notebook-outer';
+
+    this.subscribe('showNotebook', () => this.show());
+    this.subscribe('hideNotebook', () => this.hide());
+    // If the sidebar has opened, get out of the way
+    this.subscribe('sidebarOpened', () => this.hide());
+  }
+
+  init() {
+    if (!this.frame) {
+      this.frame = createNotebookFrame(this.options);
+      this.container.appendChild(this.frame);
+      this.element.appendChild(this.container);
+    }
+  }
+
+  show() {
+    this.init();
+    this.container.classList.add('is-open');
+    this.container.style.display = '';
+  }
+
+  hide() {
+    this.container.classList.remove('is-open');
+    this.container.style.display = 'none';
+  }
+
+  destroy() {
+    this.frame?.remove();
+  }
+}

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -2,6 +2,7 @@ import Hammer from 'hammerjs';
 
 import annotationCounts from './annotation-counts';
 import sidebarTrigger from './sidebar-trigger';
+import { createSidebarConfig } from './config/sidebar';
 import events from '../shared/bridge-events';
 import features from './features';
 
@@ -23,46 +24,6 @@ const defaultConfig = {
     container: '.annotator-frame',
   },
 };
-
-/**
- * Create the JSON-serializable subset of annotator configuration that should
- * be passed to the sidebar application.
- */
-function createSidebarConfig(config) {
-  const sidebarConfig = { ...config };
-
-  // Some config settings are not JSON-stringifiable (e.g. JavaScript
-  // functions) and will be omitted when the config is JSON-stringified.
-  // Add a JSON-stringifiable option for each of these so that the sidebar can
-  // at least know whether the callback functions were provided or not.
-  if (sidebarConfig.services?.length > 0) {
-    const service = sidebarConfig.services[0];
-    if (service.onLoginRequest) {
-      service.onLoginRequestProvided = true;
-    }
-    if (service.onLogoutRequest) {
-      service.onLogoutRequestProvided = true;
-    }
-    if (service.onSignupRequest) {
-      service.onSignupRequestProvided = true;
-    }
-    if (service.onProfileRequest) {
-      service.onProfileRequestProvided = true;
-    }
-    if (service.onHelpRequest) {
-      service.onHelpRequestProvided = true;
-    }
-  }
-
-  // Remove several annotator-only properties.
-  //
-  // nb. We don't currently strip all the annotator-only properties here.
-  // That's OK because validation / filtering happens in the sidebar app itself.
-  // It just results in unnecessary content in the sidebar iframe's URL string.
-  ['sidebarAppUrl', 'pluginClasses'].forEach(key => delete sidebarConfig[key]);
-
-  return sidebarConfig;
-}
 
 /**
  * Create the iframe that will load the sidebar application.
@@ -220,6 +181,17 @@ export default class Sidebar extends Guest {
 
     this.crossframe.on('showSidebar', () => this.show());
     this.crossframe.on('hideSidebar', () => this.hide());
+
+    // Re-publish the crossframe event so that anything extending Delegator
+    // can subscribe to it (without need for crossframe)
+    this.crossframe.on('showNotebook', () => {
+      this.hide();
+      this.publish('showNotebook');
+    });
+    this.crossframe.on('hideNotebook', () => {
+      this.show();
+      this.publish('hideNotebook');
+    });
 
     const eventHandlers = [
       [events.LOGIN_REQUESTED, this.onLoginRequest],
@@ -391,6 +363,7 @@ export default class Sidebar extends Guest {
 
   show() {
     this.crossframe.call('sidebarOpened');
+    this.publish('sidebarOpened');
 
     if (this.frame) {
       const width = this.frame.getBoundingClientRect().width;

--- a/src/annotator/test/notebook-test.js
+++ b/src/annotator/test/notebook-test.js
@@ -1,0 +1,118 @@
+import Notebook from '../notebook';
+
+describe('Notebook', () => {
+  // `Notebook` instances created by current test
+  let notebooks;
+
+  const createNotebook = (config = {}) => {
+    config = { notebookAppUrl: '/base/annotator/test/empty.html', ...config };
+    const element = document.createElement('div');
+    const notebook = new Notebook(element, config);
+
+    notebooks.push(notebook);
+
+    return notebook;
+  };
+
+  beforeEach(() => {
+    notebooks = [];
+  });
+
+  afterEach(() => {
+    notebooks.forEach(n => n.destroy());
+  });
+
+  describe('notebook container frame', () => {
+    it('starts hidden', () => {
+      const notebook = createNotebook();
+
+      assert.equal(notebook.container.style.display, 'none');
+    });
+
+    it('displays when opened', () => {
+      const notebook = createNotebook();
+
+      notebook.show();
+
+      assert.equal(notebook.container.style.display, '');
+      assert.isTrue(notebook.container.classList.contains('is-open'));
+    });
+
+    it('hides when closed', () => {
+      const notebook = createNotebook();
+
+      notebook.show();
+      notebook.hide();
+
+      assert.equal(notebook.container.style.display, 'none');
+      assert.isFalse(notebook.container.classList.contains('is-open'));
+    });
+  });
+
+  describe('creating the notebook iframe', () => {
+    it('creates the iframe when the notebook is shown for the first time', () => {
+      const notebook = createNotebook();
+
+      assert.isNull(notebook.frame);
+
+      notebook.show();
+
+      assert.isTrue(notebook.frame instanceof Element);
+    });
+
+    it('sets the iframe source to the configured `notebookAppUrl`', () => {
+      const notebook = createNotebook({
+        notebookAppUrl: 'http://www.example.com/foo/bar',
+      });
+
+      notebook.show();
+
+      // The rest of the config gets added as a hash to the end of the src,
+      // so split that off and look at the string before it
+      assert.equal(
+        notebook.frame.src.split('#')[0],
+        'http://www.example.com/foo/bar'
+      );
+    });
+  });
+
+  describe('responding to events', () => {
+    it('shows on `showNotebook`', () => {
+      const notebook = createNotebook();
+
+      notebook.publish('showNotebook');
+
+      assert.equal(notebook.container.style.display, '');
+    });
+
+    it('hides on `hideNotebook`', () => {
+      const notebook = createNotebook();
+
+      notebook.show();
+      notebook.publish('hideNotebook');
+
+      assert.equal(notebook.container.style.display, 'none');
+    });
+
+    it('hides on "sidebarOpened"', () => {
+      const notebook = createNotebook();
+
+      notebook.show();
+      notebook.publish('sidebarOpened');
+
+      assert.equal(notebook.container.style.display, 'none');
+    });
+  });
+
+  describe('destruction', () => {
+    it('should remove the frame', () => {
+      const notebook = createNotebook();
+      // Make sure the frame is created
+      notebook.init();
+
+      notebook.destroy();
+
+      assert.equal(notebook.frame.parentElement, null);
+    });
+  });
+});

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -234,6 +234,28 @@ describe('Sidebar', () => {
         assert.called(target);
       }));
 
+    describe('on "showNotebook" event', () => {
+      it('hides itself and republishes the event', () => {
+        const sidebar = createSidebar();
+        sinon.stub(sidebar, 'publish');
+        sinon.stub(sidebar, 'hide');
+        emitEvent('showNotebook');
+        assert.calledWith(sidebar.publish, 'showNotebook');
+        assert.calledOnce(sidebar.hide);
+      });
+    });
+
+    describe('on "hideNotebook" event', () => {
+      it('shows itself and republishes the event', () => {
+        const sidebar = createSidebar();
+        sinon.stub(sidebar, 'publish');
+        sinon.stub(sidebar, 'show');
+        emitEvent('hideNotebook');
+        assert.calledWith(sidebar.publish, 'hideNotebook');
+        assert.calledOnce(sidebar.show);
+      });
+    });
+
     describe('on LOGIN_REQUESTED event', () => {
       it('calls the onLoginRequest callback function if one was provided', () => {
         const onLoginRequest = sandbox.stub();
@@ -578,19 +600,20 @@ describe('Sidebar', () => {
         sinon.stub(sidebar, 'publish');
         sidebar.show();
         assert.calledOnce(layoutChangeHandlerSpy);
-        assert.calledOnce(sidebar.publish);
         assert.calledWith(
           sidebar.publish,
           'sidebarLayoutChanged',
           sinon.match.any
         );
+        assert.calledWith(sidebar.publish, 'sidebarOpened');
+        assert.calledTwice(sidebar.publish);
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
           expanded: true,
         });
 
         sidebar.hide();
         assert.calledTwice(layoutChangeHandlerSpy);
-        assert.calledTwice(sidebar.publish);
+        assert.calledThrice(sidebar.publish);
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
           expanded: false,
           width: fakeToolbar.getWidth(),

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -21,6 +21,7 @@ const commonPolyfills = [
 /**
  * @typedef AnnotatorConfig
  * @prop {string} assetRoot - The root URL to which URLs in `manifest` are relative
+ * @prop {string} notebookAppUrl - The URL of the sidebar's notebook
  * @prop {string} sidebarAppUrl - The URL of the sidebar's HTML page
  * @prop {Object.<string,string>} manifest -
  *   A mapping from canonical asset path to cache-busted asset path
@@ -100,6 +101,13 @@ export function bootHypothesisClient(doc, config) {
   sidebarUrl.href = config.sidebarAppUrl;
   sidebarUrl.type = 'application/annotator+html';
   doc.head.appendChild(sidebarUrl);
+
+  // Register the URL of the notebook app which the Hypothesis client should load.
+  const notebookUrl = doc.createElement('link');
+  notebookUrl.rel = 'notebook';
+  notebookUrl.href = config.notebookAppUrl;
+  notebookUrl.type = 'application/annotator+html';
+  doc.head.appendChild(notebookUrl);
 
   // Register the URL of the annotation client which is currently being used to drive
   // annotation interactions.

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -26,10 +26,18 @@ if (isBrowserSupported()) {
   if (document.querySelector('hypothesis-app')) {
     bootSidebarApp(document, { assetRoot, manifest });
   } else {
+    const notebookAppUrl = processUrlTemplate(
+      settings.notebookAppUrl || '__NOTEBOOK_APP_URL__'
+    );
     const sidebarAppUrl = processUrlTemplate(
       settings.sidebarAppUrl || '__SIDEBAR_APP_URL__'
     );
-    bootHypothesisClient(document, { assetRoot, manifest, sidebarAppUrl });
+    bootHypothesisClient(document, {
+      assetRoot,
+      manifest,
+      notebookAppUrl,
+      sidebarAppUrl,
+    });
   }
 } else {
   // Show a "quiet" warning to avoid being disruptive on non-Hypothesis sites

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -194,6 +194,7 @@ function HypothesisApp({
             {route === 'annotation' && (
               <AnnotationViewerContent onLogin={login} />
             )}
+            {route === 'notebook' && <StreamContent />}
             {route === 'stream' && <StreamContent />}
             {route === 'sidebar' && (
               <SidebarContent onLogin={login} onSignUp={signUp} />

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -116,6 +116,10 @@ describe('HypothesisApp', () => {
       contentComponent: 'SidebarContent',
     },
     {
+      route: 'notebook',
+      contentComponent: 'StreamContent',
+    },
+    {
       route: 'stream',
       contentComponent: 'StreamContent',
     },

--- a/src/sidebar/components/test/user-menu-test.js
+++ b/src/sidebar/components/test/user-menu-test.js
@@ -15,6 +15,7 @@ describe('UserMenu', () => {
   let fakeServiceConfig;
   let fakeServiceUrl;
   let fakeSettings;
+  let fakeStore;
 
   const createUserMenu = () => {
     return mount(
@@ -49,6 +50,9 @@ describe('UserMenu', () => {
     fakeSettings = {
       authDomain: 'hypothes.is',
     };
+    fakeStore = {
+      isFeatureEnabled: sinon.stub().returns(false),
+    };
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
@@ -56,6 +60,7 @@ describe('UserMenu', () => {
         isThirdPartyUser: fakeIsThirdPartyUser,
       },
       '../service-config': fakeServiceConfig,
+      '../store/use-store': callback => callback(fakeStore),
     });
   });
 
@@ -179,6 +184,38 @@ describe('UserMenu', () => {
 
       const accountMenuItem = findMenuItem(wrapper, 'Account settings');
       assert.isFalse(accountMenuItem.exists());
+    });
+  });
+
+  describe('open notebook item', () => {
+    context('notebook feature is enabled', () => {
+      it('includes the open notebook item', () => {
+        fakeStore.isFeatureEnabled.withArgs('notebook_launch').returns(true);
+        const wrapper = createUserMenu();
+
+        const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
+        assert.isTrue(openNotebookItem.exists());
+      });
+
+      it('triggers a message when open-notebook item is clicked', () => {
+        fakeStore.isFeatureEnabled.withArgs('notebook_launch').returns(true);
+        const wrapper = createUserMenu();
+
+        const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
+        openNotebookItem.props().onClick();
+        assert.calledOnce(fakeBridge.call);
+        assert.calledWith(fakeBridge.call, 'showNotebook');
+      });
+    });
+
+    context('notebook feature is not enabled', () => {
+      it('does not include the open notebook item', () => {
+        fakeStore.isFeatureEnabled.withArgs('notebook_launch').returns(false);
+        const wrapper = createUserMenu();
+
+        const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
+        assert.isFalse(openNotebookItem.exists());
+      });
     });
   });
 

--- a/src/sidebar/components/user-menu.js
+++ b/src/sidebar/components/user-menu.js
@@ -4,6 +4,7 @@ import propTypes from 'prop-types';
 import bridgeEvents from '../../shared/bridge-events';
 import serviceConfig from '../service-config';
 import { isThirdPartyUser } from '../util/account-id';
+import useStore from '../store/use-store';
 import { withServices } from '../util/service-context';
 
 import Menu from './menu';
@@ -43,6 +44,9 @@ import SvgIcon from '../../shared/components/svg-icon';
 function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
   const isThirdParty = isThirdPartyUser(auth.userid, settings.authDomain);
   const service = serviceConfig(settings);
+  const isNotebookEnabled = useStore(store =>
+    store.isFeatureEnabled('notebook_launch')
+  );
 
   const serviceSupports = feature => service && !!service[feature];
 
@@ -50,6 +54,10 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
     !isThirdParty || serviceSupports('onProfileRequestProvided');
   const isLogoutEnabled =
     !isThirdParty || serviceSupports('onLogoutRequestProvided');
+
+  const onSelectNotebook = () => {
+    bridge.call('showNotebook');
+  };
 
   const onProfileSelected = () =>
     isThirdParty && bridge.call(bridgeEvents.PROFILE_REQUESTED);
@@ -84,6 +92,12 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
             <MenuItem
               label="Account settings"
               href={serviceUrl('account.settings')}
+            />
+          )}
+          {isNotebookEnabled && (
+            <MenuItem
+              label="Open notebook"
+              onClick={() => onSelectNotebook()}
             />
           )}
         </MenuSection>

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -38,11 +38,6 @@ if (appConfig.googleAnalytics) {
   addAnalytics(appConfig.googleAnalytics);
 }
 
-const isSidebar = !(
-  window.location.pathname.startsWith('/stream') ||
-  window.location.pathname.startsWith('/a/')
-);
-
 // Install Preact renderer options to work around browser quirks
 rendererOptions.setupBrowserFixes();
 
@@ -91,9 +86,9 @@ function autosave(autosaveService) {
 }
 
 // @inject
-function setupFrameSync(frameSync) {
+function setupFrameSync(frameSync, isSidebar) {
   if (isSidebar) {
-    frameSync.connect();
+    frameSync.connect(true);
   }
 }
 
@@ -139,6 +134,12 @@ import { Injector } from '../shared/injector';
 
 function startApp(config) {
   const container = new Injector();
+
+  const isSidebar = !(
+    window.location.pathname.startsWith('/stream') ||
+    window.location.pathname.startsWith('/a/') ||
+    window.location.pathname.startsWith('/notebook')
+  );
 
   // Register services.
   container

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -15,10 +15,14 @@ export default function router($window, store) {
     const params = queryString.parse($window.location.search);
 
     let route;
+
     switch (pathSegments[0]) {
       case 'a':
         route = 'annotation';
         params.id = pathSegments[1] || '';
+        break;
+      case 'notebook':
+        route = 'notebook';
         break;
       case 'stream':
         route = 'stream';
@@ -46,6 +50,9 @@ export default function router($window, store) {
           delete queryParams.id;
           url = `/a/${id}`;
         }
+        break;
+      case 'notebook':
+        url = '/notebook';
         break;
       case 'stream':
         url = '/stream';

--- a/src/sidebar/services/test/router-test.js
+++ b/src/sidebar/services/test/router-test.js
@@ -8,6 +8,11 @@ const fixtures = [
     params: {},
   },
   {
+    path: '/notebook',
+    route: 'notebook',
+    params: {},
+  },
+  {
     path: '/a/foo',
     route: 'annotation',
     params: { id: 'foo' },

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -15,6 +15,7 @@
 @use './components/toolbar';
 @use './bucket-bar';
 @use './highlights';
+@use './notebook';
 
 // Sidebar
 .annotator-frame {

--- a/src/styles/annotator/notebook.scss
+++ b/src/styles/annotator/notebook.scss
@@ -1,0 +1,28 @@
+@use '../variables' as var;
+@use '../mixins/molecules';
+
+.notebook-outer {
+  // TODO: CSS namespace conflicts?
+  box-sizing: border-box;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  padding: var.$layout-space;
+  // Leave explicitly the right amount of room for closed-sidebar affordances
+  padding-right: var.$annotator-toolbar-width + 5px;
+
+  &.is-open {
+    // TBD: Actual opacity/overlay we'd like to use
+    background-color: rgba(0, 0, 0, 0.5);
+  }
+}
+
+.notebook-inner {
+  box-sizing: border-box;
+  @include molecules.panel;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
This PR adds basic structure, configuration and placeholder content for a Notebook iFrame in the client app.

Once I get a nod as to the approach here, I'll batten down and add tests as needed, etc.

To test this out, make sure to enable the `notebook_launch` feature flag locally.

Fixes https://github.com/hypothesis/product-backlog/issues/1153