### PR TITLE
Show ellipsis when text overflows the primary publish button

### DIFF
--- a/src/sidebar/components/annotation-editor.js
+++ b/src/sidebar/components/annotation-editor.js
@@ -146,7 +146,7 @@ function AnnotationEditor({
         onTagInput={setPendingTag}
         tagList={tags}
       />
-      <div className="annotation__form-actions u-layout-row">
+      <div className="annotation__form-actions">
         <AnnotationPublishControl
           annotation={annotation}
           isDisabled={isEmpty}

--- a/src/styles/sidebar/components/annotation-publish-control.scss
+++ b/src/styles/sidebar/components/annotation-publish-control.scss
@@ -23,6 +23,11 @@
   // To allow absolute menu alignment
   position: relative;
 
+  // Necessary to truncate the text in the primary button
+  // https://css-tricks.com/flexbox-truncated-text/
+  min-width: 0;
+  flex-shrink: 2;
+
   // Align the menu (upward) arrow correctly with the ▼ in the menu label icon
   // Note the extra `&` needed for specificity against `Menu`'s own arrow styling
   & &__menu-arrow {
@@ -39,6 +44,12 @@
   &__primary {
     @include buttons.button--primary;
     padding: var.$layout-space--small;
+
+    // Necessary to truncate the text in the button
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     // Turn off right-side border radius for alignment with the right side of
     // the control

--- a/src/styles/sidebar/components/top-bar.scss
+++ b/src/styles/sidebar/components/top-bar.scss
@@ -10,7 +10,7 @@
   background: var.$white;
   height: var.$top-bar-height;
   @media (pointer: coarse) {
-    // Nov-23-2020: removing 4px is an interim solution to increase the size
+    // 2020-11-23: removing 4px is an interim solution to increase the size
     // of the annotator-bar buttons without affecting the size of the sidebar
     // https://github.com/hypothesis/client/pull/2745/files#r527824220
     height: var.$touch-target-size - 4px;


### PR DESCRIPTION
The fix was a little esoteric, inspired from
https://css-tricks.com/flexbox-truncated-text/:

- convert the primary button to `display: block` instead of flex
- add `min-width: 0` to the parent element which has a flex display

Final result:

![image](https://user-images.githubusercontent.com/8555781/102340260-9c02b700-3f96-11eb-8495-ad4dd70d7767.png)

Closes #2780 