### PR TITLE
Capture errors responding to port requests in the host frame and forward them to Sentry

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -2,6 +2,7 @@ import Hammer from 'hammerjs';
 
 import { Bridge } from '../shared/bridge';
 import { addConfigFragment } from '../shared/config-fragment';
+import { sendErrorsTo } from '../shared/frame-error-capture';
 import { ListenerCollection } from '../shared/listener-collection';
 
 import { annotationCounts } from './annotation-counts';
@@ -113,6 +114,11 @@ export default class Sidebar {
       element.appendChild(this.hypothesisSidebar);
     }
 
+    // Register the sidebar as a handler for Hypothesis errors in this frame.
+    if (this.iframe.contentWindow) {
+      sendErrorsTo(this.iframe.contentWindow);
+    }
+
     this.guest = guest;
 
     this._listeners = new ListenerCollection();
@@ -217,6 +223,9 @@ export default class Sidebar {
       this.iframe.remove();
     }
     this._emitter.destroy();
+
+    // Unregister the sidebar iframe as a handler for errors in this frame.
+    sendErrorsTo(null);
   }
 
   /**

--- a/src/shared/frame-error-capture.js
+++ b/src/shared/frame-error-capture.js
@@ -1,0 +1,75 @@
+/** @type {Window|null} */
+let errorDestination = null;
+
+/**
+ * Wrap a callback with an error handler which forwards errors to another frame
+ * using {@link sendError}.
+ *
+ * @template {unknown[]} Args
+ * @template Result
+ * @param {(...args: Args) => Result} callback
+ * @param {string} context - A short message indicating where the error happened.
+ * @return {(...args: Args) => Result}
+ */
+export function captureErrors(callback, context) {
+  return (...args) => {
+    try {
+      return callback(...args);
+    } catch (err) {
+      sendError(err, context);
+      throw err;
+    }
+  };
+}
+
+/**
+ * Forward an error to the frame registered with {@link sendErrorsTo}.
+ *
+ * This function operates on a best-effort basis. If no error handling frame
+ * has been registered it does nothing.
+ *
+ * @param {unknown} error
+ * @param {string} context - A short message indicating where the error happened.
+ */
+export function sendError(error, context) {
+  if (!errorDestination) {
+    return;
+  }
+
+  const data = { type: 'hypothesis-error', error, context };
+  try {
+    // Try to send the error. This will currently fail in browsers which don't
+    // support structured cloning of exceptions. For these we'll need to implement
+    // a fallback.
+    errorDestination.postMessage(data, '*');
+  } catch (sendErr) {
+    console.warn('Unable to report Hypothesis error', sendErr);
+  }
+}
+
+/**
+ * Register a handler for errors sent to the current frame using {@link sendError}
+ *
+ * @param {(error: unknown, context: string) => void} callback
+ * @return {() => void} A function that unregisters the handler
+ */
+export function handleErrorsInFrames(callback) {
+  /** @param {MessageEvent} event */
+  const handleMessage = event => {
+    const { data } = event;
+    if (data && data?.type === 'hypothesis-error') {
+      callback(data.error, data.context);
+    }
+  };
+  window.addEventListener('message', handleMessage);
+  return () => window.removeEventListener('message', handleMessage);
+}
+
+/**
+ * Register a destination frame that {@link sendError} should submit errors to.
+ *
+ * @param {Window|null} destination
+ */
+export function sendErrorsTo(destination) {
+  errorDestination = destination;
+}

