### PR TITLE
Refactor annotator/config/ (6/N) 

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -5,21 +5,18 @@ import { urlFromLinkTag } from './url-from-link-tag';
 
 /**
  * @typedef {'sidebar'|'notebook'|'annotator'|'all'} AppContext
- *
  * @typedef {import('./settings').SettingsGetters} SettingsGetters
+ * @typedef {(settings: SettingsGetters, name: string) => any} ValueGetter
  *
  * @typedef ConfigDefinition
- * @prop {(settings: SettingsGetters) => any} getValue -
- *  Method to retrieve the value from the incoming source
+ * @prop {ValueGetter} getValue - Method to retrieve the value from the incoming source
  * @prop {boolean} allowInBrowserExt -
  *  Allow this setting to be read in the browser extension. If this is false
  *  and browser extension context is true, use `defaultValue` if provided otherwise
  *  ignore the config key
  * @prop {any} [defaultValue] - Sets a default if `getValue` returns undefined
  * @prop {(value: any) => any} [coerce] - Transform a value's type, value or both
- */
-
-/**
+ *
  * @typedef {Record<string, ConfigDefinition>} ConfigDefinitionMap
  */
 
@@ -77,6 +74,11 @@ function configurationKeys(appContext) {
   }
 }
 
+/** @type {ValueGetter} */
+function getHostPageSetting(settings, name) {
+  return settings.hostPageSetting(name);
+}
+
 /**
  * Definitions of configuration keys
  * @type {ConfigDefinitionMap}
@@ -90,12 +92,12 @@ const configDefinitions = {
   appType: {
     allowInBrowserExt: true,
     defaultValue: null,
-    getValue: settings => settings.hostPageSetting('appType'),
+    getValue: getHostPageSetting,
   },
   branding: {
     defaultValue: null,
     allowInBrowserExt: false,
-    getValue: settings => settings.hostPageSetting('branding'),
+    getValue: getHostPageSetting,
   },
   // URL of the client's boot script. Used when injecting the client into
   // child iframes.
@@ -107,8 +109,7 @@ const configDefinitions = {
   enableExperimentalNewNoteButton: {
     allowInBrowserExt: false,
     defaultValue: null,
-    getValue: settings =>
-      settings.hostPageSetting('enableExperimentalNewNoteButton'),
+    getValue: getHostPageSetting,
   },
   group: {
     allowInBrowserExt: true,
@@ -118,28 +119,28 @@ const configDefinitions = {
   focus: {
     allowInBrowserExt: false,
     defaultValue: null,
-    getValue: settings => settings.hostPageSetting('focus'),
+    getValue: getHostPageSetting,
   },
   theme: {
     allowInBrowserExt: false,
     defaultValue: null,
-    getValue: settings => settings.hostPageSetting('theme'),
+    getValue: getHostPageSetting,
   },
   usernameUrl: {
     allowInBrowserExt: false,
     defaultValue: null,
-    getValue: settings => settings.hostPageSetting('usernameUrl'),
+    getValue: getHostPageSetting,
   },
   onLayoutChange: {
     allowInBrowserExt: false,
     defaultValue: null,
-    getValue: settings => settings.hostPageSetting('onLayoutChange'),
+    getValue: getHostPageSetting,
   },
   openSidebar: {
     allowInBrowserExt: true,
     defaultValue: false,
     coerce: toBoolean,
-    getValue: settings => settings.hostPageSetting('openSidebar'),
+    getValue: getHostPageSetting,
   },
   query: {
     allowInBrowserExt: true,
@@ -149,12 +150,12 @@ const configDefinitions = {
   requestConfigFromFrame: {
     allowInBrowserExt: false,
     defaultValue: null,
-    getValue: settings => settings.hostPageSetting('requestConfigFromFrame'),
+    getValue: getHostPageSetting,
   },
   services: {
     allowInBrowserExt: false,
     defaultValue: null,
-    getValue: settings => settings.hostPageSetting('services'),
+    getValue: getHostPageSetting,
   },
   showHighlights: {
     allowInBrowserExt: false,
@@ -176,12 +177,12 @@ const configDefinitions = {
   subFrameIdentifier: {
     allowInBrowserExt: true,
     defaultValue: null,
-    getValue: settings => settings.hostPageSetting('subFrameIdentifier'),
+    getValue: getHostPageSetting,
   },
   externalContainerSelector: {
     allowInBrowserExt: false,
     defaultValue: null,
-    getValue: settings => settings.hostPageSetting('externalContainerSelector'),
+    getValue: getHostPageSetting,
   },
 };
 
@@ -214,7 +215,7 @@ export function getConfig(appContext = 'annotator', window_ = window) {
     }
 
     // Get the value from the configuration source
-    const value = configDef.getValue(settings);
+    const value = configDef.getValue(settings, name);
     if (value === undefined) {
       // If there is no value (e.g. undefined), then set to the default if provided,
       // otherwise ignore the config key:value pair

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -1,5 +1,7 @@
+import { isBrowserExtension } from './is-browser-extension';
 import settingsFrom from './settings';
 import { toBoolean } from '../../shared/type-coercions';
+import { urlFromLinkTag } from './url-from-link-tag';
 
 /**
  * @typedef {'sidebar'|'notebook'|'annotator'|'all'} AppContext
@@ -8,7 +10,12 @@ import { toBoolean } from '../../shared/type-coercions';
  *
  * @typedef ConfigDefinition
  * @prop {(settings: SettingsGetters) => any} getValue -
- *   Method to retrieve the value from the incoming source
+ *  Method to retrieve the value from the incoming source
+ * @prop {boolean} allowInBrowserExt -
+ *  Allow this setting to be read in the browser extension. If this is false
+ *  and browser extension context is true, use `defaultValue` if provided otherwise
+ *  ignore the config key
+ * @prop {any} [defaultValue] - Sets a default if `getValue` returns undefined
  * @prop {(value: any) => any} [coerce] - Transform a value's type, value or both
  */
 
