### PR TITLE
Small visual improvements for the notebook close button

### DIFF
--- a/src/annotator/components/NotebookModal.js
+++ b/src/annotator/components/NotebookModal.js
@@ -1,4 +1,4 @@
-import { LabeledButton } from '@hypothesis/frontend-shared';
+import { IconButton } from '@hypothesis/frontend-shared';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import classnames from 'classnames';
 
@@ -104,14 +104,12 @@ export default function NotebookModal({ eventBus, config }) {
     >
       <div className="NotebookModal__inner">
         <div className="NotebookModal__close-button-container">
-          <LabeledButton
+          <IconButton
             icon="cancel"
             title="Close the Notebook"
             onClick={onClose}
             variant="dark"
-          >
-            Close
-          </LabeledButton>
+          />
         </div>
         {groupId !== null && (
           <NotebookIframe key={iframeKey} config={config} groupId={groupId} />

--- a/src/styles/annotator/components/NotebookModal.scss
+++ b/src/styles/annotator/components/NotebookModal.scss
@@ -37,9 +37,15 @@
   &__close-button-container {
     position: absolute;
     right: 0;
-    font-size: var.$font-size--large;
-    margin: var.$layout-space--xsmall;
+    font-size: var.$font-size--heading;
+    margin: var.$layout-space--medium;
+  }
+
+  &__close-button-container > button {
     cursor: pointer;
+    // When scrolling on small devices the `X` floats. This background makes it more
+    // obvious to recognize that it is the close button for the modal.
+    background-color: var.$grey-2;
   }
 }
 


### PR DESCRIPTION
Currently, because of the `notebook` and `sidebar` are not able to
communicate directly it is not possible to place the close button on the
`notebook` app itself.

While waiting for the above to be fixed, I propose a few minor style
changes:

* Changed the `LabeledButton` to `IconButton` and only show the `X`
  (cancel icon). This is a widely understood and accepted pattern for
  modals

* Increase the size of the cancel icon

* Re-enable the cursor when hovering on the button (it seems that the
  `cursor: pointer` rule was not longer functional)

* Made the margin bigger to avoid the browser scrolling bar to hidden by
  the button. 

These changes are meant to be a temporary improvement.

The close button doesn't hide the scrolling bar (tested in latest version of Chrome, Firefox and Safari):

![image](https://user-images.githubusercontent.com/8555781/119133069-c2dc8200-ba3b-11eb-9bd0-68b9a8b1f7af.png)


The close button still looks awkward when floating on small screen devices:

![image](https://user-images.githubusercontent.com/8555781/119133385-1fd83800-ba3c-11eb-8d82-beeec1d87e7e.png)
