### PR TITLE
Explicitly specify guest/sidebar frames to ping in `startDiscovery`

### DIFF
--- a/docs/publishers/embedding.rst
+++ b/docs/publishers/embedding.rst
@@ -23,7 +23,8 @@ above script tag to the document displayed in the iframe. This will display the
 sidebar in the iframe itself.
 
 Additionally Hypothesis has limited support for enabling annotation of iframed
-content while showing the sidebar in the top-level document. To use this:
+content while showing the sidebar in the top-level document where Hypothesis
+was initially loaded. To use this:
 
 1. Add the above script tag to the top-level document
 
@@ -38,6 +39,8 @@ content while showing the sidebar in the top-level document. To use this:
    ...
    </iframe>
 
-This method *only* works for iframes which are same-origin with the top-level
-document. The client will watch for new iframes being added to the document and
-will automatically enable annotation for them.
+This method *only* works for iframes which are direct children of the top-level
+document and have the same origin.
+
+The client will watch for new iframes being added to the document and will
+automatically enable annotation for them.

--- a/src/annotator/cross-frame.js
+++ b/src/annotator/cross-frame.js
@@ -63,11 +63,27 @@ export class CrossFrame {
       frameIdentifiers.delete(frame);
     };
 
-    // Initiate connection to the sidebar.
-    discovery.startDiscovery((source, origin, token) =>
-      bridge.createChannel({ source, origin, token })
-    );
     frameObserver.observe(injectIntoFrame, iframeUnloaded);
