### PR TITLE
Improve JSX code formatting in dev server

### DIFF
--- a/dev-server/ui-playground/util/jsx-to-string.js
+++ b/dev-server/ui-playground/util/jsx-to-string.js
@@ -85,7 +85,7 @@ export function jsxToString(vnode) {
       return `<${name}${propStr}>\n${childrenStr}\n</${name}>`;
     } else {
       // No children - use a self-closing tag.
-      return `<${name}${propStr}/>`;
+      return `<${name}${propStr} />`;
     }
   } else {
     return '';


### PR DESCRIPTION
Improve the formatting of code in `jsxToString`.

 - Indent children by two spaces

 - Handle boolean props closer to how we normally set them in JSX by omitting
   them if false and including them without explicit values if true.
   This assumes that boolean props default to false. If there is a
   scenario in future where this is not the case, this behavior may need
   to be configurable.

 - Handle `bigint` numeric values. We have no use case for this, but
   TypeScript pointed out that it wasn't handled.

 - Add JSDoc comments

----

New output:

<img width="353" alt="JSX Menu after" src="https://user-images.githubusercontent.com/2458/113683985-b20ac380-96bc-11eb-9b75-dff102028114.png">

<img width="445" alt="JSX buttons after" src="https://user-images.githubusercontent.com/2458/113684018-bb942b80-96bc-11eb-99a9-73d5518e4fc0.png">
