### PR TITLE
Use latest ecmaVersion for eslint

### DIFF
--- a/embedding-examples/.eslintrc
+++ b/embedding-examples/.eslintrc
@@ -1,6 +1,6 @@
 {
-    "parserOptions": {
-        "ecmaVersion": 2018,
-        "sourceType": "module",
-    }
+  "parserOptions": {
+    "ecmaVersion": 2021,
+    "sourceType": "module"
+  }
 }

--- a/scripts/.eslintrc
+++ b/scripts/.eslintrc
@@ -1,12 +1,12 @@
 {
   "env": {
-    "node": true,
+    "node": true
   },
   "rules": {
     "no-console": "off",
     "react-hooks/rules-of-hooks": "off"
   },
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2021
   }
 }

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,5 +1,6 @@
 {
   "parserOptions": {
-    "sourceType": "module"
+    "sourceType": "module",
+    "ecmaVersion": 2021
   }
 }


### PR DESCRIPTION
I want support for the new feature in ECMAScript 2021, logical
assignments:
https://dev.to/faithfulojebiyi/new-features-in-ecmascript-2021-with-code-examples-302h#logical-assignment-operator

Is there any risk babel and eslint get out of sync?