### PR TITLE
Rename `BucketBar.element`

### DIFF
--- a/src/annotator/bucket-bar.js
+++ b/src/annotator/bucket-bar.js
@@ -11,6 +11,10 @@ import { ListenerCollection } from './util/listener-collection';
  *   at should be contained within this element.
  */
 
+/**
+ * Controller for the "bucket bar" shown alongside the sidebar indicating where
+ * annotations are in the document.
+ */
 export default class BucketBar {
   /**
    * @param {HTMLElement} container
@@ -19,10 +23,11 @@ export default class BucketBar {
    */
   constructor(container, guest, { contentContainer = document.body } = {}) {
     this._contentContainer = contentContainer;
-    this.element = document.createElement('div');
 
-    this.guest = guest;
-    container.appendChild(this.element);
+    this._bucketsContainer = document.createElement('div');
+    container.appendChild(this._bucketsContainer);
+
+    this._guest = guest;
 
     this._listeners = new ListenerCollection();
 
@@ -36,7 +41,7 @@ export default class BucketBar {
 
   destroy() {
     this._listeners.removeAll();
-    this.element.remove();
+    this._bucketsContainer.remove();
   }
 
   update() {
@@ -51,17 +56,17 @@ export default class BucketBar {
   }
 
   _update() {
-    const buckets = anchorBuckets(this.guest.anchors);
+    const buckets = anchorBuckets(this._guest.anchors);
     render(
       <Buckets
         above={buckets.above}
         below={buckets.below}
         buckets={buckets.buckets}
         onSelectAnnotations={(annotations, toggle) =>
-          this.guest.selectAnnotations(annotations, toggle)
+          this._guest.selectAnnotations(annotations, toggle)
         }
       />,
-      this.element
+      this._bucketsContainer
     );
   }
 }

--- a/src/annotator/test/bucket-bar-test.js
+++ b/src/annotator/test/bucket-bar-test.js
@@ -51,7 +51,7 @@ describe('BucketBar', () => {
   it('should render buckets for existing anchors when constructed', () => {
     const bucketBar = createBucketBar();
     assert.calledWith(fakeBucketUtil.anchorBuckets, fakeAnnotator.anchors);
-    assert.ok(bucketBar.element.querySelector('.FakeBuckets'));
+    assert.ok(bucketBar._bucketsContainer.querySelector('.FakeBuckets'));
   });
 
   describe('updating buckets', () => {


### PR DESCRIPTION
The name was vestigial. Rename it to `_bucketsContainer` to be more
meaningful and indicate that it is private. Several other private fields
have also been prefixed accordingly.