### PR TITLE
Extend shared button components to meet styling needs of client

### DIFF
--- a/dev-server/ui-playground/components/PatternPage.js
+++ b/dev-server/ui-playground/components/PatternPage.js
@@ -86,16 +86,9 @@ export function Pattern({ children, title }) {
  *
  * @param {PatternExamplesProps} props
  */
-export function PatternExamples({ children, title }) {
+export function PatternExamples({ children }) {
   return (
     <table className="PatternExamples">
-      {title && (
-        <tr>
-          <th colSpan={3}>
-            <h3>{title}</h3>
-          </th>
-        </tr>
-      )}
       <tr>
         <th>Example</th>
         <th>Details</th>
@@ -110,6 +103,8 @@ export function PatternExamples({ children, title }) {
  * @typedef PatternExampleProps
  * @prop {import("preact").ComponentChildren} children - Example source
  * @prop {string} details - Details about the pattern example
+ * @prop {Object} [style] - Optional additional inline styles to apply to the
+ *   table cell with the rendered example
  */
 
 /**
@@ -118,7 +113,7 @@ export function PatternExamples({ children, title }) {
  *
  * @param {PatternExampleProps} props
  */
-export function PatternExample({ children, details }) {
+export function PatternExample({ children, details, style = {} }) {
   const source = toChildArray(children).map((child, idx) => {
     return (
       <li key={idx}>
@@ -130,7 +125,9 @@ export function PatternExample({ children, details }) {
   });
   return (
     <tr>
-      <td className="PatternExample__example">{children}</td>
+      <td style={style}>
+        <div className="PatternExample__example">{children}</div>
+      </td>
       <td>{details}</td>
       <td>
         <ul>{source}</ul>

--- a/dev-server/ui-playground/components/patterns/SharedButtonPatterns.js
+++ b/dev-server/ui-playground/components/patterns/SharedButtonPatterns.js
@@ -15,10 +15,27 @@ export default function SharedButtonPatterns() {
   return (
     <PatternPage title="Buttons (Shared)">
       <Pattern title="IconButton">
-        <p>A button containing an icon and no label (text)</p>
+        <p>A button containing an icon and no other content.</p>
+
+        <h3>Sizes</h3>
+        <p>
+          The optional <code>size</code> property affects the proportions and
+          overall size of the button by way of padding. It does not change the
+          size of the icon itself, which is sized at&nbsp;
+          <code>1em</code>. The default sizing is <code>medium</code>.
+        </p>
         <PatternExamples>
-          <PatternExample details="Basic usage">
-            <IconButton icon="edit" title="Edit" />
+          <PatternExample details="Sizes: medium is default">
+            <IconButton icon="edit" title="Edit" size="small" />
+            <IconButton icon="edit" title="Edit" size="medium" />
+            <IconButton icon="edit" title="Edit" size="large" />
+          </PatternExample>
+        </PatternExamples>
+
+        <h3>Default variant</h3>
+        <PatternExamples>
+          <PatternExample details="Default state">
+            <IconButton icon="trash" title="Delete annotation" />
           </PatternExample>
 
           <PatternExample details="Pressed">
@@ -32,73 +49,247 @@ export default function SharedButtonPatterns() {
           <PatternExample details="Disabled">
             <IconButton icon="trash" title="Delete annotation" disabled />
           </PatternExample>
+        </PatternExamples>
 
-          <PatternExample details="Primary variant">
+        <h3>Primary variant</h3>
+        <PatternExamples>
+          <PatternExample details="Basic usage">
+            <IconButton icon="edit" title="Edit" variant="primary" />
+          </PatternExample>
+
+          <PatternExample details="Pressed">
             <IconButton
               icon="trash"
               title="Delete annotation"
+              pressed
               variant="primary"
+            />
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <IconButton
+              icon="trash"
+              title="Delete annotation"
+              expanded
+              variant="primary"
+            />
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <IconButton
+              icon="trash"
+              title="Delete annotation"
+              disabled
+              variant="primary"
+            />
+          </PatternExample>
+        </PatternExamples>
+
+        <h3>Light variant</h3>
+        <p>
+          This variant should only be used for non-critical icons on white
+          backgrounds (low contrast).
+        </p>
+        <PatternExamples>
+          <PatternExample
+            details="Basic usage"
+            style={{ backgroundColor: 'white' }}
+          >
+            <IconButton icon="collapsed" title="Edit" variant="light" />
+          </PatternExample>
+
+          <PatternExample
+            details="Pressed"
+            style={{ backgroundColor: 'white' }}
+          >
+            <IconButton
+              icon="collapsed"
+              title="Delete annotation"
+              pressed
+              variant="light"
+            />
+          </PatternExample>
+
+          <PatternExample
+            details="Expanded"
+            style={{ backgroundColor: 'white' }}
+          >
+            <IconButton
+              icon="collapsed"
+              title="Delete annotation"
+              expanded
+              variant="light"
+            />
+          </PatternExample>
+
+          <PatternExample
+            details="Disabled"
+            style={{ backgroundColor: 'white' }}
+          >
+            <IconButton
+              icon="collapsed"
+              title="Delete annotation"
+              disabled
+              variant="light"
             />
           </PatternExample>
         </PatternExamples>
       </Pattern>
 
       <Pattern title="LabeledButton">
-        <p>A button with a label (text) and optionally an icon.</p>
-        <PatternExamples title="Label only">
-          <PatternExample details="Basic usage">
+        <p>A button with content and, optionally, an icon.</p>
+
+        <h3>Sizes</h3>
+        <p>
+          As with <code>IconButton</code>, sizing affects proportions and
+          overall size via padding.
+        </p>
+
+        <PatternExamples>
+          <PatternExample details="Label only">
+            <LabeledButton size="small">Edit</LabeledButton>
             <LabeledButton>Edit</LabeledButton>
+            <LabeledButton size="large">Edit</LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Label and icon">
+            <LabeledButton icon="profile" size="small">
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile">Edit User</LabeledButton>
+            <LabeledButton icon="profile" size="large">
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample details="Label and icon: icon on right">
+            <LabeledButton icon="profile" size="small" iconPosition="right">
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile" iconPosition="right">
+              Edit User
+            </LabeledButton>
+            <LabeledButton icon="profile" size="large" iconPosition="right">
+              Edit User
+            </LabeledButton>
+          </PatternExample>
+        </PatternExamples>
+
+        <h3>Default variant</h3>
+
+        <PatternExamples>
+          <PatternExample details="Default state">
+            <LabeledButton>Edit</LabeledButton>
+            <LabeledButton icon="edit">Edit</LabeledButton>
           </PatternExample>
 
           <PatternExample details="Pressed">
             <LabeledButton pressed>Edit</LabeledButton>
+            <LabeledButton icon="edit" pressed>
+              Edit
+            </LabeledButton>
           </PatternExample>
 
           <PatternExample details="Expanded">
             <LabeledButton expanded>Edit</LabeledButton>
+            <LabeledButton icon="edit" expanded>
+              Edit
+            </LabeledButton>
           </PatternExample>
 
           <PatternExample details="Disabled">
             <LabeledButton disabled>Edit</LabeledButton>
-          </PatternExample>
-
-          <PatternExample details="Primary variant">
-            <LabeledButton variant="primary">Edit</LabeledButton>
+            <LabeledButton icon="edit" disabled>
+              Edit
+            </LabeledButton>
           </PatternExample>
         </PatternExamples>
 
-        <PatternExamples title="Label and icon">
-          <PatternExample details="Basic usage">
-            <LabeledButton icon="profile">Edit User</LabeledButton>
+        <h3>Primary variant</h3>
+
+        <PatternExamples>
+          <PatternExample details="Default state">
+            <LabeledButton variant="primary">Edit user</LabeledButton>
+            <LabeledButton icon="profile" variant="primary">
+              Edit user
+            </LabeledButton>
           </PatternExample>
 
           <PatternExample details="Pressed">
-            <LabeledButton icon="profile" pressed>
-              Edit User
+            <LabeledButton pressed variant="primary">
+              Edit user
+            </LabeledButton>
+            <LabeledButton icon="profile" pressed variant="primary">
+              Edit user
             </LabeledButton>
           </PatternExample>
 
           <PatternExample details="Expanded">
-            <LabeledButton icon="profile" expanded>
-              Edit User
+            <LabeledButton expanded variant="primary">
+              Edit user
+            </LabeledButton>
+            <LabeledButton icon="profile" expanded variant="primary">
+              Edit user
             </LabeledButton>
           </PatternExample>
 
           <PatternExample details="Disabled">
-            <LabeledButton icon="profile" disabled>
-              Edit User
+            <LabeledButton disabled variant="primary">
+              Edit user
+            </LabeledButton>
+            <LabeledButton icon="profile" disabled variant="primary">
+              Edit user
+            </LabeledButton>
+          </PatternExample>
+        </PatternExamples>
+
+        <h3>Dark variant</h3>
+
+        <p>Intended for use on non-white, very light grey backgrounds.</p>
+        <PatternExamples>
+          <PatternExample
+            details="Default state"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LabeledButton variant="dark">Buy ice cream</LabeledButton>
+            <LabeledButton icon="trash" variant="dark">
+              Buy ice cream
             </LabeledButton>
           </PatternExample>
 
-          <PatternExample details="Right icon">
-            <LabeledButton icon="profile" iconPosition="right">
-              Edit User
+          <PatternExample
+            details="Pressed"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LabeledButton pressed variant="dark">
+              Buy ice cream
+            </LabeledButton>
+            <LabeledButton icon="trash" pressed variant="dark">
+              Buy ice cream
             </LabeledButton>
           </PatternExample>
 
-          <PatternExample details="Primary variant">
-            <LabeledButton icon="profile" variant="primary">
-              Edit User
+          <PatternExample
+            details="Expanded"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LabeledButton expanded variant="dark">
+              Buy ice cream
+            </LabeledButton>
+            <LabeledButton expanded icon="edit" variant="dark">
+              Buy ice cream
+            </LabeledButton>
+          </PatternExample>
+
+          <PatternExample
+            details="Disabled"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LabeledButton disabled variant="dark">
+              Buy ice cream
+            </LabeledButton>
+            <LabeledButton disabled icon="edit" variant="dark">
+              Buy ice cream
             </LabeledButton>
           </PatternExample>
         </PatternExamples>
@@ -106,6 +297,8 @@ export default function SharedButtonPatterns() {
 
       <Pattern title="LinkButton">
         <p>A button styled to look like a link (anchor tag).</p>
+
+        <h3>Default variant</h3>
         <PatternExamples>
           <PatternExample details="Basic usage">
             <LinkButton>Show replies (10)</LinkButton>
@@ -122,9 +315,70 @@ export default function SharedButtonPatterns() {
           <PatternExample details="Disabled">
             <LinkButton disabled>Show replies (10)</LinkButton>
           </PatternExample>
+        </PatternExamples>
 
-          <PatternExample details="Primary variant">
+        <h3>Primary variant</h3>
+
+        <PatternExamples>
+          <PatternExample details="Basic usage">
             <LinkButton variant="primary">Show replies (10)</LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Pressed">
+            <LinkButton pressed variant="primary">
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Expanded">
+            <LinkButton expanded variant="primary">
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+
+          <PatternExample details="Disabled">
+            <LinkButton disabled variant="primary">
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+        </PatternExamples>
+
+        <h3>Dark variant</h3>
+        <p>For use on light grey (non-white) backgrounds.</p>
+
+        <PatternExamples>
+          <PatternExample
+            details="Basic usage"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LinkButton variant="dark">Show replies (10)</LinkButton>
+          </PatternExample>
+
+          <PatternExample
+            details="Pressed"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LinkButton pressed variant="dark">
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+
+          <PatternExample
+            details="Expanded"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LinkButton expanded variant="dark">
+              Show replies (10)
+            </LinkButton>
+          </PatternExample>
+
+          <PatternExample
+            details="Disabled"
+            style={{ backgroundColor: '#ececec' }}
+          >
+            <LinkButton disabled variant="dark">
+              Show replies (10)
+            </LinkButton>
           </PatternExample>
         </PatternExamples>
       </Pattern>

--- a/src/shared/components/buttons.js
+++ b/src/shared/components/buttons.js
@@ -15,9 +15,11 @@ import { SvgIcon } from '@hypothesis/frontend-shared';
  * @prop {boolean} [pressed] - Is this button currently "active?" (set
  *   `aria-pressed`)
  * @prop {() => any} [onClick]
+ * @prop {'small'|'medium'|'large'} [size='medium'] - Relative button size:
+ *   affects padding
  * @prop {Object} [style] - Optional inline styles
  * @prop {string} [title] - Button title; used for `aria-label` attribute
- * @prop {'primary'} [variant] - For styling: element variant
+ * @prop {'normal'|'primary'|'light'|'dark'} [variant='normal'] - For styling: element variant
  */
 
 /**
@@ -42,9 +44,10 @@ function ButtonBase({
   expanded,
   pressed,
   onClick = () => {},
+  size = 'medium',
   style = {},
   title,
-  variant,
+  variant = 'normal',
 }) {
   const otherAttributes = {};
   if (typeof disabled === 'boolean') {
@@ -64,10 +67,14 @@ function ButtonBase({
 
   return (
     <button
-      className={classnames(className, {
-        [`${className}--${variant}`]: variant,
-        [`${className}--icon-${iconPosition}`]: icon,
-      })}
+      className={classnames(
+        className,
+        `${className}--${size}`,
+        `${className}--${variant}`,
+        {
+          [`${className}--icon-${iconPosition}`]: icon,
+        }
+      )}
       onClick={onClick}
       {...otherAttributes}
       style={style}

--- a/src/shared/components/test/buttons-test.js
+++ b/src/shared/components/test/buttons-test.js
@@ -41,11 +41,39 @@ function addCommonTests({ componentName, createComponentFn, withIcon = true }) {
       assert.isTrue(wrapper.find('button').hasClass(componentName));
     });
 
-    it('renders a primary variant', () => {
-      const wrapper = createComponentFn({ variant: 'primary' });
+    ['primary', 'light', 'dark'].forEach(variant => {
+      it('renders a valid variant', () => {
+        const wrapper = createComponentFn({ variant });
+
+        assert.isTrue(
+          wrapper.find('button').hasClass(`${componentName}--${variant}`)
+        );
+      });
+    });
+
+    it('sets a `normal` variant modifier class by default', () => {
+      const wrapper = createComponentFn();
 
       assert.isTrue(
-        wrapper.find('button').hasClass(`${componentName}--primary`)
+        wrapper.find('button').hasClass(`${componentName}--normal`)
+      );
+    });
+
+    ['small', 'medium', 'large'].forEach(size => {
+      it('renders a valid size', () => {
+        const wrapper = createComponentFn({ size });
+
+        assert.isTrue(
+          wrapper.find('button').hasClass(`${componentName}--${size}`)
+        );
+      });
+    });
+
+    it('sets a `medium` size modifier class by default', () => {
+      const wrapper = createComponentFn();
+
+      assert.isTrue(
+        wrapper.find('button').hasClass(`${componentName}--medium`)
       );
     });
 

--- a/src/sidebar/components/SearchInput.js
+++ b/src/sidebar/components/SearchInput.js
@@ -80,9 +80,9 @@ export default function SearchInput({ alwaysExpanded, query, onSearch }) {
       {!isLoading && (
         <div className="SearchInput__button-container">
           <IconButton
-            className="CompactIconButton"
             icon="search"
             onClick={() => input.current.focus()}
+            size="small"
             title="Search annotations"
           />
         </div>

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -5,9 +5,8 @@ import isThirdPartyService from '../helpers/is-third-party-service';
 import { withServices } from '../service-context';
 import { applyTheme } from '../helpers/theme';
 
-import { IconButton } from '../../shared/components/buttons';
+import { IconButton, LinkButton } from '../../shared/components/buttons';
 
-import Button from './Button';
 import GroupList from './GroupList';
 import SearchInput from './SearchInput';
 import SortMenu from './SortMenu';
@@ -83,20 +82,24 @@ function TopBar({
         <span className="TopBar__login-links">⋯</span>
       )}
       {auth.status === 'logged-out' && (
-        <span className="TopBar__login-links">
-          <Button
-            className="TopBar__login-button"
-            buttonText="Sign up"
+        <span className="TopBar__login-links u-font--large u-horizontal-rhythm">
+          <LinkButton
+            className="InlineLinkButton"
             onClick={onSignUp}
             style={loginLinkStyle}
-          />{' '}
-          /
-          <Button
-            className="TopBar__login-button"
-            buttonText="Log in"
+            variant="primary"
+          >
+            Sign up
+          </LinkButton>
+          <div>/</div>
+          <LinkButton
+            className="InlineLinkButton"
             onClick={onLogin}
             style={loginLinkStyle}
-          />
+            variant="primary"
+          >
+            Log in
+          </LinkButton>
         </span>
       )}
       {auth.status === 'logged-in' && (
@@ -113,10 +116,10 @@ function TopBar({
           <StreamSearchInput />
           <div className="u-stretch" />
           <IconButton
-            className="CompactIconButton"
             icon="help"
             expanded={isHelpPanelOpen}
             onClick={requestHelp}
+            size="small"
             title="Help"
           />
           {loginControl}
@@ -129,9 +132,9 @@ function TopBar({
           <div className="u-stretch" />
           {pendingUpdateCount > 0 && (
             <IconButton
-              className="CompactIconButton"
               icon="refresh"
               onClick={applyPendingUpdates}
+              size="small"
               variant="primary"
               title={`Show ${pendingUpdateCount} new/updated ${
                 pendingUpdateCount === 1 ? 'annotation' : 'annotations'
@@ -145,18 +148,18 @@ function TopBar({
           <SortMenu />
           {showSharePageButton && (
             <IconButton
-              className="CompactIconButton"
               icon="share"
               expanded={isAnnotationsPanelOpen}
               onClick={toggleSharePanel}
+              size="small"
               title="Share annotations on this page"
             />
           )}
           <IconButton
-            className="CompactIconButton"
             icon="help"
             expanded={isHelpPanelOpen}
             onClick={requestHelp}
+            size="small"
             title="Help"
           />
           {loginControl}

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -147,13 +147,10 @@ describe('TopBar', () => {
         onSignUp,
       });
       const loginText = getLoginText(wrapper);
-      const loginButtons = loginText.find('Button');
+      const loginButtons = loginText.find('LinkButton');
       assert.equal(loginButtons.length, 2);
 
-      assert.equal(loginButtons.at(0).props().buttonText, 'Sign up');
       assert.equal(loginButtons.at(0).props().onClick, onSignUp);
-
-      assert.equal(loginButtons.at(1).props().buttonText, 'Log in');
       assert.equal(loginButtons.at(1).props().onClick, onLogin);
     });
 

--- a/src/styles/shared/components/buttons/_base.scss
+++ b/src/styles/shared/components/buttons/_base.scss
@@ -1,0 +1,118 @@
+@use "sass:map";
+
+@use "@hypothesis/frontend-shared/styles/mixins/focus";
+
+// Set colors for a button
+@mixin _colors($colormap) {
+  color: map.get($colormap, 'foreground');
+  background-color: map.get($colormap, 'background');
+
+  &:disabled {
+    color: map.get($colormap, 'disabled-foreground');
+  }
+}
+
+// Set hover colors and transition for a button
+@mixin _hover-state($colormap) {
+  &:hover:not([disabled]) {
+    color: map.get($colormap, 'hover-foreground');
+    background-color: map.get($colormap, 'hover-background');
+  }
+  transition: color 0.2s ease-out, background-color 0.2s ease-out,
+    opacity 0.2s ease-out;
+}
+
+// Set active state colors for a button
+@mixin _active-state($colormap) {
+  &[aria-expanded='true'],
+  &[aria-pressed='true'] {
+    color: map.get($colormap, 'active-foreground');
+    @if map.get($colormap, 'active-background') {
+      background-color: map.get($colormap, 'active-background');
+    }
+
+    &:hover:not([disabled]) {
+      color: map.get($colormap, 'hover-foreground');
+    }
+
+    &:focus:not([disabled]) {
+      color: map.get($colormap, 'active-foreground');
+    }
+  }
+}
+
+// Variant mixin: may be be used by variants (BEM modifier classes)
+@mixin button--variant($options) {
+  @include _colors(map.get($options, 'colormap'));
+  @if map.get($options, 'withStates') {
+    @include _active-state(map.get($options, 'colormap'));
+    @include _hover-state(map.get($options, 'colormap'));
+  }
+  @content;
+}
+
+// Base mixin for buttons.
+@mixin button($options) {
+  // Reset browser defaults
+  @include focus.outline-on-keyboard-focus;
+  padding: 0;
+  margin: 0;
+  background-color: transparent;
+  border-style: none;
+
+  @include _colors(map.get($options, 'colormap'));
+
+  @if map.get($options, 'withStates') {
+    @include _active-state(map.get($options, 'colormap'));
+    @include _hover-state(map.get($options, 'colormap'));
+  }
+
+  border-radius: map.get($options, 'border-radius');
+  border: none;
+  padding: 0.5em;
+
+  &--small {
+    padding: 0.25em;
+  }
+
+  &--large {
+    padding: 0.75em;
+  }
+
+  font-size: 1em;
+  font-weight: 700;
+  white-space: nowrap; // Keep multi-word button labels from wrapping
+
+  @if map.get($options, 'inline') {
+    display: inline;
+  } @else {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  @if map.get($options, 'withLayout') {
+    &--icon-left svg {
+      margin-right: map.get($options, 'margin');
+    }
+
+    &--icon-right svg {
+      margin-left: map.get($options, 'margin');
+    }
+    // When a button has "layout", that indicates it has some textual content:
+    // Size text to the contextual 1em, and adjust the icon to look balanced.
+    // H frontend app buttons tend to apply an icon:text ratio of ~1.25:1
+    svg {
+      width: 1.25em;
+      height: 1.25em;
+    }
+  } @else {
+    // In the case where an icon is the only content in a <button> element,
+    // size the icon based on contextual font-size. i.e. the icon IS
+    // the content
+    svg {
+      width: 1em;
+      height: 1em;
+    }
+  }
+}

--- a/src/styles/shared/components/buttons/_config.scss
+++ b/src/styles/shared/components/buttons/_config.scss
@@ -7,6 +7,7 @@ $touch-target-size: var.$touch-target-size !default;
 $color-g1: var.$color-grey-1 !default;
 $color-g2: var.$color-grey-2 !default;
 $color-g3: var.$color-grey-3 !default;
+$color-g4: var.$color-grey-4 !default;
 $color-g6: var.$color-grey-6 !default;
 $color-g7: var.$color-grey-7 !default;
 $color-gsemi: var.$color-grey-semi !default;
@@ -14,62 +15,96 @@ $color-gmid: var.$color-grey-mid !default;
 $color-brand: var.$color-brand !default;
 $color-link-hover: var.$color-link-hover !default;
 
-// The following SASS maps define color sets for each type of button
-
-// Default colors for buttons
-$colors: (
+// Colors for labeled buttons
+$LabeledButton-colors: (
   'foreground': $color-gmid,
   'background': $color-g1,
   'hover-foreground': $color-g7,
   'hover-background': $color-g2,
   'active-foreground': $color-g7,
-  'active-background': $color-g1,
-  'border': transparent,
   'disabled-foreground': $color-gmid,
 );
 
-// Icon-only buttons have a transparent background by default, and a more
-// visible active (pressed) state
-$IconButton-colors: map.merge(
-  $colors,
-  (
-    'background': transparent,
-    'hover-background': transparent,
-    'active-foreground': $color-brand,
-    'active-background': transparent,
-  )
+// Variant currently unused
+$LabeledButton-colors--light: $LabeledButton-colors;
+
+$LabeledButton-colors--primary: (
+  'foreground': $color-g1,
+  'background': $color-gmid,
+  'hover-foreground': $color-g1,
+  'hover-background': $color-g6,
+  'active-foreground': $color-g1,
+  'disabled-foreground': $color-g4,
 );
 
-$IconButton-colors--primary: map.merge(
-  $IconButton-colors,
-  (
-    'foreground': $color-brand,
-    'hover-foreground': $color-brand,
-    'active-foreground': $color-brand,
-  )
+$LabeledButton-colors--dark: (
+  'foreground': $color-gmid,
+  'background': transparent,
+  'hover-foreground': $color-g7,
+  'hover-background': $color-g3,
+  'active-foreground': $color-gmid,
+  'active-background': $color-g3,
+  'disabled-foreground': $color-gmid,
 );
 
-$LabeledButton-colors: $colors;
-
-// This set of colors is light text on dark background
-$LabeledButton-colors--primary: map.merge(
-  $colors,
-  (
-    'foreground': $color-g1,
-    'background': $color-gmid,
-    'hover-foreground': $color-g1,
-    'hover-background': $color-g6,
-    'disabled-foreground': $color-gsemi,
-  )
+// Colors for icon-only buttons
+$IconButton-colors: (
+  'foreground': $color-gmid,
+  'background': transparent,
+  'hover-foreground': $color-g7,
+  'hover-background': transparent,
+  'active-foreground': $color-brand,
+  'disabled-foreground': $color-gmid,
 );
 
-// This set of colors is for buttons styled as links on a white background
-$LinkButton-colors: map.merge(
-  $colors,
-  (
-    'background': transparent,
-    'hover-background': transparent,
-    'active-background': transparent,
-    'hover-foreground': $color-link-hover,
-  )
+$IconButton-colors--light: (
+  'foreground': $color-gsemi,
+  'background': transparent,
+  'hover-foreground': $color-g6,
+  'hover-background': transparent,
+  'active-foreground': $color-gsemi,
+  'disabled-foreground': $color-gsemi,
+);
+
+$IconButton-colors--primary: (
+  'foreground': $color-brand,
+  'background': transparent,
+  'hover-foreground': $color-brand,
+  'hover-background': transparent,
+  'active-foreground': $color-brand,
+  'disabled-foreground': $color-gmid,
+);
+
+// Variant currently unused
+$IconButton-colors--dark: $IconButton-colors;
+
+// Colors for buttons styled as "links"
+$LinkButton-colors: (
+  'foreground': $color-gmid,
+  'background': transparent,
+  'hover-foreground': $color-link-hover,
+  'hover-background': transparent,
+  'active-foreground': $color-g7,
+  'disabled-foreground': $color-gmid,
+);
+
+// Variant currently unused
+$LinkButton-colors--light: $LinkButton-colors;
+
+$LinkButton-colors--primary: (
+  'foreground': $color-brand,
+  'background': transparent,
+  'hover-foreground': $color-brand,
+  'hover-background': transparent,
+  'active-foreground': $color-brand,
+  'disabled-foreground': $color-gmid,
+);
+
+$LinkButton-colors--dark: (
+  'foreground': $color-g7,
+  'background': transparent,
+  'hover-foreground': $color-link-hover,
+  'hover-background': transparent,
+  'active-foreground': $color-g7,
+  'disabled-foreground': $color-gmid,
 );

--- a/src/styles/shared/components/buttons/_index.scss
+++ b/src/styles/shared/components/buttons/_index.scss
@@ -1,63 +1,16 @@
-@use "sass:map";
-
-@use "../../variables" as var;
-
-@use './_config' as *; // Bring variables into scope
 @use './mixins';
-
-// A button with only an icon and no label/text
-.IconButton {
-  @include mixins.Button(
-    $options: (
-      'colormap': $IconButton-colors,
-    )
-  ) {
-    @media (pointer: coarse) {
-      min-width: $touch-target-size;
-      min-height: $touch-target-size;
-    }
-  }
-  &--primary {
-    @include mixins.Button--variant(
-      $options: (
-        'colormap': $IconButton-colors--primary,
-      )
-    );
-  }
-}
 
 // A button with text, and optionally an icon
 .LabeledButton {
-  @include mixins.Button(
-    $options: (
-      'colormap': $LabeledButton-colors,
-      'withLayout': true,
-    )
-  );
-  &--primary {
-    @include mixins.Button--variant(
-      $options: (
-        'colormap': $LabeledButton-colors--primary,
-      )
-    );
-  }
+  @include mixins.LabeledButton;
+}
+
+// A button with only an icon and no label/text
+.IconButton {
+  @include mixins.IconButton;
 }
 
 // A button styled to appear as a link, with underline on hover
 .LinkButton {
-  @include mixins.Button(
-    $options: (
-      'colormap': $LinkButton-colors,
-      'withStates': false,
-    )
-  ) {
-    // Override base font-weight
-    font-weight: 400;
-  }
-  // No active states, but we do want a hover state
-  @include mixins.hover-state($LinkButton-colors) {
-    text-decoration: underline;
-  }
-  // Remove horizontal padding to allow button to appear flush-left or -right
-  padding: 0.5em 0;
+  @include mixins.LinkButton;
 }

--- a/src/styles/shared/components/buttons/mixins.scss
+++ b/src/styles/shared/components/buttons/mixins.scss
@@ -2,174 +2,141 @@
 
 @use "@hypothesis/frontend-shared/styles/mixins/focus";
 
-@use './_config' as *;
+@use './_config' as c;
+@use './_base' as base;
 
-// Reset browser native styles. This can be used in conjunction with other
-// styles via `base` or standalone for starting a custom button's styles
-// from relative scratch
-@mixin reset {
-  @include focus.outline-on-keyboard-focus;
-  // Reset native styles
-  padding: 0;
-  margin: 0;
-  background-color: transparent;
-  border-style: none;
-}
+// Allow access to the configuration values to users of this module (esp. colors)
+@forward './_config';
 
-// Set colors for a button
-@mixin _colors($colormap) {
-  color: map.get($colormap, 'foreground');
-  background-color: map.get($colormap, 'background');
-
-  &:disabled {
-    color: map.get($colormap, 'disabled-foreground');
-  }
-}
-
-// Set hover colors and transition for a button
-@mixin hover-state($colormap) {
-  &:hover:not([disabled]),
-  &:focus:not([disabled]) {
-    color: map.get($colormap, 'hover-foreground');
-    background-color: map.get($colormap, 'hover-background');
-    @content;
-  }
-  transition: color 0.2s ease-out, background-color 0.2s ease-out,
-    opacity 0.2s ease-out;
-}
-
-// Set active state colors for a button
-@mixin active-state($colormap) {
-  &[aria-expanded='true'],
-  &[aria-pressed='true'] {
-    color: map.get($colormap, 'active-foreground');
-    background-color: map.get($colormap, 'active-background');
-    @content;
-
-    &:hover:not([disabled]),
-    &:focus:not([disabled]) {
-      color: map.get($colormap, 'active-foreground');
-      background-color: map.get($colormap, 'active-background');
-      @content;
-    }
-  }
-}
-
-// Variant mixin: may be be used by variants (BEM modifier classes)
-@mixin _variant($options) {
-  @include _colors(map.get($options, 'colormap'));
-  @if map.get($options, 'withStates') {
-    @include active-state(map.get($options, 'colormap'));
-    @include hover-state(map.get($options, 'colormap'));
-  }
-  @content;
-}
-
-// Base mixin for buttons.
-@mixin _button($options) {
-  @include reset;
-  @include _colors(map.get($options, 'colormap'));
-
-  @if map.get($options, 'withStates') {
-    @include active-state(map.get($options, 'colormap'));
-    @include hover-state(map.get($options, 'colormap'));
-  }
-
-  border-radius: map.get($options, 'border-radius');
-  border: none;
-  padding: 0.5em;
-
-  font-size: 1em;
-  font-weight: 700;
-  white-space: nowrap; // Keep multi-word button labels from wrapping
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  @if map.get($options, 'withLayout') {
-    &--icon-left svg {
-      margin-right: map.get($options, 'margin');
-    }
-
-    &--icon-right svg {
-      margin-left: map.get($options, 'margin');
-    }
-    // When a button has "layout", that indicates it has some textual content:
-    // Size text to the contextual 1em, and adjust the icon to look balanced.
-    // H frontend app buttons tend to apply an icon:text ratio of ~1.25:1
-    svg {
-      width: 1.25em;
-      height: 1.25em;
-    }
-  } @else {
-    // In the case where an icon is the only content in a <button> element,
-    // size the icon based on contextual font-size. i.e. the icon IS
-    // the content
-    svg {
-      width: 1em;
-      height: 1em;
-    }
-  }
-}
-
-/**
- * Convenience function to retrieve a colormap. This obviates the need to reach
- * into the `_config` module directly from outside and is less verbose.
- *
- * @param {'colors'|'icon'|'icon--primary'|'labeled'|'labeled--primary'|'link'}
- *        [$name] - Shorthand name of colormap to retrieved. Defaults to base
- *          $colors.
- * @return {sass:map}
- */
-@function colormap($name: 'colors') {
-  $result: $colors;
-  @if $name == 'icon' {
-    $result: $IconButton-colors;
-  }
-  @if $name == 'icon--primary' {
-    $result: $IconButton-colors--primary;
-  }
-  @if $name == 'labeled' {
-    $result: $LabeledButton-colors;
-  }
-  @if $name == 'labeled--primary' {
-    $result: $LabeledButton-colors--primary;
-  }
-  @if $name == 'link' {
-    $result: $LinkButton-colors;
-  }
-  @return $result;
-}
-
-// Base mixin for <button> elements. Start here for new <button> classes
+// Base mixin for <button> elements
 @mixin Button($options: ()) {
   $defaultOptions: (
     // What colors should be used for this button's styling?
-    'colormap': $colors,
+    'colormap': c.$LabeledButton-colors,
+    // And for its variants...needed if `withVariants` is true (true is default)
+    'colormap--primary': c.$LabeledButton-colors--primary,
+    'colormap--dark': c.$LabeledButton-colors--dark,
+    'colormap--light': c.$LabeledButton-colors--light,
+    // Should this button apply an inline layout? (default is flex)
+    'inline': false,
     // Should styling be added for "active" and "hover" states for this <button>?
     'withStates': true,
     // Should styling be added to support the layout of multiple sub-elements
     // of this <button>? Not needed if <button> contains only one child.
     'withLayout': false,
+    // Provide styling for light, primary and dark variants? If this is true,
+    // make sure all variant colormaps are provided
+    'withVariants': true,
     // Internal margin around SVG icon
     'margin': 0.5em,
     'border-radius': 2px
   );
   $-options: map.merge($defaultOptions, $options);
-  @include _button($options: $-options);
+
+  @include base.button($options: $-options);
+
+  // Add styles for supported variants as modifier classes, if `withVariants` enabled
+  @if (map.get($-options, 'withVariants')) {
+    &--light {
+      $-light-options: (
+        'colormap': map.get($-options, 'colormap--light'),
+        'withStates': map.get($-options, 'withStates'),
+      );
+      @include base.button--variant($-light-options);
+    }
+
+    &--primary {
+      $-primary-options: (
+        'colormap': map.get($-options, 'colormap--primary'),
+        'withStates': map.get($-options, 'withStates'),
+      );
+      @include base.button--variant($-primary-options);
+    }
+
+    &--dark {
+      $-dark-options: (
+        'colormap': map.get($-options, 'colormap--dark'),
+        'withStates': map.get($-options, 'withStates'),
+      );
+      @include base.button--variant($-dark-options);
+    }
+  }
   @content;
 }
 
-// Mixin for --modifier variants on buttons, e.g. `.MyButton--primary`
-@mixin Button--variant($options: ()) {
+// Base mixin for a button with an icon and no label/content. Supports
+// variants and sizes. Will assert responsive touch-target sizing in
+// --medium (default) and --large variants.
+@mixin IconButton($options: ()) {
   $defaultOptions: (
-    // Colors to use when styling this variant
-    'colormap': $colors,
-    // Should this variant have styling for "active" and "hover" states?
-    'withStates': true
+    'colormap': c.$IconButton-colors,
+    'colormap--light': c.$IconButton-colors--light,
+    'colormap--primary': c.$IconButton-colors--primary,
+    'colormap--dark': c.$IconButton-colors--dark,
+    'responsive': true,
   );
   $-options: map.merge($defaultOptions, $options);
-  @include _variant($options: $-options);
+
+  @include Button($-options) {
+    // Establish a minimum touch-target for touch devices if 'responsive'
+    // option is enabled (default). This is not applied to the `--small`
+    // size variant.
+    @if map.get($-options, 'responsive') {
+      @media (pointer: coarse) {
+        &--medium,
+        &--large {
+          min-width: c.$touch-target-size;
+          min-height: c.$touch-target-size;
+        }
+      }
+    }
+  }
+
+  @content;
+}
+
+// Base mixin for a button that has text/content and, optionally, an icon.
+// Supports variants and sizes.
+@mixin LabeledButton($options: ()) {
+  $defaultOptions: (
+    'colormap': c.$LabeledButton-colors,
+    'colormap--light': c.$LabeledButton-colors--light,
+    'colormap--primary': c.$LabeledButton-colors--primary,
+    'colormap--dark': c.$LabeledButton-colors--dark,
+    'withLayout': true,
+  );
+  $-options: map.merge($defaultOptions, $options);
+
+  @include Button($-options);
+
+  @content;
+}
+
+// Base mixin for a button styled to look like an <a> link. Supports variants
+// but not pressed/active states at present.
+@mixin LinkButton($options: ()) {
+  $defaultOptions: (
+    'colormap': c.$LinkButton-colors,
+    'colormap--light': c.$LinkButton-colors--light,
+    'colormap--primary': c.$LinkButton-colors--primary,
+    'colormap--dark': c.$LinkButton-colors--dark,
+  );
+  $-options: map.merge($defaultOptions, $options);
+  @include Button($-options) {
+    // Lighter font weight for link-styled buttons
+    font-weight: 400;
+    // Add an underline on hover
+    &:hover:not([disabled]) {
+      text-decoration: underline;
+    }
+
+    &--primary {
+      // Primary variant has bolder text (and also different colors)
+      font-weight: 500;
+    }
+  }
+
+  // Remove padding to allow button to appear flush with surrounding content
+  padding: 0;
   @content;
 }

--- a/src/styles/sidebar/buttons.scss
+++ b/src/styles/sidebar/buttons.scss
@@ -1,22 +1,17 @@
 // Button styling for the sidebar extending common button-component styles
 @use '../shared/components/buttons/mixins' as buttons;
 
-// Similar to `.IconButton`, with these changes:
-// - omit responsive minimum sizing
-// - tighten padding
-.CompactIconButton {
-  // Use icon colors for base and primary variants
-  $base-options: (
-    'colormap': buttons.colormap('icon'),
+// Similar to `.LinkButton`, with inline layout (so button can be used
+// within text)
+.InlineLinkButton {
+  @include buttons.LinkButton(
+    (
+      'inline': true,
+    )
   );
-  $primary-options: (
-    'colormap': buttons.colormap('icon--primary'),
-  );
-
-  @include buttons.Button($options: $base-options) {
-    padding: 0.25em; // Override padding
-  }
-  &--primary {
-    @include buttons.Button--variant($options: $primary-options);
+  // Custom: The dark variant is used for inline, anchor-like styling and needs
+  // to be underlined at all times to match <a> styling near it
+  &--dark {
+    text-decoration: underline;
   }
 }

--- a/src/styles/ui-playground/ui-playground.scss
+++ b/src/styles/ui-playground/ui-playground.scss
@@ -28,9 +28,15 @@ h2 {
 }
 
 h3 {
-  width: 100%;
   font-size: 1.125em;
   font-weight: normal;
+  font-style: italic;
+  margin: 1em 0;
+}
+
+h4 {
+  font-size: 1em;
+  font-weight: 500;
   font-style: italic;
 }
 
@@ -82,19 +88,27 @@ pre {
   }
 }
 
-// Temporarily enforce the body font size of the client to demonstrate how
-// components would scale in-situ
 .PatternPage {
-  font-size: 13px;
+  font-size: 14px;
+
   &__content {
     padding: 2em 0;
   }
 }
 
 .Pattern {
-  margin-bottom: 4em;
+  margin: 0 0 4em 1em;
   p {
     margin: 1em;
+    margin-left: 0;
+  }
+
+  & > p:first-of-type {
+    font-size: 125%;
+  }
+
+  h2 {
+    margin-left: -1em;
   }
 }
 
@@ -102,6 +116,7 @@ pre {
   border: 1px solid var.$grey-3;
   border-collapse: collapse;
   width: 100%;
+  margin-top: 1em;
   margin-bottom: 2em;
 
   th,
@@ -120,7 +135,7 @@ pre {
     padding-bottom: 10px;
   }
 
-  tr:nth-child(even) td {
+  tr:nth-child(even) {
     background: var.$grey-0;
   }
 

--- a/src/styles/util.scss
+++ b/src/styles/util.scss
@@ -50,6 +50,10 @@
   @include layout.vertical-rhythm;
 }
 
+.u-font--large {
+  @include utils.font--large;
+}
+
 .u-font--xlarge {
   @include utils.font--xlarge;
 }


### PR DESCRIPTION
Part of #3000

**This PR's diff looks startlingly large,** but over half of the changes are boilerplate-ish updates to the pattern library that don't require careful review.

This PR is the consequences of walking through every custom pattern used in the client for the deprecated `<Button>` component and updating the shared `<*Button>` components to be extensible according to these kinds of customization needs.

The main changes of note in this PR are:

* Add (well, resuscitate) a `size` property on `<*Button>` components
* Add two new valid values for the `variant` property: `light` and `dark`
* Restructure SASS modules and mixins to make them more extensible, easier to understand (I hope) and to make the “public API” more defined
* Update shared button examples in the pattern library

It is anticipated, though not guaranteed, that these should be the last substantial changes to the shared `<*Button>` elements and their styling.

### Supporting button styling extensibility: Size and Variants

Initial designs of shared button components included a `size` property, which was pulled out as there weren’t immediately-evident use cases. Use cases have been found.

 I have had a second a-ha moment akin to the one last week about icon sizing: a `size` property has more use as a lever for adjusting a button’s proportional appearance, rather than the absolute sizing of its content.

The introduction of a `size` property here alleviates the need for custom “compact” styling for several button patterns within the client. It affects proportional padding within the component. 

Another common vector of button customization within the client is color-palette-shifting. These tend to push things either lighter (making a non-critical button appear more subtle, or darker (typically to make a button show up against a darker background). These shifts are mutually exclusive from `primary`-variant buttons, making the use of more `variant` values plausible.

As a result of working through the various custom styling patterns, some of the common variants have also been fleshed out a little more here, e.g. the `primary` variant of `LinkButton` components. 

### Pattern Library updates

A large part of the diff here is additions of patterns to the shared-button pattern library page and another refresh of pattern library styling/layout. These changes should require only light review.

### User-visible changes

The only user-visible change here is to the log in and signup links at the top right of the sidebar. These now underline on hover and are brand-red on hover to be consistent with other links and link-like elements.

Before (Sign up link is hovered):

<img width="467" alt="Screen Shot 2021-04-05 at 10 40 24 AM" src="https://user-images.githubusercontent.com/439947/113586389-70661400-95fb-11eb-9df2-75b1706543d1.png">


After (Sign up link is hovered):

<img width="442" alt="Screen Shot 2021-04-05 at 10 01 10 AM" src="https://user-images.githubusercontent.com/439947/113586209-38f76780-95fb-11eb-8bd4-48bfd1c39a89.png">

## How this fits in/other work
1. Basic shared button components, pattern library representation and their styling — DONE
2. Replace uses of `<Button>` in the sidebar with new shared variant, where doing so doesn’t require any styling customization — DONE
3. Walk through the rest of the (custom) uses of `<Button>` in the client and define path to achieve this using new shared variants — work leading up to this PR - DONE
4. Update shared buttons as needed to best serve custom patterns - THIS PR
5. Update remaining (customized) uses of `<Button>` in the client with shared variants - this work is sitting on a branch — NEXT PR
