### PR TITLE
Refactor annotator/config/ (2/N)

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -61,7 +61,14 @@ function configurationKeys(appContext) {
       return contexts.notebook;
     case 'all':
       // Complete list of configuration keys used for testing.
-      return [...contexts.annotator, ...contexts.sidebar, ...contexts.notebook];
+      return [
+        ...contexts.annotator,
+        ...contexts.sidebar,
+        ...contexts.notebook,
+        // "experimental" currently has no uses in any app contexts, but is included
+        // for test coverage
+        'experimental',
+      ];
     default:
       throw new Error(`Invalid application context used: "${appContext}"`);
   }

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -2,17 +2,74 @@ import settingsFrom from './settings';
 import { toBoolean } from '../../shared/type-coercions';
 
 /**
+ * @typedef {'sidebar'|'notebook'|'annotator'|'all'} AppContext
+ */
+
+/**
+ * List of allowed configuration keys per application context. Keys omitted
+ * in a given context will be removed from the relative configs when calling
+ * getConfig.
+ *
+ * @param {AppContext} [appContext] - The name of the app.
+ */
+function configurationKeys(appContext) {
+  const contexts = {
+    annotator: ['clientUrl', 'showHighlights', 'subFrameIdentifier'],
+    sidebar: [
+      'appType',
+      'annotations',
+      'branding',
+      'enableExperimentalNewNoteButton',
+      'externalContainerSelector',
+      'focus',
+      'group',
+      'onLayoutChange',
+      'openSidebar',
+      'query',
+      'requestConfigFromFrame',
+      'services',
+      'showHighlights',
+      'sidebarAppUrl',
+      'theme',
+      'usernameUrl',
+    ],
+    notebook: [
+      'branding',
+      'group',
+      'notebookAppUrl',
+      'requestConfigFromFrame',
+      'services',
+      'theme',
+      'usernameUrl',
+    ],
+  };
+
+  switch (appContext) {
+    case 'annotator':
+      return contexts.annotator;
+    case 'sidebar':
+      return contexts.sidebar;
+    case 'notebook':
+      return contexts.notebook;
+    case 'all':
+      // Complete list of configuration keys used for testing.
+      return [...contexts.annotator, ...contexts.sidebar, ...contexts.notebook];
+    default:
+      throw new Error(`Invalid application context used: "${appContext}"`);
+  }
+}
+
+/**
  * Reads the Hypothesis configuration from the environment.
  *
+ * @param {string[]} settingsKeys - List of settings that should be returned.
  * @param {Window} window_ - The Window object to read config from.
  */
