### PR TITLE
Simplify results count in the Notebook

### DIFF
--- a/src/sidebar/components/NotebookResultCount.js
+++ b/src/sidebar/components/NotebookResultCount.js
@@ -39,30 +39,25 @@ function NotebookResultCount({
   const matchCount = visibleCount - forcedVisibleCount;
   const threadCount = rootThread.children.length;
 
+  // When filters are applied, display a count of matching annotations.
+  // When not filtered, display a count of top-level threads.
+  // This is consistent with the sidebar
+  const displayCount = isFiltered ? matchCount : threadCount;
+
   return (
     <div className="NotebookResultCount u-layout-row">
       {isLoading && <Spinner />}
       {!isLoading && (
         <h2>
           {!hasResults && <strong>No results</strong>}
-          {hasResults && isFiltered && (
+          {hasResults && (
             <strong>
-              {matchCount} {matchCount === 1 ? 'result' : 'results'}
-            </strong>
-          )}
-          {hasResults && !isFiltered && (
-            <strong>
-              {threadCount} {threadCount === 1 ? 'thread' : 'threads'}
+              {displayCount} {displayCount === 1 ? 'result' : 'results'}
             </strong>
           )}
         </h2>
       )}
       {hasForcedVisible && <h3>(and {forcedVisibleCount} more)</h3>}
-      {!isFiltered && hasResults && (
-        <h3>
-          ({visibleCount} {visibleCount === 1 ? 'annotation' : 'annotations'})
-        </h3>
-      )}
     </div>
   );
 }

--- a/src/sidebar/components/test/NotebookResultCount-test.js
+++ b/src/sidebar/components/test/NotebookResultCount-test.js
@@ -56,20 +56,20 @@ describe('NotebookResultCount', () => {
       {
         thread: { children: [1] },
         visibleCount: 1,
-        expected: '1 thread(1 annotation)',
+        expected: '1 result',
       },
       {
         thread: { children: [1] },
         visibleCount: 2,
-        expected: '1 thread(2 annotations)',
+        expected: '1 result',
       },
       {
         thread: { children: [1, 2] },
         visibleCount: 2,
-        expected: '2 threads(2 annotations)',
+        expected: '2 results',
       },
     ].forEach(test => {
-      it('should render a count of threads and annotations', () => {
+      it('should render a count of top-level threads', () => {
         fakeCountVisible.returns(test.visibleCount);
         fakeUseRootThread.returns(test.thread);
 
@@ -119,17 +119,6 @@ describe('NotebookResultCount', () => {
     it('shows a loading spinner', () => {
       const wrapper = createComponent({ isLoading: true });
       assert.isTrue(wrapper.find('Spinner').exists());
-    });
-
-    it('shows annotation count if there are any matching annotations being fetched', () => {
-      fakeUseRootThread.returns({ children: [1, 2] });
-      // Setting countVisible to something different to demonstrate that
-      // resultCount is used while loading
-      fakeCountVisible.returns(5);
-
-      const wrapper = createComponent({ isLoading: true, resultCount: 2 });
-
-      assert.equal(wrapper.text(), '(2 annotations)');
     });
   });
 });


### PR DESCRIPTION
Previously, the Notebook showed different terminology to count matching items depending on whether filters were applied or not. This is because when no filters are being applied, what is being counted is top-level threads, while when filters _are_ applied, the count refers to matching annotations (well, technically threads, but only single-annotation threads). I had hoped to alleviate confusing by using the terminology "X threads (Y annotations)" when no filters were applied and "Z results" when filters are applied.

This starts feeling confusing, however, when pagination is in the mix. We could end up with strings like "Page 1 of X threads (Y annotations)" which doesn't really make sense.

For now, I am proposing a simpler path that also happens to be entirely consistent with the sidebar: pretend there is no difference in what we're counting :). Use the term "results" blanketly. We can keep iterating on this: this change was quick to make.

Before:

![image](https://user-images.githubusercontent.com/439947/109821625-2953c000-7c04-11eb-8b7f-ac4f0b58d3e7.png)

![image](https://user-images.githubusercontent.com/439947/109821649-307ace00-7c04-11eb-8d3c-d275139f349a.png)


After:

![image](https://user-images.githubusercontent.com/439947/109821540-1214d280-7c04-11eb-974a-c5a79743fd51.png)

![image](https://user-images.githubusercontent.com/439947/109821572-1a6d0d80-7c04-11eb-86ef-97ff9853cb38.png)

(No change in the second case).

Fixes https://github.com/hypothesis/client/issues/3019