### PR TITLE
Remove `plugin` directory from src/annotator/

### DIFF
--- a/src/annotator/cross-frame.js
+++ b/src/annotator/cross-frame.js
@@ -1,11 +1,11 @@
-import AnnotationSync from '../annotation-sync';
-import Bridge from '../../shared/bridge';
-import Discovery from '../../shared/discovery';
-import * as frameUtil from '../util/frame-util';
-import FrameObserver from '../frame-observer';
+import AnnotationSync from './annotation-sync';
+import Bridge from '../shared/bridge';
+import Discovery from '../shared/discovery';
+import * as frameUtil from './util/frame-util';
+import FrameObserver from './frame-observer';
 
 /**
- * @typedef {import('../../types/annotator').AnnotationData} AnnotationData
+ * @typedef {import('../types/annotator').AnnotationData} AnnotationData
  */
 
 /**
@@ -17,7 +17,7 @@ import FrameObserver from '../frame-observer';
  * are added to the page if they have the `enable-annotation` attribute set
  * and are same-origin with the current document.
  */
-export default class CrossFrame {
+export class CrossFrame {
   /**
    * @param {Element} element
    * @param {object} options

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -1,9 +1,9 @@
 import scrollIntoView from 'scroll-into-view';
 
 import { Adder } from './adder';
+import { CrossFrame } from './cross-frame';
 import { HTMLIntegration } from './integrations/html';
 import { PDFIntegration } from './integrations/pdf';
-import CrossFrame from './plugin/cross-frame';
 
 import { TextRange } from './anchoring/text-range';
 import {

--- a/src/annotator/test/cross-frame-test.js
+++ b/src/annotator/test/cross-frame-test.js
@@ -1,5 +1,4 @@
-import CrossFrame from '../cross-frame';
-import { $imports } from '../cross-frame';
+import { CrossFrame, $imports } from '../cross-frame';
 
 describe('CrossFrame', () => {
   let fakeDiscovery;
@@ -41,9 +40,9 @@ describe('CrossFrame', () => {
     proxyBridge = sinon.stub().returns(fakeBridge);
 
     $imports.$mock({
-      '../annotation-sync': proxyAnnotationSync,
-      '../../shared/bridge': proxyBridge,
-      '../../shared/discovery': proxyDiscovery,
+      './annotation-sync': proxyAnnotationSync,
+      '../shared/bridge': proxyBridge,
+      '../shared/discovery': proxyDiscovery,
     });
   });
 

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -116,7 +116,7 @@ describe('Guest', () => {
       './integrations/pdf': { PDFIntegration },
       './highlighter': highlighter,
       './range-util': rangeUtil,
-      './plugin/cross-frame': CrossFrame,
+      './cross-frame': { CrossFrame },
       './selection-observer': {
         SelectionObserver: FakeSelectionObserver,
       },

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -53,12 +53,12 @@ describe('anchoring', function () {
 
   before(() => {
     guestImports.$mock({
-      './plugin/cross-frame': FakeCrossFrame,
+      './cross-frame': { CrossFrame: FakeCrossFrame },
     });
   });
 
   after(() => {
-    guestImports.$restore({ './plugins/cross-frame': true });
+    guestImports.$restore({ './cross-frame': true });
   });
 
   beforeEach(() => {

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -58,7 +58,7 @@ describe('anchoring', function () {
   });
 
   after(() => {
-    guestImports.$restore({ './cross-frame': true });
+    guestImports.$restore();
   });
 
   beforeEach(() => {

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -1,6 +1,5 @@
 import { DEBOUNCE_WAIT } from '../../frame-observer';
-import CrossFrame from '../../plugin/cross-frame';
-import { $imports } from '../../plugin/cross-frame';
+import { CrossFrame, $imports } from '../../cross-frame';
 import { isLoaded } from '../../util/frame-util';
 
 describe('CrossFrame multi-frame scenario', function () {
@@ -30,8 +29,8 @@ describe('CrossFrame multi-frame scenario', function () {
     proxyBridge = sandbox.stub().returns(fakeBridge);
 
     $imports.$mock({
-      '../annotation-sync': proxyAnnotationSync,
-      '../../shared/bridge': proxyBridge,
+      './annotation-sync': proxyAnnotationSync,
+      '../shared/bridge': proxyBridge,
     });
 
     container = document.createElement('div');


### PR DESCRIPTION
The term "plugin" is vestigial. The remaining cross-frame.js module in this
directory has been moved up to the top level of `src/annotator/` since
there isn't a more specific home that is suitable. Also change the
`CrossFrame` class to be a named rather than default export per current
conventions.

In the longer term I think this class will probably need a complete overhaul and maybe before that we might group it in some other subdirectory, but for this PR I'm just moving it out of the `plugin` directory, since that's clearly inappropriate.