### PR TITLE
Fix tag service to work with non-English words

### DIFF
--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -41,12 +41,15 @@ export class TagsService {
     //   (e.g. tag "pink banana" matches query "ban"), OR
     // * tag has substring query occurring after a non-word character
     //   (e.g. tag "pink!banana" matches query "ban")
-    let regex = new RegExp('(\\W|\\b)' + query, 'i');
     return savedTags.filter(tag => {
-      if (tag.match(regex)) {
-        if (limit === null || resultCount < limit) {
-          // limit allows a subset of the results
-          // See https://github.com/hypothesis/client/issues/1606
+      const words = tag.split(/\W+/);
+      let regex = new RegExp(`^${query}`, 'i'); // Only match the start of the string
+      // limit allows a subset of the results
+      // See https://github.com/hypothesis/client/issues/1606
+      if (limit === null || resultCount < limit) {
+        const matches =
+          words.some(word => word.match(regex)) || tag.match(regex);
+        if (matches) {
           ++resultCount;
           return true;
         }

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -38,12 +38,7 @@ export class TagsService {
   filter(query, limit = null) {
     const savedTags = this._storage.getObject(TAGS_LIST_KEY) || [];
     let resultCount = 0;
-    // query will match tag if:
-    // * tag starts with query (e.g. tag "banana" matches query "ban"), OR
-    // * any word in the tag starts with query
-    //   (e.g. tag "pink banana" matches query "ban"), OR
-    // * tag has substring query occurring after a non-word character
-    //   (e.g. tag "pink!banana" matches query "ban")
+    // Match any tag where the query is a prefix of the tag or a word within the tag.
     return savedTags.filter(tag => {
       if (limit !== null && resultCount >= limit) {
         // limit allows a subset of the results

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -57,7 +57,7 @@ describe('TagsService', () => {
         updated: stamp,
       },
       ინგლისური: {
-        // "English" in Georgian
+        // Non-ASCII characters. This is "English" in Georgian
         text: 'ინგლისური',
         count: 1,
         updated: stamp,
@@ -100,7 +100,7 @@ describe('TagsService', () => {
       assert.deepEqual(tags.filter('^žŸ¡\\'), ['^žŸ¡\\¢£¤']);
     });
 
-    it('returns non-English tags that start with the query string', () => {
+    it('returns non-ASCII tags that start with the query string', () => {
       assert.deepEqual(tags.filter('ინ'), ['ინგლისური']);
     });
   });

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -56,9 +56,15 @@ describe('TagsService', () => {
         count: 1,
         updated: stamp,
       },
-      'žŸ¡¢£¤¥¦§': {
-        // ASCII chars
-        text: 'žŸ¡¢£¤¥¦§',
+      ინგლისური: {
+        // "English" in Georgian
+        text: 'ინგლისური',
+        count: 1,
+        updated: stamp,
+      },
+      '^žŸ¡\\¢£¤': {
+        // Non-word ASCII with special regex chars
+        text: '^žŸ¡\\¢£¤',
         count: 1,
         updated: stamp,
       },
@@ -90,8 +96,12 @@ describe('TagsService', () => {
       assert.deepEqual(tags.filter('b', 3), ['bar', 'bar argon', 'banana']);
     });
 
-    it('returns ASCII tags that start with the query string', () => {
-      assert.deepEqual(tags.filter('žŸ¡'), ['žŸ¡¢£¤¥¦§']);
+    it('returns non-word ASCII tags that start with the query string', () => {
+      assert.deepEqual(tags.filter('^žŸ¡\\'), ['^žŸ¡\\¢£¤']);
+    });
+
+    it('returns non-English tags that start with the query string', () => {
+      assert.deepEqual(tags.filter('ინ'), ['ინგლისური']);
     });
   });
 
@@ -131,8 +141,9 @@ describe('TagsService', () => {
         'banana',
         'bar argon',
         'future',
+        '^žŸ¡\\¢£¤',
         'argon',
-        'žŸ¡¢£¤¥¦§',
+        'ინგლისური',
       ]);
     });
   });

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -56,6 +56,12 @@ describe('TagsService', () => {
         count: 1,
         updated: stamp,
       },
+      'žŸ¡¢£¤¥¦§': {
+        // ASCII chars
+        text: 'žŸ¡¢£¤¥¦§',
+        count: 1,
+        updated: stamp,
+      },
     };
     const savedTagsList = Object.keys(savedTagsMap);
 
@@ -82,6 +88,10 @@ describe('TagsService', () => {
       assert.deepEqual(tags.filter('b', 1), ['bar']);
       assert.deepEqual(tags.filter('b', 2), ['bar', 'bar argon']);
       assert.deepEqual(tags.filter('b', 3), ['bar', 'bar argon', 'banana']);
+    });
+
+    it('returns ASCII tags that start with the query string', () => {
+      assert.deepEqual(tags.filter('žŸ¡'), ['žŸ¡¢£¤¥¦§']);
     });
   });
 
@@ -122,6 +132,7 @@ describe('TagsService', () => {
         'bar argon',
         'future',
         'argon',
+        'žŸ¡¢£¤¥¦§',
       ]);
     });
   });


### PR DESCRIPTION
This was filed as a ticket relating to auto complete not working for the word "ინგლისური" (which means "English", in Georgian) 

fixes https://github.com/hypothesis/support/issues/211


**Previous behavior**
![Jul-12-2021 14-09-25](https://user-images.githubusercontent.com/3939074/125358904-66e8f800-e31e-11eb-868a-b9527ffc05a2.gif)


### Update:

I have reworked this PR per Rob's suggestion. First split the tag by words `/W+`, then check if the query matchs any of the the start of those words. 

tag: `foo bar baz`
results:

"fo" => YES
"ba"  => YES
"baz"  => YES
"az" => NO
 
 That will ensure everything that previously worked also still works. The changed bit, is there is now a second check to see if the query matches the start of the entire tag without splitting words.  This ensures that for ASCII chars, we don't have a false negative which was exactly what the ticket demonstrated.

tag: `ინგლისური`
results:

"ინ" => YES // this case fails on master
"ნგ" => NO

However One thing that this change won't cover is cases there we have non [a-z] chars which have a delimiter such as a space.

So for example, if this was the tag
`ფუ ბარი`

And this was the query "ბარი"

It would not return that result.  I view this as a minor issue as a user could still search the first part of the tag "ფუ" and it would work. The only solution I can come up for this specific edge case is to actually split on specific chars rather than `/W+` and we would have to come up with that set of chars. I think perhaps this is a better vs best scenario were we can close out this ticket with this solution and maybe add a todo in the code for the improvement. Thoughts?

