### PR TITLE
Fix test for `mix-blend-mode: multiply` support in Firefox, recent Chrome

### DIFF
--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -2,14 +2,6 @@ import { isNodeInRange } from './range-util';
 
 const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
 
-function isCSSPropertySupported(property, value) {
-  if (typeof CSS !== 'function' || typeof CSS.supports !== 'function') {
-    /* istanbul ignore next */
-    return false;
-  }
-  return CSS.supports(property, value);
-}
-
 /**
  * Return the canvas element underneath a highlight element in a PDF page's
  * text layer.
@@ -71,10 +63,7 @@ function drawHighlightsAbovePdfCanvas(highlightEl) {
     '.hypothesis-highlight-layer'
   );
 
-  const isCssBlendSupported = isCSSPropertySupported(
-    'mix-blend-mode',
-    'multiply'
-  );
+  const isCssBlendSupported = CSS.supports('mix-blend-mode', 'multiply');
 
   if (!svgHighlightLayer) {
     // Create SVG layer. This must be in the same stacking context as


### PR DESCRIPTION
The feature test for the `CSS.supports` API did not work in the most
recent versions of Chrome or in Firefox because `typeof CSS` returns
`object` in those browsers, whereas our code assumed it returned `function`.

In Safari and older versions of Chrome `typeof CSS` does return `function`. The change most likely occurred due to
https://chromium-review.googlesource.com/c/chromium/src/+/2434404 (somewhere between Chrome 88 and Chrome 90).

All of the browsers we currently support implement the two-argument
version of `CSS.supports` (see [1]) and so we can fix the issue by removing the feature test.

Note that the single-argument version of `CSS.supports` is not supported
by some of the oldest browsers that we support (eg. Edge Legacy)

[1] https://developer.mozilla.org/en-US/docs/Web/API/CSS/supports#browser_compatibility