### PR TITLE
Remove un-implemented (skipped) test

### DIFF
--- a/src/sidebar/components/test/Annotation-test.js
+++ b/src/sidebar/components/test/Annotation-test.js
@@ -294,8 +294,6 @@ describe('Annotation', () => {
 
         assert.isFalse(toggle.exists());
       });
-
-      it('should not render other annotation sub-components');
     });
   });
 


### PR DESCRIPTION
Noticed the other day that the test runner was reporting `1 skipped test`. This was my doing, whoops, recently. Remove the unimplemented (unnecessary) test.