### PR TITLE
Modernize `SearchClient` code and improve docs

### DIFF
--- a/src/sidebar/test/search-client-test.js
+++ b/src/sidebar/test/search-client-test.js
@@ -6,6 +6,10 @@ function awaitEvent(emitter, event) {
   });
 }
 
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 describe('SearchClient', () => {
   const RESULTS = [
     { id: 'one' },
@@ -142,6 +146,19 @@ describe('SearchClient', () => {
     return awaitEvent(client, 'end').then(() => {
       assert.calledWith(onError, err);
     });
+  });
+
+  it('does not emit "error" event if search is canceled before it fails', async () => {
+    fakeSearchFn = () => Promise.reject(new Error('search failed'));
+    const client = new SearchClient(fakeSearchFn);
+    const onError = sinon.stub();
+    client.on('error', onError);
+
+    client.get({ uri: 'http://example.com' });
+    client.cancel();
+    await delay(0);
+
+    assert.notCalled(onError);
   });
 
   context('`maxResults` option present', () => {

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -136,5 +136,34 @@
  * @prop {boolean} canLeave
  */
 
+/**
+ * Query parameters for an `/api/search` API call.
+ *
+ * This type currently includes params that we've actually used.
+ *
+ * See https://h.readthedocs.io/en/latest/api-reference/#tag/annotations/paths/~1search/get
+ * for the complete list and usage of each.
+ *
+ * @typedef SearchQuery
+ * @prop {string[]} [uri]
+ * @prop {string} [group]
+ * @prop {string} [references]
+ * @prop {number} [offset]
+ * @prop {number} [limit]
+ * @prop {string} [order]
+ * @prop {string} [sort]
+ */
+
+/**
+ * Response to an `/api/search` API call.
+ *
+ * See https://h.readthedocs.io/en/latest/api-reference/#tag/annotations/paths/~1search/get
+ *
+ * @typedef SearchResult
+ * @prop {number} total
+ * @prop {Annotation[]} rows
+ * @prop {Annotation[]} [replies]
+ */
+
 // Make TypeScript treat this file as a module.
 export const unused = {};

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -152,6 +152,8 @@
  * @prop {number} [limit]
  * @prop {string} [order]
  * @prop {string} [sort]
+ * @prop {boolean} [_separate_replies] - Unofficial param that causes replies
+ *   to be returned in a separate `replies` field
  */
 
 /**
@@ -162,7 +164,8 @@
  * @typedef SearchResult
  * @prop {number} total
  * @prop {Annotation[]} rows
- * @prop {Annotation[]} [replies]
+ * @prop {Annotation[]} [replies] - Unofficial property that is populated if
+ *   `_separate_replies` query param was specified
  */
 
 // Make TypeScript treat this file as a module.


### PR DESCRIPTION
Make the code easier to follow and update by modernizing it to ES6+ and
linking to relevant Hypothesis API documentation.

 - Replace `self` with arrow-functions + `this`
 - Replace promise chains with async/await
 - Document the type of the `query` param to search requests
 - Add links to relevant Hypothesis API documentation