### PR TITLE
Set `baseURL` for pattern library

### DIFF
--- a/dev-server/ui-playground/index.js
+++ b/dev-server/ui-playground/index.js
@@ -13,4 +13,4 @@ const extraRoutes = [
   },
 ];
 
-startApp({ extraRoutes, icons: sidebarIcons });
+startApp({ baseURL: '/ui-playground', extraRoutes, icons: sidebarIcons });


### PR DESCRIPTION
The pattern library no longer serves by default at `/ui-playground`, so we need to set a `baseURL`.

This will make the pattern library available again when running the local dev server via the link on the landing page at http://localhost:3000/