### PR TITLE
Remove obsolete prop-types lint suppressions

### DIFF
--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -16,7 +16,6 @@ import {
  *
  * This is used to test PDF-specific highlighting behavior.
  */
-// eslint-disable-next-line react/prop-types
 function PdfPage({ showPlaceholder = false }) {
   return (
     <div className="page">

--- a/src/shared/test/shortcut-test.js
+++ b/src/shared/test/shortcut-test.js
@@ -132,7 +132,6 @@ describe('shared/shortcut', () => {
   });
 
   describe('useShortcut', () => {
-    // eslint-disable-next-line react/prop-types
     function Button({ shortcut = null, onClick }) {
       useShortcut(shortcut, onClick);
       return <button onClick={onClick}>Shortcut test</button>;

--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -208,9 +208,7 @@ describe('ThreadList', () => {
         fakeTopThread.children.push({ id });
       }
 
-      // eslint-disable-next-line react/prop-types
       const FakeThreadCard = ({ thread }) => {
-        // eslint-disable-next-line react/prop-types
         const height = threadHeights[thread.id];
         return <div className="fake-ThreadCard" style={{ height }} />;
       };


### PR DESCRIPTION
Prop-types checks are now globally disabled because we're using JSDoc +
TS instead.