### PR TITLE
Use standard CSS reset in annotator bundle

### DIFF
--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -7,7 +7,10 @@
 @use 'sass:color' as color;
 
 @use '../variables' as var;
-@use '../mixins/reset';
+
+// Base styles
+// -----------
+@use '../reset';
 
 // Shared styles
 // -----------------
@@ -22,23 +25,6 @@
 
 // Sidebar
 .annotator-frame {
-  // CSS reset which attempts to isolate this element and its children from
-  // host page styles.
-  //
-  // TODO - We should be able to remove these now because this element is always
-  // created inside a shadow root.
-  @include meta.load-css('../reset');
-  @include reset.nested-reset;
-  @include reset.reset-box-model;
-
-  * {
-    background: none;
-    font-size: 100%;
-    text-indent: 0;
-    height: initial;
-    width: initial;
-  }
-
   // frame styles
   position: fixed;
   top: 0;

--- a/src/styles/annotator/components/Buckets.scss
+++ b/src/styles/annotator/components/Buckets.scss
@@ -3,50 +3,46 @@
 
 $bucket-bar-width: 22px;
 
-// Bucket-bar styles are nested inside `.annotator-frame` to ensure they take
-// precedence over the CSS reset applied to `.annotator-frame`.
-.annotator-frame {
-  .Buckets__list {
-    background: var.$grey-2; // When sidebar is unfolded, remove the background transparency
-    pointer-events: none;
-    position: absolute;
-    height: 100%;
-    // 2020-11-20: interim and pragmatic solution for an apparent glitch on Safari and Chrome.
-    // Adding one pixel resolve this issue: https://github.com/hypothesis/client/pull/2750
-    width: $bucket-bar-width + 1;
-    left: -($bucket-bar-width);
-  }
+.Buckets__list {
+  background: var.$grey-2; // When sidebar is unfolded, remove the background transparency
+  pointer-events: none;
+  position: absolute;
+  height: 100%;
+  // 2020-11-20: interim and pragmatic solution for an apparent glitch on Safari and Chrome.
+  // Adding one pixel resolve this issue: https://github.com/hypothesis/client/pull/2750
+  width: $bucket-bar-width + 1;
+  left: -($bucket-bar-width);
+}
 
-  // When the sidebar is collapsed, make the background semi-transparent so the
-  // text is visible throughout (useful for pages with tight margins)
-  &.annotator-collapsed .Buckets__list {
-    background: rgba(0, 0, 0, 0.08);
-  }
+// When the sidebar is collapsed, make the background semi-transparent so the
+// text is visible throughout (useful for pages with tight margins)
+.annotator-collapsed .Buckets__list {
+  background: rgba(0, 0, 0, 0.08);
+}
 
-  .Buckets__bucket {
-    position: absolute;
-    right: 0;
-  }
+.Buckets__bucket {
+  position: absolute;
+  right: 0;
+}
 
-  .Buckets__button {
-    // Need pointer events again. Necessary because of `pointer-events` rule
-    // in `.Buckets__list`
-    pointer-events: all;
-  }
+.Buckets__button {
+  // Need pointer events again. Necessary because of `pointer-events` rule
+  // in `.Buckets__list`
+  pointer-events: all;
+}
 
-  .Buckets__button--left {
-    // Center the indicator vertically (the element is 16px tall)
-    margin-top: -8px;
-    @include buttons.indicator--left;
-  }
+.Buckets__button--left {
+  // Center the indicator vertically (the element is 16px tall)
+  margin-top: -8px;
+  @include buttons.indicator--left;
+}
 
-  .Buckets__button--up {
-    @include buttons.indicator--up;
-    // Vertically center the element (which is 22px high)
-    margin-top: -11px;
-  }
+.Buckets__button--up {
+  @include buttons.indicator--up;
+  // Vertically center the element (which is 22px high)
+  margin-top: -11px;
+}
 
-  .Buckets__button--down {
-    @include buttons.indicator--down;
-  }
+.Buckets__button--down {
+  @include buttons.indicator--down;
 }

--- a/src/styles/annotator/components/Toolbar.scss
+++ b/src/styles/annotator/components/Toolbar.scss
@@ -8,87 +8,81 @@
 @use '../mixins/layout';
 @use '../mixins/utils';
 
-// note: These components CSS classes are nested inside
-// .annotator-frame to avoid being overridden by the
-// CSS reset styles applied to .annotator-frame, which would otherwise
-// have higher specificity
-.annotator-frame {
-  // the vertical toolbar at the left-edge of the sidebar
-  // which provides controls for toggling the sidebar,
-  // toggling highlights etc.
+// The vertical toolbar at the left-edge of the sidebar
+// which provides controls for toggling the sidebar,
+// toggling highlights etc.
 
-  .Toolbar {
-    position: absolute;
-    left: -(var.$annotator-toolbar-width);
-    width: var.$annotator-toolbar-width;
-    @media (pointer: coarse) {
-      // Nov-23-2020: removing 12px is an interim solution to increase the size
-      // of the annotator-bar buttons without affecting the size of the sidebar
-      // https://github.com/hypothesis/client/pull/2745/files#r527824220
-      left: -(var.$touch-target-size - 12px);
-      width: var.$touch-target-size - 12px;
-    }
-    z-index: 2;
-  }
-
-  .Toolbar__buttonbar {
-    @include layout.vertical-rhythm(5px);
-    margin-top: var.$layout-space--small;
-  }
-
-  // Common styling for buttons in the toolbar
-  @mixin annotator-button {
-    @include buttons.button--icon-only($with-active-state: false);
-
+.Toolbar {
+  position: absolute;
+  left: -(var.$annotator-toolbar-width);
+  width: var.$annotator-toolbar-width;
+  @media (pointer: coarse) {
     // Nov-23-2020: removing 12px is an interim solution to increase the size
     // of the annotator-bar buttons without affecting the size of the sidebar
     // https://github.com/hypothesis/client/pull/2745/files#r527824220
-    @media (pointer: coarse) {
-      min-width: var.$touch-target-size - 12px;
-      min-height: var.$touch-target-size - 12px;
-    }
-    // These toolbar buttons are slightly lighter than other icon buttons
-    color: var.$grey-5;
-    background: var.$color-background;
+    left: -(var.$touch-target-size - 12px);
+    width: var.$touch-target-size - 12px;
   }
+  z-index: 2;
+}
 
-  // Toolbar button with icon
-  .Toolbar__button {
-    @include annotator-button;
-    @include utils.shadow;
-    @include utils.border;
-    border-radius: var.$annotator-border-radius;
-  }
+.Toolbar__buttonbar {
+  @include layout.vertical-rhythm(5px);
+  margin-top: var.$layout-space--small;
+}
 
-  // Control to collapse/expand the sidebar
-  .Toolbar__sidebar-toggle {
-    @include annotator-button;
-    @include utils.border--left;
-    @include utils.border--bottom;
-    // Precise positioning of expand/collapse icon
-    padding-left: 2px;
-    // Make the button fill the entire width of the toolbar and the
-    // entire height of the top bar
-    width: var.$annotator-toolbar-width;
-    height: var.$top-bar-height;
-    // Lighten the icon color
-    color: var.$grey-semi;
-  }
+// Common styling for buttons in the toolbar
+@mixin annotator-button {
+  @include buttons.button--icon-only($with-active-state: false);
 
-  /** Visible with clean theme */
-  .Toolbar__sidebar-close {
-    @include shared-buttons.reset;
-    @include buttons.button-hover;
-    @include utils.border;
-    border-right-width: 0;
-    background: var.$color-background;
-    box-shadow: var.$annotator-shadow--sidebar;
-    color: var.$grey-5;
-    // Precise positioning of close button
-    padding: 1px 6px;
-    width: 27px;
-    height: 27px;
-    margin-top: 140px;
-    margin-left: 6px;
+  // Nov-23-2020: removing 12px is an interim solution to increase the size
+  // of the annotator-bar buttons without affecting the size of the sidebar
+  // https://github.com/hypothesis/client/pull/2745/files#r527824220
+  @media (pointer: coarse) {
+    min-width: var.$touch-target-size - 12px;
+    min-height: var.$touch-target-size - 12px;
   }
+  // These toolbar buttons are slightly lighter than other icon buttons
+  color: var.$grey-5;
+  background: var.$color-background;
+}
+
+// Toolbar button with icon
+.Toolbar__button {
+  @include annotator-button;
+  @include utils.shadow;
+  @include utils.border;
+  border-radius: var.$annotator-border-radius;
+}
+
+// Control to collapse/expand the sidebar
+.Toolbar__sidebar-toggle {
+  @include annotator-button;
+  @include utils.border--left;
+  @include utils.border--bottom;
+  // Precise positioning of expand/collapse icon
+  padding-left: 2px;
+  // Make the button fill the entire width of the toolbar and the
+  // entire height of the top bar
+  width: var.$annotator-toolbar-width;
+  height: var.$top-bar-height;
+  // Lighten the icon color
+  color: var.$grey-semi;
+}
+
+/** Visible with clean theme */
+.Toolbar__sidebar-close {
+  @include shared-buttons.reset;
+  @include buttons.button-hover;
+  @include utils.border;
+  border-right-width: 0;
+  background: var.$color-background;
+  box-shadow: var.$annotator-shadow--sidebar;
+  color: var.$grey-5;
+  // Precise positioning of close button
+  padding: 1px 6px;
+  width: 27px;
+  height: 27px;
+  margin-top: 140px;
+  margin-left: 6px;
 }


### PR DESCRIPTION
Replace the scoped CSS reset in the annotator CSS bundle with the same un-scoped reset that the sidebar uses, as well as associated specificity hacks in other modules.

The scoped reset was needed when the annotator CSS was loaded directly into the host page. Following https://github.com/hypothesis/client/pull/3960 and https://github.com/hypothesis/client/pull/3961 it is no longer needed, as annotator UI elements now always use Shadow DOM for style isolation from the host page.