### PR TITLE
Fix an error when dismissing toast messages

### DIFF
--- a/src/sidebar/components/ToastMessages.js
+++ b/src/sidebar/components/ToastMessages.js
@@ -99,7 +99,7 @@ function ToastMessages({ toastMessenger }) {
           <ToastMessage
             message={message}
             key={message.id}
-            onDismiss={toastMessenger.dismiss}
+            onDismiss={id => toastMessenger.dismiss(id)}
           />
         ))}
       </ul>


### PR DESCRIPTION
Services were recently converted to ES classes. One of the side effects / downsides of this is that service methods now depend on being called with the correct receiver (ie. `this` property). This was not the case for a call made to dismiss toast messages when clicking them.