### PR TITLE
Improve speed of the Hypothesis client injection

### DIFF
--- a/src/annotator/frame-observer.js
+++ b/src/annotator/frame-observer.js
@@ -108,7 +108,7 @@ export class FrameObserver {
  * @throws {Error} if trying to access a document from a cross-origin iframe
  */
 export function onDocumentReady(frame) {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     // @ts-expect-error
     const frameDocument = frame.contentWindow.document;
     const { readyState, location } = frameDocument;
@@ -124,11 +124,7 @@ export function onDocumentReady(frame) {
       frame.hasAttribute('src') &&
       frame.src !== 'about:blank'
     ) {
-      // Unfortunately, listening for 'DOMContentLoaded' on the iframeDocument
-      // doesn't work. Instead, we need to wait for a 'load' event to be triggered.
-      frame.addEventListener('load', () => {
-        resolve();
-      });
+      setTimeout(() => onDocumentReady(frame).then(resolve).catch(reject), 10);
       return;
     }
 

--- a/src/annotator/test/frame-observer-test.js
+++ b/src/annotator/test/frame-observer-test.js
@@ -140,10 +140,16 @@ describe('annotator/frame-observer', () => {
     it("doesn't trigger onFrameAdded when annotatable iframe is from a different domain", async () => {
       const iframe = createAnnotatableIFrame();
       iframe.setAttribute('src', 'http://cross-origin.dummy');
+      let expectedError;
 
-      await onDocumentReady(iframe);
+      try {
+        await onDocumentReady(iframe);
+      } catch (error) {
+        expectedError = error;
+      }
       await waitForFrameObserver();
 
+      assert.isDefined(expectedError);
       assert.notCalled(onFrameAdded);
       assert.calledOnce(console.warn);
     });
@@ -170,13 +176,14 @@ describe('annotator/frame-observer', () => {
       fakeIFrame.setAttribute('src', 'http://my.dummy');
     });
 
-    it('waits for the iframe load event to be triggered if the document is blank', () => {
+    it('waits for the iframe to change the location and readyState if the initial document is blank', () => {
       fakeIFrameDocument.location.href = 'about:blank';
-      const onLoad = onDocumentReady(fakeIFrame);
+      const onReady = onDocumentReady(fakeIFrame);
 
-      fakeIFrame.dispatchEvent(new Event('load'));
+      fakeIFrameDocument.location.href = 'http://my.dummy';
+      fakeIFrameDocument.readyState = 'complete';
 
-      return onLoad;
+      return onReady;
     });
 
     it('waits for the iframe DOMContentLoaded event to be triggered if the document is loading', () => {


### PR DESCRIPTION
For big documents the `window.onload` event can take a while to trigger.
The Hypothesis client can be injected as soon as the document is in
`readyState === 'interactive'`, or when DOMContentLoaded` is fired,
which is the same.

In this PR instead of waiting for `window.onload`, we use a polling
logic to check the `readyState` or to default to the `DOMContentLoaded`
event.

For a medium document, on Chrome, I have noticed the logic improves the
speed by 200ms (from 791ms to 564ms). I didn't observe improvements on
Firefox and Safari (both are substantially faster than Chrome). On large
documents, this new logic should result in speed improvement, on all web
browsers.