### PR TITLE
Simplify code on `frame-rpc.js`

### DIFF
--- a/src/shared/frame-rpc.js
+++ b/src/shared/frame-rpc.js
@@ -175,12 +175,12 @@ export class RPC {
 
         this._port.postMessage(message);
       };
-      this._methods[msg.method].call(this._methods, ...msg.arguments, callback);
+      this._methods[msg.method](...msg.arguments, callback);
     } else if ('response' in msg) {
       const cb = this._callbacks[msg.response];
       delete this._callbacks[msg.response];
       if (cb) {
-        cb.apply(null, msg.arguments);
+        cb(...msg.arguments);
       }
     }
   }

--- a/src/shared/test/frame-rpc-test.js
+++ b/src/shared/test/frame-rpc-test.js
@@ -26,14 +26,9 @@ describe('RPC', () => {
       callback(result);
     };
 
-    rpc1 = new RPC(
-      /* dummy when using ports */ window,
-      port1,
-      /* dummy when using ports */ '*',
-      {
-        concat,
-      }
-    );
+    rpc1 = new RPC(port1, {
+      concat,
+    });
 
     // `plusOne` method for rpc2
     plusOne = sinon.stub().callsFake((...numbers) => {
@@ -42,14 +37,9 @@ describe('RPC', () => {
       callback(result);
     });
 
-    rpc2 = new RPC(
-      /* dummy when using ports */ window,
-      port2,
-      /* dummy when using ports */ '*',
-      {
-        plusOne,
-      }
-    );
+    rpc2 = new RPC(port2, {
+      plusOne,
+    });
   });
 
   afterEach(() => {


### PR DESCRIPTION
The `methods` constructor 's argument could be an object that uses `this`.
However, we do not rely in this feature, so I am suggesting to simplify
the execution of the callbacks.