--- a/src/shared/frame-error-capture.js
+++ b/src/shared/frame-error-capture.js
@@ -28,6 +28,11 @@ export function captureErrors(callback, context) {
  * Errors are delivered on a best-effort basis. If no error handling frame has
  * been registered or the frame is still loading, the error will not be received.
  *
+ * Ideally we would use a more robust delivery system which can queue messages
+ * until they can be processed (eg. using MessagePort). We use `window.postMessage`
+ * for the moment because we are trying to rule out problems with
+ * MessageChannel/MessagePort when setting up sidebar <-> host communication.
+ *
  * @param {unknown} error
  * @param {string} context - A short message indicating where the error happened.
  */

--- a/src/shared/frame-error-capture.js
+++ b/src/shared/frame-error-capture.js
@@ -25,8 +25,8 @@ export function captureErrors(callback, context) {
 /**
  * Forward an error to the frame registered with {@link sendErrorsTo}.
  *
- * This function operates on a best-effort basis. If no error handling frame
- * has been registered it does nothing.
+ * Errors are delivered on a best-effort basis. If no error handling frame has
+ * been registered or the frame is still loading, the error will not be received.
  *
  * @param {unknown} error
  * @param {string} context - A short message indicating where the error happened.

--- a/src/shared/test/frame-error-capture-test.js
+++ b/src/shared/test/frame-error-capture-test.js
@@ -1,0 +1,144 @@
+import { delay } from '../../test-util/wait';
+import {
+  captureErrors,
+  handleErrorsInFrames,
+  sendError,
+  sendErrorsTo,
+} from '../frame-error-capture';
+
+describe('shared/frame-error-capture', () => {
+  let errorEvents;
+
+  function handleMessage(event) {
+    if (event.data.type === 'hypothesis-error') {
+      errorEvents.push(event.data);
+    }
+  }
+
+  beforeEach(() => {
+    errorEvents = [];
+    window.addEventListener('message', handleMessage);
+  });
+
+  afterEach(() => {
+    window.removeEventListener('message', handleMessage);
+    sendErrorsTo(null);
+  });
+
+  describe('captureErrors', () => {
+    it('returns wrapped callback', () => {
+      const callback = captureErrors((a, b) => a * b, 'Testing captureErrors');
+      const result = callback(7, 8);
+      assert.equal(result, 56);
+    });
+
+    it('captures errors and forwards them to the current handler frame', async () => {
+      sendErrorsTo(window);
+
+      const error = new Error('Test error');
+      const callback = captureErrors(() => {
+        throw error;
+      }, 'Testing captureErrors');
+
+      assert.throws(() => {
+        callback();
+      }, 'Test error');
+
+      await delay(0);
+
+      assert.equal(errorEvents.length, 1);
+      assert.match(errorEvents[0], {
+        context: 'Testing captureErrors',
+        error: sinon.match({ message: 'Test error' }),
+        type: 'hypothesis-error',
+      });
+    });
+
+    it('does not forward errors if there is no handler frame', () => {
+      const callback = captureErrors(() => {
+        throw new Error('Test error');
+      }, 'Testing captureErrors');
+
+      assert.throws(() => {
+        callback();
+      }, 'Test error');
+
+      assert.equal(errorEvents.length, 0);
+    });
+
+    it('ignores errors forwarding error to handler frame', () => {
+      try {
+        sinon
+          .stub(window, 'postMessage')
+          .throws(new Error('postMessage error'));
+        sinon.stub(console, 'warn');
+
+        sendErrorsTo(window);
+        const callback = captureErrors(() => {
+          throw new Error('Test error');
+        }, 'Testing captureErrors');
+
+        assert.throws(() => {
+          callback();
+        }, 'Test error');
+
+        assert.calledOnce(window.postMessage);
+        assert.calledOnce(console.warn);
+      } finally {
+        console.warn.restore();
+        window.postMessage.restore();
+      }
+    });
+  });
+
+  describe('handleErrorsInFrames', () => {
+    it('invokes callback when an error is received', async () => {
+      const receivedErrors = [];
+
+      const removeHandler = handleErrorsInFrames((error, context) => {
+        receivedErrors.push({ error, context });
+      });
+
+      try {
+        sendErrorsTo(window);
+        sendError(new Error('Test error'), 'Test context');
+
+        await delay(0);
+
+        assert.equal(receivedErrors.length, 1);
+        assert.equal(receivedErrors[0].error.message, 'Test error');
+        assert.equal(receivedErrors[0].context, 'Test context');
+      } finally {
+        removeHandler();
+      }
+    });
+  });
+
+  // Integration test that combines `captureErrors` and `handleErrorsInFrames`.
+  it('captures and forwards errors from wrapped callbacks', async () => {
+    const receivedErrors = [];
+    const removeHandler = handleErrorsInFrames((error, context) => {
+      receivedErrors.push({ error, context });
+    });
+
+    try {
+      sendErrorsTo(window);
+      const callback = captureErrors(() => {
+        throw new Error('Test error');
+      }, 'Test context');
+
+      try {
+        callback();
+      } catch {
+        // Ignored
+      }
+      await delay(0);
+
+      assert.equal(receivedErrors.length, 1);
+      assert.equal(receivedErrors[0].error.message, 'Test error');
+      assert.equal(receivedErrors[0].context, 'Test context');
+    } finally {
+      removeHandler();
+    }
+  });
+});

--- a/src/shared/test/frame-error-capture-test.js
+++ b/src/shared/test/frame-error-capture-test.js
@@ -53,16 +53,26 @@ describe('shared/frame-error-capture', () => {
         type: 'hypothesis-error',
       });
     });
+  });
 
-    it('does not forward errors if there is no handler frame', () => {
-      const callback = captureErrors(() => {
-        throw new Error('Test error');
-      }, 'Testing captureErrors');
+  describe('sendError', () => {
+    it('sends error to handler frame', async () => {
+      sendErrorsTo(window);
+      sendError(new Error('Test error'), 'some context');
 
-      assert.throws(() => {
-        callback();
-      }, 'Test error');
+      await delay(0);
 
+      assert.equal(errorEvents.length, 1);
+      assert.match(errorEvents[0], {
+        context: 'some context',
+        error: sinon.match({ message: 'Test error' }),
+        type: 'hypothesis-error',
+      });
+    });
+
+    it('does not forward errors if there is no handler frame', async () => {
+      sendError(new Error('Test error'));
+      await delay(0);
       assert.equal(errorEvents.length, 0);
     });
 
@@ -74,13 +84,7 @@ describe('shared/frame-error-capture', () => {
         sinon.stub(console, 'warn');
 
         sendErrorsTo(window);
-        const callback = captureErrors(() => {
-          throw new Error('Test error');
-        }, 'Testing captureErrors');
-
-        assert.throws(() => {
-          callback();
-        }, 'Test error');
+        sendError(new Error('Test error'), 'some context');
 
         assert.calledOnce(window.postMessage);
         assert.calledOnce(console.warn);

--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -146,7 +146,8 @@ export function setUserInfo(user) {
 }
 
 /**
- * Reset metrics used for client-side event filtering.
+ * Testing aid that resets event counters and removes event handlers installed
+ * by {@link init}.
  */
 export function reset() {
   eventsSent = 0;

--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -13,7 +13,7 @@ import warnOnce from '../../shared/warn-once';
 let eventsSent = 0;
 const maxEventsToSendPerSession = 5;
 
-/** @type {() => void} */
+/** @type {(() => void)|null} */
 let removeFrameErrorHandler;
 
 /**
@@ -151,4 +151,5 @@ export function setUserInfo(user) {
 export function reset() {
   eventsSent = 0;
   removeFrameErrorHandler?.();
+  removeFrameErrorHandler = null;
 }

--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -14,7 +14,7 @@ let eventsSent = 0;
 const maxEventsToSendPerSession = 5;
 
 /** @type {(() => void)|null} */
-let removeFrameErrorHandler;
+let removeFrameErrorHandler = null;
 
 /**
  * Return the origin which the current script comes from.


### PR DESCRIPTION
This PR adds infrastructure that will enable us to gain visibility into errors happening in specifically wrapped blocks of Hypothesis code in the host frame. This is then used to check for errors happening during handling of port requests in `PortProvider#listen`.

This infrastructure works as follows:

1. In the annotator code, the sidebar iframe is created and a `sendErrorsTo` function is called to indicate which frame should handle captured errors from the host frame
2. In the sidebar iframe's Sentry client, `handleErrorsInFrames` is called to register a callback for errors from the host frame and send them to Sentry
3. In the annotator code, callbacks can be wrapped using a `captureErrors` function to capture any errors that the callback throws and forward them to the current handler frame. Alternatively a `sendError` function can be used from the `catch` block of a try-catch handler.

All captured errors have a `context` string to indicate where they came from, which is exposed in Sentry reports as a `context` tag.

This initial PR only supports reporting errors in browsers which can clone Errors when calling `window.postMessage`, which is currently only Chrome. In other browsers a warning is logged. We can address this in future by adding a fallback code path to pseudo-clone errors in these browsers.

This is part of the investigation into https://github.com/hypothesis/client/issues/3986.

---

Example of a Sentry report created by a dummy error thrown in `PortProvider#listen`:

<img width="801" alt="Sentry forwarded error" src="https://user-images.githubusercontent.com/2458/144080808-6f84a5d4-21ce-49d3-87b2-469f79362028.png">

In the context of the ongoing errors when creating the sidebar-host channel, this exception will show up in the breadcrumbs:

<img width="799" alt="Sentry frame error in breadcrumbs" src="https://user-images.githubusercontent.com/2458/144081020-541b6316-ae4f-4a15-a744-9edc27b8b382.png">

