### PR TITLE
Display message when too many annotations to show in Notebook

### DIFF
--- a/src/sidebar/components/Panel.js
+++ b/src/sidebar/components/Panel.js
@@ -1,0 +1,39 @@
+import { SvgIcon } from '@hypothesis/frontend-shared';
+
+import Button from './Button';
+
+/**
+ * @typedef PanelProps
+ * @prop {import("preact").ComponentChildren} children
+ * @prop {string} [icon] - Name of optional icon to render in header
+ * @prop {() => any} [onClose] - handler for closing the panel; if provided,
+ *   will render a close button that invokes this onClick
+ * @prop {string} title
+ */
+
+/**
+ * Render a "panel"-like interface
+ *
+ * @param {PanelProps} props
+ */
+export default function Panel({ children, icon, onClose, title }) {
+  const withCloseButton = typeof onClose === 'function';
+  return (
+    <div className="Panel">
+      <div className="Panel__header">
+        {icon && (
+          <div className="Panel__header-icon">
+            <SvgIcon name={icon} title={title} />
+          </div>
+        )}
+        <h2 className="Panel__title u-stretch">{title}</h2>
+        {withCloseButton && (
+          <div>
+            <Button icon="cancel" buttonText="Close" onClick={onClose} />
+          </div>
+        )}
+      </div>
+      <div className="Panel__content">{children}</div>
+    </div>
+  );
+}

--- a/src/sidebar/components/SidebarPanel.js
+++ b/src/sidebar/components/SidebarPanel.js
@@ -1,10 +1,9 @@
-import { SvgIcon } from '@hypothesis/frontend-shared';
-import { useEffect, useRef } from 'preact/hooks';
+import { useCallback, useEffect, useRef } from 'preact/hooks';
 import scrollIntoView from 'scroll-into-view';
 
 import { useStoreProxy } from '../store/use-store';
 
-import Button from './Button';
+import Panel from './Panel';
 import Slider from './Slider';
 
 /**
@@ -13,22 +12,19 @@ import Slider from './Slider';
 
 /**
  * @typedef SidebarPanelProps
- * @prop {Object} [children]
+ * @prop {import("preact").ComponentChildren} children
  * @prop {string} [icon] - An optional icon name for display next to the panel's title
  * @prop {PanelName} panelName -
  *   A string identifying this panel. Only one `panelName` may be active at any time.
  *   Multiple panels with the same `panelName` would be "in sync", opening and closing together.
- * @prop {string} title - The panel's title: rendered in its containing visual "frame"
+ * @prop {string} title - The panel's title
  * @prop {(active: boolean) => any} [onActiveChanged] -
  *   Optional callback to invoke when this panel's active status changes
  */
 
 /**
- * Base component for a sidebar panel.
- *
- * This component provides a basic visual container for sidebar panels, as well
- * as providing a close button. Only one sidebar panel (as defined by the panel's
- * `panelName`) is active at one time.
+ * Base component for a sidebar panel. Only one sidebar panel
+ * (as defined by the panel's `panelName`) is active (visible) at one time.
  *
  * @param {SidebarPanelProps} props
  */
@@ -58,25 +54,16 @@ export default function SidebarPanel({
     }
   }, [panelIsActive, onActiveChanged]);
 
-  const closePanel = () => {
+  const closePanel = useCallback(() => {
     store.toggleSidebarPanel(panelName, false);
-  };
+  }, [store, panelName]);
 
   return (
     <Slider visible={panelIsActive}>
-      <div className="SidebarPanel" ref={panelElement}>
-        <div className="SidebarPanel__header">
-          {icon && (
-            <div className="SidebarPanel__header-icon">
-              <SvgIcon name={icon} title={title} />
-            </div>
-          )}
-          <h2 className="SidebarPanel__title u-stretch">{title}</h2>
-          <div>
-            <Button icon="cancel" buttonText="Close" onClick={closePanel} />
-          </div>
-        </div>
-        <div className="SidebarPanel__content">{children}</div>
+      <div ref={panelElement}>
+        <Panel title={title} icon={icon} onClose={closePanel}>
+          {children}
+        </Panel>
       </div>
     </Slider>
   );

--- a/src/sidebar/components/test/NotebookView-test.js
+++ b/src/sidebar/components/test/NotebookView-test.js
@@ -3,6 +3,7 @@ import { act } from 'preact/test-utils';
 
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
+import { ResultSizeError } from '../../search-client';
 import NotebookView, { $imports } from '../NotebookView';
 
 describe('NotebookView', () => {
@@ -60,6 +61,7 @@ describe('NotebookView', () => {
         maxResults: 5000,
         sortBy: 'updated',
         sortOrder: 'desc',
+        onError: sinon.match.func,
       })
     );
     assert.calledWith(fakeStore.setSortKey, 'Newest');
@@ -78,6 +80,7 @@ describe('NotebookView', () => {
         maxResults: 5000,
         sortBy: 'updated',
         sortOrder: 'desc',
+        onError: sinon.match.func,
       })
     );
   });
