### PR TITLE
Make button `reset` mixin available and update uses

### DIFF
--- a/src/styles/annotator/components/AdderToolbar.scss
+++ b/src/styles/annotator/components/AdderToolbar.scss
@@ -1,4 +1,4 @@
-@use "../mixins/buttons";
+@use "../../shared/components/buttons";
 @use "../mixins/layout";
 @use "../mixins/molecules";
 @use "../mixins/utils";
@@ -80,7 +80,7 @@ $adder-transition-duration: 80ms;
 
 .AdderToolbar__button {
   @include layout.column($align: center);
-  @include buttons.reset-native-btn-styles;
+  @include buttons.reset;
 
   cursor: pointer;
   color: var.$grey-mid;

--- a/src/styles/annotator/components/Toolbar.scss
+++ b/src/styles/annotator/components/Toolbar.scss
@@ -2,6 +2,8 @@
 
 @use '../variables' as var;
 
+@use '../../shared/components/buttons' as shared-buttons;
+
 @use '../mixins/buttons';
 @use '../mixins/layout';
 @use '../mixins/utils';
@@ -75,7 +77,7 @@
 
   /** Visible with clean theme */
   .Toolbar__sidebar-close {
-    @include buttons.reset-native-btn-styles;
+    @include shared-buttons.reset;
     @include buttons.button-hover;
     @include utils.border;
     border-right-width: 0;

--- a/src/styles/shared/_index.scss
+++ b/src/styles/shared/_index.scss
@@ -1,1 +1,1 @@
-@use './components/buttons';
+@use './components/buttons/styles';

--- a/src/styles/shared/components/buttons/_base.scss
+++ b/src/styles/shared/components/buttons/_base.scss
@@ -1,7 +1,5 @@
 @use "sass:map";
 
-@use "@hypothesis/frontend-shared/styles/mixins/focus";
-
 // Set colors for a button
 @mixin _colors($colormap) {
   color: map.get($colormap, 'foreground');
@@ -53,13 +51,6 @@
 
 // Base mixin for buttons.
 @mixin button($options) {
-  // Reset browser defaults
-  @include focus.outline-on-keyboard-focus;
-  padding: 0;
-  margin: 0;
-  background-color: transparent;
-  border-style: none;
-
   @include _colors(map.get($options, 'colormap'));
 
   @if map.get($options, 'withStates') {

--- a/src/styles/shared/components/buttons/_config.scss
+++ b/src/styles/shared/components/buttons/_config.scss
@@ -108,3 +108,42 @@ $LinkButton-colors--dark: (
   'active-foreground': $color-g7,
   'disabled-foreground': $color-gmid,
 );
+
+$-IconButton: (
+  'normal': $IconButton-colors,
+  'primary': $IconButton-colors--primary,
+  'dark': $IconButton-colors--dark,
+  'light': $IconButton-colors--light,
+);
+
+$-LabeledButton: (
+  'normal': $LabeledButton-colors,
+  'primary': $LabeledButton-colors--primary,
+  'dark': $LabeledButton-colors--dark,
+  'light': $LabeledButton-colors--light,
+);
+
+$-LinkButton: (
+  'normal': $LinkButton-colors,
+  'primary': $LinkButton-colors--primary,
+  'dark': $LinkButton-colors--dark,
+  'light': $LinkButton-colors--light,
+);
+
+// Return a color map corresponding to a button component-variant combination
+// Defaults to `LabeledButton--normal`
+@function colors-for($button-type: 'LabeledButton', $variant: 'normal') {
+  $colors: map.get($-LabeledButton, 'normal');
+
+  @if $button-type == 'IconButton' {
+    $colors: map.get($-IconButton, $variant);
+  }
+  @if $button-type == 'LabeledButton' {
+    $colors: map.get($-LabeledButton, $variant);
+  }
+  @if $button-type == 'LinkButton' {
+    $colors: map.get($-LinkButton, $variant);
+  }
+
+  @return $colors;
+}

--- a/src/styles/shared/components/buttons/_index.scss
+++ b/src/styles/shared/components/buttons/_index.scss
@@ -1,2 +1,2 @@
-@forward 'config';
-@forward 'mixins';
+@forward 'config' show colors-for;
+@forward 'mixins' show reset, Button, IconButton, LabeledButton, LinkButton;

--- a/src/styles/shared/components/buttons/_index.scss
+++ b/src/styles/shared/components/buttons/_index.scss
@@ -1,16 +1,2 @@
-@use './mixins';
-
-// A button with text, and optionally an icon
-.LabeledButton {
-  @include mixins.LabeledButton;
-}
-
-// A button with only an icon and no label/text
-.IconButton {
-  @include mixins.IconButton;
-}
-
-// A button styled to appear as a link, with underline on hover
-.LinkButton {
-  @include mixins.LinkButton;
-}
+@forward 'config';
+@forward 'mixins';

--- a/src/styles/shared/components/buttons/_mixins.scss
+++ b/src/styles/shared/components/buttons/_mixins.scss
@@ -2,11 +2,17 @@
 
 @use "@hypothesis/frontend-shared/styles/mixins/focus";
 
-@use './_config' as c;
-@use './_base' as base;
+@use 'config' as c;
+@use 'base';
 
-// Allow access to the configuration values to users of this module (esp. colors)
-@forward './_config';
+// Basic reset for browser-imposed button styles
+@mixin reset {
+  @include focus.outline-on-keyboard-focus;
+  padding: 0;
+  margin: 0;
+  background-color: transparent;
+  border-style: none;
+}
 
 // Base mixin for <button> elements
 @mixin Button($options: ()) {
@@ -33,6 +39,7 @@
   );
   $-options: map.merge($defaultOptions, $options);
 
+  @include reset;
   @include base.button($options: $-options);
 
   // Add styles for supported variants as modifier classes, if `withVariants` enabled

--- a/src/styles/shared/components/buttons/_styles.scss
+++ b/src/styles/shared/components/buttons/_styles.scss
@@ -1,0 +1,16 @@
+@use 'mixins';
+
+// A button with text, and optionally an icon
+.LabeledButton {
+  @include mixins.LabeledButton;
+}
+
+// A button with only an icon and no label/text
+.IconButton {
+  @include mixins.IconButton;
+}
+
+// A button styled to appear as a link, with underline on hover
+.LinkButton {
+  @include mixins.LinkButton;
+}

--- a/src/styles/sidebar/buttons.scss
+++ b/src/styles/sidebar/buttons.scss
@@ -2,7 +2,7 @@
 
 @use '../variables' as var;
 // Button styling for the sidebar extending common button-component styles
-@use '../shared/components/buttons/mixins' as buttons;
+@use '../shared/components/buttons';
 
 // Similar to `.LinkButton`, with inline layout (so button can be used
 // within text)

--- a/src/styles/sidebar/buttons.scss
+++ b/src/styles/sidebar/buttons.scss
@@ -51,7 +51,7 @@
 // both the input and the buttons. At some point this pattern should be
 // consolidated.
 $input-button-colors: map.merge(
-  buttons.$IconButton-colors,
+  buttons.colors-for('IconButton'),
   (
     'background': var.$grey-1,
     'hover-background': var.$grey-2,

--- a/src/styles/sidebar/components/SelectionTabs.scss
+++ b/src/styles/sidebar/components/SelectionTabs.scss
@@ -1,6 +1,5 @@
-@use "@hypothesis/frontend-shared/styles/mixins/focus";
+@use "../../shared/components/buttons";
 
-@use "../../mixins/buttons";
 @use "../../mixins/layout";
 @use "../../mixins/utils";
 @use "../../variables" as var;
@@ -26,8 +25,7 @@
 }
 
 .SelectionTabs__type {
-  @include buttons.reset-native-btn-styles;
-  @include focus.outline-on-keyboard-focus;
+  @include buttons.reset;
 
   color: var.$color-text;
   cursor: pointer;


### PR DESCRIPTION
A bunch of component styles around the app use the (old) `reset-native-btn-styles` mixin. Update these components to use the mixin in the shared styles. Do a little module-naming housekeeping for clarity.