### PR TITLE
Handle annotation URI parsing errors

### DIFF
--- a/src/sidebar/helpers/annotation-metadata.js
+++ b/src/sidebar/helpers/annotation-metadata.js
@@ -6,23 +6,32 @@
 /** @typedef {import('../../types/api').TextPositionSelector} TextPositionSelector */
 /** @typedef {import('../../types/api').TextQuoteSelector} TextQuoteSelector */
 
-/** Extract a URI, domain and title from the given domain model object.
+/**
+ * Extract document metadata from an annotation.
  *
  * @param {Annotation} annotation
- *
  */
 export function documentMetadata(annotation) {
   const uri = annotation.uri;
 
-  let domain = new URL(uri).hostname;
-  let title = domain;
-
-  if (annotation.document && annotation.document.title) {
-    title = annotation.document.title[0];
+  let domain;
+  try {
+    domain = new URL(uri).hostname;
+  } catch {
+    // Annotation URI parsing on the backend is very liberal compared to the URL
+    // constructor. There is also some historic invalid data in h (eg [1]).
+    // Hence we must handle URL parsing failures in the client.
+    //
+    // [1] https://github.com/hypothesis/client/issues/3666
+    domain = '';
   }
-
   if (domain === 'localhost') {
     domain = '';
+  }
+
+  let title = domain;
+  if (annotation.document && annotation.document.title) {
+    title = annotation.document.title[0];
   }
 
   return {

--- a/src/sidebar/helpers/annotation-metadata.js
+++ b/src/sidebar/helpers/annotation-metadata.js
@@ -44,6 +44,7 @@ export function documentMetadata(annotation) {
 /**
  * Return the domain and title of an annotation for display on an annotation
  * card.
+ *
  * @param {Annotation} annotation
  */
 export function domainAndTitle(annotation) {
@@ -116,7 +117,7 @@ function titleTextFromAnnotation(annotation) {
 /**
  * Return `true` if the given annotation is a reply, `false` otherwise.
  *
- *  @param {Annotation} annotation - An annotation domain model object.
+ * @param {Annotation} annotation
  */
 export function isReply(annotation) {
   return (annotation.references || []).length > 0;

--- a/src/sidebar/helpers/test/annotation-metadata-test.js
+++ b/src/sidebar/helpers/test/annotation-metadata-test.js
@@ -51,6 +51,14 @@ describe('sidebar/helpers/annotation-metadata', () => {
           assert.equal(documentMetadata(annotation).title, 'example.com');
         });
       });
+
+      ['http://localhost:5000', '[not a URL]'].forEach(uri => {
+        it('returns empty domain if URL is invalid or private', () => {
+          const annotation = fakeAnnotation({ uri });
+          const { domain } = documentMetadata(annotation);
+          assert.equal(domain, '');
+        });
+      });
     });
 
     context('when the annotation does not have a document property', () => {


### PR DESCRIPTION
Since h has very liberal URI parsing compared to the browser's URL
constructor, as well as some completely invalid data on old annotations,
the client needs to handle errors parsing annotation `uri` values.

We may in future clean up the obviously-invalid URIs in h and introduce stricter validation, but that is a bigger project.

Surprisingly `annotation-metadata.js` is the only place I found in the
client that attempts to do this, everywhere else is just using the `uri`
field as a string.

Fixes https://github.com/hypothesis/client/issues/3666