### PR TITLE
Convert `streamer` service to an ES class (1/n)

### DIFF
--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -15,7 +15,7 @@ import useRootThread from './hooks/use-root-thread';
 /**
  * @typedef NotebookViewProps
  * @prop {import('../services/load-annotations').LoadAnnotationsService} loadAnnotationsService
- * @prop {import('../services/streamer').default} streamer
+ * @prop {import('../services/streamer').StreamerService} streamer
  */
 
 /**

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -18,7 +18,7 @@ import ThreadList from './ThreadList';
  * @prop {() => any} onSignUp
  * @prop {import('../services/frame-sync').FrameSyncService} frameSync
  * @prop {import('../services/load-annotations').LoadAnnotationsService} loadAnnotationsService
- * @prop {import('../services/streamer').default} streamer
+ * @prop {import('../services/streamer').StreamerService} streamer
  */
 
 /**

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -28,7 +28,7 @@ import UserMenu from './UserMenu';
  * @prop {() => any} onLogout - Callback invoked when user clicks "Logout" action in account menu.
  * @prop {() => any} onSignUp - Callback invoked when user clicks "Sign up" button.
  * @prop {MergedConfig} settings
- * @prop {import('../services/streamer').default} streamer
+ * @prop {import('../services/streamer').StreamerService} streamer
  */
 
 /**

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -36,7 +36,11 @@ if (process.env.NODE_ENV !== 'production') {
 // Install Preact renderer options to work around browser quirks
 rendererOptions.setupBrowserFixes();
 
-// @inject
+/**
+ * @param {import('./services/api').APIService} api
+ * @param {import('./services/streamer').StreamerService} streamer
+ * @inject
+ */
 function setupApi(api, streamer) {
   api.setClientId(streamer.clientId);
 }
