### PR TITLE
Improve focus style for adjacent buttons

### DIFF
--- a/frontend-shared/styles/mixins/focus.scss
+++ b/frontend-shared/styles/mixins/focus.scss
@@ -12,6 +12,9 @@
   &:focus {
     outline: none;
     box-shadow: 0 0 0 2px var.$color-focus-outline if($inset, inset, null);
+    // In the case where $inset is false, a z-index > 0 ensures that adjacent sibling
+    // items don't obscure the box-shadow outline.
+    z-index: if($inset, inherit, 1);
   }
 }
 


### PR DESCRIPTION
This avoids using $inset for adjacent buttons which is ideal. I did not see any side effects so far of setting z-index to 1, but it may require a bit more testing. Note that this is more of an issue in the LMS grader where we are either going to have to use $inset or this trick. I propose this is a better solution and we should only use inset in the  menu where the z-index trick fails because the items are not direct sibling.



**Before**
![before](https://user-images.githubusercontent.com/3939074/107713354-e7c49a80-6c7f-11eb-9c30-f518c8c0d5f3.gif)

**After**
![after](https://user-images.githubusercontent.com/3939074/107713352-e6936d80-6c7f-11eb-84c1-735dc64f0256.gif)

