### PR TITLE
Remove a reference to `Bridge` and strengthen type

### DIFF
--- a/src/shared/messaging/port-rpc.js
+++ b/src/shared/messaging/port-rpc.js
@@ -48,6 +48,7 @@ const PROTOCOL = 'frame-rpc';
  * @typedef {RequestMessage|ResponseMessage} Message
  *
  * @typedef {import('../../types/annotator').Destroyable} Destroyable
+ * @typedef {import('../../types/port-rpc-events').RPCEvent} RPCEvent
  */
 
 /**
@@ -62,8 +63,8 @@ const PROTOCOL = 'frame-rpc';
  *
  * [1] https://developer.mozilla.org/en-US/docs/Web/API/Channel_Messaging_API
  *
- * @template {string} OnMethod - Names of RPC methods this client responds to
- * @template {string} CallMethod - Names of RPC methods this client invokes
+ * @template {RPCEvent} OnMethod - Names of RPC methods this client responds to
+ * @template {RPCEvent} CallMethod - Names of RPC methods this client invokes
  * @implements {Destroyable}
  */
 export class PortRPC {

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -221,7 +221,7 @@ export type SidebarToHostEvent =
    */
   | 'signupRequested';
 
-export type BridgeEvent =
+export type RPCEvent =
   | HostToGuestEvent
   | HostToSidebarEvent
   | GuestToHostEvent


### PR DESCRIPTION
1. Remove a reference to the defunct class `Bridge`.

2. Make the type of `OnMethod` and `CallMethod` the union of all allowed
   RPC event names, instead of a generic string.