### PR TITLE
Revert to local icon image

### DIFF
--- a/src/images/icons/lock.svg
+++ b/src/images/icons/lock.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="48px" height="56px" viewBox="0 0 48 56" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g fill="currentColor">
+            <rect x="0" y="24" width="48" height="32"></rect>
+            <path d="M24,0 C24,0 8,0 8,16 L8,32 L16,32 L16,16.0000004 C16,8 24,8 24,8 C24,8 32,8 32,16 L32,32 L40,32 L40,16 C40,0 24,0 24,0 Z"></path>
+        </g>
+    </g>
+</svg>

--- a/src/sidebar/icons.js
+++ b/src/sidebar/icons.js
@@ -29,7 +29,6 @@ import {
   listOrdered,
   listUnordered,
   logo,
-  lock,
   plus,
   profile,
   refresh,
@@ -43,6 +42,7 @@ import {
 
 // The following icons differ here from the shared-package versions
 import annotateIcon from '../images/icons/annotate.svg';
+import lockIcon from '../images/icons/lock.svg';
 import replyIcon from '../images/icons/reply.svg';
 import sortIcon from '../images/icons/sort.svg';
 
@@ -88,7 +88,7 @@ export default {
   image,
   leave,
   link,
-  lock,
+  lock: lockIcon,
   logo,
   pointer: pointerIcon,
   profile,


### PR DESCRIPTION
Changed over to nearly all shared icons this morning, but I'm noticing in reviewing that the shared lock icon looks weird in context. 

Let's revert back to the local version of this icon until I can track this down better. I did try the filled version of the shared icon but it still looked weird (it's more of a proportion thing).

Before/shared lock icon:

![image](https://user-images.githubusercontent.com/439947/139305252-d478d500-cff4-4532-ad9f-1b92cef4ef22.png)

After/local lock icon (back to how it was):

![image](https://user-images.githubusercontent.com/439947/139305146-6bd6bebc-cfce-43c2-aa11-1704b0123c30.png)
