### PR TITLE
Adjust the dimensions of `top-bar` and `annotator-toolbar` on mobile

### DIFF
--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -102,7 +102,6 @@
 /*
   Mobile layout
   240-479 px
-  Zoomed out below 320 px
 */
 
 @media screen and (min-width: 15em) {
@@ -114,8 +113,7 @@
 
 /*
   Wide mobile layout
-  480-767 px
-  Zoomed in above 480 px
+  480-599 px
 */
 
 @media screen and (min-width: 30em) {
@@ -127,8 +125,7 @@
 
 /*
   Tablet layout
-  600-911 px
-  Zoomed in above 600 px
+  600-above px
 */
 
 @media screen and (min-width: 37.5em) {

--- a/src/styles/annotator/components/toolbar.scss
+++ b/src/styles/annotator/components/toolbar.scss
@@ -19,6 +19,10 @@
     position: absolute;
     left: -(var.$annotator-toolbar-width);
     width: var.$annotator-toolbar-width;
+    @media (pointer: coarse) {
+      left: -(var.$touch-target-size);
+      width: var.$touch-target-size;
+    }
     z-index: 2;
   }
 

--- a/src/styles/annotator/components/toolbar.scss
+++ b/src/styles/annotator/components/toolbar.scss
@@ -20,8 +20,11 @@
     left: -(var.$annotator-toolbar-width);
     width: var.$annotator-toolbar-width;
     @media (pointer: coarse) {
-      left: -(var.$touch-target-size);
-      width: var.$touch-target-size;
+      // Nov-23-2020: removing 12px is an interim solution to increase the size
+      // of the annotator-bar buttons without affecting the size of the sidebar
+      // https://github.com/hypothesis/client/pull/2745/files#r527824220
+      left: -(var.$touch-target-size - 12px);
+      width: var.$touch-target-size - 12px;
     }
     z-index: 2;
   }
@@ -34,6 +37,14 @@
   // Common styling for buttons in the toolbar
   @mixin annotator-button {
     @include buttons.button--icon-only($with-active-state: false);
+
+    // Nov-23-2020: removing 12px is an interim solution to increase the size
+    // of the annotator-bar buttons without affecting the size of the sidebar
+    // https://github.com/hypothesis/client/pull/2745/files#r527824220
+    @media (pointer: coarse) {
+      min-width: var.$touch-target-size - 12px;
+      min-height: var.$touch-target-size - 12px;
+    }
     // These toolbar buttons are slightly lighter than other icon buttons
     color: var.$grey-5;
     background: var.$color-background;

--- a/src/styles/sidebar/components/top-bar.scss
+++ b/src/styles/sidebar/components/top-bar.scss
@@ -10,7 +10,10 @@
   background: var.$white;
   height: var.$top-bar-height;
   @media (pointer: coarse) {
-    height: var.$touch-target-size;
+    // Nov-23-2020: removing 4px is an interim solution to increase the size
+    // of the annotator-bar buttons without affecting the size of the sidebar
+    // https://github.com/hypothesis/client/pull/2745/files#r527824220
+    height: var.$touch-target-size - 4px;
   }
   position: absolute;
   left: 0;

--- a/src/styles/sidebar/components/top-bar.scss
+++ b/src/styles/sidebar/components/top-bar.scss
@@ -9,6 +9,9 @@
   color: var.$grey-mid;
   background: var.$white;
   height: var.$top-bar-height;
+  @media (pointer: coarse) {
+    height: var.$touch-target-size;
+  }
   position: absolute;
   left: 0;
   right: 0;


### PR DESCRIPTION
On mobile screen sizes, buttons get a minimum recommended size (following Apple's Human Interface Guidelines). To accommodate for that, `top-bar` height and `annotator-toobar` width must be adjusted accordingly.

Final result:
![image](https://user-images.githubusercontent.com/8555781/99658760-39360280-2a60-11eb-914a-bd4f3f3b25ee.png)
