### PR TITLE
Move RPC listener together with the rest of listeners

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -114,11 +114,9 @@ export default class Sidebar {
       if (config.theme === 'clean') {
         this.iframeContainer.classList.add('annotator-frame--theme-clean');
       } else {
-        const bucketBar = new BucketBar(this.iframeContainer, guest, {
+        this.bucketBar = new BucketBar(this.iframeContainer, guest, {
           contentContainer: guest.contentContainer(),
         });
-        this._guestRPC.on('anchorsChanged', () => bucketBar.update());
-        this.bucketBar = bucketBar;
       }
 
       this.iframeContainer.appendChild(this.iframe);
@@ -283,6 +281,12 @@ export default class Sidebar {
         this._guestRPC.call('clearSelectionExceptIn', frameIdentifier);
       }
     );
+
+    // The listener will do nothing if the sidebar doesn't have a bucket bar
+    // (clean theme), but it is still actively listening.
+    this._guestRPC.on('anchorsChanged', () => {
+      this.bucketBar?.update();
+    });
   }
 
   _setupSidebarEvents() {


### PR DESCRIPTION
I moved a guest RPC listener with the rest of the listeners in the
`Sidebar#_setupGuestEvents` method. This helps to quickly see which
events from the `Guest` the `Sidebar` listens to.