### PR TITLE
Show clearer error if opening login popup window fails

### DIFF
--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -255,10 +255,16 @@ export default class OAuthClient {
       })
       .replace(/&/g, ',');
 
-    return /** @type {Window} */ ($window.open(
+    const authWindow = $window.open(
       'about:blank',
       'Log in to Hypothesis',
       authWindowSettings
-    ));
+    );
+
+    if (!authWindow) {
+      throw new Error('Failed to open login window');
+    }
+
+    return authWindow;
   }
 }

--- a/src/sidebar/util/test/oauth-client-test.js
+++ b/src/sidebar/util/test/oauth-client-test.js
@@ -183,7 +183,7 @@ describe('sidebar/util/oauth-client', () => {
     });
   });
 
-  describe('.openAuthPopupWindow', () => {
+  describe('#openAuthPopupWindow', () => {
     it('opens a popup window', () => {
       const fakeWindow = new FakeWindow();
       const popupWindow = OAuthClient.openAuthPopupWindow(fakeWindow);
@@ -194,6 +194,15 @@ describe('sidebar/util/oauth-client', () => {
         'Log in to Hypothesis',
         'height=430,left=274.5,top=169,width=475'
       );
+    });
+
+    it('throws error if popup cannot be opened', () => {
+      const fakeWindow = new FakeWindow();
+      fakeWindow.open = sinon.stub().returns(null);
+
+      assert.throws(() => {
+        OAuthClient.openAuthPopupWindow(fakeWindow);
+      }, 'Failed to open login window');
     });
   });
 


### PR DESCRIPTION
If opening the login popup window using `window.open` fails or succeeds but fails to return a `Window` reference to the caller (i.e. returns `null`) then show a more helpful error message.

There are various rare scenarios (browser bugs, browser extensions) which might cause this to happen. We have to use a popup window for the login so we're limited in what we can do to mitigate the problem, but at least we can show a better error message.

For context, we're trying to track down an issue that a new Hypothesis team member is encountering in Firefox: https://hypothes-is.slack.com/archives/C2BLQDKHA/p1617899428389800 (_Edit: The problem fixed itself for reasons unknown, but hey, we might as well continue to improve the error handling here_)