### PR TITLE
Add support for `ignoreOtherConfiguration` setting option

### DIFF
--- a/dev-server/documents/html/ignore-other-configuration.mustache
+++ b/dev-server/documents/html/ignore-other-configuration.mustache
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ignore configuration test</title>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+    </style>
+
+    <!-- This configuration is ignored -->
+    <script type="application/json" class="js-hypothesis-config">
+      {
+        "theme": "clean",
+        "openSidebar": true
+      }
+    </script>
+
+    <!-- This configuration wins -->
+    <script>
+      Object.defineProperty(window, 'hypothesisConfig', {
+        value: function () {
+          return {
+            openSidebar: false,
+            ignoreOtherConfiguration: true,
+          };
+        },
+      });
+    </script>
+  </head>
+  <body>
+    <h1>Ignore configuration test</h1>
+    <p>
+      <em>viahtml</em> sets the <code>ignoreOtherConfiguration</code> option in
+      the result of <code>window.hypothesisConfig()</code>. This option
+      disregards other sources of Hypothesis configuration that the host page
+      could include.
+    </p>
+    <p>
+      In addition, <em>viahtml</em> makes
+      <code>window.hypothesisConfig</code> non-configurable and non-writable.
+      These two settings together makes the client consistently behave on
+      <em>via</em> (PDF or html).
+    </p>
+    <p>
+      If this test works, it should make the sidebar remain closed and use the
+      classic theme. The options
+      <code>openSidebar : true</code> and <code>theme: "clean"</code>
+      should be ignored.
+    </p>
+    {{{hypothesisScript}}}
+  </body>
+</html>

--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -24,6 +24,7 @@
     <li><a href="/document/parent-frame">Annotatable iframe test</a></li>
     <li><a href="/document/sidebar-external-container">Sidebar in external container test</a></li>
     <li><a href="/document/multi-frames">Multi-frame test</a></li>
+    <li><a href="/document/ignore-other-configuration"><code>ignoreOtherConfiguration</code> test</a></li>
   </ul>
 
   <h2>Test PDF documents</h2>

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -1,4 +1,5 @@
 import { parseJsonConfig } from '../../boot/parse-json-config';
+import { toBoolean } from '../../shared/type-coercions';
 
 import configFuncSettingsFrom from './config-func-settings-from';
 import isBrowserExtension from './is-browser-extension';
@@ -20,8 +21,17 @@ import isBrowserExtension from './is-browser-extension';
  * @return {SettingsGetters}
  */
 export default function settingsFrom(window_) {
-  const jsonConfigs = parseJsonConfig(window_.document);
+  // Prioritize the `window.hypothesisConfig` function over the JSON format
+  // Via uses `window.hypothesisConfig` and makes it non-configurable and non-writable.
+  // In addition, Via sets the `ignoreOtherConfiguration` option to prevent configuration merging.
   const configFuncSettings = configFuncSettingsFrom(window_);
+
+  let jsonConfigs;
+  if (toBoolean(configFuncSettings.ignoreOtherConfiguration)) {
+    jsonConfigs = {};
+  } else {
+    jsonConfigs = parseJsonConfig(window_.document);
+  }
 
   /**
    * Return the href of the first annotator link in the given

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -580,8 +580,17 @@ describe('annotator/config/settingsFrom', () => {
         specify: 'it returns setting values from window.hypothesisConfig()',
         isBrowserExtension: false,
         configFuncSettings: { foo: 'configFuncValue' },
-        jsonSettings: {},
+        jsonSettings: { foo: 'ignored' }, // hypothesisConfig() overrides js-hypothesis-config
         expected: 'configFuncValue',
+      },
+      {
+        when: 'the client is embedded in a web page',
+        specify:
+          'it ignores settings from js-hypothesis-config if `ignoreOtherConfiguration` is present',
+        isBrowserExtension: false,
+        configFuncSettings: { ignoreOtherConfiguration: '1' },
+        jsonSettings: { foo: 'ignored' },
+        expected: null,
       },
       {
         when: 'the client is embedded in a web page',


### PR DESCRIPTION
As part of https://github.com/hypothesis/viahtml/pull/192 we decided to introduce a new `ignoreOtherConfiguration` option in the hypothesis settings.

On the first commit, I added support on non-JSON configuration (`window.hypothesisConfig()`)

On the second commit, I added a test case to  check the effect on this new option.


