### PR TITLE
Remove `isLoaded` from `frame-util.js`

### DIFF
--- a/src/annotator/hypothesis-injector.js
+++ b/src/annotator/hypothesis-injector.js
@@ -50,7 +50,7 @@ export class HypothesisInjector {
       return;
     }
 
-    frameUtil.isLoaded(frame, () => {
+    frameUtil.isDocumentReady(frame, () => {
       // Generate a random string to use as a frame ID. The format is not important.
       const subFrameIdentifier = Math.random().toString().replace(/\D/g, '');
       this._frameIdentifiers.set(frame, subFrameIdentifier);

--- a/src/annotator/hypothesis-injector.js
+++ b/src/annotator/hypothesis-injector.js
@@ -28,8 +28,8 @@ export class HypothesisInjector {
     this._frameIdentifiers = new Map();
     this._frameObserver = new FrameObserver(
       element,
-      frame => this._injectIntoFrame(frame),
-      frame => this._iframeUnloaded(frame)
+      frame => this._addHypothesis(frame),
+      frame => this._removeHypothesis(frame)
     );
   }
 
@@ -49,7 +49,7 @@ export class HypothesisInjector {
    *
    * @param {HTMLIFrameElement} frame
    */
-  _injectIntoFrame(frame) {
+  _addHypothesis(frame) {
     if (frameUtil.hasHypothesis(frame)) {
       return;
     }
@@ -69,7 +69,7 @@ export class HypothesisInjector {
   /**
    * @param {HTMLIFrameElement} frame
    */
-  _iframeUnloaded(frame) {
+  _removeHypothesis(frame) {
     this._bridge.call('destroyFrame', this._frameIdentifiers.get(frame));
     this._frameIdentifiers.delete(frame);
   }

--- a/src/annotator/hypothesis-injector.js
+++ b/src/annotator/hypothesis-injector.js
@@ -43,6 +43,10 @@ export class HypothesisInjector {
   /**
    * Inject Hypothesis client into a newly-discovered iframe.
    *
+   * IMPORTANT: This method requires that the iframe is "accessible"
+   * (frame.contentDocument|contentWindow is not null) and "ready" (DOM content
+   * has been loaded and parsed) before the method is called.
+   *
    * @param {HTMLIFrameElement} frame
    */
   _injectIntoFrame(frame) {
@@ -50,18 +54,16 @@ export class HypothesisInjector {
       return;
     }
 
-    frameUtil.isDocumentReady(frame, () => {
-      // Generate a random string to use as a frame ID. The format is not important.
-      const subFrameIdentifier = Math.random().toString().replace(/\D/g, '');
-      this._frameIdentifiers.set(frame, subFrameIdentifier);
-      const injectedConfig = {
-        ...this._config,
-        subFrameIdentifier,
-      };
+    // Generate a random string to use as a frame ID. The format is not important.
+    const subFrameIdentifier = Math.random().toString().replace(/\D/g, '');
+    this._frameIdentifiers.set(frame, subFrameIdentifier);
+    const injectedConfig = {
+      ...this._config,
+      subFrameIdentifier,
+    };
 
-      const { clientUrl } = this._config;
-      frameUtil.injectHypothesis(frame, clientUrl, injectedConfig);
-    });
+    const { clientUrl } = this._config;
+    frameUtil.injectHypothesis(frame, clientUrl, injectedConfig);
   }
 
   /**

--- a/src/annotator/test/integration/hypothesis-injector-test.js
+++ b/src/annotator/test/integration/hypothesis-injector-test.js
@@ -1,6 +1,6 @@
 import { DEBOUNCE_WAIT } from '../../frame-observer';
 import { HypothesisInjector } from '../../hypothesis-injector';
-import { isLoaded } from '../../util/frame-util';
+import { isDocumentReady } from '../../util/frame-util';
 
 describe('HypothesisInjector integration test', () => {
   let container;
@@ -65,7 +65,7 @@ describe('HypothesisInjector integration test', () => {
     createHypothesisInjector();
 
     const validFramePromise = new Promise(resolve => {
-      isLoaded(validFrame, () => {
+      isDocumentReady(validFrame, () => {
         assert(
           validFrame.contentDocument.body.hasChildNodes(),
           'expected valid frame to be modified'
@@ -74,7 +74,7 @@ describe('HypothesisInjector integration test', () => {
       });
     });
     const invalidFramePromise = new Promise(resolve => {
-      isLoaded(invalidFrame, () => {
+      isDocumentReady(invalidFrame, () => {
         assert(
           !invalidFrame.contentDocument.body.hasChildNodes(),
           'expected invalid frame to not be modified'
@@ -105,7 +105,7 @@ describe('HypothesisInjector integration test', () => {
     createHypothesisInjector();
 
     return new Promise(resolve => {
-      isLoaded(frame, () => {
+      isDocumentReady(frame, () => {
         const scriptElement =
           frame.contentDocument.querySelector('script[src]');
         assert(scriptElement, 'expected embed script to be injected');
@@ -128,7 +128,7 @@ describe('HypothesisInjector integration test', () => {
     createHypothesisInjector();
 
     return new Promise(resolve => {
-      isLoaded(frame, () => {
+      isDocumentReady(frame, () => {
         const scriptElement =
           frame.contentDocument.querySelector('script[src]');
         assert.isNull(
@@ -150,7 +150,7 @@ describe('HypothesisInjector integration test', () => {
     return new Promise(resolve => {
       // Yield to let the DOM and CrossFrame catch up
       waitForFrameObserver(() => {
-        isLoaded(frame, () => {
+        isDocumentReady(frame, () => {
           assert(
             frame.contentDocument.body.hasChildNodes(),
             'expected dynamically added frame to be modified'
@@ -192,7 +192,7 @@ describe('HypothesisInjector integration test', () => {
     createHypothesisInjector();
 
     return new Promise(resolve => {
-      isLoaded(frame, () => {
+      isDocumentReady(frame, () => {
         assert(
           frame.contentDocument.body.hasChildNodes(),
           'expected initial frame to be modified'
@@ -207,7 +207,7 @@ describe('HypothesisInjector integration test', () => {
 
           // Yield again
           waitForFrameObserver(() => {
-            isLoaded(frame, () => {
+            isDocumentReady(frame, () => {
               assert(
                 frame.contentDocument.body.hasChildNodes(),
                 'expected dynamically added frame to be modified'
@@ -230,7 +230,7 @@ describe('HypothesisInjector integration test', () => {
     return new Promise(resolve => {
       // Yield to let the DOM and CrossFrame catch up
       waitForFrameObserver(() => {
-        isLoaded(frame, () => {
+        isDocumentReady(frame, () => {
           assert(
             frame.contentDocument.body.hasChildNodes(),
             'expected dynamically added frame to be modified'
@@ -245,7 +245,7 @@ describe('HypothesisInjector integration test', () => {
 
             // Yield
             waitForFrameObserver(() => {
-              isLoaded(frame, () => {
+              isDocumentReady(frame, () => {
                 assert(
                   frame.contentDocument.body.hasChildNodes(),
                   'expected dynamically added frame to be modified'

--- a/src/annotator/util/frame-util.js
+++ b/src/annotator/util/frame-util.js
@@ -76,18 +76,3 @@ export function isDocumentReady(iframe, callback) {
     callback();
   }
 }
-
-/**
- * @param {HTMLIFrameElement} iframe
- * @param {() => void} callback
- */
-export function isLoaded(iframe, callback) {
-  const iframeDocument = /** @type {Document} */ (iframe.contentDocument);
-  if (iframeDocument.readyState !== 'complete') {
-    iframe.addEventListener('load', () => {
-      callback();
-    });
-  } else {
-    callback();
-  }
-}


### PR DESCRIPTION
I believe it would be faster to rely on `DOMContentLoaded` event
(`isDocumentReady` function). This event triggers when the DOM is fully
loaded and parsed but without waiting for the stylesheets, images, and
subframes to finish loading [1].

[1] https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event