### PR TITLE
Use TextRange class for position selector anchoring in HTML documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "core-js": "^3.4.1",
     "cross-env": "^7.0.0",
     "diff": "^5.0.0",
-    "dom-anchor-text-position": "^5.0.0",
     "dom-anchor-text-quote": "^4.0.2",
     "dompurify": "^2.0.1",
     "enzyme": "^3.8.0",

--- a/src/annotator/anchoring/html.js
+++ b/src/annotator/anchoring/html.js
@@ -21,7 +21,7 @@ async function querySelector(anchor, options = {}) {
  * It encapsulates the core anchoring algorithm, using the selectors alone or
  * in combination to establish the best anchor within the document.
  *
- * @param {Node} root - The root element of the anchoring context.
+ * @param {Element} root - The root element of the anchoring context.
  * @param {Selector[]} selectors - The selectors to try.
  * @param {Object} [options]
  *   @param {number} [options.hint]
@@ -89,7 +89,7 @@ export function anchor(root, selectors, options = {}) {
 }
 
 /**
- * @param {Node} root
+ * @param {Element} root
  * @param {Range} range
  */
 export function describe(root, range) {

--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -330,7 +330,8 @@ function findInPages(pageIndexes, quoteSelector, positionHint) {
   const offset = getPageOffset(pageIndex);
 
   const attempt = ([content, offset]) => {
-    const root = { textContent: content };
+    const root = document.createElement('div');
+    root.textContent = content;
     const anchor = TextQuoteAnchor.fromSelector(root, quoteSelector);
     if (positionHint) {
       let hint = positionHint.start - offset;

--- a/src/annotator/anchoring/test/text-range-test.js
+++ b/src/annotator/anchoring/test/text-range-test.js
@@ -302,6 +302,28 @@ describe('annotator/anchoring/text-range', () => {
       });
     });
 
+    describe('#relativeTo', () => {
+      it('returns a range with start and end positions relative to the given element', () => {
+        const parent = document.createElement('div');
+        const firstChild = document.createElement('span');
+        firstChild.append('foo');
+        const secondChild = document.createElement('span');
+        secondChild.append('bar');
+        parent.append(firstChild, secondChild);
+
+        const textRange = new TextRange(
+          new TextPosition(firstChild, 0),
+          new TextPosition(secondChild, 3)
+        );
+        const parentRange = textRange.relativeTo(parent);
+
+        assert.equal(parentRange.start.element, parent);
+        assert.equal(parentRange.start.offset, 0);
+        assert.equal(parentRange.end.element, parent);
+        assert.equal(parentRange.end.offset, 6);
+      });
+    });
+
     describe('fromRange', () => {
       it('sets `start` and `end` points of range', () => {
         const el = document.createElement('div');
@@ -323,6 +345,20 @@ describe('annotator/anchoring/text-range', () => {
         assert.throws(() => {
           TextRange.fromRange(range);
         }, 'Point is not in an element or text node');
+      });
+    });
+
+    describe('fromOffsets', () => {
+      it('returns a `TextRange` with correct start and end', () => {
+        const root = document.createElement('div');
+        root.append('Some text content');
+
+        const textRange = TextRange.fromOffsets(root, 0, 10);
+
+        assert.equal(textRange.start.element, root);
+        assert.equal(textRange.start.offset, 0);
+        assert.equal(textRange.end.element, root);
+        assert.equal(textRange.end.offset, 10);
       });
     });
   });

--- a/src/annotator/anchoring/text-range.js
+++ b/src/annotator/anchoring/text-range.js
@@ -201,6 +201,19 @@ export class TextRange {
   }
 
   /**
+   * Return a copy of this range with start and end positions relative to a
+   * given ancestor. See `TextPosition.relativeTo`.
+   *
+   * @param {Element} element
+   */
+  relativeTo(element) {
+    return new TextRange(
+      this.start.relativeTo(element),
+      this.end.relativeTo(element)
+    );
+  }
+
+  /**
    * Resolve the `TextRange` to a DOM range.
    *
    * The resulting DOM Range will always start and end in a `Text` node.
@@ -249,5 +262,19 @@ export class TextRange {
     );
     const end = TextPosition.fromPoint(range.endContainer, range.endOffset);
     return new TextRange(start, end);
+  }
+
+  /**
+   * Return a `TextRange` from the `start`th to `end`th characters in `root`.
+   *
+   * @param {Element} root
+   * @param {number} start
+   * @param {number} end
+   */
+  static fromOffsets(root, start, end) {
+    return new TextRange(
+      new TextPosition(root, start),
+      new TextPosition(root, end)
+    );
   }
 }

--- a/src/annotator/anchoring/types.js
+++ b/src/annotator/anchoring/types.js
@@ -94,7 +94,7 @@ export class RangeAnchor {
  */
 export class TextPositionAnchor {
   /**
-   * @param {Node|TextContentNode} root
+   * @param {Element} root
    * @param {number} start
    * @param {number} end
    */
@@ -105,7 +105,7 @@ export class TextPositionAnchor {
   }
 
   /**
-   * @param {Node} root
+   * @param {Element} root
    * @param {Range} range
    */
   static fromRange(root, range) {
@@ -113,7 +113,7 @@ export class TextPositionAnchor {
     return TextPositionAnchor.fromSelector(root, selector);
   }
   /**
-   * @param {Node} root
+   * @param {Element} root
    * @param {TextPositionSelector} selector
    */
   static fromSelector(root, selector) {
@@ -141,7 +141,7 @@ export class TextPositionAnchor {
  */
 export class TextQuoteAnchor {
   /**
-   * @param {Node|TextContentNode} root - A root element from which to anchor.
+   * @param {Element} root - A root element from which to anchor.
    * @param {string} exact
    * @param {Object} context
    *   @param {string} [context.prefix]
@@ -153,7 +153,7 @@ export class TextQuoteAnchor {
     this.context = context;
   }
   /**
-   * @param {Node} root
+   * @param {Element} root
    * @param {Range} range
    */
   static fromRange(root, range) {
@@ -162,7 +162,7 @@ export class TextQuoteAnchor {
   }
 
   /**
-   * @param {Node|TextContentNode} root
+   * @param {Element} root
    * @param {TextQuoteSelector} selector
    */
   static fromSelector(root, selector) {

--- a/src/annotator/anchoring/types.js
+++ b/src/annotator/anchoring/types.js
@@ -7,10 +7,7 @@
  *  2. Insulating the rest of the code from API changes in the underlying anchoring
  *     libraries.
  */
-import {
-  fromRange as posFromRange,
-  toRange as posToRange,
-} from 'dom-anchor-text-position';
+
 import {
   fromRange as quoteFromRange,
   toRange as quoteToRange,
@@ -18,6 +15,7 @@ import {
 } from 'dom-anchor-text-quote';
 
 import { SerializedRange, sniff } from './range';
+import { TextRange } from './text-range';
 
 /**
  * @typedef {import("./range").BrowserRange} BrowserRange}
@@ -109,8 +107,12 @@ export class TextPositionAnchor {
    * @param {Range} range
    */
   static fromRange(root, range) {
-    const selector = posFromRange(root, range);
-    return TextPositionAnchor.fromSelector(root, selector);
+    const textRange = TextRange.fromRange(range).relativeTo(root);
+    return new TextPositionAnchor(
+      root,
+      textRange.start.offset,
+      textRange.end.offset
+    );
   }
   /**
    * @param {Element} root
@@ -132,7 +134,7 @@ export class TextPositionAnchor {
   }
 
   toRange() {
-    return posToRange(this.root, { start: this.start, end: this.end });
+    return TextRange.fromOffsets(this.root, this.start, this.end).toRange();
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2794,13 +2794,6 @@ dom-anchor-text-position@^4.0.0:
     dom-node-iterator "^3.5.0"
     dom-seek "^4.0.1"
 
-dom-anchor-text-position@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/dom-anchor-text-position/-/dom-anchor-text-position-5.0.0.tgz#1fa0a88c8a892b2b412c676c99bd00c8fe724e2f"
-  integrity sha512-2Z5p3jBfcxh5PUdxg68GBRbt4kZ6PsxoHp/rhSmZNoWKJfI14ScPMAxJySVWI8EIf+4dMhVskjRXsCxGGe4zJA==
-  dependencies:
-    dom-seek "^5.1.0"
-
 dom-anchor-text-quote@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/dom-anchor-text-quote/-/dom-anchor-text-quote-4.0.2.tgz#2a1e0cd4e06c79b0bfa1284aecbf7062028fc2d7"
@@ -2821,11 +2814,6 @@ dom-seek@^4.0.1:
   dependencies:
     ancestors "0.0.3"
     index-of "^0.2.0"
-
-dom-seek@^5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/dom-seek/-/dom-seek-5.1.1.tgz#4e35bee763b6ba082f372345823ec9665d1fbf26"
-  integrity sha512-1strSwd201Gfhfkfsk77SX9xyJGzu12gqUo5Q0W3Njtj2QxcfQTwCDOynZ6npZ4ASUFRQq0asjYDRlFxYPKwTA==
 
 dom-serialize@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
This is the final PR in the series to convert all Range <-> text offset conversion in the client to use the same implementation. It depends on the bug fix in #2746.

- Change several parameters in `types.js` to accept an `Element` rather than a `Node`. This avoids the need to add extra code to handle non-Element values elsewhere. This required a small change in the one existing place in `anchoring/pdf.js` where we passed non-Element values for these parameters
- Change `src/annotator/anchoring/types.js` to use the `TextRange` class in the `TextPositionAnchor` implementation
- Add `TextRange.{fromOffsets, relativeTo}` helpers
- Remove the `dom-anchor-text-position` dependency which is no longer directly used

