### PR TITLE
Add `fetchJSON` utility to standardize network errors 

### DIFF
--- a/src/sidebar/services/api-routes.js
+++ b/src/sidebar/services/api-routes.js
@@ -1,3 +1,4 @@
+import { fetchJSON } from '../util/fetch';
 import { retryPromiseOperation } from '../util/retry';
 
 /**
@@ -11,12 +12,7 @@ function getJSON(url) {
     // any additional headers/config so that we can use `<link rel="preload">` in
     // the `/app.html` response to fetch them early, while the client JS app
     // is loading.
-    fetch(url).then(response => {
-      if (response.status !== 200) {
-        throw new Error(`Fetching ${url} failed`);
-      }
-      return response.json();
-    })
+    fetchJSON(url)
   );
 }
 

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -200,8 +200,7 @@ describe('APIService', () => {
         // Network error
         status: null,
         body: 'Service unreachable.',
-        expectedMessage:
-          "Fetch operation failed for URL 'https://example.com/api/profile'",
+        expectedMessage: 'Network request failed: Service unreachable.',
       },
       {
         // Request failed with an error given in the JSON body
@@ -210,14 +209,15 @@ describe('APIService', () => {
         body: {
           reason: 'Thing not found',
         },
-        expectedMessage: '404 Not Found: Thing not found',
+        expectedMessage: 'Network request failed (404): Thing not found',
       },
       {
         // Request failed with a non-JSON response
         status: 500,
         statusText: 'Server Error',
         body: 'Internal Server Error',
-        expectedMessage: '500 Internal Server Error',
+        expectedMessage:
+          'Network request failed (500): Failed to parse response',
       },
     ].forEach(({ status, body, expectedMessage }) => {
       it('rejects the call with an error', () => {

--- a/src/sidebar/util/fetch.js
+++ b/src/sidebar/util/fetch.js
@@ -1,0 +1,76 @@
+/**
+ * An error indicating a failed network request.
+ *
+ * Failures that this error can represent include:
+ *
+ *  - Failures to send an HTTP request
+ *  - Requests that returned non-2xx responses
+ *  - Failures to parse the response in the expected format (eg. JSON)
+ */
+export class FetchError extends Error {
+  /**
+   * @param {Response|null} response - The response to the `fetch` request or
+   *   `null` if the fetch failed
+   * @param {string} [reason] - Additional details about the error. This might
+   *   include context of the network request or a server-provided error in
+   *   the response.
+   */
+  constructor(response, reason = '') {
+    let message = 'Network request failed';
+    if (response) {
+      message += ` (${response.status})`;
+    }
+    if (reason) {
+      message += `: ${reason}`;
+    }
+    super(message);
+
+    this.response = response;
+    this.reason = reason;
+  }
+}
+
+/**
+ * Execute a network request and return the parsed JSON response.
+ *
+ * Throws a `FetchError` if making the request fails or the request returns
+ * a non-2xx response.
+ *
+ * Returns `null` if the request returns a 204 (No Content) response.
+ *
+ * @param {string} url
+ * @param {RequestInit} [init] - Parameters for `fetch` request
+ */
+export async function fetchJSON(url, init) {
+  let response;
+  try {
+    response = await fetch(url, init);
+  } catch (err) {
+    // If the request fails for any reason, wrap the result in a `FetchError`.
+    // Different browsers use different error messages for `fetch` failures, so
+    // wrapping the error allows downstream clients to handle this uniformly.
+    throw new FetchError(null, err.message);
+  }
+
+  if (response.status === 204 /* No Content */) {
+    return null;
+  }
+
+  // Attempt to parse a JSON response. This may fail even if the status code
+  // indicates success.
+  let data;
+  try {
+    data = await response.json();
+  } catch (err) {
+    throw new FetchError(response, 'Failed to parse response');
+  }
+
+  // If the HTTP status indicates failure, attempt to extract a server-provided
+  // reason from the response, assuming certain conventions for the formatting
+  // of error responses.
+  if (!response.ok) {
+    throw new FetchError(response, data?.reason);
+  }
+
+  return data;
+}

