### PR TITLE
Refactor annotator/config/ (2/N)

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -61,7 +61,14 @@ function configurationKeys(appContext) {
       return contexts.notebook;
     case 'all':
       // Complete list of configuration keys used for testing.
-      return [...contexts.annotator, ...contexts.sidebar, ...contexts.notebook];
+      return [
+        ...contexts.annotator,
+        ...contexts.sidebar,
+        ...contexts.notebook,
+        // "experimental" currently has no uses in any app contexts, but is included
+        // for test coverage
+        'experimental',
+      ];
     default:
       throw new Error(`Invalid application context used: "${appContext}"`);
   }


### PR DESCRIPTION
depends on https://github.com/hypothesis/client/pull/3408

-------

Change configFrom() to configDefinitions()

The main difference is that configFrom returned config key:value pairs, but now configDefinitions returns key:object pairs. Where the object may hold additional flags and methods for each specific config value. Currently the only method included is valueFn() which gets the value from its source. Others will follow.

-------


The end goal here is to have the definitions look more or less like this

```...
    openSidebar: {
      allowInBrowserExt: true,
      defaultValue: false,
      coerce: toBoolean,
      valueFn: settings.hostPageSetting,
    },
    ...

```

Where getConfig does some of the logic to set a default, coerce, restrict based on allowInBrowserExt, and define a value getter as valueFn. Much of this logic is currently inside settings and that will be pulled out so settings can be focused on just retrieving the value.

_This PR has no external changes_
