### PR TITLE
Added and unified options for the gulp test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,18 +23,18 @@ dev: node_modules/.uptodate
 
 .PHONY: test
 test: node_modules/.uptodate
-ifdef FILTER
-	yarn test --grep $(FILTER)
+ifdef ARGS
+	yarn test $(ARGS)
 else
 	yarn test
 endif
 
 .PHONY: servetests
 servetests: node_modules/.uptodate
-ifdef FILTER
-	node_modules/.bin/gulp test-watch --grep $(FILTER)
+ifdef ARGS
+	node_modules/.bin/gulp --watch $(ARGS)
 else
-	node_modules/.bin/gulp test-watch
+	node_modules/.bin/gulp --watch
 endif
 
 .PHONY: lint


### PR DESCRIPTION
The purpose of this PR is to be able to easily run karma tests in other
browsers without manually editing or making local copies of the karma
configuration.

Additions:

- `yarn gulp test --no-browser` to avoid launching the default browser.
  It is up to the developer to run the tests in whatever browser she/he
  chooses by navigating to http://localhost:9876/.

- `yarn gulp test --browser <browser>` run the tests in a different
  browser/s instead of the default browser. Chrome launcher comes by
  default with karma. Firefox, Safari and others can be installed
  independently.

Modifications:

- `yarn gulp test-watch` has been substituted by `yarn gulp test --watch` for consistency.