### PR TITLE
Convert `frameSync` service to ES class

### DIFF
--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -16,7 +16,7 @@ import ThreadList from './ThreadList';
  * @typedef SidebarViewProps
  * @prop {() => any} onLogin
  * @prop {() => any} onSignUp
- * @prop {import('../services/frame-sync').default} frameSync - Injected service
+ * @prop {import('../services/frame-sync').FrameSyncService} frameSync
  * @prop {ReturnType<import('../services/load-annotations').default>} loadAnnotationsService  - Injected service
  * @prop {import('../services/streamer').default} streamer - Injected service
  */

--- a/src/sidebar/components/ThreadCard.js
+++ b/src/sidebar/components/ThreadCard.js
@@ -14,7 +14,7 @@ import Thread from './Thread';
 /**
  * @typedef ThreadCardProps
  * @prop {Thread} thread
- * @prop {Object} frameSync - Injected service
+ * @prop {import('../services/frame-sync').FrameSyncService} frameSync
  */
 
 /**

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -73,10 +73,14 @@ function initServices(autosaveService, features, persistedDefaults) {
   persistedDefaults.init();
 }
 
+/**
+ * @param {import('./services/frame-sync').FrameSyncService} frameSync
+ * @param {import('./store').SidebarStore} store
+ */
 // @inject
 function setupFrameSync(frameSync, store) {
   if (store.route() === 'sidebar') {
-    frameSync.connect(true);
+    frameSync.connect();
   }
 }
 
@@ -101,7 +105,7 @@ import { APIRoutesService } from './services/api-routes';
 import { AuthService } from './services/auth';
 import { AutosaveService } from './services/autosave';
 import { FeaturesService } from './services/features';
-import frameSyncService from './services/frame-sync';
+import { FrameSyncService } from './services/frame-sync';
 import groupsService from './services/groups';
 import loadAnnotationsService from './services/load-annotations';
 import { LocalStorageService } from './services/local-storage';
