### PR TITLE
Remove a few unused mixins

### DIFF
--- a/src/styles/mixins/buttons.scss
+++ b/src/styles/mixins/buttons.scss
@@ -141,48 +141,6 @@
 }
 
 /**
- * An icon-only button that sits to the right of a text-input field
- * (e.g. "copy to clipboard" button in share panels)
- *
- * @param {boolean} [$compact] - Tighten padding for small spaces
- */
-@mixin button--input($compact: false) {
-  @include button;
-  @include utils.border;
-
-  @if $compact {
-    padding: var.$layout-space--xxsmall var.$layout-space--xsmall;
-  } @else {
-    padding: var.$layout-space--xsmall var.$layout-space--small;
-  }
-
-  color: var.$grey-mid;
-  background-color: var.$grey-1;
-
-  border-radius: 0; // Turn off border-radius to align with <input> edges
-  border-left: 0; // Avoid double border with the <input>
-
-  &:hover:not([disabled]),
-  &:focus:not([disabled]) {
-    background-color: var.$grey-2;
-  }
-}
-
-/**
- * A button that is styled roughly like an `<a>` element (link-like)
- */
-@mixin button--link {
-  @include button;
-  color: var.$grey-mid;
-  padding: 0;
-  &:hover:not([disabled]),
-  &:focus:not([disabled]) {
-    color: var.$color-link-hover;
-    text-decoration: underline;
-  }
-}
-
-/**
  * A button pattern that looks like a link with a small icon on the right
  * Used, e.g., in the help panel to navigate between sub-panels
  */

--- a/src/styles/mixins/forms.scss
+++ b/src/styles/mixins/forms.scss
@@ -65,28 +65,3 @@
   width: 100%;
   border-radius: 0;
 }
-
-// TODO: Deprecate
-@mixin primary-action-btn {
-  @include focus.outline-on-keyboard-focus;
-  @include utils.font--medium;
-  color: var.$grey-1;
-  background-color: var.$grey-mid;
-  height: 35px;
-  border: none;
-  border-radius: var.$border-radius;
-
-  font-weight: bold;
-
-  padding-left: 12px;
-  padding-right: 12px;
-
-  &:disabled {
-    // NB: This doesn't allow for enough contrast ratio to meet WCAG AA requirements
-    color: var.$grey-semi;
-  }
-
-  &:hover:enabled {
-    background-color: var.$grey-6;
-  }
-}


### PR DESCRIPTION
This PR removes a few mixins that are no longer needed because the styling is provided by the `frontend-shared` package.

More work to do here!