### PR TITLE
Format `@implements {...}` JSDoc tag

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -79,7 +79,7 @@ function nearestPositionedAncestor(el) {
  * it from the page's styles using shadow DOM, and the `AdderToolbar` Preact
  * component which actually renders the toolbar.
  *
- * @implements Destroyable
+ * @implements {Destroyable}
  */
 export class Adder {
   /**

--- a/src/annotator/bucket-bar-client.js
+++ b/src/annotator/bucket-bar-client.js
@@ -13,7 +13,7 @@ import { ListenerCollection } from '../shared/listener-collection';
  * 1. The set of anchors has been changed (due to annotations being added or removed)
  * 2. The position of anchors relative to the viewport of the guest has changed
  *
- * @implements Destroyable
+ * @implements {Destroyable}
  */
 export class BucketBarClient {
   /**

--- a/src/annotator/bucket-bar.js
+++ b/src/annotator/bucket-bar.js
@@ -11,7 +11,7 @@ import { anchorBuckets } from './util/buckets';
  * Controller for the "bucket bar" shown alongside the sidebar indicating where
  * annotations are in the document.
  *
- * @implements Destroyable
+ * @implements {Destroyable}
  */
 export default class BucketBar {
   /**

--- a/src/annotator/hypothesis-injector.js
+++ b/src/annotator/hypothesis-injector.js
@@ -13,7 +13,7 @@ import { onDocumentReady, FrameObserver } from './frame-observer';
  * `enable-annotation` attribute set (see {@link FrameObserver}) and can be
  * manually injected into other frames using {@link injectClient}.
  *
- * @implements Destroyable
+ * @implements {Destroyable}
  */
 export class HypothesisInjector {
   /**

--- a/src/annotator/notebook.js
+++ b/src/annotator/notebook.js
@@ -4,7 +4,7 @@ import NotebookModal from './components/NotebookModal';
 
 /** @typedef {import('../types/annotator').Destroyable} Destroyable */
 
-/** @implements Destroyable */
+/** @implements {Destroyable} */
 export default class Notebook {
   /**
    * @param {HTMLElement} element

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -53,7 +53,7 @@ function createSidebarIframe(config) {
  * The `Sidebar` class creates (1) the sidebar application iframe, (2) its container,
  * as well as (3) the adjacent controls.
  *
- * @implements Destroyable
+ * @implements {Destroyable}
  */
 export default class Sidebar {
   /**

--- a/src/annotator/util/emitter.js
+++ b/src/annotator/util/emitter.js
@@ -8,7 +8,7 @@ import { TinyEmitter } from 'tiny-emitter';
  * The different elements of the application can communicate with each other
  * without being tightly coupled.
  *
- * @implements Destroyable
+ * @implements {Destroyable}
  */
 export class Emitter {
   /**

--- a/src/shared/port-finder.js
+++ b/src/shared/port-finder.js
@@ -18,7 +18,7 @@ export const POLLING_INTERVAL_FOR_PORT = 250;
  * MessagePort-based connection to other frames. It is used together with
  * PortProvider which runs in the host frame. See PortProvider for an overview.
  *
- * @implements Destroyable
+ * @implements {Destroyable}
  */
 export class PortFinder {
   /**

--- a/src/shared/port-provider.js
+++ b/src/shared/port-provider.js
@@ -56,7 +56,7 @@ import { isMessage, isMessageEqual, isSourceWindow } from './port-util';
  *                                                           (eg. via MessageChannel connection
  *                                                           between host and other frame)
  *
- * @implements Destroyable
+ * @implements {Destroyable}
  */
 export class PortProvider {
   /**

--- a/src/shared/port-rpc.js
+++ b/src/shared/port-rpc.js
@@ -64,7 +64,7 @@ const PROTOCOL = 'frame-rpc';
  *
  * @template {string} OnMethod - Names of RPC methods this client responds to
  * @template {string} CallMethod - Names of RPC methods this client invokes
- * @implements Destroyable
+ * @implements {Destroyable}
  */
 export class PortRPC {
   constructor() {


### PR DESCRIPTION
The `@implements` tag works with or without braces. We decided to
include braces following the documentation at JSDoc:

https://jsdoc.app/tags-implements.html

See also: https://github.com/hypothesis/client/pull/4048/files#r786462923