### PR TITLE
Bump approx-string-match to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@rollup/plugin-replace": "^3.0.0",
     "@rollup/plugin-virtual": "^2.0.3",
     "@sentry/browser": "^6.0.2",
-    "approx-string-match": "^1.1.0",
+    "approx-string-match": "^2.0.0",
     "autoprefixer": "^10.0.1",
     "aws-sdk": "^2.345.0",
     "axe-core": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,10 +1527,10 @@ append-buffer@^1.0.2:
   dependencies:
     buffer-equal "^1.0.0"
 
-approx-string-match@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/approx-string-match/-/approx-string-match-1.1.0.tgz#2fb8e1d6dcb640acc1c0d1ae9f0895348d06f4c0"
-  integrity sha512-j1yQB9XhfGWsvTfHEuNsR/SrUT4XQDkAc0PEjMifyi97931LmNQyLsO6HbuvZ3HeMx+3Dvk8m8XGkUF+8lCeqw==
+approx-string-match@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/approx-string-match/-/approx-string-match-2.0.0.tgz#c7d11c5a893e76e60a2d080d91ee3bb0ec4e18fa"
+  integrity sha512-03v8MsWnZYV4Svv82EYWoVw1RIKAJ/zubmhG1FYvhJwOsBnLPxx6CPHF2dXN/yW8uwHK+653j52IwiNluJR97w==
 
 archy@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This includes a fix for incorrect results under certain conditions when the pattern length is an exact multiple of 32. See https://github.com/robertknight/approx-string-match-js/pull/13.

This could lead to occasional failures to find a fuzzy match for long quotes, with the annotations showing up in the orphans tab when instead they should have anchored to a "close-enough" match. I don't have a manual test case for the client, but see the linked PR.

The package has also been converted to a native ES module, helping with the overall progress of ESM-ification of our dependencies.