### PR TITLE
Move scroll and resize listeners to their own service

### DIFF
--- a/src/annotator/bucket-bar-client.js
+++ b/src/annotator/bucket-bar-client.js
@@ -1,0 +1,58 @@
+import { ListenerCollection } from '../shared/listener-collection';
+
+/**
+ * @typedef {import('../shared/bridge').Bridge<GuestToHostEvent, HostToGuestEvent>} HostBridge
+ * @typedef {import('../types/annotator').Destroyable} Destroyable
+ * @typedef {import('../types/bridge-events').HostToGuestEvent} HostToGuestEvent
+ * @typedef {import('../types/bridge-events').GuestToHostEvent} GuestToHostEvent
+ */
+
+/**
+ * Communicate to the `host` frame when:
+ * 1. The set of anchors has been changed (due to annotations being added or removed)
+ * 2. The position of anchors relative to the viewport of the guest has changed
+ *
+ * @implements Destroyable
+ */
+export class BucketBarClient {
+  /**
+   * @param {object} options
+   *   @param {Element} options.contentContainer - The scrollable container element for the
+   *     document content. All of the highlights that the bucket bar's buckets point
+   *     at should be contained within this element.
+   *   @param {HostBridge} options.hostRPC
+   */
+  constructor({ contentContainer, hostRPC }) {
+    this._hostRPC = hostRPC;
+    this._updatePending = false;
+    this._listeners = new ListenerCollection();
+
+    this._listeners.add(window, 'resize', () => this.update());
+    this._listeners.add(window, 'scroll', () => this.update());
+    this._listeners.add(contentContainer, 'scroll', () => this.update());
+  }
+
+  destroy() {
+    this._listeners.removeAll();
+  }
+
+  /**
+   * Notifies the BucketBar in the host frame when:
+   * 1. The set of anchors has been changed (due to annotations being added or removed)
+   * 2. The position of anchors relative to the viewport of the guest has changed
+   *
+   * Updates are debounced to reduce the overhead of gathering and sending anchor
+   * position data across frames.
+   */
+  update() {
+    if (this._updatePending) {
+      return;
+    }
+
+    this._updatePending = true;
+    requestAnimationFrame(() => {
+      this._hostRPC.call('anchorsChanged');
+      this._updatePending = false;
+    });
+  }
+}

--- a/src/annotator/bucket-bar-client.js
+++ b/src/annotator/bucket-bar-client.js
@@ -8,7 +8,8 @@ import { ListenerCollection } from '../shared/listener-collection';
  */
 
 /**
- * Communicate to the `host` frame when:
+ * Communicate to the host frame when:
+ *
  * 1. The set of anchors has been changed (due to annotations being added or removed)
  * 2. The position of anchors relative to the viewport of the guest has changed
  *

--- a/src/annotator/bucket-bar.js
+++ b/src/annotator/bucket-bar.js
@@ -1,16 +1,9 @@
 import { render } from 'preact';
 
-import { ListenerCollection } from '../shared/listener-collection';
-
 import Buckets from './components/Buckets';
 import { anchorBuckets } from './util/buckets';
 
 /**
- * @typedef BucketBarOptions
- * @prop {Element} [contentContainer] - The scrollable container element for the
- *   document content. All of the highlights that the bucket bar's buckets point
- *   at should be contained within this element.
- *
  * @typedef {import('../types/annotator').Destroyable} Destroyable
  */
 
