### PR TITLE
Add missing types

### DIFF
--- a/src/annotator/util/frame-util.js
+++ b/src/annotator/util/frame-util.js
@@ -15,29 +15,45 @@ export function findFrames(container) {
   return Array.from(container.querySelectorAll('iframe[enable-annotation]'));
 }
 
-// Check if the iframe has already been injected
+/**
+ * Check if the iframe has already been injected
+ *
+ * @param {HTMLIFrameElement} iframe
+ */
 export function hasHypothesis(iframe) {
-  return '__hypothesis' in iframe.contentWindow;
+  const iframeWindow = /** @type {Window} */ (iframe.contentWindow);
+  return '__hypothesis' in iframeWindow;
 }
 
-// Inject embed.js into the iframe
-export function injectHypothesis(iframe, scriptUrl, config) {
+/**
+ * Inject the client's boot script into the iframe. The iframe must be from the
+ * same origin as the current window.
+ *
+ * @param {HTMLIFrameElement} iframe
+ * @param {string} scriptSrc
+ * @param {Record<string, any>} config
+ */
+export function injectHypothesis(iframe, scriptSrc, config) {
   const configElement = document.createElement('script');
   configElement.className = 'js-hypothesis-config';
   configElement.type = 'application/json';
   configElement.innerText = JSON.stringify(config);
 
-  const src = scriptUrl;
   const embedElement = document.createElement('script');
   embedElement.className = 'js-hypothesis-embed';
   embedElement.async = true;
-  embedElement.src = src;
+  embedElement.src = scriptSrc;
 
-  iframe.contentDocument.body.appendChild(configElement);
-  iframe.contentDocument.body.appendChild(embedElement);
+  const iframeDocument = /** @type {Document} */ (iframe.contentDocument);
+  iframeDocument.body.appendChild(configElement);
+  iframeDocument.body.appendChild(embedElement);
 }
 
-// Check if we can access this iframe's document
+/**
+ * Check if we can access this iframe's document
+ *
+ * @param {HTMLIFrameElement} iframe
+ */
 export function isAccessible(iframe) {
   try {
     return !!iframe.contentDocument;
@@ -46,9 +62,14 @@ export function isAccessible(iframe) {
   }
 }
 
+/**
+ * @param {HTMLIFrameElement} iframe
+ * @param {() => void} callback
+ */
 export function isDocumentReady(iframe, callback) {
-  if (iframe.contentDocument.readyState === 'loading') {
-    iframe.contentDocument.addEventListener('DOMContentLoaded', () => {
+  const iframeDocument = /** @type {Document} */ (iframe.contentDocument);
+  if (iframeDocument.readyState === 'loading') {
+    iframeDocument.addEventListener('DOMContentLoaded', () => {
       callback();
     });
   } else {
@@ -56,8 +77,13 @@ export function isDocumentReady(iframe, callback) {
   }
 }
 
+/**
+ * @param {HTMLIFrameElement} iframe
+ * @param {() => void} callback
+ */
 export function isLoaded(iframe, callback) {
-  if (iframe.contentDocument.readyState !== 'complete') {
+  const iframeDocument = /** @type {Document} */ (iframe.contentDocument);
+  if (iframeDocument.readyState !== 'complete') {
     iframe.addEventListener('load', () => {
       callback();
     });


### PR DESCRIPTION
No functional change.

The added type has surfaced that `iframe.contentDocument` could be
`null`. This was no considered before. I didn't deviated from the
original behaviour and I casted the value. If in the future we found
issues we should see those in the Sentry reports.