### PR TITLE
Reduce forced reflows when drawing PDF highlights

### DIFF
--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -94,8 +94,6 @@ function drawHighlightsAbovePdfCanvas(highlightEls) {
       // of highlighted text, especially for overlapping highlights.
       //
       // This choice optimizes for the common case of dark text on a light background.
-      //
-      // @ts-ignore - `mixBlendMode` property is missing from type definitions.
       svgStyle.mixBlendMode = 'multiply';
     } else {
       // For older browsers (eg. Edge < 79) we draw all the highlights as

--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -124,7 +124,7 @@ function drawHighlightsAbovePdfCanvas(highlightEls) {
     }
 
     // Make the highlight in the text layer transparent.
-    highlightEl.className += ' is-transparent';
+    highlightEl.classList.add('is-transparent');
 
     // Associate SVG element with highlight for use by `removeHighlights`.
     highlightEl.svgHighlight = rect;


### PR DESCRIPTION
While testing the changes in https://github.com/hypothesis/client/pull/3743 to look for potential correctness or performance issues I discovered a problem with the way highlights are drawn in PDFs that can cause a lot of jank in Chrome (and other browsers too) for PDFs that have a large number of annotations spread across a small number of pages.

**Problem and solution details:**

The rendering of SVG highlights in PDFs triggered an excessive number of
style recalculations and forced reflows due to interleaving DOM changes
with DOM API calls that require current layout information (`getBoundingClientRect`).

This PR makes several changes to reduce reflows:

 1. Create all the `<hypothesis-highlight>` elements in the text layer
    before creating any of the associated SVG elements.

    This avoids interleaving creating `<hypothesis-highlight>` elements
    with measuring them in order to position the associated SVG
    `<rect>`.

 2. Change `drawHighlightsAbovePdfCanvas` to accept a list of highlight
    elements instead of a single element. By assuming all highlights for
    a single annotation are on the same page, we can avoid some repeated
    work and add all the `<rect>` elements to the parent `<svg>` in one
    batch.

These changes only reduce the thrash when creating highlights for a
single annotation. To eliminate the remaining thrash we'd need to use a
combination of optimizing DOM updates across multiple `highlightRange`
calls and/or reducing the work for PDF pages which are rendered but not
visible on-screen.

**Performance results:**

The charts below show the effect of reducing reflows in [a PDF](https://www.brookings.edu/wp-content/uploads/2020/08/FP_20200817_democracy_covid_belin_demaio.pdf) with a large number of Public annotations (~360) across a small number of pages (7).

The steps I took were:

1. Open the PDF
2. Slowly scroll down from page 1 to page 7, to ensure as many pages were rendered as possible at once
3. Switch to a group with no annotations for this document
4. Start Chrome's profiler and switch to the Public group
5. Stop profiling once all ~360 annotations have anchored

**Before:**

<img width="1179" alt="Style recalculation of doom" src="https://user-images.githubusercontent.com/2458/132521469-4497219d-7d0a-4d27-9183-0b70334348fb.png">

The purple areas at the bottom are layout and style recalculations. Hovering the mouse over the red lines interleaved with the purple areas at the bottom of this chart shows warnings from Chrome about forced reflows.

**After:**

<img width="1000" alt="Style recalculation of mild panic" src="https://user-images.githubusercontent.com/2458/132521489-2f9a1070-81e1-4d52-9663-7722e4f3c983.png">

Notice less purple at the bottom and shorter red bars at the top.