### PR TITLE
Convert `toastMessenger` service to ES class

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationActionBar.js
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.js
@@ -22,7 +22,7 @@ import AnnotationShareControl from './AnnotationShareControl';
  * @prop {() => any} onReply - Callbacks for when action buttons are clicked/tapped
  * @prop {Object} annotationsService
  * @prop {HostConfig} settings
- * @prop {Object} toastMessenger
+ * @prop {import('../../services/toast-messenger').ToastMessengerService} toastMessenger
  */
 
 /**

--- a/src/sidebar/components/Annotation/AnnotationEditor.js
+++ b/src/sidebar/components/Annotation/AnnotationEditor.js
@@ -21,7 +21,7 @@ import AnnotationPublishControl from './AnnotationPublishControl';
  * @prop {Annotation} annotation - The annotation under edit
  * @prop {Object} annotationsService - Injected service
  * @prop {MergedConfig} settings - Injected service
- * @prop {Object} toastMessenger - Injected service
+ * @prop {import('../../services/toast-messenger').ToastMessengerService} toastMessenger
  * @prop {Object} tags - Injected service
  */
 

--- a/src/sidebar/components/Annotation/AnnotationShareControl.js
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.js
@@ -24,7 +24,7 @@ import ShareLinks from '../ShareLinks';
  *  FIXME: Refactor after root cause is addressed.
  *  See https://github.com/hypothesis/client/issues/1542
  * @prop {string} shareUri - The URI to view the annotation on its own
- * @prop {Object} toastMessenger - Injected service
+ * @prop {import('../../services/toast-messenger').ToastMessengerService} toastMessenger
  */
 
 function selectionOverflowsInputElement() {

--- a/src/sidebar/components/GroupList/GroupListItem.js
+++ b/src/sidebar/components/GroupList/GroupListItem.js
@@ -17,7 +17,7 @@ import MenuItem from '../MenuItem';
  * @prop {(expand: boolean) => any} onExpand -
  *   Callback invoked to expand or collapse the current group
  * @prop {Object} groups - Injected service
- * @prop {Object} toastMessenger - Injected service
+ * @prop {import('../../services/toast-messenger').ToastMessengerService} toastMessenger
  */
 
 /**

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -58,7 +58,7 @@ function authStateFromProfile(profile) {
  * @prop {ServiceUrlGetter} serviceUrl
  * @prop {MergedConfig} settings
  * @prop {Object} session
- * @prop {Object} toastMessenger
+ * @prop {import('../services/toast-messenger').ToastMessengerService} toastMessenger
  */
 
 /**

--- a/src/sidebar/components/ModerationBanner.js
+++ b/src/sidebar/components/ModerationBanner.js
@@ -14,7 +14,7 @@ import { withServices } from '../service-context';
  *   The annotation object for this banner. This contains state about the flag count
  *   or its hidden value.
  * @prop {Object} api - Injected service
- * @prop {Object} toastMessenger - Injected service
+ * @prop {import('../services/toast-messenger').ToastMessengerService} toastMessenger
  */
 
 /**

--- a/src/sidebar/components/ShareAnnotationsPanel.js
+++ b/src/sidebar/components/ShareAnnotationsPanel.js
@@ -14,7 +14,7 @@ import Spinner from './Spinner';
 
 /**
  * @typedef ShareAnnotationsPanelProps
- * @prop {Object} toastMessenger - Injected service
+ * @prop {import('../services/toast-messenger').ToastMessengerService} toastMessenger
  */
 
 /**

--- a/src/sidebar/components/StreamView.js
+++ b/src/sidebar/components/StreamView.js
@@ -9,8 +9,8 @@ import ThreadList from './ThreadList';
 
 /**
  * @typedef StreamViewProps
- * @prop {ReturnType<import('../services/api').default>} api - Injected service
- * @prop {ReturnType<import('../services/toast-messenger').default>} toastMessenger - Injected service
+ * @prop {ReturnType<import('../services/api').default>} api
+ * @prop {import('../services/toast-messenger').ToastMessengerService} toastMessenger
  */
 
 /**

--- a/src/sidebar/components/VersionInfo.js
+++ b/src/sidebar/components/VersionInfo.js
@@ -6,7 +6,7 @@ import { LabeledButton } from '../../shared/components/buttons';
 /**
  * @typedef VersionInfoProps
  * @prop {import('../helpers/version-data').default} versionData - Object with version information
- * @prop {Object} toastMessenger - Injected service
+ * @prop {import('../services/toast-messenger').ToastMessengerService} toastMessenger
  */
 
 /**

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -113,7 +113,7 @@ import streamFilterService from './services/stream-filter';
 import streamerService from './services/streamer';
 import tagsService from './services/tags';
 import threadsService from './services/threads';
-import toastMessenger from './services/toast-messenger';
+import { ToastMessengerService } from './services/toast-messenger';
 
 // Redux store.
 import store from './store';
@@ -151,7 +151,7 @@ function startApp(config, appEl) {
     .register('streamFilter', streamFilterService)
     .register('tags', tagsService)
     .register('threadsService', threadsService)
-    .register('toastMessenger', toastMessenger)
+    .register('toastMessenger', ToastMessengerService)
     .register('store', store);
 
   // Register utility values/classes.

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -20,6 +20,9 @@ const DEFAULT_ORGANIZATION = {
     encodeURIComponent(require('../../images/icons/logo.svg')),
 };
 
+/**
+ * @param {import('./toast-messenger').ToastMessengerService} toastMessenger
+ */
 // @inject
 export default function groups(
   store,

--- a/src/sidebar/services/oauth-auth.js
+++ b/src/sidebar/services/oauth-auth.js
@@ -25,6 +25,8 @@ import { resolve } from '../util/url';
  * Interaction with OAuth endpoints in the annotation service is delegated to
  * the `OAuthClient` class.
  *
+ * @param {Window} $window
+ * @param {import('./toast-messenger').ToastMessengerService} toastMessenger
  * @inject
  */
 export default function auth(

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -12,6 +12,7 @@ const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
  *
  * Access to the current profile is exposed via the `state` property.
  *
+ * @param {import('./toast-messenger').ToastMessengerService} toastMessenger
  * @inject
  */
 export default function session(store, api, auth, settings, toastMessenger) {

--- a/src/sidebar/services/test/toast-messenger-test.js
+++ b/src/sidebar/services/test/toast-messenger-test.js
@@ -1,6 +1,6 @@
-import toastMessenger from '../toast-messenger';
+import { ToastMessengerService } from '../toast-messenger';
 
-describe('toastMessenger', function () {
+describe('ToastMessengerService', function () {
   let clock;
   let fakeStore;
   let service;
@@ -15,7 +15,7 @@ describe('toastMessenger', function () {
     };
 
     clock = sinon.useFakeTimers();
-    service = toastMessenger(fakeStore);
+    service = new ToastMessengerService(fakeStore);
   });
 
   afterEach(() => {


### PR DESCRIPTION
 - Convert toastMessenger service to an ES class using a named rather than default export
 - Specify type of `toastMessenger` references to this service

This is part of https://github.com/hypothesis/client/issues/3298.