### PR TITLE
Implement side-by-side mode for VitalSource EPUB books

### DIFF
--- a/dev-server/documents/html/vitalsource-epub.mustache
+++ b/dev-server/documents/html/vitalsource-epub.mustache
@@ -70,7 +70,7 @@
           const styles = document.createElement('style');
           styles.innerHTML = `
             iframe {
-              width: 600px;
+              width: 100%;
               height: 400px;
               resize: both;
               overflow: auto;

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -17,6 +17,7 @@ import { createIntegration } from './integrations';
 import * as rangeUtil from './range-util';
 import { SelectionObserver, selectedRange } from './selection-observer';
 import { findClosestOffscreenAnchor } from './util/buckets';
+import { frameFillsAncestor } from './util/frame';
 import { normalizeURI } from './util/url';
 
 /**
@@ -187,7 +188,7 @@ export class Guest {
      * @type {PortRPC<HostToGuestEvent, GuestToHostEvent>}
      */
     this._hostRPC = new PortRPC();
-    this._connectHost();
+    this._connectHost(hostFrame);
 
     /**
      * Channel for guest-sidebar communication.
@@ -301,7 +302,8 @@ export class Guest {
     }
   }
 
-  async _connectHost() {
+  /** @param {Window} hostFrame */
+  async _connectHost(hostFrame) {
     this._hostRPC.on('clearSelection', () => {
       if (selectedRange(document)) {
         this._informHostOnNextSelectionClear = false;
@@ -339,7 +341,7 @@ export class Guest {
       'sidebarLayoutChanged',
       /** @param {SidebarLayout} sidebarLayout */
       sidebarLayout => {
-        if (this._frameIdentifier === null) {
+        if (frameFillsAncestor(window, hostFrame)) {
           this.fitSideBySide(sidebarLayout);
         }
       }

--- a/src/annotator/integrations/html-side-by-side.js
+++ b/src/annotator/integrations/html-side-by-side.js
@@ -1,0 +1,171 @@
+/**
+ * Attempt to guess the region of the page that contains the main content.
+ *
+ * @param {Element} root
+ * @return {{ left: number, right: number }|null} -
+ *   The left/right content margins or `null` if they could not be determined
+ */
+export function guessMainContentArea(root) {
+  // Maps of (margin X coord, votes) for margin positions.
+
+  /** @type {Map<number,number>} */
+  const leftMarginVotes = new Map();
+
+  /** @type {Map<number,number>} */
+  const rightMarginVotes = new Map();
+
+  // Gather data about the paragraphs of text in the document.
+  //
+  // In future we might want to expand this to consider other text containers,
+  // since some pages, especially eg. in ebooks, may not have any paragraphs
+  // (eg. instead they may only contain tables or lists or headings).
+  const paragraphs = Array.from(root.querySelectorAll('p'))
+    .map(p => {
+      // Gather some data about them.
+      const rect = p.getBoundingClientRect();
+      const textLength = /** @type {string} */ (p.textContent).length;
+      return { rect, textLength };
+    })
+    .filter(({ rect }) => {
+      // Filter out hidden paragraphs
+      return rect.width > 0 && rect.height > 0;
+    })
+    // Select the paragraphs containing the most text.
+    .sort((a, b) => b.textLength - a.textLength)
+    .slice(0, 15);
+
+  // Let these paragraphs "vote" for what the left and right margins of the
+  // main content area in the document are.
+  paragraphs.forEach(({ rect }) => {
+    let leftVotes = leftMarginVotes.get(rect.left) ?? 0;
+    leftVotes += 1;
+    leftMarginVotes.set(rect.left, leftVotes);
+
+    let rightVotes = rightMarginVotes.get(rect.right) ?? 0;
+    rightVotes += 1;
+    rightMarginVotes.set(rect.right, rightVotes);
+  });
+
+  // Find the margin values with the most votes.
+  if (leftMarginVotes.size === 0 || rightMarginVotes.size === 0) {
+    return null;
+  }
+
+  const leftMargin = [...leftMarginVotes.entries()].sort((a, b) => b[1] - a[1]);
+  const rightMargin = [...rightMarginVotes.entries()].sort(
+    (a, b) => b[1] - a[1]
+  );
+
+  const [leftPos] = leftMargin[0];
+  const [rightPos] = rightMargin[0];
+
+  return { left: leftPos, right: rightPos };
+}
+
+/**
+ * @param {DOMRect} a
+ * @param {DOMRect} b
+ */
+function intersect(a, b) {
+  const left = Math.max(a.left, b.left);
+  const right = Math.min(a.right, b.right);
+  const top = Math.max(a.top, b.top);
+  const bottom = Math.min(a.bottom, b.bottom);
+  return new DOMRect(left, top, right - left, bottom - top);
+}
+
+/**
+ * Find content within an element to use as an anchor when scrolling.
+ *
+ * @param {Element} scrollRoot
+ * @return {Range|null} - Range to use as an anchor or `null` if a suitable
+ *   range could not be found
+ */
+function getScrollAnchor(scrollRoot) {
+  // Range representing the content whose position within the viewport we will
+  // try to maintain after running the callback.
+  let anchorRange = /** @type {Range|null} */ (null);
+
+  const viewport = intersect(
+    scrollRoot.getBoundingClientRect(),
+    new DOMRect(0, 0, window.innerWidth, window.innerHeight)
+  );
+  if (viewport.width < 0 || viewport.height < 0) {
+    // Element being scrolled is outside the viewport
+    return null;
+  }
+
+  // Create a range that includes the first word that is fully visible in the
+  // viewport.
+  //
+  // This currently visits every text node in `scrollRoot` and tests every
+  // possible anchor until it finds a suitable one. This could be optimized
+  // by skipping over elements that are entirely outside the viewport.
+  const walker = document.createTreeWalker(scrollRoot, NodeFilter.SHOW_TEXT);
+  const tempRange = document.createRange();
+
+  treeWalkLoop: while (walker.nextNode()) {
+    const textNode = /** @type {Text} */ (walker.currentNode);
+    let textLen = 0;
+
+    for (let word of textNode.data.split(/\b/)) {
+      if (/\S/.test(word)) {
+        const start = textLen;
+        const end = textLen + word.length;
+
+        tempRange.setStart(textNode, start);
+        tempRange.setEnd(textNode, end);
+
+        const wordBox = tempRange.getBoundingClientRect();
+        if (
+          wordBox.left >= viewport.left &&
+          wordBox.right <= viewport.right &&
+          wordBox.top >= viewport.top &&
+          wordBox.bottom <= viewport.bottom
+        ) {
+          anchorRange = tempRange.cloneRange();
+          break treeWalkLoop;
+        }
+      }
+
+      textLen += word.length;
+    }
+  }
+
+  return anchorRange;
+}
+
+/**
+ * Apply a layout change to the document and preserve the scroll position.
+ *
+ * This utility selects part of the content in the viewport as an _anchor_
+ * and tries to preserve the position of this content within the viewport
+ * after the callback is invoked.
+ *
+ * @param {() => any} callback - Callback that will apply the layout change
+ * @param {Element} [scrollRoot]
+ * @return {number} - Amount by which the scroll position was adjusted to keep
+ *   the anchored content in view
+ */
+export function preserveScrollPosition(
+  callback,
+  /* istanbul ignore next */
+  scrollRoot = document.documentElement
+) {
+  const anchor = getScrollAnchor(scrollRoot);
+  if (!anchor) {
+    callback();
+    return 0;
+  }
+
+  const anchorTop = anchor.getBoundingClientRect().top;
+  callback();
+  const newAnchorTop = anchor.getBoundingClientRect().top;
+
+  // Determine how far we scrolled as a result of the layout change.
+  // This will be positive if the anchor element moved down or negative if it moved up.
+  const scrollDelta = newAnchorTop - anchorTop;
+  scrollRoot.scrollTop += scrollDelta;
+
+  return scrollDelta;
+}

--- a/src/annotator/integrations/test/html-side-by-side-test.js
+++ b/src/annotator/integrations/test/html-side-by-side-test.js
@@ -1,0 +1,181 @@
+import {
+  guessMainContentArea,
+  preserveScrollPosition,
+} from '../html-side-by-side';
+
+describe('annotator/integrations/html-side-by-side', () => {
+  let contentElements;
+
+  function createContent(paragraphs) {
+    const paraElements = paragraphs.map(({ content, left, width }) => {
+      const el = document.createElement('p');
+      el.textContent = content;
+      el.style.position = 'absolute';
+      el.style.left = `${left}px`;
+      el.style.width = `${width}px`;
+      return el;
+    });
+
+    const root = document.createElement('div');
+    root.append(...paraElements);
+
+    document.body.append(root);
+    contentElements.push(root);
+
+    return root;
+  }
+
+  beforeEach(() => {
+    contentElements = [];
+  });
+
+  afterEach(() => {
+    contentElements.forEach(ce => ce.remove());
+  });
+
+  describe('guessMainContentArea', () => {
+    it('returns `null` if the document has no paragraphs', () => {
+      const content = createContent([]);
+      assert.isNull(guessMainContentArea(content));
+    });
+
+    it('returns the margins of the paragraphs with the most text', () => {
+      const paragraphs = [];
+      for (let i = 0; i < 20; i++) {
+        if (i % 2 === 0) {
+          paragraphs.push({
+            content: `Long paragraph ${i + 1}`,
+            left: 10,
+            width: 100,
+          });
+        } else {
+          paragraphs.push({
+            content: `Paragraph ${i + 1}`,
+            left: 20,
+            width: 200,
+          });
+        }
+      }
+
+      const content = createContent(paragraphs);
+      const area = guessMainContentArea(content);
+
+      assert.deepEqual(area, { left: 10, right: 110 });
+    });
+
+    it('ignores the positions of hidden paragraphs', () => {
+      const paragraphs = [];
+      for (let i = 0; i < 10; i++) {
+        paragraphs.push({
+          content: `Hidden paragraph ${i + 1}`,
+          left: 20,
+          width: 200,
+        });
+      }
+      for (let i = 0; i < 10; i++) {
+        paragraphs.push({
+          content: `Paragraph ${i + 1}`,
+          left: 10,
+          width: 100,
+        });
+      }
+
+      const content = createContent(paragraphs);
+      content.querySelectorAll('p').forEach(para => {
+        if (para.textContent.startsWith('Hidden')) {
+          para.style.display = 'none';
+        }
+      });
+
+      const area = guessMainContentArea(content);
+
+      assert.deepEqual(area, { left: 10, right: 110 });
+    });
+  });
+
+  describe('preserveScrollPosition', () => {
+    const documentText = `The four young faces on which the firelight shone
+brightened at the cheerful words, but darkened again as Jo said sadly, "We
+haven't got Father, and shall not have him for a long time." She didn't say
+"perhaps never," but each silently added it, thinking of Father far away, where
+the fighting was.`;
+
+    let scrollRoot;
+    let content;
+
+    beforeEach(() => {
+      // Create a small "viewport" which can only display part of the document
+      // text at a time.
+      scrollRoot = document.createElement('div');
+      scrollRoot.style.fontSize = '16px';
+      scrollRoot.style.width = '200px';
+      scrollRoot.style.height = '50px';
+      scrollRoot.style.overflow = 'scroll';
+      document.body.append(scrollRoot);
+
+      content = document.createElement('p');
+      content.textContent = documentText;
+      scrollRoot.append(content);
+    });
+
+    afterEach(() => {
+      scrollRoot.remove();
+    });
+
+    it('selects content as a scroll anchor and preserves its position in the viewport', () => {
+      scrollRoot.scrollTop = 200;
+      const initialScrollTop = scrollRoot.scrollTop;
+
+      const delta = preserveScrollPosition(() => {
+        // Make the viewport narrower. This will make the content taller and
+        // require `preserveScrollPosition` to adjust the scroll offset to keep
+        // the anchored content visible.
+        scrollRoot.style.width = '150px';
+      }, scrollRoot);
+
+      assert.notEqual(delta, 0);
+
+      // nb. `scrollTop` returns an integer number of pixels, whereas `delta`
+      // may be fractional.
+      assert.equal(
+        Math.floor(scrollRoot.scrollTop),
+        Math.floor(initialScrollTop + delta)
+      );
+    });
+
+    it('does not restore the scroll position if no anchor content could be found', () => {
+      // Fill content with empty text, which cannot be used as a scroll anchor.
+      content.textContent = ' '.repeat(documentText.length);
+      scrollRoot.scrollTop = 200;
+      const initialScrollTop = scrollRoot.scrollTop;
+
+      const delta = preserveScrollPosition(() => {
+        // Make the viewport narrower. This will make the content taller and
+        // require `preserveScrollPosition` to adjust the scroll offset to keep
+        // the anchored content visible.
+        scrollRoot.style.width = '150px';
+      }, scrollRoot);
+
+      assert.equal(delta, 0);
+      assert.equal(scrollRoot.scrollTop, initialScrollTop);
+    });
+
+    it('does nothing if scroll element is outside viewport', () => {
+      scrollRoot.style.position = 'absolute';
+      scrollRoot.style.top = '10000px';
+
+      scrollRoot.scrollTop = 200;
+      const initialScrollTop = scrollRoot.scrollTop;
+
+      const delta = preserveScrollPosition(() => {
+        // Make the viewport narrower. This will make the content taller and
+        // require `preserveScrollPosition` to adjust the scroll offset to keep
+        // the anchored content visible.
+        scrollRoot.style.width = '150px';
+      }, scrollRoot);
+
+      assert.equal(delta, 0);
+      assert.equal(scrollRoot.scrollTop, initialScrollTop);
+    });
+  });
+});

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -67,7 +67,9 @@ describe('annotator/integrations/vitalsource', () => {
       contentContainer: sinon.stub(),
       describe: sinon.stub(),
       destroy: sinon.stub(),
+      fitSideBySide: sinon.stub().returns(false),
       scrollToAnchor: sinon.stub(),
+      sideBySideEnabled: false,
     };
 
     FakeHTMLIntegration = sinon.stub().returns(fakeHTMLIntegration);
@@ -189,9 +191,16 @@ describe('annotator/integrations/vitalsource', () => {
       assert.equal(integration.canAnnotate(), true);
     });
 
-    it('does not support side-by-side mode', () => {
+    it('delegates to HTMLIntegration for side-by-side mode', () => {
       const integration = createIntegration();
-      assert.equal(integration.fitSideBySide(), false);
+      fakeHTMLIntegration.fitSideBySide.returns(true);
+      assert.isTrue(fakeHTMLIntegration.sideBySideEnabled);
+
+      const layout = { expanded: true, width: 150 };
+      const isActive = integration.fitSideBySide(layout);
+
+      assert.isTrue(isActive);
+      assert.calledWith(fakeHTMLIntegration.fitSideBySide, layout);
     });
 
     it('stops mouse events from propagating to parent frame', () => {

--- a/src/annotator/integrations/vitalsource.js
+++ b/src/annotator/integrations/vitalsource.js
@@ -8,6 +8,7 @@ import { injectClient } from '../hypothesis-injector';
  * @typedef {import('../../types/annotator').Annotator} Annotator
  * @typedef {import('../../types/annotator').Integration} Integration
  * @typedef {import('../../types/annotator').Selector} Selector
+ * @typedef {import('../../types/annotator').SidebarLayout} SidebarLayout
  */
 
 /**
@@ -146,6 +147,7 @@ export class VitalSourceContentIntegration {
    */
   constructor(container = document.body) {
     this._htmlIntegration = new HTMLIntegration(container);
+    this._htmlIntegration.sideBySideEnabled = true;
 
     this._listeners = new ListenerCollection();
 
@@ -223,9 +225,11 @@ export class VitalSourceContentIntegration {
     return this._htmlIntegration.contentContainer();
   }
 
-  fitSideBySide() {
-    // Not yet implemented
-    return false;
+  /**
+   * @param {SidebarLayout} layout
+   */
+  fitSideBySide(layout) {
+    return this._htmlIntegration.fitSideBySide(layout);
   }
 
   async getMetadata() {

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -39,6 +39,7 @@ describe('Guest', () => {
   let fakeBucketBarClient;
   let fakeCreateIntegration;
   let fakeFindClosestOffscreenAnchor;
+  let fakeFrameFillsAncestor;
   let fakeIntegration;
   let fakePortFinder;
   let FakePortRPC;
@@ -123,6 +124,8 @@ describe('Guest', () => {
 
     fakeFindClosestOffscreenAnchor = sinon.stub();
 
+    fakeFrameFillsAncestor = sinon.stub().returns(true);
+
     fakeIntegration = {
       anchor: sinon.stub(),
       canAnnotate: sinon.stub().returns(true),
@@ -178,6 +181,9 @@ describe('Guest', () => {
       './util/buckets': {
         findClosestOffscreenAnchor: fakeFindClosestOffscreenAnchor,
       },
+      './util/frame': {
+        frameFillsAncestor: fakeFrameFillsAncestor,
+      },
     });
   });
 
@@ -189,18 +195,21 @@ describe('Guest', () => {
 
   describe('events from host frame', () => {
     describe('on "sidebarLayoutChanged" event', () => {
-      it('calls fitSideBySide if `Guest` is the main annotatable frame', () => {
+      it('calls fitSideBySide if guest frame fills host frame', () => {
         createGuest();
         const dummyLayout = {};
+        fakeFrameFillsAncestor.withArgs(window, hostFrame).returns(true);
 
         emitHostEvent('sidebarLayoutChanged', dummyLayout);
 
+        assert.calledWith(fakeFrameFillsAncestor, window, hostFrame);
         assert.calledWith(fakeIntegration.fitSideBySide, dummyLayout);
       });
 
-      it('does not call fitSideBySide if `Guest` is not the main annotatable frame', () => {
+      it('does not call fitSideBySide if guest frame does not fill host frame', () => {
         createGuest({ subFrameIdentifier: 'dummy' });
         const dummyLayout = {};
+        fakeFrameFillsAncestor.withArgs(window, hostFrame).returns(false);
 
         emitHostEvent('sidebarLayoutChanged', dummyLayout);
 

--- a/src/annotator/util/frame.js
+++ b/src/annotator/util/frame.js
@@ -1,0 +1,25 @@
+/**
+ * Test whether an iframe fills the viewport of an ancestor frame.
+ *
+ * @param {Window} frame
+ * @param {Window} ancestor
+ */
+export function frameFillsAncestor(frame, ancestor) {
+  if (frame === ancestor) {
+    return true;
+  }
+
+  if (frame.parent !== ancestor) {
+    // To keep things simple, we initially only support direct ancestors.
+    return false;
+  }
+
+  if (!frame.frameElement) {
+    // This is a cross-origin iframe. In this case we can't tell if it fills
+    // the parent frame or not.
+    return false;
+  }
+
+  const frameBox = frame.frameElement.getBoundingClientRect();
+  return frameBox.width / frame.parent.innerWidth >= 0.8;
+}

--- a/src/annotator/util/geometry.js
+++ b/src/annotator/util/geometry.js
@@ -1,0 +1,77 @@
+/**
+ * Return the intersection of two rects.
+ *
+ * @param {DOMRect} rectA
+ * @param {DOMRect} rectB
+ */
+export function intersectRects(rectA, rectB) {
+  const left = Math.max(rectA.left, rectB.left);
+  const right = Math.min(rectA.right, rectB.right);
+  const top = Math.max(rectA.top, rectB.top);
+  const bottom = Math.min(rectA.bottom, rectB.bottom);
+  return new DOMRect(left, top, right - left, bottom - top);
+}
+
+/**
+ * Return `true` if a rect is _empty_.
+ *
+ * An empty rect is defined as one with zero or negative width/height, eg.
+ * as returned by `new DOMRect()` or `Element.getBoundingClientRect()` for a
+ * hidden element.
+ *
+ * @param {DOMRect} rect
+ */
+export function rectIsEmpty(rect) {
+  return rect.width <= 0 || rect.height <= 0;
+}
+
+/**
+ * Return true if the lines a-b and c-d overlap. The inputs must be normalized
+ * such that b >= a and d >= c.
+ *
+ * @param {number} a
+ * @param {number} b
+ * @param {number} c
+ * @param {number} d
+ */
+function linesOverlap(a, b, c, d) {
+  const maxStart = Math.max(a, c);
+  const minEnd = Math.min(b, d);
+  return maxStart < minEnd;
+}
+
+/**
+ * Return true if the intersection of `rectB` and `rectA` is non-empty.
+ *
+ * @param {DOMRect} rectA
+ * @param {DOMRect} rectB
+ */
+export function rectIntersects(rectA, rectB) {
+  if (rectIsEmpty(rectA) || rectIsEmpty(rectB)) {
+    return false;
+  }
+
+  return (
+    linesOverlap(rectA.left, rectA.right, rectB.left, rectB.right) &&
+    linesOverlap(rectA.top, rectA.bottom, rectB.top, rectB.bottom)
+  );
+}
+
+/**
+ * Return true if `rectB` is fully contained within `rectA`
+ *
+ * @param {DOMRect} rectA
+ * @param {DOMRect} rectB
+ */
+export function rectContains(rectA, rectB) {
+  if (rectIsEmpty(rectA) || rectIsEmpty(rectB)) {
+    return false;
+  }
+
+  return (
+    rectB.left >= rectA.left &&
+    rectB.right <= rectA.right &&
+    rectB.top >= rectA.top &&
+    rectB.bottom <= rectA.bottom
+  );
+}

--- a/src/annotator/util/test/frame-test.js
+++ b/src/annotator/util/test/frame-test.js
@@ -1,0 +1,56 @@
+import { frameFillsAncestor } from '../frame';
+
+describe('annotator/util/frame', () => {
+  let frames;
+
+  function createFrame() {
+    const frame = document.createElement('iframe');
+    frames.push(frame);
+
+    document.body.append(frame);
+
+    return frame;
+  }
+
+  beforeEach(() => {
+    frames = [];
+  });
+
+  afterEach(() => {
+    frames.forEach(f => f.remove());
+  });
+
+  describe('frameFillsAncestor', () => {
+    it('returns true if both frames are the same', () => {
+      assert.isTrue(frameFillsAncestor(window, window));
+    });
+
+    it('returns false if ancestor is not direct parent of frame', () => {
+      const child = createFrame();
+      assert.isFalse(frameFillsAncestor(child.contentWindow, window.parent));
+    });
+
+    it('returns true if frame fills parent', () => {
+      const child = createFrame();
+      child.style.width = `${window.innerWidth}px`;
+      assert.isTrue(frameFillsAncestor(child.contentWindow, window));
+    });
+
+    it('returns false if frame does not fill parent', () => {
+      const child = createFrame();
+      child.style.width = `${window.innerWidth * 0.5}px`;
+      assert.isFalse(frameFillsAncestor(child.contentWindow, window));
+    });
+
+    it('returns false if frames are not same-origin', () => {
+      const child = createFrame();
+
+      // Simulate cross-origin parent
+      Object.defineProperty(child.contentWindow, 'frameElement', {
+        value: null,
+      });
+
+      assert.isFalse(frameFillsAncestor(child.contentWindow, window));
+    });
+  });
+});

--- a/src/annotator/util/test/geometry-test.js
+++ b/src/annotator/util/test/geometry-test.js
@@ -1,0 +1,85 @@
+import {
+  intersectRects,
+  rectContains,
+  rectIntersects,
+  rectIsEmpty,
+} from '../geometry';
+
+function rectEquals(a, b) {
+  return (
+    a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height
+  );
+}
+
+describe('annotator/util/geometry', () => {
+  describe('intersectRects', () => {
+    it('returns the intersection of two rects', () => {
+      const rect = intersectRects(
+        new DOMRect(0, 0, 500, 500),
+        new DOMRect(10, 10, 500, 500)
+      );
+      assert.isTrue(rectEquals(rect, new DOMRect(10, 10, 490, 490)));
+    });
+  });
+
+  describe('rectIsEmpty', () => {
+    it('returns true for null rects', () => {
+      assert.isTrue(rectIsEmpty(new DOMRect()));
+    });
+
+    it('returns true for inverted rects', () => {
+      assert.isTrue(rectIsEmpty(new DOMRect(10, 10, -10, -10)));
+    });
+
+    it('returns false for rects with positive width and height', () => {
+      assert.isFalse(rectIsEmpty(new DOMRect(0, 0, 1, 1)));
+    });
+  });
+
+  describe('rectIntersects', () => {
+    it('returns false if either rect is empty', () => {
+      assert.isFalse(rectIntersects(new DOMRect(0, 0, 10, 10), new DOMRect()));
+      assert.isFalse(rectIntersects(new DOMRect(), new DOMRect(0, 0, 10, 10)));
+    });
+
+    it('returns false if rects do not intersect', () => {
+      assert.isFalse(
+        rectIntersects(new DOMRect(0, 0, 10, 10), new DOMRect(100, 0, 10, 10))
+      );
+      assert.isFalse(
+        rectIntersects(new DOMRect(0, 0, 10, 10), new DOMRect(0, 100, 10, 10))
+      );
+    });
+
+    it('returns false if rects touch but do not intersect', () => {
+      assert.isFalse(
+        rectIntersects(new DOMRect(0, 0, 10, 10), new DOMRect(10, 10, 10, 10))
+      );
+    });
+
+    it('returns true if rects intersect', () => {
+      assert.isTrue(
+        rectIntersects(new DOMRect(0, 0, 10, 10), new DOMRect(5, 5, 10, 10))
+      );
+    });
+  });
+
+  describe('rectContains', () => {
+    it('returns false if either rect is empty', () => {
+      assert.isFalse(rectContains(new DOMRect(0, 0, 10, 10), new DOMRect()));
+      assert.isFalse(rectContains(new DOMRect(), new DOMRect(0, 0, 10, 10)));
+    });
+
+    it('returns false if first rect does not fully contain second rect', () => {
+      assert.isFalse(
+        rectContains(new DOMRect(0, 0, 10, 10), new DOMRect(2, 2, 10, 10))
+      );
+    });
+
+    it('returns true if first rect contains second rect', () => {
+      assert.isTrue(
+        rectContains(new DOMRect(0, 0, 10, 10), new DOMRect(2, 2, 8, 8))
+      );
+    });
+  });
+});

--- a/src/sidebar/store/test/use-store-test.js
+++ b/src/sidebar/store/test/use-store-test.js
@@ -82,7 +82,10 @@ describe('sidebar/store/use-store', () => {
       assert.deepEqual(proxy.getThing('bar'), { id: 'bar' });
 
       // Test proxied action dispatch.
-      proxy.addThing('baz');
+      act(() => {
+        proxy.addThing('baz');
+      });
+
       assert.calledWith(addThingSpy, 'baz');
     });
 
@@ -118,8 +121,10 @@ describe('sidebar/store/use-store', () => {
 
       const { proxy } = renderTestComponent();
 
-      proxy.addThing('foo');
-      proxy.addThing('foo');
+      act(() => {
+        proxy.addThing('foo');
+        proxy.addThing('foo');
+      });
 
       assert.calledTwice(addThingSpy);
       assert.calledWith(addThingSpy, 'foo');


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/4225**~~

Implement side-by-side mode for web pages in the HTML integration, and use it to support side-by-side mode in VitalSource EPUB books. Support for side-by-side mode in VitalSource PDF books will happen separately.

The side-by-side implementation for HTML is intended to eventually be used for ordinary web pages, but is currently disabled by default and enabled only for VitalSource. This will allow us to deploy side-by-side mode in stages.

**Side-by-side mode in VitalSource:**

<img width="1181" alt="Side-by-side VitalSource" src="https://user-images.githubusercontent.com/2458/151390668-66a2c926-0f04-4739-ad0c-e40f4dbbfb90.png">

**Testing:**

**1. With the client's development server:**

Go to http://localhost:3000/document/vitalsource-epub and open/close the sidebar. The book content layout will adapt so that the content is not obscured by the sidebar.

**2. With the browser extension:**

Build the browser extension from this branch. Activate it when viewing an EPUB-based book in VitalSource or a web page which has an obvious article region. The sidebar should display alongside the article content.

Part of https://github.com/hypothesis/product-backlog/issues/1248.