### PR TITLE
Replace query-string with `URLSearchParams` in embed iframe generation

### DIFF
--- a/src/sidebar/media-embedder.js
+++ b/src/sidebar/media-embedder.js
@@ -90,7 +90,8 @@ function parseTimeString(timeValue) {
  * all parameter possibilities.
  *
  * @param {HTMLAnchorElement} link
- * @returns {string} formatted filtered URL query string, e.g. '?start=90'
+ * @returns {string} formatted filtered URL query string, e.g. '?start=90' or
+ *   an empty string if the filtered query is empty.
  * @example
  * // returns '?end=10&start=5'
  * youTubeQueryParams(link); // where `link.search` = '?t=5&baz=foo&end=10'

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
-    "lib": ["es2018", "dom"],
+    "lib": ["es2018", "dom", "dom.iterable"],
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "module": "commonjs",


### PR DESCRIPTION
Per the request in https://github.com/hypothesis/client/pull/3589#pullrequestreview-710534189, this PR extracts a subset of the changes from https://github.com/hypothesis/client/pull/3589 for easier review.

It replaces the use of the query-string dependency with URLSearchParams in `sidebar/media-embedder.js`.