@@ -83,8 +87,8 @@ function initServices(
 /**
  * @param {import('./services/frame-sync').FrameSyncService} frameSync
  * @param {import('./store').SidebarStore} store
+ * @inject
  */
-// @inject
 function setupFrameSync(frameSync, store) {
   if (store.route() === 'sidebar') {
     frameSync.connect();
@@ -121,7 +125,7 @@ import { RouterService } from './services/router';
 import { ServiceURLService } from './services/service-url';
 import { SessionService } from './services/session';
 import { StreamFilter } from './services/stream-filter';
-import streamerService from './services/streamer';
+import { StreamerService } from './services/streamer';
 import { TagsService } from './services/tags';
 import { ThreadsService } from './services/threads';
 import { ToastMessengerService } from './services/toast-messenger';
@@ -158,7 +162,7 @@ function startApp(config, appEl) {
     .register('router', RouterService)
     .register('serviceURL', ServiceURLService)
     .register('session', SessionService)
-    .register('streamer', streamerService)
+    .register('streamer', StreamerService)
     .register('streamFilter', StreamFilter)
     .register('tags', TagsService)
     .register('threadsService', ThreadsService)

--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -38,7 +38,7 @@ export class LoadAnnotationsService {
   /**
    * @param {import('./api').APIService} api
    * @param {import('../store').SidebarStore} store
-   * @param {import('./streamer').default} streamer
+   * @param {import('./streamer').StreamerService} streamer
    * @param {import('./stream-filter').StreamFilter} streamFilter
    */
   constructor(api, store, streamer, streamFilter) {

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -6,245 +6,270 @@ import Socket from '../websocket';
 import { watch } from '../util/watch';
 
 /**
- * Open a new WebSocket connection to the Hypothesis push notification service.
- * Only one websocket connection may exist at a time, any existing socket is
- * closed.
+ * `StreamerService` manages the WebSocket connection to the Hypothesis Real-Time
+ * API [1]
  *
- * @param {import('../store').SidebarStore} store
- * @param {import('./auth').AuthService} auth
- * @param {import('./groups').GroupsService} groups
- * @param {import('./session').SessionService} session
- * @param {Record<string, any>} settings
+ * This service is responsible for opening the WebSocket connection and sending
+ * messages to configure what notifications are delivered to the client.
+ * Other services call `setConfig` to specify the filtering configuration.
+ *
+ * When notifications are received via the WebSocket, this service adds them to
+ * the store. Depending on the update they may be applied immediately or added
+ * to the "pending real time updates" state so that they can be applied by the
+ * user at a convenient time.
+ *
+ * [1] https://h.readthedocs.io/en/latest/api/realtime/
+ *
+ * @inject
  */
-// @inject
-export default function Streamer(store, auth, groups, session, settings) {
-  // The randomly generated session ID
-  const clientId = generateHexString(32);
+export class StreamerService {
+  /**
+   * @param {import('../store').SidebarStore} store
+   * @param {import('./auth').AuthService} auth
+   * @param {import('./groups').GroupsService} groups
+   * @param {import('./session').SessionService} session
+   * @param {Record<string, any>} settings
+   */
+  constructor(store, auth, groups, session, settings) {
+    /** The randomly generated session ID */
+    const clientId = generateHexString(32);
 
-  // The socket instance for this Streamer instance
-  let socket;
+    /** @type {Socket|null} */
+    let socket = null;
 
-  // Flag that controls when to apply pending updates
-  let updateImmediately = true;
+    // Flag that controls when to apply pending updates
+    let updateImmediately = true;
 
-  // Client configuration messages, to be sent each time a new connection is
-  // established.
-  const configMessages = {};
+    /**
+     * Client configuration messages, to be sent each time a new connection is
+     * established.
+     *
+     * @type {Record<string, object>}
+     */
+    const configMessages = {};
 
-  function handleAnnotationNotification(message) {
-    const action = message.options.action;
-    const annotations = message.payload;
+    const applyPendingUpdates = () => {
+      const updates = Object.values(store.pendingUpdates());
+      if (updates.length) {
+        store.addAnnotations(updates);
+      }
 
-    switch (action) {
-      case 'create':
-      case 'update':
-      case 'past':
-        store.receiveRealTimeUpdates({ updatedAnnotations: annotations });
-        break;
-      case 'delete':
-        store.receiveRealTimeUpdates({ deletedAnnotations: annotations });
-        break;
-    }
+      const deletions = Object.keys(store.pendingDeletions()).map(id => ({
+        id,
+      }));
+      if (deletions.length) {
+        store.removeAnnotations(deletions);
+      }
 
-    if (updateImmediately) {
-      applyPendingUpdates();
-    }
-  }
+      store.clearPendingUpdates();
+    };
 
-  function handleSessionChangeNotification(message) {
-    session.update(message.model);
-    groups.load();
-  }
+    const handleAnnotationNotification = message => {
+      const action = message.options.action;
+      const annotations = message.payload;
 
-  function handleSocketOnError(event) {
-    warnOnce('Error connecting to H push notification service:', event);
+      switch (action) {
+        case 'create':
+        case 'update':
+        case 'past':
+          store.receiveRealTimeUpdates({ updatedAnnotations: annotations });
+          break;
+        case 'delete':
+          store.receiveRealTimeUpdates({ deletedAnnotations: annotations });
+          break;
+      }
 
-    // In development, warn if the connection failure might be due to
-    // the app's origin not having been whitelisted in the H service's config.
-    //
-    // Unfortunately the error event does not provide a way to get at the
-    // HTTP status code for HTTP -> WS upgrade requests.
-    const websocketHost = new URL(settings.websocketUrl).hostname;
-    if (['localhost', '127.0.0.1'].indexOf(websocketHost) !== -1) {
-      warnOnce(
-        'Check that your H service is configured to allow ' +
-          'WebSocket connections from ' +
-          window.location.origin
-      );
-    }
-  }
+      if (updateImmediately) {
+        applyPendingUpdates();
+      }
+    };
 
-  function handleSocketOnMessage(event) {
-    const message = JSON.parse(event.data);
-    if (!message) {
-      return;
-    }
+    const handleSessionChangeNotification = message => {
+      session.update(message.model);
+      groups.load();
+    };
 
-    if (message.type === 'annotation-notification') {
-      handleAnnotationNotification(message);
-    } else if (message.type === 'session-change') {
-      handleSessionChangeNotification(message);
-    } else if (message.type === 'whoyouare') {
-      const userid = store.profile().userid;
-      if (message.userid !== userid) {
-        console.warn(
-          'WebSocket user ID "%s" does not match logged-in ID "%s"',
-          message.userid,
-          userid
+    const handleSocketOnError = event => {
+      warnOnce('Error connecting to H push notification service:', event);
+
+      // In development, warn if the connection failure might be due to
+      // the app's origin not having been whitelisted in the H service's config.
+      //
+      // Unfortunately the error event does not provide a way to get at the
+      // HTTP status code for HTTP -> WS upgrade requests.
+      const websocketHost = new URL(settings.websocketUrl).hostname;
+      if (['localhost', '127.0.0.1'].indexOf(websocketHost) !== -1) {
+        warnOnce(
+          'Check that your H service is configured to allow ' +
+            'WebSocket connections from ' +
+            window.location.origin
         );
       }
-    } else {
-      warnOnce('received unsupported notification', message.type);
-    }
-  }
+    };
 
-  function sendClientConfig() {
-    Object.keys(configMessages).forEach(function (key) {
-      if (configMessages[key]) {
-        socket.send(configMessages[key]);
+    /** @param {MessageEvent} event */
+    const handleSocketOnMessage = event => {
+      const message = JSON.parse(event.data);
+      if (!message) {
+        return;
       }
-    });
-  }
 
-  /**
-   * Send a configuration message to the push notification service.
-   * Each message is associated with a key, which is used to re-send
-   * configuration data to the server in the event of a reconnection.
-   */
-  function setConfig(key, configMessage) {
-    configMessages[key] = configMessage;
-    if (socket && socket.isConnected()) {
-      socket.send(configMessage);
-    }
-  }
-
-  const _connect = function () {
-    // If we have no URL configured, don't do anything.
-    if (!settings.websocketUrl) {
-      return Promise.resolve();
-    }
-
-    return auth
-      .getAccessToken()
-      .then(function (token) {
-        let url;
-        if (token) {
-          // Include the access token in the URL via a query param. This method
-          // is used to send credentials because the `WebSocket` constructor does
-          // not support setting the `Authorization` header directly as we do for
-          // other API requests.
-          const parsedURL = new URL(settings.websocketUrl);
-          const queryParams = queryString.parse(parsedURL.search);
-          queryParams.access_token = token;
-          parsedURL.search = queryString.stringify(queryParams);
-          url = parsedURL.toString();
-        } else {
-          url = settings.websocketUrl;
+      if (message.type === 'annotation-notification') {
+        handleAnnotationNotification(message);
+      } else if (message.type === 'session-change') {
+        handleSessionChangeNotification(message);
+      } else if (message.type === 'whoyouare') {
+        const userid = store.profile().userid;
+        if (message.userid !== userid) {
+          console.warn(
+            'WebSocket user ID "%s" does not match logged-in ID "%s"',
+            message.userid,
+            userid
+          );
         }
+      } else {
+        warnOnce('received unsupported notification', message.type);
+      }
+    };
 
-        socket = new Socket(url);
+    /** @param {Socket} socket */
+    const sendClientConfig = socket => {
+      Object.keys(configMessages).forEach(key => {
+        if (configMessages[key]) {
+          socket.send(configMessages[key]);
+        }
+      });
+    };
 
-        socket.on('open', sendClientConfig);
-        socket.on('error', handleSocketOnError);
-        socket.on('message', handleSocketOnMessage);
+    /**
+     * Send a configuration message to the push notification service.
+     * Each message is associated with a key, which is used to re-send
+     * configuration data to the server in the event of a reconnection.
+     *
+     * @param {string} key
+     * @param {object} configMessage
+     */
+    const setConfig = (key, configMessage) => {
+      configMessages[key] = configMessage;
+      if (socket && socket.isConnected()) {
+        socket.send(configMessage);
+      }
+    };
 
-        // Configure the client ID
-        setConfig('client-id', {
-          messageType: 'client_id',
-          value: clientId,
-        });
+    const _connect = async () => {
+      // If we have no URL configured, don't do anything.
+      if (!settings.websocketUrl) {
+        return;
+      }
 
-        // Send a "whoami" message. The server will respond with a "whoyouare"
-        // reply which is useful for verifying that authentication worked as
-        // expected.
-        setConfig('auth-check', {
-          type: 'whoami',
-          id: 1,
-        });
-      })
-      .catch(function (err) {
+      let token;
+      try {
+        token = await auth.getAccessToken();
+      } catch (err) {
         console.error(
           'Failed to fetch token for WebSocket authentication',
           err
         );
-      });
-  };
-
-  let reconnectSetUp = false;
-  /**
-   * Set up automatic reconnecting when user changes.
-   */
-  function setUpAutoReconnect() {
-    if (reconnectSetUp) {
-      return;
-    }
-    reconnectSetUp = true;
-
-    // Reconnect when user changes, as auth token will have changed
-    watch(
-      store.subscribe,
-      () => store.profile().userid,
-      () => {
-        reconnect();
+        throw err;
       }
-    );
+
+      let url;
+      if (token) {
+        // Include the access token in the URL via a query param. This method
+        // is used to send credentials because the `WebSocket` constructor does
+        // not support setting the `Authorization` header directly as we do for
+        // other API requests.
+        const parsedURL = new URL(settings.websocketUrl);
+        const queryParams = queryString.parse(parsedURL.search);
+        queryParams.access_token = token;
+        parsedURL.search = queryString.stringify(queryParams);
+        url = parsedURL.toString();
+      } else {
+        url = settings.websocketUrl;
+      }
+
+      const newSocket = new Socket(url);
+      newSocket.on('open', () => sendClientConfig(newSocket));
+      newSocket.on('error', handleSocketOnError);
+      newSocket.on('message', handleSocketOnMessage);
+      socket = newSocket;
+
+      // Configure the client ID
+      setConfig('client-id', {
+        messageType: 'client_id',
+        value: clientId,
+      });
+
+      // Send a "whoami" message. The server will respond with a "whoyouare"
+      // reply which is useful for verifying that authentication worked as
+      // expected.
+      setConfig('auth-check', {
+        type: 'whoami',
+        id: 1,
+      });
+    };
+
+    /**
+     * Connect to the Hypothesis real time update service.
+     *
+     * If the service has already connected this closes the existing connection
+     * and reconnects.
+     *
+     * @return {Promise} Promise which resolves once the WebSocket connection
+     *                   process has started.
+     */
+    const reconnect = () => {
+      if (socket) {
+        socket.close();
+      }
+      return _connect();
+    };
+
+    let reconnectSetUp = false;
+    /**
+     * Set up automatic reconnecting when user changes.
+     */
+    const setUpAutoReconnect = () => {
+      if (reconnectSetUp) {
+        return;
+      }
+      reconnectSetUp = true;
+
+      // Reconnect when user changes, as auth token will have changed
+      watch(
+        store.subscribe,
+        () => store.profile().userid,
+        () => {
+          reconnect();
+        }
+      );
+    };
+
+    /**
+     * Connect to the Hypothesis real time update service.
+     *
+     * If the service has already connected this does nothing.
+     *
+     * @param {Object} [options]
+     * @param {boolean} [options.applyUpdatesImmediately] - true if pending updates should be applied immediately
+     *
+     * @return {Promise<void>} Promise which resolves once the WebSocket connection
+     *    process has started.
+     */
+    const connect = async (options = {}) => {
+      updateImmediately = options.applyUpdatesImmediately ?? true;
+      setUpAutoReconnect();
+      if (socket) {
+        return;
+      }
+      await _connect();
+    };
+
+    this.applyPendingUpdates = applyPendingUpdates;
+    this.clientId = clientId;
+    this.configMessages = configMessages;
+    this.connect = connect;
+    this.reconnect = reconnect;
+    this.setConfig = setConfig;
   }
-
-  /**
-   * Connect to the Hypothesis real time update service.
-   *
-   * If the service has already connected this does nothing.
-   *
-   * @param {Object} [options]
-   * @param {boolean} [options.applyUpdatesImmediately] - true if pending updates should be applied immediately
-   *
-   * @return {Promise<void>} Promise which resolves once the WebSocket connection
-   *    process has started.
-   */
-  function connect(options = {}) {
-    updateImmediately = options.applyUpdatesImmediately ?? true;
-    setUpAutoReconnect();
-    if (socket) {
-      return Promise.resolve();
-    }
-    return _connect();
-  }
-
-  /**
-   * Connect to the Hypothesis real time update service.
-   *
-   * If the service has already connected this closes the existing connection
-   * and reconnects.
-   *
-   * @return {Promise} Promise which resolves once the WebSocket connection
-   *                   process has started.
-   */
-  function reconnect() {
-    if (socket) {
-      socket.close();
-    }
-
-    return _connect();
-  }
-
-  function applyPendingUpdates() {
-    const updates = Object.values(store.pendingUpdates());
-    if (updates.length) {
-      store.addAnnotations(updates);
-    }
-
-    const deletions = Object.keys(store.pendingDeletions()).map(id => ({ id }));
-    if (deletions.length) {
-      store.removeAnnotations(deletions);
-    }
-
-    store.clearPendingUpdates();
-  }
-
-  this.applyPendingUpdates = applyPendingUpdates;
-  this.clientId = clientId;
-  this.configMessages = configMessages;
-  this.connect = connect;
-  this.reconnect = reconnect;
-  this.setConfig = setConfig;
 }

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -99,6 +99,7 @@ export class StreamerService {
       // HTTP status code for HTTP -> WS upgrade requests.
       const websocketHost = new URL(settings.websocketUrl).hostname;
       if (['localhost', '127.0.0.1'].indexOf(websocketHost) !== -1) {
+        /* istanbul ignore next */
         warnOnce(
           'Check that your H service is configured to allow ' +
             'WebSocket connections from ' +
@@ -128,7 +129,7 @@ export class StreamerService {
           );
         }
       } else {
-        warnOnce('received unsupported notification', message.type);
+        warnOnce('Received unsupported notification', message.type);
       }
     };
 

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -1,8 +1,7 @@
 import EventEmitter from 'tiny-emitter';
 
 import fakeReduxStore from '../../test/fake-redux-store';
-import Streamer from '../streamer';
-import { $imports } from '../streamer';
+import { StreamerService, $imports } from '../streamer';
 
 const fixtures = {
   createNotification: {
@@ -73,7 +72,7 @@ class FakeSocket extends EventEmitter {
   }
 }
 
-describe('Streamer', function () {
+describe('StreamerService', () => {
   let fakeStore;
   let fakeAuth;
   let fakeGroups;
@@ -82,7 +81,7 @@ describe('Streamer', function () {
   let activeStreamer;
 
   function createDefaultStreamer() {
-    activeStreamer = new Streamer(
+    activeStreamer = new StreamerService(
       fakeStore,
       fakeAuth,
       fakeGroups,


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/3371**~~

Convert the `streamer` service that handles WebSocket connections to an ES class as part of https://github.com/hypothesis/client/issues/3298. Other than changing `StreamerService` from a default to a named export there are no API changes. I did add some missing tests for existing error paths in the code.

Since this class has quite a few fields and helper methods the conversion is being done in two stages. This first PR converts the function to a class but all the logic remains in the constructor and the exported fields/methods are assigned as properties at the end of the constructor. A later PR will move code out of the constructor and into other methods.
