### PR TITLE
Remove `totalChildren` from `Thread` objects

### DIFF
--- a/src/sidebar/util/build-thread.js
+++ b/src/sidebar/util/build-thread.js
@@ -17,8 +17,6 @@
  * @prop {boolean} collapsed - Whether the replies in this thread should be
  *       rendered as collapsed (when true) or expanded (when false)
  * @prop {Thread[]} children
- * @prop {number} totalChildren - Computed count of this thread's immediate
- *       children. This count includes visually-hidden threads.
  * @prop {number} replyCount - Computed count of all replies to a thread
  * @prop {number} depth - The thread's depth in the hierarchy
  */
@@ -31,7 +29,6 @@ const DEFAULT_THREAD_STATE = {
   depth: 0,
   visible: true,
   replyCount: 0,
-  totalChildren: 0,
 };
 
 /**
@@ -152,7 +149,6 @@ function threadAnnotations(annotations) {
     ...DEFAULT_THREAD_STATE,
     id: 'root',
     children: rootThreads,
-    totalChildren: rootThreads.length,
   };
 
   return rootThread;


### PR DESCRIPTION
* It was unused
* It had no tests
* If there were tests, they might have kicked up that it's also buggy;  it wasn't getting recalculated after threads were removed due to filtering

For posterity: the equivalent is `thread.children.length`

Context: I had relied upon this property in one iteration of user filtering for the Notebook. Yeah, it doesn't work right. Let's remove it.