### PR TITLE
Make shadow DOM support mandatory

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -110,8 +110,8 @@ export default class Sidebar {
 
       // Wrap up the 'iframeContainer' element into a shadow DOM so it is not affected by host CSS styles
       this.hypothesisSidebar = document.createElement('hypothesis-sidebar');
-      const shadowDom = createShadowRoot(this.hypothesisSidebar);
-      shadowDom.appendChild(this.iframeContainer);
+      const shadowRoot = createShadowRoot(this.hypothesisSidebar);
+      shadowRoot.appendChild(this.iframeContainer);
 
       element.appendChild(this.hypothesisSidebar);
     }

--- a/src/annotator/util/shadow-root.js
+++ b/src/annotator/util/shadow-root.js
@@ -22,20 +22,10 @@ function loadStyles(shadowRoot) {
  * Create the shadow root for an annotator UI component and load the annotator
  * CSS styles into it.
  *
- * In browsers that support it, shadow DOM is used to isolate annotator UI
- * components from the host page's styles.
- *
  * @param {HTMLElement} container - Container element to render the UI into
- * @return {HTMLElement|ShadowRoot} -
- *   The element to render the UI into. This may be `container` or the shadow
- *   root.
+ * @return {ShadowRoot}
  */
 export function createShadowRoot(container) {
-  if (!container.attachShadow) {
-    stopEventPropagation(container);
-    return container;
-  }
-
   const shadowRoot = container.attachShadow({ mode: 'open' });
   loadStyles(shadowRoot);
 

--- a/src/annotator/util/test/shadow-root-test.js
+++ b/src/annotator/util/test/shadow-root-test.js
@@ -23,13 +23,6 @@ describe('annotator/util/shadow-root', () => {
       assert.equal(container.shadowRoot, shadowRoot);
     });
 
-    it('does not attach a shadow root if Shadow DOM is unavailable', () => {
-      container.attachShadow = null;
-      const shadowRoot = createShadowRoot(container);
-
-      assert.equal(shadowRoot, container);
-    });
-
     it('injects stylesheets into the shadow root', () => {
       createShadowRoot(container);
 


### PR DESCRIPTION
All of our target browsers now support shadow DOM [1]. Make it mandatory so it
is clear that all annotator UI elements can rely on Shadow DOM and thus don't
need to worry about their internal styles affecting or being affected by the
host page.

[1] https://caniuse.com/?search=shadow%20dom