### PR TITLE
Restore `sinon.useFakeTimers()`

### DIFF
--- a/src/sidebar/components/test/Menu-test.js
+++ b/src/sidebar/components/test/Menu-test.js
@@ -183,15 +183,19 @@ describe('Menu', () => {
       shouldClose ? 'closes' : "doesn't close"
     } when user performs a "${eventType}" (key: "${key}") on menu content`, () => {
       clock = sinon.useFakeTimers();
-      const wrapper = createMenu({ defaultOpen: true });
-      wrapper.find('.Menu__content').simulate(eventType, { key });
-      // The close event is delayed by a minimal amount of time in
-      // order to allow links to say in the DOM long enough to be
-      // followed on a click. Therefore, this test must simulate
-      // time passing in order for the menu to close.
-      clock.tick(1);
-      wrapper.update();
-      assert.equal(isOpen(wrapper), !shouldClose);
+      try {
+        const wrapper = createMenu({ defaultOpen: true });
+        wrapper.find('.Menu__content').simulate(eventType, { key });
+        // The close event is delayed by a minimal amount of time in
+        // order to allow links to say in the DOM long enough to be
+        // followed on a click. Therefore, this test must simulate
+        // time passing in order for the menu to close.
+        clock.tick(1);
+        wrapper.update();
+        assert.equal(isOpen(wrapper), !shouldClose);
+      } finally {
+        clock.restore();
+      }
     });
   });
 

--- a/src/sidebar/components/test/Menu-test.js
+++ b/src/sidebar/components/test/Menu-test.js
@@ -9,7 +9,6 @@ import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('Menu', () => {
   let container;
-  let clock;
 
   const TestLabel = () => 'Test label';
   const TestMenuItem = () => 'Test item';
@@ -39,10 +38,6 @@ describe('Menu', () => {
   afterEach(() => {
     $imports.$restore();
     container.remove();
-    if (clock) {
-      clock.restore();
-      clock = null;
-    }
   });
 
   it('opens and closes when the toggle button is clicked', () => {
@@ -182,7 +177,7 @@ describe('Menu', () => {
     it(`${
       shouldClose ? 'closes' : "doesn't close"
     } when user performs a "${eventType}" (key: "${key}") on menu content`, () => {
-      clock = sinon.useFakeTimers();
+      const clock = sinon.useFakeTimers();
       try {
         const wrapper = createMenu({ defaultOpen: true });
         wrapper.find('.Menu__content').simulate(eventType, { key });

--- a/src/sidebar/components/test/MenuKeyboardNavigation-test.js
+++ b/src/sidebar/components/test/MenuKeyboardNavigation-test.js
@@ -70,7 +70,6 @@ describe('MenuKeyboardNavigation', () => {
     });
 
     it('sets focus to the first `menuitem` child when `visible` is true', () => {
-      const clock = sinon.useFakeTimers();
       createMenuItem({ visible: true });
       clock.tick(1);
       assert.equal(document.activeElement.innerText, 'Item 1');

--- a/src/sidebar/util/test/postmessage-json-rpc-test.js
+++ b/src/sidebar/util/test/postmessage-json-rpc-test.js
@@ -148,18 +148,21 @@ describe('sidebar/util/postmessage-json-rpc', () => {
 
     it('if timeout is null, then it does not timeout', async () => {
       const clock = sinon.useFakeTimers();
-      const result = doCall(null);
-      clock.tick(100000); // wait a long time
-      fakeWindow.emitter.emit('message', {
-        origin,
-        data: {
-          jsonrpc: '2.0',
-          id: messageId,
-          result: {},
-        },
-      });
-      await result;
-      clock.restore();
+      try {
+        const result = doCall(null);
+        clock.tick(100000); // wait a long time
+        fakeWindow.emitter.emit('message', {
+          origin,
+          data: {
+            jsonrpc: '2.0',
+            id: messageId,
+            result: {},
+          },
+        });
+        await result;
+      } finally {
+        clock.restore();
+      }
     });
   });
 });


### PR DESCRIPTION
`sinon.useFakeTimers` should be restored, otherwise it has the potential to affect other tests.