### PR TITLE
Replace `useStore` hook with `useStoreProxy` in UI components

### DIFF
--- a/src/sidebar/components/annotation-action-bar.js
+++ b/src/sidebar/components/annotation-action-bar.js
@@ -2,7 +2,7 @@ import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import uiConstants from '../ui-constants';
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { isShareable, shareURI } from '../util/annotation-sharing';
 import { isPrivate, permits } from '../util/permissions';
 import { withServices } from '../util/service-context';
@@ -37,11 +37,11 @@ function AnnotationActionBar({
   settings,
   toastMessenger,
 }) {
-  const userProfile = useStore(store => store.profile());
-  const annotationGroup = useStore(store => store.getGroup(annotation.group));
-  const isLoggedIn = useStore(store => store.isLoggedIn());
+  const store = useStoreProxy();
+  const userProfile = store.profile();
+  const annotationGroup = store.getGroup(annotation.group);
+  const isLoggedIn = store.isLoggedIn();
 
-  const openSidebarPanel = useStore(store => store.openSidebarPanel);
   // Is the current user allowed to take the given `action` on this annotation?
   const userIsAuthorizedTo = action => {
     return permits(annotation.permissions, action, userProfile.userid);
@@ -55,8 +55,6 @@ function AnnotationActionBar({
   const showFlagAction = userProfile.userid !== annotation.user;
   const showShareAction = isShareable(annotation, settings);
 
-  const createDraft = useStore(store => store.createDraft);
-
   const onDelete = () => {
     if (window.confirm('Are you sure you want to delete this annotation?')) {
       annotationsService.delete(annotation).catch(err => {
@@ -66,7 +64,7 @@ function AnnotationActionBar({
   };
 
   const onEdit = () => {
-    createDraft(annotation, {
+    store.createDraft(annotation, {
       tags: annotation.tags,
       text: annotation.text,
       isPrivate: isPrivate(annotation.permissions),
@@ -85,7 +83,7 @@ function AnnotationActionBar({
 
   const onReplyClick = () => {
     if (!isLoggedIn) {
-      openSidebarPanel(uiConstants.PANEL_LOGIN_PROMPT);
+      store.openSidebarPanel(uiConstants.PANEL_LOGIN_PROMPT);
       return;
     }
     onReply();

--- a/src/sidebar/components/annotation-body.js
+++ b/src/sidebar/components/annotation-body.js
@@ -2,7 +2,7 @@ import { createElement } from 'preact';
 import { useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { isHidden } from '../util/annotation-metadata';
 import { withServices } from '../util/service-context';
 import { applyTheme } from '../util/theme';
@@ -37,7 +37,8 @@ function AnnotationBody({ annotation, settings }) {
   // collapsing/expanding is relevant?
   const [isCollapsible, setIsCollapsible] = useState(false);
 
-  const draft = useStore(store => store.getDraft(annotation));
+  const store = useStoreProxy();
+  const draft = store.getDraft(annotation);
 
   const toggleText = isCollapsed ? 'More' : 'Less';
 

--- a/src/sidebar/components/annotation-editor.js
+++ b/src/sidebar/components/annotation-editor.js
@@ -5,7 +5,7 @@ import propTypes from 'prop-types';
 import { normalizeKeyName } from '../../shared/browser-compatibility-utils';
 import { withServices } from '../util/service-context';
 import { applyTheme } from '../util/theme';
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 
 import AnnotationLicense from './annotation-license';
 import AnnotationPublishControl from './annotation-publish-control';
@@ -43,9 +43,9 @@ function AnnotationEditor({
     /** @type {string|null} */ (null)
   );
 
-  const draft = useStore(store => store.getDraft(annotation));
-  const createDraft = useStore(store => store.createDraft);
-  const group = useStore(store => store.getGroup(annotation.group));
+  const store = useStoreProxy();
+  const draft = store.getDraft(annotation);
+  const group = store.getGroup(annotation.group);
 
   if (!draft) {
     // If there's no draft, we can't be in editing mode
@@ -60,7 +60,7 @@ function AnnotationEditor({
   const isEmpty = !text && !tags.length;
 
   const onEditTags = ({ tags }) => {
-    createDraft(draft.annotation, { ...draft, tags });
+    store.createDraft(draft.annotation, { ...draft, tags });
   };
 
   /**
@@ -99,7 +99,7 @@ function AnnotationEditor({
   };
 
   const onEditText = ({ text }) => {
-    createDraft(draft.annotation, { ...draft, text });
+    store.createDraft(draft.annotation, { ...draft, text });
   };
 
   const onSave = async () => {

--- a/src/sidebar/components/annotation-header.js
+++ b/src/sidebar/components/annotation-header.js
@@ -2,7 +2,7 @@ import { createElement } from 'preact';
 import { useMemo } from 'preact/hooks';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import {
   isHighlight,
   isReply,
@@ -46,8 +46,8 @@ export default function AnnotationHeader({
   showDocumentInfo,
   threadIsCollapsed,
 }) {
+  const store = useStoreProxy();
   const isCollapsedReply = isReply(annotation) && threadIsCollapsed;
-  const setExpanded = useStore(store => store.setExpanded);
 
   const annotationIsPrivate = isPrivate(annotation.permissions);
 
@@ -64,7 +64,7 @@ export default function AnnotationHeader({
   const onReplyCountClick = () =>
     // If an annotation has replies it must have been saved and therefore have
     // an ID.
-    setExpanded(/** @type {string} */ (annotation.id), true);
+    store.setExpanded(/** @type {string} */ (annotation.id), true);
 
   return (
     <header className="annotation-header">

--- a/src/sidebar/components/annotation-publish-control.js
+++ b/src/sidebar/components/annotation-publish-control.js
@@ -1,7 +1,7 @@
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { isNew, isReply } from '../util/annotation-metadata';
 import { isShared } from '../util/permissions';
 import { withServices } from '../util/service-context';
@@ -39,13 +39,9 @@ function AnnotationPublishControl({
   onSave,
   settings,
 }) {
-  const draft = useStore(store => store.getDraft(annotation));
-  const group = useStore(store => store.getGroup(annotation.group));
-
-  const createDraft = useStore(store => store.createDraft);
-  const removeDraft = useStore(store => store.removeDraft);
-  const setDefault = useStore(store => store.setDefault);
-  const removeAnnotations = useStore(store => store.removeAnnotations);
+  const store = useStoreProxy();
+  const draft = store.getDraft(annotation);
+  const group = store.getGroup(annotation.group);
 
   if (!group) {
     // If there is no group, then don't render anything as a missing group
@@ -59,17 +55,17 @@ function AnnotationPublishControl({
 
   // Revert changes to this annotation
   const onCancel = () => {
-    removeDraft(annotation);
+    store.removeDraft(annotation);
     if (isNew(annotation)) {
-      removeAnnotations([annotation]);
+      store.removeAnnotations([annotation]);
     }
   };
 
   const onSetPrivacy = level => {
-    createDraft(annotation, { ...draft, isPrivate: level === 'private' });
+    store.createDraft(annotation, { ...draft, isPrivate: level === 'private' });
     // Persist this as privacy default for future annotations unless this is a reply
     if (!isReply(annotation)) {
-      setDefault('annotationPrivacy', level);
+      store.setDefault('annotationPrivacy', level);
     }
   };
 

--- a/src/sidebar/components/annotation-share-info.js
+++ b/src/sidebar/components/annotation-share-info.js
@@ -1,7 +1,7 @@
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { isPrivate } from '../util/permissions';
 
 import SvgIcon from '../../shared/components/svg-icon';
@@ -23,7 +23,8 @@ import SvgIcon from '../../shared/components/svg-icon';
  * @param {AnnotationShareInfoProps} props
  */
 function AnnotationShareInfo({ annotation }) {
-  const group = useStore(store => store.getGroup(annotation.group));
+  const store = useStoreProxy();
+  const group = store.getGroup(annotation.group);
 
   // Only show the name of the group and link to it if there is a
   // URL (link) returned by the API for this group. Some groups do not have links

--- a/src/sidebar/components/annotation-view.js
+++ b/src/sidebar/components/annotation-view.js
@@ -2,7 +2,7 @@ import { Fragment, createElement } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../util/service-context';
 import useRootThread from './hooks/use-root-thread';
 
@@ -21,18 +21,16 @@ import SidebarContentError from './sidebar-content-error';
  * @param {AnnotationViewProps} props
  */
 function AnnotationView({ loadAnnotationsService, onLogin }) {
-  const annotationId = useStore(store => store.routeParams().id);
-  const clearAnnotations = useStore(store => store.clearAnnotations);
-  const highlightAnnotations = useStore(store => store.highlightAnnotations);
+  const store = useStoreProxy();
+  const annotationId = store.routeParams().id;
   const rootThread = useRootThread();
-  const setExpanded = useStore(store => store.setExpanded);
-  const userid = useStore(store => store.profile().userid);
+  const userid = store.profile().userid;
 
   const [fetchError, setFetchError] = useState(false);
 
   useEffect(() => {
     setFetchError(false);
-    clearAnnotations();
+    store.clearAnnotations();
 
     loadAnnotationsService
       .loadThread(annotationId)
@@ -60,12 +58,12 @@ function AnnotationView({ loadAnnotationsService, onLogin }) {
 
         // Make the full thread of annotations visible. By default replies are
         // not shown until the user expands the thread.
-        annots.forEach(annot => setExpanded(annot.id, true));
+        annots.forEach(annot => store.setExpanded(annot.id, true));
 
         // FIXME - This should show a visual indication of which reply the
         // annotation ID in the URL refers to. That isn't currently working.
         if (topLevelAnnot.id !== annotationId) {
-          highlightAnnotations([annotationId]);
+          store.highlightAnnotations([annotationId]);
         }
       })
       .catch(() => {
@@ -79,10 +77,8 @@ function AnnotationView({ loadAnnotationsService, onLogin }) {
     userid,
 
     // Static dependencies.
-    clearAnnotations,
-    highlightAnnotations,
     loadAnnotationsService,
-    setExpanded,
+    store,
   ]);
 
   return (

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { isReply, quote } from '../util/annotation-metadata';
 import { withServices } from '../util/service-context';
 
@@ -39,15 +39,13 @@ function Annotation({
   showDocumentInfo,
   threadIsCollapsed,
 }) {
-  const isFocused = useStore(store =>
-    store.isAnnotationFocused(annotation.$tag)
-  );
-  const setExpanded = useStore(store => store.setExpanded);
+  const store = useStoreProxy();
+  const isFocused = store.isAnnotationFocused(annotation.$tag);
 
   // An annotation will have a draft if it is being edited
-  const draft = useStore(store => store.getDraft(annotation));
-  const userid = useStore(store => store.profile().userid);
-  const isSaving = useStore(store => store.isSavingAnnotation(annotation));
+  const draft = store.getDraft(annotation);
+  const userid = store.profile().userid;
+  const isSaving = store.isSavingAnnotation(annotation);
 
   const isCollapsedReply = isReply(annotation) && threadIsCollapsed;
 
@@ -66,7 +64,10 @@ function Annotation({
   const onToggleReplies = () =>
     // nb. We assume the annotation has an ID here because it is not possible
     // to create replies until the annotation has been saved.
-    setExpanded(/** @type {string} */ (annotation.id), !!threadIsCollapsed);
+    store.setExpanded(
+      /** @type {string} */ (annotation.id),
+      !!threadIsCollapsed
+    );
 
   return (
     <article

--- a/src/sidebar/components/filter-status.js
+++ b/src/sidebar/components/filter-status.js
@@ -7,7 +7,7 @@ import { countVisible } from '../util/thread';
 import Button from './button';
 
 import useRootThread from './hooks/use-root-thread';
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 
 /**
  * @typedef {import('../util/build-thread').Thread} Thread
@@ -127,10 +127,10 @@ FilterStatusPanel.propTypes = {
  * @param {FilterModeProps} props
  */
 function SelectionFilterStatus({ filterState, rootThread }) {
-  const clearSelection = useStore(store => store.clearSelection);
-  const directLinkedId = useStore(store => store.directLinkedAnnotationId());
+  const store = useStoreProxy();
+  const directLinkedId = store.directLinkedAnnotationId();
   // The total number of top-level annotations (visible or not)
-  const totalCount = useStore(store => store.annotationCount());
+  const totalCount = store.annotationCount();
   // Count the number of visible annotations—top-level only
   const visibleAnnotationCount = (rootThread.children || []).filter(
     thread => thread.annotation && thread.visible
@@ -153,7 +153,7 @@ function SelectionFilterStatus({ filterState, rootThread }) {
     <Button
       buttonText={buttonText}
       className="button--primary"
-      onClick={() => clearSelection()}
+      onClick={() => store.clearSelection()}
       icon="cancel"
     />
   );
@@ -185,7 +185,7 @@ SelectionFilterStatus.propTypes = {
  * @param {FilterModeProps} props
  */
 function QueryFilterStatus({ filterState, rootThread }) {
-  const clearSelection = useStore(store => store.clearSelection);
+  const store = useStoreProxy();
   const visibleCount = countVisible(rootThread);
   const resultCount = visibleCount - filterState.forcedVisibleCount;
 
@@ -194,7 +194,7 @@ function QueryFilterStatus({ filterState, rootThread }) {
       icon="cancel"
       className="button--primary"
       buttonText="Clear search"
-      onClick={() => clearSelection()}
+      onClick={() => store.clearSelection()}
     />
   );
 
@@ -233,17 +233,16 @@ QueryFilterStatus.propTypes = {
  * @param {FilterModeProps} props
  */
 function FocusFilterStatus({ filterState, rootThread }) {
-  const clearSelection = useStore(store => store.clearSelection);
-  const toggleFocusMode = useStore(store => store.toggleFocusMode);
+  const store = useStoreProxy();
   const visibleCount = countVisible(rootThread);
   const resultCount = visibleCount - filterState.forcedVisibleCount;
   const buttonProps = {};
 
   if (filterState.forcedVisibleCount > 0) {
-    buttonProps.onClick = () => clearSelection();
+    buttonProps.onClick = () => store.clearSelection();
     buttonProps.buttonText = 'Reset filters';
   } else {
-    buttonProps.onClick = () => toggleFocusMode();
+    buttonProps.onClick = () => store.toggleFocusMode();
     buttonProps.buttonText = filterState.focusActive
       ? 'Show all'
       : `Show only ${filterState.focusDisplayName}`;
@@ -278,12 +277,11 @@ FocusFilterStatus.propTypes = {
 export default function FilterStatus() {
   const rootThread = useRootThread();
 
-  const focusState = useStore(store => store.focusState());
-  const forcedVisibleCount = useStore(
-    store => store.forcedVisibleAnnotations().length
-  );
-  const filterQuery = useStore(store => store.filterQuery());
-  const selectedCount = useStore(store => store.selectedAnnotations().length);
+  const store = useStoreProxy();
+  const focusState = store.focusState();
+  const forcedVisibleCount = store.forcedVisibleAnnotations().length;
+  const filterQuery = store.filterQuery();
+  const selectedCount = store.selectedAnnotations().length;
 
   // Build a memoized state object with filter and selection details
   // This will be used by the FilterStatus subcomponents

--- a/src/sidebar/components/group-list-item.js
+++ b/src/sidebar/components/group-list-item.js
@@ -1,7 +1,7 @@
 import { Fragment, createElement } from 'preact';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { copyText } from '../util/copy-to-clipboard';
 import { orgName } from '../util/group-list-item-common';
 import { withServices } from '../util/service-context';
@@ -44,18 +44,14 @@ function GroupListItem({
   const isSelectable =
     (group.scopes && !group.scopes.enforced) || group.isScopedToUri;
 
-  const focusedGroupId = useStore(store => store.focusedGroupId());
+  const store = useStoreProxy();
+  const focusedGroupId = store.focusedGroupId();
   const isSelected = group.id === focusedGroupId;
-
-  const actions = useStore(store => ({
-    clearDirectLinkedGroupFetchFailed: store.clearDirectLinkedGroupFetchFailed,
-    clearDirectLinkedIds: store.clearDirectLinkedIds,
-  }));
 
   const focusGroup = () => {
     analytics.track(analytics.events.GROUP_SWITCH);
-    actions.clearDirectLinkedGroupFetchFailed();
-    actions.clearDirectLinkedIds();
+    store.clearDirectLinkedGroupFetchFailed();
+    store.clearDirectLinkedIds();
     groupsService.focus(group.id);
   };
 

--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import serviceConfig from '../service-config';
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { isThirdPartyUser } from '../util/account-id';
 import { orgName } from '../util/group-list-item-common';
 import groupsByOrganization from '../util/group-organizations';
@@ -42,11 +42,12 @@ function publisherProvidedIcon(settings) {
  * @param {GroupListProps} props
  */
 function GroupList({ serviceUrl, settings }) {
-  const currentGroups = useStore(store => store.getCurrentlyViewingGroups());
-  const featuredGroups = useStore(store => store.getFeaturedGroups());
-  const myGroups = useStore(store => store.getMyGroups());
-  const focusedGroup = useStore(store => store.focusedGroup());
-  const userid = useStore(store => store.profile().userid);
+  const store = useStoreProxy();
+  const currentGroups = store.getCurrentlyViewingGroups();
+  const featuredGroups = store.getFeaturedGroups();
+  const myGroups = store.getMyGroups();
+  const focusedGroup = store.focusedGroup();
+  const userid = store.profile().userid;
 
   const myGroupsSorted = useMemo(() => groupsByOrganization(myGroups), [
     myGroups,

--- a/src/sidebar/components/help-panel.js
+++ b/src/sidebar/components/help-panel.js
@@ -2,7 +2,7 @@ import { createElement } from 'preact';
 import { useCallback, useMemo, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import uiConstants from '../ui-constants';
 import { withServices } from '../util/service-context';
 import VersionData from '../util/version-data';
@@ -60,15 +60,15 @@ HelpPanelTab.propTypes = {
  * @param {HelpPanelProps} props
  */
 function HelpPanel({ auth, session }) {
-  const mainFrame = useStore(store => store.mainFrame());
+  const store = useStoreProxy();
+  const mainFrame = store.mainFrame();
 
   // Should this panel be auto-opened at app launch? Note that the actual
   // auto-open triggering of this panel is owned by the `hypothesis-app` component.
   // This reference is such that we know whether we should "dismiss" the tutorial
   // (permanently for this user) when it is closed.
-  const hasAutoDisplayPreference = useStore(
-    store => !!store.profile().preferences.show_sidebar_tutorial
-  );
+  const hasAutoDisplayPreference = !!store.profile().preferences
+    .show_sidebar_tutorial;
 
   // The "Tutorial" (getting started) subpanel is the default panel shown
   const [activeSubPanel, setActiveSubPanel] = useState('tutorial');

--- a/src/sidebar/components/login-prompt-panel.js
+++ b/src/sidebar/components/login-prompt-panel.js
@@ -1,7 +1,7 @@
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import uiConstants from '../ui-constants';
 
 import Button from './button';
@@ -19,7 +19,8 @@ import SidebarPanel from './sidebar-panel';
  * @param {LoginPromptPanelProps} props
  */
 export default function LoginPromptPanel({ onLogin, onSignUp }) {
-  const isLoggedIn = useStore(store => store.isLoggedIn());
+  const store = useStoreProxy();
+  const isLoggedIn = store.isLoggedIn();
   if (isLoggedIn) {
     return null;
   }

--- a/src/sidebar/components/moderation-banner.js
+++ b/src/sidebar/components/moderation-banner.js
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import * as annotationMetadata from '../util/annotation-metadata';
 import { withServices } from '../util/service-context';
 
@@ -26,12 +26,7 @@ import { withServices } from '../util/service-context';
  * @param {ModerationBannerProps} props
  */
 function ModerationBanner({ annotation, api, toastMessenger }) {
-  // actions
-  const store = useStore(store => ({
-    hide: store.hideAnnotation,
-    unhide: store.unhideAnnotation,
-  }));
-
+  const store = useStoreProxy();
   const flagCount = annotationMetadata.flagCount(annotation);
 
   const isHiddenOrFlagged =
@@ -44,7 +39,7 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
     api.annotation
       .hide({ id: annotation.id })
       .then(() => {
-        store.hide(annotation.id);
+        store.hideAnnotation(annotation.id);
       })
       .catch(() => {
         toastMessenger.error('Failed to hide annotation');
@@ -58,7 +53,7 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
     api.annotation
       .unhide({ id: annotation.id })
       .then(() => {
-        store.unhide(annotation.id);
+        store.unhideAnnotation(annotation.id);
       })
       .catch(() => {
         toastMessenger.error('Failed to unhide annotation');

--- a/src/sidebar/components/new-note-btn.js
+++ b/src/sidebar/components/new-note-btn.js
@@ -2,7 +2,7 @@ import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import uiConstants from '../ui-constants';
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../util/service-context';
 import { applyTheme } from '../util/theme';
 
@@ -19,14 +19,13 @@ import Button from './button';
  */
 
 function NewNoteButton({ annotationsService, settings }) {
-  const topLevelFrame = useStore(store => store.mainFrame());
-  const isLoggedIn = useStore(store => store.isLoggedIn());
-
-  const openSidebarPanel = useStore(store => store.openSidebarPanel);
+  const store = useStoreProxy();
+  const topLevelFrame = store.mainFrame();
+  const isLoggedIn = store.isLoggedIn();
 
   const onNewNoteBtnClick = function () {
     if (!isLoggedIn) {
-      openSidebarPanel(uiConstants.PANEL_LOGIN_PROMPT);
+      store.openSidebarPanel(uiConstants.PANEL_LOGIN_PROMPT);
       return;
     }
     if (!topLevelFrame) {

--- a/src/sidebar/components/notebook-view.js
+++ b/src/sidebar/components/notebook-view.js
@@ -4,7 +4,7 @@ import propTypes from 'prop-types';
 
 import { withServices } from '../util/service-context';
 import useRootThread from './hooks/use-root-thread';
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 
 import ThreadList from './thread-list';
 
@@ -19,21 +19,21 @@ import ThreadList from './thread-list';
  * @param {NotebookViewProps} props
  */
 function NotebookView({ loadAnnotationsService }) {
-  const focusedGroup = useStore(store => store.focusedGroup());
-  const setSortKey = useStore(store => store.setSortKey);
+  const store = useStoreProxy();
+  const focusedGroup = store.focusedGroup();
 
   // Reload annotations if focused group changes
   useEffect(() => {
     // Load all annotations in the group, unless there are more than 5000
     // of them: this is a performance safety valve
-    setSortKey('Newest');
+    store.setSortKey('Newest');
     if (focusedGroup) {
       loadAnnotationsService.load({
         groupId: focusedGroup.id,
         maxResults: 5000,
       });
     }
-  }, [loadAnnotationsService, focusedGroup, setSortKey]);
+  }, [loadAnnotationsService, focusedGroup, store]);
 
   const rootThread = useRootThread();
   const groupName = focusedGroup?.name ?? '…';

--- a/src/sidebar/components/search-input.js
+++ b/src/sidebar/components/search-input.js
@@ -3,7 +3,7 @@ import { createElement } from 'preact';
 import { useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 
 import Button from './button';
 import Spinner from './spinner';
@@ -30,7 +30,8 @@ import Spinner from './spinner';
  * @param {SearchInputProps} props
  */
 export default function SearchInput({ alwaysExpanded, query, onSearch }) {
-  const isLoading = useStore(store => store.isLoading());
+  const store = useStoreProxy();
+  const isLoading = store.isLoading();
   const input = useRef(/** @type {HTMLInputElement|null} */ (null));
 
   // The active filter query from the previous render.

--- a/src/sidebar/components/selection-tabs.js
+++ b/src/sidebar/components/selection-tabs.js
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import uiConstants from '../ui-constants';
 import { withServices } from '../util/service-context';
 
@@ -91,18 +91,12 @@ Tab.propTypes = {
  * @param {SelectionTabsProps} props
  */
 function SelectionTabs({ isLoading, settings }) {
-  const selectedTab = useStore(store => store.selectedTab());
-  const noteCount = useStore(store => store.noteCount());
-  const annotationCount = useStore(store => store.annotationCount());
-  const orphanCount = useStore(store => store.orphanCount());
-  const isWaitingToAnchorAnnotations = useStore(store =>
-    store.isWaitingToAnchorAnnotations()
-  );
-  // actions
-  const store = useStore(store => ({
-    clearSelection: store.clearSelection,
-    selectTab: store.selectTab,
-  }));
+  const store = useStoreProxy();
+  const selectedTab = store.selectedTab();
+  const noteCount = store.noteCount();
+  const annotationCount = store.annotationCount();
+  const orphanCount = store.orphanCount();
+  const isWaitingToAnchorAnnotations = store.isWaitingToAnchorAnnotations();
 
   const selectTab = tabId => {
     store.clearSelection();

--- a/src/sidebar/components/share-annotations-panel.js
+++ b/src/sidebar/components/share-annotations-panel.js
@@ -1,7 +1,7 @@
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import uiConstants from '../ui-constants';
 import { copyText } from '../util/copy-to-clipboard';
 import { withServices } from '../util/service-context';
@@ -27,8 +27,9 @@ import SvgIcon from '../../shared/components/svg-icon';
  * @param {ShareAnnotationsPanelProps} props
  */
 function ShareAnnotationsPanel({ analytics, toastMessenger }) {
-  const mainFrame = useStore(store => store.mainFrame());
-  const focusedGroup = useStore(store => store.focusedGroup());
+  const store = useStoreProxy();
+  const mainFrame = store.mainFrame();
+  const focusedGroup = store.focusedGroup();
 
   const groupName = (focusedGroup && focusedGroup.name) || '...';
   const panelTitle = `Share Annotations in ${groupName}`;

--- a/src/sidebar/components/sidebar-content-error.js
+++ b/src/sidebar/components/sidebar-content-error.js
@@ -2,7 +2,7 @@ import { createElement } from 'preact';
 import classnames from 'classnames';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 
 import Button from './button';
 import SvgIcon from '../../shared/components/svg-icon';
@@ -25,8 +25,8 @@ export default function SidebarContentError({
   onLoginRequest,
   showClearSelection = false,
 }) {
-  const clearSelection = useStore(store => store.clearSelection);
-  const isLoggedIn = useStore(store => store.isLoggedIn());
+  const store = useStoreProxy();
+  const isLoggedIn = store.isLoggedIn();
 
   const errorTitle =
     errorType === 'annotation' ? 'Annotation unavailable' : 'Group unavailable';
@@ -64,7 +64,7 @@ export default function SidebarContentError({
                 'sidebar-content-error__button': !isLoggedIn,
                 'sidebar-content-error__button--primary': isLoggedIn,
               })}
-              onClick={clearSelection}
+              onClick={() => store.clearSelection()}
             />
           )}
           {!isLoggedIn && (

--- a/src/sidebar/components/sidebar-panel.js
+++ b/src/sidebar/components/sidebar-panel.js
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'preact/hooks';
 import propTypes from 'prop-types';
 import scrollIntoView from 'scroll-into-view';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 
 import Button from './button';
 import Slider from './slider';
@@ -37,8 +37,8 @@ export default function SidebarPanel({
   title,
   onActiveChanged,
 }) {
-  const panelIsActive = useStore(store => store.isSidebarPanelOpen(panelName));
-  const togglePanelFn = useStore(store => store.toggleSidebarPanel);
+  const store = useStoreProxy();
+  const panelIsActive = store.isSidebarPanelOpen(panelName);
 
   const panelElement = useRef(/** @type {HTMLDivElement|null}*/ (null));
   const panelWasActive = useRef(panelIsActive);
@@ -57,7 +57,7 @@ export default function SidebarPanel({
   }, [panelIsActive, onActiveChanged]);
 
   const closePanel = () => {
-    togglePanelFn(panelName, false);
+    store.toggleSidebarPanel(panelName, false);
   };
 
   return (

--- a/src/sidebar/components/sidebar-view.js
+++ b/src/sidebar/components/sidebar-view.js
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'preact/hooks';
 
 import useRootThread from './hooks/use-root-thread';
 import { withServices } from '../util/service-context';
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { tabForAnnotation } from '../util/tabs';
 
 import FilterStatus from './filter-status';
@@ -38,28 +38,24 @@ function SidebarView({
   const rootThread = useRootThread();
 
   // Store state values
-  const focusedGroupId = useStore(store => store.focusedGroupId());
-  const hasAppliedFilter = useStore(store => {
-    return store.hasAppliedFilter() || store.hasSelectedAnnotations();
-  });
-  const isLoading = useStore(store => store.isLoading());
-  const isLoggedIn = useStore(store => store.isLoggedIn());
+  const store = useStoreProxy();
+  const focusedGroupId = store.focusedGroupId();
+  const hasAppliedFilter =
+    store.hasAppliedFilter() || store.hasSelectedAnnotations();
+  const isLoading = store.isLoading();
+  const isLoggedIn = store.isLoggedIn();
 
-  const linkedAnnotationId = useStore(store =>
-    store.directLinkedAnnotationId()
-  );
-  const linkedAnnotation = useStore(store => {
-    return linkedAnnotationId
-      ? store.findAnnotationByID(linkedAnnotationId)
-      : undefined;
-  });
+  const linkedAnnotationId = store.directLinkedAnnotationId();
+  const linkedAnnotation = linkedAnnotationId
+    ? store.findAnnotationByID(linkedAnnotationId)
+    : undefined;
   const directLinkedTab = linkedAnnotation
     ? tabForAnnotation(linkedAnnotation)
     : 'annotation';
 
-  const searchUris = useStore(store => store.searchUris());
-  const sidebarHasOpened = useStore(store => store.hasSidebarOpened());
-  const userId = useStore(store => store.profile().userid);
+  const searchUris = store.searchUris();
+  const sidebarHasOpened = store.hasSidebarOpened();
+  const userId = store.profile().userid;
 
   // The local `$tag` of a direct-linked annotation; populated once it
   // has anchored: meaning that it's ready to be focused and scrolled to
@@ -68,18 +64,12 @@ function SidebarView({
       ? linkedAnnotation.$tag
       : null;
 
-  // Actions
-  const clearSelection = useStore(store => store.clearSelection);
-  const selectTab = useStore(store => store.selectTab);
-
   // If, after loading completes, no `linkedAnnotation` object is present when
   // a `linkedAnnotationId` is set, that indicates an error
   const hasDirectLinkedAnnotationError =
     !isLoading && linkedAnnotationId ? !linkedAnnotation : false;
 
-  const hasDirectLinkedGroupError = useStore(store =>
-    store.directLinkedGroupFetchFailed()
-  );
+  const hasDirectLinkedGroupError = store.directLinkedGroupFetchFailed();
 
   const hasContentError =
     hasDirectLinkedAnnotationError || hasDirectLinkedGroupError;
@@ -102,7 +92,7 @@ function SidebarView({
   useEffect(() => {
     if (!prevGroupId.current || prevGroupId.current !== focusedGroupId) {
       // Clear any selected annotations when the group ID changes
-      clearSelection();
+      store.clearSelection();
       prevGroupId.current = focusedGroupId;
     }
     if (focusedGroupId && searchUris.length) {
@@ -111,13 +101,7 @@ function SidebarView({
         uris: searchUris,
       });
     }
-  }, [
-    clearSelection,
-    loadAnnotationsService,
-    focusedGroupId,
-    userId,
-    searchUris,
-  ]);
+  }, [store, loadAnnotationsService, focusedGroupId, userId, searchUris]);
 
   // When a `linkedAnnotationAnchorTag` becomes available, scroll to it
   // and focus it
@@ -125,17 +109,17 @@ function SidebarView({
     if (linkedAnnotationAnchorTag) {
       frameSync.focusAnnotations([linkedAnnotationAnchorTag]);
       frameSync.scrollToAnnotation(linkedAnnotationAnchorTag);
-      selectTab(directLinkedTab);
+      store.selectTab(directLinkedTab);
     } else if (linkedAnnotation) {
       // Make sure to allow for orphaned annotations (which won't have an anchor)
-      selectTab(directLinkedTab);
+      store.selectTab(directLinkedTab);
     }
   }, [
     directLinkedTab,
     frameSync,
     linkedAnnotation,
     linkedAnnotationAnchorTag,
-    selectTab,
+    store,
   ]);
 
   // Connect to the streamer when the sidebar has opened or if user is logged in

--- a/src/sidebar/components/sort-menu.js
+++ b/src/sidebar/components/sort-menu.js
@@ -1,6 +1,6 @@
 import { createElement } from 'preact';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 
 import Menu from './menu';
 import MenuItem from './menu-item';
@@ -10,21 +10,19 @@ import SvgIcon from '../../shared/components/svg-icon';
  * A drop-down menu of sorting options for a collection of annotations.
  */
 export default function SortMenu() {
-  const actions = useStore(store => ({
-    setSortKey: store.setSortKey,
-  }));
+  const store = useStoreProxy();
   // The currently-applied sort order
-  const sortKey = useStore(store => store.sortKey());
+  const sortKey = store.sortKey();
   // All available sorting options. These change depending on current
   // "tab" or context.
-  const sortKeysAvailable = useStore(store => store.sortKeys());
+  const sortKeysAvailable = store.sortKeys();
 
   const menuItems = sortKeysAvailable.map(sortOption => {
     return (
       <MenuItem
         key={sortOption}
         label={sortOption}
-        onClick={() => actions.setSortKey(sortOption)}
+        onClick={() => store.setSortKey(sortOption)}
         isSelected={sortOption === sortKey}
       />
     );

--- a/src/sidebar/components/stream-search-input.js
+++ b/src/sidebar/components/stream-search-input.js
@@ -1,7 +1,7 @@
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../util/service-context';
 
 import SearchInput from './search-input';
@@ -19,7 +19,8 @@ import SearchInput from './search-input';
  * @param {StreamSearchInputProps} props
  */
 function StreamSearchInput({ router }) {
-  const query = useStore(store => store.routeParams().q);
+  const store = useStoreProxy();
+  const query = store.routeParams().q;
   const setQuery = query => {
     // Re-route the user to `/stream` if they are on `/a/:id` and then set
     // the search query.

--- a/src/sidebar/components/test/annotation-action-bar-test.js
+++ b/src/sidebar/components/test/annotation-action-bar-test.js
@@ -93,7 +93,7 @@ describe('AnnotationActionBar', () => {
         shareURI: sinon.stub().returns('http://share.me'),
       },
       '../util/permissions': { permits: fakePermits },
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
     sinon.stub(window, 'confirm').returns(false);
   });

--- a/src/sidebar/components/test/annotation-body-test.js
+++ b/src/sidebar/components/test/annotation-body-test.js
@@ -55,7 +55,7 @@ describe('AnnotationBody', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../util/theme': { applyTheme: fakeApplyTheme },
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/annotation-editor-test.js
+++ b/src/sidebar/components/test/annotation-editor-test.js
@@ -54,7 +54,7 @@ describe('AnnotationEditor', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       '../util/theme': { applyTheme: fakeApplyTheme },
     });
   });

--- a/src/sidebar/components/test/annotation-header-test.js
+++ b/src/sidebar/components/test/annotation-header-test.js
@@ -40,7 +40,7 @@ describe('AnnotationHeader', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       '../util/annotation-metadata': {
         isHighlight: fakeIsHighlight,
         isReply: fakeIsReply,

--- a/src/sidebar/components/test/annotation-publish-control-test.js
+++ b/src/sidebar/components/test/annotation-publish-control-test.js
@@ -58,7 +58,7 @@ describe('AnnotationPublishControl', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       '../util/annotation-metadata': fakeMetadata,
       '../util/theme': {
         applyTheme: fakeApplyTheme,

--- a/src/sidebar/components/test/annotation-share-info-test.js
+++ b/src/sidebar/components/test/annotation-share-info-test.js
@@ -37,7 +37,7 @@ describe('AnnotationShareInfo', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       '../util/permissions': { isPrivate: fakeIsPrivate },
     });
   });

--- a/src/sidebar/components/test/annotation-test.js
+++ b/src/sidebar/components/test/annotation-test.js
@@ -62,7 +62,7 @@ describe('Annotation', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../util/annotation-metadata': fakeMetadata,
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/annotation-view-test.js
+++ b/src/sidebar/components/test/annotation-view-test.js
@@ -33,7 +33,7 @@ describe('AnnotationView', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       './hooks/use-root-thread': fakeUseRootThread,
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/filter-status-test.js
+++ b/src/sidebar/components/test/filter-status-test.js
@@ -54,7 +54,7 @@ describe('FilterStatus', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       './hooks/use-root-thread': fakeUseRootThread,
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       '../util/thread': fakeThreadUtil,
     });
   });

--- a/src/sidebar/components/test/group-list-item-test.js
+++ b/src/sidebar/components/test/group-list-item-test.js
@@ -72,7 +72,7 @@ describe('GroupListItem', () => {
         copyText: fakeCopyText,
       },
       '../util/group-list-item-common': fakeGroupListItemCommon,
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
 
     sinon.stub(window, 'confirm').returns(false);

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -63,7 +63,7 @@ describe('GroupList', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       '../service-config': fakeServiceConfig,
     });
   });

--- a/src/sidebar/components/test/help-panel-test.js
+++ b/src/sidebar/components/test/help-panel-test.js
@@ -37,7 +37,7 @@ describe('HelpPanel', function () {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       '../util/version-data': fakeVersionData,
     });
   });

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -81,7 +81,7 @@ describe('HypothesisApp', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../service-config': fakeServiceConfig,
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       '../util/session': {
         shouldAutoDisplayTutorial: fakeShouldAutoDisplayTutorial,
       },

--- a/src/sidebar/components/test/login-prompt-panel-test.js
+++ b/src/sidebar/components/test/login-prompt-panel-test.js
@@ -33,7 +33,7 @@ describe('LoginPromptPanel', function () {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/moderation-banner-test.js
+++ b/src/sidebar/components/test/moderation-banner-test.js
@@ -36,13 +36,14 @@ describe('ModerationBanner', () => {
       },
     };
 
+    const fakeStore = {
+      hideAnnotation: sinon.stub(),
+      unhideAnnotation: sinon.stub(),
+    };
+
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback =>
-        callback({
-          hide: sinon.stub(),
-          unhide: sinon.stub(),
-        }),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/new-note-btn-test.js
+++ b/src/sidebar/components/test/new-note-btn-test.js
@@ -41,7 +41,7 @@ describe('NewNoteButton', function () {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/notebook-view-test.js
+++ b/src/sidebar/components/test/notebook-view-test.js
@@ -25,7 +25,7 @@ describe('NotebookView', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       './hooks/use-root-thread': fakeUseRootThread,
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/search-input-test.js
+++ b/src/sidebar/components/test/search-input-test.js
@@ -25,7 +25,7 @@ describe('SearchInput', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/selection-tabs-test.js
+++ b/src/sidebar/components/test/selection-tabs-test.js
@@ -40,7 +40,7 @@ describe('SelectionTabs', function () {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/share-annotations-panel-test.js
+++ b/src/sidebar/components/test/share-annotations-panel-test.js
@@ -52,7 +52,7 @@ describe('ShareAnnotationsPanel', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       '../util/copy-to-clipboard': fakeCopyToClipboard,
     });
   });

--- a/src/sidebar/components/test/sidebar-content-error-test.js
+++ b/src/sidebar/components/test/sidebar-content-error-test.js
@@ -26,7 +26,7 @@ describe('SidebarContentError', () => {
       isLoggedIn: sinon.stub().returns(true),
     };
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
     $imports.$mock(mockImportedComponents());
   });
@@ -52,7 +52,9 @@ describe('SidebarContentError', () => {
 
     const clearButton = findButtonByText(wrapper, 'Show all annotations');
     assert.isTrue(clearButton.exists());
-    assert.equal(clearButton.props().onClick, fakeStore.clearSelection);
+
+    clearButton.props().onClick();
+    assert.called(fakeStore.clearSelection);
   });
 
   context('unavailable annotation, logged out', () => {

--- a/src/sidebar/components/test/sidebar-panel-test.js
+++ b/src/sidebar/components/test/sidebar-panel-test.js
@@ -29,7 +29,7 @@ describe('SidebarPanel', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       'scroll-into-view': fakeScrollIntoView,
     });
   });

--- a/src/sidebar/components/test/sidebar-view-test.js
+++ b/src/sidebar/components/test/sidebar-view-test.js
@@ -66,7 +66,7 @@ describe('SidebarView', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       './hooks/use-root-thread': fakeUseRootThread,
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       '../util/tabs': fakeTabsUtil,
     });
   });

--- a/src/sidebar/components/test/sort-menu-test.js
+++ b/src/sidebar/components/test/sort-menu-test.js
@@ -22,7 +22,7 @@ describe('SortMenu', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/stream-search-input-test.js
+++ b/src/sidebar/components/test/stream-search-input-test.js
@@ -20,7 +20,7 @@ describe('StreamSearchInput', () => {
     };
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/stream-view-test.js
+++ b/src/sidebar/components/test/stream-view-test.js
@@ -41,7 +41,7 @@ describe('StreamView', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       './hooks/use-root-thread': fakeUseRootThread,
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       '../util/search-filter': fakeSearchFilter,
     });
   });

--- a/src/sidebar/components/test/thread-card-test.js
+++ b/src/sidebar/components/test/thread-card-test.js
@@ -38,7 +38,7 @@ describe('ThreadCard', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       'lodash.debounce': fakeDebounce,
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/thread-list-test.js
+++ b/src/sidebar/components/test/thread-list-test.js
@@ -68,7 +68,7 @@ describe('ThreadList', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       '../util/annotation-metadata': fakeMetadata,
       '../util/dom': fakeDomUtil,
       '../util/visible-threads': fakeVisibleThreadsUtil,

--- a/src/sidebar/components/test/thread-test.js
+++ b/src/sidebar/components/test/thread-test.js
@@ -95,7 +95,7 @@ describe('Thread', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       '../util/thread': fakeThreadUtil,
     });
   });

--- a/src/sidebar/components/test/toast-messages-test.js
+++ b/src/sidebar/components/test/toast-messages-test.js
@@ -56,7 +56,7 @@ describe('ToastMessages', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/top-bar-test.js
+++ b/src/sidebar/components/test/top-bar-test.js
@@ -40,7 +40,7 @@ describe('TopBar', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
       '../util/is-third-party-service': fakeIsThirdPartyService,
       '../service-config': fakeServiceConfig,
     });

--- a/src/sidebar/components/test/user-menu-test.js
+++ b/src/sidebar/components/test/user-menu-test.js
@@ -61,7 +61,7 @@ describe('UserMenu', () => {
         isThirdPartyUser: fakeIsThirdPartyUser,
       },
       '../service-config': fakeServiceConfig,
-      '../store/use-store': callback => callback(fakeStore),
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/thread-card.js
+++ b/src/sidebar/components/thread-card.js
@@ -4,7 +4,7 @@ import { createElement } from 'preact';
 import { useCallback, useMemo } from 'preact/hooks';
 
 import propTypes from 'prop-types';
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../util/service-context';
 
 import Thread from './thread';
@@ -26,9 +26,10 @@ import Thread from './thread';
  * @param {ThreadCardProps} props
  */
 function ThreadCard({ frameSync, thread }) {
+  const store = useStoreProxy();
   const threadTag = thread.annotation && thread.annotation.$tag;
-  const isFocused = useStore(store => store.isAnnotationFocused(threadTag));
-  const showDocumentInfo = useStore(store => store.route() !== 'sidebar');
+  const isFocused = store.isAnnotationFocused(threadTag);
+  const showDocumentInfo = store.route() !== 'sidebar';
   const focusThreadAnnotation = useMemo(
     () =>
       debounce(tag => {

--- a/src/sidebar/components/thread-list.js
+++ b/src/sidebar/components/thread-list.js
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { isHighlight } from '../util/annotation-metadata';
 import { getElementHeightWithMargins } from '../util/dom';
 import {
@@ -44,8 +44,6 @@ function getScrollContainer() {
  * @param {ThreadListProps} props
  */
 function ThreadList({ thread }) {
-  const setForcedVisible = useStore(store => store.setForcedVisible);
-
   // Height of the visible area of the scroll container.
   const [scrollContainerHeight, setScrollContainerHeight] = useState(
     getScrollContainer().clientHeight
@@ -85,8 +83,10 @@ function ThreadList({ thread }) {
     [topLevelThreads, threadHeights, scrollPosition, scrollContainerHeight]
   );
 
+  const store = useStoreProxy();
+
   // Get the `$tag` of the most recently created unsaved annotation.
-  const newAnnotationTag = useStore(store => {
+  const newAnnotationTag = (() => {
     // If multiple unsaved annotations exist, assume that the last one in the
     // list is the most recently created one.
     const newAnnotations = store
@@ -96,7 +96,7 @@ function ThreadList({ thread }) {
       return null;
     }
     return newAnnotations[newAnnotations.length - 1].$tag;
-  });
+  })();
 
   // Scroll to newly created annotations and replies.
   //
@@ -105,10 +105,10 @@ function ThreadList({ thread }) {
   // and the thread list will scroll to that.
   useEffect(() => {
     if (newAnnotationTag) {
-      setForcedVisible(newAnnotationTag, true);
+      store.setForcedVisible(newAnnotationTag, true);
       setScrollToId(newAnnotationTag);
     }
-  }, [setForcedVisible, newAnnotationTag]);
+  }, [store, newAnnotationTag]);
 
   // Effect to scroll a particular thread into view. This is mainly used to
   // scroll a newly created annotation into view.

--- a/src/sidebar/components/thread.js
+++ b/src/sidebar/components/thread.js
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import { createElement, Fragment } from 'preact';
 
 import propTypes from 'prop-types';
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../util/service-context';
 import { countHidden, countVisible } from '../util/thread';
 
@@ -27,8 +27,6 @@ import ModerationBanner from './moderation-banner';
  * @param {ThreadProps} props
  */
 function Thread({ showDocumentInfo = false, thread, threadsService }) {
-  const setExpanded = useStore(store => store.setExpanded);
-
   // Only render this thread's annotation if it exists and the thread is `visible`
   const showAnnotation = thread.annotation && thread.visible;
 
@@ -51,7 +49,10 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
     child => countVisible(child) > 0
   );
 
-  const onToggleReplies = () => setExpanded(thread.id, !!thread.collapsed);
+  const store = useStoreProxy();
+  const onToggleReplies = () =>
+    store.setExpanded(thread.id, !!thread.collapsed);
+
   return (
     <section
       className={classnames('thread', {

--- a/src/sidebar/components/toast-messages.js
+++ b/src/sidebar/components/toast-messages.js
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../util/service-context';
 
 import SvgIcon from '../../shared/components/svg-icon';
@@ -94,7 +94,8 @@ ToastMessage.propTypes = {
  * @param {ToastMessagesProps} props
  */
 function ToastMessages({ toastMessenger }) {
-  const messages = useStore(store => store.getToastMessages());
+  const store = useStoreProxy();
+  const messages = store.getToastMessages();
   return (
     <div>
       <ul

--- a/src/sidebar/components/top-bar.js
+++ b/src/sidebar/components/top-bar.js
@@ -3,7 +3,7 @@ import propTypes from 'prop-types';
 
 import bridgeEvents from '../../shared/bridge-events';
 import serviceConfig from '../service-config';
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import uiConstants from '../ui-constants';
 import isThirdPartyService from '../util/is-third-party-service';
 import { withServices } from '../util/service-context';
@@ -51,24 +51,19 @@ function TopBar({
   const showSharePageButton = !isThirdPartyService(settings);
   const loginLinkStyle = applyTheme(['accentColor'], settings);
 
-  const filterQuery = useStore(store => store.filterQuery());
-  const setFilterQuery = useStore(store => store.setFilterQuery);
-
-  const pendingUpdateCount = useStore(store => store.pendingUpdateCount());
-
-  const togglePanelFn = useStore(store => store.toggleSidebarPanel);
+  const store = useStoreProxy();
+  const filterQuery = store.filterQuery();
+  const pendingUpdateCount = store.pendingUpdateCount();
 
   const applyPendingUpdates = () => streamer.applyPendingUpdates();
 
   const toggleSharePanel = () => {
-    togglePanelFn(uiConstants.PANEL_SHARE_ANNOTATIONS);
+    store.toggleSidebarPanel(uiConstants.PANEL_SHARE_ANNOTATIONS);
   };
 
-  const isHelpPanelOpen = useStore(store =>
-    store.isSidebarPanelOpen(uiConstants.PANEL_HELP)
-  );
-  const isAnnotationsPanelOpen = useStore(store =>
-    store.isSidebarPanelOpen(uiConstants.PANEL_SHARE_ANNOTATIONS)
+  const isHelpPanelOpen = store.isSidebarPanelOpen(uiConstants.PANEL_HELP);
+  const isAnnotationsPanelOpen = store.isSidebarPanelOpen(
+    uiConstants.PANEL_SHARE_ANNOTATIONS
   );
 
   /**
@@ -80,7 +75,7 @@ function TopBar({
     if (service && service.onHelpRequestProvided) {
       bridge.call(bridgeEvents.HELP_REQUESTED);
     } else {
-      togglePanelFn(uiConstants.PANEL_HELP);
+      store.toggleSidebarPanel(uiConstants.PANEL_HELP);
     }
   };
 
@@ -144,7 +139,10 @@ function TopBar({
               }`}
             />
           )}
-          <SearchInput query={filterQuery || null} onSearch={setFilterQuery} />
+          <SearchInput
+            query={filterQuery || null}
+            onSearch={store.setFilterQuery}
+          />
           <SortMenu />
           {showSharePageButton && (
             <Button

--- a/src/sidebar/components/user-menu.js
+++ b/src/sidebar/components/user-menu.js
@@ -4,7 +4,7 @@ import propTypes from 'prop-types';
 import bridgeEvents from '../../shared/bridge-events';
 import serviceConfig from '../service-config';
 import { isThirdPartyUser } from '../util/account-id';
-import useStore from '../store/use-store';
+import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../util/service-context';
 
 import Menu from './menu';
@@ -42,12 +42,10 @@ import SvgIcon from '../../shared/components/svg-icon';
  * @param {UserMenuProps} props
  */
 function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
-  const focusedGroupId = useStore(store => store.focusedGroupId);
+  const store = useStoreProxy();
   const isThirdParty = isThirdPartyUser(auth.userid, settings.authDomain);
   const service = serviceConfig(settings);
-  const isNotebookEnabled = useStore(store =>
-    store.isFeatureEnabled('notebook_launch')
-  );
+  const isNotebookEnabled = store.isFeatureEnabled('notebook_launch');
 
   const serviceSupports = feature => service && !!service[feature];
 
@@ -57,7 +55,7 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
     !isThirdParty || serviceSupports('onLogoutRequestProvided');
 
   const onSelectNotebook = () => {
-    bridge.call('showNotebook', focusedGroupId());
+    bridge.call('showNotebook', store.focusedGroupId());
   };
 
   const onProfileSelected = () =>


### PR DESCRIPTION
This PR switches our UI components to use the new `useStoreProxy` hook introduced in https://github.com/hypothesis/client/pull/2800 to read data from and update the store. See that PR the motivation for this change.

The code changes in this PR are pretty mechanical. In UI components they look like:

```js
// Old
const someData = useStore(store => store.getSomeData()); // Selector
const changeSomething = useStore(store => store.changeSomething); // Action

<button onClick={changeSomething}>...</button>
...


// New
const store = useStoreProxy();
const someData = store.someData(); // Selector

<button onClick={() => store.changeSomething()}>...</button>
....
```

In tests the only code that really need to change was the mocks for the hook:

```js
// Old
$imports.$mock({
  '../store/use-store': callback => callback(fakeStore),
});

// New
$imports.$mock({
  '../store/use-store': { useStoreProxy: () => fakeStore },
});
```

----

One of the tradeoffs of the new API compared to the previous API that can be seen in this PR is that state usage tracking is less fine-grained in some cases. For example, this previous code would only cause a re-render if the logged-in user ID changed:

```js
const userid = useStore(store => store.profile().userid)
```

This replacement code however will cause a re-render if any part of the profile changes:

```js
const store = useStoreProxy();
const userid = store.profile().userid
```

From what I've seen by adding debugging logging this doesn't cause too much unnecessary re-rendering in our current application and so I think this is a good trade-off for the better API. We could add an escape hatch in future to combine the benefits of the old/new API. For example, something like:

```js
// Only re-renders if `userid` property of profile changes
const userid = store.watch(() => store.profile().userid); 
```

What this means right away is that it is good practice to use fine-grained selectors where available. For example, `store.getAnnotationById(id)` rather than `store.allAnnotations().find(ann => ann.id === id)`. This practice also has the advantage that it will tend to make it easier to refactor the internal state of a store module (for example, changing the annotations list to a map keyed by ID).