### PR TITLE
Get WebSocket URL from /api/links endpoint

### DIFF
--- a/src/types/config.js
+++ b/src/types/config.js
@@ -50,7 +50,6 @@
  * @prop {string} oauthClientId
  * @prop {string[]} rpcAllowedOrigins
  * @prop {SentryConfig} [sentry]
- * @prop {string} [websocketUrl]
  */
 
 /**


### PR DESCRIPTION
Get the WebSocket URL from the /api/links endpoint instead of the `websocketUrl`
configuration in app.html. This ensures that the client uses the correct
WebSocket endpoint for the h API service it is currently talking to, which may
be different than the default when  `services` configuration is specified. This is currently the case in the Canada LMS environment for example.

When updating the tests, several had to be reworked to be less sensitive
to the number of microtask ticks in between certain events.

This depends on the h change in https://github.com/hypothesis/h/pull/7253.