### PR TITLE
Increase timeout for port discovery

### DIFF
--- a/src/shared/port-finder.js
+++ b/src/shared/port-finder.js
@@ -1,8 +1,11 @@
 import { ListenerCollection } from './listener-collection';
 import { isMessageEqual } from './port-util';
 
-const MAX_WAIT_FOR_PORT = 1000 * 10;
-const POLLING_INTERVAL_FOR_PORT = 250;
+/** Timeout for waiting for the host frame to respond to a port request. */
+export const MAX_WAIT_FOR_PORT = 1000 * 20;
+
+/** Polling interval for requests to the host frame for a port. */
+export const POLLING_INTERVAL_FOR_PORT = 250;
 
 /**
  * @typedef {import('../types/annotator').Destroyable} Destroyable

--- a/src/shared/test/port-finder-test.js
+++ b/src/shared/test/port-finder-test.js
@@ -1,7 +1,9 @@
 import { delay } from '../../test-util/wait';
-import { PortFinder } from '../port-finder';
-
-const MAX_WAIT_FOR_PORT = 1000 * 10;
+import {
+  MAX_WAIT_FOR_PORT,
+  POLLING_INTERVAL_FOR_PORT,
+  PortFinder,
+} from '../port-finder';
 
 describe('PortFinder', () => {
   const frame1 = 'guest';
@@ -122,7 +124,10 @@ describe('PortFinder', () => {
         clock.restore();
       }
 
-      assert.callCount(window.postMessage, 41);
+      const expectedCalls =
+        Math.floor(MAX_WAIT_FOR_PORT / POLLING_INTERVAL_FOR_PORT) + 1;
+
+      assert.callCount(window.postMessage, expectedCalls);
       assert.alwaysCalledWithExactly(
         window.postMessage,
         { frame1, frame2: target, type: 'request' },


### PR DESCRIPTION
On a slow device if the host page is heavily loaded with JavaScript, the 10-second timeout can be exceeded. Increase this threshold to 20s to see what effect that has on the volume of reports we receive.

Part of https://github.com/hypothesis/client/issues/3986.