### PR TITLE
Replace query-string with URLSearchParams in util/oauth-client.js

### DIFF
--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -206,6 +206,8 @@ export default class OAuthClient {
     for (let [key, value] of Object.entries(data)) {
       params.set(key, value);
     }
+
+    // Tests currently expect sorted parameters.
     params.sort();
 
     const headers = {

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -187,7 +187,9 @@ export default class OAuthClient {
     authURL.searchParams.set('response_type', 'code');
     authURL.searchParams.set('state', state);
 
-    // @ts-ignore - TS doesn't know about `location = <string>`.
+    // @ts-ignore - TS doesn't support `location = <string>`. We have to
+    // use this method to set the URL rather than `location.href = <string>`
+    // because `authWindow` is cross-origin.
     authWindow.location = authURL.toString();
 
     return authResponse.then(rsp => rsp.code);

--- a/src/sidebar/util/test/oauth-client-test.js
+++ b/src/sidebar/util/test/oauth-client-test.js
@@ -1,5 +1,4 @@
 import fetchMock from 'fetch-mock';
-import { stringify } from 'query-string';
 import sinon from 'sinon';
 
 import OAuthClient from '../oauth-client';
@@ -192,7 +191,7 @@ describe('sidebar/util/oauth-client', () => {
         fakeWindow.open,
         'about:blank',
         'Log in to Hypothesis',
-        'height=430,left=274.5,top=169,width=475'
+        'left=274.5,top=169,width=475,height=430'
       );
     });
 
@@ -229,16 +228,14 @@ describe('sidebar/util/oauth-client', () => {
       });
 
       return authorized.then(() => {
-        const params = {
+        const params = new URLSearchParams({
           client_id: config.clientId,
           origin: 'https://client.hypothes.is',
           response_mode: 'web_message',
           response_type: 'code',
           state: 'notrandom',
-        };
-        const expectedAuthUrl = `${config.authorizationEndpoint}?${stringify(
-          params
-        )}`;
+        });
+        const expectedAuthUrl = `${config.authorizationEndpoint}?${params}`;
         assert.equal(popupWindow.location.href, expectedAuthUrl);
       });
     });


### PR DESCRIPTION
Per the request in https://github.com/hypothesis/client/pull/3589#pullrequestreview-710534189, this PR extracts a subset of the changes from https://github.com/hypothesis/client/pull/3589 for easier review.

It replaces the use of the query-string dependency with URLSearchParams in `sidebar/util/oauth-client.js`.