### PR TITLE
Spike buttons ergonomics

### DIFF
--- a/dev-server/ui-playground/ButtonsDemo.js
+++ b/dev-server/ui-playground/ButtonsDemo.js
@@ -1,14 +1,11 @@
 import ComponentSection from './ComponentSection';
 import jsxToString from './jsxToString';
 
-import {
-  IconButton,
-  CompactIconButton,
+import Button, {
   CustomButton,
   IconInputButton,
   LabeledButton,
   LabeledIconButton,
-  LinkButton,
   CompactLabeledIconButton,
 } from '../../src/sidebar/components/Buttons';
 
@@ -34,31 +31,46 @@ export default function ButtonDemo() {
         </tr>
 
         <ComponentTableRow>
-          <IconButton icon="edit" size="large" title="Edit" />
+          <Button iconButton icon="edit" size="large" title="Edit" />
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <IconButton icon="edit" title="Edit" />
+          <Button iconButton icon="edit" title="Edit" />
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <IconButton icon="edit" size="small" title="Edit" />
+          <Button iconButton icon="edit" size="small" title="Edit" />
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <IconButton icon="trash" title="Delete annotation" isPressed />
+          <Button iconButton icon="trash" title="Delete annotation" isPressed />
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <IconButton icon="trash" title="Delete annotation" isExpanded />
+          <Button
+            iconButton
+            icon="trash"
+            title="Delete annotation"
+            isExpanded
+          />
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <IconButton icon="trash" title="Delete annotation" isDisabled />
+          <Button
+            iconButton
+            icon="trash"
+            title="Delete annotation"
+            isDisabled
+          />
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <IconButton icon="profile" title="User info" variant="primary" />
+          <Button
+            iconButton
+            icon="profile"
+            title="User info"
+            variant="primary"
+          />
         </ComponentTableRow>
       </table>
 
@@ -70,23 +82,29 @@ export default function ButtonDemo() {
         </tr>
 
         <ComponentTableRow>
-          <CompactIconButton icon="edit" size="large" title="Edit" />
+          <Button compactIconButton icon="edit" size="large" title="Edit" />
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <CompactIconButton icon="edit" title="Edit" />
+          <Button compactIconButton icon="edit" title="Edit" />
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <CompactIconButton icon="edit" size="small" title="Edit" />
+          <Button compactIconButton icon="edit" size="small" title="Edit" />
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <CompactIconButton icon="trash" title="Delete annotation" isPressed />
+          <Button
+            compactIconButton
+            icon="trash"
+            title="Delete annotation"
+            isPressed
+          />
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <CompactIconButton
+          <Button
+            compactIconButton
             icon="trash"
             title="Delete annotation"
             isExpanded
@@ -94,7 +112,8 @@ export default function ButtonDemo() {
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <CompactIconButton
+          <Button
+            compactIconButton
             icon="trash"
             title="Delete annotation"
             isDisabled
@@ -102,7 +121,8 @@ export default function ButtonDemo() {
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <CompactIconButton
+          <Button
+            compactIconButton
             icon="profile"
             title="User info"
             variant="primary"
@@ -264,31 +284,43 @@ export default function ButtonDemo() {
         </tr>
 
         <ComponentTableRow>
-          <LinkButton size="large">Show replies (10)</LinkButton>
+          <Button linkButton size="large">
+            Show replies (10)
+          </Button>
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <LinkButton>Show replies (10)</LinkButton>
+          <Button linkButton>Show replies (10)</Button>
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <LinkButton size="small">Show replies (10)</LinkButton>
+          <Button linkButton size="small">
+            Show replies (10)
+          </Button>
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <LinkButton isPressed>Show replies (10)</LinkButton>
+          <Button linkButton isPressed>
+            Show replies (10)
+          </Button>
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <LinkButton isExpanded>Show replies (10)</LinkButton>
+          <Button linkButton isExpanded>
+            Show replies (10)
+          </Button>
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <LinkButton isDisabled>Show replies (10)</LinkButton>
+          <Button linkButton isDisabled>
+            Show replies (10)
+          </Button>
         </ComponentTableRow>
 
         <ComponentTableRow>
-          <LinkButton variant="primary">Show replies (10)</LinkButton>
+          <Button linkButton variant="primary">
+            Show replies (10)
+          </Button>
         </ComponentTableRow>
       </table>
 

--- a/src/sidebar/components/Buttons/index.js
+++ b/src/sidebar/components/Buttons/index.js
@@ -82,7 +82,7 @@ function ButtonBase({
  * An icon-only button
  * @param {IconButtonProps} props
  */
-export function IconButton(props) {
+function IconButton(props) {
   const { icon } = props;
   return (
     <ButtonBase className="IconButton" {...props}>
@@ -95,7 +95,7 @@ export function IconButton(props) {
  * An icon-only button, styled in a compact fashion
  * @param {IconButtonProps} props
  */
-export function CompactIconButton(props) {
+function CompactIconButton(props) {
   const { icon } = props;
   return (
     <ButtonBase className="CompactIconButton" {...props}>
@@ -166,7 +166,7 @@ export function IconInputButton(props) {
  * A button styled to appear as an HTML link (<a>)
  * @param {ButtonProps} props
  */
-export function LinkButton(props) {
+function LinkButton(props) {
   const { children } = props;
   return (
     <ButtonBase className="LinkButton" {...props}>
@@ -183,5 +183,33 @@ export function LinkButton(props) {
  */
 export function CustomButton(props) {
   const { children } = props;
+  return <ButtonBase {...props}>{children}</ButtonBase>;
+}
+
+/**
+ * @typedef {{iconButton: boolean} & IconButtonProps} GuardedIconButton
+ * @typedef {{compactIconButton: boolean} & IconButtonProps} GuardedCompactIconButton
+ * @typedef {{linkButton: boolean} & ButtonProps} GuardedLinkButton
+ * @param {GuardedIconButton|GuardedCompactIconButton|GuardedLinkButton|ButtonBaseProps|any} props
+ */
+export default function Button({
+  iconButton,
+  compactIconButton,
+  linkButton,
+  children,
+  ...props
+}) {
+  if (iconButton) {
+    return <IconButton {...props} />;
+  }
+
+  if (compactIconButton) {
+    return <CompactIconButton {...props} />;
+  }
+
+  if (linkButton) {
+    return <LinkButton {...props}>{children}</LinkButton>;
+  }
+
   return <ButtonBase {...props}>{children}</ButtonBase>;
 }

--- a/src/test-util/accessibility.js
+++ b/src/test-util/accessibility.js
@@ -2,6 +2,7 @@ import { run } from 'axe-core';
 import { ReactWrapper, mount } from 'enzyme';
 import { isValidElement } from 'preact';
 
+/**@typedef {import('preact').VNode}  a*/
 /**
  * @typedef {Scenario}
  * @prop {string} [name] -


### PR DESCRIPTION
I am proposing to have only one interface for the `<Button>` component with several props that switches the use of the different versions of the button.