### PR TITLE
Call PortProvider.listen sooner

### DIFF
--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -53,6 +53,7 @@ function init() {
 
     const hypothesisAppsOrigin = new URL(sidebarConfig.sidebarAppUrl).origin;
     portProvider = new PortProvider(hypothesisAppsOrigin);
+    portProvider.listen();
 
     sidebar = new Sidebar(document.body, eventBus, guest, sidebarConfig);
     notebook = new Notebook(document.body, eventBus, getConfig('notebook'));
@@ -60,8 +61,6 @@ function init() {
     portProvider.on('frameConnected', (source, port) =>
       sidebar.onFrameConnected(source, port)
     );
-
-    portProvider.listen();
   }
 
   sidebarLinkElement.addEventListener('destroy', () => {


### PR DESCRIPTION
Call `listen` immediately after creating the PortProvider, before
creating the sidebar.

This will allow us to rule out the possibility that the sidebar sometimes fails
to connect to the PortProvider because an error occurred in the annotator code
after creating the sidebar iframe but before calling `PortProvider.listen`,
resulting in the PortProvider listener not being created.