### PR TITLE
Fix call to `store.focusGroup` in group-filtering test

### DIFF
--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -108,11 +108,11 @@ describe('sidebar/store/modules/groups', () => {
 
     it('resets focused group if it is not contained in filtered groups', () => {
       store.loadGroups([publicGroup, privateGroup]);
-      store.focusGroup(publicGroup);
-      assert.equal(store.focusedGroupId(), publicGroup.id);
-
-      store.filterGroups([privateGroup.id]);
+      store.focusGroup(privateGroup.id);
       assert.equal(store.focusedGroupId(), privateGroup.id);
+
+      store.filterGroups([publicGroup.id]);
+      assert.equal(store.focusedGroupId(), publicGroup.id);
     });
   });
 


### PR DESCRIPTION
The test was erroneously passing a Group object instead of a Group.id
and was causing warnings to be logged to the test output:

```
17 12 2021 12:31:55.467:INFO [karma-server]: Karma v6.3.9 server started at http://localhost:9876/
17 12 2021 12:31:55.468:INFO [launcher]: Launching browsers ChromeHeadless_Custom with concurrency unlimited
17 12 2021 12:31:55.474:INFO [launcher]: Starting browser ChromeHeadless
17 12 2021 12:31:56.433:INFO [Chrome Headless 97.0.4691.0 (Mac OS 10.15.7)]: Connected on socket DnLfZv7X0AN3z9fHAAAB with id 80776960
Chrome Headless 97.0.4691.0 (Mac OS 10.15.7): Executed 729 of 2995 SUCCESS (0 secs / 1.693 secs)
Chrome Headless 97.0.4691.0 (Mac OS 10.15.7): Executed 1171 of 2995 SUCCESS (0 secs / 2.676 secs)
ERROR: 'Attempted to focus group [object Object] which is not loaded'
Chrome Headless 97.0.4691.0 (Mac OS 10.15.7): Executed 2570 of 2995 SUCCESS (0 secs / 5.027 secs)
ERROR: 'Attempted to focus group [object Object] which is not loaded'
Chrome Headless 97.0.4691.0 (Mac OS 10.15.7): Executed 2995 of 2995 SUCCESS (11.116 secs / 5.274 secs)
TOTAL: 2995 SUCCESS
```

The first test asserting the `focusedGroupId()` was passing because the group it tests for would have been focused by default anyway (the first group in the list of groups loaded). I've swapped it to focus on the second group in the list to assure that the test is doing what it's expected to, intentionally.