### PR TITLE
Refactor annotator/config/ (3/N) 

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -9,7 +9,10 @@ import { toBoolean } from '../../shared/type-coercions';
  * @typedef ConfigDefinition
  * @prop {(settings: SettingsGetters) => any} getValue -
  *   Method to retrieve the value from the incoming source
- *
+ * @prop {(value: any) => any} [coerce] - Transform a value's type, value or both
+ */
+
+/**
  * @typedef {Record<string, ConfigDefinition>} ConfigDefinitionMap
  */
 
@@ -109,10 +112,10 @@ const configDefinitions = {
     getValue: settings => settings.hostPageSetting('onLayoutChange'),
   },
   openSidebar: {
+    coerce: toBoolean,
     getValue: settings =>
       settings.hostPageSetting('openSidebar', {
         allowInBrowserExt: true,
-        coerce: toBoolean,
       }),
   },
   query: {
@@ -159,8 +162,9 @@ export function getConfig(appContext = 'annotator', window_ = window) {
   let filteredKeys = configurationKeys(appContext);
   filteredKeys.forEach(name => {
     const configDef = configDefinitions[name];
-    // Get the value from the configuration source
-    config[name] = configDef.getValue(settings);
+    const value = configDef.getValue(settings);
+    // Get the value from the configuration source and run through an optional coerce method
+    config[name] = configDef.coerce ? configDef.coerce(value) : value;
   });
 
   return config;

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -77,7 +77,7 @@ describe('annotator/config/index', function () {
       it(`returns the ${settingName} value from the host page`, function () {
         const settings = {
           branding: 'BRANDING_SETTING',
-          openSidebar: 'OPEN_SIDEBAR_SETTING',
+          openSidebar: true,
           requestConfigFromFrame: 'https://embedder.com',
           services: 'SERVICES_SETTING',
         };
@@ -91,6 +91,18 @@ describe('annotator/config/index', function () {
       });
     }
   );
+
+  describe('coerces values', () => {
+    it('coerces `openSidebar` from a string to a boolean', () => {
+      fakeSettingsFrom().hostPageSetting = sinon
+        .stub()
+        .withArgs('openSidebar')
+        .returns('false');
+      const config = getConfig('all', 'WINDOW');
+      assert.equal(config.openSidebar, false);
+    });
+  });
+
   describe('application contexts', () => {
     [
       {


### PR DESCRIPTION
### Move coerce() into configDefinitions

Previously, coerce was passed to the hostPageSetting. Moving the logic up into getConfig allows any setting to have a coerce method, not just settings pulled from hostPageSetting. Eventually, other settings may need coerce logic such as showHighlights.

------

relates to 
https://github.com/hypothesis/client/issues/3236