### PR TITLE
Simplify nomenclature

### DIFF
--- a/src/shared/port-finder.js
+++ b/src/shared/port-finder.js
@@ -7,8 +7,7 @@ const POLLING_INTERVAL_FOR_PORT = 250;
 /**
  * @typedef {import('../types/annotator').Destroyable} Destroyable
  * @typedef {import('./port-util').Message} Message
- * @typedef {Message['channel']} Channel
- * @typedef {Message['port']} Port
+ * @typedef {import('./port-util').Frame} Frame
  */
 
 /**
@@ -16,14 +15,18 @@ const POLLING_INTERVAL_FOR_PORT = 250;
  * MessagePort-based connection to other frames. It is used together with
  * PortProvider which runs in the host frame. See PortProvider for an overview.
  *
- * Channel nomenclature is `[frame1]-[frame2]` so that:
- *   - `port1` should be owned by/transferred to `frame1`, and
- *   - `port2` should be owned by/transferred to `frame2`
- *
  * @implements Destroyable
  */
 export class PortFinder {
-  constructor() {
+  /**
+   * @param {object} options
+   *   @param {Exclude<Frame, 'host'>} options.source - the role of this frame
+   *   @param {Window} options.hostFrame - the frame where the `PortProvider` is
+   *     listening for messages.
+   */
+  constructor({ hostFrame, source }) {
+    this._hostFrame = hostFrame;
+    this._source = source;
     this._listeners = new ListenerCollection();
   }
 
@@ -34,20 +37,16 @@ export class PortFinder {
   /**
    * Request a specific port from `hostFrame`
    *
-   * @param {object} options
-   *   @param {Channel} options.channel - requested channel
-   *   @param {Window} options.hostFrame - frame where the hypothesis client is
-   *     loaded and `PortProvider` is listening for messages
-   *   @param {Port} options.port - requested port
+   * @param {Frame} target - the frame aiming to be discovered
    * @return {Promise<MessagePort>}
    */
-  async discover({ channel, hostFrame, port }) {
+  async discover(target) {
     let isValidRequest = false;
     if (
-      (channel === 'guest-host' && port === 'guest') ||
-      (channel === 'guest-sidebar' && port === 'guest') ||
-      (channel === 'host-sidebar' && port === 'sidebar') ||
-      (channel === 'notebook-sidebar' && port === 'notebook')
+      (this._source === 'guest' && target === 'host') ||
+      (this._source === 'guest' && target === 'sidebar') ||
+      (this._source === 'sidebar' && target === 'host') ||
+      (this._source === 'notebook' && target === 'sidebar')
     ) {
       isValidRequest = true;
     }
@@ -57,26 +56,34 @@ export class PortFinder {
     }
 
     return new Promise((resolve, reject) => {
-      function postRequest() {
-        hostFrame.postMessage(
-          { channel, port, source: 'hypothesis', type: 'request' },
+      const postRequest = () => {
+        this._hostFrame.postMessage(
+          {
+            authority: 'hypothesis',
+            frame1: this._source,
+            frame2: target,
+            type: 'request',
+          },
           '*'
         );
-      }
+      };
 
-      // In some situations, because `guest` iframe/s load in parallel to the `host`
-      // frame, we can not assume that the code in the `host` frame is executed before
-      // the code in a `guest` frame. Hence, we can't assume that `PortProvider` (in
-      // the `host` frame) is initialized before `PortFinder` (in the non-host frames).
-      // Therefore, for the `PortFinder`, we implement a polling strategy (sending a
-      // message every N milliseconds) until a response is received.
+      // Because `guest` iframes load in parallel to the `host` frame, we can
+      // not assume that the code in the `host` frame is executed before the
+      // code in a `guest` frame. Hence, we can't assume that `PortProvider` (in
+      // the `host` frame) is initialized before `PortFinder` (in the non-host
+      // frames). Therefore, for the `PortFinder`, we implement a polling
+      // strategy (sending a message every N milliseconds) until a response is
+      // received.
       const intervalId = setInterval(postRequest, POLLING_INTERVAL_FOR_PORT);
 
       // The `host` frame maybe busy, that's why we should wait.
       const timeoutId = setTimeout(() => {
         clearInterval(intervalId);
         reject(
-          new Error(`Unable to find '${port}' port on '${channel}' channel`)
+          new Error(
+            `Unable to establish ${this._source}-${target} communication channel`
+          )
         );
       }, MAX_WAIT_FOR_PORT);
 
@@ -84,9 +91,9 @@ export class PortFinder {
         const { data, ports } = /** @type {MessageEvent} */ (event);
         if (
           isMessageEqual(data, {
-            channel,
-            port,
-            source: 'hypothesis',
+            authority: 'hypothesis',
+            frame1: this._source,
+            frame2: target,
             type: 'offer',
           })
         ) {

--- a/src/shared/port-finder.js
+++ b/src/shared/port-finder.js
@@ -35,7 +35,7 @@ export class PortFinder {
   }
 
   /**
-   * Request a specific port from `hostFrame`
+   * Request a specific port from the host frame
    *
    * @param {Frame} target - the frame aiming to be discovered
    * @return {Promise<MessagePort>}

--- a/src/shared/port-util.js
+++ b/src/shared/port-util.js
@@ -3,20 +3,19 @@
 // message and avoid listening to messages that could have the same properties
 // but different source. This is not a security feature but an
 // anti-collision mechanism.
-const SOURCE = 'hypothesis';
+const AUTHORITY = 'hypothesis';
 
 /**
  * These types are the used in by `PortProvider` and `PortFinder` for the
  * inter-frame discovery and communication processes.
  *
- * @typedef {'guest-host'|'guest-sidebar'|'host-sidebar'|'notebook-sidebar'} Channel
- * @typedef {'guest'|'host'|'notebook'|'sidebar'} Port
+ * @typedef {'guest'|'host'|'notebook'|'sidebar'} Frame
  *
  * @typedef Message
- * @prop {Channel} channel
- * @prop {Port} port
- * @prop {'offer'|'request'}  type
- * @prop {SOURCE} source -
+ * @prop {AUTHORITY} authority
+ * @prop {Frame} frame1
+ * @prop {Frame} frame2
+ * @prop {'offer'|'request'} type
  */
 
 /**
@@ -26,18 +25,18 @@ const SOURCE = 'hypothesis';
  * @param {any} data
  * @return {data is Message}
  */
-function isMessageValid(data) {
+function isMessage(data) {
   if (data === null || typeof data !== 'object') {
     return false;
   }
 
-  for (let property of ['channel', 'port', 'source', 'type']) {
+  for (let property of ['frame1', 'frame2', 'type']) {
     if (typeof data[property] !== 'string') {
       return false;
     }
   }
 
-  return data.source === SOURCE;
+  return data.authority === AUTHORITY;
 }
 
 /**
@@ -47,7 +46,7 @@ function isMessageValid(data) {
  * @param {Message} message
  */
 export function isMessageEqual(data, message) {
-  if (!isMessageValid(data)) {
+  if (!isMessage(data)) {
     return false;
   }
 

--- a/src/shared/port-util.js
+++ b/src/shared/port-util.js
@@ -59,3 +59,24 @@ export function isMessageEqual(data, message) {
     return false;
   }
 }
+
+/**
+ * Check that source is of type Window.
+ *
+ * @param {MessageEventSource|null} source
+ * @return {source is Window}
+ */
+export function isSourceWindow(source) {
+  if (
+    // `source` can be of type Window | MessagePort | ServiceWorker.
+    // The simple check `source instanceof Window`` doesn't work here.
+    // Alternatively, `source` could be casted `/** @type{Window} */ (source)`
+    source === null ||
+    source instanceof MessagePort ||
+    source instanceof ServiceWorker
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/shared/test/port-provider-test.js
+++ b/src/shared/test/port-provider-test.js
@@ -83,31 +83,6 @@ describe('PortProvider', () => {
 
   describe('listens for port requests', () => {
     [
-      { source: null, reason: 'source is null' },
-      {
-        source: new MessageChannel().port1,
-        reason: 'source is a MessageChannel',
-      },
-    ].forEach(({ source, reason }) =>
-      it(`ignores port requests if ${reason}`, async () => {
-        portProvider.listen();
-        const data = {
-          authority,
-          frame1: 'sidebar',
-          frame2: 'host',
-          type: 'request',
-        };
-
-        await sendPortFinderRequest({
-          data,
-          source,
-        });
-
-        assert.notCalled(window.postMessage);
-      })
-    );
-
-    [
       // Disabled this check because it make axes-core to crash
       // Reported: https://github.com/dequelabs/axe-core/pull/3249
       //{ data: null, reason: 'if message is null' },
@@ -154,15 +129,26 @@ describe('PortProvider', () => {
           frame2: 'host',
           type: 'request',
         },
+        source: null,
+        reason: 'comes from invalid source',
+      },
+      {
+        data: {
+          authority,
+          frame1: 'sidebar',
+          frame2: 'host',
+          type: 'request',
+        },
         origin: 'https://dummy.com',
         reason: 'comes from invalid origin',
       },
-    ].forEach(({ data, reason, origin }) => {
+    ].forEach(({ data, reason, origin, source }) => {
       it(`ignores port request if message ${reason}`, async () => {
         portProvider.listen();
         await sendPortFinderRequest({
           data,
-          origin: origin ?? window.location.origin,
+          origin,
+          source,
         });
 
         assert.notCalled(window.postMessage);

--- a/src/shared/test/port-util-test.js
+++ b/src/shared/test/port-util-test.js
@@ -1,138 +1,98 @@
 import { isMessageEqual } from '../port-util';
 
-const source = 'hypothesis';
-
 describe('port-util', () => {
   describe('isMessageEqual', () => {
+    const authority = 'hypothesis';
+    const frame1 = 'guest';
+    const frame2 = 'sidebar';
+    const type = 'offer';
+
     [
       {
         data: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-        },
-        message: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
+          authority,
+          frame1,
+          frame2,
+          type,
         },
         expectedResult: true,
         reason: 'data matches the message',
       },
       {
         data: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-        },
-        message: {
-          source,
-          type: 'offer',
-          channel: 'host-sidebar',
-          port: 'guest',
+          authority,
+          frame1,
+          frame2,
+          type,
         },
         expectedResult: true,
         reason: 'data matches the message (properties in different order)',
       },
       {
         data: null,
-        message: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-        },
         expectedResult: false,
         reason: 'data is null',
       },
       {
         data: {
-          channel: 'host-sidebar',
-          port: 9, // wrong type
-          source,
-          type: 'offer',
-        },
-        message: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-        },
-        expectedResult: false,
-        reason: 'data has a property with the wrong type',
-      },
-      {
-        data: {
-          // channel property missing
-          port: 'guest',
-          source,
-          type: 'offer',
-        },
-        message: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
+          authority,
+          // frame1 property missing
+          frame2,
+          type,
         },
         expectedResult: false,
         reason: 'data has one property that is missing',
       },
       {
         data: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-          extra: 'dummy', // additional
+          authority,
+          frame1,
+          frame2: 9, // wrong type
+          type,
         },
-        message: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
+        expectedResult: false,
+        reason: 'data has one property with a wrong type',
+      },
+      {
+        data: {
+          authority,
+          extra: 'dummy', // additional
+          frame1,
+          frame2,
+          type,
         },
         expectedResult: false,
         reason: 'data has one additional property',
       },
       {
         data: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-          window, // not serializable
-        },
-        message: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-        },
-        expectedResult: false,
-        reason: "data has one property that can't be serialized",
-      },
-      {
-        data: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-        },
-        message: {
-          channel: 'guest-sidebar', // different
-          port: 'guest',
-          source,
-          type: 'offer',
+          authority,
+          frame1: 'dummy', // different
+          frame2,
+          type,
         },
         expectedResult: false,
         reason: 'data has one property that is different',
       },
-    ].forEach(({ data, message, expectedResult, reason }) => {
+      {
+        data: {
+          authority,
+          frame1,
+          frame2,
+          type,
+          window, // not serializable
+        },
+        expectedResult: false,
+        reason: "data has one property that can't be serialized",
+      },
+    ].forEach(({ data, expectedResult, reason }) => {
       it(`returns '${expectedResult}' because the ${reason}`, () => {
-        const result = isMessageEqual(data, message);
+        const result = isMessageEqual(data, {
+          authority,
+          frame1,
+          frame2,
+          type,
+        });
         assert.equal(result, expectedResult);
       });
     });

--- a/src/shared/test/port-util-test.js
+++ b/src/shared/test/port-util-test.js
@@ -1,4 +1,4 @@
-import { isMessageEqual } from '../port-util';
+import { isMessageEqual, isSourceWindow } from '../port-util';
 
 describe('port-util', () => {
   describe('isMessageEqual', () => {
@@ -96,5 +96,34 @@ describe('port-util', () => {
         assert.equal(result, expectedResult);
       });
     });
+  });
+
+  describe('isSourceWindow', () => {
+    [
+      {
+        expectedResult: true,
+        reason: 'Window',
+        source: window,
+      },
+      {
+        expectedResult: false,
+        reason: 'null',
+        source: null,
+      },
+      {
+        expectedResult: false,
+        reason: 'MessagePort',
+        source: new MessageChannel().port1,
+      },
+      {
+        expectedResult: false,
+        reason: 'ServiceWorker',
+        source: Object.create(ServiceWorker.prototype),
+      },
+    ].forEach(({ expectedResult, reason, source }) =>
+      it(`returns '${expectedResult}' because the source is ${reason}`, () => {
+        assert.equal(expectedResult, isSourceWindow(source));
+      })
+    );
   });
 });


### PR DESCRIPTION
For PortFinder, I followed this advice:
https://github.com/hypothesis/client/pull/3881#discussion_r743030606,
except that I made the argument of `PorFinder#discover` a string (instead of an object).

```
const portFinder = new PortFinder({ source: 'guest', hostFrame });
portFinder.discover('sidebar');
portFinder.discover('host');
```

For PortProvider, I followed this advice:
https://github.com/hypothesis/client/pull/3881#discussion_r743033013,
except that I used a getter.

```
cont portProvider = new PortProvider(...)
const bridge = new Bridge();
bridge.createChannel(portProvider.sidebarPort);
```

I have renamed the properties of `Message`:
- `source` becomes `authority`
- `channel` and `port` have been replaced by `frame1` and `frame2`

I did that to align `port1` and `frame1` and `port2` and `frame2`, while
also avoiding clashing with other names (`source`, `target`) which have
other meaning in the `window.postMessage` context.

I have removed a level of nesting in the `PortProvider#discover` that
make the method more readable.

I added some other suggestions from PR #3881.