### PR TITLE
Small visual improves related to focus / hover styling

### DIFF
--- a/src/styles/mixins/buttons.scss
+++ b/src/styles/mixins/buttons.scss
@@ -34,7 +34,6 @@
 @mixin button-hover {
   &:hover:not([disabled]),
   &:focus:not([disabled]) {
-    transition: 0.2s ease-out;
     color: var.$grey-7;
   }
 }
@@ -48,6 +47,8 @@
   padding: 0.5em;
   border-radius: var.$border-radius;
   border: none;
+  transition: color 0.2s ease-out, background-color 0.2s ease-out,
+    opacity 0.2s ease-out;
 
   // Icon
   svg {

--- a/src/styles/sidebar/components/menu.scss
+++ b/src/styles/sidebar/components/menu.scss
@@ -1,3 +1,4 @@
+@use "../../mixins/buttons";
 @use "../../mixins/focus";
 @use "../../mixins/layout";
 @use "../../mixins/molecules";
@@ -10,26 +11,16 @@
 
 // Toggle button that opens the menu.
 .menu__toggle {
-  @include focus.outline-on-keyboard-focus;
+  @include buttons.button--icon-only;
 
   appearance: none;
-  border: none;
   background: none;
   padding: 0;
-  color: inherit;
   // "block" display is needed so it can take up the
   //  full height of its parent container
   display: block;
   height: 100%;
   align-items: center;
-  &:hover {
-    transition: 0.2s ease-out;
-    color: var.$color-text;
-  }
-  &[aria-expanded='true'],
-  &:hover[aria-expanded='true'] {
-    color: var.$color-brand;
-  }
 }
 
 .menu__toggle-wrapper {
@@ -72,6 +63,7 @@
   @include utils.font--large;
   @include utils.border;
   @include utils.shadow;
+  @include focus.outline-on-keyboard-focus;
   background-color: white;
   position: absolute;
   top: calc(100% + 5px);


### PR DESCRIPTION
- Fix issue where clicking the menu background showed a focus ring
- Fix issue where buttons in the top-bar were not animating back from hover color
- Prevent button animation from being applied to focus ring styling (caused issue in safari)

-----

This PR is a tiny bit of housekeeping in preparation for larger UX changes related to focus styling.  https://github.com/hypothesis/client/issues/2226

1.
Here  you can see the blue focus ring being applied with a mouse click -- this is just not something we intend. It has been fixed.
![focus-ring-menu](https://user-images.githubusercontent.com/3939074/101964576-b61f4c80-3bc6-11eb-8fcc-1ba31dc36786.gif)

2.
The second issue is that transitions were only applied on hover. They are only 200ms and I see no reason why they should be asymmetrically applied only on hover.  Perhaps this is a subjective opinion, but mine is such that we should just animate on and off. Currently, it was only animating on. 

If the effect was to create an asymmetry, then I recommend we change the default to only 100ms and then :hover 200. I'm open to discussion here. But to have the color role on slowly and then blink back felt a little incorrect imo. We also need to consider matching this transition style to `<a>` tags as those have a red color change which is currently not animated at all -- which may be just fine, IDK. This PR does not touch those.

3.
Here you can see the default focus ring styling being animated due to non-specific `transition` css class being applied. 

![focus-ring-issues](https://user-images.githubusercontent.com/3939074/101964584-bcadc400-3bc6-11eb-8eef-4df42037ab31.gif)

With this PR, issues are fixed.

![fixed](https://user-images.githubusercontent.com/3939074/101964709-229a4b80-3bc7-11eb-9e32-8beac3d5e8d1.gif)


In doing this work I noticed 2 more very subtle effects that I want to bring to light. 

1. The toggle arrow in the groups menu very briefly flashes red when you click it. This is due to 2 styles being applied, animating and competing. This issue exists in the current code base. A super easy fix is to just let it render to red which I sort of think is okay since all the top buttons do that anyway. Or we could likely just ignore the effect as its really minor or try and fix it -- its minor.

![red](https://user-images.githubusercontent.com/3939074/101965238-cb957600-3bc8-11eb-96ad-8899a38b6f4c.gif)

2. After you click a topbar button and then close it, it remains dark gray. It does not return to light gray. This is due to a focus color styling being applied which is also the same rule for hover. I don't think this is bad per se, but we should consider what focus styling we are going to apply to mouse clicks. This is clearly one area we do add styling. Another is the input / texaarea boxes. Something to just keep in mind for next week.
