### PR TITLE
Fix exception in textMatchScore() when `text` is empty

### DIFF
--- a/src/annotator/anchoring/match-quote.js
+++ b/src/annotator/anchoring/match-quote.js
@@ -54,7 +54,7 @@ function search(text, str, maxErrors) {
  */
 function textMatchScore(text, str) {
   /* istanbul ignore next - `scoreMatch` will never pass an empty string */
-  if (str.length === 0) {
+  if (str.length === 0 || text.length === 0) {
     return 0.0;
   }
   const matches = search(text, str, str.length);
@@ -116,7 +116,7 @@ export function matchQuote(text, quote, context = {}) {
 
     const prefixScore = context.prefix
       ? textMatchScore(
-          text.slice(match.start - context.prefix.length, match.start),
+          text.slice(Math.max(0, match.start - context.prefix.length), match.start),
           context.prefix
         )
       : 1.0;

--- a/src/annotator/anchoring/match-quote.js
+++ b/src/annotator/anchoring/match-quote.js
@@ -53,10 +53,13 @@ function search(text, str, maxErrors) {
  * @param {string} str
  */
 function textMatchScore(text, str) {
-  /* istanbul ignore next - `scoreMatch` will never pass an empty string */
+  // `search` will return no matches if either the text or pattern is empty,
+  // otherwise it will return at least one match if the max allowed error count
+  // is at least `str.length`.
   if (str.length === 0 || text.length === 0) {
     return 0.0;
   }
+
   const matches = search(text, str, str.length);
 
   // prettier-ignore

--- a/src/annotator/anchoring/match-quote.js
+++ b/src/annotator/anchoring/match-quote.js
@@ -116,7 +116,10 @@ export function matchQuote(text, quote, context = {}) {
 
     const prefixScore = context.prefix
       ? textMatchScore(
-          text.slice(Math.max(0, match.start - context.prefix.length), match.start),
+          text.slice(
+            Math.max(0, match.start - context.prefix.length),
+            match.start
+          ),
           context.prefix
         )
       : 1.0;

--- a/src/annotator/anchoring/test/match-quote-test.js
+++ b/src/annotator/anchoring/test/match-quote-test.js
@@ -195,4 +195,14 @@ describe('matchQuote', () => {
     assert.ok(matchNoHint);
     assert.equal(matchNoHint.start, posA, 'Wrong match with no hint');
   });
+
+  it('matches with a context prefix longer than the text', () => {
+    const match = matchQuote(fixtures.solitude, 'years later', {
+      prefix: 'It used to be many',
+    });
+    assert.equal(
+      fixtures.solitude.slice(match.start, match.end),
+      'years later'
+    );
+  });
 });

--- a/src/annotator/anchoring/test/match-quote-test.js
+++ b/src/annotator/anchoring/test/match-quote-test.js
@@ -196,13 +196,22 @@ describe('matchQuote', () => {
     assert.equal(matchNoHint.start, posA, 'Wrong match with no hint');
   });
 
-  it('matches with a context prefix longer than the text', () => {
-    const match = matchQuote(fixtures.solitude, 'years later', {
-      prefix: 'It used to be many',
-    });
+  it('matches when prefix length is greater than the match start offset', () => {
+    const context = { prefix: 'It used to be many' };
+    const match = matchQuote(fixtures.solitude, 'years later', context);
+
+    assert.isAbove(context.prefix.length, match.start);
     assert.equal(
       fixtures.solitude.slice(match.start, match.end),
       'years later'
     );
+  });
+
+  it('matches when match ends at end of text and there is a non-empty suffix', () => {
+    const text = 'Some document text';
+    const match = matchQuote(text, 'text', {
+      suffix: 'missing',
+    });
+    assert.equal(text.slice(match.start, match.end), 'text');
   });
 });


### PR DESCRIPTION
I observed an exception thrown from `textMatchScore()` if `text` is empty, because `matches[0].errors` is undefined in this case:

https://github.com/hypothesis/client/blob/da3a346611aaa5777d7d352a2c57e8dc5664f5d6/src/annotator/anchoring/match-quote.js#L63

An empty `text` occurs when the length of the `context.prefix` is larger than the prefix of the first match in the page. It gives a negative first parameter for this `slice()`:

https://github.com/hypothesis/client/blob/da3a346611aaa5777d7d352a2c57e8dc5664f5d6/src/annotator/anchoring/match-quote.js#L119