### PR TITLE
Replace query-string dependency with `URLSearchParams`

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "preact": "^10.4.0",
     "prettier": "2.3.2",
     "puppeteer": "^10.0.0",
-    "query-string": "^3.0.1",
     "redux": "^4.0.1",
     "redux-thunk": "^2.1.0",
     "reselect": "^4.0.0",

--- a/scripts/gulp/create-bundle.js
+++ b/scripts/gulp/create-bundle.js
@@ -64,7 +64,7 @@ module.exports = function createBundle(config, buildOpts) {
     //
     // See node_modules/browserify/lib/builtins.js to find out which
     // modules provide the implementations of these.
-    builtins: ['console', '_process', 'querystring'],
+    builtins: ['console', '_process'],
     externalRequireName,
 
     // Map of global variable names to functions returning _source code_ for

--- a/src/sidebar/config/host-config.js
+++ b/src/sidebar/config/host-config.js
@@ -1,4 +1,3 @@
-import * as queryString from 'query-string';
 import {
   toBoolean,
   toInteger,
@@ -16,7 +15,7 @@ import {
  */
 export default function hostPageConfig(window) {
   const configStr = window.location.hash.slice(1);
-  const configJSON = queryString.parse(configStr).config;
+  const configJSON = new URLSearchParams(configStr).get('config');
   const config = JSON.parse(configJSON || '{}');
 
   // Known configuration parameters which we will import from the host page.

--- a/src/sidebar/media-embedder.js
+++ b/src/sidebar/media-embedder.js
@@ -109,23 +109,23 @@ function youTubeQueryParams(link) {
   ];
   const linkParams = new URLSearchParams(link.search);
   const filteredQuery = new URLSearchParams();
-  // Filter linkParams for allowed keys and build those entries
-  // into the filteredQuery object
-  [...linkParams.keys()]
-    .filter(key => allowedParams.includes(key))
-    .forEach(key => {
-      const value = /** @type {string} */ (linkParams.get(key));
-      if (key === 't') {
-        // `t` is not supported in embeds; `start` is
-        // `t` accepts more formats than `start`; start must be in seconds
-        // so, format it as seconds first
-        filteredQuery.set('start', parseTimeString(value));
-      } else {
-        filteredQuery.set(key, value);
-      }
-    });
 
-  // Tests currently expect sorted query params.
+  // Copy allowed params into `filteredQuery`.
+  for (let [key, value] of linkParams.entries()) {
+    if (!allowedParams.includes(key)) {
+      continue;
+    }
+    if (key === 't') {
+      // `t` is not supported in embeds; `start` is
+      // `t` accepts more formats than `start`; start must be in seconds
+      // so, format it as seconds first
+      filteredQuery.append('start', parseTimeString(value));
+    } else {
+      filteredQuery.append(key, value);
+    }
+  }
+
+  // Tests currently expect sorted parameters.
   filteredQuery.sort();
 
   query = filteredQuery.toString();

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -1,5 +1,3 @@
-import * as queryString from 'query-string';
-
 import { replaceURLParams } from '../util/url';
 
 /**
@@ -7,6 +5,12 @@ import { replaceURLParams } from '../util/url';
  * @typedef {import('../../types/api').Group} Group
  * @typedef {import('../../types/api').RouteMap} RouteMap
  * @typedef {import('../../types/api').Profile} Profile
+ */
+
+/**
+ * Types of value that can be passed as a parameter to API calls.
+ *
+ * @typedef {string|number|boolean} Param
  */
 
 /**
@@ -54,7 +58,7 @@ function stripInternalProperties(obj) {
 /**
  * Function which makes an API request.
  *
- * @template {Record<string, any>} Params
+ * @template {Record<string, Param|Param[]>} Params
  * @template {object} Body
  * @template Result
  * @callback APICall
@@ -123,8 +127,15 @@ function createAPICall(
           descriptor.url,
           params
         );
+
         const apiUrl = new URL(url);
-        apiUrl.search = queryString.stringify(queryParams);
+        for (let [key, value] of Object.entries(queryParams)) {
+          if (Array.isArray(value)) {
+            value.forEach(v => apiUrl.searchParams.append(key, v.toString()));
+          } else {
+            apiUrl.searchParams.append(key, value.toString());
+          }
+        }
 
         return fetch(apiUrl.toString(), {
           body: data ? JSON.stringify(stripInternalProperties(data)) : null,

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -1,5 +1,3 @@
-import * as queryString from 'query-string';
-
 /**
  * @typedef {'annotation'|'notebook'|'stream'|'sidebar'} RouteName
  * @typedef {Record<string,string>} RouteParams
@@ -29,7 +27,13 @@ export class RouterService {
   currentRoute() {
     const path = this._window.location.pathname;
     const pathSegments = path.slice(1).split('/');
-    const params = queryString.parse(this._window.location.search);
+    const searchParams = new URLSearchParams(this._window.location.search);
+
+    /** @type {Record<string, string>} */
+    const params = {};
+    for (let [key, value] of searchParams) {
+      params[key] = value;
+    }
 
     // The extension puts client resources under `/client/` to separate them
     // from extension-specific resources. Ignore this part.
@@ -94,9 +98,15 @@ export class RouterService {
         throw new Error(`Cannot generate URL for route "${name}"`);
     }
 
-    const query = queryString.stringify(queryParams);
-    if (query.length > 0) {
-      url += '?' + query;
+    let hasParams = false;
+    const searchParams = new URLSearchParams();
+    for (let [key, value] of Object.entries(queryParams)) {
+      hasParams = true;
+      searchParams.set(key, value);
+    }
+
+    if (hasParams) {
+      url += '?' + searchParams.toString();
     }
 
     return url;

--- a/src/sidebar/services/session.js
+++ b/src/sidebar/services/session.js
@@ -58,8 +58,8 @@ export class SessionService {
       // the /app endpoint.
       this._lastLoadTime = Date.now();
       this._lastLoad = retryPromiseOperation(() => {
-        const opts = this._authority ? { authority: this._authority } : {};
-        return this._api.profile.read(opts);
+        const authority = this._authority;
+        return this._api.profile.read(authority ? { authority } : {});
       })
         .then(session => {
           this.update(session);

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -1,5 +1,3 @@
-import * as queryString from 'query-string';
-
 import warnOnce from '../../shared/warn-once';
 import { generateHexString } from '../util/random';
 import { Socket } from '../websocket';
@@ -190,9 +188,7 @@ export class StreamerService {
       // not support setting the `Authorization` header directly as we do for
       // other API requests.
       const parsedURL = new URL(this._websocketURL);
-      const queryParams = queryString.parse(parsedURL.search);
-      queryParams.access_token = token;
-      parsedURL.search = queryString.stringify(queryParams);
+      parsedURL.searchParams.set('access_token', token);
       url = parsedURL.toString();
     } else {
       url = this._websocketURL;

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -211,7 +211,7 @@ describe('StreamerService', () => {
       return activeStreamer.connect().then(() => {
         assert.equal(
           fakeWebSocket.url,
-          'ws://example.com/ws?access_token=dummy-access-token&foo=bar'
+          'ws://example.com/ws?foo=bar&access_token=dummy-access-token'
         );
       });
     });

--- a/src/sidebar/util/test/oauth-client-test.js
+++ b/src/sidebar/util/test/oauth-client-test.js
@@ -1,5 +1,4 @@
 import fetchMock from 'fetch-mock';
-import { stringify } from 'query-string';
 import sinon from 'sinon';
 
 import OAuthClient from '../oauth-client';
@@ -192,7 +191,7 @@ describe('sidebar/util/oauth-client', () => {
         fakeWindow.open,
         'about:blank',
         'Log in to Hypothesis',
-        'height=430,left=274.5,top=169,width=475'
+        'left=274.5,top=169,width=475,height=430'
       );
     });
 
@@ -229,16 +228,14 @@ describe('sidebar/util/oauth-client', () => {
       });
 
       return authorized.then(() => {
-        const params = {
+        const params = new URLSearchParams({
           client_id: config.clientId,
           origin: 'https://client.hypothes.is',
           response_mode: 'web_message',
           response_type: 'code',
           state: 'notrandom',
-        };
-        const expectedAuthUrl = `${config.authorizationEndpoint}?${stringify(
-          params
-        )}`;
+        });
+        const expectedAuthUrl = `${config.authorizationEndpoint}?${params}`;
         assert.equal(popupWindow.location.href, expectedAuthUrl);
       });
     });

--- a/src/sidebar/util/test/url-test.js
+++ b/src/sidebar/util/test/url-test.js
@@ -9,6 +9,14 @@ describe('sidebar/util/url', () => {
       assert.equal(replaced.url, 'http://foo.com/things/test');
     });
 
+    it('should throw if param value is an array', () => {
+      assert.throws(() => {
+        replaceURLParams('http://foo.com/things/:id', {
+          id: ['foo', 'bar'],
+        });
+      }, 'Cannot use array as URL parameter');
+    });
+
     it('should URL encode params in URLs', () => {
       const replaced = replaceURLParams('http://foo.com/things/:id', {
         id: 'foo=bar',

--- a/src/sidebar/util/url.js
+++ b/src/sidebar/util/url.js
@@ -1,4 +1,9 @@
 /**
+ * @typedef {string|number|boolean} Param
+ * @typedef {Record<string, Param|Param[]>} Params
+ */
+
+/**
  * Replace parameters in a URL template with values from a `params` object.
  *
  * Returns an object containing the expanded URL and a dictionary of unused
@@ -8,17 +13,22 @@
  *     {url: '/things/foo', unusedParams: {q: 'bar'}}
  *
  * @param {string} url
- * @param {Record<string, string>} params
- * @return {{ url: string, unusedParams: Record<string, string>}}
+ * @param {Params} params
+ * @return {{ url: string, unusedParams: Params}}
  */
 export function replaceURLParams(url, params) {
-  /** @type {Record<string, string>} */
+  /** @type {Params} */
   const unusedParams = {};
   for (const param in params) {
     if (params.hasOwnProperty(param)) {
       const value = params[param];
       const urlParam = ':' + param;
       if (url.indexOf(urlParam) !== -1) {
+        // `params` allows array values but they can only be returned as unused
+        // parameters.
+        if (Array.isArray(value)) {
+          throw new TypeError('Cannot use array as URL parameter');
+        }
         url = url.replace(urlParam, encodeURIComponent(value));
       } else {
         unusedParams[param] = value;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
-    "lib": ["es2018", "dom"],
+    "lib": ["es2018", "dom", "dom.iterable"],
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "module": "commonjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6547,13 +6547,6 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-query-string@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-3.0.3.tgz#ae2e14b4d05071d4e9b9eb4873c35b0dcd42e638"
-  integrity sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=
-  dependencies:
-    strict-uri-encode "^1.0.0"
-
 querystring-es3@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -7402,11 +7395,6 @@ streamroller@^2.2.4:
     date-format "^2.1.0"
     debug "^4.1.1"
     fs-extra "^8.1.0"
-
-strict-uri-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-  integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
_nb. If we merge this PR it will supersede https://github.com/hypothesis/client/pull/3585._

This is a replacement for e466e836438e99f93b015b6c81b822cece271b37 which
replaces query-string with direct use of `URLSearchParams`.

The initial attempt to remove the query-string package encountered an
issue when calling an API service method with a parameter value that was
an array. This should have been handled by generating multiple query
params. However the `stringify` implementation in that commit generated
a single query param with comma-separated values.

Following discussion in [1] I explored how difficult it would be to just
use `URLSearchParams` directly everywhere. This proved not to be too
difficult, so that's what this PR does.

 - Add a test to verify what happens when array-valued params are passed to API calls (taken from https://github.com/hypothesis/client/pull/3586)
 - Replace use of `stringify` and `parse` functions from `query-string`
   with use of the native `URLSearchParams` API, which is now supported
   widely enough.
 - Improve typing of `params` argument to API calls to only allow types that
   can definitely be handled.

   This revealed an issue where arrays could be parsed to `replaceURLParams`,
   which did not handle this case. URL path parameters should not be arrays,
   so `replaceURLParams` now throws an error if this happens.
 - Add comments and an explicit cast in `ModerationBanner` due to an implicit assumption about annotations having IDs (ie. being saved), that was revealed by the above typing improvements.

[1] https://github.com/hypothesis/client/pull/3585#pullrequestreview-708338865
