### PR TITLE
Replace custom DOM element names in `AdderToolbar` component

### DIFF
--- a/src/annotator/components/AdderToolbar.js
+++ b/src/annotator/components/AdderToolbar.js
@@ -90,17 +90,15 @@ export default function AdderToolbar({
   // nb. The adder is hidden using the `visibility` property rather than `display`
   // so that we can compute its size in order to position it before display.
   return (
-    // @ts-ignore - TS doesn't know about our custom element types.
-    <hypothesis-adder-toolbar
-      class={classnames('annotator-adder', {
+    <div
+      className={classnames('annotator-adder', {
         'annotator-adder--down': arrowDirection === 'up',
         'annotator-adder--up': arrowDirection === 'down',
         'is-active': isVisible,
       })}
       style={{ visibility: isVisible ? 'visible' : 'hidden' }}
     >
-      {/* @ts-ignore */}
-      <hypothesis-adder-actions className="annotator-adder-actions">
+      <div className="annotator-adder-actions">
         <ToolbarButton
           icon="annotate"
           onClick={e => handleCommand(e, 'annotate')}
@@ -124,8 +122,7 @@ export default function AdderToolbar({
             shortcut={showShortcut}
           />
         )}
-        {/* @ts-ignore */}
-      </hypothesis-adder-actions>
+      </div>
       <SvgIcon
         name="pointer"
         inline={true}
@@ -134,8 +131,7 @@ export default function AdderToolbar({
           'annotator-adder-arrow--up': arrowDirection === 'up',
         })}
       />
-      {/* @ts-ignore */}
-    </hypothesis-adder-toolbar>
+    </div>
   );
 }
 

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -84,10 +84,7 @@ describe('Adder', () => {
     new Adder(adderEl, adderCallbacks);
 
     assert.called(adderEl.attachShadow);
-    assert.equal(
-      shadowEl.childNodes[0].tagName.toLowerCase(),
-      'hypothesis-adder-toolbar'
-    );
+    assert.isTrue(shadowEl.childNodes[0].classList.contains('annotator-adder'));
 
     adderEl.remove();
   });


### PR DESCRIPTION
These custom names were a method of reducing the likelihood of these
elements being affected by the page's CSS. Since Shadow DOM support is
now much more ubiquitous this is not an issue, so switch back to
ordinary `<div>`s.

Note that the shadow hosts still use custom element names to prevent
them being impacted by page styles.  The elements being changed here are
inside the shadow DOM.