### PR TITLE
Add tall iframe manual test that mimics VitalSource reader

### DIFF
--- a/dev-server/documents/html/tall-iframe.mustache
+++ b/dev-server/documents/html/tall-iframe.mustache
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tall iframe test</title>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+      iframe {
+        width: 80%;
+        margin-left: auto;
+        margin-right: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Tall iframe test</h1>
+
+    <p>
+      The iframe below has an <code>enable-annotation</code> attribute so
+      that Hypothesis is injected into it by the parent frame.
+    </p>
+    <p>
+      This iframe resizes itself to fit the content, as opposed to being
+      scrollable. This mimics the way book content is presented in the
+      VitalSource Bookshelf reader. See <a href="https://github.com/hypothesis/client/issues/3590">
+      this GitHub issue</a>.
+    </p>
+
+    <iframe src="/document/injectable-frame" enable-annotation></iframe>
+
+    {{{hypothesisScript}}}
+
+    <script>
+      const frame = document.querySelector('iframe');
+
+      // Resize iframe to fit document content when it has loaded.
+      frame.contentWindow.addEventListener('DOMContentLoaded', () => {
+        frame.height = frame.contentDocument.documentElement.scrollHeight + 'px';
+      });
+    </script>
+  </body>
+</html>

--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -30,6 +30,7 @@
       <li><a href="/document/shadow-dom">Content in shadow DOM</a></li>
       <li><a href="/document/host-in-shadow-root">Hypothesis loaded into frame in shadow root</a></li>
       <li><a href="/document/parent-frame">Annotation-enabled iframe</a></li>
+      <li><a href="/document/tall-iframe">Tall iframe</a></li>
       <li><a href="/document/sidebar-external-container">Sidebar in external container</a></li>
       <li><a href="/document/multi-frames">Page containing multiple iframes with Hypothesis loaded</a></li>
       <li><a href="/document/ignore-other-configuration"><code>ignoreOtherConfiguration</code>


### PR DESCRIPTION
Add a test case for tall iframes where the height of the frame is set to match the document height. This mimics how the new VitalSource Bookshelf reader presents book content. See https://github.com/hypothesis/client/issues/3590#issuecomment-886229080.