### PR TITLE
Provide access to replies in headless threads

### DIFF
--- a/src/sidebar/components/annotation-missing.js
+++ b/src/sidebar/components/annotation-missing.js
@@ -1,0 +1,65 @@
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
+
+import AnnotationReplyToggle from './annotation-reply-toggle';
+
+/**
+ * @typedef AnnotationMissingProps
+ * @prop {string} threadId
+ * @prop {boolean} isReply
+ * @prop {number} replyCount
+ * @prop {boolean} threadIsCollapsed
+ */
+
+/**
+ * Renders in place of an annotation if a thread's annotation is missing.
+ *
+ * @param {AnnotationMissingProps} props
+ */
+function AnnotationMissing({
+  isReply,
+  threadId,
+  replyCount,
+  threadIsCollapsed,
+}) {
+  const shouldShowReplyToggle = !isReply;
+  const isCollapsedReply = isReply && threadIsCollapsed;
+
+  return (
+    <article
+      className={classnames('annotation', 'annotation--missing', {
+        'is-collapsed': threadIsCollapsed,
+      })}
+    >
+      {!isCollapsedReply && (
+        <div>
+          <em>Message not available.</em>
+        </div>
+      )}
+
+      {!isCollapsedReply && (
+        <footer className="annotation__footer">
+          <div className="annotation__controls u-layout-row">
+            {shouldShowReplyToggle && (
+              <AnnotationReplyToggle
+                threadId={threadId}
+                replyCount={replyCount}
+                threadIsCollapsed={threadIsCollapsed}
+              />
+            )}
+          </div>
+        </footer>
+      )}
+    </article>
+  );
+}
+
+AnnotationMissing.propTypes = {
+  isReply: propTypes.bool.isRequired,
+  replyCount: propTypes.number.isRequired,
+  threadIsCollapsed: propTypes.bool,
+  threadId: propTypes.string.isRequired,
+};
+
+export default AnnotationMissing;

--- a/src/sidebar/components/annotation-reply-toggle.js
+++ b/src/sidebar/components/annotation-reply-toggle.js
@@ -1,0 +1,56 @@
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
+
+import { useStoreProxy } from '../store/use-store';
+
+import Button from './button';
+
+/**
+ * @typedef {import("../../types/api").Annotation} Annotation
+ */
+
+/**
+ * @typedef AnnotationReplyToggleProps
+ * @prop {string} threadId
+ * @prop {boolean} threadIsCollapsed
+ * @prop {number} replyCount
+ */
+
+/**
+ * Render a thread-card control to toggle (expand or collapse) all of this
+ * thread's children.
+ *
+ * @param {AnnotationReplyToggleProps} props
+ */
+function AnnotationReplyToggle({ threadId, threadIsCollapsed, replyCount }) {
+  const store = useStoreProxy();
+  const hasAppliedFilter = store.hasAppliedFilter();
+
+  const toggleAction = threadIsCollapsed ? 'Show replies' : 'Hide replies';
+  const toggleText = `${toggleAction} (${replyCount})`;
+
+  const onToggleReplies = () =>
+    store.setExpanded(/** @type {string} */ (threadId), !!threadIsCollapsed);
+
+  // Do not show the reply toggle if there is filtering going on, or if
+  // there are no replies to toggle.
+  if (hasAppliedFilter || replyCount < 1) {
+    return null;
+  }
+
+  return (
+    <Button
+      className="annotation__reply-toggle"
+      onClick={onToggleReplies}
+      buttonText={toggleText}
+    />
+  );
+}
+
+AnnotationReplyToggle.propTypes = {
+  threadId: propTypes.string.isRequired,
+  threadIsCollapsed: propTypes.bool.isRequired,
+  replyCount: propTypes.number,
+};
+
+export default AnnotationReplyToggle;

--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -11,7 +11,7 @@ import AnnotationBody from './annotation-body';
 import AnnotationEditor from './annotation-editor';
 import AnnotationHeader from './annotation-header';
 import AnnotationQuote from './annotation-quote';
-import Button from './button';
+import AnnotationReplyToggle from './annotation-reply-toggle';
 
 /**
  * @typedef {import("../../types/api").Annotation} Annotation
@@ -53,21 +53,11 @@ function Annotation({
 
   const isEditing = !!draft && !isSaving;
 
-  const toggleAction = threadIsCollapsed ? 'Show replies' : 'Hide replies';
-  const toggleText = `${toggleAction} (${replyCount})`;
-
   const shouldShowActions = !isSaving && !isEditing;
-  const shouldShowReplyToggle = replyCount > 0 && !isReply(annotation);
+  const threadId = /** @type {string} */ (annotation.id);
+  const shouldShowReplyToggle = !isReply(annotation) && threadId;
 
   const onReply = () => annotationsService.reply(annotation, userid);
