### PR TITLE
Unify HTML and PDF code paths in `Guest` (3/n)

### DIFF
--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -148,7 +148,7 @@ export class PDFIntegration {
 
     try {
       const hasText = await documentHasText();
-      this._showNoSelectableTextWarning(!hasText);
+      this._toggleNoSelectableTextWarning(!hasText);
     } catch (err) {
       /* istanbul ignore next */
       console.warn('Unable to check for text in PDF:', err);
@@ -161,7 +161,7 @@ export class PDFIntegration {
    *
    * @param {boolean} showWarning
    */
-  _showNoSelectableTextWarning(showWarning) {
+  _toggleNoSelectableTextWarning(showWarning) {
     // Get a reference to the top-level DOM element associated with the PDF.js
     // viewer.
     const outerContainer = /** @type {HTMLElement} */ (document.querySelector(

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -22,7 +22,7 @@ describe('PDFIntegration', () => {
   let viewerContainer;
 
   let fakeAnnotator;
-  let fakePdfAnchoring;
+  let fakePDFAnchoring;
   let fakePDFMetadata;
   let fakePDFViewerApplication;
   let pdfIntegration;
@@ -53,7 +53,7 @@ describe('PDFIntegration', () => {
       anchoring: null,
     };
 
-    fakePdfAnchoring = {
+    fakePDFAnchoring = {
       anchor: sinon.stub(),
       describe: sinon.stub(),
       documentHasText: sinon.stub().resolves(true),
@@ -68,7 +68,7 @@ describe('PDFIntegration', () => {
 
     $imports.$mock({
       './pdf-metadata': { PDFMetadata: sinon.stub().returns(fakePDFMetadata) },
-      '../anchoring/pdf': fakePdfAnchoring,
+      '../anchoring/pdf': fakePDFAnchoring,
 
       // Disable debouncing of updates.
       'lodash.debounce': callback => callback,
@@ -143,13 +143,13 @@ describe('PDFIntegration', () => {
   describe('#anchor', () => {
     it('anchors provided selectors', async () => {
       pdfIntegration = createPDFIntegration();
-      fakePdfAnchoring.anchor.returns({});
+      fakePDFAnchoring.anchor.returns({});
       const selectors = [];
 
       const range = await pdfIntegration.anchor({}, selectors);
 
-      assert.calledWith(fakePdfAnchoring.anchor, sinon.match.any, selectors);
-      assert.equal(range, fakePdfAnchoring.anchor());
+      assert.calledWith(fakePDFAnchoring.anchor, sinon.match.any, selectors);
+      assert.equal(range, fakePDFAnchoring.anchor());
     });
   });
 
@@ -157,12 +157,12 @@ describe('PDFIntegration', () => {
     it('generates selectors for passed range', async () => {
       pdfIntegration = createPDFIntegration();
       const range = {};
-      fakePdfAnchoring.describe.returns([]);
+      fakePDFAnchoring.describe.returns([]);
 
       const selectors = await pdfIntegration.describe({}, range);
 
-      assert.calledWith(fakePdfAnchoring.describe, sinon.match.any, range);
-      assert.equal(selectors, fakePdfAnchoring.describe());
+      assert.calledWith(fakePDFAnchoring.describe, sinon.match.any, range);
+      assert.equal(selectors, fakePDFAnchoring.describe());
     });
   });
 
@@ -186,12 +186,12 @@ describe('PDFIntegration', () => {
   }
 
   it('does not show a warning when PDF has selectable text', async () => {
-    fakePdfAnchoring.documentHasText.resolves(true);
+    fakePDFAnchoring.documentHasText.resolves(true);
 
     pdfIntegration = createPDFIntegration();
     await delay(0); // Wait for text check to complete.
 
-    assert.called(fakePdfAnchoring.documentHasText);
+    assert.called(fakePDFAnchoring.documentHasText);
     assert.isNull(getWarningBanner());
   });
 
@@ -201,17 +201,17 @@ describe('PDFIntegration', () => {
     pdfIntegration = createPDFIntegration();
     await delay(0); // Wait for text check to complete.
 
-    assert.notCalled(fakePdfAnchoring.documentHasText);
+    assert.notCalled(fakePDFAnchoring.documentHasText);
     assert.isNull(getWarningBanner());
   });
 
   it('shows a warning when PDF has no selectable text', async () => {
-    fakePdfAnchoring.documentHasText.resolves(false);
+    fakePDFAnchoring.documentHasText.resolves(false);
 
     pdfIntegration = createPDFIntegration();
     await delay(0); // Wait for text check to complete.
 
-    assert.called(fakePdfAnchoring.documentHasText);
+    assert.called(fakePDFAnchoring.documentHasText);
     const banner = getWarningBanner();
     assert.isNotNull(banner);
     assert.include(

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -85,7 +85,7 @@ describe('Guest', () => {
 
     fakeDocumentMeta = {
       destroy: sinon.stub(),
-      metadata: { title: 'Test title' },
+      getDocumentMetadata: sinon.stub().returns({ title: 'Test title' }),
       uri: sinon.stub().returns('https://example.com/test.html'),
     };
     DocumentMeta = sandbox.stub().returns(fakeDocumentMeta);
@@ -377,7 +377,7 @@ describe('Guest', () => {
             'getDocumentInfo',
             createCallback(
               fakeDocumentMeta.uri(),
-              fakeDocumentMeta.metadata,
+              fakeDocumentMeta.getDocumentMetadata(),
               done
             )
           );
@@ -636,7 +636,10 @@ describe('Guest', () => {
       const annotation = await guest.createAnnotation();
 
       assert.equal(annotation.uri, fakeDocumentMeta.uri());
-      assert.deepEqual(annotation.document, fakeDocumentMeta.metadata);
+      assert.deepEqual(
+        annotation.document,
+        fakeDocumentMeta.getDocumentMetadata()
+      );
     });
 
     it('adds selectors for selected ranges to the annotation', async () => {

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -70,7 +70,6 @@
  * @typedef Annotator
  * @prop {Anchor[]} anchors
  * @prop {(ann: AnnotationData) => Promise<Anchor[]>} anchor
- * @prop {AnchoringImpl} anchoring - Anchoring implementation for the current document type
  */
 
 /**


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/3198**

Unify the code paths in the `Guest` class that invoke document
type/viewer-specific code such as getting the document URI and metadata
and anchoring and generating selectors.

 - Replace `pdfIntegration` and `documentMeta` fields in `Guest` with an
   `integration` field which provides the interface to document-type
   specific functionality
 - Replace the roundabout method of `PDFIntegration` customizing the
   anchoring logic with `anchor` and `describe` methods which the
   `Guest` calls as needed
 - Add documentation and tests for `uri` and `getMetadata` methods in
   `PDFIntegration`

Part of https://github.com/hypothesis/client/issues/3128