### PR TITLE
Force re-evaluation of annotator entry point when client is reloaded

### DIFF
--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -68,6 +68,8 @@ function injectScript(doc, src, forceReload = false) {
     // Module scripts are only evaluated once per URL in a document. Adding
     // a dynamic fragment forces re-evaluation without breaking browser or CDN
     // caching of the script, as a query string would do.
+    //
+    // See examples in https://html.spec.whatwg.org/multipage/webappapis.html#integration-with-the-javascript-module-system
     src += `#ts=${Date.now()}`;
   }
 
@@ -193,8 +195,6 @@ export function bootHypothesisClient(doc, config) {
 
     // Force re-evaluation of JS module scripts, so that the annotator entry
     // point code gets re-run if the client is unloaded and later re-loaded.
-    // We do this even if the client has not been loaded before because it is
-    // simpler and there are no negative effects (eg. to caching).
     { forceModuleReload: true }
   );
 }

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -98,7 +98,7 @@ describe('bootstrap', () => {
     });
 
     it('loads assets for the annotation layer', () => {
-      clock.tick(123);
+      clock.tick(123); // Set timestamp used by module cache-busting fragment.
 
       runBoot('annotator');
       const expectedAssets = [


### PR DESCRIPTION
The [recent change](https://hyp.is/YbAnNDZBEeyRyFdbbT210g/github.com/hypothesis/client/pull/3810) to load the annotator bundle as a JS module script rather than a classic script broke re-loading of the client, eg. when toggling the browser extension on and off in a page. This is because module scripts are only evaluated the first time that they are loaded in a page, unlike classic scripts. This prevented the annotator entry module (src/annotator/index.js) from re-running when the client was reloaded.

It turns out that it is possible to force re-evaluation of module scripts without a negative impact on browser or CDN caching by appending a dynamic fragment (`#ts=<timestamp>`) to the script URL. This commit applies this technique to force re-evaluation of all module scripts added to the host page by the boot script.

An alternative fix I considered was to revert to loading this bundle as a classic script. However that would have prevented us from using native ES module features within the annotator bundle, or forced us to use some emulation of it.

----

**Testing:**

In the Hypothesis client's dev server's home page (http://localhost:3000/) click the "Unload client"/"Load client" toggle button under the "Page features" heading. The client should be un-loaded and reloaded each time.

Also if you look at scripts in the page's `<head>` you should see that the "annotator.bundle.js" script has a `#ts=<timestamp>` hash fragment.