### PR TITLE
Keep the content within the grid boundaries

### DIFF
--- a/src/styles/sidebar/components/NotebookView.scss
+++ b/src/styles/sidebar/components/NotebookView.scss
@@ -5,6 +5,8 @@
 .NotebookView {
   display: grid;
   row-gap: var.$layout-space--small;
+  // See https://css-tricks.com/preventing-a-grid-blowout/
+  grid-template-columns: minmax(0, auto);
   grid-template-areas:
     'heading'
     'filters'


### PR DESCRIPTION
This small trick borrowed from
https://css-tricks.com/preventing-a-grid-blowout/ keeps the grid content
within the grid boundaries, thus improving the responsive design.

## Before

https://user-images.githubusercontent.com/8555781/109205164-8257ca00-77a6-11eb-9bd2-4ec5ab031740.mov

## After

https://user-images.githubusercontent.com/8555781/109205169-85eb5100-77a6-11eb-82d6-b953986cf974.mov
