### PR TITLE
Convert CommonJS requires in tests to ES imports

### DIFF
--- a/src/annotator/anchoring/test/html-baselines/index.js
+++ b/src/annotator/anchoring/test/html-baselines/index.js
@@ -21,15 +21,21 @@
 //     them as `<fixture name>.json` in this directory
 //  4. Add an entry to the fixture list below.
 
+import minimalDoc from './minimal.html';
+import minimalJSON from './minimal.json';
+
+import wikipediaDoc from './wikipedia-regression-testing.html';
+import wikipediaJSON from './wikipedia-regression-testing.json';
+
 export default [
   {
     name: 'Minimal Document',
-    html: require('./minimal.html'),
-    annotations: require('./minimal.json'),
+    html: minimalDoc,
+    annotations: minimalJSON,
   },
   {
     name: 'Wikipedia - Regression Testing',
-    html: require('./wikipedia-regression-testing.html'),
-    annotations: require('./wikipedia-regression-testing.json'),
+    html: wikipediaDoc,
+    annotations: wikipediaJSON,
   },
 ];

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -4,6 +4,7 @@
 import Guest from '../../guest';
 import { $imports as guestImports } from '../../guest';
 import { EventBus } from '../../util/emitter';
+import testPageHTML from './test-page.html';
 
 function quoteSelector(quote) {
   return {
@@ -64,7 +65,7 @@ describe('anchoring', () => {
   beforeEach(() => {
     sinon.stub(console, 'warn');
     container = document.createElement('div');
-    container.innerHTML = require('./test-page.html');
+    container.innerHTML = testPageHTML;
     document.body.appendChild(container);
     const eventBus = new EventBus();
     guest = new Guest(container, eventBus);

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -11,7 +11,8 @@ import { APIService } from '../api';
 //
 // `curl https://hypothes.is/api/ | sed 's/hypothes.is/example.com/g' | jq . > api-index.json`
 //
-const routes = require('./api-index.json').links;
+import apiIndex from './api-index.json';
+const routes = apiIndex.links;
 
 describe('APIService', () => {
   let fakeAuth;

--- a/src/sidebar/test/websocket-test.js
+++ b/src/sidebar/test/websocket-test.js
@@ -25,7 +25,7 @@ describe('websocket wrapper', () => {
   const WebSocket = window.WebSocket;
 
   beforeEach(() => {
-    global.WebSocket = FakeWebSocket;
+    globalThis.WebSocket = FakeWebSocket;
     clock = sinon.useFakeTimers();
     connectionCount = 0;
 
@@ -36,7 +36,7 @@ describe('websocket wrapper', () => {
   });
 
   afterEach(() => {
-    global.WebSocket = WebSocket;
+    globalThis.WebSocket = WebSocket;
     clock.restore();
     console.warn.restore();
     console.error.restore();


### PR DESCRIPTION
In preparation for modernizing the client's module bundling, convert remaining CommonJS `require` statements in tests to ES imports.

I also replaced a reference to the Node-specific `global` variable with ES-standard `globalThis` as a way to access the global object.