### PR TITLE
Refine API for defining store modules

### DIFF
--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -23,30 +23,17 @@ import { createReducer, bindSelectors } from './util';
  */
 
 /**
- * Map of action name to reducer function.
+ * Map of action type to reducer function.
  *
  * @template State
- * @typedef {{ [action: string]: (s: State, action: any) => Partial<State> }} Reducers
+ * @typedef {{ [action: string]: (s: State, action: any) => Partial<State> }} ReducerMap
  */
 
 /**
- * Configuration for a store module.
+ * Map of selector name to selector function.
  *
  * @template State
- * @template {object} Actions
- * @template {object} Selectors
- * @template {object} RootSelectors
- * @typedef ModuleConfig
- * @prop {string} namespace -
- *   The key under which this module's state will live in the store's root state
- * @prop {Reducers<State>} reducers -
- *   Map of action types to "reducer" functions that process an action and return
- *   the changes to the state
- * @prop {Actions} actionCreators
- *   Object containing action creator functions
- * @prop {Selectors} selectors
- *   Object containing selector functions
- * @prop {RootSelectors} [rootSelectors]
+ * @typedef {{ [name: string]: (s: State, ...args: any[]) => any }} SelectorMap
  */
 
 /**
@@ -56,9 +43,18 @@ import { createReducer, bindSelectors } from './util';
  * @template {object} Actions
  * @template {object} Selectors
  * @template {object} RootSelectors
- * @typedef {ModuleConfig<State, Actions, Selectors, RootSelectors> & {
- *   initialState: (...args: any[]) => State
- * }} Module
+ * @typedef Module
+ * @prop {string} namespace -
+ *   The key under which this module's state will live in the store's root state
+ * @prop {(...args: any[]) => State} initialState
+ * @prop {ReducerMap<State>} reducers -
+ *   Map of action types to "reducer" functions that process an action and return
+ *   the changes to the state
+ * @prop {Actions} actionCreators
+ *   Object containing action creator functions
+ * @prop {Selectors} selectors
+ *   Object containing selector functions
+ * @prop {RootSelectors} [rootSelectors]
  */
 
 /**
@@ -191,15 +187,24 @@ export function createStore(modules, initArgs = [], middleware = []) {
   return store;
 }
 
+// The properties of the `config` argument to `createStoreModule` below are
+// declared inline due to https://github.com/microsoft/TypeScript/issues/43403.
+
 /**
  * Create a store module that can be passed to `createStore`.
  *
  * @template State
  * @template Actions
- * @template Selectors
+ * @template {SelectorMap<State>} Selectors
  * @template RootSelectors
  * @param {(...args: any[]) => State} initialState
- * @param {ModuleConfig<State,Actions,Selectors,RootSelectors>} config
+ * @param {object} config
+ *   @param {string} config.namespace -
+ *     The key under which this module's state will live in the store's root state
+ *   @param {ReducerMap<State>} config.reducers -
+ *   @param {Actions} config.actionCreators
+ *   @param {Selectors} config.selectors
+ *   @param {RootSelectors} [config.rootSelectors]
  * @return {Module<State,Actions,Selectors,RootSelectors>}
  */
 export function createStoreModule(initialState, config) {

--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -37,14 +37,14 @@ import { createReducer, bindSelectors } from './util';
  * @template {object} Selectors
  * @template {object} RootSelectors
  * @typedef Module
- * @prop {(...args: any[]) => State} init -
+ * @prop {(...args: any[]) => State} initialState -
  *   Function that returns the initial state for the module
  * @prop {string} namespace -
  *   The key under which this module's state will live in the store's root state
- * @prop {Reducers<State>} update -
+ * @prop {Reducers<State>} reducers -
  *   Map of action types to "reducer" functions that process an action and return
  *   the changes to the state
- * @prop {Actions} actions
+ * @prop {Actions} actionCreators
  *   Object containing action creator functions
  * @prop {Selectors} selectors
  *   Object containing selector functions
@@ -99,7 +99,7 @@ import { createReducer, bindSelectors } from './util';
  *    from that state.
  *
  * In addition to the standard Redux store interface, the returned store also exposes
- * each action and selector from the input modules as a method. For example, if
+ * each action creator and selector from the input modules as a method. For example, if
  * a store is created from a module that has a `getWidget(<id>)` selector and
  * an `addWidget(<object>)` action, a consumer would use `store.getWidget(<id>)`
  * to fetch an item and `store.addWidget(<object>)` to dispatch an action that
@@ -112,7 +112,7 @@ import { createReducer, bindSelectors } from './util';
  * what store state a component depends upon and re-render when it changes.
  *
  * @param {Module<any,any,any,any>[]} modules
- * @param {any[]} [initArgs] - Arguments to pass to each state module's `init` function
+ * @param {any[]} [initArgs] - Arguments to pass to each state module's `initialState` function
  * @param {any[]} [middleware] - List of additional Redux middlewares to use
  * @return Store<any,any,any>
  */
@@ -137,9 +137,9 @@ export function createStore(modules, initArgs = [], middleware = []) {
   //
   modules.forEach(module => {
     if (module.namespace) {
-      initialState[module.namespace] = module.init(...initArgs);
+      initialState[module.namespace] = module.initialState(...initArgs);
 
-      allReducers[module.namespace] = createReducer(module.update);
+      allReducers[module.namespace] = createReducer(module.reducers);
       allSelectors[module.namespace] = {
         selectors: module.selectors,
         rootSelectors: module.rootSelectors || {},
@@ -172,7 +172,7 @@ export function createStore(modules, initArgs = [], middleware = []) {
   const store = redux.createStore(reducer, initialState, enhancer);
 
   // Add actions and selectors as methods to the store.
-  const actions = Object.assign({}, ...modules.map(m => m.actions));
+  const actions = Object.assign({}, ...modules.map(m => m.actionCreators));
   const boundActions = redux.bindActionCreators(actions, store.dispatch);
   const boundSelectors = bindSelectors(allSelectors, store.getState);
 

--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -197,7 +197,7 @@ export function createStore(modules, initArgs = [], middleware = []) {
  * @template Actions
  * @template {SelectorMap<State>} Selectors
  * @template RootSelectors
- * @param {(...args: any[]) => State} initialState
+ * @param {State | ((...args: any[]) => State)} initialState
  * @param {object} config
  *   @param {string} config.namespace -
  *     The key under which this module's state will live in the store's root state
@@ -211,6 +211,12 @@ export function createStoreModule(initialState, config) {
   // The `initialState` argument is separate to `config` as this allows
   // TypeScript to infer the `State` type in the `config` argument at the
   // `createStoreModule` call site.
+
+  if (!(initialState instanceof Function)) {
+    const state = initialState;
+    initialState = () => state;
+  }
+
   return {
     initialState,
     ...config,

--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -36,9 +36,7 @@ import { createReducer, bindSelectors } from './util';
  * @template {object} Actions
  * @template {object} Selectors
  * @template {object} RootSelectors
- * @typedef Module
- * @prop {(...args: any[]) => State} initialState -
- *   Function that returns the initial state for the module
+ * @typedef ModuleConfig
  * @prop {string} namespace -
  *   The key under which this module's state will live in the store's root state
  * @prop {Reducers<State>} reducers -
@@ -49,6 +47,18 @@ import { createReducer, bindSelectors } from './util';
  * @prop {Selectors} selectors
  *   Object containing selector functions
  * @prop {RootSelectors} [rootSelectors]
+ */
+
+/**
+ * Type of a store module returned by `createStoreModule`.
+ *
+ * @template State
+ * @template {object} Actions
+ * @template {object} Selectors
+ * @template {object} RootSelectors
+ * @typedef {ModuleConfig<State, Actions, Selectors, RootSelectors> & {
+ *   initialState: (...args: any[]) => State
+ * }} Module
  */
 
 /**
@@ -188,12 +198,16 @@ export function createStore(modules, initArgs = [], middleware = []) {
  * @template Actions
  * @template Selectors
  * @template RootSelectors
- * @param {Module<State,Actions,Selectors,RootSelectors>} config
+ * @param {(...args: any[]) => State} initialState
+ * @param {ModuleConfig<State,Actions,Selectors,RootSelectors>} config
  * @return {Module<State,Actions,Selectors,RootSelectors>}
  */
-export function createStoreModule(config) {
-  // This helper doesn't currently do anything at runtime. It does ensure more
-  // helpful error messages when typechecking if there is something incorrect
-  // in the configuration though.
-  return config;
+export function createStoreModule(initialState, config) {
+  // The `initialState` argument is separate to `config` as this allows
+  // TypeScript to infer the `State` type in the `config` argument at the
+  // `createStoreModule` call site.
+  return {
+    initialState,
+    ...config,
+  };
 }

--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -182,8 +182,7 @@ export function createStore(modules, initArgs = [], middleware = []) {
 }
 
 /**
- * Helper to validate a store module configuration before it is passed to
- * `createStore`.
+ * Create a store module that can be passed to `createStore`.
  *
  * @template State
  * @template Actions
@@ -192,9 +191,9 @@ export function createStore(modules, initArgs = [], middleware = []) {
  * @param {Module<State,Actions,Selectors,RootSelectors>} config
  * @return {Module<State,Actions,Selectors,RootSelectors>}
  */
-export function storeModule(config) {
+export function createStoreModule(config) {
   // This helper doesn't currently do anything at runtime. It does ensure more
   // helpful error messages when typechecking if there is something incorrect
-  // in the configuration.
+  // in the configuration though.
   return config;
 }

--- a/src/sidebar/store/modules/activity.js
+++ b/src/sidebar/store/modules/activity.js
@@ -188,8 +188,7 @@ function isSavingAnnotation(state, annotation) {
 
 /** @typedef {import('../../../types/api').Annotation} Annotation */
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   reducers,
   namespace: 'activity',
 

--- a/src/sidebar/store/modules/activity.js
+++ b/src/sidebar/store/modules/activity.js
@@ -6,7 +6,7 @@
 import { actionTypes } from '../util';
 import { storeModule } from '../create-store';
 
-function init() {
+function initialState() {
   return {
     /**
      * Annotation `$tag`s that correspond to annotations with active API requests
@@ -32,7 +32,7 @@ function init() {
   };
 }
 
-const update = {
+const reducers = {
   API_REQUEST_STARTED(state) {
     return {
       ...state,
@@ -107,7 +107,7 @@ const update = {
   },
 };
 
-const actions = actionTypes(update);
+const actions = actionTypes(reducers);
 
 /** Action Creators */
 
@@ -189,11 +189,11 @@ function isSavingAnnotation(state, annotation) {
 /** @typedef {import('../../../types/api').Annotation} Annotation */
 
 export default storeModule({
-  init,
-  update,
+  initialState,
+  reducers,
   namespace: 'activity',
 
-  actions: {
+  actionCreators: {
     annotationFetchStarted,
     annotationFetchFinished,
     annotationSaveStarted,

--- a/src/sidebar/store/modules/activity.js
+++ b/src/sidebar/store/modules/activity.js
@@ -4,7 +4,7 @@
  */
 
 import { actionTypes } from '../util';
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 function initialState() {
   return {
@@ -188,7 +188,7 @@ function isSavingAnnotation(state, annotation) {
 
 /** @typedef {import('../../../types/api').Annotation} Annotation */
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   reducers,
   namespace: 'activity',

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -554,8 +554,7 @@ function savedAnnotations(state) {
   });
 }
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   namespace: 'annotations',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -17,7 +17,7 @@ import { createSelector } from 'reselect';
 import * as metadata from '../../helpers/annotation-metadata';
 import { countIf, toTrueMap, trueKeys } from '../../util/collections';
 import * as util from '../util';
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 import route from './route';
 
@@ -554,7 +554,7 @@ function savedAnnotations(state) {
   });
 }
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   namespace: 'annotations',
   reducers,

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -89,7 +89,7 @@ function initializeAnnotation(annotation, tag) {
   });
 }
 
-function init() {
+function initialState() {
   return {
     /** @type {Annotation[]} */
     annotations: [],
@@ -105,7 +105,7 @@ function init() {
   };
 }
 
-const update = {
+const reducers = {
   ADD_ANNOTATIONS: function (state, action) {
     const updatedIDs = {};
     const updatedTags = {};
@@ -232,7 +232,7 @@ const update = {
   },
 };
 
-const actions = util.actionTypes(update);
+const actions = util.actionTypes(reducers);
 
 /* Action creators */
 
@@ -555,10 +555,10 @@ function savedAnnotations(state) {
 }
 
 export default storeModule({
-  init: init,
+  initialState,
   namespace: 'annotations',
-  update: update,
-  actions: {
+  reducers,
+  actionCreators: {
     addAnnotations,
     clearAnnotations,
     focusAnnotations,

--- a/src/sidebar/store/modules/defaults.js
+++ b/src/sidebar/store/modules/defaults.js
@@ -1,6 +1,6 @@
 import * as util from '../util';
 
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 /**
  * A store module for managing client-side user-convenience defaults.
@@ -57,7 +57,7 @@ function getDefaults(state) {
   return state;
 }
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   namespace: 'defaults',
   reducers,

--- a/src/sidebar/store/modules/defaults.js
+++ b/src/sidebar/store/modules/defaults.js
@@ -16,7 +16,7 @@ import { storeModule } from '../create-store';
  * `persistedDefaults` service.
  */
 
-function init() {
+function initialState() {
   /**
    * Note that the persisted presence of any of these defaults cannot be
    * guaranteed, so consumers of said defaults should be prepared to handle
@@ -29,13 +29,13 @@ function init() {
   };
 }
 
-const update = {
+const reducers = {
   SET_DEFAULT: function (state, action) {
     return { [action.defaultKey]: action.value };
   },
 };
 
-const actions = util.actionTypes(update);
+const actions = util.actionTypes(reducers);
 
 function setDefault(defaultKey, value) {
   return { type: actions.SET_DEFAULT, defaultKey: defaultKey, value: value };
@@ -58,10 +58,10 @@ function getDefaults(state) {
 }
 
 export default storeModule({
-  init,
+  initialState,
   namespace: 'defaults',
-  update,
-  actions: {
+  reducers,
+  actionCreators: {
     setDefault,
   },
   selectors: {

--- a/src/sidebar/store/modules/defaults.js
+++ b/src/sidebar/store/modules/defaults.js
@@ -57,8 +57,7 @@ function getDefaults(state) {
   return state;
 }
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   namespace: 'defaults',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/direct-linked.js
+++ b/src/sidebar/store/modules/direct-linked.js
@@ -142,8 +142,7 @@ function directLinkedGroupFetchFailed(state) {
   return state.directLinkedGroupFetchFailed;
 }
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   namespace: 'directLinked',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/direct-linked.js
+++ b/src/sidebar/store/modules/direct-linked.js
@@ -2,7 +2,7 @@ import * as util from '../util';
 
 import { storeModule } from '../create-store';
 
-function init(settings) {
+function initialState(settings) {
   return {
     /**
      * The ID of the direct-linked group.
@@ -42,7 +42,7 @@ function init(settings) {
   };
 }
 
-const update = {
+const reducers = {
   UPDATE_DIRECT_LINKED_GROUP_FETCH_FAILED(state, action) {
     return {
       directLinkedGroupFetchFailed: action.directLinkedGroupFetchFailed,
@@ -73,7 +73,7 @@ const update = {
   },
 };
 
-const actions = util.actionTypes(update);
+const actions = util.actionTypes(reducers);
 
 /**
  * Set the direct linked group id.
@@ -143,10 +143,10 @@ function directLinkedGroupFetchFailed(state) {
 }
 
 export default storeModule({
-  init,
+  initialState,
   namespace: 'directLinked',
-  update,
-  actions: {
+  reducers,
+  actionCreators: {
     setDirectLinkedGroupFetchFailed,
     setDirectLinkedGroupId,
     setDirectLinkedAnnotationId,

--- a/src/sidebar/store/modules/direct-linked.js
+++ b/src/sidebar/store/modules/direct-linked.js
@@ -1,6 +1,6 @@
 import * as util from '../util';
 
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 function initialState(settings) {
   return {
@@ -142,7 +142,7 @@ function directLinkedGroupFetchFailed(state) {
   return state.directLinkedGroupFetchFailed;
 }
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   namespace: 'directLinked',
   reducers,

--- a/src/sidebar/store/modules/drafts.js
+++ b/src/sidebar/store/modules/drafts.js
@@ -187,8 +187,7 @@ const unsavedAnnotations = createSelector(
   drafts => drafts.filter(d => !d.annotation.id).map(d => d.annotation)
 );
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   namespace: 'drafts',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/drafts.js
+++ b/src/sidebar/store/modules/drafts.js
@@ -2,7 +2,7 @@ import { createSelector } from 'reselect';
 
 import * as metadata from '../../helpers/annotation-metadata';
 import * as util from '../util';
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 /** @typedef {import('../../../types/api').Annotation} Annotation */
 
@@ -187,7 +187,7 @@ const unsavedAnnotations = createSelector(
   drafts => drafts.filter(d => !d.annotation.id).map(d => d.annotation)
 );
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   namespace: 'drafts',
   reducers,

--- a/src/sidebar/store/modules/drafts.js
+++ b/src/sidebar/store/modules/drafts.js
@@ -11,7 +11,7 @@ import { storeModule } from '../create-store';
  * existing annotations.
  */
 
-function init() {
+function initialState() {
   return [];
 }
 
@@ -57,7 +57,7 @@ export class Draft {
 
 /* Reducer */
 
-const update = {
+const reducers = {
   DISCARD_ALL_DRAFTS: function () {
     return [];
   },
@@ -77,7 +77,7 @@ const update = {
   },
 };
 
-const actions = util.actionTypes(update);
+const actions = util.actionTypes(reducers);
 
 /* Actions */
 
@@ -188,10 +188,10 @@ const unsavedAnnotations = createSelector(
 );
 
 export default storeModule({
-  init,
+  initialState,
   namespace: 'drafts',
-  update,
-  actions: {
+  reducers,
+  actionCreators: {
     createDraft,
     deleteNewAndEmptyDrafts,
     discardAllDrafts,

--- a/src/sidebar/store/modules/filters.js
+++ b/src/sidebar/store/modules/filters.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 
 import { actionTypes } from '../util';
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 /**
  * Manage state pertaining to the filtering of annotations in the UI.
@@ -285,7 +285,7 @@ function hasAppliedFilter(state) {
   return !!(state.query || Object.keys(getFilters(state)).length);
 }
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   namespace: 'filters',
   reducers,

--- a/src/sidebar/store/modules/filters.js
+++ b/src/sidebar/store/modules/filters.js
@@ -56,7 +56,7 @@ import { storeModule } from '../create-store';
  * @prop {string} displayName
  */
 
-function init(settings) {
+function initialState(settings) {
   const focusConfig = settings.focus || {};
   return {
     /**
@@ -105,7 +105,7 @@ function focusFiltersFromConfig(focusConfig) {
   };
 }
 
-const update = {
+const reducers = {
   CHANGE_FOCUS_MODE_USER: function (state, action) {
     if (isValidFocusConfig({ user: action.user })) {
       return {
@@ -152,7 +152,7 @@ const update = {
   },
 };
 
-const actions = actionTypes(update);
+const actions = actionTypes(reducers);
 
 // Action creators
 
@@ -286,10 +286,10 @@ function hasAppliedFilter(state) {
 }
 
 export default storeModule({
-  init,
+  initialState,
   namespace: 'filters',
-  update,
-  actions: {
+  reducers,
+  actionCreators: {
     changeFocusModeUser,
     setFilter,
     setFilterQuery,

--- a/src/sidebar/store/modules/filters.js
+++ b/src/sidebar/store/modules/filters.js
@@ -285,8 +285,7 @@ function hasAppliedFilter(state) {
   return !!(state.query || Object.keys(getFilters(state)).length);
 }
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   namespace: 'filters',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -6,7 +6,7 @@ import {
 import shallowEqual from 'shallowequal';
 
 import * as util from '../util';
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 /**
  * @typedef {import('../../../types/annotator').DocumentMetadata} DocumentMetadata
@@ -155,7 +155,7 @@ const searchUris = createShallowEqualSelector(
   uris => uris
 );
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   namespace: 'frames',
   reducers,

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -155,8 +155,7 @@ const searchUris = createShallowEqualSelector(
   uris => uris
 );
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   namespace: 'frames',
   reducers,
 

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -20,12 +20,12 @@ import { storeModule } from '../create-store';
  * @prop {string} uri - Current primary URI of the document being displayed
  */
 
-function init() {
+function initialState() {
   // The list of frames connected to the sidebar app
   return [];
 }
 
-const update = {
+const reducers = {
   CONNECT_FRAME: function (state, action) {
     return [...state, action.frame];
   },
@@ -49,7 +49,7 @@ const update = {
   },
 };
 
-const actions = util.actionTypes(update);
+const actions = util.actionTypes(reducers);
 
 /**
  * Add a frame to the list of frames currently connected to the sidebar app.
@@ -156,11 +156,11 @@ const searchUris = createShallowEqualSelector(
 );
 
 export default storeModule({
-  init: init,
+  initialState,
   namespace: 'frames',
-  update: update,
+  reducers,
 
-  actions: {
+  actionCreators: {
     connectFrame,
     destroyFrame,
     updateFrameAnnotationFetchStatus,

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -9,7 +9,7 @@ import session from './session';
  * @typedef {import('../../../types/api').Group} Group
  */
 
-function init() {
+function initialState() {
   return {
     /**
      * List of groups.
@@ -25,7 +25,7 @@ function init() {
   };
 }
 
-const update = {
+const reducers = {
   FOCUS_GROUP(state, action) {
     const group = state.groups.find(g => g.id === action.id);
     if (!group) {
@@ -67,7 +67,7 @@ const update = {
   },
 };
 
-const actions = util.actionTypes(update);
+const actions = util.actionTypes(reducers);
 
 function clearGroups() {
   return {
@@ -198,10 +198,10 @@ const getCurrentlyViewingGroups = createSelector(
 );
 
 export default storeModule({
-  init,
+  initialState,
   namespace: 'groups',
-  update,
-  actions: {
+  reducers,
+  actionCreators: {
     focusGroup,
     loadGroups,
     clearGroups,

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -197,8 +197,7 @@ const getCurrentlyViewingGroups = createSelector(
   }
 );
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   namespace: 'groups',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 
 import * as util from '../util';
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 import session from './session';
 
@@ -197,7 +197,7 @@ const getCurrentlyViewingGroups = createSelector(
   }
 );
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   namespace: 'groups',
   reducers,

--- a/src/sidebar/store/modules/links.js
+++ b/src/sidebar/store/modules/links.js
@@ -1,6 +1,6 @@
 import { actionTypes } from '../util';
 import { replaceURLParams } from '../../util/url';
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 function initialState() {
   return null;
@@ -53,7 +53,7 @@ function getLink(state, linkName, params = {}) {
   return url;
 }
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   namespace: 'links',
   reducers,

--- a/src/sidebar/store/modules/links.js
+++ b/src/sidebar/store/modules/links.js
@@ -53,8 +53,7 @@ function getLink(state, linkName, params = {}) {
   return url;
 }
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   namespace: 'links',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/links.js
+++ b/src/sidebar/store/modules/links.js
@@ -2,11 +2,11 @@ import { actionTypes } from '../util';
 import { replaceURLParams } from '../../util/url';
 import { storeModule } from '../create-store';
 
-function init() {
+function initialState() {
   return null;
 }
 
-const update = {
+const reducers = {
   UPDATE_LINKS(state, action) {
     return {
       ...action.links,
@@ -14,7 +14,7 @@ const update = {
   },
 };
 
-const actions = actionTypes(update);
+const actions = actionTypes(reducers);
 
 /**
  * Update the link map
@@ -54,10 +54,10 @@ function getLink(state, linkName, params = {}) {
 }
 
 export default storeModule({
-  init,
+  initialState,
   namespace: 'links',
-  update,
-  actions: {
+  reducers,
+  actionCreators: {
     updateLinks,
   },
   selectors: {

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -9,7 +9,7 @@
 
 import { createSelector } from 'reselect';
 
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 import { actionTypes } from '../util';
 
 import annotations from './annotations';
@@ -183,7 +183,7 @@ function hasPendingDeletion(state, id) {
   return state.pendingDeletions.hasOwnProperty(id);
 }
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   namespace: 'realTimeUpdates',
   reducers,

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -183,8 +183,7 @@ function hasPendingDeletion(state, id) {
   return state.pendingDeletions.hasOwnProperty(id);
 }
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   namespace: 'realTimeUpdates',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -16,7 +16,7 @@ import annotations from './annotations';
 import groups from './groups';
 import route from './route';
 
-function init() {
+function initialState() {
   return {
     // Map of ID -> updated annotation for updates that have been received over
     // the WebSocket but not yet applied
@@ -28,7 +28,7 @@ function init() {
   };
 }
 
-const update = {
+const reducers = {
   RECEIVE_REAL_TIME_UPDATES(state, action) {
     return {
       pendingUpdates: { ...action.pendingUpdates },
@@ -76,7 +76,7 @@ const update = {
   },
 };
 
-const actions = actionTypes(update);
+const actions = actionTypes(reducers);
 
 /**
  * Record pending updates representing changes on the server that the client
@@ -184,10 +184,10 @@ function hasPendingDeletion(state, id) {
 }
 
 export default storeModule({
-  init,
+  initialState,
   namespace: 'realTimeUpdates',
-  update,
-  actions: {
+  reducers,
+  actionCreators: {
     receiveRealTimeUpdates,
     clearPendingUpdates,
   },

--- a/src/sidebar/store/modules/route.js
+++ b/src/sidebar/store/modules/route.js
@@ -1,6 +1,6 @@
 import { actionTypes } from '../util';
 
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 function initialState() {
   return {
@@ -58,7 +58,7 @@ function routeParams(state) {
   return state.params;
 }
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   namespace: 'route',
   reducers,

--- a/src/sidebar/store/modules/route.js
+++ b/src/sidebar/store/modules/route.js
@@ -58,8 +58,7 @@ function routeParams(state) {
   return state.params;
 }
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   namespace: 'route',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/route.js
+++ b/src/sidebar/store/modules/route.js
@@ -2,7 +2,7 @@ import { actionTypes } from '../util';
 
 import { storeModule } from '../create-store';
 
-function init() {
+function initialState() {
   return {
     /**
      * The current route.
@@ -21,18 +21,18 @@ function init() {
   };
 }
 
-const update = {
+const reducers = {
   CHANGE_ROUTE(state, { name, params }) {
     return { name, params };
   },
 };
 
-const actions = actionTypes(update);
+const actions = actionTypes(reducers);
 
 /**
  * Change the active route.
  *
- * @param {string} name - Name of the route to activate. See `init` for possible values
+ * @param {string} name - Name of the route to activate. See `initialState` for possible values
  * @param {Object.<string,string>} params - Parameters associated with the route
  */
 function changeRoute(name, params = {}) {
@@ -59,10 +59,10 @@ function routeParams(state) {
 }
 
 export default storeModule({
-  init,
+  initialState,
   namespace: 'route',
-  update,
-  actions: {
+  reducers,
+  actionCreators: {
     changeRoute,
   },
   selectors: {

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -22,7 +22,7 @@ import { createSelector } from 'reselect';
 import * as metadata from '../../helpers/annotation-metadata';
 import { countIf, trueKeys, toTrueMap } from '../../util/collections';
 import * as util from '../util';
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 /**
  * Default sort keys for each tab.
@@ -387,7 +387,7 @@ const sortKeys = createSelector(
   }
 );
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   namespace: 'selection',
   reducers,

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -387,8 +387,7 @@ const sortKeys = createSelector(
   }
 );
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   namespace: 'selection',
   reducers,
 

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -44,7 +44,7 @@ function initialSelection(settings) {
   return selection;
 }
 
-function init(settings) {
+function initialState(settings) {
   return {
     /**
      * The following objects map annotation identifiers to a boolean
@@ -100,7 +100,7 @@ const resetSelection = () => {
   };
 };
 
-const update = {
+const reducers = {
   CLEAR_SELECTION: function () {
     return resetSelection();
   },
@@ -204,7 +204,7 @@ const update = {
   },
 };
 
-const actions = util.actionTypes(update);
+const actions = util.actionTypes(reducers);
 
 /* Action Creators */
 
@@ -388,11 +388,11 @@ const sortKeys = createSelector(
 );
 
 export default storeModule({
-  init: init,
+  initialState,
   namespace: 'selection',
-  update: update,
+  reducers,
 
-  actions: {
+  actionCreators: {
     clearSelection,
     selectAnnotations,
     selectTab,

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -110,8 +110,7 @@ function profile(state) {
   return state.profile;
 }
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   namespace: 'session',
   reducers,
 

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -1,6 +1,6 @@
 import * as util from '../util';
 
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 /**
  * @typedef {import('../../../types/api').Profile} Profile
@@ -110,7 +110,7 @@ function profile(state) {
   return state.profile;
 }
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   namespace: 'session',
   reducers,

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -23,7 +23,7 @@ const initialProfile = {
   userid: null,
 };
 
-function init(settings) {
+function initialState(settings) {
   return {
     /**
      * The app's default authority (user identity provider), from settings,
@@ -41,7 +41,7 @@ function init(settings) {
   };
 }
 
-const update = {
+const reducers = {
   UPDATE_PROFILE: function (state, action) {
     return {
       profile: { ...action.profile },
@@ -49,7 +49,7 @@ const update = {
   },
 };
 
-const actions = util.actionTypes(update);
+const actions = util.actionTypes(reducers);
 
 /**
  * Update the profile information for the current user.
@@ -111,11 +111,11 @@ function profile(state) {
 }
 
 export default storeModule({
-  init,
+  initialState,
   namespace: 'session',
-  update,
+  reducers,
 
-  actions: {
+  actionCreators: {
     updateProfile,
   },
 

--- a/src/sidebar/store/modules/sidebar-panels.js
+++ b/src/sidebar/store/modules/sidebar-panels.js
@@ -16,7 +16,7 @@ import * as util from '../util';
 
 import { storeModule } from '../create-store';
 
-function init() {
+function initialState() {
   return {
     /*
      * The `panelName` of the currently-active sidebar panel.
@@ -32,7 +32,7 @@ function init() {
   };
 }
 
-const update = {
+const reducers = {
   OPEN_SIDEBAR_PANEL: function (state, action) {
     return { activePanelName: action.panelName };
   },
@@ -76,7 +76,7 @@ const update = {
   },
 };
 
-const actions = util.actionTypes(update);
+const actions = util.actionTypes(reducers);
 
 /**
  * Designate `panelName` as the currently-active panel name
@@ -124,10 +124,10 @@ function isSidebarPanelOpen(state, panelName) {
 
 export default storeModule({
   namespace: 'sidebarPanels',
-  init: init,
-  update: update,
+  initialState,
+  reducers,
 
-  actions: {
+  actionCreators: {
     openSidebarPanel,
     closeSidebarPanel,
     toggleSidebarPanel,

--- a/src/sidebar/store/modules/sidebar-panels.js
+++ b/src/sidebar/store/modules/sidebar-panels.js
@@ -14,7 +14,7 @@
 
 import * as util from '../util';
 
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 function initialState() {
   return {
@@ -122,7 +122,7 @@ function isSidebarPanelOpen(state, panelName) {
   return state.activePanelName === panelName;
 }
 
-export default storeModule({
+export default createStoreModule({
   namespace: 'sidebarPanels',
   initialState,
   reducers,

--- a/src/sidebar/store/modules/sidebar-panels.js
+++ b/src/sidebar/store/modules/sidebar-panels.js
@@ -122,9 +122,8 @@ function isSidebarPanelOpen(state, panelName) {
   return state.activePanelName === panelName;
 }
 
-export default createStoreModule({
+export default createStoreModule(initialState, {
   namespace: 'sidebarPanels',
-  initialState,
   reducers,
 
   actionCreators: {

--- a/src/sidebar/store/modules/test/real-time-updates-test.js
+++ b/src/sidebar/store/modules/test/real-time-updates-test.js
@@ -5,8 +5,8 @@ import realTimeUpdates from '../real-time-updates';
 import { $imports } from '../real-time-updates';
 import selection from '../selection';
 
-const { removeAnnotations } = annotations.actions;
-const { focusGroup } = groups.actions;
+const { removeAnnotations } = annotations.actionCreators;
+const { focusGroup } = groups.actionCreators;
 
 describe('sidebar/store/modules/real-time-updates', () => {
   let fakeAnnotationExists;

--- a/src/sidebar/store/modules/test/sidebar-panels-test.js
+++ b/src/sidebar/store/modules/test/sidebar-panels-test.js
@@ -12,7 +12,7 @@ describe('sidebar/store/modules/sidebar-panels', () => {
     store = createStore([sidebarPanels]);
   });
 
-  describe('#init', () => {
+  describe('#initialState', () => {
     it('sets initial `activePanelName` to `null`', () => {
       assert.equal(getSidebarPanelsState().activePanelName, null);
     });

--- a/src/sidebar/store/modules/toast-messages.js
+++ b/src/sidebar/store/modules/toast-messages.js
@@ -1,4 +1,4 @@
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 import * as util from '../util';
 
@@ -112,7 +112,7 @@ function hasMessage(state, type, text) {
   });
 }
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   namespace: 'toastMessages',
   reducers,

--- a/src/sidebar/store/modules/toast-messages.js
+++ b/src/sidebar/store/modules/toast-messages.js
@@ -16,13 +16,13 @@ import * as util from '../util';
  * maintains state only; it's up to other layers to handle the management
  * and interactions with these messages.
  */
-function init() {
+function initialState() {
   return {
     messages: [],
   };
 }
 
-const update = {
+const reducers = {
   ADD_MESSAGE: function (state, action) {
     return {
       messages: state.messages.concat({ ...action.message }),
@@ -47,7 +47,7 @@ const update = {
   },
 };
 
-const actions = util.actionTypes(update);
+const actions = util.actionTypes(reducers);
 
 /** Actions */
 
@@ -113,10 +113,10 @@ function hasMessage(state, type, text) {
 }
 
 export default storeModule({
-  init,
+  initialState,
   namespace: 'toastMessages',
-  update,
-  actions: {
+  reducers,
+  actionCreators: {
     addToastMessage: addMessage,
     removeToastMessage: removeMessage,
     updateToastMessage: updateMessage,

--- a/src/sidebar/store/modules/toast-messages.js
+++ b/src/sidebar/store/modules/toast-messages.js
@@ -112,8 +112,7 @@ function hasMessage(state, type, text) {
   });
 }
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   namespace: 'toastMessages',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/viewer.js
+++ b/src/sidebar/store/modules/viewer.js
@@ -7,7 +7,7 @@ import { storeModule } from '../create-store';
  * sidebar.
  */
 
-function init() {
+function initialState() {
   return {
     // Has the sidebar ever been opened? NB: This is not necessarily the
     // current state of the sidebar, but tracks whether it has ever been open
@@ -16,7 +16,7 @@ function init() {
   };
 }
 
-const update = {
+const reducers = {
   SET_HIGHLIGHTS_VISIBLE: function (state, action) {
     return { visibleHighlights: action.visible };
   },
@@ -30,7 +30,7 @@ const update = {
   },
 };
 
-const actions = util.actionTypes(update);
+const actions = util.actionTypes(reducers);
 
 // Action creators
 
@@ -56,10 +56,10 @@ function hasSidebarOpened(state) {
 }
 
 export default storeModule({
-  init: init,
+  initialState,
   namespace: 'viewer',
-  update: update,
-  actions: {
+  reducers,
+  actionCreators: {
     setShowHighlights,
     setSidebarOpened,
   },

--- a/src/sidebar/store/modules/viewer.js
+++ b/src/sidebar/store/modules/viewer.js
@@ -1,6 +1,6 @@
 import * as util from '../util';
 
-import { storeModule } from '../create-store';
+import { createStoreModule } from '../create-store';
 
 /**
  * This module defines actions and state related to the display mode of the
@@ -55,7 +55,7 @@ function hasSidebarOpened(state) {
   return state.sidebarHasOpened;
 }
 
-export default storeModule({
+export default createStoreModule({
   initialState,
   namespace: 'viewer',
   reducers,

--- a/src/sidebar/store/modules/viewer.js
+++ b/src/sidebar/store/modules/viewer.js
@@ -55,8 +55,7 @@ function hasSidebarOpened(state) {
   return state.sidebarHasOpened;
 }
 
-export default createStoreModule({
-  initialState,
+export default createStoreModule(initialState, {
   namespace: 'viewer',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/test/create-store-test.js
+++ b/src/sidebar/store/test/create-store-test.js
@@ -7,12 +7,12 @@ const A = 0;
 const modules = [
   {
     // namespaced module A
-    init(value = 0) {
+    initialState(value = 0) {
       return { count: value };
     },
     namespace: 'a',
 
-    update: {
+    reducers: {
       INCREMENT_COUNTER_A: (state, action) => {
         return { count: state.count + action.amount };
       },
@@ -21,7 +21,7 @@ const modules = [
       },
     },
 
-    actions: {
+    actionCreators: {
       incrementA(amount) {
         return { type: 'INCREMENT_COUNTER_A', amount };
       },
@@ -41,12 +41,12 @@ const modules = [
   },
   {
     // namespaced module B
-    init(value = 0) {
+    initialState(value = 0) {
       return { count: value };
     },
     namespace: 'b',
 
-    update: {
+    reducers: {
       INCREMENT_COUNTER_B: (state, action) => {
         return { count: state.count + action.amount };
       },
@@ -55,7 +55,7 @@ const modules = [
       },
     },
 
-    actions: {
+    actionCreators: {
       incrementB(amount) {
         return { type: 'INCREMENT_COUNTER_B', amount };
       },
@@ -95,7 +95,7 @@ describe('createStore', () => {
     assert.calledWith(subscriber);
   });
 
-  it('passes initial state args to `init` function', () => {
+  it('passes initial state args to `initialState` function', () => {
     const store = counterStore([21]);
     assert.equal(store.getState().a.count, 21);
   });
@@ -108,20 +108,20 @@ describe('createStore', () => {
 
   it('adds selectors as methods to the store', () => {
     const store = counterStore();
-    store.dispatch(modules[A].actions.incrementA(5));
+    store.dispatch(modules[A].actionCreators.incrementA(5));
     assert.equal(store.getCountA(), 5);
   });
 
   it('adds root selectors as methods to the store', () => {
     const store = counterStore();
-    store.dispatch(modules[A].actions.incrementA(5));
+    store.dispatch(modules[A].actionCreators.incrementA(5));
     assert.equal(store.getCountAFromRoot(), 5);
   });
 
   it('applies `thunk` middleware by default', () => {
     const store = counterStore();
     const doubleAction = (dispatch, getState) => {
-      dispatch(modules[A].actions.incrementA(getState().a.count));
+      dispatch(modules[A].actionCreators.incrementA(getState().a.count));
     };
 
     store.incrementA(5);

--- a/src/sidebar/store/test/create-store-test.js
+++ b/src/sidebar/store/test/create-store-test.js
@@ -173,6 +173,18 @@ describe('createStore', () => {
     assert.equal(store.getState().b.count, 0);
   });
 
+  it('supports modules with static initial state', () => {
+    const initialState = { value: 42 };
+    const module = createStoreModule(initialState, {
+      namespace: 'test',
+      actionCreators: {},
+      reducers: {},
+      selectors: {},
+    });
+    const store = createStore([module]);
+    assert.equal(store.getState().test.value, 42);
+  });
+
   if (process.env.NODE_ENV !== 'production') {
     it('freezes store state in development builds', () => {
       const store = counterStore();

--- a/src/sidebar/store/test/create-store-test.js
+++ b/src/sidebar/store/test/create-store-test.js
@@ -1,15 +1,16 @@
 /* global process */
 
-import { createStore } from '../create-store';
+import { createStore, createStoreModule } from '../create-store';
 
 const A = 0;
 
+function initialState(value = 0) {
+  return { count: value };
+}
+
 const modules = [
-  {
-    // namespaced module A
-    initialState(value = 0) {
-      return { count: value };
-    },
+  // namespaced module A
+  createStoreModule(initialState, {
     namespace: 'a',
 
     reducers: {
@@ -38,12 +39,10 @@ const modules = [
         return state.a.count;
       },
     },
-  },
-  {
-    // namespaced module B
-    initialState(value = 0) {
-      return { count: value };
-    },
+  }),
+
+  // namespaced module B
+  createStoreModule(initialState, {
     namespace: 'b',
 
     reducers: {
@@ -66,7 +65,7 @@ const modules = [
         return state.count;
       },
     },
-  },
+  }),
 ];
 
 function counterStore(initArgs = [], middleware = []) {

--- a/src/sidebar/store/test/use-store-test.js
+++ b/src/sidebar/store/test/use-store-test.js
@@ -1,16 +1,13 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import { createStore } from '../create-store';
+import { createStore, createStoreModule } from '../create-store';
 import { useStoreProxy, $imports } from '../use-store';
 
 // Store module for use with `createStore` in tests.
-const thingsModule = {
+const initialState = () => ({ things: [] });
+const thingsModule = createStoreModule(initialState, {
   namespace: 'things',
-
-  initialState: () => ({
-    things: [],
-  }),
 
   reducers: {
     ADD_THING(state, action) {
@@ -36,7 +33,7 @@ const thingsModule = {
       return state.things.find(t => t.id === id);
     },
   },
-};
+});
 
 describe('sidebar/store/use-store', () => {
   afterEach(() => {

--- a/src/sidebar/store/test/use-store-test.js
+++ b/src/sidebar/store/test/use-store-test.js
@@ -8,11 +8,11 @@ import { useStoreProxy, $imports } from '../use-store';
 const thingsModule = {
   namespace: 'things',
 
-  init: () => ({
+  initialState: () => ({
     things: [],
   }),
 
-  update: {
+  reducers: {
     ADD_THING(state, action) {
       if (state.things.some(t => t.id === action.thing.id)) {
         return {};
@@ -21,7 +21,7 @@ const thingsModule = {
     },
   },
 
-  actions: {
+  actionCreators: {
     addThing(id) {
       return { type: 'ADD_THING', thing: { id } };
     },


### PR DESCRIPTION
This PR includes some refinements to the API for creating store modules, with the following goals:

- Align names better with standard Redux terminology. This will help understandability for new developers who already have some exposure to Redux, as well as make the connection between our store modules and Redux concepts more explicit
- Make it easier to improve type coverage in future  (see notes on `initialState` below). Store modules are currently the area of the client codebase where we have the most gaps in coverage.

This is part of https://github.com/hypothesis/client/issues/3460.

Before this PR, store modules were defined with:

```js
function init() { ... }
const update = { ... };
...
export default storeModule({
  init,
  namespace: 'things',
  actions: { ... },
  update: { ... },
  selectors: { ... },
});
```

After the changes in this PR, the same definition looks like:

```js
// `initialState` can be a function or just a static value.
function initialState() { ... }
const reducers = { ... };
...
export default createStoreModule(initialState, {
  namespace: 'things',
  actionCreators: { ... },
  reducers: { ... },
  selectors: { ... },
});
```

The changes here are:

- `actions` has been renamed to `actionCreators` and `update` has been renamed to `reducers` to match the corresponding Redux concepts
- `init` has been renamed to `initialState` for obviousness and extracted into a separate argument. Moving this into a separate argument has no immediate impact but will help with type inference in future (see commit message for example). Additionally `initialState` can be a value rather than a function. This is useful for the many modules where the initial state has no dependency on the arguments passed to `init`.
- The `storeModule` function has been renamed to `createStoreModule` as it now does more than just return its argument

See individual commit messages for more details.