### PR TITLE
Organize `config`-like modules out of top-level directory

### DIFF
--- a/src/sidebar/components/group-list.js
+++ b/src/sidebar/components/group-list.js
@@ -2,7 +2,7 @@ import { createElement } from 'preact';
 import { useMemo, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
-import serviceConfig from '../service-config';
+import serviceConfig from '../config/service-config';
 import { useStoreProxy } from '../store/use-store';
 import { isThirdPartyUser } from '../helpers/account-id';
 import { orgName } from '../helpers/group-list-item-common';

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -4,7 +4,7 @@ import { useEffect, useMemo } from 'preact/hooks';
 import propTypes from 'prop-types';
 
 import bridgeEvents from '../../shared/bridge-events';
-import serviceConfig from '../service-config';
+import serviceConfig from '../config/service-config';
 import { useStoreProxy } from '../store/use-store';
 import uiConstants from '../ui-constants';
 import { parseAccountID } from '../helpers/account-id';

--- a/src/sidebar/components/test/group-list-test.js
+++ b/src/sidebar/components/test/group-list-test.js
@@ -64,7 +64,7 @@ describe('GroupList', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../store/use-store': { useStoreProxy: () => fakeStore },
-      '../service-config': fakeServiceConfig,
+      '../config/service-config': fakeServiceConfig,
     });
   });
 

