### PR TITLE
Restructure filters store for extensibility and clarity

### DIFF
--- a/src/sidebar/components/hooks/test/use-root-thread-test.js
+++ b/src/sidebar/components/hooks/test/use-root-thread-test.js
@@ -15,7 +15,7 @@ describe('sidebar/components/hooks/use-root-thread', () => {
       filterQuery: sinon.stub().returns('itchy'),
       route: sinon.stub().returns('66'),
       selectionState: sinon.stub().returns({ hi: 'there' }),
-      userFilter: sinon.stub().returns('hotspur'),
+      getFilterValues: sinon.stub().returns({ user: 'hotspur' }),
     };
     fakeThreadAnnotations = sinon.stub().returns('fakeThreadAnnotations');
 

--- a/src/sidebar/components/hooks/use-root-thread.js
+++ b/src/sidebar/components/hooks/use-root-thread.js
@@ -17,22 +17,16 @@ export default function useRootThread() {
   const query = store.filterQuery();
   const route = store.route();
   const selectionState = store.selectionState();
-  const userFilter = store.userFilter();
+  const filters = store.getFilterValues();
 
   const threadState = useMemo(() => {
     /** @type {Object.<string,string>} */
-    const filters = {};
-    if (userFilter) {
-      filters.user = userFilter;
-    }
     return {
       annotations,
-      filters,
-      query,
       route,
       selection: { ...selectionState, filterQuery: query, filters },
     };
-  }, [annotations, query, route, selectionState, userFilter]);
+  }, [annotations, query, route, selectionState, filters]);
 
   return threadAnnotations(threadState);
 }

--- a/src/sidebar/store/modules/filters.js
+++ b/src/sidebar/store/modules/filters.js
@@ -3,31 +3,49 @@ import { createSelector } from 'reselect';
 import { actionTypes } from '../util';
 
 /**
+ * Manage state pertaining to the filtering of annotations in the UI.
+ *
+ * There are a few sources of filtering that gets applied to annotations:
+ *
+ * - focusFilters: Filters defined by config/settings. Currently supports a
+ *   user filter. Application of these filters may be toggled on/off by user
+ *   interaction (`focusActive`), but the values of these filters are set by
+ *   config/settings or RPC (not by user directly). The value(s) of
+ *   focusFilters are retained even when focus is inactive such that they might
+ *   be re-applied later.
+ * - filters: Filters set by faceting/filtering UI. Any filter here is currently
+ *   active (applied).
+ * - query: String query that is either typed in by the user or provided in
+ *   settings. A query string may contain supported facets.
+ *   (see `util/search-filter`)
+ */
+
+/**
+ * Structure of focus-mode config, provided in settings (app config)
  * @typedef FocusConfig
- * @prop {User} user
+ * @prop {FocusUserConfig} user
  */
 
 /**
- * @typedef FocusedUser
- * @prop {string} filter - The identifier to use for filtering annotations
- *           derived from either a userId or a username. This may take the
- *           form of a username, e.g. 'oakbucket', or a userid
- * @prop {string} displayName
- */
-
-/**
- * @typedef User
+ * @typedef FocusUserConfig
  * @prop {string} [userid]
  * @prop {string} [username]
  * @prop {string} displayName - User's display name
  */
 
 /**
- * @typedef Focus
- * @prop {boolean} configured - Focus config contains valid `user` and
- *           is good to go
- * @prop {boolean} active - Focus mode is currently applied
- * @prop {FocusedUser} [user] - User to focus on (filter annotations for)
+ * @typedef FilterOption
+ * @prop {string} value - The machine-readable value of the option
+ * @prop {string} display - The human-facing "pretty" value of the option
+ */
+
+/**
+ * Valid/recognized filters
+ * @typedef {'user'} FilterKey
+ */
+
+/**
+ * @typedef {Object.<FilterKey, FilterOption>} Filters
  */
 
 /**
@@ -37,59 +55,78 @@ import { actionTypes } from '../util';
  * @prop {string} displayName
  */
 
