### PR TITLE
Set codecov to fail if not 100% per patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,11 @@ coverage:
       default:
         # prevent spurious codecov errors resulting from tiny fluctuations
         threshold: 0.1%
+    patch:
+      default:
+        # basic
+        target: 100%
+        threshold: 0%
+        # advanced
+        if_ci_failed: error
+        only_pulls: false


### PR DESCRIPTION
This sets the patch requirement to 100% coverage or otherwise fails CI. 

This may not do what you expect. For example if the patch only removes tests and reduces coverage overall, it may still pass the patch test because inside the patch itself is 100% coverage on src file changes (because there are none). 

The overall coverage project test still needs to be 0.1% relative to the baseline (this is unchanged)