--- a/src/sidebar/components/test/hypothesis-app-test.js
+++ b/src/sidebar/components/test/hypothesis-app-test.js
@@ -80,7 +80,7 @@ describe('HypothesisApp', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../service-config': fakeServiceConfig,
+      '../config/service-config': fakeServiceConfig,
       '../store/use-store': { useStoreProxy: () => fakeStore },
       '../helpers/session': {
         shouldAutoDisplayTutorial: fakeShouldAutoDisplayTutorial,

--- a/src/sidebar/components/test/top-bar-test.js
+++ b/src/sidebar/components/test/top-bar-test.js
@@ -42,7 +42,7 @@ describe('TopBar', () => {
     $imports.$mock({
       '../store/use-store': { useStoreProxy: () => fakeStore },
       '../helpers/is-third-party-service': fakeIsThirdPartyService,
-      '../service-config': fakeServiceConfig,
+      '../config/service-config': fakeServiceConfig,
     });
   });
 

--- a/src/sidebar/components/test/user-menu-test.js
+++ b/src/sidebar/components/test/user-menu-test.js
@@ -60,7 +60,7 @@ describe('UserMenu', () => {
       '../helpers/account-id': {
         isThirdPartyUser: fakeIsThirdPartyUser,
       },
-      '../service-config': fakeServiceConfig,
+      '../config/service-config': fakeServiceConfig,
       '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });

--- a/src/sidebar/components/top-bar.js
+++ b/src/sidebar/components/top-bar.js
@@ -2,7 +2,7 @@ import { Fragment, createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import bridgeEvents from '../../shared/bridge-events';
-import serviceConfig from '../service-config';
+import serviceConfig from '../config/service-config';
 import { useStoreProxy } from '../store/use-store';
 import uiConstants from '../ui-constants';
 import isThirdPartyService from '../helpers/is-third-party-service';

--- a/src/sidebar/components/user-menu.js
+++ b/src/sidebar/components/user-menu.js
@@ -2,7 +2,7 @@ import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import bridgeEvents from '../../shared/bridge-events';
-import serviceConfig from '../service-config';
+import serviceConfig from '../config/service-config';
 import { isThirdPartyUser } from '../helpers/account-id';
 import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../service-context';

--- a/src/sidebar/config/fetch-config.js
+++ b/src/sidebar/config/fetch-config.js
@@ -1,5 +1,5 @@
 import getApiUrl from './get-api-url';
-import hostConfig from '../host-config';
+import hostConfig from './host-config';
 import * as postMessageJsonRpc from '../util/postmessage-json-rpc';
 
 /**

--- a/src/sidebar/config/fetch-config.js
+++ b/src/sidebar/config/fetch-config.js
@@ -1,10 +1,10 @@
-import getApiUrl from './config/get-api-url';
-import hostConfig from './host-config';
-import * as postMessageJsonRpc from './util/postmessage-json-rpc';
+import getApiUrl from './get-api-url';
+import hostConfig from '../host-config';
+import * as postMessageJsonRpc from '../util/postmessage-json-rpc';
 
 /**
- * @typedef {import('../types/config').SidebarConfig} SidebarConfig
- * @typedef {import('../types/config').MergedConfig} MergedConfig
+ * @typedef {import('../../types/config').SidebarConfig} SidebarConfig
+ * @typedef {import('../../types/config').MergedConfig} MergedConfig
  */
 
 /**

--- a/src/sidebar/config/get-api-url.js
+++ b/src/sidebar/config/get-api-url.js
@@ -1,4 +1,4 @@
-import serviceConfig from '../service-config';
+import serviceConfig from './service-config';
 
 /**
  * Function that returns apiUrl from the settings object.

--- a/src/sidebar/config/get-api-url.js
+++ b/src/sidebar/config/get-api-url.js
@@ -1,4 +1,4 @@
-import serviceConfig from './service-config';
+import serviceConfig from '../service-config';
 
 /**
  * Function that returns apiUrl from the settings object.

--- a/src/sidebar/config/host-config.js
+++ b/src/sidebar/config/host-config.js
@@ -4,9 +4,9 @@ import {
   toInteger,
   toObject,
   toString,
-} from '../shared/type-coercions';
+} from '../../shared/type-coercions';
 
-/** @typedef {import('../types/config').HostConfig} HostConfig */
+/** @typedef {import('../../types/config').HostConfig} HostConfig */
 
 /**
  * Return the app configuration specified by the frame embedding the Hypothesis

--- a/src/sidebar/config/service-config.js
+++ b/src/sidebar/config/service-config.js
@@ -1,6 +1,6 @@
 /**
- * @typedef {import('../types/config').HostConfig} HostConfig
- * @typedef {import('../types/config').Service} Service
+ * @typedef {import('../../types/config').HostConfig} HostConfig
+ * @typedef {import('../../types/config').Service} Service
  */
 
 /**

--- a/src/sidebar/config/test/fetch-config-test.js
+++ b/src/sidebar/config/test/fetch-config-test.js
@@ -1,6 +1,6 @@
 import { fetchConfig, $imports } from '../fetch-config';
 
-describe('sidebar/fetch-config', () => {
+describe('sidebar/config/fetch-config', () => {
   let fakeHostConfig;
   let fakeJsonRpc;
   let fakeWindow;
@@ -14,9 +14,9 @@ describe('sidebar/fetch-config', () => {
     };
     fakeApiUrl = sinon.stub().returns('https://dev.hypothes.is/api/');
     $imports.$mock({
-      './host-config': fakeHostConfig,
-      './util/postmessage-json-rpc': fakeJsonRpc,
-      './config/get-api-url': fakeApiUrl,
+      '../host-config': fakeHostConfig,
+      '../util/postmessage-json-rpc': fakeJsonRpc,
+      './get-api-url': fakeApiUrl,
     });
 
     // By default, embedder provides no custom config.
@@ -39,7 +39,7 @@ describe('sidebar/fetch-config', () => {
     $imports.$restore();
   });
 
-  describe('fetchConfig', () => {
+  describe('config/fetch-config', () => {
     context('direct embed', () => {
       // no `requestConfigFromFrame` variable
       //

--- a/src/sidebar/config/test/fetch-config-test.js
+++ b/src/sidebar/config/test/fetch-config-test.js
@@ -14,7 +14,7 @@ describe('sidebar/config/fetch-config', () => {
     };
     fakeApiUrl = sinon.stub().returns('https://dev.hypothes.is/api/');
     $imports.$mock({
-      '../host-config': fakeHostConfig,
+      './host-config': fakeHostConfig,
       '../util/postmessage-json-rpc': fakeJsonRpc,
       './get-api-url': fakeApiUrl,
     });

--- a/src/sidebar/config/test/get-api-url-test.js
+++ b/src/sidebar/config/test/get-api-url-test.js
@@ -1,8 +1,8 @@
 import getApiUrl from '../get-api-url';
 
-describe('sidebar/get-api-url', function () {
-  context('when there is a service object in settings', function () {
-    it('returns apiUrl from the service object', function () {
+describe('sidebar/config/get-api-url', () => {
+  context('when there is a service object in settings', () => {
+    it('returns apiUrl from the service object', () => {
       const settings = {
         apiUrl: 'someApiUrl',
         services: [
@@ -15,8 +15,8 @@ describe('sidebar/get-api-url', function () {
     });
   });
 
-  context('when there is no service object in settings', function () {
-    it('returns apiUrl from the settings object', function () {
+  context('when there is no service object in settings', () => {
+    it('returns apiUrl from the settings object', () => {
       const settings = {
         apiUrl: 'someApiUrl',
       };
@@ -27,7 +27,7 @@ describe('sidebar/get-api-url', function () {
   context(
     'when there is a service object in settings but does not contain an apiUrl key',
     function () {
-      it('throws error', function () {
+      it('throws error', () => {
         const settings = {
           apiUrl: 'someApiUrl',
           services: [{}],

--- a/src/sidebar/config/test/host-config-test.js
+++ b/src/sidebar/config/test/host-config-test.js
@@ -8,7 +8,7 @@ function fakeWindow(config) {
   };
 }
 
-describe('sidebar/host-config', function () {
+describe('sidebar/config/host-config', function () {
   it('parses config from location string and returns whitelisted params', function () {
     const window_ = fakeWindow({
       annotations: '1234',

--- a/src/sidebar/config/test/service-config-test.js
+++ b/src/sidebar/config/test/service-config-test.js
@@ -1,7 +1,7 @@
 import serviceConfig from '../service-config';
 
-describe('serviceConfig', function () {
-  it('returns null if services is not an array', function () {
+describe('config/service-config', () => {
+  it('returns null if services is not an array', () => {
     const settings = {
       services: 'someString',
     };
@@ -9,7 +9,7 @@ describe('serviceConfig', function () {
     assert.isNull(serviceConfig(settings));
   });
 
-  it('returns null if the settings object has no services', function () {
+  it('returns null if the settings object has no services', () => {
     const settings = {
       services: [],
     };
@@ -17,7 +17,7 @@ describe('serviceConfig', function () {
     assert.isNull(serviceConfig(settings));
   });
 
-  it('returns the first service in the settings object', function () {
+  it('returns the first service in the settings object', () => {
     const settings = {
       services: [
         {

--- a/src/sidebar/fetch-config.js
+++ b/src/sidebar/fetch-config.js
@@ -1,4 +1,4 @@
-import getApiUrl from './get-api-url';
+import getApiUrl from './config/get-api-url';
 import hostConfig from './host-config';
 import * as postMessageJsonRpc from './util/postmessage-json-rpc';
 

--- a/src/sidebar/helpers/annotation-sharing.js
+++ b/src/sidebar/helpers/annotation-sharing.js
@@ -3,7 +3,7 @@
  * @typedef {import('../../types/config').HostConfig} HostConfig
  */
 
-import serviceConfig from '../service-config';
+import serviceConfig from '../config/service-config';
 
 /**
  * Retrieve an appropriate sharing link for this annotation.

--- a/src/sidebar/helpers/groups.js
+++ b/src/sidebar/helpers/groups.js
@@ -4,7 +4,7 @@
  */
 
 import escapeStringRegexp from 'escape-string-regexp';
-import serviceConfig from '../service-config';
+import serviceConfig from '../config/service-config';
 
 /**
  * Should users be able to leave private groups of which they

--- a/src/sidebar/helpers/is-third-party-service.js
+++ b/src/sidebar/helpers/is-third-party-service.js
@@ -2,7 +2,7 @@
  * @typedef {import('../../types/config').MergedConfig} MergedConfig
  */
 
-import serviceConfig from '../service-config';
+import serviceConfig from '../config/service-config';
 
 /**
  * Return `true` if the first configured service is a "third-party" service.

--- a/src/sidebar/helpers/session.js
+++ b/src/sidebar/helpers/session.js
@@ -1,4 +1,4 @@
-import serviceConfig from '../service-config';
+import serviceConfig from '../config/service-config';
 
 /**
  * @typedef {import('../../types/config').HostConfig} HostConfig

--- a/src/sidebar/helpers/test/annotation-sharing-test.js
+++ b/src/sidebar/helpers/test/annotation-sharing-test.js
@@ -17,7 +17,7 @@ describe('sidebar/helpers/annotation-sharing', () => {
     };
 
     sharingUtil.$imports.$mock({
-      '../service-config': fakeServiceConfig,
+      '../config/service-config': fakeServiceConfig,
     });
   });
 

--- a/src/sidebar/helpers/test/groups-test.js
+++ b/src/sidebar/helpers/test/groups-test.js
@@ -6,7 +6,7 @@ describe('sidebar/helpers/groups', () => {
     beforeEach(() => {
       fakeServiceConfig = sinon.stub().returns(null);
       $imports.$mock({
-        '../service-config': fakeServiceConfig,
+        '../config/service-config': fakeServiceConfig,
       });
     });
 

--- a/src/sidebar/helpers/test/is-third-party-service-test.js
+++ b/src/sidebar/helpers/test/is-third-party-service-test.js
@@ -10,7 +10,7 @@ describe('sidebar/helpers/is-third-party-service', () => {
     fakeSettings = { authDomain: 'hypothes.is' };
 
     $imports.$mock({
-      '../service-config': fakeServiceConfig,
+      '../config/service-config': fakeServiceConfig,
     });
   });
 

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -9,7 +9,7 @@ import {
 } from './cross-origin-rpc.js';
 import addAnalytics from './ga';
 import disableOpenerForExternalLinks from './util/disable-opener-for-external-links';
-import { fetchConfig } from './fetch-config';
+import { fetchConfig } from './config/fetch-config';
 import * as sentry from './util/sentry';
 
 // Read settings rendered into sidebar app HTML by service/extension.

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -1,4 +1,4 @@
-import serviceConfig from '../service-config';
+import serviceConfig from '../config/service-config';
 import { isReply } from '../helpers/annotation-metadata';
 import { combineGroups } from '../helpers/groups';
 import { awaitStateChange } from '../store/util';

--- a/src/sidebar/services/oauth-auth.js
+++ b/src/sidebar/services/oauth-auth.js
@@ -1,6 +1,6 @@
 import { TinyEmitter } from 'tiny-emitter';
 
-import serviceConfig from '../service-config';
+import serviceConfig from '../config/service-config';
 import OAuthClient from '../util/oauth-client';
 import { resolve } from '../util/url';
 

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -1,4 +1,4 @@
-import serviceConfig from '../service-config';
+import serviceConfig from '../config/service-config';
 import * as retryUtil from '../util/retry';
 import * as sentry from '../util/sentry';
 

--- a/src/sidebar/services/test/session-test.js
+++ b/src/sidebar/services/test/session-test.js
@@ -56,7 +56,7 @@ describe('sidebar/services/session', function () {
     fakeToastMessenger = { error: sandbox.spy() };
 
     $imports.$mock({
-      '../service-config': fakeServiceConfig,
+      '../config/service-config': fakeServiceConfig,
       '../util/sentry': fakeSentry,
     });
 

--- a/src/sidebar/test/fetch-config-test.js
+++ b/src/sidebar/test/fetch-config-test.js
@@ -16,7 +16,7 @@ describe('sidebar/fetch-config', () => {
     $imports.$mock({
       './host-config': fakeHostConfig,
       './util/postmessage-json-rpc': fakeJsonRpc,
-      './get-api-url': fakeApiUrl,
+      './config/get-api-url': fakeApiUrl,
     });
 
     // By default, embedder provides no custom config.


### PR DESCRIPTION
There were half a dozen modules in the top-level directory that felt like they fit the theme of "config" or "settings". Thus they don't belong in `util` nor `helpers`, but I was going to see if moving them into a `config` directory would fly. The dependency graph is not muddied any further by this. Once again, I have zero attachment to the actual naming of the module directory. 

(NB: There are still some things in the top-level directory that I think could be moved, e.g. is there any reason `media-embedder` can't be a `util`? But leaving that aside for a moment and just focusing on these config-ish things).

What think y'all?