### PR TITLE
Type and private properties methods

### DIFF
--- a/src/annotator/annotation-sync.js
+++ b/src/annotator/annotation-sync.js
@@ -28,11 +28,11 @@
 export class AnnotationSync {
   /**
    * @param {EventBus} eventBus - Event bus for communicating with the annotator code (eg. the Guest)
-   * @param {SidebarBridge} bridge - Channel for communicating with the sidebar
+   * @param {SidebarBridge} sidebarBridge - Channel for communicating with the sidebar
    */
-  constructor(eventBus, bridge) {
+  constructor(eventBus, sidebarBridge) {
     this._emitter = eventBus.createEmitter();
-    this._sidebar = bridge;
+    this._sidebarRPC = sidebarBridge;
 
     /**
      * Mapping from annotation tags to annotation objects for annotations which
@@ -45,7 +45,7 @@ export class AnnotationSync {
     this.destroyed = false;
 
     // Relay events from the sidebar to the rest of the annotator.
-    this._sidebar.on('deleteAnnotation', (body, callback) => {
+    this._sidebarRPC.on('deleteAnnotation', (body, callback) => {
       if (this.destroyed) {
         callback(null);
         return;
@@ -57,7 +57,7 @@ export class AnnotationSync {
       callback(null);
     });
 
-    this._sidebar.on('loadAnnotations', (bodies, callback) => {
+    this._sidebarRPC.on('loadAnnotations', (bodies, callback) => {
       if (this.destroyed) {
         callback(null);
         return;
@@ -72,7 +72,7 @@ export class AnnotationSync {
       if (annotation.$tag) {
         return;
       }
-      this._sidebar.call('createAnnotation', this._format(annotation));
+      this._sidebarRPC.call('createAnnotation', this._format(annotation));
     });
   }
 
@@ -89,7 +89,7 @@ export class AnnotationSync {
       return;
     }
 
-    this._sidebar.call(
+    this._sidebarRPC.call(
       'syncAnchoringStatus',
       annotations.map(ann => this._format(ann))
     );

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -1,4 +1,5 @@
 import { Bridge } from '../shared/bridge';
+import { PortFinder } from '../shared/port-finder';
 import { ListenerCollection } from '../shared/listener-collection';
 
 import { Adder } from './adder';
@@ -117,11 +118,8 @@ export default class Guest {
    * @param {EventBus} eventBus -
    *   Enables communication between components sharing the same eventBus
    * @param {Record<string, any>} [config]
-   * @param {Window} [hostFrame] -
-   *   Host frame which this guest is associated with. This is expected to be
-   *   an ancestor of the guest frame. It may be same or cross origin.
    */
-  constructor(element, eventBus, config = {}, hostFrame = window) {
+  constructor(element, eventBus, config = {}) {
     this.element = element;
     this._emitter = eventBus.createEmitter();
     this._highlightsVisible = false;
@@ -162,10 +160,17 @@ export default class Guest {
 
     // Set the frame identifier if it's available.
     // The "top" guest instance will have this as null since it's in a top frame not a sub frame
-    this._frameIdentifier = config.subFrameIdentifier || null;
+    /** @type {string|null} */
+    this._frameIdentifier = config.subFrameIdentifier;
+    this._hostFrame =
+      config.subFrameIdentifier === null ? window : window.parent;
+    this._portFinder = new PortFinder({
+      hostFrame: this._hostFrame,
+      source: 'guest',
+    });
 
     /**
-     * Channel for sidebar-guest communication.
+     * Channel for guest-sidebar communication.
      *
      * @type {Bridge<GuestToSidebarEvent,SidebarToGuestEvent>}
      */
@@ -176,6 +181,10 @@ export default class Guest {
     // in this frame.
     this._annotationSync = new AnnotationSync(eventBus, this._bridge);
     this._connectAnnotationSync();
+
+    // Discover and connect to the sidebar frame. All RPC events must be
+    // registered before creating the channel.
+    this._connectToSidebar();
 
     // Set up automatic and integration-triggered injection of client into
     // iframes in this frame.
@@ -202,7 +211,6 @@ export default class Guest {
      */
     this._focusedAnnotations = new Set();
 
-    this._hostFrame = hostFrame;
     this._listeners.add(window, 'unload', () => this._notifyGuestUnload());
   }
 
@@ -361,7 +369,16 @@ export default class Guest {
     });
   }
 
+  /**
+   * Attempt to connect to the sidebar frame.
+   */
+  async _connectToSidebar() {
+    const sidebarPort = await this._portFinder.discover('sidebar');
+    this._bridge.createChannel(sidebarPort);
+  }
+
   destroy() {
+    this._portFinder.destroy();
     this._notifyGuestUnload();
     this._hypothesisInjector.destroy();
     this._listeners.removeAll();
@@ -387,25 +404,8 @@ export default class Guest {
       type: 'hypothesisGuestUnloaded',
       frameIdentifier: this._frameIdentifier,
     };
-    this._hostFrame.postMessage(message, '*');
-  }
 
-  /**
-   * Attempt to connect to the sidebar frame.
-   *
-   * @param {Window} frame - The window containing the sidebar application
-   * @param {string} origin - Origin of the sidebar application (eg. 'https://hypothes.is/')
-   */
-  connectToSidebar(frame, origin) {
-    const channel = new MessageChannel();
-    frame.postMessage(
-      {
-        type: 'hypothesisGuestReady',
-      },
-      origin,
-      [channel.port2]
-    );
-    this._bridge.createChannel(channel.port1);
+    this._hostFrame.postMessage(message, '*');
   }
 
   /**

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -19,8 +19,6 @@ import Notebook from './notebook';
 import Sidebar from './sidebar';
 import { EventBus } from './util/emitter';
 
-const window_ = /** @type {HypothesisWindow} */ (window);
-
 // Look up the URL of the sidebar. This element is added to the page by the
 // boot script before the "annotator" bundle loads.
 const sidebarLinkElement = /** @type {HTMLLinkElement} */ (
@@ -42,63 +40,26 @@ const sidebarLinkElement = /** @type {HTMLLinkElement} */ (
  * client is initially loaded, is also the only guest frame.
  */
 function init() {
-  // Create an internal global used to share data between same-origin guest and
-  // host frames.
-  window_.__hypothesis = {};
-
   const annotatorConfig = getConfig('annotator');
-  const hostFrame = annotatorConfig.subFrameIdentifier ? window.parent : window;
+  const isHostFrame = annotatorConfig.subFrameIdentifier === null;
 
   // Create the guest that handles creating annotations and displaying highlights.
   const eventBus = new EventBus();
-  const guest = new Guest(document.body, eventBus, annotatorConfig, hostFrame);
+  const guest = new Guest(document.body, eventBus, annotatorConfig);
 
   let sidebar;
-  if (window === hostFrame) {
+  let notebook;
+  if (isHostFrame) {
     sidebar = new Sidebar(document.body, eventBus, guest, getConfig('sidebar'));
 
-    // Expose sidebar window reference for use by same-origin guest frames.
-    window_.__hypothesis.sidebarWindow = sidebar.ready.then(() => [
-      sidebar.iframe.contentWindow,
-    ]);
-  }
-
-  // Clear `annotations` value from the notebook's config to prevent direct-linked
-  // annotations from filtering the threads.
-  const notebook = new Notebook(document.body, eventBus, getConfig('notebook'));
-
-  // Set up communication between this host/guest frame and the sidebar frame.
-  let sidebarWindow = window_.__hypothesis.sidebarWindow;
-  try {
-    // If this is a guest-only frame which doesn't have its own sidebar, try
-    // to connect to the one created by the parent frame. This only works if
-    // the host and guest frames are same-origin.
-    if (!sidebarWindow) {
-      sidebarWindow = /** @type {HypothesisWindow} */ (window.parent)
-        .__hypothesis?.sidebarWindow;
-    }
-  } catch {
-    // `window.parent` access can fail due to it being cross-origin.
-  }
-
-  if (sidebarWindow) {
-    const sidebarOrigin = new URL(sidebarLinkElement.href).origin;
-    sidebarWindow.then(([frame]) =>
-      guest.connectToSidebar(frame, sidebarOrigin)
-    );
-  } else {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `Hypothesis guest frame in ${location.origin} could not find a sidebar to connect to.
-Guest frames can only connect to sidebars in their same-origin parent frame.`
-    );
+    // Clear `annotations` value from the notebook's config to prevent direct-linked
+    // annotations from filtering the threads.
+    notebook = new Notebook(document.body, eventBus, getConfig('notebook'));
   }
 
   sidebarLinkElement.addEventListener('destroy', () => {
-    delete window_.__hypothesis;
     sidebar?.destroy();
-
-    notebook.destroy();
+    notebook?.destroy();
     guest.destroy();
 
     // Remove all the `<link>`, `<script>` and `<style>` elements added to the

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -18,6 +18,8 @@ import { createShadowRoot } from './util/shadow-root';
  * @typedef {import('../types/bridge-events').SidebarToHostEvent} SidebarToHostEvent
  * @typedef {import('../types/annotator').SidebarLayout} SidebarLayout
  * @typedef {import('../types/annotator').Destroyable} Destroyable
+ * @typedef {'contentContainer'|'createAnnotation'|'fitSideBySide'} DependenciesSidebar
+ * @typedef {'anchors'|'scrollToAnchor'|'selectAnnotations'} DependenciesBucketBar
  */
 
 // Minimum width to which the iframeContainer can be resized.
@@ -57,7 +59,7 @@ export default class Sidebar {
    * @param {HTMLElement} element
    * @param {import('./util/emitter').EventBus} eventBus -
    *   Enables communication between components sharing the same eventBus
-   * @param {Guest} guest -
+   * @param {Pick<Guest, DependenciesSidebar|DependenciesBucketBar>} guest -
    *   The `Guest` instance for the current frame. It is currently assumed that
    *   it is always possible to annotate in the frame where the sidebar is
    *   displayed.

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -2,6 +2,7 @@ import Hammer from 'hammerjs';
 
 import { Bridge } from '../shared/bridge';
 import { ListenerCollection } from '../shared/listener-collection';
+import { PortProvider } from '../shared/port-provider';
 
 import { annotationCounts } from './annotation-counts';
 import BucketBar from './bucket-bar';
@@ -64,9 +65,11 @@ export default class Sidebar {
    */
   constructor(element, eventBus, guest, config = {}) {
     this._emitter = eventBus.createEmitter();
+    const hypothesisAppsOrigin = new URL(config.sidebarAppUrl).origin;
+    this._portProvider = new PortProvider(hypothesisAppsOrigin);
 
     /**
-     * Channel for sidebar-host communication.
+     * Channel for host-sidebar communication.
      *
      * @type {Bridge<HostToSidebarEvent,SidebarToHostEvent>}
      */
@@ -172,23 +175,7 @@ export default class Sidebar {
     this._notifyOfLayoutChange(false);
     this._setupSidebarEvents();
 
-    /**
-     * A promise that resolves when the sidebar application is ready to
-     * communicate with the host and guest frames.
-     *
-     * @type {Promise<void>}
-     */
-    this.ready = new Promise(resolve => {
-      this._listeners.add(window, 'message', event => {
-        const { data, ports } = /** @type {MessageEvent} */ (event);
-        if (data?.type === 'hypothesisSidebarReady') {
-          this._sidebarRPC.createChannel(ports[0]);
-          resolve();
-        }
-      });
-    });
-
-    this.ready.then(() => {
+    this._sidebarRPC.onConnect(() => {
       // Show the UI
       if (this.iframeContainer) {
         this.iframeContainer.style.display = '';
@@ -210,6 +197,10 @@ export default class Sidebar {
       }
     });
 
+    // Create channel *after* all bridge events are registered with the `on` method.
+    this._sidebarRPC.createChannel(this._portProvider.sidebarPort);
+    this._portProvider.listen();
+
     // Notify sidebar when a guest is unloaded. This message is routed via
     // the host frame because in Safari guest frames are unable to send messages
     // directly to the sidebar during a window's 'unload' event.
@@ -223,6 +214,7 @@ export default class Sidebar {
   }
 
   destroy() {
+    this._portProvider.destroy();
     this.bucketBar?.destroy();
     this._listeners.removeAll();
     this._hammerManager?.destroy();

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1,3 +1,4 @@
+import { delay } from '../../test-util/wait';
 import Guest, { $imports } from '../guest';
 import { EventBus } from '../util/emitter';
 
@@ -30,36 +31,29 @@ class FakeTextRange {
 describe('Guest', () => {
   const sandbox = sinon.createSandbox();
   let eventBus;
+  let guests;
   let highlighter;
   let rangeUtil;
   let notifySelectionChanged;
 
-  let hostFrame;
-
   let FakeAnnotationSync;
   let fakeAnnotationSync;
-  let FakeBridge;
   let fakeBridge;
-
-  let fakeCreateIntegration;
   let fakeIntegration;
-
   let FakeHypothesisInjector;
   let fakeHypothesisInjector;
-
-  let guests;
+  let fakePortFinder;
 
   const createGuest = (config = {}) => {
     const element = document.createElement('div');
     eventBus = new EventBus();
-    const guest = new Guest(element, eventBus, config, hostFrame);
+    const guest = new Guest(element, eventBus, config);
     guests.push(guest);
     return guest;
   };
 
   beforeEach(() => {
     guests = [];
-    FakeAdder.instance = null;
     highlighter = {
       getHighlightsContainingNode: sinon.stub().returns([]),
       highlightRange: sinon.stub().returns([]),
@@ -75,6 +69,8 @@ describe('Guest', () => {
     };
     notifySelectionChanged = null;
 
+    FakeAdder.instance = null;
+
     fakeAnnotationSync = {
       destroy: sinon.stub(),
       sync: sinon.stub(),
@@ -87,7 +83,6 @@ describe('Guest', () => {
       destroy: sinon.stub(),
       on: sinon.stub(),
     };
-    FakeBridge = sinon.stub().returns(fakeBridge);
 
     fakeIntegration = {
       anchor: sinon.stub(),
@@ -104,17 +99,16 @@ describe('Guest', () => {
       uri: sinon.stub().resolves('https://example.com/test.pdf'),
     };
 
-    fakeCreateIntegration = sinon.stub().returns(fakeIntegration);
-
-    hostFrame = {
-      postMessage: sinon.stub(),
-    };
-
     fakeHypothesisInjector = {
       destroy: sinon.stub(),
       injectClient: sinon.stub().resolves(),
     };
     FakeHypothesisInjector = sinon.stub().returns(fakeHypothesisInjector);
+
+    fakePortFinder = {
+      discover: sinon.stub(),
+      destroy: sinon.stub(),
+    };
 
     class FakeSelectionObserver {
       constructor(callback) {
@@ -123,14 +117,21 @@ describe('Guest', () => {
       }
     }
 
+    sandbox.stub(window.parent, 'postMessage');
+
     $imports.$mock({
-      '../shared/bridge': { Bridge: FakeBridge },
+      '../shared/bridge': { Bridge: sinon.stub().returns(fakeBridge) },
+      '../shared/port-finder': {
+        PortFinder: sinon.stub().returns(fakePortFinder),
+      },
       './adder': { Adder: FakeAdder },
       './anchoring/text-range': {
         TextRange: FakeTextRange,
       },
       './annotation-sync': { AnnotationSync: FakeAnnotationSync },
-      './integrations': { createIntegration: fakeCreateIntegration },
+      './integrations': {
+        createIntegration: sinon.stub().returns(fakeIntegration),
+      },
       './highlighter': highlighter,
       './hypothesis-injector': { HypothesisInjector: FakeHypothesisInjector },
       './range-util': rangeUtil,
@@ -1135,7 +1136,7 @@ describe('Guest', () => {
       guest.destroy();
 
       assert.calledWith(
-        hostFrame.postMessage,
+        window.parent.postMessage,
         {
           type: 'hypothesisGuestUnloaded',
           frameIdentifier: 'frame-id',
@@ -1151,7 +1152,7 @@ describe('Guest', () => {
     window.dispatchEvent(new Event('unload'));
 
     assert.calledWith(
-      hostFrame.postMessage,
+      window.parent.postMessage,
       {
         type: 'hypothesisGuestUnloaded',
         frameIdentifier: 'frame-id',
@@ -1164,6 +1165,19 @@ describe('Guest', () => {
     const guest = createGuest();
     guest.destroy();
     assert.calledWith(fakeHypothesisInjector.destroy);
+  });
+
+  it('discovers and creates a channel for communication with the sidebar', async () => {
+    const { port1 } = new MessageChannel();
+    fakePortFinder.discover.resolves(port1);
+    createGuest();
+
+    await delay(0);
+
+    assert.calledWith(
+      fakeBridge.createChannel,
+      sinon.match.instanceOf(MessagePort)
+    );
   });
 
   describe('#contentContainer', () => {
@@ -1211,37 +1225,6 @@ describe('Guest', () => {
 
       assert.calledWith(FakeHypothesisInjector, guest.element, config);
       assert.calledWith(fakeHypothesisInjector.injectClient, frame);
-    });
-  });
-
-  describe('#connectToSidebar', () => {
-    it('sends a `hypothesisGuestReady` notification to the sidebar', async () => {
-      const guest = createGuest();
-      const sidebarFrame = { postMessage: sinon.stub() };
-      const sidebarOrigin = 'https://dummy.hypothes.is/';
-
-      guest.connectToSidebar(sidebarFrame, sidebarOrigin);
-
-      assert.calledWith(
-        sidebarFrame.postMessage,
-        {
-          type: 'hypothesisGuestReady',
-        },
-        sidebarOrigin,
-        [sinon.match.instanceOf(MessagePort)]
-      );
-    });
-
-    it('creates a channel for communication with the sidebar', () => {
-      const guest = createGuest();
-      const sidebarFrame = { postMessage: sinon.stub() };
-
-      guest.connectToSidebar(sidebarFrame, 'https://dummy.hypothes.is');
-
-      assert.calledWith(
-        fakeBridge.createChannel,
-        sinon.match.instanceOf(MessagePort)
-      );
     });
   });
 });

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -1,7 +1,7 @@
 // Tests that the expected parts of the page are highlighted when annotations
 // with various combinations of selector are anchored.
 
-import Guest from '../../guest';
+import Guest, { $imports } from '../../guest';
 import { EventBus } from '../../util/emitter';
 import testPageHTML from './test-page.html';
 
@@ -50,6 +50,15 @@ describe('anchoring', () => {
     container.innerHTML = testPageHTML;
     document.body.appendChild(container);
     const eventBus = new EventBus();
+    const fakePortFinder = {
+      discover: sinon.stub().resolves(new MessageChannel().port1),
+      destroy: sinon.stub(),
+    };
+    $imports.$mock({
+      '../shared/port-finder': {
+        PortFinder: sinon.stub().returns(fakePortFinder),
+      },
+    });
     guest = new Guest(container, eventBus);
   });
 
@@ -57,6 +66,7 @@ describe('anchoring', () => {
     guest.destroy();
     container.remove();
     console.warn.restore();
+    $imports.$restore();
   });
 
   [

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -225,11 +225,11 @@ describe('Sidebar', () => {
     });
 
     it('creates an annotation when toolbar button is clicked', () => {
-      const sidebar = createSidebar();
+      createSidebar();
 
       FakeToolbarController.args[0][1].createAnnotation();
 
-      assert.called(sidebar.guest.createAnnotation);
+      assert.called(fakeGuest.createAnnotation);
     });
 
     it('sets create annotation button to "Annotation" when selection becomes non-empty', () => {

--- a/src/shared/port-finder.js
+++ b/src/shared/port-finder.js
@@ -7,8 +7,7 @@ const POLLING_INTERVAL_FOR_PORT = 250;
 /**
  * @typedef {import('../types/annotator').Destroyable} Destroyable
  * @typedef {import('./port-util').Message} Message
- * @typedef {Message['channel']} Channel
- * @typedef {Message['port']} Port
+ * @typedef {import('./port-util').Frame} Frame
  */
 
 /**
@@ -16,14 +15,18 @@ const POLLING_INTERVAL_FOR_PORT = 250;
  * MessagePort-based connection to other frames. It is used together with
  * PortProvider which runs in the host frame. See PortProvider for an overview.
  *
- * Channel nomenclature is `[frame1]-[frame2]` so that:
- *   - `port1` should be owned by/transferred to `frame1`, and
- *   - `port2` should be owned by/transferred to `frame2`
- *
  * @implements Destroyable
  */
 export class PortFinder {
-  constructor() {
+  /**
+   * @param {object} options
+   *   @param {Exclude<Frame, 'host'>} options.source - the role of this frame
+   *   @param {Window} options.hostFrame - the frame where the `PortProvider` is
+   *     listening for messages.
+   */
+  constructor({ hostFrame, source }) {
+    this._hostFrame = hostFrame;
+    this._source = source;
     this._listeners = new ListenerCollection();
   }
 
@@ -34,20 +37,16 @@ export class PortFinder {
   /**
    * Request a specific port from `hostFrame`
    *
-   * @param {object} options
-   *   @param {Channel} options.channel - requested channel
-   *   @param {Window} options.hostFrame - frame where the hypothesis client is
-   *     loaded and `PortProvider` is listening for messages
-   *   @param {Port} options.port - requested port
+   * @param {Frame} target - the frame aiming to be discovered
    * @return {Promise<MessagePort>}
    */
-  async discover({ channel, hostFrame, port }) {
+  async discover(target) {
     let isValidRequest = false;
     if (
-      (channel === 'guest-host' && port === 'guest') ||
-      (channel === 'guest-sidebar' && port === 'guest') ||
-      (channel === 'host-sidebar' && port === 'sidebar') ||
-      (channel === 'notebook-sidebar' && port === 'notebook')
+      (this._source === 'guest' && target === 'host') ||
+      (this._source === 'guest' && target === 'sidebar') ||
+      (this._source === 'sidebar' && target === 'host') ||
+      (this._source === 'notebook' && target === 'sidebar')
     ) {
       isValidRequest = true;
     }
@@ -57,26 +56,34 @@ export class PortFinder {
     }
 
     return new Promise((resolve, reject) => {
-      function postRequest() {
-        hostFrame.postMessage(
-          { channel, port, source: 'hypothesis', type: 'request' },
+      const postRequest = () => {
+        this._hostFrame.postMessage(
+          {
+            authority: 'hypothesis',
+            frame1: this._source,
+            frame2: target,
+            type: 'request',
+          },
           '*'
         );
-      }
+      };
 
-      // In some situations, because `guest` iframe/s load in parallel to the `host`
-      // frame, we can not assume that the code in the `host` frame is executed before
-      // the code in a `guest` frame. Hence, we can't assume that `PortProvider` (in
-      // the `host` frame) is initialized before `PortFinder` (in the non-host frames).
-      // Therefore, for the `PortFinder`, we implement a polling strategy (sending a
-      // message every N milliseconds) until a response is received.
+      // Because `guest` iframes load in parallel to the `host` frame, we can
+      // not assume that the code in the `host` frame is executed before the
+      // code in a `guest` frame. Hence, we can't assume that `PortProvider` (in
+      // the `host` frame) is initialized before `PortFinder` (in the non-host
+      // frames). Therefore, for the `PortFinder`, we implement a polling
+      // strategy (sending a message every N milliseconds) until a response is
+      // received.
       const intervalId = setInterval(postRequest, POLLING_INTERVAL_FOR_PORT);
 
       // The `host` frame maybe busy, that's why we should wait.
       const timeoutId = setTimeout(() => {
         clearInterval(intervalId);
         reject(
-          new Error(`Unable to find '${port}' port on '${channel}' channel`)
+          new Error(
+            `Unable to establish ${this._source}-${target} communication channel`
+          )
         );
       }, MAX_WAIT_FOR_PORT);
 
@@ -84,9 +91,9 @@ export class PortFinder {
         const { data, ports } = /** @type {MessageEvent} */ (event);
         if (
           isMessageEqual(data, {
-            channel,
-            port,
-            source: 'hypothesis',
+            authority: 'hypothesis',
+            frame1: this._source,
+            frame2: target,
             type: 'offer',
           })
         ) {

--- a/src/shared/port-util.js
+++ b/src/shared/port-util.js
@@ -3,20 +3,19 @@
 // message and avoid listening to messages that could have the same properties
 // but different source. This is not a security feature but an
 // anti-collision mechanism.
-const SOURCE = 'hypothesis';
+const AUTHORITY = 'hypothesis';
 
 /**
  * These types are the used in by `PortProvider` and `PortFinder` for the
  * inter-frame discovery and communication processes.
  *
- * @typedef {'guest-host'|'guest-sidebar'|'host-sidebar'|'notebook-sidebar'} Channel
- * @typedef {'guest'|'host'|'notebook'|'sidebar'} Port
+ * @typedef {'guest'|'host'|'notebook'|'sidebar'} Frame
  *
  * @typedef Message
- * @prop {Channel} channel
- * @prop {Port} port
- * @prop {'offer'|'request'}  type
- * @prop {SOURCE} source -
+ * @prop {AUTHORITY} authority
+ * @prop {Frame} frame1
+ * @prop {Frame} frame2
+ * @prop {'offer'|'request'} type
  */
 
 /**
@@ -26,18 +25,18 @@ const SOURCE = 'hypothesis';
  * @param {any} data
  * @return {data is Message}
  */
-function isMessageValid(data) {
+function isMessage(data) {
   if (data === null || typeof data !== 'object') {
     return false;
   }
 
-  for (let property of ['channel', 'port', 'source', 'type']) {
+  for (let property of ['frame1', 'frame2', 'type']) {
     if (typeof data[property] !== 'string') {
       return false;
     }
   }
 
-  return data.source === SOURCE;
+  return data.authority === AUTHORITY;
 }
 
 /**
@@ -47,7 +46,7 @@ function isMessageValid(data) {
  * @param {Message} message
  */
 export function isMessageEqual(data, message) {
-  if (!isMessageValid(data)) {
+  if (!isMessage(data)) {
     return false;
   }
 

--- a/src/shared/test/port-util-test.js
+++ b/src/shared/test/port-util-test.js
@@ -1,138 +1,98 @@
 import { isMessageEqual } from '../port-util';
 
-const source = 'hypothesis';
-
 describe('port-util', () => {
   describe('isMessageEqual', () => {
+    const authority = 'hypothesis';
+    const frame1 = 'guest';
+    const frame2 = 'sidebar';
+    const type = 'offer';
+
     [
       {
         data: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-        },
-        message: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
+          authority,
+          frame1,
+          frame2,
+          type,
         },
         expectedResult: true,
         reason: 'data matches the message',
       },
       {
         data: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-        },
-        message: {
-          source,
-          type: 'offer',
-          channel: 'host-sidebar',
-          port: 'guest',
+          authority,
+          frame1,
+          frame2,
+          type,
         },
         expectedResult: true,
         reason: 'data matches the message (properties in different order)',
       },
       {
         data: null,
-        message: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-        },
         expectedResult: false,
         reason: 'data is null',
       },
       {
         data: {
-          channel: 'host-sidebar',
-          port: 9, // wrong type
-          source,
-          type: 'offer',
-        },
-        message: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-        },
-        expectedResult: false,
-        reason: 'data has a property with the wrong type',
-      },
-      {
-        data: {
-          // channel property missing
-          port: 'guest',
-          source,
-          type: 'offer',
-        },
-        message: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
+          authority,
+          // frame1 property missing
+          frame2,
+          type,
         },
         expectedResult: false,
         reason: 'data has one property that is missing',
       },
       {
         data: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-          extra: 'dummy', // additional
+          authority,
+          frame1,
+          frame2: 9, // wrong type
+          type,
         },
-        message: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
+        expectedResult: false,
+        reason: 'data has one property with a wrong type',
+      },
+      {
+        data: {
+          authority,
+          extra: 'dummy', // additional
+          frame1,
+          frame2,
+          type,
         },
         expectedResult: false,
         reason: 'data has one additional property',
       },
       {
         data: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-          window, // not serializable
-        },
-        message: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-        },
-        expectedResult: false,
-        reason: "data has one property that can't be serialized",
-      },
-      {
-        data: {
-          channel: 'host-sidebar',
-          port: 'guest',
-          source,
-          type: 'offer',
-        },
-        message: {
-          channel: 'guest-sidebar', // different
-          port: 'guest',
-          source,
-          type: 'offer',
+          authority,
+          frame1: 'dummy', // different
+          frame2,
+          type,
         },
         expectedResult: false,
         reason: 'data has one property that is different',
       },
-    ].forEach(({ data, message, expectedResult, reason }) => {
+      {
+        data: {
+          authority,
+          frame1,
+          frame2,
+          type,
+          window, // not serializable
+        },
+        expectedResult: false,
+        reason: "data has one property that can't be serialized",
+      },
+    ].forEach(({ data, expectedResult, reason }) => {
       it(`returns '${expectedResult}' because the ${reason}`, () => {
-        const result = isMessageEqual(data, message);
+        const result = isMessageEqual(data, {
+          authority,
+          frame1,
+          frame2,
+          type,
+        });
         assert.equal(result, expectedResult);
       });
     });

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -1,6 +1,9 @@
 import debounce from 'lodash.debounce';
 
 import { Bridge } from '../../shared/bridge';
+import { ListenerCollection } from '../../shared/listener-collection';
+import { PortFinder } from '../../shared/port-finder';
+import { isMessageEqual } from '../../shared/port-util';
 import { isReply, isPublic } from '../helpers/annotation-metadata';
 import { watch } from '../util/watch';
 
@@ -58,6 +61,14 @@ export class FrameSyncService {
    * @param {import('../store').SidebarStore} store
    */
   constructor($window, annotationsService, store) {
+    this._window = $window;
+    this._store = store;
+    this._portFinder = new PortFinder({
+      hostFrame: this._window.parent,
+      source: 'sidebar',
+    });
+    this._listeners = new ListenerCollection();
+
     /**
      * Channel for sidebar-host communication.
      *
@@ -71,9 +82,6 @@ export class FrameSyncService {
      * @type {Bridge<SidebarToGuestEvent,GuestToSidebarEvent>}
      */
     this._guestRPC = new Bridge();
-
-    this._store = store;
-    this._window = $window;
 
     // Set of tags of annotations that are currently loaded into the frame
     const inFrame = new Set();
@@ -226,7 +234,7 @@ export class FrameSyncService {
   /**
    * Connect to the host frame and guest frame(s) in the current browser tab.
    */
-  connect() {
+  async connect() {
     /**
      * Query the guest in a frame for the URL and metadata of the document that
      * is currently loaded and add the result to the set of connected frames.
@@ -253,24 +261,6 @@ export class FrameSyncService {
 
     this._guestRPC.onConnect(addFrame);
 
-    // Listen for messages from new guest frames that want to connect.
-    //
-    // The message will include a `MessagePort` to use for communication with
-    // the guest.
-    this._window.addEventListener('message', e => {
-      if (e.data?.type !== 'hypothesisGuestReady') {
-        return;
-      }
-      if (e.ports.length === 0) {
-        console.warn(
-          'Ignoring `hypothesisGuestReady` message without a MessagePort'
-        );
-        return;
-      }
-      const port = e.ports[0];
-      this._guestRPC.createChannel(port);
-    });
-
     this._setupSyncToGuests();
     this._setupSyncFromGuests();
 
@@ -295,14 +285,25 @@ export class FrameSyncService {
       this._guestRPC.call('setHighlightsVisible', visible);
     });
 
-    // Create channel for sidebar <-> host communication and send port to host.
-    //
-    // This also serves to notify the host that the sidebar application is ready.
-    const hostChannel = new MessageChannel();
-    this._hostRPC.createChannel(hostChannel.port1);
-    this._window.parent.postMessage({ type: 'hypothesisSidebarReady' }, '*', [
-      hostChannel.port2,
-    ]);
+    // Create channel for sidebar-host communication and send port to host.
+    const hostPort = await this._portFinder.discover('host');
+    this._hostRPC.createChannel(hostPort);
+
+    // Create channel for guest-sidebar communication
+    hostPort.start();
+    this._listeners.add(hostPort, 'message', event => {
+      const { data, ports } = /** @type {MessageEvent} */ (event);
+      if (
+        isMessageEqual(data, {
+          authority: 'hypothesis',
+          frame1: 'guest',
+          frame2: 'sidebar',
+          type: 'offer',
+        })
+      ) {
+        this._guestRPC.createChannel(ports[0]);
+      }
+    });
   }
 
   /**
@@ -335,5 +336,11 @@ export class FrameSyncService {
    */
   scrollToAnnotation(tag) {
     this._guestRPC.call('scrollToAnnotation', tag);
+  }
+
+  // Only used to cleanup tests
+  destroy() {
+    this._portFinder.destroy();
+    this._listeners.removeAll();
   }
 }

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -3,6 +3,7 @@ import EventEmitter from 'tiny-emitter';
 import { Injector } from '../../../shared/injector';
 import * as annotationFixtures from '../../test/annotation-fixtures';
 import createFakeStore from '../../test/fake-redux-store';
+import { delay } from '../../../test-util/wait';
 
 import { FrameSyncService, $imports, formatAnnot } from '../frame-sync';
 
@@ -57,12 +58,37 @@ describe('FrameSyncService', () => {
   let FakeBridge;
 
   let fakeAnnotationsService;
-  let fakeStore;
   let fakeBridges;
+  let fakePortFinder;
+  let fakeStore;
   let frameSync;
   let fakeWindow;
+  const { port1: hostPort, port2: sidebarPort } = new MessageChannel();
 
   beforeEach(() => {
+    fakeAnnotationsService = { create: sinon.stub() };
+
+    fakeBridges = [];
+    FakeBridge = sinon.stub().callsFake(() => {
+      const emitter = new EventEmitter();
+      const bridge = {
+        call: sinon.stub(),
+        createChannel: sinon.stub(),
+        emit: emitter.emit.bind(emitter),
+        on: emitter.on.bind(emitter),
+        onConnect: function (listener) {
+          emitter.on('connect', listener);
+        },
+      };
+      fakeBridges.push(bridge);
+      return bridge;
+    });
+
+    fakePortFinder = {
+      destroy: sinon.stub(),
+      discover: sinon.stub().resolves(sidebarPort),
+    };
+
     fakeStore = createFakeStore(
       { annotations: [] },
       {
@@ -84,29 +110,14 @@ describe('FrameSyncService', () => {
       }
     );
 
-    fakeAnnotationsService = { create: sinon.stub() };
-
-    fakeBridges = [];
-    FakeBridge = sinon.stub().callsFake(() => {
-      const emitter = new EventEmitter();
-      const bridge = {
-        call: sinon.stub(),
-        createChannel: sinon.stub(),
-        emit: emitter.emit.bind(emitter),
-        on: emitter.on.bind(emitter),
-        onConnect: function (listener) {
-          emitter.on('connect', listener);
-        },
-      };
-      fakeBridges.push(bridge);
-      return bridge;
-    });
-
     fakeWindow = new FakeWindow();
     fakeWindow.parent = new FakeWindow();
 
     $imports.$mock({
       '../../shared/bridge': { Bridge: FakeBridge },
+      '../../shared/port-finder': {
+        PortFinder: sinon.stub().returns(fakePortFinder),
+      },
     });
 
     frameSync = new Injector()
@@ -118,6 +129,7 @@ describe('FrameSyncService', () => {
   });
 
   afterEach(() => {
+    frameSync.destroy();
     $imports.$restore();
   });
 
@@ -134,63 +146,28 @@ describe('FrameSyncService', () => {
   }
 
   describe('#connect', () => {
-    let testChannel;
+    it('discovers and connects to the host frame', async () => {
+      await frameSync.connect();
 
-    beforeEach(() => {
-      testChannel = new MessageChannel();
-
-      sinon.stub(console, 'warn');
-      sinon.stub(window, 'MessageChannel');
-      window.MessageChannel.returns(testChannel);
+      assert.calledWith(hostBridge().createChannel, sidebarPort);
     });
 
-    afterEach(() => {
-      console.warn.restore();
-      window.MessageChannel.restore();
-    });
+    it('connects to new guests when they are ready', async () => {
+      const { port1 } = new MessageChannel();
 
-    it('sends `hypothesisSidebarReady` notification to host frame with message port', () => {
       frameSync.connect();
-
-      assert.calledWith(hostBridge().createChannel, testChannel.port1);
-      assert.calledWith(
-        fakeWindow.parent.postMessage,
+      hostPort.postMessage(
         {
-          type: 'hypothesisSidebarReady',
+          authority: 'hypothesis',
+          frame1: 'guest',
+          frame2: 'sidebar',
+          type: 'offer',
         },
-        '*',
-        [testChannel.port2]
+        [port1]
       );
-    });
+      await delay(0);
 
-    it('connects to new guests when they are ready', () => {
-      const channel = new MessageChannel();
-
-      frameSync.connect();
-      fakeWindow.dispatchEvent(
-        new MessageEvent('message', {
-          data: { type: 'hypothesisGuestReady' },
-          ports: [channel.port1],
-        })
-      );
-
-      assert.calledWith(guestBridge().createChannel, channel.port1);
-    });
-
-    [
-      { data: 'not-an-object' },
-      { data: {} },
-      { data: { type: 'unknownType' } },
-      {
-        // No ports provided with message
-        data: { type: 'hypothesisGuestReady' },
-      },
-    ].forEach(messageInit => {
-      it('ignores `hypothesisGuestReady` messages that are invalid', () => {
-        frameSync.connect();
-        fakeWindow.dispatchEvent(new MessageEvent('message', messageInit));
-        assert.notCalled(guestBridge().createChannel);
-      });
+      assert.calledWith(guestBridge().createChannel, port1);
     });
   });
 

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -149,15 +149,6 @@
  * @typedef Globals
  * @prop {import('./pdfjs').PDFViewerApplication} [PDFViewerApplication] -
  *   PDF.js entry point. If set, triggers loading of PDF rather than HTML integration.
- * @prop {object} [__hypothesis] - Internal data related to supporting guests in iframes
- *   @prop {Promise<[Window]>} [__hypothesis.sidebarWindow] -
- *     The sidebar window that is active in this frame. This resolves once the sidebar
- *     application has started and is ready to connect to guests.
- *
- *     The `Window` object is wrapped in an array to avoid issues with
- *     combining promises with cross-origin objects in old browsers
- *     (eg. Safari 11, Chrome <= 63) which trigger an exception when trying to
- *     test if the object has a `then` method. See https://github.com/whatwg/dom/issues/536.
  */
 
 /**


### PR DESCRIPTION
The first commit it narrows the type of `Guest` used in the `Sidebar`. See the commit description for more details.

The second commit is very minor, it rearranges a method and a few fields. In addition, it prepends two fields with underscore to indicate that the are meant to be private.