### PR TITLE
Use `search_after` rather than `offset` to paginate through annotations in search API

### DIFF
--- a/src/sidebar/search-client.js
+++ b/src/sidebar/search-client.js
@@ -67,10 +67,12 @@ export default class SearchClient extends TinyEmitter {
   }
 
   /**
-   * Fetch a batch of annotations starting from `offset`.
+   * Fetch a batch of annotations.
    *
-   * @param {SearchQuery} query
-   * @param {string} [searchAfter]
+   * @param {SearchQuery} query - Query params for /api/search call
+   * @param {string} [searchAfter] - Cursor value to use when paginating
+   *   through results. Omitted for the first page. See docs for `search_after`
+   *   query param for /api/search API.
    */
   async _getBatch(query, searchAfter) {
     /** @type {SearchQuery} */
@@ -129,7 +131,8 @@ export default class SearchClient extends TinyEmitter {
       // If the current batch was full, there might be additional batches available.
       const nextBatchAvailable = chunk.length === this._chunkSize;
 
-      // Get the cursor for the start of the next batch.
+      // Get the cursor for the start of the next batch. This is the last
+      // value for whatever field results are sorted by from the current batch.
       const nextSearchAfter =
         chunk.length > 0 ? chunk[chunk.length - 1][this._sortBy] : null;
 

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -146,7 +146,6 @@
  *
  * @typedef SearchQuery
  * @prop {number} [limit]
- * @prop {number} [offset]
  * @prop {string[]} [uri]
  * @prop {string} [group]
  * @prop {string} [order]

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -145,12 +145,13 @@
  * for the complete list and usage of each.
  *
  * @typedef SearchQuery
+ * @prop {number} [limit]
+ * @prop {number} [offset]
  * @prop {string[]} [uri]
  * @prop {string} [group]
- * @prop {string} [references]
- * @prop {number} [offset]
- * @prop {number} [limit]
  * @prop {string} [order]
+ * @prop {string} [references]
+ * @prop {string} [search_after]
  * @prop {string} [sort]
  * @prop {boolean} [_separate_replies] - Unofficial param that causes replies
  *   to be returned in a separate `replies` field


### PR DESCRIPTION
Some time ago we [introduced](https://github.com/hypothesis/product-backlog/issues/744) an alternative way to page through annotation search results on the backend by using cursor-based rather than offset-based pagination and we [recommend](https://h.readthedocs.io/en/latest/api-reference/#tag/annotations/paths/~1search/get) its usage in our API documentation.

We never got around to changing the Hypothesis client to using it though. This PR addresses that by making the client use the `search_after` query param in `/api/search` calls rather than `offset`. This has several benefits:

- It should improve the total time taken to fetch annotations in larger groups in the notebook and on very heavily annotated pages.
- It fixes a potential race condition where annotations could be fetched multiple times or not at all if annotations were added/updated while a search was in progress.
- It means that the client is using the Hypothesis API in the same way we tell other people to use it

Changes in detail:

- Change the `SearchClient#_getBatch` implementation to use `search_after` rather than `offset`
- Add tests for setting of `search_after` query param in tests
- Refactor remaining `SearchClient` tests that still used promise chains to instead using async/await for readability and also add new lines so that they more clearly follow the arrange-act-assert pattern