### PR TITLE
Sidebar on window resize

### DIFF
--- a/src/annotator/pdf-sidebar.js
+++ b/src/annotator/pdf-sidebar.js
@@ -20,7 +20,7 @@ const MIN_PDF_WIDTH = 680;
 
 export default class PdfSidebar extends Sidebar {
   constructor(element, config) {
-    super(element, { ...defaultConfig, ...config });
+    super(element, { ...defaultConfig, ...config }, false);
 
     this._lastSidebarLayoutState = {
       expanded: false,
@@ -36,7 +36,8 @@ export default class PdfSidebar extends Sidebar {
     this.sideBySideActive = false;
 
     this.subscribe('sidebarLayoutChanged', state => this.fitSideBySide(state));
-    this.window.addEventListener('resize', () => this.fitSideBySide());
+
+    this._registerEvent(window, 'resize', () => this.fitSideBySide());
   }
 
   /**

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -174,7 +174,7 @@ describe('Sidebar', () => {
 
   describe('toolbar buttons', () => {
     it('shows or hides sidebar when toolbar button is clicked', () => {
-      const sidebar = createSidebar({});
+      const sidebar = createSidebar();
       sinon.stub(sidebar, 'show');
       sinon.stub(sidebar, 'hide');
 
@@ -186,7 +186,7 @@ describe('Sidebar', () => {
     });
 
     it('shows or hides highlights when toolbar button is clicked', () => {
-      const sidebar = createSidebar({});
+      const sidebar = createSidebar();
       sinon.stub(sidebar, 'setAllVisibleHighlights');
 
       FakeToolbarController.args[0][1].setHighlightsVisible(true);
@@ -198,7 +198,7 @@ describe('Sidebar', () => {
     });
 
     it('creates an annotation when toolbar button is clicked', () => {
-      const sidebar = createSidebar({});
+      const sidebar = createSidebar();
       sinon.stub(sidebar, 'createAnnotation');
 
       FakeToolbarController.args[0][1].createAnnotation();
@@ -312,7 +312,7 @@ describe('Sidebar', () => {
       });
 
       it('does not crash if there is no services', () => {
-        createSidebar({}); // No config.services
+        createSidebar(); // No config.services
         emitEvent(events.LOGIN_REQUESTED);
       });
 
@@ -372,7 +372,7 @@ describe('Sidebar', () => {
     let sidebar;
 
     beforeEach(() => {
-      sidebar = createSidebar({});
+      sidebar = createSidebar();
     });
 
     describe('panstart event', () => {
@@ -469,7 +469,7 @@ describe('Sidebar', () => {
     });
 
     it('does not show the sidebar if not configured to.', () => {
-      const sidebar = createSidebar({});
+      const sidebar = createSidebar();
       const show = sandbox.stub(sidebar, 'show');
       sidebar.publish('panelReady');
       assert.notCalled(show);
@@ -480,7 +480,7 @@ describe('Sidebar', () => {
     let sidebar;
 
     beforeEach(() => {
-      sidebar = createSidebar({});
+      sidebar = createSidebar();
     });
 
     it('the sidebar is destroyed and the frame is detached', () => {
@@ -534,7 +534,7 @@ describe('Sidebar', () => {
 
   describe('#setAllVisibleHighlights', () =>
     it('sets the state through crossframe and emits', () => {
-      const sidebar = createSidebar({});
+      const sidebar = createSidebar();
       sidebar.setAllVisibleHighlights(true);
       assert.calledWith(fakeCrossFrame.call, 'setVisibleHighlights', true);
     }));
@@ -545,8 +545,38 @@ describe('Sidebar', () => {
   });
 
   it('shows toolbar controls when using the default theme', () => {
-    createSidebar({});
+    createSidebar();
     assert.equal(fakeToolbar.useMinimalControls, false);
+  });
+
+  it('hides the sidebar if window is resized', () => {
+    const sidebar = createSidebar();
+    sidebar.show();
+    assert.isNotEmpty(sidebar.frame.style.marginLeft);
+
+    window.dispatchEvent(new Event('resize'));
+    assert.isEmpty(sidebar.frame.style.marginLeft);
+  });
+
+  describe('register/unregister events', () => {
+    it('triggers registered event listener', () => {
+      const sidebar = createSidebar();
+      const listener = sinon.stub();
+      sidebar._registerEvent(window, 'resize', listener);
+
+      window.dispatchEvent(new Event('resize'));
+      assert.calledOnce(listener);
+    });
+
+    it('unregisters event listeners', () => {
+      const sidebar = createSidebar();
+      const listener = sinon.stub();
+      sidebar._registerEvent(window, 'resize', listener);
+      sidebar.destroy();
+
+      window.dispatchEvent(new Event('resize'));
+      assert.notCalled(listener);
+    });
   });
 
   describe('layout change notifier', () => {


### PR DESCRIPTION
Hide sidebar when browser window is resized

Currently, if the client's sidebar is opened it doesn't behave
graciously when the browser window is resized. Sometimes the sidebar
appears floating on the middle of the window.
    
We [discussed](https://hypothes-is.slack.com/archives/C1M8NH76X/p1610728400038200) several alternative solutions. When the sidebar is opened and the window is resized, then:
    
1. close the sidebar and the user opens it manually
2. maintain the sidebar open but scale it properly
3. close the sidebar and open it after X milliseconds of the last resize
       event
4. close the sidebar if the width of the window is reduced, but
       maintain it open if the window's width is increased
    
We implemented solution #1. However, this issue is still visible on the
PDF-sidebar. It would be great if the both sidebars (PDF and non-PDF)
have the same behaviour.

In addition, I added a mechanism to register and unregister events, to
avoid resource leaks.