### PR TITLE
Fix deprecated warning from recent karam upgrade

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -346,10 +346,10 @@ gulp.task(
 function runKarma(done) {
   const karma = require('karma');
   new karma.Server(
-    {
-      configFile: path.resolve(__dirname, './src/karma.config.js'),
-      ...karmaOptions,
-    },
+    karma.config.parseConfig(
+      path.resolve(__dirname, './src/karma.config.js'),
+      karmaOptions
+    ),
     done
   ).start();
 }


### PR DESCRIPTION
I started to see an warning recently when running test. 

```
02 04 2021 10:27:53.931:WARN [karma-server]: Passing raw CLI options to `new Server(config, done)` is deprecated. Use `parseConfig(configFilePath, cliOptions, {promiseConfig: true, throwErrors: true})` to prepare a processed `Config` instance and pass that as the `config` argument instead.
```

I tracked it down a change in karma/lib/runner.js. I could not find docs on this, either because I'm terrible at searching for them or karama did not document this well, but in any case when looking at the code, it appears that karam now wants a `Config` object rather than just a general Object. Karam exports a config object creator method (`parseConfig()`) from its lib/index.js file so I'm guessing what it wants. I made this change and the warning went away. Tests still seem to work as expected, watch, grep, etc all work.


### Commit

Karam expects the config to be of type `Config`. This can be done by calling the karma.config.parseConfig method which creates a Config object that can be passed to karma.Server()

TODO:

- [ ] Update frontend-shared
- [ ] Update lms
- [ ] maybe move some of this to a shared place?