### PR TITLE
Modernize `AdderToolbar` styles and convert to tailwind

### DIFF
--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -10,19 +10,7 @@
 
 @use './base';
 
-// Shared styles
-// -----------------
-@use '@hypothesis/frontend-shared/styles';
-
-// Extensions and overrides to patterns from `frontend-shared`
-@use '../frontend-shared';
-
-// Annotator-specific components.
-@use './components/AdderToolbar';
-@use './components/Buckets';
-@use './components/NotebookModal';
-@use './components/Toolbar';
-@use './components/WarningBanner';
+@use './components';
 
 @use './utilities';
 

--- a/src/styles/annotator/components/AdderToolbar.scss
+++ b/src/styles/annotator/components/AdderToolbar.scss
@@ -1,129 +1,37 @@
-@use '../variables' as var;
+@layer components {
+  // Main class for the root element of the "adder" toolbar that appears when the
+  // user makes a text selection.
+  .AdderToolbar {
+    // Reset all inherited properties to their initial values. This prevents CSS
+    // property values from the host page being inherited by elements of the
+    // Adder, even when using Shadow DOM.
+    all: initial;
 
-$adder-transition-duration: 80ms;
+    // Provide some hover-related behavior that cannot be feasibly duplicated
+    // using utility styles.
+    //
+    // When the container/parent element containing the annotator toolbar
+    // buttons is hovered, dim the buttons except the specifically-hovered
+    // button, which should be darkened. The "annotate" and "highlight" buttons
+    // use icons and a label, so dimming/darkening their text color suffices,
+    // but the badge-count pill needs its background-color dimmed/darkened as
+    // well (`.dim-bg`).
+    .dim-items-on-hover:hover {
+      .dim-item:not(:hover) {
+        @apply text-grey-5;
 
-// Main class for the root element of the "adder" toolbar that appears when the
-// user makes a text selection.
-.AdderToolbar {
-  // Reset all inherited properties to their initial values. This prevents CSS
-  // property values from the host page being inherited by elements of the
-  // Adder, even when using Shadow DOM.
-  all: initial;
+        .dim-bg {
+          @apply bg-grey-5;
+        }
+      }
 
-  position: absolute;
-  box-sizing: border-box;
-  direction: ltr;
-  border-radius: var.$annotator-border-radius;
+      .dim-item:hover {
+        @apply text-grey-9;
 
-  // Prevent the browser from selecting text in the adder itself during text
-  // selection.
-  //
-  // See https://github.com/hypothesis/product-backlog/issues/878
-  user-select: none;
-
-  // The adder toolbar has a distinctive, broad-spreading drop shadow
-  box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.25);
-
-  // Give the adder a very low opacity initially.  It will then fade-in when
-  // shown.
-  opacity: 0.05;
-
-  // Adder entry animation settings
-  animation-duration: $adder-transition-duration;
-  animation-timing-function: ease-in;
-  animation-fill-mode: forwards;
-
-  &--down.is-active {
-    animation-name: adder-fade-in, adder-pop-down;
-  }
-
-  &--up.is-active {
-    animation-name: adder-fade-in, adder-pop-up;
-  }
-}
-
-.AdderToolbar__arrow {
-  position: absolute;
-  z-index: 2;
-  color: var.$color-border;
-  fill: var.$color-background;
-
-  // Horizontal centering, part 1
-  left: 50%;
-
-  // Override `Icon` default 1em sizing
-  height: auto;
-  width: auto;
-
-  &--down {
-    // These transforms:
-    // 1) Translate -50% (left) on the X axis to complete horizontal centering
-    // 2) Translate up (Y) by 1px to eliminate a faint border line visible in Safari
-    transform: rotateX(180deg) translateX(-50%) translateY(1px);
-  }
-
-  &--up {
-    // Align at top edge of parent element...
-    top: 0;
-    // Translate on X axis -50% (left) to complete horizontal centering
-    // Translate -100% on Y axis (up) to position arrow above parent
-    transform: translate(-50%, -100%);
-  }
-}
-
-.AdderToolbar__badge {
-  // The badge should be vertically aligned with icons in other toolbar buttons
-  // and the label underneath should also align with labels in other buttons.
-  border-radius: var.$annotator-border-radius;
-  color: var.$color-text--inverted;
-  font-weight: bold;
-  // For positioning the number appropriately within the badge background
-  padding: 2px 4px;
-}
-
-.AdderToolbar__separator {
-  // Override border color to be a little darker
-  border-right: 1px solid var.$grey-4;
-}
-
-// The toolbar has full contrast when not hovered. When the toolbar is hovered,
-// the buttons are dimmed except for the one which is currently hovered.
-.AdderToolbar__actions:hover {
-  .AdderToolbar__button:not(:hover) {
-    color: var.$grey-semi;
-
-    .AdderToolbar__badge {
-      background-color: var.$grey-semi;
+        .dim-bg {
+          @apply bg-grey-9;
+        }
+      }
     }
-  }
-}
-
-@keyframes adder-fade-in {
-  0% {
-    opacity: 0.05;
-  }
-  20% {
-    opacity: 0.7;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-@keyframes adder-pop-up {
-  from {
-    transform: scale(0.8) translateY(10px);
-  }
-  to {
-    transform: scale(1) translateY(0px);
-  }
-}
-
-@keyframes adder-pop-down {
-  from {
-    transform: scale(0.8) translateY(-10px);
-  }
-  to {
-    transform: scale(1) translateY(0px);
   }
 }

--- a/src/styles/annotator/components/_index.scss
+++ b/src/styles/annotator/components/_index.scss
@@ -1,0 +1,12 @@
+@use 'tailwindcss/components';
+@use '@hypothesis/frontend-shared/styles';
+
+// Extensions and overrides to patterns from `frontend-shared`
+@use '../../frontend-shared';
+
+// Annotator-specific components.
+@use './AdderToolbar';
+@use './Buckets';
+@use './NotebookModal';
+@use './Toolbar';
+@use './WarningBanner';

--- a/src/styles/frontend-shared.scss
+++ b/src/styles/frontend-shared.scss
@@ -33,32 +33,6 @@
   }
 }
 
-// Used in the AdderToolbar, a transparent button that has an icon and a small
-// label below the icon
-.LabeledIconButton {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-
-  &:hover:not([disabled]) {
-    background-color: transparent;
-  }
-
-  cursor: pointer;
-  font-weight: normal;
-  font-size: var.$annotator-adder-font-size;
-  line-height: var.$annotator-adder-line-height;
-  padding: var.$layout-space--small;
-  transition: color 80ms;
-  background: transparent;
-
-  &__label {
-    margin-top: var.$layout-space--xxsmall;
-    transition: color 80ms;
-  }
-}
-
 // Override any background color on a LabeledButton
 .TransparentButton {
   background-color: transparent;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -123,7 +123,6 @@ $sidebar--theme-clean: '.theme-clean';
 // -----------------------------------
 $annotator-toolbar-width: 33px;
 
-$annotator-base-font-size: 14px;
 $annotator-base-line-height: 20px;
 
 $annotator-adder-font-size: 12px;

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -10,10 +10,20 @@ export default {
   ],
   theme: {
     extend: {
+      animation: {
+        adderPopUp: 'adderPopUp 0.08s ease-in forwards',
+        adderPopDown: 'adderPopDown 0.08s ease-in forwards',
+      },
+      boxShadow: {
+        adderToolbar: '0px 2px 10px 0px rgba(0, 0, 0, 0.25)',
+      },
       colors: {
         slate: {
           // TODO remove when available from upstream preset
           1: '#e3e3e5',
+        },
+        'color-text': {
+          inverted: '#f2f2f2',
         },
       },
       fontFamily: {
@@ -31,9 +41,41 @@ export default {
       fontSize: {
         tiny: ['10px'],
         sm: ['11px', '1.4'],
+        'annotator-sm': ['12px'],
         base: ['13px', '1.4'],
         lg: ['14px'],
         xl: ['16px'],
+        annotator: {
+          sm: ['12px'],
+        },
+      },
+      keyframes: {
+        adderPopDown: {
+          '0%': {
+            opacity: '0.05',
+            transform: 'scale(0.8) translateY(10px)',
+          },
+          '20%': {
+            opacity: '0.7',
+          },
+          '100%': {
+            opacity: '1',
+            transform: 'scale(1) translateY(0px)',
+          },
+        },
+        adderPopUp: {
+          '0%': {
+            opacity: '0.05',
+            transform: 'scale(0.8) translateY(-10px)',
+          },
+          '20%': {
+            opacity: '0.7',
+          },
+          '100%': {
+            opacity: '1',
+            transform: 'scale(1) translateY(0px)',
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
This PR updates the styling for the annotator's `AdderToolbar` component. It also introduces a components layer for the `annotator` app.

The adder is 1px taller as a result of these changes (due to use of standardized-scale spacing) but should otherwise look identical to the user. I have checked in Chrome, Firefox and Safari.

Styles for this component have more complexity than most and required a bit of consideration. A few external styles have been left in place to handle:

* Resetting `all: initial`, as this element serves as the root in a shadow DOM. I want to be careful here as I don't fully understand the implications here. The commit adding this rule is here: https://github.com/hypothesis/client/commit/56f5243e95c7b24486c7a7a98cac4a5a6764da7a (5 years ago). There is no equivalent utility class for this in Tailwind (I don't think there really _could_ be).
* Setting `direction: ltr`. I'm ignorant here, but believe direction is typically set as an HTML attribute, not a CSS rule? It was added 6 years ago here: https://github.com/hypothesis/client/commit/ceb8e238c4b47e6ba505a8e27e464d9c06af5477
* The hover behavior of the adder toolbar is too complex to implement with utility styles alone. It's the first time I've run into a real case in our world in which there is no clear utility-class solution. Of course we could create a Tailwind plugin or somesuch, but I think that's overkill here. I'd like to leave this in place until we've converted at least the rest of the annotator components to see if we end up with more external CSS, and why, and give it a think.

I did a little local intra-component breakdown to chunk off some sub-components for styling clarity but there is no functional change here.

Part of https://github.com/hypothesis/client/issues/4178