### PR TITLE
Remove deprecated `component.base` usage in `useElementShouldClose` hook

### DIFF
--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -49,7 +49,6 @@ function TagEditor({
 
   // Set up callback to monitor outside click events to close the AutocompleteList
   const closeWrapperRef = useRef(/** @type {HTMLElement|null} */ (null));
-  /** @ts-ignore - TODO: fix useElementShouldClose Ref types */
   useElementShouldClose(closeWrapperRef, suggestionsListOpen, () => {
     setSuggestionsListOpen(false);
   });

--- a/src/sidebar/components/hooks/use-element-should-close.js
+++ b/src/sidebar/components/hooks/use-element-should-close.js
@@ -9,20 +9,18 @@ import { listen } from '../../util/dom';
  */
 
 /**
- * This hook adds appropriate `eventListener`s to the document when a target
- * element (`closeableEl`) is open. Events such as `click` and `focus` on
- * elements that fall outside of `closeableEl` in the document, or keydown
- * events for the `esc` key, will invoke the provided `handleClose` function
- * to indicate that `closeableEl` should be closed. This hook also performs
- * cleanup to remove `eventListener`s when appropriate.
+ * This hook provides a way to close or hide an element when a user interacts
+ * with elements outside of it or presses the Esc key. It can be used to
+ * create non-modal popups (eg. for menus, autocomplete lists and non-modal dialogs)
+ * that automatically close when appropriate.
  *
- * @param {Ref<HTMLElement>} closeableEl -
- *   Reference to a DOM element that should be closed when DOM elements external
- *   to it are interacted with or `Esc` is pressed
- * @param {boolean} isOpen - Whether the element is currently open. This hook does
- *                        not attach event listeners/do anything if it's not.
- * @param {() => void} handleClose - A function that will do the actual closing
- *                                   of `closeableEl`
+ * When the element is visible/open, this hook monitors for document interactions
+ * that should close it - such as clicks outside the element or Esc key presses.
+ * When such an interaction happens, the `handleClose` callback is invoked.
+ *
+ * @param {Ref<HTMLElement>} closeableEl - Outer DOM element for the popup
+ * @param {boolean} isOpen - Whether the popup is currently visible/open
+ * @param {() => void} handleClose - Callback invoked to close the popup
  */
 export default function useElementShouldClose(
   closeableEl,

--- a/src/sidebar/components/hooks/use-element-should-close.js
+++ b/src/sidebar/components/hooks/use-element-should-close.js
@@ -9,15 +9,6 @@ import { listen } from '../../util/dom';
  */
 
 /**
- * @typedef PreactElement
- * @prop {Node} base
- */
-
-/**
- * @typedef {Ref<HTMLElement> | Ref<PreactElement>} PreactRef
- */
-
-/**
  * This hook adds appropriate `eventListener`s to the document when a target
  * element (`closeableEl`) is open. Events such as `click` and `focus` on
  * elements that fall outside of `closeableEl` in the document, or keydown
@@ -25,13 +16,9 @@ import { listen } from '../../util/dom';
  * to indicate that `closeableEl` should be closed. This hook also performs
  * cleanup to remove `eventListener`s when appropriate.
  *
- * Limitation: This will not work when attached to a custom component that has
- * more than one element nested under a root <Fragment>
- *
- * @param {PreactRef} closeableEl - ref object:
- *                                Reference to a DOM element or preat component
- *                                that should be closed when DOM elements external
- *                                to it are interacted with or `Esc` is pressed
+ * @param {Ref<HTMLElement>} closeableEl -
+ *   Reference to a DOM element that should be closed when DOM elements external
+ *   to it are interacted with or `Esc` is pressed
  * @param {boolean} isOpen - Whether the element is currently open. This hook does
  *                        not attach event listeners/do anything if it's not.
  * @param {() => void} handleClose - A function that will do the actual closing
@@ -42,25 +29,6 @@ export default function useElementShouldClose(
   isOpen,
   handleClose
 ) {
-  /**
-   *  Helper to return the underlying node object whether
-   *  `closeableEl` is attached to an HTMLNode or Preact component.
-   *
-   *  @param {PreactRef} closeableEl
-   *  @returns {Node}
-   */
-
-  const getCurrentNode = closeableEl => {
-    // if base is present, assume its a preact component
-    const node = /** @type {PreactElement} */ (closeableEl.current).base
-      ? /** @type {PreactElement} */ (closeableEl.current).base
-      : closeableEl.current;
-    if (typeof node !== 'object') {
-      throw new Error('useElementShouldClose can not find a node reference');
-    }
-    return /** @type {Node} */ (node);
-  };
-
   useEffect(() => {
     if (!isOpen) {
       return () => {};
@@ -80,8 +48,7 @@ export default function useElementShouldClose(
       document.body,
       'focus',
       event => {
-        const current = getCurrentNode(closeableEl);
-        if (!current.contains(/** @type {Node} */ (event.target))) {
+        if (!closeableEl.current.contains(/** @type {Node} */ (event.target))) {
           handleClose();
         }
       },
@@ -94,8 +61,7 @@ export default function useElementShouldClose(
       document.body,
       ['mousedown', 'click'],
       event => {
-        const current = getCurrentNode(closeableEl);
-        if (!current.contains(/** @type {Node} */ (event.target))) {
+        if (!closeableEl.current.contains(/** @type {Node} */ (event.target))) {
           handleClose();
         }
       },


### PR DESCRIPTION
The `useElementShouldClose` hook that we use to implement non-modal popups (eg. for `Menu`, `TagEditor` and others) supported passing a Preact component instance rather than a DOM element. This support relies on a [deprecated](https://github.com/preactjs/preact/pull/2971) property of Preact component instances. _(Update: The linked Preact PR actually removes the property entirely, it doesn't just deprecate it. All the more reason to land this!)_

We weren't actually using this functionality anywhere. All uses of `useElementShouldClose` passed an element ref. Therefore I have simply removed this functionality and associated tests.

While doing this I found an opportunity, in a second commit, to improve the documentation to explain what the hook is used for rather than how it is implemented internally.

This hook is also used in the LMS frontend, so I think it would make sense to move it to the frontend-shared package. I plan to do that in a separate PR.