### PR TITLE
Replace query-string with URLSearchParams in APIService

### DIFF
--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -1,5 +1,3 @@
-import * as queryString from 'query-string';
-
 import { replaceURLParams } from '../util/url';
 
 /**
@@ -52,9 +50,15 @@ function stripInternalProperties(obj) {
  */
 
 /**
+ * Types of value that can be passed as a parameter to API calls.
+ *
+ * @typedef {string|number|boolean} Param
+ */
+
+/**
  * Function which makes an API request.
  *
- * @template {Record<string, any>} Params
+ * @template {Record<string, Param|Param[]>} Params
  * @template {object} Body
  * @template Result
  * @callback APICall
@@ -123,10 +127,17 @@ function createAPICall(
           descriptor.url,
           params
         );
-        const apiUrl = new URL(url);
-        apiUrl.search = queryString.stringify(queryParams);
 
-        return fetch(apiUrl.toString(), {
+        const apiURL = new URL(url);
+        for (let [key, value] of Object.entries(queryParams)) {
+          if (Array.isArray(value)) {
+            value.forEach(v => apiURL.searchParams.append(key, v.toString()));
+          } else {
+            apiURL.searchParams.append(key, value.toString());
+          }
+        }
+
+        return fetch(apiURL.toString(), {
           body: data ? JSON.stringify(stripInternalProperties(data)) : null,
           headers,
           method: descriptor.method,


### PR DESCRIPTION
Per the request in https://github.com/hypothesis/client/pull/3589#pullrequestreview-710534189, this PR extracts a subset of the changes from https://github.com/hypothesis/client/pull/3589 for easier review.

It replaces the use of the query-string dependency with URLSearchParams in `sidebar/services/api.js`. There are no functional changes here. The new code is a little longer because we have to explicitly handle API parameter values which are arrays now. There is an existing test for this.