### PR TITLE
Add horizontal-rhythm util styles (back) to annotation header

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationHeader.js
+++ b/src/sidebar/components/Annotation/AnnotationHeader.js
@@ -120,7 +120,7 @@ function AnnotationHeader({
 
   return (
     <header className="AnnotationHeader">
-      <div className="AnnotationHeader__row">
+      <div className="AnnotationHeader__row u-horizontal-rhythm">
         {annotationIsPrivate && !isEditing && (
           <SvgIcon
             className="AnnotationHeader__icon"
@@ -154,7 +154,7 @@ function AnnotationHeader({
       </div>
 
       {showExtendedInfo && (
-        <div className="AnnotationHeader__row">
+        <div className="AnnotationHeader__row u-horizontal-rhythm">
           <AnnotationShareInfo annotation={annotation} />
           {!isEditing && isHighlight(annotation) && (
             <div className="AnnotationHeader__highlight">

--- a/src/styles/sidebar/components/AnnotationHeader.scss
+++ b/src/styles/sidebar/components/AnnotationHeader.scss
@@ -23,7 +23,8 @@
 
   // Timestamps are right aligned in a flex row
   &__timestamps {
-    margin-left: auto;
+    flex-grow: 1;
+    text-align: right;
   }
 
   &__highlight-icon {


### PR DESCRIPTION
Add back horizontal-rhythm util styles, but use a different alignment
technique for a child element to assure that timestamps align right in
annotation cards.

Sorry for the song-and-dance here; moved a little too fast earlier today.

Before this fix, in Notebook view:

![image](https://user-images.githubusercontent.com/439947/113440514-92bd1f00-93ba-11eb-915e-5cdd4e821eaf.png)

After:

![image](https://user-images.githubusercontent.com/439947/113440483-85a03000-93ba-11eb-8596-4b22d69107ad.png)
