### PR TITLE
Remove `PDFViewerApplication` global field after test

### DIFF
--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -75,7 +75,7 @@ describe('annotator/anchoring/pdf', () => {
   /** Clean up any resources created by the fake PDF.js viewer. */
   function cleanupViewer() {
     viewer?.dispose();
-    window.PDFViewerApplication = null;
+    delete window.PDFViewerApplication;
   }
 
   beforeEach(() => {


### PR DESCRIPTION
The tests crashed if either of these commands was executed:

- `yarn test --grep anchoring`, or
- `yarn test --grep 'anchoring/test/pdf|test/integration/anchoring'`

`src/anotator/anchoring/test/pdf-test.js` cleanup the PDF viewer by setting
the `window.PDFViewerApplication` to `null`. After that, if another test
creates a `Guest` instance (like
`src/annotator/test/integration/anchoring-test.js`) it will think that the
document is a PDF and will crash. This is the code that checks if the
document is a PDF:

https://github.com/hypothesis/client/blob/492ab6d56a5685356ca6b3a48644e047bb28dca0/src/annotator/integrations/pdf.js#L53-L56

The solution is either deleting `window.PDFViewerApplication' or setting
it to `undefined`.