### PR TITLE
Add types for methods of `APIService` that make API calls

### DIFF
--- a/src/sidebar/components/AnnotationView.js
+++ b/src/sidebar/components/AnnotationView.js
@@ -56,7 +56,9 @@ function AnnotationView({ loadAnnotationsService, onLogin }) {
 
         // Make the full thread of annotations visible. By default replies are
         // not shown until the user expands the thread.
-        annots.forEach(annot => store.setExpanded(annot.id, true));
+        annots.forEach(annot =>
+          store.setExpanded(/** @type {string} */ (annot.id), true)
+        );
 
         // FIXME - This should show a visual indication of which reply the
         // annotation ID in the URL refers to. That isn't currently working.

--- a/src/sidebar/components/ModerationBanner.js
+++ b/src/sidebar/components/ModerationBanner.js
@@ -34,10 +34,11 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
    * Hide an annotation from non-moderator users.
    */
   const hideAnnotation = () => {
+    const id = /** @type {string} */ (annotation.id);
     api.annotation
-      .hide({ id: annotation.id })
+      .hide({ id })
       .then(() => {
-        store.hideAnnotation(annotation.id);
+        store.hideAnnotation(id);
       })
       .catch(() => {
         toastMessenger.error('Failed to hide annotation');
@@ -48,10 +49,11 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
    * Un-hide an annotation from non-moderator users.
    */
   const unhideAnnotation = () => {
+    const id = /** @type {string} */ (annotation.id);
     api.annotation
-      .unhide({ id: annotation.id })
+      .unhide({ id })
       .then(() => {
-        store.unhideAnnotation(annotation.id);
+        store.unhideAnnotation(id);
       })
       .catch(() => {
         toastMessenger.error('Failed to unhide annotation');

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -90,7 +90,9 @@ function get(object, path) {
  * @param {Promise<RouteMap>} links - API route data from API index endpoint (`/api/`)
  * @param {string} route - The dotted path of the named API route (eg. `annotation.create`)
  * @param {APIMethodCallbacks} callbacks
- * @return {APICall<Record<string, any>, object, object>}
+ * @return {APICall<Record<string, any>, object, object>} - Function that makes
+ *   an API call. The returned `APICall` has generic parameter, body and return types.
+ *   This can be cast to an `APICall` with more specific types.
  */
 function createAPICall(
   links,

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -52,15 +52,6 @@ function stripInternalProperties(obj) {
  */
 
 /**
- * Options controlling how an API call is made or processed.
- *
- * @typedef APICallOptions
- * @prop {boolean} [includeMetadata] - If false (the default), the response is
- *   just the JSON response from the API. If true, the response is an `APIResponse`
- *   containing additional metadata about the request and response.
- */
-
-/**
  * Function which makes an API request.
  *
  * @template {Record<string, any>} Params
@@ -69,7 +60,6 @@ function stripInternalProperties(obj) {
  * @callback APICall
  * @param {Params} params - A map of URL and query string parameters to include with the request.
  * @param {Body} [data] - The body of the request.
- * @param {APICallOptions} [options]
  * @return {Promise<Result>}
  */
 
@@ -107,10 +97,9 @@ function createAPICall(
   route,
   { getAccessToken, getClientId, onRequestStarted, onRequestFinished }
 ) {
-  return function (params, data, options = {}) {
+  return (params, data) => {
     onRequestStarted();
 
-    let accessToken;
     return Promise.all([links, getAccessToken()])
       .then(([links, token]) => {
         const descriptor = get(links, route);
@@ -119,7 +108,6 @@ function createAPICall(
           'Hypothesis-Client-Version': '__VERSION__', // replaced by versionify
         };
 
-        accessToken = token;
         if (token) {
           headers.Authorization = 'Bearer ' + token;
         }
@@ -170,11 +158,7 @@ function createAPICall(
             throw translateResponseToError(response, data);
           }
 
-          if (options.includeMetadata) {
-            return { data, token: accessToken };
-          } else {
-            return data;
-          }
+          return data;
         },
         err => {
           // `fetch` failed to execute the request, or parsing the response failed.

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -378,8 +378,9 @@ export class GroupsService {
       userGroups.find(g => g.id === id || g.groupid === id) ||
       tryFetchGroup(id);
 
-    const groups = (await Promise.all(groupIds.map(getGroup))).filter(
-      g => g !== null
+    const groupResults = await Promise.all(groupIds.map(getGroup));
+    const groups = /** @type {Group[]} */ (
+      groupResults.filter(g => g !== null)
     );
 
     // Optional direct linked group id. This is used in the Notebook context.

--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -180,7 +180,7 @@ export class LoadAnnotationsService {
       //    fetch the top-level annotation
       if (isReply(annotation)) {
         annotation = await this._api.annotation.get({
-          id: annotation.references[0],
+          id: /** @type {string[]} */ (annotation.references)[0],
         });
       }
 
@@ -198,9 +198,10 @@ export class LoadAnnotationsService {
     // configure the connection to the real-time update service to send us
     // updates to any of the annotations in the thread.
     if (!isReply(annotation)) {
+      const id = /** @type {string} */ (annotation.id);
       this._streamFilter
-        .addClause('/references', 'one_of', annotation.id, true)
-        .addClause('/id', 'equals', annotation.id, true);
+        .addClause('/references', 'one_of', id, true)
+        .addClause('/id', 'equals', id, true);
       this._streamer.setConfig('filter', {
         filter: this._streamFilter.getFilter(),
       });

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -222,7 +222,7 @@ describe('APIService', () => {
     });
   });
 
-  it('API calls return just the JSON response if `includeMetadata` is false', () => {
+  it('API calls return the JSON response', () => {
     expectCall('get', 'profile', 200, { userid: 'acct:user@example.com' });
     return api.profile.read({}).then(response => {
       assert.match(
@@ -232,23 +232,6 @@ describe('APIService', () => {
         })
       );
     });
-  });
-
-  it('API calls return an `APIResponse` if `includeMetadata` is true', () => {
-    expectCall('get', 'profile', 200, { userid: 'acct:user@example.com' });
-    return api.profile
-      .read({}, null, { includeMetadata: true })
-      .then(response => {
-        assert.match(
-          response,
-          sinon.match({
-            data: {
-              userid: 'acct:user@example.com',
-            },
-            token: 'faketoken',
-          })
-        );
-      });
   });
 
   it('omits Authorization header if no access token is available', () => {

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -142,6 +142,7 @@
  *
  * @typedef Group
  * @prop {string} id
+ * @prop {string} groupid
  * @prop {'private'|'open'} type
  * @prop {Organization} organization - nb. This field is nullable in the API, but
  *   we assign a default organization on the client.


### PR DESCRIPTION
This PR is some follow-on work related to the recent changes around query string parameters in API calls. It adds types for the parameter, body and return types of methods of `APIService` that are used to make calls to the Hypothesis API.

This is done via annotations at the end of the `APIService` constructor (see `src/sidebar/services/api.js`) like this:

```js
things: {
  /** @type {APICall<Params, Body, Result>} */
  fetch: apiCall('things.fetch'),
}
```

Where `things.fetch` is called elsewhere in the code using:

```js
const result = api.things.fetch(params, body);
```

`Params` is an object type specifying the allowed parameters. `Body` is the type of the JSON body or `void` if the method doesn't require one. `Result` is the type of the JSON response or `void` if the API call doesn't return a result.

In the process of doing this I was reminded that API calls support an `includeMetadata` option which causes them to return data other than just the parsed JSON response. This option is not actually used currently so to simplify things I just removed it.