### PR TITLE
Fix visual regression caused in touch mode

### DIFF
--- a/src/styles/mixins/buttons.scss
+++ b/src/styles/mixins/buttons.scss
@@ -57,13 +57,21 @@
   @include button-hover;
 }
 
-/* A button with an icon and no displayed text */
-@mixin button--icon-only($with-active-state: true) {
+/*
+ * A button with an icon and no displayed text.
+ *
+ * @param {boolean} [$with-active-state] - Adds an active state color when pressed / expanded
+ * @param {boolean} [$coarse-min-size] - Overrides the minimum height and width in mobile view.
+ */
+@mixin button--icon-only(
+  $with-active-state: true,
+  $coarse-min-size: var.$touch-target-size
+) {
   @include button;
   color: var.$grey-mid;
   @media (pointer: coarse) {
-    min-width: var.$touch-target-size;
-    min-height: var.$touch-target-size;
+    min-width: $coarse-min-size;
+    min-height: $coarse-min-size;
   }
   @if $with-active-state == true {
     &[aria-expanded='true'],

--- a/src/styles/sidebar/components/menu.scss
+++ b/src/styles/sidebar/components/menu.scss
@@ -11,8 +11,8 @@
 
 // Toggle button that opens the menu.
 .menu__toggle {
-  @include buttons.button--icon-only;
-
+  // Override $coarse-min-size so the button's size won't change in mobile view.
+  @include buttons.button--icon-only($coarse-min-size: inherit);
   appearance: none;
   background: none;
   padding: 0;


### PR DESCRIPTION
- Added  override to button--icon-only mixin for min-size
- Set the override value for menu__toggle to "inherit"

This regression was caused when adding the `buttons.button--icon-only` mixin to the post annotation drop down toggle button (menu__toggle). This is indeed an icon button, but for visual fidelity, we are not going to bump the minimum size to the 44px in mobile view.

-----------

toggle button no longer balloons to 44px.

fixes https://github.com/hypothesis/client/issues/2861

![Screen Shot 2021-01-07 at 2 12 17 PM](https://user-images.githubusercontent.com/3939074/103950790-6151f180-50f2-11eb-8c92-cfb6655c3ba4.png)
