### PR TITLE
Convert `autosave` and `persistedDefaults` services to ES classes

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -69,8 +69,10 @@ function persistDefaults(persistedDefaults) {
 
 /**
  * Set up autosave-new-highlights service
+ *
+ * @param {import('./services/autosave').AutosaveService} autosaveService
+ * @inject
  */
-// @inject
 function autosave(autosaveService) {
   autosaveService.init();
 }
@@ -101,7 +103,7 @@ import { AnnotationsService } from './services/annotations';
 import apiService from './services/api';
 import { APIRoutesService } from './services/api-routes';
 import authService from './services/oauth-auth';
-import autosaveService from './services/autosave';
+import { AutosaveService } from './services/autosave';
 import featuresService from './services/features';
 import frameSyncService from './services/frame-sync';
 import groupsService from './services/groups';
@@ -138,7 +140,7 @@ function startApp(config, appEl) {
     .register('api', apiService)
     .register('apiRoutes', APIRoutesService)
     .register('auth', authService)
-    .register('autosaveService', autosaveService)
+    .register('autosaveService', AutosaveService)
     .register('bridge', bridgeService)
     .register('features', featuresService)
     .register('frameSync', frameSyncService)

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -59,8 +59,10 @@ function setupRoute(groups, session, router) {
 /**
  * Fetch any persisted client-side defaults, and persist any app-state changes to
  * those defaults
+ *
+ * @param {import('./services/persisted-defaults').PersistedDefaultsService} persistedDefaults
+ * @inject
  */
-// @inject
 function persistDefaults(persistedDefaults) {
   persistedDefaults.init();
 }
@@ -105,7 +107,7 @@ import frameSyncService from './services/frame-sync';
 import groupsService from './services/groups';
 import loadAnnotationsService from './services/load-annotations';
 import { LocalStorageService } from './services/local-storage';
-import persistedDefaultsService from './services/persisted-defaults';
+import { PersistedDefaultsService } from './services/persisted-defaults';
 import { RouterService } from './services/router';
 import serviceUrlService from './services/service-url';
 import sessionService from './services/session';
@@ -143,7 +145,7 @@ function startApp(config, appEl) {
     .register('groups', groupsService)
     .register('loadAnnotationsService', loadAnnotationsService)
     .register('localStorage', LocalStorageService)
-    .register('persistedDefaults', persistedDefaultsService)
+    .register('persistedDefaults', PersistedDefaultsService)
     .register('router', RouterService)
     .register('serviceUrl', serviceUrlService)
     .register('session', sessionService)

--- a/src/sidebar/services/persisted-defaults.js
+++ b/src/sidebar/services/persisted-defaults.js
@@ -1,52 +1,59 @@
 import { watch } from '../util/watch';
 
-/**
- * A service for reading and persisting convenient client-side defaults for
- * the (browser) user.
- */
-
 const DEFAULT_KEYS = {
   annotationPrivacy: 'hypothesis.privacy',
   focusedGroup: 'hypothesis.groups.focus',
 };
 
 /**
- * @param {import('./local-storage').LocalStorageService} localStorage
- * @param {import('../store').SidebarStore} store
+ * A service for reading and persisting convenient client-side defaults for
+ * the (browser) user.
+ *
+ * @inject
  */
-// @inject
-export default function persistedDefaults(localStorage, store) {
+export class PersistedDefaultsService {
   /**
-   * Store subscribe callback for persisting changes to defaults. It will only
-   * persist defaults that it "knows about" via `DEFAULT_KEYS`.
+   * @param {import('./local-storage').LocalStorageService} localStorage
+   * @param {import('../store').SidebarStore} store
    */
-  function persistChangedDefaults(defaults, prevDefaults) {
-    for (let defaultKey in defaults) {
-      if (
-        prevDefaults[defaultKey] !== defaults[defaultKey] &&
-        defaultKey in DEFAULT_KEYS
-      ) {
-        localStorage.setItem(DEFAULT_KEYS[defaultKey], defaults[defaultKey]);
-      }
-    }
+  constructor(localStorage, store) {
+    this._storage = localStorage;
+    this._store = store;
   }
 
-  return {
+  /**
+   * Initially populate the store with any available persisted defaults,
+   * then subscribe to the store in order to persist any changes to
+   * those defaults.
+   */
+  init() {
     /**
-     * Initially populate the store with any available persisted defaults,
-     * then subscribe to the store in order to persist any changes to
-     * those defaults.
+     * Store subscribe callback for persisting changes to defaults. It will only
+     * persist defaults that it "knows about" via `DEFAULT_KEYS`.
      */
-    init() {
-      // Read persisted defaults into the store
-      Object.keys(DEFAULT_KEYS).forEach(defaultKey => {
-        // `localStorage.getItem` will return `null` for a non-existent key
-        const defaultValue = localStorage.getItem(DEFAULT_KEYS[defaultKey]);
-        store.setDefault(defaultKey, defaultValue);
-      });
+    const persistChangedDefaults = (defaults, prevDefaults) => {
+      for (let defaultKey in defaults) {
+        if (
+          prevDefaults[defaultKey] !== defaults[defaultKey] &&
+          defaultKey in DEFAULT_KEYS
+        ) {
+          this._storage.setItem(DEFAULT_KEYS[defaultKey], defaults[defaultKey]);
+        }
+      }
+    };
 
-      // Listen for changes to those defaults from the store and persist them
-      watch(store.subscribe, () => store.getDefaults(), persistChangedDefaults);
-    },
-  };
+    // Read persisted defaults into the store
+    Object.keys(DEFAULT_KEYS).forEach(defaultKey => {
+      // `localStorage.getItem` will return `null` for a non-existent key
+      const defaultValue = this._storage.getItem(DEFAULT_KEYS[defaultKey]);
+      this._store.setDefault(defaultKey, defaultValue);
+    });
+
+    // Listen for changes to those defaults from the store and persist them
+    watch(
+      this._store.subscribe,
+      () => this._store.getDefaults(),
+      persistChangedDefaults
+    );
+  }
 }

--- a/src/sidebar/services/test/autosave-test.js
+++ b/src/sidebar/services/test/autosave-test.js
@@ -2,9 +2,9 @@ import * as annotationFixtures from '../../test/annotation-fixtures';
 import createFakeStore from '../../test/fake-redux-store';
 import { waitFor } from '../../../test-util/wait';
 
-import autosaveService, { $imports } from '../autosave';
+import { AutosaveService, $imports } from '../autosave';
 
-describe('autosaveService', () => {
+describe('AutosaveService', () => {
   let fakeAnnotationsService;
   let fakeNewHighlights;
   let fakeRetryPromiseOperation;
@@ -33,12 +33,15 @@ describe('autosaveService', () => {
     return newHighlight;
   };
 
+  const createService = () =>
+    new AutosaveService(fakeAnnotationsService, fakeStore);
+
   afterEach(() => {
     $imports.$restore();
   });
 
   it('should subscribe to store updates and check for new highlights', () => {
-    const svc = autosaveService(fakeAnnotationsService, fakeStore);
+    const svc = createService();
     svc.init();
 
     fakeStore.setState({});
@@ -47,7 +50,7 @@ describe('autosaveService', () => {
   });
 
   it('should save new highlights', () => {
-    const svc = autosaveService(fakeAnnotationsService, fakeStore);
+    const svc = createService();
     svc.init();
     const newHighlight = oneNewHighlight();
 
@@ -58,7 +61,7 @@ describe('autosaveService', () => {
   });
 
   it('should not try to save a highlight that is already being saved', () => {
-    const svc = autosaveService(fakeAnnotationsService, fakeStore);
+    const svc = createService();
     svc.init();
 
     oneNewHighlight();
@@ -72,7 +75,7 @@ describe('autosaveService', () => {
 
   it('should not retry a highlight that failed to save', async () => {
     fakeAnnotationsService.save.rejects(new Error('Something went wrong'));
-    const svc = autosaveService(fakeAnnotationsService, fakeStore);
+    const svc = createService();
     svc.init();
 
     oneNewHighlight();

--- a/src/sidebar/services/test/persisted-defaults-test.js
+++ b/src/sidebar/services/test/persisted-defaults-test.js
@@ -1,12 +1,12 @@
 import fakeReduxStore from '../../test/fake-redux-store';
-import persistedDefaults from '../persisted-defaults';
+import { PersistedDefaultsService } from '../persisted-defaults';
 
 const DEFAULT_KEYS = {
   annotationPrivacy: 'hypothesis.privacy',
   focusedGroup: 'hypothesis.groups.focus',
 };
 
-describe('sidebar/services/persisted-defaults', function () {
+describe('PersistedDefaultsService', () => {
   let fakeLocalStorage;
   let fakeGetItem;
   let fakeSetItem;
@@ -36,9 +36,13 @@ describe('sidebar/services/persisted-defaults', function () {
     };
   });
 
+  function createService() {
+    return new PersistedDefaultsService(fakeLocalStorage, fakeStore);
+  }
+
   describe('#init', () => {
     it('should retrieve persisted defaults from `localStorage`', () => {
-      const svc = persistedDefaults(fakeLocalStorage, fakeStore);
+      const svc = createService();
 
       svc.init();
 
@@ -55,7 +59,7 @@ describe('sidebar/services/persisted-defaults', function () {
 
     it('should set defaults on the store with the values returned by `localStorage`', () => {
       fakeLocalStorage.getItem.returns('bananas');
-      const svc = persistedDefaults(fakeLocalStorage, fakeStore);
+      const svc = createService();
 
       svc.init();
 
@@ -66,7 +70,7 @@ describe('sidebar/services/persisted-defaults', function () {
 
     it('should set default to `null` if key non-existent in storage', () => {
       fakeLocalStorage.getItem.returns(null);
-      const svc = persistedDefaults(fakeLocalStorage, fakeStore);
+      const svc = createService();
 
       svc.init();
 
@@ -77,7 +81,7 @@ describe('sidebar/services/persisted-defaults', function () {
 
     context('when defaults change in the store', () => {
       it('should persist changes to a known default', () => {
-        const svc = persistedDefaults(fakeLocalStorage, fakeStore);
+        const svc = createService();
         svc.init();
 
         const updatedDefaults = { annotationPrivacy: 'carrots' };
@@ -94,7 +98,7 @@ describe('sidebar/services/persisted-defaults', function () {
       });
 
       it('should persist subsequent changes to known defaults', () => {
-        const svc = persistedDefaults(fakeLocalStorage, fakeStore);
+        const svc = createService();
         svc.init();
 
         const updatedDefaults = { annotationPrivacy: 'carrots' };
@@ -123,7 +127,7 @@ describe('sidebar/services/persisted-defaults', function () {
         fakeLocalStorage.getItem.returns('carrots');
         fakeStore.getDefaults.returns(defaults);
         fakeStore.setState({ defaults: defaults });
-        const svc = persistedDefaults(fakeLocalStorage, fakeStore);
+        const svc = createService();
         svc.init();
 
         fakeStore.getDefaults.returns(defaults);
@@ -133,7 +137,7 @@ describe('sidebar/services/persisted-defaults', function () {
       });
 
       it('should not persist changes for default keys it is unaware of', () => {
-        const svc = persistedDefaults(fakeLocalStorage, fakeStore);
+        const svc = createService();
         svc.init();
 
         fakeStore.getDefaults.returns({ foople: 'grapefruit' });


### PR DESCRIPTION
This is a straightforward conversion of the `autosave` and `persistedDefaults` services to ES classes.

There are no significant changes to the APIs or internals.

Part of https://github.com/hypothesis/client/issues/3298