### PR TITLE
Remove obsolete reference to `__hypothesis` global

### DIFF
--- a/src/annotator/hypothesis-injector.js
+++ b/src/annotator/hypothesis-injector.js
@@ -85,13 +85,13 @@ export class HypothesisInjector {
 }
 
 /**
- * Check if the Hypothesis client has already been injected into an iframe
+ * Check if the client was added to a frame by {@link injectHypothesis}.
  *
  * @param {HTMLIFrameElement} iframe
  */
 function hasHypothesis(iframe) {
-  const iframeWindow = /** @type {Window} */ (iframe.contentWindow);
-  return '__hypothesis' in iframeWindow;
+  const iframeDocument = /** @type {Document} */ (iframe.contentDocument);
+  return iframeDocument.querySelector('script.js-hypothesis-config') !== null;
 }
 
 /**

--- a/src/annotator/test/integration/hypothesis-injector-test.js
+++ b/src/annotator/test/integration/hypothesis-injector-test.js
@@ -155,7 +155,11 @@ describe('HypothesisInjector integration test', () => {
 
   it('excludes injection from already injected iframes', async () => {
     const iframe = createAnnotatableIFrame();
-    iframe.contentWindow.eval('window.__hypothesis = {}');
+
+    // Add a client config in the same way as the injector.
+    const configScript = document.createElement('script');
+    configScript.className = 'js-hypothesis-config';
+    iframe.contentDocument.body.append(configScript);
 
     createHypothesisInjector();
     await onDocumentReady(iframe);


### PR DESCRIPTION
The `hasHypothesis` function always returned false because it relied on a global
variable that no longer exists. The fact that it was broken didn't cause
noticeable problems because the client's boot script also has a check for
whether Hypothesis is already injected.

Replace the broken check with a working one that corresponds to the nearby
`injectHypothesis` function.