### PR TITLE
Update/modernize browser support check

### DIFF
--- a/dev-server/serve-package.js
+++ b/dev-server/serve-package.js
@@ -32,6 +32,7 @@ function servePackage(port) {
   const serveBootScript = function (req, res) {
     const entryPath = require.resolve('../');
     const entryScript = readFileSync(entryPath).toString('utf-8');
+    res.append('Content-Type', 'application/javascript; charset=utf-8');
     res.send(entryScript);
   };
 

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -66,7 +66,15 @@ gulp.task('build-boot-script', async () => {
 
 gulp.task('watch-boot-script', () => {
   gulp.watch(
-    manifestSourceFiles,
+    [
+      manifestSourceFiles,
+
+      // This relies on the boot script only depending on modules in src/boot.
+      //
+      // We could alternatively use `watchJS` to rebuild the bundle, but we'd
+      // need to make its logging less noisy first.
+      'src/boot/**/*.js',
+    ],
     { delay: 500 },
     gulp.task('build-boot-script')
   );

--- a/src/boot/browser-check.js
+++ b/src/boot/browser-check.js
@@ -9,6 +9,8 @@
  * @return {boolean}
  */
 export function isBrowserSupported() {
+  // Checks that return a truthy value if they succeed and throw or return
+  // a falsey value if they fail.
   const checks = [
     // ES APIs.
     () => Promise.resolve(),
@@ -17,7 +19,10 @@ export function isBrowserSupported() {
     // DOM API checks for frequently-used APIs.
     () => new URL(document.location.href), // URL constructor.
     () => new Request('https://hypothes.is'), // Part of the `fetch` API.
-    () => Element.prototype.prepend.name,
+    () => Element.prototype.attachShadow,
+
+    // CSS feature checks
+    () => CSS.supports('display: grid'),
 
     // DOM API checks for less frequently-used APIs.
     // These are less likely to have been polyfilled by the host page.
@@ -31,12 +36,12 @@ export function isBrowserSupported() {
         XPathResult.ANY_TYPE,
         null /* result */
       );
+      return true;
     },
   ];
 
   try {
-    checks.forEach(check => check());
-    return true;
+    return checks.every(check => check());
   } catch (err) {
     return false;
   }


### PR DESCRIPTION
Update the representative feature tests to check for Shadow DOM v1 and CSS grid.

This avoids loading the client in browsers that are definitely too old, which should in turn prevent us receiving Sentry reports from them.

In the process I found issues with rebuilding of the boot script by `make dev`. See the last commit. If checking out this branch to test manually, **restart the dev server.**

To test manually, verify that the client starts on this branch. You can also try changing one of the checks to return a falsey value (eg. change the `CSS.supports('display: grid')` check to `CSS.supports('display: invalid')`) and seeing that the client does not start.