### PR TITLE
Replace deprecated method `String.prototype.substr`

### DIFF
--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -533,9 +533,8 @@ export async function anchor(root, selectors) {
       const { index, offset, text } = await findPageByOffset(position.start);
       const start = position.start - offset;
       const end = position.end - offset;
-      const length = end - start;
 
-      const matchedText = text.substr(start, length);
+      const matchedText = text.substring(start, end);
       if (quote.exact !== matchedText) {
         throw new Error('quote mismatch');
       }


### PR DESCRIPTION
`String.protoype.substr` is a deprecated method (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr). It is recommended to be replaced by `String.prototype.substring` method (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring).