### PR TITLE
Add prefix to distinguish provenance of `$tag`

### DIFF
--- a/src/annotator/annotation-sync.js
+++ b/src/annotator/annotation-sync.js
@@ -110,7 +110,7 @@ export class AnnotationSync {
     if (annotation.$tag) {
       return annotation;
     }
-    tag = tag || generateHexString(8);
+    tag = tag || 'a:' + generateHexString(8);
     Object.defineProperty(annotation, '$tag', {
       value: tag,
     });

--- a/src/sidebar/services/annotations.js
+++ b/src/sidebar/services/annotations.js
@@ -70,7 +70,7 @@ export class AnnotationsService {
     // We need a unique local/app identifier for this new annotation such
     // that we might look it up later in the store. It won't have an ID yet,
     // as it has not been persisted to the service.
-    const $tag = generateHexString(8);
+    const $tag = 's:' + generateHexString(8);
 
     /** @type {Annotation} */
     const annotation = Object.assign(


### PR DESCRIPTION
For debugging purposes having a prefix to indicate whether the annotation was created locally ('a:' for the annotator, 's:' for the sidebar) or fetched from the server may be useful.