### PR TITLE
Compute buckets on two steps (guest/host frames)

### DIFF
--- a/src/annotator/bucket-bar-client.js
+++ b/src/annotator/bucket-bar-client.js
@@ -65,8 +65,6 @@ export class BucketBarClient {
 
     this._updatePending = true;
     requestAnimationFrame(() => {
-      // Computing anchor positions may be expensive when there are many
-      // annotations or a forced layout reflow
       const positions = computeAnchorPositions(this._anchors);
       this._hostRPC.call('anchorsChanged', positions);
       this._updatePending = false;

--- a/src/annotator/bucket-bar-client.js
+++ b/src/annotator/bucket-bar-client.js
@@ -65,8 +65,8 @@ export class BucketBarClient {
 
     this._updatePending = true;
     requestAnimationFrame(() => {
-      // In document with many annotations computing the anchor positions can
-      // block the JS event loop for up to 200 ms.
+      // Computing anchor positions may be expensive when there are many
+      // annotations or a forced layout reflow
       const positions = computeAnchorPositions(this._anchors);
       this._hostRPC.call('anchorsChanged', positions);
       this._updatePending = false;

--- a/src/annotator/bucket-bar.js
+++ b/src/annotator/bucket-bar.js
@@ -1,9 +1,10 @@
 import { render } from 'preact';
 
 import Buckets from './components/Buckets';
-import { anchorBuckets } from './util/buckets';
+import { computeBuckets } from './util/buckets';
 
 /**
+ * @typedef {import('../types/annotator').AnchorPosition} AnchorPosition
  * @typedef {import('../types/annotator').Destroyable} Destroyable
  */
 
@@ -16,7 +17,6 @@ import { anchorBuckets } from './util/buckets';
 export default class BucketBar {
   /**
    * @param {HTMLElement} container
-   * @param {Pick<import('./guest').default, 'anchors'>} guest
    * @param {object} options
    *   @param {(tags: string[]) => void} options.onFocusAnnotations
    *   @param {(tags: string[], direction: 'down'|'up') => void} options.onScrollToClosestOffScreenAnchor
@@ -24,7 +24,6 @@ export default class BucketBar {
    */
   constructor(
     container,
-    guest,
     {
       onFocusAnnotations,
       onScrollToClosestOffScreenAnchor,
@@ -34,13 +33,12 @@ export default class BucketBar {
     this._bucketsContainer = document.createElement('div');
     container.appendChild(this._bucketsContainer);
 
-    this._guest = guest;
     this._onFocusAnnotations = onFocusAnnotations;
     this._onScrollToClosestOffScreenAnchor = onScrollToClosestOffScreenAnchor;
     this._onSelectAnnotations = onSelectAnnotations;
 
-    // Immediately render the buckets for the current anchors.
-    this.update();
+    // Immediately render the bucket bar
+    this.update([]);
   }
 
   destroy() {
@@ -48,8 +46,11 @@ export default class BucketBar {
     this._bucketsContainer.remove();
   }
 
-  update() {
-    const buckets = anchorBuckets(this._guest.anchors);
+  /**
+   * @param {AnchorPosition[]} positions
+   */
+  update(positions) {
+    const buckets = computeBuckets(positions);
     render(
       <Buckets
         above={buckets.above}

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -618,7 +618,7 @@ export default class Guest {
   _updateAnchors(anchors, notify) {
     this.anchors = anchors;
     if (notify) {
-      this._bucketBarClient?.update();
+      this._bucketBarClient?.update(this.anchors);
     }
   }
 

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -41,9 +41,6 @@ function init() {
 
   const hostFrame = annotatorConfig.subFrameIdentifier ? window.parent : window;
 
-  // Create the guest that handles creating annotations and displaying highlights.
-  const guest = new Guest(document.body, annotatorConfig, hostFrame);
-
   let sidebar;
   let notebook;
   let portProvider;
@@ -54,13 +51,16 @@ function init() {
     portProvider = new PortProvider(hypothesisAppsOrigin);
 
     const eventBus = new EventBus();
-    sidebar = new Sidebar(document.body, eventBus, guest, sidebarConfig);
+    sidebar = new Sidebar(document.body, eventBus, sidebarConfig);
     notebook = new Notebook(document.body, eventBus, getConfig('notebook'));
 
     portProvider.on('frameConnected', (source, port) =>
       sidebar.onFrameConnected(source, port)
     );
   }
+
+  // Create the guest that handles creating annotations and displaying highlights.
+  const guest = new Guest(document.body, annotatorConfig, hostFrame);
 
   sidebarLinkElement.addEventListener('destroy', () => {
     portProvider?.destroy();

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -302,6 +302,7 @@ export default class Sidebar {
       'anchorsChanged',
       /** @param {AnchorPosition[]} positions  */
       positions => {
+        // Currently, only one guest frame sends anchor positions to the bucket bar
         this.bucketBar?.update(positions);
       }
     );

--- a/src/annotator/test/bucket-bar-client-test.js
+++ b/src/annotator/test/bucket-bar-client-test.js
@@ -1,11 +1,11 @@
 import { delay } from '../../test-util/wait';
-import { BucketBarClient } from '../bucket-bar-client';
+import { BucketBarClient, $imports } from '../bucket-bar-client';
 
 describe('BucketBarClient', () => {
   const sandbox = sinon.createSandbox();
   let bucketBarClients;
   let contentContainer;
-  let fakeBridge;
+  let fakeRPC;
 
   beforeEach(() => {
     sandbox
@@ -13,19 +13,24 @@ describe('BucketBarClient', () => {
       .callsFake(cb => setTimeout(cb, 0));
     bucketBarClients = [];
     contentContainer = document.createElement('div');
-    fakeBridge = { call: sinon.stub() };
+    fakeRPC = { call: sinon.stub() };
+
+    $imports.$mock({
+      './util/buckets': { computeAnchorPositions: sinon.stub().returns([]) },
+    });
   });
 
   afterEach(() => {
     bucketBarClients.forEach(bucketBarClient => bucketBarClient.destroy());
     contentContainer.remove();
     sandbox.restore();
+    $imports.$restore();
   });
 
   const createBucketBarClient = () => {
     const bucketBarClient = new BucketBarClient({
       contentContainer,
-      hostRPC: fakeBridge,
+      hostRPC: fakeRPC,
     });
     bucketBarClients.push(bucketBarClient);
     return bucketBarClient;
@@ -37,8 +42,8 @@ describe('BucketBarClient', () => {
     window.dispatchEvent(new Event('resize'));
     await delay(0);
 
-    assert.calledOnce(fakeBridge.call);
-    assert.calledWith(fakeBridge.call, 'anchorsChanged');
+    assert.calledOnce(fakeRPC.call);
+    assert.calledWith(fakeRPC.call, 'anchorsChanged');
   });
 
   it('should update buckets when the window is scrolled', async () => {
@@ -47,8 +52,8 @@ describe('BucketBarClient', () => {
     window.dispatchEvent(new Event('scroll'));
     await delay(0);
 
-    assert.calledOnce(fakeBridge.call);
-    assert.calledWith(fakeBridge.call, 'anchorsChanged');
+    assert.calledOnce(fakeRPC.call);
+    assert.calledWith(fakeRPC.call, 'anchorsChanged');
   });
 
   it('should update buckets when the contentContainer element scrolls', async () => {
@@ -57,8 +62,8 @@ describe('BucketBarClient', () => {
     contentContainer.dispatchEvent(new Event('scroll'));
     await delay(0);
 
-    assert.calledOnce(fakeBridge.call);
-    assert.calledWith(fakeBridge.call, 'anchorsChanged');
+    assert.calledOnce(fakeRPC.call);
+    assert.calledWith(fakeRPC.call, 'anchorsChanged');
   });
 
   describe('#destroy', () => {
@@ -71,7 +76,7 @@ describe('BucketBarClient', () => {
       window.dispatchEvent(new Event('scroll'));
       await delay(0);
 
-      assert.notCalled(fakeBridge.call);
+      assert.notCalled(fakeRPC.call);
     });
   });
 
@@ -82,8 +87,8 @@ describe('BucketBarClient', () => {
       bucketBarClient.update();
       await delay(0);
 
-      assert.calledOnce(fakeBridge.call);
-      assert.calledWith(fakeBridge.call, 'anchorsChanged');
+      assert.calledOnce(fakeRPC.call);
+      assert.calledWith(fakeRPC.call, 'anchorsChanged');
     });
 
     it('does not update if another update is pending', async () => {
@@ -93,8 +98,8 @@ describe('BucketBarClient', () => {
       bucketBarClient.update();
       await delay(0);
 
-      assert.calledOnce(fakeBridge.call);
-      assert.calledWith(fakeBridge.call, 'anchorsChanged');
+      assert.calledOnce(fakeRPC.call);
+      assert.calledWith(fakeRPC.call, 'anchorsChanged');
     });
   });
 });

--- a/src/annotator/test/bucket-bar-test.js
+++ b/src/annotator/test/bucket-bar-test.js
@@ -4,8 +4,7 @@ describe('BucketBar', () => {
   let bucketBars;
   let bucketProps;
   let container;
-  let fakeBucketUtil;
-  let fakeGuest;
+  let fakeComputeBuckets;
   let fakeOnFocusAnnotations;
   let fakeOnScrollToClosestOffScreenAnchor;
   let fakeOnSelectAnnotations;
@@ -15,15 +14,7 @@ describe('BucketBar', () => {
     bucketProps = {};
     container = document.createElement('div');
 
-    fakeBucketUtil = {
-      anchorBuckets: sinon.stub().returns({}),
-    };
-
-    fakeGuest = {
-      anchors: [],
-      scrollToAnchor: sinon.stub(),
-      selectAnnotations: sinon.stub(),
-    };
+    fakeComputeBuckets = sinon.stub().returns({});
 
     fakeOnFocusAnnotations = sinon.stub();
     fakeOnScrollToClosestOffScreenAnchor = sinon.stub();
@@ -36,7 +27,7 @@ describe('BucketBar', () => {
 
     $imports.$mock({
       './components/Buckets': FakeBuckets,
-      './util/buckets': fakeBucketUtil,
+      './util/buckets': { computeBuckets: fakeComputeBuckets },
     });
   });
 
@@ -47,7 +38,7 @@ describe('BucketBar', () => {
   });
 
   const createBucketBar = () => {
-    const bucketBar = new BucketBar(container, fakeGuest, {
+    const bucketBar = new BucketBar(container, {
       onFocusAnnotations: fakeOnFocusAnnotations,
       onScrollToClosestOffScreenAnchor: fakeOnScrollToClosestOffScreenAnchor,
       onSelectAnnotations: fakeOnSelectAnnotations,
@@ -56,9 +47,9 @@ describe('BucketBar', () => {
     return bucketBar;
   };
 
-  it('should render buckets for existing anchors when constructed', () => {
+  it('should render the bucket bar with no buckets when constructed', () => {
     const bucketBar = createBucketBar();
-    assert.calledWith(fakeBucketUtil.anchorBuckets, fakeGuest.anchors);
+    assert.calledWith(fakeComputeBuckets, []);
     assert.ok(bucketBar._bucketsContainer.querySelector('.FakeBuckets'));
   });
 
@@ -93,12 +84,12 @@ describe('BucketBar', () => {
   describe('#update', () => {
     it('updates the buckets', () => {
       const bucketBar = createBucketBar();
-      fakeBucketUtil.anchorBuckets.resetHistory();
+      fakeComputeBuckets.resetHistory();
 
-      bucketBar.update();
+      bucketBar.update([1, 2]);
 
-      assert.calledOnce(fakeBucketUtil.anchorBuckets);
-      assert.calledWith(fakeBucketUtil.anchorBuckets, fakeGuest.anchors);
+      assert.calledOnce(fakeComputeBuckets);
+      assert.calledWith(fakeComputeBuckets, [1, 2]);
     });
   });
 

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1203,11 +1203,14 @@ describe('Guest', () => {
 
     it('calls the `BucketBarClient#update` method', () => {
       const guest = createGuest();
-      const anchor = createAnchor();
+      const anchor1 = createAnchor();
+      const anchor2 = createAnchor();
+      guest.anchors.push(anchor1, anchor2);
 
-      guest.detach(anchor.annotation.$tag);
+      guest.detach(anchor1.annotation.$tag);
 
       assert.calledOnce(fakeBucketBarClient.update);
+      assert.calledWith(fakeBucketBarClient.update, [anchor2]);
     });
   });
 

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -22,7 +22,6 @@ describe('Sidebar', () => {
   let fakePortRPCs;
   let FakeBucketBar;
   let fakeBucketBar;
-  let fakeGuest;
   let FakeToolbarController;
   let fakeToolbar;
   let fakeSendErrorsTo;
@@ -95,7 +94,7 @@ describe('Sidebar', () => {
     containers.push(container);
 
     const eventBus = new EventBus();
-    const sidebar = new Sidebar(container, eventBus, fakeGuest, config);
+    const sidebar = new Sidebar(container, eventBus, config);
     sidebars.push(sidebar);
 
     return sidebar;
@@ -134,8 +133,6 @@ describe('Sidebar', () => {
       update: sinon.stub(),
     };
     FakeBucketBar = sinon.stub().returns(fakeBucketBar);
-
-    fakeGuest = sinon.stub();
 
     fakeToolbar = {
       getWidth: sinon.stub().returns(100),
@@ -481,9 +478,10 @@ describe('Sidebar', () => {
         const sidebar = createSidebar();
         connectGuest(sidebar);
 
-        emitGuestEvent('anchorsChanged');
+        emitGuestEvent('anchorsChanged', [1, 2]);
 
         assert.calledOnce(sidebar.bucketBar.update);
+        assert.calledWith(sidebar.bucketBar.update, [1, 2]);
       });
     });
   });
@@ -948,7 +946,7 @@ describe('Sidebar', () => {
     it('calls the "focusAnnotations" RPC method', () => {
       const sidebar = createSidebar();
       connectGuest(sidebar);
-      const { onFocusAnnotations } = FakeBucketBar.getCall(0).args[2];
+      const { onFocusAnnotations } = FakeBucketBar.getCall(0).args[1];
       const tags = ['t1', 't2'];
 
       onFocusAnnotations(tags);
@@ -960,7 +958,7 @@ describe('Sidebar', () => {
       const sidebar = createSidebar();
       connectGuest(sidebar);
       const { onScrollToClosestOffScreenAnchor } =
-        FakeBucketBar.getCall(0).args[2];
+        FakeBucketBar.getCall(0).args[1];
       const tags = ['t1', 't2'];
       const direction = 'down';
 
@@ -977,7 +975,7 @@ describe('Sidebar', () => {
     it('calls the "selectAnnotations" RPC method', () => {
       const sidebar = createSidebar();
       connectGuest(sidebar);
-      const { onSelectAnnotations } = FakeBucketBar.getCall(0).args[2];
+      const { onSelectAnnotations } = FakeBucketBar.getCall(0).args[1];
       const tags = ['t1', 't2'];
       const toggle = true;
 

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -478,10 +478,11 @@ describe('Sidebar', () => {
         const sidebar = createSidebar();
         connectGuest(sidebar);
 
-        emitGuestEvent('anchorsChanged', [1, 2]);
+        const anchorPositions = [{ tag: 't0', top: 1, bottom: 2 }];
+        emitGuestEvent('anchorsChanged', anchorPositions);
 
         assert.calledOnce(sidebar.bucketBar.update);
-        assert.calledWith(sidebar.bucketBar.update, [1, 2]);
+        assert.calledWith(sidebar.bucketBar.update, anchorPositions);
       });
     });
   });

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -59,8 +59,8 @@
  *
  * @typedef AnchorPosition
  * @prop {string} tag - annotation tag
- * @prop {number} top
- * @prop {number} bottom
+ * @prop {number} top - in pixel
+ * @prop {number} bottom - in pixel
  */
 
 /**

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -54,6 +54,16 @@
  */
 
 /**
+ * Top and bottom positions of the bounding box created by the union of the
+ * highlight elements associated to an anchor.
+ *
+ * @typedef AnchorPosition
+ * @prop {string} tag - annotation tag
+ * @prop {number} top
+ * @prop {number} bottom
+ */
+
+/**
  * Anchoring implementation for a particular document type (eg. PDF or HTML).
  *
  * This is responsible for converting between serialized "selectors" that can

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -55,7 +55,9 @@
 
 /**
  * Top and bottom positions of the bounding box created by the union of the
- * highlight elements associated to an anchor.
+ * highlight elements associated to an anchor. Top and bottom positions are
+ * based on the viewport. The value zero corresponds to the top of viewport.
+ * Hidden elements that are above the viewport have negative values.
  *
  * @typedef AnchorPosition
  * @prop {string} tag - annotation tag


### PR DESCRIPTION
~~Depends on #4071~~ 

The functionality to compute the buckets has been split in two steps:

1. Guest frame computes and sends a list of the anchors's top/bottom
   positions with the `anchorsChanged` RPC event.

2. In the host frame, `BucketBar` uses the list anchor's positions to
   compute the buckets.

There is one issue with the current approach: if an iframe doesn't cover
the entire host frame's viewport buckets can appear offset.


This is a video that issue:

https://user-images.githubusercontent.com/8555781/147335655-0223571e-57ca-4a28-8278-5b5878729814.mov

