### PR TITLE
Update packages before running prettier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,11 +56,11 @@ clean:
 	rm -rf build
 
 .PHONY: format
-format:
+format: node_modules/.uptodate
 	yarn run format
 
 .PHONY: checkformatting
-checkformatting:
+checkformatting: node_modules/.uptodate
 	yarn run checkformatting
 
 .PHONY: sure


### PR DESCRIPTION
If `make sure` or `make checkformatting` are the first command that are
run after version update that included prettier, the commands will use
the previous version of prettier.