### PR TITLE
Hide the adder when click on the `New annotation` button

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -135,11 +135,9 @@ export default class Guest {
     this._adder = new Adder(this.element, {
       onAnnotate: async () => {
         await this.createAnnotation();
-        /** @type {Selection} */ (document.getSelection()).removeAllRanges();
       },
       onHighlight: async () => {
         await this.createAnnotation({ highlight: true });
-        /** @type {Selection} */ (document.getSelection()).removeAllRanges();
       },
       onShowAnnotations: anns => {
         this.selectAnnotations(anns);
@@ -619,6 +617,10 @@ export default class Guest {
 
     this._sidebarRPC.call('createAnnotation', annotation);
     this.anchor(annotation);
+
+    // Removing the text selection triggers the `SelectionObserver` callback,
+    // which causes the adder to be removed after some delay.
+    document.getSelection()?.removeAllRanges();
 
     return annotation;
   }

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -852,6 +852,18 @@ describe('Guest', () => {
       ]);
     });
 
+    it('hides the adder when creating an annotation', async () => {
+      const guest = createGuest();
+      const removeAllRanges = sandbox.stub();
+      sandbox.stub(document, 'getSelection').returns({ removeAllRanges });
+
+      await guest.createAnnotation();
+
+      assert.calledOnce(removeAllRanges);
+      notifySelectionChanged(null); // removing the text selection triggers the selection observer
+      assert.calledOnce(FakeAdder.instance.hide);
+    });
+
     it('sets `$tag` property', async () => {
       const guest = createGuest();
       const annotation = await guest.createAnnotation();


### PR DESCRIPTION
There was a difference in behaviour when creating an annotation using
the `Adder` vs. using the `New annotation` button in the sidebar:

* clicking on the adder's `Annotation` button made the adder disappears.

* clicking on the sidebar's `New Annotation` didn't hide the adder.

This PR makes the adder to disappears when `New Annotation` button is
pressed.

Before:


https://user-images.githubusercontent.com/8555781/145251239-da821363-6e43-4529-8872-75bbcf34bdef.mov


After:

https://user-images.githubusercontent.com/8555781/145250838-aba6da07-80f8-4e49-8eb3-3ce670d693ef.mov