### PR TITLE
Create "InputButton" from IconButton

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationShareControl.js
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.js
@@ -9,7 +9,6 @@ import { isIOS } from '../../../shared/user-agent';
 
 import { IconButton } from '../../../shared/components/buttons';
 
-import Button from '../Button';
 import ShareLinks from '../ShareLinks';
 
 /**
@@ -144,11 +143,12 @@ function AnnotationShareControl({
                 readOnly
                 ref={inputRef}
               />
-              <Button
+              <IconButton
+                className="InputButton"
                 icon="copy"
                 title="Copy share link to clipboard"
                 onClick={copyShareLink}
-                className="annotation-share-panel__icon-button"
+                size="small"
               />
             </div>
             {inContextAvailable ? (

--- a/src/sidebar/components/Annotation/test/AnnotationShareControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationShareControl-test.js
@@ -18,10 +18,6 @@ describe('AnnotationShareControl', () => {
 
   let container;
 
-  const getButton = (wrapper, iconName) => {
-    return wrapper.find('Button').filter({ icon: iconName });
-  };
-
   const getIconButton = (wrapper, iconName) => {
     return wrapper.find('IconButton').filter({ icon: iconName });
   };
@@ -139,7 +135,7 @@ describe('AnnotationShareControl', () => {
       const wrapper = createComponent();
       openElement(wrapper);
 
-      getButton(wrapper, 'copy').props().onClick();
+      getIconButton(wrapper, 'copy').props().onClick();
 
       assert.calledWith(
         fakeCopyToClipboard.copyText,
@@ -151,7 +147,7 @@ describe('AnnotationShareControl', () => {
       const wrapper = createComponent();
       openElement(wrapper);
 
-      getButton(wrapper, 'copy').props().onClick();
+      getIconButton(wrapper, 'copy').props().onClick();
 
       assert.calledWith(
         fakeToastMessenger.success,
@@ -164,7 +160,7 @@ describe('AnnotationShareControl', () => {
       const wrapper = createComponent();
       openElement(wrapper);
 
-      getButton(wrapper, 'copy').props().onClick();
+      getIconButton(wrapper, 'copy').props().onClick();
 
       assert.calledWith(fakeToastMessenger.error, 'Unable to copy link');
     });

--- a/src/sidebar/components/ShareAnnotationsPanel.js
+++ b/src/sidebar/components/ShareAnnotationsPanel.js
@@ -6,7 +6,8 @@ import { copyText } from '../util/copy-to-clipboard';
 import { withServices } from '../service-context';
 import { notNull } from '../util/typing';
 
-import Button from './Button';
+import { IconButton } from '../../shared/components/buttons';
+
 import ShareLinks from './ShareLinks';
 import SidebarPanel from './SidebarPanel';
 import Spinner from './Spinner';
@@ -78,11 +79,11 @@ function ShareAnnotationsPanel({ toastMessenger }) {
                   value={shareURI}
                   readOnly
                 />
-                <Button
+                <IconButton
+                  className="InputButton"
                   icon="copy"
                   onClick={copyShareLink}
                   title="Copy share link"
-                  className="ShareAnnotationsPanel__icon-button"
                 />
               </div>
               <p>

--- a/src/sidebar/components/test/ShareAnnotationsPanel-test.js
+++ b/src/sidebar/components/test/ShareAnnotationsPanel-test.js
@@ -172,7 +172,7 @@ describe('ShareAnnotationsPanel', () => {
       it('copies link to clipboard when copy button clicked', () => {
         const wrapper = createShareAnnotationsPanel();
 
-        wrapper.find('Button').props().onClick();
+        wrapper.find('IconButton').props().onClick();
 
         assert.calledWith(fakeCopyToClipboard.copyText, fakeBouncerLink);
       });
@@ -180,7 +180,7 @@ describe('ShareAnnotationsPanel', () => {
       it('confirms link copy when successful', () => {
         const wrapper = createShareAnnotationsPanel();
 
-        wrapper.find('Button').props().onClick();
+        wrapper.find('IconButton').props().onClick();
 
         assert.calledWith(
           fakeToastMessenger.success,
@@ -192,7 +192,7 @@ describe('ShareAnnotationsPanel', () => {
         fakeCopyToClipboard.copyText.throws();
         const wrapper = createShareAnnotationsPanel();
 
-        wrapper.find('Button').props().onClick();
+        wrapper.find('IconButton').props().onClick();
 
         assert.calledWith(fakeToastMessenger.error, 'Unable to copy link');
       });

--- a/src/styles/sidebar/buttons.scss
+++ b/src/styles/sidebar/buttons.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @use '../variables' as var;
 // Button styling for the sidebar extending common button-component styles
 @use '../shared/components/buttons/mixins' as buttons;
@@ -42,4 +44,32 @@
       'responsive': false,
     )
   );
+}
+
+// This is for styling an icon-only button that sits to the right of a
+// text input field. It is really part of a composite pattern that includes
+// both the input and the buttons. At some point this pattern should be
+// consolidated.
+$input-button-colors: map.merge(
+  buttons.$IconButton-colors,
+  (
+    'background': var.$grey-1,
+    'hover-background': var.$grey-2,
+  )
+);
+
+.InputButton {
+  $-options: (
+    'colormap': $input-button-colors,
+    'withVariants': false,
+  );
+  @include buttons.IconButton($-options) {
+    border: 1px solid var.$grey-3;
+    border-radius: 0; // Turn off border-radius to align with <input> edges
+    border-left: 0; // Avoid double border with the <input>
+    padding: var.$layout-space--xsmall var.$layout-space--small;
+    &--small {
+      padding: var.$layout-space--xxsmall var.$layout-space--xsmall;
+    }
+  }
 }

--- a/src/styles/sidebar/components/AnnotationShareControl.scss
+++ b/src/styles/sidebar/components/AnnotationShareControl.scss
@@ -38,10 +38,6 @@
     @include forms.form-input--with-button($compact: true);
   }
 
-  &__icon-button {
-    @include buttons.button--input($compact: true);
-  }
-
   &__details {
     @include utils.font--small;
     padding: var.$layout-space--xsmall 0;

--- a/src/styles/sidebar/components/ShareAnnotationsPanel.scss
+++ b/src/styles/sidebar/components/ShareAnnotationsPanel.scss
@@ -16,10 +16,6 @@
     @include forms.form-input--with-button;
   }
 
-  &__icon-button {
-    @include buttons.button--input;
-  }
-
   // FIXME: Centralize styling of different sizes of Spinner in a reusable
   // class or mixin.
   // Spinner uses `em`-sizing; make the font-size of the containing element


### PR DESCRIPTION
Use `IconButton` in `ShareAnnotationsPanel` and
`AnnotationShareControl`, with custom styling to make
the buttons pair well with a text input.

It would be ideal to create a design pattern from the
combo of the input + button in the future.

Part of #3000 

No visual changes:

![image](https://user-images.githubusercontent.com/439947/113746432-52201700-96d4-11eb-885e-898f91faa462.png)

and

![image](https://user-images.githubusercontent.com/439947/113746456-5815f800-96d4-11eb-85c4-203bfe6e3d11.png)
