### PR TITLE
Split `selection` into two store modules and refactor complex `rootSelectors`

### DIFF
--- a/src/sidebar/components/filter-status.js
+++ b/src/sidebar/components/filter-status.js
@@ -1,4 +1,5 @@
 import { createElement } from 'preact';
+import { useMemo } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import { countVisible } from '../util/thread';
@@ -9,8 +10,17 @@ import useRootThread from './hooks/use-root-thread';
 import useStore from '../store/use-store';
 
 /**
- * @typedef {import('../store/modules/filters').FilterState} FilterState
  * @typedef {import('../util/build-thread').Thread} Thread
+ */
+
+/**
+ * @typedef FilterState
+ * @prop {string|null} filterQuery
+ * @prop {boolean} focusActive
+ * @prop {boolean} focusConfigured
+ * @prop {string|null} focusDisplayName
+ * @prop {number} forcedVisibleCount
+ * @prop {number} selectedCount
  */
 
 /**
@@ -267,7 +277,26 @@ FocusFilterStatus.propTypes = {
  */
 export default function FilterStatus() {
   const rootThread = useRootThread();
-  const filterState = useStore(store => store.filterState());
+
+  const focusState = useStore(store => store.focusState());
+  const forcedVisibleCount = useStore(
+    store => store.forcedVisibleAnnotations().length
+  );
+  const filterQuery = useStore(store => store.filterQuery());
+  const selectedCount = useStore(store => store.selectedAnnotations().length);
+
+  // Build a memoized state object with filter and selection details
+  // This will be used by the FilterStatus subcomponents
+  const filterState = useMemo(() => {
+    return {
+      filterQuery,
+      focusActive: focusState.active,
+      focusConfigured: focusState.configured,
+      focusDisplayName: focusState.displayName,
+      forcedVisibleCount,
+      selectedCount,
+    };
+  }, [focusState, forcedVisibleCount, filterQuery, selectedCount]);
 
   if (filterState.selectedCount > 0) {
     return (

--- a/src/sidebar/components/filter-status.js
+++ b/src/sidebar/components/filter-status.js
@@ -9,7 +9,7 @@ import useRootThread from './hooks/use-root-thread';
 import useStore from '../store/use-store';
 
 /**
- * @typedef {import('../store/modules/selection').FilterState} FilterState
+ * @typedef {import('../store/modules/filters').FilterState} FilterState
  * @typedef {import('../util/build-thread').Thread} Thread
  */
 

--- a/src/sidebar/components/hooks/test/use-root-thread-test.js
+++ b/src/sidebar/components/hooks/test/use-root-thread-test.js
@@ -7,7 +7,11 @@ describe('sidebar/components/hooks/use-root-thread', () => {
 
   beforeEach(() => {
     fakeStore = {
-      threadState: sinon.stub(),
+      allAnnotations: sinon.stub().returns(['1', '2']),
+      filterQuery: sinon.stub().returns('itchy'),
+      route: sinon.stub().returns('66'),
+      selectionState: sinon.stub().returns({ hi: 'there' }),
+      userFilter: sinon.stub().returns('hotspur'),
     };
     fakeThreadAnnotations = sinon.stub();
 
@@ -23,11 +27,14 @@ describe('sidebar/components/hooks/use-root-thread', () => {
 
   it('should return results of `threadAnnotations` with current thread state', () => {
     fakeThreadAnnotations.returns('a tisket, a tasket');
-    fakeStore.threadState.returns('current-thread-state');
 
     const results = useRootThread();
 
-    assert.calledWith(fakeThreadAnnotations, 'current-thread-state');
+    const threadState = fakeThreadAnnotations.getCall(0).args[0];
+    assert.deepEqual(threadState.annotations, ['1', '2']);
+    assert.equal(threadState.selection.filterQuery, 'itchy');
+    assert.equal(threadState.route, '66');
+    assert.equal(threadState.selection.filters.user, 'hotspur');
     assert.equal(results, 'a tisket, a tasket');
   });
 });

--- a/src/sidebar/components/hooks/use-root-thread.js
+++ b/src/sidebar/components/hooks/use-root-thread.js
@@ -10,5 +10,23 @@ import threadAnnotations from '../../util/thread-annotations';
  * @return {Thread}
  */
 export default function useRootThread() {
-  return useStore(store => threadAnnotations(store.threadState()));
+  const annotations = useStore(store => store.allAnnotations());
+  const query = useStore(store => store.filterQuery());
+  const route = useStore(store => store.route());
+  const selectionState = useStore(store => store.selectionState());
+  const filters = useStore(store => {
+    /** @type {Object.<string,string>} */
+    const filters = {};
+    const userFilter = store.userFilter();
+    if (userFilter) {
+      filters.user = userFilter;
+    }
+    return filters;
+  });
+
+  return threadAnnotations({
+    annotations,
+    route,
+    selection: { ...selectionState, filterQuery: query, filters },
+  });
 }

--- a/src/sidebar/components/hooks/use-root-thread.js
+++ b/src/sidebar/components/hooks/use-root-thread.js
@@ -1,3 +1,5 @@
+import { useMemo } from 'preact/hooks';
+
 import useStore from '../../store/use-store';
 import threadAnnotations from '../../util/thread-annotations';
 
@@ -14,19 +16,22 @@ export default function useRootThread() {
   const query = useStore(store => store.filterQuery());
   const route = useStore(store => store.route());
   const selectionState = useStore(store => store.selectionState());
-  const filters = useStore(store => {
+  const userFilter = useStore(store => store.userFilter());
+
+  const threadState = useMemo(() => {
     /** @type {Object.<string,string>} */
     const filters = {};
-    const userFilter = store.userFilter();
     if (userFilter) {
       filters.user = userFilter;
     }
-    return filters;
-  });
+    return {
+      annotations,
+      filters,
+      query,
+      route,
+      selection: { ...selectionState, filterQuery: query, filters },
+    };
+  }, [annotations, query, route, selectionState, userFilter]);
 
-  return threadAnnotations({
-    annotations,
-    route,
-    selection: { ...selectionState, filterQuery: query, filters },
-  });
+  return threadAnnotations(threadState);
 }

--- a/src/sidebar/components/sidebar-view.js
+++ b/src/sidebar/components/sidebar-view.js
@@ -39,7 +39,9 @@ function SidebarView({
 
   // Store state values
   const focusedGroupId = useStore(store => store.focusedGroupId());
-  const hasAppliedFilter = useStore(store => store.hasAppliedFilter());
+  const hasAppliedFilter = useStore(store => {
+    return store.hasAppliedFilter() || store.hasSelectedAnnotations();
+  });
   const isLoading = useStore(store => store.isLoading());
   const isLoggedIn = useStore(store => store.isLoggedIn());
 

--- a/src/sidebar/components/test/filter-status-test.js
+++ b/src/sidebar/components/test/filter-status-test.js
@@ -16,6 +16,14 @@ function getFilterState() {
   };
 }
 
+function getFocusState() {
+  return {
+    active: false,
+    configured: false,
+    focusDisplayName: '',
+  };
+}
+
 describe('FilterStatus', () => {
   let fakeStore;
   let fakeUseRootThread;
@@ -33,7 +41,11 @@ describe('FilterStatus', () => {
       annotationCount: sinon.stub(),
       clearSelection: sinon.stub(),
       directLinkedAnnotationId: sinon.stub(),
+      filterQuery: sinon.stub().returns(null),
       filterState: sinon.stub().returns(getFilterState()),
+      focusState: sinon.stub().returns(getFocusState()),
+      forcedVisibleAnnotations: sinon.stub().returns([]),
+      selectedAnnotations: sinon.stub().returns([]),
       toggleFocusMode: sinon.stub(),
     };
 
@@ -77,11 +89,8 @@ describe('FilterStatus', () => {
   });
 
   context('(State 2): filtered by query', () => {
-    let filterState;
-
     beforeEach(() => {
-      filterState = { ...getFilterState(), filterQuery: 'foobar' };
-      fakeStore.filterState.returns(filterState);
+      fakeStore.filterQuery.returns('foobar');
       fakeThreadUtil.countVisible.returns(1);
     });
 
@@ -105,15 +114,9 @@ describe('FilterStatus', () => {
   });
 
   context('(State 3): filtered by query with force-expanded threads', () => {
-    let filterState;
-
     beforeEach(() => {
-      filterState = {
-        ...getFilterState(),
-        filterQuery: 'foobar',
-        forcedVisibleCount: 3,
-      };
-      fakeStore.filterState.returns(filterState);
+      fakeStore.filterQuery.returns('foobar');
+      fakeStore.forcedVisibleAnnotations.returns([1, 2, 3]);
       fakeThreadUtil.countVisible.returns(5);
     });
 
@@ -130,14 +133,8 @@ describe('FilterStatus', () => {
   });
 
   context('(State 4): selected annotations', () => {
-    let filterState;
-
     beforeEach(() => {
-      filterState = {
-        ...getFilterState(),
-        selectedCount: 1,
-      };
-      fakeStore.filterState.returns(filterState);
+      fakeStore.selectedAnnotations.returns([1]);
     });
 
     it('should show the count of annotations', () => {
@@ -145,8 +142,7 @@ describe('FilterStatus', () => {
     });
 
     it('should pluralize annotations when necessary', () => {
-      filterState.selectedCount = 4;
-      fakeStore.filterState.returns(filterState);
+      fakeStore.selectedAnnotations.returns([1, 2, 3, 4]);
 
       assertFilterText(createComponent(), 'Showing 4 annotations');
     });
@@ -198,16 +194,12 @@ describe('FilterStatus', () => {
   });
 
   context('(State 5): user-focus mode active', () => {
-    let filterState;
-
     beforeEach(() => {
-      filterState = {
-        ...getFilterState(),
-        focusActive: true,
-        focusConfigured: true,
-        focusDisplayName: 'Ebenezer Studentolog',
-      };
-      fakeStore.filterState.returns(filterState);
+      fakeStore.focusState.returns({
+        active: true,
+        configured: true,
+        displayName: 'Ebenezer Studentolog',
+      });
       fakeThreadUtil.countVisible.returns(1);
     });
 
@@ -244,17 +236,13 @@ describe('FilterStatus', () => {
   });
 
   context('(State 6): user-focus mode active, filtered by query', () => {
-    let filterState;
-
     beforeEach(() => {
-      filterState = {
-        ...getFilterState(),
-        focusActive: true,
-        focusConfigured: true,
-        focusDisplayName: 'Ebenezer Studentolog',
-        filterQuery: 'biscuits',
-      };
-      fakeStore.filterState.returns(filterState);
+      fakeStore.focusState.returns({
+        active: true,
+        configured: true,
+        displayName: 'Ebenezer Studentolog',
+      });
+      fakeStore.filterQuery.returns('biscuits');
       fakeThreadUtil.countVisible.returns(1);
     });
 
@@ -289,18 +277,14 @@ describe('FilterStatus', () => {
   context(
     '(State 7): user-focus mode active, filtered by query, force-expanded threads',
     () => {
-      let filterState;
-
       beforeEach(() => {
-        filterState = {
-          ...getFilterState(),
-          focusActive: true,
-          focusConfigured: true,
-          focusDisplayName: 'Ebenezer Studentolog',
-          filterQuery: 'biscuits',
-          forcedVisibleCount: 2,
-        };
-        fakeStore.filterState.returns(filterState);
+        fakeStore.focusState.returns({
+          active: true,
+          configured: true,
+          displayName: 'Ebenezer Studentolog',
+        });
+        fakeStore.filterQuery.returns('biscuits');
+        fakeStore.forcedVisibleAnnotations.returns([1, 2]);
         fakeThreadUtil.countVisible.returns(3);
       });
 
@@ -318,17 +302,13 @@ describe('FilterStatus', () => {
   );
 
   context('(State 8): user-focus mode active, selected annotations', () => {
-    let filterState;
-
     beforeEach(() => {
-      filterState = {
-        ...getFilterState(),
-        focusActive: true,
-        focusConfigured: true,
-        focusDisplayName: 'Ebenezer Studentolog',
-        selectedCount: 2,
-      };
-      fakeStore.filterState.returns(filterState);
+      fakeStore.focusState.returns({
+        active: true,
+        configured: true,
+        displayName: 'Ebenezer Studentolog',
+      });
+      fakeStore.selectedAnnotations.returns([1, 2]);
     });
 
     it('should ignore user and display selected annotations', () => {
@@ -345,17 +325,13 @@ describe('FilterStatus', () => {
   });
 
   context('(State 9): user-focus mode active, force-expanded threads', () => {
-    let filterState;
-
     beforeEach(() => {
-      filterState = {
-        ...getFilterState(),
-        focusActive: true,
-        focusConfigured: true,
-        focusDisplayName: 'Ebenezer Studentolog',
-        forcedVisibleCount: 3,
-      };
-      fakeStore.filterState.returns(filterState);
+      fakeStore.focusState.returns({
+        active: true,
+        configured: true,
+        displayName: 'Ebenezer Studentolog',
+      });
+      fakeStore.forcedVisibleAnnotations.returns([1, 2, 3]);
       fakeThreadUtil.countVisible.returns(7);
     });
 
@@ -367,8 +343,7 @@ describe('FilterStatus', () => {
     });
 
     it('should handle cases when there are no focused-user annotations', () => {
-      filterState = { ...filterState, forcedVisibleCount: 7 };
-      fakeStore.filterState.returns(filterState);
+      fakeStore.forcedVisibleAnnotations.returns([1, 2, 3, 4, 5, 6, 7]);
       assertFilterText(
         createComponent(),
         'No annotations by Ebenezer Studentolog (and 7 more)'
@@ -385,16 +360,12 @@ describe('FilterStatus', () => {
   });
 
   context('(State 10): user-focus mode configured but inactive', () => {
-    let filterState;
-
     beforeEach(() => {
-      filterState = {
-        ...getFilterState(),
-        focusActive: false,
-        focusConfigured: true,
-        focusDisplayName: 'Ebenezer Studentolog',
-      };
-      fakeStore.filterState.returns(filterState);
+      fakeStore.focusState.returns({
+        active: false,
+        configured: true,
+        displayName: 'Ebenezer Studentolog',
+      });
       fakeThreadUtil.countVisible.returns(7);
     });
 

--- a/src/sidebar/components/test/sidebar-view-test.js
+++ b/src/sidebar/components/test/sidebar-view-test.js
@@ -51,6 +51,7 @@ describe('SidebarView', () => {
       focusedGroupId: sinon.stub(),
       hasAppliedFilter: sinon.stub(),
       hasFetchedAnnotations: sinon.stub(),
+      hasSelectedAnnotations: sinon.stub(),
       hasSidebarOpened: sinon.stub(),
       isLoading: sinon.stub().returns(false),
       isLoggedIn: sinon.stub(),
@@ -252,6 +253,14 @@ describe('SidebarView', () => {
 
     it('does not render tabs if there is an applied filter', () => {
       fakeStore.hasAppliedFilter.returns(true);
+
+      const wrapper = createComponent();
+
+      assert.isFalse(wrapper.find('SelectionTabs').exists());
+    });
+
+    it('does not render tabs if there are selected annotations', () => {
+      fakeStore.hasSelectedAnnotations.returns(true);
 
       const wrapper = createComponent();
 

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -36,6 +36,7 @@ import annotations from './modules/annotations';
 import defaults from './modules/defaults';
 import directLinked from './modules/direct-linked';
 import drafts from './modules/drafts';
+import filters from './modules/filters';
 import frames from './modules/frames';
 import groups from './modules/groups';
 import links from './modules/links';
@@ -57,6 +58,7 @@ import viewer from './modules/viewer';
  * @typedef {import("./modules/defaults").DefaultsStore} DefaultsStore
  * @typedef {import("./modules/direct-linked").DirectLinkedStore} DirectLinkedStore
  * @typedef {import("./modules/drafts").DraftsStore} DraftsStore
+ * @typedef {import("./modules/filters").FiltersStore} FiltersStore
  * @typedef {import("./modules/frames").FramesStore} FramesStore
  * @typedef {import("./modules/groups").GroupsStore} GroupsStore
  * @typedef {import("./modules/links").LinksStore} LinksStore
@@ -76,6 +78,7 @@ import viewer from './modules/viewer';
  *  DefaultsStore &
  *  DirectLinkedStore &
  *  DraftsStore &
+ *  FiltersStore &
  *  FramesStore &
  *  GroupsStore &
  *  LinksStore &
@@ -109,6 +112,7 @@ export default function store(settings) {
     defaults,
     directLinked,
     drafts,
+    filters,
     frames,
     links,
     groups,

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -413,6 +413,15 @@ const annotationCount = createSelector(
 );
 
 /**
+ * Retrieve all annotations currently in the store
+ *
+ * @type {(state: any) => Annotation[]}
+ */
+function allAnnotations(state) {
+  return state.annotations;
+}
+
+/**
  * Does the annotation indicated by `id` exist in the collection?
  *
  * @param {string} id
@@ -556,9 +565,10 @@ function savedAnnotations(state) {
  * @prop {typeof unhideAnnotation} unhideAnnotation
  * @prop {typeof updateAnchorStatus} updateAnchorStatus
  * @prop {typeof updateFlagStatus} updateFlagStatus
- 
+
  *
  * // Selectors
+ * @prop {() => Annotation[]} allAnnotations
  * @prop {() => number} annotationCount
  * @prop {(id: string) => boolean} annotationExists
  * @prop {(id: string) => Annotation} findAnnotationByID
@@ -591,6 +601,7 @@ export default {
   },
 
   selectors: {
+    allAnnotations,
     annotationCount,
     annotationExists,
     findAnnotationByID,

--- a/src/sidebar/store/modules/filters.js
+++ b/src/sidebar/store/modules/filters.js
@@ -1,7 +1,6 @@
 import { createSelector } from 'reselect';
 
 import { actionTypes } from '../util';
-import { trueKeys } from '../../util/collections';
 
 /**
  * @typedef FocusConfig
@@ -24,7 +23,7 @@ import { trueKeys } from '../../util/collections';
  */
 
 /**
- * @typedef FocusState
+ * @typedef Focus
  * @prop {boolean} configured - Focus config contains valid `user` and
  *           is good to go
  * @prop {boolean} active - Focus mode is currently applied
@@ -32,14 +31,10 @@ import { trueKeys } from '../../util/collections';
  */
 
 /**
- * TODO potentially split into `FilterState` and `FocusState`?
- * @typedef FilterState
- * @prop {string|null} filterQuery
- * @prop {boolean} focusActive
- * @prop {boolean} focusConfigured
- * @prop {string|null} focusDisplayName
- * @prop {number} forcedVisibleCount
- * @prop {number} selectedCount
+ * @typedef FocusState
+ * @prop {boolean} active
+ * @prop {boolean} configured
+ * @prop {string} displayName
  */
 
 /**
@@ -54,7 +49,7 @@ import { trueKeys } from '../../util/collections';
  * and may be toggled via `toggleFocusMode`.
  *
  * @param {FocusConfig} focusConfig
- * @return {FocusState}
+ * @return {Focus}
  */
 function setFocus(focusConfig) {
   const focusDefaultState = {
@@ -172,39 +167,17 @@ function filterQuery(state) {
 }
 
 /**
- * Returns the display name for a user or the userid
- * if display name is not present. If both are missing
- * then this returns an empty string.
+ * Summary of focus state
  *
- * @return {string}
+ * @type {(state: any) => FocusState}
  */
-function focusModeUserPrettyName(state) {
-  if (!state.focus.configured) {
-    return '';
-  }
-  return state.focus.user.displayName;
-}
-
-/**
- * Summary of applied filters
- *
- * @type {(state: any) => FilterState}
- */
-const filterState = createSelector(
-  rootState => rootState.selection,
-  rootState => rootState.filters,
-  (selection, filters) => {
-    // TODO FIXME
-    const forcedVisibleCount = trueKeys(selection.forcedVisible).length;
-    // TODO FIXME
-    const selectedCount = trueKeys(selection.selected).length;
+const focusState = createSelector(
+  state => state.focus,
+  focus => {
     return {
-      filterQuery: filters.query,
-      focusActive: filters.focus.active,
-      focusConfigured: filters.focus.configured,
-      focusDisplayName: focusModeUserPrettyName(filters),
-      forcedVisibleCount,
-      selectedCount,
+      active: focus.active,
+      configured: focus.configured,
+      displayName: focus.configured ? focus.user.displayName : '',
     };
   }
 );
@@ -219,9 +192,7 @@ const filterState = createSelector(
  *
  * // Selectors
  * @prop {() => string|null} filterQuery
- *
- * // Root Selectors
- * @prop {() => FilterState} filterState
+ * @prop {() => FocusState} focusState
  *
  */
 
@@ -236,8 +207,6 @@ export default {
   },
   selectors: {
     filterQuery,
-  },
-  rootSelectors: {
-    filterState,
+    focusState,
   },
 };

--- a/src/sidebar/store/modules/filters.js
+++ b/src/sidebar/store/modules/filters.js
@@ -1,0 +1,243 @@
+import { createSelector } from 'reselect';
+
+import { actionTypes } from '../util';
+import { trueKeys } from '../../util/collections';
+
+/**
+ * @typedef FocusConfig
+ * @prop {User} user
+ */
+
+/**
+ * @typedef FocusedUser
+ * @prop {string} filter - The identifier to use for filtering annotations
+ *           derived from either a userId or a username. This may take the
+ *           form of a username, e.g. 'oakbucket', or a userid
+ * @prop {string} displayName
+ */
+
+/**
+ * @typedef User
+ * @prop {string} [userid]
+ * @prop {string} [username]
+ * @prop {string} displayName - User's display name
+ */
+
+/**
+ * @typedef FocusState
+ * @prop {boolean} configured - Focus config contains valid `user` and
+ *           is good to go
+ * @prop {boolean} active - Focus mode is currently applied
+ * @prop {FocusedUser} [user] - User to focus on (filter annotations for)
+ */
+
+/**
+ * TODO potentially split into `FilterState` and `FocusState`?
+ * @typedef FilterState
+ * @prop {string|null} filterQuery
+ * @prop {boolean} focusActive
+ * @prop {boolean} focusConfigured
+ * @prop {string|null} focusDisplayName
+ * @prop {number} forcedVisibleCount
+ * @prop {number} selectedCount
+ */
+
+/**
+ * Configure (user-)focused mode. User-focus mode may be set in one of two
+ * ways:
+ * - A `focus` object containing a valid `user` object is present in the
+ *   application's `settings` object during initialization time
+ * - A `user` object is given to the `changeFocusedUser` action (this
+ *   is implemented via an RPC method call)
+ * For focus mode to be considered configured, it must have a valid `user`.
+ * A successfully-configured focus mode will be set to `active` immediately
+ * and may be toggled via `toggleFocusMode`.
+ *
+ * @param {FocusConfig} focusConfig
+ * @return {FocusState}
+ */
+function setFocus(focusConfig) {
+  const focusDefaultState = {
+    configured: false,
+    active: false,
+  };
+
+  // To be able to apply a focused mode, a `user` object must be present,
+  // and that user object must have either a `username` or a `userid`
+  const focusUser = focusConfig.user || {};
+  const userFilter = focusUser.username || focusUser.userid;
+
+  // If that requirement is not met, we can't configure/activate focus mode
+  if (!userFilter) {
+    return focusDefaultState;
+  }
+
+  return {
+    configured: true,
+    active: true, // Activate valid focus mode immediately
+    user: {
+      filter: userFilter,
+      displayName: focusUser.displayName || userFilter || '',
+    },
+  };
+}
+
+function init(settings) {
+  return {
+    filters: {},
+    focus: setFocus(settings.focus || /** @type FocusConfig */ ({})),
+    query: settings.query || null,
+  };
+}
+
+const update = {
+  CHANGE_FOCUS_MODE_USER: function (state, action) {
+    return {
+      focus: setFocus({ user: action.user }),
+    };
+  },
+
+  SET_FILTER_QUERY: function (state, action) {
+    return { query: action.query };
+  },
+
+  SET_FOCUS_MODE: function (state, action) {
+    const active =
+      typeof action.active !== 'undefined'
+        ? action.active
+        : !state.focus.active;
+    return {
+      focus: {
+        ...state.focus,
+        active,
+      },
+    };
+  },
+
+  // Actions defined in other modules
+
+  CLEAR_SELECTION: function (state) {
+    return {
+      filters: {},
+      focus: {
+        ...state.focus,
+        active: false,
+      },
+      query: null,
+    };
+  },
+};
+
+const actions = actionTypes(update);
+
+// Action creators
+
+/** Set the query used to filter displayed annotations. */
+function setFilterQuery(query) {
+  return dispatch => {
+    dispatch({
+      type: actions.SET_FILTER_QUERY,
+      query: query,
+    });
+  };
+}
+
+/**
+ * Clears any applied filters, changes the focused user and sets
+ * focused enabled to `true`.
+ *
+ * @param {User} user - The user to focus on
+ */
+function changeFocusModeUser(user) {
+  return { type: actions.CHANGE_FOCUS_MODE_USER, user };
+}
+
+/**
+ * Toggle whether or not a (user-)focus mode is applied, either inverting the
+ * current active state or setting it to a target `active` state, if provided.
+ *
+ * @param {boolean} [active] - Optional `active` state for focus mode
+ */
+function toggleFocusMode(active) {
+  return {
+    type: actions.SET_FOCUS_MODE,
+    active,
+  };
+}
+
+// Selectors
+
+function filterQuery(state) {
+  return state.query;
+}
+
+/**
+ * Returns the display name for a user or the userid
+ * if display name is not present. If both are missing
+ * then this returns an empty string.
+ *
+ * @return {string}
+ */
+function focusModeUserPrettyName(state) {
+  if (!state.focus.configured) {
+    return '';
+  }
+  return state.focus.user.displayName;
+}
+
+/**
+ * Summary of applied filters
+ *
+ * @type {(state: any) => FilterState}
+ */
+const filterState = createSelector(
+  rootState => rootState.selection,
+  rootState => rootState.filters,
+  (selection, filters) => {
+    // TODO FIXME
+    const forcedVisibleCount = trueKeys(selection.forcedVisible).length;
+    // TODO FIXME
+    const selectedCount = trueKeys(selection.selected).length;
+    return {
+      filterQuery: filters.query,
+      focusActive: filters.focus.active,
+      focusConfigured: filters.focus.configured,
+      focusDisplayName: focusModeUserPrettyName(filters),
+      forcedVisibleCount,
+      selectedCount,
+    };
+  }
+);
+
+/**
+ * @typedef FiltersStore
+ *
+ * // Actions
+ * @prop {typeof changeFocusModeUser} changeFocusModeUser
+ * @prop {typeof setFilterQuery} setFilterQuery
+ * @prop {typeof toggleFocusMode} toggleFocusMode
+ *
+ * // Selectors
+ * @prop {() => string|null} filterQuery
+ *
+ * // Root Selectors
+ * @prop {() => FilterState} filterState
+ *
+ */
+
+export default {
+  init,
+  namespace: 'filters',
+  update,
+  actions: {
+    changeFocusModeUser,
+    setFilterQuery,
+    toggleFocusMode,
+  },
+  selectors: {
+    filterQuery,
+  },
+  rootSelectors: {
+    filterState,
+  },
+};

--- a/src/sidebar/store/modules/filters.js
+++ b/src/sidebar/store/modules/filters.js
@@ -127,16 +127,6 @@ const actions = actionTypes(update);
 
 // Action creators
 
-/** Set the query used to filter displayed annotations. */
-function setFilterQuery(query) {
-  return dispatch => {
-    dispatch({
-      type: actions.SET_FILTER_QUERY,
-      query: query,
-    });
-  };
-}
-
 /**
  * Clears any applied filters, changes the focused user and sets
  * focused enabled to `true`.
@@ -145,6 +135,14 @@ function setFilterQuery(query) {
  */
 function changeFocusModeUser(user) {
   return { type: actions.CHANGE_FOCUS_MODE_USER, user };
+}
+
+/** Set the query used to filter displayed annotations. */
+function setFilterQuery(query) {
+  return {
+    type: actions.SET_FILTER_QUERY,
+    query: query,
+  };
 }
 
 /**

--- a/src/sidebar/store/modules/filters.js
+++ b/src/sidebar/store/modules/filters.js
@@ -183,6 +183,13 @@ const focusState = createSelector(
 );
 
 /**
+ * Retrieve any applied user filter
+ */
+function userFilter(state) {
+  return state.focus.active ? state.focus.user.filter : null;
+}
+
+/**
  * @typedef FiltersStore
  *
  * // Actions
@@ -193,6 +200,7 @@ const focusState = createSelector(
  * // Selectors
  * @prop {() => string|null} filterQuery
  * @prop {() => FocusState} focusState
+ * @prop {() => string|null} userFilter
  *
  */
 
@@ -208,5 +216,6 @@ export default {
   selectors: {
     filterQuery,
     focusState,
+    userFilter,
   },
 };

--- a/src/sidebar/store/modules/filters.js
+++ b/src/sidebar/store/modules/filters.js
@@ -183,6 +183,13 @@ const focusState = createSelector(
 );
 
 /**
+ * Are there currently any active (applied) filters?
+ */
+function hasAppliedFilter(state) {
+  return !!state.query || state.focus?.active;
+}
+
+/**
  * Retrieve any applied user filter
  */
 function userFilter(state) {
@@ -200,6 +207,7 @@ function userFilter(state) {
  * // Selectors
  * @prop {() => string|null} filterQuery
  * @prop {() => FocusState} focusState
+ * @prop {() => boolean} hasAppliedFilter
  * @prop {() => string|null} userFilter
  *
  */
@@ -216,6 +224,7 @@ export default {
   selectors: {
     filterQuery,
     focusState,
+    hasAppliedFilter,
     userFilter,
   },
 };

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -8,17 +8,12 @@
  */
 
 /**
- * @typedef ThreadState
- * @prop {Annotation[]} annotations
- * @prop {Object} selection
- *   @prop {Object<string,boolean>} selection.expanded
- *   @prop {string|null} selection.filterQuery
- *   @prop {Object<string,string>} selection.filters
- *   @prop {string[]} selection.forcedVisible
- *   @prop {string[]} selection.selected
- *   @prop {string} selection.sortKey
- *   @prop {'annotation'|'note'|'orphan'} selection.selectedTab
- * @prop {string} route
+ * @typedef SelectionState
+ *   @prop {Object<string,boolean>} expanded
+ *   @prop {string[]} forcedVisible
+ *   @prop {string[]} selected
+ *   @prop {string} sortKey
+ *   @prop {'annotation'|'note'|'orphan'} selectedTab
  */
 
 import { createSelector } from 'reselect';
@@ -357,6 +352,17 @@ function selectedTab(state) {
   return state.selectedTab;
 }
 
+function selectionState(state) {
+  const selectionState = {
+    expanded: expandedMap(state),
+    forcedVisible: forcedVisibleAnnotations(state),
+    selected: selectedAnnotations(state),
+    sortKey: sortKey(state),
+    selectedTab: selectedTab(state),
+  };
+  return selectionState;
+}
+
 /**
  * Retrieve the current sort option key
  *
@@ -381,44 +387,6 @@ function sortKeys(state) {
 }
 
 /* Selectors that take root state */
-
-/**
- * Retrieve state needed to calculate the root thread
- *
- * TODO: Refactor
- *  - Remove route entirely and make that logic the responsibility of a caller
- *  - Remove all filter-related properties. Those should come from `filterState`
- *  - Likely remove `annotations` as well
- *  - Likely rename this to `selectionState`, and it may not need to be a
- *    `rootSelector`
- *
- * @type {(rootState: any) => ThreadState}
- */
-const threadState = createSelector(
-  rootState => rootState.annotations.annotations,
-  rootState => rootState.route.name,
-  rootState => rootState.selection,
-  rootState => rootState.filters,
-  (annotations, routeName, selection, filters) => {
-    const setFilters = /** @type {Object.<string,string>} */ ({});
-    // TODO FIXME
-    const userFilter = filters.focus.active && filters.focus.user.filter;
-    if (userFilter) {
-      setFilters.user = userFilter;
-    }
-    // TODO remove filterQuery, filters from this returned object
-    const selectionState = {
-      expanded: expandedMap(selection),
-      filterQuery: filters.query,
-      filters: setFilters,
-      forcedVisible: forcedVisibleAnnotations(selection),
-      selected: selectedAnnotations(selection),
-      sortKey: sortKey(selection),
-      selectedTab: selectedTab(selection),
-    };
-    return { annotations, route: routeName, selection: selectionState };
-  }
-);
 
 /**
  * Is any sort of filtering currently applied to the list of annotations? This
@@ -462,12 +430,12 @@ const hasAppliedFilter = createSelector(
  * @prop {() => boolean} hasSelectedAnnotations
  * @prop {() => string[]} selectedAnnotations
  * @prop {() => string} selectedTab
+ * @prop {() => SelectionState} selectionState
  * @prop {() => string} sortKey
  * @prop {() => string[]} sortKeys
  *
  * // Root Selectors
  * @prop {() => boolean} hasAppliedFilter
- * @prop {() => ThreadState} threadState
  *
  */
 
@@ -493,12 +461,12 @@ export default {
     hasSelectedAnnotations,
     selectedAnnotations,
     selectedTab,
+    selectionState,
     sortKey,
     sortKeys,
   },
 
   rootSelectors: {
     hasAppliedFilter,
-    threadState,
   },
 };

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -337,16 +337,18 @@ function selectedTab(state) {
 /**
  * @return {SelectionState}
  */
-function selectionState(state) {
-  const selectionState = {
-    expanded: expandedMap(state),
-    forcedVisible: forcedVisibleAnnotations(state),
-    selected: selectedAnnotations(state),
-    sortKey: sortKey(state),
-    selectedTab: selectedTab(state),
-  };
-  return selectionState;
-}
+const selectionState = createSelector(
+  state => state,
+  selection => {
+    return {
+      expanded: expandedMap(selection),
+      forcedVisible: forcedVisibleAnnotations(selection),
+      selected: selectedAnnotations(selection),
+      sortKey: sortKey(selection),
+      selectedTab: selectedTab(selection),
+    };
+  }
+);
 
 /**
  * Retrieve the current sort option key

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -386,31 +386,6 @@ function sortKeys(state) {
   return sortKeysForTab;
 }
 
-/* Selectors that take root state */
-
-/**
- * Is any sort of filtering currently applied to the list of annotations? This
- * includes a search query, but also if annotations are selected or a user
- * is focused.
- *
- * TODO: FIXME/refactor — this may need to be split into two selectors across
- *   two store modules that calling code needs to combine. It also may be
- *   logic that doesn't belong at all at the store level
- *
- * @type {(state: any) => boolean}
- */
-const hasAppliedFilter = createSelector(
-  rootState => rootState.selection,
-  rootState => rootState.filters,
-  (selection, filters) => {
-    return (
-      !!filters.query ||
-      filters.focus.active ||
-      hasSelectedAnnotations(selection)
-    );
-  }
-);
-
 /**
  * @typedef SelectionStore
  *
@@ -433,9 +408,6 @@ const hasAppliedFilter = createSelector(
  * @prop {() => SelectionState} selectionState
  * @prop {() => string} sortKey
  * @prop {() => string[]} sortKeys
- *
- * // Root Selectors
- * @prop {() => boolean} hasAppliedFilter
  *
  */
 
@@ -464,9 +436,5 @@ export default {
     selectionState,
     sortKey,
     sortKeys,
-  },
-
-  rootSelectors: {
-    hasAppliedFilter,
   },
 };

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -87,10 +87,6 @@ const setTab = (newTab, oldTab) => {
   };
 };
 
-/**
- * Return state object representing a reset selection. This
- * resets user-set filters (but leaves focus mode intact)
- */
 const resetSelection = () => {
   return {
     forcedVisible: {},
@@ -312,20 +308,6 @@ const forcedVisibleAnnotations = createSelector(
 );
 
 /**
- * Returns the annotation ID of the first annotation in the selection that is
- * selected (`true`) or `null` if there are none.
- *
- * @type {(state: any) => string|null}
- */
-const getFirstSelectedAnnotationId = createSelector(
-  state => state.selected,
-  selection => {
-    const selectedIds = trueKeys(selection);
-    return selectedIds.length ? selectedIds[0] : null;
-  }
-);
-
-/**
  * Are any annotations currently selected?
  *
  * @type {(state: any) => boolean}
@@ -352,6 +334,9 @@ function selectedTab(state) {
   return state.selectedTab;
 }
 
+/**
+ * @return {SelectionState}
+ */
 function selectionState(state) {
   const selectionState = {
     expanded: expandedMap(state),
@@ -401,7 +386,6 @@ function sortKeys(state) {
  * // Selectors
  * @prop {() => Object<string,boolean>} expandedMap
  * @prop {() => string[]} forcedVisibleAnnotations
- * @prop {() => string|null} getFirstSelectedAnnotationId
  * @prop {() => boolean} hasSelectedAnnotations
  * @prop {() => string[]} selectedAnnotations
  * @prop {() => string} selectedTab
@@ -429,7 +413,6 @@ export default {
   selectors: {
     expandedMap,
     forcedVisibleAnnotations,
-    getFirstSelectedAnnotationId,
     hasSelectedAnnotations,
     selectedAnnotations,
     selectedTab,

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -8,34 +8,6 @@
  */
 
 /**
- * @typedef User
- * @prop {string} [userid]
- * @prop {string} [username]
- * @prop {string} displayName - User's display name
- */
-
-/**
- * @typedef FocusedUser
- * @prop {string} filter - The identifier to use for filtering annotations
- *           derived from either a userId or a username. This may take the
- *           form of a username, e.g. 'oakbucket', or a userid
- * @prop {string} displayName
- */
-
-/**
- * @typedef FocusState
- * @prop {boolean} configured - Focus config contains valid `user` and
- *           is good to go
- * @prop {boolean} active - Focus mode is currently applied
- * @prop {FocusedUser} [user] - User to focus on (filter annotations for)
- */
-
-/**
- * @typedef FocusConfig
- * @prop {User} user
- */
-
-/**
  * @typedef ThreadState
  * @prop {Annotation[]} annotations
  * @prop {Object} selection
@@ -47,16 +19,6 @@
  *   @prop {string} selection.sortKey
  *   @prop {'annotation'|'note'|'orphan'} selection.selectedTab
  * @prop {string} route
- */
-
-/**
- * @typedef FilterState
- * @prop {string|null} filterQuery
- * @prop {boolean} focusActive
- * @prop {boolean} focusConfigured
- * @prop {string|null} focusDisplayName
- * @prop {number} forcedVisibleCount
- * @prop {number} selectedCount
  */
 
 import { createSelector } from 'reselect';
@@ -86,46 +48,6 @@ function initialSelection(settings) {
   return selection;
 }
 
-/**
- * Configure (user-)focused mode. User-focus mode may be set in one of two
- * ways:
- * - A `focus` object containing a valid `user` object is present in the
- *   application's `settings` object during initialization time
- * - A `user` object is given to the `changeFocusedUser` action (this
- *   is implemented via an RPC method call)
- * For focus mode to be considered configured, it must have a valid `user`.
- * A successfully-configured focus mode will be set to `active` immediately
- * and may be toggled via `toggleFocusMode`.
- *
- * @param {FocusConfig} focusConfig
- * @return {FocusState}
- */
-function setFocus(focusConfig) {
-  const focusDefaultState = {
-    configured: false,
-    active: false,
-  };
-
-  // To be able to apply a focused mode, a `user` object must be present,
-  // and that user object must have either a `username` or a `userid`
-  const focusUser = focusConfig.user || {};
-  const userFilter = focusUser.username || focusUser.userid;
-
-  // If that requirement is not met, we can't configure/activate focus mode
-  if (!userFilter) {
-    return focusDefaultState;
-  }
-
-  return {
-    configured: true,
-    active: true, // Activate valid focus mode immediately
-    user: {
-      filter: userFilter,
-      displayName: focusUser.displayName || userFilter || '',
-    },
-  };
-}
-
 function init(settings) {
   return {
     /**
@@ -152,9 +74,6 @@ function init(settings) {
     // match the currently-applied filters
     forcedVisible: {},
 
-    filterQuery: settings.query || null,
-    focusMode: setFocus(settings.focus || /** @type FocusConfig */ ({})),
-
     selectedTab: uiConstants.TAB_ANNOTATIONS,
     // Key by which annotations are currently sorted.
     sortKey: TAB_SORTKEY_DEFAULT[uiConstants.TAB_ANNOTATIONS],
@@ -179,26 +98,18 @@ const setTab = (newTab, oldTab) => {
  */
 const resetSelection = () => {
   return {
-    filterQuery: null,
     forcedVisible: {},
     selected: {},
   };
 };
 
 const update = {
-  CHANGE_FOCUS_MODE_USER: function (state, action) {
-    return {
-      ...resetSelection(),
-      focusMode: setFocus({ user: action.user }),
-    };
-  },
-
   CLEAR_SELECTION: function () {
     return resetSelection();
   },
 
   SELECT_ANNOTATIONS: function (state, action) {
-    return { ...resetSelection(), selected: action.selection };
+    return { selected: action.selection };
   },
 
   SELECT_TAB: function (state, action) {
@@ -209,24 +120,6 @@ const update = {
     const newExpanded = { ...state.expanded };
     newExpanded[action.id] = action.expanded;
     return { expanded: newExpanded };
-  },
-
-  SET_FILTER_QUERY: function (state, action) {
-    return { ...resetSelection(), expanded: {}, filterQuery: action.query };
-  },
-
-  SET_FOCUS_MODE: function (state, action) {
-    const active =
-      typeof action.active !== 'undefined'
-        ? action.active
-        : !state.focusMode.active;
-    return {
-      ...resetSelection(),
-      focusMode: {
-        ...state.focusMode,
-        active,
-      },
-    };
   },
 
   SET_FORCED_VISIBLE: function (state, action) {
@@ -247,6 +140,8 @@ const update = {
     return { selected: selection };
   },
 
+  /** Actions defined in other modules */
+
   /**
    * Automatically select the Page Notes tab, for convenience, if all of the
    * top-level annotations in `action.annotations` are Page Notes and the
@@ -263,6 +158,18 @@ const update = {
       return setTab(uiConstants.TAB_NOTES, state.selectedTab);
     }
     return {};
+  },
+
+  CHANGE_FOCUS_MODE_USER: function () {
+    return resetSelection();
+  },
+
+  SET_FILTER_QUERY: function () {
+    return { ...resetSelection(), expanded: {} };
+  },
+
+  SET_FOCUS_MODE: function () {
+    return resetSelection();
   },
 
   REMOVE_ANNOTATIONS: function (state, action) {
@@ -301,16 +208,6 @@ const actions = util.actionTypes(update);
 /* Action Creators */
 
 /**
- * Clears any applied filters, changes the focused user and sets
- * focused enabled to `true`.
- *
- * @param {User} user - The user to focus on
- */
-function changeFocusModeUser(user) {
-  return { type: actions.CHANGE_FOCUS_MODE_USER, user };
-}
-
-/**
  * Clear all selected annotations and filters. This will leave user-focus
  * alone, however.
  */
@@ -328,7 +225,7 @@ function clearSelection() {
  */
 function selectAnnotations(ids) {
   return dispatch => {
-    dispatch({ type: actions.SET_FOCUS_MODE, active: false });
+    dispatch({ type: actions.CLEAR_SELECTION });
     dispatch({
       type: actions.SELECT_ANNOTATIONS,
       selection: toTrueMap(ids),
@@ -362,14 +259,6 @@ function setExpanded(id, expanded) {
   };
 }
 
-/** Set the query used to filter displayed annotations. */
-function setFilterQuery(query) {
-  return {
-    type: actions.SET_FILTER_QUERY,
-    query: query,
-  };
-}
-
 /**
  * A user may "force" an annotation to be visible, even if it would be otherwise
  * not be visible because of applied filters. Set the force-visibility for a
@@ -396,19 +285,6 @@ function setSortKey(key) {
 }
 
 /**
- * Toggle whether or not a (user-)focus mode is applied, either inverting the
- * current active state or setting it to a target `active` state, if provided.
- *
- * @param {boolean} [active] - Optional `active` state for focus mode
- */
-function toggleFocusMode(active) {
-  return {
-    type: actions.SET_FOCUS_MODE,
-    active,
-  };
-}
-
-/**
  * Toggle the selected state for the annotations in `toggledAnnotations`:
  * unselect any that are selected; select any that are unselected.
  *
@@ -430,56 +306,6 @@ function toggleSelectedAnnotations(toggleIds) {
  */
 function expandedMap(state) {
   return state.expanded;
-}
-
-function filterQuery(state) {
-  return state.filterQuery;
-}
-
-/**
- * Is a focus mode currently applied?
- *
- * @return {boolean}
- */
-function focusModeActive(state) {
-  return state.focusMode.active;
-}
-
-/**
- * Does the state have a configured focus mode? That is, does it have a valid
- * focus mode filter that could be applied (regardless of whether it is currently
- * active)?
- *
- * @return {boolean}
- */
-function focusModeConfigured(state) {
-  return state.focusMode.configured;
-}
-
-/**
- * Returns the user identifier for a focused user or `null` if no focused user.
- *
- * @return {string|null}
- */
-function focusModeUserFilter(state) {
-  if (!focusModeActive(state)) {
-    return null;
-  }
-  return state.focusMode.user.filter;
-}
-
-/**
- * Returns the display name for a user or the userid
- * if display name is not present. If both are missing
- * then this returns an empty string.
- *
- * @return {string}
- */
-function focusModeUserPrettyName(state) {
-  if (!focusModeConfigured(state)) {
-    return '';
-  }
-  return state.focusMode.user.displayName;
 }
 
 /**
@@ -523,21 +349,6 @@ const selectedAnnotations = createSelector(
 );
 
 /**
- * Is any sort of filtering currently applied to the list of annotations? This
- * includes a search query, but also if annotations are selected or a user
- * is focused.
- *
- * @type {(state: any) => boolean}
- */
-const hasAppliedFilter = createSelector(
-  filterQuery,
-  focusModeActive,
-  hasSelectedAnnotations,
-  (filterQuery, focusModeActive, hasSelectedAnnotations) =>
-    !!filterQuery || focusModeActive || hasSelectedAnnotations
-);
-
-/**
  * Return the currently-selected tab
  *
  * @return {'annotation'|'note'|'orphan'}
@@ -569,29 +380,17 @@ function sortKeys(state) {
   return sortKeysForTab;
 }
 
-/**
- * Summary of applied filters
- *
- * @type {(state: any) => FilterState}
- */
-const filterState = createSelector(
-  state => state,
-  selection => {
-    return {
-      filterQuery: filterQuery(selection),
-      focusActive: focusModeActive(selection),
-      focusConfigured: focusModeConfigured(selection),
-      focusDisplayName: focusModeUserPrettyName(selection),
-      forcedVisibleCount: forcedVisibleAnnotations(selection).length,
-      selectedCount: selectedAnnotations(selection).length,
-    };
-  }
-);
-
 /* Selectors that take root state */
 
 /**
  * Retrieve state needed to calculate the root thread
+ *
+ * TODO: Refactor
+ *  - Remove route entirely and make that logic the responsibility of a caller
+ *  - Remove all filter-related properties. Those should come from `filterState`
+ *  - Likely remove `annotations` as well
+ *  - Likely rename this to `selectionState`, and it may not need to be a
+ *    `rootSelector`
  *
  * @type {(rootState: any) => ThreadState}
  */
@@ -599,16 +398,19 @@ const threadState = createSelector(
   rootState => rootState.annotations.annotations,
   rootState => rootState.route.name,
   rootState => rootState.selection,
-  (annotations, routeName, selection) => {
-    const filters = /** @type {Object.<string,string>} */ ({});
-    const userFilter = focusModeUserFilter(selection);
+  rootState => rootState.filters,
+  (annotations, routeName, selection, filters) => {
+    const setFilters = /** @type {Object.<string,string>} */ ({});
+    // TODO FIXME
+    const userFilter = filters.focus.active && filters.focus.user.filter;
     if (userFilter) {
-      filters.user = userFilter;
+      setFilters.user = userFilter;
     }
+    // TODO remove filterQuery, filters from this returned object
     const selectionState = {
       expanded: expandedMap(selection),
-      filterQuery: filterQuery(selection),
-      filters,
+      filterQuery: filters.query,
+      filters: setFilters,
       forcedVisible: forcedVisibleAnnotations(selection),
       selected: selectedAnnotations(selection),
       sortKey: sortKey(selection),
@@ -619,31 +421,44 @@ const threadState = createSelector(
 );
 
 /**
+ * Is any sort of filtering currently applied to the list of annotations? This
+ * includes a search query, but also if annotations are selected or a user
+ * is focused.
+ *
+ * TODO: FIXME/refactor — this may need to be split into two selectors across
+ *   two store modules that calling code needs to combine. It also may be
+ *   logic that doesn't belong at all at the store level
+ *
+ * @type {(state: any) => boolean}
+ */
+const hasAppliedFilter = createSelector(
+  rootState => rootState.selection,
+  rootState => rootState.filters,
+  (selection, filters) => {
+    return (
+      !!filters.query ||
+      filters.focus.active ||
+      hasSelectedAnnotations(selection)
+    );
+  }
+);
+
+/**
  * @typedef SelectionStore
  *
  * // Actions
- * @prop {typeof changeFocusModeUser} changeFocusModeUser
  * @prop {typeof clearSelection} clearSelection
  * @prop {typeof selectAnnotations} selectAnnotations
  * @prop {typeof selectTab} selectTab
  * @prop {typeof setExpanded} setExpanded
- * @prop {typeof setFilterQuery} setFilterQuery
  * @prop {typeof setForcedVisible} setForcedVisible
  * @prop {typeof setSortKey} setSortKey
- * @prop {typeof toggleFocusMode} toggleFocusMode
  * @prop {typeof toggleSelectedAnnotations} toggleSelectedAnnotations
  *
  * // Selectors
  * @prop {() => Object<string,boolean>} expandedMap
- * @prop {() => string|null} filterQuery
- * @prop {() => FilterState} filterState
- * @prop {() => boolean} focusModeActive
- * @prop {() => boolean} focusModeConfigured
- * @prop {() => string|null} focusModeUserFilter
- * @prop {() => string} focusModeUserPrettyName
  * @prop {() => string[]} forcedVisibleAnnotations
  * @prop {() => string|null} getFirstSelectedAnnotationId
- * @prop {() => boolean} hasAppliedFilter
  * @prop {() => boolean} hasSelectedAnnotations
  * @prop {() => string[]} selectedAnnotations
  * @prop {() => string} selectedTab
@@ -651,6 +466,7 @@ const threadState = createSelector(
  * @prop {() => string[]} sortKeys
  *
  * // Root Selectors
+ * @prop {() => boolean} hasAppliedFilter
  * @prop {() => ThreadState} threadState
  *
  */
@@ -661,29 +477,19 @@ export default {
   update: update,
 
   actions: {
-    changeFocusModeUser,
     clearSelection,
     selectAnnotations,
     selectTab,
     setExpanded,
-    setFilterQuery,
     setForcedVisible,
     setSortKey,
-    toggleFocusMode,
     toggleSelectedAnnotations,
   },
 
   selectors: {
     expandedMap,
-    filterQuery,
-    filterState,
-    focusModeActive,
-    focusModeConfigured,
-    focusModeUserFilter,
-    focusModeUserPrettyName,
     forcedVisibleAnnotations,
     getFirstSelectedAnnotationId,
-    hasAppliedFilter,
     hasSelectedAnnotations,
     selectedAnnotations,
     selectedTab,
@@ -692,6 +498,7 @@ export default {
   },
 
   rootSelectors: {
+    hasAppliedFilter,
     threadState,
   },
 };

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -318,6 +318,19 @@ describe('sidebar/store/modules/annotations', function () {
     });
   });
 
+  describe('allAnnotations', () => {
+    it('returns all the annotations in the store', () => {
+      const store = createTestStore();
+      const annotation1 = fixtures.oldPageNote();
+      const annotation2 = fixtures.defaultAnnotation();
+      store.addAnnotations([annotation1, annotation2]);
+      assert.deepEqual(store.allAnnotations(), [
+        store.findAnnotationByID(annotation1.id),
+        store.findAnnotationByID(annotation2.id),
+      ]);
+    });
+  });
+
   describe('orphanCount', () => {
     it('returns number of orphaned annotations', () => {
       const orphan = Object.assign(fixtures.oldAnnotation(), { $orphan: true });

--- a/src/sidebar/store/modules/test/filters-test.js
+++ b/src/sidebar/store/modules/test/filters-test.js
@@ -112,6 +112,33 @@ describe('sidebar/store/modules/filters', () => {
         assert.isEmpty(focusState.displayName);
       });
     });
+
+    describe('hasAppliedFilter', () => {
+      it('returns true if there is a search query set', () => {
+        store.setFilterQuery('foobar');
+
+        assert.isTrue(store.hasAppliedFilter());
+      });
+
+      it('returns true if user-focused mode is active', () => {
+        store = createStore(
+          [filters],
+          [{ focus: { user: { username: 'somebody' } } }]
+        );
+
+        assert.isTrue(store.hasAppliedFilter());
+      });
+
+      it('returns false if user-focused mode is configured but inactive', () => {
+        store = createStore(
+          [filters],
+          [{ focus: { user: { username: 'somebody' } } }]
+        );
+        store.toggleFocusMode(false);
+
+        assert.isFalse(store.hasAppliedFilter());
+      });
+    });
   });
 
   describe('userFilter', () => {

--- a/src/sidebar/store/modules/test/filters-test.js
+++ b/src/sidebar/store/modules/test/filters-test.js
@@ -1,8 +1,6 @@
-// import uiConstants from '../../../ui-constants';
 import createStore from '../../create-store';
 import filters from '../filters';
 import selection from '../selection';
-// import * as fixtures from '../../../test/annotation-fixtures';
 
 describe('sidebar/store/modules/filters', () => {
   let store;
@@ -113,6 +111,20 @@ describe('sidebar/store/modules/filters', () => {
         assert.isFalse(focusState.configured);
         assert.isEmpty(focusState.displayName);
       });
+    });
+  });
+
+  describe('userFilter', () => {
+    it('returns null if user focus inactive', () => {
+      assert.isNull(store.userFilter());
+    });
+
+    it('returns current user filter when user focus active', () => {
+      store.changeFocusModeUser({
+        username: 'filbert',
+        displayName: 'Pantomime Nutball',
+      });
+      assert.equal(store.userFilter(), 'filbert');
     });
   });
 });

--- a/src/sidebar/store/modules/test/filters-test.js
+++ b/src/sidebar/store/modules/test/filters-test.js
@@ -1,0 +1,138 @@
+// import uiConstants from '../../../ui-constants';
+import createStore from '../../create-store';
+import filters from '../filters';
+import selection from '../selection';
+// import * as fixtures from '../../../test/annotation-fixtures';
+
+describe('sidebar/store/modules/filters', () => {
+  let store;
+  let fakeSettings = [{}, {}];
+
+  const getFiltersState = () => {
+    return store.getState().filters;
+  };
+
+  beforeEach(() => {
+    store = createStore([filters, selection], fakeSettings);
+  });
+
+  describe('actions', () => {
+    describe('changeFocusModeUser', () => {
+      it('sets the focused user and activates focus', () => {
+        store.toggleFocusMode(false);
+        store.changeFocusModeUser({
+          username: 'testuser',
+          displayName: 'Test User',
+        });
+        const focusState = getFiltersState().focus;
+        assert.isTrue(focusState.active);
+        assert.isTrue(focusState.configured);
+        assert.equal(focusState.user.filter, 'testuser');
+        assert.equal(focusState.user.displayName, 'Test User');
+      });
+
+      // When the LMS app wants the client to disable focus mode it sends a
+      // changeFocusModeUser() RPC call with {username: undefined, displayName:
+      // undefined}:
+      //
+      // https://github.com/hypothesis/lms/blob/d6b88fd7e375a4b23899117556b3e39cfe18986b/lms/static/scripts/frontend_apps/components/LMSGrader.js#L46
+      //
+      // This is the LMS app's way of asking the client to disable focus mode.
+      it('deactivates and disables focus if username is undefined', () => {
+        store.toggleFocusMode(true);
+        store.changeFocusModeUser({
+          username: undefined,
+          displayName: undefined,
+        });
+        const focusState = getFiltersState().focus;
+        assert.isFalse(focusState.active);
+        assert.isFalse(focusState.configured);
+      });
+    });
+
+    describe('setFilterQuery', () => {
+      it('sets the filter query', () => {
+        store.setFilterQuery('a-query');
+        assert.equal(getFiltersState().query, 'a-query');
+        assert.equal(store.filterQuery(), 'a-query');
+      });
+    });
+
+    describe('toggleFocusMode', () => {
+      it('toggles the current active state if called without arguments', () => {
+        store.toggleFocusMode(false);
+        store.toggleFocusMode();
+        const focusState = getFiltersState().focus;
+        assert.isTrue(focusState.active);
+      });
+
+      it('toggles the current active state to designated state', () => {
+        store.toggleFocusMode(true);
+        store.toggleFocusMode(false);
+        const focusState = getFiltersState().focus;
+        assert.isFalse(focusState.active);
+      });
+    });
+
+    describe('CLEAR_SELECTION', () => {
+      it('responds to CLEAR_SELECTION by clearing filters and focus', () => {
+        store.changeFocusModeUser({
+          username: 'testuser',
+          displayName: 'Test User',
+        });
+        store.toggleFocusMode(true);
+
+        let focusState = getFiltersState().focus;
+        assert.isTrue(focusState.active);
+
+        store.clearSelection();
+
+        focusState = getFiltersState().focus;
+        assert.isFalse(focusState.active);
+      });
+    });
+  });
+
+  describe('selectors', () => {
+    describe('filterState', () => {
+      it('returns the current filter query', () => {
+        store.setFilterQuery('doodah, doodah');
+        assert.equal(store.filterState().filterQuery, 'doodah, doodah');
+      });
+
+      it('returns user focus information', () => {
+        store.changeFocusModeUser({
+          username: 'filbert',
+          displayName: 'Pantomime Nutball',
+        });
+
+        const filterState = store.filterState();
+        assert.isTrue(filterState.focusActive);
+        assert.isTrue(filterState.focusConfigured);
+        assert.equal(filterState.focusDisplayName, 'Pantomime Nutball');
+      });
+
+      it('returns a count of forced-visible annotations', () => {
+        store.setForcedVisible('kaboodle', true);
+        store.setForcedVisible('stampy', false);
+
+        assert.equal(store.filterState().forcedVisibleCount, 1);
+      });
+
+      it('returns a count of selected annotations', () => {
+        store.selectAnnotations(['tabulature', 'felonious']);
+        assert.equal(store.filterState().selectedCount, 2);
+      });
+
+      it('returns empty filter states when no filters active', () => {
+        const filterState = store.filterState();
+        assert.isFalse(filterState.focusActive);
+        assert.isFalse(filterState.focusConfigured);
+        assert.isEmpty(filterState.focusDisplayName);
+        assert.isNull(filterState.filterQuery);
+        assert.equal(filterState.forcedVisibleCount, 0);
+        assert.equal(filterState.selectedCount, 0);
+      });
+    });
+  });
+});

--- a/src/sidebar/store/modules/test/filters-test.js
+++ b/src/sidebar/store/modules/test/filters-test.js
@@ -94,44 +94,24 @@ describe('sidebar/store/modules/filters', () => {
   });
 
   describe('selectors', () => {
-    describe('filterState', () => {
-      it('returns the current filter query', () => {
-        store.setFilterQuery('doodah, doodah');
-        assert.equal(store.filterState().filterQuery, 'doodah, doodah');
-      });
-
+    describe('focusState', () => {
       it('returns user focus information', () => {
         store.changeFocusModeUser({
           username: 'filbert',
           displayName: 'Pantomime Nutball',
         });
 
-        const filterState = store.filterState();
-        assert.isTrue(filterState.focusActive);
-        assert.isTrue(filterState.focusConfigured);
-        assert.equal(filterState.focusDisplayName, 'Pantomime Nutball');
+        const focusState = store.focusState();
+        assert.isTrue(focusState.active);
+        assert.isTrue(focusState.configured);
+        assert.equal(focusState.displayName, 'Pantomime Nutball');
       });
 
-      it('returns a count of forced-visible annotations', () => {
-        store.setForcedVisible('kaboodle', true);
-        store.setForcedVisible('stampy', false);
-
-        assert.equal(store.filterState().forcedVisibleCount, 1);
-      });
-
-      it('returns a count of selected annotations', () => {
-        store.selectAnnotations(['tabulature', 'felonious']);
-        assert.equal(store.filterState().selectedCount, 2);
-      });
-
-      it('returns empty filter states when no filters active', () => {
-        const filterState = store.filterState();
-        assert.isFalse(filterState.focusActive);
-        assert.isFalse(filterState.focusConfigured);
-        assert.isEmpty(filterState.focusDisplayName);
-        assert.isNull(filterState.filterQuery);
-        assert.equal(filterState.forcedVisibleCount, 0);
-        assert.equal(filterState.selectedCount, 0);
+      it('returns empty focus values when no focus is configured or set', () => {
+        const focusState = store.focusState();
+        assert.isFalse(focusState.active);
+        assert.isFalse(focusState.configured);
+        assert.isEmpty(focusState.displayName);
       });
     });
   });

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -1,6 +1,7 @@
 import uiConstants from '../../../ui-constants';
 import createStore from '../../create-store';
 import annotations from '../annotations';
+import filters from '../filters';
 import selection from '../selection';
 import route from '../route';
 import * as fixtures from '../../../test/annotation-fixtures';
@@ -14,7 +15,7 @@ describe('sidebar/store/modules/selection', () => {
   };
 
   beforeEach(() => {
-    store = createStore([annotations, selection, route], fakeSettings);
+    store = createStore([annotations, filters, selection, route], fakeSettings);
   });
 
   describe('getFirstSelectedAnnotationId', function () {
@@ -66,7 +67,7 @@ describe('sidebar/store/modules/selection', () => {
 
     it('returns true if user-focused mode is active', () => {
       store = createStore(
-        [selection],
+        [filters, selection],
         [{ focus: { user: { username: 'somebody' } } }]
       );
 
@@ -75,7 +76,7 @@ describe('sidebar/store/modules/selection', () => {
 
     it('returns false if user-focused mode is configured but inactive', () => {
       store = createStore(
-        [selection],
+        [filters, selection],
         [{ focus: { user: { username: 'somebody' } } }]
       );
       store.toggleFocusMode(false);
@@ -116,47 +117,6 @@ describe('sidebar/store/modules/selection', () => {
 
     it('returns null when no filterQuery is present', function () {
       assert.isNull(store.filterQuery());
-    });
-  });
-
-  describe('filterState', () => {
-    it('returns the current filter query', () => {
-      store.setFilterQuery('doodah, doodah');
-      assert.equal(store.filterState().filterQuery, 'doodah, doodah');
-    });
-
-    it('returns user focus information', () => {
-      store.changeFocusModeUser({
-        username: 'filbert',
-        displayName: 'Pantomime Nutball',
-      });
-
-      const filterState = store.filterState();
-      assert.isTrue(filterState.focusActive);
-      assert.isTrue(filterState.focusConfigured);
-      assert.equal(filterState.focusDisplayName, 'Pantomime Nutball');
-    });
-
-    it('returns a count of forced-visible annotations', () => {
-      store.setForcedVisible('kaboodle', true);
-      store.setForcedVisible('stampy', false);
-
-      assert.equal(store.filterState().forcedVisibleCount, 1);
-    });
-
-    it('returns a count of selected annotations', () => {
-      store.selectAnnotations(['tabulature', 'felonious']);
-      assert.equal(store.filterState().selectedCount, 2);
-    });
-
-    it('returns empty filter states when no filters active', () => {
-      const filterState = store.filterState();
-      assert.isFalse(filterState.focusActive);
-      assert.isFalse(filterState.focusConfigured);
-      assert.isEmpty(filterState.focusDisplayName);
-      assert.isNull(filterState.filterQuery);
-      assert.equal(filterState.forcedVisibleCount, 0);
-      assert.equal(filterState.selectedCount, 0);
     });
   });
 
@@ -268,6 +228,45 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
+  describe('CHANGE_FOCUS_MODE_USER', () => {
+    it('clears selection', () => {
+      store.selectAnnotations([1, 2, 3]);
+      store.setForcedVisible(2, true);
+
+      store.changeFocusModeUser({
+        username: 'testuser',
+        displayName: 'Test User',
+      });
+
+      assert.isEmpty(store.selectedAnnotations());
+      assert.isEmpty(store.forcedVisibleAnnotations());
+    });
+  });
+
+  describe('SET_FILTER_QUERY', () => {
+    it('clears selection', () => {
+      store.selectAnnotations([1, 2, 3]);
+      store.setForcedVisible(2, true);
+
+      store.setFilterQuery('foobar');
+
+      assert.isEmpty(store.selectedAnnotations());
+      assert.isEmpty(store.forcedVisibleAnnotations());
+    });
+  });
+
+  describe('SET_FOCUS_MODE', () => {
+    it('clears selection', () => {
+      store.selectAnnotations([1, 2, 3]);
+      store.setForcedVisible(2, true);
+
+      store.toggleFocusMode(true);
+
+      assert.isEmpty(store.selectedAnnotations());
+      assert.isEmpty(store.forcedVisibleAnnotations());
+    });
+  });
+
   describe('#REMOVE_ANNOTATIONS', function () {
     it('removing an annotation should also remove it from the selection', function () {
       store.selectAnnotations([1, 2, 3]);
@@ -282,185 +281,6 @@ describe('sidebar/store/modules/selection', () => {
       });
       assert.deepEqual(store.forcedVisibleAnnotations(), ['1']);
       assert.deepEqual(store.expandedMap(), { 1: true });
-    });
-  });
-
-  describe('setFilterQuery()', function () {
-    it('sets the filter query', function () {
-      store.setFilterQuery('a-query');
-      assert.equal(getSelectionState().filterQuery, 'a-query');
-    });
-
-    it('resets the force-visible and expanded sets', function () {
-      store.setForcedVisible('123', true);
-      store.setExpanded('456', true);
-      store.setFilterQuery('some-query');
-      assert.deepEqual(getSelectionState().forcedVisible, {});
-      assert.deepEqual(getSelectionState().expanded, {});
-    });
-  });
-
-  describe('changeFocusModeUser', function () {
-    it('sets the focused user and enables focus mode', function () {
-      store.toggleFocusMode(false);
-      store.changeFocusModeUser({
-        username: 'testuser',
-        displayName: 'Test User',
-      });
-      assert.equal(store.focusModeUserFilter(), 'testuser');
-      assert.equal(store.focusModeUserPrettyName(), 'Test User');
-      assert.equal(store.focusModeActive(), true);
-      assert.equal(store.focusModeConfigured(), true);
-    });
-
-    // When the LMS app wants the client to disable focus mode it sends a
-    // changeFocusModeUser() RPC call with {username: undefined, displayName:
-    // undefined}:
-    //
-    // https://github.com/hypothesis/lms/blob/d6b88fd7e375a4b23899117556b3e39cfe18986b/lms/static/scripts/frontend_apps/components/LMSGrader.js#L46
-    //
-    // This is the LMS app's way of asking the client to disable focus mode.
-    it('disables focus mode if username is undefined', function () {
-      store.toggleFocusMode(true);
-      store.changeFocusModeUser({
-        username: undefined,
-        displayName: undefined,
-      });
-      assert.equal(store.focusModeActive(), false);
-      assert.equal(store.focusModeConfigured(), false);
-    });
-
-    it('clears other applied selections', () => {
-      store.toggleFocusMode(true);
-      store.setForcedVisible('someAnnotationId');
-      store.setFilterQuery('somequery');
-      store.changeFocusModeUser({
-        username: 'testuser',
-        displayName: 'Test User',
-      });
-
-      assert.isEmpty(getSelectionState().forcedVisible);
-      assert.isNull(store.filterQuery());
-    });
-  });
-
-  describe('toggleFocusMode', function () {
-    it('toggles the current active state if called without arguments', function () {
-      store.toggleFocusMode(false);
-      store.toggleFocusMode();
-      assert.isTrue(store.focusModeActive());
-    });
-
-    it('toggles the current active state to designated state', function () {
-      store.toggleFocusMode(true);
-      store.toggleFocusMode(false);
-      assert.isFalse(store.focusModeActive());
-    });
-  });
-
-  describe('focusModeConfigured', function () {
-    it('should be true when the focus setting is present and user valid', function () {
-      store = createStore(
-        [selection],
-        [{ focus: { user: { username: 'anybody' } } }]
-      );
-      assert.isTrue(store.focusModeConfigured());
-    });
-
-    it('should be false when the focus setting is present but user object invalid', function () {
-      store = createStore([selection], [{ focus: { user: {} } }]);
-      assert.isFalse(store.focusModeConfigured());
-    });
-
-    it('should be false when the focus setting is not present', function () {
-      assert.equal(store.focusModeConfigured(), false);
-    });
-  });
-
-  describe('focusModeActive', function () {
-    it('should return true by default when focus mode is active', function () {
-      store = createStore(
-        [selection],
-        [{ focus: { user: { username: 'anybody' } } }]
-      );
-      assert.equal(getSelectionState().focusMode.configured, true);
-      assert.equal(getSelectionState().focusMode.active, true);
-      assert.equal(store.focusModeActive(), true);
-    });
-
-    it('should return false when focus config is not valid', () => {
-      store = createStore(
-        [selection],
-        [{ focus: { user: { blerp: 'anybody' } } }]
-      );
-      assert.isFalse(store.focusModeActive());
-    });
-
-    it('should return false by default when focus mode is not active', function () {
-      assert.equal(store.focusModeActive(), false);
-    });
-  });
-
-  describe('focusModeUserPrettyName', function () {
-    it('returns `displayName` when available', function () {
-      store = createStore(
-        [selection],
-        [
-          {
-            focus: {
-              user: { username: 'anybody', displayName: 'FakeDisplayName' },
-            },
-          },
-        ]
-      );
-      assert.equal(store.focusModeUserPrettyName(), 'FakeDisplayName');
-    });
-
-    it('returns the `username` when `displayName` is missing', function () {
-      store = createStore(
-        [selection],
-        [{ focus: { user: { username: 'anybody', userid: 'nobody' } } }]
-      );
-      assert.equal(store.focusModeUserPrettyName(), 'anybody');
-    });
-
-    it('returns the `userid` if `displayName` and `username` are missing', () => {
-      store = createStore(
-        [selection],
-        [{ focus: { user: { userid: 'nobody' } } }]
-      );
-      assert.equal(store.focusModeUserPrettyName(), 'nobody');
-    });
-
-    it('returns empty string if focus mode is not configured', () => {
-      store = createStore([selection], [{ focus: {} }]);
-      assert.equal(store.focusModeUserPrettyName(), '');
-    });
-  });
-
-  describe('focusModeUserFilter', function () {
-    it('should return the user identifier when present', function () {
-      store = createStore(
-        [selection],
-        [{ focus: { user: { userid: 'acct:userid@authority' } } }]
-      );
-      assert.equal(store.focusModeUserFilter(), 'acct:userid@authority');
-    });
-    it('should return null when no filter available', function () {
-      store = createStore([selection], [{ focus: { user: {} } }]);
-      assert.isNull(store.focusModeUserFilter());
-    });
-    it('should return null when the user object is not present', function () {
-      assert.isNull(store.focusModeUserFilter());
-    });
-    it('should return the username when present but no userid', function () {
-      // remove once LMS no longer sends username in RPC or config
-      // https://github.com/hypothesis/client/issues/1516
-      store = createStore(
-        [selection],
-        [{ focus: { user: { username: 'fake_user_name' } } }]
-      );
-      assert.equal(store.focusModeUserFilter(), 'fake_user_name');
     });
   });
 

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -120,28 +120,12 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('threadState', () => {
-    it('returns the current annotations in rootState', () => {
-      const myAnnotation = fixtures.defaultAnnotation();
-      store.addAnnotations([myAnnotation]);
-
-      // `addAnnotations` injects some additional properties to annotations,
-      // so we can't compare objects
-      assert.equal(store.threadState().annotations[0].id, myAnnotation.id);
-      assert.lengthOf(store.threadState().annotations, 1);
-    });
-
-    it('returns the current route name from rootState', () => {
-      store.changeRoute('kamchatka');
-
-      assert.equal(store.threadState().route, 'kamchatka');
-    });
-
+  describe('selectionState', () => {
     it('returns relevant state about tab and sort', () => {
       store.selectTab('orphan');
       store.setSortKey('pyrrhic');
 
-      const selection = store.threadState().selection;
+      const selection = store.selectionState();
 
       assert.equal(selection.selectedTab, 'orphan');
       assert.equal(selection.sortKey, 'pyrrhic');
@@ -151,30 +135,14 @@ describe('sidebar/store/modules/selection', () => {
       store.selectAnnotations(['1', '2']);
       store.setExpanded('3', true);
       store.setExpanded('4', false);
+      store.setForcedVisible('5', true);
+      store.setForcedVisible('6', true);
 
-      const selection = store.threadState().selection;
+      const selection = store.selectionState();
 
       assert.deepEqual(selection.expanded, { 3: true, 4: false });
       assert.deepEqual(selection.selected, ['1', '2']);
-    });
-
-    it('returns the relevant state when user-focus mode is applied', () => {
-      store.changeFocusModeUser({
-        username: 'testuser',
-        displayName: 'Test User',
-      });
-
-      const selection = store.threadState().selection;
-
-      assert.deepEqual(selection.filters, { user: 'testuser' });
-    });
-
-    it('returns the relevant state when a filter query is applied', () => {
-      store.setFilterQuery('frappe');
-
-      const selection = store.threadState().selection;
-
-      assert.equal(selection.filterQuery, 'frappe');
+      assert.deepEqual(selection.forcedVisible, ['5', '6']);
     });
   });
 

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -58,46 +58,6 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('hasAppliedFilter', () => {
-    it('returns true if there is a search query set', () => {
-      store.setFilterQuery('foobar');
-
-      assert.isTrue(store.hasAppliedFilter());
-    });
-
-    it('returns true if user-focused mode is active', () => {
-      store = createStore(
-        [filters, selection],
-        [{ focus: { user: { username: 'somebody' } } }]
-      );
-
-      assert.isTrue(store.hasAppliedFilter());
-    });
-
-    it('returns false if user-focused mode is configured but inactive', () => {
-      store = createStore(
-        [filters, selection],
-        [{ focus: { user: { username: 'somebody' } } }]
-      );
-      store.toggleFocusMode(false);
-
-      assert.isFalse(store.hasAppliedFilter());
-    });
-
-    it('returns true if there are selected annotations', () => {
-      store.selectAnnotations([1]);
-
-      assert.isTrue(store.hasAppliedFilter());
-    });
-
-    it('returns false after selection is cleared', () => {
-      store.setFilterQuery('foobar');
-      store.clearSelection();
-
-      assert.isFalse(store.hasAppliedFilter());
-    });
-  });
-
   describe('hasSelectedAnnotations', function () {
     it('returns true if there are any selected annotations', function () {
       store.selectAnnotations([1]);

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -18,18 +18,6 @@ describe('sidebar/store/modules/selection', () => {
     store = createStore([annotations, filters, selection, route], fakeSettings);
   });
 
-  describe('getFirstSelectedAnnotationId', function () {
-    it('returns the first selected annotation id it finds', function () {
-      store.selectAnnotations([1, 2]);
-      assert.equal(store.getFirstSelectedAnnotationId(), 1);
-    });
-
-    it('returns null if no selected annotation ids are found', function () {
-      store.selectAnnotations([]);
-      assert.isNull(store.getFirstSelectedAnnotationId());
-    });
-  });
-
   describe('setForcedVisible', function () {
     it('sets the visibility of the annotation', function () {
       store.setForcedVisible('id1', true);

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -61,7 +61,7 @@ describe('store', function () {
 
     it('sets `filterQuery` to null', () => {
       store.clearSelection();
-      assert.isNull(store.getState().selection.filterQuery);
+      assert.isNull(store.getState().filters.query);
     });
 
     it('sets `directLinkedGroupFetchFailed` to false', () => {

--- a/src/sidebar/util/thread-annotations.js
+++ b/src/sidebar/util/thread-annotations.js
@@ -5,9 +5,23 @@ import { generateFacetedFilter } from './search-filter';
 import filterAnnotations from './view-filter';
 import { shouldShowInTab } from './tabs';
 
+/** @typedef {import('../../types/api').Annotation} Annotation */
 /** @typedef {import('./build-thread').Thread} Thread */
 /** @typedef {import('./build-thread').Options} BuildThreadOptions */
-/** @typedef {import('../store/modules/selection').ThreadState} ThreadState */
+
+/**
+ * @typedef ThreadState
+ * @prop {Annotation[]} annotations
+ * @prop {Object} selection
+ *   @prop {Object<string,boolean>} selection.expanded
+ *   @prop {string|null} selection.filterQuery
+ *   @prop {Object<string,string>} selection.filters
+ *   @prop {string[]} selection.forcedVisible
+ *   @prop {string[]} selection.selected
+ *   @prop {string} selection.sortKey
+ *   @prop {'annotation'|'note'|'orphan'} selection.selectedTab
+ * @prop {string|null} route
+ */
 
 // Sort functions keyed on sort option
 const sortFns = {


### PR DESCRIPTION
Motivation for these changes: we're about to add on to filtering capabilities in the app and the `selection` module has long been over-stretched and its responsibilities unclear. Managing yet more filtering in this single module seemed unwise. Also, there was some complex logic encapsulated in some `rootSelector`s for the benefit of some components and hooks that were smelly: they were causing store modules (and their states) to be too coupled.

This PR:

* splits `selection` into two modules: `selection` and `filters`
* Removes some selectors that were unused
* Removes the large `rootSelector`s `threadState`, `filterState` and `hasAppliedFilter` in exchange for smaller supporting selectors to accomplish those computations. Components (`FilterStatus`, `SidebarView`) and a hook (`useRootThread`) now have more logic in them to munge these state objects together, instead of relying on the monster `rootSelector`s.
* Restructures the threading integration tests to use the `useRootThread` hook instead of calling `threadAnnotations` directly. 

This is a large diff. I'll add copious commenting and point out some large swaths that aren't new code, just relocated code. It may also be useful to walk through the commits.

Supports https://github.com/hypothesis/product-backlog/issues/1161