### PR TITLE
Do not set crossorigin attribute when preloading stylesheets

### DIFF
--- a/src/annotator/util/shadow-root.js
+++ b/src/annotator/util/shadow-root.js
@@ -14,10 +14,6 @@ function loadStyles(shadowRoot) {
   }
 
   const linkEl = document.createElement('link');
-
-  // This needs to match the `crossorigin` attribute on the preloaded stylesheet.
-  linkEl.crossOrigin = 'anonymous';
-
   linkEl.rel = 'stylesheet';
   linkEl.href = url;
   shadowRoot.appendChild(linkEl);

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -109,12 +109,18 @@ function injectLink(doc, rel, type, url) {
  * @param {string} type - Type of resource
  * @param {string} url
  */
-function preloadUrl(doc, type, url) {
+function preloadURL(doc, type, url) {
   const link = doc.createElement('link');
   link.rel = 'preload';
   link.as = type;
-  link.crossOrigin = 'anonymous';
   link.href = url;
+
+  // If this is a resource that we are going to read the contents of, then we
+  // need to make a cross-origin request. For other types, use a non cross-origin
+  // request which returns a response that is opaque.
+  if (type === 'fetch') {
+    link.crossOrigin = 'anonymous';
+  }
 
   tagElement(link);
   doc.head.appendChild(link);
@@ -178,7 +184,7 @@ export function bootHypothesisClient(doc, config) {
   injectLink(doc, 'notebook', 'html', config.notebookAppUrl);
 
   // Preload the styles used by the shadow roots of annotator UI elements.
-  preloadUrl(doc, 'style', assetURL(config, 'styles/annotator.css'));
+  preloadURL(doc, 'style', assetURL(config, 'styles/annotator.css'));
 
   // Register the URL of the annotation client which is currently being used to drive
   // annotation interactions.
@@ -218,8 +224,8 @@ export function bootHypothesisClient(doc, config) {
  */
 export function bootSidebarApp(doc, config) {
   // Preload `/api/` and `/api/links` API responses.
-  preloadUrl(doc, 'fetch', config.apiUrl);
-  preloadUrl(doc, 'fetch', config.apiUrl + 'links');
+  preloadURL(doc, 'fetch', config.apiUrl);
+  preloadURL(doc, 'fetch', config.apiUrl + 'links');
 
   const polyfills = polyfillBundles(commonPolyfills);
 

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -126,7 +126,7 @@ describe('bootstrap', () => {
         'https://marginal.ly/client/build/styles/annotator.1234.css'
       );
       assert.equal(preloadLinks[0].as, 'style');
-      assert.equal(preloadLinks[0].crossOrigin, 'anonymous');
+      assert.equal(preloadLinks[0].crossOrigin, null);
     });
 
     it('creates the link to the sidebar iframe', () => {


### PR DESCRIPTION
The `crossorigin="anonymous"` attribute was added to `<link rel="preload">` elements created by the boot script because it was needed when preloading API responses, so that the response can be read by our JS.

We don't need to use cross-origin requests when preloading stylesheets however, and we were seeing occassional errors in Chrome which appear to be connected to this. See https://github.com/hypothesis/client/issues/3987. This PR changes the logic that generates `<link rel="preload">` attributes in the boot script so that the `crossorigin` is only added for preloads with an `as="fetch"` attribute.

If testing this locally, make sure that the app loads, the `<link rel="preload">` added to the host page by the client does not have a `crossorigin` attribute on it, and there should be no console errors/warnings in Chrome. Note that in Safari there are existing warnings about unused preloads for _API requests_, as opposed to the stylesheet.

See also the docs on the [crossorigin attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin).

I believe this should fix https://github.com/hypothesis/client/issues/3987.

---

Stylesheet preload without `crossorigin` attribute in the dev server:

<img width="775" alt="No crossorigin preload" src="https://user-images.githubusercontent.com/2458/144491329-8987c985-5275-4328-bc6f-4bf845a1f286.png">


