### PR TITLE
Remove `default` export from service-config

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationActionBar.js
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.js
@@ -1,7 +1,7 @@
 import { IconButton } from '@hypothesis/frontend-shared';
 
 import { confirm } from '../../../shared/prompts';
-import serviceConfig from '../../config/service-config';
+import { serviceConfig } from '../../config/service-config';
 import {
   sharingEnabled,
   annotationSharingLink,

--- a/src/sidebar/components/GroupList/GroupList.js
+++ b/src/sidebar/components/GroupList/GroupList.js
@@ -4,7 +4,7 @@ import { serviceConfig } from '../../config/service-config';
 import { isThirdPartyUser } from '../../helpers/account-id';
 import { orgName } from '../../helpers/group-list-item-common';
 import groupsByOrganization from '../../helpers/group-organizations';
-import isThirdPartyService from '../../helpers/is-third-party-service';
+import { isThirdPartyService } from '../../helpers/is-third-party-service';
 import { withServices } from '../../service-context';
 import { useStoreProxy } from '../../store/use-store';
 

--- a/src/sidebar/components/GroupList/GroupList.js
+++ b/src/sidebar/components/GroupList/GroupList.js
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'preact/hooks';
 
-import serviceConfig from '../../config/service-config';
+import { serviceConfig } from '../../config/service-config';
 import { isThirdPartyUser } from '../../helpers/account-id';
 import { orgName } from '../../helpers/group-list-item-common';
 import groupsByOrganization from '../../helpers/group-organizations';

--- a/src/sidebar/components/GroupList/test/GroupList-test.js
+++ b/src/sidebar/components/GroupList/test/GroupList-test.js
@@ -165,7 +165,9 @@ describe('GroupList', () => {
   context('when `isThirdPartyService` is true', () => {
     beforeEach(() => {
       $imports.$mock({
-        '../../helpers/is-third-party-service': () => true,
+        '../../helpers/is-third-party-service': {
+          isThirdPartyService: () => true,
+        },
       });
     });
 

--- a/src/sidebar/components/GroupList/test/GroupList-test.js
+++ b/src/sidebar/components/GroupList/test/GroupList-test.js
@@ -58,7 +58,7 @@ describe('GroupList', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../../store/use-store': { useStoreProxy: () => fakeStore },
-      '../../config/service-config': fakeServiceConfig,
+      '../../config/service-config': { serviceConfig: fakeServiceConfig },
     });
   });
 

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -3,7 +3,7 @@ import { useEffect, useMemo } from 'preact/hooks';
 
 import bridgeEvents from '../../shared/bridge-events';
 import { confirm } from '../../shared/prompts';
-import serviceConfig from '../config/service-config';
+import { serviceConfig } from '../config/service-config';
 import { useStoreProxy } from '../store/use-store';
 import { parseAccountID } from '../helpers/account-id';
 import { shouldAutoDisplayTutorial } from '../helpers/session';

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -1,7 +1,7 @@
 import { IconButton, LinkButton } from '@hypothesis/frontend-shared';
 
 import bridgeEvents from '../../shared/bridge-events';
-import serviceConfig from '../config/service-config';
+import { serviceConfig } from '../config/service-config';
 import { useStoreProxy } from '../store/use-store';
 import isThirdPartyService from '../helpers/is-third-party-service';
 import { withServices } from '../service-context';

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -3,7 +3,7 @@ import { IconButton, LinkButton } from '@hypothesis/frontend-shared';
 import bridgeEvents from '../../shared/bridge-events';
 import { serviceConfig } from '../config/service-config';
 import { useStoreProxy } from '../store/use-store';
-import isThirdPartyService from '../helpers/is-third-party-service';
+import { isThirdPartyService } from '../helpers/is-third-party-service';
 import { withServices } from '../service-context';
 import { applyTheme } from '../helpers/theme';
 

--- a/src/sidebar/components/Tutorial.js
+++ b/src/sidebar/components/Tutorial.js
@@ -1,6 +1,6 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
 
-import isThirdPartyService from '../helpers/is-third-party-service';
+import { isThirdPartyService } from '../helpers/is-third-party-service';
 import { withServices } from '../service-context';
 
 /**

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -2,7 +2,7 @@ import { SvgIcon } from '@hypothesis/frontend-shared';
 import { useState } from 'preact/hooks';
 
 import bridgeEvents from '../../shared/bridge-events';
-import serviceConfig from '../config/service-config';
+import { serviceConfig } from '../config/service-config';
 import { isThirdPartyUser } from '../helpers/account-id';
 import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../service-context';

--- a/src/sidebar/components/test/HypothesisApp-test.js
+++ b/src/sidebar/components/test/HypothesisApp-test.js
@@ -80,7 +80,7 @@ describe('HypothesisApp', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../config/service-config': fakeServiceConfig,
+      '../config/service-config': { serviceConfig: fakeServiceConfig },
       '../store/use-store': { useStoreProxy: () => fakeStore },
       '../helpers/session': {
         shouldAutoDisplayTutorial: fakeShouldAutoDisplayTutorial,

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -40,7 +40,7 @@ describe('TopBar', () => {
     $imports.$mock({
       '../store/use-store': { useStoreProxy: () => fakeStore },
       '../helpers/is-third-party-service': fakeIsThirdPartyService,
-      '../config/service-config': fakeServiceConfig,
+      '../config/service-config': { serviceConfig: fakeServiceConfig },
     });
   });
 

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -39,7 +39,9 @@ describe('TopBar', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../store/use-store': { useStoreProxy: () => fakeStore },
-      '../helpers/is-third-party-service': fakeIsThirdPartyService,
+      '../helpers/is-third-party-service': {
+        isThirdPartyService: fakeIsThirdPartyService,
+      },
       '../config/service-config': { serviceConfig: fakeServiceConfig },
     });
   });

--- a/src/sidebar/components/test/Tutorial-test.js
+++ b/src/sidebar/components/test/Tutorial-test.js
@@ -18,7 +18,9 @@ describe('Tutorial', function () {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../helpers/is-third-party-service': fakeIsThirdPartyService,
+      '../helpers/is-third-party-service': {
+        isThirdPartyService: fakeIsThirdPartyService,
+      },
     });
   });
 

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -57,7 +57,7 @@ describe('UserMenu', () => {
       '../helpers/account-id': {
         isThirdPartyUser: fakeIsThirdPartyUser,
       },
-      '../config/service-config': fakeServiceConfig,
+      '../config/service-config': { serviceConfig: fakeServiceConfig },
       '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });

--- a/src/sidebar/config/get-api-url.js
+++ b/src/sidebar/config/get-api-url.js
@@ -1,4 +1,4 @@
-import serviceConfig from './service-config';
+import { serviceConfig } from './service-config';
 
 /**
  * Function that returns apiUrl from the settings object.

--- a/src/sidebar/config/service-config.js
+++ b/src/sidebar/config/service-config.js
@@ -11,7 +11,7 @@
  * @return {Service|null}
  */
 
-export default function serviceConfig(settings) {
+export function serviceConfig(settings) {
   if (!Array.isArray(settings.services) || settings.services.length === 0) {
     return null;
   }

--- a/src/sidebar/config/test/service-config-test.js
+++ b/src/sidebar/config/test/service-config-test.js
@@ -1,4 +1,4 @@
-import serviceConfig from '../service-config';
+import { serviceConfig } from '../service-config';
 
 describe('config/service-config', () => {
   it('returns null if services is not an array', () => {

--- a/src/sidebar/helpers/annotation-sharing.js
+++ b/src/sidebar/helpers/annotation-sharing.js
@@ -3,7 +3,7 @@
  * @typedef {import('../../types/config').HostConfig} HostConfig
  */
 
-import serviceConfig from '../config/service-config';
+import { serviceConfig } from '../config/service-config';
 
 /**
  * Retrieve an appropriate sharing link for this annotation.

--- a/src/sidebar/helpers/groups.js
+++ b/src/sidebar/helpers/groups.js
@@ -6,7 +6,7 @@
 // @ts-expect-error - Ignore error about default-importing a CommonJS module.
 import escapeStringRegexp from 'escape-string-regexp';
 
-import serviceConfig from '../config/service-config';
+import { serviceConfig } from '../config/service-config';
 
 /**
  * Should users be able to leave private groups of which they

--- a/src/sidebar/helpers/is-third-party-service.js
+++ b/src/sidebar/helpers/is-third-party-service.js
@@ -2,7 +2,7 @@
  * @typedef {import('../../types/config').MergedConfig} MergedConfig
  */
 
-import serviceConfig from '../config/service-config';
+import { serviceConfig } from '../config/service-config';
 
 /**
  * Return `true` if the first configured service is a "third-party" service.

--- a/src/sidebar/helpers/is-third-party-service.js
+++ b/src/sidebar/helpers/is-third-party-service.js
@@ -15,7 +15,7 @@ import { serviceConfig } from '../config/service-config';
  * @param {MergedConfig} settings
  * @return {boolean}
  */
-export default function isThirdPartyService(settings) {
+export function isThirdPartyService(settings) {
   const service = serviceConfig(settings);
 
   if (service === null) {

--- a/src/sidebar/helpers/session.js
+++ b/src/sidebar/helpers/session.js
@@ -1,4 +1,4 @@
-import serviceConfig from '../config/service-config';
+import { serviceConfig } from '../config/service-config';
 
 /**
  * @typedef {import('../../types/config').HostConfig} HostConfig

--- a/src/sidebar/helpers/test/annotation-sharing-test.js
+++ b/src/sidebar/helpers/test/annotation-sharing-test.js
@@ -17,7 +17,7 @@ describe('sidebar/helpers/annotation-sharing', () => {
     };
 
     sharingUtil.$imports.$mock({
-      '../config/service-config': fakeServiceConfig,
+      '../config/service-config': { serviceConfig: fakeServiceConfig },
     });
   });
 

--- a/src/sidebar/helpers/test/groups-test.js
+++ b/src/sidebar/helpers/test/groups-test.js
@@ -6,7 +6,7 @@ describe('sidebar/helpers/groups', () => {
     beforeEach(() => {
       fakeServiceConfig = sinon.stub().returns(null);
       $imports.$mock({
-        '../config/service-config': fakeServiceConfig,
+        '../config/service-config': { serviceConfig: fakeServiceConfig },
       });
     });
 

--- a/src/sidebar/helpers/test/is-third-party-service-test.js
+++ b/src/sidebar/helpers/test/is-third-party-service-test.js
@@ -10,7 +10,7 @@ describe('sidebar/helpers/is-third-party-service', () => {
     fakeSettings = { authDomain: 'hypothes.is' };
 
     $imports.$mock({
-      '../config/service-config': fakeServiceConfig,
+      '../config/service-config': { serviceConfig: fakeServiceConfig },
     });
   });
 

--- a/src/sidebar/helpers/test/is-third-party-service-test.js
+++ b/src/sidebar/helpers/test/is-third-party-service-test.js
@@ -1,4 +1,4 @@
-import isThirdPartyService from '../is-third-party-service';
+import { isThirdPartyService } from '../is-third-party-service';
 import { $imports } from '../is-third-party-service';
 
 describe('sidebar/helpers/is-third-party-service', () => {

--- a/src/sidebar/services/auth.js
+++ b/src/sidebar/services/auth.js
@@ -1,6 +1,6 @@
 import { TinyEmitter } from 'tiny-emitter';
 
-import serviceConfig from '../config/service-config';
+import { serviceConfig } from '../config/service-config';
 import OAuthClient from '../util/oauth-client';
 import { resolve } from '../util/url';
 

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -1,4 +1,4 @@
-import serviceConfig from '../config/service-config';
+import { serviceConfig } from '../config/service-config';
 import { isReply } from '../helpers/annotation-metadata';
 import { combineGroups } from '../helpers/groups';
 import { awaitStateChange } from '../store/util';

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -1,4 +1,4 @@
-import serviceConfig from '../config/service-config';
+import { serviceConfig } from '../config/service-config';
 import { retryPromiseOperation } from '../util/retry';
 import * as sentry from '../util/sentry';
 

--- a/src/sidebar/services/test/session-test.js
+++ b/src/sidebar/services/test/session-test.js
@@ -55,7 +55,7 @@ describe('SessionService', () => {
     };
 
     $imports.$mock({
-      '../config/service-config': fakeServiceConfig,
+      '../config/service-config': { serviceConfig: fakeServiceConfig },
       '../util/retry': { retryPromiseOperation },
       '../util/sentry': fakeSentry,
     });


### PR DESCRIPTION
We have been replacing default exports from services. We only allow
default exports on preact components.