+
+    /**
+     * Attempt to connect to the sidebar frame.
+     *
+     * Returns a promise that resolves once the connection has been established.
+     *
+     * @param {Window} frame - The window containing the sidebar application
+     * @return {Promise<void>}
+     */
+    this.connectToSidebar = frame => {
+      return new Promise(resolve => {
+        discovery.startDiscovery(
+          (source, origin, token) => {
+            bridge.createChannel({ source, origin, token });
+            resolve();
+          },
+          [frame]
+        );
+      });
+    };
 
     /**
      * Remove the connection between the sidebar and annotator.

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -68,7 +68,7 @@ function init() {
     sidebar = new Sidebar(document.body, eventBus, guest, getConfig('sidebar'));
 
     // Expose sidebar window reference for use by same-origin guest frames.
-    window_.__hypothesis.sidebarWindow = sidebar.sidebarWindow;
+    window_.__hypothesis.sidebarWindow = sidebar.iframe.contentWindow;
   }
 
   // Clear `annotations` value from the notebook's config to prevent direct-linked
@@ -77,7 +77,7 @@ function init() {
 
   // Set up communication between this host/guest frame and the sidebar frame.
   const sidebarWindow = sidebar
-    ? sidebar.sidebarWindow
+    ? sidebar.iframe.contentWindow
     : /** @type {HypothesisWindow} */ (window.parent).__hypothesis
         ?.sidebarWindow;
   if (sidebarWindow) {

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -67,7 +67,12 @@ export default class Sidebar {
    */
   constructor(element, eventBus, guest, config = {}) {
     this._emitter = eventBus.createEmitter();
+
+    /**
+     * The `<iframe>` element containing the sidebar application.
+     */
     this.iframe = createSidebarIframe(config);
+
     this.options = config;
 
     /** @type {BucketBar|null} */
@@ -190,13 +195,6 @@ export default class Sidebar {
     // Initial layout notification
     this._notifyOfLayoutChange(false);
     this._setupSidebarEvents();
-  }
-
-  /**
-   * Return a reference to the `Window` containing the sidebar application.
-   */
-  get sidebarWindow() {
-    return /** @type {Window} */ (this.iframe.contentWindow);
   }
 
   destroy() {

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -192,6 +192,13 @@ export default class Sidebar {
     this._setupSidebarEvents();
   }
 
+  /**
+   * Return a reference to the `Window` containing the sidebar application.
+   */
+  get sidebarWindow() {
+    return /** @type {Window} */ (this.iframe.contentWindow);
+  }
+
   destroy() {
     this.bucketBar?.destroy();
     this._listeners.removeAll();

--- a/src/annotator/test/cross-frame-test.js
+++ b/src/annotator/test/cross-frame-test.js
@@ -78,18 +78,24 @@ describe('CrossFrame', () => {
         emit: sinon.match.func,
       });
     });
+  });
 
-    it('starts the discovery of new channels', () => {
-      createCrossFrame();
-      assert.called(fakeDiscovery.startDiscovery);
-    });
+  describe('#connectToSidebar', () => {
+    it('starts the discovery of new channels', async () => {
+      const cf = createCrossFrame();
+      const sidebarFrame = {};
+      fakeDiscovery.startDiscovery.callsFake((callback, frames) => {
+        setTimeout(() => callback(frames[0], 'ORIGIN', 'TOKEN'), 0);
+      });
 
-    it('creates a channel when a new frame is discovered', () => {
-      createCrossFrame();
-      fakeDiscovery.startDiscovery.yield('SOURCE', 'ORIGIN', 'TOKEN');
+      await cf.connectToSidebar(sidebarFrame);
+
+      assert.calledWith(fakeDiscovery.startDiscovery, sinon.match.func, [
+        sidebarFrame,
+      ]);
       assert.called(fakeBridge.createChannel);
       assert.calledWith(fakeBridge.createChannel, {
-        source: 'SOURCE',
+        source: sidebarFrame,
         origin: 'ORIGIN',
         token: 'TOKEN',
       });

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -137,7 +137,7 @@ describe('CrossFrame multi-frame scenario', () => {
     const frame = document.createElement('iframe');
     frame.setAttribute('enable-annotation', '');
     container.appendChild(frame);
-    frame.contentWindow.eval('window.__hypothesis_frame = true');
+    frame.contentWindow.eval('window.__hypothesis = {}');
 
     crossFrame = createCrossFrame();
 

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -145,6 +145,16 @@ describe('Sidebar', () => {
     });
   });
 
+  describe('#iframe', () => {
+    it('returns a reference to the `<iframe>` containing the sidebar', () => {
+      const sidebar = createSidebar();
+      const iframe = containers[0]
+        .querySelector('hypothesis-sidebar')
+        .shadowRoot.querySelector('iframe');
+      assert.equal(sidebar.iframe, iframe);
+    });
+  });
+
   function getConfigString(sidebar) {
     return sidebar.iframe.src;
   }

--- a/src/annotator/util/frame-util.js
+++ b/src/annotator/util/frame-util.js
@@ -17,7 +17,7 @@ export function findFrames(container) {
 
 // Check if the iframe has already been injected
 export function hasHypothesis(iframe) {
-  return iframe.contentWindow.__hypothesis_frame === true;
+  return '__hypothesis' in iframe.contentWindow;
 }
 
 // Inject embed.js into the iframe

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -236,8 +236,13 @@ export class FrameSyncService {
     };
 
     const discovery = new Discovery(window, { server: true });
-    discovery.startDiscovery((source, origin, token) =>
-      this._bridge.createChannel({ source, origin, token })
+    discovery.startDiscovery(
+      (source, origin, token) =>
+        this._bridge.createChannel({ source, origin, token }),
+      [
+        // Ping the host frame which is in most cases also the only guest.
+        window.parent,
+      ]
     );
     this._bridge.onConnect(addFrame);
 

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -142,9 +142,8 @@
  * @typedef Globals
  * @prop {import('./pdfjs').PDFViewerApplication} [PDFViewerApplication] -
  *   PDF.js entry point. If set, triggers loading of PDF rather than HTML integration.
- * @prop {boolean} [__hypothesis_frame] -
- *   Flag used to indicate that the "annotator" part of Hypothesis is loaded in
- *   the current frame.
+ * @prop {object} [__hypothesis] - Internal data related to supporting guests in iframes
+ *   @prop {Window} [sidebarWindow] - The sidebar window that is active in this frame.
  */
 
 /**


### PR DESCRIPTION
The logic used by guest/host and sidebar frames to find each other in
`Discovery#startDiscovery` relied on traversing the frame tree starting
from `window.top` using `window.frames`. Since `window.frames` doesn't
include frames in shadow roots, this did not work if _both_ the guest and
sidebar are contained within a shadow root. The sidebar is always
contained in a shadow root created by the `<hypothesis-sidebar>`
element, so this simplifies to only working if the guest/host is not
contained in a shadow root.

For current use cases it is possible for guest frames to get a direct
reference to the sidebar frame they should be communicating with and for
the sidebar to get direct a reference to the host frame (its parent).
This avoids the need for `window.frames` traversal.

This commit leverages that by changing `startDiscovery` to take an
explicit array of frames to ping. Guest frames invoke `startDiscovery`
passing a reference to the sidebar frame and sidebar frames invoke
`startDiscovery` passing a reference to the parent (host) frame.

This fixes the following scenarios:

 - Hypothesis not completing loading if host frame is contained within a
   shadow root. eg. In the VitalSource book reader. _See http://localhost:3000/document/host-in-shadow-root test case in client dev server._

 - Same-origin guest frames loading Hypothesis after the sidebar has
   already loaded. See http://localhost:3000/document/parent-frame test
   case in client dev server.

 - Multiple sidebars attempting to connect to the same guest frame, if
   Hypothesis is loaded multiple times in different parts of the frame
   tree. See http://localhost:3000/document/multi-frames test case in
   client dev server.

This approach has some limitations:

 - Child guest frames which are not same-origin with the parent host frame
   are not supported.
 - Child guest frames which attempt to connect to the sidebar before it
   has loaded will fail to connect. This could be remedied by making the
   guest wait for confirmation of the sidebar having loaded before
   calling `connectToSidebar`. This doesn't affect the host frame since
   the sidebar pings that frame directly.

These limitations are acceptable in the short term but will be remedied
by a larger overhaul of inter-frame communication that is currently
being worked on.

Fixes https://github.com/hypothesis/client/issues/3590
This is also a short-term fix for https://github.com/hypothesis/client/issues/249 and https://github.com/hypothesis/client/issues/187. A better solution will be coming with https://github.com/hypothesis/client/issues/3533.

---

- [x] Add a test case to the client's dev server which reproduces the issue from the VitalSource reader (possibly as separate PR) (https://github.com/hypothesis/client/pull/3600)
- [x] Update the tests for `Discovery`, `CrossFrame`, `FrameSync`
