### PR TITLE
Ignore zero-height highlights when creating bucket bar buckets

### DIFF
--- a/src/annotator/util/buckets.js
+++ b/src/annotator/util/buckets.js
@@ -118,6 +118,10 @@ function getAnchorPositions(anchors) {
       return;
     }
     const anchorBox = getBoundingClientRect(anchor.highlights);
+    if (anchorBox.top >= anchorBox.bottom) {
+      // Empty rect. The highlights may be disconnected from the document or hidden.
+      return;
+    }
     anchorPositions.push({
       top: anchorBox.top,
       bottom: anchorBox.bottom,

--- a/src/annotator/util/test/buckets-test.js
+++ b/src/annotator/util/test/buckets-test.js
@@ -165,11 +165,18 @@ describe('annotator/util/buckets', () => {
 
     it('only buckets annotations that have highlights', () => {
       const badAnchor = { highlights: [] };
-      fakeAnchors.push(badAnchor);
       const bucketSet = anchorBuckets([badAnchor]);
       assert.equal(bucketSet.buckets.length, 0);
       assert.isEmpty(bucketSet.above.anchors); // Holder for above-screen anchors
       assert.isEmpty(bucketSet.below.anchors); // Holder for below-screen anchors
+    });
+
+    it('does not bucket annotations whose highlights have zero area', () => {
+      const badAnchor = { highlights: [0, 0] };
+      const bucketSet = anchorBuckets([badAnchor]);
+      assert.equal(bucketSet.buckets.length, 0);
+      assert.isEmpty(bucketSet.above.anchors);
+      assert.isEmpty(bucketSet.below.anchors);
     });
 
     it('sorts anchors by top position', () => {


### PR DESCRIPTION
When a PDF page transitions from a rendered to non-rendered state the
text layer element is removed and existing highlights in that layer
briefly become disconnected from the document. As a result they have an
empty/zero client rect as returned by `element.getBoundingClientRect()`.
This caused the bucket-building logic to think that the anchor
had moved to the top of the screen as the `top` and `bottom` coordinates
of the anchor box became zero. This could lead to anchors which should
be in the "below screen" bucket briefly jumping to the "above screen"
bucket. Once re-anchoring completes and the highlight is anchored into a
placeholder element for the non-rendered page, its anchor box becomes
non-empty again and the anchor "jumps back" to the "below screen" box.

This commit adds logic to ignore any highlights which have zero height,
including highlight elements that are disconnected from the document.

----

**Steps to reproduce:**

On master:

1. Open http://localhost:3000/pdf/gatsby, scroll to page 62 and highlight the text "When I came home to West Egg"
2. Slowly scroll the document up. Around page 53/54 (I think this may vary depending on screen height), you will briefly see the annotation jump from the "below screen" bucket at the bottom of the page to the "above screen" bucket and then return to the "below screen" bucket

On this branch repeat step 2. You should see the annotation disappear from the "below screen" bucket at around the page 53/54 mark, but it won't appear in the "above screen" bucket during this time.