### PR TITLE
Fix type issue with the latest frontend-shared version

### DIFF
--- a/dev-server/ui-playground/index.js
+++ b/dev-server/ui-playground/index.js
@@ -3,11 +3,13 @@ import ButtonPatterns from './components/ButtonPatterns';
 
 import sidebarIcons from '../../src/sidebar/icons';
 
+/** @type {import('@hypothesis/frontend-shared/lib/pattern-library').PlaygroundRoute[]} */
 const extraRoutes = [
   {
     route: '/buttons',
     title: 'Buttons',
     component: ButtonPatterns,
+    group: 'components',
   },
 ];
 


### PR DESCRIPTION
In the latest version of the frontent-shared package, `extraRoute` has a
mandatory property `group` that must be either
`"home" | "foundations" | "patterns" | "components"`;

There are three ways to fix this:

* make the `group` property optional in the frontend-shared package (I
  don't know if that's a good idea).

* cast the `string` type to one of the allowed types: `    group:
  /** @type {'components'} */ ('components'),`

* convert the `string` type to const without casting (this PR).