### PR TITLE
Refactor AuthService internals and rename `tokenGetter` to `getAccessToken`

### DIFF
--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -210,7 +210,7 @@ export default function api(apiRoutes, auth, store) {
 
   function apiCall(route) {
     return createAPICall(links, route, {
-      getAccessToken: auth.tokenGetter,
+      getAccessToken: auth.getAccessToken,
       getClientId,
       onRequestStarted: store.apiRequestStarted,
       onRequestFinished: store.apiRequestFinished,

--- a/src/sidebar/services/auth.js
+++ b/src/sidebar/services/auth.js
@@ -208,7 +208,7 @@ export class AuthService extends TinyEmitter {
       // Determine how to get an access token, depending on the login method being used.
       if (!tokenInfoPromise) {
         const grantToken = getGrantToken();
-        if (typeof grantToken !== 'undefined') {
+        if (grantToken !== undefined) {
           if (grantToken) {
             // User is logged-in on the publisher's website.
             // Exchange the grant token for a new access token.

--- a/src/sidebar/services/auth.js
+++ b/src/sidebar/services/auth.js
@@ -16,7 +16,7 @@ import { resolve } from '../util/url';
  * Authorization service.
  *
  * This service is responsible for acquiring access tokens for making API
- * requests and making them available via the `tokenGetter()` method.
+ * requests and making them available via the `getAccessToken()` method.
  *
  * Access tokens are acquired via the OAuth authorization flow, loading valid
  * tokens from a previous session or, on some websites, by exchanging a grant
@@ -124,7 +124,7 @@ export class AuthService extends TinyEmitter {
       $window.addEventListener('storage', ({ key }) => {
         if (key === storageKey()) {
           // Reset cached token information. Tokens will be reloaded from storage
-          // on the next call to `tokenGetter()`.
+          // on the next call to `getAccessToken()`.
           tokenInfoPromise = null;
           this.emit('oauthTokensChanged');
         }
@@ -196,7 +196,7 @@ export class AuthService extends TinyEmitter {
      *
      * @return {Promise<string|null>} The API access token or `null` if not logged in.
      */
-    const tokenGetter = async () => {
+    const getAccessToken = async () => {
       // Step 1: Determine how to get an access token, depending on the login
       // method being used.
       if (!tokenInfoPromise) {
@@ -239,8 +239,8 @@ export class AuthService extends TinyEmitter {
       // Step 3: Re-fetch the token if it is no longer valid
       if (origToken !== tokenInfoPromise) {
         // A token refresh has been initiated via a call to `refreshAccessToken`
-        // below since `tokenGetter()` was called.
-        return tokenGetter();
+        // below since `getAccessToken()` was called.
+        return getAccessToken();
       }
 
       if (Date.now() > token.expiresAt) {
@@ -254,7 +254,7 @@ export class AuthService extends TinyEmitter {
           persist: !usingGrantToken,
         });
 
-        return tokenGetter();
+        return getAccessToken();
       }
 
       // Step 4: If the token was valid, return it
@@ -305,6 +305,6 @@ export class AuthService extends TinyEmitter {
     // TODO - Convert these to ordinary class methods.
     this.login = login;
     this.logout = logout;
-    this.tokenGetter = tokenGetter;
+    this.getAccessToken = getAccessToken;
   }
 }

--- a/src/sidebar/services/auth.js
+++ b/src/sidebar/services/auth.js
@@ -162,6 +162,20 @@ export class AuthService extends TinyEmitter {
     };
 
     /**
+     * Exchange authorization code retrieved from login popup for a new
+     * access token.
+     */
+    const exchangeAuthCodeForToken = async () => {
+      const code = /** @type {string} */ (authCode);
+      authCode = null; // Auth codes can only be used once.
+
+      const client = await oauthClient();
+      const tokenInfo = await client.exchangeAuthCode(code);
+      saveToken(tokenInfo);
+      return tokenInfo;
+    };
+
+    /**
      * Retrieve an access token for the API.
      *
      * @return {Promise<string|null>} The API access token or `null` if not logged in.
@@ -189,16 +203,7 @@ export class AuthService extends TinyEmitter {
             tokenInfoPromise = Promise.resolve(null);
           }
         } else if (authCode) {
-          // Exchange authorization code retrieved from login popup for a new
-          // access token.
-          const code = authCode;
-          authCode = null; // Auth codes can only be used once.
-          tokenInfoPromise = oauthClient()
-            .then(client => client.exchangeAuthCode(code))
-            .then(tokenInfo => {
-              saveToken(tokenInfo);
-              return tokenInfo;
-            });
+          tokenInfoPromise = exchangeAuthCodeForToken();
         } else {
           // Attempt to load the tokens from the previous session.
           tokenInfoPromise = Promise.resolve(loadToken());

--- a/src/sidebar/services/auth.js
+++ b/src/sidebar/services/auth.js
@@ -238,8 +238,8 @@ export class AuthService extends TinyEmitter {
 
       // Step 3: Re-fetch the token if it is no longer valid
       if (origToken !== tokenInfoPromise) {
-        // A token refresh has been initiated via a call to `refreshAccessToken`
-        // below since `getAccessToken()` was called.
+        // The token source was changed while waiting for the token to be fetched.
+        // This can happen for various reasons. We'll just need to try again.
         return getAccessToken();
       }
 

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -281,7 +281,7 @@ export default function groups(
     ] = await Promise.all([
       api.profile.groups.read({ expand: expandParam }),
       api.groups.list(listParams),
-      auth.tokenGetter(),
+      auth.getAccessToken(),
       directLinkedAnnApi,
       directLinkedGroupApi,
     ]);

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -125,7 +125,7 @@ export default function Streamer(store, auth, groups, session, settings) {
     }
 
     return auth
-      .tokenGetter()
+      .getAccessToken()
       .then(function (token) {
         let url;
         if (token) {

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -65,7 +65,7 @@ describe('sidebar.services.api', function () {
       routes: sinon.stub().returns(Promise.resolve(routes)),
     };
     fakeAuth = {
-      tokenGetter: sinon.stub().returns(Promise.resolve('faketoken')),
+      getAccessToken: sinon.stub().returns(Promise.resolve('faketoken')),
     };
     fakeStore = {
       apiRequestStarted: sinon.stub(),
@@ -235,7 +235,7 @@ describe('sidebar.services.api', function () {
   });
 
   it('omits Authorization header if no access token is available', () => {
-    fakeAuth.tokenGetter.returns(Promise.resolve(null));
+    fakeAuth.getAccessToken.returns(Promise.resolve(null));
     expectCall('get', 'profile');
     return api.profile.read().then(() => {
       const [, options] = fetchMock.lastCall();

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -49,7 +49,7 @@ describe('sidebar/services/groups', function () {
 
   beforeEach(function () {
     fakeAuth = {
-      tokenGetter: sinon.stub().returns('1234'),
+      getAccessToken: sinon.stub().returns('1234'),
     };
 
     fakeMetadata = {
@@ -566,7 +566,7 @@ describe('sidebar/services/groups', function () {
       );
 
       // The user is logged out.
-      fakeAuth.tokenGetter.returns(null);
+      fakeAuth.getAccessToken.returns(null);
 
       return svc.load().then(groups => {
         const groupIds = groups.map(g => g.id);
@@ -630,7 +630,7 @@ describe('sidebar/services/groups', function () {
       );
 
       // The user is logged out.
-      fakeAuth.tokenGetter.returns(null);
+      fakeAuth.getAccessToken.returns(null);
 
       return svc.load().then(groups => {
         const linkedToGroupShown = groups.some(g => g.id === 'out-of-scope');
@@ -659,7 +659,7 @@ describe('sidebar/services/groups', function () {
         Promise.resolve({ name: 'Public', id: '__world__' })
       );
 
-      fakeAuth.tokenGetter.returns(null);
+      fakeAuth.getAccessToken.returns(null);
 
       return svc.load().then(groups => {
         const publicGroupShown = groups.some(g => g.id === '__world__');
@@ -693,7 +693,7 @@ describe('sidebar/services/groups', function () {
             groups.push({ name: 'BioPub', id: 'biopub' });
           }
 
-          fakeAuth.tokenGetter.returns(loggedIn ? '1234' : null);
+          fakeAuth.getAccessToken.returns(loggedIn ? '1234' : null);
           fakeApi.groups.list.returns(Promise.resolve(groups));
 
           return svc.load().then(groups => {

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -93,7 +93,7 @@ describe('Streamer', function () {
 
   beforeEach(function () {
     fakeAuth = {
-      tokenGetter: function () {
+      getAccessToken: function () {
         return Promise.resolve('dummy-access-token');
       },
     };
@@ -208,7 +208,7 @@ describe('Streamer', function () {
     });
 
     it('should not include credentials in the URL if the client has no access token', function () {
-      fakeAuth.tokenGetter = function () {
+      fakeAuth.getAccessToken = function () {
         return Promise.resolve(null);
       };
 


### PR DESCRIPTION
This PR renames AuthService's weirdly-named `tokenGetter` method [1] to the more obvious `getAccessToken` and simplifies some internals of AuthService by using modern syntax (Promise chains => async/await) and extracting some helper functions out of the long `getAccessToken` method (`getGrantToken`, `exchangeAuthCodeForToken`). There are no functional changes.

There is still a TODO at the bottom of the AuthService constructor about converting closures into normal class methods. I plan to address that separately. It turned out to be easier to do this cleanup first.

[1] From memory I think the name `tokenGetter` came from some Angular 1.x-related feature originally.