### PR TITLE
Remove `onConnect` method from Bridge

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -189,7 +189,7 @@ export default class Sidebar {
     this._notifyOfLayoutChange(false);
     this._setupSidebarEvents();
 
-    this._sidebarRPC.onConnect(() => {
+    this._sidebarRPC.on('ready', () => {
       // Show the UI
       if (this.iframeContainer) {
         this.iframeContainer.style.display = '';

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -106,7 +106,6 @@ describe('Guest', () => {
         createChannel: sinon.stub(),
         destroy: sinon.stub(),
         on: sinon.stub(),
-        onConnect: sinon.stub(),
       };
       fakeBridges.push(bridge);
       return bridge;

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -72,8 +72,7 @@ describe('Sidebar', () => {
    * when the sidebar has loaded and is ready.
    */
   const connectSidebarApp = () => {
-    const callback = sidebarBridge().onConnect.getCall(0).args[0];
-    callback();
+    emitSidebarEvent('ready');
   };
 
   const createSidebar = (config = {}) => {
@@ -116,7 +115,6 @@ describe('Sidebar', () => {
         createChannel: sinon.stub(),
         destroy: sinon.stub(),
         on: sinon.stub(),
-        onConnect: sinon.stub(),
       };
       fakeBridges.push(bridge);
       return bridge;

--- a/src/shared/bridge.js
+++ b/src/shared/bridge.js
@@ -19,12 +19,6 @@ export class Bridge {
     this.links = [];
     /** @type {Record<string, (...args: any[]) => void>} */
     this.channelListeners = {};
-    /** @type {Array<(channel: PortRPC) => void>} */
-    this.onConnectListeners = [];
-
-    // `connect` is registered with a callback so it triggers a `postMessage`
-    // response from the reciprocal port.
-    this.on('connect', cb => cb());
   }
 
   /**
@@ -48,22 +42,7 @@ export class Bridge {
    */
   createChannel(port) {
     const channel = new PortRPC(port, this.channelListeners);
-
-    let connected = false;
-    const ready = () => {
-      if (connected) {
-        return;
-      }
-      connected = true;
-      this.onConnectListeners.forEach(cb => cb(channel));
-    };
-
-    // Fire off a connection attempt
-    channel.call('connect', ready);
-
-    // Store the newly created channel in our collection
     this.links.push(channel);
-
     return channel;
   }
 
@@ -155,16 +134,6 @@ export class Bridge {
       throw new Error(`Listener '${method}' already bound in Bridge`);
     }
     this.channelListeners[method] = listener;
-    return this;
-  }
-
-  /**
-   * Add a listener to be called upon a new connection.
-   *
-   * @param {(channel: PortRPC) => void} listener
-   */
-  onConnect(listener) {
-    this.onConnectListeners.push(listener);
     return this;
   }
 }

--- a/src/shared/test/bridge-test.js
+++ b/src/shared/test/bridge-test.js
@@ -194,59 +194,6 @@ describe('shared/bridge', () => {
     });
   });
 
-  describe('#onConnect', () => {
-    // Simulate a Bridge attached to the other end of a channel receiving
-    // the `connect` RPC request and handling it using the `connect` handler
-    // registered by the Bridge.
-    const runConnectHandler = channel => {
-      const connectCall = channel.call
-        .getCalls()
-        .find(call => call.firstArg === 'connect');
-
-      // Invoke the `connect` handler. Here we're invoking it on `channel` but
-      // in the actual app this would be called on the counterpart channel in
-      // the other frame.
-      channel.methods.connect(...connectCall.args.slice(1));
-    };
-
-    it('runs callbacks when channel connects', () => {
-      const onConnectCallback = sinon.stub();
-      bridge.onConnect(onConnectCallback);
-
-      const channel = createChannel();
-
-      runConnectHandler(channel);
-
-      assert.calledWith(onConnectCallback, channel);
-    });
-
-    it('allows multiple callbacks to be registered', () => {
-      const onConnectCallback1 = sinon.stub();
-      const onConnectCallback2 = sinon.stub();
-      bridge.onConnect(onConnectCallback1);
-      bridge.onConnect(onConnectCallback2);
-
-      const channel = createChannel();
-
-      runConnectHandler(channel);
-
-      assert.calledWith(onConnectCallback1, channel);
-      assert.calledWith(onConnectCallback2, channel);
-    });
-
-    it('only invokes `onConnect` callback once', () => {
-      const onConnectCallback = sinon.stub();
-      bridge.onConnect(onConnectCallback);
-
-      const channel = createChannel();
-
-      runConnectHandler(channel);
-      runConnectHandler(channel);
-
-      assert.calledOnce(onConnectCallback);
-    });
-  });
-
   describe('#destroy', () =>
     it('destroys all opened channels', () => {
       const channel1 = bridge.createChannel();

--- a/src/shared/test/integration/rpc-bridge-test.js
+++ b/src/shared/test/integration/rpc-bridge-test.js
@@ -24,34 +24,6 @@ describe('PortRPC-Bridge integration', () => {
     clock.restore();
   });
 
-  describe('establishing a connection', () => {
-    it('should invoke Bridge `onConnect` callbacks after connecting', async () => {
-      const bridge = createBridge();
-      const reciprocalBridge = createBridge();
-      reciprocalBridge.on('method', cb => cb(null));
-      let callbackCount = 0;
-      const callback = () => {
-        ++callbackCount;
-      };
-      bridge.onConnect(callback);
-      bridge.onConnect(callback); // allows multiple callbacks to be registered
-      reciprocalBridge.onConnect(callback);
-
-      const channel = bridge.createChannel(port1);
-      const reciprocalChannel = reciprocalBridge.createChannel(port2);
-      await bridge.call('method');
-
-      assert.equal(callbackCount, 3);
-
-      // Additional calls to the RPC `connect` method are ignored
-      await channel.call('connect');
-      await reciprocalChannel.call('connect');
-      await bridge.call('method');
-
-      assert.equal(callbackCount, 3);
-    });
-  });
-
   describe('sending and receiving RPC messages', () => {
     it('should invoke Bridge method handler on every channel when calling a RPC method', async () => {
       const bridge = createBridge();

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -258,7 +258,7 @@ export class FrameSyncService {
    *
    * @param {PortRPC} channel
    */
-  _addFrame(channel) {
+  _addGuestFrame(channel) {
     // Synchronize highlight visibility in this guest with the sidebar's controls.
     channel.call('setHighlightsVisible', this._highlightsVisible);
 
@@ -322,7 +322,7 @@ export class FrameSyncService {
         })
       ) {
         const channel = this._guestRPC.createChannel(ports[0]);
-        this._addFrame(channel);
+        this._addGuestFrame(channel);
       }
     });
   }

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -444,7 +444,7 @@ describe('FrameSyncService', () => {
     });
   });
 
-  context('when a new frame connects', () => {
+  context('when a new guest frame connects', () => {
     beforeEach(() => {
       frameSync.connect();
     });

--- a/src/types/bridge-events.d.ts
+++ b/src/types/bridge-events.d.ts
@@ -138,6 +138,11 @@ export type SidebarToGuestEvent =
  */
 export type SidebarToHostEvent =
   /**
+   * The sidebar notifies the host that it has loaded and is ready to be displayed.
+   */
+  | 'ready'
+
+  /**
    * The sidebar relays to the host to close the sidebar.
    */
   | 'closeSidebar'


### PR DESCRIPTION
Simplify the Bridge class by removing the `onConnect` API and replacing
current calls with alternative approaches.

The `onConnect` method was a way to register a callback that would be invoked
after a test RPC call over a newly-connected channel succeeded.

The purpose of this method was not that clear however and its existence
suggested that it is necessary to wait for the callback to be invoked before
making RPC requests on the new channel. This is not the case, at least not any more, as the underlying
transport buffers messages until the receiver is ready to consume them. Therefore
RPC requests can be made as soon as `createChannel` returns.

The current uses of `onConnect` were replaced as follows:

 1. The host frame used it to be notified when the sidebar application has
    loaded. This has been replaced with an explicit `ready` RPC call.

 2. The sidebar waited for this callback before querying metadata for a
    newly-connected guest. It now sends a metadata query to the guest
    immediately when it receives the guest port from the host frame. This saves
    an unnecessary round-trip between the host and guest. In future we can
    optimize metadata querying more by having the guest _push_ metadata to
    the sidebar rather than waiting for the sidebar to query it. See https://github.com/hypothesis/client/pull/4113.

Removing this API is a step towards combining the `Bridge` and `PortRPC` classes. See https://github.com/hypothesis/client/pull/4111.

This is part of https://github.com/hypothesis/client/issues/4094.