### PR TITLE
POC: Shared Button components, Take 2

### DIFF
--- a/dev-server/templates/ui-playground.mustache
+++ b/dev-server/templates/ui-playground.mustache
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>UI component playground</title>
-  <link rel="stylesheet" href="{{ resourceRoot }}/styles/sidebar.css">
   <link rel="stylesheet" href="{{ resourceRoot }}/styles/ui-playground.css">
 </head>
 <body>

--- a/dev-server/ui-playground/ButtonsSharedDemo.js
+++ b/dev-server/ui-playground/ButtonsSharedDemo.js
@@ -1,0 +1,320 @@
+import {
+  PatternPage,
+  Pattern,
+  PatternExamples,
+  PatternExample,
+} from './Patterns';
+
+import {
+  CustomButton,
+  IconButton,
+  LabeledButton,
+  LinkButton,
+} from '../../src/shared/components/Buttons';
+
+export default function ButtonsSharedDemo() {
+  return (
+    <PatternPage title="Buttons (Shared)">
+      <Pattern title="IconButton">
+        <p>A button containing an icon and no label (text)</p>
+        <PatternExamples>
+          <PatternExample details="Sizes">
+            <IconButton icon="edit" size="large" title="Edit" />
+            <IconButton icon="edit" title="Edit" />
+            <IconButton icon="edit" size="small" title="Edit" />
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <IconButton
+              icon="trash"
+              size="large"
+              title="Delete annotation"
+              pressed
+            />
+            <IconButton icon="trash" title="Delete annotation" pressed />
+            <IconButton
+              icon="trash"
+              size="small"
+              title="Delete annotation"
+              pressed
+            />
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <IconButton
+              icon="trash"
+              size="large"
+              title="Delete annotation"
+              expanded
+            />
+            <IconButton icon="trash" title="Delete annotation" expanded />
+            <IconButton
+              icon="trash"
+              size="small"
+              title="Delete annotation"
+              expanded
+            />
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <IconButton
+              icon="trash"
+              size="large"
+              title="Delete annotation"
+              disabled
+            />
+            <IconButton icon="trash" title="Delete annotation" disabled />
+            <IconButton
+              icon="trash"
+              size="small"
+              title="Delete annotation"
+              disabled
+            />
+          </PatternExample>
+
+          <PatternExample details="Primary variant">
+            <IconButton
+              icon="trash"
+              size="large"
+              title="Delete annotation"
+              variant="primary"
+            />
+            <IconButton
+              icon="trash"
+              title="Delete annotation"
+              variant="primary"
+            />
+            <IconButton
+              icon="trash"
+              size="small"
+              title="Delete annotation"
+              variant="primary"
+            />
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="LabeledButton">
+        <p>A button with a label (text) and optionally an icon.</p>
+        <PatternExamples title="Label only">
+          <PatternExample details="Sizes">
+            <LabeledButton size="large">Edit</LabeledButton>
+            <LabeledButton>Edit</LabeledButton>
+            <LabeledButton size="small">Edit</LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <LabeledButton size="large" pressed>
+              Edit
+            </LabeledButton>
+            <LabeledButton pressed>Edit</LabeledButton>
+            <LabeledButton size="small" pressed>
+              Edit
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <LabeledButton size="large" expanded>
+              Edit
+            </LabeledButton>
+            <LabeledButton expanded>Edit</LabeledButton>
+            <LabeledButton size="small" expanded>
+              Edit
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <LabeledButton size="large" disabled>
+              Edit
+            </LabeledButton>
+            <LabeledButton disabled>Edit</LabeledButton>
+            <LabeledButton size="small" disabled>
+              Edit
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Primary variant">
+            <LabeledButton size="large" variant="primary">
+              Edit
+            </LabeledButton>
+            <LabeledButton variant="primary">Edit</LabeledButton>
+            <LabeledButton size="small" variant="primary">
+              Edit
+            </LabeledButton>
+          </PatternExample>
+        </PatternExamples>
+
+        <PatternExamples title="Label and icon">
+          <PatternExample details="Sizes">
+            <LabeledButton icon="profile" size="large">
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile">Edit User</LabeledButton>
+            <LabeledButton icon="profile" size="small">
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <LabeledButton icon="profile" size="large" pressed>
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile" pressed>
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile" pressed size="small">
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <LabeledButton icon="profile" size="large" expanded>
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile" expanded>
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile" expanded size="small">
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <LabeledButton icon="profile" size="large" disabled>
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile" disabled>
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile" disabled size="small">
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Right icon">
+            <LabeledButton icon="profile" size="large" iconPosition="right">
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile" iconPosition="right">
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile" size="small" iconPosition="right">
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Primary variant">
+            <LabeledButton icon="profile" size="large" variant="primary">
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile" variant="primary">
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile" size="small" variant="primary">
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="LinkButton">
+        <p>A button styled to look like a link (anchor tag).</p>
+        <PatternExamples>
+          <PatternExample details="Sizes">
+            <LinkButton size="large">Show replies (10)</LinkButton>
+            <LinkButton>Show replies (10)</LinkButton>
+            <LinkButton size="small">Show replies (10)</LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <LinkButton size="large" pressed>
+              Show replies (10)
+            </LinkButton>
+            <LinkButton pressed>Show replies (10)</LinkButton>
+            <LinkButton size="small" pressed>
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <LinkButton size="large" expanded>
+              Show replies (10)
+            </LinkButton>
+            <LinkButton expanded>Show replies (10)</LinkButton>
+            <LinkButton size="small" expanded>
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <LinkButton size="large" disabled>
+              Show replies (10)
+            </LinkButton>
+            <LinkButton disabled>Show replies (10)</LinkButton>
+            <LinkButton size="small" disabled>
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Primary variant">
+            <LinkButton size="large" variant="primary">
+              Show replies (10)
+            </LinkButton>
+            <LinkButton variant="primary">Show replies (10)</LinkButton>
+            <LinkButton size="small" variant="primary">
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="CustomButton">
+        <p>
+          Customized by passing a class name. This example could also have been
+          accomplished by using `LabeledButton` with a `className`.
+        </p>
+        <PatternExamples>
+          <PatternExample>
+            <CustomButton className="TestCustomButton" size="large">
+              100
+            </CustomButton>
+          </PatternExample>
+
+          <PatternExample>
+            <CustomButton className="TestCustomButton">100</CustomButton>
+          </PatternExample>
+
+          <PatternExample>
+            <CustomButton className="TestCustomButton" size="small">
+              100
+            </CustomButton>
+          </PatternExample>
+
+          <PatternExample>
+            <CustomButton className="TestCustomButton" pressed>
+              Show replies (10)
+            </CustomButton>
+          </PatternExample>
+
+          <PatternExample>
+            <CustomButton className="TestCustomButton" expanded>
+              Show replies (10)
+            </CustomButton>
+          </PatternExample>
+
+          <PatternExample>
+            <CustomButton className="TestCustomButton" disabled>
+              Show replies (10)
+            </CustomButton>
+          </PatternExample>
+
+          <PatternExample>
+            <CustomButton className="TestCustomButton" variant="primary">
+              Show replies(10)
+            </CustomButton>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+    </PatternPage>
+  );
+}

