### PR TITLE
Bump `frontend-shared`; use `Actions` in one component

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@babel/core": "^7.1.6",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
-    "@hypothesis/frontend-shared": "3.2.0",
+    "@hypothesis/frontend-shared": "3.3.0",
     "@octokit/rest": "^18.0.0",
     "@sentry/browser": "^6.0.2",
     "approx-string-match": "^1.1.0",

--- a/src/sidebar/components/LoginPromptPanel.js
+++ b/src/sidebar/components/LoginPromptPanel.js
@@ -1,4 +1,4 @@
-import { LabeledButton } from '@hypothesis/frontend-shared';
+import { Actions, LabeledButton } from '@hypothesis/frontend-shared';
 
 import { useStoreProxy } from '../store/use-store';
 
@@ -28,14 +28,14 @@ export default function LoginPromptPanel({ onLogin, onSignUp }) {
       panelName="loginPrompt"
     >
       <p>Please log in to create annotations or highlights.</p>
-      <div className="LoginPromptPanel__buttons">
+      <Actions>
         <LabeledButton title="Sign up" onClick={onSignUp}>
           Sign up
         </LabeledButton>
         <LabeledButton title="Log in" variant="primary" onClick={onLogin}>
           Log in
         </LabeledButton>
-      </div>
+      </Actions>
     </SidebarPanel>
   );
 }

--- a/src/styles/sidebar/components/LoginPromptPanel.scss
+++ b/src/styles/sidebar/components/LoginPromptPanel.scss
@@ -1,7 +1,0 @@
-@use "../../mixins/layout";
-@use "../../variables" as var;
-
-.LoginPromptPanel__buttons {
-  @include layout.row;
-  @include layout.horizontal-rhythm(var.$layout-space--xsmall);
-}

--- a/src/styles/sidebar/sidebar.scss
+++ b/src/styles/sidebar/sidebar.scss
@@ -36,7 +36,6 @@
 @use './components/HypothesisApp';
 @use './components/LaunchErrorPanel';
 @use './components/LoggedOutMessage';
-@use './components/LoginPromptPanel';
 @use './components/MarkdownEditor';
 @use './components/MarkdownView';
 @use './components/Menu';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1016,10 +1016,10 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@hypothesis/frontend-shared@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-3.2.0.tgz#f045a046871e1fcc4f8f7e5f5ab7a4b76f1d454c"
-  integrity sha512-uV4xRGJMESN1v43Wl076aVgdSxJ/Q3YBqLBK0W1HT7TKvKbEWF4TP/ifk2D9W7NJ8ljx59pXKQQoR0mfNzBYxQ==
+"@hypothesis/frontend-shared@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-3.3.0.tgz#50186386e4a81e921df6d56dd10fcd452175d920"
+  integrity sha512-SRYpmjwfMbL4QB5M/a2ca8+BNiEa2z5XLdHJetJLGNpBE4xZW6brpAvZPsZJbdbqt6WJO4+wgQPnM46C8HHQdw==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
This PR:

* Bumps the `frontend-shared` package version to `3.3.0`. No user-visible changes.
* This version of the package provides some logic-free "container" components. The second commit here takes advantage of those to rectify an inconsistency.

## Using `Actions` in `LoginPromptPanel`

Replacing component classname-based styling with `Actions` in the `LoginPromptPanel` has the following benefits:

* It applies visual consistency. Here, the buttons were styled to align left, when our convention is to align right. The spacing between the buttons was also not consistent with other sets of buttons.
* It rectifies the individualistic approach that components are currently taking to styling their sets of buttons. In `LoginPromptPanel`'s case, there was a classname, `LoginPromptPanel__buttons` that applied the styling. In other components, this might be called `&__actions` or `&-actions` or something entirely different.
* It removes the need for this component to have any custom CSS at all, so we can remove the SASS module.

Less code, less CSS, more consistency.

### Before

![image](https://user-images.githubusercontent.com/439947/123684953-18b2ff80-d81c-11eb-8da2-65c903a56c6d.png)


### After

![image](https://user-images.githubusercontent.com/439947/123684712-cd005600-d81b-11eb-9f33-c3c63ee51ac7.png)

There are many other places in the `client` that could benefit from using the container components. This is just an example.

## To see it in action

On this branch, fire up your local dev server and go to a test page with Hypothesis embedded. Log yourself out using the sidebar's user menu. Now, select some text and click _Annotate_. You should see the "login prompt panel."