### PR TITLE
Remove prop types from components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,9 @@
 
     // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
     "react/jsx-uses-react": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+
+    // Replaced by TypeScript's static checking.
+    "react/prop-types": "off"
   }
 }

--- a/src/annotator/components/AdderToolbar.js
+++ b/src/annotator/components/AdderToolbar.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import propTypes from 'prop-types';
 
 import { useShortcut } from '../../shared/shortcut';
 
@@ -32,14 +31,6 @@ function ToolbarButton({ badgeCount, icon, label, onClick, shortcut }) {
     </button>
   );
 }
-
-ToolbarButton.propTypes = {
-  badgeCount: propTypes.number,
-  icon: propTypes.string,
-  label: propTypes.string.isRequired,
-  onClick: propTypes.func.isRequired,
-  shortcut: propTypes.string,
-};
 
 /**
  * Union of possible toolbar commands.
@@ -132,10 +123,3 @@ export default function AdderToolbar({
     </div>
   );
 }
-
-AdderToolbar.propTypes = {
-  arrowDirection: propTypes.oneOf(['up', 'down']).isRequired,
-  isVisible: propTypes.bool.isRequired,
-  onCommand: propTypes.func.isRequired,
-  annotationCount: propTypes.number,
-};

--- a/src/annotator/components/Buckets.js
+++ b/src/annotator/components/Buckets.js
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import propTypes from 'prop-types';
 import scrollIntoView from 'scroll-into-view';
 
 import { setHighlightsFocused } from '../highlighter';
@@ -48,11 +47,6 @@ function BucketButton({ bucket, onSelectAnnotations }) {
   );
 }
 
-BucketButton.propTypes = {
-  bucket: propTypes.object.isRequired,
-  onSelectAnnotations: propTypes.func.isRequired,
-};
-
 /**
  * An up- or down-pointing button that will scroll to the next closest bucket
  * of annotations in the given direction.
@@ -82,11 +76,6 @@ function NavigationBucketButton({ bucket, direction }) {
     </button>
   );
 }
-
-NavigationBucketButton.propTypes = {
-  bucket: propTypes.object.isRequired,
-  direction: propTypes.string,
-};
 
 /**
  * A list of buckets, including up and down navigation (when applicable) and
@@ -134,10 +123,3 @@ export default function Buckets({
     </ul>
   );
 }
-
-Buckets.propTypes = {
-  above: propTypes.object.isRequired,
-  below: propTypes.object.isRequired,
-  buckets: propTypes.array.isRequired,
-  onSelectAnnotations: propTypes.func.isRequired,
-};

--- a/src/annotator/components/Toolbar.js
+++ b/src/annotator/components/Toolbar.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import propTypes from 'prop-types';
 
 /**
  * @param {Object} props
@@ -41,16 +40,6 @@ function ToolbarButton({
     </button>
   );
 }
-
-ToolbarButton.propTypes = {
-  buttonRef: propTypes.any,
-  expanded: propTypes.bool,
-  className: propTypes.string,
-  label: propTypes.string.isRequired,
-  icon: propTypes.string.isRequired,
-  onClick: propTypes.func.isRequired,
-  selected: propTypes.bool,
-};
 
 /**
  * @typedef ToolbarProps
@@ -137,15 +126,3 @@ export default function Toolbar({
     </div>
   );
 }
-
-Toolbar.propTypes = {
-  closeSidebar: propTypes.func.isRequired,
-  createAnnotation: propTypes.func.isRequired,
-  isSidebarOpen: propTypes.bool.isRequired,
-  newAnnotationType: propTypes.oneOf(['annotation', 'note']).isRequired,
-  showHighlights: propTypes.bool.isRequired,
-  toggleHighlights: propTypes.func.isRequired,
-  toggleSidebar: propTypes.func.isRequired,
-  toggleSidebarRef: propTypes.any,
-  useMinimalControls: propTypes.bool,
-};

--- a/src/sidebar/components/Annotation/Annotation.js
+++ b/src/sidebar/components/Annotation/Annotation.js
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../../store/use-store';
 import { quote } from '../../helpers/annotation-metadata';
@@ -120,16 +119,6 @@ function Annotation({
     </article>
   );
 }
-
-Annotation.propTypes = {
-  annotation: propTypes.object,
-  hasAppliedFilter: propTypes.bool.isRequired,
-  isReply: propTypes.bool,
-  onToggleReplies: propTypes.func,
-  replyCount: propTypes.number.isRequired,
-  threadIsCollapsed: propTypes.bool.isRequired,
-  annotationsService: propTypes.object.isRequired,
-};
 
 Annotation.injectedProps = ['annotationsService'];
 

--- a/src/sidebar/components/Annotation/AnnotationActionBar.js
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import { useStoreProxy } from '../../store/use-store';
 import {
   sharingEnabled,
@@ -120,14 +118,6 @@ function AnnotationActionBar({
     </div>
   );
 }
-
-AnnotationActionBar.propTypes = {
-  annotation: propTypes.object.isRequired,
-  onReply: propTypes.func.isRequired,
-  annotationsService: propTypes.object.isRequired,
-  settings: propTypes.object.isRequired,
-  toastMessenger: propTypes.object.isRequired,
-};
 
 AnnotationActionBar.injectedProps = [
   'annotationsService',

--- a/src/sidebar/components/Annotation/AnnotationBody.js
+++ b/src/sidebar/components/Annotation/AnnotationBody.js
@@ -1,5 +1,4 @@
 import { useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../../store/use-store';
 import { isHidden } from '../../helpers/annotation-metadata';
@@ -89,11 +88,6 @@ function AnnotationBody({ annotation, settings }) {
     </div>
   );
 }
-
-AnnotationBody.propTypes = {
-  annotation: propTypes.object.isRequired,
-  settings: propTypes.object,
-};
 
 AnnotationBody.injectedProps = ['settings'];
 

--- a/src/sidebar/components/Annotation/AnnotationDocumentInfo.js
+++ b/src/sidebar/components/Annotation/AnnotationDocumentInfo.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 /** @typedef {import("../../../types/api").Annotation} Annotation */
 
 /**
@@ -33,9 +31,3 @@ export default function AnnotationDocumentInfo({ domain, link, title }) {
     </div>
   );
 }
-
-AnnotationDocumentInfo.propTypes = {
-  domain: propTypes.string,
-  link: propTypes.string,
-  title: propTypes.string.isRequired,
-};

--- a/src/sidebar/components/Annotation/AnnotationEditor.js
+++ b/src/sidebar/components/Annotation/AnnotationEditor.js
@@ -1,6 +1,5 @@
 import { normalizeKeyName } from '@hypothesis/frontend-shared';
 import { useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import { withServices } from '../../service-context';
 import { applyTheme } from '../../helpers/theme';
@@ -157,14 +156,6 @@ function AnnotationEditor({
     </div>
   );
 }
-
-AnnotationEditor.propTypes = {
-  annotation: propTypes.object.isRequired,
-  annotationsService: propTypes.object,
-  settings: propTypes.object,
-  tags: propTypes.object.isRequired,
-  toastMessenger: propTypes.object,
-};
 
 AnnotationEditor.injectedProps = [
   'annotationsService',

--- a/src/sidebar/components/Annotation/AnnotationHeader.js
+++ b/src/sidebar/components/Annotation/AnnotationHeader.js
@@ -1,6 +1,5 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
 import { useMemo } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../../store/use-store';
 import {
@@ -144,10 +143,3 @@ export default function AnnotationHeader({
     </header>
   );
 }
-
-AnnotationHeader.propTypes = {
-  annotation: propTypes.object.isRequired,
-  isEditing: propTypes.bool,
-  replyCount: propTypes.number,
-  threadIsCollapsed: propTypes.bool.isRequired,
-};

--- a/src/sidebar/components/Annotation/AnnotationLicense.js
+++ b/src/sidebar/components/Annotation/AnnotationLicense.js
@@ -22,5 +22,3 @@ export default function AnnotationLicense() {
     </div>
   );
 }
-
-AnnotationLicense.propTypes = {};

--- a/src/sidebar/components/Annotation/AnnotationPublishControl.js
+++ b/src/sidebar/components/Annotation/AnnotationPublishControl.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../../store/use-store';
 import { isNew, isReply } from '../../helpers/annotation-metadata';
@@ -131,13 +130,6 @@ function AnnotationPublishControl({
     </div>
   );
 }
-
-AnnotationPublishControl.propTypes = {
-  annotation: propTypes.object.isRequired,
-  isDisabled: propTypes.bool,
-  onSave: propTypes.func.isRequired,
-  settings: propTypes.object.isRequired,
-};
 
 AnnotationPublishControl.injectedProps = ['settings'];
 

--- a/src/sidebar/components/Annotation/AnnotationQuote.js
+++ b/src/sidebar/components/Annotation/AnnotationQuote.js
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import propTypes from 'prop-types';
 
 import { isOrphan, quote } from '../../helpers/annotation-metadata';
 import { withServices } from '../../service-context';
@@ -60,12 +59,6 @@ function AnnotationQuote({ annotation, isFocused, settings = {} }) {
     </div>
   );
 }
-
-AnnotationQuote.propTypes = {
-  annotation: propTypes.object.isRequired,
-  isFocused: propTypes.bool,
-  settings: propTypes.object,
-};
 
 AnnotationQuote.injectedProps = ['settings'];
 

--- a/src/sidebar/components/Annotation/AnnotationReplyToggle.js
+++ b/src/sidebar/components/Annotation/AnnotationReplyToggle.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import Button from '../Button';
 
 /**
@@ -31,11 +29,5 @@ function AnnotationReplyToggle({
     />
   );
 }
-
-AnnotationReplyToggle.propTypes = {
-  onToggleReplies: propTypes.func,
-  replyCount: propTypes.number,
-  threadIsCollapsed: propTypes.bool.isRequired,
-};
 
 export default AnnotationReplyToggle;

--- a/src/sidebar/components/Annotation/AnnotationShareControl.js
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.js
@@ -1,6 +1,5 @@
 import { SvgIcon, useElementShouldClose } from '@hypothesis/frontend-shared';
 import { useEffect, useRef, useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import { isShareableURI } from '../../helpers/annotation-sharing';
 import { copyText } from '../../util/copy-to-clipboard';
@@ -180,14 +179,6 @@ function AnnotationShareControl({
     </div>
   );
 }
-
-AnnotationShareControl.propTypes = {
-  annotation: propTypes.object.isRequired,
-  group: propTypes.object,
-  shareUri: propTypes.string.isRequired,
-  analytics: propTypes.object.isRequired,
-  toastMessenger: propTypes.object.isRequired,
-};
 
 AnnotationShareControl.injectedProps = ['analytics', 'toastMessenger'];
 

--- a/src/sidebar/components/Annotation/AnnotationShareInfo.js
+++ b/src/sidebar/components/Annotation/AnnotationShareInfo.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../../store/use-store';
 import { isPrivate } from '../../helpers/permissions';
@@ -55,9 +54,5 @@ function AnnotationShareInfo({ annotation }) {
     </div>
   );
 }
-
-AnnotationShareInfo.propTypes = {
-  annotation: propTypes.object.isRequired,
-};
 
 export default AnnotationShareInfo;

--- a/src/sidebar/components/Annotation/AnnotationTimestamps.js
+++ b/src/sidebar/components/Annotation/AnnotationTimestamps.js
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import { format as formatDate } from '../../util/date';
 import { decayingInterval, toFuzzyString } from '../../util/time';
@@ -108,10 +107,3 @@ export default function AnnotationTimestamps({
     </div>
   );
 }
-
-AnnotationTimestamps.propTypes = {
-  annotationCreated: propTypes.string,
-  annotationUpdated: propTypes.string,
-  annotationUrl: propTypes.string,
-  withEditedTimestamp: propTypes.bool,
-};

--- a/src/sidebar/components/Annotation/AnnotationUser.js
+++ b/src/sidebar/components/Annotation/AnnotationUser.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import { isThirdPartyUser, username } from '../../helpers/account-id';
 import { withServices } from '../../service-context';
 
@@ -67,12 +65,6 @@ function AnnotationUser({ annotation, features, serviceUrl, settings }) {
   );
 }
 
-AnnotationUser.propTypes = {
-  annotation: propTypes.object.isRequired,
-  features: propTypes.object.isRequired,
-  serviceUrl: propTypes.func.isRequired,
-  settings: propTypes.object.isRequired,
-};
-
 AnnotationUser.injectedProps = ['features', 'serviceUrl', 'settings'];
+
 export default withServices(AnnotationUser);

--- a/src/sidebar/components/AnnotationView.js
+++ b/src/sidebar/components/AnnotationView.js
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../service-context';
@@ -92,11 +91,6 @@ function AnnotationView({ loadAnnotationsService, onLogin }) {
     </>
   );
 }
-
-AnnotationView.propTypes = {
-  onLogin: propTypes.func.isRequired,
-  loadAnnotationsService: propTypes.object,
-};
 
 AnnotationView.injectedProps = ['loadAnnotationsService'];
 

--- a/src/sidebar/components/AutocompleteList.js
+++ b/src/sidebar/components/AutocompleteList.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { useMemo } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 const defaultListFormatter = item => item;
 
@@ -95,13 +94,3 @@ export default function AutocompleteList({
     </div>
   );
 }
-
-AutocompleteList.propTypes = {
-  activeItem: propTypes.number,
-  id: propTypes.string,
-  itemPrefixId: propTypes.string,
-  list: propTypes.array.isRequired,
-  listFormatter: propTypes.func,
-  onSelectItem: propTypes.func.isRequired,
-  open: propTypes.bool,
-};

--- a/src/sidebar/components/Button.js
+++ b/src/sidebar/components/Button.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import propTypes from 'prop-types';
 
 /**
  * @typedef ButtonProps
@@ -87,36 +86,3 @@ export default function Button({
     </button>
   );
 }
-
-/**
- * Validation callback for `propTypes`. The given `propName` is conditionally
- * required depending on the presence or absence of the `buttonText` property. Return
- * an `Error` on validation failure, per propTypes API.
- *
- * @return {Error|undefined}
- */
-function requiredStringIfButtonTextMissing(props, propName, componentName) {
-  if (
-    typeof props.buttonText !== 'string' &&
-    typeof props[propName] !== 'string'
-  ) {
-    return new Error(
-      `string property '${propName}' must be supplied to component '${componentName}'\
-if string property 'buttonText' omitted`
-    );
-  }
-  return undefined;
-}
-
-Button.propTypes = {
-  buttonText: propTypes.string,
-  className: propTypes.string,
-  icon: requiredStringIfButtonTextMissing,
-  iconPosition: propTypes.string,
-  isExpanded: propTypes.bool,
-  isPressed: propTypes.bool,
-  onClick: propTypes.func,
-  disabled: propTypes.bool,
-  style: propTypes.object,
-  title: requiredStringIfButtonTextMissing,
-};

