### PR TITLE
Add ability to open Notebook with keyboard from User Menu

### DIFF
--- a/src/sidebar/components/Menu.js
+++ b/src/sidebar/components/Menu.js
@@ -41,15 +41,21 @@ let ignoreNextClick = false;
  *   `false`, the consumer is responsible for positioning.
  * @prop {string} [contentClass] - Additional CSS classes to apply to the menu.
  * @prop {boolean} [defaultOpen] - Whether the menu is open or closed when initially rendered.
+ *   Ignored if `open` is present.
  * @prop {(open: boolean) => any} [onOpenChanged] - Callback invoked when the menu is
  *   opened or closed.  This can be used, for example, to reset any ephemeral state that the
  *   menu content may have.
+ * @prop {boolean} [open] - Whether the menu is currently open; overrides internal state
+ *   management for openness. External components managing state in this way should
+ *   also pass an `onOpenChanged` handler to respond when the user closes the menu.
  * @prop {string} title -
  *   A title for the menu. This is important for accessibility if the menu's toggle button
  *   has only an icon as a label.
  * @prop {boolean} [menuIndicator] -
  *   Whether to display an indicator next to the label that there is a dropdown menu.
  */
+
+const noop = () => {};
 
 /**
  * A drop-down menu.
@@ -79,11 +85,17 @@ export default function Menu({
   contentClass,
   defaultOpen = false,
   label,
+  open,
   onOpenChanged,
   menuIndicator = true,
   title,
 }) {
-  const [isOpen, setOpen] = useState(defaultOpen);
+  /** @type {[boolean, (open: boolean) => void]} */
+  let [isOpen, setOpen] = useState(defaultOpen);
+  if (typeof open === 'boolean') {
+    isOpen = open;
+    setOpen = onOpenChanged || noop;
+  }
 
   // Notify parent when menu is opened or closed.
   const wasOpen = useRef(isOpen);
@@ -109,6 +121,7 @@ export default function Menu({
       event.preventDefault();
       return;
     }
+
     setOpen(!isOpen);
   };
   const closeMenu = useCallback(() => setOpen(false), [setOpen]);

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -1,4 +1,5 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
+import { useState } from 'preact/hooks';
 
 import bridgeEvents from '../../shared/bridge-events';
 import serviceConfig from '../config/service-config';
@@ -44,6 +45,7 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
   const isThirdParty = isThirdPartyUser(auth.userid, settings.authDomain);
   const service = serviceConfig(settings);
   const isNotebookEnabled = store.isFeatureEnabled('notebook_launch');
+  const [isOpen, setOpen] = useState(false);
 
   const serviceSupports = feature => service && !!service[feature];
 
@@ -54,6 +56,15 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
 
   const onSelectNotebook = () => {
     bridge.call('openNotebook', store.focusedGroupId());
+  };
+
+  // Temporary access to the Notebook without feature flag:
+  // type the key 'n' when user menu is focused/open
+  const onKeyDown = event => {
+    if (event.key === 'n') {
+      onSelectNotebook();
+      setOpen(false);
+    }
   };
 
   const onProfileSelected = () =>
@@ -77,8 +88,16 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
     </span>
   );
   return (
-    <div className="UserMenu">
-      <Menu label={menuLabel} title={auth.displayName} align="right">
+    // FIXME: KeyDown handling is temporary for Notebook "easter egg"
+    /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
+    <div className="UserMenu" onKeyDown={onKeyDown}>
+      <Menu
+        label={menuLabel}
+        title={auth.displayName}
+        align="right"
+        open={isOpen}
+        onOpenChanged={setOpen}
+      >
         <MenuSection>
           <MenuItem
             label={auth.displayName}

--- a/src/sidebar/components/test/Menu-test.js
+++ b/src/sidebar/components/test/Menu-test.js
@@ -54,6 +54,17 @@ describe('Menu', () => {
     assert.isFalse(isOpen(wrapper));
   });
 
+  it('leaves the management of open/closed state to parent component if `open` prop present', () => {
+    // When `open` is present, `Menu` will invoke `onOpenChanged` on interactions
+    // but will not modify the its open state directly.
+    const wrapper = createMenu({ open: true });
+
+    assert.isTrue(isOpen(wrapper));
+
+    wrapper.find('button').simulate('click');
+    assert.isTrue(isOpen(wrapper));
+  });
+
   it('calls `onOpenChanged` prop when menu is opened or closed', () => {
     const onOpenChanged = sinon.stub();
     const wrapper = createMenu({ onOpenChanged });
@@ -70,6 +81,12 @@ describe('Menu', () => {
     wrapper.find('button').simulate('mousedown');
     // Make sure the follow-up click doesn't close the menu.
     wrapper.find('button').simulate('click');
+
+    assert.isTrue(isOpen(wrapper));
+  });
+
+  it('gives precedence to `open` over `defaultOpen`', () => {
+    const wrapper = createMenu({ open: true, defaultOpen: false });
 
     assert.isTrue(isOpen(wrapper));
   });

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -1,4 +1,5 @@
 import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
 
 import bridgeEvents from '../../../shared/bridge-events';
 import UserMenu from '../UserMenu';
@@ -205,6 +206,22 @@ describe('UserMenu', () => {
         openNotebookItem.props().onClick();
         assert.calledOnce(fakeBridge.call);
         assert.calledWith(fakeBridge.call, 'openNotebook', 'mygroup');
+      });
+
+      it('opens the notebook and closes itself when `n` is typed', () => {
+        const wrapper = createUserMenu();
+        // Make the menu "open"
+        act(() => {
+          wrapper.find('Menu').props().onOpenChanged(true);
+        });
+        wrapper.update();
+        assert.isTrue(wrapper.find('Menu').props().open);
+
+        wrapper.find('.UserMenu').simulate('keydown', { key: 'n' });
+        assert.calledOnce(fakeBridge.call);
+        assert.calledWith(fakeBridge.call, 'openNotebook', 'mygroup');
+        // Now the menu is "closed" again
+        assert.isFalse(wrapper.find('Menu').props().open);
       });
     });
 


### PR DESCRIPTION
This PR provides the ability for any user to open the Notebook by using a keyboard command, regardless of feature-flag status. If the UserMenu is open or focused, and the user types `n`, the Notebook will open. This will allow easier access in more contexts, where managing access via feature flags is cumbersome. Primarily this will aid the support and success folks.

These changes include some changes to the `Menu` component to allow parent components to manage the Menu's open/closed state. This allows the UserMenu to close its menu when the Notebook is opened.

To test:

* Turn off the Notebook-related [feature flag locally](http://localhost:5000/admin/features), though technically that's orthogonal to these changes. It can help you feel confident that the Notebook itself is not somehow feature-flag-proteced.
* In your local dev client, open the user menu and type `n`.

Fixes https://github.com/hypothesis/client/issues/3123