### PR TITLE
Support MessageChannel in `frame-rpc.js`

### DIFF
--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -115,7 +115,7 @@ describe('shared/bridge', () => {
       sandbox.stub(channel, 'call').throws(new Error(''));
       sandbox.stub(channel, 'destroy');
 
-      const callback = function () {
+      const callback = () => {
         assert.called(channel.destroy);
         done();
       };
@@ -184,9 +184,10 @@ describe('shared/bridge', () => {
       };
 
       const data = {
-        protocol: 'frame-rpc',
-        method: 'connect',
         arguments: ['TOKEN'],
+        method: 'connect',
+        protocol: 'frame-rpc',
+        version: '1.0.0',
       };
 
       const event = {
@@ -212,9 +213,10 @@ describe('shared/bridge', () => {
       };
 
       const data = {
-        protocol: 'frame-rpc',
-        method: 'connect',
         arguments: ['TOKEN'],
+        method: 'connect',
+        protocol: 'frame-rpc',
+        version: '1.0.0',
       };
 
       const event = {

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -27,7 +27,7 @@ describe('shared/bridge', () => {
     it('creates a new channel with the provided options', () => {
       const channel = createChannel();
       assert.equal(channel.sourceFrame, window);
-      assert.equal(channel.destFrame, fakeWindow);
+      assert.equal(channel.destFrameOrPort, fakeWindow);
       assert.equal(channel.origin, 'http://example.com');
     });
 

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -27,7 +27,7 @@ describe('shared/bridge', () => {
     it('creates a new channel with the provided options', () => {
       const channel = createChannel();
       assert.equal(channel.sourceFrame, window);
-      assert.equal(channel.destFrameOrPort, fakeWindow);
+      assert.equal(channel.destFrame, fakeWindow);
       assert.equal(channel.origin, 'http://example.com');
     });
 

--- a/src/shared/test/frame-rpc-test.js
+++ b/src/shared/test/frame-rpc-test.js
@@ -1,0 +1,146 @@
+import { RPC } from '../frame-rpc';
+
+describe('shared/bridge', () => {
+  let port1;
+  let port2;
+  let rpc1;
+  let rpc2;
+  let plusOne;
+
+  beforeEach(() => {
+    const channel = new MessageChannel();
+    port1 = channel.port1;
+    port2 = channel.port2;
+
+    // `concat` method for rpc1
+    const concat = (arg0, ...args) => {
+      const callback = args.pop();
+      const result = arg0.concat(...args);
+      callback(result);
+    };
+
+    rpc1 = new RPC(
+      /** dummy when using ports */ window,
+      port1,
+      /** dummy when using ports */ '*',
+      {
+        concat,
+      }
+    );
+
+    // `plusOne` method for rpc2
+    plusOne = sinon.stub().callsFake((...numbers) => {
+      const callback = numbers.pop();
+      const result = numbers.map(value => value + 1);
+      callback(result);
+    });
+
+    rpc2 = new RPC(
+      /** dummy when using ports */ window,
+      port2,
+      /** dummy when using ports */ '*',
+      {
+        plusOne,
+      }
+    );
+  });
+
+  afterEach(() => {
+    rpc1.destroy();
+    rpc2.destroy();
+  });
+
+  it('should call the method `plusOne` on rpc2', done => {
+    rpc1.call('plusOne', 1, 2, 3, value => {
+      assert.deepEqual(value, [2, 3, 4]);
+      done();
+    });
+  });
+
+  it('should not call the method `plusOne` if rpc1 is destroyed', () => {
+    rpc1.destroy();
+
+    rpc1.call('plusOne', 1, 2, 3);
+    assert.notCalled(plusOne);
+  });
+
+  it('should not call the method `plusOne` if rpc2 is destroyed', done => {
+    rpc2.destroy();
+
+    rpc1.call('plusOne', 1, 2, 3, () => {
+      done(new Error('Unexpected call'));
+    });
+
+    setTimeout(() => {
+      assert.notCalled(plusOne);
+      done();
+    }, 100);
+  });
+
+  it('should call the method `concat` on rpc1', done => {
+    rpc2.call('concat', 'hello', ' ', 'world', value => {
+      assert.equal(value, 'hello world');
+      done();
+    });
+
+    rpc2.call('concat', [1], [2], [3], value => {
+      assert.deepEqual(value, [1, 2, 3]);
+      done();
+    });
+  });
+
+  it('should ignore invalid messages', done => {
+    // Correct message
+    port1.postMessage({
+      arguments: [1, 2],
+      method: 'plusOne',
+      protocol: 'frame-rpc',
+      version: '1.0.0',
+    });
+
+    // Incorrect argument
+    port1.postMessage({
+      arguments: 'test',
+      method: 'plusOne',
+      protocol: 'frame-rpc',
+      version: '1.0.0',
+    });
+
+    // Incorrect method
+    port1.postMessage({
+      arguments: [1, 2],
+      method: 'dummy',
+      protocol: 'frame-rpc',
+      version: '1.0.0',
+    });
+
+    // Incorrect protocol
+    port1.postMessage({
+      arguments: [1, 2],
+      method: 'plusOne',
+      protocol: 'dummy',
+      version: '1.0.0',
+    });
+
+    // Incorrect version
+    port1.postMessage({
+      arguments: [1, 2],
+      method: 'plusOne',
+      protocol: 'frame-rpc',
+      version: 'dummy',
+    });
+
+    // All incorrect
+    port1.postMessage({});
+    port1.postMessage(null);
+    port1.postMessage(undefined);
+    port1.postMessage(0);
+    port1.postMessage('');
+    port1.postMessage('dummy');
+
+    setTimeout(() => {
+      assert.calledOnce(plusOne);
+      done();
+    }, 100);
+  });
+});


### PR DESCRIPTION
* added support for `MessageChannel` in the `RPC` class. I also simplified some internals.
* `bridge-test.js` refactor to use arrow functions
* added `frame-rpc-test.js` to test specifically the `RPC` class with `MessageChannel`.