### PR TITLE
Make service-using components typecheck correctly

### DIFF
--- a/src/sidebar/components/Annotation/Annotation.js
+++ b/src/sidebar/components/Annotation/Annotation.js
@@ -53,7 +53,7 @@ function Annotation({
   const isEditing = annotation && !!store.getDraft(annotation) && !isSaving;
 
   const userid = store.profile().userid;
-  const showActions = annotation && !isSaving && !isEditing;
+  const showActions = !isSaving && !isEditing;
   const showReplyToggle = !isReply && !hasAppliedFilter && replyCount > 0;
 
   const onReply = () => annotationsService.reply(annotation, userid);
@@ -105,7 +105,7 @@ function Annotation({
               />
             )}
             {isSaving && <div className="Annotation__actions">Saving...</div>}
-            {showActions && (
+            {showActions && annotation && (
               <div className="u-layout-row--justify-right u-stretch">
                 <AnnotationActionBar
                   annotation={annotation}
@@ -120,6 +120,4 @@ function Annotation({
   );
 }
 
-Annotation.injectedProps = ['annotationsService'];
-
-export default withServices(Annotation);
+export default withServices(Annotation, ['annotationsService']);

--- a/src/sidebar/components/Annotation/Annotation.js
+++ b/src/sidebar/components/Annotation/Annotation.js
@@ -105,7 +105,7 @@ function Annotation({
               />
             )}
             {isSaving && <div className="Annotation__actions">Saving...</div>}
-            {showActions && annotation && (
+            {annotation && showActions && (
               <div className="u-layout-row--justify-right u-stretch">
                 <AnnotationActionBar
                   annotation={annotation}

--- a/src/sidebar/components/Annotation/AnnotationActionBar.js
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.js
@@ -130,10 +130,8 @@ function AnnotationActionBar({
   );
 }
 
-AnnotationActionBar.injectedProps = [
+export default withServices(AnnotationActionBar, [
   'annotationsService',
   'settings',
   'toastMessenger',
-];
-
-export default withServices(AnnotationActionBar);
+]);

--- a/src/sidebar/components/Annotation/AnnotationBody.js
+++ b/src/sidebar/components/Annotation/AnnotationBody.js
@@ -85,6 +85,4 @@ function AnnotationBody({ annotation, settings }) {
   );
 }
 
-AnnotationBody.injectedProps = ['settings'];
-
-export default withServices(AnnotationBody);
+export default withServices(AnnotationBody, ['settings']);

--- a/src/sidebar/components/Annotation/AnnotationEditor.js
+++ b/src/sidebar/components/Annotation/AnnotationEditor.js
@@ -157,11 +157,9 @@ function AnnotationEditor({
   );
 }
 
-AnnotationEditor.injectedProps = [
+export default withServices(AnnotationEditor, [
   'annotationsService',
   'settings',
   'tags',
   'toastMessenger',
-];
-
-export default withServices(AnnotationEditor);
+]);

--- a/src/sidebar/components/Annotation/AnnotationHeader.js
+++ b/src/sidebar/components/Annotation/AnnotationHeader.js
@@ -171,6 +171,4 @@ function AnnotationHeader({
   );
 }
 
-AnnotationHeader.injectedProps = ['settings'];
-
-export default withServices(AnnotationHeader);
+export default withServices(AnnotationHeader, ['settings']);

--- a/src/sidebar/components/Annotation/AnnotationPublishControl.js
+++ b/src/sidebar/components/Annotation/AnnotationPublishControl.js
@@ -130,6 +130,4 @@ function AnnotationPublishControl({
   );
 }
 
-AnnotationPublishControl.injectedProps = ['settings'];
-
-export default withServices(AnnotationPublishControl);
+export default withServices(AnnotationPublishControl, ['settings']);

--- a/src/sidebar/components/Annotation/AnnotationQuote.js
+++ b/src/sidebar/components/Annotation/AnnotationQuote.js
@@ -60,6 +60,4 @@ function AnnotationQuote({ annotation, isFocused, settings = {} }) {
   );
 }
 
-AnnotationQuote.injectedProps = ['settings'];
-
-export default withServices(AnnotationQuote);
+export default withServices(AnnotationQuote, ['settings']);

--- a/src/sidebar/components/Annotation/AnnotationShareControl.js
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.js
@@ -177,6 +177,4 @@ function AnnotationShareControl({
   );
 }
 
-AnnotationShareControl.injectedProps = ['toastMessenger'];
-
-export default withServices(AnnotationShareControl);
+export default withServices(AnnotationShareControl, ['toastMessenger']);

--- a/src/sidebar/components/AnnotationView.js
+++ b/src/sidebar/components/AnnotationView.js
@@ -92,6 +92,4 @@ function AnnotationView({ loadAnnotationsService, onLogin }) {
   );
 }
 
-AnnotationView.injectedProps = ['loadAnnotationsService'];
-
-export default withServices(AnnotationView);
+export default withServices(AnnotationView, ['loadAnnotationsService']);

--- a/src/sidebar/components/Excerpt.js
+++ b/src/sidebar/components/Excerpt.js
@@ -56,9 +56,9 @@ const noop = () => {};
  *   when it is collapsed.
  * @prop {number} [overflowThreshold] - An additional margin of pixels by which
  *   the content height can exceed `collapsedHeight` before it becomes collapsible.
- * @prop {(isCollapsible?: boolean) => any} [onCollapsibleChanged] - Called when the content height
+ * @prop {(isCollapsible: boolean) => any} [onCollapsibleChanged] - Called when the content height
  *   exceeds or falls below `collapsedHeight + overflowThreshold`.
- * @prop {(collapsed?: boolean) => any} [onToggleCollapsed] - When `inlineControls` is `false`, this
+ * @prop {(collapsed: boolean) => any} [onToggleCollapsed] - When `inlineControls` is `false`, this
  *   function is called when the user requests to expand the content by clicking a
  *   zone at the bottom of the container.
  * @prop {Object} [settings] - Used for theming.
@@ -158,6 +158,4 @@ function Excerpt({
   );
 }
 
-Excerpt.injectedProps = ['settings'];
-
-export default withServices(Excerpt);
+export default withServices(Excerpt, ['settings']);

--- a/src/sidebar/components/Excerpt.js
+++ b/src/sidebar/components/Excerpt.js
@@ -56,9 +56,9 @@ const noop = () => {};
  *   when it is collapsed.
  * @prop {number} [overflowThreshold] - An additional margin of pixels by which
  *   the content height can exceed `collapsedHeight` before it becomes collapsible.
- * @prop {(isCollapsible: boolean) => any} [onCollapsibleChanged] - Called when the content height
+ * @prop {(isCollapsible: boolean) => void} [onCollapsibleChanged] - Called when the content height
  *   exceeds or falls below `collapsedHeight + overflowThreshold`.
- * @prop {(collapsed: boolean) => any} [onToggleCollapsed] - When `inlineControls` is `false`, this
+ * @prop {(collapsed: boolean) => void} [onToggleCollapsed] - When `inlineControls` is `false`, this
  *   function is called when the user requests to expand the content by clicking a
  *   zone at the bottom of the container.
  * @prop {Object} [settings] - Used for theming.

--- a/src/sidebar/components/GroupList/GroupList.js
+++ b/src/sidebar/components/GroupList/GroupList.js
@@ -148,6 +148,4 @@ function GroupList({ settings }) {
   );
 }
 
-GroupList.injectedProps = ['settings'];
-
-export default withServices(GroupList);
+export default withServices(GroupList, ['settings']);

--- a/src/sidebar/components/GroupList/GroupListItem.js
+++ b/src/sidebar/components/GroupList/GroupListItem.js
@@ -149,6 +149,4 @@ function GroupListItem({
   );
 }
 
-GroupListItem.injectedProps = ['groups', 'toastMessenger'];
-
-export default withServices(GroupListItem);
+export default withServices(GroupListItem, ['groups', 'toastMessenger']);

--- a/src/sidebar/components/HelpPanel.js
+++ b/src/sidebar/components/HelpPanel.js
@@ -10,7 +10,7 @@ import Tutorial from './Tutorial';
 import VersionInfo from './VersionInfo';
 
 /**
- * @typedef {import('../components/UserMenu').AuthState} AuthState
+ * @typedef {import('../helpers/version-data').AuthState} AuthState
  */
 
 /**
@@ -42,7 +42,7 @@ function HelpPanelTab({ linkText, url }) {
 
 /**
  * @typedef HelpPanelProps
- * @prop {AuthState} auth - Object with auth and user information
+ * @prop {AuthState} auth
  * @prop {import('../services/session').SessionService} session
  */
 
@@ -153,6 +153,4 @@ function HelpPanel({ auth, session }) {
   );
 }
 
-HelpPanel.injectedProps = ['session'];
-
-export default withServices(HelpPanel);
+export default withServices(HelpPanel, ['session']);

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -172,6 +172,7 @@ function HypothesisApp({ auth, bridge, settings, session, toastMessenger }) {
     >
       {route !== 'notebook' && (
         <TopBar
+          // @ts-expect-error - This type mistmatch needs to be fixed or the prop removed.
           auth={authState}
           onLogin={login}
           onSignUp={signUp}
@@ -199,12 +200,10 @@ function HypothesisApp({ auth, bridge, settings, session, toastMessenger }) {
   );
 }
 
-HypothesisApp.injectedProps = [
+export default withServices(HypothesisApp, [
   'auth',
   'bridge',
   'session',
   'settings',
   'toastMessenger',
-];
-
-export default withServices(HypothesisApp);
+]);

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -172,7 +172,7 @@ function HypothesisApp({ auth, bridge, settings, session, toastMessenger }) {
     >
       {route !== 'notebook' && (
         <TopBar
-          // @ts-expect-error - This type mistmatch needs to be fixed or the prop removed.
+          // @ts-expect-error - This type mismatch needs to be fixed or the prop removed.
           auth={authState}
           onLogin={login}
           onSignUp={signUp}

--- a/src/sidebar/components/ModerationBanner.js
+++ b/src/sidebar/components/ModerationBanner.js
@@ -96,6 +96,4 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
   );
 }
 
-ModerationBanner.injectedProps = ['api', 'toastMessenger'];
-
-export default withServices(ModerationBanner);
+export default withServices(ModerationBanner, ['api', 'toastMessenger']);

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -177,6 +177,7 @@ function NotebookView({ loadAnnotationsService, streamer }) {
   );
 }
 
-NotebookView.injectedProps = ['loadAnnotationsService', 'streamer'];
-
-export default withServices(NotebookView);
+export default withServices(NotebookView, [
+  'loadAnnotationsService',
+  'streamer',
+]);

--- a/src/sidebar/components/SelectionTabs.js
+++ b/src/sidebar/components/SelectionTabs.js
@@ -169,6 +169,4 @@ function SelectionTabs({ annotationsService, isLoading, settings }) {
   );
 }
 
-SelectionTabs.injectedProps = ['annotationsService', 'settings'];
-
-export default withServices(SelectionTabs);
+export default withServices(SelectionTabs, ['annotationsService', 'settings']);

--- a/src/sidebar/components/ShareAnnotationsPanel.js
+++ b/src/sidebar/components/ShareAnnotationsPanel.js
@@ -117,6 +117,4 @@ function ShareAnnotationsPanel({ toastMessenger }) {
   );
 }
 
-ShareAnnotationsPanel.injectedProps = ['toastMessenger'];
-
-export default withServices(ShareAnnotationsPanel);
+export default withServices(ShareAnnotationsPanel, ['toastMessenger']);

--- a/src/sidebar/components/ShareLinks.js
+++ b/src/sidebar/components/ShareLinks.js
@@ -1,7 +1,5 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
 
-import { withServices } from '../service-context';
-
 /**
  * @typedef ShareLinkProps
  * @prop {string} iconName - The name of the SVG icon to use for this link
@@ -68,4 +66,4 @@ function ShareLinks({ shareURI }) {
   );
 }
 
-export default withServices(ShareLinks);
+export default ShareLinks;

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -157,6 +157,8 @@ function SidebarView({
   );
 }
 
-SidebarView.injectedProps = ['frameSync', 'loadAnnotationsService', 'streamer'];
-
-export default withServices(SidebarView);
+export default withServices(SidebarView, [
+  'frameSync',
+  'loadAnnotationsService',
+  'streamer',
+]);

--- a/src/sidebar/components/StreamSearchInput.js
+++ b/src/sidebar/components/StreamSearchInput.js
@@ -29,6 +29,4 @@ function StreamSearchInput({ router }) {
   );
 }
 
-StreamSearchInput.injectedProps = ['router'];
-
-export default withServices(StreamSearchInput);
+export default withServices(StreamSearchInput, ['router']);

--- a/src/sidebar/components/StreamView.js
+++ b/src/sidebar/components/StreamView.js
@@ -66,6 +66,4 @@ function StreamView({ api, toastMessenger }) {
   return <ThreadList threads={rootThread.children} />;
 }
 
-StreamView.injectedProps = ['api', 'toastMessenger'];
-
-export default withServices(StreamView);
+export default withServices(StreamView, ['api', 'toastMessenger']);

--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -338,6 +338,4 @@ function TagEditor({
   );
 }
 
-TagEditor.injectedProps = ['tags'];
-
-export default withServices(TagEditor);
+export default withServices(TagEditor, ['tags']);

--- a/src/sidebar/components/Thread.js
+++ b/src/sidebar/components/Thread.js
@@ -129,6 +129,4 @@ function Thread({ thread, threadsService }) {
   );
 }
 
-Thread.injectedProps = ['threadsService'];
-
-export default withServices(Thread);
+export default withServices(Thread, ['threadsService']);

--- a/src/sidebar/components/ThreadCard.js
+++ b/src/sidebar/components/ThreadCard.js
@@ -13,7 +13,7 @@ import Thread from './Thread';
 
 /**
  * @typedef ThreadCardProps
- * @prop {Thread} thread
+ * @prop {import('../helpers/build-thread').Thread} thread
  * @prop {import('../services/frame-sync').FrameSyncService} frameSync
  */
 
@@ -26,7 +26,7 @@ import Thread from './Thread';
 function ThreadCard({ frameSync, thread }) {
   const store = useStoreProxy();
   const threadTag = thread.annotation && thread.annotation.$tag;
-  const isFocused = store.isAnnotationFocused(threadTag);
+  const isFocused = threadTag && store.isAnnotationFocused(threadTag);
   const focusThreadAnnotation = useMemo(
     () =>
       debounce(tag => {
@@ -79,6 +79,4 @@ function ThreadCard({ frameSync, thread }) {
   );
 }
 
-ThreadCard.injectedProps = ['frameSync'];
-
-export default withServices(ThreadCard);
+export default withServices(ThreadCard, ['frameSync']);

--- a/src/sidebar/components/ToastMessages.js
+++ b/src/sidebar/components/ToastMessages.js
@@ -107,6 +107,4 @@ function ToastMessages({ toastMessenger }) {
   );
 }
 
-ToastMessages.injectedProps = ['toastMessenger'];
-
-export default withServices(ToastMessages);
+export default withServices(ToastMessages, ['toastMessenger']);

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -130,7 +130,7 @@ function TopBar({
       {/* Sidebar view */}
       {isSidebar && (
         <div className="TopBar__inner content">
-          <GroupList className="GroupList" auth={auth} />
+          <GroupList />
           <div className="u-stretch" />
           {pendingUpdateCount > 0 && (
             <IconButton
@@ -171,6 +171,4 @@ function TopBar({
   );
 }
 
-TopBar.injectedProps = ['bridge', 'settings', 'streamer'];
-
-export default withServices(TopBar);
+export default withServices(TopBar, ['bridge', 'settings', 'streamer']);

--- a/src/sidebar/components/Tutorial.js
+++ b/src/sidebar/components/Tutorial.js
@@ -68,6 +68,4 @@ function Tutorial({ settings }) {
   );
 }
 
-Tutorial.injectedProps = ['settings'];
-
-export default withServices(Tutorial);
+export default withServices(Tutorial, ['settings']);

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -128,6 +128,4 @@ function UserMenu({ auth, bridge, onLogout, settings }) {
   );
 }
 
-UserMenu.injectedProps = ['bridge', 'settings'];
-
-export default withServices(UserMenu);
+export default withServices(UserMenu, ['bridge', 'settings']);

--- a/src/sidebar/components/VersionInfo.js
+++ b/src/sidebar/components/VersionInfo.js
@@ -49,6 +49,4 @@ function VersionInfo({ toastMessenger, versionData }) {
   );
 }
 
-VersionInfo.injectedProps = ['toastMessenger'];
-
-export default withServices(VersionInfo);
+export default withServices(VersionInfo, ['toastMessenger']);

--- a/src/sidebar/helpers/account-id.js
+++ b/src/sidebar/helpers/account-id.js
@@ -2,6 +2,8 @@
  * Parses H account names of the form 'acct:<username>@<provider>'
  * into a {username, provider} object or null if the input does not
  * match the expected form.
+ *
+ * @param {string|null} user
  */
 export function parseAccountID(user) {
   if (!user) {
@@ -34,7 +36,7 @@ export function username(user) {
  * Returns true if the user's provider (authority) differs from the default
  * authority for the application.
  *
- * @param {string} user
+ * @param {string|null} user
  * @param {string} defaultAuthority - The application's default authority
  *   (user identity provider)
  */

--- a/src/sidebar/helpers/version-data.js
+++ b/src/sidebar/helpers/version-data.js
@@ -1,5 +1,7 @@
 /**
- * @typedef {import('../components/UserMenu').AuthState} AuthState
+ * @typedef AuthState
+ * @prop {string|null} [userid]
+ * @prop {string} [displayName]
  */
 
 /**

--- a/src/sidebar/test/service-context-test.js
+++ b/src/sidebar/test/service-context-test.js
@@ -11,17 +11,11 @@ describe('sidebar/service-context', () => {
     function TestComponent(props) {
       lastProps = props;
     }
-    TestComponent.injectedProps = ['aService'];
-    const WrappedComponent = withServices(TestComponent);
+    const WrappedComponent = withServices(TestComponent, ['aService']);
 
     beforeEach(() => {
       lastProps = null;
       container = document.createElement('div');
-    });
-
-    it('returns the input component if there are no service dependencies', () => {
-      function TestComponent() {}
-      assert.equal(withServices(TestComponent), TestComponent);
     });
 
     it('looks up services that a Component depends on and injects them as props', () => {


### PR DESCRIPTION
Previously all components that used injected services did not have their usage type-checked because `withServices(SomeComponent)` returned `any`.

This commit refactors the API of `withServices` to make it easier to typecheck and adds types. The major API change is that the list of injected services is now passed as a second argument to `withServices` rather than by setting an `injectedProps` property on the component. This makes it easy to infer that the component returned by `withServices(Widget, ['serviceA', 'serviceB'])` has the same props as `Widget` but without `serviceA` or `serviceB`.

Making these changes also turned up a handful of mistakes in existing
types which are fixed here:

 - Correct `auth` type used by `HelpPanel` (This prop should probably be removed in future in favor of having `HelpPanel` get the information from the store, but that's out of scope for this PR)
 - Correct type of `thread` prop used by `ThreadCard`
 - Correct optionality of boolean arguments in callbacks to `Excerpt`
 - Change `showActions` logic in `Annotation` to make it more obvious to TS that the actions are only shown when there is an annotation
 - Remove unused props passed to `GroupList`