### PR TITLE
Clear user-focus filter when returning to "all students" view in grading mode

### DIFF
--- a/src/sidebar/store/modules/filters.js
+++ b/src/sidebar/store/modules/filters.js
@@ -106,14 +106,9 @@ function focusFiltersFromConfig(focusConfig) {
 
 const reducers = {
   CHANGE_FOCUS_MODE_USER: function (state, action) {
-    if (isValidFocusConfig({ user: action.user })) {
-      return {
-        focusActive: true,
-        focusFilters: focusFiltersFromConfig({ user: action.user }),
-      };
-    }
     return {
-      focusActive: false,
+      focusActive: isValidFocusConfig({ user: action.user }),
+      focusFilters: focusFiltersFromConfig({ user: action.user }),
     };
   },
 

--- a/src/sidebar/store/modules/test/filters-test.js
+++ b/src/sidebar/store/modules/test/filters-test.js
@@ -36,14 +36,26 @@ describe('sidebar/store/modules/filters', () => {
       //
       // This is the LMS app's way of asking the client to disable focus mode.
       it('deactivates and disables focus if username is undefined', () => {
-        store.toggleFocusMode(true);
+        // Set to a valid user first; this will set and also activate
+        // the filter
+        store.changeFocusModeUser({
+          username: 'testuser',
+          displayName: 'Test User',
+        });
+
+        const firstFilterState = getFiltersState();
+        assert.isTrue(firstFilterState.focusActive);
+        assert.equal(firstFilterState.focusFilters.user.value, 'testuser');
+
+        // Now, emulate the "empty" filter message from the LMS app.
         store.changeFocusModeUser({
           username: undefined,
           displayName: undefined,
         });
-        const filterState = getFiltersState();
-        assert.isFalse(filterState.focusActive);
-        assert.isUndefined(filterState.focusFilters.user);
+
+        const secondFilterState = getFiltersState();
+        assert.isFalse(secondFilterState.focusActive);
+        assert.isUndefined(secondFilterState.focusFilters.user);
       });
     });
 


### PR DESCRIPTION
This PR attempts to alleviate a UI confusion in LMS (non-Speedgrader) grading mode when an instructor returns to viewing all students after focusing on one or more students individually. 

*Note*: The screengrabs in this ticket show a slightly different control interface (e.g. the arrow buttons) for the grading mode within LMS. This is because I was running a local LMS branch that is midway through refactoring some of that UI. It doesn't have any bearing on the functionality in this branch, but I can re-do screenshots if a reviewer finds this confusing.

Before these changes, a potentially confusing deactivated-but-still-available user-focus filter for the last-viewed student remained after returning to viewing all users:

![image](https://user-images.githubusercontent.com/439947/144858344-f7870faf-cccf-4b39-b859-911b09e8b66e.png)

After these changes, the user filter is unset (removed) entirely when returning to viewing all students:

![image](https://user-images.githubusercontent.com/439947/144858276-f4dd1cae-f85a-4636-893c-6847b2953fbf.png)

### Test these changes

* Check out this branch
* Launch a grade-able local Blackboard assignment (you may need to configure an assignment; a few instructions can be found in #3991 ).
* "Focus" on a student or two using the drop-down or arrow controls, then return to "All students." On this branch, you should not see a vestigial user filter hanging out.
