### PR TITLE
Handle multi-step chapter load process more reliably in VitalSource integration

### DIFF
--- a/dev-server/documents/html/vitalsource-epub.mustache
+++ b/dev-server/documents/html/vitalsource-epub.mustache
@@ -27,7 +27,7 @@
 
           let chapterIndex = 0;
 
-          const setChapter = index => {
+          const setChapter = (index, initialLoad = false) => {
             if (index < 0 || index >= chapterURLs.length) {
               return;
             }
@@ -38,8 +38,31 @@
             // does. The client should be robust to either approach.
             this.contentFrame?.remove();
             this.contentFrame = document.createElement('iframe');
-            this.contentFrame.src = chapterURLs[chapterIndex];
             this.shadowRoot.append(this.contentFrame);
+
+            const chapterURL = chapterURLs[chapterIndex];
+
+            if (initialLoad) {
+              // Simulate client loading after VS chapter content has already
+              // loaded.
+              this.contentFrame.src = chapterURL;
+            } else {
+              // Simulate chapter navigation after client is injected. These
+              // navigations happen in several stages:
+              //
+              // 1. The previous chapter's iframe is removed
+              // 2. A new iframe is created. The initial HTML is a "blank" page
+              //    containing (invisible) content data for the new chapter as
+              //    text in the page.
+              // 3. The content data is posted to the server via a form
+              //    submission, which returns the decoded HTML.
+              //
+              // The client should only inject into the new frame after step 3.
+              this.contentFrame.src = 'about:blank';
+              setTimeout(() => {
+                this.contentFrame.src = chapterURL;
+              }, 50);
+            }
           };
 
           const styles = document.createElement('style');
@@ -66,7 +89,7 @@
           this.nextButton.onclick = () => setChapter(chapterIndex + 1);
           controlBar.append(this.nextButton);
 
-          setChapter(0);
+          setChapter(0, true /* initialLoad */);
         }
       }
       customElements.define('mosaic-book', MosaicElement);

--- a/dev-server/documents/html/vitalsource-epub.mustache
+++ b/dev-server/documents/html/vitalsource-epub.mustache
@@ -60,7 +60,9 @@
               // The client should only inject into the new frame after step 3.
               this.contentFrame.src = 'about:blank';
               setTimeout(() => {
-                this.contentFrame.src = chapterURL;
+                // Set the final URL in a way that doesn't update the `src` attribute
+                // of the iframe, to make sure the client isn't relying on that.
+                this.contentFrame.contentWindow.location.href = chapterURL;
               }, 50);
             }
           };

--- a/dev-server/documents/html/vitalsource-epub.mustache
+++ b/dev-server/documents/html/vitalsource-epub.mustache
@@ -27,7 +27,7 @@
 
           let chapterIndex = 0;
 
-          const setChapter = (index, initialLoad = false) => {
+          const setChapter = (index, { initialLoad = false } = {}) => {
             if (index < 0 || index >= chapterURLs.length) {
               return;
             }
@@ -89,7 +89,7 @@
           this.nextButton.onclick = () => setChapter(chapterIndex + 1);
           controlBar.append(this.nextButton);
 
-          setChapter(0, true /* initialLoad */);
+          setChapter(0, { initialLoad: true });
         }
       }
       customElements.define('mosaic-book', MosaicElement);

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -137,6 +137,31 @@ describe('annotator/integrations/vitalsource', () => {
       assert.calledWith(fakeGuest.injectClient, fakeViewer.contentFrame);
     });
 
