### PR TITLE
Fix prop typechecking for `TopBar` component

### DIFF
--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -21,19 +21,21 @@ import UserMenu from './UserMenu';
 
 /**
  * @typedef TopBarProps
- * @prop {AuthState} [auth]
+ * @prop {AuthState} auth
  * @prop {Bridge} bridge
- * @prop {boolean} [isSidebar] - Flag indicating whether the app is the sidebar or a top-level page.
- * @prop {() => any} [onLogin] - Callback invoked when user clicks "Login" button.
- * @prop {() => any} [onLogout] - Callback invoked when user clicks "Logout" action in account menu.
- * @prop {() => any} [onSignUp] - Callback invoked when user clicks "Sign up" button.
- * @prop {MergedConfig} [settings]
- * @prop {Object} [streamer]
+ * @prop {boolean} isSidebar - Flag indicating whether the app is the sidebar or a top-level page.
+ * @prop {() => any} onLogin - Callback invoked when user clicks "Login" button.
+ * @prop {() => any} onLogout - Callback invoked when user clicks "Logout" action in account menu.
+ * @prop {() => any} onSignUp - Callback invoked when user clicks "Sign up" button.
+ * @prop {MergedConfig} settings
+ * @prop {import('../services/streamer').default} streamer
  */
 
 /**
  * The toolbar which appears at the top of the sidebar providing actions
  * to switch groups, view account information, sort/filter annotations etc.
+ *
+ * @param {TopBarProps} props
  */
 function TopBar({
   auth,

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -17,6 +17,7 @@ import MenuSection from './MenuSection';
 
 /**
  * @typedef AuthState
+ * @prop {'logged-in'|'logged-out'|'unknown'} status
  * @prop {string} displayName
  * @prop {string} userid
  * @prop {string} username


### PR DESCRIPTION
The type of the `props` argument to `TopBar` was not specified, so its
props were not type-checked. Specifying a type for `props` turned up
several mistakes in other types ~~and also found a bug where the `bridge`
was not set in `HypothesisApp`, leading to a crash if a parter site
tried to specify the `onHelpRequested` callback. I don't think any
parter sites are actually using this currently, but our documentation
for publishers says it should work [1].~~ (_Edit: This part was completely wrong. The test case below works just fine on `master`_)

 - Specify the type of the `props` object so that the props are actually
   type-checked
 - Add missing `status` field to `AuthState` type
 - Correctly set the optionality of various props
 - ~~Set `bridge` prop in `HypothesisApp` when rendering `TopBar`. This
   code could probably use a redesign to avoid the dependency on the `bridge`
   service in `TopBar` by passing in an `onHelp` callback instead.
   That's out of scope for this commit.~~ (_Edit: This part was completely wrong. The test case below works on `master`. I've reverted this change_)

[1] https://h.readthedocs.io/projects/client/en/latest/publishers/config/#cmdoption-arg-onhelprequest

----

**Testing:**

To test the user-visible change in this PR, apply the following change, then visit http://localhost:3000 and click on the "?" button in the sidebar. You should see an alert appear with the message "Help requested".

```diff
diff --git a/dev-server/templates/client-config.js.mustache b/dev-server/templates/client-config.js.mustache
index ddcfaa466..7f3e8df0e 100644
--- a/dev-server/templates/client-config.js.mustache
+++ b/dev-server/templates/client-config.js.mustache
@@ -22,15 +22,15 @@
       // },
 
       // Example services config
-      // services: [{
-      //   apiUrl: 'http://localhost:5000/api',
-      //   authority: 'partner.org',
-      //   allowLeavingGroups: false,
-      //   groups: ['a-group-id', 'another-group-id'],
-      // }],
+      services: [{
+        apiUrl: 'http://localhost:5000/api/',
+        authority: 'localhost',
+        allowLeavingGroups: false,
+        onHelpRequest: () => alert('Help requested'),
+      }],
 
       // Open the sidebar when the page loads
       openSidebar: true,
     };
   };
```

I'm not aware that any publishers are actually using this functionality, and I'm not sure that we really want to allow publishers to prevent the default Help panel being shown as it includes useful information that may be needed to help troubleshoot issues. Making that change will involve wider discussions though.