### PR TITLE
Convert `annotations` service to an ES class

### DIFF
--- a/src/sidebar/components/Annotation/Annotation.js
+++ b/src/sidebar/components/Annotation/Annotation.js
@@ -26,7 +26,7 @@ import AnnotationReplyToggle from './AnnotationReplyToggle';
  * @prop {VoidFunction} onToggleReplies - Callback to expand/collapse reply threads
  * @prop {number} replyCount - Number of replies to this annotation's thread
  * @prop {boolean} threadIsCollapsed - Is the thread to which this annotation belongs currently collapsed?
- * @prop {Object} annotationsService - Injected service
+ * @prop {import('../../services/annotations').AnnotationsService} annotationsService
  */
 
 /**

--- a/src/sidebar/components/Annotation/AnnotationActionBar.js
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.js
@@ -20,7 +20,7 @@ import AnnotationShareControl from './AnnotationShareControl';
  * @typedef AnnotationActionBarProps
  * @prop {Annotation} annotation - The annotation in question
  * @prop {() => any} onReply - Callbacks for when action buttons are clicked/tapped
- * @prop {Object} annotationsService
+ * @prop {import('../../services/annotations').AnnotationsService} annotationsService
  * @prop {HostConfig} settings
  * @prop {import('../../services/toast-messenger').ToastMessengerService} toastMessenger
  */

--- a/src/sidebar/components/Annotation/AnnotationEditor.js
+++ b/src/sidebar/components/Annotation/AnnotationEditor.js
@@ -19,7 +19,7 @@ import AnnotationPublishControl from './AnnotationPublishControl';
 /**
  * @typedef AnnotationEditorProps
  * @prop {Annotation} annotation - The annotation under edit
- * @prop {Object} annotationsService - Injected service
+ * @prop {import('../../services/annotations').AnnotationsService} annotationsService
  * @prop {MergedConfig} settings - Injected service
  * @prop {import('../../services/toast-messenger').ToastMessengerService} toastMessenger
  * @prop {Object} tags - Injected service

--- a/src/sidebar/components/SelectionTabs.js
+++ b/src/sidebar/components/SelectionTabs.js
@@ -73,7 +73,7 @@ function Tab({
  * @typedef SelectionTabsProps
  * @prop {boolean} isLoading - Are we waiting on any annotations from the server?
  * @prop {MergedConfig} settings - Injected service.
- * @prop {Object} annotationsService - Injected service.
+ * @prop {import('../services/annotations').AnnotationsService} annotationsService
  */
 
 /**

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -95,7 +95,7 @@ import { ServiceContext } from './service-context';
 // Services.
 import bridgeService from '../shared/bridge';
 
-import annotationsService from './services/annotations';
+import { AnnotationsService } from './services/annotations';
 import apiService from './services/api';
 import { APIRoutesService } from './services/api-routes';
 import authService from './services/oauth-auth';
@@ -132,7 +132,7 @@ function startApp(config, appEl) {
 
   // Register services.
   container
-    .register('annotationsService', annotationsService)
+    .register('annotationsService', AnnotationsService)
     .register('api', apiService)
     .register('apiRoutes', APIRoutesService)
     .register('auth', authService)

--- a/src/sidebar/services/autosave.js
+++ b/src/sidebar/services/autosave.js
@@ -3,6 +3,10 @@
  */
 import { retryPromiseOperation } from '../util/retry';
 
+/**
+ * @param {import('./annotations').AnnotationsService} annotationsService
+ * @param {import('../store').SidebarStore} store
+ */
 // @inject
 export default function autosaveService(annotationsService, store) {
   // A Set of annotation $tags that have save requests in-flight

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -28,6 +28,9 @@ export function formatAnnot(ann) {
  * This service runs in the sidebar and is responsible for keeping the set of
  * annotations displayed in connected frames in sync with the set shown in the
  * sidebar.
+ *
+ * @param {import('./annotations').AnnotationsService} annotationsService
+ * @param {import('../store').SidebarStore} store
  */
 // @inject
 export default function FrameSync(annotationsService, bridge, store) {
@@ -132,6 +135,8 @@ export default function FrameSync(annotationsService, bridge, store) {
     //
     // Updates are coalesced to reduce the overhead from processing
     // triggered by each `UPDATE_ANCHOR_STATUS` action that is dispatched.
+
+    /** @type {Record<string,'anchored'|'orphan'|'timeout'>} */
     let anchoringStatusUpdates = {};
     const scheduleAnchoringStatusUpdate = debounce(() => {
       store.updateAnchorStatus(anchoringStatusUpdates);

--- a/src/sidebar/services/test/annotations-test.js
+++ b/src/sidebar/services/test/annotations-test.js
@@ -1,8 +1,8 @@
 import * as fixtures from '../../test/annotation-fixtures';
 
-import annotationsService, { $imports } from '../annotations';
+import { AnnotationsService, $imports } from '../annotations';
 
-describe('annotationsService', () => {
+describe('AnnotationsService', () => {
   let fakeApi;
   let fakeMetadata;
   let fakeStore;
@@ -41,7 +41,7 @@ describe('annotationsService', () => {
       annotationSaveStarted: sinon.stub(),
       createDraft: sinon.stub(),
       deleteNewAndEmptyDrafts: sinon.stub(),
-      focusedGroupId: sinon.stub(),
+      focusedGroupId: sinon.stub().returns('test-group'),
       getDefault: sinon.stub(),
       getDraft: sinon.stub().returns(null),
       isLoggedIn: sinon.stub().returns(true),
@@ -64,7 +64,7 @@ describe('annotationsService', () => {
       },
     });
 
-    svc = annotationsService(fakeApi, fakeStore);
+    svc = new AnnotationsService(fakeApi, fakeStore);
   });
 
   afterEach(() => {
@@ -226,6 +226,14 @@ describe('annotationsService', () => {
       assert.calledWith(fakeStore.setExpanded, 'aparent', true);
       assert.calledWith(fakeStore.setExpanded, 'anotherparent', true);
       assert.calledWith(fakeStore.setExpanded, 'yetanotherancestor', true);
+    });
+
+    it('throws an error if there is no focused group', () => {
+      fakeStore.focusedGroupId.returns(null);
+
+      assert.throws(() => {
+        svc.create(fixtures.newAnnotation(), now);
+      }, 'Cannot create annotation without a group');
     });
   });
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/3298

In the process an issue was uncovered where an annotation could
incorrectly be created without a group if there was no focused group.
Address the issue by throwing an error in `AnnotationsService#create` if
there is no focused group. Handling the situation in a
context-appropriate way is left an exercise for higher-level code.