-/**
- * Configure (user-)focused mode. User-focus mode may be set in one of two
- * ways:
- * - A `focus` object containing a valid `user` object is present in the
- *   application's `settings` object during initialization time
- * - A `user` object is given to the `changeFocusedUser` action (this
- *   is implemented via an RPC method call)
- * For focus mode to be considered configured, it must have a valid `user`.
- * A successfully-configured focus mode will be set to `active` immediately
- * and may be toggled via `toggleFocusMode`.
- *
- * @param {FocusConfig} focusConfig
- * @return {Focus}
- */
-function setFocus(focusConfig) {
-  const focusDefaultState = {
-    configured: false,
-    active: false,
-  };
-
-  // To be able to apply a focused mode, a `user` object must be present,
-  // and that user object must have either a `username` or a `userid`
-  const focusUser = focusConfig.user || {};
-  const userFilter = focusUser.username || focusUser.userid;
-
-  // If that requirement is not met, we can't configure/activate focus mode
-  if (!userFilter) {
-    return focusDefaultState;
-  }
-
+function init(settings) {
+  const focusConfig = settings.focus || {};
   return {
-    configured: true,
-    active: true, // Activate valid focus mode immediately
-    user: {
-      filter: userFilter,
-      displayName: focusUser.displayName || userFilter || '',
-    },
+    /**
+     * @type {Filters}
+     */
+    filters: {},
+
+    // immediately activate focus mode if there is a valid config
+    focusActive: isValidFocusConfig(focusConfig),
+    focusFilters: focusFiltersFromConfig(focusConfig),
+
+    /** @type {string|null} */
+    query: settings.query || null,
   };
 }
 
-function init(settings) {
+/**
+ * Given the provided focusConfig: is it a valid configuration for focus?
+ * At this time, a `user` filter is required.
+ *
+ * @param {FocusConfig} focusConfig
+ * @return {boolean}
+ */
+function isValidFocusConfig(focusConfig) {
+  return !!(focusConfig.user?.username || focusConfig.user?.userid);
+}
+
+/**
+ * Compose an object of keyed `FilterOption`s from the given `focusConfig`.
+ * At present, this will create a `user` `FilterOption` if the config is valid.
+ *
+ * @param {FocusConfig} focusConfig
+ * @return {Filters}
+ */
+function focusFiltersFromConfig(focusConfig) {
+  if (!isValidFocusConfig(focusConfig)) {
+    return {};
+  }
+  const userFilterValue =
+    focusConfig.user.username || focusConfig.user.userid || '';
   return {
-    filters: {},
-    focus: setFocus(settings.focus || /** @type FocusConfig */ ({})),
-    query: settings.query || null,
+    user: {
+      value: userFilterValue,
+      display: focusConfig.user.displayName || userFilterValue,
+    },
   };
 }
 
 const update = {
   CHANGE_FOCUS_MODE_USER: function (state, action) {
+    if (isValidFocusConfig({ user: action.user })) {
+      return {
+        focusActive: true,
+        focusFilters: focusFiltersFromConfig({ user: action.user }),
+      };
+    }
     return {
-      focus: setFocus({ user: action.user }),
+      focusActive: false,
     };
+  },
+
+  SET_FILTER: function (state, action) {
+    const updatedFilters = {
+      ...state.filters,
+      [action.filterName]: action.filterOption,
+    };
+    // If the filter's value is empty, remove the filter
+    if (action.filterOption?.value === '') {
+      delete updatedFilters[action.filterName];
+    }
+    return { filters: updatedFilters };
   },
 
   SET_FILTER_QUERY: function (state, action) {
@@ -97,27 +134,18 @@ const update = {
   },
 
   SET_FOCUS_MODE: function (state, action) {
-    const active =
-      typeof action.active !== 'undefined'
-        ? action.active
-        : !state.focus.active;
+    const active = action.active ?? !state.focusActive;
     return {
-      focus: {
-        ...state.focus,
-        active,
-      },
+      focusActive: active,
     };
   },
 
   // Actions defined in other modules
 
-  CLEAR_SELECTION: function (state) {
+  CLEAR_SELECTION: function () {
     return {
       filters: {},
-      focus: {
-        ...state.focus,
-        active: false,
-      },
+      focusActive: false,
       query: null,
     };
   },
@@ -128,20 +156,31 @@ const actions = actionTypes(update);
 // Action creators
 
 /**
- * Clears any applied filters, changes the focused user and sets
- * focused enabled to `true`.
+ * Change the focused user filter and activate focus
  *
- * @param {User} user - The user to focus on
+ * @param {FocusUserConfig} user - The user to focus on
  */
 function changeFocusModeUser(user) {
   return { type: actions.CHANGE_FOCUS_MODE_USER, user };
+}
+
+/**
+ * @param {FilterKey} filterName
+ * @param {FilterOption} filterOption
+ */
+function setFilter(filterName, filterOption) {
+  return {
+    type: actions.SET_FILTER,
+    filterName,
+    filterOption,
+  };
 }
 
 /** Set the query used to filter displayed annotations. */
 function setFilterQuery(query) {
   return {
     type: actions.SET_FILTER_QUERY,
-    query: query,
+    query,
   };
 }
 
@@ -170,13 +209,57 @@ function filterQuery(state) {
  * @type {(state: any) => FocusState}
  */
 const focusState = createSelector(
-  state => state.focus,
-  focus => {
+  state => state.focusActive,
+  state => state.focusFilters,
+  (focusActive, focusFilters) => {
     return {
-      active: focus.active,
-      configured: focus.configured,
-      displayName: focus.configured ? focus.user.displayName : '',
+      active: focusActive,
+      configured: !!focusFilters?.user,
+      displayName: focusFilters?.user?.display || '',
     };
+  }
+);
+
+/**
+ * Get all currently-applied filters. If focus is active, will also return
+ * `focusFilters`, though `filters` will supersede in the case of key collisions.
+ * `query` is not considered a "filter" in this context.
+ *
+ * @return {Filters}
+ */
+const getFilters = createSelector(
+  state => state.filters,
+  state => state.focusActive,
+  state => state.focusFilters,
+  (filters, focusActive, focusFilters) => {
+    if (focusActive) {
+      return { ...focusFilters, ...filters };
+    }
+    return { ...filters };
+  }
+);
+
+/**
+ * Retrieve an applied filter by name/key
+ */
+function getFilter(state, filterName) {
+  const filters = getFilters(state);
+  return filters[filterName];
+}
+
+/**
+ * Retrieve the (string) values of all currently-applied filters.
+ *
+ * @return {Object<string,string>}
+ */
+const getFilterValues = createSelector(
+  state => getFilters(state),
+  allFilters => {
+    const filterValues = {};
+    Object.keys(allFilters).forEach(
+      filterKey => (filterValues[filterKey] = allFilters[filterKey].value)
+    );
+    return filterValues;
   }
 );
 
@@ -184,14 +267,7 @@ const focusState = createSelector(
  * Are there currently any active (applied) filters?
  */
 function hasAppliedFilter(state) {
-  return !!state.query || state.focus?.active;
-}
-
-/**
- * Retrieve any applied user filter
- */
-function userFilter(state) {
-  return state.focus.active ? state.focus.user.filter : null;
+  return !!(state.query || Object.keys(getFilters(state)).length);
 }
 
 /**
@@ -199,15 +275,17 @@ function userFilter(state) {
  *
  * // Actions
  * @prop {typeof changeFocusModeUser} changeFocusModeUser
+ * @prop {typeof setFilter} setFilter
  * @prop {typeof setFilterQuery} setFilterQuery
  * @prop {typeof toggleFocusMode} toggleFocusMode
  *
  * // Selectors
  * @prop {() => string|null} filterQuery
  * @prop {() => FocusState} focusState
+ * @prop {(filterName: string) => FilterOption|undefined} getFilter
+ * @prop {() => Object<string,FilterOption>} getFilters
+ * @prop {() => Object<string,string>} getFilterValues
  * @prop {() => boolean} hasAppliedFilter
- * @prop {() => string|null} userFilter
- *
  */
 
 export default {
@@ -216,13 +294,16 @@ export default {
   update,
   actions: {
     changeFocusModeUser,
+    setFilter,
     setFilterQuery,
     toggleFocusMode,
   },
   selectors: {
     filterQuery,
     focusState,
+    getFilter,
+    getFilters,
+    getFilterValues,
     hasAppliedFilter,
-    userFilter,
   },
 };

--- a/src/sidebar/store/modules/test/filters-test.js
+++ b/src/sidebar/store/modules/test/filters-test.js
@@ -22,11 +22,10 @@ describe('sidebar/store/modules/filters', () => {
           username: 'testuser',
           displayName: 'Test User',
         });
-        const focusState = getFiltersState().focus;
-        assert.isTrue(focusState.active);
-        assert.isTrue(focusState.configured);
-        assert.equal(focusState.user.filter, 'testuser');
-        assert.equal(focusState.user.displayName, 'Test User');
+        const filterState = getFiltersState();
+        assert.isTrue(filterState.focusActive);
+        assert.equal(filterState.focusFilters.user.value, 'testuser');
+        assert.equal(filterState.focusFilters.user.display, 'Test User');
       });
 
       // When the LMS app wants the client to disable focus mode it sends a
@@ -42,9 +41,54 @@ describe('sidebar/store/modules/filters', () => {
           username: undefined,
           displayName: undefined,
         });
-        const focusState = getFiltersState().focus;
-        assert.isFalse(focusState.active);
-        assert.isFalse(focusState.configured);
+        const filterState = getFiltersState();
+        assert.isFalse(filterState.focusActive);
+        assert.isUndefined(filterState.focusFilters.user);
+      });
+    });
+
+    describe('setFilter', () => {
+      it('adds the filter to the filters', () => {
+        store.setFilter('whatever', {
+          value: 'anyOldThing',
+          display: 'Any Old Thing',
+        });
+
+        const filters = store.getFilters();
+
+        assert.equal(filters.whatever.value, 'anyOldThing');
+        assert.equal(filters.whatever.display, 'Any Old Thing');
+        assert.lengthOf(Object.keys(filters), 1);
+      });
+
+      it('removes the filter if the filter value is empty', () => {
+        store.setFilter('whatever', {
+          value: 'anyOldThing',
+          display: 'Any Old Thing',
+        });
+        store.setFilter('whatever', { value: '', display: 'Any Old Thing' });
+
+        const filters = store.getFilters();
+
+        assert.lengthOf(Object.keys(filters), 0);
+        assert.isUndefined(filters.whatever);
+      });
+
+      it('replaces pre-existing filter with the same key', () => {
+        store.setFilter('whatever', {
+          value: 'anyOldThing',
+          display: 'Any Old Thing',
+        });
+        store.setFilter('whatever', {
+          value: 'thisOldThing',
+          display: 'This Old Thing',
+        });
+
+        const filters = store.getFilters();
+
+        assert.lengthOf(Object.keys(filters), 1);
+        assert.equal(filters.whatever.value, 'thisOldThing');
+        assert.equal(filters.whatever.display, 'This Old Thing');
       });
     });
 
@@ -60,15 +104,15 @@ describe('sidebar/store/modules/filters', () => {
       it('toggles the current active state if called without arguments', () => {
         store.toggleFocusMode(false);
         store.toggleFocusMode();
-        const focusState = getFiltersState().focus;
-        assert.isTrue(focusState.active);
+        const filterState = getFiltersState();
+        assert.isTrue(filterState.focusActive);
       });
 
       it('toggles the current active state to designated state', () => {
         store.toggleFocusMode(true);
         store.toggleFocusMode(false);
-        const focusState = getFiltersState().focus;
-        assert.isFalse(focusState.active);
+        const filterState = getFiltersState();
+        assert.isFalse(filterState.focusActive);
       });
     });
 
@@ -80,13 +124,13 @@ describe('sidebar/store/modules/filters', () => {
         });
         store.toggleFocusMode(true);
 
-        let focusState = getFiltersState().focus;
-        assert.isTrue(focusState.active);
+        let filterState = getFiltersState();
+        assert.isTrue(filterState.focusActive);
 
         store.clearSelection();
 
-        focusState = getFiltersState().focus;
-        assert.isFalse(focusState.active);
+        filterState = getFiltersState();
+        assert.isFalse(filterState.focusActive);
       });
     });
   });
