### PR TITLE
Add information about loaded scripts to error reports

### DIFF
--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -121,6 +121,17 @@ export function init(config) {
   // later when frames where the "annotator" code has loaded have connected to
   // the sidebar via `postMessage` RPC messages.
   Sentry.setExtra('document_url', document.referrer);
+
+  /** @param {HTMLScriptElement} script */
+  const isJavaScript = script =>
+    !script.type || script.type.match(/javascript|module/);
+
+  // Include information about the scripts on the page. This may help with
+  // debugging of errors caused by scripts injected by browser extensions.
+  const loadedScripts = Array.from(document.querySelectorAll('script'))
+    .filter(isJavaScript)
+    .map(script => script.src || '<inline>');
+  Sentry.setExtra('loaded_scripts', loadedScripts);
 }
 
 /**

--- a/src/sidebar/util/test/sentry-test.js
+++ b/src/sidebar/util/test/sentry-test.js
@@ -104,13 +104,24 @@ describe('sidebar/util/sentry', () => {
       );
     });
 
-    it('adds extra context to reports', () => {
+    it('adds "document_url" context to reports', () => {
       sentry.init({ dsn: 'test-dsn', environment: 'dev' });
       assert.calledWith(
         fakeSentry.setExtra,
         'document_url',
         'https://example.com'
       );
+    });
+
+    it('adds "loaded_scripts" context to reports', () => {
+      sentry.init({ dsn: 'test-dsn', environment: 'dev' });
+      assert.calledWith(fakeSentry.setExtra, 'loaded_scripts');
+
+      const urls = fakeSentry.setExtra
+        .getCalls()
+        .find(call => call.args[0] === 'loaded_scripts').args[1];
+      assert.isTrue(urls.length > 0);
+      urls.forEach(url => assert.match(url, /<inline>|http:.*\.js/));
     });
 
     function getBeforeSendHook() {


### PR DESCRIPTION
Add information to Sentry error reports about what JavaScript files were included on the page. The information will show up as the "loaded_scripts" key in the "Additional Data" section of Sentry reports.

I have a hypothesis that Sentry issues like [this one](https://sentry.io/organizations/hypothesis/issues/2528337318/events/e176f165836149b99d439fa71e69453c/?project=69811&query=is%3Aunresolved) might be caused by unwanted `<script>` tags injected by extension or the browser. We try to block most unexpected scripts using strict Content-Security-Policy settings, but extension and custom browser-injected scripts may be able to bypass this.

If this information turns out not to be useful I will just remove it.