### PR TITLE
Rephrased comment referring to Delegator

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -208,8 +208,8 @@ export default class Sidebar {
     this.guest.crossframe.on('openSidebar', () => this.open());
     this.guest.crossframe.on('closeSidebar', () => this.close());
 
-    // Re-publish the crossframe event so that anything extending Delegator
-    // can subscribe to it (without need for crossframe)
+    // Sidebar listens to the `openNotebook` event coming from the sidebar's
+    // iframe and re-publish it via the emitter to the Notebook
     this.guest.crossframe.on('openNotebook', (
       /** @type {string} */ groupId
     ) => {

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -209,7 +209,7 @@ export default class Sidebar {
     this.guest.crossframe.on('closeSidebar', () => this.close());
 
     // Sidebar listens to the `openNotebook` event coming from the sidebar's
-    // iframe and re-publish it via the emitter to the Notebook
+    // iframe and re-publishes it via the emitter to the Notebook
     this.guest.crossframe.on('openNotebook', (
       /** @type {string} */ groupId
     ) => {


### PR DESCRIPTION
Delegator does no longer exits.

The new comment explains the source of the events and its final
destination.