### PR TITLE
Move scroll container measuring into a layout effect

### DIFF
--- a/src/sidebar/components/test/thread-list-test.js
+++ b/src/sidebar/components/test/thread-list-test.js
@@ -239,9 +239,9 @@ describe('ThreadList', () => {
       const wrapper = createComponent();
       const renderedThreads = wrapper.find('ThreadCard');
 
-      // "5" is the current expected value given the thread heights, scroll
+      // "7" is the current expected value given the thread heights, scroll
       // container size and constants in `../util/visible-threads`.
-      assert.equal(renderedThreads.length, 5);
+      assert.equal(renderedThreads.length, 7);
     });
 
     it('updates thread heights as the list is scrolled', () => {


### PR DESCRIPTION
`ThreadList` was measuring the height and scroll offset of the scroll
container inside the render function instead of a layout effect. As a result
it could fail if the scroll container is rendered by a parent component
and its DOM has not yet been created.

This issue was uncovered when trying to change the app to call
`router.sync()` before waiting for `groups.load()` to complete.

A test expectation had to be changed becaused it turned out that the
scroll container had the wrong height when it was measured in the
previous way (it was measured as 0px instead of the expected 350px).