### PR TITLE
Ignore unknown keys when checking payload / message match

### DIFF
--- a/src/shared/port-util.js
+++ b/src/shared/port-util.js
@@ -17,7 +17,7 @@
  * @param {any} data
  * @return {data is Message}
  */
-function isMessage(data) {
+export function isMessage(data) {
   if (data === null || typeof data !== 'object') {
     return false;
   }
@@ -32,7 +32,7 @@ function isMessage(data) {
 }
 
 /**
- * Compares a `postMessage` data to one `Message`
+ * Return true if the data payload from a MessageEvent matches `message`.
  *
  * @param {any} data
  * @param {Message} message
@@ -44,7 +44,7 @@ export function isMessageEqual(data, message) {
 
   try {
     return (
-      JSON.stringify(data, Object.keys(data).sort()) ===
+      JSON.stringify(data, Object.keys(message).sort()) ===
       JSON.stringify(message, Object.keys(message).sort())
     );
   } catch {

--- a/src/shared/port-util.js
+++ b/src/shared/port-util.js
@@ -42,14 +42,12 @@ export function isMessageEqual(data, message) {
     return false;
   }
 
-  try {
-    return (
-      JSON.stringify(data, Object.keys(message).sort()) ===
-      JSON.stringify(message, Object.keys(message).sort())
-    );
-  } catch {
-    return false;
-  }
+  // We assume `JSON.stringify` cannot throw because `isMessage` verifies that
+  // all the fields we serialize here are serializable values.
+  return (
+    JSON.stringify(data, Object.keys(message).sort()) ===
+    JSON.stringify(message, Object.keys(message).sort())
+  );
 }
 
 /**

--- a/src/shared/test/port-util-test.js
+++ b/src/shared/test/port-util-test.js
@@ -1,6 +1,39 @@
-import { isMessageEqual, isSourceWindow } from '../port-util';
+import { isMessage, isMessageEqual, isSourceWindow } from '../port-util';
 
 describe('port-util', () => {
+  describe('isMessage', () => {
+    [
+      {
+        frame1: 'guest',
+        frame2: 'sidebar',
+        type: 'request',
+      },
+
+      {
+        frame1: 'guest',
+        frame2: 'sidebar',
+        type: 'request',
+        extraField: 'foo',
+      },
+    ].forEach(data => {
+      it('returns true for objects with the expected fields', () => {
+        assert.isTrue(isMessage(data));
+      });
+    });
+
+    [
+      null,
+      undefined,
+      {},
+      'str',
+      { frame1: 'guest', frame2: false, type: 'request' },
+    ].forEach(data => {
+      it('returns false if data is not a valid message', () => {
+        assert.isFalse(isMessage(data));
+      });
+    });
+  });
+
   describe('isMessageEqual', () => {
     const frame1 = 'guest';
     const frame2 = 'sidebar';
@@ -55,16 +88,6 @@ describe('port-util', () => {
       },
       {
         data: {
-          extra: 'dummy', // additional
-          frame1,
-          frame2,
-          type,
-        },
-        expectedResult: false,
-        reason: 'data has one additional property',
-      },
-      {
-        data: {
           frame1: 'dummy', // different
           frame2,
           type,
@@ -74,10 +97,9 @@ describe('port-util', () => {
       },
       {
         data: {
-          frame1,
+          frame1: new Date(), // not JSON-serializable
           frame2,
           type,
-          window, // not serializable
         },
         expectedResult: false,
         reason: "data has one property that can't be serialized",

--- a/src/shared/test/port-util-test.js
+++ b/src/shared/test/port-util-test.js
@@ -95,15 +95,6 @@ describe('port-util', () => {
         expectedResult: false,
         reason: 'data has one property that is different',
       },
-      {
-        data: {
-          frame1: new Date(), // not JSON-serializable
-          frame2,
-          type,
-        },
-        expectedResult: false,
-        reason: "data has one property that can't be serialized",
-      },
     ].forEach(({ data, expectedResult, reason }) => {
       it(`returns '${expectedResult}' because the ${reason}`, () => {
         const result = isMessageEqual(data, {


### PR DESCRIPTION
_This PR contains the second and third commits extracted from https://github.com/hypothesis/client/pull/4004, since that part of the PR [was approved](https://github.com/hypothesis/client/pull/4004#issuecomment-988059095) but we wanted to revisit the first part._

When comparing a MessageEvent's data to an expected message, only
compare the known fields of the message and ignore any unknown fields.

Unknown fields don't cause problems for us in parsing the message, and
there is a risk that it might cause us to silently ignore messages in
some environments. We don't know yet if that actually happens.
