### PR TITLE
Prevent scrolling on the body of the host

### DIFF
--- a/src/annotator/notebook.js
+++ b/src/annotator/notebook.js
@@ -84,6 +84,10 @@ export default class Notebook extends Delegator {
     this._update();
     container.classList.add('is-open');
     container.style.display = '';
+
+    // The overflow CSS property is set to hidden to prevent scrolling of the guest page,
+    // while the notebook is shown as modal. It is restored on the close method.
+    // I believe this hack only works if this.element points to document.body of the guest page.
     this.originalOverflowStyle = this.element.style.overflow;
     this.element.style.overflow = 'hidden';
   }


### PR DESCRIPTION
This PR prevents scrolling of the body of the host when the notebook is
opened.

Reported [here](https://github.com/hypothesis/client/pull/3024#pullrequestreview-592240569).

This solution doesn't work for iOS < 13.

Depends on #3061.