### PR TITLE
Improve Adder location for touch screen devices

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -1,6 +1,7 @@
 import { createElement, render } from 'preact';
 
 import AdderToolbar from './components/adder-toolbar';
+import { isTouchDevice } from '../shared/user-agent';
 import { createShadowRoot } from './util/shadow-root';
 
 /**
@@ -180,9 +181,12 @@ export class Adder {
     // Set the initial arrow direction based on whether the selection was made
     // forwards/upwards or downwards/backwards.
     /** @type {ArrowDirection} */ let arrowDirection;
-    if (isRTLselection) {
+    if (isRTLselection && !isTouchDevice()) {
       arrowDirection = ARROW_POINTING_DOWN;
     } else {
+      // Render the adder below the selection for touch devices due to competing
+      // space with the native copy/paste bar that typical (not always) renders above
+      // the selection.
       arrowDirection = ARROW_POINTING_UP;
     }
     let top;
@@ -192,6 +196,9 @@ export class Adder {
     // and close to the end.
     const hMargin = Math.min(ARROW_H_MARGIN, selectionRect.width);
     const adderWidth = this._width();
+    // Render the adder a little lower on touch devices to provide room for the native
+    // selection handles so that the interactions with selection don't compete with the adder.
+    const touchScreenOffset = isTouchDevice() ? 10 : 0;
     const adderHeight = this._height();
     if (isRTLselection) {
       left = selectionRect.left - adderWidth / 2 + hMargin;
@@ -212,7 +219,11 @@ export class Adder {
     }
 
     if (arrowDirection === ARROW_POINTING_UP) {
-      top = selectionRect.top + selectionRect.height + ARROW_HEIGHT;
+      top =
+        selectionRect.top +
+        selectionRect.height +
+        ARROW_HEIGHT +
+        touchScreenOffset;
     } else {
       top = selectionRect.top - adderHeight - ARROW_HEIGHT;
     }

--- a/src/annotator/range-util.js
+++ b/src/annotator/range-util.js
@@ -10,6 +10,8 @@ export function isSelectionBackwards(selection) {
   }
 
   const range = selection.getRangeAt(0);
+  // Does not work correctly on iOS when selecting nodes backwards.
+  // https://bugs.webkit.org/show_bug.cgi?id=220523
   return range.startContainer === selection.focusNode;
 }
 

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -2,7 +2,12 @@ import { act } from 'preact/test-utils';
 import { createElement } from 'preact';
 import { mount } from 'enzyme';
 
-import { Adder, ARROW_POINTING_UP, ARROW_POINTING_DOWN } from '../adder';
+import {
+  Adder,
+  ARROW_POINTING_UP,
+  ARROW_POINTING_DOWN,
+  $imports,
+} from '../adder';
 
 function rect(left, top, width, height) {
   return { left, top, width, height };
@@ -50,6 +55,7 @@ describe('Adder', () => {
   afterEach(() => {
     adderCtrl.hide();
     adderEl.remove();
+    $imports.$restore();
   });
 
   function windowSize() {
@@ -199,6 +205,12 @@ describe('Adder', () => {
       assert.equal(target.arrowDirection, ARROW_POINTING_UP);
     });
 
+    it('does not position the adder above the top of the viewport even when selection is backwards', () => {
+      const target = adderCtrl._calculateTarget(rect(100, -100, 100, 20), true);
+      assert.isAtLeast(target.top, 0);
+      assert.equal(target.arrowDirection, ARROW_POINTING_UP);
+    });
+
     it('does not position the adder below the bottom of the viewport', () => {
       const viewSize = windowSize();
       const target = adderCtrl._calculateTarget(
@@ -220,6 +232,22 @@ describe('Adder', () => {
     it('does not positon the adder beyond the left edge of the viewport', () => {
       const target = adderCtrl._calculateTarget(rect(-100, 100, 10, 10), false);
       assert.isAtLeast(target.left, 0);
+    });
+
+    context('touch device', () => {
+      it('positions the adder below the selection even if the selection is backwards', () => {
+        $imports.$mock({
+          '../shared/user-agent': {
+            isTouchDevice: sinon.stub().returns(true),
+          },
+        });
+        const target = adderCtrl._calculateTarget(
+          rect(100, 200, 100, 20),
+          true
+        );
+        assert.isAbove(target.top, 220);
+        assert.equal(target.arrowDirection, ARROW_POINTING_UP);
+      });
     });
   });
 

--- a/src/shared/test/user-agent-test.js
+++ b/src/shared/test/user-agent-test.js
@@ -1,4 +1,4 @@
-import { isMacOS, isIOS } from '../user-agent';
+import { isMacOS, isIOS, isTouchDevice } from '../user-agent';
 
 describe('shared/user-agent', () => {
   describe('isMacOS', () => {
@@ -16,6 +16,23 @@ describe('shared/user-agent', () => {
           'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.92 Safari/537.36 Edg/80.0.361.109'
         )
       );
+    });
+  });
+
+  describe('isTouchDevice', () => {
+    let matchMedia;
+
+    beforeEach(() => {
+      matchMedia = sinon.spy(window, 'matchMedia');
+    });
+
+    afterEach(() => {
+      window.matchMedia.restore();
+    });
+
+    it('calls `window.matchMedia` with the query string "(pointer: coarse)"', () => {
+      isTouchDevice(window);
+      assert.calledWith(matchMedia, '(pointer: coarse)');
     });
   });
 

--- a/src/shared/user-agent.js
+++ b/src/shared/user-agent.js
@@ -35,3 +35,14 @@ export const isIOS = (
     (_navigator.userAgent.includes('Mac') && _ontouchend)
   );
 };
+
+/**
+ * Returns true when the device is a touch device such
+ * as android or iOS.
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer#browser_compatibility
+ *
+ * @param _window {Window} - Test seam
+ */
+export const isTouchDevice = (_window = window) => {
+  return _window.matchMedia('(pointer: coarse)').matches;
+};


### PR DESCRIPTION
- Ensure that the adder location is always below the highlighted selection on a touch devices so that it does not compete with the copy/paste bar.
- Add a little extra margin (10px) to the adder on touch devices to give room for the selection handles
- Add helper method `isTouchDevice` for touch devices
- Add comment in isSelectionBackwards to explain that iOS does not have the same selection object as non-iOS devices
- Add 1 missing test coverage case in adder.js

------

fixes https://github.com/hypothesis/client/issues/2626

This ticket was initially created to address issues with the events dealing with drag and drop on a touch device.  Ideally, it would be nice if there were events that gave a "end" to a "drag" event, but no such event exists. I presume that is because you can re-adjust the selection handles after the fact. For all intents and purposes we're no longer going to try and hide the adder when a selection is being made.

That leads the second set of problems outlined in the ticket: The adder on touch devices tends to get in the way of the copy & paste bar when you make a selection from bottom to top (backwards) as you can see here.

(master branch)
![102418112-f8270480-3fb1-11eb-9ba6-992729f9e60b](https://user-images.githubusercontent.com/3939074/102828498-c212c780-4399-11eb-9a17-fa5e54b3d2f3.gif)

More so, I discovered that android and iOS are not equal in this behavoir. For reasons I don't yet understand, window.getSelection() does not return the same object on iOS that is returned on safari or chrome on mac desktop or android. In other words, it appears iOS is the outlier. For that reason, the condition in the last line of `isSelectionBackwards` always returns false in iOS because those two nodes are never the same. 

For that reason, iOS will never render the add near the start of a range selection and so the adder is almost always below the highlighted text. The only times it flips is when it's close to the bottom of the screen. 

With android, its different and will in fact render above the highlight selection if you create it backwards. This leads to problems because it cover the  build-in copy bar. This fix presented here is to force the adder to only render below a selection on all touch devices (except when off the bottom of screen). This is already the case on iOS (But I suspect it was inadvertent). This PR further forces both iOS and android (or rather, all touch devices) to render it below the highlighted text.

Additionally, I added a 10px margin to create separation between the adder the the highlighted text to give more room for the grab handles. These blue handles can impede the adder esp. on android where they are large.

Per best practice, I avoid using being specific with the user-agent. It's my hope we don't get into specific conditions based on iOS vs android, but I think it's very reasonable to have a condition for touch devices in general. 

In this next gif  you can see the adder never blocks the copy & paste bar.

(this branch)
![android-adder](https://user-images.githubusercontent.com/3939074/102829248-8a0c8400-439b-11eb-93fc-79ba5fd9a022.gif)


The adder can still render above a selection if it falls off the bottom of the screen! In this case, it will render under the copy and paste bar, but.

1. We can't know for sure where the copy & past bar is. In some cases it renders below when the selection is made near the top of the screen so we're always guessing in a way.
2. It's totally reasonable to assume users know how to, and can easily scroll to center the text better in the viewport. Scrolling on mobile is just part of the nature of the device and its reasonable to assume users can make scrolling corrections in these edge cases.

There is no way to guess where the copy & paste bar shows up, but these changes here fix the bulk of the problem. The remaining edge cases only show up when near the bottom or top of the screen. 






