### PR TITLE
Require quote selectors when anchoring in PDFs

### DIFF
--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -245,7 +245,7 @@ describe('annotator/anchoring/pdf', () => {
 
         // Test that all of the selectors anchor and that each selector individually
         // anchors correctly as well
-        const subsets = [[position, quote], [position], [quote]];
+        const subsets = [[position, quote], [quote]];
         const subsetsAnchored = subsets.map(subset => {
           const types = subset.map(s => {
             return s.type;
@@ -269,6 +269,21 @@ describe('annotator/anchoring/pdf', () => {
         return Promise.all(subsetsAnchored);
       });
     });
+
+    [[], [{ type: 'TextPositionSelector', start: 0, end: 200 }]].forEach(
+      selectors => {
+        it('fails to anchor if there is no quote selector', async () => {
+          let error;
+          try {
+            await pdfAnchoring.anchor(container, selectors);
+          } catch (err) {
+            error = err;
+          }
+          assert.instanceOf(error, Error);
+          assert.equal(error.message, 'No quote selector found');
+        });
+      }
+    );
 
     it('anchors text in older PDF.js versions', async () => {
       initViewer(fixtures.pdfPages, { newTextRendering: false });


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/3687**~~

Changes in text rendering across PDF.js versions can render position
selectors invalid. Therefore any anchoring done with position selectors must
be checked against the quote, as we do with HTML annotations.

This commit disallows anchoring using only position selectors in PDFs
and restructures `anchor` control flow using async/await to make it
easier to follow.

We have been capturing quote selectors with PDF annotations forever, so
there should be no impact on old annotations.