### PR TITLE
Remove anchors from the `BucketSet` data structure

### DIFF
--- a/src/annotator/components/Buckets.js
+++ b/src/annotator/components/Buckets.js
@@ -14,17 +14,15 @@ import classnames from 'classnames';
  *   @param {(tags: string[], toggle: boolean) => void} props.onSelectAnnotations
  */
 function BucketButton({ bucket, onFocusAnnotations, onSelectAnnotations }) {
-  const buttonTitle = `Select nearby annotations (${bucket.anchors.length})`;
+  const buttonTitle = `Select nearby annotations (${bucket.tags.size})`;
 
   function selectAnnotations(event) {
-    const tags = bucket.anchors.map(anchor => anchor.annotation.$tag);
-    onSelectAnnotations(tags, event.metaKey || event.ctrlKey);
+    onSelectAnnotations([...bucket.tags], event.metaKey || event.ctrlKey);
   }
 
   function setFocus(hasFocus) {
     if (hasFocus) {
-      const tags = bucket.anchors.map(anchor => anchor.annotation.$tag);
-      onFocusAnnotations(tags);
+      onFocusAnnotations([...bucket.tags]);
     } else {
       onFocusAnnotations([]);
     }
@@ -40,7 +38,7 @@ function BucketButton({ bucket, onFocusAnnotations, onSelectAnnotations }) {
       title={buttonTitle}
       aria-label={buttonTitle}
     >
-      {bucket.anchors.length}
+      {bucket.tags.size}
     </button>
   );
 }
@@ -59,21 +57,18 @@ function NavigationBucketButton({
   direction,
   onScrollToClosestOffScreenAnchor,
 }) {
-  const buttonTitle = `Go ${direction} to next annotations (${bucket.anchors.length})`;
-
-  function scrollToClosest() {
-    const tags = bucket.anchors.map(anchor => anchor.annotation.$tag);
-    onScrollToClosestOffScreenAnchor(tags, direction);
-  }
+  const buttonTitle = `Go ${direction} to next annotations (${bucket.tags.size})`;
 
   return (
     <button
       className={classnames('Buckets__button', `Buckets__button--${direction}`)}
-      onClick={scrollToClosest}
+      onClick={() =>
+        onScrollToClosestOffScreenAnchor([...bucket.tags], direction)
+      }
       title={buttonTitle}
       aria-label={buttonTitle}
     >
-      {bucket.anchors.length}
+      {bucket.tags.size}
     </button>
   );
 }
@@ -98,8 +93,8 @@ export default function Buckets({
   onScrollToClosestOffScreenAnchor,
   onSelectAnnotations,
 }) {
-  const showUpNavigation = above.anchors.length > 0;
-  const showDownNavigation = below.anchors.length > 0;
+  const showUpNavigation = above.tags.size > 0;
+  const showDownNavigation = below.tags.size > 0;
 
   return (
     <ul className="Buckets__list">

--- a/src/annotator/components/test/Buckets-test.js
+++ b/src/annotator/components/test/Buckets-test.js
@@ -13,28 +13,19 @@ describe('Buckets', () => {
 
   beforeEach(() => {
     fakeAbove = {
-      anchors: [
-        { annotation: { $tag: 'a1' }, highlights: ['hi'] },
-        { annotation: { $tag: 'a2' }, highlights: ['there'] },
-      ],
+      tags: new Set(['a1', 'a2']),
       position: 150,
     };
     fakeBelow = {
-      anchors: [
-        { annotation: { $tag: 'b1' }, highlights: ['ho'] },
-        { annotation: { $tag: 'b2' }, highlights: ['there'] },
-      ],
+      tags: new Set(['b1', 'b2']),
       position: 550,
     };
     fakeBuckets = [
       {
-        anchors: [
-          { annotation: { $tag: 't1' }, highlights: ['hi'] },
-          { annotation: { $tag: 't2' }, highlights: ['yay'] },
-        ],
+        tags: new Set(['t1', 't2']),
         position: 250,
       },
-      { anchors: ['you', 'also', 'are', 'welcome'], position: 350 },
+      { tags: new Set(['t3', 't4', 't5', 't6']), position: 350 },
     ];
     fakeOnFocusAnnotations = sinon.stub();
     fakeOnScrollToClosestOffScreenAnchor = sinon.stub();
@@ -68,7 +59,7 @@ describe('Buckets', () => {
     });
 
     it('does not render an up navigation button if there are no above-screen anchors', () => {
-      fakeAbove = { anchors: [], position: 150 };
+      fakeAbove = { tags: new Set(), position: 150 };
       const wrapper = createComponent();
       assert.isFalse(wrapper.find('.Buckets__button--up').exists());
     });
@@ -88,7 +79,7 @@ describe('Buckets', () => {
     });
 
     it('does not render a down navigation button if there are no below-screen anchors', () => {
-      fakeBelow = { anchors: [], position: 550 };
+      fakeBelow = { tags: new Set(), position: 550 };
       const wrapper = createComponent();
       assert.isFalse(wrapper.find('.Buckets__button--down').exists());
     });
@@ -164,10 +155,7 @@ describe('Buckets', () => {
 
       assert.calledOnce(fakeOnSelectAnnotations);
       const call = fakeOnSelectAnnotations.getCall(0);
-      assert.deepEqual(call.args[0], [
-        fakeBuckets[0].anchors[0].annotation.$tag,
-        fakeBuckets[0].anchors[1].annotation.$tag,
-      ]);
+      assert.deepEqual(call.args[0], [...fakeBuckets[0].tags]);
       assert.equal(call.args[1], false);
     });
 

--- a/src/annotator/components/test/Buckets-test.js
+++ b/src/annotator/components/test/Buckets-test.js
@@ -118,7 +118,7 @@ describe('Buckets', () => {
       assert.equal(wrapper.find('.Buckets__button--left').length, 2);
     });
 
-    it('focuses associated anchors when mouse enters the element', () => {
+    it('focuses on associated annotations when mouse enters the element', () => {
       const wrapper = createComponent();
 
       wrapper.find('.Buckets__button--left').first().simulate('mousemove');
@@ -127,7 +127,7 @@ describe('Buckets', () => {
       assert.calledWith(fakeOnFocusAnnotations, ['t1', 't2']);
     });
 
-    it('removes focus on associated anchors when element is blurred', () => {
+    it('removes focus on associated annotations when element is blurred', () => {
       const wrapper = createComponent();
 
       wrapper.find('.Buckets__button--left').first().simulate('blur');
@@ -136,7 +136,7 @@ describe('Buckets', () => {
       assert.calledWith(fakeOnFocusAnnotations, []);
     });
 
-    it('removes focus on associated anchors when mouse leaves the element', () => {
+    it('removes focus on associated annotations when mouse leaves the element', () => {
       const wrapper = createComponent();
 
       wrapper.find('.Buckets__button--left').first().simulate('mouseout');

--- a/src/annotator/util/buckets.js
+++ b/src/annotator/util/buckets.js
@@ -14,7 +14,7 @@ import { getBoundingClientRect } from '../highlighter';
 /**
  * @typedef BucketSet
  * @prop {Bucket} above - A single bucket containing all the annotation
- *   tags which anchors are offscreen upwards
+ *   tags whose anchors are offscreen upwards
  * @prop {Bucket} below - A single bucket containing all the annotation
  *   tags which anchors are offscreen downwards
  * @prop {Bucket[]} buckets - On-screen buckets

--- a/src/annotator/util/test/buckets-test.js
+++ b/src/annotator/util/test/buckets-test.js
@@ -63,7 +63,7 @@ describe('annotator/util/buckets', () => {
   });
 
   /** @param {number} index */
-  const getTag = index => {
+  const tagForAnchor = index => {
     return fakeAnchors[index].annotation.$tag;
   };
 
@@ -125,32 +125,44 @@ describe('annotator/util/buckets', () => {
   describe('anchorBuckets', () => {
     it('puts anchors that are above the screen into the `above` bucket', () => {
       const bucketSet = anchorBuckets(fakeAnchors);
-      assert.deepEqual([...bucketSet.above.tags], [getTag(0), getTag(1)]);
+      assert.deepEqual(
+        [...bucketSet.above.tags],
+        [tagForAnchor(0), tagForAnchor(1)]
+      );
     });
 
     it('puts anchors that are below the screen into the `below` bucket', () => {
       const bucketSet = anchorBuckets(fakeAnchors);
-      assert.deepEqual([...bucketSet.below.tags], [getTag(4), getTag(5)]);
+      assert.deepEqual(
+        [...bucketSet.below.tags],
+        [tagForAnchor(4), tagForAnchor(5)]
+      );
     });
 
     it('puts on-screen anchors into a buckets', () => {
       const bucketSet = anchorBuckets(fakeAnchors);
-      assert.deepEqual([...bucketSet.buckets[0].tags], [getTag(2), getTag(3)]);
+      assert.deepEqual(
+        [...bucketSet.buckets[0].tags],
+        [tagForAnchor(2), tagForAnchor(3)]
+      );
     });
 
     it('puts anchors into separate buckets if more than 60px separates their boxes', () => {
       fakeAnchors[2].highlights = [201, 15]; // bottom 216
       fakeAnchors[3].highlights = [301, 15]; // top 301 - more than 60px from 216
       const bucketSet = anchorBuckets(fakeAnchors);
-      assert.deepEqual([...bucketSet.buckets[0].tags], [getTag(2)]);
-      assert.deepEqual([...bucketSet.buckets[1].tags], [getTag(3)]);
+      assert.deepEqual([...bucketSet.buckets[0].tags], [tagForAnchor(2)]);
+      assert.deepEqual([...bucketSet.buckets[1].tags], [tagForAnchor(3)]);
     });
 
     it('puts overlapping anchors into a shared bucket', () => {
       fakeAnchors[2].highlights = [201, 200]; // Bottom 401
       fakeAnchors[3].highlights = [285, 100]; // Bottom 385
       const bucketSet = anchorBuckets(fakeAnchors);
-      assert.deepEqual([...bucketSet.buckets[0].tags], [getTag(2), getTag(3)]);
+      assert.deepEqual(
+        [...bucketSet.buckets[0].tags],
+        [tagForAnchor(2), tagForAnchor(3)]
+      );
     });
 
     it('positions the bucket at vertical midpoint of the box containing all bucket anchors', () => {
@@ -185,9 +197,18 @@ describe('annotator/util/buckets', () => {
         fakeAnchors[0],
         fakeAnchors[1],
       ]);
-      assert.deepEqual([...bucketSet.above.tags], [getTag(0), getTag(1)]);
-      assert.deepEqual([...bucketSet.buckets[0].tags], [getTag(2), getTag(3)]);
-      assert.deepEqual([...bucketSet.below.tags], [getTag(4), getTag(5)]);
+      assert.deepEqual(
+        [...bucketSet.above.tags],
+        [tagForAnchor(0), tagForAnchor(1)]
+      );
+      assert.deepEqual(
+        [...bucketSet.buckets[0].tags],
+        [tagForAnchor(2), tagForAnchor(3)]
+      );
+      assert.deepEqual(
+        [...bucketSet.below.tags],
+        [tagForAnchor(4), tagForAnchor(5)]
+      );
     });
 
     it('returns only above- and below-screen anchors if none are on-screen', () => {
@@ -199,11 +220,14 @@ describe('annotator/util/buckets', () => {
       const bucketSet = anchorBuckets(fakeAnchors);
       assert.equal(bucketSet.buckets.length, 0);
       // Above-screen
-      assert.deepEqual([...bucketSet.above.tags], [getTag(0), getTag(1)]);
+      assert.deepEqual(
+        [...bucketSet.above.tags],
+        [tagForAnchor(0), tagForAnchor(1)]
+      );
       // Below-screen
       assert.deepEqual(
         [...bucketSet.below.tags],
-        [getTag(2), getTag(3), getTag(4), getTag(5)]
+        [tagForAnchor(2), tagForAnchor(3), tagForAnchor(4), tagForAnchor(5)]
       );
     });
   });


### PR DESCRIPTION
This PR makes the `Buckets` component to accept a simplified data
structure that doesn't contain `anchor`s. The `anchor` objects are no
longer needed and they can't be serialised (because they contain DOM
elements).

On the second commit, I changed the term `anchor` to `annotation` when referring to certain events. 