### PR TITLE
Reimplement service URL fetching

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationHeader.js
+++ b/src/sidebar/components/Annotation/AnnotationHeader.js
@@ -20,7 +20,6 @@ import AnnotationUser from './AnnotationUser';
 
 /**
  * @typedef {import("../../../types/api").Annotation} Annotation
- * @typedef {import('../../services/service-url').ServiceUrlGetter} ServiceUrlGetter
  * @typedef {import('../../../types/config').MergedConfig} MergedConfig
  */
 
@@ -30,7 +29,6 @@ import AnnotationUser from './AnnotationUser';
  * @prop {boolean} [isEditing] - Whether the annotation is actively being edited
  * @prop {number} replyCount - How many replies this annotation currently has
  * @prop {boolean} threadIsCollapsed - Is this thread currently collapsed?
- * @prop {ServiceUrlGetter} serviceUrl - Injected service
  * @prop {MergedConfig} settings - Injected
  *
  */
@@ -47,7 +45,6 @@ function AnnotationHeader({
   isEditing,
   replyCount,
   threadIsCollapsed,
-  serviceUrl,
   settings,
 }) {
   const store = useStoreProxy();
@@ -63,7 +60,7 @@ function AnnotationHeader({
 
   const authorLink = (() => {
     if (!isThirdParty) {
-      return serviceUrl('user', { user: annotation.user });
+      return store.getLink('user', { user: annotation.user });
     } else {
       return (
         (settings.usernameUrl &&
@@ -174,6 +171,6 @@ function AnnotationHeader({
   );
 }
 
-AnnotationHeader.injectedProps = ['serviceUrl', 'settings'];
+AnnotationHeader.injectedProps = ['settings'];
 
 export default withServices(AnnotationHeader);

--- a/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
@@ -15,7 +15,6 @@ describe('AnnotationHeader', () => {
   let fakeIsReply;
   let fakeHasBeenEdited;
   let fakeIsPrivate;
-  let fakeServiceUrl;
   let fakeSettings;
   let fakeStore;
 
@@ -26,7 +25,6 @@ describe('AnnotationHeader', () => {
         isEditing={false}
         replyCount={0}
         threadIsCollapsed={false}
-        serviceUrl={fakeServiceUrl}
         settings={fakeSettings}
         {...props}
       />
@@ -47,11 +45,11 @@ describe('AnnotationHeader', () => {
 
     fakeAnnotationDisplayName = sinon.stub().returns('Robbie Burns');
 
-    fakeServiceUrl = sinon.stub().returns('http://example.com');
     fakeSettings = { usernameUrl: 'http://foo.bar/' };
 
     fakeStore = {
       defaultAuthority: sinon.stub().returns('foo.com'),
+      getLink: sinon.stub().returns('http://example.com'),
       isFeatureEnabled: sinon.stub().returns(false),
       route: sinon.stub().returns('sidebar'),
       setExpanded: sinon.stub(),

--- a/src/sidebar/components/GroupList/GroupList.js
+++ b/src/sidebar/components/GroupList/GroupList.js
@@ -16,7 +16,6 @@ import GroupListSection from './GroupListSection';
 /**
  * @typedef {import('../../../types/config').MergedConfig} MergedConfig
  * @typedef {import('../../../types/api').Group} Group
- * @typedef {import('../../services/service-url').ServiceUrlGetter} ServiceUrlGetter
  */
 
 /**
@@ -30,7 +29,6 @@ function publisherProvidedIcon(settings) {
 
 /**
  * @typedef GroupListProps
- * @prop {ServiceUrlGetter} serviceUrl
  * @prop {MergedConfig} settings
  */
 
@@ -40,7 +38,7 @@ function publisherProvidedIcon(settings) {
  *
  * @param {GroupListProps} props
  */
-function GroupList({ serviceUrl, settings }) {
+function GroupList({ settings }) {
   const store = useStoreProxy();
   const currentGroups = store.getCurrentlyViewingGroups();
   const featuredGroups = store.getFeaturedGroups();
@@ -65,7 +63,7 @@ function GroupList({ serviceUrl, settings }) {
   const defaultAuthority = store.defaultAuthority();
   const canCreateNewGroup =
     userid && !isThirdPartyUser(userid, defaultAuthority);
-  const newGroupLink = serviceUrl('groups.new');
+  const newGroupLink = store.getLink('groups.new');
 
   // The group whose submenu is currently open, or `null` if no group item is
   // currently expanded.
@@ -150,6 +148,6 @@ function GroupList({ serviceUrl, settings }) {
   );
 }
 
-GroupList.injectedProps = ['serviceUrl', 'settings'];
+GroupList.injectedProps = ['settings'];
 
 export default withServices(GroupList);

--- a/src/sidebar/components/GroupList/test/GroupList-test.js
+++ b/src/sidebar/components/GroupList/test/GroupList-test.js
@@ -7,15 +7,12 @@ import mockImportedComponents from '../../../../test-util/mock-imported-componen
 
 describe('GroupList', () => {
   let fakeServiceConfig;
-  let fakeServiceUrl;
   let fakeSettings;
   let fakeStore;
   let testGroup;
 
   function createGroupList() {
-    return mount(
-      <GroupList serviceUrl={fakeServiceUrl} settings={fakeSettings} />
-    );
+    return mount(<GroupList settings={fakeSettings} />);
   }
 
   /**
@@ -46,12 +43,12 @@ describe('GroupList', () => {
       organization: { id: 'testorg', name: 'Test Org' },
     };
 
-    fakeServiceUrl = sinon.stub();
     fakeSettings = {};
     fakeStore = {
       defaultAuthority: sinon.stub().returns('hypothes.is'),
       getCurrentlyViewingGroups: sinon.stub().returns([]),
       getFeaturedGroups: sinon.stub().returns([]),
+      getLink: sinon.stub().returns(''),
       getMyGroups: sinon.stub().returns([]),
       focusedGroup: sinon.stub().returns(testGroup),
       profile: sinon.stub().returns({ userid: null }),
@@ -156,7 +153,7 @@ describe('GroupList', () => {
   });
 
   it('opens new window at correct URL when "New private group" is clicked', () => {
-    fakeServiceUrl
+    fakeStore.getLink
       .withArgs('groups.new')
       .returns('https://example.com/groups/new');
     fakeStore.profile.returns({ userid: 'jsmith@hypothes.is' });

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -22,7 +22,6 @@ import TopBar from './TopBar';
 
 /**
  * @typedef {import('../../types/api').Profile} Profile
- * @typedef {import('../services/service-url').ServiceUrlGetter} ServiceUrlGetter
  * @typedef {import('../../types/config').MergedConfig} MergedConfig
  * @typedef {import('../../shared/bridge').default} Bridge
  */
@@ -55,7 +54,6 @@ function authStateFromProfile(profile) {
  * @typedef HypothesisAppProps
  * @prop {import('../services/auth').AuthService} auth
  * @prop {Bridge} bridge
- * @prop {ServiceUrlGetter} serviceUrl
  * @prop {MergedConfig} settings
  * @prop {Object} session
  * @prop {import('../services/toast-messenger').ToastMessengerService} toastMessenger
@@ -69,14 +67,7 @@ function authStateFromProfile(profile) {
  *
  * @param {HypothesisAppProps} props
  */
-function HypothesisApp({
-  auth,
-  bridge,
-  serviceUrl,
-  settings,
-  session,
-  toastMessenger,
-}) {
+function HypothesisApp({ auth, bridge, settings, session, toastMessenger }) {
   const store = useStoreProxy();
   const hasFetchedProfile = store.hasFetchedProfile();
   const profile = store.profile();
@@ -127,7 +118,7 @@ function HypothesisApp({
       bridge.call(bridgeEvents.SIGNUP_REQUESTED);
       return;
     }
-    window.open(serviceUrl('signup'));
+    window.open(store.getLink('signup'));
   };
 
   const promptToLogout = async () => {
@@ -211,7 +202,6 @@ function HypothesisApp({
 HypothesisApp.injectedProps = [
   'auth',
   'bridge',
-  'serviceUrl',
   'session',
   'settings',
   'toastMessenger',

--- a/src/sidebar/components/LoggedOutMessage.js
+++ b/src/sidebar/components/LoggedOutMessage.js
@@ -1,13 +1,10 @@
 import { LinkButton, SvgIcon } from '@hypothesis/frontend-shared';
 
-import { withServices } from '../service-context';
-
-/** @typedef {import('../services/service-url').ServiceUrlGetter} ServiceUrlGetter */
+import { useStoreProxy } from '../store/use-store';
 
 /**
  * @typedef LoggedOutMessageProps
  * @prop {() => any} onLogin
- * @prop {ServiceUrlGetter} serviceUrl
  */
 
 /**
@@ -17,7 +14,9 @@ import { withServices } from '../service-context';
  *
  * @param {LoggedOutMessageProps} props
  */
-function LoggedOutMessage({ onLogin, serviceUrl }) {
+function LoggedOutMessage({ onLogin }) {
+  const store = useStoreProxy();
+
   return (
     <div className="LoggedOutMessage">
       <span>
@@ -25,7 +24,7 @@ function LoggedOutMessage({ onLogin, serviceUrl }) {
         To reply or make your own annotations on this document,{' '}
         <a
           className="LoggedOutMessage__link"
-          href={serviceUrl('signup')}
+          href={store.getLink('signup')}
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -54,6 +53,4 @@ function LoggedOutMessage({ onLogin, serviceUrl }) {
   );
 }
 
-LoggedOutMessage.injectedProps = ['serviceUrl'];
-
-export default withServices(LoggedOutMessage);
+export default LoggedOutMessage;

--- a/src/sidebar/components/TagList.js
+++ b/src/sidebar/components/TagList.js
@@ -2,7 +2,6 @@ import { useMemo } from 'preact/hooks';
 import { useStoreProxy } from '../store/use-store';
 
 import { isThirdPartyUser } from '../helpers/account-id';
-import { withServices } from '../service-context';
 
 /** @typedef {import('../../types/api').Annotation} Annotation */
 
@@ -10,14 +9,13 @@ import { withServices } from '../service-context';
  * @typedef TagListProps
  * @prop {Annotation} annotation - Annotation that owns the tags.
  * @prop {string[]} tags - List of tags as strings.
- * @prop {(a: string, b: Object<'tag', string>) => any} serviceUrl - Services
  */
 
 /**
  * Component to render an annotation's tags.
  * @param {TagListProps} props
  */
-function TagList({ annotation, serviceUrl, tags }) {
+function TagList({ annotation, tags }) {
   const store = useStoreProxy();
   const defaultAuthority = store.defaultAuthority();
   const renderLink = useMemo(
@@ -32,7 +30,7 @@ function TagList({ annotation, serviceUrl, tags }) {
    * @return {string}
    */
   const createTagSearchURL = tag => {
-    return serviceUrl('search.tag', { tag: tag });
+    return store.getLink('search.tag', { tag: tag });
   };
 
   return (
@@ -63,6 +61,4 @@ function TagList({ annotation, serviceUrl, tags }) {
   );
 }
 
-TagList.injectedProps = ['serviceUrl'];
-
-export default withServices(TagList);
+export default TagList;

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -12,7 +12,6 @@ import MenuItem from './MenuItem';
 import MenuSection from './MenuSection';
 
 /**
- * @typedef {import('../services/service-url').ServiceUrlGetter} ServiceUrlGetter
  * @typedef {import('../../types/config').MergedConfig} MergedConfig
  * /
 
@@ -28,7 +27,6 @@ import MenuSection from './MenuSection';
  * @prop {AuthState} auth - object representing authenticated user and auth status
  * @prop {() => any} onLogout - onClick callback for the "log out" button
  * @prop {Object} bridge
- * @prop {ServiceUrlGetter} serviceUrl
  * @prop {MergedConfig} settings
  */
 
@@ -40,7 +38,7 @@ import MenuSection from './MenuSection';
  *
  * @param {UserMenuProps} props
  */
-function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
+function UserMenu({ auth, bridge, onLogout, settings }) {
   const store = useStoreProxy();
   const defaultAuthority = store.defaultAuthority();
 
@@ -77,7 +75,7 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
     const props = {};
     if (isSelectableProfile) {
       if (!isThirdParty) {
-        props.href = serviceUrl('user', { user: auth.username });
+        props.href = store.getLink('user', { user: auth.username });
       }
       props.onClick = onProfileSelected;
     }
@@ -109,7 +107,7 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
           {!isThirdParty && (
             <MenuItem
               label="Account settings"
-              href={serviceUrl('account.settings')}
+              href={store.getLink('account.settings')}
             />
           )}
           {isNotebookEnabled && (
@@ -129,6 +127,6 @@ function UserMenu({ auth, bridge, onLogout, serviceUrl, settings }) {
   );
 }
 
-UserMenu.injectedProps = ['bridge', 'serviceUrl', 'settings'];
+UserMenu.injectedProps = ['bridge', 'settings'];
 
 export default withServices(UserMenu);

--- a/src/sidebar/components/test/HypothesisApp-test.js
+++ b/src/sidebar/components/test/HypothesisApp-test.js
@@ -14,7 +14,6 @@ describe('HypothesisApp', () => {
   let fakeServiceConfig = null;
   let fakeSession = null;
   let fakeShouldAutoDisplayTutorial = null;
-  let fakeServiceUrl = null;
   let fakeSettings = null;
   let fakeToastMessenger = null;
 
@@ -23,7 +22,6 @@ describe('HypothesisApp', () => {
       <HypothesisApp
         auth={fakeAuth}
         bridge={fakeBridge}
-        serviceUrl={fakeServiceUrl}
         settings={fakeSettings}
         session={fakeSession}
         toastMessenger={fakeToastMessenger}
@@ -55,6 +53,8 @@ describe('HypothesisApp', () => {
         },
       }),
       route: sinon.stub().returns('sidebar'),
+
+      getLink: sinon.stub(),
     };
 
     fakeAuth = {};
@@ -64,8 +64,6 @@ describe('HypothesisApp', () => {
       logout: sinon.stub(),
       reload: sinon.stub().returns(Promise.resolve({ userid: null })),
     };
-
-    fakeServiceUrl = sinon.stub();
 
     fakeSettings = {};
 
@@ -244,7 +242,9 @@ describe('HypothesisApp', () => {
 
     context('when not using a third-party service', () => {
       it('opens the signup URL in a new tab', () => {
-        fakeServiceUrl.withArgs('signup').returns('https://ann.service/signup');
+        fakeStore.getLink
+          .withArgs('signup')
+          .returns('https://ann.service/signup');
         const wrapper = createComponent();
         clickSignUp(wrapper);
         assert.calledWith(window.open, 'https://ann.service/signup');

--- a/src/sidebar/components/test/LoggedOutMessage-test.js
+++ b/src/sidebar/components/test/LoggedOutMessage-test.js
@@ -7,18 +7,21 @@ import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
 describe('LoggedOutMessage', () => {
+  let fakeStore;
+
   const createLoggedOutMessage = props => {
-    return mount(
-      <LoggedOutMessage
-        onLogin={sinon.stub()}
-        serviceUrl={sinon.stub()}
-        {...props}
-      />
-    );
+    return mount(<LoggedOutMessage onLogin={sinon.stub()} {...props} />);
   };
 
   beforeEach(() => {
+    fakeStore = {
+      getLink: sinon.stub().returns('signup_link'),
+    };
+
     $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      '../store/use-store': { useStoreProxy: () => fakeStore },
+    });
   });
 
   afterEach(() => {
@@ -26,12 +29,11 @@ describe('LoggedOutMessage', () => {
   });
 
   it('should link to signup', () => {
-    const fakeServiceUrl = sinon.stub().returns('signup_link');
-    const wrapper = createLoggedOutMessage({ serviceUrl: fakeServiceUrl });
+    const wrapper = createLoggedOutMessage();
 
     const signupLink = wrapper.find('.LoggedOutMessage__link').at(0);
 
-    assert.calledWith(fakeServiceUrl, 'signup');
+    assert.calledWith(fakeStore.getLink, 'signup');
     assert.equal(signupLink.prop('href'), 'signup_link');
   });
 

--- a/src/sidebar/components/test/TagList-test.js
+++ b/src/sidebar/components/test/TagList-test.js
@@ -7,30 +7,20 @@ import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
 describe('TagList', () => {
-  let fakeServiceUrl;
   let fakeIsThirdPartyUser;
   let fakeStore;
   const fakeTags = ['tag1', 'tag2'];
 
   function createComponent(props) {
-    return mount(
-      <TagList
-        // props
-        annotation={{}}
-        tags={fakeTags}
-        // service props
-        serviceUrl={fakeServiceUrl}
-        {...props}
-      />
-    );
+    return mount(<TagList annotation={{}} tags={fakeTags} {...props} />);
   }
 
   beforeEach(() => {
-    fakeServiceUrl = sinon.stub().returns('http://serviceurl.com');
     fakeIsThirdPartyUser = sinon.stub().returns(false);
 
     fakeStore = {
       defaultAuthority: sinon.stub().returns('hypothes.is'),
+      getLink: sinon.stub().returns('http://serviceurl.com'),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -66,10 +56,10 @@ describe('TagList', () => {
       });
     });
 
-    it('calls fakeServiceUrl()', () => {
+    it('gets the links for tags', () => {
       createComponent();
-      assert.calledWith(fakeServiceUrl, 'search.tag', { tag: 'tag1' });
-      assert.calledWith(fakeServiceUrl, 'search.tag', { tag: 'tag2' });
+      assert.calledWith(fakeStore.getLink, 'search.tag', { tag: 'tag1' });
+      assert.calledWith(fakeStore.getLink, 'search.tag', { tag: 'tag2' });
     });
   });
 
@@ -87,9 +77,9 @@ describe('TagList', () => {
       });
     });
 
-    it('does not call fakeServiceUrl()', () => {
+    it('does not fetch tag link', () => {
       createComponent();
-      assert.notCalled(fakeServiceUrl);
+      assert.notCalled(fakeStore.getLink);
     });
   });
 

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -13,7 +13,6 @@ describe('UserMenu', () => {
   let fakeIsThirdPartyUser;
   let fakeOnLogout;
   let fakeServiceConfig;
-  let fakeServiceUrl;
   let fakeSettings;
   let fakeStore;
 
@@ -23,7 +22,6 @@ describe('UserMenu', () => {
         auth={fakeAuth}
         bridge={fakeBridge}
         onLogout={fakeOnLogout}
-        serviceUrl={fakeServiceUrl}
         settings={fakeSettings}
       />
     );
@@ -46,11 +44,11 @@ describe('UserMenu', () => {
     fakeIsThirdPartyUser = sinon.stub();
     fakeOnLogout = sinon.stub();
     fakeServiceConfig = sinon.stub();
-    fakeServiceUrl = sinon.stub();
     fakeSettings = {};
     fakeStore = {
       defaultAuthority: sinon.stub().returns('hypothes.is'),
       focusedGroupId: sinon.stub().returns('mygroup'),
+      getLink: sinon.stub(),
       isFeatureEnabled: sinon.stub().returns(false),
     };
 
@@ -72,7 +70,7 @@ describe('UserMenu', () => {
     context('first-party user', () => {
       beforeEach(() => {
         fakeIsThirdPartyUser.returns(false);
-        fakeServiceUrl.returns('profile-link');
+        fakeStore.getLink.returns('profile-link');
       });
 
       it('should be enabled', () => {
@@ -174,7 +172,7 @@ describe('UserMenu', () => {
 
       const accountMenuItem = findMenuItem(wrapper, 'Account settings');
       assert.isTrue(accountMenuItem.exists());
-      assert.calledWith(fakeServiceUrl, 'account.settings');
+      assert.calledWith(fakeStore.getLink, 'account.settings');
     });
 
     it('should not be present if third-party user', () => {

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -65,12 +65,19 @@ function setupRoute(groups, session, router) {
  * @param {import('./services/autosave').AutosaveService} autosaveService
  * @param {import('./services/features').FeaturesService} features
  * @param {import('./services/persisted-defaults').PersistedDefaultsService} persistedDefaults
+ * @param {import('./services/service-url').ServiceURLService} serviceURL
  * @inject
  */
-function initServices(autosaveService, features, persistedDefaults) {
+function initServices(
+  autosaveService,
+  features,
+  persistedDefaults,
+  serviceURL
+) {
   autosaveService.init();
   features.init();
   persistedDefaults.init();
+  serviceURL.init();
 }
 
 // @inject
@@ -107,7 +114,7 @@ import loadAnnotationsService from './services/load-annotations';
 import { LocalStorageService } from './services/local-storage';
 import { PersistedDefaultsService } from './services/persisted-defaults';
 import { RouterService } from './services/router';
-import serviceUrlService from './services/service-url';
+import { ServiceURLService } from './services/service-url';
 import sessionService from './services/session';
 import { StreamFilter } from './services/stream-filter';
 import streamerService from './services/streamer';
@@ -145,7 +152,7 @@ function startApp(config, appEl) {
     .register('localStorage', LocalStorageService)
     .register('persistedDefaults', PersistedDefaultsService)
     .register('router', RouterService)
-    .register('serviceUrl', serviceUrlService)
+    .register('serviceURL', ServiceURLService)
     .register('session', sessionService)
     .register('streamer', streamerService)
     .register('streamFilter', StreamFilter)

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -122,7 +122,7 @@ function createAPICall(
           headers['X-Client-Id'] = clientId;
         }
 
-        const { url, params: queryParams } = replaceURLParams(
+        const { url, unusedParams: queryParams } = replaceURLParams(
           descriptor.url,
           params
         );

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -29,7 +29,6 @@ const DEFAULT_ORGANIZATION = {
 export default function groups(
   store,
   api,
-  serviceUrl,
   session,
   settings,
   toastMessenger,

--- a/src/sidebar/services/service-url.js
+++ b/src/sidebar/services/service-url.js
@@ -1,71 +1,34 @@
-import * as urlUtil from '../util/url';
-
 /**
- * A function that returns an absolute URL given a link name and params, by
- * expanding named URL templates received from the annotation service's API.
+ * Service for fetching the data needed to render URLs that point to the H
+ * service.
  *
- * The links object from the API is a map of link names to URL templates:
+ * The H API has an `/api/links` endpoint that returns a map of link name to
+ * URL template for URLs that point to the H API. This service fetches that
+ * data and persists it in the store.
  *
- * {
- *   signup: "http://localhost:5000/signup",
- *   user: "http://localhost:5000/u/:user",
- *   ...
- * }
+ * To use a link within a UI component, use `store.getLink(name, params)`.
  *
- * Given a link name (e.g. 'user') and params (e.g. {user: 'bob'}) return
- * an absolute URL by expanding the named URL template from the API with the
- * given params (e.g. "http://localhost:5000/u/bob").
- *
- * Before the links object has been received from the API this function
- * always returns empty strings as the URLs. After the links object has been
- * received from the API this function starts returning the real URLs.
- *
- * @callback ServiceUrlGetter
- * @param {string} linkName - The name of the link to expand
- * @param {object} [params] - The params with which to expand the link
- * @returns {string} The expanded absolute URL, or an empty string if the
- *                   links haven't been received from the API yet
- * @throws {Error} If the links have been received from the API but the given
- *                 linkName is unknown
- * @throws {Error} If one or more of the params given isn't used in the URL
- *                 template
- */
-
-/**
- * @param {import('../store').SidebarStore} store
- * @param {import('./api-routes').APIRoutesService} apiRoutes
- * @return {ServiceUrlGetter}
  * @inject
  */
-export default function serviceUrl(store, apiRoutes) {
-  apiRoutes
-    .links()
-    .then(store.updateLinks)
-    .catch(function (error) {
-      console.warn('The links API request was rejected: ' + error.message);
-    });
+export class ServiceURLService {
+  /**
+   * @param {import('./api-routes').APIRoutesService} apiRoutes
+   * @param {import('../store').SidebarStore} store
+   */
+  constructor(apiRoutes, store) {
+    this._apiRoutes = apiRoutes;
+    this._store = store;
+  }
 
-  return function (linkName, params) {
-    const links = store.getState().links;
-
-    if (links === null) {
-      return '';
+  /**
+   * Fetch URL templates for links from the API and persist them in the store.
+   */
+  async init() {
+    try {
+      const links = await this._apiRoutes.links();
+      this._store.updateLinks(links);
+    } catch (error) {
+      console.warn('Failed to fetch Hypothesis links: ' + error.message);
     }
-
-    const path = links[linkName];
-
-    if (!path) {
-      throw new Error('Unknown link ' + linkName);
-    }
-
-    params = params || {};
-    const url = urlUtil.replaceURLParams(path, params);
-
-    const unused = Object.keys(url.params);
-    if (unused.length > 0) {
-      throw new Error('Unknown link parameters: ' + unused.join(', '));
-    }
-
-    return url.url;
-  };
+  }
 }

--- a/src/sidebar/services/service-url.js
+++ b/src/sidebar/services/service-url.js
@@ -28,7 +28,7 @@ export class ServiceURLService {
       const links = await this._apiRoutes.links();
       this._store.updateLinks(links);
     } catch (error) {
-      console.warn('Failed to fetch Hypothesis links: ' + error.message);
+      console.warn(`Failed to fetch Hypothesis links: ${error.message}`);
     }
   }
 }

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -43,7 +43,6 @@ describe('sidebar/services/groups', function () {
   let fakeSession;
   let fakeSettings;
   let fakeApi;
-  let fakeServiceUrl;
   let fakeMetadata;
   let fakeToastMessenger;
 
@@ -120,7 +119,6 @@ describe('sidebar/services/groups', function () {
         },
       },
     };
-    fakeServiceUrl = sinon.stub();
     fakeSettings = { group: null };
 
     $imports.$mock({
@@ -136,7 +134,6 @@ describe('sidebar/services/groups', function () {
     return groups(
       fakeStore,
       fakeApi,
-      fakeServiceUrl,
       fakeSession,
       fakeSettings,
       fakeToastMessenger,

--- a/src/sidebar/services/test/service-url-test.js
+++ b/src/sidebar/services/test/service-url-test.js
@@ -1,164 +1,48 @@
-import serviceUrlFactory from '../service-url';
-import { $imports } from '../service-url';
+import { ServiceURLService } from '../service-url';
 
-/** Return a fake store object. */
-function fakeStore() {
-  let links = null;
-  return {
-    updateLinks: function (newLinks) {
-      links = newLinks;
-    },
-    getState: function () {
-      return { links: links };
-    },
-  };
-}
+const links = {
+  'account.settings': 'https://hypothes.is/account/settings',
+};
 
-function createServiceUrl(linksPromise) {
-  const replaceURLParams = sinon
-    .stub()
-    .returns({ url: 'EXPANDED_URL', params: {} });
+describe('ServiceURLService', () => {
+  let fakeStore;
+  let fakeAPIRoutes;
 
-  $imports.$mock({
-    '../util/url': { replaceURLParams: replaceURLParams },
-  });
+  beforeEach(() => {
+    fakeStore = {
+      updateLinks: sinon.stub(),
+    };
+    fakeAPIRoutes = {
+      links: sinon.stub().resolves(links),
+    };
 
-  const store = fakeStore();
-
-  const apiRoutes = {
-    links: sinon.stub().returns(linksPromise),
-  };
-
-  return {
-    store: store,
-    apiRoutes,
-    serviceUrl: serviceUrlFactory(store, apiRoutes),
-    replaceURLParams: replaceURLParams,
-  };
-}
-
-describe('sidebar.service-url', function () {
-  beforeEach(function () {
     sinon.stub(console, 'warn');
   });
 
-  afterEach(function () {
+  afterEach(() => {
     console.warn.restore();
-    $imports.$restore();
   });
 
-  context('before the API response has been received', function () {
-    let serviceUrl;
-    let apiRoutes;
+  describe('#init', () => {
+    it('fetches links and updates store with response', async () => {
+      const service = new ServiceURLService(fakeAPIRoutes, fakeStore);
 
-    beforeEach(function () {
-      // Create a serviceUrl function with an unresolved Promise that will
-      // never be resolved - it never receives the links from store.links().
-      const parts = createServiceUrl(new Promise(function () {}));
+      await service.init();
 
-      serviceUrl = parts.serviceUrl;
-      apiRoutes = parts.apiRoutes;
+      assert.calledWith(fakeStore.updateLinks, links);
     });
 
-    it('sends one API request for the links at boot time', function () {
-      assert.calledOnce(apiRoutes.links);
-      assert.isTrue(apiRoutes.links.calledWithExactly());
-    });
+    it('logs a warning if links cannot be fetched', async () => {
+      fakeAPIRoutes.links.returns(Promise.reject(new Error('Fetch failed')));
+      const service = new ServiceURLService(fakeAPIRoutes, fakeStore);
 
-    it('returns an empty string for any link', function () {
-      assert.equal(serviceUrl('foo'), '');
-    });
+      await service.init();
 
-    it('returns an empty string even if link params are given', function () {
-      assert.equal(serviceUrl('foo', { bar: 'bar' }), '');
-    });
-  });
-
-  context('after the API response has been received', function () {
-    let store;
-    let linksPromise;
-    let replaceURLParams;
-    let serviceUrl;
-
-    beforeEach(function () {
-      // The links Promise that store.links() will return.
-      linksPromise = Promise.resolve({
-        first_link: 'http://example.com/first_page/:foo',
-        second_link: 'http://example.com/second_page',
-      });
-
-      const parts = createServiceUrl(linksPromise);
-
-      store = parts.store;
-      serviceUrl = parts.serviceUrl;
-      replaceURLParams = parts.replaceURLParams;
-    });
-
-    it('updates store with the real links', function () {
-      return linksPromise.then(function (links) {
-        assert.deepEqual(store.getState(), { links: links });
-      });
-    });
-
-    it('calls replaceURLParams with the path and given params', function () {
-      return linksPromise.then(function () {
-        const params = { foo: 'bar' };
-
-        serviceUrl('first_link', params);
-
-        assert.calledOnce(replaceURLParams);
-        assert.deepEqual(replaceURLParams.args[0], [
-          'http://example.com/first_page/:foo',
-          params,
-        ]);
-      });
-    });
-
-    it('passes an empty params object to replaceURLParams if no params are given', function () {
-      return linksPromise.then(function () {
-        serviceUrl('first_link');
-
-        assert.calledOnce(replaceURLParams);
-        assert.deepEqual(replaceURLParams.args[0][1], {});
-      });
-    });
-
-    it('returns the expanded URL from replaceURLParams', function () {
-      return linksPromise.then(function () {
-        const renderedUrl = serviceUrl('first_link');
-
-        assert.equal(renderedUrl, 'EXPANDED_URL');
-      });
-    });
-
-    it("throws an error if it doesn't have the requested link", function () {
-      return linksPromise.then(function () {
-        assert.throws(
-          function () {
-            serviceUrl('madeUpLinkName');
-          },
-          Error,
-          'Unknown link madeUpLinkName'
-        );
-      });
-    });
-
-    it('throws an error if replaceURLParams returns unused params', function () {
-      const params = { unused_param_1: 'foo', unused_param_2: 'bar' };
-      replaceURLParams.returns({
-        url: 'EXPANDED_URL',
-        params: params,
-      });
-
-      return linksPromise.then(function () {
-        assert.throws(
-          function () {
-            serviceUrl('first_link', params);
-          },
-          Error,
-          'Unknown link parameters: unused_param_1, unused_param_2'
-        );
-      });
+      assert.notCalled(fakeStore.updateLinks);
+      assert.calledWith(
+        console.warn,
+        'Failed to fetch Hypothesis links: Fetch failed'
+      );
     });
   });
 });

--- a/src/sidebar/store/modules/links.js
+++ b/src/sidebar/store/modules/links.js
@@ -34,7 +34,7 @@ function updateLinks(newLinks) {
  * Returns an empty string if links have not been fetched yet.
  *
  * @param {string} linkName
- * @param {Record<string,string>} params
+ * @param {Record<string, string>} [params]
  * @return {string}
  */
 function getLink(state, linkName, params = {}) {
@@ -45,11 +45,10 @@ function getLink(state, linkName, params = {}) {
   if (!template) {
     throw new Error(`Unknown link "${linkName}"`);
   }
-  const { url, params: unusedParams } = replaceURLParams(template, params);
-  if (Object.keys(unusedParams).length > 0) {
-    throw new Error(
-      `Unused parameters: ${Object.keys(unusedParams).join(', ')}`
-    );
+  const { url, unusedParams } = replaceURLParams(template, params);
+  const unusedKeys = Object.keys(unusedParams);
+  if (unusedKeys.length > 0) {
+    throw new Error(`Unused parameters: ${unusedKeys.join(', ')}`);
   }
   return url;
 }

--- a/src/sidebar/store/modules/links.js
+++ b/src/sidebar/store/modules/links.js
@@ -9,7 +9,7 @@ function init() {
 const update = {
   UPDATE_LINKS(state, action) {
     return {
-      ...action.newLinks,
+      ...action.links,
     };
   },
 };
@@ -17,14 +17,14 @@ const update = {
 const actions = actionTypes(update);
 
 /**
- * Update links
+ * Update the link map
  *
- * @param {object} newLinks - Link map returned by the `/api/links` endpoint
+ * @param {Record<string, string>} links - Link map fetched from the `/api/links` endpoint
  */
-function updateLinks(newLinks) {
+function updateLinks(links) {
   return {
     type: actions.UPDATE_LINKS,
-    newLinks,
+    links,
   };
 }
 

--- a/src/sidebar/store/modules/links.js
+++ b/src/sidebar/store/modules/links.js
@@ -1,17 +1,7 @@
+import { actionTypes } from '../util';
+import { replaceURLParams } from '../../util/url';
 import { storeModule } from '../create-store';
 
-import { actionTypes } from '../util';
-
-/**
- * Reducer for storing a "links" object in the Redux state store.
- *
- * The links object is initially null, and can only be updated by completely
- * replacing it with a new links object.
- *
- * Used by serviceUrl.
- */
-
-/** Return the initial links. */
 function init() {
   return null;
 }
@@ -26,12 +16,42 @@ const update = {
 
 const actions = actionTypes(update);
 
-/** Return updated links based on the given current state and action object. */
+/**
+ * Update links
+ *
+ * @param {object} newLinks - Link map returned by the `/api/links` endpoint
+ */
 function updateLinks(newLinks) {
   return {
     type: actions.UPDATE_LINKS,
     newLinks,
   };
+}
+
+/**
+ * Render a service link (URL) using the given `params`
+ *
+ * Returns an empty string if links have not been fetched yet.
+ *
+ * @param {string} linkName
+ * @param {Record<string,string>} params
+ * @return {string}
+ */
+function getLink(state, linkName, params = {}) {
+  if (!state) {
+    return '';
+  }
+  const template = state[linkName];
+  if (!template) {
+    throw new Error(`Unknown link "${linkName}"`);
+  }
+  const { url, params: unusedParams } = replaceURLParams(template, params);
+  if (Object.keys(unusedParams).length > 0) {
+    throw new Error(
+      `Unused parameters: ${Object.keys(unusedParams).join(', ')}`
+    );
+  }
+  return url;
 }
 
 export default storeModule({
@@ -41,5 +61,7 @@ export default storeModule({
   actions: {
     updateLinks,
   },
-  selectors: {},
+  selectors: {
+    getLink,
+  },
 });

--- a/src/sidebar/util/test/url-test.js
+++ b/src/sidebar/util/test/url-test.js
@@ -1,27 +1,27 @@
-import * as urlUtil from '../url';
+import { replaceURLParams } from '../url';
 
 describe('sidebar/util/url', function () {
   describe('replaceURLParams()', function () {
     it('should replace params in URLs', function () {
-      const replaced = urlUtil.replaceURLParams('http://foo.com/things/:id', {
+      const replaced = replaceURLParams('http://foo.com/things/:id', {
         id: 'test',
       });
       assert.equal(replaced.url, 'http://foo.com/things/test');
     });
 
     it('should URL encode params in URLs', function () {
-      const replaced = urlUtil.replaceURLParams('http://foo.com/things/:id', {
+      const replaced = replaceURLParams('http://foo.com/things/:id', {
         id: 'foo=bar',
       });
       assert.equal(replaced.url, 'http://foo.com/things/foo%3Dbar');
     });
 
     it('should return unused params', function () {
-      const replaced = urlUtil.replaceURLParams('http://foo.com/:id', {
+      const replaced = replaceURLParams('http://foo.com/:id', {
         id: 'test',
         q: 'unused',
       });
-      assert.deepEqual(replaced.params, { q: 'unused' });
+      assert.deepEqual(replaced.unusedParams, { q: 'unused' });
     });
   });
 });

--- a/src/sidebar/util/url.js
+++ b/src/sidebar/util/url.js
@@ -5,11 +5,11 @@
  * parameters.
  *
  *   replaceURLParams('/things/:id', {id: 'foo', q: 'bar'}) =>
- *     {url: '/things/foo', params: {q: 'bar'}}
+ *     {url: '/things/foo', unusedParams: {q: 'bar'}}
  *
  * @param {string} url
  * @param {Record<string, string>} params
- * @return {{ url: string, params: Record<string, string>}}
+ * @return {{ url: string, unusedParams: Record<string, string>}}
  */
 export function replaceURLParams(url, params) {
   /** @type {Record<string, string>} */
@@ -25,7 +25,7 @@ export function replaceURLParams(url, params) {
       }
     }
   }
-  return { url: url, params: unusedParams };
+  return { url, unusedParams };
 }
 
 /**

--- a/src/sidebar/util/url.js
+++ b/src/sidebar/util/url.js
@@ -8,10 +8,11 @@
  *     {url: '/things/foo', params: {q: 'bar'}}
  *
  * @param {string} url
- * @param {Record<string, any>} params
- * @return {{ url: string, params: Record<string, any>}}
+ * @param {Record<string, string>} params
+ * @return {{ url: string, params: Record<string, string>}}
  */
 export function replaceURLParams(url, params) {
+  /** @type {Record<string, string>} */
   const unusedParams = {};
   for (const param in params) {
     if (params.hasOwnProperty(param)) {


### PR DESCRIPTION
I started working on converting the `serviceUrl` service to an ES class and then discovered that the way it worked was fundamentally broken. This service is responsible for fetching and rendering the URLs in the sidebar/notebook that point to pages on the H website, such as account settings pages, tags, user profiles etc. If the https://hypothes.is/api/links request was slow to respond, various `<a>` elements in the app could end up not being re-rendered with the correct `href` when the response was received.

This PR re-works the way these links are fetched and used to avoid the problem, and also fit the patterns of existing code. See the commit message for an explanation of the changes and how it resolves the issue.

Part of https://github.com/hypothesis/client/issues/3298.