### PR TITLE
Notebook prototype: load group annotations

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -184,9 +184,9 @@ export default class Sidebar extends Guest {
 
     // Re-publish the crossframe event so that anything extending Delegator
     // can subscribe to it (without need for crossframe)
-    this.crossframe.on('showNotebook', () => {
+    this.crossframe.on('showNotebook', groupId => {
       this.hide();
-      this.publish('showNotebook');
+      this.publish('showNotebook', [groupId]);
     });
     this.crossframe.on('hideNotebook', () => {
       this.show();

--- a/src/annotator/test/notebook-test.js
+++ b/src/annotator/test/notebook-test.js
@@ -74,6 +74,36 @@ describe('Notebook', () => {
         'http://www.example.com/foo/bar'
       );
     });
+
+    it('does not create a new iframe if shown again with same group ID', () => {
+      const notebook = createNotebook();
+      notebook._groupId = 'mygroup';
+
+      // The first showing will create a new iFrame
+      notebook.publish('showNotebook', ['myGroup']);
+      const removeSpy = sinon.spy(notebook.frame, 'remove');
+      // Show it again — the group hasn't changed so the iframe won't be
+      // replaced
+      notebook.publish('showNotebook', ['myGroup']);
+
+      assert.notCalled(removeSpy);
+    });
+
+    it('does not create a new iframe if shown again with same group ID', () => {
+      const notebook = createNotebook();
+      notebook._groupId = 'mygroup';
+
+      // First show: creates an iframe
+      notebook.publish('showNotebook', ['myGroup']);
+      const removeSpy = sinon.spy(notebook.frame, 'remove');
+
+      // Show again with another group
+      notebook.publish('showNotebook', ['anotherGroup']);
+
+      // Show again, which will remove the first iframe and create a new one
+      notebook.show();
+      assert.calledOnce(removeSpy);
+    });
   });
 
   describe('responding to events', () => {
@@ -108,7 +138,7 @@ describe('Notebook', () => {
     it('should remove the frame', () => {
       const notebook = createNotebook();
       // Make sure the frame is created
-      notebook.init();
+      notebook.show();
 
       notebook.destroy();
 

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -239,8 +239,12 @@ describe('Sidebar', () => {
         const sidebar = createSidebar();
         sinon.stub(sidebar, 'publish');
         sinon.stub(sidebar, 'hide');
-        emitEvent('showNotebook');
-        assert.calledWith(sidebar.publish, 'showNotebook');
+        emitEvent('showNotebook', 'mygroup');
+        assert.calledWith(
+          sidebar.publish,
+          'showNotebook',
+          sinon.match(['mygroup'])
+        );
         assert.calledOnce(sidebar.hide);
       });
     });

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -17,6 +17,7 @@ import SidebarView from './sidebar-view';
 import StreamView from './stream-view';
 
 import HelpPanel from './help-panel';
+import NotebookView from './notebook-view';
 import ShareAnnotationsPanel from './share-annotations-panel';
 import ToastMessages from './toast-messages';
 import TopBar from './top-bar';
@@ -175,16 +176,19 @@ function HypothesisApp({
     <div
       className={classnames('hypothesis-app', 'js-thread-list-scroll-root', {
         'theme-clean': isThemeClean,
+        'hypothesis-app--notebook': route === 'notebook',
       })}
       style={backgroundStyle}
     >
-      <TopBar
-        auth={authState}
-        onLogin={login}
-        onSignUp={signUp}
-        onLogout={logout}
-        isSidebar={isSidebar}
-      />
+      {route !== 'notebook' && (
+        <TopBar
+          auth={authState}
+          onLogin={login}
+          onSignUp={signUp}
+          onLogout={logout}
+          isSidebar={isSidebar}
+        />
+      )}
       <div className="hypothesis-app__content">
         <ToastMessages />
         <HelpPanel auth={authState} />
@@ -193,7 +197,7 @@ function HypothesisApp({
         {route && (
           <main>
             {route === 'annotation' && <AnnotationView onLogin={login} />}
-            {route === 'notebook' && <StreamView />}
+            {route === 'notebook' && <NotebookView />}
             {route === 'stream' && <StreamView />}
             {route === 'sidebar' && (
               <SidebarView onLogin={login} onSignUp={signUp} />

--- a/src/sidebar/components/notebook-view.js
+++ b/src/sidebar/components/notebook-view.js
@@ -1,0 +1,80 @@
+import { createElement } from 'preact';
+import { useEffect } from 'preact/hooks';
+import propTypes from 'prop-types';
+
+import { withServices } from '../util/service-context';
+import useRootThread from './hooks/use-root-thread';
+import useStore from '../store/use-store';
+
+import ThreadList from './thread-list';
+
+/**
+ * @typedef NotebookViewProps
+ * @prop {Object} [loadAnnotationsService] - Injected service
+ */
+
+/**
+ * The main content of the "notebook" route (https://hypothes.is/notebook)
+ *
+ * @param {NotebookViewProps} props
+ */
+function NotebookView({ loadAnnotationsService }) {
+  const focusedGroup = useStore(store => store.focusedGroup());
+  const setSortKey = useStore(store => store.setSortKey);
+
+  // Reload annotations if focused group changes
+  useEffect(() => {
+    // Load all annotations in the group, unless there are more than 5000
+    // of them: this is a performance safety valve
+    setSortKey('Newest');
+    if (focusedGroup) {
+      loadAnnotationsService.load({
+        groupId: focusedGroup.id,
+        maxResults: 5000,
+      });
+    }
+  }, [loadAnnotationsService, focusedGroup, setSortKey]);
+
+  const rootThread = useRootThread();
+  const groupName = focusedGroup?.name ?? '…';
+
+  const hasResults = rootThread.totalChildren > 0;
+  const threadCount =
+    rootThread.totalChildren === 1
+      ? '1 thread'
+      : `${rootThread.totalChildren} threads`;
+  const annotationCount =
+    rootThread.replyCount === 1
+      ? '1 annotation'
+      : `${rootThread.replyCount} annotations`;
+
+  return (
+    <div className="notebook-view">
+      <header className="notebook-view__heading">
+        <h1>{groupName}</h1>
+      </header>
+      <div className="notebook-view__results">
+        {hasResults ? (
+          <span>
+            <h2>{threadCount}</h2> ({annotationCount})
+          </span>
+        ) : (
+          <span>
+            <h2>No results</h2>
+          </span>
+        )}
+      </div>
+      <div className="notebook-view__items">
+        <ThreadList thread={rootThread} />
+      </div>
+    </div>
+  );
+}
+
+NotebookView.propTypes = {
+  loadAnnotationsService: propTypes.object,
+};
+
+NotebookView.injectedProps = ['loadAnnotationsService'];
+
+export default withServices(NotebookView);

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -96,11 +96,15 @@ describe('HypothesisApp', () => {
   it('does not render content if route is not yet determined', () => {
     fakeStore.route.returns(null);
     const wrapper = createComponent();
-    ['main', 'AnnotationView', 'StreamView', 'SidebarView'].forEach(
-      contentComponent => {
-        assert.isFalse(wrapper.exists(contentComponent));
-      }
-    );
+    [
+      'main',
+      'AnnotationView',
+      'NotebookView',
+      'StreamView',
+      'SidebarView',
+    ].forEach(contentComponent => {
+      assert.isFalse(wrapper.exists(contentComponent));
+    });
   });
 
   [
@@ -114,7 +118,7 @@ describe('HypothesisApp', () => {
     },
     {
       route: 'notebook',
-      contentComponent: 'StreamView',
+      contentComponent: 'NotebookView',
     },
     {
       route: 'stream',

--- a/src/sidebar/components/test/notebook-view-test.js
+++ b/src/sidebar/components/test/notebook-view-test.js
@@ -1,0 +1,97 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+
+import NotebookView, { $imports } from '../notebook-view';
+
+describe('NotebookView', () => {
+  let fakeLoadAnnotationsService;
+  let fakeUseRootThread;
+  let fakeStore;
+
+  beforeEach(() => {
+    fakeLoadAnnotationsService = {
+      load: sinon.stub(),
+    };
+
+    fakeUseRootThread = sinon.stub().returns({});
+
+    fakeStore = {
+      focusedGroup: sinon.stub().returns({}),
+      setSortKey: sinon.stub(),
+    };
+
+    $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      './hooks/use-root-thread': fakeUseRootThread,
+      '../store/use-store': callback => callback(fakeStore),
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  function createComponent() {
+    return mount(
+      <NotebookView loadAnnotationsService={fakeLoadAnnotationsService} />
+    );
+  }
+
+  it('loads annotations for the currently-focused group', () => {
+    fakeStore.focusedGroup.returns({ id: 'hallothere', name: 'Hallo' });
+    createComponent();
+
+    assert.calledWith(
+      fakeLoadAnnotationsService.load,
+      sinon.match({ groupId: 'hallothere', maxResults: 5000 })
+    );
+    assert.calledWith(fakeStore.setSortKey, 'Newest');
+  });
+
+  it('renders the current group name', () => {
+    fakeStore.focusedGroup.returns({ id: 'hallothere', name: 'Hallo' });
+    const wrapper = createComponent();
+
+    assert.equal(wrapper.find('.notebook-view__heading').text(), 'Hallo');
+  });
+
+  it('renders a placeholder if group name missing', () => {
+    fakeStore.focusedGroup.returns({ id: 'hallothere' });
+    const wrapper = createComponent();
+
+    assert.equal(wrapper.find('.notebook-view__heading').text(), '…');
+  });
+
+  describe('results count', () => {
+    [
+      {
+        rootThread: { totalChildren: 5, replyCount: 15 },
+        expected: '5 threads (15 annotations)',
+      },
+      {
+        rootThread: { totalChildren: 0, replyCount: 0 },
+        expected: 'No results',
+      },
+      {
+        rootThread: { totalChildren: 0, replyCount: 15 },
+        expected: 'No results',
+      },
+      {
+        rootThread: { totalChildren: 1, replyCount: 1 },
+        expected: '1 thread (1 annotation)',
+      },
+    ].forEach(test => {
+      it('renders number of threads and annotations', () => {
+        fakeUseRootThread.returns(test.rootThread);
+        const wrapper = createComponent();
+
+        assert.equal(
+          wrapper.find('.notebook-view__results').text(),
+          test.expected
+        );
+      });
+    });
+  });
+});

--- a/src/sidebar/components/test/user-menu-test.js
+++ b/src/sidebar/components/test/user-menu-test.js
@@ -51,6 +51,7 @@ describe('UserMenu', () => {
       authDomain: 'hypothes.is',
     };
     fakeStore = {
+      focusedGroupId: sinon.stub().returns('mygroup'),
       isFeatureEnabled: sinon.stub().returns(false),
     };
 
@@ -204,7 +205,7 @@ describe('UserMenu', () => {
         const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
         openNotebookItem.props().onClick();
         assert.calledOnce(fakeBridge.call);
-        assert.calledWith(fakeBridge.call, 'showNotebook');
+        assert.calledWith(fakeBridge.call, 'showNotebook', 'mygroup');
       });
     });
 

--- a/src/sidebar/components/user-menu.js
+++ b/src/sidebar/components/user-menu.js
@@ -42,6 +42,7 @@ import SvgIcon from '../../shared/components/svg-icon';
  * @param {UserMenuProps} props
  */
 function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
+  const focusedGroupId = useStore(store => store.focusedGroupId);
   const isThirdParty = isThirdPartyUser(auth.userid, settings.authDomain);
   const service = serviceConfig(settings);
   const isNotebookEnabled = useStore(store =>
@@ -56,7 +57,7 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
     !isThirdParty || serviceSupports('onLogoutRequestProvided');
 
   const onSelectNotebook = () => {
-    bridge.call('showNotebook');
+    bridge.call('showNotebook', focusedGroupId());
   };
 
   const onProfileSelected = () =>

--- a/src/sidebar/test/search-client-test.js
+++ b/src/sidebar/test/search-client-test.js
@@ -122,4 +122,34 @@ describe('SearchClient', () => {
       assert.calledWith(onError, err);
     });
   });
+
+  context('`maxResults` option present', () => {
+    it('emits error if results size exceeds `maxResults`', () => {
+      const client = new SearchClient(fakeSearchFn, { maxResults: 2 });
+      const onError = sinon.stub();
+      client.on('error', onError);
+
+      client.get({ uri: 'http://example.com' });
+
+      return awaitEvent(client, 'end').then(() => {
+        assert.calledOnce(onError);
+        assert.equal(
+          onError.getCall(0).args[0].message,
+          'Results size exceeds maximum allowed annotations'
+        );
+      });
+    });
+
+    it('does not emit an error if results size is <= `maxResults`', () => {
+      const client = new SearchClient(fakeSearchFn, { maxResults: 20 });
+      const onError = sinon.stub();
+      client.on('error', onError);
+
+      client.get({ uri: 'http://example.com' });
+
+      return awaitEvent(client, 'end').then(() => {
+        assert.notCalled(onError);
+      });
+    });
+  });
 });

--- a/src/styles/sidebar/components/hypothesis-app.scss
+++ b/src/styles/sidebar/components/hypothesis-app.scss
@@ -20,6 +20,15 @@
   &__content {
     @include layout.sidebar-content;
   }
+
+  // FIXME: Temporary affordance for the Notebook view to override some
+  // layout spacing that assumes the presence of the top bar
+  &--notebook {
+    padding: var.$layout-space;
+    @include responsive.respond-to(tablets desktops) {
+      padding: var.$layout-space--xlarge;
+    }
+  }
 }
 
 // Disable scroll anchoring as it interferes with `ThreadList` and

--- a/src/styles/sidebar/components/notebook-view.scss
+++ b/src/styles/sidebar/components/notebook-view.scss
@@ -1,0 +1,50 @@
+@use "../../mixins/responsive";
+@use "../../mixins/utils";
+@use "../../variables" as var;
+
+.notebook-view {
+  display: grid;
+  row-gap: var.$layout-space--xsmall;
+  grid-template-areas:
+    'heading'
+    'results'
+    'items';
+
+  h1 {
+    display: inline;
+    font-size: var.$font-size--heading;
+    font-weight: bold;
+  }
+
+  h2 {
+    display: inline;
+    font-size: var.$font-size--subheading;
+    font-weight: bold;
+  }
+
+  &__heading {
+    grid-area: heading;
+    font-size: var.$font-size--heading;
+    font-weight: bold;
+  }
+
+  &__results {
+    grid-area: results;
+  }
+
+  &__items {
+    grid-area: items;
+  }
+
+  @include responsive.tablet-and-up {
+    grid-template-areas:
+      'heading results'
+      'items items';
+
+    &__results {
+      // Right-aligned when sharing a row with the heading
+      text-align: right;
+      align-self: end;
+    }
+  }
+}

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -38,6 +38,7 @@
 @use './components/menu-item';
 @use './components/menu-section';
 @use './components/moderation-banner';
+@use './components/notebook-view';
 @use './components/selection-tabs';
 @use './components/share-annotations-panel';
 @use './components/search-input';

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -79,6 +79,8 @@ $font-size--xsmall: 10px;
 $font-size--small: 11px;
 $font-size--medium: 13px;
 $font-size--large: 14px;
+$font-size--subheading: 16px;
+$font-size--heading: 18px;
 $line-height: 1.4;
 
 // Minimum font size for <input> fields on iOS. If the font size is smaller than
@@ -92,6 +94,8 @@ $layout-space--xxsmall: $layout-space * (1/4);
 $layout-space--xsmall: $layout-space * (1/2);
 $layout-space--small: $layout-space * (3/4);
 $layout-space--medium: $layout-space;
+$layout-space--large: $layout-space * 2;
+$layout-space--xlarge: $layout-space * 4;
 
 // Minimum recommended size for tap targets on mobile.
 // This value originated from Apple's Human Interface Guidelines.


### PR DESCRIPTION
Depends on #2766 

Part of https://github.com/hypothesis/product-backlog/issues/1161

This PR provides the ability to view the set of annotation threads in the currently-focused group in the Notebook, ordered reverse-chronologically.

To see in action, make sure the `notebook_launch` feature flag is enabled for you locally and use the `Open Notebook` option from the user menu in the sidebar. You should see a reverse-chronological view of all of the annotations in the currently-focused group, with some thread and annotation count information at the top.

On wider screens, it looks like this:

![image](https://user-images.githubusercontent.com/439947/100260925-08e6dc00-2f18-11eb-8202-a9e1d771ff12.png)

On narrow screens:

![image](https://user-images.githubusercontent.com/439947/100260892-fbc9ed00-2f17-11eb-81dd-fb6f3a721cc0.png)


How this PR accomplishes this:

* Passes the currently-focused group ID when showing the notebook and setting that as the focused group for the Notebook
* Updates the `SearchClient` and `LoadAnnotationsServices` to be able to (somewhat safely) load all of the annotations in a given group
* Establishes a `NotebookView` component and its bits and bobs and the minimal basis of a responsive layout. This view loads all annotations from the current group in reverse-chronological order.

## What to Expect (in scope for this PR)

* Getting the vocabulary and wording right for how we tell users how many "things" they're looking at.
* A group's annotations should load, assuming there are fewer than 5000 annotations in the group at hand. You should see newest annotations first.
* The annotation collection should change (correctly) if you close the Notebook, change the focused group, and open the Notebook again.


![image](https://user-images.githubusercontent.com/439947/100261883-662f5d00-2f19-11eb-81ed-cf7aaa5c0b8c.png)

![image](https://user-images.githubusercontent.com/439947/100261927-734c4c00-2f19-11eb-9be9-5abc29c2bf47.png)


## What not to Expect (out of scope for this PR)

* Nice loading affordances—we need to handle a loading state for this new view
* Truly handsome layout and design—current components should fit on the screen but are basic and inelegant at this time. And we need the right UI for exiting this view.
* The right stuff on the annotation cards themselves, necessarily. We're just wholesale reusing the sidebar's annotation thread cards at present
* Filtering by user. Not yet, but coming!

Fixes https://github.com/hypothesis/client/issues/2728
Fixes https://github.com/hypothesis/client/issues/2726
Addresses parts of https://github.com/hypothesis/client/issues/2730
