### PR TITLE
TagEditor now removes repeated tags without changing filter() order.

### DIFF
--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -72,13 +72,11 @@ function TagEditor({
    * @return {string[]}
    */
   const removeDuplicates = (suggestions, duplicates) => {
-    const suggestionsSet = [];
-    suggestions.forEach(suggestion => {
-      if (duplicates.indexOf(suggestion) < 0) {
-        suggestionsSet.push(suggestion);
-      }
-    });
-    return suggestionsSet.sort();
+    // suggestions already sorted the way the service wants
+
+    // only remove duplicates
+    // (array.filter returns a new array and preserves original input order)
+    return suggestions.filter(suggestion => duplicates.indexOf(suggestion) < 0);
   };
 
   /**

--- a/src/sidebar/components/test/TagEditor-test.js
+++ b/src/sidebar/components/test/TagEditor-test.js
@@ -99,8 +99,8 @@ describe('TagEditor', function () {
     const wrapper = createComponent();
     wrapper.find('input').instance().value = 'non-empty';
     typeInput(wrapper);
-    assert.equal(wrapper.find('AutocompleteList').prop('list')[0], 'tag3');
-    assert.equal(wrapper.find('AutocompleteList').prop('list')[1], 'tag4');
+    assert.equal(wrapper.find('AutocompleteList').prop('list')[0], 'tag4');
+    assert.equal(wrapper.find('AutocompleteList').prop('list')[1], 'tag3');
   });
 
   it('shows case-insensitive matches to suggested tags', () => {
@@ -121,8 +121,32 @@ describe('TagEditor', function () {
 
     // Even though the entered text was lower case ('aa'), the suggested tag
     // should be rendered with its original casing (upper-case here)
-    assert.equal(firstSuggestedTag, 'AAArgh');
-    assert.equal(secondSuggestedTag, 'fine AArdvark');
+    assert.equal(firstSuggestedTag, 'fine AArdvark');
+    assert.equal(secondSuggestedTag, 'AAArgh');
+  });
+
+  it('preserves order of tag-suggestions returned from filter()', () => {
+    fakeTagsService.filter.returns(['aabbcc', 'aabb', 'aa']);
+    const wrapper = createComponent();
+    wrapper.find('input').instance().value = 'aa';
+    typeInput(wrapper);
+
+    const formattingFn = wrapper.find('AutocompleteList').prop('listFormatter');
+    const tagList = wrapper.find('AutocompleteList').prop('list');
+
+    const firstSuggestedTag = mount(formattingFn(tagList[0]))
+      .find('span')
+      .text();
+    const secondSuggestedTag = mount(formattingFn(tagList[1]))
+      .find('span')
+      .text();
+    const thirdSuggestedTag = mount(formattingFn(tagList[2]))
+      .find('span')
+      .text();
+
+    assert.equal(firstSuggestedTag, 'aabbcc');
+    assert.equal(secondSuggestedTag, 'aabb');
+    assert.equal(thirdSuggestedTag, 'aa');
   });
 
   it('shows suggested tags as-is if they do not seem to match the input', () => {
@@ -149,8 +173,8 @@ describe('TagEditor', function () {
       .text();
 
     // Obviously, these don't have a `bb` substring; we'll just render them...
-    assert.equal(firstSuggestedTag, 'AAArgh');
-    assert.equal(secondSuggestedTag, 'fine AArdvark');
+    assert.equal(firstSuggestedTag, 'fine AArdvark');
+    assert.equal(secondSuggestedTag, 'AAArgh');
   });
 
   it('passes the text value to filter() after receiving input', () => {
@@ -302,10 +326,10 @@ describe('TagEditor', function () {
         const wrapper = createComponent();
         wrapper.find('input').instance().value = 't';
         typeInput(wrapper);
-        // suggestions: [tag3, tag4]
+        // suggestions: [tag4, tag3]
         navigateDown(wrapper);
         keyAction[0](wrapper);
-        assertAddTagsSuccess(wrapper, 'tag3');
+        assertAddTagsSuccess(wrapper, 'tag4');
         // ensure focus is still on the input field
         assert.equal(document.activeElement.nodeName, 'INPUT');
       });


### PR DESCRIPTION
The design of the tag-suggestions feature intends to defer ordering criteria to the tag-service, 
however this was not respected in the component.

The current tag service (`filter`) orders matching tag suggestions by descending frequency.
The TagEditor component (since #1558 - 15 months back) would then reorder tag suggestions alphabetically.

This change modifies the TagEditor to display tag-suggestions in the order returned by the service.

- Adds test "preserves order of tag-suggestions returned from filter()"
- Updates several tests which presumed the component would alphabetize tags.
- Reimplements `TagEditor.updateSuggestions` to not alphabetize or otherwise reorder suggestions.
- Closes https://github.com/hypothesis/product-backlog/issues/1196

**Impact**:  Users may notice a change in the ordering criteria from alpha back to frequecy-desc (current tag-service impl).