### PR TITLE
Update `AnnotationBody` to use `LabeledButton`

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationBody.js
+++ b/src/sidebar/components/Annotation/AnnotationBody.js
@@ -5,7 +5,8 @@ import { isHidden } from '../../helpers/annotation-metadata';
 import { withServices } from '../../service-context';
 import { applyTheme } from '../../helpers/theme';
 
-import Button from '../Button';
+import { LabeledButton } from '../../../shared/components/buttons';
+
 import Excerpt from '../Excerpt';
 import MarkdownView from '../MarkdownView';
 import TagList from '../TagList';
@@ -71,17 +72,13 @@ function AnnotationBody({ annotation, settings }) {
       )}
       {isCollapsible && (
         <div className="AnnotationBody__collapse-toggle">
-          {/* @ts-ignore - TODO: Button props need to be fixed */}
-          <Button
-            buttonText={toggleText}
-            className="AnnotationBody__collapse-toggle-button"
-            isExpanded={!isCollapsed}
-            onClick={() => {
-              setIsCollapsed(!isCollapsed);
-            }}
-            aria-label="Toggle visibility of full annotation text"
-            title="Toggle visibility of full annotation text"
-          />
+          <LabeledButton
+            expanded={!isCollapsed}
+            onClick={() => setIsCollapsed(!isCollapsed)}
+            title={`Toggle visibility of full annotation text: Show ${toggleText}`}
+          >
+            {toggleText}
+          </LabeledButton>
         </div>
       )}
       {showTagList && <TagList annotation={annotation} tags={tags} />}

--- a/src/sidebar/components/Annotation/test/AnnotationBody-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationBody-test.js
@@ -88,7 +88,7 @@ describe('AnnotationBody', () => {
 
     // By default, `isCollapsible` is `false` until changed by `Excerpt`,
     // so the expand/collapse button will not render
-    assert.isFalse(wrapper.find('Button').exists());
+    assert.isFalse(wrapper.find('LabeledButton').exists());
   });
 
   it('renders controls to expand/collapse the excerpt if it is collapsible', () => {
@@ -101,14 +101,13 @@ describe('AnnotationBody', () => {
     });
     wrapper.update();
 
-    const button = wrapper.find('Button');
+    const button = wrapper.find('LabeledButton');
     assert.isOk(button.exists());
-    assert.equal(button.props().buttonText, 'More');
     assert.equal(
       button.props().title,
-      'Toggle visibility of full annotation text'
+      'Toggle visibility of full annotation text: Show More'
     );
-    assert.isFalse(button.props().isExpanded);
+    assert.isFalse(button.props().expanded);
   });
 
   it('shows appropriate button text to collapse the Excerpt if expanded', () => {
@@ -123,18 +122,17 @@ describe('AnnotationBody', () => {
     wrapper.update();
 
     act(() => {
-      wrapper.find('Button').props().onClick();
+      wrapper.find('LabeledButton').props().onClick();
     });
     wrapper.update();
 
-    const buttonProps = wrapper.find('Button').props();
+    const buttonProps = wrapper.find('LabeledButton').props();
 
-    assert.equal(buttonProps.buttonText, 'Less');
     assert.equal(
       buttonProps.title,
-      'Toggle visibility of full annotation text'
+      'Toggle visibility of full annotation text: Show Less'
     );
-    assert.isTrue(buttonProps.isExpanded);
+    assert.isTrue(buttonProps.expanded);
   });
 
   describe('tag list and editor', () => {


### PR DESCRIPTION
Part of #3000 

Update the `AnnotationBody` component to use shared `LabeledButton`. This has a visual change. The button to expand/collapse long annotation content has long had a special exception in its styling: it had a transparent background. I've maintained this until now because "it's the way it was when I found it." I find myself asking _why_, however, especially since it's the only "labeled button on white" we use that has a transparent background. These changes make it use the shared `LabeledButton` and eliminates the background override so that the button is more consistent with our other buttons.

Before:

![image](https://user-images.githubusercontent.com/439947/113739685-04a0ab80-96ce-11eb-9ca9-0a9489bfaf00.png)

After:

![image](https://user-images.githubusercontent.com/439947/113739702-09fdf600-96ce-11eb-9578-399d1708c7de.png)
