### PR TITLE
Update `MarkdownEditor` with shared components, patterns

### DIFF
--- a/src/sidebar/components/MarkdownEditor.js
+++ b/src/sidebar/components/MarkdownEditor.js
@@ -1,5 +1,10 @@
-import classnames from 'classnames';
-import { SvgIcon, normalizeKeyName } from '@hypothesis/frontend-shared';
+import {
+  Icon,
+  IconButton,
+  LabeledButton,
+  Link,
+  normalizeKeyName,
+} from '@hypothesis/frontend-shared';
 import { createRef } from 'preact';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
@@ -108,7 +113,7 @@ function handleToolbarCommand(command, inputEl) {
 function ToolbarButton({
   buttonRef,
   disabled = false,
-  iconName,
+  iconName = '',
   label,
   onClick,
   shortcutKey,
@@ -122,27 +127,27 @@ function ToolbarButton({
     tooltip += ` (${modifierKey}-${shortcutKey.toUpperCase()})`;
   }
 
+  const buttonProps = {
+    buttonRef,
+    disabled,
+    icon: iconName,
+    onClick,
+    tabIndex,
+    title: tooltip,
+  };
+
+  if (label) {
+    return (
+      <LabeledButton
+        classes="u-font--normal TransparentButton"
+        {...buttonProps}
+      >
+        {label}
+      </LabeledButton>
+    );
+  }
   return (
-    <button
-      className={classnames(
-        'MarkdownEditor__toolbar-button',
-        label && 'is-text'
-      )}
-      disabled={disabled}
-      onClick={onClick}
-      aria-label={tooltip}
-      title={tooltip}
-      tabIndex={tabIndex}
-      ref={buttonRef}
-    >
-      {iconName && (
-        <SvgIcon
-          name={iconName}
-          className="MarkdownEditor__toolbar-button-icon"
-        />
-      )}
-      {label}
-    </button>
+    <IconButton classes="MarkdownEditor__toolbar-button" {...buttonProps} />
   );
 }
 
@@ -267,7 +272,7 @@ function Toolbar({ isPreviewing, onCommand, onTogglePreview }) {
 
   return (
     <div
-      className="MarkdownEditor__toolbar"
+      className="hyp-u-layout-row hyp-u-border--left hyp-u-border--right hyp-u-border--top hyp-u-bg-color--white MarkdownEditor__toolbar"
       role="toolbar"
       aria-label="Markdown editor toolbar"
       onKeyDown={handleKeyDown}
@@ -344,22 +349,18 @@ function Toolbar({ isPreviewing, onCommand, onTogglePreview }) {
         title="Bulleted list"
       />
       <span className="hyp-u-stretch" />
-      <div className="MarkdownEditor__toolbar-help-link">
-        <a
+      <div className="hyp-u-layout-row--center">
+        <Link
           href="https://web.hypothes.is/help/formatting-annotations-with-markdown/"
           target="_blank"
-          rel="noopener noreferrer"
-          className="MarkdownEditor__toolbar-button"
-          ref={buttonRefs[buttonIds.help]}
+          classes="u-font--xsmall IconOnlyLink"
+          linkRef={buttonRefs[buttonIds.help]}
           tabIndex={getTabIndex(buttonIds.help)}
           title="Formatting help"
           aria-label="Formatting help"
         >
-          <SvgIcon
-            name="help"
-            className="MarkdownEditor__toolbar-button-icon"
-          />
-        </a>
+          <Icon name="help" />
+        </Link>
       </div>
       <ToolbarButton
         label={isPreviewing ? 'Write' : 'Preview'}
@@ -429,7 +430,7 @@ export default function MarkdownEditor({
   };
 
   return (
-    <div className="MarkdownEditor">
+    <div className="u-line-height">
       <Toolbar
         onCommand={handleCommand}
         isPreviewing={preview}
@@ -438,7 +439,11 @@ export default function MarkdownEditor({
       {preview ? (
         <MarkdownView
           markdown={text}
-          textClass={{ MarkdownEditor__preview: true }}
+          textClass={{
+            'hyp-u-border': true,
+            'hyp-u-bg-color--grey-1': true,
+            'hyp-u-padding': true,
+          }}
           textStyle={textStyle}
         />
       ) : (

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -112,7 +112,7 @@ describe('MarkdownEditor', () => {
         const text = 'toolbar command test';
         const wrapper = createComponent({ text, onEditText });
         const button = wrapper.find(
-          `ToolbarButton[title="${command}"] > button`
+          `ToolbarButton[title="${command}"] > IconButton button`
         );
         const input = wrapper.find('textarea').getDOMNode();
         input.selectionStart = 0;
@@ -153,7 +153,7 @@ describe('MarkdownEditor', () => {
               test.setOs();
               const wrapper = createComponent();
               const button = wrapper.find(
-                `ToolbarButton[title="${command}"] > button`
+                `ToolbarButton[title="${command}"] > IconButton`
               );
 
               const buttonTitlePattern = new RegExp(

--- a/src/styles/sidebar/components/MarkdownEditor.scss
+++ b/src/styles/sidebar/components/MarkdownEditor.scss
@@ -1,62 +1,14 @@
-@use '../../mixins/buttons';
-@use '../../mixins/forms';
-@use '../../mixins/layout';
-@use '../../mixins/utils';
 @use '../../variables' as var;
 
-.MarkdownEditor {
-  /* Reset line-height to avoid having extra gaps/vertical spacing in the
-     element's container
-  */
-  line-height: 1;
-}
+@use '../../mixins/forms';
 
 .MarkdownEditor__toolbar {
-  @include layout.row;
   // Toolbar buttons wrap on non-touch devices if they don't fit. We don't use
   // scrolling because that's less convenient to use with a mouse/touchpad.
   flex-wrap: wrap;
-
-  @include utils.border;
-  border-bottom: none;
-
-  background-color: white;
   border-radius: var.$border-radius var.$border-radius 0 0;
   width: 100%;
-  margin-bottom: -0.1em;
-  padding: 5px 5px;
-}
-
-.MarkdownEditor__toolbar-button {
-  @include buttons.button--icon-only($with-active-state: false);
-  min-width: 24px;
-  min-height: 24px;
-
-  padding-top: 0;
-  padding-bottom: 0;
-
-  color: var.$grey-5;
-  transition: none;
-
-  &:disabled {
-    color: var.$grey-3;
-  }
-}
-
-svg.MarkdownEditor__toolbar-button-icon {
-  // Stronger specificity to override mixin button styling
-  @include utils.icon--xsmall;
-}
-
-.MarkdownEditor__preview {
-  @include utils.border;
-  background-color: var.$grey-1;
-  padding: 10px;
-}
-
-.MarkdownEditor__toolbar-help-link {
-  @include layout.row($align: center);
-  margin-bottom: 2px; // Tweak to align help icon better with adjacent buttons
+  padding: 0.25rem;
 }
 
 .MarkdownEditor__input {
@@ -66,6 +18,11 @@ svg.MarkdownEditor__toolbar-button-icon {
   min-height: 8em;
   resize: vertical;
   width: 100%;
+}
+
+.MarkdownEditor__toolbar-button {
+  padding: 0.5rem;
+  font-size: 10px;
 }
 
 @media (pointer: coarse) {
@@ -84,16 +41,9 @@ svg.MarkdownEditor__toolbar-button-icon {
     // This saves vertical space.
     flex-wrap: unset;
     overflow-x: scroll;
-  }
 
-  // Make the toolbar buttons larger and easier to tap.
-  .MarkdownEditor__toolbar-button {
-    min-width: var.$touch-target-size;
-    min-height: var.$touch-target-size;
-  }
-
-  svg.MarkdownEditor__toolbar-button-icon {
-    // Stronger specificity to override mixin button styling
-    @include utils.icon--small;
+    &-button {
+      font-size: 12px;
+    }
   }
 }

--- a/src/styles/sidebar/frontend-shared.scss
+++ b/src/styles/sidebar/frontend-shared.scss
@@ -32,3 +32,24 @@
     min-height: auto;
   }
 }
+
+// Override any background color on a LabeledButton
+.TransparentButton {
+  background-color: transparent;
+
+  &:hover:not([disabled]) {
+    background-color: transparent;
+  }
+}
+
+// Links
+
+// Styling for a Link that contains only an Icon and no text. Override coloring
+// and add some padding
+.IconOnlyLink {
+  padding: var.$layout-space;
+  color: var.$grey-7;
+  &:hover:not([disabled]) {
+    color: var.$grey-7;
+  }
+}

--- a/src/styles/util.scss
+++ b/src/styles/util.scss
@@ -5,7 +5,7 @@
 // Utility classes
 // These will be extracted and considered when developing typography patterns
 .u-font--xsmall {
-  @include utils.font--xsmall;
+  font-size: 10px;
 }
 
 .u-font--small {
@@ -26,6 +26,10 @@
 
 .u-font--italic {
   font-style: italic;
+}
+
+.u-font--normal {
+  font-weight: normal;
 }
 
 .u-line-height {


### PR DESCRIPTION
Update the `MarkdownEditor` component to use `Icon`, `IconButton`,
`LabeledButton` and `Link` where relevant. Reduce complexity of
local component CSS and use utility styles where possible. Extract
button and link style overrides to `frontend_shared` SASS module.

Part of https://github.com/hypothesis/client/issues/3876
Part of https://github.com/hypothesis/frontend-shared/issues/232

There are some relatively subtle user-visible changes as a result of this. I've endeavored to respect some of the local idiosyncrasies of styling, while reducing the amount of local overrides and letting more "standard" patterns apply.

Before: 

![image](https://user-images.githubusercontent.com/439947/141498516-1d1c5803-8f61-43e1-aa98-4912eb55f7c3.png)

After:

![image](https://user-images.githubusercontent.com/439947/141498612-6450752c-551d-4ecc-84b1-bea38fcb648d.png)

Notably:

* Color is a titch darker to increase contrast and match standard `IconButton` styling
* Vertical height increases by a couple of pixels as standard padding units are applied

After, narrow viewports:

![image](https://user-images.githubusercontent.com/439947/141498814-121b85be-bd69-4658-868c-884094b0a06d.png)
