### PR TITLE
Update GitHub API authentication and add logging to release scripts

### DIFF
--- a/scripts/create-github-release.js
+++ b/scripts/create-github-release.js
@@ -29,7 +29,7 @@ async function createGitHubRelease() {
   }
 
   const octokit = new Octokit({
-    auth: `token ${process.env.GITHUB_TOKEN}`,
+    auth: process.env.GITHUB_TOKEN,
   });
 
   const changes = await changelistSinceTag(octokit);

--- a/scripts/create-github-release.js
+++ b/scripts/create-github-release.js
@@ -33,17 +33,27 @@ async function createGitHubRelease() {
   });
 
   const changes = await changelistSinceTag(octokit);
-
   const [owner, repo] = pkg.repository.split('/');
+  const releaseName = `v${pkg.version}`;
+
+  console.log(
+    `Creating release ${releaseName} of ${owner}/${repo} with changelog:
+
+${changes}
+`
+  );
 
   await octokit.repos.createRelease({
+    // Required params.
+    owner,
+    repo,
+    tag_name: releaseName,
+
+    // Optional params.
     body: changes,
     draft: false,
-    name: `v${pkg.version}`,
-    owner,
+    name: releaseName,
     prerelease: true,
-    repo,
-    tag_name: `v${pkg.version}`,
   });
 }
 

--- a/scripts/generate-change-list.js
+++ b/scripts/generate-change-list.js
@@ -137,7 +137,7 @@ async function changelistSinceTag(octokit, tag = getHighestVersionTag()) {
 
 if (require.main === module) {
   const { Octokit } = require('@octokit/rest');
-  const octokit = new Octokit({ auth: `token ${process.env.GITHUB_TOKEN}` });
+  const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
   const tag = process.argv[2] || getHighestVersionTag();
 
   changelistSinceTag(octokit, tag)


### PR DESCRIPTION
Recent releases of the client don't have the expected release notes in https://github.com/hypothesis/client/releases. The release notes should be a list of titles of PRs that were merged along with a link to the PR. Instead the release notes are just the commit description from the commit that was tagged. When I run the `generate-change-list.js` script locally I get the expected output, so I suspect the issue may relate to the Node version that Jenkins is using.

This PR adds logging to the `create-github-release.js` script to show the changelog that has been generated locally before making the request to GitHub to create the release. It also replaces a deprecated approach to authenticating with the GitHub API.