### PR TITLE
Refactor long promise chain to async/await in API client

### DIFF
--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -62,6 +62,8 @@ export function init(config) {
       'NetworkError when attempting to fetch resource', // Firefox
 
       // Ignore network request failures due to empty JSON bodies.
+      // TODO - Consider removing these once `fetch` callers have been changed
+      // to handle `Response.json()` calls failing.
       'JSON.parse: unexpected end of data', // Firefox
       'Unexpected end of JSON input', // Opera Mobile
 


### PR DESCRIPTION
This PR is some refactoring in preparation for improving the handling of a situation where API calls return 200 responses but the response body is empty, causing `Response.json()` to fail. I haven't confirmed with absolute certainty that this is the cause, but it looks like the most likely explanation for [some Sentry issues](https://sentry.io/organizations/hypothesis/issues/1274716662/events/72e201e05ffb4bc58d10d84dddc1047f/activity/?project=69811&query=is%3Aunresolved).

This PR refactors a lengthy promise chain in the function that executes API calls to use async/await, to make it easier to follow the control flow. There should be no functional changes.

Related issue: https://github.com/hypothesis/client/issues/3631