### PR TITLE
Remove unneeded horizontal-rhythm from AnnotationHeader

### DIFF
--- a/src/styles/sidebar/components/AnnotationHeader.scss
+++ b/src/styles/sidebar/components/AnnotationHeader.scss
@@ -7,7 +7,6 @@
 .AnnotationHeader {
   &__row {
     @include layout.row($align: baseline);
-    @include layout.horizontal-rhythm;
     // Wrap onto multiple rows from bottom to top
     flex-wrap: wrap-reverse;
   }


### PR DESCRIPTION
Remove an unneeded horizontal-rhythm mixin from AnnotationHeader. Fixes
a visual regression in which the timestamps were not appearing right-aligned
in the header of annotation cards.