### PR TITLE
Add tags to frontend-shared publish action

### DIFF
--- a/.github/workflows/frontend-shared.yml
+++ b/.github/workflows/frontend-shared.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@v2
     # Additionally fetch master to be able to diff for changes in the frontend-shared/ folder
     - name: Fetch origin
-      run: git fetch origin master:master
+      run: git fetch --tags origin master:master
     # Setup .npmrc file to publish to npm
     - name: Setup Nodejs
       uses: actions/setup-node@v1


### PR DESCRIPTION
Currently the FES publishing step is still not working. It actually worked the very first time
https://github.com/hypothesis/client/actions/runs/521765987

but then failed each time after...
https://github.com/hypothesis/client/actions/runs/527819552

It's still unclear to me exactly why, but the error does indicate that tag data is still not downloaded. `fetch` does need a tag option to get tag data so it makes sense to add this in. This still does not explain why it worked once, so this is still somewhat of a guess.  