### PR TITLE
Do not clear filters after initial groups fetch completes

### DIFF
--- a/src/sidebar/components/sidebar-view.js
+++ b/src/sidebar/components/sidebar-view.js
@@ -91,8 +91,15 @@ function SidebarView({
   // Reload annotations when group, user or document search URIs change
   useEffect(() => {
     if (!prevGroupId.current || prevGroupId.current !== focusedGroupId) {
-      // Clear any selected annotations when the group ID changes
-      store.clearSelection();
+      // Clear any selected annotations and filters when the group ID changes.
+      //
+      // We don't clear the selection/filters on the initial load when
+      // the focused group transitions from null to non-null, as this would clear
+      // any filters intended to be used for the initial display (eg. to focus
+      // on a particular user).
+      if (prevGroupId.current) {
+        store.clearSelection();
+      }
       prevGroupId.current = focusedGroupId;
     }
     if (focusedGroupId && searchUris.length) {

--- a/src/sidebar/components/test/sidebar-view-test.js
+++ b/src/sidebar/components/test/sidebar-view-test.js
@@ -100,6 +100,16 @@ describe('SidebarView', () => {
       assert.calledOnce(fakeStore.clearSelection);
     });
 
+    it('does not clear selected annotations when group ID is first set on startup', () => {
+      fakeStore.focusedGroupId.returns(null);
+      wrapper = createComponent();
+      fakeStore.focusedGroupId.returns('foobar');
+
+      wrapper.setProps({});
+
+      assert.notCalled(fakeStore.clearSelection);
+    });
+
     it('loads annotations when searchURIs change', () => {
       fakeStore.searchUris.returns(['abandon-ship']);
       wrapper.setProps({});


### PR DESCRIPTION
https://github.com/hypothesis/client/pull/2837 caused a regression where
the initial annotation filters would be cleared after groups where
fetched for the first time. This is because `SidebarView` had logic to
clear the selection/filters when switching groups. This used to work
because `SidebarView` was only rendered after groups were initially
rendered. This is no longer the case after #2837.

Slack thread: https://hypothes-is.slack.com/archives/C1M8NH76X/p1608299842322000