### PR TITLE
Destroy crossframe instance when guest is destroyed

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -342,6 +342,7 @@ export default class Guest {
 
     this.pdfIntegration?.destroy();
     this._emitter.destroy();
+    this.crossframe.destroy();
   }
 
   /**

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -948,4 +948,34 @@ describe('Guest', () => {
       assert.calledWith(removeHighlights, highlights);
     });
   });
+
+  describe('#destroy', () => {
+    it('disconnects from sidebar events', () => {
+      const guest = createGuest();
+      guest.destroy();
+      assert.calledOnce(fakeCrossFrame.destroy);
+    });
+
+    it('removes the adder toolbar', () => {
+      const guest = createGuest();
+      const adder = guest.element.querySelector('hypothesis-adder');
+      assert.equal(adder.parentElement, guest.element);
+
+      guest.destroy();
+
+      assert.isNull(adder.parentElement);
+    });
+
+    it('cleans up PDF integration', () => {
+      const guest = createGuest({ documentType: 'pdf' });
+      guest.destroy();
+      assert.calledOnce(fakePdfIntegration.destroy);
+    });
+
+    it('removes all highlights', () => {
+      const guest = createGuest();
+      guest.destroy();
+      assert.calledWith(highlighter.removeAllHighlights, guest.element);
+    });
+  });
 });


### PR DESCRIPTION
Referencing issue https://github.com/hypothesis/client/issues/3131

It appears [`frame-sync.js`](https://github.com/hypothesis/client/blob/master/src/sidebar/services/frame-sync.js) is responsible for setting up a subscription to `beforeCreateAnnotation` which then calls `annotationsService.create`. This subscription is never destroyed so when the client is "unloaded/loaded" it creates duplicate subscriptions, makings things buggy.

From what I'm seeing, [`cross-frame.js`](https://github.com/hypothesis/client/blob/master/src/annotator/plugin/cross-frame.js#L60) is the only place responsible for dispatching `destroyFrame` to the `bridge` instance in `frame-sync.js`, but the `destroy` method is never invoked when the `Guest` instance is destroyed.