### PR TITLE
Remove last remaining use of `store.getState`

### DIFF
--- a/src/sidebar/components/test/AnnotationView-test.js
+++ b/src/sidebar/components/test/AnnotationView-test.js
@@ -14,7 +14,6 @@ describe('AnnotationView', () => {
   beforeEach(() => {
     fakeStore = {
       clearAnnotations: sinon.stub(),
-      getState: sinon.stub().returns({}),
       highlightAnnotations: sinon.stub(),
       routeParams: sinon.stub().returns({ id: 'test_annotation_id' }),
       profile: sinon.stub().returns({ userid: null }),

--- a/src/sidebar/components/test/SidebarPanel-test.js
+++ b/src/sidebar/components/test/SidebarPanel-test.js
@@ -17,11 +17,6 @@ describe('SidebarPanel', () => {
     fakeScrollIntoView = sinon.stub();
 
     fakeStore = {
-      getState: sinon.stub().returns({
-        sidebarPanels: {
-          activePanelName: null,
-        },
-      }),
       isSidebarPanelOpen: sinon.stub().returns(false),
       toggleSidebarPanel: sinon.stub(),
     };

--- a/src/sidebar/components/test/StreamView-test.js
+++ b/src/sidebar/components/test/StreamView-test.js
@@ -30,7 +30,6 @@ describe('StreamView', () => {
       annotationFetchStarted: sinon.stub(),
       annotationFetchFinished: sinon.stub(),
       clearAnnotations: sinon.spy(),
-      getState: sinon.stub().returns({}),
       routeParams: sinon.stub().returns({ id: 'test' }),
       setSortKey: sinon.spy(),
     };

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -66,7 +66,7 @@ export class FrameSyncService {
 
       watch(
         store.subscribe,
-        [() => store.getState().annotations.annotations, () => store.frames()],
+        [() => store.allAnnotations(), () => store.frames()],
         ([annotations, frames], [prevAnnotations]) => {
           let publicAnns = 0;
           const inSidebar = new Set();

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -54,8 +54,11 @@ describe('FrameSyncService', () => {
 
   beforeEach(function () {
     fakeStore = createFakeStore(
-      { annotations: { annotations: [] } },
+      { annotations: [] },
       {
+        allAnnotations() {
+          return this.getState().annotations;
+        },
         connectFrame: sinon.stub(),
         destroyFrame: sinon.stub(),
         findIDsForTags: sinon.stub(),
@@ -110,7 +113,7 @@ describe('FrameSyncService', () => {
   context('when annotations are loaded into the sidebar', function () {
     it('sends a "loadAnnotations" message to the frame', function () {
       fakeStore.setState({
-        annotations: { annotations: [fixtures.ann] },
+        annotations: [fixtures.ann],
       });
       assert.calledWithMatch(
         fakeBridge.call,
@@ -122,12 +125,12 @@ describe('FrameSyncService', () => {
     it('sends a "loadAnnotations" message only for new annotations', function () {
       const ann2 = Object.assign({}, fixtures.ann, { $tag: 't2', id: 'a2' });
       fakeStore.setState({
-        annotations: { annotations: [fixtures.ann] },
+        annotations: [fixtures.ann],
       });
       fakeBridge.call.reset();
 
       fakeStore.setState({
-        annotations: { annotations: [fixtures.ann, ann2] },
+        annotations: [fixtures.ann, ann2],
       });
 
       assert.calledWithMatch(
@@ -139,7 +142,7 @@ describe('FrameSyncService', () => {
 
     it('does not send a "loadAnnotations" message for replies', function () {
       fakeStore.setState({
-        annotations: { annotations: [annotationFixtures.newReply()] },
+        annotations: [annotationFixtures.newReply()],
       });
       assert.isFalse(fakeBridge.call.calledWith('loadAnnotations'));
     });
@@ -148,7 +151,7 @@ describe('FrameSyncService', () => {
   context('when annotation count has changed', function () {
     it('sends a "publicAnnotationCountChanged" message to the frame when there are public annotations', function () {
       fakeStore.setState({
-        annotations: { annotations: [annotationFixtures.publicAnnotation()] },
+        annotations: [annotationFixtures.publicAnnotation()],
       });
       assert.calledWithMatch(
         fakeBridge.call,
@@ -162,7 +165,7 @@ describe('FrameSyncService', () => {
       delete annot.permissions;
 
       fakeStore.setState({
-        annotations: { annotations: [annot] },
+        annotations: [annot],
       });
       assert.calledWithMatch(
         fakeBridge.call,
@@ -174,7 +177,7 @@ describe('FrameSyncService', () => {
     it('does not send a "publicAnnotationCountChanged" message to the frame if annotation fetch is not complete', function () {
       fakeStore.frames.returns([{ uri: 'http://example.com' }]);
       fakeStore.setState({
-        annotations: { annotations: [annotationFixtures.publicAnnotation()] },
+        annotations: [annotationFixtures.publicAnnotation()],
       });
       assert.isFalse(
         fakeBridge.call.calledWith('publicAnnotationCountChanged')
@@ -184,7 +187,7 @@ describe('FrameSyncService', () => {
     it('does not send a "publicAnnotationCountChanged" message if there are no connected frames', function () {
       fakeStore.frames.returns([]);
       fakeStore.setState({
-        annotations: { annotations: [annotationFixtures.publicAnnotation()] },
+        annotations: [annotationFixtures.publicAnnotation()],
       });
       assert.isFalse(
         fakeBridge.call.calledWith('publicAnnotationCountChanged')
@@ -195,10 +198,10 @@ describe('FrameSyncService', () => {
   context('when annotations are removed from the sidebar', function () {
     it('sends a "deleteAnnotation" message to the frame', function () {
       fakeStore.setState({
-        annotations: { annotations: [fixtures.ann] },
+        annotations: [fixtures.ann],
       });
       fakeStore.setState({
-        annotations: { annotations: [] },
+        annotations: [],
       });
       assert.calledWithMatch(
         fakeBridge.call,


### PR DESCRIPTION
We decided a while back to deprecate the use of `store.getState` in code that uses the store in favor of selector methods. This enables us to change the internal state structure of the store without having to change the UI components and services that use it. This PR eliminates the last remaining use of `getState` in the `FrameSyncService` implementation and also removes some unused `getState` stubs in UI component tests.