### PR TITLE
Git ignore yalc related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ package-lock.json
 .tlskey.pem
 
 .tox
+
+# yalc related files
+yalc.lock
+.yalc/


### PR DESCRIPTION
The @hypothesis/frontend-shared lives now in another repo. The
recommended way to test the package in the context of the client is
using yalc. Therefore, it is better to ignores yalc related files so
they are not committed by mistake.