### PR TITLE
Streamline Karma configuration

### DIFF
--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -1,23 +1,17 @@
-/* global process */
-
-/* global __dirname */
+/* global __dirname, process */
 
 const path = require('path');
-const glob = require('glob');
 
 let chromeFlags = [];
 
-// Output only summary and errors in development to make output easier to parse.
-let mochaOutputMode = 'minimal';
-
 process.env.CHROME_BIN = require('puppeteer').executablePath();
 
-// In Docker, the tests run as root, so the sandbox must be disabled.
 if (process.env.RUNNING_IN_DOCKER) {
+  // In Docker, the tests run as root, so the sandbox must be disabled.
   chromeFlags.push('--no-sandbox');
 
   // Disable `/dev/shm` usage as this can cause Chrome to fail to load large
-  // HTML pages, such as the one Karma creates with all the tests loaded.
+  // HTML pages.
   //
   // See https://github.com/GoogleChrome/puppeteer/issues/1834 and
   // https://github.com/karma-runner/karma-chrome-launcher/issues/198.
@@ -29,27 +23,12 @@ if (process.env.RUNNING_IN_DOCKER) {
 }
 
 module.exports = function (config) {
-  let testFiles = ['**/test/*-test.js', '**/integration/*-test.js'];
-
-  if (config.grep) {
-    const allFiles = testFiles
-      .map(pattern => glob.sync(pattern, { cwd: __dirname }))
-      .flat();
-    testFiles = allFiles.filter(path => path.match(config.grep));
-
-    // eslint-disable-next-line no-console
-    console.log(`Running tests matching pattern "${config.grep}": `, testFiles);
-  }
-
   config.set({
-    // base path that will be used to resolve all patterns (eg. files, exclude)
+    // Base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: './',
 
-    // frameworks to use
-    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['mocha', 'chai', 'sinon', 'source-map-support'],
 
-    // list of files / patterns to load in the browser
     files: [
       // Empty HTML file to assist with some tests
       { pattern: './annotator/test/empty.html', watched: false },
@@ -68,18 +47,13 @@ module.exports = function (config) {
       },
     ],
 
-    // list of files to exclude
-    exclude: [],
-
-    // preprocess matching files before serving them to the browser
-    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-
     mochaReporter: {
       // Display a helpful diff when comparing complex objects
       // See https://www.npmjs.com/package/karma-mocha-reporter#showdiff
       showDiff: true,
 
-      output: mochaOutputMode,
+      // Output only summary and errors in development to make output easier to parse.
+      output: 'minimal',
     },
 
     coverageIstanbulReporter: {
@@ -94,27 +68,12 @@ module.exports = function (config) {
     // for more helpful rendering of test failures
     reporters: ['progress', 'mocha', 'coverage-istanbul'],
 
-    // web server port
-    port: 9876,
-
-    // enable / disable colors in the output (reporters and logs)
-    colors: true,
-
-    // level of logging
-    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_INFO,
-
     browserConsoleLogOptions: {
       level: 'log',
       format: '%b %T: %m',
       terminal: true,
     },
 
-    // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
-
-    // start these browsers
-    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ['ChromeHeadless_Custom'],
     browserNoActivityTimeout: 20000,
 
@@ -124,10 +83,6 @@ module.exports = function (config) {
         flags: chromeFlags,
       },
     },
-
-    // Continuous Integration mode
-    // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false,
 
     // Log slow tests so we can fix them before they timeout
     reportSlowerThan: 500,


### PR DESCRIPTION
Streamline the Karma configuration to remove obsolete settings and make
it easier to see what non-default configuration we have supplied.

 - Remove `grep` option handling. The `--grep` option when running tests
   is now used in gulpfile.js to select which _files_ are included in
   the test.

 - Remove comments which add little value

 - Remove config settings that just set default values which are not
   expected to change in future ([docs on default settings](http://karma-runner.github.io/6.3/config/configuration-file.html))