### PR TITLE
Rename `PDF` => `PDFIntegration` and move to `src/annotator/integrations` (2/n)

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -1,9 +1,9 @@
 import scrollIntoView from 'scroll-into-view';
 
 import { Adder } from './adder';
+import { PDFIntegration } from './integrations/pdf';
 import CrossFrame from './plugin/cross-frame';
 import DocumentMeta from './plugin/document';
-import PDFIntegration from './plugin/pdf';
 
 import * as htmlAnchoring from './anchoring/html';
 import { TextRange } from './anchoring/text-range';

--- a/src/annotator/integrations/pdf-metadata.js
+++ b/src/annotator/integrations/pdf-metadata.js
@@ -59,7 +59,7 @@ function pdfViewerInitialized(app) {
  *    // Do something with the URL of the PDF.
  * })
  */
-export default class PDFMetadata {
+export class PDFMetadata {
   /**
    * Construct a `PDFMetadata` that returns URIs/metadata associated with a
    * given PDF viewer.

--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -7,7 +7,7 @@ import RenderingStates from '../pdfjs-rendering-states';
 import { createShadowRoot } from '../util/shadow-root';
 import { ListenerCollection } from '../util/listener-collection';
 
-import PDFMetadata from './pdf-metadata';
+import { PDFMetadata } from './pdf-metadata';
 
 /**
  * @typedef {import('../../types/annotator').Anchor} Anchor
@@ -21,7 +21,7 @@ import PDFMetadata from './pdf-metadata';
 // is enough room. Otherwise, allow sidebar to overlap PDF
 const MIN_PDF_WIDTH = 680;
 
-export default class PDF {
+export class PDFIntegration {
   /**
    * @param {Annotator} annotator
    */

--- a/src/annotator/integrations/test/pdf-metadata-test.js
+++ b/src/annotator/integrations/test/pdf-metadata-test.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'tiny-emitter';
 
-import PDFMetadata from '../pdf-metadata';
+import { PDFMetadata } from '../pdf-metadata';
 
 /**
  * Fake implementation of PDF.js `window.PDFViewerApplication.metadata`.
@@ -126,7 +126,7 @@ function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-describe('annotator/plugin/pdf-metadata', function () {
+describe('PDFMetadata', function () {
   [
     {
       // PDF.js < 1.6.210: `documentload` event dispatched via DOM.

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -44,8 +44,8 @@ describe('Guest', () => {
   let DocumentMeta;
   let fakeDocumentMeta;
 
-  let PdfIntegration;
-  let fakePdfIntegration;
+  let PDFIntegration;
+  let fakePDFIntegration;
 
   const createGuest = (config = {}) => {
     const element = document.createElement('div');
@@ -90,7 +90,7 @@ describe('Guest', () => {
     };
     DocumentMeta = sandbox.stub().returns(fakeDocumentMeta);
 
-    fakePdfIntegration = {
+    fakePDFIntegration = {
       contentContainer: sinon.stub().returns({}),
       destroy: sinon.stub(),
       fitSideBySide: sinon.stub().returns(false),
@@ -99,7 +99,7 @@ describe('Guest', () => {
         .resolves({ documentFingerprint: 'test-fingerprint' }),
       uri: sinon.stub().resolves('https://example.com/test.pdf'),
     };
-    PdfIntegration = sinon.stub().returns(fakePdfIntegration);
+    PDFIntegration = sinon.stub().returns(fakePDFIntegration);
 
     class FakeSelectionObserver {
       constructor(callback) {
@@ -114,7 +114,7 @@ describe('Guest', () => {
       './anchoring/text-range': {
         TextRange: FakeTextRange,
       },
-      './integrations/pdf': { PDFIntegration: PdfIntegration },
+      './integrations/pdf': { PDFIntegration },
       './highlighter': highlighter,
       './range-util': rangeUtil,
       './plugin/cross-frame': CrossFrame,
@@ -389,7 +389,7 @@ describe('Guest', () => {
           guest = createGuest({ documentType: 'pdf' });
           const metadata = { title: 'hi' };
 
-          fakePdfIntegration.getMetadata.resolves(metadata);
+          fakePDFIntegration.getMetadata.resolves(metadata);
 
           emitGuestEvent(
             'getDocumentInfo',
@@ -400,8 +400,8 @@ describe('Guest', () => {
         it('calls the callback with fallback URL if PDF URL cannot be determined', done => {
           guest = createGuest({ documentType: 'pdf' });
 
-          fakePdfIntegration.getMetadata.resolves({});
-          fakePdfIntegration.uri.rejects(new Error('Not a PDF document'));
+          fakePDFIntegration.getMetadata.resolves({});
+          fakePDFIntegration.uri.rejects(new Error('Not a PDF document'));
 
           emitGuestEvent(
             'getDocumentInfo',
@@ -416,7 +416,7 @@ describe('Guest', () => {
             link: [{ href: window.location.href }],
           };
 
-          fakePdfIntegration.getMetadata.rejects(
+          fakePDFIntegration.getMetadata.rejects(
             new Error('Not a PDF document')
           );
 
@@ -969,7 +969,7 @@ describe('Guest', () => {
     it('cleans up PDF integration', () => {
       const guest = createGuest({ documentType: 'pdf' });
       guest.destroy();
-      assert.calledOnce(fakePdfIntegration.destroy);
+      assert.calledOnce(fakePDFIntegration.destroy);
     });
 
     it('removes all highlights', () => {
@@ -989,7 +989,7 @@ describe('Guest', () => {
       const guest = createGuest({ documentType: 'pdf' });
       assert.equal(
         guest.contentContainer(),
-        fakePdfIntegration.contentContainer()
+        fakePDFIntegration.contentContainer()
       );
     });
   });
@@ -1003,23 +1003,23 @@ describe('Guest', () => {
 
     it('attempts to fit content alongside sidebar in PDF documents', () => {
       const guest = createGuest({ documentType: 'pdf' });
-      fakePdfIntegration.fitSideBySide.returns(false);
+      fakePDFIntegration.fitSideBySide.returns(false);
       const layout = { expanded: true, width: 100 };
 
       guest.fitSideBySide(layout);
 
-      assert.calledWith(fakePdfIntegration.fitSideBySide, layout);
+      assert.calledWith(fakePDFIntegration.fitSideBySide, layout);
     });
 
     it('enables closing sidebar on document click if side-by-side is not activated', () => {
       const guest = createGuest({ documentType: 'pdf' });
-      fakePdfIntegration.fitSideBySide.returns(false);
+      fakePDFIntegration.fitSideBySide.returns(false);
       const layout = { expanded: true, width: 100 };
 
       guest.fitSideBySide(layout);
       assert.isTrue(guest.closeSidebarOnDocumentClick);
 
-      fakePdfIntegration.fitSideBySide.returns(true);
+      fakePDFIntegration.fitSideBySide.returns(true);
       guest.fitSideBySide(layout);
       assert.isFalse(guest.closeSidebarOnDocumentClick);
     });

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -114,11 +114,11 @@ describe('Guest', () => {
       './anchoring/text-range': {
         TextRange: FakeTextRange,
       },
+      './integrations/pdf': { PDFIntegration: PdfIntegration },
       './highlighter': highlighter,
       './range-util': rangeUtil,
       './plugin/cross-frame': CrossFrame,
       './plugin/document': DocumentMeta,
-      './plugin/pdf': PdfIntegration,
       './selection-observer': {
         SelectionObserver: FakeSelectionObserver,
       },


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/3190**~~

Create an `integrations` directory within `src/annotator` which will
house the `*Integration` classes that encapsulate document
type/viewer-specific functionality, and create the first version of the
PDF integration by moving/renaming the existing `PDF` class. The
supporting `PDFMetadata` class has also been moved.

Per recently agreed code conventions [1], the `PDFIntegration` and
`PDFMetadata` classes are no longer default exports.

[1] https://github.com/hypothesis/frontend-toolkit/blob/master/docs/js-guide.md#default-exports
[Related Slack thread](https://hypothes-is.slack.com/archives/C1M8NH76X/p1615303150029900?thread_ts=1615302509.028600)

Part of https://github.com/hypothesis/client/issues/3128
