### PR TITLE
Adjust the position of the adder on window.resize

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -117,6 +117,7 @@ export default class Guest {
     this.element = element;
     this._emitter = eventBus.createEmitter();
     this.visibleHighlights = false;
+    this._isAdderVisible = false;
 
     this.adder = new Adder(this.element, {
       onAnnotate: async () => {
@@ -221,6 +222,8 @@ export default class Guest {
         this.focusAnnotations([]);
       }
     });
+
+    this._listeners.add(window, 'resize', () => this._repositionAdder());
   }
 
   /**
@@ -244,6 +247,19 @@ export default class Guest {
         };
       }
     );
+  }
+
+  /**
+   * Shift the position of the adder on window 'resize' events
+   */
+  _repositionAdder() {
+    if (this._isAdderVisible === false) {
+      return;
+    }
+    const range = window.getSelection()?.getRangeAt(0);
+    if (range) {
+      this._onSelection(range);
+    }
   }
 
   _setupInitialState(config) {
@@ -600,10 +616,12 @@ export default class Guest {
     this._emitter.publish('hasSelectionChanged', true);
 
     this.adder.annotationsForSelection = annotationsForSelection();
+    this._isAdderVisible = true;
     this.adder.show(focusRect, isBackwards);
   }
 
   _onClearSelection() {
+    this._isAdderVisible = false;
     this.adder.hide();
     this.selectedRanges = [];
     this._emitter.publish('hasSelectionChanged', false);


### PR DESCRIPTION
First commit is a refactor to use the `ListenerCollection` utility.

Second commit is the actual fix for #3194.

Applying this PR, this is how the `adder` repositions on `window.resize`:

https://user-images.githubusercontent.com/8555781/112584454-2b223500-8df8-11eb-94c1-3d72f65f42bf.mov