### PR TITLE
Reduce `Sidebar` dependency on `Guest`

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -342,6 +342,16 @@ export default class Guest {
       }
     );
 
+    this._hostRPC.on(
+      'sidebarLayoutChanged',
+      /** @param {SidebarLayout} sidebarLayout */
+      sidebarLayout => {
+        if (this._frameIdentifier === null) {
+          this.fitSideBySide(sidebarLayout);
+        }
+      }
+    );
+
     // Discover and connect to the host frame. All RPC events must be
     // registered before creating the channel.
     const hostPort = await this._portFinder.discover('host');

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -134,8 +134,6 @@ export default class Sidebar {
       sendErrorsTo(this.iframe.contentWindow);
     }
 
-    this.guest = guest;
-
     this._listeners = new ListenerCollection();
 
     // Set up the toolbar on the left edge of the sidebar.
@@ -430,9 +428,7 @@ export default class Sidebar {
       this.onLayoutChange(layoutState);
     }
 
-    this.guest.fitSideBySide(layoutState);
-
-    this._emitter.publish('sidebarLayoutChanged', layoutState);
+    this._guestRPC.call('sidebarLayoutChanged', layoutState);
   }
 
   /**

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -183,7 +183,7 @@ describe('Guest', () => {
         assert.calledWith(fakeIntegration.fitSideBySide, dummyLayout);
       });
 
-      it('does not calls fitSideBySide if `Guest` is not the main annotatable frame', () => {
+      it('does not call fitSideBySide if `Guest` is not the main annotatable frame', () => {
         createGuest({ subFrameIdentifier: 'dummy' });
         const dummyLayout = {};
 

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -619,14 +619,17 @@ describe('Sidebar', () => {
       sidebar.onFrameConnected('dummy', port1);
 
       assert.notCalled(sidebarBridge().createChannel);
+      assert.notCalled(guestBridge().createChannel);
     });
 
     it('create RPC channels for recognized source frames', () => {
       const sidebar = createSidebar();
       const { port1 } = new MessageChannel();
       sidebar.onFrameConnected('sidebar', port1);
+      sidebar.onFrameConnected('guest', port1);
 
       assert.calledWith(sidebarBridge().createChannel, port1);
+      assert.calledWith(guestBridge().createChannel, port1);
     });
   });
 

--- a/src/types/bridge-events.d.ts
+++ b/src/types/bridge-events.d.ts
@@ -73,7 +73,12 @@ export type HostToGuestEvent =
   /**
    * The host informs guests that text should be unselected, except in the guest with a given frame identifier
    */
-  | 'clearSelectionExceptIn';
+  | 'clearSelectionExceptIn'
+
+  /**
+   * The host informs guests that the sidebar layout has been changed.
+   */
+  | 'sidebarLayoutChanged';
 
 /**
  * Events that the host sends to the sidebar


### PR DESCRIPTION
Replace the 'sidebarLayoutChanged' event emitter for an RPC call using
the `guest-host` communication channel. This change is a step further
into be able to instantiate `Sidebar` independently from the `Guest`.
This may be desirable in scenarios that has several iframes, like Ebooks
and VitalSource.

In the second commit I make a few general improvements to the `Sidebar` and `Guest` tests.