### PR TITLE
Disable template caching in dev server

### DIFF
--- a/dev-server/serve-dev.js
+++ b/dev-server/serve-dev.js
@@ -71,6 +71,11 @@ function serveDev(port, config) {
   const app = express();
 
   app.engine('mustache', mustacheExpress());
+
+  // Disable template caching.
+  // See https://github.com/bryanburgers/node-mustache-express/issues/13.
+  app.disable('view cache');
+
   app.set('view engine', 'mustache');
   app.set('views', [HTML_PATH, path.join(__dirname, '/templates')]);
 


### PR DESCRIPTION
mustache-express caches templates by default unless Express's `view cache` option is explicitly set to `false`, as opposed to merely being unset. This is not mentioned in the documentation :(

I debated whether to replace the mustache-express dependency with a
custom integration. mustache-express does provide support for partials
though which might be useful in future. For future reference, rendering
templates without this dependency would look like:

```js
app.engine('mustache', async (filePath, options, callback) => {
  try {
    const template = await fsPromises.readFile(filePath, {
      encoding: 'utf8',
    });
    const rendered = Mustache.render(template, options);
    callback(null, rendered);
  } catch (err) {
    callback(err);
  }
});
```