### PR TITLE
Refactor Guest `createAnnotation` method and add missing tests

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -546,15 +546,16 @@ export default class Guest extends Delegator {
     annotation.document = info.metadata;
     annotation.uri = info.uri;
 
-    // `selectors` is an array of arrays: each item is an array of selectors
-    // identifying a distinct target.
     const root = this.element;
-    const selectors = await Promise.all(
+    const rangeSelectors = await Promise.all(
       ranges.map(range => this.anchoring.describe(root, range))
     );
-    annotation.target = selectors.map(selector => ({
+    annotation.target = rangeSelectors.map(selectors => ({
       source: info.uri,
-      selector,
+
+      // In the Hypothesis API the field containing the selectors is called
+      // `selector`, despite being a list.
+      selector: selectors,
     }));
 
     this.publish('beforeAnnotationCreated', [annotation]);

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -122,13 +122,13 @@ export default class Guest extends Delegator {
     this.element.appendChild(this.adderToolbar);
 
     this.adderCtrl = new Adder(this.adderToolbar, {
-      onAnnotate: () => {
-        this.createAnnotation();
+      onAnnotate: async () => {
+        await this.createAnnotation();
         /** @type {Selection} */ (document.getSelection()).removeAllRanges();
       },
-      onHighlight: () => {
+      onHighlight: async () => {
         this.setVisibleHighlights(true);
-        this.createHighlight();
+        await this.createHighlight();
         /** @type {Selection} */ (document.getSelection()).removeAllRanges();
       },
       onShowAnnotations: anns => {
@@ -572,6 +572,8 @@ export default class Guest extends Delegator {
    *
    * This flag indicates that the sidebar should save the new annotation
    * automatically and not show a form for the user to enter a comment about it.
+   *
+   * @return {Promise<AnnotationData>}
    */
   createHighlight() {
     return this.createAnnotation({ $highlight: true });

--- a/src/annotator/test/annotation-sync-test.js
+++ b/src/annotator/test/annotation-sync-test.js
@@ -114,7 +114,9 @@ describe('AnnotationSync', function () {
 
     context('when "beforeAnnotationCreated" is emitted', function () {
       it('calls bridge.call() passing the event', function () {
-        const ann = { id: 1 };
+        // nb. Setting an empty `$tag` here matches what `Guest#createAnnotation`
+        // does.
+        const ann = { id: 1, $tag: '' };
         createAnnotationSync();
 
         options.emit('beforeAnnotationCreated', ann);
@@ -126,7 +128,16 @@ describe('AnnotationSync', function () {
         });
       });
 
-      context('if the annotation has a $tag', function () {
+      it('assigns a non-empty tag to the annotation', () => {
+        const ann = { id: 1, $tag: '' };
+        createAnnotationSync();
+
+        options.emit('beforeAnnotationCreated', ann);
+
+        assert.notEmpty(ann.$tag);
+      });
+
+      context('if the annotation already has a $tag', function () {
         it('does not call bridge.call()', function () {
           const ann = { id: 1, $tag: 'tag1' };
           createAnnotationSync();
@@ -134,6 +145,15 @@ describe('AnnotationSync', function () {
           options.emit('beforeAnnotationCreated', ann);
 
           assert.notCalled(fakeBridge.call);
+        });
+
+        it('does not modify the tag', () => {
+          const ann = { id: 1, $tag: 'sometag' };
+          createAnnotationSync();
+
+          options.emit('beforeAnnotationCreated', ann);
+
+          assert.equal(ann.$tag, 'sometag');
         });
       });
     });

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -29,10 +29,6 @@ class FakeTextRange {
   }
 }
 
-// A little helper which returns a promise that resolves after a timeout
-const timeoutPromise = (millis = 0) =>
-  new Promise(resolve => setTimeout(resolve, millis));
-
 describe('Guest', () => {
   const sandbox = sinon.createSandbox();
   let highlighter;
@@ -609,29 +605,34 @@ describe('Guest', () => {
   });
 
   describe('#createAnnotation', () => {
-    it('adds metadata to the annotation object', () => {
+    it('adds metadata to the annotation object', async () => {
       const guest = createGuest();
       const annotation = {};
 
-      guest.createAnnotation(annotation);
+      await guest.createAnnotation(annotation);
 
-      return timeoutPromise().then(() => {
-        assert.equal(annotation.uri, fakeDocumentMeta.uri());
-        assert.deepEqual(annotation.document, fakeDocumentMeta.metadata);
-      });
+      assert.equal(annotation.uri, fakeDocumentMeta.uri());
+      assert.deepEqual(annotation.document, fakeDocumentMeta.metadata);
     });
 
-    it('merges properties of input object into returned annotation', () => {
+    it('merges properties of input object into returned annotation', async () => {
       const guest = createGuest();
       let annotation = { foo: 'bar' };
-      annotation = guest.createAnnotation(annotation);
+
+      annotation = await guest.createAnnotation(annotation);
+
       assert.equal(annotation.foo, 'bar');
     });
 
-    it('triggers a "beforeAnnotationCreated" event', done => {
+    it('triggers a "beforeAnnotationCreated" event', async () => {
       const guest = createGuest();
-      guest.subscribe('beforeAnnotationCreated', () => done());
-      guest.createAnnotation();
+      const callback = sinon.stub();
+      guest.subscribe('beforeAnnotationCreated', callback);
+      const annotation = {};
+
+      await guest.createAnnotation(annotation);
+
+      assert.calledWith(callback, annotation);
     });
   });
 

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -570,8 +570,28 @@ describe('Guest', () => {
     });
   });
 
-  describe('when adder toolbar buttons are clicked', () =>
-    // TODO - Add tests for "Annotate" and "Highlight" buttons.
+  describe('when adder toolbar buttons are clicked', () => {
+    // nb. Detailed tests for properties of new annotations are in the
+    // `createAnnotation` tests.
+    it('creates a new annotation if "Annotate" is clicked', async () => {
+      const guest = createGuest();
+      const callback = sinon.stub();
+      guest.subscribe('beforeAnnotationCreated', callback);
+
+      await FakeAdder.instance.options.onAnnotate();
+
+      assert.called(callback);
+    });
+
+    it('creates a new highlight if "Highlight" is clicked', async () => {
+      const guest = createGuest();
+      const callback = sinon.stub();
+      guest.subscribe('beforeAnnotationCreated', callback);
+
+      await FakeAdder.instance.options.onHighlight();
+
+      assert.calledWith(callback, sinon.match({ $highlight: true }));
+    });
 
     it('shows annotations if "Show" is clicked', () => {
       createGuest();
@@ -580,7 +600,8 @@ describe('Guest', () => {
 
       assert.calledWith(fakeCrossFrame.call, 'openSidebar');
       assert.calledWith(fakeCrossFrame.call, 'showAnnotations', ['ann1']);
-    }));
+    });
+  });
 
   describe('#getDocumentInfo', () => {
     let guest;

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -629,9 +629,8 @@ describe('Guest', () => {
   describe('#createAnnotation', () => {
     it('adds document metadata to the annotation', async () => {
       const guest = createGuest();
-      const annotation = {};
 
-      await guest.createAnnotation(annotation);
+      const annotation = await guest.createAnnotation();
 
       assert.equal(annotation.uri, fakeDocumentMeta.uri());
       assert.deepEqual(annotation.document, fakeDocumentMeta.metadata);
@@ -658,22 +657,42 @@ describe('Guest', () => {
       ]);
     });
 
-    it('merges properties of input object into returned annotation', async () => {
+    it('sets `$tag` to a falsey value', async () => {
       const guest = createGuest();
-      let annotation = { foo: 'bar' };
+      const annotation = await guest.createAnnotation();
+      assert.notOk(annotation.$tag);
+    });
 
-      annotation = await guest.createAnnotation(annotation);
+    it('sets falsey `$highlight` if `highlight` is false', async () => {
+      const guest = createGuest();
+      const annotation = await guest.createAnnotation();
+      assert.notOk(annotation.$highlight);
+    });
 
-      assert.equal(annotation.foo, 'bar');
+    it('sets `$highlight` to true if `highlight` is true', async () => {
+      const guest = createGuest();
+      const annotation = await guest.createAnnotation({ highlight: true });
+      assert.equal(annotation.$highlight, true);
+    });
+
+    it('opens sidebar if `highlight` is false', async () => {
+      const guest = createGuest();
+      await guest.createAnnotation();
+      assert.calledWith(fakeCrossFrame.call, 'openSidebar');
+    });
+
+    it('does not open sidebar if `highlight` is true', async () => {
+      const guest = createGuest();
+      await guest.createAnnotation({ highlight: true });
+      assert.notCalled(fakeCrossFrame.call);
     });
 
     it('triggers a "beforeAnnotationCreated" event', async () => {
       const guest = createGuest();
       const callback = sinon.stub();
       guest.subscribe('beforeAnnotationCreated', callback);
-      const annotation = {};
 
-      await guest.createAnnotation(annotation);
+      const annotation = await guest.createAnnotation();
 
       assert.calledWith(callback, annotation);
     });


### PR DESCRIPTION
I noticed it was quite hard to follow the async flow of the `Guest#createAnnotation` method and see which properties of the annotation are guaranteed to be populated before it is sent to the sidebar. Also the method is inherently async but returns synchronously, so there is no way to properly wait for it to complete. This PR refactors `createAnnotation` using async/await to fix that. It also adds some missing tests for this important method.

Changes in detail:

- Refactor `createAnnotation` method of `Guest` to use async/await, which simplifies the control flow. I also renamed a misleading `selectors` variable
- Add tests for triggering this method by clicking on the "Annotate" or "Highlight" buttons in the adder toolbar, which is how this method gets called in the actual application
- Add tests for the `target` field of new annotations, which contains the selectors for the annotation
