### PR TITLE
Anchor quotes to best match in whole PDF

### DIFF
--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -295,6 +295,16 @@ describe('annotator/anchoring/pdf', () => {
       assert.equal(range.toString(), 'Jane Austen');
     });
 
+    // See https://github.com/hypothesis/client/issues/3705
+    it('anchors quotes to best match across all pages', async () => {
+      // This should anchor to an exact match on the third page, rather than a
+      // close match on the second page.
+      viewer.pdfViewer.setCurrentPage(2);
+      const quote = { type: 'TextQuoteSelector', exact: 'Netherfield Park is' };
+      const range = await pdfAnchoring.anchor(container, [quote]);
+      assert.equal(range.toString(), 'Netherfield Park is');
+    });
+
     // See https://github.com/hypothesis/client/issues/1329
     it('anchors selectors that match the last text on the page', async () => {
       viewer.pdfViewer.setCurrentPage(1);


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/3707**~~

Anchor quote selectors to the best match in the whole PDF, rather than the best match in the first-searched page which contains at least one match above the minimum quality threshold.

This fixes an issue described in https://github.com/hypothesis/client/issues/3705 where sub-optimal matches could be returned if the position hint is no longer valid due to changes in PDF.js text rendering between the PDF.js version in which the annotation was created and the current PDF.js version.

A downside of this change is that anchoring a quote selector now requires extracting the text of the entire PDF, whereas before quote anchoring typically only needed to extract text for pages up to and including the one that contained the quote. This can make anchoring feel slower in very long documents.

Fixes https://github.com/hypothesis/client/issues/3705

----

Implementation notes:

- Add test case in `anchoring/test/pdf-test.js` for the new behavior
- Add `findQuote` helper in `anchoring/pdf.js` which finds best match for quote across entire document
- Change `anchor` function in `anchoring/pdf.js` to use `findQuote` to find the best match
- Change the existing cache of `quote + position => (start, end)` to use a `Map` rather than an object. Maps avoid some of the quirks of using an object as a map (eg. needing to add extra code to only check own properties) and in my testing can be slightly faster.