### PR TITLE
Convert `api` service to an ES class

### DIFF
--- a/src/sidebar/components/ModerationBanner.js
+++ b/src/sidebar/components/ModerationBanner.js
@@ -13,7 +13,7 @@ import { withServices } from '../service-context';
  * @prop {Annotation} annotation -
  *   The annotation object for this banner. This contains state about the flag count
  *   or its hidden value.
- * @prop {Object} api - Injected service
+ * @prop {import('../services/api').APIService} api
  * @prop {import('../services/toast-messenger').ToastMessengerService} toastMessenger
  */
 

--- a/src/sidebar/components/StreamView.js
+++ b/src/sidebar/components/StreamView.js
@@ -9,7 +9,7 @@ import ThreadList from './ThreadList';
 
 /**
  * @typedef StreamViewProps
- * @prop {ReturnType<import('../services/api').default>} api
+ * @prop {import('../services/api').APIService} api
  * @prop {import('../services/toast-messenger').ToastMessengerService} toastMessenger
  */
 

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -107,7 +107,7 @@ import { ServiceContext } from './service-context';
 import bridgeService from '../shared/bridge';
 
 import { AnnotationsService } from './services/annotations';
-import apiService from './services/api';
+import { APIService } from './services/api';
 import { APIRoutesService } from './services/api-routes';
 import { AuthService } from './services/auth';
 import { AutosaveService } from './services/autosave';
@@ -144,7 +144,7 @@ function startApp(config, appEl) {
   // Register services.
   container
     .register('annotationsService', AnnotationsService)
-    .register('api', apiService)
+    .register('api', APIService)
     .register('apiRoutes', APIRoutesService)
     .register('auth', AuthService)
     .register('autosaveService', AutosaveService)

--- a/src/sidebar/services/annotations.js
+++ b/src/sidebar/services/annotations.js
@@ -16,7 +16,7 @@ import { generateHexString } from '../util/random';
 // @inject
 export class AnnotationsService {
   /**
-   * @param {ReturnType<import('./api').default>} api
+   * @param {import('./api').APIService} api
    * @param {import('../store').SidebarStore} store
    */
   constructor(api, store) {

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -22,6 +22,7 @@ const DEFAULT_ORGANIZATION = {
 
 /**
  * @param {import('../store').SidebarStore} store
+ * @param {import('./api').APIService} api
  * @param {import('./toast-messenger').ToastMessengerService} toastMessenger
  * @param {import('./auth').AuthService} auth
  */

--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -30,7 +30,7 @@ import { SearchClient } from '../search-client';
 import { isReply } from '../helpers/annotation-metadata';
 
 /**
- * @param {ReturnType<import('./api').default>} api
+ * @param {import('./api').APIService} api
  * @param {import('../store').SidebarStore} store
  * @param {import('./streamer').default} streamer
  * @param {import('./stream-filter').StreamFilter} streamFilter

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -13,6 +13,7 @@ const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
  * Access to the current profile is exposed via the `state` property.
  *
  * @param {import('../store').SidebarStore} store
+ * @param {import('./api').APIService} api
  * @param {import('./auth').AuthService} auth
  * @param {import('./toast-messenger').ToastMessengerService} toastMessenger
  * @inject

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -1,6 +1,6 @@
 import fetchMock from 'fetch-mock';
 
-import apiFactory from '../api';
+import { APIService } from '../api';
 
 // API route directory.
 //
@@ -13,7 +13,7 @@ import apiFactory from '../api';
 //
 const routes = require('./api-index.json').links;
 
-describe('sidebar.services.api', function () {
+describe('APIService', () => {
   let fakeAuth;
   let fakeStore;
   let api;
@@ -72,7 +72,7 @@ describe('sidebar.services.api', function () {
       apiRequestFinished: sinon.stub(),
     };
 
-    api = apiFactory(fakeApiRoutes, fakeAuth, fakeStore);
+    api = new APIService(fakeApiRoutes, fakeAuth, fakeStore);
 
     fetchMock.catch(() => {
       throw new Error('Unexpected `fetch` call');


### PR DESCRIPTION
This is a pretty straightforward conversion with no significant refactoring other than the function => class conversion.

Part of https://github.com/hypothesis/client/issues/3298