### PR TITLE
Add built-in "connect" and "close" events to PortRPC

### DIFF
--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -56,7 +56,8 @@ function init() {
 
   if (hostFrame === window) {
     // Ensure port "close" notifications from eg. guest frames are delivered properly.
-    installPortCloseWorkaroundForSafari();
+    const removeWorkaround = installPortCloseWorkaroundForSafari();
+    destroyables.push({ destroy: removeWorkaround });
 
     const sidebarConfig = getConfig('sidebar');
 

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -9,7 +9,10 @@ import { registerIcons } from '@hypothesis/frontend-shared';
 import { annotatorIcons } from './icons';
 registerIcons(annotatorIcons);
 
-import { PortProvider } from '../shared/messaging';
+import {
+  PortProvider,
+  installPortCloseWorkaroundForSafari,
+} from '../shared/messaging';
 import { getConfig } from './config/index';
 import { Guest } from './guest';
 import { HypothesisInjector } from './hypothesis-injector';
@@ -52,6 +55,9 @@ function init() {
   const destroyables = [];
 
   if (hostFrame === window) {
+    // Ensure port "close" notifications from eg. guest frames are delivered properly.
+    installPortCloseWorkaroundForSafari();
+
     const sidebarConfig = getConfig('sidebar');
 
     const hypothesisAppsOrigin = new URL(sidebarConfig.sidebarAppUrl).origin;

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -218,21 +218,6 @@ export class Sidebar {
         this.open();
       }
     });
-
-    // Notify other frames when a guest is unloaded. The ports are first
-    // transferred from the guest to the host frame to work around a bug in
-    // Safari <= 15. See https://bugs.webkit.org/show_bug.cgi?id=231167.
-    this._listeners.add(window, 'message', event => {
-      const { data, ports } = /** @type {MessageEvent} */ (event);
-      if (data?.type === 'hypothesisGuestUnloaded') {
-        for (let port of ports) {
-          const rpc = new PortRPC();
-          rpc.connect(port);
-          rpc.call('frameDestroyed');
-          rpc.destroy();
-        }
-      }
-    });
   }
 
   destroy() {
@@ -316,7 +301,7 @@ export class Sidebar {
       );
     }
 
-    guestRPC.on('frameDestroyed', () => {
+    guestRPC.on('close', () => {
       guestRPC.destroy();
       this._guestRPC = this._guestRPC.filter(rpc => rpc !== guestRPC);
     });

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1231,48 +1231,6 @@ describe('Guest', () => {
       guest.destroy();
       assert.called(sidebarRPC().destroy);
     });
-
-    it('notifies host frame that guest has been unloaded', () => {
-      const guest = createGuest({ subFrameIdentifier: 'frame-id' });
-
-      const hostPort = {};
-      hostRPC().disconnect.returns(hostPort);
-
-      const sidebarPort = {};
-      sidebarRPC().disconnect.returns(sidebarPort);
-
-      guest.destroy();
-
-      assert.calledWith(
-        hostFrame.postMessage,
-        {
-          type: 'hypothesisGuestUnloaded',
-        },
-        '*',
-        sinon.match.array.contains([sidebarPort, hostPort])
-      );
-    });
-  });
-
-  it('notifies host and sidebar frames when guest is unloaded', () => {
-    createGuest({ subFrameIdentifier: 'frame-id' });
-
-    const hostPort = {};
-    hostRPC().disconnect.returns(hostPort);
-
-    const sidebarPort = {};
-    sidebarRPC().disconnect.returns(sidebarPort);
-
-    window.dispatchEvent(new Event('unload'));
-
-    assert.calledWith(
-      hostFrame.postMessage,
-      {
-        type: 'hypothesisGuestUnloaded',
-      },
-      '*',
-      sinon.match.array.contains([sidebarPort, hostPort])
-    );
   });
 
   it('discovers and creates a channel for communication with the sidebar', async () => {

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -216,28 +216,6 @@ describe('Sidebar', () => {
     assert.calledWith(fakeSendErrorsTo, sidebar.iframe.contentWindow);
   });
 
-  it('notifies other frames when a guest is unloaded', () => {
-    const guestHostChannel = new MessageChannel();
-    const guestSidebarChannel = new MessageChannel();
-    const guestPorts = [guestHostChannel.port1, guestSidebarChannel.port1];
-    createSidebar();
-
-    const event = new MessageEvent('message', {
-      data: { type: 'hypothesisGuestUnloaded' },
-      ports: guestPorts,
-    });
-
-    const prevPorts = fakePortRPCs.length;
-    window.dispatchEvent(event);
-
-    const tempPortRPCs = fakePortRPCs.slice(prevPorts);
-    assert.equal(tempPortRPCs.length, guestPorts.length);
-    tempPortRPCs.forEach(rpc => {
-      assert.calledWith(rpc.call, 'frameDestroyed');
-      assert.called(rpc.destroy);
-    });
-  });
-
   function getConfigString(sidebar) {
     return sidebar.iframe.src;
   }
@@ -508,13 +486,13 @@ describe('Sidebar', () => {
       });
     });
 
-    describe('on "frameDestroyed" event', () => {
+    describe('on "close" event', () => {
       it('disconnects the guest', () => {
         const sidebar = createSidebar();
         connectGuest(sidebar);
         guestRPC().call.resetHistory();
 
-        emitGuestEvent('frameDestroyed');
+        emitGuestEvent('close');
 
         assert.called(guestRPC().destroy);
 

--- a/src/shared/messaging/index.js
+++ b/src/shared/messaging/index.js
@@ -1,4 +1,4 @@
 export { PortFinder } from './port-finder';
 export { PortProvider } from './port-provider';
-export { PortRPC } from './port-rpc';
+export { PortRPC, installPortCloseWorkaroundForSafari } from './port-rpc';
 export { isMessageEqual } from './port-util';

--- a/src/shared/messaging/port-rpc.js
+++ b/src/shared/messaging/port-rpc.js
@@ -83,6 +83,7 @@ function sendCall(port, method, args = [], sequence = -1) {
  * @return {() => void} - Callback that removes the listener
  */
 export function installPortCloseWorkaroundForSafari(
+  /* istanbul ignore next */
   userAgent = navigator.userAgent
 ) {
   if (!shouldUseSafariWorkaround(userAgent)) {

--- a/src/shared/messaging/test/port-rpc-test.js
+++ b/src/shared/messaging/test/port-rpc-test.js
@@ -45,6 +45,9 @@ describe('PortRPC', () => {
   afterEach(() => {
     rpc1.destroy();
     rpc2.destroy();
+
+    // Restore any temporarily mocked DOM APIs.
+    sinon.restore();
   });
 
   it('should call the method `plusOne` on rpc2', done => {
@@ -201,10 +204,11 @@ describe('PortRPC', () => {
     sender.connect(port1);
     await waitForMessageDelivery();
 
-    closeHandler.resetHistory();
+    assert.notCalled(closeHandler);
     sender.destroy();
     await waitForMessageDelivery();
 
+    assert.calledOnce(closeHandler);
     assert.calledWith(closeHandler);
   });
 
@@ -219,10 +223,11 @@ describe('PortRPC', () => {
     sender.connect(port1);
     await waitForMessageDelivery();
 
-    closeHandler.resetHistory();
+    assert.notCalled(closeHandler);
     window.dispatchEvent(new Event('unload'));
     await waitForMessageDelivery();
 
+    assert.calledOnce(closeHandler);
     assert.calledWith(closeHandler);
   });
 
@@ -297,7 +302,7 @@ describe('PortRPC', () => {
       sender.connect(transferredPort);
       await waitForMessageDelivery();
 
-      closeHandler.resetHistory();
+      assert.notCalled(closeHandler);
 
       // Emulate the Safari bug by disabling `postMessage` on the sending port
       // in the original frame. When the port is transferred to the "parent"
@@ -326,7 +331,6 @@ describe('PortRPC', () => {
       const removeWorkaround = installPortCloseWorkaroundForSafari(userAgent);
       removeWorkaround();
       assert.notCalled(window.addEventListener);
-      window.addEventListener.restore();
     });
   });
 });

--- a/src/shared/messaging/test/port-rpc-test.js
+++ b/src/shared/messaging/test/port-rpc-test.js
@@ -225,4 +225,24 @@ describe('PortRPC', () => {
 
     assert.calledWith(closeHandler);
   });
+
+  it('should only invoke "close" handler once', async () => {
+    const { port1, port2 } = new MessageChannel();
+    const sender = new PortRPC();
+    const receiver = new PortRPC();
+    const closeHandler = sinon.stub();
+
+    receiver.on('close', closeHandler);
+    receiver.connect(port2);
+    sender.connect(port1);
+
+    // Invoke "close" manually. In a real app it will be invoked when the
+    // window is unloaded and/or the PortRPC is destroyed.
+    sender.call('close');
+    sender.call('close');
+
+    await waitForMessageDelivery();
+
+    assert.calledOnce(closeHandler);
+  });
 });

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -249,7 +249,10 @@ export class FrameSyncService {
       });
     });
 
-    guestRPC.on('frameDestroyed', () => {
+    // TODO - Close connection if we don't receive a "connect" message within
+    // a certain time frame.
+
+    guestRPC.on('close', () => {
       const frame = this._store.frames().find(f => f.id === frameIdentifier);
       if (frame) {
         this._store.destroyFrame(frame);

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -549,7 +549,7 @@ describe('FrameSyncService', () => {
       frameSync.connect();
       await connectGuest();
 
-      emitGuestEvent('frameDestroyed');
+      emitGuestEvent('close');
 
       assert.called(guestRPC().destroy);
     });
@@ -562,7 +562,7 @@ describe('FrameSyncService', () => {
         frameIdentifier: fixtures.framesListEntry.id,
         uri: 'http://example.org',
       });
-      emitGuestEvent('frameDestroyed');
+      emitGuestEvent('close');
 
       assert.calledWith(fakeStore.destroyFrame, fixtures.framesListEntry);
     });

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -20,10 +20,7 @@ export type GuestToHostEvent =
   /**
    * The guest informs the host that the anchors have been changed in the main annotatable frame.
    */
-  | 'anchorsChanged'
-
-  /** The guest was unloaded. */
-  | 'frameDestroyed';
+  | 'anchorsChanged';
 
 /**
  * Events that the guest sends to the sidebar
@@ -65,10 +62,7 @@ export type GuestToSidebarEvent =
   /**
    * The guest is asking the sidebar to toggle some annotations.
    */
-  | 'toggleAnnotationSelection'
-
-  /** The guest frame was unloaded. */
-  | 'frameDestroyed';
+  | 'toggleAnnotationSelection';
 
 /**
  * Events that the host sends to the guest


### PR DESCRIPTION
Add two built-in events to PortRPC which are dispatched when PortRPC connects to
a port and when it is destroyed or the containing frame is unloaded. These
events can be used in the counterpart PortRPC to confirm that the sender has
successfully received and connected to the port, and to get notified when the
port goes away.

Sending the `close` event in the context of a window unloading in Safari
<= 15 requires a workaround that involves registering a handler in the
parent frame. This handler is currently installed in the host frame.

The new "close" event is used to replace the "frameDestroyed" message
that was used by guests to notify the sidebar when it went away. This solves
several problems:

 - It centralizes the workaround for https://bugs.webkit.org/show_bug.cgi?id=231167 in `post-rpc.js`, instead of having it spread between several modules. A benefit of this is that the workaround can be tested end-to-end more easily. See the PortRPC tests.
 - It provides a generic way to for a PortRPC user to know when the channel has closed, rather than needing to implement this for each scenario where it is needed
 - If MessagePort gains a built-in close event in future, which I hope it will, since this really requires browser support to handle all scenarios (eg. process crashes), it will be easy to adapt PortRPC to use it
 - It provides a way to, in future, handle the case where a guest is unloaded before it has received and connected to the port, by having the host/sidebar frames expect the "connect" call within a timeout. This is not yet implemented.

**Changes in detail:**

 - Add built-in `close` and `connect` events to `PortRPC`
 - Remove `frameDestroyed` event handler in `FrameSyncService` and replace with `close` handler
 - Install workaround for `close` event delivery in host frame, in the annotator entry point
 - Add `close` event handler in `Sidebar` class, which cleans up the host side of the guest-host connection when the guest goes away
 - Remove the `PortRPC#disconnect` method. It is no longer used and it complicates the internals and usage of PortRPC as it adds additional state transitions (initialized => connected => disconnected => connected etc.) that have to be handled.

The `connect` event is not yet used in this PR. That will be used in a follow-up to clean up guest connections if a guest navigates away before it receives a port.

**Testing:**

Try the following in Safari, Chrome and Firefox:

1. Go to http://localhost:3000/document/vitalsource-epub
2. Add an annotation at the top of each book chapter
3. Navigate back and forth between the chapters, and verify that the correct annotations are shown in the sidebar after each navigation