### PR TITLE
Convert module paths in sourcemaps to absolute URLs

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -31,6 +31,19 @@ function bundleConfig({ name, entry }) {
       chunkFileNames: `${name}-[name].bundle.js`,
       entryFileNames: '[name].bundle.js',
       sourcemap: true,
+
+      // Rewrite source paths from "../../src/path/to/module.js" to
+      // "app:///src/path/to/module.js". Converting the paths to absolute URLs
+      // prevents Sentry from resolving them against the sourcemap URL, which
+      // in turn keeps module URLs consistent across releases. This helps issue
+      // grouping. See https://gist.github.com/robertknight/cbdee9db50601c5244d9e483930c32ca.
+      //
+      // The "app:" scheme is one of several URI schemes (others being "https:"
+      // and "webpack:") that Sentry feeds through the module URL => module path
+      // cleaning process.
+      sourcemapPathTransform: sourcePath => {
+        return sourcePath.replace(/^\.\.\/\.\.\//, 'app:///');
+      },
     },
     preserveEntrySignatures: false,
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -42,7 +42,8 @@ function bundleConfig({ name, entry }) {
       // and "webpack:") that Sentry feeds through the module URL => module path
       // cleaning process.
       sourcemapPathTransform: sourcePath => {
-        return sourcePath.replace(/^\.\.\/\.\.\//, 'app:///');
+        const url = new URL(`app:///${sourcePath}`);
+        return url.toString();
       },
     },
     preserveEntrySignatures: false,


### PR DESCRIPTION
Rewrite source paths in sourcemaps from being relative to the sourcemap URL (eg. "../../src/path/to/file.js") to absolute URLs ("app:///src/path/to/file.js"). This ensures that the resolved source URLs, which result from joining the sourcemap URL to the source path, remain consistent across releases. This in turn improves issue grouping. For example, the resolved source URL for a crash in `port-finder.js` would previously have been: https://cdn.hypothes.is/hypothesis/1.930.0/src/shared/port-finder.js. With this change the resolved URL will now be app:///src/shared/port-finder.js.

The sourcemap file contains the full code of each source file, so changing the URL here doesn't affect the ability to see source files in browser devtools or set breakpoints.

For a full explanation of how Sentry processes JavaScript crash reports and determines the fingerprint used to group issues, see https://gist.github.com/robertknight/cbdee9db50601c5244d9e483930c32ca.

Hopefully fixes https://github.com/hypothesis/client/issues/3681.

---

**Testing:**

On master if you run `gulp build-js` and look at `build/scripts/sidebar.bundle.js.map` you'll see that it contains source references like this:

```
"sources":["../../src/boot/parse-json-config.js","../../node_modules/preact/dist/preact.mjs", ...]
```

On this branch, the corresponding output looks like this:

```
"sources":["app:///src/boot/parse-json-config.js","app:///node_modules/preact/dist/preact.mjs", ...]
```