### PR TITLE
Make `Guest#selectedRanges` part of the public API

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -136,6 +136,8 @@ export default class Guest {
     this._highlightsVisible = false;
     this._isAdderVisible = false;
     this._informHostOnNextSelectionClear = true;
+    /** @type {Range[]} - Ranges of the current text selection. */
+    this.selectedRanges = [];
 
     this._adder = new Adder(this.element, {
       onAnnotate: async () => {
@@ -609,8 +611,8 @@ export default class Guest {
    * @return {Promise<AnnotationData>} - The new annotation
    */
   async createAnnotation({ highlight = false } = {}) {
-    const ranges = this.selectedRanges ?? [];
-    this.selectedRanges = null;
+    const ranges = this.selectedRanges;
+    this.selectedRanges = [];
 
     const info = await this.getDocumentInfo();
     const root = this.element;


### PR DESCRIPTION
I defined a type and initialise the value of `Guest#selectedRanges` in
the constructor.

As far as I know, this is used only in tests.

Follow up of https://github.com/hypothesis/client/pull/3904/files#r764767461