### PR TITLE
Use ES2015 class methods

### DIFF
--- a/src/annotator/annotation-sync.js
+++ b/src/annotator/annotation-sync.js
@@ -23,7 +23,7 @@
  *
  * @implements Destroyable
  */
-export default class AnnotationSync {
+export class AnnotationSync {
   /**
    * @param {EventBus} eventBus - Event bus for communicating with the annotator code (eg. the Guest)
    * @param {Bridge} bridge - Channel for communicating with the sidebar

--- a/src/annotator/cross-frame.js
+++ b/src/annotator/cross-frame.js
@@ -1,4 +1,4 @@
-import AnnotationSync from './annotation-sync';
+import { AnnotationSync } from './annotation-sync';
 import Bridge from '../shared/bridge';
 import * as frameUtil from './util/frame-util';
 import FrameObserver from './frame-observer';

--- a/src/annotator/cross-frame.js
+++ b/src/annotator/cross-frame.js
@@ -105,12 +105,9 @@ export class CrossFrame {
    * Subscribe to an event from the sidebar.
    *
    * @param {string} method
-   * @param {(...args: any[]) => void} listener -- Final argument is an optional
-   *   callback of the type: `(error: string|Error|null, ...result: any[]) => void`.
-   *   This callback must be invoked in order to respond (via `postMessage`)
-   *   to the other frame/s with a result or an error.
-   * @throws {Error} If trying to register a callback after a channel has already been created
-   * @throws {Error} If trying to register a callback with the same name multiple times
+   * @param {(...args: any[]) => void} listener
+   *
+   * @see {Bridge.on} for details.
    */
   on(method, listener) {
     this._bridge.on(method, listener);
@@ -119,12 +116,10 @@ export class CrossFrame {
   /**
    * Call an RPC method exposed by the sidebar to the annotator.
    *
-   * @param {string} method
-   * @param {any[]} args - Arguments to method. Final argument is an optional
-   *   callback with this type: `(error: string|Error|null, ...result: any[]) => void`.
-   *   This callback, if any, will be triggered once a response (via `postMessage`)
-   *   comes back from the other frame/s. If the first argument (error) is `null`
-   *   it means successful execution of the whole remote procedure call.
+   * @param {string} method - Name of remote method to call.
+   * @param {any[]} args
+   *
+   * @see {Bridge.call} for details.
    */
   call(method, ...args) {
     this._bridge.call(method, ...args);

--- a/src/annotator/cross-frame.js
+++ b/src/annotator/cross-frame.js
@@ -28,9 +28,9 @@ export class CrossFrame {
    * @param {Record<string, any>} config
    */
   constructor(element, eventBus, config) {
-    this.bridge = new Bridge();
-    this.annotationSync = new AnnotationSync(eventBus, this.bridge);
-    this.frameObserver = new FrameObserver(element);
+    this._bridge = new Bridge();
+    this._annotationSync = new AnnotationSync(eventBus, this._bridge);
+    this._frameObserver = new FrameObserver(element);
     const frameIdentifiers = new Map();
 
     /**
@@ -56,11 +56,11 @@ export class CrossFrame {
     };
 
     const iframeUnloaded = frame => {
-      this.bridge.call('destroyFrame', frameIdentifiers.get(frame));
+      this._bridge.call('destroyFrame', frameIdentifiers.get(frame));
       frameIdentifiers.delete(frame);
     };
 
-    this.frameObserver.observe(injectIntoFrame, iframeUnloaded);
+    this._frameObserver.observe(injectIntoFrame, iframeUnloaded);
   }
 
   /**
@@ -80,16 +80,16 @@ export class CrossFrame {
       origin,
       [channel.port2]
     );
-    this.bridge.createChannel(channel.port1);
+    this._bridge.createChannel(channel.port1);
   }
 
   /**
    * Remove the connection between the sidebar and annotator.
    */
   destroy() {
-    this.bridge.destroy();
-    this.annotationSync.destroy();
-    this.frameObserver.disconnect();
+    this._bridge.destroy();
+    this._annotationSync.destroy();
+    this._frameObserver.disconnect();
   }
 
   /**
@@ -98,7 +98,7 @@ export class CrossFrame {
    * @param {AnnotationData[]} annotations
    */
   sync(annotations) {
-    this.annotationSync.sync(annotations);
+    this._annotationSync.sync(annotations);
   }
 
   /**
@@ -113,7 +113,7 @@ export class CrossFrame {
    * @throws {Error} If trying to register a callback with the same name multiple times
    */
   on(method, listener) {
-    this.bridge.on(method, listener);
+    this._bridge.on(method, listener);
   }
 
   /**
@@ -127,7 +127,7 @@ export class CrossFrame {
    *   it means successful execution of the whole remote procedure call.
    */
   call(method, ...args) {
-    this.bridge.call(method, ...args);
+    this._bridge.call(method, ...args);
   }
 
   /**
@@ -137,6 +137,6 @@ export class CrossFrame {
    * @param {(channel: RPC) => void} callback
    */
   onConnect(callback) {
-    this.bridge.onConnect(callback);
+    this._bridge.onConnect(callback);
   }
 }

--- a/src/annotator/test/annotation-sync-test.js
+++ b/src/annotator/test/annotation-sync-test.js
@@ -1,6 +1,6 @@
 import { EventBus } from '../util/emitter';
 
-import AnnotationSync from '../annotation-sync';
+import { AnnotationSync } from '../annotation-sync';
 
 describe('AnnotationSync', () => {
   let createAnnotationSync;

--- a/src/annotator/test/cross-frame-test.js
+++ b/src/annotator/test/cross-frame-test.js
@@ -29,7 +29,7 @@ describe('CrossFrame', () => {
     proxyBridge = sinon.stub().returns(fakeBridge);
 
     $imports.$mock({
-      './annotation-sync': proxyAnnotationSync,
+      './annotation-sync': { AnnotationSync: proxyAnnotationSync },
       '../shared/bridge': proxyBridge,
     });
   });

--- a/src/annotator/test/cross-frame-test.js
+++ b/src/annotator/test/cross-frame-test.js
@@ -5,8 +5,8 @@ describe('CrossFrame', () => {
   let fakeBridge;
   let fakeEventBus;
 
-  let proxyAnnotationSync;
-  let proxyBridge;
+  let FakeAnnotationSync;
+  let FakeBridge;
 
   const createCrossFrame = (options = {}) => {
     fakeEventBus = {};
@@ -25,12 +25,12 @@ describe('CrossFrame', () => {
 
     fakeAnnotationSync = { sync: sinon.stub(), destroy: sinon.stub() };
 
-    proxyAnnotationSync = sinon.stub().returns(fakeAnnotationSync);
-    proxyBridge = sinon.stub().returns(fakeBridge);
+    FakeAnnotationSync = sinon.stub().returns(fakeAnnotationSync);
+    FakeBridge = sinon.stub().returns(fakeBridge);
 
     $imports.$mock({
-      './annotation-sync': { AnnotationSync: proxyAnnotationSync },
-      '../shared/bridge': proxyBridge,
+      './annotation-sync': { AnnotationSync: FakeAnnotationSync },
+      '../shared/bridge': FakeBridge,
     });
   });
 
@@ -41,12 +41,12 @@ describe('CrossFrame', () => {
   describe('CrossFrame constructor', () => {
     it('instantiates the AnnotationSync component', () => {
       createCrossFrame();
-      assert.called(proxyAnnotationSync);
+      assert.called(FakeAnnotationSync);
     });
 
     it('passes along options to AnnotationSync', () => {
       createCrossFrame();
-      assert.calledWith(proxyAnnotationSync, fakeEventBus, fakeBridge);
+      assert.calledWith(FakeAnnotationSync, fakeEventBus, fakeBridge);
     });
   });
 

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -29,7 +29,7 @@ describe('CrossFrame multi-frame scenario', () => {
     proxyBridge = sandbox.stub().returns(fakeBridge);
 
     $imports.$mock({
-      './annotation-sync': proxyAnnotationSync,
+      './annotation-sync': { AnnotationSync: proxyAnnotationSync },
       '../shared/bridge': proxyBridge,
     });
 


### PR DESCRIPTION
The documentation for the `on` and `call` is referred to the `Bridge#call|on`.

Changed default export for named export.