### PR TITLE
Unify all `delay` functions into a common test utility

### DIFF
--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -1,3 +1,4 @@
+import { delay } from '../../../test-util/wait';
 import * as pdfAnchoring from '../pdf';
 import { matchQuote } from '../match-quote';
 import { TextRange } from '../text-range';
@@ -17,10 +18,6 @@ function findText(container, text) {
     throw new Error('Text not found');
   }
   return TextRange.fromOffsets(container, pos, pos + text.length).toRange();
-}
-
-function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 const fixtures = {

--- a/src/annotator/integrations/test/pdf-metadata-test.js
+++ b/src/annotator/integrations/test/pdf-metadata-test.js
@@ -1,5 +1,6 @@
 import EventEmitter from 'tiny-emitter';
 
+import { delay } from '../../../test-util/wait';
 import { PDFMetadata } from '../pdf-metadata';
 
 /**
@@ -155,10 +156,6 @@ class FakePDFViewerApplication {
   completeInit() {
     this._resolveInitializedPromise();
   }
-}
-
-function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 describe('PDFMetadata', () => {

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -1,12 +1,8 @@
-import { PDFIntegration, isPDF, $imports } from '../pdf';
-
+import { delay } from '../../../test-util/wait';
 import FakePDFViewerApplication from '../../anchoring/test/fake-pdf-viewer-application';
 import { RenderingStates } from '../../anchoring/pdf';
 import { createPlaceholder } from '../../anchoring/placeholder';
-
-function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
+import { PDFIntegration, isPDF, $imports } from '../pdf';
 
 function awaitEvent(target, eventName) {
   return new Promise(resolve => {

--- a/src/sidebar/components/GroupList/test/GroupListItem-test.js
+++ b/src/sidebar/components/GroupList/test/GroupListItem-test.js
@@ -1,11 +1,8 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
+import { delay } from '../../../../test-util/wait';
 import GroupListItem, { $imports } from '../GroupListItem';
-
-function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
 
 describe('GroupListItem', () => {
   let fakeConfirm;

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -1,6 +1,6 @@
+import { delay, waitFor } from '../../../test-util/wait';
 import fakeReduxStore from '../../test/fake-redux-store';
 import { GroupsService, $imports } from '../groups';
-import { waitFor } from '../../../test-util/wait';
 
 /**
  * Generate a truth table containing every possible combination of a set of
@@ -837,8 +837,6 @@ describe('GroupsService', () => {
       });
     });
   });
-
-  const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
   describe('automatic re-fetching', () => {
     it('refetches groups when the logged-in user changes', async () => {

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -1,5 +1,6 @@
 import EventEmitter from 'tiny-emitter';
 
+import { delay } from '../../../test-util/wait';
 import fakeReduxStore from '../../test/fake-redux-store';
 import { StreamerService, $imports } from '../streamer';
 
@@ -251,10 +252,6 @@ describe('StreamerService', () => {
   });
 
   describe('Automatic reconnection', () => {
-    function delay(ms) {
-      return new Promise(resolve => setTimeout(resolve, ms));
-    }
-
     it('should reconnect when user changes', () => {
       let oldWebSocket;
       createDefaultStreamer();

--- a/src/sidebar/test/search-client-test.js
+++ b/src/sidebar/test/search-client-test.js
@@ -1,13 +1,10 @@
+import { delay } from '../../test-util/wait';
 import { ResultSizeError, SearchClient } from '../search-client';
 
 function awaitEvent(emitter, event) {
   return new Promise(resolve => {
     emitter.on(event, resolve);
   });
-}
-
-function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 const RESULTS = [

--- a/src/test-util/wait.js
+++ b/src/test-util/wait.js
@@ -32,3 +32,8 @@ export async function waitFor(
     });
   });
 }
+
+/** @param {number} ms */
+export function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Although the `delay` utility function is a small function that can
almost be in-lined, I decided to create a common `delay` function in
`wait.js` and replace all usage in tests by the new function.