### PR TITLE
Allow Preact.Fragment shorter syntax

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,23 +1,34 @@
 {
   "presets": [
-    ["@babel/preset-react", {
-      "pragma": "createElement"
-    }],
+    [
+      "@babel/preset-react",
+      {
+        "pragma": "createElement",
+        "pragmaFrag": "Fragment"
+      }
+    ],
 
     // Compile JS for browser targets set by `browserslist` key in package.json.
-    ["@babel/preset-env", {
-       "bugfixes": true
-    }]
+    [
+      "@babel/preset-env",
+      {
+        "bugfixes": true
+      }
+    ]
   ],
   "plugins": ["inject-args"],
   "ignore": ["**/vendor/*"],
   "env": {
     "development": {
       "presets": [
-        ["@babel/preset-react", {
-          "development": true,
-          "pragma": "createElement"
-        }]
+        [
+          "@babel/preset-react",
+          {
+            "development": true,
+            "pragma": "createElement",
+            "pragmaFrag": "Fragment"
+          }
+        ]
       ]
     }
   }

--- a/frontend-shared/babel.config.json
+++ b/frontend-shared/babel.config.json
@@ -2,7 +2,9 @@
   "presets": [
     [
       "@babel/preset-react", {
-        "pragma": "createElement"
+        "pragma": "createElement",
+        "pragmaFrag": "Fragment"
+
     }],
     ["@babel/preset-env", {
         "bugfixes": true,
@@ -19,7 +21,8 @@
       "presets": [
         ["@babel/preset-react", {
           "development": true,
-          "pragma": "createElement"
+          "pragma": "createElement",
+          "pragmaFrag": "Fragment"
         }]
       ]
     }

--- a/src/annotator/plugin/pdf.js
+++ b/src/annotator/plugin/pdf.js
@@ -20,7 +20,7 @@ import PDFMetadata from './pdf-metadata';
  */
 function WarningBanner() {
   return (
-    <Fragment>
+    <>
       <div className="annotator-pdf-warning-banner__type">
         <SvgIcon
           name="caution"
@@ -38,7 +38,7 @@ function WarningBanner() {
         </a>{' '}
         in order to annotate with Hypothesis.
       </div>
-    </Fragment>
+    </>
   );
 }
 

--- a/src/sidebar/components/AnnotationView.js
+++ b/src/sidebar/components/AnnotationView.js
@@ -82,7 +82,7 @@ function AnnotationView({ loadAnnotationsService, onLogin }) {
   ]);
 
   return (
-    <Fragment>
+    <>
       {fetchError && (
         // This is the same error shown if a direct-linked annotation cannot
         // be fetched in the sidebar. Fortunately the error message makes sense
@@ -90,7 +90,7 @@ function AnnotationView({ loadAnnotationsService, onLogin }) {
         <SidebarContentError errorType="annotation" onLoginRequest={onLogin} />
       )}
       <ThreadList thread={rootThread} />
-    </Fragment>
+    </>
   );
 }
 

--- a/src/sidebar/components/GroupListItem.js
+++ b/src/sidebar/components/GroupListItem.js
@@ -105,7 +105,7 @@ function GroupListItem({
       onClick={isSelectable ? focusGroup : toggleSubmenu}
       onToggleSubmenu={toggleSubmenu}
       submenu={
-        <Fragment>
+        <>
           <ul>
             {activityUrl && (
               <li>
@@ -143,7 +143,7 @@ function GroupListItem({
               This group is restricted to specific URLs.
             </p>
           )}
-        </Fragment>
+        </>
       }
     />
   );

--- a/src/sidebar/components/Menu.js
+++ b/src/sidebar/components/Menu.js
@@ -186,7 +186,7 @@ export default function Menu({
         </span>
       </button>
       {isOpen && (
-        <Fragment>
+        <>
           {menuArrow(arrowClass)}
           <div
             className={classnames(
@@ -203,7 +203,7 @@ export default function Menu({
               {children}
             </MenuKeyboardNavigation>
           </div>
-        </Fragment>
+        </>
       )}
     </div>
   );

--- a/src/sidebar/components/MenuItem.js
+++ b/src/sidebar/components/MenuItem.js
@@ -215,7 +215,7 @@ export default function MenuItem({
     );
   }
   return (
-    <Fragment>
+    <>
       {menuItem}
       {hasSubmenuVisible && (
         <Slider visible={/** @type {boolean} */ (isSubmenuVisible)}>
@@ -228,7 +228,7 @@ export default function MenuItem({
           </MenuKeyboardNavigation>
         </Slider>
       )}
-    </Fragment>
+    </>
   );
 }
 

--- a/src/sidebar/components/MenuSection.js
+++ b/src/sidebar/components/MenuSection.js
@@ -28,14 +28,14 @@ import propTypes from 'prop-types';
  */
 export default function MenuSection({ heading, children }) {
   return (
-    <Fragment>
+    <>
       {heading && <h2 className="MenuSection__heading">{heading}</h2>}
       <ul className="MenuSection__content">
         {toChildArray(children).map(child => (
           <li key={/** @type {JSXElement} **/ (child).key}>{child}</li>
         ))}
       </ul>
-    </Fragment>
+    </>
   );
 }
 

--- a/src/sidebar/components/ShareAnnotationsPanel.js
+++ b/src/sidebar/components/ShareAnnotationsPanel.js
@@ -62,7 +62,7 @@ function ShareAnnotationsPanel({ analytics, toastMessenger }) {
       {sharingReady && (
         <div className="ShareAnnotationsPanel">
           {shareURI ? (
-            <Fragment>
+            <>
               <div className="ShareAnnotationsPanel__intro">
                 {notNull(focusedGroup).type === 'private' ? (
                   <p>
@@ -111,7 +111,7 @@ function ShareAnnotationsPanel({ analytics, toastMessenger }) {
                 shareURI={shareURI}
                 analyticsEventName={analytics.events.DOCUMENT_SHARED}
               />
-            </Fragment>
+            </>
           ) : (
             <p>
               These annotations cannot be shared because this document is not

--- a/src/sidebar/components/Thread.js
+++ b/src/sidebar/components/Thread.js
@@ -64,7 +64,7 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
   const annotationContent = useMemo(() => {
     if (showAnnotation) {
       return (
-        <Fragment>
+        <>
           <ModerationBanner annotation={thread.annotation} />
           <Annotation
             annotation={thread.annotation}
@@ -75,7 +75,7 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
             showDocumentInfo={showDocumentInfo}
             threadIsCollapsed={thread.collapsed}
           />
-        </Fragment>
+        </>
       );
     } else if (showMissingAnnotation) {
       return (

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -79,7 +79,7 @@ function TopBar({
   };
 
   const loginControl = (
-    <Fragment>
+    <>
       {auth.status === 'unknown' && (
         <span className="TopBar__login-links">⋯</span>
       )}
@@ -103,7 +103,7 @@ function TopBar({
       {auth.status === 'logged-in' && (
         <UserMenu auth={auth} onLogout={onLogout} />
       )}
-    </Fragment>
+    </>
   );
 
   return (

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -5,21 +5,19 @@
     "lib": ["es2018", "dom"],
     "jsx": "react",
     "jsxFactory": "createElement",
+    "jsxFragmentFactory": "Fragment",
     "module": "commonjs",
     "noEmit": true,
     "strict": true,
     "noImplicitAny": false,
     "target": "ES2020"
   },
-  "include": [
-    "**/*.js",
-    "../frontend-shared/src/**/*.js",
-  ],
+  "include": ["**/*.js", "../frontend-shared/src/**/*.js"],
   "exclude": [
     // Tests are not checked.
     "**/test/**/*.js",
     "test-util/**/*.js",
     "karma.config.js",
-    "../frontend-shared/src/**/test/*.js",
+    "../frontend-shared/src/**/test/*.js"
   ]
 }


### PR DESCRIPTION
Currently, the were two ways to return multiple elements at once:

```javascript
   const List = (
        <Fragment>
          <li>A</li>
          <li>B</li>
          <li>C</li>
        </Fragment>
   );
```

or

```javascript
   const List = (
         [
          <li>A</li>
          <li>B</li>
          <li>C</li>
        ]
   );
```

This allows a third, shorter syntax for Fragment:

```javascript
   const List = (
        <>
          <li>A</li>
          <li>B</li>
          <li>C</li>
        </>
   );
```
See also the [Preact documentation about fragments](https://preactjs.com/guide/v10/components#fragments)