### PR TITLE
Kill gulp-karma process on Ctrl-C

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -352,6 +352,15 @@ function runKarma(done) {
     },
     done
   ).start();
+
+  process.on('SIGINT', () => {
+    // Give Karma a chance to handle SIGINT and cleanup, but forcibly
+    // exit if it takes too long.
+    setTimeout(() => {
+      done();
+      process.exit(1);
+    }, 5000);
+  });
 }
 
 // Unit and integration testing tasks.


### PR DESCRIPTION
The only way to kill `yarn test --watch` is sending a SIGINT via a
<kbd>Ctrl</kbd>+<kbd>C</kbd> keyboard shorcut. Killing karma process in
this way sometimes leaves the parent gulp process orphan. That's because
when karma is killed by SIGINT sometimes doesn't run the `done` in the
callback, hence leaving the gulp process waiting for the `done` signal.

On more rare occasions, I have seen orphan karma process too.

The solution presented here registers a listener for SIGINT and call the
`done` function. It doesn't unregister the event.