### PR TITLE
Revise how guest notifies host and sidebar when it is unloaded

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -482,6 +482,16 @@ export default class Guest {
   _sendUnloadNotification() {
     const ports = [];
 
+    // There is currently a race condition where the guest can fail to notify
+    // the host and sidebar when it unloads if it has not yet received its ports
+    // for guest-host and guest-sidebar commmunication.
+    //
+    // For the moment this can be tolerated as guest frames are not displayed in
+    // the sidebar until the guest has received the port and sent a
+    // `documentInfoChanged` notification on it. Nevertheless the host / sidebar
+    // will be left with a disconnected PortRPC for the guest, so we should aim
+    // to fix this in future.
+
     const sidebarPort = this._sidebarRPC.disconnect();
     if (sidebarPort) {
       ports.push(sidebarPort);

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -109,6 +109,7 @@ describe('Guest', () => {
         call: sinon.stub(),
         connect: sinon.stub(),
         destroy: sinon.stub(),
+        disconnect: sinon.stub(),
         on: sinon.stub(),
       };
       fakePortRPCs.push(rpc);
@@ -1244,7 +1245,12 @@ describe('Guest', () => {
     });
 
     it('notifies host frame that guest has been unloaded', () => {
+      const sidebarPort = {};
+      const hostPort = {};
+
       const guest = createGuest({ subFrameIdentifier: 'frame-id' });
+      hostRPC().disconnect.returns(hostPort);
+      sidebarRPC().disconnect.returns(sidebarPort);
 
       guest.destroy();
 
@@ -1252,15 +1258,19 @@ describe('Guest', () => {
         hostFrame.postMessage,
         {
           type: 'hypothesisGuestUnloaded',
-          frameIdentifier: 'frame-id',
         },
-        '*'
+        '*',
+        sinon.match.array.contains([sidebarPort, hostPort])
       );
     });
   });
 
   it('notifies host frame when guest frame is unloaded', () => {
+    const sidebarPort = {};
+    const hostPort = {};
     createGuest({ subFrameIdentifier: 'frame-id' });
+    hostRPC().disconnect.returns(hostPort);
+    sidebarRPC().disconnect.returns(sidebarPort);
 
     window.dispatchEvent(new Event('unload'));
 
@@ -1268,9 +1278,9 @@ describe('Guest', () => {
       hostFrame.postMessage,
       {
         type: 'hypothesisGuestUnloaded',
-        frameIdentifier: 'frame-id',
       },
-      '*'
+      '*',
+      sinon.match.array.contains([sidebarPort, hostPort])
     );
   });
 

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1245,11 +1245,12 @@ describe('Guest', () => {
     });
 
     it('notifies host frame that guest has been unloaded', () => {
-      const sidebarPort = {};
-      const hostPort = {};
-
       const guest = createGuest({ subFrameIdentifier: 'frame-id' });
+
+      const hostPort = {};
       hostRPC().disconnect.returns(hostPort);
+
+      const sidebarPort = {};
       sidebarRPC().disconnect.returns(sidebarPort);
 
       guest.destroy();
@@ -1265,11 +1266,13 @@ describe('Guest', () => {
     });
   });
 
-  it('notifies host frame when guest frame is unloaded', () => {
-    const sidebarPort = {};
-    const hostPort = {};
+  it('notifies host and sidebar frames when guest is unloaded', () => {
     createGuest({ subFrameIdentifier: 'frame-id' });
+
+    const hostPort = {};
     hostRPC().disconnect.returns(hostPort);
+
+    const sidebarPort = {};
     sidebarRPC().disconnect.returns(sidebarPort);
 
     window.dispatchEvent(new Event('unload'));

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -48,8 +48,11 @@ describe('anchoring', () => {
     container = document.createElement('div');
     container.innerHTML = testPageHTML;
     document.body.appendChild(container);
+
     const fakePortFinder = {
-      discover: sinon.stub().resolves(new MessageChannel().port1),
+      discover: sinon.stub().callsFake(async () => {
+        return new MessageChannel().port1;
+      }),
       destroy: sinon.stub(),
     };
     guestImports.$mock({
@@ -57,6 +60,7 @@ describe('anchoring', () => {
         PortFinder: sinon.stub().returns(fakePortFinder),
       },
     });
+
     guest = new Guest(container);
   });
 

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -497,6 +497,23 @@ describe('Sidebar', () => {
         assert.calledOnce(sidebar.bucketBar.update);
       });
     });
+
+    describe('on "frameDestroyed" event', () => {
+      it('disconnects the guest', () => {
+        const sidebar = createSidebar();
+        connectGuest(sidebar);
+        guestRPC().call.resetHistory();
+
+        emitGuestEvent('frameDestroyed');
+
+        assert.called(guestRPC().destroy);
+
+        // Trigger a notification to all connected guests. This should no longer
+        // be sent to the guest that has just been disconnected.
+        sidebar.open();
+        assert.notCalled(guestRPC().call);
+      });
+    });
   });
 
   describe('pan gestures', () => {

--- a/src/shared/messaging/port-rpc.js
+++ b/src/shared/messaging/port-rpc.js
@@ -123,13 +123,24 @@ export class PortRPC {
   }
 
   /**
-   * Disconnect the RPC channel. After this is invoked no further method calls
-   * will be received.
+   * Disconnect and return the current MessagePort.
+   *
+   * This does not close the port, so it can still be used afterwards.
+   */
+  disconnect() {
+    const port = this._port;
+    this._port = null;
+    this._listeners.removeAll();
+    return port;
+  }
+
+  /**
+   * Disconnect the RPC channel and close the MessagePort.
    */
   destroy() {
+    const port = this.disconnect();
+    port?.close();
     this._destroyed = true;
-    this._listeners.removeAll();
-    this._port?.close();
   }
 
   /**

--- a/src/shared/messaging/test/port-rpc-test.js
+++ b/src/shared/messaging/test/port-rpc-test.js
@@ -174,4 +174,24 @@ describe('PortRPC', () => {
     assert.calledWith(testMethod, 'first', 'call');
     assert.calledWith(testMethod, 'second', 'call');
   });
+
+  describe('#disconnect', () => {
+    it('disconnects and returns port', async () => {
+      const rpc = new PortRPC();
+      const testMethod = sinon.stub();
+      rpc.on('test', testMethod);
+
+      assert.isNull(rpc.disconnect());
+
+      const { port1 } = new MessageChannel();
+      rpc.connect(port1);
+
+      assert.equal(rpc.disconnect(), port1);
+      assert.isNull(rpc.disconnect());
+
+      rpc.call('test');
+      await waitForMessageDelivery();
+      assert.notCalled(testMethod);
+    });
+  });
 });

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -472,12 +472,25 @@ describe('FrameSyncService', () => {
     });
   });
 
-  context('when a frame is destroyed', () => {
-    const frameId = fixtures.framesListEntry.id;
-
-    it('removes the frame from the frames list', () => {
+  context('when a guest frame is destroyed', () => {
+    it('disconnects the guest', async () => {
       frameSync.connect();
-      emitHostEvent('frameDestroyed', frameId);
+      await connectGuest();
+
+      emitGuestEvent('frameDestroyed');
+
+      assert.called(guestRPC().destroy);
+    });
+
+    it('removes the guest from the store', async () => {
+      frameSync.connect();
+      await connectGuest();
+
+      emitGuestEvent('documentInfoChanged', {
+        frameIdentifier: fixtures.framesListEntry.id,
+        uri: 'http://example.org',
+      });
+      emitGuestEvent('frameDestroyed');
 
       assert.calledWith(fakeStore.destroyFrame, fixtures.framesListEntry);
     });

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -20,7 +20,10 @@ export type GuestToHostEvent =
   /**
    * The guest informs the host that the anchors have been changed in the main annotatable frame.
    */
-  | 'anchorsChanged';
+  | 'anchorsChanged'
+
+  /** The guest was unloaded. */
+  | 'frameDestroyed';
 
 /**
  * Events that the guest sends to the sidebar
@@ -62,7 +65,10 @@ export type GuestToSidebarEvent =
   /**
    * The guest is asking the sidebar to toggle some annotations.
    */
-  | 'toggleAnnotationSelection';
+  | 'toggleAnnotationSelection'
+
+  /** The guest frame was unloaded. */
+  | 'frameDestroyed';
 
 /**
  * Events that the host sends to the guest
@@ -102,11 +108,6 @@ export type HostToGuestEvent =
  * Events that the host sends to the sidebar
  */
 export type HostToSidebarEvent =
-  /**
-   * The host informs the sidebar that a guest frame has been destroyed
-   */
-  | 'frameDestroyed'
-
   /**
    * Highlights have been toggled on/off.
    */


### PR DESCRIPTION
Change how the guest notifies other frames, specifically the sidebar and host,
when it is unloaded. The host and sidebar now receive a `frameDestroyed` message
from the corresponding guest port, which allows them to easily close the right
port and remove it from the list of active guest ports.

Due to a Safari bug (see code comments) we can't send the `frameDestroyed`
messages from the guest frame while it is being unloaded. However it is possible
to first transfer the port to the host frame and then have the host frame send
the message on the same port. I also tried sending the message from the guest
frame, and then transferring the port to the host frame, but that didn't work.
This workaround has the advantage that it is transparent to the receiver of the
`frameDestroyed` message.

This change is also a step towards possibly not relying on user-provided guest
frame identifiers in the sidebar, which only become available once the
`documentInfoChanged` call has been received. Instead the sidebar could
use its own internal IDs for guest frames, avoiding the possibility for
conflicts.

Changes in detail:

 - Add `disconnect` method to PortRPC. This disconnects the MessagePort (if any) from the PortRPC and returns it. This allows the port to be transferred to another frame.

 - When guest is unloaded, transfer ports to the host frame in a
   `hypothesisGuestUnloaded` message, and make the host frame dispatch
   `frameDestroyed` calls on these ports.

 - Handle `frameDestroyed` in sidebar by closing port, removing it from
   the active guest list and removing the associated frame from the
   store

 - Handle `frameDestroyed` in host frame by closing port and removing it
   from the active guest list

---

**Testing:**

In Safari, Chrome and Firefox:

1. Load the example at http://localhost:3000/document/vitalsource-epub
2. Click the "Next chapter" and "Prev chapter" buttons to navigate backwards and forwards
3. Click on Help => About this version in the sidebar, and check that the "URLs" field shows two entries, one for the host page and one for the current guest chapter.
