### PR TITLE
Display the annotation header on the top-level annotation

### DIFF
--- a/src/sidebar/components/Annotation/Annotation.js
+++ b/src/sidebar/components/Annotation/Annotation.js
@@ -26,6 +26,7 @@ import AnnotationReplyToggle from './AnnotationReplyToggle';
  * @prop {VoidFunction} onToggleReplies - Callback to expand/collapse reply threads
  * @prop {number} replyCount - Number of replies to this annotation's thread
  * @prop {boolean} threadIsCollapsed - Is the thread to which this annotation belongs currently collapsed?
+ * @prop {'visible'|'hidden'|'header-only'} [visibility] - The portion of the annotation to display
  * @prop {import('../../services/annotations').AnnotationsService} annotationsService
  */
 
@@ -41,6 +42,7 @@ function Annotation({
   onToggleReplies,
   replyCount,
   threadIsCollapsed,
+  visibility = 'visible',
   annotationsService,
 }) {
   const isCollapsedReply = isReply && threadIsCollapsed;
@@ -57,6 +59,21 @@ function Annotation({
   const showReplyToggle = !isReply && !hasAppliedFilter && replyCount > 0;
 
   const onReply = () => annotationsService.reply(annotation, userid);
+
+  if (visibility === 'hidden') {
+    return null;
+  }
+
+  if (visibility === 'header-only') {
+    return annotation ? (
+      <AnnotationHeader
+        annotation={annotation}
+        isEditing={isEditing}
+        replyCount={replyCount}
+        threadIsCollapsed={threadIsCollapsed}
+      />
+    ) : null;
+  }
 
   return (
     <article

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -295,6 +295,24 @@ describe('Annotation', () => {
     });
   });
 
+  context('visibility', () => {
+    it('should not render if visibility is `hidden`', () => {
+      const wrapper = createComponent({
+        visibility: 'hidden',
+      });
+
+      assert.isTrue(wrapper.isEmptyRender());
+    });
+
+    it('should render AnnotationHeader if visibility is `header-only`', () => {
+      const wrapper = createComponent({
+        visibility: 'header-only',
+      });
+
+      assert.isTrue(wrapper.find('AnnotationHeader').exists());
+    });
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility([

--- a/src/sidebar/components/test/Thread-test.js
+++ b/src/sidebar/components/test/Thread-test.js
@@ -214,12 +214,13 @@ describe('Thread', () => {
       noAnnotationThread = createThread();
       noAnnotationThread.annotation = undefined;
       noAnnotationThread.visible = false;
+      noAnnotationThread.parent = true;
     });
 
     it('does not render any kind of annotation component', () => {
       const wrapper = createComponent({ thread: noAnnotationThread });
 
-      assert.isFalse(wrapper.find('Annotation').exists());
+      assert.equal(wrapper.find('Annotation').prop('visibility'), 'hidden');
     });
   });
 
@@ -238,6 +239,16 @@ describe('Thread', () => {
 
       assert.calledOnce(fakeThreadsService.forceVisible);
       assert.calledWith(fakeThreadsService.forceVisible, thread);
+    });
+
+    it('shows annotation header (which includes the document target) on the first hidden thread', () => {
+      const thread = createThread();
+      thread.visible = false;
+      const wrapper = createComponent({ thread });
+      assert.equal(
+        wrapper.find('Annotation').prop('visibility'),
+        'header-only'
+      );
     });
   });
 


### PR DESCRIPTION
This PR enforces the annotation header to be always present, even if the
top level annotation is hidden by a filter. The annotation header
contains the document target. This information is specially important
in the context of the notebook, where annotations from different
documents are displayed together.

Initially, I included the `AnnotationHeader` component directly into the
`Thread` component, assuming the `isEditing` prop to be always `false`.
However, on two cases the annotation header is displayed differently if
the annotation is actively being edited. Hence, I decided  the best
approach was to instruct `Annotation` component to only display the header
by adding an extra prop `visibility` which can take three values:
`hidden`, `visible` or `header-only`.

On the notebook context:

Before  | After
------- | -------
![image](https://user-images.githubusercontent.com/8555781/118481786-256c1000-b714-11eb-9587-c92eec4a5146.png) | ![image](https://user-images.githubusercontent.com/8555781/118481312-a1b22380-b713-11eb-84ae-0bc197bce1ea.png)

On the sidebar context:

Before  | After
------- | -------
![image](https://user-images.githubusercontent.com/8555781/118482013-75e36d80-b714-11eb-91cd-6f829e88e48a.png) | ![image](https://user-images.githubusercontent.com/8555781/118481623-f81f6200-b713-11eb-84c8-9818a3bc8d9f.png)


Closes # 3250