### PR TITLE
POC: Implement simple front-end pagination for the Notebook

### DIFF
--- a/src/sidebar/components/AnnotationView.js
+++ b/src/sidebar/components/AnnotationView.js
@@ -88,7 +88,7 @@ function AnnotationView({ loadAnnotationsService, onLogin }) {
         // for this scenario as well.
         <SidebarContentError errorType="annotation" onLoginRequest={onLogin} />
       )}
-      <ThreadList thread={rootThread} />
+      <ThreadList threads={rootThread.children} />
     </>
   );
 }

--- a/src/sidebar/components/Button.js
+++ b/src/sidebar/components/Button.js
@@ -14,6 +14,8 @@ import propTypes from 'prop-types';
  *   See `buttons` SCSS mixins module for more details.
  * @prop {string} [icon] -
  *   The name of the SVGIcon to render. This is optional if a `buttonText` is provided.
+ * @prop {'left'|'right'} [iconPosition] - Whether icon should render to the left or
+ *   to the right of label text
  * @prop {boolean} [isExpanded] -
  *   Is the expandable element controlled by this button currently expanded?
  * @prop {boolean} [isPressed] -
@@ -40,6 +42,7 @@ export default function Button({
   className = '',
   disabled = false,
   icon = '',
+  iconPosition = 'left',
   isExpanded,
   isPressed,
   onClick = () => {},
@@ -78,8 +81,9 @@ export default function Button({
       disabled={disabled}
       {...extraProps}
     >
-      {icon && <SvgIcon name={icon} />}
+      {icon && iconPosition === 'left' && <SvgIcon name={icon} />}
       {buttonText}
+      {icon && iconPosition === 'right' && <SvgIcon name={icon} />}
     </button>
   );
 }
@@ -108,6 +112,7 @@ Button.propTypes = {
   buttonText: propTypes.string,
   className: propTypes.string,
   icon: requiredStringIfButtonTextMissing,
+  iconPosition: propTypes.string,
   isExpanded: propTypes.bool,
   isPressed: propTypes.bool,
   onClick: propTypes.func,

--- a/src/sidebar/components/NotebookResultCount.js
+++ b/src/sidebar/components/NotebookResultCount.js
@@ -1,8 +1,18 @@
+import propTypes from 'prop-types';
+
 import useRootThread from './hooks/use-root-thread';
-import { useStoreProxy } from '../store/use-store';
 import { countVisible } from '../helpers/thread';
 
 import Spinner from './Spinner';
+
+/**
+ * @typedef NotebookResultCountProps
+ * @prop {number} currentPage
+ * @prop {number} forcedVisibleCount
+ * @prop {boolean} isFiltered
+ * @prop {boolean} isLoading
+ * @prop {number} resultCount
+ */
 
 /**
  * Render count of annotations (or filtered results) visible in the notebook view
@@ -12,21 +22,22 @@ import Spinner from './Spinner';
  * - Annotations are unfiltered: "X threads (Y annotations)"
  *     Thread count does not render until all annotations are loaded
  * - Annotations are filtered: "X results [(and Y more)]"
+ *
+ * @param {NotebookResultCountProps} props
  */
-function NotebookResultCount() {
-  const store = useStoreProxy();
-
-  const forcedVisibleCount = store.forcedVisibleThreads().length;
-  const hasAppliedFilter = store.hasAppliedFilter();
-  const resultCount = store.annotationResultCount();
-  const isLoading = store.isLoading();
-
+function NotebookResultCount({
+  currentPage,
+  forcedVisibleCount,
+  isFiltered,
+  isLoading,
+  resultCount,
+}) {
   const rootThread = useRootThread();
   const visibleCount = isLoading ? resultCount : countVisible(rootThread);
 
   const hasResults = rootThread.children.length > 0;
 
-  const hasForcedVisible = hasAppliedFilter && forcedVisibleCount > 0;
+  const hasForcedVisible = isFiltered && forcedVisibleCount > 0;
   const matchCount = visibleCount - forcedVisibleCount;
   const threadCount = rootThread.children.length;
 
@@ -35,21 +46,22 @@ function NotebookResultCount() {
       {isLoading && <Spinner />}
       {!isLoading && (
         <h2>
-          {!hasResults && <span>No results</span>}
-          {hasResults && hasAppliedFilter && (
-            <span>
+          {currentPage > 1 && <span>Page {currentPage} of </span>}
+          {!hasResults && <em>No results</em>}
+          {hasResults && isFiltered && (
+            <em>
               {matchCount} {matchCount === 1 ? 'result' : 'results'}
-            </span>
+            </em>
           )}
-          {hasResults && !hasAppliedFilter && (
-            <span>
+          {hasResults && !isFiltered && (
+            <em>
               {threadCount} {threadCount === 1 ? 'thread' : 'threads'}
-            </span>
+            </em>
           )}
         </h2>
       )}
       {hasForcedVisible && <h3>(and {forcedVisibleCount} more)</h3>}
-      {!hasAppliedFilter && hasResults && (
+      {!isFiltered && hasResults && (
         <h3>
           ({visibleCount} {visibleCount === 1 ? 'annotation' : 'annotations'})
         </h3>
@@ -58,6 +70,12 @@ function NotebookResultCount() {
   );
 }
 
-NotebookResultCount.propTypes = {};
+NotebookResultCount.propTypes = {
+  currentPage: propTypes.number,
+  forcedVisibleCount: propTypes.number,
+  isFiltered: propTypes.bool,
+  isLoading: propTypes.bool,
+  resultCount: propTypes.number,
+};
 
 export default NotebookResultCount;

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -51,7 +51,7 @@ function NotebookView({ loadAnnotationsService }) {
         <NotebookResultCount />
       </div>
       <div className="NotebookView__items">
-        <ThreadList thread={rootThread} />
+        <ThreadList threads={rootThread.children} />
       </div>
     </div>
   );

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -1,5 +1,6 @@
-import { useEffect } from 'preact/hooks';
+import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
+import scrollIntoView from 'scroll-into-view';
 
 import { withServices } from '../service-context';
 import useRootThread from './hooks/use-root-thread';
@@ -7,7 +8,8 @@ import { useStoreProxy } from '../store/use-store';
 
 import NotebookFilters from './NotebookFilters';
 import NotebookResultCount from './NotebookResultCount';
-import ThreadList from './ThreadList';
+
+import PaginatedThreadList from './PaginatedThreadList';
 
 /**
  * @typedef NotebookViewProps
@@ -21,37 +23,88 @@ import ThreadList from './ThreadList';
  */
 function NotebookView({ loadAnnotationsService }) {
   const store = useStoreProxy();
-  const focusedGroup = store.focusedGroup();
 
-  // Reload annotations if focused group changes
+  const filters = store.getFilterValues();
+  const focusedGroup = store.focusedGroup();
+  const forcedVisibleCount = store.forcedVisibleThreads().length;
+  const hasAppliedFilter = store.hasAppliedFilter();
+  const isLoading = store.isLoading();
+  const resultCount = store.annotationResultCount();
+
+  const rootThread = useRootThread();
+
+  const groupName = focusedGroup?.name ?? '…';
+
+  const lastPaginationPage = useRef(1);
+  const [paginationPage, setPaginationPage] = useState(1);
+
+  // Load all annotations; re-load if `focusedGroup` changes
   useEffect(() => {
     // Load all annotations in the group, unless there are more than 5000
-    // of them: this is a performance safety valve
+    // of them: this is a performance safety valve.
+
+    // NB: In current implementation, this will only happen/load once (initial
+    // annotation fetch on application startup), as there is no mechanism
+    // within the Notebook to change the `focusedGroup`. If the focused group
+    // is changed within the sidebar and the Notebook re-opened, an entirely
+    // new iFrame/app is created. This will need to be revisited.
     store.setSortKey('Newest');
     if (focusedGroup) {
       loadAnnotationsService.load({
         groupId: focusedGroup.id,
         maxResults: 5000,
       });
+      setPaginationPage(1);
     }
   }, [loadAnnotationsService, focusedGroup, store]);
 
-  const rootThread = useRootThread();
-  const groupName = focusedGroup?.name ?? '…';
+  // Pagination-page-changing callback
+  const onChangePage = newPage => {
+    setPaginationPage(newPage);
+  };
+
+  // When filter values are changed in any way, reset pagination to page 1
+  useEffect(() => {
+    onChangePage(1);
+  }, [filters]);
+
+  // Scroll back to here when pagination page changes
+  const threadListScrollTop = useRef(/** @type {HTMLElement|null}*/ (null));
+
+  useLayoutEffect(() => {
+    // If pagination page has changed, scroll to top of list of page of threads
+    // to semi-represent a new page load
+    // TODO: Transition and effects here should be improved
+    if (paginationPage !== lastPaginationPage.current) {
+      scrollIntoView(threadListScrollTop.current);
+      lastPaginationPage.current = paginationPage;
+    }
+  }, [paginationPage]);
 
   return (
     <div className="NotebookView">
-      <header className="NotebookView__heading">
+      <header className="NotebookView__heading" ref={threadListScrollTop}>
         <h1 className="NotebookView__group-name">{groupName}</h1>
       </header>
       <div className="NotebookView__filters">
         <NotebookFilters />
       </div>
       <div className="NotebookView__results">
-        <NotebookResultCount />
+        <NotebookResultCount
+          forcedVisibleCount={forcedVisibleCount}
+          currentPage={paginationPage}
+          isFiltered={hasAppliedFilter}
+          isLoading={isLoading}
+          resultCount={resultCount}
+        />
       </div>
       <div className="NotebookView__items">
-        <ThreadList threads={rootThread.children} />
+        <PaginatedThreadList
+          currentPage={paginationPage}
+          isLoading={isLoading}
+          onChangePage={onChangePage}
+          threads={rootThread.children}
+        />
       </div>
     </div>
   );

--- a/src/sidebar/components/PaginatedThreadList.js
+++ b/src/sidebar/components/PaginatedThreadList.js
@@ -1,0 +1,68 @@
+import { useMemo } from 'preact/hooks';
+import propTypes from 'prop-types';
+
+import { countVisible } from '../helpers/thread';
+
+import PaginationNavigation from './PaginationNavigation';
+import ThreadList from './ThreadList';
+
+/** @typedef {import('../helpers/build-thread').Thread} Thread */
+
+/**
+ * @typedef PaginatedThreadListProps
+ * @prop {number} currentPage
+ * @prop {boolean} isLoading
+ * @prop {(page: number) => void} onChangePage
+ * @prop {Thread[]} threads
+ * @prop {number} [pageSize]
+ */
+
+/**
+ * Determine which subset of all current `threads` to show on the current
+ * page of results, and how many pages of results there are total.
+ *
+ * Render the threads for the current page of results, and pagination controls.
+ *
+ * @param {PaginatedThreadListProps} props
+ */
+function PaginatedThreadList({
+  currentPage,
+  isLoading,
+  onChangePage,
+  threads,
+  pageSize = 10,
+}) {
+  const { paginatedThreads, totalPages } = useMemo(() => {
+    const visibleThreads = threads.filter(thread => countVisible(thread) > 0);
+    const startIndex = (currentPage - 1) * pageSize;
+    const endIndex = startIndex + pageSize;
+    const totalPages = Math.ceil(visibleThreads.length / pageSize);
+    return {
+      paginatedThreads: visibleThreads.slice(startIndex, endIndex),
+      totalPages,
+    };
+  }, [threads, currentPage, pageSize]);
+
+  return (
+    <>
+      <ThreadList threads={paginatedThreads} />
+      {!isLoading && (
+        <PaginationNavigation
+          currentPage={currentPage}
+          onChangePage={onChangePage}
+          totalPages={totalPages}
+        />
+      )}
+    </>
+  );
+}
+
+PaginatedThreadList.propTypes = {
+  isLoading: propTypes.bool,
+  threads: propTypes.array,
+  currentPage: propTypes.number,
+  onChangePage: propTypes.func,
+  pageSize: propTypes.number,
+};
+
+export default PaginatedThreadList;

--- a/src/sidebar/components/PaginationNavigation.js
+++ b/src/sidebar/components/PaginationNavigation.js
@@ -1,0 +1,134 @@
+import propTypes from 'prop-types';
+
+import Button from './Button';
+
+/** @typedef {number|null} PageNumber */
+
+/**
+ * Determine the set of page number buttons to show in the navigation
+ * controls, in addition to "next" and "back" buttons.
+ *
+ * @param {number} totalPages
+ * @param {number} currentPage
+ * @return {PageNumber[]} Set of navigation page options to show. `null`
+ *   values represent gaps in the sequence of pages, to be represented later
+ *   as ellipses (...)
+ */
+function availablePageButtons(currentPage, totalPages) {
+  if (totalPages <= 1) {
+    return [];
+  }
+  // Maximum number of distinct pages to show in controls
+  const MAX_PAGES = 5;
+
+  // Start with first, last and current page. Use a set to avoid dupes.
+  const pageNumbers = new Set([1, currentPage, totalPages]);
+
+  // Fill out the `pageNumbers` with additional pages near the currentPage,
+  // if available
+  let increment = 1;
+  while (pageNumbers.size < Math.min(totalPages, MAX_PAGES)) {
+    // Build the set "outward" from the currently-active page
+    if (currentPage + increment <= totalPages) {
+      pageNumbers.add(currentPage + increment);
+    }
+    if (currentPage - increment >= 1) {
+      pageNumbers.add(currentPage - increment);
+    }
+    increment++;
+  }
+
+  const pageOptions = /** @type {PageNumber[]} */ ([]);
+  [...pageNumbers]
+    .sort((a, b) => a - b)
+    .forEach((page, idx, arr) => {
+      if (idx > 0 && page - arr[idx - 1] > 1) {
+        // Two page entries are non-sequential. Push a `null` value between
+        // them to indicate the gap, which will later be represented as an
+        // ellipsis
+        pageOptions.push(null);
+      }
+      pageOptions.push(page);
+    });
+  return pageOptions;
+}
+
+/**
+ * @typedef PaginationNavigationProps
+ * @prop {number} currentPage - The currently-visible page of results
+ * @prop {(page: number) => void} onChangePage - Callback for changing page
+ * @prop {number} totalPages
+ */
+
+/**
+ *  Render pagination navigation controls, with buttons to go to previous
+ *  and next pages (where relevant) and up to five numbered page buttons.
+ *
+ * @param {PaginationNavigationProps} props
+ */
+function PaginationNavigation({ currentPage, onChangePage, totalPages }) {
+  const hasNextPage = currentPage < totalPages;
+  const hasPreviousPage = currentPage > 1;
+  const pageNumbers = availablePageButtons(currentPage, totalPages);
+
+  const changePageTo = (pageNumber, eventTarget) => {
+    onChangePage(pageNumber);
+    // Because changing pagination page doesn't reload the page (as it would
+    // in a "traditional" HTML context), the clicked-upon navigation button
+    // will awkwardly retain focus unless it is actively removed.
+    // TODO: Evaluate this for a11y issues
+    /** @type HTMLElement */ (eventTarget)?.blur();
+  };
+
+  return (
+    <div className="PaginationNavigation">
+      <div className="PaginationNavigation__relative PaginationNavigation__prev">
+        {hasPreviousPage && (
+          <Button
+            className="PaginationNavigation__button"
+            icon="arrow-left"
+            buttonText="prev"
+            title="Go to previous page"
+            onClick={e => changePageTo(currentPage - 1, e.target)}
+          />
+        )}
+      </div>
+      <ul className="PaginationNavigation__pages">
+        {pageNumbers.map((page, idx) => (
+          <li key={`page-${idx}`}>
+            {page === null ? (
+              <div className="PaginationNavigation__gap">...</div>
+            ) : (
+              <Button
+                key={`page-${idx}`}
+                buttonText={page.toString()}
+                className="PaginationNavigation__page-button"
+                isPressed={page === currentPage}
+                onClick={e => changePageTo(page, e.target)}
+              />
+            )}
+          </li>
+        ))}
+      </ul>
+      <div className="PaginationNavigation__relative PaginationNavigation__next">
+        {hasNextPage && (
+          <Button
+            className="PaginationNavigation__button PaginationNavigation__button-right"
+            icon="arrow-right"
+            buttonText="next"
+            iconPosition="right"
+            onClick={e => changePageTo(currentPage + 1, e.target)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+PaginationNavigation.propTypes = {
+  currentPage: propTypes.number,
+  onChangePage: propTypes.func,
+  totalPages: propTypes.number,
+};
+
+export default PaginationNavigation;

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -152,7 +152,7 @@ function SidebarView({
         <SidebarContentError errorType="group" onLoginRequest={onLogin} />
       )}
       {showTabs && <SelectionTabs isLoading={isLoading} />}
-      <ThreadList thread={rootThread} />
+      <ThreadList threads={rootThread.children} />
       {showLoggedOutMessage && <LoggedOutMessage onLogin={onLogin} />}
     </div>
   );

--- a/src/sidebar/components/StreamView.js
+++ b/src/sidebar/components/StreamView.js
@@ -64,7 +64,7 @@ function StreamView({ api, toastMessenger }) {
 
   const rootThread = useRootThread();
 
-  return <ThreadList thread={rootThread} />;
+  return <ThreadList threads={rootThread.children} />;
 }
 
 StreamView.propTypes = {

--- a/src/sidebar/components/ThreadList.js
+++ b/src/sidebar/components/ThreadList.js
@@ -33,7 +33,7 @@ function roundScrollPosition(pos) {
 
 /**
  * @typedef ThreadListProps
- * @prop {Thread} thread
+ * @prop {Thread[]} threads
  */
 
 /**
@@ -47,7 +47,7 @@ function roundScrollPosition(pos) {
  *
  * @param {ThreadListProps} props
  */
-function ThreadList({ thread }) {
+function ThreadList({ threads }) {
   // Height of the visible area of the scroll container.
   const [scrollContainerHeight, setScrollContainerHeight] = useState(
     window.innerHeight
@@ -74,7 +74,7 @@ function ThreadList({ thread }) {
     /** @type {string|null} */ (null)
   );
 
-  const topLevelThreads = thread.children;
+  const topLevelThreads = threads;
 
   const {
     offscreenLowerHeight,
@@ -210,7 +210,7 @@ function ThreadList({ thread }) {
 
 ThreadList.propTypes = {
   /** Should annotations render extra document metadata? */
-  thread: propTypes.object.isRequired,
+  threads: propTypes.array.isRequired,
 };
 
 export default ThreadList;

--- a/src/styles/sidebar/components/NotebookResultCount.scss
+++ b/src/styles/sidebar/components/NotebookResultCount.scss
@@ -8,7 +8,10 @@
   line-height: 1;
 
   & h2 {
-    font-weight: bold;
+    em {
+      font-weight: bold;
+      font-style: normal;
+    }
   }
 
   & h3 {

--- a/src/styles/sidebar/components/PaginationNavigation.scss
+++ b/src/styles/sidebar/components/PaginationNavigation.scss
@@ -1,0 +1,56 @@
+@use '../../mixins/buttons';
+@use "../../mixins/layout";
+@use "../../mixins/utils";
+@use "../../variables" as var;
+
+.PaginationNavigation {
+  @include utils.font--large;
+  @include layout.row;
+
+  &__relative {
+    // Set a constant width for the previous and next buttons so that
+    // there is no jumping around as they appear and disappear.
+    width: 5em;
+  }
+
+  &__next {
+    // Make sure "next" button is flush right
+    @include layout.row($justify: flex-end);
+  }
+
+  &__pages {
+    @include layout.row($justify: center, $align: center);
+    flex-grow: 1;
+  }
+
+  &__button,
+  &__page-button {
+    @include buttons.button--labeled;
+    background-color: transparent;
+    &:hover:not([disabled]),
+    &:focus:not([disabled]) {
+      background-color: var.$grey-3;
+    }
+
+    &[disabled] {
+      visibility: hidden;
+    }
+  }
+
+  &__page-button {
+    margin: 0 var.$layout-space--xsmall;
+    padding: var.$layout-space--xsmall var.$layout-space--small;
+  }
+
+  &__button-right {
+    // TODO VERY TEMPORARY adjustment until we can adjust the actual icon
+    svg {
+      margin-left: 0.25em;
+    }
+    padding-right: 0.25em;
+  }
+
+  &__page-button[aria-pressed='true'] {
+    background-color: var.$grey-3;
+  }
+}

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -41,6 +41,7 @@
 @use './components/ModerationBanner';
 @use './components/NotebookView';
 @use './components/NotebookResultCount';
+@use './components/PaginationNavigation';
 @use './components/SelectionTabs';
 @use './components/ShareAnnotationsPanel';
 @use './components/SearchInput';


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/2924

This PR is a POC for front-end pagination of threads in the Notebook view, to make large sets of threads usable. Right now, larger sets of threads cause uncomfortable amounts of scrolling, and it’s hard to keep track of one’s general place.

Code is WIP quality.

I am looking for high-level implementation feedback and any usability red flags here. This behavior was demo’ed to the dev team on February 8, 2021.

### General Premises and Notes

* Pagination is based on _top-level threads_, not annotations. That is, it controls the number of annotation thread cards that will show up on a single page of results. While this will generally limit the (vertical) length of pages, it is technically not guaranteed that pages will stay under a certain vertical height, as it depends on the content of annotations and the depth of reply nesting. _I believe this to be okay_.
* Pagination page size is dialed way down in this POC: 10 root threads per page. This is too small, but is meant to make playing around with this easier.
* This POC aims to solve the very basic first concerns of simple pagination. In scope are: how front-end threads are paginated (logically) and how the pagination controls look and feel to the user. There’s a lot more to do here—effectively everything else is out of scope (URL hashing/navigation; paginating back-end result sets).

### Pagination UX

Pagination UX is derived from review of UX articles, UX example sites (e.g. dribbble.com), inspiration from sites that I feel do pagination well (Etsy, Nordstrom), and checking in on the heavy-hitters (Google).

Exploratory sketches are on [Balsamiq](https://balsamiq.cloud/s9ipy1g/pb2ycd2/r3DA1) (credentials in shared password manager for H team members).

I decided on trying out page-based navigation (versus infinite loading) for these reasons:

* It’s more intuitive (IMHO) with a bounded set of results. Infinite loading feels more naturally suited for a changing, “stream” of results.
* Page-based pagination constrains vertical size and scrolling, such that top-of-view and filters stay reasonably well at hand.
* It’s easier (or, even, possible) to jump forward in or backward results without having to load everything between or scroll through a whole lot.
* Page-based pagination can be more naturally mapped to URLs, and it’s easier to support the back button (NB: URL/navigation support has not yet been implemented).

For the main navigation controls, the goals are:

* Provide relative controls (prev/next) where relevant. “Prev” does seem to be a widely-used text string for buttons (versus “Previous”) and it makes the buttons considerably more visually balanced.
* Always show numbered links/buttons to first and last page of results.
* Always show numbered link/button for the active page.
* Show numbered links/buttons for the pages “near” the currently-active page, up to five numbered links/buttons total.

This is more easily shown by examples:

![image](https://user-images.githubusercontent.com/439947/107384547-1267f500-6ac0-11eb-89e0-108366fe7981.png)

![image](https://user-images.githubusercontent.com/439947/107384598-1c89f380-6ac0-11eb-8a20-3a0f036357f5.png)

![image](https://user-images.githubusercontent.com/439947/107384660-2c093c80-6ac0-11eb-8c0c-570b866b18b7.png)

![image](https://user-images.githubusercontent.com/439947/107384724-388d9500-6ac0-11eb-9584-d75988fcf753.png)

![image](https://user-images.githubusercontent.com/439947/107384756-404d3980-6ac0-11eb-81c7-b17c767ba3d5.png)

Smaller page set:

![image](https://user-images.githubusercontent.com/439947/107384902-6541ac80-6ac0-11eb-8025-fa36e8f537ff.png)

### Implementation

There are three main logical concerns for this pagination:

1. We need to manage state about pagination: what page we’re on right now, responding to changes to that page, and resetting back to page 1 on certain other state changes. (`NotebookView`, but could be moved to the store if we wanted).
2. We need to map pagination onto the total set of results (threads), determine the total number of pages and show the right threads for the current page. (`PaginatedThreadList`)
3. We need to present pagination controls and information to the user. (`PaginationNavigation`).

#### In more depth:

* `NotebookView`: Manages state related to which pagination page is currently active (provides page-changing callback to child components). Responds to page changes.
    
    This logic is in this component because of the proximity to the loading of annotations, which affects pagination. If we moved pagination-state management to the store, we’d have more independence about where this logic lives.

    `NotebookView`’ would need to be updated if we changed how pagination state is managed, or if we changed what things cause a pagination “reset.”

* `PaginatedThreadList`: Determines which `threads` are meaningful for pagination calculation (currently: all _visible_ top-level threads). Determines how many pages of results are in the current set and which threads should be visible on the current page.

     Passes currently-visible threads onto `ThreadList` and pagination metadata to `PaginationNavigation` .

     `PaginatedThreadList` would need to be updated if the relationship between root-level `threads` and pagination changed (e.g. if `threads` were not the total set of results). It’s expected that this would happen when we start integrating back-end support for filtering and thread retrieval.

* `PaginationNavigation`: Takes `currentPage`, `totalPages` and the `onChangePage` callback and renders pagination controls.

     `PaginationNavigation` would need to be updated if we changed our minds about how we wanted pagination-control behavior or appearance to change, but is independent of other pagination logic.

* `NotebookResultCount`: Changed to be able to render what page of results is showing. Also refactored lightly to remove dependency on `storeProxy` (this is consistent with other child components of `NotebookView`.

Changes since informal demo to team:

* Pagination page number will be rendered at the top of the view next to total results count when the page number is > 1. This is directly cribbed from Google (try it!) and I like it because:
	* It doesn’t clutter the top of the view with extra information (“Page 1”) when it’s not relevant.
	* It obviates the need for the results-count component to know about the total number of pages of results (which is calculated in a sibling component).

![image](https://user-images.githubusercontent.com/439947/107384960-71c60500-6ac0-11eb-94a4-6e500aeb558a.png)

![image](https://user-images.githubusercontent.com/439947/107385023-83a7a800-6ac0-11eb-8ac3-ce8af3c6aa11.png)

In the not-too-distant future, on wider screens, we'll be moving the filters to the left of results, and we may wish de-clutter this a little bit.

### Supporting changes

* `ThreadList` takes an Array of `Thread` objects instead of a single "root" Thread.
* `Button` takes an icon-position prop

### Known further steps

- [ ] Likely: Extract page-button-number logic from `PaginationNavigation` into a utility and comment it more clearly
- [ ] Address spacing issues with the `arrow-right` icon (see `PaginationNavigation.scss` for current workaround)
- [ ] Write tests (obviously)
