### PR TITLE
POC - Add integration for new VitalSource Bookshelf reader

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -1,7 +1,6 @@
 import { Adder } from './adder';
 import { CrossFrame } from './cross-frame';
-import { HTMLIntegration } from './integrations/html';
-import { PDFIntegration } from './integrations/pdf';
+import { createIntegration } from './integrations';
 
 import { TextRange } from './anchoring/text-range';
 import {
@@ -22,7 +21,6 @@ import { ListenerCollection } from './util/listener-collection';
  * @typedef {import('../types/annotator').AnnotationData} AnnotationData
  * @typedef {import('../types/annotator').Anchor} Anchor
  * @typedef {import('../types/annotator').Destroyable} Destroyable
- * @typedef {import('../types/annotator').Integration} Integration
  * @typedef {import('../types/annotator').SidebarLayout} SidebarLayout
  * @typedef {import('../types/api').Target} Target
  */
@@ -154,11 +152,11 @@ export default class Guest {
      */
     this.anchors = [];
 
-    /** @type {Integration} */
-    this._integration =
-      config.documentType === 'pdf'
-        ? new PDFIntegration(this)
-        : new HTMLIntegration(this.element);
+    /**
+     * Integration that handles document-type specific functionality in the
+     * guest.
+     */
+    this._integration = createIntegration(this, config.documentType);
 
     // Set the frame identifier if it's available.
     // The "top" guest instance will have this as null since it's in a top frame not a sub frame

--- a/src/annotator/integrations/index.js
+++ b/src/annotator/integrations/index.js
@@ -1,0 +1,30 @@
+import { HTMLIntegration } from './html';
+import { PDFIntegration } from './pdf';
+import { VitalSourceIntegration } from './vitalsource';
+
+/**
+ * @typedef {import('../../types/annotator').Annotator} Annotator
+ * @typedef {import('../../types/annotator').Integration} Integration
+ */
+
+/**
+ * Create the `Integration` implementation for the given document type.
+ *
+ * Integrations handle the document-type specific functionality of guest frames.
+ *
+ * @param {Annotator} guest
+ * @param {string} documentType
+ * @return {Integration}
+ */
+export function createIntegration(guest, documentType) {
+  switch (documentType) {
+    case 'html':
+      return new HTMLIntegration(guest.element);
+    case 'pdf':
+      return new PDFIntegration(guest);
+    case 'vitalsource':
+      return new VitalSourceIntegration(guest.element);
+    default:
+      throw new Error('Unable to create integration. Unknown document type');
+  }
+}

--- a/src/annotator/integrations/vitalsource.js
+++ b/src/annotator/integrations/vitalsource.js
@@ -1,0 +1,225 @@
+import warnOnce from '../../shared/warn-once';
+import { ListenerCollection } from '../util/listener-collection';
+import { HTMLIntegration } from './html';
+
+/**
+ * @typedef {import('../../types/annotator').Anchor} Anchor
+ * @typedef {import('../../types/annotator').Integration} Integration
+ * @typedef {import('../../types/annotator').Selector} Selector
+ */
+
+/**
+ * Identify which frame this is in the VitalSource Bookshelf reader.
+ *
+ * Returns `null` if this is not Bookshelf, `container-frame` if this is frame
+ * where the sidebar should be loaded or `content-frame` if this is the frame
+ * containing the chapter content.
+ *
+ * @return {'container-frame'|'content-frame'|null}
+ */
+export function vitalSourceFrameRole() {
+  if (!window.origin.endsWith('.vitalsource.com')) {
+    return null;
+  }
+  if (document.querySelector('mosaic-book')) {
+    return 'container-frame';
+  } else {
+    return 'content-frame';
+  }
+}
+
+/**
+ * @param {HTMLIFrameElement} frame
+ */
+async function waitForIFrameToLoad(frame) {
+  if (!frame.contentDocument) {
+    throw new Error('Frame is not accessible');
+  }
+
+  if (frame.contentDocument.location.href === 'about:blank') {
+    await new Promise(resolve => {
+      frame.addEventListener('load', resolve);
+    });
+  } else {
+    return;
+  }
+}
+
+/**
+ * Load the Hypothesis client into the VitalSource Bookshelf's content frame.
+ *
+ * The Bookshelf app contains multiple frames. This function should be run
+ * in the "container" frame in order to configure and load the client into
+ * the "content" frames where the chapter content is displayed.
+ * See {@link vitalSourceFrameRole}.
+ *
+ * @param {string} bootScript - URL to the client's boot script
+ */
+export function loadClientInVitalSourceContentFrame(bootScript) {
+  const bookElement = document.querySelector('mosaic-book');
+  if (!bookElement || !bookElement.shadowRoot) {
+    throw new Error(
+      'Failed to set up Hypothesis integration with Bookshelf. Content frame not found.'
+    );
+  }
+
+  /** @param {HTMLIFrameElement} contentFrame */
+  const injectClient = async contentFrame => {
+    await waitForIFrameToLoad(contentFrame);
+
+    if (
+      !contentFrame ||
+      !contentFrame.contentDocument ||
+      !contentFrame.contentWindow
+    ) {
+      warnOnce('VitalSource content frame not found or not accessible.');
+      return;
+    }
+
+    const contentDocument = contentFrame.contentDocument;
+
+    // @ts-ignore
+    contentFrame.contentWindow.hypothesisConfig = () => ({
+      subFrameIdentifier: 'vitalsource-content',
+
+      // TODO - Set configuration for LMS context if appropriate.
+    });
+
+    const script = contentDocument.createElement('script');
+    script.src = bootScript;
+    contentDocument.body.appendChild(script);
+  };
+
+  // Perform the initial injection into the currently loaded chapter.
+  const shadowRoot = bookElement.shadowRoot;
+  let contentFrame = shadowRoot.querySelector('iframe');
+  if (!contentFrame) {
+    return;
+  }
+  injectClient(contentFrame);
+
+  // Re-inject client when the current chapter changes.
+  const mo = new MutationObserver(() => {
+    const newContentFrame = shadowRoot.querySelector('iframe');
+    if (newContentFrame === contentFrame || !newContentFrame) {
+      return;
+    }
+    contentFrame = newContentFrame;
+    injectClient(contentFrame);
+  });
+  mo.observe(shadowRoot, { childList: true, subtree: true });
+}
+
+/**
+ * Integration for VitalSource's Bookshelf ebook reader.
+ *
+ * The Bookshelf reader consists of several frames. This integration is for the
+ * frame that contains the content of the current chapter. See {@link vitalSourceFrameRole}
+ *
+ * The VitalSource integration delegates to the standard HTML integration for
+ * most functionality, but it adds logic to:
+ *
+ *  - Customize the document URI and metadata that is associated with annotations
+ *  - Prevent VitalSource's built-in selection menu from getting in the way
+ *    of the adder
+ *  - (add other things here)
+ *
+ * @implements {Integration}
+ */
+export class VitalSourceIntegration {
+  constructor(container) {
+    this._htmlIntegration = new HTMLIntegration(container);
+
+    this._listeners = new ListenerCollection();
+
+    // Prevent mouse events from reaching the window. This prevents VitalSource
+    // from showing its native selection menu, which obscures the client's
+    // annotation toolbar.
+    //
+    // VitalSource only checks the selection on the `mouseup` and `mouseout` events,
+    // but we also need to stop `mousedown` to prevent the client's `SelectionObserver`
+    // from thinking that the mouse is held down when a selection change occurs.
+    // This has the unwanted side effect of allowing the adder to appear while
+    // dragging the mouse.
+    //
+    // This is a potentially brittle interaction between SelectionObserver and
+    // VitalSourceIntegration. It would be better to find a more resilient
+    // approach - perhaps enable integrations to customize selection interaction?
+    //
+    // Another option would be to pass in the Guest's root element to
+    // `SelectionObserver` and prevent it from adding any event handlers to
+    // elements outside of that.
+    const stopEvents = ['mousedown', 'mouseup', 'mouseout'];
+    for (let event of stopEvents) {
+      this._listeners.add(document.documentElement, event, e => {
+        e.stopPropagation();
+      });
+    }
+  }
+
+  destroy() {
+    this._listeners.removeAll();
+    this._htmlIntegration.destroy();
+  }
+
+  /**
+   * @param {HTMLElement} root
+   * @param {Selector[]} selectors
+   */
+  anchor(root, selectors) {
+    return this._htmlIntegration.anchor(root, selectors);
+  }
+
+  /**
+   * @param {HTMLElement} root
+   * @param {Range} range
+   */
+  describe(root, range) {
+    return this._htmlIntegration.describe(root, range);
+  }
+
+  contentContainer() {
+    return this._htmlIntegration.contentContainer();
+  }
+
+  fitSideBySide() {
+    // Not yet implemented
+    return false;
+  }
+
+  async getMetadata() {
+    // Return minimal metadata which includes only the information we really
+    // want to include.
+    return {
+      title: document.title,
+      link: [],
+    };
+  }
+
+  async uri() {
+    // An example of a typical URL for the chapter content in the Bookshelf reader is:
+    //
+    // https://jigsaw.vitalsource.com/books/9781848317703/epub/OPS/xhtml/chapter_001.html#cfi=/6/10%5B;vnd.vst.idref=chap001%5D!/4
+    //
+    // Where "9781848317703" is the VitalSource book ID ("vbid"), "chapter_001.html"
+    // is the location of the HTML page for the current chapter within the book
+    // and the `#cfi` fragment identifies the scroll location.
+    //
+    // Note that this URL is typically different than what is displayed in the
+    // iframe's `src` attribute.
+
+    // Strip off search parameters and fragments.
+    const uri = new URL(document.location.href);
+    uri.search = '';
+    return uri.toString();
+  }
+
+  /**
+   * @param {Anchor} anchor
+   */
+  scrollToAnchor(anchor) {
+    // TODO - Customize this to work with the tall iframe that VitalSource
+    // creates for its reader.
+    return this._htmlIntegration.scrollToAnchor(anchor);
+  }
+}

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -68,6 +68,7 @@
  * Subset of the annotator `Guest` instance that is exposed to other modules
  *
  * @typedef Annotator
+ * @prop {HTMLElement} element
  * @prop {Anchor[]} anchors
  * @prop {(ann: AnnotationData) => Promise<Anchor[]>} anchor
  */


### PR DESCRIPTION
This is a proof-of-concept integration with the new VitalSource Bookshelf reader.

In contrast to the current integration in the LMS app where the Bookshelf reader is treated just like any other HTML document, this PR adds a new document/app type integration for VitalSource Bookshelf, similar to how we have a specific integration for PDF.js. The new integration (see `src/annotator/integrations/vitalsource.js`) delegates to the standard HTML integration for creating and anchoring selectors, but it has its own logic for:

- Extracting the URL and metadata for annotations
- Configuring and loading the client into the current chapter as the user navigates around the book
- Preventing VitalSource's own selection menu from interfering with the Hypothesis one. We currently prevent the VS selection menu from appearing at all when this integration is active, but we could provide some toggle switch in future.

Similar to other ebook readers that we integrate with, the VitalSource book reader contains multiple frames. In particular there is an innermost frame which contains the actual content of the current chapter (the "content frame"), and a same-origin parent frame (the "container frame"). Both are hosted at https://jigsaw.vitalsource.com. The previous client integration worked by loading the client into just the content frame. This doesn't work with the new reader because the content frame is reaaally tall (however long the content is). Instead this new integration loads the client into the container frame and sets up the content frame as a guest frame.

----

**To test this branch with the development client:**

1. Go to https://bookshelf.vitalsource.com and open a book
2. Open the browser console, switch to the Console tab and select the `wrapper.html` frame. This is the parent frame of the one that contains the book content.
3. Paste the following snippet into the browser console:
   ```js
   { const d = document;
     const s = d.createElement('script'); s.src = 'http://localhost:5000/embed.js';
     d.body.appendChild(s) }
   ```
   
The Hypothesis sidebar should then appear on the left edge of the light-blue sidebar. As you scroll the document content, it should remain in place.

<img width="861" alt="VitalSource new reader integration" src="https://user-images.githubusercontent.com/2458/130052394-f2d210fc-ddee-44c2-9066-237828760e29.png">

If you make a text selection in the document, you should see only the Hypothesis annotation controls and not the VitalSource ones:

<img width="652" alt="VitalSource adder" src="https://user-images.githubusercontent.com/2458/130052620-585727cf-88d0-45a7-928b-eb7dffdafcd0.png">

As you navigate to different chapters of the book, the client should be loaded into each new chapter.

When you create a new annotation, it should have more minimal URL and document metadata associated with it than you'd normally get in an HTML document. In particular, only the host and path of the URL are captured, excluding some irrelevant query parameters. Additionally the only document metadata is the title. Example payload of `POST /api/annotations` request when creating an annotation:

<img width="664" alt="VS annotation metadata" src="https://user-images.githubusercontent.com/2458/130053106-984486ff-d32c-4384-994a-46b633f2d4a9.png">

The reason for the minimal document metadata is that in this context we can use our special knowledge of what web application we're in to only extract the relevant information. This means that annotations won't be lost if the book reader changes in future to add new URL parameters etc.

**Known issues (being worked on):**

- Clicking on an annotation in the sidebar does not yet scroll to the correct location. This is the most important issue to resolve.
- The adder toolbar appears while you are dragging a selection with the mouse. It should only appear when the mouse is released.
- Annotation locations are not indicated in the bucket bar
- Annotations sometimes orphan when navigating from one chapter to the next
