### PR TITLE
Improved performance on `deleteAnnotation` RPC event

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -543,18 +543,20 @@ export default class Guest {
    * @param {boolean} [notify] - For internal use. Whether to emit an `anchorsChanged` notification
    */
   detach(tag, notify = true) {
-    /** @type {Anchor[]} */
-    const anchors = [];
-    for (let anchor of this.anchors) {
-      if (anchor.annotation.$tag !== tag) {
-        anchors.push(anchor);
-      } else if (anchor.highlights) {
+    for (let anchor of this._annotations.get(tag) ?? []) {
+      if (anchor.highlights) {
         removeHighlights(anchor.highlights);
       }
     }
 
     this._deferredDetach.delete(tag);
     this._annotations.delete(tag);
+
+    /** @type {Anchor[]} */
+    let anchors = [];
+    for (let anchor of this._annotations.values()) {
+      anchors = anchors.concat(anchor);
+    }
 
     this._updateAnchors(anchors, notify);
   }

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -735,4 +735,14 @@ export default class Guest {
   get focusedAnnotationTags() {
     return this._focusedAnnotations;
   }
+
+  /**
+   * Use only for testing purposes
+   *
+   * @param {string} $tag
+   * @param {Anchor[]} anchors
+   */
+  setAnnotations($tag, anchors) {
+    this._annotations.set($tag, anchors);
+  }
 }

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -313,15 +313,23 @@ export default class Guest {
       'focusAnnotations',
       /** @param {string[]} tags */
       (tags = []) => {
-        this._focusedAnnotations.clear();
-        tags.forEach(tag => this._focusedAnnotations.add(tag));
-
-        for (let anchor of this.anchors) {
-          if (anchor.highlights) {
-            const toggle = tags.includes(anchor.annotation.$tag);
-            setHighlightsFocused(anchor.highlights, toggle);
+        this._focusedAnnotations.forEach(tag => {
+          for (let anchor of this._annotations.get(tag) ?? []) {
+            if (anchor.highlights) {
+              setHighlightsFocused(anchor.highlights, false);
+            }
           }
-        }
+        });
+
+        this._focusedAnnotations = new Set(tags);
+
+        this._focusedAnnotations.forEach(tag => {
+          for (let anchor of this._annotations.get(tag) ?? []) {
+            if (anchor.highlights) {
+              setHighlightsFocused(anchor.highlights, true);
+            }
+          }
+        });
       }
     );
 
@@ -393,6 +401,7 @@ export default class Guest {
   destroy() {
     this._annotations.clear();
     this._deferredDetach.clear();
+    this._focusedAnnotations.clear();
     this._portFinder.destroy();
     this._notifyGuestUnload();
     this._hypothesisInjector.destroy();

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -420,12 +420,18 @@ describe('Guest', () => {
     });
 
     describe('on "deleteAnnotation" event', () => {
-      it('detaches annotation', () => {
+      it('defers detach annotation until it is anchored', async () => {
         const guest = createGuest();
         const callback = sinon.stub();
+        const ann = { target: [], uri: 'uri', $tag: 'tag1' };
         guest._emitter.subscribe('anchorsChanged', callback);
 
-        emitSidebarEvent('deleteAnnotation', 'tag1');
+        emitSidebarEvent('deleteAnnotation', ann.$tag);
+
+        assert.notCalled(callback);
+
+        emitSidebarEvent('loadAnnotations', [ann]);
+        await delay(0);
 
         assert.calledOnce(callback);
         assert.calledWith(callback, []);

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -203,7 +203,7 @@ describe('Guest', () => {
       }
     };
 
-    describe('on "focusAnnotations" event', () => {
+    describe('on "focusAnnotations" event', async () => {
       it('focuses any annotations with a matching tag', () => {
         const highlight0 = document.createElement('span');
         const highlight1 = document.createElement('span');
@@ -212,6 +212,8 @@ describe('Guest', () => {
           { annotation: { $tag: 'tag1' }, highlights: [highlight0] },
           { annotation: { $tag: 'tag2' }, highlights: [highlight1] },
         ];
+        guest.setAnnotations('tag1', [{ highlights: [highlight0] }]);
+        guest.setAnnotations('tag2', [{ highlights: [highlight1] }]);
 
         emitSidebarEvent('focusAnnotations', ['tag1']);
 
@@ -223,19 +225,24 @@ describe('Guest', () => {
       });
 
       it('unfocuses any annotations without a matching tag', () => {
-        const highlight0 = document.createElement('span');
-        const highlight1 = document.createElement('span');
+        const highlights0 = [document.createElement('span')];
+        const highlights1 = [document.createElement('span')];
         const guest = createGuest();
         guest.anchors = [
-          { annotation: { $tag: 'tag1' }, highlights: [highlight0] },
-          { annotation: { $tag: 'tag2' }, highlights: [highlight1] },
+          { annotation: { $tag: 'tag1' }, highlights: highlights0 },
+          { annotation: { $tag: 'tag2' }, highlights: highlights1 },
         ];
+        guest.setAnnotations('tag1', [{ highlights: highlights0 }]);
+        guest.setAnnotations('tag2', [{ highlights: highlights1 }]);
 
         emitSidebarEvent('focusAnnotations', ['tag1']);
+        highlighter.setHighlightsFocused.resetHistory();
+
+        emitSidebarEvent('focusAnnotations', ['tag2']);
 
         assert.calledWith(
           highlighter.setHighlightsFocused,
-          guest.anchors[1].highlights,
+          guest.anchors[0].highlights,
           false
         );
       });

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1020,11 +1020,12 @@ describe('Guest', () => {
     });
 
     it('destroys targets that have been removed from the annotation', () => {
-      const annotation = {};
+      const annotation = { $tag: 'tag1' };
       const target = {};
       const highlights = [];
       const guest = createGuest();
       guest.anchors = [{ annotation, target, highlights }];
+      guest.setAnnotations('tag1', guest.anchors);
       const { removeHighlights } = highlighter;
 
       return guest.anchor(annotation).then(() => {
@@ -1062,18 +1063,26 @@ describe('Guest', () => {
   });
 
   describe('#detach', () => {
+    let guest;
+
     let nextTagId = 0;
     function createAnchor() {
-      return {
-        annotation: { $tag: `t${nextTagId++}` },
+      const $tag = `t${nextTagId++}`;
+      const anchor = {
+        annotation: { $tag },
         highlights: [document.createElement('span')],
       };
+      guest.anchors.push(anchor);
+      guest.setAnnotations($tag, [anchor]);
+      return anchor;
     }
 
+    beforeEach(() => {
+      guest = createGuest();
+    });
+
     it('removes anchors associated with the removed annotation', () => {
-      const guest = createGuest();
       const anchor = createAnchor();
-      guest.anchors.push(anchor);
 
       guest.detach(anchor.annotation.$tag);
 
@@ -1081,10 +1090,8 @@ describe('Guest', () => {
     });
 
     it('removes any highlights associated with the annotation', () => {
-      const guest = createGuest();
       const anchor = createAnchor();
       const { removeHighlights } = highlighter;
-      guest.anchors.push(anchor);
 
       guest.detach(anchor.annotation.$tag);
 
@@ -1093,10 +1100,8 @@ describe('Guest', () => {
     });
 
     it('keeps anchors and highlights associated with other annotations', () => {
-      const guest = createGuest();
       const anchorA = createAnchor();
       const anchorB = createAnchor();
-      guest.anchors.push(anchorA, anchorB);
 
       guest.detach(anchorA.annotation.$tag);
 
@@ -1107,7 +1112,6 @@ describe('Guest', () => {
     });
 
     it('emits an `anchorsChanged` event with updated anchors', () => {
-      const guest = createGuest();
       const anchor = createAnchor();
       const anchorsChanged = sandbox.stub();
       guest._emitter.subscribe('anchorsChanged', anchorsChanged);


### PR DESCRIPTION
This is a minor improvement. Instead of looping through _all_ the
annotations to check if we need to remove the highlights, we access this
subset of annotations directly, remove the highlights, delete them from
the `Guest#_annotation` map and use the reminder annotations to notify
the `Sidebar` via `anchorsChanged`.
