### PR TITLE
Rename `crossframe` to `bridge` on `features` object 

### DIFF
--- a/src/annotator/features.js
+++ b/src/annotator/features.js
@@ -7,9 +7,12 @@ const _set = features => {
   _features = features || {};
 };
 
-export default {
-  init: function (crossframe) {
-    crossframe.on(events.FEATURE_FLAGS_UPDATED, _set);
+export const features = {
+  /**
+   * @param {import('../shared/bridge').Bridge} bridge - Channel for host-sidebar communication
+   */
+  init: function (bridge) {
+    bridge.on(events.FEATURE_FLAGS_UPDATED, _set);
   },
 
   reset: function () {

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -7,7 +7,7 @@ import { ListenerCollection } from '../shared/listener-collection';
 import annotationCounts from './annotation-counts';
 import BucketBar from './bucket-bar';
 import { createSidebarConfig } from './config/sidebar';
-import features from './features';
+import { features } from './features';
 import sidebarTrigger from './sidebar-trigger';
 import { ToolbarController } from './toolbar';
 import { createShadowRoot } from './util/shadow-root';

--- a/src/annotator/test/features-test.js
+++ b/src/annotator/test/features-test.js
@@ -1,6 +1,5 @@
 import events from '../../shared/bridge-events';
-import features from '../features';
-import { $imports } from '../features';
+import { features, $imports } from '../features';
 
 describe('features - annotation layer', () => {
   let featureFlagsUpdateHandler;


### PR DESCRIPTION
Follow up of https://github.com/hypothesis/client/pull/3807

* reference to the `crossframe` service is inaccurate
* changed default export to a named export, as per team conventions