### PR TITLE
Remove aria-label from TagEditor and AnnotationPublishControl button

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationPublishControl.js
+++ b/src/sidebar/components/Annotation/AnnotationPublishControl.js
@@ -85,7 +85,6 @@ function AnnotationPublishControl({
           style={buttonStyle}
           onClick={onSave}
           disabled={isDisabled}
-          title={`Publish this annotation to ${publishDestination}`}
           size="large"
           variant="primary"
         >

--- a/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
@@ -78,7 +78,7 @@ describe('AnnotationPublishControl', () => {
   });
 
   const getPublishButton = wrapper =>
-    wrapper.find('LabeledButton[title^="Publish this annotation"]');
+    wrapper.find('LabeledButton.PublishControlButton');
 
   describe('theming', () => {
     it('should apply theme styles', () => {
@@ -102,10 +102,7 @@ describe('AnnotationPublishControl', () => {
         const wrapper = createAnnotationPublishControl();
 
         const btn = getPublishButton(wrapper);
-        assert.equal(
-          btn.prop('title'),
-          `Publish this annotation to ${fakeGroup.name}`
-        );
+        assert.equal(btn.text(), `Post to ${fakeGroup.name}`);
       });
     });
 
@@ -117,7 +114,7 @@ describe('AnnotationPublishControl', () => {
         const wrapper = createAnnotationPublishControl();
 
         const btn = getPublishButton(wrapper);
-        assert.equal(btn.prop('title'), 'Publish this annotation to Only Me');
+        assert.equal(btn.text(), 'Post to Only Me');
       });
     });
 

--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -318,7 +318,6 @@ function TagEditor({
           className="TagEditor__input"
           type="text"
           autoComplete="off"
-          aria-label="Add tag field"
           aria-autocomplete="list"
           aria-activedescendant={activeDescendant}
           aria-controls={`${tagEditorId}-AutocompleteList`}


### PR DESCRIPTION
Per WCAG 2.1 criterion: 2.5.3 Label in Name--we should not differentiate between the aria-label and the visual name in an input element. In the case of the TagEditor, the `placeholder` and `aria-label` were different. The simple fix is to remove `aria-label`.

The second problem is with AnnotationPublishControl's button where the `aria-label` and button's text did not match. Again, the simple fix is to remove `aria-label`.


-----

In both cases I have tested with Mac voiceover and the button's text and input's placeholder are read out as expected.
fixes https://github.com/hypothesis/product-backlog/issues/1127

relates to https://github.com/hypothesis/product-backlog/issues/1114