### PR TITLE
Do not provide share link if (annotation or document) URL is not available on the web

### DIFF
--- a/src/sidebar/components/annotation-action-bar.js
+++ b/src/sidebar/components/annotation-action-bar.js
@@ -3,7 +3,7 @@ import propTypes from 'prop-types';
 
 import uiConstants from '../ui-constants';
 import { useStoreProxy } from '../store/use-store';
-import { isShareable, shareURI } from '../util/annotation-sharing';
+import { sharingEnabled, shareURI } from '../util/annotation-sharing';
 import { isPrivate, permits } from '../util/permissions';
 import { withServices } from '../util/service-context';
 
@@ -53,7 +53,7 @@ function AnnotationActionBar({
   //  Only authenticated users can flag an annotation, except the annotation's author.
   const showFlagAction =
     !!userProfile.userid && userProfile.userid !== annotation.user;
-  const showShareAction = isShareable(annotation, settings);
+  const showShareAction = sharingEnabled(settings) && shareURI(annotation);
 
   const onDelete = () => {
     if (window.confirm('Are you sure you want to delete this annotation?')) {

--- a/src/sidebar/components/test/annotation-action-bar-test.js
+++ b/src/sidebar/components/test/annotation-action-bar-test.js
@@ -23,7 +23,8 @@ describe('AnnotationActionBar', () => {
   let fakePermits;
   let fakeSettings;
   // Fake dependencies
-  let fakeIsShareable;
+  let fakeShareURI;
+  let fakeSharingEnabled;
   let fakeStore;
 
   function createComponent(props = {}) {
@@ -76,7 +77,8 @@ describe('AnnotationActionBar', () => {
     fakePermits = sinon.stub().returns(true);
     fakeSettings = {};
 
-    fakeIsShareable = sinon.stub().returns(true);
+    fakeSharingEnabled = sinon.stub().returns(true);
+    fakeShareURI = sinon.stub().returns('http://share.me');
 
     fakeStore = {
       createDraft: sinon.stub(),
@@ -89,8 +91,8 @@ describe('AnnotationActionBar', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../util/annotation-sharing': {
-        isShareable: fakeIsShareable,
-        shareURI: sinon.stub().returns('http://share.me'),
+        sharingEnabled: fakeSharingEnabled,
+        shareURI: fakeShareURI,
       },
       '../util/permissions': { permits: fakePermits },
       '../store/use-store': { useStoreProxy: () => fakeStore },
@@ -236,8 +238,15 @@ describe('AnnotationActionBar', () => {
       assert.isTrue(wrapper.find('AnnotationShareControl').exists());
     });
 
-    it('does not show share action button if annotation is not shareable', () => {
-      fakeIsShareable.returns(false);
+    it('does not show share action button if sharing is not enabled', () => {
+      fakeSharingEnabled.returns(false);
+      const wrapper = createComponent();
+
+      assert.isFalse(wrapper.find('AnnotationShareControl').exists());
+    });
+
+    it('does not show share action button if annotation lacks sharing URI', () => {
+      fakeShareURI.returns(undefined);
       const wrapper = createComponent();
 
       assert.isFalse(wrapper.find('AnnotationShareControl').exists());

--- a/src/sidebar/util/annotation-sharing.js
+++ b/src/sidebar/util/annotation-sharing.js
@@ -1,8 +1,46 @@
 /**
+ * @typedef {import('../../types/api').Annotation} Annotation
  * @typedef {import('../../types/config').HostConfig} HostConfig
  */
 
 import serviceConfig from '../service-config';
+
+/**
+ * Generate a URI for sharing: a bouncer link built to share annotations in
+ * a specific group (groupID) on a specific document (documentURI).
+ *
+ * @param {string} documentURI
+ * @param {string} groupID
+ * @return {string}
+ */
+export function getSharingLink(documentURI, groupID) {
+  return `https://hyp.is/go?url=${encodeURIComponent(
+    documentURI
+  )}&group=${groupID}`;
+}
+
+/**
+ * Are annotations made against `uri` meaningfully shareable? The
+ * target URI needs to be available on the web, which here is determined by
+ * a protocol of `http` or `https`.
+ *
+ * @param {string} uri
+ * @return {boolean}
+ */
+export function isShareableURI(uri) {
+  return /^http(s?):/.test(uri);
+}
+
+/**
+ * Return the service-provided sharing URI for an annotation. Prefer the
+ * `incontext` link when available; fallback to `html` if not present.
+ *
+ * @param {Annotation} annotation
+ * @return {string|undefined}
+ */
+export function shareURI(annotation) {
+  return annotation.links?.incontext ?? annotation.links?.html;
+}
 
 /**
  * Is the sharing of annotations enabled? Check for any defined `serviceConfig`,
@@ -20,28 +58,4 @@ export function sharingEnabled(settings) {
     return true;
   }
   return serviceConfig_.enableShareLinks;
-}
-
-/**
- * Return any defined standalone URI for this `annotation`, preferably the
- * `incontext` URI, but fallback to `html` link if not present.
- *
- * @param {object} annotation
- * @return {string|undefined}
- */
-export function shareURI(annotation) {
-  const links = annotation.links;
-  return links && (links.incontext || links.html);
-}
-
-/**
- * For an annotation to be "shareable", sharing links need to be enabled overall
- * and the annotation itself needs to have a sharing URI.
- *
- * @param {object} annotation
- * @param {HostConfig} settings
- * @return {boolean}
- */
-export function isShareable(annotation, settings) {
-  return !!(sharingEnabled(settings) && shareURI(annotation));
 }

--- a/src/sidebar/util/test/annotation-sharing-test.js
+++ b/src/sidebar/util/test/annotation-sharing-test.js
@@ -24,7 +24,44 @@ describe('sidebar.util.annotation-sharing', () => {
     sharingUtil.$imports.$restore();
   });
 
-  describe('#annotationSharingEnabled', () => {
+  describe('getSharingLink', () => {
+    it('generates a bouncer link based on the document URI and group id', () => {
+      assert.equal(
+        sharingUtil.getSharingLink('https://www.example.com', 'testprivate'),
+        'https://hyp.is/go?url=https%3A%2F%2Fwww.example.com&group=testprivate'
+      );
+    });
+  });
+
+  describe('isShareableURI', () => {
+    [
+      'http://www.example.com',
+      'http://www.foo.bar',
+      'http://hi',
+      'http:foo',
+      'https://www.foo.bar/baz/ding.html',
+    ].forEach(validURI => {
+      it('returns true for URLs with http and https protocols', () => {
+        assert.isTrue(sharingUtil.isShareableURI(validURI));
+      });
+    });
+
+    [
+      'httf://www.example.com',
+      'htt://whatever',
+      'ftp://warez.napster.nostalgia',
+      'file://hithere',
+      'chrome://extensions',
+      'http//www.wrong',
+      'www.example.com',
+    ].forEach(invalidURI => {
+      it('returns false for any URL not beginning with http or https', () => {
+        assert.isFalse(sharingUtil.isShareableURI(invalidURI));
+      });
+    });
+  });
+
+  describe('sharingEnabled', () => {
     it('returns true if no service settings present', () => {
       fakeServiceConfig.returns(null);
       assert.isTrue(sharingUtil.sharingEnabled({}));
@@ -46,7 +83,7 @@ describe('sidebar.util.annotation-sharing', () => {
     });
   });
 
-  describe('#shareURI', () => {
+  describe('shareURI', () => {
     it('returns `incontext` link if set on annotation', () => {
       assert.equal(
         sharingUtil.shareURI(fakeAnnotation),
@@ -74,25 +111,6 @@ describe('sidebar.util.annotation-sharing', () => {
       delete fakeAnnotation.links;
 
       assert.isUndefined(sharingUtil.shareURI(fakeAnnotation));
-    });
-  });
-
-  describe('#isShareable', () => {
-    it('returns `true` if sharing enabled and there is a share link available', () => {
-      fakeServiceConfig.returns(null);
-      assert.isTrue(sharingUtil.isShareable(fakeAnnotation, {}));
-    });
-
-    it('returns `false` if sharing not enabled', () => {
-      fakeServiceConfig.returns({ enableShareLinks: false });
-      assert.isFalse(sharingUtil.isShareable(fakeAnnotation, {}));
-    });
-
-    it('returns `false` if no sharing link available on annotation', () => {
-      fakeServiceConfig.returns(null);
-      delete fakeAnnotation.links;
-
-      assert.isFalse(sharingUtil.isShareable(fakeAnnotation, {}));
     });
   });
 });

--- a/src/styles/mixins/molecules.scss
+++ b/src/styles/mixins/molecules.scss
@@ -20,9 +20,9 @@
  * annotation (thread) cards. Will vertically-space its children. Adds a
  * hover/active intensified box shadow and accounts for "theme-clean" affordances.
  */
-@mixin card {
+@mixin card($rhythm: var.$layout-space) {
   @include card-frame;
-  @include layout.vertical-rhythm;
+  @include layout.vertical-rhythm($rhythm);
   padding: var.$layout-space;
 
   &:hover,
@@ -114,9 +114,12 @@
 /**
  * Base styles for a "panel"-like element, with appropriate
  * padding, heading and close-button styles.
+ *
+ * @param {length} [$rhythm] - An optional value to use for vertical rhythm
+ *   (spacing, vertically)
  */
-@mixin panel {
-  @include card;
+@mixin panel($rhythm: var.$layout-space) {
+  @include card($rhythm);
 
   &__header {
     @include layout.row($align: center);
@@ -152,7 +155,7 @@
  * `panel` with tighter margins and padding, for use in more confined spaces
  */
 @mixin panel--compact {
-  @include panel;
+  @include panel($rhythm: var.$layout-space--xsmall);
   width: 20em;
   // Keep panel constrained within annotation card boundaries and not cut off
   // on left side when sidebar is extremely narrow
@@ -160,8 +163,7 @@
   padding: var.$layout-space--small;
 
   &__header {
-    padding: 0;
-    border-bottom: none;
+    padding-bottom: var.$layout-space--xsmall;
   }
 }
 

--- a/src/styles/sidebar/components/annotation-share-control.scss
+++ b/src/styles/sidebar/components/annotation-share-control.scss
@@ -25,8 +25,14 @@
     bottom: 40px;
   }
 
-  // Override the pointer cursor that applies to the entire annotation card
+  // Override the pointer cursor that applies to the entire card
   cursor: default;
+
+  // Hide the bottom border on the panel's header if displaying
+  // input (with sharing link) directly below
+  &--shareable &__header {
+    border-bottom: none;
+  }
 
   &__form-input {
     @include forms.form-input--with-button($compact: true);
@@ -36,7 +42,7 @@
     @include buttons.button--input($compact: true);
   }
 
-  &__permissions {
+  &__details {
     @include utils.font--small;
     padding: var.$layout-space--xsmall 0;
   }


### PR DESCRIPTION
There has been some (understandable) ongoing confusion around share links for single annotations or sets of annotations that pertain to a URI that is not available on the web. Specifically, it's confusing if one annotates a local PDF and then attempts to share a single annotation or a set of annotations on that PDF. Before these changes, the application would happily cook up a bouncer (sharing) link for you, but that link wouldn't do anything useful.

## With these changes...

*Note*: For convenience, the screenshots here show both share-single-annotation and share-a-page's-annotations open at the same time. While this isn't broken or impossible, it's probably slightly unusual.

These changes create a new UI path for both the share-single-annotation and share-a-page's-annotations components. When the URI is "shareable," there is no change from before, which looks like this:

<img width="469" alt="Screen Shot 2021-01-07 at 1 57 23 PM" src="https://user-images.githubusercontent.com/439947/103933196-f8b64500-50f0-11eb-9fa5-276e760fdd2e.png">

If the URI in question is not "shareable," the interfaces will look like this:

<img width="470" alt="Screen Shot 2021-01-07 at 2 02 19 PM" src="https://user-images.githubusercontent.com/439947/103933236-08ce2480-50f1-11eb-8ea9-6564a055ead8.png">

To support these changes, component changes were needed (duh), but a few other supporting changes were made as well to the `util/annotation-sharing` module, and some adjustments to `card` and `panel` molecules that I'll elaborate on with inline comments in this PR.

I manually tested that:

* When built into the local extension, local PDF files appropriately get the new, unshareable treatment.
* When built into the local extension, web-hosted PDF files still allow sharing correctly.

Fixes #2786