### PR TITLE
Support new PDF.js fingerprint API

### DIFF
--- a/src/types/pdfjs.js
+++ b/src/types/pdfjs.js
@@ -51,7 +51,13 @@
 
 /**
  * @typedef PDFDocument
- * @prop {string} fingerprint
+ * @prop {string} [fingerprint] - PDF fingerprint in PDF.js before v2.10.377.
+ *   May exist in later versions depending on the PDF.js build.
+ * @prop {[string, string|null]} [fingerprints] - PDF fingerprints in PDF.js after
+ *   v2.10.377. See https://github.com/mozilla/pdf.js/pull/13661. The first
+ *   entry of this array is the "original" fingerprint and the same as the
+ *   `fingerprint` property in older versions. The second entry is the "modified"
+ *   fingerprint. See "File Identifiers" section in the PDF spec.
  * @prop {() => Promise<PDFDocumentMetadata>} getMetadata
  */
 


### PR DESCRIPTION
In https://github.com/mozilla/pdf.js/pull/13661 the API for retrieving
PDF fingerprints (aka. File Identifiers) changed. In generic builds of
PDF.js the old API remains available, but not in the non-generic one
that Firefox's built-in viewer uses.

This commit makes Hypothesis use the new API if available or the old API
otherwise. The fingerprint value should be the same in both cases.

Fixes #3673

----

**Testing:**

Example PDF for testing: https://arxiv.org/ftp/arxiv/papers/2106/2106.04651.pdf, which has fingerprint 835121d1b268bd9c323505dd56851cc0.

1. Install the latest version of Firefox and open a PDF in the native viewer. Use the bookmarklet to load the production Hypothesis client. Click on the "?" button => "About this version" in the Hypothesis sidebar and observe that the fingerprint is displayed as N/A, whereas in Via or the Chrome extension a valid fingerprint should be shown.
2. Switch to this branch and use the bookmarklet to load the development client into Firefox's copy of PDF.js. The fingerprint that the client shows should now match the one that Via displays.