### PR TITLE
Remove unused babel-plugin-transform-async-to-promises dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "babel-plugin-inject-args": "^1.0.0",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-mockable-imports": "^2.0.0",
-    "babel-plugin-transform-async-to-promises": "^0.8.6",
     "chai": "^4.1.2",
     "chance": "^1.0.13",
     "classnames": "^2.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1809,11 +1809,6 @@ babel-plugin-polyfill-regenerator@^0.2.3:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.2.4"
 
-babel-plugin-transform-async-to-promises@^0.8.6:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.15.tgz#13b6d8ef13676b4e3c576d3600b85344bb1ba346"
-  integrity sha512-fDXP68ZqcinZO2WCiimCL9zhGjGXOnn3D33zvbh+yheZ/qOrNVVDDIBtAaM3Faz8TRvQzHiRKsu3hfrBAhEncQ==
-
 bach@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/bach/-/bach-1.2.0.tgz#4b3ce96bf27134f79a1b414a51c14e34c3bd9880"


### PR DESCRIPTION
This dependency used to be used to enable the boot script to run in IE
11 and other old browsers. It is no longer used however.
See https://github.com/hypothesis/client/pull/3944#issuecomment-976289004.