### PR TITLE
Change serialization of nullish query parameters in API calls

### DIFF
--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -128,12 +128,15 @@ function createAPICall(
           params
         );
 
+        /** @param {Param?} param */
+        const serialize = param => param?.toString() ?? '';
+
         const apiURL = new URL(url);
         for (let [key, value] of Object.entries(queryParams)) {
           if (Array.isArray(value)) {
-            value.forEach(v => apiURL.searchParams.append(key, v.toString()));
+            value.forEach(v => apiURL.searchParams.append(key, serialize(v)));
           } else {
-            apiURL.searchParams.append(key, value.toString());
+            apiURL.searchParams.append(key, serialize(value));
           }
         }
 

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -173,6 +173,14 @@ describe('APIService', () => {
     return api.search({ uri: [pdfURL, fingerprintURL] });
   });
 
+  // Test serialization of nullish parameters in API calls. This behavior matches
+  // the query-string package that we used to use.
+  it('sends empty query parameters if value is nullish', () => {
+    expectCall('get', 'search?a=&b=&c=false&d=');
+
+    return api.search({ a: undefined, b: null, c: false, d: [null] });
+  });
+
   it("fetches the user's profile", () => {
     const profile = { userid: 'acct:user@publisher.org' };
     expectCall('get', 'profile?authority=publisher.org', 200, profile);


### PR DESCRIPTION
The Notebook view failed to show results after merging https://github.com/hypothesis/client/pull/3623 because the parameters passed to the API search call included `{ uri: undefined }` and the logic for serializing parameters failed to handle this, so the search API call was not made.

The previous behavior was to generate _empty_ query string parameters if the value was nullish (ie. `undefined` or `null`, but not `false`).

This commit makes the handling of nullish values in API method calls match the previous behavior and adds a test.