### PR TITLE
Refactor `PDFMetadata` tests

### DIFF
--- a/src/annotator/integrations/test/pdf-metadata-test.js
+++ b/src/annotator/integrations/test/pdf-metadata-test.js
@@ -227,13 +227,15 @@ describe('PDFMetadata', function () {
   }
 
   describe('#getUri', () => {
-    it('returns the non-file URI', async () => {
-      const { pdfMetadata } = createPDFMetadata();
-      const uri = await pdfMetadata.getUri();
-      assert.equal(uri, 'http://fake.com/');
+    ['http://fake.com/', 'https://example.com/test.pdf'].forEach(pdfURL => {
+      it('returns the PDF URL if it is an HTTP(S) URL', async () => {
+        const { pdfMetadata } = createPDFMetadata({ url: pdfURL });
+        const uri = await pdfMetadata.getUri();
+        assert.equal(uri, pdfURL);
+      });
     });
 
-    it('returns the fingerprint as a URN when the PDF URL is a local file', async () => {
+    it('returns the fingerprint as a URN when the PDF URL is a file:// URL', async () => {
       const { pdfMetadata } = createPDFMetadata({
         url: 'file:///test.pdf',
         fingerprint: 'fakeFingerprint',
@@ -294,6 +296,13 @@ describe('PDFMetadata', function () {
       );
       assert.isUndefined(fileLink);
     });
+
+    // In order, the title is obtained from:
+    //  1. The `dc:title` field
+    //  2. The `documentInfo.Title` field
+    //  3. The `title` property of the HTML `document` (which PDF.js in turn
+    //     initializes based on the filename from the `Content-Disposition` header
+    //     or URL if that is not available)
 
     it('gets the title from the dc:title field', async () => {
       const { pdfMetadata } = createPDFMetadata();

--- a/src/annotator/integrations/test/pdf-metadata-test.js
+++ b/src/annotator/integrations/test/pdf-metadata-test.js
@@ -192,7 +192,7 @@ describe('PDFMetadata', function () {
   // The `initializedPromise` param simulates different versions of PDF.js with
   // and without the `PDFViewerApplication.initializedPromise` API.
   [true, false].forEach(initializedPromise => {
-    it('does not wait for the PDF to load if it has already loaded', function () {
+    it('does not wait for the PDF to load if it has already loaded', async () => {
       const fakePDFViewerApplication = new FakePDFViewerApplication('', {
         initializedPromise,
       });
@@ -202,9 +202,8 @@ describe('PDFMetadata', function () {
         fingerprint: 'fakeFingerprint',
       });
       const pdfMetadata = new PDFMetadata(fakePDFViewerApplication);
-      return pdfMetadata.getUri().then(function (uri) {
-        assert.equal(uri, 'http://fake.com/');
-      });
+      const uri = await pdfMetadata.getUri();
+      assert.equal(uri, 'http://fake.com/');
     });
   });
 
@@ -227,37 +226,35 @@ describe('PDFMetadata', function () {
     };
   }
 
-  describe('#getUri', function () {
-    it('returns the non-file URI', function () {
+  describe('#getUri', () => {
+    it('returns the non-file URI', async () => {
       const { pdfMetadata } = createPDFMetadata();
-      return pdfMetadata.getUri().then(function (uri) {
-        assert.equal(uri, 'http://fake.com/');
-      });
+      const uri = await pdfMetadata.getUri();
+      assert.equal(uri, 'http://fake.com/');
     });
 
-    it('returns the fingerprint as a URN when the PDF URL is a local file', function () {
+    it('returns the fingerprint as a URN when the PDF URL is a local file', async () => {
       const { pdfMetadata } = createPDFMetadata({
         url: 'file:///test.pdf',
         fingerprint: 'fakeFingerprint',
       });
-      return pdfMetadata.getUri().then(function (uri) {
-        assert.equal(uri, 'urn:x-pdf:fakeFingerprint');
-      });
+      const uri = await pdfMetadata.getUri();
+      assert.equal(uri, 'urn:x-pdf:fakeFingerprint');
     });
 
-    it('resolves relative URLs', () => {
+    it('resolves relative URLs', async () => {
       const { fakePDFViewerApplication, pdfMetadata } = createPDFMetadata({
         url: 'index.php?action=download&file_id=wibble',
         fingerprint: 'fakeFingerprint',
       });
 
-      return pdfMetadata.getUri().then(uri => {
-        const expected = new URL(
-          fakePDFViewerApplication.url,
-          document.location.href
-        ).toString();
-        assert.equal(uri, expected);
-      });
+      const uri = await pdfMetadata.getUri();
+
+      const expected = new URL(
+        fakePDFViewerApplication.url,
+        document.location.href
+      ).toString();
+      assert.equal(uri, expected);
     });
   });
 


### PR DESCRIPTION
This PR is some refactoring of the tests for the code that reads metadata (URL, fingerprint, title) from PDFs in preparation for fixing https://github.com/hypothesis/client/issues/3372. There are no functional changes.

See individual commit messages for full details, but in summary:

- Move some setup logic from `beforeEach` blocks to helper functions so that it can be customized by individual tests
- Convert async/await to promise chains
- Refactor tests for `getMetadata` so that individual tests only check properties of the result they are interested in, rather than the whole result.
- Add missing explicit tests for the presence of the document fingerprint and PDF URL in the `links` property of the `getMetadata` result