### PR TITLE
Reduce boot script cache expiry time

### DIFF
--- a/scripts/deploy-to-s3.js
+++ b/scripts/deploy-to-s3.js
@@ -132,7 +132,7 @@ async function uploadPackageToS3(bucket, options) {
     // nb. When deploying to cdn.hypothes.is, the max-age seen by the browser is
     // the higher of the value here and CloudFlare's "Browser Cache TTL"
     // setting.
-    aliasCacheControl = 'public, max-age=1800, must-revalidate';
+    aliasCacheControl = 'public, s-maxage=300, max-age=60, must-revalidate';
   } else {
     aliasCacheControl = 'no-cache';
   }


### PR DESCRIPTION
Reduce the potential for mismatches between the client versions loaded in the annotator and sidebar when rolling out a new release by shortening the cache expiry time on the boot script.

Set a very short expiry time on the browser cache TTL and a slightly longer time on the edge cache.