### PR TITLE
Do not link to third-party annotation documents in annotation cards

### DIFF
--- a/src/sidebar/components/Annotation/Annotation.js
+++ b/src/sidebar/components/Annotation/Annotation.js
@@ -26,7 +26,6 @@ import AnnotationReplyToggle from './AnnotationReplyToggle';
  * @prop {boolean} isReply
  * @prop {VoidFunction} onToggleReplies - Callback to expand/collapse reply threads
  * @prop {number} replyCount - Number of replies to this annotation's thread
- * @prop {boolean} showDocumentInfo - Should extended document info be rendered (e.g. in non-sidebar contexts)?
  * @prop {boolean} threadIsCollapsed - Is the thread to which this annotation belongs currently collapsed?
  * @prop {Object} annotationsService - Injected service
  */
@@ -42,7 +41,6 @@ function Annotation({
   isReply,
   onToggleReplies,
   replyCount,
-  showDocumentInfo,
   threadIsCollapsed,
   annotationsService,
 }) {
@@ -76,7 +74,6 @@ function Annotation({
             annotation={annotation}
             isEditing={isEditing}
             replyCount={replyCount}
-            showDocumentInfo={showDocumentInfo}
             threadIsCollapsed={threadIsCollapsed}
           />
 
@@ -130,7 +127,6 @@ Annotation.propTypes = {
   isReply: propTypes.bool,
   onToggleReplies: propTypes.func,
   replyCount: propTypes.number.isRequired,
-  showDocumentInfo: propTypes.bool.isRequired,
   threadIsCollapsed: propTypes.bool.isRequired,
   annotationsService: propTypes.object.isRequired,
 };

--- a/src/sidebar/components/Annotation/AnnotationDocumentInfo.js
+++ b/src/sidebar/components/Annotation/AnnotationDocumentInfo.js
@@ -1,12 +1,12 @@
 import propTypes from 'prop-types';
 
-import * as annotationMetadata from '../../helpers/annotation-metadata';
-
 /** @typedef {import("../../../types/api").Annotation} Annotation */
 
 /**
  * @typedef AnnotationDocumentInfoProps
- * @prop {Annotation} annotation - Annotation for which the document metadata will be rendered
+ * @prop {string} [domain] - The domain associated with the document
+ * @prop {string} [link] - A link to the document (directly)
+ * @prop {string} title - The document's title
  */
 
 /**
@@ -15,27 +15,17 @@ import * as annotationMetadata from '../../helpers/annotation-metadata';
  *
  * @param {AnnotationDocumentInfoProps} props
  */
-export default function AnnotationDocumentInfo({ annotation }) {
-  const documentInfo = annotationMetadata.domainAndTitle(annotation);
-  // If there's no document title, nothing to do here
-  if (!documentInfo.titleText) {
-    return null;
-  }
-
+export default function AnnotationDocumentInfo({ domain, link, title }) {
   return (
     <div className="AnnotationDocumentInfo u-layout-row u-horizontal-rhythm">
       <div className="AnnotationDocumentInfo__title u-color-text--muted">
         on &quot;
-        {documentInfo.titleLink ? (
-          <a href={documentInfo.titleLink}>{documentInfo.titleText}</a>
-        ) : (
-          <span>{documentInfo.titleText}</span>
-        )}
+        {link ? <a href={link}>{title}</a> : <span>{title}</span>}
         &quot;
       </div>
-      {documentInfo.domain && (
+      {domain && (
         <div className="AnnotationDocumentInfo__domain u-color-text--muted">
-          ({documentInfo.domain})
+          ({domain})
         </div>
       )}
     </div>
@@ -43,5 +33,7 @@ export default function AnnotationDocumentInfo({ annotation }) {
 }
 
 AnnotationDocumentInfo.propTypes = {
-  annotation: propTypes.object.isRequired,
+  domain: propTypes.string,
+  link: propTypes.string,
+  title: propTypes.string.isRequired,
 };

--- a/src/sidebar/components/Annotation/AnnotationDocumentInfo.js
+++ b/src/sidebar/components/Annotation/AnnotationDocumentInfo.js
@@ -17,17 +17,13 @@ import propTypes from 'prop-types';
  */
 export default function AnnotationDocumentInfo({ domain, link, title }) {
   return (
-    <div className="AnnotationDocumentInfo u-layout-row u-horizontal-rhythm">
-      <div className="AnnotationDocumentInfo__title u-color-text--muted">
+    <div className="u-layout-row u-horizontal-rhythm">
+      <div className="u-color-text--muted">
         on &quot;
         {link ? <a href={link}>{title}</a> : <span>{title}</span>}
         &quot;
       </div>
-      {domain && (
-        <div className="AnnotationDocumentInfo__domain u-color-text--muted">
-          ({domain})
-        </div>
-      )}
+      {domain && <span className="u-color-text--muted">({domain})</span>}
     </div>
   );
 }

--- a/src/sidebar/components/Annotation/AnnotationDocumentInfo.js
+++ b/src/sidebar/components/Annotation/AnnotationDocumentInfo.js
@@ -20,7 +20,13 @@ export default function AnnotationDocumentInfo({ domain, link, title }) {
     <div className="u-layout-row u-horizontal-rhythm">
       <div className="u-color-text--muted">
         on &quot;
-        {link ? <a href={link}>{title}</a> : <span>{title}</span>}
+        {link ? (
+          <a href={link} target="_blank" rel="noopener noreferrer">
+            {title}
+          </a>
+        ) : (
+          <span>{title}</span>
+        )}
         &quot;
       </div>
       {domain && <span className="u-color-text--muted">({domain})</span>}

--- a/src/sidebar/components/Annotation/AnnotationHeader.js
+++ b/src/sidebar/components/Annotation/AnnotationHeader.js
@@ -48,6 +48,11 @@ export default function AnnotationHeader({
 
   const annotationIsPrivate = isPrivate(annotation.permissions);
 
+  // Link (URL) to single-annotation view for this annotation, if it has
+  // been provided by the service. Note: this property is not currently
+  // present on third-party annotations.
+  const annotationUrl = annotation.links?.html || '';
+
   const showTimestamps = !isEditing && annotation.created;
   const showEditedTimestamp = useMemo(() => {
     return hasBeenEdited(annotation) && !isCollapsedReply;
@@ -58,10 +63,22 @@ export default function AnnotationHeader({
   const showReplyButton = replyCount > 0 && isCollapsedReply;
   const showExtendedInfo = !isReply(annotation);
 
-  const annotationUrl = annotation.links?.html || '';
+  // Pull together some document metadata related to this annotation
   const documentInfo = domainAndTitle(annotation);
+  // There are some cases at present in which linking directly to an
+  // annotation's document is not immediately feasible—e.g in an LMS context
+  // where the original document might not be available outside of an
+  // assignment (e.g. Canvas files), and/or wouldn't be able to present
+  // any associated annotations.
+  // For the present, disable links to annotation documents for all third-party
+  // annotations until we have a more nuanced way of making linking determinations.
+  // The absence of a link to a single-annotation view is a signal that this
+  // is a third-party annotation.
+  // Also, of course, verify that there is a URL to the document (titleLink)
   const documentLink =
     annotationUrl && documentInfo.titleLink ? documentInfo.titleLink : '';
+  // Show document information on non-sidebar routes, assuming there is a title
+  // to show, at the least
   const showDocumentInfo =
     store.route() !== 'sidebar' && documentInfo.titleText;
 
@@ -93,7 +110,9 @@ export default function AnnotationHeader({
         {showTimestamps && (
           <div className="AnnotationHeader__timestamps">
             <AnnotationTimestamps
-              annotation={annotation}
+              annotationCreated={annotation.created}
+              annotationUpdated={annotation.updated}
+              annotationUrl={annotationUrl}
               withEditedTimestamp={showEditedTimestamp}
             />
           </div>

--- a/src/sidebar/components/Annotation/AnnotationHeader.js
+++ b/src/sidebar/components/Annotation/AnnotationHeader.js
@@ -4,6 +4,7 @@ import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../../store/use-store';
 import {
+  domainAndTitle,
   isHighlight,
   isReply,
   hasBeenEdited,
@@ -26,9 +27,6 @@ import AnnotationUser from './AnnotationUser';
  * @prop {Annotation} annotation
  * @prop {boolean} [isEditing] - Whether the annotation is actively being edited
  * @prop {number} replyCount - How many replies this annotation currently has
- * @prop {boolean} [showDocumentInfo] -
- *   Should document metadata be rendered? Hint: this is enabled for single annotation
- *   and stream views.
  * @prop {boolean} threadIsCollapsed - Is this thread currently collapsed?
  */
 
@@ -43,7 +41,6 @@ export default function AnnotationHeader({
   annotation,
   isEditing,
   replyCount,
-  showDocumentInfo,
   threadIsCollapsed,
 }) {
   const store = useStoreProxy();
@@ -60,6 +57,13 @@ export default function AnnotationHeader({
   const replyButtonText = `${replyCount} ${replyPluralized}`;
   const showReplyButton = replyCount > 0 && isCollapsedReply;
   const showExtendedInfo = !isReply(annotation);
+
+  const annotationUrl = annotation.links?.html || '';
+  const documentInfo = domainAndTitle(annotation);
+  const documentLink =
+    annotationUrl && documentInfo.titleLink ? documentInfo.titleLink : '';
+  const showDocumentInfo =
+    store.route() !== 'sidebar' && documentInfo.titleText;
 
   const onReplyCountClick = () =>
     // If an annotation has replies it must have been saved and therefore have
@@ -110,7 +114,11 @@ export default function AnnotationHeader({
             </div>
           )}
           {showDocumentInfo && (
-            <AnnotationDocumentInfo annotation={annotation} />
+            <AnnotationDocumentInfo
+              domain={documentInfo.domain}
+              link={documentLink}
+              title={documentInfo.titleText}
+            />
           )}
         </div>
       )}
@@ -122,6 +130,5 @@ AnnotationHeader.propTypes = {
   annotation: propTypes.object.isRequired,
   isEditing: propTypes.bool,
   replyCount: propTypes.number,
-  showDocumentInfo: propTypes.bool,
   threadIsCollapsed: propTypes.bool.isRequired,
 };

--- a/src/sidebar/components/Annotation/AnnotationTimestamps.js
+++ b/src/sidebar/components/Annotation/AnnotationTimestamps.js
@@ -80,13 +80,16 @@ export default function AnnotationTimestamps({
   return (
     <div className="AnnotationTimestamps">
       {withEditedTimestamp && (
-        <span className="AnnotationTimestamps__edited" title={updated.absolute}>
+        <span
+          className="AnnotationTimestamps__timestamp AnnotationTimestamps__edited"
+          title={updated.absolute}
+        >
           ({editedString}){' '}
         </span>
       )}
       {annotationUrl ? (
         <a
-          className="AnnotationTimestamps__created"
+          className="AnnotationTimestamps__timestamp AnnotationTimestamps__timestamp--linked"
           target="_blank"
           rel="noopener noreferrer"
           title={created.absolute}
@@ -96,7 +99,7 @@ export default function AnnotationTimestamps({
         </a>
       ) : (
         <span
-          className="AnnotationTimestamps__created"
+          className="AnnotationTimestamps__timestamp AnnotationTimestamps__created"
           title={created.absolute}
         >
           {created.relative}

--- a/src/sidebar/components/Annotation/AnnotationTimestamps.js
+++ b/src/sidebar/components/Annotation/AnnotationTimestamps.js
@@ -10,7 +10,9 @@ import { decayingInterval, toFuzzyString } from '../../util/time';
 
 /**
  * @typedef AnnotationTimestampsProps
- * @prop {Annotation} annotation
+ * @prop {string} annotationCreated
+ * @prop {string} annotationUpdated
+ * @prop {string} [annotationUrl]
  * @prop {boolean} [withEditedTimestamp] - Should a timestamp for when this
  *   annotation was last edited be rendered?
  */
@@ -26,17 +28,19 @@ import { decayingInterval, toFuzzyString } from '../../util/time';
  * @param {AnnotationTimestampsProps} props
  */
 export default function AnnotationTimestamps({
-  annotation,
+  annotationCreated,
+  annotationUpdated,
+  annotationUrl,
   withEditedTimestamp,
 }) {
   // "Current" time, used when calculating the relative age of `timestamp`.
   const [now, setNow] = useState(() => new Date());
-  const createdDate = useMemo(() => new Date(annotation.created), [
-    annotation.created,
+  const createdDate = useMemo(() => new Date(annotationCreated), [
+    annotationCreated,
   ]);
   const updatedDate = useMemo(
-    () => withEditedTimestamp && new Date(annotation.updated),
-    [annotation.updated, withEditedTimestamp]
+    () => withEditedTimestamp && new Date(annotationUpdated),
+    [annotationUpdated, withEditedTimestamp]
   );
 
   const created = useMemo(() => {
@@ -61,10 +65,10 @@ export default function AnnotationTimestamps({
     // Determine which of the two Dates to use for the `decayingInterval`
     // It should be the latest relevant date, as the interval will be
     // shorter the closer the date is to "now"
-    const laterDate = updatedDate ? annotation.updated : annotation.created;
+    const laterDate = updatedDate ? annotationUpdated : annotationCreated;
     const cancelRefresh = decayingInterval(laterDate, () => setNow(new Date()));
     return cancelRefresh;
-  }, [annotation, createdDate, updatedDate, now]);
+  }, [annotationCreated, annotationUpdated, createdDate, updatedDate, now]);
 
   // Do not show the relative timestamp for the edited date if it is the same
   // as the relative timestamp for the created date
@@ -72,8 +76,6 @@ export default function AnnotationTimestamps({
     updated && updated.relative !== created.relative
       ? `edited ${updated.relative}`
       : 'edited';
-
-  const annotationUrl = annotation.links?.html || '';
 
   return (
     <div className="AnnotationTimestamps">
@@ -105,6 +107,8 @@ export default function AnnotationTimestamps({
 }
 
 AnnotationTimestamps.propTypes = {
-  annotation: propTypes.object.isRequired,
+  annotationCreated: propTypes.string,
+  annotationUpdated: propTypes.string,
+  annotationUrl: propTypes.string,
   withEditedTimestamp: propTypes.bool,
 };

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -35,7 +35,6 @@ describe('Annotation', () => {
         isReply={false}
         onToggleReplies={fakeOnToggleReplies}
         replyCount={0}
-        showDocumentInfo={false}
         threadIsCollapsed={true}
         {...props}
       />

--- a/src/sidebar/components/Annotation/test/AnnotationDocumentInfo-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationDocumentInfo-test.js
@@ -22,17 +22,22 @@ describe('AnnotationDocumentInfo', () => {
     assert.include(wrapper.text(), '"Turtles"');
   });
 
-  it('should render a link if available', () => {
+  it('links to document in new tab/window when link available', () => {
     const wrapper = createAnnotationDocumentInfo();
     const link = wrapper.find('a');
 
     assert.equal(link.prop('href'), 'http://www.baz');
+    assert.equal(link.prop('target'), '_blank');
   });
 
-  it('should render domain if available', () => {
-    const wrapper = createAnnotationDocumentInfo();
+  it('does not link to document when no link available', () => {});
 
-    assert.include(wrapper.text(), '(www.foo.bar)');
+  it('should render domain if available', () => {
+    const wrapper = createAnnotationDocumentInfo({ link: '' });
+
+    const link = wrapper.find('a');
+    assert.include(wrapper.text(), '"Turtles"');
+    assert.isFalse(link.exists());
   });
 
   it(

--- a/src/sidebar/components/Annotation/test/AnnotationDocumentInfo-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationDocumentInfo-test.js
@@ -18,23 +18,21 @@ describe('AnnotationDocumentInfo', () => {
 
   it('should render the document title', () => {
     const wrapper = createAnnotationDocumentInfo();
-    const info = wrapper.find('.AnnotationDocumentInfo__title');
 
-    assert.equal(info.text(), 'on "Turtles"');
+    assert.include(wrapper.text(), '"Turtles"');
   });
 
   it('should render a link if available', () => {
     const wrapper = createAnnotationDocumentInfo();
-    const link = wrapper.find('.AnnotationDocumentInfo__title a');
+    const link = wrapper.find('a');
 
     assert.equal(link.prop('href'), 'http://www.baz');
   });
 
   it('should render domain if available', () => {
     const wrapper = createAnnotationDocumentInfo();
-    const domain = wrapper.find('.AnnotationDocumentInfo__domain');
 
-    assert.equal(domain.text(), '(www.foo.bar)');
+    assert.include(wrapper.text(), '(www.foo.bar)');
   });
 
   it(

--- a/src/sidebar/components/Annotation/test/AnnotationDocumentInfo-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationDocumentInfo-test.js
@@ -1,89 +1,46 @@
 import { mount } from 'enzyme';
 
-import * as fixtures from '../../../test/annotation-fixtures';
-
 import { checkAccessibility } from '../../../../test-util/accessibility';
-import mockImportedComponents from '../../../../test-util/mock-imported-components';
 
-import AnnotationDocumentInfo, { $imports } from '../AnnotationDocumentInfo';
+import AnnotationDocumentInfo from '../AnnotationDocumentInfo';
 
 describe('AnnotationDocumentInfo', () => {
-  let fakeDomainAndTitle;
-  let fakeMetadata;
-
   const createAnnotationDocumentInfo = props => {
     return mount(
       <AnnotationDocumentInfo
-        annotation={fixtures.defaultAnnotation()}
+        domain="www.foo.bar"
+        link="http://www.baz"
+        title="Turtles"
         {...props}
       />
     );
   };
 
-  beforeEach(() => {
-    fakeDomainAndTitle = sinon.stub();
-    fakeMetadata = { domainAndTitle: fakeDomainAndTitle };
-
-    $imports.$mock(mockImportedComponents());
-    $imports.$mock({
-      '../../helpers/annotation-metadata': fakeMetadata,
-    });
-  });
-
-  afterEach(() => {
-    $imports.$restore();
-  });
-
-  it('should not render if there is no document title', () => {
-    fakeDomainAndTitle.returns({});
-
-    const wrapper = createAnnotationDocumentInfo();
-    const info = wrapper.find('.AnnotationDocumentInfo');
-
-    assert.notOk(info.exists());
-  });
-
   it('should render the document title', () => {
-    fakeDomainAndTitle.returns({ titleText: 'I have a title' });
-
     const wrapper = createAnnotationDocumentInfo();
-    const info = wrapper.find('.AnnotationDocumentInfo');
+    const info = wrapper.find('.AnnotationDocumentInfo__title');
 
-    assert.isOk(info.exists());
+    assert.equal(info.text(), 'on "Turtles"');
   });
 
   it('should render a link if available', () => {
-    fakeDomainAndTitle.returns({
-      titleText: 'I have a title',
-      titleLink: 'https://www.example.com',
-    });
-
     const wrapper = createAnnotationDocumentInfo();
     const link = wrapper.find('.AnnotationDocumentInfo__title a');
 
-    assert.equal(link.prop('href'), 'https://www.example.com');
+    assert.equal(link.prop('href'), 'http://www.baz');
   });
 
   it('should render domain if available', () => {
-    fakeDomainAndTitle.returns({
-      titleText: 'I have a title',
-      domain: 'www.example.com',
-    });
-
     const wrapper = createAnnotationDocumentInfo();
     const domain = wrapper.find('.AnnotationDocumentInfo__domain');
 
-    assert.equal(domain.text(), '(www.example.com)');
+    assert.equal(domain.text(), '(www.foo.bar)');
   });
 
   it(
     'should pass a11y checks',
     checkAccessibility({
       content: () => {
-        fakeDomainAndTitle.returns({
-          titleText: 'I have a title',
-          domain: 'www.example.com',
-        });
         return createAnnotationDocumentInfo();
       },
     })

--- a/src/sidebar/components/Annotation/test/AnnotationTimestamps-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationTimestamps-test.js
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import * as fixtures from '../../../test/annotation-fixtures';
 import { act } from 'preact/test-utils';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
@@ -15,7 +14,9 @@ describe('AnnotationTimestamps', () => {
   const createComponent = props =>
     mount(
       <AnnotationTimestamps
-        annotation={fixtures.defaultAnnotation()}
+        annotationCreated="2015-05-10T20:18:56.613388+00:00"
+        annotationUpdated="2015-05-10T20:18:56.613388+00:00"
+        annotationUrl="http://www.example.com"
         withEditedTimestamp={false}
         {...props}
       />
@@ -43,10 +44,7 @@ describe('AnnotationTimestamps', () => {
   });
 
   it('renders a linked created timestamp if annotation has a link', () => {
-    const annotation = fixtures.defaultAnnotation();
-    annotation.links = { html: 'http://www.example.com' };
-
-    const wrapper = createComponent({ annotation });
+    const wrapper = createComponent();
 
     const link = wrapper.find('a.AnnotationTimestamps__created');
     assert.equal(link.prop('href'), 'http://www.example.com');
@@ -55,7 +53,7 @@ describe('AnnotationTimestamps', () => {
   });
 
   it('renders an unlinked created timestamp if annotation does not have a link', () => {
-    const wrapper = createComponent();
+    const wrapper = createComponent({ annotationUrl: '' });
 
     const link = wrapper.find('a.AnnotationTimestamps__created');
     const span = wrapper.find('span.AnnotationTimestamps__created');

--- a/src/sidebar/components/Annotation/test/AnnotationTimestamps-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationTimestamps-test.js
@@ -46,7 +46,7 @@ describe('AnnotationTimestamps', () => {
   it('renders a linked created timestamp if annotation has a link', () => {
     const wrapper = createComponent();
 
-    const link = wrapper.find('a.AnnotationTimestamps__created');
+    const link = wrapper.find('a');
     assert.equal(link.prop('href'), 'http://www.example.com');
     assert.equal(link.prop('title'), 'absolute date');
     assert.equal(link.text(), 'fuzzy string');
@@ -55,7 +55,7 @@ describe('AnnotationTimestamps', () => {
   it('renders an unlinked created timestamp if annotation does not have a link', () => {
     const wrapper = createComponent({ annotationUrl: '' });
 
-    const link = wrapper.find('a.AnnotationTimestamps__created');
+    const link = wrapper.find('a');
     const span = wrapper.find('span.AnnotationTimestamps__created');
     assert.isFalse(link.exists());
     assert.isTrue(span.exists());

--- a/src/sidebar/components/Thread.js
+++ b/src/sidebar/components/Thread.js
@@ -14,7 +14,6 @@ import ModerationBanner from './ModerationBanner';
 
 /**
  * @typedef ThreadProps
- * @prop {boolean} [showDocumentInfo]
  * @prop {Thread} thread
  * @prop {Object} threadsService - Injected service
  */
@@ -26,7 +25,7 @@ import ModerationBanner from './ModerationBanner';
  *
  * @param {ThreadProps} props
  */
-function Thread({ showDocumentInfo = false, thread, threadsService }) {
+function Thread({ thread, threadsService }) {
   // Render this thread's replies only if the thread is expanded
   const showChildren = !thread.collapsed;
 
@@ -68,7 +67,6 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
             isReply={!!thread.parent}
             onToggleReplies={onToggleReplies}
             replyCount={thread.replyCount}
-            showDocumentInfo={showDocumentInfo}
             threadIsCollapsed={thread.collapsed}
           />
         </>
@@ -76,7 +74,6 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
     [
       hasAppliedFilter,
       onToggleReplies,
-      showDocumentInfo,
       thread.annotation,
       thread.parent,
       thread.replyCount,
@@ -129,7 +126,6 @@ function Thread({ showDocumentInfo = false, thread, threadsService }) {
 }
 
 Thread.propTypes = {
-  showDocumentInfo: propTypes.bool,
   thread: propTypes.object.isRequired,
 
   // Injected

--- a/src/sidebar/components/ThreadCard.js
+++ b/src/sidebar/components/ThreadCard.js
@@ -28,7 +28,6 @@ function ThreadCard({ frameSync, thread }) {
   const store = useStoreProxy();
   const threadTag = thread.annotation && thread.annotation.$tag;
   const isFocused = store.isAnnotationFocused(threadTag);
-  const showDocumentInfo = store.route() !== 'sidebar';
   const focusThreadAnnotation = useMemo(
     () =>
       debounce(tag => {
@@ -57,10 +56,7 @@ function ThreadCard({ frameSync, thread }) {
 
   // Memoize threads to reduce avoid re-rendering when something changes in a
   // parent component but the `Thread` itself has not changed.
-  const threadContent = useMemo(
-    () => <Thread thread={thread} showDocumentInfo={showDocumentInfo} />,
-    [thread, showDocumentInfo]
-  );
+  const threadContent = useMemo(() => <Thread thread={thread} />, [thread]);
 
   return (
     /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */

--- a/src/sidebar/components/test/Thread-test.js
+++ b/src/sidebar/components/test/Thread-test.js
@@ -70,7 +70,6 @@ describe('Thread', () => {
   const createComponent = props => {
     return mount(
       <Thread
-        showDocumentInfo={false}
         thread={createThread()}
         threadsService={fakeThreadsService}
         {...props}

--- a/src/sidebar/components/test/ThreadCard-test.js
+++ b/src/sidebar/components/test/ThreadCard-test.js
@@ -58,22 +58,6 @@ describe('ThreadCard', () => {
     assert(wrapper.find('.ThreadCard').hasClass('is-focused'));
   });
 
-  it('shows document info if current route is not sidebar', () => {
-    fakeStore.route.returns('whatever');
-
-    const wrapper = createComponent();
-
-    assert.isTrue(wrapper.find('Thread').props().showDocumentInfo);
-  });
-
-  it('does not show document info if current route is sidebar', () => {
-    fakeStore.route.returns('sidebar');
-
-    const wrapper = createComponent();
-
-    assert.isFalse(wrapper.find('Thread').props().showDocumentInfo);
-  });
-
   describe('mouse and click events', () => {
     it('scrolls to the annotation when the `ThreadCard` is clicked', () => {
       const wrapper = createComponent();

--- a/src/styles/sidebar/components/AnnotationTimestamps.scss
+++ b/src/styles/sidebar/components/AnnotationTimestamps.scss
@@ -2,16 +2,19 @@
 @use "../../mixins/utils";
 
 .AnnotationTimestamps {
+  &__timestamp {
+    color: var.$color-text--light;
+
+    &--linked {
+      &:hover {
+        color: var.$color-text--light;
+        text-decoration: underline;
+      }
+    }
+  }
+
   &__edited {
     @include utils.font--small;
     font-style: italic;
-    color: var.$color-text--light;
-  }
-
-  &__created {
-    color: var.$color-text--light;
-    &:hover {
-      text-decoration: underline;
-    }
   }
 }


### PR DESCRIPTION
The main goal of this PR is to avoid confusion for users of the Notebook *in LMS contexts* by removing (mostly broken) links to annotation documents and adjusting some styling so that unlinked timestamps don't look like they're links. The only visible change to annotation cards in non-LMS contexts is that *links to an annotation's document open in a new tab*. Please see a summary of the original problem here: https://github.com/hypothesis/client/issues/3098

The PR description is long but the user-visible changes are small.

To be clear, this still leaves us the flexibility to re-enable linking to documents later in these contexts, if we figure out how to do so sanely.

This PR does the following:

* It makes changes that have the effect of removing links to documents from third-party annotations in the Notebook view. First-party annotations still link to their documents. Document titles domains are (still) shown for all annotations (where that metadata is available, at least) regardless of their party-ness.

    The `AnnotationDocumentInfo` component is highlighted in the following screenshot. It shows what the component looks like in the Notebook view, after these changes, for a first-party annotation (no visible change). It would look the same in stream and single-annotation views, too:

    <img width="685" alt="Screen Shot 2021-03-05 at 8 50 13 AM" src="https://user-images.githubusercontent.com/439947/110124460-1968e700-7d90-11eb-8a66-d4e152883d0c.png">

    And for third-party annotations (e.g. LMS contexts), where the document is (now) not linked. Stream and single-annotation views are not available for third parties, so this change is N/A in those views:

    <img width="673" alt="Screen Shot 2021-03-05 at 8 53 32 AM" src="https://user-images.githubusercontent.com/439947/110124640-559c4780-7d90-11eb-953d-fedad5e64318.png">

    _Note_: The second screenshot doesn't show a domain, but that is not related to these changes. If a domain were available for the document here (i.e. if the property is returned by the h API service), it would be shown.
    
    The `AnnotationDocumentInfo` component is only used in non-sidebar views: that is, the single-annotation, stream and (now) Notebook views. It shows document metadata for an annotation (card). Before these changes, it would link the document title to the document URL when a document URL was available, for all annotations. After these changes, it will not link documents for third-party annotations (but will still show document titles and domains). 

    This change was made to prevent Notebook annotation cards from linking to their documents when the Notebook is viewed within the LMS context (note: LMS annotations are third-party). Not all LMS documents are available directly (outside of an assignment context or LMS auth scope) and the direct-linked document would lose its auth context (i.e. course annotations wouldn't show up on it). _For now_ it's easiest to disable linking—so we can get the Notebook in front of users without massive confusion—until we can look at this with more nuance and see if it's feasible to support somehow direct-linking documents from LMS contexts.

* Logical heavy lifting was moved out of a couple of leaf components into `AnnotationHeader`, per our recent pattern of making leaf components dumber. This was natural when refactoring `AnnotationDocumentInfo` as needed for these changes, and `AnnotationTimestamps` has been duly adjusted to match this pattern.
* It removes the unnecessary prop-forwarding of `showDocumentInfo` and instead determines whether or not to show document info in the `AnnotationHeader` component, along with other related logic. Previously, `showDocumentInfo` was passed from `ThreadCard` -> `Thread` -> `Annotation` -> `AnnotationHeader`, which seemed...like unneeded complexity.
* It adjust styling such that unlinked timestamps in annotation-card headers don't "behave" confusingly like links on hover. Third-party annotations' timestamps are not linked.

    Before, timestamps would underline-on-hover even when not a link:

    ![image](https://user-images.githubusercontent.com/439947/110125052-e115d880-7d90-11eb-8efd-af5686dcd0f3.png)

    Now, they do not if not linked (underline-on-hover is retained for actual links):

    ![image](https://user-images.githubusercontent.com/439947/110125159-0276c480-7d91-11eb-9fa5-fdb0800cec7d.png)

* It makes linked documents open in a new tab. This is the only change here visible to first party annotations.

### To test in LMS context

* Get your local LMS env going
* Make sure the Notebook feature flag is enabled in your local `h` ( http://localhost:5000/admin/features )
* Open a localhost LMS assignment (and make sure it has at least one annotation). For reference, I'm using this assignment in our Canvas instance. I'm logged in as a student, but logging in as an instructor should work, too:

    ![image](https://user-images.githubusercontent.com/439947/110125514-63060180-7d91-11eb-905a-22497d4d54df.png)

* Open the Notebook from the user menu
* Document titles should be visible, but not linked
* Hovering over the timestamp should not show an underline

Opening in draft until:

* [x] This PR description could be clearer and could use some screenshots
* [x] Linked documents should open in a new tab. I totally spaced on this and will push a commit to address it.
* [x] Look into test misses

Fixes https://github.com/hypothesis/client/issues/3098