-export default function configFrom(window_) {
+function configFrom(settingsKeys, window_) {
   const settings = settingsFrom(window_);
-  return {
+  const allConfigSettings = {
     annotations: settings.annotations,
-    // URL where client assets are served from. Used when injecting the client
-    // into child iframes.
-    assetRoot: settings.hostPageSetting('assetRoot', {
+    appType: settings.hostPageSetting('appType', {
       allowInBrowserExt: true,
     }),
     branding: settings.hostPageSetting('branding'),
@@ -50,4 +107,24 @@ export default function configFrom(window_) {
       'externalContainerSelector'
     ),
   };
+
+  // Only return what we asked for
+  const resultConfig = {};
+  settingsKeys.forEach(key => {
+    resultConfig[key] = allConfigSettings[key];
+  });
+  return resultConfig;
+}
+
+/**
+ * Return the configuration for a given application context.
+ *
+ * @param {AppContext} [appContext] - The name of the app.
+ */
+export function getConfig(appContext = 'annotator', window_ = window) {
+  // Filter the config based on the application context as some config values
+  // may be inappropriate or erroneous for some applications.
+  const filteredKeys = configurationKeys(appContext);
+  const config = configFrom(filteredKeys, window_);
+  return config;
 }

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -1,7 +1,7 @@
-import configFrom from '../index';
+import { getConfig } from '../index';
 import { $imports } from '../index';
 
-describe('annotator.config.index', function () {
+describe('annotator/config/index', function () {
   let fakeSettingsFrom;
 
   beforeEach(() => {
@@ -19,7 +19,7 @@ describe('annotator.config.index', function () {
   });
 
   it('gets the configuration settings', function () {
-    configFrom('WINDOW');
+    getConfig('all', 'WINDOW');
 
     assert.calledOnce(fakeSettingsFrom);
     assert.calledWithExactly(fakeSettingsFrom, 'WINDOW');
@@ -27,10 +27,10 @@ describe('annotator.config.index', function () {
 
   ['sidebarAppUrl', 'query', 'annotations', 'group', 'showHighlights'].forEach(
     settingName => {
-      it('returns the ' + settingName + ' setting', () => {
+      it(`returns the ${settingName} setting`, () => {
         fakeSettingsFrom()[settingName] = 'SETTING_VALUE';
 
-        const config = configFrom('WINDOW');
+        const config = getConfig('all', 'WINDOW');
 
         assert.equal(config[settingName], 'SETTING_VALUE');
       });
@@ -46,77 +46,101 @@ describe('annotator.config.index', function () {
 
     it('throws an error', function () {
       assert.throws(function () {
-        configFrom('WINDOW');
+        getConfig('all', 'WINDOW');
       }, "there's no link");
     });
   });
 
-  ['assetRoot', 'subFrameIdentifier'].forEach(function (settingName) {
-    it(
-      'reads ' +
-        settingName +
-        ' from the host page, even when in a browser extension',
-      function () {
-        configFrom('WINDOW');
-        assert.calledWithExactly(
-          fakeSettingsFrom().hostPageSetting,
-          settingName,
-          { allowInBrowserExt: true }
-        );
-      }
-    );
-  });
-
-  it('reads openSidebar from the host page, even when in a browser extension', function () {
-    configFrom('WINDOW');
-    sinon.assert.calledWith(
-      fakeSettingsFrom().hostPageSetting,
-      'openSidebar',
-      sinon.match({
-        allowInBrowserExt: true,
-        coerce: sinon.match.func,
-      })
-    );
+  ['appType', 'openSidebar', 'subFrameIdentifier'].forEach(function (
+    settingName
+  ) {
+    it(`reads ${settingName} from the host page, even when in a browser extension`, function () {
+      getConfig('all', 'WINDOW');
+      assert.calledWith(
+        fakeSettingsFrom().hostPageSetting,
+        settingName,
+        sinon.match({ allowInBrowserExt: true })
+      );
+    });
   });
 
   ['branding', 'services'].forEach(function (settingName) {
-    it(
-      'reads ' +
-        settingName +
-        ' from the host page only when in an embedded client',
-      function () {
-        configFrom('WINDOW');
+    it(`reads ${settingName} from the host page only when in an embedded client`, function () {
+      getConfig('all', 'WINDOW');
 
-        assert.calledWithExactly(
-          fakeSettingsFrom().hostPageSetting,
-          settingName
-        );
-      }
-    );
+      assert.calledWithExactly(fakeSettingsFrom().hostPageSetting, settingName);
+    });
   });
 
-  [
-    'assetRoot',
-    'branding',
-    'openSidebar',
-    'requestConfigFromFrame',
-    'services',
-  ].forEach(function (settingName) {
-    it('returns the ' + settingName + ' value from the host page', function () {
-      const settings = {
-        assetRoot: 'chrome-extension://1234/client/',
-        branding: 'BRANDING_SETTING',
-        openSidebar: 'OPEN_SIDEBAR_SETTING',
-        requestConfigFromFrame: 'https://embedder.com',
-        services: 'SERVICES_SETTING',
-      };
-      fakeSettingsFrom().hostPageSetting = function (settingName) {
-        return settings[settingName];
-      };
+  ['branding', 'openSidebar', 'requestConfigFromFrame', 'services'].forEach(
+    function (settingName) {
+      it(`returns the ${settingName} value from the host page`, function () {
+        const settings = {
+          branding: 'BRANDING_SETTING',
+          openSidebar: 'OPEN_SIDEBAR_SETTING',
+          requestConfigFromFrame: 'https://embedder.com',
+          services: 'SERVICES_SETTING',
+        };
+        fakeSettingsFrom().hostPageSetting = function (settingName) {
+          return settings[settingName];
+        };
 
-      const settingValue = configFrom('WINDOW')[settingName];
+        const settingValue = getConfig('all', 'WINDOW')[settingName];
 
-      assert.equal(settingValue, settings[settingName]);
+        assert.equal(settingValue, settings[settingName]);
+      });
+    }
+  );
+  describe('application contexts', () => {
+    [
+      {
+        app: 'annotator',
+        expectedKeys: ['clientUrl', 'showHighlights', 'subFrameIdentifier'],
+      },
+      {
+        app: 'sidebar',
+        expectedKeys: [
+          'appType',
+          'annotations',
+          'branding',
+          'enableExperimentalNewNoteButton',
+          'externalContainerSelector',
+          'focus',
+          'group',
+          'onLayoutChange',
+          'openSidebar',
+          'query',
+          'requestConfigFromFrame',
+          'services',
+          'showHighlights',
+          'sidebarAppUrl',
+          'theme',
+          'usernameUrl',
+        ],
+      },
+      {
+        app: 'notebook',
+        expectedKeys: [
+          'branding',
+          'group',
+          'notebookAppUrl',
+          'requestConfigFromFrame',
+          'services',
+          'theme',
+          'usernameUrl',
+        ],
+      },
+    ].forEach(test => {
+      it(`ignore values not belonging to "${test.app}" context`, () => {
+        const config = getConfig(test.app, 'WINDOW');
+        assert.deepEqual(Object.keys(config), test.expectedKeys);
+      });
     });
+  });
+
+  it(`throws an error if an invalid context was passed`, () => {
+    assert.throws(() => {
+      getConfig('fake', 'WINDOW');
+    }, 'Invalid application context used: "fake"');
   });
 });


### PR DESCRIPTION
Change configFrom() to configDefinitions()

The main difference is that configFrom returned config key:value pairs, but now configDefinitions returns key:object pairs. Where the object may hold additional flags and methods for each specific config value. Currently the only method included is valueFn() which gets the value from its source. Others will follow.

-------


The end goal here is to have the definitions look more or less like this

```...
    openSidebar: {
      allowInBrowserExt: true,
      defaultValue: false,
      coerce: toBoolean,
      valueFn: settings.hostPageSetting,
    },
    ...

```

Where getConfig does some of the logic to get a value from valueFn, set a optional default, coerce the value (optional), and/or restrict based on allowInBrowserExt. Much of this logic is currently inside settings and that will be pulled out so settings can be focused on just retrieving the value.

_This PR has no external changes_
