### PR TITLE
Add manual test case for when Hypothesis is loaded into an iframe inside a shadow root

### DIFF
--- a/dev-server/documents/html/host-in-shadow-root.mustache
+++ b/dev-server/documents/html/host-in-shadow-root.mustache
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Guest frame in shadow root</title>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+    </style>
+    <template id="content-container-template">
+      <iframe src="/document/burns" width="100%" height="400"></iframe>
+    </template>
+    <script>
+      class ContentContainerElement extends HTMLElement {
+        constructor() {
+          super();
+
+          const template = document.getElementById(
+            'content-container-template'
+          );
+          const shadowRoot = this.attachShadow({ mode: 'open' });
+          shadowRoot.append(template.content.cloneNode(true));
+        }
+      }
+      customElements.define('content-container', ContentContainerElement);
+    </script>
+  </head>
+  <body>
+    <h2>Guest frame in shadow root</h2>
+    <p>
+      This is a test for when the Hypothesis client is loaded inside an
+      <code>&lt;iframe&gt;</code> which is in turn contained within a shadow root.
+      Such frames are <a href="https://github.com/WICG/webcomponents/issues/145">not
+      discoverable</a> via <code>window.frames</code>.
+    </p>
+    <content-container></content-container>
+  </body>
+</html>

--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -15,27 +15,42 @@
   <h1>Hypothesis Client development server</h1>
   <p>Welcome to the Hypothesis client's development server.</p>
   <h2>Test HTML documents</h2>
-  <ul>
-    <li><a href="/document/burns">Poems and Songs of Robert Burns</a></li>
-    <li><a href="/document/doyle">The Disappearance of Lady Carfax, by Arthur Conan Doyle</a></li>
-    <li><a href="/document/tolstoy">Anna Karenina, by Leo Tolstoy</a></li>
-    <li><a href="/document/z-index">z-index test</a></li>
-    <li><a href="/document/shadow-dom">Shadow DOM test</a></li>
-    <li><a href="/document/parent-frame">Annotatable iframe test</a></li>
-    <li><a href="/document/sidebar-external-container">Sidebar in external container test</a></li>
-    <li><a href="/document/multi-frames">Multi-frame test</a></li>
-    <li><a href="/document/ignore-other-configuration"><code>ignoreOtherConfiguration</code> test</a></li>
-  </ul>
+    <h3>General HTML test documents</h3>
+    <p>These document test typical/simple scenarios.</p>
+    <ul>
+      <li><a href="/document/burns">Poems and Songs of Robert Burns</a></li>
+      <li><a href="/document/doyle">The Disappearance of Lady Carfax, by Arthur Conan Doyle</a></li>
+      <li><a href="/document/tolstoy">Anna Karenina, by Leo Tolstoy</a></li>
+    </ul>
+
+    <h3>Scenario HTML test documents</h3>
+    <p>These documents test less common scenarios and edge cases.</p>
+    <ul>
+      <li><a href="/document/z-index">Content with high <code>z-index</code> style</a></li>
+      <li><a href="/document/shadow-dom">Content in shadow DOM</a></li>
+      <li><a href="/document/parent-frame">Annotation-enabled iframe</a></li>
+      <li><a href="/document/sidebar-external-container">Sidebar in external container</a></li>
+      <li><a href="/document/multi-frames">Page containing multiple iframes with Hypothesis loaded</a></li>
+      <li><a href="/document/ignore-other-configuration"><code>ignoreOtherConfiguration</code>
+          configuration option enabled</a></li>
+    </ul>
 
   <h2>Test PDF documents</h2>
+  <h3>General test documents</h3>
+  <p>These documents test typical/simple scenarios.</p>
   <ul>
     <li><a href="/pdf/nils-olav">Brigadier Sir Nils Olav III</a></li>
-    <li><a href="/pdf/nils-olav" class="js-randomize-url">Brigadier Sir Nils Olav III</a> (randomized URL)</li>
     <li><a href="/pdf/budlong">The Budlong Pickle Company (Wikipedia)</a></li>
     <li><a href="/pdf/widdershins">Widdershins (Wikipedia)</a></li>
-    <li><a href="/pdf/painting"><em>The Development of British Landscape Painting in Water-Colours</em></a> (excerpt)
-      by Alexander J. Finberg & E.A. Taylor (this PDF does not have select-able text)</li>
-    <li><a href="/pdf/gatsby">The Great Gatsby</a> (full novel)</li>
+  </ul>
+
+  <h3>Scenario PDF test documents</h3>
+  <p>These documents test less common scenarios and edge cases.</p>
+  <ul>
+    <li><a href="/pdf/nils-olav" class="js-randomize-url">PDF with URL that changes on each
+        visit</a></li>
+    <li><a href="/pdf/painting">PDF without selectable text</a></li>
+    <li><a href="/pdf/gatsby">The Great Gatsby</a> (A long document)</li>
   </ul>
 
   <h2>Page feature tests</h2>

--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -28,6 +28,7 @@
     <ul>
       <li><a href="/document/z-index">Content with high <code>z-index</code> style</a></li>
       <li><a href="/document/shadow-dom">Content in shadow DOM</a></li>
+      <li><a href="/document/host-in-shadow-root">Hypothesis loaded into frame in shadow root</a></li>
       <li><a href="/document/parent-frame">Annotation-enabled iframe</a></li>
       <li><a href="/document/sidebar-external-container">Sidebar in external container</a></li>
       <li><a href="/document/multi-frames">Page containing multiple iframes with Hypothesis loaded</a></li>


### PR DESCRIPTION
The first commit in this PR reorganizes the test cases on the home page of the dev server to split general HTML/PDF test documents from those which test for specific scenarios (non-standard configuration, documents with properties that may cause problems etc.):

<img width="607" alt="Client dev server homepage reorganization" src="https://user-images.githubusercontent.com/2458/126641820-d8cb0e43-33c0-4900-87d9-77087e9e8610.png">

The second commit in this PR adds a manual test case to the dev server that exercises the problem preventing the client from working with [the new VitalSource book reader](https://github.com/hypothesis/client/issues/3590).

To test, restart the dev server and go to http://localhost:3000/document/host-in-shadow-root. Observe that the Annotate/Highlight toolbar appears when selecting text, but the sidebar does not.