### PR TITLE
Remove `beforeAnnotationCreated` event handler in `DocumentMeta`

### DIFF
--- a/src/annotator/plugin/document.js
+++ b/src/annotator/plugin/document.js
@@ -72,19 +72,7 @@ export default class DocumentMeta extends Delegator {
     this.document = options.document || document;
     this.normalizeURI = options.normalizeURI || normalizeURI;
 
-    /**
-     * Event handler that adds document metadata to new annotations.
-     */
-    this.beforeAnnotationCreated = annotation => {
-      annotation.document = this.metadata;
-    };
-    this.subscribe('beforeAnnotationCreated', this.beforeAnnotationCreated);
-
     this.getDocumentMetadata();
-  }
-
-  destroy() {
-    this.unsubscribe('beforeAnnotationCreated', this.beforeAnnotationCreated);
   }
 
   /**

--- a/src/annotator/plugin/test/document-test.js
+++ b/src/annotator/plugin/test/document-test.js
@@ -43,12 +43,6 @@ describe('DocumentMeta', function () {
     testDocument.destroy();
   });
 
-  it('attaches document metadata to new annotations', () => {
-    const annotation = {};
-    testDocument.publish('beforeAnnotationCreated', [annotation]);
-    assert.equal(annotation.document, testDocument.metadata);
-  });
-
   describe('annotation should have some metadata', function () {
     let metadata = null;
 


### PR DESCRIPTION
This handler sets the `document` property of new annotations to metadata
extracted from `<meta>` and `<link>` tags on the page. It is unnecessary
however because the `Guest` class sets this property (see the `createAnnotation` method) using either
`DocumentMeta.metadata` or `PDF.getMetadata`, depending on the document
type, before it emits the `beforeAnnotationCreated` event.

In PDFs this code is a serious hazard because if the
`beforeAnnotationCreated` event subscriber in `DocumentMeta` runs before
`AnnotationSync`'s corresponding event handler then DocumentMeta will
overwrite the PDF document-specific annotation metadata with generic
HTML document metadata - losing the critical `documentFingerprint`
property. Fortunately this problem did not occur because the `Guest`
constructor instantiates the `AnnotationSync` class before the
`DocumentMeta` class. Consequently AnnotationSync's
`beforeAnnotationCreated` event handler runs before DocumentMeta's and
pushes new annotations to the sidebar with the correct document metadata
before `DocumentMeta` overwrites it.

----

**Testing:**

1. Go to http://localhost:3000, open the browser dev tools and switch to the Network tab. Create a new highlight and verify that the JSON payload in the request sent to the server has a `document` property with HTML metadata (this is an object with fields such as `twitter`, `dc` etc. Most of these will be empty.
2. Go to http://localhost:3000/pdf/nils-olav and repeat the process. This time the `document` property of the payload should include a `documentFingerprint` field

Both these behaviors should be the same as on master.