### PR TITLE
Refactor annotator/config/index.js

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -2,52 +2,218 @@ import settingsFrom from './settings';
 import { toBoolean } from '../../shared/type-coercions';
 
 /**
- * Reads the Hypothesis configuration from the environment.
- *
- * @param {Window} window_ - The Window object to read config from.
+ * @typedef ConfigDefinition
+ * @prop {boolean} allowInBrowserExt - Allow this name to be available in the browser extension
+ * @prop {any} [defaultValue] - Sets a default if `valueFn` returns undefined
+ * @prop {([configName]: string) => any} valueFn -
+ *   Method to retrieve the value from the incoming source
+ * @prop {(value: any) => any} [coerce] - Transform a value's type value or value
  */
-export default function configFrom(window_) {
-  const settings = settingsFrom(window_);
+
+/**
+ * @typedef {Record<string, ConfigDefinition>} ConfigDefinitionMap
+ */
+
+/**
+ * Total list of configuration keys.
+ */
+const configurationKeys = [
+  'annotations',
+  'assetRoot',
+  'branding',
+  'clientUrl',
+  'enableExperimentalNewNoteButton',
+  'experimental',
+  'group',
+  'focus',
+  'theme',
+  'usernameUrl',
+  'onLayoutChange',
+  'openSidebar',
+  'query',
+  'requestConfigFromFrame',
+  'services',
+  'showHighlights',
+  'notebookAppUrl',
+  'sidebarAppUrl',
+  'subFrameIdentifier',
+  'externalContainerSelector',
+];
+
+/**
+ * List of allowed configuration keys per application context. Keys omitted
+ * in a given context will be removed from the relative configs when calling
+ * getConfig.
+ */
+const configurationContexts = {
+  // For testing
+  all: [...configurationKeys],
+
+  annotator: [...configurationKeys],
+
+  sidebar: [...configurationKeys],
+
+  // Notebook must omit the `annotations` setting
+  notebook: configurationKeys.filter(
+    configProperty => configProperty !== 'annotations'
+  ),
+};
+
+/**
+ * The definition for configuration sources, their default values
+ * @return {ConfigDefinitionMap}
+ */
+function configDefinitions(settings) {
   return {
-    annotations: settings.annotations,
+    annotations: {
+      defaultValue: null,
+      allowInBrowserExt: true,
+      valueFn: () => settings.annotations,
+    },
     // URL where client assets are served from. Used when injecting the client
     // into child iframes.
-    assetRoot: settings.hostPageSetting('assetRoot', {
+    assetRoot: {
+      defaultValue: null,
       allowInBrowserExt: true,
-    }),
-    branding: settings.hostPageSetting('branding'),
+      valueFn: settings.hostPageSetting,
+    },
+    branding: {
+      defaultValue: null,
+      allowInBrowserExt: false,
+      valueFn: settings.hostPageSetting,
+    },
     // URL of the client's boot script. Used when injecting the client into
     // child iframes.
-    clientUrl: settings.clientUrl,
-    enableExperimentalNewNoteButton: settings.hostPageSetting(
-      'enableExperimentalNewNoteButton'
-    ),
-    experimental: settings.hostPageSetting('experimental', {
+    clientUrl: {
+      allowInBrowserExt: true,
+      defaultValue: null,
+      valueFn: () => settings.clientUrl,
+    },
+    enableExperimentalNewNoteButton: {
+      allowInBrowserExt: false,
+      defaultValue: null,
+      valueFn: settings.hostPageSetting,
+    },
+    experimental: {
+      allowInBrowserExt: false,
       defaultValue: {},
-    }),
-    group: settings.group,
-    focus: settings.hostPageSetting('focus'),
-    theme: settings.hostPageSetting('theme'),
-    usernameUrl: settings.hostPageSetting('usernameUrl'),
-    onLayoutChange: settings.hostPageSetting('onLayoutChange'),
-    openSidebar: settings.hostPageSetting('openSidebar', {
+      valueFn: settings.hostPageSetting,
+    },
+    group: {
       allowInBrowserExt: true,
-      // Coerce value to a boolean because it may come from via as a string
+      defaultValue: null,
+      valueFn: () => settings.group,
+    },
+    focus: {
+      allowInBrowserExt: false,
+      defaultValue: null,
+      valueFn: settings.hostPageSetting,
+    },
+    theme: {
+      allowInBrowserExt: false,
+      defaultValue: null,
+      valueFn: settings.hostPageSetting,
+    },
+    usernameUrl: {
+      allowInBrowserExt: false,
+      defaultValue: null,
+      valueFn: settings.hostPageSetting,
+    },
+    onLayoutChange: {
+      allowInBrowserExt: false,
+      defaultValue: null,
+      valueFn: settings.hostPageSetting,
+    },
+    openSidebar: {
+      allowInBrowserExt: true,
+      defaultValue: false,
       coerce: toBoolean,
-    }),
-    query: settings.query,
-    requestConfigFromFrame: settings.hostPageSetting('requestConfigFromFrame'),
-    services: settings.hostPageSetting('services'),
-    showHighlights: settings.showHighlights,
-    notebookAppUrl: settings.notebookAppUrl,
-    sidebarAppUrl: settings.sidebarAppUrl,
-    // Subframe identifier given when a frame is being embedded into
-    // by a top level client
-    subFrameIdentifier: settings.hostPageSetting('subFrameIdentifier', {
+      valueFn: settings.hostPageSetting,
+    },
+    query: {
       allowInBrowserExt: true,
-    }),
-    externalContainerSelector: settings.hostPageSetting(
-      'externalContainerSelector'
-    ),
+      defaultValue: null,
+      valueFn: () => settings.query,
+    },
+    requestConfigFromFrame: {
+      allowInBrowserExt: false,
+      defaultValue: null,
+      valueFn: settings.hostPageSetting,
+    },
+    services: {
+      allowInBrowserExt: false,
+      defaultValue: null,
+      valueFn: settings.hostPageSetting,
+    },
+    showHighlights: {
+      allowInBrowserExt: true,
+      defaultValue: null,
+      valueFn: () => settings.showHighlights,
+    },
+    notebookAppUrl: {
+      allowInBrowserExt: true,
+      defaultValue: null,
+      valueFn: () => settings.notebookAppUrl,
+    },
+    sidebarAppUrl: {
+      allowInBrowserExt: true,
+      defaultValue: null,
+      valueFn: () => settings.sidebarAppUrl,
+    },
+    // Sub-frame identifier given when a frame is being embedded into
+    // by a top level client
+    subFrameIdentifier: {
+      allowInBrowserExt: true,
+      defaultValue: null,
+      valueFn: settings.hostPageSetting,
+    },
+    externalContainerSelector: {
+      allowInBrowserExt: false,
+      defaultValue: null,
+      valueFn: settings.hostPageSetting,
+    },
   };
+}
+
+/**
+ * Return the configuration for a given application context.
+ *
+ * @param {'sidebar'|'notebook'|'annotator'|'all'} [appContext] - The name of the app.
+ */
+export default function getConfig(appContext = 'annotator', window_ = window) {
+  const config = {};
+
+  // Filter the config based on the application context as some config values
+  // may be inappropriate or erroneous for some applications.
+  let partialConfigDef = {};
+  const settings = settingsFrom(window_);
+  const configDefs = configDefinitions(settings);
+
+  // One of 'annotator', 'sidebar', or 'notebook' or 'all'
+  let filteredKeys = configurationContexts[appContext];
+  filteredKeys.forEach(key => {
+    partialConfigDef[key] = configDefs[key];
+  });
+
+  for (const [name, configDef] of Object.entries(partialConfigDef)) {
+    // If allowInBrowserExt is false and this is the browser extension context, skip value
+    if (!configDef.allowInBrowserExt && settings.isBrowserExtension) {
+      continue;
+    }
+
+    const coerceFn = configDef.coerce ? configDef.coerce : name => name; // use no-op if omitted
+    // Get the value from the configuration source and run through an optional coerce method
+    let value = coerceFn(configDef.valueFn(name));
+
+    // If a defaultValue is provided and the value is undefined, set the default
+    if (value === undefined && configDef.defaultValue !== undefined) {
+      value = configDef.defaultValue;
+    }
+
+    // Only pass the value if its not undefined
+    if (value !== undefined) {
+      config[name] = value;
+    }
+  }
+  return config;
 }

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -218,6 +218,9 @@ export default function settingsFrom(window_) {
     get query() {
       return query();
     },
-    hostPageSetting: hostPageSetting,
+
+    hostPageSetting,
+
+    isBrowserExtension: isBrowserExtension(urlFromLinkTag('sidebar')),
   };
 }

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -1,17 +1,25 @@
-import configFrom from '../index';
+import getConfig from '../index';
 import { $imports } from '../index';
 
