### PR TITLE
Avoid traversing object tree in `immutable` if already frozen

### DIFF
--- a/src/sidebar/util/immutable.js
+++ b/src/sidebar/util/immutable.js
@@ -7,6 +7,10 @@
  * in enumerable fields.
  */
 function deepFreeze(object) {
+  if (Object.isFrozen(object)) {
+    return object;
+  }
+
   Object.freeze(object);
 
   Object.values(object).forEach(val => {

--- a/src/sidebar/util/test/immutable-test.js
+++ b/src/sidebar/util/test/immutable-test.js
@@ -17,4 +17,11 @@ describe('immutable', () => {
     assert.isTrue(Object.isFrozen(obj.objectValue));
     assert.isTrue(Object.isFrozen(obj.arrayValue));
   });
+
+  it('does nothing if object is already frozen', () => {
+    const obj = { child: {} };
+
+    assert.equal(immutable(obj), obj); // Freezes object and returns it.
+    assert.equal(immutable(obj), obj); // Just returns input.
+  });
 });


### PR DESCRIPTION
This makes store updates faster in debug builds when a lot of data is
loaded into the client. In this case most sub-trees in the store are
already frozen after an update (since they are objects from the previous
state) and only the new parts need to be frozen.

As a reminder, the `immutable` utility does nothing in production builds.