### PR TITLE
Add license and description to frontend-shared package

### DIFF
--- a/frontend-shared/package.json
+++ b/frontend-shared/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@hypothesis/frontend-shared",
   "version": "1.0.0",
+  "description": "Shared components, styles and utilities for Hypothesis projects",
+  "license": "BSD-2-Clause",
   "repository": "hypothesis/client",
   "devDependencies": {
     "@babel/cli": "^7.1.6",


### PR DESCRIPTION
All npm packages should have a license, and yarn complains if there
isn't one. The license chosen here is the same as in the client's
package.json.