### PR TITLE
Add test case for multi-valued parameters in API requests

### DIFF
--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -156,6 +156,23 @@ describe('APIService', () => {
     return api.search({ uri: 'http://foobar.com/?foo=bar;baz=qux' });
   });
 
+  // Test that covers the most critical use case of multiple values being
+  // provided for an API parameter. Other API calls accept multiple values
+  // as well though.
+  it('repeats query parameters when multiple values are provided', () => {
+    const pdfURL = 'https://example.com/test.pdf';
+    const fingerprintURL = 'urn:x-pdf:foobar';
+
+    expectCall(
+      'get',
+      `search?uri=${encodeURIComponent(pdfURL)}&uri=${encodeURIComponent(
+        fingerprintURL
+      )}`
+    );
+
+    return api.search({ uri: [pdfURL, fingerprintURL] });
+  });
+
   it("fetches the user's profile", () => {
     const profile = { userid: 'acct:user@publisher.org' };
     expectCall('get', 'profile?authority=publisher.org', 200, profile);


### PR DESCRIPTION
Check that multi-valued parameters are handled as expected when making
API requests. The test uses the example of a `search` API call with
multiple URIs, as that's the most important example.

Add a test case that would have caught the regression introduced by
https://github.com/hypothesis/client/pull/3582.