### PR TITLE
Highlight the annotation's anchor on mouseover

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -269,13 +269,13 @@ export default class Guest {
     this._listeners.add(this.element, 'mouseover', ({ target }) => {
       const tags = annotationsAt(/** @type {Element} */ (target));
       if (tags.length && this._highlightsVisible) {
-        this._sidebarRPC.call('focusAnnotations', tags);
+        this._focusAnnotations(tags);
       }
     });
 
     this._listeners.add(this.element, 'mouseout', () => {
       if (this._highlightsVisible) {
-        this._sidebarRPC.call('focusAnnotations', []);
+        this._focusAnnotations([]);
       }
     });
 


### PR DESCRIPTION
Previously, when a user hover on an annotation it didn't change the
color of the anchor.

With this change, hovering an annotation result in the anchors to be
highlighted. The UI behaviour is therefore identical when hovering on an
annotation card in the sidebar, on an bucket in the bucket bar, or on an
annotation in the actual text.

### Before

https://user-images.githubusercontent.com/8555781/150350023-53e98956-483e-41bb-9836-993156e2bcc6.mov

### After

https://user-images.githubusercontent.com/8555781/150349993-46963f96-b120-4c55-ad2a-66e97c6e4b55.mov

With overlapping annotations:

https://user-images.githubusercontent.com/8555781/150351313-01be77ae-7265-4fab-bacb-70d902d6f642.mov

