### PR TITLE
General improvement on `shared/bridge.js`

### DIFF
--- a/src/annotator/cross-frame.js
+++ b/src/annotator/cross-frame.js
@@ -89,7 +89,7 @@ export class CrossFrame {
      * Subscribe to an event from the sidebar.
      *
      * @param {string} event
-     * @param {Function} callback
+     * @param {(...args: any[]) => void} callback
      */
     this.on = (event, callback) => bridge.on(event, callback);
 
@@ -105,7 +105,7 @@ export class CrossFrame {
      * Register a callback to be invoked once the connection to the sidebar
      * is set up.
      *
-     * @param {Function} callback
+     * @param {(...args: any[]) => void} callback
      */
     this.onConnect = callback => bridge.onConnect(callback);
   }

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -104,25 +104,24 @@ export default class Bridge {
     };
 
     const promises = this.links.map(l => {
-      const p = new Promise((resolve, reject) => {
+      const promise = new Promise((resolve, reject) => {
         const timeout = setTimeout(() => resolve(null), 1000);
         try {
-          return l.channel.call(method, ...args, (err, result) => {
+          l.channel.call(method, ...args, (err, result) => {
             clearTimeout(timeout);
             if (err) {
-              return reject(err);
+              reject(err);
             } else {
-              return resolve(result);
+              resolve(result);
             }
           });
         } catch (error) {
-          const err = error;
-          return reject(err);
+          reject(error);
         }
       });
 
       // Don't assign here. The disconnect is handled asynchronously.
-      return p.catch(_makeDestroyFn(l.channel));
+      return promise.catch(_makeDestroyFn(l.channel));
     });
 
     let resultPromise = Promise.all(promises);

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -24,7 +24,7 @@ export default class Bridge {
    * This removes the event listeners for messages arriving from other windows.
    */
   destroy() {
-    Array.from(this.links).map(link => link.channel.destroy());
+    this.links.map(link => link.channel.destroy());
   }
 
   /**
@@ -47,9 +47,7 @@ export default class Bridge {
         return;
       }
       connected = true;
-      Array.from(this.onConnectListeners).forEach(cb =>
-        cb.call(null, channel, source)
-      );
+      this.onConnectListeners.forEach(cb => cb.call(null, channel, source));
     };
 
     const connect = (_token, cb) => {
@@ -100,9 +98,7 @@ export default class Bridge {
     const _makeDestroyFn = c => {
       return error => {
         c.destroy();
-        this.links = Array.from(this.links)
-          .filter(l => l.channel !== c)
-          .map(l => l);
+        this.links = this.links.filter(l => l.channel !== c);
         throw error;
       };
     };
@@ -111,7 +107,7 @@ export default class Bridge {
       const p = new Promise((resolve, reject) => {
         const timeout = setTimeout(() => resolve(null), 1000);
         try {
-          return l.channel.call(method, ...Array.from(args), (err, result) => {
+          return l.channel.call(method, ...args, (err, result) => {
             clearTimeout(timeout);
             if (err) {
               return reject(err);

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -49,9 +49,7 @@ describe('shared/bridge', () => {
     it('adds the channel to the .links property', () => {
       const channel = createChannel();
       assert.isTrue(
-        bridge.links.some(
-          link => link.channel === channel && link.window === fakeWindow
-        )
+        bridge.links.some(registeredChannel => registeredChannel === channel)
       );
     });
 


### PR DESCRIPTION
The following improvements don't modify the functionality of `shared/bridge.js`:

* Added types and comment about a callback
* Remove unnecessary `Array.from(...)`
* Simplify promise
* Simplify `this.link` property

Closes #3580 