### PR TITLE
Remove all links, stylesheets and scripts added by the boot script when the client is unloaded

### DIFF
--- a/dev-server/serve-dev.js
+++ b/dev-server/serve-dev.js
@@ -29,9 +29,31 @@ function renderScript(context) {
   const scriptTemplate = `
     {{{hypothesisConfig}}}
     <script>
-    const embedScript = document.createElement('script');
-    embedScript.src = '{{{clientUrl}}}'.replace('{current_host}', document.location.hostname);
-    document.body.appendChild(embedScript);
+    const toggleClientButton = document.querySelector('#toggleClient');
+
+    function loadClient() {
+      const embedScript = document.createElement('script');
+      embedScript.src = '{{{clientUrl}}}'.replace('{current_host}', document.location.hostname);
+      document.body.appendChild(embedScript);
+      toggleClient.textContent = 'Unload client';
+    }
+
+    function unloadClient() {
+      const annotatorLink = document.querySelector('link[type="application/annotator+html"]');
+      annotatorLink?.dispatchEvent(new Event('destroy'));
+      toggleClient.textContent = 'Load client';
+    }
+
+    toggleClientButton.onclick = () => {
+      const isLoaded = document.querySelector('link[type="application/annotator+html"]');
+      if (isLoaded) {
+        unloadClient();
+      } else {
+        loadClient();
+      }
+    };
+
+    loadClient();
     </script>
   `;
   return Mustache.render(scriptTemplate, context);

--- a/dev-server/serve-dev.js
+++ b/dev-server/serve-dev.js
@@ -28,35 +28,12 @@ const TEMPLATE_PATH = `${__dirname}/templates/`;
 function renderScript(context) {
   const scriptTemplate = `
     {{{hypothesisConfig}}}
-    <script>
 
-    // Button to load/unload the client. Not present on all pages so we create
-    // a dummy one if missing.
-    const toggleClientButton = document.querySelector('.js-toggle-client') || document.createElement('button');
+    <script type="module">
+      import { loadClient } from '/scripts/util.js';
 
-    function loadClient() {
-      const embedScript = document.createElement('script');
-      embedScript.src = '{{{clientUrl}}}'.replace('{current_host}', document.location.hostname);
-      document.body.appendChild(embedScript);
-      toggleClientButton.textContent = 'Unload client';
-    }
-
-    function unloadClient() {
-      const annotatorLink = document.querySelector('link[type="application/annotator+html"]');
-      annotatorLink?.dispatchEvent(new Event('destroy'));
-      toggleClientButton.textContent = 'Load client';
-    }
-
-    toggleClientButton.onclick = () => {
-      const isLoaded = document.querySelector('link[type="application/annotator+html"]');
-      if (isLoaded) {
-        unloadClient();
-      } else {
-        loadClient();
-      }
-    };
-
-    loadClient();
+      const clientUrl = '{{{clientUrl}}}'.replace('{current_host}', document.location.hostname);
+      loadClient(clientUrl);
     </script>
   `;
   return Mustache.render(scriptTemplate, context);

--- a/dev-server/serve-dev.js
+++ b/dev-server/serve-dev.js
@@ -29,19 +29,22 @@ function renderScript(context) {
   const scriptTemplate = `
     {{{hypothesisConfig}}}
     <script>
-    const toggleClientButton = document.querySelector('#toggleClient');
+
+    // Button to load/unload the client. Not present on all pages so we create
+    // a dummy one if missing.
+    const toggleClientButton = document.querySelector('.js-toggle-client') || document.createElement('button');
 
     function loadClient() {
       const embedScript = document.createElement('script');
       embedScript.src = '{{{clientUrl}}}'.replace('{current_host}', document.location.hostname);
       document.body.appendChild(embedScript);
-      toggleClient.textContent = 'Unload client';
+      toggleClientButton.textContent = 'Unload client';
     }
 
     function unloadClient() {
       const annotatorLink = document.querySelector('link[type="application/annotator+html"]');
       annotatorLink?.dispatchEvent(new Event('destroy'));
-      toggleClient.textContent = 'Load client';
+      toggleClientButton.textContent = 'Load client';
     }
 
     toggleClientButton.onclick = () => {

--- a/dev-server/static/scripts/index.js
+++ b/dev-server/static/scripts/index.js
@@ -1,3 +1,5 @@
+// Code for controls on the dev server homepage.
+
 import { activeClientUrl, loadClient, unloadClient } from './util.js';
 
 const toggleClientButton = document.querySelector('.js-toggle-client');

--- a/dev-server/static/scripts/index.js
+++ b/dev-server/static/scripts/index.js
@@ -1,0 +1,16 @@
+import { activeClientUrl, loadClient, unloadClient } from './util.js';
+
+const toggleClientButton = document.querySelector('.js-toggle-client');
+toggleClientButton.textContent = 'Unload client';
+const clientUrl = activeClientUrl;
+
+toggleClientButton.onclick = () => {
+  if (activeClientUrl) {
+    unloadClient();
+    toggleClientButton.textContent = 'Load client';
+  } else {
+    loadClient(clientUrl);
+    toggleClientButton.textContent = 'Unload client';
+  }
+};
+

--- a/dev-server/static/scripts/util.js
+++ b/dev-server/static/scripts/util.js
@@ -1,0 +1,25 @@
+/** @type {string|null} */
+export let activeClientUrl;
+
+/**
+ * Load the Hypothesis client into the page.
+ *
+ * @param {string} clientUrl
+ */
+export function loadClient(clientUrl) {
+  const embedScript = document.createElement('script');
+  embedScript.src = clientUrl;
+  document.body.appendChild(embedScript);
+  activeClientUrl = clientUrl;
+}
+
+/**
+ * Remove the Hypothesis client from the page.
+ *
+ * This uses the same method as the browser extension does to deactivate the client.
+ */
+export function unloadClient() {
+  const annotatorLink = document.querySelector('link[type="application/annotator+html"]');
+  annotatorLink?.dispatchEvent(new Event('destroy'));
+  activeClientUrl = null;
+}

--- a/dev-server/templates/client-config.js.mustache
+++ b/dev-server/templates/client-config.js.mustache
@@ -2,9 +2,6 @@
   window.hypothesisConfig = function() {
     return {
       // enableExperimentalNewNoteButton: true,
-      experimental: {
-        pdfSideBySide: true,
-      },
       // showHighlights: 'always',
       // theme: 'clean',
 

--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -49,5 +49,6 @@
     <li><a href="https://h.readthedocs.io/en/latest/api/">Hypothesis API documentation</a></li>
   </ul>
   {{{hypothesisScript}}}
+  <script type="module" src="/scripts/index.js"></script>
 </body>
 </html>

--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -40,7 +40,7 @@
   <button data-hypothesis-trigger>
     Open sidebar
   </button>
-  <button id="toggleClient">Load client</button>
+  <button class="js-toggle-client">Load client</button>
   <h2>Useful links</h2>
   <ul>
     <li><a href="https://github.com/hypothesis/client">GitHub project</a></li>

--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -40,6 +40,7 @@
   <button data-hypothesis-trigger>
     Open sidebar
   </button>
+  <button id="toggleClient">Load client</button>
   <h2>Useful links</h2>
   <ul>
     <li><a href="https://github.com/hypothesis/client">GitHub project</a></li>

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -78,7 +78,7 @@ function init() {
 
     // Remove all the `<link>`, `<script>` and `<style>` elements added to the
     // page by the boot script.
-    const clientAssets = document.querySelectorAll('[hypothesis-asset]');
+    const clientAssets = document.querySelectorAll('[data-hypothesis-asset]');
     clientAssets.forEach(el => el.remove());
   });
 }

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -73,9 +73,13 @@ function init() {
   const annotator = new Klass(document.body, config);
   const notebook = new Notebook(document.body, config);
   appLinkEl.addEventListener('destroy', function () {
-    appLinkEl.remove();
     annotator.destroy();
     notebook.destroy();
+
+    // Remove all the `<link>`, `<script>` and `<style>` elements added to the
+    // page by the boot script.
+    const clientAssets = document.querySelectorAll('[hypothesis-asset]');
+    clientAssets.forEach(el => el.remove());
   });
 }
 

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -80,7 +80,7 @@ function injectLink(doc, rel, type, url) {
   const link = doc.createElement('link');
   link.rel = rel;
   link.href = url;
-  link.type = 'application/annotator+' + type;
+  link.type = `application/annotator+${type}`;
 
   tagElement(link);
   doc.head.appendChild(link);

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -36,7 +36,7 @@ const commonPolyfills = [
  * @param {HTMLElement} el
  */
 function tagElement(el) {
-  el.setAttribute('hypothesis-asset', '');
+  el.setAttribute('data-hypothesis-asset', '');
 }
 
 /**

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -69,13 +69,13 @@ describe('bootstrap', function () {
 
   function findAssets(doc_) {
     const scripts = Array.from(
-      doc_.querySelectorAll('script[hypothesis-asset]')
+      doc_.querySelectorAll('script[data-hypothesis-asset]')
     ).map(function (el) {
       return el.src;
     });
 
     const styles = Array.from(
-      doc_.querySelectorAll('link[rel="stylesheet"][hypothesis-asset]')
+      doc_.querySelectorAll('link[rel="stylesheet"][data-hypothesis-asset]')
     ).map(function (el) {
       return el.href;
     });
@@ -102,7 +102,7 @@ describe('bootstrap', function () {
         'link[type="application/annotator+html"]'
       );
       assert.ok(sidebarAppLink);
-      assert.isTrue(sidebarAppLink.hasAttribute('hypothesis-asset'));
+      assert.isTrue(sidebarAppLink.hasAttribute('data-hypothesis-asset'));
       assert.equal(sidebarAppLink.href, 'https://marginal.ly/app.html');
     });
 

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -68,14 +68,14 @@ describe('bootstrap', function () {
   }
 
   function findAssets(doc_) {
-    const scripts = Array.from(doc_.querySelectorAll('script')).map(function (
-      el
-    ) {
+    const scripts = Array.from(
+      doc_.querySelectorAll('script[hypothesis-asset]')
+    ).map(function (el) {
       return el.src;
     });
 
     const styles = Array.from(
-      doc_.querySelectorAll('link[rel="stylesheet"]')
+      doc_.querySelectorAll('link[rel="stylesheet"][hypothesis-asset]')
     ).map(function (el) {
       return el.href;
     });
@@ -102,6 +102,7 @@ describe('bootstrap', function () {
         'link[type="application/annotator+html"]'
       );
       assert.ok(sidebarAppLink);
+      assert.isTrue(sidebarAppLink.hasAttribute('hypothesis-asset'));
       assert.equal(sidebarAppLink.href, 'https://marginal.ly/app.html');
     });
 


### PR DESCRIPTION
This PR fixes an issue where deactivating and re-activating the browser extension did not work properly after the recent addition of a new `link[type="application/annotator+html"]` element for the notebook. The problem is that the boot script checks for the existence of such a link and if found assumes the client is already active and bails out. There used to be a single link that was removed when the boot script was unloaded. Now there are multiple such links and only one gets removed when the client is unloaded.

The fix here is a general improvement to unloading of `<link>` and `<script>` tags added by the boot script when the client is unloaded. All such elements are tagged with a `hypothesis-asset` attribute by the boot script and then elements with this attribute are removed when the client is unloaded.

I also added a "Load client" / "Unload client" toggle button to the dev server to make it easier to test this without having to build the extension.