### PR TITLE
POC: Extend side-by-side mode to support HTML documents

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -5,6 +5,10 @@ import sidebarTrigger from './sidebar-trigger';
 import { createSidebarConfig } from './config/sidebar';
 import events from '../shared/bridge-events';
 import features from './features';
+import {
+  guessMainContentArea,
+  preserveScrollPosition,
+} from './util/document-resizing';
 
 import Guest from './guest';
 import { ToolbarController } from './toolbar';
@@ -166,12 +170,150 @@ export default class Sidebar extends Guest {
     // Initial layout notification
     this._notifyOfLayoutChange(false);
     this._setupSidebarEvents();
+
+    // Is the document currently displayed side-by-side with the sidebar?
+    this.sideBySideActive = false;
+
+    /** @type {LayoutState} */
+    let lastSidebarLayoutState = {
+      expanded: false,
+      width: 0,
+      height: 0,
+    };
+    this.subscribe('sidebarLayoutChanged', state => {
+      lastSidebarLayoutState = state;
+      this.fitSideBySide(state);
+    });
+
+    const fitSideBySideOnResize = () =>
+      this.fitSideBySide(lastSidebarLayoutState);
+    window.addEventListener('resize', fitSideBySideOnResize);
+    this._cleanupSideBySide = () => {
+      window.removeEventListener('resize', fitSideBySideOnResize);
+    };
   }
 
   destroy() {
+    this._cleanupSideBySide();
     this._hammerManager?.destroy();
     this.frame?.remove();
     super.destroy();
+  }
+
+  /**
+   * Respond to the sidebar opening or document being resized by updating the
+   * side-by-side mode.
+   *
+   * Subclasses may override `minSideBySideWidth`, `activateSideBySide` and
+   * `deactivateSideBySide` to customize what changes are made to the document
+   * when it is activated.
+   *
+   * @param {LayoutState} layoutState
+   */
+  fitSideBySide(layoutState) {
+    const maximumWidthToFit = window.innerWidth - layoutState.width;
+
+    this.sideBySideActive =
+      layoutState.expanded && maximumWidthToFit >= this.minSideBySideWidth();
+    this.closeSidebarOnDocumentClick = !this.sideBySideActive;
+
+    if (this.sideBySideActive) {
+      this.activateSideBySide(layoutState.width);
+    } else {
+      this.deactivateSideBySide();
+    }
+  }
+
+  /**
+   * Resize the document content after side-by-side mode is activated.
+   *
+   * Subclasses can override this to customize how the document viewer is
+   * resized when side-by-side mode is activated. If they do, they should also
+   * implement `deactivateSideBySide`.
+   *
+   * @param {number} sidebarWidth
+   */
+  activateSideBySide(sidebarWidth) {
+    // When side-by-side mode is activated, what we want to achieve is that the
+    // main content of the page is fully visible alongside the sidebar, with
+    // as much space given to the main content as possible. A challenge is that
+    // we don't know how the page will respond to reducing the width of the body.
+    //
+    // - The content might have margins which automatically get reduced as the
+    //   available width is reduced. For example a blog post with a fixed-width
+    //   article in the middle and `margin: auto` for both margins.
+    //
+    //   In this scenario we'd want to reduce the document width by the full
+    //   width of the sidebar.
+    //
+    // - There might be sidebars to the left and/or right of the main content
+    //   which cause the main content to be squashed when the width is reduced.
+    //   For example a news website with a column of ads on the right.
+    //
+    //   In this scenario we'd want to not reduce the document width or reduce
+    //   it by a smaller amount and let the Hypothesis sidebar cover up the
+    //   document's sidebar, leaving as much space as possible to the content.
+    //
+    // Therefore what we do is to initially reduce the width of the document by
+    // the full width of the sidebar, then we use heuristics to analyze the
+    // resulting page layout and determine whether there is significant "free space"
+    // (ie. anything that is not the main content of the document, such as ads or
+    // links to related stories) to the right of the main content. If there is,
+    // we make the document wider again to allow more space for the main content.
+    //
+    // These heuristics assume a typical "article" page with one central block
+    // of content. If we can't find the "main content" then we just assume that
+    // everything on the page is potentially content that the user might want
+    // to annotate and so try to keep it all visible.
+    const padding = 10;
+    const width = window.innerWidth - sidebarWidth;
+    const rightMargin = window.innerWidth - width + padding;
+
+    preserveScrollPosition(() => {
+      // FIXME: If there is a CSS rule that sets the `width` of the body, that
+      // will override this margin. eg. There are various sites that have
+      // `width: 100%` rules for the body.
+      document.body.style.marginRight = `${rightMargin}px`;
+
+      const contentArea = guessMainContentArea(document.body);
+      if (contentArea) {
+        // Check if we can give the main content more space by letting the
+        // sidebar overlap stuff in the document to the right of the main content.
+        const freeSpace = window.innerWidth - sidebarWidth - contentArea.right;
+        if (freeSpace > 200) {
+          document.body.style.marginRight = `${rightMargin - freeSpace}px`;
+        }
+
+        // If the main content appears to be right up against the edge of the
+        // window, add padding for readability.
+        if (contentArea.left < 10) {
+          document.body.style.marginLeft = `${padding}px`;
+        }
+      }
+    });
+  }
+
+  /**
+   * Undo the effects of `activateSideBySide`.
+   */
+  deactivateSideBySide() {
+    preserveScrollPosition(() => {
+      document.body.style.marginLeft = '';
+      document.body.style.marginRight = '';
+    });
+  }
+
+  /**
+   * Return the minimum width that the document must have for side-by-side
+   * mode to be enabled when the sidebar is open.
+   *
+   * Subclasses can override this to specify a different minimum width for
+   * a particular document viewer.
+   *
+   * @return {number}
+   */
+  minSideBySideWidth() {
+    return 400;
   }
 
   _setupSidebarEvents() {

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -729,4 +729,46 @@ describe('Sidebar', () => {
       assert.isUndefined(sidebar.plugins.BucketBar);
     });
   });
