### PR TITLE
Sort root threads by date created in notebook

### DIFF
--- a/src/sidebar/helpers/test/thread-sorters-test.js
+++ b/src/sidebar/helpers/test/thread-sorters-test.js
@@ -25,22 +25,22 @@ describe('sidebar/util/thread-sorters', () => {
   describe('sorting by newest annotation thread first', () => {
     [
       {
-        a: [{ updated: 40 }, { updated: 5 }],
-        b: [{ updated: 20 }, { updated: 3 }],
+        a: [{ created: 40 }, { created: 5 }],
+        b: [{ created: 20 }, { created: 3 }],
         expected: -1,
       },
       {
-        a: [{ updated: 20 }, { updated: 3 }],
-        b: [{ updated: 20 }, { updated: 3 }],
+        a: [{ created: 20 }, { created: 3 }],
+        b: [{ created: 20 }, { created: 3 }],
         expected: 0,
       },
       {
-        a: [{ updated: 20 }, { updated: 3 }],
-        b: [{ updated: 40 }, { updated: 5 }],
+        a: [{ created: 20 }, { created: 3 }],
+        b: [{ created: 40 }, { created: 5 }],
         expected: 1,
       },
     ].forEach(testCase => {
-      it('sorts by newest updated root annotation', () => {
+      it('sorts by newest created root annotation', () => {
         // Disable eslint: `sorters` properties start with capital letters
         // to match their displayed sort option values
         /* eslint-disable-next-line new-cap */
@@ -52,22 +52,22 @@ describe('sidebar/util/thread-sorters', () => {
   describe('sorting by oldest annotation thread first', () => {
     [
       {
-        a: [{ updated: 20 }, { updated: 5 }],
-        b: [{ updated: 40 }, { updated: 3 }],
+        a: [{ created: 20 }, { created: 5 }],
+        b: [{ created: 40 }, { created: 3 }],
         expected: 1,
       },
       {
-        a: [{ updated: 20 }, { updated: 3 }],
-        b: [{ updated: 20 }, { updated: 3 }],
+        a: [{ created: 20 }, { created: 3 }],
+        b: [{ created: 20 }, { created: 3 }],
         expected: 0,
       },
       {
-        a: [{ updated: 40 }, { updated: 3 }],
-        b: [{ updated: 20 }, { updated: 5 }],
+        a: [{ created: 40 }, { created: 3 }],
+        b: [{ created: 20 }, { created: 5 }],
         expected: -1,
       },
     ].forEach(testCase => {
-      it('sorts by oldest updated root annotation', () => {
+      it('sorts by oldest created root annotation', () => {
         // Disable eslint: `sorters` properties start with capital letters
         // to match their displayed sort option values
         /* eslint-disable-next-line new-cap */

--- a/src/sidebar/helpers/thread-sorters.js
+++ b/src/sidebar/helpers/thread-sorters.js
@@ -21,7 +21,7 @@ function compareHeadlessThreads(a, b) {
 }
 
 /**
- * Find the most recent updated date amongst a thread's root annotation set
+ * Find the most recent created date amongst a thread's root annotation set
  *
  * @param {Thread} thread
  * @return {string}
@@ -30,13 +30,13 @@ function newestRootAnnotationDate(thread) {
   const annotations = rootAnnotations([thread]);
   return annotations.reduce(
     (newestDate, annotation) =>
-      annotation.updated > newestDate ? annotation.updated : newestDate,
+      annotation.created > newestDate ? annotation.created : newestDate,
     ''
   );
 }
 
 /**
- * Find the oldest updated date amongst a thread's root annotation set
+ * Find the oldest created date amongst a thread's root annotation set
  *
  * @param {Thread} thread
  * @return {string}
@@ -45,9 +45,9 @@ function oldestRootAnnotationDate(thread) {
   const annotations = rootAnnotations([thread]);
   return annotations.reduce((oldestDate, annotation) => {
     if (!oldestDate) {
-      oldestDate = annotation.updated;
+      oldestDate = annotation.created;
     }
-    return annotation.updated < oldestDate ? annotation.updated : oldestDate;
+    return annotation.created < oldestDate ? annotation.created : oldestDate;
   }, '');
 }
 

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -12,14 +12,16 @@ const fixtures = {
   annotations: [
     {
       $orphan: false,
+      created: 50,
       id: '1',
       references: [],
       target: [{ selector: [] }],
       text: 'first annotation',
-      updated: 50,
+      updated: 300,
     },
     {
       $orphan: false,
+      created: 200,
       id: '2',
       references: [],
       text: 'second annotation',
@@ -28,6 +30,7 @@ const fixtures = {
     },
     {
       $orphan: false,
+      created: 100,
       id: '3',
       references: ['2'],
       text: 'reply to first annotation',


### PR DESCRIPTION
- Add `Created` sorter method to sort by date created as opposed to date modified.


fixes https://github.com/hypothesis/client/issues/3142