### PR TITLE
Remove `default` export from is-third-party-service

### DIFF
--- a/src/sidebar/components/GroupList/GroupList.js
+++ b/src/sidebar/components/GroupList/GroupList.js
@@ -4,7 +4,7 @@ import { serviceConfig } from '../../config/service-config';
 import { isThirdPartyUser } from '../../helpers/account-id';
 import { orgName } from '../../helpers/group-list-item-common';
 import groupsByOrganization from '../../helpers/group-organizations';
-import isThirdPartyService from '../../helpers/is-third-party-service';
+import { isThirdPartyService } from '../../helpers/is-third-party-service';
 import { withServices } from '../../service-context';
 import { useStoreProxy } from '../../store/use-store';
 

--- a/src/sidebar/components/GroupList/test/GroupList-test.js
+++ b/src/sidebar/components/GroupList/test/GroupList-test.js
@@ -165,7 +165,9 @@ describe('GroupList', () => {
   context('when `isThirdPartyService` is true', () => {
     beforeEach(() => {
       $imports.$mock({
-        '../../helpers/is-third-party-service': () => true,
+        '../../helpers/is-third-party-service': {
+          isThirdPartyService: () => true,
+        },
       });
     });
 

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -3,7 +3,7 @@ import { IconButton, LinkButton } from '@hypothesis/frontend-shared';
 import bridgeEvents from '../../shared/bridge-events';
 import { serviceConfig } from '../config/service-config';
 import { useStoreProxy } from '../store/use-store';
-import isThirdPartyService from '../helpers/is-third-party-service';
+import { isThirdPartyService } from '../helpers/is-third-party-service';
 import { withServices } from '../service-context';
 import { applyTheme } from '../helpers/theme';
 

--- a/src/sidebar/components/Tutorial.js
+++ b/src/sidebar/components/Tutorial.js
@@ -1,6 +1,6 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
 
-import isThirdPartyService from '../helpers/is-third-party-service';
+import { isThirdPartyService } from '../helpers/is-third-party-service';
 import { withServices } from '../service-context';
 
 /**

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -39,7 +39,9 @@ describe('TopBar', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../store/use-store': { useStoreProxy: () => fakeStore },
-      '../helpers/is-third-party-service': fakeIsThirdPartyService,
+      '../helpers/is-third-party-service': {
+        isThirdPartyService: fakeIsThirdPartyService,
+      },
       '../config/service-config': { serviceConfig: fakeServiceConfig },
     });
   });

--- a/src/sidebar/components/test/Tutorial-test.js
+++ b/src/sidebar/components/test/Tutorial-test.js
@@ -18,7 +18,9 @@ describe('Tutorial', function () {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../helpers/is-third-party-service': fakeIsThirdPartyService,
+      '../helpers/is-third-party-service': {
+        isThirdPartyService: fakeIsThirdPartyService,
+      },
     });
   });
 

--- a/src/sidebar/helpers/is-third-party-service.js
+++ b/src/sidebar/helpers/is-third-party-service.js
@@ -15,7 +15,7 @@ import { serviceConfig } from '../config/service-config';
  * @param {MergedConfig} settings
  * @return {boolean}
  */
-export default function isThirdPartyService(settings) {
+export function isThirdPartyService(settings) {
   const service = serviceConfig(settings);
 
   if (service === null) {

--- a/src/sidebar/helpers/test/is-third-party-service-test.js
+++ b/src/sidebar/helpers/test/is-third-party-service-test.js
@@ -1,4 +1,4 @@
-import isThirdPartyService from '../is-third-party-service';
+import { isThirdPartyService } from '../is-third-party-service';
 import { $imports } from '../is-third-party-service';
 
 describe('sidebar/helpers/is-third-party-service', () => {


### PR DESCRIPTION
We have been replacing default exports from services. We only allow
default exports on preact components.