### PR TITLE
Clean up `Guest` tests

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -729,16 +729,6 @@ export default class Guest {
   }
 
   /**
-   * Return the tags of annotations that are currently displayed in a focused
-   * state.
-   *
-   * @return {Set<string>}
-   */
-  get focusedAnnotationTags() {
-    return this._focusedAnnotations;
-  }
-
-  /**
    * Use only for testing purposes
    *
    * @param {string} $tag


### PR DESCRIPTION
Using the top-most `beforeEach`, I create a default `Guest` instance for 
each test and removed multiple repetitions of `createGuest()` function.

Created two functions `makeAnnotation` and `makeAnchor` that eliminates
a fair amount of boiler plate code in the test. `makeAnnotation` returns
an object of the shape of `AnnotationData` that can be feed to the
`Guest#anchor` method. `makeAnchor` simulates `Guest#anchor` and
allows to easily populates `Guest#anchors` field.

I moved `emitSidebarEvent` to the top.

Replaced all instances of `sinon` to `sandbox`.

Removed `Guest#focusedAnnotationTags` which was only used for testing
and it is not needed any more.

Simplified and standardized some tests.
