### PR TITLE
Renamed two `Bridge` events to more obvious name

### DIFF
--- a/src/annotator/annotation-sync.js
+++ b/src/annotator/annotation-sync.js
@@ -90,7 +90,7 @@ export class AnnotationSync {
     }
 
     this._sidebar.call(
-      'sync',
+      'syncAnchoringStatus',
       annotations.map(ann => this._format(ann))
     );
   }

--- a/src/annotator/test/annotation-sync-test.js
+++ b/src/annotator/test/annotation-sync-test.js
@@ -155,13 +155,15 @@ describe('AnnotationSync', () => {
   });
 
   describe('#sync', () => {
-    it('calls "sync" method of the bridge', () => {
+    it('calls "syncAnchoringStatus" RPC method in the sidebar', () => {
       const ann = { id: 1 };
       const annotationSync = createAnnotationSync();
 
       annotationSync.sync([ann]);
 
-      assert.calledWith(fakeBridge.call, 'sync', [{ msg: ann, tag: ann.$tag }]);
+      assert.calledWith(fakeBridge.call, 'syncAnchoringStatus', [
+        { msg: ann, tag: ann.$tag },
+      ]);
     });
   });
 

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -190,7 +190,7 @@ export class FrameSyncService {
       }, 10);
 
       // Anchoring an annotation in the frame completed
-      this._guestRPC.on('sync', events_ => {
+      this._guestRPC.on('syncAnchoringStatus', events_ => {
         events_.forEach(event => {
           inFrame.add(event.tag);
           anchoringStatusUpdates[event.tag] = event.msg.$orphan

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -414,16 +414,22 @@ describe('FrameSyncService', () => {
     }
 
     it('updates the anchoring status for the annotation', () => {
-      guestBridge().emit('sync', [{ tag: 't1', msg: { $orphan: false } }]);
+      guestBridge().emit('syncAnchoringStatus', [
+        { tag: 't1', msg: { $orphan: false } },
+      ]);
 
       expireDebounceTimeout();
 
       assert.calledWith(fakeStore.updateAnchorStatus, { t1: 'anchored' });
     });
 
-    it('coalesces multiple "sync" messages', () => {
-      guestBridge().emit('sync', [{ tag: 't1', msg: { $orphan: false } }]);
-      guestBridge().emit('sync', [{ tag: 't2', msg: { $orphan: true } }]);
+    it('coalesces multiple "syncAnchoringStatus" messages', () => {
+      guestBridge().emit('syncAnchoringStatus', [
+        { tag: 't1', msg: { $orphan: false } },
+      ]);
+      guestBridge().emit('syncAnchoringStatus', [
+        { tag: 't2', msg: { $orphan: true } },
+      ]);
 
       expireDebounceTimeout();
 

--- a/src/types/bridge-events.d.ts
+++ b/src/types/bridge-events.d.ts
@@ -54,7 +54,7 @@ export type GuestToSidebarEvent =
   /**
    * The guest informs the sidebar whether annotations were successfully anchored
    */
-  | 'sync'
+  | 'syncAnchoringStatus'
 
   /**
    * The guest is asking the sidebar to toggle some annotations.


### PR DESCRIPTION
First commit: renamed `beforeCreateAnnotation` to `createAnnotation`
Second commit: renamed `sync` to `syncAnchoringStatus`