### PR TITLE
Extract HTMLIntegration class (4/n)

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -1,11 +1,10 @@
 import scrollIntoView from 'scroll-into-view';
 
 import { Adder } from './adder';
+import { HTMLIntegration } from './integrations/html';
 import { PDFIntegration } from './integrations/pdf';
 import CrossFrame from './plugin/cross-frame';
-import DocumentMeta from './plugin/document';
 
-import * as htmlAnchoring from './anchoring/html';
 import { TextRange } from './anchoring/text-range';
 import {
   getHighlightsContainingNode,
@@ -148,16 +147,7 @@ export default class Guest {
     if (config.documentType === 'pdf') {
       this.integration = new PDFIntegration(this);
     } else {
-      const documentMeta = new DocumentMeta();
-      this.integration = {
-        anchor: htmlAnchoring.anchor,
-        contentContainer: () => this.element,
-        describe: htmlAnchoring.describe,
-        destroy: () => {},
-        fitSideBySide: () => false,
-        getMetadata: () => Promise.resolve(documentMeta.getDocumentMetadata()),
-        uri: () => Promise.resolve(documentMeta.uri()),
-      };
+      this.integration = new HTMLIntegration(this.element);
     }
 
     // Set the frame identifier if it's available.

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -22,8 +22,9 @@ import { normalizeURI } from './util/url';
  * @typedef {import('./util/emitter').EventBus} EventBus
  * @typedef {import('../types/annotator').AnnotationData} AnnotationData
  * @typedef {import('../types/annotator').Anchor} Anchor
+ * @typedef {import('../types/annotator').Integration} Integration
+ * @typedef {import('../types/annotator').SidebarLayout} SidebarLayout
  * @typedef {import('../types/api').Target} Target
- * @typedef {import('./sidebar').LayoutState} LayoutState
  */
 
 /**
@@ -142,13 +143,11 @@ export default class Guest {
     /** @type {Anchor[]} */
     this.anchors = [];
 
-    // Setup the document type-specific integration consisting of metadata extraction,
-    // anchoring module and logic to respond to activity (eg. scrolling) in the page.
-    if (config.documentType === 'pdf') {
-      this.integration = new PDFIntegration(this);
-    } else {
-      this.integration = new HTMLIntegration(this.element);
-    }
+    /** @type {Integration} */
+    this.integration =
+      config.documentType === 'pdf'
+        ? new PDFIntegration(this)
+        : new HTMLIntegration(this.element);
 
     // Set the frame identifier if it's available.
     // The "top" guest instance will have this as null since it's in a top frame not a sub frame
@@ -664,7 +663,7 @@ export default class Guest {
   /**
    * Attempt to fit the document content alongside the sidebar.
    *
-   * @param {LayoutState} sidebarLayout
+   * @param {SidebarLayout} sidebarLayout
    */
   fitSideBySide(sidebarLayout) {
     const active = this.integration.fitSideBySide(sidebarLayout);

--- a/src/annotator/integrations/html-metadata.js
+++ b/src/annotator/integrations/html-metadata.js
@@ -57,10 +57,9 @@ function createMetadata() {
 }
 
 /**
- * DocumentMeta reads metadata/links from the current HTML document and
- * populates the `document` property of new annotations.
+ * HTMLMetadata reads metadata/links from the current HTML document.
  */
-export default class DocumentMeta {
+export class HTMLMetadata {
   /**
    * @param {object} [options]
    *   @param {Document} [options.document]

--- a/src/annotator/integrations/html.js
+++ b/src/annotator/integrations/html.js
@@ -1,0 +1,34 @@
+import { anchor, describe } from '../anchoring/html';
+
+import { HTMLMetadata } from './html-metadata';
+
+export class HTMLIntegration {
+  constructor(container = document.body) {
+    this.container = container;
+    this.anchor = anchor;
+    this.describe = describe;
+
+    this._htmlMeta = new HTMLMetadata();
+  }
+
+  destroy() {
+    // There is nothing to do here yet.
+  }
+
+  contentContainer() {
+    return this.container;
+  }
+
+  fitSideBySide() {
+    // Not yet implemented.
+    return false;
+  }
+
+  async getMetadata() {
+    return this._htmlMeta.getDocumentMetadata();
+  }
+
+  async uri() {
+    return this._htmlMeta.uri();
+  }
+}

--- a/src/annotator/integrations/html.js
+++ b/src/annotator/integrations/html.js
@@ -2,6 +2,18 @@ import { anchor, describe } from '../anchoring/html';
 
 import { HTMLMetadata } from './html-metadata';
 
+/**
+ * @typedef {import('../../types/annotator').Integration} Integration
+ */
+
+/**
+ * Document type integration for ordinary web pages.
+ *
+ * This integration is used for web pages and applications that are not handled
+ * by a more specific integration (eg. for PDFs).
+ *
+ * @implements {Integration}
+ */
 export class HTMLIntegration {
   constructor(container = document.body) {
     this.container = container;

--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -13,8 +13,9 @@ import { PDFMetadata } from './pdf-metadata';
  * @typedef {import('../../types/annotator').Anchor} Anchor
  * @typedef {import('../../types/annotator').Annotator} Annotator
  * @typedef {import('../../types/annotator').HypothesisWindow} HypothesisWindow
+ * @typedef {import('../../types/annotator').Integration} Integration
+ * @typedef {import('../../types/annotator').SidebarLayout} SidebarLayout
  * @typedef {import('../../types/api').Selector} Selector
- * @typedef {import('../sidebar').LayoutState} LayoutState
  */
 
 // The viewport and controls for PDF.js start breaking down below about 670px
@@ -22,6 +23,11 @@ import { PDFMetadata } from './pdf-metadata';
 // is enough room. Otherwise, allow sidebar to overlap PDF
 const MIN_PDF_WIDTH = 680;
 
+/**
+ * Integration that works with PDF.js
+ *
+ * @implements {Integration}
+ */
 export class PDFIntegration {
   /**
    * @param {Annotator} annotator
@@ -274,7 +280,7 @@ export class PDFIntegration {
    * for the sidebar, and prompt PDF.js to re-render the PDF pages to scale
    * within that resized container.
    *
-   * @param {LayoutState} sidebarLayout
+   * @param {SidebarLayout} sidebarLayout
    * @return {boolean} - True if side-by-side mode was activated
    */
   fitSideBySide(sidebarLayout) {

--- a/src/annotator/integrations/test/html-metadata-test.js
+++ b/src/annotator/integrations/test/html-metadata-test.js
@@ -11,9 +11,9 @@
  */
 
 import { normalizeURI } from '../../util/url';
-import DocumentMeta from '../document';
+import { HTMLMetadata } from '../html-metadata';
 
-describe('DocumentMeta', function () {
+describe('HTMLMetadata', function () {
   let fakeNormalizeURI;
   let tempDocument;
   let tempDocumentHead;
@@ -29,7 +29,7 @@ describe('DocumentMeta', function () {
       return normalizeURI(url, base);
     });
 
-    testDocument = new DocumentMeta({
+    testDocument = new HTMLMetadata({
       document: tempDocument,
       normalizeURI: fakeNormalizeURI,
     });
@@ -258,7 +258,7 @@ describe('DocumentMeta', function () {
           href,
         },
       };
-      const doc = new DocumentMeta({
+      const doc = new HTMLMetadata({
         document: fakeDocument,
         baseURI,
       });

--- a/src/annotator/integrations/test/html-test.js
+++ b/src/annotator/integrations/test/html-test.js
@@ -1,23 +1,23 @@
 import { HTMLIntegration, $imports } from '../html';
 
 describe('HTMLIntegration', () => {
-  let fakeHtmlAnchoring;
-  let fakeHtmlMetadata;
+  let fakeHTMLAnchoring;
+  let fakeHTMLMetadata;
 
   beforeEach(() => {
-    fakeHtmlAnchoring = {
+    fakeHTMLAnchoring = {
       anchor: sinon.stub(),
       describe: sinon.stub(),
     };
 
-    fakeHtmlMetadata = {
+    fakeHTMLMetadata = {
       getDocumentMetadata: sinon.stub().returns({ title: 'Example site' }),
       uri: sinon.stub().returns('https://example.com/'),
     };
 
-    const HTMLMetadata = sinon.stub().returns(fakeHtmlMetadata);
+    const HTMLMetadata = sinon.stub().returns(fakeHTMLMetadata);
     $imports.$mock({
-      '../anchoring/html': fakeHtmlAnchoring,
+      '../anchoring/html': fakeHTMLAnchoring,
       './html-metadata': { HTMLMetadata },
     });
   });
@@ -28,8 +28,8 @@ describe('HTMLIntegration', () => {
 
   it('implements `anchor` and `destroy` using HTML anchoring', () => {
     const integration = new HTMLIntegration();
-    assert.equal(integration.anchor, fakeHtmlAnchoring.anchor);
-    assert.equal(integration.describe, fakeHtmlAnchoring.describe);
+    assert.equal(integration.anchor, fakeHTMLAnchoring.anchor);
+    assert.equal(integration.describe, fakeHTMLAnchoring.describe);
   });
 
   describe('#contentContainer', () => {
@@ -40,7 +40,7 @@ describe('HTMLIntegration', () => {
   });
 
   describe('#destroy', () => {
-    it('cleans up integration', () => {
+    it('does nothing', () => {
       new HTMLIntegration().destroy();
     });
   });

--- a/src/annotator/integrations/test/html-test.js
+++ b/src/annotator/integrations/test/html-test.js
@@ -1,0 +1,69 @@
+import { HTMLIntegration, $imports } from '../html';
+
+describe('HTMLIntegration', () => {
+  let fakeHtmlAnchoring;
+  let fakeHtmlMetadata;
+
+  beforeEach(() => {
+    fakeHtmlAnchoring = {
+      anchor: sinon.stub(),
+      describe: sinon.stub(),
+    };
+
+    fakeHtmlMetadata = {
+      getDocumentMetadata: sinon.stub().returns({ title: 'Example site' }),
+      uri: sinon.stub().returns('https://example.com/'),
+    };
+
+    const HTMLMetadata = sinon.stub().returns(fakeHtmlMetadata);
+    $imports.$mock({
+      '../anchoring/html': fakeHtmlAnchoring,
+      './html-metadata': { HTMLMetadata },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('implements `anchor` and `destroy` using HTML anchoring', () => {
+    const integration = new HTMLIntegration();
+    assert.equal(integration.anchor, fakeHtmlAnchoring.anchor);
+    assert.equal(integration.describe, fakeHtmlAnchoring.describe);
+  });
+
+  describe('#contentContainer', () => {
+    it('returns body by default', () => {
+      const integration = new HTMLIntegration();
+      assert.equal(integration.contentContainer(), document.body);
+    });
+  });
+
+  describe('#destroy', () => {
+    it('cleans up integration', () => {
+      new HTMLIntegration().destroy();
+    });
+  });
+
+  describe('#fitSideBySide', () => {
+    it('does nothing', () => {
+      new HTMLIntegration().fitSideBySide({});
+    });
+  });
+
+  describe('#getMetadata', () => {
+    it('returns document metadata', async () => {
+      const integration = new HTMLIntegration();
+      assert.deepEqual(await integration.getMetadata(), {
+        title: 'Example site',
+      });
+    });
+  });
+
+  describe('#uri', () => {
+    it('returns main document URL', async () => {
+      const integration = new HTMLIntegration();
+      assert.deepEqual(await integration.uri(), 'https://example.com/');
+    });
+  });
+});

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -73,14 +73,19 @@
  */
 
 /**
+ * Details about the current layout state of the sidebar.
+ *
+ * This is used in notifications about sidebar layout changes which other parts
+ * of the annotator react to.
+ *
  * @typedef SidebarLayout
- * @prop {boolean} expanded
- * @prop {number} width
+ * @prop {boolean} expanded - Whether sidebar is open or closed
+ * @prop {number} width - Current width of sidebar in pixels
  */
 
 /**
  * Interface for document type/viewer integrations that handle all the details
- * of supporting a specific document type (web page, PDF, ebook etc.).
+ * of supporting a specific document type (web page, PDF, ebook, etc.).
  *
  * @typedef Integration
  * @prop {(root: HTMLElement, selectors: Selector[]) => Promise<Range>} anchor -
@@ -93,13 +98,15 @@
  *   Return the main element that contains the document content. This is used
  *   by controls such as the bucket bar to know when the content might have scrolled.
  * @prop {() => void} destroy -
- *   Clean up the integration and remove any event listeners, caches etc.
+ *   Clean up the integration and remove any event listeners, caches, etc.
  * @prop {(layout: SidebarLayout) => boolean} fitSideBySide -
  *   Attempt to resize the content so that it is visible alongside the sidebar.
  *   Returns `true` if the sidebar and content are displayed side-by-side or
  *   false otherwise.
- * @prop {() => Promise<object>} getMetadata
- * @prop {() => Promise<string>} uri - Return the URL of the currently loaded document
+ * @prop {() => Promise<DocumentMetadata>} getMetadata - Return the metadata of
+ *   the currently loaded document, such as title, PDF fingerprint, etc.
+ * @prop {() => Promise<string>} uri - Return the URL of the currently loaded document.
+ *   This may be different than the current URL (`location.href`) in a PDF for example.
  */
 
 /**

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -73,6 +73,36 @@
  */
 
 /**
+ * @typedef SidebarLayout
+ * @prop {boolean} expanded
+ * @prop {number} width
+ */
+
+/**
+ * Interface for document type/viewer integrations that handle all the details
+ * of supporting a specific document type (web page, PDF, ebook etc.).
+ *
+ * @typedef Integration
+ * @prop {(root: HTMLElement, selectors: Selector[]) => Promise<Range>} anchor -
+ *   Attempt to resolve a set of serialized selectors to the corresponding content in the
+ *   current document.
+ * @prop {(root: HTMLElement, range: Range) => Selector[]|Promise<Selector[]>} describe -
+ *   Generate a list of serializable selectors which represent the content in
+ *   `range`.
+ * @prop {() => HTMLElement} contentContainer -
+ *   Return the main element that contains the document content. This is used
+ *   by controls such as the bucket bar to know when the content might have scrolled.
+ * @prop {() => void} destroy -
+ *   Clean up the integration and remove any event listeners, caches etc.
+ * @prop {(layout: SidebarLayout) => boolean} fitSideBySide -
+ *   Attempt to resize the content so that it is visible alongside the sidebar.
+ *   Returns `true` if the sidebar and content are displayed side-by-side or
+ *   false otherwise.
+ * @prop {() => Promise<object>} getMetadata
+ * @prop {() => Promise<string>} uri - Return the URL of the currently loaded document
+ */
+
+/**
  * @typedef DocumentMetadata
  * @prop {string} title
  * @prop {Object[]} link


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/3199**

This PR extracts the integration that handles HTML documents into an `HTMLIntegration` class, to match the `PDFIntegration` class added in https://github.com/hypothesis/client/pull/3198. It also renames the existing `DocumentMeta` class to `HTMLMetadata` to match the `PDFMetadata` class and moves it from `src/annotator/plugins` to `src/annotator/integrations`.

The `HTMLIntegration` and `PDFIntegration` class implement a common `Integration` interface which is also added in this PR in `src/types/annotator.js`.

Part of https://github.com/hypothesis/client/issues/3128