### PR TITLE
Fix menu caret positioning

### DIFF
--- a/src/styles/sidebar/components/menu.scss
+++ b/src/styles/sidebar/components/menu.scss
@@ -21,14 +21,17 @@
   display: block;
   height: 100%;
   align-items: center;
+
+  // nb. This selector is nested to ensure it has higher specificity than the
+  // default icon size set by the `buttons.button--icon-only` mixin above.
+  .menu__toggle-icon {
+    @include utils.icon--xsmall;
+  }
 }
 
 .menu__toggle-wrapper {
   @include layout.row($align: center);
   height: 100%;
-}
-.menu__toggle-icon {
-  @include utils.icon--xsmall;
 }
 
 // Triangular indicator next to the toggle button indicating that there is


### PR DESCRIPTION
https://github.com/hypothesis/client/pull/2818 inadvertently changed the size
of the `.menu-toggle__icon` SVG element from 10x10px to 16x16px due to an
`svg` selector introduced by the `buttons.button--icon-only` mixin
taking precedence over the `.menu-toggle__icon` selector.

As a result, the caret's vertical position was incorrect and it did not
remain vertically centered when flipped.

This commit nests the `.menu-toggle__icon` selector inside the parent
`.menu-toggle` selector to restore the caret icon back to its 10x10
pixel size.

----

Current state on master (incorrect):

![Menu caret offset](https://user-images.githubusercontent.com/2458/102325079-a2833580-3f7a-11eb-98f1-bd1b5c4cb942.gif)

How it looks with this PR (correct):

![Menu caret correct](https://user-images.githubusercontent.com/2458/102325125-b169e800-3f7a-11eb-8d80-b37a9c214ef6.gif)
