### PR TITLE
Create an dev test scenario for a sandboxed guest frame

### DIFF
--- a/dev-server/documents/html/cross-origin-iframe.mustache
+++ b/dev-server/documents/html/cross-origin-iframe.mustache
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Cross-origin guest iframe</title>
+    <title>Cross-origin, sandboxed guest iframe</title>
     <style>
       body {
         font-family: sans-serif;
@@ -18,10 +18,13 @@
 
   </head>
   <body>
-    <h1>Cross-origin guest iframe</h1>
+    <h1>Cross-origin, sandboxed guest iframe</h1>
     <p>
       The cross-origin iframe below should behave like a normal guest iframe. It should
       be possible to select text and add annotations.
+    </p>
+    <p>
+      Currently, the effects of sandboxing the guest iframe are more notable in Safari.
     </p>
     <iframe></iframe>
     <script>
@@ -29,7 +32,9 @@
       const { port, hostname } = document.location;
       const newPort = port === '3000' ? '3002' : '3000';
       const src = `//${hostname}:${newPort}/document/doyle-embedded`;
-      document.querySelector('iframe').setAttribute('src', src);
+      const iframe = document.querySelector('iframe');
+      iframe.setAttribute('src', src);
+      iframe.setAttribute('sandbox', 'allow-scripts');
     </script>
     {{{hypothesisScript}}}
   </body>


### PR DESCRIPTION
This will allow us to test the effects of sandboxing the guest iframes.
In the past, it affected the inter-frame communication (#4012) but can
also affect other process. For example, it has revealed a possible
collision with the `createIntegration` function:

```
Sandbox access violation: Blocked a frame at "http://localhost:3002" from accessing a frame at "http://localhost:3000".  The frame requesting access is sandboxed and lacks the "allow-same-origin" flag.
```

The above error is from Safari.