### PR TITLE
Refactor annotator/config/ (1/N)

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -61,7 +61,14 @@ function configurationKeys(appContext) {
       return contexts.notebook;
     case 'all':
       // Complete list of configuration keys used for testing.
-      return [...contexts.annotator, ...contexts.sidebar, ...contexts.notebook];
+      return [
+        ...contexts.annotator,
+        ...contexts.sidebar,
+        ...contexts.notebook,
+        // "experimental" currently has no uses in any app contexts, but is included
+        // for test coverage
+        'experimental',
+      ];
     default:
       throw new Error(`Invalid application context used: "${appContext}"`);
   }

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -2,17 +2,74 @@ import settingsFrom from './settings';
 import { toBoolean } from '../../shared/type-coercions';
 
 /**
+ * @typedef {'sidebar'|'notebook'|'annotator'|'all'} AppContext
+ */
+
+/**
+ * List of allowed configuration keys per application context. Keys omitted
+ * in a given context will be removed from the relative configs when calling
+ * getConfig.
+ *
+ * @param {AppContext} [appContext] - The name of the app.
+ */
+function configurationKeys(appContext) {
+  const contexts = {
+    annotator: ['clientUrl', 'showHighlights', 'subFrameIdentifier'],
+    sidebar: [
+      'appType',
+      'annotations',
+      'branding',
+      'enableExperimentalNewNoteButton',
+      'externalContainerSelector',
+      'focus',
+      'group',
+      'onLayoutChange',
+      'openSidebar',
+      'query',
+      'requestConfigFromFrame',
+      'services',
+      'showHighlights',
+      'sidebarAppUrl',
+      'theme',
+      'usernameUrl',
+    ],
+    notebook: [
+      'branding',
+      'group',
+      'notebookAppUrl',
+      'requestConfigFromFrame',
+      'services',
+      'theme',
+      'usernameUrl',
+    ],
+  };
+
+  switch (appContext) {
+    case 'annotator':
+      return contexts.annotator;
+    case 'sidebar':
+      return contexts.sidebar;
+    case 'notebook':
+      return contexts.notebook;
+    case 'all':
+      // Complete list of configuration keys used for testing.
+      return [...contexts.annotator, ...contexts.sidebar, ...contexts.notebook];
+    default:
+      throw new Error(`Invalid application context used: "${appContext}"`);
+  }
+}
+
+/**
  * Reads the Hypothesis configuration from the environment.
  *
+ * @param {string[]} settingsKeys - List of settings that should be returned.
  * @param {Window} window_ - The Window object to read config from.
  */
