### PR TITLE
Remove `off` method on `Bridge` class

### DIFF
--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -147,16 +147,6 @@ export default class Bridge {
   }
 
   /**
-   * Unregister any callbacks registered with `on`.
-   *
-   * @param {string} method
-   */
-  off(method) {
-    delete this.channelListeners[method];
-    return this;
-  }
-
-  /**
    * Add a function to be called upon a new connection.
    *
    * @param {Function} callback

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -166,14 +166,6 @@ describe('shared/bridge', () => {
     });
   });
 
-  describe('#off', () =>
-    it('removes the method from the method registry', () => {
-      createChannel();
-      bridge.on('message1', sandbox.spy());
-      bridge.off('message1');
-      assert.isUndefined(bridge.channelListeners.message1);
-    }));
-
   describe('#onConnect', () => {
     it('adds a callback that is called when a channel is connected', done => {
       let channel;


### PR DESCRIPTION
This method was not used anywhere. In addition for this method to have
the intended effect, it needed to be called before `createChannel`,
because at that point the methods are registered with the `RPC` class
and there is no way to remove the listeners.