--- a/dev-server/ui-playground/ButtonsSidebarDemo.js
+++ b/dev-server/ui-playground/ButtonsSidebarDemo.js
@@ -1,0 +1,438 @@
+import {
+  PatternPage,
+  Pattern,
+  PatternExamples,
+  PatternExample,
+} from './Patterns';
+
+import { IconButton, LabeledButton } from '../../src/shared/components/Buttons';
+
+export default function ButtonsSidebarDemo() {
+  return (
+    <PatternPage title="Buttons: Sidebar">
+      <Pattern title="IconButton: CompactIconButton">
+        <p>
+          In several places in the Sidebar, there isn&rsquo;t enough room to
+          display an icon button with its full padding and touch-target
+          affordances. In other words, we need an icon button for tight spaces.
+        </p>
+        <p>
+          In the long run, it would be ideal to be able to provide the full
+          mobile touch-target size.
+        </p>
+        <PatternExamples>
+          <PatternExample details="Sizes">
+            <IconButton
+              className="CompactIconButton"
+              icon="edit"
+              size="large"
+              title="Edit"
+            />
+            <IconButton
+              className="CompactIconButton"
+              icon="edit"
+              title="Edit"
+            />
+            <IconButton
+              className="CompactIconButton"
+              icon="edit"
+              size="small"
+              title="Edit"
+            />
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <IconButton
+              className="CompactIconButton"
+              icon="trash"
+              title="Delete annotation"
+              size="large"
+              pressed
+            />
+            <IconButton
+              className="CompactIconButton"
+              icon="trash"
+              title="Delete annotation"
+              pressed
+            />
+            <IconButton
+              className="CompactIconButton"
+              icon="trash"
+              title="Delete annotation"
+              size="small"
+              pressed
+            />
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <IconButton
+              className="CompactIconButton"
+              icon="trash"
+              size="large"
+              title="Delete annotation"
+              expanded
+            />
+            <IconButton
+              className="CompactIconButton"
+              icon="trash"
+              title="Delete annotation"
+              expanded
+            />
+            <IconButton
+              className="CompactIconButton"
+              icon="trash"
+              size="small"
+              title="Delete annotation"
+              expanded
+            />
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <IconButton
+              className="CompactIconButton"
+              icon="trash"
+              size="large"
+              title="Delete annotation"
+              disabled
+            />
+            <IconButton
+              className="CompactIconButton"
+              icon="trash"
+              title="Delete annotation"
+              disabled
+            />
+            <IconButton
+              className="CompactIconButton"
+              icon="trash"
+              size="small"
+              title="Delete annotation"
+              disabled
+            />
+          </PatternExample>
+
+          <PatternExample details="Primary variant">
+            <IconButton
+              className="CompactIconButton"
+              icon="profile"
+              size="large"
+              title="User info"
+              variant="primary"
+            />
+            <IconButton
+              className="CompactIconButton"
+              icon="profile"
+              title="User info"
+              variant="primary"
+            />
+            <IconButton
+              className="CompactIconButton"
+              icon="profile"
+              size="small"
+              title="User info"
+              variant="primary"
+            />
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="IconButton: IconInputButton">
+        <p>
+          This component is used to the right of a text input and the two make
+          up a compound component.
+        </p>
+        <PatternExamples>
+          <PatternExample details="Sizes">
+            <IconButton
+              className="IconInputButton"
+              icon="copy"
+              size="large"
+              title="Copy"
+            />
+            <IconButton className="IconInputButton" icon="copy" title="Copy" />
+            <IconButton
+              className="IconInputButton"
+              icon="copy"
+              size="small"
+              title="Copy"
+            />
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <IconButton
+              className="IconInputButton"
+              icon="trash"
+              size="large"
+              title="Delete annotation"
+              pressed
+            />
+            <IconButton
+              className="IconInputButton"
+              icon="trash"
+              title="Delete annotation"
+              pressed
+            />
+            <IconButton
+              className="IconInputButton"
+              icon="trash"
+              size="small"
+              title="Delete annotation"
+              pressed
+            />
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <IconButton
+              className="IconInputButton"
+              icon="trash"
+              size="large"
+              title="Delete annotation"
+              expanded
+            />
+            <IconButton
+              className="IconInputButton"
+              icon="trash"
+              title="Delete annotation"
+              expanded
+            />
+            <IconButton
+              className="IconInputButton"
+              icon="trash"
+              size="small"
+              title="Delete annotation"
+              expanded
+            />
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <IconButton
+              className="IconInputButton"
+              icon="trash"
+              size="large"
+              title="Delete annotation"
+              disabled
+            />
+            <IconButton
+              className="IconInputButton"
+              icon="trash"
+              title="Delete annotation"
+              disabled
+            />
+            <IconButton
+              className="IconInputButton"
+              icon="trash"
+              size="small"
+              title="Delete annotation"
+              disabled
+            />
+          </PatternExample>
+
+          <PatternExample details="Primary variant">
+            <IconButton
+              className="IconInputButton"
+              icon="profile"
+              size="large"
+              title="User info"
+              variant="primary"
+            />
+            <IconButton
+              className="IconInputButton"
+              icon="profile"
+              title="User info"
+              variant="primary"
+            />
+            <IconButton
+              className="IconInputButton"
+              icon="profile"
+              size="small"
+              title="User info"
+              variant="primary"
+            />
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="LabeledButton: CompactLabeledButton">
+        <p>A labeled button with tighter padding.</p>
+        <PatternExamples>
+          <PatternExample details="Sizes">
+            <LabeledButton
+              className="CompactLabeledButton"
+              icon="profile"
+              size="large"
+            >
+              Edit User
+            </LabeledButton>
+            <LabeledButton className="CompactLabeledButton" icon="profile">
+              Edit User
+            </LabeledButton>
+            <LabeledButton
+              className="CompactLabeledButton"
+              icon="profile"
+              size="small"
+            >
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <LabeledButton
+              className="CompactLabeledButton"
+              icon="profile"
+              pressed
+              size="large"
+            >
+              Edit User
+            </LabeledButton>
+            <LabeledButton
+              className="CompactLabeledButton"
+              icon="profile"
+              pressed
+            >
+              Edit User
+            </LabeledButton>
+            <LabeledButton
+              className="CompactLabeledButton"
+              icon="profile"
+              pressed
+              size="small"
+            >
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <LabeledButton
+              className="CompactLabeledButton"
+              icon="profile"
+              expanded
+              size="large"
+            >
+              Edit User
+            </LabeledButton>
+            <LabeledButton
+              className="CompactLabeledButton"
+              icon="profile"
+              expanded
+            >
+              Edit User
+            </LabeledButton>
+            <LabeledButton
+              className="CompactLabeledButton"
+              icon="profile"
+              expanded
+              size="small"
+            >
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <LabeledButton
+              className="CompactLabeledButton"
+              icon="profile"
+              disabled
+              size="large"
+            >
+              Edit User
+            </LabeledButton>
+            <LabeledButton
+              className="CompactLabeledButton"
+              icon="profile"
+              disabled
+            >
+              Edit User
+            </LabeledButton>
+            <LabeledButton
+              className="CompactLabeledButton"
+              icon="profile"
+              disabled
+              size="small"
+            >
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Primary variant">
+            <LabeledButton
+              className="CompactLabeledButton"
+              icon="profile"
+              size="large"
+              variant="primary"
+            >
+              Edit User
+            </LabeledButton>
+            <LabeledButton
+              className="CompactLabeledButton"
+              icon="profile"
+              variant="primary"
+            >
+              Edit User
+            </LabeledButton>
+            <LabeledButton
+              className="CompactLabeledButton"
+              icon="profile"
+              size="small"
+              variant="primary"
+            >
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="LabeledButton: Custom on Grey">
+        <p>
+          Example of customizing a button to display well on a darker
+          background.
+        </p>
+        <PatternExamples>
+          <PatternExample details="Sizes">
+            <LabeledButton size="large" className="TestCustomButton">
+              100
+            </LabeledButton>
+            <LabeledButton className="TestCustomButton">100</LabeledButton>
+            <LabeledButton size="small" className="TestCustomButton">
+              100
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <LabeledButton size="large" className="TestCustomButton" pressed>
+              100
+            </LabeledButton>
+            <LabeledButton className="TestCustomButton" pressed>
+              100
+            </LabeledButton>
+            <LabeledButton size="small" className="TestCustomButton" pressed>
+              100
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <LabeledButton size="large" className="TestCustomButton" expanded>
+              100
+            </LabeledButton>
+            <LabeledButton className="TestCustomButton" expanded>
+              100
+            </LabeledButton>
+            <LabeledButton size="small" className="TestCustomButton" expanded>
+              100
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <LabeledButton size="large" className="TestCustomButton" disabled>
+              100
+            </LabeledButton>
+            <LabeledButton className="TestCustomButton" disabled>
+              100
+            </LabeledButton>
+            <LabeledButton size="small" className="TestCustomButton" disabled>
+              100
+            </LabeledButton>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+    </PatternPage>
+  );
+}

