### PR TITLE
Replace `whitelistUrls` in Sentry config with `allowUrls`

### DIFF
--- a/src/sidebar/util/test/sentry-test.js
+++ b/src/sidebar/util/test/sentry-test.js
@@ -69,7 +69,7 @@ describe('sidebar/util/sentry', () => {
       assert.calledWith(
         fakeSentry.init,
         sinon.match({
-          whitelistUrls: ['https://cdn.hypothes.is'],
+          allowUrls: ['https://cdn.hypothes.is'],
         })
       );
     });
@@ -88,7 +88,7 @@ describe('sidebar/util/sentry', () => {
       );
     });
 
-    it('disables the URL whitelist if `document.currentScript` is inaccessible', () => {
+    it('disables the URL allowlist if `document.currentScript` is inaccessible', () => {
       fakeDocumentCurrentScript.get(() => null);
 
       sentry.init({
@@ -99,7 +99,7 @@ describe('sidebar/util/sentry', () => {
       assert.calledWith(
         fakeSentry.init,
         sinon.match({
-          whitelistUrls: undefined,
+          allowUrls: undefined,
         })
       );
     });

--- a/src/sidebar/util/test/sentry-test.js
+++ b/src/sidebar/util/test/sentry-test.js
@@ -74,7 +74,7 @@ describe('sidebar/util/sentry', () => {
       );
     });
 
-    it('configures Sentry to ignore Errors with matching the text "Fetch operation failed"', () => {
+    it('configures Sentry to ignore certain errors', () => {
       sentry.init({
         dsn: 'test-dsn',
         environment: 'dev',


### PR DESCRIPTION
Replace the deprecated `whitelistUrls` config option in Sentry with
`allowUrls`. `whitelistUrls` was deprecated in Sentry v5.18.0.

Also revise the comments to be more succinct and note what happens if an
exception does not have a useful stack trace. That behavior is not documented
but I can see it from [the code](https://github.com/getsentry/sentry-javascript/blob/74a08294122a0a900b9299919a3dd2d5a8a6e694/packages/core/src/integrations/inboundfilters.ts#L144) (note `!url` test at start of line, where `url` refers to the URL from the stack trace).

See https://docs.sentry.io/platforms/javascript/configuration/options/#allow-urls.