### PR TITLE
Hide annotation layers in PDF when there is a selection

### DIFF
--- a/src/annotator/plugin/pdf.js
+++ b/src/annotator/plugin/pdf.js
@@ -75,9 +75,32 @@ export default class PDF extends Delegator {
     this._warningBanner = null;
 
     this._checkForSelectableText();
+
+    // Hide annotation layer when the user is making a selection. The annotation
+    // layer appears above the invisible text layer and can interfere with text
+    // selection. See https://github.com/hypothesis/client/issues/1464.
+    this._updateAnnotationLayerVisibility = () => {
+      const selection = /** @type {Selection} */ (window_.getSelection());
+
+      // Add CSS class to indicate whether there is a selection. Annotation
+      // layers are then hidden by a CSS rule in `pdfjs-overrides.scss`.
+      this.pdfViewer.viewer.classList.toggle(
+        'is-selecting',
+        !selection.isCollapsed
+      );
+    };
+
+    document.addEventListener(
+      'selectionchange',
+      this._updateAnnotationLayerVisibility
+    );
   }
 
   destroy() {
+    document.removeEventListener(
+      'selectionchange',
+      this._updateAnnotationLayerVisibility
+    );
     this.pdfViewer.viewer.classList.remove('has-transparent-text-layer');
     this.observer.disconnect();
   }

--- a/src/annotator/plugin/test/pdf-test.js
+++ b/src/annotator/plugin/test/pdf-test.js
@@ -85,6 +85,8 @@ describe('annotator/plugin/pdf', () => {
   it('hides annotation layers when there is a text selection', async () => {
     // This tests checks for a CSS class on the root PDF viewer element.
     // The annotation layers are hidden by a CSS rule that uses this class.
+
+    // Start with an empty selection.
     const selection = window.getSelection();
     if (!selection.isCollapsed) {
       selection.collapseToStart();
@@ -92,11 +94,18 @@ describe('annotator/plugin/pdf', () => {
     pdfPlugin = createPDFPlugin();
     assert.isFalse(pdfViewerHasClass('is-selecting'));
 
+    // Make the selection non-empty.
     selection.selectAllChildren(document.body);
     await awaitEvent(document, 'selectionchange');
     assert.isTrue(pdfViewerHasClass('is-selecting'));
 
+    // Then make the selection empty again.
     selection.collapseToStart();
+    await awaitEvent(document, 'selectionchange');
+    assert.isFalse(pdfViewerHasClass('is-selecting'));
+
+    // Finally, remove the selection entirely.
+    selection.removeAllRanges();
     await awaitEvent(document, 'selectionchange');
     assert.isFalse(pdfViewerHasClass('is-selecting'));
   });

--- a/src/annotator/plugin/test/pdf-test.js
+++ b/src/annotator/plugin/test/pdf-test.js
@@ -6,6 +6,14 @@ function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function awaitEvent(target, eventName) {
+  return new Promise(resolve => {
+    target.addEventListener(eventName, event => resolve(event), {
+      once: true,
+    });
+  });
+}
+
 describe('annotator/plugin/pdf', () => {
   let container;
   let fakeAnnotator;
@@ -61,15 +69,36 @@ describe('annotator/plugin/pdf', () => {
     $imports.$restore();
   });
 
+  function pdfViewerHasClass(className) {
+    return fakePDFViewerApplication.pdfViewer.viewer.classList.contains(
+      className
+    );
+  }
+
   describe('#constructor', () => {
     it('adds CSS classes to override PDF.js styles', () => {
       pdfPlugin = createPDFPlugin();
-      assert.isTrue(
-        fakePDFViewerApplication.pdfViewer.viewer.classList.contains(
-          'has-transparent-text-layer'
-        )
-      );
+      assert.isTrue(pdfViewerHasClass('has-transparent-text-layer'));
     });
+  });
+
+  it('hides annotation layers when there is a text selection', async () => {
+    // This tests checks for a CSS class on the root PDF viewer element.
+    // The annotation layers are hidden by a CSS rule that uses this class.
+    const selection = window.getSelection();
+    if (!selection.isCollapsed) {
+      selection.collapseToStart();
+    }
+    pdfPlugin = createPDFPlugin();
+    assert.isFalse(pdfViewerHasClass('is-selecting'));
+
+    selection.selectAllChildren(document.body);
+    await awaitEvent(document, 'selectionchange');
+    assert.isTrue(pdfViewerHasClass('is-selecting'));
+
+    selection.collapseToStart();
+    await awaitEvent(document, 'selectionchange');
+    assert.isFalse(pdfViewerHasClass('is-selecting'));
   });
 
   describe('#destroy', () => {

--- a/src/styles/annotator/pdfjs-overrides.scss
+++ b/src/styles/annotator/pdfjs-overrides.scss
@@ -11,6 +11,12 @@
   }
 }
 
+// Hide annotation layer while selecting text.
+// See https://github.com/hypothesis/client/issues/1464
+#viewer.is-selecting .annotationLayer {
+  display: none;
+}
+
 // When using search funcionality of PDF.js the matches should highlight the content but not cover it. Fix for #648
 .textLayer .highlight.selected {
   background-color: rgba(0, 100, 0, 0.5);


### PR DESCRIPTION
Content in a PDF's annotation layer, such as link annotations, can
interfere with text selection and also cause creating annotations to
fail [1]. This commit resolves the problem by temporarily hiding annotation
layers when there is a non-empty selection. This allows the user to
select text inside link annotations (for example) while still enabling
the user to activate the link normally when there is no selection.

Fixes https://github.com/hypothesis/client/issues/1464

[1] This is because the annotation layer is outside the text layer and
    the PDF anchoring code expects the selection to be within the text
    layer.

----

**Testing**

With the client's dev server running go to http://localhost:3000/pdf/budlong and try to make a selection that ends inside a link in the text. On master the text selection jumps to include the whole page when doing this. On this branch it should be possible to make the selection normally, as if you were working with a web page. Also click on one of these links when there is no selection and see that it behaves normally. Note that you can't _start_ the selection inside a link, but that's true of normal web pages as well.