### PR TITLE
Generate `.d.ts` files as part of the frontend-shared package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,6 +17,7 @@ const createBundle = require('./scripts/gulp/create-bundle');
 const createStyleBundle = require('./scripts/gulp/create-style-bundle');
 const {
   buildFrontendSharedJs,
+  buildFrontendSharedTypes,
   linkFrontendShared,
 } = require('./scripts/gulp/frontend-shared');
 const manifest = require('./scripts/gulp/manifest');
@@ -137,7 +138,10 @@ gulp.task(
   })
 );
 
-gulp.task('build-frontend-shared-js', buildFrontendSharedJs);
+gulp.task(
+  'build-frontend-shared-js',
+  gulp.parallel(buildFrontendSharedJs, buildFrontendSharedTypes)
+);
 
 gulp.task('link-frontend-shared', linkFrontendShared);
 
@@ -147,7 +151,10 @@ gulp.task(
 );
 
 gulp.task('watch-frontend-shared', () => {
-  gulp.watch('./frontend-shared/src/**', gulp.series(buildFrontendSharedJs));
+  gulp.watch(
+    './frontend-shared/src/**',
+    gulp.series('build-frontend-shared-js')
+  );
 });
 
 gulp.task(

--- a/scripts/gulp/run.js
+++ b/scripts/gulp/run.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const { spawn } = require('child_process');
+
+/**
+ * Run a command and return a promise for when it completes.
+ *
+ * Output and environment is forwarded as if running a CLI command in the terminal
+ * or make.
+ *
+ * This function is useful for running CLI tools as part of a gulp command.
+ *
+ * @param {string} cmd - Command to run
+ * @param {string[]} args - Command arguments
+ * @param {object} options - Options to forward to `spawn`
+ * @return {Promise<void>}
+ */
+function run(cmd, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    spawn(cmd, args, { env: process.env, stdio: 'inherit', ...options }).on(
+      'exit',
+      code => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`${cmd} exited with status ${code}`));
+        }
+      }
+    );
+  });
+}
+
+module.exports = { run };


### PR DESCRIPTION
Generate TypeScript definition files as part of the frontend-shared package so that TS can typecheck code that uses the package in other projects. This creates `.d.ts` files alongside each of the `.js` files in `frontend-shared/lib`.

Within the client repository we don't need to generate these files because TypeScript will read the JSDoc comments. When the package is consumed from other projects however, it seems that it does not read the JSDoc comments. Note that when these `.d.ts` files exist, they are used in preference to JSDoc comments by other code in the client repository. Therefore they
need to be kept up to date when the files are recompiled in watch mode.

In the process of adding this I discovered an issue that the method of running CLI commands in gulp tasks in `scripts/gulp/frontend-shared.js` did not fail if the exit status was non-zero. I created a `run` utility that handles this correctly along with providing the desired defaults.

This PR is a prerequisite for https://github.com/hypothesis/lms/pull/2384.