--- a/src/sidebar/components/Excerpt.js
+++ b/src/sidebar/components/Excerpt.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { useCallback, useLayoutEffect, useRef, useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import observeElementSize from '../util/observe-element-size';
 import { withServices } from '../service-context';
@@ -38,12 +37,6 @@ function InlineControls({ isCollapsed, setCollapsed, linkStyle = {} }) {
     </div>
   );
 }
-
-InlineControls.propTypes = {
-  isCollapsed: propTypes.bool,
-  setCollapsed: propTypes.func,
-  linkStyle: propTypes.object,
-};
 
 const noop = () => {};
 
@@ -162,17 +155,6 @@ function Excerpt({
     </div>
   );
 }
-
-Excerpt.propTypes = {
-  children: propTypes.object,
-  inlineControls: propTypes.bool,
-  collapse: propTypes.bool,
-  collapsedHeight: propTypes.number,
-  overflowThreshold: propTypes.number,
-  onCollapsibleChanged: propTypes.func,
-  onToggleCollapsed: propTypes.func,
-  settings: propTypes.object,
-};
 
 Excerpt.injectedProps = ['settings'];
 

--- a/src/sidebar/components/FilterSelect.js
+++ b/src/sidebar/components/FilterSelect.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import propTypes from 'prop-types';
 
 import Menu from './Menu';
 import MenuItem from './MenuItem';
