### PR TITLE
Convert `loadAnnotationsService` to an ES class

### DIFF
--- a/src/sidebar/components/AnnotationView.js
+++ b/src/sidebar/components/AnnotationView.js
@@ -10,7 +10,7 @@ import SidebarContentError from './SidebarContentError';
 /**
  * @typedef AnnotationViewProps
  * @prop {() => any} onLogin
- * @prop {ReturnType<import('../services/load-annotations').default>} loadAnnotationsService - Injected service
+ * @prop {import('../services/load-annotations').LoadAnnotationsService} loadAnnotationsService
  */
 
 /**

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -14,8 +14,8 @@ import useRootThread from './hooks/use-root-thread';
 
 /**
  * @typedef NotebookViewProps
- * @prop {ReturnType<import('../services/load-annotations').default>} loadAnnotationsService - Injected service
- * @prop {import('../services/streamer').default} streamer - Injected service
+ * @prop {import('../services/load-annotations').LoadAnnotationsService} loadAnnotationsService
+ * @prop {import('../services/streamer').default} streamer
  */
 
 /**

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -17,8 +17,8 @@ import ThreadList from './ThreadList';
  * @prop {() => any} onLogin
  * @prop {() => any} onSignUp
  * @prop {import('../services/frame-sync').FrameSyncService} frameSync
- * @prop {ReturnType<import('../services/load-annotations').default>} loadAnnotationsService  - Injected service
- * @prop {import('../services/streamer').default} streamer - Injected service
+ * @prop {import('../services/load-annotations').LoadAnnotationsService} loadAnnotationsService
+ * @prop {import('../services/streamer').default} streamer
  */
 
 /**

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -114,7 +114,7 @@ import { AutosaveService } from './services/autosave';
 import { FeaturesService } from './services/features';
 import { FrameSyncService } from './services/frame-sync';
 import groupsService from './services/groups';
-import loadAnnotationsService from './services/load-annotations';
+import { LoadAnnotationsService } from './services/load-annotations';
 import { LocalStorageService } from './services/local-storage';
 import { PersistedDefaultsService } from './services/persisted-defaults';
 import { RouterService } from './services/router';
@@ -152,7 +152,7 @@ function startApp(config, appEl) {
     .register('features', FeaturesService)
     .register('frameSync', FrameSyncService)
     .register('groups', groupsService)
-    .register('loadAnnotationsService', loadAnnotationsService)
+    .register('loadAnnotationsService', LoadAnnotationsService)
     .register('localStorage', LocalStorageService)
     .register('persistedDefaults', PersistedDefaultsService)
     .register('router', RouterService)

--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -1,6 +1,5 @@
-import { SearchClient } from '../search-client';
-
 import { isReply } from '../helpers/annotation-metadata';
+import { SearchClient } from '../search-client';
 
 /**
  * @typedef {import('../search-client').SortBy} SortBy

--- a/src/sidebar/services/test/load-annotations-test.js
+++ b/src/sidebar/services/test/load-annotations-test.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'tiny-emitter';
 
-import loadAnnotationsService, { $imports } from '../load-annotations';
+import { LoadAnnotationsService, $imports } from '../load-annotations';
 
 let searchClients;
 let longRunningSearchClient = false;
@@ -45,7 +45,7 @@ class FakeSearchClient extends EventEmitter {
   }
 }
 
-describe('loadAnnotationsService', () => {
+describe('LoadAnnotationsService', () => {
   let fakeApi;
   let fakeStore;
   let fakeStreamer;
@@ -112,7 +112,7 @@ describe('loadAnnotationsService', () => {
         return { uri: uri };
       })
     );
-    return loadAnnotationsService(
+    return new LoadAnnotationsService(
       fakeApi,
       fakeStore,
       fakeStreamer,
@@ -120,7 +120,7 @@ describe('loadAnnotationsService', () => {
     );
   }
 
-  describe('load', () => {
+  describe('#load', () => {
     it('unloads any existing annotations', () => {
       // When new clients connect, all existing annotations should be unloaded
       // before reloading annotations for each currently-connected client.
@@ -382,7 +382,7 @@ describe('loadAnnotationsService', () => {
     });
   });
 
-  describe('loadThread', () => {
+  describe('#loadThread', () => {
     let threadAnnotations = [
       { id: 'parent_annotation_1' },
       { id: 'parent_annotation_2', references: ['parent_annotation_1'] },


### PR DESCRIPTION
Convert this service to a class and expand the documentation slightly.
This is a straightforward conversion with no API or internal changes (other than the class-ification).

Part of https://github.com/hypothesis/client/issues/3298