### PR TITLE
Convert `apiRoutes` service to ES class

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -97,7 +97,7 @@ import bridgeService from '../shared/bridge';
 
 import annotationsService from './services/annotations';
 import apiService from './services/api';
-import apiRoutesService from './services/api-routes';
+import { APIRoutesService } from './services/api-routes';
 import authService from './services/oauth-auth';
 import autosaveService from './services/autosave';
 import featuresService from './services/features';
@@ -134,7 +134,7 @@ function startApp(config, appEl) {
   container
     .register('annotationsService', annotationsService)
     .register('api', apiService)
-    .register('apiRoutes', apiRoutesService)
+    .register('apiRoutes', APIRoutesService)
     .register('auth', authService)
     .register('autosaveService', autosaveService)
     .register('bridge', bridgeService)

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -202,6 +202,8 @@ function createAPICall(
  * to get auth tokens. The URLs for API endpoints are fetched from the `/api`
  * endpoint, a responsibility delegated to the `apiRoutes` service which does
  * not use authentication.
+ *
+ * @param {import('./api-routes').APIRoutesService} apiRoutes
  */
 // @inject
 export default function api(apiRoutes, auth, store) {

--- a/src/sidebar/services/oauth-auth.js
+++ b/src/sidebar/services/oauth-auth.js
@@ -27,6 +27,7 @@ import { resolve } from '../util/url';
  *
  * @param {Window} $window
  * @param {import('./toast-messenger').ToastMessengerService} toastMessenger
+ * @param {import('./api-routes').APIRoutesService} apiRoutes
  * @inject
  */
 export default function auth(

--- a/src/sidebar/services/service-url.js
+++ b/src/sidebar/services/service-url.js
@@ -32,6 +32,8 @@ import * as urlUtil from '../util/url';
  */
 
 /**
+ * @param {import('../store').SidebarStore} store
+ * @param {import('./api-routes').APIRoutesService} apiRoutes
  * @return {ServiceUrlGetter}
  * @inject
  */

--- a/src/sidebar/services/test/api-routes-test.js
+++ b/src/sidebar/services/test/api-routes-test.js
@@ -1,4 +1,4 @@
-import { APIRoutesService } from '../api-routes';
+import { APIRoutesService, $imports } from '../api-routes';
 
 // Abridged version of the response returned by https://hypothes.is/api,
 // with the domain name changed.
@@ -34,6 +34,21 @@ const linksResponse = {
   'oauth.authorize': 'https://annotation.service/oauth/authorize',
 };
 
+/**
+ * Fake `retryPromiseOperation` that does not wait between retries.
+ */
+async function fakeRetryPromiseOperation(callback) {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      const result = await callback();
+      return result;
+    } catch {
+      // Try again
+    }
+  }
+}
+
 describe('APIRoutesService', () => {
   let apiRoutes;
   let fakeSettings;
@@ -60,9 +75,14 @@ describe('APIRoutesService', () => {
     };
 
     apiRoutes = new APIRoutesService(fakeSettings);
+
+    $imports.$mock({
+      '../util/retry': { retryPromiseOperation: fakeRetryPromiseOperation },
+    });
   });
 
   afterEach(() => {
+    $imports.$restore();
     window.fetch.restore();
   });
 

--- a/src/sidebar/services/test/api-routes-test.js
+++ b/src/sidebar/services/test/api-routes-test.js
@@ -83,11 +83,16 @@ describe('APIRoutesService', () => {
       );
     });
 
-    it('retries the route fetch until it succeeds', () => {
-      window.fetch.onFirstCall().returns(httpResponse(500, null));
-      return apiRoutes.routes().then(routes => {
-        assert.deepEqual(routes, apiIndexResponse.links);
-      });
+    it('retries the route fetch until it succeeds', async () => {
+      window.fetch
+        .withArgs('https://annotation.service/api/')
+        .onFirstCall()
+        .returns(httpResponse(500, null));
+
+      const routes = await apiRoutes.routes();
+
+      assert.calledTwice(window.fetch);
+      assert.deepEqual(routes, apiIndexResponse.links);
     });
   });
 

--- a/src/sidebar/services/test/api-routes-test.js
+++ b/src/sidebar/services/test/api-routes-test.js
@@ -1,4 +1,4 @@
-import apiRoutesFactory from '../api-routes';
+import { APIRoutesService } from '../api-routes';
 
 // Abridged version of the response returned by https://hypothes.is/api,
 // with the domain name changed.
@@ -34,7 +34,7 @@ const linksResponse = {
   'oauth.authorize': 'https://annotation.service/oauth/authorize',
 };
 
-describe('sidebar.api-routes', () => {
+describe('APIRoutesService', () => {
   let apiRoutes;
   let fakeSettings;
 
@@ -59,7 +59,7 @@ describe('sidebar.api-routes', () => {
       apiUrl: 'https://annotation.service/api/',
     };
 
-    apiRoutes = apiRoutesFactory(fakeSettings);
+    apiRoutes = new APIRoutesService(fakeSettings);
   });
 
   afterEach(() => {

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -6,6 +6,22 @@
  */
 
 /**
+ * An entry in the API index response (`/api`) describing an API route.
+ *
+ * @typedef RouteMetadata
+ * @prop {string} method - HTTP method
+ * @prop {string} url - URL template
+ * @prop {string} desc - Description of API route
+ */
+
+/**
+ * Structure of the `links` field of the API index response (`/api`) describing
+ * available API routes.
+ *
+ * @typedef {{ [key: string]: RouteMap|RouteMetadata }} RouteMap
+ */
+
+/**
  * @typedef TextQuoteSelector
  * @prop {'TextQuoteSelector'} type
  * @prop {string} exact


### PR DESCRIPTION
Follow the pattern introduced in https://github.com/hypothesis/client/pull/3296 to convert the API routes service to a class and improve various types along the way.