### PR TITLE
Refactor annotator/config/ (5/N)

### DIFF
--- a/src/annotator/config/is-browser-extension.js
+++ b/src/annotator/config/is-browser-extension.js
@@ -1,11 +1,12 @@
 /**
  * Return true if the client is from a browser extension.
  *
- * @returns {boolean} true if this instance of the Hypothesis client is one
+ * @param {string} url
+ * @returns {boolean} - Returns true if this instance of the Hypothesis client is one
  *   distributed in a browser extension, false if it's one embedded in a
  *   website.
  *
  */
-export default function isBrowserExtension(app) {
-  return !(app.startsWith('http://') || app.startsWith('https://'));
+export function isURLFromBrowserExtension(url) {
+  return !(url.startsWith('http://') || url.startsWith('https://'));
 }

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -2,7 +2,7 @@ import { parseJsonConfig } from '../../boot/parse-json-config';
 import { toBoolean } from '../../shared/type-coercions';
 
 import configFuncSettingsFrom from './config-func-settings-from';
-import isBrowserExtension from './is-browser-extension';
+import { isURLFromBrowserExtension } from './is-browser-extension';
 import { urlFromLinkTag } from './url-from-link-tag';
 
 /**
@@ -81,6 +81,7 @@ export default function settingsFrom(window_) {
     return jsonConfigs.group || groupFromURL();
   }
 
+  // TODO: Move this to a coerce method
   function showHighlights() {
     let showHighlights_ = hostPageSetting('showHighlights');
 
@@ -132,9 +133,10 @@ export default function settingsFrom(window_) {
     const allowInBrowserExt = options.allowInBrowserExt || false;
     const hasDefaultValue = typeof options.defaultValue !== 'undefined';
 
+    // TODO: Remove this logic
     if (
       !allowInBrowserExt &&
-      isBrowserExtension(urlFromLinkTag(window_, 'sidebar', 'html'))
+      isURLFromBrowserExtension(urlFromLinkTag(window_, 'sidebar', 'html'))
     ) {
       return hasDefaultValue ? options.defaultValue : null;
     }

--- a/src/annotator/config/test/is-browser-extension-test.js
+++ b/src/annotator/config/test/is-browser-extension-test.js
@@ -1,6 +1,6 @@
-import isBrowserExtension from '../is-browser-extension';
+import { isURLFromBrowserExtension } from '../is-browser-extension';
 
-describe('annotator.config.isBrowserExtension', function () {
+describe('isURLFromBrowserExtension', function () {
   [
     {
       url: 'chrome-extension://abcxyz',
@@ -29,7 +29,7 @@ describe('annotator.config.isBrowserExtension', function () {
     },
   ].forEach(function (test) {
     it('returns ' + test.returns + ' for ' + test.url, function () {
-      assert.equal(isBrowserExtension(test.url), test.returns);
+      assert.equal(isURLFromBrowserExtension(test.url), test.returns);
     });
   });
 });

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -15,7 +15,9 @@ describe('annotator/config/settingsFrom', () => {
 
     $imports.$mock({
       './config-func-settings-from': fakeConfigFuncSettingsFrom,
-      './is-browser-extension': fakeIsBrowserExtension,
+      './is-browser-extension': {
+        isURLFromBrowserExtension: fakeIsBrowserExtension,
+      },
       './url-from-link-tag': {
         urlFromLinkTag: fakeUrlFromLinkTag,
       },
@@ -376,7 +378,7 @@ describe('annotator/config/settingsFrom', () => {
       {
         when: 'the client is embedded in a web page',
         specify: 'it returns setting values from window.hypothesisConfig()',
-        isBrowserExtension: false,
+        isURLFromBrowserExtension: false,
         configFuncSettings: { foo: 'configFuncValue' },
         jsonSettings: { foo: 'ignored' }, // hypothesisConfig() overrides js-hypothesis-config
         expected: 'configFuncValue',
@@ -385,7 +387,7 @@ describe('annotator/config/settingsFrom', () => {
         when: 'the client is embedded in a web page',
         specify:
           'it ignores settings from js-hypothesis-config if `ignoreOtherConfiguration` is present',
-        isBrowserExtension: false,
+        isURLFromBrowserExtension: false,
         configFuncSettings: { ignoreOtherConfiguration: '1' },
         jsonSettings: { foo: 'ignored' },
         expected: null,
@@ -393,7 +395,7 @@ describe('annotator/config/settingsFrom', () => {
       {
         when: 'the client is embedded in a web page',
         specify: 'it returns setting values from js-hypothesis-config objects',
-        isBrowserExtension: false,
+        isURLFromBrowserExtension: false,
         configFuncSettings: {},
         jsonSettings: { foo: 'jsonValue' },
         expected: 'jsonValue',
@@ -402,7 +404,7 @@ describe('annotator/config/settingsFrom', () => {
         when: 'the client is embedded in a web page',
         specify:
           'hypothesisConfig() settings override js-hypothesis-config ones',
-        isBrowserExtension: false,
+        isURLFromBrowserExtension: false,
         configFuncSettings: { foo: 'configFuncValue' },
         jsonSettings: { foo: 'jsonValue' },
         expected: 'configFuncValue',
@@ -411,7 +413,7 @@ describe('annotator/config/settingsFrom', () => {
         when: 'the client is embedded in a web page',
         specify:
           'even a null from hypothesisConfig() overrides js-hypothesis-config',
-        isBrowserExtension: false,
+        isURLFromBrowserExtension: false,
         configFuncSettings: { foo: null },
         jsonSettings: { foo: 'jsonValue' },
         expected: null,
@@ -420,7 +422,7 @@ describe('annotator/config/settingsFrom', () => {
         when: 'the client is embedded in a web page',
         specify:
           'even an undefined from hypothesisConfig() overrides js-hypothesis-config',
-        isBrowserExtension: false,
+        isURLFromBrowserExtension: false,
         configFuncSettings: { foo: undefined },
         jsonSettings: { foo: 'jsonValue' },
         expected: undefined,
@@ -428,7 +430,7 @@ describe('annotator/config/settingsFrom', () => {
       {
         when: 'the client is in a browser extension',
         specify: 'it always returns null',
-        isBrowserExtension: true,
+        isURLFromBrowserExtension: true,
         configFuncSettings: { foo: 'configFuncValue' },
         jsonSettings: { foo: 'jsonValue' },
         expected: null,
@@ -436,7 +438,7 @@ describe('annotator/config/settingsFrom', () => {
       {
         when: 'the client is in a browser extension and allowInBrowserExt: true is given',
         specify: 'it returns settings from window.hypothesisConfig()',
-        isBrowserExtension: true,
+        isURLFromBrowserExtension: true,
         allowInBrowserExt: true,
         configFuncSettings: { foo: 'configFuncValue' },
         jsonSettings: {},
@@ -445,7 +447,7 @@ describe('annotator/config/settingsFrom', () => {
       {
         when: 'the client is in a browser extension and allowInBrowserExt: true is given',
         specify: 'it returns settings from js-hypothesis-configs',
-        isBrowserExtension: true,
+        isURLFromBrowserExtension: true,
         allowInBrowserExt: true,
         configFuncSettings: {},
         jsonSettings: { foo: 'jsonValue' },
@@ -454,7 +456,7 @@ describe('annotator/config/settingsFrom', () => {
       {
         when: 'no default value is provided',
         specify: 'it returns null',
-        isBrowserExtension: false,
+        isURLFromBrowserExtension: false,
         allowInBrowserExt: false,
         configFuncSettings: {},
         jsonSettings: {},
@@ -464,7 +466,7 @@ describe('annotator/config/settingsFrom', () => {
       {
         when: 'a default value is provided',
         specify: 'it returns that default value',
-        isBrowserExtension: false,
+        isURLFromBrowserExtension: false,
         allowInBrowserExt: false,
         configFuncSettings: {},
         jsonSettings: {},
@@ -474,7 +476,7 @@ describe('annotator/config/settingsFrom', () => {
       {
         when: 'a default value is provided but it is overridden',
         specify: 'it returns the overridden value',
-        isBrowserExtension: false,
+        isURLFromBrowserExtension: false,
         allowInBrowserExt: false,
         configFuncSettings: { foo: 'not the default value' },
         jsonSettings: {},
@@ -484,7 +486,7 @@ describe('annotator/config/settingsFrom', () => {
       {
         when: 'the client is in a browser extension and a default value is provided',
         specify: 'it returns the default value',
-        isBrowserExtension: true,
+        isURLFromBrowserExtension: true,
         allowInBrowserExt: false,
         configFuncSettings: { foo: 'ignore me' },
         jsonSettings: { foo: 'also ignore me' },
@@ -494,7 +496,7 @@ describe('annotator/config/settingsFrom', () => {
     ].forEach(function (test) {
       context(test.when, () => {
         specify(test.specify, () => {
-          fakeIsBrowserExtension.returns(test.isBrowserExtension);
+          fakeIsBrowserExtension.returns(test.isURLFromBrowserExtension);
           fakeConfigFuncSettingsFrom.returns(test.configFuncSettings);
           fakeParseJsonConfig.returns(test.jsonSettings);
           const settings = settingsFrom(fakeWindow());


### PR DESCRIPTION

### Add allowInBrowserExt and defaultValue to configDefinitions 

- Logic for `allowInBrowserExt` and `defaultValue` are moved up into getConfig() from various places inside settings. There are no external changes here, but there are a few subtle changes to how a config values work.

  1. Previously if in a browser ext context and  `allowInBrowserEx` was false (default), then the value was was changed to null. This bit of logic was not entirely explicit, but now the logic is that the value will be set to the `defaultValue` if provided or otherwise the value will be omitted entirely. Currently, all values have a `defaultValue` and most of the defaults are null. This ensures things work the same, but also helps bring clarity to what values will be transformed under this condition. Later we can revisit these config values and determine if any don't need a default or simply leave them as is.

  2. The `defaultValue` was previously only used for several fields, but now its set for every field for clarity. It should also be noted that the `defaultValue` will now take precedent over the `coerce` method if settings returns an undefined value for that config key. This is in contrast to how it worked before, but was problematic under some possible circumstances. For example, if a settings value was not found or undefined, and a `defaultValue` was true and the coerce was `toBoolean`, then the value would become false rather than true and that is confusing because the default would not work due to the `coerce` taking precedent. This is now fixed.

- Remove default export from is-browser-extension

--------

relates to 
https://github.com/hypothesis/client/issues/3236