### PR TITLE
Accommodate sorting of "headless" threads

### DIFF
--- a/src/sidebar/util/test/thread-annotations-test.js
+++ b/src/sidebar/util/test/thread-annotations-test.js
@@ -1,6 +1,7 @@
 import * as annotationFixtures from '../../test/annotation-fixtures';
 import uiConstants from '../../ui-constants';
 import threadAnnotations from '../thread-annotations';
+import { sorters } from '../thread-sorters';
 import { $imports } from '../thread-annotations';
 import immutable from '../immutable';
 
@@ -100,71 +101,15 @@ describe('sidebar/utils/thread-annotations', () => {
     });
 
     describe('when sort order changes', () => {
-      function sortBy(annotations, sortCompareFn) {
-        return annotations.slice().sort((a, b) => {
-          if (sortCompareFn(a, b)) {
-            return -1;
-          }
-          return sortCompareFn(b, a) ? 1 : 0;
-        });
-      }
-
-      // Format TextPositionSelector for the given position `pos`
-      function targetWithPos(pos) {
-        return [
-          {
-            selector: [{ type: 'TextPositionSelector', start: pos }],
-          },
-        ];
-      }
-
-      const annotations = [
-        {
-          target: targetWithPos(1),
-          updated: 20,
-        },
-        {
-          target: targetWithPos(100),
-          updated: 100,
-        },
-        {
-          target: targetWithPos(50),
-          updated: 50,
-        },
-        {
-          target: targetWithPos(20),
-          updated: 10,
-        },
-      ];
-
-      [
-        {
-          order: 'Location',
-          expectedOrder: [0, 3, 2, 1],
-        },
-        {
-          order: 'Oldest',
-          expectedOrder: [3, 0, 2, 1],
-        },
-        {
-          order: 'Newest',
-          expectedOrder: [1, 2, 0, 3],
-        },
-      ].forEach(testCase => {
-        it(`sorts correctly when sorting by ${testCase.order}`, () => {
-          fakeThreadState.selection.sortKey = testCase.order;
+      ['Location', 'Oldest', 'Newest'].forEach(testCase => {
+        it(`uses the appropriate sorting function when sorting by ${testCase}`, () => {
+          fakeThreadState.selection.sortKey = testCase;
 
           threadAnnotations(fakeThreadState);
 
           // The sort compare fn passed to `buildThread`
           const sortCompareFn = fakeBuildThread.args[0][1].sortCompareFn;
-
-          // Sort the test annotations by the sort compare fn that would be
-          // used by `build-thread` and make sure it's as expected
-          const actualOrder = sortBy(annotations, sortCompareFn).map(annot =>
-            annotations.indexOf(annot)
-          );
-          assert.deepEqual(actualOrder, testCase.expectedOrder);
+          assert.equal(sortCompareFn, sorters[testCase]);
         });
       });
     });

--- a/src/sidebar/util/test/thread-sorters-test.js
+++ b/src/sidebar/util/test/thread-sorters-test.js
@@ -1,0 +1,123 @@
+import { sorters, $imports } from '../thread-sorters';
+
+describe('sidebar/util/thread-sorters', () => {
+  let fakeRootAnnotations;
+  let fakeLocation;
+
+  beforeEach(() => {
+    // The thread argument passed to `Newest` or `Oldest` sorting functions
+    // gets wrapped with an additional Array by `*RootAnnotationDate` before
+    // being passed on to `rootAnnotations`. This unwraps that extra array
+    // and returns the original first argument to `*RootAnnotationDate`
+    fakeRootAnnotations = sinon.stub().callsFake(threads => threads[0]);
+    fakeLocation = sinon.stub().callsFake(annotation => annotation.location);
+
+    $imports.$mock({
+      './annotation-metadata': { location: fakeLocation },
+      './thread': { rootAnnotations: fakeRootAnnotations },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  describe('sorting by newest annotation thread first', () => {
+    [
+      {
+        a: [{ updated: 40 }, { updated: 5 }],
+        b: [{ updated: 20 }, { updated: 3 }],
+        expected: -1,
+      },
+      {
+        a: [{ updated: 20 }, { updated: 3 }],
+        b: [{ updated: 20 }, { updated: 3 }],
+        expected: 0,
+      },
+      {
+        a: [{ updated: 20 }, { updated: 3 }],
+        b: [{ updated: 40 }, { updated: 5 }],
+        expected: 1,
+      },
+    ].forEach(testCase => {
+      it('sorts by newest updated root annotation', () => {
+        // Disable eslint: `sorters` properties start with capital letters
+        // to match their displayed sort option values
+        /* eslint-disable-next-line new-cap */
+        assert.equal(sorters.Newest(testCase.a, testCase.b), testCase.expected);
+      });
+    });
+  });
+
+  describe('sorting by oldest annotation thread first', () => {
+    [
+      {
+        a: [{ updated: 20 }, { updated: 5 }],
+        b: [{ updated: 40 }, { updated: 3 }],
+        expected: 1,
+      },
+      {
+        a: [{ updated: 20 }, { updated: 3 }],
+        b: [{ updated: 20 }, { updated: 3 }],
+        expected: 0,
+      },
+      {
+        a: [{ updated: 40 }, { updated: 3 }],
+        b: [{ updated: 20 }, { updated: 5 }],
+        expected: -1,
+      },
+    ].forEach(testCase => {
+      it('sorts by oldest updated root annotation', () => {
+        // Disable eslint: `sorters` properties start with capital letters
+        // to match their displayed sort option values
+        /* eslint-disable-next-line new-cap */
+        assert.equal(sorters.Oldest(testCase.a, testCase.b), testCase.expected);
+      });
+    });
+  });
+
+  describe('sorting by document location', () => {
+    [
+      {
+        a: { annotation: { location: 5 } },
+        b: { annotation: { location: 10 } },
+        expected: -1,
+      },
+      {
+        a: { annotation: { location: 10 } },
+        b: { annotation: { location: 10 } },
+        expected: 0,
+      },
+      {
+        a: { annotation: { location: 10 } },
+        b: { annotation: { location: 5 } },
+        expected: 1,
+      },
+      {
+        a: {},
+        b: { annotation: { location: 5 } },
+        expected: -1,
+      },
+      {
+        a: {},
+        b: {},
+        expected: 0,
+      },
+      {
+        a: { annotation: { location: 10 } },
+        b: {},
+        expected: 1,
+      },
+    ].forEach(testCase => {
+      it('sorts by annotation location', () => {
+        assert.equal(
+          // Disable eslint: `sorters` properties start with capital letters
+          // to match their displayed sort option values
+          /* eslint-disable-next-line new-cap */
+          sorters.Location(testCase.a, testCase.b),
+          testCase.expected
+        );
+      });
+    });
+  });
+});

--- a/src/sidebar/util/test/thread-test.js
+++ b/src/sidebar/util/test/thread-test.js
@@ -51,4 +51,45 @@ describe('sidebar/util/thread', () => {
       assert.equal(threadUtil.countHidden(thread), 3);
     });
   });
+
+  describe('rootAnnotations', () => {
+    it("returns all of the annotations in the thread's child threads if there is at least one annotation present", () => {
+      const fixture = {
+        children: [
+          { annotation: 1, children: [] },
+          { children: [] },
+          { annotation: 2, children: [] },
+        ],
+      };
+      assert.deepEqual(threadUtil.rootAnnotations(fixture.children), [1, 2]);
+    });
+
+    it('returns all of the annotations at the first depth that has any annotations', () => {
+      const fixture = {
+        children: [
+          {
+            children: [
+              { annotation: 1, children: [] },
+              { children: [] },
+              { annotation: 2, children: [] },
+            ],
+          },
+          { children: [{ children: [{ annotation: 3, children: [] }] }] },
+          { children: [{ annotation: 4, children: [] }] },
+        ],
+      };
+
+      assert.deepEqual(threadUtil.rootAnnotations(fixture.children), [1, 2, 4]);
+    });
+
+    it('throws an exception if fed a thread hierarchy with no annotations', () => {
+      const fixture = {
+        children: [{ children: [{ children: [] }] }],
+      };
+
+      assert.throws(() => {
+        threadUtil.rootAnnotations(fixture.children);
+      }, /Thread contains no annotations/);
+    });
+  });
 });

--- a/src/sidebar/util/thread-annotations.js
+++ b/src/sidebar/util/thread-annotations.js
@@ -1,13 +1,13 @@
 import buildThread from './build-thread';
 import memoize from './memoize';
-import * as metadata from './annotation-metadata';
 import { generateFacetedFilter } from './search-filter';
 import filterAnnotations from './view-filter';
 import { shouldShowInTab } from './tabs';
+import { sorters } from './thread-sorters';
 
 /** @typedef {import('../../types/api').Annotation} Annotation */
 /** @typedef {import('./build-thread').Thread} Thread */
-/** @typedef {import('./build-thread').Options} BuildThreadOptions */
+/** @typedef {import('./build-thread').BuildThreadOptions} BuildThreadOptions */
 
 /**
  * @typedef ThreadState
@@ -23,19 +23,6 @@ import { shouldShowInTab } from './tabs';
  * @prop {string|null} route
  */
 
-// Sort functions keyed on sort option
-const sortFns = {
-  Newest: function (a, b) {
-    return a.updated > b.updated;
-  },
-  Oldest: function (a, b) {
-    return a.updated < b.updated;
-  },
-  Location: function (a, b) {
-    return metadata.location(a) < metadata.location(b);
-  },
-};
-
 /**
  * Cobble together the right set of options and filters based on current
  * `threadState` to build the root thread.
@@ -46,12 +33,11 @@ const sortFns = {
 function buildRootThread(threadState) {
   const selection = threadState.selection;
 
-  /** @type {Partial<BuildThreadOptions>} */
   const options = {
     expanded: selection.expanded,
     forcedVisible: selection.forcedVisible,
     selected: selection.selected,
-    sortCompareFn: sortFns[selection.sortKey],
+    sortCompareFn: sorters[selection.sortKey],
   };
 
   // Is there a filter query present, or an applied user (focus) filter?

--- a/src/sidebar/util/thread-sorters.js
+++ b/src/sidebar/util/thread-sorters.js
@@ -1,0 +1,94 @@
+import { location } from './annotation-metadata';
+import { rootAnnotations } from './thread';
+
+/** @typedef {import('./build-thread').Thread} Thread */
+
+/**
+ * Sort comparison function when one or both threads being compared is lacking
+ * an annotation.
+ * Sort such that a thread without an annotation sorts to the top
+ *
+ * @param {Thread} a
+ * @param {Thread} b
+ * @return {number}
+ */
+function compareHeadlessThreads(a, b) {
+  if (!a.annotation && !b.annotation) {
+    return 0;
+  } else {
+    return !a.annotation ? -1 : 1;
+  }
+}
+
+/**
+ * Find the most recent updated date amongst a thread's root annotation set
+ *
+ * @param {Thread} thread
+ * @return {string}
+ */
+function newestRootAnnotationDate(thread) {
+  const annotations = rootAnnotations([thread]);
+  return annotations.reduce(
+    (newestDate, annotation) =>
+      annotation.updated > newestDate ? annotation.updated : newestDate,
+    ''
+  );
+}
+
+/**
+ * Find the oldest updated date amongst a thread's root annotation set
+ *
+ * @param {Thread} thread
+ * @return {string}
+ */
+function oldestRootAnnotationDate(thread) {
+  const annotations = rootAnnotations([thread]);
+  return annotations.reduce((oldestDate, annotation) => {
+    if (!oldestDate) {
+      oldestDate = annotation.updated;
+    }
+    return annotation.updated < oldestDate ? annotation.updated : oldestDate;
+  }, '');
+}
+
+/**
+ * Sorting comparison functions for the three defined application options for
+ * sorting annotation (threads)
+ */
+export const sorters = {
+  Newest: function (a, b) {
+    const dateA = newestRootAnnotationDate(a);
+    const dateB = newestRootAnnotationDate(b);
+    if (dateA > dateB) {
+      return -1;
+    } else if (dateA < dateB) {
+      return 1;
+    }
+    return 0;
+  },
+
+  Oldest: function (a, b) {
+    const dateA = oldestRootAnnotationDate(a);
+    const dateB = oldestRootAnnotationDate(b);
+    if (dateA < dateB) {
+      return -1;
+    } else if (dateA > dateB) {
+      return 1;
+    }
+    return 0;
+  },
+
+  Location: function (a, b) {
+    if (!a.annotation || !b.annotation) {
+      return compareHeadlessThreads(a, b);
+    }
+    const aLocation = location(a.annotation);
+    const bLocation = location(b.annotation);
+    if (aLocation < bLocation) {
+      return -1;
+    } else if (aLocation > bLocation) {
+      return 1;
+    }
+    return 0;
+  },
+};

--- a/src/sidebar/util/thread.js
+++ b/src/sidebar/util/thread.js
@@ -1,3 +1,6 @@
+import { notNull } from './typing';
+
+/** @typedef {import('../../types/api').Annotation} Annotation */
 /** @typedef {import('../util/build-thread').Thread} Thread */
 
 /**
@@ -30,4 +33,59 @@ export function countHidden(thread) {
  */
 export function countVisible(thread) {
   return countByVisibility(thread, true);
+}
+
+/**
+ * Find the topmost annotations in a thread.
+ *
+ * For the (vast) majority of threads, this is the single annotation at the
+ * top level of the thread hierarchy.
+ *
+ * However, when the top-level thread lacks
+ * an annotation, as is the case if that annotation has been deleted but still
+ * has replies, find the first level of descendants that has at least one
+ * annotation (reply) and return the set of annotations (replies) at that level.
+ *
+ * For example, given the (overly-complex) thread-annotation structure of:
+ *
+ * [missing]
+ *   - [missing]
+ *       - reply 1
+ *            - reply 2
+ *            - reply 3
+ *       - reply 4
+ *   - [missing]
+ *       - reply 5
+ *   - [missing]
+ *      - [missing]
+ *          - reply 6
+ *
+ * Return [reply 1, reply 4, reply 5]
+ *
+ * @param {Thread[]} threads
+ * @return {Annotation[]}
+ */
+export function rootAnnotations(threads) {
+  // If there are any threads at this level with extant annotations, return
+  // those annotations
+  const threadAnnotations = threads
+    .filter(thread => !!thread.annotation)
+    .map(thread => notNull(thread.annotation));
+
+  if (threadAnnotations.length) {
+    return threadAnnotations;
+  }
+
+  // Else, search across all children at once (an entire hierarchical level)
+  const allChildren = [];
+  threads.forEach(thread => {
+    if (thread.children) {
+      allChildren.push(...thread.children);
+    }
+  });
+  if (allChildren.length) {
+    return rootAnnotations(allChildren);
+  }
+
+  throw new Error('Thread contains no annotations');
 }


### PR DESCRIPTION
Refactor sorting functions to operate on threads instead of annotations. This allows the sorting of threads that are missing an annotation at their topmost level ("headless" threads).

## User-facing changes

None in sidebar. In the Notebook, headless annotations are now chronologically sorted into the set of annotations based on the most-recent updated date of their topmost-level replies.

## Changes

* Comparison functions operate on `{Thread}` objects instead of `{Annotation}` objects
* Comparison functions now return `{number}` instead of `{boolean}` (i.e. adhere to `Array.prototype.sort()` `compareFn` API).
* These changes introduce a new utility module, `thread-sorting`, to serve as a home for the fleshed-out thread sorting functions. This clarifies `thread-annotations` more. I'm not married to the current module organization by any means.
* These changes also clean up some typing complexity vis-a-vis `BuildThreadOptions` and eliminates the wholesale "default options" approach from before.
