### PR TITLE
Handle reply-toggling for headless threads

### DIFF
--- a/src/sidebar/components/AnnotationMissing.js
+++ b/src/sidebar/components/AnnotationMissing.js
@@ -1,0 +1,65 @@
+import classnames from 'classnames';
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
+
+import AnnotationReplyToggle from './AnnotationReplyToggle';
+
+/** @typedef {import('./Annotation').AnnotationProps} AnnotationProps */
+
+/**
+ * @typedef {Omit<AnnotationProps, 'annotation'|'showDocumentInfo'|'annotationsService'>} AnnotationMissingProps
+ */
+
+/**
+ * Renders in place of an annotation if a thread's annotation is missing.
+ *
+ * @param {AnnotationMissingProps} props
+ */
+function AnnotationMissing({
+  hasAppliedFilter,
+  isReply,
+  onToggleReplies,
+  replyCount,
+  threadIsCollapsed,
+}) {
+  const showReplyToggle = !isReply && !hasAppliedFilter && replyCount > 0;
+  const isCollapsedReply = isReply && threadIsCollapsed;
+
+  return (
+    <article
+      className={classnames('Annotation', 'Annotation--missing', {
+        'is-collapsed': threadIsCollapsed,
+      })}
+    >
+      {!isCollapsedReply && (
+        <div>
+          <em>Message not available.</em>
+        </div>
+      )}
+
+      {!isCollapsedReply && (
+        <footer className="Annotation__footer">
+          <div className="Annotation__controls u-layout-row">
+            {showReplyToggle && (
+              <AnnotationReplyToggle
+                onToggleReplies={onToggleReplies}
+                replyCount={replyCount}
+                threadIsCollapsed={threadIsCollapsed}
+              />
+            )}
+          </div>
+        </footer>
+      )}
+    </article>
+  );
+}
+
+AnnotationMissing.propTypes = {
+  hasAppliedFilter: propTypes.bool,
+  isReply: propTypes.bool.isRequired,
+  onToggleReplies: propTypes.func,
+  replyCount: propTypes.number.isRequired,
+  threadIsCollapsed: propTypes.bool,
+};
+
+export default AnnotationMissing;

--- a/src/sidebar/components/AnnotationReplyToggle.js
+++ b/src/sidebar/components/AnnotationReplyToggle.js
@@ -1,0 +1,42 @@
+import { createElement } from 'preact';
+import propTypes from 'prop-types';
+
+import Button from './Button';
+
+/**
+ * @typedef AnnotationReplyToggleProps
+ * @prop {() => any} onToggleReplies
+ * @prop {number} replyCount
+ * @prop {boolean} threadIsCollapsed
+ */
+
+/**
+ * Render a thread-card control to toggle (expand or collapse) all of this
+ * thread's children.
+ *
+ * @param {AnnotationReplyToggleProps} props
+ */
+function AnnotationReplyToggle({
+  onToggleReplies,
+  replyCount,
+  threadIsCollapsed,
+}) {
+  const toggleAction = threadIsCollapsed ? 'Show replies' : 'Hide replies';
+  const toggleText = `${toggleAction} (${replyCount})`;
+
+  return (
+    <Button
+      className="Annotation__reply-toggle"
+      onClick={onToggleReplies}
+      buttonText={toggleText}
+    />
+  );
+}
+
+AnnotationReplyToggle.propTypes = {
+  onToggleReplies: propTypes.func,
+  replyCount: propTypes.number,
+  threadIsCollapsed: propTypes.bool.isRequired,
+};
+
+export default AnnotationReplyToggle;

