### PR TITLE
Fix port discovery after a guest iframe is navigated

### DIFF
--- a/src/shared/messaging/port-finder.js
+++ b/src/shared/messaging/port-finder.js
@@ -1,4 +1,5 @@
 import { ListenerCollection } from '../listener-collection';
+import { generateHexString } from '../random';
 import { isMessageEqual } from './port-util';
 
 /** Timeout for waiting for the host frame to respond to a port request. */
@@ -58,6 +59,8 @@ export class PortFinder {
       throw new Error('Invalid request of channel/port');
     }
 
+    const requestId = generateHexString(6);
+
     return new Promise((resolve, reject) => {
       const postRequest = () => {
         this._hostFrame.postMessage(
@@ -65,6 +68,7 @@ export class PortFinder {
             frame1: this._source,
             frame2: target,
             type: 'request',
+            requestId,
           },
           '*'
         );
@@ -96,6 +100,7 @@ export class PortFinder {
             frame1: this._source,
             frame2: target,
             type: 'offer',
+            requestId,
           })
         ) {
           clearInterval(intervalId);

--- a/src/shared/messaging/port-provider.js
+++ b/src/shared/messaging/port-provider.js
@@ -139,7 +139,7 @@ export class PortProvider {
     const handleRequest = event => {
       const { data, origin, source } = /** @type {MessageEvent} */ (event);
 
-      if (!isMessage(data) || data.type !== 'request' || !data.requestId) {
+      if (!isMessage(data) || data.type !== 'request') {
         // If this does not look like a message intended for us, ignore it.
         return;
       }

--- a/src/shared/messaging/port-util.js
+++ b/src/shared/messaging/port-util.js
@@ -24,7 +24,7 @@ export function isMessage(data) {
     return false;
   }
 
-  for (let property of ['frame1', 'frame2', 'type']) {
+  for (let property of ['frame1', 'frame2', 'type', 'requestId']) {
     if (typeof data[property] !== 'string') {
       return false;
     }

--- a/src/shared/messaging/port-util.js
+++ b/src/shared/messaging/port-util.js
@@ -8,6 +8,8 @@
  * @prop {Frame} frame1
  * @prop {Frame} frame2
  * @prop {'offer'|'request'} type
+ * @prop {string} requestId - ID of the request. Used to associate `offer`
+ *   responses with requests and enable PortProvider to ignore re-sent requests.
  */
 
 /**
@@ -35,7 +37,7 @@ export function isMessage(data) {
  * Return true if the data payload from a MessageEvent matches `message`.
  *
  * @param {any} data
- * @param {Message} message
+ * @param {Partial<Message>} message
  */
 export function isMessageEqual(data, message) {
   if (!isMessage(data)) {

--- a/src/shared/messaging/test/port-provider-test.js
+++ b/src/shared/messaging/test/port-provider-test.js
@@ -40,6 +40,7 @@ describe('PortProvider', () => {
           frame1: 'sidebar',
           frame2: 'host',
           type: 'request',
+          requestId: 'abcdef',
         },
       });
 
@@ -60,14 +61,24 @@ describe('PortProvider', () => {
 
     it('reports errors validating messages', async () => {
       await sendPortFinderRequest({
-        data: { frame1: 'sidebar', frame2: 'invalid', type: 'request' },
+        data: {
+          frame1: 'sidebar',
+          frame2: 'invalid',
+          type: 'request',
+          requestId: 'abcdef',
+        },
       });
       assert.called(fakeSendError);
     });
 
     it('only reports errors once', async () => {
       const request = {
-        data: { frame1: 'sidebar', frame2: 'invalid', type: 'request' },
+        data: {
+          frame1: 'sidebar',
+          frame2: 'invalid',
+          type: 'request',
+          requestId: 'abcdef',
+        },
       };
       await sendPortFinderRequest(request);
       await sendPortFinderRequest(request);
@@ -87,6 +98,7 @@ describe('PortProvider', () => {
           frame1: 'dummy', // invalid source
           frame2: 'host',
           type: 'request',
+          requestId: 'abcdef',
         },
         reason: 'contains an invalid frame1',
       },
@@ -95,6 +107,7 @@ describe('PortProvider', () => {
           frame1: 'sidebar',
           frame2: 'dummy', // invalid target
           type: 'request',
+          requestId: 'abcdef',
         },
         reason: 'contains an invalid frame2',
       },
@@ -103,6 +116,7 @@ describe('PortProvider', () => {
           frame1: 'sidebar',
           frame2: 'host',
           type: 'dummy', // invalid type
+          requestId: 'abcdef',
         },
         reason: 'contains an invalid type',
       },
@@ -111,6 +125,7 @@ describe('PortProvider', () => {
           frame1: 'sidebar',
           frame2: 'host',
           type: 'request',
+          requestId: 'abcdef',
         },
         source: null,
         reason: 'comes from invalid source',
@@ -120,6 +135,7 @@ describe('PortProvider', () => {
           frame1: 'sidebar',
           frame2: 'host',
           type: 'request',
+          requestId: 'abcdef',
         },
         origin: 'https://dummy.com',
         reason: 'comes from invalid origin',
@@ -141,6 +157,7 @@ describe('PortProvider', () => {
         frame1: 'sidebar',
         frame2: 'host',
         type: 'request',
+        requestId: 'abcdef',
       };
 
       await sendPortFinderRequest({
@@ -160,6 +177,7 @@ describe('PortProvider', () => {
         frame1: 'guest',
         frame2: 'sidebar',
         type: 'request',
+        requestId: 'abcdef',
       };
 
       await sendPortFinderRequest({ data, origin: 'null' });
@@ -174,6 +192,7 @@ describe('PortProvider', () => {
         frame1: 'guest',
         frame2: 'sidebar',
         type: 'request',
+        requestId: 'abcdef',
       };
 
       for (let i = 0; i < 4; ++i) {
@@ -196,6 +215,7 @@ describe('PortProvider', () => {
           frame1: 'sidebar',
           frame2: 'host',
           type: 'request',
+          requestId: 'abcdef',
         },
       });
 
@@ -207,6 +227,7 @@ describe('PortProvider', () => {
         frame1: 'guest',
         frame2: 'sidebar',
         type: 'request',
+        requestId: 'ghijkl',
       };
       await sendPortFinderRequest({
         data,
@@ -228,6 +249,7 @@ describe('PortProvider', () => {
           frame1: 'sidebar',
           frame2: 'host',
           type: 'request',
+          requestId: 'abcdef',
         },
       });
 
@@ -243,6 +265,7 @@ describe('PortProvider', () => {
           frame1: 'guest',
           frame2: 'host',
           type: 'request',
+          requestId: 'ghijkl',
         },
       });
 

--- a/src/shared/messaging/test/port-util-test.js
+++ b/src/shared/messaging/test/port-util-test.js
@@ -7,6 +7,7 @@ describe('port-util', () => {
         frame1: 'guest',
         frame2: 'sidebar',
         type: 'request',
+        requestId: 'abcdef',
       },
 
       {
@@ -38,6 +39,7 @@ describe('port-util', () => {
     const frame1 = 'guest';
     const frame2 = 'sidebar';
     const type = 'offer';
+    const requestId = 'abcdef';
 
     [
       {
@@ -45,6 +47,7 @@ describe('port-util', () => {
           frame1,
           frame2,
           type,
+          requestId,
         },
         expectedResult: true,
         reason: 'data matches the message',
@@ -54,6 +57,7 @@ describe('port-util', () => {
           frame1,
           frame2,
           type,
+          requestId,
         },
         expectedResult: true,
         reason: 'data matches the message (properties in different order)',
@@ -73,6 +77,7 @@ describe('port-util', () => {
           // frame1 property missing
           frame2,
           type,
+          requestId,
         },
         expectedResult: false,
         reason: 'data has one property that is missing',
@@ -82,6 +87,7 @@ describe('port-util', () => {
           frame1,
           frame2: 9, // wrong type
           type,
+          requestId,
         },
         expectedResult: false,
         reason: 'data has one property with a wrong type',
@@ -91,6 +97,7 @@ describe('port-util', () => {
           frame1: 'dummy', // different
           frame2,
           type,
+          requestId,
         },
         expectedResult: false,
         reason: 'data has one property that is different',

--- a/src/shared/messaging/test/port-util-test.js
+++ b/src/shared/messaging/test/port-util-test.js
@@ -14,6 +14,7 @@ describe('port-util', () => {
         frame1: 'guest',
         frame2: 'sidebar',
         type: 'request',
+        requestId: 'bar',
         extraField: 'foo',
       },
     ].forEach(data => {
@@ -27,7 +28,15 @@ describe('port-util', () => {
       undefined,
       {},
       'str',
-      { frame1: 'guest', frame2: false, type: 'request' },
+
+      // Wrong type for a property
+      { frame1: 'guest', frame2: false, type: 'request', requestId: 'bar' },
+
+      // Missing properties
+      { frame2: 'sidebar', type: 'request', requestId: 'r1' }, // Missing 'frame1'
+      { frame1: 'guest', type: 'request', requestId: 'r1' }, // Missing 'frame2'
+      { frame1: 'guest', frame2: 'sidebar', requestId: 'r1' }, // Missing 'type'
+      { frame1: 'guest', frame2: 'sidebar', type: 'request' }, // Missing 'requestId'
     ].forEach(data => {
       it('returns false if data is not a valid message', () => {
         assert.isFalse(isMessage(data));

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -171,6 +171,7 @@ describe('FrameSyncService', () => {
         frame1: 'guest',
         frame2: 'sidebar',
         type: 'offer',
+        requestId: 'abc',
       },
       [port1]
     );


### PR DESCRIPTION
PortProvider previously used a `WeakMap<Window, Set<Channel>>` to keep
track of which ports had been requested from a particular source frame,
where the map keys came from `MessageEvent.source`. A problem with this
approach is that for messages from an iframe, `MessageEvent.source` refers to a
`WindowProxy` which retains the same identity across page navigations.
As a result if a guest iframe was navigated to a new page which also
embedded the client as a guest (or into which the client was
subsequently injected as a guest), the guest in the new document would
not be able to retrieve any ports.

Implement a fix whereby each call to `PortFinder.discover` generates a
random request ID which is sent with the initial port request plus any
re-sent requests. PortProvider then keeps track of the request IDs it
has seen and ignores messages with a previously seen request ID.

This change would also fix port discovery if the guest in a frame was
unloaded and later re-loaded.