### PR TITLE
Remove one pixel gap between bucket-bar and iframe

### DIFF
--- a/src/styles/annotator/bucket-bar.scss
+++ b/src/styles/annotator/bucket-bar.scss
@@ -11,7 +11,9 @@
     pointer-events: none;
     position: absolute;
     height: 100%;
-    width: var.$annotator-bucket-bar-width;
+    // 2020-11-20: interim and pragmatic solution for an apparent glitch on Safari and Chrome.
+    // Adding one pixel resolve this issue: https://github.com/hypothesis/client/pull/2750
+    width: var.$annotator-bucket-bar-width + 1;
     left: -(var.$annotator-bucket-bar-width);
   }
 


### PR DESCRIPTION
On mobile devices, reseting the zoom level (pinch gesture) leaves a one pixel gap between the `bucket-bar` and the `iframe`. Adding one extra pixel to the width of the `bucket-bar` eliminates this issue.

This issue sometimes goes away by simple by opening and closing the sidebar. One explanation for that could be that the touch event modifies de zoom level. Otherwise I have not other explanation for this seemingly random behaviour.

I have observed this one-pixel gap in Chrome and Safari. Here two screenshoots from an iPad:

Safari:
![IMG-0367](https://user-images.githubusercontent.com/8555781/99819734-200c7f00-2b50-11eb-9364-dfb6c7b353d2.PNG)

Chrome:
![IMG-0368](https://user-images.githubusercontent.com/8555781/99819795-331f4f00-2b50-11eb-80ee-fa1a9e68bd56.PNG)

