### PR TITLE
Hide sidebar on 'mousedown' event

### DIFF
--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -462,29 +462,20 @@ describe('Guest', () => {
       fakeSidebarFrame?.remove();
     });
 
-    it('hides sidebar when the user taps or clicks in the page', () => {
-      for (let event of ['click', 'touchstart']) {
+    it('hides sidebar on user "mousedown" or "touchstart" events in the document', () => {
+      for (let event of ['mousedown', 'touchstart']) {
         rootElement.dispatchEvent(new Event(event));
         assert.calledWith(guest.crossframe.call, 'closeSidebar');
+        guest.crossframe.call.resetHistory();
       }
     });
 
-    it('does not hide sidebar if configured not to close sidebar on document click', () => {
-      for (let event of ['click', 'touchstart']) {
+    it('does not hide sidebar if configured not to close sidebar', () => {
+      for (let event of ['mousedown', 'touchstart']) {
         guest.closeSidebarOnDocumentClick = false;
         rootElement.dispatchEvent(new Event(event));
         assert.notCalled(guest.crossframe.call);
-      }
-    });
-
-    it('does not hide sidebar if event occurs inside annotator UI', () => {
-      fakeSidebarFrame = document.createElement('div');
-      fakeSidebarFrame.className = 'annotator-frame';
-      rootElement.appendChild(fakeSidebarFrame);
-
-      for (let event of ['click', 'touchstart']) {
-        fakeSidebarFrame.dispatchEvent(new Event(event, { bubbles: true }));
-        assert.notCalled(guest.crossframe.call);
+        guest.crossframe.call.resetHistory();
       }
     });
   });

--- a/src/annotator/util/shadow-root.js
+++ b/src/annotator/util/shadow-root.js
@@ -62,6 +62,7 @@ export function createShadowRoot(container) {
  * @param {HTMLElement|ShadowRoot} element
  */
 function stopEventPropagation(element) {
-  element.addEventListener('click', event => event.stopPropagation());
+  element.addEventListener('mouseup', event => event.stopPropagation());
+  element.addEventListener('mousedown', event => event.stopPropagation());
   element.addEventListener('touchstart', event => event.stopPropagation());
 }

--- a/src/annotator/util/test/shadow-root-test.js
+++ b/src/annotator/util/test/shadow-root-test.js
@@ -58,7 +58,7 @@ describe('annotator/util/shadow-root', () => {
       link.setAttribute('rel', 'stylesheet');
     });
 
-    it('stops propagation of click events', () => {
+    it('stops propagation of "mouseup" events', () => {
       const onClick = sinon.stub();
       container.addEventListener('click', onClick);
 
@@ -68,13 +68,29 @@ describe('annotator/util/shadow-root', () => {
       innerElement.dispatchEvent(
         // `composed` property is necessary to bubble up the event out of the shadow DOM.
         // browser generated events, have this property set to true.
-        new Event('click', { bubbles: true, composed: true })
+        new Event('mouseup', { bubbles: true, composed: true })
       );
 
       assert.notCalled(onClick);
     });
 
-    it('stops propagation of touchstart events', () => {
+    it('stops propagation of "mousedown" events', () => {
+      const onClick = sinon.stub();
+      container.addEventListener('mousedown', onClick);
+
+      const shadowRoot = createShadowRoot(container);
+      const innerElement = document.createElement('div');
+      shadowRoot.appendChild(innerElement);
+      innerElement.dispatchEvent(
+        // `composed` property is necessary to bubble up the event out of the shadow DOM.
+        // browser generated events, have this property set to true.
+        new Event('mousedown', { bubbles: true, composed: true })
+      );
+
+      assert.notCalled(onClick);
+    });
+
+    it('stops propagation of "touchstart" events', () => {
       const onTouch = sinon.stub();
       container.addEventListener('touchstart', onTouch);
 


### PR DESCRIPTION
When the selection of text finishes on the sidebar's iframe, the click
event is not fired. Hence, the sidebar is not collapsed and the adder is
not displayed. This is because events don't bubble up through the
iframe.

This PR makes the sidebar to collapse on 'mousedown' events on the host
page. This is similar in nature to the 'touchstart' event that `Guest`
already listens (although for totally different reason).

Closes #463