### PR TITLE
Remove unused 'sidebarOpened' event emitter

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -499,7 +499,6 @@ export default class Sidebar {
 
   open() {
     this._sidebarRPC.call('sidebarOpened');
-    this._emitter.publish('sidebarOpened');
 
     if (this.iframeContainer) {
       const width = this.iframeContainer.getBoundingClientRect().width;

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -783,15 +783,14 @@ describe('Sidebar', () => {
           'sidebarLayoutChanged',
           sinon.match.any
         );
-        assert.calledWith(sidebar._emitter.publish, 'sidebarOpened');
-        assert.calledTwice(sidebar._emitter.publish);
+        assert.calledOnce(sidebar._emitter.publish);
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
           expanded: true,
         });
 
         sidebar.close();
         assert.calledTwice(layoutChangeHandlerSpy);
-        assert.calledThrice(sidebar._emitter.publish);
+        assert.calledTwice(sidebar._emitter.publish);
         assertLayoutValues(layoutChangeHandlerSpy.lastCall.args[0], {
           expanded: false,
           width: fakeToolbar.getWidth(),


### PR DESCRIPTION
There is both a 'sidebarOpened' event emitter and RPC event by the same name. The RPC
event is used, while the event emitter is not.