### PR TITLE
Add stricter types for the discovery `Message`

### DIFF
--- a/src/shared/port-finder.js
+++ b/src/shared/port-finder.js
@@ -7,20 +7,20 @@ const POLLING_INTERVAL_FOR_PORT = 250;
 /**
  * @typedef {import('../types/annotator').Destroyable} Destroyable
  * @typedef {import('./port-util').Message} Message
- * @typedef {import('./port-util').Frame} Frame
+ * @typedef {'guest'|'notebook'|'sidebar'} SourceFrame
  */
 
 /**
  * PortFinder is used by non-host frames in the client to establish a
  * MessagePort-based connection to other frames. It is used together with
  * PortProvider which runs in the host frame. See PortProvider for an overview.
- *
+ * @template {SourceFrame} T
  * @implements Destroyable
  */
 export class PortFinder {
   /**
    * @param {object} options
-   *   @param {Exclude<Frame, 'host'>} options.source - the role of this frame
+   *   @param {T} options.source - the role of this frame
    *   @param {Window} options.hostFrame - the frame where the `PortProvider` is
    *     listening for messages.
    */
@@ -37,30 +37,19 @@ export class PortFinder {
   /**
    * Request a specific port from the host frame
    *
-   * @param {Frame} target - the frame aiming to be discovered
+   * @param {T extends 'guest' ? 'host'|'sidebar' : T extends 'notebook' ? 'sidebar' : 'host'} target - the frame aiming to be discovered
    * @return {Promise<MessagePort>}
    */
-  async discover(target) {
-    let isValidRequest = false;
-    if (
-      (this._source === 'guest' && target === 'host') ||
-      (this._source === 'guest' && target === 'sidebar') ||
-      (this._source === 'sidebar' && target === 'host') ||
-      (this._source === 'notebook' && target === 'sidebar')
-    ) {
-      isValidRequest = true;
-    }
-
-    if (!isValidRequest) {
-      throw new Error('Invalid request of channel/port');
-    }
-
+  discover(target) {
     return new Promise((resolve, reject) => {
+      const frame1 = this._source;
+      const frame2 = target;
+
       const postRequest = () => {
         this._hostFrame.postMessage(
           {
-            frame1: this._source,
-            frame2: target,
+            frame1,
+            frame2,
             type: 'request',
           },
           '*'
@@ -89,11 +78,14 @@ export class PortFinder {
       const listenerId = this._listeners.add(window, 'message', event => {
         const { data, ports } = /** @type {MessageEvent} */ (event);
         if (
-          isMessageEqual(data, {
-            frame1: this._source,
-            frame2: target,
-            type: 'offer',
-          })
+          isMessageEqual(
+            data,
+            /** @type {Message} */ ({
+              frame1,
+              frame2,
+              type: 'offer',
+            })
+          )
         ) {
           clearInterval(intervalId);
           clearTimeout(timeoutId);

--- a/src/shared/port-provider.js
+++ b/src/shared/port-provider.js
@@ -6,7 +6,6 @@ import { isMessageEqual, isSourceWindow } from './port-util';
 /**
  * @typedef {import('../types/annotator').Destroyable} Destroyable
  * @typedef {import('./port-util').Message} Message
- * @typedef {import('./port-util').Frame} Frame
  * @typedef {'guest-host'|'guest-sidebar'|'notebook-sidebar'|'sidebar-host'} Channel
  */
 
@@ -124,6 +123,8 @@ export class PortProvider {
    *   @param {any} options.data - the data to be compared with `allowedMessage`.
    *   @param {string} options.origin - the origin to be compared with
    *     `allowedOrigin`.
+   *
+   * @return {data is Message}
    */
   _messageMatches({ allowedMessage, allowedOrigin, data, origin }) {
     if (allowedOrigin !== '*' && origin !== allowedOrigin) {

--- a/src/shared/port-util.js
+++ b/src/shared/port-util.js
@@ -2,12 +2,12 @@
  * These types are the used in by `PortProvider` and `PortFinder` for the
  * inter-frame discovery and communication processes.
  *
- * @typedef {'guest'|'host'|'notebook'|'sidebar'} Frame
- *
- * @typedef Message
- * @prop {Frame} frame1
- * @prop {Frame} frame2
- * @prop {'offer'|'request'} type
+ * @typedef {{frame1: 'guest', frame2: 'host'}} GuestChannel1 - guest-host
+ * @typedef {{frame1: 'guest', frame2: 'sidebar'}} GuestChannel2 - guest-sidebar
+ * @typedef {{frame1: 'notebook', frame2: 'sidebar'}} NotebookChannel - notebook-sidebar
+ * @typedef {{frame1: 'sidebar', frame2: 'host'}} SidebarChannel - sidebar-host
+ * @typedef {GuestChannel1|GuestChannel2|NotebookChannel|SidebarChannel} Channel
+ * @typedef {Channel & {type: 'offer'|'request'}} Message
  */
 
 /**

--- a/src/shared/test/port-finder-test.js
+++ b/src/shared/test/port-finder-test.js
@@ -72,18 +72,6 @@ describe('PortFinder', () => {
   });
 
   describe('#discover', () => {
-    ['guest', 'invalid'].forEach(target =>
-      it('rejects if requesting an invalid port', async () => {
-        let error;
-        try {
-          await portFinder.discover(target);
-        } catch (e) {
-          error = e;
-        }
-        assert.equal(error.message, 'Invalid request of channel/port');
-      })
-    );
-
     [
       { source: 'guest', target: 'host' },
       { source: 'guest', target: 'sidebar' },


### PR DESCRIPTION
More stricter types allows to reduce errors during development and
better ergonomics as IDE are able to add accurate autocomplete. Before,
`PortProvider` allowed to listen for all short of frame combinations,
while `PortFinder#discover` allowed to all type of frames as argument.
Now, the set of these possibilities is reduced to only valid
combinations.

In `PortFinder#discover`, the addition of types, makes the check of
valid combinations of frames unnecessary.

The price to pay for these stricter types is a bit more verbose types,
and in the case of `PortFinder#discover` the use of conditional types.

Example in `PortFinder`:

https://user-images.githubusercontent.com/8555781/142216237-16c5bf25-cb6e-4578-b4f9-4be6612740a0.mov

Example in `PortProvider`:

https://user-images.githubusercontent.com/8555781/142216284-e7366305-3268-4ef3-bce8-0576c47d825c.mov
