### PR TITLE
Remove unnecessary `requestAnimationFrame` callbacks in `Guest`

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -510,7 +510,7 @@ export default class Guest extends Delegator {
     }
 
     // Remove all the highlights that have no corresponding target anymore.
-    requestAnimationFrame(() => removeHighlights(deadHighlights));
+    removeHighlights(deadHighlights);
 
     // Anchor any targets of this annotation that are not anchored already.
     for (let target of annotation.target) {
@@ -542,10 +542,8 @@ export default class Guest extends Delegator {
 
     this.anchors = anchors;
 
-    requestAnimationFrame(() => {
-      removeHighlights(unhighlight);
-      this.plugins.BucketBar?.update();
-    });
+    removeHighlights(unhighlight);
+    this.plugins.BucketBar?.update();
   }
 
   /**

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -77,8 +77,6 @@ describe('Guest', () => {
     };
     notifySelectionChanged = null;
 
-    sinon.stub(window, 'requestAnimationFrame').yields();
-
     fakeCrossFrame = {
       onConnect: sinon.stub(),
       on: sinon.stub(),
@@ -114,7 +112,6 @@ describe('Guest', () => {
   });
 
   afterEach(() => {
-    window.requestAnimationFrame.restore();
     sandbox.restore();
     $imports.$restore();
   });


### PR DESCRIPTION
Profiling anchoring of large numbers of annotations in Chrome showed
that there was significant overhead [1] for scheduling and
executing `requestAnimationFrame` callbacks. In the case of `Guest.anchor`, the
callback often did nothing (it called `removeHighlights` with an array that is usually empty).

There isn't a need for this any more AFAICS so just invoke the logic
synchronously, which is much cheaper.

[1] On the branch where I tested this originally, which also had the changes in https://github.com/hypothesis/client/pull/2779, it was about ~10% of the total time to anchor annotations.