### PR TITLE
Use shadow DOM to encapsulate sidebar's style

### DIFF
--- a/src/annotator/delegator.js
+++ b/src/annotator/delegator.js
@@ -28,7 +28,7 @@ export default class Delegator {
    * Construct the `Delegator` instance.
    *
    * @param {HTMLElement} element
-   * @param {Object} [config]
+   * @param {Record<string, any>} [config]
    */
   constructor(element, config) {
     this.options = { ...config };

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -107,7 +107,7 @@ export default class Guest extends Delegator {
    * @param {HTMLElement} element -
    *   The root element in which the `Guest` instance should be able to anchor
    *   or create annotations. In an ordinary web page this typically `document.body`.
-   * @param {Object} config
+   * @param {Record<string, any>} config
    * @param {typeof htmlAnchoring} anchoring - Anchoring implementation
    */
   constructor(element, config, anchoring = htmlAnchoring) {

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -18,7 +18,6 @@ import iconSet from './icons';
 registerIcons(iconSet);
 
 import configFrom from './config/index';
-import BucketBarPlugin from './plugin/bucket-bar';
 import CrossFramePlugin from './plugin/cross-frame';
 import DocumentPlugin from './plugin/document';
 import Guest from './guest';
@@ -28,9 +27,6 @@ import PdfSidebar from './pdf-sidebar';
 import Sidebar from './sidebar';
 
 const pluginClasses = {
-  // UI plugins
-  BucketBar: BucketBarPlugin,
-
   // Document type plugins
   PDF: PDFPlugin,
   Document: DocumentPlugin,

--- a/src/annotator/pdf-sidebar.js
+++ b/src/annotator/pdf-sidebar.js
@@ -8,7 +8,6 @@ import Sidebar from './sidebar';
 const defaultConfig = {
   PDF: {},
   BucketBar: {
-    container: '.annotator-frame',
     scrollables: ['#viewerContainer'],
   },
 };
@@ -19,6 +18,10 @@ const defaultConfig = {
 const MIN_PDF_WIDTH = 680;
 
 export default class PdfSidebar extends Sidebar {
+  /**
+   * @param {HTMLElement} element
+   * @param {Record<string, any>} config
+   */
   constructor(element, config) {
     super(element, { ...defaultConfig, ...config });
 


### PR DESCRIPTION
A side effect of using shadow DOM for the sidebar is that the BucketBar
'plugin' cannot be injected easily using a current query mechanism.
After consulting with @robertknight, we decided to avoid using the
normal plugin injection mechanism and instead instantiate the BucketBar
from the sidebar.

This PR also includes:

- a (non documented) configuration option to disable the shadow DOM
  encapsulation. This can be removed in the future if not needed.
- more strict types
- simplification of the logic in the sidebar

I have tested these changes in the following browsers:

Brower\OS    | MacOS              | Windows
------------ | ------------------ | -----------------
Chrome 57    | :heavy_check_mark: | :heavy_check_mark:
Chrome beta  | :heavy_check_mark: | :heavy_check_mark:
Edge 17      |                    | :heavy_check_mark:
Edge beta    | :heavy_check_mark: | :heavy_check_mark:
Firefox 53   | :heavy_check_mark: | :heavy_check_mark:
Firefox beta | :heavy_check_mark: | :heavy_check_mark:
Safari 10    | :heavy_check_mark: |
Safari 14    | :heavy_check_mark: |