### PR TITLE
Preload `/api/` and `/api/links` responses in boot script

### DIFF
--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -16,6 +16,7 @@ const commonPolyfills = [
  * @prop {string} assetRoot - The root URL to which URLs in `manifest` are relative
  * @prop {Object.<string,string>} manifest -
  *   A mapping from canonical asset path to cache-busted asset path
+ * @prop {string} apiUrl
  */
 
 /**
@@ -81,6 +82,27 @@ function injectLink(doc, rel, type, url) {
   link.rel = rel;
   link.href = url;
   link.type = `application/annotator+${type}`;
+
+  tagElement(link);
+  doc.head.appendChild(link);
+}
+
+/**
+ * Preload a URL using a `<link rel="preload" as="<type>" ...>` element
+ *
+ * This can be used to preload an API request or other resource which we know
+ * that the client will load.
+ *
+ * @param {Document} doc
+ * @param {string} type - Type of resource
+ * @param {string} url
+ */
+function preloadUrl(doc, type, url) {
+  const link = doc.createElement('link');
+  link.rel = 'preload';
+  link.as = type;
+  link.crossOrigin = 'anonymous';
+  link.href = url;
 
   tagElement(link);
   doc.head.appendChild(link);
@@ -163,6 +185,10 @@ export function bootHypothesisClient(doc, config) {
  * @param {SidebarAppConfig} config
  */
 export function bootSidebarApp(doc, config) {
+  // Preload `/api/` and `/api/links` API responses.
+  preloadUrl(doc, 'fetch', config.apiUrl);
+  preloadUrl(doc, 'fetch', config.apiUrl + 'links');
+
   const polyfills = polyfillBundles(commonPolyfills);
 
   injectAssets(doc, config, [

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -24,7 +24,7 @@ if (isBrowserSupported()) {
   // Check whether this is the sidebar app (indicated by the presence of a
   // `<hypothesis-app>` element) and load the appropriate part of the client.
   if (document.querySelector('hypothesis-app')) {
-    bootSidebarApp(document, { assetRoot, manifest });
+    bootSidebarApp(document, { assetRoot, manifest, apiUrl: settings.apiUrl });
   } else {
     const notebookAppUrl = processUrlTemplate(
       settings.notebookAppUrl || '__NOTEBOOK_APP_URL__'


### PR DESCRIPTION
https://github.com/hypothesis/h/pull/5862 introduced an optimization to startup of the sidebar app, which also applies to the upcoming "Notebook" app, by preloading the `/api/` and `/api/links` API responses.

Because this change was made in h it only benefitted the embedded client, but not the browser extension.

This commit moves the logic to add the `<link rel="preload">` links to the client's boot script. The upside of this is that it works with all distributions of the client and can be changed in future without needing to modify h and the browser extension etc. separately.

The downside is that because the `<link>` is no longer in the sidebar app's HTML but in the boot script the prefetch will start a little later. Since Cloudflare caches the `/api/` and `/api/links` responses, these requests are still very likely to have completed by the time the client code starts executing.

There is a counterpart change in https://github.com/hypothesis/h/pull/6420 which removes the `<link rel="preload">` elements from https://hypothes.is/app.html. They can be deployed in either order.