### PR TITLE
Remove ThreadList debugging code

### DIFF
--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -75,9 +75,11 @@ describe('ThreadList', () => {
       '../util/dom': fakeDomUtil,
       '../helpers/visible-threads': fakeVisibleThreadsUtil,
     });
+    sinon.stub(console, 'warn');
   });
 
   afterEach(() => {
+    console.warn.restore();
     $imports.$restore();
     // Make sure all mounted components are unmounted
     wrappers.forEach(wrapper => wrapper.unmount());
@@ -303,6 +305,17 @@ describe('ThreadList', () => {
     const wrapper = createComponent();
     const cards = wrapper.find('ThreadCard');
     assert.equal(cards.length, fakeTopThread.children.length);
+  });
+
+  it('does not error if thread heights cannot be measured', () => {
+    // Render the `ThreadList` unconnected to a document. This will prevent
+    // it from being able to measure the height of rendered threads.
+    const wrapper = mount(<ThreadList threads={fakeTopThread.children} />);
+    wrappers.push(wrapper);
+    assert.calledWith(
+      console.warn,
+      'ThreadList could not measure thread. Element not found.'
+    );
   });
 
   it(


### PR DESCRIPTION
I believe we know what was causing the issue in ThreadList where an
effect callback was sometimes called with closed-over variables which did not
match the most recent render. See [1] for details. The issue really
needs to be resolved in a more general way than trying to work around it
in individual components.

This commit removes code added for debugging this and also adds a check for a
legitimate way (ie. without anything going wrong inside Preact) that the problem
could occur, although it should never happen in the actual app as we
never render `ThreadList` in a container that is disconnected from the
document.

[1] https://github.com/hypothesis/client/pull/3665#issuecomment-895857072