### PR TITLE
Fix incorrect use of `hasClass` in `Button` test

### DIFF
--- a/src/sidebar/components/test/button-test.js
+++ b/src/sidebar/components/test/button-test.js
@@ -127,8 +127,8 @@ describe('Button', () => {
     const wrapper = createComponent({ className: 'my-class' });
 
     assert.isTrue(wrapper.find('button').hasClass('my-class'));
-    assert.isFalse(wrapper.hasClass('button--icon-only'));
-    assert.isFalse(wrapper.hasClass('button--labeled'));
+    assert.isFalse(wrapper.find('button').hasClass('button--icon-only'));
+    assert.isFalse(wrapper.find('button').hasClass('button--labeled'));
   });
 
   it('disables the button when `disabled` prop is true', () => {


### PR DESCRIPTION
The Enzyme `hasClass` method was being called on a non-DOM node by
mistake. This didn't cause any problems, but it just meant that the test
was not checking what it intended to check.