### PR TITLE
WIP: proof of concept for notebook-sidebar communication

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -301,11 +301,9 @@ export default class Sidebar {
     // Sidebar listens to the `openNotebook` event coming from the sidebar's
     // iframe and re-publishes it via the emitter to the Notebook
     this._sidebarRPC.on(
-      'openNotebook',
-      /** @param {string} groupId */
-      groupId => {
+      'openNotebook', () => {
         this.hide();
-        this._emitter.publish('openNotebook', groupId);
+        this._emitter.publish('openNotebook');
       }
     );
     this._emitter.subscribe('closeNotebook', () => {

--- a/src/sidebar/components/GroupList/GroupListItem.js
+++ b/src/sidebar/components/GroupList/GroupListItem.js
@@ -16,6 +16,7 @@ import MenuItem from '../MenuItem';
  * @prop {boolean} [isExpanded] - Whether the submenu for this group is expanded
  * @prop {(expand: boolean) => any} onExpand -
  *   Callback invoked to expand or collapse the current group
+ * @prop {import('../../services/frame-sync').FrameSyncService} frameSync
  * @prop {import('../../services/groups').GroupsService} groups
  * @prop {import('../../services/toast-messenger').ToastMessengerService} toastMessenger
  */
@@ -30,6 +31,7 @@ import MenuItem from '../MenuItem';
  */
 function GroupListItem({
   isExpanded,
+  frameSync,
   group,
   groups: groupsService,
   onExpand,
@@ -48,6 +50,7 @@ function GroupListItem({
     store.clearDirectLinkedGroupFetchFailed();
     store.clearDirectLinkedIds();
     groupsService.focus(group.id);
+    frameSync.notifyNotebook('groupChanged', group.id);
   };
 
   const leaveGroup = async () => {
@@ -149,4 +152,8 @@ function GroupListItem({
   );
 }
 
-export default withServices(GroupListItem, ['groups', 'toastMessenger']);
+export default withServices(GroupListItem, [
+  'frameSync',
+  'groups',
+  'toastMessenger',
+]);

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -56,7 +56,7 @@ function UserMenu({ auth, frameSync, onLogout, settings }) {
     !isThirdParty || serviceSupports('onLogoutRequestProvided');
 
   const onSelectNotebook = () => {
-    frameSync.notifyHost('openNotebook', store.focusedGroupId());
+    frameSync.notifyHost('openNotebook');
   };
 
   // Temporary access to the Notebook without feature flag:

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -580,8 +580,8 @@ describe('FrameSyncService', () => {
   describe('#notifyHost', () => {
     it('sends a message to the host frame', () => {
       frameSync.connect();
-      frameSync.notifyHost('openNotebook', 'group-id');
-      assert.calledWith(hostBridge().call, 'openNotebook', 'group-id');
+      frameSync.notifyHost('openNotebook');
+      assert.calledWith(hostBridge().call, 'openNotebook');
     });
   });
 });

--- a/src/types/bridge-events.d.ts
+++ b/src/types/bridge-events.d.ts
@@ -134,6 +134,11 @@ export type SidebarToGuestEvent =
   | 'setHighlightsVisible';
 
 /**
+ * Events that the notebook sends to the sidebar
+ */
+export type NotebookToSidebarEvent = never;
+
+/**
  * Events that the sidebar sends to the host
  */
 export type SidebarToHostEvent =
@@ -203,10 +208,21 @@ export type SidebarToHostEvent =
    */
   | 'signupRequested';
 
+/**
+ * Events that the sidebar sends to the notebook
+ */
+export type SidebarToNotebookEvent =
+  /**
+   * The sidebar informs to the notebook that a different group has been selected.
+   */
+  'groupChanged';
+
 export type BridgeEvent =
   | HostToGuestEvent
   | HostToSidebarEvent
   | GuestToHostEvent
   | GuestToSidebarEvent
+  | NotebookToSidebarEvent
   | SidebarToGuestEvent
-  | SidebarToHostEvent;
+  | SidebarToHostEvent
+  | SidebarToNotebookEvent;


### PR DESCRIPTION
This PR enables a new communication channel between the notebook and the
sidebar. This in turn prevents the notebook from having to re-initialise
the notebook app (re-rendering parent iframe) each time the notebook is
opened, hence speeding up the app after the first rendering.

This is very crude WIP PR, just to demonstrate the feasibility of the
channel and to get preliminary feedback.

You can compare the speed difference between the before and after videos:

### Before
https://user-images.githubusercontent.com/8555781/148407477-da4436f3-64e4-4326-9df2-d375ce5be819.mov

### After
https://user-images.githubusercontent.com/8555781/148407493-3edc3c97-5f87-4b26-9e70-e8c853cd06f8.mov

Related to: #3313
Closes https://github.com/hypothesis/client/issues/3182