### PR TITLE
Fix naming issue with the BucketBar

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -78,7 +78,7 @@ export default class Sidebar extends Guest {
       if (config.theme === 'clean') {
         frame.classList.add('annotator-frame--theme-clean');
       } else {
-        this.bucketbar = new BucketBar(frame, this, config.BucketBar);
+        this.bucketBar = new BucketBar(frame, this, config.BucketBar);
       }
 
       // Undocumented switch to enable/disable the wrapping of the sidebar inside a shadow DOM

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -787,6 +787,11 @@ describe('Sidebar', () => {
   });
 
   describe('config', () => {
+    it('does have the BucketBar', () => {
+      const sidebar = createSidebar();
+      assert.isNotNull(sidebar.bucketBar);
+    });
+
     it('does not have the BucketBar if the clean theme is enabled', () => {
       const sidebar = createSidebar({ theme: 'clean' });
       assert.isNull(sidebar.bucketBar);


### PR DESCRIPTION
In PR #3055, we removed reference to the plugin system for the
BucketBar and we create a property `bucketBar` in `Guest` class. I
overlook one of this reference in the `sidebar`.