### PR TITLE
Make bucket bar use document-type specific scroll-to-anchor method

### DIFF
--- a/src/annotator/bucket-bar.js
+++ b/src/annotator/bucket-bar.js
@@ -18,7 +18,7 @@ import { ListenerCollection } from './util/listener-collection';
 export default class BucketBar {
   /**
    * @param {HTMLElement} container
-   * @param {Pick<import('./guest').default, 'anchors'|'selectAnnotations'>} guest
+   * @param {Pick<import('./guest').default, 'anchors'|'scrollToAnchor'|'selectAnnotations'>} guest
    * @param {BucketBarOptions} [options]
    */
   constructor(container, guest, { contentContainer = document.body } = {}) {
@@ -65,6 +65,7 @@ export default class BucketBar {
         onSelectAnnotations={(annotations, toggle) =>
           this._guest.selectAnnotations(annotations, toggle)
         }
+        scrollToAnchor={anchor => this._guest.scrollToAnchor(anchor)}
       />,
       this._bucketsContainer
     );

--- a/src/annotator/components/Buckets.js
+++ b/src/annotator/components/Buckets.js
@@ -1,11 +1,11 @@
 import classnames from 'classnames';
-import scrollIntoView from 'scroll-into-view';
 
 import { setHighlightsFocused } from '../highlighter';
 import { findClosestOffscreenAnchor } from '../util/buckets';
 
 /**
  * @typedef {import('../../types/annotator').AnnotationData} AnnotationData
+ * @typedef {import('../../types/annotator').Anchor} Anchor
  * @typedef {import('../util/buckets').Bucket} Bucket
  */
 
@@ -53,14 +53,15 @@ function BucketButton({ bucket, onSelectAnnotations }) {
  * @param {Object} props
  *   @param {Bucket} props.bucket
  *   @param {'up'|'down'} props.direction
+ *   @param {(a: Anchor) => void} props.scrollToAnchor
  */
-function NavigationBucketButton({ bucket, direction }) {
+function NavigationBucketButton({ bucket, direction, scrollToAnchor }) {
   const buttonTitle = `Go ${direction} to next annotations (${bucket.anchors.length})`;
 
   function scrollToClosest() {
     const closest = findClosestOffscreenAnchor(bucket.anchors, direction);
-    if (closest?.highlights?.length) {
-      scrollIntoView(closest.highlights[0]);
+    if (closest) {
+      scrollToAnchor(closest);
     }
   }
 
@@ -85,12 +86,14 @@ function NavigationBucketButton({ bucket, direction }) {
  *   @param {Bucket} props.below
  *   @param {Bucket[]} props.buckets
  *   @param {(annotations: AnnotationData[], toggle: boolean) => any} props.onSelectAnnotations
+ *   @param {(a: Anchor) => void} props.scrollToAnchor
  */
 export default function Buckets({
   above,
   below,
   buckets,
   onSelectAnnotations,
+  scrollToAnchor,
 }) {
   const showUpNavigation = above.anchors.length > 0;
   const showDownNavigation = below.anchors.length > 0;
@@ -99,7 +102,11 @@ export default function Buckets({
     <ul className="Buckets__list">
       {showUpNavigation && (
         <li className="Buckets__bucket" style={{ top: above.position }}>
-          <NavigationBucketButton bucket={above} direction="up" />
+          <NavigationBucketButton
+            bucket={above}
+            direction="up"
+            scrollToAnchor={scrollToAnchor}
+          />
         </li>
       )}
       {buckets.map((bucket, index) => (
@@ -116,7 +123,11 @@ export default function Buckets({
       ))}
       {showDownNavigation && (
         <li className="Buckets__bucket" style={{ top: below.position }}>
-          <NavigationBucketButton bucket={below} direction="down" />
+          <NavigationBucketButton
+            bucket={below}
+            direction="down"
+            scrollToAnchor={scrollToAnchor}
+          />
         </li>
       )}
     </ul>

--- a/src/annotator/components/Buckets.js
+++ b/src/annotator/components/Buckets.js
@@ -53,7 +53,8 @@ function BucketButton({ bucket, onSelectAnnotations }) {
  * @param {Object} props
  *   @param {Bucket} props.bucket
  *   @param {'up'|'down'} props.direction
- *   @param {(a: Anchor) => void} props.scrollToAnchor
+ *   @param {(a: Anchor) => void} props.scrollToAnchor - Callback invoked to
+ *     scroll the document to a given anchor
  */
 function NavigationBucketButton({ bucket, direction, scrollToAnchor }) {
   const buttonTitle = `Go ${direction} to next annotations (${bucket.anchors.length})`;
@@ -86,7 +87,8 @@ function NavigationBucketButton({ bucket, direction, scrollToAnchor }) {
  *   @param {Bucket} props.below
  *   @param {Bucket[]} props.buckets
  *   @param {(annotations: AnnotationData[], toggle: boolean) => any} props.onSelectAnnotations
- *   @param {(a: Anchor) => void} props.scrollToAnchor
+ *   @param {(a: Anchor) => void} props.scrollToAnchor - Callback invoked to
+ *     scroll the document to a given anchor
  */
 export default function Buckets({
   above,

--- a/src/annotator/components/test/Buckets-test.js
+++ b/src/annotator/components/test/Buckets-test.js
@@ -7,7 +7,6 @@ import Buckets, { $imports } from '../Buckets';
 describe('Buckets', () => {
   let fakeBucketsUtil;
   let fakeHighlighter;
-  let fakeScrollIntoView;
 
   let fakeAbove;
   let fakeBelow;
@@ -43,10 +42,8 @@ describe('Buckets', () => {
     fakeHighlighter = {
       setHighlightsFocused: sinon.stub(),
     };
-    fakeScrollIntoView = sinon.stub();
 
     $imports.$mock({
-      'scroll-into-view': fakeScrollIntoView,
       '../highlighter': fakeHighlighter,
       '../util/buckets': fakeBucketsUtil,
     });
@@ -99,7 +96,8 @@ describe('Buckets', () => {
     it('scrolls to anchors above when up navigation button is pressed', () => {
       const fakeAnchor = { highlights: ['hi'] };
       fakeBucketsUtil.findClosestOffscreenAnchor.returns(fakeAnchor);
-      const wrapper = createComponent();
+      const scrollToAnchor = sinon.stub();
+      const wrapper = createComponent({ scrollToAnchor });
       const upButton = wrapper.find('.Buckets__button--up');
 
       upButton.simulate('click');
@@ -109,13 +107,14 @@ describe('Buckets', () => {
         fakeAbove.anchors,
         'up'
       );
-      assert.calledWith(fakeScrollIntoView, fakeAnchor.highlights[0]);
+      assert.calledWith(scrollToAnchor, fakeAnchor);
     });
 
     it('scrolls to anchors below when down navigation button is pressed', () => {
       const fakeAnchor = { highlights: ['hi'] };
       fakeBucketsUtil.findClosestOffscreenAnchor.returns(fakeAnchor);
-      const wrapper = createComponent();
+      const scrollToAnchor = sinon.stub();
+      const wrapper = createComponent({ scrollToAnchor });
       const downButton = wrapper.find('.Buckets__button--down');
 
       downButton.simulate('click');
@@ -125,7 +124,7 @@ describe('Buckets', () => {
         fakeBelow.anchors,
         'down'
       );
-      assert.calledWith(fakeScrollIntoView, fakeAnchor.highlights[0]);
+      assert.calledWith(scrollToAnchor, fakeAnchor);
     });
   });
 

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -593,6 +593,15 @@ export default class Guest {
   }
 
   /**
+   * Scroll the document content so that `anchor` is visible.
+   *
+   * @param {Anchor} anchor
+   */
+  scrollToAnchor(anchor) {
+    return this._integration.scrollToAnchor(anchor);
+  }
+
+  /**
    * Set whether highlights are visible in the document or not.
    *
    * @param {boolean} shouldShowHighlights

--- a/src/annotator/test/bucket-bar-test.js
+++ b/src/annotator/test/bucket-bar-test.js
@@ -3,14 +3,14 @@ import { $imports } from '../bucket-bar';
 
 describe('BucketBar', () => {
   const sandbox = sinon.createSandbox();
-  let fakeAnnotator;
+  let fakeGuest;
   let fakeBucketUtil;
   let bucketBars;
   let bucketProps;
   let container;
 
   const createBucketBar = function (options) {
-    const bucketBar = new BucketBar(container, fakeAnnotator, options);
+    const bucketBar = new BucketBar(container, fakeGuest, options);
     bucketBars.push(bucketBar);
     return bucketBar;
   };
@@ -19,8 +19,9 @@ describe('BucketBar', () => {
     container = document.createElement('div');
     bucketBars = [];
     bucketProps = {};
-    fakeAnnotator = {
+    fakeGuest = {
       anchors: [],
+      scrollToAnchor: sinon.stub(),
       selectAnnotations: sinon.stub(),
     };
 
@@ -50,7 +51,7 @@ describe('BucketBar', () => {
 
   it('should render buckets for existing anchors when constructed', () => {
     const bucketBar = createBucketBar();
-    assert.calledWith(fakeBucketUtil.anchorBuckets, fakeAnnotator.anchors);
+    assert.calledWith(fakeBucketUtil.anchorBuckets, fakeGuest.anchors);
     assert.ok(bucketBar._bucketsContainer.querySelector('.FakeBuckets'));
   });
 
@@ -79,7 +80,17 @@ describe('BucketBar', () => {
 
       const fakeAnnotations = ['hi', 'there'];
       bucketProps.onSelectAnnotations(fakeAnnotations, true);
-      assert.calledWith(fakeAnnotator.selectAnnotations, fakeAnnotations, true);
+      assert.calledWith(fakeGuest.selectAnnotations, fakeAnnotations, true);
+    });
+
+    it('should scroll to anchor when Buckets component invokes callback', () => {
+      const bucketBar = createBucketBar();
+      bucketBar._update();
+
+      const anchor = {};
+      bucketProps.scrollToAnchor(anchor);
+
+      assert.calledWith(fakeGuest.scrollToAnchor, anchor);
     });
 
     context('when `contentContainer` is specified', () => {

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -709,6 +709,17 @@ describe('Guest', () => {
     });
   });
 
+  describe('#scrollToAnchor', () => {
+    it("invokes the document integration's `scrollToAnchor` implementation", () => {
+      const guest = createGuest();
+      const anchor = {};
+
+      guest.scrollToAnchor(anchor);
+
+      assert.calledWith(fakeHTMLIntegration.scrollToAnchor, anchor);
+    });
+  });
+
   describe('#getDocumentInfo', () => {
     let guest;
 


### PR DESCRIPTION
9bec434d784a7457462c00d0e993537045c8e51f moved the logic for scrolling
to an anchor into the document integrations, in order to enable
custom logic depending on the document type. The bucket bar however
was still using a generic approach.

Change the bucket bar to use the same `scrollToAnchor` implementation as
when scrolling is triggered by clicking an annotation card in the
sidebar.

 - Add `scrollToAnchor` method to `Guest`
 - Modify bucket bar controller to use this method

Related to https://github.com/hypothesis/client/issues/3269