### PR TITLE
Rename `destroyFrame` to `frameDestroyed`

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -217,7 +217,7 @@ export default class Sidebar {
     this._listeners.add(window, 'message', event => {
       const { data } = /** @type {MessageEvent} */ (event);
       if (data?.type === 'hypothesisGuestUnloaded') {
-        this._sidebarRPC.call('destroyFrame', data.frameIdentifier);
+        this._sidebarRPC.call('frameDestroyed', data.frameIdentifier);
       }
     });
   }

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -206,7 +206,7 @@ describe('Sidebar', () => {
     });
     window.dispatchEvent(event);
 
-    assert.calledWith(fakeBridge.call, 'destroyFrame', 'frame-id');
+    assert.calledWith(fakeBridge.call, 'frameDestroyed', 'frame-id');
   });
 
   function getConfigString(sidebar) {

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -281,7 +281,7 @@ export class FrameSyncService {
     // Listen for notifications of a guest being unloaded. This message is routed
     // via the host frame rather than coming directly from the unloaded guest
     // to work around https://bugs.webkit.org/show_bug.cgi?id=231167.
-    this._hostRPC.on('destroyFrame', frameIdentifier => {
+    this._hostRPC.on('frameDestroyed', frameIdentifier => {
       const frame = this._store.frames().find(f => f.id === frameIdentifier);
       if (frame) {
         this._store.destroyFrame(frame);

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -491,7 +491,7 @@ describe('FrameSyncService', () => {
 
     it('removes the frame from the frames list', () => {
       frameSync.connect();
-      hostBridge().emit('destroyFrame', frameId);
+      hostBridge().emit('frameDestroyed', frameId);
 
       assert.calledWith(fakeStore.destroyFrame, fixtures.framesListEntry);
     });

--- a/src/types/bridge-events.d.ts
+++ b/src/types/bridge-events.d.ts
@@ -10,7 +10,7 @@ export type HostToSidebarEvent =
   /**
    * The host informs the sidebar that a guest frame has been destroyed
    */
-  | 'destroyFrame'
+  | 'frameDestroyed'
 
   /**
    * Highlights have been toggled on/off.


### PR DESCRIPTION
There are two type of events:

* command events (`openSidebar`, `closeSidebar`): direct the receiving
  frame to take a specific action.

* information events ('sidebarOpened`, `helpRequested`): informs the
  receiving frame that an action _already_ took place, in case a follow
  up action needs to happen.

The `destroyFrame` aligns more with the second type.

Follow up of: https://github.com/hypothesis/client/pull/3838/files#r731077947