-describe('annotator.config.index', function () {
+describe('src/annotator/config/index', function () {
   let fakeSettingsFrom;
+  let fakeHostPageSetting;
 
-  beforeEach(() => {
+  function mockFakeSettings(params) {
+    fakeHostPageSetting = sinon.stub().returns('fake_value');
     fakeSettingsFrom = sinon.stub().returns({
-      hostPageSetting: sinon.stub(),
+      hostPageSetting: fakeHostPageSetting,
+      isBrowserExtension: false,
+      ...params,
     });
 
     $imports.$mock({
       './settings': fakeSettingsFrom,
     });
+  }
+
+  beforeEach(() => {
+    mockFakeSettings();
   });
 
   afterEach(() => {
@@ -19,7 +27,7 @@ describe('annotator.config.index', function () {
   });
 
   it('gets the configuration settings', function () {
-    configFrom('WINDOW');
+    getConfig('all', 'WINDOW');
 
     assert.calledOnce(fakeSettingsFrom);
     assert.calledWithExactly(fakeSettingsFrom, 'WINDOW');
@@ -30,7 +38,7 @@ describe('annotator.config.index', function () {
       it('returns the ' + settingName + ' setting', () => {
         fakeSettingsFrom()[settingName] = 'SETTING_VALUE';
 
-        const config = configFrom('WINDOW');
+        const config = getConfig('all', 'WINDOW');
 
         assert.equal(config[settingName], 'SETTING_VALUE');
       });
@@ -46,77 +54,220 @@ describe('annotator.config.index', function () {
 
     it('throws an error', function () {
       assert.throws(function () {
-        configFrom('WINDOW');
+        getConfig('all', 'WINDOW');
       }, "there's no link");
     });
   });
 
-  ['assetRoot', 'subFrameIdentifier'].forEach(function (settingName) {
-    it(
-      'reads ' +
-        settingName +
-        ' from the host page, even when in a browser extension',
-      function () {
-        configFrom('WINDOW');
-        assert.calledWithExactly(
-          fakeSettingsFrom().hostPageSetting,
-          settingName,
-          { allowInBrowserExt: true }
-        );
-      }
-    );
+  context('embedded client detected', function () {
+    it('returns all config values', () => {
+      const config = getConfig('all', 'WINDOW');
+      assert.deepEqual(
+        [
+          'annotations',
+          'assetRoot',
+          'branding',
+          'clientUrl',
+          'enableExperimentalNewNoteButton',
+          'experimental',
+          'externalContainerSelector',
+          'focus',
+          'group',
+          'notebookAppUrl',
+          'onLayoutChange',
+          'openSidebar',
+          'query',
+          'requestConfigFromFrame',
+          'services',
+          'showHighlights',
+          'sidebarAppUrl',
+          'subFrameIdentifier',
+          'theme',
+          'usernameUrl',
+        ],
+        Object.keys(config).sort()
+      );
+    });
   });
 
-  it('reads openSidebar from the host page, even when in a browser extension', function () {
-    configFrom('WINDOW');
-    sinon.assert.calledWith(
-      fakeSettingsFrom().hostPageSetting,
-      'openSidebar',
-      sinon.match({
-        allowInBrowserExt: true,
-        coerce: sinon.match.func,
-      })
-    );
+  context('browser extension detected', function () {
+    beforeEach(() => {
+      mockFakeSettings({
+        isBrowserExtension: true,
+      });
+    });
+    it('returns only config values where `allowInBrowserExt` is true', () => {
+      const config = getConfig('all', 'WINDOW');
+      assert.deepEqual(
+        [
+          'annotations',
+          'assetRoot',
+          'clientUrl',
+          'group',
+          'notebookAppUrl',
+          'openSidebar',
+          'query',
+          'showHighlights',
+          'sidebarAppUrl',
+          'subFrameIdentifier',
+        ],
+        Object.keys(config).sort()
+      );
+    });
   });
 
-  ['branding', 'services'].forEach(function (settingName) {
-    it(
-      'reads ' +
-        settingName +
-        ' from the host page only when in an embedded client',
-      function () {
-        configFrom('WINDOW');
-
-        assert.calledWithExactly(
-          fakeSettingsFrom().hostPageSetting,
-          settingName
-        );
-      }
-    );
+  describe('hostPageSetting config values', () => {
+    it('calls the valueFn() and passes the config name as a param', () => {
+      getConfig('all', 'WINDOW');
+      [
+        'assetRoot',
+        'branding',
+        'enableExperimentalNewNoteButton',
+        'experimental',
+        'focus',
+        'theme',
+        'usernameUrl',
+        'onLayoutChange',
+        'openSidebar',
+        'requestConfigFromFrame',
+        'services',
+        'subFrameIdentifier',
+        'externalContainerSelector',
+      ].forEach(name => {
+        assert.calledWith(fakeSettingsFrom().hostPageSetting, name);
+      });
+    });
   });
 
-  [
-    'assetRoot',
-    'branding',
-    'openSidebar',
-    'requestConfigFromFrame',
-    'services',
-  ].forEach(function (settingName) {
-    it('returns the ' + settingName + ' value from the host page', function () {
-      const settings = {
-        assetRoot: 'chrome-extension://1234/client/',
-        branding: 'BRANDING_SETTING',
-        openSidebar: 'OPEN_SIDEBAR_SETTING',
-        requestConfigFromFrame: 'https://embedder.com',
-        services: 'SERVICES_SETTING',
-      };
-      fakeSettingsFrom().hostPageSetting = function (settingName) {
-        return settings[settingName];
-      };
+  describe('default value', () => {
+    it('sets corresponding default values if settings are undefined', () => {
+      mockFakeSettings({
+        isBrowserExtension: false,
+        hostPageSetting: sinon.stub().returns(undefined),
+        annotations: undefined,
+        clientUrl: undefined,
+        group: undefined,
+        query: undefined,
+        showHighlights: undefined,
+        notebookAppUrl: undefined,
+      });
 
-      const settingValue = configFrom('WINDOW')[settingName];
+      const config = getConfig('all', 'WINDOW');
 
-      assert.equal(settingValue, settings[settingName]);
+      assert.deepEqual(config, {
+        annotations: null,
+        assetRoot: null,
+        branding: null,
+        clientUrl: null,
+        enableExperimentalNewNoteButton: null,
+        experimental: {},
+        externalContainerSelector: null,
+        focus: null,
+        group: null,
+        notebookAppUrl: null,
+        onLayoutChange: null,
+        openSidebar: false,
+        query: null,
+        requestConfigFromFrame: null,
+        services: null,
+        showHighlights: null,
+        sidebarAppUrl: null,
+        subFrameIdentifier: null,
+        theme: null,
+        usernameUrl: null,
+      });
+    });
+  });
+
+  describe('coerces values', () => {
+    it('coerces `openSidebar` from a string to a boolean', () => {
+      fakeHostPageSetting.withArgs('openSidebar').returns('false');
+      const config = getConfig('all', 'WINDOW');
+      assert.equal(config.openSidebar, false);
+    });
+  });
+
+  describe('application contexts', () => {
+    [
+      {
+        app: 'annotator',
+        expectedKeys: [
+          'annotations',
+          'assetRoot',
+          'branding',
+          'clientUrl',
+          'enableExperimentalNewNoteButton',
+          'experimental',
+          'externalContainerSelector',
+          'focus',
+          'group',
+          'notebookAppUrl',
+          'onLayoutChange',
+          'openSidebar',
+          'query',
+          'requestConfigFromFrame',
+          'services',
+          'showHighlights',
+          'sidebarAppUrl',
+          'subFrameIdentifier',
+          'theme',
+          'usernameUrl',
+        ],
+      },
+      {
+        app: 'notebook',
+        expectedKeys: [
+          'assetRoot',
+          'branding',
+          'clientUrl',
+          'enableExperimentalNewNoteButton',
+          'experimental',
+          'externalContainerSelector',
+          'focus',
+          'group',
+          'notebookAppUrl',
+          'onLayoutChange',
+          'openSidebar',
+          'query',
+          'requestConfigFromFrame',
+          'services',
+          'showHighlights',
+          'sidebarAppUrl',
+          'subFrameIdentifier',
+          'theme',
+          'usernameUrl',
+        ],
+      },
+      {
+        app: 'sidebar',
+        expectedKeys: [
+          'annotations',
+          'assetRoot',
+          'branding',
+          'clientUrl',
+          'enableExperimentalNewNoteButton',
+          'experimental',
+          'externalContainerSelector',
+          'focus',
+          'group',
+          'notebookAppUrl',
+          'onLayoutChange',
+          'openSidebar',
+          'query',
+          'requestConfigFromFrame',
+          'services',
+          'showHighlights',
+          'sidebarAppUrl',
+          'subFrameIdentifier',
+          'theme',
+          'usernameUrl',
+        ],
+      },
+    ].forEach(test => {
+      it('ignore values not belonging to a namespace', () => {
+        const config = getConfig(test.app, 'WINDOW');
+        assert.deepEqual(Object.keys(config).sort(), test.expectedKeys);
+      });
     });
   });
 });

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -5,8 +5,21 @@ describe('annotator/config/settingsFrom', () => {
   let fakeConfigFuncSettingsFrom;
   let fakeIsBrowserExtension;
   let fakeParseJsonConfig;
+  let link;
+
+  function appendLink(href, rel) {
+    const link = document.createElement('link');
+    link.type = 'application/annotator+html';
+    link.rel = rel;
+    if (href) {
+      link.href = href;
+    }
+    document.head.appendChild(link);
+    return link;
+  }
 
   beforeEach(() => {
+    link = appendLink('http://example.com/app.html', 'sidebar');
     fakeConfigFuncSettingsFrom = sinon.stub().returns({});
     fakeIsBrowserExtension = sinon.stub().returns(false);
     fakeParseJsonConfig = sinon.stub().returns({});
@@ -19,6 +32,7 @@ describe('annotator/config/settingsFrom', () => {
   });
 
   afterEach(() => {
+    link.remove();
     $imports.$restore();
   });
 
@@ -42,7 +56,7 @@ describe('annotator/config/settingsFrom', () => {
           beforeEach(
             'add an application/annotator+html notebook <link>',
             () => {
-              link = appendLink('http://example.com/app.html', 'notebook');
+              link = appendLink('http://example.com/notebook', 'notebook');
             }
           );
 
@@ -53,7 +67,7 @@ describe('annotator/config/settingsFrom', () => {
           it('returns the href from the notebook link', () => {
             assert.equal(
               settingsFrom(window).notebookAppUrl,
-              'http://example.com/app.html'
+              'http://example.com/notebook'
             );
           });
         }
@@ -83,7 +97,6 @@ describe('annotator/config/settingsFrom', () => {
 
       context('when the annotator+html notebook link has no href', () => {
         let link;
-
         beforeEach(
           'add an application/annotator+html notebook <link> with no href',
           () => {
@@ -113,16 +126,6 @@ describe('annotator/config/settingsFrom', () => {
 
     describe('#sidebarAppUrl', () => {
       context("when there's an application/annotator+html sidebar link", () => {
-        let link;
-
-        beforeEach('add an application/annotator+html sidebar <link>', () => {
-          link = appendLink('http://example.com/app.html', 'sidebar');
-        });
-
-        afterEach('tidy up the sidebar link', () => {
-          link.remove();
-        });
-
         it('returns the href from the sidebar link', () => {
           assert.equal(
             settingsFrom(window).sidebarAppUrl,
@@ -132,39 +135,34 @@ describe('annotator/config/settingsFrom', () => {
       });
 
       context('when there are multiple annotator+html sidebar links', () => {
-        let link1;
         let link2;
 
         beforeEach('add two sidebar links to the document', () => {
-          link1 = appendLink('http://example.com/app1', 'sidebar');
           link2 = appendLink('http://example.com/app2', 'sidebar');
         });
 
         afterEach('tidy up the sidebar links', () => {
-          link1.remove();
           link2.remove();
         });
 
         it('returns the href from the first one', () => {
           assert.equal(
             settingsFrom(window).sidebarAppUrl,
-            'http://example.com/app1'
+            'http://example.com/app.html'
           );
         });
       });
 
       context('when the annotator+html sidebar link has no href', () => {
-        let link;
+        let link2;
 
-        beforeEach(
-          'add an application/annotator+html sidebar <link> with no href',
-          () => {
-            link = appendLink(null, 'sidebar');
-          }
-        );
+        beforeEach(() => {
+          link.remove(); // Remove the default link
+          link2 = appendLink(null, 'sidebar'); // Add a new link without href=""
+        });
 
         afterEach('tidy up the sidebar link', () => {
-          link.remove();
+          link2.remove();
         });
 
         it('throws an error', () => {
@@ -175,6 +173,9 @@ describe('annotator/config/settingsFrom', () => {
       });
 
       context("when there's no annotator+html sidebar link", () => {
+        beforeEach(() => {
+          link.remove(); // Remove the default link
+        });
         it('throws an error', () => {
           assert.throws(() => {
             settingsFrom(window).sidebarAppUrl; // eslint-disable-line no-unused-expressions

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -17,7 +17,7 @@ import { registerIcons } from '@hypothesis/frontend-shared';
 import iconSet from './icons';
 registerIcons(iconSet);
 
-import configFrom from './config/index';
+import getConfig from './config/index';
 import Guest from './guest';
 import Notebook from './notebook';
 import Sidebar from './sidebar';
@@ -31,12 +31,12 @@ const appLinkEl = /** @type {Element} */ (document.querySelector(
   'link[type="application/annotator+html"][rel="sidebar"]'
 ));
 
-const config = configFrom(window);
+const annotatorConfig = getConfig('annotator');
 
 function init() {
   const isPDF = typeof window_.PDFViewerApplication !== 'undefined';
 
-  if (config.subFrameIdentifier) {
+  if (annotatorConfig.subFrameIdentifier) {
     // Other modules use this to detect if this
     // frame context belongs to hypothesis.
     // Needs to be a global property that's set.
@@ -44,14 +44,14 @@ function init() {
   }
 
   // Load the PDF anchoring/metadata integration.
-  config.documentType = isPDF ? 'pdf' : 'html';
+  annotatorConfig.documentType = isPDF ? 'pdf' : 'html';
 
   const eventBus = new EventBus();
-  const guest = new Guest(document.body, eventBus, config);
-  const sidebar = !config.subFrameIdentifier
-    ? new Sidebar(document.body, eventBus, guest, config)
+  const guest = new Guest(document.body, eventBus, annotatorConfig);
+  const sidebar = !annotatorConfig.subFrameIdentifier
+    ? new Sidebar(document.body, eventBus, guest, getConfig('sidebar'))
     : null;
-  const notebook = new Notebook(document.body, eventBus, config);
+  const notebook = new Notebook(document.body, eventBus, getConfig('notebook'));
 
   appLinkEl.addEventListener('destroy', () => {
     sidebar?.destroy();


### PR DESCRIPTION
Continuation of https://github.com/hypothesis/client/pull/3232 _Since the branch was force-pushed, I can't reopen the PR._

The changes here are mostly structural. I removed the class API and replaced it with just a single getConfig export. Additionally, I have used a separate list of keys with simple filters to defined the application contexts.

A follow up would be an audit of sidebar and annotator to see if any other keys could be omitted from those contexts. And, additionally, do we need to default all these values to null?

fixes https://github.com/hypothesis/client/issues/3236

### Commits

Expose `isBrowserExtension` flag from settingsFrom() …

The `isBrowserExtension` is needed external to the settings to be able to filter config values. As a result, settings-test.js needs a minor reconfiguration so that the link is mocked before each test.

---------

Refactor config/index.js to add app contexts …

Refactor config/index.js in an effort to filter the config based on the application context (sidebar, notebook, annotator, This refactor moves all the rules to a single configuration definition that makes it clear 1. where a setting comes from and 2. what rules it follows before getting passed along to the rest of the app.

Additionally, it was unclear which settings were allowed in the browser extension context because only the hostPageSetting settings made use of the boolean flag but some of the getters did not.

Other changes:

- When in browser context (isBrowserExtension), values which are prohibited are now omitted rather than set to null
- When requeuing a config using an app context, values outside of that context are omitted.
- Move isBrowserExtension flag from settings to index.js configDefinitions

--------