+
+  describe('side-by-side mode', () => {
+    it('activates side-by-side mode when sidebar is opened', () => {
+      throw new Error('Implement me!');
+    });
+
+    it('deactivates side-by-side mode when sidebar is opened', () => {
+      throw new Error('Implement me!');
+    });
+
+    it('updates side-by-side mode when window is resized', () => {
+      throw new Error('Implement me!');
+    });
+
+    it('does not activate side-by-side mode if there is not enough space', () => {
+      throw new Error('Implement me!');
+    });
+
+    describe('#activateSideBySide', () => {
+      it('resizes document to make space for sidebar', () => {
+        throw new Error('Implement me!');
+      });
+
+      it('allows secondary content to remain under the sidebar', () => {
+        throw new Error('Implement me!');
+      });
+
+      it('preserves scroll position after resizing document', () => {
+        throw new Error('Implement me!');
+      });
+    });
+
+    describe('#deactivateSideBySide', () => {
+      it('removes the style properties set by `activateSideBySide`', () => {
+        throw new Error('Implement me!');
+      });
+
+      it('preserves scroll position after resizing document', () => {
+        throw new Error('Implement me!');
+      });
+    });
+  });
 });

--- a/src/annotator/util/document-resizing.js
+++ b/src/annotator/util/document-resizing.js
@@ -1,0 +1,102 @@
+// Utilities related to resizing web pages in order to make space for the
+// sidebar to be visible alongside the content.
+
+/**
+ * Attempt to guess the region of the page that contains the main content.
+ *
+ * @param {Element} root
+ * @return {{ left: number, right: number }|null} -
+ *   The left/right content margins or `null` if they could not be determined
+ */
+export function guessMainContentArea(root) {
+  /** @type {Map<number,number>} */
+  const leftMarginVotes = new Map();
+
+  /** @type {Map<number,number>} */
+  const rightMarginVotes = new Map();
+
+  // Gather data about the paragraphs of text in the document.
+  const paragraphs = Array.from(root.querySelectorAll('p'))
+    .map(p => {
+      // Gather some data about them.
+      const rect = p.getBoundingClientRect();
+      const textLength = /** @type {string} */ (p.textContent).length;
+      return { rect, textLength };
+    })
+    .filter(({ rect }) => {
+      // Filter out hidden paragraphs
+      return rect.width > 0 && rect.height > 0;
+    })
+    // Select the paragraphs containing the most text.
+    .sort((a, b) => b.textLength - a.textLength)
+    .slice(0, 15);
+
+  // Let these paragraphs "vote" for what the left and right margins of the
+  // main content area in the document are.
+  paragraphs.forEach(({ rect }) => {
+    let leftVotes = leftMarginVotes.get(rect.left) ?? 0;
+    leftVotes += 1;
+    leftMarginVotes.set(rect.left, leftVotes);
+
+    let rightVotes = rightMarginVotes.get(rect.right) ?? 0;
+    rightVotes += 1;
+    rightMarginVotes.set(rect.right, rightVotes);
+  });
+
+  // Find the margin values with the most votes.
+  if (leftMarginVotes.size === 0 || rightMarginVotes.size === 0) {
+    return null;
+  }
+
+  const leftMargin = [...leftMarginVotes.entries()].sort((a, b) => b[1] - a[1]);
+  const rightMargin = [...rightMarginVotes.entries()].sort(
+    (a, b) => b[1] - a[1]
+  );
+
+  const [leftPos, leftVotes] = leftMargin[0];
+  const [rightPos, rightVotes] = rightMargin[0];
+
+  // If we didn't find at least `minVotes` paragraphs with the same left or
+  // right edge, then we don't have enough confidence.
+  const minVotes = 5;
+  if (leftVotes < minVotes || rightVotes < minVotes) {
+    return null;
+  }
+
+  return { left: leftPos, right: rightPos };
+}
+
+/**
+ * Apply a layout change to the document and preserve the scroll position.
+ *
+ * This utility tries to ensure that the same part of the document remains
+ * visible on screen after the content is resized.
+ *
+ * @param {() => any} callback - Callback that will apply the layout change
+ */
+export function preserveScrollPosition(callback) {
+  // Element that we are going to scroll in order to keep the same content on
+  // screen after the document has been resized.
+  const scrollRoot = document.documentElement;
+
+  // Find an element near the top of the screen to serve as a reference point.
+  // We are currently just picking whatever element is in the middle of the screen,
+  // but this should ideally be an element that will scroll together with the
+  // scroll root, eg. excluding fixed elements.
+  const anchorElement = document.elementFromPoint(window.innerWidth / 2, 1);
+  if (!anchorElement) {
+    callback();
+    return;
+  }
+
+  const anchorTop = anchorElement.getBoundingClientRect().top;
+
+  callback();
+
+  const newAnchorTop = anchorElement.getBoundingClientRect().top;
+
+  // Determine how far we scrolled as a result of the layout change.
+  // This will be positive if the anchor element moved down or negative if it moved up.
+  const scrollDelta = newAnchorTop - anchorTop;
+  scrollRoot.scrollTop += scrollDelta;
+}