-
-  const onToggleReplies = () =>
-    // nb. We assume the annotation has an ID here because it is not possible
-    // to create replies until the annotation has been saved.
-    store.setExpanded(
-      /** @type {string} */ (annotation.id),
-      !!threadIsCollapsed
-    );
 
   return (
     <article
@@ -99,10 +89,10 @@ function Annotation({
         <footer className="annotation__footer">
           <div className="annotation__controls u-layout-row">
             {shouldShowReplyToggle && (
-              <Button
-                className="annotation__reply-toggle"
-                onClick={onToggleReplies}
-                buttonText={toggleText}
+              <AnnotationReplyToggle
+                threadId={threadId}
+                threadIsCollapsed={threadIsCollapsed}
+                replyCount={replyCount}
               />
             )}
             {isSaving && <div className="annotation__actions">Saving...</div>}

--- a/src/sidebar/components/filter-status.js
+++ b/src/sidebar/components/filter-status.js
@@ -279,7 +279,7 @@ export default function FilterStatus() {
 
   const store = useStoreProxy();
   const focusState = store.focusState();
-  const forcedVisibleCount = store.forcedVisibleAnnotations().length;
+  const forcedVisibleCount = store.forcedVisibleThreads().length;
   const filterQuery = store.filterQuery();
   const selectedCount = store.selectedAnnotations().length;
 

--- a/src/sidebar/components/notebook-result-count.js
+++ b/src/sidebar/components/notebook-result-count.js
@@ -18,7 +18,7 @@ import Spinner from './spinner';
 function NotebookResultCount() {
   const store = useStoreProxy();
 
-  const forcedVisibleCount = store.forcedVisibleAnnotations().length;
+  const forcedVisibleCount = store.forcedVisibleThreads().length;
   const hasAppliedFilter = store.hasAppliedFilter();
   const resultCount = store.annotationResultCount();
   const isLoading = store.isLoading();

--- a/src/sidebar/components/notebook-result-count.js
+++ b/src/sidebar/components/notebook-result-count.js
@@ -28,7 +28,7 @@ function NotebookResultCount() {
 
   const hasResults = rootThread.children.length > 0;
 
-  const hasForcedVisible = forcedVisibleCount > 0;
+  const hasForcedVisible = hasAppliedFilter && forcedVisibleCount > 0;
   const matchCount = visibleCount - forcedVisibleCount;
   const threadCount = rootThread.children.length;
 

--- a/src/sidebar/helpers/build-thread.js
+++ b/src/sidebar/helpers/build-thread.js
@@ -296,9 +296,7 @@ export default function buildThread(annotations, options) {
     thread.children = thread.children.filter(child => {
       const isSelected = options.selected.includes(child.id);
       const isForcedVisible =
-        hasForcedVisible &&
-        child.annotation &&
-        options.forcedVisible.includes(child.annotation.$tag);
+        hasForcedVisible && options.forcedVisible.includes(child.id);
       return isSelected || isForcedVisible;
     });
   }
@@ -312,19 +310,16 @@ export default function buildThread(annotations, options) {
   thread = mapThread(thread, thread => {
     let threadIsVisible = thread.visible;
 
-    if (!thread.annotation) {
-      threadIsVisible = false; // Nothing to show
-    } else if (options.filterFn) {
-      if (
-        hasForcedVisible &&
-        options.forcedVisible.includes(thread.annotation.$tag)
-      ) {
-        // This annotation may or may not match the filter, but we should
+    if (options.filterFn) {
+      if (hasForcedVisible && options.forcedVisible.includes(thread.id)) {
+        // This thread may or may not match the filter, but we should
         // make sure it is visible because it has been forced visible by user
         threadIsVisible = true;
-      } else {
-        // Otherwise, visibility depends on whether it matches the filter
+      } else if (thread.annotation) {
+        // Otherwise, visibility depends on whether its annotation matches the filter
         threadIsVisible = !!options.filterFn(thread.annotation);
+      } else {
+        threadIsVisible = false;
       }
     }
     return { ...thread, visible: threadIsVisible };

--- a/src/sidebar/helpers/thread.js
+++ b/src/sidebar/helpers/thread.js
@@ -13,8 +13,7 @@ import { notNull } from '../util/typing';
  * @return {number}
  */
 function countByVisibility(thread, visibility) {
-  const matchesVisibility =
-    !!thread.annotation && thread.visible === visibility;
+  const matchesVisibility = thread.visible === visibility;
   return thread.children.reduce(
     (count, reply) => count + countByVisibility(reply, visibility),
     matchesVisibility ? 1 : 0

--- a/src/sidebar/services/threads.js
+++ b/src/sidebar/services/threads.js
@@ -16,8 +16,8 @@ export default function threadsService(store) {
     thread.children.forEach(child => {
       forceVisible(child);
     });
-    if (!thread.visible && thread.annotation) {
-      store.setForcedVisible(thread.annotation.$tag, true);
+    if (!thread.visible) {
+      store.setForcedVisible(thread.id, true);
     }
   }
 

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -65,7 +65,7 @@ function init(settings) {
     // until explicitly expanded.
     expanded: initialSelection(settings) || {},
 
-    // Set of annotations that have been "forced" visible by the user
+    // Set of threads that have been "forced" visible by the user
     // (e.g. by clicking on "Show x more" button) even though they may not
     // match the currently-applied filters
     forcedVisible: {},
@@ -256,11 +256,11 @@ function setExpanded(id, expanded) {
 }
 
 /**
- * A user may "force" an annotation to be visible, even if it would be otherwise
+ * A user may "force" an thread to be visible, even if it would be otherwise
  * not be visible because of applied filters. Set the force-visibility for a
- * single annotation, without affecting other forced-visible annotations.
+ * single thread, without affecting other forced-visible threads.
  *
- * @param {string} id
+ * @param {string} id - Thread id
  * @param {boolean} visible - Should this annotation be visible, even if it
  *        conflicts with current filters?
  */
@@ -307,7 +307,7 @@ function expandedMap(state) {
 /**
  * @type {(state: any) => string[]}
  */
-const forcedVisibleAnnotations = createSelector(
+const forcedVisibleThreads = createSelector(
   state => state.forcedVisible,
   forcedVisible => trueKeys(forcedVisible)
 );
@@ -347,7 +347,7 @@ const selectionState = createSelector(
   selection => {
     return {
       expanded: expandedMap(selection),
-      forcedVisible: forcedVisibleAnnotations(selection),
+      forcedVisible: forcedVisibleThreads(selection),
       selected: selectedAnnotations(selection),
       sortKey: sortKey(selection),
       selectedTab: selectedTab(selection),
@@ -398,7 +398,7 @@ export default storeModule({
 
   selectors: {
     expandedMap,
-    forcedVisibleAnnotations,
+    forcedVisibleThreads,
     hasSelectedAnnotations,
     selectedAnnotations,
     selectedTab,


### PR DESCRIPTION
This is part 2 of 2 to address #2865, which pertains to handling headless threads in the Notebook.

In #2887, we’ve made it so that headless threads can be sorted chronologically into thread collections by re-working how thread-sorting works.

**In this set of changes, the aim is to make what shows up on a headless thread “card” minimally useful by at least allowing the user to expand and collapse the thread replies.**

These changes also fix some related, inter-tangled bugs I ran into and adjusted some underlying logic, necessary to make this work right. The explanation here is long because the changes, while not enormous in scope, are nuanced. 

###  Draft Status

This PR is currently in draft state because there’s UI nuance here and I’d like to get another set of eyes on this before tightening things up and progressing. I’m also looking for input on the structure of the new UI components here as they quasi-introduce a different component pattern (`AnnotationMissing`, specifically).

**Code is currently prototype-quality, so I’m not looking for a detail-level pass here.**

Out of scope right now:

* Getting a headless annotation card to a truly "nice" state. We're aiming for "better than it was" and only addressing the ability to access replies at this stage.
* The details of what the reply-toggling and "Show X more" controls look like. They might not be perfect, but I'm retaining them as they were.
* Whether or not empty threads should be counted when counting the total number of annotations in various places. It's already inconsistent. I'd like to address this in a follow-up.

##  Briefly, before and after (TL;DR for the end result)

### Before

In the notebook, headless threads show up properly sorted, but are useless, as there is no reply toggle rendered:

![image](https://user-images.githubusercontent.com/439947/106013108-25bf9d00-608a-11eb-880e-8a979b760103.png)

When the Notebook is filtered by user, the “Message not available.” text renders even if that part of the thread is not relevant to the matching results, and the layout is wonky:

![image](https://user-images.githubusercontent.com/439947/106013137-2c4e1480-608a-11eb-8f88-df7f64840c84.png)

And, in reconciling the two above, I ran into another bug on `master` with the existing implementation of the reply toggle combined with search filtering. The eagle-eyed among you might also spot the count mismatch:

![expand-replies-search-bug](https://user-images.githubusercontent.com/439947/106013191-37a14000-608a-11eb-9b98-00666a4b76f7.gif)

(NB: The odd rendering of the "Show x more" button is a screen-capture artifact, nothing to worry about).

### After

Reply toggles are available for headless threads in the Notebook:

![image](https://user-images.githubusercontent.com/439947/106013338-57d0ff00-608a-11eb-8534-b862f361d42a.png)

When filtered, the “Message not available.” text only shows up when that part of the thread is cogent to the matching results:

![image](https://user-images.githubusercontent.com/439947/106013357-5e5f7680-608a-11eb-976c-a1e1365d8394.png)

And the reply-toggle bug in the previous video is rectified by not rendering it when search filters are applied (and it doesn’t, as such, apply):

![image](https://user-images.githubusercontent.com/439947/106013377-63242a80-608a-11eb-8a1e-b2a47cc35bef.png)

## Terminology

* _Headless thread_: An annotation thread for which the top-level annotation has been deleted but at least one reply still remains.
* _Empty thread_: A thread that lacks an `annotation`, at any level in the hierarchy.
* _Reply Toggle:_ A control rendered at the annotation level for showing or hiding all of the replies in the entire (nested) thread hierarchy. Only rendered for the top-level annotation in a thread. Currently rendered as a button-that-looks-like-a-link:

    ![image](https://user-images.githubusercontent.com/439947/106013455-79ca8180-608a-11eb-9f25-54f5018a323c.png)

* _Forced visible_: When a thread doesn’t match a search filter, its visibility is set to `false`. However, a user can “force”-expand one or more `visible:false` threads by using a button in the UI:

    ![image](https://user-images.githubusercontent.com/439947/106013496-818a2600-608a-11eb-98ce-1f1e70cea209.png)

    Clicking this results in:

    ![image](https://user-images.githubusercontent.com/439947/106013531-88b13400-608a-11eb-82f7-65395008b7da.png)

Threads that are made to show up in this manner—the threads associated with the second and third annotations here—are said to be “forced-visible” as they wouldn’t normally be visible in this context.
* _Thread_: A thread:
	* Has 0 or 1 `parent` references (root-level threads do not have parents)
	* Has 0 - n `children` Threads
	* Has 0 or 1 `annotation`: this is important here
	* Has a visibility property (`visible:boolean`)  `visible`’s purpose is to denote whether the thread matches the currently-applied front-end filters or not, or has been forced-visible by the user—that is, should this thread _show up_ at _all_ or not?
	* Has a collapsed property (`collapsed:boolean`): note that this is distinct from visibility. A root-level thread, by default without any applied filters, is visible but collapsed.

## The  `AnnotationMissing` and `AnnotationReplyToggle` components

Before these changes, a greatly simplified structure of the `Thread` UI component (NB: Not the same as a `Thread` data object described above!) was:

```
<Thread>
  {thread.visible && thread.annotation && <Annotation … />}
  {!thread.annotation && <div>Message not available.</div>}
</Thread>
```

There were two things that needed to be remedied here:

1. The reply toggle, which we need to show for headless annotations, was buried within the `Annotation` component. We don’t have an `Annotation` for these headless threads, so that logic needs to be extracted somehow to be available in both contexts (a visible top-level thread, with or without an annotation).
2. An `Annotation` will only render if the thread is visible. The _Message not available_ text renders even if the thread itself is not visible. FIX IT.

In these changes, I’ve approached these by:

* Creating an `AnnotationMissing` component. This gets rendered when the thread is visible but there is no `annotation` available. It’s sort of the annotation-less analog to `Annotation`.
* Extracting the reply-toggle UI logic into `AnnotationReplyToggle` and using it both in `Annotation` and `AnnotationMissing`

`Thread` UI component logic updates to something like this:

```
<Thread>
  {thread.visible && thread.annotation && <Annotation … />}
  {thread.visible && !thread.annotation && <AnnotationMissing … />}
</Thread>
```

_Note_: I’m not convinced `AnnotationMissing` gets it quite right. What I’m going for is an “Annotation-like container when there’s no annotation” with a minimal subset of annotation-y things. The props handling and CSS styles, etc., are up for debate.

## Thread visibility

The above didn’t work independently because all empty threads were being set to `visible:false`. Thus, `AnnotationMissing` never rendered. Some adjustments to thread visibility we necessary to support these changes and fix existing bugs/inconsistencies:

* Stop setting all empty threads to `visible:false`. Treat them like any other thread and set their visibility appropriately to the context. This allows us to use the `Annotation` and `AnnotationMissing` and render them at the right times.
	* When search filters are applied: Search filters pertain to annotations, not threads, and as empty threads have no annotation, they can’t match filters. Set empty threads to `visible:false` when filters are applied, unless they have been _forced visible_ by the user…and…
* Re-factor _force visible_ logic to act on _threads_, not _annotations_ so that the previous item is possible (a user can force-visible an empty thread).