### PR TITLE
Sync annotations in the notebook

### DIFF
--- a/src/sidebar/components/AnnotationView.js
+++ b/src/sidebar/components/AnnotationView.js
@@ -10,7 +10,7 @@ import SidebarContentError from './SidebarContentError';
 /**
  * @typedef AnnotationViewProps
  * @prop {() => any} onLogin
- * @prop {Object} [loadAnnotationsService] - Injected service
+ * @prop {ReturnType<import('../services/load-annotations').default>} loadAnnotationsService - Injected service
  */
 
 /**

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -15,8 +15,8 @@ import PaginatedThreadList from './PaginatedThreadList';
 
 /**
  * @typedef NotebookViewProps
- * @prop {Object} [loadAnnotationsService] - Injected service
- * @prop {Object} [streamer] - Injected service
+ * @prop {ReturnType<import('../services/load-annotations').default>} loadAnnotationsService - Injected service
+ * @prop {import('../services/streamer').default} streamer - Injected service
  */
 
 /**
@@ -69,7 +69,7 @@ function NotebookView({ loadAnnotationsService, streamer }) {
 
   // Establish websocket connection
   useEffect(() => {
-    if (streamer && hasFetchedProfile) {
+    if (hasFetchedProfile) {
       streamer.connect({ applyUpdatesImmediately: false });
     }
   }, [hasFetchedProfile, streamer]);

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -8,10 +8,9 @@ import { useStoreProxy } from '../store/use-store';
 
 import NotebookFilters from './NotebookFilters';
 import NotebookResultCount from './NotebookResultCount';
-import useRootThread from './hooks/use-root-thread';
-
 import Panel from './Panel';
 import PaginatedThreadList from './PaginatedThreadList';
+import useRootThread from './hooks/use-root-thread';
 
 /**
  * @typedef NotebookViewProps

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -16,9 +16,9 @@ import ThreadList from './ThreadList';
  * @typedef SidebarViewProps
  * @prop {() => any} onLogin
  * @prop {() => any} onSignUp
- * @prop {Object} [frameSync] - Injected service
- * @prop {Object} [loadAnnotationsService]  - Injected service
- * @prop {Object} [streamer] - Injected service
+ * @prop {import('../services/frame-sync').default} frameSync - Injected service
+ * @prop {ReturnType<import('../services/load-annotations').default>} loadAnnotationsService  - Injected service
+ * @prop {import('../services/streamer').default} streamer - Injected service
  */
 
 /**

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -131,7 +131,7 @@ function SidebarView({
   const hasFetchedProfile = store.hasFetchedProfile();
   useEffect(() => {
     if (hasFetchedProfile && (sidebarHasOpened || isLoggedIn)) {
-      streamer.connect();
+      streamer.connect({ applyUpdatesImmediately: false });
     }
   }, [hasFetchedProfile, isLoggedIn, sidebarHasOpened, streamer]);
 

--- a/src/sidebar/components/StreamView.js
+++ b/src/sidebar/components/StreamView.js
@@ -9,8 +9,8 @@ import ThreadList from './ThreadList';
 
 /**
  * @typedef StreamViewProps
- * @prop {Object} [api] - Injected service
- * @prop {Object} [toastMessenger] - Injected service
+ * @prop {ReturnType<import('../services/api').default>} api - Injected service
+ * @prop {ReturnType<import('../services/toast-messenger').default>} toastMessenger - Injected service
  */
 
 /**

--- a/src/sidebar/components/test/NotebookView-test.js
+++ b/src/sidebar/components/test/NotebookView-test.js
@@ -13,6 +13,7 @@ describe('NotebookView', () => {
   let fakeUseRootThread;
   let fakeScrollIntoView;
   let fakeStore;
+  let fakeStreamer;
 
   beforeEach(() => {
     fakeLoadAnnotationsService = {
@@ -32,6 +33,13 @@ describe('NotebookView', () => {
       isLoading: sinon.stub().returns(false),
       annotationResultCount: sinon.stub().returns(0),
       setSortKey: sinon.stub(),
+      pendingUpdateCount: sinon.stub().returns(0),
+      hasFetchedProfile: sinon.stub().returns(true),
+    };
+
+    fakeStreamer = {
+      connect: sinon.stub(),
+      applyPendingUpdates: sinon.stub(),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -48,7 +56,10 @@ describe('NotebookView', () => {
 
   function createComponent() {
     return mount(
-      <NotebookView loadAnnotationsService={fakeLoadAnnotationsService} />
+      <NotebookView
+        loadAnnotationsService={fakeLoadAnnotationsService}
+        streamer={fakeStreamer}
+      />
     );
   }
 
@@ -132,6 +143,38 @@ describe('NotebookView', () => {
   it('renders filters', () => {
     const wrapper = createComponent();
     assert.isTrue(wrapper.find('NotebookFilters').exists());
+  });
+
+  describe('synchronization of annotations', () => {
+    beforeEach(() => {
+      fakeStore.focusedGroup.returns({ id: 'hallothere', name: 'Hallo' });
+      fakeStore.pendingUpdateCount.returns(3);
+    });
+
+    it("doesn't display button to synchronize annotations if filters are applied", () => {
+      fakeStore.hasAppliedFilter.returns(true);
+      const wrapper = createComponent();
+
+      const button = wrapper.find('IconButton[icon="refresh"]');
+      assert.isFalse(button.exists());
+    });
+
+    it('shows button to synchronize annotations if no filters are applied', () => {
+      const wrapper = createComponent();
+
+      const button = wrapper.find('IconButton[icon="refresh"]');
+      assert.isTrue(button.exists());
+      assert.include(button.prop('title'), 'Show 3 new or updated annotations');
+    });
+
+    it('synchronizes pending annotations', () => {
+      const wrapper = createComponent();
+
+      const button = wrapper.find('IconButton[icon="refresh"]');
+      assert.isTrue(button.exists());
+      button.prop('onClick')();
+      assert.called(fakeStreamer.applyPendingUpdates);
+    });
   });
 
   describe('pagination', () => {

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -56,9 +56,9 @@ function stripInternalProperties(obj) {
  * Function which makes an API request.
  *
  * @callback APICallFunction
- * @param {any} [params] - A map of URL and query string parameters to include with the request.
- * @param {any} [data] - The body of the request.
- * @param {APICallOptions} options
+ * @param {Record<string, any>} params - A map of URL and query string parameters to include with the request.
+ * @param {Object} [data] - The body of the request.
+ * @param {APICallOptions} [options]
  * @return {Promise<any|APIResponse>}
  */
 

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -162,7 +162,7 @@ export default function groups(
     });
   }
 
