### PR TITLE
Fix error when VitalSource integration injects client into content frame

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -176,6 +176,10 @@ export default class Guest {
       source: 'guest',
     });
 
+    // Set up automatic and integration-triggered injection of client into
+    // iframes in this frame.
+    this._hypothesisInjector = new HypothesisInjector(this.element, config);
+
     /**
      * Integration that handles document-type specific functionality in the
      * guest.
@@ -197,10 +201,6 @@ export default class Guest {
      */
     this._sidebarRPC = new PortRPC();
     this._connectSidebar();
-
-    // Set up automatic and integration-triggered injection of client into
-    // iframes in this frame.
-    this._hypothesisInjector = new HypothesisInjector(this.element, config);
 
     this._bucketBarClient =
       this._frameIdentifier === null


### PR DESCRIPTION
Construction of the integration was recently moved to happen earlier in the
Guest.  This caused a regression in the VitalSource integration, which may
synchronously call `Guest#injectClient` when constructed. `injectClient` in turn
relies on `_hypothesisInjector` being initialized, which was not the case.

The error could be seen in the dev server's VS test case at
http://localhost:3000/document/vitalsource-epub.

Fix the issue by moving `_hypothesisInjector` initialization to happen earlier
in the Guest constructor, before `createIntegration` is called.