### PR TITLE
Refactor helpers in anchoring/pdf.js to async/await

### DIFF
--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -16,14 +16,6 @@ import { TextQuoteAnchor } from './types';
  */
 
 /**
- * @typedef PdfTextRange
- * @prop {number} pageIndex
- * @prop {Object} anchor
- * @prop {number} anchor.start - Start character offset within the page's text
- * @prop {number} anchor.end - End character offset within the page's text
- */
-
-/**
  * Enum values for page rendering states (IRenderableView#renderingState)
  * in PDF.js. Taken from web/pdf_rendering_queue.js in the PDF.js library.
  *

--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -29,17 +29,15 @@ export const RenderingStates = {
   FINISHED: 3,
 };
 
-// Caches for performance.
-
 /**
  * Map of page index to page text content.
  *
- * @type {Record<number,Promise<string> | undefined>}
+ * @type {Map<number, Promise<string>>}
  */
-let pageTextCache = {};
+const pageTextCache = new Map();
 
 /**
- * A cache that maps a `(quote, text offset in document)` key to a specific
+ * A cache that maps a `<quote>:<text offset>` key to a specific
  * location in the document.
  *
  * The components of the key come from an annotation's selectors. This is used
@@ -161,7 +159,7 @@ export async function documentHasText() {
 function getPageTextContent(pageIndex) {
   // If we already have or are fetching the text for this page, return the
   // existing result.
-  const cachedText = pageTextCache[pageIndex];
+  const cachedText = pageTextCache.get(pageIndex);
   if (cachedText) {
     return cachedText;
   }
@@ -188,9 +186,9 @@ function getPageTextContent(pageIndex) {
 
   // This function synchronously populates the cache with a promise so that
   // multiple calls don't call `PDFPageProxy.getTextContent` twice.
-  const pageText = getPageText();
-  pageTextCache[pageIndex] = pageText;
-  return pageText;
+  const text = getPageText();
+  pageTextCache.set(pageIndex, text);
+  return text;
 }
 
 /**
@@ -497,6 +495,6 @@ export async function describe(root, range) {
  * This exists mainly as a helper for use in tests.
  */
 export function purgeCache() {
-  pageTextCache = {};
+  pageTextCache.clear();
   quotePositionCache.clear();
 }

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -245,7 +245,7 @@ describe('annotator/anchoring/pdf', () => {
 
         // Test that all of the selectors anchor and that each selector individually
         // anchors correctly as well
-        const subsets = [[position, quote], [position], [quote]];
+        const subsets = [[position, quote], [quote]];
         const subsetsAnchored = subsets.map(subset => {
           const types = subset.map(s => {
             return s.type;
@@ -269,6 +269,21 @@ describe('annotator/anchoring/pdf', () => {
         return Promise.all(subsetsAnchored);
       });
     });
+
+    [[], [{ type: 'TextPositionSelector', start: 0, end: 200 }]].forEach(
+      selectors => {
+        it('fails to anchor if there is no quote selector', async () => {
+          let error;
+          try {
+            await pdfAnchoring.anchor(container, selectors);
+          } catch (err) {
+            error = err;
+          }
+          assert.instanceOf(error, Error);
+          assert.equal(error.message, 'No quote selector found');
+        });
+      }
+    );
 
     it('anchors text in older PDF.js versions', async () => {
       initViewer(fixtures.pdfPages, { newTextRendering: false });

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -295,6 +295,16 @@ describe('annotator/anchoring/pdf', () => {
       assert.equal(range.toString(), 'Jane Austen');
     });
 
+    // See https://github.com/hypothesis/client/issues/3705
+    it('anchors quotes to best match across all pages', async () => {
+      // This should anchor to an exact match on the third page, rather than a
+      // close match on the second page.
+      viewer.pdfViewer.setCurrentPage(2);
+      const quote = { type: 'TextQuoteSelector', exact: 'Netherfield Park is' };
+      const range = await pdfAnchoring.anchor(container, [quote]);
+      assert.equal(range.toString(), 'Netherfield Park is');
+    });
+
     // See https://github.com/hypothesis/client/issues/1329
     it('anchors selectors that match the last text on the page', async () => {
       viewer.pdfViewer.setCurrentPage(1);


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/3706**

This is some follow-up refactoring to make some of the PDF anchoring code easier to follow. See individual commits for details, but in summary:

- Convert some functions that were conceptually async iteration over all pages in a document to use async/await instead of Promise/chains + recursion
- Remove an unused typedef
- Convert the remaining non-Map cache to use a Map as well