### PR TITLE
Sync route before waiting for groups and profile to load

### DIFF
--- a/src/sidebar/components/test/thread-list-test.js
+++ b/src/sidebar/components/test/thread-list-test.js
@@ -239,9 +239,9 @@ describe('ThreadList', () => {
       const wrapper = createComponent();
       const renderedThreads = wrapper.find('ThreadCard');
 
-      // "5" is the current expected value given the thread heights, scroll
+      // "7" is the current expected value given the thread heights, scroll
       // container size and constants in `../util/visible-threads`.
-      assert.equal(renderedThreads.length, 5);
+      assert.equal(renderedThreads.length, 7);
     });
 
     it('updates thread heights as the list is scrolled', () => {

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -52,9 +52,9 @@ function setupApi(api, streamer) {
  */
 // @inject
 function setupRoute(groups, session, router) {
-  Promise.all([groups.load(), session.load()]).finally(() => {
-    router.sync();
-  });
+  groups.load();
+  session.load();
+  router.sync();
 }
 
 /**


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/2836**

Do not wait for groups and profile to load before calling
`router.sync()` to set the initial route and thereby render the
appropriate content component.

Historically the main view components assumed that the user profile and
groups were already loaded before they were rendered, but this is no
longer the case.

This fixes a brief flash of the sidebar's `TopBar` component inside the
notebook when it initially loads. It also results in the "Annotations"
and "Page Notes" tabs appearing immediately in the sidebar rather than
waiting until the groups list is populated.
