### PR TITLE
Make listener passive

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -241,9 +241,6 @@ export default class Sidebar {
   _setupGestures() {
     const toggleButton = this.toolbar.sidebarToggleButton;
     if (toggleButton) {
-      // Prevent any default gestures on the handle.
-      this._listeners.add(toggleButton, 'touchmove', e => e.preventDefault());
-
       this._hammerManager = new Hammer.Manager(toggleButton).on(
         'panstart panend panleft panright',
         /* istanbul ignore next */

--- a/src/annotator/util/shadow-root.js
+++ b/src/annotator/util/shadow-root.js
@@ -49,7 +49,7 @@ export function createShadowRoot(container) {
 }
 
 /**
- * Stop bubbling up of 'click' and 'touchstart' events.
+ * Stop bubbling up of several events.
  *
  * This makes the host page a little bit less aware of the annotator activity.
  * It is still possible for the host page to manipulate the events on the capturing
@@ -64,5 +64,7 @@ export function createShadowRoot(container) {
 function stopEventPropagation(element) {
   element.addEventListener('mouseup', event => event.stopPropagation());
   element.addEventListener('mousedown', event => event.stopPropagation());
-  element.addEventListener('touchstart', event => event.stopPropagation());
+  element.addEventListener('touchstart', event => event.stopPropagation(), {
+    passive: true,
+  });
 }


### PR DESCRIPTION
Chrome 89 printed the following warnings on the console:

```
shadow-root.js:67 [Violation] Added non-passive event listener to a scroll-blocking 'touchstart' event. Consider marking event handler as 'passive' to make the page more responsive
```

See also: https://www.chromestatus.com/feature/5745543795965952

I have removed a listener that it isn't no longer needed, because it is wrapped in
a shadow DOM that already stop the bubbling up of the event.

Another 'touchstart' listener had the potential to slow down scrolling
on the host page on mobile devices. To avoid that we have made listener
passive.

These changes remove the warnings without affecting the current
behaviour of the application.