### PR TITLE
Remove `authority` field from discovery message

### DIFF
--- a/src/shared/port-finder.js
+++ b/src/shared/port-finder.js
@@ -59,7 +59,6 @@ export class PortFinder {
       const postRequest = () => {
         this._hostFrame.postMessage(
           {
-            authority: 'hypothesis',
             frame1: this._source,
             frame2: target,
             type: 'request',
@@ -91,7 +90,6 @@ export class PortFinder {
         const { data, ports } = /** @type {MessageEvent} */ (event);
         if (
           isMessageEqual(data, {
-            authority: 'hypothesis',
             frame1: this._source,
             frame2: target,
             type: 'offer',

--- a/src/shared/port-provider.js
+++ b/src/shared/port-provider.js
@@ -90,28 +90,24 @@ export class PortProvider {
     this._allowedMessages = [
       {
         allowedOrigin: '*',
-        authority: 'hypothesis',
         frame1: 'guest',
         frame2: 'host',
         type: 'request',
       },
       {
         allowedOrigin: '*',
-        authority: 'hypothesis',
         frame1: 'guest',
         frame2: 'sidebar',
         type: 'request',
       },
       {
         allowedOrigin: this._hypothesisAppsOrigin,
-        authority: 'hypothesis',
         frame1: 'sidebar',
         frame2: 'host',
         type: 'request',
       },
       {
         allowedOrigin: this._hypothesisAppsOrigin,
-        authority: 'hypothesis',
         frame1: 'notebook',
         frame2: 'sidebar',
         type: 'request',
@@ -213,7 +209,7 @@ export class PortProvider {
         return;
       }
 
-      const { authority, frame1, frame2 } = match;
+      const { frame1, frame2 } = match;
       const channel = /** @type {Channel} */ (`${frame1}-${frame2}`);
 
       let windowChannelMap = this._channels.get(channel);
@@ -231,7 +227,7 @@ export class PortProvider {
       }
 
       /** @type {Message} */
-      const message = { authority, frame1, frame2, type: 'offer' };
+      const message = { frame1, frame2, type: 'offer' };
       const options = { channel, message, origin, source };
 
       // `sidebar-host` channel is an special case, because it is created in the

--- a/src/shared/port-util.js
+++ b/src/shared/port-util.js
@@ -1,10 +1,3 @@
-// Because there are many `postMessages` on the `host` frame, the SOURCE property
-// is added to the hypothesis `postMessages` to identify the provenance of the
-// message and avoid listening to messages that could have the same properties
-// but different source. This is not a security feature but an
-// anti-collision mechanism.
-const AUTHORITY = 'hypothesis';
-
 /**
  * These types are the used in by `PortProvider` and `PortFinder` for the
  * inter-frame discovery and communication processes.
@@ -12,7 +5,6 @@ const AUTHORITY = 'hypothesis';
  * @typedef {'guest'|'host'|'notebook'|'sidebar'} Frame
  *
  * @typedef Message
- * @prop {AUTHORITY} authority
  * @prop {Frame} frame1
  * @prop {Frame} frame2
  * @prop {'offer'|'request'} type
@@ -36,7 +28,7 @@ function isMessage(data) {
     }
   }
 
-  return data.authority === AUTHORITY;
+  return true;
 }
 
 /**

--- a/src/shared/test/port-finder-test.js
+++ b/src/shared/test/port-finder-test.js
@@ -4,7 +4,6 @@ import { PortFinder } from '../port-finder';
 const MAX_WAIT_FOR_PORT = 1000 * 5;
 
 describe('PortFinder', () => {
-  const authority = 'hypothesis';
   const frame1 = 'guest';
   const type = 'offer';
   let portFinder;
@@ -52,7 +51,6 @@ describe('PortFinder', () => {
 
         sendPortProviderOffer({
           data: {
-            authority,
             frame1,
             frame2: target,
             type,
@@ -100,7 +98,6 @@ describe('PortFinder', () => {
         portFinder.discover(target).then(port => (resolvedPort = port));
         sendPortProviderOffer({
           data: {
-            authority,
             frame1: source,
             frame2: target,
             type,
@@ -128,7 +125,7 @@ describe('PortFinder', () => {
       assert.callCount(window.postMessage, 21);
       assert.alwaysCalledWithExactly(
         window.postMessage,
-        { authority, frame1, frame2: target, type: 'request' },
+        { frame1, frame2: target, type: 'request' },
         '*'
       );
 

--- a/src/shared/test/port-provider-test.js
+++ b/src/shared/test/port-provider-test.js
@@ -1,8 +1,6 @@
 import { delay } from '../../test-util/wait';
 import { PortProvider } from '../port-provider';
 
-const authority = 'hypothesis';
-
 describe('PortProvider', () => {
   let portProvider;
 
@@ -38,7 +36,6 @@ describe('PortProvider', () => {
       portProvider.destroy();
       await sendPortFinderRequest({
         data: {
-          authority,
           frame1: 'sidebar',
           frame2: 'host',
           type: 'request',
@@ -61,7 +58,6 @@ describe('PortProvider', () => {
       portProvider.destroy();
       portProvider = new PortProvider(window.location.origin);
       const data = {
-        authority,
         frame1: 'sidebar',
         frame2: 'host',
         type: 'request',
@@ -83,22 +79,9 @@ describe('PortProvider', () => {
 
   describe('listens for port requests', () => {
     [
-      // Disabled this check because it make axes-core to crash
-      // Reported: https://github.com/dequelabs/axe-core/pull/3249
-      //{ data: null, reason: 'if message is null' },
       {
         data: {
-          authority: 'dummy', // invalid authority
-          frame1: 'sidebar',
-          frame2: 'host',
-          type: 'request',
-        },
-        reason: 'contains an invalid authority',
-      },
-      {
-        data: {
-          authority,
-          frame1: 'host', // invalid source
+          frame1: 'dummy', // invalid source
           frame2: 'host',
           type: 'request',
         },
@@ -106,7 +89,6 @@ describe('PortProvider', () => {
       },
       {
         data: {
-          authority,
           frame1: 'sidebar',
           frame2: 'dummy', // invalid target
           type: 'request',
@@ -115,16 +97,14 @@ describe('PortProvider', () => {
       },
       {
         data: {
-          authority,
           frame1: 'sidebar',
           frame2: 'host',
-          type: 'offer', // invalid type
+          type: 'dummy', // invalid type
         },
         reason: 'contains an invalid type',
       },
       {
         data: {
-          authority,
           frame1: 'sidebar',
           frame2: 'host',
           type: 'request',
@@ -134,7 +114,6 @@ describe('PortProvider', () => {
       },
       {
         data: {
-          authority,
           frame1: 'sidebar',
           frame2: 'host',
           type: 'request',
@@ -158,7 +137,6 @@ describe('PortProvider', () => {
     it('responds to a valid port request', async () => {
       portProvider.listen();
       const data = {
-        authority,
         frame1: 'sidebar',
         frame2: 'host',
         type: 'request',
@@ -178,7 +156,6 @@ describe('PortProvider', () => {
     it('responds to the first valid port request but ignores additional requests', async () => {
       portProvider.listen();
       const data = {
-        authority,
         frame1: 'guest',
         frame2: 'sidebar',
         type: 'request',
@@ -202,7 +179,6 @@ describe('PortProvider', () => {
       portProvider.listen();
       await sendPortFinderRequest({
         data: {
-          authority,
           frame1: 'sidebar',
           frame2: 'host',
           type: 'request',
@@ -214,7 +190,6 @@ describe('PortProvider', () => {
       sidebarPort.onmessage = handler;
 
       const data = {
-        authority,
         frame1: 'guest',
         frame2: 'sidebar',
         type: 'request',
@@ -236,7 +211,6 @@ describe('PortProvider', () => {
       const handler = sinon.stub();
       portProvider.on('hostPortRequest', handler);
       const data = {
-        authority,
         frame1: 'guest',
         frame2: 'host',
         type: 'request',

--- a/src/shared/test/port-util-test.js
+++ b/src/shared/test/port-util-test.js
@@ -2,7 +2,6 @@ import { isMessageEqual, isSourceWindow } from '../port-util';
 
 describe('port-util', () => {
   describe('isMessageEqual', () => {
-    const authority = 'hypothesis';
     const frame1 = 'guest';
     const frame2 = 'sidebar';
     const type = 'offer';
@@ -10,7 +9,6 @@ describe('port-util', () => {
     [
       {
         data: {
-          authority,
           frame1,
           frame2,
           type,
@@ -20,7 +18,6 @@ describe('port-util', () => {
       },
       {
         data: {
-          authority,
           frame1,
           frame2,
           type,
@@ -34,8 +31,12 @@ describe('port-util', () => {
         reason: 'data is null',
       },
       {
+        data: 'dummy',
+        expectedResult: false,
+        reason: 'data is string',
+      },
+      {
         data: {
-          authority,
           // frame1 property missing
           frame2,
           type,
@@ -45,7 +46,6 @@ describe('port-util', () => {
       },
       {
         data: {
-          authority,
           frame1,
           frame2: 9, // wrong type
           type,
@@ -55,7 +55,6 @@ describe('port-util', () => {
       },
       {
         data: {
-          authority,
           extra: 'dummy', // additional
           frame1,
           frame2,
@@ -66,7 +65,6 @@ describe('port-util', () => {
       },
       {
         data: {
-          authority,
           frame1: 'dummy', // different
           frame2,
           type,
@@ -76,7 +74,6 @@ describe('port-util', () => {
       },
       {
         data: {
-          authority,
           frame1,
           frame2,
           type,
@@ -88,7 +85,6 @@ describe('port-util', () => {
     ].forEach(({ data, expectedResult, reason }) => {
       it(`returns '${expectedResult}' because the ${reason}`, () => {
         const result = isMessageEqual(data, {
-          authority,
           frame1,
           frame2,
           type,


### PR DESCRIPTION
Following these two comments:
* https://github.com/hypothesis/client/pull/3929/files#r750399422
* https://github.com/hypothesis/client/pull/3929/files#r750414036

I am proposing in this PR to remove the anti-collision field `authority`
from the message that is send to discover frames. I believe the message
contains enough information to avoid to be confused by other unrelated
`postMessage` in the host frame.