@@ -55,14 +54,5 @@ function FilterSelect({
     </Menu>
   );
 }
-
-FilterSelect.propTypes = {
-  defaultOption: propTypes.object,
-  icon: propTypes.string,
-  onSelect: propTypes.func,
-  options: propTypes.array,
-  selectedOption: propTypes.object,
-  title: propTypes.string,
-};
 
 export default FilterSelect;

--- a/src/sidebar/components/FilterStatus.js
+++ b/src/sidebar/components/FilterStatus.js
@@ -1,5 +1,4 @@
 import { useMemo } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import { countVisible } from '../helpers/thread';
 
@@ -104,16 +103,6 @@ function FilterStatusPanel({
   );
 }
 
-FilterStatusPanel.propTypes = {
-  resultCount: propTypes.number.isRequired,
-  actionButton: propTypes.object.isRequired,
-  additionalCount: propTypes.number,
-  entitySingular: propTypes.string,
-  entityPlural: propTypes.string,
-  filterQuery: propTypes.string,
-  focusDisplayName: propTypes.string,
-};
-
 /**
  * This status is used when there are selected annotations (including direct-
  * linked annotations). This status takes precedence over others.
@@ -165,11 +154,6 @@ function SelectionFilterStatus({ filterState, rootThread }) {
   );
 }
 
-SelectionFilterStatus.propTypes = {
-  filterState: propTypes.object.isRequired,
-  rootThread: propTypes.object.isRequired,
-};
-
 /**
  * This status is used when there is an applied filter query and
  * `SelectionFilterStatus` does not apply.
@@ -209,11 +193,6 @@ function QueryFilterStatus({ filterState, rootThread }) {
     />
   );
 }
-
-QueryFilterStatus.propTypes = {
-  filterState: propTypes.object.isRequired,
-  rootThread: propTypes.object.isRequired,
-};
 
 /**
  * This status is used if user-focus mode is configured and neither
@@ -263,11 +242,6 @@ function FocusFilterStatus({ filterState, rootThread }) {
   );
 }
 
-FocusFilterStatus.propTypes = {
-  filterState: propTypes.object.isRequired,
-  rootThread: propTypes.object.isRequired,
-};
-
 /**
  * Determine which (if any) of the filter status variants to render depending
  * on current `filterState`. Only one filter status panel is displayed at a time:
@@ -313,5 +287,3 @@ export default function FilterStatus() {
   }
   return null;
 }
-
-FilterStatus.propTypes = {};

--- a/src/sidebar/components/GroupList.js
+++ b/src/sidebar/components/GroupList.js
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import serviceConfig from '../config/service-config';
 import { useStoreProxy } from '../store/use-store';
@@ -148,11 +147,6 @@ function GroupList({ serviceUrl, settings }) {
     </Menu>
   );
 }
-
-GroupList.propTypes = {
-  serviceUrl: propTypes.func,
-  settings: propTypes.object,
-};
 
 GroupList.injectedProps = ['serviceUrl', 'settings'];
 

--- a/src/sidebar/components/GroupListItem.js
+++ b/src/sidebar/components/GroupListItem.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import { useStoreProxy } from '../store/use-store';
 import { copyText } from '../util/copy-to-clipboard';
 import { orgName } from '../helpers/group-list-item-common';
@@ -147,15 +145,6 @@ function GroupListItem({
     />
   );
 }
-
-GroupListItem.propTypes = {
-  group: propTypes.object.isRequired,
-  isExpanded: propTypes.bool,
-  onExpand: propTypes.func,
-  analytics: propTypes.object.isRequired,
-  groups: propTypes.object.isRequired,
-  toastMessenger: propTypes.object.isRequired,
-};
 
 GroupListItem.injectedProps = ['analytics', 'groups', 'toastMessenger'];
 

--- a/src/sidebar/components/GroupListSection.js
+++ b/src/sidebar/components/GroupListSection.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import GroupListItem from './GroupListItem';
 import MenuSection from './MenuSection';
 
@@ -42,10 +40,3 @@ export default function GroupListSection({
     </MenuSection>
   );
 }
-
-GroupListSection.propTypes = {
-  expandedGroup: propTypes.object,
-  groups: propTypes.arrayOf(propTypes.object),
-  heading: propTypes.string,
-  onExpandGroup: propTypes.func,
-};

--- a/src/sidebar/components/HelpPanel.js
+++ b/src/sidebar/components/HelpPanel.js
@@ -1,6 +1,5 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
 import { useCallback, useMemo, useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../service-context';
@@ -40,11 +39,6 @@ function HelpPanelTab({ linkText, url }) {
     </div>
   );
 }
-
-HelpPanelTab.propTypes = {
-  linkText: propTypes.string.isRequired,
-  url: propTypes.string.isRequired,
-};
 
 /**
  * @typedef HelpPanelProps
@@ -160,10 +154,6 @@ function HelpPanel({ auth, session }) {
   );
 }
 
-HelpPanel.propTypes = {
-  auth: propTypes.object.isRequired,
-  session: propTypes.object.isRequired,
-};
-
 HelpPanel.injectedProps = ['session'];
+
 export default withServices(HelpPanel);

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { useEffect, useMemo } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import bridgeEvents from '../../shared/bridge-events';
 import serviceConfig from '../config/service-config';
@@ -200,15 +199,6 @@ function HypothesisApp({
     </div>
   );
 }
-
-HypothesisApp.propTypes = {
-  auth: propTypes.object,
-  bridge: propTypes.object,
-  serviceUrl: propTypes.func,
-  settings: propTypes.object,
-  session: propTypes.object,
-  toastMessenger: propTypes.object,
-};
 
 HypothesisApp.injectedProps = [
   'auth',

--- a/src/sidebar/components/LoggedOutMessage.js
+++ b/src/sidebar/components/LoggedOutMessage.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import propTypes from 'prop-types';
 
 import { withServices } from '../service-context';
 
@@ -54,11 +53,6 @@ function LoggedOutMessage({ onLogin, serviceUrl }) {
     </div>
   );
 }
-
-LoggedOutMessage.propTypes = {
-  onLogin: propTypes.func.isRequired,
-  serviceUrl: propTypes.func.isRequired,
-};
 
 LoggedOutMessage.injectedProps = ['serviceUrl'];
 

--- a/src/sidebar/components/LoginPromptPanel.js
+++ b/src/sidebar/components/LoginPromptPanel.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import { useStoreProxy } from '../store/use-store';
 
 import Button from './Button';
@@ -44,8 +42,3 @@ export default function LoginPromptPanel({ onLogin, onSignUp }) {
     </SidebarPanel>
   );
 }
-
-LoginPromptPanel.propTypes = {
-  onLogin: propTypes.func.isRequired,
-  onSignUp: propTypes.func.isRequired,
-};

--- a/src/sidebar/components/MarkdownEditor.js
+++ b/src/sidebar/components/MarkdownEditor.js
@@ -2,7 +2,6 @@ import classnames from 'classnames';
 import { SvgIcon, normalizeKeyName } from '@hypothesis/frontend-shared';
 import { createRef } from 'preact';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import {
   LinkType,
@@ -146,17 +145,6 @@ function ToolbarButton({
     </button>
   );
 }
-
-ToolbarButton.propTypes = {
-  buttonRef: propTypes.object.isRequired,
-  disabled: propTypes.bool,
-  iconName: propTypes.string,
-  label: propTypes.string,
-  onClick: propTypes.func.isRequired,
-  shortcutKey: propTypes.string,
-  tabIndex: propTypes.number.isRequired,
-  title: propTypes.string,
-};
 
 /**
  * @typedef {'bold'|'italic'|'quote'|'link'|'image'|'math'|'numlist'|'list'|'preview'|'help'} ButtonID
@@ -383,12 +371,6 @@ function Toolbar({ isPreviewing, onCommand, onTogglePreview }) {
   );
 }
 
-Toolbar.propTypes = {
-  isPreviewing: propTypes.bool,
-  onCommand: propTypes.func,
-  onTogglePreview: propTypes.func,
-};
-
 /**
  * @typedef MarkdownEditorProps
  * @prop {string} label - An accessible label for the input field.
@@ -478,10 +460,3 @@ export default function MarkdownEditor({
     </div>
   );
 }
-
-MarkdownEditor.propTypes = {
-  textStyle: propTypes.object,
-  label: propTypes.string.isRequired,
-  text: propTypes.string,
-  onEditText: propTypes.func,
-};

--- a/src/sidebar/components/MarkdownView.js
+++ b/src/sidebar/components/MarkdownView.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { useEffect, useMemo, useRef } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import { replaceLinksWithEmbeds } from '../media-embedder';
 import renderMarkdown from '../render-markdown';
@@ -52,9 +51,3 @@ export default function MarkdownView({
     />
   );
 }
-
-MarkdownView.propTypes = {
-  markdown: propTypes.string,
-  textClass: propTypes.object,
-  textStyle: propTypes.object,
-};

--- a/src/sidebar/components/Menu.js
+++ b/src/sidebar/components/Menu.js
@@ -5,7 +5,6 @@ import {
   useElementShouldClose,
 } from '@hypothesis/frontend-shared';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import MenuKeyboardNavigation from './MenuKeyboardNavigation';
 
@@ -207,19 +206,3 @@ export default function Menu({
     </div>
   );
 }
-
-Menu.propTypes = {
-  align: propTypes.oneOf(['left', 'right']),
-  arrowClass: propTypes.string,
-  label: propTypes.oneOfType([
-    propTypes.object.isRequired,
-    propTypes.string.isRequired,
-  ]),
-  children: propTypes.any,
-  containerPositioned: propTypes.bool,
-  contentClass: propTypes.string,
-  defaultOpen: propTypes.bool,
-  onOpenChanged: propTypes.func,
-  title: propTypes.string.isRequired,
-  menuIndicator: propTypes.bool,
-};

--- a/src/sidebar/components/MenuItem.js
+++ b/src/sidebar/components/MenuItem.js
@@ -1,7 +1,6 @@
 import classnames from 'classnames';
 import { SvgIcon, normalizeKeyName } from '@hypothesis/frontend-shared';
 import { useEffect, useRef } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import MenuKeyboardNavigation from './MenuKeyboardNavigation';
 import Slider from './Slider';
@@ -230,18 +229,3 @@ export default function MenuItem({
     </>
   );
 }
-
-MenuItem.propTypes = {
-  href: propTypes.string,
-  iconAlt: propTypes.string,
-  icon: propTypes.string,
-  isDisabled: propTypes.bool,
-  isExpanded: propTypes.bool,
-  isSelected: propTypes.bool,
-  isSubmenuItem: propTypes.bool,
-  isSubmenuVisible: propTypes.bool,
-  label: propTypes.string.isRequired,
-  onClick: propTypes.func,
-  onToggleSubmenu: propTypes.func,
-  submenu: propTypes.any,
-};

--- a/src/sidebar/components/MenuKeyboardNavigation.js
+++ b/src/sidebar/components/MenuKeyboardNavigation.js
@@ -1,6 +1,5 @@
 import { normalizeKeyName } from '@hypothesis/frontend-shared';
 import { useEffect, useRef } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 function isElementVisible(element) {
   return element.offsetParent !== null;
@@ -110,18 +109,3 @@ export default function MenuKeyboardNavigation({
     </div>
   );
 }
-
-MenuKeyboardNavigation.propTypes = {
-  className: propTypes.string,
-
-  // Callback when the menu is closed via keyboard input
-  closeMenu: propTypes.func,
-
-  // When  true`, sets focus on the first item in the list
-  // which has a role="menuitem" attribute.
-  visible: propTypes.bool,
-
-  // Array of nodes which may contain <MenuItems> or any nodes
-  // that have role set to 'menuitem', 'menuitemradio', or 'menuitemcheckbox'
-  children: propTypes.any.isRequired,
-};

--- a/src/sidebar/components/MenuSection.js
+++ b/src/sidebar/components/MenuSection.js
@@ -1,5 +1,4 @@
 import { toChildArray } from 'preact';
-import propTypes from 'prop-types';
 
 /** @typedef {import("preact").JSX.Element} JSXElement */
 
