### PR TITLE
Add `Escape` shortcut to hide adder

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -338,6 +338,9 @@ export class Adder {
         case 'show':
           this._onShowAnnotations(this.annotationsForSelection);
           break;
+        case 'hide':
+          this.hide();
+          break;
         default:
           break;
       }

--- a/src/annotator/components/AdderToolbar.js
+++ b/src/annotator/components/AdderToolbar.js
@@ -35,7 +35,7 @@ function ToolbarButton({ badgeCount, icon, label, onClick, shortcut }) {
 /**
  * Union of possible toolbar commands.
  *
- * @typedef {'annotate'|'highlight'|'show'} Command
+ * @typedef {'annotate'|'highlight'|'show'|'hide'} Command
  */
 
 /**
@@ -70,6 +70,11 @@ export default function AdderToolbar({
   const annotateShortcut = isVisible ? 'a' : null;
   const highlightShortcut = isVisible ? 'h' : null;
   const showShortcut = isVisible ? 's' : null;
+  const hideShortcut = isVisible ? 'Escape' : null;
+
+  // Add a shortcut to close the adder. Note, there is no button associated with this
+  // shortcut because any outside click will also hide the adder.
+  useShortcut(hideShortcut, () => onCommand('hide'));
 
   // nb. The adder is hidden using the `visibility` property rather than `display`
   // so that we can compute its size in order to position it before display.

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -75,7 +75,7 @@ describe('Adder', () => {
     assert.exists(shadowRoot.querySelector('.AdderToolbar'));
   });
 
-  describe('button handling', () => {
+  describe('button and shortcut handling', () => {
     const getButton = label =>
       getContent(adder).querySelector(`button[title^="${label}"]`);
 
@@ -152,6 +152,17 @@ describe('Adder', () => {
       showAdder();
       triggerShortcut('s');
       assert.called(adderCallbacks.onShowAnnotations);
+    });
+
+    it('hides the adder when `Escape` shortcut is pressed', () => {
+      adder.annotationsForSelection = ['ann1'];
+      showAdder();
+
+      triggerShortcut('Escape');
+
+      const pos = adderRect();
+      assert.equal(pos.left, 0);
+      assert.equal(pos.top, 0);
     });
 
     it('does not call callbacks when adder is hidden', () => {


### PR DESCRIPTION
The adder now hides when the escape key is pressed. (WCAG 2.1 criterion 1.4.13)

---------

Note: Low priority

fixes https://github.com/hypothesis/product-backlog/issues/1128

relates to https://github.com/hypothesis/product-backlog/issues/1114

