### PR TITLE
Fix potential issue when converting `TextRange` to a `Range`

### DIFF
--- a/src/annotator/anchoring/test/text-range-test.js
+++ b/src/annotator/anchoring/test/text-range-test.js
@@ -106,7 +106,7 @@ describe('annotator/anchoring/text-range', () => {
         }, 'Offset exceeds text length');
       });
 
-      it('throws if offset is 0 and `dir` option is not specified', () => {
+      it('throws if offset is 0 and `direction` option is not specified', () => {
         const el = document.createElement('div');
         const pos = new TextPosition(el, 0);
         assert.throws(() => {
@@ -114,13 +114,13 @@ describe('annotator/anchoring/text-range', () => {
         });
       });
 
-      describe('when `dir` is `RESOLVE_FORWARDS`', () => {
+      describe('when `direction` is `RESOLVE_FORWARDS`', () => {
         it('resolves to next text node if needed', () => {
           const el = document.createElement('div');
           el.innerHTML = '<b></b>bar';
 
           const pos = new TextPosition(el.querySelector('b'), 0);
-          const resolved = pos.resolve({ dir: RESOLVE_FORWARDS });
+          const resolved = pos.resolve({ direction: RESOLVE_FORWARDS });
 
           assert.equal(resolved.node, el.childNodes[1]);
           assert.equal(resolved.offset, 0);
@@ -130,18 +130,18 @@ describe('annotator/anchoring/text-range', () => {
           const el = document.createElement('div');
           const pos = new TextPosition(el, 0);
           assert.throws(() => {
-            pos.resolve({ dir: RESOLVE_FORWARDS });
+            pos.resolve({ direction: RESOLVE_FORWARDS });
           });
         });
       });
 
-      describe('when `dir` is `RESOLVE_BACKWARDS`', () => {
+      describe('when `direction` is `RESOLVE_BACKWARDS`', () => {
         it('resolves to previous text node if needed', () => {
           const el = document.createElement('div');
           el.innerHTML = 'bar<b></b>';
 
           const pos = new TextPosition(el.querySelector('b'), 0);
-          const resolved = pos.resolve({ dir: RESOLVE_BACKWARDS });
+          const resolved = pos.resolve({ direction: RESOLVE_BACKWARDS });
 
           assert.equal(resolved.node, el.childNodes[0]);
           assert.equal(resolved.offset, el.childNodes[0].data.length);
@@ -151,7 +151,7 @@ describe('annotator/anchoring/text-range', () => {
           const el = document.createElement('div');
           const pos = new TextPosition(el, 0);
           assert.throws(() => {
-            pos.resolve({ dir: RESOLVE_BACKWARDS });
+            pos.resolve({ direction: RESOLVE_BACKWARDS });
           });
         });
       });

--- a/src/annotator/anchoring/text-range.js
+++ b/src/annotator/anchoring/text-range.js
@@ -132,14 +132,14 @@ export class TextPosition {
    * Resolve the position to a specific text node and offset within that node.
    *
    * Throws if `this.offset` exceeds the length of the element's text. In the
-   * case where the element has no text and `this.offset` is 0, the `dir` option
-   * determines what happens.
+   * case where the element has no text and `this.offset` is 0, the `direction`
+   * option determines what happens.
    *
    * Offsets at the boundary between two nodes are resolved to the start of the
    * node that begins at the boundary.
    *
    * @param {Object} [options]
-   *   @param {RESOLVE_FORWARDS|RESOLVE_BACKWARDS} [options.dir] -
+   *   @param {RESOLVE_FORWARDS|RESOLVE_BACKWARDS} [options.direction] -
    *     Specifies in which direction to search for the nearest text node if
    *     `this.offset` is `0` and `this.element` has no text. If not specified
    *     an error is thrown.
@@ -150,13 +150,13 @@ export class TextPosition {
     try {
       return resolveOffsets(this.element, this.offset)[0];
     } catch (err) {
-      if (this.offset === 0 && options.dir !== undefined) {
+      if (this.offset === 0 && options.direction !== undefined) {
         const tw = document.createTreeWalker(
           this.element.getRootNode(),
           NodeFilter.SHOW_TEXT
         );
         tw.currentNode = this.element;
-        const forwards = options.dir === RESOLVE_FORWARDS;
+        const forwards = options.direction === RESOLVE_FORWARDS;
         const text = /** @type {Text|null} */ (forwards
           ? tw.nextNode()
           : tw.previousNode());
@@ -270,8 +270,8 @@ export class TextRange {
         this.end.offset
       );
     } else {
-      start = this.start.resolve({ dir: RESOLVE_FORWARDS });
-      end = this.end.resolve({ dir: RESOLVE_BACKWARDS });
+      start = this.start.resolve({ direction: RESOLVE_FORWARDS });
+      end = this.end.resolve({ direction: RESOLVE_BACKWARDS });
     }
 
     const range = new Range();


### PR DESCRIPTION
This PR fixes an edge case when converting a `TextRange` (a pair of (element, text offset) points) to a DOM `Range` using `TextRange.toRange` [1].

If the `TextRange`'s `start` or `end` points referred to an element containing no text then `TextRange.toRange()` would always throw an error. This is because there was no text node in the `start`/`end` element to resolve to. When the start or end element has no text AND the offset is zero however, we can do better.

Suppose we have the following DOM structure:

```html
<div>
  <b></b>foo<u></u>
</div>
```

If a `TextRange` is somehow created where the start point is `{ element: <b>, offset: 0 }` and the end point is `{ element: <u>, offset: 0 }` then when calling `toRange` we want it to return a range which uses the start and end points of the `"foo"` text node as its boundary points, even though these points are outside the start/end elements.

This PR implements this by adding a `dir` option to `TextPosition.resolve()` to control how this edge case is handled and then making use of that in `TextRange.toRange()`.

Similar issues came up in the past with the `*Range` classes inherited from AnnotatorJS (`NormalizedRange` etc.) and the correct behavior in these scenarios was never nailed down properly.

[1] This is done when drawing highlights or creating selectors from the current selection in PDFs, and will also become relevant if we change `RangeSelector` anchoring to use `TextRange` in future.