@@ -38,8 +37,3 @@ export default function MenuSection({ heading, children }) {
     </>
   );
 }
-
-MenuSection.propTypes = {
-  heading: propTypes.string,
-  children: propTypes.any.isRequired,
-};

--- a/src/sidebar/components/ModerationBanner.js
+++ b/src/sidebar/components/ModerationBanner.js
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';
 import * as annotationMetadata from '../helpers/annotation-metadata';
@@ -96,12 +95,6 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
     </div>
   );
 }
-
-ModerationBanner.propTypes = {
-  annotation: propTypes.object.isRequired,
-  api: propTypes.object.isRequired,
-  toastMessenger: propTypes.object.isRequired,
-};
 
 ModerationBanner.injectedProps = ['api', 'toastMessenger'];
 

--- a/src/sidebar/components/NewNoteBtn.js
+++ b/src/sidebar/components/NewNoteBtn.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../service-context';
 import { applyTheme } from '../helpers/theme';
@@ -48,10 +46,6 @@ function NewNoteButton({ annotationsService, settings }) {
     </div>
   );
 }
-NewNoteButton.propTypes = {
-  annotationsService: propTypes.object.isRequired,
-  settings: propTypes.object.isRequired,
-};
 
 NewNoteButton.injectedProps = ['annotationsService', 'settings'];
 

