### PR TITLE
Run GitHub Actions checks on `pull_request` rather than `push` event

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,5 +1,5 @@
 name: Continuous integration
-on: [push]
+on: pull_request
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This ensures that GitHub Actions checks run for PRs submitted from forks,
which includes all PRs submitted by people outside the Hypothesis
organization.

Note that this change which commit the checks run on. See [1] for details.

This change also matches how GitHub CI is set up in other projects (eg. lms, h).

[1] https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request

This fixes an issue discovered when reviewing https://github.com/hypothesis/client/pull/3174