### PR TITLE
Throw an error when adding a handler if a channel has already been created

### DIFF
--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -135,18 +135,18 @@ export default class Bridge {
   }
 
   /**
-   * Register a callback to be invoked when any connected channel sends a
+   * Register a listener to be invoked when any connected channel sends a
    * message to this `Bridge`.
    *
    * @param {string} method
-   * @param {(...args: any[]) => void} callback -- Final argument is an optional
+   * @param {(...args: any[]) => void} listener -- Final argument is an optional
    *   callback of the type: `(error: string|Error|null, ...result: any[]) => void`.
    *   This callback must be invoked in order to respond (via `postMessage`)
    *   to the other frame/s with a result or an error.
    * @throws {Error} If trying to register a callback after a channel has already been created
    * @throws {Error} If trying to register a callback with the same name multiple times
    */
-  on(method, callback) {
+  on(method, listener) {
     if (this.links.length > 0) {
       throw new Error(
         `Listener '${method}' can't be registered because a channel has already been created`
@@ -155,17 +155,17 @@ export default class Bridge {
     if (this.channelListeners[method]) {
       throw new Error(`Listener '${method}' already bound in Bridge`);
     }
-    this.channelListeners[method] = callback;
+    this.channelListeners[method] = listener;
     return this;
   }
 
   /**
-   * Add a function to be called upon a new connection.
+   * Add a listener to be called upon a new connection.
    *
-   * @param {(error: null, channel: RPC, window: Window) => void} callback
+   * @param {(error: null, channel: RPC, window: Window) => void} listener
    */
-  onConnect(callback) {
-    this.onConnectListeners.push(callback);
+  onConnect(listener) {
+    this.onConnectListeners.push(listener);
     return this;
   }
 }

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -143,8 +143,15 @@ export default class Bridge {
    *   callback of the type: `(error: string|Error|null, ...result: any[]) => void`.
    *   This callback must be invoked in order to respond (via `postMessage`)
    *   to the other frame/s with a result or an error.
+   * @throws {Error} If trying to register a callback after a channel has already been created
+   * @throws {Error} If trying to register a callback with the same name multiple times
    */
   on(method, callback) {
+    if (this.links.length > 0) {
+      throw new Error(
+        `Listener '${method}' can't be registered because a channel has already been created`
+      );
+    }
     if (this.channelListeners[method]) {
       throw new Error(`Listener '${method}' already bound in Bridge`);
     }

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -168,14 +168,39 @@ describe('shared/bridge', () => {
 
   describe('#on', () => {
     it('adds a method to the method registry', () => {
-      createChannel();
       bridge.on('message1', sandbox.spy());
+      createChannel();
       assert.isFunction(bridge.channelListeners.message1);
     });
 
+    it('raise an error if trying to register a listener after a channel has been already created', () => {
+      createChannel();
+      let error;
+      try {
+        bridge.on('message1', () => {});
+      } catch (err) {
+        error = err;
+      }
+
+      assert.equal(
+        error.message,
+        "Listener 'message1' can't be registered because a channel has already been created"
+      );
+    });
+
     it('only allows registering a method once', () => {
-      bridge.on('message1', sandbox.spy());
-      assert.throws(() => bridge.on('message1', sandbox.spy()));
+      bridge.on('message1', () => {});
+      let error;
+      try {
+        bridge.on('message1', () => {});
+      } catch (err) {
+        error = err;
+      }
+
+      assert.equal(
+        error.message,
+        "Listener 'message1' already bound in Bridge"
+      );
     });
   });
 

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -188,7 +188,7 @@ describe('shared/bridge', () => {
       );
     });
 
-    it('only allows registering a method once', () => {
+    it('only allows registering a listener once', () => {
       bridge.on('message1', () => {});
       let error;
       try {


### PR DESCRIPTION
First commit, 'error when adding a handler if a channel has been created':

The RPC class design requires all the handlers to be provided up-front.
Currently, adding a new handler after a channel is created has no
effect. To make more obvious this misuse, the method now throws an
error.


Second commit, 'rename `callback` to `listener`':

The word `listener` matches better the internal property names of
`this.channelListeners` and `this.onConnectListeners`. In addition, it
helps to differentiate from the `callback` function which is the last
(optional) argument of the `listener`. The `callback` is used to send
back a `postMessage` response to the other frame/s.

