### PR TITLE
Improved separation between primary (main) and secondary `Guest`s

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -166,11 +166,6 @@ export default class Guest {
      */
     this.anchors = [];
 
-    // Set the frame identifier if it's available.
-    // The "top" guest instance will have this as 'main' since it's in a top frame not a sub frame
-    /** @type {string} */
-    this._frameIdentifier = config.subFrameIdentifier ?? 'main';
-
     this._portFinder = new PortFinder({
       hostFrame: this._hostFrame,
       source: 'guest',
@@ -205,7 +200,12 @@ export default class Guest {
      * Integration that handles document-type specific functionality in the
      * guest.
      */
-    this._integration = createIntegration(this);
+    const [integration, frameIdentifier] = createIntegration(
+      this,
+      config.subFrameIdentifier
+    );
+    this._integration = integration;
+    this._frameIdentifier = frameIdentifier;
 
     this._sideBySideActive = false;
 

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -329,8 +329,9 @@ export default class Guest {
 
   async _connectHostEvents() {
     this._hostRPC.on(
-      'deselectTextExcept',
-      /** @type {string} */ frameIdentifier => {
+      'unselectTextExceptIn',
+      /** @param {string} frameIdentifier */
+      frameIdentifier => {
         if (this._frameIdentifier === frameIdentifier) {
           return;
         }
@@ -344,8 +345,9 @@ export default class Guest {
     );
 
     this._hostRPC.on(
-      'createAnnotationAt',
-      /** @type {string} */ frameIdentifier => {
+      'createAnnotationIn',
+      /** @param {string} frameIdentifier */
+      frameIdentifier => {
         if (this._frameIdentifier === frameIdentifier) {
           this.createAnnotation();
         }
@@ -652,7 +654,7 @@ export default class Guest {
     }
 
     this.selectedRanges = [range];
-    this._hostRPC.call('textSelectedAt', this._frameIdentifier);
+    this._hostRPC.call('textSelectedIn', this._frameIdentifier);
 
     this._adder.annotationsForSelection = annotationsForSelection();
     this._isAdderVisible = true;
@@ -664,7 +666,7 @@ export default class Guest {
     this._adder.hide();
     this.selectedRanges = [];
     if (informHostFrame) {
-      this._hostRPC.call('textDeselectedAt', this._frameIdentifier);
+      this._hostRPC.call('textUnselectedIn', this._frameIdentifier);
     }
   }
 

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -30,6 +30,7 @@ import { normalizeURI } from './util/url';
  * @typedef {import('../types/bridge-events').GuestToHostEvent} GuestToHostEvent
  * @typedef {import('../types/bridge-events').GuestToSidebarEvent} GuestToSidebarEvent
  * @typedef {import('../types/bridge-events').SidebarToGuestEvent} SidebarToGuestEvent
+ * @typedef {import('./integrations').FrameIdentifier} FrameIdentifier
  * @typedef {import('./util/emitter').EventBus} EventBus
  */
 
@@ -330,7 +331,7 @@ export default class Guest {
   async _connectHostEvents() {
     this._hostRPC.on(
       'unselectTextExceptIn',
-      /** @param {string} frameIdentifier */
+      /** @param {FrameIdentifier} frameIdentifier */
       frameIdentifier => {
         if (this._frameIdentifier === frameIdentifier) {
           return;
@@ -346,7 +347,7 @@ export default class Guest {
 
     this._hostRPC.on(
       'createAnnotationIn',
-      /** @param {string} frameIdentifier */
+      /** @param {FrameIdentifier} frameIdentifier */
       frameIdentifier => {
         if (this._frameIdentifier === frameIdentifier) {
           this.createAnnotation();

--- a/src/annotator/integrations/index.js
+++ b/src/annotator/integrations/index.js
@@ -11,6 +11,7 @@ import {
 /**
  * @typedef {import('../../types/annotator').Annotator} Annotator
  * @typedef {import('../../types/annotator').Integration} Integration
+ * @typedef {'main'|`sub_${string}`} FrameIdentifier - role based frame identifier
  */
 
 /**
@@ -21,7 +22,7 @@ import {
  *
  * @param {Annotator} annotator
  * @param {string|null} [frameIdentifier]
- * @return {[Integration, 'main'|`sub_${string}`]}.
+ * @return {[Integration, FrameIdentifier]}
  */
 export function createIntegration(annotator, frameIdentifier = null) {
   if (isPDF()) {

--- a/src/annotator/integrations/test/index-test.js
+++ b/src/annotator/integrations/test/index-test.js
@@ -36,38 +36,55 @@ describe('createIntegration', () => {
     const annotator = {};
     fakeIsPDF.returns(true);
 
-    const integration = createIntegration(annotator);
+    const [integration, frameIdentifier] = createIntegration(annotator);
 
     assert.calledWith(FakePDFIntegration, annotator);
     assert.instanceOf(integration, FakePDFIntegration);
+    assert.equal(frameIdentifier, 'main');
   });
 
   it('creates VitalSource container integration in the VS Bookshelf reader', () => {
     const annotator = {};
     fakeVitalSourceFrameRole.returns('container');
 
-    const integration = createIntegration(annotator);
+    const [integration, frameIdentifier] = createIntegration(annotator);
 
     assert.calledWith(FakeVitalSourceContainerIntegration, annotator);
     assert.instanceOf(integration, FakeVitalSourceContainerIntegration);
+    assert.match(frameIdentifier, /sub_\w{10}/);
   });
 
   it('creates VitalSource content integration in the VS Bookshelf reader', () => {
     const annotator = {};
     fakeVitalSourceFrameRole.returns('content');
 
-    const integration = createIntegration(annotator);
+    const [integration, frameIdentifier] = createIntegration(annotator);
 
     assert.calledWith(FakeVitalSourceContentIntegration);
     assert.instanceOf(integration, FakeVitalSourceContentIntegration);
+    assert.equal(frameIdentifier, 'main');
   });
 
-  it('creates HTML integration in web pages', () => {
+  it('creates HTML integration in the main frame', () => {
     const annotator = {};
 
-    const integration = createIntegration(annotator);
+    const [integration, frameIdentifier] = createIntegration(annotator);
 
     assert.calledWith(FakeHTMLIntegration);
     assert.instanceOf(integration, FakeHTMLIntegration);
+    assert.equal(frameIdentifier, 'main');
+  });
+
+  it('creates HTML integration in the secondary iframes', () => {
+    const annotator = {};
+
+    const [integration, frameIdentifier] = createIntegration(
+      annotator,
+      'other annotatable iframe'
+    );
+
+    assert.calledWith(FakeHTMLIntegration);
+    assert.instanceOf(integration, FakeHTMLIntegration);
+    assert.match(frameIdentifier, /sub_\w{10}/);
   });
 });

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -70,7 +70,7 @@ export default class Sidebar {
     this._emitter = eventBus.createEmitter();
 
     /**
-     * Tracks which `Guest` has a text selection. It uses the frame i«dentifier
+     * Tracks which `Guest` has a text selection. It uses the frame identifier
      * which uniquely identifies each `Guest`. If there is no text selected, the
      * value is set to `null`.
      *
@@ -145,7 +145,7 @@ export default class Sidebar {
     const toolbarContainer = document.createElement('div');
     this.toolbar = new ToolbarController(toolbarContainer, {
       createAnnotation: () =>
-        this._guestRPC.call('createAnnotationAt', this._selectionAt ?? 'main'),
+        this._guestRPC.call('createAnnotationIn', this._selectionAt ?? 'main'),
       setSidebarOpen: open => (open ? this.open() : this.close()),
       setHighlightsVisible: show => this.setHighlightsVisible(show),
     });
@@ -266,20 +266,22 @@ export default class Sidebar {
 
   _setupGuestEvents() {
     this._guestRPC.on(
-      'textSelectedAt',
-      /** @type {string} */ frameIdentifier => {
+      'textSelectedIn',
+      /** @param {string} frameIdentifier */
+      frameIdentifier => {
         this._selectionAt = frameIdentifier;
         this.toolbar.newAnnotationType = 'annotation';
-        this._guestRPC.call('deselectTextExcept', frameIdentifier);
+        this._guestRPC.call('unselectTextExceptIn', frameIdentifier);
       }
     );
 
     this._guestRPC.on(
-      'textDeselectedAt',
-      /** @type {string} */ frameIdentifier => {
+      'textUnselectedIn',
+      /** @param {string}  frameIdentifier */
+      frameIdentifier => {
         this._selectionAt = null;
         this.toolbar.newAnnotationType = 'note';
-        this._guestRPC.call('deselectTextExcept', frameIdentifier);
+        this._guestRPC.call('unselectTextExceptIn', frameIdentifier);
       }
     );
   }
@@ -297,10 +299,14 @@ export default class Sidebar {
 
     // Sidebar listens to the `openNotebook` event coming from the sidebar's
     // iframe and re-publishes it via the emitter to the Notebook
-    this._sidebarRPC.on('openNotebook', (/** @type {string} */ groupId) => {
-      this.hide();
-      this._emitter.publish('openNotebook', groupId);
-    });
+    this._sidebarRPC.on(
+      'openNotebook',
+      /** @param {string} groupId */
+      groupId => {
+        this.hide();
+        this._emitter.publish('openNotebook', groupId);
+      }
+    );
     this._emitter.subscribe('closeNotebook', () => {
       this.show();
     });

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -132,7 +132,12 @@ describe('Guest', () => {
       },
       './annotation-sync': { AnnotationSync: FakeAnnotationSync },
       './integrations': {
-        createIntegration: sinon.stub().returns(fakeIntegration),
+        createIntegration: sinon
+          .stub()
+          .callsFake((_, subFrameIdentifier) => [
+            fakeIntegration,
+            subFrameIdentifier ?? 'main',
+          ]),
       },
       './highlighter': highlighter,
       './hypothesis-injector': { HypothesisInjector: FakeHypothesisInjector },

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -629,7 +629,7 @@ describe('Guest', () => {
 
       simulateSelectionWithText();
 
-      assert.calledWith(fakeBridge.call, 'textSelectedAt', 'main');
+      assert.calledWith(fakeBridge.call, 'textSelectedIn', 'main');
     });
 
     it('calls "textSelectionAt" RPC method with the subFrameIdentifier as argument if selection is non-empty', () => {
@@ -638,18 +638,18 @@ describe('Guest', () => {
 
       simulateSelectionWithText();
 
-      assert.calledWith(fakeBridge.call, 'textSelectedAt', subFrameIdentifier);
+      assert.calledWith(fakeBridge.call, 'textSelectedIn', subFrameIdentifier);
     });
 
-    it('calls "textDeselectedAt" RPC method with argument "main" if selection is empty', () => {
+    it('calls "textUnselectedIn" RPC method with argument "main" if selection is empty', () => {
       createGuest();
 
       simulateSelectionWithoutText();
 
-      assert.calledWith(fakeBridge.call, 'textDeselectedAt', 'main');
+      assert.calledWith(fakeBridge.call, 'textUnselectedIn', 'main');
     });
 
-    it('calls "textDeselectedAt" RPC method with the subFrameIdentifier as argument if selection is empty', () => {
+    it('calls "textUnselectedIn" RPC method with the subFrameIdentifier as argument if selection is empty', () => {
       const subFrameIdentifier = 'other frame';
       createGuest({ subFrameIdentifier });
 
@@ -657,7 +657,7 @@ describe('Guest', () => {
 
       assert.calledWith(
         fakeBridge.call,
-        'textDeselectedAt',
+        'textUnselectedIn',
         subFrameIdentifier
       );
     });
@@ -667,7 +667,7 @@ describe('Guest', () => {
       guest.selectedRanges = [1];
       const handler = fakeBridge.on
         .getCalls()
-        .find(call => call.args[0] === 'deselectTextExcept').args[1];
+        .find(call => call.args[0] === 'unselectTextExceptIn').args[1];
 
       simulateSelectionWithText();
       fakeBridge.call.resetHistory();
@@ -677,12 +677,12 @@ describe('Guest', () => {
       assert.notCalled(fakeBridge.call);
     });
 
-    it("doesn't unselects text if frame identifiers matches", () => {
+    it("doesn't deselect text if frame identifiers matches", () => {
       const guest = createGuest();
       guest.selectedRanges = [1];
       const handler = fakeBridge.on
         .getCalls()
-        .find(call => call.args[0] === 'deselectTextExcept').args[1];
+        .find(call => call.args[0] === 'unselectTextExceptIn').args[1];
 
       simulateSelectionWithText();
       handler('main'); // doesn't unselect the text because it matches the frameIdentifier
@@ -801,12 +801,12 @@ describe('Guest', () => {
   });
 
   describe('#createAnnotation', () => {
-    it('creates an annotation if host calls with "createAnnotationAt" RPC method', () => {
+    it('creates an annotation if host calls with "createAnnotationIn" RPC method', () => {
       const guest = createGuest();
       sinon.stub(guest, 'createAnnotation');
       const handler = fakeBridge.on
         .getCalls()
-        .find(call => call.args[0] === 'createAnnotationAt').args[1];
+        .find(call => call.args[0] === 'createAnnotationIn').args[1];
 
       handler('dummy');
       assert.notCalled(guest.createAnnotation);

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -237,22 +237,22 @@ describe('Sidebar', () => {
 
       FakeToolbarController.args[0][1].createAnnotation();
 
-      assert.calledWith(fakeBridge.call, 'createAnnotationAt', 'main');
+      assert.calledWith(fakeBridge.call, 'createAnnotationIn', 'main');
     });
 
     it('creates an annotation on another frame toolbar button is clicked', () => {
       createSidebar({});
 
-      // make a text selection on another frame
+      // Make a text selection in another frame
       const handler = fakeBridge.on
         .getCalls()
-        .find(call => call.args[0] === 'textSelectedAt').args[1];
+        .find(call => call.args[0] === 'textSelectedIn').args[1];
       const frameIdentifier = 'other frame';
       handler(frameIdentifier);
 
       FakeToolbarController.args[0][1].createAnnotation();
 
-      assert.calledWith(fakeBridge.call, 'createAnnotationAt', frameIdentifier);
+      assert.calledWith(fakeBridge.call, 'createAnnotationIn', frameIdentifier);
     });
 
     it('sets create annotation button to "Annotation" when selection becomes non-empty', () => {
@@ -260,7 +260,7 @@ describe('Sidebar', () => {
 
       const handler = fakeBridge.on
         .getCalls()
-        .find(call => call.args[0] === 'textSelectedAt').args[1];
+        .find(call => call.args[0] === 'textSelectedIn').args[1];
       handler('dummy');
 
       assert.equal(sidebar.toolbar.newAnnotationType, 'annotation');
@@ -271,7 +271,7 @@ describe('Sidebar', () => {
 
       const handler = fakeBridge.on
         .getCalls()
-        .find(call => call.args[0] === 'textDeselectedAt').args[1];
+        .find(call => call.args[0] === 'textUnselectedIn').args[1];
       handler('dummy');
 
       assert.equal(sidebar.toolbar.newAnnotationType, 'note');
@@ -630,7 +630,7 @@ describe('Sidebar', () => {
   });
 
   describe('#onFrameConnected', () => {
-    it('creates a channel to communicate to the guests', () => {
+    it('creates a channel to communicate with the guests', () => {
       const sidebar = createSidebar();
       const { port1 } = new MessageChannel();
       sidebar.onFrameConnected('guest', port1);

--- a/src/types/bridge-events.d.ts
+++ b/src/types/bridge-events.d.ts
@@ -8,14 +8,14 @@
  */
 export type GuestToHostEvent =
   /**
-   * The guest informs the host that text has been deselected at a frame with that identifier.
+   * The guest informs the host that text has been unselected at a frame with that identifier.
    */
-  | 'textDeselectedAt'
+  | 'textUnselectedIn'
 
   /**
    * The guest informs the host that text has been selected at a frame with that identifier.
    */
-  | 'textSelectedAt';
+  | 'textSelectedIn';
 
 /**
  * Events that the guest sends to the sidebar
@@ -63,12 +63,12 @@ export type HostToGuestEvent =
   /**
    * The host request the guest at a frame with that identifier to create an annotation.
    */
-  | 'createAnnotationAt'
+  | 'createAnnotationIn'
 
   /**
    * The host informs the guests that text should be deselected if it doesn't match the current frame identifier.
    */
-  | 'deselectTextExcept';
+  | 'unselectTextExceptIn';
 
 /**
  * Events that the host sends to the sidebar

--- a/src/types/bridge-events.d.ts
+++ b/src/types/bridge-events.d.ts
@@ -4,23 +4,18 @@
  */
 
 /**
- * Events that the host sends to the sidebar
+ * Events that the guest sends to the host
  */
-export type HostToSidebarEvent =
+export type GuestToHostEvent =
   /**
-   * The host informs the sidebar that a guest frame has been destroyed
+   * The guest informs the host that text has been deselected at a frame with that identifier.
    */
-  | 'frameDestroyed'
+  | 'textDeselectedAt'
 
   /**
-   * Highlights have been toggled on/off.
+   * The guest informs the host that text has been selected at a frame with that identifier.
    */
-  | 'setHighlightsVisible'
-
-  /**
-   * The host informs the sidebar that the sidebar has been opened.
-   */
-  | 'sidebarOpened';
+  | 'textSelectedAt';
 
 /**
  * Events that the guest sends to the sidebar
@@ -60,6 +55,39 @@ export type GuestToSidebarEvent =
    * The guest is asking the sidebar to toggle some annotations.
    */
   | 'toggleAnnotationSelection';
+
+/**
+ * Events that the host sends to the guest
+ */
+export type HostToGuestEvent =
+  /**
+   * The host request the guest at a frame with that identifier to create an annotation.
+   */
+  | 'createAnnotationAt'
+
+  /**
+   * The host informs the guests that text should be deselected if it doesn't match the current frame identifier.
+   */
+  | 'deselectTextExcept';
+
+/**
+ * Events that the host sends to the sidebar
+ */
+export type HostToSidebarEvent =
+  /**
+   * The host informs the sidebar that a guest frame has been destroyed
+   */
+  | 'frameDestroyed'
+
+  /**
+   * Highlights have been toggled on/off.
+   */
+  | 'setHighlightsVisible'
+
+  /**
+   * The host informs the sidebar that the sidebar has been opened.
+   */
+  | 'sidebarOpened';
 
 /**
  * Events that the sidebar sends to the guest(s)
@@ -166,7 +194,9 @@ export type SidebarToHostEvent =
   | 'signupRequested';
 
 export type BridgeEvent =
+  | HostToGuestEvent
   | HostToSidebarEvent
+  | GuestToHostEvent
   | GuestToSidebarEvent
   | SidebarToGuestEvent
   | SidebarToHostEvent;


### PR DESCRIPTION
Before this PR, page notes were associated to the URL of the host frame.
This is because the `Guest` class in the host frame was given the 'main'
role.

In this PR, the logic for deciding which frame contains the main
annotatable content is delegated to the `createIntegration` function.
Using some simple heuristics, this function decides which frames
contains the primary annotatable content. For the primary annotatable
frame it returns 'main' as the frame identifier. For other annotatable
frames it returns an identifier of the form `sub_[10 alpha-numerical]`.
The heuristic could be enhanced in the future.

On a second commit, I make the type stricter. This commit could be dropped.

Closes https://github.com/hypothesis/product-backlog/issues/1235

---

**Testing:**

1. Open the [local development VS EPUB page](http://localhost:3000/document/vitalsource-epub)

2. Create a page note for the current chapter

3. Navigate to another chapter, the notes disappears because it is
   associated with the URL of the previous chapter.

In the case of the VS the main annotatable frame is associated with an
specific iframe, not the host frame. For other web pages and PDFs there
should not be any change in behaviour.
