### PR TITLE
Refactor `anchor` method in `Guest`

### DIFF
--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -785,7 +785,7 @@ describe('Guest', () => {
       };
       fakeHTMLIntegration.anchor
         .onFirstCall()
-        .returns(Promise.reject())
+        .returns(Promise.reject(new Error('Failed to anchor')))
         .onSecondCall()
         .returns(Promise.resolve(range));
 
@@ -801,7 +801,9 @@ describe('Guest', () => {
           { selector: [{ type: 'TextQuoteSelector', exact: 'notinhere' }] },
         ],
       };
-      fakeHTMLIntegration.anchor.returns(Promise.reject());
+      fakeHTMLIntegration.anchor.returns(
+        Promise.reject(new Error('Failed to anchor'))
+      );
 
       return guest
         .anchor(annotation)
@@ -816,7 +818,9 @@ describe('Guest', () => {
           { selector: [{ type: 'TextQuoteSelector', exact: 'neitherami' }] },
         ],
       };
-      fakeHTMLIntegration.anchor.returns(Promise.reject());
+      fakeHTMLIntegration.anchor.returns(
+        Promise.reject(new Error('Failed to anchor'))
+      );
 
       return guest
         .anchor(annotation)
@@ -915,20 +919,6 @@ describe('Guest', () => {
         assert.calledOnce(removeHighlights);
         assert.calledWith(removeHighlights, highlights);
       });
-    });
-
-    it('does not reanchor targets that are already anchored', () => {
-      const guest = createGuest();
-      const annotation = {
-        target: [{ selector: [{ type: 'TextQuoteSelector', exact: 'hello' }] }],
-      };
-      fakeHTMLIntegration.anchor.returns(Promise.resolve(range));
-      return guest.anchor(annotation).then(() =>
-        guest.anchor(annotation).then(() => {
-          assert.equal(guest.anchors.length, 1);
-          assert.calledOnce(fakeHTMLIntegration.anchor);
-        })
-      );
     });
   });
 

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -34,10 +34,13 @@
  */
 
 /**
- * @typedef Target
- * @prop {string} source
- * @prop {Selector[]} [selector]
+ * An entry in the `target` field of an annotation which identifies the document
+ * and region of the document that it refers to.
  *
+ * @typedef Target
+ * @prop {string} source - URI of the document
+ * @prop {Selector[]} [selector] - Region of the document
+ */
 
 /**
  * TODO - Fill out remaining properties
@@ -68,7 +71,9 @@
  *   @prop {string[]} permissions.update
  *   @prop {string[]} permissions.delete
  *
- * @prop {Target[]} target
+ * @prop {Target[]} target - Which document and region this annotation refers to.
+ *   The Hypothesis API structure allows for multiple targets, but the current
+ *   h server only allows for one target per annotation.
  *
  * @prop {Object} [moderation]
  *   @prop {number} moderation.flagCount


### PR DESCRIPTION
Rewrite the `Guest#anchor` method to simplify the control flow and generally make it easier to understand and change. There are no functional changes for annotations with one target (associated document location), which includes all existing Hypothesis annotations.

There is a functional change to handling of annotations with multiple targets [2]. Previously `anchor` would try to be smart about only re-anchoring targets which were not already anchored. In the new implementation all targets for an annotation are re-anchored. This will have no effect in practice because the Hypothesis client and server only support creating and storing one target per annotation. The anchoring logic has always supported multiple targets in theory though. Maybe in future we could just drop all support for multiple targets in the Hypothesis client. I demurred from going that far in this PR however.

 - Convert `anchor` method to async and replace Promise chains with async/await
 - Replace the logic that removes existing anchors and highlights for an annotation with a call to the `detach` method. This required adding an internal parameter to `detach` to control whether `anchorsChanged` is emitted, so that `anchor` only emits `anchorsChanged` once.
 - Add an explicit error to `Promise.reject` calls in tests so that the tests are easier to debug if they fail
 - Add some notes to the docs for the `Target` type and `annotation.target` field about usage in Hypothesis

[1] `Guest#createAnnotation` creates one target per `Range` in the `Selection` returned by `window.getSelection()`. The [Selection API documentation](https://w3c.github.io/selection-api/#definition) states that a selection "can be associated with a single range" (ie. there are zero or one ranges in the selection).
[2] _Multiple targets_ means that an annotation refers to more than one location in a document. Not supported on the Hypothesis client or server, but the representation of annotations in the API allows for it.