### PR TITLE
Make sure long URLs and other strings wrap in version-info panel

### DIFF
--- a/src/styles/sidebar/components/version-info.scss
+++ b/src/styles/sidebar/components/version-info.scss
@@ -30,7 +30,7 @@
       margin-left: 1em; // Space between key and value
       flex-basis: 70%;
       flex-grow: 1;
-      overflow-wrap: break-word; // Keep really long userids from overflowing
+      overflow-wrap: anywhere; // Keep long userids and urls from overflowing
     }
   }
 }


### PR DESCRIPTION
Fixes #2851

Before 

![image](https://user-images.githubusercontent.com/439947/103937251-80528280-50f6-11eb-8559-33ff801a1049.png)

After

![image](https://user-images.githubusercontent.com/439947/103937278-8a748100-50f6-11eb-80e0-0bb17dde3ee4.png)
