### PR TITLE
Remove `PortProvider#hostPortFrom` method

### DIFF
--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -54,14 +54,12 @@ function init() {
     const hypothesisAppsOrigin = new URL(sidebarConfig.sidebarAppUrl).origin;
     portProvider = new PortProvider(hypothesisAppsOrigin);
 
-    sidebar = new Sidebar(
-      document.body,
-      eventBus,
-      portProvider.hostPortFor('sidebar'),
-      guest,
-      sidebarConfig
-    );
+    sidebar = new Sidebar(document.body, eventBus, guest, sidebarConfig);
     notebook = new Notebook(document.body, eventBus, getConfig('notebook'));
+
+    portProvider.on('frameConnected', (source, port) =>
+      sidebar.onFrameConnected(source, port)
+    );
 
     portProvider.listen();
   }

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -219,7 +219,7 @@ export default class Sidebar {
   }
 
   /**
-   * Establish RPC channels from specific source frames
+   * Setup communication with a frame that has connected to the host.
    *
    * @param {'guest'|'sidebar'} source
    * @param {MessagePort} port

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -48,8 +48,7 @@ describe('Sidebar', () => {
     containers.push(container);
 
     const eventBus = new EventBus();
-    const { port1 } = new MessageChannel();
-    const sidebar = new Sidebar(container, eventBus, port1, fakeGuest, config);
+    const sidebar = new Sidebar(container, eventBus, fakeGuest, config);
     sidebars.push(sidebar);
 
     return sidebar;
@@ -528,6 +527,24 @@ describe('Sidebar', () => {
       const sidebar = createSidebar();
       sidebar.destroy();
       assert.called(sidebar.bucketBar.destroy);
+    });
+  });
+
+  describe('#onFrameConnected', () => {
+    it('ignores unrecognized source frames', () => {
+      const sidebar = createSidebar();
+      const { port1 } = new MessageChannel();
+      sidebar.onFrameConnected('dummy', port1);
+
+      assert.notCalled(fakeBridge.createChannel);
+    });
+
+    it('create RPC channels for recognized source frames', () => {
+      const sidebar = createSidebar();
+      const { port1 } = new MessageChannel();
+      sidebar.onFrameConnected('sidebar', port1);
+
+      assert.calledWith(fakeBridge.createChannel, port1);
     });
   });
 

--- a/src/shared/port-provider.js
+++ b/src/shared/port-provider.js
@@ -135,22 +135,12 @@ export class PortProvider {
 
   /**
    * @param {'frameConnected'} eventName
-   * @param {(source: 'guest', port: MessagePort) => void} handler - this handler
+   * @param {(source: 'guest'|'sidebar', port: MessagePort) => void} handler - this handler
    *   fires when a request for the host frame has been granted. Currently, only
    *   the 'guest-host' channel triggers this listener.
    */
   on(eventName, handler) {
     this._emitter.on(eventName, handler);
-  }
-
-  /**
-   * Returns the `host` port from the `sidebar-host` channel.
-   *
-   * @param {'sidebar'} _targetFrame
-   */
-  // eslint-disable-next-line no-unused-vars
-  hostPortFor(_targetFrame) {
-    return this._sidebarHostChannel.port2;
   }
 
   /**
@@ -209,7 +199,7 @@ export class PortProvider {
         this._sidebarHostChannel.port2.postMessage(message, [
           messageChannel.port2,
         ]);
-      } else if (frame2 === 'host' && frame1 === 'guest') {
+      } else if (frame2 === 'host') {
         this._emitter.emit('frameConnected', frame1, messageChannel.port2);
       }
     });

--- a/src/shared/port-provider.js
+++ b/src/shared/port-provider.js
@@ -136,8 +136,7 @@ export class PortProvider {
   /**
    * @param {'frameConnected'} eventName
    * @param {(source: 'guest'|'sidebar', port: MessagePort) => void} handler - this handler
-   *   fires when a request for the host frame has been granted. Currently, only
-   *   the 'guest-host' channel triggers this listener.
+   *   fires when a request for the host frame has been granted.
    */
   on(eventName, handler) {
     this._emitter.on(eventName, handler);

--- a/src/shared/test/port-provider-test.js
+++ b/src/shared/test/port-provider-test.js
@@ -46,12 +46,6 @@ describe('PortProvider', () => {
     });
   });
 
-  describe('#hostPortFor', () => {
-    it('returns the `host` port of the `sidebar-host` channel', () => {
-      assert.instanceOf(portProvider.hostPortFor('sidebar'), MessagePort);
-    });
-  });
-
   describe('#listen', () => {
     it('ignores all port requests before `listen` is called', async () => {
       portProvider.listen();
@@ -210,13 +204,27 @@ describe('PortProvider', () => {
       portProvider.listen();
       const handler = sinon.stub();
       portProvider.on('frameConnected', handler);
-      const data = {
-        frame1: 'guest',
-        frame2: 'host',
-        type: 'request',
-      };
       await sendPortFinderRequest({
-        data,
+        data: {
+          frame1: 'sidebar',
+          frame2: 'host',
+          type: 'request',
+        },
+      });
+
+      assert.calledWith(
+        handler,
+        'sidebar',
+        sinon.match.instanceOf(MessagePort)
+      );
+
+      handler.resetHistory();
+      await sendPortFinderRequest({
+        data: {
+          frame1: 'guest',
+          frame2: 'host',
+          type: 'request',
+        },
       });
 
       assert.calledWith(handler, 'guest', sinon.match.instanceOf(MessagePort));


### PR DESCRIPTION
There are two methods to get the host port from `PortProvider`:

- `#hostPortFrom` which returns the host port exclusively from the
  `sidebar-host` channel.

- `#on` allows to register a listener that is fired upon requests
  of host frames for channels other than the `sidebar-host`.

This is an attempt to simplify the API of `PortProvider` and merge both
methods into one.

Advantages:

- simplifies the `Sidebar` constructor signature (no need to pass the
  host port)

- avoids the pitfall of creating host-sidebar RPC channel before
  registering the RPC methods

- prepares for future guest-host channel see https://github.com/hypothesis/client/blob/ad93317debdac0d2c3abec83eb9d690934632ef3/src/annotator/index.js#L64-L66 (where the `#on` method is use to create the guest-host channel).