### PR TITLE
Remove comments referencing old dependencies

### DIFF
--- a/src/sidebar/helpers/version-data.js
+++ b/src/sidebar/helpers/version-data.js
@@ -37,7 +37,7 @@ export default class VersionData {
       }
     }
 
-    this.version = '__VERSION__'; // replaced by versionify
+    this.version = '__VERSION__';
     this.userAgent = window_.navigator.userAgent;
     this.urls = documentInfo.map(di => di.uri).join(', ') || noValueString;
 

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -98,7 +98,7 @@ function createAPICall(
 
       const headers = {
         'Content-Type': 'application/json',
-        'Hypothesis-Client-Version': '__VERSION__', // replaced by versionify
+        'Hypothesis-Client-Version': '__VERSION__',
       };
 
       if (token) {

--- a/src/sidebar/test/media-embedder-test.js
+++ b/src/sidebar/test/media-embedder-test.js
@@ -72,10 +72,6 @@ describe('sidebar/media-embedder', () => {
 
       assert.equal(
         embedUrl(element),
-        // queryString's #stringify sorts keys, so resulting query string
-        // will be reliably as follows, regardless of original ordering
-        // Note also `v` param is handled elsewhere and is not "allowed" in
-        // queryString.
         'https://www.youtube.com/embed/QCkm0lL-6lc?end=10&start=5'
       );
     });
@@ -163,8 +159,6 @@ describe('sidebar/media-embedder', () => {
 
       assert.equal(
         embedUrl(element),
-        // queryString's #stringify sorts keys, so resulting query string
-        // will be reliably as follows, regardless of original ordering
         'https://www.youtube.com/embed/QCkm0lL-6lc?end=10&start=5'
       );
     });
@@ -199,8 +193,6 @@ describe('sidebar/media-embedder', () => {
 
       assert.equal(
         embedUrl(element),
-        // queryString's #stringify sorts keys, so resulting query string
-        // will be reliably as follows, regardless of original ordering
         'https://www.youtube.com/embed/QCkm0lL-6lc?end=10&start=5'
       );
     });

--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -64,7 +64,7 @@ export function init(config) {
       'Object Not Found Matching Id',
     ],
 
-    release: '__VERSION__', // replaced by versionify
+    release: '__VERSION__',
 
     // See https://docs.sentry.io/error-reporting/configuration/filtering/?platform=javascript#before-send
     beforeSend: (event, hint) => {


### PR DESCRIPTION
 - versionify was removed as part of the Browserify => Rollup transition
 - We now use URLSearchParams instead of the query-string/querystring
   packages for query string serialization and parsing

I didn't add replacement comments because I felt that both were stating things that were reasonably clear from the code in question.