--- a/src/sidebar/components/NotebookFilters.js
+++ b/src/sidebar/components/NotebookFilters.js
@@ -28,6 +28,4 @@ function NotebookFilters() {
   );
 }
 
-NotebookFilters.propTypes = {};
-
 export default NotebookFilters;

--- a/src/sidebar/components/NotebookResultCount.js
+++ b/src/sidebar/components/NotebookResultCount.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import useRootThread from './hooks/use-root-thread';
 import { countVisible } from '../helpers/thread';
 
@@ -66,12 +64,5 @@ function NotebookResultCount({
     </div>
   );
 }
-
-NotebookResultCount.propTypes = {
-  forcedVisibleCount: propTypes.number,
-  isFiltered: propTypes.bool,
-  isLoading: propTypes.bool,
-  resultCount: propTypes.number,
-};
 
 export default NotebookResultCount;

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -1,5 +1,4 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 import scrollIntoView from 'scroll-into-view';
 
 import { withServices } from '../service-context';
@@ -104,10 +103,6 @@ function NotebookView({ loadAnnotationsService }) {
     </div>
   );
 }
-
-NotebookView.propTypes = {
-  loadAnnotationsService: propTypes.object,
-};
 
 NotebookView.injectedProps = ['loadAnnotationsService'];
 

--- a/src/sidebar/components/PaginatedThreadList.js
+++ b/src/sidebar/components/PaginatedThreadList.js
@@ -1,5 +1,4 @@
 import { useMemo } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import { countVisible } from '../helpers/thread';
 
@@ -56,13 +55,5 @@ function PaginatedThreadList({
     </>
   );
 }
-
-PaginatedThreadList.propTypes = {
-  isLoading: propTypes.bool,
-  threads: propTypes.array,
-  currentPage: propTypes.number,
-  onChangePage: propTypes.func,
-  pageSize: propTypes.number,
-};
 
 export default PaginatedThreadList;

--- a/src/sidebar/components/PaginationNavigation.js
+++ b/src/sidebar/components/PaginationNavigation.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import { pageNumberOptions } from '../util/pagination';
 
 import Button from './Button';
@@ -79,11 +77,5 @@ function PaginationNavigation({ currentPage, onChangePage, totalPages }) {
     </div>
   );
 }
