### PR TITLE
Refactor `LoadAnnotationsService#load` for flexibility

### DIFF
--- a/src/sidebar/components/sidebar-view.js
+++ b/src/sidebar/components/sidebar-view.js
@@ -102,7 +102,10 @@ function SidebarView({
       prevGroupId.current = focusedGroupId;
     }
     if (focusedGroupId && searchUris.length) {
-      loadAnnotationsService.load(searchUris, focusedGroupId);
+      loadAnnotationsService.load({
+        groupId: focusedGroupId,
+        uris: searchUris,
+      });
     }
   }, [
     clearSelection,


### PR DESCRIPTION
This PR makes the `load` method of `LoadAnnotationsService` more flexible for use with the Notebook.

Previously, the `load` and `searchAndLoad` methods in this service assumed the presence of both `groupId` and one ore more `uris`. This was designed with the `SidebarView` in mind: it was meant to load all annotations that are in a single group and were on one or more document `uri`s—i.e. "get me all of the annotations in this group for the URI I'm looking at."

For Notebook, we want to be able to retrieve annotations for a group regardless of document/URI. This makes `load` take an `options` object, and no longer considers `uris` required (`SidebarView` already guards against loading annotations until at least one `uri` is available).

`groupId` is still required, but that may change in the future as we adapt...