### PR TITLE
Memoize `Annotation` and `Thread` components

### DIFF
--- a/src/sidebar/components/thread-card.js
+++ b/src/sidebar/components/thread-card.js
@@ -56,6 +56,13 @@ function ThreadCard({ frameSync, thread }) {
     return !!target.closest('button') || !!target.closest('a');
   };
 
+  // Memoize threads to reduce avoid re-rendering when something changes in a
+  // parent component but the `Thread` itself has not changed.
+  const threadContent = useMemo(
+    () => <Thread thread={thread} showDocumentInfo={showDocumentInfo} />,
+    [thread, showDocumentInfo]
+  );
+
   return (
     /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
     <div
@@ -73,7 +80,7 @@ function ThreadCard({ frameSync, thread }) {
         'is-focused': isFocused,
       })}
     >
-      <Thread thread={thread} showDocumentInfo={showDocumentInfo} />
+      {threadContent}
     </div>
   );
 }

--- a/src/sidebar/components/thread.js
+++ b/src/sidebar/components/thread.js
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import { createElement, Fragment } from 'preact';
+import { useMemo } from 'preact/hooks';
 
 import propTypes from 'prop-types';
 import { useStoreProxy } from '../store/use-store';
@@ -53,6 +54,30 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
   const onToggleReplies = () =>
     store.setExpanded(thread.id, !!thread.collapsed);
 
+  // Memoize annotation content to avoid re-rendering an annotation when content
+  // in other annotations/threads change.
+  const annotationContent = useMemo(
+    () =>
+      showAnnotation && (
+        <Fragment>
+          <ModerationBanner annotation={thread.annotation} />
+          <Annotation
+            annotation={thread.annotation}
+            replyCount={thread.replyCount}
+            showDocumentInfo={showDocumentInfo}
+            threadIsCollapsed={thread.collapsed}
+          />
+        </Fragment>
+      ),
+    [
+      showAnnotation,
+      thread.annotation,
+      thread.replyCount,
+      showDocumentInfo,
+      thread.collapsed,
+    ]
+  );
+
   return (
     <section
       className={classnames('thread', {
@@ -72,17 +97,7 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
       )}
 
       <div className="thread__content">
-        {showAnnotation && (
-          <Fragment>
-            <ModerationBanner annotation={thread.annotation} />
-            <Annotation
-              annotation={thread.annotation}
-              replyCount={thread.replyCount}
-              showDocumentInfo={showDocumentInfo}
-              threadIsCollapsed={thread.collapsed}
-            />
-          </Fragment>
-        )}
+        {annotationContent}
 
         {!thread.annotation && (
           <div className="thread__unavailable-message">


### PR DESCRIPTION
Typing in replies in large threads (eg. those that already have hundres
of replies) was slow because every keystroke would cause every
reply to be re-rendered. The critical thread list virtualization
optimization in the client only applies to top-level threads and doesn't
benefit the case of a single thread with a large number of replies.

Implement some easy performance optimizations for large threads (ie.
with hundreds of replies) by memoizing:

 1) `Thread` components so that they don't re-render if something
    changes in a parent but the thread itself is unchanged.
 2) `Annotation` components so that they don't re-render if something
    changes elsewhere in the thread list but the current annotation is not
    changed.

As a result, creating and editing replies in large threads is faster. The
initial action to show a large thread list by clicking "Show replies" is still
slow because this change doesn't help the initial render. However,
editing performance is the most important issue from a user's
perspective.

Partial fix for #2897