### PR TITLE
Report more detailed errors if port requests cannot be handled

### DIFF
--- a/src/shared/port-util.js
+++ b/src/shared/port-util.js
@@ -17,7 +17,7 @@
  * @param {any} data
  * @return {data is Message}
  */
-function isMessage(data) {
+export function isMessage(data) {
   if (data === null || typeof data !== 'object') {
     return false;
   }

--- a/src/shared/port-util.js
+++ b/src/shared/port-util.js
@@ -32,7 +32,7 @@ export function isMessage(data) {
 }
 
 /**
- * Compares a `postMessage` data to one `Message`
+ * Return true if the data payload from a MessageEvent matches `message`.
  *
  * @param {any} data
  * @param {Message} message
@@ -44,7 +44,7 @@ export function isMessageEqual(data, message) {
 
   try {
     return (
-      JSON.stringify(data, Object.keys(data).sort()) ===
+      JSON.stringify(data, Object.keys(message).sort()) ===
       JSON.stringify(message, Object.keys(message).sort())
     );
   } catch {

--- a/src/shared/port-util.js
+++ b/src/shared/port-util.js
@@ -42,14 +42,12 @@ export function isMessageEqual(data, message) {
     return false;
   }
 
-  try {
-    return (
-      JSON.stringify(data, Object.keys(message).sort()) ===
-      JSON.stringify(message, Object.keys(message).sort())
-    );
-  } catch {
-    return false;
-  }
+  // We assume `JSON.stringify` cannot throw because `isMessage` verifies that
+  // all the fields we serialize here are serializable values.
+  return (
+    JSON.stringify(data, Object.keys(message).sort()) ===
+    JSON.stringify(message, Object.keys(message).sort())
+  );
 }
 
 /**

--- a/src/shared/test/port-provider-test.js
+++ b/src/shared/test/port-provider-test.js
@@ -1,8 +1,24 @@
 import { delay } from '../../test-util/wait';
-import { PortProvider } from '../port-provider';
+import { PortProvider, $imports } from '../port-provider';
 
 describe('PortProvider', () => {
+  let capturedErrors;
   let portProvider;
+
+  // Fake for `captureErrors` which allows us to inspect errors thrown when
+  // PortProvider handles message events sent to the window.
+  //
+  // Only used in tests that actually expect errors. Other tests use the real
+  // implementation which re-throws unexpected errors.
+  function captureErrors(callback) {
+    return (...args) => {
+      try {
+        callback(...args);
+      } catch (err) {
+        capturedErrors.push(err);
+      }
+    };
+  }
 
   async function sendPortFinderRequest({
     data,
@@ -24,9 +40,11 @@ describe('PortProvider', () => {
   beforeEach(() => {
     sinon.stub(window, 'postMessage');
     portProvider = new PortProvider(window.location.origin);
+    capturedErrors = [];
   });
 
   afterEach(() => {
+    $imports.$restore();
     window.postMessage.restore();
     portProvider.destroy();
   });
@@ -74,20 +92,12 @@ describe('PortProvider', () => {
   describe('listens for port requests', () => {
     [
       {
+        // Example of message with missing fields. Unit tests for `isMessage`
+        // cover this in more detail.
         data: {
-          frame1: 'dummy', // invalid source
-          frame2: 'host',
           type: 'request',
         },
-        reason: 'contains an invalid frame1',
-      },
-      {
-        data: {
-          frame1: 'sidebar',
-          frame2: 'dummy', // invalid target
-          type: 'request',
-        },
-        reason: 'contains an invalid frame2',
+        reason: 'is missing fields',
       },
       {
         data: {
@@ -96,24 +106,6 @@ describe('PortProvider', () => {
           type: 'dummy', // invalid type
         },
         reason: 'contains an invalid type',
-      },
-      {
-        data: {
-          frame1: 'sidebar',
-          frame2: 'host',
-          type: 'request',
-        },
-        source: null,
-        reason: 'comes from invalid source',
-      },
-      {
-        data: {
-          frame1: 'sidebar',
-          frame2: 'host',
-          type: 'request',
-        },
-        origin: 'https://dummy.com',
-        reason: 'comes from invalid origin',
       },
     ].forEach(({ data, reason, origin, source }) => {
       it(`ignores port request if message ${reason}`, async () => {
@@ -125,6 +117,67 @@ describe('PortProvider', () => {
         });
 
         assert.notCalled(window.postMessage);
+      });
+    });
+
+    [
+      {
+        data: {
+          frame1: 'dummy', // invalid source
+          frame2: 'host',
+          type: 'request',
+        },
+        reason: 'contains an invalid frame1',
+        expectedError: 'Port request has unsupported channel dummy-host',
+      },
+      {
+        data: {
+          frame1: 'sidebar',
+          frame2: 'dummy', // invalid target
+          type: 'request',
+        },
+        reason: 'contains an invalid frame2',
+        expectedError: 'Port request has unsupported channel sidebar-dummy',
+      },
+      {
+        data: {
+          frame1: 'sidebar',
+          frame2: 'host',
+          type: 'request',
+        },
+        source: null,
+        reason: 'comes from invalid source',
+        expectedError:
+          'Port request for sidebar-host came from a non-Window source',
+      },
+      {
+        data: {
+          frame1: 'sidebar',
+          frame2: 'host',
+          type: 'request',
+        },
+        origin: 'https://dummy.com',
+        reason: 'comes from invalid origin',
+        expectedError: `Port request for sidebar-host came from non-allowed origin https://dummy.com. Allowed origins: ${location.origin}`,
+      },
+    ].forEach(({ data, expectedError, reason, origin, source }) => {
+      it(`reports error if message ${reason}`, async () => {
+        $imports.$mock({
+          './frame-error-capture': { captureErrors },
+        });
+
+        portProvider.listen();
+
+        await sendPortFinderRequest({
+          data,
+          origin,
+          source,
+        });
+
+        assert.notCalled(window.postMessage);
+        assert.equal(capturedErrors.length, 1);
+        assert.instanceOf(capturedErrors[0], Error);
+        assert.equal(capturedErrors[0].message, expectedError);
       });
     });
 
@@ -144,6 +197,31 @@ describe('PortProvider', () => {
         { ...data, type: 'offer' },
         window.location.origin,
         [sinon.match.instanceOf(MessagePort)]
+      );
+    });
+
+    it('reports an error if sending port to source frame fails', async () => {
+      $imports.$mock({
+        './frame-error-capture': { captureErrors },
+      });
+
+      portProvider.listen();
+      const data = {
+        frame1: 'sidebar',
+        frame2: 'host',
+        type: 'request',
+      };
+
+      window.postMessage.throws(new Error('Something went wrong'));
+      await sendPortFinderRequest({
+        data,
+      });
+
+      assert.equal(capturedErrors.length, 1);
+      assert.instanceOf(capturedErrors[0], Error);
+      assert.equal(
+        capturedErrors[0].message,
+        'Failed to send port for channel sidebar-host: Something went wrong'
       );
     });
 

--- a/src/shared/test/port-util-test.js
+++ b/src/shared/test/port-util-test.js
@@ -1,6 +1,39 @@
-import { isMessageEqual, isSourceWindow } from '../port-util';
+import { isMessage, isMessageEqual, isSourceWindow } from '../port-util';
 
 describe('port-util', () => {
+  describe('isMessage', () => {
+    [
+      {
+        frame1: 'guest',
+        frame2: 'sidebar',
+        type: 'request',
+      },
+
+      {
+        frame1: 'guest',
+        frame2: 'sidebar',
+        type: 'request',
+        extraField: 'foo',
+      },
+    ].forEach(data => {
+      it('returns true for objects with the expected fields', () => {
+        assert.isTrue(isMessage(data));
+      });
+    });
+
+    [
+      null,
+      undefined,
+      {},
+      'str',
+      { frame1: 'guest', frame2: false, type: 'request' },
+    ].forEach(data => {
+      it('returns false if data is not a valid message', () => {
+        assert.isFalse(isMessage(data));
+      });
+    });
+  });
+
   describe('isMessageEqual', () => {
     const frame1 = 'guest';
     const frame2 = 'sidebar';
@@ -55,16 +88,6 @@ describe('port-util', () => {
       },
       {
         data: {
-          extra: 'dummy', // additional
-          frame1,
-          frame2,
-          type,
-        },
-        expectedResult: false,
-        reason: 'data has one additional property',
-      },
-      {
-        data: {
           frame1: 'dummy', // different
           frame2,
           type,
@@ -74,10 +97,9 @@ describe('port-util', () => {
       },
       {
         data: {
-          frame1,
+          frame1: new Date(), // not JSON-serializable
           frame2,
           type,
-          window, // not serializable
         },
         expectedResult: false,
         reason: "data has one property that can't be serialized",

--- a/src/shared/test/port-util-test.js
+++ b/src/shared/test/port-util-test.js
@@ -95,15 +95,6 @@ describe('port-util', () => {
         expectedResult: false,
         reason: 'data has one property that is different',
       },
-      {
-        data: {
-          frame1: new Date(), // not JSON-serializable
-          frame2,
-          type,
-        },
-        expectedResult: false,
-        reason: "data has one property that can't be serialized",
-      },
     ].forEach(({ data, expectedResult, reason }) => {
       it(`returns '${expectedResult}' because the ${reason}`, () => {
         const result = isMessageEqual(data, {


### PR DESCRIPTION
This PR makes two improvements that will help us drill down into the causes of communication errors between frames that we are seeing in Sentry:

- The first commit causes failures in validating the details or sender of a message to produce an error rather than just failing silently. With the new logic, incoming messages are first checked to see if they have the correct structure and `type` value for a port request. If not the message is ignored. If the message passes this test, the same validation of the source and channel is applied as previously, but errors are now reported if the various checks fail.
- The second commit changes payload <-> message comparisons to only check known fields of the message, allowing us to rule out the possibility that unknown fields added by extensions or other sources are causing problems.

See the commit messages for more details.

Related to https://github.com/hypothesis/client/issues/3986.