### PR TITLE
Use `notifyHost` instead of `_hostRPC.call`

### DIFF
--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -129,7 +129,7 @@ export class FrameSyncService {
           if (frames.length > 0) {
             if (frames.every(frame => frame.isAnnotationFetchComplete)) {
               if (publicAnns === 0 || publicAnns !== prevPublicAnns) {
-                this._hostRPC.call(
+                this.notifyHost(
                   sidebarToHostEvents.PUBLIC_ANNOTATION_COUNT_CHANGED,
                   publicAnns
                 );
@@ -156,7 +156,7 @@ export class FrameSyncService {
           // and delete the (unsaved) annotation so it gets un-selected in the
           // target document
           if (!store.isLoggedIn()) {
-            this._hostRPC.call(sidebarToHostEvents.OPEN_SIDEBAR);
+            this.notifyHost(sidebarToHostEvents.OPEN_SIDEBAR);
             store.openSidebarPanel('loginPrompt');
             this._guestRPC.call(
               sidebarToGuestEvents.DELETE_ANNOTATION,
@@ -212,11 +212,11 @@ export class FrameSyncService {
       );
 
       this._guestRPC.on(guestToSidebarEvents.OPEN_SIDEBAR, () => {
-        this._hostRPC.call(sidebarToHostEvents.OPEN_SIDEBAR);
+        this.notifyHost(sidebarToHostEvents.OPEN_SIDEBAR);
       });
 
       this._guestRPC.on(guestToSidebarEvents.CLOSE_SIDEBAR, () => {
-        this._hostRPC.call(sidebarToHostEvents.CLOSE_SIDEBAR);
+        this.notifyHost(sidebarToHostEvents.CLOSE_SIDEBAR);
       });
     };
   }

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -604,8 +604,12 @@ describe('FrameSyncService', () => {
   describe('#notifyHost', () => {
     it('sends a message to the host frame', () => {
       frameSync.connect();
-      frameSync.notifyHost('openNotebook', 'group-id');
-      assert.calledWith(hostBridge().call, 'openNotebook', 'group-id');
+      frameSync.notifyHost(sidebarToHostEvents.OPEN_NOTEBOOK, 'group-id');
+      assert.calledWith(
+        hostBridge().call,
+        sidebarToHostEvents.OPEN_NOTEBOOK,
+        'group-id'
+      );
     });
   });
 });


### PR DESCRIPTION
`notifyHost` method has a more strict type (a subset of `Bridge` event
that can be passed to the host). By using it everywhere, including in
the own class, we prevent possible mistakes (passing incorrect events).