### PR TITLE
Rename `frame-rpc.js` to `port-rpc.js`

### DIFF
--- a/src/annotator/cross-frame.js
+++ b/src/annotator/cross-frame.js
@@ -4,7 +4,7 @@ import * as frameUtil from './util/frame-util';
 import FrameObserver from './frame-observer';
 
 /**
- * @typedef {import('../shared/frame-rpc').RPC} RPC
+ * @typedef {import('../shared/port-rpc').PortRPC} RPC
  * @typedef {import('../types/annotator').AnnotationData} AnnotationData
  * @typedef {import('../types/annotator').Destroyable} Destroyable
  * @typedef {import('./util/emitter').EventBus} EventBus

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -1,4 +1,4 @@
-import { RPC } from './frame-rpc';
+import { PortRPC } from './port-rpc';
 
 /** @typedef {import('../types/annotator').Destroyable} Destroyable */
 
@@ -10,11 +10,11 @@ import { RPC } from './frame-rpc';
  */
 export default class Bridge {
   constructor() {
-    /** @type {RPC[]} */
+    /** @type {PortRPC[]} */
     this.links = [];
     /** @type {Record<string, (...args: any[]) => void>} */
     this.channelListeners = {};
-    /** @type {Array<(channel: RPC) => void>} */
+    /** @type {Array<(channel: PortRPC) => void>} */
     this.onConnectListeners = [];
   }
 
@@ -35,13 +35,13 @@ export default class Bridge {
    * and `on` send and receive messages over.
    *
    * @param {MessagePort} port
-   * @return {RPC} - Channel for communicating with the reciprocal port.
+   * @return {PortRPC} - Channel for communicating with the reciprocal port.
    */
   createChannel(port) {
     const listeners = { connect: cb => cb(), ...this.channelListeners };
 
     // Set up a channel
-    const channel = new RPC(port, listeners);
+    const channel = new PortRPC(port, listeners);
 
     let connected = false;
     const ready = () => {
@@ -84,7 +84,7 @@ export default class Bridge {
       args = args.slice(0, -1);
     }
 
-    /** @param {RPC} channel */
+    /** @param {PortRPC} channel */
     const _makeDestroyFn = channel => {
       return error => {
         channel.destroy();
@@ -155,7 +155,7 @@ export default class Bridge {
   /**
    * Add a listener to be called upon a new connection.
    *
-   * @param {(channel: RPC) => void} listener
+   * @param {(channel: PortRPC) => void} listener
    */
   onConnect(listener) {
     this.onConnectListeners.push(listener);

--- a/src/shared/port-rpc.js
+++ b/src/shared/port-rpc.js
@@ -61,7 +61,7 @@ const PROTOCOL = 'frame-rpc';
  *
  * @implements Destroyable
  */
-export class RPC {
+export class PortRPC {
   /**
    * Create an RPC client for sending and receiving RPC message using a
    * `MessagePort`.

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -1,6 +1,6 @@
 import { default as Bridge, $imports } from '../bridge';
 
-class FakeRPC {
+class FakePortRPC {
   constructor(port, methods) {
     this.port = port;
     this.methods = methods;
@@ -23,7 +23,7 @@ describe('shared/bridge', () => {
     };
 
     $imports.$mock({
-      './frame-rpc': { RPC: FakeRPC },
+      './port-rpc': { PortRPC: FakePortRPC },
     });
   });
 
@@ -58,7 +58,7 @@ describe('shared/bridge', () => {
 
     it('returns the newly created channel', () => {
       const channel = createChannel();
-      assert.instanceOf(channel, FakeRPC);
+      assert.instanceOf(channel, FakePortRPC);
     });
   });
 

--- a/src/shared/test/integration/rpc-bridge-test.js
+++ b/src/shared/test/integration/rpc-bridge-test.js
@@ -1,6 +1,6 @@
 import Bridge from '../../bridge';
 
-describe('RPC-Bridge integration', () => {
+describe('PortRPC-Bridge integration', () => {
   let clock;
   let port1;
   let port2;

--- a/src/shared/test/port-rpc-test.js
+++ b/src/shared/test/port-rpc-test.js
@@ -1,4 +1,4 @@
-import { RPC } from '../frame-rpc';
+import { PortRPC } from '../port-rpc';
 
 describe('RPC', () => {
   let port1;
@@ -26,7 +26,7 @@ describe('RPC', () => {
       callback(result);
     };
 
-    rpc1 = new RPC(port1, {
+    rpc1 = new PortRPC(port1, {
       concat,
     });
 
@@ -37,7 +37,7 @@ describe('RPC', () => {
       callback(result);
     });
 
-    rpc2 = new RPC(port2, {
+    rpc2 = new PortRPC(port2, {
       plusOne,
     });
   });


### PR DESCRIPTION
In addition, the class it is now called `PortRPC` to follow our
conventions.