### PR TITLE
Prevent long quoted excerpts from breaking layout in Notebook

### DIFF
--- a/src/styles/sidebar/components/NotebookView.scss
+++ b/src/styles/sidebar/components/NotebookView.scss
@@ -5,8 +5,10 @@
 .NotebookView {
   display: grid;
   row-gap: var.$layout-space--small;
+
   // See https://css-tricks.com/preventing-a-grid-blowout/
   grid-template-columns: minmax(0, auto);
+
   grid-template-areas:
     'heading'
     'filters'
@@ -42,6 +44,9 @@
       'heading heading'
       'filters results'
       'items items';
+
+    // See https://css-tricks.com/preventing-a-grid-blowout/
+    grid-template-columns: minmax(0, auto) minmax(0, auto);
 
     &__filters {
       justify-self: start;


### PR DESCRIPTION
Because of the sometimes-arcane nature of grid layouts, it is sometimes
necessary to apply definite width values on grid areas (versus `auto`)
to prevent content from escaping. 

This fixes a situation in which very long unbroken quoted excerpts could
blow out the layout width in the Notebook.

I'm not going to pretend I fully understand this (even Chris Coyier admits the same in his explanation: See https://css-tricks.com/preventing-a-grid-blowout/)

Before:

![image](https://user-images.githubusercontent.com/439947/135291297-9f642ff7-9ba1-4e4c-b27f-be941b6788e3.png)

After:

![image](https://user-images.githubusercontent.com/439947/135291242-f32cc4fc-0c07-44cc-a575-592358b3e977.png)



Fixes https://github.com/hypothesis/private-issues/issues/67 (private repo)

