### PR TITLE
Refine design and loading state for `NotebookResultCount`

### DIFF
--- a/src/sidebar/components/notebook-result-count.js
+++ b/src/sidebar/components/notebook-result-count.js
@@ -4,20 +4,27 @@ import useRootThread from './hooks/use-root-thread';
 import { useStoreProxy } from '../store/use-store';
 import { countVisible } from '../util/thread';
 
+import Spinner from './spinner';
+
 /**
  * Render count of annotations (or filtered results) visible in the notebook view
  *
  * There are three possible overall states:
  * - No results (regardless of whether annotations are filtered): "No results"
  * - Annotations are unfiltered: "X threads (Y annotations)"
+ *     Thread count does not render until all annotations are loaded
  * - Annotations are filtered: "X results [(and Y more)]"
  */
 function NotebookResultCount() {
   const store = useStoreProxy();
+
   const forcedVisibleCount = store.forcedVisibleAnnotations().length;
   const hasAppliedFilter = store.hasAppliedFilter();
+  const resultCount = store.annotationResultCount();
+  const isLoading = store.isLoading();
+
   const rootThread = useRootThread();
-  const visibleCount = countVisible(rootThread);
+  const visibleCount = isLoading ? resultCount : countVisible(rootThread);
 
   const hasResults = rootThread.children.length > 0;
 
@@ -26,27 +33,30 @@ function NotebookResultCount() {
   const threadCount = rootThread.children.length;
 
   return (
-    <span className="notebook-result-count">
-      {!hasResults && <h2>No results</h2>}
-      {hasResults && hasAppliedFilter && (
-        <span>
-          <h2>
-            {matchCount} {matchCount === 1 ? 'result' : 'results'}
-          </h2>
-          {hasForcedVisible && <em> (and {forcedVisibleCount} more)</em>}
-        </span>
+    <div className="notebook-result-count u-layout-row">
+      {isLoading && <Spinner />}
+      {!isLoading && (
+        <h2>
+          {!hasResults && <span>No results</span>}
+          {hasResults && hasAppliedFilter && (
+            <span>
+              {matchCount} {matchCount === 1 ? 'result' : 'results'}
+            </span>
+          )}
+          {hasResults && !hasAppliedFilter && (
+            <span>
+              {threadCount} {threadCount === 1 ? 'thread' : 'threads'}
+            </span>
+          )}
+        </h2>
       )}
-      {hasResults && !hasAppliedFilter && (
-        <span>
-          <h2>
-            {threadCount} {threadCount === 1 ? 'thread' : 'threads'}
-          </h2>{' '}
-          <em>
-            ({visibleCount} {visibleCount === 1 ? 'annotation' : 'annotations'})
-          </em>
-        </span>
+      {hasForcedVisible && <h3>(and {forcedVisibleCount} more)</h3>}
+      {!hasAppliedFilter && hasResults && (
+        <h3>
+          ({visibleCount} {visibleCount === 1 ? 'annotation' : 'annotations'})
+        </h3>
       )}
-    </span>
+    </div>
   );
 }
 

--- a/src/sidebar/components/notebook-view.js
+++ b/src/sidebar/components/notebook-view.js
@@ -43,7 +43,7 @@ function NotebookView({ loadAnnotationsService }) {
   return (
     <div className="notebook-view">
       <header className="notebook-view__heading">
-        <h1>{groupName}</h1>
+        <h1 className="notebook-view__group-name">{groupName}</h1>
       </header>
       <div className="notebook-view__filters">
         <NotebookFilters />

--- a/src/sidebar/components/test/notebook-result-count-test.js
+++ b/src/sidebar/components/test/notebook-result-count-test.js
@@ -6,6 +6,8 @@ import { $imports } from '../notebook-result-count';
 
 describe('NotebookResultCount', () => {
   let fakeCountVisible;
+  let fakeIsLoading;
+  let fakeAnnotationResultCount;
   let fakeUseRootThread;
   let fakeStore;
 
@@ -15,11 +17,15 @@ describe('NotebookResultCount', () => {
 
   beforeEach(() => {
     fakeCountVisible = sinon.stub().returns(0);
-    fakeUseRootThread = sinon.stub().returns({});
+    fakeUseRootThread = sinon.stub().returns({ children: [] });
+    fakeIsLoading = sinon.stub().returns(false);
+    fakeAnnotationResultCount = sinon.stub().returns(0);
 
     fakeStore = {
       forcedVisibleAnnotations: sinon.stub().returns([]),
       hasAppliedFilter: sinon.stub().returns(false),
+      isLoading: fakeIsLoading,
+      annotationResultCount: fakeAnnotationResultCount,
     };
 
     $imports.$mock({
@@ -58,17 +64,17 @@ describe('NotebookResultCount', () => {
       {
         thread: { children: [1] },
         visibleCount: 1,
-        expected: '1 thread (1 annotation)',
+        expected: '1 thread(1 annotation)',
       },
       {
         thread: { children: [1] },
         visibleCount: 2,
-        expected: '1 thread (2 annotations)',
+        expected: '1 thread(2 annotations)',
       },
       {
         thread: { children: [1, 2] },
         visibleCount: 2,
-        expected: '2 threads (2 annotations)',
+        expected: '2 threads(2 annotations)',
       },
     ].forEach(test => {
       it('should render a count of threads and annotations', () => {
@@ -100,7 +106,7 @@ describe('NotebookResultCount', () => {
         forcedVisible: [1],
         thread: { children: [1] },
         visibleCount: 3,
-        expected: '2 results (and 1 more)',
+        expected: '2 results(and 1 more)',
       },
     ].forEach(test => {
       it('should render a count of results', () => {
@@ -113,6 +119,29 @@ describe('NotebookResultCount', () => {
 
         assert.equal(wrapper.text(), test.expected);
       });
+    });
+  });
+
+  context('when loading', () => {
+    beforeEach(() => {
+      fakeIsLoading.returns(true);
+    });
+
+    it('shows a loading spinner', () => {
+      const wrapper = createComponent();
+      assert.isTrue(wrapper.find('Spinner').exists());
+    });
+
+    it('shows annotation count if there are any matching annotations being fetched', () => {
+      fakeUseRootThread.returns({ children: [1, 2] });
+      // Setting countVisible to something different to demonstrate that
+      // resultCount is used while loading
+      fakeCountVisible.returns(5);
+      fakeAnnotationResultCount.returns(2);
+
+      const wrapper = createComponent();
+
+      assert.equal(wrapper.text(), '(2 annotations)');
     });
   });
 });

--- a/src/sidebar/search-client.js
+++ b/src/sidebar/search-client.js
@@ -47,6 +47,7 @@ export default class SearchClient extends TinyEmitter {
     this._canceled = false;
     /** @type {Annotation[]} */
     this._results = [];
+    this._resultCount = null;
   }
 
   _getBatch(query, offset) {
@@ -90,6 +91,11 @@ export default class SearchClient extends TinyEmitter {
         }
 
         const chunk = results.rows.concat(results.replies || []);
+        if (self._resultCount === null) {
+          // Emit the result count (total) on first encountering it
+          self._resultCount = results.total;
+          self.emit('resultCount', self._resultCount);
+        }
         if (self._incremental) {
           self.emit('results', chunk);
         } else {
@@ -133,6 +139,7 @@ export default class SearchClient extends TinyEmitter {
    */
   get(query) {
     this._results = [];
+    this._resultCount = null;
     this._getBatch(query, 0);
   }
 

--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -50,6 +50,10 @@ export default function loadAnnotationsService(
 
     searchClient = new SearchClient(api.search, searchOptions);
 
+    searchClient.on('resultCount', resultCount => {
+      store.setAnnotationResultCount(resultCount);
+    });
+
     searchClient.on('results', results => {
       if (results.length) {
         store.addAnnotations(results);

--- a/src/sidebar/services/test/load-annotations-test.js
+++ b/src/sidebar/services/test/load-annotations-test.js
@@ -19,6 +19,8 @@ class FakeSearchClient extends EventEmitter {
         query.uri = ['http://www.example.com'];
       }
 
+      this.emit('resultCount', 2);
+
       for (let i = 0; i < query.uri.length; i++) {
         const uri = query.uri[i];
         this.emit('results', [{ id: uri + '123', group: query.group }]);
@@ -60,6 +62,7 @@ describe('loadAnnotationsService', () => {
       frames: sinon.stub(),
       removeAnnotations: sinon.stub(),
       savedAnnotations: sinon.stub(),
+      setAnnotationResultCount: sinon.stub(),
       updateFrameAnnotationFetchStatus: sinon.stub(),
     };
 
@@ -194,6 +197,16 @@ describe('loadAnnotationsService', () => {
       ].forEach(uri => {
         assert.calledWith(fakeStore.addAnnotations, [sinon.match({ id: uri })]);
       });
+    });
+
+    it('updates the expected result count in the store', () => {
+      fakeUris = ['http://example.com'];
+      const svc = createService();
+
+      svc.load({ groupId: fakeGroupId, uris: fakeUris });
+
+      assert.calledOnce(fakeStore.setAnnotationResultCount);
+      assert.calledWith(fakeStore.setAnnotationResultCount, 2);
     });
 
     it('updates annotation fetch status for all frames', () => {

--- a/src/sidebar/store/modules/activity.js
+++ b/src/sidebar/store/modules/activity.js
@@ -24,6 +24,11 @@ function init() {
      * Have annotations ever been fetched?
      */
     hasFetchedAnnotations: false,
+    /**
+     * The number of total annotation results the service reported as
+     * matching the most recent load/search request
+     */
+    annotationResultCount: null,
   };
 }
 
@@ -95,6 +100,12 @@ const update = {
       activeAnnotationFetches: state.activeAnnotationFetches - 1,
     };
   },
+
+  SET_ANNOTATION_RESULT_COUNT(state, action) {
+    return {
+      annotationResultCount: action.resultCount,
+    };
+  },
 };
 
 const actions = actionTypes(update);
@@ -131,7 +142,15 @@ function apiRequestFinished() {
   return { type: actions.API_REQUEST_FINISHED };
 }
 
+function setAnnotationResultCount(resultCount) {
+  return { type: actions.SET_ANNOTATION_RESULT_COUNT, resultCount };
+}
+
 /** Selectors */
+
+function annotationResultCount(state) {
+  return state.annotationResultCount;
+}
 
 function hasFetchedAnnotations(state) {
   return state.hasFetchedAnnotations;
@@ -182,6 +201,7 @@ export default storeModule({
     annotationSaveFinished,
     apiRequestStarted,
     apiRequestFinished,
+    setAnnotationResultCount,
   },
 
   selectors: {
@@ -189,5 +209,6 @@ export default storeModule({
     isLoading,
     isFetchingAnnotations,
     isSavingAnnotation,
+    annotationResultCount,
   },
 });

--- a/src/sidebar/store/modules/test/activity-test.js
+++ b/src/sidebar/store/modules/test/activity-test.js
@@ -215,4 +215,12 @@ describe('sidebar/store/modules/activity', () => {
       });
     });
   });
+
+  describe('#annotationResultCount', () => {
+    it('returns the result count from the last API search/load', () => {
+      assert.isNull(store.annotationResultCount());
+      store.setAnnotationResultCount(5);
+      assert.equal(store.annotationResultCount(), 5);
+    });
+  });
 });

--- a/src/sidebar/test/search-client-test.js
+++ b/src/sidebar/test/search-client-test.js
@@ -35,6 +35,16 @@ describe('SearchClient', () => {
     });
   });
 
+  it('emits "resultCount"', () => {
+    const client = new SearchClient(fakeSearchFn);
+    const onResultCount = sinon.stub();
+    client.on('resultCount', onResultCount);
+    client.get({ uri: 'http://example.com' });
+    return awaitEvent(client, 'end').then(() => {
+      assert.calledWith(onResultCount, RESULTS.length);
+    });
+  });
+
   it('emits "end" only once', () => {
     const client = new SearchClient(fakeSearchFn, { chunkSize: 2 });
     client.on('results', sinon.stub());
@@ -54,6 +64,17 @@ describe('SearchClient', () => {
     return awaitEvent(client, 'end').then(() => {
       assert.calledWith(onResults, RESULTS.slice(0, 2));
       assert.calledWith(onResults, RESULTS.slice(2, 4));
+    });
+  });
+
+  it('emits "resultCount" only once in incremental mode', () => {
+    const client = new SearchClient(fakeSearchFn, { chunkSize: 2 });
+    const onResultCount = sinon.stub();
+    client.on('resultCount', onResultCount);
+    client.get({ uri: 'http://example.com' });
+    return awaitEvent(client, 'end').then(() => {
+      assert.calledWith(onResultCount, RESULTS.length);
+      assert.calledOnce(onResultCount);
     });
   });
 

--- a/src/styles/sidebar/components/notebook-result-count.scss
+++ b/src/styles/sidebar/components/notebook-result-count.scss
@@ -1,0 +1,17 @@
+@use "../../variables" as var;
+@use "../../mixins/layout";
+
+.notebook-result-count {
+  @include layout.horizontal-rhythm;
+  font-size: var.$font-size--large;
+  // Normalize line height to ensure vertical stability (no jumping around)
+  line-height: 1;
+
+  & h2 {
+    font-weight: bold;
+  }
+
+  & h3 {
+    font-style: italic;
+  }
+}

--- a/src/styles/sidebar/components/notebook-view.scss
+++ b/src/styles/sidebar/components/notebook-view.scss
@@ -10,23 +10,8 @@
     'results'
     'items';
 
-  /* TODO: find a better place for these heading styles */
-  h1 {
-    display: inline;
-    font-size: var.$font-size--heading;
-    font-weight: bold;
-  }
-
-  h2 {
-    display: inline;
-    font-size: var.$font-size--subheading;
-    font-weight: bold;
-  }
-
   &__heading {
     grid-area: heading;
-    font-size: var.$font-size--heading;
-    font-weight: bold;
   }
 
   &__filters {
@@ -41,6 +26,11 @@
     grid-area: items;
   }
 
+  &__group-name {
+    font-size: var.$font-size--heading;
+    font-weight: bold;
+  }
+
   @include responsive.tablet-and-up {
     grid-template-areas:
       'heading heading'
@@ -52,7 +42,9 @@
     }
 
     &__results {
+      // Align right and bottom
       justify-self: end;
+      align-self: flex-end;
     }
   }
 }

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -40,6 +40,7 @@
 @use './components/menu-section';
 @use './components/moderation-banner';
 @use './components/notebook-view';
+@use './components/notebook-result-count';
 @use './components/selection-tabs';
 @use './components/share-annotations-panel';
 @use './components/search-input';


### PR DESCRIPTION
Redesign the results count for the notebook to better handle its behavior when loading (sometimes large) sets of annotations.

## Before

Before these changes, annotation and thread counts would increment as batches of annotations were retrieved:

![loading-affordance](https://user-images.githubusercontent.com/439947/104471115-76ae9c00-5588-11eb-8daa-b088e832fa74.gif)

## After

When loading:

* Render the total number of annotations we're retrieving from the service, as reported by the service as the `total` number in the batch
* Do not render thread counts as they cannot be determined until the full annotation set is present
* Render a small spinner as a visual hint that loading is still underway

On a 3G connection, this looks like:

![notebook-loading-3g](https://user-images.githubusercontent.com/439947/104471288-ab225800-5588-11eb-921b-fa884c3ad767.gif)

I'm sure more tuning could make this even better, but I've done the basics of making sure that nothing jumps around as things are loading in, etc.

Fixes #2864