### PR TITLE
Fix scrolling to highlights in un-rendered PDF pages

### DIFF
--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -353,6 +353,9 @@ export class PDFIntegration {
       return;
     }
 
+    // nb. We only compute the scroll offset once at the start of scrolling.
+    // This is important as the highlight may be removed from the document during
+    // the scroll due to a page transitioning from rendered <-> un-rendered.
     await scrollElement(this.contentContainer(), offset);
 
     if (inPlaceholder) {

--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -54,7 +54,7 @@ export class PDFIntegration {
   /**
    * @param {Annotator} annotator
    * @param {object} options
-   *   @param {number} [options.reanchoringWait] - Max time to wait for
+   *   @param {number} [options.reanchoringMaxWait] - Max time to wait for
    *     re-anchoring to complete when scrolling to an un-rendered page.
    */
   constructor(annotator, options = {}) {
@@ -82,7 +82,7 @@ export class PDFIntegration {
      * Amount of time to wait for re-anchoring to complete when scrolling to
      * an anchor in a not-yet-rendered page.
      */
-    this._reanchoringWait = options.reanchoringWait ?? 3000;
+    this._reanchoringMaxWait = options.reanchoringMaxWait ?? 3000;
 
     /**
      * A banner shown at the top of the PDF viewer warning the user if the PDF
@@ -361,7 +361,7 @@ export class PDFIntegration {
     if (inPlaceholder) {
       const anchor = await this._waitForAnnotationToBeAnchored(
         annotation,
-        this._reanchoringWait
+        this._reanchoringMaxWait
       );
       if (!anchor) {
         return;
@@ -390,6 +390,9 @@ export class PDFIntegration {
       anchor = this.annotator.anchors.find(a => a.annotation === annotation);
       if (!anchor || anchorIsInPlaceholder(anchor)) {
         anchor = null;
+
+        // If no anchor was found, wait a bit longer and check again to see if
+        // re-anchoring completed.
         await delay(20);
       }
     } while (!anchor && Date.now() - start < maxWait);

--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -35,7 +35,7 @@ const MIN_PDF_WIDTH = 680;
  *
  * @param {Anchor} anchor
  */
-function anchorIsPlaceholder(anchor) {
+function anchorIsInPlaceholder(anchor) {
   const highlight = anchor.highlights?.[0];
   return highlight && isInPlaceholder(highlight);
 }
@@ -347,7 +347,7 @@ export class PDFIntegration {
    */
   async scrollToAnchor(anchor) {
     const annotation = anchor.annotation;
-    const isPlaceholder = anchorIsPlaceholder(anchor);
+    const inPlaceholder = anchorIsInPlaceholder(anchor);
     const offset = this._anchorOffset(anchor);
     if (offset === null) {
       return;
@@ -355,7 +355,7 @@ export class PDFIntegration {
 
     await scrollElement(this.contentContainer(), offset);
 
-    if (isPlaceholder) {
+    if (inPlaceholder) {
       const anchor = await this._waitForAnnotationToBeAnchored(
         annotation,
         this._reanchoringWait
@@ -385,7 +385,7 @@ export class PDFIntegration {
       // nb. Re-anchoring might result in a different anchor object for the
       // same annotation.
       anchor = this.annotator.anchors.find(a => a.annotation === annotation);
-      if (!anchor || anchorIsPlaceholder(anchor)) {
+      if (!anchor || anchorIsInPlaceholder(anchor)) {
         anchor = null;
         await delay(20);
       }

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -456,7 +456,7 @@ describe('PDFIntegration', () => {
 
     it('skips scrolling to final anchor if re-anchoring does not complete within timeout', async () => {
       const highlight = createPlaceholderHighlight();
-      const integration = createPDFIntegration({ reanchoringWait: 10 });
+      const integration = createPDFIntegration({ reanchoringMaxWait: 10 });
       const annotation = { $tag: 'tag1' };
       const anchor = { annotation, highlights: [highlight] };
 

--- a/src/annotator/util/scroll.js
+++ b/src/annotator/util/scroll.js
@@ -1,0 +1,74 @@
+/**
+ * Return a promise that resolves on the next animation frame.
+ */
+function nextAnimationFrame() {
+  return new Promise(resolve => {
+    requestAnimationFrame(resolve);
+  });
+}
+
+/**
+ * Linearly interpolate between two values.
+ *
+ * @param {number} a
+ * @param {number} b
+ * @param {number} fraction - Value in [0, 1]
+ */
+function interpolate(a, b, fraction) {
+  return a + fraction * (b - a);
+}
+
+/**
+ * Return the offset of `element` from the top of a positioned ancestor `parent`.
+ *
+ * @param {HTMLElement} element
+ * @param {HTMLElement} parent - Positioned ancestor of `element`
+ * @return {number}
+ */
+export function offsetRelativeTo(element, parent) {
+  let offset = 0;
+  while (element !== parent && parent.contains(element)) {
+    offset += element.offsetTop;
+    element = /** @type {HTMLElement} */ (element.offsetParent);
+  }
+  return offset;
+}
+
+/**
+ * Scroll `element` until its `scrollTop` offset reaches a target value.
+ *
+ * @param {Element} element - Container element to scroll
+ * @param {number} offset - Target value for the scroll offset
+ * @param {object} options
+ *   @param {number} [options.maxDuration]
+ * @return {Promise<void>} - A promise that resolves once the scroll animation
+ *   is complete
+ */
+export async function scrollElement(
+  element,
+  offset,
+  { maxDuration = 500 } = {}
+) {
+  const initialOffset = element.scrollTop;
+  const targetOffset = offset;
+  const scrollStart = Date.now();
+
+  // Choose a scroll duration proportional to the scroll distance, but capped
+  // to avoid it being too slow.
+  const pixelsPerMs = 3;
+  const scrollDuration = Math.min(
+    Math.abs(targetOffset - initialOffset) / pixelsPerMs,
+    maxDuration
+  );
+
+  let scrollFraction = 0.0;
+  while (scrollFraction < 1.0) {
+    await nextAnimationFrame();
+    scrollFraction = Math.min(1.0, (Date.now() - scrollStart) / scrollDuration);
+    element.scrollTop = interpolate(
+      initialOffset,
+      targetOffset,
+      scrollFraction
+    );
+  }
+}

--- a/src/annotator/util/scroll.js
+++ b/src/annotator/util/scroll.js
@@ -47,6 +47,7 @@ export function offsetRelativeTo(element, parent) {
 export async function scrollElement(
   element,
   offset,
+  /* istanbul ignore next - default options are overridden in tests */
   { maxDuration = 500 } = {}
 ) {
   const initialOffset = element.scrollTop;

--- a/src/annotator/util/scroll.js
+++ b/src/annotator/util/scroll.js
@@ -50,15 +50,15 @@ export async function scrollElement(
   /* istanbul ignore next - default options are overridden in tests */
   { maxDuration = 500 } = {}
 ) {
-  const initialOffset = element.scrollTop;
-  const targetOffset = offset;
+  const startOffset = element.scrollTop;
+  const endOffset = offset;
   const scrollStart = Date.now();
 
   // Choose a scroll duration proportional to the scroll distance, but capped
   // to avoid it being too slow.
   const pixelsPerMs = 3;
   const scrollDuration = Math.min(
-    Math.abs(targetOffset - initialOffset) / pixelsPerMs,
+    Math.abs(endOffset - startOffset) / pixelsPerMs,
     maxDuration
   );
 
@@ -66,10 +66,6 @@ export async function scrollElement(
   while (scrollFraction < 1.0) {
     await nextAnimationFrame();
     scrollFraction = Math.min(1.0, (Date.now() - scrollStart) / scrollDuration);
-    element.scrollTop = interpolate(
-      initialOffset,
-      targetOffset,
-      scrollFraction
-    );
+    element.scrollTop = interpolate(startOffset, endOffset, scrollFraction);
   }
 }

--- a/src/annotator/util/test/scroll-test.js
+++ b/src/annotator/util/test/scroll-test.js
@@ -1,0 +1,71 @@
+import { offsetRelativeTo, scrollElement } from '../scroll';
+
+describe('annotator/util/scroll', () => {
+  let containers;
+
+  beforeEach(() => {
+    sinon.stub(window, 'requestAnimationFrame');
+    window.requestAnimationFrame.yields();
+    containers = [];
+  });
+
+  afterEach(() => {
+    containers.forEach(c => c.remove());
+    window.requestAnimationFrame.restore();
+  });
+
+  function createContainer() {
+    const el = document.createElement('div');
+    containers.push(el);
+    document.body.append(el);
+    return el;
+  }
+
+  describe('offsetRelativeTo', () => {
+    it('returns the offset of an element relative to the given ancestor', () => {
+      const parent = createContainer();
+      parent.style.position = 'relative';
+
+      const child = document.createElement('div');
+      child.style.position = 'absolute';
+      child.style.top = '100px';
+      parent.append(child);
+
+      const grandchild = document.createElement('div');
+      grandchild.style.position = 'absolute';
+      grandchild.style.top = '150px';
+      child.append(grandchild);
+
+      assert.equal(offsetRelativeTo(child, parent), 100);
+      assert.equal(offsetRelativeTo(grandchild, parent), 250);
+    });
+
+    it('returns 0 if the parent is not an ancestor of the element', () => {
+      const parent = document.createElement('div');
+      const child = document.createElement('div');
+      child.style.position = 'absolute';
+      child.style.top = '100px';
+
+      assert.equal(offsetRelativeTo(child, parent), 0);
+    });
+  });
+
+  describe('scrollElement', () => {
+    it("animates the element's `scrollTop` offset to the target position", async () => {
+      const container = createContainer();
+      container.style.overflow = 'scroll';
+      container.style.width = '200px';
+      container.style.height = '500px';
+      container.style.position = 'relative';
+
+      const child = document.createElement('div');
+      child.style.height = '3000px';
+      container.append(child);
+
+      await scrollElement(container, 2000, { maxDuration: 5 });
+
+      assert.equal(container.scrollTop, 2000);
+      container.remove();
+    });
+  });
+});


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/3343**~~

When scrolling to an anchor in a page that has not been rendered by
PDF.js, the anchor actually references a placeholder element in the
middle of the page. In order to scroll to the correct location, scrolling
for such anchors needs to happen in three phases:

 1. Scroll to the approximate location of the final anchor, given by the
    placeholder anchor. This will trigger PDF.js to re-render the target
    page.
 2. Wait for PDF.js to finish re-rendering the page and for the client
    to finish re-anchoring the annotation.
 3. Scroll to the real/non-placeholder anchor.

Changes in detail:

- Add a `scrollElement` utility in `annotator/util/scroll.js` which animates an element's scroll to a target offset and returns a promise for when the scroll is complete
- Change `PDFIntegration`'s `scrollToAnchor` method to make use of `scrollElement` to implement the three-phase scrolling process described above

Known issues:

- When scrolling to an annotation in an un-rendered page, the highlight should appear focused, but does not. I will address this separately (see https://github.com/hypothesis/client/pull/3345).
- Depending on system performance, PDF complexity etc. scrolling can feel too slow. I'm planning to tweak this once the basic functionality is working properly. In this PR the total scrolling time should be about the same as before

Fixes https://github.com/hypothesis/client/issues/3269