-
-PaginationNavigation.propTypes = {
-  currentPage: propTypes.number,
-  onChangePage: propTypes.func,
-  totalPages: propTypes.number,
-};
 
 export default PaginationNavigation;

--- a/src/sidebar/components/SearchInput.js
+++ b/src/sidebar/components/SearchInput.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { useRef, useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';
 
@@ -90,9 +89,3 @@ export default function SearchInput({ alwaysExpanded, query, onSearch }) {
     </form>
   );
 }
-
-SearchInput.propTypes = {
-  alwaysExpanded: propTypes.bool,
-  query: propTypes.string,
-  onSearch: propTypes.func,
-};

--- a/src/sidebar/components/SelectionTabs.js
+++ b/src/sidebar/components/SelectionTabs.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../service-context';
@@ -68,15 +67,6 @@ function Tab({
     </div>
   );
 }
-
-Tab.propTypes = {
-  children: propTypes.node.isRequired,
-  count: propTypes.number.isRequired,
-  isSelected: propTypes.bool.isRequired,
-  isWaitingToAnchor: propTypes.bool.isRequired,
-  label: propTypes.string.isRequired,
-  onSelect: propTypes.func.isRequired,
-};
 
 /**
  * @typedef SelectionTabsProps
@@ -169,10 +159,6 @@ function SelectionTabs({ isLoading, settings }) {
     </div>
   );
 }
-SelectionTabs.propTypes = {
-  isLoading: propTypes.bool.isRequired,
-  settings: propTypes.object.isRequired,
-};
 
 SelectionTabs.injectedProps = ['settings'];
 

--- a/src/sidebar/components/ShareAnnotationsPanel.js
+++ b/src/sidebar/components/ShareAnnotationsPanel.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';
 import { pageSharingLink } from '../helpers/annotation-sharing';
@@ -122,11 +121,6 @@ function ShareAnnotationsPanel({ analytics, toastMessenger }) {
     </SidebarPanel>
   );
 }
-
-ShareAnnotationsPanel.propTypes = {
-  analytics: propTypes.object.isRequired,
-  toastMessenger: propTypes.object.isRequired,
-};
 
 ShareAnnotationsPanel.injectedProps = ['analytics', 'toastMessenger'];
 

--- a/src/sidebar/components/ShareLinks.js
+++ b/src/sidebar/components/ShareLinks.js
@@ -1,10 +1,19 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import propTypes from 'prop-types';
 
 import { withServices } from '../service-context';
 
 /**
+ * @typedef ShareLinkProps
+ * @prop {string} iconName - The name of the SVG icon to use for this link
+ * @prop {string} label - Accessible label/tooltip for link
+ * @prop {string} uri - URI for sharing this annotation
+ * @prop {() => void} onClick - Callback for analytics tracking
+ */
+
+/**
  * A single sharing link as a list item
+ *
+ * @param {ShareLinkProps} props
  */
 function ShareLink({ label, iconName, uri, onClick }) {
   return (
@@ -23,16 +32,12 @@ function ShareLink({ label, iconName, uri, onClick }) {
   );
 }
 
-ShareLink.propTypes = {
-  /** The name of the SVG icon to use for this link */
-  iconName: propTypes.string.isRequired,
-  /** Accessible label / tooltip for link. */
-  label: propTypes.string.isRequired,
-  /** URI for sharing this annotation on the given social service */
-  uri: propTypes.string.isRequired,
-  /** click callback (for analytics tracking) */
-  onClick: propTypes.func.isRequired,
-};
+/**
+ * @typedef ShareLinksProps
+ * @prop {object} analytics
+ * @prop {string} analyticsEventName
+ * @prop {string} shareURI - The URL to share
+ */
 
 /**
  * A list of share links to social-media platforms.
@@ -77,16 +82,6 @@ function ShareLinks({ analytics, analyticsEventName, shareURI }) {
     </ul>
   );
 }
-
-ShareLinks.propTypes = {
-  /** Analytics event to track when share links are clicked */
-  analyticsEventName: propTypes.string.isRequired,
-  /** URI to shared resource(s), e.g. an annotation or collection of annotations */
-  shareURI: propTypes.string.isRequired,
-
-  // Services/injected
-  analytics: propTypes.object.isRequired,
-};
 
 ShareLinks.injectedProps = ['analytics'];
 

--- a/src/sidebar/components/SidebarContentError.js
+++ b/src/sidebar/components/SidebarContentError.js
@@ -1,6 +1,5 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
-import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';
 
@@ -76,9 +75,3 @@ export default function SidebarContentError({
     </div>
   );
 }
-
-SidebarContentError.propTypes = {
-  errorType: propTypes.oneOf(['annotation', 'group']).isRequired,
-  showClearSelection: propTypes.bool,
-  onLoginRequest: propTypes.func.isRequired,
-};

--- a/src/sidebar/components/SidebarPanel.js
+++ b/src/sidebar/components/SidebarPanel.js
@@ -1,6 +1,5 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
 import { useEffect, useRef } from 'preact/hooks';
-import propTypes from 'prop-types';
 import scrollIntoView from 'scroll-into-view';
 
 import { useStoreProxy } from '../store/use-store';
@@ -82,11 +81,3 @@ export default function SidebarPanel({
     </Slider>
   );
 }
-
-SidebarPanel.propTypes = {
-  children: propTypes.any,
-  icon: propTypes.string,
-  panelName: propTypes.string.isRequired,
-  title: propTypes.string.isRequired,
-  onActiveChanged: propTypes.func,
-};

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -1,4 +1,3 @@
-import propTypes from 'prop-types';
 import { useEffect, useRef } from 'preact/hooks';
 
 import useRootThread from './hooks/use-root-thread';
@@ -157,14 +156,6 @@ function SidebarView({
     </div>
   );
 }
-
-SidebarView.propTypes = {
-  onLogin: propTypes.func.isRequired,
-  onSignUp: propTypes.func.isRequired,
-  frameSync: propTypes.object,
-  loadAnnotationsService: propTypes.object,
-  streamer: propTypes.object,
-};
 
 SidebarView.injectedProps = ['frameSync', 'loadAnnotationsService', 'streamer'];
 

