### PR TITLE
Remove unused classname

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -74,7 +74,7 @@ export default class Sidebar extends Guest {
     } else {
       frame = document.createElement('div');
       frame.style.display = 'none';
-      frame.className = 'annotator-frame annotator-outer';
+      frame.className = 'annotator-frame';
 
       if (config.theme === 'clean') {
         frame.classList.add('annotator-frame--theme-clean');


### PR DESCRIPTION
On doing some work on the sidebar, I found the sidebar has a classname
`.annotator-outer` which doesn't have any associated style.

I couldn't find any other references to `annotator-outer` in the
project.