### PR TITLE
Convert remaining anonymous callbacks to arrow functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,8 @@
 {
   "extends": ["hypothesis", "plugin:jsx-a11y/recommended"],
   "rules": {
+    "prefer-arrow-callback": ["error", { "allowNamedFunctions": true }],
+
     // Suppressed to make ESLint v6 migration easier.
     "no-prototype-builtins": "off",
 

--- a/dev-server/serve-dev.js
+++ b/dev-server/serve-dev.js
@@ -81,7 +81,7 @@ function serveDev(port, config) {
   app.use('/pdf-source', express.static(PDF_PATH));
 
   // Enable CORS for assets so that cross-origin font loading works.
-  app.use(function (req, res, next) {
+  app.use((req, res, next) => {
     res.append('Access-Control-Allow-Origin', '*');
     res.append('Access-Control-Allow-Methods', 'GET');
     next();

--- a/dev-server/serve-package.js
+++ b/dev-server/serve-package.js
@@ -23,7 +23,7 @@ function servePackage(port) {
   const app = express();
 
   // Enable CORS for assets so that cross-origin font loading works.
-  app.use(function (req, res, next) {
+  app.use((req, res, next) => {
     res.append('Access-Control-Allow-Origin', '*');
     res.append('Access-Control-Allow-Methods', 'GET');
     next();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,18 +59,14 @@ function parseCommandLine() {
 const karmaOptions = parseCommandLine();
 
 /** A list of all modules included in vendor bundles. */
-const vendorModules = Object.keys(vendorBundles.bundles).reduce(function (
-  deps,
-  key
-) {
+const vendorModules = Object.keys(vendorBundles.bundles).reduce((deps, key) => {
   return deps.concat(vendorBundles.bundles[key]);
-},
-[]);
+}, []);
 
 // Builds the bundles containing vendor JS code
-gulp.task('build-vendor-js', function () {
+gulp.task('build-vendor-js', () => {
   const finished = [];
-  Object.keys(vendorBundles.bundles).forEach(function (name) {
+  Object.keys(vendorBundles.bundles).forEach(name => {
     finished.push(
       createBundle({
         name: name,
@@ -147,9 +143,9 @@ const appBundleConfigs = appBundles.concat(polyfillBundles).map(config => {
 
 gulp.task(
   'build-js',
-  gulp.parallel('build-vendor-js', function () {
+  gulp.parallel('build-vendor-js', () => {
     return Promise.all(
-      appBundleConfigs.map(function (config) {
+      appBundleConfigs.map(config => {
         return createBundle(config);
       })
     );
@@ -159,7 +155,7 @@ gulp.task(
 gulp.task(
   'watch-js',
   gulp.series('build-vendor-js', function watchJS() {
-    appBundleConfigs.forEach(function (config) {
+    appBundleConfigs.forEach(config => {
       createBundle(config, { watch: true });
     });
   })
@@ -178,7 +174,7 @@ const cssBundles = [
   './src/styles/ui-playground/ui-playground.scss',
 ];
 
-gulp.task('build-css', function () {
+gulp.task('build-css', () => {
   mkdirSync(STYLE_DIR, { recursive: true });
   const bundles = cssBundles.map(entry =>
     createStyleBundle({
@@ -205,7 +201,7 @@ const fontFiles = [
   'node_modules/katex/dist/fonts/*.woff2',
 ];
 
-gulp.task('build-fonts', function () {
+gulp.task('build-fonts', () => {
   return gulp
     .src(fontFiles)
     .pipe(changed(FONTS_DIR))
@@ -220,7 +216,7 @@ gulp.task(
 );
 
 const imageFiles = 'src/images/**/*';
-gulp.task('build-images', function () {
+gulp.task('build-images', () => {
   return gulp
     .src(imageFiles)
     .pipe(changed(IMAGES_DIR))
@@ -308,17 +304,17 @@ function generateManifest(opts) {
     .pipe(gulp.dest('build/'));
 }
 
-gulp.task('watch-manifest', function () {
+gulp.task('watch-manifest', () => {
   gulp.watch(MANIFEST_SOURCE_FILES, { delay: 500 }, function updateManifest() {
     return generateManifest({ usingDevServer: true });
   });
 });
 
-gulp.task('serve-package', function () {
+gulp.task('serve-package', () => {
   servePackage(3001);
 });
 
-gulp.task('serve-test-pages', function () {
+gulp.task('serve-test-pages', () => {
   serveDev(3000, { clientUrl: `//{current_host}:3001/hypothesis` });
 });
 

--- a/scripts/gulp/create-bundle.js
+++ b/scripts/gulp/create-bundle.js
@@ -16,14 +16,14 @@ const watchify = require('watchify');
 const minifyStream = require('./minify-stream');
 
 function streamFinished(stream) {
-  return new Promise(function (resolve, reject) {
+  return new Promise((resolve, reject) => {
     stream.on('finish', resolve);
     stream.on('error', reject);
   });
 }
 
 function waitForever() {
-  return new Promise(function () {});
+  return new Promise(() => {});
 }
 
 /**
@@ -100,7 +100,7 @@ module.exports = function createBundle(config, buildOpts) {
   // Specify modules that Browserify should not parse.
   // The 'noParse' array must contain full file paths,
   // not module names.
-  bundleOpts.noParse = (config.noParse || []).map(function (id) {
+  bundleOpts.noParse = (config.noParse || []).map(id => {
     // If package.json specifies a custom entry point for the module for
     // use in the browser, resolve that.
     const packageConfig = require('../../package.json');
@@ -137,7 +137,7 @@ module.exports = function createBundle(config, buildOpts) {
 
   const bundle = browserify([], bundleOpts);
 
-  (config.require || []).forEach(function (req) {
+  (config.require || []).forEach(req => {
     // When another bundle uses 'bundle.external(<module path>)',
     // the module path is rewritten relative to the
     // base directory and a '/' prefix is added, so
@@ -168,7 +168,7 @@ module.exports = function createBundle(config, buildOpts) {
   bundle.add(config.entry || []);
   bundle.external(config.external || []);
 
-  (config.transforms || []).forEach(function (transform) {
+  (config.transforms || []).forEach(transform => {
     if (transform === 'babel') {
       bundle.transform(babelify);
     }
@@ -194,7 +194,7 @@ module.exports = function createBundle(config, buildOpts) {
   function build() {
     const output = fs.createWriteStream(bundlePath);
     let stream = bundle.bundle();
-    stream.on('error', function (err) {
+    stream.on('error', err => {
       log('Build error', err.toString());
     });
 
@@ -208,23 +208,23 @@ module.exports = function createBundle(config, buildOpts) {
 
   if (buildOpts.watch) {
     bundle.plugin(watchify);
-    bundle.on('update', function (ids) {
+    bundle.on('update', ids => {
       const start = Date.now();
 
       log('Source files changed', ids);
       build()
-        .then(function () {
+        .then(() => {
           log('Updated %s (%d ms)', bundleFileName, Date.now() - start);
         })
-        .catch(function (err) {
+        .catch(err => {
           console.error('Building updated bundle failed:', err);
         });
     });
     build()
-      .then(function () {
+      .then(() => {
         log('Built ' + bundleFileName);
       })
-      .catch(function (err) {
+      .catch(err => {
         console.error('Error building bundle:', err);
       });
 

--- a/scripts/gulp/manifest.js
+++ b/scripts/gulp/manifest.js
@@ -18,7 +18,7 @@ module.exports = function (opts) {
   const manifest = {};
 
   return through.obj(
-    function (file, enc, callback) {
+    (file, enc, callback) => {
       const hash = crypto.createHash('sha1');
       hash.update(file.contents);
 

--- a/src/annotator/anchoring/test/html-test.js
+++ b/src/annotator/anchoring/test/html-test.js
@@ -62,7 +62,7 @@ function toRange(root, descriptor) {
 }
 
 function findByType(selectors, type) {
-  return selectors.find(function (s) {
+  return selectors.find(s => {
     return s.type === type;
   });
 }
@@ -71,7 +71,7 @@ function findByType(selectors, type) {
  * Return a copy of a list of selectors sorted by type.
  */
 function sortByType(selectors) {
-  return selectors.slice().sort(function (a, b) {
+  return selectors.slice().sort((a, b) => {
     return a.type.localeCompare(b.type);
   });
 }
@@ -304,16 +304,16 @@ const expectedFailures = [
   // Currently empty.
 ];
 
-describe('HTML anchoring', function () {
+describe('HTML anchoring', () => {
   let container;
 
-  beforeEach(function () {
+  beforeEach(() => {
     container = document.createElement('section');
     container.innerHTML = fixture;
     document.body.appendChild(container);
   });
 
-  afterEach(function () {
+  afterEach(() => {
     container.remove();
   });
 
@@ -345,7 +345,7 @@ describe('HTML anchoring', function () {
       const positionSel = findByType(selectors, 'TextPositionSelector');
       const quoteSel = findByType(selectors, 'TextQuoteSelector');
 
-      const failInfo = expectedFailures.find(function (f) {
+      const failInfo = expectedFailures.find(f => {
         return f[0] === testCase.description;
       });
       let failTypes = {};
@@ -363,8 +363,8 @@ describe('HTML anchoring', function () {
 
       // Map each selector back to a Range and check that it refers to the same
       // text. We test each selector in turn to make sure they are all valid.
-      const anchored = selectors.map(function (sel) {
-        return html.anchor(container, [sel]).then(function (anchoredRange) {
+      const anchored = selectors.map(sel => {
+        return html.anchor(container, [sel]).then(anchoredRange => {
           assert.equal(range.toString(), anchoredRange.toString());
         });
       });
@@ -372,13 +372,13 @@ describe('HTML anchoring', function () {
     });
   });
 
-  describe('When anchoring fails', function () {
+  describe('When anchoring fails', () => {
     const validQuoteSelector = {
       type: 'TextQuoteSelector',
       exact: 'Lorem ipsum',
     };
 
-    it('throws an error if anchoring using a quote fails', async function () {
+    it('throws an error if anchoring using a quote fails', async () => {
       const quoteSelector = {
         type: 'TextQuoteSelector',
         exact: 'This text does not appear in the web page',
@@ -389,7 +389,7 @@ describe('HTML anchoring', function () {
       );
     });
 
-    it('does not throw an error if anchoring using a position fails', function () {
+    it('does not throw an error if anchoring using a position fails', () => {
       const positionSelector = {
         type: 'TextPositionSelector',
         start: 1000,
@@ -401,7 +401,7 @@ describe('HTML anchoring', function () {
       return html.anchor(container, [positionSelector, validQuoteSelector]);
     });
 
-    it('does not throw an error if anchoring using a range fails', function () {
+    it('does not throw an error if anchoring using a range fails', () => {
       const rangeSelector = {
         type: 'RangeSelector',
         startContainer: '/main',
@@ -416,15 +416,15 @@ describe('HTML anchoring', function () {
     });
   });
 
-  describe('Web page baselines', function () {
+  describe('Web page baselines', () => {
     let frame;
 
-    before(function () {
+    before(() => {
       frame = document.createElement('iframe');
       document.body.appendChild(frame);
     });
 
-    after(function () {
+    after(() => {
       frame.remove();
     });
 

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -40,7 +40,7 @@ const fixtures = {
   ],
 };
 
-describe('annotator/anchoring/pdf', function () {
+describe('annotator/anchoring/pdf', () => {
   let container;
   let viewer;
 
@@ -74,47 +74,47 @@ describe('annotator/anchoring/pdf', function () {
     window.PDFViewerApplication = null;
   }
 
-  beforeEach(function () {
+  beforeEach(() => {
     container = document.createElement('div');
     document.body.appendChild(container);
     initViewer(fixtures.pdfPages);
   });
 
-  afterEach(function () {
+  afterEach(() => {
     cleanupViewer();
     container.remove();
   });
 
-  describe('#describe', function () {
-    it('returns position and quote selectors', function () {
+  describe('#describe', () => {
+    it('returns position and quote selectors', () => {
       viewer.pdfViewer.setCurrentPage(2);
       const range = findText(container, 'Netherfield Park');
-      return pdfAnchoring.describe(container, range).then(function (selectors) {
-        const types = selectors.map(function (s) {
+      return pdfAnchoring.describe(container, range).then(selectors => {
+        const types = selectors.map(s => {
           return s.type;
         });
         assert.deepEqual(types, ['TextPositionSelector', 'TextQuoteSelector']);
       });
     });
 
-    it('returns a position selector with correct start/end offsets', function () {
+    it('returns a position selector with correct start/end offsets', () => {
       viewer.pdfViewer.setCurrentPage(2);
       const quote = 'Netherfield Park';
       const range = findText(container, quote);
       const contentStr = fixtures.pdfPages.join('');
       const expectedPos = contentStr.replace(/\n/g, '').lastIndexOf(quote);
 
-      return pdfAnchoring.describe(container, range).then(function (selectors) {
+      return pdfAnchoring.describe(container, range).then(selectors => {
         const position = selectors[0];
         assert.equal(position.start, expectedPos);
         assert.equal(position.end, expectedPos + quote.length);
       });
     });
 
-    it('returns a quote selector with the correct quote', function () {
+    it('returns a quote selector with the correct quote', () => {
       viewer.pdfViewer.setCurrentPage(2);
       const range = findText(container, 'Netherfield Park');
-      return pdfAnchoring.describe(container, range).then(function (selectors) {
+      return pdfAnchoring.describe(container, range).then(selectors => {
         const quote = selectors[1];
 
         assert.deepEqual(quote, {
@@ -126,7 +126,7 @@ describe('annotator/anchoring/pdf', function () {
       });
     });
 
-    it('returns selector when range starts at end of text node with no next siblings', function () {
+    it('returns selector when range starts at end of text node with no next siblings', () => {
       // this problem is referenced in client issue #122
       // But what is happening is the startContainer is referencing a text
       // elment inside of a node. The logic in pdf#describe() was assuming if the
@@ -155,7 +155,7 @@ describe('annotator/anchoring/pdf', function () {
       const contentStr = fixtures.pdfPages.join('');
       const expectedPos = contentStr.replace(/\n/g, '').lastIndexOf(quote);
 
-      return pdfAnchoring.describe(container, range).then(function (selectors) {
+      return pdfAnchoring.describe(container, range).then(selectors => {
         const position = selectors[0];
         assert.equal(position.start, expectedPos);
         assert.equal(position.end, expectedPos + quote.length);
@@ -206,33 +206,33 @@ describe('annotator/anchoring/pdf', function () {
     });
   });
 
-  describe('#anchor', function () {
-    it('anchors previously created selectors if the page is rendered', function () {
+  describe('#anchor', () => {
+    it('anchors previously created selectors if the page is rendered', () => {
       viewer.pdfViewer.setCurrentPage(2);
       const range = findText(container, 'My dear Mr. Bennet');
-      return pdfAnchoring.describe(container, range).then(function (selectors) {
+      return pdfAnchoring.describe(container, range).then(selectors => {
         const position = selectors[0];
         const quote = selectors[1];
 
         // Test that all of the selectors anchor and that each selector individually
         // anchors correctly as well
         const subsets = [[position, quote], [position], [quote]];
-        const subsetsAnchored = subsets.map(function (subset) {
-          const types = subset.map(function (s) {
+        const subsetsAnchored = subsets.map(subset => {
+          const types = subset.map(s => {
             return s.type;
           });
           const description = 'anchoring failed with ' + types.join(', ');
 
           return pdfAnchoring
             .anchor(container, subset)
-            .then(function (anchoredRange) {
+            .then(anchoredRange => {
               assert.equal(
                 anchoredRange.toString(),
                 range.toString(),
                 description
               );
             })
-            .catch(function (err) {
+            .catch(err => {
               console.warn(description);
               throw err;
             });
@@ -268,12 +268,12 @@ describe('annotator/anchoring/pdf', function () {
         offset: 100000,
       },
     ].forEach(({ offset }) => {
-      it('anchors using a quote if the position selector fails', function () {
+      it('anchors using a quote if the position selector fails', () => {
         viewer.pdfViewer.setCurrentPage(0);
         const range = findText(container, 'Pride And Prejudice');
         return pdfAnchoring
           .describe(container, range)
-          .then(function (selectors) {
+          .then(selectors => {
             const position = selectors[0];
             const quote = selectors[1];
 
@@ -288,16 +288,16 @@ describe('annotator/anchoring/pdf', function () {
       });
     });
 
-    it('anchors to a placeholder element if the page is not rendered', function () {
+    it('anchors to a placeholder element if the page is not rendered', () => {
       viewer.pdfViewer.setCurrentPage(2);
       const range = findText(container, 'Netherfield Park');
       return pdfAnchoring
         .describe(container, range)
-        .then(function (selectors) {
+        .then(selectors => {
           viewer.pdfViewer.setCurrentPage(0);
           return pdfAnchoring.anchor(container, selectors);
         })
-        .then(function (anchoredRange) {
+        .then(anchoredRange => {
           assert.equal(anchoredRange.toString(), 'Loading annotations...');
         });
     });

--- a/src/annotator/annotation-counts.js
+++ b/src/annotator/annotation-counts.js
@@ -18,7 +18,7 @@ export default function annotationCounts(rootEl, crossframe) {
 
   function updateAnnotationCountElems(newCount) {
     const elems = rootEl.querySelectorAll('[' + ANNOTATION_COUNT_ATTR + ']');
-    Array.from(elems).forEach(function (elem) {
+    Array.from(elems).forEach(elem => {
       elem.textContent = newCount;
     });
   }

--- a/src/annotator/config/test/config-func-settings-from-test.js
+++ b/src/annotator/config/test/config-func-settings-from-test.js
@@ -1,22 +1,22 @@
 import configFuncSettingsFrom from '../config-func-settings-from';
 
-describe('annotator.config.configFuncSettingsFrom', function () {
+describe('annotator.config.configFuncSettingsFrom', () => {
   const sandbox = sinon.createSandbox();
 
-  afterEach('reset the sandbox', function () {
+  afterEach('reset the sandbox', () => {
     sandbox.restore();
   });
 
-  context("when there's no window.hypothesisConfig() function", function () {
-    it('returns {}', function () {
+  context("when there's no window.hypothesisConfig() function", () => {
+    it('returns {}', () => {
       const fakeWindow = {};
 
       assert.deepEqual(configFuncSettingsFrom(fakeWindow), {});
     });
   });
 
-  context("when window.hypothesisConfig() isn't a function", function () {
-    beforeEach('stub console.warn()', function () {
+  context("when window.hypothesisConfig() isn't a function", () => {
+    beforeEach('stub console.warn()', () => {
       sandbox.stub(console, 'warn');
     });
 
@@ -24,11 +24,11 @@ describe('annotator.config.configFuncSettingsFrom', function () {
       return { hypothesisConfig: 42 };
     }
 
-    it('returns {}', function () {
+    it('returns {}', () => {
       assert.deepEqual(configFuncSettingsFrom(fakeWindow()), {});
     });
 
-    it('logs a warning', function () {
+    it('logs a warning', () => {
       configFuncSettingsFrom(fakeWindow());
 
       assert.calledOnce(console.warn);
@@ -40,8 +40,8 @@ describe('annotator.config.configFuncSettingsFrom', function () {
     });
   });
 
-  context('when window.hypothesisConfig() is a function', function () {
-    it('returns whatever window.hypothesisConfig() returns', function () {
+  context('when window.hypothesisConfig() is a function', () => {
+    it('returns whatever window.hypothesisConfig() returns', () => {
       // It just blindly returns whatever hypothesisConfig() returns
       // (even if it's not an object).
       const fakeWindow = { hypothesisConfig: sinon.stub().returns(42) };

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -1,7 +1,7 @@
 import { getConfig } from '../index';
 import { $imports } from '../index';
 
-describe('annotator/config/index', function () {
+describe('annotator/config/index', () => {
   let fakeSettingsFrom;
   let fakeIsBrowserExtension;
 
@@ -34,7 +34,7 @@ describe('annotator/config/index', function () {
     $imports.$restore();
   });
 
-  it('gets the configuration settings', function () {
+  it('gets the configuration settings', () => {
     getConfig('all', 'WINDOW');
 
     assert.calledOnce(fakeSettingsFrom);
@@ -53,22 +53,22 @@ describe('annotator/config/index', function () {
     }
   );
 
-  context("when there's no application/annotator+html <link>", function () {
-    beforeEach('remove the application/annotator+html <link>', function () {
+  context("when there's no application/annotator+html <link>", () => {
+    beforeEach('remove the application/annotator+html <link>', () => {
       Object.defineProperty(fakeSettingsFrom(), 'sidebarAppUrl', {
         get: sinon.stub().throws(new Error("there's no link")),
       });
     });
 
-    it('throws an error', function () {
-      assert.throws(function () {
+    it('throws an error', () => {
+      assert.throws(() => {
         getConfig('all', 'WINDOW');
       }, "there's no link");
     });
   });
 
   describe('browser extension', () => {
-    context('when client is loaded from the browser extension', function () {
+    context('when client is loaded from the browser extension', () => {
       it('returns only config values where `allowInBrowserExt` is true or the defaultValue if provided', () => {
         fakeIsBrowserExtension.returns(true);
         const config = getConfig('all', 'WINDOW');
@@ -99,7 +99,7 @@ describe('annotator/config/index', function () {
       });
     });
 
-    context('when client is not loaded from browser extension', function () {
+    context('when client is not loaded from browser extension', () => {
       it('returns all config values', () => {
         fakeIsBrowserExtension.returns(false);
         const config = getConfig('all', 'WINDOW');
@@ -182,8 +182,8 @@ describe('annotator/config/index', function () {
   });
 
   ['branding', 'openSidebar', 'requestConfigFromFrame', 'services'].forEach(
-    function (settingName) {
-      it(`returns the ${settingName} value from the host page`, function () {
+    settingName => {
+      it(`returns the ${settingName} value from the host page`, () => {
         const settings = {
           branding: 'BRANDING_SETTING',
           openSidebar: true,

--- a/src/annotator/config/test/is-browser-extension-test.js
+++ b/src/annotator/config/test/is-browser-extension-test.js
@@ -1,6 +1,6 @@
 import { isBrowserExtension } from '../is-browser-extension';
 
-describe('annotator.config.isBrowserExtension', function () {
+describe('annotator.config.isBrowserExtension', () => {
   [
     {
       url: 'chrome-extension://abcxyz',
@@ -27,8 +27,8 @@ describe('annotator.config.isBrowserExtension', function () {
       url: 'ftp://partner.org',
       returns: true,
     },
-  ].forEach(function (test) {
-    it('returns ' + test.returns + ' for ' + test.url, function () {
+  ].forEach(test => {
+    it('returns ' + test.returns + ' for ' + test.url, () => {
       assert.equal(isBrowserExtension(test.url), test.returns);
     });
   });

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -133,7 +133,7 @@ describe('annotator/config/settingsFrom', () => {
         url: 'http://localhost:3000',
         returns: null,
       },
-    ].forEach(function (test) {
+    ].forEach(test => {
       describe(test.describe, () => {
         it(test.it, () => {
           assert.deepEqual(
@@ -237,7 +237,7 @@ describe('annotator/config/settingsFrom', () => {
         url: 'http://localhost:3000',
         returns: null,
       },
-    ].forEach(function (test) {
+    ].forEach(test => {
       describe(test.describe, () => {
         it(test.it, () => {
           assert.deepEqual(
@@ -323,7 +323,7 @@ describe('annotator/config/settingsFrom', () => {
         input: /regex/,
         output: /regex/,
       },
-    ].forEach(function (test) {
+    ].forEach(test => {
       it(test.it, () => {
         fakeParseJsonConfig.returns({
           showHighlights: test.input,
@@ -397,7 +397,7 @@ describe('annotator/config/settingsFrom', () => {
         jsonSettings: { foo: 'jsonValue' },
         expected: undefined,
       },
-    ].forEach(function (test) {
+    ].forEach(test => {
       context(test.when, () => {
         specify(test.specify, () => {
           fakeConfigFuncSettingsFrom.returns(test.configFuncSettings);

--- a/src/annotator/integrations/test/html-metadata-test.js
+++ b/src/annotator/integrations/test/html-metadata-test.js
@@ -328,7 +328,7 @@ describe('HTMLMetadata', () => {
       // created by a `<base>` tag.
       ['blob:1234', 'doi:foo'],
       ['chrome://foo', 'chrome://blah'],
-    ].forEach(function (...args) {
+    ].forEach((...args) => {
       const [href, baseURI] = Array.from(args[0]);
       it("should return the document's URL if it and the baseURI do not have an allowed scheme", () => {
         const doc = createDoc(href, baseURI);

--- a/src/annotator/integrations/test/pdf-metadata-test.js
+++ b/src/annotator/integrations/test/pdf-metadata-test.js
@@ -145,7 +145,7 @@ function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-describe('PDFMetadata', function () {
+describe('PDFMetadata', () => {
   [
     {
       // PDF.js < 1.6.210: `documentload` event dispatched via DOM.

--- a/src/annotator/range-util.js
+++ b/src/annotator/range-util.js
@@ -67,7 +67,7 @@ export function forEachNodeInRange(range, callback) {
 export function getTextBoundingBoxes(range) {
   const whitespaceOnly = /^\s*$/;
   const textNodes = [];
-  forEachNodeInRange(range, function (node) {
+  forEachNodeInRange(range, node => {
     if (
       node.nodeType === Node.TEXT_NODE &&
       !(/** @type {string} */ (node.textContent).match(whitespaceOnly))
@@ -77,7 +77,7 @@ export function getTextBoundingBoxes(range) {
   });
 
   let rects = [];
-  textNodes.forEach(function (node) {
+  textNodes.forEach(node => {
     const nodeRange = node.ownerDocument.createRange();
     nodeRange.selectNodeContents(node);
     if (node === range.startContainer) {

--- a/src/annotator/sidebar-trigger.js
+++ b/src/annotator/sidebar-trigger.js
@@ -13,7 +13,7 @@ export default function trigger(rootEl, showFn) {
     '[' + SIDEBAR_TRIGGER_BTN_ATTR + ']'
   );
 
-  Array.from(triggerElems).forEach(function (triggerElem) {
+  Array.from(triggerElems).forEach(triggerElem => {
     triggerElem.addEventListener('click', handleCommand);
   });
 

--- a/src/annotator/test/annotation-counts-test.js
+++ b/src/annotator/test/annotation-counts-test.js
@@ -1,13 +1,13 @@
 import annotationCounts from '../annotation-counts';
 
-describe('annotationCounts', function () {
+describe('annotationCounts', () => {
   let countEl1;
   let countEl2;
   let CrossFrame;
   let fakeCrossFrame;
   let sandbox;
 
-  beforeEach(function () {
+  beforeEach(() => {
     CrossFrame = null;
     fakeCrossFrame = {};
     sandbox = sinon.createSandbox();
@@ -26,13 +26,13 @@ describe('annotationCounts', function () {
     CrossFrame.returns(fakeCrossFrame);
   });
 
-  afterEach(function () {
+  afterEach(() => {
     sandbox.restore();
     countEl1.remove();
     countEl2.remove();
   });
 
-  describe('listen for "publicAnnotationCountChanged" event', function () {
+  describe('listen for "publicAnnotationCountChanged" event', () => {
     const emitEvent = function () {
       let crossFrameArgs;
       let evt;
@@ -53,7 +53,7 @@ describe('annotationCounts', function () {
       }
     };
 
-    it('displays the updated annotation count on the appropriate elements', function () {
+    it('displays the updated annotation count on the appropriate elements', () => {
       const newCount = 10;
       annotationCounts(document.body, fakeCrossFrame);
 

--- a/src/annotator/test/annotation-sync-test.js
+++ b/src/annotator/test/annotation-sync-test.js
@@ -2,14 +2,14 @@ import EventEmitter from 'tiny-emitter';
 
 import AnnotationSync from '../annotation-sync';
 
-describe('AnnotationSync', function () {
+describe('AnnotationSync', () => {
   let createAnnotationSync;
   let fakeBridge;
   let options;
   let publish;
   const sandbox = sinon.createSandbox();
 
-  beforeEach(function () {
+  beforeEach(() => {
     const emitter = new EventEmitter();
     const listeners = {};
 
@@ -18,7 +18,7 @@ describe('AnnotationSync', function () {
     };
 
     fakeBridge = {
-      on: sandbox.spy(function (method, fn) {
+      on: sandbox.spy((method, fn) => {
         listeners[method] = fn;
       }),
       call: sandbox.stub(),
@@ -39,24 +39,24 @@ describe('AnnotationSync', function () {
     };
   });
 
-  afterEach(function () {
+  afterEach(() => {
     sandbox.restore();
   });
 
-  describe('#constructor', function () {
-    context('when "deleteAnnotation" is published', function () {
-      it('calls emit("annotationDeleted")', function () {
+  describe('#constructor', () => {
+    context('when "deleteAnnotation" is published', () => {
+      it('calls emit("annotationDeleted")', () => {
         const ann = { id: 1, $tag: 'tag1' };
         const eventStub = sinon.stub();
         options.on('annotationDeleted', eventStub);
         createAnnotationSync();
 
-        publish('deleteAnnotation', { msg: ann }, function () {});
+        publish('deleteAnnotation', { msg: ann }, () => {});
 
         assert.calledWith(eventStub, ann);
       });
 
-      it("calls the 'deleteAnnotation' event's callback function", function (done) {
+      it("calls the 'deleteAnnotation' event's callback function", done => {
         const ann = { id: 1, $tag: 'tag1' };
         const callback = function (err, ret) {
           assert.isNull(err);
@@ -68,7 +68,7 @@ describe('AnnotationSync', function () {
         publish('deleteAnnotation', { msg: ann }, callback);
       });
 
-      it('deletes any existing annotation from its cache before calling emit', function () {
+      it('deletes any existing annotation from its cache before calling emit', () => {
         const ann = { id: 1, $tag: 'tag1' };
         const annSync = createAnnotationSync();
         annSync.cache.tag1 = ann;
@@ -76,22 +76,22 @@ describe('AnnotationSync', function () {
           assert(!annSync.cache.tag1);
         };
 
-        publish('deleteAnnotation', { msg: ann }, function () {});
+        publish('deleteAnnotation', { msg: ann }, () => {});
       });
 
-      it('deletes any existing annotation from its cache', function () {
+      it('deletes any existing annotation from its cache', () => {
         const ann = { id: 1, $tag: 'tag1' };
         const annSync = createAnnotationSync();
         annSync.cache.tag1 = ann;
 
-        publish('deleteAnnotation', { msg: ann }, function () {});
+        publish('deleteAnnotation', { msg: ann }, () => {});
 
         assert(!annSync.cache.tag1);
       });
     });
 
-    context('when "loadAnnotations" is published', function () {
-      it('calls emit("annotationsLoaded")', function () {
+    context('when "loadAnnotations" is published', () => {
+      it('calls emit("annotationsLoaded")', () => {
         const annotations = [
           { id: 1, $tag: 'tag1' },
           { id: 2, $tag: 'tag2' },
@@ -106,14 +106,14 @@ describe('AnnotationSync', function () {
         options.on('annotationsLoaded', loadedStub);
         createAnnotationSync();
 
-        publish('loadAnnotations', bodies, function () {});
+        publish('loadAnnotations', bodies, () => {});
 
         assert.calledWith(loadedStub, annotations);
       });
     });
 
-    context('when "beforeAnnotationCreated" is emitted', function () {
-      it('calls bridge.call() passing the event', function () {
+    context('when "beforeAnnotationCreated" is emitted', () => {
+      it('calls bridge.call() passing the event', () => {
         // nb. Setting an empty `$tag` here matches what `Guest#createAnnotation`
         // does.
         const ann = { id: 1, $tag: '' };
@@ -137,8 +137,8 @@ describe('AnnotationSync', function () {
         assert.notEmpty(ann.$tag);
       });
 
-      context('if the annotation already has a $tag', function () {
-        it('does not call bridge.call()', function () {
+      context('if the annotation already has a $tag', () => {
+        it('does not call bridge.call()', () => {
           const ann = { id: 1, $tag: 'tag1' };
           createAnnotationSync();
 

--- a/src/annotator/test/features-test.js
+++ b/src/annotator/test/features-test.js
@@ -2,7 +2,7 @@ import events from '../../shared/bridge-events';
 import features from '../features';
 import { $imports } from '../features';
 
-describe('features - annotation layer', function () {
+describe('features - annotation layer', () => {
   let featureFlagsUpdateHandler;
   let fakeWarnOnce;
 
@@ -15,7 +15,7 @@ describe('features - annotation layer', function () {
     featureFlagsUpdateHandler(features || initialFeatures);
   };
 
-  beforeEach(function () {
+  beforeEach(() => {
     fakeWarnOnce = sinon.stub();
     $imports.$mock({
       '../shared/warn-once': fakeWarnOnce,
@@ -33,28 +33,28 @@ describe('features - annotation layer', function () {
     setFeatures();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     features.reset();
     $imports.$restore();
   });
 
-  describe('flagEnabled', function () {
-    it('should retrieve features data', function () {
+  describe('flagEnabled', () => {
+    it('should retrieve features data', () => {
       assert.equal(features.flagEnabled('feature_on'), true);
       assert.equal(features.flagEnabled('feature_off'), false);
     });
 
-    it('should return false if features have not been loaded', function () {
+    it('should return false if features have not been loaded', () => {
       // simulate feature data not having been loaded yet
       features.reset();
       assert.equal(features.flagEnabled('feature_on'), false);
     });
 
-    it('should return false for unknown flags', function () {
+    it('should return false for unknown flags', () => {
       assert.isFalse(features.flagEnabled('unknown_feature'));
     });
 
-    it('should warn when accessing unknown flags', function () {
+    it('should warn when accessing unknown flags', () => {
       assert.isFalse(features.flagEnabled('unknown_feature'));
       assert.calledOnce(fakeWarnOnce);
       assert.calledWith(fakeWarnOnce, 'looked up unknown feature');

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -30,7 +30,7 @@ function annotateQuote(quote) {
  */
 function highlightedPhrases(container) {
   return Array.from(container.querySelectorAll('.hypothesis-highlight')).map(
-    function (el) {
+    el => {
       return el.textContent;
     }
   );
@@ -47,7 +47,7 @@ function FakeCrossFrame() {
   this.sync = sinon.stub();
 }
 
-describe('anchoring', function () {
+describe('anchoring', () => {
   let guest;
   let container;
 
@@ -92,20 +92,20 @@ describe('anchoring', function () {
   ].forEach(testCase => {
     it(`should highlight ${testCase.tag} when annotations are loaded`, () => {
       const normalize = function (quotes) {
-        return quotes.map(function (q) {
+        return quotes.map(q => {
           return simplifyWhitespace(q);
         });
       };
 
-      const annotations = testCase.quotes.map(function (q) {
+      const annotations = testCase.quotes.map(q => {
         return annotateQuote(q);
       });
 
-      const anchored = annotations.map(function (ann) {
+      const anchored = annotations.map(ann => {
         return guest.anchor(ann);
       });
 
-      return Promise.all(anchored).then(function () {
+      return Promise.all(anchored).then(() => {
         const assertFn = testCase.expectFail
           ? assert.notDeepEqual
           : assert.deepEqual;

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -2,7 +2,7 @@ import { DEBOUNCE_WAIT } from '../../frame-observer';
 import { CrossFrame, $imports } from '../../cross-frame';
 import { isLoaded } from '../../util/frame-util';
 
-describe('CrossFrame multi-frame scenario', function () {
+describe('CrossFrame multi-frame scenario', () => {
   let fakeAnnotationSync;
   let fakeBridge;
   let proxyAnnotationSync;
@@ -18,7 +18,7 @@ describe('CrossFrame multi-frame scenario', function () {
     return setTimeout(cb, wait);
   };
 
-  beforeEach(function () {
+  beforeEach(() => {
     fakeBridge = {
       createChannel: sandbox.stub(),
       call: sandbox.stub(),
@@ -47,7 +47,7 @@ describe('CrossFrame multi-frame scenario', function () {
     crossFrame = null;
   });
 
-  afterEach(function () {
+  afterEach(() => {
     sandbox.restore();
     crossFrame.destroy();
     container.parentNode.removeChild(container);
@@ -59,7 +59,7 @@ describe('CrossFrame multi-frame scenario', function () {
     return new CrossFrame(container, options);
   }
 
-  it('detects frames on page', function () {
+  it('detects frames on page', () => {
     // Create a frame before initializing
     const validFrame = document.createElement('iframe');
     validFrame.setAttribute('enable-annotation', '');
@@ -74,8 +74,8 @@ describe('CrossFrame multi-frame scenario', function () {
     // Now initialize
     crossFrame = createCrossFrame();
 
-    const validFramePromise = new Promise(function (resolve) {
-      isLoaded(validFrame, function () {
+    const validFramePromise = new Promise(resolve => {
+      isLoaded(validFrame, () => {
         assert(
           validFrame.contentDocument.body.hasChildNodes(),
           'expected valid frame to be modified'
@@ -83,8 +83,8 @@ describe('CrossFrame multi-frame scenario', function () {
         resolve();
       });
     });
-    const invalidFramePromise = new Promise(function (resolve) {
-      isLoaded(invalidFrame, function () {
+    const invalidFramePromise = new Promise(resolve => {
+      isLoaded(invalidFrame, () => {
         assert(
           !invalidFrame.contentDocument.body.hasChildNodes(),
           'expected invalid frame to not be modified'
@@ -96,7 +96,7 @@ describe('CrossFrame multi-frame scenario', function () {
     return Promise.all([validFramePromise, invalidFramePromise]);
   });
 
-  it('detects removed frames', function () {
+  it('detects removed frames', () => {
     // Create a frame before initializing
     const frame = document.createElement('iframe');
     frame.setAttribute('enable-annotation', '');
@@ -111,15 +111,15 @@ describe('CrossFrame multi-frame scenario', function () {
     assert.calledWith(fakeBridge.call, 'destroyFrame');
   });
 
-  it('injects embed script in frame', function () {
+  it('injects embed script in frame', () => {
     const frame = document.createElement('iframe');
     frame.setAttribute('enable-annotation', '');
     container.appendChild(frame);
 
     crossFrame = createCrossFrame();
 
-    return new Promise(function (resolve) {
-      isLoaded(frame, function () {
+    return new Promise(resolve => {
+      isLoaded(frame, () => {
         const scriptElement =
           frame.contentDocument.querySelector('script[src]');
         assert(scriptElement, 'expected embed script to be injected');
@@ -133,7 +133,7 @@ describe('CrossFrame multi-frame scenario', function () {
     });
   });
 
-  it('excludes injection from already injected frames', function () {
+  it('excludes injection from already injected frames', () => {
     const frame = document.createElement('iframe');
     frame.setAttribute('enable-annotation', '');
     container.appendChild(frame);
@@ -141,8 +141,8 @@ describe('CrossFrame multi-frame scenario', function () {
 
     crossFrame = createCrossFrame();
 
-    return new Promise(function (resolve) {
-      isLoaded(frame, function () {
+    return new Promise(resolve => {
+      isLoaded(frame, () => {
         const scriptElement =
           frame.contentDocument.querySelector('script[src]');
         assert.isNull(
@@ -154,7 +154,7 @@ describe('CrossFrame multi-frame scenario', function () {
     });
   });
 
-  it('detects dynamically added frames', function () {
+  it('detects dynamically added frames', () => {
     // Initialize with no initial frame, unlike before
     crossFrame = createCrossFrame();
 
@@ -163,10 +163,10 @@ describe('CrossFrame multi-frame scenario', function () {
     frame.setAttribute('enable-annotation', '');
     container.appendChild(frame);
 
-    return new Promise(function (resolve) {
+    return new Promise(resolve => {
       // Yield to let the DOM and CrossFrame catch up
-      waitForFrameObserver(function () {
-        isLoaded(frame, function () {
+      waitForFrameObserver(() => {
+        isLoaded(frame, () => {
           assert(
             frame.contentDocument.body.hasChildNodes(),
             'expected dynamically added frame to be modified'
@@ -177,7 +177,7 @@ describe('CrossFrame multi-frame scenario', function () {
     });
   });
 
-  it('detects dynamically removed frames', function () {
+  it('detects dynamically removed frames', () => {
     // Create a frame before initializing
     const frame = document.createElement('iframe');
     frame.setAttribute('enable-annotation', '');
@@ -186,13 +186,13 @@ describe('CrossFrame multi-frame scenario', function () {
     // Now initialize
     crossFrame = createCrossFrame();
 
-    return new Promise(function (resolve) {
+    return new Promise(resolve => {
       // Yield to let the DOM and CrossFrame catch up
-      waitForFrameObserver(function () {
+      waitForFrameObserver(() => {
         frame.remove();
 
         // Yield again
-        waitForFrameObserver(function () {
+        waitForFrameObserver(() => {
           assert.calledWith(fakeBridge.call, 'destroyFrame');
           resolve();
         });
@@ -200,7 +200,7 @@ describe('CrossFrame multi-frame scenario', function () {
     });
   });
 
-  it('detects a frame dynamically removed, and added again', function () {
+  it('detects a frame dynamically removed, and added again', () => {
     // Create a frame before initializing
     const frame = document.createElement('iframe');
     frame.setAttribute('enable-annotation', '');
@@ -209,8 +209,8 @@ describe('CrossFrame multi-frame scenario', function () {
     // Now initialize
     crossFrame = createCrossFrame();
 
-    return new Promise(function (resolve) {
-      isLoaded(frame, function () {
+    return new Promise(resolve => {
+      isLoaded(frame, () => {
         assert(
           frame.contentDocument.body.hasChildNodes(),
           'expected initial frame to be modified'
@@ -219,13 +219,13 @@ describe('CrossFrame multi-frame scenario', function () {
         frame.remove();
 
         // Yield to let the DOM and CrossFrame catch up
-        waitForFrameObserver(function () {
+        waitForFrameObserver(() => {
           // Add the frame again
           container.appendChild(frame);
 
           // Yield again
-          waitForFrameObserver(function () {
-            isLoaded(frame, function () {
+          waitForFrameObserver(() => {
+            isLoaded(frame, () => {
               assert(
                 frame.contentDocument.body.hasChildNodes(),
                 'expected dynamically added frame to be modified'
@@ -238,7 +238,7 @@ describe('CrossFrame multi-frame scenario', function () {
     });
   });
 
-  it('detects a frame dynamically added, removed, and added again', function () {
+  it('detects a frame dynamically added, removed, and added again', () => {
     // Initialize with no initial frame
     crossFrame = createCrossFrame();
 
@@ -247,10 +247,10 @@ describe('CrossFrame multi-frame scenario', function () {
     frame.setAttribute('enable-annotation', '');
     container.appendChild(frame);
 
-    return new Promise(function (resolve) {
+    return new Promise(resolve => {
       // Yield to let the DOM and CrossFrame catch up
-      waitForFrameObserver(function () {
-        isLoaded(frame, function () {
+      waitForFrameObserver(() => {
+        isLoaded(frame, () => {
           assert(
             frame.contentDocument.body.hasChildNodes(),
             'expected dynamically added frame to be modified'
@@ -259,13 +259,13 @@ describe('CrossFrame multi-frame scenario', function () {
           frame.remove();
 
           // Yield again
-          waitForFrameObserver(function () {
+          waitForFrameObserver(() => {
             // Add the frame again
             container.appendChild(frame);
 
             // Yield
-            waitForFrameObserver(function () {
-              isLoaded(frame, function () {
+            waitForFrameObserver(() => {
+              isLoaded(frame, () => {
                 assert(
                   frame.contentDocument.body.hasChildNodes(),
                   'expected dynamically added frame to be modified'

--- a/src/annotator/test/range-util-test.js
+++ b/src/annotator/test/range-util-test.js
@@ -21,11 +21,11 @@ function roundCoords(rect) {
   };
 }
 
-describe('annotator.range-util', function () {
+describe('annotator.range-util', () => {
   let selection;
   let testNode;
 
-  beforeEach(function () {
+  beforeEach(() => {
     selection = window.getSelection();
     selection.collapse(null);
 
@@ -34,7 +34,7 @@ describe('annotator.range-util', function () {
     document.body.appendChild(testNode);
   });
 
-  afterEach(function () {
+  afterEach(() => {
     testNode.parentElement.removeChild(testNode);
   });
 
@@ -79,15 +79,15 @@ describe('annotator.range-util', function () {
     });
   });
 
-  describe('#getTextBoundingBoxes', function () {
-    it('gets the bounding box of a range in a text node', function () {
+  describe('#getTextBoundingBoxes', () => {
+    it('gets the bounding box of a range in a text node', () => {
       testNode.innerHTML = 'plain text';
       const rng = createRange(testNode.firstChild, 0, 5);
       const boxes = rangeUtil.getTextBoundingBoxes(rng);
       assert.ok(boxes.length);
     });
 
-    it('gets the bounding box of a range containing a text node', function () {
+    it('gets the bounding box of a range containing a text node', () => {
       testNode.innerHTML = 'plain text';
       const rng = createRange(testNode, 0, 1);
 
@@ -105,7 +105,7 @@ describe('annotator.range-util', function () {
       ]);
     });
 
-    it('returns the bounding box in viewport coordinates', function () {
+    it('returns the bounding box in viewport coordinates', () => {
       testNode.innerHTML = 'plain text';
       const rng = createRange(testNode, 0, 1);
 
@@ -118,17 +118,17 @@ describe('annotator.range-util', function () {
     });
   });
 
-  describe('#selectionFocusRect', function () {
-    it('returns null if the selection is empty', function () {
+  describe('#selectionFocusRect', () => {
+    it('returns null if the selection is empty', () => {
       assert.isNull(rangeUtil.selectionFocusRect(selection));
     });
 
-    it('returns a point if the selection is not empty', function () {
+    it('returns a point if the selection is not empty', () => {
       selectNode(testNode);
       assert.ok(rangeUtil.selectionFocusRect(selection));
     });
 
-    it("returns the first line's rect if the selection is backwards", function () {
+    it("returns the first line's rect if the selection is backwards", () => {
       selectNode(testNode);
       selection.collapseToEnd();
       selection.extend(testNode, 0);
@@ -137,7 +137,7 @@ describe('annotator.range-util', function () {
       assert.equal(rect.top, testNode.offsetTop);
     });
 
-    it("returns the last line's rect if the selection is forwards", function () {
+    it("returns the last line's rect if the selection is forwards", () => {
       selectNode(testNode);
       const rect = rangeUtil.selectionFocusRect(selection);
       assert.equal(rect.left, testNode.offsetLeft);

--- a/src/annotator/test/sidebar-trigger-test.js
+++ b/src/annotator/test/sidebar-trigger-test.js
@@ -1,10 +1,10 @@
 import sidebarTrigger from '../sidebar-trigger';
 
-describe('sidebarTrigger', function () {
+describe('sidebarTrigger', () => {
   let triggerEl1;
   let triggerEl2;
 
-  beforeEach(function () {
+  beforeEach(() => {
     triggerEl1 = document.createElement('button');
     triggerEl1.setAttribute('data-hypothesis-trigger', '');
     document.body.appendChild(triggerEl1);
@@ -14,7 +14,7 @@ describe('sidebarTrigger', function () {
     document.body.appendChild(triggerEl2);
   });
 
-  it('calls the show callback which a trigger button is clicked', function () {
+  it('calls the show callback which a trigger button is clicked', () => {
     const fakeShowFn = sinon.stub();
     sidebarTrigger(document, fakeShowFn);
 

--- a/src/annotator/util/frame-util.js
+++ b/src/annotator/util/frame-util.js
@@ -48,7 +48,7 @@ export function isAccessible(iframe) {
 
 export function isDocumentReady(iframe, callback) {
   if (iframe.contentDocument.readyState === 'loading') {
-    iframe.contentDocument.addEventListener('DOMContentLoaded', function () {
+    iframe.contentDocument.addEventListener('DOMContentLoaded', () => {
       callback();
     });
   } else {
@@ -58,7 +58,7 @@ export function isDocumentReady(iframe, callback) {
 
 export function isLoaded(iframe, callback) {
   if (iframe.contentDocument.readyState !== 'complete') {
-    iframe.addEventListener('load', function () {
+    iframe.addEventListener('load', () => {
       callback();
     });
   } else {

--- a/src/annotator/util/test/frame-util-test.js
+++ b/src/annotator/util/test/frame-util-test.js
@@ -1,7 +1,7 @@
 import * as frameUtil from '../frame-util';
 
-describe('annotator/util/frame-util', function () {
-  describe('findFrames', function () {
+describe('annotator/util/frame-util', () => {
+  describe('findFrames', () => {
     let container;
 
     const _addFrameToContainer = (options = {}) => {
@@ -14,16 +14,16 @@ describe('annotator/util/frame-util', function () {
       return frame;
     };
 
-    beforeEach(function () {
+    beforeEach(() => {
       container = document.createElement('div');
       document.body.appendChild(container);
     });
 
-    afterEach(function () {
+    afterEach(() => {
       container.remove();
     });
 
-    it('should return valid frames', function () {
+    it('should return valid frames', () => {
       let foundFrames = frameUtil.findFrames(container);
 
       assert.lengthOf(

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -114,7 +114,7 @@ function preloadUrl(doc, type, url) {
  * @param {string[]} assets
  */
 function injectAssets(doc, config, assets) {
-  assets.forEach(function (path) {
+  assets.forEach(path => {
     const url = config.assetRoot + 'build/' + config.manifest[path];
     if (url.match(/\.css/)) {
       injectStylesheet(doc, url);

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -5,11 +5,11 @@ function assetUrl(url) {
   return `https://marginal.ly/client/build/${url}`;
 }
 
-describe('bootstrap', function () {
+describe('bootstrap', () => {
   let fakePolyfills;
   let iframe;
 
-  beforeEach(function () {
+  beforeEach(() => {
     iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
 
@@ -22,7 +22,7 @@ describe('bootstrap', function () {
     });
   });
 
-  afterEach(function () {
+  afterEach(() => {
     $imports.$restore();
     iframe.remove();
   });
@@ -47,7 +47,7 @@ describe('bootstrap', function () {
       'styles/sidebar.css',
     ];
 
-    const manifest = assetNames.reduce(function (manifest, path) {
+    const manifest = assetNames.reduce((manifest, path) => {
       const url = path.replace(/\.([a-z]+)$/, '.1234.$1');
       manifest[path] = url;
       return manifest;
@@ -73,21 +73,21 @@ describe('bootstrap', function () {
   function findAssets(doc_) {
     const scripts = Array.from(
       doc_.querySelectorAll('script[data-hypothesis-asset]')
-    ).map(function (el) {
+    ).map(el => {
       return el.src;
     });
 
     const styles = Array.from(
       doc_.querySelectorAll('link[rel="stylesheet"][data-hypothesis-asset]')
-    ).map(function (el) {
+    ).map(el => {
       return el.href;
     });
 
     return scripts.concat(styles).sort();
   }
 
-  describe('bootHypothesisClient', function () {
-    it('loads assets for the annotation layer', function () {
+  describe('bootHypothesisClient', () => {
+    it('loads assets for the annotation layer', () => {
       runBoot('annotator');
       const expectedAssets = [
         'scripts/annotator.bundle.1234.js',
@@ -98,7 +98,7 @@ describe('bootstrap', function () {
       assert.deepEqual(findAssets(iframe.contentDocument), expectedAssets);
     });
 
-    it('creates the link to the sidebar iframe', function () {
+    it('creates the link to the sidebar iframe', () => {
       runBoot('annotator');
 
       const sidebarAppLink = iframe.contentDocument.querySelector(
@@ -109,7 +109,7 @@ describe('bootstrap', function () {
       assert.equal(sidebarAppLink.href, 'https://marginal.ly/app.html');
     });
 
-    it('does nothing if Hypothesis is already loaded in the document', function () {
+    it('does nothing if Hypothesis is already loaded in the document', () => {
       const link = iframe.contentDocument.createElement('link');
       link.type = 'application/annotator+html';
       iframe.contentDocument.head.appendChild(link);
@@ -136,8 +136,8 @@ describe('bootstrap', function () {
     });
   });
 
-  describe('bootSidebarApp', function () {
-    it('loads assets for the sidebar application', function () {
+  describe('bootSidebarApp', () => {
+    it('loads assets for the sidebar application', () => {
       runBoot('sidebar');
       const expectedAssets = [
         'scripts/katex.bundle.1234.js',

--- a/src/boot/test/parse-json-config-test.js
+++ b/src/boot/test/parse-json-config-test.js
@@ -1,6 +1,6 @@
 import { parseJsonConfig } from '../parse-json-config';
 
-describe('#parseJsonConfig', function () {
+describe('#parseJsonConfig', () => {
   const sandbox = sinon.createSandbox();
 
   function appendJSHypothesisConfig(document_, jsonString) {
@@ -12,7 +12,7 @@ describe('#parseJsonConfig', function () {
     document_.body.appendChild(el);
   }
 
-  afterEach(function () {
+  afterEach(() => {
     // Remove test config scripts.
     const elements = document.querySelectorAll('.js-settings-test');
     for (let i = 0; i < elements.length; i++) {
@@ -22,98 +22,98 @@ describe('#parseJsonConfig', function () {
     sandbox.restore();
   });
 
-  context('when there are no JSON scripts', function () {
-    it('returns {}', function () {
+  context('when there are no JSON scripts', () => {
+    it('returns {}', () => {
       assert.deepEqual(parseJsonConfig(document), {});
     });
   });
 
-  context("when there's JSON scripts with no top-level objects", function () {
-    beforeEach('add JSON scripts with no top-level objects', function () {
+  context("when there's JSON scripts with no top-level objects", () => {
+    beforeEach('add JSON scripts with no top-level objects', () => {
       appendJSHypothesisConfig(document, 'null');
       appendJSHypothesisConfig(document, '23');
       appendJSHypothesisConfig(document, 'true');
     });
 
-    it('ignores them', function () {
+    it('ignores them', () => {
       assert.deepEqual(parseJsonConfig(document), {});
     });
   });
 
-  context("when there's a JSON script with a top-level array", function () {
-    beforeEach('add a JSON script containing a top-level array', function () {
+  context("when there's a JSON script with a top-level array", () => {
+    beforeEach('add a JSON script containing a top-level array', () => {
       appendJSHypothesisConfig(document, '["a", "b", "c"]');
     });
 
-    it('returns the array, parsed into an object', function () {
+    it('returns the array, parsed into an object', () => {
       assert.deepEqual(parseJsonConfig(document), { 0: 'a', 1: 'b', 2: 'c' });
     });
   });
 
-  context("when there's a JSON script with a top-level string", function () {
-    beforeEach('add a JSON script with a top-level string', function () {
+  context("when there's a JSON script with a top-level string", () => {
+    beforeEach('add a JSON script with a top-level string', () => {
       appendJSHypothesisConfig(document, '"hi"');
     });
 
-    it('returns the string, parsed into an object', function () {
+    it('returns the string, parsed into an object', () => {
       assert.deepEqual(parseJsonConfig(document), { 0: 'h', 1: 'i' });
     });
   });
 
-  context("when there's a JSON script containing invalid JSON", function () {
-    beforeEach('stub console.warn()', function () {
+  context("when there's a JSON script containing invalid JSON", () => {
+    beforeEach('stub console.warn()', () => {
       sandbox.stub(console, 'warn');
     });
 
-    beforeEach('add a JSON script containing invalid JSON', function () {
+    beforeEach('add a JSON script containing invalid JSON', () => {
       appendJSHypothesisConfig(document, 'this is not valid json');
     });
 
-    it('logs a warning', function () {
+    it('logs a warning', () => {
       parseJsonConfig(document);
 
       assert.called(console.warn);
     });
 
-    it('returns {}', function () {
+    it('returns {}', () => {
       assert.deepEqual(parseJsonConfig(document), {});
     });
 
-    it('still returns settings from other JSON scripts', function () {
+    it('still returns settings from other JSON scripts', () => {
       appendJSHypothesisConfig(document, '{"foo": "FOO", "bar": "BAR"}');
 
       assert.deepEqual(parseJsonConfig(document), { foo: 'FOO', bar: 'BAR' });
     });
   });
 
-  context("when there's a JSON script with an empty object", function () {
-    beforeEach('add a JSON script containing an empty object', function () {
+  context("when there's a JSON script with an empty object", () => {
+    beforeEach('add a JSON script containing an empty object', () => {
       appendJSHypothesisConfig(document, '{}');
     });
 
-    it('ignores it', function () {
+    it('ignores it', () => {
       assert.deepEqual(parseJsonConfig(document), {});
     });
   });
 
-  context("when there's a JSON script containing some settings", function () {
-    beforeEach('add a JSON script containing some settings', function () {
+  context("when there's a JSON script containing some settings", () => {
+    beforeEach('add a JSON script containing some settings', () => {
       appendJSHypothesisConfig(document, '{"foo": "FOO", "bar": "BAR"}');
     });
 
-    it('returns the settings', function () {
+    it('returns the settings', () => {
       assert.deepEqual(parseJsonConfig(document), { foo: 'FOO', bar: 'BAR' });
     });
   });
 
-  context('when there are JSON scripts with different settings', function () {
-    beforeEach('add some JSON scripts with different settings', function () {
+  context('when there are JSON scripts with different settings', () => {
+    beforeEach('add some JSON scripts with different settings', () => {
       appendJSHypothesisConfig(document, '{"foo": "FOO"}');
       appendJSHypothesisConfig(document, '{"bar": "BAR"}');
       appendJSHypothesisConfig(document, '{"gar": "GAR"}');
     });
 
-    it('merges them all into one returned object', function () {
+    it('merges them all into one returned object', () => {
       assert.deepEqual(parseJsonConfig(document), {
         foo: 'FOO',
         bar: 'BAR',
@@ -122,8 +122,8 @@ describe('#parseJsonConfig', function () {
     });
   });
 
-  context('when multiple JSON scripts contain the same setting', function () {
-    beforeEach('add some JSON scripts with different settings', function () {
+  context('when multiple JSON scripts contain the same setting', () => {
+    beforeEach('add some JSON scripts with different settings', () => {
       appendJSHypothesisConfig(document, '{"foo": "first"}');
       appendJSHypothesisConfig(document, '{"foo": "second"}');
       appendJSHypothesisConfig(document, '{"foo": "third"}');
@@ -131,7 +131,7 @@ describe('#parseJsonConfig', function () {
 
     specify(
       'settings from later in the page override ones from earlier',
-      function () {
+      () => {
         assert.equal(parseJsonConfig(document).foo, 'third');
       }
     );

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -98,22 +98,18 @@ export default class Bridge {
       };
     };
 
-    const promises = this.links.map(function (l) {
-      const p = new Promise(function (resolve, reject) {
+    const promises = this.links.map(l => {
+      const p = new Promise((resolve, reject) => {
         const timeout = setTimeout(() => resolve(null), 1000);
         try {
-          return l.channel.call(
-            method,
-            ...Array.from(args),
-            function (err, result) {
-              clearTimeout(timeout);
-              if (err) {
-                return reject(err);
-              } else {
-                return resolve(result);
-              }
+          return l.channel.call(method, ...Array.from(args), (err, result) => {
+            clearTimeout(timeout);
+            if (err) {
+              return reject(err);
+            } else {
+              return resolve(result);
             }
-          );
+          });
         } catch (error) {
           const err = error;
           return reject(err);

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -1,7 +1,7 @@
 import Bridge from '../bridge';
 import { RPC } from '../frame-rpc';
 
-describe('shared/bridge', function () {
+describe('shared/bridge', () => {
   const sandbox = sinon.createSandbox();
   let bridge;
   let createChannel;
@@ -23,15 +23,15 @@ describe('shared/bridge', function () {
 
   afterEach(() => sandbox.restore());
 
-  describe('#createChannel', function () {
-    it('creates a new channel with the provided options', function () {
+  describe('#createChannel', () => {
+    it('creates a new channel with the provided options', () => {
       const channel = createChannel();
       assert.equal(channel.sourceFrame, window);
       assert.equal(channel.destFrame, fakeWindow);
       assert.equal(channel.origin, 'http://example.com');
     });
 
-    it('adds the channel to the .links property', function () {
+    it('adds the channel to the .links property', () => {
       const channel = createChannel();
       assert.isTrue(
         bridge.links.some(
@@ -40,7 +40,7 @@ describe('shared/bridge', function () {
       );
     });
 
-    it('registers any existing listeners on the channel', function () {
+    it('registers any existing listeners on the channel', () => {
       const message1 = sandbox.spy();
       const message2 = sandbox.spy();
       bridge.on('message1', message1);
@@ -50,14 +50,14 @@ describe('shared/bridge', function () {
       assert.propertyVal(channel._methods, 'message2', message2);
     });
 
-    it('returns the newly created channel', function () {
+    it('returns the newly created channel', () => {
       const channel = createChannel();
       assert.instanceOf(channel, RPC);
     });
   });
 
-  describe('#call', function () {
-    it('forwards the call to every created channel', function () {
+  describe('#call', () => {
+    it('forwards the call to every created channel', () => {
       const channel = createChannel();
       sandbox.stub(channel, 'call');
       bridge.call('method1', 'params1');
@@ -65,14 +65,14 @@ describe('shared/bridge', function () {
       assert.calledWith(channel.call, 'method1', 'params1');
     });
 
-    it('provides a timeout', function (done) {
+    it('provides a timeout', done => {
       const channel = createChannel();
       sandbox.stub(channel, 'call');
       sandbox.stub(window, 'setTimeout').yields();
       bridge.call('method1', 'params1', done);
     });
 
-    it('calls a callback when all channels return successfully', function (done) {
+    it('calls a callback when all channels return successfully', done => {
       const channel1 = createChannel();
       const channel2 = bridge.createChannel(
         fakeWindow,
@@ -91,7 +91,7 @@ describe('shared/bridge', function () {
       bridge.call('method1', 'params1', callback);
     });
 
-    it('calls a callback with an error when a channels fails', function (done) {
+    it('calls a callback with an error when a channels fails', done => {
       const error = new Error('Uh oh');
       const channel1 = createChannel();
       const channel2 = bridge.createChannel(
@@ -110,7 +110,7 @@ describe('shared/bridge', function () {
       bridge.call('method1', 'params1', callback);
     });
 
-    it('destroys the channel when a call fails', function (done) {
+    it('destroys the channel when a call fails', done => {
       const channel = createChannel();
       sandbox.stub(channel, 'call').throws(new Error(''));
       sandbox.stub(channel, 'destroy');
@@ -123,59 +123,59 @@ describe('shared/bridge', function () {
       bridge.call('method1', 'params1', callback);
     });
 
-    it('no longer publishes to a channel that has had an error', function (done) {
+    it('no longer publishes to a channel that has had an error', done => {
       const channel = createChannel();
       sandbox.stub(channel, 'call').throws(new Error('oeunth'));
-      bridge.call('method1', 'params1', function () {
+      bridge.call('method1', 'params1', () => {
         assert.calledOnce(channel.call);
-        bridge.call('method1', 'params1', function () {
+        bridge.call('method1', 'params1', () => {
           assert.calledOnce(channel.call);
           done();
         });
       });
     });
 
-    it('treats a timeout as a success with no result', function (done) {
+    it('treats a timeout as a success with no result', done => {
       const channel = createChannel();
       sandbox.stub(channel, 'call');
       sandbox.stub(window, 'setTimeout').yields();
-      bridge.call('method1', 'params1', function (err, res) {
+      bridge.call('method1', 'params1', (err, res) => {
         assert.isNull(err);
         assert.deepEqual(res, [null]);
         done();
       });
     });
 
-    it('returns a promise object', function () {
+    it('returns a promise object', () => {
       createChannel();
       const ret = bridge.call('method1', 'params1');
       assert.instanceOf(ret, Promise);
     });
   });
 
-  describe('#on', function () {
-    it('adds a method to the method registry', function () {
+  describe('#on', () => {
+    it('adds a method to the method registry', () => {
       createChannel();
       bridge.on('message1', sandbox.spy());
       assert.isFunction(bridge.channelListeners.message1);
     });
 
-    it('only allows registering a method once', function () {
+    it('only allows registering a method once', () => {
       bridge.on('message1', sandbox.spy());
       assert.throws(() => bridge.on('message1', sandbox.spy()));
     });
   });
 
   describe('#off', () =>
-    it('removes the method from the method registry', function () {
+    it('removes the method from the method registry', () => {
       createChannel();
       bridge.on('message1', sandbox.spy());
       bridge.off('message1');
       assert.isUndefined(bridge.channelListeners.message1);
     }));
 
-  describe('#onConnect', function () {
-    it('adds a callback that is called when a channel is connected', function (done) {
+  describe('#onConnect', () => {
+    it('adds a callback that is called when a channel is connected', done => {
       let channel;
       const callback = function (c, s) {
         assert.strictEqual(c, channel);
@@ -200,7 +200,7 @@ describe('shared/bridge', function () {
       channel = createChannel();
     });
 
-    it('allows multiple callbacks to be registered', function (done) {
+    it('allows multiple callbacks to be registered', done => {
       let channel;
       let callbackCount = 0;
       const callback = (c, s) => {
@@ -231,7 +231,7 @@ describe('shared/bridge', function () {
   });
 
   describe('#destroy', () =>
-    it('destroys all opened channels', function () {
+    it('destroys all opened channels', () => {
       const channel1 = bridge.createChannel(
         fakeWindow,
         'http://example.com',

--- a/src/sidebar/components/test/AutocompletList-test.js
+++ b/src/sidebar/components/test/AutocompletList-test.js
@@ -6,7 +6,7 @@ import { $imports } from '../AutocompleteList';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('AutocompleteList', function () {
+describe('AutocompleteList', () => {
   let fakeList;
   let fakeOnSelectItem;
   let fakeListFormatter;
@@ -20,7 +20,7 @@ describe('AutocompleteList', function () {
     );
   }
 
-  beforeEach(function () {
+  beforeEach(() => {
     fakeList = ['tag1', 'tag2'];
     fakeOnSelectItem = sinon.stub();
     fakeListFormatter = sinon.stub();

--- a/src/sidebar/components/test/HelpPanel-test.js
+++ b/src/sidebar/components/test/HelpPanel-test.js
@@ -7,7 +7,7 @@ import { $imports } from '../HelpPanel';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('HelpPanel', function () {
+describe('HelpPanel', () => {
   let fakeAuth;
   let fakeSessionService;
   let fakeStore;

--- a/src/sidebar/components/test/LoginPromptPanel-test.js
+++ b/src/sidebar/components/test/LoginPromptPanel-test.js
@@ -6,7 +6,7 @@ import { $imports } from '../LoginPromptPanel';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('LoginPromptPanel', function () {
+describe('LoginPromptPanel', () => {
   let fakeOnLogin;
   let fakeOnSignUp;
 

--- a/src/sidebar/components/test/ModerationBanner-test.js
+++ b/src/sidebar/components/test/ModerationBanner-test.js
@@ -95,13 +95,13 @@ describe('ModerationBanner', () => {
     });
   });
 
-  it('displays the number of flags the annotation has received', function () {
+  it('displays the number of flags the annotation has received', () => {
     const ann = fixtures.moderatedAnnotation({ flagCount: 10 });
     const wrapper = createComponent({ annotation: ann });
     assert.include(wrapper.text(), 'Flagged for review x10');
   });
 
-  it('displays in a more compact form if the annotation is a reply', function () {
+  it('displays in a more compact form if the annotation is a reply', () => {
     const wrapper = createComponent({
       annotation: {
         ...fixtures.oldReply(),
@@ -113,7 +113,7 @@ describe('ModerationBanner', () => {
     wrapper.exists('.is-reply');
   });
 
-  it('does not display in a more compact form if the annotation is not a reply', function () {
+  it('does not display in a more compact form if the annotation is not a reply', () => {
     const wrapper = createComponent({
       annotation: {
         ...fixtures.moderatedAnnotation({}),
@@ -125,7 +125,7 @@ describe('ModerationBanner', () => {
     assert.isFalse(wrapper.exists('.is-reply'));
   });
 
-  it('reports if the annotation was hidden', function () {
+  it('reports if the annotation was hidden', () => {
     const wrapper = createComponent({
       annotation: fixtures.moderatedAnnotation({
         flagCount: 1,
@@ -135,7 +135,7 @@ describe('ModerationBanner', () => {
     assert.include(wrapper.text(), 'Hidden from users');
   });
 
-  it('hides the annotation if "Hide" is clicked', function () {
+  it('hides the annotation if "Hide" is clicked', () => {
     const wrapper = createComponent({
       annotation: fixtures.moderatedAnnotation({
         flagCount: 10,
@@ -145,7 +145,7 @@ describe('ModerationBanner', () => {
     assert.calledWith(fakeApi.annotation.hide, { id: 'ann-id' });
   });
 
-  it('reports an error if hiding the annotation fails', function (done) {
+  it('reports an error if hiding the annotation fails', done => {
     const wrapper = createComponent({
       annotation: moderatedAnnotation({
         flagCount: 10,
@@ -154,13 +154,13 @@ describe('ModerationBanner', () => {
     fakeApi.annotation.hide.returns(Promise.reject(new Error('Network Error')));
     wrapper.find('button').simulate('click');
 
-    setTimeout(function () {
+    setTimeout(() => {
       assert.calledWith(fakeToastMessenger.error, 'Failed to hide annotation');
       done();
     }, 0);
   });
 
-  it('unhides the annotation if "Unhide" is clicked', function () {
+  it('unhides the annotation if "Unhide" is clicked', () => {
     const wrapper = createComponent({
       annotation: moderatedAnnotation({
         flagCount: 1,
@@ -171,7 +171,7 @@ describe('ModerationBanner', () => {
     assert.calledWith(fakeApi.annotation.unhide, { id: 'ann-id' });
   });
 
-  it('reports an error if unhiding the annotation fails', function (done) {
+  it('reports an error if unhiding the annotation fails', done => {
     const wrapper = createComponent({
       annotation: moderatedAnnotation({
         flagCount: 1,
@@ -182,7 +182,7 @@ describe('ModerationBanner', () => {
       Promise.reject(new Error('Network Error'))
     );
     wrapper.find('button').simulate('click');
-    setTimeout(function () {
+    setTimeout(() => {
       assert.calledWith(
         fakeToastMessenger.error,
         'Failed to unhide annotation'

--- a/src/sidebar/components/test/Spinner-test.js
+++ b/src/sidebar/components/test/Spinner-test.js
@@ -4,7 +4,7 @@ import Spinner from '../Spinner';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 
-describe('Spinner', function () {
+describe('Spinner', () => {
   const createSpinner = (props = {}) => mount(<Spinner {...props} />);
 
   // A Spinner is a trivial component with no props. Just make sure it renders.

--- a/src/sidebar/components/test/TagEditor-test.js
+++ b/src/sidebar/components/test/TagEditor-test.js
@@ -8,7 +8,7 @@ import { $imports } from '../TagEditor';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('TagEditor', function () {
+describe('TagEditor', () => {
   let containers = [];
   let fakeTags = ['tag1', 'tag2'];
   let fakeTagsService;
@@ -39,7 +39,7 @@ describe('TagEditor', function () {
     );
   }
 
-  beforeEach(function () {
+  beforeEach(() => {
     fakeOnAddTag = sinon.stub().returns(true);
     fakeOnRemoveTag = sinon.stub();
     fakeOnTagInput = sinon.stub();
@@ -50,7 +50,7 @@ describe('TagEditor', function () {
     $imports.$mock(mockImportedComponents());
   });
 
-  afterEach(function () {
+  afterEach(() => {
     containers.forEach(container => {
       container.remove();
     });
@@ -519,7 +519,7 @@ describe('TagEditor', function () {
   });
 
   describe('accessibility validation', () => {
-    beforeEach(function () {
+    beforeEach(() => {
       // create a full dom tree for a11y testing
       $imports.$mock({
         './AutocompleteList': AutocompleteList,

--- a/src/sidebar/components/test/Tutorial-test.js
+++ b/src/sidebar/components/test/Tutorial-test.js
@@ -6,7 +6,7 @@ import { $imports } from '../Tutorial';
 import { checkAccessibility } from '../../../test-util/accessibility';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
-describe('Tutorial', function () {
+describe('Tutorial', () => {
   let fakeIsThirdPartyService;
 
   function createComponent(props) {

--- a/src/sidebar/config/host-config.js
+++ b/src/sidebar/config/host-config.js
@@ -94,7 +94,7 @@ export default function hostPageConfig(window) {
     },
   };
 
-  return Object.keys(config).reduce(function (result, key) {
+  return Object.keys(config).reduce((result, key) => {
     if (paramWhiteList.indexOf(key) !== -1) {
       // Ignore `null` values as these indicate a default value.
       // In this case the config value set in the sidebar app HTML config is

--- a/src/sidebar/config/test/get-api-url-test.js
+++ b/src/sidebar/config/test/get-api-url-test.js
@@ -26,14 +26,14 @@ describe('sidebar/config/get-api-url', () => {
 
   context(
     'when there is a service object in settings but does not contain an apiUrl key',
-    function () {
+    () => {
       it('throws error', () => {
         const settings = {
           apiUrl: 'someApiUrl',
           services: [{}],
         };
         assert.throws(
-          function () {
+          () => {
             getApiUrl(settings);
           },
           Error,

--- a/src/sidebar/config/test/host-config-test.js
+++ b/src/sidebar/config/test/host-config-test.js
@@ -8,8 +8,8 @@ function fakeWindow(config) {
   };
 }
 
-describe('sidebar/config/host-config', function () {
-  it('parses config from location string and returns whitelisted params', function () {
+describe('sidebar/config/host-config', () => {
+  it('parses config from location string and returns whitelisted params', () => {
     const window_ = fakeWindow({
       annotations: '1234',
       group: 'abc12',
@@ -39,7 +39,7 @@ describe('sidebar/config/host-config', function () {
     });
   });
 
-  it('coerces `requestConfigFromFrame` and `openSidebar` values', function () {
+  it('coerces `requestConfigFromFrame` and `openSidebar` values', () => {
     const window_ = fakeWindow({
       openSidebar: 'false',
       requestConfigFromFrame: {
@@ -57,7 +57,7 @@ describe('sidebar/config/host-config', function () {
     });
   });
 
-  it('ignores non-whitelisted config params', function () {
+  it('ignores non-whitelisted config params', () => {
     const window_ = fakeWindow({
       apiUrl: 'https://not-the-hypothesis/api/',
     });
@@ -65,7 +65,7 @@ describe('sidebar/config/host-config', function () {
     assert.deepEqual(hostPageConfig(window_), {});
   });
 
-  it('ignores `null` values in config', function () {
+  it('ignores `null` values in config', () => {
     const window_ = fakeWindow({
       openSidebar: null,
     });

--- a/src/sidebar/helpers/annotation-metadata.js
+++ b/src/sidebar/helpers/annotation-metadata.js
@@ -136,7 +136,7 @@ export function isPublic(annotation) {
     return isPublic;
   }
 
-  annotation.permissions.read.forEach(function (perm) {
+  annotation.permissions.read.forEach(perm => {
     const readPermArr = perm.split(':');
     if (readPermArr.length === 2 && readPermArr[0] === 'group') {
       isPublic = true;

--- a/src/sidebar/helpers/permissions.js
+++ b/src/sidebar/helpers/permissions.js
@@ -78,7 +78,7 @@ export function defaultPermissions(userid, groupid, savedLevel) {
  * @return {boolean}
  */
 export function isShared(perms) {
-  return perms.read.some(function (principal) {
+  return perms.read.some(principal => {
     return principal.indexOf('group:') === 0;
   });
 }

--- a/src/sidebar/helpers/test/account-id-test.js
+++ b/src/sidebar/helpers/test/account-id-test.js
@@ -1,43 +1,43 @@
 import { parseAccountID, username, isThirdPartyUser } from '../account-id';
 
-describe('sidebar/helpers/account-id', function () {
+describe('sidebar/helpers/account-id', () => {
   const term = 'acct:hacker@example.com';
 
-  describe('parseAccountID', function () {
-    it('should extract the username and provider', function () {
+  describe('parseAccountID', () => {
+    it('should extract the username and provider', () => {
       assert.deepEqual(parseAccountID(term), {
         username: 'hacker',
         provider: 'example.com',
       });
     });
 
-    it('should return null if the ID is invalid', function () {
+    it('should return null if the ID is invalid', () => {
       assert.equal(parseAccountID('bogus'), null);
     });
   });
 
-  describe('username', function () {
-    it('should return the username from the account ID', function () {
+  describe('username', () => {
+    it('should return the username from the account ID', () => {
       assert.equal(username(term), 'hacker');
     });
 
-    it('should return an empty string if the ID is invalid', function () {
+    it('should return an empty string if the ID is invalid', () => {
       assert.equal(username('bogus'), '');
     });
   });
 
-  describe('isThirdPartyUser', function () {
-    it('should return true if user is a third party user', function () {
+  describe('isThirdPartyUser', () => {
+    it('should return true if user is a third party user', () => {
       assert.isTrue(isThirdPartyUser('acct:someone@example.com', 'ex.com'));
     });
 
-    it('should return false if user is not a third party user', function () {
+    it('should return false if user is not a third party user', () => {
       assert.isFalse(
         isThirdPartyUser('acct:someone@example.com', 'example.com')
       );
     });
 
-    it('should return false if the user is invalid', function () {
+    it('should return false if the user is invalid', () => {
       assert.isFalse(isThirdPartyUser('bogus', 'example.com'));
     });
   });

--- a/src/sidebar/helpers/test/build-thread-test.js
+++ b/src/sidebar/helpers/test/build-thread-test.js
@@ -38,9 +38,9 @@ const defaultBuildThreadOpts = {
  */
 function filter(thread, keys) {
   const result = {};
-  keys.forEach(function (key) {
+  keys.forEach(key => {
     if (key === 'children') {
-      result[key] = thread[key].map(function (child) {
+      result[key] = thread[key].map(child => {
         return filter(child, keys);
       });
     } else {

--- a/src/sidebar/helpers/test/group-organizations-test.js
+++ b/src/sidebar/helpers/test/group-organizations-test.js
@@ -1,9 +1,9 @@
 import * as orgFixtures from '../../test/group-fixtures';
 import groupsByOrganization from '../group-organizations';
 
-describe('sidebar/helpers/group-organizations', function () {
-  context('when sorting organizations and their contained groups', function () {
-    it('should put the default organization groups last', function () {
+describe('sidebar/helpers/group-organizations', () => {
+  context('when sorting organizations and their contained groups', () => {
+    it('should put the default organization groups last', () => {
       const defaultOrg = orgFixtures.defaultOrganization();
       const groups = [
         orgFixtures.expandedGroup({ organization: defaultOrg }),
@@ -16,7 +16,7 @@ describe('sidebar/helpers/group-organizations', function () {
       assert.equal(sortedGroups[2].organization.id, defaultOrg.id);
     });
 
-    it('should sort organizations by name', function () {
+    it('should sort organizations by name', () => {
       const org1 = orgFixtures.organization({ name: 'zzzzz' });
       const org2 = orgFixtures.organization({ name: 'aaaaa' });
       const org3 = orgFixtures.organization({ name: 'yyyyy' });
@@ -33,7 +33,7 @@ describe('sidebar/helpers/group-organizations', function () {
       assert.equal(sortedGroups[2].organization.name, 'zzzzz');
     });
 
-    it('should sort organizations secondarily by id', function () {
+    it('should sort organizations secondarily by id', () => {
       const org1 = orgFixtures.organization({ name: 'zzzzz', id: 'zzzzz' });
       const org2 = orgFixtures.organization({ name: 'zzzzz', id: 'aaaaa' });
       const org3 = orgFixtures.organization({ name: 'zzzzz', id: 'yyyyy' });
@@ -50,7 +50,7 @@ describe('sidebar/helpers/group-organizations', function () {
       assert.equal(sortedGroups[2].organization.id, 'zzzzz');
     });
 
-    it('should only include logo for first group in each organization', function () {
+    it('should only include logo for first group in each organization', () => {
       const org = orgFixtures.organization({ name: 'Aluminum' });
       const org2 = orgFixtures.organization({ name: 'Zirconium' });
       const groups = [
@@ -69,8 +69,8 @@ describe('sidebar/helpers/group-organizations', function () {
     });
   });
 
-  context('when encountering missing data', function () {
-    it('should be able to sort without any groups in the default org', function () {
+  context('when encountering missing data', () => {
+    it('should be able to sort without any groups in the default org', () => {
       const org = orgFixtures.organization({ name: 'Aluminum' });
       const groups = [
         { name: 'Aluminum', organization: org },
@@ -85,7 +85,7 @@ describe('sidebar/helpers/group-organizations', function () {
       });
     });
 
-    it('should omit any groups without an organization', function () {
+    it('should omit any groups without an organization', () => {
       const org = orgFixtures.organization({ name: 'Europium' });
       const groups = [
         { name: 'Aluminum', organization: org },
@@ -102,7 +102,7 @@ describe('sidebar/helpers/group-organizations', function () {
       });
     });
 
-    it('should omit any groups with unexpanded organizations', function () {
+    it('should omit any groups with unexpanded organizations', () => {
       const org = orgFixtures.organization({ name: 'Europium' });
       const groups = [
         { name: 'Aluminum', organization: org },
@@ -119,7 +119,7 @@ describe('sidebar/helpers/group-organizations', function () {
       });
     });
 
-    it('should omit logo property if not present on organization', function () {
+    it('should omit logo property if not present on organization', () => {
       const org = orgFixtures.organization({ logo: undefined });
       const org2 = orgFixtures.organization({ logo: null });
       const groups = [
@@ -137,8 +137,8 @@ describe('sidebar/helpers/group-organizations', function () {
     });
   });
 
-  context('when building data structures', function () {
-    it('returned group objects should be immutable', function () {
+  context('when building data structures', () => {
+    it('returned group objects should be immutable', () => {
       const group = orgFixtures.expandedGroup({ name: 'Halfnium' });
       const groups = [group];
 

--- a/src/sidebar/helpers/test/session-test.js
+++ b/src/sidebar/helpers/test/session-test.js
@@ -2,7 +2,7 @@ import * as sessionUtil from '../session';
 
 describe('sidebar/helpers/session', () => {
   describe('#shouldShowSidebarTutorial', () => {
-    it('shows sidebar tutorial if the settings object has the show_sidebar_tutorial key set', function () {
+    it('shows sidebar tutorial if the settings object has the show_sidebar_tutorial key set', () => {
       const sessionState = {
         preferences: {
           show_sidebar_tutorial: true,
@@ -12,7 +12,7 @@ describe('sidebar/helpers/session', () => {
       assert.isTrue(sessionUtil.shouldShowSidebarTutorial(sessionState));
     });
 
-    it('hides sidebar tutorial if the settings object does not have the show_sidebar_tutorial key set', function () {
+    it('hides sidebar tutorial if the settings object does not have the show_sidebar_tutorial key set', () => {
       const sessionState = {
         preferences: {
           show_sidebar_tutorial: false,

--- a/src/sidebar/helpers/test/tabs-test.js
+++ b/src/sidebar/helpers/test/tabs-test.js
@@ -1,8 +1,8 @@
 import * as fixtures from '../../test/annotation-fixtures';
 import * as tabs from '../tabs';
 
-describe('sidebar/helpers/tabs', function () {
-  describe('tabForAnnotation', function () {
+describe('sidebar/helpers/tabs', () => {
+  describe('tabForAnnotation', () => {
     [
       {
         ann: fixtures.defaultAnnotation(),
@@ -25,7 +25,7 @@ describe('sidebar/helpers/tabs', function () {
     });
   });
 
-  describe('shouldShowInTab', function () {
+  describe('shouldShowInTab', () => {
     [
       {
         // Anchoring in progress.

--- a/src/sidebar/markdown-commands.js
+++ b/src/sidebar/markdown-commands.js
@@ -238,7 +238,7 @@ export function toggleBlockStyle(state, prefix) {
   // Test whether all lines in the selected range already have the style
   // applied
   let blockHasStyle = true;
-  transformLines(state, start, end, function (state, lineStart) {
+  transformLines(state, start, end, (state, lineStart) => {
     if (state.text.slice(lineStart, lineStart + prefix.length) !== prefix) {
       blockHasStyle = false;
     }
@@ -247,12 +247,12 @@ export function toggleBlockStyle(state, prefix) {
 
   if (blockHasStyle) {
     // Remove the formatting.
-    return transformLines(state, start, end, function (state, lineStart) {
+    return transformLines(state, start, end, (state, lineStart) => {
       return replaceText(state, lineStart, prefix.length, '');
     });
   } else {
     // Add the block style to any lines which do not already have it applied
-    return transformLines(state, start, end, function (state, lineStart) {
+    return transformLines(state, start, end, (state, lineStart) => {
       if (state.text.slice(lineStart, lineStart + prefix.length) === prefix) {
         return state;
       } else {

--- a/src/sidebar/render-markdown.js
+++ b/src/sidebar/render-markdown.js
@@ -114,7 +114,7 @@ function extractMath(content) {
 }
 
 function insertMath(html, mathBlocks) {
-  return mathBlocks.reduce(function (html, block) {
+  return mathBlocks.reduce((html, block) => {
     let renderedMath;
     try {
       if (block.inline) {

--- a/src/sidebar/services/test/auth-test.js
+++ b/src/sidebar/services/test/auth-test.js
@@ -5,7 +5,7 @@ import { AuthService, $imports } from '../auth';
 const DEFAULT_TOKEN_EXPIRES_IN_SECS = 1000;
 const TOKEN_KEY = 'hypothesis.oauth.hypothes%2Eis.token';
 
-describe('AuthService', function () {
+describe('AuthService', () => {
   let FakeOAuthClient;
   let auth;
   let nowStub;
@@ -32,7 +32,7 @@ describe('AuthService', function () {
     return auth.login();
   }
 
-  beforeEach(function () {
+  beforeEach(() => {
     // Setup fake clock. This has to be done before setting up the `window`
     // fake which makes use of timers.
     clock = sinon.useFakeTimers();
@@ -100,7 +100,7 @@ describe('AuthService', function () {
       .get('auth');
   });
 
-  afterEach(function () {
+  afterEach(() => {
     $imports.$restore();
 
     performance.now.restore();
@@ -119,14 +119,14 @@ describe('AuthService', function () {
     });
   });
 
-  describe('#getAccessToken', function () {
+  describe('#getAccessToken', () => {
     const successfulTokenResponse = Promise.resolve({
       accessToken: 'firstAccessToken',
       refreshToken: 'firstRefreshToken',
       expiresAt: 100,
     });
 
-    it('exchanges the grant token for an access token if provided', function () {
+    it('exchanges the grant token for an access token if provided', () => {
       fakeClient.exchangeGrantToken.returns(successfulTokenResponse);
 
       return auth.getAccessToken().then(token => {
@@ -135,9 +135,9 @@ describe('AuthService', function () {
       });
     });
 
-    context('when the access token request fails', function () {
+    context('when the access token request fails', () => {
       const expectedErr = new Error('Grant token exchange failed');
-      beforeEach('make access token requests fail', function () {
+      beforeEach('make access token requests fail', () => {
         fakeClient.exchangeGrantToken.returns(Promise.reject(expectedErr));
       });
 
@@ -147,8 +147,8 @@ describe('AuthService', function () {
         }, func);
       }
 
-      it('shows an error message to the user', function () {
-        return assertThatAccessTokenPromiseWasRejectedAnd(function () {
+      it('shows an error message to the user', () => {
+        return assertThatAccessTokenPromiseWasRejectedAnd(() => {
           assert.calledOnce(fakeToastMessenger.error);
           assert.calledWith(
             fakeToastMessenger.error,
@@ -160,22 +160,22 @@ describe('AuthService', function () {
         });
       });
 
-      it('returns a rejected promise', function () {
+      it('returns a rejected promise', () => {
         return assertThatAccessTokenPromiseWasRejectedAnd(err => {
           assert.equal(err.message, expectedErr.message);
         });
       });
     });
 
-    it('should cache tokens for future use', function () {
+    it('should cache tokens for future use', () => {
       fakeClient.exchangeGrantToken.returns(successfulTokenResponse);
       return auth
         .getAccessToken()
-        .then(function () {
+        .then(() => {
           fakeClient.exchangeGrantToken.reset();
           return auth.getAccessToken();
         })
-        .then(function (token) {
+        .then(token => {
           assert.equal(token, 'firstAccessToken');
           assert.notCalled(fakeClient.exchangeGrantToken);
         });
@@ -185,7 +185,7 @@ describe('AuthService', function () {
     // flight when getAccessToken() is called again, then it should just return
     // the pending Promise for the first request again (and not send a second
     // concurrent HTTP request).
-    it('should not make two concurrent access token requests', function () {
+    it('should not make two concurrent access token requests', () => {
       let respond;
       fakeClient.exchangeGrantToken.returns(
         new Promise(resolve => {
@@ -208,15 +208,15 @@ describe('AuthService', function () {
       });
     });
 
-    it('should not attempt to exchange a grant token if none was provided', function () {
+    it('should not attempt to exchange a grant token if none was provided', () => {
       fakeSettings.services = [{ authority: 'publisher.org' }];
-      return auth.getAccessToken().then(function (token) {
+      return auth.getAccessToken().then(token => {
         assert.notCalled(fakeClient.exchangeGrantToken);
         assert.equal(token, null);
       });
     });
 
-    it('should refresh the access token if it expired', function () {
+    it('should refresh the access token if it expired', () => {
       fakeClient.exchangeGrantToken.returns(
         Promise.resolve(successfulTokenResponse)
       );
@@ -250,7 +250,7 @@ describe('AuthService', function () {
 
     // It only sends one refresh request, even if getAccessToken() is called
     // multiple times and the refresh response hasn't come back yet.
-    it('does not send more than one refresh request', function () {
+    it('does not send more than one refresh request', () => {
       fakeClient.exchangeGrantToken.returns(
         Promise.resolve(successfulTokenResponse)
       );
@@ -291,13 +291,13 @@ describe('AuthService', function () {
         });
     });
 
-    context('when a refresh request fails', function () {
-      beforeEach('make refresh token requests fail', function () {
+    context('when a refresh request fails', () => {
+      beforeEach('make refresh token requests fail', () => {
         fakeClient.refreshToken.returns(Promise.reject(new Error('failed')));
         fakeClient.exchangeGrantToken.returns(successfulTokenResponse);
       });
 
-      it('logs the user out', function () {
+      it('logs the user out', () => {
         expireAccessToken();
 
         return auth.getAccessToken(token => {

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -52,7 +52,7 @@ describe('FrameSyncService', () => {
   let fakeBridge;
   let frameSync;
 
-  beforeEach(function () {
+  beforeEach(() => {
     fakeStore = createFakeStore(
       { annotations: [] },
       {
@@ -110,8 +110,8 @@ describe('FrameSyncService', () => {
     $imports.$restore();
   });
 
-  context('when annotations are loaded into the sidebar', function () {
-    it('sends a "loadAnnotations" message to the frame', function () {
+  context('when annotations are loaded into the sidebar', () => {
+    it('sends a "loadAnnotations" message to the frame', () => {
       fakeStore.setState({
         annotations: [fixtures.ann],
       });
@@ -122,7 +122,7 @@ describe('FrameSyncService', () => {
       );
     });
 
-    it('sends a "loadAnnotations" message only for new annotations', function () {
+    it('sends a "loadAnnotations" message only for new annotations', () => {
       const ann2 = Object.assign({}, fixtures.ann, { $tag: 't2', id: 'a2' });
       fakeStore.setState({
         annotations: [fixtures.ann],
@@ -140,7 +140,7 @@ describe('FrameSyncService', () => {
       );
     });
 
-    it('does not send a "loadAnnotations" message for replies', function () {
+    it('does not send a "loadAnnotations" message for replies', () => {
       fakeStore.setState({
         annotations: [annotationFixtures.newReply()],
       });
@@ -148,8 +148,8 @@ describe('FrameSyncService', () => {
     });
   });
 
-  context('when annotation count has changed', function () {
-    it('sends a "publicAnnotationCountChanged" message to the frame when there are public annotations', function () {
+  context('when annotation count has changed', () => {
+    it('sends a "publicAnnotationCountChanged" message to the frame when there are public annotations', () => {
       fakeStore.setState({
         annotations: [annotationFixtures.publicAnnotation()],
       });
@@ -160,7 +160,7 @@ describe('FrameSyncService', () => {
       );
     });
 
-    it('sends a "publicAnnotationCountChanged" message to the frame when there are only private annotations', function () {
+    it('sends a "publicAnnotationCountChanged" message to the frame when there are only private annotations', () => {
       const annot = annotationFixtures.defaultAnnotation();
       delete annot.permissions;
 
@@ -174,7 +174,7 @@ describe('FrameSyncService', () => {
       );
     });
 
-    it('does not send a "publicAnnotationCountChanged" message to the frame if annotation fetch is not complete', function () {
+    it('does not send a "publicAnnotationCountChanged" message to the frame if annotation fetch is not complete', () => {
       fakeStore.frames.returns([{ uri: 'http://example.com' }]);
       fakeStore.setState({
         annotations: [annotationFixtures.publicAnnotation()],
@@ -184,7 +184,7 @@ describe('FrameSyncService', () => {
       );
     });
 
-    it('does not send a "publicAnnotationCountChanged" message if there are no connected frames', function () {
+    it('does not send a "publicAnnotationCountChanged" message if there are no connected frames', () => {
       fakeStore.frames.returns([]);
       fakeStore.setState({
         annotations: [annotationFixtures.publicAnnotation()],
@@ -195,8 +195,8 @@ describe('FrameSyncService', () => {
     });
   });
 
-  context('when annotations are removed from the sidebar', function () {
-    it('sends a "deleteAnnotation" message to the frame', function () {
+  context('when annotations are removed from the sidebar', () => {
+    it('sends a "deleteAnnotation" message to the frame', () => {
       fakeStore.setState({
         annotations: [fixtures.ann],
       });
@@ -211,9 +211,9 @@ describe('FrameSyncService', () => {
     });
   });
 
-  context('when a new annotation is created in the frame', function () {
+  context('when a new annotation is created in the frame', () => {
     context('when an authenticated user is present', () => {
-      it('creates the annotation in the sidebar', function () {
+      it('creates the annotation in the sidebar', () => {
         fakeStore.isLoggedIn.returns(true);
         const ann = { target: [] };
 
@@ -265,7 +265,7 @@ describe('FrameSyncService', () => {
     });
   });
 
-  context('when anchoring completes', function () {
+  context('when anchoring completes', () => {
     let clock = sinon.stub();
 
     beforeEach(() => {
@@ -282,7 +282,7 @@ describe('FrameSyncService', () => {
       clock.tick(20);
     }
 
-    it('updates the anchoring status for the annotation', function () {
+    it('updates the anchoring status for the annotation', () => {
       fakeBridge.emit('sync', [{ tag: 't1', msg: { $orphan: false } }]);
 
       expireDebounceTimeout();
@@ -303,7 +303,7 @@ describe('FrameSyncService', () => {
     });
   });
 
-  context('when a new frame connects', function () {
+  context('when a new frame connects', () => {
     let frameInfo;
     const fakeChannel = {
       call: function (name, callback) {
@@ -312,7 +312,7 @@ describe('FrameSyncService', () => {
       destroy: sinon.stub(),
     };
 
-    it("adds the page's metadata to the frames list", function () {
+    it("adds the page's metadata to the frames list", () => {
       frameInfo = fixtures.htmlDocumentInfo;
 
       fakeBridge.emit('connect', fakeChannel);
@@ -334,18 +334,18 @@ describe('FrameSyncService', () => {
     });
   });
 
-  context('when a frame is destroyed', function () {
+  context('when a frame is destroyed', () => {
     const frameId = fixtures.framesListEntry.id;
 
-    it('removes the frame from the frames list', function () {
+    it('removes the frame from the frames list', () => {
       fakeBridge.emit('destroyFrame', frameId);
 
       assert.calledWith(fakeStore.destroyFrame, fixtures.framesListEntry);
     });
   });
 
-  describe('on "showAnnotations" message', function () {
-    it('selects annotations which have an ID', function () {
+  describe('on "showAnnotations" message', () => {
+    it('selects annotations which have an ID', () => {
       fakeStore.findIDsForTags.returns(['id1', 'id2', 'id3']);
       fakeBridge.emit('showAnnotations', ['tag1', 'tag2', 'tag3']);
 
@@ -354,15 +354,15 @@ describe('FrameSyncService', () => {
     });
   });
 
-  describe('on "focusAnnotations" message', function () {
-    it('focuses the annotations', function () {
+  describe('on "focusAnnotations" message', () => {
+    it('focuses the annotations', () => {
       fakeBridge.emit('focusAnnotations', ['tag1', 'tag2', 'tag3']);
       assert.calledWith(fakeStore.focusAnnotations, ['tag1', 'tag2', 'tag3']);
     });
   });
 
-  describe('on "toggleAnnotationSelection" message', function () {
-    it('toggles the selected state of the annotations', function () {
+  describe('on "toggleAnnotationSelection" message', () => {
+    it('toggles the selected state of the annotations', () => {
       fakeStore.findIDsForTags.returns(['id1', 'id2', 'id3']);
       fakeBridge.emit('toggleAnnotationSelection', ['tag1', 'tag2', 'tag3']);
       assert.calledWith(fakeStore.toggleSelectedAnnotations, [
@@ -373,28 +373,28 @@ describe('FrameSyncService', () => {
     });
   });
 
-  describe('on "sidebarOpened" message', function () {
-    it('sets the sidebar open in the store', function () {
+  describe('on "sidebarOpened" message', () => {
+    it('sets the sidebar open in the store', () => {
       fakeBridge.emit('sidebarOpened');
 
       assert.calledWith(fakeStore.setSidebarOpened, true);
     });
   });
 
-  describe('on a relayed bridge call', function () {
-    it('calls "openSidebar"', function () {
+  describe('on a relayed bridge call', () => {
+    it('calls "openSidebar"', () => {
       fakeBridge.emit('openSidebar');
 
       assert.calledWith(fakeBridge.call, 'openSidebar');
     });
 
-    it('calls "closeSidebar"', function () {
+    it('calls "closeSidebar"', () => {
       fakeBridge.emit('closeSidebar');
 
       assert.calledWith(fakeBridge.call, 'closeSidebar');
     });
 
-    it('calls "setVisibleHighlights"', function () {
+    it('calls "setVisibleHighlights"', () => {
       fakeBridge.emit('setVisibleHighlights');
 
       assert.calledWith(fakeBridge.call, 'setVisibleHighlights');

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -37,7 +37,7 @@ const dummyGroups = [
   { name: 'Group 3', id: 'id3' },
 ];
 
-describe('GroupsService', function () {
+describe('GroupsService', () => {
   let fakeAuth;
   let fakeStore;
   let fakeSession;
@@ -46,7 +46,7 @@ describe('GroupsService', function () {
   let fakeMetadata;
   let fakeToastMessenger;
 
-  beforeEach(function () {
+  beforeEach(() => {
     fakeAuth = {
       getAccessToken: sinon.stub().returns('1234'),
     };
@@ -216,7 +216,7 @@ describe('GroupsService', function () {
     });
   });
 
-  describe('#load', function () {
+  describe('#load', () => {
     it('filters out direct-linked groups that are out of scope and scope enforced', () => {
       const svc = createService();
       fakeStore.getDefault.returns(dummyGroups[0].id);
@@ -258,7 +258,7 @@ describe('GroupsService', function () {
       });
     });
 
-    it('combines groups from both endpoints', function () {
+    it('combines groups from both endpoints', () => {
       const svc = createService();
 
       const groups = [
@@ -333,7 +333,7 @@ describe('GroupsService', function () {
       });
     });
 
-    it('loads all available groups', function () {
+    it('loads all available groups', () => {
       const svc = createService();
 
       return svc.load().then(() => {
@@ -341,7 +341,7 @@ describe('GroupsService', function () {
       });
     });
 
-    it('sends `expand` parameter', function () {
+    it('sends `expand` parameter', () => {
       const svc = createService();
       fakeApi.groups.list.returns(
         Promise.resolve([{ id: 'groupa', name: 'GroupA' }])
@@ -493,7 +493,7 @@ describe('GroupsService', function () {
       });
     });
 
-    it('injects a default organization if group is missing an organization', function () {
+    it('injects a default organization if group is missing an organization', () => {
       const svc = createService();
       const groups = [{ id: '39r39f', name: 'Ding Dong!' }];
       fakeApi.groups.list.returns(Promise.resolve(groups));
@@ -826,8 +826,8 @@ describe('GroupsService', function () {
     });
   });
 
-  describe('#leave', function () {
-    it('should call the group leave API', function () {
+  describe('#leave', () => {
+    it('should call the group leave API', () => {
       const s = createService();
       return s.leave('id2').then(() => {
         assert.calledWithMatch(fakeApi.group.member.delete, {
@@ -840,7 +840,7 @@ describe('GroupsService', function () {
 
   const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-  describe('automatic re-fetching', function () {
+  describe('automatic re-fetching', () => {
     it('refetches groups when the logged-in user changes', async () => {
       const svc = createService();
 

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -216,7 +216,7 @@ describe('StreamerService', () => {
       });
     });
 
-    it('should not include credentials in the URL if the client has no access token', function () {
+    it('should not include credentials in the URL if the client has no access token', () => {
       fakeAuth.getAccessToken.resolves(null);
 
       createDefaultStreamer();

--- a/src/sidebar/services/test/toast-messenger-test.js
+++ b/src/sidebar/services/test/toast-messenger-test.js
@@ -1,6 +1,6 @@
 import { ToastMessengerService } from '../toast-messenger';
 
-describe('ToastMessengerService', function () {
+describe('ToastMessengerService', () => {
   let clock;
   let fakeStore;
   let service;

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -34,7 +34,7 @@ import route from './route';
 function excludeAnnotations(current, annotations) {
   const ids = {};
   const tags = {};
-  annotations.forEach(function (annot) {
+  annotations.forEach(annot => {
     if (annot.id) {
       ids[annot.id] = true;
     }
@@ -42,7 +42,7 @@ function excludeAnnotations(current, annotations) {
       tags[annot.$tag] = true;
     }
   });
-  return current.filter(function (annot) {
+  return current.filter(annot => {
     const shouldRemove =
       (annot.id && annot.id in ids) || (annot.$tag && annot.$tag in tags);
     return !shouldRemove;
@@ -50,13 +50,13 @@ function excludeAnnotations(current, annotations) {
 }
 
 function findByID(annotations, id) {
-  return annotations.find(function (annot) {
+  return annotations.find(annot => {
     return annot.id === id;
   });
 }
 
 function findByTag(annotations, tag) {
-  return annotations.find(function (annot) {
+  return annotations.find(annot => {
     return annot.$tag === tag;
   });
 }
@@ -170,7 +170,7 @@ const reducers = {
   },
 
   HIDE_ANNOTATION: function (state, action) {
-    const anns = state.annotations.map(function (ann) {
+    const anns = state.annotations.map(ann => {
       if (ann.id !== action.id) {
         return ann;
       }
@@ -190,7 +190,7 @@ const reducers = {
   },
 
   UNHIDE_ANNOTATION: function (state, action) {
-    const anns = state.annotations.map(function (ann) {
+    const anns = state.annotations.map(ann => {
       if (ann.id !== action.id) {
         return ann;
       }
@@ -200,7 +200,7 @@ const reducers = {
   },
 
   UPDATE_ANCHOR_STATUS: function (state, action) {
-    const annotations = state.annotations.map(function (annot) {
+    const annotations = state.annotations.map(annot => {
       if (!action.statusUpdates.hasOwnProperty(annot.$tag)) {
         return annot;
       }
@@ -216,7 +216,7 @@ const reducers = {
   },
 
   UPDATE_FLAG_STATUS: function (state, action) {
-    const annotations = state.annotations.map(function (annot) {
+    const annotations = state.annotations.map(annot => {
       const match = annot.id && annot.id === action.id;
       if (match) {
         if (annot.flagged === action.isFlagged) {
@@ -558,7 +558,7 @@ const orphanCount = createSelector(
  * @return {Annotation[]}
  */
 function savedAnnotations(state) {
-  return state.annotations.filter(function (ann) {
+  return state.annotations.filter(ann => {
     return !metadata.isNew(ann);
   });
 }

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -33,7 +33,7 @@ const reducers = {
   },
 
   UPDATE_FRAME_ANNOTATION_FETCH_STATUS: function (state, action) {
-    const frames = state.map(function (frame) {
+    const frames = state.map(frame => {
       const match = frame.uri && frame.uri === action.uri;
       if (match) {
         return Object.assign({}, frame, {
@@ -115,13 +115,13 @@ function searchUrisForFrame(frame) {
   let uris = [frame.uri];
 
   if (frame.metadata && frame.metadata.documentFingerprint) {
-    uris = frame.metadata.link.map(function (link) {
+    uris = frame.metadata.link.map(link => {
       return link.href;
     });
   }
 
   if (frame.metadata && frame.metadata.link) {
-    frame.metadata.link.forEach(function (link) {
+    frame.metadata.link.forEach(link => {
       if (link.href.startsWith('doi:')) {
         uris.push(link.href);
       }

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -12,8 +12,8 @@ function createTestStore() {
 // still in `sidebar/store/test/index-test.js`. These tests should be migrated
 // here in future.
 
-describe('sidebar/store/modules/annotations', function () {
-  describe('#addAnnotations()', function () {
+describe('sidebar/store/modules/annotations', () => {
+  describe('#addAnnotations()', () => {
     const ANCHOR_TIME_LIMIT = 1000;
     let clock;
     let store;
@@ -26,17 +26,17 @@ describe('sidebar/store/modules/annotations', function () {
       return storeAnn.$tag;
     }
 
-    beforeEach(function () {
+    beforeEach(() => {
       clock = sinon.useFakeTimers();
       store = createTestStore();
       store.changeRoute('sidebar', {});
     });
 
-    afterEach(function () {
+    afterEach(() => {
       clock.restore();
     });
 
-    it('adds annotations not in the store', function () {
+    it('adds annotations not in the store', () => {
       const annot = fixtures.defaultAnnotation();
       store.addAnnotations([annot]);
       assert.match(store.getState().annotations.annotations, [
@@ -44,20 +44,20 @@ describe('sidebar/store/modules/annotations', function () {
       ]);
     });
 
-    it('assigns a local tag to annotations', function () {
+    it('assigns a local tag to annotations', () => {
       const annotA = Object.assign(fixtures.defaultAnnotation(), { id: 'a1' });
       const annotB = Object.assign(fixtures.defaultAnnotation(), { id: 'a2' });
 
       store.addAnnotations([annotA, annotB]);
 
-      const tags = store.getState().annotations.annotations.map(function (a) {
+      const tags = store.getState().annotations.annotations.map(a => {
         return a.$tag;
       });
 
       assert.deepEqual(tags, ['t1', 't2']);
     });
 
-    it('updates annotations with matching IDs in the store', function () {
+    it('updates annotations with matching IDs in the store', () => {
       const annot = fixtures.defaultAnnotation();
       store.addAnnotations([annot]);
       const update = Object.assign({}, fixtures.defaultAnnotation(), {
@@ -69,7 +69,7 @@ describe('sidebar/store/modules/annotations', function () {
       assert.equal(updatedAnnot.text, 'update');
     });
 
-    it('updates annotations with matching tags in the store', function () {
+    it('updates annotations with matching tags in the store', () => {
       const annot = fixtures.newAnnotation();
       annot.$tag = 'local-tag';
       store.addAnnotations([annot]);
@@ -82,7 +82,7 @@ describe('sidebar/store/modules/annotations', function () {
       assert.equal(annots[0].id, 'server-id');
     });
 
-    it('preserves anchoring status of updated annotations', function () {
+    it('preserves anchoring status of updated annotations', () => {
       const annot = fixtures.defaultAnnotation();
       store.addAnnotations([annot]);
       store.updateAnchorStatus({ [tagForID(annot.id)]: 'anchored' });
@@ -96,7 +96,7 @@ describe('sidebar/store/modules/annotations', function () {
       assert.isFalse(updatedAnnot.$orphan);
     });
 
-    it('sets the timeout flag on annotations that fail to anchor within a time limit', function () {
+    it('sets the timeout flag on annotations that fail to anchor within a time limit', () => {
       const annot = fixtures.defaultAnnotation();
       store.addAnnotations([annot]);
 
@@ -105,7 +105,7 @@ describe('sidebar/store/modules/annotations', function () {
       assert.isTrue(store.getState().annotations.annotations[0].$anchorTimeout);
     });
 
-    it('does not set the timeout flag on annotations that do anchor within a time limit', function () {
+    it('does not set the timeout flag on annotations that do anchor within a time limit', () => {
       const annot = fixtures.defaultAnnotation();
       store.addAnnotations([annot]);
       store.updateAnchorStatus({ [tagForID(annot.id)]: 'anchored' });
@@ -117,18 +117,18 @@ describe('sidebar/store/modules/annotations', function () {
       );
     });
 
-    it('does not attempt to modify orphan status if annotations are removed before anchoring timeout expires', function () {
+    it('does not attempt to modify orphan status if annotations are removed before anchoring timeout expires', () => {
       const annot = fixtures.defaultAnnotation();
       store.addAnnotations([annot]);
       store.updateAnchorStatus({ [tagForID(annot.id)]: 'anchored' });
       store.removeAnnotations([annot]);
 
-      assert.doesNotThrow(function () {
+      assert.doesNotThrow(() => {
         clock.tick(ANCHOR_TIME_LIMIT);
       });
     });
 
-    it('does not expect annotations to anchor on the stream', function () {
+    it('does not expect annotations to anchor on the stream', () => {
       const isOrphan = function () {
         return !!metadata.isOrphan(store.getState().annotations.annotations[0]);
       };
@@ -142,7 +142,7 @@ describe('sidebar/store/modules/annotations', function () {
       assert.isFalse(isOrphan());
     });
 
-    it('initializes the $orphan field for new annotations', function () {
+    it('initializes the $orphan field for new annotations', () => {
       store.addAnnotations([fixtures.newAnnotation()]);
       assert.isFalse(store.getState().annotations.annotations[0].$orphan);
     });
@@ -162,19 +162,19 @@ describe('sidebar/store/modules/annotations', function () {
       });
     });
 
-    describe('focusAnnotations', function () {
-      it('adds the provided annotation IDs to the focused annotations', function () {
+    describe('focusAnnotations', () => {
+      it('adds the provided annotation IDs to the focused annotations', () => {
         store.focusAnnotations(['1', '2', '3']);
         assert.deepEqual(store.focusedAnnotations(), ['1', '2', '3']);
       });
 
-      it('replaces any other focused annotation IDs', function () {
+      it('replaces any other focused annotation IDs', () => {
         store.focusAnnotations(['1']);
         store.focusAnnotations(['2', '3']);
         assert.deepEqual(store.focusedAnnotations(), ['2', '3']);
       });
 
-      it('sets focused annotations to an empty object if no IDs provided', function () {
+      it('sets focused annotations to an empty object if no IDs provided', () => {
         store.focusAnnotations(['1']);
         store.focusAnnotations([]);
         assert.isEmpty(store.focusedAnnotations());
@@ -344,8 +344,8 @@ describe('sidebar/store/modules/annotations', function () {
     });
   });
 
-  describe('#savedAnnotations', function () {
-    it('returns annotations which are saved', function () {
+  describe('#savedAnnotations', () => {
+    it('returns annotations which are saved', () => {
       const store = createTestStore();
       store.addAnnotations([
         fixtures.newAnnotation(),
@@ -360,15 +360,15 @@ describe('sidebar/store/modules/annotations', function () {
     });
   });
 
-  describe('#findIDsForTags', function () {
-    it('returns the IDs corresponding to the provided local tags', function () {
+  describe('#findIDsForTags', () => {
+    it('returns the IDs corresponding to the provided local tags', () => {
       const store = createTestStore();
       const ann = fixtures.defaultAnnotation();
       store.addAnnotations([Object.assign(ann, { $tag: 't1' })]);
       assert.deepEqual(store.findIDsForTags(['t1']), [ann.id]);
     });
 
-    it('does not return IDs for annotations that do not have an ID', function () {
+    it('does not return IDs for annotations that do not have an ID', () => {
       const store = createTestStore();
       const ann = fixtures.newAnnotation();
       store.addAnnotations([Object.assign(ann, { $tag: 't1' })]);
@@ -376,8 +376,8 @@ describe('sidebar/store/modules/annotations', function () {
     });
   });
 
-  describe('#hideAnnotation', function () {
-    it('sets the `hidden` state to `true`', function () {
+  describe('#hideAnnotation', () => {
+    it('sets the `hidden` state to `true`', () => {
       const store = createTestStore();
       const ann = fixtures.moderatedAnnotation({ hidden: false });
 
@@ -389,8 +389,8 @@ describe('sidebar/store/modules/annotations', function () {
     });
   });
 
-  describe('#unhideAnnotation', function () {
-    it('sets the `hidden` state to `false`', function () {
+  describe('#unhideAnnotation', () => {
+    it('sets the `hidden` state to `false`', () => {
       const store = createTestStore();
       const ann = fixtures.moderatedAnnotation({ hidden: true });
 
@@ -402,8 +402,8 @@ describe('sidebar/store/modules/annotations', function () {
     });
   });
 
-  describe('#removeAnnotations', function () {
-    it('removes the annotation', function () {
+  describe('#removeAnnotations', () => {
+    it('removes the annotation', () => {
       const store = createTestStore();
       const ann = fixtures.defaultAnnotation();
       store.addAnnotations([ann]);
@@ -412,7 +412,7 @@ describe('sidebar/store/modules/annotations', function () {
     });
   });
 
-  describe('#updateFlagStatus', function () {
+  describe('#updateFlagStatus', () => {
     [
       {
         description: 'non-moderator flags annotation',

--- a/src/sidebar/store/modules/test/defaults-test.js
+++ b/src/sidebar/store/modules/test/defaults-test.js
@@ -1,7 +1,7 @@
 import { createStore } from '../../create-store';
 import defaults from '../defaults';
 
-describe('store/modules/defaults', function () {
+describe('store/modules/defaults', () => {
   let store;
 
   beforeEach(() => {
@@ -9,7 +9,7 @@ describe('store/modules/defaults', function () {
   });
 
   describe('actions', () => {
-    describe('#setDefault', function () {
+    describe('#setDefault', () => {
       it('should update the indicated default with the new value', () => {
         const beforePrivacy = store.getDefault('annotationPrivacy');
         store.setDefault('annotationPrivacy', 'private');

--- a/src/sidebar/store/modules/test/frames-test.js
+++ b/src/sidebar/store/modules/test/frames-test.js
@@ -1,7 +1,7 @@
 import { createStore } from '../../create-store';
 import frames from '../frames';
 
-describe('sidebar/store/modules/frames', function () {
+describe('sidebar/store/modules/frames', () => {
   let store;
 
   beforeEach(() => {
@@ -9,16 +9,16 @@ describe('sidebar/store/modules/frames', function () {
     store = createStore([frames]);
   });
 
-  describe('#connectFrame', function () {
-    it('adds the frame to the list of connected frames', function () {
+  describe('#connectFrame', () => {
+    it('adds the frame to the list of connected frames', () => {
       const frame = { uri: 'http://example.com' };
       store.connectFrame(frame);
       assert.deepEqual(store.frames(), [frame]);
     });
   });
 
-  describe('#destroyFrame', function () {
-    it('removes the frame from the list of connected frames', function () {
+  describe('#destroyFrame', () => {
+    it('removes the frame from the list of connected frames', () => {
       const frameList = [
         { uri: 'http://example.com' },
         { uri: 'http://example.org' },
@@ -30,8 +30,8 @@ describe('sidebar/store/modules/frames', function () {
     });
   });
 
-  describe('#updateFrameAnnotationFetchStatus', function () {
-    it('updates the isAnnotationFetchComplete status of the frame', function () {
+  describe('#updateFrameAnnotationFetchStatus', () => {
+    it('updates the isAnnotationFetchComplete status of the frame', () => {
       const frame = {
         uri: 'http://example.com',
       };
@@ -44,7 +44,7 @@ describe('sidebar/store/modules/frames', function () {
       assert.deepEqual(store.frames(), [expectedFrame]);
     });
 
-    it('does not update the isAnnotationFetchComplete status of the wrong frame', function () {
+    it('does not update the isAnnotationFetchComplete status of the wrong frame', () => {
       const frame = {
         uri: 'http://example.com',
       };
@@ -82,7 +82,7 @@ describe('sidebar/store/modules/frames', function () {
     });
   });
 
-  describe('#searchUris', function () {
+  describe('#searchUris', () => {
     [
       {
         when: 'one HTML frame',

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -17,8 +17,8 @@ describe('sidebar/store/modules/selection', () => {
     store = createStore([annotations, filters, selection, route], fakeSettings);
   });
 
-  describe('setForcedVisible', function () {
-    it('sets the visibility of the annotation', function () {
+  describe('setForcedVisible', () => {
+    it('sets the visibility of the annotation', () => {
       store.setForcedVisible('id1', true);
       assert.deepEqual(getSelectionState().forcedVisible, { id1: true });
     });
@@ -34,8 +34,8 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('setExpanded()', function () {
-    it('sets the expanded state of the annotation', function () {
+  describe('setExpanded()', () => {
+    it('sets the expanded state of the annotation', () => {
       store.setExpanded('parent_id', true);
       store.setExpanded('whatnot', false);
       assert.deepEqual(store.expandedMap(), {
@@ -45,24 +45,24 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('hasSelectedAnnotations', function () {
-    it('returns true if there are any selected annotations', function () {
+  describe('hasSelectedAnnotations', () => {
+    it('returns true if there are any selected annotations', () => {
       store.selectAnnotations([1]);
       assert.isTrue(store.hasSelectedAnnotations());
     });
 
-    it('returns false if there are no selected annotations', function () {
+    it('returns false if there are no selected annotations', () => {
       assert.isFalse(store.hasSelectedAnnotations());
     });
   });
 
-  describe('filterQuery', function () {
-    it('returns the filterQuery value when provided', function () {
+  describe('filterQuery', () => {
+    it('returns the filterQuery value when provided', () => {
       store.setFilterQuery('tag:foo');
       assert.equal(store.filterQuery(), 'tag:foo');
     });
 
-    it('returns null when no filterQuery is present', function () {
+    it('returns null when no filterQuery is present', () => {
       assert.isNull(store.filterQuery());
     });
   });
@@ -93,8 +93,8 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('selectAnnotations()', function () {
-    it('adds the passed annotations to the selectedAnnotations', function () {
+  describe('selectAnnotations()', () => {
+    it('adds the passed annotations to the selectedAnnotations', () => {
       store.selectAnnotations([1, 2, 3]);
       assert.deepEqual(getSelectionState().selected, {
         1: true,
@@ -103,7 +103,7 @@ describe('sidebar/store/modules/selection', () => {
       });
     });
 
-    it('replaces any annotations originally in the selection', function () {
+    it('replaces any annotations originally in the selection', () => {
       store.selectAnnotations([1]);
       store.selectAnnotations([2, 3]);
       assert.deepEqual(getSelectionState().selected, {
@@ -112,7 +112,7 @@ describe('sidebar/store/modules/selection', () => {
       });
     });
 
-    it('empties the selection object if no annotations are selected', function () {
+    it('empties the selection object if no annotations are selected', () => {
       store.selectAnnotations([1]);
       store.selectAnnotations([]);
       assert.isObject(getSelectionState().selected);
@@ -120,8 +120,8 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('toggleSelectedAnnotations()', function () {
-    it('adds annotations missing from the selectedAnnotations', function () {
+  describe('toggleSelectedAnnotations()', () => {
+    it('adds annotations missing from the selectedAnnotations', () => {
       store.selectAnnotations([1, 2]);
       store.toggleSelectedAnnotations([3, 4]);
       assert.deepEqual(getSelectionState().selected, {
@@ -132,7 +132,7 @@ describe('sidebar/store/modules/selection', () => {
       });
     });
 
-    it('removes annotations already in the selection', function () {
+    it('removes annotations already in the selection', () => {
       store.selectAnnotations([1, 3]);
       store.toggleSelectedAnnotations([1, 2]);
       assert.deepEqual(getSelectionState().selected, {
@@ -194,8 +194,8 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('#REMOVE_ANNOTATIONS', function () {
-    it('removing an annotation should also remove it from the selection', function () {
+  describe('#REMOVE_ANNOTATIONS', () => {
+    it('removing an annotation should also remove it from the selection', () => {
       store.selectAnnotations([1, 2, 3]);
       store.setForcedVisible(2, true);
       store.setForcedVisible(1, true);
@@ -211,43 +211,43 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('selectTab()', function () {
-    it('sets the selected tab', function () {
+  describe('selectTab()', () => {
+    it('sets the selected tab', () => {
       store.selectTab('annotation');
       assert.equal(getSelectionState().selectedTab, 'annotation');
     });
 
-    it('allows sorting annotations by time and document location', function () {
+    it('allows sorting annotations by time and document location', () => {
       store.selectTab('annotation');
       assert.deepEqual(store.sortKeys(), ['Newest', 'Oldest', 'Location']);
     });
 
-    it('allows sorting page notes by time', function () {
+    it('allows sorting page notes by time', () => {
       store.selectTab('note');
       assert.deepEqual(store.sortKeys(), ['Newest', 'Oldest']);
     });
 
-    it('allows sorting orphans by time and document location', function () {
+    it('allows sorting orphans by time and document location', () => {
       store.selectTab('orphan');
       assert.deepEqual(store.sortKeys(), ['Newest', 'Oldest', 'Location']);
     });
 
-    it('sorts annotations by document location by default', function () {
+    it('sorts annotations by document location by default', () => {
       store.selectTab('annotation');
       assert.deepEqual(getSelectionState().sortKey, 'Location');
     });
 
-    it('sorts page notes from oldest to newest by default', function () {
+    it('sorts page notes from oldest to newest by default', () => {
       store.selectTab('note');
       assert.deepEqual(getSelectionState().sortKey, 'Oldest');
     });
 
-    it('sorts orphans by document location by default', function () {
+    it('sorts orphans by document location by default', () => {
       store.selectTab('orphan');
       assert.deepEqual(getSelectionState().sortKey, 'Location');
     });
 
-    it('does not reset the sort key unless necessary', function () {
+    it('does not reset the sort key unless necessary', () => {
       // Select the tab, setting sort key to 'Oldest', and then manually
       // override the sort key.
       store.selectTab('note');

--- a/src/sidebar/store/modules/test/toast-messages-test.js
+++ b/src/sidebar/store/modules/test/toast-messages-test.js
@@ -1,7 +1,7 @@
 import { createStore } from '../../create-store';
 import toastMessages from '../toast-messages';
 
-describe('store/modules/toast-messages', function () {
+describe('store/modules/toast-messages', () => {
   let store;
   let fakeToastMessage;
 

--- a/src/sidebar/store/modules/test/viewer-test.js
+++ b/src/sidebar/store/modules/test/viewer-test.js
@@ -1,20 +1,20 @@
 import { createStore } from '../../create-store';
 import viewer from '../viewer';
 
-describe('store/modules/viewer', function () {
+describe('store/modules/viewer', () => {
   let store;
 
   beforeEach(() => {
     store = createStore([viewer]);
   });
 
-  describe('#setShowHighlights', function () {
-    it('sets a flag indicating that highlights are visible', function () {
+  describe('#setShowHighlights', () => {
+    it('sets a flag indicating that highlights are visible', () => {
       store.setShowHighlights(true);
       assert.isTrue(store.getState().viewer.visibleHighlights);
     });
 
-    it('sets a flag indicating that highlights are not visible', function () {
+    it('sets a flag indicating that highlights are not visible', () => {
       store.setShowHighlights(false);
       assert.isFalse(store.getState().viewer.visibleHighlights);
     });

--- a/src/sidebar/store/test/debug-middleware-test.js
+++ b/src/sidebar/store/test/debug-middleware-test.js
@@ -8,10 +8,10 @@ function id(state) {
   return state;
 }
 
-describe('debug middleware', function () {
+describe('debug middleware', () => {
   let store;
 
-  beforeEach(function () {
+  beforeEach(() => {
     sinon.stub(console, 'log');
     sinon.stub(console, 'group');
     sinon.stub(console, 'groupEnd');
@@ -20,7 +20,7 @@ describe('debug middleware', function () {
     store = redux.createStore(id, {}, enhancer);
   });
 
-  afterEach(function () {
+  afterEach(() => {
     console.log.restore();
     console.group.restore();
     console.groupEnd.restore();
@@ -28,13 +28,13 @@ describe('debug middleware', function () {
     delete window.debug;
   });
 
-  it('logs app state changes when "window.debug" is truthy', function () {
+  it('logs app state changes when "window.debug" is truthy', () => {
     window.debug = true;
     store.dispatch({ type: 'SOMETHING_HAPPENED' });
     assert.called(console.log);
   });
 
-  it('logs nothing when "window.debug" is falsey', function () {
+  it('logs nothing when "window.debug" is falsey', () => {
     store.dispatch({ type: 'SOMETHING_HAPPENED' });
     assert.notCalled(console.log);
   });

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -16,7 +16,7 @@ const fixtures = immutable({
   ],
 });
 
-describe('createSidebarStore', function () {
+describe('createSidebarStore', () => {
   let store;
 
   function tagForID(id) {
@@ -27,22 +27,22 @@ describe('createSidebarStore', function () {
     return storeAnn.$tag;
   }
 
-  beforeEach(function () {
+  beforeEach(() => {
     store = createSidebarStore({});
   });
 
-  describe('initialization', function () {
-    it('does not set a selection when settings.annotations is null', function () {
+  describe('initialization', () => {
+    it('does not set a selection when settings.annotations is null', () => {
       assert.isFalse(store.hasSelectedAnnotations());
       assert.equal(Object.keys(store.expandedMap()).length, 0);
     });
 
-    it('sets the selection when settings.annotations is set', function () {
+    it('sets the selection when settings.annotations is set', () => {
       store = createSidebarStore({ annotations: 'testid' });
       assert.deepEqual(store.selectedAnnotations(), ['testid']);
     });
 
-    it('expands the selected annotations when settings.annotations is set', function () {
+    it('expands the selected annotations when settings.annotations is set', () => {
       store = createSidebarStore({ annotations: 'testid' });
       assert.deepEqual(store.expandedMap(), {
         testid: true,
@@ -93,35 +93,35 @@ describe('createSidebarStore', function () {
     });
   });
 
-  describe('#removeAnnotations()', function () {
-    it('removes annotations from the current state', function () {
+  describe('#removeAnnotations()', () => {
+    it('removes annotations from the current state', () => {
       const annot = defaultAnnotation();
       store.addAnnotations([annot]);
       store.removeAnnotations([annot]);
       assert.deepEqual(store.getState().annotations.annotations, []);
     });
 
-    it('matches annotations to remove by ID', function () {
+    it('matches annotations to remove by ID', () => {
       store.addAnnotations(fixtures.pair);
       store.removeAnnotations([{ id: fixtures.pair[0].id }]);
 
-      const ids = store.getState().annotations.annotations.map(function (a) {
+      const ids = store.getState().annotations.annotations.map(a => {
         return a.id;
       });
       assert.deepEqual(ids, [fixtures.pair[1].id]);
     });
 
-    it('matches annotations to remove by tag', function () {
+    it('matches annotations to remove by tag', () => {
       store.addAnnotations(fixtures.pair);
       store.removeAnnotations([{ $tag: fixtures.pair[0].$tag }]);
 
-      const tags = store.getState().annotations.annotations.map(function (a) {
+      const tags = store.getState().annotations.annotations.map(a => {
         return a.$tag;
       });
       assert.deepEqual(tags, [fixtures.pair[1].$tag]);
     });
 
-    it('switches back to the Annotations tab when the last orphan is removed', function () {
+    it('switches back to the Annotations tab when the last orphan is removed', () => {
       const orphan = Object.assign(defaultAnnotation(), { $orphan: true });
       store.addAnnotations([orphan]);
       store.selectTab('orphan');
@@ -130,8 +130,8 @@ describe('createSidebarStore', function () {
     });
   });
 
-  describe('#clearAnnotations()', function () {
-    it('removes all annotations', function () {
+  describe('#clearAnnotations()', () => {
+    it('removes all annotations', () => {
       const annot = defaultAnnotation();
       store.addAnnotations([annot]);
       store.clearAnnotations();
@@ -139,7 +139,7 @@ describe('createSidebarStore', function () {
     });
   });
 
-  describe('#setShowHighlights()', function () {
+  describe('#setShowHighlights()', () => {
     [{ state: true }, { state: false }].forEach(testCase => {
       it(`sets the visibleHighlights state flag to ${testCase.state}`, () => {
         store.setShowHighlights(testCase.state);
@@ -148,8 +148,8 @@ describe('createSidebarStore', function () {
     });
   });
 
-  describe('#updatingAnchorStatus', function () {
-    it("updates the annotation's orphan flag", function () {
+  describe('#updatingAnchorStatus', () => {
+    it("updates the annotation's orphan flag", () => {
       const annot = defaultAnnotation();
       store.addAnnotations([annot]);
       store.updateAnchorStatus({ [tagForID(annot.id)]: 'orphan' });

--- a/src/sidebar/store/test/util-test.js
+++ b/src/sidebar/store/test/util-test.js
@@ -38,9 +38,9 @@ const fixtures = {
   },
 };
 
-describe('sidebar/store/util', function () {
-  describe('actionTypes', function () {
-    it('returns an object with values equal to keys', function () {
+describe('sidebar/store/util', () => {
+  describe('actionTypes', () => {
+    it('returns an object with values equal to keys', () => {
       assert.deepEqual(
         util.actionTypes({
           SOME_ACTION: sinon.stub(),
@@ -54,8 +54,8 @@ describe('sidebar/store/util', function () {
     });
   });
 
-  describe('createReducer', function () {
-    it('returns an object if input state is undefined', function () {
+  describe('createReducer', () => {
+    it('returns an object if input state is undefined', () => {
       // See redux.js:assertReducerShape in the "redux" package.
       const reducer = util.createReducer(fixtures.update);
       const initialState = reducer(undefined, {
@@ -64,7 +64,7 @@ describe('sidebar/store/util', function () {
       assert.isOk(initialState);
     });
 
-    it('returns a reducer that combines each update function from the input object', function () {
+    it('returns a reducer that combines each update function from the input object', () => {
       const reducer = util.createReducer(fixtures.update);
       const newState = reducer(
         {},
@@ -78,7 +78,7 @@ describe('sidebar/store/util', function () {
       });
     });
 
-    it('returns a new object if the action was handled', function () {
+    it('returns a new object if the action was handled', () => {
       const reducer = util.createReducer(fixtures.update);
       const originalState = { someFlag: false };
       assert.notEqual(
@@ -87,7 +87,7 @@ describe('sidebar/store/util', function () {
       );
     });
 
-    it('returns the original object if the action was not handled', function () {
+    it('returns the original object if the action was not handled', () => {
       const reducer = util.createReducer(fixtures.update);
       const originalState = { someFlag: false };
       assert.equal(
@@ -96,7 +96,7 @@ describe('sidebar/store/util', function () {
       );
     });
 
-    it('preserves state not modified by the update function', function () {
+    it('preserves state not modified by the update function', () => {
       const reducer = util.createReducer(fixtures.update);
       const newState = reducer(
         { otherFlag: false },
@@ -111,7 +111,7 @@ describe('sidebar/store/util', function () {
       });
     });
 
-    it('supports reducer functions that return an array', function () {
+    it('supports reducer functions that return an array', () => {
       const action = {
         type: 'FIRST_ITEM',
         item: 'bar',
@@ -128,7 +128,7 @@ describe('sidebar/store/util', function () {
     });
   });
 
-  describe('bindSelectors', function () {
+  describe('bindSelectors', () => {
     it('binds selectors to current value of module state', () => {
       const getState = sinon.stub().returns({
         namespace1: {
@@ -211,7 +211,7 @@ describe('sidebar/store/util', function () {
       store.setState({ val: 5 });
       return util
         .awaitStateChange(store, getValWhenGreaterThanTwo)
-        .then(function (actual) {
+        .then(actual => {
           assert.equal(actual, expected);
         });
     });

--- a/src/sidebar/store/util.js
+++ b/src/sidebar/store/util.js
@@ -8,7 +8,7 @@
  * @return {{ [index in keyof T]: string }}
  */
 export function actionTypes(reducers) {
-  return Object.keys(reducers).reduce(function (types, key) {
+  return Object.keys(reducers).reduce((types, key) => {
     types[key] = key;
     return types;
   }, /** @type {any} */ ({}));

--- a/src/sidebar/test/cross-origin-rpc-test.js
+++ b/src/sidebar/test/cross-origin-rpc-test.js
@@ -10,14 +10,14 @@ class FakeWindow {
   }
 }
 
-describe('sidebar/cross-origin-rpc', function () {
+describe('sidebar/cross-origin-rpc', () => {
   let fakeStore;
   let fakeWarnOnce;
   let fakeWindow;
   let settings;
   let frame;
 
-  beforeEach(function () {
+  beforeEach(() => {
     fakeStore = {
       changeFocusModeUser: sinon.stub(),
     };
@@ -40,8 +40,8 @@ describe('sidebar/cross-origin-rpc', function () {
     $imports.$restore();
   });
 
-  describe('#startServer', function () {
-    it('sends a response with the "ok" result', function () {
+  describe('#startServer', () => {
+    it('sends a response with the "ok" result', () => {
       startServer(fakeStore, settings, fakeWindow);
 
       fakeWindow.emitter.emit('message', {
@@ -64,7 +64,7 @@ describe('sidebar/cross-origin-rpc', function () {
       );
     });
 
-    it('calls the registered method with the provided params', function () {
+    it('calls the registered method with the provided params', () => {
       startServer(fakeStore, settings, fakeWindow);
 
       fakeWindow.emitter.emit('message', {
@@ -83,7 +83,7 @@ describe('sidebar/cross-origin-rpc', function () {
       );
     });
 
-    it('calls the registered method with no params', function () {
+    it('calls the registered method with no params', () => {
       startServer(fakeStore, settings, fakeWindow);
 
       fakeWindow.emitter.emit('message', {
@@ -98,7 +98,7 @@ describe('sidebar/cross-origin-rpc', function () {
       assert.isTrue(fakeStore.changeFocusModeUser.calledWithExactly());
     });
 
-    it('does not call the unregistered method', function () {
+    it('does not call the unregistered method', () => {
       startServer(fakeStore, settings, fakeWindow);
 
       fakeWindow.emitter.emit('message', {
@@ -132,8 +132,8 @@ describe('sidebar/cross-origin-rpc', function () {
       {},
       { rpcAllowedOrigins: [] },
       { rpcAllowedOrigins: ['https://allowed1.com', 'https://allowed2.com'] },
-    ].forEach(function (settings) {
-      it("doesn't respond if the origin isn't allowed", function () {
+    ].forEach(settings => {
+      it("doesn't respond if the origin isn't allowed", () => {
         startServer(fakeStore, settings, fakeWindow);
 
         fakeWindow.emitter.emit('message', {
@@ -150,7 +150,7 @@ describe('sidebar/cross-origin-rpc', function () {
       });
     });
 
-    it("responds with an error if there's no method", function () {
+    it("responds with an error if there's no method", () => {
       startServer(fakeStore, settings, fakeWindow);
       let jsonRpcRequest = { jsonrpc: '2.0', id: 42 }; // No "method" member.
 
@@ -176,8 +176,8 @@ describe('sidebar/cross-origin-rpc', function () {
       );
     });
 
-    ['unknownMethod', null].forEach(function (method) {
-      it('responds with an error if the method is unknown', function () {
+    ['unknownMethod', null].forEach(method => {
+      it('responds with an error if the method is unknown', () => {
         startServer(fakeStore, settings, fakeWindow);
 
         fakeWindow.emitter.emit('message', {
@@ -204,12 +204,12 @@ describe('sidebar/cross-origin-rpc', function () {
     });
   });
 
-  describe('#preStartServer', function () {
-    beforeEach(function () {
+  describe('#preStartServer', () => {
+    beforeEach(() => {
       preStartServer(fakeWindow);
     });
 
-    it('responds to an incoming request that arrives before the server starts', function () {
+    it('responds to an incoming request that arrives before the server starts', () => {
       fakeWindow.emitter.emit('message', {
         data: { jsonrpc: '2.0', method: 'changeFocusModeUser', id: 42 },
         origin: 'https://allowed1.com',
@@ -228,7 +228,7 @@ describe('sidebar/cross-origin-rpc', function () {
       );
     });
 
-    it('responds to multiple incoming requests that arrive before the server starts', function () {
+    it('responds to multiple incoming requests that arrive before the server starts', () => {
       const messageEvent = id => ({
         data: { jsonrpc: '2.0', method: 'changeFocusModeUser', id },
         origin: 'https://allowed1.com',
@@ -255,7 +255,7 @@ describe('sidebar/cross-origin-rpc', function () {
       assert.isTrue(frame.postMessage.calledWithExactly(...response(44)));
     });
 
-    it("does not respond to pre-start incoming requests if the origin isn't allowed", function () {
+    it("does not respond to pre-start incoming requests if the origin isn't allowed", () => {
       fakeWindow.emitter.emit('message', {
         data: { jsonrpc: '2.0', method: 'changeFocusModeUser', id: 42 },
         origin: 'https://fake.com',

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -44,7 +44,7 @@ describe('integration: annotation threading', () => {
   let store;
   let forceUpdate;
 
-  beforeEach(function () {
+  beforeEach(() => {
     const container = new Injector()
       .register('store', { factory: createSidebarStore })
       .register('annotationsService', () => {})

--- a/src/sidebar/test/markdown-commands-test.js
+++ b/src/sidebar/test/markdown-commands-test.js
@@ -42,25 +42,25 @@ function formatState(state) {
   );
 }
 
-describe('markdown commands', function () {
-  describe('span formatting', function () {
+describe('markdown commands', () => {
+  describe('span formatting', () => {
     function toggle(state, prefix, suffix, placeholder) {
       prefix = prefix || '**';
       suffix = suffix || '**';
       return commands.toggleSpanStyle(state, prefix, suffix, placeholder);
     }
 
-    it('adds formatting to spans', function () {
+    it('adds formatting to spans', () => {
       const output = toggle(parseState('make <sel>text</sel> bold'));
       assert.equal(formatState(output), 'make **<sel>text</sel>** bold');
     });
 
-    it('removes formatting from spans', function () {
+    it('removes formatting from spans', () => {
       const output = toggle(parseState('make **<sel>text</sel>** bold'));
       assert.equal(formatState(output), 'make <sel>text</sel> bold');
     });
 
-    it('adds formatting to spans when the prefix and suffix differ', function () {
+    it('adds formatting to spans when the prefix and suffix differ', () => {
       const output = toggle(
         parseState('make <sel>math</sel> mathy'),
         '\\(',
@@ -69,7 +69,7 @@ describe('markdown commands', function () {
       assert.equal(formatState(output), 'make \\(<sel>math</sel>\\) mathy');
     });
 
-    it('inserts placeholders if the selection is empty', function () {
+    it('inserts placeholders if the selection is empty', () => {
       const output = toggle(
         parseState('make <sel></sel> bold'),
         '**',
@@ -80,7 +80,7 @@ describe('markdown commands', function () {
     });
   });
 
-  describe('block formatting', function () {
+  describe('block formatting', () => {
     [
       {
         tag: 'adds formatting to blocks',
@@ -113,7 +113,7 @@ describe('markdown commands', function () {
     });
   });
 
-  describe('link formatting', function () {
+  describe('link formatting', () => {
     const linkify = function (text, linkType) {
       return commands.convertSelectionToLink(parseState(text), linkType);
     };
@@ -144,7 +144,7 @@ describe('markdown commands', function () {
       });
     });
 
-    it('converts URLs to image links', function () {
+    it('converts URLs to image links', () => {
       const output = linkify(
         'one <sel>http://foobar.com</sel> three',
         commands.LinkType.IMAGE_LINK

--- a/src/sidebar/test/media-embedder-test.js
+++ b/src/sidebar/test/media-embedder-test.js
@@ -1,6 +1,6 @@
 import * as mediaEmbedder from '../media-embedder.js';
 
-describe('sidebar/media-embedder', function () {
+describe('sidebar/media-embedder', () => {
   function domElement(html) {
     const element = document.createElement('div');
     element.innerHTML = html;
@@ -39,7 +39,7 @@ describe('sidebar/media-embedder', function () {
     });
   }
 
-  it('replaces YouTube watch links with iframes', function () {
+  it('replaces YouTube watch links with iframes', () => {
     const urls = [
       'https://www.youtube.com/watch?v=QCkm0lL-6lc',
       'https://www.youtube.com/watch/?v=QCkm0lL-6lc',
@@ -47,7 +47,7 @@ describe('sidebar/media-embedder', function () {
       'https://www.youtube.com/watch?foo=bar&v=QCkm0lL-6lc&h=j',
       'https://www.youtube.com/watch?v=QCkm0lL-6lc&foo=bar',
     ];
-    urls.forEach(function (url) {
+    urls.forEach(url => {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -59,13 +59,13 @@ describe('sidebar/media-embedder', function () {
     });
   });
 
-  it('allows whitelisted parameters in YouTube watch URLs', function () {
+  it('allows whitelisted parameters in YouTube watch URLs', () => {
     const urls = [
       'https://www.youtube.com/watch?v=QCkm0lL-6lc&start=5&end=10',
       'https://www.youtube.com/watch?v=QCkm0lL-6lc&end=10&start=5',
       'https://www.youtube.com/watch/?v=QCkm0lL-6lc&end=10&start=5',
     ];
-    urls.forEach(function (url) {
+    urls.forEach(url => {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -81,13 +81,13 @@ describe('sidebar/media-embedder', function () {
     });
   });
 
-  it('translates YouTube watch `t` param to `start` for embed', function () {
+  it('translates YouTube watch `t` param to `start` for embed', () => {
     const urls = [
       'https://www.youtube.com/watch?v=QCkm0lL-6lc&t=5&end=10',
       'https://www.youtube.com/watch?v=QCkm0lL-6lc&end=10&t=5',
       'https://www.youtube.com/watch/?v=QCkm0lL-6lc&end=10&t=5',
     ];
-    urls.forEach(function (url) {
+    urls.forEach(url => {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -99,7 +99,7 @@ describe('sidebar/media-embedder', function () {
     });
   });
 
-  it('parses YouTube `t` param values into seconds', function () {
+  it('parses YouTube `t` param values into seconds', () => {
     const cases = [
       [
         'https://www.youtube.com/watch?v=QCkm0lL-6lc&t=5m',
@@ -142,7 +142,7 @@ describe('sidebar/media-embedder', function () {
         'https://www.youtube.com/embed/QCkm0lL-6lc?start=10',
       ],
     ];
-    cases.forEach(function (url) {
+    cases.forEach(url => {
       const element = domElement('<a href="' + url[0] + '">' + url[0] + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -151,12 +151,12 @@ describe('sidebar/media-embedder', function () {
     });
   });
 
-  it('excludes non-whitelisted params in YouTube watch links', function () {
+  it('excludes non-whitelisted params in YouTube watch links', () => {
     const urls = [
       'https://www.youtube.com/watch?v=QCkm0lL-6lc&start=5&end=10&baz=dingdong',
       'https://www.youtube.com/watch/?v=QCkm0lL-6lc&autoplay=1&end=10&start=5',
     ];
-    urls.forEach(function (url) {
+    urls.forEach(url => {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -170,12 +170,12 @@ describe('sidebar/media-embedder', function () {
     });
   });
 
-  it('replaces YouTube share links with iframes', function () {
+  it('replaces YouTube share links with iframes', () => {
     const urls = [
       'https://youtu.be/QCkm0lL-6lc',
       'https://youtu.be/QCkm0lL-6lc/',
     ];
-    urls.forEach(function (url) {
+    urls.forEach(url => {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -187,12 +187,12 @@ describe('sidebar/media-embedder', function () {
     });
   });
 
-  it('allows whitelisted parameters in YouTube share links', function () {
+  it('allows whitelisted parameters in YouTube share links', () => {
     const urls = [
       'https://youtu.be/QCkm0lL-6lc?start=5&end=10',
       'https://youtu.be/QCkm0lL-6lc/?end=10&start=5',
     ];
-    urls.forEach(function (url) {
+    urls.forEach(url => {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -206,12 +206,12 @@ describe('sidebar/media-embedder', function () {
     });
   });
 
-  it('translates YouTube share URL `t` param to `start` for embed', function () {
+  it('translates YouTube share URL `t` param to `start` for embed', () => {
     const urls = [
       'https://youtu.be/QCkm0lL-6lc?t=5&end=10',
       'https://youtu.be/QCkm0lL-6lc/?end=10&t=5',
     ];
-    urls.forEach(function (url) {
+    urls.forEach(url => {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -223,12 +223,12 @@ describe('sidebar/media-embedder', function () {
     });
   });
 
-  it('excludes non-whitelisted params in YouTube share links', function () {
+  it('excludes non-whitelisted params in YouTube share links', () => {
     const urls = [
       'https://youtu.be/QCkm0lL-6lc?foo=bar&t=5&end=10&baz=dingdong',
       'https://youtu.be/QCkm0lL-6lc/?autoplay=1&end=10&t=5',
     ];
-    urls.forEach(function (url) {
+    urls.forEach(url => {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -240,7 +240,7 @@ describe('sidebar/media-embedder', function () {
     });
   });
 
-  it('replaces Vimeo links with iframes', function () {
+  it('replaces Vimeo links with iframes', () => {
     const urls = [
       'https://vimeo.com/149000090',
       'https://vimeo.com/149000090/',
@@ -249,7 +249,7 @@ describe('sidebar/media-embedder', function () {
       'https://vimeo.com/149000090?foo=bar&a=b',
       'https://vimeo.com/149000090/?foo=bar&a=b',
     ];
-    urls.forEach(function (url) {
+    urls.forEach(url => {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -261,7 +261,7 @@ describe('sidebar/media-embedder', function () {
     });
   });
 
-  it('replaces Vimeo channel links with iframes', function () {
+  it('replaces Vimeo channel links with iframes', () => {
     const urls = [
       'https://vimeo.com/channels/staffpicks/148845534',
       'https://vimeo.com/channels/staffpicks/148845534/',
@@ -271,7 +271,7 @@ describe('sidebar/media-embedder', function () {
       'https://vimeo.com/channels/staffpicks/148845534?foo=bar&id=1',
       'https://vimeo.com/channels/otherchannel/148845534',
     ];
-    urls.forEach(function (url) {
+    urls.forEach(url => {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -299,7 +299,7 @@ describe('sidebar/media-embedder', function () {
     });
   });
 
-  it('replaces internet archive links with iframes', function () {
+  it('replaces internet archive links with iframes', () => {
     const urls = [
       // Video details page.
       'https://archive.org/details/PATH',
@@ -313,7 +313,7 @@ describe('sidebar/media-embedder', function () {
       // Embed link generated by the "Share" links on the details pages.
       'https://archive.org/embed/PATH?start=360&end=420.3',
     ];
-    urls.forEach(function (url) {
+    urls.forEach(url => {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -327,7 +327,7 @@ describe('sidebar/media-embedder', function () {
     });
   });
 
-  it('replaces audio links with html5 audio elements', function () {
+  it('replaces audio links with html5 audio elements', () => {
     const urls = [
       'https://archive.org/download/testmp3testfile/mpthreetest.mp3',
       'https://archive.org/download/testmp3testfile/mpthreetest.mp3#fragment',
@@ -341,7 +341,7 @@ describe('sidebar/media-embedder', function () {
       'https://wisc.pb.unizin.org/frenchcscr/wp-content/uploads/sites/208/2018/03/6Léry_Conclusion.mp3',
       'https://wisc.pb.unizin.org/frenchcscr/wp-content/uploads/sites/208/2018/03/6L%25C3%25A9ry_Conclusion.mp3',
     ];
-    urls.forEach(function (url) {
+    urls.forEach(url => {
       const element = domElement('<a href="' + url + '">' + url + '</a>');
 
       mediaEmbedder.replaceLinksWithEmbeds(element);
@@ -361,7 +361,7 @@ describe('sidebar/media-embedder', function () {
     });
   });
 
-  it('does not replace links if the link text is different', function () {
+  it('does not replace links if the link text is different', () => {
     const url = 'https://youtu.be/QCkm0lL-6lc';
     const element = domElement('<a href="' + url + '">different label</a>');
 
@@ -371,7 +371,7 @@ describe('sidebar/media-embedder', function () {
     assert.equal(element.children[0].tagName, 'A');
   });
 
-  it('does not replace non-media links', function () {
+  it('does not replace non-media links', () => {
     const url = 'https://example.com/example.html';
     const element = domElement('<a href="' + url + '">' + url + '</a>');
 
@@ -381,7 +381,7 @@ describe('sidebar/media-embedder', function () {
     assert.equal(element.children[0].tagName, 'A');
   });
 
-  it('does not mess with the rest of the HTML', function () {
+  it('does not mess with the rest of the HTML', () => {
     const url = 'https://www.youtube.com/watch?v=QCkm0lL-6lc';
     const element = domElement(
       '<p>Look at this video:</p>\n\n' +
@@ -400,7 +400,7 @@ describe('sidebar/media-embedder', function () {
     assert.equal(element.children[2].outerHTML, "<p>Isn't it cool!</p>");
   });
 
-  it('replaces multiple links with multiple embeds', function () {
+  it('replaces multiple links with multiple embeds', () => {
     const url1 = 'https://www.youtube.com/watch?v=QCkm0lL-6lc';
     const url2 = 'https://youtu.be/abcdefg';
     const element = domElement(

--- a/src/sidebar/test/search-client-test.js
+++ b/src/sidebar/test/search-client-test.js
@@ -1,7 +1,7 @@
 import { ResultSizeError, SearchClient } from '../search-client';
 
 function awaitEvent(emitter, event) {
-  return new Promise(function (resolve) {
+  return new Promise(resolve => {
     emitter.on(event, resolve);
   });
 }

--- a/src/sidebar/test/websocket-test.js
+++ b/src/sidebar/test/websocket-test.js
@@ -6,7 +6,7 @@ import {
   RECONNECT_MIN_DELAY,
 } from '../websocket';
 
-describe('websocket wrapper', function () {
+describe('websocket wrapper', () => {
   let fakeSocket;
   let clock;
   let connectionCount;
@@ -24,7 +24,7 @@ describe('websocket wrapper', function () {
 
   const WebSocket = window.WebSocket;
 
-  beforeEach(function () {
+  beforeEach(() => {
     global.WebSocket = FakeWebSocket;
     clock = sinon.useFakeTimers();
     connectionCount = 0;
@@ -35,7 +35,7 @@ describe('websocket wrapper', function () {
     sinon.stub(console, 'error');
   });
 
-  afterEach(function () {
+  afterEach(() => {
     global.WebSocket = WebSocket;
     clock.restore();
     console.warn.restore();
@@ -43,7 +43,7 @@ describe('websocket wrapper', function () {
   });
 
   context('when the connection is closed by the browser or server', () => {
-    it('should reconnect after an abnormal disconnection', function () {
+    it('should reconnect after an abnormal disconnection', () => {
       new Socket('ws://test:1234');
       assert.ok(fakeSocket);
       const initialSocket = fakeSocket;
@@ -54,7 +54,7 @@ describe('websocket wrapper', function () {
       assert.notEqual(fakeSocket, initialSocket);
     });
 
-    it('should reconnect if initial connection fails', function () {
+    it('should reconnect if initial connection fails', () => {
       new Socket('ws://test:1234');
       assert.ok(fakeSocket);
       const initialSocket = fakeSocket;
@@ -65,7 +65,7 @@ describe('websocket wrapper', function () {
       assert.notEqual(fakeSocket, initialSocket);
     });
 
-    it('should send queued messages after a reconnect', function () {
+    it('should send queued messages after a reconnect', () => {
       // simulate WebSocket setup and initial connection
       const socket = new Socket('ws://test:1234');
       fakeSocket.onopen({});
@@ -80,7 +80,7 @@ describe('websocket wrapper', function () {
     });
 
     [CLOSE_NORMAL, CLOSE_GOING_AWAY].forEach(closeCode => {
-      it('should not reconnect after a normal disconnection', function () {
+      it('should not reconnect after a normal disconnection', () => {
         new Socket('ws://test:1234');
         assert.ok(fakeSocket);
         const initialSocket = fakeSocket;
@@ -117,7 +117,7 @@ describe('websocket wrapper', function () {
     });
   });
 
-  it('should queue messages sent prior to connection', function () {
+  it('should queue messages sent prior to connection', () => {
     const socket = new Socket('ws://test:1234');
     socket.send({ abc: 'foo' });
     assert.notCalled(fakeSocket.send);
@@ -125,7 +125,7 @@ describe('websocket wrapper', function () {
     assert.calledWith(fakeSocket.send, '{"abc":"foo"}');
   });
 
-  it('should send messages immediately when connected', function () {
+  it('should send messages immediately when connected', () => {
     const socket = new Socket('ws://test:1234');
     fakeSocket.readyState = FakeWebSocket.OPEN;
     socket.send({ abc: 'foo' });

--- a/src/sidebar/util/collections.js
+++ b/src/sidebar/util/collections.js
@@ -11,7 +11,7 @@
  * @return {number}
  */
 export function countIf(ary, predicate) {
-  return ary.reduce(function (count, item) {
+  return ary.reduce((count, item) => {
     return predicate(item) ? count + 1 : count;
   }, 0);
 }

--- a/src/sidebar/util/test/memoize-test.js
+++ b/src/sidebar/util/test/memoize-test.js
@@ -1,6 +1,6 @@
 import memoize from '../memoize';
 
-describe('memoize', function () {
+describe('memoize', () => {
   let count = 0;
   let memoized;
 
@@ -9,22 +9,22 @@ describe('memoize', function () {
     return arg * arg;
   }
 
-  beforeEach(function () {
+  beforeEach(() => {
     count = 0;
     memoized = memoize(square);
   });
 
-  it('computes the result of the function', function () {
+  it('computes the result of the function', () => {
     assert.equal(memoized(12), 144);
   });
 
-  it('does not recompute if the input is unchanged', function () {
+  it('does not recompute if the input is unchanged', () => {
     memoized(42);
     memoized(42);
     assert.equal(count, 1);
   });
 
-  it('recomputes if the input changes', function () {
+  it('recomputes if the input changes', () => {
     memoized(42);
     memoized(39);
     assert.equal(count, 2);

--- a/src/sidebar/util/test/retry-test.js
+++ b/src/sidebar/util/test/retry-test.js
@@ -1,18 +1,18 @@
 import * as retryUtil from '../retry';
 
-describe('sidebar.util.retry', function () {
-  describe('.retryPromiseOperation', function () {
-    it('should return the result of the operation function', function () {
+describe('sidebar.util.retry', () => {
+  describe('.retryPromiseOperation', () => {
+    it('should return the result of the operation function', () => {
       const operation = sinon.stub().returns(Promise.resolve(42));
       const wrappedOperation = retryUtil.retryPromiseOperation(operation);
-      return wrappedOperation.then(function (result) {
+      return wrappedOperation.then(result => {
         assert.equal(result, 42);
       });
     });
 
-    it('should retry the operation if it fails', function () {
+    it('should retry the operation if it fails', () => {
       const results = [new Error('fail'), 'ok'];
-      const operation = sinon.spy(function () {
+      const operation = sinon.spy(() => {
         const nextResult = results.shift();
         if (nextResult instanceof Error) {
           return Promise.reject(nextResult);
@@ -23,14 +23,14 @@ describe('sidebar.util.retry', function () {
       const wrappedOperation = retryUtil.retryPromiseOperation(operation, {
         minTimeout: 1,
       });
-      return wrappedOperation.then(function (result) {
+      return wrappedOperation.then(result => {
         assert.equal(result, 'ok');
       });
     });
 
-    it('should return the error if it repeatedly fails', async function () {
+    it('should return the error if it repeatedly fails', async () => {
       const error = new Error('error');
-      const operation = sinon.spy(function () {
+      const operation = sinon.spy(() => {
         return Promise.reject(error);
       });
       const wrappedOperation = retryUtil.retryPromiseOperation(operation, {

--- a/src/sidebar/util/test/url-test.js
+++ b/src/sidebar/util/test/url-test.js
@@ -1,22 +1,22 @@
 import { replaceURLParams } from '../url';
 
-describe('sidebar/util/url', function () {
-  describe('replaceURLParams()', function () {
-    it('should replace params in URLs', function () {
+describe('sidebar/util/url', () => {
+  describe('replaceURLParams()', () => {
+    it('should replace params in URLs', () => {
       const replaced = replaceURLParams('http://foo.com/things/:id', {
         id: 'test',
       });
       assert.equal(replaced.url, 'http://foo.com/things/test');
     });
 
-    it('should URL encode params in URLs', function () {
+    it('should URL encode params in URLs', () => {
       const replaced = replaceURLParams('http://foo.com/things/:id', {
         id: 'foo=bar',
       });
       assert.equal(replaced.url, 'http://foo.com/things/foo%3Dbar');
     });
 
-    it('should return unused params', function () {
+    it('should return unused params', () => {
       const replaced = replaceURLParams('http://foo.com/:id', {
         id: 'test',
         q: 'unused',


### PR DESCRIPTION
We've been gradually converting anonymous functions to arrow functions
since adopting ES6. This commit uses ESLint to finish the process by
converting the remaining non-named, non-`this`-using callbacks to arrow
functions.

 - Enable `prefer-arrow-callbacks` lint rule. The `allowNamedFunctions`
   option is enabled because we have a few instances (eg. in
   gulpfile.js) of explicitly naming functions for use in debugging /
   logging etc.
 - Run `eslint --fix .` and `yarn format` to automatically fix up the
   code
