### PR TITLE
Set a custom :focus outline style 

### DIFF
--- a/frontend-shared/styles/mixins/focus.scss
+++ b/frontend-shared/styles/mixins/focus.scss
@@ -1,3 +1,25 @@
+@use '../variables' as var;
+
+/**
+ * Add stylized focus to interactive elements such <input> or <textarea>
+ *
+ * @param {boolean} $inset -
+ *   The focus style is implemented with a box-shadow and this parameter determines whether
+ *   the box-shadow should be inset on the element. Set this to true when the element
+ *   may be adjacent to another in order to prevent part of the outline from being obscured.
+ */
+@mixin outline($inset: false) {
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px var.$color-focus-outline if($inset, inset, null);
+  }
+}
+
+@mixin outline--hide {
+  outline: none;
+  box-shadow: none;
+}
+
 /**
  * Display an outline on an element only when it has keyboard focus.
  *
@@ -6,18 +28,21 @@
  *
  * [1] https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
  * [2] https://github.com/WICG/focus-visible
+ *
+ * @param {boolean} $inset - Does the outline render inset or not
  */
-@mixin outline-on-keyboard-focus {
+@mixin outline-on-keyboard-focus($inset: false) {
+  @include outline($inset);
   // Selector for browsers using JS polyfill, which adds the "focus-visible"
   // class to a keyboard-focused element.
   &:focus:not(.focus-visible) {
-    outline: none;
+    @include outline--hide;
   }
 
   // Selector for browsers with native :focus-visible support.
   // (Do not combine with above, as an unsupported pseudo-class disables the
   // entire selector)
   &:focus:not(:focus-visible) {
-    outline: none;
+    @include outline--hide;
   }
 }

--- a/frontend-shared/styles/variables.scss
+++ b/frontend-shared/styles/variables.scss
@@ -1,0 +1,2 @@
+// Other colors
+$color-focus-outline: #51a7e8;

--- a/src/styles/mixins/forms.scss
+++ b/src/styles/mixins/forms.scss
@@ -16,17 +16,9 @@
   }
 }
 
-@mixin focus-outline {
-  border-color: var.$color-focus-outline;
-  box-shadow: 0px 1px 2px var.$color-shadow--base inset,
-    0px 0px 5px var.$color-focus-shadow;
-}
-
 @mixin form-input-focus {
-  outline: none;
   background-color: var.$white;
 
-  @include focus-outline;
   @include placeholder {
     color: var.$color-text--light;
   }
@@ -47,6 +39,7 @@
   }
 
   @include utils.border;
+  @include focus.outline;
   border-radius: var.$border-radius;
   color: var.$color-text--light;
   background-color: var.$grey-0;

--- a/src/styles/sidebar/components/MarkdownEditor.scss
+++ b/src/styles/sidebar/components/MarkdownEditor.scss
@@ -28,26 +28,24 @@
 }
 
 .MarkdownEditor__toolbar-button {
-  @include buttons.reset-native-btn-styles;
-  @include layout.row(center, center);
-  appearance: none;
+  @include buttons.button--icon-only($with-active-state: false);
   min-width: 24px;
   min-height: 24px;
 
-  color: var.$grey-5;
+  padding-top: 0;
+  padding-bottom: 0;
 
-  &:hover,
-  &:focus {
-    color: var.$grey-7;
-  }
+  color: var.$grey-5;
+  transition: none;
 
   &:disabled {
     color: var.$grey-3;
   }
+}
 
-  &-icon {
-    @include utils.icon--xsmall;
-  }
+svg.MarkdownEditor__toolbar-button-icon {
+  // Stronger specificity to override mixin button styling
+  @include utils.icon--xsmall;
 }
 
 .MarkdownEditor__preview {
@@ -91,9 +89,10 @@
   .MarkdownEditor__toolbar-button {
     min-width: var.$touch-target-size;
     min-height: var.$touch-target-size;
+  }
 
-    &-icon {
-      @include utils.icon--small;
-    }
+  svg.MarkdownEditor__toolbar-button-icon {
+    // Stronger specificity to override mixin button styling
+    @include utils.icon--small;
   }
 }

--- a/src/styles/sidebar/components/MenuItem.scss
+++ b/src/styles/sidebar/components/MenuItem.scss
@@ -18,7 +18,7 @@ a.MenuItem:hover {
 }
 
 .MenuItem {
-  @include focus.outline-on-keyboard-focus;
+  @include focus.outline-on-keyboard-focus($inset: true);
   @include layout.row($align: center);
   align-self: stretch;
   flex-grow: 1;

--- a/src/styles/sidebar/components/SelectionTabs.scss
+++ b/src/styles/sidebar/components/SelectionTabs.scss
@@ -33,6 +33,8 @@
   cursor: pointer;
   min-width: 85px;
   min-height: 18px;
+  // Give the tab a radius to allow :focus styling to appear similar to that of buttons
+  border-radius: var.$border-radius;
 
   user-select: none;
 

--- a/src/styles/sidebar/elements.scss
+++ b/src/styles/sidebar/elements.scss
@@ -1,9 +1,16 @@
+@use "@hypothesis/frontend-shared/styles/mixins/focus";
+
 @use "../variables" as var;
 
 // basic standard styling for elements
 a {
+  @include focus.outline-on-keyboard-focus;
+  // Ensure the tag has width in order for :focus styling to render correctly.
+  display: inline-block;
   color: var.$color-link;
   text-decoration: none;
+  // Give links a radius to allow :focus styling to appear similar to that of buttons
+  border-radius: var.$border-radius;
 }
 
 a:active,


### PR DESCRIPTION
### Commits

- Remove existing customized styling on text and input fields
- Override default outline style and instead, replace with a box-shadow that is styled similar to the default outline but with a fixed color
- This allows the outline to still retain a small border radius, and a custom color at the same time

--------------

Change markdown editor :focus styling to look more like button …

- This makes the focus outline behave with a rounded radius.

-------------

Research details
https://docs.google.com/document/d/1iO4uIxp7ECXZnZjnsXQqyxikQKxdtTuZrsbeRNcFba0/edit

fixes https://github.com/hypothesis/lms/issues/2296
fixes https://github.com/hypothesis/client/issues/2226

### Changes Propose

I decided to go with #3 box-shadow effect (see doc) because is honors border-radius and it won't muck with the border styling.  I choose a width of 2px because it was similar to safai / chrome's native styling and a color we already had in our variables.scss file. _Ideally, I would have rather just made overrides to the default outline color, but this was not possible on all browsers (details in google doc above)_

### branch
![focus_2](https://user-images.githubusercontent.com/3939074/107289682-3f61cc80-6a1a-11eb-8752-1fedbc91e0b3.gif)

### master
![outline-current](https://user-images.githubusercontent.com/3939074/106679069-c0c7e380-6570-11eb-8d0f-6c6d7fb9fa57.gif)
