### PR TITLE
Convert `tags` service to ES class

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.js
+++ b/src/sidebar/components/Annotation/AnnotationEditor.js
@@ -22,7 +22,7 @@ import AnnotationPublishControl from './AnnotationPublishControl';
  * @prop {import('../../services/annotations').AnnotationsService} annotationsService
  * @prop {MergedConfig} settings - Injected service
  * @prop {import('../../services/toast-messenger').ToastMessengerService} toastMessenger
- * @prop {Object} tags - Injected service
+ * @prop {import('../../services/tags').TagsService} tags
  */
 
 /**
@@ -75,7 +75,7 @@ function AnnotationEditor({
     }
     const tagList = [...tags, newTag];
     // Update the tag locally for the suggested-tag list
-    tagsService.store(tagList.map(tag => ({ text: tag })));
+    tagsService.store(tagList);
     onEditTags({ tags: tagList });
     return true;
   };

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -104,7 +104,7 @@ describe('AnnotationEditor', () => {
         const storeCall = fakeTagsService.store.getCall(0);
         const draftCall = fakeStore.createDraft.getCall(0);
 
-        assert.deepEqual(storeCall.args[0], [{ text: 'newTag' }]);
+        assert.deepEqual(storeCall.args[0], ['newTag']);
         assert.deepEqual(draftCall.args[1].tags, ['newTag']);
       });
 

--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -20,7 +20,7 @@ let tagEditorIdCounter = 0;
  * @prop {(tag: string) => boolean} onRemoveTag - Callback to remove a tag from the annotation
  * @prop {(tag: string) => any} onTagInput - Callback when inputted tag text changes
  * @prop {string[]} tagList - The list of tags for the annotation under edit
- * @prop {Object} tags - Injected service
+ * @prop {import('../services/tags').TagsService} tags
  */
 
 /**

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -111,7 +111,7 @@ import serviceUrlService from './services/service-url';
 import sessionService from './services/session';
 import { StreamFilter } from './services/stream-filter';
 import streamerService from './services/streamer';
-import tagsService from './services/tags';
+import { TagsService } from './services/tags';
 import { ThreadsService } from './services/threads';
 import { ToastMessengerService } from './services/toast-messenger';
 
@@ -149,7 +149,7 @@ function startApp(config, appEl) {
     .register('session', sessionService)
     .register('streamer', streamerService)
     .register('streamFilter', StreamFilter)
-    .register('tags', tagsService)
+    .register('tags', TagsService)
     .register('threadsService', ThreadsService)
     .register('toastMessenger', ToastMessengerService)
     .register('store', store);

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -1,4 +1,4 @@
-import tagsFactory from '../tags';
+import { TagsService } from '../tags';
 
 const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
 const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
@@ -17,7 +17,7 @@ class FakeStorage {
   }
 }
 
-describe('sidebar/services/tags', () => {
+describe('TagsService', () => {
   let fakeLocalStorage;
   let tags;
 
@@ -62,7 +62,7 @@ describe('sidebar/services/tags', () => {
     fakeLocalStorage.setObject(TAGS_MAP_KEY, savedTagsMap);
     fakeLocalStorage.setObject(TAGS_LIST_KEY, savedTagsList);
 
-    tags = tagsFactory(fakeLocalStorage);
+    tags = new TagsService(fakeLocalStorage);
   });
 
   describe('#filter', () => {
@@ -87,7 +87,7 @@ describe('sidebar/services/tags', () => {
 
   describe('#store', () => {
     it('saves new tags to storage', () => {
-      tags.store([{ text: 'new' }]);
+      tags.store(['new']);
 
       const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
       assert.include(storedTagsList, 'new');
@@ -104,14 +104,14 @@ describe('sidebar/services/tags', () => {
     });
 
     it('increases the count for a tag already stored', () => {
-      tags.store([{ text: 'bar' }]);
+      tags.store(['bar']);
       const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
       assert.equal(storedTagsMap.bar.count, 6);
     });
 
     it('orders list by count descending, lexical ascending', () => {
       for (let i = 0; i < 6; i++) {
-        tags.store([{ text: 'foo' }]);
+        tags.store(['foo']);
       }
 
       const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);


### PR DESCRIPTION
This conversion revealed some incorrect and inconsistent types.

- The `filter` method was documented to return a `Tag` array but actually
  returned a string array
- The `store` method required a list of `Tag`s but only used the `text`
  property from it. This method has been simplified to just accept a
  list of tag strings instead.

Part of https://github.com/hypothesis/client/issues/3298