### PR TITLE
Add user filtering to the Notebook

### DIFF
--- a/src/sidebar/components/filter-select.js
+++ b/src/sidebar/components/filter-select.js
@@ -1,0 +1,69 @@
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
+
+import Menu from './menu';
+import MenuItem from './menu-item';
+import SvgIcon from '../../shared/components/svg-icon';
+
+/**
+ * @typedef {import('../store/modules/filters').FilterOption} FilterOption
+ */
+
+/**
+ * @typedef FilterSelectProps
+ * @prop {FilterOption} defaultOption
+ * @prop {string} [icon]
+ * @prop {(selectedFilter: FilterOption) => any} onSelect
+ * @prop {FilterOption[]} options
+ * @prop {FilterOption} [selectedOption]
+ * @prop {string} title
+ */
+
+/**
+ * A select-element-like control for selecting one of a defined set of
+ * options.
+ *
+ * @param {FilterSelectProps} props
+ */
+function FilterSelect({
+  defaultOption,
+  icon,
+  onSelect,
+  options,
+  selectedOption,
+  title,
+}) {
+  const filterOptions = [defaultOption, ...options];
+  const selected = selectedOption ?? defaultOption;
+
+  const menuLabel = (
+    <span className="filter-select__menu-label">
+      {icon && <SvgIcon name={icon} className="filter-select__menu-icon" />}
+      {selected.display}
+    </span>
+  );
+
+  return (
+    <Menu label={menuLabel} title={title}>
+      {filterOptions.map(filterOption => (
+        <MenuItem
+          onClick={() => onSelect(filterOption)}
+          key={filterOption.value}
+          isSelected={filterOption.value === selected.value}
+          label={filterOption.display}
+        />
+      ))}
+    </Menu>
+  );
+}
+
+FilterSelect.propTypes = {
+  defaultOption: propTypes.object,
+  icon: propTypes.string,
+  onSelect: propTypes.func,
+  options: propTypes.array,
+  selectedOption: propTypes.object,
+  title: propTypes.string,
+};
+
+export default FilterSelect;

