### PR TITLE
Move anchor scrolling logic to integrations

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -1,5 +1,3 @@
-import scrollIntoView from 'scroll-into-view';
-
 import { Adder } from './adder';
 import { CrossFrame } from './cross-frame';
 import { HTMLIntegration } from './integrations/html';
@@ -310,7 +308,7 @@ export default class Guest {
       const defaultNotPrevented = this.element.dispatchEvent(event);
 
       if (defaultNotPrevented) {
-        scrollIntoView(anchor.highlights[0]);
+        this._integration.scrollToAnchor(anchor);
       }
     });
 

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -300,6 +300,9 @@ export default class Guest {
         return;
       }
 
+      // Emit a custom event that the host page can respond to. This is useful,
+      // for example, if the highlighted content is contained in a collapsible
+      // section of the page that needs to be un-collapsed.
       const event = new CustomEvent('scrolltorange', {
         bubbles: true,
         cancelable: true,

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -293,25 +293,24 @@ export default class Guest {
     });
 
     this.crossframe.on('scrollToAnnotation', tag => {
-      for (let anchor of this.anchors) {
-        if (anchor.highlights) {
-          if (anchor.annotation.$tag === tag) {
-            const range = resolveAnchor(anchor);
-            if (!range) {
-              continue;
-            }
+      const anchor = this.anchors.find(a => a.annotation.$tag === tag);
+      if (!anchor?.highlights) {
+        return;
+      }
+      const range = resolveAnchor(anchor);
+      if (!range) {
+        return;
+      }
 
-            const event = new CustomEvent('scrolltorange', {
-              bubbles: true,
-              cancelable: true,
-              detail: range,
-            });
-            const defaultNotPrevented = this.element.dispatchEvent(event);
-            if (defaultNotPrevented) {
-              scrollIntoView(anchor.highlights[0]);
-            }
-          }
-        }
+      const event = new CustomEvent('scrolltorange', {
+        bubbles: true,
+        cancelable: true,
+        detail: range,
+      });
+      const defaultNotPrevented = this.element.dispatchEvent(event);
+
+      if (defaultNotPrevented) {
+        scrollIntoView(anchor.highlights[0]);
       }
     });
 

--- a/src/annotator/integrations/html.js
+++ b/src/annotator/integrations/html.js
@@ -1,8 +1,11 @@
+import scrollIntoView from 'scroll-into-view';
+
 import { anchor, describe } from '../anchoring/html';
 
 import { HTMLMetadata } from './html-metadata';
 
 /**
+ * @typedef {import('../../types/annotator').Anchor} Anchor
  * @typedef {import('../../types/annotator').Integration} Integration
  */
 
@@ -42,5 +45,15 @@ export class HTMLIntegration {
 
   async uri() {
     return this._htmlMeta.uri();
+  }
+
+  /**
+   * @param {Anchor} anchor
+   */
+  scrollToAnchor(anchor) {
+    const highlights = /** @type {Element[]} */ (anchor.highlights);
+    return new Promise(resolve => {
+      scrollIntoView(highlights[0], resolve);
+    });
   }
 }

--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -1,5 +1,6 @@
 import debounce from 'lodash.debounce';
 import { render } from 'preact';
+import scrollIntoView from 'scroll-into-view';
 
 import {
   RenderingStates,
@@ -309,5 +310,17 @@ export class PDFIntegration {
     this.pdfViewer.update();
 
     return active;
+  }
+
+  /**
+   * @param {Anchor} anchor
+   */
+  scrollToAnchor(anchor) {
+    // TODO - Account for pages changing state between un-rendered and rendered
+    // while scrolling.
+    const highlights = /** @type {Element[]} */ (anchor.highlights);
+    return new Promise(resolve => {
+      scrollIntoView(highlights[0], resolve);
+    });
   }
 }

--- a/src/annotator/integrations/test/html-test.js
+++ b/src/annotator/integrations/test/html-test.js
@@ -3,6 +3,7 @@ import { HTMLIntegration, $imports } from '../html';
 describe('HTMLIntegration', () => {
   let fakeHTMLAnchoring;
   let fakeHTMLMetadata;
+  let fakeScrollIntoView;
 
   beforeEach(() => {
     fakeHTMLAnchoring = {
@@ -15,8 +16,11 @@ describe('HTMLIntegration', () => {
       uri: sinon.stub().returns('https://example.com/'),
     };
 
+    fakeScrollIntoView = sinon.stub().yields();
+
     const HTMLMetadata = sinon.stub().returns(fakeHTMLMetadata);
     $imports.$mock({
+      'scroll-into-view': fakeScrollIntoView,
       '../anchoring/html': fakeHTMLAnchoring,
       './html-metadata': { HTMLMetadata },
     });
@@ -57,6 +61,21 @@ describe('HTMLIntegration', () => {
       assert.deepEqual(await integration.getMetadata(), {
         title: 'Example site',
       });
+    });
+  });
+
+  describe('#scrollToAnchor', () => {
+    it('scrolls to first highlight of anchor', async () => {
+      const highlight = document.createElement('div');
+      document.body.appendChild(highlight);
+
+      const anchor = { highlights: [highlight] };
+
+      const integration = new HTMLIntegration();
+      await integration.scrollToAnchor(anchor);
+
+      assert.calledOnce(fakeScrollIntoView);
+      assert.calledWith(fakeScrollIntoView, highlight, sinon.match.func);
     });
   });
 

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -26,6 +26,7 @@ describe('PDFIntegration', () => {
   let fakePDFAnchoring;
   let fakePDFMetadata;
   let fakePDFViewerApplication;
+  let fakeScrollIntoView;
   let pdfIntegration;
 
   function createPDFIntegration() {
@@ -61,6 +62,8 @@ describe('PDFIntegration', () => {
       documentHasText: sinon.stub().resolves(true),
     };
 
+    fakeScrollIntoView = sinon.stub().yields();
+
     fakePDFMetadata = {
       getMetadata: sinon
         .stub()
@@ -69,6 +72,7 @@ describe('PDFIntegration', () => {
     };
 
     $imports.$mock({
+      'scroll-into-view': fakeScrollIntoView,
       './pdf-metadata': { PDFMetadata: sinon.stub().returns(fakePDFMetadata) },
       '../anchoring/pdf': fakePDFAnchoring,
 
@@ -359,6 +363,21 @@ describe('PDFIntegration', () => {
       assert.isFalse(active);
       assert.calledOnce(fakePDFViewerApplication.pdfViewer.update);
       assert.equal(pdfContainer().style.width, 'auto');
+    });
+  });
+
+  describe('#scrollToAnchor', () => {
+    it('scrolls to first highlight of anchor', async () => {
+      const highlight = document.createElement('div');
+      document.body.appendChild(highlight);
+
+      const anchor = { highlights: [highlight] };
+
+      const integration = createPDFIntegration();
+      await integration.scrollToAnchor(anchor);
+
+      assert.calledOnce(fakeScrollIntoView);
+      assert.calledWith(fakeScrollIntoView, highlight, sinon.match.func);
     });
   });
 });

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -325,6 +325,15 @@ describe('Guest', () => {
         assert.notCalled(fakeHTMLIntegration.scrollToAnchor);
       });
 
+      it('does nothing if the anchor has no highlights', () => {
+        const guest = createGuest();
+
+        guest.anchors = [{ annotation: { $tag: 'tag1' } }];
+        emitGuestEvent('scrollToAnnotation', 'tag1');
+
+        assert.notCalled(fakeHTMLIntegration.scrollToAnchor);
+      });
+
       it("does nothing if the anchor's range cannot be resolved", () => {
         const highlight = document.createElement('span');
         const guest = createGuest();

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -2,8 +2,6 @@ import Guest from '../guest';
 import { EventBus } from '../util/emitter';
 import { $imports } from '../guest';
 
-const scrollIntoView = sinon.stub();
-
 class FakeAdder {
   constructor(container, options) {
     FakeAdder.instance = this;
@@ -90,6 +88,7 @@ describe('Guest', () => {
       destroy: sinon.stub(),
       fitSideBySide: sinon.stub(),
       getMetadata: sinon.stub().resolves({ title: 'Test title' }),
+      scrollToAnchor: sinon.stub().resolves(),
       uri: sinon.stub().resolves('https://example.com/test.html'),
     };
     HTMLIntegration = sinon.stub().returns(fakeHTMLIntegration);
@@ -101,6 +100,7 @@ describe('Guest', () => {
       getMetadata: sinon
         .stub()
         .resolves({ documentFingerprint: 'test-fingerprint' }),
+      scrollToAnchor: sinon.stub().resolves(),
       uri: sinon.stub().resolves('https://example.com/test.pdf'),
     };
     PDFIntegration = sinon.stub().returns(fakePDFIntegration);
@@ -125,7 +125,6 @@ describe('Guest', () => {
       './selection-observer': {
         SelectionObserver: FakeSelectionObserver,
       },
-      'scroll-into-view': scrollIntoView,
     });
   });
 
@@ -266,10 +265,6 @@ describe('Guest', () => {
     });
 
     describe('on "scrollToAnnotation" event', () => {
-      beforeEach(() => {
-        scrollIntoView.reset();
-      });
-
       it('scrolls to the anchor with the matching tag', () => {
         const highlight = document.createElement('span');
         const guest = createGuest();
@@ -284,8 +279,8 @@ describe('Guest', () => {
 
         emitGuestEvent('scrollToAnnotation', 'tag1');
 
-        assert.called(scrollIntoView);
-        assert.calledWith(scrollIntoView, highlight);
+        assert.called(fakeHTMLIntegration.scrollToAnchor);
+        assert.calledWith(fakeHTMLIntegration.scrollToAnchor, guest.anchors[0]);
       });
 
       it('emits a "scrolltorange" DOM event', () => {
@@ -327,7 +322,7 @@ describe('Guest', () => {
 
         emitGuestEvent('scrollToAnnotation', 'tag1');
 
-        assert.notCalled(scrollIntoView);
+        assert.notCalled(fakeHTMLIntegration.scrollToAnchor);
       });
 
       it("does nothing if the anchor's range cannot be resolved", () => {
@@ -348,7 +343,7 @@ describe('Guest', () => {
         emitGuestEvent('scrollToAnnotation', 'tag1');
 
         assert.notCalled(eventEmitted);
-        assert.notCalled(scrollIntoView);
+        assert.notCalled(fakeHTMLIntegration.scrollToAnchor);
       });
     });
 

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -107,6 +107,9 @@
  *   the currently loaded document, such as title, PDF fingerprint, etc.
  * @prop {() => Promise<string>} uri - Return the URL of the currently loaded document.
  *   This may be different than the current URL (`location.href`) in a PDF for example.
+ * @prop {(a: Anchor) => Promise<void>} scrollToAnchor - Scroll to an anchor.
+ *   This will only be called if the anchor has at least one highlight (ie.
+ *   `anchor.highlights` is a non-empty array)
  */
 
 /**


### PR DESCRIPTION
The client currently uses the same logic to scroll to a highlight for PDF and HTML documents. For PDF documents additional logic will be required to deal with the fact that pages can change between being un-rendered and rendered as the document scrolls, which causes https://github.com/hypothesis/client/issues/3269.

This PR is an initial step towards that by moving the logic for scrolling to an anchor from the `Guest` class to the `HTMLIntegration` and `PDFIntegration` classes as a `scrollToAnchor` method.

- The first commit refactors a `"scrollToAnnotation"` event handler in `Guest` for readability
- The second commit adds a `scrollToAnchor` method to the `*Integration` classes and modifies `Guest` to use it. The initial implementation of `scrollToAnchor` in the *Integration classes is the same as before, so there should be no functional changes

Part of https://github.com/hypothesis/client/issues/3269

