### PR TITLE
Set NOTEBOOK_APP_URL env for QA, prod; add to docs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,6 +118,7 @@ node {
                     // the sidebar from the qa h deployment.
                     sh """
                     export SIDEBAR_APP_URL=https://qa.hypothes.is/app.html
+                    export NOTEBOOK_APP_URL=https://qa.hypothes.is/notebook
                     yarn version --no-git-tag-version --new-version ${qaVersion}
                     """
 
@@ -187,6 +188,7 @@ stage('Publish') {
                     // Bump the package version and create the GitHub release.
                     sh """
                     export SIDEBAR_APP_URL=https://hypothes.is/app.html
+                    export NOTEBOOK_APP_URL=https://hypothes.is/notebook
                     yarn version --no-git-tag-version --new-version ${newPkgVersion}
                     """
                     sh "scripts/create-github-release.js"

--- a/docs/developers/envvars.rst
+++ b/docs/developers/envvars.rst
@@ -4,6 +4,12 @@ Environment Variables
 This section documents all the environment variables supported by the client's
 build tasks.
 
+.. envvar:: NOTEBOOK_APP_URL
+
+   The default value for the :option:`notebookAppUrl` config setting (the URL of
+   the notebook app's iframe).
+   ``https://hypothes.is/notebook`` by default.
+
 .. envvar:: SIDEBAR_APP_URL
 
    The default value for the :option:`sidebarAppUrl` config setting (the URL of


### PR DESCRIPTION
This will make Notebook available on QA and prod (though very much still obscured behind a feature flag).

Fixes #2725