### PR TITLE
POC: Button component and styling approach

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
 
     // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
     "react/jsx-uses-react": "off",
+    "react/prop-types": "off",
     "react/react-in-jsx-scope": "off"
   }
 }

--- a/dev-server/templates/ui-playground.mustache
+++ b/dev-server/templates/ui-playground.mustache
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>UI component playground</title>
-  <link rel="stylesheet" href="{{ resourceRoot }}/styles/sidebar.css">
   <link rel="stylesheet" href="{{ resourceRoot }}/styles/ui-playground.css">
 </head>
 <body>

--- a/dev-server/ui-playground/ButtonsDemo.js
+++ b/dev-server/ui-playground/ButtonsDemo.js
@@ -1,0 +1,380 @@
+import ComponentSection from './ComponentSection';
+import jsxToString from './jsxToString';
+
+import {
+  IconButton,
+  CompactIconButton,
+  CustomButton,
+  IconInputButton,
+  LabeledButton,
+  LabeledIconButton,
+  LinkButton,
+  CompactLabeledIconButton,
+} from '../../src/sidebar/components/Buttons';
+
+function ComponentTableRow({ children }) {
+  return (
+    <tr>
+      <td>{children}</td>
+      <td>
+        <code>{jsxToString(children)}</code>
+      </td>
+    </tr>
+  );
+}
+
+export default function ButtonDemo() {
+  return (
+    <ComponentSection title="Buttons">
+      <h3>IconButton</h3>
+      <table className="ComponentTable">
+        <tr>
+          <th>Example</th>
+          <th>Source</th>
+        </tr>
+
+        <ComponentTableRow>
+          <IconButton icon="edit" size="large" title="Edit" />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <IconButton icon="edit" title="Edit" />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <IconButton icon="edit" size="small" title="Edit" />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <IconButton icon="trash" title="Delete annotation" isPressed />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <IconButton icon="trash" title="Delete annotation" isExpanded />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <IconButton icon="trash" title="Delete annotation" isDisabled />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <IconButton icon="profile" title="User info" variant="primary" />
+        </ComponentTableRow>
+      </table>
+
+      <h3>CompactIconButton</h3>
+      <table className="ComponentTable">
+        <tr>
+          <th>Example</th>
+          <th>Source</th>
+        </tr>
+
+        <ComponentTableRow>
+          <CompactIconButton icon="edit" size="large" title="Edit" />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CompactIconButton icon="edit" title="Edit" />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CompactIconButton icon="edit" size="small" title="Edit" />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CompactIconButton icon="trash" title="Delete annotation" isPressed />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CompactIconButton
+            icon="trash"
+            title="Delete annotation"
+            isExpanded
+          />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CompactIconButton
+            icon="trash"
+            title="Delete annotation"
+            isDisabled
+          />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CompactIconButton
+            icon="profile"
+            title="User info"
+            variant="primary"
+          />
+        </ComponentTableRow>
+      </table>
+
+      <h3>LabeledButton</h3>
+      <table className="ComponentTable">
+        <tr>
+          <th>Example</th>
+          <th>Source</th>
+        </tr>
+
+        <ComponentTableRow>
+          <LabeledButton size="large">Edit</LabeledButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LabeledButton>Edit</LabeledButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LabeledButton size="small">Edit</LabeledButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LabeledButton isPressed>Edit</LabeledButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LabeledButton isExpanded>Edit</LabeledButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LabeledButton isDisabled>Edit</LabeledButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LabeledButton variant="primary">Edit</LabeledButton>
+        </ComponentTableRow>
+      </table>
+
+      <h3>LabeledIconButton</h3>
+      <table className="ComponentTable">
+        <tr>
+          <th>Example</th>
+          <th>Source</th>
+        </tr>
+
+        <ComponentTableRow>
+          <LabeledIconButton icon="profile" size="large">
+            Edit User
+          </LabeledIconButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LabeledIconButton icon="profile">Edit User</LabeledIconButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LabeledIconButton icon="profile" size="small">
+            Edit User
+          </LabeledIconButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LabeledIconButton icon="profile" isPressed>
+            Edit User
+          </LabeledIconButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LabeledIconButton icon="profile" isExpanded>
+            Edit User
+          </LabeledIconButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LabeledIconButton icon="profile" isDisabled>
+            Edit User
+          </LabeledIconButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LabeledIconButton icon="profile" variant="primary">
+            Edit User
+          </LabeledIconButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LabeledIconButton icon="profile" iconPosition="right">
+            Edit User
+          </LabeledIconButton>
+        </ComponentTableRow>
+      </table>
+
+      <h3>CompactLabeledIconButton</h3>
+      <table className="ComponentTable">
+        <tr>
+          <th>Example</th>
+          <th>Source</th>
+        </tr>
+
+        <ComponentTableRow>
+          <CompactLabeledIconButton icon="profile" size="large">
+            Edit User
+          </CompactLabeledIconButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CompactLabeledIconButton icon="profile">
+            Edit User
+          </CompactLabeledIconButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CompactLabeledIconButton icon="profile" size="small">
+            Edit User
+          </CompactLabeledIconButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CompactLabeledIconButton icon="profile" isPressed>
+            Edit User
+          </CompactLabeledIconButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CompactLabeledIconButton icon="profile" isExpanded>
+            Edit User
+          </CompactLabeledIconButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CompactLabeledIconButton icon="profile" isDisabled>
+            Edit User
+          </CompactLabeledIconButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CompactLabeledIconButton icon="profile" variant="primary">
+            Edit User
+          </CompactLabeledIconButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CompactLabeledIconButton icon="profile" iconPosition="right">
+            Edit User
+          </CompactLabeledIconButton>
+        </ComponentTableRow>
+      </table>
+
+      <h3>LinkButton</h3>
+      <table className="ComponentTable">
+        <tr>
+          <th>Example</th>
+          <th>Source</th>
+        </tr>
+
+        <ComponentTableRow>
+          <LinkButton size="large">Show replies (10)</LinkButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LinkButton>Show replies (10)</LinkButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LinkButton size="small">Show replies (10)</LinkButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LinkButton isPressed>Show replies (10)</LinkButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LinkButton isExpanded>Show replies (10)</LinkButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LinkButton isDisabled>Show replies (10)</LinkButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <LinkButton variant="primary">Show replies (10)</LinkButton>
+        </ComponentTableRow>
+      </table>
+
+      <h3>IconInputButton</h3>
+      <table className="ComponentTable">
+        <tr>
+          <th>Example</th>
+          <th>Source</th>
+        </tr>
+
+        <ComponentTableRow>
+          <IconInputButton icon="copy" size="large" title="Copy" />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <IconInputButton icon="copy" title="Copy" />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <IconInputButton icon="copy" size="small" title="Copy" />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <IconInputButton icon="trash" title="Delete annotation" isPressed />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <IconInputButton icon="trash" title="Delete annotation" isExpanded />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <IconInputButton icon="trash" title="Delete annotation" isDisabled />
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <IconInputButton icon="profile" title="User info" variant="primary" />
+        </ComponentTableRow>
+      </table>
+
+      <h3>CustomButton</h3>
+      <table className="ComponentTable">
+        <tr>
+          <th>Example</th>
+          <th>Source</th>
+        </tr>
+
+        <ComponentTableRow>
+          <CustomButton className="TestCustomButton" size="large">
+            100
+          </CustomButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CustomButton className="TestCustomButton">100</CustomButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CustomButton className="TestCustomButton" size="small">
+            100
+          </CustomButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CustomButton className="TestCustomButton" isPressed>
+            Show replies (10)
+          </CustomButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CustomButton className="TestCustomButton" isExpanded>
+            Show replies (10)
+          </CustomButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CustomButton className="TestCustomButton" isDisabled>
+            Show replies (10)
+          </CustomButton>
+        </ComponentTableRow>
+
+        <ComponentTableRow>
+          <CustomButton className="TestCustomButton" variant="primary">
+            Show replies(10)
+          </CustomButton>
+        </ComponentTableRow>
+      </table>
+    </ComponentSection>
+  );
+}

