### PR TITLE
No need to import createElement and Fragment from preact

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,23 +1,36 @@
 {
   "presets": [
-    ["@babel/preset-react", {
-      "pragma": "createElement"
-    }],
+    [
+      "@babel/preset-react",
+      {
+        "runtime": "automatic",
+        "importSource": "preact"
+      }
+    ],
 
     // Compile JS for browser targets set by `browserslist` key in package.json.
-    ["@babel/preset-env", {
-       "bugfixes": true
-    }]
+    [
+      "@babel/preset-env",
+      {
+        "bugfixes": true
+      }
+    ]
   ],
   "plugins": ["inject-args"],
   "ignore": ["**/vendor/*"],
   "env": {
     "development": {
       "presets": [
-        ["@babel/preset-react", {
-          "development": true,
-          "pragma": "createElement"
-        }]
+        [
+          "@babel/preset-react",
+          {
+            "development": true,
+            "runtime": "automatic",
+            // Use `preact/compat/jsx-dev-runtime` which is an alias for `preact/jsx-runtime`.
+            // See https://github.com/preactjs/preact/issues/2974.
+            "importSource": "preact/compat"
+          }
+        ]
       ]
     }
   }

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,10 @@
     "no-prototype-builtins": "off",
 
     // Handled by Prettier.
-    "comma-dangle": "off"
+    "comma-dangle": "off",
+
+    // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
+    "react/jsx-uses-react": "off",
+    "react/react-in-jsx-scope": "off"
   }
 }

--- a/frontend-shared/babel.config.json
+++ b/frontend-shared/babel.config.json
@@ -1,10 +1,15 @@
 {
   "presets": [
     [
-      "@babel/preset-react", {
-        "pragma": "createElement"
-    }],
-    ["@babel/preset-env", {
+      "@babel/preset-react",
+      {
+        "runtime": "automatic",
+        "importSource": "preact"
+      }
+    ],
+    [
+      "@babel/preset-env",
+      {
         "bugfixes": true,
         "targets": {
           "chrome": "57",
@@ -12,15 +17,20 @@
           "safari": "10.1",
           "edge": "17"
         }
-    }]
+      }
+    ]
   ],
   "env": {
     "development": {
       "presets": [
-        ["@babel/preset-react", {
-          "development": true,
-          "pragma": "createElement"
-        }]
+        [
+          "@babel/preset-react",
+          {
+            "development": true,
+            "runtime": "automatic",
+            "importSource": "preact/compat"
+          }
+        ]
       ]
     }
   }

--- a/frontend-shared/src/hooks/test/use-element-should-close-test.js
+++ b/frontend-shared/src/hooks/test/use-element-should-close-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { useRef } from 'preact/hooks';
 import { act } from 'preact/test-utils';
 

--- a/frontend-shared/src/svg-icon.js
+++ b/frontend-shared/src/svg-icon.js
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { createElement } from 'preact';
 import { useLayoutEffect, useRef } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/frontend-shared/src/test/svg-icon-test.js
+++ b/frontend-shared/src/test/svg-icon-test.js
@@ -1,4 +1,4 @@
-import { createElement, render } from 'preact';
+import { render } from 'preact';
 
 import { SvgIcon, availableIcons, registerIcons } from '../svg-icon';
 

--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -1,4 +1,4 @@
-import { createElement, render } from 'preact';
+import { render } from 'preact';
 
 import AdderToolbar from './components/adder-toolbar';
 import { isTouchDevice } from '../shared/user-agent';

--- a/src/annotator/components/adder-toolbar.js
+++ b/src/annotator/components/adder-toolbar.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { useShortcut } from '../../shared/shortcut';

--- a/src/annotator/components/buckets.js
+++ b/src/annotator/components/buckets.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import classnames from 'classnames';
 import propTypes from 'prop-types';
 import scrollIntoView from 'scroll-into-view';

--- a/src/annotator/components/test/buckets-test.js
+++ b/src/annotator/components/test/buckets-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 

--- a/src/annotator/components/test/toolbar-test.js
+++ b/src/annotator/components/test/toolbar-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import Toolbar from '../toolbar';
 

--- a/src/annotator/components/toolbar.js
+++ b/src/annotator/components/toolbar.js
@@ -1,6 +1,5 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
 import propTypes from 'prop-types';
