### PR TITLE
Give some breathing room with line-height in markdown editor

### DIFF
--- a/src/styles/sidebar/components/MarkdownEditor.scss
+++ b/src/styles/sidebar/components/MarkdownEditor.scss
@@ -62,6 +62,7 @@ svg.MarkdownEditor__toolbar-button-icon {
 .MarkdownEditor__input {
   @include forms.form-input;
 
+  line-height: var.$line-height;
   min-height: 8em;
   resize: vertical;
   width: 100%;


### PR DESCRIPTION
I see what happened here :). Sometime in the recent past, I reset `line-height` to `1` on the _main containing element_, which unfortunately reset it on the `input`/textarea field, which is where the spacier line-height was actually needed.

I've updated styles to apply the spacier line-height directly to the input.

With luck, we'll get to sorting out base styling for forms and fields in the near future and some of this will get more consolidated.

Fixes https://github.com/hypothesis/client/issues/3221