### PR TITLE
Improve visibility of focused PDF highlights

### DIFF
--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -331,6 +331,16 @@ export function setHighlightsFocused(highlights, focused) {
     // `<hypothesis-highlight>` element.
     if (h.svgHighlight) {
       h.svgHighlight.classList.toggle('is-focused', focused);
+
+      // Ensure that focused highlights are drawn above un-focused highlights
+      // on the same page.
+      //
+      // SVG elements are rendered in document order so to achieve this we need
+      // to move the element to be the last child of its parent.
+      if (focused) {
+        const parent = /** @type {SVGElement} */ (h.svgHighlight.parentNode);
+        parent.append(h.svgHighlight);
+      }
     } else {
       h.classList.toggle('hypothesis-highlight-focused', focused);
     }

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -485,6 +485,23 @@ describe('annotator/highlighter', () => {
       );
     });
 
+    it('raises focused highlights in PDFs', () => {
+      const root = document.createElement('div');
+      render(<PdfPage />, root);
+      const highlights1 = highlightPdfRange(root);
+      const highlights2 = highlightPdfRange(root);
+      const svgLayer = root.querySelector('svg');
+
+      const lastSVGHighlight = highlights =>
+        highlights[highlights.length - 1].svgHighlight;
+
+      setHighlightsFocused(highlights1, true);
+      assert.equal(svgLayer.lastChild, lastSVGHighlight(highlights1));
+
+      setHighlightsFocused(highlights2, true);
+      assert.equal(svgLayer.lastChild, lastSVGHighlight(highlights2));
+    });
+
     it('removes class from PDF highlights when not focused', () => {
       const root = document.createElement('div');
       render(<PdfPage />, root);


### PR DESCRIPTION
When the same text is highlighted multiple times in a PDF, it can be hard to
distinguish focused highlights as the `<rect>`s for focused highlights
could be obscured by `<rect>`s for overlapping unfocused highlights.

SVG elements are painted in the order they appear in the document and don't
yet support a z-index property [1], so this commit fixes the issue by moving
`<rect>`s to be last amongst siblings when focused.

[1] The SVG 2 spec does support a z-index attribute, but none of the major
    browsers support it yet. See https://bugs.webkit.org/show_bug.cgi?id=90738,
    https://bugs.chromium.org/p/chromium/issues/detail?id=670177 and
    https://bugzilla.mozilla.org/show_bug.cgi?id=360148.

---

These screenshots show the effect on text that has several (3+) overlapping highlights. The annotation card on the right corresponds to the first highlight from this set which is drawn first.

**All highlights unfocused:**

<img width="1130" alt="PDF highlight unfocused" src="https://user-images.githubusercontent.com/2458/133204746-d6e2eb9b-fb57-4a44-b352-275a1beea461.png">

**Bottom highlight focused (before):**

<img width="1147" alt="PDF highlight focused - original" src="https://user-images.githubusercontent.com/2458/133204765-d44755f7-c1de-4ae0-b0dc-aa89e0cbbdbb.png">

The blue color for the focused highlight is obscured by the yellow unfocused highlights drawn above it.

**Bottom highlight focused (after):**

<img width="1149" alt="PDF highlight focused - improved" src="https://user-images.githubusercontent.com/2458/133205060-4a5c5ebd-c9c9-4b85-adfc-f73c56c494f0.png">

The focused highlight's SVG `<rect>` has been moved to the top of the z-index so it is now easier to see.