### PR TITLE
Refactor annotator/config/ (2/N)

### DIFF
--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -3,6 +3,22 @@ import { parseJsonConfig } from '../../boot/parse-json-config';
 import configFuncSettingsFrom from './config-func-settings-from';
 import isBrowserExtension from './is-browser-extension';
 
+/**
+ * @typedef SettingsGetters
+ * @prop {string|null} annotations
+ * @prop {string|null} query
+ * @prop {string|null} group
+ * @prop {string} showHighlights
+ * @prop {string} clientUrl
+ * @prop {string} sidebarAppUrl
+ * @prop {string} notebookAppUrl
+ 
+ * @prop {(name: string, options?: Object) => (string|null)} hostPageSetting
+ */
+
+/**
+ * @return {SettingsGetters}
+ */
 export default function settingsFrom(window_) {
   const jsonConfigs = parseJsonConfig(window_.document);
   const configFuncSettings = configFuncSettingsFrom(window_);


### PR DESCRIPTION
Change configFrom() to configDefinitions() 

The main difference is that configFrom returned config key:value pairs, but now configDefinitions returns key:object pairs. Where the object may hold additional flags and methods for each specific config value. Currently the only method included is valueFn() which gets the value from its source. Others will follow.

Additionally:
- Remove `experimental` from configDefinitions/configFrom as it is not used

-------


The end goal here is to have the definitions look more or less like this

```...
    openSidebar: {
      allowInBrowserExt: true,
      defaultValue: false,
      coerce: toBoolean,
      getValue: settings => settings.hostPageSetting,
    },
    ...

```

Where getConfig will do the logic to get a value from getValue, set a optional default, coerce the value if needed, and/or restrict based on allowInBrowserExt. Much of this logic is currently inside settings.js and that will be pulled out so settings can be reduced to only retrieving the value from source.

_This PR has no external changes_
