### PR TITLE
Fix KaTeX font loading

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -17,8 +17,6 @@ import manifest from './scripts/gulp/manifest.js';
 import serveDev from './dev-server/serve-dev.js';
 import servePackage from './dev-server/serve-package.js';
 
-const FONTS_DIR = 'build/fonts';
-
 gulp.task('build-js', () => buildJS('./rollup.config.mjs'));
 
 gulp.task('watch-js', () => watchJS('./rollup.config.mjs'));
@@ -48,17 +46,13 @@ gulp.task(
   })
 );
 
-const fontFiles = [
-  'src/styles/vendor/fonts/*.woff',
-  'node_modules/katex/dist/fonts/*.woff',
-  'node_modules/katex/dist/fonts/*.woff2',
-];
+const fontFiles = ['node_modules/katex/dist/fonts/*.woff2'];
 
 gulp.task('build-fonts', () => {
-  return gulp
-    .src(fontFiles)
-    .pipe(changed(FONTS_DIR))
-    .pipe(gulp.dest(FONTS_DIR));
+  // Fonts are located in a subdirectory of `build/styles` so that we can reuse
+  // KaTeX's CSS bundle directly without any URL rewriting.
+  const fontsDir = 'build/styles/fonts';
+  return gulp.src(fontFiles).pipe(changed(fontsDir)).pipe(gulp.dest(fontsDir));
 });
 
 gulp.task(
@@ -68,8 +62,8 @@ gulp.task(
   })
 );
 
-const MANIFEST_SOURCE_FILES =
-  'build/@(fonts|scripts|styles)/*.@(js|css|woff|jpg|png|svg)';
+// Files to reference in `build/manifest.json`, used by `build/boot.js`.
+const MANIFEST_SOURCE_FILES = 'build/{styles,scripts}/*.{js,css,map}';
 
 let isFirstBuild = true;
 


### PR DESCRIPTION
When rendering math, the custom KaTex fonts failed to load due to the relative URL references in `build/styles/katex.min.css` not matching the actual location of the fonts in `build/fonts`. The KaTeX CSS assumes a URL structure like:

```
katex.min.css
fonts/
  KaTeX_AMS-Regular.woff2
```

Previously font URLs in katex.min.css were rewritten from `url('fonts/foo.woff2')` to `url('../fonts/foo.woff2')` by a PostCSS plugin when building the CSS bundles. However this got lost when replacing the client's local style-bundling script with the one from the @hypothesis/frontend-shared package.

By relocating the fonts to a subdirectory of `build/styles` we can make the asset references work without needing to do any rewriting of URLs in the KaTeX CSS bundle.

In the process, the list of fonts included in the bundle was simplified to include just WOFF2 fonts, since all modern browsers support that format. Additionally an obsolete reference to fonts in src/styles/vendor
was removed.

An alternative approach would be to re-introduce URL rewriting in the CSS bundling in @hypothesis/frontend-build. The approach taken here seems simpler for our current needs though.

---

**Testing:**

Create an annotation with a LaTeX equation (eg. `$$ x * 2 $$`) and verify in the browser's devtools that it fetches KaTeX fonts when the annotation is rendered. If you compare the rendering of the equation on this branch to a production client, you'll see that it looks better. In production the client is currently falling back to system fonts.