### PR TITLE
Fix anchoring issues in newest PDF.js releases

### DIFF
--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -180,7 +180,7 @@ function getPageTextContent(pageIndex) {
     });
     let items = textContent.items;
 
-    // Older versions of PDF.js did not create elements in the text layer for
+    // Versions of PDF.js < v2.9.359 did not create elements in the text layer for
     // text items that contained all-whitespace strings. Newer versions (after
     // https://github.com/mozilla/pdf.js/pull/13257) do. The same commit also
     // introduced the `hasEOL` property to text items, so we use the absence

--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -156,22 +156,30 @@ export async function documentHasText() {
 /**
  * Return the text of a given PDF page.
  *
+ * The page text returned by this function should match the `textContent` of the
+ * text layer element that PDF.js creates for rendered pages. This allows
+ * offsets computed in the text to be reused as offsets within the text layer
+ * element's content. This is important to create correct Ranges for anchored
+ * selectors.
+ *
  * @param {number} pageIndex
  * @return {Promise<string>}
  */
-async function getPageTextContent(pageIndex) {
+function getPageTextContent(pageIndex) {
+  // If we already have or are fetching the text for this page, return the
+  // existing result.
   const cachedText = pageTextCache[pageIndex];
   if (cachedText) {
     return cachedText;
   }
 
-  // Join together PDF.js `TextItem`s representing pieces of text in a PDF page.
-  const joinItems = items => {
-    let itemStrings = items.map(item => item.str);
+  const getPageText = async () => {
+    const pageView = await getPageView(pageIndex);
+    const textContent = await pageView.pdfPage.getTextContent({
+      normalizeWhitespace: true,
+    });
+    let items = textContent.items;
 
-    // We want the text returned by `getPageTextContent` to match the `textContent`
-    // of the transparent text layer, so that text offsets match up.
-    //
     // Older versions of PDF.js did not create elements in the text layer for
     // text items that contained all-whitespace strings. Newer versions (after
     // https://github.com/mozilla/pdf.js/pull/13257) do. The same commit also
@@ -179,22 +187,15 @@ async function getPageTextContent(pageIndex) {
     // of this property to determine if we need to filter out whitespace-only strings.
     const excludeEmpty = items.length > 0 && !('hasEOL' in items[0]);
     if (excludeEmpty) {
-      itemStrings = itemStrings.filter(s => /\S/.test(s));
+      items = items.filter(it => /\S/.test(it.str));
     }
 
-    return itemStrings.join('');
+    return items.map(it => it.str).join('');
   };
 
-  // Fetch the text content for a given page as a string.
-  const getTextContent = async pageIndex => {
-    const pageView = await getPageView(pageIndex);
-    const textContent = await pageView.pdfPage.getTextContent({
-      normalizeWhitespace: true,
-    });
-    return joinItems(textContent.items);
-  };
-
-  const pageText = getTextContent(pageIndex);
+  // This function synchronously populates the cache with a promise so that
+  // multiple calls don't call `PDFPageProxy.getTextContent` twice.
+  const pageText = getPageText();
   pageTextCache[pageIndex] = pageText;
   return pageText;
 }

--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -437,13 +437,6 @@ export function anchor(root, selectors) {
   /** @type {Promise<Range>} */
   let result = Promise.reject('unable to anchor');
 
-  const checkQuote = range => {
-    if (quote && quote.exact !== range.toString()) {
-      throw new Error('quote mismatch');
-    }
-    return range;
-  };
-
   if (position) {
     result = result.catch(() => {
       return findPage(position.start).then(({ index, offset, textContent }) => {
@@ -451,7 +444,10 @@ export function anchor(root, selectors) {
         const end = position.end - offset;
         const length = end - start;
 
-        checkQuote(textContent.substr(start, length));
+        const matchedText = textContent.substr(start, length);
+        if (quote && quote.exact !== matchedText) {
+          throw new Error('quote mismatch');
+        }
 
         return anchorByPosition(index, start, end);
       });

--- a/src/annotator/anchoring/test/fake-pdf-viewer-application.js
+++ b/src/annotator/anchoring/test/fake-pdf-viewer-application.js
@@ -15,6 +15,15 @@ import { TinyEmitter as EventEmitter } from 'tiny-emitter';
 import { RenderingStates } from '../pdf';
 
 /**
+ * Options that control global aspects of the PDF.js fake, such as which
+ * version of PDF.js is being emulated.
+ *
+ * @typedef PDFJSConfig
+ * @prop {boolean} newTextRendering - Whether to emulate the PDF.js text rendering
+ *   changes added in v2.9.359.
+ */
+
+/**
  * Create the DOM structure for a page which matches the structure produced by
  * PDF.js
  *
@@ -75,8 +84,8 @@ class FakePDFPageProxy {
     const makeTextItem = str => {
       if (this._config.newTextRendering) {
         // The `hasEOL` property was added in https://github.com/mozilla/pdf.js/pull/13257
-        // and is used to feature-detect whether whitespace-only items need
-        // to ignored in the `items` array. The value is unimportant.
+        // and its existence is used to feature-detect whether whitespace-only
+        // items need to be ignored in the `items` array.
         return { str, hasEOL: false };
       } else {
         return { str };
@@ -224,15 +233,6 @@ class FakePDFViewer {
     }
   }
 }
-
-/**
- * Options that control global aspects of the PDF.js fake, such as which
- * version of PDF.js is being emulated.
- *
- * @typedef PDFJSConfig
- * @prop {boolean} newTextRendering - Whether to emulate the PDF.js text rendering
- *   changes added in v2.9.359.
- */
 
 /**
  * @typedef Options

--- a/src/annotator/anchoring/test/fake-pdf-viewer-application.js
+++ b/src/annotator/anchoring/test/fake-pdf-viewer-application.js
@@ -81,6 +81,7 @@ class FakePDFPageProxy {
       );
     }
 
+    /** @param {string} str */
     const makeTextItem = str => {
       if (this._config.newTextRendering) {
         // The `hasEOL` property was added in https://github.com/mozilla/pdf.js/pull/13257
@@ -151,10 +152,10 @@ class FakePDFViewer {
   /**
    * @param {Options} options
    */
-  constructor(options) {
-    this._config = options.config;
-    this._container = options.container;
-    this._content = options.content;
+  constructor({ config, container, content }) {
+    this._config = config;
+    this._container = container;
+    this._content = content;
 
     /** @type {FakePDFPageView} */
     this._pages = [];


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/hypothesis/client/issues/3674 which occurs in PDF.js releases after v2.9.359, which include the text rendering changes from https://github.com/mozilla/pdf.js/pull/13257. The changes in this PR are backwards compatible with earlier versions of PDF.js.

The problem is described in detail in the second commit in this PR, but briefly the issue is that there was a mismatch between the page text fetched using PDF.js's APIs and the contents of the transparent text layer element that PDF.js creates for rendered pages. The client relies on these being the same.

In addition to resolving the problem for the current version of PDF.js I also added a check that will make the issue easier to debug if this mismatch happens again in later versions.

Part of https://github.com/hypothesis/client/issues/3674 

- [x] Update tests to cover old and new versions of PDF.js, since we'll need to support both
- [x] File a separate PR to update the version of PDF.js used by the dev server
- [x] Create separate issue for handling of line breaks (https://github.com/hypothesis/client/issues/3693)

----

**Testing:**

The easiest way to test these changes locally is to create a temporary local branch that combines the changes from this branch and https://github.com/hypothesis/client/pull/3691. If you open up any of the test PDF assignments in the dev server, check that you can highlight some text and create an annotation, that the highlight is created in the correct place and that clicking on an annotation card scrolls to the correct location.

Alternatively you can build a browser extension that uses a build from this branch of the client combined with https://github.com/hypothesis/browser-extension/pull/631.
