### PR TITLE
Convert `RangeAnchor` to use XPath utilities and `TextRange`

### DIFF
--- a/src/annotator/anchoring/html.js
+++ b/src/annotator/anchoring/html.js
@@ -1,7 +1,6 @@
 import { RangeAnchor, TextPositionAnchor, TextQuoteAnchor } from './types';
 
 /**
- * @typedef {import("./types").AnyRangeType} AnyRangeType
  * @typedef {import('../../types/api').Selector} Selector
  */
 

--- a/src/annotator/anchoring/test/text-range-test.js
+++ b/src/annotator/anchoring/test/text-range-test.js
@@ -204,6 +204,37 @@ describe('annotator/anchoring/text-range', () => {
       });
     });
 
+    describe('fromCharOffset', () => {
+      let el;
+      beforeEach(() => {
+        el = document.createElement('div');
+        el.append('hello', 'world');
+      });
+
+      it('returns TextPosition for offset in Text node', () => {
+        assert.deepEqual(
+          TextPosition.fromCharOffset(el.firstChild, 1),
+          TextPosition.fromPoint(el.firstChild, 1)
+        );
+      });
+
+      it('returns TextPosition for offset in Element node', () => {
+        assert.deepEqual(
+          TextPosition.fromCharOffset(el, 5),
+          new TextPosition(el, 5)
+        );
+      });
+
+      it('throws for an offset in a non-Text/Element node', () => {
+        const comment = document.createComment('This is a test');
+        el.append(comment);
+
+        assert.throws(() => {
+          TextPosition.fromCharOffset(comment, 3);
+        }, 'Node is not an element or text node');
+      });
+    });
+
     describe('fromPoint', () => {
       it('returns TextPosition for offset in Text node', () => {
         const el = document.createElement('div');

--- a/src/annotator/anchoring/text-range.js
+++ b/src/annotator/anchoring/text-range.js
@@ -171,10 +171,29 @@ export class TextPosition {
   }
 
   /**
-   * Construct a `TextPosition` representing the range start or end point (node, offset).
+   * Construct a `TextPosition` that refers to the `offset`th character within
+   * `node`.
    *
    * @param {Node} node
    * @param {number} offset
+   * @return {TextPosition}
+   */
+  static fromCharOffset(node, offset) {
+    switch (node.nodeType) {
+      case Node.TEXT_NODE:
+        return TextPosition.fromPoint(node, offset);
+      case Node.ELEMENT_NODE:
+        return new TextPosition(/** @type {Element} */ (node), offset);
+      default:
+        throw new Error('Node is not an element or text node');
+    }
+  }
+
+  /**
+   * Construct a `TextPosition` representing the range start or end point (node, offset).
+   *
+   * @param {Node} node - Text or Element node
+   * @param {number} offset - Offset within the node.
    * @return {TextPosition}
    */
   static fromPoint(node, offset) {

--- a/src/annotator/anchoring/types.js
+++ b/src/annotator/anchoring/types.js
@@ -8,21 +8,14 @@
  *     libraries.
  */
 
-import { SerializedRange, sniff } from './range';
-import { TextRange } from './text-range';
 import { matchQuote } from './match-quote';
+import { TextRange, TextPosition } from './text-range';
+import { nodeFromXPath, xpathFromNode } from './xpath';
 
 /**
- * @typedef {import("./range").BrowserRange} BrowserRange}
- * @typedef {import("./range").NormalizedRange} NormalizedRange}
- * @typedef {Range|BrowserRange|NormalizedRange|SerializedRange} AnyRangeType
- *
  * @typedef {import('../../types/api').RangeSelector} RangeSelector
  * @typedef {import('../../types/api').TextPositionSelector} TextPositionSelector
  * @typedef {import('../../types/api').TextQuoteSelector} TextQuoteSelector
- *
- * @typedef TextContentNode
- * @prop {string} textContent
  */
 
 /**
@@ -31,16 +24,16 @@ import { matchQuote } from './match-quote';
 export class RangeAnchor {
   /**
    * @param {Node} root - A root element from which to anchor.
-   * @param {AnyRangeType} range -  A range describing the anchor.
+   * @param {Range} range -  A range describing the anchor.
    */
   constructor(root, range) {
     this.root = root;
-    this.range = sniff(range).normalize(this.root);
+    this.range = range;
   }
 
   /**
    * @param {Node} root -  A root element from which to anchor.
-   * @param {AnyRangeType} range -  A range describing the anchor.
+   * @param {Range} range -  A range describing the anchor.
    */
   static fromRange(root, range) {
     return new RangeAnchor(root, range);
@@ -49,35 +42,55 @@ export class RangeAnchor {
   /**
    * Create an anchor from a serialized `RangeSelector` selector.
    *
-   * @param {Node} root -  A root element from which to anchor.
+   * @param {Element} root -  A root element from which to anchor.
    * @param {RangeSelector} selector
    */
   static fromSelector(root, selector) {
-    const data = {
-      start: selector.startContainer,
-      startOffset: selector.startOffset,
-      end: selector.endContainer,
-      endOffset: selector.endOffset,
-    };
-    const range = new SerializedRange(data);
+    const startContainer = nodeFromXPath(selector.startContainer, root);
+    if (!startContainer) {
+      throw new Error('Failed to resolve startContainer XPath');
+    }
+
+    const endContainer = nodeFromXPath(selector.endContainer, root);
+    if (!endContainer) {
+      throw new Error('Failed to resolve endContainer XPath');
+    }
+
+    const startPos = TextPosition.fromCharOffset(
+      startContainer,
+      selector.startOffset
+    );
+    const endPos = TextPosition.fromCharOffset(
+      endContainer,
+      selector.endOffset
+    );
+
+    const range = new TextRange(startPos, endPos).toRange();
     return new RangeAnchor(root, range);
   }
 
   toRange() {
-    return this.range.toRange();
+    return this.range;
   }
 
   /**
    * @return {RangeSelector}
    */
   toSelector() {
-    const range = this.range.serialize(this.root);
+    // "Shrink" the range so that it tightly wraps its text. This ensures more
+    // predictable output for a given text selection.
+    const normalizedRange = TextRange.fromRange(this.range).toRange();
+
+    const textRange = TextRange.fromRange(normalizedRange);
+    const startContainer = xpathFromNode(textRange.start.element, this.root);
+    const endContainer = xpathFromNode(textRange.end.element, this.root);
+
     return {
       type: 'RangeSelector',
-      startContainer: range.start,
-      startOffset: range.startOffset,
-      endContainer: range.end,
-      endOffset: range.endOffset,
+      startContainer,
+      startOffset: textRange.start.offset,
+      endContainer,
+      endOffset: textRange.end.offset,
     };
   }
 }


### PR DESCRIPTION
Convert `RangeAnchor` to use `TextRange` and the XPath <-> Node mapping
functions in xpath.js directly, rather than the `SerializedRange` and
`NormalizedRange` classes.

This change will mean that all conversion between text positions and
(text node, offset) points in the client will use the same implementation (which
we can ensure is well debugged, tested, documented, optimized etc.).
For `RangeAnchor` selectors this conversion is used for the
`startOffset` and `endOffset` fields.

The new implementation also avoids modifying the DOM, unlike the
previous implementation which would sometimes split text nodes. Avoid
DOM modifications during anchoring opens up the possibility of
adding caching to optimize extraction of text from the document and converting
between text offsets and text node positions.

There is a follow-up PR which removes the old implementation - https://github.com/hypothesis/client/pull/2831.