### PR TITLE
Fetch annotations in parallel with the user profile and groups in the notebook

### DIFF
--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -34,11 +34,13 @@ function NotebookView({ loadAnnotationsService }) {
 
   const groupName = focusedGroup?.name ?? '…';
 
-  // Get the ID of the group to fetch annotations from. Once groups are fetched
-  // this is the same as the focused group ID. In the case where the notebook
-  // is configured to open with a specific group we can start fetching annotations
-  // sooner, without waiting for the group fetch to complete, by falling back
-  // to the initially-configured group.
+  // Get the ID of the group to fetch annotations from.
+  //
+  // Once groups have been fetched and one has been focused, use its ID. If
+  // groups haven't been fetched yet but we know the ID of the group that is
+  // likely to be focused (eg. because the notebook has been configured to
+  // display a particular group when launched), we can optimistically fetch
+  // annotations from that group.
   const groupId = focusedGroup?.id || store.directLinkedGroupId();
 
   const lastPaginationPage = useRef(1);

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -34,6 +34,13 @@ function NotebookView({ loadAnnotationsService }) {
 
   const groupName = focusedGroup?.name ?? '…';
 
+  // Get the ID of the group to fetch annotations from. Once groups are fetched
+  // this is the same as the focused group ID. In the case where the notebook
+  // is configured to open with a specific group we can start fetching annotations
+  // sooner, without waiting for the group fetch to complete, by falling back
+  // to the initially-configured group.
+  const groupId = focusedGroup?.id || store.directLinkedGroupId();
+
   const lastPaginationPage = useRef(1);
   const [paginationPage, setPaginationPage] = useState(1);
 
@@ -48,9 +55,9 @@ function NotebookView({ loadAnnotationsService }) {
     // is changed within the sidebar and the Notebook re-opened, an entirely
     // new iFrame/app is created. This will need to be revisited.
     store.setSortKey('Newest');
-    if (focusedGroup) {
+    if (groupId) {
       loadAnnotationsService.load({
-        groupId: focusedGroup.id,
+        groupId,
         maxResults: 5000,
 
         // Load annotations in reverse-chronological order because that is how
@@ -67,7 +74,7 @@ function NotebookView({ loadAnnotationsService }) {
         sortOrder: 'desc',
       });
     }
-  }, [loadAnnotationsService, focusedGroup, store]);
+  }, [loadAnnotationsService, groupId, store]);
 
   // Pagination-page-changing callback
   const onChangePage = newPage => {

--- a/src/sidebar/components/test/NotebookView-test.js
+++ b/src/sidebar/components/test/NotebookView-test.js
@@ -21,6 +21,7 @@ describe('NotebookView', () => {
     fakeScrollIntoView = sinon.stub();
 
     fakeStore = {
+      directLinkedGroupId: sinon.stub().returns(null),
       focusedGroup: sinon.stub().returns({}),
       forcedVisibleThreads: sinon.stub().returns([]),
       getFilterValues: sinon.stub().returns({}),
@@ -62,6 +63,32 @@ describe('NotebookView', () => {
       })
     );
     assert.calledWith(fakeStore.setSortKey, 'Newest');
+  });
+
+  it('loads annotations for the direct-linked group if there is no focused group', () => {
+    fakeStore.focusedGroup.returns(null);
+    fakeStore.directLinkedGroupId.returns('direct123');
+
+    createComponent();
+
+    assert.calledWith(
+      fakeLoadAnnotationsService.load,
+      sinon.match({
+        groupId: 'direct123',
+        maxResults: 5000,
+        sortBy: 'updated',
+        sortOrder: 'desc',
+      })
+    );
+  });
+
+  it('does not load annotations if there is no focused or direct-linked group', () => {
+    fakeStore.focusedGroup.returns(null);
+    fakeStore.directLinkedGroupId.returns(null);
+
+    createComponent();
+
+    assert.notCalled(fakeLoadAnnotationsService.load);
   });
 
   it('renders the current group name', () => {

--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -35,7 +35,10 @@ export default function loadAnnotationsService(
   let searchClient = null;
 
   /**
-   * Load annotations
+   * Load annotations from Hypothesis.
+   *
+   * The existing set of loaded annotations is cleared before the new set
+   * is fetched. If an existing annotation fetch is in progress it is canceled.
    *
    * @param {LoadAnnotationOptions} options
    */
@@ -44,6 +47,10 @@ export default function loadAnnotationsService(
     store.removeAnnotations(store.savedAnnotations());
 
     // Cancel previously running search client.
+    //
+    // This will emit the "end" event for the existing client and trigger cleanup
+    // associated with that client (eg. resetting the count of in-flight
+    // annotation fetches).
     if (searchClient) {
       searchClient.cancel();
     }


### PR DESCRIPTION
Optimize the initial fetch of annotations in the notebook by eagerly fetching annotations in the direct-linked group, rather than waiting for groups to be fetched and the focused group to be set.

In the common case where the notebook is configured to focus on a specific group, this allows the initial annotation fetch to happen in parallel with the groups and profile fetch, reducing the time until threads are displayed by several hundred milliseconds or more.

If for any reason the focused group ends up being different than the direct-linked group, then annotations will simply be re-fetched at that point. I verified that `loadAnnotationsService#load` handles this correctly and added some comments to clarify that.

We could do something like this in the sidebar in future as well, but it will be more complex to make it effective there because the user is less likely to already be logged in, so the direct-linked group may not be accessible.