### PR TITLE
Wrap YouTube video frames in the browser extension

### DIFF
--- a/src/media-embed.html
+++ b/src/media-embed.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en" style="height: 100%">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Hypothesis embedded media</title>
+  </head>
+  <body style="height: 100%; margin: 0">
+    <!--
+      This file is the source for https://cdn.hypothes.is/media-embed.html.
+      It must be re-uploaded manually to S3 after any changes and made publicly
+      readable.
+
+      It is part of a workaround for embedded YouTube videos in the browser extension.
+      See https://github.com/hypothesis/product-backlog/issues/1297.
+    -->
+    <iframe
+      id="media-embed"
+      src="about:blank"
+      width="100%"
+      height="100%"
+      style="border: none"
+      allow="fullscreen"
+    ></iframe>
+    <script>
+      const params = new URLSearchParams(location.search);
+      const url = params.get('url');
+      const frame = document.getElementById('media-embed');
+      if (url) {
+        frame.src = url;
+      }
+    </script>
+  </body>
+</html>

--- a/src/sidebar/util/url.js
+++ b/src/sidebar/util/url.js
@@ -38,3 +38,10 @@ export function replaceURLParams(url, params) {
 export function resolve(relativeURL, baseURL) {
   return new URL(relativeURL, baseURL).href;
 }
+
+/**
+ * Is the current document served from a local source such as a browser extension?
+ */
+export function servedFromLocalFile() {
+  return location.protocol.includes('extension');
+}


### PR DESCRIPTION
This PR implements a workaround for https://github.com/hypothesis/product-backlog/issues/1297. It causes embedded YouTube videos to be wrapped in a tiny HTML file hosted at https://cdn.hypothes.is/media-embed.html, but only in the browser extension. The purpose of this wrapper is to ensure that a `Referer` header is sent when `https://www.youtube.com/embed/{video_id}` is fetched. Without this header YouTube blocks some videos from playing inline.

The source for media-embed.html is included in the client source tree, but it is not uploaded as part of the CI process. Instead the file has been uploaded to S3 manually via the AWS console. This should be adequate since we expect this file to change very rarely. I considered making media-embed.html a view that is part of h, as app.html and the notebook are, but logically this really should be an implementation detail that is part of the client.

The workaround comes in two parts:

1. The first commit adds a generic hook for rewriting media embed URLs in `media-embedder.js`
2. The second commit makes use of this hook in `components/MarkdownView.js` to rewrite `https://www.youtube.com/embed/{video_id}` URLs as `https://cdn.hypothes.is/media-embed.html?url={embed_url}`, but only when the sidebar or notebook are served from the browser extension

**TODO:**

- Tests
- Decide whether `media-embed.html` needs to be versioned

**Testing:**

On master:

1. Build the browser extension locally
2. Activate the dev extension on a site
3. Try to embed a copyrighted YouTube video (eg. https://www.youtube.com/watch?v=orJSJGHjBLI or examples from https://github.com/hypothesis/product-backlog/issues/1297) in an annotation.

The video should fail to load.

Repeat the same steps on this branch and it should load.