### PR TITLE
Fix KaTeX import

### DIFF
--- a/src/sidebar/render-markdown.js
+++ b/src/sidebar/render-markdown.js
@@ -1,6 +1,6 @@
 import createDOMPurify from 'dompurify';
 import escapeHtml from 'escape-html';
-import * as katex from 'katex';
+import katex from 'katex';
 import showdown from 'showdown';
 
 const DOMPurify = createDOMPurify(window);

--- a/src/sidebar/test/render-markdown-test.js
+++ b/src/sidebar/test/render-markdown-test.js
@@ -7,12 +7,14 @@ describe('render-markdown', () => {
   beforeEach(() => {
     $imports.$mock({
       katex: {
-        renderToString: function (input, opts) {
-          if (opts && opts.displayMode) {
-            return 'math+display:' + input;
-          } else {
-            return 'math:' + input;
-          }
+        default: {
+          renderToString: function (input, opts) {
+            if (opts && opts.displayMode) {
+              return 'math+display:' + input;
+            } else {
+              return 'math:' + input;
+            }
+          },
         },
       },
     });


### PR DESCRIPTION
Per the release notes in https://github.com/hypothesis/client/pull/3887 (see notes for v0.14.0), KaTeX should be imported using a default import rather than namespace import.

This fixes an error I observed during the build, along with a failure to render math equations in annotations:

```
[12:19:55] Rollup warning: src/sidebar/render-markdown.js (121:29) 'renderToString' is not exported by 'node_modules/katex/dist/katex.mjs' (https://rollupjs.org/guide/en/#error-name-is-not-
exported-by-module)
```