### PR TITLE
Simplify PortProvider request handling

### DIFF
--- a/src/shared/port-provider.js
+++ b/src/shared/port-provider.js
@@ -76,12 +76,6 @@ export class PortProvider {
     /** @type {Map<Channel, WeakMap<Window, MessageChannel>>} */
     this._channels = new Map();
 
-    // Two important characteristics of `MessagePort`:
-    // - Once created, a MessagePort can only be transferred to a different
-    //   frame once, and if any frame attempts to transfer it again it gets
-    //   neutered.
-    // - Messages are queued until the other port is ready to listen (`port.start()`)
-
     // Create the `sidebar-host` channel immediately, while other channels are
     // created on demand
     this._sidebarHostChannel = new MessageChannel();


### PR DESCRIPTION
This PR simplifies some PortProvider internals to try to make the overall sequence of steps involved in handling a port request easier to follow.

- The data structure that keeps track of already handled requests has been simplified. It used to be a `Map<Channel, WeakMap<Window, MessageChannel>>`, where `Window` was the source window. The WeakMap however was effectively used as a set. Only the presence of an entry affected future behavior, not the value. It is now a `WeakMap<Window, Set<Channel>>` that maps from source window to channels requested by that source.

- The code paths for the sidebar-host channel and other channels have been unified. As a result the `_sendPorts` helper was only called in one place and it was possible to inline it to avoid indirection tax. In the process an obsolete reference to `onHostPortRequest` was removed.

- I removed an internal comment about a couple of aspects of MessagePort behavior, as it was not directly relevant for the surrounding code.

The external behavior/API is unchanged, so there are no changes to the tests.