### PR TITLE
Fix PDF side-by-side mode not activating

### DIFF
--- a/src/annotator/test/toolbar-test.js
+++ b/src/annotator/test/toolbar-test.js
@@ -16,7 +16,7 @@ describe('ToolbarController', () => {
 
     const FakeToolbar = props => {
       toolbarProps = props;
-      return null;
+      return <div style={{ width: '150px' }} />;
     };
 
     $imports.$mock({
@@ -26,6 +26,7 @@ describe('ToolbarController', () => {
 
   afterEach(() => {
     $imports.$restore();
+    container.remove();
   });
 
   it('has expected default state', () => {
@@ -135,7 +136,11 @@ describe('ToolbarController', () => {
 
   describe('#getWidth', () => {
     it(`returns the toolbar's width`, () => {
-      assert.isNumber(createToolbar().getWidth());
+      // For the measured width to return the correct value, the toolbar must be rendered
+      // into a document.
+      document.body.appendChild(container);
+      const toolbar = createToolbar();
+      assert.equal(toolbar.getWidth(), 150);
     });
   });
 

--- a/src/annotator/toolbar.js
+++ b/src/annotator/toolbar.js
@@ -49,7 +49,8 @@ export class ToolbarController {
   }
 
   getWidth() {
-    return this._container.getBoundingClientRect().width;
+    const content = /** @type {HTMLElement} */ (this._container.firstChild);
+    return content.getBoundingClientRect().width;
   }
 
   /**


### PR DESCRIPTION
The `ToolbarController#getWidth` method started incorrectly returning 0
after 243c06d3d01172e25dfc86c823d0c5b3dda04e53. This commit moved the
content of the toolbar to a child of `ToolbarController._container` and
the `getWidth` method was not updated accordingly.

The incorrect result of `this.toolbar.getWidth()` in `Sidebar` later
resulted in an incorrect calculation of the sidebar's width and caused
`PdfSidebar` to think that the window was too narrow to support
side-by-side mode.

Fix the problem by updating `ToolbarController#getWidth` so that it
returns the correct value again.