### PR TITLE
Load Rollup configs with `import(...)` to fix warning

### DIFF
--- a/rollup-tests.config.mjs
+++ b/rollup-tests.config.mjs
@@ -1,5 +1,7 @@
+import { readFileSync } from 'fs';
+
 import alias from '@rollup/plugin-alias';
-import babel from '@rollup/plugin-babel';
+import { babel } from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
@@ -42,7 +44,8 @@ export default {
       preventAssignment: true,
       values: {
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-        __VERSION__: require('./package.json').version,
+        __VERSION__: JSON.parse(readFileSync('./package.json').toString())
+          .version,
       },
     }),
     nodeResolve({

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,3 +1,5 @@
+import { readFileSync } from 'fs';
+
 import alias from '@rollup/plugin-alias';
 import { babel } from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
@@ -51,7 +53,8 @@ function bundleConfig({ name, entry, format = 'es' }) {
         preventAssignment: true,
         values: {
           'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-          __VERSION__: require('./package.json').version,
+          __VERSION__: JSON.parse(readFileSync('./package.json').toString())
+            .version,
         },
       }),
       babel({


### PR DESCRIPTION
Convert the Rollup config files to have a `.mjs` extension so that Node
can natively load them as ES modules and then load them using
`import(...)` rather than the `loadConfigFile` helper.

This avoids a deprecation warning when importing `rollup/dist/loadConfigFile`:

```
(node:21339) [DEP0148] DeprecationWarning: Use of deprecated folder
mapping "./dist/" in the "exports" field module ...
```

This also makes the way the config file is loaded more transparent, since its
just a regular dynamic import.

The downside of this change is that we don't get a `warnings` object
back to print warnings that occur during bundling.
Instead have to pass an `onwarn` handler to `rollup.{rollup, watch}`. On the other hand, emitting warnings this way avoids mistakes where the caller forgets to call `warnings.flush()`.

One other side effect of this is that `require` can no longer be used in the `.mjs` files to load JSON modules. Instead `package.json` has to be read using `readFileSync` and parsed using `JSON.parse` ([related reading](https://www.stefanjudis.com/snippets/how-to-import-json-files-in-es-modules-node-js/)). If we're going to start using ES modules for regular Node scripts in future we might as well get used to differences in how certain things have to be written though.