### PR TITLE
Replace * and / with math.div() in sass files

### DIFF
--- a/src/styles/mixins/buttons.scss
+++ b/src/styles/mixins/buttons.scss
@@ -17,6 +17,8 @@
  *
  * And pass 'my-component-button' as the `className` prop to `Button`.
  */
+@use "sass:math";
+
 @use "@hypothesis/frontend-shared/styles/mixins/focus";
 
 @use "./layout";
@@ -270,18 +272,18 @@ $indicator-vertical-offset: 6px;
   // This creates a left-pointing "wedge" in grey
   // offset to the left of the element
   &::before {
-    border-width: $indicator-height / 2;
+    border-width: math.div($indicator-height, 2);
     border-right: $indicator-horizontal-offset solid var.$grey-3;
-    margin-top: -1 * ($indicator-height / 2);
+    margin-top: -1 * math.div($indicator-height, 2);
   }
 
   // This creates a left-pointing "wedge" in white, on top
   // of the grey wedge and one pixel narrower so that the
   // grey wedge appears as a border around it
   &::after {
-    border-width: $indicator-height / 2 - 1;
+    border-width: math.div($indicator-height, 2) - 1;
     border-right: ($indicator-horizontal-offset - 1) solid var.$color-background;
-    margin-top: -1 * ($indicator-height / 2 - 1);
+    margin-top: -1 * (math.div($indicator-height, 2) - 1);
   }
 }
 
@@ -297,16 +299,16 @@ $indicator-vertical-offset: 6px;
 
   // Grey (border) arrow pointing up
   &::before {
-    border-width: $indicator-width / 2;
+    border-width: math.div($indicator-width, 2);
     border-bottom: $indicator-vertical-offset solid var.$grey-3;
-    margin-left: -1 * ($indicator-width / 2);
+    margin-left: -1 * math.div($indicator-width, 2);
   }
 
   // White (fill) arrow pointing up
   &::after {
-    border-width: $indicator-width / 2 - 1;
+    border-width: math.div($indicator-width, 2) - 1;
     border-bottom: ($indicator-vertical-offset - 1) solid var.$color-background;
-    margin-left: -1 * ($indicator-width / 2 - 1);
+    margin-left: -1 * (math.div($indicator-width, 2) - 1);
   }
 }
 
@@ -322,15 +324,15 @@ $indicator-vertical-offset: 6px;
 
   // Grey (border) arrow, pointing down
   &::before {
-    border-width: $indicator-width / 2;
+    border-width: math.div($indicator-width, 2);
     border-top: $indicator-vertical-offset solid var.$grey-3;
-    margin-left: -1 * ($indicator-width / 2);
+    margin-left: -1 * math.div($indicator-width, 2);
   }
 
   // White (fill) arrow, pointing down
   &::after {
-    border-width: $indicator-width / 2 - 1;
+    border-width: math.div($indicator-width, 2) - 1;
     border-top: ($indicator-vertical-offset - 1) solid var.$color-background;
-    margin-left: -1 * ($indicator-width / 2 - 1);
+    margin-left: -1 * (math.div($indicator-width, 2) - 1);
   }
 }

--- a/src/styles/sidebar/components/Spinner.scss
+++ b/src/styles/sidebar/components/Spinner.scss
@@ -5,6 +5,7 @@
 //
 //   <!-- Three nested spans -->
 //   <span class="Spinner"><span><span></span></span></span>
+@use "sass:math";
 
 $container-width: 1em;
 $container-height: $container-width;
@@ -44,13 +45,13 @@ $part-height: 3 * $part-width;
   content: '';
   position: absolute;
   top: 0;
-  left: ($container-width - $part-width) / 2;
+  left: math.div(($container-width - $part-width), 2);
   width: $part-width;
   height: $part-height;
   border-radius: 0.1em;
   background: #eee;
   box-shadow: 0 ($container-height - $part-height) rgba(0, 0, 0, 0.15);
-  transform-origin: 50% $container-height / 2;
+  transform-origin: 50% math.div($container-height, 2);
 }
 
 .Spinner:before {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,4 +1,5 @@
 @use "sass:color";
+@use "sass:math";
 
 // Greys (layout colors)
 // These may be used for non-textual styling of components and elements
@@ -90,9 +91,9 @@ $touch-input-font-size: 16px;
 // Layout spacing
 // -------------------------
 $layout-space: 1em;
-$layout-space--xxsmall: $layout-space * (1/4);
-$layout-space--xsmall: $layout-space * (1/2);
-$layout-space--small: $layout-space * (3/4);
+$layout-space--xxsmall: math.div($layout-space, 4);
+$layout-space--xsmall: math.div($layout-space, 2);
+$layout-space--small: math.div($layout-space * 3, 4);
 $layout-space--medium: $layout-space;
 $layout-space--large: $layout-space * 2;
 $layout-space--xlarge: $layout-space * 4;


### PR DESCRIPTION
See https://sass-lang.com/documentation/breaking-changes/slash-div for details


After upgrading to sass to v1.32, a new deprecation warning was appearing in the console,  but not actually failing the tests so CI was passing.

https://github.com/hypothesis/client/runs/2655035699