### PR TITLE
Simplify construction of `AnnotationSync` service

### DIFF
--- a/src/annotator/annotation-sync.js
+++ b/src/annotator/annotation-sync.js
@@ -1,6 +1,8 @@
 /**
- * @typedef {import('../types/annotator').AnnotationData} AnnotationData
  * @typedef {import('../shared/bridge').default} Bridge
+ * @typedef {import('../types/annotator').AnnotationData} AnnotationData
+ * @typedef {import('../types/annotator').Destroyable} Destroyable
+ * @typedef {import('./util/emitter').EventBus} EventBus
  */
 
 /**
@@ -18,18 +20,16 @@
  *
  * It also listens for events from Guest when new annotations are created or
  * annotations successfully anchor and relays these to the sidebar app.
+ *
+ * @implements Destroyable
  */
 export default class AnnotationSync {
   /**
-   * @param {Bridge} bridge
-   * @param {Object} options
-   *   @param {(event: string, callback: (...args: any[]) => void) => void} options.on -
-   *     Function that registers a listener for an event from the rest of the
-   *     annotator
-   *   @param {(event: string, ...args: any[]) => void} options.emit -
-   *     Function that publishes an event to the rest of the annotator
+   * @param {EventBus} eventBus - Event bus for communicating with the annotator code (eg. the Guest)
+   * @param {Bridge} bridge - Channel for communicating with the sidebar
    */
-  constructor(bridge, options) {
+  constructor(eventBus, bridge) {
+    this._emitter = eventBus.createEmitter();
     this.bridge = bridge;
 
     /**
@@ -40,25 +40,22 @@ export default class AnnotationSync {
      */
     this.cache = {};
 
-    this._on = options.on;
-    this._emit = options.emit;
-
     // Relay events from the sidebar to the rest of the annotator.
     this.bridge.on('deleteAnnotation', (body, callback) => {
       const annotation = this._parse(body);
       delete this.cache[annotation.$tag];
-      this._emit('annotationDeleted', annotation);
+      this._emitter.publish('annotationDeleted', annotation);
       callback(null, this._format(annotation));
     });
 
     this.bridge.on('loadAnnotations', (bodies, callback) => {
       const annotations = bodies.map(body => this._parse(body));
-      this._emit('annotationsLoaded', annotations);
+      this._emitter.publish('annotationsLoaded', annotations);
       callback(null, annotations);
     });
 
     // Relay events from annotator to sidebar.
-    this._on('beforeAnnotationCreated', annotation => {
+    this._emitter.subscribe('beforeAnnotationCreated', annotation => {
       if (annotation.$tag) {
         return;
       }
@@ -127,5 +124,9 @@ export default class AnnotationSync {
       tag: annotation.$tag,
       msg: annotation,
     };
+  }
+
+  destroy() {
+    this._emitter.destroy();
   }
 }

--- a/src/annotator/cross-frame.js
+++ b/src/annotator/cross-frame.js
@@ -6,6 +6,7 @@ import FrameObserver from './frame-observer';
 /**
  * @typedef {import('../types/annotator').AnnotationData} AnnotationData
  * @typedef {import('../types/annotator').Destroyable} Destroyable
+ * @typedef {import('./util/emitter').EventBus} EventBus
  */
 
 /**
@@ -22,15 +23,12 @@ import FrameObserver from './frame-observer';
 export class CrossFrame {
   /**
    * @param {Element} element
-   * @param {object} options
-   *   @param {Record<string, any>} options.config,
-   *   @param {(event: string, ...args: any[]) => void} options.on
-   *   @param {(event: string, ...args: any[]) => void } options.emit
+   * @param {EventBus} eventBus - Event bus for communicating with the annotator code (eg. the Guest)
+   * @param {Record<string, any>} config
    */
-  constructor(element, options) {
-    const { config, on, emit } = options;
+  constructor(element, eventBus, config) {
     const bridge = new Bridge();
-    const annotationSync = new AnnotationSync(bridge, { on, emit });
+    const annotationSync = new AnnotationSync(eventBus, bridge);
     const frameObserver = new FrameObserver(element);
     const frameIdentifiers = new Map();
 
@@ -88,6 +86,7 @@ export class CrossFrame {
      */
     this.destroy = () => {
       bridge.destroy();
+      annotationSync.destroy();
       frameObserver.disconnect();
     };
 

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -165,11 +165,7 @@ export default class Guest {
     this._frameIdentifier = config.subFrameIdentifier || null;
 
     // Setup connection to sidebar.
-    this.crossframe = new CrossFrame(this.element, {
-      config,
-      on: (event, handler) => this._emitter.subscribe(event, handler),
-      emit: (event, ...args) => this._emitter.publish(event, ...args),
-    });
+    this.crossframe = new CrossFrame(this.element, eventBus, config);
     this.crossframe.onConnect(() => this._setupInitialState(config));
     this._connectSidebarEvents();
 

--- a/src/annotator/test/annotation-sync-test.js
+++ b/src/annotator/test/annotation-sync-test.js
@@ -36,9 +36,9 @@ describe('AnnotationSync', () => {
     emitter.destroy();
   });
 
-  describe('#constructor', () => {
-    context('when "deleteAnnotation" is published', () => {
-      it('calls publish("annotationDeleted")', () => {
+  describe('handling events from the sidebar', () => {
+    describe('on "deleteAnnotation" event', () => {
+      it('publish "annotationDeleted" to the annotator', () => {
         const ann = { id: 1, $tag: 'tag1' };
         const eventStub = sinon.stub();
         emitter.subscribe('annotationDeleted', eventStub);
@@ -61,7 +61,7 @@ describe('AnnotationSync', () => {
         publish('deleteAnnotation', { msg: ann }, callback);
       });
 
-      it('deletes any existing annotation from its cache before calling publish', done => {
+      it('deletes any existing annotation from its cache before publishing event to the annotator', done => {
         const annSync = createAnnotationSync();
         const ann = { id: 1, $tag: 'tag1' };
         annSync.cache.tag1 = ann;
@@ -84,8 +84,8 @@ describe('AnnotationSync', () => {
       });
     });
 
-    context('when "loadAnnotations" is published', () => {
-      it('calls publish("annotationsLoaded")', () => {
+    describe('on "loadAnnotations" event', () => {
+      it('publish "annotationsLoaded" to the annotator', () => {
         const annotations = [
           { id: 1, $tag: 'tag1' },
           { id: 2, $tag: 'tag2' },
@@ -105,9 +105,11 @@ describe('AnnotationSync', () => {
         assert.calledWith(loadedStub, annotations);
       });
     });
+  });
 
-    context('when "beforeAnnotationCreated" is published', () => {
-      it('calls bridge.call() passing the event', () => {
+  describe('handling events from the annotator', () => {
+    describe('on "beforeAnnotationCreated" event', () => {
+      it('calls "beforeCreateAnnotation" RPC method in the sidebar', () => {
         // nb. Setting an empty `$tag` here matches what `Guest#createAnnotation`
         // does.
         const ann = { id: 1, $tag: '' };

--- a/src/annotator/test/annotation-sync-test.js
+++ b/src/annotator/test/annotation-sync-test.js
@@ -51,9 +51,9 @@ describe('AnnotationSync', () => {
 
       it("calls the 'deleteAnnotation' event's callback function", done => {
         const ann = { id: 1, $tag: 'tag1' };
-        const callback = function (err, ret) {
+        const callback = function (err, result) {
           assert.isNull(err);
-          assert.deepEqual(ret, { tag: 'tag1', msg: ann });
+          assert.isUndefined(result);
           done();
         };
         createAnnotationSync();
@@ -85,7 +85,7 @@ describe('AnnotationSync', () => {
     });
 
     describe('on "loadAnnotations" event', () => {
-      it('publish "annotationsLoaded" to the annotator', () => {
+      it('publishes "annotationsLoaded" to the annotator', () => {
         const annotations = [
           { id: 1, $tag: 'tag1' },
           { id: 2, $tag: 'tag2' },
@@ -167,6 +167,29 @@ describe('AnnotationSync', () => {
   });
 
   describe('#destroy', () => {
+    it('ignore `loadAnnotations` and `deleteAnnotation` events from the sidebar', () => {
+      const ann = { msg: { id: 1 }, tag: 'tag1' };
+      const annotationSync = createAnnotationSync();
+      annotationSync.destroy();
+      const cb = sinon.stub();
+
+      publish('loadAnnotations', [ann], cb);
+      publish('deleteAnnotation', ann, cb);
+
+      assert.calledTwice(cb);
+      assert.calledWith(cb.firstCall, null);
+      assert.calledWith(cb.secondCall, null);
+    });
+
+    it('disables annotation syncing with the sidebar', () => {
+      const annotationSync = createAnnotationSync();
+      annotationSync.destroy();
+
+      annotationSync.sync([{ id: 1 }]);
+
+      assert.notCalled(fakeBridge.call);
+    });
+
     it('ignores "beforeAnnotationCreated" events from the annotator', () => {
       const annotationSync = createAnnotationSync();
       annotationSync.destroy();

--- a/src/annotator/test/cross-frame-test.js
+++ b/src/annotator/test/cross-frame-test.js
@@ -1,20 +1,17 @@
 import { CrossFrame, $imports } from '../cross-frame';
 
 describe('CrossFrame', () => {
-  let fakeBridge;
   let fakeAnnotationSync;
+  let fakeBridge;
+  let fakeEventBus;
 
-  let proxyBridge;
   let proxyAnnotationSync;
+  let proxyBridge;
 
-  const createCrossFrame = options => {
-    const defaults = {
-      config: {},
-      on: sinon.stub(),
-      emit: sinon.stub(),
-    };
+  const createCrossFrame = (options = {}) => {
+    fakeEventBus = {};
     const element = document.createElement('div');
-    return new CrossFrame(element, { ...defaults, ...options });
+    return new CrossFrame(element, fakeEventBus, options);
   };
 
   beforeEach(() => {
@@ -26,7 +23,7 @@ describe('CrossFrame', () => {
       on: sinon.stub(),
     };
 
-    fakeAnnotationSync = { sync: sinon.stub() };
+    fakeAnnotationSync = { sync: sinon.stub(), destroy: sinon.stub() };
 
     proxyAnnotationSync = sinon.stub().returns(fakeAnnotationSync);
     proxyBridge = sinon.stub().returns(fakeBridge);
@@ -49,10 +46,7 @@ describe('CrossFrame', () => {
 
     it('passes along options to AnnotationSync', () => {
       createCrossFrame();
-      assert.calledWith(proxyAnnotationSync, fakeBridge, {
-        on: sinon.match.func,
-        emit: sinon.match.func,
-      });
+      assert.calledWith(proxyAnnotationSync, fakeEventBus, fakeBridge);
     });
   });
 
@@ -92,6 +86,12 @@ describe('CrossFrame', () => {
       const cf = createCrossFrame();
       cf.destroy();
       assert.called(fakeBridge.destroy);
+    });
+
+    it('destroys the AnnotationSync object', () => {
+      const cf = createCrossFrame();
+      cf.destroy();
+      assert.called(fakeAnnotationSync.destroy);
     });
   });
 

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -32,7 +32,6 @@ describe('Guest', () => {
   const sandbox = sinon.createSandbox();
   let eventBus;
   let highlighter;
-  let guestConfig;
   let rangeUtil;
   let notifySelectionChanged;
 
@@ -49,7 +48,7 @@ describe('Guest', () => {
   const createGuest = (config = {}) => {
     const element = document.createElement('div');
     eventBus = new EventBus();
-    const guest = new Guest(element, eventBus, { ...guestConfig, ...config });
+    const guest = new Guest(element, eventBus, config);
     guests.push(guest);
     return guest;
   };
@@ -57,7 +56,6 @@ describe('Guest', () => {
   beforeEach(() => {
     guests = [];
     FakeAdder.instance = null;
-    guestConfig = {};
     highlighter = {
       getHighlightsContainingNode: sinon.stub().returns([]),
       highlightRange: sinon.stub().returns([]),

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -9,7 +9,7 @@ describe('CrossFrame multi-frame scenario', () => {
   let proxyBridge;
   let container;
   let crossFrame;
-  let options;
+  let config;
 
   const sandbox = sinon.createSandbox();
 
@@ -24,7 +24,7 @@ describe('CrossFrame multi-frame scenario', () => {
       call: sandbox.stub(),
       destroy: sandbox.stub(),
     };
-    fakeAnnotationSync = {};
+    fakeAnnotationSync = { destroy: sandbox.stub() };
     proxyAnnotationSync = sandbox.stub().returns(fakeAnnotationSync);
     proxyBridge = sandbox.stub().returns(fakeBridge);
 
@@ -36,12 +36,8 @@ describe('CrossFrame multi-frame scenario', () => {
     container = document.createElement('div');
     document.body.appendChild(container);
 
-    options = {
-      config: {
-        clientUrl: 'data:,', // empty data uri
-      },
-      on: sandbox.stub(),
-      emit: sandbox.stub(),
+    config = {
+      clientUrl: 'data:,', // empty data uri
     };
 
     crossFrame = null;
@@ -56,7 +52,8 @@ describe('CrossFrame multi-frame scenario', () => {
   });
 
   function createCrossFrame() {
-    return new CrossFrame(container, options);
+    const eventBus = {};
+    return new CrossFrame(container, eventBus, config);
   }
 
   it('detects frames on page', () => {
@@ -125,7 +122,7 @@ describe('CrossFrame multi-frame scenario', () => {
         assert(scriptElement, 'expected embed script to be injected');
         assert.equal(
           scriptElement.src,
-          options.config.clientUrl,
+          config.clientUrl,
           'unexpected embed script source'
         );
         resolve();


### PR DESCRIPTION
`CrossFrame` created an emitter and wrapped the `subscribe` and
`publish` methods into two functions that were passed as arguments to
the `AnnotationSync`'s constructor.

A simpler and more direct approach is to pass the event bus directly to
`AnnotationSync`.