--- a/src/sidebar/components/FilterStatus.js
+++ b/src/sidebar/components/FilterStatus.js
@@ -279,7 +279,7 @@ export default function FilterStatus() {
 
   const store = useStoreProxy();
   const focusState = store.focusState();
-  const forcedVisibleCount = store.forcedVisibleAnnotations().length;
+  const forcedVisibleCount = store.forcedVisibleThreads().length;
   const filterQuery = store.filterQuery();
   const selectedCount = store.selectedAnnotations().length;
 

--- a/src/sidebar/components/NotebookResultCount.js
+++ b/src/sidebar/components/NotebookResultCount.js
@@ -18,7 +18,7 @@ import Spinner from './Spinner';
 function NotebookResultCount() {
   const store = useStoreProxy();
 
-  const forcedVisibleCount = store.forcedVisibleAnnotations().length;
+  const forcedVisibleCount = store.forcedVisibleThreads().length;
   const hasAppliedFilter = store.hasAppliedFilter();
   const resultCount = store.annotationResultCount();
   const isLoading = store.isLoading();

--- a/src/sidebar/components/NotebookResultCount.js
+++ b/src/sidebar/components/NotebookResultCount.js
@@ -28,7 +28,7 @@ function NotebookResultCount() {
 
   const hasResults = rootThread.children.length > 0;
 
-  const hasForcedVisible = forcedVisibleCount > 0;
+  const hasForcedVisible = hasAppliedFilter && forcedVisibleCount > 0;
   const matchCount = visibleCount - forcedVisibleCount;
   const threadCount = rootThread.children.length;
 

--- a/src/sidebar/components/test/AnnotationMissing-test.js
+++ b/src/sidebar/components/test/AnnotationMissing-test.js
@@ -1,0 +1,101 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+
+import AnnotationMissing, { $imports } from '../AnnotationMissing';
+
+import { checkAccessibility } from '../../../test-util/accessibility';
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+
+describe('AnnotationMissing', () => {
+  let fakeOnToggleReplies;
+
+  function createComponent(props = {}) {
+    return mount(
+      <AnnotationMissing
+        hasAppliedFilter={false}
+        isReply={false}
+        onToggleReplies={fakeOnToggleReplies}
+        replyCount={5}
+        threadIsCollapsed={true}
+        {...props}
+      />
+    );
+  }
+
+  beforeEach(() => {
+    fakeOnToggleReplies = sinon.stub();
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  context('collapsed reply', () => {
+    it('does not show message-unavailable text', () => {
+      const wrapper = createComponent({
+        isReply: true,
+        threadIsCollapsed: true,
+      });
+      assert.equal(wrapper.text(), '');
+    });
+
+    it('does not render a reply toggle', () => {
+      const wrapper = createComponent({
+        isReply: true,
+        threadIsCollapsed: true,
+      });
+
+      assert.isFalse(wrapper.find('AnnotationReplyToggle').exists());
+    });
+  });
+
+  context('collapsed thread, not a reply', () => {
+    it('shows message-unavailable text', () => {
+      const wrapper = createComponent({
+        isReply: false,
+        threadIsCollapsed: true,
+      });
+
+      assert.match(wrapper.text(), /Message not available/);
+    });
+
+    it('renders a reply toggle control', () => {
+      const wrapper = createComponent({
+        isReply: false,
+        threadIsCollapsed: true,
+      });
+
+      const toggle = wrapper.find('AnnotationReplyToggle');
+      assert.equal(toggle.props().onToggleReplies, fakeOnToggleReplies);
+    });
+  });
+
+  context('expanded thread, not a reply', () => {
+    it('shows message-unavailable text', () => {
+      const wrapper = createComponent({
+        isReply: false,
+        threadIsCollapsed: false,
+      });
+
+      assert.match(wrapper.text(), /Message not available/);
+    });
+
+    it('renders a reply toggle control', () => {
+      const wrapper = createComponent({
+        isReply: false,
+        threadIsCollapsed: false,
+      });
+
+      const toggle = wrapper.find('AnnotationReplyToggle');
+      assert.equal(toggle.props().onToggleReplies, fakeOnToggleReplies);
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    })
+  );
+});

--- a/src/sidebar/components/test/AnnotationReplyToggle-test.js
+++ b/src/sidebar/components/test/AnnotationReplyToggle-test.js
@@ -1,0 +1,63 @@
+import { mount } from 'enzyme';
+import { createElement } from 'preact';
+import { act } from 'preact/test-utils';
+
+import AnnotationReplyToggle from '../AnnotationReplyToggle';
+
+import { checkAccessibility } from '../../../test-util/accessibility';
+
+describe('AnnotationReplyToggle', () => {
+  let fakeOnToggleReplies;
+
+  function createComponent(props = {}) {
+    return mount(
+      <AnnotationReplyToggle
+        onToggleReplies={fakeOnToggleReplies}
+        replyCount={5}
+        threadIsCollapsed={true}
+        {...props}
+      />
+    );
+  }
+
+  beforeEach(() => {
+    fakeOnToggleReplies = sinon.stub();
+    // Note that this component does not mock imported components
+    // because it entirely consists of a `Button`
+  });
+
+  it('renders expand wording if thread is collapsed', () => {
+    const wrapper = createComponent();
+
+    assert.match(wrapper.text(), /^Show replies/);
+  });
+
+  it('renders collapse wording if thread is expanded', () => {
+    const wrapper = createComponent({ threadIsCollapsed: false });
+
+    assert.match(wrapper.text(), /^Hide replies/);
+  });
+
+  it('shows the reply count', () => {
+    const wrapper = createComponent({ replyCount: 7 });
+    assert.equal(wrapper.text(), 'Show replies (7)');
+  });
+
+  it('invokes the toggle callback when clicked', () => {
+    const wrapper = createComponent();
+    const button = wrapper.find('Button');
+
+    act(() => {
+      button.props().onClick();
+    });
+
+    assert.calledOnce(fakeOnToggleReplies);
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    })
+  );
+});

--- a/src/sidebar/components/test/FilterStatus-test.js
+++ b/src/sidebar/components/test/FilterStatus-test.js
@@ -44,7 +44,7 @@ describe('FilterStatus', () => {
       filterQuery: sinon.stub().returns(null),
       filterState: sinon.stub().returns(getFilterState()),
       focusState: sinon.stub().returns(getFocusState()),
-      forcedVisibleAnnotations: sinon.stub().returns([]),
+      forcedVisibleThreads: sinon.stub().returns([]),
       selectedAnnotations: sinon.stub().returns([]),
       toggleFocusMode: sinon.stub(),
     };
@@ -116,7 +116,7 @@ describe('FilterStatus', () => {
   context('(State 3): filtered by query with force-expanded threads', () => {
     beforeEach(() => {
       fakeStore.filterQuery.returns('foobar');
-      fakeStore.forcedVisibleAnnotations.returns([1, 2, 3]);
+      fakeStore.forcedVisibleThreads.returns([1, 2, 3]);
       fakeThreadUtil.countVisible.returns(5);
     });
 
@@ -284,7 +284,7 @@ describe('FilterStatus', () => {
           displayName: 'Ebenezer Studentolog',
         });
         fakeStore.filterQuery.returns('biscuits');
-        fakeStore.forcedVisibleAnnotations.returns([1, 2]);
+        fakeStore.forcedVisibleThreads.returns([1, 2]);
         fakeThreadUtil.countVisible.returns(3);
       });
 
@@ -331,7 +331,7 @@ describe('FilterStatus', () => {
         configured: true,
         displayName: 'Ebenezer Studentolog',
       });
-      fakeStore.forcedVisibleAnnotations.returns([1, 2, 3]);
+      fakeStore.forcedVisibleThreads.returns([1, 2, 3]);
       fakeThreadUtil.countVisible.returns(7);
     });
 
@@ -343,7 +343,7 @@ describe('FilterStatus', () => {
     });
 
     it('should handle cases when there are no focused-user annotations', () => {
-      fakeStore.forcedVisibleAnnotations.returns([1, 2, 3, 4, 5, 6, 7]);
+      fakeStore.forcedVisibleThreads.returns([1, 2, 3, 4, 5, 6, 7]);
       assertFilterText(
         createComponent(),
         'No annotations by Ebenezer Studentolog (and 7 more)'

--- a/src/sidebar/components/test/NotebookResultCount-test.js
+++ b/src/sidebar/components/test/NotebookResultCount-test.js
@@ -22,7 +22,7 @@ describe('NotebookResultCount', () => {
     fakeAnnotationResultCount = sinon.stub().returns(0);
 
     fakeStore = {
-      forcedVisibleAnnotations: sinon.stub().returns([]),
+      forcedVisibleThreads: sinon.stub().returns([]),
       hasAppliedFilter: sinon.stub().returns(false),
       isLoading: fakeIsLoading,
       annotationResultCount: fakeAnnotationResultCount,
@@ -111,7 +111,7 @@ describe('NotebookResultCount', () => {
     ].forEach(test => {
       it('should render a count of results', () => {
         fakeStore.hasAppliedFilter.returns(true);
-        fakeStore.forcedVisibleAnnotations.returns(test.forcedVisible);
+        fakeStore.forcedVisibleThreads.returns(test.forcedVisible);
         fakeUseRootThread.returns(test.thread);
         fakeCountVisible.returns(test.visibleCount);
 

--- a/src/sidebar/components/test/Thread-test.js
+++ b/src/sidebar/components/test/Thread-test.js
@@ -81,6 +81,7 @@ describe('Thread', () => {
 
   beforeEach(() => {
     fakeStore = {
+      hasAppliedFilter: sinon.stub().returns(false),
       setExpanded: sinon.stub(),
     };
 
@@ -189,7 +190,7 @@ describe('Thread', () => {
     });
   });
 
-  context('thread annotation has been deleted', () => {
+  context('visible thread whose annotation has been deleted', () => {
     let noAnnotationThread;
 
     beforeEach(() => {
@@ -204,10 +205,29 @@ describe('Thread', () => {
       assert.isFalse(wrapper.find('ModerationBanner').exists());
     });
 
-    it('renders an unavailable message', () => {
+    it('renders a missing annotation component', () => {
       const wrapper = createComponent({ thread: noAnnotationThread });
 
-      assert.isTrue(wrapper.find('.Thread__unavailable-message').exists());
+      const annotationMissing = wrapper.find('AnnotationMissing');
+
+      assert.isTrue(annotationMissing.exists());
+    });
+  });
+
+  context('non-visible thread whose annotation has been deleted', () => {
+    let noAnnotationThread;
+
+    beforeEach(() => {
+      noAnnotationThread = createThread();
+      noAnnotationThread.annotation = undefined;
+      noAnnotationThread.visible = false;
+    });
+
+    it('does not render any kind of annotation component', () => {
+      const wrapper = createComponent({ thread: noAnnotationThread });
+
+      assert.isFalse(wrapper.find('Annotation').exists());
+      assert.isFalse(wrapper.find('AnnotationMissing').exists());
     });
   });
 

--- a/src/sidebar/helpers/build-thread.js
+++ b/src/sidebar/helpers/build-thread.js
@@ -296,9 +296,7 @@ export default function buildThread(annotations, options) {
     thread.children = thread.children.filter(child => {
       const isSelected = options.selected.includes(child.id);
       const isForcedVisible =
-        hasForcedVisible &&
-        child.annotation &&
-        options.forcedVisible.includes(child.annotation.$tag);
+        hasForcedVisible && options.forcedVisible.includes(child.id);
       return isSelected || isForcedVisible;
     });
   }
@@ -312,19 +310,16 @@ export default function buildThread(annotations, options) {
   thread = mapThread(thread, thread => {
     let threadIsVisible = thread.visible;
 
-    if (!thread.annotation) {
-      threadIsVisible = false; // Nothing to show
-    } else if (options.filterFn) {
-      if (
-        hasForcedVisible &&
-        options.forcedVisible.includes(thread.annotation.$tag)
-      ) {
-        // This annotation may or may not match the filter, but we should
+    if (options.filterFn) {
+      if (hasForcedVisible && options.forcedVisible.includes(thread.id)) {
+        // This thread may or may not match the filter, but we should
         // make sure it is visible because it has been forced visible by user
         threadIsVisible = true;
-      } else {
-        // Otherwise, visibility depends on whether it matches the filter
+      } else if (thread.annotation) {
+        // Otherwise, visibility depends on whether its annotation matches the filter
         threadIsVisible = !!options.filterFn(thread.annotation);
+      } else {
+        threadIsVisible = false;
       }
     }
     return { ...thread, visible: threadIsVisible };

--- a/src/sidebar/helpers/thread.js
+++ b/src/sidebar/helpers/thread.js
@@ -13,8 +13,7 @@ import { notNull } from '../util/typing';
  * @return {number}
  */
 function countByVisibility(thread, visibility) {
-  const matchesVisibility =
-    !!thread.annotation && thread.visible === visibility;
+  const matchesVisibility = thread.visible === visibility;
   return thread.children.reduce(
     (count, reply) => count + countByVisibility(reply, visibility),
     matchesVisibility ? 1 : 0

--- a/src/sidebar/services/test/threads-test.js
+++ b/src/sidebar/services/test/threads-test.js
@@ -2,32 +2,30 @@ import threadsService from '../threads';
 
 const NESTED_THREADS = {
   id: 'top',
-  annotation: { $tag: 'top-tag' },
+  annotation: {},
   children: [
     {
       id: '1',
-      annotation: { $tag: '1-tag' },
+      annotation: {},
       children: [
         {
           id: '1a',
-          annotation: { $tag: '1a-tag' },
-          children: [
-            { annotation: { $tag: '1ai-tag' }, id: '1ai', children: [] },
-          ],
+          annotation: {},
+          children: [{ annotation: {}, id: '1ai', children: [] }],
         },
         {
           id: '1b',
-          annotation: { $tag: '1b-tag' },
+          annotation: {},
           children: [],
           visible: true,
         },
         {
           id: '1c',
-          annotation: { $tag: '1c-tag' },
+          annotation: {},
           children: [
             {
               id: '1ci',
-              annotation: { $tag: '1ci-tag' },
+              annotation: {},
               children: [],
               visible: false,
             },
@@ -37,32 +35,32 @@ const NESTED_THREADS = {
     },
     {
       id: '2',
-      annotation: { $tag: '2-tag' },
+      annotation: {},
       children: [
-        { id: '2a', annotation: { $tag: '2a-tag' }, children: [] },
+        { id: '2a', annotation: {}, children: [] },
         {
           id: '2b',
           children: [
             {
               id: '2bi',
-              annotation: { $tag: '2bi-tag' },
+              annotation: {},
               children: [],
               visible: true,
             },
-            { id: '2bii', annotation: { $tag: '2bii-tag' }, children: [] },
+            { id: '2bii', annotation: {}, children: [] },
           ],
         },
       ],
     },
     {
       id: '3',
-      annotation: { $tag: '3-tag' },
+      annotation: {},
       children: [],
     },
   ],
 };
 
-describe('threadsService', function () {
+describe('threadsService', () => {
   let fakeStore;
   let service;
 
@@ -77,17 +75,17 @@ describe('threadsService', function () {
     let nonVisibleThreadIds;
     beforeEach(() => {
       nonVisibleThreadIds = [
-        'top-tag',
-        '1-tag',
-        '2-tag',
-        '3-tag',
-        '1a-tag',
-        '1c-tag',
-        '2a-tag',
-        //'2b-tag',  Not visible, but also does not have an annotation
-        '1ai-tag',
-        '1ci-tag',
-        '2bii-tag',
+        'top',
+        '1',
+        '2',
+        '3',
+        '1a',
+        '1c',
+        '2a',
+        '2b',
+        '1ai',
+        '1ci',
+        '2bii',
       ];
     });
     it('should set the thread and its children force-visible in the store', () => {
@@ -109,13 +107,7 @@ describe('threadsService', function () {
       for (let i = 0; i < fakeStore.setForcedVisible.callCount; i++) {
         calledWithThreadIds.push(fakeStore.setForcedVisible.getCall(i).args[0]);
       }
-      assert.deepEqual(calledWithThreadIds, [
-        '1ai-tag',
-        '1a-tag',
-        '1ci-tag',
-        '1c-tag',
-        '1-tag',
-      ]);
+      assert.deepEqual(calledWithThreadIds, ['1ai', '1a', '1ci', '1c', '1']);
     });
   });
 });

--- a/src/sidebar/services/threads.js
+++ b/src/sidebar/services/threads.js
@@ -16,8 +16,8 @@ export default function threadsService(store) {
     thread.children.forEach(child => {
       forceVisible(child);
     });
-    if (!thread.visible && thread.annotation) {
-      store.setForcedVisible(thread.annotation.$tag, true);
+    if (!thread.visible) {
+      store.setForcedVisible(thread.id, true);
     }
   }
 

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -65,7 +65,7 @@ function init(settings) {
     // until explicitly expanded.
     expanded: initialSelection(settings) || {},
 
-    // Set of annotations that have been "forced" visible by the user
+    // Set of threads that have been "forced" visible by the user
     // (e.g. by clicking on "Show x more" button) even though they may not
     // match the currently-applied filters
     forcedVisible: {},
@@ -256,11 +256,11 @@ function setExpanded(id, expanded) {
 }
 
 /**
- * A user may "force" an annotation to be visible, even if it would be otherwise
+ * A user may "force" an thread to be visible, even if it would be otherwise
  * not be visible because of applied filters. Set the force-visibility for a
- * single annotation, without affecting other forced-visible annotations.
+ * single thread, without affecting other forced-visible threads.
  *
- * @param {string} id
+ * @param {string} id - Thread id
  * @param {boolean} visible - Should this annotation be visible, even if it
  *        conflicts with current filters?
  */
@@ -307,7 +307,7 @@ function expandedMap(state) {
 /**
  * @type {(state: any) => string[]}
  */
-const forcedVisibleAnnotations = createSelector(
+const forcedVisibleThreads = createSelector(
   state => state.forcedVisible,
   forcedVisible => trueKeys(forcedVisible)
 );
@@ -347,7 +347,7 @@ const selectionState = createSelector(
   selection => {
     return {
       expanded: expandedMap(selection),
-      forcedVisible: forcedVisibleAnnotations(selection),
+      forcedVisible: forcedVisibleThreads(selection),
       selected: selectedAnnotations(selection),
       sortKey: sortKey(selection),
       selectedTab: selectedTab(selection),
@@ -398,7 +398,7 @@ export default storeModule({
 
   selectors: {
     expandedMap,
-    forcedVisibleAnnotations,
+    forcedVisibleThreads,
     hasSelectedAnnotations,
     selectedAnnotations,
     selectedTab,

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -31,7 +31,7 @@ describe('sidebar/store/modules/selection', () => {
         id1: true,
         id2: false,
       });
-      assert.deepEqual(store.forcedVisibleAnnotations(), ['id1']);
+      assert.deepEqual(store.forcedVisibleThreads(), ['id1']);
     });
   });
 
@@ -155,7 +155,7 @@ describe('sidebar/store/modules/selection', () => {
       });
 
       assert.isEmpty(store.selectedAnnotations());
-      assert.isEmpty(store.forcedVisibleAnnotations());
+      assert.isEmpty(store.forcedVisibleThreads());
     });
   });
 
@@ -167,7 +167,7 @@ describe('sidebar/store/modules/selection', () => {
       store.setFilter('user', { value: 'dingbat', display: 'Ding Bat' });
 
       assert.isEmpty(store.selectedAnnotations());
-      assert.isEmpty(store.forcedVisibleAnnotations());
+      assert.isEmpty(store.forcedVisibleThreads());
     });
   });
 
@@ -179,7 +179,7 @@ describe('sidebar/store/modules/selection', () => {
       store.setFilterQuery('foobar');
 
       assert.isEmpty(store.selectedAnnotations());
-      assert.isEmpty(store.forcedVisibleAnnotations());
+      assert.isEmpty(store.forcedVisibleThreads());
     });
   });
 
@@ -191,7 +191,7 @@ describe('sidebar/store/modules/selection', () => {
       store.toggleFocusMode(true);
 
       assert.isEmpty(store.selectedAnnotations());
-      assert.isEmpty(store.forcedVisibleAnnotations());
+      assert.isEmpty(store.forcedVisibleThreads());
     });
   });
 
@@ -207,7 +207,7 @@ describe('sidebar/store/modules/selection', () => {
         1: true,
         3: true,
       });
-      assert.deepEqual(store.forcedVisibleAnnotations(), ['1']);
+      assert.deepEqual(store.forcedVisibleThreads(), ['1']);
       assert.deepEqual(store.expandedMap(), { 1: true });
     });
   });


### PR DESCRIPTION
This PR is a review-ready variant of https://github.com/hypothesis/client/pull/2932 — please see that PR for (long) description.

New working branch here because of a complex rebasing situation and a refactoring of some components. Changes since https://github.com/hypothesis/client/pull/2932:

* `AnnotationReplyToggle` is now a "dumb" component per suggestion.
* `Annotation` and `AnnotationMissing` props are more "harmonized" now; `AnnotationMissing` props are a subset of `Annotation` props. Minor refactoring of `Thread` and `Annotation` to accommodate this.
* Tests added for everything here.

Fixes https://github.com/hypothesis/client/issues/2865