-  /*
+  /**
    * Fetch a specific group.
    *
    * @param {string} id

--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -29,6 +29,12 @@ import { SearchClient } from '../search-client';
 
 import { isReply } from '../helpers/annotation-metadata';
 
+/**
+ * @param {ReturnType<import('./api').default>} api
+ * @param {import('../store').SidebarStore} store
+ * @param {import('./streamer').default} streamer
+ * @param {import('./stream-filter').default} streamFilter
+ */
 // @inject
 export default function loadAnnotationsService(
   api,
@@ -83,7 +89,7 @@ export default function loadAnnotationsService(
 
     const searchOptions = {
       incremental: true,
-      maxResults: maxResults ?? null,
+      maxResults,
       separateReplies: false,
 
       // Annotations are fetched in order of creation by default. This is expected
@@ -97,8 +103,8 @@ export default function loadAnnotationsService(
       //
       // If the backend would allow us to sort on document location, we could do even better.
 
-      sortBy: /** @type {SortBy} */ (sortBy ?? 'created'),
-      sortOrder: /** @type {SortOrder} */ (sortOrder ?? 'asc'),
+      sortBy,
+      sortOrder,
     };
 
     searchClient = new SearchClient(api.search, searchOptions);

--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -89,8 +89,8 @@ export default function loadAnnotationsService(
 
     const searchOptions = {
       incremental: true,
-      maxResults,
       separateReplies: false,
+      maxResults,
 
       // Annotations are fetched in order of creation by default. This is expected
       // to roughly correspond to the order in which threads end up being sorted

--- a/src/sidebar/services/stream-filter.js
+++ b/src/sidebar/services/stream-filter.js
@@ -1,15 +1,11 @@
 /**
- * @typedef {'equals'|'one_of'} Operator
- */
-
-/**
  * Filter clause against which annotation updates are tested before being
  * sent to the client.
  *
  * @typedef FilterClause
- * @prop {string} field
- * @prop {Operator} operator
- * @prop {any} value
+ * @prop {'/group'|'/id'|'/references'|'/uri'} field
+ * @prop {'equals'|'one_of'} operator
+ * @prop {string|string[]} value
  * @prop {boolean} case_sensitive - TODO: Backend doesn't use this at present,
  *   but it seems important for certain fields (eg. ID).
  */
@@ -56,10 +52,10 @@ export default class StreamFilter {
   /**
    * Add a matching clause to the configuration.
    *
-   * @param {string} field - Field to filter by
-   * @param {Operator} operator - How to filter
-   * @param {any} value - Value to match
-   * @param {boolean} caseSensitive - Whether matching should be case sensitive
+   * @param {FilterClause['field']} field - Field to filter by
+   * @param {FilterClause['operator']} operator - How to filter
+   * @param {FilterClause['value']} value - Value to match
+   * @param {FilterClause['case_sensitive']} caseSensitive - Whether matching should be case sensitive
    */
   addClause(field, operator, value, caseSensitive = false) {
     this.filter.clauses.push({

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -9,6 +9,12 @@ import { watch } from '../util/watch';
  * Open a new WebSocket connection to the Hypothesis push notification service.
  * Only one websocket connection may exist at a time, any existing socket is
  * closed.
+ *
+ * @param {import('../store').SidebarStore} store
+ * @param {ReturnType<import('./oauth-auth').default>} auth
+ * @param {ReturnType<import('./groups').default>} groups
+ * @param {ReturnType<import('./session').default>} session
+ * @param {Record<string, any>} settings
  */
 // @inject
 export default function Streamer(store, auth, groups, session, settings) {

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -18,6 +18,9 @@ export default function Streamer(store, auth, groups, session, settings) {
   // The socket instance for this Streamer instance
   let socket;
 
+  // Flag that controls when to apply pending updates
+  let updateImmediately = true;
+
   // Client configuration messages, to be sent each time a new connection is
   // established.
   const configMessages = {};
@@ -37,7 +40,7 @@ export default function Streamer(store, auth, groups, session, settings) {
         break;
     }
 
-    if (store.route() !== 'sidebar') {
+    if (updateImmediately) {
       applyPendingUpdates();
     }
   }
@@ -186,10 +189,14 @@ export default function Streamer(store, auth, groups, session, settings) {
    *
    * If the service has already connected this does nothing.
    *
-   * @return {Promise} Promise which resolves once the WebSocket connection
-   *                   process has started.
+   * @param {Object} [options]
+   * @param {boolean} [options.applyUpdatesImmediately] - true if pending updates should be applied immediately
+   *
+   * @return {Promise<void>} Promise which resolves once the WebSocket connection
+   *    process has started.
    */
-  function connect() {
+  function connect(options = {}) {
+    updateImmediately = options.applyUpdatesImmediately ?? true;
     setUpAutoReconnect();
     if (socket) {
       return Promise.resolve();

--- a/src/sidebar/services/test/load-annotations-test.js
+++ b/src/sidebar/services/test/load-annotations-test.js
@@ -7,7 +7,13 @@ let longRunningSearchClient = false;
 class FakeSearchClient extends EventEmitter {
   constructor(
     searchFn,
-    { incremental, separateReplies, sortBy = 'created', sortOrder = 'asc' }
+    {
+      incremental,
+      separateReplies,
+      sortBy = 'created',
+      sortOrder = 'asc',
+      maxResults = null,
+    }
   ) {
     super();
 
@@ -18,6 +24,7 @@ class FakeSearchClient extends EventEmitter {
     this.separateReplies = !!separateReplies;
     this.sortBy = sortBy;
     this.sortOrder = sortOrder;
+    this.maxResults = maxResults;
 
     this.get = sinon.spy(query => {
       if (!query.uri) {
@@ -257,16 +264,29 @@ describe('loadAnnotationsService', () => {
       assert.isFalse(searchClients[0].separateReplies);
     });
 
-    it('loads annotations with default sort order', () => {
+    it('search annotations with default SearchClient parameters', () => {
       const svc = createService();
 
       svc.load({ groupId: fakeGroupId, uris: fakeUris });
 
       assert.equal(searchClients[0].sortBy, 'created');
       assert.equal(searchClients[0].sortOrder, 'asc');
+      assert.equal(searchClients[0].maxResults, null);
+
+      svc.load({
+        groupId: fakeGroupId,
+        uris: fakeUris,
+        sortBy: undefined,
+        sortOrder: undefined,
+        maxResults: undefined,
+      });
+
+      assert.equal(searchClients[1].sortBy, 'created');
+      assert.equal(searchClients[1].sortOrder, 'asc');
+      assert.equal(searchClients[1].maxResults, null);
     });
 
-    it('loads annotations with custom sort order', () => {
+    it('search annotations with custom SearchClient parameters', () => {
       const svc = createService();
 
       svc.load({
@@ -274,10 +294,12 @@ describe('loadAnnotationsService', () => {
         uris: fakeUris,
         sortBy: 'updated',
         sortOrder: 'desc',
+        maxResults: 50,
       });
 
       assert.equal(searchClients[0].sortBy, 'updated');
       assert.equal(searchClients[0].sortOrder, 'desc');
+      assert.equal(searchClients[0].maxResults, 50);
     });
 
     it("cancels previously search client if it's still running", () => {

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -111,7 +111,6 @@ describe('Streamer', function () {
         }),
         receiveRealTimeUpdates: sinon.stub(),
         removeAnnotations: sinon.stub(),
-        route: sinon.stub().returns('sidebar'),
       }
     );
 
@@ -297,12 +296,11 @@ describe('Streamer', function () {
   describe('annotation notifications', function () {
     beforeEach(function () {
       createDefaultStreamer();
-      return activeStreamer.connect();
     });
 
     context('when the app is the stream', function () {
       beforeEach(function () {
-        fakeStore.route.returns('stream');
+        return activeStreamer.connect();
       });
 
       it('applies updates immediately', function () {
@@ -324,6 +322,10 @@ describe('Streamer', function () {
     });
 
     context('when the app is the sidebar', function () {
+      beforeEach(function () {
+        return activeStreamer.connect({ applyUpdatesImmediately: false });
+      });
+
       it('saves pending updates', function () {
         fakeWebSocket.notify(fixtures.createNotification);
         assert.calledWith(fakeStore.receiveRealTimeUpdates, {
@@ -347,17 +349,6 @@ describe('Streamer', function () {
         fakeWebSocket.notify(fixtures.createNotification);
 
         assert.notCalled(fakeStore.addAnnotations);
-      });
-
-      it('does not apply deletions immediately', function () {
-        const ann = fixtures.deleteNotification.payload;
-        fakeStore.pendingDeletions.returns({
-          [ann.id]: true,
-        });
-
-        fakeWebSocket.notify(fixtures.deleteNotification);
-
-        assert.notCalled(fakeStore.removeAnnotations);
       });
     });
   });

--- a/src/sidebar/services/toast-messenger.js
+++ b/src/sidebar/services/toast-messenger.js
@@ -80,7 +80,7 @@ export default function toastMessenger(store) {
    * Add an error toast message with `messageText`
    *
    * @param {string} messageText
-   * @param {MessageOptions} options
+   * @param {MessageOptions} [options]
    */
   const error = (messageText, options) => {
     addMessage('error', messageText, options);
@@ -90,7 +90,7 @@ export default function toastMessenger(store) {
    * Add a success toast message with `messageText`
    *
    * @param {string} messageText
-   * @param {MessageOptions} options
+   * @param {MessageOptions} [options]
    */
   const success = (messageText, options) => {
     addMessage('success', messageText, options);
@@ -100,7 +100,7 @@ export default function toastMessenger(store) {
    * Add a warn/notice toast message with `messageText`
    *
    * @param {string} messageText
-   * @param {MessageOptions} options
+   * @param {MessageOptions} [options]
    */
   const notice = (messageText, options) => {
     addMessage('notice', messageText, options);

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -342,7 +342,7 @@ function highlightAnnotations(ids) {
 /**
  * Remove annotations from the currently displayed set.
  *
- * @param {Annotation[]} annotations -
+ * @param {AnnotationStub[]} annotations -
  *   Annotations to remove. These may be complete annotations or stubs which
  *   only contain an `id` property.
  */

--- a/src/sidebar/store/modules/drafts.js
+++ b/src/sidebar/store/modules/drafts.js
@@ -97,7 +97,6 @@ function createDraft(annotation, changes) {
  *
  * An empty draft has no text and no reference tags.
  */
-
 function deleteNewAndEmptyDrafts() {
   const { removeAnnotations } = require('./annotations');
 

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -83,8 +83,8 @@ const actions = actionTypes(update);
  * has been notified about but has not yet applied.
  *
  * @param {Object} args
- * @param {Annotation[]} args.updatedAnnotations
- * @param {Annotation[]} args.deletedAnnotations
+ * @param {Annotation[]} [args.updatedAnnotations]
+ * @param {Annotation[]} [args.deletedAnnotations]
  */
 function receiveRealTimeUpdates({
   updatedAnnotations = [],

--- a/src/sidebar/util/url.js
+++ b/src/sidebar/util/url.js
@@ -8,8 +8,8 @@
  *     {url: '/things/foo', params: {q: 'bar'}}
  *
  * @param {string} url
- * @param {Object} params
- * @return {{ url: string, params: Object }}
+ * @param {Record<string, any>} params
+ * @return {{ url: string, params: Record<string, any>}}
  */
 export function replaceURLParams(url, params) {
   const unusedParams = {};

--- a/src/sidebar/util/watch.js
+++ b/src/sidebar/util/watch.js
@@ -38,7 +38,7 @@ import shallowEqual from 'shallowequal';
  *
  * Values are compared using strict equality (`===`).
  *
- * @param {(callback: Function) => Function} subscribe - Function used to
+ * @param {(callback: () => void) => Function} subscribe - Function used to
  *   subscribe to notifications of _potential_ changes in the watched values.
  * @param {Function|Array<Function>} watchFns - A function or array of functions
  *   which return the current watched values

--- a/src/sidebar/websocket.js
+++ b/src/sidebar/websocket.js
@@ -60,7 +60,7 @@ export default class Socket extends TinyEmitter {
         minTimeout: RECONNECT_MIN_DELAY * 2,
         // Don't retry forever -- fail permanently after 10 retries
         retries: 10,
-        // Randomize retry times to minimise the thundering herd effect
+        // Randomize retry times to minimize the thundering herd effect
         randomize: true,
       });
 
@@ -76,7 +76,7 @@ export default class Socket extends TinyEmitter {
             return;
           }
           const err = new Error(
-            'WebSocket closed abnormally, code: ' + event.code
+            `WebSocket closed abnormally, code: ${event.code}`
           );
           console.warn(err);
           onAbnormalClose(err);

--- a/src/styles/sidebar/components/NotebookResultCount.scss
+++ b/src/styles/sidebar/components/NotebookResultCount.scss
@@ -3,7 +3,6 @@
 
 .NotebookResultCount {
   @include layout.horizontal-rhythm;
-  font-size: var.$font-size--large;
   // Normalize line height to ensure vertical stability (no jumping around)
   line-height: 1;
 


### PR DESCRIPTION
This PR displays a button when there are new/deleted/updated annotations
on the selected group. Clicking on the button updates the annotation thread
with the updated annotations. Currently, the button is placed by the
thread count.
 
If there are filters applied in the notebook the button is not shown.
    
To test this change make sure you update `h` to the latest version (so
it includes https://github.com/hypothesis/h/pull/6580)