### PR TITLE
Adjust sizing for IconButtons and add compact styling for sidebar buttons

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationActionBar.js
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.js
@@ -88,7 +88,7 @@ function AnnotationActionBar({
   };
 
   return (
-    <div className="AnnotationActionBar u-layout-row">
+    <div className="AnnotationActionBar u-layout-row u-font--xlarge">
       {showEditAction && (
         <IconButton icon="edit" title="Edit" onClick={onEdit} />
       )}

--- a/src/sidebar/components/SearchInput.js
+++ b/src/sidebar/components/SearchInput.js
@@ -3,7 +3,7 @@ import { useRef, useState } from 'preact/hooks';
 
 import { useStoreProxy } from '../store/use-store';
 
-import Button from './Button';
+import { IconButton } from '../../shared/components/buttons';
 import Spinner from './Spinner';
 
 /**
@@ -78,12 +78,14 @@ export default function SearchInput({ alwaysExpanded, query, onSearch }) {
         }
       />
       {!isLoading && (
-        <Button
-          className="SearchInput__icon-button TopBar__icon-button"
-          icon="search"
-          onClick={() => input.current.focus()}
-          title="Search annotations"
-        />
+        <div className="SearchInput__button-container">
+          <IconButton
+            className="CompactIconButton"
+            icon="search"
+            onClick={() => input.current.focus()}
+            title="Search annotations"
+          />
+        </div>
       )}
       {isLoading && <Spinner />}
     </form>

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -5,6 +5,8 @@ import isThirdPartyService from '../helpers/is-third-party-service';
 import { withServices } from '../service-context';
 import { applyTheme } from '../helpers/theme';
 
+import { IconButton } from '../../shared/components/buttons';
+
 import Button from './Button';
 import GroupList from './GroupList';
 import SearchInput from './SearchInput';
@@ -110,10 +112,10 @@ function TopBar({
         <div className="TopBar__inner content">
           <StreamSearchInput />
           <div className="u-stretch" />
-          <Button
-            className="TopBar__icon-button"
+          <IconButton
+            className="CompactIconButton"
             icon="help"
-            isExpanded={isHelpPanelOpen}
+            expanded={isHelpPanelOpen}
             onClick={requestHelp}
             title="Help"
           />
@@ -126,10 +128,11 @@ function TopBar({
           <GroupList className="GroupList" auth={auth} />
           <div className="u-stretch" />
           {pendingUpdateCount > 0 && (
-            <Button
-              className="TopBar__icon-button TopBar__icon-button--refresh"
+            <IconButton
+              className="CompactIconButton"
               icon="refresh"
               onClick={applyPendingUpdates}
+              variant="primary"
               title={`Show ${pendingUpdateCount} new/updated ${
                 pendingUpdateCount === 1 ? 'annotation' : 'annotations'
               }`}
@@ -141,18 +144,18 @@ function TopBar({
           />
           <SortMenu />
           {showSharePageButton && (
-            <Button
-              className="TopBar__icon-button"
+            <IconButton
+              className="CompactIconButton"
               icon="share"
-              isExpanded={isAnnotationsPanelOpen}
+              expanded={isAnnotationsPanelOpen}
               onClick={toggleSharePanel}
               title="Share annotations on this page"
             />
           )}
-          <Button
-            className="TopBar__icon-button"
+          <IconButton
+            className="CompactIconButton"
             icon="help"
-            isExpanded={isHelpPanelOpen}
+            expanded={isHelpPanelOpen}
             onClick={requestHelp}
             title="Help"
           />

--- a/src/sidebar/components/test/SearchInput-test.js
+++ b/src/sidebar/components/test/SearchInput-test.js
@@ -100,7 +100,7 @@ describe('SearchInput', () => {
   it('renders search button when app is not in "loading" state', () => {
     fakeStore.isLoading.returns(false);
     const wrapper = createSearchInput();
-    assert.isTrue(wrapper.exists('Button'));
+    assert.isTrue(wrapper.exists('IconButton'));
   });
 
   it(

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -50,7 +50,7 @@ describe('TopBar', () => {
 
   // Helper to retrieve an `Button` by icon name, for convenience
   function getButton(wrapper, iconName) {
-    return wrapper.find('Button').filter({ icon: iconName });
+    return wrapper.find('IconButton').filter({ icon: iconName });
   }
 
   function createTopBar(props = {}) {
@@ -108,7 +108,7 @@ describe('TopBar', () => {
 
         wrapper.update();
 
-        assert.isTrue(helpButton.props().isExpanded);
+        assert.isTrue(helpButton.props().expanded);
       });
 
       context('help service handler configured in services', () => {
@@ -212,7 +212,7 @@ describe('TopBar', () => {
     const wrapper = createTopBar();
     const shareButton = getButton(wrapper, 'share');
 
-    assert.isTrue(shareButton.prop('isExpanded'));
+    assert.isTrue(shareButton.prop('expanded'));
   });
 
   it('displays search input in the sidebar', () => {

--- a/src/styles/mixins/utils.scss
+++ b/src/styles/mixins/utils.scss
@@ -74,6 +74,12 @@
   font-weight: 500;
 }
 
+@mixin font--xlarge {
+  @include font-base;
+  font-size: var.$font-size--subheading;
+  font-weight: 500;
+}
+
 @mixin shadow {
   box-shadow: 0 1px 1px var.$color-shadow--base;
 }

--- a/src/styles/shared/components/buttons/mixins.scss
+++ b/src/styles/shared/components/buttons/mixins.scss
@@ -95,13 +95,51 @@
     &--icon-right svg {
       margin-left: map.get($options, 'margin');
     }
+    // When a button has "layout", that indicates it has some textual content:
+    // Size text to the contextual 1em, and adjust the icon to look balanced.
+    // H frontend app buttons tend to apply an icon:text ratio of ~1.25:1
+    svg {
+      width: 1.25em;
+      height: 1.25em;
+    }
+  } @else {
+    // In the case where an icon is the only content in a <button> element,
+    // size the icon based on contextual font-size. i.e. the icon IS
+    // the content
+    svg {
+      width: 1em;
+      height: 1em;
+    }
   }
+}
 
-  // (icon) SVG sizing is relevant
-  svg {
-    width: 1.25em;
-    height: 1.25em;
+/**
+ * Convenience function to retrieve a colormap. This obviates the need to reach
+ * into the `_config` module directly from outside and is less verbose.
+ *
+ * @param {'colors'|'icon'|'icon--primary'|'labeled'|'labeled--primary'|'link'}
+ *        [$name] - Shorthand name of colormap to retrieved. Defaults to base
+ *          $colors.
+ * @return {sass:map}
+ */
+@function colormap($name: 'colors') {
+  $result: $colors;
+  @if $name == 'icon' {
+    $result: $IconButton-colors;
   }
+  @if $name == 'icon--primary' {
+    $result: $IconButton-colors--primary;
+  }
+  @if $name == 'labeled' {
+    $result: $LabeledButton-colors;
+  }
+  @if $name == 'labeled--primary' {
+    $result: $LabeledButton-colors--primary;
+  }
+  @if $name == 'link' {
+    $result: $LinkButton-colors;
+  }
+  @return $result;
 }
 
 // Base mixin for <button> elements. Start here for new <button> classes

--- a/src/styles/sidebar/buttons.scss
+++ b/src/styles/sidebar/buttons.scss
@@ -1,0 +1,22 @@
+// Button styling for the sidebar extending common button-component styles
+@use '../shared/components/buttons/mixins' as buttons;
+
+// Similar to `.IconButton`, with these changes:
+// - omit responsive minimum sizing
+// - tighten padding
+.CompactIconButton {
+  // Use icon colors for base and primary variants
+  $base-options: (
+    'colormap': buttons.colormap('icon'),
+  );
+  $primary-options: (
+    'colormap': buttons.colormap('icon--primary'),
+  );
+
+  @include buttons.Button($options: $base-options) {
+    padding: 0.25em; // Override padding
+  }
+  &--primary {
+    @include buttons.Button--variant($options: $primary-options);
+  }
+}

--- a/src/styles/sidebar/components/SearchInput.scss
+++ b/src/styles/sidebar/components/SearchInput.scss
@@ -8,7 +8,7 @@
   color: var.$color-text;
 }
 
-.SearchInput__icon-button {
+.SearchInput__button-container {
   order: 0;
 }
 

--- a/src/styles/sidebar/components/TopBar.scss
+++ b/src/styles/sidebar/components/TopBar.scss
@@ -4,7 +4,7 @@
 @use "../../variables" as var;
 
 .TopBar {
-  @include utils.font--large;
+  @include utils.font--xlarge;
   @include utils.border--bottom;
   color: var.$grey-mid;
   background: var.$white;
@@ -24,38 +24,6 @@
   // Force TopBar onto a new compositor layer so that it does not judder when
   // the window is scrolled.
   transform: translate3d(0, 0, 0);
-
-  &__icon-button {
-    @include buttons.button--icon-only;
-    padding: 0.25em;
-    @media (pointer: coarse) {
-      // Until the top bar can be refactored to allow for breathing room around
-      // the search interface, we can't spare the room for comfortable tap targets
-      // on touchscreen devices. This overrides `Button`'s larger tap targets.
-      min-width: auto;
-      min-height: auto;
-    }
-  }
-
-  &__icon-button {
-    color: var.$grey-mid;
-
-    &.is-active {
-      color: var.$grey-7;
-
-      &:hover {
-        color: var.$grey-7;
-      }
-    }
-  }
-
-  &__icon-button--refresh {
-    color: var.$color-brand;
-
-    &:hover {
-      color: var.$color-brand;
-    }
-  }
 
   &__menu-label {
     padding: var.$layout-space--xxsmall;

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -15,6 +15,9 @@
 // FIXME: Replace with shared-package variant when available
 @use '../shared';
 
+// Custom button styling for the application
+@use './buttons';
+
 // Components
 // ----------
 @use './components/Annotation';

--- a/src/styles/util.scss
+++ b/src/styles/util.scss
@@ -50,6 +50,9 @@
   @include layout.vertical-rhythm;
 }
 
+.u-font--xlarge {
+  @include utils.font--xlarge;
+}
 // Icons
 
 // These utilities establish dimensions appropriate for icon elements


### PR DESCRIPTION
This PR accomplishes the following:

* It updates the scale of icons on icon-only buttons (in the shared button component styles)
* It adds `.CompactIconButton` styling for the sidebar and makes use of it in several components (in a sidebar SASS module)

### Icon scaling for icon-only buttons (shared styles)

I had an ah-ha moment when I sat down and started to figure out how to refactor styling for "compact" icon-only buttons in the sidebar. It led me to the realization that the default scaling of button content should depend on the "main" content of a given button:

* For labeled buttons, the text on the button is the "main content." Any icon present is illustrative, but subservient to the text label. In these cases, we've (long) styled buttons such that the text is rendered at `1em`. Typically, we then size the accompanying icon at about `1.25x` the font size. No changes here: this is already how labeled buttons are styled and it's working fine so far.
* For icon-only buttons, we were (before these changes) also sizing icons at `1.25em`. This made it fiddly to get the exact icon size one intended. My lightning bolt was that, ah!, the icon in these cases _is_ the content of this button. Icon-only button styling has been adjusted in these changes such that icons are sized at `1em`.

The icon-sizing change feels intuitively correct. For example, it makes it much easier to work along with the styles that come with the (third-party) `Spinner`, which size the spinner at `1em`.

### `CompactIconButton` and icon-only button support in sidebar

To style icon-only buttons that show up in the `TopBar` (where they need to have less padding and no min-sizing in touchscreen interfaces), I've created `.CompactIconButton` styling in a module that lives in `src/styles/sidebar/buttons.scss`.

* Is this location OK for the module? I'm not attached to it. The idea is that these block/component-level styles are available throughout the sidebar.
* Is the casing OK? I left it as `CompactIconButton` because it applies to an entire component, but I don't want to imply it _is_ a component, as such.

### User-facing changes

As a result of these changes, annotation-action icons in annotation footers are now 32x32 instead of 29.25x29.25. The icons remain the same size (16px square), but the padding is more "in rhythm." They are still 44x44px for touch screens (no change). Dimensions of buttons/icons in the top bar are unchanged.

Before:

![image](https://user-images.githubusercontent.com/439947/112881343-8d4d9500-9099-11eb-9961-e818c6bb1faf.png)

After:

![image](https://user-images.githubusercontent.com/439947/112881270-76a73e00-9099-11eb-96f4-460a29d842af.png)


Part of https://github.com/hypothesis/client/issues/3000

