### PR TITLE
Modernize RPC client/server class.

### DIFF
--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -1,4 +1,4 @@
-import RPC from './frame-rpc';
+import { RPC } from './frame-rpc';
 
 /**
  * The Bridge service sets up a channel between frames and provides an events

--- a/src/shared/frame-rpc.js
+++ b/src/shared/frame-rpc.js
@@ -64,8 +64,8 @@ export class RPC {
     if (origin === '*') {
       this.origin = '*';
     } else {
-      const uorigin = new URL(origin);
-      this.origin = uorigin.protocol + '//' + uorigin.host;
+      const url = new URL(origin);
+      this.origin = url.protocol + '//' + url.host;
     }
 
     this._sequence = 0;

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -1,7 +1,7 @@
 import Bridge from '../bridge';
-import RPC from '../frame-rpc';
+import { RPC } from '../frame-rpc';
 
-describe('shared.bridge', function () {
+describe('shared/bridge', function () {
   const sandbox = sinon.createSandbox();
   let bridge;
   let createChannel;
@@ -26,8 +26,8 @@ describe('shared.bridge', function () {
   describe('#createChannel', function () {
     it('creates a new channel with the provided options', function () {
       const channel = createChannel();
-      assert.equal(channel.src, window);
-      assert.equal(channel.dst, fakeWindow);
+      assert.equal(channel.sourceFrame, window);
+      assert.equal(channel.destFrame, fakeWindow);
       assert.equal(channel.origin, 'http://example.com');
     });
 


### PR DESCRIPTION
Modernize the `RPC` class in `src/shared/frame-rpc` that serves as both
the client and server for RPC requests between frames.

This code was originally imported from
https://github.com/substack/frame-rpc but now that we've adopted it, it
makes sense to modernize it to match the conventions and requirements of
the rest of our code (eg. in terms of linting and style).

nb. We're missing unit tests for this module specifically but we do have indirect tests via other modules for much of it.

 - Convert `frame-rpc.js` to modern syntax
 - Update JSDoc documentation for methods and class
 - Convert `RPC` class to a named rather than default export
 - Inline the `apply` method into the `call` method, since only `call`
   was used externally
 - Remove unused option for `methods` constructor argument to be a
   function
 - Rename `src` and `dest` public fields to the more explicit
   `sourceFrame` and `destFrame`

Depending on what we decide to do with regards to fixing sidebar <-> notebook communication this may end up being obsolete. We'll see 🤷 