### PR TITLE
Always use current `document.baseURI` in `HTMLMetadata`

### DIFF
--- a/src/annotator/integrations/html-metadata.js
+++ b/src/annotator/integrations/html-metadata.js
@@ -49,13 +49,9 @@ export class HTMLMetadata {
   /**
    * @param {object} [options]
    *   @param {Document} [options.document]
-   *   @param {string} [options.baseURI]
-   *   @param {normalizeURI} [options.normalizeURI]
    */
   constructor(options = {}) {
     this.document = options.document || document;
-    this.baseURI = options.baseURI || this.document.baseURI;
-    this.normalizeURI = options.normalizeURI || normalizeURI;
   }
 
   /**
@@ -279,7 +275,7 @@ export class HTMLMetadata {
    * exception if the URL cannot be parsed.
    */
   _absoluteUrl(url) {
-    return this.normalizeURI(url, this.baseURI);
+    return normalizeURI(url, this.document.baseURI);
   }
 
   // Get the true URI record when it's masked via a different protocol.
@@ -297,10 +293,10 @@ export class HTMLMetadata {
 
     // Otherwise, try using the location specified by the <base> element.
     if (
-      this.baseURI &&
-      allowedSchemes.includes(new URL(this.baseURI).protocol)
+      this.document.baseURI &&
+      allowedSchemes.includes(new URL(this.document.baseURI).protocol)
     ) {
-      return this.baseURI;
+      return this.document.baseURI;
     }
 
     // Fall back to returning the document URI, even though the scheme is not

--- a/src/annotator/integrations/test/html-metadata-test.js
+++ b/src/annotator/integrations/test/html-metadata-test.js
@@ -10,11 +10,9 @@
  ** https://github.com/openannotation/annotator/blob/master/LICENSE
  */
 
-import { normalizeURI } from '../../util/url';
 import { HTMLMetadata } from '../html-metadata';
 
 describe('HTMLMetadata', () => {
-  let fakeNormalizeURI;
   let tempDocument;
   let tempDocumentHead;
   let testDocument = null;
@@ -25,13 +23,8 @@ describe('HTMLMetadata', () => {
     tempDocumentHead = document.createElement('head');
     tempDocument.appendChild(tempDocumentHead);
 
-    fakeNormalizeURI = sinon.stub().callsFake((url, base) => {
-      return normalizeURI(url, base);
-    });
-
     testDocument = new HTMLMetadata({
       document: tempDocument,
-      normalizeURI: fakeNormalizeURI,
     });
   });
 
@@ -296,6 +289,7 @@ describe('HTMLMetadata', () => {
       // document.
       const fakeDocument = {
         createElement: htmlDoc.createElement.bind(htmlDoc), // eslint-disable-line no-restricted-properties
+        baseURI: baseURI ?? href,
         querySelectorAll: htmlDoc.querySelectorAll.bind(htmlDoc), // eslint-disable-line no-restricted-properties
         location: {
           href,
@@ -303,7 +297,6 @@ describe('HTMLMetadata', () => {
       };
       const doc = new HTMLMetadata({
         document: fakeDocument,
-        baseURI,
       });
       return doc;
     };


### PR DESCRIPTION
`HTMLMetadata` read `document.baseURI` only once in the constructor,
risking issues due to the cached value becoming stale. `document.baseURI` is
available in all supported browsers and is easily mocked where needed in
tests, so just always read the current value when needed.

Also remove a `normalizeURI` test seam that was unused. If we did want
to mock this in future we'd use the `$imports` object as we do in other
tests.