### PR TITLE
Make Sidebar collaborate with rather than inherit from Guest

### DIFF
--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -48,15 +48,15 @@ const config = configFrom(window);
 function init() {
   const isPDF = typeof window_.PDFViewerApplication !== 'undefined';
 
-  /** @type {new (e: HTMLElement, config: any) => Guest} */
-  let Klass = isPDF ? PdfSidebar : Sidebar;
+  /** @type {(new (e: HTMLElement, config: any, guest: Guest) => Sidebar)|null} */
+  let SidebarClass = isPDF ? PdfSidebar : Sidebar;
 
   if (config.subFrameIdentifier) {
     // Make sure the PDF plugin is loaded if the subframe contains the PDF.js viewer.
     if (isPDF) {
       config.PDF = {};
     }
-    Klass = Guest;
+    SidebarClass = null;
 
     // Other modules use this to detect if this
     // frame context belongs to hypothesis.
@@ -66,11 +66,16 @@ function init() {
 
   config.pluginClasses = pluginClasses;
 
-  const annotator = new Klass(document.body, config);
+  const guest = new Guest(document.body, config);
+  const sidebar = SidebarClass
+    ? new SidebarClass(document.body, config, guest)
+    : null;
   const notebook = new Notebook(document.body, config);
-  appLinkEl.addEventListener('destroy', function () {
-    annotator.destroy();
+
+  appLinkEl.addEventListener('destroy', () => {
+    sidebar?.destroy();
     notebook.destroy();
+    guest.destroy();
 
     // Remove all the `<link>`, `<script>` and `<style>` elements added to the
     // page by the boot script.

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -48,7 +48,7 @@ const config = configFrom(window);
 function init() {
   const isPDF = typeof window_.PDFViewerApplication !== 'undefined';
 
-  /** @type {(new (e: HTMLElement, config: any, guest: Guest) => Sidebar)|null} */
+  /** @type {(new (e: HTMLElement, guest: Guest, config: Record<string,any>) => Sidebar)|null} */
   let SidebarClass = isPDF ? PdfSidebar : Sidebar;
 
   if (config.subFrameIdentifier) {
@@ -68,7 +68,7 @@ function init() {
 
   const guest = new Guest(document.body, config);
   const sidebar = SidebarClass
-    ? new SidebarClass(document.body, config, guest)
+    ? new SidebarClass(document.body, guest, config)
     : null;
   const notebook = new Notebook(document.body, config);
 

--- a/src/annotator/pdf-sidebar.js
+++ b/src/annotator/pdf-sidebar.js
@@ -21,11 +21,11 @@ const MIN_PDF_WIDTH = 680;
 export default class PdfSidebar extends Sidebar {
   /**
    * @param {HTMLElement} element
-   * @param {Record<string, any>} config
    * @param {Guest} guest
+   * @param {Record<string, any>} [config]
    */
-  constructor(element, config, guest) {
-    super(element, { ...defaultConfig, ...config }, guest);
+  constructor(element, guest, config = {}) {
+    super(element, guest, { ...defaultConfig, ...config });
 
     this._lastSidebarLayoutState = {
       expanded: false,

--- a/src/annotator/pdf-sidebar.js
+++ b/src/annotator/pdf-sidebar.js
@@ -1,6 +1,7 @@
 import Sidebar from './sidebar';
 
 /**
+ * @typedef {import('./guest').default} Guest
  * @typedef {import('../types/annotator').HypothesisWindow} HypothesisWindow
  * @typedef {import('./sidebar').LayoutState} LayoutState
  */
@@ -21,9 +22,10 @@ export default class PdfSidebar extends Sidebar {
   /**
    * @param {HTMLElement} element
    * @param {Record<string, any>} config
+   * @param {Guest} guest
    */
-  constructor(element, config) {
-    super(element, { ...defaultConfig, ...config });
+  constructor(element, config, guest) {
+    super(element, { ...defaultConfig, ...config }, guest);
 
     this._lastSidebarLayoutState = {
       expanded: false,

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -62,13 +62,13 @@ export default class Sidebar extends Delegator {
    * Create the sidebar iframe, its container and adjacent controls.
    *
    * @param {HTMLElement} element
-   * @param {Record<string, any>} config
    * @param {Guest} guest -
    *   The `Guest` instance for the current frame. It is currently assumed that
    *   it is always possible to annotate in the frame where the sidebar is
    *   displayed.
+   * @param {Record<string, any>} [config]
    */
-  constructor(element, config, guest) {
+  constructor(element, guest, config = {}) {
     super(element, config);
 
     this.iframe = createSidebarIframe(config);

--- a/src/annotator/test/pdf-sidebar-test.js
+++ b/src/annotator/test/pdf-sidebar-test.js
@@ -24,7 +24,7 @@ describe('PdfSidebar', () => {
   const createPdfSidebar = config => {
     const fakeGuest = {};
     const element = document.createElement('div');
-    return new PdfSidebar(element, config, fakeGuest);
+    return new PdfSidebar(element, fakeGuest, config);
   };
 
   let unmockSidebar;

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -41,7 +41,7 @@ describe('Sidebar', () => {
     document.body.appendChild(container);
     containers.push(container);
 
-    const sidebar = new Sidebar(container, config, fakeGuest);
+    const sidebar = new Sidebar(container, fakeGuest, config);
     sidebars.push(sidebar);
 
     return sidebar;

--- a/src/test-util/mock-base.js
+++ b/src/test-util/mock-base.js
@@ -1,0 +1,33 @@
+/**
+ * Mock the base class of a derived class.
+ *
+ * In unit tests for a derived class it may be useful to mock the base class
+ * so that the tests only depend on the interface of the base class and not
+ * its implementation.
+ *
+ * This cannot be done using `$imports.$mock` because the links between the
+ * derived and base class are set once when the derived class is initially
+ * evaluated.
+ *
+ * Although it is possible to mock a base class using this function, using
+ * composition over inheritance generally makes mocking easier.
+ *
+ * @param {object} derivedClass - The derived class constructor to mock
+ * @param {object} mockBase - The new mock class
+ * @return {() => void} A function that un-mocks the base class
+ */
+export function mockBaseClass(derivedClass, mockBase) {
+  const originalBase = derivedClass.__proto__;
+
+  // Modify the base class reference used by `super` expressions.
+  derivedClass.__proto__ = mockBase;
+
+  // Modify the prototype chain used by instances of the derived class to find
+  // methods or properties defined on the base class.
+  derivedClass.prototype.__proto__ = mockBase.prototype;
+
+  return () => {
+    derivedClass.__proto__ = originalBase;
+    derivedClass.prototype.__proto__ = originalBase.prototype;
+  };
+}


### PR DESCRIPTION
Change the relationship between the `Guest` and `Sidebar` classes from
one of inheritance to one where `Sidebar` receives a reference to the
`Guest` instance and calls methods on it or subscribes to events from
it. The `Guest` also no longer "owns" references to the bucket bar /
toolbar objects that logically belong to the sidebar. Instead it emits
events which the sidebar responds to.

This change makes the interface of the `Guest` used by the `Sidebar`
more explicit and ensures a better boundary between the two. This also
makes it easier for the `Sidebar` tests to be concerned only with the
interface of the `Guest` and not its implementation details. In future
this change will also make it possible to have a frame which does not
contain a sidebar but is not annotateable. We had a need for this
historically when integrating with epub viewers, although it was never
implemented.

Updating the tests for `PdfSidebar` was complicated by the fact that the
`PdfSidebar` tests are not pure unit tests. They instantiate the
`Sidebar` base class and so depend on many implementation details of it.
To make this change and others easier, the `PdfSidebar` tests have been
changed to mock the `Sidebar` base class. The steps involved in this are
non-obvious so I extracted the logic into a utility function.

Fixes https://github.com/hypothesis/client/issues/2976

 - Change `Sidebar` to no longer inherit `Guest` but accept it as a
   constructor argument
 - Remove direct references to the `BucketBar` and `ToolbarController`
   instances from the `Guest` class and instead emit events from the
   `Guest` which the `Sidebar` responds to.
 - Add a `mockBaseClass` testing helper in `src/test-util/mock-base.js`
   and change the `PdfSidebar` tests to use it, so that they are less
   coupled to `Sidebar` implementation details.
