### PR TITLE
Convert `router` service to a native ES class

### DIFF
--- a/src/sidebar/components/StreamSearchInput.js
+++ b/src/sidebar/components/StreamSearchInput.js
@@ -5,7 +5,7 @@ import SearchInput from './SearchInput';
 
 /**
  * @typedef StreamSearchInputProps
- * @prop {Object} router - Injected service
+ * @prop {import('../services/router').RouterService} router
  */
 
 /**

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -44,6 +44,10 @@ function setupApi(api, streamer) {
 /**
  * Perform the initial fetch of groups and user profile and then set the initial
  * route to match the current URL.
+ *
+ * @param {Object} groups
+ * @param {Object} session
+ * @param {import('./services/router').RouterService} router
  */
 // @inject
 function setupRoute(groups, session, router) {
@@ -102,7 +106,7 @@ import groupsService from './services/groups';
 import loadAnnotationsService from './services/load-annotations';
 import localStorageService from './services/local-storage';
 import persistedDefaultsService from './services/persisted-defaults';
-import routerService from './services/router';
+import { RouterService } from './services/router';
 import serviceUrlService from './services/service-url';
 import sessionService from './services/session';
 import streamFilterService from './services/stream-filter';
@@ -140,7 +144,7 @@ function startApp(config, appEl) {
     .register('loadAnnotationsService', loadAnnotationsService)
     .register('localStorage', localStorageService)
     .register('persistedDefaults', persistedDefaultsService)
-    .register('router', routerService)
+    .register('router', RouterService)
     .register('serviceUrl', serviceUrlService)
     .register('session', sessionService)
     .register('streamer', streamerService)

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -1,6 +1,11 @@
 import * as queryString from 'query-string';
 
 /**
+ * @typedef {'annotation'|'notebook'|'stream'|'sidebar'} RouteName
+ * @typedef {Record<string,string>} RouteParams
+ */
+
+/**
  * A service that manages the association between the route and route parameters
  * implied by the URL and the corresponding route state in the store.
  */
@@ -18,6 +23,8 @@ export class RouterService {
 
   /**
    * Return the name and parameters of the current route.
+   *
+   * @return {{ route: RouteName, params: RouteParams }}
    */
   currentRoute() {
     const path = this._window.location.pathname;
@@ -36,6 +43,7 @@ export class RouterService {
     // extension.
     const mainSegment = pathSegments[0].replace(/\.html$/, '');
 
+    /** @type {RouteName} */
     let route;
 
     switch (mainSegment) {
@@ -60,8 +68,8 @@ export class RouterService {
   /**
    * Generate a URL for a given route.
    *
-   * @param {string} name
-   * @param {Object.<string,string>} params
+   * @param {RouteName} name
+   * @param {RouteParams} params
    */
   routeUrl(name, params = {}) {
     let url;
@@ -122,8 +130,8 @@ export class RouterService {
   /**
    * Navigate to a given route.
    *
-   * @param {string} name
-   * @param {Object.<string,string>} params
+   * @param {RouteName} name
+   * @param {RouteParams} params
    */
   navigate(name, params) {
     this._window.history.pushState({}, '', this.routeUrl(name, params));

--- a/src/sidebar/services/test/router-test.js
+++ b/src/sidebar/services/test/router-test.js
@@ -1,5 +1,5 @@
 import EventEmitter from 'tiny-emitter';
-import router from '../router';
+import { RouterService } from '../router';
 
 const fixtures = [
   // Sidebar for the embedded Hypothesis client.
@@ -40,12 +40,12 @@ const fixtures = [
   },
 ];
 
-describe('router', () => {
+describe('RouterService', () => {
   let fakeWindow;
   let fakeStore;
 
   function createService() {
-    return router(fakeWindow, fakeStore);
+    return new RouterService(fakeWindow, fakeStore);
   }
 
   function updateUrl(path, search) {


### PR DESCRIPTION
Services in `src/sidebar/services` are effectively classes. They are
currently implemented with a convention that was more common pre-ES6 where
the constructor is a function that creates the fields as local variables
and the methods using closures and returns an object that references the
closures.

This pattern has advantages, especially pre-ES6, as it avoids issues with
incorrect use of `this` and hides internal state from consumers. However
it also has downsides:

 - It is less obvious to readers that they are looking at something that
   is logically a class

 - This is not an idiom we use elsewhere in the codebase, where we use
   native classes instead

 - Static analysis tools don't support this pattern for creating a class
   as well as they support a native class. For example `TS` creates a
   named type for native classes, which is convenient to reference
   in JSDoc comments

This commit starts a process of refactoring service classes to ES
classes which are named `<Thing>Service`, using the router service as a
first example. Per recently agreed conventions, the classes are named
rather than default exports.

Related Slack discussion: https://hypothes-is.slack.com/archives/C1M8NH76X/p1618312556291000?thread_ts=1618307159.290300&cid=C1M8NH76X 