### PR TITLE
Fix race condition if annotations are deleted before anchoring

### DIFF
--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -420,12 +420,18 @@ describe('Guest', () => {
     });
 
     describe('on "deleteAnnotation" event', () => {
-      it('detaches annotation', () => {
+      it('defers detach annotation until it is anchored', async () => {
         const guest = createGuest();
         const callback = sinon.stub();
+        const ann = { target: [], uri: 'uri', $tag: 'tag1' };
         guest._emitter.subscribe('anchorsChanged', callback);
 
-        emitSidebarEvent('deleteAnnotation', 'tag1');
+        emitSidebarEvent('deleteAnnotation', ann.$tag);
+
+        assert.notCalled(callback);
+
+        emitSidebarEvent('loadAnnotations', [ann]);
+        await delay(0);
 
         assert.calledOnce(callback);
         assert.calledWith(callback, []);


### PR DESCRIPTION
This commit fixes a situation when annotations are deleted in the
`sidebar` frame before the `guest` frame finishes to anchor the
annotations.

`Guest` tracks of which annotations needs to be deleted in a field
`Guest#_deferredDetach`. This annotation set is check on every anchor
event.

`Guest` also adds a `Map` that tracks of which annotations have been
anchored. This `Guesst#_annotations` field allows for future performance
optimisations.

Suggested here: https://github.com/hypothesis/client/pull/3983#pullrequestreview-820618608