### PR TITLE
Fix minor mistakes in UI tests

### DIFF
--- a/src/sidebar/components/test/annotation-editor-test.js
+++ b/src/sidebar/components/test/annotation-editor-test.js
@@ -68,7 +68,7 @@ describe('AnnotationEditor', () => {
 
     const wrapper = createComponent();
 
-    assert.isEmpty(wrapper);
+    assert.equal(wrapper.html(), '');
   });
 
   describe('markdown content editor', () => {

--- a/src/sidebar/components/test/annotation-timestamps-test.js
+++ b/src/sidebar/components/test/annotation-timestamps-test.js
@@ -87,9 +87,10 @@ describe('AnnotationTimestamps', () => {
   });
 
   it('is updated after time passes', () => {
-    fakeTime.decayingInterval.callsFake((date, callback) =>
-      setTimeout(callback, 10)
-    );
+    fakeTime.decayingInterval.callsFake((date, callback) => {
+      const id = setTimeout(callback, 10);
+      return () => clearTimeout(id);
+    });
     const wrapper = createComponent();
     fakeTime.toFuzzyString.returns('60 jiffies');
 

--- a/src/sidebar/components/test/excerpt-test.js
+++ b/src/sidebar/components/test/excerpt-test.js
@@ -8,9 +8,9 @@ import { $imports } from '../excerpt';
 import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('Excerpt', () => {
-  const SHORT_DIV = <div id="foo" style="height: 5px;" />;
+  const SHORT_DIV = <div id="foo" style={{ height: 5 }} />;
   const TALL_DIV = (
-    <div id="foo" style="height: 200px;">
+    <div id="foo" style={{ height: 200 }}>
       foo bar
     </div>
   );

--- a/src/sidebar/components/test/filter-status-test.js
+++ b/src/sidebar/components/test/filter-status-test.js
@@ -84,7 +84,7 @@ describe('FilterStatus', () => {
   context('(State 1): no search filters active', () => {
     it('should return null if filter state indicates no active filters', () => {
       const wrapper = createComponent();
-      assert.isEmpty(wrapper);
+      assert.equal(wrapper.children().length, 0);
     });
   });
 


### PR DESCRIPTION
This PR fixes some mistakes / bad practices found in our existing tests while I was checking some upstream changes in the Enzyme adapter for Preact.

There are all cases where the tests happened to pass but either didn't do what was intended or are liable to break with changes in implementation details of the libraries we use.

- Don't use `assert.isEmpty(wrapper)` to test whether a render produced no output. This happens to always pass due to implementation details of a wrapper, but it doesn't do what is intended. Instead you either need to:
   - Check that the component produced no HTML output (`assert.equal(wrapper.html(), '')`). This is the easiest option if the component you are testing includes at least some direct HTML output. Alternatively:
   - Drill down to the component you are interested in and check that it has no children (`assert.equal(wrapper.find('MyWidget').children().length, 0)`)
- Always pass an object rather than a string as the value for the `style` prop. Preact currently supports passing a string as the value for `style` but this is a "non-standard" (in the sense that React doesn't support it) feature that is probably going away in future. The [React docs](https://reactjs.org/docs/dom-elements.html#style) mention that `style`'s lack of support for strings is a security feature.
- Fix an instance where a function that was passed to `useEffect` was mocked in a test in such a way that it returned a number instead of a cleanup function. This meant that a timeout could potentially not be properly cleaned up.