### PR TITLE
WIP - Fetch annotations for each frame separately

### DIFF
--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -81,6 +81,7 @@ function NotebookView({ loadAnnotationsService, streamer }) {
     store.setSortKey('Newest');
     if (groupId) {
       loadAnnotationsService.load({
+        frameId: null,
         groupId,
         // Load annotations in reverse-chronological order because that is how
         // threads are sorted in the notebook view. By aligning the fetch

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -51,7 +51,7 @@ function SidebarView({
     ? tabForAnnotation(linkedAnnotation)
     : 'annotation';
 
-  const searchUris = store.searchUris();
+  const searchURIMap = store.searchURIMap();
   const sidebarHasOpened = store.hasSidebarOpened();
   const userId = store.profile().userid;
 
@@ -105,13 +105,16 @@ function SidebarView({
       }
       prevGroupId.current = focusedGroupId;
     }
-    if (focusedGroupId && searchUris.length) {
-      loadAnnotationsService.load({
-        groupId: focusedGroupId,
-        uris: searchUris,
-      });
+    if (focusedGroupId && searchURIMap.size) {
+      for (let [frameId, uris] of searchURIMap) {
+        loadAnnotationsService.load({
+          frameId,
+          groupId: focusedGroupId,
+          uris,
+        });
+      }
     }
-  }, [store, loadAnnotationsService, focusedGroupId, userId, searchUris]);
+  }, [store, loadAnnotationsService, focusedGroupId, userId, searchURIMap]);
 
   // When a `linkedAnnotationAnchorTag` becomes available, scroll to it
   // and focus it

--- a/src/sidebar/components/StreamView.js
+++ b/src/sidebar/components/StreamView.js
@@ -42,7 +42,10 @@ function StreamView({ api, toastMessenger }) {
       try {
         store.annotationFetchStarted();
         const results = await api.search(queryParams);
-        store.addAnnotations([...results.rows, ...results.replies]);
+        store.addAnnotations(null /* frameId */, [
+          ...results.rows,
+          ...results.replies,
+        ]);
       } finally {
         store.annotationFetchFinished();
       }

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -297,7 +297,7 @@ export class FrameSyncService {
         this._hostRPC.call('showHighlights');
 
         // Create the new annotation in the sidebar.
-        this._annotationsService.create(annot);
+        this._annotationsService.create(frameIdentifier, annot);
       }
     );
 

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -455,8 +455,8 @@ export class GroupsService {
         .filter(ann => !isReply(ann))
         .map(ann => ({ ...ann, group: newGroupId }));
 
-      if (updatedAnnotations.length) {
-        this._store.addAnnotations(updatedAnnotations);
+      for (let ann of updatedAnnotations) {
+        this._store.addAnnotations(ann.$frameId, [ann]);
       }
 
       // Persist this group as the last focused group default

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -71,6 +71,7 @@ export class StreamerService {
   applyPendingUpdates() {
     const updates = Object.values(this._store.pendingUpdates());
     if (updates.length) {
+      // TODO - Handle multiple frames
       this._store.addAnnotations(updates);
     }
 
@@ -169,6 +170,9 @@ export class StreamerService {
    * @param {object} configMessage
    */
   setConfig(key, configMessage) {
+    // TODO - Figure out how to handle multiple frames. Do we create a separate
+    // connection for each frame or make changes on the backend so we can figure
+    // out which annotation goes with which frame?
     this._configMessages[key] = configMessage;
     if (this._socket?.isConnected()) {
       this._socket.send(configMessage);

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -79,6 +79,9 @@
  * @prop {string} $tag - A locally-generated unique identifier for annotations.
  *   This is set for all annotations, whether they have been saved to the backend
  *   or not.
+ * @prop {string|null} $frameId - Local identifier for the frame that this annotation
+ *   is associated with. TODO - Decide what to do if the same annotation
+ *   is returned for multiple frames.
  * @prop {string[]} [references]
  * @prop {string} created
  * @prop {boolean} [flagged]


### PR DESCRIPTION
Explore a client-side solution to sending annotations to correct frame
if annotation URL does not exactly match frame URL (see [1]). In the
client-side solution, a separate search request is made for each frame
and the returned annotations are then associated with that frame.

Some issues to resolve:

 - How can we test this locally with the dev server?
 - What if searches for different frames return the same annotation?
    - Allow annotations to be associated with multiple frames by making the `$frameId` property an array?
    - Preferentially associate the annotation with the main frame?
 - How should the WebSocket be adapted?
    - A separate WebSocket connection per frame?
 - What do about frame IDs for non-sidebar applications (notebook, stream, single annotation page) where annotations are not associated with frames?
    - Treat the annotation these views like the sidebar when there is only one main frame?

[1] https://github.com/hypothesis/client/issues/4191