### PR TITLE
Fix focus group for Notebook in LMS context

### DIFF
--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -366,7 +366,10 @@ export default function groups(
       g => g !== null
     );
 
-    addGroupsToStore(groups);
+    // Optional direct linked group id. This is used in the Notebook context.
+    const focusedGroupId = store.directLinkedGroupId();
+
+    addGroupsToStore(groups, focusedGroupId);
 
     if (error) {
       // @ts-ignore - TS can't track the type of `error` here.

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -37,7 +37,7 @@ const dummyGroups = [
   { name: 'Group 3', id: 'id3' },
 ];
 
-describe('groups', function () {
+describe('sidebar/services/groups', function () {
   let fakeAuth;
   let fakeStore;
   let fakeSession;
@@ -812,6 +812,28 @@ describe('groups', function () {
           'Unable to fetch group configuration: Something went wrong'
         );
         assert.deepEqual(groups, []);
+      });
+
+      it('initially sets the focused group to the `directLinkedGroupId`', async () => {
+        setServiceConfigGroups(Promise.resolve(['id-a', 'id-b', 'id-c']));
+        fakeApi.profile.groups.read.resolves([groupA, groupB, groupC]);
+        fakeStore.directLinkedGroupId.returns('id-c');
+
+        const svc = service();
+        await svc.load();
+
+        assert.calledWith(fakeStore.focusGroup, 'id-c');
+      });
+
+      it('does not set the focused group if no `directLinkedGroupId`', async () => {
+        setServiceConfigGroups(Promise.resolve(['id-a', 'id-b', 'id-c']));
+        fakeApi.profile.groups.read.resolves([groupA, groupB, groupC]);
+        fakeStore.directLinkedGroupId.returns(null);
+
+        const svc = service();
+        await svc.load();
+
+        assert.notCalled(fakeStore.focusGroup);
       });
     });
   });


### PR DESCRIPTION
Now that the config passes the `group` value from the LMS iframe, we can use it to set the initial focus group. This still was not flushed out and I traced it down to how we load the groups service. 

### Testing

**This particular issue is very specific to set up.**
1. Requires canvas (or any LMS that can launch the assignment in the same window as the LMS)
2. Requires third party cookies to be disabled (to prevent localStorage from working in iframes with different hostnames)
3. **Do not** load the canvas assignment in a new window  because then localStorage will work and you can't repo this exact situation 

I use this assignment: https://hypothesis.instructure.com/courses/125/assignments/874

Select any group except for the first, then open the notebook and observe that that group is indeed used in the notebook and so are the annotations.

Secondly, observe that the notebook still works in http://localhost:3000 for non LMS usage. 

----------

### Commit

Use directLinkedGroupId when loading groups

Change loadServiceSpecifiedGroups() so that it can optionally pass along a group ID setting value from the `directLinkedGroupId` selector to be an initially focused.

When loading groups from a service e.g. `loadServiceSpecifiedGroups`, previously it assumed that the `directLinkedGroupId` value would not be used in this context. Since the introduction of the Notebook and specifically in the context of LMS, we have both a service setting which contains the groups  (`settings.services[0].groups <Promise>`)
and a top level group to set focus too. (`settings.group`).

fixes https://github.com/hypothesis/client/issues/3251