--- a/src/annotator/util/test/document-resizing-test.js
+++ b/src/annotator/util/test/document-resizing-test.js
@@ -1,0 +1,29 @@
+describe('annotator/util/document-resizing', () => {
+  describe('guessMainContentArea', () => {
+    it('returns `null` if the document has no paragraphs', () => {
+      throw new Error('Implement me!');
+    });
+
+    it('ignores the positions of hidden paragraphs', () => {
+      throw new Error('Implement me!');
+    });
+
+    it('returns the margins of the paragraphs with the most text', () => {
+      throw new Error('Implement me!');
+    });
+
+    it('returns `null` if there are not enough paragraphs with common margins', () => {
+      throw new Error('Implement me!');
+    });
+  });
+
+  describe('preserveScrollPosition', () => {
+    it('saves the scroll position, invokes the callback and then restores the scroll position', () => {
+      throw new Error('Implement me!');
+    });
+
+    it('does not restore the scroll position if no anchor element could be found', () => {
+      throw new Error('Implement me!');
+    });
+  });
+});


### PR DESCRIPTION
This is a proof of concept solution for https://github.com/hypothesis/product-backlog/issues/94. It extends the recently introduced "side-by-side" mode for PDFs to also apply to HTML documents.

When the sidebar is opened, the page content is shrunk to make space to see the content alongside the sidebar. The implementation attempts to to choose the amount of shrinking such that the main content of the page is fully visible and allowed as much horizontal space as possible. This means allowing peripheral content such as ads on the side of the page to remain covered by the sidebar. Additionally, the client adjusts the scroll position of the page when opening and closing the sidebar to try and keep the same part of the content visible, despite the layout changes to the page.