--- a/dev-server/ui-playground/ComponentSection.js
+++ b/dev-server/ui-playground/ComponentSection.js
@@ -1,0 +1,8 @@
+export default function ComponentSection({ title, children }) {
+  return (
+    <section className="ComponentSection__wrapper">
+      <h1>{title}</h1>
+      {children}
+    </section>
+  );
+}

--- a/dev-server/ui-playground/PlaygroundApp.js
+++ b/dev-server/ui-playground/PlaygroundApp.js
@@ -1,41 +1,24 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
 
-import Button from '../../src/sidebar/components/Button';
+import ComponentSection from './ComponentSection';
+
+import ButtonsDemo from './ButtonsDemo';
+
 import Menu from '../../src/sidebar/components/Menu';
 import MenuItem from '../../src/sidebar/components/MenuItem';
 
 import { useRoute } from './router';
 
-function ComponentDemo({ title, children }) {
-  return (
-    <section>
-      <h1 className="heading">{title}</h1>
-      {children}
-    </section>
-  );
-}
-
-function ButtonDemo() {
-  return (
-    <ComponentDemo title="Button">
-      <Button buttonText="Text button" />
-      <Button icon="edit" title="Icon button" />
-      <Button icon="trash" buttonText="Icon + text button" />
-      <Button disabled={true} buttonText="Disabled button" />
-    </ComponentDemo>
-  );
-}
-
 function MenuDemo() {
   return (
-    <ComponentDemo title="Menu">
+    <ComponentSection title="Menu">
       <Menu label="Edit">
         <MenuItem label="Zoom in" />
         <MenuItem label="Zoom out" />
         <MenuItem label="Undo" />
         <MenuItem label="Redo" />
       </Menu>
-    </ComponentDemo>
+    </ComponentSection>
   );
 }
 