@@ -139,7 +143,7 @@ function startApp(config, appEl) {
     .register('autosaveService', AutosaveService)
     .register('bridge', bridgeService)
     .register('features', FeaturesService)
-    .register('frameSync', frameSyncService)
+    .register('frameSync', FrameSyncService)
     .register('groups', groupsService)
     .register('loadAnnotationsService', loadAnnotationsService)
     .register('localStorage', LocalStorageService)

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -2,7 +2,7 @@ import debounce from 'lodash.debounce';
 
 import bridgeEvents from '../../shared/bridge-events';
 import Discovery from '../../shared/discovery';
-import * as metadata from '../helpers/annotation-metadata';
+import { isReply, isPublic } from '../helpers/annotation-metadata';
 import { watch } from '../util/watch';
 
 /**
@@ -25,205 +25,223 @@ export function formatAnnot(ann) {
 }
 
 /**
- * This service runs in the sidebar and is responsible for keeping the set of
- * annotations displayed in connected frames in sync with the set shown in the
- * sidebar.
+ * Service that synchronizes annotations between the sidebar and host page.
  *
- * @param {import('./annotations').AnnotationsService} annotationsService
- * @param {import('../store').SidebarStore} store
+ * Annotations are synced in both directions. New annotations created in the host
+ * page are added to the store in the sidebar and persisted to the backend. Annotations
+ * fetched from the API and added to the sidebar's store are sent to the host
+ * page in order to create highlights in the document. When an annotation is
+ * deleted in the sidebar it is removed from the host page.
+ *
+ * This service also synchronizes the selection and focus states of annotations,
+ * so that clicking a highlight in the page filters the selection in the sidebar
+ * and hovering an annotation in the sidebar highlights the corresponding
+ * highlights in the page.
+ *
+ * For annotations sent from the sidebar to host page, only the subset of annotation
+ * data needed to create the highlights is sent. This is a security/privacy
+ * feature to prevent the host page observing the contents or authors of annotations.
+ *
+ * @inject
  */
-// @inject
-export default function FrameSync(annotationsService, bridge, store) {
-  // Set of tags of annotations that are currently loaded into the frame
-  const inFrame = new Set();
-
+export class FrameSyncService {
   /**
-   * Watch for changes to the set of annotations displayed in the sidebar and
-   * notify connected frames about new/updated/deleted annotations.
+   * @param {import('./annotations').AnnotationsService} annotationsService
+   * @param {import('../../shared/bridge').default} bridge
+   * @param {import('../store').SidebarStore} store
    */
-  function setupSyncToFrame() {
-    let prevPublicAnns = 0;
+  constructor(annotationsService, bridge, store) {
+    this._bridge = bridge;
+    this._store = store;
 
-    watch(
-      store.subscribe,
-      [() => store.getState().annotations.annotations, () => store.frames()],
-      ([annotations, frames], [prevAnnotations]) => {
-        let publicAnns = 0;
-        const inSidebar = new Set();
-        const added = [];
+    // Set of tags of annotations that are currently loaded into the frame
+    const inFrame = new Set();
 
-        annotations.forEach(function (annot) {
-          if (metadata.isReply(annot)) {
-            // The frame does not need to know about replies
-            return;
-          }
+    /**
+     * Watch for changes to the set of annotations displayed in the sidebar and
+     * notify connected frames about new/updated/deleted annotations.
+     */
+    this._setupSyncToFrame = () => {
+      let prevPublicAnns = 0;
 
-          if (metadata.isPublic(annot)) {
-            ++publicAnns;
-          }
+      watch(
+        store.subscribe,
+        [() => store.getState().annotations.annotations, () => store.frames()],
+        ([annotations, frames], [prevAnnotations]) => {
+          let publicAnns = 0;
+          const inSidebar = new Set();
+          const added = [];
 
-          inSidebar.add(annot.$tag);
-          if (!inFrame.has(annot.$tag)) {
-            added.push(annot);
-          }
-        });
-        const deleted = prevAnnotations.filter(function (annot) {
-          return !inSidebar.has(annot.$tag);
-        });
+          annotations.forEach(annot => {
+            if (isReply(annot)) {
+              // The frame does not need to know about replies
+              return;
+            }
 
-        // We currently only handle adding and removing annotations from the frame
-        // when they are added or removed in the sidebar, but not re-anchoring
-        // annotations if their selectors are updated.
-        if (added.length > 0) {
-          bridge.call('loadAnnotations', added.map(formatAnnot));
-          added.forEach(function (annot) {
-            inFrame.add(annot.$tag);
+            if (isPublic(annot)) {
+              ++publicAnns;
+            }
+
+            inSidebar.add(annot.$tag);
+            if (!inFrame.has(annot.$tag)) {
+              added.push(annot);
+            }
           });
-        }
-        deleted.forEach(function (annot) {
-          bridge.call('deleteAnnotation', formatAnnot(annot));
-          inFrame.delete(annot.$tag);
-        });
+          const deleted = prevAnnotations.filter(
+            annot => !inSidebar.has(annot.$tag)
+          );
 
-        if (frames.length > 0) {
-          if (
-            frames.every(function (frame) {
-              return frame.isAnnotationFetchComplete;
-            })
-          ) {
-            if (publicAnns === 0 || publicAnns !== prevPublicAnns) {
-              bridge.call(
-                bridgeEvents.PUBLIC_ANNOTATION_COUNT_CHANGED,
-                publicAnns
-              );
-              prevPublicAnns = publicAnns;
+          // We currently only handle adding and removing annotations from the frame
+          // when they are added or removed in the sidebar, but not re-anchoring
+          // annotations if their selectors are updated.
+          if (added.length > 0) {
+            bridge.call('loadAnnotations', added.map(formatAnnot));
+            added.forEach(annot => {
+              inFrame.add(annot.$tag);
+            });
+          }
+          deleted.forEach(annot => {
+            bridge.call('deleteAnnotation', formatAnnot(annot));
+            inFrame.delete(annot.$tag);
+          });
+
+          if (frames.length > 0) {
+            if (frames.every(frame => frame.isAnnotationFetchComplete)) {
+              if (publicAnns === 0 || publicAnns !== prevPublicAnns) {
+                bridge.call(
+                  bridgeEvents.PUBLIC_ANNOTATION_COUNT_CHANGED,
+                  publicAnns
+                );
+                prevPublicAnns = publicAnns;
+              }
             }
           }
         }
+      );
+    };
+
+    /** @param {string|null} frameIdentifier */
+    const destroyFrame = frameIdentifier => {
+      const frames = store.frames();
+      const frameToDestroy = frames.find(frame => frame.id === frameIdentifier);
+      if (frameToDestroy) {
+        store.destroyFrame(frameToDestroy);
       }
-    );
-  }
+    };
 
-  /**
-   * Listen for messages coming in from connected frames and add new annotations
-   * to the sidebar.
-   */
-  function setupSyncFromFrame() {
-    // A new annotation, note or highlight was created in the frame
-    bridge.on('beforeCreateAnnotation', function (event) {
-      const annot = Object.assign({}, event.msg, { $tag: event.tag });
-      // If user is not logged in, we can't really create a meaningful highlight
-      // or annotation. Instead, we need to open the sidebar, show an error,
-      // and delete the (unsaved) annotation so it gets un-selected in the
-      // target document
-      if (!store.isLoggedIn()) {
-        bridge.call('openSidebar');
-        store.openSidebarPanel('loginPrompt');
-        bridge.call('deleteAnnotation', formatAnnot(annot));
-        return;
-      }
-      inFrame.add(event.tag);
-
-      // Create the new annotation in the sidebar.
-      annotationsService.create(annot);
-    });
-
-    bridge.on('destroyFrame', frameIdentifier => destroyFrame(frameIdentifier));
-
-    // Map of annotation tag to anchoring status
-    // ('anchored'|'orphan'|'timeout').
-    //
-    // Updates are coalesced to reduce the overhead from processing
-    // triggered by each `UPDATE_ANCHOR_STATUS` action that is dispatched.
-
-    /** @type {Record<string,'anchored'|'orphan'|'timeout'>} */
-    let anchoringStatusUpdates = {};
-    const scheduleAnchoringStatusUpdate = debounce(() => {
-      store.updateAnchorStatus(anchoringStatusUpdates);
-      anchoringStatusUpdates = {};
-    }, 10);
-
-    // Anchoring an annotation in the frame completed
-    bridge.on('sync', function (events_) {
-      events_.forEach(function (event) {
+    /**
+     * Listen for messages coming in from connected frames and add new annotations
+     * to the sidebar.
+     */
+    this._setupSyncFromFrame = () => {
+      // A new annotation, note or highlight was created in the frame
+      bridge.on('beforeCreateAnnotation', event => {
+        const annot = Object.assign({}, event.msg, { $tag: event.tag });
+        // If user is not logged in, we can't really create a meaningful highlight
+        // or annotation. Instead, we need to open the sidebar, show an error,
+        // and delete the (unsaved) annotation so it gets un-selected in the
+        // target document
+        if (!store.isLoggedIn()) {
+          bridge.call('openSidebar');
+          store.openSidebarPanel('loginPrompt');
+          bridge.call('deleteAnnotation', formatAnnot(annot));
+          return;
+        }
         inFrame.add(event.tag);
-        anchoringStatusUpdates[event.tag] = event.msg.$orphan
-          ? 'orphan'
-          : 'anchored';
-        scheduleAnchoringStatusUpdate();
+
+        // Create the new annotation in the sidebar.
+        annotationsService.create(annot);
       });
-    });
 
-    bridge.on('showAnnotations', function (tags) {
-      store.selectAnnotations(store.findIDsForTags(tags));
-      store.selectTab('annotation');
-    });
+      bridge.on('destroyFrame', frameIdentifier =>
+        destroyFrame(frameIdentifier)
+      );
 
-    bridge.on('focusAnnotations', function (tags) {
-      store.focusAnnotations(tags || []);
-    });
+      // Map of annotation tag to anchoring status
+      // ('anchored'|'orphan'|'timeout').
+      //
+      // Updates are coalesced to reduce the overhead from processing
+      // triggered by each `UPDATE_ANCHOR_STATUS` action that is dispatched.
 
-    bridge.on('toggleAnnotationSelection', function (tags) {
-      store.toggleSelectedAnnotations(store.findIDsForTags(tags));
-    });
+      /** @type {Record<string,'anchored'|'orphan'|'timeout'>} */
+      let anchoringStatusUpdates = {};
+      const scheduleAnchoringStatusUpdate = debounce(() => {
+        store.updateAnchorStatus(anchoringStatusUpdates);
+        anchoringStatusUpdates = {};
+      }, 10);
 
-    bridge.on('sidebarOpened', function () {
-      store.setSidebarOpened(true);
-    });
-
-    // These invoke the matching methods by name on the Guests
-    bridge.on('openSidebar', function () {
-      bridge.call('openSidebar');
-    });
-    bridge.on('closeSidebar', function () {
-      bridge.call('closeSidebar');
-    });
-    bridge.on('setVisibleHighlights', function (state) {
-      bridge.call('setVisibleHighlights', state);
-    });
-  }
-
-  /**
-   * Query the Hypothesis annotation client in a frame for the URL and metadata
-   * of the document that is currently loaded and add the result to the set of
-   * connected frames.
-   */
-  function addFrame(channel) {
-    channel.call('getDocumentInfo', function (err, info) {
-      if (err) {
-        channel.destroy();
-        return;
-      }
-
-      store.connectFrame({
-        id: info.frameIdentifier,
-        metadata: info.metadata,
-        uri: info.uri,
+      // Anchoring an annotation in the frame completed
+      bridge.on('sync', events_ => {
+        events_.forEach(event => {
+          inFrame.add(event.tag);
+          anchoringStatusUpdates[event.tag] = event.msg.$orphan
+            ? 'orphan'
+            : 'anchored';
+          scheduleAnchoringStatusUpdate();
+        });
       });
-    });
-  }
 
-  function destroyFrame(frameIdentifier) {
-    const frames = store.frames();
-    const frameToDestroy = frames.find(function (frame) {
-      return frame.id === frameIdentifier;
-    });
-    if (frameToDestroy) {
-      store.destroyFrame(frameToDestroy);
-    }
+      bridge.on('showAnnotations', tags => {
+        store.selectAnnotations(store.findIDsForTags(tags));
+        store.selectTab('annotation');
+      });
+
+      bridge.on('focusAnnotations', tags => {
+        store.focusAnnotations(tags || []);
+      });
+
+      bridge.on('toggleAnnotationSelection', tags => {
+        store.toggleSelectedAnnotations(store.findIDsForTags(tags));
+      });
+
+      bridge.on('sidebarOpened', () => {
+        store.setSidebarOpened(true);
+      });
+
+      // These invoke the matching methods by name on the Guests
+      bridge.on('openSidebar', () => {
+        bridge.call('openSidebar');
+      });
+      bridge.on('closeSidebar', () => {
+        bridge.call('closeSidebar');
+      });
+      bridge.on('setVisibleHighlights', state => {
+        bridge.call('setVisibleHighlights', state);
+      });
+    };
   }
 
   /**
    * Find and connect to Hypothesis clients in the current window.
    */
-  this.connect = function () {
-    const discovery = new Discovery(window, { server: true });
-    discovery.startDiscovery(bridge.createChannel.bind(bridge));
-    bridge.onConnect(addFrame);
+  connect() {
+    /**
+     * Query the Hypothesis annotation client in a frame for the URL and metadata
+     * of the document that is currently loaded and add the result to the set of
+     * connected frames.
+     */
+    const addFrame = channel => {
+      channel.call('getDocumentInfo', (err, info) => {
+        if (err) {
+          channel.destroy();
+          return;
+        }
 
-    setupSyncToFrame();
-    setupSyncFromFrame();
-  };
+        this._store.connectFrame({
+          id: info.frameIdentifier,
+          metadata: info.metadata,
+          uri: info.uri,
+        });
+      });
+    };
+
+    const discovery = new Discovery(window, { server: true });
+    discovery.startDiscovery(this._bridge.createChannel.bind(this._bridge));
+    this._bridge.onConnect(addFrame);
+
+    this._setupSyncToFrame();
+    this._setupSyncFromFrame();
+  }
 
   /**
    * Focus annotations with the given $tags.
@@ -233,17 +251,17 @@ export default function FrameSync(annotationsService, bridge, store) {
    *
    * @param {string[]} tags - annotation $tags
    */
-  this.focusAnnotations = function (tags) {
-    store.focusAnnotations(tags);
-    bridge.call('focusAnnotations', tags);
-  };
+  focusAnnotations(tags) {
+    this._store.focusAnnotations(tags);
+    this._bridge.call('focusAnnotations', tags);
+  }
 
   /**
    * Scroll the frame to the highlight for an annotation with a given tag.
    *
    * @param {string} tag
    */
-  this.scrollToAnnotation = function (tag) {
-    bridge.call('scrollToAnnotation', tag);
-  };
+  scrollToAnnotation(tag) {
+    this._bridge.call('scrollToAnnotation', tag);
+  }
 }

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -4,7 +4,7 @@ import { Injector } from '../../../shared/injector';
 import * as annotationFixtures from '../../test/annotation-fixtures';
 import createFakeStore from '../../test/fake-redux-store';
 
-import FrameSync, { $imports, formatAnnot } from '../frame-sync';
+import { FrameSyncService, $imports, formatAnnot } from '../frame-sync';
 
 const fixtures = {
   ann: Object.assign({ $tag: 't1' }, annotationFixtures.defaultAnnotation()),
@@ -97,7 +97,7 @@ describe('sidebar/services/frame-sync', function () {
       .register('annotationsService', { value: fakeAnnotationsService })
       .register('bridge', { value: fakeBridge })
       .register('store', { value: fakeStore })
-      .register('frameSync', FrameSync)
+      .register('frameSync', FrameSyncService)
       .get('frameSync');
 
     frameSync.connect();


### PR DESCRIPTION
Convert the `frameSync` service to an ES class and rewrite the
documentation that explains what the service does.

Some internal `frameSync` methods are still set up in the constructor
with closures. These can be converted to ES class methods in later
refactoring.

Some of the syntax of the `FrameSyncService` internals has been modernized but there is no
change to the logic in this PR, although I saw a few things that could be simplified in future.