### PR TITLE
Find best match for quote selectors in PDFs across all pages (v2)

### DIFF
--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -378,12 +378,10 @@ async function anchorQuote(quoteSelector, positionHint) {
   }
 
   // Search pages for the best match, ignoring whitespace differences.
-  const [strippedPrefix] = quoteSelector.prefix
-    ? stripSpaces(quoteSelector.prefix)
-    : [];
-  const [strippedSuffix] = quoteSelector.suffix
-    ? stripSpaces(quoteSelector.suffix)
-    : [];
+  const [strippedPrefix] =
+    quoteSelector.prefix !== undefined ? stripSpaces(quoteSelector.prefix) : [];
+  const [strippedSuffix] =
+    quoteSelector.suffix !== undefined ? stripSpaces(quoteSelector.suffix) : [];
   const [strippedQuote] = stripSpaces(quoteSelector.exact);
 
   let bestMatch;

--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -315,6 +315,10 @@ async function anchorByPosition(pageIndex, start, end) {
 /**
  * Return a string with spaces stripped and offsets into the input string.
  *
+ * This function optimizes for performance of stripping the main space chars
+ * that PDF.js generates over handling all kinds of whitespace that could
+ * occur in a string.
+ *
  * @param {string} str
  * @return {[string, number[]]}
  */

--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -387,10 +387,12 @@ async function anchorQuote(quoteSelector, positionHint) {
   let bestMatch;
   for (let page of pageIndexes) {
     const text = await getPageTextContent(page);
+    const [strippedText, offsets] = stripSpaces(text);
 
-    // Expected offset of quote in current page based on position hint.
-    let hint;
-    if (expectedPageIndex !== undefined) {
+    // Determine expected offset of quote in current page based on position hint.
+    let strippedHint;
+    if (expectedPageIndex !== undefined && expectedOffsetInPage !== undefined) {
+      let hint;
       if (page < expectedPageIndex) {
         hint = text.length; // Prefer matches closer to end of page.
       } else if (page === expectedPageIndex) {
@@ -398,13 +400,8 @@ async function anchorQuote(quoteSelector, positionHint) {
       } else {
         hint = 0; // Prefer matches closer to start of page.
       }
-    }
 
-    const [strippedText, offsets] = stripSpaces(text);
-
-    // Convert expected offset in original text into offset into stripped text.
-    let strippedHint;
-    if (hint !== undefined) {
+      // Convert expected offset in original text into offset into stripped text.
       strippedHint = 0;
       while (strippedHint < offsets.length && offsets[strippedHint] < hint) {
         ++strippedHint;

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -295,6 +295,29 @@ describe('annotator/anchoring/pdf', () => {
       assert.equal(range.toString(), 'Jane Austen');
     });
 
+    // See https://github.com/hypothesis/client/issues/3705
+    [
+      // Exact match for text in PDF.
+      'Netherfield Park is',
+
+      // Exact match for text in PDF when whitespace differences are ignored.
+      'Netherfield  Park  is',
+      'NetherfieldParkis',
+
+      // Close match for text in PDF.
+      'Netherfield Park as',
+    ].forEach(quoteText => {
+      it('anchors quotes to best match across all pages', async () => {
+        viewer.pdfViewer.setCurrentPage(2);
+        const quote = { type: 'TextQuoteSelector', exact: quoteText };
+        const range = await pdfAnchoring.anchor(container, [quote]);
+
+        // This should anchor to an exact match on the third page, rather than a
+        // close match on the second page.
+        assert.equal(range.toString(), 'Netherfield Park is');
+      });
+    });
+
     // See https://github.com/hypothesis/client/issues/1329
     it('anchors selectors that match the last text on the page', async () => {
       viewer.pdfViewer.setCurrentPage(1);


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/3736**~~

This is a second attempt at resolving #3705. Compared to the first version in https://github.com/hypothesis/client/pull/3706 this approach aims to perform better in long documents and where the difference between the captured quote and current PDF text is only in whitespace content.

----

As described in #3705, stopping a quote search as soon as we find an
approximate match could result in quotes anchoring to suboptimal matches
if the position selector is no longer accurate.

We want to balance finding the best match against making the search
efficient in long documents. The approach taken in this commit is to
continue to search pages in priority order, but instead of returning the
first "good enough" match (below `matchQuote`'s error threshold), return
the first exact match ignoring whitespace differences, or the nearest
match in the whole document otherwise.

We ignore whitespace differences because this is the main change between
the current version of PDF.js that we include in Hypothesis products, and
newer versions that we are trying to migrate to (see #3687). It is also
likely to be the main source of text differences between PDF.js and
other viewers.

 - Change `anchorQuote` to ignore whitespace differences when searching
   for approximate matches
 - Change `anchorQuote` to keep searching for the best match if it does
   not find a whitespace-insensitive exact match in the current page
 - Add tests for whitespace changes

Fixes https://github.com/hypothesis/client/issues/3705
