### PR TITLE
Replace window confirm with dialog with custom implementation

### DIFF
--- a/src/shared/components/ConfirmDialog.js
+++ b/src/shared/components/ConfirmDialog.js
@@ -1,0 +1,39 @@
+import Dialog from './Dialog';
+
+import { LabeledButton } from './buttons';
+
+/**
+ * @typedef ConfirmDialogProps
+ * @prop {string} title - Title of the dialog
+ * @prop {string} message - Main text of the message
+ * @prop {string} confirmAction - Label for the "Confirm" button
+ * @prop {() => any} onConfirm - Callback invoked if the user clicks the "Confirm" button
+ * @prop {() => any} onCancel - Callback invoked if the user cancels
+ */
+
+/**
+ * A prompt asking the user to confirm an action.
+ *
+ * @param {ConfirmDialogProps} props
+ */
+export default function ConfirmDialog({
+  title,
+  message,
+  confirmAction,
+  onConfirm,
+  onCancel,
+}) {
+  return (
+    <Dialog
+      title={title}
+      onCancel={onCancel}
+      buttons={[
+        <LabeledButton key="ok" onClick={onConfirm} variant="primary">
+          {confirmAction}
+        </LabeledButton>,
+      ]}
+    >
+      <p>{message}</p>
+    </Dialog>
+  );
+}

