### PR TITLE
Fix off-by-one error by setting root thread `visible:false`

### DIFF
--- a/src/sidebar/helpers/build-thread.js
+++ b/src/sidebar/helpers/build-thread.js
@@ -306,7 +306,11 @@ export default function buildThread(annotations, options) {
     thread.children = thread.children.filter(options.threadFilterFn);
   }
 
-  // Set visibility for threads
+  // Set visibility for threads.
+  // The root thread itself should be set as non-visible, to avoid confusion
+  // when counting visible threads. It's a container thread: its children
+  // are the top-level annotations.
+  thread.visible = false;
   thread = mapThread(thread, thread => {
     let threadIsVisible = thread.visible;
 

--- a/src/sidebar/helpers/test/build-thread-test.js
+++ b/src/sidebar/helpers/test/build-thread-test.js
@@ -69,9 +69,9 @@ function createThread(fixture, options, keys) {
   return rootThread.children;
 }
 
-describe('sidebar/helpers/build-thread', function () {
-  describe('threading', function () {
-    it('arranges parents and children as a thread', function () {
+describe('sidebar/helpers/build-thread', () => {
+  describe('threading', () => {
+    it('arranges parents and children as a thread', () => {
       const thread = createThread(SIMPLE_FIXTURE);
       assert.deepEqual(thread, [
         {
@@ -376,6 +376,15 @@ describe('sidebar/helpers/build-thread', function () {
             visible: true,
           },
         ]);
+      });
+
+      it('sets root thread visible:false so it does not get counted as a visible thread', () => {
+        // Always set the root-level thread `visible:false` such that it is
+        // not inadvertently counted as a visible thread. It doesn't contain
+        // any thread content itself; its children are top-level threads.
+        const thread = buildThread(SIMPLE_FIXTURE, defaultBuildThreadOpts);
+
+        assert.isFalse(thread.visible);
       });
 
       it('shows threads containing replies that match the filter', () => {


### PR DESCRIPTION
This PR fixes an off-by-one error in unfiltered results count in the Notebook by making sure the root thread is always set to `visible:false`. 

The visible-thread-counting utility functions in `/src/sidebar/helpers/thread`  have been around for a long time, and are used to calculate how many annotation-threads match a given set of applied filters. This is the code that calculates the number of results when you search or filter in the sidebar (e.g. “Showing 2 results for ‘foo’”).

These utilities were re-used in the Notebook. They are correctly counting results when a user filter is applied, but were off by one when counting unfiltered results (they were not previously used to count visible threads an _unfiltered_ root thread in the sidebar, and that’s where this bug creeps in).

The problem happens because:

* The root thread contains a topmost, well, root thread. This thread doesn’t have an associated annotation or any content but is merely a container for all of the top-level annotations. The default visibility for all threads in the entire thread tree is `visible:true`. Thus, the root thread is set as `visible: true` when building an unfiltered thread tree.
* The `countVisible` function counts any `thread` in the entire root-thread tree that has `visible:true`.
* Previous happy path: When annotations are filtered, the root thread is re-built and any annotation-thread that doesn’t match the filter(s) is set to `visible: false`. The `countVisible` function was previously only ever used to count all results in the sidebar when annotations were filtered. Because of this filtered state, and the root thread being marked as `visible:false`, filtered annotation counts were correct.
* Recent sad path: When used against an unfiltered root thread, with the root-level container thread still marked as `visible:true`, `countVisible` is off by one because it is counting that content-less root thread.

There are two points at which this bug could be fixed: adjust the counting functions, or adjust visibility logic in the thread-building code. At first glance, I thought the former would be more straightforward. But  that would involve introducing some sort of “ignore the topmost thread when counting visible threads,” or similar, which broke down because those visibility-counting functions are also used to count visible threads in individual annotation threads in other contexts.

What I’ve done here is make it so the root-level thread is always set to `visible:false`. “Semantically,” I don’t love this, but it does the trick.

I wrote this loooooong description because I’m more than open to other approaches if anyone’s got ‘em.
Fixes #3137