### PR TITLE
Do not select/focus the input element on iOS

### DIFF
--- a/src/shared/test/user-agent-test.js
+++ b/src/shared/test/user-agent-test.js
@@ -1,4 +1,4 @@
-import { isMacOS } from '../user-agent';
+import { isMacOS, isIOS } from '../user-agent';
 
 describe('shared/user-agent', () => {
   describe('isMacOS', () => {
@@ -16,6 +16,30 @@ describe('shared/user-agent', () => {
           'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.92 Safari/537.36 Edg/80.0.361.109'
         )
       );
+    });
+  });
+
+  describe('isIOS', () => {
+    it('returns true when the user agent is an iOS', () => {
+      assert.isBoolean(isIOS()); // Test to check default parameters
+      assert.isTrue(
+        isIOS({ platform: 'iPad Simulator', userAgent: 'dummy' }, false)
+      );
+      assert.isTrue(
+        isIOS({ platform: 'iPhone Simulator', userAgent: 'dummy' }, false)
+      );
+      assert.isTrue(
+        isIOS({ platform: 'iPod Simulator', userAgent: 'dummy' }, false)
+      );
+      assert.isTrue(isIOS({ platform: 'iPad', userAgent: 'dummy' }, false));
+      assert.isTrue(isIOS({ platform: 'iPhone', userAgent: 'dummy' }, false));
+      assert.isTrue(isIOS({ platform: 'iPod', userAgent: 'dummy' }, false));
+      assert.isTrue(isIOS({ platform: 'dummy', userAgent: 'Mac' }, true));
+    });
+
+    it('returns false when the user agent is not an iOS', () => {
+      assert.isFalse(isIOS({ platform: 'dummy', userAgent: 'dummy' }, true));
+      assert.isFalse(isIOS({ platform: 'dummy', userAgent: 'Mac' }, false));
     });
   });
 });

--- a/src/shared/user-agent.js
+++ b/src/shared/user-agent.js
@@ -10,3 +10,28 @@
 export const isMacOS = (_userAgent = window.navigator.userAgent) => {
   return _userAgent.indexOf('Mac OS') >= 0;
 };
+
+/**
+ * Returns true when device is iOS.
+ * https://stackoverflow.com/a/9039885/14463679
+ *
+ * @param _navigator {{platform: string, userAgent: string}}
+ * @param _ontouchend {boolean}
+ */
+export const isIOS = (
+  _navigator = window.navigator,
+  _ontouchend = 'ontouchend' in document
+) => {
+  return (
+    [
+      'iPad Simulator',
+      'iPhone Simulator',
+      'iPod Simulator',
+      'iPad',
+      'iPhone',
+      'iPod',
+    ].includes(_navigator.platform) ||
+    // iPad on iOS 13 detection
+    (_navigator.userAgent.includes('Mac') && _ontouchend)
+  );
+};

--- a/src/sidebar/components/annotation-share-control.js
+++ b/src/sidebar/components/annotation-share-control.js
@@ -10,6 +10,7 @@ import Button from './button';
 import useElementShouldClose from './hooks/use-element-should-close';
 import ShareLinks from './share-links';
 import SvgIcon from '../../shared/components/svg-icon';
+import { isIOS } from '../../shared/user-agent';
 
 /**
  * @typedef {import('../../types/api').Annotation} Annotation
@@ -27,6 +28,12 @@ import SvgIcon from '../../shared/components/svg-icon';
  * @prop {Object} analytics - Injected service
  * @prop {Object} toastMessenger - Injected service
  */
+
+function selectionOverflowsInputElement() {
+  // On iOS the selection overflows the input element
+  // See: https://github.com/hypothesis/client/pull/2799
+  return isIOS();
+}
 
 /**
  * "Popup"-style component for sharing a single annotation.
@@ -56,7 +63,8 @@ function AnnotationShareControl({
   useEffect(() => {
     if (wasOpen.current !== isOpen) {
       wasOpen.current = isOpen;
-      if (isOpen) {
+
+      if (isOpen && !selectionOverflowsInputElement()) {
         // Panel was just opened: select and focus the share URI for convenience
         inputRef.current.focus();
         inputRef.current.select();

--- a/src/sidebar/components/test/annotation-share-control-test.js
+++ b/src/sidebar/components/test/annotation-share-control-test.js
@@ -16,6 +16,7 @@ describe('AnnotationShareControl', () => {
   let fakeGroup;
   let fakeIsPrivate;
   let fakeShareUri;
+  let fakeIsIOS;
 
   let container;
 
@@ -42,6 +43,13 @@ describe('AnnotationShareControl', () => {
       wrapper.find('Button').props().onClick();
     });
     wrapper.update();
+  }
+
+  function isLinkInputFocused() {
+    return (
+      document.activeElement.getAttribute('aria-label') ===
+      'Use this URL to share this annotation'
+    );
   }
 
   beforeEach(() => {
@@ -74,17 +82,20 @@ describe('AnnotationShareControl', () => {
     };
     fakeIsPrivate = sinon.stub().returns(false);
     fakeShareUri = 'https://www.example.com';
+    fakeIsIOS = sinon.stub().returns(false);
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../util/copy-to-clipboard': fakeCopyToClipboard,
       '../util/permissions': { isPrivate: fakeIsPrivate },
       './hooks/use-element-should-close': sinon.stub(),
+      '../../shared/user-agent': { isIOS: fakeIsIOS },
     });
   });
 
   afterEach(() => {
     $imports.$restore();
+    container.remove();
   });
 
   it('does not render component if `group` prop not OK', () => {
@@ -191,17 +202,21 @@ describe('AnnotationShareControl', () => {
     });
   });
 
-  it('focuses the share-URI input when opened', () => {
-    document.body.focus();
-
+  it('focuses the share-URI input when opened on non-iOS', () => {
     const wrapper = createComponent();
     openElement(wrapper);
     wrapper.update();
 
-    assert.equal(
-      document.activeElement.getAttribute('aria-label'),
-      'Use this URL to share this annotation'
-    );
+    assert.isTrue(isLinkInputFocused());
+  });
+
+  it("doesn't focuses the share-URI input when opened on iOS", () => {
+    fakeIsIOS.returns(true);
+    const wrapper = createComponent();
+    openElement(wrapper);
+    wrapper.update();
+
+    assert.isFalse(isLinkInputFocused());
   });
 
   it(


### PR DESCRIPTION
The text in the input element of the `annotation-share-control` is selected and focused when the element is created. This is to facilitate copy/paste via keyboard shortcuts. This selection/focus mechanism is working well except for iOS (both Chrome and Safari) where:

* the selection/focus is not shown in the input field except by clicking on the input element.

* the selection overflows the right margin of the input field

![98568461-1eed6f00-227f-11eb-8342-217c13b257e1](https://user-images.githubusercontent.com/8555781/101459091-12207180-3938-11eb-908b-5ba6a79a3c4e.png)

I tested `overflow: hidden` on the input element but that causes the selection to overflow on the left margin and to show the right portion of the text of the link:

![image](https://user-images.githubusercontent.com/8555781/101459603-bd312b00-3938-11eb-834f-0bb31fa45ad3.png)


Because of these two issues, I recommend to suppress selection/focus on iOS devices.

Closes #858