### PR TITLE
Use new-style confirm prompt in all browsers

### DIFF
--- a/src/shared/prompts.js
+++ b/src/shared/prompts.js
@@ -23,16 +23,6 @@ export async function confirm({
   message,
   confirmAction = 'Yes',
 }) {
-  const start = Date.now();
-
-  // Use the legacy `window.confirm` API where available until we've polished
-  // the new one. In Chrome >= 91 `window.confirm` will immediately return false
-  // so we have no option but to use the new implementation.
-  const result = window.confirm(message);
-  if (result || Date.now() - start >= 10) {
-    return result;
-  }
-
   const container = document.createElement('div');
   container.setAttribute('data-testid', 'confirm-container');
 

--- a/src/shared/test/prompts-test.js
+++ b/src/shared/test/prompts-test.js
@@ -37,13 +37,7 @@ describe('shared/prompts', () => {
       return document.querySelector('[data-testid="confirm-container"]');
     }
 
-    it('uses `window.confirm` if available', async () => {
-      window.confirm.returns(true);
-      const result = await confirm({ message: 'Do the thing?' });
-      assert.equal(result, true);
-    });
-
-    it('renders a custom dialog if `window.confirm` is not available', async () => {
+    it('renders a custom dialog', async () => {
       const result = confirm({
         title: 'Confirm action?',
         message: 'Do the thing?',


### PR DESCRIPTION
_Some recent discussion amongst the Twitterati reminded me that we never completed the work to transition `window.confirm` to a custom dialog. This PR finishes this off._
 
We previously implemented a custom confirm dialog for use in browsers
which disallow use of `window.confirm` in cross-origin iframes (Chrome 9x) but
kept `window.confirm` in other browsers while the design of the new
dialogs was polished.

The polishing has now been done, so this commit switches all confirm
prompts to use the new dialog. This makes the experience look better
and be consistent across browsers.

As a reminder, here is what the new dialogs look like:

<img width="505" alt="Delete annotation prompt" src="https://user-images.githubusercontent.com/2458/128321946-abf12bd7-2c58-45ea-8bfa-b506ecac70bc.png">

<img width="485" alt="Discard drafts prompt" src="https://user-images.githubusercontent.com/2458/128321963-80c79f40-0942-4701-b132-99b9cc6320fe.png">
