### PR TITLE
Debounce on window.resize event

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -1,4 +1,5 @@
 import Hammer from 'hammerjs';
+import debounce from 'lodash.debounce';
 
 import annotationCounts from './annotation-counts';
 import sidebarTrigger from './sidebar-trigger';
@@ -151,7 +152,11 @@ export default class Sidebar extends Guest {
       this.toolbarWidth = 0;
     }
 
-    this._registerEvent(window, 'resize', () => this._onResize());
+    this._registerEvent(
+      window,
+      'resize',
+      debounce(() => this._onResize(), 10)
+    );
 
     this._gestureState = {
       // Initial position at the start of a drag/pan resize event (in pixels).

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -97,6 +97,9 @@ describe('Sidebar', () => {
       './toolbar': {
         ToolbarController: FakeToolbarController,
       },
+
+      // Disable debouncing of updates.
+      'lodash.debounce': callback => callback,
     });
   });
 


### PR DESCRIPTION
Based on @lyzadanger [suggestion](https://github.com/hypothesis/client/pull/2937#pullrequestreview-585794221) I added debouncing to the listener associated to the `window.resize` event.

Although I am waiting only 10ms to fire the event, it feels sluggish.