### PR TITLE
Swap default exports to named exports

### DIFF
--- a/dev-server/ui-playground/index.js
+++ b/dev-server/ui-playground/index.js
@@ -1,7 +1,7 @@
 import { startApp } from '@hypothesis/frontend-shared/lib/pattern-library';
 import ButtonPatterns from './components/ButtonPatterns';
 
-import sidebarIcons from '../../src/sidebar/icons';
+import { sidebarIcons } from '../../src/sidebar/icons';
 
 /** @type {import('@hypothesis/frontend-shared/lib/pattern-library').PlaygroundRoute[]} */
 const extraRoutes = [

--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -1,6 +1,6 @@
 /* global PDFViewerApplication */
 
-import warnOnce from '../../shared/warn-once';
+import { warnOnce } from '../../shared/warn-once';
 import { matchQuote } from './match-quote';
 import { createPlaceholder } from './placeholder';
 import { TextPosition, TextRange } from './text-range';

--- a/src/annotator/anchoring/test/fake-pdf-viewer-application.js
+++ b/src/annotator/anchoring/test/fake-pdf-viewer-application.js
@@ -251,7 +251,7 @@ class FakePDFViewer {
  *
  * The original is defined at https://github.com/mozilla/pdf.js/blob/master/web/app.js
  */
-export default class FakePDFViewerApplication {
+export class FakePDFViewerApplication {
   /**
    * @param {Options} options
    */

--- a/src/annotator/anchoring/test/html-baselines/index.js
+++ b/src/annotator/anchoring/test/html-baselines/index.js
@@ -27,7 +27,7 @@ import minimalJSON from './minimal.json';
 import wikipediaDoc from './wikipedia-regression-testing.html';
 import wikipediaJSON from './wikipedia-regression-testing.json';
 
-export default [
+export const htmlBaselines = [
   {
     name: 'Minimal Document',
     html: minimalDoc,

--- a/src/annotator/anchoring/test/html-test.js
+++ b/src/annotator/anchoring/test/html-test.js
@@ -1,7 +1,7 @@
 import * as html from '../html';
 
 import fixture from './html-anchoring-fixture.html';
-import htmlBaselines from './html-baselines';
+import { htmlBaselines } from './html-baselines';
 
 /** Return all text node children of `container`. */
 function textNodes(container) {

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -3,7 +3,7 @@ import * as pdfAnchoring from '../pdf';
 import { matchQuote } from '../match-quote';
 import { TextRange } from '../text-range';
 
-import FakePDFViewerApplication from './fake-pdf-viewer-application';
+import { FakePDFViewerApplication } from './fake-pdf-viewer-application';
 
 /**
  * Return a DOM Range which refers to the specified `text` in `container`.

--- a/src/annotator/bucket-bar.js
+++ b/src/annotator/bucket-bar.js
@@ -14,7 +14,7 @@ import { computeBuckets } from './util/buckets';
  *
  * @implements {Destroyable}
  */
-export default class BucketBar {
+export class BucketBar {
   /**
    * @param {HTMLElement} container
    * @param {object} options

--- a/src/annotator/config/config-func-settings-from.js
+++ b/src/annotator/config/config-func-settings-from.js
@@ -22,7 +22,7 @@
  * @return {object} - Any config settings returned by hypothesisConfig()
  *
  */
-export default function configFuncSettingsFrom(window_) {
+export function configFuncSettingsFrom(window_) {
   if (!window_.hasOwnProperty('hypothesisConfig')) {
     return {};
   }

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -1,5 +1,5 @@
 import { isBrowserExtension } from './is-browser-extension';
-import settingsFrom from './settings';
+import { settingsFrom } from './settings';
 import { toBoolean } from '../../shared/type-coercions';
 import { urlFromLinkTag } from './url-from-link-tag';
 

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -1,7 +1,7 @@
 import { parseJsonConfig } from '../../boot/parse-json-config';
 import { toBoolean } from '../../shared/type-coercions';
 
-import configFuncSettingsFrom from './config-func-settings-from';
+import { configFuncSettingsFrom } from './config-func-settings-from';
 import { urlFromLinkTag } from './url-from-link-tag';
 
 /**
@@ -20,7 +20,7 @@ import { urlFromLinkTag } from './url-from-link-tag';
 /**
  * @return {SettingsGetters}
  */
-export default function settingsFrom(window_) {
+export function settingsFrom(window_) {
   // Prioritize the `window.hypothesisConfig` function over the JSON format
   // Via uses `window.hypothesisConfig` and makes it non-configurable and non-writable.
   // In addition, Via sets the `ignoreOtherConfiguration` option to prevent configuration merging.

--- a/src/annotator/config/test/config-func-settings-from-test.js
+++ b/src/annotator/config/test/config-func-settings-from-test.js
@@ -1,4 +1,4 @@
-import configFuncSettingsFrom from '../config-func-settings-from';
+import { configFuncSettingsFrom } from '../config-func-settings-from';
 
 describe('annotator.config.configFuncSettingsFrom', () => {
   const sandbox = sinon.createSandbox();

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -1,5 +1,4 @@
-import { getConfig } from '../index';
-import { $imports } from '../index';
+import { getConfig, $imports } from '../index';
 
 describe('annotator/config/index', () => {
   let fakeSettingsFrom;
@@ -20,7 +19,7 @@ describe('annotator/config/index', () => {
     fakeIsBrowserExtension = sinon.stub();
 
     $imports.$mock({
-      './settings': fakeSettingsFrom,
+      './settings': { settingsFrom: fakeSettingsFrom },
       './is-browser-extension': {
         isBrowserExtension: fakeIsBrowserExtension,
       },
@@ -135,16 +134,18 @@ describe('annotator/config/index', () => {
     beforeEach(() => {
       // Remove all fake values
       $imports.$mock({
-        './settings': sinon.stub().returns({
-          hostPageSetting: sinon.stub().returns(undefined),
-          annotations: undefined,
-          clientUrl: undefined,
-          group: undefined,
-          notebookAppUrl: undefined,
-          showHighlights: undefined,
-          sidebarAppUrl: undefined,
-          query: undefined,
-        }),
+        './settings': {
+          settingsFrom: sinon.stub().returns({
+            hostPageSetting: sinon.stub().returns(undefined),
+            annotations: undefined,
+            clientUrl: undefined,
+            group: undefined,
+            notebookAppUrl: undefined,
+            showHighlights: undefined,
+            sidebarAppUrl: undefined,
+            query: undefined,
+          }),
+        },
       });
     });
 

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -1,5 +1,4 @@
-import settingsFrom from '../settings';
-import { $imports } from '../settings';
+import { settingsFrom, $imports } from '../settings';
 
 describe('annotator/config/settingsFrom', () => {
   let fakeConfigFuncSettingsFrom;
@@ -12,7 +11,9 @@ describe('annotator/config/settingsFrom', () => {
     fakeParseJsonConfig = sinon.stub().returns({});
 
     $imports.$mock({
-      './config-func-settings-from': fakeConfigFuncSettingsFrom,
+      './config-func-settings-from': {
+        configFuncSettingsFrom: fakeConfigFuncSettingsFrom,
+      },
       './url-from-link-tag': {
         urlFromLinkTag: fakeUrlFromLinkTag,
       },

--- a/src/annotator/features.js
+++ b/src/annotator/features.js
@@ -1,4 +1,4 @@
-import warnOnce from '../shared/warn-once';
+import { warnOnce } from '../shared/warn-once';
 
 let _features = {};
 

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -116,7 +116,7 @@ function removeTextSelection() {
  * @implements {Annotator}
  * @implements {Destroyable}
  */
-export default class Guest {
+export class Guest {
   /**
    * @param {HTMLElement} element -
    *   The root element in which the `Guest` instance should be able to anchor

--- a/src/annotator/icons.js
+++ b/src/annotator/icons.js
@@ -20,7 +20,7 @@ import pointerIcon from '../images/icons/pointer.svg';
  * Set of icons used by the annotator part of the application via the `SvgIcon`
  * component.
  */
-export default {
+export const annotatorIcons = {
   annotate: annotateIcon,
   cancel,
   caution,

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -11,7 +11,7 @@ registerIcons(iconSet);
 
 import { PortProvider } from '../shared/messaging';
 import { getConfig } from './config/index';
-import Guest from './guest';
+import { Guest } from './guest';
 import Notebook from './notebook';
 import Sidebar from './sidebar';
 import { EventBus } from './util/emitter';

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -12,8 +12,8 @@ registerIcons(iconSet);
 import { PortProvider } from '../shared/messaging';
 import { getConfig } from './config/index';
 import { Guest } from './guest';
-import Notebook from './notebook';
-import Sidebar from './sidebar';
+import { Notebook } from './notebook';
+import { Sidebar } from './sidebar';
 import { EventBus } from './util/emitter';
 
 // Look up the URL of the sidebar. This element is added to the page by the

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -6,8 +6,8 @@ import 'preact/debug';
 
 // Load icons.
 import { registerIcons } from '@hypothesis/frontend-shared';
-import iconSet from './icons';
-registerIcons(iconSet);
+import { annotatorIcons } from './icons';
+registerIcons(annotatorIcons);
 
 import { PortProvider } from '../shared/messaging';
 import { getConfig } from './config/index';

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -1,5 +1,5 @@
 import { delay } from '../../../test-util/wait';
-import FakePDFViewerApplication from '../../anchoring/test/fake-pdf-viewer-application';
+import { FakePDFViewerApplication } from '../../anchoring/test/fake-pdf-viewer-application';
 import { RenderingStates } from '../../anchoring/pdf';
 import { createPlaceholder } from '../../anchoring/placeholder';
 import { PDFIntegration, isPDF, $imports } from '../pdf';

--- a/src/annotator/notebook.js
+++ b/src/annotator/notebook.js
@@ -5,7 +5,7 @@ import NotebookModal from './components/NotebookModal';
 /** @typedef {import('../types/annotator').Destroyable} Destroyable */
 
 /** @implements {Destroyable} */
-export default class Notebook {
+export class Notebook {
   /**
    * @param {HTMLElement} element
    * @param {import('./util/emitter').EventBus} eventBus -

--- a/src/annotator/sidebar-trigger.js
+++ b/src/annotator/sidebar-trigger.js
@@ -8,7 +8,7 @@ const SIDEBAR_TRIGGER_BTN_ATTR = 'data-hypothesis-trigger';
  * @param {object} showFn - Function which shows the sidebar.
  */
 
-export default function trigger(rootEl, showFn) {
+export function sidebarTrigger(rootEl, showFn) {
   const triggerElems = rootEl.querySelectorAll(
     '[' + SIDEBAR_TRIGGER_BTN_ATTR + ']'
   );

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -6,7 +6,7 @@ import { ListenerCollection } from '../shared/listener-collection';
 import { PortRPC } from '../shared/messaging';
 
 import { annotationCounts } from './annotation-counts';
-import BucketBar from './bucket-bar';
+import { BucketBar } from './bucket-bar';
 import { createAppConfig } from './config/app';
 import { features } from './features';
 import sidebarTrigger from './sidebar-trigger';

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -9,7 +9,7 @@ import { annotationCounts } from './annotation-counts';
 import { BucketBar } from './bucket-bar';
 import { createAppConfig } from './config/app';
 import { features } from './features';
-import sidebarTrigger from './sidebar-trigger';
+import { sidebarTrigger } from './sidebar-trigger';
 import { ToolbarController } from './toolbar';
 import { createShadowRoot } from './util/shadow-root';
 

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -14,7 +14,7 @@ import { ToolbarController } from './toolbar';
 import { createShadowRoot } from './util/shadow-root';
 
 /**
- * @typedef {import('./guest').default} Guest
+ * @typedef {import('./guest').Guest} Guest
  * @typedef {import('../types/annotator').AnchorPosition} AnchorPosition
  * @typedef {import('../types/annotator').SidebarLayout} SidebarLayout
  * @typedef {import('../types/annotator').Destroyable} Destroyable

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -56,7 +56,7 @@ function createSidebarIframe(config) {
  *
  * @implements {Destroyable}
  */
-export default class Sidebar {
+export class Sidebar {
   /**
    * @param {HTMLElement} element
    * @param {import('./util/emitter').EventBus} eventBus -

--- a/src/annotator/test/bucket-bar-test.js
+++ b/src/annotator/test/bucket-bar-test.js
@@ -1,4 +1,4 @@
-import BucketBar, { $imports } from '../bucket-bar';
+import { BucketBar, $imports } from '../bucket-bar';
 
 describe('BucketBar', () => {
   let bucketBars;

--- a/src/annotator/test/features-test.js
+++ b/src/annotator/test/features-test.js
@@ -16,7 +16,7 @@ describe('features - annotation layer', () => {
   beforeEach(() => {
     fakeWarnOnce = sinon.stub();
     $imports.$mock({
-      '../shared/warn-once': fakeWarnOnce,
+      '../shared/warn-once': { warnOnce: fakeWarnOnce },
     });
 
     features.init({

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1,5 +1,5 @@
 import { delay } from '../../test-util/wait';
-import Guest, { $imports } from '../guest';
+import { Guest, $imports } from '../guest';
 
 class FakeAdder {
   constructor(container, options) {

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -1,7 +1,7 @@
 // Tests that the expected parts of the page are highlighted when annotations
 // with various combinations of selector are anchored.
 
-import Guest, { $imports as guestImports } from '../../guest';
+import { Guest, $imports as guestImports } from '../../guest';
 import testPageHTML from './test-page.html';
 
 function quoteSelector(quote) {

--- a/src/annotator/test/notebook-test.js
+++ b/src/annotator/test/notebook-test.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'preact/hooks';
 import { act } from 'preact/test-utils';
 
-import Notebook, { $imports } from '../notebook';
+import { Notebook, $imports } from '../notebook';
 import { EventBus } from '../util/emitter';
 
 describe('Notebook', () => {

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -1,5 +1,5 @@
 import { addConfigFragment } from '../../shared/config-fragment';
-import Sidebar, { MIN_RESIZE, $imports } from '../sidebar';
+import { Sidebar, MIN_RESIZE, $imports } from '../sidebar';
 import { EventBus } from '../util/emitter';
 
 const DEFAULT_WIDTH = 350;

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -155,7 +155,7 @@ describe('Sidebar', () => {
     $imports.$mock({
       '../shared/frame-error-capture': { sendErrorsTo: fakeSendErrorsTo },
       '../shared/messaging': { PortRPC: FakePortRPC },
-      './bucket-bar': { default: FakeBucketBar },
+      './bucket-bar': { BucketBar: FakeBucketBar },
       './config/app': { createAppConfig: fakeCreateAppConfig },
       './toolbar': {
         ToolbarController: FakeToolbarController,

--- a/src/annotator/test/sidebar-trigger-test.js
+++ b/src/annotator/test/sidebar-trigger-test.js
@@ -1,4 +1,4 @@
-import sidebarTrigger from '../sidebar-trigger';
+import { sidebarTrigger } from '../sidebar-trigger';
 
 describe('sidebarTrigger', () => {
   let triggerEl1;

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -8,7 +8,7 @@
 import { parseJsonConfig } from './parse-json-config';
 
 import { bootHypothesisClient, bootSidebarApp } from './boot';
-import processUrlTemplate from './url-template';
+import { processUrlTemplate } from './url-template';
 import { isBrowserSupported } from './browser-check';
 
 // @ts-ignore - This file is generated before the boot bundle is built.

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -1,5 +1,4 @@
-import { bootHypothesisClient, bootSidebarApp } from '../boot';
-import { $imports } from '../boot';
+import { bootHypothesisClient, bootSidebarApp, $imports } from '../boot';
 
 function assetUrl(url) {
   return `https://marginal.ly/client/build/${url}`;

--- a/src/boot/test/url-template-test.js
+++ b/src/boot/test/url-template-test.js
@@ -1,4 +1,4 @@
-import processUrlTemplate from '../url-template';
+import { processUrlTemplate } from '../url-template';
 
 describe('processUrlTemplate', () => {
   let fakeDocument;

--- a/src/boot/url-template.js
+++ b/src/boot/url-template.js
@@ -36,7 +36,7 @@ function currentScriptOrigin(document_ = document) {
  * @param {string} url
  * @param {Document} document_
  */
-export default function processUrlTemplate(url, document_ = document) {
+export function processUrlTemplate(url, document_ = document) {
   if (url.indexOf('{') === -1) {
     // Not a template. This should always be the case in production.
     return url;

--- a/src/shared/test/warn-once-test.js
+++ b/src/shared/test/warn-once-test.js
@@ -1,4 +1,4 @@
-import warnOnce from '../warn-once';
+import { warnOnce } from '../warn-once';
 
 describe('warnOnce', () => {
   beforeEach(() => {

--- a/src/shared/warn-once.js
+++ b/src/shared/warn-once.js
@@ -11,7 +11,7 @@ let shownWarnings = {};
  *   are concatenated into a string key which is used to determine if the warning
  *   has been logged before.
  */
-export default function warnOnce(...args) {
+export function warnOnce(...args) {
   const key = args.join();
   if (key in shownWarnings) {
     return;

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import * as fixtures from '../../../test/annotation-fixtures';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
-import mockImportedComponents from '../../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
 
 import Annotation, { $imports } from '../Annotation';
 

--- a/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
@@ -7,7 +7,7 @@ import { $imports } from '../AnnotationActionBar';
 import * as fixtures from '../../../test/annotation-fixtures';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
-import mockImportedComponents from '../../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
 import { waitFor } from '../../../../test-util/wait';
 
 describe('AnnotationActionBar', () => {

--- a/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
@@ -1,8 +1,7 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import AnnotationActionBar from '../AnnotationActionBar';
-import { $imports } from '../AnnotationActionBar';
+import AnnotationActionBar, { $imports } from '../AnnotationActionBar';
 
 import * as fixtures from '../../../test/annotation-fixtures';
 

--- a/src/sidebar/components/Annotation/test/AnnotationBody-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationBody-test.js
@@ -4,7 +4,7 @@ import { act } from 'preact/test-utils';
 import * as fixtures from '../../../test/annotation-fixtures';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
-import mockImportedComponents from '../../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
 
 import AnnotationBody, { $imports } from '../AnnotationBody';
 

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -5,7 +5,7 @@ import * as fixtures from '../../../test/annotation-fixtures';
 import { waitFor } from '../../../../test-util/wait';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
-import mockImportedComponents from '../../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
 
 import AnnotationEditor, { $imports } from '../AnnotationEditor';
 

--- a/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import * as fixtures from '../../../test/annotation-fixtures';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
-import mockImportedComponents from '../../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
 
 import AnnotationHeader, { $imports } from '../AnnotationHeader';
 

--- a/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import * as fixtures from '../../../test/annotation-fixtures';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
-import mockImportedComponents from '../../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
 
 import AnnotationPublishControl, {
   $imports,

--- a/src/sidebar/components/Annotation/test/AnnotationQuote-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationQuote-test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
-import mockImportedComponents from '../../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
 
 import AnnotationQuote, { $imports } from '../AnnotationQuote';
 

--- a/src/sidebar/components/Annotation/test/AnnotationShareControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationShareControl-test.js
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
-import mockImportedComponents from '../../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
 
 import AnnotationShareControl, { $imports } from '../AnnotationShareControl';
 

--- a/src/sidebar/components/Annotation/test/AnnotationShareInfo-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationShareInfo-test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import * as fixtures from '../../../test/annotation-fixtures';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
-import mockImportedComponents from '../../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
 
 import AnnotationShareInfo, { $imports } from '../AnnotationShareInfo';
 

--- a/src/sidebar/components/AnnotationView.js
+++ b/src/sidebar/components/AnnotationView.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'preact/hooks';
 
 import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../service-context';
-import useRootThread from './hooks/use-root-thread';
+import { useRootThread } from './hooks/use-root-thread';
 
 import ThreadList from './ThreadList';
 import SidebarContentError from './SidebarContentError';

--- a/src/sidebar/components/Excerpt.js
+++ b/src/sidebar/components/Excerpt.js
@@ -2,7 +2,7 @@ import { LinkButton } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback, useLayoutEffect, useRef, useState } from 'preact/hooks';
 
-import observeElementSize from '../util/observe-element-size';
+import { observeElementSize } from '../util/observe-element-size';
 import { withServices } from '../service-context';
 import { applyTheme } from '../helpers/theme';
 

--- a/src/sidebar/components/FilterStatus.js
+++ b/src/sidebar/components/FilterStatus.js
@@ -5,7 +5,7 @@ import { useMemo } from 'preact/hooks';
 import { countVisible } from '../helpers/thread';
 import { useStoreProxy } from '../store/use-store';
 
-import useRootThread from './hooks/use-root-thread';
+import { useRootThread } from './hooks/use-root-thread';
 
 /**
  * @typedef {import('../helpers/build-thread').Thread} Thread

--- a/src/sidebar/components/GroupList/GroupList.js
+++ b/src/sidebar/components/GroupList/GroupList.js
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'preact/hooks';
 import { serviceConfig } from '../../config/service-config';
 import { isThirdPartyUser } from '../../helpers/account-id';
 import { orgName } from '../../helpers/group-list-item-common';
-import groupsByOrganization from '../../helpers/group-organizations';
+import { groupsByOrganization } from '../../helpers/group-organizations';
 import { isThirdPartyService } from '../../helpers/is-third-party-service';
 import { withServices } from '../../service-context';
 import { useStoreProxy } from '../../store/use-store';

--- a/src/sidebar/components/GroupList/test/GroupList-test.js
+++ b/src/sidebar/components/GroupList/test/GroupList-test.js
@@ -3,7 +3,7 @@ import { act } from 'preact/test-utils';
 
 import GroupList, { $imports } from '../GroupList';
 
-import mockImportedComponents from '../../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
 
 describe('GroupList', () => {
   let fakeServiceConfig;

--- a/src/sidebar/components/GroupList/test/GroupList-test.js
+++ b/src/sidebar/components/GroupList/test/GroupList-test.js
@@ -110,10 +110,12 @@ describe('GroupList', () => {
 
   it('sorts groups within each section by organization', () => {
     const testGroups = populateGroupSections();
-    const fakeGroupOrganizations = groups =>
+    const fakeGroupsByOrganization = groups =>
       groups.sort((a, b) => a.id.localeCompare(b.id));
     $imports.$mock({
-      '../../helpers/group-organizations': fakeGroupOrganizations,
+      '../../helpers/group-organizations': {
+        groupsByOrganization: fakeGroupsByOrganization,
+      },
     });
 
     const wrapper = createGroupList();
@@ -123,7 +125,7 @@ describe('GroupList', () => {
     sections.forEach(section => {
       assert.deepEqual(
         section.prop('groups'),
-        fakeGroupOrganizations(testGroups)
+        fakeGroupsByOrganization(testGroups)
       );
     });
   });

--- a/src/sidebar/components/GroupList/test/GroupListSection-test.js
+++ b/src/sidebar/components/GroupList/test/GroupListSection-test.js
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 
 import GroupListSection, { $imports } from '../GroupListSection';
 
-import mockImportedComponents from '../../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
 
 describe('GroupListSection', () => {
   const testGroups = [

--- a/src/sidebar/components/HelpPanel.js
+++ b/src/sidebar/components/HelpPanel.js
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useState } from 'preact/hooks';
 
 import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../service-context';
-import VersionData from '../helpers/version-data';
+import { VersionData } from '../helpers/version-data';
 
 import SidebarPanel from './SidebarPanel';
 import Tutorial from './Tutorial';

--- a/src/sidebar/components/MarkdownView.js
+++ b/src/sidebar/components/MarkdownView.js
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import { useEffect, useMemo, useRef } from 'preact/hooks';
 
 import { replaceLinksWithEmbeds } from '../media-embedder';
-import { renderMathAndMarkdown as renderMarkdown } from '../render-markdown';
+import { renderMathAndMarkdown } from '../render-markdown';
 
 /**
  * @typedef MarkdownViewProps
@@ -25,7 +25,7 @@ export default function MarkdownView({
   textStyle = {},
 }) {
   const html = useMemo(
-    () => (markdown ? renderMarkdown(markdown) : ''),
+    () => (markdown ? renderMathAndMarkdown(markdown) : ''),
     [markdown]
   );
   const content = /** @type {{ current: HTMLDivElement }} */ (useRef());

--- a/src/sidebar/components/MarkdownView.js
+++ b/src/sidebar/components/MarkdownView.js
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import { useEffect, useMemo, useRef } from 'preact/hooks';
 
 import { replaceLinksWithEmbeds } from '../media-embedder';
-import renderMarkdown from '../render-markdown';
+import { renderMathAndMarkdown as renderMarkdown } from '../render-markdown';
 
 /**
  * @typedef MarkdownViewProps

--- a/src/sidebar/components/NotebookResultCount.js
+++ b/src/sidebar/components/NotebookResultCount.js
@@ -1,6 +1,6 @@
 import { Spinner } from '@hypothesis/frontend-shared';
 
-import useRootThread from './hooks/use-root-thread';
+import { useRootThread } from './hooks/use-root-thread';
 import { countVisible } from '../helpers/thread';
 
 /**

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -9,7 +9,7 @@ import { useStoreProxy } from '../store/use-store';
 import NotebookFilters from './NotebookFilters';
 import NotebookResultCount from './NotebookResultCount';
 import PaginatedThreadList from './PaginatedThreadList';
-import useRootThread from './hooks/use-root-thread';
+import { useRootThread } from './hooks/use-root-thread';
 
 /**
  * @typedef NotebookViewProps

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'preact/hooks';
 
-import useRootThread from './hooks/use-root-thread';
+import { useRootThread } from './hooks/use-root-thread';
 import { withServices } from '../service-context';
 import { useStoreProxy } from '../store/use-store';
 import { tabForAnnotation } from '../helpers/tabs';

--- a/src/sidebar/components/StreamView.js
+++ b/src/sidebar/components/StreamView.js
@@ -2,7 +2,7 @@ import { useCallback, useEffect } from 'preact/hooks';
 
 import * as searchFilter from '../util/search-filter';
 import { withServices } from '../service-context';
-import useRootThread from './hooks/use-root-thread';
+import { useRootThread } from './hooks/use-root-thread';
 import { useStoreProxy } from '../store/use-store';
 
 import ThreadList from './ThreadList';

--- a/src/sidebar/components/VersionInfo.js
+++ b/src/sidebar/components/VersionInfo.js
@@ -5,7 +5,7 @@ import { withServices } from '../service-context';
 
 /**
  * @typedef VersionInfoProps
- * @prop {import('../helpers/version-data').default} versionData - Object with version information
+ * @prop {import('../helpers/version-data').VersionData} versionData - Object with version information
  * @prop {import('../services/toast-messenger').ToastMessengerService} toastMessenger
  */
 

--- a/src/sidebar/components/hooks/test/use-filter-options-test.js
+++ b/src/sidebar/components/hooks/test/use-filter-options-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
-import { useUserFilterOptions } from '../use-filter-options';
-import { $imports } from '../use-filter-options';
+import { useUserFilterOptions, $imports } from '../use-filter-options';
 
 describe('sidebar/components/hooks/use-user-filter-options', () => {
   let fakeAccountId;

--- a/src/sidebar/components/hooks/test/use-root-thread-test.js
+++ b/src/sidebar/components/hooks/test/use-root-thread-test.js
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 
-import useRootThread, { $imports } from '../use-root-thread';
+import { useRootThread, $imports } from '../use-root-thread';
 
 describe('sidebar/components/hooks/use-root-thread', () => {
   let fakeStore;

--- a/src/sidebar/components/hooks/test/use-root-thread-test.js
+++ b/src/sidebar/components/hooks/test/use-root-thread-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
-import useRootThread from '../use-root-thread';
-import { $imports } from '../use-root-thread';
+import useRootThread, { $imports } from '../use-root-thread';
 
 describe('sidebar/components/hooks/use-root-thread', () => {
   let fakeStore;
@@ -20,7 +19,9 @@ describe('sidebar/components/hooks/use-root-thread', () => {
 
     $imports.$mock({
       '../../store/use-store': { useStoreProxy: () => fakeStore },
-      '../../helpers/thread-annotations': fakeThreadAnnotations,
+      '../../helpers/thread-annotations': {
+        threadAnnotations: fakeThreadAnnotations,
+      },
     });
 
     // Mount a dummy component to be able to use the `useRootThread` hook

--- a/src/sidebar/components/hooks/use-root-thread.js
+++ b/src/sidebar/components/hooks/use-root-thread.js
@@ -11,7 +11,7 @@ import { threadAnnotations } from '../../helpers/thread-annotations';
  *
  * @return {Thread}
  */
-export default function useRootThread() {
+export function useRootThread() {
   const store = useStoreProxy();
   const annotations = store.allAnnotations();
   const query = store.filterQuery();

--- a/src/sidebar/components/hooks/use-root-thread.js
+++ b/src/sidebar/components/hooks/use-root-thread.js
@@ -1,7 +1,7 @@
 import { useMemo } from 'preact/hooks';
 
 import { useStoreProxy } from '../../store/use-store';
-import threadAnnotations from '../../helpers/thread-annotations';
+import { threadAnnotations } from '../../helpers/thread-annotations';
 
 /** @typedef {import('../../helpers/build-thread').Thread} Thread */
 

--- a/src/sidebar/components/test/AnnotationView-test.js
+++ b/src/sidebar/components/test/AnnotationView-test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 
 import { waitFor } from '../../../test-util/wait';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 import AnnotationView, { $imports } from '../AnnotationView';
 

--- a/src/sidebar/components/test/AnnotationView-test.js
+++ b/src/sidebar/components/test/AnnotationView-test.js
@@ -2,7 +2,6 @@ import { mount } from 'enzyme';
 
 import { waitFor } from '../../../test-util/wait';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
-
 import AnnotationView, { $imports } from '../AnnotationView';
 
 describe('AnnotationView', () => {
@@ -32,7 +31,7 @@ describe('AnnotationView', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      './hooks/use-root-thread': fakeUseRootThread,
+      './hooks/use-root-thread': { useRootThread: fakeUseRootThread },
       '../store/use-store': { useStoreProxy: () => fakeStore },
     });
   });

--- a/src/sidebar/components/test/AutocompletList-test.js
+++ b/src/sidebar/components/test/AutocompletList-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
-import AutocompleteList from '../AutocompleteList';
-import { $imports } from '../AutocompleteList';
+import AutocompleteList, { $imports } from '../AutocompleteList';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/AutocompletList-test.js
+++ b/src/sidebar/components/test/AutocompletList-test.js
@@ -4,7 +4,7 @@ import AutocompleteList from '../AutocompleteList';
 import { $imports } from '../AutocompleteList';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('AutocompleteList', () => {
   let fakeList;

--- a/src/sidebar/components/test/Excerpt-test.js
+++ b/src/sidebar/components/test/Excerpt-test.js
@@ -1,8 +1,7 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import Excerpt from '../Excerpt';
-import { $imports } from '../Excerpt';
+import Excerpt, { $imports } from '../Excerpt';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 

--- a/src/sidebar/components/test/Excerpt-test.js
+++ b/src/sidebar/components/test/Excerpt-test.js
@@ -39,7 +39,9 @@ describe('Excerpt', () => {
     document.body.appendChild(container);
 
     $imports.$mock({
-      '../util/observe-element-size': fakeObserveElementSize,
+      '../util/observe-element-size': {
+        observeElementSize: fakeObserveElementSize,
+      },
     });
   });
 

--- a/src/sidebar/components/test/FilterSelect-test.js
+++ b/src/sidebar/components/test/FilterSelect-test.js
@@ -5,7 +5,7 @@ import { $imports } from '../FilterSelect';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('FilterSelect', () => {
   let someOptions;

--- a/src/sidebar/components/test/FilterSelect-test.js
+++ b/src/sidebar/components/test/FilterSelect-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
-import FilterSelect from '../FilterSelect';
-import { $imports } from '../FilterSelect';
+import FilterSelect, { $imports } from '../FilterSelect';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 

--- a/src/sidebar/components/test/FilterStatus-test.js
+++ b/src/sidebar/components/test/FilterStatus-test.js
@@ -1,8 +1,7 @@
 import { mount } from 'enzyme';
 
-import FilterStatus, { $imports } from '../FilterStatus';
-
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import FilterStatus, { $imports } from '../FilterStatus';
 
 function getFilterState() {
   return {
@@ -53,7 +52,7 @@ describe('FilterStatus', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      './hooks/use-root-thread': fakeUseRootThread,
+      './hooks/use-root-thread': { useRootThread: fakeUseRootThread },
       '../store/use-store': { useStoreProxy: () => fakeStore },
       '../helpers/thread': fakeThreadUtil,
     });

--- a/src/sidebar/components/test/FilterStatus-test.js
+++ b/src/sidebar/components/test/FilterStatus-test.js
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 
 import FilterStatus, { $imports } from '../FilterStatus';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 function getFilterState() {
   return {

--- a/src/sidebar/components/test/HelpPanel-test.js
+++ b/src/sidebar/components/test/HelpPanel-test.js
@@ -5,7 +5,7 @@ import HelpPanel from '../HelpPanel';
 import { $imports } from '../HelpPanel';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('HelpPanel', () => {
   let fakeAuth;

--- a/src/sidebar/components/test/HelpPanel-test.js
+++ b/src/sidebar/components/test/HelpPanel-test.js
@@ -41,7 +41,7 @@ describe('HelpPanel', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../store/use-store': { useStoreProxy: () => fakeStore },
-      '../helpers/version-data': FakeVersionData,
+      '../helpers/version-data': { VersionData: FakeVersionData },
     });
   });
 

--- a/src/sidebar/components/test/HelpPanel-test.js
+++ b/src/sidebar/components/test/HelpPanel-test.js
@@ -1,8 +1,7 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import HelpPanel from '../HelpPanel';
-import { $imports } from '../HelpPanel';
+import HelpPanel, { $imports } from '../HelpPanel';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/HypothesisApp-test.js
+++ b/src/sidebar/components/test/HypothesisApp-test.js
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import HypothesisApp, { $imports } from '../HypothesisApp';
 
 describe('HypothesisApp', () => {

--- a/src/sidebar/components/test/LoggedOutMessage-test.js
+++ b/src/sidebar/components/test/LoggedOutMessage-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
-import LoggedOutMessage from '../LoggedOutMessage';
-import { $imports } from '../LoggedOutMessage';
+import LoggedOutMessage, { $imports } from '../LoggedOutMessage';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/LoggedOutMessage-test.js
+++ b/src/sidebar/components/test/LoggedOutMessage-test.js
@@ -4,7 +4,7 @@ import LoggedOutMessage from '../LoggedOutMessage';
 import { $imports } from '../LoggedOutMessage';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('LoggedOutMessage', () => {
   let fakeStore;

--- a/src/sidebar/components/test/LoginPromptPanel-test.js
+++ b/src/sidebar/components/test/LoginPromptPanel-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
-import LoginPromptPanel from '../LoginPromptPanel';
-import { $imports } from '../LoginPromptPanel';
+import LoginPromptPanel, { $imports } from '../LoginPromptPanel';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/LoginPromptPanel-test.js
+++ b/src/sidebar/components/test/LoginPromptPanel-test.js
@@ -4,7 +4,7 @@ import LoginPromptPanel from '../LoginPromptPanel';
 import { $imports } from '../LoginPromptPanel';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('LoginPromptPanel', () => {
   let fakeOnLogin;

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -3,8 +3,7 @@ import { render } from 'preact';
 import { act } from 'preact/test-utils';
 
 import { LinkType } from '../../markdown-commands';
-import MarkdownEditor from '../MarkdownEditor';
-import { $imports } from '../MarkdownEditor';
+import MarkdownEditor, { $imports } from '../MarkdownEditor';
 
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import { checkAccessibility } from '../../../test-util/accessibility';

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -6,7 +6,7 @@ import { LinkType } from '../../markdown-commands';
 import MarkdownEditor from '../MarkdownEditor';
 import { $imports } from '../MarkdownEditor';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('MarkdownEditor', () => {

--- a/src/sidebar/components/test/MarkdownView-test.js
+++ b/src/sidebar/components/test/MarkdownView-test.js
@@ -1,23 +1,24 @@
 import { mount } from 'enzyme';
 
-import MarkdownView from '../MarkdownView';
-import { $imports } from '../MarkdownView';
+import MarkdownView, { $imports } from '../MarkdownView';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('MarkdownView', () => {
-  let fakeMediaEmbedder;
-  let fakeRenderMarkdown;
+  let fakeRenderMathAndMarkdown;
+  let fakeReplaceLinksWithEmbeds;
 
   beforeEach(() => {
-    fakeRenderMarkdown = markdown => `rendered:${markdown}`;
-    fakeMediaEmbedder = {
-      replaceLinksWithEmbeds: sinon.stub(),
-    };
+    fakeRenderMathAndMarkdown = markdown => `rendered:${markdown}`;
+    fakeReplaceLinksWithEmbeds = sinon.stub();
 
     $imports.$mock({
-      '../render-markdown': fakeRenderMarkdown,
-      '../media-embedder': fakeMediaEmbedder,
+      '../render-markdown': {
+        renderMathAndMarkdown: fakeRenderMathAndMarkdown,
+      },
+      '../media-embedder': {
+        replaceLinksWithEmbeds: fakeReplaceLinksWithEmbeds,
+      },
     });
   });
 
@@ -46,7 +47,7 @@ describe('MarkdownView', () => {
   it('replaces links with embeds in rendered output', () => {
     const wrapper = mount(<MarkdownView markdown="**test**" />);
     const rendered = wrapper.find('.MarkdownView').getDOMNode();
-    assert.calledWith(fakeMediaEmbedder.replaceLinksWithEmbeds, rendered, {
+    assert.calledWith(fakeReplaceLinksWithEmbeds, rendered, {
       className: 'MarkdownView__embed',
     });
   });

--- a/src/sidebar/components/test/Menu-test.js
+++ b/src/sidebar/components/test/Menu-test.js
@@ -4,7 +4,7 @@ import { act } from 'preact/test-utils';
 import Menu from '../Menu';
 import { $imports } from '../Menu';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('Menu', () => {

--- a/src/sidebar/components/test/MenuItem-test.js
+++ b/src/sidebar/components/test/MenuItem-test.js
@@ -5,7 +5,7 @@ import MenuItem from '../MenuItem';
 import { $imports } from '../MenuItem';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('MenuItem', () => {
   let containers = [];

--- a/src/sidebar/components/test/MenuItem-test.js
+++ b/src/sidebar/components/test/MenuItem-test.js
@@ -1,8 +1,7 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import MenuItem from '../MenuItem';
-import { $imports } from '../MenuItem';
+import MenuItem, { $imports } from '../MenuItem';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/MenuKeyboardNavigation-test.js
+++ b/src/sidebar/components/test/MenuKeyboardNavigation-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
-import MenuKeyboardNavigation from '../MenuKeyboardNavigation';
-import { $imports } from '../MenuKeyboardNavigation';
+import MenuKeyboardNavigation, { $imports } from '../MenuKeyboardNavigation';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/MenuKeyboardNavigation-test.js
+++ b/src/sidebar/components/test/MenuKeyboardNavigation-test.js
@@ -4,7 +4,7 @@ import MenuKeyboardNavigation from '../MenuKeyboardNavigation';
 import { $imports } from '../MenuKeyboardNavigation';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('MenuKeyboardNavigation', () => {
   let fakeCloseMenu;

--- a/src/sidebar/components/test/MenuSection-test.js
+++ b/src/sidebar/components/test/MenuSection-test.js
@@ -4,7 +4,7 @@ import MenuSection from '../MenuSection';
 import { $imports } from '../MenuSection';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('MenuSection', () => {
   const createMenuSection = props =>

--- a/src/sidebar/components/test/ModerationBanner-test.js
+++ b/src/sidebar/components/test/ModerationBanner-test.js
@@ -5,7 +5,7 @@ import ModerationBanner from '../ModerationBanner';
 import { $imports } from '../ModerationBanner';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 const moderatedAnnotation = fixtures.moderatedAnnotation;
 

--- a/src/sidebar/components/test/ModerationBanner-test.js
+++ b/src/sidebar/components/test/ModerationBanner-test.js
@@ -1,8 +1,7 @@
 import { mount } from 'enzyme';
 
 import * as fixtures from '../../test/annotation-fixtures';
-import ModerationBanner from '../ModerationBanner';
-import { $imports } from '../ModerationBanner';
+import ModerationBanner, { $imports } from '../ModerationBanner';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/NotebookFilters-test.js
+++ b/src/sidebar/components/test/NotebookFilters-test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import NotebookFilters from '../NotebookFilters';
 import { $imports } from '../NotebookFilters';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('NotebookFilters', () => {
   let fakeStore;

--- a/src/sidebar/components/test/NotebookResultCount-test.js
+++ b/src/sidebar/components/test/NotebookResultCount-test.js
@@ -2,8 +2,7 @@ import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 
-import NotebookResultCount from '../NotebookResultCount';
-import { $imports } from '../NotebookResultCount';
+import NotebookResultCount, { $imports } from '../NotebookResultCount';
 
 describe('NotebookResultCount', () => {
   let fakeCountVisible;

--- a/src/sidebar/components/test/NotebookResultCount-test.js
+++ b/src/sidebar/components/test/NotebookResultCount-test.js
@@ -26,7 +26,7 @@ describe('NotebookResultCount', () => {
     fakeUseRootThread = sinon.stub().returns({ children: [] });
 
     $imports.$mock({
-      './hooks/use-root-thread': fakeUseRootThread,
+      './hooks/use-root-thread': { useRootThread: fakeUseRootThread },
       '../helpers/thread': { countVisible: fakeCountVisible },
     });
   });

--- a/src/sidebar/components/test/NotebookView-test.js
+++ b/src/sidebar/components/test/NotebookView-test.js
@@ -2,9 +2,7 @@ import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
-
 import { ResultSizeError } from '../../search-client';
 import NotebookView, { $imports } from '../NotebookView';
 
@@ -44,7 +42,7 @@ describe('NotebookView', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      './hooks/use-root-thread': fakeUseRootThread,
+      './hooks/use-root-thread': { useRootThread: fakeUseRootThread },
       '../store/use-store': { useStoreProxy: () => fakeStore },
       'scroll-into-view': fakeScrollIntoView,
     });

--- a/src/sidebar/components/test/NotebookView-test.js
+++ b/src/sidebar/components/test/NotebookView-test.js
@@ -3,7 +3,7 @@ import { act } from 'preact/test-utils';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 import { ResultSizeError } from '../../search-client';
 import NotebookView, { $imports } from '../NotebookView';

--- a/src/sidebar/components/test/PaginatedThreadList-test.js
+++ b/src/sidebar/components/test/PaginatedThreadList-test.js
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 
 import PaginatedThreadList, { $imports } from '../PaginatedThreadList';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('PaginatedThreadList', () => {
   // Fake props

--- a/src/sidebar/components/test/SearchInput-test.js
+++ b/src/sidebar/components/test/SearchInput-test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import SearchInput from '../SearchInput';
 import { $imports } from '../SearchInput';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('SearchInput', () => {

--- a/src/sidebar/components/test/SelectionTabs-test.js
+++ b/src/sidebar/components/test/SelectionTabs-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
-import SelectionTabs from '../SelectionTabs';
-import { $imports } from '../SelectionTabs';
+import SelectionTabs, { $imports } from '../SelectionTabs';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/SelectionTabs-test.js
+++ b/src/sidebar/components/test/SelectionTabs-test.js
@@ -4,7 +4,7 @@ import SelectionTabs from '../SelectionTabs';
 import { $imports } from '../SelectionTabs';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('SelectionTabs', () => {
   // mock services

--- a/src/sidebar/components/test/ShareAnnotationsPanel-test.js
+++ b/src/sidebar/components/test/ShareAnnotationsPanel-test.js
@@ -4,7 +4,7 @@ import ShareAnnotationsPanel from '../ShareAnnotationsPanel';
 import { $imports } from '../ShareAnnotationsPanel';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('ShareAnnotationsPanel', () => {
   let fakeStore;

--- a/src/sidebar/components/test/ShareLinks-test.js
+++ b/src/sidebar/components/test/ShareLinks-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
-import ShareLinks from '../ShareLinks';
-import { $imports } from '../ShareLinks';
+import ShareLinks, { $imports } from '../ShareLinks';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/ShareLinks-test.js
+++ b/src/sidebar/components/test/ShareLinks-test.js
@@ -4,7 +4,7 @@ import ShareLinks from '../ShareLinks';
 import { $imports } from '../ShareLinks';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('ShareLinks', () => {
   const shareLink =

--- a/src/sidebar/components/test/SidebarContentError-test.js
+++ b/src/sidebar/components/test/SidebarContentError-test.js
@@ -4,7 +4,7 @@ import SidebarContentError from '../SidebarContentError';
 import { $imports } from '../SidebarContentError';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('SidebarContentError', () => {
   let fakeStore;

--- a/src/sidebar/components/test/SidebarPanel-test.js
+++ b/src/sidebar/components/test/SidebarPanel-test.js
@@ -4,7 +4,7 @@ import SidebarPanel from '../SidebarPanel';
 import { $imports } from '../SidebarPanel';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('SidebarPanel', () => {
   let fakeStore;

--- a/src/sidebar/components/test/SidebarPanel-test.js
+++ b/src/sidebar/components/test/SidebarPanel-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
-import SidebarPanel from '../SidebarPanel';
-import { $imports } from '../SidebarPanel';
+import SidebarPanel, { $imports } from '../SidebarPanel';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/SidebarView-test.js
+++ b/src/sidebar/components/test/SidebarView-test.js
@@ -4,7 +4,7 @@ import SidebarView from '../SidebarView';
 import { $imports } from '../SidebarView';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('SidebarView', () => {
   let fakeFrameSync;

--- a/src/sidebar/components/test/SidebarView-test.js
+++ b/src/sidebar/components/test/SidebarView-test.js
@@ -1,10 +1,8 @@
 import { mount } from 'enzyme';
 
-import SidebarView from '../SidebarView';
-import { $imports } from '../SidebarView';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import SidebarView, { $imports } from '../SidebarView';
 
 describe('SidebarView', () => {
   let fakeFrameSync;
@@ -70,7 +68,7 @@ describe('SidebarView', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      './hooks/use-root-thread': fakeUseRootThread,
+      './hooks/use-root-thread': { useRootThread: fakeUseRootThread },
       '../store/use-store': { useStoreProxy: () => fakeStore },
       '../helpers/tabs': fakeTabsUtil,
     });

--- a/src/sidebar/components/test/SortMenu-test.js
+++ b/src/sidebar/components/test/SortMenu-test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import SortMenu from '../SortMenu';
 import { $imports } from '../SortMenu';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('SortMenu', () => {
   let fakeStore;

--- a/src/sidebar/components/test/StreamSearchInput-test.js
+++ b/src/sidebar/components/test/StreamSearchInput-test.js
@@ -1,8 +1,7 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import StreamSearchInput from '../StreamSearchInput';
-import { $imports } from '../StreamSearchInput';
+import StreamSearchInput, { $imports } from '../StreamSearchInput';
 
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 

--- a/src/sidebar/components/test/StreamSearchInput-test.js
+++ b/src/sidebar/components/test/StreamSearchInput-test.js
@@ -4,7 +4,7 @@ import { act } from 'preact/test-utils';
 import StreamSearchInput from '../StreamSearchInput';
 import { $imports } from '../StreamSearchInput';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('StreamSearchInput', () => {
   let fakeRouter;

--- a/src/sidebar/components/test/StreamView-test.js
+++ b/src/sidebar/components/test/StreamView-test.js
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import { waitFor } from '../../../test-util/wait';
 
 import StreamView, { $imports } from '../StreamView';

--- a/src/sidebar/components/test/StreamView-test.js
+++ b/src/sidebar/components/test/StreamView-test.js
@@ -40,7 +40,7 @@ describe('StreamView', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      './hooks/use-root-thread': fakeUseRootThread,
+      './hooks/use-root-thread': { useRootThread: fakeUseRootThread },
       '../store/use-store': { useStoreProxy: () => fakeStore },
       '../util/search-filter': fakeSearchFilter,
     });

--- a/src/sidebar/components/test/TagEditor-test.js
+++ b/src/sidebar/components/test/TagEditor-test.js
@@ -6,7 +6,7 @@ import TagEditor from '../TagEditor';
 import { $imports } from '../TagEditor';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('TagEditor', () => {
   let containers = [];

--- a/src/sidebar/components/test/TagList-test.js
+++ b/src/sidebar/components/test/TagList-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
-import TagList from '../TagList';
-import { $imports } from '../TagList';
+import TagList, { $imports } from '../TagList';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/TagList-test.js
+++ b/src/sidebar/components/test/TagList-test.js
@@ -4,7 +4,7 @@ import TagList from '../TagList';
 import { $imports } from '../TagList';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('TagList', () => {
   let fakeIsThirdPartyUser;

--- a/src/sidebar/components/test/Thread-test.js
+++ b/src/sidebar/components/test/Thread-test.js
@@ -5,7 +5,7 @@ import Thread from '../Thread';
 import { $imports } from '../Thread';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 // Utility functions to build nested threads
 let lastThreadId = 0;

--- a/src/sidebar/components/test/ThreadCard-test.js
+++ b/src/sidebar/components/test/ThreadCard-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
-import ThreadCard from '../ThreadCard';
-import { $imports } from '../ThreadCard';
+import ThreadCard, { $imports } from '../ThreadCard';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/ThreadCard-test.js
+++ b/src/sidebar/components/test/ThreadCard-test.js
@@ -4,7 +4,7 @@ import ThreadCard from '../ThreadCard';
 import { $imports } from '../ThreadCard';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('ThreadCard', () => {
   let fakeDebounce;

--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -5,7 +5,7 @@ import ThreadList from '../ThreadList';
 import { $imports } from '../ThreadList';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('ThreadList', () => {
   let fakeDomUtil;

--- a/src/sidebar/components/test/ToastMessages-test.js
+++ b/src/sidebar/components/test/ToastMessages-test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 import ToastMessages, { $imports } from '../ToastMessages';
 import { checkAccessibility } from '../../../test-util/accessibility';

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import TopBar, { $imports } from '../TopBar';
 
 describe('TopBar', () => {

--- a/src/sidebar/components/test/Tutorial-test.js
+++ b/src/sidebar/components/test/Tutorial-test.js
@@ -4,7 +4,7 @@ import Tutorial from '../Tutorial';
 import { $imports } from '../Tutorial';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('Tutorial', () => {
   let fakeIsThirdPartyService;

--- a/src/sidebar/components/test/Tutorial-test.js
+++ b/src/sidebar/components/test/Tutorial-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
-import Tutorial from '../Tutorial';
-import { $imports } from '../Tutorial';
+import Tutorial, { $imports } from '../Tutorial';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import UserMenu, { $imports } from '../UserMenu';
 
 describe('UserMenu', () => {

--- a/src/sidebar/components/test/VersionInfo-test.js
+++ b/src/sidebar/components/test/VersionInfo-test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import VersionInfo from '../VersionInfo';
 import { $imports } from '../VersionInfo';
 
-import mockImportedComponents from '../../../test-util/mock-imported-components';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('VersionInfo', () => {

--- a/src/sidebar/config/fetch-config.js
+++ b/src/sidebar/config/fetch-config.js
@@ -1,5 +1,5 @@
 import { getApiUrl } from './get-api-url';
-import { hostPageConfig as hostConfig } from './host-config';
+import { hostPageConfig } from './host-config';
 import * as postMessageJsonRpc from '../util/postmessage-json-rpc';
 
 /**
@@ -89,10 +89,10 @@ function fetchConfigFromAncestorFrame(origin, window_ = window) {
  * @return {Promise<object>} - The merged settings.
  */
 function fetchConfigLegacy(appConfig, window_ = window) {
-  const hostPageConfig = hostConfig(window_);
+  const hostConfig = hostPageConfig(window_);
 
   let embedderConfig;
-  const origin = /** @type string */ (hostPageConfig.requestConfigFromFrame);
+  const origin = /** @type string */ (hostConfig.requestConfigFromFrame);
   embedderConfig = fetchConfigFromAncestorFrame(origin, window_);
 
   return embedderConfig.then(embedderConfig => {
@@ -190,13 +190,13 @@ async function fetchGroupsAsync(config, rpcCall) {
  * @return {Promise<MergedConfig>} - The merged settings.
  */
 export async function fetchConfig(appConfig, window_ = window) {
-  const hostPageConfig = hostConfig(window);
+  const hostConfig = hostPageConfig(window);
 
-  const requestConfigFromFrame = hostPageConfig.requestConfigFromFrame;
+  const requestConfigFromFrame = hostConfig.requestConfigFromFrame;
 
   if (!requestConfigFromFrame) {
     // Directly embed: just get the config.
-    return fetchConfigEmbed(appConfig, hostPageConfig);
+    return fetchConfigEmbed(appConfig, hostConfig);
   }
   if (typeof requestConfigFromFrame === 'string') {
     // Legacy: send RPC to all parents to find config. (deprecated)
@@ -222,7 +222,7 @@ export async function fetchConfig(appConfig, window_ = window) {
     // as this is needed in the Notebook.
     return {
       ...rpcMergedConfig,
-      ...(hostPageConfig.group ? { group: hostPageConfig.group } : {}),
+      ...(hostConfig.group ? { group: hostConfig.group } : {}),
     };
   } else {
     throw new Error(

--- a/src/sidebar/config/fetch-config.js
+++ b/src/sidebar/config/fetch-config.js
@@ -1,5 +1,5 @@
-import getApiUrl from './get-api-url';
-import hostConfig from './host-config';
+import { getApiUrl } from './get-api-url';
+import { hostPageConfig as hostConfig } from './host-config';
 import * as postMessageJsonRpc from '../util/postmessage-json-rpc';
 
 /**

--- a/src/sidebar/config/get-api-url.js
+++ b/src/sidebar/config/get-api-url.js
@@ -8,7 +8,7 @@ import { serviceConfig } from './service-config';
  * @throws {Error} If the settings has a service but the service doesn't have an apiUrl
  *
  */
-export default function getApiUrl(settings) {
+export function getApiUrl(settings) {
   const service = serviceConfig(settings);
 
   if (service) {

--- a/src/sidebar/config/host-config.js
+++ b/src/sidebar/config/host-config.js
@@ -15,7 +15,7 @@ import {
  * @param {Window} window
  * @return {HostConfig}
  */
-export default function hostPageConfig(window) {
+export function hostPageConfig(window) {
   const config = parseConfigFragment(window.location.href);
 
   // Known configuration parameters which we will import from the host page.

--- a/src/sidebar/config/test/fetch-config-test.js
+++ b/src/sidebar/config/test/fetch-config-test.js
@@ -1,26 +1,26 @@
 import { fetchConfig, $imports } from '../fetch-config';
 
 describe('sidebar/config/fetch-config', () => {
-  let fakeHostConfig;
+  let fakeHostPageConfig;
   let fakeJsonRpc;
   let fakeWindow;
   let fakeApiUrl;
   let fakeTopWindow;
 
   beforeEach(() => {
-    fakeHostConfig = sinon.stub();
+    fakeHostPageConfig = sinon.stub();
     fakeJsonRpc = {
       call: sinon.stub(),
     };
     fakeApiUrl = sinon.stub().returns('https://dev.hypothes.is/api/');
     $imports.$mock({
-      './host-config': fakeHostConfig,
+      './host-config': { hostPageConfig: fakeHostPageConfig },
       '../util/postmessage-json-rpc': fakeJsonRpc,
-      './get-api-url': fakeApiUrl,
+      './get-api-url': { getApiUrl: fakeApiUrl },
     });
 
     // By default, embedder provides no custom config.
-    fakeHostConfig.returns({});
+    fakeHostPageConfig.returns({});
 
     // By default, fetching config from parent frames fails.
     fakeJsonRpc.call.throws(new Error('call() response not set'));
@@ -59,7 +59,7 @@ describe('sidebar/config/fetch-config', () => {
       it('merges the hostPageConfig onto appConfig and returns the result', async () => {
         // hostPageConfig shall take precedent over appConfig
         const appConfig = { foo: 'bar', appType: 'via' };
-        fakeHostConfig.returns({ foo: 'baz' });
+        fakeHostPageConfig.returns({ foo: 'baz' });
         const mergedConfig = await fetchConfig(appConfig);
         assert.deepEqual(mergedConfig, {
           foo: 'baz',
@@ -79,7 +79,7 @@ describe('sidebar/config/fetch-config', () => {
       // exposed to the document itself.
       const expectedTimeout = 3000;
       beforeEach(() => {
-        fakeHostConfig.returns({
+        fakeHostPageConfig.returns({
           requestConfigFromFrame: 'https://embedder.com',
         });
         sinon.stub(console, 'warn');
@@ -169,7 +169,7 @@ describe('sidebar/config/fetch-config', () => {
       // exposed to the document itself.
       beforeEach(() => {
         fakeJsonRpc.call.resolves({});
-        fakeHostConfig.returns({
+        fakeHostPageConfig.returns({
           requestConfigFromFrame: {
             origin: 'https://embedder.com',
             ancestorLevel: 2,
@@ -192,7 +192,7 @@ describe('sidebar/config/fetch-config', () => {
 
       [0, 1, 2].forEach(level => {
         it(`finds ${level}'th ancestor window according to how high the level is`, async () => {
-          fakeHostConfig.returns({
+          fakeHostPageConfig.returns({
             requestConfigFromFrame: {
               origin: 'https://embedder.com',
               ancestorLevel: level,
@@ -205,7 +205,7 @@ describe('sidebar/config/fetch-config', () => {
       });
 
       it('throws an error when target ancestor exceeds top window', async () => {
-        fakeHostConfig.returns({
+        fakeHostPageConfig.returns({
           requestConfigFromFrame: {
             origin: 'https://embedder.com',
             ancestorLevel: 10, // The top window is only 2 levels high
@@ -279,7 +279,7 @@ describe('sidebar/config/fetch-config', () => {
       });
 
       it('creates a merged config and also adds back the `group` value from the host config', async () => {
-        fakeHostConfig.returns({
+        fakeHostPageConfig.returns({
           requestConfigFromFrame: {
             origin: 'https://embedder.com',
             ancestorLevel: 2,
@@ -306,7 +306,7 @@ describe('sidebar/config/fetch-config', () => {
       });
 
       it('missing ancestorLevel', async () => {
-        fakeHostConfig.returns({
+        fakeHostPageConfig.returns({
           requestConfigFromFrame: {
             origin: 'https://embedder.com',
             // missing ancestorLevel
@@ -319,7 +319,7 @@ describe('sidebar/config/fetch-config', () => {
       });
 
       it('missing origin', async () => {
-        fakeHostConfig.returns({
+        fakeHostPageConfig.returns({
           requestConfigFromFrame: {
             // missing origin
             ancestorLevel: 2,

--- a/src/sidebar/config/test/get-api-url-test.js
+++ b/src/sidebar/config/test/get-api-url-test.js
@@ -1,4 +1,4 @@
-import getApiUrl from '../get-api-url';
+import { getApiUrl } from '../get-api-url';
 
 describe('sidebar/config/get-api-url', () => {
   context('when there is a service object in settings', () => {

--- a/src/sidebar/config/test/host-config-test.js
+++ b/src/sidebar/config/test/host-config-test.js
@@ -1,5 +1,5 @@
 import { addConfigFragment } from '../../../shared/config-fragment';
-import hostPageConfig from '../host-config';
+import { hostPageConfig } from '../host-config';
 
 function fakeWindow(config) {
   return {

--- a/src/sidebar/cross-origin-rpc.js
+++ b/src/sidebar/cross-origin-rpc.js
@@ -1,4 +1,4 @@
-import warnOnce from '../shared/warn-once';
+import { warnOnce } from '../shared/warn-once';
 
 import { normalizeGroupIds } from './helpers/groups';
 

--- a/src/sidebar/helpers/build-thread.js
+++ b/src/sidebar/helpers/build-thread.js
@@ -284,7 +284,7 @@ const replySortCompareFn = (a, b) => {
  * @return {Thread} - The root thread, whose children are the top-level
  *                    annotations to display.
  */
-export default function buildThread(annotations, options) {
+export function buildThread(annotations, options) {
   const hasSelection = options.selected.length > 0;
   const hasForcedVisible = options.forcedVisible.length > 0;
 

--- a/src/sidebar/helpers/group-organizations.js
+++ b/src/sidebar/helpers/group-organizations.js
@@ -1,4 +1,4 @@
-import immutable from '../util/immutable';
+import { immutable } from '../util/immutable';
 
 /**
  * @typedef {import('../../types/api').Group} Group
@@ -83,7 +83,7 @@ function organizations(groups) {
  * @param {Array<Group>} groups
  * @return {Array<object>} - groups sorted by which organization they're in
  */
-export default function groupsByOrganization(groups) {
+export function groupsByOrganization(groups) {
   const orgs = organizations(groups);
   const defaultOrganizationGroups = [];
   const sortedGroups = [];

--- a/src/sidebar/helpers/test/build-thread-test.js
+++ b/src/sidebar/helpers/test/build-thread-test.js
@@ -1,4 +1,4 @@
-import buildThread from '../build-thread';
+import { buildThread } from '../build-thread';
 import * as metadata from '../../helpers/annotation-metadata';
 
 // Fixture with two top level annotations, one note and one reply

--- a/src/sidebar/helpers/test/group-organizations-test.js
+++ b/src/sidebar/helpers/test/group-organizations-test.js
@@ -1,5 +1,5 @@
 import * as orgFixtures from '../../test/group-fixtures';
-import groupsByOrganization from '../group-organizations';
+import { groupsByOrganization } from '../group-organizations';
 
 describe('sidebar/helpers/group-organizations', () => {
   context('when sorting organizations and their contained groups', () => {

--- a/src/sidebar/helpers/test/is-third-party-service-test.js
+++ b/src/sidebar/helpers/test/is-third-party-service-test.js
@@ -1,5 +1,4 @@
-import { isThirdPartyService } from '../is-third-party-service';
-import { $imports } from '../is-third-party-service';
+import { isThirdPartyService, $imports } from '../is-third-party-service';
 
 describe('sidebar/helpers/is-third-party-service', () => {
   let fakeServiceConfig;

--- a/src/sidebar/helpers/test/thread-annotations-test.js
+++ b/src/sidebar/helpers/test/thread-annotations-test.js
@@ -1,9 +1,8 @@
 import * as annotationFixtures from '../../test/annotation-fixtures';
 
-import threadAnnotations from '../thread-annotations';
+import { threadAnnotations, $imports } from '../thread-annotations';
 import { sorters } from '../thread-sorters';
-import { $imports } from '../thread-annotations';
-import immutable from '../../util/immutable';
+import { immutable } from '../../util/immutable';
 
 const fixtures = immutable({
   emptyThread: {
@@ -45,9 +44,9 @@ describe('sidebar/helpers/thread-annotations', () => {
     };
 
     $imports.$mock({
-      './build-thread': fakeBuildThread,
+      './build-thread': { buildThread: fakeBuildThread },
       '../util/search-filter': fakeSearchFilter,
-      './view-filter': fakeFilterAnnotations,
+      './view-filter': { filterAnnotations: fakeFilterAnnotations },
     });
   });
 

--- a/src/sidebar/helpers/test/version-data-test.js
+++ b/src/sidebar/helpers/test/version-data-test.js
@@ -1,4 +1,4 @@
-import VersionData from '../version-data';
+import { VersionData } from '../version-data';
 
 describe('sidebar/helpers/version-data', () => {
   let clock;

--- a/src/sidebar/helpers/test/view-filter-test.js
+++ b/src/sidebar/helpers/test/view-filter-test.js
@@ -1,4 +1,4 @@
-import filterAnnotations, { $imports } from '../view-filter';
+import { filterAnnotations, $imports } from '../view-filter';
 
 function isoDateWithAge(age) {
   return new Date(Date.now() - age * 1000).toISOString();

--- a/src/sidebar/helpers/thread-annotations.js
+++ b/src/sidebar/helpers/thread-annotations.js
@@ -1,8 +1,8 @@
-import buildThread from './build-thread';
+import { buildThread } from './build-thread';
 
-import memoize from '../util/memoize';
+import { memoize } from '../util/memoize';
 import { generateFacetedFilter } from '../util/search-filter';
-import filterAnnotations from './view-filter';
+import { filterAnnotations } from './view-filter';
 import { shouldShowInTab } from './tabs';
 import { sorters } from './thread-sorters';
 
@@ -71,6 +71,4 @@ function buildRootThread(threadState) {
   return buildThread(threadState.annotations, options);
 }
 
-const threadAnnotations = memoize(buildRootThread);
-
-export default threadAnnotations;
+export const threadAnnotations = memoize(buildRootThread);

--- a/src/sidebar/helpers/version-data.js
+++ b/src/sidebar/helpers/version-data.js
@@ -19,7 +19,7 @@
  * @prop {DocMetadata} [metadata] - Document metadata
  */
 
-export default class VersionData {
+export class VersionData {
   /**
    * @param {AuthState} userInfo
    * @param {DocumentInfo[]} documentInfo - Metadata for connected frames.

--- a/src/sidebar/helpers/view-filter.js
+++ b/src/sidebar/helpers/view-filter.js
@@ -158,7 +158,7 @@ const fieldMatchers = {
  * `generateFacetedFilter`.
  * @return {string[]} IDs of matching annotations.
  */
-export default function filterAnnotations(annotations, filters) {
+export function filterAnnotations(annotations, filters) {
   // Convert the input filter object into a filter tree, expanding "any"
   // filters.
   const fieldFilters = Object.entries(filters)

--- a/src/sidebar/icons.js
+++ b/src/sidebar/icons.js
@@ -56,7 +56,7 @@ import pointerIcon from '../images/icons/pointer.svg';
  * Set of icons used by the sidebar application via the `SvgIcon`
  * component.
  */
-export default {
+export const sidebarIcons = {
   add: plus,
   annotate: annotateIcon,
   'arrow-left': arrowLeft,

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -7,7 +7,7 @@ import {
   startServer as startRPCServer,
   preStartServer as preStartRPCServer,
 } from './cross-origin-rpc.js';
-import disableOpenerForExternalLinks from './util/disable-opener-for-external-links';
+import { disableOpenerForExternalLinks } from './util/disable-opener-for-external-links';
 import * as sentry from './util/sentry';
 
 // Read settings rendered into sidebar app HTML by service/extension.
@@ -100,9 +100,9 @@ function setupFrameSync(frameSync, store) {
 
 // Register icons used by the sidebar app (and maybe other assets in future).
 import { registerIcons } from '@hypothesis/frontend-shared';
-import iconSet from './icons';
+import { sidebarIcons } from './icons';
 
-registerIcons(iconSet);
+registerIcons(sidebarIcons);
 
 // The entry point component for the app.
 import { render } from 'preact';

--- a/src/sidebar/render-markdown.js
+++ b/src/sidebar/render-markdown.js
@@ -131,7 +131,7 @@ function insertMath(html, mathBlocks) {
   }, html);
 }
 
-export default function renderMathAndMarkdown(markdown) {
+export function renderMathAndMarkdown(markdown) {
   // KaTeX takes care of escaping its input, so we want to avoid passing its
   // output through the HTML sanitizer. Therefore we first extract the math
   // blocks from the input, render and sanitize the remaining markdown and then

--- a/src/sidebar/services/auth.js
+++ b/src/sidebar/services/auth.js
@@ -1,7 +1,7 @@
 import { TinyEmitter } from 'tiny-emitter';
 
 import { serviceConfig } from '../config/service-config';
-import OAuthClient from '../util/oauth-client';
+import { OAuthClient } from '../util/oauth-client';
 import { resolve } from '../util/url';
 
 /**

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -1,7 +1,7 @@
 import { generateHexString } from '../../shared/random';
-import warnOnce from '../../shared/warn-once';
-import { Socket } from '../websocket';
+import { warnOnce } from '../../shared/warn-once';
 import { watch } from '../util/watch';
+import { Socket } from '../websocket';
 
 /**
  * `StreamerService` manages the WebSocket connection to the Hypothesis Real-Time

--- a/src/sidebar/services/test/auth-test.js
+++ b/src/sidebar/services/test/auth-test.js
@@ -1,5 +1,5 @@
 import { Injector } from '../../../shared/injector';
-import FakeWindow from '../../test/fake-window';
+import { FakeWindow } from '../../test/fake-window';
 import { AuthService, $imports } from '../auth';
 
 const DEFAULT_TOKEN_EXPIRES_IN_SECS = 1000;
@@ -87,7 +87,7 @@ describe('AuthService', () => {
     fakeWindow = new FakeWindow();
 
     $imports.$mock({
-      '../util/oauth-client': FakeOAuthClient,
+      '../util/oauth-client': { OAuthClient: FakeOAuthClient },
     });
 
     auth = new Injector()

--- a/src/sidebar/services/test/autosave-test.js
+++ b/src/sidebar/services/test/autosave-test.js
@@ -1,5 +1,5 @@
 import * as annotationFixtures from '../../test/annotation-fixtures';
-import createFakeStore from '../../test/fake-redux-store';
+import { fakeReduxStore } from '../../test/fake-redux-store';
 import { waitFor } from '../../../test-util/wait';
 
 import { AutosaveService, $imports } from '../autosave';
@@ -14,7 +14,7 @@ describe('AutosaveService', () => {
     fakeAnnotationsService = { save: sinon.stub().resolves() };
     fakeNewHighlights = sinon.stub().returns([]);
     fakeRetryPromiseOperation = sinon.stub().callsFake(callback => callback());
-    fakeStore = createFakeStore({}, { newHighlights: fakeNewHighlights });
+    fakeStore = fakeReduxStore({}, { newHighlights: fakeNewHighlights });
 
     $imports.$mock({
       '../util/retry': {

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -2,7 +2,7 @@ import EventEmitter from 'tiny-emitter';
 
 import { Injector } from '../../../shared/injector';
 import * as annotationFixtures from '../../test/annotation-fixtures';
-import createFakeStore from '../../test/fake-redux-store';
+import { fakeReduxStore } from '../../test/fake-redux-store';
 import { delay } from '../../../test-util/wait';
 
 import { FrameSyncService, $imports, formatAnnot } from '../frame-sync';
@@ -91,7 +91,7 @@ describe('FrameSyncService', () => {
       discover: sinon.stub().resolves(sidebarPort),
     };
 
-    fakeStore = createFakeStore(
+    fakeStore = fakeReduxStore(
       { annotations: [] },
       {
         allAnnotations() {

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -1,5 +1,5 @@
 import { delay, waitFor } from '../../../test-util/wait';
-import fakeReduxStore from '../../test/fake-redux-store';
+import { fakeReduxStore } from '../../test/fake-redux-store';
 import { GroupsService, $imports } from '../groups';
 
 /**

--- a/src/sidebar/services/test/persisted-defaults-test.js
+++ b/src/sidebar/services/test/persisted-defaults-test.js
@@ -1,4 +1,4 @@
-import fakeReduxStore from '../../test/fake-redux-store';
+import { fakeReduxStore } from '../../test/fake-redux-store';
 import { PersistedDefaultsService } from '../persisted-defaults';
 
 const DEFAULT_KEYS = {

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'tiny-emitter';
 
 import { delay } from '../../../test-util/wait';
-import fakeReduxStore from '../../test/fake-redux-store';
+import { fakeReduxStore } from '../../test/fake-redux-store';
 import { StreamerService, $imports } from '../streamer';
 
 const fixtures = {
@@ -129,7 +129,7 @@ describe('StreamerService', () => {
     fakeWarnOnce = sinon.stub();
 
     $imports.$mock({
-      '../../shared/warn-once': fakeWarnOnce,
+      '../../shared/warn-once': { warnOnce: fakeWarnOnce },
       '../websocket': { Socket: FakeSocket },
     });
   });

--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -3,7 +3,7 @@
 import * as redux from 'redux';
 import thunk from 'redux-thunk';
 
-import immutable from '../util/immutable';
+import { immutable } from '../util/immutable';
 
 import { createReducer, bindSelectors } from './util';
 

--- a/src/sidebar/store/debug-middleware.js
+++ b/src/sidebar/store/debug-middleware.js
@@ -10,7 +10,7 @@
  *
  * @param {import("redux").Store} store
  */
-export default function debugMiddleware(store) {
+export function debugMiddleware(store) {
   /* eslint-disable no-console */
   let serial = 0;
 

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -1,21 +1,21 @@
 import { createStore } from './create-store';
 import { debugMiddleware } from './debug-middleware';
-import { activity } from './modules/activity';
-import { annotations } from './modules/annotations';
-import { defaults } from './modules/defaults';
-import { directLinked } from './modules/direct-linked';
-import { drafts } from './modules/drafts';
-import { filters } from './modules/filters';
-import { framesModule as frames } from './modules/frames';
-import { groups } from './modules/groups';
-import { links } from './modules/links';
-import { realTimeUpdates } from './modules/real-time-updates';
-import { routeModule as route } from './modules/route';
-import { selection } from './modules/selection';
-import { session } from './modules/session';
-import { sidebarPanels } from './modules/sidebar-panels';
-import { toastMessages } from './modules/toast-messages';
-import { viewer } from './modules/viewer';
+import { activityModule } from './modules/activity';
+import { annotationsModule } from './modules/annotations';
+import { defaultsModule } from './modules/defaults';
+import { directLinkedModule } from './modules/direct-linked';
+import { draftsModule } from './modules/drafts';
+import { filtersModule } from './modules/filters';
+import { framesModule } from './modules/frames';
+import { groupsModule } from './modules/groups';
+import { linksModule } from './modules/links';
+import { realTimeUpdatesModule } from './modules/real-time-updates';
+import { routeModule } from './modules/route';
+import { selectionModule } from './modules/selection';
+import { sessionModule } from './modules/session';
+import { sidebarPanelsModule } from './modules/sidebar-panels';
+import { toastMessagesModule } from './modules/toast-messages';
+import { viewerModule } from './modules/viewer';
 
 /**
  * @template M
@@ -23,22 +23,22 @@ import { viewer } from './modules/viewer';
  */
 
 /**
- * @typedef {StoreFromModule<activity> &
- *   StoreFromModule<annotations> &
- *   StoreFromModule<defaults> &
- *   StoreFromModule<directLinked> &
- *   StoreFromModule<drafts> &
- *   StoreFromModule<filters> &
- *   StoreFromModule<frames> &
- *   StoreFromModule<groups> &
- *   StoreFromModule<links> &
- *   StoreFromModule<realTimeUpdates> &
- *   StoreFromModule<route> &
- *   StoreFromModule<selection> &
- *   StoreFromModule<session> &
- *   StoreFromModule<sidebarPanels> &
- *   StoreFromModule<toastMessages> &
- *   StoreFromModule<viewer>
+ * @typedef {StoreFromModule<activityModule> &
+ *   StoreFromModule<annotationsModule> &
+ *   StoreFromModule<defaultsModule> &
+ *   StoreFromModule<directLinkedModule> &
+ *   StoreFromModule<draftsModule> &
+ *   StoreFromModule<filtersModule> &
+ *   StoreFromModule<framesModule> &
+ *   StoreFromModule<groupsModule> &
+ *   StoreFromModule<linksModule> &
+ *   StoreFromModule<realTimeUpdatesModule> &
+ *   StoreFromModule<routeModule> &
+ *   StoreFromModule<selectionModule> &
+ *   StoreFromModule<sessionModule> &
+ *   StoreFromModule<sidebarPanelsModule> &
+ *   StoreFromModule<toastMessagesModule> &
+ *   StoreFromModule<viewerModule>
  *  } SidebarStore
  */
 
@@ -59,22 +59,22 @@ export function createSidebarStore(settings) {
   const middleware = [debugMiddleware];
 
   const modules = [
-    activity,
-    annotations,
-    defaults,
-    directLinked,
-    drafts,
-    filters,
-    frames,
-    links,
-    groups,
-    realTimeUpdates,
-    route,
-    selection,
-    session,
-    sidebarPanels,
-    toastMessages,
-    viewer,
+    activityModule,
+    annotationsModule,
+    defaultsModule,
+    directLinkedModule,
+    draftsModule,
+    filtersModule,
+    framesModule,
+    linksModule,
+    groupsModule,
+    realTimeUpdatesModule,
+    routeModule,
+    selectionModule,
+    sessionModule,
+    sidebarPanelsModule,
+    toastMessagesModule,
+    viewerModule,
   ];
   return /** @type {SidebarStore} */ (
     createStore(modules, [settings], middleware)

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -1,21 +1,21 @@
 import { createStore } from './create-store';
-import debugMiddleware from './debug-middleware';
-import activity from './modules/activity';
-import annotations from './modules/annotations';
-import defaults from './modules/defaults';
-import directLinked from './modules/direct-linked';
-import drafts from './modules/drafts';
-import filters from './modules/filters';
-import frames from './modules/frames';
-import groups from './modules/groups';
-import links from './modules/links';
-import realTimeUpdates from './modules/real-time-updates';
-import route from './modules/route';
-import selection from './modules/selection';
-import session from './modules/session';
-import sidebarPanels from './modules/sidebar-panels';
-import toastMessages from './modules/toast-messages';
-import viewer from './modules/viewer';
+import { debugMiddleware } from './debug-middleware';
+import { activity } from './modules/activity';
+import { annotations } from './modules/annotations';
+import { defaults } from './modules/defaults';
+import { directLinked } from './modules/direct-linked';
+import { drafts } from './modules/drafts';
+import { filters } from './modules/filters';
+import { framesModule as frames } from './modules/frames';
+import { groups } from './modules/groups';
+import { links } from './modules/links';
+import { realTimeUpdates } from './modules/real-time-updates';
+import { routeModule as route } from './modules/route';
+import { selection } from './modules/selection';
+import { session } from './modules/session';
+import { sidebarPanels } from './modules/sidebar-panels';
+import { toastMessages } from './modules/toast-messages';
+import { viewer } from './modules/viewer';
 
 /**
  * @template M

--- a/src/sidebar/store/modules/activity.js
+++ b/src/sidebar/store/modules/activity.js
@@ -190,7 +190,7 @@ function isSavingAnnotation(state, annotation) {
 
 /** @typedef {import('../../../types/api').Annotation} Annotation */
 
-export default createStoreModule(initialState, {
+export const activity = createStoreModule(initialState, {
   reducers,
   namespace: 'activity',
 

--- a/src/sidebar/store/modules/activity.js
+++ b/src/sidebar/store/modules/activity.js
@@ -190,7 +190,7 @@ function isSavingAnnotation(state, annotation) {
 
 /** @typedef {import('../../../types/api').Annotation} Annotation */
 
-export const activity = createStoreModule(initialState, {
+export const activityModule = createStoreModule(initialState, {
   reducers,
   namespace: 'activity',
 

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -559,7 +559,7 @@ function savedAnnotations(state) {
   });
 }
 
-export const annotations = createStoreModule(initialState, {
+export const annotationsModule = createStoreModule(initialState, {
   namespace: 'annotations',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -19,7 +19,7 @@ import { countIf, toTrueMap, trueKeys } from '../../util/collections';
 import * as util from '../util';
 import { createStoreModule } from '../create-store';
 
-import route from './route';
+import { routeModule as route } from './route';
 
 /**
  * Return a copy of `current` with all matching annotations in `annotations`
@@ -559,7 +559,7 @@ function savedAnnotations(state) {
   });
 }
 
-export default createStoreModule(initialState, {
+export const annotations = createStoreModule(initialState, {
   namespace: 'annotations',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/defaults.js
+++ b/src/sidebar/store/modules/defaults.js
@@ -49,7 +49,7 @@ function getDefaults(state) {
   return state;
 }
 
-export default createStoreModule(initialState, {
+export const defaults = createStoreModule(initialState, {
   namespace: 'defaults',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/defaults.js
+++ b/src/sidebar/store/modules/defaults.js
@@ -49,7 +49,7 @@ function getDefaults(state) {
   return state;
 }
 
-export const defaults = createStoreModule(initialState, {
+export const defaultsModule = createStoreModule(initialState, {
   namespace: 'defaults',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/direct-linked.js
+++ b/src/sidebar/store/modules/direct-linked.js
@@ -142,7 +142,7 @@ function directLinkedGroupFetchFailed(state) {
   return state.directLinkedGroupFetchFailed;
 }
 
-export const directLinked = createStoreModule(initialState, {
+export const directLinkedModule = createStoreModule(initialState, {
   namespace: 'directLinked',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/direct-linked.js
+++ b/src/sidebar/store/modules/direct-linked.js
@@ -142,7 +142,7 @@ function directLinkedGroupFetchFailed(state) {
   return state.directLinkedGroupFetchFailed;
 }
 
-export default createStoreModule(initialState, {
+export const directLinked = createStoreModule(initialState, {
   namespace: 'directLinked',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/drafts.js
+++ b/src/sidebar/store/modules/drafts.js
@@ -186,7 +186,7 @@ const unsavedAnnotations = createSelector(
   drafts => drafts.filter(d => !d.annotation.id).map(d => d.annotation)
 );
 
-export default createStoreModule(initialState, {
+export const drafts = createStoreModule(initialState, {
   namespace: 'drafts',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/drafts.js
+++ b/src/sidebar/store/modules/drafts.js
@@ -186,7 +186,7 @@ const unsavedAnnotations = createSelector(
   drafts => drafts.filter(d => !d.annotation.id).map(d => d.annotation)
 );
 
-export const drafts = createStoreModule(initialState, {
+export const draftsModule = createStoreModule(initialState, {
   namespace: 'drafts',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/filters.js
+++ b/src/sidebar/store/modules/filters.js
@@ -279,7 +279,7 @@ function hasAppliedFilter(state) {
   return !!(state.query || Object.keys(getFilters(state)).length);
 }
 
-export const filters = createStoreModule(initialState, {
+export const filtersModule = createStoreModule(initialState, {
   namespace: 'filters',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/filters.js
+++ b/src/sidebar/store/modules/filters.js
@@ -279,7 +279,7 @@ function hasAppliedFilter(state) {
   return !!(state.query || Object.keys(getFilters(state)).length);
 }
 
-export default createStoreModule(initialState, {
+export const filters = createStoreModule(initialState, {
   namespace: 'filters',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -155,7 +155,7 @@ const searchUris = createShallowEqualSelector(
   uris => uris
 );
 
-export default createStoreModule(initialState, {
+export const framesModule = createStoreModule(initialState, {
   namespace: 'frames',
   reducers,
 

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 import * as util from '../util';
 import { createStoreModule } from '../create-store';
 
-import session from './session';
+import { session } from './session';
 
 /**
  * @typedef {import('../../../types/api').Group} Group
@@ -261,7 +261,7 @@ const getCurrentlyViewingGroups = createSelector(
   }
 );
 
-export default createStoreModule(initialState, {
+export const groups = createStoreModule(initialState, {
   namespace: 'groups',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 import * as util from '../util';
 import { createStoreModule } from '../create-store';
 
-import { session } from './session';
+import { sessionModule } from './session';
 
 /**
  * @typedef {import('../../../types/api').Group} Group
@@ -235,7 +235,7 @@ const getInScopeGroups = createSelector(
 const getMyGroups = createSelector(
   /** @param {{ groups: State, session: SessionState }} rootState */
   rootState => filteredGroups(rootState.groups),
-  rootState => session.selectors.isLoggedIn(rootState.session),
+  rootState => sessionModule.selectors.isLoggedIn(rootState.session),
   (groups, loggedIn) => {
     // If logged out, the Public group still has isMember set to true so only
     // return groups with membership in logged in state.
@@ -261,7 +261,7 @@ const getCurrentlyViewingGroups = createSelector(
   }
 );
 
-export const groups = createStoreModule(initialState, {
+export const groupsModule = createStoreModule(initialState, {
   namespace: 'groups',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/links.js
+++ b/src/sidebar/store/modules/links.js
@@ -51,7 +51,7 @@ function getLink(state, linkName, params = {}) {
   return url;
 }
 
-export const links = createStoreModule(initialState, {
+export const linksModule = createStoreModule(initialState, {
   namespace: 'links',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/links.js
+++ b/src/sidebar/store/modules/links.js
@@ -51,7 +51,7 @@ function getLink(state, linkName, params = {}) {
   return url;
 }
 
-export default createStoreModule(initialState, {
+export const links = createStoreModule(initialState, {
   namespace: 'links',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -12,9 +12,9 @@ import { createSelector } from 'reselect';
 import { createStoreModule } from '../create-store';
 import { actionTypes } from '../util';
 
-import { annotations } from './annotations';
-import { groups } from './groups';
-import { routeModule as route } from './route';
+import { annotationsModule } from './annotations';
+import { groupsModule } from './groups';
+import { routeModule } from './route';
 
 const initialState = {
   /**
@@ -112,8 +112,8 @@ function receiveRealTimeUpdates({
       const routeState = getState().route;
 
       if (
-        ann.group === groups.selectors.focusedGroupId(groupState) ||
-        route.selectors.route(routeState) !== 'sidebar'
+        ann.group === groupsModule.selectors.focusedGroupId(groupState) ||
+        routeModule.selectors.route(routeState) !== 'sidebar'
       ) {
         pendingUpdates[/** @type {string} */ (ann.id)] = ann;
       }
@@ -130,7 +130,7 @@ function receiveRealTimeUpdates({
       // new annotation (saved in pendingUpdates and removed above), that has
       // not yet been loaded.
       const annotationsState = getState().annotations;
-      if (annotations.selectors.annotationExists(annotationsState, id)) {
+      if (annotationsModule.selectors.annotationExists(annotationsState, id)) {
         pendingDeletions[id] = true;
       }
     });
@@ -193,7 +193,7 @@ function hasPendingDeletion(state, id) {
   return state.pendingDeletions.hasOwnProperty(id);
 }
 
-export const realTimeUpdates = createStoreModule(initialState, {
+export const realTimeUpdatesModule = createStoreModule(initialState, {
   namespace: 'realTimeUpdates',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -12,9 +12,9 @@ import { createSelector } from 'reselect';
 import { createStoreModule } from '../create-store';
 import { actionTypes } from '../util';
 
-import annotations from './annotations';
-import groups from './groups';
-import route from './route';
+import { annotations } from './annotations';
+import { groups } from './groups';
+import { routeModule as route } from './route';
 
 const initialState = {
   /**
@@ -193,7 +193,7 @@ function hasPendingDeletion(state, id) {
   return state.pendingDeletions.hasOwnProperty(id);
 }
 
-export default createStoreModule(initialState, {
+export const realTimeUpdates = createStoreModule(initialState, {
   namespace: 'realTimeUpdates',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/route.js
+++ b/src/sidebar/store/modules/route.js
@@ -63,7 +63,7 @@ function routeParams(state) {
   return state.params;
 }
 
-export default createStoreModule(initialState, {
+export const routeModule = createStoreModule(initialState, {
   namespace: 'route',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -381,7 +381,7 @@ const sortKeys = createSelector(
   }
 );
 
-export default createStoreModule(initialState, {
+export const selection = createStoreModule(initialState, {
   namespace: 'selection',
   reducers,
 

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -381,7 +381,7 @@ const sortKeys = createSelector(
   }
 );
 
-export const selection = createStoreModule(initialState, {
+export const selectionModule = createStoreModule(initialState, {
   namespace: 'selection',
   reducers,
 

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -117,7 +117,7 @@ function profile(state) {
   return state.profile;
 }
 
-export const session = createStoreModule(initialState, {
+export const sessionModule = createStoreModule(initialState, {
   namespace: 'session',
   reducers,
 

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -117,7 +117,7 @@ function profile(state) {
   return state.profile;
 }
 
-export default createStoreModule(initialState, {
+export const session = createStoreModule(initialState, {
   namespace: 'session',
   reducers,
 

--- a/src/sidebar/store/modules/sidebar-panels.js
+++ b/src/sidebar/store/modules/sidebar-panels.js
@@ -121,7 +121,7 @@ function isSidebarPanelOpen(state, panelName) {
   return state.activePanelName === panelName;
 }
 
-export const sidebarPanels = createStoreModule(initialState, {
+export const sidebarPanelsModule = createStoreModule(initialState, {
   namespace: 'sidebarPanels',
   reducers,
 

--- a/src/sidebar/store/modules/sidebar-panels.js
+++ b/src/sidebar/store/modules/sidebar-panels.js
@@ -121,7 +121,7 @@ function isSidebarPanelOpen(state, panelName) {
   return state.activePanelName === panelName;
 }
 
-export default createStoreModule(initialState, {
+export const sidebarPanels = createStoreModule(initialState, {
   namespace: 'sidebarPanels',
   reducers,
 

--- a/src/sidebar/store/modules/test/activity-test.js
+++ b/src/sidebar/store/modules/test/activity-test.js
@@ -1,5 +1,5 @@
 import { createStore } from '../../create-store';
-import activity from '../activity';
+import { activity } from '../activity';
 
 describe('sidebar/store/modules/activity', () => {
   let store;

--- a/src/sidebar/store/modules/test/activity-test.js
+++ b/src/sidebar/store/modules/test/activity-test.js
@@ -1,11 +1,11 @@
 import { createStore } from '../../create-store';
-import { activity } from '../activity';
+import { activityModule } from '../activity';
 
 describe('sidebar/store/modules/activity', () => {
   let store;
 
   beforeEach(() => {
-    store = createStore([activity]);
+    store = createStore([activityModule]);
   });
 
   describe('hasFetchedAnnotations', () => {

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -1,11 +1,11 @@
 import * as fixtures from '../../../test/annotation-fixtures';
 import * as metadata from '../../../helpers/annotation-metadata';
 import { createStore } from '../../create-store';
-import { annotations } from '../annotations';
-import { routeModule as route } from '../route';
+import { annotationsModule } from '../annotations';
+import { routeModule } from '../route';
 
 function createTestStore() {
-  return createStore([annotations, route], [{}]);
+  return createStore([annotationsModule, routeModule], [{}]);
 }
 
 // Tests for some of the functionality in this store module are currently in

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -1,8 +1,8 @@
 import * as fixtures from '../../../test/annotation-fixtures';
 import * as metadata from '../../../helpers/annotation-metadata';
 import { createStore } from '../../create-store';
-import annotations from '../annotations';
-import route from '../route';
+import { annotations } from '../annotations';
+import { routeModule as route } from '../route';
 
 function createTestStore() {
   return createStore([annotations, route], [{}]);

--- a/src/sidebar/store/modules/test/defaults-test.js
+++ b/src/sidebar/store/modules/test/defaults-test.js
@@ -1,11 +1,11 @@
 import { createStore } from '../../create-store';
-import { defaults } from '../defaults';
+import { defaultsModule } from '../defaults';
 
 describe('store/modules/defaults', () => {
   let store;
 
   beforeEach(() => {
-    store = createStore([defaults]);
+    store = createStore([defaultsModule]);
   });
 
   describe('actions', () => {

--- a/src/sidebar/store/modules/test/defaults-test.js
+++ b/src/sidebar/store/modules/test/defaults-test.js
@@ -1,5 +1,5 @@
 import { createStore } from '../../create-store';
-import defaults from '../defaults';
+import { defaults } from '../defaults';
 
 describe('store/modules/defaults', () => {
   let store;

--- a/src/sidebar/store/modules/test/direct-linked-test.js
+++ b/src/sidebar/store/modules/test/direct-linked-test.js
@@ -1,5 +1,5 @@
 import { createStore } from '../../create-store';
-import { directLinked } from '../direct-linked';
+import { directLinkedModule } from '../direct-linked';
 
 describe('sidebar/store/modules/direct-linked', () => {
   let store;
@@ -11,7 +11,7 @@ describe('sidebar/store/modules/direct-linked', () => {
 
   beforeEach(() => {
     fakeSettings = {};
-    store = createStore([directLinked], [fakeSettings]);
+    store = createStore([directLinkedModule], [fakeSettings]);
   });
 
   describe('setDirectLinkedGroupFetchFailed', () => {
@@ -35,7 +35,7 @@ describe('sidebar/store/modules/direct-linked', () => {
   it('sets directLinkedAnnotationId to settings.annotations during store init', () => {
     fakeSettings.annotations = 'ann-id';
 
-    store = createStore([directLinked], [fakeSettings]);
+    store = createStore([directLinkedModule], [fakeSettings]);
 
     assert.equal(store.directLinkedAnnotationId(), 'ann-id');
   });
@@ -51,7 +51,7 @@ describe('sidebar/store/modules/direct-linked', () => {
   it('sets directLinkedGroupId to settings.group during store init', () => {
     fakeSettings.group = 'group-id';
 
-    store = createStore([directLinked], [fakeSettings]);
+    store = createStore([directLinkedModule], [fakeSettings]);
 
     assert.equal(store.directLinkedGroupId(), 'group-id');
   });

--- a/src/sidebar/store/modules/test/direct-linked-test.js
+++ b/src/sidebar/store/modules/test/direct-linked-test.js
@@ -1,5 +1,5 @@
 import { createStore } from '../../create-store';
-import directLinked from '../direct-linked';
+import { directLinked } from '../direct-linked';
 
 describe('sidebar/store/modules/direct-linked', () => {
   let store;

--- a/src/sidebar/store/modules/test/drafts-test.js
+++ b/src/sidebar/store/modules/test/drafts-test.js
@@ -1,8 +1,8 @@
 import { createStore } from '../../create-store';
-import { annotations } from '../annotations';
-import { drafts } from '../drafts';
+import { annotationsModule } from '../annotations';
+import { draftsModule } from '../drafts';
 import { Draft } from '../drafts';
-import { selection } from '../selection';
+import { selectionModule } from '../selection';
 import { immutable } from '../../../util/immutable';
 
 const fixtures = immutable({
@@ -31,7 +31,10 @@ describe('store/modules/drafts', () => {
   let store;
 
   beforeEach(() => {
-    store = createStore([drafts, annotations, selection], [{}]);
+    store = createStore(
+      [draftsModule, annotationsModule, selectionModule],
+      [{}]
+    );
   });
 
   describe('Draft', () => {

--- a/src/sidebar/store/modules/test/drafts-test.js
+++ b/src/sidebar/store/modules/test/drafts-test.js
@@ -1,9 +1,9 @@
 import { createStore } from '../../create-store';
-import annotations from '../annotations';
-import drafts from '../drafts';
+import { annotations } from '../annotations';
+import { drafts } from '../drafts';
 import { Draft } from '../drafts';
-import selection from '../selection';
-import immutable from '../../../util/immutable';
+import { selection } from '../selection';
+import { immutable } from '../../../util/immutable';
 
 const fixtures = immutable({
   draftWithText: {

--- a/src/sidebar/store/modules/test/filters-test.js
+++ b/src/sidebar/store/modules/test/filters-test.js
@@ -1,6 +1,6 @@
 import { createStore } from '../../create-store';
-import { filters } from '../filters';
-import { selection } from '../selection';
+import { filtersModule } from '../filters';
+import { selectionModule } from '../selection';
 
 describe('sidebar/store/modules/filters', () => {
   let store;
@@ -11,7 +11,7 @@ describe('sidebar/store/modules/filters', () => {
   };
 
   beforeEach(() => {
-    store = createStore([filters, selection], fakeSettings);
+    store = createStore([filtersModule, selectionModule], fakeSettings);
   });
 
   describe('actions', () => {
@@ -88,7 +88,7 @@ describe('sidebar/store/modules/filters', () => {
 
       it('disables focus mode if there is a conflicting filter key', () => {
         store = createStore(
-          [filters],
+          [filtersModule],
           [{ focus: { user: { username: 'somebody' } } }]
         );
 
@@ -286,7 +286,7 @@ describe('sidebar/store/modules/filters', () => {
     describe('getFocusFilters', () => {
       it('returns any set focus filters', () => {
         store = createStore(
-          [filters],
+          [filtersModule],
           [
             {
               focus: {
@@ -313,7 +313,7 @@ describe('sidebar/store/modules/filters', () => {
 
       it('returns true if user-focused mode is active', () => {
         store = createStore(
-          [filters],
+          [filtersModule],
           [{ focus: { user: { username: 'somebody' } } }]
         );
 
@@ -338,7 +338,7 @@ describe('sidebar/store/modules/filters', () => {
 
       it('returns false if user-focused mode is configured but inactive', () => {
         store = createStore(
-          [filters],
+          [filtersModule],
           [{ focus: { user: { username: 'somebody' } } }]
         );
         store.toggleFocusMode(false);

--- a/src/sidebar/store/modules/test/filters-test.js
+++ b/src/sidebar/store/modules/test/filters-test.js
@@ -1,6 +1,6 @@
 import { createStore } from '../../create-store';
-import filters from '../filters';
-import selection from '../selection';
+import { filters } from '../filters';
+import { selection } from '../selection';
 
 describe('sidebar/store/modules/filters', () => {
   let store;

--- a/src/sidebar/store/modules/test/frames-test.js
+++ b/src/sidebar/store/modules/test/frames-test.js
@@ -1,12 +1,12 @@
 import { createStore } from '../../create-store';
-import { framesModule as frames } from '../frames';
+import { framesModule } from '../frames';
 
 describe('sidebar/store/modules/frames', () => {
   let store;
 
   beforeEach(() => {
     // Setup a store for tests.
-    store = createStore([frames]);
+    store = createStore([framesModule]);
   });
 
   describe('#connectFrame', () => {

--- a/src/sidebar/store/modules/test/frames-test.js
+++ b/src/sidebar/store/modules/test/frames-test.js
@@ -1,5 +1,5 @@
 import { createStore } from '../../create-store';
-import frames from '../frames';
+import { framesModule as frames } from '../frames';
 
 describe('sidebar/store/modules/frames', () => {
   let store;

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -1,6 +1,6 @@
 import { createStore } from '../../create-store';
-import { groups } from '../groups';
-import { session } from '../session';
+import { groupsModule } from '../groups';
+import { sessionModule } from '../session';
 import { immutable } from '../../../util/immutable';
 
 describe('sidebar/store/modules/groups', () => {
@@ -73,7 +73,7 @@ describe('sidebar/store/modules/groups', () => {
   beforeEach(() => {
     // The empty second argument (settings) needed here because of the
     // dependency on the `session` module
-    store = createStore([groups, session], [{}]);
+    store = createStore([groupsModule, sessionModule], [{}]);
   });
 
   describe('filterGroups', () => {

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -1,7 +1,7 @@
 import { createStore } from '../../create-store';
-import groups from '../groups';
-import session from '../session';
-import immutable from '../../../util/immutable';
+import { groups } from '../groups';
+import { session } from '../session';
+import { immutable } from '../../../util/immutable';
 
 describe('sidebar/store/modules/groups', () => {
   const publicGroup = immutable({

--- a/src/sidebar/store/modules/test/links-test.js
+++ b/src/sidebar/store/modules/test/links-test.js
@@ -1,11 +1,11 @@
 import { createStore } from '../../create-store';
-import { links } from '../links';
+import { linksModule } from '../links';
 
 describe('sidebar/store/modules/links', () => {
   let store;
 
   beforeEach(() => {
-    store = createStore([links]);
+    store = createStore([linksModule]);
   });
 
   function addLinks() {

--- a/src/sidebar/store/modules/test/links-test.js
+++ b/src/sidebar/store/modules/test/links-test.js
@@ -1,5 +1,5 @@
 import { createStore } from '../../create-store';
-import links from '../links';
+import { links } from '../links';
 
 describe('sidebar/store/modules/links', () => {
   let store;

--- a/src/sidebar/store/modules/test/real-time-updates-test.js
+++ b/src/sidebar/store/modules/test/real-time-updates-test.js
@@ -1,9 +1,8 @@
 import { createStore } from '../../create-store';
-import annotations from '../annotations';
-import groups from '../groups';
-import realTimeUpdates from '../real-time-updates';
-import { $imports } from '../real-time-updates';
-import selection from '../selection';
+import { annotations } from '../annotations';
+import { groups } from '../groups';
+import { realTimeUpdates, $imports } from '../real-time-updates';
+import { selection } from '../selection';
 
 const { removeAnnotations } = annotations.actionCreators;
 const { focusGroup } = groups.actionCreators;
@@ -38,17 +37,17 @@ describe('sidebar/store/modules/real-time-updates', () => {
 
     $imports.$mock({
       './annotations': {
-        default: {
+        annotations: {
           selectors: { annotationExists: fakeAnnotationExists },
         },
       },
       './groups': {
-        default: {
+        groups: {
           selectors: { focusedGroupId: fakeFocusedGroupId },
         },
       },
       './route': {
-        default: {
+        routeModule: {
           selectors: { route: fakeRoute },
         },
       },

--- a/src/sidebar/store/modules/test/real-time-updates-test.js
+++ b/src/sidebar/store/modules/test/real-time-updates-test.js
@@ -1,11 +1,11 @@
 import { createStore } from '../../create-store';
-import { annotations } from '../annotations';
-import { groups } from '../groups';
-import { realTimeUpdates, $imports } from '../real-time-updates';
-import { selection } from '../selection';
+import { annotationsModule } from '../annotations';
+import { groupsModule } from '../groups';
+import { realTimeUpdatesModule, $imports } from '../real-time-updates';
+import { selectionModule } from '../selection';
 
-const { removeAnnotations } = annotations.actionCreators;
-const { focusGroup } = groups.actionCreators;
+const { removeAnnotations } = annotationsModule.actionCreators;
+const { focusGroup } = groupsModule.actionCreators;
 
 describe('sidebar/store/modules/real-time-updates', () => {
   let fakeAnnotationExists;
@@ -31,18 +31,18 @@ describe('sidebar/store/modules/real-time-updates', () => {
     });
 
     store = createStore(
-      [realTimeUpdates, annotations, selection],
+      [realTimeUpdatesModule, annotationsModule, selectionModule],
       [fakeSettings]
     );
 
     $imports.$mock({
       './annotations': {
-        annotations: {
+        annotationsModule: {
           selectors: { annotationExists: fakeAnnotationExists },
         },
       },
       './groups': {
-        groups: {
+        groupsModule: {
           selectors: { focusedGroupId: fakeFocusedGroupId },
         },
       },

--- a/src/sidebar/store/modules/test/route-test.js
+++ b/src/sidebar/store/modules/test/route-test.js
@@ -1,11 +1,11 @@
 import { createStore } from '../../create-store';
-import { routeModule as route } from '../route';
+import { routeModule } from '../route';
 
 describe('store/modules/route', () => {
   let store;
 
   beforeEach(() => {
-    store = createStore([route]);
+    store = createStore([routeModule]);
   });
 
   it('sets initial route to `null`', () => {

--- a/src/sidebar/store/modules/test/route-test.js
+++ b/src/sidebar/store/modules/test/route-test.js
@@ -1,5 +1,5 @@
 import { createStore } from '../../create-store';
-import route from '../route';
+import { routeModule as route } from '../route';
 
 describe('store/modules/route', () => {
   let store;

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -1,8 +1,8 @@
 import { createStore } from '../../create-store';
-import { annotations } from '../annotations';
-import { filters } from '../filters';
-import { selection } from '../selection';
-import { routeModule as route } from '../route';
+import { annotationsModule } from '../annotations';
+import { filtersModule } from '../filters';
+import { selectionModule } from '../selection';
+import { routeModule } from '../route';
 import * as fixtures from '../../../test/annotation-fixtures';
 
 describe('sidebar/store/modules/selection', () => {
@@ -14,7 +14,10 @@ describe('sidebar/store/modules/selection', () => {
   };
 
   beforeEach(() => {
-    store = createStore([annotations, filters, selection, route], fakeSettings);
+    store = createStore(
+      [annotationsModule, filtersModule, selectionModule, routeModule],
+      fakeSettings
+    );
   });
 
   describe('setForcedVisible', () => {

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -1,8 +1,8 @@
 import { createStore } from '../../create-store';
-import annotations from '../annotations';
-import filters from '../filters';
-import selection from '../selection';
-import route from '../route';
+import { annotations } from '../annotations';
+import { filters } from '../filters';
+import { selection } from '../selection';
+import { routeModule as route } from '../route';
 import * as fixtures from '../../../test/annotation-fixtures';
 
 describe('sidebar/store/modules/selection', () => {

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -1,5 +1,5 @@
 import { createStore } from '../../create-store';
-import { session } from '../session';
+import { sessionModule } from '../session';
 
 describe('sidebar/store/modules/session', () => {
   let fakeSettings;
@@ -7,7 +7,7 @@ describe('sidebar/store/modules/session', () => {
 
   beforeEach(() => {
     fakeSettings = {};
-    store = createStore([session], [fakeSettings]);
+    store = createStore([sessionModule], [fakeSettings]);
   });
 
   describe('#updateProfile', () => {
@@ -21,7 +21,7 @@ describe('sidebar/store/modules/session', () => {
   describe('#defaultAuthority', () => {
     it('returns the default authority from the settings', () => {
       fakeSettings.authDomain = 'foo.com';
-      store = createStore([session], [fakeSettings]);
+      store = createStore([sessionModule], [fakeSettings]);
 
       assert.equal(store.defaultAuthority(), 'foo.com');
     });

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -1,5 +1,5 @@
 import { createStore } from '../../create-store';
-import session from '../session';
+import { session } from '../session';
 
 describe('sidebar/store/modules/session', () => {
   let fakeSettings;

--- a/src/sidebar/store/modules/test/sidebar-panels-test.js
+++ b/src/sidebar/store/modules/test/sidebar-panels-test.js
@@ -1,5 +1,5 @@
 import { createStore } from '../../create-store';
-import sidebarPanels from '../sidebar-panels';
+import { sidebarPanels } from '../sidebar-panels';
 
 describe('sidebar/store/modules/sidebar-panels', () => {
   let store;

--- a/src/sidebar/store/modules/test/sidebar-panels-test.js
+++ b/src/sidebar/store/modules/test/sidebar-panels-test.js
@@ -1,5 +1,5 @@
 import { createStore } from '../../create-store';
-import { sidebarPanels } from '../sidebar-panels';
+import { sidebarPanelsModule } from '../sidebar-panels';
 
 describe('sidebar/store/modules/sidebar-panels', () => {
   let store;
@@ -9,7 +9,7 @@ describe('sidebar/store/modules/sidebar-panels', () => {
   };
 
   beforeEach(() => {
-    store = createStore([sidebarPanels]);
+    store = createStore([sidebarPanelsModule]);
   });
 
   describe('#initialState', () => {

--- a/src/sidebar/store/modules/test/toast-messages-test.js
+++ b/src/sidebar/store/modules/test/toast-messages-test.js
@@ -1,12 +1,12 @@
 import { createStore } from '../../create-store';
-import { toastMessages } from '../toast-messages';
+import { toastMessagesModule } from '../toast-messages';
 
 describe('store/modules/toast-messages', () => {
   let store;
   let fakeToastMessage;
 
   beforeEach(() => {
-    store = createStore([toastMessages]);
+    store = createStore([toastMessagesModule]);
     fakeToastMessage = {
       id: 'myToast',
       type: 'anyType',

--- a/src/sidebar/store/modules/test/toast-messages-test.js
+++ b/src/sidebar/store/modules/test/toast-messages-test.js
@@ -1,5 +1,5 @@
 import { createStore } from '../../create-store';
-import toastMessages from '../toast-messages';
+import { toastMessages } from '../toast-messages';
 
 describe('store/modules/toast-messages', () => {
   let store;

--- a/src/sidebar/store/modules/test/viewer-test.js
+++ b/src/sidebar/store/modules/test/viewer-test.js
@@ -1,11 +1,11 @@
 import { createStore } from '../../create-store';
-import { viewer } from '../viewer';
+import { viewerModule } from '../viewer';
 
 describe('store/modules/viewer', () => {
   let store;
 
   beforeEach(() => {
-    store = createStore([viewer]);
+    store = createStore([viewerModule]);
   });
 
   describe('hasSidebarOpened', () => {

--- a/src/sidebar/store/modules/test/viewer-test.js
+++ b/src/sidebar/store/modules/test/viewer-test.js
@@ -1,5 +1,5 @@
 import { createStore } from '../../create-store';
-import viewer from '../viewer';
+import { viewer } from '../viewer';
 
 describe('store/modules/viewer', () => {
   let store;

--- a/src/sidebar/store/modules/toast-messages.js
+++ b/src/sidebar/store/modules/toast-messages.js
@@ -112,7 +112,7 @@ function hasMessage(state, type, text) {
   });
 }
 
-export const toastMessages = createStoreModule(initialState, {
+export const toastMessagesModule = createStoreModule(initialState, {
   namespace: 'toastMessages',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/toast-messages.js
+++ b/src/sidebar/store/modules/toast-messages.js
@@ -112,7 +112,7 @@ function hasMessage(state, type, text) {
   });
 }
 
-export default createStoreModule(initialState, {
+export const toastMessages = createStoreModule(initialState, {
   namespace: 'toastMessages',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/viewer.js
+++ b/src/sidebar/store/modules/viewer.js
@@ -43,7 +43,7 @@ function hasSidebarOpened(state) {
   return state.sidebarHasOpened;
 }
 
-export const viewer = createStoreModule(initialState, {
+export const viewerModule = createStoreModule(initialState, {
   namespace: 'viewer',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/modules/viewer.js
+++ b/src/sidebar/store/modules/viewer.js
@@ -43,7 +43,7 @@ function hasSidebarOpened(state) {
   return state.sidebarHasOpened;
 }
 
-export default createStoreModule(initialState, {
+export const viewer = createStoreModule(initialState, {
   namespace: 'viewer',
   reducers,
   actionCreators: {

--- a/src/sidebar/store/test/debug-middleware-test.js
+++ b/src/sidebar/store/test/debug-middleware-test.js
@@ -2,7 +2,7 @@
 
 import * as redux from 'redux';
 
-import debugMiddleware from '../debug-middleware';
+import { debugMiddleware } from '../debug-middleware';
 
 function id(state) {
   return state;

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -1,6 +1,6 @@
 import * as annotationFixtures from '../../test/annotation-fixtures';
 import { createSidebarStore } from '../index';
-import immutable from '../../util/immutable';
+import { immutable } from '../../util/immutable';
 
 const defaultAnnotation = annotationFixtures.defaultAnnotation;
 const newAnnotation = annotationFixtures.newAnnotation;

--- a/src/sidebar/store/test/util-test.js
+++ b/src/sidebar/store/test/util-test.js
@@ -1,4 +1,4 @@
-import fakeStore from '../../test/fake-redux-store';
+import { fakeReduxStore } from '../../test/fake-redux-store';
 
 import * as util from '../util';
 
@@ -194,7 +194,7 @@ describe('sidebar/store/util', () => {
     let store;
 
     beforeEach(() => {
-      store = fakeStore({
+      store = fakeReduxStore({
         fake: { val: 0 },
       });
     });

--- a/src/sidebar/test/bootstrap.js
+++ b/src/sidebar/test/bootstrap.js
@@ -16,8 +16,8 @@ configure({ adapter: new Adapter() });
 // Make all the icons that are available for use with `SvgIcon` in the actual
 // app available in the tests. This enables validation of icon names passed to
 // `SvgIcon`.
-import sidebarIcons from '../icons';
-import annotatorIcons from '../../annotator/icons';
+import { sidebarIcons } from '../icons';
+import { annotatorIcons } from '../../annotator/icons';
 import { registerIcons } from '@hypothesis/frontend-shared';
 registerIcons({
   ...sidebarIcons,

--- a/src/sidebar/test/cross-origin-rpc-test.js
+++ b/src/sidebar/test/cross-origin-rpc-test.js
@@ -38,7 +38,7 @@ describe('sidebar/cross-origin-rpc', () => {
 
     $imports.$mock({
       './helpers/groups': { normalizeGroupIds: fakeNormalizeGroupIds },
-      '../shared/warn-once': fakeWarnOnce,
+      '../shared/warn-once': { warnOnce: fakeWarnOnce },
     });
   });
 

--- a/src/sidebar/test/fake-redux-store.js
+++ b/src/sidebar/test/fake-redux-store.js
@@ -11,7 +11,7 @@ import * as redux from 'redux';
  *        returned store.
  * @return {object} Redux store
  */
-export default function fakeStore(initialState, methods) {
+export function fakeReduxStore(initialState, methods) {
   function update(state, action) {
     if (action.state) {
       return Object.assign({}, state, action.state);

--- a/src/sidebar/test/fake-window.js
+++ b/src/sidebar/test/fake-window.js
@@ -1,4 +1,4 @@
-export default class FakeWindow {
+export class FakeWindow {
   constructor() {
     this.callbacks = [];
 

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -3,10 +3,9 @@ import { useReducer } from 'preact/hooks';
 import { act } from 'preact/test-utils';
 
 import { Injector } from '../../../shared/injector';
-import { createSidebarStore } from '../../store';
-
+import { useRootThread } from '../../components/hooks/use-root-thread';
 import { ServiceContext } from '../../service-context';
-import useRootThread from '../../components/hooks/use-root-thread';
+import { createSidebarStore } from '../../store';
 
 const fixtures = {
   annotations: [

--- a/src/sidebar/test/render-markdown-test.js
+++ b/src/sidebar/test/render-markdown-test.js
@@ -1,5 +1,4 @@
-import renderMarkdown from '../render-markdown';
-import { $imports } from '../render-markdown';
+import { renderMathAndMarkdown, $imports } from '../render-markdown';
 
 describe('render-markdown', () => {
   let render;
@@ -19,7 +18,7 @@ describe('render-markdown', () => {
       },
     });
 
-    render = markdown => renderMarkdown(markdown);
+    render = markdown => renderMathAndMarkdown(markdown);
   });
 
   afterEach(() => {
@@ -61,21 +60,21 @@ describe('render-markdown', () => {
       // library. This is not an extensive test of sanitization behavior, that
       // is left to DOMPurify's tests.
       assert.equal(
-        renderMarkdown('one **two** <script>alert("three")</script>'),
+        renderMathAndMarkdown('one **two** <script>alert("three")</script>'),
         '<p>one <strong>two</strong> </p>'
       );
     });
 
     it('should open links in a new window', () => {
       assert.equal(
-        renderMarkdown('<a href="http://example.com">test</a>'),
+        renderMathAndMarkdown('<a href="http://example.com">test</a>'),
         '<p><a href="http://example.com" target="_blank">test</a></p>'
       );
     });
 
     it('should render strikethrough', () => {
       assert.equal(
-        renderMarkdown('This is ~~no longer the case~~'),
+        renderMathAndMarkdown('This is ~~no longer the case~~'),
         '<p>This is <del>no longer the case</del></p>'
       );
     });

--- a/src/sidebar/util/disable-opener-for-external-links.js
+++ b/src/sidebar/util/disable-opener-for-external-links.js
@@ -15,7 +15,7 @@
  *
  * @param {Element} root - Root element
  */
-export default function disableOpenerForExternalLinks(root) {
+export function disableOpenerForExternalLinks(root) {
   root.addEventListener('click', event => {
     const target = /** @type {HTMLElement} */ (event.target);
 

--- a/src/sidebar/util/immutable.js
+++ b/src/sidebar/util/immutable.js
@@ -28,7 +28,7 @@ function deepFreeze(object) {
  * @param {object} object
  * @return {object} Returns the input object
  */
-export default function immutable(object) {
+export function immutable(object) {
   if (process.env.NODE_ENV === 'production') {
     return object;
   } else {

--- a/src/sidebar/util/memoize.js
+++ b/src/sidebar/util/memoize.js
@@ -10,7 +10,7 @@
  * @param {(arg: Arg) => Result} fn
  * @return {(arg: Arg) => Result}
  */
-export default function memoize(fn) {
+export function memoize(fn) {
   if (fn.length !== 1) {
     throw new Error('Memoize input must be a function of one argument');
   }

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -39,7 +39,7 @@ export class TokenError extends Error {
  * OAuthClient handles interaction with the annotation service's OAuth
  * endpoints.
  */
-export default class OAuthClient {
+export class OAuthClient {
   /**
    * Create a new OAuthClient
    *

--- a/src/sidebar/util/observe-element-size.js
+++ b/src/sidebar/util/observe-element-size.js
@@ -13,7 +13,7 @@ import { ListenerCollection } from '../../shared/listener-collection';
  *   element when a change in its size is detected.
  * @return {() => void}
  */
-export default function observeElementSize(element, onSizeChanged) {
+export function observeElementSize(element, onSizeChanged) {
   if (typeof ResizeObserver !== 'undefined') {
     const observer = new ResizeObserver(() =>
       onSizeChanged(element.clientWidth, element.clientHeight)

--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/browser';
 
 import { parseConfigFragment } from '../../shared/config-fragment';
 import { handleErrorsInFrames } from '../../shared/frame-error-capture';
-import warnOnce from '../../shared/warn-once';
+import { warnOnce } from '../../shared/warn-once';
 
 /**
  * @typedef SentryConfig

--- a/src/sidebar/util/test/disable-opener-for-external-links-test.js
+++ b/src/sidebar/util/test/disable-opener-for-external-links-test.js
@@ -1,4 +1,4 @@
-import disableOpenerForExternalLinks from '../disable-opener-for-external-links';
+import { disableOpenerForExternalLinks } from '../disable-opener-for-external-links';
 
 describe('sidebar.util.disable-opener-for-external-links', () => {
   let containerEl;

--- a/src/sidebar/util/test/immutable-test.js
+++ b/src/sidebar/util/test/immutable-test.js
@@ -1,4 +1,4 @@
-import immutable from '../immutable';
+import { immutable } from '../immutable';
 
 describe('immutable', () => {
   it('deeply freezes objects', () => {

--- a/src/sidebar/util/test/memoize-test.js
+++ b/src/sidebar/util/test/memoize-test.js
@@ -1,4 +1,4 @@
-import memoize from '../memoize';
+import { memoize } from '../memoize';
 
 describe('memoize', () => {
   let count = 0;

--- a/src/sidebar/util/test/oauth-client-test.js
+++ b/src/sidebar/util/test/oauth-client-test.js
@@ -1,7 +1,7 @@
 import fetchMock from 'fetch-mock';
 
-import FakeWindow from '../../test/fake-window';
-import OAuthClient, { TokenError, $imports } from '../oauth-client';
+import { FakeWindow } from '../../test/fake-window';
+import { OAuthClient, TokenError, $imports } from '../oauth-client';
 
 const fixtures = {
   tokenResponse: {

--- a/src/sidebar/util/test/observe-element-size-test.js
+++ b/src/sidebar/util/test/observe-element-size-test.js
@@ -1,4 +1,4 @@
-import observeElementSize from '../observe-element-size';
+import { observeElementSize } from '../observe-element-size';
 
 /**
  * Wait for a condition to become true.

--- a/src/sidebar/util/test/sentry-test.js
+++ b/src/sidebar/util/test/sentry-test.js
@@ -27,7 +27,7 @@ describe('sidebar/util/sentry', () => {
       '../../shared/frame-error-capture': {
         handleErrorsInFrames: fakeHandleErrorsInFrames,
       },
-      '../../shared/warn-once': fakeWarnOnce,
+      '../../shared/warn-once': { warnOnce: fakeWarnOnce },
     });
   });
 

--- a/src/test-util/mock-imported-components.js
+++ b/src/test-util/mock-imported-components.js
@@ -62,7 +62,7 @@ function getDisplayName(component) {
  *
  * @return {Function} - A function that can be passed to `$imports.$mock`.
  */
-export default function mockImportedComponents() {
+export function mockImportedComponents() {
   return (source, symbol, value) => {
     if (!isComponent(value) || !source.startsWith('.')) {
       return null;


### PR DESCRIPTION
Except for Preact components, change all the default exports to named exports.

Follow up of [this comment](https://github.com/hypothesis/client/pull/4048/files#r778767765).

I needed to make only a few minor adjustments:
- [rename the exports in `src/sidebar/store/modules`](https://github.com/hypothesis/client/pull/4169/commits/fb161527556c8bce9a303927f05ae564c61c7022)
- I renamed a few variable (that mocked objects) in test for consistency