### PR TITLE
Remove flag icon from annotation cards for LMS users

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationActionBar.js
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.js
@@ -1,6 +1,7 @@
 import { IconButton } from '@hypothesis/frontend-shared';
 
 import { confirm } from '../../../shared/prompts';
+import serviceConfig from '../../config/service-config';
 import {
   sharingEnabled,
   annotationSharingLink,
@@ -24,6 +25,15 @@ import AnnotationShareControl from './AnnotationShareControl';
  * @prop {HostConfig} settings
  * @prop {import('../../services/toast-messenger').ToastMessengerService} toastMessenger
  */
+
+/** @param {HostConfig} settings */
+function flaggingEnabled(settings) {
+  const service = serviceConfig(settings);
+  if (service?.allowFlagging === false) {
+    return false;
+  }
+  return true;
+}
 
 /**
  * A collection of buttons in the footer area of an annotation that take
@@ -53,7 +63,9 @@ function AnnotationActionBar({
 
   //  Only authenticated users can flag an annotation, except the annotation's author.
   const showFlagAction =
-    !!userProfile.userid && userProfile.userid !== annotation.user;
+    flaggingEnabled(settings) &&
+    !!userProfile.userid &&
+    userProfile.userid !== annotation.user;
 
   const shareLink =
     sharingEnabled(settings) && annotationSharingLink(annotation);

--- a/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
@@ -269,6 +269,13 @@ describe('AnnotationActionBar', () => {
       assert.isFalse(getButton(wrapper, 'flag').exists());
     });
 
+    it('hides flag button if flagging is disabled in the settings', () => {
+      fakeSettings = { services: [{ allowFlagging: false }] };
+      const wrapper = createComponent();
+
+      assert.isFalse(getButton(wrapper, 'flag').exists());
+    });
+
     it('shows flag button if user is not author', () => {
       const wrapper = createComponent();
 

--- a/src/types/config.js
+++ b/src/types/config.js
@@ -15,6 +15,7 @@
  * @prop {string[]|Promise<string[]>} [groups] -
  *   List of groups to show. The embedder can specify an array. In the sidebar
  *   this may be converted to a Promise if this information is fetched asynchronously.
+ * @prop {boolean} [allowFlagging]
  * @prop {boolean} [allowLeavingGroups]
  * @prop {boolean} [enableShareLinks]
  * @prop {Function} [onLoginRequest]


### PR DESCRIPTION
1. Added an option (`allowFlagging`) in the service configuration to
   enable/disable flagging.

2. Added logic in `AnnotationActionBar` component to hide the flag icon
   if the service configuration has the option `allowFlagging`.

Closes https://github.com/hypothesis/product-backlog/issues/1126
(together with  https://github.com/hypothesis/lms/pull/2713)