--- a/src/sidebar/components/hooks/test/use-filter-options-test.js
+++ b/src/sidebar/components/hooks/test/use-filter-options-test.js
@@ -1,0 +1,111 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import { useUserFilterOptions } from '../use-filter-options';
+import { $imports } from '../use-filter-options';
+
+describe('sidebar/components/hooks/use-user-filter-options', () => {
+  let fakeStore;
+  let lastUserOptions;
+
+  // Mount a dummy component to be able to use the hook
+  function DummyComponent() {
+    lastUserOptions = useUserFilterOptions();
+  }
+
+  function annotationFixtures() {
+    return [
+      {
+        user: 'acct:dingbat@localhost',
+        user_info: { display_name: 'Ding Bat' },
+      },
+      {
+        user: 'acct:abalone@localhost',
+        user_info: { display_name: 'Aba Lone' },
+      },
+      {
+        user: 'acct:bananagram@localhost',
+        user_info: { display_name: 'Zerk' },
+      },
+      {
+        user: 'acct:dingbat@localhost',
+        user_info: { display_name: 'Ding Bat' },
+      },
+    ];
+  }
+
+  beforeEach(() => {
+    fakeStore = {
+      allAnnotations: sinon.stub().returns([]),
+      getFocusFilters: sinon.stub().returns({}),
+      isFeatureEnabled: sinon.stub().returns(false),
+    };
+
+    $imports.$mock({
+      '../../store/use-store': { useStoreProxy: () => fakeStore },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('should return a user filter option for each user who has authored an annotation', () => {
+    fakeStore.allAnnotations.returns(annotationFixtures());
+
+    mount(<DummyComponent />);
+
+    assert.deepEqual(lastUserOptions, [
+      { value: 'abalone', display: 'abalone' },
+      { value: 'bananagram', display: 'bananagram' },
+      { value: 'dingbat', display: 'dingbat' },
+    ]);
+  });
+
+  it('should use display names if feature flag enabled', () => {
+    fakeStore.allAnnotations.returns(annotationFixtures());
+    fakeStore.isFeatureEnabled.withArgs('client_display_names').returns(true);
+
+    mount(<DummyComponent />);
+
+    assert.deepEqual(lastUserOptions, [
+      { value: 'abalone', display: 'Aba Lone' },
+      { value: 'dingbat', display: 'Ding Bat' },
+      { value: 'bananagram', display: 'Zerk' },
+    ]);
+  });
+
+  it('should add focused-user filter information if configured', () => {
+    fakeStore.allAnnotations.returns(annotationFixtures());
+    fakeStore.isFeatureEnabled.withArgs('client_display_names').returns(true);
+    fakeStore.getFocusFilters.returns({
+      user: { value: 'carrotNumberOne', display: 'Number One Carrot' },
+    });
+
+    mount(<DummyComponent />);
+
+    assert.deepEqual(lastUserOptions, [
+      { value: 'abalone', display: 'Aba Lone' },
+      { value: 'dingbat', display: 'Ding Bat' },
+      { value: 'carrotNumberOne', display: 'Number One Carrot' },
+      { value: 'bananagram', display: 'Zerk' },
+    ]);
+  });
+
+  it('always uses display name for focused user', () => {
+    fakeStore.allAnnotations.returns(annotationFixtures());
+    fakeStore.isFeatureEnabled.withArgs('client_display_names').returns(false);
+    fakeStore.getFocusFilters.returns({
+      user: { value: 'carrotNumberOne', display: 'Numero Uno Zanahoria' },
+    });
+
+    mount(<DummyComponent />);
+
+    assert.deepEqual(lastUserOptions, [
+      { value: 'abalone', display: 'abalone' },
+      { value: 'bananagram', display: 'bananagram' },
+      { value: 'dingbat', display: 'dingbat' },
+      { value: 'carrotNumberOne', display: 'Numero Uno Zanahoria' },
+    ]);
+  });
+});

--- a/src/sidebar/components/hooks/use-filter-options.js
+++ b/src/sidebar/components/hooks/use-filter-options.js
@@ -1,0 +1,51 @@
+import { useMemo } from 'preact/hooks';
+
+import { useStoreProxy } from '../../store/use-store';
+import { username } from '../../util/account-id';
+
+/** @typedef {import('../../store/modules/filters').FilterOption} FilterOption */
+
+/**
+ * Generate a list of users for filtering annotations; update when set of
+ * annotations or filter state changes meaningfully.
+ *
+ * @return {FilterOption[]}
+ */
+export function useUserFilterOptions() {
+  const store = useStoreProxy();
+  const annotations = store.allAnnotations();
+  const focusFilters = store.getFocusFilters();
+  const showDisplayNames = store.isFeatureEnabled('client_display_names');
+
+  return useMemo(() => {
+    // Determine unique users (authors) in annotation collection
+    const users = {};
+    annotations.forEach(annotation => {
+      const username_ = username(annotation.user);
+      const displayValue =
+        showDisplayNames && annotation.user_info?.display_name
+          ? annotation.user_info.display_name
+          : username_;
+      users[username_] = displayValue;
+    });
+
+    // If user-focus is configured (even if not applied) add a filter
+    // option for that user. Note that this always respects the display
+    // value, even if `client_display_names` feature flags is not enabled:
+    // this matches current implementation of focus mode.
+    if (focusFilters.user) {
+      const username_ =
+        username(focusFilters.user.value) || focusFilters.user.value;
+      users[username_] = focusFilters.user.display;
+    }
+
+    // Convert to `FilterOption` objects
+    const userOptions = Object.keys(users).map(user => {
+      return { display: users[user], value: user };
+    });
+
+    userOptions.sort((a, b) => a.display.localeCompare(b.display));
+
+    return userOptions;
+  }, [annotations, focusFilters, showDisplayNames]);
+}

--- a/src/sidebar/components/notebook-filters.js
+++ b/src/sidebar/components/notebook-filters.js
@@ -1,0 +1,35 @@
+import { createElement } from 'preact';
+
+import { useStoreProxy } from '../store/use-store';
+import { useUserFilterOptions } from './hooks/use-filter-options';
+
+import FilterSelect from './filter-select';
+
+/**
+ * @typedef {import('../store/modules/filters').FilterOption} FilterOption
+ */
+
+/**
+ * Filters for the Notebook
+ */
+function NotebookFilters() {
+  const store = useStoreProxy();
+
+  const userFilter = store.getFilter('user');
+  const userFilterOptions = useUserFilterOptions();
+
+  return (
+    <FilterSelect
+      defaultOption={{ value: '', display: 'Everybody' }}
+      icon="profile"
+      onSelect={userFilter => store.setFilter('user', userFilter)}
+      options={userFilterOptions}
+      selectedOption={userFilter}
+      title="Filter by user"
+    />
+  );
+}
+
+NotebookFilters.propTypes = {};
+
+export default NotebookFilters;

--- a/src/sidebar/components/notebook-result-count.js
+++ b/src/sidebar/components/notebook-result-count.js
@@ -1,0 +1,55 @@
+import { createElement } from 'preact';
+
+import useRootThread from './hooks/use-root-thread';
+import { useStoreProxy } from '../store/use-store';
+import { countVisible } from '../util/thread';
+
+/**
+ * Render count of annotations (or filtered results) visible in the notebook view
+ *
+ * There are three possible overall states:
+ * - No results (regardless of whether annotations are filtered): "No results"
+ * - Annotations are unfiltered: "X threads (Y annotations)"
+ * - Annotations are filtered: "X results [(and Y more)]"
+ */
+function NotebookResultCount() {
+  const store = useStoreProxy();
+  const forcedVisibleCount = store.forcedVisibleAnnotations().length;
+  const hasAppliedFilter = store.hasAppliedFilter();
+  const rootThread = useRootThread();
+  const visibleCount = countVisible(rootThread);
+
+  const hasResults = rootThread.children.length > 0;
+
+  const hasForcedVisible = forcedVisibleCount > 0;
+  const matchCount = visibleCount - forcedVisibleCount;
+  const threadCount = rootThread.children.length;
+
+  return (
+    <span className="notebook-result-count">
+      {!hasResults && <h2>No results</h2>}
+      {hasResults && hasAppliedFilter && (
+        <span>
+          <h2>
+            {matchCount} {matchCount === 1 ? 'result' : 'results'}
+          </h2>
+          {hasForcedVisible && <em> (and {forcedVisibleCount} more)</em>}
+        </span>
+      )}
+      {hasResults && !hasAppliedFilter && (
+        <span>
+          <h2>
+            {threadCount} {threadCount === 1 ? 'thread' : 'threads'}
+          </h2>{' '}
+          <em>
+            ({visibleCount} {visibleCount === 1 ? 'annotation' : 'annotations'})
+          </em>
+        </span>
+      )}
+    </span>
+  );
+}
+
+NotebookResultCount.propTypes = {};
+
+export default NotebookResultCount;

--- a/src/sidebar/components/notebook-view.js
+++ b/src/sidebar/components/notebook-view.js
@@ -6,6 +6,7 @@ import { withServices } from '../util/service-context';
 import useRootThread from './hooks/use-root-thread';
 import { useStoreProxy } from '../store/use-store';
 
+import NotebookFilters from './notebook-filters';
 import NotebookResultCount from './notebook-result-count';
 import ThreadList from './thread-list';
 
@@ -44,6 +45,9 @@ function NotebookView({ loadAnnotationsService }) {
       <header className="notebook-view__heading">
         <h1>{groupName}</h1>
       </header>
+      <div className="notebook-view__filters">
+        <NotebookFilters />
+      </div>
       <div className="notebook-view__results">
         <NotebookResultCount />
       </div>

--- a/src/sidebar/components/notebook-view.js
+++ b/src/sidebar/components/notebook-view.js
@@ -6,6 +6,7 @@ import { withServices } from '../util/service-context';
 import useRootThread from './hooks/use-root-thread';
 import { useStoreProxy } from '../store/use-store';
 
+import NotebookResultCount from './notebook-result-count';
 import ThreadList from './thread-list';
 
 /**
@@ -38,31 +39,13 @@ function NotebookView({ loadAnnotationsService }) {
   const rootThread = useRootThread();
   const groupName = focusedGroup?.name ?? '…';
 
-  const hasResults = rootThread.totalChildren > 0;
-  const threadCount =
-    rootThread.totalChildren === 1
-      ? '1 thread'
-      : `${rootThread.totalChildren} threads`;
-  const annotationCount =
-    rootThread.replyCount === 1
-      ? '1 annotation'
-      : `${rootThread.replyCount} annotations`;
-
   return (
     <div className="notebook-view">
       <header className="notebook-view__heading">
         <h1>{groupName}</h1>
       </header>
       <div className="notebook-view__results">
-        {hasResults ? (
-          <span>
-            <h2>{threadCount}</h2> ({annotationCount})
-          </span>
-        ) : (
-          <span>
-            <h2>No results</h2>
-          </span>
-        )}
+        <NotebookResultCount />
       </div>
       <div className="notebook-view__items">
         <ThreadList thread={rootThread} />

--- a/src/sidebar/components/test/filter-select-test.js
+++ b/src/sidebar/components/test/filter-select-test.js
@@ -1,0 +1,92 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import FilterSelect from '../filter-select';
+import { $imports } from '../filter-select';
+
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+
+describe('FilterSelect', () => {
+  let someOptions;
+  const createComponent = props => {
+    return mount(
+      <FilterSelect
+        defaultOption={{ value: '', display: 'all' }}
+        onSelect={() => null}
+        options={someOptions}
+        title="Select one"
+        {...props}
+      />
+    );
+  };
+
+  beforeEach(() => {
+    someOptions = [
+      { value: 'onevalue', display: 'One Value' },
+      { value: 'twovalue', display: 'Two Value' },
+    ];
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('should render option display values', () => {
+    const wrapper = createComponent();
+
+    const selectItems = wrapper.find('MenuItem');
+
+    assert.equal(selectItems.length, 3);
+    // First, the default option
+    assert.deepEqual(selectItems.at(0).props().label, 'all');
+    // Then the other options
+    assert.deepEqual(selectItems.at(1).props().label, 'One Value');
+    assert.deepEqual(selectItems.at(2).props().label, 'Two Value');
+  });
+
+  it('should invoke `onSelect` callback when an option is selected', () => {
+    const fakeOnSelect = sinon.stub();
+
+    const wrapper = createComponent({ onSelect: fakeOnSelect });
+
+    const secondOption = wrapper.find('MenuItem').at(1);
+    secondOption.props().onClick();
+
+    assert.calledOnce(fakeOnSelect);
+    assert.calledWith(
+      fakeOnSelect,
+      sinon.match({ value: 'onevalue', display: 'One Value' })
+    );
+  });
+
+  it('should render provided icon and selected option in label', () => {
+    const wrapper = createComponent({ icon: 'profile' });
+
+    const label = mount(wrapper.find('Menu').props().label);
+    const icon = label.find('SvgIcon');
+
+    assert.isTrue(icon.exists());
+    assert.equal(icon.props().name, 'profile');
+    // Default option should be selected as we didn't indicate a selected option
+    assert.equal(label.text(), 'all');
+  });
+
+  it('should render provided title', () => {
+    const wrapper = createComponent({ title: 'Select something' });
+
+    assert.equal(wrapper.find('Menu').props().title, 'Select something');
+  });
+
+  it('should denote the selected option as selected', () => {
+    const wrapper = createComponent({
+      selectedOption: { value: 'twovalue', display: 'Two Value' },
+    });
+
+    const label = mount(wrapper.find('Menu').props().label);
+
+    assert.equal(label.text(), 'Two Value');
+    assert.isFalse(wrapper.find('MenuItem').at(1).props().isSelected);
+    assert.isTrue(wrapper.find('MenuItem').at(2).props().isSelected);
+  });
+});

--- a/src/sidebar/components/test/notebook-filters-test.js
+++ b/src/sidebar/components/test/notebook-filters-test.js
@@ -1,0 +1,92 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import NotebookFilters from '../notebook-filters';
+import { $imports } from '../notebook-filters';
+
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+
+describe('NotebookFilters', () => {
+  let fakeStore;
+  let fakeUseUserFilterOptions;
+
+  const createComponent = () => {
+    return mount(<NotebookFilters />);
+  };
+
+  beforeEach(() => {
+    fakeUseUserFilterOptions = sinon.stub().returns([]);
+
+    fakeStore = {
+      getFilter: sinon.stub().returns(undefined),
+      setFilter: sinon.stub(),
+    };
+
+    $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      './hooks/use-filter-options': {
+        useUserFilterOptions: fakeUseUserFilterOptions,
+      },
+      '../store/use-store': { useStoreProxy: () => fakeStore },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('should render a user filter with options', () => {
+    fakeUseUserFilterOptions.returns([
+      { display: 'One User', value: 'oneuser' },
+    ]);
+
+    const wrapper = createComponent();
+
+    const props = wrapper.find('FilterSelect').props();
+    assert.deepEqual(props.options[0], {
+      display: 'One User',
+      value: 'oneuser',
+    });
+    assert.deepEqual(props.defaultOption, { value: '', display: 'Everybody' });
+    assert.equal(props.icon, 'profile');
+    assert.equal(props.title, 'Filter by user');
+    assert.equal(props.options.length, 1);
+    assert.isUndefined(props.selectedOption);
+  });
+
+  it('should render the filter with a selected option if a user filter is applied', () => {
+    fakeUseUserFilterOptions.returns([
+      { display: 'One User', value: 'oneuser' },
+    ]);
+    fakeStore.getFilter
+      .withArgs('user')
+      .returns({ display: 'One User', value: 'oneuser' });
+
+    const wrapper = createComponent();
+
+    assert.deepEqual(wrapper.find('FilterSelect').props().selectedOption, {
+      display: 'One User',
+      value: 'oneuser',
+    });
+  });
+
+  it('should set a user filter when a user is selected', () => {
+    fakeUseUserFilterOptions.returns([
+      { display: 'One User', value: 'oneuser' },
+    ]);
+
+    const wrapper = createComponent();
+
+    wrapper
+      .find('FilterSelect')
+      .props()
+      .onSelect({ display: 'One User', value: 'oneuser' });
+
+    assert.calledOnce(fakeStore.setFilter);
+    assert.calledWith(
+      fakeStore.setFilter,
+      'user',
+      sinon.match({ display: 'One User', value: 'oneuser' })
+    );
+  });
+});

--- a/src/sidebar/components/test/notebook-result-count-test.js
+++ b/src/sidebar/components/test/notebook-result-count-test.js
@@ -1,0 +1,118 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import NotebookResultCount from '../notebook-result-count';
+import { $imports } from '../notebook-result-count';
+
+describe('NotebookResultCount', () => {
+  let fakeCountVisible;
+  let fakeUseRootThread;
+  let fakeStore;
+
+  const createComponent = () => {
+    return mount(<NotebookResultCount />);
+  };
+
+  beforeEach(() => {
+    fakeCountVisible = sinon.stub().returns(0);
+    fakeUseRootThread = sinon.stub().returns({});
+
+    fakeStore = {
+      forcedVisibleAnnotations: sinon.stub().returns([]),
+      hasAppliedFilter: sinon.stub().returns(false),
+    };
+
+    $imports.$mock({
+      './hooks/use-root-thread': fakeUseRootThread,
+      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../util/thread': { countVisible: fakeCountVisible },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  context('when there are no results', () => {
+    it('should show "No Results" if no filters are applied', () => {
+      fakeStore.hasAppliedFilter.returns(false);
+      fakeUseRootThread.returns({ children: [] });
+
+      const wrapper = createComponent();
+
+      assert.equal(wrapper.text(), 'No results');
+    });
+
+    it('should show "No Results" if filters are applied', () => {
+      fakeStore.hasAppliedFilter.returns(true);
+      fakeUseRootThread.returns({ children: [] });
+
+      const wrapper = createComponent();
+
+      assert.equal(wrapper.text(), 'No results');
+    });
+  });
+
+  context('no applied filter', () => {
+    [
+      {
+        thread: { children: [1] },
+        visibleCount: 1,
+        expected: '1 thread (1 annotation)',
+      },
+      {
+        thread: { children: [1] },
+        visibleCount: 2,
+        expected: '1 thread (2 annotations)',
+      },
+      {
+        thread: { children: [1, 2] },
+        visibleCount: 2,
+        expected: '2 threads (2 annotations)',
+      },
+    ].forEach(test => {
+      it('should render a count of threads and annotations', () => {
+        fakeCountVisible.returns(test.visibleCount);
+        fakeUseRootThread.returns(test.thread);
+
+        const wrapper = createComponent();
+
+        assert.equal(wrapper.text(), test.expected);
+      });
+    });
+  });
+
+  context('with one or more applied filters', () => {
+    [
+      {
+        forcedVisible: [],
+        thread: { children: [1] },
+        visibleCount: 1,
+        expected: '1 result',
+      },
+      {
+        forcedVisible: [],
+        thread: { children: [1] },
+        visibleCount: 2,
+        expected: '2 results',
+      },
+      {
+        forcedVisible: [1],
+        thread: { children: [1] },
+        visibleCount: 3,
+        expected: '2 results (and 1 more)',
+      },
+    ].forEach(test => {
+      it('should render a count of results', () => {
+        fakeStore.hasAppliedFilter.returns(true);
+        fakeStore.forcedVisibleAnnotations.returns(test.forcedVisible);
+        fakeUseRootThread.returns(test.thread);
+        fakeCountVisible.returns(test.visibleCount);
+
+        const wrapper = createComponent();
+
+        assert.equal(wrapper.text(), test.expected);
+      });
+    });
+  });
+});

--- a/src/sidebar/components/test/notebook-view-test.js
+++ b/src/sidebar/components/test/notebook-view-test.js
@@ -64,34 +64,9 @@ describe('NotebookView', () => {
     assert.equal(wrapper.find('.notebook-view__heading').text(), '…');
   });
 
-  describe('results count', () => {
-    [
-      {
-        rootThread: { totalChildren: 5, replyCount: 15 },
-        expected: '5 threads (15 annotations)',
-      },
-      {
-        rootThread: { totalChildren: 0, replyCount: 0 },
-        expected: 'No results',
-      },
-      {
-        rootThread: { totalChildren: 0, replyCount: 15 },
-        expected: 'No results',
-      },
-      {
-        rootThread: { totalChildren: 1, replyCount: 1 },
-        expected: '1 thread (1 annotation)',
-      },
-    ].forEach(test => {
-      it('renders number of threads and annotations', () => {
-        fakeUseRootThread.returns(test.rootThread);
-        const wrapper = createComponent();
-
-        assert.equal(
-          wrapper.find('.notebook-view__results').text(),
-          test.expected
-        );
-      });
-    });
+  it('renders results (counts)', () => {
+    const wrapper = createComponent();
+    assert.isTrue(wrapper.find('NotebookResultCount').exists());
+  });
   });
 });

--- a/src/sidebar/components/test/notebook-view-test.js
+++ b/src/sidebar/components/test/notebook-view-test.js
@@ -68,5 +68,9 @@ describe('NotebookView', () => {
     const wrapper = createComponent();
     assert.isTrue(wrapper.find('NotebookResultCount').exists());
   });
+
+  it('renders filters', () => {
+    const wrapper = createComponent();
+    assert.isTrue(wrapper.find('NotebookFilters').exists());
   });
 });

--- a/src/sidebar/store/modules/filters.js
+++ b/src/sidebar/store/modules/filters.js
@@ -170,10 +170,21 @@ function changeFocusModeUser(user) {
  * @param {FilterOption} filterOption
  */
 function setFilter(filterName, filterOption) {
-  return {
-    type: actions.SET_FILTER,
-    filterName,
-    filterOption,
+  return (dispatch, getState) => {
+    // If there is a filter conflict with focusFilters, deactivate focus
+    // mode to prevent unintended collisions and let the new filter value
+    // take precedence.
+    if (getState().filters.focusFilters?.[filterName]) {
+      dispatch({
+        type: actions.SET_FOCUS_MODE,
+        active: false,
+      });
+    }
+    dispatch({
+      type: actions.SET_FILTER,
+      filterName,
+      filterOption,
+    });
   };
 }
 
@@ -263,6 +274,10 @@ const getFilterValues = createSelector(
   }
 );
 
+function getFocusFilters(state) {
+  return state.focusFilters;
+}
+
 /**
  * Are there currently any active (applied) filters?
  */
@@ -286,6 +301,7 @@ export default storeModule({
     getFilter,
     getFilters,
     getFilterValues,
+    getFocusFilters,
     hasAppliedFilter,
   },
 });

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -156,6 +156,10 @@ const update = {
     return resetSelection();
   },
 
+  SET_FILTER: function () {
+    return { ...resetSelection(), expanded: {} };
+  },
+
   SET_FILTER_QUERY: function () {
     return { ...resetSelection(), expanded: {} };
   },

--- a/src/sidebar/store/modules/test/filters-test.js
+++ b/src/sidebar/store/modules/test/filters-test.js
@@ -74,6 +74,26 @@ describe('sidebar/store/modules/filters', () => {
         assert.isUndefined(filters.whatever);
       });
 
+      it('disables focus mode if there is a conflicting filter key', () => {
+        store = createStore(
+          [filters],
+          [{ focus: { user: { username: 'somebody' } } }]
+        );
+
+        assert.isTrue(store.focusState().active);
+
+        // No conflict in focusFilters on `elephant`
+        store.setFilter('elephant', {
+          value: 'pink',
+          display: 'Pink Elephant',
+        });
+
+        assert.isTrue(store.focusState().active);
+
+        store.setFilter('user', { value: '', display: 'Everybody' });
+        assert.isFalse(store.focusState().active);
+      });
+
       it('replaces pre-existing filter with the same key', () => {
         store.setFilter('whatever', {
           value: 'anyOldThing',
@@ -248,6 +268,27 @@ describe('sidebar/store/modules/filters', () => {
         const filterValues = store.getFilterValues();
 
         assert.equal(filterValues.user, 'filbert');
+      });
+    });
+
+    describe('getFocusFilters', () => {
+      it('returns any set focus filters', () => {
+        store = createStore(
+          [filters],
+          [
+            {
+              focus: {
+                user: { username: 'somebody', displayName: 'Ding Bat' },
+              },
+            },
+          ]
+        );
+        const focusFilters = store.getFocusFilters();
+        assert.exists(focusFilters.user);
+        assert.deepEqual(focusFilters.user, {
+          value: 'somebody',
+          display: 'Ding Bat',
+        });
       });
     });
 

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -159,6 +159,18 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
+  describe('SET_FILTER', () => {
+    it('clears selection', () => {
+      store.selectAnnotations([1, 2, 3]);
+      store.setForcedVisible(2, true);
+
+      store.setFilter('user', { value: 'dingbat', display: 'Ding Bat' });
+
+      assert.isEmpty(store.selectedAnnotations());
+      assert.isEmpty(store.forcedVisibleAnnotations());
+    });
+  });
+
   describe('SET_FILTER_QUERY', () => {
     it('clears selection', () => {
       store.selectAnnotations([1, 2, 3]);

--- a/src/styles/sidebar/components/filter-select.scss
+++ b/src/styles/sidebar/components/filter-select.scss
@@ -1,0 +1,21 @@
+@use "../../mixins/utils";
+@use "../../variables" as var;
+
+.filter-select {
+  &__menu-label {
+    @include utils.font--large;
+    align-items: center;
+    color: var.$color-text;
+    display: flex;
+
+    // Prevent label from wrapping if top bar is too narrow to fit all of its
+    // items.
+    flex-shrink: 0;
+    font-weight: bold;
+  }
+
+  &__menu-icon {
+    @include utils.icon--medium;
+    margin-right: var.$layout-space--xsmall;
+  }
+}

--- a/src/styles/sidebar/components/notebook-view.scss
+++ b/src/styles/sidebar/components/notebook-view.scss
@@ -10,6 +10,7 @@
     'results'
     'items';
 
+  /* TODO: find a better place for these heading styles */
   h1 {
     display: inline;
     font-size: var.$font-size--heading;
@@ -28,6 +29,10 @@
     font-weight: bold;
   }
 
+  &__filters {
+    grid-area: filters;
+  }
+
   &__results {
     grid-area: results;
   }
@@ -38,13 +43,16 @@
 
   @include responsive.tablet-and-up {
     grid-template-areas:
-      'heading results'
+      'heading heading'
+      'filters results'
       'items items';
 
+    &__filters {
+      justify-self: start;
+    }
+
     &__results {
-      // Right-aligned when sharing a row with the heading
-      text-align: right;
-      align-self: end;
+      justify-self: end;
     }
   }
 }

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -26,6 +26,7 @@
 @use './components/autocomplete-list';
 @use './components/button';
 @use './components/excerpt';
+@use './components/filter-select';
 @use './components/filter-status';
 @use './components/group-list';
 @use './components/group-list-item';


### PR DESCRIPTION
This is a ~~draft~~ PR of all the bits and pieces needed to add rudimentary user filtering to the Notebook. What I'd like to ascertain with this ~~draft~~ PR is:

- [x] General approach OK?
- [x] Would reviewer preference be to break up this into smaller PRs? Each commit here is self-sufficient, so it can be chunked up in arbitrary ways. (Decided: keep as one PR)

## A Few Screenshots

On launch (not in user-focus mode), Notebook looks like this:

![image](https://user-images.githubusercontent.com/439947/102379555-f733aa00-3f94-11eb-99db-1068fde7b7ae.png)

When filtering by user, the count of matches changes to use a "results" unit:

![image](https://user-images.githubusercontent.com/439947/102379667-16cad280-3f95-11eb-893c-4122416c2827.png)

"Force-expanding" a non-matching thread will update the results count similar to in the sidebar:

![image](https://user-images.githubusercontent.com/439947/102379714-264a1b80-3f95-11eb-9c22-0e1ca4a1bd29.png)

When user-focus mode is active (e.g. in grading mode), opening the Notebook will filter by the currently-focused user initially:

![image](https://user-images.githubusercontent.com/439947/102379997-6dd0a780-3f95-11eb-9772-0c3c133c1f15.png)

(but the user can change which user to filter by, or set it to "Everybody").

## A List

You should expect these changes to accomplish the following:

* A user filter should appear in the notebook. This simple filter shows one user per "line"
* On initial opening, the user filter should indicate that “Everybody” ’s annotations are showing
* The user filter uses the "profile" icon to indicate its user-y-ness (but also has an accessible title)
* The user menu should include all users who have at least one annotation in the current group
* Users should be in alphabetical order
	* If the `client_display_names` feature flag is enabled, the user’s display names will display, and will be alphabetized
	* If not, the names shown will be (alphabetized) usernames
* Selecting a user from the filter menu should filter the annotations shown to annotations by that user
	* The count of matches should change from `X threads (y annotations)` to `X results` (or `1 result` if singular)
	* The user selected should be represented in the filter label
	* Opening the filter again should show the user visibly selected
	* Clicking on any “Show x more in conversation” buttons will update the match count to `X results (and y more)` similarly to how the sidebar handles this state
* Selecting “Everybody” from the user filter should show all annotations in the group again
* When in a user-focused mode:
	* On Notebook launch, that focused user will be selected in the user filter and their annotations shown
	* The focused user will show up in the user filter even if that user has no annotations in the current group
	* Other users, or “Everybody” can be selected as above to change the user filtering

### What's not included

Literally everything else, including things like URL hash/history management, handling really long lists of users, handling empty result sets more gracefully, anything but the most elementary visual styling, etc., etc.

_Edited_: Moving out of draft now

Part of https://github.com/hypothesis/client/issues/2731