### PR TITLE
Fix occassionally slow frame-error-capture tests

### DIFF
--- a/src/shared/test/frame-error-capture-test.js
+++ b/src/shared/test/frame-error-capture-test.js
@@ -28,7 +28,15 @@ describe('shared/frame-error-capture', () => {
     return stub;
   }
 
+  let origPrepareStackTrace;
+
   beforeEach(() => {
+    // Replace the `prepareStackTrace` handler installed by source-map-support
+    // for the duration of these tests, as they make accesses to the `error.stack`
+    // property much more expensive, which sometimes caused timeouts in CI.
+    origPrepareStackTrace = Error.prepareStackTrace;
+    Error.prepareStackTrace = undefined;
+
     errorEvents = [];
     window.addEventListener('message', handleMessage);
   });
@@ -36,6 +44,8 @@ describe('shared/frame-error-capture', () => {
   afterEach(() => {
     window.removeEventListener('message', handleMessage);
     sendErrorsTo(null);
+
+    Error.prepareStackTrace = origPrepareStackTrace;
   });
 
   describe('captureErrors', () => {


### PR DESCRIPTION
These tests access the `error.stack` property, which in turn triggers the `Error.prepareStackTrace` [1] handler installed by source-map-support [2] (this library is involved in translating errors thrown in tests to their original source locations). This
is expensive and has caused some CI timeouts.

The workaround is to disable the `error.stack` handler for the duration of these tests.

[1] https://v8.dev/docs/stack-trace-api#customizing-stack-traces
[2] https://github.com/evanw/node-source-map-support/blob/ac2c3e4c633c66931981ac94b44e6963addbe3f4/source-map-support.js#L584