### PR TITLE
Add shared Buttons components, styles, pattern library examples

### DIFF
--- a/dev-server/tsconfig.json
+++ b/dev-server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "lib": ["es2018", "dom"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "module": "commonjs",
+    "noEmit": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "target": "ES2020"
+  },
+  "include": ["ui-playground/**/*.js"]
+}

--- a/dev-server/ui-playground/components/PatternPage.js
+++ b/dev-server/ui-playground/components/PatternPage.js
@@ -91,7 +91,7 @@ export function PatternExamples({ children, title }) {
     <table className="PatternExamples">
       {title && (
         <tr>
-          <th colSpan="3">
+          <th colSpan={3}>
             <h3>{title}</h3>
           </th>
         </tr>

--- a/dev-server/ui-playground/components/PlaygroundApp.js
+++ b/dev-server/ui-playground/components/PlaygroundApp.js
@@ -54,7 +54,7 @@ export default function PlaygroundApp() {
               <a
                 className="PlaygroundApp__nav-link"
                 key={c.route}
-                href={c.route}
+                href={/** @type string */ (c.route)}
                 onClick={e => navigate(e, c.route)}
               >
                 {c.title}

--- a/dev-server/ui-playground/components/PlaygroundApp.js
+++ b/dev-server/ui-playground/components/PlaygroundApp.js
@@ -1,6 +1,7 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
 
 import MenuPatterns from './patterns/MenuPatterns';
+import SharedButtonPatterns from './patterns/SharedButtonPatterns';
 
 import { useRoute } from '../router';
 
@@ -23,6 +24,11 @@ const routes = [
     route: '/menu',
     title: 'Menu',
     component: MenuPatterns,
+  },
+  {
+    route: '/shared-buttons',
+    title: 'Buttons (Shared)',
+    component: SharedButtonPatterns,
   },
 ];
 

--- a/dev-server/ui-playground/components/patterns/MenuPatterns.js
+++ b/dev-server/ui-playground/components/patterns/MenuPatterns.js
@@ -15,7 +15,7 @@ export default function MenuPatterns() {
         <p>A simple Menu usage example</p>
         <PatternExamples>
           <PatternExample details="Menu">
-            <Menu label="Edit">
+            <Menu title="Example Menu" label="Edit">
               <MenuItem label="Zoom in" />
               <MenuItem label="Zoom out" />
               <MenuItem label="Undo" />

--- a/dev-server/ui-playground/components/patterns/SharedButtonPatterns.js
+++ b/dev-server/ui-playground/components/patterns/SharedButtonPatterns.js
@@ -1,0 +1,133 @@
+import {
+  PatternPage,
+  Pattern,
+  PatternExamples,
+  PatternExample,
+} from '../PatternPage';
+
+import {
+  IconButton,
+  LabeledButton,
+  LinkButton,
+} from '../../../../src/shared/components/buttons';
+
+export default function SharedButtonPatterns() {
+  return (
+    <PatternPage title="Buttons (Shared)">
+      <Pattern title="IconButton">
+        <p>A button containing an icon and no label (text)</p>
+        <PatternExamples>
+          <PatternExample details="Basic usage">
+            <IconButton icon="edit" title="Edit" />
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <IconButton icon="trash" title="Delete annotation" pressed />
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <IconButton icon="trash" title="Delete annotation" expanded />
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <IconButton icon="trash" title="Delete annotation" disabled />
+          </PatternExample>
+
+          <PatternExample details="Primary variant">
+            <IconButton
+              icon="trash"
+              title="Delete annotation"
+              variant="primary"
+            />
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="LabeledButton">
+        <p>A button with a label (text) and optionally an icon.</p>
+        <PatternExamples title="Label only">
+          <PatternExample details="Basic usage">
+            <LabeledButton>Edit</LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <LabeledButton pressed>Edit</LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <LabeledButton expanded>Edit</LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <LabeledButton disabled>Edit</LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Primary variant">
+            <LabeledButton variant="primary">Edit</LabeledButton>
+          </PatternExample>
+        </PatternExamples>
+
+        <PatternExamples title="Label and icon">
+          <PatternExample details="Basic usage">
+            <LabeledButton icon="profile">Edit User</LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <LabeledButton icon="profile" pressed>
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <LabeledButton icon="profile" expanded>
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <LabeledButton icon="profile" disabled>
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Right icon">
+            <LabeledButton icon="profile" iconPosition="right">
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Primary variant">
+            <LabeledButton icon="profile" variant="primary">
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+
+      <Pattern title="LinkButton">
+        <p>A button styled to look like a link (anchor tag).</p>
+        <PatternExamples>
+          <PatternExample details="Basic usage">
+            <LinkButton>Show replies (10)</LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <LinkButton pressed>Show replies (10)</LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <LinkButton expanded>Show replies (10)</LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <LinkButton disabled>Show replies (10)</LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Primary variant">
+            <LinkButton variant="primary">Show replies (10)</LinkButton>
+          </PatternExample>
+        </PatternExamples>
+      </Pattern>
+    </PatternPage>
+  );
+}

--- a/dev-server/ui-playground/index.js
+++ b/dev-server/ui-playground/index.js
@@ -7,4 +7,4 @@ import sidebarIcons from '../../src/sidebar/icons';
 registerIcons(sidebarIcons);
 
 const container = document.querySelector('#app');
-render(<PlaygroundApp />, container);
+render(<PlaygroundApp />, /** @type Element */ (container));

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "checkformatting": "prettier --check '**/*.{js,scss}'",
     "format": "prettier --list-different --write '**/*.{js,scss}'",
     "test": "gulp test",
-    "typecheck": "tsc --build src/tsconfig.json",
+    "typecheck": "tsc --build tsconfig.json",
     "report-coverage": "codecov -f coverage/coverage-final.json",
     "version": "make clean build"
   }

--- a/src/shared/components/buttons.js
+++ b/src/shared/components/buttons.js
@@ -1,0 +1,121 @@
+import classnames from 'classnames';
+
+import { SvgIcon } from '@hypothesis/frontend-shared';
+
+/**
+ * @typedef ButtonProps
+ * @prop {import("preact").ComponentChildren} [children]
+ * @prop {string} [className]
+ * @prop {string} [icon] - Name of `SvgIcon` to render in the button
+ * @prop {'left'|'right'} [iconPosition] - Icon positioned to left or to
+ *   right of button text
+ * @prop {boolean} [disabled]
+ * @prop {boolean} [expanded] - Is the element associated with this button
+ *   expanded (set `aria-expanded`)
+ * @prop {boolean} [pressed] - Is this button currently "active?" (set
+ *   `aria-pressed`)
+ * @prop {() => any} [onClick]
+ * @prop {string} [title] - Button title; used for `aria-label` attribute
+ * @prop {'primary'} [variant] - For styling: element variant
+ */
+
+/**
+ * @typedef IconButtonBaseProps
+ * @prop {string} icon - Icon is required for icon buttons
+ * @prop {string} title - Title is required for icon buttons
+ */
+
+/**
+ * @typedef {ButtonProps & IconButtonBaseProps} IconButtonProps
+ */
+
+/**
+ * @param {ButtonProps} props
+ */
+function ButtonBase({
+  children,
+  className,
+  icon,
+  iconPosition = 'left',
+  disabled,
+  expanded,
+  pressed,
+  onClick = () => {},
+  title,
+  variant,
+}) {
+  const otherAttributes = {};
+  if (typeof disabled === 'boolean') {
+    otherAttributes.disabled = disabled;
+  }
+  if (typeof title !== 'undefined') {
+    otherAttributes.title = title;
+    otherAttributes['aria-label'] = title;
+  }
+
+  if (typeof expanded === 'boolean') {
+    otherAttributes['aria-expanded'] = expanded;
+  }
+  if (typeof pressed === 'boolean') {
+    otherAttributes['aria-pressed'] = pressed;
+  }
+
+  return (
+    <button
+      className={classnames(className, {
+        [`${className}--${variant}`]: variant,
+        [`${className}--icon-${iconPosition}`]: icon,
+      })}
+      onClick={onClick}
+      {...otherAttributes}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * An icon-only button
+ *
+ * @param {IconButtonProps} props
+ */
+export function IconButton(props) {
+  const { className = 'IconButton', ...restProps } = props;
+  const { icon } = props;
+  return (
+    <ButtonBase className={className} {...restProps}>
+      <SvgIcon name={icon} />
+    </ButtonBase>
+  );
+}
+
+/**
+ * A labeled button, with or without an icon
+ *
+ * @param {ButtonProps} props
+ */
+export function LabeledButton(props) {
+  const { icon, iconPosition = 'left' } = props;
+  const { children, className = 'LabeledButton', ...restProps } = props;
+  return (
+    <ButtonBase className={className} {...restProps}>
+      {icon && iconPosition === 'left' && <SvgIcon name={icon} />}
+      {children}
+      {icon && iconPosition === 'right' && <SvgIcon name={icon} />}
+    </ButtonBase>
+  );
+}
+
+/**
+ * A button styled to appear as an HTML link (<a>)
+ *
+ * @param {ButtonProps} props
+ */
+export function LinkButton(props) {
+  const { children } = props;
+  return (
+    <ButtonBase className="LinkButton" {...props}>
+      {children}
+    </ButtonBase>
+  );
+}

--- a/src/shared/components/test/buttons-test.js
+++ b/src/shared/components/test/buttons-test.js
@@ -1,0 +1,220 @@
+import { mount } from 'enzyme';
+
+import { IconButton, LabeledButton, LinkButton } from '../buttons.js';
+import { $imports } from '../buttons.js';
+
+import { checkAccessibility } from '../../../test-util/accessibility';
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+
+// Add common tests for a button component for stuff provided by `ButtonBase`
+function addCommonTests({ componentName, createComponentFn, withIcon = true }) {
+  describe(`${componentName} common support`, () => {
+    if (withIcon) {
+      it('renders the indicated icon', () => {
+        const wrapper = createComponentFn({ icon: 'fakeIcon' });
+        const button = wrapper.find('button');
+        const icon = wrapper.find('SvgIcon');
+        assert.equal(icon.prop('name'), 'fakeIcon');
+        // Icon is positioned "left" even if it is the only element in the <button>
+        assert.isTrue(button.hasClass(`${componentName}--icon-left`));
+      });
+    }
+
+    it('invokes callback on click', () => {
+      const onClick = sinon.stub();
+      const wrapper = createComponentFn({ onClick });
+
+      wrapper.find('button').simulate('click');
+      assert.calledOnce(onClick);
+    });
+
+    it('uses an internal no-op callback if no `onClick` is provided', () => {
+      // This test merely exercises the `onClick` prop default-value branch
+      // in the code
+      const wrapper = createComponentFn({ onClick: undefined });
+      wrapper.find('button').simulate('click');
+    });
+
+    it('uses a default className', () => {
+      const wrapper = createComponentFn();
+
+      assert.isTrue(wrapper.find('button').hasClass(componentName));
+    });
+
+    it('renders a primary variant', () => {
+      const wrapper = createComponentFn({ variant: 'primary' });
+
+      assert.isTrue(
+        wrapper.find('button').hasClass(`${componentName}--primary`)
+      );
+    });
+
+    it('overrides className when provided', () => {
+      const wrapper = createComponentFn({
+        className: 'CustomClassName',
+        variant: 'primary',
+      });
+
+      assert.isTrue(wrapper.find('button').hasClass('CustomClassName'));
+      assert.isTrue(
+        wrapper.find('button').hasClass('CustomClassName--primary')
+      );
+      assert.isFalse(wrapper.find('button').hasClass(componentName));
+    });
+
+    [
+      {
+        propName: 'expanded',
+        propValue: true,
+        attributeName: 'aria-expanded',
+        attributeValue: 'true',
+      },
+      {
+        propName: 'pressed',
+        propValue: true,
+        attributeName: 'aria-pressed',
+        attributeValue: 'true',
+      },
+      {
+        propName: 'title',
+        propValue: 'Click here',
+        attributeName: 'aria-label',
+        attributeValue: 'Click here',
+      },
+      {
+        propName: 'disabled',
+        propValue: true,
+        attributeName: 'disabled',
+        attributeValue: '',
+      },
+    ].forEach(testCase => {
+      it('sets attributes on the button element', () => {
+        const wrapper = createComponentFn({
+          [testCase.propName]: testCase.propValue,
+        });
+
+        const element = wrapper.find('button').getDOMNode();
+
+        assert.equal(
+          element.getAttribute(testCase.attributeName),
+          testCase.attributeValue
+        );
+      });
+    });
+  });
+}
+
+describe('buttons', () => {
+  let fakeOnClick;
+
+  beforeEach(() => {
+    fakeOnClick = sinon.stub();
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  describe('IconButton', () => {
+    function createComponent(props = {}) {
+      return mount(
+        <IconButton
+          icon="fakeIcon"
+          title="My Action"
+          onClick={fakeOnClick}
+          {...props}
+        />
+      );
+    }
+
+    addCommonTests({
+      componentName: 'IconButton',
+      createComponentFn: createComponent,
+    });
+
+    it(
+      'should pass a11y checks',
+      checkAccessibility({
+        content: () => createComponent(),
+      })
+    );
+  });
+
+  describe('LabeledButton', () => {
+    function createComponent(props = {}) {
+      return mount(
+        <LabeledButton title="My Action" onClick={fakeOnClick} {...props}>
+          Do this
+        </LabeledButton>
+      );
+    }
+
+    addCommonTests({
+      componentName: 'LabeledButton',
+      createComponentFn: createComponent,
+    });
+
+    it('renders the indicated icon on the right if `iconPosition` is `right`', () => {
+      const wrapper = createComponent({
+        icon: 'fakeIcon',
+        iconPosition: 'right',
+      });
+
+      const icon = wrapper.find('SvgIcon');
+      const button = wrapper.find('button');
+      assert.equal(icon.prop('name'), 'fakeIcon');
+      assert.isTrue(button.hasClass('LabeledButton--icon-right'));
+    });
+
+    it('does not render an icon if none indicated', () => {
+      // Icon not required for `LabeledButton`
+      const wrapper = createComponent();
+
+      const icon = wrapper.find('SvgIcon');
+      assert.isFalse(icon.exists());
+    });
+
+    it('renders children', () => {
+      const wrapper = createComponent();
+
+      assert.equal(wrapper.text(), 'Do this');
+    });
+
+    it(
+      'should pass a11y checks',
+      checkAccessibility({
+        content: () => createComponent(),
+      })
+    );
+  });
+
+  describe('LinkButton', () => {
+    function createComponent(props = {}) {
+      return mount(
+        <LinkButton title="My Action" onClick={fakeOnClick} {...props}>
+          Do this
+        </LinkButton>
+      );
+    }
+
+    addCommonTests({
+      componentName: 'LinkButton',
+      createComponentFn: createComponent,
+      withIcon: false,
+    });
+
+    it('renders children', () => {
+      const wrapper = createComponent();
+
+      assert.equal(wrapper.text(), 'Do this');
+    });
+
+    it(
+      'should pass a11y checks',
+      checkAccessibility({
+        content: () => createComponent(),
+      })
+    );
+  });
+});

--- a/src/styles/shared/_index.scss
+++ b/src/styles/shared/_index.scss
@@ -1,0 +1,1 @@
+@use './components/buttons';

--- a/src/styles/shared/components/buttons/_config.scss
+++ b/src/styles/shared/components/buttons/_config.scss
@@ -1,0 +1,75 @@
+@use 'sass:map';
+@use '../../variables' as var;
+
+// Map variables to local tokens
+$touch-target-size: var.$touch-target-size !default;
+
+$color-g1: var.$color-grey-1 !default;
+$color-g2: var.$color-grey-2 !default;
+$color-g3: var.$color-grey-3 !default;
+$color-g6: var.$color-grey-6 !default;
+$color-g7: var.$color-grey-7 !default;
+$color-gsemi: var.$color-grey-semi !default;
+$color-gmid: var.$color-grey-mid !default;
+$color-brand: var.$color-brand !default;
+$color-link-hover: var.$color-link-hover !default;
+
+// The following SASS maps define color sets for each type of button
+
+// Default colors for buttons
+$colors: (
+  'foreground': $color-gmid,
+  'background': $color-g1,
+  'hover-foreground': $color-g7,
+  'hover-background': $color-g2,
+  'active-foreground': $color-g7,
+  'active-background': $color-g1,
+  'border': transparent,
+  'disabled-foreground': $color-gmid,
+);
+
+// Icon-only buttons have a transparent background by default, and a more
+// visible active (pressed) state
+$IconButton-colors: map.merge(
+  $colors,
+  (
+    'background': transparent,
+    'hover-background': transparent,
+    'active-foreground': $color-brand,
+    'active-background': transparent,
+  )
+);
+
+$IconButton-colors--primary: map.merge(
+  $IconButton-colors,
+  (
+    'foreground': $color-brand,
+    'hover-foreground': $color-brand,
+    'active-foreground': $color-brand,
+  )
+);
+
+$LabeledButton-colors: $colors;
+
+// This set of colors is light text on dark background
+$LabeledButton-colors--primary: map.merge(
+  $colors,
+  (
+    'foreground': $color-g1,
+    'background': $color-gmid,
+    'hover-foreground': $color-g1,
+    'hover-background': $color-g6,
+    'disabled-foreground': $color-gsemi,
+  )
+);
+
+// This set of colors is for buttons styled as links on a white background
+$LinkButton-colors: map.merge(
+  $colors,
+  (
+    'background': transparent,
+    'hover-background': transparent,
+    'active-background': transparent,
+    'hover-foreground': $color-link-hover,
+  )
+);

--- a/src/styles/shared/components/buttons/_index.scss
+++ b/src/styles/shared/components/buttons/_index.scss
@@ -1,0 +1,63 @@
+@use "sass:map";
+
+@use "../../variables" as var;
+
+@use './_config' as *; // Bring variables into scope
+@use './mixins';
+
+// A button with only an icon and no label/text
+.IconButton {
+  @include mixins.Button(
+    $options: (
+      'colormap': $IconButton-colors,
+    )
+  ) {
+    @media (pointer: coarse) {
+      min-width: $touch-target-size;
+      min-height: $touch-target-size;
+    }
+  }
+  &--primary {
+    @include mixins.Button--variant(
+      $options: (
+        'colormap': $IconButton-colors--primary,
+      )
+    );
+  }
+}
+
+// A button with text, and optionally an icon
+.LabeledButton {
+  @include mixins.Button(
+    $options: (
+      'colormap': $LabeledButton-colors,
+      'withLayout': true,
+    )
+  );
+  &--primary {
+    @include mixins.Button--variant(
+      $options: (
+        'colormap': $LabeledButton-colors--primary,
+      )
+    );
+  }
+}
+
+// A button styled to appear as a link, with underline on hover
+.LinkButton {
+  @include mixins.Button(
+    $options: (
+      'colormap': $LinkButton-colors,
+      'withStates': false,
+    )
+  ) {
+    // Override base font-weight
+    font-weight: 400;
+  }
+  // No active states, but we do want a hover state
+  @include mixins.hover-state($LinkButton-colors) {
+    text-decoration: underline;
+  }
+  // Remove horizontal padding to allow button to appear flush-left or -right
+  padding: 0.5em 0;
+}

--- a/src/styles/shared/components/buttons/mixins.scss
+++ b/src/styles/shared/components/buttons/mixins.scss
@@ -1,0 +1,137 @@
+@use "sass:map";
+
+@use "@hypothesis/frontend-shared/styles/mixins/focus";
+
+@use './_config' as *;
+
+// Reset browser native styles. This can be used in conjunction with other
+// styles via `base` or standalone for starting a custom button's styles
+// from relative scratch
+@mixin reset {
+  @include focus.outline-on-keyboard-focus;
+  // Reset native styles
+  padding: 0;
+  margin: 0;
+  background-color: transparent;
+  border-style: none;
+}
+
+// Set colors for a button
+@mixin _colors($colormap) {
+  color: map.get($colormap, 'foreground');
+  background-color: map.get($colormap, 'background');
+
+  &:disabled {
+    color: map.get($colormap, 'disabled-foreground');
+  }
+}
+
+// Set hover colors and transition for a button
+@mixin hover-state($colormap) {
+  &:hover:not([disabled]),
+  &:focus:not([disabled]) {
+    color: map.get($colormap, 'hover-foreground');
+    background-color: map.get($colormap, 'hover-background');
+    @content;
+  }
+  transition: color 0.2s ease-out, background-color 0.2s ease-out,
+    opacity 0.2s ease-out;
+}
+
+// Set active state colors for a button
+@mixin active-state($colormap) {
+  &[aria-expanded='true'],
+  &[aria-pressed='true'] {
+    color: map.get($colormap, 'active-foreground');
+    background-color: map.get($colormap, 'active-background');
+    @content;
+
+    &:hover:not([disabled]),
+    &:focus:not([disabled]) {
+      color: map.get($colormap, 'active-foreground');
+      background-color: map.get($colormap, 'active-background');
+      @content;
+    }
+  }
+}
+
+// Variant mixin: may be be used by variants (BEM modifier classes)
+@mixin _variant($options) {
+  @include _colors(map.get($options, 'colormap'));
+  @if map.get($options, 'withStates') {
+    @include active-state(map.get($options, 'colormap'));
+    @include hover-state(map.get($options, 'colormap'));
+  }
+  @content;
+}
+
+// Base mixin for buttons.
+@mixin _button($options) {
+  @include reset;
+  @include _colors(map.get($options, 'colormap'));
+
+  @if map.get($options, 'withStates') {
+    @include active-state(map.get($options, 'colormap'));
+    @include hover-state(map.get($options, 'colormap'));
+  }
+
+  border-radius: map.get($options, 'border-radius');
+  border: none;
+  padding: 0.5em;
+
+  font-size: 1em;
+  font-weight: 700;
+  white-space: nowrap; // Keep multi-word button labels from wrapping
+
+  @if map.get($options, 'withLayout') {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    &--icon-left svg {
+      margin-right: map.get($options, 'margin');
+    }
+
+    &--icon-right svg {
+      margin-left: map.get($options, 'margin');
+    }
+  }
+
+  // (icon) SVG sizing is relevant
+  svg {
+    width: 1.25em;
+    height: 1.25em;
+  }
+}
+
+// Base mixin for <button> elements. Start here for new <button> classes
+@mixin Button($options: ()) {
+  $defaultOptions: (
+    // What colors should be used for this button's styling?
+    'colormap': $colors,
+    // Should styling be added for "active" and "hover" states for this <button>?
+    'withStates': true,
+    // Should styling be added to support the layout of multiple sub-elements
+    // of this <button>? Not needed if <button> contains only one child.
+    'withLayout': false,
+    // Internal margin around SVG icon
+    'margin': 0.5em,
+    'border-radius': 2px
+  );
+  $-options: map.merge($defaultOptions, $options);
+  @include _button($options: $-options);
+  @content;
+}
+
+// Mixin for --modifier variants on buttons, e.g. `.MyButton--primary`
+@mixin Button--variant($options: ()) {
+  $defaultOptions: (
+    // Colors to use when styling this variant
+    'colormap': $colors,
+    // Should this variant have styling for "active" and "hover" states?
+    'withStates': true
+  );
+  $-options: map.merge($defaultOptions, $options);
+  @include _variant($options: $-options);
+  @content;
+}

--- a/src/styles/shared/variables/_index.scss
+++ b/src/styles/shared/variables/_index.scss
@@ -1,0 +1,7 @@
+@forward 'colors' as color-*;
+
+$border-radius: 2px;
+
+// Minimum recommended size for tap targets on mobile.
+// This value originated from Apple's Human Interface Guidelines.
+$touch-target-size: 44px;

--- a/src/styles/shared/variables/colors.scss
+++ b/src/styles/shared/variables/colors.scss
@@ -1,0 +1,37 @@
+// Greys (layout colors)
+// These may be used for non-textual styling of components and elements
+$white: #fff !default;
+
+// Interim color variable for migration purposes.
+// Used as very-subtle background color for form fields. $grey-1 is too dark.
+$grey-0: #fafafa;
+
+$grey-1: #f2f2f2;
+$grey-2: #ececec;
+
+$grey-3: #dbdbdb;
+
+$grey-4: #a6a6a6;
+
+// Interim color variable for migration purposes, as the step between `$grey-4`
+// and `$grey-5` is large. Represents `base-semi` in proposed future palette,
+// minus blue tint.
+$grey-semi: #9c9c9c;
+
+// This is the lightest grey admissible on a white, $grey-0 or $grey-1
+// background to meet WCAG-AA text contrast requirements.
+$grey-5: #737373;
+
+// Interim color variable for migration purposes, as the step between `$grey-5`
+// and `$grey-6` is large. Represents `base-mid` in proposed future palette,
+// minus blue tint.
+// This is the lightest grey admissible on $grey-2, $grey-3
+$grey-mid: #595959;
+
+$grey-6: #3f3f3f;
+
+$grey-7: #202020;
+
+$brand: #bd1c2b;
+
+$link-hover: #84141e !default;

--- a/src/styles/ui-playground/ui-playground.scss
+++ b/src/styles/ui-playground/ui-playground.scss
@@ -3,6 +3,7 @@
 @use '../mixins/layout';
 @use '../variables' as var;
 
+@use '../shared';
 @use '../sidebar/components/Menu';
 @use '../sidebar/components/MenuItem';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "references": [{ "path": "src/" }, { "path": "dev-server/" }],
+  "files": []
+}


### PR DESCRIPTION
~~Depends on #3184~~
Part of https://github.com/hypothesis/client/issues/3000

This PR adds a collection of shared button components and their styling to some temporary `shared` directories in this repo. These assets will ultimately be moved to the `frontend-shared` package.

Examples of all of the shared button components are visible in the UI-Playground in your local web dev server.

Changes since last variant of these components in #3173 

* Removal of the `size` props from button components. We might need sizes in the future, but we, admittedly, do not yet. Associated simplification of examples in the pattern library.
* Removal of the `CustomButton` component as all immediately-foreseeable customizations can be accomplished by styling the existing other components (we can always add it back).

_Updated_: Another commit pushed that adds a local `tsconfig.json` to the `dev-server` directory. At present, this only includes things in `ui-playground` for linting, and does not include changes to run this linting in a script or CI integration. This allowed me to find a couple of `typedef` oversights in the button components.

_Updated again_: I'm going to take this out of draft, as tests are now written.