### PR TITLE
Make `PortProvider#listen` a private  method

### DIFF
--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -52,7 +52,6 @@ function init() {
 
     const hypothesisAppsOrigin = new URL(sidebarConfig.sidebarAppUrl).origin;
     portProvider = new PortProvider(hypothesisAppsOrigin);
-    portProvider.listen();
 
     const eventBus = new EventBus();
     sidebar = new Sidebar(document.body, eventBus, guest, sidebarConfig);

--- a/src/shared/port-provider.js
+++ b/src/shared/port-provider.js
@@ -60,6 +60,8 @@ import { isMessage, isMessageEqual, isSourceWindow } from './port-util';
  */
 export class PortProvider {
   /**
+   * Begin listening to port requests from other frames.
+   *
    * @param {string} hypothesisAppsOrigin - the origin of the hypothesis apps
    *   is use to send the notebook and sidebar ports to only the frames that
    *   match the origin.
@@ -112,41 +114,11 @@ export class PortProvider {
         type: 'request',
       },
     ];
+
+    this._listen();
   }
 
-  /**
-   * Check that data and origin matches the expected values.
-   *
-   * @param {object} options
-   *   @param {Message} options.allowedMessage - the `data` must match this
-   *     `Message`.
-   *   @param {string} options.allowedOrigin - the `origin` must match this
-   *     value. If `allowedOrigin` is '*', the origin is ignored.
-   *   @param {any} options.data - the data to be compared with `allowedMessage`.
-   *   @param {string} options.origin - the origin to be compared with
-   *     `allowedOrigin`.
-   */
-  _messageMatches({ allowedMessage, allowedOrigin, data, origin }) {
-    if (allowedOrigin !== '*' && origin !== allowedOrigin) {
-      return false;
-    }
-
-    return isMessageEqual(data, allowedMessage);
-  }
-
-  /**
-   * @param {'frameConnected'} eventName
-   * @param {(source: 'guest'|'sidebar', port: MessagePort) => void} handler - this handler
-   *   fires when a request for the host frame has been granted.
-   */
-  on(eventName, handler) {
-    this._emitter.on(eventName, handler);
-  }
-
-  /**
-   * Initiate the listener of port requests by other frames.
-   */
-  listen() {
+  _listen() {
     const errorContext = 'Handling port request';
     const sentErrors = /** @type {Set<string>} */ (new Set());
 
@@ -244,6 +216,33 @@ export class PortProvider {
       'message',
       captureErrors(handleRequest, errorContext)
     );
+  }
+
+  /**
+   * @param {object} options
+   *   @param {Message} options.allowedMessage - the `data` must match this
+   *     `Message`.
+   *   @param {string} options.allowedOrigin - the `origin` must match this
+   *     value. If `allowedOrigin` is '*', the origin is ignored.
+   *   @param {any} options.data - the data to be compared with `allowedMessage`.
+   *   @param {string} options.origin - the origin to be compared with
+   *     `allowedOrigin`.
+   */
+  _messageMatches({ allowedMessage, allowedOrigin, data, origin }) {
+    if (allowedOrigin !== '*' && origin !== allowedOrigin) {
+      return false;
+    }
+
+    return isMessageEqual(data, allowedMessage);
+  }
+
+  /**
+   * @param {'frameConnected'} eventName
+   * @param {(source: 'guest'|'sidebar', port: MessagePort) => void} handler - this handler
+   *   fires when a frame connects to the host frame
+   */
+  on(eventName, handler) {
+    this._emitter.on(eventName, handler);
   }
 
   destroy() {

--- a/src/shared/test/integration/inter-frame-communication-test.js
+++ b/src/shared/test/integration/inter-frame-communication-test.js
@@ -70,7 +70,6 @@ describe('PortProvider-PortFinder-PortRPC integration', () => {
       await delay(10); // simulate scenario when host frame is ready before the guest frame
 
       const portProvider = new PortProvider(window.location.origin);
-      portProvider.listen();
 
       const guestRPC = new PortRPC();
       guestRPC.on('ping', cb => cb('pong'));
@@ -133,8 +132,7 @@ describe('PortProvider-PortFinder-PortRPC integration', () => {
     const simulateHost = async () => {
       await delay(10); // simulate scenario when host frame is ready before the guest frame
 
-      const portProvider = new PortProvider(window.location.origin);
-      portProvider.listen();
+      new PortProvider(window.location.origin);
     };
 
     return Promise.all([simulateGuest(), simulateSidebar(), simulateHost()]);
@@ -161,7 +159,6 @@ describe('PortProvider-PortFinder-PortRPC integration', () => {
 
     const simulateHost = () => {
       const portProvider = new PortProvider(window.location.origin);
-      portProvider.listen();
 
       const sidebarRPC = new PortRPC();
       sidebarRPC.on('ping', cb => cb('pong'));

--- a/src/shared/test/port-provider-test.js
+++ b/src/shared/test/port-provider-test.js
@@ -47,31 +47,6 @@ describe('PortProvider', () => {
     });
   });
 
-  describe('#listen', () => {
-    it('ignores all port requests before `listen` is called', async () => {
-      portProvider.listen();
-      portProvider.destroy();
-      portProvider = new PortProvider(window.location.origin);
-      const data = {
-        frame1: 'sidebar',
-        frame2: 'host',
-        type: 'request',
-      };
-      await sendPortFinderRequest({
-        data,
-      });
-
-      assert.notCalled(window.postMessage);
-
-      portProvider.listen();
-      await sendPortFinderRequest({
-        data,
-      });
-
-      assert.calledOnce(window.postMessage);
-    });
-  });
-
   describe('reporting message errors', () => {
     let fakeSendError;
 
@@ -81,8 +56,6 @@ describe('PortProvider', () => {
       $imports.$mock({
         './frame-error-capture': { sendError: fakeSendError },
       });
-
-      portProvider.listen();
     });
 
     it('reports errors validating messages', async () => {
@@ -153,7 +126,6 @@ describe('PortProvider', () => {
       },
     ].forEach(({ data, reason, origin, source }) => {
       it(`ignores port request if message ${reason}`, async () => {
-        portProvider.listen();
         await sendPortFinderRequest({
           data,
           origin,
@@ -165,7 +137,6 @@ describe('PortProvider', () => {
     });
 
     it('responds to a valid port request', async () => {
-      portProvider.listen();
       const data = {
         frame1: 'sidebar',
         frame2: 'host',
@@ -185,7 +156,6 @@ describe('PortProvider', () => {
     });
 
     it('responds to a valid port request from a source with an opaque origin', async () => {
-      portProvider.listen();
       const data = {
         frame1: 'guest',
         frame2: 'sidebar',
@@ -200,7 +170,6 @@ describe('PortProvider', () => {
     });
 
     it('responds to the first valid port request but ignores additional requests', async () => {
-      portProvider.listen();
       const data = {
         frame1: 'guest',
         frame2: 'sidebar',
@@ -222,7 +191,6 @@ describe('PortProvider', () => {
     });
 
     it('sends the counterpart port via the sidebar port', async () => {
-      portProvider.listen();
       await sendPortFinderRequest({
         data: {
           frame1: 'sidebar',
@@ -253,7 +221,6 @@ describe('PortProvider', () => {
     });
 
     it('sends the counterpart port via the listener', async () => {
-      portProvider.listen();
       const handler = sinon.stub();
       portProvider.on('frameConnected', handler);
       await sendPortFinderRequest({


### PR DESCRIPTION
I can't see any negative consequence of starting to listen to
postMessage discovery message immediately after `PortProvider` is
instantiated. (In fact, this is what it was currently happening). These
messages won't be lost, and the `PortRPC`s won't create the
communication channels before the RPC methods are registered.

On the other hand, it simplifies the use of `PortProvider` and
eliminates the potential problem of `PortProvider#listen` been called
more than once.