### PR TITLE
Remove `HTMLMetadata`'s `metadata` field and improve `title` tests

### DIFF
--- a/src/annotator/integrations/test/html-metadata-test.js
+++ b/src/annotator/integrations/test/html-metadata-test.js
@@ -62,8 +62,7 @@ describe('HTMLMetadata', function () {
         <link rel="canonical" href="http://example.com/canonical"></link>
       `;
 
-      testDocument.getDocumentMetadata();
-      metadata = testDocument.metadata;
+      metadata = testDocument.getDocumentMetadata();
     });
 
     it('should have metadata', () => assert.ok(metadata));
@@ -167,12 +166,12 @@ describe('HTMLMetadata', function () {
         <link rel="alternate" href="http://a:b:c">
       `;
 
-      testDocument.getDocumentMetadata();
+      const metadata = testDocument.getDocumentMetadata();
 
       // There should be one link with the document location and one for the
       // valid `<link>` tag.
-      assert.deepEqual(testDocument.metadata.link.length, 2);
-      assert.deepEqual(testDocument.metadata.link[1], {
+      assert.deepEqual(metadata.link.length, 2);
+      assert.deepEqual(metadata.link[1], {
         rel: 'alternate',
         href: 'https://example.com/foo',
         type: '',
@@ -183,19 +182,19 @@ describe('HTMLMetadata', function () {
       tempDocumentHead.innerHTML = `
         <link rel="favicon" href="http://a:b:c">
       `;
-      testDocument.getDocumentMetadata();
-      assert.isUndefined(testDocument.metadata.favicon);
+      const metadata = testDocument.getDocumentMetadata();
+      assert.isUndefined(metadata.favicon);
     });
 
     it('should ignore `<meta>` PDF links with invalid URIs', () => {
       tempDocumentHead.innerHTML = `
         <meta name="citation_pdf_url" content="http://a:b:c">
       `;
-      testDocument.getDocumentMetadata();
+      const metadata = testDocument.getDocumentMetadata();
 
       // There should only be one link for the document's location.
       // The invalid PDF link should be ignored.
-      assert.equal(testDocument.metadata.link.length, 1);
+      assert.equal(metadata.link.length, 1);
     });
   });
 


### PR DESCRIPTION
This PR contains some refactoring of the `HTMLMetadata` class I did while looking into an issue I thought may have been related (https://github.com/hypothesis/h/issues/6702).

The change is to remove the `metadata` field and enforce that callers always call `getDocumentMetadata` instead. The difference is that `getDocumentMetadata` always reads the latest metadata, whereas the `metadata` field may be stale and not reflect the current contents of the page. The actual application was always doing this, but removing this field prevents misuse in future. Internally this field was used to pass data between `getDocumentMetadata` and various helper methods. The use of this field led to non-obvious dependencies between these helper methods. This has been refactored to pass data explicitly with arguments/return values.

During this refactoring I found that the tests for the `title` property returned by `HTMLMetadata#getDocumentMetadata` were incomplete and only covered one of its branches. I have an extended the test to cover all cases.
