### PR TITLE
Change default export to named export for `Bridge`

### DIFF
--- a/src/annotator/annotation-sync.js
+++ b/src/annotator/annotation-sync.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../shared/bridge').default} Bridge
+ * @typedef {import('../shared/bridge').Bridge} Bridge
  * @typedef {import('../types/annotator').AnnotationData} AnnotationData
  * @typedef {import('../types/annotator').Destroyable} Destroyable
  * @typedef {import('./util/emitter').EventBus} EventBus

--- a/src/annotator/cross-frame.js
+++ b/src/annotator/cross-frame.js
@@ -1,5 +1,5 @@
 import { AnnotationSync } from './annotation-sync';
-import Bridge from '../shared/bridge';
+import { Bridge } from '../shared/bridge';
 import * as frameUtil from './util/frame-util';
 import FrameObserver from './frame-observer';
 

--- a/src/annotator/test/cross-frame-test.js
+++ b/src/annotator/test/cross-frame-test.js
@@ -30,7 +30,7 @@ describe('CrossFrame', () => {
 
     $imports.$mock({
       './annotation-sync': { AnnotationSync: FakeAnnotationSync },
-      '../shared/bridge': FakeBridge,
+      '../shared/bridge': { Bridge: FakeBridge },
     });
   });
 

--- a/src/annotator/test/integration/multi-frame-test.js
+++ b/src/annotator/test/integration/multi-frame-test.js
@@ -30,7 +30,7 @@ describe('CrossFrame multi-frame scenario', () => {
 
     $imports.$mock({
       './annotation-sync': { AnnotationSync: proxyAnnotationSync },
-      '../shared/bridge': proxyBridge,
+      '../shared/bridge': { Bridge: proxyBridge },
     });
 
     container = document.createElement('div');

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -8,7 +8,7 @@ import { RPC } from './frame-rpc';
  *
  * @implements Destroyable
  */
-export default class Bridge {
+export class Bridge {
   constructor() {
     /** @type {RPC[]} */
     this.links = [];

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -1,4 +1,4 @@
-import { default as Bridge, $imports } from '../bridge';
+import { Bridge, $imports } from '../bridge';
 
 class FakeRPC {
   constructor(port, methods) {

--- a/src/shared/test/integration/rpc-bridge-test.js
+++ b/src/shared/test/integration/rpc-bridge-test.js
@@ -1,4 +1,4 @@
-import Bridge from '../../bridge';
+import { Bridge } from '../../bridge';
 
 describe('RPC-Bridge integration', () => {
   let clock;

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -23,7 +23,7 @@ import TopBar from './TopBar';
 /**
  * @typedef {import('../../types/api').Profile} Profile
  * @typedef {import('../../types/config').MergedConfig} MergedConfig
- * @typedef {import('../../shared/bridge').default} Bridge
+ * @typedef {import('../../shared/bridge').Bridge} Bridge
  * @typedef {import('./UserMenu').AuthState} AuthState
  */
 

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -16,7 +16,7 @@ import UserMenu from './UserMenu';
 /**
  * @typedef {import('../../types/config').MergedConfig} MergedConfig
  * @typedef {import('../components/UserMenu').AuthState} AuthState
- * @typedef {import('../../shared/bridge').default} Bridge
+ * @typedef {import('../../shared/bridge').Bridge} Bridge
  */
 
 /**

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -108,7 +108,7 @@ import LaunchErrorPanel from './components/LaunchErrorPanel';
 import { ServiceContext } from './service-context';
 
 // Services.
-import bridgeService from '../shared/bridge';
+import { Bridge } from '../shared/bridge';
 
 import { AnnotationsService } from './services/annotations';
 import { APIService } from './services/api';
@@ -152,7 +152,7 @@ function startApp(config, appEl) {
     .register('apiRoutes', APIRoutesService)
     .register('auth', AuthService)
     .register('autosaveService', AutosaveService)
-    .register('bridge', bridgeService)
+    .register('bridge', Bridge)
     .register('features', FeaturesService)
     .register('frameSync', FrameSyncService)
     .register('groups', GroupsService)

--- a/src/sidebar/services/features.js
+++ b/src/sidebar/services/features.js
@@ -15,7 +15,7 @@ import { watch } from '../util/watch';
  */
 export class FeaturesService {
   /**
-   * @param {import('../../shared/bridge').default} bridge
+   * @param {import('../../shared/bridge').Bridge} bridge
    * @param {import('../store').SidebarStore} store
    */
   constructor(bridge, store) {

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -47,7 +47,7 @@ export class FrameSyncService {
   /**
    * @param {Window} $window - Test seam
    * @param {import('./annotations').AnnotationsService} annotationsService
-   * @param {import('../../shared/bridge').default} bridge
+   * @param {import('../../shared/bridge').Bridge} bridge
    * @param {import('../store').SidebarStore} store
    */
   constructor($window, annotationsService, bridge, store) {


### PR DESCRIPTION
Following our conventions only Preact components should have default
exports.