### PR TITLE
Push document metadata from guest to sidebar

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -195,7 +195,7 @@ export default class Guest {
      * @type {PortRPC<HostToGuestEvent, GuestToHostEvent>}
      */
     this._hostRPC = new PortRPC();
-    this._connectHostEvents();
+    this._connectHost();
 
     /**
      * Channel for guest-sidebar communication.
@@ -203,7 +203,7 @@ export default class Guest {
      * @type {PortRPC<SidebarToGuestEvent, GuestToSidebarEvent>}
      */
     this._sidebarRPC = new PortRPC();
-    this._connectSidebarEvents();
+    this._connectSidebar();
 
     // Set up automatic and integration-triggered injection of client into
     // iframes in this frame.
@@ -327,7 +327,7 @@ export default class Guest {
     }
   }
 
-  async _connectHostEvents() {
+  async _connectHost() {
     this._hostRPC.on(
       'clearSelectionExceptIn',
       /** @param {string|null} frameIdentifier */
@@ -367,7 +367,7 @@ export default class Guest {
     this._hostRPC.connect(hostPort);
   }
 
-  async _connectSidebarEvents() {
+  async _connectSidebar() {
     // Handlers for events sent when user hovers or clicks on an annotation card
     // in the sidebar.
     this._sidebarRPC.on(

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -141,7 +141,7 @@ describe('Guest', () => {
     FakeHypothesisInjector = sinon.stub().returns(fakeHypothesisInjector);
 
     fakePortFinder = {
-      discover: sinon.stub(),
+      discover: sinon.stub().resolves({}),
       destroy: sinon.stub(),
     };
 
@@ -341,40 +341,6 @@ describe('Guest', () => {
 
         assert.notCalled(eventEmitted);
         assert.notCalled(fakeIntegration.scrollToAnchor);
-      });
-    });
-
-    describe('on "getDocumentInfo" event', () => {
-      let guest;
-
-      afterEach(() => {
-        guest.destroy();
-        sandbox.restore();
-      });
-
-      function createCallback(expectedUri, expectedMetadata, done) {
-        return (err, result) => {
-          assert.strictEqual(err, null);
-          try {
-            assert.equal(result.uri, expectedUri);
-            assert.deepEqual(result.metadata, expectedMetadata);
-            done();
-          } catch (e) {
-            done(e);
-          }
-        };
-      }
-
-      it('calls the callback with document URL and metadata', done => {
-        guest = createGuest();
-        const metadata = { title: 'hi' };
-
-        fakeIntegration.getMetadata.resolves(metadata);
-
-        emitSidebarEvent(
-          'getDocumentInfo',
-          createCallback('https://example.com/test.pdf', metadata, done)
-        );
       });
     });
 
@@ -805,6 +771,8 @@ describe('Guest', () => {
   describe('#createAnnotation', () => {
     it('creates an annotation if host calls "createAnnotationIn" RPC method', async () => {
       createGuest();
+      await delay(0);
+      sidebarRPC().call.resetHistory(); // Discard `documentInfoChanged` call
 
       emitHostEvent('createAnnotationIn', 'dummy');
       await delay(0);
@@ -1284,6 +1252,19 @@ describe('Guest', () => {
     createGuest({ subFrameIdentifier: 'frame-id' });
 
     assert.notCalled(FakeBucketBarClient);
+  });
+
+  it('sends document metadata and URIs to sidebar', async () => {
+    createGuest();
+    await delay(0);
+    assert.calledWith(sidebarRPC().call, 'documentInfoChanged', {
+      uri: 'https://example.com/test.pdf',
+      metadata: {
+        title: 'Test title',
+        documentFingerprint: 'test-fingerprint',
+      },
+      frameIdentifier: null,
+    });
   });
 
   describe('#fitSideBySide', () => {

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -25,23 +25,12 @@ const fixtures = {
     },
   },
 
-  // Response to the `getDocumentInfo` channel message for a frame displaying
-  // an HTML document
+  // Argument to the `documentInfoChanged` call made by a guest displaying an HTML
+  // document.
   htmlDocumentInfo: {
     uri: 'http://example.org',
     metadata: {
       link: [],
-    },
-    frameIdentifier: null,
-  },
-
-  // Response to the `getDocumentInfo` channel message for a frame displaying
-  // a PDF
-  pdfDocumentInfo: {
-    uri: 'http://example.org/paper.pdf',
-    metadata: {
-      documentFingerprint: '1234',
-      link: [{ href: 'http://example.org/paper.pdf' }, { href: 'urn:1234' }],
     },
     frameIdentifier: null,
   },
@@ -457,35 +446,14 @@ describe('FrameSyncService', () => {
 
     it("adds the page's metadata to the frames list", async () => {
       const frameInfo = fixtures.htmlDocumentInfo;
-      setupPortRPC = rpc => {
-        rpc.call.withArgs('getDocumentInfo').callsFake((method, callback) => {
-          callback(null, frameInfo);
-        });
-      };
-
       await connectGuest();
+      emitGuestEvent('documentInfoChanged', frameInfo);
 
       assert.calledWith(fakeStore.connectFrame, {
         id: frameInfo.frameIdentifier,
         metadata: frameInfo.metadata,
         uri: frameInfo.uri,
       });
-    });
-
-    it('closes the channel and does not add frame to store if getting document info fails', async () => {
-      let channel;
-      setupPortRPC = rpc => {
-        rpc.call.withArgs('getDocumentInfo').callsFake((method, callback) => {
-          callback('Error getting document info');
-        });
-        channel = rpc;
-      };
-
-      await connectGuest();
-
-      assert.ok(channel);
-      assert.called(channel.destroy);
-      assert.notCalled(fakeStore.connectFrame);
     });
 
     it("synchronizes highlight visibility in the guest with the sidebar's controls", async () => {

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -46,6 +46,9 @@ export type GuestToSidebarEvent =
    */
   | 'openSidebar'
 
+  /** The guest is notifying the sidebar of the current document metadata and URIs. */
+  | 'documentInfoChanged'
+
   /**
    * The guest is asking the sidebar to display some annotations.
    */
@@ -112,11 +115,6 @@ export type SidebarToGuestEvent =
    * The sidebar is asking the guest(s) to focus on certain annotations.
    */
   | 'focusAnnotations'
-
-  /**
-   * The sidebar is asking the guest(s) for the URL and other metadata about the document.
-   */
-  | 'getDocumentInfo'
 
   /**
    * The sidebar is asking the guest(s) to load annotations.


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/4112**~~

Change the way document metadata and URIs for guest frames gets from the guest to the sidebar, so that the guest _pushes_ the information via a `documentInfoChanged` call instead of the sidebar requesting it via `getDocumentInfo`. This achieves two things:

 1. It enables the sidebar to get the initial document URI faster, as
    the guest can fetch the information and send it to the sidebar over
    the message channel while the sidebar is still loading. This in turn
    allows the initial annotation search request to be made sooner and
    for annotations to appear quicker.

    This fixes https://github.com/hypothesis/client/issues/4094.

    In practice this doesn't improve the best case metadata fetch time
    significantly (only 5-10ms or so) but does seem to reduce the variance in
    fetch times.

 2. It will in future enable the guest to inform the sidebar of
    URI/metadata changes after the initial load. This can happen if a
    client-side navigation happens in an HTML document for example or if
    the currently loaded PDF is changed in PDF.js.

A known weak point of both the previous and the new implementation is that there isn't good error handling of the guest fails to read the document metadata. The sidebar will just remain in a loading state. The main case where this can happen currently is if a PDF fails to load. In that case though it is obvious that something is wrong.