### PR TITLE
Allow `group` to be passed to the merged config

### DIFF
--- a/src/sidebar/config/fetch-config.js
+++ b/src/sidebar/config/fetch-config.js
@@ -106,7 +106,7 @@ function fetchConfigLegacy(appConfig, window_ = window) {
  * Merge client configuration from h service with config from the hash fragment.
  *
  * @param {Object} appConfig - App config settings rendered into `app.html` by the h service.
- * @param {Object} hostPageConfig - App configuration specified by the embedding  frame.
+ * @param {Object} hostPageConfig - App configuration specified by the embedding frame.
  * @return {Object} - The merged settings.
  */
 function fetchConfigEmbed(appConfig, hostPageConfig) {
@@ -212,11 +212,18 @@ export async function fetchConfig(appConfig, window_ = window) {
       requestConfigFromFrame.ancestorLevel,
       window_
     );
-    return await fetchConfigRpc(
+
+    const rpcMergedConfig = await fetchConfigRpc(
       appConfig,
       parentFrame,
       requestConfigFromFrame.origin
     );
+    // Add back the optional focused group id from the host page config
+    // as this is needed in the Notebook.
+    return {
+      ...rpcMergedConfig,
+      ...(hostPageConfig.group ? { group: hostPageConfig.group } : {}),
+    };
   } else {
     throw new Error(
       'Improper `requestConfigFromFrame` object. Both `ancestorLevel` and `origin` need to be specified'

--- a/src/sidebar/config/test/fetch-config-test.js
+++ b/src/sidebar/config/test/fetch-config-test.js
@@ -277,6 +277,27 @@ describe('sidebar/config/fetch-config', () => {
           'Unable to fetch groups'
         );
       });
+
+      it('creates a merged config and also adds back the `group` value from the host config', async () => {
+        fakeHostConfig.returns({
+          requestConfigFromFrame: {
+            origin: 'https://embedder.com',
+            ancestorLevel: 2,
+          },
+          group: '1234',
+        });
+        const appConfig = { foo: 'bar', appType: 'via' };
+        fakeJsonRpc.call.resolves({ foo: 'baz' });
+
+        const result = await fetchConfig(appConfig, fakeWindow);
+
+        assert.deepEqual(result, {
+          foo: 'baz',
+          appType: 'via',
+          group: '1234',
+          apiUrl: fakeApiUrl(),
+        });
+      });
     });
 
     context('incorrect requestConfigFromFrame object', () => {


### PR DESCRIPTION
When the host config value for `requestConfigFromFrame` is an object containing a string and a number, it is assumed that the remaining host config is be fetched from the parent frame via RPC. In this context, any other values passed along via the iframe URL hash are ignored. One such value is the `group` which is used by the notebook to focus a group and filter only to that groups annotations.

This changes the method that merges the configs to allow that `group` value to be taken from the iframe's url and incorporated into the final merged config so that the notebook can set that value in its own store.


blocks https://github.com/hypothesis/client/issues/3251