### PR TITLE
Fix frame discoverability

### DIFF
--- a/dev-server/documents/html/sidebar-external-container.mustache
+++ b/dev-server/documents/html/sidebar-external-container.mustache
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Annotatable iframe test</title>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+      .container {
+        display: flex;
+      }
+      #my-sidebar {
+        flex: 0 0 20%;
+      }
+      iframe {
+        flex: 1;
+        height: 400px;
+        resize: both;
+        overflow: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Sidebar on external container test</h1>
+    <p>
+      The sidebar is placed inside the element with `#my-sidebar` id. The iframe
+      below has an `enable-annotation` attribute. The client detects and injects
+      the annotator into the iframe, which makes the iframe content annotatable.
+    </p>
+    <div class="container">
+      <div id="my-sidebar"></div>
+      <iframe src="/document/injectable-frame" enable-annotation></iframe>
+    </div>
+    {{{hypothesisScript}}}
+    <script>
+      window.hypothesisConfig = function () {
+        return {
+          externalContainerSelector: '#my-sidebar',
+        };
+      };
+    </script>
+  </body>
+</html>

--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -22,6 +22,7 @@
     <li><a href="/document/z-index">z-index test</a></li>
     <li><a href="/document/shadow-dom">Shadow DOM test</a></li>
     <li><a href="/document/parent-frame">Annotatable iframe test</a></li>
+    <li><a href="/document/sidebar-external-container">Sidebar on external container test</a></li>
     <li><a href="/document/multi-frames">Multi-frame test</a></li>
   </ul>
 


### PR DESCRIPTION
After one failed attempt to limit the frame discoverability (#3352), I
suggest here another temporary fix which involves:

* Disable the top-down, breadth-first traversal of frames to enable
  discoverability.

* Replace it by a targeted discoverability: identify the sender of the
  initial postMessage message and direct it to the right frame:

     - if the sender is the `sidebar` iframe (server frame), the
       postMessage is sent *only* to the `host` frame using
       `window.parent`.

     - if the sender is an annotatable iframe(s), send the postMessage
       to the `sidebar` iframe.

Pros:

- resolves the broken ePub example

- resolves the hyper-connectivity of frames

Cons:

- the `notebook` iframe is still not able to be discovered

- introduce an artificial delay on the discoverablity of annotatable
  iframes that could potentially brake

## Background

The client relies on an inter-frame communication system between the
`host` frame, where the client is initially loaded, and a number of
children iframes. For the communication to work, every frame needs to be
able to discover the iframe that acts as a server by sending a
`frame.postMessage`. Currently, the `sidebar` iframe is the server.

The following frames must establish communication with the server
`sidebar` iframe:

- `host` frame (where the client is initially loaded)
- `notebook` iframe
- additional annotatable iframe(s) (each have an `enable-annotation`
  attribute) where the another client instance is injected.

This layout represents the current arrangement of frames:

```
host frame (client)
|-> (generally, shadow DOMed) sidebar iframe (server)
|-> (generally, shadow DOMed) notebook iframe (client)
|-> [annotatable iframe/s] (client)
     |-> [annotatable iframe/s] (client)

```

There are two problems with the current discoverability algorithm:

1. It relies on `window.frames` to list all the other frames. Because
   `sidebar` and `notebook` iframes are generally wrapped on a shadow
   DOM they are not listed on `window.frames`.

2. It is very generic: the algorithm starts from the top-most frame in
   the hierarchy (`window.top`) and send messages to all the frame
   children *recursively*. If there are several clients initialised on
   individual frames, this algorithm causes *all* the `host` frames to
   be connected to all the `sidebar` iframes.
