### PR TITLE
Use modern clipboard API to copy text to the clipboard

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -40,6 +40,7 @@ function createSidebarIframe(config) {
 
   // Enable media in annotations to be shown fullscreen
   sidebarFrame.setAttribute('allowfullscreen', '');
+  sidebarFrame.setAttribute('allow', 'clipboard-write');
 
   sidebarFrame.src = sidebarAppSrc;
   sidebarFrame.title = 'Hypothesis annotation viewer';

--- a/src/sidebar/components/annotation-share-control.js
+++ b/src/sidebar/components/annotation-share-control.js
@@ -69,9 +69,9 @@ function AnnotationShareControl({
     return null;
   }
 
-  const copyShareLink = () => {
+  const copyShareLink = async () => {
     try {
-      copyText(shareUri);
+      await copyText(shareUri);
       toastMessenger.success('Copied share link to clipboard');
     } catch (err) {
       toastMessenger.error('Unable to copy link');

--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -85,9 +85,9 @@ function GroupListItem({
   /**
    * @param {string} url
    */
-  const copyLink = url => {
+  const copyLink = async url => {
     try {
-      copyText(url);
+      await copyText(url);
       toastMessenger.success(`Copied link for "${group.name}"`);
     } catch (err) {
       toastMessenger.error('Unable to copy link');

--- a/src/sidebar/components/share-annotations-panel.js
+++ b/src/sidebar/components/share-annotations-panel.js
@@ -44,9 +44,9 @@ function ShareAnnotationsPanel({ analytics, toastMessenger }) {
       : '';
   })(mainFrame, focusedGroup);
 
-  const copyShareLink = () => {
+  const copyShareLink = async () => {
     try {
-      copyText(shareURI);
+      await copyText(shareURI);
       toastMessenger.success('Copied share link to clipboard');
     } catch (err) {
       toastMessenger.error('Unable to copy link');

--- a/src/sidebar/components/test/annotation-share-control-test.js
+++ b/src/sidebar/components/test/annotation-share-control-test.js
@@ -62,7 +62,7 @@ describe('AnnotationShareControl', () => {
       },
     };
     fakeCopyToClipboard = {
-      copyText: sinon.stub(),
+      copyText: sinon.stub().resolves(),
     };
     fakeToastMessenger = {
       success: sinon.stub(),
@@ -133,11 +133,12 @@ describe('AnnotationShareControl', () => {
       );
     });
 
-    it('confirms link copy when successful', () => {
+    it('confirms link copy when successful', async () => {
       const wrapper = createComponent();
       openElement(wrapper);
 
       getButton(wrapper, 'copy').props().onClick();
+      await fakeCopyToClipboard;
 
       assert.calledWith(
         fakeToastMessenger.success,
@@ -145,12 +146,13 @@ describe('AnnotationShareControl', () => {
       );
     });
 
-    it('flashes an error if link copying unsuccessful', () => {
-      fakeCopyToClipboard.copyText.throws();
+    it('flashes an error if link copying unsuccessful', async () => {
+      fakeCopyToClipboard.copyText.rejects();
       const wrapper = createComponent();
       openElement(wrapper);
 
       getButton(wrapper, 'copy').props().onClick();
+      await fakeCopyToClipboard;
 
       assert.calledWith(fakeToastMessenger.error, 'Unable to copy link');
     });

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -54,7 +54,7 @@ describe('GroupListItem', () => {
       leave: sinon.stub(),
     };
 
-    fakeCopyText = sinon.stub();
+    fakeCopyText = sinon.stub().resolves();
 
     function FakeMenuItem() {
       return null;
@@ -363,21 +363,23 @@ describe('GroupListItem', () => {
     });
   });
 
-  it('copies activity URL if "Copy link" action is clicked', () => {
+  it('copies activity URL if "Copy link" action is clicked', async () => {
     const wrapper = createGroupListItem(fakeGroup, {
       isExpanded: true,
     });
     clickMenuItem(getSubmenu(wrapper), 'Copy invite link');
+    await fakeCopyText;
     assert.calledWith(fakeCopyText, 'https://annotate.com/groups/groupid');
     assert.calledWith(fakeToastMessenger.success, 'Copied link for "Test"');
   });
 
-  it('reports an error if "Copy link" action fails', () => {
-    fakeCopyText.throws(new Error('Something went wrong'));
+  it('reports an error if "Copy link" action fails', async () => {
+    fakeCopyText.rejects();
     const wrapper = createGroupListItem(fakeGroup, {
       isExpanded: true,
     });
     clickMenuItem(getSubmenu(wrapper), 'Copy invite link');
+    await fakeCopyText;
     assert.calledWith(fakeCopyText, 'https://annotate.com/groups/groupid');
     assert.calledWith(fakeToastMessenger.error, 'Unable to copy link');
   });

--- a/src/sidebar/components/test/share-annotations-panel-test.js
+++ b/src/sidebar/components/test/share-annotations-panel-test.js
@@ -36,7 +36,7 @@ describe('ShareAnnotationsPanel', () => {
       track: sinon.stub(),
     };
     fakeCopyToClipboard = {
-      copyText: sinon.stub(),
+      copyText: sinon.stub().resolves(),
     };
     fakeToastMessenger = {
       success: sinon.stub(),
@@ -158,21 +158,24 @@ describe('ShareAnnotationsPanel', () => {
         );
       });
 
-      it('confirms link copy when successful', () => {
+      it('confirms link copy when successful', async () => {
         const wrapper = createShareAnnotationsPanel();
 
         wrapper.find('Button').props().onClick();
+        await fakeCopyToClipboard;
 
         assert.calledWith(
           fakeToastMessenger.success,
           'Copied share link to clipboard'
         );
       });
-      it('flashes an error if link copying unsuccessful', () => {
+
+      it('flashes an error if link copying unsuccessful', async () => {
         fakeCopyToClipboard.copyText.throws();
         const wrapper = createShareAnnotationsPanel();
 
         wrapper.find('Button').props().onClick();
+        await fakeCopyToClipboard;
 
         assert.calledWith(fakeToastMessenger.error, 'Unable to copy link');
       });

--- a/src/sidebar/components/test/version-info-test.js
+++ b/src/sidebar/components/test/version-info-test.js
@@ -31,7 +31,7 @@ describe('VersionInfo', function () {
 
   beforeEach(() => {
     fakeCopyToClipboard = {
-      copyText: sinon.stub(),
+      copyText: sinon.stub().resolves(),
     };
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
@@ -72,10 +72,11 @@ describe('VersionInfo', function () {
       assert.calledWith(fakeCopyToClipboard.copyText, 'fakeString');
     });
 
-    it('confirms info copy when successful', () => {
+    it('confirms info copy when successful', async () => {
       const wrapper = createComponent();
 
       wrapper.find('Button').props().onClick();
+      await fakeCopyToClipboard;
 
       assert.calledWith(
         fakeToastMessenger.success,
@@ -83,11 +84,12 @@ describe('VersionInfo', function () {
       );
     });
 
-    it('flashes an error if info copying unsuccessful', () => {
-      fakeCopyToClipboard.copyText.throws();
+    it('flashes an error if info copying unsuccessful', async () => {
+      fakeCopyToClipboard.copyText.rejects();
       const wrapper = createComponent();
 
       wrapper.find('Button').props().onClick();
+      await fakeCopyToClipboard;
 
       assert.calledWith(
         fakeToastMessenger.error,

--- a/src/sidebar/components/version-info.js
+++ b/src/sidebar/components/version-info.js
@@ -18,9 +18,9 @@ import Button from './button';
  * @param {VersionInfoProps} props
  */
 function VersionInfo({ toastMessenger, versionData }) {
-  const copyVersionData = () => {
+  const copyVersionData = async () => {
     try {
-      copyText(versionData.asFormattedString());
+      await copyText(versionData.asFormattedString());
       toastMessenger.success('Copied version info to clipboard');
     } catch (err) {
       toastMessenger.error('Unable to copy version info');

--- a/src/sidebar/util/copy-to-clipboard.js
+++ b/src/sidebar/util/copy-to-clipboard.js
@@ -1,5 +1,21 @@
 /**
- * Copy the string `text` to the clipboard.
+ * Copy the string `text` using clipboard API. If it fails use the legacy hack.
+ *
+ * If clipboard.writeText is been called from an iframe, the iframe must allow `clipboard-write`
+ *
+ * @param {string} text
+ * @return {Promise<void>}
+ */
+export function copyText(text) {
+  try {
+    return navigator.clipboard.writeText(text);
+  } catch {
+    return copyTextAlternative(text);
+  }
+}
+
+/**
+ * Copy the string `text` to the clipboard (legacy)
  *
  * In most browsers, this function can only be called in response to a user
  * gesture. For example in response to a "click" event.
@@ -8,8 +24,9 @@
  *   This function may throw an exception if the browser rejects the attempt
  *   to copy text.
  * @param {string} text
+ * @return {Promise<void>}
  */
-export function copyText(text) {
+function copyTextAlternative(text) {
   const temp = document.createElement('input');
   temp.value = text;
   temp.setAttribute('data-testid', 'copy-text');
@@ -30,4 +47,5 @@ export function copyText(text) {
   } finally {
     temp.remove();
   }
+  return Promise.resolve();
 }


### PR DESCRIPTION
It is very convenient to use the clipboard API, instead of the
legacy `document.execCommand('copy')` with all the added pieces.

However, we still need the legacy functionality for old browsers.

Before merging this PR, all supported browsers (in all platforms)
must be tested.

There is a good review of pros and cons of using the clipboard API [here](https://stackoverflow.com/a/30810322/14463679).