### PR TITLE
Modernize WebSocket wrapper

### DIFF
--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -2,7 +2,7 @@ import * as queryString from 'query-string';
 
 import warnOnce from '../../shared/warn-once';
 import { generateHexString } from '../util/random';
-import Socket from '../websocket';
+import { Socket } from '../websocket';
 import { watch } from '../util/watch';
 
 /**

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -129,7 +129,7 @@ describe('StreamerService', () => {
 
     $imports.$mock({
       '../../shared/warn-once': fakeWarnOnce,
-      '../websocket': FakeSocket,
+      '../websocket': { Socket: FakeSocket },
     });
   });
 

--- a/src/sidebar/test/websocket-test.js
+++ b/src/sidebar/test/websocket-test.js
@@ -1,4 +1,5 @@
-import Socket, {
+import {
+  Socket,
   CLOSE_NORMAL,
   CLOSE_GOING_AWAY,
   CLOSE_ABNORMAL,

--- a/src/sidebar/websocket.js
+++ b/src/sidebar/websocket.js
@@ -16,7 +16,7 @@ export const CLOSE_ABNORMAL = 1006;
 // considered abnormal closures.
 
 // Minimum delay, in ms, before reconnecting after an abnormal connection close.
-const RECONNECT_MIN_DELAY = 1000;
+export const RECONNECT_MIN_DELAY = 1000;
 
 /**
  * Socket is a minimal wrapper around WebSocket which provides:
@@ -74,7 +74,7 @@ export class Socket extends TinyEmitter {
       if (operation) {
         if (!operation.retry(error)) {
           console.error(
-            'reached max retries attempting to reconnect websocket'
+            'Reached max retries attempting to reconnect WebSocket'
           );
         }
         return;

--- a/src/sidebar/websocket.js
+++ b/src/sidebar/websocket.js
@@ -27,79 +27,49 @@ const RECONNECT_MIN_DELAY = 1000;
  * - Uses the standard EventEmitter API for reporting open, close, error
  *   and message events.
  */
