### PR TITLE
Refactor annotator/config/ (4/N)

### DIFF
--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -3,6 +3,7 @@ import { toBoolean } from '../../shared/type-coercions';
 
 import configFuncSettingsFrom from './config-func-settings-from';
 import isBrowserExtension from './is-browser-extension';
+import { urlFromLinkTag } from './url-from-link-tag';
 
 /**
  * @typedef SettingsGetters
@@ -31,75 +32,6 @@ export default function settingsFrom(window_) {
     jsonConfigs = {};
   } else {
     jsonConfigs = parseJsonConfig(window_.document);
-  }
-
-  /**
-   * Return the href of the first annotator link in the given
-   * document with this `rel` attribute.
-   *
-   * Return the value of the href attribute of the first
-   * `<link type="application/annotator+html" rel="${rel}">`
-   * element in the given document. This URL is used as the `src` for sidebar
-   * or notebook iframes.
-   *
-   * @param {string} rel - The `rel` attribute to match
-   * @return {string} - The URL to use for the iframe
-   * @throws {Error} - If there's no link with the `rel` indicated, or the first
-   *   matching link has no `href`
-   */
-  function urlFromLinkTag(rel) {
-    const link = window_.document.querySelector(
-      `link[type="application/annotator+html"][rel="${rel}"]`
-    );
-
-    if (!link) {
-      throw new Error(
-        `No application/annotator+html (rel="${rel}") link in the document`
-      );
-    }
-
-    if (!link.href) {
-      throw new Error(
-        `application/annotator+html (rel="${rel}") link has no href`
-      );
-    }
-
-    return link.href;
-  }
-
-  /**
-   * Return the href URL of the first annotator client link in the given document.
-   *
-   * Return the value of the href attribute of the first
-   * `<link type="application/annotator+javascript" rel="hypothesis-client">`
-   * element in the given document.
-   *
-   * This URL is used to identify where the client is from and what url should
-   * be used inside of subframes.
-   *
-   * @return {string} - The URL that the client is hosted from
-   * @throws {Error} - If there's no annotator link or the first annotator has
-   *   no href.
-   *
-   */
-  function clientUrl() {
-    const link = window_.document.querySelector(
-      'link[type="application/annotator+javascript"][rel="hypothesis-client"]'
-    );
-
-    if (!link) {
-      throw new Error(
-        'No application/annotator+javascript (rel="hypothesis-client") link in the document'
-      );
-    }
-
-    if (!link.href) {
-      throw new Error(
-        'application/annotator+javascript (rel="hypothesis-client") link has no href'
-      );
-    }
-
-    return link.href;
   }
 
   /**
@@ -199,20 +131,20 @@ export default function settingsFrom(window_) {
   function hostPageSetting(name, options = {}) {
     const allowInBrowserExt = options.allowInBrowserExt || false;
     const hasDefaultValue = typeof options.defaultValue !== 'undefined';
-    // Optional coerce method, or a no-op.
-    const coerceValue =
-      typeof options.coerce === 'function' ? options.coerce : name => name;
 
-    if (!allowInBrowserExt && isBrowserExtension(urlFromLinkTag('sidebar'))) {
+    if (
+      !allowInBrowserExt &&
+      isBrowserExtension(urlFromLinkTag(window_, 'sidebar', 'html'))
+    ) {
       return hasDefaultValue ? options.defaultValue : null;
     }
 
     if (configFuncSettings.hasOwnProperty(name)) {
-      return coerceValue(configFuncSettings[name]);
+      return configFuncSettings[name];
     }
 
     if (jsonConfigs.hasOwnProperty(name)) {
-      return coerceValue(jsonConfigs[name]);
+      return jsonConfigs[name];
     }
 
     if (hasDefaultValue) {
@@ -227,19 +159,19 @@ export default function settingsFrom(window_) {
       return annotations();
     },
     get clientUrl() {
-      return clientUrl();
+      return urlFromLinkTag(window_, 'hypothesis-client', 'javascript');
     },
     get group() {
       return group();
     },
     get notebookAppUrl() {
-      return urlFromLinkTag('notebook');
+      return urlFromLinkTag(window_, 'notebook', 'html');
     },
     get showHighlights() {
       return showHighlights();
     },
     get sidebarAppUrl() {
-      return urlFromLinkTag('sidebar');
+      return urlFromLinkTag(window_, 'sidebar', 'html');
     },
     get query() {
       return query();

--- a/src/annotator/config/test/url-from-link-tag-test.js
+++ b/src/annotator/config/test/url-from-link-tag-test.js
@@ -1,0 +1,67 @@
+import { urlFromLinkTag } from '../url-from-link-tag';
+
+describe('url-from-link-tag', () => {
+  function appendLink(href, rel, type) {
+    const link = document.createElement('link');
+    link.type = 'application/annotator+' + type;
+    link.rel = rel;
+    if (href) {
+      link.href = href;
+    }
+    document.head.appendChild(link);
+    return link;
+  }
+
+  it('returns the url from the matching link tag of type "html"', () => {
+    const link = appendLink('http://example.com/app.html', 'sidebar', 'html');
+    assert.equal(
+      urlFromLinkTag(window, 'sidebar', 'html'),
+      'http://example.com/app.html'
+    );
+    link.remove();
+  });
+
+  it('returns the url from the matching link tag of type javascript', () => {
+    const link = appendLink(
+      'http://example.com/app.html',
+      'hypothesis-client',
+      'javascript'
+    );
+    assert.equal(
+      urlFromLinkTag(window, 'hypothesis-client', 'javascript'),
+      'http://example.com/app.html'
+    );
+    link.remove();
+  });
+
+  context('when there are multiple matching links', () => {
+    it('returns the href from the first matching link', () => {
+      const link1 = appendLink('http://example.com/app1', 'notebook', 'html');
+      const link2 = appendLink('http://example.com/app2', 'notebook', 'html');
+      assert.equal(
+        urlFromLinkTag(window, 'notebook', 'html'),
+        'http://example.com/app1'
+      );
+      link1.remove();
+      link2.remove();
+    });
+  });
+
+  context('missing or invalid link tag', () => {
+    ['html', 'javascript'].forEach(type => {
+      it('throws an error if link tag is missing', () => {
+        assert.throws(() => {
+          urlFromLinkTag(window, 'fakeApp', type);
+        }, `No application/annotator+${type} (rel="fakeApp") link in the document`);
+      });
+
+      it('throws an error if href is missing in link tag', () => {
+        const link = appendLink(null, 'fakeApp', type);
+        assert.throws(() => {
+          urlFromLinkTag(window, 'fakeApp', type);
+        }, `application/annotator+${type} (rel="fakeApp") link has no href`);
+        link.remove();
+      });
+    });
+  });
+});

--- a/src/annotator/config/url-from-link-tag.js
+++ b/src/annotator/config/url-from-link-tag.js
@@ -1,0 +1,35 @@
+/**
+ * Return the URL of a resource related to the Hypothesis client that has been stored in
+ * the page via a `<link type="application/annotator+{type}">` tag.
+ *
+ * These link tags are generally written to the page by the boot script, which may be executed
+ * in a separate JavaScript realm (eg. in the browser extension), and thus can share information
+ * with the annotator code via the DOM but not JS globals.
+ *
+ * @param {Window} window_
+ * @param {string} rel - The `rel` attribute to match
+ * @param {'javascript'|'html'} type - Type of resource that the link refers to
+ * @throws {Error} - If there's no link with the `rel` indicated, or the first
+ *   matching link has no `href`
+ */
+export function urlFromLinkTag(window_, rel, type) {
+  const link = /** @type {HTMLLinkElement} */ (
+    window_.document.querySelector(
+      `link[type="application/annotator+${type}"][rel="${rel}"]`
+    )
+  );
+
+  if (!link) {
+    throw new Error(
+      `No application/annotator+${type} (rel="${rel}") link in the document`
+    );
+  }
+
+  if (!link.href) {
+    throw new Error(
+      `application/annotator+${type} (rel="${rel}") link has no href`
+    );
+  }
+
+  return link.href;
+}


### PR DESCRIPTION
### Move urlFromLinkTag to its own module

- Add a new parameter to urlFromLinkTag called "type" to allow urlFromLinkTag to get the client url as well as sidebar and notebook urls. This eliminates the need to have a custom clientUrl method in settings.js

- urlFromLinkTag() will also soon be needed outside of settings.js as part of a future refactor to move logic into getConfig() which determines if the browser extension context is true.

- Remove the deprecated "coerce" option from hostPageSetting as this is now moved to configDefinitions

---------

relates to 
https://github.com/hypothesis/client/issues/3236
