### PR TITLE
Hide the flag icon if user is unauthenticated

### DIFF
--- a/src/sidebar/components/annotation-action-bar.js
+++ b/src/sidebar/components/annotation-action-bar.js
@@ -50,9 +50,9 @@ function AnnotationActionBar({
   const showDeleteAction = userIsAuthorizedTo('delete');
   const showEditAction = userIsAuthorizedTo('update');
 
-  // Anyone may flag an annotation except the annotation's author.
-  // This option is even presented to anonymous users
-  const showFlagAction = userProfile.userid !== annotation.user;
+  //  Only authenticated users can flag an annotation, except the annotation's author.
+  const showFlagAction =
+    !!userProfile.userid && userProfile.userid !== annotation.user;
   const showShareAction = isShareable(annotation, settings);
 
   const onDelete = () => {
@@ -72,10 +72,6 @@ function AnnotationActionBar({
   };
 
   const onFlag = () => {
-    if (!userProfile.userid) {
-      toastMessenger.error('You must be logged in to report an annotation');
-      return;
-    }
     annotationsService
       .flag(annotation)
       .catch(() => toastMessenger.error('Flagging annotation failed'));

--- a/src/sidebar/components/test/annotation-action-bar-test.js
+++ b/src/sidebar/components/test/annotation-action-bar-test.js
@@ -245,25 +245,28 @@ describe('AnnotationActionBar', () => {
   });
 
   describe('flag action button', () => {
-    it('shows flag button if user is not author', () => {
-      const wrapper = createComponent();
-
-      assert.isTrue(getButton(wrapper, 'flag').exists());
-    });
-
-    it('sets a flash error when clicked if user is not logged in', () => {
+    it('hides flag button if user is not authenticated', () => {
       fakeStore.profile.returns({
         userid: null,
       });
 
-      const button = getButton(createComponent(), 'flag');
+      const wrapper = createComponent();
 
-      act(() => {
-        button.props().onClick();
-      });
+      assert.isFalse(getButton(wrapper, 'flag').exists());
+    });
 
-      assert.calledOnce(fakeToastMessenger.error);
-      assert.notCalled(fakeAnnotationsService.flag);
+    it('hides flag button if user is author', () => {
+      fakeAnnotation.user = fakeUserProfile.userid;
+
+      const wrapper = createComponent();
+
+      assert.isFalse(getButton(wrapper, 'flag').exists());
+    });
+
+    it('shows flag button if user is not author', () => {
+      const wrapper = createComponent();
+
+      assert.isTrue(getButton(wrapper, 'flag').exists());
     });
 
     it('invokes flag on service when clicked', () => {
@@ -289,14 +292,6 @@ describe('AnnotationActionBar', () => {
       });
 
       await waitFor(() => fakeToastMessenger.error.called);
-    });
-
-    it('does not show flag action button if user is author', () => {
-      fakeAnnotation.user = fakeUserProfile.userid;
-
-      const wrapper = createComponent();
-
-      assert.isFalse(getButton(wrapper, 'flag').exists());
     });
 
     context('previously-flagged annotation', () => {


### PR DESCRIPTION
Previously, all users were able to click the flag icon. However, unauthenticated users were shown the following toast message if they click the icon: `You must be logged in to report an annotation`.

The behaviour has been changed so that the flag button is only shown (and clickable) for authenticated users.

Closes https://github.com/hypothesis/product-backlog/issues/1037