+    it("doesn't re-inject if content frame is removed", async () => {
+      fakeGuest.injectClient.resetHistory();
+
+      // Remove the content frame. This will trigger a re-injection check, but
+      // do nothing as there is no content frame.
+      fakeViewer.contentFrame.remove();
+      await delay(0);
+
+      assert.notCalled(fakeGuest.injectClient);
+    });
+
+    it("doesn't re-inject if content frame siblings change", async () => {
+      fakeGuest.injectClient.resetHistory();
+
+      // Modify the DOM tree. This will trigger a re-injection check, but do
+      // nothing as we've already handled the current frame.
+      fakeViewer.contentFrame.insertAdjacentElement(
+        'afterend',
+        document.createElement('div')
+      );
+      await delay(0);
+
+      assert.notCalled(fakeGuest.injectClient);
+    });
+
     it('does not allow annotation in the container frame', async () => {
       assert.equal(integration.canAnnotate(), false);
 

--- a/src/annotator/integrations/vitalsource.js
+++ b/src/annotator/integrations/vitalsource.js
@@ -67,6 +67,9 @@ export class VitalSourceContainerIntegration {
       //
       // The format of the decoded HTML can vary, but as a simple heuristic,
       // we look for a text paragraph.
+      //
+      // If the document has not yet finished loading, then we rely on this function
+      // being called again once loading completes.
       const isBookContent = frame.contentDocument?.querySelector('p');
       if (isBookContent) {
         annotator.injectClient(frame);
@@ -77,6 +80,7 @@ export class VitalSourceContainerIntegration {
     const injectClientIntoContentFrame = () => {
       const frame = shadowRoot.querySelector('iframe');
       if (!frame || contentFrames.has(frame)) {
+        // Either there is no content frame or we are already watching it.
         return;
       }
       contentFrames.add(frame);
@@ -90,9 +94,6 @@ export class VitalSourceContainerIntegration {
     injectClientIntoContentFrame();
 
     // Re-inject client into content frame after a chapter navigation.
-    //
-    // We currently don't do any debouncing here and rely on `injectClient` to
-    // be idempotent and cheap.
     this._frameObserver = new MutationObserver(injectClientIntoContentFrame);
     this._frameObserver.observe(shadowRoot, { childList: true, subtree: true });
   }

--- a/src/annotator/integrations/vitalsource.js
+++ b/src/annotator/integrations/vitalsource.js
@@ -60,10 +60,10 @@ export class VitalSourceContainerIntegration {
 
     /** @param {HTMLIFrameElement} frame */
     const injectIfContentReady = frame => {
-      // Check if this frame contains ebook content, as opposed to being a
-      // "blank" frame containing encrypted book content, as hidden text,
-      // which is created initially after a chapter navigation. These "blank"
-      // pages are replaced with the real content after a form submission.
+      // Check if this frame contains decoded ebook content, as opposed to
+      // invisible and encrypted book content, which is created initially after a
+      // chapter navigation. These encrypted pages are replaced with the real
+      // content after a form submission.
       //
       // The format of the decoded HTML can vary, but as a simple heuristic,
       // we look for a text paragraph.


### PR DESCRIPTION
Injection of the client into a new chapter/section after navigating chapters/pages in VitalSource did not always work reliably. The issue is that the real VS viewer loads new chapters/pages in multiple steps:

1. It removes the iframe for the previous chapter/page
2. It creates an iframe for the new chapter/page. The iframe URL that is initially loaded returns a "blank" page containing some encrypted data for the book. You can see this if you look at the document request made after a navigation in devtools:  <img width="700" alt="Initial content request" src="https://user-images.githubusercontent.com/2458/150815572-02866dce-d132-4cce-ad73-7418d10f0aaf.png">
3. Finally it makes a form submission using the content from the initial request as a payload. This returns the actual HTML: <img width="694" alt="Decoded content request" src="https://user-images.githubusercontent.com/2458/150815765-94d1c040-0a97-4126-97bf-c13bb78234cb.png">

The client previously tried to inject itself as soon as it detected the new iframe, and did not react if that iframe was later navigated. As a result, it would sometimes inject itself after stage 2 and failed to re-inject itself after stage 3. As a result, the new chapter content could not be annotated.

Summary of changes:

1. The first commit updates the test page at http://localhost:3000/document/vitalsource-epub to emulate this behavior of the real VS viewer
2. The the second commit updates the VitalSource integration to handle this behavior more reliably, by avoiding injecting the client into the initial "blank" frame and listening for `load` events on the new chapter's iframe to respond to the real content loading