### PR TITLE
Make mockImportedComponents only mock first-party components

### DIFF
--- a/src/sidebar/components/Annotation/test/AnnotationShareInfo-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationShareInfo-test.js
@@ -52,7 +52,7 @@ describe('AnnotationShareInfo', () => {
       const groupLink = wrapper.find('a');
 
       assert.equal(groupLink.prop('href'), fakeGroup.links.html);
-      assert.equal(groupLink.text(), fakeGroup.name);
+      assert.include(groupLink.text(), fakeGroup.name);
     });
 
     it('should display a group icon for private and restricted groups', () => {

--- a/src/sidebar/components/test/FilterSelect-test.js
+++ b/src/sidebar/components/test/FilterSelect-test.js
@@ -70,7 +70,7 @@ describe('FilterSelect', () => {
     assert.isTrue(icon.exists());
     assert.equal(icon.props().name, 'profile');
     // Default option should be selected as we didn't indicate a selected option
-    assert.equal(label.text(), 'all');
+    assert.include(label.text(), 'all');
   });
 
   it('should render provided title', () => {

--- a/src/sidebar/components/test/HelpPanel-test.js
+++ b/src/sidebar/components/test/HelpPanel-test.js
@@ -50,7 +50,7 @@ describe('HelpPanel', () => {
       const wrapper = createComponent();
       const subHeader = wrapper.find('.HelpPanel__sub-panel-title');
 
-      assert.equal(subHeader.text(), 'Getting started');
+      assert.include(subHeader.text(), 'Getting started');
       assert.isTrue(wrapper.find('Tutorial').exists());
       assert.isFalse(wrapper.find('VersionInfo').exists());
     });
@@ -59,14 +59,14 @@ describe('HelpPanel', () => {
       const wrapper = createComponent();
       const link = wrapper.find('.HelpPanel__sub-panel-navigation-button');
 
-      assert.equal(link.text(), 'About this version');
+      assert.include(link.text(), 'About this version');
     });
 
     it('should switch to versionInfo sub-panel when footer link clicked', () => {
       const wrapper = createComponent();
       wrapper.find('.HelpPanel__sub-panel-navigation-button').simulate('click');
 
-      assert.equal(
+      assert.include(
         wrapper.find('.HelpPanel__sub-panel-title').text(),
         'About this version'
       );
@@ -88,7 +88,7 @@ describe('HelpPanel', () => {
 
       assert.isTrue(wrapper.find('VersionInfo').exists());
       assert.isFalse(wrapper.find('Tutorial').exists());
-      assert.equal(link.text(), 'Getting started');
+      assert.include(link.text(), 'Getting started');
     });
 
     it('should switch to tutorial sub-panel when link clicked', () => {

--- a/src/sidebar/components/test/MenuItem-test.js
+++ b/src/sidebar/components/test/MenuItem-test.js
@@ -90,8 +90,8 @@ describe('MenuItem', () => {
 
   describe('icons', () => {
     it('renders an SVG icon if an icon name is provided', () => {
-      const wrapper = createMenuItem({ icon: 'an-svg-icon' });
-      assert.isTrue(wrapper.exists('SvgIcon[name="an-svg-icon"]'));
+      const wrapper = createMenuItem({ icon: 'edit' });
+      assert.isTrue(wrapper.exists('SvgIcon[name="edit"]'));
     });
 
     it('renders a blank space for an icon if `icon` is "blank"', () => {
@@ -108,7 +108,7 @@ describe('MenuItem', () => {
     });
 
     it('renders top-level menu item icons on the left', () => {
-      const wrapper = createMenuItem({ icon: 'an-svg-icon' });
+      const wrapper = createMenuItem({ icon: 'edit' });
       const iconSpaces = wrapper.find('.MenuItem__icon-container');
 
       // There should be only one icon space, on the left.
@@ -164,7 +164,7 @@ describe('MenuItem', () => {
 
     it('renders submenu item icons on the right', () => {
       const wrapper = createMenuItem({
-        icon: 'an-svg-icon',
+        icon: 'edit',
         isSubmenuItem: true,
         submenu: <div role="menuitem">Submenu content</div>,
       });
@@ -304,7 +304,7 @@ describe('MenuItem', () => {
         // eslint-disable-next-line react/display-name
         content: () => (
           <div role="menu">
-            <MenuItem label="Test" icon="an-svg-icon" />
+            <MenuItem label="Test" icon="edit" />
           </div>
         ),
       },

--- a/src/sidebar/components/test/TagEditor-test.js
+++ b/src/sidebar/components/test/TagEditor-test.js
@@ -90,7 +90,7 @@ describe('TagEditor', () => {
     const wrapper = createComponent();
     wrapper.find('li').forEach((tag, i) => {
       assert.isTrue(tag.hasClass('TagEditor__item'));
-      assert.equal(tag.text(), fakeTags[i]);
+      assert.include(tag.text(), fakeTags[i]);
       assert.equal(tag.prop('aria-label'), `Tag: ${fakeTags[i]}`);
     });
   });

--- a/src/test-util/mock-imported-components.js
+++ b/src/test-util/mock-imported-components.js
@@ -38,7 +38,9 @@ function getDisplayName(component) {
 
 /**
  * Helper for use with `babel-plugin-mockable-imports` that mocks components
- * imported by a file.
+ * imported by a file. This will only mock components that are local to the
+ * package; it will not mock external components. This is to aid in catching
+ * integration issues, at the slight cost of unit isolation.
  *
  * Mocked components will have the same display name as the original component,
  * minus any wrappers (eg. `Widget` and `withServices(Widget)` both become
@@ -62,7 +64,7 @@ function getDisplayName(component) {
  */
 export default function mockImportedComponents() {
   return (source, symbol, value) => {
-    if (!isComponent(value)) {
+    if (!isComponent(value) || !source.startsWith('.')) {
       return null;
     }
 


### PR DESCRIPTION
This PR shows how we might avoid mocking third-party components such that we don't make incorrect assumptions about their behavior.

There were 9 test failures after this change, which fit these patterns:

* Referencing an icon name in `SvgIcon` that isn't registered
* Checking for `wrapper.text()` string equality inside or near `Button` components. Because of internal structure of Button components, these strings are followed by a line break character `\n`. Updated tests to use `assert.include` instead of `assert.equal` in these cases.

The approach used here might be naive, and I'm not sure how we'd want to manage this change across projects (LMS has its own `mock-imported-components`, e.g.), so I'm putting this in draft for now.

Part of https://github.com/hypothesis/client/issues/3567