### PR TITLE
Add classname prefix to avoid conflicts with `frontend-shared`

### DIFF
--- a/src/sidebar/components/Panel.js
+++ b/src/sidebar/components/Panel.js
@@ -17,14 +17,14 @@ import { LabeledButton, SvgIcon } from '@hypothesis/frontend-shared';
 export default function Panel({ children, icon, onClose, title }) {
   const withCloseButton = typeof onClose === 'function';
   return (
-    <div className="Panel">
-      <div className="Panel__header">
+    <div className="client-Panel">
+      <div className="client-Panel__header">
         {icon && (
-          <div className="Panel__header-icon">
+          <div className="client-Panel__header-icon">
             <SvgIcon name={icon} title={title} />
           </div>
         )}
-        <h2 className="Panel__title u-stretch">{title}</h2>
+        <h2 className="client-Panel__title u-stretch">{title}</h2>
         {withCloseButton && (
           <div>
             <LabeledButton icon="cancel" title="Close" onClick={onClose}>
@@ -33,7 +33,7 @@ export default function Panel({ children, icon, onClose, title }) {
           </div>
         )}
       </div>
-      <div className="Panel__content">{children}</div>
+      <div className="client-Panel__content">{children}</div>
     </div>
   );
 }

--- a/src/sidebar/components/test/Panel-test.js
+++ b/src/sidebar/components/test/Panel-test.js
@@ -24,7 +24,7 @@ describe('Panel', () => {
 
   it('renders the provided title', () => {
     const wrapper = createPanel({ title: 'My Panel' });
-    const titleEl = wrapper.find('.Panel__title');
+    const titleEl = wrapper.find('.client-Panel__title');
     assert.equal(titleEl.text(), 'My Panel');
   });
 

--- a/src/styles/sidebar/components/Panel.scss
+++ b/src/styles/sidebar/components/Panel.scss
@@ -1,6 +1,12 @@
 @use "../../mixins/molecules";
 
-.Panel {
+// TODO: Fix my naming, likely when converting to using shared `Panel` component
+// from @hypothesis/frontend-shared
+// This naming (`client-` prefix) is to avoid classname collisions with the
+// `.Panel` class currently used in @hypothesis/frontend-shared
+// In future, the `frontend-shared` classnames will be prefixed, obviating
+// the need to be defensive in applications that use the package.
+.client-Panel {
   @include molecules.panel;
   position: relative;
   margin-bottom: 0.75em;


### PR DESCRIPTION
Add a temporary class name prefix to the local `Panel` component styles.

This will avoid conflicts with the styling for the new `Panel` component
in the `frontend-shared` package as of version 2.0.

In the future:

* This local `Panel` will be supplanted by the shared variant, and
* Shared component classnames will be prefixed to avoid future conflicts