### PR TITLE
Allow shrink and truncate long group names on top bar

### DIFF
--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -89,7 +89,7 @@ function GroupList({ serviceUrl, settings }) {
         {icon && (
           <img className="group-list__menu-icon" src={icon} alt={altName} />
         )}
-        {focusedGroup.name}
+        <div className="group-list__menu-title">{focusedGroup.name}</div>
       </span>
     );
   } else {

--- a/src/styles/sidebar/components/group-list.scss
+++ b/src/styles/sidebar/components/group-list.scss
@@ -11,9 +11,10 @@
   color: var.$color-text;
   display: flex;
 
-  // Prevent label from wrapping if top bar is too narrow to fit all of its
-  // items.
-  flex-shrink: 0;
+  // Allow to shrink and truncate the menu-title
+  flex-shrink: 1;
+  min-width: 0;
+
   font-weight: bold;
 }
 
@@ -25,4 +26,12 @@
   // better with the text.
   position: relative;
   top: 1px;
+}
+
+.group-list__menu-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  // Prevent label from wrapping if top bar is too narrow to fit all of its
+  // items.
+  white-space: nowrap;
 }

--- a/src/styles/sidebar/components/menu.scss
+++ b/src/styles/sidebar/components/menu.scss
@@ -6,7 +6,9 @@
 @use "../../variables" as var;
 
 .menu {
-  position: relative;
+  // Allows text truncation in flex elements:
+  // https://css-tricks.com/flexbox-truncated-text/
+  min-width: 0;
 }
 
 // Toggle button that opens the menu.
@@ -19,6 +21,11 @@
   // "block" display is needed so it can take up the
   //  full height of its parent container
   display: block;
+
+  // This allows the size of the button to fit the parent element and eventually,
+  // allows to truncate (with ellipsis) long labels
+  width: 100%;
+
   height: 100%;
   align-items: center;
 

--- a/src/styles/sidebar/components/search-input.scss
+++ b/src/styles/sidebar/components/search-input.scss
@@ -10,6 +10,7 @@
 
 .search-input__icon-button {
   order: 0;
+  background-color: #ffffff !important;
 }
 
 .search-input__input {
@@ -39,7 +40,7 @@
   // on the search icon) or when `is-expanded` is applied.
   &:focus,
   &.is-expanded {
-    max-width: 150px;
+    max-width: 145px;
     padding-left: 6px;
   }
 }


### PR DESCRIPTION
- I follow [this recipe](https://css-tricks.com/flexbox-truncated-text/) to truncate elements that uses `display: flex`: `min-width: 0` on flex child.
  

- I set background color to white on the search icon/button to covers other
  elements when the search field is expanded

- I made the search field a little bit smaller because the search icon
  was cut on iPhones.

![image](https://user-images.githubusercontent.com/8555781/102505057-d7c67b00-4081-11eb-85e4-4843a9e7333c.png)


When the search input field is expanded it produce a flickering in the group name:

![Dec-17-2020 16-09-26](https://user-images.githubusercontent.com/8555781/102505437-4572a700-4082-11eb-837a-0258abed92ca.gif)

This is because the animation forces the group name to become smaller and the ellipsis need to be recalculated. Setting the `text-overflow: clip` get rides of the flickering.
