### PR TITLE
Update components to use store as source for `defaultAuthority`

### DIFF
--- a/src/sidebar/components/GroupList.js
+++ b/src/sidebar/components/GroupList.js
@@ -61,8 +61,9 @@ function GroupList({ serviceUrl, settings }) {
     [currentGroups]
   );
 
-  const { authDomain } = settings;
-  const canCreateNewGroup = userid && !isThirdPartyUser(userid, authDomain);
+  const defaultAuthority = store.defaultAuthority();
+  const canCreateNewGroup =
+    userid && !isThirdPartyUser(userid, defaultAuthority);
   const newGroupLink = serviceUrl('groups.new');
 
   // The group whose submenu is currently open, or `null` if no group item is

--- a/src/sidebar/components/TagList.js
+++ b/src/sidebar/components/TagList.js
@@ -1,4 +1,5 @@
 import { useMemo } from 'preact/hooks';
+import { useStoreProxy } from '../store/use-store';
 
 import { isThirdPartyUser } from '../helpers/account-id';
 import { withServices } from '../service-context';
@@ -10,18 +11,19 @@ import { withServices } from '../service-context';
  * @prop {Annotation} annotation - Annotation that owns the tags.
  * @prop {string[]} tags - List of tags as strings.
  * @prop {(a: string, b: Object<'tag', string>) => any} serviceUrl - Services
- * @prop {{ authDomain: string }} settings
  */
 
 /**
  * Component to render an annotation's tags.
  * @param {TagListProps} props
  */
-function TagList({ annotation, serviceUrl, settings, tags }) {
+function TagList({ annotation, serviceUrl, tags }) {
+  const store = useStoreProxy();
+  const defaultAuthority = store.defaultAuthority();
   const renderLink = useMemo(
     // Show a link if the authority of the user is not 3rd party
-    () => !isThirdPartyUser(annotation.user, settings.authDomain),
-    [annotation, settings]
+    () => !isThirdPartyUser(annotation.user, defaultAuthority),
+    [annotation, defaultAuthority]
   );
 
   /**
@@ -61,6 +63,6 @@ function TagList({ annotation, serviceUrl, settings, tags }) {
   );
 }
 
-TagList.injectedProps = ['serviceUrl', 'settings'];
+TagList.injectedProps = ['serviceUrl'];
 
 export default withServices(TagList);

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -42,7 +42,9 @@ import MenuSection from './MenuSection';
  */
 function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
   const store = useStoreProxy();
-  const isThirdParty = isThirdPartyUser(auth.userid, settings.authDomain);
+  const defaultAuthority = store.defaultAuthority();
+
+  const isThirdParty = isThirdPartyUser(auth.userid, defaultAuthority);
   const service = serviceConfig(settings);
   const isNotebookEnabled = store.isFeatureEnabled('notebook_launch');
   const [isOpen, setOpen] = useState(false);

--- a/src/sidebar/components/test/GroupList-test.js
+++ b/src/sidebar/components/test/GroupList-test.js
@@ -48,10 +48,9 @@ describe('GroupList', () => {
     };
 
     fakeServiceUrl = sinon.stub();
-    fakeSettings = {
-      authDomain: 'hypothes.is',
-    };
+    fakeSettings = {};
     fakeStore = {
+      defaultAuthority: sinon.stub().returns('hypothes.is'),
       getCurrentlyViewingGroups: sinon.stub().returns([]),
       getFeaturedGroups: sinon.stub().returns([]),
       getMyGroups: sinon.stub().returns([]),

--- a/src/sidebar/components/test/TagList-test.js
+++ b/src/sidebar/components/test/TagList-test.js
@@ -6,9 +6,10 @@ import { $imports } from '../TagList';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('TagList', function () {
+describe('TagList', () => {
   let fakeServiceUrl;
   let fakeIsThirdPartyUser;
+  let fakeStore;
   const fakeTags = ['tag1', 'tag2'];
 
   function createComponent(props) {
@@ -19,21 +20,25 @@ describe('TagList', function () {
         tags={fakeTags}
         // service props
         serviceUrl={fakeServiceUrl}
-        settings={{}}
         {...props}
       />
     );
   }
 
-  beforeEach(function () {
+  beforeEach(() => {
     fakeServiceUrl = sinon.stub().returns('http://serviceurl.com');
     fakeIsThirdPartyUser = sinon.stub().returns(false);
+
+    fakeStore = {
+      defaultAuthority: sinon.stub().returns('hypothes.is'),
+    };
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../helpers/account-id': {
         isThirdPartyUser: fakeIsThirdPartyUser,
       },
+      '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });
 
@@ -69,7 +74,7 @@ describe('TagList', function () {
   });
 
   context('when `isThirdPartyUser` returns true', () => {
-    beforeEach(function () {
+    beforeEach(() => {
       fakeIsThirdPartyUser.returns(true);
     });
 

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -47,10 +47,9 @@ describe('UserMenu', () => {
     fakeOnLogout = sinon.stub();
     fakeServiceConfig = sinon.stub();
     fakeServiceUrl = sinon.stub();
-    fakeSettings = {
-      authDomain: 'hypothes.is',
-    };
+    fakeSettings = {};
     fakeStore = {
+      defaultAuthority: sinon.stub().returns('hypothes.is'),
       focusedGroupId: sinon.stub().returns('mygroup'),
       isFeatureEnabled: sinon.stub().returns(false),
     };


### PR DESCRIPTION
This is a quick follow-on PR from #3140 (depends on #3140). Update references of `settings.authDomain` to use `store.defaultAuthority()` selector in a few components. Striking while the iron's hot.