### PR TITLE
Remove unneeded functionality from the bucket-bar

### DIFF
--- a/src/annotator/plugin/bucket-bar.js
+++ b/src/annotator/plugin/bucket-bar.js
@@ -6,7 +6,7 @@ import Buckets from '../components/Buckets';
 import { anchorBuckets } from '../util/buckets';
 
 export default class BucketBar extends Delegator {
-  constructor(element, options, annotator) {
+  constructor(container, options, annotator) {
     const defaultOptions = {
       // Selectors for the scrollable elements on the page
       scrollables: [],
@@ -19,26 +19,6 @@ export default class BucketBar extends Delegator {
     super(el, opts);
 
     this.annotator = annotator;
-
-    // The element to append this plugin's element to; defaults to the provided
-    // `element` unless a `container` option was provided
-    let container = /** @type {HTMLElement} */ (element);
-
-    if (this.options.container) {
-      // If a container element selector has been provided, and there is an
-      // element corresponding to that container — use it
-      const containerEl = /** @type {HTMLElement | null } */ (document.querySelector(
-        this.options.container
-      ));
-      if (containerEl) {
-        container = containerEl;
-      } else {
-        // A container selector has been supplied, but it didn't pan out...
-        console.warn(
-          `Unable to find container element for selector '${this.options.container}'`
-        );
-      }
-    }
     container.appendChild(this.element);
 
     this.updateFunc = () => this.update();

--- a/src/annotator/plugin/test/bucket-bar-test.js
+++ b/src/annotator/plugin/test/bucket-bar-test.js
@@ -43,34 +43,6 @@ describe('BucketBar', () => {
     sandbox.restore();
   });
 
-  describe('initializing and attaching to the DOM', () => {
-    let containerEl;
-
-    beforeEach(() => {
-      // Any element referenced by `options.container` selector needs to be
-      // present on the `document` before initialization
-      containerEl = document.createElement('div');
-      containerEl.className = 'bucket-bar-container';
-      document.body.appendChild(containerEl);
-      sandbox.stub(console, 'warn'); // Restored in test-global `afterEach`
-    });
-
-    afterEach(() => {
-      containerEl.remove();
-    });
-
-    it('will append its element to any supplied `options.container` selector', () => {
-      bucketBar = createBucketBar({ container: '.bucket-bar-container' });
-      assert.exists(containerEl.querySelector('.annotator-bucket-bar'));
-    });
-
-    it('will append itself to the element passed to constructor if `options.container` non-existent', () => {
-      bucketBar = createBucketBar({ container: '.bucket-bar-nope' });
-      assert.notExists(containerEl.querySelector('.annotator-bucket-bar'));
-      assert.calledOnce(console.warn);
-    });
-  });
-
   describe('updating buckets', () => {
     it('should update buckets when the window is resized', () => {
       bucketBar = createBucketBar();


### PR DESCRIPTION
Because of recent changes in the sidebar (#2904), the BucketBar
component is no longer used as a plugin. @robertknight suggested to
remove all unneeded functionality.

Closes #2907