### PR TITLE
Load notebook view correctly in extension

### DIFF
--- a/src/annotator/notebook.js
+++ b/src/annotator/notebook.js
@@ -34,7 +34,7 @@ export default class Notebook extends Delegator {
     this._groupId = null;
     this._prevGroupId = null;
 
-    this.container = document.createElement('div');
+    this.container = document.createElement('hypothesis-notebook');
     this.container.style.display = 'none';
     this.container.className = 'notebook-outer';
 

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -86,8 +86,8 @@ function autosave(autosaveService) {
 }
 
 // @inject
-function setupFrameSync(frameSync, isSidebar) {
-  if (isSidebar) {
+function setupFrameSync(frameSync, store) {
+  if (store.route() === 'sidebar') {
     frameSync.connect(true);
   }
 }
@@ -135,12 +135,6 @@ import { Injector } from '../shared/injector';
 function startApp(config) {
   const container = new Injector();
 
-  const isSidebar = !(
-    window.location.pathname.startsWith('/stream') ||
-    window.location.pathname.startsWith('/a/') ||
-    window.location.pathname.startsWith('/notebook')
-  );
-
   // Register services.
   container
     .register('analytics', analyticsService)
@@ -172,7 +166,6 @@ function startApp(config) {
   // that use them, since they don't depend on instances of other services.
   container
     .register('$window', { value: window })
-    .register('isSidebar', { value: isSidebar })
     .register('settings', { value: config });
 
   // Initialize services.

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -24,7 +24,6 @@ const DEFAULT_ORGANIZATION = {
 export default function groups(
   store,
   api,
-  isSidebar,
   serviceUrl,
   session,
   settings,
@@ -216,7 +215,7 @@ export default function groups(
     // Step 1: Get the URI of the active document, so we can fetch groups
     // associated with that document.
     let documentUri;
-    if (isSidebar) {
+    if (store.route() === 'sidebar') {
       documentUri = await getDocumentUriForGroupSearch();
     }
 

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -14,9 +14,21 @@ export default function router($window, store) {
     const pathSegments = path.slice(1).split('/');
     const params = queryString.parse($window.location.search);
 
+    // The extension puts client resources under `/client/` to separate them
+    // from extension-specific resources. Ignore this part.
+    if (pathSegments[0] === 'client') {
+      pathSegments.shift();
+    }
+
+    // Routes loaded from h have no file extensions (eg. `/a/:id`, `/notebook`).
+    //
+    // Routes loaded from custom builds or the Chrome extension may have a '.html'
+    // extension.
+    const mainSegment = pathSegments[0].replace(/\.html$/, '');
+
     let route;
 
-    switch (pathSegments[0]) {
+    switch (mainSegment) {
       case 'a':
         route = 'annotation';
         params.id = pathSegments[1] || '';

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -40,7 +40,6 @@ const dummyGroups = [
 describe('groups', function () {
   let fakeAuth;
   let fakeStore;
-  let fakeIsSidebar;
   let fakeSession;
   let fakeSettings;
   let fakeApi;
@@ -97,10 +96,10 @@ describe('groups', function () {
         setDirectLinkedGroupFetchFailed: sinon.stub(),
         clearDirectLinkedGroupFetchFailed: sinon.stub(),
         profile: sinon.stub().returns({ userid: null }),
+        route: sinon.stub().returns('sidebar'),
       }
     );
     fakeSession = sessionWithThreeGroups();
-    fakeIsSidebar = true;
     fakeApi = {
       annotation: {
         get: sinon.stub(),
@@ -137,7 +136,6 @@ describe('groups', function () {
     return groups(
       fakeStore,
       fakeApi,
-      fakeIsSidebar,
       fakeServiceUrl,
       fakeSession,
       fakeSettings,
@@ -482,7 +480,7 @@ describe('groups', function () {
 
     context('in the stream and single annotation page', () => {
       beforeEach(() => {
-        fakeIsSidebar = false;
+        fakeStore.route.returns('stream');
       });
 
       it('does not wait for the document URL', () => {

--- a/src/sidebar/services/test/router-test.js
+++ b/src/sidebar/services/test/router-test.js
@@ -2,11 +2,14 @@ import EventEmitter from 'tiny-emitter';
 import router from '../router';
 
 const fixtures = [
+  // Sidebar for the embedded Hypothesis client.
   {
     path: '/app.html',
     route: 'sidebar',
     params: {},
   },
+
+  // Pages in "h" where the content is the client app.
   {
     path: '/notebook',
     route: 'notebook',
@@ -22,6 +25,18 @@ const fixtures = [
     search: 'q=foobar',
     route: 'stream',
     params: { q: 'foobar' },
+  },
+
+  // Browser extension.
+  {
+    path: '/client/app.html',
+    route: 'sidebar',
+    params: {},
+  },
+  {
+    path: '/client/notebook.html',
+    route: 'notebook',
+    params: {},
   },
 ];
 
@@ -71,8 +86,9 @@ describe('router', () => {
 
   describe('#navigate', () => {
     fixtures.forEach(({ path, search, route, params }) => {
-      if (route === 'sidebar') {
-        // You can't navigate _to_ the sidebar from another route.
+      // Skip scenarios where the app launches with a single route and cannot
+      // be navigated elsewhere afterwards.
+      if (route === 'sidebar' || path.startsWith('/client/')) {
         return;
       }
 


### PR DESCRIPTION
When the app launches the `router` service sets the initial route based on the path. When the notebook view is loaded from the extension the path is `/client/notebook.html` rather than `/notebook`. This PR updates the `router` service to match
the `/client/notebook.html` path to the `notebook` route.

In the process of fixing this I found an issue where the notebook's outer `<div>` was mis-positioned due to generic styles on https://example.com. I fixed this by changing the tag to `<hypothesis-notebook>` following the example of other UI elements created by the annotator.

Fixes https://github.com/hypothesis/client/issues/2866.

----

**Before:**

<img width="948" alt="Extension notebook before" src="https://user-images.githubusercontent.com/2458/104743089-321b3000-5743-11eb-94b1-4947972627d0.png">

**After:**

<img width="950" alt="Extension notebook after" src="https://user-images.githubusercontent.com/2458/104743135-4101e280-5743-11eb-87e5-75e8d6744714.png">
