### PR TITLE
 Improved performance on `focusAnnotations` RPC event

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -735,4 +735,14 @@ export default class Guest {
   get focusedAnnotationTags() {
     return this._focusedAnnotations;
   }
+
+  /**
+   * Use only for testing purposes
+   *
+   * @param {string} $tag
+   * @param {Anchor[]} anchors
+   */
+  setAnnotations($tag, anchors) {
+    this._annotations.set($tag, anchors);
+  }
 }

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -313,15 +313,23 @@ export default class Guest {
       'focusAnnotations',
       /** @param {string[]} tags */
       (tags = []) => {
-        this._focusedAnnotations.clear();
-        tags.forEach(tag => this._focusedAnnotations.add(tag));
-
-        for (let anchor of this.anchors) {
-          if (anchor.highlights) {
-            const toggle = tags.includes(anchor.annotation.$tag);
-            setHighlightsFocused(anchor.highlights, toggle);
+        this._focusedAnnotations.forEach(tag => {
+          for (let anchor of this._annotations.get(tag) ?? []) {
+            if (anchor.highlights) {
+              setHighlightsFocused(anchor.highlights, false);
+            }
           }
-        }
+        });
+
+        this._focusedAnnotations = new Set(tags);
+
+        this._focusedAnnotations.forEach(tag => {
+          for (let anchor of this._annotations.get(tag) ?? []) {
+            if (anchor.highlights) {
+              setHighlightsFocused(anchor.highlights, true);
+            }
+          }
+        });
       }
     );
 
@@ -393,6 +401,7 @@ export default class Guest {
   destroy() {
     this._annotations.clear();
     this._deferredDetach.clear();
+    this._focusedAnnotations.clear();
     this._portFinder.destroy();
     this._notifyGuestUnload();
     this._hypothesisInjector.destroy();

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -203,7 +203,7 @@ describe('Guest', () => {
       }
     };
 
-    describe('on "focusAnnotations" event', () => {
+    describe('on "focusAnnotations" event', async () => {
       it('focuses any annotations with a matching tag', () => {
         const highlight0 = document.createElement('span');
         const highlight1 = document.createElement('span');
@@ -212,6 +212,8 @@ describe('Guest', () => {
           { annotation: { $tag: 'tag1' }, highlights: [highlight0] },
           { annotation: { $tag: 'tag2' }, highlights: [highlight1] },
         ];
+        guest.setAnnotations('tag1', [{ highlights: [highlight0] }]);
+        guest.setAnnotations('tag2', [{ highlights: [highlight1] }]);
 
         emitSidebarEvent('focusAnnotations', ['tag1']);
 
@@ -223,19 +225,24 @@ describe('Guest', () => {
       });
 
       it('unfocuses any annotations without a matching tag', () => {
-        const highlight0 = document.createElement('span');
-        const highlight1 = document.createElement('span');
+        const highlights0 = [document.createElement('span')];
+        const highlights1 = [document.createElement('span')];
         const guest = createGuest();
         guest.anchors = [
-          { annotation: { $tag: 'tag1' }, highlights: [highlight0] },
-          { annotation: { $tag: 'tag2' }, highlights: [highlight1] },
+          { annotation: { $tag: 'tag1' }, highlights: highlights0 },
+          { annotation: { $tag: 'tag2' }, highlights: highlights1 },
         ];
+        guest.setAnnotations('tag1', [{ highlights: highlights0 }]);
+        guest.setAnnotations('tag2', [{ highlights: highlights1 }]);
 
         emitSidebarEvent('focusAnnotations', ['tag1']);
+        highlighter.setHighlightsFocused.resetHistory();
+
+        emitSidebarEvent('focusAnnotations', ['tag2']);
 
         assert.calledWith(
           highlighter.setHighlightsFocused,
-          guest.anchors[1].highlights,
+          guest.anchors[0].highlights,
           false
         );
       });


### PR DESCRIPTION
Instead of looping through _all_ the annotations to toggle the
highlight, we target specifically the two subsets that we are interested
on:
    
* the previously focus annotations: to turn the highlight off
* the new focused annotations: to turn the highlights on.