@@ -24,43 +17,23 @@ export default class BucketBar {
   /**
    * @param {HTMLElement} container
    * @param {Pick<import('./guest').default, 'anchors'|'scrollToAnchor'|'selectAnnotations'>} guest
-   * @param {BucketBarOptions} [options]
    */
-  constructor(container, guest, { contentContainer = document.body } = {}) {
-    this._contentContainer = contentContainer;
-
-    this._bucketsContainer = document.createElement('div');
-    container.appendChild(this._bucketsContainer);
+  constructor(container, guest) {
+    this._bucketBar = document.createElement('bucket-bar');
+    container.appendChild(this._bucketBar);
 
     this._guest = guest;
 
-    this._listeners = new ListenerCollection();
-
-    this._listeners.add(window, 'resize', () => this.update());
-    this._listeners.add(window, 'scroll', () => this.update());
-    this._listeners.add(contentContainer, 'scroll', () => this.update());
-
     // Immediately render the buckets for the current anchors.
-    this._update();
+    this.update();
   }
 
   destroy() {
-    this._listeners.removeAll();
-    this._bucketsContainer.remove();
+    render(null, this._bucketBar);
+    this._bucketBar.remove();
   }
 
   update() {
-    if (this._updatePending) {
-      return;
-    }
-    this._updatePending = true;
-    requestAnimationFrame(() => {
-      this._update();
-      this._updatePending = false;
-    });
-  }
-
-  _update() {
     const buckets = anchorBuckets(this._guest.anchors);
     render(
       <Buckets
@@ -72,7 +45,7 @@ export default class BucketBar {
         }
         scrollToAnchor={anchor => this._guest.scrollToAnchor(anchor)}
       />,
-      this._bucketsContainer
+      this._bucketBar
     );
   }
 }

--- a/src/annotator/bucket-bar.js
+++ b/src/annotator/bucket-bar.js
@@ -19,8 +19,8 @@ export default class BucketBar {
    * @param {Pick<import('./guest').default, 'anchors'|'scrollToAnchor'|'selectAnnotations'>} guest
    */
   constructor(container, guest) {
-    this._bucketBar = document.createElement('bucket-bar');
-    container.appendChild(this._bucketBar);
+    this._bucketsContainer = document.createElement('div');
+    container.appendChild(this._bucketsContainer);
 
     this._guest = guest;
 
@@ -29,8 +29,8 @@ export default class BucketBar {
   }
 
   destroy() {
-    render(null, this._bucketBar);
-    this._bucketBar.remove();
+    render(null, this._bucketsContainer);
+    this._bucketsContainer.remove();
   }
 
   update() {
@@ -45,7 +45,7 @@ export default class BucketBar {
         }
         scrollToAnchor={anchor => this._guest.scrollToAnchor(anchor)}
       />,
-      this._bucketBar
+      this._bucketsContainer
     );
   }
 }

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -114,9 +114,7 @@ export default class Sidebar {
       if (config.theme === 'clean') {
         this.iframeContainer.classList.add('annotator-frame--theme-clean');
       } else {
-        this.bucketBar = new BucketBar(this.iframeContainer, guest, {
-          contentContainer: guest.contentContainer(),
-        });
+        this.bucketBar = new BucketBar(this.iframeContainer, guest);
       }
 
       this.iframeContainer.appendChild(this.iframe);

--- a/src/annotator/test/bucket-bar-client-test.js
+++ b/src/annotator/test/bucket-bar-client-test.js
@@ -1,0 +1,100 @@
+import { delay } from '../../test-util/wait';
+import { BucketBarClient } from '../bucket-bar-client';
+
+describe('BucketBarClient', () => {
+  const sandbox = sinon.createSandbox();
+  let bucketBarClients;
+  let contentContainer;
+  let fakeBridge;
+
+  beforeEach(() => {
+    sandbox
+      .stub(window, 'requestAnimationFrame')
+      .callsFake(cb => setTimeout(cb, 0));
+    bucketBarClients = [];
+    contentContainer = document.createElement('div');
+    fakeBridge = { call: sinon.stub() };
+  });
+
+  afterEach(() => {
+    bucketBarClients.forEach(bucketBarClient => bucketBarClient.destroy());
+    contentContainer.remove();
+    sandbox.restore();
+  });
+
+  const createBucketBarClient = () => {
+    const bucketBarClient = new BucketBarClient({
+      contentContainer,
+      hostRPC: fakeBridge,
+    });
+    bucketBarClients.push(bucketBarClient);
+    return bucketBarClient;
+  };
+
+  it('should update buckets when the window is resized', async () => {
+    createBucketBarClient();
+
+    window.dispatchEvent(new Event('resize'));
+    await delay(0);
+
+    assert.calledOnce(fakeBridge.call);
+    assert.calledWith(fakeBridge.call, 'anchorsChanged');
+  });
+
+  it('should update buckets when the window is scrolled', async () => {
+    createBucketBarClient();
+
+    window.dispatchEvent(new Event('scroll'));
+    await delay(0);
+
+    assert.calledOnce(fakeBridge.call);
+    assert.calledWith(fakeBridge.call, 'anchorsChanged');
+  });
+
+  it('should update buckets when the contentContainer element scrolls', async () => {
+    createBucketBarClient();
+
+    contentContainer.dispatchEvent(new Event('scroll'));
+    await delay(0);
+
+    assert.calledOnce(fakeBridge.call);
+    assert.calledWith(fakeBridge.call, 'anchorsChanged');
+  });
+
+  describe('#destroy', () => {
+    it('stops listening for events', async () => {
+      const bucketBarClient = createBucketBarClient();
+
+      bucketBarClient.destroy();
+      contentContainer.dispatchEvent(new Event('scroll'));
+      window.dispatchEvent(new Event('resize'));
+      window.dispatchEvent(new Event('scroll'));
+      await delay(0);
+
+      assert.notCalled(fakeBridge.call);
+    });
+  });
+
+  describe('#update', () => {
+    it('updates if no other update is pending', async () => {
+      const bucketBarClient = createBucketBarClient();
+
+      bucketBarClient.update();
+      await delay(0);
+
+      assert.calledOnce(fakeBridge.call);
+      assert.calledWith(fakeBridge.call, 'anchorsChanged');
+    });
+
+    it('does not update if another update is pending', async () => {
+      const bucketBarClient = createBucketBarClient();
+
+      bucketBarClient.update();
+      bucketBarClient.update();
+      await delay(0);
+
+      assert.calledOnce(fakeBridge.call);
+      assert.calledWith(fakeBridge.call, 'anchorsChanged');
+    });
+  });
+});

--- a/src/annotator/test/bucket-bar-test.js
+++ b/src/annotator/test/bucket-bar-test.js
@@ -48,7 +48,7 @@ describe('BucketBar', () => {
   it('should render buckets for existing anchors when constructed', () => {
     const bucketBar = createBucketBar();
     assert.calledWith(fakeBucketUtil.anchorBuckets, fakeGuest.anchors);
-    assert.ok(bucketBar._bucketBar.querySelector('.FakeBuckets'));
+    assert.ok(bucketBar._bucketsContainer.querySelector('.FakeBuckets'));
   });
 
   it('should select annotations when Buckets component invokes callback', () => {
@@ -82,7 +82,7 @@ describe('BucketBar', () => {
   });
 
   describe('#destroy', () => {
-    it('removes the bucket-bar element', () => {
+    it('removes the BucketBar container element', () => {
       const bucketBar = createBucketBar();
 
       bucketBar.destroy();

--- a/src/annotator/test/bucket-bar-test.js
+++ b/src/annotator/test/bucket-bar-test.js
@@ -1,32 +1,25 @@
-import BucketBar from '../bucket-bar';
-import { $imports } from '../bucket-bar';
+import BucketBar, { $imports } from '../bucket-bar';
 
 describe('BucketBar', () => {
-  const sandbox = sinon.createSandbox();
-  let fakeGuest;
-  let fakeBucketUtil;
   let bucketBars;
   let bucketProps;
   let container;
-
-  const createBucketBar = function (options) {
-    const bucketBar = new BucketBar(container, fakeGuest, options);
-    bucketBars.push(bucketBar);
-    return bucketBar;
-  };
+  let fakeBucketUtil;
+  let fakeGuest;
 
   beforeEach(() => {
-    container = document.createElement('div');
     bucketBars = [];
     bucketProps = {};
+    container = document.createElement('div');
+
+    fakeBucketUtil = {
+      anchorBuckets: sinon.stub().returns({}),
+    };
+
     fakeGuest = {
       anchors: [],
       scrollToAnchor: sinon.stub(),
       selectAnnotations: sinon.stub(),
-    };
-
-    fakeBucketUtil = {
-      anchorBuckets: sinon.stub().returns({}),
     };
 
     const FakeBuckets = props => {
@@ -38,119 +31,63 @@ describe('BucketBar', () => {
       './components/Buckets': FakeBuckets,
       './util/buckets': fakeBucketUtil,
     });
-
-    sandbox.stub(window, 'requestAnimationFrame').yields();
   });
 
   afterEach(() => {
     bucketBars.forEach(bucketBar => bucketBar.destroy());
     $imports.$restore();
-    sandbox.restore();
     container.remove();
   });
+
+  const createBucketBar = () => {
+    const bucketBar = new BucketBar(container, fakeGuest);
+    bucketBars.push(bucketBar);
+    return bucketBar;
+  };
 
   it('should render buckets for existing anchors when constructed', () => {
     const bucketBar = createBucketBar();
     assert.calledWith(fakeBucketUtil.anchorBuckets, fakeGuest.anchors);
-    assert.ok(bucketBar._bucketsContainer.querySelector('.FakeBuckets'));
+    assert.ok(bucketBar._bucketBar.querySelector('.FakeBuckets'));
   });
 
-  describe('updating buckets', () => {
-    it('should update buckets when the window is resized', () => {
-      createBucketBar();
+  it('should select annotations when Buckets component invokes callback', () => {
+    createBucketBar();
+    const fakeAnnotations = ['hi', 'there'];
+
+    bucketProps.onSelectAnnotations(fakeAnnotations, true);
+
+    assert.calledWith(fakeGuest.selectAnnotations, fakeAnnotations, true);
+  });
+
+  it('should scroll to anchor when Buckets component invokes callback', () => {
+    createBucketBar();
+    const anchor = {};
+
+    bucketProps.scrollToAnchor(anchor);
+
+    assert.calledWith(fakeGuest.scrollToAnchor, anchor);
+  });
+
+  describe('#update', () => {
+    it('updates the buckets', () => {
+      const bucketBar = createBucketBar();
       fakeBucketUtil.anchorBuckets.resetHistory();
 
-      window.dispatchEvent(new Event('resize'));
-
-      assert.calledOnce(fakeBucketUtil.anchorBuckets);
-    });
-
-    it('should update buckets when the window is scrolled', () => {
-      createBucketBar();
-      fakeBucketUtil.anchorBuckets.resetHistory();
-
-      window.dispatchEvent(new Event('scroll'));
-
-      assert.calledOnce(fakeBucketUtil.anchorBuckets);
-    });
-
-    it('should select annotations when Buckets component invokes callback', () => {
-      const bucketBar = createBucketBar();
-      bucketBar._update();
-
-      const fakeAnnotations = ['hi', 'there'];
-      bucketProps.onSelectAnnotations(fakeAnnotations, true);
-      assert.calledWith(fakeGuest.selectAnnotations, fakeAnnotations, true);
-    });
-
-    it('should scroll to anchor when Buckets component invokes callback', () => {
-      const bucketBar = createBucketBar();
-      bucketBar._update();
-
-      const anchor = {};
-      bucketProps.scrollToAnchor(anchor);
-
-      assert.calledWith(fakeGuest.scrollToAnchor, anchor);
-    });
-
-    context('when `contentContainer` is specified', () => {
-      let contentContainer;
-
-      beforeEach(() => {
-        contentContainer = document.createElement('div');
-        document.body.appendChild(contentContainer);
-      });
-
-      afterEach(() => {
-        contentContainer.remove();
-      });
-
-      it('should update buckets when any scrollable scrolls', () => {
-        createBucketBar({ contentContainer });
-        fakeBucketUtil.anchorBuckets.resetHistory();
-
-        contentContainer.dispatchEvent(new Event('scroll'));
-
-        assert.calledOnce(fakeBucketUtil.anchorBuckets);
-      });
-    });
-
-    context('when no `contentContainer` is specified', () => {
-      it('should update buckets when body is scrolled', () => {
-        createBucketBar({ contentContainer: undefined });
-        fakeBucketUtil.anchorBuckets.resetHistory();
-
-        document.body.dispatchEvent(new Event('scroll'));
-
-        assert.calledOnce(fakeBucketUtil.anchorBuckets);
-      });
-    });
-
-    it('should not update if another update is pending', () => {
-      const bucketBar = createBucketBar();
-      bucketBar._updatePending = true;
       bucketBar.update();
-      assert.notCalled(window.requestAnimationFrame);
-    });
 
-    it('deletes the bucketbar element after destroy method is called', () => {
+      assert.calledOnce(fakeBucketUtil.anchorBuckets);
+      assert.calledWith(fakeBucketUtil.anchorBuckets, fakeGuest.anchors);
+    });
+  });
+
+  describe('#destroy', () => {
+    it('removes the bucket-bar element', () => {
       const bucketBar = createBucketBar();
+
       bucketBar.destroy();
+
       assert.isFalse(container.hasChildNodes());
     });
-  });
-
-  it('should stop listening for scroll events when destroyed', () => {
-    const container = document.createElement('div');
-    const bucketBar = createBucketBar({ contentContainer: container });
-    fakeBucketUtil.anchorBuckets.resetHistory();
-
-    bucketBar.destroy();
-
-    container.dispatchEvent(new Event('scroll'));
-    window.dispatchEvent(new Event('resize'));
-    window.dispatchEvent(new Event('scroll'));
-
-    assert.notCalled(fakeBucketUtil.anchorBuckets);
   });
 });

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1296,7 +1296,7 @@ describe('Guest', () => {
     });
   });
 
-  it('does not configure the BucketBarClient if guest is the main annotatable frame', () => {
+  it('does not configure the BucketBarClient if guest is not the main annotatable frame', () => {
     createGuest({ subFrameIdentifier: 'frame-id' });
 
     assert.notCalled(FakeBucketBarClient);

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -128,12 +128,7 @@ describe('Sidebar', () => {
     };
     FakeBucketBar = sinon.stub().returns(fakeBucketBar);
 
-    class FakeGuest {
-      constructor() {
-        this.contentContainer = sinon.stub().returns(document.body);
-      }
-    }
-    fakeGuest = new FakeGuest();
+    fakeGuest = sinon.stub();
 
     fakeToolbar = {
       getWidth: sinon.stub().returns(100),
@@ -939,20 +934,6 @@ describe('Sidebar', () => {
         externalContainerSelector: `.${EXTERNAL_CONTAINER_SELECTOR}`,
       });
       assert.isNull(sidebar.bucketBar);
-    });
-
-    it('configures bucket bar to observe `contentContainer` scrolling if specified', () => {
-      const contentContainer = document.createElement('div');
-      fakeGuest.contentContainer.returns(contentContainer);
-
-      const sidebar = createSidebar();
-
-      assert.calledWith(
-        FakeBucketBar,
-        sidebar.iframeContainer,
-        fakeGuest,
-        sinon.match({ contentContainer })
-      );
     });
   });
 });


### PR DESCRIPTION
This is a step towards making the bucket bar works for a `guest` frame
that is not in the `host` frame. When that's the case the observation of
scrolling and resize can't happen in the `host` frame.

A new service has been created, `BucketClient`. The service is
instantiated only in the `guest` frame that contains the main
annotatable content. The service observes changes in the elements that
could impact the relative position of the anchors relative to the
viewport. If these changes are detected, as well as addition or deletion
of anchors, it sends the `anchorsChanged` RPC event to the `host` frame
so that the positions can be recalculated. As a result of the new
service the `BucketBar` has been simplified.