-export default function configFrom(window_) {
+function configFrom(settingsKeys, window_) {
   const settings = settingsFrom(window_);
-  return {
+  const allConfigSettings = {
     annotations: settings.annotations,
-    // URL where client assets are served from. Used when injecting the client
-    // into child iframes.
-    assetRoot: settings.hostPageSetting('assetRoot', {
+    appType: settings.hostPageSetting('appType', {
       allowInBrowserExt: true,
     }),
     branding: settings.hostPageSetting('branding'),
@@ -50,4 +107,24 @@ export default function configFrom(window_) {
       'externalContainerSelector'
     ),
   };
+
+  // Only return what we asked for
+  const resultConfig = {};
+  settingsKeys.forEach(key => {
+    resultConfig[key] = allConfigSettings[key];
+  });
+  return resultConfig;
+}
+
+/**
+ * Return the configuration for a given application context.
+ *
+ * @param {AppContext} [appContext] - The name of the app.
+ */
+export function getConfig(appContext = 'annotator', window_ = window) {
+  // Filter the config based on the application context as some config values
+  // may be inappropriate or erroneous for some applications.
+  const filteredKeys = configurationKeys(appContext);
+  const config = configFrom(filteredKeys, window_);
+  return config;
 }

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -61,14 +61,7 @@ function configurationKeys(appContext) {
       return contexts.notebook;
     case 'all':
       // Complete list of configuration keys used for testing.
-      return [
-        ...contexts.annotator,
-        ...contexts.sidebar,
-        ...contexts.notebook,
-        // "experimental" currently has no uses in any app contexts, but is included
-        // for test coverage
-        'experimental',
-      ];
+      return [...contexts.annotator, ...contexts.sidebar, ...contexts.notebook];
     default:
       throw new Error(`Invalid application context used: "${appContext}"`);
   }

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -3,14 +3,6 @@ import { toBoolean } from '../../shared/type-coercions';
 
 /**
  * @typedef {'sidebar'|'notebook'|'annotator'|'all'} AppContext
- *
- * @typedef ConfigDefinition
- * @prop {() => any} valueFn -
- *   Method to retrieve the value from the incoming source
- */
-
-/**
- * @typedef {Record<string, ConfigDefinition>} ConfigDefinitionMap
  */
 
 /**
@@ -68,90 +60,60 @@ function configurationKeys(appContext) {
 }
 
 /**
- * The definition for configuration sources, their default values
- * @return {ConfigDefinitionMap}
+ * Reads the Hypothesis configuration from the environment.
+ *
+ * @param {string[]} settingsKeys - List of settings that should be returned.
+ * @param {Window} window_ - The Window object to read config from.
  */
-function configDefinitions(settings) {
-  return {
-    annotations: {
-      valueFn: () => settings.annotations,
-    },
-    appType: {
-      valueFn: () =>
-        settings.hostPageSetting('appType', {
-          allowInBrowserExt: true,
-        }),
-    },
-    branding: {
-      valueFn: () => settings.hostPageSetting('branding'),
-    },
+function configFrom(settingsKeys, window_) {
+  const settings = settingsFrom(window_);
+  const allConfigSettings = {
+    annotations: settings.annotations,
+    appType: settings.hostPageSetting('appType', {
+      allowInBrowserExt: true,
+    }),
+    branding: settings.hostPageSetting('branding'),
     // URL of the client's boot script. Used when injecting the client into
     // child iframes.
-    clientUrl: {
-      valueFn: () => settings.clientUrl,
-    },
-    enableExperimentalNewNoteButton: {
-      valueFn: () =>
-        settings.hostPageSetting('enableExperimentalNewNoteButton'),
-    },
-    experimental: {
-      valueFn: () =>
-        settings.hostPageSetting('experimental', {
-          defaultValue: {},
-        }),
-    },
-    group: {
-      valueFn: () => settings.group,
-    },
-    focus: {
-      valueFn: () => settings.hostPageSetting('focus'),
-    },
-    theme: {
-      valueFn: () => settings.hostPageSetting('theme'),
-    },
-    usernameUrl: {
-      valueFn: () => settings.hostPageSetting('usernameUrl'),
-    },
-    onLayoutChange: {
-      valueFn: () => settings.hostPageSetting('onLayoutChange'),
-    },
-    openSidebar: {
-      valueFn: () =>
-        settings.hostPageSetting('openSidebar', {
-          allowInBrowserExt: true,
-          coerce: toBoolean,
-        }),
-    },
-    query: {
-      valueFn: () => settings.query,
-    },
-    requestConfigFromFrame: {
-      valueFn: () => settings.hostPageSetting('requestConfigFromFrame'),
-    },
-    services: {
-      valueFn: () => settings.hostPageSetting('services'),
-    },
-    showHighlights: {
-      valueFn: () => settings.showHighlights,
-    },
-    notebookAppUrl: {
-      valueFn: () => settings.notebookAppUrl,
-    },
-    sidebarAppUrl: {
-      valueFn: () => settings.sidebarAppUrl,
-    },
-    // Sub-frame identifier given when a frame is being embedded into
+    clientUrl: settings.clientUrl,
+    enableExperimentalNewNoteButton: settings.hostPageSetting(
+      'enableExperimentalNewNoteButton'
+    ),
+    experimental: settings.hostPageSetting('experimental', {
+      defaultValue: {},
+    }),
+    group: settings.group,
+    focus: settings.hostPageSetting('focus'),
+    theme: settings.hostPageSetting('theme'),
+    usernameUrl: settings.hostPageSetting('usernameUrl'),
+    onLayoutChange: settings.hostPageSetting('onLayoutChange'),
+    openSidebar: settings.hostPageSetting('openSidebar', {
+      allowInBrowserExt: true,
+      // Coerce value to a boolean because it may come from via as a string
+      coerce: toBoolean,
+    }),
+    query: settings.query,
+    requestConfigFromFrame: settings.hostPageSetting('requestConfigFromFrame'),
+    services: settings.hostPageSetting('services'),
+    showHighlights: settings.showHighlights,
+    notebookAppUrl: settings.notebookAppUrl,
+    sidebarAppUrl: settings.sidebarAppUrl,
+    // Subframe identifier given when a frame is being embedded into
     // by a top level client
-    subFrameIdentifier: {
-      valueFn: () =>
-        settings.hostPageSetting('subFrameIdentifier', {
-          allowInBrowserExt: true,
-        }),
-    },
-    externalContainerSelector: {
-      valueFn: () => settings.hostPageSetting('externalContainerSelector'),
-    },
+    subFrameIdentifier: settings.hostPageSetting('subFrameIdentifier', {
+      allowInBrowserExt: true,
+    }),
+    externalContainerSelector: settings.hostPageSetting(
+      'externalContainerSelector'
+    ),
   };
+
+  // Only return what we asked for
+  const resultConfig = {};
+  settingsKeys.forEach(key => {
+    resultConfig[key] = allConfigSettings[key];
+  });
+  return resultConfig;
 }
 
 /**
@@ -160,17 +122,9 @@ function configDefinitions(settings) {
  * @param {AppContext} [appContext] - The name of the app.
  */
 export function getConfig(appContext = 'annotator', window_ = window) {
-  const settings = settingsFrom(window_);
-  const configDefs = configDefinitions(settings);
-  const config = {};
   // Filter the config based on the application context as some config values
   // may be inappropriate or erroneous for some applications.
-  let filteredKeys = configurationKeys(appContext);
-  filteredKeys.forEach(name => {
-    const configDef = configDefs[name];
-    // Get the value from the configuration source and run through an optional coerce method
-    config[name] = configDef.valueFn();
-  });
-
+  const filteredKeys = configurationKeys(appContext);
+  const config = configFrom(filteredKeys, window_);
   return config;
 }

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -1,7 +1,7 @@
-import configFrom from '../index';
+import { getConfig } from '../index';
 import { $imports } from '../index';
 
-describe('annotator.config.index', function () {
+describe('annotator/config/index', function () {
   let fakeSettingsFrom;
 
   beforeEach(() => {
@@ -19,7 +19,7 @@ describe('annotator.config.index', function () {
   });
 
   it('gets the configuration settings', function () {
-    configFrom('WINDOW');
+    getConfig('all', 'WINDOW');
 
     assert.calledOnce(fakeSettingsFrom);
     assert.calledWithExactly(fakeSettingsFrom, 'WINDOW');
@@ -27,10 +27,10 @@ describe('annotator.config.index', function () {
 
   ['sidebarAppUrl', 'query', 'annotations', 'group', 'showHighlights'].forEach(
     settingName => {
-      it('returns the ' + settingName + ' setting', () => {
+      it(`returns the ${settingName} setting`, () => {
         fakeSettingsFrom()[settingName] = 'SETTING_VALUE';
 
-        const config = configFrom('WINDOW');
+        const config = getConfig('all', 'WINDOW');
 
         assert.equal(config[settingName], 'SETTING_VALUE');
       });
@@ -46,77 +46,101 @@ describe('annotator.config.index', function () {
 
     it('throws an error', function () {
       assert.throws(function () {
-        configFrom('WINDOW');
+        getConfig('all', 'WINDOW');
       }, "there's no link");
     });
   });
 
-  ['assetRoot', 'subFrameIdentifier'].forEach(function (settingName) {
-    it(
-      'reads ' +
-        settingName +
-        ' from the host page, even when in a browser extension',
-      function () {
-        configFrom('WINDOW');
-        assert.calledWithExactly(
-          fakeSettingsFrom().hostPageSetting,
-          settingName,
-          { allowInBrowserExt: true }
-        );
-      }
-    );
-  });
-
-  it('reads openSidebar from the host page, even when in a browser extension', function () {
-    configFrom('WINDOW');
-    sinon.assert.calledWith(
-      fakeSettingsFrom().hostPageSetting,
-      'openSidebar',
-      sinon.match({
-        allowInBrowserExt: true,
-        coerce: sinon.match.func,
-      })
-    );
+  ['appType', 'openSidebar', 'subFrameIdentifier'].forEach(function (
+    settingName
+  ) {
+    it(`reads ${settingName} from the host page, even when in a browser extension`, function () {
+      getConfig('all', 'WINDOW');
+      assert.calledWith(
+        fakeSettingsFrom().hostPageSetting,
+        settingName,
+        sinon.match({ allowInBrowserExt: true })
+      );
+    });
   });
 
   ['branding', 'services'].forEach(function (settingName) {
-    it(
-      'reads ' +
-        settingName +
-        ' from the host page only when in an embedded client',
-      function () {
-        configFrom('WINDOW');
+    it(`reads ${settingName} from the host page only when in an embedded client`, function () {
+      getConfig('all', 'WINDOW');
 
-        assert.calledWithExactly(
-          fakeSettingsFrom().hostPageSetting,
-          settingName
-        );
-      }
-    );
+      assert.calledWithExactly(fakeSettingsFrom().hostPageSetting, settingName);
+    });
   });
 
-  [
-    'assetRoot',
-    'branding',
-    'openSidebar',
-    'requestConfigFromFrame',
-    'services',
-  ].forEach(function (settingName) {
-    it('returns the ' + settingName + ' value from the host page', function () {
-      const settings = {
-        assetRoot: 'chrome-extension://1234/client/',
-        branding: 'BRANDING_SETTING',
-        openSidebar: 'OPEN_SIDEBAR_SETTING',
-        requestConfigFromFrame: 'https://embedder.com',
-        services: 'SERVICES_SETTING',
-      };
-      fakeSettingsFrom().hostPageSetting = function (settingName) {
-        return settings[settingName];
-      };
+  ['branding', 'openSidebar', 'requestConfigFromFrame', 'services'].forEach(
+    function (settingName) {
+      it(`returns the ${settingName} value from the host page`, function () {
+        const settings = {
+          branding: 'BRANDING_SETTING',
+          openSidebar: 'OPEN_SIDEBAR_SETTING',
+          requestConfigFromFrame: 'https://embedder.com',
+          services: 'SERVICES_SETTING',
+        };
+        fakeSettingsFrom().hostPageSetting = function (settingName) {
+          return settings[settingName];
+        };
 
-      const settingValue = configFrom('WINDOW')[settingName];
+        const settingValue = getConfig('all', 'WINDOW')[settingName];
 
-      assert.equal(settingValue, settings[settingName]);
+        assert.equal(settingValue, settings[settingName]);
+      });
+    }
+  );
+  describe('application contexts', () => {
+    [
+      {
+        app: 'annotator',
+        expectedKeys: ['clientUrl', 'showHighlights', 'subFrameIdentifier'],
+      },
+      {
+        app: 'sidebar',
+        expectedKeys: [
+          'appType',
+          'annotations',
+          'branding',
+          'enableExperimentalNewNoteButton',
+          'externalContainerSelector',
+          'focus',
+          'group',
+          'onLayoutChange',
+          'openSidebar',
+          'query',
+          'requestConfigFromFrame',
+          'services',
+          'showHighlights',
+          'sidebarAppUrl',
+          'theme',
+          'usernameUrl',
+        ],
+      },
+      {
+        app: 'notebook',
+        expectedKeys: [
+          'branding',
+          'group',
+          'notebookAppUrl',
+          'requestConfigFromFrame',
+          'services',
+          'theme',
+          'usernameUrl',
+        ],
+      },
+    ].forEach(test => {
+      it(`ignore values not belonging to "${test.app}" context`, () => {
+        const config = getConfig(test.app, 'WINDOW');
+        assert.deepEqual(Object.keys(config), test.expectedKeys);
+      });
     });
+  });
+
+  it(`throws an error if an invalid context was passed`, () => {
+    assert.throws(() => {
+      getConfig('fake', 'WINDOW');
+    }, 'Invalid application context used: "fake"');
   });
 });


### PR DESCRIPTION
Refactor `annotator/config/index.js` to expose a slightly different method for getting the config called `getConfig`. This now takes a app name as a string which may return a subset of config values appropriate for a given application such as the "sidebar" or "notebook".

Previously, part of this change was in this longer PR: https://github.com/hypothesis/client/pull/3291
The plan is still to move forward with a similar (if not same approach) but broken up in to smaller steps.

Partially fixes https://github.com/hypothesis/client/issues/3236


The next steps at a high level are

- [ ] Audit the existing keys to see if which keys may be able to be omitted from the app contexts (notebook, sidebar, guest)
- [x] Add a config def map that has a valueFn and gets the setting from setting.js [3411](https://github.com/hypothesis/client/pull/3411)
- [x] Move the browser extension logic out of settings and add flags into the config defs as needed [3421](https://github.com/hypothesis/client/pull/3421)
- [x] Consolidate the default value(s) and move them into the config defs. Currently some undefined configs become null and its not very explicit. (https://github.com/hypothesis/client/pull/3421)
- [x] Move the existing coerce methods or logic out into a coerce fn's in the config defs. Some of that logic is buried in settings [3421](https://github.com/hypothesis/client/pull/3421)
- [ ] Audit the settings.js file and see if any existing gettings need custom coerce methods
- [ ] Add validation methods as needed to pass/fail incoming config values. Note this is different than "coerce". e.g. "true" may be `true`, but "foo" would be an error.



