### PR TITLE
Small visual improvements for the notebook close button

### DIFF
--- a/src/annotator/components/NotebookModal.js
+++ b/src/annotator/components/NotebookModal.js
@@ -98,6 +98,10 @@ export default function NotebookModal({ eventBus, config }) {
     emitter.current.publish('closeNotebook');
   };
 
+  if (groupId === null) {
+    return null;
+  }
+
   return (
     <div
       className={classnames('NotebookModal__outer', { 'is-hidden': isHidden })}
@@ -111,9 +115,7 @@ export default function NotebookModal({ eventBus, config }) {
             variant="dark"
           />
         </div>
-        {groupId !== null && (
-          <NotebookIframe key={iframeKey} config={config} groupId={groupId} />
-        )}
+        <NotebookIframe key={iframeKey} config={config} groupId={groupId} />
       </div>
     </div>
   );

--- a/src/annotator/components/NotebookModal.js
+++ b/src/annotator/components/NotebookModal.js
@@ -1,4 +1,4 @@
-import { LabeledButton } from '@hypothesis/frontend-shared';
+import { IconButton } from '@hypothesis/frontend-shared';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import classnames from 'classnames';
 
@@ -104,14 +104,12 @@ export default function NotebookModal({ eventBus, config }) {
     >
       <div className="NotebookModal__inner">
         <div className="NotebookModal__close-button-container">
-          <LabeledButton
+          <IconButton
             icon="cancel"
             title="Close the Notebook"
             onClick={onClose}
             variant="dark"
-          >
-            Close
-          </LabeledButton>
+          />
         </div>
         {groupId !== null && (
           <NotebookIframe key={iframeKey} config={config} groupId={groupId} />

--- a/src/annotator/components/test/NotebookModal-test.js
+++ b/src/annotator/components/test/NotebookModal-test.js
@@ -109,7 +109,7 @@ describe('NotebookModal', () => {
     assert.isFalse(outer.hasClass('is-hidden'));
 
     act(() => {
-      wrapper.find('LabeledButton').prop('onClick')();
+      wrapper.find('IconButton').prop('onClick')();
     });
     wrapper.update();
 
@@ -125,7 +125,7 @@ describe('NotebookModal', () => {
     });
     assert.equal(document.body.style.overflow, 'hidden');
     act(() => {
-      wrapper.find('LabeledButton').prop('onClick')();
+      wrapper.find('IconButton').prop('onClick')();
     });
     assert.notEqual(document.body.style.overflow, 'hidden');
   });

--- a/src/annotator/components/test/NotebookModal-test.js
+++ b/src/annotator/components/test/NotebookModal-test.js
@@ -34,15 +34,14 @@ describe('NotebookModal', () => {
     const wrapper = createComponent();
     const outer = wrapper.find('.NotebookModal__outer');
 
-    assert.isTrue(outer.hasClass('is-hidden'));
-    assert.isFalse(wrapper.find('iframe').exists());
+    assert.isFalse(outer.exists());
   });
 
   it('shows modal on "openNotebook" event', () => {
     const wrapper = createComponent();
     let outer = wrapper.find('.NotebookModal__outer');
 
-    assert.isTrue(outer.hasClass('is-hidden'));
+    assert.isFalse(outer.exists());
     assert.isFalse(wrapper.find('iframe').exists());
 
     emitter.publish('openNotebook', 'myGroup');
@@ -124,6 +123,7 @@ describe('NotebookModal', () => {
       emitter.publish('openNotebook', 'myGroup');
     });
     assert.equal(document.body.style.overflow, 'hidden');
+    wrapper.update();
     act(() => {
       wrapper.find('IconButton').prop('onClick')();
     });

--- a/src/styles/annotator/components/NotebookModal.scss
+++ b/src/styles/annotator/components/NotebookModal.scss
@@ -37,8 +37,11 @@
   &__close-button-container {
     position: absolute;
     right: 0;
-    font-size: var.$font-size--large;
-    margin: var.$layout-space--xsmall;
+    font-size: var.$font-size--heading;
+    margin: var.$layout-space--medium;
+  }
+
+  &__close-button-container > button {
     cursor: pointer;
   }
 }


### PR DESCRIPTION
Because the `notebook` and `sidebar` are not able to communicate
directly (hopefully this will change soon), it is not possible to place
the close button on the `notebook` app itself.

While waiting for the above to be fixed, I propose a few minor style changes:

- Changed the `LabeledButton` to `IconButton` and only show the `X` (cancel
  icon). This is a widely understood and accepted pattern for modals

- Increase the size of the cancel icon

- Re-enable the cursor when hovering on the button (it seems that the
  `cursor: pointer` rule was not longer functional)

- Made the margin bigger to avoid the browser scrolling bar to hidden by the
  button.

These changes are meant to be a temporary improvement.

On a second commit, I addressed a behaviour only observed in Firefox, where the close button was displayed briefly at the bottom of the page when reloading a document with the hypothesis client.

The close button doesn't hide the scrolling bar (tested in latest version of
Chrome, Firefox and Safari):

![Screenshot 2021-06-30 at 14 32 31](https://user-images.githubusercontent.com/8555781/123961353-8859f380-d9b0-11eb-95e0-ebb7f5ca410a.png)

The close button still looks awkward when floating on small screen devices, but that's the only way to not take top space from the top part of the notebook app:

![image](https://user-images.githubusercontent.com/8555781/119133385-1fd83800-ba3c-11eb-8d82-beeec1d87e7e.png)