### PR TITLE
Prevent Node globals from being included in typechecking environment

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
-    "lib": ["es2018", "dom", "dom.iterable"],
+    "lib": ["es2020", "dom", "dom.iterable"],
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "module": "commonjs",
@@ -12,9 +12,14 @@
     "target": "ES2020",
 
     // Let argument to catch statement be `any` rather than `unknown`.
-    "useUnknownInCatchVariables": false
+    "useUnknownInCatchVariables": false,
+
+    // Prevent automatic inclusion of global variables defined in `@types/<name>` packages.
+    // This prevents eg. Node globals from `@types/node` being included when writing
+    // code for the browser.
+    "types": []
   },
-  "include": ["**/*.js"],
+  "include": ["**/*.js", "types/process.d.ts"],
   "exclude": [
     // Tests are not checked.
     "**/test/**/*.js",

--- a/src/types/process.d.ts
+++ b/src/types/process.d.ts
@@ -1,0 +1,7 @@
+type Process = { env: Record<string, string> };
+
+/**
+ * Dummy `process` global that supports `process.env.NODE_ENV` checks to guard
+ * debug-only code.
+ */
+declare const process: Process;


### PR DESCRIPTION
By default TypeScript includes all `@types/<name>` packages. This includes
@types/node, though we don't use it directly, because it is a transitive
dependency (see `yarn why @types/node`).

As a result Node's globals are added to the environment TS sees, even though
they don't really exist when our code runs in a browser. These globals
include overloads for `setTimeout` and `setInterval` which return a different
type (`Timeout`), causing spurious errors when assigning the result to a number.

Fix the problem by using the `types` option [1] in tsconfig.json to explicitly
specify which `@types/<name>` packages  to include when checking code in src/
This does mean that if we ever intentionally add @types packages which declare
globals (eg. for mocha), we'll need to explicitly list them here.

In the process the ES target was updated to fix an error about a `BigInt` reference.

[1] https://www.typescriptlang.org/tsconfig#types