### PR TITLE
Replace `panelReady` event for triggering initial sidebar display

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -166,7 +166,6 @@ export default class Guest {
     // Set up listeners for messages coming from the sidebar to this guest.
     this._bridge = new Bridge();
     this._bridge.onConnect(() => {
-      this._emitter.publish('panelReady');
       this.setVisibleHighlights(config.showHighlights === 'always');
     });
     this._connectSidebarEvents();

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -110,13 +110,6 @@ export default class Sidebar {
 
     this._listeners = new ListenerCollection();
 
-    this._emitter.subscribe('panelReady', () => {
-      // Show the UI
-      if (this.iframeContainer) {
-        this.iframeContainer.style.display = '';
-      }
-    });
-
     this._emitter.subscribe('beforeAnnotationCreated', annotation => {
       // When a new non-highlight annotation is created, focus
       // the sidebar so that the text editor can be focused as
@@ -125,15 +118,6 @@ export default class Sidebar {
         /** @type {Window} */ (this.iframe.contentWindow).focus();
       }
     });
-
-    if (
-      config.openSidebar ||
-      config.annotations ||
-      config.query ||
-      config.group
-    ) {
-      this._emitter.subscribe('panelReady', () => this.open());
-    }
 
     // Set up the toolbar on the left edge of the sidebar.
     const toolbarContainer = document.createElement('div');
@@ -208,6 +192,22 @@ export default class Sidebar {
           resolve();
         }
       });
+    });
+
+    this.ready.then(() => {
+      // Show the UI
+      if (this.iframeContainer) {
+        this.iframeContainer.style.display = '';
+      }
+
+      if (
+        config.openSidebar ||
+        config.annotations ||
+        config.query ||
+        config.group
+      ) {
+        this.open();
+      }
     });
 
     // Notify sidebar when a guest is unloaded. This message is routed via

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -154,14 +154,6 @@ describe('Guest', () => {
       assert.deepEqual(FakeAnnotationSync.lastCall.args[0], eventBus);
     });
 
-    it('publishes the "panelReady" event when a connection is established', () => {
-      const handler = sandbox.stub();
-      const guest = createGuest();
-      guest._emitter.subscribe('panelReady', handler);
-      fakeBridge.onConnect.yield();
-      assert.called(handler);
-    });
-
     describe('event subscription', () => {
       let emitter;
       let guest;


### PR DESCRIPTION
The initial un-hiding and opening of the sidebar was previously
triggered by a `panelReady` event emitted by the Guest in the host frame
when it connects.

As part of eliminating the need for the host frame to also be a guest,
change the initial sidebar open to use the `Sidebar.ready` promise
instead, which is resolved when the sidebar applicaiton sends a
`hypothesisSidebarReady` notice to the `Sidebar` app.

Part of https://github.com/hypothesis/client/issues/3798