--- a/src/sidebar/components/Slider.js
+++ b/src/sidebar/components/Slider.js
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 /**
  * @typedef SliderProps
@@ -102,8 +101,3 @@ export default function Slider({ children, visible }) {
     </div>
   );
 }
-
-Slider.propTypes = {
-  children: propTypes.any,
-  visible: propTypes.bool,
-};

--- a/src/sidebar/components/SortMenu.js
+++ b/src/sidebar/components/SortMenu.js
@@ -46,5 +46,3 @@ export default function SortMenu() {
     </div>
   );
 }
-
-SortMenu.propTypes = {};

--- a/src/sidebar/components/Spinner.js
+++ b/src/sidebar/components/Spinner.js
@@ -16,5 +16,3 @@ export default function Spinner() {
     </div>
   );
 }
-
-Spinner.propTypes = {};

--- a/src/sidebar/components/StreamSearchInput.js
+++ b/src/sidebar/components/StreamSearchInput.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../service-context';
 
@@ -30,10 +28,6 @@ function StreamSearchInput({ router }) {
     <SearchInput query={query} onSearch={setQuery} alwaysExpanded={true} />
   );
 }
-
-StreamSearchInput.propTypes = {
-  router: propTypes.object,
-};
 
 StreamSearchInput.injectedProps = ['router'];
 

--- a/src/sidebar/components/StreamView.js
+++ b/src/sidebar/components/StreamView.js
@@ -1,5 +1,4 @@
 import { useCallback, useEffect } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import * as searchFilter from '../util/search-filter';
 import { withServices } from '../service-context';
@@ -66,11 +65,6 @@ function StreamView({ api, toastMessenger }) {
 
   return <ThreadList threads={rootThread.children} />;
 }
-
-StreamView.propTypes = {
-  api: propTypes.object,
-  toastMessenger: propTypes.object,
-};
 
 StreamView.injectedProps = ['api', 'toastMessenger'];
 

--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -4,7 +4,6 @@ import {
   useElementShouldClose,
 } from '@hypothesis/frontend-shared';
 import { useRef, useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import { withServices } from '../service-context';
 
@@ -338,14 +337,6 @@ function TagEditor({
     </div>
   );
 }
-
-TagEditor.propTypes = {
-  onAddTag: propTypes.func.isRequired,
-  onRemoveTag: propTypes.func.isRequired,
-  onTagInput: propTypes.func,
-  tagList: propTypes.array.isRequired,
-  tags: propTypes.object.isRequired,
-};
 
 TagEditor.injectedProps = ['tags'];
 

--- a/src/sidebar/components/TagList.js
+++ b/src/sidebar/components/TagList.js
@@ -1,5 +1,4 @@
 import { useMemo } from 'preact/hooks';
-import propTypes from 'prop-types';
 
 import { isThirdPartyUser } from '../helpers/account-id';
 import { withServices } from '../service-context';
@@ -61,13 +60,6 @@ function TagList({ annotation, serviceUrl, settings, tags }) {
     </ul>
   );
 }
-
-TagList.propTypes = {
-  annotation: propTypes.object.isRequired,
-  tags: propTypes.array.isRequired,
-  serviceUrl: propTypes.func,
-  settings: propTypes.object,
-};
 
 TagList.injectedProps = ['serviceUrl', 'settings'];
 

--- a/src/sidebar/components/Thread.js
+++ b/src/sidebar/components/Thread.js
@@ -1,7 +1,6 @@
 import classnames from 'classnames';
 import { useCallback, useMemo } from 'preact/hooks';
 
-import propTypes from 'prop-types';
 import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../service-context';
 import { countHidden, countVisible } from '../helpers/thread';
@@ -124,13 +123,6 @@ function Thread({ thread, threadsService }) {
     </section>
   );
 }
-
-Thread.propTypes = {
-  thread: propTypes.object.isRequired,
-
-  // Injected
-  threadsService: propTypes.object.isRequired,
-};
 
 Thread.injectedProps = ['threadsService'];
 

--- a/src/sidebar/components/ThreadCard.js
+++ b/src/sidebar/components/ThreadCard.js
@@ -2,7 +2,6 @@ import classnames from 'classnames';
 import debounce from 'lodash.debounce';
 import { useCallback, useMemo } from 'preact/hooks';
 
-import propTypes from 'prop-types';
 import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../service-context';
 
@@ -79,11 +78,6 @@ function ThreadCard({ frameSync, thread }) {
     </div>
   );
 }
-
-ThreadCard.propTypes = {
-  thread: propTypes.object.isRequired,
-  frameSync: propTypes.object.isRequired,
-};
 
 ThreadCard.injectedProps = ['frameSync'];
 

--- a/src/sidebar/components/ThreadList.js
+++ b/src/sidebar/components/ThreadList.js
@@ -1,5 +1,4 @@
 import { useEffect, useLayoutEffect, useMemo, useState } from 'preact/hooks';
-import propTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 
 import { useStoreProxy } from '../store/use-store';
@@ -207,10 +206,5 @@ function ThreadList({ threads }) {
     </div>
   );
 }
-
-ThreadList.propTypes = {
-  /** Should annotations render extra document metadata? */
-  threads: propTypes.array.isRequired,
-};
 
 export default ThreadList;

--- a/src/sidebar/components/ToastMessages.js
+++ b/src/sidebar/components/ToastMessages.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import propTypes from 'prop-types';
 
 import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../service-context';
@@ -75,11 +74,6 @@ function ToastMessage({ message, onDismiss }) {
   );
 }
 
