### PR TITLE
Fix test warnings from missing prop

### DIFF
--- a/src/sidebar/components/test/AnnotationView-test.js
+++ b/src/sidebar/components/test/AnnotationView-test.js
@@ -27,7 +27,9 @@ describe('AnnotationView', () => {
 
     fakeOnLogin = sinon.stub();
 
-    fakeUseRootThread = sinon.stub().returns({});
+    fakeUseRootThread = sinon.stub().returns({
+      children: [],
+    });
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({

--- a/src/sidebar/components/test/SidebarView-test.js
+++ b/src/sidebar/components/test/SidebarView-test.js
@@ -34,7 +34,9 @@ describe('SidebarView', () => {
     fakeLoadAnnotationsService = {
       load: sinon.stub(),
     };
-    fakeUseRootThread = sinon.stub().returns({});
+    fakeUseRootThread = sinon.stub().returns({
+      children: [],
+    });
     fakeStreamer = {
       connect: sinon.stub(),
     };

--- a/src/sidebar/components/test/StreamView-test.js
+++ b/src/sidebar/components/test/StreamView-test.js
@@ -17,7 +17,9 @@ describe('StreamView', () => {
       search: sinon.stub().resolves({ rows: [], replies: [], total: 0 }),
     };
 
-    fakeUseRootThread = sinon.stub().returns({});
+    fakeUseRootThread = sinon.stub().returns({
+      children: [],
+    });
 
     fakeSearchFilter = {
       toObject: sinon.stub().returns({}),


### PR DESCRIPTION
The ThreadList component has a required felid  `threads` but its value was undefined in tests. The value comes from the mocked version of `useRootThread.children`

--------------

I'm not actually sure when this started but I noticed it for the first time today. 

![Screen Shot 2021-03-01 at 3 54 31 PM](https://user-images.githubusercontent.com/3939074/109576476-a702b900-7aa8-11eb-8f0b-8281ef11bf8d.png)
