### PR TITLE
Refactor SidebarContentError to use Panel and shared LabeledButtons

### DIFF
--- a/src/sidebar/components/SidebarContentError.js
+++ b/src/sidebar/components/SidebarContentError.js
@@ -1,9 +1,8 @@
-import { SvgIcon } from '@hypothesis/frontend-shared';
-import classnames from 'classnames';
-
 import { useStoreProxy } from '../store/use-store';
 
-import Button from './Button';
+import { LabeledButton } from '../../shared/components/buttons';
+
+import Panel from './Panel';
 
 /**
  * @typedef SidebarContentErrorProps
@@ -43,35 +42,23 @@ export default function SidebarContentError({
   })();
 
   return (
-    <div className="SidebarContentError">
-      <div className="SidebarContentError__header">
-        <div className="SidebarContentError__header-icon">
-          <SvgIcon name="restricted" title={errorTitle} />
-        </div>
-        <div className="SidebarContentError__title u-stretch">{errorTitle}</div>
+    <Panel icon="restricted" title={errorTitle}>
+      <p>{errorMessage}</p>
+      <div className="u-layout-row--justify-right u-horizontal-rhythm">
+        {showClearSelection && (
+          <LabeledButton
+            variant={isLoggedIn ? 'primary' : undefined}
+            onClick={() => store.clearSelection()}
+          >
+            Show all annotations
+          </LabeledButton>
+        )}
+        {!isLoggedIn && (
+          <LabeledButton variant="primary" onClick={onLoginRequest}>
+            Log in
+          </LabeledButton>
+        )}
       </div>
-      <div className="SidebarContentError__content">
-        <p>{errorMessage}</p>
-        <div className="SidebarContentError__actions">
-          {showClearSelection && (
-            <Button
-              buttonText="Show all annotations"
-              className={classnames({
-                SidebarContentError__button: !isLoggedIn,
-                'SidebarContentError__button--primary': isLoggedIn,
-              })}
-              onClick={() => store.clearSelection()}
-            />
-          )}
-          {!isLoggedIn && (
-            <Button
-              buttonText="Log in"
-              className="SidebarContentError__button--primary"
-              onClick={onLoginRequest}
-            />
-          )}
-        </div>
-      </div>
-    </div>
+    </Panel>
   );
 }

--- a/src/sidebar/components/test/SidebarContentError-test.js
+++ b/src/sidebar/components/test/SidebarContentError-test.js
@@ -35,11 +35,10 @@ describe('SidebarContentError', () => {
   });
 
   const findButtonByText = (wrapper, text) => {
-    return wrapper.find('Button').filter({ buttonText: text });
-  };
-
-  const errorText = wrapper => {
-    return wrapper.find('.SidebarContentError__content').text();
+    return wrapper
+      .find('LabeledButton')
+      .filterWhere(button => button.text() === text)
+      .at(0);
   };
 
   it('should provide a button to clear the selection (show all annotations)', () => {
@@ -50,6 +49,7 @@ describe('SidebarContentError', () => {
     });
 
     const clearButton = findButtonByText(wrapper, 'Show all annotations');
+
     assert.isTrue(clearButton.exists());
 
     clearButton.props().onClick();
@@ -63,10 +63,10 @@ describe('SidebarContentError', () => {
       const wrapper = createComponent();
 
       assert.include(
-        errorText(wrapper),
+        wrapper.text(),
         'The annotation associated with the current URL is unavailable'
       );
-      assert.include(errorText(wrapper), 'You may need to log in');
+      assert.include(wrapper.text(), 'You may need to log in');
     });
 
     it('should render a log in button', () => {
@@ -88,10 +88,10 @@ describe('SidebarContentError', () => {
       const wrapper = createComponent();
 
       assert.include(
-        errorText(wrapper),
+        wrapper.text(),
         'The current URL links to an annotation, but that annotation'
       );
-      assert.notInclude(errorText(wrapper), 'You may need to log in');
+      assert.notInclude(wrapper.text(), 'You may need to log in');
     });
 
     it('should not provide an option to log in', () => {
@@ -111,10 +111,10 @@ describe('SidebarContentError', () => {
       const wrapper = createComponent({ errorType: 'group' });
 
       assert.include(
-        errorText(wrapper),
+        wrapper.text(),
         'The group associated with the current URL is unavailable'
       );
-      assert.include(errorText(wrapper), 'You may need to log in');
+      assert.include(wrapper.text(), 'You may need to log in');
     });
 
     it('should provide option to log in', () => {
@@ -134,10 +134,10 @@ describe('SidebarContentError', () => {
       const wrapper = createComponent({ errorType: 'group' });
 
       assert.include(
-        errorText(wrapper),
+        wrapper.text(),
         'The current URL links to a group, but that group'
       );
-      assert.notInclude(errorText(wrapper), 'You may need to log in');
+      assert.notInclude(wrapper.text(), 'You may need to log in');
     });
 
     it('should not provide an option to log in', () => {

--- a/src/styles/annotator/notebook.scss
+++ b/src/styles/annotator/notebook.scss
@@ -26,7 +26,7 @@
 .Notebook__inner {
   position: relative;
   box-sizing: border-box;
-  @include molecules.panel;
+  @include molecules.card-frame;
   padding: 0;
   width: 100%;
   height: 100%;
@@ -37,7 +37,6 @@
   width: 100%;
   height: 100%;
   border: none;
-  margin-top: 0 !important; // disables the margin-top set by vertical-rhythm mixin
 }
 
 .Notebook__close-button {

--- a/src/styles/mixins/layout.scss
+++ b/src/styles/mixins/layout.scss
@@ -60,11 +60,16 @@
  * Establish a horizontal (margin) rhythm for this element's immediate
  * children (i.e. put equal space between children).
  *
+ * This mixin uses `!important` such that it can compete with specificity
+ * of reset rules that set some of our element's margins to 0. That allows
+ * these rules—which are applied to a parent element—to be able to assert
+ * margins, as it should be able to do.
+ *
  * @param $size [5px] - Size of horizontal margin between child elements
  */
 @mixin horizontal-rhythm($size: 5px) {
   & > * + * {
-    margin-left: $size;
+    margin-left: $size !important;
   }
 }
 
