### PR TITLE
Refactor token fetching and error handling in OAuthClient

### DIFF
--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -191,7 +191,7 @@ export default class OAuthClient {
     });
 
     if (response.status !== 200) {
-      throw new Error('Request failed');
+      throw new Error(`Request failed with status ${response.status}`);
     }
 
     return response.json();
@@ -201,6 +201,7 @@ export default class OAuthClient {
    * Fetch an OAuth access token.
    *
    * @param {Record<string, string>} data - Parameters for form POST request
+   * @return {Promise<TokenInfo>}
    */
   async _getAccessToken(data) {
     // The request to `tokenEndpoint` returns an OAuth "Access Token Response".

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -3,7 +3,7 @@ import { generateHexString } from './random';
 /**
  * An object holding the details of an access token from the tokenUrl endpoint.
  *
- * @typedef {Object} TokenInfo
+ * @typedef TokenInfo
  * @prop {string} accessToken  - The access token itself.
  * @prop {number} expiresAt    - The date when the timestamp will expire.
  * @prop {string} refreshToken - The refresh token that can be used to
@@ -25,24 +25,13 @@ export class TokenError extends Error {
 }
 
 /**
- * Generate a short random string suitable for use as the "state" param in
- * authorization requests.
- *
- * See https://tools.ietf.org/html/rfc6749#section-4.1.1.
- */
-function generateState() {
-  return generateHexString(16);
-}
-
-/**
  * OAuthClient configuration.
  *
- * @typedef {Object} Config
- * @property {string} clientId - OAuth client ID
- * @property {string} tokenEndpoint - OAuth token exchange/refresh endpoint
- * @property {string} authorizationEndpoint - OAuth authorization endpoint
- * @property {string} revokeEndpoint - RFC 7009 token revocation endpoint
- * @property {() => string} [generateState] - Authorization "state" parameter generator
+ * @typedef Config
+ * @prop {string} clientId - OAuth client ID
+ * @prop {string} tokenEndpoint - OAuth token exchange/refresh endpoint
+ * @prop {string} authorizationEndpoint - OAuth authorization endpoint
+ * @prop {string} revokeEndpoint - RFC 7009 token revocation endpoint
  */
 
 /**
@@ -60,9 +49,6 @@ export default class OAuthClient {
     this.tokenEndpoint = config.tokenEndpoint;
     this.authorizationEndpoint = config.authorizationEndpoint;
     this.revokeEndpoint = config.revokeEndpoint;
-
-    // Test seam
-    this.generateState = config.generateState || generateState;
   }
 
   /**
@@ -136,7 +122,9 @@ export default class OAuthClient {
   authorize($window, authWindow) {
     // Random state string used to check that auth messages came from the popup
     // window that we opened.
-    const state = this.generateState();
+    //
+    // See https://tools.ietf.org/html/rfc6749#section-4.1.1.
+    const state = generateHexString(16);
 
     // Promise which resolves or rejects when the user accepts or closes the
     // auth popup.

--- a/src/sidebar/util/test/oauth-client-test.js
+++ b/src/sidebar/util/test/oauth-client-test.js
@@ -1,6 +1,7 @@
 import fetchMock from 'fetch-mock';
 import sinon from 'sinon';
 
+import { TokenError } from '../oauth-client';
 import OAuthClient from '../oauth-client';
 
 import FakeWindow from '../../test/fake-window';
@@ -88,7 +89,8 @@ describe('sidebar/util/oauth-client', () => {
         status: 400,
       });
       return client.exchangeAuthCode('unknowncode').catch(err => {
-        assert.equal(err.message, 'Authorization code exchange failed');
+        assert.instanceOf(err, TokenError);
+        assert.equal(err.message, 'Failed to fetch access token');
       });
     });
   });
@@ -121,7 +123,8 @@ describe('sidebar/util/oauth-client', () => {
         status: 400,
       });
       return client.exchangeGrantToken('unknowntoken').catch(err => {
-        assert.equal(err.message, 'Failed to retrieve access token');
+        assert.instanceOf(err, TokenError);
+        assert.equal(err.message, 'Failed to fetch access token');
       });
     });
   });
@@ -152,7 +155,8 @@ describe('sidebar/util/oauth-client', () => {
     it('rejects if the request fails', () => {
       fetchMock.post(config.tokenEndpoint, { status: 400 });
       return client.refreshToken('invalid-token').catch(err => {
-        assert.equal(err.message, 'Failed to refresh access token');
+        assert.instanceOf(err, TokenError);
+        assert.equal(err.message, 'Failed to fetch access token');
       });
     });
   });
@@ -170,14 +174,15 @@ describe('sidebar/util/oauth-client', () => {
     });
 
     it('resolves if the request succeeds', () => {
-      fetchMock.post(config.revokeEndpoint, { status: 200 });
+      fetchMock.post(config.revokeEndpoint, { status: 200, body: {} });
       return client.revokeToken('valid-access-token');
     });
 
     it('rejects if the request fails', () => {
       fetchMock.post(config.revokeEndpoint, { status: 400 });
       return client.revokeToken('invalid-token').catch(err => {
-        assert.equal(err.message, 'failed');
+        assert.instanceOf(err, TokenError);
+        assert.equal(err.message, 'Failed to revoke access token');
       });
     });
   });

--- a/src/sidebar/util/test/oauth-client-test.js
+++ b/src/sidebar/util/test/oauth-client-test.js
@@ -1,7 +1,7 @@
 import fetchMock from 'fetch-mock';
 import sinon from 'sinon';
 
-import { TokenError } from '../oauth-client';
+import { $imports, TokenError } from '../oauth-client';
 import OAuthClient from '../oauth-client';
 
 import FakeWindow from '../../test/fake-window';
@@ -31,7 +31,6 @@ describe('sidebar/util/oauth-client', () => {
     authorizationEndpoint: 'https://annota.te/oauth/authorize',
     tokenEndpoint: 'https://annota.te/api/token',
     revokeEndpoint: 'https://annota.te/oauth/revoke',
-    generateState: () => 'notrandom',
   };
 
   beforeEach(() => {
@@ -44,6 +43,7 @@ describe('sidebar/util/oauth-client', () => {
   });
 
   afterEach(() => {
+    $imports.$restore();
     fetchMock.restore();
     clock.restore();
   });
@@ -215,6 +215,12 @@ describe('sidebar/util/oauth-client', () => {
 
     beforeEach(() => {
       fakeWindow = new FakeWindow();
+
+      $imports.$mock({
+        './random': {
+          generateHexString: () => 'notrandom',
+        },
+      });
     });
 
     function authorize() {

--- a/src/sidebar/util/test/oauth-client-test.js
+++ b/src/sidebar/util/test/oauth-client-test.js
@@ -1,10 +1,8 @@
 import fetchMock from 'fetch-mock';
 import sinon from 'sinon';
 
-import { $imports, TokenError } from '../oauth-client';
-import OAuthClient from '../oauth-client';
-
 import FakeWindow from '../../test/fake-window';
+import OAuthClient, { TokenError, $imports } from '../oauth-client';
 
 const fixtures = {
   tokenResponse: {


### PR DESCRIPTION
Prepare for upcoming improvements to handling of network errors across
the client by refactoring some `fetch` requests and error handling in
OAuthClient.

 - Extract duplicated logic for fetching an access token into a
   `_getAccessToken` method.
 - Create a `TokenError` class to wrap all errors that may be thrown
   when fetching or revoking an access token. This makes it easier for
   downstream consumers to handle such errors in a uniform way.

   The `TokenError` error links to the network or other error that
   caused it via the `cause` property, following the convention
   currently being standardized in https://github.com/tc39/proposal-error-cause.
- Remove a `generateState` test seam in favor of using `$imports.$mock`. This addresses a code coverage gap.
   
See https://github.com/hypothesis/client/pull/3671 for more background on where this is going and why.