### PR TITLE
Remove unnecessary check and simplify code

### DIFF
--- a/src/annotator/frame-observer.js
+++ b/src/annotator/frame-observer.js
@@ -29,6 +29,7 @@ export default class FrameObserver {
     this._mutationObserver.observe(this._target, {
       childList: true,
       subtree: true,
+      attributeFilter: ['enable-annotation'],
     });
   }
 

--- a/src/annotator/util/frame-util.js
+++ b/src/annotator/util/frame-util.js
@@ -1,12 +1,18 @@
 /**
  * Return all `<iframe>` elements under `container` which are annotate-able.
  *
+ * To enable annotation, an iframe must be opted-in by adding the
+ * `enable-annotation` attribute.
+ *
+ * Eventually we may want annotation to be enabled by default for iframes that
+ * pass certain tests. However we need to resolve a number of issues before we
+ * can do that. See https://github.com/hypothesis/client/issues/530
+ *
  * @param {Element} container
  * @return {HTMLIFrameElement[]}
  */
 export function findFrames(container) {
-  const frames = Array.from(container.getElementsByTagName('iframe'));
-  return frames.filter(shouldEnableAnnotation);
+  return Array.from(container.querySelectorAll('iframe[enable-annotation]'));
 }
 
 // Check if the iframe has already been injected
@@ -38,29 +44,6 @@ export function isAccessible(iframe) {
   } catch (e) {
     return false;
   }
-}
-
-/**
- * Return `true` if an iframe should be made annotate-able.
- *
- * To enable annotation, an iframe must be opted-in by adding the
- * "enable-annotation" attribute and must be visible.
- *
- * @param  {HTMLIFrameElement} iframe the frame being checked
- * @returns {boolean}   result of our validity checks
- */
-function shouldEnableAnnotation(iframe) {
-  // Ignore the Hypothesis sidebar.
-  const isNotClientFrame = !iframe.classList.contains('h-sidebar-iframe');
-
-  // Require iframes to opt into annotation support.
-  //
-  // Eventually we may want annotation to be enabled by default for iframes that
-  // pass certain tests. However we need to resolve a number of issues before we
-  // can do that. See https://github.com/hypothesis/client/issues/530
-  const enabled = iframe.hasAttribute('enable-annotation');
-
-  return isNotClientFrame && enabled;
 }
 
 export function isDocumentReady(iframe, callback) {

--- a/src/annotator/util/test/frame-util-test.js
+++ b/src/annotator/util/test/frame-util-test.js
@@ -1,6 +1,6 @@
 import * as frameUtil from '../frame-util';
 
-describe('annotator.util.frame-util', function () {
+describe('annotator/util/frame-util', function () {
   describe('findFrames', function () {
     let container;
 
@@ -51,18 +51,6 @@ describe('annotator.util.frame-util', function () {
 
       const foundFrames = frameUtil.findFrames(container);
       assert.lengthOf(foundFrames, 0);
-    });
-
-    it('should not return the Hypothesis sidebar', function () {
-      _addFrameToContainer({ className: 'h-sidebar-iframe other-class-too' });
-
-      const foundFrames = frameUtil.findFrames(container);
-
-      assert.lengthOf(
-        foundFrames,
-        0,
-        'frames with hypothesis className should not be found'
-      );
     });
   });
 });


### PR DESCRIPTION
- Observe changes in `enable-annotation` attribute. Currently, if an
  existing iframe adds the attribute it won't be detected.

- `sidebar` or `notebook` iframes are shadow DOMed so they are not
  returned by `querySelector...` or `getElement...` (from elements
  outside the shadow root). Therefore, it is not necessary to filter
  these iframes out.