--- a/dev-server/ui-playground/Patterns.js
+++ b/dev-server/ui-playground/Patterns.js
@@ -1,0 +1,60 @@
+import { toChildArray } from 'preact';
+
+import jsxToString from './jsxToString';
+
+export function PatternPage({ title, children }) {
+  return (
+    <section className="PatternPage">
+      <h1>{title}</h1>
+      <div className="PatternPage__content">{children}</div>
+    </section>
+  );
+}
+
+export function Pattern({ children, title }) {
+  return (
+    <section className="Pattern">
+      <h2>{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+export function PatternExamples({ children, title }) {
+  return (
+    <table className="PatternExamples">
+      {title && (
+        <tr>
+          <th colSpan="3">
+            <h3>{title}</h3>
+          </th>
+        </tr>
+      )}
+      <tr>
+        <th>Example</th>
+        <th>Details</th>
+        <th>Source</th>
+      </tr>
+      {children}
+    </table>
+  );
+}
+
+export function PatternExample({ children, details }) {
+  const source = toChildArray(children).map((child, idx) => {
+    return (
+      <li key={idx}>
+        <code>{jsxToString(child)}</code>
+      </li>
+    );
+  });
+  return (
+    <tr>
+      <td className="PatternExample__example">{children}</td>
+      <td>{details}</td>
+      <td>
+        <ul>{source}</ul>
+      </td>
+    </tr>
+  );
+}

--- a/dev-server/ui-playground/PlaygroundApp.js
+++ b/dev-server/ui-playground/PlaygroundApp.js
@@ -1,43 +1,9 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
 
-import Button from '../../src/sidebar/components/Button';
-import Menu from '../../src/sidebar/components/Menu';
-import MenuItem from '../../src/sidebar/components/MenuItem';
+import ButtonsSharedDemo from './ButtonsSharedDemo';
+import ButtonsSidebarDemo from './ButtonsSidebarDemo';
 
 import { useRoute } from './router';
-
-function ComponentDemo({ title, children }) {
-  return (
-    <section>
-      <h1 className="heading">{title}</h1>
-      {children}
-    </section>
-  );
-}
-
-function ButtonDemo() {
-  return (
-    <ComponentDemo title="Button">
-      <Button buttonText="Text button" />
-      <Button icon="edit" title="Icon button" />
-      <Button icon="trash" buttonText="Icon + text button" />
-      <Button disabled={true} buttonText="Disabled button" />
-    </ComponentDemo>
-  );
-}
-
-function MenuDemo() {
-  return (
-    <ComponentDemo title="Menu">
-      <Menu label="Edit">
-        <MenuItem label="Zoom in" />
-        <MenuItem label="Zoom out" />
-        <MenuItem label="Undo" />
-        <MenuItem label="Redo" />
-      </Menu>
-    </ComponentDemo>
-  );
-}
 
 function HomeRoute() {
   return (
@@ -55,14 +21,14 @@ const routes = [
     component: HomeRoute,
   },
   {
-    route: '/button',
-    title: 'Button',
-    component: ButtonDemo,
+    route: '/buttons',
+    title: 'Buttons (Shared)',
+    component: ButtonsSharedDemo,
   },
   {
-    route: '/menu',
-    title: 'Menu',
-    component: MenuDemo,
+    route: '/sidebar-buttons',
+    title: 'Buttons (Sidebar)',
+    component: ButtonsSidebarDemo,
   },
 ];
 
@@ -83,23 +49,25 @@ export default function PlaygroundApp() {
   return (
     <main className="PlaygroundApp">
       <div className="PlaygroundApp__sidebar">
-        <a
-          className="PlaygroundApp__nav-link u-center"
-          href={baseUrl}
-          onClick={e => navigate(e, '/')}
-        >
-          <SvgIcon name="logo" />
-        </a>
-        {demoRoutes.map(c => (
-          <a
-            className="PlaygroundApp__nav-link"
-            key={c.route}
-            href={c.route}
-            onClick={e => navigate(e, c.route)}
-          >
-            {c.title}
+        <div className="PlaygroundApp__sidebar-home">
+          <a href={baseUrl} onClick={e => navigate(e, '/')}>
+            <SvgIcon name="logo" />
           </a>
-        ))}
+        </div>
+        <ul>
+          {demoRoutes.map(c => (
+            <li key={c.route}>
+              <a
+                className="PlaygroundApp__nav-link"
+                key={c.route}
+                href={c.route}
+                onClick={e => navigate(e, c.route)}
+              >
+                {c.title}
+              </a>
+            </li>
+          ))}
+        </ul>
       </div>
       <div className="PlaygroundApp__content">{content}</div>
     </main>

--- a/dev-server/ui-playground/jsxToString.js
+++ b/dev-server/ui-playground/jsxToString.js
@@ -1,0 +1,50 @@
+function escapeQuotes(str) {
+  return str.replace(/"/g, '\\"');
+}
+
+function componentName(type) {
+  if (typeof type === 'string') {
+    return type;
+  } else {
+    return type.displayName || type.name;
+  }
+}
+
+export default function jsxToString(vnode) {
+  if (typeof vnode === 'string' || typeof vnode === 'number') {
+    return vnode.toString();
+  } else if (vnode?.type) {
+    const name = componentName(vnode.type);
+
+    // TODO - Add in the `key` prop which is extracted off the props into `vnode.key`.
+    let propStr = Object.entries(vnode.props)
+      .map(([name, value]) => {
+        if (name === 'children') {
+          return '';
+        }
+        // nb. We assume that `value` is something that can easily be stringified
+        // using `String(value)`.
+        return `${name}="${escapeQuotes(String(value))}"`;
+      })
+      .join(' ')
+      .trim();
+    if (propStr.length > 0) {
+      propStr = ' ' + propStr;
+    }
+
+    const children = vnode.props.children;
+    if (children) {
+      // TODO - Be smart about splitting children over multiple lines if
+      // there are enough of them or the string is too long.
+      const childrenStr = Array.isArray(children)
+        ? children.map(jsxToString).join('')
+        : jsxToString(children);
+      return `<${name}${propStr}>${childrenStr}</${name}>`;
+    } else {
+      // No children - use a self-closing tag.
+      return `<${name}${propStr}/>`;
+    }
+  } else {
+    return '';
+  }
+}

--- a/src/shared/components/Buttons.js
+++ b/src/shared/components/Buttons.js
@@ -1,0 +1,133 @@
+import classnames from 'classnames';
+
+import { SvgIcon } from '@hypothesis/frontend-shared';
+
+/**
+ * @typedef ButtonProps
+ * @prop {Object} [children]
+ * @prop {string} [icon] - name of `SvgIcon` to render in the button
+ * @prop {'left'|'right'} [iconPosition] - Icon positioned to left or to
+ *   right of button text
+ * @prop {boolean} [disabled]
+ * @prop {boolean} [expanded] - Is the element associated with this button
+ *   expanded (set `aria-expanded`)
+ * @prop {boolean} [pressed] - Is this button currently "active?" (set
+ *   `aria-pressed`)
+ * @prop {() => any} [onClick]
+ * @prop {'small'|'medium'|'large'} [size] - For styling, size variant
+ * @prop {string} [title]
+ * @prop {'primary'} [variant] - For styling: element variant
+ */
+
+/**
+ * @typedef IconButtonBaseProps
+ * @prop {string} icon - Icon is required for icon buttons
+ * @prop {string} title - Title is required for icon buttons
+ */
+
+/**
+ * @typedef {ButtonProps & { className: string }} ButtonBaseProps
+ * @typedef {ButtonBaseProps & IconButtonBaseProps} IconButtonProps
+ */
+
+/**
+ * @param {ButtonBaseProps} props
+ */
+function ButtonBase({
+  children,
+  className,
+  icon,
+  iconPosition = 'left',
+  disabled,
+  expanded,
+  pressed,
+  onClick = () => {},
+  size = 'medium',
+  title,
+  variant,
+}) {
+  const ariaAttributes = {};
+  const otherAttributes = {};
+  if (typeof disabled === 'boolean') {
+    otherAttributes.disabled = disabled;
+  }
+  if (typeof title !== 'undefined') {
+    otherAttributes.title = title;
+    ariaAttributes['aria-label'] = title;
+  }
+
+  if (typeof expanded === 'boolean') {
+    ariaAttributes['aria-expanded'] = expanded;
+  }
+  if (typeof pressed === 'boolean') {
+    ariaAttributes['aria-pressed'] = pressed;
+  }
+
+  return (
+    <button
+      className={classnames(className, `${className}--size-${size}`, {
+        [`${className}--${variant}`]: variant,
+        [`${className}--icon-${iconPosition}`]: icon,
+      })}
+      onClick={onClick}
+      {...otherAttributes}
+      {...ariaAttributes}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * An icon-only button
+ * @param {IconButtonProps} props
+ */
+export function IconButton(props) {
+  const { className = 'IconButton', ...restProps } = props;
+  const { icon } = props;
+  return (
+    <ButtonBase className={className} {...restProps}>
+      <SvgIcon name={icon} />
+    </ButtonBase>
+  );
+}
+
+/**
+ * A labeled button with no icon
+ * @param {ButtonBaseProps} props
+ */
+export function LabeledButton(props) {
+  const { icon, iconPosition = 'left' } = props;
+  const { children, className = 'LabeledButton', ...restProps } = props;
+  return (
+    <ButtonBase className={className} {...restProps}>
+      {icon && iconPosition === 'left' && <SvgIcon name={icon} />}
+      {children}
+      {icon && iconPosition === 'right' && <SvgIcon name={icon} />}
+    </ButtonBase>
+  );
+}
+
+/**
+ * A button styled to appear as an HTML link (<a>)
+ * @param {ButtonProps} props
+ */
+export function LinkButton(props) {
+  const { children } = props;
+  return (
+    <ButtonBase className="LinkButton" {...props}>
+      {children}
+    </ButtonBase>
+  );
+}
+
+/**
+ * A custom button. Forwards on provided `className`
+ *
+ * Uses `ButtonBaseProps` to allow `className`
+ * @param {ButtonBaseProps} props
+ */
+export function CustomButton(props) {
+  const { children } = props;
+  return <ButtonBase {...props}>{children}</ButtonBase>;
+}

--- a/src/styles/shared/_index.scss
+++ b/src/styles/shared/_index.scss
@@ -1,0 +1,2 @@
+@use './components/Buttons' as buttons;
+@include buttons.styles;

--- a/src/styles/shared/components/Buttons/_index.scss
+++ b/src/styles/shared/components/Buttons/_index.scss
@@ -1,0 +1,166 @@
+@use "sass:map";
+@use "@hypothesis/frontend-shared/styles/mixins/focus";
+@use './mixins';
+@use "../../variables" as var;
+
+// Design tokens from variables
+$-settings: (
+  'border-radius': var.$border-radius,
+  // Internal margin between elements, e.g. SVG and label
+  'margin': 0.5em,
+  'touch-target-size': var.$touch-target-size,
+  'color-g1': var.$color-grey-1,
+  'color-g2': var.$color-grey-2,
+  'color-g3': var.$color-grey-3,
+  'color-gsemi': var.$color-grey-semi,
+  'color-gmid': var.$color-grey-mid,
+  'color-g6': var.$color-grey-6,
+  'color-g7': var.$color-grey-7,
+  'color-brand': var.$color-brand,
+  'color-link-hover': var.$color-link-hover,
+);
+
+// Configure this module to override any of the default settings values
+@mixin configure($settings: null) {
+  @if $settings {
+    $-settings: map.merge($-settings, $settings) !global;
+  }
+}
+
+$colors: (
+  'foreground': map.get($-settings, 'color-gmid'),
+  'background': map.get($-settings, 'color-g1'),
+  'hover-foreground': map.get($-settings, 'color-g7'),
+  'hover-background': map.get($-settings, 'color-g2'),
+  'active-foreground': map.get($-settings, 'color-g7'),
+  'active-background': map.get($-settings, 'color-g1'),
+  'border': transparent,
+  'disabled-foreground': map.get($-settings, 'color-gmid'),
+);
+
+// Icon-only buttons have a transparent background by default, and a more
+// visible active (pressed) state
+$IconButton-colors: map.merge(
+  $colors,
+  (
+    'background': transparent,
+    'hover-background': transparent,
+    'active-foreground': map.get($-settings, 'color-brand'),
+    'active-background': transparent,
+  )
+);
+
+$IconButton-colors--primary: map.merge(
+  $IconButton-colors,
+  (
+    'foreground': map.get($-settings, 'color-brand'),
+    'hover-foreground': map.get($-settings, 'color-brand'),
+    'active-foreground': map.get($-settings, 'color-brand'),
+  )
+);
+
+// LABELED BUTTON colors
+$LabeledButton-colors: $colors;
+
+// This set of colors is light text on dark background
+$LabeledButton-colors--primary: map.merge(
+  $colors,
+  (
+    'foreground': map.get($-settings, 'color-g1'),
+    'background': map.get($-settings, 'color-gmid'),
+    'hover-foreground': map.get($-settings, 'color-g1'),
+    'hover-background': map.get($-settings, 'color-g6'),
+    'disabled-foreground': map.get($-settings, 'color-gsemi'),
+  )
+);
+
+// This set of colors is for buttons styled as links on a white background
+$LinkButton-colors: map.merge(
+  $colors,
+  (
+    'background': transparent,
+    'hover-background': transparent,
+    'active-background': transparent,
+    'hover-foreground': map.get($-settings, 'color-link-hover'),
+  )
+);
+
+// MIXINS ////////////////////////////////
+// Button base block element mixin
+@mixin Button(
+  $colormap: $colors,
+  $settings: $-settings,
+  $withStates: true,
+  $withLayout: false
+) {
+  @include mixins.button(
+    $colormap: $colormap,
+    $settings: $settings,
+    $withStates: $withStates,
+    $withLayout: $withLayout
+  ) {
+    @content;
+  }
+}
+
+// Mixin for --modifier variants on Buttons, e.g. `.MyButton--primary`
+@mixin Button--variant($colormap: $colors, $withStates: false) {
+  @include mixins.variant($colormap: $colormap, $withStates: $withStates);
+}
+
+// Block mixin for a button with an icon and nothing else
+@mixin IconButton {
+  @include Button($colormap: $IconButton-colors, $withStates: true) {
+    @media (pointer: coarse) {
+      min-width: map.get($-settings, 'touch-target-size');
+      min-height: map.get($-settings, 'touch-target-size');
+    }
+  }
+  &--primary {
+    @include Button--variant($IconButton-colors--primary, $withStates: true);
+  }
+  @content;
+}
+
+// Block mixin for a button with a text label and (optional) icon
+@mixin LabeledButton {
+  @include Button(
+    $colormap: $LabeledButton-colors,
+    $withLayout: true,
+    $withStates: true
+  );
+  &--primary {
+    @include Button--variant($LabeledButton-colors--primary, $withStates: true);
+  }
+  @content;
+}
+
+// Block mixin for a button styled to look like a link
+@mixin LinkButton {
+  @include Button($LinkButton-colors) {
+    // Override base font-weight
+    font-weight: 400;
+  }
+  // No active states
+  @include mixins.hover-state($LinkButton-colors) {
+    text-decoration: underline;
+  }
+  @content;
+}
+
+@mixin styles {
+  // A button with only an icon and no text (label)
+  .IconButton {
+    @include IconButton;
+  }
+
+  // A button with text and optionally an icon
+  .LabeledButton {
+    @include LabeledButton;
+  }
+
+  // A button styled to appear as a link, with underline on hover
+  .LinkButton {
+    @include LinkButton;
+  }
+}

--- a/src/styles/shared/components/Buttons/mixins.scss
+++ b/src/styles/shared/components/Buttons/mixins.scss
@@ -1,0 +1,111 @@
+@use "sass:map";
+@use "@hypothesis/frontend-shared/styles/mixins/focus";
+
+// Reset browser native styles. This can be used in conjunction with other
+// styles via `base` or standalone for starting a custom button's styles
+// from relative scratch
+@mixin reset {
+  @include focus.outline-on-keyboard-focus;
+  // Reset native styles
+  padding: 0;
+  margin: 0;
+  background-color: transparent;
+  border-style: none;
+}
+
+// Set colors for a button
+@mixin _colors($colormap) {
+  color: map.get($colormap, 'foreground');
+  background-color: map.get($colormap, 'background');
+
+  &:disabled {
+    color: map.get($colormap, 'disabled-foreground');
+  }
+}
+
+// Set hover colors and transition for a button
+@mixin hover-state($colormap) {
+  &:hover:not([disabled]),
+  &:focus:not([disabled]) {
+    color: map.get($colormap, 'hover-foreground');
+    background-color: map.get($colormap, 'hover-background');
+    @content;
+  }
+  transition: color 0.2s ease-out, background-color 0.2s ease-out,
+    opacity 0.2s ease-out;
+}
+
+// Set active state colors for a button
+@mixin active-state($colormap) {
+  &[aria-expanded='true'],
+  &[aria-pressed='true'] {
+    color: map.get($colormap, 'active-foreground');
+    background-color: map.get($colormap, 'active-background');
+    @content;
+
+    &:hover:not([disabled]),
+    &:focus:not([disabled]) {
+      color: map.get($colormap, 'active-foreground');
+      background-color: map.get($colormap, 'active-background');
+      @content;
+    }
+  }
+}
+
+// Variant mixin: may be be used by variants (BEM modifier classes)
+@mixin variant($colormap, $withStates: false) {
+  @include _colors($colormap);
+  @if $withStates {
+    @include active-state($colormap);
+    @include hover-state($colormap);
+  }
+}
+
+// Base mixin for buttons. Should only be used once per block-level class (BEM blocks)
+@mixin button($colormap, $settings, $withLayout: false, $withStates: false) {
+  @include reset;
+  @include _colors($colormap);
+
+  @if $withStates {
+    @include active-state($colormap);
+    @include hover-state($colormap);
+  }
+
+  border-radius: map.get($settings, 'border-radius');
+  border: none;
+  padding: 0.5em;
+
+  font-size: 1em;
+  font-weight: 700;
+  white-space: nowrap; // Keep multi-word button labels from wrapping
+
+  @if $withLayout {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    &--icon-left svg {
+      margin-right: map.get($settings, 'margin');
+    }
+
+    &--icon-right svg {
+      margin-left: map.get($settings, 'margin');
+    }
+  }
+
+  &--size-small {
+    font-size: 0.825em;
+  }
+
+  &--size-large {
+    font-size: 1.25em;
+  }
+
+  // (icon) SVG sizing is relevant
+  svg {
+    width: 1.25em;
+    height: 1.25em;
+  }
+
+  @content;
+}

--- a/src/styles/shared/variables/_index.scss
+++ b/src/styles/shared/variables/_index.scss
@@ -1,0 +1,7 @@
+@forward 'colors' as color-*;
+
+$border-radius: 2px;
+
+// Minimum recommended size for tap targets on mobile.
+// This value originated from Apple's Human Interface Guidelines.
+$touch-target-size: 44px;

--- a/src/styles/shared/variables/colors.scss
+++ b/src/styles/shared/variables/colors.scss
@@ -1,0 +1,37 @@
+// Greys (layout colors)
+// These may be used for non-textual styling of components and elements
+$white: #fff !default;
+
+// Interim color variable for migration purposes.
+// Used as very-subtle background color for form fields. $grey-1 is too dark.
+$grey-0: #fafafa;
+
+$grey-1: #f2f2f2;
+$grey-2: #ececec;
+
+$grey-3: #dbdbdb;
+
+$grey-4: #a6a6a6;
+
+// Interim color variable for migration purposes, as the step between `$grey-4`
+// and `$grey-5` is large. Represents `base-semi` in proposed future palette,
+// minus blue tint.
+$grey-semi: #9c9c9c;
+
+// This is the lightest grey admissible on a white, $grey-0 or $grey-1
+// background to meet WCAG-AA text contrast requirements.
+$grey-5: #737373;
+
+// Interim color variable for migration purposes, as the step between `$grey-5`
+// and `$grey-6` is large. Represents `base-mid` in proposed future palette,
+// minus blue tint.
+// This is the lightest grey admissible on $grey-2, $grey-3
+$grey-mid: #595959;
+
+$grey-6: #3f3f3f;
+
+$grey-7: #202020;
+
+$brand: #bd1c2b;
+
+$link-hover: #84141e !default;

--- a/src/styles/sidebar/components/Buttons.scss
+++ b/src/styles/sidebar/components/Buttons.scss
@@ -1,0 +1,68 @@
+@use "sass:map";
+@use "../../variables" as var;
+@use '../../shared/components/Buttons' as buttons;
+
+// An icon-only button with tighter padding (e.g. TopBar icons)
+.CompactIconButton {
+  // Override larger touch-target min size
+  @include buttons.configure(
+    $settings: (
+      'touch-target-size': auto,
+    )
+  );
+  @include buttons.IconButton {
+    // Smaller Icon
+    & svg {
+      width: 1em;
+      height: 1em;
+    }
+    // Tighter padding
+    padding: 0.25em;
+  }
+}
+
+// A button with text and/or icon,
+// with tighter padding/internal margins
+.CompactLabeledButton {
+  // Reduce margin on internal SVG
+  @include buttons.configure(
+    $settings: (
+      'margin': 0.25em,
+    )
+  );
+  @include buttons.LabeledButton {
+    // tighter padding overall
+    padding: 0.25em 0.5em;
+  }
+}
+
+//An icon-only button rendered to the right of a text input field
+.IconInputButton {
+  @include buttons.configure(
+    $settings: (
+      // Sharp edges to assimilate with input field
+      'border-radius': 0,
+    )
+  );
+
+  @include buttons.Button($withStates: true) {
+    // Add a border to line up with input field
+    border: 1px solid var.$grey-3;
+    // No border on the left because that's the side adjacent to input field
+    border-left: none;
+  }
+}
+
+// EXAMPLE of Custom Button styling
+.TestCustomButton {
+  // Custom Button components can define their own color maps
+  $custom-colormap: map.merge(
+    buttons.$colors,
+    (
+      'background': transparent,
+      'hover-background': var.$grey-3,
+      'active-background': var.$grey-3,
+    )
+  );
+  @include buttons.Button($custom-colormap, $withStates: true);
+}

--- a/src/styles/ui-playground/ui-playground.scss
+++ b/src/styles/ui-playground/ui-playground.scss
@@ -1,5 +1,37 @@
+@use '../reset';
+@use '../sidebar/elements';
+@use '../mixins/layout';
+@use '../variables' as var;
+
+@use '../shared';
+@use '../sidebar/components/Buttons';
+
 $title-font: 20pt;
-$background-color: #ededed;
+$background-color: #9b9595;
+
+body {
+  font-size: 100%;
+}
+
+h1 {
+  font-size: 1.75em;
+  font-weight: bold;
+}
+
+h2 {
+  font-size: 1.5em;
+  width: 100%;
+  border-left: 6px solid var.$color-brand;
+  font-weight: bold;
+  padding-left: 0.5em;
+}
+
+h3 {
+  width: 100%;
+  font-size: 1.125em;
+  font-weight: normal;
+  font-style: italic;
+}
 
 // Utilities
 .u-center {
@@ -8,45 +40,114 @@ $background-color: #ededed;
 
 // Component styles
 .PlaygroundApp {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-areas:
+    'navigation'
+    'content';
 
-  max-width: 600px;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 10px;
-  min-height: 90vh;
-}
+  &__content {
+    padding: var.$layout-space;
+  }
 
-.PlaygroundApp__sidebar {
-  display: flex;
-  flex-direction: column;
-  padding: 10px;
-  background-color: $background-color;
-  border-radius: 3px;
-  margin-right: 10px;
-}
+  &__sidebar {
+    grid-area: 'navigation';
+    max-height: 20em;
+    overflow: scroll;
+    background-color: var.$grey-2;
+  }
 
-.PlaygroundApp__nav-link {
-  padding: 5px;
-  font-size: 12pt;
+  &__sidebar-home {
+    text-align: center;
+    padding: var.$layout-space;
+  }
 
-  &:hover {
-    background-color: #ddd;
+  &__content {
+    grid-area: 'content';
   }
 }
 
-.PlaygroundApp__content {
-  flex-grow: 1;
+.PlaygroundApp__nav-link {
+  width: 100%;
+  padding: var.$layout-space;
+  font-size: var.$font-size--subheading;
+  border-left: 5px solid transparent;
+  &:hover {
+    background-color: var.$grey-3;
+    border-left: 5px solid var.$color-brand;
+  }
 }
 
-.heading {
-  font-size: $title-font;
-  border-bottom: 2px solid $background-color;
-  margin-bottom: 20px;
+// Temporarily enforce the body font size of the client to demonstrate how
+// components would scale in-situ
+.PatternPage {
+  font-size: 13px;
+  &__content {
+    padding: 2em 0;
+  }
+}
+
+.Pattern {
+  margin-bottom: 4em;
+  p {
+    margin: 1em;
+  }
+}
+
+.PatternExamples {
+  border: 1px solid var.$grey-3;
+  border-collapse: collapse;
+  width: 100%;
+  margin-bottom: 2em;
+
+  th,
+  td {
+    padding: 0.5em;
+  }
+
+  th {
+    background-color: var.$grey-1;
+    border-bottom: 1px solid var.$grey-3;
+    text-align: left;
+  }
+
+  td {
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
+  tr:nth-child(even) td {
+    background: var.$grey-0;
+  }
+
+  code {
+    color: var.$grey-mid;
+  }
+}
+
+.PatternExample {
+  &__example {
+    display: flex;
+    align-items: center;
+    & > * + * {
+      margin-left: 1em;
+    }
+  }
 }
 
 // Element styles
 body {
   font-family: sans-serif;
+}
+
+@media screen and (min-width: 60em) {
+  .PlaygroundApp {
+    height: 100vh;
+    grid-template-columns: 20em auto;
+    column-gap: 1em;
+    grid-template-areas: 'navigation content';
+
+    &__sidebar {
+      max-height: none;
+    }
+  }
 }


### PR DESCRIPTION
I was slowing myself down by drafting up a big explanation of every little piece of this, but I wonder if a better approach is to give some light pointers and let y'all explore a bit on your own.

This diff is big, but a lot (most?) of that is the playground-app changes and additions; the first two commits are the actual proposed changes. An extra wrinkle is that much of this would be extracted into the `frontend-shared` package, so, use your imagination.

To see what some of the proposed shared and customized sidebar Buttons look like, fire up your local devserver and go to the UI playground (linked to from the local dev's landing page). 

I'll expand and explain early next week when I'm fresher, but in case anyone wanted to take a peek at the overall approach...