### PR TITLE
Improve UI for LMS Grading for assignments with Blackboard groups

### DIFF
--- a/src/sidebar/components/FilterStatus.js
+++ b/src/sidebar/components/FilterStatus.js
@@ -1,4 +1,4 @@
-import { LabeledButton } from '@hypothesis/frontend-shared';
+import { LabeledButton, Spinner } from '@hypothesis/frontend-shared';
 
 import { useMemo } from 'preact/hooks';
 
@@ -68,37 +68,46 @@ function FilterStatusPanel({
   focusDisplayName,
   resultCount,
 }) {
+  const store = useStoreProxy();
   return (
     <div className="FilterStatus">
-      <div className="hyp-u-layout-row--align-center">
-        <div className="FilterStatus__text">
-          {resultCount > 0 && <span>Showing </span>}
-          <span className="filter-facet">
-            {resultCount > 0 ? resultCount : 'No'}{' '}
-            {resultCount === 1 ? entitySingular : entityPlural}
-          </span>
-          {filterQuery && (
-            <span>
-              {' '}
-              for{' '}
-              <span className="filter-facet--pre">&#39;{filterQuery}&#39;</span>
-            </span>
-          )}
-          {focusDisplayName && (
-            <span>
-              {' '}
-              by <span className="filter-facet">{focusDisplayName}</span>
-            </span>
-          )}
-          {additionalCount > 0 && (
-            <span className="filter-facet--muted">
-              {' '}
-              (and {additionalCount} more)
-            </span>
-          )}
+      {store.isLoading() ? (
+        <div className="hyp-u-layout-row--center">
+          <Spinner />
         </div>
-        <div>{actionButton}</div>
-      </div>
+      ) : (
+        <div className="hyp-u-layout-row--align-center">
+          <div className="FilterStatus__text">
+            {resultCount > 0 && <span>Showing </span>}
+            <span className="filter-facet">
+              {resultCount > 0 ? resultCount : 'No'}{' '}
+              {resultCount === 1 ? entitySingular : entityPlural}
+            </span>
+            {filterQuery && (
+              <span>
+                {' '}
+                for{' '}
+                <span className="filter-facet--pre">
+                  &#39;{filterQuery}&#39;
+                </span>
+              </span>
+            )}
+            {focusDisplayName && (
+              <span>
+                {' '}
+                by <span className="filter-facet">{focusDisplayName}</span>
+              </span>
+            )}
+            {additionalCount > 0 && (
+              <span className="filter-facet--muted">
+                {' '}
+                (and {additionalCount} more)
+              </span>
+            )}
+          </div>
+          <div>{actionButton}</div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -88,14 +88,20 @@ function SidebarView({
   // Reload annotations when group, user or document search URIs change
   useEffect(() => {
     if (!prevGroupId.current || prevGroupId.current !== focusedGroupId) {
-      // Clear any selected annotations and filters when the group ID changes.
-      //
+      // Clear any selected annotations and filters when the focused group
+      // changes.
       // We don't clear the selection/filters on the initial load when
       // the focused group transitions from null to non-null, as this would clear
       // any filters intended to be used for the initial display (eg. to focus
       // on a particular user).
       if (prevGroupId.current) {
+        // Respect applied focus-mode filtering when changing focused group
+        let restoreFocus = store.focusState().active;
+
         store.clearSelection();
+        if (restoreFocus) {
+          store.toggleFocusMode(true);
+        }
       }
       prevGroupId.current = focusedGroupId;
     }

--- a/src/sidebar/components/test/FilterStatus-test.js
+++ b/src/sidebar/components/test/FilterStatus-test.js
@@ -44,6 +44,7 @@ describe('FilterStatus', () => {
       filterState: sinon.stub().returns(getFilterState()),
       focusState: sinon.stub().returns(getFocusState()),
       forcedVisibleThreads: sinon.stub().returns([]),
+      isLoading: sinon.stub().returns(false),
       selectedAnnotations: sinon.stub().returns([]),
       toggleFocusMode: sinon.stub(),
     };
@@ -79,6 +80,16 @@ describe('FilterStatus', () => {
       callback: fakeStore.clearSelection,
     });
   }
+
+  context('Loading', () => {
+    it('shows a loading spinner', () => {
+      fakeStore.filterQuery.returns('foobar');
+      fakeStore.isLoading.returns(true);
+      const wrapper = createComponent();
+
+      assert.isTrue(wrapper.find('Spinner').exists());
+    });
+  });
 
   context('(State 1): no search filters active', () => {
     it('should return null if filter state indicates no active filters', () => {

--- a/src/sidebar/components/test/SidebarView-test.js
+++ b/src/sidebar/components/test/SidebarView-test.js
@@ -48,8 +48,10 @@ describe('SidebarView', () => {
       annotationExists: sinon.stub(),
       directLinkedAnnotationId: sinon.stub(),
       directLinkedGroupFetchFailed: sinon.stub(),
+      filteredGroupIDs: sinon.stub().returns([]),
       findAnnotationByID: sinon.stub(),
       focusedGroupId: sinon.stub(),
+      focusState: sinon.stub().returns({ active: false }),
       hasAppliedFilter: sinon.stub(),
       hasFetchedAnnotations: sinon.stub(),
       hasFetchedProfile: sinon.stub().returns(true),
@@ -59,6 +61,7 @@ describe('SidebarView', () => {
       isLoggedIn: sinon.stub(),
       profile: sinon.stub().returns({ userid: null }),
       searchUris: sinon.stub().returns([]),
+      toggleFocusMode: sinon.stub(),
     };
 
     fakeTabsUtil = {
@@ -94,11 +97,23 @@ describe('SidebarView', () => {
       assert.notCalled(fakeStore.clearSelection);
     });
 
-    it('clears selected annotations and loads annotations when groupId changes', () => {
+    it('clears selected annotations and selections and loads annotations when groupId changes', () => {
       fakeStore.focusedGroupId.returns('affable');
       wrapper.setProps({});
+      assert.calledOnce(fakeStore.focusState);
       assert.calledOnce(fakeLoadAnnotationsService.load);
       assert.calledOnce(fakeStore.clearSelection);
+      assert.notCalled(fakeStore.toggleFocusMode);
+    });
+
+    it('restores focus mode after changing focused group', () => {
+      fakeStore.focusedGroupId.returns('affable');
+      fakeStore.focusState.returns({ active: true });
+
+      wrapper.setProps({});
+
+      assert.calledOnce(fakeStore.clearSelection);
+      assert.calledWith(fakeStore.toggleFocusMode, true);
     });
 
     it('does not clear selected annotations when group ID is first set on startup', () => {

--- a/src/sidebar/cross-origin-rpc.js
+++ b/src/sidebar/cross-origin-rpc.js
@@ -11,7 +11,10 @@ let preStartQueue = [];
  */
 const registeredMethods = store => {
   return {
-    changeFocusModeUser: store.changeFocusModeUser,
+    changeFocusModeUser: userInfo => {
+      store.changeFocusModeUser(userInfo);
+      store.filterGroups(userInfo?.groups);
+    },
   };
 };
 

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -141,8 +141,9 @@
  * TODO - Fill out remaining properties
  *
  * @typedef Group
- * @prop {string} id
- * @prop {string} groupid
+ * @prop {string} id - a.k.a. "pubid", unique per authority.
+ * @prop {string} [groupid] - Fully-qualified ID with authority.
+ *   Not all groups have a `groupid`. LMS groups always have a `groupid`.
  * @prop {'private'|'open'} type
  * @prop {Organization} organization - nb. This field is nullable in the API, but
  *   we assign a default organization on the client.


### PR DESCRIPTION
This PR improves the UI of LMS user-focused grading mode for assignments with multiple groups. Some of the changes here require corresponding LMS-side changes to see in action, but are innocuous with current LMS `master`.

Changes:

1. Show a loading spinner in `FilterStatus` panels when annotations or groups are loading
2. Retain user-focus filter when navigating between groups in LMS grading mode
3. Accept `groups` property in the `changeFocusModeUser` RPC method and filter the groups shown in the sidebar to that set of `groupids`

![bb-groups-grading](https://user-images.githubusercontent.com/439947/144626361-262cc39f-7ef1-4107-b0ab-64b3e32dcc5a.gif)

(There is apparent jumpiness in a few spots in the video here, but they are artifacts of the screen-capture software; in reality everything looks smooth).

### 1. Show loading spinner

Now that we are retaining user filtering when the instructor navigates between groups—i.e. changes the focused group—we're persisting filters across an annotation load. Displaying a spinner in the filter information panel prevents UI flashing or incorrect counts being displayed temporarily.

The effects of this change can only be seen by running the LMS PR branch https://github.com/hypothesis/lms/pull/3475 in tandem with these changes.

### 2. Retain user-focus filter when changing focused group

Previously, changing the focused group would reset _all_ filters and selections. Now, if the focused group changes when a user-focus filter is active, it will be restored after the group is changed. This provides better UI continuity for instructors.

This change can be seen on a BB-groups-enabled assignment on LMS `master` (you do not have to run the LMS PR branch to see them).

### 3. Filter on groups designated in RPC call

Expand `changeFocusMode` RPC call to accept a `groups` property that contains the list of `groupids` corresponding to the relevant list of groups for the focused user. 

This feature can be seen in play if this branch is tested in concert with https://github.com/hypothesis/lms/pull/3475 With these changes, as an instructor navigates from user to user in grading mode, only those groups relevant to the focused student will be loaded in the sidebar. The instructor’s full set of groups will be loaded on launch, and whenever they are not focusing on a single student.

### How to test

Apologies in advance that you’ll need to configure a gradable localhost Blackboard assignment with groups. In brief:

#### Configure a grade-able assignment and make some student submissions

1. Check out this branch and run it
2. Check out this LMS PR’s branch and run it: https://github.com/hypothesis/lms/pull/3475
3. Create a BB localhost assignment (I use the `blackboardteacher` user)—do not forget to activate the checkbox that makes it gradable!
4. Configure the assignment to use BB groups (this feature should be activated for localhost). Might I suggest “Lyza’s Group set” as it contains 5 groups and has students preassigned to groups that makes testing this out fairly clear.
5. Log in as `blackboardstudent` and `blackboardstudent2` (1password) and launch the assignment. Add a few annotations in each available group for each student. At least you can reuse this assignment later on if you want to test grading/BB groups. If that’s any consolation. *Note*: The assignment must be configured as gradable _before_ launching it as any students, or, at least, any annotations added before that will be ignored.

#### Test out grading mode

Log in as `blackboardteacher` and launch the assignment. This should put you in grading mode.

* On launch, you should see all of the assignment Group Set’s groups in the sidebar. If you used “Lyza’s Group Set”, there should be five groups.
* Navigate to a student in the grading bar. You should see some loading behavior and be in user-focused mode. Only the groups that this student is a member of should be present in the sidebar. If you used “Lyza’s Group Set”, `blackboardstudent` and `blackboardstudent2` each belong to two groups. They both belong to group 5 but their second group is different. You should be able to toggle the user-focus filter, and you should be able to navigate between the student’s groups as expected.
* Navigate to a different student in the grading bar. You should see their groups only (and other actions as described for the previous student should still work).
* Navigate back to “All Students.” You should see all of the Group Set’s groups again. You should not see any user-focus-filter status in the sidebar.


Part of https://github.com/hypothesis/lms/issues/3416