### PR TITLE
Prepare config for namespaces

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -2,52 +2,162 @@ import settingsFrom from './settings';
 import { toBoolean } from '../../shared/type-coercions';
 
 /**
- * Reads the Hypothesis configuration from the environment.
- *
- * @param {Window} window_ - The Window object to read config from.
+ * @typedef ConfigDefinition
+ * @prop {Array<string>} namespaces - Namespaces that this name is valid in
+ * @prop {boolean} allowInBrowserExt - Allow this name to be available in the browser extension
+ * @prop {any} [defaultValue] - Sets a default if `valueFn` returns undefined
+ * @prop {([configName]: string) => any} valueFn -
+ *   Method to retrieve the value from the incoming source
+ * @prop {(value: any) => any} coerce - Transform a value's type value or value
  */
-export default function configFrom(window_) {
-  const settings = settingsFrom(window_);
-  return {
-    annotations: settings.annotations,
-    // URL where client assets are served from. Used when injecting the client
-    // into child iframes.
-    assetRoot: settings.hostPageSetting('assetRoot', {
-      allowInBrowserExt: true,
-    }),
-    branding: settings.hostPageSetting('branding'),
-    // URL of the client's boot script. Used when injecting the client into
-    // child iframes.
-    clientUrl: settings.clientUrl,
-    enableExperimentalNewNoteButton: settings.hostPageSetting(
-      'enableExperimentalNewNoteButton'
-    ),
-    experimental: settings.hostPageSetting('experimental', {
-      defaultValue: {},
-    }),
-    group: settings.group,
-    focus: settings.hostPageSetting('focus'),
-    theme: settings.hostPageSetting('theme'),
-    usernameUrl: settings.hostPageSetting('usernameUrl'),
-    onLayoutChange: settings.hostPageSetting('onLayoutChange'),
-    openSidebar: settings.hostPageSetting('openSidebar', {
-      allowInBrowserExt: true,
-      // Coerce value to a boolean because it may come from via as a string
-      coerce: toBoolean,
-    }),
-    query: settings.query,
-    requestConfigFromFrame: settings.hostPageSetting('requestConfigFromFrame'),
-    services: settings.hostPageSetting('services'),
-    showHighlights: settings.showHighlights,
-    notebookAppUrl: settings.notebookAppUrl,
-    sidebarAppUrl: settings.sidebarAppUrl,
-    // Subframe identifier given when a frame is being embedded into
-    // by a top level client
-    subFrameIdentifier: settings.hostPageSetting('subFrameIdentifier', {
-      allowInBrowserExt: true,
-    }),
-    externalContainerSelector: settings.hostPageSetting(
-      'externalContainerSelector'
-    ),
-  };
+
+/**
+ * @typedef ConfigDefinitionMap
+ * @prop {ConfigDefinition} annotations
+ * @prop {ConfigDefinition} assetRoot
+ * @prop {ConfigDefinition} branding
+ * @prop {ConfigDefinition} clientUrl
+ * @prop {ConfigDefinition} enableExperimentalNewNoteButton
+ * @prop {ConfigDefinition} experimental
+ * @prop {ConfigDefinition} group
+ * @prop {ConfigDefinition} focus
+ * @prop {ConfigDefinition} theme
+ * @prop {ConfigDefinition} usernameUrl
+ * @prop {ConfigDefinition} onLayoutChange
+ * @prop {ConfigDefinition} openSidebar
+ * @prop {ConfigDefinition} query
+ * @prop {ConfigDefinition} requestConfigFromFrame
+ * @prop {ConfigDefinition} services
+ * @prop {ConfigDefinition} showHighlights
+ * @prop {ConfigDefinition} notebookAppUrl
+ * @prop {ConfigDefinition} sidebarAppUrl
+ * @prop {ConfigDefinition} subFrameIdentifier
+ * @prop {ConfigDefinition} externalContainerSelector
+ */
+
+/**
+ * Reads the Hypothesis configuration from the environment.
+ */
+export default class Config {
+  /**
+   * @param {Window} window_ - The Window object to read config from.
+   */
+  constructor(window_) {
+    const settings = settingsFrom(window_);
+    this.isBrowserExtension = settings.isBrowserExtension;
+
+    // Base (default) config definition
+    const defaults = {
+      namespaces: ['annotator', 'sidebar', 'notebook'],
+      allowInBrowserExt: false,
+      defaultValue: null,
+      valueFn: settings.hostPageSetting,
+      coerce: name => name, //no-op.
+    };
+
+    // The definition for configuration sources, their default values and app limitations.
+    /** @type {ConfigDefinitionMap} */
+    this.configDefinitions = {
+      annotations: {
+        ...defaults,
+        allowInBrowserExt: true,
+        valueFn: () => settings.annotations,
+      },
+      // URL where client assets are served from. Used when injecting the client
+      // into child iframes.
+      assetRoot: {
+        ...defaults,
+        allowInBrowserExt: true,
+      },
+      branding: { ...defaults },
+      // URL of the client's boot script. Used when injecting the client into
+      // child iframes.
+      clientUrl: {
+        ...defaults,
+        allowInBrowserExt: true,
+        valueFn: () => settings.clientUrl,
+      },
+      enableExperimentalNewNoteButton: { ...defaults },
+      experimental: {
+        ...defaults,
+        defaultValue: {},
+      },
+      group: {
+        ...defaults,
+        allowInBrowserExt: true,
+        valueFn: () => settings.group,
+      },
+      focus: { ...defaults },
+      theme: { ...defaults },
+      usernameUrl: { ...defaults },
+      onLayoutChange: { ...defaults },
+      openSidebar: {
+        ...defaults,
+        allowInBrowserExt: true,
+        coerce: toBoolean,
+      },
+      query: {
+        ...defaults,
+        allowInBrowserExt: true,
+        valueFn: () => settings.query,
+      },
+      requestConfigFromFrame: { ...defaults },
+      services: { ...defaults },
+      showHighlights: {
+        ...defaults,
+        allowInBrowserExt: true,
+        valueFn: () => settings.showHighlights,
+      },
+      notebookAppUrl: {
+        ...defaults,
+        allowInBrowserExt: true,
+        valueFn: () => settings.notebookAppUrl,
+      },
+      sidebarAppUrl: {
+        ...defaults,
+        allowInBrowserExt: true,
+        valueFn: () => settings.sidebarAppUrl,
+      },
+      // Sub-frame identifier given when a frame is being embedded into
+      // by a top level client
+      subFrameIdentifier: {
+        ...defaults,
+        allowInBrowserExt: true,
+      },
+      externalContainerSelector: { ...defaults },
+    };
+  }
+
+  /**
+   * Return the configuration.
+   *
+   * @param {'sidebar'|'notebook'|'annotator'|null} [namespace] -
+   *   The name of the app. Omit this param to return the total configuration
+   */
+  get(namespace = null) {
+    const partialConfig = {};
+    for (const [key, configDefs] of Object.entries(this.configDefinitions)) {
+      // If namespace is requested, skip any values not belonging to the namespace
+      if (namespace && !configDefs.namespaces.includes(namespace)) {
+        continue;
+      }
+
+      // If allowInBrowserExt is false and this is the browser extension context, skip value
+      if (!configDefs.allowInBrowserExt && this.isBrowserExtension) {
+        continue;
+      }
+
+      // Get the value from the configuration source and run through a coerce method. Note
+      // the default coerce method is a no-op.
+      const value = configDefs.coerce(configDefs.valueFn.call(this, key));
+
+      // If a defaultValue is provided and the value is undefined, set the default
+      if (value === undefined && configDefs.defaultValue !== undefined) {
+        partialConfig[key] = configDefs.defaultValue;
+      } else {
+        partialConfig[key] = value;
+      }
+    }
+    return partialConfig;
+  }
 }

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -218,6 +218,9 @@ export default function settingsFrom(window_) {
     get query() {
       return query();
     },
-    hostPageSetting: hostPageSetting,
+
+    hostPageSetting,
+
+    isBrowserExtension: isBrowserExtension(urlFromLinkTag('sidebar')),
   };
 }

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -1,17 +1,25 @@
-import configFrom from '../index';
+import Config from '../index';
 import { $imports } from '../index';
 
 describe('annotator.config.index', function () {
   let fakeSettingsFrom;
+  let fakeHostPageSetting;
 
-  beforeEach(() => {
+  function mockFakeSettings(params) {
+    fakeHostPageSetting = sinon.stub().returns('fake_value');
     fakeSettingsFrom = sinon.stub().returns({
-      hostPageSetting: sinon.stub(),
+      hostPageSetting: fakeHostPageSetting,
+      isBrowserExtension: false,
+      ...params,
     });
 
     $imports.$mock({
       './settings': fakeSettingsFrom,
     });
+  }
+
+  beforeEach(() => {
+    mockFakeSettings();
   });
 
   afterEach(() => {
@@ -19,7 +27,7 @@ describe('annotator.config.index', function () {
   });
 
   it('gets the configuration settings', function () {
-    configFrom('WINDOW');
+    new Config('WINDOW');
 
     assert.calledOnce(fakeSettingsFrom);
     assert.calledWithExactly(fakeSettingsFrom, 'WINDOW');
@@ -30,7 +38,7 @@ describe('annotator.config.index', function () {
       it('returns the ' + settingName + ' setting', () => {
         fakeSettingsFrom()[settingName] = 'SETTING_VALUE';
 
-        const config = configFrom('WINDOW');
+        const config = new Config('WINDOW').get();
 
         assert.equal(config[settingName], 'SETTING_VALUE');
       });
@@ -46,77 +54,238 @@ describe('annotator.config.index', function () {
 
     it('throws an error', function () {
       assert.throws(function () {
-        configFrom('WINDOW');
+        new Config('WINDOW').get();
       }, "there's no link");
     });
   });
 
-  ['assetRoot', 'subFrameIdentifier'].forEach(function (settingName) {
-    it(
-      'reads ' +
-        settingName +
-        ' from the host page, even when in a browser extension',
-      function () {
-        configFrom('WINDOW');
-        assert.calledWithExactly(
-          fakeSettingsFrom().hostPageSetting,
-          settingName,
-          { allowInBrowserExt: true }
-        );
-      }
-    );
+  context('embedded client detected', function () {
+    it('return all config values', () => {
+      const config = new Config('WINDOW').get();
+      assert.deepEqual(
+        [
+          'annotations',
+          'assetRoot',
+          'branding',
+          'clientUrl',
+          'enableExperimentalNewNoteButton',
+          'experimental',
+          'externalContainerSelector',
+          'focus',
+          'group',
+          'notebookAppUrl',
+          'onLayoutChange',
+          'openSidebar',
+          'query',
+          'requestConfigFromFrame',
+          'services',
+          'showHighlights',
+          'sidebarAppUrl',
+          'subFrameIdentifier',
+          'theme',
+          'usernameUrl',
+        ],
+        Object.keys(config).sort()
+      );
+    });
   });
 
-  it('reads openSidebar from the host page, even when in a browser extension', function () {
-    configFrom('WINDOW');
-    sinon.assert.calledWith(
-      fakeSettingsFrom().hostPageSetting,
-      'openSidebar',
-      sinon.match({
-        allowInBrowserExt: true,
-        coerce: sinon.match.func,
-      })
-    );
+  context('browser extension detected', function () {
+    beforeEach(() => {
+      mockFakeSettings({
+        isBrowserExtension: true,
+      });
+    });
+    it('returns only config values where `allowInBrowserExt` is true', () => {
+      const config = new Config('WINDOW').get();
+      assert.deepEqual(
+        [
+          'annotations',
+          'assetRoot',
+          'clientUrl',
+          'group',
+          'notebookAppUrl',
+          'openSidebar',
+          'query',
+          'showHighlights',
+          'sidebarAppUrl',
+          'subFrameIdentifier',
+        ],
+        Object.keys(config).sort()
+      );
+    });
   });
 
-  ['branding', 'services'].forEach(function (settingName) {
-    it(
-      'reads ' +
-        settingName +
-        ' from the host page only when in an embedded client',
-      function () {
-        configFrom('WINDOW');
-
-        assert.calledWithExactly(
-          fakeSettingsFrom().hostPageSetting,
-          settingName
-        );
-      }
-    );
+  describe('hostPageSetting config values', () => {
+    it('calls the valueFn() and passes the config name as a param', () => {
+      new Config('WINDOW').get();
+      [
+        'assetRoot',
+        'branding',
+        'enableExperimentalNewNoteButton',
+        'experimental',
+        'focus',
+        'theme',
+        'usernameUrl',
+        'onLayoutChange',
+        'openSidebar',
+        'requestConfigFromFrame',
+        'services',
+        'subFrameIdentifier',
+        'externalContainerSelector',
+      ].forEach(name => {
+        assert.calledWith(fakeSettingsFrom().hostPageSetting, name);
+      });
+    });
   });
 
-  [
-    'assetRoot',
-    'branding',
-    'openSidebar',
-    'requestConfigFromFrame',
-    'services',
-  ].forEach(function (settingName) {
-    it('returns the ' + settingName + ' value from the host page', function () {
-      const settings = {
-        assetRoot: 'chrome-extension://1234/client/',
-        branding: 'BRANDING_SETTING',
-        openSidebar: 'OPEN_SIDEBAR_SETTING',
-        requestConfigFromFrame: 'https://embedder.com',
-        services: 'SERVICES_SETTING',
-      };
-      fakeSettingsFrom().hostPageSetting = function (settingName) {
-        return settings[settingName];
-      };
+  describe('default value', () => {
+    it('sets corresponding default values if settings are undefined', () => {
+      mockFakeSettings({
+        isBrowserExtension: true,
+        hostPageSetting: sinon.stub().returns(undefined),
+        annotations: undefined,
+        clientUrl: undefined,
+        group: undefined,
+        query: undefined,
+        showHighlights: undefined,
+        notebookAppUrl: undefined,
+      });
+      const config = new Config('WINDOW').get();
+      assert.deepEqual(config, {
+        annotations: null,
+        assetRoot: null,
+        clientUrl: null,
+        group: null,
+        openSidebar: false,
+        query: null,
+        showHighlights: null,
+        notebookAppUrl: null,
+        sidebarAppUrl: null,
+        subFrameIdentifier: null,
+      });
+    });
+  });
 
-      const settingValue = configFrom('WINDOW')[settingName];
+  describe('coerces values', () => {
+    it('coerces `openSidebar` from a string to a boolean', () => {
+      fakeHostPageSetting.withArgs('openSidebar').returns('false');
+      const config = new Config('WINDOW').get();
+      assert.equal(config.openSidebar, false);
+    });
+  });
 
-      assert.equal(settingValue, settings[settingName]);
+  describe('namespaces', () => {
+    [
+      {
+        namespace: null, // get all config values
+        expectedKeys: [
+          'annotations',
+          'assetRoot',
+          'branding',
+          'clientUrl',
+          'enableExperimentalNewNoteButton',
+          'experimental',
+          'externalContainerSelector',
+          'focus',
+          'group',
+          'notebookAppUrl',
+          'onLayoutChange',
+          'openSidebar',
+          'query',
+          'requestConfigFromFrame',
+          'services',
+          'showHighlights',
+          'sidebarAppUrl',
+          'subFrameIdentifier',
+          'theme',
+          'usernameUrl',
+        ],
+      },
+      {
+        namespace: 'fake',
+        expectedKeys: [],
+      },
+      {
+        namespace: 'annotator',
+        expectedKeys: [
+          'annotations',
+          'assetRoot',
+          'branding',
+          'clientUrl',
+          'enableExperimentalNewNoteButton',
+          'experimental',
+          'externalContainerSelector',
+          'focus',
+          'group',
+          'notebookAppUrl',
+          'onLayoutChange',
+          'openSidebar',
+          'query',
+          'requestConfigFromFrame',
+          'services',
+          'showHighlights',
+          'sidebarAppUrl',
+          'subFrameIdentifier',
+          'theme',
+          'usernameUrl',
+        ],
+      },
+      {
+        namespace: 'notebook',
+        expectedKeys: [
+          'annotations',
+          'assetRoot',
+          'branding',
+          'clientUrl',
+          'enableExperimentalNewNoteButton',
+          'experimental',
+          'externalContainerSelector',
+          'focus',
+          'group',
+          'notebookAppUrl',
+          'onLayoutChange',
+          'openSidebar',
+          'query',
+          'requestConfigFromFrame',
+          'services',
+          'showHighlights',
+          'sidebarAppUrl',
+          'subFrameIdentifier',
+          'theme',
+          'usernameUrl',
+        ],
+      },
+      {
+        namespace: 'sidebar',
+        expectedKeys: [
+          'annotations',
+          'assetRoot',
+          'branding',
+          'clientUrl',
+          'enableExperimentalNewNoteButton',
+          'experimental',
+          'externalContainerSelector',
+          'focus',
+          'group',
+          'notebookAppUrl',
+          'onLayoutChange',
+          'openSidebar',
+          'query',
+          'requestConfigFromFrame',
+          'services',
+          'showHighlights',
+          'sidebarAppUrl',
+          'subFrameIdentifier',
+          'theme',
+          'usernameUrl',
+        ],
+      },
+    ].forEach(test => {
+      it('ignore values not belonging to a namespace', () => {
+        const config = new Config('WINDOW').get(test.namespace);
+        assert.deepEqual(Object.keys(config).sort(), test.expectedKeys);
+      });
     });
   });
 });

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -5,8 +5,21 @@ describe('annotator/config/settingsFrom', () => {
   let fakeConfigFuncSettingsFrom;
   let fakeIsBrowserExtension;
   let fakeParseJsonConfig;
+  let link;
+
+  function appendLink(href, rel) {
+    const link = document.createElement('link');
+    link.type = 'application/annotator+html';
+    link.rel = rel;
+    if (href) {
+      link.href = href;
+    }
+    document.head.appendChild(link);
+    return link;
+  }
 
   beforeEach(() => {
+    link = appendLink('http://example.com/app.html', 'sidebar');
     fakeConfigFuncSettingsFrom = sinon.stub().returns({});
     fakeIsBrowserExtension = sinon.stub().returns(false);
     fakeParseJsonConfig = sinon.stub().returns({});
@@ -19,6 +32,7 @@ describe('annotator/config/settingsFrom', () => {
   });
 
   afterEach(() => {
+    link.remove();
     $imports.$restore();
   });
 
@@ -42,7 +56,7 @@ describe('annotator/config/settingsFrom', () => {
           beforeEach(
             'add an application/annotator+html notebook <link>',
             () => {
-              link = appendLink('http://example.com/app.html', 'notebook');
+              link = appendLink('http://example.com/notebook', 'notebook');
             }
           );
 
@@ -53,7 +67,7 @@ describe('annotator/config/settingsFrom', () => {
           it('returns the href from the notebook link', () => {
             assert.equal(
               settingsFrom(window).notebookAppUrl,
-              'http://example.com/app.html'
+              'http://example.com/notebook'
             );
           });
         }
@@ -83,7 +97,6 @@ describe('annotator/config/settingsFrom', () => {
 
       context('when the annotator+html notebook link has no href', () => {
         let link;
-
         beforeEach(
           'add an application/annotator+html notebook <link> with no href',
           () => {
@@ -113,16 +126,6 @@ describe('annotator/config/settingsFrom', () => {
 
     describe('#sidebarAppUrl', () => {
       context("when there's an application/annotator+html sidebar link", () => {
-        let link;
-
-        beforeEach('add an application/annotator+html sidebar <link>', () => {
-          link = appendLink('http://example.com/app.html', 'sidebar');
-        });
-
-        afterEach('tidy up the sidebar link', () => {
-          link.remove();
-        });
-
         it('returns the href from the sidebar link', () => {
           assert.equal(
             settingsFrom(window).sidebarAppUrl,
@@ -132,39 +135,34 @@ describe('annotator/config/settingsFrom', () => {
       });
 
       context('when there are multiple annotator+html sidebar links', () => {
-        let link1;
         let link2;
 
         beforeEach('add two sidebar links to the document', () => {
-          link1 = appendLink('http://example.com/app1', 'sidebar');
           link2 = appendLink('http://example.com/app2', 'sidebar');
         });
 
         afterEach('tidy up the sidebar links', () => {
-          link1.remove();
           link2.remove();
         });
 
         it('returns the href from the first one', () => {
           assert.equal(
             settingsFrom(window).sidebarAppUrl,
-            'http://example.com/app1'
+            'http://example.com/app.html'
           );
         });
       });
 
       context('when the annotator+html sidebar link has no href', () => {
-        let link;
+        let link2;
 
-        beforeEach(
-          'add an application/annotator+html sidebar <link> with no href',
-          () => {
-            link = appendLink(null, 'sidebar');
-          }
-        );
+        beforeEach(() => {
+          link.remove(); // Remove the default link
+          link2 = appendLink(null, 'sidebar'); // Add a new link without href=""
+        });
 
         afterEach('tidy up the sidebar link', () => {
-          link.remove();
+          link2.remove();
         });
 
         it('throws an error', () => {
@@ -175,6 +173,9 @@ describe('annotator/config/settingsFrom', () => {
       });
 
       context("when there's no annotator+html sidebar link", () => {
+        beforeEach(() => {
+          link.remove(); // Remove the default link
+        });
         it('throws an error', () => {
           assert.throws(() => {
             settingsFrom(window).sidebarAppUrl; // eslint-disable-line no-unused-expressions

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -17,7 +17,7 @@ import { registerIcons } from '@hypothesis/frontend-shared';
 import iconSet from './icons';
 registerIcons(iconSet);
 
-import configFrom from './config/index';
+import Config from './config/index';
 import Guest from './guest';
 import Notebook from './notebook';
 import Sidebar from './sidebar';
@@ -31,12 +31,13 @@ const appLinkEl = /** @type {Element} */ (document.querySelector(
   'link[type="application/annotator+html"][rel="sidebar"]'
 ));
 
-const config = configFrom(window);
+const config = new Config(window);
+const annotatorConfig = config.get();
 
 function init() {
   const isPDF = typeof window_.PDFViewerApplication !== 'undefined';
 
-  if (config.subFrameIdentifier) {
+  if (annotatorConfig.subFrameIdentifier) {
     // Other modules use this to detect if this
     // frame context belongs to hypothesis.
     // Needs to be a global property that's set.
@@ -44,14 +45,18 @@ function init() {
   }
 
   // Load the PDF anchoring/metadata integration.
-  config.documentType = isPDF ? 'pdf' : 'html';
+  annotatorConfig.documentType = isPDF ? 'pdf' : 'html';
 
   const eventBus = new EventBus();
-  const guest = new Guest(document.body, eventBus, config);
-  const sidebar = !config.subFrameIdentifier
-    ? new Sidebar(document.body, eventBus, guest, config)
+  const guest = new Guest(document.body, eventBus, annotatorConfig);
+  const sidebar = !annotatorConfig.subFrameIdentifier
+    ? new Sidebar(document.body, eventBus, guest, config.get('sidebar'))
     : null;
-  const notebook = new Notebook(document.body, eventBus, config);
+  const notebook = new Notebook(
+    document.body,
+    eventBus,
+    config.get('notebook')
+  );
 
   appLinkEl.addEventListener('destroy', () => {
     sidebar?.destroy();


### PR DESCRIPTION
The purpose of this PR is to refactor the config/index and config/settings files in preparations for namespaces. The namespaces will be needed to omit values based on context because we now have a "notebook" app. The notebook can be compromised with `annotations` config because it shared the same thread components. The proper fix here is to omit that value from the settings in the first place. There may be other settings that can actually be omitted in other contexts and a audit should be done--I have started this.

In preparing namespaces, I discovered some confusing and conflicting aspects of setting.js. The efforts here is to condense the configuration definitions into a single place (config/index.js) that is clearly readable. In doing so, we move the conditional bits for browser extension and any type/value manululations out from the settings.js file itself and into the definitions itself.

The settings.js file may now solely be responsible for collecting the raw settings from various sources ( js-hypothesis-config, hypothesisConfig() or window.location.href, etc.)

i also discovered that the browser extension flag was not being applied to all the getters in settings.js which was very confusing to read. Furthermore, values that are rejected due to namespace or browser ext flag are omitted rather than nulled. I believe this makes more sense. 

### Commits
----------

Expose `isBrowserExtension` flag from settingsFrom() …
fa9cfa6
The `isBrowserExtension` is needed external to the settings to be able to filter config values. As a result, settings-test.js needs a minor reconfiguration so that the link is mocked before each test.


-----------

Refactor config/index.js and add namespaces …
9066b81
In an effort to filter the config based on the application type (sidebar, notebook, etc), there were some aspects on the config and settings that were confusing. This refactor moves all the rules to a single configuration definition that makes it clear 1. where a setting comes from and 2. what rules it follows before getting passed along to components.

Additionally, it was unclear which settings were allowed in the browser extension context because only the hostPageSetting settings paid attention
to the flag and some of the getters did not.

Changes:
- When in browser context, values which are prohibited are now omitted rather than set to null
corers methods
- When requeuing a config using a namespace, values outside of that namespace are omitted.

Note: Currently, all the namespaces request all values, but that will need to change.

TODO:
- Remove custom coerce code form some of the getters in settings.js
- Remove allowInBrowserExt flag in settings.js
- Modify namespaces as needed for "annotator" and "sidebar"
- Can contentContainer be moved into settings?
- Use HostConfig typedef and use for Sidebar()
- Add AnnotatorConfig typedef and use for Guest()
- Review / add any other config types needed for notebook, pdf, etc.