### PR TITLE
Prevent sidebar controls overlapping scrollbar in PDFs

### DIFF
--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -319,8 +319,17 @@ export class PDFIntegration {
     const maximumWidthToFit = window.innerWidth - sidebarLayout.width;
     const active = sidebarLayout.expanded && maximumWidthToFit >= MIN_PDF_WIDTH;
 
-    this.pdfContainer.style.width = active ? maximumWidthToFit + 'px' : 'auto';
-    this.pdfContainer.classList.toggle('hypothesis-side-by-side', active);
+    // If the sidebar is closed we reserve enough space for the toolbar controls
+    // so that they don't overlap a) the chevron-menu on the right side of
+    // PDF.js's top toolbar and b) the document's scrollbar.
+    //
+    // If the sidebar is open we reserve space for the whole sidebar if there is
+    // room, otherwise we reserve the same space as in the closed state to
+    // prevent the PDF content shifting when opening and closing the sidebar.
+    const reservedSpace = active
+      ? sidebarLayout.width
+      : sidebarLayout.toolbarWidth;
+    this.pdfContainer.style.width = `calc(100% - ${reservedSpace}px)`;
 
     // The following logic is pulled from PDF.js `webViewerResize`
     const currentScaleValue = this.pdfViewer.currentScaleValue;

--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -319,11 +319,11 @@ export class PDFIntegration {
     const maximumWidthToFit = window.innerWidth - sidebarLayout.width;
     const active = sidebarLayout.expanded && maximumWidthToFit >= MIN_PDF_WIDTH;
 
-    // If the sidebar is closed we reserve enough space for the toolbar controls
+    // If the sidebar is closed, we reserve enough space for the toolbar controls
     // so that they don't overlap a) the chevron-menu on the right side of
     // PDF.js's top toolbar and b) the document's scrollbar.
     //
-    // If the sidebar is open we reserve space for the whole sidebar if there is
+    // If the sidebar is open, we reserve space for the whole sidebar if there is
     // room, otherwise we reserve the same space as in the closed state to
     // prevent the PDF content shifting when opening and closing the sidebar.
     const reservedSpace = active

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -312,7 +312,7 @@ describe('PDFIntegration', () => {
 
       assert.isTrue(active);
       assert.calledOnce(fakePDFViewerApplication.pdfViewer.update);
-      assert.equal(pdfContainer().style.width, 1350 - 428 + 'px');
+      assert.equal(pdfContainer().style.width, 'calc(100% - 428px)');
     });
 
     /**
@@ -336,7 +336,7 @@ describe('PDFIntegration', () => {
 
         assert.isTrue(active);
         assert.calledOnce(fakePDFViewerApplication.pdfViewer.update);
-        assert.equal(pdfContainer().style.width, 1350 - 428 + 'px');
+        assert.equal(pdfContainer().style.width, 'calc(100% - 428px)');
       });
     });
 
@@ -348,10 +348,11 @@ describe('PDFIntegration', () => {
         expanded: false,
         width: 428,
         height: 728,
+        toolbarWidth: 115,
       });
 
       assert.isFalse(active);
-      assert.equal(pdfContainer().style.width, 'auto');
+      assert.equal(pdfContainer().style.width, 'calc(100% - 115px)');
     });
 
     it('does not activate side-by-side mode if there is not enough room', () => {
@@ -362,11 +363,12 @@ describe('PDFIntegration', () => {
         expanded: true,
         width: 428,
         height: 728,
+        toolbarWidth: 115,
       });
 
       assert.isFalse(active);
       assert.calledOnce(fakePDFViewerApplication.pdfViewer.update);
-      assert.equal(pdfContainer().style.width, 'auto');
+      assert.equal(pdfContainer().style.width, 'calc(100% - 115px)');
     });
   });
 

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -13,12 +13,7 @@ import { createShadowRoot } from './util/shadow-root';
 
 /**
  * @typedef {import('./guest').default} Guest
- *
- * @typedef LayoutState
- * @prop {boolean} expanded
- * @prop {number} width
- * @prop {number} height
- *
+ * @typedef {import('../types/annotator').SidebarLayout} SidebarLayout
  * @typedef {import('../types/annotator').Destroyable} Destroyable
  */
 
@@ -349,10 +344,11 @@ export default class Sidebar {
       expanded = frameVisibleWidth > toolbarWidth;
     }
 
-    const layoutState = /** @type LayoutState */ ({
+    const layoutState = /** @type {SidebarLayout} */ ({
       expanded,
       width: expanded ? frameVisibleWidth : toolbarWidth,
       height: rect.height,
+      toolbarWidth,
     });
 
     if (this.onLayoutChange) {

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -653,14 +653,14 @@ describe('Sidebar', () => {
     let layoutChangeHandlerSpy;
 
     const assertLayoutValues = (args, expectations) => {
-      const expected = Object.assign(
-        {
-          width: DEFAULT_WIDTH + fakeToolbar.getWidth(),
-          height: DEFAULT_HEIGHT,
-          expanded: true,
-        },
-        expectations
-      );
+      const expected = {
+        width: DEFAULT_WIDTH + fakeToolbar.getWidth(),
+        height: DEFAULT_HEIGHT,
+        expanded: true,
+        toolbarWidth: fakeToolbar.getWidth(),
+
+        ...expectations,
+      };
 
       assert.deepEqual(args, expected);
     };
@@ -800,6 +800,7 @@ describe('Sidebar', () => {
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
           expanded: true,
           width: DEFAULT_WIDTH,
+          toolbarWidth: 0,
         });
 
         sidebar.close();
@@ -807,6 +808,7 @@ describe('Sidebar', () => {
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
           expanded: false,
           width: 0,
+          toolbarWidth: 0,
         });
       });
 

--- a/src/styles/annotator/pdfjs-overrides.scss
+++ b/src/styles/annotator/pdfjs-overrides.scss
@@ -21,15 +21,3 @@
 .textLayer .highlight.selected {
   background-color: rgba(0, 100, 0, 0.5);
 }
-
-// Make sure sidebar bucket bar/toolbar don't obscure PDF JS tools menu
-// This gives enough room for `.annotator-frame-button` which uses a hard-coded
-// width of 30px
-#toolbarViewer {
-  margin-right: 30px;
-}
-
-// The affordance is not needed in side-by-side mode
-.hypothesis-side-by-side #toolbarViewer {
-  margin-right: 0;
-}

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -81,6 +81,8 @@
  * @typedef SidebarLayout
  * @prop {boolean} expanded - Whether sidebar is open or closed
  * @prop {number} width - Current width of sidebar in pixels
+ * @prop {number} toolbarWidth - Width of controls (toolbar, bucket bar) on the
+ *   edge of the sidebar.
  */
 
 /**


### PR DESCRIPTION
When the sidebar is closed or there is not enough room to show the
sidebar alongside the PDF content, reserve space for the sidebar's
toolbar and bucket bar. This fixes an issue where the sidebar's controls
would overlap the document's scrollbar, making scrolling the PDF less
convenient, especially in long documents.

This also removes the need for some CSS overrides that reposition
elements in PDF.js's toolbar. By ensuring that the `<body>` does not
overlap the sidebar controls, the PDF.js toolbar which is contained
within the body doesn't either.

Fixes #3759