### PR TITLE
Replaced `container.parentNode.removeChild(...)`

### DIFF
--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -846,7 +846,7 @@ describe('Guest', () => {
     });
 
     afterEach(() => {
-      document.body.removeChild(el);
+      el.remove();
     });
 
     it("doesn't mark an annotation lacking targets as an orphan", () => {

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -72,7 +72,7 @@ describe('anchoring', () => {
 
   afterEach(() => {
     guest.destroy();
-    container.parentNode.removeChild(container);
+    container.remove();
     console.warn.restore();
   });
 

--- a/src/annotator/test/range-util-test.js
+++ b/src/annotator/test/range-util-test.js
@@ -35,7 +35,7 @@ describe('annotator.range-util', () => {
   });
 
   afterEach(() => {
-    testNode.parentElement.removeChild(testNode);
+    testNode.remove();
   });
 
   function selectNode(node) {


### PR DESCRIPTION
`container.parentNode.removeChild(...)` is an old pattern. The simpler `Element.remove` is currently supported by our
test environment.