### PR TITLE
Convert `session` service to an ES class

### DIFF
--- a/src/sidebar/components/HelpPanel.js
+++ b/src/sidebar/components/HelpPanel.js
@@ -43,7 +43,7 @@ function HelpPanelTab({ linkText, url }) {
 /**
  * @typedef HelpPanelProps
  * @prop {AuthState} auth - Object with auth and user information
- * @prop {Object} session - Injected service
+ * @prop {import('../services/session').SessionService} session
  */
 
 /**
@@ -86,17 +86,16 @@ function HelpPanel({ auth, session }) {
     setActiveSubPanel(panelName);
   };
 
-  const dismissFn = session.dismissSidebarTutorial; // Reference for useCallback dependency
   const onActiveChanged = useCallback(
     active => {
       if (!active && hasAutoDisplayPreference) {
         // If the tutorial is currently being auto-displayed, update the user
         // preference to disable the auto-display from happening on subsequent
         // app launches
-        dismissFn();
+        session.dismissSidebarTutorial();
       }
     },
-    [dismissFn, hasAutoDisplayPreference]
+    [session, hasAutoDisplayPreference]
   );
 
   return (

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -55,7 +55,7 @@ function authStateFromProfile(profile) {
  * @prop {import('../services/auth').AuthService} auth
  * @prop {Bridge} bridge
  * @prop {MergedConfig} settings
- * @prop {Object} session
+ * @prop {import('../services/session').SessionService} session
  * @prop {import('../services/toast-messenger').ToastMessengerService} toastMessenger
  */
 

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -46,7 +46,7 @@ function setupApi(api, streamer) {
  * route to match the current URL.
  *
  * @param {Object} groups
- * @param {Object} session
+ * @param {import('./services/session').SessionService} session
  * @param {import('./services/router').RouterService} router
  */
 // @inject

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -119,7 +119,7 @@ import { LocalStorageService } from './services/local-storage';
 import { PersistedDefaultsService } from './services/persisted-defaults';
 import { RouterService } from './services/router';
 import { ServiceURLService } from './services/service-url';
-import sessionService from './services/session';
+import { SessionService } from './services/session';
 import { StreamFilter } from './services/stream-filter';
 import streamerService from './services/streamer';
 import { TagsService } from './services/tags';
@@ -157,7 +157,7 @@ function startApp(config, appEl) {
     .register('persistedDefaults', PersistedDefaultsService)
     .register('router', RouterService)
     .register('serviceURL', ServiceURLService)
-    .register('session', sessionService)
+    .register('session', SessionService)
     .register('streamer', streamerService)
     .register('streamFilter', StreamFilter)
     .register('tags', TagsService)

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -10,161 +10,154 @@ const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
  * This service handles fetching the user's profile, updating profile settings
  * and logging out.
  *
- * Access to the current profile is exposed via the `state` property.
- *
- * @param {import('../store').SidebarStore} store
- * @param {import('./api').APIService} api
- * @param {import('./auth').AuthService} auth
- * @param {import('./toast-messenger').ToastMessengerService} toastMessenger
  * @inject
  */
-export default function session(store, api, auth, settings, toastMessenger) {
-  // Cache the result of load()
-  let lastLoad;
-  let lastLoadTime;
-
-  // Return the authority from the first service defined in the settings.
-  // Return null if there are no services defined in the settings.
-  function getAuthority() {
-    const service = serviceConfig(settings);
-    if (service === null) {
-      return null;
-    }
-    return service.authority;
-  }
-
-  // Options to pass to `retry.operation` when fetching the user's profile.
-  const profileFetchRetryOpts = {};
-
+export class SessionService {
   /**
-   * Fetch the user's profile from the annotation service.
-   *
-   * If the profile has been previously fetched within `CACHE_TTL` ms, then this
-   * method returns a cached profile instead of triggering another fetch.
-   *
-   * @return {Promise<Profile>} A promise for the user's profile data.
+   * @param {import('../store').SidebarStore} store
+   * @param {import('./api').APIService} api
+   * @param {import('./auth').AuthService} auth
+   * @param {import('./toast-messenger').ToastMessengerService} toastMessenger
    */
-  function load() {
-    if (!lastLoadTime || Date.now() - lastLoadTime > CACHE_TTL) {
-      // The load attempt is automatically retried with a backoff.
-      //
-      // This serves to make loading the app in the extension cope better with
-      // flakey connectivity but it also throttles the frequency of calls to
-      // the /app endpoint.
-      lastLoadTime = Date.now();
-      lastLoad = retryUtil
-        .retryPromiseOperation(function () {
-          const authority = getAuthority();
-          const opts = {};
-          if (authority) {
-            opts.authority = authority;
-          }
-          return api.profile.read(opts);
-        }, profileFetchRetryOpts)
-        .then(function (session) {
-          update(session);
-          lastLoadTime = Date.now();
-          return session;
-        })
-        .catch(function (err) {
-          lastLoadTime = null;
-          throw err;
-        });
-    }
-    return lastLoad;
-  }
+  constructor(store, api, auth, settings, toastMessenger) {
+    // Cache the result of load()
+    let lastLoad;
+    let lastLoadTime;
 
-  /**
-   * Store the preference server-side that the user dismissed the sidebar
-   * tutorial and then update the local profile data.
-   */
-  function dismissSidebarTutorial() {
-    return api.profile
-      .update({}, { preferences: { show_sidebar_tutorial: false } })
-      .then(update);
-  }
-
-  /**
-   * Update the local profile data.
-   *
-   * This method can be used to update the profile data in the client when new
-   * data is pushed from the server via the real-time API.
-   *
-   * @param {Profile} model
-   * @return {Profile} The updated profile data
-   */
-  function update(model) {
-    const prevSession = store.profile();
-    const userChanged = model.userid !== prevSession.userid;
-
-    store.updateProfile(model);
-
-    lastLoad = Promise.resolve(model);
-    lastLoadTime = Date.now();
-
-    if (userChanged) {
-      // Associate error reports with the current user in Sentry.
-      if (model.userid) {
-        sentry.setUserInfo({
-          id: model.userid,
-        });
-      } else {
-        sentry.setUserInfo(null);
+    // Return the authority from the first service defined in the settings.
+    // Return null if there are no services defined in the settings.
+    function getAuthority() {
+      const service = serviceConfig(settings);
+      if (service === null) {
+        return null;
       }
+      return service.authority;
     }
 
-    // Return the model
-    return model;
-  }
+    // Options to pass to `retry.operation` when fetching the user's profile.
+    const profileFetchRetryOpts = {};
 
-  /**
-   * Log the user out of the current session.
-   */
-  function logout() {
-    const loggedOut = auth.logout().then(() => {
-      // Re-fetch the logged-out user's profile.
-      return reload();
+    /**
+     * Fetch the user's profile from the annotation service.
+     *
+     * If the profile has been previously fetched within `CACHE_TTL` ms, then this
+     * method returns a cached profile instead of triggering another fetch.
+     *
+     * @return {Promise<Profile>} A promise for the user's profile data.
+     */
+    function load() {
+      if (!lastLoadTime || Date.now() - lastLoadTime > CACHE_TTL) {
+        // The load attempt is automatically retried with a backoff.
+        //
+        // This serves to make loading the app in the extension cope better with
+        // flakey connectivity but it also throttles the frequency of calls to
+        // the /app endpoint.
+        lastLoadTime = Date.now();
+        lastLoad = retryUtil
+          .retryPromiseOperation(function () {
+            const authority = getAuthority();
+            const opts = {};
+            if (authority) {
+              opts.authority = authority;
+            }
+            return api.profile.read(opts);
+          }, profileFetchRetryOpts)
+          .then(function (session) {
+            update(session);
+            lastLoadTime = Date.now();
+            return session;
+          })
+          .catch(function (err) {
+            lastLoadTime = null;
+            throw err;
+          });
+      }
+      return lastLoad;
+    }
+
+    /**
+     * Store the preference server-side that the user dismissed the sidebar
+     * tutorial and then update the local profile data.
+     */
+    function dismissSidebarTutorial() {
+      return api.profile
+        .update({}, { preferences: { show_sidebar_tutorial: false } })
+        .then(update);
+    }
+
+    /**
+     * Update the local profile data.
+     *
+     * This method can be used to update the profile data in the client when new
+     * data is pushed from the server via the real-time API.
+     *
+     * @param {Profile} model
+     * @return {Profile} The updated profile data
+     */
+    function update(model) {
+      const prevSession = store.profile();
+      const userChanged = model.userid !== prevSession.userid;
+
+      store.updateProfile(model);
+
+      lastLoad = Promise.resolve(model);
+      lastLoadTime = Date.now();
+
+      if (userChanged) {
+        // Associate error reports with the current user in Sentry.
+        if (model.userid) {
+          sentry.setUserInfo({
+            id: model.userid,
+          });
+        } else {
+          sentry.setUserInfo(null);
+        }
+      }
+
+      // Return the model
+      return model;
+    }
+
+    /**
+     * Log the user out of the current session.
+     */
+    function logout() {
+      const loggedOut = auth.logout().then(() => {
+        // Re-fetch the logged-out user's profile.
+        return reload();
+      });
+
+      return loggedOut.catch(err => {
+        toastMessenger.error('Log out failed');
+        throw new Error(err);
+      });
+    }
+
+    /**
+     * Clear the cached profile information and re-fetch it from the server.
+     *
+     * This can be used to refresh the user's profile state after logging in.
+     *
+     * @return {Promise<Profile>}
+     */
+    function reload() {
+      lastLoad = null;
+      lastLoadTime = null;
+      return load();
+    }
+
+    auth.on('oauthTokensChanged', () => {
+      reload();
     });
 
-    return loggedOut.catch(err => {
-      toastMessenger.error('Log out failed');
-      throw new Error(err);
-    });
-  }
-
-  /**
-   * Clear the cached profile information and re-fetch it from the server.
-   *
-   * This can be used to refresh the user's profile state after logging in.
-   *
-   * @return {Promise<Profile>}
-   */
-  function reload() {
-    lastLoad = null;
-    lastLoadTime = null;
-    return load();
-  }
-
-  auth.on('oauthTokensChanged', () => {
-    reload();
-  });
-
-  return {
-    dismissSidebarTutorial,
-    load,
-    logout,
-    reload,
+    this.dismissSidebarTutorial = dismissSidebarTutorial;
+    this.load = load;
+    this.logout = logout;
+    this.reload = reload;
 
     // Exposed for use in tests
-    profileFetchRetryOpts,
+    this.profileFetchRetryOpts = profileFetchRetryOpts;
 
-    // For the moment, we continue to expose the session state as a property on
-    // this service. In future, other services which access the session state
-    // will do so directly from store or via selector functions
-    get state() {
-      return store.profile();
-    },
-
-    update,
-  };
+    this.update = update;
+  }
 }

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -13,7 +13,7 @@ import { watch } from '../util/watch';
  * @param {import('../store').SidebarStore} store
  * @param {import('./auth').AuthService} auth
  * @param {ReturnType<import('./groups').default>} groups
- * @param {ReturnType<import('./session').default>} session
+ * @param {import('./session').SessionService} session
  * @param {Record<string, any>} settings
  */
 // @inject

--- a/src/sidebar/services/test/session-test.js
+++ b/src/sidebar/services/test/session-test.js
@@ -155,14 +155,8 @@ describe('SessionService', () => {
         fakeApi.profile.read.rejects(fetchError);
 
         const session = createService();
-        let error;
-        try {
-          await session.load();
-        } catch (err) {
-          error = err;
-        }
 
-        assert.equal(error, fetchError);
+        assert.rejects(session.load(), fetchError.message);
         assert.notCalled(fakeStore.updateProfile);
       });
 

--- a/src/sidebar/services/test/session-test.js
+++ b/src/sidebar/services/test/session-test.js
@@ -1,10 +1,9 @@
 import EventEmitter from 'tiny-emitter';
 
-import sessionFactory from '../session';
-import { $imports } from '../session';
+import { SessionService, $imports } from '../session';
 import { Injector } from '../../../shared/injector';
 
-describe('sidebar/services/session', function () {
+describe('SessionService', function () {
   let fakeAuth;
   let fakeSentry;
   let fakeServiceConfig;
@@ -59,7 +58,7 @@ describe('sidebar/services/session', function () {
       .register('api', { value: fakeApi })
       .register('auth', { value: fakeAuth })
       .register('settings', { value: fakeSettings })
-      .register('session', sessionFactory)
+      .register('session', SessionService)
       .register('toastMessenger', { value: fakeToastMessenger })
       .get('session');
   });
@@ -69,7 +68,7 @@ describe('sidebar/services/session', function () {
     sandbox.restore();
   });
 
-  describe('#load()', function () {
+  describe('#load', function () {
     context('when the host page provides an OAuth grant token', function () {
       beforeEach(function () {
         fakeServiceConfig.returns({
@@ -180,7 +179,7 @@ describe('sidebar/services/session', function () {
     });
   });
 
-  describe('#update()', function () {
+  describe('#update', function () {
     it('updates the user ID for Sentry error reports', function () {
       session.update({
         userid: 'anne',
@@ -191,7 +190,7 @@ describe('sidebar/services/session', function () {
     });
   });
 
-  describe('#dismissSidebarTutorial()', function () {
+  describe('#dismissSidebarTutorial', function () {
     beforeEach(function () {
       fakeApi.profile.update.returns(
         Promise.resolve({
@@ -313,13 +312,6 @@ describe('sidebar/services/session', function () {
             userid: 'acct:different_user@hypothes.is',
           });
         });
-    });
-  });
-
-  // nb. This is a legacy property that should be removed.
-  describe('#state', () => {
-    it('returns the profile data', () => {
-      assert.equal(session.state, fakeStore.profile());
     });
   });
 });

--- a/src/sidebar/services/test/session-test.js
+++ b/src/sidebar/services/test/session-test.js
@@ -156,7 +156,7 @@ describe('SessionService', () => {
 
         const session = createService();
 
-        assert.rejects(session.load(), fetchError.message);
+        await assert.rejects(session.load(), fetchError.message);
         assert.notCalled(fakeStore.updateProfile);
       });
 


### PR DESCRIPTION
This PR converts the `session` service to an ES class as part of https://github.com/hypothesis/client/issues/3298. In the process two unnecessary public fields (`state`, `profileFetchRetryOpts`) were removed.

In the process I also improved the types and docs for the `retryPromiseOperation` utility which we use in a few places to automatically retry requests. See the last commit for details.

Changes to the `session` service:

 - Convert the `session` service to an ES class
 - Update references to the `session` service elsewhere in the code to be typed

Changes to the tests:

 - Added a new test to check what happens if fetching the profile fails after all the retries are exhausted
 - Remove unnecessary use of custom Sinon sandbox
 - Refactor the way the service instance is created in tests to allow individual tests to do custom setup before the service is constructed
 - Change the way that the delay between retries is removed in tests to match how this is done in the `APIRoutesService` tests, using a simple `retryPromiseOperation` mock
 