### PR TITLE
Revert "Bump commander from 6.2.1 to 7.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chance": "^1.0.13",
     "classnames": "^2.2.4",
     "codecov": "^3.1.0",
-    "commander": "^7.0.0",
+    "commander": "^6.0.0",
     "core-js": "^3.4.1",
     "cross-env": "^7.0.0",
     "diff": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2406,10 +2406,10 @@ commander@^2.19.0, commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-7.0.0.tgz#3e2bbfd8bb6724760980988fb5b22b7ee6b71ab2"
-  integrity sha512-ovx/7NkTrnPuIV8sqk/GjUIIM1+iUQeqA3ye2VNpq9sVoiZsooObWlQy+OPWGI17GDaEoybuAGJm6U8yC077BA==
+commander@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 commander@~2.11.0:
   version "2.11.0"


### PR DESCRIPTION
Reverts hypothesis/client#2889

This broke the `scripts/deploy-to-s3.js` script: https://jenkins.hypothes.is/job/client/job/master/2534/console.