### PR TITLE
Fix clicking on PDF closing sidebar when side-by-side is active

### DIFF
--- a/src/annotator/pdf-sidebar.js
+++ b/src/annotator/pdf-sidebar.js
@@ -51,7 +51,7 @@ export default class PdfSidebar extends Sidebar {
    */
   activateSideBySide(width) {
     this.sideBySideActive = true;
-    this.closeSidebarOnDocumentClick = false;
+    this.guest.closeSidebarOnDocumentClick = false;
     this.pdfContainer.style.width = width + 'px';
     this.pdfContainer.classList.add('hypothesis-side-by-side');
   }
@@ -62,7 +62,7 @@ export default class PdfSidebar extends Sidebar {
    */
   deactivateSideBySide() {
     this.sideBySideActive = false;
-    this.closeSidebarOnDocumentClick = true;
+    this.guest.closeSidebarOnDocumentClick = true;
     this.pdfContainer.style.width = 'auto';
     this.pdfContainer.classList.remove('hypothesis-side-by-side');
   }

--- a/src/annotator/test/pdf-sidebar-test.js
+++ b/src/annotator/test/pdf-sidebar-test.js
@@ -4,7 +4,7 @@ import Delegator from '../delegator';
 import { mockBaseClass } from '../../test-util/mock-base';
 
 class FakeSidebar extends Delegator {
-  constructor(element, config, guest) {
+  constructor(element, guest, config) {
     super(element, config);
     this.guest = guest;
   }
@@ -17,12 +17,12 @@ class FakeSidebar extends Delegator {
 describe('PdfSidebar', () => {
   const sandbox = sinon.createSandbox();
 
+  let fakeGuest;
   let fakePDFViewerApplication;
   let fakePDFContainer;
   let fakePDFViewerUpdate;
 
   const createPdfSidebar = config => {
-    const fakeGuest = {};
     const element = document.createElement('div');
     return new PdfSidebar(element, fakeGuest, config);
   };
@@ -45,6 +45,10 @@ describe('PdfSidebar', () => {
     // See https://github.com/sinonjs/sinon/issues/1537
     // Can't stub an undefined property in a sandbox
     window.PDFViewerApplication = fakePDFViewerApplication;
+
+    fakeGuest = {
+      closeSidebarOnDocumentClick: true,
+    };
 
     unmockSidebar = mockBaseClass(PdfSidebar, FakeSidebar);
   });
@@ -88,6 +92,18 @@ describe('PdfSidebar', () => {
         assert.isTrue(sidebar.sideBySideActive);
         assert.calledOnce(fakePDFViewerUpdate);
         assert.equal(fakePDFContainer.style.width, 1300 - 428 + 'px');
+      });
+
+      it('disables closing sidebar on document click when side-by-side is active', () => {
+        const sidebar = createPdfSidebar();
+        sidebar.activateSideBySide();
+        assert.isFalse(fakeGuest.closeSidebarOnDocumentClick);
+      });
+
+      it('enables closing sidebar on document click when side-by-side is inactive', () => {
+        const sidebar = createPdfSidebar();
+        sidebar.deactivateSideBySide();
+        assert.isTrue(fakeGuest.closeSidebarOnDocumentClick);
       });
 
       it('does not activate side-by-side mode if there is not enough room', () => {


### PR DESCRIPTION
Fix a regression introduced in b52f00e0e1800 where clicking in a PDF
when side-by-side is active would cause the sidebar to close instead of
remaining open. That PR made `PdfSidebar` no longer inherit (indirectly)
from Guest but did not update the references to the `closeSidebarOnDocumentClick`
property of the Guest.