Similar to the PDF side-by-side implementation, the page is not shrunk if the amount of horizontal room that would be left for the page's content is below a threshold. This means that on a mobile phone or small tablet for example, the client will just continue to behave as it does today.

## Examples

### Web page where main content extends to right edge of page

Before this PR:

<img width="800" alt="HTML side-by-side inactive" src="https://user-images.githubusercontent.com/2458/101738448-11b1e300-3abe-11eb-8a7a-77cf7481bcf9.png">

After this PR:

<img width="800" alt="HTML side-by-side active" src="https://user-images.githubusercontent.com/2458/101738460-15456a00-3abe-11eb-8884-d6c981a1484e.png">

### Web page where there is significant horizontal space given to unimportant content (ads) to the right of the main content

Before this PR:

<img width="800" alt="HTML side-by-side inactive - page with ads" src="https://user-images.githubusercontent.com/2458/101738616-5473bb00-3abe-11eb-9d97-c9d10b0fa9b7.png">

After this PR:

(Note that part of the page's content has been allowed to remain under the sidebar to allow more horizontal room for the main content)

<img width="800" alt="HTML side-by-side active - page with ads" src="https://user-images.githubusercontent.com/2458/101738640-5dfd2300-3abe-11eb-9ac9-b836f7e6c8d3.png">

## Known limitations

The simple method used to resize pages does not work on all websites. On sites where it fails, the sidebar will continue to overlap the content as it does today. This is something that can be improved over time.

## Implementation notes

We recently improved the experience of annotating PDF documents by
showing the sidebar alongside the content when there is enough
horizontal space available. This commit extends that approach to web pages,
with modifications to allow for differences between web pages and PDFs:

 - Web pages do not have a known layout and response to being resized
   that we can rely on

 - Web pages will often have peripheral content on the side which we
   should not try to squeeze into the available space when the sidebar
   is opened. Instead we should continue to allow the sidebar to cover
   it up to make more room for the main content

This is implemented by first shrinking the `<body>` by the full width of
the sidebar when it opens and then increasing the `<body>`'s width if
there is space between the "main content" of the page and the edge of
the sidebar. Whatever is in this space (eg. related stories, ads) will
then be covered up by the sidebar.

Determining what consitutes the "main content" of the page
is done by heuristics in `guessMainContentArea`. These heuristics assume
that the main content can be inferred by considering the longest
paragraphs of text on the page and looking for common vertical margins
amongst them.

Resizing the document will generally cause the content to shift. To try
and ensure the same content remains visible before and after opening the
sidebar, a `preserveScrollPosition` helper attempts to determine how
much the content shifted after the relayout and adjust the scroll
position to keep, near-enough, the same content visible. To do this, it
chooses an element near the top of the screen as an anchor and checks
how much it shifts following the resize. It then adjusts the document's
scroll position to compensate.