### PR TITLE
Remove servetests make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ help:
 	@echo "make checkformatting   Check code formatting"
 	@echo "make format            Automatically format code"
 	@echo "make test              Run the unit tests once"
-	@echo "make servetests        Start the unit test server on localhost"
 	@echo "make sure              Make sure that the formatter, linter, tests, etc all pass"
 	@echo "make docs              Build docs website and serve it locally"
 	@echo "make checkdocs         Crash if building the docs website fails"
@@ -27,14 +26,6 @@ ifdef ARGS
 	yarn test $(ARGS)
 else
 	yarn test
-endif
-
-.PHONY: servetests
-servetests: node_modules/.uptodate
-ifdef ARGS
-	node_modules/.bin/gulp --watch $(ARGS)
-else
-	node_modules/.bin/gulp --watch
 endif
 
 .PHONY: lint

--- a/docs/developers/developing.rst
+++ b/docs/developers/developing.rst
@@ -109,14 +109,21 @@ Hypothesis uses Karma and mocha for testing. To run all the tests once, run:
 
    make test
 
-You can filter the tests which are run by running ``make test FILTER=<pattern>``.
-Only test files matching ``<pattern>`` will be executed.
+You can filter the tests which are run by running ``make test ARGS='--grep <pattern>'``,
+or ``yarn test --grep <pattern>``. Only test files matching the regex ``<pattern>`` will
+be executed.
 
 To run tests and automatically re-run them whenever any source files change, run:
 
 .. code-block:: sh
 
-   make servetests
+   make test ARGS='--watch' 
+
+or
+
+.. code-block:: sh
+
+   yarn test --watch
 
 This command will also serve the tests on localhost (typically `http://localhost:9876`)
 so that break points can be set and the browser's console can be used for interactive


### PR DESCRIPTION
With the recent changes in the gulp test command (#2989), everything
that could be achieved by `make servetest` can be done by options to the
`make test` target.