### PR TITLE
Refactor and add app contexts to config

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -2,52 +2,239 @@ import settingsFrom from './settings';
 import { toBoolean } from '../../shared/type-coercions';
 
 /**
- * Reads the Hypothesis configuration from the environment.
- *
- * @param {Window} window_ - The Window object to read config from.
+ * @typedef ConfigDefinition
+ * @prop {boolean} allowInBrowserExt - Allow this name to be available in the browser extension
+ * @prop {any} [defaultValue] - Sets a default if `valueFn` returns undefined
+ * @prop {([configName]: string) => any} valueFn -
+ *   Method to retrieve the value from the incoming source
+ * @prop {(value: any) => any} [coerce] - Transform a value's type value or value
  */
-export default function configFrom(window_) {
-  const settings = settingsFrom(window_);
-  return {
-    annotations: settings.annotations,
-    // URL where client assets are served from. Used when injecting the client
-    // into child iframes.
-    assetRoot: settings.hostPageSetting('assetRoot', {
-      allowInBrowserExt: true,
-    }),
-    branding: settings.hostPageSetting('branding'),
-    // URL of the client's boot script. Used when injecting the client into
-    // child iframes.
-    clientUrl: settings.clientUrl,
-    enableExperimentalNewNoteButton: settings.hostPageSetting(
-      'enableExperimentalNewNoteButton'
-    ),
-    experimental: settings.hostPageSetting('experimental', {
-      defaultValue: {},
-    }),
-    group: settings.group,
-    focus: settings.hostPageSetting('focus'),
-    theme: settings.hostPageSetting('theme'),
-    usernameUrl: settings.hostPageSetting('usernameUrl'),
-    onLayoutChange: settings.hostPageSetting('onLayoutChange'),
-    openSidebar: settings.hostPageSetting('openSidebar', {
-      allowInBrowserExt: true,
-      // Coerce value to a boolean because it may come from via as a string
-      coerce: toBoolean,
-    }),
-    query: settings.query,
-    requestConfigFromFrame: settings.hostPageSetting('requestConfigFromFrame'),
-    services: settings.hostPageSetting('services'),
-    showHighlights: settings.showHighlights,
-    notebookAppUrl: settings.notebookAppUrl,
-    sidebarAppUrl: settings.sidebarAppUrl,
-    // Subframe identifier given when a frame is being embedded into
-    // by a top level client
-    subFrameIdentifier: settings.hostPageSetting('subFrameIdentifier', {
-      allowInBrowserExt: true,
-    }),
-    externalContainerSelector: settings.hostPageSetting(
-      'externalContainerSelector'
-    ),
-  };
+
+/**
+ * @typedef ConfigDefinitionMap
+ * @prop {ConfigDefinition} [annotations]
+ * @prop {ConfigDefinition} [assetRoot]
+ * @prop {ConfigDefinition} [branding]
+ * @prop {ConfigDefinition} [clientUrl]
+ * @prop {ConfigDefinition} [enableExperimentalNewNoteButton]
+ * @prop {ConfigDefinition} [experimental]
+ * @prop {ConfigDefinition} [group]
+ * @prop {ConfigDefinition} [focus]
+ * @prop {ConfigDefinition} [theme]
+ * @prop {ConfigDefinition} [usernameUrl]
+ * @prop {ConfigDefinition} [onLayoutChange]
+ * @prop {ConfigDefinition} [openSidebar]
+ * @prop {ConfigDefinition} [query]
+ * @prop {ConfigDefinition} [requestConfigFromFrame]
+ * @prop {ConfigDefinition} [services]
+ * @prop {ConfigDefinition} [showHighlights]
+ * @prop {ConfigDefinition} [notebookAppUrl]
+ * @prop {ConfigDefinition} [sidebarAppUrl]
+ * @prop {ConfigDefinition} [subFrameIdentifier]
+ * @prop {ConfigDefinition} [externalContainerSelector]
+ */
+
+/**
+ * Reads the Hypothesis configuration from the environment.
+ */
+export default class Config {
+  /**
+   * @param {Window} window_ - The Window object to read config from.
+   */
+  constructor(window_) {
+    this.settings = settingsFrom(window_);
+    this.isBrowserExtension = this.settings.isBrowserExtension;
+  }
+
+  /**
+   * The definition for configuration sources, their default values
+   * @return {ConfigDefinitionMap}
+   */
+  configDefinitions() {
+    return {
+      annotations: {
+        defaultValue: null,
+        allowInBrowserExt: true,
+        valueFn: () => this.settings.annotations,
+      },
+      // URL where client assets are served from. Used when injecting the client
+      // into child iframes.
+      assetRoot: {
+        defaultValue: null,
+        allowInBrowserExt: true,
+        valueFn: this.settings.hostPageSetting,
+      },
+      branding: {
+        defaultValue: null,
+        allowInBrowserExt: false,
+        valueFn: this.settings.hostPageSetting,
+      },
+      // URL of the client's boot script. Used when injecting the client into
+      // child iframes.
+      clientUrl: {
+        allowInBrowserExt: true,
+        defaultValue: null,
+        valueFn: () => this.settings.clientUrl,
+      },
+      enableExperimentalNewNoteButton: {
+        allowInBrowserExt: false,
+        defaultValue: null,
+        valueFn: this.settings.hostPageSetting,
+      },
+      experimental: {
+        allowInBrowserExt: false,
+        defaultValue: {},
+        valueFn: this.settings.hostPageSetting,
+      },
+      group: {
+        allowInBrowserExt: true,
+        defaultValue: null,
+        valueFn: () => this.settings.group,
+      },
+      focus: {
+        allowInBrowserExt: false,
+        defaultValue: null,
+        valueFn: this.settings.hostPageSetting,
+      },
+      theme: {
+        allowInBrowserExt: false,
+        defaultValue: null,
+        valueFn: this.settings.hostPageSetting,
+      },
+      usernameUrl: {
+        allowInBrowserExt: false,
+        defaultValue: null,
+        valueFn: this.settings.hostPageSetting,
+      },
+      onLayoutChange: {
+        allowInBrowserExt: false,
+        defaultValue: null,
+        valueFn: this.settings.hostPageSetting,
+      },
+      openSidebar: {
+        allowInBrowserExt: true,
+        defaultValue: false,
+        coerce: toBoolean,
+        valueFn: this.settings.hostPageSetting,
+      },
+      query: {
+        allowInBrowserExt: true,
+        defaultValue: null,
+        valueFn: () => this.settings.query,
+      },
+      requestConfigFromFrame: {
+        allowInBrowserExt: false,
+        defaultValue: null,
+        valueFn: this.settings.hostPageSetting,
+      },
+      services: {
+        allowInBrowserExt: false,
+        defaultValue: null,
+        valueFn: this.settings.hostPageSetting,
+      },
+      showHighlights: {
+        allowInBrowserExt: true,
+        defaultValue: null,
+        valueFn: () => this.settings.showHighlights,
+      },
+      notebookAppUrl: {
+        allowInBrowserExt: true,
+        defaultValue: null,
+        valueFn: () => this.settings.notebookAppUrl,
+      },
+      sidebarAppUrl: {
+        allowInBrowserExt: true,
+        defaultValue: null,
+        valueFn: () => this.settings.sidebarAppUrl,
+      },
+      // Sub-frame identifier given when a frame is being embedded into
+      // by a top level client
+      subFrameIdentifier: {
+        allowInBrowserExt: true,
+        defaultValue: null,
+        valueFn: this.settings.hostPageSetting,
+      },
+      externalContainerSelector: {
+        allowInBrowserExt: false,
+        defaultValue: null,
+        valueFn: this.settings.hostPageSetting,
+      },
+    };
+  }
+
+  annotatorDefinitions() {
+    return this.configDefinitions();
+  }
+
+  sidebarDefinitions() {
+    return this.configDefinitions();
+  }
+
+  notebookDefinitions() {
+    const config = this.configDefinitions();
+    // Don't pass `annotations` setting to notebook.
+    delete config.annotations;
+    return config;
+  }
+
+  /**
+   * Process the config definition to create the final config value.
+   *   - find the value from its source (valueFn)
+   *   - filter allowInBrowserExt as needed
+   *   - coerce the value if necessary
+   *   - set a default if the value is undefined
+   * @param {string} name - Config key name
+   * @param {ConfigDefinition} configDef
+   */
+  createValueFromDefinition(name, configDef) {
+    // If allowInBrowserExt is false and this is the browser extension context, skip value
+    if (!configDef.allowInBrowserExt && this.isBrowserExtension) {
+      return undefined;
+    }
+
+    const coerceFn = configDef.coerce ? configDef.coerce : name => name; // use no-op if omitted
+    // Get the value from the configuration source and run through an optional coerce method
+    const value = coerceFn(configDef.valueFn.call(this, name));
+
+    // If a defaultValue is provided and the value is undefined, set the default
+    if (value === undefined && configDef.defaultValue !== undefined) {
+      return configDef.defaultValue;
+    } else {
+      return value;
+    }
+  }
+
+  /**
+   * Return the configuration for a given application context
+   *
+   * @param {'sidebar'|'notebook'|'annotator'} [appContext] -
+   *   The name of the app. Omit this param to return the total configuration
+   */
+  getConfig(appContext = 'annotator') {
+    const config = {};
+
+    // Filter the config based on the application context as some config values
+    // may be inappropriate or erroneous for some applications.
+    let partialConfigDef = {};
+    switch (appContext) {
+      case 'annotator':
+        partialConfigDef = this.annotatorDefinitions();
+        break;
+      case 'sidebar':
+        partialConfigDef = this.sidebarDefinitions();
+        break;
+      case 'notebook':
+        partialConfigDef = this.notebookDefinitions();
+        break;
+    }
+
+    for (const [name, configDef] of Object.entries(partialConfigDef)) {
+      const value = this.createValueFromDefinition(name, configDef);
+      // Only pass the value if its not undefined
+      if (value !== undefined) {
+        config[name] = value;
+      }
+    }
+    return config;
+  }
 }

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -218,6 +218,9 @@ export default function settingsFrom(window_) {
     get query() {
       return query();
     },
-    hostPageSetting: hostPageSetting,
+
+    hostPageSetting,
+
+    isBrowserExtension: isBrowserExtension(urlFromLinkTag('sidebar')),
   };
 }

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -5,8 +5,21 @@ describe('annotator/config/settingsFrom', () => {
   let fakeConfigFuncSettingsFrom;
   let fakeIsBrowserExtension;
   let fakeParseJsonConfig;
+  let link;
+
+  function appendLink(href, rel) {
+    const link = document.createElement('link');
+    link.type = 'application/annotator+html';
+    link.rel = rel;
+    if (href) {
+      link.href = href;
+    }
+    document.head.appendChild(link);
+    return link;
+  }
 
   beforeEach(() => {
+    link = appendLink('http://example.com/app.html', 'sidebar');
     fakeConfigFuncSettingsFrom = sinon.stub().returns({});
     fakeIsBrowserExtension = sinon.stub().returns(false);
     fakeParseJsonConfig = sinon.stub().returns({});
@@ -19,6 +32,7 @@ describe('annotator/config/settingsFrom', () => {
   });
 
   afterEach(() => {
+    link.remove();
     $imports.$restore();
   });
 
@@ -42,7 +56,7 @@ describe('annotator/config/settingsFrom', () => {
           beforeEach(
             'add an application/annotator+html notebook <link>',
             () => {
-              link = appendLink('http://example.com/app.html', 'notebook');
+              link = appendLink('http://example.com/notebook', 'notebook');
             }
           );
 
@@ -53,7 +67,7 @@ describe('annotator/config/settingsFrom', () => {
           it('returns the href from the notebook link', () => {
             assert.equal(
               settingsFrom(window).notebookAppUrl,
-              'http://example.com/app.html'
+              'http://example.com/notebook'
             );
           });
         }
@@ -83,7 +97,6 @@ describe('annotator/config/settingsFrom', () => {
 
       context('when the annotator+html notebook link has no href', () => {
         let link;
-
         beforeEach(
           'add an application/annotator+html notebook <link> with no href',
           () => {
@@ -113,16 +126,6 @@ describe('annotator/config/settingsFrom', () => {
 
     describe('#sidebarAppUrl', () => {
       context("when there's an application/annotator+html sidebar link", () => {
-        let link;
-
-        beforeEach('add an application/annotator+html sidebar <link>', () => {
-          link = appendLink('http://example.com/app.html', 'sidebar');
-        });
-
-        afterEach('tidy up the sidebar link', () => {
-          link.remove();
-        });
-
         it('returns the href from the sidebar link', () => {
           assert.equal(
             settingsFrom(window).sidebarAppUrl,
@@ -132,39 +135,34 @@ describe('annotator/config/settingsFrom', () => {
       });
 
       context('when there are multiple annotator+html sidebar links', () => {
-        let link1;
         let link2;
 
         beforeEach('add two sidebar links to the document', () => {
-          link1 = appendLink('http://example.com/app1', 'sidebar');
           link2 = appendLink('http://example.com/app2', 'sidebar');
         });
 
         afterEach('tidy up the sidebar links', () => {
-          link1.remove();
           link2.remove();
         });
 
         it('returns the href from the first one', () => {
           assert.equal(
             settingsFrom(window).sidebarAppUrl,
-            'http://example.com/app1'
+            'http://example.com/app.html'
           );
         });
       });
 
       context('when the annotator+html sidebar link has no href', () => {
-        let link;
+        let link2;
 
-        beforeEach(
-          'add an application/annotator+html sidebar <link> with no href',
-          () => {
-            link = appendLink(null, 'sidebar');
-          }
-        );
+        beforeEach(() => {
+          link.remove(); // Remove the default link
+          link2 = appendLink(null, 'sidebar'); // Add a new link without href=""
+        });
 
         afterEach('tidy up the sidebar link', () => {
-          link.remove();
+          link2.remove();
         });
 
         it('throws an error', () => {
@@ -175,6 +173,9 @@ describe('annotator/config/settingsFrom', () => {
       });
 
       context("when there's no annotator+html sidebar link", () => {
+        beforeEach(() => {
+          link.remove(); // Remove the default link
+        });
         it('throws an error', () => {
           assert.throws(() => {
             settingsFrom(window).sidebarAppUrl; // eslint-disable-line no-unused-expressions

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -17,7 +17,7 @@ import { registerIcons } from '@hypothesis/frontend-shared';
 import iconSet from './icons';
 registerIcons(iconSet);
 
-import configFrom from './config/index';
+import Config from './config/index';
 import Guest from './guest';
 import Notebook from './notebook';
 import Sidebar from './sidebar';
@@ -31,12 +31,13 @@ const appLinkEl = /** @type {Element} */ (document.querySelector(
   'link[type="application/annotator+html"][rel="sidebar"]'
 ));
 
-const config = configFrom(window);
+const config = new Config(window);
+const annotatorConfig = config.getConfig('annotator');
 
 function init() {
   const isPDF = typeof window_.PDFViewerApplication !== 'undefined';
 
-  if (config.subFrameIdentifier) {
+  if (annotatorConfig.subFrameIdentifier) {
     // Other modules use this to detect if this
     // frame context belongs to hypothesis.
     // Needs to be a global property that's set.
@@ -44,14 +45,18 @@ function init() {
   }
 
   // Load the PDF anchoring/metadata integration.
-  config.documentType = isPDF ? 'pdf' : 'html';
+  annotatorConfig.documentType = isPDF ? 'pdf' : 'html';
 
   const eventBus = new EventBus();
-  const guest = new Guest(document.body, eventBus, config);
-  const sidebar = !config.subFrameIdentifier
-    ? new Sidebar(document.body, eventBus, guest, config)
+  const guest = new Guest(document.body, eventBus, annotatorConfig);
+  const sidebar = !annotatorConfig.subFrameIdentifier
+    ? new Sidebar(document.body, eventBus, guest, config.getConfig('sidebar'))
     : null;
-  const notebook = new Notebook(document.body, eventBus, config);
+  const notebook = new Notebook(
+    document.body,
+    eventBus,
+    config.getConfig('notebook')
+  );
 
   appLinkEl.addEventListener('destroy', () => {
     sidebar?.destroy();


### PR DESCRIPTION
The purpose of this PR is to refactor the config/index and config/settings files in preparations for different application contexts. Values may now need to be omitted based on context because we now have a "notebook" app. The notebook can be compromised with  the `annotations` config because it shared the same thread components. There may be other settings that could actually be omitted in other contexts and an audit should be done.

I discovered some confusing and conflicting aspects of setting.js. The effort here is to condense the configuration definitions into a single place (config/index.js) that is clear and readable. In doing so, I added conditional logic for the browser extension and any type/value manululations  into the definitions itself in **index.js**. _(note, in a subsequent change, we could remove redundant code in settings.js)_

The **settings.js** file may now solely be responsible for collecting the raw settings from various sources ( js-hypothesis-config, hypothesisConfig() or window.location.href, etc.)

i also discovered that the browser extension flag was not being applied to all the getters in **settings.js** which was confusing to read. Furthermore, values that are rejected due to the browser ext flag are omitted rather than nulled. I believe this makes more sense.  

### Commits
----------

Expose `isBrowserExtension` flag from settingsFrom() …
fa9cfa6
The `isBrowserExtension` is needed external to the settings to be able to filter config values. As a result, settings-test.js needs a minor reconfiguration so that the link is mocked before each test.

-----------

Refactor config/index.js to add contexts

Refactor config/index.js in an effort to filter the config based on the application context (sidebar, notebook, annotator, This refactor moves all the rules to a single configuration definition that makes it clear 1. where a setting comes from and 2. what rules it follows before getting passed along to the rest of the app.

Additionally, it was unclear which settings were allowed in the browser extension context because only the hostPageSetting settings made use of the boolean flag but some of the getters did not.

Changes:
- When in browser context (isBrowserExtension), values which are prohibited are now omitted rather than set to null
- When requeuing a config using an app context, values outside of that context are omitted.


----------

Fixes https://github.com/hypothesis/client/issues/3105

### 
TODO

- [ ] - Remove custom coerce code form some of the getters in settings.js
- [ ] - Remove allowInBrowserExt flag in settings.js
- [ ] - Modify app contexts as needed for "annotator" and "sidebar"
- [ ] - Can contentContainer be moved into settings or out of the config?
- [ ] - Review / add any other config types needed in other parts of the app.