@@ -55,9 +38,9 @@ const routes = [
     component: HomeRoute,
   },
   {
-    route: '/button',
-    title: 'Button',
-    component: ButtonDemo,
+    route: '/buttons',
+    title: 'Buttons',
+    component: ButtonsDemo,
   },
   {
     route: '/menu',
@@ -83,23 +66,25 @@ export default function PlaygroundApp() {
   return (
     <main className="PlaygroundApp">
       <div className="PlaygroundApp__sidebar">
-        <a
-          className="PlaygroundApp__nav-link u-center"
-          href={baseUrl}
-          onClick={e => navigate(e, '/')}
-        >
-          <SvgIcon name="logo" />
-        </a>
-        {demoRoutes.map(c => (
-          <a
-            className="PlaygroundApp__nav-link"
-            key={c.route}
-            href={c.route}
-            onClick={e => navigate(e, c.route)}
-          >
-            {c.title}
+        <div className="PlaygroundApp__sidebar-home">
+          <a href={baseUrl} onClick={e => navigate(e, '/')}>
+            <SvgIcon name="logo" />
           </a>
-        ))}
+        </div>
+        <ul>
+          {demoRoutes.map(c => (
+            <li key={c.route}>
+              <a
+                className="PlaygroundApp__nav-link"
+                key={c.route}
+                href={c.route}
+                onClick={e => navigate(e, c.route)}
+              >
+                {c.title}
+              </a>
+            </li>
+          ))}
+        </ul>
       </div>
       <div className="PlaygroundApp__content">{content}</div>
     </main>

--- a/dev-server/ui-playground/jsxToString.js
+++ b/dev-server/ui-playground/jsxToString.js
@@ -1,0 +1,50 @@
+function escapeQuotes(str) {
+  return str.replace(/"/g, '\\"');
+}
+
+function componentName(type) {
+  if (typeof type === 'string') {
+    return type;
+  } else {
+    return type.displayName || type.name;
+  }
+}
+
+export default function jsxToString(vnode) {
+  if (typeof vnode === 'string' || typeof vnode === 'number') {
+    return vnode.toString();
+  } else if (vnode?.type) {
+    const name = componentName(vnode.type);
+
+    // TODO - Add in the `key` prop which is extracted off the props into `vnode.key`.
+    let propStr = Object.entries(vnode.props)
+      .map(([name, value]) => {
+        if (name === 'children') {
+          return '';
+        }
+        // nb. We assume that `value` is something that can easily be stringified
+        // using `String(value)`.
+        return `${name}="${escapeQuotes(String(value))}"`;
+      })
+      .join(' ')
+      .trim();
+    if (propStr.length > 0) {
+      propStr = ' ' + propStr;
+    }
+
+    const children = vnode.props.children;
+    if (children) {
+      // TODO - Be smart about splitting children over multiple lines if
+      // there are enough of them or the string is too long.
+      const childrenStr = Array.isArray(children)
+        ? children.map(jsxToString).join('')
+        : jsxToString(children);
+      return `<${name}${propStr}>${childrenStr}</${name}>`;
+    } else {
+      // No children - use a self-closing tag.
+      return `<${name}${propStr}/>`;
+    }
+  } else {
+    return '';
+  }
+}

--- a/src/sidebar/components/Annotation/AnnotationActionBar.js
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.js
@@ -8,7 +8,7 @@ import {
 import { isPrivate, permits } from '../../helpers/permissions';
 import { withServices } from '../../service-context';
 
-import Button from '../Button';
+import { IconButton } from '../Buttons';
 
 import AnnotationShareControl from './AnnotationShareControl';
 
@@ -91,11 +91,13 @@ function AnnotationActionBar({
 
   return (
     <div className="AnnotationActionBar u-layout-row">
-      {showEditAction && <Button icon="edit" title="Edit" onClick={onEdit} />}
-      {showDeleteAction && (
-        <Button icon="trash" title="Delete" onClick={onDelete} />
+      {showEditAction && (
+        <IconButton icon="edit" title="Edit" onClick={onEdit} />
       )}
-      <Button icon="reply" title="Reply" onClick={onReplyClick} />
+      {showDeleteAction && (
+        <IconButton icon="trash" title="Delete" onClick={onDelete} />
+      )}
+      <IconButton icon="reply" title="Reply" onClick={onReplyClick} />
       {shareLink && (
         <AnnotationShareControl
           annotation={annotation}
@@ -104,14 +106,14 @@ function AnnotationActionBar({
         />
       )}
       {showFlagAction && !annotation.flagged && (
-        <Button
+        <IconButton
           icon="flag"
           title="Report this annotation to moderators"
           onClick={onFlag}
         />
       )}
       {showFlagAction && annotation.flagged && (
-        <Button
+        <IconButton
           isPressed={true}
           icon="flag--active"
           title="Annotation has been reported to the moderators"

--- a/src/sidebar/components/Annotation/AnnotationReplyToggle.js
+++ b/src/sidebar/components/Annotation/AnnotationReplyToggle.js
@@ -1,6 +1,6 @@
 import propTypes from 'prop-types';
 
-import Button from '../Button';
+import { LinkButton } from '../Buttons';
 
 /**
  * @typedef AnnotationReplyToggleProps
@@ -23,13 +23,7 @@ function AnnotationReplyToggle({
   const toggleAction = threadIsCollapsed ? 'Show replies' : 'Hide replies';
   const toggleText = `${toggleAction} (${replyCount})`;
 
-  return (
-    <Button
-      className="Annotation__reply-toggle"
-      onClick={onToggleReplies}
-      buttonText={toggleText}
-    />
-  );
+  return <LinkButton onClick={onToggleReplies}>{toggleText}</LinkButton>;
 }
 
 AnnotationReplyToggle.propTypes = {

--- a/src/sidebar/components/Buttons/index.js
+++ b/src/sidebar/components/Buttons/index.js
@@ -1,0 +1,187 @@
+import classnames from 'classnames';
+
+import { SvgIcon } from '@hypothesis/frontend-shared';
+
+/**
+ * @typedef ButtonProps
+ * @prop {Object} [children]
+ * @prop {string} [icon] - name of `SvgIcon` to render in the button
+ * @prop {'left'|'right'} [iconPosition] - Icon positioned to left or to
+ *   right of button text
+ * @prop {boolean} [isDisabled]
+ * @prop {boolean} [isExpanded] - Is the element associated with this button
+ *   expanded (set `aria-expanded`)
+ * @prop {boolean} [isPressed] - Is this button currently "active?" (set
+ *   `aria-pressed`)
+ * @prop {() => any} [onClick]
+ * @prop {'small'|'medium'|'large'} [size] - For styling, size variant
+ * @prop {string} [title]
+ * @prop {'primary'} [variant] - For styling: element variant
+ */
+
+/**
+ * @typedef IconButtonBaseProps
+ * @prop {string} icon - Icon is required for icon buttons
+ * @prop {string} title - Title is required for icon buttons
+ */
+
+/**
+ * @typedef {ButtonProps & { className: string }} ButtonBaseProps
+ * @typedef {ButtonProps & IconButtonBaseProps} IconButtonProps
+ */
+
+/**
+ * @param {ButtonBaseProps} props
+ */
+function ButtonBase({
+  children,
+  className,
+  icon,
+  iconPosition = 'left',
+  isDisabled,
+  isExpanded,
+  isPressed,
+  onClick = () => {},
+  size = 'medium',
+  title,
+  variant,
+}) {
+  const ariaAttributes = {};
+  const otherAttributes = {};
+  if (typeof isDisabled === 'boolean') {
+    otherAttributes.disabled = isDisabled;
+  }
+  if (typeof title !== 'undefined') {
+    otherAttributes.title = title;
+    ariaAttributes['aria-label'] = title;
+  }
+
+  if (typeof isExpanded === 'boolean') {
+    ariaAttributes['aria-expanded'] = isExpanded;
+  }
+  if (typeof isPressed === 'boolean') {
+    ariaAttributes['aria-pressed'] = isPressed;
+  }
+
+  return (
+    <button
+      className={classnames(className, `${className}--size-${size}`, {
+        [`${className}--${variant}`]: variant,
+        [`${className}--icon-${iconPosition}`]: icon,
+      })}
+      onClick={onClick}
+      {...otherAttributes}
+      {...ariaAttributes}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * An icon-only button
+ * @param {IconButtonProps} props
+ */
+export function IconButton(props) {
+  const { icon } = props;
+  return (
+    <ButtonBase className="IconButton" {...props}>
+      <SvgIcon name={icon} />
+    </ButtonBase>
+  );
+}
+
+/**
+ * An icon-only button, styled in a compact fashion
+ * @param {IconButtonProps} props
+ */
+export function CompactIconButton(props) {
+  const { icon } = props;
+  return (
+    <ButtonBase className="CompactIconButton" {...props}>
+      <SvgIcon name={icon} />
+    </ButtonBase>
+  );
+}
+
+/**
+ * A labeled button with no icon
+ * @param {ButtonProps} props
+ */
+export function LabeledButton(props) {
+  const { children } = props;
+  return (
+    <ButtonBase className="LabeledButton" {...props}>
+      {children}
+    </ButtonBase>
+  );
+}
+
+/**
+ * A button with an icon (default on left) and a label
+ * @param {IconButtonProps} props
+ */
+export function LabeledIconButton(props) {
+  const { children, icon, iconPosition = 'left' } = props;
+  return (
+    <ButtonBase className="LabeledIconButton" {...props}>
+      {iconPosition === 'left' && <SvgIcon name={icon} />}
+      {children}
+      {iconPosition === 'right' && <SvgIcon name={icon} />}
+    </ButtonBase>
+  );
+}
+
+/**
+ * A button with an icon (default on left) and a label, styled
+ * in a compact fashion
+ * @param {IconButtonProps} props
+ */
+export function CompactLabeledIconButton(props) {
+  const { children, icon, iconPosition = 'left' } = props;
+  return (
+    <ButtonBase className="CompactLabeledIconButton" {...props}>
+      {iconPosition === 'left' && <SvgIcon name={icon} />}
+      {children}
+      {iconPosition === 'right' && <SvgIcon name={icon} />}
+    </ButtonBase>
+  );
+}
+
+/**
+ * An icon-only button, styled to pair with a text input field. The button
+ * is assumed to be to the right of the text input.
+ * @param {IconButtonProps} props
+ */
+export function IconInputButton(props) {
+  const { icon } = props;
+  return (
+    <ButtonBase className="IconInputButton" {...props}>
+      <SvgIcon name={icon} />
+    </ButtonBase>
+  );
+}
+
+/**
+ * A button styled to appear as an HTML link (<a>)
+ * @param {ButtonProps} props
+ */
+export function LinkButton(props) {
+  const { children } = props;
+  return (
+    <ButtonBase className="LinkButton" {...props}>
+      {children}
+    </ButtonBase>
+  );
+}
+
+/**
+ * A custom button. Forwards on provided `className`
+ *
+ * Uses `ButtonBaseProps` to allow `className`
+ * @param {ButtonBaseProps} props
+ */
+export function CustomButton(props) {
+  const { children } = props;
+  return <ButtonBase {...props}>{children}</ButtonBase>;
+}

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -8,6 +8,7 @@ import { withServices } from '../service-context';
 import { applyTheme } from '../helpers/theme';
 
 import Button from './Button';
+import { CompactIconButton } from './Buttons';
 import GroupList from './GroupList';
 import SearchInput from './SearchInput';
 import SortMenu from './SortMenu';
@@ -112,8 +113,7 @@ function TopBar({
         <div className="TopBar__inner content">
           <StreamSearchInput />
           <div className="u-stretch" />
-          <Button
-            className="TopBar__icon-button"
+          <CompactIconButton
             icon="help"
             isExpanded={isHelpPanelOpen}
             onClick={requestHelp}
@@ -128,13 +128,13 @@ function TopBar({
           <GroupList className="GroupList" auth={auth} />
           <div className="u-stretch" />
           {pendingUpdateCount > 0 && (
-            <Button
-              className="TopBar__icon-button TopBar__icon-button--refresh"
+            <CompactIconButton
               icon="refresh"
               onClick={applyPendingUpdates}
               title={`Show ${pendingUpdateCount} new/updated ${
                 pendingUpdateCount === 1 ? 'annotation' : 'annotations'
               }`}
+              variant="primary"
             />
           )}
           <SearchInput
@@ -143,16 +143,14 @@ function TopBar({
           />
           <SortMenu />
           {showSharePageButton && (
-            <Button
-              className="TopBar__icon-button"
+            <CompactIconButton
               icon="share"
               isExpanded={isAnnotationsPanelOpen}
               onClick={toggleSharePanel}
               title="Share annotations on this page"
             />
           )}
-          <Button
-            className="TopBar__icon-button"
+          <CompactIconButton
             icon="help"
             isExpanded={isHelpPanelOpen}
             onClick={requestHelp}

--- a/src/sidebar/components/VersionInfo.js
+++ b/src/sidebar/components/VersionInfo.js
@@ -3,7 +3,7 @@ import propTypes from 'prop-types';
 import { copyText } from '../util/copy-to-clipboard';
 import { withServices } from '../service-context';
 
-import Button from './Button';
+import { LabeledIconButton } from './Buttons';
 
 /**
  * @typedef VersionInfoProps
@@ -43,11 +43,13 @@ function VersionInfo({ toastMessenger, versionData }) {
         <dd className="VersionInfo__value">{versionData.timestamp}</dd>
       </dl>
       <div className="u-layout-row--justify-center">
-        <Button
-          buttonText="Copy version details"
+        <LabeledIconButton
+          title="Copy version details"
           onClick={copyVersionData}
           icon="copy"
-        />
+        >
+          Copy version details
+        </LabeledIconButton>
       </div>
     </div>
   );

--- a/src/styles/sidebar/components/Buttons.scss
+++ b/src/styles/sidebar/components/Buttons.scss
@@ -1,0 +1,304 @@
+@use "sass:map";
+@use "@hypothesis/frontend-shared/styles/mixins/focus";
+@use "../variables" as var;
+
+// VARIABLE MAPPING
+// This section maps variables from the client's variables to tokens
+// consumable by this component's styles
+$border-radius: var.$border-radius;
+$touch-target-size: var.$touch-target-size;
+
+$color-g1: var.$grey-1;
+$color-g2: var.$grey-2;
+$color-g3: var.$grey-3;
+$color-gsemi: var.$grey-semi;
+// grey-4 and grey-5 unused because of contrast requirements
+$color-gmid: var.$grey-mid;
+$color-g6: var.$grey-6;
+$color-g7: var.$grey-7;
+$color-brand: var.$color-brand;
+$color-link-hover: var.$color-link-hover;
+
+// VARIABLES AND COLOR MAPS
+// This section sets up some "local" variables and colormaps (SASS maps
+// containing color sets)
+$base-sizes: (
+  'small': 0.825em,
+  'medium': 1em,
+  'large': 1.25em,
+);
+
+// COLOR MAPS: BASE COLORS
+// There are currently two sets (maps) of colors from which button styling
+// are derived:
+// - $base-colors: Intended for rendering a button on a white background.
+// - $base-colors--onGrey: Intended for rendering a button on a light-grey
+//   background.
+$base-colors: (
+  'foreground': $color-gmid,
+  'background': $color-g1,
+  'hover-foreground': $color-g7,
+  'hover-background': $color-g2,
+  'active-foreground': $color-g7,
+  'active-background': $color-g1,
+  'border': transparent,
+  'disabled-foreground': $color-gmid,
+);
+
+$base-colors--onGrey: (
+  'foreground': $color-gmid,
+  'background': $color-g2,
+  'hover-foreground': $color-g7,
+  'hover-background': $color-g3,
+  'active-foreground': $color-g7,
+  'active-background': $color-g2,
+  'border': transparent,
+  'disabled-foreground': $color-gmid,
+);
+
+// TOKENS AND COLOR MAPS: COLORS for specific Button components
+// Each Button component class gets a color map by "extending" the base
+// color map as needed
+
+// Icon-only buttons have a transparent background by default, and a more
+// visible active (pressed) state
+$IconButton-colors: map.merge(
+  $base-colors,
+  (
+    'background': transparent,
+    'hover-background': transparent,
+    'active-foreground': $color-brand,
+    'active-background': transparent,
+  )
+);
+
+// Allow variant of icon-only button that is visually emphasized
+// (always brand-colored, even when not active/pressed)
+$IconButton-colors--primary: map.merge(
+  $IconButton-colors,
+  (
+    'foreground': $color-brand,
+    'hover-foreground': $color-brand,
+    'active-foreground': $color-brand,
+  )
+);
+
+$LabeledButton-colors: $base-colors;
+
+// This set of colors is light text on dark background
+$LabeledButton--primary-colors: map.merge(
+  $base-colors,
+  (
+    'foreground': $color-g1,
+    'background': $color-gmid,
+    'hover-foreground': $color-g1,
+    'hover-background': $color-g6,
+    'disabled-foreground': $color-gsemi,
+  )
+);
+
+// This set of colors is for buttons styled as links on a white background
+$LinkButton-colors: map.merge(
+  $base-colors,
+  (
+    'background': transparent,
+    'hover-background': transparent,
+    'active-background': transparent,
+    'hover-foreground': $color-link-hover,
+  )
+);
+
+// Input buttons are icon-only buttons positioned next to text inputs.
+// They have a background color (cf. standard icon buttons) and a border.
+$InputButton-colors: map.merge(
+  $base-colors,
+  (
+    'border': $color-g3,
+  )
+);
+
+// BUTTON MIXINS
+
+// Reset browser native styles. This can be used in conjunction with other
+// styles via `base` or standalone for starting a custom button's styles
+// from relative scratch
+@mixin reset {
+  @include focus.outline-on-keyboard-focus;
+  // Reset native styles
+  padding: 0;
+  margin: 0;
+  background-color: transparent;
+  border-style: none;
+}
+
+@mixin hover-state($colormap: $base-colors) {
+  &:hover:not([disabled]),
+  &:focus:not([disabled]) {
+    color: map.get($colormap, 'hover-foreground');
+    background-color: map.get($colormap, 'hover-background');
+    @content;
+  }
+  transition: color 0.2s ease-out, background-color 0.2s ease-out,
+    opacity 0.2s ease-out;
+}
+
+@mixin active-state($colormap: $base-colors) {
+  &[aria-expanded='true'],
+  &[aria-pressed='true'] {
+    color: map.get($colormap, 'active-foreground');
+    background-color: map.get($colormap, 'active-background');
+    @content;
+
+    &:hover:not([disabled]),
+    &:focus:not([disabled]) {
+      color: map.get($colormap, 'active-foreground');
+      background-color: map.get($colormap, 'active-background');
+      @content;
+    }
+  }
+}
+
+// Base mixin for all button-ish components
+@mixin base($colormap: $base-colors) {
+  @include reset;
+
+  border-radius: $border-radius;
+  border: none;
+  padding: 0.5em;
+
+  font-size: map.get($base-sizes, 'medium');
+  font-weight: 700;
+  white-space: nowrap; // Keep multi-word button labels from wrapping
+
+  color: map.get($colormap, 'foreground');
+  background-color: map.get($colormap, 'background');
+
+  &--size-small {
+    font-size: map.get($base-sizes, 'small');
+  }
+
+  &--size-large {
+    font-size: map.get($base-sizes, 'large');
+  }
+
+  // (icon) SVG sizing is relevant
+  svg {
+    width: 1.25em;
+    height: 1.25em;
+  }
+
+  &:disabled {
+    color: map.get($colormap, 'disabled-foreground');
+  }
+}
+
+// Convenience wrapper for a button with active (pressed) and hover states
+@mixin baseWithStates($colormap: $base-colors) {
+  @include base($colormap);
+  @include active-state($colormap);
+  @include hover-state($colormap);
+}
+
+// Extra mixin for buttons that contain both an icon and label/text content
+// to help with aligning the text vs. icon and space between text and icon
+@mixin with-icon-and-content($margin: 0.5em) {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  &--icon-left svg {
+    margin-right: $margin;
+  }
+
+  &--icon-right svg {
+    margin-left: $margin;
+  }
+}
+
+// COMPONENT CLASSES
+
+.IconButton {
+  @include baseWithStates($IconButton-colors);
+  &--primary {
+    @include baseWithStates($IconButton-colors--primary);
+  }
+  @media (pointer: coarse) {
+    min-width: $touch-target-size;
+    min-height: $touch-target-size;
+  }
+}
+
+// An icon-only button with tighter padding (e.g. TopBar icons)
+.CompactIconButton {
+  @include baseWithStates($colormap: $IconButton-colors);
+  &--primary {
+    @include baseWithStates($IconButton-colors--primary);
+  }
+  & svg {
+    width: 1em;
+    height: 1em;
+  }
+  padding: 0.25em;
+}
+
+// A button with text and no icon
+.LabeledButton {
+  @include baseWithStates($LabeledButton-colors);
+  &--primary {
+    @include baseWithStates($LabeledButton--primary-colors);
+  }
+}
+
+// A button with both text and icon
+.LabeledIconButton {
+  @include baseWithStates($LabeledButton-colors);
+  &--primary {
+    @include baseWithStates($LabeledButton--primary-colors);
+  }
+  @include with-icon-and-content;
+}
+
+// A button with both text and icon, tighter padding/internal margins
+.CompactLabeledIconButton {
+  @include baseWithStates($LabeledButton-colors);
+  &--primary {
+    @include baseWithStates($LabeledButton--primary-colors);
+  }
+  @include with-icon-and-content($margin: 0.25em);
+  padding: 0.25em 0.5em;
+}
+
+// An icon-only button rendered to the right of a text input field
+.IconInputButton {
+  @include baseWithStates($InputButton-colors);
+  // Add a border to line up with input field
+  border: 1px solid map.get($InputButton-colors, 'border');
+  // Sharp edges to assimilate with input field
+  border-radius: none;
+  // No border on the left because that's the side adjacent to input field
+  border-left: none;
+}
+
+// A button styled to appear as a link, with underline on hover
+.LinkButton {
+  @include base($LinkButton-colors);
+  @include hover-state($LinkButton-colors) {
+    text-decoration: underline;
+  }
+  font-weight: 400;
+}
+
+// EXAMPLE of Custom Button styling: This is temporary
+.TestCustomButton {
+  // Custom Button components can define their own color maps
+  $custom-colormap: map.merge(
+    $base-colors,
+    (
+      'background': transparent,
+      'hover-background': $color-g3,
+      'active-background': $color-g3,
+    )
+  );
+  // ...and make use of common Button mixins if so desired
+  @include baseWithStates($colormap: $custom-colormap);
+}

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -25,6 +25,7 @@
 @use './components/AnnotationUser';
 @use './components/AutocompleteList';
 @use './components/Button';
+@use './components/Buttons';
 @use './components/Excerpt';
 @use './components/FilterSelect';
 @use './components/FilterStatus';

--- a/src/styles/ui-playground/ui-playground.scss
+++ b/src/styles/ui-playground/ui-playground.scss
@@ -1,6 +1,34 @@
-$title-font: 20pt;
-$background-color: #ededed;
+@use '../reset';
+@use '../sidebar/elements';
+@use '../mixins/layout';
+@use '../variables' as var;
 
+@use '../sidebar/components/Buttons';
+
+$title-font: 20pt;
+$background-color: #9b9595;
+
+body {
+  font-size: 100%;
+}
+
+h1 {
+  font-size: 1.5em;
+  font-weight: bold;
+  margin: 1em 0;
+}
+
+h2 {
+  font-size: 1.25em;
+  font-weight: bold;
+  margin: 1em 0;
+}
+
+h3 {
+  font-size: 1.125em;
+  font-weight: bold;
+  margin: 1em 0;
+}
 // Utilities
 .u-center {
   align-self: center;
@@ -8,45 +36,92 @@ $background-color: #ededed;
 
 // Component styles
 .PlaygroundApp {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-areas:
+    'navigation'
+    'content';
 
-  max-width: 600px;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 10px;
-  min-height: 90vh;
-}
+  &__content {
+    padding: var.$layout-space;
+  }
 
-.PlaygroundApp__sidebar {
-  display: flex;
-  flex-direction: column;
-  padding: 10px;
-  background-color: $background-color;
-  border-radius: 3px;
-  margin-right: 10px;
-}
+  &__sidebar {
+    grid-area: 'navigation';
+    max-height: 20em;
+    overflow: scroll;
+    background-color: var.$grey-2;
+  }
 
-.PlaygroundApp__nav-link {
-  padding: 5px;
-  font-size: 12pt;
+  &__sidebar-home {
+    text-align: center;
+    padding: var.$layout-space;
+  }
 
-  &:hover {
-    background-color: #ddd;
+  &__content {
+    grid-area: 'content';
   }
 }
 
-.PlaygroundApp__content {
-  flex-grow: 1;
+.PlaygroundApp__nav-link {
+  width: 100%;
+  padding: var.$layout-space;
+  font-size: var.$font-size--subheading;
+  border-left: 5px solid transparent;
+  &:hover {
+    background-color: var.$grey-3;
+    border-left: 5px solid var.$color-brand;
+  }
 }
 
-.heading {
-  font-size: $title-font;
-  border-bottom: 2px solid $background-color;
-  margin-bottom: 20px;
+// Temporarily enforce the body font size of the client to demonstrate how
+// components would scale in-situ
+.ComponentSection__wrapper {
+  font-size: 13px;
+}
+
+.ComponentTable {
+  display: grid;
+  border-collapse: collapse;
+
+  grid-template-columns:
+    minmax(auto, auto)
+    minmax(20em, 1.67fr);
+
+  thead,
+  tbody,
+  tr {
+    display: contents;
+  }
+
+  th,
+  td {
+    padding: 0.5em;
+  }
+
+  td {
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
+  tr:nth-child(even) td {
+    background: var.$grey-0;
+  }
 }
 
 // Element styles
 body {
   font-family: sans-serif;
+}
+
+@media screen and (min-width: 60em) {
+  .PlaygroundApp {
+    height: 100vh;
+    grid-template-columns: 20em auto;
+    column-gap: 1em;
+    grid-template-areas: 'navigation content';
+
+    &__sidebar {
+      max-height: none;
+    }
+  }
 }


### PR DESCRIPTION
This PR is a POC for an approach to implementing and applying styling to `Button` components, with an eye to a sharable, modular set of components for use across apps.

I’m looking for sanity-check level feedback on the high-level component and styling approach.

To review draft new Button components in-browser, check out this branch, run `make dev` and open http://localhost:3000/ui-playground/buttons in your browser. (Don’t take the current state of this UI Playground page as fully-baked; it’s just a working area).

### Input solicited

I’m looking for feedback on the general approach in these two places only:

* `src/sidebar/components/Buttons/index.js` - Button preact components
* `src/styles/sidebar/components/Buttons.scss` - Their SASS styling


### Notes about the state of this code

* the `react/prop-types` ESLint rule is turned off in this branch; placeholder until we do this correctly. The `propTypes` for these `Button` components were intolerable to maintain.
* The pattern library styling and component details should be generally ignored completely here (i.e. don’t review them). I’m using that area truly as a play- and test-ground right now.
* I’ve tossed Rob’s `jsxToString` snippet into this branch because it’s useful for the present moment

### Notes about the structure of the Buttons components module

* The approach used to create the base `ButtonBase` component and the other Button components. Specifically, the use of props spreading and forwarding. We have historically not done this, but it sure allows for some more streamlined code here.
* The `Buttons` module naming is to prevent namespace conflicts for now with `Button`.
* I haven’t yet determined how the `Button`  components will be split into modules (or if they will be).
* `ButtonBase` is not for direct use (obviously, as it’s not exported)
* Each Button component is rendered with _one_ block CSS `class` . Except in the case of `CustomButton`, which takes a `className` prop, that `className` is applied by the component itself.

Put in another way, it’s not possible override the `className` for a `Button` component. “Overriding” is really a “new type of button” and should be handled via the `CustomButton` component.

This may seem overly restrictive, but I believe it could help us keep out of trouble.
* Each `Button` component has the same API surface, and the pattern here is that most props are forwarded on to `ButtonBase`. This is different than what we’ve (ever) done before but rest-props seems to make a lot of sense here and DRYs the hell out of this stuff.

### Notes about the structure of the SCSS

In the same way that nesting/extending is limited in the component code, it is also here: I’ve avoided nesting anything more than one level deep. Bit-by-bit style building in multiple layers of mixins and overrides has proven problematic in our current styling implementation.

I’d like to split this single SASS module into multiple (potentially), but have not yet done that splitting-up. Instead, I’ve commented several “sections” of the module.

One thing that I’d like to call out is the “hoisting” of references to variables from the client’s `variables` SASS module to the very top, and the mapping of those values to some local “tokens”. How we handle these values when this work gets moved into the shared package can be abstracted for now, but the rest of the source does not have a dependency on anything in the client.

To this end, I’ve elected to unroll a few of the simpler util mixins versus introducing dependencies (e.g. flexbox layout, a border on one button). I’m also using `em` units directly here instead of abstracting them through a variable. Striking a balance here so we don’t end up with dependency spaghetti.

The `Button` components’ styling is independent with a caveat: sizing is based on `em`s (as it is, primarily, in the client), which means that Buttons inherit the containing `font-size`. To make Buttons scale to what they’d look like in the client,  I’ve applied a `13px` `font-size` rule to a wrapping element in the UI playground (that’s the client’s `body` font size for better or worse).


