### PR TITLE
Bump Chrome version requirement to v 57

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "watchify": "^3.7.0",
     "wrap-text": "^1.0.7"
   },
-  "browserslist": "chrome 55, edge 17, firefox 53, safari 10.1",
+  "browserslist": "chrome 57, edge 17, firefox 53, safari 10.1",
   "browserify": {
     "transform": [
       "browserify-versionify",


### PR DESCRIPTION
This is the first version of Chrome that supports CSS Grid without a flag.

I'll do the same in LMS.

Fixes #2739