### PR TITLE
Optimize perceived loading time by varying /api/search page size

### DIFF
--- a/src/sidebar/search-client.js
+++ b/src/sidebar/search-client.js
@@ -35,10 +35,10 @@ export default class SearchClient extends TinyEmitter {
   /**
    * @param {(query: SearchQuery) => Promise<SearchResult>} searchFn - Function for querying the search API
    * @param {Object} options
-   *   @param {(index: number) => number} [options.pageSize] - Callback that returns
-   *     the page size to use when fetching the index'th page of results.
-   *     Callers can vary this to balance the latency of getting some results
-   *     against the time taken to fetch all results.
+   *   @param {(index: number) => number} [options.getPageSize] -
+   *     Callback that returns the page size to use when fetching the index'th
+   *     page of results.  Callers can vary this to balance the latency of
+   *     getting some results against the time taken to fetch all results.
    *
    *     The returned page size must be at least 1 and no more than the maximum
    *     value of the `limit` query param for the search API.
@@ -61,7 +61,7 @@ export default class SearchClient extends TinyEmitter {
   constructor(
     searchFn,
     {
-      pageSize = defaultPageSize,
+      getPageSize = defaultPageSize,
       separateReplies = true,
       incremental = true,
       maxResults = null,
@@ -71,7 +71,7 @@ export default class SearchClient extends TinyEmitter {
   ) {
     super();
     this._searchFn = searchFn;
-    this._pageSize = pageSize;
+    this._getPageSize = getPageSize;
     this._separateReplies = separateReplies;
     this._incremental = incremental;
     this._maxResults = maxResults;
@@ -94,7 +94,7 @@ export default class SearchClient extends TinyEmitter {
    * @param {number} [pageIndex]
    */
   async _getPage(query, searchAfter, pageIndex = 0) {
-    const pageSize = this._pageSize(pageIndex);
+    const pageSize = this._getPageSize(pageIndex);
 
     /** @type {SearchQuery} */
     const searchQuery = {

--- a/src/sidebar/test/search-client-test.js
+++ b/src/sidebar/test/search-client-test.js
@@ -68,7 +68,7 @@ describe('SearchClient', () => {
   });
 
   it('fetches pages of results for a single URI', async () => {
-    const client = new SearchClient(fakeSearchFn, { pageSize: 3 });
+    const client = new SearchClient(fakeSearchFn, { pageSize: () => 3 });
 
     client.get({ uri: 'http://example.com' });
     await awaitEvent(client, 'end');
@@ -115,7 +115,7 @@ describe('SearchClient', () => {
   });
 
   it('emits "end" only once', done => {
-    const client = new SearchClient(fakeSearchFn, { pageSize: 2 });
+    const client = new SearchClient(fakeSearchFn, { pageSize: () => 2 });
     client.on('results', sinon.stub());
     let emitEndCounter = 0;
     client.on('end', () => {
@@ -127,7 +127,7 @@ describe('SearchClient', () => {
   });
 
   it('emits "results" with pages in incremental mode', async () => {
-    const client = new SearchClient(fakeSearchFn, { pageSize: 2 });
+    const client = new SearchClient(fakeSearchFn, { pageSize: () => 2 });
     const onResults = sinon.stub();
     client.on('results', onResults);
 
@@ -139,7 +139,7 @@ describe('SearchClient', () => {
   });
 
   it('emits "resultCount" only once in incremental mode', async () => {
-    const client = new SearchClient(fakeSearchFn, { pageSize: 2 });
+    const client = new SearchClient(fakeSearchFn, { pageSize: () => 2 });
     const onResultCount = sinon.stub();
     client.on('resultCount', onResultCount);
 
@@ -152,7 +152,7 @@ describe('SearchClient', () => {
 
   it('emits "results" once in non-incremental mode', async () => {
     const client = new SearchClient(fakeSearchFn, {
-      pageSize: 2,
+      pageSize: () => 2,
       incremental: false,
     });
     const onResults = sinon.stub();
@@ -280,7 +280,7 @@ describe('SearchClient', () => {
   ].forEach(({ sortBy, sortOrder, expectedSearchAfter }) => {
     it('sets correct "search_after" query parameter depending on `sortBy` and `sortOrder`', async () => {
       const client = new SearchClient(fakeSearchFn, {
-        pageSize: 2,
+        pageSize: () => 2,
         sortBy,
         sortOrder,
       });
@@ -293,5 +293,22 @@ describe('SearchClient', () => {
         .map(call => call.args[0].search_after);
       assert.deepEqual(searchAfterParams, expectedSearchAfter);
     });
+  });
+
+  it('fetches pages in sizes specified by `pageSize` callback', async () => {
+    const pageSizes = [1, 2, 10];
+    const pageSizeCallback = sinon.spy(index => pageSizes[index]);
+
+    const client = new SearchClient(fakeSearchFn, {
+      pageSize: pageSizeCallback,
+    });
+
+    client.get({ uri: 'http://example.com' });
+    await awaitEvent(client, 'end');
+
+    const limitParams = fakeSearchFn.getCalls().map(call => call.args[0].limit);
+    assert.deepEqual(limitParams, pageSizes);
+    const pageIndexes = pageSizeCallback.getCalls().map(call => call.args[0]);
+    assert.deepEqual(pageIndexes, [0, 1, 2]);
   });
 });

--- a/src/sidebar/test/search-client-test.js
+++ b/src/sidebar/test/search-client-test.js
@@ -68,7 +68,7 @@ describe('SearchClient', () => {
   });
 
   it('fetches pages of results for a single URI', async () => {
-    const client = new SearchClient(fakeSearchFn, { pageSize: () => 3 });
+    const client = new SearchClient(fakeSearchFn, { getPageSize: () => 3 });
 
     client.get({ uri: 'http://example.com' });
     await awaitEvent(client, 'end');
@@ -115,7 +115,7 @@ describe('SearchClient', () => {
   });
 
   it('emits "end" only once', done => {
-    const client = new SearchClient(fakeSearchFn, { pageSize: () => 2 });
+    const client = new SearchClient(fakeSearchFn, { getPageSize: () => 2 });
     client.on('results', sinon.stub());
     let emitEndCounter = 0;
     client.on('end', () => {
@@ -127,7 +127,7 @@ describe('SearchClient', () => {
   });
 
   it('emits "results" with pages in incremental mode', async () => {
-    const client = new SearchClient(fakeSearchFn, { pageSize: () => 2 });
+    const client = new SearchClient(fakeSearchFn, { getPageSize: () => 2 });
     const onResults = sinon.stub();
     client.on('results', onResults);
 
@@ -139,7 +139,7 @@ describe('SearchClient', () => {
   });
 
   it('emits "resultCount" only once in incremental mode', async () => {
-    const client = new SearchClient(fakeSearchFn, { pageSize: () => 2 });
+    const client = new SearchClient(fakeSearchFn, { getPageSize: () => 2 });
     const onResultCount = sinon.stub();
     client.on('resultCount', onResultCount);
 
@@ -152,7 +152,7 @@ describe('SearchClient', () => {
 
   it('emits "results" once in non-incremental mode', async () => {
     const client = new SearchClient(fakeSearchFn, {
-      pageSize: () => 2,
+      getPageSize: () => 2,
       incremental: false,
     });
     const onResults = sinon.stub();
@@ -280,7 +280,7 @@ describe('SearchClient', () => {
   ].forEach(({ sortBy, sortOrder, expectedSearchAfter }) => {
     it('sets correct "search_after" query parameter depending on `sortBy` and `sortOrder`', async () => {
       const client = new SearchClient(fakeSearchFn, {
-        pageSize: () => 2,
+        getPageSize: () => 2,
         sortBy,
         sortOrder,
       });
@@ -297,10 +297,10 @@ describe('SearchClient', () => {
 
   it('fetches pages in sizes specified by `pageSize` callback', async () => {
     const pageSizes = [1, 2, 10];
-    const pageSizeCallback = sinon.spy(index => pageSizes[index]);
+    const getPageSize = sinon.spy(index => pageSizes[index]);
 
     const client = new SearchClient(fakeSearchFn, {
-      pageSize: pageSizeCallback,
+      getPageSize,
     });
 
     client.get({ uri: 'http://example.com' });
@@ -308,7 +308,7 @@ describe('SearchClient', () => {
 
     const limitParams = fakeSearchFn.getCalls().map(call => call.args[0].limit);
     assert.deepEqual(limitParams, pageSizes);
-    const pageIndexes = pageSizeCallback.getCalls().map(call => call.args[0]);
+    const pageIndexes = getPageSize.getCalls().map(call => call.args[0]);
     assert.deepEqual(pageIndexes, [0, 1, 2]);
   });
 });


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/3162**

When fetching annotations from the backend there is a trade-off between
the time taken to generate a page (less if the page size is smaller) and
the time taken to fetch all pages (less if the page size is larger).

To optimize the perceived loading time we can pick a smaller page size
for the first page, enabling the first screenful of annotations/threads
to appear quickly, and then use a larger page size for the remaining
pages.

 - Change the `pageSize` option for `SearchClient` from a fixed number
   to a callback that returns the page size for a given page index

 - Set the default value for the `pageSize` option to use a small page
   size (50) for the first page and a larger size (200) for remaining
   pages