### PR TITLE
Fix GitHub release notes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -189,13 +189,15 @@ stage('Publish') {
                     sh "git push https://github.com/hypothesis/client.git v${newPkgVersion}"
                     sh "sleep 2" // Give GitHub a moment to realize the tag exists.
 
-                    // Bump the package version and create the GitHub release.
+                    // Bump the package version.
                     sh """
                     export SIDEBAR_APP_URL=https://hypothes.is/app.html
                     export NOTEBOOK_APP_URL=https://hypothes.is/notebook
                     yarn version --no-git-tag-version --new-version ${newPkgVersion}
                     """
-                    sh "scripts/create-github-release.js"
+
+                    // Create GitHub release with changes since previous release.
+                    sh "scripts/create-github-release.js ${pkgVersion}"
 
                     sh "echo '//registry.npmjs.org/:_authToken=${env.NPM_TOKEN}' >> \$HOME/.npmrc"
                     sh "yarn publish --no-interactive --tag ${npmTag} --new-version=${newPkgVersion}"


### PR DESCRIPTION
This is a follow up to https://github.com/hypothesis/client/pull/3425#issuecomment-845884247.

`create-github-release.js` had an implicit assumption that it was run
before the new version was tagged. It would generate the change log
based on PRs merged since the most recent tag. However Jenkins now runs
this script after the tag is created. As a result the change log was
always empty.

Fix the issue by explicitly passing the previous version as an argument
to the script so that it doesn't matter whether the new version has been
tagged or not.