### PR TITLE
Remove query-string dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "preact": "^10.4.0",
     "prettier": "2.3.2",
     "puppeteer": "^10.0.0",
-    "query-string": "^3.0.1",
     "redux": "^4.0.1",
     "redux-thunk": "^2.1.0",
     "reselect": "^4.0.0",

--- a/scripts/gulp/create-bundle.js
+++ b/scripts/gulp/create-bundle.js
@@ -64,7 +64,7 @@ module.exports = function createBundle(config, buildOpts) {
     //
     // See node_modules/browserify/lib/builtins.js to find out which
     // modules provide the implementations of these.
-    builtins: ['console', '_process', 'querystring'],
+    builtins: ['console', '_process'],
     externalRequireName,
 
     // Map of global variable names to functions returning _source code_ for

--- a/src/sidebar/config/host-config.js
+++ b/src/sidebar/config/host-config.js
@@ -1,4 +1,3 @@
-import * as queryString from 'query-string';
 import {
   toBoolean,
   toInteger,
@@ -16,7 +15,7 @@ import {
  */
 export default function hostPageConfig(window) {
   const configStr = window.location.hash.slice(1);
-  const configJSON = queryString.parse(configStr).config;
+  const configJSON = new URLSearchParams(configStr).get('config');
   const config = JSON.parse(configJSON || '{}');
 
   // Known configuration parameters which we will import from the host page.

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -1,5 +1,3 @@
-import * as queryString from 'query-string';
-
 /**
  * @typedef {'annotation'|'notebook'|'stream'|'sidebar'} RouteName
  * @typedef {Record<string,string>} RouteParams
@@ -29,7 +27,13 @@ export class RouterService {
   currentRoute() {
     const path = this._window.location.pathname;
     const pathSegments = path.slice(1).split('/');
-    const params = queryString.parse(this._window.location.search);
+    const searchParams = new URLSearchParams(this._window.location.search);
+
+    /** @type {Record<string, string>} */
+    const params = {};
+    for (let [key, value] of searchParams) {
+      params[key] = value;
+    }
 
     // The extension puts client resources under `/client/` to separate them
     // from extension-specific resources. Ignore this part.
@@ -94,9 +98,15 @@ export class RouterService {
         throw new Error(`Cannot generate URL for route "${name}"`);
     }
 
-    const query = queryString.stringify(queryParams);
-    if (query.length > 0) {
-      url += '?' + query;
+    let hasParams = false;
+    const searchParams = new URLSearchParams();
+    for (let [key, value] of Object.entries(queryParams)) {
+      hasParams = true;
+      searchParams.set(key, value);
+    }
+
+    if (hasParams) {
+      url += '?' + searchParams.toString();
     }
 
     return url;

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -1,5 +1,3 @@
-import * as queryString from 'query-string';
-
 import warnOnce from '../../shared/warn-once';
 import { generateHexString } from '../util/random';
 import { Socket } from '../websocket';
@@ -190,9 +188,7 @@ export class StreamerService {
       // not support setting the `Authorization` header directly as we do for
       // other API requests.
       const parsedURL = new URL(this._websocketURL);
-      const queryParams = queryString.parse(parsedURL.search);
-      queryParams.access_token = token;
-      parsedURL.search = queryString.stringify(queryParams);
+      parsedURL.searchParams.set('access_token', token);
       url = parsedURL.toString();
     } else {
       url = this._websocketURL;

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -211,7 +211,7 @@ describe('StreamerService', () => {
       return activeStreamer.connect().then(() => {
         assert.equal(
           fakeWebSocket.url,
-          'ws://example.com/ws?access_token=dummy-access-token&foo=bar'
+          'ws://example.com/ws?foo=bar&access_token=dummy-access-token'
         );
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6552,13 +6552,6 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-query-string@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-3.0.3.tgz#ae2e14b4d05071d4e9b9eb4873c35b0dcd42e638"
-  integrity sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=
-  dependencies:
-    strict-uri-encode "^1.0.0"
-
 querystring-es3@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -7407,11 +7400,6 @@ streamroller@^2.2.4:
     date-format "^2.1.0"
     debug "^4.1.1"
     fs-extra "^8.1.0"
-
-strict-uri-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-  integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This is the last in a series of PRs (https://github.com/hypothesis/client/pull/3621, https://github.com/hypothesis/client/pull/3622, https://github.com/hypothesis/client/pull/3623) that replaces the query-string dependency with the URLSearchParams browser API. This depends on the previous PRs in the series.

The first commit removes the remaining few uses of this dependency. The second commit removes the dependency itself and also disallows the use of the same-API-different-implementation `querystring` package that Browserify provides.