### PR TITLE
Always use object shorthand for properties

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,7 @@
   "extends": ["hypothesis", "plugin:jsx-a11y/recommended"],
   "rules": {
     "prefer-arrow-callback": ["error", { "allowNamedFunctions": true }],
+    "object-shorthand": ["error", "properties"],
 
     // Suppressed to make ESLint v6 migration easier.
     "no-prototype-builtins": "off",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,7 @@ function parseCommandLine() {
 
   const { grep, watch, browser } = commander.opts();
   const karmaOptions = {
-    grep: grep,
+    grep,
     singleRun: !watch,
   };
 
@@ -69,7 +69,7 @@ gulp.task('build-vendor-js', () => {
   Object.keys(vendorBundles.bundles).forEach(name => {
     finished.push(
       createBundle({
-        name: name,
+        name,
         require: vendorBundles.bundles[name],
         minify: IS_PRODUCTION_BUILD,
         path: SCRIPT_DIR,

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -172,6 +172,6 @@ export default function settingsFrom(window_) {
     get query() {
       return query();
     },
-    hostPageSetting: hostPageSetting,
+    hostPageSetting,
   };
 }

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -62,7 +62,7 @@ describe('annotator/config/settingsFrom', () => {
   function fakeWindow(href) {
     return {
       location: {
-        href: href,
+        href,
       },
       document: {
         querySelector: sinon.stub().returns({ href: 'hi' }),

--- a/src/shared/frame-rpc.js
+++ b/src/shared/frame-rpc.js
@@ -127,7 +127,7 @@ export class RPC {
         protocol: 'frame-rpc',
         version: VERSION,
         sequence: seq,
-        method: method,
+        method,
         arguments: args,
       },
       this.origin

--- a/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
@@ -249,7 +249,7 @@ describe('AnnotationHeader', () => {
       fakeHasBeenEdited.returns(true);
 
       const wrapper = createAnnotationHeader({
-        annotation: annotation,
+        annotation,
       });
       const timestamp = wrapper.find('AnnotationTimestamps');
       assert.equal(timestamp.props().withEditedTimestamp, true);
@@ -272,7 +272,7 @@ describe('AnnotationHeader', () => {
       fakeIsReply.returns(true);
 
       const wrapper = createAnnotationHeader({
-        annotation: annotation,
+        annotation,
         threadIsCollapsed: true,
       });
 

--- a/src/sidebar/components/TagList.js
+++ b/src/sidebar/components/TagList.js
@@ -30,7 +30,7 @@ function TagList({ annotation, tags }) {
    * @return {string}
    */
   const createTagSearchURL = tag => {
-    return store.getLink('search.tag', { tag: tag });
+    return store.getLink('search.tag', { tag });
   };
 
   return (

--- a/src/sidebar/helpers/annotation-metadata.js
+++ b/src/sidebar/helpers/annotation-metadata.js
@@ -26,9 +26,9 @@ export function documentMetadata(annotation) {
   }
 
   return {
-    uri: uri,
-    domain: domain,
-    title: title,
+    uri,
+    domain,
+    title,
   };
 }
 

--- a/src/sidebar/helpers/test/groups-test.js
+++ b/src/sidebar/helpers/test/groups-test.js
@@ -207,7 +207,7 @@ describe('sidebar/helpers/groups', () => {
       },
     ].forEach(({ description, scopes, isScopedToUri, uri }) => {
       it(description, () => {
-        const userGroups = [{ id: 'groupa', name: 'GroupA', scopes: scopes }];
+        const userGroups = [{ id: 'groupa', name: 'GroupA', scopes }];
         const featuredGroups = [];
 
         const groups = combineGroups(userGroups, featuredGroups, uri);

--- a/src/sidebar/render-markdown.js
+++ b/src/sidebar/render-markdown.js
@@ -17,7 +17,7 @@ function targetBlank() {
   function filter(text) {
     return text.replace(/<a href=/g, '<a target="_blank" href=');
   }
-  return [{ type: 'output', filter: filter }];
+  return [{ type: 'output', filter }];
 }
 
 let converter;
@@ -86,7 +86,7 @@ function extractMath(content) {
     const id = mathBlocks.length + 1;
     const placeholder = mathPlaceholder(id);
     mathBlocks.push({
-      id: id,
+      id,
       expression: replacedContent.slice(mathStart + 2, mathEnd - 2),
       inline: inlineMathStart !== -1,
     });
@@ -108,7 +108,7 @@ function extractMath(content) {
   }
 
   return {
-    mathBlocks: mathBlocks,
+    mathBlocks,
     content: replacedContent,
   };
 }

--- a/src/sidebar/services/annotations.js
+++ b/src/sidebar/services/annotations.js
@@ -81,7 +81,7 @@ export class AnnotationsService {
         updated: now.toISOString(),
         user: userid,
         user_info: userInfo,
-        $tag: $tag,
+        $tag,
         hidden: false,
         links: {},
       },

--- a/src/sidebar/services/test/load-annotations-test.js
+++ b/src/sidebar/services/test/load-annotations-test.js
@@ -109,7 +109,7 @@ describe('LoadAnnotationsService', () => {
   function createService() {
     fakeStore.frames.returns(
       fakeUris.map(uri => {
-        return { uri: uri };
+        return { uri };
       })
     );
     return new LoadAnnotationsService(
@@ -167,7 +167,7 @@ describe('LoadAnnotationsService', () => {
       // Override the default frames set by the service call above.
       fakeStore.frames.returns([
         {
-          uri: uri,
+          uri,
           metadata: {
             documentFingerprint: 'fingerprint',
             link: [

--- a/src/sidebar/services/test/persisted-defaults-test.js
+++ b/src/sidebar/services/test/persisted-defaults-test.js
@@ -126,12 +126,12 @@ describe('PersistedDefaultsService', () => {
         const defaults = { focusedGroup: 'carrots' };
         fakeLocalStorage.getItem.returns('carrots');
         fakeStore.getDefaults.returns(defaults);
-        fakeStore.setState({ defaults: defaults });
+        fakeStore.setState({ defaults });
         const svc = createService();
         svc.init();
 
         fakeStore.getDefaults.returns(defaults);
-        fakeStore.setState({ defaults: defaults });
+        fakeStore.setState({ defaults });
 
         assert.notCalled(fakeLocalStorage.setItem);
       });

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -432,7 +432,7 @@ describe('StreamerService', () => {
         };
         fakeWebSocket.notify({
           type: 'session-change',
-          model: model,
+          model,
         });
         assert.ok(fakeSession.update.calledWith(model));
         assert.calledOnce(fakeGroups.load);

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -157,7 +157,7 @@ const reducers = {
 
     return {
       annotations: added.concat(updated).concat(unchanged),
-      nextTag: nextTag,
+      nextTag,
     };
   },
 
@@ -212,7 +212,7 @@ const reducers = {
         return Object.assign({}, annot, { $orphan: state === 'orphan' });
       }
     });
-    return { annotations: annotations };
+    return { annotations };
   },
 
   UPDATE_FLAG_STATUS: function (state, action) {
@@ -237,7 +237,7 @@ const reducers = {
         return annot;
       }
     });
-    return { annotations: annotations };
+    return { annotations };
   },
 };
 
@@ -258,7 +258,7 @@ function addAnnotations(annotations) {
 
     dispatch({
       type: actions.ADD_ANNOTATIONS,
-      annotations: annotations,
+      annotations,
       currentAnnotationCount: getState().annotations.annotations.length,
     });
 
@@ -327,7 +327,7 @@ function focusAnnotations(tags) {
 function hideAnnotation(id) {
   return {
     type: actions.HIDE_ANNOTATION,
-    id: id,
+    id,
   };
 }
 
@@ -378,7 +378,7 @@ export function removeAnnotations(annotations) {
 function unhideAnnotation(id) {
   return {
     type: actions.UNHIDE_ANNOTATION,
-    id: id,
+    id,
   };
 }
 
@@ -406,8 +406,8 @@ function updateAnchorStatus(statusUpdates) {
 function updateFlagStatus(id, isFlagged) {
   return {
     type: actions.UPDATE_FLAG_STATUS,
-    id: id,
-    isFlagged: isFlagged,
+    id,
+    isFlagged,
   };
 }
 

--- a/src/sidebar/store/modules/defaults.js
+++ b/src/sidebar/store/modules/defaults.js
@@ -30,7 +30,7 @@ const reducers = {
 const actions = util.actionTypes(reducers);
 
 function setDefault(defaultKey, value) {
-  return { type: actions.SET_DEFAULT, defaultKey: defaultKey, value: value };
+  return { type: actions.SET_DEFAULT, defaultKey, value };
 }
 
 /** Selectors */

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -55,7 +55,7 @@ const actions = util.actionTypes(reducers);
  * @param {Frame} frame
  */
 function connectFrame(frame) {
-  return { type: actions.CONNECT_FRAME, frame: frame };
+  return { type: actions.CONNECT_FRAME, frame };
 }
 
 /**
@@ -64,7 +64,7 @@ function connectFrame(frame) {
  * @param {Frame} frame
  */
 function destroyFrame(frame) {
-  return { type: actions.DESTROY_FRAME, frame: frame };
+  return { type: actions.DESTROY_FRAME, frame };
 }
 
 /**
@@ -77,7 +77,7 @@ function updateFrameAnnotationFetchStatus(uri, isFetchComplete) {
   return {
     type: actions.UPDATE_FRAME_ANNOTATION_FETCH_STATUS,
     isAnnotationFetchComplete: isFetchComplete,
-    uri: uri,
+    uri,
   };
 }
 

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -281,7 +281,7 @@ function setForcedVisible(id, visible) {
 function setSortKey(key) {
   return {
     type: actions.SET_SORT_KEY,
-    key: key,
+    key,
   };
 }
 

--- a/src/sidebar/store/modules/sidebar-panels.js
+++ b/src/sidebar/store/modules/sidebar-panels.js
@@ -83,7 +83,7 @@ const actions = util.actionTypes(reducers);
  * @param {PanelName} panelName
  */
 function openSidebarPanel(panelName) {
-  return { type: actions.OPEN_SIDEBAR_PANEL, panelName: panelName };
+  return { type: actions.OPEN_SIDEBAR_PANEL, panelName };
 }
 
 /**
@@ -92,7 +92,7 @@ function openSidebarPanel(panelName) {
  * @param {PanelName} panelName
  */
 function closeSidebarPanel(panelName) {
-  return { type: actions.CLOSE_SIDEBAR_PANEL, panelName: panelName };
+  return { type: actions.CLOSE_SIDEBAR_PANEL, panelName };
 }
 
 /**
@@ -106,8 +106,8 @@ function closeSidebarPanel(panelName) {
 function toggleSidebarPanel(panelName, panelState) {
   return {
     type: actions.TOGGLE_SIDEBAR_PANEL,
-    panelName: panelName,
-    panelState: panelState,
+    panelName,
+    panelState,
   };
 }
 

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -33,7 +33,7 @@ describe('sidebar/store/modules/session', () => {
       { userid: null, expectedIsLoggedIn: false },
     ].forEach(({ userid, expectedIsLoggedIn }) => {
       it('returns whether the user is logged in', () => {
-        store.updateProfile({ userid: userid });
+        store.updateProfile({ userid });
         assert.equal(store.isLoggedIn(), expectedIsLoggedIn);
       });
     });

--- a/src/sidebar/test/cross-origin-rpc-test.js
+++ b/src/sidebar/test/cross-origin-rpc-test.js
@@ -182,7 +182,7 @@ describe('sidebar/cross-origin-rpc', () => {
 
         fakeWindow.emitter.emit('message', {
           origin: 'https://allowed1.com',
-          data: { jsonrpc: '2.0', method: method, id: 42 },
+          data: { jsonrpc: '2.0', method, id: 42 },
           source: frame,
         });
 

--- a/src/sidebar/test/fake-redux-store.js
+++ b/src/sidebar/test/fake-redux-store.js
@@ -23,7 +23,7 @@ export default function fakeStore(initialState, methods) {
   const store = redux.createStore(update, initialState);
 
   store.setState = function (state) {
-    store.dispatch({ type: 'SET_STATE', state: state });
+    store.dispatch({ type: 'SET_STATE', state });
   };
 
   return Object.assign(store, methods);

--- a/src/sidebar/test/group-fixtures.js
+++ b/src/sidebar/test/group-fixtures.js
@@ -6,8 +6,8 @@ export function group() {
   const id = chance.hash({ length: 15 });
   const name = chance.string();
   const group = {
-    id: id,
-    name: name,
+    id,
+    name,
     links: {
       html: `http://localhost:5000/groups/${id}/${name}`,
     },

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -190,7 +190,7 @@ export default class OAuthClient {
         origin: $window.location.origin,
         response_mode: 'web_message',
         response_type: 'code',
-        state: state,
+        state,
       });
 
     // @ts-ignore - TS doesn't know about `location = <string>`.
@@ -248,10 +248,10 @@ export default class OAuthClient {
     // key=value format.
     const authWindowSettings = queryString
       .stringify({
-        left: left,
-        top: top,
-        width: width,
-        height: height,
+        left,
+        top,
+        width,
+        height,
       })
       .replace(/&/g, ',');
 


### PR DESCRIPTION
Enforce the use of object shorthand syntax everywhere for consistency.
eg. `{ foo }` instead of `{ foo: foo }`. We had already converted most
occurrences manually.

For the moment this only applies to properties and not methods, to avoid a conflict with https://github.com/hypothesis/client/pull/3568. (ie. `{ foo: function () { ... } }` is not converted to `{ foo() { ... } }`.)