-import { createElement } from 'preact';
 
 /**
  * @param {Object} props

--- a/src/annotator/plugin/bucket-bar.js
+++ b/src/annotator/plugin/bucket-bar.js
@@ -1,6 +1,6 @@
 import Delegator from '../delegator';
 
-import { createElement, render } from 'preact';
+import { render } from 'preact';
 import Buckets from '../components/buckets';
 
 import { anchorBuckets } from '../util/buckets';

--- a/src/annotator/plugin/pdf.js
+++ b/src/annotator/plugin/pdf.js
@@ -1,6 +1,6 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
 import debounce from 'lodash.debounce';
-import { Fragment, createElement, render } from 'preact';
+import { render } from 'preact';
 
 import * as pdfAnchoring from '../anchoring/pdf';
 import Delegator from '../delegator';
@@ -20,7 +20,7 @@ import PDFMetadata from './pdf-metadata';
  */
 function WarningBanner() {
   return (
-    <Fragment>
+    <>
       <div className="annotator-pdf-warning-banner__type">
         <SvgIcon
           name="caution"
@@ -38,7 +38,7 @@ function WarningBanner() {
         </a>{' '}
         in order to annotate with Hypothesis.
       </div>
-    </Fragment>
+    </>
   );
 }
 

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -1,5 +1,4 @@
 import { act } from 'preact/test-utils';
-import { createElement } from 'preact';
 import { mount } from 'enzyme';
 
 import {

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -1,4 +1,4 @@
-import { createElement, render } from 'preact';
+import { render } from 'preact';
 
 import {
   getBoundingClientRect,

--- a/src/annotator/toolbar.js
+++ b/src/annotator/toolbar.js
@@ -1,4 +1,4 @@
-import { createElement, createRef, render } from 'preact';
+import { createRef, render } from 'preact';
 
 import Toolbar from './components/toolbar';
 

--- a/src/shared/test/renderer-options-test.js
+++ b/src/shared/test/renderer-options-test.js
@@ -1,5 +1,4 @@
 import { createElement } from 'preact';
-
 import { setupBrowserFixes } from '../renderer-options';
 
 describe('shared/renderer-options', () => {

--- a/src/shared/test/shortcut-test.js
+++ b/src/shared/test/shortcut-test.js
@@ -1,4 +1,4 @@
-import { createElement, render } from 'preact';
+import { render } from 'preact';
 import { act } from 'preact/test-utils';
 
 import { matchShortcut, installShortcut, useShortcut } from '../shortcut';

--- a/src/sidebar/components/Annotation.js
+++ b/src/sidebar/components/Annotation.js
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';

--- a/src/sidebar/components/AnnotationActionBar.js
+++ b/src/sidebar/components/AnnotationActionBar.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';

--- a/src/sidebar/components/AnnotationBody.js
+++ b/src/sidebar/components/AnnotationBody.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/AnnotationDocumentInfo.js
+++ b/src/sidebar/components/AnnotationDocumentInfo.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import * as annotationMetadata from '../helpers/annotation-metadata';

--- a/src/sidebar/components/AnnotationEditor.js
+++ b/src/sidebar/components/AnnotationEditor.js
@@ -1,5 +1,4 @@
 import { normalizeKeyName } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import { useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/AnnotationHeader.js
+++ b/src/sidebar/components/AnnotationHeader.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import { useMemo } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/AnnotationLicense.js
+++ b/src/sidebar/components/AnnotationLicense.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 
 /**
  * Render information about CC licensing

--- a/src/sidebar/components/AnnotationMissing.js
+++ b/src/sidebar/components/AnnotationMissing.js
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import AnnotationReplyToggle from './AnnotationReplyToggle';

--- a/src/sidebar/components/AnnotationPublishControl.js
+++ b/src/sidebar/components/AnnotationPublishControl.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';

--- a/src/sidebar/components/AnnotationQuote.js
+++ b/src/sidebar/components/AnnotationQuote.js
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { isOrphan, quote } from '../helpers/annotation-metadata';

--- a/src/sidebar/components/AnnotationReplyToggle.js
+++ b/src/sidebar/components/AnnotationReplyToggle.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import Button from './Button';

--- a/src/sidebar/components/AnnotationShareControl.js
+++ b/src/sidebar/components/AnnotationShareControl.js
@@ -1,5 +1,4 @@
 import { SvgIcon, useElementShouldClose } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/AnnotationShareInfo.js
+++ b/src/sidebar/components/AnnotationShareInfo.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';

--- a/src/sidebar/components/AnnotationTimestamps.js
+++ b/src/sidebar/components/AnnotationTimestamps.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { useEffect, useMemo, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/AnnotationUser.js
+++ b/src/sidebar/components/AnnotationUser.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { isThirdPartyUser, username } from '../helpers/account-id';

--- a/src/sidebar/components/AnnotationView.js
+++ b/src/sidebar/components/AnnotationView.js
@@ -1,4 +1,3 @@
-import { Fragment, createElement } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
@@ -82,7 +81,7 @@ function AnnotationView({ loadAnnotationsService, onLogin }) {
   ]);
 
   return (
-    <Fragment>
+    <>
       {fetchError && (
         // This is the same error shown if a direct-linked annotation cannot
         // be fetched in the sidebar. Fortunately the error message makes sense
@@ -90,7 +89,7 @@ function AnnotationView({ loadAnnotationsService, onLogin }) {
         <SidebarContentError errorType="annotation" onLoginRequest={onLogin} />
       )}
       <ThreadList thread={rootThread} />
-    </Fragment>
+    </>
   );
 }
 

--- a/src/sidebar/components/AutocompleteList.js
+++ b/src/sidebar/components/AutocompleteList.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import classnames from 'classnames';
 import { useMemo } from 'preact/hooks';
 import propTypes from 'prop-types';

--- a/src/sidebar/components/Button.js
+++ b/src/sidebar/components/Button.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 /**

--- a/src/sidebar/components/Excerpt.js
+++ b/src/sidebar/components/Excerpt.js
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { createElement } from 'preact';
 import { useCallback, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/FilterSelect.js
+++ b/src/sidebar/components/FilterSelect.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import Menu from './Menu';

--- a/src/sidebar/components/FilterStatus.js
+++ b/src/sidebar/components/FilterStatus.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { useMemo } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/GroupList.js
+++ b/src/sidebar/components/GroupList.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { useMemo, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/GroupListItem.js
+++ b/src/sidebar/components/GroupListItem.js
@@ -1,4 +1,3 @@
-import { Fragment, createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';
@@ -105,7 +104,7 @@ function GroupListItem({
       onClick={isSelectable ? focusGroup : toggleSubmenu}
       onToggleSubmenu={toggleSubmenu}
       submenu={
-        <Fragment>
+        <>
           <ul>
             {activityUrl && (
               <li>
@@ -143,7 +142,7 @@ function GroupListItem({
               This group is restricted to specific URLs.
             </p>
           )}
-        </Fragment>
+        </>
       }
     />
   );

--- a/src/sidebar/components/GroupListSection.js
+++ b/src/sidebar/components/GroupListSection.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import GroupListItem from './GroupListItem';

--- a/src/sidebar/components/HelpPanel.js
+++ b/src/sidebar/components/HelpPanel.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import { useCallback, useMemo, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { createElement } from 'preact';
 import { useEffect, useMemo } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/LoggedOutMessage.js
+++ b/src/sidebar/components/LoggedOutMessage.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { withServices } from '../service-context';

--- a/src/sidebar/components/LoginPromptPanel.js
+++ b/src/sidebar/components/LoginPromptPanel.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';

--- a/src/sidebar/components/MarkdownEditor.js
+++ b/src/sidebar/components/MarkdownEditor.js
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import { SvgIcon, normalizeKeyName } from '@hypothesis/frontend-shared';
-import { createElement, createRef } from 'preact';
+import { createRef } from 'preact';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/MarkdownView.js
+++ b/src/sidebar/components/MarkdownView.js
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { createElement } from 'preact';
 import { useEffect, useMemo, useRef } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/Menu.js
+++ b/src/sidebar/components/Menu.js
@@ -4,7 +4,6 @@ import {
   normalizeKeyName,
   useElementShouldClose,
 } from '@hypothesis/frontend-shared';
-import { Fragment, createElement } from 'preact';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 
@@ -186,7 +185,7 @@ export default function Menu({
         </span>
       </button>
       {isOpen && (
-        <Fragment>
+        <>
           {menuArrow(arrowClass)}
           <div
             className={classnames(
@@ -203,7 +202,7 @@ export default function Menu({
               {children}
             </MenuKeyboardNavigation>
           </div>
-        </Fragment>
+        </>
       )}
     </div>
   );

--- a/src/sidebar/components/MenuItem.js
+++ b/src/sidebar/components/MenuItem.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { SvgIcon, normalizeKeyName } from '@hypothesis/frontend-shared';
-import { Fragment, createElement } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 import propTypes from 'prop-types';
 
@@ -215,7 +214,7 @@ export default function MenuItem({
     );
   }
   return (
-    <Fragment>
+    <>
       {menuItem}
       {hasSubmenuVisible && (
         <Slider visible={/** @type {boolean} */ (isSubmenuVisible)}>
@@ -228,7 +227,7 @@ export default function MenuItem({
           </MenuKeyboardNavigation>
         </Slider>
       )}
-    </Fragment>
+    </>
   );
 }
 

--- a/src/sidebar/components/MenuKeyboardNavigation.js
+++ b/src/sidebar/components/MenuKeyboardNavigation.js
@@ -1,5 +1,4 @@
 import { normalizeKeyName } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/MenuSection.js
+++ b/src/sidebar/components/MenuSection.js
@@ -1,4 +1,4 @@
-import { Fragment, createElement, toChildArray } from 'preact';
+import { toChildArray } from 'preact';
 import propTypes from 'prop-types';
 
 /** @typedef {import("preact").JSX.Element} JSXElement */
@@ -28,14 +28,14 @@ import propTypes from 'prop-types';
  */
 export default function MenuSection({ heading, children }) {
   return (
-    <Fragment>
+    <>
       {heading && <h2 className="MenuSection__heading">{heading}</h2>}
       <ul className="MenuSection__content">
         {toChildArray(children).map(child => (
           <li key={/** @type {JSXElement} **/ (child).key}>{child}</li>
         ))}
       </ul>
-    </Fragment>
+    </>
   );
 }
 

--- a/src/sidebar/components/ModerationBanner.js
+++ b/src/sidebar/components/ModerationBanner.js
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';

--- a/src/sidebar/components/NewNoteBtn.js
+++ b/src/sidebar/components/NewNoteBtn.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';

--- a/src/sidebar/components/NotebookFilters.js
+++ b/src/sidebar/components/NotebookFilters.js
@@ -1,5 +1,3 @@
-import { createElement } from 'preact';
-
 import { useStoreProxy } from '../store/use-store';
 import { useUserFilterOptions } from './hooks/use-filter-options';
 

--- a/src/sidebar/components/NotebookResultCount.js
+++ b/src/sidebar/components/NotebookResultCount.js
@@ -1,5 +1,3 @@
-import { createElement } from 'preact';
-
 import useRootThread from './hooks/use-root-thread';
 import { useStoreProxy } from '../store/use-store';
 import { countVisible } from '../helpers/thread';

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { useEffect } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/SearchInput.js
+++ b/src/sidebar/components/SearchInput.js
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { createElement } from 'preact';
 import { useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/SelectionTabs.js
+++ b/src/sidebar/components/SelectionTabs.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';

--- a/src/sidebar/components/ShareAnnotationsPanel.js
+++ b/src/sidebar/components/ShareAnnotationsPanel.js
@@ -1,4 +1,3 @@
-import { createElement, Fragment } from 'preact';
 import { SvgIcon } from '@hypothesis/frontend-shared';
 import propTypes from 'prop-types';
 
@@ -62,7 +61,7 @@ function ShareAnnotationsPanel({ analytics, toastMessenger }) {
       {sharingReady && (
         <div className="ShareAnnotationsPanel">
           {shareURI ? (
-            <Fragment>
+            <>
               <div className="ShareAnnotationsPanel__intro">
                 {notNull(focusedGroup).type === 'private' ? (
                   <p>
@@ -111,7 +110,7 @@ function ShareAnnotationsPanel({ analytics, toastMessenger }) {
                 shareURI={shareURI}
                 analyticsEventName={analytics.events.DOCUMENT_SHARED}
               />
-            </Fragment>
+            </>
           ) : (
             <p>
               These annotations cannot be shared because this document is not

--- a/src/sidebar/components/ShareLinks.js
+++ b/src/sidebar/components/ShareLinks.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { withServices } from '../service-context';

--- a/src/sidebar/components/SidebarContentError.js
+++ b/src/sidebar/components/SidebarContentError.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import classnames from 'classnames';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/SidebarPanel.js
+++ b/src/sidebar/components/SidebarPanel.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 import propTypes from 'prop-types';
 import scrollIntoView from 'scroll-into-view';

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 import { useEffect, useRef } from 'preact/hooks';
 

--- a/src/sidebar/components/Slider.js
+++ b/src/sidebar/components/Slider.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/SortMenu.js
+++ b/src/sidebar/components/SortMenu.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 
 import { useStoreProxy } from '../store/use-store';
 

--- a/src/sidebar/components/Spinner.js
+++ b/src/sidebar/components/Spinner.js
@@ -1,5 +1,3 @@
-import { createElement } from 'preact';
-
 /**
  * Loading indicator.
  */

--- a/src/sidebar/components/StreamSearchInput.js
+++ b/src/sidebar/components/StreamSearchInput.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';

--- a/src/sidebar/components/StreamView.js
+++ b/src/sidebar/components/StreamView.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { useCallback, useEffect } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -3,7 +3,6 @@ import {
   normalizeKeyName,
   useElementShouldClose,
 } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import { useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/TagList.js
+++ b/src/sidebar/components/TagList.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { useMemo } from 'preact/hooks';
 import propTypes from 'prop-types';
 

--- a/src/sidebar/components/Thread.js
+++ b/src/sidebar/components/Thread.js
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { createElement, Fragment } from 'preact';
 import { useCallback, useMemo } from 'preact/hooks';
 
 import propTypes from 'prop-types';
@@ -64,7 +63,7 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
   const annotationContent = useMemo(() => {
     if (showAnnotation) {
       return (
-        <Fragment>
+        <>
           <ModerationBanner annotation={thread.annotation} />
           <Annotation
             annotation={thread.annotation}
@@ -75,7 +74,7 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
             showDocumentInfo={showDocumentInfo}
             threadIsCollapsed={thread.collapsed}
           />
-        </Fragment>
+        </>
       );
     } else if (showMissingAnnotation) {
       return (

--- a/src/sidebar/components/ThreadCard.js
+++ b/src/sidebar/components/ThreadCard.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import debounce from 'lodash.debounce';
-import { createElement } from 'preact';
 import { useCallback, useMemo } from 'preact/hooks';
 
 import propTypes from 'prop-types';

--- a/src/sidebar/components/ThreadList.js
+++ b/src/sidebar/components/ThreadList.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { useEffect, useLayoutEffect, useMemo, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
 import debounce from 'lodash.debounce';

--- a/src/sidebar/components/ToastMessages.js
+++ b/src/sidebar/components/ToastMessages.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -1,4 +1,3 @@
-import { Fragment, createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import bridgeEvents from '../../shared/bridge-events';
@@ -79,7 +78,7 @@ function TopBar({
   };
 
   const loginControl = (
-    <Fragment>
+    <>
       {auth.status === 'unknown' && (
         <span className="TopBar__login-links">⋯</span>
       )}
@@ -103,7 +102,7 @@ function TopBar({
       {auth.status === 'logged-in' && (
         <UserMenu auth={auth} onLogout={onLogout} />
       )}
-    </Fragment>
+    </>
   );
 
   return (

--- a/src/sidebar/components/Tutorial.js
+++ b/src/sidebar/components/Tutorial.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import isThirdPartyService from '../helpers/is-third-party-service';

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import bridgeEvents from '../../shared/bridge-events';

--- a/src/sidebar/components/VersionInfo.js
+++ b/src/sidebar/components/VersionInfo.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import propTypes from 'prop-types';
 
 import { copyText } from '../util/copy-to-clipboard';

--- a/src/sidebar/components/hooks/test/use-filter-options-test.js
+++ b/src/sidebar/components/hooks/test/use-filter-options-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import { useUserFilterOptions } from '../use-filter-options';
 import { $imports } from '../use-filter-options';

--- a/src/sidebar/components/hooks/test/use-root-thread-test.js
+++ b/src/sidebar/components/hooks/test/use-root-thread-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import useRootThread from '../use-root-thread';
 import { $imports } from '../use-root-thread';

--- a/src/sidebar/components/test/Annotation-test.js
+++ b/src/sidebar/components/test/Annotation-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import * as fixtures from '../../test/annotation-fixtures';
 

--- a/src/sidebar/components/test/AnnotationActionBar-test.js
+++ b/src/sidebar/components/test/AnnotationActionBar-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import AnnotationActionBar from '../AnnotationActionBar';

--- a/src/sidebar/components/test/AnnotationBody-test.js
+++ b/src/sidebar/components/test/AnnotationBody-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import * as fixtures from '../../test/annotation-fixtures';

--- a/src/sidebar/components/test/AnnotationDocumentInfo-test.js
+++ b/src/sidebar/components/test/AnnotationDocumentInfo-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import * as fixtures from '../../test/annotation-fixtures';
 import AnnotationDocumentInfo from '../AnnotationDocumentInfo';

--- a/src/sidebar/components/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/test/AnnotationEditor-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import * as fixtures from '../../test/annotation-fixtures';

--- a/src/sidebar/components/test/AnnotationHeader-test.js
+++ b/src/sidebar/components/test/AnnotationHeader-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import * as fixtures from '../../test/annotation-fixtures';
 import AnnotationHeader from '../AnnotationHeader';

--- a/src/sidebar/components/test/AnnotationMissing-test.js
+++ b/src/sidebar/components/test/AnnotationMissing-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import AnnotationMissing, { $imports } from '../AnnotationMissing';
 

--- a/src/sidebar/components/test/AnnotationPublishControl-test.js
+++ b/src/sidebar/components/test/AnnotationPublishControl-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import * as fixtures from '../../test/annotation-fixtures';
 import AnnotationPublishControl from '../AnnotationPublishControl';

--- a/src/sidebar/components/test/AnnotationQuote-test.js
+++ b/src/sidebar/components/test/AnnotationQuote-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import AnnotationQuote from '../AnnotationQuote';
 import { $imports } from '../AnnotationQuote';

--- a/src/sidebar/components/test/AnnotationReplyToggle-test.js
+++ b/src/sidebar/components/test/AnnotationReplyToggle-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import AnnotationReplyToggle from '../AnnotationReplyToggle';

--- a/src/sidebar/components/test/AnnotationShareControl-test.js
+++ b/src/sidebar/components/test/AnnotationShareControl-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import AnnotationShareControl from '../AnnotationShareControl';

--- a/src/sidebar/components/test/AnnotationShareInfo-test.js
+++ b/src/sidebar/components/test/AnnotationShareInfo-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import * as fixtures from '../../test/annotation-fixtures';
 import AnnotationShareInfo from '../AnnotationShareInfo';

--- a/src/sidebar/components/test/AnnotationTimestamps-test.js
+++ b/src/sidebar/components/test/AnnotationTimestamps-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import * as fixtures from '../../test/annotation-fixtures';
 import { act } from 'preact/test-utils';
 

--- a/src/sidebar/components/test/AnnotationUser-test.js
+++ b/src/sidebar/components/test/AnnotationUser-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import AnnotationUser from '../AnnotationUser';
 import { $imports } from '../AnnotationUser';

--- a/src/sidebar/components/test/AnnotationView-test.js
+++ b/src/sidebar/components/test/AnnotationView-test.js
@@ -1,4 +1,3 @@
-import { createElement } from 'preact';
 import { mount } from 'enzyme';
 
 import { waitFor } from '../../../test-util/wait';

--- a/src/sidebar/components/test/AutocompletList-test.js
+++ b/src/sidebar/components/test/AutocompletList-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import AutocompleteList from '../AutocompleteList';
 import { $imports } from '../AutocompleteList';

--- a/src/sidebar/components/test/Button-test.js
+++ b/src/sidebar/components/test/Button-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import Button from '../Button';
 import { $imports } from '../Button';

--- a/src/sidebar/components/test/Excerpt-test.js
+++ b/src/sidebar/components/test/Excerpt-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import Excerpt from '../Excerpt';

--- a/src/sidebar/components/test/FilterSelect-test.js
+++ b/src/sidebar/components/test/FilterSelect-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import FilterSelect from '../FilterSelect';
 import { $imports } from '../FilterSelect';

--- a/src/sidebar/components/test/FilterStatus-test.js
+++ b/src/sidebar/components/test/FilterStatus-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import FilterStatus, { $imports } from '../FilterStatus';
 

--- a/src/sidebar/components/test/GroupList-test.js
+++ b/src/sidebar/components/test/GroupList-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import GroupList from '../GroupList';

--- a/src/sidebar/components/test/GroupListItem-test.js
+++ b/src/sidebar/components/test/GroupListItem-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import { events } from '../../services/analytics';

--- a/src/sidebar/components/test/GroupListSection-test.js
+++ b/src/sidebar/components/test/GroupListSection-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import GroupListSection from '../GroupListSection';
 import { $imports } from '../GroupListSection';

--- a/src/sidebar/components/test/HelpPanel-test.js
+++ b/src/sidebar/components/test/HelpPanel-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import HelpPanel from '../HelpPanel';

--- a/src/sidebar/components/test/HypothesisApp-test.js
+++ b/src/sidebar/components/test/HypothesisApp-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import bridgeEvents from '../../../shared/bridge-events';
 import mockImportedComponents from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/LoggedOutMessage-test.js
+++ b/src/sidebar/components/test/LoggedOutMessage-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import LoggedOutMessage from '../LoggedOutMessage';
 import { $imports } from '../LoggedOutMessage';

--- a/src/sidebar/components/test/LoginPromptPanel-test.js
+++ b/src/sidebar/components/test/LoginPromptPanel-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import LoginPromptPanel from '../LoginPromptPanel';
 import { $imports } from '../LoginPromptPanel';

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme';
-import { createElement, render } from 'preact';
+import { render } from 'preact';
 import { act } from 'preact/test-utils';
 
 import { LinkType } from '../../markdown-commands';

--- a/src/sidebar/components/test/MarkdownView-test.js
+++ b/src/sidebar/components/test/MarkdownView-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import MarkdownView from '../MarkdownView';
 import { $imports } from '../MarkdownView';

--- a/src/sidebar/components/test/Menu-test.js
+++ b/src/sidebar/components/test/Menu-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import Menu from '../Menu';

--- a/src/sidebar/components/test/MenuItem-test.js
+++ b/src/sidebar/components/test/MenuItem-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import MenuItem from '../MenuItem';

--- a/src/sidebar/components/test/MenuKeyboardNavigation-test.js
+++ b/src/sidebar/components/test/MenuKeyboardNavigation-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import MenuKeyboardNavigation from '../MenuKeyboardNavigation';
 import { $imports } from '../MenuKeyboardNavigation';

--- a/src/sidebar/components/test/MenuSection-test.js
+++ b/src/sidebar/components/test/MenuSection-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import MenuSection from '../MenuSection';
 import { $imports } from '../MenuSection';

--- a/src/sidebar/components/test/ModerationBanner-test.js
+++ b/src/sidebar/components/test/ModerationBanner-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import * as fixtures from '../../test/annotation-fixtures';
 import ModerationBanner from '../ModerationBanner';

--- a/src/sidebar/components/test/NewNoteBtn-test.js
+++ b/src/sidebar/components/test/NewNoteBtn-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import NewNoteButton from '../NewNoteBtn';

--- a/src/sidebar/components/test/NotebookFilters-test.js
+++ b/src/sidebar/components/test/NotebookFilters-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import NotebookFilters from '../NotebookFilters';
 import { $imports } from '../NotebookFilters';

--- a/src/sidebar/components/test/NotebookResultCount-test.js
+++ b/src/sidebar/components/test/NotebookResultCount-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import NotebookResultCount from '../NotebookResultCount';
 import { $imports } from '../NotebookResultCount';

--- a/src/sidebar/components/test/NotebookView-test.js
+++ b/src/sidebar/components/test/NotebookView-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 

--- a/src/sidebar/components/test/SearchInput-test.js
+++ b/src/sidebar/components/test/SearchInput-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import SearchInput from '../SearchInput';
 import { $imports } from '../SearchInput';

--- a/src/sidebar/components/test/SelectionTabs-test.js
+++ b/src/sidebar/components/test/SelectionTabs-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import SelectionTabs from '../SelectionTabs';
 import { $imports } from '../SelectionTabs';

--- a/src/sidebar/components/test/ShareAnnotationsPanel-test.js
+++ b/src/sidebar/components/test/ShareAnnotationsPanel-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import ShareAnnotationsPanel from '../ShareAnnotationsPanel';
 import { $imports } from '../ShareAnnotationsPanel';

--- a/src/sidebar/components/test/ShareLinks-test.js
+++ b/src/sidebar/components/test/ShareLinks-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import ShareLinks from '../ShareLinks';
 import { $imports } from '../ShareLinks';

--- a/src/sidebar/components/test/SidebarContentError-test.js
+++ b/src/sidebar/components/test/SidebarContentError-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import SidebarContentError from '../SidebarContentError';
 import { $imports } from '../SidebarContentError';

--- a/src/sidebar/components/test/SidebarPanel-test.js
+++ b/src/sidebar/components/test/SidebarPanel-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import SidebarPanel from '../SidebarPanel';
 import { $imports } from '../SidebarPanel';

--- a/src/sidebar/components/test/SidebarView-test.js
+++ b/src/sidebar/components/test/SidebarView-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import SidebarView from '../SidebarView';
 import { $imports } from '../SidebarView';

--- a/src/sidebar/components/test/SortMenu-test.js
+++ b/src/sidebar/components/test/SortMenu-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import SortMenu from '../SortMenu';
 import { $imports } from '../SortMenu';

--- a/src/sidebar/components/test/Spinner-test.js
+++ b/src/sidebar/components/test/Spinner-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import Spinner from '../Spinner';
 

--- a/src/sidebar/components/test/StreamSearchInput-test.js
+++ b/src/sidebar/components/test/StreamSearchInput-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import StreamSearchInput from '../StreamSearchInput';

--- a/src/sidebar/components/test/StreamView-test.js
+++ b/src/sidebar/components/test/StreamView-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 import { waitFor } from '../../../test-util/wait';

--- a/src/sidebar/components/test/TagEditor-test.js
+++ b/src/sidebar/components/test/TagEditor-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import AutocompleteList from '../AutocompleteList';

--- a/src/sidebar/components/test/TagList-test.js
+++ b/src/sidebar/components/test/TagList-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import TagList from '../TagList';
 import { $imports } from '../TagList';

--- a/src/sidebar/components/test/Thread-test.js
+++ b/src/sidebar/components/test/Thread-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import Thread from '../Thread';

--- a/src/sidebar/components/test/ThreadCard-test.js
+++ b/src/sidebar/components/test/ThreadCard-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import ThreadCard from '../ThreadCard';
 import { $imports } from '../ThreadCard';

--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import ThreadList from '../ThreadList';

--- a/src/sidebar/components/test/ToastMessages-test.js
+++ b/src/sidebar/components/test/ToastMessages-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import mockImportedComponents from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import bridgeEvents from '../../../shared/bridge-events';
 import TopBar from '../TopBar';

--- a/src/sidebar/components/test/Tutorial-test.js
+++ b/src/sidebar/components/test/Tutorial-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import Tutorial from '../Tutorial';
 import { $imports } from '../Tutorial';

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import bridgeEvents from '../../../shared/bridge-events';
 import UserMenu from '../UserMenu';

--- a/src/sidebar/components/test/VersionInfo-test.js
+++ b/src/sidebar/components/test/VersionInfo-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import VersionInfo from '../VersionInfo';
 import { $imports } from '../VersionInfo';

--- a/src/sidebar/components/test/slider-test.js
+++ b/src/sidebar/components/test/slider-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 
 import Slider from '../Slider';
 

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -99,7 +99,7 @@ import iconSet from './icons';
 registerIcons(iconSet);
 
 // The entry point component for the app.
-import { createElement, render } from 'preact';
+import { render } from 'preact';
 import HypothesisApp from './components/HypothesisApp';
 import { ServiceContext } from './service-context';
 

--- a/src/sidebar/service-context.js
+++ b/src/sidebar/service-context.js
@@ -12,7 +12,7 @@
  * @typedef {import("redux").Store} Store
  */
 
-import { createContext, createElement } from 'preact';
+import { createContext } from 'preact';
 import { useContext } from 'preact/hooks';
 
 /**

--- a/src/sidebar/store/test/use-store-test.js
+++ b/src/sidebar/store/test/use-store-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { act } from 'preact/test-utils';
 
 import createStore from '../create-store';

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { createElement } from 'preact';
 import { useReducer } from 'preact/hooks';
 import { act } from 'preact/test-utils';
 

--- a/src/sidebar/test/service-context-test.js
+++ b/src/sidebar/test/service-context-test.js
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme';
-import { createElement, render } from 'preact';
+import { render } from 'preact';
 import propTypes from 'prop-types';
 
 import { ServiceContext, withServices, useService } from '../service-context';

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,23 +3,20 @@
     "allowJs": true,
     "checkJs": true,
     "lib": ["es2018", "dom"],
-    "jsx": "react",
-    "jsxFactory": "createElement",
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "module": "commonjs",
     "noEmit": true,
     "strict": true,
     "noImplicitAny": false,
     "target": "ES2020"
   },
-  "include": [
-    "**/*.js",
-    "../frontend-shared/src/**/*.js",
-  ],
+  "include": ["**/*.js", "../frontend-shared/src/**/*.js"],
   "exclude": [
     // Tests are not checked.
     "**/test/**/*.js",
     "test-util/**/*.js",
     "karma.config.js",
-    "../frontend-shared/src/**/test/*.js",
+    "../frontend-shared/src/**/test/*.js"
   ]
 }


### PR DESCRIPTION
This PR enables Babel `"runtime": "automatic"`. This features auto imports the functions that JSX transpiles to.

These are some advantages of enabling this option:
- improve ergonomics: no need to import createElement and Fragment from preact
- potentially an improvement in the bundle size, although not in our particular case (it has not impact)
- promotes the use of the Fragment shorter syntax, `<></>`