### PR TITLE
Use a named export for `StreamFilter` class

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -109,7 +109,7 @@ import persistedDefaultsService from './services/persisted-defaults';
 import { RouterService } from './services/router';
 import serviceUrlService from './services/service-url';
 import sessionService from './services/session';
-import streamFilterService from './services/stream-filter';
+import { StreamFilter } from './services/stream-filter';
 import streamerService from './services/streamer';
 import tagsService from './services/tags';
 import threadsService from './services/threads';
@@ -148,7 +148,7 @@ function startApp(config, appEl) {
     .register('serviceUrl', serviceUrlService)
     .register('session', sessionService)
     .register('streamer', streamerService)
-    .register('streamFilter', streamFilterService)
+    .register('streamFilter', StreamFilter)
     .register('tags', tagsService)
     .register('threadsService', threadsService)
     .register('toastMessenger', toastMessenger)

--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -33,7 +33,7 @@ import { isReply } from '../helpers/annotation-metadata';
  * @param {ReturnType<import('./api').default>} api
  * @param {import('../store').SidebarStore} store
  * @param {import('./streamer').default} streamer
- * @param {import('./stream-filter').default} streamFilter
+ * @param {import('./stream-filter').StreamFilter} streamFilter
  */
 // @inject
 export default function loadAnnotationsService(

--- a/src/sidebar/services/stream-filter.js
+++ b/src/sidebar/services/stream-filter.js
@@ -44,9 +44,9 @@ function defaultFilter() {
  * See https://github.com/hypothesis/h/blob/master/h/streamer/filter.py
  * for the schema.
  */
-export default class StreamFilter {
+export class StreamFilter {
   constructor() {
-    this.filter = defaultFilter();
+    this._filter = defaultFilter();
   }
 
   /**
@@ -58,7 +58,7 @@ export default class StreamFilter {
    * @param {FilterClause['case_sensitive']} caseSensitive - Whether matching should be case sensitive
    */
   addClause(field, operator, value, caseSensitive = false) {
-    this.filter.clauses.push({
+    this._filter.clauses.push({
       field,
       operator,
       value,
@@ -69,12 +69,12 @@ export default class StreamFilter {
 
   /** Return the JSON-serializable filtering configuration. */
   getFilter() {
-    return this.filter;
+    return this._filter;
   }
 
   /** Reset the configuration to return all updates. */
   resetFilter() {
-    this.filter = defaultFilter();
+    this._filter = defaultFilter();
     return this;
   }
 }

--- a/src/sidebar/services/test/stream-filter-test.js
+++ b/src/sidebar/services/test/stream-filter-test.js
@@ -1,6 +1,6 @@
-import StreamFilter from '../stream-filter';
+import { StreamFilter } from '../stream-filter';
 
-describe('sidebar/services/stream-filter', () => {
+describe('StreamFilter', () => {
   describe('#addClause', () => {
     [
       {


### PR DESCRIPTION
Update `StreamFilter` class to current service conventions. Part of
https://github.com/hypothesis/client/issues/3298.

I considered adding a `Service` suffix to the class name but it seemed a bit unnecessary. I figure we can settle on that later.