### PR TITLE
Ignore direct linked annotations in notebook

### DIFF
--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -31,6 +31,7 @@ function NotebookView({ loadAnnotationsService }) {
   const hasAppliedFilter = store.hasAppliedFilter();
   const isLoading = store.isLoading();
   const resultCount = store.annotationResultCount();
+  const selectAnnotations = store.selectAnnotations;
 
   const rootThread = useRootThread();
 
@@ -100,6 +101,11 @@ function NotebookView({ loadAnnotationsService }) {
   useEffect(() => {
     onChangePage(1);
   }, [filters, focusedGroup]);
+
+  useEffect(() => {
+    // The notebook ignores any direct linked annotations
+    selectAnnotations([]);
+  }, [selectAnnotations]);
 
   // Scroll back to here when pagination page changes
   const threadListScrollTop = useRef(/** @type {HTMLElement|null}*/ (null));


### PR DESCRIPTION
I'd like to get some early feedback about this issue.

I went around a bit with how to best tackle this. I did not want to add any complexity to the store nor do I want to add any special conditions outside the notebook. I initially thought that clearing the URL fragment might be the best approach, but there is not really a mechanism to reset the host config after `window.history.pushState` to update the annotations list from the url. That seems complex.

However, this solution seems to be lightweight and I don't think there is any harm is clearing the selected values in the store because they still in fact remain selected in the sidebar after the notebook closes--which may in fact be a bug in and of itself. It seems to me that modifying the store should update sidebar the threads, but I have not looked at specifics. Or, it may be safe to restore the selected annotations when the notebook closes, but I have not done that in this PR.

fixes https://github.com/hypothesis/client/issues/3105

![selected](https://user-images.githubusercontent.com/3939074/112384438-a924f580-8cab-11eb-803e-9ade208807b1.gif)
