### PR TITLE
Support MessageChannel in  `bridge.js`

### DIFF
--- a/src/annotator/cross-frame.js
+++ b/src/annotator/cross-frame.js
@@ -64,9 +64,9 @@ export class CrossFrame {
     };
 
     // Initiate connection to the sidebar.
-    const onDiscoveryCallback = (source, origin, token) =>
-      bridge.createChannel(source, origin, token);
-    discovery.startDiscovery(onDiscoveryCallback);
+    discovery.startDiscovery((source, origin, token) =>
+      bridge.createChannel({ source, origin, token })
+    );
     frameObserver.observe(injectIntoFrame, iframeUnloaded);
 
     /**

--- a/src/annotator/test/cross-frame-test.js
+++ b/src/annotator/test/cross-frame-test.js
@@ -88,7 +88,11 @@ describe('CrossFrame', () => {
       createCrossFrame();
       fakeDiscovery.startDiscovery.yield('SOURCE', 'ORIGIN', 'TOKEN');
       assert.called(fakeBridge.createChannel);
-      assert.calledWith(fakeBridge.createChannel, 'SOURCE', 'ORIGIN', 'TOKEN');
+      assert.calledWith(fakeBridge.createChannel, {
+        source: 'SOURCE',
+        origin: 'ORIGIN',
+        token: 'TOKEN',
+      });
     });
   });
 

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -29,7 +29,8 @@ export default class Bridge {
 
   /**
    * Deprecated - Remove after MessagePort conversion
-   * @typedef windowOptions
+   *
+   * @typedef WindowOptions
    * @prop {Window} source - The source window
    * @prop {string} origin - The origin of the document in `source`
    * @prop {string} token - Shared token between the `source` and this window
@@ -43,7 +44,7 @@ export default class Bridge {
    * The created channel is added to the list of channels which `call`
    * and `on` send and receive messages over.
    *
-   * @param {windowOptions|MessagePort} options
+   * @param {WindowOptions|MessagePort} options
    * @return {RPC} - Channel for communicating with the window.
    */
   createChannel(options) {
@@ -99,7 +100,7 @@ export default class Bridge {
    * The created channel is added to the list of channels which `call`
    * and `on` send and receive messages over.
    *
-   * @param {windowOptions} options
+   * @param {WindowOptions} options
    * @return {RPC} - Channel for communicating with the window.
    * @deprecated
    */

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -118,7 +118,6 @@ export default class Bridge {
     const connect = (_token, cb) => {
       if (_token === token) {
         cb();
-        ready(); // This is necessary for testing only.
       }
     };
 

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -14,7 +14,7 @@ export default class Bridge {
     this.links = [];
     /** @type {Record<string, (...args: any[]) => void>} */
     this.channelListeners = {};
-    /** @type {Array<(channel: RPC, window?: Window) => void>} */
+    /** @type {Array<(channel: RPC) => void>} */
     this.onConnectListeners = [];
   }
 
@@ -113,7 +113,7 @@ export default class Bridge {
         return;
       }
       connected = true;
-      this.onConnectListeners.forEach(cb => cb(channel, source));
+      this.onConnectListeners.forEach(cb => cb(channel));
     };
 
     const connect = (_token, cb) => {
@@ -227,7 +227,7 @@ export default class Bridge {
   /**
    * Add a listener to be called upon a new connection.
    *
-   * @param {(channel: RPC, window?: Window) => void} listener
+   * @param {(channel: RPC) => void} listener
    */
   onConnect(listener) {
     this.onConnectListeners.push(listener);

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -258,7 +258,7 @@ describe('shared/bridge', () => {
 
       runConnectHandler(channel);
 
-      assert.calledWith(onConnectCallback, channel, fakeWindow);
+      assert.calledWith(onConnectCallback, channel);
     });
 
     it('does not run callback if a Window channel connects with wrong token', () => {
@@ -298,8 +298,8 @@ describe('shared/bridge', () => {
 
       runConnectHandler(channel);
 
-      assert.calledWith(onConnectCallback1, channel, fakeWindow);
-      assert.calledWith(onConnectCallback2, channel, fakeWindow);
+      assert.calledWith(onConnectCallback1, channel);
+      assert.calledWith(onConnectCallback2, channel);
     });
 
     it('only invokes `onConnect` callback once', () => {

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -22,7 +22,11 @@ describe('shared/bridge', () => {
     bridge = new Bridge();
 
     createChannel = () =>
-      bridge.createChannel(fakeWindow, 'http://example.com', 'TOKEN');
+      bridge.createChannel({
+        source: fakeWindow,
+        origin: 'http://example.com',
+        token: 'TOKEN',
+      });
 
     fakeWindow = {
       postMessage: sandbox.stub(),
@@ -85,11 +89,11 @@ describe('shared/bridge', () => {
 
     it('calls a callback when all channels return successfully', done => {
       const channel1 = createChannel();
-      const channel2 = bridge.createChannel(
-        fakeWindow,
-        'http://example.com',
-        'NEKOT'
-      );
+      const channel2 = bridge.createChannel({
+        source: fakeWindow,
+        origin: 'http://example.com',
+        token: 'NEKOT',
+      });
       channel1.call.yields(null, 'result1');
       channel2.call.yields(null, 'result2');
 
@@ -105,11 +109,11 @@ describe('shared/bridge', () => {
     it('calls a callback with an error when a channels fails', done => {
       const error = new Error('Uh oh');
       const channel1 = createChannel();
-      const channel2 = bridge.createChannel(
-        fakeWindow,
-        'http://example.com',
-        'NEKOT'
-      );
+      const channel2 = bridge.createChannel({
+        source: fakeWindow,
+        origin: 'http://example.com',
+        token: 'NEKOT',
+      });
       channel1.call.throws(error);
       channel2.call.yields(null, 'result2');
 
@@ -260,16 +264,16 @@ describe('shared/bridge', () => {
 
   describe('#destroy', () =>
     it('destroys all opened channels', () => {
-      const channel1 = bridge.createChannel(
-        fakeWindow,
-        'http://example.com',
-        'foo'
-      );
-      const channel2 = bridge.createChannel(
-        fakeWindow,
-        'http://example.com',
-        'bar'
-      );
+      const channel1 = bridge.createChannel({
+        source: fakeWindow,
+        origin: 'http://example.com',
+        token: 'foo',
+      });
+      const channel2 = bridge.createChannel({
+        source: fakeWindow,
+        origin: 'http://example.com',
+        token: 'bar',
+      });
 
       bridge.destroy();
 

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -236,7 +236,9 @@ export class FrameSyncService {
     };
 
     const discovery = new Discovery(window, { server: true });
-    discovery.startDiscovery(this._bridge.createChannel.bind(this._bridge));
+    discovery.startDiscovery((source, origin, token) =>
+      this._bridge.createChannel({ source, origin, token })
+    );
     this._bridge.onConnect(addFrame);
 
     this._setupSyncToFrame();


### PR DESCRIPTION
Initially, I tried to if/else portions of the code to accommodate for
`MessagePort`, aiming to avoid duplication of the code (like I did for
`shared/frame-rpc.js` #3565). However, I found that, unlike
`shared/frame-rpc.js`, this resulted into a spaghetti-type of code, not
very understandable.

Then, I followed @robertknight suggestion:

* Package up the data needed to create a channel for a window into one object, then make createChannel accept either that object or a MessagePort, and only have createChannel as the public API

* Have two separate public methods, createChannelForWindow and createChannelForPort, which work with a Window and MessagePort respectively. Internally these could delegate to a shared helper to do most of the work

The two internal methods to support the current communication using `Window` and the new `MessagePort`,  leads to clearer results, although some code is duplicated in both methods.

This PR will result on a reduction in code coverage, which will be fix
by #3598.