### PR TITLE
Move "no selectable text" PDF warning banner into shadow DOM

### DIFF
--- a/src/annotator/components/WarningBanner.js
+++ b/src/annotator/components/WarningBanner.js
@@ -1,0 +1,26 @@
+import { SvgIcon } from '@hypothesis/frontend-shared';
+
+/**
+ * A banner shown at the top of the PDF viewer if the PDF cannot be annotated
+ * by Hypothesis.
+ */
+export default function WarningBanner() {
+  return (
+    <div className="WarningBanner WarningBanner--notice">
+      <div className="WarningBanner__type">
+        <SvgIcon name="caution" className="WarningBanner__icon" />
+      </div>
+      <div className="WarningBanner__message">
+        <strong>This PDF does not contain selectable text:</strong>{' '}
+        <a
+          target="_blank"
+          rel="noreferrer"
+          href="https://web.hypothes.is/help/how-to-ocr-optimize-pdfs/"
+        >
+          Learn how to fix this
+        </a>{' '}
+        in order to annotate with Hypothesis.
+      </div>
+    </div>
+  );
+}

--- a/src/annotator/plugin/test/pdf-test.js
+++ b/src/annotator/plugin/test/pdf-test.js
@@ -126,7 +126,7 @@ describe('annotator/plugin/pdf', () => {
   });
 
   function getWarningBanner() {
-    return document.querySelector('.annotator-pdf-warning-banner');
+    return document.querySelector('hypothesis-banner');
   }
 
   it('does not show a warning when PDF has selectable text', async () => {
@@ -163,7 +163,7 @@ describe('annotator/plugin/pdf', () => {
     assert.isNotNull(banner);
     assert.isTrue(mainContainer.contains(banner));
     assert.include(
-      banner.textContent,
+      banner.shadowRoot.textContent,
       'This PDF does not contain selectable text'
     );
 

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -4,7 +4,6 @@
 @use "sass:color" as color;
 
 @use '../variables' as var;
-@use '../mixins/molecules';
 @use '../mixins/reset';
 
 // Shared styles
@@ -15,6 +14,7 @@
 @use './components/AdderToolbar';
 @use './components/Buckets';
 @use './components/Toolbar';
+@use './components/WarningBanner';
 @use './highlights';
 @use './notebook';
 
@@ -84,20 +84,6 @@
 // it is manually resized by dragging
 .annotator-no-transition {
   transition: none !important;
-}
-
-.annotator-pdf-warning-banner {
-  @include molecules.banner;
-  position: absolute;
-  left: 0;
-  top: 0;
-  right: 0;
-
-  font-size: var.$annotator-adder-font-size;
-
-  // The Z-index is necessary to raise the banner above the toolbar at the
-  // top of the PDF.js viewer.
-  z-index: 10000;
 }
 
 /** Affordances for clean theme */

--- a/src/styles/annotator/components/WarningBanner.scss
+++ b/src/styles/annotator/components/WarningBanner.scss
@@ -1,0 +1,7 @@
+@use '../mixins/molecules';
+@use '../variables' as var;
+
+.WarningBanner {
+  @include molecules.banner;
+  font-size: var.$annotator-adder-font-size;
+}


### PR DESCRIPTION
For consistency with the rest of the UI elements rendered by the annotator code, move the warning banner at the top of the PDF viewer into shadow DOM. This is also another step towards not needing to load any global CSS (eg. our CSS reset) into the host page.

 - Change the container element for the banner from `<div>` to
   `<hypothesis-banner>` to match other `<hypothesis-*>` UI container
   elements
 - Move the `WarningBanner` component into `components/WarningBanner.js`
   and rename the CSS classes to match
   
The new DOM structure for the banner looks as follows:

<img width="586" alt="pdf-warning-banner-dom" src="https://user-images.githubusercontent.com/2458/109276996-9fc07e80-780e-11eb-9661-97e220996933.png">

**Testing:**

With the client's dev server running, go to http://localhost:3000/pdf/painting and verify that the banner shows up correctly at the top of the viewer.