### PR TITLE
Add responsive layout for pagination controls

### DIFF
--- a/src/styles/sidebar/components/PaginationNavigation.scss
+++ b/src/styles/sidebar/components/PaginationNavigation.scss
@@ -1,20 +1,15 @@
 @use '../../mixins/buttons';
 @use "../../mixins/layout";
+@use "../../mixins/responsive";
 @use "../../mixins/utils";
 @use "../../variables" as var;
 
 .PaginationNavigation {
   @include utils.font--large;
 
-  // Lay out page navigation buttons horizontally as:
-  // | prevPage  |       numberedPages          | nextPage
-  //
-  // e.g.
-  // | [<- prev] | [2] ... [5] [6] [7] ... [10] | [next ->] |
   display: grid;
-  grid-template-columns: 8em auto 8em;
   align-items: center;
-  grid-template-areas: 'prevPage numberedPages nextPage';
+  grid-template-areas: 'prevPage nextPage';
 
   &__prev {
     grid-area: prevPage;
@@ -26,8 +21,9 @@
   }
 
   &__pages {
-    grid-area: numberedPages;
-    @include layout.row($justify: center, $align: center);
+    // On narrower viewports, there isn't enough room to display all of
+    // the numbered page buttons; fall back to just prev and next options
+    display: none;
   }
 
   &__button,
@@ -53,5 +49,22 @@
       margin-left: var.$layout-space--xxsmall;
     }
     padding-right: var.$layout-space--xxsmall;
+  }
+
+  @include responsive.wide-handheld-and-up {
+    // Where there's enough horizontal space,
+    // lay out page navigation buttons horizontally as:
+    // | prevPage  |       numberedPages          | nextPage
+    //
+    // e.g.
+    // | [<- prev] | [2] ... [5] [6] [7] ... [10] | [next ->] |
+    grid-template-columns: 8em auto 8em;
+    grid-template-areas: 'prevPage numberedPages nextPage';
+
+    &__pages {
+      display: block;
+      grid-area: numberedPages;
+      @include layout.row($justify: center, $align: center);
+    }
   }
 }


### PR DESCRIPTION
This PR contains ongoing work towards better responsive design in the Notebook. The widescreen layout for the pagination controls was not workable on particularly narrow viewports—the resulting set of controls was too wide and broke out of the layout grid.

These changes update the navigation-control styling to use a mobile-first approach.

On narrow screens, before ("Next" button is offscreen to the right):

![image](https://user-images.githubusercontent.com/439947/109211113-c5507800-777b-11eb-8987-c7739229bf6d.png)

And after:

![image](https://user-images.githubusercontent.com/439947/109211052-b073e480-777b-11eb-8c9f-04f17ef804a4.png)


Wider-screen layouts are unchanged.

We may iterate on this later and decide to show a subset of the numbered buttons for narrower screens, but this makes things at least functional and not broken.

Part of https://github.com/hypothesis/client/issues/3021