### PR TITLE
Provide a UI path for sharing when a page's or annotation's URI is not web-accessible

### DIFF
--- a/src/sidebar/components/annotation-action-bar.js
+++ b/src/sidebar/components/annotation-action-bar.js
@@ -3,7 +3,10 @@ import propTypes from 'prop-types';
 
 import uiConstants from '../ui-constants';
 import { useStoreProxy } from '../store/use-store';
-import { isShareable, shareURI } from '../util/annotation-sharing';
+import {
+  sharingEnabled,
+  annotationSharingLink,
+} from '../util/annotation-sharing';
 import { isPrivate, permits } from '../util/permissions';
 import { withServices } from '../util/service-context';
 
@@ -53,7 +56,9 @@ function AnnotationActionBar({
   //  Only authenticated users can flag an annotation, except the annotation's author.
   const showFlagAction =
     !!userProfile.userid && userProfile.userid !== annotation.user;
-  const showShareAction = isShareable(annotation, settings);
+
+  const shareLink =
+    sharingEnabled(settings) && annotationSharingLink(annotation);
 
   const onDelete = () => {
     if (window.confirm('Are you sure you want to delete this annotation?')) {
@@ -92,11 +97,11 @@ function AnnotationActionBar({
         <Button icon="trash" title="Delete" onClick={onDelete} />
       )}
       <Button icon="reply" title="Reply" onClick={onReplyClick} />
-      {showShareAction && (
+      {shareLink && (
         <AnnotationShareControl
           annotation={annotation}
           group={annotationGroup}
-          shareUri={shareURI(annotation)}
+          shareUri={shareLink}
         />
       )}
       {showFlagAction && !annotation.flagged && (

--- a/src/sidebar/components/share-annotations-panel.js
+++ b/src/sidebar/components/share-annotations-panel.js
@@ -1,14 +1,17 @@
-import { createElement } from 'preact';
+import { createElement, Fragment } from 'preact';
 import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';
 import uiConstants from '../ui-constants';
+import { pageSharingLink } from '../util/annotation-sharing';
 import { copyText } from '../util/copy-to-clipboard';
 import { withServices } from '../util/service-context';
+import { notNull } from '../util/typing';
 
 import Button from './button';
 import ShareLinks from './share-links';
 import SidebarPanel from './sidebar-panel';
+import Spinner from './spinner';
 import SvgIcon from '../../shared/components/svg-icon';
 
 /**
@@ -18,7 +21,7 @@ import SvgIcon from '../../shared/components/svg-icon';
  */
 
 /**
- * A panel for sharing the current group's annotations.
+ * A panel for sharing the current group's annotations on the current document.
  *
  * Links within this component allow a user to share the set of annotations that
  * are on the current page (as defined by the main frame's URI) and contained
@@ -30,24 +33,20 @@ function ShareAnnotationsPanel({ analytics, toastMessenger }) {
   const store = useStoreProxy();
   const mainFrame = store.mainFrame();
   const focusedGroup = store.focusedGroup();
-
   const groupName = (focusedGroup && focusedGroup.name) || '...';
   const panelTitle = `Share Annotations in ${groupName}`;
 
-  // Generate bouncer sharing link for annotations in the current group.
-  // This is the URI format for the web-sharing link shown in the input
-  // and is available to be copied to clipboard
-  const shareURI = ((frame, group) => {
-    return group && frame
-      ? `https://hyp.is/go?url=${encodeURIComponent(frame.uri)}&group=${
-          group.id
-        }`
-      : '';
-  })(mainFrame, focusedGroup);
+  // To be able to concoct a sharing link, a focused group and frame need to
+  // be available
+  const sharingReady = focusedGroup && mainFrame;
+
+  const shareURI =
+    sharingReady &&
+    pageSharingLink(notNull(mainFrame).uri, notNull(focusedGroup).id);
 
   const copyShareLink = () => {
     try {
-      copyText(shareURI);
+      copyText(/** @type {string} */ (shareURI));
       toastMessenger.success('Copied share link to clipboard');
     } catch (err) {
       toastMessenger.error('Unable to copy link');
@@ -59,55 +58,70 @@ function ShareAnnotationsPanel({ analytics, toastMessenger }) {
       title={panelTitle}
       panelName={uiConstants.PANEL_SHARE_ANNOTATIONS}
     >
-      {focusedGroup && mainFrame && (
+      {!sharingReady && (
+        <div className="share-annotations-panel__spinner">
+          <Spinner />
+        </div>
+      )}
+      {sharingReady && (
         <div className="share-annotations-panel">
-          <div className="share-annotations-panel__intro">
-            {focusedGroup.type === 'private' ? (
+          {shareURI ? (
+            <Fragment>
+              <div className="share-annotations-panel__intro">
+                {notNull(focusedGroup).type === 'private' ? (
+                  <p>
+                    Use this link to share these annotations with other group
+                    members:
+                  </p>
+                ) : (
+                  <p>Use this link to share these annotations with anyone:</p>
+                )}
+              </div>
+              <div className="u-layout-row">
+                <input
+                  aria-label="Use this URL to share these annotations"
+                  className="share-annotations-panel__form-input"
+                  type="text"
+                  value={shareURI}
+                  readOnly
+                />
+                <Button
+                  icon="copy"
+                  onClick={copyShareLink}
+                  title="Copy share link"
+                  className="share-annotations-panel__icon-button"
+                />
+              </div>
               <p>
-                Use this link to share these annotations with other group
-                members:
+                {notNull(focusedGroup).type === 'private' ? (
+                  <span>
+                    Annotations in the private group{' '}
+                    <em>{notNull(focusedGroup).name}</em> are only visible to
+                    group members.
+                  </span>
+                ) : (
+                  <span>
+                    Anyone using this link may view the annotations in the group{' '}
+                    <em>{notNull(focusedGroup).name}</em>.
+                  </span>
+                )}{' '}
+                <span>
+                  Private (
+                  <SvgIcon name="lock" inline className="u-icon--inline" />{' '}
+                  <em>Only Me</em>) annotations are only visible to you.
+                </span>
               </p>
-            ) : (
-              <p>Use this link to share these annotations with anyone:</p>
-            )}
-          </div>
-          <div className="u-layout-row">
-            <input
-              aria-label="Use this URL to share these annotations"
-              className="share-annotations-panel__form-input"
-              type="text"
-              value={shareURI}
-              readOnly
-            />
-            <Button
-              icon="copy"
-              onClick={copyShareLink}
-              title="Copy share link"
-              className="share-annotations-panel__icon-button"
-            />
-          </div>
-          <p>
-            {focusedGroup.type === 'private' ? (
-              <span>
-                Annotations in the private group <em>{focusedGroup.name}</em>{' '}
-                are only visible to group members.
-              </span>
-            ) : (
-              <span>
-                Anyone using this link may view the annotations in the group{' '}
-                <em>{focusedGroup.name}</em>.
-              </span>
-            )}{' '}
-            <span>
-              Private (
-              <SvgIcon name="lock" inline className="u-icon--inline" />{' '}
-              <em>Only Me</em>) annotations are only visible to you.
-            </span>
-          </p>
-          <ShareLinks
-            shareURI={shareURI}
-            analyticsEventName={analytics.events.DOCUMENT_SHARED}
-          />
+              <ShareLinks
+                shareURI={shareURI}
+                analyticsEventName={analytics.events.DOCUMENT_SHARED}
+              />
+            </Fragment>
+          ) : (
+            <p>
+              These annotations cannot be shared because this document is not
+              available on the web.
+            </p>
+          )}
         </div>
       )}
     </SidebarPanel>

--- a/src/sidebar/components/test/annotation-action-bar-test.js
+++ b/src/sidebar/components/test/annotation-action-bar-test.js
@@ -23,7 +23,8 @@ describe('AnnotationActionBar', () => {
   let fakePermits;
   let fakeSettings;
   // Fake dependencies
-  let fakeIsShareable;
+  let fakeAnnotationSharingLink;
+  let fakeSharingEnabled;
   let fakeStore;
 
   function createComponent(props = {}) {
@@ -76,7 +77,8 @@ describe('AnnotationActionBar', () => {
     fakePermits = sinon.stub().returns(true);
     fakeSettings = {};
 
-    fakeIsShareable = sinon.stub().returns(true);
+    fakeSharingEnabled = sinon.stub().returns(true);
+    fakeAnnotationSharingLink = sinon.stub().returns('http://share.me');
 
     fakeStore = {
       createDraft: sinon.stub(),
@@ -89,8 +91,8 @@ describe('AnnotationActionBar', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../util/annotation-sharing': {
-        isShareable: fakeIsShareable,
-        shareURI: sinon.stub().returns('http://share.me'),
+        sharingEnabled: fakeSharingEnabled,
+        annotationSharingLink: fakeAnnotationSharingLink,
       },
       '../util/permissions': { permits: fakePermits },
       '../store/use-store': { useStoreProxy: () => fakeStore },
@@ -236,8 +238,15 @@ describe('AnnotationActionBar', () => {
       assert.isTrue(wrapper.find('AnnotationShareControl').exists());
     });
 
-    it('does not show share action button if annotation is not shareable', () => {
-      fakeIsShareable.returns(false);
+    it('does not show share action button if sharing is not enabled', () => {
+      fakeSharingEnabled.returns(false);
+      const wrapper = createComponent();
+
+      assert.isFalse(wrapper.find('AnnotationShareControl').exists());
+    });
+
+    it('does not show share action button if annotation lacks sharing URI', () => {
+      fakeAnnotationSharingLink.returns(undefined);
       const wrapper = createComponent();
 
       assert.isFalse(wrapper.find('AnnotationShareControl').exists());

--- a/src/sidebar/util/test/annotation-sharing-test.js
+++ b/src/sidebar/util/test/annotation-sharing-test.js
@@ -13,6 +13,7 @@ describe('sidebar.util.annotation-sharing', () => {
         incontext: 'https://www.example.com',
         html: 'https://www.example2.com',
       },
+      uri: 'https://www.example3.com',
     };
 
     sharingUtil.$imports.$mock({
@@ -24,7 +25,110 @@ describe('sidebar.util.annotation-sharing', () => {
     sharingUtil.$imports.$restore();
   });
 
-  describe('#annotationSharingEnabled', () => {
+  describe('annotationSharingLink', () => {
+    context('sharing an annotation whose document is on the web', () => {
+      it('returns `incontext` link if set on annotation', () => {
+        assert.equal(
+          sharingUtil.annotationSharingLink(fakeAnnotation),
+          'https://www.example.com'
+        );
+      });
+
+      it('returns `html` link if `incontext` link not set on annotation', () => {
+        delete fakeAnnotation.links.incontext;
+
+        assert.equal(
+          sharingUtil.annotationSharingLink(fakeAnnotation),
+          'https://www.example2.com'
+        );
+      });
+
+      it('returns null if links empty', () => {
+        delete fakeAnnotation.links.incontext;
+        delete fakeAnnotation.links.html;
+
+        assert.isNull(sharingUtil.annotationSharingLink(fakeAnnotation));
+      });
+
+      it('returns null if no links on annotation', () => {
+        delete fakeAnnotation.links;
+
+        assert.isNull(sharingUtil.annotationSharingLink(fakeAnnotation));
+      });
+    });
+
+    context('sharing an annotation whose document is not on the web', () => {
+      beforeEach(() => {
+        fakeAnnotation.uri = 'file://not-on-web';
+      });
+
+      it('returns `html` link if set on annotation', () => {
+        assert.equal(
+          sharingUtil.annotationSharingLink(fakeAnnotation),
+          'https://www.example2.com'
+        );
+      });
+
+      it('returns null if no `html` link', () => {
+        delete fakeAnnotation.links.html;
+
+        assert.isNull(sharingUtil.annotationSharingLink(fakeAnnotation));
+      });
+
+      it('returns null if no links on annotation', () => {
+        delete fakeAnnotation.links;
+
+        assert.isNull(sharingUtil.annotationSharingLink(fakeAnnotation));
+      });
+    });
+  });
+
+  describe('pageSharingLink', () => {
+    it('generates a bouncer link based on the document URI and group id', () => {
+      assert.equal(
+        sharingUtil.pageSharingLink('https://www.example.com', 'testprivate'),
+        'https://hyp.is/go?url=https%3A%2F%2Fwww.example.com&group=testprivate'
+      );
+    });
+
+    it('returns null if the `documentURI` is not a shareable URI', () => {
+      assert.isNull(
+        sharingUtil.pageSharingLink('file://on-my-computer.pdf', 'testprivate')
+      );
+    });
+  });
+
+  describe('isShareableURI', () => {
+    [
+      'http://www.example.com',
+      'http://www.foo.bar',
+      'http://hi',
+      'http:foo',
+      'https://www.foo.bar/baz/ding.html',
+      'HTTP://WWW.FOO.BAR/BAZ',
+      'HTTPS://WWW.FOO.COM',
+    ].forEach(validURI => {
+      it('returns true for URLs with http and https protocols', () => {
+        assert.isTrue(sharingUtil.isShareableURI(validURI));
+      });
+    });
+
+    [
+      'httf://www.example.com',
+      'htt://whatever',
+      'ftp://warez.napster.nostalgia',
+      'file://hithere',
+      'chrome://extensions',
+      'http//www.wrong',
+      'www.example.com',
+    ].forEach(invalidURI => {
+      it('returns false for any URL not beginning with http or https', () => {
+        assert.isFalse(sharingUtil.isShareableURI(invalidURI));
+      });
+    });
+  });
+
+  describe('sharingEnabled', () => {
     it('returns true if no service settings present', () => {
       fakeServiceConfig.returns(null);
       assert.isTrue(sharingUtil.sharingEnabled({}));
@@ -43,56 +147,6 @@ describe('sidebar.util.annotation-sharing', () => {
     it('returns false if service settings really sets it to nope', () => {
       fakeServiceConfig.returns({ enableShareLinks: false });
       assert.isFalse(sharingUtil.sharingEnabled({}));
-    });
-  });
-
-  describe('#shareURI', () => {
-    it('returns `incontext` link if set on annotation', () => {
-      assert.equal(
-        sharingUtil.shareURI(fakeAnnotation),
-        'https://www.example.com'
-      );
-    });
-
-    it('returns `html` link if `incontext` link not set on annotation', () => {
-      delete fakeAnnotation.links.incontext;
-
-      assert.equal(
-        sharingUtil.shareURI(fakeAnnotation),
-        'https://www.example2.com'
-      );
-    });
-
-    it('returns `undefined` if links empty', () => {
-      delete fakeAnnotation.links.incontext;
-      delete fakeAnnotation.links.html;
-
-      assert.isUndefined(sharingUtil.shareURI(fakeAnnotation));
-    });
-
-    it('returns `undefined` if no links on annotation', () => {
-      delete fakeAnnotation.links;
-
-      assert.isUndefined(sharingUtil.shareURI(fakeAnnotation));
-    });
-  });
-
-  describe('#isShareable', () => {
-    it('returns `true` if sharing enabled and there is a share link available', () => {
-      fakeServiceConfig.returns(null);
-      assert.isTrue(sharingUtil.isShareable(fakeAnnotation, {}));
-    });
-
-    it('returns `false` if sharing not enabled', () => {
-      fakeServiceConfig.returns({ enableShareLinks: false });
-      assert.isFalse(sharingUtil.isShareable(fakeAnnotation, {}));
-    });
-
-    it('returns `false` if no sharing link available on annotation', () => {
-      fakeServiceConfig.returns(null);
-      delete fakeAnnotation.links;
-
-      assert.isFalse(sharingUtil.isShareable(fakeAnnotation, {}));
     });
   });
 });

--- a/src/sidebar/util/typing.js
+++ b/src/sidebar/util/typing.js
@@ -1,0 +1,11 @@
+/**
+ * Helper function for cases in which logically a reference is definitely
+ * not nullish, but TS can't infer that correctly. This will cast the `arg`
+ * and appease type-checking.
+ *
+ * @template T
+ * @param {T} arg
+ */
+export function notNull(arg) {
+  return /** @type {NonNullable<T>} */ (arg);
+}

--- a/src/styles/mixins/molecules.scss
+++ b/src/styles/mixins/molecules.scss
@@ -20,9 +20,9 @@
  * annotation (thread) cards. Will vertically-space its children. Adds a
  * hover/active intensified box shadow and accounts for "theme-clean" affordances.
  */
-@mixin card {
+@mixin card($rhythm: var.$layout-space) {
   @include card-frame;
-  @include layout.vertical-rhythm;
+  @include layout.vertical-rhythm($rhythm);
   padding: var.$layout-space;
 
   &:hover,
@@ -114,9 +114,12 @@
 /**
  * Base styles for a "panel"-like element, with appropriate
  * padding, heading and close-button styles.
+ *
+ * @param {length} [$rhythm] - An optional value to use for vertical rhythm
+ *   (spacing, vertically)
  */
-@mixin panel {
-  @include card;
+@mixin panel($rhythm: var.$layout-space) {
+  @include card($rhythm);
 
   &__header {
     @include layout.row($align: center);
@@ -152,16 +155,15 @@
  * `panel` with tighter margins and padding, for use in more confined spaces
  */
 @mixin panel--compact {
-  @include panel;
-  width: 20em;
+  @include panel($rhythm: var.$layout-space--xsmall);
+  width: 24em;
   // Keep panel constrained within annotation card boundaries and not cut off
   // on left side when sidebar is extremely narrow
   max-width: 85vw;
   padding: var.$layout-space--small;
 
   &__header {
-    padding: 0;
-    border-bottom: none;
+    padding-bottom: var.$layout-space--xsmall;
   }
 }
 

--- a/src/styles/sidebar/components/annotation-share-control.scss
+++ b/src/styles/sidebar/components/annotation-share-control.scss
@@ -25,8 +25,14 @@
     bottom: 40px;
   }
 
-  // Override the pointer cursor that applies to the entire annotation card
+  // Override the pointer cursor that applies to the entire card
   cursor: default;
+
+  // Hide the bottom border on the panel's header if displaying
+  // input (with sharing link) directly below
+  &__header {
+    border-bottom: none;
+  }
 
   &__form-input {
     @include forms.form-input--with-button($compact: true);
@@ -36,7 +42,7 @@
     @include buttons.button--input($compact: true);
   }
 
-  &__permissions {
+  &__details {
     @include utils.font--small;
     padding: var.$layout-space--xsmall 0;
   }

--- a/src/styles/sidebar/components/share-annotations-panel.scss
+++ b/src/styles/sidebar/components/share-annotations-panel.scss
@@ -19,4 +19,12 @@
   &__icon-button {
     @include buttons.button--input;
   }
+
+  // FIXME: Centralize styling of different sizes of Spinner in a reusable
+  // class or mixin.
+  // Spinner uses `em`-sizing; make the font-size of the containing element
+  // larger to make spinner larger
+  &__spinner {
+    font-size: (var.$layout-space * 2);
+  }
 }

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -74,8 +74,10 @@
  *   @prop {number} moderation.flagCount
  *
  * @prop {Object} links
- *   @prop {string} [links.incontext]
- *   @prop {string} [links.html]
+ *   @prop {string} [links.incontext] - A "bouncer" URL to the annotation in
+ *     context on its target document
+ *   @prop {string} [links.html] - An `h`-website URL to view the annotation
+ *     by itself
  *
  * @prop {Object} [user_info]
  *   @prop {string|null} user_info.display_name


### PR DESCRIPTION
There has been some (understandable) ongoing confusion around share links for single annotations or sets of annotations that pertain to a URI that is not available on the web. Specifically, it's confusing if one annotates a local PDF and then attempts to share a single annotation or a set of annotations on that PDF. Before these changes, the application would happily cook up a bouncer (sharing) link for you, but that link wouldn't do anything useful.

This PR replaces https://github.com/hypothesis/client/pull/2871

## With these changes...

These changes create a new UI path for both "share this page's annotations" and "share this annotation" when the page's URI or the annotation's URI (respectively) are not web-accessible.

When the page's URI is not web-accessible, using the share-this-page's-annotations button will now result in:

![image](https://user-images.githubusercontent.com/439947/104061454-9fb8e080-51c6-11eb-8164-ab65944bda2e.png)

When an annotation's URI is not web-accessible, using the share-this-annotation button will now result in:

![image](https://user-images.githubusercontent.com/439947/104061516-bd864580-51c6-11eb-9b2f-f153b12b724a.png)

The link provided, as explained, will go to the single-annotation view.

The "panel" that the share-this-annotation content shows up in has been slightly widened—from `20em` to `24em` (with a `max-width` of `85vw` to keep it from getting ungainly on narrow viewports). This accommodates the longer text needed to explain the not-available-in-context wording without risking that this panel on the first annotation in the list could overlap the top bar.

I manually tested that:

* When built into the local extension, local PDF files appropriately get the new, unshareable treatment.
* When built into the local extension, web-hosted PDF files still allow sharing correctly.

Fixes #2786