### PR TITLE
Stop loading annotator.css bundle in the host page (load it into shadow roots only)

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -18,6 +18,7 @@ gulp.task('build-css', () =>
   buildCSS([
     // Hypothesis client
     './src/styles/annotator/annotator.scss',
+    './src/styles/annotator/highlights.scss',
     './src/styles/annotator/pdfjs-overrides.scss',
     './src/styles/sidebar/sidebar.scss',
 

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -110,8 +110,8 @@ export default class Sidebar {
 
       // Wrap up the 'iframeContainer' element into a shadow DOM so it is not affected by host CSS styles
       this.hypothesisSidebar = document.createElement('hypothesis-sidebar');
-      const shadowDom = createShadowRoot(this.hypothesisSidebar);
-      shadowDom.appendChild(this.iframeContainer);
+      const shadowRoot = createShadowRoot(this.hypothesisSidebar);
+      shadowRoot.appendChild(this.iframeContainer);
 
       element.appendChild(this.hypothesisSidebar);
     }

--- a/src/annotator/util/shadow-root.js
+++ b/src/annotator/util/shadow-root.js
@@ -22,20 +22,10 @@ function loadStyles(shadowRoot) {
  * Create the shadow root for an annotator UI component and load the annotator
  * CSS styles into it.
  *
- * In browsers that support it, shadow DOM is used to isolate annotator UI
- * components from the host page's styles.
- *
  * @param {HTMLElement} container - Container element to render the UI into
- * @return {HTMLElement|ShadowRoot} -
- *   The element to render the UI into. This may be `container` or the shadow
- *   root.
+ * @return {ShadowRoot}
  */
 export function createShadowRoot(container) {
-  if (!container.attachShadow) {
-    stopEventPropagation(container);
-    return container;
-  }
-
   const shadowRoot = container.attachShadow({ mode: 'open' });
   loadStyles(shadowRoot);
 

--- a/src/annotator/util/shadow-root.js
+++ b/src/annotator/util/shadow-root.js
@@ -2,9 +2,10 @@
  * Load stylesheets for annotator UI components into the shadow DOM root.
  */
 function loadStyles(shadowRoot) {
+  // Find the preloaded stylesheet added by the boot script.
   const url = /** @type {HTMLLinkElement|undefined} */ (
     document.querySelector(
-      'link[rel="stylesheet"][href*="/build/styles/annotator.css"]'
+      'link[rel="preload"][href*="/build/styles/annotator.css"]'
     )
   )?.href;
 
@@ -13,6 +14,10 @@ function loadStyles(shadowRoot) {
   }
 
   const linkEl = document.createElement('link');
+
+  // This needs to match the `crossorigin` attribute on the preloaded stylesheet.
+  linkEl.crossOrigin = 'anonymous';
+
   linkEl.rel = 'stylesheet';
   linkEl.href = url;
   shadowRoot.appendChild(linkEl);

--- a/src/annotator/util/test/shadow-root-test.js
+++ b/src/annotator/util/test/shadow-root-test.js
@@ -23,13 +23,6 @@ describe('annotator/util/shadow-root', () => {
       assert.equal(container.shadowRoot, shadowRoot);
     });
 
-    it('does not attach a shadow root if Shadow DOM is unavailable', () => {
-      container.attachShadow = null;
-      const shadowRoot = createShadowRoot(container);
-
-      assert.equal(shadowRoot, container);
-    });
-
     it('injects stylesheets into the shadow root', () => {
       createShadowRoot(container);
 

--- a/src/annotator/util/test/shadow-root-test.js
+++ b/src/annotator/util/test/shadow-root-test.js
@@ -3,14 +3,24 @@ import { createShadowRoot } from '../shadow-root';
 describe('annotator/util/shadow-root', () => {
   let applyFocusVisiblePolyfill;
   let container;
+  let preloadedStylesheet;
 
   beforeEach(() => {
+    // Create the stylesheet preload that would normally be added by the boot script.
+    preloadedStylesheet = document.createElement('link');
+    preloadedStylesheet.rel = 'preload';
+    preloadedStylesheet.as = 'style';
+    preloadedStylesheet.href = '/build/styles/annotator.css';
+    document.head.append(preloadedStylesheet);
+
     container = document.createElement('div');
     applyFocusVisiblePolyfill = window.applyFocusVisiblePolyfill;
     window.applyFocusVisiblePolyfill = sinon.stub();
   });
 
   afterEach(() => {
+    preloadedStylesheet.remove();
+
     container.remove();
     window.applyFocusVisiblePolyfill = applyFocusVisiblePolyfill;
   });
@@ -39,7 +49,7 @@ describe('annotator/util/shadow-root', () => {
 
     it('does not inject stylesheets into the shadow root if style is not found', () => {
       const link = document.querySelector(
-        'link[rel="stylesheet"][href*="/build/styles/annotator.css"]'
+        'link[rel="preload"][href*="/build/styles/annotator.css"]'
       );
       // Removing the `rel` attribute is enough for the URL to not be found
       link.removeAttribute('rel');

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -121,6 +121,14 @@ function preloadUrl(doc, type, url) {
 }
 
 /**
+ * @param {SidebarAppConfig|AnnotatorConfig} config
+ * @param {string} path
+ */
+function assetURL(config, path) {
+  return config.assetRoot + 'build/' + config.manifest[path];
+}
+
+/**
  * @param {Document} doc
  * @param {SidebarAppConfig|AnnotatorConfig} config
  * @param {string[]} assets
@@ -129,7 +137,7 @@ function preloadUrl(doc, type, url) {
  */
 function injectAssets(doc, config, assets, { forceModuleReload } = {}) {
   assets.forEach(path => {
-    const url = config.assetRoot + 'build/' + config.manifest[path];
+    const url = assetURL(config, path);
     if (url.match(/\.css/)) {
       injectStylesheet(doc, url);
     } else {
@@ -169,6 +177,9 @@ export function bootHypothesisClient(doc, config) {
   // Register the URL of the notebook app which the Hypothesis client should load.
   injectLink(doc, 'notebook', 'html', config.notebookAppUrl);
 
+  // Preload the styles used by the shadow roots of annotator UI elements.
+  preloadUrl(doc, 'style', assetURL(config, 'styles/annotator.css'));
+
   // Register the URL of the annotation client which is currently being used to drive
   // annotation interactions.
   injectLink(
@@ -189,7 +200,7 @@ export function bootHypothesisClient(doc, config) {
 
       'scripts/annotator.bundle.js',
 
-      'styles/annotator.css',
+      'styles/highlights.css',
       'styles/pdfjs-overrides.css',
     ],
 

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -35,6 +35,7 @@ describe('bootstrap', () => {
       // Annotation layer
       'scripts/annotator.bundle.js',
       'styles/annotator.css',
+      'styles/highlights.css',
       'styles/pdfjs-overrides.css',
 
       // Sidebar app
@@ -103,11 +104,29 @@ describe('bootstrap', () => {
       runBoot('annotator');
       const expectedAssets = [
         'scripts/annotator.bundle.1234.js#ts=123',
-        'styles/annotator.1234.css',
+        'styles/highlights.1234.css',
         'styles/pdfjs-overrides.1234.css',
       ].map(assetUrl);
 
       assert.deepEqual(findAssets(iframe.contentDocument), expectedAssets);
+    });
+
+    it('preloads assets used wihin shadow roots in the annotation layer', () => {
+      runBoot('annotator');
+
+      const preloadLinks = [
+        ...iframe.contentDocument.querySelectorAll('link[rel=preload]'),
+      ];
+      preloadLinks.sort((a, b) => a.href.localeCompare(b.href));
+
+      assert.equal(preloadLinks.length, 1);
+
+      assert.equal(
+        preloadLinks[0].href,
+        'https://marginal.ly/client/build/styles/annotator.1234.css'
+      );
+      assert.equal(preloadLinks[0].as, 'style');
+      assert.equal(preloadLinks[0].crossOrigin, 'anonymous');
     });
 
     it('creates the link to the sidebar iframe', () => {

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -75,13 +75,6 @@
   }
 }
 
-.annotator-placeholder {
-  opacity: 0;
-  position: absolute;
-  top: 50%;
-  z-index: -1;
-}
-
 // this disables the width transition for the sidebar when
 // it is manually resized by dragging
 .annotator-no-transition {

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -16,7 +16,6 @@
 @use './components/NotebookModal';
 @use './components/Toolbar';
 @use './components/WarningBanner';
-@use './highlights';
 
 // Sidebar
 .annotator-frame {

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -21,6 +21,9 @@
 .annotator-frame {
   // CSS reset which attempts to isolate this element and its children from
   // host page styles.
+  //
+  // TODO - We should be able to remove these now because this element is always
+  // created inside a shadow root.
   @include meta.load-css('../reset');
   @include reset.nested-reset;
   @include reset.reset-box-model;

--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -1,4 +1,7 @@
-// SASS entry point for annotator styling
+// Styles for annotator UI elements. This stylesheet is loaded within shadow
+// roots to avoid affecting the host page. Styles for elements (eg. highlights)
+// which do not use shadow roots go in other bundles (eg. highlights.css,
+// pdfjs-overrides.scss).
 
 @use 'sass:meta';
 @use 'sass:color' as color;

--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -78,3 +78,12 @@
     }
   }
 }
+
+// Placeholder element to which annotations for off-screen content in PDFs
+// is anchored.
+.annotator-placeholder {
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  z-index: -1;
+}


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/3960**

With the exception of highlight styles, the styles in annotator.css are
now only used by UI elements contained within shadow roots. As a result,
we can stop loading annotator.css as a stylesheet into the host page,
preventing these styles from affecting the host page.

This change should simplify the ongoing changes to the way styling is done in the client. See https://github.com/hypothesis/client/pull/3931#discussion_r755875572 for context.

 - Stop loading annotator.css into the host page as a stylesheet.
   Instead add it as a preload link instead, ready for use by shadow
   roots.

 - Move highlights styles into a separate bundle and load that in the
   host page.

Fixes https://github.com/hypothesis/client/issues/2979

---

**Testing:**

On this branch, the styling of the various annotator UI elements should look the same as it did before. Additionally if you look at the `<head>` of the page, you can see that `annotator.css` is now loaded with `<link rel="preload" ...>` instead of `<link rel="stylesheet" ...>` and there is a new `highlights.css` bundle which is loaded with `<link rel="stylesheet" ...>`:

<img width="729" alt="Annotator CSS preload" src="https://user-images.githubusercontent.com/2458/143245764-b61059b1-dc84-4b26-9d9d-567669ef13fc.png">


