### PR TITLE
Update dependabot config to remove outdated dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,3 @@ updates:
     interval: weekly
     time: "10:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: query-string
-    versions:
-    - "> 3.0.3"


### PR DESCRIPTION
We no longer use `query-string`