### PR TITLE
Decomposes tags service into `tagProvider` and `tagStore` services

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -117,6 +117,7 @@ import frameSyncService from './services/frame-sync';
 import groupsService from './services/groups';
 import loadAnnotationsService from './services/load-annotations';
 import localStorageService from './services/local-storage';
+import localTagsService from './services/local-tags';
 import persistedDefaultsService from './services/persisted-defaults';
 import routerService from './services/router';
 import serviceUrlService from './services/service-url';
@@ -157,6 +158,8 @@ function startApp(config) {
     .register('streamer', streamerService)
     .register('streamFilter', streamFilterService)
     .register('tags', tagsService)
+    .register('tagProvider', localTagsService)
+    .register('tagStore', localTagsService)
     .register('threadsService', threadsService)
     .register('toastMessenger', toastMessenger)
     .register('store', store);

--- a/src/sidebar/services/local-tags.js
+++ b/src/sidebar/services/local-tags.js
@@ -1,0 +1,83 @@
+/** @typedef {import('./tags').Tag} Tag */
+
+
+/**
+ * Service for fetching tag suggestions and storing data to generate them.
+ *
+ * The `tags` service stores metadata about recently used tags to local storage
+ * and provides a `filter` method to fetch tags matching a query, ranked based
+ * on frequency of usage.
+ */
+// @inject
+export default function localTags(localStorage) {
+  const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
+  const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
+
+  /**
+   * Return a list of tag suggestions matching `query`.
+   *
+   * @param {string} query
+   * @param {number|null} limit - Optional limit of the results.
+   * @return {Tag[]} List of matching tags
+   */
+  function filter(query, limit = null) {
+    const savedTags = localStorage.getObject(TAGS_LIST_KEY) || [];
+    let resultCount = 0;
+    // query will match tag if:
+    // * tag starts with query (e.g. tag "banana" matches query "ban"), OR
+    // * any word in the tag starts with query
+    //   (e.g. tag "pink banana" matches query "ban"), OR
+    // * tag has substring query occurring after a non-word character
+    //   (e.g. tag "pink!banana" matches query "ban")
+    let regex = new RegExp('(\\W|\\b)' + query, 'i');
+    return savedTags.filter(tag => {
+      if (tag.match(regex)) {
+        if (limit === null || resultCount < limit) {
+          // limit allows a subset of the results
+          // See https://github.com/hypothesis/client/issues/1606
+          ++resultCount;
+          return true;
+        }
+      }
+      return false;
+    });
+  }
+
+  /**
+   * Update the list of stored tag suggestions based on the tags that a user has
+   * entered for a given annotation.
+   *
+   * @param {Tag[]} tags - List of tags.
+   */
+  function store(tags) {
+    // Update the stored (tag, frequency) map.
+    const savedTags = localStorage.getObject(TAGS_MAP_KEY) || {};
+    tags.forEach(tag => {
+      if (savedTags[tag.text]) {
+        savedTags[tag.text].count += 1;
+        savedTags[tag.text].updated = Date.now();
+      } else {
+        savedTags[tag.text] = {
+          text: tag.text,
+          count: 1,
+          updated: Date.now(),
+        };
+      }
+    });
+    localStorage.setObject(TAGS_MAP_KEY, savedTags);
+
+    // Sort tag suggestions by frequency.
+    const tagsList = Object.keys(savedTags).sort((t1, t2) => {
+      if (savedTags[t1].count !== savedTags[t2].count) {
+        return savedTags[t2].count - savedTags[t1].count;
+      }
+      return t1.localeCompare(t2);
+    });
+    localStorage.setObject(TAGS_LIST_KEY, tagsList);
+  }
+
+  return {
+    filter,
+    store,
+  };
+}

--- a/src/sidebar/services/test/tag-provider-test.js
+++ b/src/sidebar/services/test/tag-provider-test.js
@@ -1,0 +1,87 @@
+import tagProviderFactory from '../local-tags';
+
+const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
+const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
+
+class FakeStorage {
+  constructor() {
+    this._storage = {};
+  }
+
+  getObject(key) {
+    return this._storage[key];
+  }
+
+  setObject(key, value) {
+    this._storage[key] = value;
+  }
+}
+
+describe('sidebar/services/tag-provider', () => {
+  let fakeLocalStorage;
+  let tags;
+
+  beforeEach(() => {
+    fakeLocalStorage = new FakeStorage();
+
+    const stamp = Date.now();
+    const savedTagsMap = {
+      foo: {
+        text: 'foo',
+        count: 1,
+        updated: stamp,
+      },
+      bar: {
+        text: 'bar',
+        count: 5,
+        updated: stamp,
+      },
+      'bar argon': {
+        text: 'bar argon',
+        count: 2,
+        updated: stamp,
+      },
+      banana: {
+        text: 'banana',
+        count: 2,
+        updated: stamp,
+      },
+      future: {
+        text: 'future',
+        count: 2,
+        updated: stamp,
+      },
+      argon: {
+        text: 'argon',
+        count: 1,
+        updated: stamp,
+      },
+    };
+    const savedTagsList = Object.keys(savedTagsMap);
+
+    fakeLocalStorage.setObject(TAGS_MAP_KEY, savedTagsMap);
+    fakeLocalStorage.setObject(TAGS_LIST_KEY, savedTagsList);
+
+    tags = tagProviderFactory(fakeLocalStorage);
+  });
+
+  describe('#filter', () => {
+    it('returns tags that start with the query string', () => {
+      assert.deepEqual(tags.filter('b'), ['bar', 'bar argon', 'banana']);
+    });
+
+    it('returns tags that have any word starting with the query string', () => {
+      assert.deepEqual(tags.filter('ar'), ['bar argon', 'argon']);
+    });
+
+    it('is case insensitive', () => {
+      assert.deepEqual(tags.filter('Ar'), ['bar argon', 'argon']);
+    });
+
+    it('limits tags when provided a limit value', () => {
+      assert.deepEqual(tags.filter('b', 1), ['bar']);
+      assert.deepEqual(tags.filter('b', 2), ['bar', 'bar argon']);
+      assert.deepEqual(tags.filter('b', 3), ['bar', 'bar argon', 'banana']);
+    });
+  });
+});

--- a/src/sidebar/services/test/tag-store-test.js
+++ b/src/sidebar/services/test/tag-store-test.js
@@ -1,0 +1,108 @@
+import tagStoreFactory from '../local-tags';
+
+const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
+const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
+
+class FakeStorage {
+  constructor() {
+    this._storage = {};
+  }
+
+  getObject(key) {
+    return this._storage[key];
+  }
+
+  setObject(key, value) {
+    this._storage[key] = value;
+  }
+}
+
+describe('sidebar/services/tag-store', () => {
+  let fakeLocalStorage;
+  let tags;
+
+  beforeEach(() => {
+    fakeLocalStorage = new FakeStorage();
+
+    const stamp = Date.now();
+    const savedTagsMap = {
+      foo: {
+        text: 'foo',
+        count: 1,
+        updated: stamp,
+      },
+      bar: {
+        text: 'bar',
+        count: 5,
+        updated: stamp,
+      },
+      'bar argon': {
+        text: 'bar argon',
+        count: 2,
+        updated: stamp,
+      },
+      banana: {
+        text: 'banana',
+        count: 2,
+        updated: stamp,
+      },
+      future: {
+        text: 'future',
+        count: 2,
+        updated: stamp,
+      },
+      argon: {
+        text: 'argon',
+        count: 1,
+        updated: stamp,
+      },
+    };
+    const savedTagsList = Object.keys(savedTagsMap);
+
+    fakeLocalStorage.setObject(TAGS_MAP_KEY, savedTagsMap);
+    fakeLocalStorage.setObject(TAGS_LIST_KEY, savedTagsList);
+
+    tags = tagStoreFactory(fakeLocalStorage);
+  });
+
+  describe('#store', () => {
+    it('saves new tags to storage', () => {
+      tags.store([{ text: 'new' }]);
+
+      const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
+      assert.include(storedTagsList, 'new');
+
+      const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
+      assert.match(
+        storedTagsMap.new,
+        sinon.match({
+          count: 1,
+          text: 'new',
+          updated: sinon.match.number,
+        })
+      );
+    });
+
+    it('increases the count for a tag already stored', () => {
+      tags.store([{ text: 'bar' }]);
+      const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
+      assert.equal(storedTagsMap.bar.count, 6);
+    });
+
+    it('orders list by count descending, lexical ascending', () => {
+      for (let i = 0; i < 6; i++) {
+        tags.store([{ text: 'foo' }]);
+      }
+
+      const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
+      assert.deepEqual(storedTagsList, [
+        'foo',
+        'bar',
+        'banana',
+        'bar argon',
+        'future',
+        'argon',
+      ]);
+    });
+  });
+});

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -1,128 +1,48 @@
 import tagsFactory from '../tags';
+import { Injector } from '../../../shared/injector';
 
-const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
-const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
-
-class FakeStorage {
-  constructor() {
-    this._storage = {};
-  }
-
-  getObject(key) {
-    return this._storage[key];
-  }
-
-  setObject(key, value) {
-    this._storage[key] = value;
-  }
-}
+let fakeTagProvider;
+let fakeTagStore;
+let sandbox;
 
 describe('sidebar/services/tags', () => {
-  let fakeLocalStorage;
   let tags;
 
   beforeEach(() => {
-    fakeLocalStorage = new FakeStorage();
+    sandbox = sinon.createSandbox();
 
-    const stamp = Date.now();
-    const savedTagsMap = {
-      foo: {
-        text: 'foo',
-        count: 1,
-        updated: stamp,
-      },
-      bar: {
-        text: 'bar',
-        count: 5,
-        updated: stamp,
-      },
-      'bar argon': {
-        text: 'bar argon',
-        count: 2,
-        updated: stamp,
-      },
-      banana: {
-        text: 'banana',
-        count: 2,
-        updated: stamp,
-      },
-      future: {
-        text: 'future',
-        count: 2,
-        updated: stamp,
-      },
-      argon: {
-        text: 'argon',
-        count: 1,
-        updated: stamp,
-      },
+    fakeTagProvider = {
+      filter: sinon.stub()
     };
-    const savedTagsList = Object.keys(savedTagsMap);
 
-    fakeLocalStorage.setObject(TAGS_MAP_KEY, savedTagsMap);
-    fakeLocalStorage.setObject(TAGS_LIST_KEY, savedTagsList);
+    fakeTagStore = {
+      store: sinon.stub()
+    };
 
-    tags = tagsFactory(fakeLocalStorage);
+    tags = new Injector()
+      .register('tagProvider', { value: fakeTagProvider })
+      .register('tagStore', { value: fakeTagStore })
+      .register( 'tags', tagsFactory)
+      .get('tags');
+  });
+
+  afterEach(function () {
+    sandbox.restore();
   });
 
   describe('#filter', () => {
-    it('returns tags that start with the query string', () => {
-      assert.deepEqual(tags.filter('b'), ['bar', 'bar argon', 'banana']);
-    });
-
-    it('returns tags that have any word starting with the query string', () => {
-      assert.deepEqual(tags.filter('ar'), ['bar argon', 'argon']);
-    });
-
-    it('is case insensitive', () => {
-      assert.deepEqual(tags.filter('Ar'), ['bar argon', 'argon']);
-    });
-
-    it('limits tags when provided a limit value', () => {
-      assert.deepEqual(tags.filter('b', 1), ['bar']);
-      assert.deepEqual(tags.filter('b', 2), ['bar', 'bar argon']);
-      assert.deepEqual(tags.filter('b', 3), ['bar', 'bar argon', 'banana']);
+    it('delegates query call to tag-provider', () => {
+      let query = 'pourquoi';
+      tags.filter(query);
+      return assert.calledWith(fakeTagProvider.filter, query);
     });
   });
 
   describe('#store', () => {
-    it('saves new tags to storage', () => {
-      tags.store([{ text: 'new' }]);
-
-      const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
-      assert.include(storedTagsList, 'new');
-
-      const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
-      assert.match(
-        storedTagsMap.new,
-        sinon.match({
-          count: 1,
-          text: 'new',
-          updated: sinon.match.number,
-        })
-      );
-    });
-
-    it('increases the count for a tag already stored', () => {
-      tags.store([{ text: 'bar' }]);
-      const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
-      assert.equal(storedTagsMap.bar.count, 6);
-    });
-
-    it('orders list by count descending, lexical ascending', () => {
-      for (let i = 0; i < 6; i++) {
-        tags.store([{ text: 'foo' }]);
-      }
-
-      const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
-      assert.deepEqual(storedTagsList, [
-        'foo',
-        'bar',
-        'banana',
-        'bar argon',
-        'future',
-        'argon',
-      ]);
+    it('delegates store call to tag-store', () => {
+      let theTags = [{ text: 'parce que' }];
+      tags.store(theTags);
+      return assert.calledWith(fakeTagStore.store, theTags);
     });
   });
 });


### PR DESCRIPTION
This is in preparation for simpler customization of `tagProvider`
services beyond the current cache implemented in localStorage.

- The tag service now injects a tagProvider and tagStore
- The localStorage implementation has moved to local-tags.js
- local-tags.js is now injected back as *both* tagProvider and tagStore.

(Preserves existing functionality in client)