### PR TITLE
Rename `crossframe` to `bridge` on `annotationCounts` function

### DIFF
--- a/src/annotator/annotation-counts.js
+++ b/src/annotator/annotation-counts.js
@@ -4,17 +4,15 @@ const ANNOTATION_COUNT_ATTR = 'data-hypothesis-annotation-count';
 
 /**
  * Update the elements in the container element with the count data attribute
- * with the new annotation count.
+ * with the new annotation count. See:
+ * https://h.readthedocs.io/projects/client/en/latest/publishers/host-page-integration/#cmdoption-arg-data-hypothesis-annotation-count
  *
  * @param {Element} rootEl - The DOM element which contains the elements that
- * display annotation count.
+ *   display annotation count.
+ * @param {import('../shared/bridge').Bridge} bridge - Channel for host-sidebar communication
  */
-
-export default function annotationCounts(rootEl, crossframe) {
-  crossframe.on(
-    events.PUBLIC_ANNOTATION_COUNT_CHANGED,
-    updateAnnotationCountElems
-  );
+export function annotationCounts(rootEl, bridge) {
+  bridge.on(events.PUBLIC_ANNOTATION_COUNT_CHANGED, updateAnnotationCountElems);
 
   function updateAnnotationCountElems(newCount) {
     const elems = rootEl.querySelectorAll('[' + ANNOTATION_COUNT_ATTR + ']');

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -4,7 +4,7 @@ import { Bridge } from '../shared/bridge';
 import events from '../shared/bridge-events';
 import { ListenerCollection } from '../shared/listener-collection';
 
-import annotationCounts from './annotation-counts';
+import { annotationCounts } from './annotation-counts';
 import BucketBar from './bucket-bar';
 import { createSidebarConfig } from './config/sidebar';
 import features from './features';

--- a/src/annotator/test/annotation-counts-test.js
+++ b/src/annotator/test/annotation-counts-test.js
@@ -1,4 +1,4 @@
-import annotationCounts from '../annotation-counts';
+import { annotationCounts } from '../annotation-counts';
 
 describe('annotationCounts', () => {
   let countEl1;


### PR DESCRIPTION
Follow up of https://github.com/hypothesis/client/pull/3807

* reference to the `crossframe` service is inaccurate
* changed default export to a named export, as per team conventions