### PR TITLE
Simplify Button styling customizations

### DIFF
--- a/dev-server/ui-playground/components/ButtonPatterns.js
+++ b/dev-server/ui-playground/components/ButtonPatterns.js
@@ -35,12 +35,15 @@ export default function ButtonPatterns() {
 
         <Library.Example title="Basic usage">
           <Library.Demo withSource>
-            <LinkButton className="InlineLinkButton">Log in</LinkButton>
+            <LinkButton classes="InlineLinkButton">Log in</LinkButton>
           </Library.Demo>
         </Library.Example>
-        <Library.Example title="Dark variant: Always has underline">
+        <Library.Example title="Dark variant, customized with underline">
           <Library.Demo withSource>
-            <LinkButton className="InlineLinkButton" variant="dark">
+            <LinkButton
+              classes="InlineLinkButton InlineLinkButton--underlined"
+              variant="dark"
+            >
               Log in
             </LinkButton>
           </Library.Demo>
@@ -58,19 +61,19 @@ export default function ButtonPatterns() {
           <Library.Demo withSource>
             <IconButton
               className="NonResponsiveIconButton"
-              icon="edit"
+              icon="copy"
               title="Edit"
               size="small"
             />
             <IconButton
               className="NonResponsiveIconButton"
-              icon="edit"
+              icon="copy"
               title="Edit"
               size="medium"
             />
             <IconButton
               className="NonResponsiveIconButton"
-              icon="edit"
+              icon="copy"
               title="Edit"
               size="large"
             />

--- a/dev-server/ui-playground/components/ButtonPatterns.js
+++ b/dev-server/ui-playground/components/ButtonPatterns.js
@@ -90,17 +90,17 @@ export default function ButtonPatterns() {
 
         <Library.Example title="Page numbers">
           <Library.Demo withSource style={{ backgroundColor: '#ececec' }}>
-            <LabeledButton className="PaginationPageButton" variant="dark">
+            <LabeledButton classes="PaginationPageButton" variant="dark">
               9
             </LabeledButton>
             <LabeledButton
-              className="PaginationPageButton"
+              classes="PaginationPageButton"
               variant="dark"
               pressed
             >
               10
             </LabeledButton>
-            <LabeledButton className="PaginationPageButton" variant="dark">
+            <LabeledButton classes="PaginationPageButton" variant="dark">
               11
             </LabeledButton>
           </Library.Demo>
@@ -109,14 +109,14 @@ export default function ButtonPatterns() {
         <Library.Example title="Navigation buttons">
           <Library.Demo withSource style={{ backgroundColor: '#ececec' }}>
             <LabeledButton
-              className="PaginationPageButton"
+              classes="PaginationPageButton"
               icon="arrow-left"
               variant="dark"
             >
               Prev
             </LabeledButton>
             <LabeledButton
-              className="PaginationPageButton"
+              classes="PaginationPageButton"
               icon="arrow-right"
               iconPosition="right"
               variant="dark"

--- a/dev-server/ui-playground/components/ButtonPatterns.js
+++ b/dev-server/ui-playground/components/ButtonPatterns.js
@@ -60,19 +60,19 @@ export default function ButtonPatterns() {
         <Library.Example variant="wide" title="Sizes (medium is default)">
           <Library.Demo withSource>
             <IconButton
-              className="NonResponsiveIconButton"
+              classes="NonResponsiveIconButton"
               icon="copy"
               title="Edit"
               size="small"
             />
             <IconButton
-              className="NonResponsiveIconButton"
+              classes="NonResponsiveIconButton"
               icon="copy"
               title="Edit"
               size="medium"
             />
             <IconButton
-              className="NonResponsiveIconButton"
+              classes="NonResponsiveIconButton"
               icon="copy"
               title="Edit"
               size="large"

--- a/dev-server/ui-playground/components/ButtonPatterns.js
+++ b/dev-server/ui-playground/components/ButtonPatterns.js
@@ -20,7 +20,7 @@ export default function ButtonPatterns() {
 
         <Library.Example title="Basic usage">
           <Library.Demo withSource>
-            <LabeledButton className="PublishControlButton" variant="primary">
+            <LabeledButton classes="PublishControlButton" variant="primary">
               Publish to My Group
             </LabeledButton>
           </Library.Demo>

--- a/dev-server/ui-playground/components/ButtonPatterns.js
+++ b/dev-server/ui-playground/components/ButtonPatterns.js
@@ -126,33 +126,6 @@ export default function ButtonPatterns() {
           </Library.Demo>
         </Library.Example>
       </Library.Pattern>
-
-      <Library.Pattern title="InputButton">
-        <p>
-          Customizes <code>IconButton</code> styling to make the button part of
-          a composite pattern with an input field to the left.
-        </p>
-
-        <Library.Example title="Basic usage">
-          <Library.Demo withSource>
-            <IconButton
-              className="InputButton"
-              title="Copy version details"
-              icon="copy"
-            />
-          </Library.Demo>
-        </Library.Example>
-        <Library.Example title="Small size">
-          <Library.Demo withSource>
-            <IconButton
-              className="InputButton"
-              title="Copy version details"
-              icon="copy"
-              size="small"
-            />
-          </Library.Demo>
-        </Library.Example>
-      </Library.Pattern>
     </Library.Page>
   );
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@babel/core": "^7.1.6",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
-    "@hypothesis/frontend-shared": "3.8.1",
+    "@hypothesis/frontend-shared": "3.9.0",
     "@octokit/rest": "^18.0.0",
     "@sentry/browser": "^6.0.2",
     "approx-string-match": "^1.1.0",

--- a/src/sidebar/components/Annotation/AnnotationPublishControl.js
+++ b/src/sidebar/components/Annotation/AnnotationPublishControl.js
@@ -81,7 +81,8 @@ function AnnotationPublishControl({
     <div className="AnnotationPublishControl">
       <div className="annotation-publish-button">
         <LabeledButton
-          className="PublishControlButton"
+          classes="PublishControlButton"
+          data-testid="publish-control-button"
           style={buttonStyle}
           onClick={onSave}
           disabled={isDisabled}

--- a/src/sidebar/components/Annotation/AnnotationShareControl.js
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.js
@@ -1,6 +1,8 @@
 import {
   IconButton,
   SvgIcon,
+  TextInput,
+  TextInputWithButton,
   useElementShouldClose,
 } from '@hypothesis/frontend-shared';
 import { useEffect, useRef, useState } from 'preact/hooks';
@@ -136,22 +138,22 @@ function AnnotationShareControl({
             </div>
           </div>
           <div className="annotation-share-panel__content">
-            <div className="u-layout-row">
-              <input
-                aria-label="Use this URL to share this annotation"
-                className="annotation-share-panel__form-input"
-                type="text"
-                value={shareUri}
-                readOnly
-                ref={inputRef}
-              />
-              <IconButton
-                className="InputButton"
-                icon="copy"
-                title="Copy share link to clipboard"
-                onClick={copyShareLink}
-                size="small"
-              />
+            <div className="u-layout-row annotation-share-panel__inputs">
+              <TextInputWithButton>
+                <TextInput
+                  aria-label="Use this URL to share this annotation"
+                  type="text"
+                  value={shareUri}
+                  readOnly
+                  inputRef={inputRef}
+                />
+                <IconButton
+                  icon="copy"
+                  title="Copy share link to clipboard"
+                  onClick={copyShareLink}
+                  variant="dark"
+                />
+              </TextInputWithButton>
             </div>
             {inContextAvailable ? (
               <div className="annotation-share-panel__details">

--- a/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
@@ -78,7 +78,7 @@ describe('AnnotationPublishControl', () => {
   });
 
   const getPublishButton = wrapper =>
-    wrapper.find('LabeledButton.PublishControlButton');
+    wrapper.find('LabeledButton[data-testid="publish-control-button"]');
 
   describe('theming', () => {
     it('should apply theme styles', () => {

--- a/src/sidebar/components/Excerpt.js
+++ b/src/sidebar/components/Excerpt.js
@@ -26,7 +26,7 @@ function InlineControls({ isCollapsed, setCollapsed, linkStyle = {} }) {
     <div className="Excerpt__inline-controls">
       <div className="Excerpt__toggle-container">
         <LinkButton
-          className="InlineLinkButton"
+          classes="InlineLinkButton InlineLinkButton--underlined"
           onClick={() => setCollapsed(!isCollapsed)}
           expanded={!isCollapsed}
           title="Toggle visibility of full excerpt text"

--- a/src/sidebar/components/LoggedOutMessage.js
+++ b/src/sidebar/components/LoggedOutMessage.js
@@ -32,7 +32,7 @@ function LoggedOutMessage({ onLogin }) {
         </a>{' '}
         or{' '}
         <LinkButton
-          className="InlineLinkButton"
+          classes="InlineLinkButton InlineLinkButton--underlined"
           onClick={onLogin}
           variant="dark"
         >

--- a/src/sidebar/components/PaginationNavigation.js
+++ b/src/sidebar/components/PaginationNavigation.js
@@ -36,7 +36,7 @@ function PaginationNavigation({ currentPage, onChangePage, totalPages }) {
       <div className="PaginationNavigation__relative PaginationNavigation__prev">
         {hasPreviousPage && (
           <LabeledButton
-            className="PaginationPageButton"
+            classes="PaginationPageButton"
             icon="arrow-left"
             title="Go to previous page"
             onClick={e => changePageTo(currentPage - 1, e.target)}
@@ -53,7 +53,7 @@ function PaginationNavigation({ currentPage, onChangePage, totalPages }) {
               <div className="PaginationNavigation__gap">...</div>
             ) : (
               <LabeledButton
-                className="PaginationPageButton"
+                classes="PaginationPageButton"
                 key={`page-${idx}`}
                 title={`Go to page ${page}`}
                 pressed={page === currentPage}
@@ -69,7 +69,7 @@ function PaginationNavigation({ currentPage, onChangePage, totalPages }) {
       <div className="PaginationNavigation__relative PaginationNavigation__next">
         {hasNextPage && (
           <LabeledButton
-            className="PaginationPageButton"
+            classes="PaginationPageButton"
             icon="arrow-right"
             iconPosition="right"
             title="Go to next page"

--- a/src/sidebar/components/ShareAnnotationsPanel.js
+++ b/src/sidebar/components/ShareAnnotationsPanel.js
@@ -1,4 +1,10 @@
-import { IconButton, Spinner, SvgIcon } from '@hypothesis/frontend-shared';
+import {
+  IconButton,
+  Spinner,
+  SvgIcon,
+  TextInput,
+  TextInputWithButton,
+} from '@hypothesis/frontend-shared';
 
 import { useStoreProxy } from '../store/use-store';
 import { pageSharingLink } from '../helpers/annotation-sharing';
@@ -69,19 +75,20 @@ function ShareAnnotationsPanel({ toastMessenger }) {
                 )}
               </div>
               <div className="u-layout-row">
-                <input
-                  aria-label="Use this URL to share these annotations"
-                  className="ShareAnnotationsPanel__form-input"
-                  type="text"
-                  value={shareURI}
-                  readOnly
-                />
-                <IconButton
-                  className="InputButton"
-                  icon="copy"
-                  onClick={copyShareLink}
-                  title="Copy share link"
-                />
+                <TextInputWithButton>
+                  <TextInput
+                    aria-label="Use this URL to share these annotations"
+                    type="text"
+                    value={shareURI}
+                    readOnly
+                  />
+                  <IconButton
+                    icon="copy"
+                    onClick={copyShareLink}
+                    title="Copy share link"
+                    variant="dark"
+                  />
+                </TextInputWithButton>
               </div>
               <p>
                 {notNull(focusedGroup).type === 'private' ? (

--- a/src/sidebar/components/Thread.js
+++ b/src/sidebar/components/Thread.js
@@ -93,7 +93,7 @@ function Thread({ thread, threadsService }) {
         <div className="Thread__collapse">
           <div className="Thread__collapse-button-container">
             <IconButton
-              className="NonResponsiveIconButton"
+              classes="NonResponsiveIconButton"
               expanded={!thread.collapsed}
               icon={toggleIcon}
               title={toggleTitle}

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -86,7 +86,7 @@ function TopBar({
       {auth.status === 'logged-out' && (
         <span className="TopBar__login-links u-font--large u-horizontal-rhythm">
           <LinkButton
-            className="InlineLinkButton"
+            classes="InlineLinkButton"
             onClick={onSignUp}
             style={loginLinkStyle}
             variant="primary"
@@ -95,7 +95,7 @@ function TopBar({
           </LinkButton>
           <div>/</div>
           <LinkButton
-            className="InlineLinkButton"
+            classes="InlineLinkButton"
             onClick={onLogin}
             style={loginLinkStyle}
             variant="primary"

--- a/src/styles/mixins/forms.scss
+++ b/src/styles/mixins/forms.scss
@@ -54,14 +54,3 @@
     font-size: var.$touch-input-font-size;
   }
 }
-
-/**
- * A text input that has a button to its right; no border radius
- *
- * @param {boolean} [$compact] - For use in compact areas, with tighter padding
- */
-@mixin form-input--with-button($compact: false) {
-  @include form-input($compact);
-  width: 100%;
-  border-radius: 0;
-}

--- a/src/styles/sidebar/buttons.scss
+++ b/src/styles/sidebar/buttons.scss
@@ -8,16 +8,11 @@
 // Similar to `.LinkButton`, with inline layout (so button can be used
 // within text)
 .InlineLinkButton {
-  @include buttons.LinkButton(
-    (
-      'inline': true,
-    )
-  );
-  // Custom: The dark variant is used for inline, anchor-like styling and needs
-  // to be underlined at all times to match <a> styling near it
-  &--dark {
-    text-decoration: underline;
-  }
+  display: inline;
+}
+
+.InlineLinkButton--underlined {
+  text-decoration: underline;
 }
 
 .PublishControlButton {

--- a/src/styles/sidebar/buttons.scss
+++ b/src/styles/sidebar/buttons.scss
@@ -31,11 +31,10 @@
 
 // An IconButton, but override minimum height/width on touch screen devices
 .NonResponsiveIconButton {
-  @include buttons.IconButton(
-    (
-      'responsive': false,
-    )
-  );
+  @media (pointer: coarse) {
+    min-width: auto;
+    min-height: auto;
+  }
 }
 
 // This is for styling an icon-only button that sits to the right of a

--- a/src/styles/sidebar/buttons.scss
+++ b/src/styles/sidebar/buttons.scss
@@ -24,9 +24,7 @@
 // This button style has asymmetrical padding. Hold it here to see if
 // this kind of padding is useful in other patterns.
 .PaginationPageButton {
-  @include buttons.LabeledButton {
-    padding: var.$layout-space--small var.$layout-space;
-  }
+  padding: var.$layout-space--small var.$layout-space;
 }
 
 // An IconButton, but override minimum height/width on touch screen devices

--- a/src/styles/sidebar/buttons.scss
+++ b/src/styles/sidebar/buttons.scss
@@ -15,14 +15,10 @@
   text-decoration: underline;
 }
 
+// Disable border-radius on right side so it can align with a button next to it
 .PublishControlButton {
-  @include buttons.LabeledButton {
-    // Border-radius turned off
-    &--primary {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-    }
-  }
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 // This button style has asymmetrical padding. Hold it here to see if

--- a/src/styles/sidebar/buttons.scss
+++ b/src/styles/sidebar/buttons.scss
@@ -1,8 +1,5 @@
 @use "sass:map";
 
-// Button styling for the sidebar extending common button-component styles
-@use '@hypothesis/frontend-shared/styles/components/buttons';
-
 @use '../variables' as var;
 
 // Similar to `.LinkButton`, with inline layout (so button can be used
@@ -32,33 +29,5 @@
   @media (pointer: coarse) {
     min-width: auto;
     min-height: auto;
-  }
-}
-
-// This is for styling an icon-only button that sits to the right of a
-// text input field. It is really part of a composite pattern that includes
-// both the input and the buttons. At some point this pattern should be
-// consolidated.
-$input-button-colors: map.merge(
-  buttons.colors-for('IconButton'),
-  (
-    'background': var.$grey-1,
-    'hover-background': var.$grey-2,
-  )
-);
-
-.InputButton {
-  $-options: (
-    'colormap': $input-button-colors,
-    'withVariants': false,
-  );
-  @include buttons.IconButton($-options) {
-    border: 1px solid var.$grey-3;
-    border-radius: 0; // Turn off border-radius to align with <input> edges
-    border-left: 0; // Avoid double border with the <input>
-    padding: var.$layout-space--xsmall var.$layout-space--small;
-    &--small {
-      padding: var.$layout-space--xxsmall var.$layout-space--xsmall;
-    }
   }
 }

--- a/src/styles/sidebar/components/AnnotationShareControl.scss
+++ b/src/styles/sidebar/components/AnnotationShareControl.scss
@@ -34,8 +34,9 @@
     border-bottom: none;
   }
 
-  &__form-input {
-    @include forms.form-input--with-button($compact: true);
+  &__inputs {
+    @include utils.font--small;
+    width: 100%;
   }
 
   &__details {

--- a/src/styles/sidebar/components/ShareAnnotationsPanel.scss
+++ b/src/styles/sidebar/components/ShareAnnotationsPanel.scss
@@ -11,16 +11,4 @@
     color: var.$color-text;
     font-weight: 500;
   }
-
-  &__form-input {
-    @include forms.form-input--with-button;
-  }
-
-  // FIXME: Centralize styling of different sizes of Spinner in a reusable
-  // class or mixin.
-  // Spinner uses `em`-sizing; make the font-size of the containing element
-  // larger to make spinner larger
-  &__spinner {
-    font-size: (var.$layout-space * 2);
-  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1113,10 +1113,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
-"@hypothesis/frontend-shared@3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-3.8.1.tgz#1c9804dcba299865e98157a772c997f906dd2ace"
-  integrity sha512-J6Gk6ZZCI0qYjH6nA0rIupMbxSMjIMt6ZFx+TkAERVs0zAYRc5P6kiUJIuk+YnMlkVNWTq+vdvAXqwSFGd7AdA==
+"@hypothesis/frontend-shared@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-3.9.0.tgz#1d6dceba0755c4bad62c655cd9b55890c6c49174"
+  integrity sha512-tNZVBxyCyML2KXqS6QWZxIfxWxERxyEj0M336iHJZSrw1a4MwONC/7vpY++yf7/YlE7y4xXPRq9NydyBVOR3tA==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
This PR simplifies the way that Button component design patterns are customized (extended) in the client, and updates two components (`AnnotationShareControl`, `ShareAnnotationsPanel`) to use the shared `TextInputWithButton` component, which eliminates the need for a custom `.InputButton` design pattern in the client. The styling for the text-inputs-with-button in those two components is slightly visually different (see below), but there are no other user-visible changes in this work.

This PR achieves simplification by taking advantage of the recently-added support for a `classes` prop to the Button components in the shared package. This allows adding _additional_ CSS classes to Buttons, instead of fully obliterating the component classes, as the `className` prop does. This in turn allows styling to override just what it needs to, without having to muck around with (honestly really mind-meltingly-confusing) mixins.

This in turn allows us to continue towards _not_ providing mixins as part of the frontend-shared package's API, which is a mid-term goal. The existence of a custom-button pattern-library page in this repository made this work much easier than it might have been, yay.

### User-visible changes

`ShareAnnotationsPanel`, before:

<img width="435" alt="Screen Shot 2021-09-10 at 8 33 43 AM" src="https://user-images.githubusercontent.com/439947/132855685-46f43bc6-32eb-4324-a5c5-776335843078.png">

`ShareAnnotationsPanel`, after:

<img width="425" alt="Screen Shot 2021-09-10 at 8 32 53 AM" src="https://user-images.githubusercontent.com/439947/132855722-012d3f02-9236-45e4-94d3-a1be810f9631.png">

`AnnotationShareControl`, before:

<img width="450" alt="Screen Shot 2021-09-10 at 8 33 49 AM" src="https://user-images.githubusercontent.com/439947/132855748-9334ab70-fa8f-4cb1-90a8-5a0a2cb87d3c.png">

`AnnotationShareControl`, after:

<img width="428" alt="Screen Shot 2021-09-10 at 8 33 02 AM" src="https://user-images.githubusercontent.com/439947/132855760-a8e548d4-27f1-44f2-85fa-deca127af034.png">

_Note:_ In doing this work, I noticed that the `ShareAnnotationsPanel` doesn't put focus on the text-input field when opened (this pre-existed these changes). I will track that separately, as it should be done as part of migrating the panel to a (non-modal) Dialog overall for focus control, and that in turn has a couple of dependencies.