-ToastMessage.propTypes = {
-  message: propTypes.object.isRequired,
-  onDismiss: propTypes.func,
-};
-
 /**
  * @typedef ToastMessagesProps
  * @prop {Object} toastMessenger - Injected service
@@ -112,10 +106,6 @@ function ToastMessages({ toastMessenger }) {
     </div>
   );
 }
-
-ToastMessages.propTypes = {
-  toastMessenger: propTypes.object.isRequired,
-};
 
 ToastMessages.injectedProps = ['toastMessenger'];
 

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import bridgeEvents from '../../shared/bridge-events';
 import serviceConfig from '../config/service-config';
 import { useStoreProxy } from '../store/use-store';
@@ -164,23 +162,6 @@ function TopBar({
     </div>
   );
 }
-
-TopBar.propTypes = {
-  auth: propTypes.shape({
-    status: propTypes.string.isRequired,
-    // Additional properties when user is logged in.
-    displayName: propTypes.string,
-    userid: propTypes.string,
-    username: propTypes.string,
-  }),
-  bridge: propTypes.object.isRequired,
-  isSidebar: propTypes.bool,
-  onLogin: propTypes.func,
-  onLogout: propTypes.func,
-  onSignUp: propTypes.func,
-  settings: propTypes.object,
-  streamer: propTypes.object,
-};
 
 TopBar.injectedProps = ['bridge', 'settings', 'streamer'];
 

--- a/src/sidebar/components/Tutorial.js
+++ b/src/sidebar/components/Tutorial.js
@@ -7,6 +7,10 @@ import { withServices } from '../service-context';
  * Subcomponent: an "instruction" within the tutorial step that includes an
  * icon and a "command" associated with that icon. Encapsulating these together
  * allows for styling to keep them from having a line break between them.
+ *
+ * @param {object} props
+ *   @param {string} props.commandName - Name of the "command" the instruction represents
+ *   @param {string} props.iconName - Name of the icon to display
  */
 function TutorialInstruction({ commandName, iconName }) {
   return (
@@ -16,13 +20,6 @@ function TutorialInstruction({ commandName, iconName }) {
     </span>
   );
 }
-
-TutorialInstruction.propTypes = {
-  /* the name of the "command" the instruction represents, e.g. "Annotate" */
-  commandName: propTypes.string.isRequired,
-  /* the name of the SVGIcon to display with this instruction */
-  iconName: propTypes.string.isRequired,
-};
 
 /**
  * Tutorial for using the sidebar app

--- a/src/sidebar/components/Tutorial.js
+++ b/src/sidebar/components/Tutorial.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import propTypes from 'prop-types';
 
 import isThirdPartyService from '../helpers/is-third-party-service';
 import { withServices } from '../service-context';
@@ -71,10 +70,6 @@ function Tutorial({ settings }) {
     </ol>
   );
 }
-
-Tutorial.propTypes = {
-  settings: propTypes.object.isRequired,
-};
 
 Tutorial.injectedProps = ['settings'];
 

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -1,5 +1,4 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
-import propTypes from 'prop-types';
 
 import bridgeEvents from '../../shared/bridge-events';
 import serviceConfig from '../config/service-config';
@@ -108,14 +107,6 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
     </div>
   );
 }
-
-UserMenu.propTypes = {
-  auth: propTypes.object.isRequired,
-  onLogout: propTypes.func.isRequired,
-  bridge: propTypes.object.isRequired,
-  serviceUrl: propTypes.func.isRequired,
-  settings: propTypes.object.isRequired,
-};
 
 UserMenu.injectedProps = ['bridge', 'serviceUrl', 'settings'];
 

--- a/src/sidebar/components/VersionInfo.js
+++ b/src/sidebar/components/VersionInfo.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import { copyText } from '../util/copy-to-clipboard';
 import { withServices } from '../service-context';
 
@@ -52,11 +50,6 @@ function VersionInfo({ toastMessenger, versionData }) {
     </div>
   );
 }
-
-VersionInfo.propTypes = {
-  versionData: propTypes.object.isRequired,
-  toastMessenger: propTypes.object.isRequired,
-};
 
 VersionInfo.injectedProps = ['toastMessenger'];
 

--- a/src/sidebar/service-context.js
+++ b/src/sidebar/service-context.js
@@ -44,7 +44,7 @@ export const ServiceContext = createContext(fallbackInjector);
  * Wrap a React component to inject any services it depends upon as props.
  *
  * Components declare their service dependencies in an `injectedProps` static
- * property. These services also need to be declared in `propTypes`.
+ * property.
  *
  * Any props which are passed directly will override injected props.
  *
@@ -97,12 +97,6 @@ export function withServices(Component) {
   const wrappedName = Component.displayName || Component.name;
   Wrapper.displayName = `withServices(${wrappedName})`;
 
-  // Forward the prop types, except for those expected to be injected via
-  // the `ServiceContext`.
-  Wrapper.propTypes = { ...Component.propTypes };
-  Component.injectedProps.forEach(prop => {
-    delete Wrapper.propTypes[prop];
-  });
   return Wrapper;
 }
 

--- a/src/sidebar/test/service-context-test.js
+++ b/src/sidebar/test/service-context-test.js
@@ -1,6 +1,5 @@
 import { mount } from 'enzyme';
 import { render } from 'preact';
-import propTypes from 'prop-types';
 
 import { ServiceContext, withServices, useService } from '../service-context';
 
@@ -38,20 +37,6 @@ describe('sidebar/service-context', () => {
       );
       assert.deepEqual(lastProps, { aService: testService });
       assert.calledWith(injector.get, 'aService');
-    });
-
-    it('copies propTypes except for injected properties to wrapper', () => {
-      function TestComponent() {}
-      TestComponent.propTypes = {
-        notInjected: propTypes.string,
-        injected: propTypes.string,
-      };
-      TestComponent.injectedProps = ['injected'];
-
-      const Wrapped = withServices(TestComponent);
-
-      assert.deepEqual(Wrapped.propTypes, { notInjected: propTypes.string });
-      assert.isUndefined(Wrapped.injectedProps);
     });
 
     it('does not look up services if they are passed as props', () => {

--- a/src/test-util/mock-imported-components.js
+++ b/src/test-util/mock-imported-components.js
@@ -1,11 +1,19 @@
 /**
- * Return true if `value` "looks like" a React/Preact component.
+ * Return true if an imported `value` "looks like" a Preact function component.
+ *
+ * This check can have false positives (ie. match values which are not really components).
+ * That's OK because typical usage in a test is to first mock all components with
+ * `$imports.$mock(mockImportedComponents())` and then mock other things with
+ * `$imports.$mock(...)`. The more specific mocks will override the generic
+ * component mocks.
  */
 function isComponent(value) {
   return (
     typeof value === 'function' &&
-    value.hasOwnProperty('propTypes') &&
-    value.name.match(/^[A-Z]/)
+    value.name.match(/^[A-Z]/) &&
+    // Check that function is not an ES class. Note this only works with real
+    // ES classes and may not work with ones transpiled to ES5.
+    !value.toString().match(/^class\b/)
   );
 }
 

--- a/src/test-util/mock-imported-components.js
+++ b/src/test-util/mock-imported-components.js
@@ -72,9 +72,6 @@ export default function mockImportedComponents() {
     // is an Enzyme wrapper.
     mock.displayName = getDisplayName(value);
 
-    // Mocked components validate props in the same way as the real component.
-    mock.propTypes = value.propTypes;
-
     return mock;
   };
 }


### PR DESCRIPTION
See individual commit messages for details. The only non-obvious change is that `mockImportedComponents` now needs a different (and not completely accurate, but Good Enough™) method to detect whether an import is a component or not.

Fixes https://github.com/hypothesis/client/issues/3030