### PR TITLE
Remove `annotations` config from Notebook

### DIFF
--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -51,7 +51,14 @@ function init() {
   const sidebar = !config.subFrameIdentifier
     ? new Sidebar(document.body, eventBus, guest, config)
     : null;
-  const notebook = new Notebook(document.body, eventBus, config);
+  // Clear `annotations` value from the notebook's config to prevent direct-linked
+  // annotations from filtering the threads.
+  //
+  // TODO: Refactor configFrom() so it can export application specific configs
+  // for different usages such as the notebook.
+  const notebookConfig = { ...config };
+  notebookConfig.annotations = null;
+  const notebook = new Notebook(document.body, eventBus, notebookConfig);
 
   appLinkEl.addEventListener('destroy', () => {
     sidebar?.destroy();


### PR DESCRIPTION
As a result of the config/index.js refactor being overfly complex and increasing the code. I think it might be best to just fix the ticket itself and circle back to a more robust refactor of the config/index and /settings modules in the annotator at a later time.

This proposed change is quick and easy fix for the ticket itself.  I have closed out https://github.com/hypothesis/client/pull/3232 with some comments and I think we can revisit when time permits or we have a need for further divergent configurations. I wrote up a new ticket with some thoughts for that work so we can track it from there. https://github.com/hypothesis/client/issues/3236
 
fixes https://github.com/hypothesis/client/issues/3105
