### PR TITLE
Rename bridge to contain the name of the target frame

### DIFF
--- a/src/annotator/annotation-sync.js
+++ b/src/annotator/annotation-sync.js
@@ -28,11 +28,11 @@
 export class AnnotationSync {
   /**
    * @param {EventBus} eventBus - Event bus for communicating with the annotator code (eg. the Guest)
-   * @param {SidebarBridge} bridge - Channel for communicating with the sidebar
+   * @param {SidebarBridge} sidebarBridge - Channel for communicating with the sidebar
    */
-  constructor(eventBus, bridge) {
+  constructor(eventBus, sidebarBridge) {
     this._emitter = eventBus.createEmitter();
-    this._sidebar = bridge;
+    this._sidebarRPC = sidebarBridge;
 
     /**
      * Mapping from annotation tags to annotation objects for annotations which
@@ -45,7 +45,7 @@ export class AnnotationSync {
     this.destroyed = false;
 
     // Relay events from the sidebar to the rest of the annotator.
-    this._sidebar.on('deleteAnnotation', (body, callback) => {
+    this._sidebarRPC.on('deleteAnnotation', (body, callback) => {
       if (this.destroyed) {
         callback(null);
         return;
@@ -57,7 +57,7 @@ export class AnnotationSync {
       callback(null);
     });
 
-    this._sidebar.on('loadAnnotations', (bodies, callback) => {
+    this._sidebarRPC.on('loadAnnotations', (bodies, callback) => {
       if (this.destroyed) {
         callback(null);
         return;
@@ -72,7 +72,7 @@ export class AnnotationSync {
       if (annotation.$tag) {
         return;
       }
-      this._sidebar.call('createAnnotation', this._format(annotation));
+      this._sidebarRPC.call('createAnnotation', this._format(annotation));
     });
   }
 
@@ -89,7 +89,7 @@ export class AnnotationSync {
       return;
     }
 
-    this._sidebar.call(
+    this._sidebarRPC.call(
       'syncAnchoringStatus',
       annotations.map(ann => this._format(ann))
     );


### PR DESCRIPTION
In a future PR (#3904), `Guest` will contain two bridges (like `FrameSync`).
Naming them by the destination frame will help identify the purpose of
it.

The agreed name for this `Bridge`s is to contain the word `RPC` to
indicate that it is a remote (inter-frame) procedure.