--- a/src/shared/components/Dialog.js
+++ b/src/shared/components/Dialog.js
@@ -8,6 +8,10 @@ import { LabeledButton } from './buttons';
 let idCounter = 0;
 
 /**
+ * Return an element ID beginning with `prefix` that is unique per component instance.
+ *
+ * This avoids different instances of a component re-using the same ID.
+ *
  * @param {string} prefix
  */
 function useUniqueId(prefix) {
@@ -28,7 +32,7 @@ function useUniqueId(prefix) {
  * @prop {Children} [buttons] -
  *   Additional `Button` elements to display at the bottom of the dialog.
  *   A "Cancel" button is added automatically if the `onCancel` prop is set.
- * @prop {string} [contentClass] - e.g. <button>
+ * @prop {string} [contentClass] - CSS class to apply to the dialog's content
  * @prop {'dialog'|'alertdialog'} [role] - The aria role for the dialog (defaults to" dialog")
  * @prop {string} title - The title of the dialog.
  * @prop {() => any} [onCancel] -
@@ -97,8 +101,8 @@ export default function Dialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // If the content of the dialog contains a paragraph of text, mark it as the
-  // dialog's accessible description.
+  // Try to assign the dialog an accessible description, using the content of
+  // the first paragraph of text in it.
   //
   // A limitation of this approach is that it doesn't update if the dialog's
   // content changes after the initial render.

--- a/src/shared/components/Dialog.js
+++ b/src/shared/components/Dialog.js
@@ -1,0 +1,152 @@
+import { useElementShouldClose } from '@hypothesis/frontend-shared';
+import { Fragment } from 'preact';
+import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
+import classNames from 'classnames';
+
+import { LabeledButton } from './buttons';
+
+let idCounter = 0;
+
+/**
+ * @param {string} prefix
+ */
+function useUniqueId(prefix) {
+  const [id] = useState(() => {
+    ++idCounter;
+    return `${prefix}-${idCounter}`;
+  });
+  return id;
+}
+
+/**
+ * @typedef {import("preact").ComponentChildren} Children
+ *
+ * @typedef DialogProps
+ * @prop {Children} children - The content of the dialog.
+ * @prop {import("preact/hooks").Ref<HTMLElement>} [initialFocus] -
+ *   Child element to focus when the dialog is rendered.
+ * @prop {Children} [buttons] -
+ *   Additional `Button` elements to display at the bottom of the dialog.
+ *   A "Cancel" button is added automatically if the `onCancel` prop is set.
+ * @prop {string} [contentClass] - e.g. <button>
+ * @prop {'dialog'|'alertdialog'} [role] - The aria role for the dialog (defaults to" dialog")
+ * @prop {string} title - The title of the dialog.
+ * @prop {() => any} [onCancel] -
+ *   A callback to invoke when the user cancels the dialog. If provided, a
+ *   "Cancel" button will be displayed.
+ * @prop {string} [cancelLabel] - Label for the cancel button
+ */
+
+/**
+ * HTML control that can be disabled.
+ *
+ * @typedef {HTMLElement & { disabled: boolean }} InputElement
+ */
+
+/**
+ * A modal dialog wrapper with a title. The wrapper sets initial focus to itself
+ * unless an element inside of it is specified with the `initialFocus` ref.
+ * Optional action buttons may be passed in with the `buttons` prop but the
+ * cancel button is automatically generated when the on `onCancel` function is
+ * passed.
+ *
+ * Canonical resources:
+ *
+ * https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html
+ * https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/alertdialog.html
+ *
+ * If the dialog's content, specified by the `children` prop, contains a paragraph
+ * (`<p>`) element, that element will be identified as the dialog's accessible
+ * description.
+ *
+ * @param {DialogProps} props
+ */
+export default function Dialog({
+  children,
+  contentClass,
+  initialFocus,
+  onCancel,
+  cancelLabel = 'Cancel',
+  role = 'dialog',
+  title,
+  buttons,
+}) {
+  const dialogTitleId = useUniqueId('dialog-title');
+  const dialogDescriptionId = useUniqueId('dialog-description');
+
+  const rootEl = useRef(/** @type {HTMLDivElement | null} */ (null));
+
+  useElementShouldClose(rootEl, true, () => {
+    if (onCancel) {
+      onCancel();
+    }
+  });
+
+  useEffect(() => {
+    const focusEl = /** @type {InputElement|undefined} */ (initialFocus?.current);
+    if (focusEl && !focusEl.disabled) {
+      focusEl.focus();
+    } else {
+      // Modern accessibility guidance is to focus the dialog itself rather than
+      // trying to be smart about focusing a particular control within the
+      // dialog. See resources above.
+      rootEl.current.focus();
+    }
+    // We only want to run this effect once when the dialog is mounted.
+    //
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // If the content of the dialog contains a paragraph of text, mark it as the
+  // dialog's accessible description.
+  //
+  // A limitation of this approach is that it doesn't update if the dialog's
+  // content changes after the initial render.
+  useLayoutEffect(() => {
+    const description = rootEl.current.querySelector('p');
+    if (description) {
+      description.id = dialogDescriptionId;
+      rootEl.current.setAttribute('aria-describedby', dialogDescriptionId);
+    }
+  }, [dialogDescriptionId]);
+
+  return (
+    <Fragment>
+      <div className="Dialog__background" />
+      <div className="Dialog__container">
+        <div
+          tabIndex={-1}
+          ref={rootEl}
+          role={role}
+          aria-labelledby={dialogTitleId}
+          aria-modal={true}
+          className={classNames('Dialog__content', contentClass)}
+        >
+          <h1 className="Dialog__title" id={dialogTitleId}>
+            {title}
+            <span className="u-stretch" />
+            {onCancel && (
+              <button
+                aria-label="Close"
+                className="Dialog__cancel-btn"
+                onClick={onCancel}
+              >
+                ✕
+              </button>
+            )}
+          </h1>
+          {children}
+          <div className="u-stretch" />
+          <div className="Dialog__actions">
+            {onCancel && (
+              <LabeledButton icon="cancel" onClick={onCancel}>
+                {cancelLabel}
+              </LabeledButton>
+            )}
+            {buttons}
+          </div>
+        </div>
+      </div>
+    </Fragment>
+  );
+}

--- a/src/shared/components/test/ConfirmDialog-test.js
+++ b/src/shared/components/test/ConfirmDialog-test.js
@@ -1,0 +1,39 @@
+import { mount } from 'enzyme';
+
+import mockImportedComponents from '../../../test-util/mock-imported-components';
+
+import ConfirmDialog, { $imports } from '../ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  beforeEach(() => {
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('renders dialog', () => {
+    const confirm = sinon.stub();
+    const cancel = sinon.stub();
+
+    const wrapper = mount(
+      <ConfirmDialog
+        title="Delete annotation?"
+        message="Do you want to delete this annotation?"
+        confirmAction="Do it!"
+        onConfirm={confirm}
+        onCancel={cancel}
+      />
+    );
+
+    const dialog = wrapper.find('Dialog');
+    assert.equal(dialog.prop('title'), 'Delete annotation?');
+    assert.equal(
+      dialog.children().text(),
+      'Do you want to delete this annotation?'
+    );
+    assert.equal(dialog.prop('onCancel'), cancel);
+    assert.equal(mount(dialog.prop('buttons')[0]).prop('onClick'), confirm);
+  });
+});

--- a/src/shared/components/test/Dialog-test.js
+++ b/src/shared/components/test/Dialog-test.js
@@ -1,0 +1,185 @@
+import { mount } from 'enzyme';
+import { createRef } from 'preact';
+
+import Dialog from '../Dialog';
+import { checkAccessibility } from '../../../test-util/accessibility';
+
+describe('Dialog', () => {
+  it('renders content', () => {
+    const wrapper = mount(
+      <Dialog>
+        <span>content</span>
+      </Dialog>
+    );
+    assert.isTrue(wrapper.contains(<span>content</span>));
+  });
+
+  it('adds `contentClass` value to class list', () => {
+    const wrapper = mount(
+      <Dialog contentClass="foo">
+        <span>content</span>
+      </Dialog>
+    );
+    assert.isTrue(wrapper.find('.Dialog__content').hasClass('foo'));
+  });
+
+  it('renders buttons', () => {
+    const wrapper = mount(
+      <Dialog
+        buttons={[
+          <button key="foo" name="foo" />,
+          <button key="bar" name="bar" />,
+        ]}
+      />
+    );
+    assert.isTrue(wrapper.contains(<button key="foo" name="foo" />));
+    assert.isTrue(wrapper.contains(<button key="bar" name="bar" />));
+  });
+
+  it('renders the title', () => {
+    const wrapper = mount(<Dialog title="Test dialog" />);
+    const header = wrapper.find('h1');
+    assert.equal(header.text().indexOf('Test dialog'), 0);
+  });
+
+  it('closes when Escape key is pressed', () => {
+    const onCancel = sinon.stub();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    mount(<Dialog title="Test dialog" onCancel={onCancel} />, {
+      attachTo: container,
+    });
+
+    const event = new Event('keydown');
+    event.key = 'Escape';
+    document.body.dispatchEvent(event);
+    assert.called(onCancel);
+    container.remove();
+  });
+
+  it('closes when close button is clicked', () => {
+    const onCancel = sinon.stub();
+    const wrapper = mount(<Dialog title="Test dialog" onCancel={onCancel} />);
+
+    wrapper.find('.Dialog__cancel-btn').simulate('click');
+
+    assert.called(onCancel);
+  });
+
+  it(`defaults cancel button's label to "Cancel"`, () => {
+    const wrapper = mount(<Dialog onCancel={sinon.stub()} />);
+    assert.equal(wrapper.find('LabeledButton').text().trim(), 'Cancel');
+  });
+
+  it('adds a custom label to the cancel button', () => {
+    const wrapper = mount(
+      <Dialog onCancel={sinon.stub()} cancelLabel="hello" />
+    );
+    assert.equal(wrapper.find('LabeledButton').text().trim(), 'hello');
+  });
+
+  describe('initial focus', () => {
+    let container;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+      container.remove();
+    });
+
+    it('focuses the `initialFocus` element', () => {
+      const inputRef = createRef();
+
+      mount(
+        <Dialog initialFocus={inputRef}>
+          <input ref={inputRef} />
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(document.activeElement, inputRef.current);
+    });
+
+    it('focuses the dialog if `initialFocus` prop is missing', () => {
+      const wrapper = mount(
+        <Dialog>
+          <div>Test</div>
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(
+        document.activeElement,
+        wrapper.find('[role="dialog"]').getDOMNode()
+      );
+    });
+
+    it('focuses the dialog if `initialFocus` ref is `null`', () => {
+      const wrapper = mount(
+        <Dialog initialFocus={{ current: null }}>
+          <div>Test</div>
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(
+        document.activeElement,
+        wrapper.find('[role="dialog"]').getDOMNode()
+      );
+    });
+
+    it('focuses the dialog if `initialFocus` element is disabled', () => {
+      const inputRef = createRef();
+
+      const wrapper = mount(
+        <Dialog initialFocus={inputRef}>
+          <button ref={inputRef} disabled={true} />
+        </Dialog>,
+        { attachTo: container }
+      );
+
+      assert.equal(
+        document.activeElement,
+        wrapper.find('[role="dialog"]').getDOMNode()
+      );
+    });
+  });
+
+  it("marks the first `<p>` in the dialog's content as the accessible description", () => {
+    const wrapper = mount(
+      <Dialog>
+        <p>Enter a URL</p>
+      </Dialog>
+    );
+    const content = wrapper.find('[role="dialog"]').getDOMNode();
+    const paragraphEl = wrapper.find('p').getDOMNode();
+
+    assert.ok(content.getAttribute('aria-describedby'));
+    assert.equal(content.getAttribute('aria-describedby'), paragraphEl.id);
+  });
+
+  it("does not set an accessible description if the dialog's content does not have a `<p>`", () => {
+    const wrapper = mount(
+      <Dialog>
+        <button>Click me</button>
+      </Dialog>
+    );
+    const content = wrapper.find('[role="dialog"]').getDOMNode();
+    assert.isNull(content.getAttribute('aria-describedby'));
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      // eslint-disable-next-line react/display-name
+      content: () => (
+        <Dialog title="Test dialog">
+          <div>test</div>
+        </Dialog>
+      ),
+    })
+  );
+});

--- a/src/shared/prompts.js
+++ b/src/shared/prompts.js
@@ -35,6 +35,12 @@ export async function confirm({
 
   const container = document.createElement('div');
   container.setAttribute('data-testid', 'confirm-container');
+
+  // Ensure dialog appears above any existing content. The Z-index value here
+  // is Good Enough™ for current usage.
+  container.style.position = 'relative';
+  container.style.zIndex = '10';
+
   document.body.appendChild(container);
 
   return new Promise(resolve => {

--- a/src/shared/prompts.js
+++ b/src/shared/prompts.js
@@ -1,0 +1,59 @@
+import { render } from 'preact';
+
+import ConfirmDialog from './components/ConfirmDialog';
+
+/**
+ * Show the user a prompt asking them to confirm an action.
+ *
+ * This is like an async version of `window.confirm` except that:
+ *
+ *  - It can be used inside iframes (browsers are starting to prevent this
+ *    for the native `window.confirm` dialog)
+ *  - The visual style of the dialog matches the Hypothesis design system
+ *
+ * @param {object} options - Options for the `ConfirmDialog`
+ *   @prop {string} [title]
+ *   @prop {string} message
+ *   @prop {string} [confirmAction]
+ * @return {Promise<boolean>} - Promise that resolves with `true` if the user
+ *   confirmed the action or `false` if they canceled it.
+ */
+export async function confirm({
+  title = 'Confirm',
+  message,
+  confirmAction = 'Yes',
+}) {
+  const start = Date.now();
+
+  // Use the legacy `window.confirm` API where available until we've polished
+  // the new one. In Chrome >= 91 `window.confirm` will immediately return false
+  // so we have no option but to use the new implementation.
+  const result = window.confirm(message);
+  if (result || Date.now() - start >= 10) {
+    return result;
+  }
+
+  const container = document.createElement('div');
+  container.setAttribute('data-testid', 'confirm-container');
+  document.body.appendChild(container);
+
+  return new Promise(resolve => {
+    /** @param {boolean} result */
+    const close = result => {
+      render(null, container);
+      container.remove();
+      resolve(result);
+    };
+
+    render(
+      <ConfirmDialog
+        title={title}
+        message={message}
+        confirmAction={confirmAction}
+        onConfirm={() => close(true)}
+        onCancel={() => close(false)}
+      />,
+      container
+    );
+  });
+}

--- a/src/shared/test/prompts-test.js
+++ b/src/shared/test/prompts-test.js
@@ -1,0 +1,96 @@
+import { confirm, $imports } from '../prompts';
+
+function FakeConfirmDialog({
+  confirmAction,
+  message,
+  onCancel,
+  onConfirm,
+  title,
+}) {
+  return (
+    <div>
+      <h1>{title}</h1>
+      <p>{message}</p>
+      <button data-testid="confirm" onClick={onConfirm}>
+        {confirmAction}
+      </button>
+      <button data-testid="cancel" onClick={onCancel}>
+        Cancel
+      </button>
+    </div>
+  );
+}
+
+describe('shared/prompts', () => {
+  describe('confirm', () => {
+    beforeEach(() => {
+      sinon.stub(window, 'confirm').returns(false);
+
+      $imports.$mock({
+        './components/ConfirmDialog': FakeConfirmDialog,
+      });
+    });
+
+    afterEach(() => {
+      window.confirm.restore();
+    });
+
+    function getCustomDialog() {
+      return document.querySelector('[data-testid="confirm-container"]');
+    }
+
+    function clickConfirm() {
+      const confirmButton = getCustomDialog().querySelector(
+        '[data-testid="confirm"]'
+      );
+      confirmButton.click();
+    }
+
+    function clickCancel() {
+      const cancelButton = getCustomDialog().querySelector(
+        '[data-testid="cancel"]'
+      );
+      cancelButton.click();
+    }
+
+    it('uses `window.confirm` if available', async () => {
+      window.confirm.returns(true);
+      const result = await confirm({ message: 'Do the thing?' });
+      assert.equal(result, true);
+    });
+
+    it('renders a custom dialog if `window.confirm` is not available', async () => {
+      const result = confirm({
+        title: 'Confirm action?',
+        message: 'Do the thing?',
+        confirmAction: 'Yeah!',
+      });
+      const dialog = getCustomDialog();
+
+      assert.ok(dialog);
+      assert.equal(dialog.querySelector('h1').textContent, 'Confirm action?');
+      assert.equal(dialog.querySelector('p').textContent, 'Do the thing?');
+      assert.equal(
+        dialog.querySelector('[data-testid=confirm]').textContent,
+        'Yeah!'
+      );
+
+      clickConfirm();
+      await result;
+
+      assert.notOk(getCustomDialog());
+    });
+
+    it('returns true if "Confirm" button is clicked', async () => {
+      const result = confirm({ message: 'Do the thing?' });
+      clickConfirm();
+      assert.isTrue(await result);
+    });
+
+    it('returns false if "Cancel" button is clicked', async () => {
+      const result = confirm({ message: 'Do the thing?' });
+      clickCancel();
+      assert.isFalse(await result);
+    });
+  });
+});

--- a/src/sidebar/components/Annotation/AnnotationActionBar.js
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.js
@@ -7,6 +7,7 @@ import { isPrivate, permits } from '../../helpers/permissions';
 import { withServices } from '../../service-context';
 
 import { IconButton } from '../../../shared/components/buttons';
+import { confirm } from '../../../shared/prompts';
 
 import AnnotationShareControl from './AnnotationShareControl';
 
@@ -57,11 +58,19 @@ function AnnotationActionBar({
   const shareLink =
     sharingEnabled(settings) && annotationSharingLink(annotation);
 
-  const onDelete = () => {
-    if (window.confirm('Are you sure you want to delete this annotation?')) {
-      annotationsService.delete(annotation).catch(err => {
+  const onDelete = async () => {
+    if (
+      await confirm({
+        title: 'Delete annotation?',
+        message: 'Are you sure you want to delete this annotation?',
+        confirmAction: 'Delete',
+      })
+    ) {
+      try {
+        await annotationsService.delete(annotation);
+      } catch (err) {
         toastMessenger.error(err.message);
-      });
+      }
     }
   };
 

--- a/src/sidebar/components/GroupList/GroupListItem.js
+++ b/src/sidebar/components/GroupList/GroupListItem.js
@@ -2,6 +2,7 @@ import { orgName } from '../../helpers/group-list-item-common';
 import { withServices } from '../../service-context';
 import { useStoreProxy } from '../../store/use-store';
 import { copyText } from '../../util/copy-to-clipboard';
+import { confirm } from '../../../shared/prompts';
 
 import MenuItem from '../MenuItem';
 
@@ -49,9 +50,15 @@ function GroupListItem({
     groupsService.focus(group.id);
   };
 
-  const leaveGroup = () => {
+  const leaveGroup = async () => {
     const message = `Are you sure you want to leave the group "${group.name}"?`;
-    if (window.confirm(message)) {
+    if (
+      await confirm({
+        title: 'Leave group?',
+        message,
+        confirmAction: 'Leave',
+      })
+    ) {
       groupsService.leave(group.id);
     }
   };

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -2,6 +2,7 @@ import classnames from 'classnames';
 import { useEffect, useMemo } from 'preact/hooks';
 
 import bridgeEvents from '../../shared/bridge-events';
+import { confirm } from '../../shared/prompts';
 import serviceConfig from '../config/service-config';
 import { useStoreProxy } from '../store/use-store';
 import { parseAccountID } from '../helpers/account-id';
@@ -129,26 +130,33 @@ function HypothesisApp({
     window.open(serviceUrl('signup'));
   };
 
-  const promptToLogout = () => {
-    // TODO - Replace this with a UI which doesn't look terrible.
-    let text = '';
+  const promptToLogout = async () => {
     const drafts = store.countDrafts();
+    if (drafts === 0) {
+      return true;
+    }
+
+    let message = '';
     if (drafts === 1) {
-      text =
+      message =
         'You have an unsaved annotation.\n' +
         'Do you really want to discard this draft?';
     } else if (drafts > 1) {
-      text =
+      message =
         'You have ' +
         drafts +
         ' unsaved annotations.\n' +
         'Do you really want to discard these drafts?';
     }
-    return drafts === 0 || window.confirm(text);
+    return confirm({
+      title: 'Discard drafts?',
+      message,
+      confirmAction: 'Discard',
+    });
   };
 
-  const logout = () => {
-    if (!promptToLogout()) {
+  const logout = async () => {
+    if (!(await promptToLogout())) {
       return;
     }
     store.clearGroups();

--- a/src/styles/shared/_index.scss
+++ b/src/styles/shared/_index.scss
@@ -1,1 +1,2 @@
 @use './components/buttons/styles';
+@use './components/Dialog';

--- a/src/styles/shared/components/_Dialog.scss
+++ b/src/styles/shared/components/_Dialog.scss
@@ -1,0 +1,74 @@
+@use "@hypothesis/frontend-shared/styles/mixins/focus";
+
+@use "../variables" as var;
+
+$title-font-size: 19px;
+
+.Dialog__container {
+  display: flex;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.Dialog__background {
+  background-color: black;
+  bottom: 0;
+  left: 0;
+  opacity: 0.5;
+  position: fixed;
+  right: 0;
+  top: 0;
+}
+
+.Dialog__content {
+  @include focus.outline-on-keyboard-focus;
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+  max-width: 700px; // default for older browsers
+  max-width: min(700px, 90vw);
+  background-color: white;
+  border-radius: 3px;
+  margin: auto;
+  padding: 20px;
+}
+
+.Dialog__title {
+  display: flex;
+  align-items: center;
+  font-size: $title-font-size;
+}
+
+.Dialog__cancel-btn {
+  @include focus.outline-on-keyboard-focus;
+  border: 0;
+  background: none;
+  color: var.$color-grey-6;
+
+  // Given the button a large hit target and ensure the 'X' label is large
+  // enough to see easily and aligned with the right edge of the dialog.
+  // Add negative margins so that the button does not force the dialog to
+  // grow in height.
+  font-size: $title-font-size;
+  padding: 5px;
+  margin: -10px 0px;
+
+  &:hover {
+    cursor: pointer;
+    color: var.$color-brand;
+  }
+}
+
+.Dialog__actions {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  margin-top: 10px;
+
+  & > *:not(:first-child) {
+    margin-left: 5px;
+  }
+}


### PR DESCRIPTION
This is a spike of a proposed solution for https://github.com/hypothesis/client/issues/3254. It replaces the native `window.confirm` dialog with a custom one which is based on the `Dialog` component that was originally developed for the LMS app.

The confirm prompt has two APIs:

 - A Preact component (`ConfirmDialog`) which can be used like any other component. The caller is responsible for managing its visibility
 - A convenience `confirm({ title, message, confirmAction })` function which is like an async version of `window.confirm` and can be used in contexts where it would be inconvenient to manage the visibility of the `ConfirmDialog` manually. I have used this second API here to replace the existing `window.confirm` calls.

Changes in the code:

 - Import `Dialog` component and tests from the LMS app, adjusted to avoid some LMS frontend dependencies
 - Add `ConfirmDialog` component and `confirm` utility in `src/shared/prompts`
 - Convert the three existing uses of `window.confirm` in the sidebar to use the new `confirm` utility
 
----

<img width="475" alt="delete-annotation-prompt" src="https://user-images.githubusercontent.com/2458/114175038-6e6cbf80-9931-11eb-83b1-45842dca33f4.png">

<img width="474" alt="discard-drafts-prompt" src="https://user-images.githubusercontent.com/2458/114175047-7167b000-9931-11eb-88c8-e382e455af62.png">

<img width="481" alt="leave-group-prompt" src="https://user-images.githubusercontent.com/2458/114175051-7462a080-9931-11eb-8901-8c4c8e71817f.png">
