### PR TITLE
Extend `TextRange` class to support use in anchoring / describing ranges

### DIFF
--- a/src/annotator/anchoring/test/text-range-test.js
+++ b/src/annotator/anchoring/test/text-range-test.js
@@ -174,7 +174,7 @@ describe('annotator/anchoring/text-range', () => {
 
   describe('TextRange', () => {
     describe('#toRange', () => {
-      it('resolves start and end points', () => {
+      it('resolves start and end points in same element', () => {
         const el = document.createElement('div');
         el.textContent = 'one two three';
 
@@ -185,6 +185,51 @@ describe('annotator/anchoring/text-range', () => {
         const range = textRange.toRange();
 
         assert.equal(range.toString(), 'two');
+      });
+
+      it('resolves start and end points in same element but different text nodes', () => {
+        const el = document.createElement('div');
+        el.append('one', 'two', 'three');
+
+        const textRange = new TextRange(
+          new TextPosition(el, 0),
+          new TextPosition(el, el.textContent.length)
+        );
+        const range = textRange.toRange();
+
+        assert.equal(range.toString(), el.textContent);
+      });
+
+      it('resolves start and end points in same element with start > end', () => {
+        const el = document.createElement('div');
+        el.textContent = 'one two three';
+
+        const textRange = new TextRange(
+          new TextPosition(el, 7),
+          new TextPosition(el, 4)
+        );
+        const range = textRange.toRange();
+
+        assert.equal(range.startContainer, el.firstChild);
+        assert.equal(range.startOffset, 4);
+        assert.isTrue(range.collapsed);
+      });
+
+      it('resolves start and end points in different elements', () => {
+        const parent = document.createElement('div');
+        const firstChild = document.createElement('span');
+        firstChild.append('foo');
+        const secondChild = document.createElement('span');
+        secondChild.append('bar');
+        parent.append(firstChild, secondChild);
+
+        const textRange = new TextRange(
+          new TextPosition(firstChild, 0),
+          new TextPosition(secondChild, 3)
+        );
+        const range = textRange.toRange();
+
+        assert.equal(range.toString(), 'foobar');
       });
 
       it('throws if start point cannot be resolved', () => {

--- a/src/annotator/anchoring/test/text-range-test.js
+++ b/src/annotator/anchoring/test/text-range-test.js
@@ -88,6 +88,38 @@ describe('annotator/anchoring/text-range', () => {
       });
     });
 
+    describe('#relativeTo', () => {
+      it("throws an error if argument is not an ancestor of position's element", () => {
+        const el = document.createElement('div');
+        el.append('One');
+        const pos = TextPosition.fromPoint(el.firstChild, 0);
+
+        assert.throws(() => {
+          pos.relativeTo(document.body);
+        }, 'Parent is not an ancestor of current element');
+      });
+
+      it('returns a TextPosition with offset relative to the given parent', () => {
+        const grandparent = document.createElement('div');
+        const parent = document.createElement('div');
+        const child = document.createElement('span');
+
+        grandparent.append('a', parent);
+        parent.append('bc', child);
+        child.append('def');
+
+        const childPos = TextPosition.fromPoint(child.firstChild, 3);
+
+        const parentPos = childPos.relativeTo(parent);
+        assert.equal(parentPos.element, parent);
+        assert.equal(parentPos.offset, 5);
+
+        const grandparentPos = childPos.relativeTo(grandparent);
+        assert.equal(grandparentPos.element, grandparent);
+        assert.equal(grandparentPos.offset, 6);
+      });
+    });
+
     describe('fromPoint', () => {
       it('returns TextPosition for offset in Text node', () => {
         const el = document.createElement('div');
@@ -155,13 +187,27 @@ describe('annotator/anchoring/text-range', () => {
         assert.equal(range.toString(), 'two');
       });
 
-      it('throws if start or end points cannot be resolved', () => {
+      it('throws if start point cannot be resolved', () => {
         const el = document.createElement('div');
         el.textContent = 'one two three';
 
         const textRange = new TextRange(
-          new TextPosition(el, 4),
-          new TextPosition(el, 20)
+          new TextPosition(el, 100),
+          new TextPosition(el, 5)
+        );
+
+        assert.throws(() => {
+          textRange.toRange();
+        }, 'Offset exceeds text length');
+      });
+
+      it('throws if end point cannot be resolved', () => {
+        const el = document.createElement('div');
+        el.textContent = 'one two three';
+
+        const textRange = new TextRange(
+          new TextPosition(el, 5),
+          new TextPosition(el, 100)
         );
 
         assert.throws(() => {

--- a/src/annotator/anchoring/text-range.js
+++ b/src/annotator/anchoring/text-range.js
@@ -32,10 +32,33 @@ export class TextPosition {
       throw new Error('Offset is invalid');
     }
 
+    /** Element that `offset` is relative to. */
     this.element = element;
 
     /** Character offset from the start of the element's `textContent`. */
     this.offset = offset;
+  }
+
+  /**
+   * Return a copy of this position with offset relative to a given ancestor
+   * element.
+   *
+   * @param {Element} parent - Ancestor of `this.element`
+   * @return {TextPosition}
+   */
+  relativeTo(parent) {
+    if (!parent.contains(this.element)) {
+      throw new Error('Parent is not an ancestor of current element');
+    }
+
+    let el = this.element;
+    let offset = this.offset;
+    while (el !== parent) {
+      offset += previousSiblingsTextLength(el);
+      el = /** @type {Element} */ (el.parentElement);
+    }
+
+    return new TextPosition(el, offset);
   }
 
   /**
@@ -140,6 +163,10 @@ export class TextRange {
 
   /**
    * Resolve the `TextRange` to a DOM range.
+   *
+   * The resulting DOM Range will always start and end in a `Text` node.
+   * Hence `TextRange.fromRange(range).toRange()` can be used to "shrink" a
+   * range to the text it contains.
    *
    * May throw if the `start` or `end` positions cannot be resolved to a range.
    *


### PR DESCRIPTION
We currently have several different implementations of (element, text offset) <=> `Range` conversion in the client that are used variously by PDF anchoring, HTML anchoring and highlighting. I plan to unify these so that we just have one hopefully simple and well-tested one.

This PR adds two features to the recently added `TextRange` class to support this:

- A `TextPosition.relativeTo` method which takes a text position that describes a character offset relative to a particular element, and converts it to be relative to some ancestor of the position's element. This can be used for example to generate a text position selector from a range like so:

   ```js
   const selector = {
     type: 'TextPositionSelector',
     start: TextPosition.fromPoint(range.startContainer, range.startOffset).relativeTo(document.body),
     end: TextPosition.fromPoint(range.endContainer, range.endOffset).relativeTo(document.body),
   }
   ```
- An optimization for `TextRange.toRange` which avoids iterating over the same text nodes twice when the start and end points refer to the same element. I have taken the existing `TextPosition.resolve` method and generalized it to a `resolveOffsets` function which resolves one or more offsets within the same element. This function is then used by both `TextPosition.resolve` and `TextRange.toRange`
