### PR TITLE
Limit and fix communication between frames

### DIFF
--- a/src/annotator/cross-frame.js
+++ b/src/annotator/cross-frame.js
@@ -61,8 +61,9 @@ export class CrossFrame {
     };
 
     // Initiate connection to the sidebar.
-    const onDiscoveryCallback = (source, origin, token) =>
+    const onDiscoveryCallback = (source, origin, token) => {
       bridge.createChannel(source, origin, token);
+    };
     discovery.startDiscovery(onDiscoveryCallback);
     frameObserver.observe(injectIntoFrame, iframeUnloaded);
 

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -164,6 +164,7 @@ export default class Guest {
     // Setup connection to sidebar.
     this.crossframe = new CrossFrame(this.element, {
       config,
+      server: config.server,
       on: (event, handler) => this._emitter.subscribe(event, handler),
       emit: (event, ...args) => this._emitter.publish(event, ...args),
     });

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -41,6 +41,9 @@ function init() {
     // frame context belongs to hypothesis.
     // Needs to be a global property that's set.
     window_.__hypothesis_frame = true;
+    config.server = false;
+  } else {
+    config.server = true;
   }
 
   // Load the PDF anchoring/metadata integration.

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -6,7 +6,7 @@ import * as rendererOptions from '../shared/renderer-options';
 import {
   startServer as startRPCServer,
   preStartServer as preStartRPCServer,
-} from './cross-origin-rpc.js';
+} from './cross-origin-rpc';
 import disableOpenerForExternalLinks from './util/disable-opener-for-external-links';
 import { fetchConfig } from './config/fetch-config';
 import * as sentry from './util/sentry';

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -235,7 +235,7 @@ export class FrameSyncService {
       });
     };
 
-    const discovery = new Discovery(window, { server: true });
+    const discovery = new Discovery(window);
     discovery.startDiscovery(this._bridge.createChannel.bind(this._bridge));
     this._bridge.onConnect(addFrame);
 


### PR DESCRIPTION
The client relies on an inter-frame communication between the host
frame, where the client was initially loaded, and a number of iframe
children. For the communication to work, every frame needs to be able to
discover the iframe that acts as a server by sending a
`frame.postMessage`. Currently, the `sidebar` iframe is the server.

The following frames must establish communication with the server
`sidebar` iframe:

- `host` frame (where the client was initially loaded)
- `notebook` iframe
- additional annotatable iframe(s) (each have an `enable-annotation`
  attribute) where the `guest` instance is injected.

This layout represents the current arrangement of frames:

```
host frame (client)
  |-> sidebar iframe (server)
  |-> notebook iframe (client)
  |-> annotatable iframe/s (client)
```

There are two problems with the current discoverability algorithm:

1. It relies on `window.frames` to list all the other frames. Because
   `sidebar` and `notebook` iframes are now wrapped on a shadow DOM they
   are not listed on `window.frames`.

2. It is very generic: the algorithm starts from the topmost frame in
   the hierarchy (`window.top`) and send messages to all the frame
   children *recursively*. If there are several clients initialised on
   individual frames, this algorithm causes *all* the `host` frames to
   be connected to all the `sidebar` iframes.

To solve both problems, I investigated swapping the server from the
`sidebar` to the `host` frame. All iframe children are able to find the
`host` frame (`window.parent`). In addition, this approach would have
the advantage that the server will be initialised first and ready to
listen for message before any of the iframe children is initialised.
This layout describes the intended arrangement:

```
host frame (server)
  |-> sidebar iframe (client)
  |-> notebook iframe (client)
  |-> annotatable iframe/s (client)
```

While this would have been a clean solution, I found that the server is
coupled to the `store` functionality in the sidebar. Decoupling both would
take some efforts.

Instead, in this PR I am suggesting a pragmatic approach based on (1)
saving a reference to the `sidebar` iframe on a global window variable
in the `host` frame and (2) the current parent-children frame
arrangement. While not as clean as the first approach, it would resolve
both problems:

1. No dependent on `window.frames`: when the `host` frame successfully
   establishes a communication with the `sidebar` iframe, it saves the
   reference to the `sidebar` iframe on a global reference.

2. Targeted discoverability: identify the sender of the initial
   postMessage message and direct it to the right frame:
     - if the sender is the `sidebar` iframe (server frame), the
       postMessage is sent *only* to the host frame using
       `window.parent`.
     - if the sender is the `notebook` or an annotatable iframe(s), we
       try send the postMessage to the sibling `sidebar` iframe, if a
       reference is known, otherwise we retry later.
