### PR TITLE
Proposed fix for clearing the selection on another iframe

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -314,23 +314,24 @@ export default class Guest {
 
   async _connectHostEvents() {
     this._hostRPC.on(
-      'deselectTextExcept',
-      /** @type {string} */ frameIdentifier => {
+      'clearSelectionExceptIn',
+      /** @param {string} frameIdentifier */
+      frameIdentifier => {
         if (this._frameIdentifier === frameIdentifier) {
           return;
         }
 
         this._onClearSelection({ informHostFrame: false });
-        // It would be nice to clear the shadow of the selection calling
-        // `document.getSelection()?.removeAllRanges();` however, because of the
-        // selection observer, that will trigger a call to `_onClearSelection({informHostFrame: true})`
-        // which in turn will remove the selection from the `Guest` that has the selection.
+        // TODO: clear the selection calling `document.getSelection()?.removeAllRanges();`
+        // without triggering the selection observer (that in turns calls
+        // `_onClearSelection({informHostFrame: true})` and changes `Sidebar#._guestWithSelection`).
       }
     );
 
     this._hostRPC.on(
-      'createAnnotationAt',
-      /** @type {string} */ frameIdentifier => {
+      'createAnnotationIn',
+      /** @param {string} frameIdentifier */
+      frameIdentifier => {
         if (this._frameIdentifier === frameIdentifier) {
           this.createAnnotation();
         }
@@ -655,7 +656,7 @@ export default class Guest {
     }
 
     this.selectedRanges = [range];
-    this._hostRPC.call('textSelectedAt', this._frameIdentifier);
+    this._hostRPC.call('textSelectedIn', this._frameIdentifier);
 
     this._adder.annotationsForSelection = annotationsForSelection();
     this._isAdderVisible = true;
@@ -667,7 +668,7 @@ export default class Guest {
     this._adder.hide();
     this.selectedRanges = [];
     if (informHostFrame) {
-      this._hostRPC.call('textDeselectedAt', this._frameIdentifier);
+      this._hostRPC.call('textUnselectedIn', this._frameIdentifier);
     }
   }
 

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -322,9 +322,6 @@ export default class Guest {
         }
 
         this._onClearSelection({ informHostFrame: false });
-        // TODO: clear the selection calling `document.getSelection()?.removeAllRanges();`
-        // without triggering the selection observer (that in turns calls
-        // `_onClearSelection({informHostFrame: true})` and changes `Sidebar#._guestWithSelection`).
       }
     );
 
@@ -667,8 +664,14 @@ export default class Guest {
     this._isAdderVisible = false;
     this._adder.hide();
     this.selectedRanges = [];
+
     if (informHostFrame) {
       this._hostRPC.call('textUnselectedIn', this._frameIdentifier);
+    } else {
+      // Remove all current selection without re-triggering this method again.
+      // 'selectionchange' must be canceled on the next tick in the event loop.
+      document.getSelection()?.removeAllRanges();
+      setTimeout(() => this._selectionObserver.cancelPendingCallback(), 0);
     }
   }
 

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -26,6 +26,8 @@ import { normalizeURI } from './util/url';
  * @typedef {import('../types/annotator').Destroyable} Destroyable
  * @typedef {import('../types/annotator').SidebarLayout} SidebarLayout
  * @typedef {import('../types/api').Target} Target
+ * @typedef {import('../types/bridge-events').HostToGuestEvent} HostToGuestEvent
+ * @typedef {import('../types/bridge-events').GuestToHostEvent} GuestToHostEvent
  * @typedef {import('../types/bridge-events').GuestToSidebarEvent} GuestToSidebarEvent
  * @typedef {import('../types/bridge-events').SidebarToGuestEvent} SidebarToGuestEvent
  * @typedef {import('./util/emitter').EventBus} EventBus
@@ -102,8 +104,9 @@ function resolveAnchor(anchor) {
  * loads Hypothesis (not all frames will be annotation-enabled). In one frame,
  * usually the top-level one, there will also be an instance of the `Sidebar`
  * class that shows the sidebar app and surrounding UI. The `Guest` instance in
- * each frame connects to the sidebar as part of its initialization, when
- * {@link _connectSidebarEvents} is called.
+ * each frame connects to the sidebar frame as part of its initialization, when
+ * {@link _connectSidebarEvents} is called. The `Guest` is also connected to the
+ * host frame using the {@link _connectHostEvents} method.
  *
  * The anchoring implementation defaults to a generic one for HTML documents and
  * can be overridden to handle different document types.
@@ -164,13 +167,22 @@ export default class Guest {
     this.anchors = [];
 
     // Set the frame identifier if it's available.
-    // The "top" guest instance will have this as null since it's in a top frame not a sub frame
-    /** @type {string|null} */
-    this._frameIdentifier = config.subFrameIdentifier || null;
+    // The "top" guest instance will have this as 'main' since it's in a top frame not a sub frame
+    /** @type {string} */
+    this._frameIdentifier = config.subFrameIdentifier ?? 'main';
+
     this._portFinder = new PortFinder({
       hostFrame: this._hostFrame,
       source: 'guest',
     });
+
+    /**
+     * Channel for host-guest communication.
+     *
+     * @type {Bridge<GuestToHostEvent,HostToGuestEvent>}
+     */
+    this._hostRPC = new Bridge();
+    this._connectHostEvents();
 
     /**
      * Channel for guest-sidebar communication.
@@ -298,6 +310,37 @@ export default class Guest {
     if (range) {
       this._onSelection(range);
     }
+  }
+
+  async _connectHostEvents() {
+    this._hostRPC.on(
+      'deselectTextExcept',
+      /** @type {string} */ frameIdentifier => {
+        if (this._frameIdentifier === frameIdentifier) {
+          return;
+        }
+
+        this._onClearSelection({ informHostFrame: false });
+        // It would be nice to clear the shadow of the selection calling
+        // `document.getSelection()?.removeAllRanges();` however, because of the
+        // selection observer, that will trigger a call to `_onClearSelection({informHostFrame: true})`
+        // which in turn will remove the selection from the `Guest` that has the selection.
+      }
+    );
+
+    this._hostRPC.on(
+      'createAnnotationAt',
+      /** @type {string} */ frameIdentifier => {
+        if (this._frameIdentifier === frameIdentifier) {
+          this.createAnnotation();
+        }
+      }
+    );
+
+    // Discover and connect to the host frame. All RPC events must be
+    // registered before creating the channel.
+    const hostPort = await this._portFinder.discover('host');
+    this._hostRPC.createChannel(hostPort);
   }
 
   async _connectSidebarEvents() {
@@ -612,18 +655,20 @@ export default class Guest {
     }
 
     this.selectedRanges = [range];
-    this._emitter.publish('hasSelectionChanged', true);
+    this._hostRPC.call('textSelectedAt', this._frameIdentifier);
 
     this._adder.annotationsForSelection = annotationsForSelection();
     this._isAdderVisible = true;
     this._adder.show(focusRect, isBackwards);
   }
 
-  _onClearSelection() {
+  _onClearSelection({ informHostFrame = true } = {}) {
     this._isAdderVisible = false;
     this._adder.hide();
     this.selectedRanges = [];
-    this._emitter.publish('hasSelectionChanged', false);
+    if (informHostFrame) {
+      this._hostRPC.call('textDeselectedAt', this._frameIdentifier);
+    }
   }
 
   /**

--- a/src/annotator/selection-observer.js
+++ b/src/annotator/selection-observer.js
@@ -56,7 +56,7 @@ export class SelectionObserver {
         return;
       }
 
-      this._cancelPendingCallback();
+      this.cancelPendingCallback();
 
       // Schedule a notification after a short delay. The delay serves two
       // purposes:
@@ -87,10 +87,10 @@ export class SelectionObserver {
 
   disconnect() {
     this._listeners.removeAll();
-    this._cancelPendingCallback();
+    this.cancelPendingCallback();
   }
 
-  _cancelPendingCallback() {
+  cancelPendingCallback() {
     if (this._pendingCallback) {
       clearTimeout(this._pendingCallback);
       this._pendingCallback = null;

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -628,24 +628,70 @@ describe('Guest', () => {
       assert.notCalled(FakeAdder.instance.show);
     });
 
-    it('emits `hasSelectionChanged` event with argument `true` if selection is non-empty', () => {
-      const guest = createGuest();
-      const callback = sandbox.stub();
-      guest._emitter.subscribe('hasSelectionChanged', callback);
+    it('calls "textSelectionAt" RPC method with argument "main" if selection is non-empty', () => {
+      createGuest();
 
       simulateSelectionWithText();
 
-      assert.calledWith(callback, true);
+      assert.calledWith(fakeBridge.call, 'textSelectedAt', 'main');
     });
 
-    it('emits `hasSelectionChanged` event with argument `false` if selection is empty', () => {
-      const guest = createGuest();
-      const callback = sandbox.stub();
-      guest._emitter.subscribe('hasSelectionChanged', callback);
+    it('calls "textSelectionAt" RPC method with the subFrameIdentifier as argument if selection is non-empty', () => {
+      const subFrameIdentifier = 'other frame';
+      createGuest({ subFrameIdentifier });
+
+      simulateSelectionWithText();
+
+      assert.calledWith(fakeBridge.call, 'textSelectedAt', subFrameIdentifier);
+    });
+
+    it('calls "textDeselectedAt" RPC method with argument "main" if selection is empty', () => {
+      createGuest();
 
       simulateSelectionWithoutText();
 
-      assert.calledWith(callback, false);
+      assert.calledWith(fakeBridge.call, 'textDeselectedAt', 'main');
+    });
+
+    it('calls "textDeselectedAt" RPC method with the subFrameIdentifier as argument if selection is empty', () => {
+      const subFrameIdentifier = 'other frame';
+      createGuest({ subFrameIdentifier });
+
+      simulateSelectionWithoutText();
+
+      assert.calledWith(
+        fakeBridge.call,
+        'textDeselectedAt',
+        subFrameIdentifier
+      );
+    });
+
+    it('unselects text if another iframe has made a selection', () => {
+      const guest = createGuest();
+      guest.selectedRanges = [1];
+      const handler = fakeBridge.on
+        .getCalls()
+        .find(call => call.args[0] === 'deselectTextExcept').args[1];
+
+      simulateSelectionWithText();
+      fakeBridge.call.resetHistory();
+      handler('dummy');
+
+      assert.equal(guest.selectedRanges.length, 0);
+      assert.notCalled(fakeBridge.call);
+    });
+
+    it("doesn't unselects text if frame identifiers matches", () => {
+      const guest = createGuest();
+      guest.selectedRanges = [1];
+      const handler = fakeBridge.on
+        .getCalls()
+        .find(call => call.args[0] === 'deselectTextExcept').args[1];
+
+      simulateSelectionWithText();
+      handler('main'); // doesn't unselect the text because it matches the frameIdentifier
+
+      assert.equal(guest.selectedRanges.length, 1);
     });
   });
 
@@ -759,6 +805,20 @@ describe('Guest', () => {
   });
 
   describe('#createAnnotation', () => {
+    it('creates an annotation if host calls with "createAnnotationAt" RPC method', () => {
+      const guest = createGuest();
+      sinon.stub(guest, 'createAnnotation');
+      const handler = fakeBridge.on
+        .getCalls()
+        .find(call => call.args[0] === 'createAnnotationAt').args[1];
+
+      handler('dummy');
+      assert.notCalled(guest.createAnnotation);
+
+      handler('main');
+      assert.calledOnce(guest.createAnnotation);
+    });
+
     it('adds document metadata to the annotation', async () => {
       const guest = createGuest();
 

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -633,7 +633,7 @@ describe('Guest', () => {
 
       simulateSelectionWithText();
 
-      assert.calledWith(fakeBridge.call, 'textSelectedAt', 'main');
+      assert.calledWith(fakeBridge.call, 'textSelectedIn', 'main');
     });
 
     it('calls "textSelectionAt" RPC method with the subFrameIdentifier as argument if selection is non-empty', () => {
@@ -642,18 +642,18 @@ describe('Guest', () => {
 
       simulateSelectionWithText();
 
-      assert.calledWith(fakeBridge.call, 'textSelectedAt', subFrameIdentifier);
+      assert.calledWith(fakeBridge.call, 'textSelectedIn', subFrameIdentifier);
     });
 
-    it('calls "textDeselectedAt" RPC method with argument "main" if selection is empty', () => {
+    it('calls "textUnselectedIn" RPC method with argument "main" if selection is empty', () => {
       createGuest();
 
       simulateSelectionWithoutText();
 
-      assert.calledWith(fakeBridge.call, 'textDeselectedAt', 'main');
+      assert.calledWith(fakeBridge.call, 'textUnselectedIn', 'main');
     });
 
-    it('calls "textDeselectedAt" RPC method with the subFrameIdentifier as argument if selection is empty', () => {
+    it('calls "textUnselectedIn" RPC method with the subFrameIdentifier as argument if selection is empty', () => {
       const subFrameIdentifier = 'other frame';
       createGuest({ subFrameIdentifier });
 
@@ -661,7 +661,7 @@ describe('Guest', () => {
 
       assert.calledWith(
         fakeBridge.call,
-        'textDeselectedAt',
+        'textUnselectedIn',
         subFrameIdentifier
       );
     });
@@ -671,7 +671,7 @@ describe('Guest', () => {
       guest.selectedRanges = [1];
       const handler = fakeBridge.on
         .getCalls()
-        .find(call => call.args[0] === 'deselectTextExcept').args[1];
+        .find(call => call.args[0] === 'clearSelectionExceptIn').args[1];
 
       simulateSelectionWithText();
       fakeBridge.call.resetHistory();
@@ -681,12 +681,12 @@ describe('Guest', () => {
       assert.notCalled(fakeBridge.call);
     });
 
-    it("doesn't unselects text if frame identifiers matches", () => {
+    it("doesn't deselect text if frame identifiers matches", () => {
       const guest = createGuest();
       guest.selectedRanges = [1];
       const handler = fakeBridge.on
         .getCalls()
-        .find(call => call.args[0] === 'deselectTextExcept').args[1];
+        .find(call => call.args[0] === 'clearSelectionExceptIn').args[1];
 
       simulateSelectionWithText();
       handler('main'); // doesn't unselect the text because it matches the frameIdentifier
@@ -805,12 +805,12 @@ describe('Guest', () => {
   });
 
   describe('#createAnnotation', () => {
-    it('creates an annotation if host calls with "createAnnotationAt" RPC method', () => {
+    it('creates an annotation if host calls with "createAnnotationIn" RPC method', () => {
       const guest = createGuest();
       sinon.stub(guest, 'createAnnotation');
       const handler = fakeBridge.on
         .getCalls()
-        .find(call => call.args[0] === 'createAnnotationAt').args[1];
+        .find(call => call.args[0] === 'createAnnotationIn').args[1];
 
       handler('dummy');
       assert.notCalled(guest.createAnnotation);

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -237,22 +237,22 @@ describe('Sidebar', () => {
 
       FakeToolbarController.args[0][1].createAnnotation();
 
-      assert.calledWith(fakeBridge.call, 'createAnnotationAt', 'main');
+      assert.calledWith(fakeBridge.call, 'createAnnotationIn', 'main');
     });
 
     it('creates an annotation on another frame toolbar button is clicked', () => {
       createSidebar({});
 
-      // make a text selection on another frame
+      // Make a text selection in another frame
       const handler = fakeBridge.on
         .getCalls()
-        .find(call => call.args[0] === 'textSelectedAt').args[1];
+        .find(call => call.args[0] === 'textSelectedIn').args[1];
       const frameIdentifier = 'other frame';
       handler(frameIdentifier);
 
       FakeToolbarController.args[0][1].createAnnotation();
 
-      assert.calledWith(fakeBridge.call, 'createAnnotationAt', frameIdentifier);
+      assert.calledWith(fakeBridge.call, 'createAnnotationIn', frameIdentifier);
     });
 
     it('sets create annotation button to "Annotation" when selection becomes non-empty', () => {
@@ -260,7 +260,7 @@ describe('Sidebar', () => {
 
       const handler = fakeBridge.on
         .getCalls()
-        .find(call => call.args[0] === 'textSelectedAt').args[1];
+        .find(call => call.args[0] === 'textSelectedIn').args[1];
       handler('dummy');
 
       assert.equal(sidebar.toolbar.newAnnotationType, 'annotation');
@@ -271,7 +271,7 @@ describe('Sidebar', () => {
 
       const handler = fakeBridge.on
         .getCalls()
-        .find(call => call.args[0] === 'textDeselectedAt').args[1];
+        .find(call => call.args[0] === 'textUnselectedIn').args[1];
       handler('dummy');
 
       assert.equal(sidebar.toolbar.newAnnotationType, 'note');
@@ -630,7 +630,7 @@ describe('Sidebar', () => {
   });
 
   describe('#onFrameConnected', () => {
-    it('creates a channel to communicate to the guests', () => {
+    it('creates a channel to communicate with the guests', () => {
       const sidebar = createSidebar();
       const { port1 } = new MessageChannel();
       sidebar.onFrameConnected('guest', port1);

--- a/src/types/bridge-events.d.ts
+++ b/src/types/bridge-events.d.ts
@@ -4,23 +4,18 @@
  */
 
 /**
- * Events that the host sends to the sidebar
+ * Events that the guest sends to the host
  */
-export type HostToSidebarEvent =
+export type GuestToHostEvent =
   /**
-   * The host informs the sidebar that a guest frame has been destroyed
+   * The guest informs the host that text has been deselected at a frame with that identifier.
    */
-  | 'frameDestroyed'
+  | 'textDeselectedAt'
 
   /**
-   * Highlights have been toggled on/off.
+   * The guest informs the host that text has been selected at a frame with that identifier.
    */
-  | 'setHighlightsVisible'
-
-  /**
-   * The host informs the sidebar that the sidebar has been opened.
-   */
-  | 'sidebarOpened';
+  | 'textSelectedAt';
 
 /**
  * Events that the guest sends to the sidebar
@@ -60,6 +55,39 @@ export type GuestToSidebarEvent =
    * The guest is asking the sidebar to toggle some annotations.
    */
   | 'toggleAnnotationSelection';
+
+/**
+ * Events that the host sends to the guest
+ */
+export type HostToGuestEvent =
+  /**
+   * The host request the guest at a frame with that identifier to create an annotation.
+   */
+  | 'createAnnotationAt'
+
+  /**
+   * The host informs the guests that text should be deselected if it doesn't match the current frame identifier.
+   */
+  | 'deselectTextExcept';
+
+/**
+ * Events that the host sends to the sidebar
+ */
+export type HostToSidebarEvent =
+  /**
+   * The host informs the sidebar that a guest frame has been destroyed
+   */
+  | 'frameDestroyed'
+
+  /**
+   * Highlights have been toggled on/off.
+   */
+  | 'setHighlightsVisible'
+
+  /**
+   * The host informs the sidebar that the sidebar has been opened.
+   */
+  | 'sidebarOpened';
 
 /**
  * Events that the sidebar sends to the guest(s)
@@ -166,7 +194,9 @@ export type SidebarToHostEvent =
   | 'signupRequested';
 
 export type BridgeEvent =
+  | HostToGuestEvent
   | HostToSidebarEvent
+  | GuestToHostEvent
   | GuestToSidebarEvent
   | SidebarToGuestEvent
   | SidebarToHostEvent;

--- a/src/types/bridge-events.d.ts
+++ b/src/types/bridge-events.d.ts
@@ -8,14 +8,14 @@
  */
 export type GuestToHostEvent =
   /**
-   * The guest informs the host that text has been deselected at a frame with that identifier.
+   * The guest informs the host that text has been unselected at a frame with that identifier.
    */
-  | 'textDeselectedAt'
+  | 'textUnselectedIn'
 
   /**
    * The guest informs the host that text has been selected at a frame with that identifier.
    */
-  | 'textSelectedAt';
+  | 'textSelectedIn';
 
 /**
  * Events that the guest sends to the sidebar
@@ -63,12 +63,12 @@ export type HostToGuestEvent =
   /**
    * The host request the guest at a frame with that identifier to create an annotation.
    */
-  | 'createAnnotationAt'
+  | 'createAnnotationIn'
 
   /**
-   * The host informs the guests that text should be deselected if it doesn't match the current frame identifier.
+   * The host informs the guests that text should be unselect if it doesn't match the current frame identifier.
    */
-  | 'deselectTextExcept';
+  | 'clearSelectionExceptIn';
 
 /**
  * Events that the host sends to the sidebar


### PR DESCRIPTION
The proposal consist of removing the selection without re-triggering the `SelectionObserver`. 

This is done by (1) making `SelectionObserver#_cancelPendingUpdates` a public method (this would be equivalent to `lodash.debounce#cancel`) and (2) using this method to cancel the update caused by removing the selection. 