### PR TITLE
Replace query-string dependency with wrapper around URLSearchParams (v2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "preact": "^10.4.0",
     "prettier": "2.3.2",
     "puppeteer": "^10.0.0",
-    "query-string": "^3.0.1",
     "redux": "^4.0.1",
     "redux-thunk": "^2.1.0",
     "reselect": "^4.0.0",

--- a/scripts/gulp/create-bundle.js
+++ b/scripts/gulp/create-bundle.js
@@ -64,7 +64,7 @@ module.exports = function createBundle(config, buildOpts) {
     //
     // See node_modules/browserify/lib/builtins.js to find out which
     // modules provide the implementations of these.
-    builtins: ['console', '_process', 'querystring'],
+    builtins: ['console', '_process'],
     externalRequireName,
 
     // Map of global variable names to functions returning _source code_ for

--- a/src/sidebar/components/ModerationBanner.js
+++ b/src/sidebar/components/ModerationBanner.js
@@ -30,14 +30,22 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
   const isHiddenOrFlagged =
     flagCount !== null && (flagCount > 0 || annotation.hidden);
 
+  if (!isHiddenOrFlagged) {
+    return null;
+  }
+
+  // In order to have been hidden or flagged, this annotation must have been
+  // saved.
+  const id = /** @type {string} */ (annotation.id);
+
   /**
    * Hide an annotation from non-moderator users.
    */
   const hideAnnotation = () => {
     api.annotation
-      .hide({ id: annotation.id })
+      .hide({ id })
       .then(() => {
-        store.hideAnnotation(annotation.id);
+        store.hideAnnotation(id);
       })
       .catch(() => {
         toastMessenger.error('Failed to hide annotation');
@@ -49,9 +57,9 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
    */
   const unhideAnnotation = () => {
     api.annotation
-      .unhide({ id: annotation.id })
+      .unhide({ id })
       .then(() => {
-        store.unhideAnnotation(annotation.id);
+        store.unhideAnnotation(id);
       })
       .catch(() => {
         toastMessenger.error('Failed to unhide annotation');
@@ -77,9 +85,6 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
     'is-reply': annotationMetadata.isReply(annotation),
   });
 
-  if (!isHiddenOrFlagged) {
-    return null;
-  }
   return (
     <div className={bannerClasses}>
       {!!flagCount && !annotation.hidden && (

--- a/src/sidebar/config/host-config.js
+++ b/src/sidebar/config/host-config.js
@@ -1,4 +1,4 @@
-import * as queryString from 'query-string';
+import * as queryString from '../util/query-string';
 import {
   toBoolean,
   toInteger,
@@ -16,7 +16,7 @@ import {
  */
 export default function hostPageConfig(window) {
   const configStr = window.location.hash.slice(1);
-  const configJSON = queryString.parse(configStr).config;
+  const configJSON = queryString.parseLast(configStr).config;
   const config = JSON.parse(configJSON || '{}');
 
   // Known configuration parameters which we will import from the host page.

--- a/src/sidebar/media-embedder.js
+++ b/src/sidebar/media-embedder.js
@@ -1,4 +1,4 @@
-import * as queryString from 'query-string';
+import * as queryString from './util/query-string';
 
 /**
  * Return an HTML5 audio player with the given src URL.
@@ -109,7 +109,8 @@ function youTubeQueryParams(link) {
     'start',
     't', // will be translated to `start`
   ];
-  const linkParams = queryString.parse(link.search);
+  const linkParams = queryString.parseLast(link.search);
+  /** @type {Record<string, string>} */
   const filteredQuery = {};
   // Filter linkParams for allowed keys and build those entries
   // into the filteredQuery object
@@ -274,7 +275,7 @@ const embedGenerators = [
     // Extract start and end times, which may appear either as query string
     // params or path params.
     let slug = slugMatch[2];
-    const linkParams = queryString.parse(link.search);
+    const linkParams = queryString.parseLast(link.search);
     let startTime = linkParams.start;
     let endTime = linkParams.end;
 

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -1,9 +1,9 @@
-import * as queryString from 'query-string';
-
+import * as queryString from '../util/query-string';
 import { replaceURLParams } from '../util/url';
 
 /**
  * @typedef {import('../../types/api').RouteMap} RouteMap
+ * @typedef {import('../util/query-string').Params} Params
  */
 
 /**
@@ -60,7 +60,7 @@ function stripInternalProperties(obj) {
  * Function which makes an API request.
  *
  * @callback APICallFunction
- * @param {Record<string, any>} params - A map of URL and query string parameters to include with the request.
+ * @param {Params} params - A map of URL and query string parameters to include with the request.
  * @param {object} [data] - The body of the request.
  * @param {APICallOptions} [options]
  * @return {Promise<any|APIResponse>}

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -1,4 +1,4 @@
-import * as queryString from 'query-string';
+import * as queryString from '../util/query-string';
 
 /**
  * @typedef {'annotation'|'notebook'|'stream'|'sidebar'} RouteName
@@ -29,7 +29,7 @@ export class RouterService {
   currentRoute() {
     const path = this._window.location.pathname;
     const pathSegments = path.slice(1).split('/');
-    const params = queryString.parse(this._window.location.search);
+    const params = queryString.parseLast(this._window.location.search);
 
     // The extension puts client resources under `/client/` to separate them
     // from extension-specific resources. Ignore this part.

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -58,8 +58,8 @@ export class SessionService {
       // the /app endpoint.
       this._lastLoadTime = Date.now();
       this._lastLoad = retryPromiseOperation(() => {
-        const opts = this._authority ? { authority: this._authority } : {};
-        return this._api.profile.read(opts);
+        const authority = this._authority;
+        return this._api.profile.read(authority ? { authority } : {});
       })
         .then(session => {
           this.update(session);

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -1,8 +1,7 @@
-import * as queryString from 'query-string';
-
 import warnOnce from '../../shared/warn-once';
 import { generateHexString } from '../util/random';
 import { Socket } from '../websocket';
+import * as queryString from '../util/query-string';
 import { watch } from '../util/watch';
 
 /**
@@ -190,6 +189,7 @@ export class StreamerService {
       // not support setting the `Authorization` header directly as we do for
       // other API requests.
       const parsedURL = new URL(this._websocketURL);
+      /** @type {import('../util/query-string').Params} */
       const queryParams = queryString.parse(parsedURL.search);
       queryParams.access_token = token;
       parsedURL.search = queryString.stringify(queryParams);

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -1,5 +1,4 @@
-import * as queryString from 'query-string';
-
+import * as queryString from './query-string';
 import * as random from './random';
 
 /**

--- a/src/sidebar/util/query-string.js
+++ b/src/sidebar/util/query-string.js
@@ -1,0 +1,78 @@
+/**
+ * Types of value which `stringify` can serialize.
+ *
+ * @typedef {string|number|boolean} Param
+ */
+
+/**
+ * Record mapping query parameter names to value or values (if the parameter
+ * should be repeated).
+ *
+ * @typedef {Record<string, Param|Param[]>} Params
+ */
+
+/**
+ * Generate a query string from a record of query parameters.
+ *
+ * The returned string does not have a leading "?" and the parameters are
+ * sorted by name. If the value is an array then the query parameter is added
+ * multiple times, once per value.
+ *
+ * @example
+ *   stringify({ foo: 'bar', meep: 'one two' }) // Returns "foo=bar&meep=one+two"
+ *   stringify({ foo: ['bar', 'baz'] }) // Returns "foo=bar&foo=baz"
+ *
+ * @param {Params} params
+ * @return {string}
+ */
+export function stringify(params) {
+  const searchParams = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach(v => searchParams.append(key, v.toString()));
+    } else {
+      searchParams.append(key, value.toString());
+    }
+  });
+  searchParams.sort();
+  return searchParams.toString();
+}
+
+/**
+ * Parse a query string into a record of parameters.
+ *
+ * Non-repeated parameters are returned as strings, repeated parameters are
+ * returned as an array of values.
+ *
+ * @param {string} query - Query string which may have a leading "?"
+ * @return {Record<string, string|string[]>}
+ */
+export function parse(query) {
+  const params = new URLSearchParams(query);
+  /** @type {Record<string, string|string[]>} */
+  const result = Object.create(null);
+  for (let key of params.keys()) {
+    const values = params.getAll(key);
+    result[key] = values.length > 1 ? values : values[0];
+  }
+  return result;
+}
+
+/**
+ * Parse a query string into a record of parameters.
+ *
+ * This differs from `parse` in that if a parameter is repeated, only the last
+ * value is returned.
+ *
+ * @param {string} query - Query string which may have a leading "?"
+ * @return {Record<string, string>}
+ */
+export function parseLast(query) {
+  const params = new URLSearchParams(query);
+  /** @type {Record<string, string>} */
+  const result = Object.create(null);
+  for (let [key, value] of params) {
+    result[key] = value;
+  }
+  return result;
+}

--- a/src/sidebar/util/test/oauth-client-test.js
+++ b/src/sidebar/util/test/oauth-client-test.js
@@ -1,5 +1,5 @@
 import fetchMock from 'fetch-mock';
-import { stringify } from 'query-string';
+import { stringify } from '../query-string';
 import sinon from 'sinon';
 
 import OAuthClient from '../oauth-client';

--- a/src/sidebar/util/test/query-string-test.js
+++ b/src/sidebar/util/test/query-string-test.js
@@ -1,0 +1,54 @@
+import { parse, parseLast, stringify } from '../query-string';
+
+describe('sidebar/util/query-string', () => {
+  describe('parse, parseLast', () => {
+    [parse, parseLast].forEach(parseFn => {
+      it('returns parsed record', () => {
+        const query = '?foo=bar+baz%2Fboop&baz=meep';
+        const parsed = parseFn(query);
+        assert.deepEqual(parsed, { foo: 'bar baz/boop', baz: 'meep' });
+      });
+
+      it('returns object without a prototype', () => {
+        const parsed = parseFn('?foo=bar');
+        assert.isFalse('hasOwnProperty' in parsed);
+      });
+    });
+  });
+
+  describe('parse', () => {
+    it('returns array if parameter is repeated', () => {
+      const query = '?foo=one&foo=two';
+      const parsed = parse(query);
+      assert.deepEqual(parsed, { foo: ['one', 'two'] });
+    });
+  });
+
+  describe('parseLast', () => {
+    it('returns last value if parameter is repeated', () => {
+      const query = '?foo=one&foo=two';
+      const parsed = parseLast(query);
+      assert.deepEqual(parsed, { foo: 'two' });
+    });
+  });
+
+  describe('stringify', () => {
+    it('returns formatted query with sorted params', () => {
+      const params = { foo: 'bar baz/boop', baz: 'meep' };
+      const formatted = stringify(params);
+      assert.equal(formatted, 'baz=meep&foo=bar+baz%2Fboop');
+    });
+
+    it('stringifies numbers and booleans', () => {
+      const params = { aBool: true, aNumber: 1.23 };
+      const formatted = stringify(params);
+      assert.equal(formatted, 'aBool=true&aNumber=1.23');
+    });
+
+    it('adds parameter multiple times if value is an array', () => {
+      const params = { foo: ['one', 'two'] };
+      const formatted = stringify(params);
+      assert.equal(formatted, 'foo=one&foo=two');
+    });
+  });
+});

--- a/src/sidebar/util/test/url-test.js
+++ b/src/sidebar/util/test/url-test.js
@@ -9,6 +9,14 @@ describe('sidebar/util/url', () => {
       assert.equal(replaced.url, 'http://foo.com/things/test');
     });
 
+    it('should throw if param value is an array', () => {
+      assert.throws(() => {
+        replaceURLParams('http://foo.com/things/:id', {
+          id: ['foo', 'bar'],
+        });
+      }, 'Cannot use array as URL parameter');
+    });
+
     it('should URL encode params in URLs', () => {
       const replaced = replaceURLParams('http://foo.com/things/:id', {
         id: 'foo=bar',

--- a/src/sidebar/util/url.js
+++ b/src/sidebar/util/url.js
@@ -1,4 +1,8 @@
 /**
+ * @typedef {import('./query-string').Params} Params
+ */
+
+/**
  * Replace parameters in a URL template with values from a `params` object.
  *
  * Returns an object containing the expanded URL and a dictionary of unused
@@ -8,17 +12,22 @@
  *     {url: '/things/foo', unusedParams: {q: 'bar'}}
  *
  * @param {string} url
- * @param {Record<string, string>} params
- * @return {{ url: string, unusedParams: Record<string, string>}}
+ * @param {Params} params
+ * @return {{ url: string, unusedParams: Params}}
  */
 export function replaceURLParams(url, params) {
-  /** @type {Record<string, string>} */
+  /** @type {Params} */
   const unusedParams = {};
   for (const param in params) {
     if (params.hasOwnProperty(param)) {
       const value = params[param];
       const urlParam = ':' + param;
       if (url.indexOf(urlParam) !== -1) {
+        // `params` allows array values but they can only be returned as unused
+        // parameters.
+        if (Array.isArray(value)) {
+          throw new TypeError('Cannot use array as URL parameter');
+        }
         url = url.replace(urlParam, encodeURIComponent(value));
       } else {
         unusedParams[param] = value;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
-    "lib": ["es2018", "dom"],
+    "lib": ["es2018", "dom", "dom.iterable"],
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "module": "commonjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6604,13 +6604,6 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-query-string@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-3.0.3.tgz#ae2e14b4d05071d4e9b9eb4873c35b0dcd42e638"
-  integrity sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=
-  dependencies:
-    strict-uri-encode "^1.0.0"
-
 querystring-es3@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -7475,11 +7468,6 @@ streamroller@^2.2.4:
     date-format "^2.1.0"
     debug "^4.1.1"
     fs-extra "^8.1.0"
-
-strict-uri-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-  integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR is an updated version of https://github.com/hypothesis/client/pull/3582 which fixes the issues that required it to be reverted (see https://github.com/hypothesis/client/pull/3584). It makes the typing of the `params` argument to API calls stricter, which would have caught the issue, and also resolves a number of subtle bugs in existing code to do with repeated query parameters that were found as a result.

A summary of the changes compared to https://github.com/hypothesis/client/pull/3582:

- The `stringify` and `parse` functions in `src/sidebar/util/query-string.js` now handle repeated parameters in a way that is consistent with the previous implementation (from the `query-string` package). If an array value is passed as a parameter value to `stringify` then repeated parameters are added to the query string. If a query string with repeated parameters is passed to `parse`, the value for the property in the returned object will be an array.
- The typing of the `params` object to API calls (eg. as in `apiService.search(params)`) has been made stricter. This catches situations in which a caller passes a value that might not be serialized as expected.
- I discovered that various callers of `parse` that did not handle array values in the returned object properly. These have been migrated to use an alternative `parseLast` function which only returns the last value when a parameter is repeated. For these callers this is currently an appropriate approach (as opposed to modifying the caller to handle an array value).
- An issue was found with the existing `replaceURLParams` function where it did not check for parameter values being arrays. Correct code should not do this, so this now results in an error being thrown.
- An implicit assumption about annotations already being saved in `ModerationBanner` was discovered. This assumption is now documented explicitly.