### PR TITLE
Suppress additional Sentry errors

### DIFF
--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -51,8 +51,28 @@ export function init(config) {
   Sentry.init({
     dsn: config.dsn,
     environment: config.environment,
-    // Do not log Fetch failures to avoid inundating with unhandled fetch exceptions
-    ignoreErrors: ['Fetch operation failed'],
+
+    // Ignore various errors due to circumstances outside of our control.
+    ignoreErrors: [
+      // Ignore transient network request failures. Some of these ought to be
+      // caught and handled better but for now we are suppressing them to
+      // improve the signal-to-noise ratio.
+      'Failed to fetch', // Chrome
+      'Fetch operation failed',
+      'NetworkError when attempting to fetch resource', // Firefox
+
+      // Ignore network request failures due to empty JSON bodies.
+      'JSON.parse: unexpected end of data', // Firefox
+      'Unexpected end of JSON input', // Opera Mobile
+
+      // Ignore network request cancellations
+      'AbortError: The operation was aborted.', // Firefox
+
+      // Ignore an error that appears to come from CefSharp (embedded Chromium).
+      // See https://forum.sentry.io/t/unhandledrejection-non-error-promise-rejection-captured-with-value/14062/20
+      'Object Not Found Matching Id',
+    ],
+
     release: '__VERSION__', // replaced by versionify
     whitelistUrls,
 

--- a/src/sidebar/util/test/sentry-test.js
+++ b/src/sidebar/util/test/sentry-test.js
@@ -83,7 +83,7 @@ describe('sidebar/util/sentry', () => {
       assert.calledWith(
         fakeSentry.init,
         sinon.match({
-          ignoreErrors: ['Fetch operation failed'],
+          ignoreErrors: sinon.match.array,
         })
       );
     });


### PR DESCRIPTION
The recent changes to inter-frame communication have fixed a lot of the noise in Sentry that used to occur due to multiple frames on a page loading Hypothesis, triggering Discovery errors. This PR further reduces noise for the [client project](https://sentry.io/organizations/hypothesis/issues/?project=69811&query=is%3Aunresolved&statsPeriod=14d) in Sentry that can occur due to factors outside of our control.

Suppress various errors that can occur due to transient network issues
or unusual or old browsers. This helps improve the signal-to-noise ratio
of reports in Sentry. The error strings are taken from a read through the
current open reports in Sentry.

Some of the transient network errors could be caught and handled more gracefully.
However for the moment suppressing them will allow us to focus on more
important crashes.