### PR TITLE
Align bucket bar class names with current conventions

### DIFF
--- a/src/annotator/bucket-bar.js
+++ b/src/annotator/bucket-bar.js
@@ -17,7 +17,6 @@ export default class BucketBar {
   constructor(container, guest, options = {}) {
     this.options = options;
     this.element = document.createElement('div');
-    this.element.className = 'annotator-bucket-bar';
 
     this.guest = guest;
     container.appendChild(this.element);

--- a/src/annotator/components/Buckets.js
+++ b/src/annotator/components/Buckets.js
@@ -35,7 +35,7 @@ function BucketButton({ bucket, onSelectAnnotations }) {
 
   return (
     <button
-      className="bucket-button bucket-button--left"
+      className="Buckets__button Buckets__button--left"
       onClick={event => selectAnnotations(event)}
       onMouseMove={() => setFocus(true)}
       onMouseOut={() => setFocus(false)}
@@ -73,7 +73,7 @@ function NavigationBucketButton({ bucket, direction }) {
   }
   return (
     <button
-      className={classnames('bucket-button', `bucket-button--${direction}`)}
+      className={classnames('Buckets__button', `Buckets__button--${direction}`)}
       onClick={event => scrollToClosest(event)}
       title={buttonTitle}
       aria-label={buttonTitle}
@@ -108,14 +108,18 @@ export default function Buckets({
   const showDownNavigation = below.anchors.length > 0;
 
   return (
-    <ul className="buckets">
+    <ul className="Buckets__list">
       {showUpNavigation && (
-        <li className="bucket" style={{ top: above.position }}>
+        <li className="Buckets__bucket" style={{ top: above.position }}>
           <NavigationBucketButton bucket={above} direction="up" />
         </li>
       )}
       {buckets.map((bucket, index) => (
-        <li className="bucket" style={{ top: bucket.position }} key={index}>
+        <li
+          className="Buckets__bucket"
+          style={{ top: bucket.position }}
+          key={index}
+        >
           <BucketButton
             bucket={bucket}
             onSelectAnnotations={onSelectAnnotations}
@@ -123,7 +127,7 @@ export default function Buckets({
         </li>
       ))}
       {showDownNavigation && (
-        <li className="bucket" style={{ top: below.position }}>
+        <li className="Buckets__bucket" style={{ top: below.position }}>
           <NavigationBucketButton bucket={below} direction="down" />
         </li>
       )}

--- a/src/annotator/components/test/Buckets-test.js
+++ b/src/annotator/components/test/Buckets-test.js
@@ -59,9 +59,9 @@ describe('Buckets', () => {
   describe('up and down navigation', () => {
     it('renders an up navigation button if there are above-screen anchors', () => {
       const wrapper = createComponent();
-      const upButton = wrapper.find('.bucket-button--up');
+      const upButton = wrapper.find('.Buckets__button--up');
       // The list item element wrapping the button
-      const bucketItem = wrapper.find('.bucket').first();
+      const bucketItem = wrapper.find('.Buckets__bucket').first();
 
       assert.isTrue(upButton.exists());
       assert.equal(
@@ -73,15 +73,15 @@ describe('Buckets', () => {
     it('does not render an up navigation button if there are no above-screen anchors', () => {
       fakeAbove = { anchors: [], position: 150 };
       const wrapper = createComponent();
-      assert.isFalse(wrapper.find('.bucket-button--up').exists());
+      assert.isFalse(wrapper.find('.Buckets__button--up').exists());
     });
 
     it('renders a down navigation button if there are below-screen anchors', () => {
       const wrapper = createComponent();
 
-      const downButton = wrapper.find('.bucket-button--down');
+      const downButton = wrapper.find('.Buckets__button--down');
       // The list item element wrapping the button
-      const bucketItem = wrapper.find('.bucket').last();
+      const bucketItem = wrapper.find('.Buckets__bucket').last();
 
       assert.isTrue(downButton.exists());
       assert.equal(
@@ -93,14 +93,14 @@ describe('Buckets', () => {
     it('does not render a down navigation button if there are no below-screen anchors', () => {
       fakeBelow = { anchors: [], position: 550 };
       const wrapper = createComponent();
-      assert.isFalse(wrapper.find('.bucket-button--down').exists());
+      assert.isFalse(wrapper.find('.Buckets__button--down').exists());
     });
 
     it('scrolls to anchors above when up navigation button is pressed', () => {
       const fakeAnchor = { highlights: ['hi'] };
       fakeBucketsUtil.findClosestOffscreenAnchor.returns(fakeAnchor);
       const wrapper = createComponent();
-      const upButton = wrapper.find('.bucket-button--up');
+      const upButton = wrapper.find('.Buckets__button--up');
 
       upButton.simulate('click');
 
@@ -116,7 +116,7 @@ describe('Buckets', () => {
       const fakeAnchor = { highlights: ['hi'] };
       fakeBucketsUtil.findClosestOffscreenAnchor.returns(fakeAnchor);
       const wrapper = createComponent();
-      const downButton = wrapper.find('.bucket-button--down');
+      const downButton = wrapper.find('.Buckets__button--down');
 
       downButton.simulate('click');
 
@@ -133,13 +133,13 @@ describe('Buckets', () => {
     it('renders a bucket button for each bucket', () => {
       const wrapper = createComponent();
 
-      assert.equal(wrapper.find('.bucket-button--left').length, 2);
+      assert.equal(wrapper.find('.Buckets__button--left').length, 2);
     });
 
     it('focuses associated anchors when mouse enters the element', () => {
       const wrapper = createComponent();
 
-      wrapper.find('.bucket-button--left').first().simulate('mousemove');
+      wrapper.find('.Buckets__button--left').first().simulate('mousemove');
 
       assert.calledTwice(fakeHighlighter.setHighlightsFocused);
       assert.calledWith(
@@ -157,7 +157,7 @@ describe('Buckets', () => {
     it('removes focus on associated anchors when element is blurred', () => {
       const wrapper = createComponent();
 
-      wrapper.find('.bucket-button--left').first().simulate('blur');
+      wrapper.find('.Buckets__button--left').first().simulate('blur');
 
       assert.calledTwice(fakeHighlighter.setHighlightsFocused);
       assert.calledWith(
@@ -175,7 +175,7 @@ describe('Buckets', () => {
     it('removes focus on associated anchors when mouse leaves the element', () => {
       const wrapper = createComponent();
 
-      wrapper.find('.bucket-button--left').first().simulate('mouseout');
+      wrapper.find('.Buckets__button--left').first().simulate('mouseout');
 
       assert.calledTwice(fakeHighlighter.setHighlightsFocused);
       assert.calledWith(
@@ -192,7 +192,7 @@ describe('Buckets', () => {
       });
 
       wrapper
-        .find('.bucket-button--left')
+        .find('.Buckets__button--left')
         .first()
         .simulate('click', { metaKey: false, ctrlKey: false });
 
@@ -212,7 +212,7 @@ describe('Buckets', () => {
       });
 
       wrapper
-        .find('.bucket-button--left')
+        .find('.Buckets__button--left')
         .first()
         .simulate('click', { metaKey: true, ctrlKey: false });
 

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -13,8 +13,8 @@
 
 // Annotator-specific components.
 @use './components/AdderToolbar';
+@use './components/Buckets';
 @use './components/Toolbar';
-@use './bucket-bar';
 @use './highlights';
 @use './notebook';
 

--- a/src/styles/annotator/components/Buckets.scss
+++ b/src/styles/annotator/components/Buckets.scss
@@ -1,6 +1,8 @@
 @use "../mixins/buttons";
 @use "../variables" as var;
 
+$bucket-bar-width: 22px;
+
 // Bucket-bar styles are nested inside `.annotator-frame` to ensure they take
 // precedence over the CSS reset applied to `.annotator-frame`.
 .annotator-frame {
@@ -11,8 +13,8 @@
     height: 100%;
     // 2020-11-20: interim and pragmatic solution for an apparent glitch on Safari and Chrome.
     // Adding one pixel resolve this issue: https://github.com/hypothesis/client/pull/2750
-    width: var.$annotator-bucket-bar-width + 1;
-    left: -(var.$annotator-bucket-bar-width);
+    width: $bucket-bar-width + 1;
+    left: -($bucket-bar-width);
   }
 
   // When the sidebar is collapsed, make the background semi-transparent so the

--- a/src/styles/annotator/components/Buckets.scss
+++ b/src/styles/annotator/components/Buckets.scss
@@ -1,12 +1,10 @@
 @use "../mixins/buttons";
-@use "../mixins/reset";
-@use "../mixins/utils";
 @use "../variables" as var;
 
 // Bucket-bar styles are nested inside `.annotator-frame` to ensure they take
 // precedence over the CSS reset applied to `.annotator-frame`.
 .annotator-frame {
-  .annotator-bucket-bar {
+  .Buckets__list {
     background: var.$grey-2; // When sidebar is unfolded, remove the background transparency
     pointer-events: none;
     position: absolute;
@@ -19,35 +17,34 @@
 
   // When the sidebar is collapsed, make the background semi-transparent so the
   // text is visible throughout (useful for pages with tight margins)
-  &.annotator-collapsed .annotator-bucket-bar {
+  &.annotator-collapsed .Buckets__list {
     background: rgba(0, 0, 0, 0.08);
   }
 
-  .buckets,
-  .bucket {
+  .Buckets__bucket {
     position: absolute;
     right: 0;
   }
 
-  .bucket-button {
+  .Buckets__button {
     // Need pointer events again. Necessary because of `pointer-events` rule
-    // in `.annotator-bucket-bar`
+    // in `.Buckets__list`
     pointer-events: all;
   }
 
-  .bucket-button--left {
+  .Buckets__button--left {
     // Center the indicator vertically (the element is 16px tall)
     margin-top: -8px;
     @include buttons.indicator--left;
   }
 
-  .bucket-button--up {
+  .Buckets__button--up {
     @include buttons.indicator--up;
     // Vertically center the element (which is 22px high)
     margin-top: -11px;
   }
 
-  .bucket-button--down {
+  .Buckets__button--down {
     @include buttons.indicator--down;
   }
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -120,7 +120,6 @@ $sidebar--theme-clean: '.theme-clean';
 
 // Annotator-specific values
 // -----------------------------------
-$annotator-bucket-bar-width: 22px;
 $annotator-toolbar-width: 33px;
 
 $annotator-base-font-size: 14px;
@@ -130,7 +129,6 @@ $annotator-adder-font-size: 12px;
 $annotator-adder-line-height: 1em;
 
 $annotator-bucket-bar-font-size: 10px;
-$annotator-bucket-bar-line-height: 14px;
 
 $annotator-border-radius: 4px;
 


### PR DESCRIPTION
Rename CSS classes used by the bucket bar to match the `Buckets` component name and move the corresponding styles into src/styles/annotator/components/Buckets.scss.

As was recently done with the sidebar's vertical toolbar, the styles on the bucket bar container were moved to an element rendered by the `Buckets` component itself, so that there is a 1:1 association between JS modules and SASS modules for the bucket bar. In the process the DOM structure has been simplified slightly to remove the outer `.annotator-bucket-bar` class.

Before:

<img width="426" alt="buckets-css-before" src="https://user-images.githubusercontent.com/2458/109272917-6df8e900-7809-11eb-9fc5-3ee63808db00.png">

After:

<img width="430" alt="buckets-css-after" src="https://user-images.githubusercontent.com/2458/109272942-75b88d80-7809-11eb-99cd-d19ad86734f1.png">

Visually there should be no changes. I did note that on master, and in this branch, the buckets look as if they are a little too far right as the right border of the bucket is slightly clipped. I also think it might look better if the right edge aligned with the toolbar buttons above.

<img width="77" alt="bucket-alignment" src="https://user-images.githubusercontent.com/2458/109273104-a8fb1c80-7809-11eb-89cb-e6434e48d502.png">

Adjusting this is out of scope for this PR however.