### PR TITLE
Fix test watch mode

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,11 +61,14 @@ function logRollupWarning(warning) {
   log(`Rollup warning: ${warning} (${warning.url})`);
 }
 
+async function readConfig(path) {
+  const { default: config } = await import(path);
+  return Array.isArray(config) ? config : [config];
+}
+
 async function buildJS(rollupConfig) {
-  let { default: configs } = await import(rollupConfig);
-  if (!Array.isArray(configs)) {
-    configs = [configs];
-  }
+  const configs = await readConfig(rollupConfig);
+
   await Promise.all(
     configs.map(async config => {
       const bundle = await rollup.rollup({
@@ -78,7 +81,8 @@ async function buildJS(rollupConfig) {
 }
 
 async function watchJS(rollupConfig) {
-  const { default: configs } = await import(rollupConfig);
+  const configs = await readConfig(rollupConfig);
+
   const watcher = rollup.watch(
     configs.map(config => ({
       ...config,


### PR DESCRIPTION
Fix `gulp test --watch`. See https://github.com/hypothesis/frontend-shared/pull/214.

I plan to look at extracting the duplicated parts of the various projects' gulpfiles into a shared package shortly, to make this kind of change easier to do in one place.