### PR TITLE
Register a `connect` listener at class instantiation

### DIFF
--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -16,6 +16,10 @@ export class Bridge {
     this.channelListeners = {};
     /** @type {Array<(channel: PortRPC) => void>} */
     this.onConnectListeners = [];
+
+    // `connect` is registered with a callback so it triggers a `postMessage`
+    // response from the reciprocal port.
+    this.on('connect', cb => cb());
   }
 
   /**
@@ -38,10 +42,7 @@ export class Bridge {
    * @return {PortRPC} - Channel for communicating with the reciprocal port.
    */
   createChannel(port) {
-    const listeners = { connect: cb => cb(), ...this.channelListeners };
-
-    // Set up a channel
-    const channel = new PortRPC(port, listeners);
+    const channel = new PortRPC(port, this.channelListeners);
 
     let connected = false;
     const ready = () => {


### PR DESCRIPTION
Previously, if the user tried to register a listener called `connect`, it
could lead to problems and result in the channel not be connected.

With this change, we reserve the `connect` name for internal purposes,
and if a user tries to register the `connect` listener it would result
on an error been raised.