### PR TITLE
Changes in configuration files: prettierc and babel.config.json

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "singleQuote": true
-}

--- a/frontend-shared/.babelrc.cjs
+++ b/frontend-shared/.babelrc.cjs
@@ -1,4 +1,6 @@
-{
+'use strict';
+
+module.exports = {
   "presets": [
     [
       "@babel/preset-react",
@@ -28,6 +30,8 @@
           {
             "development": true,
             "runtime": "automatic",
+            // Use `preact/compat/jsx-dev-runtime` which is an alias for `preact/jsx-runtime`.
+            // See https://github.com/preactjs/preact/issues/2974.
             "importSource": "preact/compat"
           }
         ]

--- a/package.json
+++ b/package.json
@@ -113,6 +113,10 @@
       ]
     ]
   },
+  "prettier": {
+    "arrowParens": "avoid",
+    "singleQuote": true
+  },
   "browser": {
     "fetch-mock": "./node_modules/fetch-mock/cjs/client.js"
   },

--- a/scripts/gulp/frontend-shared.js
+++ b/scripts/gulp/frontend-shared.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const fs = require('fs');
-
 const gulp = require('gulp');
 const babel = require('gulp-babel');
 const sourcemaps = require('gulp-sourcemaps');
@@ -10,10 +8,8 @@ const { run } = require('./run');
 
 const buildFrontendSharedJs = () => {
   // There does not appear to be a simple way of forcing gulp-babel to use a config
-  // file. Load it up as JSON and pass it in manually.
-  const babelConfig = JSON.parse(
-    fs.readFileSync('./frontend-shared/babel.config.json')
-  );
+  // file. Load it up and pass it in manually.
+  const babelConfig = require('../../frontend-shared/.babelrc.cjs');
 
   return (
     gulp

--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -102,7 +102,7 @@ module.exports = function (config) {
             // The existence of this preset option is due to a config issue with frontend-shared/
             // where jsx modules are not transpiled to js.
             // See https://github.com/hypothesis/client/issues/2929
-            presets: require('../frontend-shared/babel.config.json').presets,
+            presets: require('../frontend-shared/.babelrc.cjs').presets,
             extensions: ['.js'],
             plugins: [
               'mockable-imports',


### PR DESCRIPTION
* moved prettierc to package.json. This is a minimal configuration file with no comments.
* moved frontend-shared/babel.config.json to frontend-shared/.babelrc.cjs. This changes allows the configuration to have comments and continue to be loaded via CommonJS `require`.