### PR TITLE
Move notebook container into shadow DOM

### DIFF
--- a/src/annotator/test/notebook-test.js
+++ b/src/annotator/test/notebook-test.js
@@ -23,10 +23,18 @@ describe('Notebook', () => {
   });
 
   describe('notebook container frame', () => {
-    it('starts hidden', () => {
+    it('is not created until the notebook is shown', () => {
       const notebook = createNotebook();
+      assert.isNull(notebook.container);
 
-      assert.equal(notebook.container.style.display, 'none');
+      notebook.show();
+      assert.isNotNull(notebook.container);
+    });
+
+    it('is not created if `hide` is called before notebook is first shown', () => {
+      const notebook = createNotebook();
+      notebook.hide();
+      assert.isNull(notebook.container);
     });
 
     it('displays when opened', () => {
@@ -137,12 +145,15 @@ describe('Notebook', () => {
   describe('destruction', () => {
     it('should remove the frame', () => {
       const notebook = createNotebook();
+      const hostDocument = notebook.element;
+
       // Make sure the frame is created
       notebook.show();
+      assert.isNotNull(hostDocument.querySelector('hypothesis-notebook'));
 
       notebook.destroy();
 
-      assert.equal(notebook.frame.parentElement, null);
+      assert.isNull(hostDocument.querySelector('hypothesis-notebook'));
     });
   });
 });

--- a/src/styles/annotator/notebook.scss
+++ b/src/styles/annotator/notebook.scss
@@ -2,7 +2,6 @@
 @use '../mixins/molecules';
 
 .notebook-outer {
-  // TODO: CSS namespace conflicts?
   box-sizing: border-box;
   position: fixed;
   top: 0;


### PR DESCRIPTION
Follow the example of the `<hypothesis-sidebar>` element by making the `<hypothesis-notebook>` element an unstyled shadow-host which serves as the root container for the notebook, isolating it from the page's styles. Inside this is a styled element which serves as the visual container.

As well as isolating the notebook from the host page's styles, this will also make it possible to avoid loading annotator styles into the host page. See https://github.com/hypothesis/client/issues/2979.

To reduce resource usage a little when the notebook is not used, only the notebook's shadow host is created initially. The styled inner container is created when the notebook is shown for the first time.