### PR TITLE
Change default export to name export

### DIFF
--- a/src/annotator/annotation-counts.js
+++ b/src/annotator/annotation-counts.js
@@ -1,4 +1,4 @@
-import events from '../shared/bridge-events';
+import { bridgeEvents } from '../shared/bridge-events';
 
 const ANNOTATION_COUNT_ATTR = 'data-hypothesis-annotation-count';
 
@@ -12,7 +12,7 @@ const ANNOTATION_COUNT_ATTR = 'data-hypothesis-annotation-count';
 
 export default function annotationCounts(rootEl, crossframe) {
   crossframe.on(
-    events.PUBLIC_ANNOTATION_COUNT_CHANGED,
+    bridgeEvents.PUBLIC_ANNOTATION_COUNT_CHANGED,
     updateAnnotationCountElems
   );
 

--- a/src/annotator/features.js
+++ b/src/annotator/features.js
@@ -1,4 +1,4 @@
-import events from '../shared/bridge-events';
+import { bridgeEvents } from '../shared/bridge-events';
 import warnOnce from '../shared/warn-once';
 
 let _features = {};
@@ -9,7 +9,7 @@ const _set = features => {
 
 export default {
   init: function (crossframe) {
-    crossframe.on(events.FEATURE_FLAGS_UPDATED, _set);
+    crossframe.on(bridgeEvents.FEATURE_FLAGS_UPDATED, _set);
   },
 
   reset: function () {

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -1,7 +1,7 @@
 import Hammer from 'hammerjs';
 
 import { Bridge } from '../shared/bridge';
-import events from '../shared/bridge-events';
+import { bridgeEvents } from '../shared/bridge-events';
 import { ListenerCollection } from '../shared/listener-collection';
 
 import annotationCounts from './annotation-counts';
@@ -253,11 +253,11 @@ export default class Sidebar {
     });
 
     const eventHandlers = [
-      [events.LOGIN_REQUESTED, this.onLoginRequest],
-      [events.LOGOUT_REQUESTED, this.onLogoutRequest],
-      [events.SIGNUP_REQUESTED, this.onSignupRequest],
-      [events.PROFILE_REQUESTED, this.onProfileRequest],
-      [events.HELP_REQUESTED, this.onHelpRequest],
+      [bridgeEvents.LOGIN_REQUESTED, this.onLoginRequest],
+      [bridgeEvents.LOGOUT_REQUESTED, this.onLogoutRequest],
+      [bridgeEvents.SIGNUP_REQUESTED, this.onSignupRequest],
+      [bridgeEvents.PROFILE_REQUESTED, this.onProfileRequest],
+      [bridgeEvents.HELP_REQUESTED, this.onHelpRequest],
     ];
     eventHandlers.forEach(([event, handler]) => {
       if (handler) {

--- a/src/annotator/test/features-test.js
+++ b/src/annotator/test/features-test.js
@@ -1,4 +1,4 @@
-import events from '../../shared/bridge-events';
+import { bridgeEvents } from '../../shared/bridge-events';
 import features from '../features';
 import { $imports } from '../features';
 
@@ -23,7 +23,7 @@ describe('features - annotation layer', () => {
 
     features.init({
       on: function (topic, handler) {
-        if (topic === events.FEATURE_FLAGS_UPDATED) {
+        if (topic === bridgeEvents.FEATURE_FLAGS_UPDATED) {
           featureFlagsUpdateHandler = handler;
         }
       },

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -1,4 +1,4 @@
-import events from '../../shared/bridge-events';
+import { bridgeEvents } from '../../shared/bridge-events';
 
 import Sidebar, { MIN_RESIZE } from '../sidebar';
 import { $imports } from '../sidebar';
@@ -366,7 +366,7 @@ describe('Sidebar', () => {
         const onLoginRequest = sandbox.stub();
         createSidebar({ services: [{ onLoginRequest }] });
 
-        emitEvent(events.LOGIN_REQUESTED);
+        emitEvent(bridgeEvents.LOGIN_REQUESTED);
 
         assert.called(onLoginRequest);
       });
@@ -386,7 +386,7 @@ describe('Sidebar', () => {
           ],
         });
 
-        emitEvent(events.LOGIN_REQUESTED);
+        emitEvent(bridgeEvents.LOGIN_REQUESTED);
 
         assert.called(firstOnLogin);
         assert.notCalled(secondOnLogin);
@@ -406,7 +406,7 @@ describe('Sidebar', () => {
           ],
         });
 
-        emitEvent(events.LOGIN_REQUESTED);
+        emitEvent(bridgeEvents.LOGIN_REQUESTED);
 
         assert.notCalled(secondOnLogin);
         assert.notCalled(thirdOnLogin);
@@ -414,17 +414,17 @@ describe('Sidebar', () => {
 
       it('does not crash if there is no services', () => {
         createSidebar(); // No config.services
-        emitEvent(events.LOGIN_REQUESTED);
+        emitEvent(bridgeEvents.LOGIN_REQUESTED);
       });
 
       it('does not crash if services is an empty array', () => {
         createSidebar({ services: [] });
-        emitEvent(events.LOGIN_REQUESTED);
+        emitEvent(bridgeEvents.LOGIN_REQUESTED);
       });
 
       it('does not crash if the first service has no onLoginRequest', () => {
         createSidebar({ services: [{}] });
-        emitEvent(events.LOGIN_REQUESTED);
+        emitEvent(bridgeEvents.LOGIN_REQUESTED);
       });
     });
 
@@ -433,7 +433,7 @@ describe('Sidebar', () => {
         const onLogoutRequest = sandbox.stub();
         createSidebar({ services: [{ onLogoutRequest }] });
 
-        emitEvent(events.LOGOUT_REQUESTED);
+        emitEvent(bridgeEvents.LOGOUT_REQUESTED);
 
         assert.called(onLogoutRequest);
       }));
@@ -443,7 +443,7 @@ describe('Sidebar', () => {
         const onSignupRequest = sandbox.stub();
         createSidebar({ services: [{ onSignupRequest }] });
 
-        emitEvent(events.SIGNUP_REQUESTED);
+        emitEvent(bridgeEvents.SIGNUP_REQUESTED);
 
         assert.called(onSignupRequest);
       }));
@@ -453,7 +453,7 @@ describe('Sidebar', () => {
         const onProfileRequest = sandbox.stub();
         createSidebar({ services: [{ onProfileRequest }] });
 
-        emitEvent(events.PROFILE_REQUESTED);
+        emitEvent(bridgeEvents.PROFILE_REQUESTED);
 
         assert.called(onProfileRequest);
       }));
@@ -463,7 +463,7 @@ describe('Sidebar', () => {
         const onHelpRequest = sandbox.stub();
         createSidebar({ services: [{ onHelpRequest }] });
 
-        emitEvent(events.HELP_REQUESTED);
+        emitEvent(bridgeEvents.HELP_REQUESTED);
 
         assert.called(onHelpRequest);
       }));

--- a/src/shared/bridge-events.js
+++ b/src/shared/bridge-events.js
@@ -2,7 +2,7 @@
  * This module defines the set of global events that are dispatched
  * across the bridge between the sidebar and annotator
  */
-export default {
+export const bridgeEvents = {
   // Events that the sidebar sends to the annotator
   // ----------------------------------------------
 

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import { useEffect, useMemo } from 'preact/hooks';
 
-import bridgeEvents from '../../shared/bridge-events';
+import { bridgeEvents } from '../../shared/bridge-events';
 import { confirm } from '../../shared/prompts';
 import { serviceConfig } from '../config/service-config';
 import { useStoreProxy } from '../store/use-store';

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -1,6 +1,6 @@
 import { IconButton, LinkButton } from '@hypothesis/frontend-shared';
 
-import bridgeEvents from '../../shared/bridge-events';
+import { bridgeEvents } from '../../shared/bridge-events';
 import { serviceConfig } from '../config/service-config';
 import { useStoreProxy } from '../store/use-store';
 import { isThirdPartyService } from '../helpers/is-third-party-service';

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -1,7 +1,7 @@
 import { SvgIcon } from '@hypothesis/frontend-shared';
 import { useState } from 'preact/hooks';
 
-import bridgeEvents from '../../shared/bridge-events';
+import { bridgeEvents } from '../../shared/bridge-events';
 import { serviceConfig } from '../config/service-config';
 import { isThirdPartyUser } from '../helpers/account-id';
 import { useStoreProxy } from '../store/use-store';

--- a/src/sidebar/components/test/HypothesisApp-test.js
+++ b/src/sidebar/components/test/HypothesisApp-test.js
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 
-import bridgeEvents from '../../../shared/bridge-events';
+import { bridgeEvents } from '../../../shared/bridge-events';
 import mockImportedComponents from '../../../test-util/mock-imported-components';
 
 import HypothesisApp, { $imports } from '../HypothesisApp';

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 
-import bridgeEvents from '../../../shared/bridge-events';
+import { bridgeEvents } from '../../../shared/bridge-events';
 import TopBar from '../TopBar';
 import { $imports } from '../TopBar';
 

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import bridgeEvents from '../../../shared/bridge-events';
+import { bridgeEvents } from '../../../shared/bridge-events';
 import UserMenu from '../UserMenu';
 import { $imports } from '../UserMenu';
 

--- a/src/sidebar/services/features.js
+++ b/src/sidebar/services/features.js
@@ -1,4 +1,4 @@
-import bridgeEvents from '../../shared/bridge-events';
+import { bridgeEvents } from '../../shared/bridge-events';
 import { watch } from '../util/watch';
 
 /**

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -1,6 +1,6 @@
 import debounce from 'lodash.debounce';
 
-import bridgeEvents from '../../shared/bridge-events';
+import { bridgeEvents } from '../../shared/bridge-events';
 import { Bridge } from '../../shared/bridge';
 import { isReply, isPublic } from '../helpers/annotation-metadata';
 import { watch } from '../util/watch';

--- a/src/sidebar/services/test/features-test.js
+++ b/src/sidebar/services/test/features-test.js
@@ -1,4 +1,4 @@
-import bridgeEvents from '../../../shared/bridge-events';
+import { bridgeEvents } from '../../../shared/bridge-events';
 import { FeaturesService } from '../features';
 
 describe('FeaturesService', () => {


### PR DESCRIPTION
As per team conventions, we only use default exports for Preact
components.