@@ -76,75 +83,104 @@ function configurationKeys(appContext) {
  */
 const configDefinitions = {
   annotations: {
+    allowInBrowserExt: true,
+    defaultValue: null,
     getValue: settings => settings.annotations,
   },
   appType: {
-    getValue: settings =>
-      settings.hostPageSetting('appType', {
-        allowInBrowserExt: true,
-      }),
+    allowInBrowserExt: true,
+    defaultValue: null,
+    getValue: settings => settings.hostPageSetting('appType'),
   },
   branding: {
+    defaultValue: null,
+    allowInBrowserExt: false,
     getValue: settings => settings.hostPageSetting('branding'),
   },
   // URL of the client's boot script. Used when injecting the client into
   // child iframes.
   clientUrl: {
+    allowInBrowserExt: true,
+    defaultValue: null,
     getValue: settings => settings.clientUrl,
   },
   enableExperimentalNewNoteButton: {
+    allowInBrowserExt: false,
+    defaultValue: null,
     getValue: settings =>
       settings.hostPageSetting('enableExperimentalNewNoteButton'),
   },
   group: {
+    allowInBrowserExt: true,
+    defaultValue: null,
     getValue: settings => settings.group,
   },
   focus: {
+    allowInBrowserExt: false,
+    defaultValue: null,
     getValue: settings => settings.hostPageSetting('focus'),
   },
   theme: {
+    allowInBrowserExt: false,
+    defaultValue: null,
     getValue: settings => settings.hostPageSetting('theme'),
   },
   usernameUrl: {
+    allowInBrowserExt: false,
+    defaultValue: null,
     getValue: settings => settings.hostPageSetting('usernameUrl'),
   },
   onLayoutChange: {
+    allowInBrowserExt: false,
+    defaultValue: null,
     getValue: settings => settings.hostPageSetting('onLayoutChange'),
   },
   openSidebar: {
+    allowInBrowserExt: true,
+    defaultValue: false,
     coerce: toBoolean,
-    getValue: settings =>
-      settings.hostPageSetting('openSidebar', {
-        allowInBrowserExt: true,
-      }),
+    getValue: settings => settings.hostPageSetting('openSidebar'),
   },
   query: {
+    allowInBrowserExt: true,
+    defaultValue: null,
     getValue: settings => settings.query,
   },
   requestConfigFromFrame: {
+    allowInBrowserExt: false,
+    defaultValue: null,
     getValue: settings => settings.hostPageSetting('requestConfigFromFrame'),
   },
   services: {
+    allowInBrowserExt: false,
+    defaultValue: null,
     getValue: settings => settings.hostPageSetting('services'),
   },
   showHighlights: {
+    allowInBrowserExt: false,
+    defaultValue: null,
     getValue: settings => settings.showHighlights,
   },
   notebookAppUrl: {
+    allowInBrowserExt: true,
+    defaultValue: null,
     getValue: settings => settings.notebookAppUrl,
   },
   sidebarAppUrl: {
+    allowInBrowserExt: true,
+    defaultValue: null,
     getValue: settings => settings.sidebarAppUrl,
   },
   // Sub-frame identifier given when a frame is being embedded into
   // by a top level client
   subFrameIdentifier: {
-    getValue: settings =>
-      settings.hostPageSetting('subFrameIdentifier', {
-        allowInBrowserExt: true,
-      }),
+    allowInBrowserExt: true,
+    defaultValue: null,
+    getValue: settings => settings.hostPageSetting('subFrameIdentifier'),
   },
   externalContainerSelector: {
+    allowInBrowserExt: false,
+    defaultValue: null,
     getValue: settings => settings.hostPageSetting('externalContainerSelector'),
   },
 };
@@ -162,8 +198,33 @@ export function getConfig(appContext = 'annotator', window_ = window) {
   let filteredKeys = configurationKeys(appContext);
   filteredKeys.forEach(name => {
     const configDef = configDefinitions[name];
+    const hasDefault = configDef.defaultValue !== undefined; // A default could be null
+    const isURLFromBrowserExtension = isBrowserExtension(
+      urlFromLinkTag(window_, 'sidebar', 'html')
+    );
+
+    // Only allow certain values in the browser extension context
+    if (!configDef.allowInBrowserExt && isURLFromBrowserExtension) {
+      // If the value is not allowed here, then set to the default if provided, otherwise ignore
+      // the key:value pair
+      if (hasDefault) {
+        config[name] = configDef.defaultValue;
+      }
+      return;
+    }
+
+    // Get the value from the configuration source
     const value = configDef.getValue(settings);
-    // Get the value from the configuration source and run through an optional coerce method
+    if (value === undefined) {
+      // If there is no value (e.g. undefined), then set to the default if provided,
+      // otherwise ignore the config key:value pair
+      if (hasDefault) {
+        config[name] = configDef.defaultValue;
+      }
+      return;
+    }
+
+    // Finally, run the value through an optional coerce method
     config[name] = configDef.coerce ? configDef.coerce(value) : value;
   });
 

--- a/src/annotator/config/is-browser-extension.js
+++ b/src/annotator/config/is-browser-extension.js
@@ -1,11 +1,12 @@
 /**
  * Return true if the client is from a browser extension.
  *
- * @returns {boolean} true if this instance of the Hypothesis client is one
+ * @param {string} url
+ * @returns {boolean} - Returns true if this instance of the Hypothesis client is one
  *   distributed in a browser extension, false if it's one embedded in a
  *   website.
  *
  */
-export default function isBrowserExtension(app) {
-  return !(app.startsWith('http://') || app.startsWith('https://'));
+export function isBrowserExtension(url) {
+  return !(url.startsWith('http://') || url.startsWith('https://'));
 }

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -2,7 +2,7 @@ import { parseJsonConfig } from '../../boot/parse-json-config';
 import { toBoolean } from '../../shared/type-coercions';
 
 import configFuncSettingsFrom from './config-func-settings-from';
-import isBrowserExtension from './is-browser-extension';
+import { isBrowserExtension } from './is-browser-extension';
 import { urlFromLinkTag } from './url-from-link-tag';
 
 /**
@@ -81,6 +81,7 @@ export default function settingsFrom(window_) {
     return jsonConfigs.group || groupFromURL();
   }
 
+  // TODO: Move this to a coerce method
   function showHighlights() {
     let showHighlights_ = hostPageSetting('showHighlights');
 
@@ -132,6 +133,7 @@ export default function settingsFrom(window_) {
     const allowInBrowserExt = options.allowInBrowserExt || false;
     const hasDefaultValue = typeof options.defaultValue !== 'undefined';
 
+    // TODO: Remove this logic
     if (
       !allowInBrowserExt &&
       isBrowserExtension(urlFromLinkTag(window_, 'sidebar', 'html'))

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -3,14 +3,30 @@ import { $imports } from '../index';
 
 describe('annotator/config/index', function () {
   let fakeSettingsFrom;
+  let fakeIsBrowserExtension;
 
   beforeEach(() => {
     fakeSettingsFrom = sinon.stub().returns({
-      hostPageSetting: sinon.stub(),
+      hostPageSetting: sinon.stub().returns('fakeValue'),
+      // getters
+      annotations: 'fakeValue',
+      clientUrl: 'fakeValue',
+      group: 'fakeValue',
+      notebookAppUrl: 'fakeValue',
+      showHighlights: 'fakeValue',
+      sidebarAppUrl: 'fakeValue',
+      query: 'fakeValue',
     });
+    fakeIsBrowserExtension = sinon.stub();
 
     $imports.$mock({
       './settings': fakeSettingsFrom,
+      './is-browser-extension': {
+        isBrowserExtension: fakeIsBrowserExtension,
+      },
+      './url-from-link-tag': {
+        urlFromLinkTag: sinon.stub(),
+      },
     });
   });
 
@@ -51,24 +67,117 @@ describe('annotator/config/index', function () {
     });
   });
 
-  ['appType', 'openSidebar', 'subFrameIdentifier'].forEach(function (
-    settingName
-  ) {
-    it(`reads ${settingName} from the host page, even when in a browser extension`, function () {
-      getConfig('all', 'WINDOW');
-      assert.calledWith(
-        fakeSettingsFrom().hostPageSetting,
-        settingName,
-        sinon.match({ allowInBrowserExt: true })
-      );
+  describe('browser extension', () => {
+    context('when client is loaded from the browser extension', function () {
+      it('returns only config values where `allowInBrowserExt` is true or the defaultValue if provided', () => {
+        fakeIsBrowserExtension.returns(true);
+        const config = getConfig('all', 'WINDOW');
+        assert.deepEqual(
+          {
+            appType: 'fakeValue',
+            annotations: 'fakeValue',
+            branding: null,
+            clientUrl: 'fakeValue',
+            enableExperimentalNewNoteButton: null,
+            externalContainerSelector: null,
+            focus: null,
+            group: 'fakeValue',
+            notebookAppUrl: 'fakeValue',
+            onLayoutChange: null,
+            openSidebar: true, // coerced
+            query: 'fakeValue',
+            requestConfigFromFrame: null,
+            services: null,
+            showHighlights: null,
+            sidebarAppUrl: 'fakeValue',
+            subFrameIdentifier: 'fakeValue',
+            theme: null,
+            usernameUrl: null,
+          },
+          config
+        );
+      });
+    });
+
+    context('when client is not loaded from browser extension', function () {
+      it('returns all config values', () => {
+        fakeIsBrowserExtension.returns(false);
+        const config = getConfig('all', 'WINDOW');
+        assert.deepEqual(
+          {
+            appType: 'fakeValue',
+            annotations: 'fakeValue',
+            branding: 'fakeValue',
+            clientUrl: 'fakeValue',
+            enableExperimentalNewNoteButton: 'fakeValue',
+            externalContainerSelector: 'fakeValue',
+            focus: 'fakeValue',
+            group: 'fakeValue',
+            notebookAppUrl: 'fakeValue',
+            onLayoutChange: 'fakeValue',
+            openSidebar: true, // coerced
+            query: 'fakeValue',
+            requestConfigFromFrame: 'fakeValue',
+            services: 'fakeValue',
+            showHighlights: 'fakeValue',
+            sidebarAppUrl: 'fakeValue',
+            subFrameIdentifier: 'fakeValue',
+            theme: 'fakeValue',
+            usernameUrl: 'fakeValue',
+          },
+          config
+        );
+      });
     });
   });
 
-  ['branding', 'services'].forEach(function (settingName) {
-    it(`reads ${settingName} from the host page only when in an embedded client`, function () {
-      getConfig('all', 'WINDOW');
+  describe('default values', () => {
+    beforeEach(() => {
+      // Remove all fake values
+      $imports.$mock({
+        './settings': sinon.stub().returns({
+          hostPageSetting: sinon.stub().returns(undefined),
+          annotations: undefined,
+          clientUrl: undefined,
+          group: undefined,
+          notebookAppUrl: undefined,
+          showHighlights: undefined,
+          sidebarAppUrl: undefined,
+          query: undefined,
+        }),
+      });
+    });
 
-      assert.calledWithExactly(fakeSettingsFrom().hostPageSetting, settingName);
+    afterEach(() => {
+      $imports.$restore({
+        './settings': true,
+      });
+    });
+
+    it('sets corresponding default values if settings are undefined', () => {
+      const config = getConfig('all', 'WINDOW');
+
+      assert.deepEqual(config, {
+        appType: null,
+        annotations: null,
+        branding: null,
+        clientUrl: null,
+        enableExperimentalNewNoteButton: null,
+        externalContainerSelector: null,
+        focus: null,
+        group: null,
+        notebookAppUrl: null,
+        onLayoutChange: null,
+        openSidebar: false,
+        query: null,
+        requestConfigFromFrame: null,
+        services: null,
+        showHighlights: null,
+        sidebarAppUrl: null,
+        subFrameIdentifier: null,
+        theme: null,
+        usernameUrl: null,
+      });
     });
   });
 

--- a/src/annotator/config/test/is-browser-extension-test.js
+++ b/src/annotator/config/test/is-browser-extension-test.js
@@ -1,4 +1,4 @@
-import isBrowserExtension from '../is-browser-extension';
+import { isBrowserExtension } from '../is-browser-extension';
 
 describe('annotator.config.isBrowserExtension', function () {
   [

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -15,7 +15,9 @@ describe('annotator/config/settingsFrom', () => {
 
     $imports.$mock({
       './config-func-settings-from': fakeConfigFuncSettingsFrom,
-      './is-browser-extension': fakeIsBrowserExtension,
+      './is-browser-extension': {
+        isBrowserExtension: fakeIsBrowserExtension,
+      },
       './url-from-link-tag': {
         urlFromLinkTag: fakeUrlFromLinkTag,
       },


### PR DESCRIPTION
### Pass config name directly to getValue()

This change fixes the usage of redundant names being expressed in the configDefinitions map.

--------------

relates to 
https://github.com/hypothesis/client/issues/3236