@@ -72,12 +77,17 @@
  * Establish a vertical (margin) rhythm for this element's immediate
  * children (i.e. put equal space between children).
  *
+ * This mixin uses `!important` such that it can compete with specificity
+ * of reset rules that set some of our element's margins to 0. That allows
+ * these rules—which are applied to a parent element—to be able to assert
+ * margins, as it should be able to do.
+ *
  * @param $size [var.$layout-space--medium]: Spacing size (padding)
  * @FIXME Find workaround for SvgIcon exception
  */
 @mixin vertical-rhythm($size: var.$layout-space) {
   & > * + *:not([class*='SvgIcon--inline']) {
-    margin-top: $size;
+    margin-top: $size !important;
   }
 }
 

--- a/src/styles/sidebar/components/SidebarContentError.scss
+++ b/src/styles/sidebar/components/SidebarContentError.scss
@@ -1,8 +1,0 @@
-@use "../../mixins/molecules";
-@use "../../variables" as var;
-
-.SidebarContentError {
-  @include molecules.panel;
-  position: relative;
-  margin-bottom: 0.75em;
-}

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -53,7 +53,6 @@
 @use './components/ShareAnnotationsPanel';
 @use './components/SearchInput';
 @use './components/ShareLinks';
-@use './components/SidebarContentError';
 @use './components/Spinner';
 @use './components/TagEditor';
 @use './components/TagList';


### PR DESCRIPTION
This PR updates the `SharedContentError` component to use `Panel`, obviating the need for component-specific styling and making things more consistent. Use new shared `LabeledButtons` here, as well.

There is an additional commit that adds an `!important` rule to two, carefully-selected utility mixins. Please read that commit's description for justification/information. (I never, ever use `!important`. Until now).

Fixes #3192 
Part of #3000