### PR TITLE
Only send annotations to matching frame

### DIFF
--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -225,12 +225,15 @@ export class FrameSyncService {
     /** @type {PortRPC<GuestToSidebarEvent, SidebarToGuestEvent>} */
     const guestRPC = new PortRPC();
 
-    // Generate a temporary ID for this guest until we learn its "real" ID.
+    // Add guest RPC to map with a temporary ID until we learn the real ID.
+    //
+    // We need to add the guest to the map immediately so that any notifications
+    // sent from this service to all guests, before we learn the real frame ID,
+    // are sent to this new guest.
     ++this._nextGuestId;
     let frameIdentifier = /** @type {string|null} */ (
       `temp-${this._nextGuestId}`
     );
-
     this._guestRPC.set(frameIdentifier, guestRPC);
 
     // Update document metadata for this guest. We currently assume that the

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -35,22 +35,18 @@ export function formatAnnot({ $tag, target, uri }) {
 }
 
 /**
- * Return the frame in `frames` which best matches `ann`.
+ * Return the frame which best matches an annotation.
+ *
+ * If there is a frame whose URL exactly matches the annotation, it will be
+ * returned. Otherwise the main frame will be returned. Currently this may fail
+ * to return the expected frame if an annotation was fetched from h that
+ * does not match one of the frame URIs. This can happen due to URI expansion /
+ * document equivalence in h.
  *
  * @param {Frame[]} frames
  * @param {Annotation} ann
  */
 function frameForAnnotation(frames, ann) {
-  // Choose the frame whose URL exactly matches this annotation. If there is
-  // none, we'll use the main frame.
-  //
-  // An annotation's URI may not match the frame URI. To handle these
-  // cases we'll need to either make separate search API calls for each
-  // frame, or get the backend to return information about which search
-  // URIs matched a frame.
-  //
-  // If there are multiple frames with a matching URI, we'll send it
-  // whichever one connected first, which is usually the main frame.
   const frame = frames.find(f => f.uri === ann.uri);
   if (frame) {
     return frame;

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -14,8 +14,10 @@ class FakeWindow extends EventTarget {
   }
 }
 
+const testAnnotation = annotationFixtures.defaultAnnotation();
+
 const fixtures = {
-  ann: Object.assign({ $tag: 't1' }, annotationFixtures.defaultAnnotation()),
+  ann: { $tag: 't1', ...testAnnotation },
 
   // New annotation received from the frame
   newAnnFromFrame: {
@@ -28,11 +30,13 @@ const fixtures = {
   // Argument to the `documentInfoChanged` call made by a guest displaying an HTML
   // document.
   htmlDocumentInfo: {
-    uri: 'http://example.org',
+    uri: testAnnotation.uri,
     metadata: {
       link: [],
     },
-    frameIdentifier: null,
+
+    // This should match the guest frame ID from `framesListEntry`.
+    frameIdentifier: 'abc',
   },
 
   // The entry in the list of frames currently connected
@@ -200,7 +204,9 @@ describe('FrameSyncService', () => {
     });
 
     it('sends a "loadAnnotations" message to the frame', async () => {
+      const frameInfo = fixtures.htmlDocumentInfo;
       await connectGuest();
+      emitGuestEvent('documentInfoChanged', frameInfo);
 
       fakeStore.setState({
         annotations: [fixtures.ann],
@@ -214,7 +220,9 @@ describe('FrameSyncService', () => {
     });
 
     it('sends a "loadAnnotations" message only for new annotations', async () => {
+      const frameInfo = fixtures.htmlDocumentInfo;
       await connectGuest();
+      emitGuestEvent('documentInfoChanged', frameInfo);
 
       const ann2 = Object.assign({}, fixtures.ann, { $tag: 't2', id: 'a2' });
       fakeStore.setState({


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/4129**

When the sidebar is connected to multiple guest frames it will send all
incoming annotations to all frames. The result is typically that the
annotation will anchor in one frame and orphan in the others. Depending
on what order this happens in, the annotation will non-deterministically
show up as an Annotation or Orphan in the sidebar.

In order to determine which frames an annotation should be sent to in
all cases, we'd either need the backend to return information about which
search URIs an annotation matches or make a separate search request for
each frame and record the associated frame with the results. This
will require some significant refactoring of the annotation search
service.

As an interim step, make `FrameSyncService` send annotations only to a
single frame based on matching URL, with a fallback to sending to the
main frame if there is no exact match. This will work as expected for
most pages, and is at least deterministic when it does fail. When we
have a solution for being able to match annotations to frames more
generally, we can adapt this code to use it.

This is a partial solution to https://github.com/hypothesis/client/issues/3992.

**TODO:**

- [x] FrameSyncService needs some additional tests to cover the new behaviors.
- [x] Test this with VitalSource using the browser extension

**Testing:**

In one of the dev server test pages that contains an annotation-enabled iframe, try annotating the host frame (if possible) and the iframe, and then reload the page several times.

On master, annotations may sometimes appear in the "Orphans" tab. On this branch, all the annotations should consistently anchor in the expected frame.
