### PR TITLE
Added a button to close the notebook

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -199,14 +199,14 @@ export default class Guest extends Delegator {
 
     // Hide the sidebar in response to a document click or tap, so it doesn't obscure
     // the document content.
-    const maybeHideSidebar = event => {
+    const maybeCloseSidebar = event => {
       if (!this.closeSidebarOnDocumentClick || this.isEventInAnnotator(event)) {
         // Don't hide the sidebar if event occurred inside Hypothesis UI, or
         // the user is making a selection, or the behavior was disabled because
         // the sidebar doesn't overlap the content.
         return;
       }
-      this.crossframe?.call('hideSidebar');
+      this.crossframe?.call('closeSidebar');
     };
 
     addListener('click', event => {
@@ -215,7 +215,7 @@ export default class Guest extends Delegator {
         const toggle = event.metaKey || event.ctrlKey;
         this.selectAnnotations(annotations, toggle);
       } else {
-        maybeHideSidebar(event);
+        maybeCloseSidebar(event);
       }
     });
 
@@ -223,7 +223,7 @@ export default class Guest extends Delegator {
     // on touch-input devices, not all elements will generate a "click" event.
     addListener('touchstart', event => {
       if (!annotationsAt(event.target).length) {
-        maybeHideSidebar(event);
+        maybeCloseSidebar(event);
       }
     });
 
@@ -587,7 +587,7 @@ export default class Guest extends Delegator {
     targets.then(() => this.anchor(/** @type {AnnotationData} */ (annotation)));
 
     if (!annotation.$highlight) {
-      this.crossframe?.call('showSidebar');
+      this.crossframe?.call('openSidebar');
     }
     return annotation;
   }
@@ -611,7 +611,7 @@ export default class Guest extends Delegator {
   showAnnotations(annotations) {
     const tags = annotations.map(a => a.$tag);
     this.crossframe?.call('showAnnotations', tags);
-    this.crossframe?.call('showSidebar');
+    this.crossframe?.call('openSidebar');
   }
 
   /**

--- a/src/annotator/notebook.js
+++ b/src/annotator/notebook.js
@@ -1,6 +1,7 @@
 import Delegator from './delegator';
 import { createSidebarConfig } from './config/sidebar';
 import { createShadowRoot } from './util/shadow-root';
+import { render } from 'preact';
 
 /**
  * Create the iframe that will load the notebook application.
@@ -51,13 +52,13 @@ export default class Notebook extends Delegator {
      */
     this.container = null;
 
-    this.subscribe('showNotebook', groupId => {
+    this.subscribe('openNotebook', groupId => {
       this._groupId = groupId;
-      this.show();
+      this.open();
     });
-    this.subscribe('hideNotebook', () => this.hide());
+    this.subscribe('closeNotebook', () => this.close());
     // If the sidebar has opened, get out of the way
-    this.subscribe('sidebarOpened', () => this.hide());
+    this.subscribe('sidebarOpened', () => this.close());
   }
 
   _update() {
@@ -76,14 +77,14 @@ export default class Notebook extends Delegator {
     }
   }
 
-  show() {
+  open() {
     const container = this._initContainer();
     this._update();
     container.classList.add('is-open');
     container.style.display = '';
   }
 
-  hide() {
+  close() {
     if (this.container) {
       this.container.classList.remove('is-open');
       this.container.style.display = 'none';

--- a/src/annotator/notebook.js
+++ b/src/annotator/notebook.js
@@ -3,6 +3,9 @@ import { createSidebarConfig } from './config/sidebar';
 import { createShadowRoot } from './util/shadow-root';
 import { render } from 'preact';
 
+// FIXME: use the button from the frontend shared package once this is stable.
+import Button from '../sidebar/components/Button';
+
 /**
  * Create the iframe that will load the notebook application.
  *
@@ -33,7 +36,9 @@ export default class Notebook extends Delegator {
     super(element, config);
     this.frame = null;
 
+    /** @type {null|string} */
     this._groupId = null;
+    /** @type {null|string} */
     this._prevGroupId = null;
 
     /**
@@ -56,8 +61,7 @@ export default class Notebook extends Delegator {
       this._groupId = groupId;
       this.open();
     });
-    this.subscribe('closeNotebook', () => this.close());
-    // If the sidebar has opened, get out of the way
+    // Defensive programming: if the sidebar has opened, get out of the way
     this.subscribe('sidebarOpened', () => this.close());
   }
 
@@ -105,6 +109,25 @@ export default class Notebook extends Delegator {
     this.container.style.display = 'none';
     this.container.className = 'notebook-outer';
     shadowRoot.appendChild(this.container);
+
+    render(
+      <div className="Notebook__controller-bar">
+        <Button
+          icon="cancel"
+          className="Notebook__close-button"
+          buttonText="Close"
+          title="Close the Notebook"
+          onClick={event => {
+            // Guest 'component' captures all click events in the host page and opens the sidebar.
+            // We stop the propagation of the event to prevent the sidebar to be opened.
+            event.stopPropagation();
+            this.close();
+            this.publish('closeNotebook');
+          }}
+        />
+      </div>,
+      this.container
+    );
 
     return this.container;
   }

--- a/src/annotator/notebook.js
+++ b/src/annotator/notebook.js
@@ -84,6 +84,8 @@ export default class Notebook extends Delegator {
     this._update();
     container.classList.add('is-open');
     container.style.display = '';
+    this.originalOverflowStyle = this.element.style.overflow;
+    this.element.style.overflow = 'hidden';
   }
 
   close() {
@@ -91,6 +93,8 @@ export default class Notebook extends Delegator {
       this.container.classList.remove('is-open');
       this.container.style.display = 'none';
     }
+    this.element.style.overflow = /** @type {string} */ (this
+      .originalOverflowStyle);
   }
 
   destroy() {

--- a/src/annotator/notebook.js
+++ b/src/annotator/notebook.js
@@ -61,8 +61,6 @@ export default class Notebook extends Delegator {
       this._groupId = groupId;
       this.open();
     });
-    // Defensive programming: if the sidebar has opened, get out of the way
-    this.subscribe('sidebarOpened', () => this.close());
   }
 
   _update() {
@@ -110,20 +108,22 @@ export default class Notebook extends Delegator {
     this.container.className = 'notebook-outer';
     shadowRoot.appendChild(this.container);
 
+    const close = event => {
+      // Guest 'component' captures all click or touchstart events in the host page and opens the sidebar.
+      // We stop the propagation of the event to prevent the sidebar to be opened.
+      event.stopPropagation();
+      this.close();
+      this.publish('closeNotebook');
+    };
+
     render(
-      <div className="Notebook__controller-bar">
+      <div className="Notebook__controller-bar" onTouchStart={close}>
         <Button
           icon="cancel"
           className="Notebook__close-button"
           buttonText="Close"
           title="Close the Notebook"
-          onClick={event => {
-            // Guest 'component' captures all click events in the host page and opens the sidebar.
-            // We stop the propagation of the event to prevent the sidebar to be opened.
-            event.stopPropagation();
-            this.close();
-            this.publish('closeNotebook');
-          }}
+          onClick={close}
         />
       </div>,
       this.container

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -237,13 +237,14 @@ export default class Sidebar extends Delegator {
 
     // Re-publish the crossframe event so that anything extending Delegator
     // can subscribe to it (without need for crossframe)
-    this.guest.crossframe.on('openNotebook', groupId => {
-      this.close();
+    this.guest.crossframe.on('openNotebook', (
+      /** @type {string} */ groupId
+    ) => {
+      this.hide();
       this.publish('openNotebook', [groupId]);
     });
-    this.guest.crossframe.on('closeNotebook', () => {
-      this.open();
-      this.publish('closeNotebook');
+    this.subscribe('closeNotebook', () => {
+      this.show();
     });
 
     const eventHandlers = [
@@ -471,5 +472,23 @@ export default class Sidebar extends Delegator {
    */
   setAllVisibleHighlights(shouldShowHighlights) {
     this.guest.crossframe.call('setVisibleHighlights', shouldShowHighlights);
+  }
+
+  /**
+   * Shows the sidebar's controls
+   */
+  show() {
+    if (this.iframeContainer) {
+      this.iframeContainer.classList.remove('is-hidden');
+    }
+  }
+
+  /**
+   * Hides the sidebar's controls
+   */
+  hide() {
+    if (this.iframeContainer) {
+      this.iframeContainer.classList.add('is-hidden');
+    }
   }
 }

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -135,14 +135,14 @@ export default class Sidebar extends Delegator {
       config.query ||
       config.group
     ) {
-      this.subscribe('panelReady', () => this.show());
+      this.subscribe('panelReady', () => this.open());
     }
 
     // Set up the toolbar on the left edge of the sidebar.
     const toolbarContainer = document.createElement('div');
     this.toolbar = new ToolbarController(toolbarContainer, {
       createAnnotation: () => guest.createAnnotation(),
-      setSidebarOpen: open => (open ? this.show() : this.hide()),
+      setSidebarOpen: open => (open ? this.open() : this.close()),
       setHighlightsVisible: show => this.setAllVisibleHighlights(show),
     });
 
@@ -179,7 +179,7 @@ export default class Sidebar extends Delegator {
       final: /** @type {number|null} */ (null),
     };
     this._setupGestures();
-    this.hide();
+    this.close();
 
     // Publisher-provided callback functions
     const [serviceConfig] = config.services || [];
@@ -229,21 +229,21 @@ export default class Sidebar extends Delegator {
 
   _setupSidebarEvents() {
     annotationCounts(document.body, this.guest.crossframe);
-    sidebarTrigger(document.body, () => this.show());
+    sidebarTrigger(document.body, () => this.open());
     features.init(this.guest.crossframe);
 
-    this.guest.crossframe.on('showSidebar', () => this.show());
-    this.guest.crossframe.on('hideSidebar', () => this.hide());
+    this.guest.crossframe.on('openSidebar', () => this.open());
+    this.guest.crossframe.on('closeSidebar', () => this.close());
 
     // Re-publish the crossframe event so that anything extending Delegator
     // can subscribe to it (without need for crossframe)
-    this.guest.crossframe.on('showNotebook', groupId => {
-      this.hide();
-      this.publish('showNotebook', [groupId]);
+    this.guest.crossframe.on('openNotebook', groupId => {
+      this.close();
+      this.publish('openNotebook', [groupId]);
     });
-    this.guest.crossframe.on('hideNotebook', () => {
-      this.show();
-      this.publish('hideNotebook');
+    this.guest.crossframe.on('closeNotebook', () => {
+      this.open();
+      this.publish('closeNotebook');
     });
 
     const eventHandlers = [
@@ -370,9 +370,9 @@ export default class Sidebar extends Delegator {
   _onResize() {
     if (this.toolbar.sidebarOpen === true) {
       if (window.innerWidth < MIN_RESIZE) {
-        this.hide();
+        this.close();
       } else {
-        this.show();
+        this.open();
       }
     }
   }
@@ -409,9 +409,9 @@ export default class Sidebar extends Delegator {
           this._gestureState.final === null ||
           this._gestureState.final <= -MIN_RESIZE
         ) {
-          this.show();
+          this.open();
         } else {
-          this.hide();
+          this.close();
         }
         this._resetGestureState();
         break;
@@ -430,7 +430,7 @@ export default class Sidebar extends Delegator {
     }
   }
 
-  show() {
+  open() {
     this.guest.crossframe.call('sidebarOpened');
     this.publish('sidebarOpened');
 
@@ -449,7 +449,7 @@ export default class Sidebar extends Delegator {
     this._notifyOfLayoutChange(true);
   }
 
-  hide() {
+  close() {
     if (this.iframeContainer) {
       this.iframeContainer.style.marginLeft = '';
       this.iframeContainer.classList.add('annotator-collapsed');

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -450,7 +450,7 @@ describe('Guest', () => {
     it('hides sidebar when the user taps or clicks in the page', () => {
       for (let event of ['click', 'touchstart']) {
         rootElement.dispatchEvent(new Event(event));
-        assert.calledWith(guest.plugins.CrossFrame.call, 'hideSidebar');
+        assert.calledWith(guest.plugins.CrossFrame.call, 'closeSidebar');
       }
     });
 
@@ -565,7 +565,7 @@ describe('Guest', () => {
 
       FakeAdder.instance.options.onShowAnnotations([{ $tag: 'ann1' }]);
 
-      assert.calledWith(fakeCrossFrame.call, 'showSidebar');
+      assert.calledWith(fakeCrossFrame.call, 'openSidebar');
       assert.calledWith(fakeCrossFrame.call, 'showAnnotations', ['ann1']);
     }));
 

--- a/src/annotator/test/notebook-test.js
+++ b/src/annotator/test/notebook-test.js
@@ -114,6 +114,20 @@ describe('Notebook', () => {
     });
   });
 
+  describe('responding to user input', () => {
+    it('closes the notebook when close button clicked', () => {
+      const notebook = createNotebook();
+
+      notebook.open();
+
+      const button = notebook.container.getElementsByClassName(
+        'Notebook__close-button'
+      )[0];
+      button.click();
+      assert.equal(notebook.container.style.display, 'none');
+    });
+  });
+
   describe('responding to events', () => {
     it('opens on `openNotebook`', () => {
       const notebook = createNotebook();
@@ -121,15 +135,6 @@ describe('Notebook', () => {
       notebook.publish('openNotebook');
 
       assert.equal(notebook.container.style.display, '');
-    });
-
-    it('closes on `closeNotebook`', () => {
-      const notebook = createNotebook();
-
-      notebook.open();
-      notebook.publish('closeNotebook');
-
-      assert.equal(notebook.container.style.display, 'none');
     });
 
     it('closes on "sidebarOpened"', () => {

--- a/src/annotator/test/notebook-test.js
+++ b/src/annotator/test/notebook-test.js
@@ -27,20 +27,20 @@ describe('Notebook', () => {
       const notebook = createNotebook();
       assert.isNull(notebook.container);
 
-      notebook.show();
+      notebook.open();
       assert.isNotNull(notebook.container);
     });
 
     it('is not created if `hide` is called before notebook is first shown', () => {
       const notebook = createNotebook();
-      notebook.hide();
+      notebook.close();
       assert.isNull(notebook.container);
     });
 
     it('displays when opened', () => {
       const notebook = createNotebook();
 
-      notebook.show();
+      notebook.open();
 
       assert.equal(notebook.container.style.display, '');
       assert.isTrue(notebook.container.classList.contains('is-open'));
@@ -49,8 +49,8 @@ describe('Notebook', () => {
     it('hides when closed', () => {
       const notebook = createNotebook();
 
-      notebook.show();
-      notebook.hide();
+      notebook.open();
+      notebook.close();
 
       assert.equal(notebook.container.style.display, 'none');
       assert.isFalse(notebook.container.classList.contains('is-open'));
@@ -58,12 +58,12 @@ describe('Notebook', () => {
   });
 
   describe('creating the notebook iframe', () => {
-    it('creates the iframe when the notebook is shown for the first time', () => {
+    it('creates the iframe when the notebook is opened for the first time', () => {
       const notebook = createNotebook();
 
       assert.isNull(notebook.frame);
 
-      notebook.show();
+      notebook.open();
 
       assert.isTrue(notebook.frame instanceof Element);
     });
@@ -73,7 +73,7 @@ describe('Notebook', () => {
         notebookAppUrl: 'http://www.example.com/foo/bar',
       });
 
-      notebook.show();
+      notebook.open();
 
       // The rest of the config gets added as a hash to the end of the src,
       // so split that off and look at the string before it
@@ -83,16 +83,16 @@ describe('Notebook', () => {
       );
     });
 
-    it('does not create a new iframe if shown again with same group ID', () => {
+    it('does not create a new iframe if opened again with same group ID', () => {
       const notebook = createNotebook();
       notebook._groupId = 'mygroup';
 
-      // The first showing will create a new iFrame
-      notebook.publish('showNotebook', ['myGroup']);
+      // The first opening will create a new iFrame
+      notebook.publish('openNotebook', ['myGroup']);
       const removeSpy = sinon.spy(notebook.frame, 'remove');
-      // Show it again — the group hasn't changed so the iframe won't be
+      // Open it again — the group hasn't changed so the iframe won't be
       // replaced
-      notebook.publish('showNotebook', ['myGroup']);
+      notebook.publish('openNotebook', ['myGroup']);
 
       assert.notCalled(removeSpy);
     });
@@ -101,41 +101,41 @@ describe('Notebook', () => {
       const notebook = createNotebook();
       notebook._groupId = 'mygroup';
 
-      // First show: creates an iframe
-      notebook.publish('showNotebook', ['myGroup']);
+      // First open: creates an iframe
+      notebook.publish('openNotebook', ['myGroup']);
       const removeSpy = sinon.spy(notebook.frame, 'remove');
 
-      // Show again with another group
-      notebook.publish('showNotebook', ['anotherGroup']);
+      // Open again with another group
+      notebook.publish('openNotebook', ['anotherGroup']);
 
-      // Show again, which will remove the first iframe and create a new one
-      notebook.show();
+      // Open again, which will remove the first iframe and create a new one
+      notebook.open();
       assert.calledOnce(removeSpy);
     });
   });
 
   describe('responding to events', () => {
-    it('shows on `showNotebook`', () => {
+    it('opens on `openNotebook`', () => {
       const notebook = createNotebook();
 
-      notebook.publish('showNotebook');
+      notebook.publish('openNotebook');
 
       assert.equal(notebook.container.style.display, '');
     });
 
-    it('hides on `hideNotebook`', () => {
+    it('closes on `closeNotebook`', () => {
       const notebook = createNotebook();
 
-      notebook.show();
-      notebook.publish('hideNotebook');
+      notebook.open();
+      notebook.publish('closeNotebook');
 
       assert.equal(notebook.container.style.display, 'none');
     });
 
-    it('hides on "sidebarOpened"', () => {
+    it('closes on "sidebarOpened"', () => {
       const notebook = createNotebook();
 
-      notebook.show();
+      notebook.open();
       notebook.publish('sidebarOpened');
 
       assert.equal(notebook.container.style.display, 'none');
@@ -148,7 +148,7 @@ describe('Notebook', () => {
       const hostDocument = notebook.element;
 
       // Make sure the frame is created
-      notebook.show();
+      notebook.open();
       assert.isNotNull(hostDocument.querySelector('hypothesis-notebook'));
 
       notebook.destroy();

--- a/src/annotator/test/notebook-test.js
+++ b/src/annotator/test/notebook-test.js
@@ -136,15 +136,6 @@ describe('Notebook', () => {
 
       assert.equal(notebook.container.style.display, '');
     });
-
-    it('closes on "sidebarOpened"', () => {
-      const notebook = createNotebook();
-
-      notebook.open();
-      notebook.publish('sidebarOpened');
-
-      assert.equal(notebook.container.style.display, 'none');
-    });
   });
 
   describe('destruction', () => {

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -278,29 +278,29 @@ describe('Sidebar', () => {
         assert.called(target);
       }));
 
-    describe('on "openNotebook" event', () => {
-      it('hides itself and republishes the event', () => {
+    describe('on "openNotebook" crossframe event', () => {
+      it('hides the sidebar', () => {
         const sidebar = createSidebar();
+        sinon.stub(sidebar, 'hide').callThrough();
         sinon.stub(sidebar, 'publish');
-        sinon.stub(sidebar, 'close');
         emitEvent('openNotebook', 'mygroup');
         assert.calledWith(
           sidebar.publish,
           'openNotebook',
           sinon.match(['mygroup'])
         );
-        assert.calledOnce(sidebar.close);
+        assert.calledOnce(sidebar.hide);
+        assert.notEqual(sidebar.iframeContainer.style.visibility, 'hidden');
       });
     });
 
-    describe('on "closeNotebook" event', () => {
-      it('opens itself and republishes the event', () => {
+    describe('on "closeNotebook" internal event', () => {
+      it('shows the sidebar', () => {
         const sidebar = createSidebar();
-        sinon.stub(sidebar, 'publish');
-        sinon.stub(sidebar, 'open');
-        emitEvent('closeNotebook');
-        assert.calledWith(sidebar.publish, 'closeNotebook');
-        assert.calledOnce(sidebar.open);
+        sinon.stub(sidebar, 'show').callThrough();
+        sidebar.publish('closeNotebook');
+        assert.calledOnce(sidebar.show);
+        assert.equal(sidebar.iframeContainer.style.visibility, '');
       });
     });
 

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -198,16 +198,16 @@ describe('Sidebar', () => {
   });
 
   describe('toolbar buttons', () => {
-    it('shows or hides sidebar when toolbar button is clicked', () => {
+    it('opens and closes sidebar when toolbar button is clicked', () => {
       const sidebar = createSidebar();
-      sinon.stub(sidebar, 'show');
-      sinon.stub(sidebar, 'hide');
+      sinon.stub(sidebar, 'open');
+      sinon.stub(sidebar, 'close');
 
       FakeToolbarController.args[0][1].setSidebarOpen(true);
-      assert.called(sidebar.show);
+      assert.called(sidebar.open);
 
       FakeToolbarController.args[0][1].setSidebarOpen(false);
-      assert.called(sidebar.hide);
+      assert.called(sidebar.close);
     });
 
     it('shows or hides highlights when toolbar button is clicked', () => {
@@ -262,45 +262,45 @@ describe('Sidebar', () => {
       return result;
     };
 
-    describe('on "show" event', () =>
-      it('shows the frame', () => {
-        const target = sandbox.stub(Sidebar.prototype, 'show');
+    describe('on "open" event', () =>
+      it('opens the frame', () => {
+        const target = sandbox.stub(Sidebar.prototype, 'open');
         createSidebar();
-        emitEvent('showSidebar');
+        emitEvent('openSidebar');
         assert.called(target);
       }));
 
-    describe('on "hide" event', () =>
-      it('hides the frame', () => {
-        const target = sandbox.stub(Sidebar.prototype, 'hide');
+    describe('on "close" event', () =>
+      it('closes the frame', () => {
+        const target = sandbox.stub(Sidebar.prototype, 'close');
         createSidebar();
-        emitEvent('hideSidebar');
+        emitEvent('closeSidebar');
         assert.called(target);
       }));
 
-    describe('on "showNotebook" event', () => {
+    describe('on "openNotebook" event', () => {
       it('hides itself and republishes the event', () => {
         const sidebar = createSidebar();
         sinon.stub(sidebar, 'publish');
-        sinon.stub(sidebar, 'hide');
-        emitEvent('showNotebook', 'mygroup');
+        sinon.stub(sidebar, 'close');
+        emitEvent('openNotebook', 'mygroup');
         assert.calledWith(
           sidebar.publish,
-          'showNotebook',
+          'openNotebook',
           sinon.match(['mygroup'])
         );
-        assert.calledOnce(sidebar.hide);
+        assert.calledOnce(sidebar.close);
       });
     });
 
-    describe('on "hideNotebook" event', () => {
-      it('shows itself and republishes the event', () => {
+    describe('on "closeNotebook" event', () => {
+      it('opens itself and republishes the event', () => {
         const sidebar = createSidebar();
         sinon.stub(sidebar, 'publish');
-        sinon.stub(sidebar, 'show');
-        emitEvent('hideNotebook');
-        assert.calledWith(sidebar.publish, 'hideNotebook');
-        assert.calledOnce(sidebar.show);
+        sinon.stub(sidebar, 'open');
+        emitEvent('closeNotebook');
+        assert.calledWith(sidebar.publish, 'closeNotebook');
+        assert.calledOnce(sidebar.open);
       });
     });
 
@@ -448,18 +448,18 @@ describe('Sidebar', () => {
         assert.equal(sidebar.iframeContainer.style.pointerEvents, '');
       });
 
-      it('calls `show` if the widget is fully visible', () => {
+      it('calls `open` if the widget is fully visible', () => {
         sidebar._gestureState = { final: -500 };
-        const show = sandbox.stub(sidebar, 'show');
+        const open = sandbox.stub(sidebar, 'open');
         sidebar._onPan({ type: 'panend' });
-        assert.calledOnce(show);
+        assert.calledOnce(open);
       });
 
-      it('calls `hide` if the widget is not fully visible', () => {
+      it('calls `close` if the widget is not fully visible', () => {
         sidebar._gestureState = { final: -100 };
-        const hide = sandbox.stub(sidebar, 'hide');
+        const close = sandbox.stub(sidebar, 'close');
         sidebar._onPan({ type: 'panend' });
-        assert.calledOnce(hide);
+        assert.calledOnce(close);
       });
     });
 
@@ -480,43 +480,43 @@ describe('Sidebar', () => {
       const sidebar = createSidebar({
         annotations: 'ann-id',
       });
-      const show = sandbox.stub(sidebar, 'show');
+      const open = sandbox.stub(sidebar, 'open');
       sidebar.publish('panelReady');
-      assert.calledOnce(show);
+      assert.calledOnce(open);
     });
 
     it('opens the sidebar when a direct-linked group is present.', () => {
       const sidebar = createSidebar({
         group: 'group-id',
       });
-      const show = sandbox.stub(sidebar, 'show');
+      const open = sandbox.stub(sidebar, 'open');
       sidebar.publish('panelReady');
-      assert.calledOnce(show);
+      assert.calledOnce(open);
     });
 
     it('opens the sidebar when a direct-linked query is present.', () => {
       const sidebar = createSidebar({
         query: 'tag:foo',
       });
-      const show = sandbox.stub(sidebar, 'show');
+      const open = sandbox.stub(sidebar, 'open');
       sidebar.publish('panelReady');
-      assert.calledOnce(show);
+      assert.calledOnce(open);
     });
 
     it('opens the sidebar when openSidebar is set to true.', () => {
       const sidebar = createSidebar({
         openSidebar: true,
       });
-      const show = sandbox.stub(sidebar, 'show');
+      const open = sandbox.stub(sidebar, 'open');
       sidebar.publish('panelReady');
-      assert.calledOnce(show);
+      assert.calledOnce(open);
     });
 
-    it('does not show the sidebar if not configured to.', () => {
+    it('does not open the sidebar if not configured to.', () => {
       const sidebar = createSidebar();
-      const show = sandbox.stub(sidebar, 'show');
+      const open = sandbox.stub(sidebar, 'open');
       sidebar.publish('panelReady');
-      assert.notCalled(show);
+      assert.notCalled(open);
     });
   });
 
@@ -538,22 +538,22 @@ describe('Sidebar', () => {
     });
   });
 
-  describe('#show', () => {
+  describe('#open', () => {
     it('shows highlights if "showHighlights" is set to "whenSidebarOpen"', () => {
       const sidebar = createSidebar({ showHighlights: 'whenSidebarOpen' });
-      sidebar.show();
+      sidebar.open();
       assert.calledWith(sidebar.guest.setVisibleHighlights, true);
     });
 
     it('does not show highlights otherwise', () => {
       const sidebar = createSidebar({ showHighlights: 'never' });
-      sidebar.show();
+      sidebar.open();
       assert.notCalled(sidebar.guest.setVisibleHighlights);
     });
 
     it('updates the `sidebarOpen` property of the toolbar', () => {
       const sidebar = createSidebar();
-      sidebar.show();
+      sidebar.open();
       assert.equal(fakeToolbar.sidebarOpen, true);
     });
   });
@@ -562,8 +562,8 @@ describe('Sidebar', () => {
     it('hides highlights if "showHighlights" is set to "whenSidebarOpen"', () => {
       const sidebar = createSidebar({ showHighlights: 'whenSidebarOpen' });
 
-      sidebar.show();
-      sidebar.hide();
+      sidebar.open();
+      sidebar.close();
 
       assert.calledWith(sidebar.guest.setVisibleHighlights, false);
     });
@@ -571,8 +571,8 @@ describe('Sidebar', () => {
     it('updates the `sidebarOpen` property of the toolbar', () => {
       const sidebar = createSidebar();
 
-      sidebar.show();
-      sidebar.hide();
+      sidebar.open();
+      sidebar.close();
 
       assert.equal(fakeToolbar.sidebarOpen, false);
     });
@@ -605,21 +605,21 @@ describe('Sidebar', () => {
       assert.equal(fakeToolbar.sidebarOpen, false);
     });
 
-    it('invokes the "show" method when window is resized', () => {
-      // Calling the 'show' methods adjust the marginLeft at different screen sizes
+    it('invokes the "open" method when window is resized', () => {
+      // Calling the 'open' methods adjust the marginLeft at different screen sizes
       const sidebar = createSidebar({ openSidebar: true });
       sidebar.publish('panelReady');
-      sinon.stub(sidebar, 'show');
+      sinon.stub(sidebar, 'open');
 
       // Make the window very small
       window.innerWidth = MIN_RESIZE;
       window.dispatchEvent(new Event('resize'));
-      assert.calledOnce(sidebar.show);
+      assert.calledOnce(sidebar.open);
 
       // Make the window very large
       window.innerWidth = MIN_RESIZE * 10;
       window.dispatchEvent(new Event('resize'));
-      assert.calledTwice(sidebar.show);
+      assert.calledTwice(sidebar.open);
     });
   });
 
@@ -697,7 +697,7 @@ describe('Sidebar', () => {
 
       it('notifies when sidebar changes expanded state', () => {
         sinon.stub(sidebar, 'publish');
-        sidebar.show();
+        sidebar.open();
         assert.calledOnce(layoutChangeHandlerSpy);
         assert.calledWith(
           sidebar.publish,
@@ -710,7 +710,7 @@ describe('Sidebar', () => {
           expanded: true,
         });
 
-        sidebar.hide();
+        sidebar.close();
         assert.calledTwice(layoutChangeHandlerSpy);
         assert.calledThrice(sidebar.publish);
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
@@ -768,14 +768,14 @@ describe('Sidebar', () => {
       });
 
       it('notifies when sidebar changes expanded state', () => {
-        sidebar.show();
+        sidebar.open();
         assert.calledOnce(layoutChangeHandlerSpy);
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
           expanded: true,
           width: DEFAULT_WIDTH,
         });
 
-        sidebar.hide();
+        sidebar.close();
         assert.calledTwice(layoutChangeHandlerSpy);
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
           expanded: false,

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -54,7 +54,7 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
     !isThirdParty || serviceSupports('onLogoutRequestProvided');
 
   const onSelectNotebook = () => {
-    bridge.call('showNotebook', store.focusedGroupId());
+    bridge.call('openNotebook', store.focusedGroupId());
   };
 
   const onProfileSelected = () =>

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -204,7 +204,7 @@ describe('UserMenu', () => {
         const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
         openNotebookItem.props().onClick();
         assert.calledOnce(fakeBridge.call);
-        assert.calledWith(fakeBridge.call, 'showNotebook', 'mygroup');
+        assert.calledWith(fakeBridge.call, 'openNotebook', 'mygroup');
       });
     });
 

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -114,7 +114,7 @@ export default function FrameSync(annotationsService, bridge, store) {
       // and delete the (unsaved) annotation so it gets un-selected in the
       // target document
       if (!store.isLoggedIn()) {
-        bridge.call('showSidebar');
+        bridge.call('openSidebar');
         store.openSidebarPanel('loginPrompt');
         bridge.call('deleteAnnotation', formatAnnot(annot));
         return;
@@ -167,11 +167,11 @@ export default function FrameSync(annotationsService, bridge, store) {
     });
 
     // These invoke the matching methods by name on the Guests
-    bridge.on('showSidebar', function () {
-      bridge.call('showSidebar');
+    bridge.on('openSidebar', function () {
+      bridge.call('openSidebar');
     });
-    bridge.on('hideSidebar', function () {
-      bridge.call('hideSidebar');
+    bridge.on('closeSidebar', function () {
+      bridge.call('closeSidebar');
     });
     bridge.on('setVisibleHighlights', function (state) {
       bridge.call('setVisibleHighlights', state);

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -243,7 +243,7 @@ describe('sidebar/services/frame-sync', function () {
         const ann = { target: [] };
         fakeBridge.emit('beforeCreateAnnotation', { tag: 't1', msg: ann });
 
-        assert.calledWith(fakeBridge.call, 'showSidebar');
+        assert.calledWith(fakeBridge.call, 'openSidebar');
       });
 
       it('should open the login prompt panel', () => {
@@ -369,16 +369,16 @@ describe('sidebar/services/frame-sync', function () {
   });
 
   describe('on a relayed bridge call', function () {
-    it('calls "showSidebar"', function () {
-      fakeBridge.emit('showSidebar');
+    it('calls "openSidebar"', function () {
+      fakeBridge.emit('openSidebar');
 
-      assert.calledWith(fakeBridge.call, 'showSidebar');
+      assert.calledWith(fakeBridge.call, 'openSidebar');
     });
 
-    it('calls "hideSidebar"', function () {
-      fakeBridge.emit('hideSidebar');
+    it('calls "closeSidebar"', function () {
+      fakeBridge.emit('closeSidebar');
 
-      assert.calledWith(fakeBridge.call, 'hideSidebar');
+      assert.calledWith(fakeBridge.call, 'closeSidebar');
     });
 
     it('calls "setVisibleHighlights"', function () {

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -47,6 +47,11 @@
   user-select: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
 
+  &.is-hidden {
+    visibility: hidden;
+    transition: visibility var.$annotator-timing--sidebar-collapse-transition;
+  }
+
   &.annotator-collapsed {
     margin-left: 0;
 

--- a/src/styles/annotator/notebook.scss
+++ b/src/styles/annotator/notebook.scss
@@ -1,16 +1,19 @@
 @use '../variables' as var;
 @use '../mixins/molecules';
+@use "../mixins/buttons";
 
 .notebook-outer {
   box-sizing: border-box;
   position: fixed;
+  // This large zIndex is used to bring the notebook to the front, so it is not
+  // hidden by other elements from the host page. It is the same value used by
+  // the sidebar
+  z-index: 2147483647;
   top: 0;
   left: 0;
   width: 100vw;
   height: 100vh;
   padding: var.$layout-space;
-  // Leave explicitly the right amount of room for closed-sidebar affordances
-  padding-right: var.$annotator-toolbar-width + 5px;
 
   &.is-open {
     // TBD: Actual opacity/overlay we'd like to use
@@ -24,4 +27,30 @@
   padding: 0;
   width: 100%;
   height: 100%;
+
+  // FIXME: these properties produce a visual break between the Notebook__controller-bar and the iframe.
+  // A better approach would be if the Notebook__controller-bar and iframe could be children of notebook-inner.
+  border: none;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+// This container element has the purpose of pushing children to the right side.
+.Notebook__controller-bar {
+  font-size: var.$font-size--large;
+  display: flex;
+  justify-content: flex-end;
+  background-color: var.$grey-2;
+  padding: var.$layout-space--xsmall;
+
+  // FIXME: these properties emulates as if the Notebook__controller-bar would be part of the iframe.
+  border-top-left-radius: var.$border-radius;
+  border-top-right-radius: var.$border-radius;
+}
+
+.Notebook__close-button {
+  @include buttons.button--labeled(
+    $background-color: var.$grey-2,
+    $active-background-color: var.$grey-3
+  );
 }

--- a/src/styles/annotator/notebook.scss
+++ b/src/styles/annotator/notebook.scss
@@ -40,8 +40,6 @@
   font-size: var.$font-size--large;
   display: flex;
   justify-content: flex-end;
-  background-color: var.$grey-2;
-  padding: var.$layout-space--xsmall;
 
   // FIXME: these properties emulates as if the Notebook__controller-bar would be part of the iframe.
   border-top-left-radius: var.$border-radius;
@@ -49,8 +47,10 @@
 }
 
 .Notebook__close-button {
+  position: absolute;
   @include buttons.button--labeled(
     $background-color: var.$grey-2,
     $active-background-color: var.$grey-3
   );
+  margin: var.$layout-space--xsmall;
 }

--- a/src/styles/sidebar/components/HypothesisApp.scss
+++ b/src/styles/sidebar/components/HypothesisApp.scss
@@ -24,9 +24,9 @@
   // FIXME: Temporary affordance for the Notebook view to override some
   // layout spacing that assumes the presence of the top bar
   &--notebook {
-    padding: var.$layout-space;
+    padding: 0 var.$layout-space;
     @include responsive.respond-to(tablets desktops) {
-      padding: var.$layout-space--xlarge;
+      padding: 0 var.$layout-space--xlarge;
     }
   }
 }

--- a/src/styles/sidebar/components/HypothesisApp.scss
+++ b/src/styles/sidebar/components/HypothesisApp.scss
@@ -24,9 +24,9 @@
   // FIXME: Temporary affordance for the Notebook view to override some
   // layout spacing that assumes the presence of the top bar
   &--notebook {
-    padding: 0 var.$layout-space;
+    padding: var.$layout-space;
     @include responsive.respond-to(tablets desktops) {
-      padding: 0 var.$layout-space--xlarge;
+      padding: var.$layout-space--xlarge;
     }
   }
 }


### PR DESCRIPTION
 This PR introduces a button to close the notebook app.

* the buttons is outside the notebook application. That way it doesn't interfere in case we ever want to render the notebook in a different context or standalone.
 
* the button sticks to the top-right position without taking space from the notebook. However this creates a funny behaviour when the viewport is very narrow.

![image](https://user-images.githubusercontent.com/8555781/109184236-13bb4200-778f-11eb-99e2-b4ae23a95c94.png)

* opening the notebook hides the _whole_ sidebar, leaving their current UI state of the sidebar (open or close) untouched. Thus, when the the notebook is closed the previous UI state of the sidebar is preserved.

* sets the zIndex of the container element `<hypothesis-notebook>` to a very high number so it is not hidden by any element in the host page.

* opening of the notebook happens through the sidebar who listens to the `openNotebook` event. After the notebook closes, the sidebar 'regains' control.