### PR TITLE
Use `Icon` component in a slew of sidebar components

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationShareControl.js
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.js
@@ -1,6 +1,6 @@
 import {
+  Icon,
   IconButton,
-  SvgIcon,
   TextInput,
   TextInputWithButton,
   useElementShouldClose,
@@ -168,11 +168,7 @@ function AnnotationShareControl({
             )}
             {showShareLinks && <ShareLinks shareURI={shareUri} />}
           </div>
-          <SvgIcon
-            name="pointer"
-            inline={true}
-            className="annotation-share-panel__arrow"
-          />
+          <Icon name="pointer" classes="annotation-share-panel__arrow" />
         </div>
       )}
     </div>

--- a/src/sidebar/components/FilterSelect.js
+++ b/src/sidebar/components/FilterSelect.js
@@ -1,4 +1,4 @@
-import { SvgIcon } from '@hypothesis/frontend-shared';
+import { Icon } from '@hypothesis/frontend-shared';
 
 import Menu from './Menu';
 import MenuItem from './MenuItem';
@@ -36,7 +36,9 @@ function FilterSelect({
 
   const menuLabel = (
     <span className="FilterSelect__menu-label">
-      {icon && <SvgIcon name={icon} className="FilterSelect__menu-icon" />}
+      {icon && (
+        <Icon name={icon} classes="u-icon--medium hyp-u-margin--right--3" />
+      )}
       {selected.display}
     </span>
   );

--- a/src/sidebar/components/HelpPanel.js
+++ b/src/sidebar/components/HelpPanel.js
@@ -1,4 +1,4 @@
-import { SvgIcon } from '@hypothesis/frontend-shared';
+import { Icon } from '@hypothesis/frontend-shared';
 import { useCallback, useMemo, useState } from 'preact/hooks';
 
 import { useStoreProxy } from '../store/use-store';
@@ -25,16 +25,11 @@ function HelpPanelTab({ linkText, url }) {
     <div className="HelpPanel-tabs__tab">
       <a
         href={url}
-        className="HelpPanel-tabs__link"
+        className="hyp-u-horizontal-spacing--2 hyp-u-layout-row--center HelpPanel-tabs__link"
         target="_blank"
         rel="noopener noreferrer"
       >
-        {linkText}{' '}
-        <SvgIcon
-          name="external"
-          className="HelpPanel-tabs__icon"
-          inline={true}
-        />
+        <span>{linkText}</span> <Icon name="external" classes="u-icon--small" />
       </a>
     </div>
   );
@@ -130,10 +125,7 @@ function HelpPanel({ auth, session }) {
                 aria-label="Show tutorial panel"
               >
                 Getting started
-                <SvgIcon
-                  name="arrow-right"
-                  className="HelpPanel__sub-panel-link-icon"
-                />
+                <Icon name="arrow-right" />
               </button>
             )}
             {activeSubPanel === 'tutorial' && (
@@ -143,7 +135,7 @@ function HelpPanel({ auth, session }) {
                 aria-label="Show version information panel"
               >
                 About this version
-                <SvgIcon name="arrow-right" />
+                <Icon name="arrow-right" />
               </button>
             )}
           </div>

--- a/src/sidebar/components/LoggedOutMessage.js
+++ b/src/sidebar/components/LoggedOutMessage.js
@@ -1,4 +1,4 @@
-import { LinkButton, SvgIcon } from '@hypothesis/frontend-shared';
+import { LinkButton, Icon } from '@hypothesis/frontend-shared';
 
 import { useStoreProxy } from '../store/use-store';
 
@@ -46,7 +46,7 @@ function LoggedOutMessage({ onLogin }) {
           aria-label="Hypothesis homepage"
           title="Hypothesis homepage"
         >
-          <SvgIcon name="logo" className="LoggedOutMessage__logo-icon" />
+          <Icon name="logo" classes="u-icon--xlarge hyp-u-color--grey-7" />
         </a>
       </div>
     </div>

--- a/src/sidebar/components/ShareAnnotationsPanel.js
+++ b/src/sidebar/components/ShareAnnotationsPanel.js
@@ -1,7 +1,7 @@
 import {
   IconButton,
   Spinner,
-  SvgIcon,
+  Icon,
   TextInput,
   TextInputWithButton,
 } from '@hypothesis/frontend-shared';
@@ -105,8 +105,8 @@ function ShareAnnotationsPanel({ toastMessenger }) {
                 )}{' '}
                 <span>
                   Private (
-                  <SvgIcon name="lock" inline className="u-icon--inline" />{' '}
-                  <em>Only Me</em>) annotations are only visible to you.
+                  <Icon name="lock" classes="u-inline" /> <em>Only Me</em>)
+                  annotations are only visible to you.
                 </span>
               </p>
               <ShareLinks shareURI={shareURI} />

--- a/src/sidebar/components/ShareLinks.js
+++ b/src/sidebar/components/ShareLinks.js
@@ -1,4 +1,4 @@
-import { SvgIcon } from '@hypothesis/frontend-shared';
+import { Icon } from '@hypothesis/frontend-shared';
 
 /**
  * @typedef ShareLinkProps
@@ -22,7 +22,7 @@ function ShareLink({ label, iconName, uri }) {
         target="_blank"
         rel="noopener noreferrer"
       >
-        <SvgIcon name={iconName} className="ShareLinks__icon" />
+        <Icon name={iconName} classes="ShareLinks__icon" />
       </a>
     </li>
   );

--- a/src/sidebar/components/SortMenu.js
+++ b/src/sidebar/components/SortMenu.js
@@ -1,4 +1,4 @@
-import { SvgIcon } from '@hypothesis/frontend-shared';
+import { Icon } from '@hypothesis/frontend-shared';
 
 import { useStoreProxy } from '../store/use-store';
 
@@ -29,7 +29,7 @@ export default function SortMenu() {
 
   const menuLabel = (
     <span className="TopBar__menu-label">
-      <SvgIcon name="sort" className="TopBar__menu-icon" />
+      <Icon name="sort" classes="TopBar__menu-icon" />
     </span>
   );
 

--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -1,5 +1,5 @@
 import {
-  SvgIcon,
+  Icon,
   normalizeKeyName,
   useElementShouldClose,
 } from '@hypothesis/frontend-shared';
@@ -292,7 +292,7 @@ function TagEditor({
                 title={`Remove Tag: ${tag}`}
                 className="TagEditor__delete"
               >
-                <SvgIcon name="cancel" />
+                <Icon name="cancel" />
               </button>
             </li>
           );

--- a/src/sidebar/components/ToastMessages.js
+++ b/src/sidebar/components/ToastMessages.js
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { SvgIcon } from '@hypothesis/frontend-shared';
+import { Icon } from '@hypothesis/frontend-shared';
 
 import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../service-context';
@@ -49,7 +49,7 @@ function ToastMessage({ message, onDismiss }) {
         )}
       >
         <div className="toast-message__type">
-          <SvgIcon name={iconName} className="toast-message__icon" />
+          <Icon name={iconName} classes="toast-message__icon" />
         </div>
         <div className="toast-message__message">
           <strong>{prefix}: </strong>

--- a/src/sidebar/components/Tutorial.js
+++ b/src/sidebar/components/Tutorial.js
@@ -1,4 +1,4 @@
-import { SvgIcon } from '@hypothesis/frontend-shared';
+import { Icon } from '@hypothesis/frontend-shared';
 
 import { isThirdPartyService } from '../helpers/is-third-party-service';
 import { withServices } from '../service-context';
@@ -15,7 +15,10 @@ import { withServices } from '../service-context';
 function TutorialInstruction({ commandName, iconName }) {
   return (
     <span className="Tutorial__instruction">
-      <SvgIcon name={iconName} inline={true} className="Tutorial__icon" />
+      <Icon
+        name={iconName}
+        classes="hyp-u-margin--right--1 hyp-u-color--grey-6 u-inline Tutorial__icon"
+      />
       <em>{commandName}</em>
     </span>
   );

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -1,4 +1,4 @@
-import { SvgIcon } from '@hypothesis/frontend-shared';
+import { Icon } from '@hypothesis/frontend-shared';
 import { useState } from 'preact/hooks';
 
 import { serviceConfig } from '../config/service-config';
@@ -85,7 +85,7 @@ function UserMenu({ auth, frameSync, onLogout, settings }) {
 
   const menuLabel = (
     <span className="TopBar__menu-label">
-      <SvgIcon name="profile" className="TopBar__menu-icon" />
+      <Icon name="profile" classes="TopBar__menu-icon" />
     </span>
   );
   return (

--- a/src/sidebar/components/test/FilterSelect-test.js
+++ b/src/sidebar/components/test/FilterSelect-test.js
@@ -65,7 +65,7 @@ describe('FilterSelect', () => {
     const wrapper = createComponent({ icon: 'profile' });
 
     const label = mount(wrapper.find('Menu').props().label);
-    const icon = label.find('SvgIcon');
+    const icon = label.find('Icon');
 
     assert.isTrue(icon.exists());
     assert.equal(icon.props().name, 'profile');

--- a/src/sidebar/components/test/ToastMessages-test.js
+++ b/src/sidebar/components/test/ToastMessages-test.js
@@ -166,7 +166,7 @@ describe('ToastMessages', () => {
         const wrapper = createComponent();
 
         const iconProps = wrapper
-          .find('SvgIcon')
+          .find('Icon')
           .map(iconWrapper => iconWrapper.props().name);
 
         assert.deepEqual(iconProps, testCase.icons);

--- a/src/styles/sidebar/components/AnnotationShareControl.scss
+++ b/src/styles/sidebar/components/AnnotationShareControl.scss
@@ -47,9 +47,10 @@
   // Position the pointer icon absolutely and flip it to make it point at the
   // share icon
   &__arrow {
+    display: inline;
     @include molecules.menu-arrow($direction: 'down');
     right: 0px;
-    bottom: -8px;
+    bottom: -12px;
   }
 
   .ShareLinks__icon {

--- a/src/styles/sidebar/components/FilterSelect.scss
+++ b/src/styles/sidebar/components/FilterSelect.scss
@@ -24,9 +24,4 @@
     flex-shrink: 0;
     font-weight: bold;
   }
-
-  &__menu-icon {
-    @include utils.icon--medium;
-    margin-right: var.$layout-space--xsmall;
-  }
 }

--- a/src/styles/sidebar/components/LoggedOutMessage.scss
+++ b/src/styles/sidebar/components/LoggedOutMessage.scss
@@ -24,13 +24,3 @@
   @include layout.row(center);
   margin-top: 25px;
 }
-
-.LoggedOutMessage__logo-icon {
-  width: 30px;
-  height: 30px;
-  color: var.$grey-mid;
-
-  &:hover {
-    color: var.$grey-7;
-  }
-}

--- a/src/styles/sidebar/components/Tutorial.scss
+++ b/src/styles/sidebar/components/Tutorial.scss
@@ -8,10 +8,7 @@
   }
 
   &__icon {
-    @include utils.icon--inline;
-    margin-right: 1px;
     margin-bottom: -1px; // Pull the icon a little toward the baseline
-    color: var.$grey-5;
   }
 
   &__instruction {

--- a/src/styles/util.scss
+++ b/src/styles/util.scss
@@ -49,6 +49,10 @@
   @include utils.icon--small;
 }
 
+.u-icon--medium {
+  @include utils.icon--medium;
+}
+
 .u-icon--large {
   @include utils.icon--large;
 }

--- a/src/styles/util.scss
+++ b/src/styles/util.scss
@@ -57,6 +57,11 @@
   @include utils.icon--large;
 }
 
+.u-icon--xlarge {
+  width: 30px;
+  height: 30px;
+}
+
 // Misc
 
 // Make element content invisible except to assistive technology


### PR DESCRIPTION
This PR subs in `Icon` for `SvgIcon`, without touching anything else (it's so hard!) in a bunch of sidebar components. After this, `SvgIcon` needs to be replaced in:

* Three sidebar components for which a drop-in replacement proves tricky (i.e. some surrounding styles will need to be massaged out): `Menu`, `MenuItem`, `MarkdownEditor`
* Annotator components

Getting there!

If I did my work right, there should be no user-visible changes here.

Part of https://github.com/hypothesis/client/issues/3876
Part of the next `frontend-shared` pass; strategy explained here: https://github.com/hypothesis/frontend-shared/issues/232