### PR TITLE
Improve fuzzy quote matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "core-js": "^3.4.1",
     "cross-env": "^7.0.0",
     "diff": "^5.0.0",
-    "dom-anchor-text-quote": "^4.0.2",
     "dompurify": "^2.0.1",
     "enzyme": "^3.8.0",
     "enzyme-adapter-preact-pure": "^2.0.0",

--- a/src/annotator/anchoring/test/types-test.js
+++ b/src/annotator/anchoring/test/types-test.js
@@ -225,19 +225,13 @@ describe('annotator/anchoring/types', () => {
   });
 
   describe('TextQuoteAnchor', () => {
-    let fakeQuoteToRange;
-    let fakeQuoteFromRange;
-    let fakeToTextPosition;
+    let fakeMatchQuote;
 
     beforeEach(() => {
-      fakeQuoteToRange = sinon.stub();
-      fakeQuoteFromRange = sinon.stub();
-      fakeToTextPosition = sinon.stub();
+      fakeMatchQuote = sinon.stub();
       $imports.$mock({
-        'dom-anchor-text-quote': {
-          fromRange: fakeQuoteFromRange,
-          toRange: fakeQuoteToRange,
-          toTextPosition: fakeToTextPosition,
+        './match-quote': {
+          matchQuote: fakeMatchQuote,
         },
       });
     });
@@ -255,12 +249,11 @@ describe('annotator/anchoring/types', () => {
 
     describe('#fromRange', () => {
       it('returns a TextQuoteAnchor instance', () => {
-        fakeQuoteFromRange.returns({
-          prefix: 'Four score and ',
-          suffix: 'brought forth on this continent',
-        });
-        const anchor = TextQuoteAnchor.fromRange(container, new Range());
-        assert.called(fakeQuoteFromRange);
+        const range = new Range();
+        range.selectNodeContents(container);
+        const anchor = TextQuoteAnchor.fromRange(container, range);
+
+        // TODO - Check the properties of the returned anchor.
         assert.instanceOf(anchor, TextQuoteAnchor);
       });
     });
@@ -292,9 +285,7 @@ describe('annotator/anchoring/types', () => {
     describe('#toRange', () => {
       it('returns a valid DOM Range', () => {
         $imports.$restore({
-          'dom-anchor-text-quote': {
-            toRange: true,
-          },
+          './match-quote': true,
         });
         const quoteAnchor = new TextQuoteAnchor(container, 'Liberty');
         const range = quoteAnchor.toRange();
@@ -303,11 +294,7 @@ describe('annotator/anchoring/types', () => {
       });
 
       it('throws if the quote is not found', () => {
-        $imports.$restore({
-          'dom-anchor-text-quote': {
-            toRange: true,
-          },
-        });
+        fakeMatchQuote.returns(null);
         const quoteAnchor = new TextQuoteAnchor(
           container,
           'five score and nine years ago'
@@ -321,9 +308,7 @@ describe('annotator/anchoring/types', () => {
     describe('#toPositionAnchor', () => {
       it('returns a TextPositionAnchor instance', () => {
         $imports.$restore({
-          'dom-anchor-text-quote': {
-            toTextPosition: true,
-          },
+          './match-quote': true,
         });
         const quoteAnchor = new TextQuoteAnchor(container, 'Liberty');
         const pos = quoteAnchor.toPositionAnchor();
@@ -332,9 +317,7 @@ describe('annotator/anchoring/types', () => {
 
       it('throws if the quote is not found', () => {
         $imports.$restore({
-          'dom-anchor-text-quote': {
-            toTextPosition: true,
-          },
+          './match-quote': true,
         });
         const quoteAnchor = new TextQuoteAnchor(
           container,
@@ -348,9 +331,8 @@ describe('annotator/anchoring/types', () => {
 
     describe('integration tests', () => {
       beforeEach(() => {
-        // restore dom-anchor-text-quote to test third party lib integration
         $imports.$restore({
-          'dom-anchor-text-quote': true,
+          './match-quote': true,
         });
       });
 

--- a/src/annotator/anchoring/test/types-test.js
+++ b/src/annotator/anchoring/test/types-test.js
@@ -5,6 +5,8 @@ import {
   $imports,
 } from '../types';
 
+import { TextRange } from '../text-range';
+
 // These are primarily basic API tests for the anchoring classes. Tests for
 // anchoring a variety of HTML and PDF content exist in `html-test` and
 // `pdf-test`.
@@ -249,12 +251,23 @@ describe('annotator/anchoring/types', () => {
 
     describe('#fromRange', () => {
       it('returns a TextQuoteAnchor instance', () => {
-        const range = new Range();
-        range.selectNodeContents(container);
+        const quote = 'our fathers';
+        const text = container.textContent;
+        const pos = text.indexOf(quote);
+        const range = TextRange.fromOffsets(
+          container,
+          pos,
+          pos + quote.length
+        ).toRange();
+
         const anchor = TextQuoteAnchor.fromRange(container, range);
 
-        // TODO - Check the properties of the returned anchor.
         assert.instanceOf(anchor, TextQuoteAnchor);
+        assert.equal(anchor.exact, quote);
+        assert.deepEqual(anchor.context, {
+          prefix: text.slice(Math.max(0, pos - 32), pos),
+          suffix: text.slice(pos + quote.length, pos + quote.length + 32),
+        });
       });
     });
 

--- a/src/annotator/anchoring/types.js
+++ b/src/annotator/anchoring/types.js
@@ -134,6 +134,11 @@ export class TextPositionAnchor {
 }
 
 /**
+ * @typedef QuoteMatchOptions
+ * @prop {number} [hint] - Expected position of match in text. See `matchQuote`.
+ */
+
+/**
  * Converts between `TextQuoteSelector` selectors and `Range` objects.
  */
 export class TextQuoteAnchor {
@@ -151,6 +156,10 @@ export class TextQuoteAnchor {
   }
 
   /**
+   * Create a `TextQuoteAnchor` from a range.
+   *
+   * Will throw if `range` does not contain any text nodes.
+   *
    * @param {Element} root
    * @param {Range} range
    */
@@ -200,21 +209,16 @@ export class TextQuoteAnchor {
   }
 
   /**
-   * @param {Object} [options]
-   *   @param {number} [options.hint] -
-   *     Offset hint to disambiguate matches
+   * @param {QuoteMatchOptions} [options]
    */
   toRange(options = {}) {
     return this.toPositionAnchor(options).toRange();
   }
 
   /**
-   * @param {Object} [options]
-   *   @param {number} [options.hint] -
-   *     Character offset hint to disambiguate matches.
+   * @param {QuoteMatchOptions} [options]
    */
   toPositionAnchor(options = {}) {
-    // eslint-disable-line no-unused-vars
     const text = /** @type {string} */ (this.root.textContent);
     const match = matchQuote(text, this.exact, {
       ...this.context,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1254,11 +1254,6 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ancestors@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/ancestors/-/ancestors-0.0.3.tgz#124eb944447d68b302057047d15d077a9da5179d"
-  integrity sha1-Ek65RER9aLMCBXBH0V0Hep2lF50=
-
 ansi-colors@4.1.1, ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
@@ -2761,11 +2756,6 @@ di@^0.0.1:
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
   integrity sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=
 
-diff-match-patch@^1.0.0:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
-  integrity sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==
-
 diff@4.0.2, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -2803,35 +2793,6 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
-
-dom-anchor-text-position@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/dom-anchor-text-position/-/dom-anchor-text-position-4.0.0.tgz#4c839b3bded94f0cab0f06a0189468f3f1ec2bb2"
-  integrity sha1-TIObO97ZTwyrDwagGJRo8/HsK7I=
-  dependencies:
-    dom-node-iterator "^3.5.0"
-    dom-seek "^4.0.1"
-
-dom-anchor-text-quote@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/dom-anchor-text-quote/-/dom-anchor-text-quote-4.0.2.tgz#2a1e0cd4e06c79b0bfa1284aecbf7062028fc2d7"
-  integrity sha1-Kh4M1OBsebC/oShK7L9wYgKPwtc=
-  dependencies:
-    diff-match-patch "^1.0.0"
-    dom-anchor-text-position "^4.0.0"
-
-dom-node-iterator@^3.5.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/dom-node-iterator/-/dom-node-iterator-3.5.3.tgz#32b68aa440962f1734487029f544a3db704637b7"
-  integrity sha1-MraKpECWLxc0SHAp9USj23BGN7c=
-
-dom-seek@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/dom-seek/-/dom-seek-4.0.3.tgz#f14dddf04b3fb062d901c7b00b0c142a06e0a94b"
-  integrity sha1-8U3d8Es/sGLZAcewCwwUKgbgqUs=
-  dependencies:
-    ancestors "0.0.3"
-    index-of "^0.2.0"
 
 dom-serialize@^2.2.1:
   version "2.2.1"
@@ -4303,11 +4264,6 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
-
-index-of@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/index-of/-/index-of-0.2.0.tgz#38c1e2367ea55dffad3b6eb592ec1cc3090d7d65"
-  integrity sha1-OMHiNn6lXf+tO261kuwcwwkNfWU=
 
 indexof@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/2814**~~

This PR replaces the quote selector anchoring algorithm with a new one added in #2087. See notes from the original draft below for the rationale.

Changes in detail:

 - Change `TextQuoteAnchor` to use `matchQuote` rather than `dom-anchor-text-quote` to find matches in the document text
 - Change `TextQuoteAnchor.toSelector` to directly generate a selector rather than delegating to `dom-anchor-text-quote`
 - Improve the tests for `TextQuoteAnchor`. In particular, make sure to check the properties of objects returned by the various methods instead of just their type.
 - Replace unnecessary `dom-anchor-text-quote` usage in tests for `anchoring/pdf.js`.

One choice I want to note regarding the tests is that they mock `matchQuote` but not `TextRange` (used for text position <-> Range conversion). I think this is a good balance of making it easy to test the behaviors of `TextQuoteAnchor` without coupling the tests too much to implementation details.

----

**Notes from the original draft PR:**

1. On pages where there are many annotations and significant edits since those annotations were created, anchoring quote selectors can be really slow and lock up the browser for several seconds. See http://www.americanyawp.com/text/01-the-new-world/ for example and #189 (this issue also contains analysis of the problem). The new implementation has similar performance when all the quotes match exactly, but is much faster in the worst case.
2. The previous implementation has quite a low tolerance for mismatches between the current and originally anchored text before it gives up and considers an annotation to be "orphaned". The new implementation can tolerate more mismatches, allowing it to anchor quotes that previously orphaned.
3. It is difficult to describe how exactly the current "fuzzy" matching works and how fuzzy/approximate it allows matches to be. This means we can't easily explain to users/internally about why an incorrect match happened or fuzzy anchoring failed when we should have found a match. Finding the best match for an annotation in an edited document in all cases would require general intelligence. In lieu of that, I think the best approach is for us to try and have a straightforward algorithm that works well in the majority of cases and where we can easily describe how it works, what it's limitations are and tweak it as necessary.

----

As an illustration of the performance improvements, here is a comparison of the amount of time spend anchoring annotations in the Public group on http://www.americanyawp.com/text/01-the-new-world/.

With the previous implementation:

<img width="350" alt="DATQ quote matcher" src="https://user-images.githubusercontent.com/2458/100739895-b9008d00-33cf-11eb-8367-a241112b3a21.png">

With the new implementation:

<img width="373" alt="Myers quote matcher" src="https://user-images.githubusercontent.com/2458/100739946-d2a1d480-33cf-11eb-9b65-950a2b009f99.png">

On this page, the old algorithm produced 329 matches and 137 orphans. The new implementation finds 403 matches and 63 orphans. Here is an example of an annotation that anchors with the new implementation but did not under the old one:

<img width="1136" alt="fuzzy-match" src="https://user-images.githubusercontent.com/2458/100740174-2d3b3080-33d0-11eb-9d0e-12e772b6736c.png">

Note there are significant changes in the text, but the current text is close enough to the text that was originally annotated to consider it a match.

Note: Not all of the 403 matches are good. In particular both the old and new implementations are prone to finding incorrect matches for short terms (eg. for "mastodons" and "megafauna" in this document). The new implementation should make it easier to rectify that later by changing this logic though.

----

The technical changes in this PR are:

- Implement a new fuzzy/approximate quote selecting matching algorithm in the `matchQuote` function in `src/annotator/anchoring/match-quote.js`
- Change the `TextQuoteAnchor` class to use `matchQuote` to anchor text quotes, and `TextRange` to generate quote selectors

For details on the fuzzy string matching algorithm itself, see the [approx-string-match README](https://github.com/robertknight/approx-string-match-js). The heart of the previous implementation came from the [diff-match-patch](https://github.com/google/diff-match-patch) library, which was used indirectly via `dom-anchor-text-quote`. The TL;DR is that this library uses a more recent algorithm which can tolerate a larger number of errors with reasonable efficiency. It is also easier to program with because it accepts arbitrarily long patterns, whereas diff-match-patch only allows patterns up to 32 characters and so dom-anchor-text-quote had to work around that.