### PR TITLE
Fix adder font family

### DIFF
--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -23,6 +23,11 @@
 @use './components/Toolbar';
 @use './components/WarningBanner';
 
+// Styles for all top-level elements in shadow roots.
+:host > * {
+  font-family: var.$sans-font-family;
+}
+
 // Sidebar
 .annotator-frame {
   // frame styles


### PR DESCRIPTION
Fix a regression after e7cdcc0de0bc8d5338d2b830e3626977b953929c, which added the client's standard CSS reset to the annotator CSS bundle. The font-family used by the adder buttons was changed from the user agent's default for `<button>` elements to `inherit` by this reset. The result was that the font family would vary depending on the web page.

Fix this by adding a `:host > *` selector which sets style properties for all shadow roots created by the annotator. This is the equivalent of the `body` selector in sidebar.scss.

The issue could have been fixed by setting `font-family` on individual elements, but setting it on the root elements in shadow roots means that this property is set in the same way that it is for elements in the sidebar.

---

**Testing:**

Adder styling when visiting http://localhost:3000/document/burns:

Before:

<img width="307" alt="Adder styling before" src="https://user-images.githubusercontent.com/2458/143864096-75be4e1b-01de-49fb-9d1a-4bb0aef025ab.png">

After:

<img width="400" alt="Adder styling after" src="https://user-images.githubusercontent.com/2458/143863972-04531863-7835-450b-8c13-ec49b7c0320c.png">


