### PR TITLE
Convert host <-> guest communication to use MessageChannel

### DIFF
--- a/src/annotator/cross-frame.js
+++ b/src/annotator/cross-frame.js
@@ -76,7 +76,6 @@ export class CrossFrame {
       frame.postMessage(
         {
           type: 'hypothesisGuestReady',
-          port: channel.port2,
         },
         origin,
         [channel.port2]

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -78,9 +78,15 @@ function init() {
   const notebook = new Notebook(document.body, eventBus, getConfig('notebook'));
 
   // Set up communication between this host/guest frame and the sidebar frame.
-  const sidebarWindow =
-    window_.__hypothesis.sidebarWindow ||
-    /** @type {HypothesisWindow} */ (window.parent).__hypothesis?.sidebarWindow;
+  let sidebarWindow = window_.__hypothesis.sidebarWindow;
+  try {
+    sidebarWindow = /** @type {HypothesisWindow} */ (window.parent).__hypothesis
+      ?.sidebarWindow;
+  } catch {
+    // `window.parent` access can fail due to it being cross-origin. This is
+    // handled below.
+  }
+
   if (sidebarWindow) {
     const sidebarOrigin = new URL(sidebarLinkElement.href).origin;
     sidebarWindow.then(frame =>
@@ -89,7 +95,8 @@ function init() {
   } else {
     // eslint-disable-next-line no-console
     console.warn(
-      `Hypothesis guest frame in ${location.origin} could not find a sidebar to connect to`
+      `Hypothesis guest frame in ${location.origin} could not find a sidebar to connect to.
+Guest frames can only connect to sidebars in their same-origin parent frame.`
     );
   }
 

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -80,11 +80,15 @@ function init() {
   // Set up communication between this host/guest frame and the sidebar frame.
   let sidebarWindow = window_.__hypothesis.sidebarWindow;
   try {
-    sidebarWindow = /** @type {HypothesisWindow} */ (window.parent).__hypothesis
-      ?.sidebarWindow;
+    // If this is a guest-only frame which doesn't have its own sidebar, try
+    // to connect to the one created by the parent frame. This only works if
+    // the host and guest frames are same-origin.
+    if (!sidebarWindow) {
+      sidebarWindow = /** @type {HypothesisWindow} */ (window.parent)
+        .__hypothesis?.sidebarWindow;
+    }
   } catch {
-    // `window.parent` access can fail due to it being cross-origin. This is
-    // handled below.
+    // `window.parent` access can fail due to it being cross-origin.
   }
 
   if (sidebarWindow) {

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -195,6 +195,21 @@ export default class Sidebar {
     // Initial layout notification
     this._notifyOfLayoutChange(false);
     this._setupSidebarEvents();
+
+    /**
+     * A promise that resolves when the sidebar application is ready to
+     * communicate with the host and guest frames.
+     *
+     * @type {Promise<void>}
+     */
+    this.ready = new Promise(resolve => {
+      this._listeners.add(window, 'message', event => {
+        const data = /** @type {MessageEvent} */ (event).data;
+        if (data?.type === 'hypothesisSidebarReady') {
+          resolve();
+        }
+      });
+    });
   }
 
   destroy() {

--- a/src/annotator/test/cross-frame-test.js
+++ b/src/annotator/test/cross-frame-test.js
@@ -68,9 +68,9 @@ describe('CrossFrame', () => {
         sidebarFrame.postMessage,
         {
           type: 'hypothesisGuestReady',
-          port: sinon.match.instanceOf(MessagePort),
         },
-        sidebarOrigin
+        sidebarOrigin,
+        [sinon.match.instanceOf(MessagePort)]
       );
     });
 

--- a/src/annotator/test/cross-frame-test.js
+++ b/src/annotator/test/cross-frame-test.js
@@ -78,7 +78,7 @@ describe('CrossFrame', () => {
       const cf = createCrossFrame();
       const sidebarFrame = { postMessage: sinon.stub() };
 
-      cf.connectToSidebar(sidebarFrame);
+      cf.connectToSidebar(sidebarFrame, 'https://dummy.hypothes.is');
 
       assert.calledWith(
         fakeBridge.createChannel,

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -159,8 +159,8 @@ describe('Sidebar', () => {
     it('returns a promise that resolves when `hypothesisSidebarReady` message is received', async () => {
       const sidebar = createSidebar();
 
-      // Check `sidebar.ready` is not resolved before `hypothesisSidebarReady`
-      // message is received.
+      // Check `sidebar.ready` is not already resolved, by racing it against
+      // an immediately resolved promise.
       assert.equal(
         await Promise.race([sidebar.ready, Promise.resolve('not-ready')]),
         'not-ready'

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -155,6 +155,27 @@ describe('Sidebar', () => {
     });
   });
 
+  describe('#ready', () => {
+    it('returns a promise that resolves when `hypothesisSidebarReady` message is received', async () => {
+      const sidebar = createSidebar();
+
+      // Check `sidebar.ready` is not resolved before `hypothesisSidebarReady`
+      // message is received.
+      assert.equal(
+        await Promise.race([sidebar.ready, Promise.resolve('not-ready')]),
+        'not-ready'
+      );
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { type: 'hypothesisSidebarReady' },
+        })
+      );
+
+      return sidebar.ready;
+    });
+  });
+
   function getConfigString(sidebar) {
     return sidebar.iframe.src;
   }

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -247,13 +247,13 @@ export class FrameSyncService {
       if (e.data?.type !== 'hypothesisGuestReady') {
         return;
       }
-      const port = /** @type {unknown} */ (e.data.port);
-      if (!(port instanceof MessagePort)) {
+      if (e.ports.length === 0) {
         console.warn(
           'Ignoring `hypothesisGuestReady` message without a MessagePort'
         );
         return;
       }
+      const port = e.ports[0];
       this._bridge.createChannel(port);
     });
 

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -153,8 +153,8 @@ describe('FrameSyncService', () => {
       },
     ].forEach(messageInit => {
       it('ignores `hypothesisGuestReady` messages that are invalid', () => {
+        frameSync.connect();
         fakeWindow.dispatchEvent(new MessageEvent('message', messageInit));
-
         assert.notCalled(fakeBridge.createChannel);
       });
     });

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -135,7 +135,8 @@ describe('FrameSyncService', () => {
       frameSync.connect();
       fakeWindow.dispatchEvent(
         new MessageEvent('message', {
-          data: { type: 'hypothesisGuestReady', port: channel.port1 },
+          data: { type: 'hypothesisGuestReady' },
+          ports: [channel.port1],
         })
       );
 
@@ -143,25 +144,16 @@ describe('FrameSyncService', () => {
     });
 
     [
-      'not-an-object',
-      {},
-      { type: 'unknownType' },
+      { data: 'not-an-object' },
+      { data: {} },
+      { data: { type: 'unknownType' } },
       {
-        // Missing `port` property
-        type: 'hypothesisGuestReady',
+        // No ports provided with message
+        data: { type: 'hypothesisGuestReady' },
       },
-      {
-        // `port` property is not a MessagePort
-        type: 'hypothesisGuestReady',
-        port: {},
-      },
-    ].forEach(message => {
+    ].forEach(messageInit => {
       it('ignores `hypothesisGuestReady` messages that are invalid', () => {
-        fakeWindow.dispatchEvent(
-          new MessageEvent('message', {
-            data: message,
-          })
-        );
+        fakeWindow.dispatchEvent(new MessageEvent('message', messageInit));
 
         assert.notCalled(fakeBridge.createChannel);
       });

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -143,7 +143,9 @@
  * @prop {import('./pdfjs').PDFViewerApplication} [PDFViewerApplication] -
  *   PDF.js entry point. If set, triggers loading of PDF rather than HTML integration.
  * @prop {object} [__hypothesis] - Internal data related to supporting guests in iframes
- *   @prop {Window} [sidebarWindow] - The sidebar window that is active in this frame.
+ *   @prop {Promise<Window>} [__hypothesis.sidebarWindow] -
+ *     The sidebar window that is active in this frame. This resolves once the sidebar
+ *     application has started and is ready to connect to guests.
  */
 
 /**


### PR DESCRIPTION
This commit implements the initial transition of communication between
guest/host frames and the sidebar to use `MessageChannel` as the
underlying transport instead of `window.postMessage`, building on
previous changes to the `Bridge` and `RPC` classes.

This change aligns with an ongoing to plan to use `MessageChannel`
instead of `window.postMessage`, and also resolves an issue where guest
frames may fail to connect to the sidebar if the annotator code loads in
the guest before the sidebar application has finished loading.

This initial version has several limitations compared to what is planned
for the final version of the new inter-frame communication system:

 - It only supports guest frames which are the same frame as the host or
   a direct, same-origin child.
 - Sidebar <-> host communication relies on the host frame also being a
   guest frame. In order for the host frame to receive messages from the
   sidebar, it must run the logic to establish sidebar <-> guest communication.
   In other words, it is not possible to have a host frame which cannot
   also be annotated.
 - The only supported roles for frames are sidebar and host/guest. There
   is no separate role for notebook frames for use in notebook <->
   sidebar communication.

Making this change involved replacing the protocol used by guest frames
and the sidebar to discover each other. The new one is a minimal protocol
which is intended to be temporary and replaced with a different one in future
that addresses the above limitations (see `shared/communicator.js` in [this draft](https://github.com/hypothesis/client/pull/3534/files)).

1. When the sidebar application starts up it notifies the parent frame that
   it is ready to connect to guests via a `hypothesisSidebarReady`
   message.
2. Guest frames wait for this notification to be received before
   connecting to the sidebar. When they connect, they create a
   `MessageChannel` and send one port to the sidebar via a
   `hypothesisGuestReady` message and use the other port locally.
3. When the sidebar receives a `hypothesisGuestReady` message it creates
   a channel to communicate with the guest.
