### PR TITLE
Add github action to publish frontend-shared package

### DIFF
--- a/.github/.eslintrc
+++ b/.github/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "parserOptions": {}
+}

--- a/.github/actions/frontend-shared-version/action.yml
+++ b/.github/actions/frontend-shared-version/action.yml
@@ -1,0 +1,18 @@
+name: 'Get Updated Package Version'
+inputs:
+  # The shared package name, "@hypothesis/frontend-shared"
+  shared-package:
+    required: true
+    default: ''
+    description: 'The npm package name'
+  # The client package name, "hypothesis"
+  parent-package:
+    required: true
+    default: ''
+    description: 'The npm package name'
+outputs:
+  updated_version:
+    description: 'The new version of the npm package'
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/.github/actions/frontend-shared-version/index.js
+++ b/.github/actions/frontend-shared-version/index.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const core = require('@actions/core');
+const util = require('util');
+
+const exec = util.promisify(require('child_process').exec);
+
+/**
+ * Returns true is there is a non-zero length diff between the last published version
+ * and master within the frontend-shared/ folder.
+ */
+async function haveChangesOccurred() {
+  const parentPackage = core.getInput('parent-package');
+  const versionResult = await exec(`npm view ${parentPackage}@latest version`);
+  const version = versionResult.stdout.trim();
+  const diffResult = await exec(`git diff --stat v${version}..master frontend-shared/`)
+  return diffResult.stdout.length > 0;
+}
+
+/**
+ * Increment the minor part of a `MAJOR.MINOR.PATCH` semver version.
+ */
+function bumpMinorVersion(version) {
+  const parts = version.split('.')
+  if (parts.length !== 3) {
+    throw new Error(`${version} is not a valid MAJOR.MINOR.PATCH version`);
+  }
+  const majorVersion = parseInt(parts[0]);
+  const newMinorVersion = parseInt(parts[1]) + 1;
+  const patchVersion = parseInt(parts[2]);
+  if (isNaN(majorVersion) || isNaN(newMinorVersion) || isNaN(patchVersion)) {
+    throw new Error(`${version} does not have valid integer parts`);
+  }
+  return `${parts[0]}.${newMinorVersion}.${parts[2]}`
+}
+
+/**
+ * Get the current version from npm and bump the minor part by 1.
+ */
+async function getNewVersion() {
+  const sharedPackage = core.getInput('shared-package');
+  const result = await exec(`npm view ${sharedPackage} version`);
+  const newVersion = bumpMinorVersion(result.stdout);
+  return newVersion;
+}
+
+async function main() {
+  if (await haveChangesOccurred()) {
+    // eslint-disable-next-line no-console
+    console.log('Changes detected in frontend-shared/, publishing new version...');
+    const newVersion = await getNewVersion();
+    core.setOutput("updated_version", newVersion);
+  } else {
+    // eslint-disable-next-line no-console
+    console.log('No changes detected in frontend-shared/');
+    core.setOutput("updated_version", null);
+  }
+}
+
+main().catch(error => {
+  core.setFailed(error.message);
+})
+

--- a/.github/workflows/frontend-shared.yml
+++ b/.github/workflows/frontend-shared.yml
@@ -1,0 +1,44 @@
+name: frontend-shared package
+on:
+  release:
+    types:
+      - published
+jobs:
+  update-frontend-shared-version:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    # Additionally fetch master to be able to diff for changes in the frontend-shared/ folder
+    - name: Fetch origin
+      run: git fetch origin master:master
+    # Setup .npmrc file to publish to npm
+    - name: Setup Nodejs
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Install client
+      run: yarn install --frozen-lockfile
+    - name: Get new version
+      uses: ./.github/actions/frontend-shared-version
+      id: version
+      with:
+        shared-package: '@hypothesis/frontend-shared'
+        parent-package: 'hypothesis'
+    - name: Set up frontend-shared
+      run: yarn setup-frontend-shared
+      # If updated_version is null, skip this step
+      if: ${{ steps.version.outputs.updated_version }}
+    - name: Set new version in package.json
+      working-directory: frontend-shared
+      run: yarn version --no-git-tag-version --new-version ${{ steps.version.outputs.updated_version }}
+      # If updated_version is null, skip this step
+      if: ${{ steps.version.outputs.updated_version }}
+    - name: Publish package
+      working-directory: frontend-shared
+      run: npm publish --access public
+      # If updated_version is null, skip this step
+      if: ${{ steps.version.outputs.updated_version }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "repository": "hypothesis/client",
   "dependencies": {},
   "devDependencies": {
+    "@actions/core": "^1.2.6",
     "@babel/core": "^7.1.6",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
@@ -118,7 +119,7 @@
   "main": "./build/boot.js",
   "scripts": {
     "build": "cross-env NODE_ENV=production gulp build",
-    "lint": "eslint .",
+    "lint": "eslint . .github",
     "checkformatting": "prettier --check '**/*.{js,scss}'",
     "format": "prettier --list-different --write '**/*.{js,scss}'",
     "test": "gulp test",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@actions/core@^1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.6.tgz#a78d49f41a4def18e88ce47c2cac615d5694bf09"
+  integrity sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"


### PR DESCRIPTION
Add custom github action to publish frontend-shared package …

Action will perform the following:
- Test if any changes to the frontend-shared/ folder have been made since the last release of the client (parent).
- If they have, then it will get the last published version of the frontend-shared package, add 1 to the number, and save new version to package.json file
- Build the frontend-shared for release
- Publish the frontend-shared package to npm
----------------

_updated_

depends on https://github.com/hypothesis/client/pull/2875

This PR is based on the github action docs for publishing a package to npm. https://docs.github.com/en/actions/guides/publishing-nodejs-packages 

The core difference is that this kicks off its own custom action that invokes nodejs and runs a file `index.js` inside the actions folder.  

It first checks to see if there are any actual changes to frontend-shared by looking at the diff. If there are, then it
bumps the minor number of the verison similar to our `Jenkins` file. 

I did test this out a number of times on a different event `[push]` and it did publish several versions to npmjs which is why the number is currently sitting at 1.4.0. I assume we could force this back to 1.0.0 if we wanted, but it didn't actually seem straightforward so I left it for now. -- TBD.

_I have not actually tested this on the "release" event the action is currently targeted to fire for, so that remains to be tested._ 

Foring the action to run on [push] will yield this result. To get it to actually publish a package, we will likely need to test this out on a release with an actual change in frontend-shared/. 

![Screen Shot 2021-01-28 at 11 15 13 AM](https://user-images.githubusercontent.com/3939074/106188486-dfd30980-615b-11eb-9089-1e60e811e64b.png)
