### PR TITLE
Fix issues with stack trace column numbers in Safari and Firefox

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -11,7 +11,17 @@ import virtual from '@rollup/plugin-virtual';
 const isProd = process.env.NODE_ENV === 'production';
 const prodPlugins = [];
 if (isProd) {
-  prodPlugins.push(terser());
+  // Minify output.
+  prodPlugins.push(
+    terser({
+      format: {
+        // Strip *all* comments from minified output. This works around an
+        // issue with column numbers in stack traces in Safari.
+        // See https://bugs.webkit.org/show_bug.cgi?id=221548.
+        comments: false,
+      },
+    })
+  );
 
   // Eliminate debug-only imports.
   prodPlugins.push(

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -15,10 +15,17 @@ if (isProd) {
   prodPlugins.push(
     terser({
       format: {
-        // Strip *all* comments from minified output. This works around an
-        // issue with column numbers in stack traces in Safari.
-        // See https://bugs.webkit.org/show_bug.cgi?id=221548.
+        // Strip *all* comments from minified output. This works around an issue
+        // with column numbers in stack traces in Safari. See
+        // https://bugs.webkit.org/show_bug.cgi?id=221548 and
+        // https://github.com/hypothesis/client/issues/4045.
         comments: false,
+
+        // Limit length of lines in output. This makes the minfied output easier
+        // to examine in tools that struggle with long lines and limits the
+        // impact of an issue with stack trace column numbers in Firefox.
+        // See https://github.com/hypothesis/client/issues/4045.
+        max_line_len: 1024,
       },
     })
   );


### PR DESCRIPTION
This PR fixes two issues which caused stack traces from Firefox and Safari to be resolved to the wrong location by Sentry.

- In Safari, column numbers in the stack traces are [wrong](https://bugs.webkit.org/show_bug.cgi?id=221548) if the output contains inline comments. This is easy to fix by asking Terser to strip _all_ comments. By default it strips _most_ comments, except for those containing certain strings.
- In Firefox, column numbers in stack traces use code points, whereas many tools (including Sentry) expect UTF-16 code units. This causes a mismatch if the output contains characters that require multiple UTF-16 code units to represent. In our case these almost all came from a table of emojis in the Showdown dependency.

  This second issue is fixed simply by limiting the length of lines in the output, which limits the region of the code impacted by this issue. This fix is imperfect, but it solves our problem effectively and also makes minified bundles a lot easier to examine in various tools. There are other ways the issue could be solved (eg. replacing all affected characters in the output), but in my testing this increased bundle size much more (~2%).

Fixes https://github.com/hypothesis/client/issues/4045.

---

**Testing:**

Apply this diff and restart the dev server:

```diff
diff --git a/rollup.config.mjs b/rollup.config.mjs
index 8487e2b2e..7aa42518e 100644
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -8,7 +8,7 @@ import { string } from 'rollup-plugin-string';
 import { terser } from 'rollup-plugin-terser';
 import virtual from '@rollup/plugin-virtual';
 
-const isProd = process.env.NODE_ENV === 'production';
+const isProd = true;
 const prodPlugins = [];
 if (isProd) {
   // Minify output.
diff --git a/src/shared/port-finder.js b/src/shared/port-finder.js
index c4a20821d..8105a675c 100644
--- a/src/shared/port-finder.js
+++ b/src/shared/port-finder.js
@@ -86,6 +86,10 @@ export class PortFinder {
         );
       }, MAX_WAIT_FOR_PORT);
 
+      if (this._source === 'sidebar') {
+        console.error('Testing error handling');
+      }
+
       const listenerId = this._listeners.add(window, 'message', event => {
         const { data, ports } = /** @type {MessageEvent} */ (event);
         if (
```

Then open the client's dev server in Safari and Firefox. Expand the stack trace from the dev console and you should see the issue reported in the correct location, and consistent across both browsers:

<img width="275" alt="firefox-stack-trace" src="https://user-images.githubusercontent.com/2458/146360552-ca3d7342-3d29-4b63-9082-29aaefb9cebd.png">

<img width="339" alt="safari-stack-trace" src="https://user-images.githubusercontent.com/2458/146360648-c4c8e9b7-cdc9-4811-89ed-8df6eac6306f.png">

In contrast, if you apply the same diff against the master branch and restart the dev server, you will see stack traces reported in the wrong locations and differently in each browser:

<img width="330" alt="safari-stack-trace-master" src="https://user-images.githubusercontent.com/2458/146361047-aef974ea-f2f6-4df5-8ded-043bd54d8e3e.png">

<img width="297" alt="firefox-stack-trace-master" src="https://user-images.githubusercontent.com/2458/146360946-977f417e-1628-41df-8acd-f489ad4c1131.png">

