### PR TITLE
Use maps for PDF text and anchoring caches

### DIFF
--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -179,7 +179,7 @@ export async function documentHasText() {
 function getPageTextContent(pageIndex) {
   // If we already have or are fetching the text for this page, return the
   // existing result.
-  const cachedText = pageTextCache[pageIndex];
+  const cachedText = pageTextCache.get(pageIndex);
   if (cachedText) {
     return cachedText;
   }

--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -42,7 +42,7 @@ export const RenderingStates = {
 /**
  * Map of page index to page text content.
  *
- * @type {Map<number,Promise<string> | undefined>}
+ * @type {Map<number, Promise<string>>}
  */
 const pageTextCache = new Map();
 


### PR DESCRIPTION
Using maps is a little faster and avoids the need for `hasOwnProperty` checks (which we weren't doing, but probably should have). The quote position cache has been converted to a single level map as this is more ergonomic to work with and the second level maps almost always had exactly one entry in them.