### PR TITLE
Ensure PDF integration is loaded in PDF documents

### DIFF
--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -52,10 +52,6 @@ function init() {
   let SidebarClass = isPDF ? PdfSidebar : Sidebar;
 
   if (config.subFrameIdentifier) {
-    // Make sure the PDF plugin is loaded if the subframe contains the PDF.js viewer.
-    if (isPDF) {
-      config.PDF = {};
-    }
     SidebarClass = null;
 
     // Other modules use this to detect if this
@@ -65,6 +61,11 @@ function init() {
   }
 
   config.pluginClasses = pluginClasses;
+
+  // Load the PDF anchoring/metadata integration.
+  if (isPDF) {
+    config.PDF = {};
+  }
 
   const guest = new Guest(document.body, config);
   const sidebar = SidebarClass

--- a/src/annotator/pdf-sidebar.js
+++ b/src/annotator/pdf-sidebar.js
@@ -7,7 +7,6 @@ import Sidebar from './sidebar';
  */
 
 const defaultConfig = {
-  PDF: {},
   BucketBar: {
     scrollables: ['#viewerContainer'],
   },


### PR DESCRIPTION
The [recent refactor](https://github.com/hypothesis/client/pull/3076) to change the relationship between the `Guest` and `Sidebar`
classes broke PDF.js integration because the `PdfSidebar` class is no
longer able to modify the config that is passed to the `Guest` class.
Previously it would pass `PDF: {}` in the config to the `super()` call
which would then result in the `Guest` class loading the PDF
integration.

This now has to be done in the `index.js` module. We already had to do
this previously for ebooks. Now it has to be done for all scenarios.

**Testing:**

Go to http://localhost:3000/pdf/nils-olav and click Help => About this version in the sidebar. On master there is a line in the panel that reads: "Fingerprint: N/A". With this change it now reads: "Fingerprint: <hex string>" as it should.