-export default class Socket extends TinyEmitter {
+export class Socket extends TinyEmitter {
+  /**
+   * Connect to the WebSocket endpoint at `url`.
+   *
+   * @param {string} url
+   */
   constructor(url) {
     super();
 
-    const self = this;
-
-    // queue of JSON objects which have not yet been submitted
+    /**
+     * Queue of JSON objects which have not yet been submitted
+     *
+     * @type {object[]}
+     */
     const messageQueue = [];
 
-    // the current WebSocket instance
+    /**
+     * The active `WebSocket` instance
+     *
+     * @type {WebSocket}
+     */
     let socket;
 
     // a pending operation to connect a WebSocket
     let operation;
 
-    function sendMessages() {
+    const sendMessages = () => {
       while (messageQueue.length > 0) {
         const messageString = JSON.stringify(messageQueue.shift());
         socket.send(messageString);
       }
-    }
+    };
 
-    // Connect the websocket immediately. If a connection attempt is already in
-    // progress, do nothing.
-    function connect() {
-      if (operation) {
-        return;
-      }
-
-      operation = retry.operation({
-        minTimeout: RECONNECT_MIN_DELAY * 2,
-        // Don't retry forever -- fail permanently after 10 retries
-        retries: 10,
-        // Randomize retry times to minimize the thundering herd effect
-        randomize: true,
-      });
-
-      operation.attempt(function () {
-        socket = new WebSocket(url);
-        socket.onopen = function (event) {
-          onOpen();
-          self.emit('open', event);
-        };
-        socket.onclose = function (event) {
-          if (event.code === CLOSE_NORMAL || event.code === CLOSE_GOING_AWAY) {
-            self.emit('close', event);
-            return;
-          }
-          const err = new Error(
-            `WebSocket closed abnormally, code: ${event.code}`
-          );
-          console.warn(err);
-          onAbnormalClose(err);
-        };
-        socket.onerror = function (event) {
-          self.emit('error', event);
-        };
-        socket.onmessage = function (event) {
-          self.emit('message', event);
-        };
-      });
-    }
-
-    // onOpen is called when a websocket connection is successfully established.
-    function onOpen() {
-      operation = null;
-      sendMessages();
-    }
-
-    // onAbnormalClose is called when a websocket connection closes abnormally.
-    // This may be the result of a failure to connect, or an abnormal close after
-    // a previous successful connection.
-    function onAbnormalClose(error) {
+    /**
+     * Handler for when the WebSocket disconnects "abnormally".
+     *
+     * This may be the result of a failure to connect, or an abnormal close after
+     * a previous successful connection.
+     *
+     * @param {Error} error
+     * @param {() => void} reconnect
+     */
+    const onAbnormalClose = (error, reconnect) => {
       // If we're already in a reconnection loop, trigger a retry...
       if (operation) {
         if (!operation.retry(error)) {
@@ -112,14 +82,59 @@ export default class Socket extends TinyEmitter {
       // ...otherwise reconnect the websocket after a short delay.
       let delay = RECONNECT_MIN_DELAY;
       delay += Math.floor(Math.random() * delay);
-      operation = setTimeout(function () {
+      operation = setTimeout(() => {
         operation = null;
-        connect();
+        reconnect();
       }, delay);
-    }
+    };
+
+    /**
+     * Connect the WebSocket.
+     *
+     * If a connection attempt is already in progress, do nothing.
+     */
+    const connect = () => {
+      if (operation) {
+        return;
+      }
+
+      operation = retry.operation({
+        minTimeout: RECONNECT_MIN_DELAY * 2,
+        // Don't retry forever -- fail permanently after 10 retries
+        retries: 10,
+        // Randomize retry times to minimize the thundering herd effect
+        randomize: true,
+      });
+
+      operation.attempt(() => {
+        socket = new WebSocket(url);
+        socket.onopen = event => {
+          operation = null;
+          sendMessages();
+          this.emit('open', event);
+        };
+        socket.onclose = event => {
+          if (event.code === CLOSE_NORMAL || event.code === CLOSE_GOING_AWAY) {
+            this.emit('close', event);
+            return;
+          }
+          const err = new Error(
+            `WebSocket closed abnormally, code: ${event.code}`
+          );
+          console.warn(err);
+          onAbnormalClose(err, connect);
+        };
+        socket.onerror = event => {
+          this.emit('error', event);
+        };
+        socket.onmessage = event => {
+          this.emit('message', event);
+        };
+      });
+    };
 
     /** Close the underlying WebSocket connection */
-    this.close = function () {
+    this.close = () => {
       // nb. Always sent a status code in the `close()` call to work around
       // a problem in the backend's ws4py library.
       //
@@ -139,8 +154,10 @@ export default class Socket extends TinyEmitter {
     /**
      * Send a JSON object via the WebSocket connection, or queue it
      * for later delivery if not currently connected.
+     *
+     * @param {object} message
      */
-    this.send = function (message) {
+    this.send = message => {
       messageQueue.push(message);
       if (this.isConnected()) {
         sendMessages();
@@ -148,7 +165,7 @@ export default class Socket extends TinyEmitter {
     };
 
     /** Returns true if the WebSocket is currently connected. */
-    this.isConnected = function () {
+    this.isConnected = () => {
       return socket.readyState === WebSocket.OPEN;
     };
 

--- a/src/sidebar/websocket.js
+++ b/src/sidebar/websocket.js
@@ -94,22 +94,13 @@ export class Socket extends TinyEmitter {
       // ...otherwise reconnect the websocket after a short delay.
       let delay = RECONNECT_MIN_DELAY;
       delay += Math.floor(Math.random() * delay);
-      setTimeout(() => {
-        operation = null;
-        reconnect();
-      }, delay);
+      setTimeout(reconnect, delay);
     };
 
     /**
      * Connect the WebSocket.
-     *
-     * If a connection attempt is already in progress, do nothing.
      */
     const connect = () => {
-      if (operation) {
-        return;
-      }
-
       operation = /** @type {RetryOperation} */ (
         retry.operation({
           minTimeout: RECONNECT_MIN_DELAY * 2,


### PR DESCRIPTION
Modernize our auto-reconnecting wrapper for `WebSocket` to match current
conventions in the client and improve the documentation.

 - Use named rather than default exports
 - Convert functions to arrow functions and remove unneeded `self` alias.
 - Add JSDoc comments and types
 
_Added since first review:_

- Add three additional tests
- Improve documentation for internal `operation` variable used for automatic reconnections
- Remove a code path that could not be triggered related to calling `connect` while already connected

A circular reference between the `connect` and `onAbnormalClose` functions was broken by adding a second argument to `onAbnormalClose`.