--- a/src/sidebar/util/fetch.js
+++ b/src/sidebar/util/fetch.js
@@ -36,13 +36,14 @@ export class FetchError extends Error {
 /**
  * Execute a network request and return the parsed JSON response.
  *
- * Throws {@link FetchError} if making the request fails or the request returns
- * a non-2xx response.
- *
- * Returns `null` if the request returns a 204 (No Content) response.
+ * fetchJSON wraps the browser's `fetch` API to standardize error handling when
+ * making network requests that return JSON responses.
  *
  * @param {string} url
  * @param {RequestInit} [init] - Parameters for `fetch` request
+ * @return {Promise<any>} - Parsed JSON response or `null` if response status is 204 (No Content)
+ * @throws {FetchError} if the request fails, returns a non-2xx status or a JSON
+ *   response is expected but cannot be parsed
  */
 export async function fetchJSON(url, init) {
   let response;

--- a/src/sidebar/util/fetch.js
+++ b/src/sidebar/util/fetch.js
@@ -36,7 +36,7 @@ export class FetchError extends Error {
 /**
  * Execute a network request and return the parsed JSON response.
  *
- * Throws a `FetchError` if making the request fails or the request returns
+ * Throws {@link FetchError} if making the request fails or the request returns
  * a non-2xx response.
  *
  * Returns `null` if the request returns a 204 (No Content) response.

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -1,3 +1,4 @@
+import { fetchJSON } from './fetch';
 import { generateHexString } from './random';
 
 /**
@@ -184,17 +185,11 @@ export default class OAuthClient {
     const headers = {
       'Content-Type': 'application/x-www-form-urlencoded',
     };
-    const response = await fetch(url, {
+    return fetchJSON(url, {
       method: 'POST',
       headers,
       body: params.toString(),
     });
-
-    if (response.status !== 200) {
-      throw new Error(`Request failed with status ${response.status}`);
-    }
-
-    return response.json();
   }
 
   /**

--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -54,21 +54,10 @@ export function init(config) {
 
     // Ignore various errors due to circumstances outside of our control.
     ignoreErrors: [
-      // Ignore transient network request failures. Some of these ought to be
+      // Ignore network request failures. Some of these ought to be
       // caught and handled better but for now we are suppressing them to
       // improve the signal-to-noise ratio.
-      'Failed to fetch', // Chrome
-      'Fetch operation failed',
-      'NetworkError when attempting to fetch resource', // Firefox
-
-      // Ignore network request failures due to empty JSON bodies.
-      // TODO - Consider removing these once `fetch` callers have been changed
-      // to handle `Response.json()` calls failing.
-      'JSON.parse: unexpected end of data', // Firefox
-      'Unexpected end of JSON input', // Opera Mobile
-
-      // Ignore network request cancellations
-      'AbortError: The operation was aborted.', // Firefox
+      'Network request failed', // Standard message prefix for `FetchError` errors
 
       // Ignore an error that appears to come from CefSharp (embedded Chromium).
       // See https://forum.sentry.io/t/unhandledrejection-non-error-promise-rejection-captured-with-value/14062/20

--- a/src/sidebar/util/test/fetch-test.js
+++ b/src/sidebar/util/test/fetch-test.js
@@ -37,6 +37,8 @@ describe('sidebar/util/fetch', () => {
       }
 
       assert.instanceOf(err, FetchError);
+      assert.equal(err.url, 'https://example.com');
+      assert.equal(err.response, null);
       assert.include(err.message, 'Network request failed: Fetch failed');
     });
 
@@ -55,6 +57,8 @@ describe('sidebar/util/fetch', () => {
         err = e;
       }
       assert.instanceOf(err, FetchError);
+      assert.equal(err.url, 'https://example.com');
+      assert.equal(err.response, fakeResponse);
       assert.equal(
         err.message,
         'Network request failed (200): Failed to parse response'
@@ -71,6 +75,8 @@ describe('sidebar/util/fetch', () => {
         err = e;
       }
       assert.instanceOf(err, FetchError);
+      assert.equal(err.url, 'https://example.com');
+      assert.equal(err.response, fakeResponse);
       assert.equal(err.message, 'Network request failed (400): server error');
     });
 

--- a/src/sidebar/util/test/fetch-test.js
+++ b/src/sidebar/util/test/fetch-test.js
@@ -66,8 +66,8 @@ describe('sidebar/util/fetch', () => {
     });
 
     it('throws a FetchError if the response has a non-2xx status code', async () => {
-      fakeResponse.status = 400;
-      fakeResponse.json.resolves({ reason: 'server error' });
+      fakeResponse.status = 404;
+      fakeResponse.json.resolves({ reason: 'Thing not found' });
       let err;
       try {
         err = await fetchJSON('https://example.com');
@@ -77,7 +77,10 @@ describe('sidebar/util/fetch', () => {
       assert.instanceOf(err, FetchError);
       assert.equal(err.url, 'https://example.com');
       assert.equal(err.response, fakeResponse);
-      assert.equal(err.message, 'Network request failed (400): server error');
+      assert.equal(
+        err.message,
+        'Network request failed (404): Thing not found'
+      );
     });
 
     it('returns the parsed JSON response if the request was successful', async () => {

--- a/src/sidebar/util/test/fetch-test.js
+++ b/src/sidebar/util/test/fetch-test.js
@@ -1,0 +1,83 @@
+import { FetchError, fetchJSON } from '../fetch';
+
+describe('sidebar/util/fetch', () => {
+  describe('fetchJSON', () => {
+    let fakeResponse;
+
+    beforeEach(() => {
+      fakeResponse = {
+        status: 200,
+        json: sinon.stub().resolves({}),
+        get ok() {
+          return this.status >= 200 && this.status <= 299;
+        },
+      };
+      sinon.stub(window, 'fetch').resolves(fakeResponse);
+      window.fetch.resolves(fakeResponse);
+    });
+
+    afterEach(() => {
+      window.fetch.restore();
+    });
+
+    it('fetches the requested URL', async () => {
+      const init = { method: 'GET' };
+      await fetchJSON('https://example.com', init);
+      assert.calledWith(window.fetch, 'https://example.com', init);
+    });
+
+    it('throws a FetchError if `fetch` fails', async () => {
+      window.fetch.rejects(new Error('Fetch failed'));
+
+      let err;
+      try {
+        await fetchJSON('https://example.com');
+      } catch (e) {
+        err = e;
+      }
+
+      assert.instanceOf(err, FetchError);
+      assert.include(err.message, 'Network request failed: Fetch failed');
+    });
+
+    it('returns null if the response succeeds with a 204 status', async () => {
+      fakeResponse.status = 204;
+      const result = await fetchJSON('https://example.com');
+      assert.strictEqual(result, null);
+    });
+
+    it('throws a FetchError if parsing JSON response fails', async () => {
+      fakeResponse.json.rejects(new Error('Oh no'));
+      let err;
+      try {
+        await fetchJSON('https://example.com');
+      } catch (e) {
+        err = e;
+      }
+      assert.instanceOf(err, FetchError);
+      assert.equal(
+        err.message,
+        'Network request failed (200): Failed to parse response'
+      );
+    });
+
+    it('throws a FetchError if the response has a non-2xx status code', async () => {
+      fakeResponse.status = 400;
+      fakeResponse.json.resolves({ reason: 'server error' });
+      let err;
+      try {
+        err = await fetchJSON('https://example.com');
+      } catch (e) {
+        err = e;
+      }
+      assert.instanceOf(err, FetchError);
+      assert.equal(err.message, 'Network request failed (400): server error');
+    });
+
+    it('returns the parsed JSON response if the request was successful', async () => {
+      fakeResponse.json.resolves({ foo: 'bar' });
+      const result = await fetchJSON('https://example.com');
+      assert.deepEqual(result, { foo: 'bar' });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a `fetchJSON` utility that wraps the browser's `fetch` API in order to standardize the handling of various kinds of request failure and produce errors which are more useful downstream. The issues which motivated this change are:

- The format of errors thrown when a `fetch` request fails varies depending on the error and browser. This makes it difficult to handle them consistently downstream (eg. filtering in Sentry)
- We don't currently handle failure to parse JSON responses in various places, but we see in Sentry that it does occasionally happen that a 200 response which should have a JSON body does not.
- There is some duplication of code in making requests that return JSON responses and processing the result

The `fetchJSON` utility throws a `FetchError` error in all the above cases which consumers can test for.

- The first commit adds the `fetchJSON` utility in src/sidebar/util/fetch.js.
- The subsequent commits update services and utilities in the client that call `fetch` to use `fetchJSON` instead.
- The last commit simplifies the Sentry error filtering configuration to only look for the standardized error responses.

I'm probably going to split this into some smaller chunks, but I've put it all in a single draft for initial discussion.

Fixes https://github.com/hypothesis/client/issues/2184
Part of https://github.com/hypothesis/client/issues/3631