@@ -113,6 +157,100 @@ describe('sidebar/store/modules/filters', () => {
       });
     });
 
+    describe('getFilter', () => {
+      it('returns the specified filter', () => {
+        store.setFilter('five', { value: 'cinq', display: '5' });
+
+        const fiveFilter = store.getFilter('five');
+
+        assert.equal(fiveFilter.value, 'cinq');
+        assert.equal(fiveFilter.display, '5');
+      });
+
+      it('returns undefined if no such filter', () => {
+        assert.isUndefined(store.getFilter('nobodyLivesHere'));
+      });
+    });
+
+    describe('getFilters', () => {
+      it('returns all of the filters', () => {
+        store.setFilter('bananagram', {
+          value: 'bananagram007',
+          display: 'Riviera Bananagram',
+        });
+        store.setFilter('beepingNoise', {
+          value: 'reallyAnnoying',
+          display: 'Definitely Most Annoying',
+        });
+
+        const filters = store.getFilters();
+
+        assert.lengthOf(Object.keys(filters), 2);
+        assert.exists(filters.bananagram);
+        assert.exists(filters.beepingNoise);
+        assert.equal(filters.beepingNoise.value, 'reallyAnnoying');
+      });
+
+      it('includes the `focusFilters` if `focusActive`', () => {
+        store.changeFocusModeUser({
+          username: 'filbert',
+          displayName: 'Pantomime Nutball',
+        });
+
+        const filters = store.getFilters();
+
+        assert.exists(filters.user);
+        assert.equal(filters.user.value, 'filbert');
+        assert.equal(filters.user.display, 'Pantomime Nutball');
+      });
+
+      it('gives preference to `filters` over `focusFilters`', () => {
+        store.setFilter('user', {
+          value: 'thisGuy',
+          name: 'Brenda, For Some Reason',
+        });
+        store.changeFocusModeUser({
+          username: 'filbert',
+          displayName: 'Pantomime Nutball',
+        });
+
+        const filters = store.getFilters();
+
+        assert.equal(filters.user.value, 'thisGuy');
+      });
+    });
+
+    describe('getFilterValues', () => {
+      it('returns the string values of all defined filters', () => {
+        store.setFilter('goodNoise', {
+          value: 'plop',
+          display: 'Plopping Noises',
+        });
+        store.setFilter('avoidNoise', {
+          value: 'beep',
+          display: 'Beeping Noises',
+        });
+
+        const filterValues = store.getFilterValues();
+
+        assert.lengthOf(Object.keys(filterValues), 2);
+        assert.exists(filterValues.goodNoise);
+        assert.exists(filterValues.avoidNoise);
+        assert.equal(filterValues.goodNoise, 'plop');
+      });
+
+      it('includes the focusFilters if focusActive', () => {
+        store.changeFocusModeUser({
+          username: 'filbert',
+          displayName: 'Pantomime Nutball',
+        });
+
+        const filterValues = store.getFilterValues();
+
+        assert.equal(filterValues.user, 'filbert');
+      });
+    });
+
     describe('hasAppliedFilter', () => {
       it('returns true if there is a search query set', () => {
         store.setFilterQuery('foobar');
@@ -129,6 +267,22 @@ describe('sidebar/store/modules/filters', () => {
         assert.isTrue(store.hasAppliedFilter());
       });
 
+      it('returns true if there is an applied filter', () => {
+        store.setFilter('anyWhichWay', { value: 'nope', display: 'Fatigue' });
+
+        assert.isTrue(store.hasAppliedFilter());
+      });
+
+      it('returns true if there are both applied filters and focus filters', () => {
+        store.changeFocusModeUser({
+          username: 'filbert',
+          displayName: 'Pantomime Nutball',
+        });
+        store.setFilter('anyWhichWay', { value: 'nope', display: 'Fatigue' });
+
+        assert.isTrue(store.hasAppliedFilter());
+      });
+
       it('returns false if user-focused mode is configured but inactive', () => {
         store = createStore(
           [filters],
@@ -138,20 +292,6 @@ describe('sidebar/store/modules/filters', () => {
 
         assert.isFalse(store.hasAppliedFilter());
       });
-    });
-  });
-
-  describe('userFilter', () => {
-    it('returns null if user focus inactive', () => {
-      assert.isNull(store.userFilter());
-    });
-
-    it('returns current user filter when user focus active', () => {
-      store.changeFocusModeUser({
-        username: 'filbert',
-        displayName: 'Pantomime Nutball',
-      });
-      assert.equal(store.userFilter(), 'filbert');
     });
   });
 });


### PR DESCRIPTION
This PR adjusts the `filters` store module internals[1] and adds some selectors to support extension and sanity as we build the Notebook. These changes were motivated by the implementation of a user filter for the Notebook.

Why?:

* We needed more clarity about the precedence and interplay of `filters` with user-focus mode
* User focus configuration was needlessly complex and hard to human-parse (this was a comment raised in the last set of changes pertaining to this module). Also, the previous `focus` nested object in the store-state has been flattened out a bit and is now represented by `focusActive` (boolean) and `focusFilters` (an object with the same structure as `filters`)
* We need a way of setting and getting filters for the Notebook—you'll see new actions and selectors for this

A few of the changes here will seem abstract absent their applied use in the Notebook—I've extracted this commit from a local feature branch that does implement such a (user) filter. I didn't want to end up with another ginormous diff.

[1] : The API remains unchanged or additive except for the removal of the `store.userFilter` selector in favor of other (new) mechanisms for retrieving filters. This change has been accounted for in `useRootThread`.

Part of https://github.com/hypothesis/product-backlog/issues/1161