### PR TITLE
Rename `on` to `register` in the `Bridge` and `CrossFrame` classes

### DIFF
--- a/src/annotator/annotation-counts.js
+++ b/src/annotator/annotation-counts.js
@@ -11,7 +11,7 @@ const ANNOTATION_COUNT_ATTR = 'data-hypothesis-annotation-count';
  */
 
 export default function annotationCounts(rootEl, crossframe) {
-  crossframe.on(
+  crossframe.register(
     events.PUBLIC_ANNOTATION_COUNT_CHANGED,
     updateAnnotationCountElems
   );

--- a/src/annotator/annotation-sync.js
+++ b/src/annotator/annotation-sync.js
@@ -44,14 +44,14 @@ export default class AnnotationSync {
     this._emit = options.emit;
 
     // Relay events from the sidebar to the rest of the annotator.
-    this.bridge.on('deleteAnnotation', (body, callback) => {
+    this.bridge.register('deleteAnnotation', (body, callback) => {
       const annotation = this._parse(body);
       delete this.cache[annotation.$tag];
       this._emit('annotationDeleted', annotation);
       callback(null, this._format(annotation));
     });
 
-    this.bridge.on('loadAnnotations', (bodies, callback) => {
+    this.bridge.register('loadAnnotations', (bodies, callback) => {
       const annotations = bodies.map(body => this._parse(body));
       this._emit('annotationsLoaded', annotations);
       callback(null, annotations);

--- a/src/annotator/cross-frame.js
+++ b/src/annotator/cross-frame.js
@@ -91,7 +91,7 @@ export class CrossFrame {
      * @param {string} event
      * @param {Function} callback
      */
-    this.on = (event, callback) => bridge.on(event, callback);
+    this.register = (event, callback) => bridge.register(event, callback);
 
     /**
      * Call an RPC method exposed by the sidebar to the annotator.

--- a/src/annotator/features.js
+++ b/src/annotator/features.js
@@ -9,7 +9,7 @@ const _set = features => {
 
 export default {
   init: function (crossframe) {
-    crossframe.on(events.FEATURE_FLAGS_UPDATED, _set);
+    crossframe.register(events.FEATURE_FLAGS_UPDATED, _set);
   },
 
   reset: function () {

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -293,7 +293,7 @@ export default class Guest {
   _connectSidebarEvents() {
     // Handlers for events sent when user hovers or clicks on an annotation card
     // in the sidebar.
-    this.crossframe.on('focusAnnotations', (tags = []) => {
+    this.crossframe.register('focusAnnotations', (tags = []) => {
       this._focusedAnnotations.clear();
       tags.forEach(tag => this._focusedAnnotations.add(tag));
 
@@ -305,7 +305,7 @@ export default class Guest {
       }
     });
 
-    this.crossframe.on('scrollToAnnotation', tag => {
+    this.crossframe.register('scrollToAnnotation', tag => {
       const anchor = this.anchors.find(a => a.annotation.$tag === tag);
       if (!anchor?.highlights) {
         return;
@@ -331,14 +331,14 @@ export default class Guest {
     });
 
     // Handler for when sidebar requests metadata for the current document
-    this.crossframe.on('getDocumentInfo', cb => {
+    this.crossframe.register('getDocumentInfo', cb => {
       this.getDocumentInfo()
         .then(info => cb(null, info))
         .catch(reason => cb(reason));
     });
 
     // Handler for controls on the sidebar
-    this.crossframe.on('setVisibleHighlights', showHighlights => {
+    this.crossframe.register('setVisibleHighlights', showHighlights => {
       this.setVisibleHighlights(showHighlights);
     });
   }

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -209,12 +209,12 @@ export default class Sidebar {
     sidebarTrigger(document.body, () => this.open());
     features.init(this.guest.crossframe);
 
-    this.guest.crossframe.on('openSidebar', () => this.open());
-    this.guest.crossframe.on('closeSidebar', () => this.close());
+    this.guest.crossframe.register('openSidebar', () => this.open());
+    this.guest.crossframe.register('closeSidebar', () => this.close());
 
     // Sidebar listens to the `openNotebook` event coming from the sidebar's
     // iframe and re-publishes it via the emitter to the Notebook
-    this.guest.crossframe.on(
+    this.guest.crossframe.register(
       'openNotebook',
       (/** @type {string} */ groupId) => {
         this.hide();
@@ -234,7 +234,7 @@ export default class Sidebar {
     ];
     eventHandlers.forEach(([event, handler]) => {
       if (handler) {
-        this.guest.crossframe.on(event, () => handler());
+        this.guest.crossframe.register(event, () => handler());
       }
     });
   }

--- a/src/annotator/test/annotation-counts-test.js
+++ b/src/annotator/test/annotation-counts-test.js
@@ -20,7 +20,7 @@ describe('annotationCounts', () => {
     countEl2.setAttribute('data-hypothesis-annotation-count', '');
     document.body.appendChild(countEl2);
 
-    fakeCrossFrame.on = sandbox.stub().returns(fakeCrossFrame);
+    fakeCrossFrame.register = sandbox.stub().returns(fakeCrossFrame);
 
     CrossFrame = sandbox.stub();
     CrossFrame.returns(fakeCrossFrame);
@@ -42,7 +42,7 @@ describe('annotationCounts', () => {
       const args =
         2 <= arguments.length ? Array.prototype.slice.call(arguments, 1) : [];
 
-      crossFrameArgs = fakeCrossFrame.on.args;
+      crossFrameArgs = fakeCrossFrame.register.args;
       for (let i = 0, len = crossFrameArgs.length; i < len; i++) {
         evt = crossFrameArgs[i][0];
         fn = crossFrameArgs[i][1];

--- a/src/annotator/test/annotation-sync-test.js
+++ b/src/annotator/test/annotation-sync-test.js
@@ -18,7 +18,7 @@ describe('AnnotationSync', () => {
     };
 
     fakeBridge = {
-      on: sandbox.spy((method, fn) => {
+      register: sandbox.spy((method, fn) => {
         listeners[method] = fn;
       }),
       call: sandbox.stub(),

--- a/src/annotator/test/cross-frame-test.js
+++ b/src/annotator/test/cross-frame-test.js
@@ -30,7 +30,7 @@ describe('CrossFrame', () => {
       createChannel: sinon.stub(),
       onConnect: sinon.stub(),
       call: sinon.stub(),
-      on: sinon.stub(),
+      register: sinon.stub(),
     };
 
     fakeAnnotationSync = { sync: sinon.stub() };
@@ -114,11 +114,11 @@ describe('CrossFrame', () => {
     });
   });
 
-  describe('#on', () => {
+  describe('#register', () => {
     it('proxies the call to the bridge', () => {
       const bridge = createCrossFrame();
-      bridge.on('event', 'arg');
-      assert.calledWith(fakeBridge.on, 'event', 'arg');
+      bridge.register('event', 'arg');
+      assert.calledWith(fakeBridge.register, 'event', 'arg');
     });
   });
 

--- a/src/annotator/test/features-test.js
+++ b/src/annotator/test/features-test.js
@@ -22,7 +22,7 @@ describe('features - annotation layer', () => {
     });
 
     features.init({
-      on: function (topic, handler) {
+      register: function (topic, handler) {
         if (topic === events.FEATURE_FLAGS_UPDATED) {
           featureFlagsUpdateHandler = handler;
         }

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -74,7 +74,7 @@ describe('Guest', () => {
 
     fakeCrossFrame = {
       onConnect: sinon.stub(),
-      on: sinon.stub(),
+      register: sinon.stub(),
       call: sinon.stub(),
       sync: sinon.stub(),
       destroy: sinon.stub(),
@@ -219,7 +219,7 @@ describe('Guest', () => {
 
   describe('events from sidebar', () => {
     const emitGuestEvent = (event, ...args) => {
-      for (let [evt, fn] of fakeCrossFrame.on.args) {
+      for (let [evt, fn] of fakeCrossFrame.register.args) {
         if (event === evt) {
           fn(...args);
         }
@@ -1044,7 +1044,7 @@ describe('Guest', () => {
       const annotation = { $tag: 'tag1', target: [target] };
 
       // Focus the annotation (in the sidebar) before it is anchored in the page.
-      const [, focusAnnotationsCallback] = fakeCrossFrame.on.args.find(
+      const [, focusAnnotationsCallback] = fakeCrossFrame.register.args.find(
         args => args[0] === 'focusAnnotations'
       );
       focusAnnotationsCallback([annotation.$tag]);

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -43,7 +43,7 @@ function simplifyWhitespace(quote) {
 function FakeCrossFrame() {
   this.destroy = sinon.stub();
   this.onConnect = sinon.stub();
-  this.on = sinon.stub();
+  this.register = sinon.stub();
   this.sync = sinon.stub();
 }
 

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -66,7 +66,7 @@ describe('Sidebar', () => {
     sidebars = [];
     containers = [];
     fakeCrossFrame = {
-      on: sandbox.stub(),
+      register: sandbox.stub(),
       call: sandbox.stub(),
     };
 
@@ -253,7 +253,7 @@ describe('Sidebar', () => {
   describe('crossframe listeners', () => {
     const emitEvent = (event, ...args) => {
       const result = [];
-      for (let [evt, fn] of fakeCrossFrame.on.args) {
+      for (let [evt, fn] of fakeCrossFrame.register.args) {
         if (event === evt) {
           result.push(fn(...args));
         }

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -138,7 +138,7 @@ export default class Bridge {
    * @param {string} method
    * @param {Function} callback
    */
-  on(method, callback) {
+  register(method, callback) {
     if (this.channelListeners[method]) {
       throw new Error(`Listener '${method}' already bound in Bridge`);
     }

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -43,8 +43,8 @@ describe('shared/bridge', () => {
     it('registers any existing listeners on the channel', () => {
       const message1 = sandbox.spy();
       const message2 = sandbox.spy();
-      bridge.on('message1', message1);
-      bridge.on('message2', message2);
+      bridge.register('message1', message1);
+      bridge.register('message2', message2);
       const channel = createChannel();
       assert.propertyVal(channel._methods, 'message1', message1);
       assert.propertyVal(channel._methods, 'message2', message2);
@@ -153,23 +153,23 @@ describe('shared/bridge', () => {
     });
   });
 
-  describe('#on', () => {
+  describe('#register', () => {
     it('adds a method to the method registry', () => {
       createChannel();
-      bridge.on('message1', sandbox.spy());
+      bridge.register('message1', sandbox.spy());
       assert.isFunction(bridge.channelListeners.message1);
     });
 
     it('only allows registering a method once', () => {
-      bridge.on('message1', sandbox.spy());
-      assert.throws(() => bridge.on('message1', sandbox.spy()));
+      bridge.register('message1', sandbox.spy());
+      assert.throws(() => bridge.register('message1', sandbox.spy()));
     });
   });
 
   describe('#off', () =>
     it('removes the method from the method registry', () => {
       createChannel();
-      bridge.on('message1', sandbox.spy());
+      bridge.register('message1', sandbox.spy());
       bridge.off('message1');
       assert.isUndefined(bridge.channelListeners.message1);
     }));

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -135,7 +135,7 @@ export class FrameSyncService {
      */
     this._setupSyncFromFrame = () => {
       // A new annotation, note or highlight was created in the frame
-      bridge.on('beforeCreateAnnotation', event => {
+      bridge.register('beforeCreateAnnotation', event => {
         const annot = Object.assign({}, event.msg, { $tag: event.tag });
         // If user is not logged in, we can't really create a meaningful highlight
         // or annotation. Instead, we need to open the sidebar, show an error,
@@ -153,7 +153,7 @@ export class FrameSyncService {
         annotationsService.create(annot);
       });
 
-      bridge.on('destroyFrame', frameIdentifier =>
+      bridge.register('destroyFrame', frameIdentifier =>
         destroyFrame(frameIdentifier)
       );
 
@@ -171,7 +171,7 @@ export class FrameSyncService {
       }, 10);
 
       // Anchoring an annotation in the frame completed
-      bridge.on('sync', events_ => {
+      bridge.register('sync', events_ => {
         events_.forEach(event => {
           inFrame.add(event.tag);
           anchoringStatusUpdates[event.tag] = event.msg.$orphan
@@ -181,31 +181,31 @@ export class FrameSyncService {
         });
       });
 
-      bridge.on('showAnnotations', tags => {
+      bridge.register('showAnnotations', tags => {
         store.selectAnnotations(store.findIDsForTags(tags));
         store.selectTab('annotation');
       });
 
-      bridge.on('focusAnnotations', tags => {
+      bridge.register('focusAnnotations', tags => {
         store.focusAnnotations(tags || []);
       });
 
-      bridge.on('toggleAnnotationSelection', tags => {
+      bridge.register('toggleAnnotationSelection', tags => {
         store.toggleSelectedAnnotations(store.findIDsForTags(tags));
       });
 
-      bridge.on('sidebarOpened', () => {
+      bridge.register('sidebarOpened', () => {
         store.setSidebarOpened(true);
       });
 
       // These invoke the matching methods by name on the Guests
-      bridge.on('openSidebar', () => {
+      bridge.register('openSidebar', () => {
         bridge.call('openSidebar');
       });
-      bridge.on('closeSidebar', () => {
+      bridge.register('closeSidebar', () => {
         bridge.call('closeSidebar');
       });
-      bridge.on('setVisibleHighlights', state => {
+      bridge.register('setVisibleHighlights', state => {
         bridge.call('setVisibleHighlights', state);
       });
     };

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -80,7 +80,7 @@ describe('FrameSyncService', () => {
     fakeBridge = {
       call: sinon.stub(),
       createChannel: sinon.stub(),
-      on: emitter.on.bind(emitter),
+      register: emitter.on.bind(emitter),
       onConnect: function (listener) {
         emitter.on('connect', listener);
       },


### PR DESCRIPTION
I believe `bridge.register('method', ....)` indicates better the fact
that there is a registration phase before the `method` can be invoked.

`bridge.on` feels like the addition of the listener can happen
at anytime. That's not true, all methods must be register before the
channel is created.