### PR TITLE
Use `useStoreProxy` in `useRootThread` hook

### DIFF
--- a/src/sidebar/components/hooks/test/use-root-thread-test.js
+++ b/src/sidebar/components/hooks/test/use-root-thread-test.js
@@ -20,7 +20,7 @@ describe('sidebar/components/hooks/use-root-thread', () => {
     fakeThreadAnnotations = sinon.stub().returns('fakeThreadAnnotations');
 
     $imports.$mock({
-      '../../store/use-store': callback => callback(fakeStore),
+      '../../store/use-store': { useStoreProxy: () => fakeStore },
       '../../util/thread-annotations': fakeThreadAnnotations,
     });
 

--- a/src/sidebar/components/hooks/use-root-thread.js
+++ b/src/sidebar/components/hooks/use-root-thread.js
@@ -1,6 +1,6 @@
 import { useMemo } from 'preact/hooks';
 
-import useStore from '../../store/use-store';
+import { useStoreProxy } from '../../store/use-store';
 import threadAnnotations from '../../util/thread-annotations';
 
 /** @typedef {import('../../util/build-thread').Thread} Thread */
@@ -12,11 +12,12 @@ import threadAnnotations from '../../util/thread-annotations';
  * @return {Thread}
  */
 export default function useRootThread() {
-  const annotations = useStore(store => store.allAnnotations());
-  const query = useStore(store => store.filterQuery());
-  const route = useStore(store => store.route());
-  const selectionState = useStore(store => store.selectionState());
-  const userFilter = useStore(store => store.userFilter());
+  const store = useStoreProxy();
+  const annotations = store.allAnnotations();
+  const query = store.filterQuery();
+  const route = store.route();
+  const selectionState = store.selectionState();
+  const userFilter = store.userFilter();
 
   const threadState = useMemo(() => {
     /** @type {Object.<string,string>} */


### PR DESCRIPTION
Change `useRootThread` hook to use the new API for reading data from the
store.