### PR TITLE
Preserve line breaks and format version information

### DIFF
--- a/src/sidebar/helpers/test/version-data-test.js
+++ b/src/sidebar/helpers/test/version-data-test.js
@@ -79,22 +79,38 @@ describe('sidebar/helpers/version-data', () => {
   });
 
   describe('#asFormattedString', () => {
-    ['timestamp', 'account', 'url'].forEach(prop => {
-      it(`includes a line for the value of ${prop} in the string`, () => {
+    [
+      ['Version', 'version'],
+      ['User Agent', 'userAgent'],
+      ['URL', 'url'],
+      ['Fingerprint', 'fingerprint'],
+      ['Account', 'account'],
+      ['Date', 'timestamp'],
+    ].forEach(prop => {
+      it(`includes a line for the value of ${prop[1]} in the string`, () => {
         const versionData = new VersionData({}, {});
         const formatted = versionData.asFormattedString();
-        const subStr = `${prop}: ${versionData[prop]}\r\n`;
+        const subStr = `${prop[0]}: ${versionData[prop[1]]}\n`;
         assert.include(formatted, subStr);
       });
     });
   });
 
   describe('#asEncodedURLString', () => {
-    ['timestamp', 'account'].forEach(prop => {
-      it(`includes encoded value for ${prop} in URL string`, () => {
+    [
+      ['Version', 'version'],
+      ['User Agent', 'userAgent'],
+      ['URL', 'url'],
+      ['Fingerprint', 'fingerprint'],
+      ['Account', 'account'],
+      ['Date', 'timestamp'],
+    ].forEach(prop => {
+      it(`includes encoded value for ${prop[1]} in URL string`, () => {
         const versionData = new VersionData({}, {});
         const encoded = versionData.asEncodedURLString();
-        const subStr = encodeURIComponent(`${prop}: ${versionData[prop]}\r\n`);
+        const subStr = encodeURIComponent(
+          `${prop[0]}: ${versionData[prop[1]]}\n`
+        );
         assert.include(encoded, subStr);
       });
     });

--- a/src/sidebar/helpers/version-data.js
+++ b/src/sidebar/helpers/version-data.js
@@ -35,15 +35,15 @@ export default class VersionData {
       }
     }
 
-    this.timestamp = new Date().toString();
+    this.version = '__VERSION__'; // replaced by versionify
+    this.userAgent = window_.navigator.userAgent;
     this.url = documentInfo.uri || noValueString;
     this.fingerprint =
       docMeta && docMeta.documentFingerprint
         ? docMeta.documentFingerprint
         : noValueString;
     this.account = accountString;
-    this.userAgent = window_.navigator.userAgent;
-    this.version = '__VERSION__';
+    this.timestamp = new Date().toString();
   }
 
   /**
@@ -53,13 +53,13 @@ export default class VersionData {
    * @return {string} - Single, multiline string representing current version data
    */
   asFormattedString() {
-    let versionString = '';
-    for (let prop in this) {
-      if (Object.prototype.hasOwnProperty.call(this, prop)) {
-        versionString += `${prop}: ${this[prop]}\r\n`;
-      }
-    }
-    return versionString;
+    return `Version: ${this.version}
+User Agent: ${this.userAgent}
+URL: ${this.url}
+Fingerprint: ${this.fingerprint}
+Account: ${this.account}
+Date: ${this.timestamp}
+`;
   }
 
   /**

--- a/src/sidebar/util/copy-to-clipboard.js
+++ b/src/sidebar/util/copy-to-clipboard.js
@@ -10,7 +10,7 @@
  * @param {string} text
  */
 export function copyText(text) {
-  const temp = document.createElement('input');
+  const temp = document.createElement('textarea'); // use textarea instead of input to preserve line breaks
   temp.value = text;
   temp.setAttribute('data-testid', 'copy-text');
   // Recipe from https://stackoverflow.com/a/34046084/14463679


### PR DESCRIPTION
I have tested successfully on the latest version of Chrome, Safari and
Firefox. I also tested successfully on an Android and iOS devices.

I couldn't tested more exhaustively on other desktop/mobile browser
versions because SauceLabs didn't allowed me to retrieve the pasted
text.

Closes https://github.com/hypothesis/product-backlog/issues/1180