### PR TITLE
Retry `/api/links` fetch if it fails

### DIFF
--- a/src/sidebar/services/test/api-routes-test.js
+++ b/src/sidebar/services/test/api-routes-test.js
@@ -133,5 +133,17 @@ describe('APIRoutesService', () => {
         }
       );
     });
+
+    it('retries the link fetch until it succeeds', async () => {
+      window.fetch
+        .withArgs(apiIndexResponse.links.links.url)
+        .onFirstCall()
+        .returns(httpResponse(500, null));
+
+      const links = await apiRoutes.links();
+
+      assert.equal(window.fetch.callCount, 3); // One `/api` fetch, two `/api/links` fetches.
+      assert.deepEqual(links, linksResponse);
+    });
   });
 });


### PR DESCRIPTION
The `APIRoutesService` service had logic to automatically retry fetching of the `/api` endpoint used to get the metadata for various endpoints, but not the endpoint used to fetch URL templates for URLs in the H service. This means that if the request failed due to a temporary issue, all links in the sidebar/notebook pointing into the H service would remain blank for the rest of the session.

Move the logic for retrying API metadata fetching into the `getJSON` helper function so that it is used both when fetching the API index (`/api`) and the service links (`/api/links`).
