### PR TITLE
Rename top-level view components

### DIFF
--- a/src/sidebar/components/annotation-view.js
+++ b/src/sidebar/components/annotation-view.js
@@ -10,7 +10,7 @@ import ThreadList from './thread-list';
 import SidebarContentError from './sidebar-content-error';
 
 /**
- * @typedef AnnotationViewerContentProps
+ * @typedef AnnotationViewProps
  * @prop {() => any} onLogin
  * @prop {Object} [loadAnnotationsService] - Injected service
  */
@@ -18,9 +18,9 @@ import SidebarContentError from './sidebar-content-error';
 /**
  * The main content for the single annotation page (aka. https://hypothes.is/a/<annotation ID>)
  *
- * @param {AnnotationViewerContentProps} props
+ * @param {AnnotationViewProps} props
  */
-function AnnotationViewerContent({ loadAnnotationsService, onLogin }) {
+function AnnotationView({ loadAnnotationsService, onLogin }) {
   const annotationId = useStore(store => store.routeParams().id);
   const clearAnnotations = useStore(store => store.clearAnnotations);
   const highlightAnnotations = useStore(store => store.highlightAnnotations);
@@ -98,11 +98,11 @@ function AnnotationViewerContent({ loadAnnotationsService, onLogin }) {
   );
 }
 
-AnnotationViewerContent.propTypes = {
+AnnotationView.propTypes = {
   onLogin: propTypes.func.isRequired,
   loadAnnotationsService: propTypes.object,
 };
 
-AnnotationViewerContent.injectedProps = ['loadAnnotationsService'];
+AnnotationView.injectedProps = ['loadAnnotationsService'];
 
-export default withServices(AnnotationViewerContent);
+export default withServices(AnnotationView);

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -12,7 +12,7 @@ import { shouldAutoDisplayTutorial } from '../util/session';
 import { applyTheme } from '../util/theme';
 import { withServices } from '../util/service-context';
 
-import AnnotationViewerContent from './annotation-viewer-content';
+import AnnotationView from './annotation-view';
 import HelpPanel from './help-panel';
 import ShareAnnotationsPanel from './share-annotations-panel';
 import SidebarView from './sidebar-view';
@@ -191,9 +191,7 @@ function HypothesisApp({
 
         {route && (
           <main>
-            {route === 'annotation' && (
-              <AnnotationViewerContent onLogin={login} />
-            )}
+            {route === 'annotation' && <AnnotationView onLogin={login} />}
             {route === 'notebook' && <StreamContent />}
             {route === 'stream' && <StreamContent />}
             {route === 'sidebar' && (

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -15,7 +15,7 @@ import { withServices } from '../util/service-context';
 import AnnotationViewerContent from './annotation-viewer-content';
 import HelpPanel from './help-panel';
 import ShareAnnotationsPanel from './share-annotations-panel';
-import SidebarContent from './sidebar-content';
+import SidebarView from './sidebar-view';
 import StreamContent from './stream-content';
 import ToastMessages from './toast-messages';
 import TopBar from './top-bar';
@@ -197,7 +197,7 @@ function HypothesisApp({
             {route === 'notebook' && <StreamContent />}
             {route === 'stream' && <StreamContent />}
             {route === 'sidebar' && (
-              <SidebarContent onLogin={login} onSignUp={signUp} />
+              <SidebarView onLogin={login} onSignUp={signUp} />
             )}
           </main>
         )}

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -13,10 +13,11 @@ import { applyTheme } from '../util/theme';
 import { withServices } from '../util/service-context';
 
 import AnnotationView from './annotation-view';
+import SidebarView from './sidebar-view';
+import StreamView from './stream-view';
+
 import HelpPanel from './help-panel';
 import ShareAnnotationsPanel from './share-annotations-panel';
-import SidebarView from './sidebar-view';
-import StreamContent from './stream-content';
 import ToastMessages from './toast-messages';
 import TopBar from './top-bar';
 
@@ -192,8 +193,8 @@ function HypothesisApp({
         {route && (
           <main>
             {route === 'annotation' && <AnnotationView onLogin={login} />}
-            {route === 'notebook' && <StreamContent />}
-            {route === 'stream' && <StreamContent />}
+            {route === 'notebook' && <StreamView />}
+            {route === 'stream' && <StreamView />}
             {route === 'sidebar' && (
               <SidebarView onLogin={login} onSignUp={signUp} />
             )}

--- a/src/sidebar/components/sidebar-view.js
+++ b/src/sidebar/components/sidebar-view.js
@@ -15,7 +15,7 @@ import SidebarContentError from './sidebar-content-error';
 import ThreadList from './thread-list';
 
 /**
- * @typedef SidebarContentProps
+ * @typedef SidebarViewProps
  * @prop {() => any} onLogin
  * @prop {() => any} onSignUp
  * @prop {Object} [frameSync] - Injected service
@@ -26,9 +26,9 @@ import ThreadList from './thread-list';
 /**
  * Render the sidebar and its components
  *
- * @param {SidebarContentProps} props
+ * @param {SidebarViewProps} props
  */
-function SidebarContent({
+function SidebarView({
   frameSync,
   onLogin,
   onSignUp,
@@ -151,7 +151,7 @@ function SidebarContent({
   );
 }
 
-SidebarContent.propTypes = {
+SidebarView.propTypes = {
   onLogin: propTypes.func.isRequired,
   onSignUp: propTypes.func.isRequired,
   frameSync: propTypes.object,
@@ -159,10 +159,6 @@ SidebarContent.propTypes = {
   streamer: propTypes.object,
 };
 
-SidebarContent.injectedProps = [
-  'frameSync',
-  'loadAnnotationsService',
-  'streamer',
-];
+SidebarView.injectedProps = ['frameSync', 'loadAnnotationsService', 'streamer'];
 
-export default withServices(SidebarContent);
+export default withServices(SidebarView);

--- a/src/sidebar/components/stream-view.js
+++ b/src/sidebar/components/stream-view.js
@@ -10,7 +10,7 @@ import useStore from '../store/use-store';
 import ThreadList from './thread-list';
 
 /**
- * @typedef StreamContentProps
+ * @typedef StreamViewProps
  * @prop {Object} [api] - Injected service
  * @prop {Object} [toastMessenger] - Injected service
  */
@@ -18,9 +18,9 @@ import ThreadList from './thread-list';
 /**
  * The main content of the "stream" route (https://hypothes.is/stream)
  *
- * @param {StreamContentProps} props
+ * @param {StreamViewProps} props
  */
-function StreamContent({ api, toastMessenger }) {
+function StreamView({ api, toastMessenger }) {
   const addAnnotations = useStore(store => store.addAnnotations);
   const annotationFetchStarted = useStore(
     store => store.annotationFetchStarted
@@ -82,11 +82,11 @@ function StreamContent({ api, toastMessenger }) {
   return <ThreadList thread={rootThread} />;
 }
 
-StreamContent.propTypes = {
+StreamView.propTypes = {
   api: propTypes.object,
   toastMessenger: propTypes.object,
 };
 
-StreamContent.injectedProps = ['api', 'toastMessenger'];
+StreamView.injectedProps = ['api', 'toastMessenger'];
 
-export default withServices(StreamContent);
+export default withServices(StreamView);

--- a/src/sidebar/components/test/annotation-view-test.js
+++ b/src/sidebar/components/test/annotation-view-test.js
@@ -4,11 +4,9 @@ import { mount } from 'enzyme';
 import { waitFor } from '../../../test-util/wait';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-import AnnotationViewerContent, {
-  $imports,
-} from '../annotation-viewer-content';
+import AnnotationView, { $imports } from '../annotation-view';
 
-describe('AnnotationViewerContent', () => {
+describe('AnnotationView', () => {
   let fakeStore;
   let fakeOnLogin;
   let fakeUseRootThread;
@@ -45,7 +43,7 @@ describe('AnnotationViewerContent', () => {
 
   function createComponent(props = {}) {
     return mount(
-      <AnnotationViewerContent
+      <AnnotationView
         loadAnnotationsService={fakeLoadAnnotationsService}
         onLogin={fakeOnLogin}
         {...props}

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -96,7 +96,7 @@ describe('HypothesisApp', () => {
   it('does not render content if route is not yet determined', () => {
     fakeStore.route.returns(null);
     const wrapper = createComponent();
-    ['main', 'AnnotationViewerContent', 'StreamContent', 'SidebarView'].forEach(
+    ['main', 'AnnotationView', 'StreamContent', 'SidebarView'].forEach(
       contentComponent => {
         assert.isFalse(wrapper.exists(contentComponent));
       }
@@ -106,7 +106,7 @@ describe('HypothesisApp', () => {
   [
     {
       route: 'annotation',
-      contentComponent: 'AnnotationViewerContent',
+      contentComponent: 'AnnotationView',
     },
     {
       route: 'sidebar',

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -96,7 +96,7 @@ describe('HypothesisApp', () => {
   it('does not render content if route is not yet determined', () => {
     fakeStore.route.returns(null);
     const wrapper = createComponent();
-    ['main', 'AnnotationView', 'StreamContent', 'SidebarView'].forEach(
+    ['main', 'AnnotationView', 'StreamView', 'SidebarView'].forEach(
       contentComponent => {
         assert.isFalse(wrapper.exists(contentComponent));
       }
@@ -114,11 +114,11 @@ describe('HypothesisApp', () => {
     },
     {
       route: 'notebook',
-      contentComponent: 'StreamContent',
+      contentComponent: 'StreamView',
     },
     {
       route: 'stream',
-      contentComponent: 'StreamContent',
+      contentComponent: 'StreamView',
     },
   ].forEach(({ route, contentComponent }) => {
     it('renders app content for route', () => {

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -96,14 +96,11 @@ describe('HypothesisApp', () => {
   it('does not render content if route is not yet determined', () => {
     fakeStore.route.returns(null);
     const wrapper = createComponent();
-    [
-      'main',
-      'AnnotationViewerContent',
-      'StreamContent',
-      'SidebarContent',
-    ].forEach(contentComponent => {
-      assert.isFalse(wrapper.exists(contentComponent));
-    });
+    ['main', 'AnnotationViewerContent', 'StreamContent', 'SidebarView'].forEach(
+      contentComponent => {
+        assert.isFalse(wrapper.exists(contentComponent));
+      }
+    );
   });
 
   [
@@ -113,7 +110,7 @@ describe('HypothesisApp', () => {
     },
     {
       route: 'sidebar',
-      contentComponent: 'SidebarContent',
+      contentComponent: 'SidebarView',
     },
     {
       route: 'notebook',

--- a/src/sidebar/components/test/sidebar-view-test.js
+++ b/src/sidebar/components/test/sidebar-view-test.js
@@ -1,13 +1,13 @@
 import { mount } from 'enzyme';
 import { createElement } from 'preact';
 
-import SidebarContent from '../sidebar-content';
-import { $imports } from '../sidebar-content';
+import SidebarView from '../sidebar-view';
+import { $imports } from '../sidebar-view';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('SidebarContent', () => {
+describe('SidebarView', () => {
   let fakeFrameSync;
   let fakeLoadAnnotationsService;
   let fakeUseRootThread;
@@ -17,7 +17,7 @@ describe('SidebarContent', () => {
 
   const createComponent = props =>
     mount(
-      <SidebarContent
+      <SidebarView
         onLogin={() => null}
         onSignUp={() => null}
         frameSync={fakeFrameSync}

--- a/src/sidebar/components/test/stream-view-test.js
+++ b/src/sidebar/components/test/stream-view-test.js
@@ -4,9 +4,9 @@ import { createElement } from 'preact';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 import { waitFor } from '../../../test-util/wait';
 
-import StreamContent, { $imports } from '../stream-content';
+import StreamView, { $imports } from '../stream-view';
 
-describe('StreamContent', () => {
+describe('StreamView', () => {
   let fakeApi;
   let fakeUseRootThread;
   let fakeSearchFilter;
@@ -52,7 +52,7 @@ describe('StreamContent', () => {
 
   function createComponent() {
     return mount(
-      <StreamContent api={fakeApi} toastMessenger={fakeToastMessenger} />
+      <StreamView api={fakeApi} toastMessenger={fakeToastMessenger} />
     );
   }
 


### PR DESCRIPTION
This PR renames several components to use a new `*View` naming convention for top-/route-level view components. Root component `HypothesisApp` renders one of these `*View` components depending on route.

This naming change was discussed in Slack.

New Notebook component will be named `NotebookView` to follow suit.