### PR TITLE
Defer initial WebSocket connection until profile is fetched

### DIFF
--- a/src/sidebar/components/sidebar-view.js
+++ b/src/sidebar/components/sidebar-view.js
@@ -123,11 +123,12 @@ function SidebarView({
   ]);
 
   // Connect to the streamer when the sidebar has opened or if user is logged in
+  const hasFetchedProfile = store.hasFetchedProfile();
   useEffect(() => {
-    if (sidebarHasOpened || isLoggedIn) {
+    if (hasFetchedProfile && (sidebarHasOpened || isLoggedIn)) {
       streamer.connect();
     }
-  }, [streamer, sidebarHasOpened, isLoggedIn]);
+  }, [hasFetchedProfile, isLoggedIn, sidebarHasOpened, streamer]);
 
   return (
     <div>

--- a/src/sidebar/components/test/sidebar-view-test.js
+++ b/src/sidebar/components/test/sidebar-view-test.js
@@ -51,6 +51,7 @@ describe('SidebarView', () => {
       focusedGroupId: sinon.stub(),
       hasAppliedFilter: sinon.stub(),
       hasFetchedAnnotations: sinon.stub(),
+      hasFetchedProfile: sinon.stub().returns(true),
       hasSelectedAnnotations: sinon.stub(),
       hasSidebarOpened: sinon.stub(),
       isLoading: sinon.stub().returns(false),


### PR DESCRIPTION
Following https://github.com/hypothesis/client/pull/2837 the
`SidebarView` component may now be rendered before the profile has been
fetched. This component contains an effect which triggers the initial
WebSocket connection. Since the WebSocket reconnects after the profile userid
changes, this was causing the initial connection to almost immediately
be disconnected if the user was logged in. Fix this by deferring the initial
connection until after the profile has been fetched.
