### PR TITLE
Add basic pagination controls to Notebook

### DIFF
--- a/src/sidebar/components/AnnotationView.js
+++ b/src/sidebar/components/AnnotationView.js
@@ -88,7 +88,7 @@ function AnnotationView({ loadAnnotationsService, onLogin }) {
         // for this scenario as well.
         <SidebarContentError errorType="annotation" onLoginRequest={onLogin} />
       )}
-      <ThreadList thread={rootThread} />
+      <ThreadList threads={rootThread.children} />
     </>
   );
 }

--- a/src/sidebar/components/Button.js
+++ b/src/sidebar/components/Button.js
@@ -14,6 +14,8 @@ import propTypes from 'prop-types';
  *   See `buttons` SCSS mixins module for more details.
  * @prop {string} [icon] -
  *   The name of the SVGIcon to render. This is optional if a `buttonText` is provided.
+ * @prop {'left'|'right'} [iconPosition] - Whether icon should render to the left or
+ *   to the right of label text
  * @prop {boolean} [isExpanded] -
  *   Is the expandable element controlled by this button currently expanded?
  * @prop {boolean} [isPressed] -
@@ -40,6 +42,7 @@ export default function Button({
   className = '',
   disabled = false,
   icon = '',
+  iconPosition = 'left',
   isExpanded,
   isPressed,
   onClick = () => {},
@@ -78,8 +81,9 @@ export default function Button({
       disabled={disabled}
       {...extraProps}
     >
-      {icon && <SvgIcon name={icon} />}
+      {icon && iconPosition === 'left' && <SvgIcon name={icon} />}
       {buttonText}
+      {icon && iconPosition === 'right' && <SvgIcon name={icon} />}
     </button>
   );
 }
@@ -108,6 +112,7 @@ Button.propTypes = {
   buttonText: propTypes.string,
   className: propTypes.string,
   icon: requiredStringIfButtonTextMissing,
+  iconPosition: propTypes.string,
   isExpanded: propTypes.bool,
   isPressed: propTypes.bool,
   onClick: propTypes.func,

--- a/src/sidebar/components/NotebookResultCount.js
+++ b/src/sidebar/components/NotebookResultCount.js
@@ -1,8 +1,17 @@
+import propTypes from 'prop-types';
+
 import useRootThread from './hooks/use-root-thread';
-import { useStoreProxy } from '../store/use-store';
 import { countVisible } from '../helpers/thread';
 
 import Spinner from './Spinner';
+
+/**
+ * @typedef NotebookResultCountProps
+ * @prop {number} forcedVisibleCount
+ * @prop {boolean} isFiltered
+ * @prop {boolean} isLoading
+ * @prop {number} resultCount
+ */
 
 /**
  * Render count of annotations (or filtered results) visible in the notebook view
@@ -12,21 +21,21 @@ import Spinner from './Spinner';
  * - Annotations are unfiltered: "X threads (Y annotations)"
  *     Thread count does not render until all annotations are loaded
  * - Annotations are filtered: "X results [(and Y more)]"
+ *
+ * @param {NotebookResultCountProps} props
  */
-function NotebookResultCount() {
-  const store = useStoreProxy();
-
-  const forcedVisibleCount = store.forcedVisibleThreads().length;
-  const hasAppliedFilter = store.hasAppliedFilter();
-  const resultCount = store.annotationResultCount();
-  const isLoading = store.isLoading();
-
+function NotebookResultCount({
+  forcedVisibleCount,
+  isFiltered,
+  isLoading,
+  resultCount,
+}) {
   const rootThread = useRootThread();
   const visibleCount = isLoading ? resultCount : countVisible(rootThread);
 
   const hasResults = rootThread.children.length > 0;
 
-  const hasForcedVisible = hasAppliedFilter && forcedVisibleCount > 0;
+  const hasForcedVisible = isFiltered && forcedVisibleCount > 0;
   const matchCount = visibleCount - forcedVisibleCount;
   const threadCount = rootThread.children.length;
 
@@ -35,21 +44,21 @@ function NotebookResultCount() {
       {isLoading && <Spinner />}
       {!isLoading && (
         <h2>
-          {!hasResults && <span>No results</span>}
-          {hasResults && hasAppliedFilter && (
-            <span>
+          {!hasResults && <strong>No results</strong>}
+          {hasResults && isFiltered && (
+            <strong>
               {matchCount} {matchCount === 1 ? 'result' : 'results'}
-            </span>
+            </strong>
           )}
-          {hasResults && !hasAppliedFilter && (
-            <span>
+          {hasResults && !isFiltered && (
+            <strong>
               {threadCount} {threadCount === 1 ? 'thread' : 'threads'}
-            </span>
+            </strong>
           )}
         </h2>
       )}
       {hasForcedVisible && <h3>(and {forcedVisibleCount} more)</h3>}
-      {!hasAppliedFilter && hasResults && (
+      {!isFiltered && hasResults && (
         <h3>
           ({visibleCount} {visibleCount === 1 ? 'annotation' : 'annotations'})
         </h3>
@@ -58,6 +67,11 @@ function NotebookResultCount() {
   );
 }
 
-NotebookResultCount.propTypes = {};
+NotebookResultCount.propTypes = {
+  forcedVisibleCount: propTypes.number,
+  isFiltered: propTypes.bool,
+  isLoading: propTypes.bool,
+  resultCount: propTypes.number,
+};
 
 export default NotebookResultCount;

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -51,7 +51,7 @@ function NotebookView({ loadAnnotationsService }) {
         <NotebookResultCount />
       </div>
       <div className="NotebookView__items">
-        <ThreadList thread={rootThread} />
+        <ThreadList threads={rootThread.children} />
       </div>
     </div>
   );

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -1,5 +1,6 @@
-import { useEffect } from 'preact/hooks';
+import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import propTypes from 'prop-types';
+import scrollIntoView from 'scroll-into-view';
 
 import { withServices } from '../service-context';
 import useRootThread from './hooks/use-root-thread';
@@ -7,7 +8,8 @@ import { useStoreProxy } from '../store/use-store';
 
 import NotebookFilters from './NotebookFilters';
 import NotebookResultCount from './NotebookResultCount';
-import ThreadList from './ThreadList';
+
+import PaginatedThreadList from './PaginatedThreadList';
 
 /**
  * @typedef NotebookViewProps
@@ -21,12 +23,31 @@ import ThreadList from './ThreadList';
  */
 function NotebookView({ loadAnnotationsService }) {
   const store = useStoreProxy();
-  const focusedGroup = store.focusedGroup();
 
-  // Reload annotations if focused group changes
+  const filters = store.getFilterValues();
+  const focusedGroup = store.focusedGroup();
+  const forcedVisibleCount = store.forcedVisibleThreads().length;
+  const hasAppliedFilter = store.hasAppliedFilter();
+  const isLoading = store.isLoading();
+  const resultCount = store.annotationResultCount();
+
+  const rootThread = useRootThread();
+
+  const groupName = focusedGroup?.name ?? '…';
+
+  const lastPaginationPage = useRef(1);
+  const [paginationPage, setPaginationPage] = useState(1);
+
+  // Load all annotations; re-load if `focusedGroup` changes
   useEffect(() => {
     // Load all annotations in the group, unless there are more than 5000
-    // of them: this is a performance safety valve
+    // of them: this is a performance safety valve.
+
+    // NB: In current implementation, this will only happen/load once (initial
+    // annotation fetch on application startup), as there is no mechanism
+    // within the Notebook to change the `focusedGroup`. If the focused group
+    // is changed within the sidebar and the Notebook re-opened, an entirely
+    // new iFrame/app is created. This will need to be revisited.
     store.setSortKey('Newest');
     if (focusedGroup) {
       loadAnnotationsService.load({
@@ -36,22 +57,49 @@ function NotebookView({ loadAnnotationsService }) {
     }
   }, [loadAnnotationsService, focusedGroup, store]);
 
-  const rootThread = useRootThread();
-  const groupName = focusedGroup?.name ?? '…';
+  // Pagination-page-changing callback
+  const onChangePage = newPage => {
+    setPaginationPage(newPage);
+  };
+
+  // When filter values or focused group are changed, reset pagination to page 1
+  useEffect(() => {
+    onChangePage(1);
+  }, [filters, focusedGroup]);
+
+  // Scroll back to here when pagination page changes
+  const threadListScrollTop = useRef(/** @type {HTMLElement|null}*/ (null));
+  useLayoutEffect(() => {
+    // TODO: Transition and effects here should be improved
+    if (paginationPage !== lastPaginationPage.current) {
+      scrollIntoView(threadListScrollTop.current);
+      lastPaginationPage.current = paginationPage;
+    }
+  }, [paginationPage]);
 
   return (
     <div className="NotebookView">
-      <header className="NotebookView__heading">
+      <header className="NotebookView__heading" ref={threadListScrollTop}>
         <h1 className="NotebookView__group-name">{groupName}</h1>
       </header>
       <div className="NotebookView__filters">
         <NotebookFilters />
       </div>
       <div className="NotebookView__results">
-        <NotebookResultCount />
+        <NotebookResultCount
+          forcedVisibleCount={forcedVisibleCount}
+          isFiltered={hasAppliedFilter}
+          isLoading={isLoading}
+          resultCount={resultCount}
+        />
       </div>
       <div className="NotebookView__items">
-        <ThreadList threads={rootThread.children} />
+        <PaginatedThreadList
+          currentPage={paginationPage}
+          isLoading={isLoading}
+          onChangePage={onChangePage}
+          threads={rootThread.children}
+        />
       </div>
     </div>
   );

--- a/src/sidebar/components/PaginatedThreadList.js
+++ b/src/sidebar/components/PaginatedThreadList.js
@@ -1,0 +1,68 @@
+import { useMemo } from 'preact/hooks';
+import propTypes from 'prop-types';
+
+import { countVisible } from '../helpers/thread';
+
+import PaginationNavigation from './PaginationNavigation';
+import ThreadList from './ThreadList';
+
+/** @typedef {import('../helpers/build-thread').Thread} Thread */
+
+/**
+ * @typedef PaginatedThreadListProps
+ * @prop {number} currentPage
+ * @prop {boolean} isLoading
+ * @prop {(page: number) => void} onChangePage
+ * @prop {Thread[]} threads
+ * @prop {number} [pageSize]
+ */
+
+/**
+ * Determine which subset of all current `threads` to show on the current
+ * page of results, and how many pages of results there are total.
+ *
+ * Render the threads for the current page of results, and pagination controls.
+ *
+ * @param {PaginatedThreadListProps} props
+ */
+function PaginatedThreadList({
+  currentPage,
+  isLoading,
+  onChangePage,
+  threads,
+  pageSize = 10,
+}) {
+  const { paginatedThreads, totalPages } = useMemo(() => {
+    const visibleThreads = threads.filter(thread => countVisible(thread) > 0);
+    const startIndex = (currentPage - 1) * pageSize;
+    const endIndex = startIndex + pageSize;
+    const totalPages = Math.ceil(visibleThreads.length / pageSize);
+    return {
+      paginatedThreads: visibleThreads.slice(startIndex, endIndex),
+      totalPages,
+    };
+  }, [threads, currentPage, pageSize]);
+
+  return (
+    <>
+      <ThreadList threads={paginatedThreads} />
+      {!isLoading && (
+        <PaginationNavigation
+          currentPage={currentPage}
+          onChangePage={onChangePage}
+          totalPages={totalPages}
+        />
+      )}
+    </>
+  );
+}
+
+PaginatedThreadList.propTypes = {
+  isLoading: propTypes.bool,
+  threads: propTypes.array,
+  currentPage: propTypes.number,
+  onChangePage: propTypes.func,
+  pageSize: propTypes.number,
+};
+
+export default PaginatedThreadList;

--- a/src/sidebar/components/PaginationNavigation.js
+++ b/src/sidebar/components/PaginationNavigation.js
@@ -1,0 +1,89 @@
+import propTypes from 'prop-types';
+
+import { pageNumberOptions } from '../util/pagination';
+
+import Button from './Button';
+
+/**
+ * @typedef PaginationNavigationProps
+ * @prop {number} currentPage - The currently-visible page of results. Pages
+ *   start at 1 (not 0).
+ * @prop {(page: number) => void} onChangePage - Callback for changing page
+ * @prop {number} totalPages
+ */
+
+/**
+ * Render pagination navigation controls, with buttons to go next, previous
+ * and nearby pages.
+ *
+ * @param {PaginationNavigationProps} props
+ */
+function PaginationNavigation({ currentPage, onChangePage, totalPages }) {
+  // Pages are 1-indexed
+  const hasNextPage = currentPage < totalPages;
+  const hasPreviousPage = currentPage > 1;
+  const pageNumbers = pageNumberOptions(currentPage, totalPages);
+
+  const changePageTo = (pageNumber, eventTarget) => {
+    onChangePage(pageNumber);
+    // Because changing pagination page doesn't reload the page (as it would
+    // in a "traditional" HTML context), the clicked-upon navigation button
+    // will awkwardly retain focus unless it is actively removed.
+    // TODO: Evaluate this for a11y issues
+    /** @type HTMLElement */ (eventTarget)?.blur();
+  };
+
+  return (
+    <div className="PaginationNavigation">
+      <div className="PaginationNavigation__relative PaginationNavigation__prev">
+        {hasPreviousPage && (
+          <Button
+            className="PaginationNavigation__button"
+            icon="arrow-left"
+            buttonText="prev"
+            title="Go to previous page"
+            onClick={e => changePageTo(currentPage - 1, e.target)}
+          />
+        )}
+      </div>
+      <ul className="PaginationNavigation__pages">
+        {pageNumbers.map((page, idx) => (
+          <li key={idx}>
+            {page === null ? (
+              <div className="PaginationNavigation__gap">...</div>
+            ) : (
+              <Button
+                key={`page-${idx}`}
+                buttonText={page.toString()}
+                title={`Go to page ${page}`}
+                className="PaginationNavigation__page-button"
+                isPressed={page === currentPage}
+                onClick={e => changePageTo(page, e.target)}
+              />
+            )}
+          </li>
+        ))}
+      </ul>
+      <div className="PaginationNavigation__relative PaginationNavigation__next">
+        {hasNextPage && (
+          <Button
+            className="PaginationNavigation__button PaginationNavigation__button-right"
+            icon="arrow-right"
+            buttonText="next"
+            iconPosition="right"
+            title="Go to next page"
+            onClick={e => changePageTo(currentPage + 1, e.target)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+PaginationNavigation.propTypes = {
+  currentPage: propTypes.number,
+  onChangePage: propTypes.func,
+  totalPages: propTypes.number,
+};
+
+export default PaginationNavigation;

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -152,7 +152,7 @@ function SidebarView({
         <SidebarContentError errorType="group" onLoginRequest={onLogin} />
       )}
       {showTabs && <SelectionTabs isLoading={isLoading} />}
-      <ThreadList thread={rootThread} />
+      <ThreadList threads={rootThread.children} />
       {showLoggedOutMessage && <LoggedOutMessage onLogin={onLogin} />}
     </div>
   );

--- a/src/sidebar/components/StreamView.js
+++ b/src/sidebar/components/StreamView.js
@@ -64,7 +64,7 @@ function StreamView({ api, toastMessenger }) {
 
   const rootThread = useRootThread();
 
-  return <ThreadList thread={rootThread} />;
+  return <ThreadList threads={rootThread.children} />;
 }
 
 StreamView.propTypes = {

--- a/src/sidebar/components/ThreadList.js
+++ b/src/sidebar/components/ThreadList.js
@@ -33,7 +33,7 @@ function roundScrollPosition(pos) {
 
 /**
  * @typedef ThreadListProps
- * @prop {Thread} thread
+ * @prop {Thread[]} threads
  */
 
 /**
@@ -47,7 +47,7 @@ function roundScrollPosition(pos) {
  *
  * @param {ThreadListProps} props
  */
-function ThreadList({ thread }) {
+function ThreadList({ threads }) {
   // Height of the visible area of the scroll container.
   const [scrollContainerHeight, setScrollContainerHeight] = useState(
     window.innerHeight
@@ -74,7 +74,7 @@ function ThreadList({ thread }) {
     /** @type {string|null} */ (null)
   );
 
-  const topLevelThreads = thread.children;
+  const topLevelThreads = threads;
 
   const {
     offscreenLowerHeight,
@@ -210,7 +210,7 @@ function ThreadList({ thread }) {
 
 ThreadList.propTypes = {
   /** Should annotations render extra document metadata? */
-  thread: propTypes.object.isRequired,
+  threads: propTypes.array.isRequired,
 };
 
 export default ThreadList;

--- a/src/sidebar/components/test/Button-test.js
+++ b/src/sidebar/components/test/Button-test.js
@@ -34,6 +34,23 @@ describe('Button', () => {
     assert.equal(wrapper.find('SvgIcon').prop('name'), 'fakeIcon');
   });
 
+  it('positions `SvgIcon` left (first) by default', () => {
+    const wrapper = createComponent({ buttonText: 'My Button' });
+
+    assert.isTrue(wrapper.find('button').childAt(0).is('SvgIcon'));
+    assert.equal(wrapper.find('button').childAt(1).text(), 'My Button');
+  });
+
+  it('positions `SvgIcon` right (second) with `iconPosition` prop', () => {
+    const wrapper = createComponent({
+      buttonText: 'My Button',
+      iconPosition: 'right',
+    });
+
+    assert.equal(wrapper.find('button').childAt(0).text(), 'My Button');
+    assert.isTrue(wrapper.find('button').childAt(1).is('SvgIcon'));
+  });
+
   [true, false].forEach(isExpanded => {
     it('sets `aria-expanded` attribute if `isExpanded` is a boolean', () => {
       const wrapper = createComponent({ isExpanded });

--- a/src/sidebar/components/test/PaginatedThreadList-test.js
+++ b/src/sidebar/components/test/PaginatedThreadList-test.js
@@ -1,0 +1,136 @@
+import { mount } from 'enzyme';
+
+import PaginatedThreadList, { $imports } from '../PaginatedThreadList';
+
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+
+describe('PaginatedThreadList', () => {
+  // Fake props
+  let fakeOnChangePage;
+  let fakeThreads;
+
+  let threadCount;
+
+  // Mocked dependencies
+  let fakeCountVisible;
+
+  function getNThreads(n) {
+    // Fill an array with numbers 1...n
+    // These can stand in for "Threads" in this component
+    return [...Array(n + 1).keys()].slice(1);
+  }
+
+  function createComponent(props) {
+    return mount(
+      <PaginatedThreadList
+        currentPage={1}
+        isLoading={false}
+        onChangePage={fakeOnChangePage}
+        threads={fakeThreads}
+        {...props}
+      />
+    );
+  }
+
+  beforeEach(() => {
+    fakeOnChangePage = sinon.stub();
+    // Every "thread" passed to the component will be considered visible
+    fakeCountVisible = sinon.stub().returns(1);
+
+    threadCount = 22;
+    // Create an array populated with 1...n numbers
+    fakeThreads = getNThreads(threadCount);
+
+    $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      '../helpers/thread': { countVisible: fakeCountVisible },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  const testCases = [
+    {
+      currentPage: 1,
+      visibleThreads: 22,
+      pageSize: 10,
+      pageCount: 3,
+      pageThreads: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    },
+    {
+      currentPage: 2,
+      visibleThreads: 22,
+      pageSize: 5,
+      pageCount: 5,
+      pageThreads: [6, 7, 8, 9, 10],
+    },
+    {
+      currentPage: 2,
+      visibleThreads: 20,
+      pageSize: 10,
+      pageCount: 2,
+      pageThreads: [11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+    },
+    {
+      currentPage: 1,
+      visibleThreads: 2,
+      pageSize: 10,
+      pageCount: 1,
+      pageThreads: [1, 2],
+    },
+    {
+      currentPage: 3,
+      visibleThreads: 455,
+      pageSize: 10,
+      pageCount: 46,
+      pageThreads: [21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
+    },
+  ];
+
+  testCases.forEach(testCase => {
+    it('should calculate total pages of results based on visible threads', () => {
+      const threads = getNThreads(testCase.visibleThreads);
+      const componentProps = { currentPage: testCase.currentPage, threads };
+      // This is to make sure the default-page-size code path is exercised in tests
+      if (testCase.pageSize !== 10) {
+        componentProps.pageSize = testCase.pageSize;
+      }
+      const wrapper = createComponent(componentProps);
+
+      assert.equal(
+        wrapper.find('PaginationNavigation').props().totalPages,
+        testCase.pageCount
+      );
+    });
+
+    it('passes current page through to pagination controls', () => {
+      const threads = getNThreads(testCase.visibleThreads);
+      const wrapper = createComponent({
+        currentPage: testCase.currentPage,
+        threads,
+        pageSize: testCase.pageSize,
+      });
+
+      assert.equal(
+        wrapper.find('PaginationNavigation').props().currentPage,
+        testCase.currentPage
+      );
+    });
+
+    it('passes threads for current page to thread list component', () => {
+      const threads = getNThreads(testCase.visibleThreads);
+      const wrapper = createComponent({
+        currentPage: testCase.currentPage,
+        threads,
+        pageSize: testCase.pageSize,
+      });
+
+      assert.deepEqual(
+        wrapper.find('ThreadList').props().threads,
+        testCase.pageThreads
+      );
+    });
+  });
+});

--- a/src/sidebar/components/test/PaginationNavigation-test.js
+++ b/src/sidebar/components/test/PaginationNavigation-test.js
@@ -1,0 +1,151 @@
+import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
+
+import PaginationNavigation, { $imports } from '../PaginationNavigation';
+
+describe('PaginationNavigation', () => {
+  let fakeOnChangePage;
+  let fakePageNumberOptions;
+
+  const findButton = (wrapper, title) =>
+    wrapper.find('button').filterWhere(n => n.props().title === title);
+
+  const createComponent = (props = {}) => {
+    return mount(
+      <PaginationNavigation
+        currentPage={1}
+        onChangePage={fakeOnChangePage}
+        totalPages={10}
+        {...props}
+      />
+    );
+  };
+
+  beforeEach(() => {
+    fakeOnChangePage = sinon.stub();
+    fakePageNumberOptions = sinon.stub().returns([1, 2, 3, 4, null, 10]);
+
+    $imports.$mock({
+      '../util/pagination': { pageNumberOptions: fakePageNumberOptions },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  describe('prev button', () => {
+    it('should render a prev button when there are previous pages to show', () => {
+      const wrapper = createComponent({ currentPage: 2 });
+
+      const button = findButton(wrapper, 'Go to previous page');
+
+      assert.isTrue(button.exists());
+    });
+
+    it('should not render a prev button if there are no previous pages to show', () => {
+      const wrapper = createComponent({ currentPage: 1 });
+
+      const button = findButton(wrapper, 'Go to previous page');
+
+      assert.isFalse(button.exists());
+    });
+
+    it('should invoke the onChangePage callback when clicked', () => {
+      const wrapper = createComponent({ currentPage: 2 });
+
+      const button = findButton(wrapper, 'Go to previous page');
+
+      button.simulate('click');
+
+      assert.calledWith(fakeOnChangePage, 1);
+    });
+
+    it('should remove focus from button after clicked', () => {
+      const wrapper = createComponent({ currentPage: 2 });
+
+      const button = findButton(wrapper, 'Go to previous page');
+      const buttonEl = button.getDOMNode();
+      const blurSpy = sinon.spy(buttonEl, 'blur');
+
+      act(() => {
+        button.simulate('click');
+      });
+
+      assert.equal(blurSpy.callCount, 1);
+    });
+  });
+
+  describe('next button', () => {
+    it('should render a next button when there are further pages to show', () => {
+      const wrapper = createComponent({ currentPage: 1 });
+
+      const button = findButton(wrapper, 'Go to next page');
+
+      assert.isTrue(button.exists());
+    });
+
+    it('should not render a next button if there are no further pages to show', () => {
+      const wrapper = createComponent({ currentPage: 10 });
+
+      const button = findButton(wrapper, 'Go to next page');
+
+      assert.isFalse(button.exists());
+    });
+
+    it('should invoke the `onChangePage` callback when clicked', () => {
+      const wrapper = createComponent({ currentPage: 1 });
+
+      const button = findButton(wrapper, 'Go to next page');
+
+      button.simulate('click');
+
+      assert.calledWith(fakeOnChangePage, 2);
+    });
+
+    it('should remove focus from button after clicked', () => {
+      const wrapper = createComponent({ currentPage: 1 });
+
+      const button = findButton(wrapper, 'Go to next page');
+      const buttonEl = button.getDOMNode();
+      const blurSpy = sinon.spy(buttonEl, 'blur');
+
+      act(() => {
+        button.simulate('click');
+      });
+
+      assert.equal(blurSpy.callCount, 1);
+    });
+  });
+
+  describe('page number buttons', () => {
+    it('should render buttons for each page number available', () => {
+      fakePageNumberOptions.returns([1, 2, 3, 4, null, 10]);
+
+      const wrapper = createComponent();
+
+      [1, 2, 3, 4, 10].forEach(pageNumber => {
+        const button = findButton(wrapper, `Go to page ${pageNumber}`);
+
+        assert.isTrue(button.exists());
+      });
+
+      // There is one "gap":
+      assert.equal(wrapper.find('.PaginationNavigation__gap').length, 1);
+    });
+
+    it('should invoke the onChangePage callback when page number button clicked', () => {
+      fakePageNumberOptions.returns([1, 2, 3, 4, null, 10]);
+
+      const wrapper = createComponent();
+
+      [1, 2, 3, 4, 10].forEach(pageNumber => {
+        const button = findButton(wrapper, `Go to page ${pageNumber}`);
+
+        button.simulate('click');
+
+        assert.calledWith(fakeOnChangePage, pageNumber);
+      });
+    });
+  });
+});

--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -17,9 +17,12 @@ describe('ThreadList', () => {
   let wrappers;
 
   function createComponent(props) {
-    const wrapper = mount(<ThreadList thread={fakeTopThread} {...props} />, {
-      attachTo: fakeScrollContainer,
-    });
+    const wrapper = mount(
+      <ThreadList threads={fakeTopThread.children} {...props} />,
+      {
+        attachTo: fakeScrollContainer,
+      }
+    );
     wrappers.push(wrapper);
     return wrapper;
   }

--- a/src/sidebar/util/pagination.js
+++ b/src/sidebar/util/pagination.js
@@ -1,0 +1,72 @@
+/**
+ * The number of an available pagination page, or `null`, indicating a gap
+ * between sequential numbered pages.
+ *
+ * @typedef {number|null} PageNumber
+ */
+
+/**
+ * Determine the set of (pagination) page numbers that should be provided to
+ * a user, given the current page the user is on, the total number of pages
+ * available, and the number of individual page options desired.
+ *
+ * The first, last and current pages will always be included in the returned
+ * results. Additional pages adjacent to the current page will be added until
+ * `maxPages` is reached. Gaps in the sequence of pages are represented by
+ * `null` values.
+ *
+ * @example
+ *   pageNumberOptions(1, 10, 5) => [1, 2, 3, 4, null, 10]
+ *   pageNumberOptions(3, 10, 5) => [1, 2, 3, 4, null, 10]
+ *   pageNumberOptions(6, 10, 5) => [1, null, 5, 6, 7, null, 10]
+ *   pageNumberOptions(9, 10, 5) => [1, null, 7, 8, 9, 10]
+ *   pageNumberOptions(2, 3, 5) => [1, 2, 3]
+ *
+ * @param {number} currentPage - The currently-visible/-active page of results.
+ *   Note that pages are 1-indexed
+ * @param {number} totalPages
+ * @param {number} [maxPages] - The maximum number of numbered pages to make
+ *   available
+ * @return {PageNumber[]} Set of navigation page options to show. `null`
+ *   values represent gaps in the sequence of pages, to be represented later
+ *   as ellipses (...)
+ */
+export function pageNumberOptions(currentPage, totalPages, maxPages = 5) {
+  if (totalPages <= 1) {
+    return [];
+  }
+
+  // Start with first, last and current page. Use a set to avoid dupes.
+  const pageNumbers = new Set([1, currentPage, totalPages]);
+
+  // Fill out the `pageNumbers` with additional pages near the currentPage,
+  // if available
+  let increment = 1;
+  while (pageNumbers.size < Math.min(totalPages, maxPages)) {
+    // Build the set "outward" from the currently-active page
+    if (currentPage + increment <= totalPages) {
+      pageNumbers.add(currentPage + increment);
+    }
+    if (currentPage - increment >= 1) {
+      pageNumbers.add(currentPage - increment);
+    }
+    ++increment;
+  }
+
+  const pageOptions = /** @type {PageNumber[]} */ ([]);
+
+  // Construct a numerically-sorted array with `null` entries inserted
+  // between non-sequential entries
+  [...pageNumbers]
+    .sort((a, b) => a - b)
+    .forEach((page, idx, arr) => {
+      if (idx > 0 && page - arr[idx - 1] > 1) {
+        // Two page entries are non-sequential. Push a `null` value between
+        // them to indicate the gap, which will later be represented as an
+        // ellipsis
+        pageOptions.push(null);
+      }
+      pageOptions.push(page);
+    });
+  return pageOptions;
+}

--- a/src/sidebar/util/test/pagination-test.js
+++ b/src/sidebar/util/test/pagination-test.js
@@ -1,0 +1,22 @@
+import { pageNumberOptions } from '../pagination';
+
+describe('sidebar/util/pagination', () => {
+  describe('pageNumberOptions', () => {
+    [
+      { args: [1, 10, 5], expected: [1, 2, 3, 4, null, 10] },
+      { args: [3, 10, 5], expected: [1, 2, 3, 4, null, 10] },
+      { args: [6, 10, 5], expected: [1, null, 5, 6, 7, null, 10] },
+      { args: [9, 10, 5], expected: [1, null, 7, 8, 9, 10] },
+      { args: [2, 3, 5], expected: [1, 2, 3] },
+      { args: [3, 10, 7], expected: [1, 2, 3, 4, 5, 6, null, 10] },
+      { args: [1, 1, 5], expected: [] },
+    ].forEach(testCase => {
+      it('should produce expected available page numbers', () => {
+        assert.deepEqual(
+          pageNumberOptions(...testCase.args),
+          testCase.expected
+        );
+      });
+    });
+  });
+});

--- a/src/styles/mixins/buttons.scss
+++ b/src/styles/mixins/buttons.scss
@@ -87,17 +87,27 @@
   }
 }
 
-/* A button with displayed text. It may or may not have an icon. */
-@mixin button--labeled {
+/**
+ * A button with displayed text. It may or may not have an icon. The default
+ * colors assume the button is displayed on a white background.
+ *
+ * @param {CSSColor} [$background-color] - The button's background color when
+ *   neither hovered nor active.
+ * @param {CSSColor} [$active-background-color]
+ */
+@mixin button--labeled(
+  $background-color: var.$grey-1,
+  $active-background-color: var.$grey-2
+) {
   @include button;
   white-space: nowrap; // Keep multi-word button labels from wrapping
   color: var.$grey-mid;
   font-weight: 700;
-  background-color: var.$grey-1;
+  background-color: $background-color;
 
   &:hover:not([disabled]),
   &:focus:not([disabled]) {
-    background-color: var.$grey-2;
+    background-color: $active-background-color;
   }
 
   // Icon

--- a/src/styles/sidebar/components/NotebookResultCount.scss
+++ b/src/styles/sidebar/components/NotebookResultCount.scss
@@ -8,7 +8,10 @@
   line-height: 1;
 
   & h2 {
-    font-weight: bold;
+    strong {
+      font-weight: bold;
+      font-style: normal;
+    }
   }
 
   & h3 {

--- a/src/styles/sidebar/components/PaginationNavigation.scss
+++ b/src/styles/sidebar/components/PaginationNavigation.scss
@@ -1,0 +1,50 @@
+@use '../../mixins/buttons';
+@use "../../mixins/layout";
+@use "../../mixins/utils";
+@use "../../variables" as var;
+
+.PaginationNavigation {
+  @include utils.font--large;
+  @include layout.row;
+
+  &__relative {
+    // Set a minimum width for the previous and next button containers so that
+    // there is no jumping around as they appear and disappear.
+    min-width: 5em;
+  }
+
+  &__next {
+    // Make sure "next" button is flush right
+    @include layout.row($justify: flex-end);
+  }
+
+  &__pages {
+    @include layout.row($justify: center, $align: center);
+    flex-grow: 1;
+  }
+
+  &__button,
+  &__page-button {
+    @include buttons.button--labeled(
+      $background-color: transparent,
+      $active-background-color: var.$grey-3
+    );
+  }
+
+  &__page-button {
+    margin: var.$layout-space--xxsmall;
+    padding: var.$layout-space--small var.$layout-space;
+  }
+
+  &__button-right {
+    // TODO TEMPORARY adjustment until we can adjust the actual icon
+    svg {
+      margin-left: var.$layout-space--xxsmall;
+    }
+    padding-right: var.$layout-space--xxsmall;
+  }
+
+  &__page-button[aria-pressed='true'] {
+    background-color: var.$grey-3;
+  }
+}

--- a/src/styles/sidebar/components/PaginationNavigation.scss
+++ b/src/styles/sidebar/components/PaginationNavigation.scss
@@ -5,22 +5,29 @@
 
 .PaginationNavigation {
   @include utils.font--large;
-  @include layout.row;
 
-  &__relative {
-    // Set a minimum width for the previous and next button containers so that
-    // there is no jumping around as they appear and disappear.
-    min-width: 5em;
+  // Lay out page navigation buttons horizontally as:
+  // | prevPage  |       numberedPages          | nextPage
+  //
+  // e.g.
+  // | [<- prev] | [2] ... [5] [6] [7] ... [10] | [next ->] |
+  display: grid;
+  grid-template-columns: 8em auto 8em;
+  align-items: center;
+  grid-template-areas: 'prevPage numberedPages nextPage';
+
+  &__prev {
+    grid-area: prevPage;
   }
 
   &__next {
-    // Make sure "next" button is flush right
-    @include layout.row($justify: flex-end);
+    grid-area: nextPage;
+    justify-self: end;
   }
 
   &__pages {
+    grid-area: numberedPages;
     @include layout.row($justify: center, $align: center);
-    flex-grow: 1;
   }
 
   &__button,
@@ -34,17 +41,17 @@
   &__page-button {
     margin: var.$layout-space--xxsmall;
     padding: var.$layout-space--small var.$layout-space;
+
+    &[aria-pressed='true'] {
+      background-color: var.$grey-3;
+    }
   }
 
   &__button-right {
-    // TODO TEMPORARY adjustment until we can adjust the actual icon
+    // FIXME Button SVG margins assume that the icon is on the left
     svg {
       margin-left: var.$layout-space--xxsmall;
     }
     padding-right: var.$layout-space--xxsmall;
-  }
-
-  &__page-button[aria-pressed='true'] {
-    background-color: var.$grey-3;
   }
 }

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -41,6 +41,7 @@
 @use './components/ModerationBanner';
 @use './components/NotebookView';
 @use './components/NotebookResultCount';
+@use './components/PaginationNavigation';
 @use './components/SelectionTabs';
 @use './components/ShareAnnotationsPanel';
 @use './components/SearchInput';


### PR DESCRIPTION
This is a cleaned-up branch based on #2983

This PR adds basic front-end pagination controls to the bottom of the Notebook view. See #2983 for discussion.

Changes since POC (ignoring refactoring and cleanup):

* There is nothing at the top of the view (no page number). We ran into some UX challenges with that and it will be addressed in subsequent work
* Target areas for pagination buttons increased
* Tests for everything