### PR TITLE
Fix display names in Notebook user filter

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationHeader.js
+++ b/src/sidebar/components/Annotation/AnnotationHeader.js
@@ -53,10 +53,10 @@ function AnnotationHeader({
   settings,
 }) {
   const store = useStoreProxy();
-  const authDomain = store.authDomain();
+  const defaultAuthority = store.defaultAuthority();
   const displayNamesEnabled = store.isFeatureEnabled('client_display_names');
 
-  const isThirdParty = isThirdPartyUser(annotation.user, authDomain);
+  const isThirdParty = isThirdPartyUser(annotation.user, defaultAuthority);
   const authorDisplayName = annotationDisplayName(
     annotation,
     isThirdParty,

--- a/src/sidebar/components/Annotation/AnnotationUser.js
+++ b/src/sidebar/components/Annotation/AnnotationUser.js
@@ -1,19 +1,11 @@
-import { isThirdPartyUser, username } from '../../helpers/account-id';
-import { annotationDisplayName } from '../../helpers/annotation-user';
-import { withServices } from '../../service-context';
-
 /**
  * @typedef {import("../../../types/api").Annotation} Annotation
- * @typedef {import('../../../types/config').MergedConfig} MergedConfig
- * @typedef {import('../../services/service-url').ServiceUrlGetter} ServiceUrlGetter
  */
 
 /**
  * @typedef AnnotationUserProps
- * @prop {Annotation} annotation - The annotation whose user is relevant
- * @prop {Object} features - Injected service
- * @prop {ServiceUrlGetter} serviceUrl - Injected service
- * @prop {MergedConfig} settings - Injected service
+ * @prop {string} [authorLink]
+ * @prop {string} displayName
  */
 
 /**
@@ -22,30 +14,13 @@ import { withServices } from '../../service-context';
  *
  * @param {AnnotationUserProps} props
  */
-function AnnotationUser({ annotation, features, serviceUrl, settings }) {
-  const user = annotation.user;
-  const isFirstPartyUser = !isThirdPartyUser(user, settings.authDomain);
-  const username_ = username(user);
-
-  // How should the user's name be displayed?
-  const displayName = annotationDisplayName(
-    annotation,
-    !isFirstPartyUser,
-    features.flagEnabled('client_display_names')
-  );
-
-  const shouldLinkToActivity = isFirstPartyUser || settings.usernameUrl;
-
-  if (shouldLinkToActivity) {
+function AnnotationUser({ authorLink, displayName }) {
+  if (authorLink) {
     return (
       <div className="AnnotationUser">
         <a
           className="AnnotationUser__link"
-          href={
-            isFirstPartyUser
-              ? serviceUrl('user', { user })
-              : `${settings.usernameUrl}${username_}`
-          }
+          href={authorLink}
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -62,6 +37,4 @@ function AnnotationUser({ annotation, features, serviceUrl, settings }) {
   );
 }
 
-AnnotationUser.injectedProps = ['features', 'serviceUrl', 'settings'];
-
-export default withServices(AnnotationUser);
+export default AnnotationUser;

--- a/src/sidebar/components/Annotation/AnnotationUser.js
+++ b/src/sidebar/components/Annotation/AnnotationUser.js
@@ -1,4 +1,5 @@
 import { isThirdPartyUser, username } from '../../helpers/account-id';
+import { annotationDisplayName } from '../../helpers/annotation-user';
 import { withServices } from '../../service-context';
 
 /**
@@ -27,15 +28,11 @@ function AnnotationUser({ annotation, features, serviceUrl, settings }) {
   const username_ = username(user);
 
   // How should the user's name be displayed?
-  const displayName = (() => {
-    if (isFirstPartyUser && !features.flagEnabled('client_display_names')) {
-      return username_;
-    }
-    if (annotation.user_info && annotation.user_info.display_name) {
-      return annotation.user_info.display_name;
-    }
-    return username_;
-  })();
+  const displayName = annotationDisplayName(
+    annotation,
+    !isFirstPartyUser,
+    features.flagEnabled('client_display_names')
+  );
 
   const shouldLinkToActivity = isFirstPartyUser || settings.usernameUrl;
 

--- a/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
@@ -51,7 +51,7 @@ describe('AnnotationHeader', () => {
     fakeSettings = { usernameUrl: 'http://foo.bar/' };
 
     fakeStore = {
-      authDomain: sinon.stub().returns('foo.com'),
+      defaultAuthority: sinon.stub().returns('foo.com'),
       isFeatureEnabled: sinon.stub().returns(false),
       route: sinon.stub().returns('sidebar'),
       setExpanded: sinon.stub(),

--- a/src/sidebar/components/Annotation/test/AnnotationUser-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationUser-test.js
@@ -7,6 +7,7 @@ import AnnotationUser, { $imports } from '../AnnotationUser';
 
 describe('AnnotationUser', () => {
   let fakeAnnotation;
+  let fakeAnnotationUser;
   let fakeFeatures;
   let fakeIsThirdPartyUser;
   let fakeServiceUrl;
@@ -28,6 +29,11 @@ describe('AnnotationUser', () => {
     fakeAnnotation = {
       user: 'someone@hypothes.is',
     };
+    fakeAnnotationUser = {
+      annotationDisplayName: sinon
+        .stub()
+        .callsFake(annotation => annotation.user),
+    };
     fakeFeatures = { flagEnabled: sinon.stub() };
     fakeIsThirdPartyUser = sinon.stub().returns(false);
     fakeServiceUrl = sinon.stub();
@@ -40,6 +46,7 @@ describe('AnnotationUser', () => {
         isThirdPartyUser: fakeIsThirdPartyUser,
         username: fakeUsername,
       },
+      '../../helpers/annotation-user': fakeAnnotationUser,
     });
   });
 
@@ -89,58 +96,17 @@ describe('AnnotationUser', () => {
     });
   });
 
-  describe('rendered user name', () => {
-    context('feature flag on', () => {
-      beforeEach(() => {
-        fakeFeatures.flagEnabled.withArgs('client_display_names').returns(true);
-      });
-      it('should render a display name when feature flag on and info available', () => {
-        fakeAnnotation.user_info = {
-          display_name: 'Maple Oaks',
-        };
+  it('renders the annotation author name', () => {
+    fakeFeatures.flagEnabled.withArgs('client_display_names').returns(true);
 
-        const wrapper = createAnnotationUser();
-        const linkEl = wrapper.find('a');
+    createAnnotationUser();
 
-        assert.equal(linkEl.text(), 'Maple Oaks');
-      });
-
-      it('should render a username when feature flag on but info not present', () => {
-        fakeUsername.returns('myusername');
-
-        const wrapper = createAnnotationUser();
-        const linkEl = wrapper.find('a');
-
-        assert.equal(linkEl.text(), 'myusername');
-      });
-    });
-
-    context('feature flag off', () => {
-      it('should render a username for first-party users when feature flag off', () => {
-        fakeFeatures.flagEnabled.returns(false);
-        fakeUsername.returns('myusername');
-        fakeAnnotation.user_info = {
-          display_name: 'Maple Oaks',
-        };
-
-        const wrapper = createAnnotationUser();
-        const linkEl = wrapper.find('a');
-
-        assert.equal(linkEl.text(), 'myusername');
-      });
-
-      it('should render a display name for third-party users', () => {
-        fakeAnnotation.user_info = {
-          display_name: 'Maple Oaks',
-        };
-        fakeIsThirdPartyUser.returns(true);
-        fakeFeatures.flagEnabled.returns(false);
-
-        const wrapper = createAnnotationUser();
-
-        assert.equal(wrapper.text(), 'Maple Oaks');
-      });
-    });
+    assert.calledWith(
+      fakeAnnotationUser.annotationDisplayName,
+      fakeAnnotation,
+      false,
+      true
+    );
   });
 
   it(

--- a/src/sidebar/components/Annotation/test/AnnotationUser-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationUser-test.js
@@ -1,112 +1,32 @@
 import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
-import mockImportedComponents from '../../../../test-util/mock-imported-components';
 
-import AnnotationUser, { $imports } from '../AnnotationUser';
+import AnnotationUser from '../AnnotationUser';
 
 describe('AnnotationUser', () => {
-  let fakeAnnotation;
-  let fakeAnnotationUser;
-  let fakeFeatures;
-  let fakeIsThirdPartyUser;
-  let fakeServiceUrl;
-  let fakeSettings;
-  let fakeUsername;
-
-  const createAnnotationUser = () => {
-    return mount(
-      <AnnotationUser
-        annotation={fakeAnnotation}
-        features={fakeFeatures}
-        serviceUrl={fakeServiceUrl}
-        settings={fakeSettings}
-      />
-    );
+  const createAnnotationUser = props => {
+    return mount(<AnnotationUser displayName="Filbert Bronzo" {...props} />);
   };
 
-  beforeEach(() => {
-    fakeAnnotation = {
-      user: 'someone@hypothes.is',
-    };
-    fakeAnnotationUser = {
-      annotationDisplayName: sinon
-        .stub()
-        .callsFake(annotation => annotation.user),
-    };
-    fakeFeatures = { flagEnabled: sinon.stub() };
-    fakeIsThirdPartyUser = sinon.stub().returns(false);
-    fakeServiceUrl = sinon.stub();
-    fakeSettings = {};
-    fakeUsername = sinon.stub();
-
-    $imports.$mock(mockImportedComponents());
-    $imports.$mock({
-      '../../helpers/account-id': {
-        isThirdPartyUser: fakeIsThirdPartyUser,
-        username: fakeUsername,
-      },
-      '../../helpers/annotation-user': fakeAnnotationUser,
-    });
-  });
-
-  afterEach(() => {
-    $imports.$restore();
-  });
-
-  describe('link to user activity', () => {
-    context('first-party user', () => {
-      it('should provide a link to the user profile', () => {
-        fakeIsThirdPartyUser.returns(false);
-        fakeServiceUrl.returns('link-to-user');
-
-        const wrapper = createAnnotationUser();
-        const linkEl = wrapper.find('a');
-
-        assert.isOk(linkEl.exists());
-        assert.calledWith(fakeServiceUrl, 'user', {
-          user: fakeAnnotation.user,
-        });
-        assert.equal(linkEl.prop('href'), 'link-to-user');
-      });
+  it('links to the author activity page if link provided', () => {
+    const wrapper = createAnnotationUser({
+      authorLink: 'http://www.foo.bar/baz',
     });
 
-    context('third-party user', () => {
-      beforeEach(() => {
-        fakeIsThirdPartyUser.returns(true);
-      });
-
-      it('should link to user if `settings.usernameUrl` is set', () => {
-        fakeSettings.usernameUrl = 'http://example.com?user=';
-        fakeUsername.returns('elephant');
-
-        const wrapper = createAnnotationUser();
-        const linkEl = wrapper.find('a');
-
-        assert.isOk(linkEl.exists());
-        assert.equal(linkEl.prop('href'), 'http://example.com?user=elephant');
-      });
-
-      it('should not link to user if `settings.usernameUrl` is not set', () => {
-        const wrapper = createAnnotationUser();
-        const linkEl = wrapper.find('a');
-
-        assert.isNotOk(linkEl.exists());
-      });
-    });
+    assert.isTrue(wrapper.find('a[href="http://www.foo.bar/baz"]').exists());
   });
 
-  it('renders the annotation author name', () => {
-    fakeFeatures.flagEnabled.withArgs('client_display_names').returns(true);
+  it('does not link to the author activity page if no link provided', () => {
+    const wrapper = createAnnotationUser();
 
-    createAnnotationUser();
+    assert.isFalse(wrapper.find('a').exists());
+  });
 
-    assert.calledWith(
-      fakeAnnotationUser.annotationDisplayName,
-      fakeAnnotation,
-      false,
-      true
-    );
+  it('renders the author name', () => {
+    const wrapper = createAnnotationUser();
+
+    assert.equal(wrapper.text(), 'Filbert Bronzo');
   });
 
   it(

--- a/src/sidebar/components/hooks/test/use-filter-options-test.js
+++ b/src/sidebar/components/hooks/test/use-filter-options-test.js
@@ -52,7 +52,7 @@ describe('sidebar/components/hooks/use-user-filter-options', () => {
 
     fakeStore = {
       allAnnotations: sinon.stub().returns([]),
-      authDomain: sinon.stub().returns('foo.com'),
+      defaultAuthority: sinon.stub().returns('foo.com'),
       getFocusFilters: sinon.stub().returns({}),
       isFeatureEnabled: sinon.stub().returns(false),
       profile: sinon.stub().returns({}),

--- a/src/sidebar/components/hooks/use-filter-options.js
+++ b/src/sidebar/components/hooks/use-filter-options.js
@@ -15,7 +15,7 @@ import { annotationDisplayName } from '../../helpers/annotation-user';
 export function useUserFilterOptions() {
   const store = useStoreProxy();
   const annotations = store.allAnnotations();
-  const authDomain = store.authDomain();
+  const defaultAuthority = store.defaultAuthority();
   const displayNamesEnabled = store.isFeatureEnabled('client_display_names');
   const focusFilters = store.getFocusFilters();
   const currentUsername = username(store.profile().userid);
@@ -27,7 +27,7 @@ export function useUserFilterOptions() {
       const username_ = username(annotation.user);
       users[username_] = annotationDisplayName(
         annotation,
-        isThirdPartyUser(annotation.user, authDomain),
+        isThirdPartyUser(annotation.user, defaultAuthority),
         displayNamesEnabled
       );
     });
@@ -64,8 +64,8 @@ export function useUserFilterOptions() {
     return userOptions;
   }, [
     annotations,
-    authDomain,
     currentUsername,
+    defaultAuthority,
     displayNamesEnabled,
     focusFilters.user,
   ]);

--- a/src/sidebar/helpers/account-id.js
+++ b/src/sidebar/helpers/account-id.js
@@ -31,17 +31,19 @@ export function username(user) {
 }
 
 /**
- * Returns true if the authority is of a 3rd party user.
+ * Returns true if the user's provider (authority) differs from the default
+ * authority for the application.
  *
  * @param {string} user
- * @param {string} authDomain
+ * @param {string} defaultAuthority - The application's default authority
+ *   (user identity provider)
  */
-export function isThirdPartyUser(user, authDomain) {
+export function isThirdPartyUser(user, defaultAuthority) {
   const account = parseAccountID(user);
 
   if (!account) {
     return false;
   }
 
-  return account.provider !== authDomain;
+  return account.provider !== defaultAuthority;
 }

--- a/src/sidebar/helpers/annotation-user.js
+++ b/src/sidebar/helpers/annotation-user.js
@@ -1,0 +1,34 @@
+/**
+ * @typedef {import("../../types/api").Annotation} Annotation
+ */
+
+import { username } from './account-id';
+
+/**
+ * What string should we use to represent the author (user) of a given
+ * annotation: a display name or a username?
+ *
+ * The nice, human-readable display name should be used when a display_name
+ * is available on the annotation AND:
+ * - The author (user) associated with the annotation is a third-party user, OR
+ * - The `client_display_names` feature flag is enabled
+ *
+ * Return the string that should be used for display on an annotation: either the
+ * username or the display name.
+ *
+ * @param {Pick<Annotation, 'user'|'user_info'>} annotation
+ * @param {boolean} isThirdPartyUser - Is the annotation's user third-party?
+ * @param {boolean} isFeatureFlagEnabled - Is the `client_display_names`
+ *   feature flag enabled
+ * @returns {string}
+ */
+export function annotationDisplayName(
+  annotation,
+  isThirdPartyUser,
+  isFeatureFlagEnabled
+) {
+  const useDisplayName = isFeatureFlagEnabled || isThirdPartyUser;
+  return useDisplayName && annotation.user_info?.display_name
+    ? annotation.user_info.display_name
+    : username(annotation.user);
+}

--- a/src/sidebar/helpers/test/annotation-user-test.js
+++ b/src/sidebar/helpers/test/annotation-user-test.js
@@ -1,0 +1,67 @@
+import { annotationDisplayName } from '../annotation-user';
+
+describe('sidebar/helpers/annotation-user', () => {
+  const fakeAnnotations = {
+    withDisplayName: {
+      user: 'acct:albert@victoriana.com',
+      user_info: { display_name: 'Albert, Prince Consort' },
+    },
+    noDisplayName: {
+      user: 'acct:albert@victoriana.com',
+      user_info: {},
+    },
+    noUserInfo: {
+      user: 'acct:albert@victoriana.com',
+    },
+  };
+
+  [
+    {
+      annotation: fakeAnnotations.withDisplayName,
+      isThirdParty: false,
+      isFeatureEnabled: false,
+      expected: 'albert',
+    },
+    {
+      annotation: fakeAnnotations.withDisplayName,
+      isThirdParty: true,
+      isFeatureEnabled: false,
+      expected: 'Albert, Prince Consort',
+    },
+    {
+      annotation: fakeAnnotations.withDisplayName,
+      isThirdParty: false,
+      isFeatureEnabled: true,
+      expected: 'Albert, Prince Consort',
+    },
+    {
+      annotation: fakeAnnotations.withDisplayName,
+      isThirdParty: true,
+      isFeatureEnabled: true,
+      expected: 'Albert, Prince Consort',
+    },
+    {
+      annotation: fakeAnnotations.noDisplayName,
+      isThirdParty: true,
+      isFeatureEnabled: true,
+      expected: 'albert',
+    },
+    {
+      annotation: fakeAnnotations.noUserInfo,
+      isThirdParty: true,
+      isFeatureEnabled: true,
+      expected: 'albert',
+    },
+  ].forEach(testCase => {
+    it('should return the appropriate author string for an annotation', () => {
+      assert.equal(
+        annotationDisplayName(
+          testCase.annotation,
+          testCase.isThirdParty,
+          testCase.isFeatureEnabled
+        ),
+        testCase.expected
+      );
+    });
+  });
+});

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -23,8 +23,16 @@ const initialProfile = {
   userid: null,
 };
 
-function init() {
+function init(settings) {
   return {
+    /**
+     * The app's authentication domain, from settings
+     * FIXME: This returns an empty string when `authDomain` is missing
+     * because other app logic has long assumed its string-y presence:
+     * behavior when it's missing is undefined. This setting should be
+     * enforced similarly to how `apiUrl` is enforced.
+     */
+    authDomain: settings?.authDomain ?? '',
     /**
      * Profile object fetched from the `/api/profile` endpoint.
      */
@@ -50,6 +58,14 @@ function updateProfile(profile) {
     type: actions.UPDATE_PROFILE,
     profile,
   };
+}
+
+/**
+ *
+ * @returns {string}
+ */
+function authDomain(state) {
+  return state.authDomain;
 }
 
 /**
@@ -103,6 +119,7 @@ export default storeModule({
   },
 
   selectors: {
+    authDomain,
     hasFetchedProfile,
     isFeatureEnabled,
     isLoggedIn,

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -26,13 +26,14 @@ const initialProfile = {
 function init(settings) {
   return {
     /**
-     * The app's authentication domain, from settings
+     * The app's default authority (user identity provider), from settings,
+     * e.g. `hypothes.is` or `localhost`
      * FIXME: This returns an empty string when `authDomain` is missing
      * because other app logic has long assumed its string-y presence:
      * behavior when it's missing is undefined. This setting should be
      * enforced similarly to how `apiUrl` is enforced.
      */
-    authDomain: settings?.authDomain ?? '',
+    defaultAuthority: settings?.authDomain ?? '',
     /**
      * Profile object fetched from the `/api/profile` endpoint.
      */
@@ -62,10 +63,10 @@ function updateProfile(profile) {
 
 /**
  *
- * @returns {string}
+ * @return {string}
  */
-function authDomain(state) {
-  return state.authDomain;
+function defaultAuthority(state) {
+  return state.defaultAuthority;
 }
 
 /**
@@ -119,7 +120,7 @@ export default storeModule({
   },
 
   selectors: {
-    authDomain,
+    defaultAuthority,
     hasFetchedProfile,
     isFeatureEnabled,
     isLoggedIn,

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -71,7 +71,9 @@ describe('sidebar/store/modules/groups', () => {
   let store;
 
   beforeEach(() => {
-    store = createStore([groups, session]);
+    // The empty second argument (settings) needed here because of the
+    // dependency on the `session` module
+    store = createStore([groups, session], [{}]);
   });
 
   describe('focusGroup', () => {

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -18,12 +18,12 @@ describe('sidebar/store/modules/session', () => {
     });
   });
 
-  describe('#authDomain', () => {
-    it('returns the authDomain from the settings', () => {
+  describe('#defaultAuthority', () => {
+    it('returns the default authority from the settings', () => {
       fakeSettings.authDomain = 'foo.com';
       store = createStore([session], [fakeSettings]);
 
-      assert.equal(store.authDomain(), 'foo.com');
+      assert.equal(store.defaultAuthority(), 'foo.com');
     });
   });
 

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -1,18 +1,29 @@
 import createStore from '../../create-store';
 import session from '../session';
 
-describe('sidebar/store/modules/session', function () {
+describe('sidebar/store/modules/session', () => {
+  let fakeSettings;
   let store;
 
   beforeEach(() => {
-    store = createStore([session]);
+    fakeSettings = {};
+    store = createStore([session], [fakeSettings]);
   });
 
-  describe('#updateProfile', function () {
-    it('updates the profile data', function () {
+  describe('#updateProfile', () => {
+    it('updates the profile data', () => {
       const newProfile = Object.assign({ userid: 'john' });
       store.updateProfile({ userid: 'john' });
       assert.deepEqual(store.profile(), newProfile);
+    });
+  });
+
+  describe('#authDomain', () => {
+    it('returns the authDomain from the settings', () => {
+      fakeSettings.authDomain = 'foo.com';
+      store = createStore([session], [fakeSettings]);
+
+      assert.equal(store.authDomain(), 'foo.com');
     });
   });
 


### PR DESCRIPTION
The Notebook was incorrectly rendering usernames instead of display names in the user filter in third-party contexts.

This was because of a mistaken belief that the feature flag (`client_display_names`) was the determining factor whether to use display names. It turns out that it is actually a combination of the feature flag and whether the annotation's author-user is first- or third-party. Display names should used for annotation authors in all third-party contexts, and in first-party contexts if the feature flag is enabled.

## To Test

1. Turn the `notebook_launch` feature flag _on_ (for convenience) and the `client_display_names` feature flag _off_ (important) in your [local h instance](http://localhost:5000/admin/features)
2. Spin up your LMS dev env
3. Launch a local LMS assignment in a course in which at least one user has made an annotation
4. Open the notebook

### Before

In LMS context:

* Names in the user-filtering dropdown are unreadable gibberish (usernames) (this is incorrect behavior)
* Names on annotation cards are nice display names (this is correct behavior)

In "regular" sidebar context (not LMS, locally):

* Names on annotation cards are usernames, not display names (this is correct behavior)

### After

In LMS context:

* *Names in the user-filtering dropdown are display names*
* Names on annotation cards are nice display names (no change)

In "regular" sidebar context (not LMS, locally):

* Names on annotation cards are usernames, not display names (no change)

Finally, turn the `client_display_names` feature flag back on in your local instance and walk through the above again. Display names should be used in all cases, including the sidebar.

## Implementation details

This logic ("Should we show a display name for this annotation's author-user?") existed in two places, and the Notebook's version was wrong. First goal: a single source of truth for this composite logic. Adding a helper module with function for this is one of the commits here.

To determine an annotation user's "party-ness" (is annotation's user first- or third-party?), the caller needs access to the current `authDomain`. This has existed on the `settings` object/service for some time, but as a convenience, I have made this available in the store's `session` module state. This obviates the need to have to pass or inject the `settings` service into the `use-filter-options` hook module. One less level of complexity. In doing this, I surfaced an issue with a lack of enforcement/validation of `authDomain` during boot; we've been assuming it's there and valid but not proving so. I noted this but did not take steps at this time to rectify.  This is another commit.

The last commit here is a refactor commit to bring `AnnotationUser` into line with the other "leaf" components under `AnnotationHeader` by making it a dumb component. This commit is not essential for this fix.

Fixes https://github.com/hypothesis/client/issues/3135