@@ -89,6 +92,20 @@ describe('NotebookView', () => {
     createComponent();
 
     assert.notCalled(fakeLoadAnnotationsService.load);
+  });
+
+  it('shows a message if too many annotations to load', () => {
+    // Simulate the loading service emitting an error indicating
+    // too many annotations to load
+    fakeLoadAnnotationsService.load.callsFake(options => {
+      options.onError(new ResultSizeError(5000));
+    });
+    fakeStore.focusedGroup.returns({ id: 'hallothere', name: 'Hallo' });
+    const wrapper = createComponent();
+
+    const message = wrapper.find('.NotebookView__messages');
+    assert.include(message.text(), 'up to 5000 results at a time');
+    assert.isTrue(message.exists());
   });
 
   it('renders the current group name', () => {

--- a/src/sidebar/components/test/Panel-test.js
+++ b/src/sidebar/components/test/Panel-test.js
@@ -1,0 +1,68 @@
+import { mount } from 'enzyme';
+
+import Panel from '../Panel';
+import { $imports } from '../Panel';
+
+import { checkAccessibility } from '../../../test-util/accessibility';
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+
+describe('Panel', () => {
+  const createPanel = props =>
+    mount(
+      <Panel title="Test Panel" {...props}>
+        Test panel
+      </Panel>
+    );
+
+  beforeEach(() => {
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('renders the provided title', () => {
+    const wrapper = createPanel({ title: 'My Panel' });
+    const titleEl = wrapper.find('.Panel__title');
+    assert.equal(titleEl.text(), 'My Panel');
+  });
+
+  it('renders an icon if provided', () => {
+    const wrapper = createPanel({ icon: 'restricted' });
+
+    const icon = wrapper.find('SvgIcon').filter({ name: 'restricted' });
+
+    assert.isTrue(icon.exists());
+  });
+
+  context('when `onClose` is provided', () => {
+    it('renders a close button', () => {
+      const wrapper = createPanel({
+        onClose: sinon.stub(),
+      });
+
+      const closeButton = wrapper.find('Button');
+      assert.isTrue(closeButton.exists());
+      assert.equal(closeButton.props().buttonText, 'Close');
+    });
+
+    it('invokes `onClose` handler when close button is clicked', () => {
+      const onClose = sinon.stub();
+      const wrapper = createPanel({
+        onClose,
+      });
+
+      wrapper.find('Button').props().onClick();
+
+      assert.calledOnce(onClose);
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createPanel(),
+    })
+  );
+});

--- a/src/sidebar/components/test/SidebarPanel-test.js
+++ b/src/sidebar/components/test/SidebarPanel-test.js
@@ -37,24 +37,22 @@ describe('SidebarPanel', () => {
     $imports.$restore();
   });
 
-  it('renders the provided title', () => {
-    const wrapper = createSidebarPanel({ title: 'My Panel' });
-    const titleEl = wrapper.find('.SidebarPanel__title');
-    assert.equal(titleEl.text(), 'My Panel');
+  it('renders a panel with provided title and icon', () => {
+    const wrapper = createSidebarPanel({
+      title: 'My Panel',
+      icon: 'restricted',
+    });
+
+    const panel = wrapper.find('Panel');
+
+    assert.equal(panel.props().icon, 'restricted');
+    assert.equal(panel.props().title, 'My Panel');
   });
 
-  it('renders an icon if provided', () => {
-    const wrapper = createSidebarPanel({ icon: 'restricted' });
-
-    const icon = wrapper.find('SvgIcon').filter({ name: 'restricted' });
-
-    assert.isTrue(icon.exists());
-  });
-
-  it('closes the panel when close button is clicked', () => {
+  it('provides an `onClose` handler that closes the panel', () => {
     const wrapper = createSidebarPanel({ panelName: 'flibberty' });
 
-    wrapper.find('Button').props().onClick();
+    wrapper.find('Panel').props().onClose();
 
     assert.calledWith(fakeStore.toggleSidebarPanel, 'flibberty', false);
   });

--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -19,9 +19,11 @@
  *   with the expected presentation order of annotations/threads in the current
  *   view.
  * @prop {SortOrder} [sortOrder]
+ * @prop {(error: Error) => any} [onError] - Optional error handler for
+ *   SearchClient. Default error handling logs errors to console.
  */
 
-import SearchClient from '../search-client';
+import { SearchClient } from '../search-client';
 
 import { isReply } from '../helpers/annotation-metadata';
 
@@ -43,7 +45,7 @@ export default function loadAnnotationsService(
    * @param {LoadAnnotationOptions} options
    */
   function load(options) {
-    const { groupId, uris } = options;
+    const { groupId, onError, uris } = options;
     store.removeAnnotations(store.savedAnnotations());
 
     // Cancel previously running search client.
@@ -93,7 +95,11 @@ export default function loadAnnotationsService(
     });
 
     searchClient.on('error', error => {
-      console.error(error);
+      if (typeof onError === 'function') {
+        onError(error);
+      } else {
+        console.error(error);
+      }
     });
 
     searchClient.on('end', () => {

--- a/src/sidebar/services/test/load-annotations-test.js
+++ b/src/sidebar/services/test/load-annotations-test.js
@@ -85,7 +85,9 @@ describe('loadAnnotationsService', () => {
 
     fakeUris = ['http://example.com'];
     $imports.$mock({
-      '../search-client': FakeSearchClient,
+      '../search-client': {
+        SearchClient: FakeSearchClient,
+      },
     });
   });
 
@@ -304,7 +306,7 @@ describe('loadAnnotationsService', () => {
       assert.calledOnce(fakeStore.annotationFetchFinished);
     });
 
-    it('logs an error to the console if the search client runs into an error', () => {
+    it('logs an error by default to the console if the search client emits an error', () => {
       const svc = createService();
       const error = new Error('search for annotations failed');
 
@@ -312,6 +314,17 @@ describe('loadAnnotationsService', () => {
       searchClients[0].emit('error', error);
 
       assert.calledWith(console.error, error);
+    });
+
+    it('invokes error callback, if provided, when search client emits an error', () => {
+      const svc = createService();
+      const onError = sinon.stub();
+      const error = new Error('Something went wrong');
+
+      svc.load({ groupId: fakeGroupId, uris: fakeUris, onError });
+      searchClients[0].emit('error', error);
+
+      assert.calledWith(onError, error);
     });
   });
 

--- a/src/sidebar/test/search-client-test.js
+++ b/src/sidebar/test/search-client-test.js
@@ -1,4 +1,4 @@
-import SearchClient from '../search-client';
+import { ResultSizeError, SearchClient } from '../search-client';
 
 function awaitEvent(emitter, event) {
   return new Promise(function (resolve) {
@@ -218,10 +218,7 @@ describe('SearchClient', () => {
       await awaitEvent(client, 'end');
 
       assert.calledOnce(onError);
-      assert.equal(
-        onError.getCall(0).args[0].message,
-        'Results size exceeds maximum allowed annotations'
-      );
+      assert.instanceOf(onError.getCall(0).args[0], ResultSizeError);
     });
 
     it('does not emit an error if results size is <= `maxResults`', async () => {

--- a/src/styles/sidebar/components/NotebookView.scss
+++ b/src/styles/sidebar/components/NotebookView.scss
@@ -52,5 +52,9 @@
       justify-self: end;
       align-self: flex-end;
     }
+
+    &__messages {
+      padding: 1em 0;
+    }
   }
 }

--- a/src/styles/sidebar/components/Panel.scss
+++ b/src/styles/sidebar/components/Panel.scss
@@ -1,0 +1,7 @@
+@use "../../mixins/molecules";
+
+.Panel {
+  @include molecules.panel;
+  position: relative;
+  margin-bottom: 0.75em;
+}

--- a/src/styles/sidebar/components/SidebarPanel.scss
+++ b/src/styles/sidebar/components/SidebarPanel.scss
@@ -1,7 +1,0 @@
-@use "../../mixins/molecules";
-
-.SidebarPanel {
-  @include molecules.panel;
-  position: relative;
-  margin-bottom: 0.75em;
-}

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -48,7 +48,6 @@
 @use './components/SearchInput';
 @use './components/ShareLinks';
 @use './components/SidebarContentError';
-@use './components/SidebarPanel';
 @use './components/Spinner';
 @use './components/TagEditor';
 @use './components/TagList';

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -42,6 +42,7 @@
 @use './components/NotebookView';
 @use './components/NotebookResultCount';
 @use './components/PaginationNavigation';
+@use './components/Panel';
 @use './components/SelectionTabs';
 @use './components/ShareAnnotationsPanel';
 @use './components/SearchInput';


### PR DESCRIPTION
This draft PR starts the work of showing a user-friendly message if there are too many annotations in a group to show within the Notebook at present (current max: 5000).

Initial screenshots. _Note_: Wording is totally preliminary. More on that shortly. Also note that I've dialed down the `maxResults` to 5 here to be able to show the error, but it would normally be 5000.

Wider screens:

![image](https://user-images.githubusercontent.com/439947/111361005-c894a080-8663-11eb-8148-f68fb976091b.png)

Narrower screens:

![image](https://user-images.githubusercontent.com/439947/111361041-d2b69f00-8663-11eb-963a-3c7438667d83.png)

### Implementation Notes

* Makes `LoadAnnotationService#load` take an optional `onError` handler for when the `SearchClient` emits an error. This allows for alternate error handling than `console.error`
* Updates `search-client` to emit a `resultCount` before an `error` on `maxResults` to allow handling code to know how many annotations it was _trying_ to retrieve.
* Adds a generic `Panel` component that is also used by `SidebarPanel`
* Updates the `NotebookView` to render a `Panel` if there are too many annotations to show.

### Next Steps

* [x] Get product owner input on how to word this and stylistic approval. I can contribute to wordsmithing but need some guidance about level of levity allowed, tone, whatnot.
* [x] Get technical feedback and general acceptance on approach
* [x] Write tests and clean up

When it's ready and lands it:

Fixes https://github.com/hypothesis/client/issues/3124