### PR TITLE
Fix creation of a page note in VitalSource

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -302,28 +302,12 @@ export class Guest {
   }
 
   async _connectHost() {
-    this._hostRPC.on(
-      'clearSelectionExceptIn',
-      /** @param {string|null} frameIdentifier */
-      frameIdentifier => {
-        if (this._frameIdentifier === frameIdentifier) {
-          return;
-        }
+    this._hostRPC.on('clearSelection', () => {
+      this._informHostOnNextSelectionClear = false;
+      removeTextSelection();
+    });
 
-        this._informHostOnNextSelectionClear = false;
-        removeTextSelection();
-      }
-    );
-
-    this._hostRPC.on(
-      'createAnnotationIn',
-      /** @param {string|null} frameIdentifier */
-      frameIdentifier => {
-        if (this._frameIdentifier === frameIdentifier) {
-          this.createAnnotation();
-        }
-      }
-    );
+    this._hostRPC.on('createAnnotation', () => this.createAnnotation());
 
     this._hostRPC.on(
       'focusAnnotations',
@@ -692,7 +676,7 @@ export class Guest {
     }
 
     this.selectedRanges = [range];
-    this._hostRPC.call('textSelectedIn', this._frameIdentifier);
+    this._hostRPC.call('textSelected');
 
     this._adder.annotationsForSelection = annotationsForSelection();
     this._isAdderVisible = true;
@@ -704,7 +688,7 @@ export class Guest {
     this._adder.hide();
     this.selectedRanges = [];
     if (this._informHostOnNextSelectionClear) {
-      this._hostRPC.call('textUnselectedIn', this._frameIdentifier);
+      this._hostRPC.call('textUnselected');
     }
     this._informHostOnNextSelectionClear = true;
   }

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -439,6 +439,17 @@ describe('Guest', () => {
       });
     });
 
+    describe('on "createAnnotation" event', () => {
+      it('creates an annotation', async () => {
+        createGuest();
+
+        emitHostEvent('createAnnotation');
+        await delay(0);
+
+        assert.calledWith(sidebarRPC().call, 'createAnnotation');
+      });
+    });
+
     describe('on "deleteAnnotation" event', () => {
       it('detaches annotation', () => {
         createGuest();
@@ -645,38 +656,20 @@ describe('Guest', () => {
       assert.notCalled(FakeAdder.instance.show);
     });
 
-    it('calls "textSelectedIn" RPC method with argument "null" if selection is non-empty', () => {
+    it('calls "textSelected" RPC method when selecting text', () => {
       createGuest();
 
       simulateSelectionWithText();
 
-      assert.calledWith(hostRPC().call, 'textSelectedIn', null);
+      assert.calledWith(hostRPC().call, 'textSelected');
     });
 
-    it('calls "textSelectedIn" RPC method with the subFrameIdentifier as argument if selection is non-empty', () => {
-      const subFrameIdentifier = 'subframe identifier';
-      createGuest({ subFrameIdentifier });
-
-      simulateSelectionWithText();
-
-      assert.calledWith(hostRPC().call, 'textSelectedIn', subFrameIdentifier);
-    });
-
-    it('calls "textUnselectedIn" RPC method with argument "null" if selection is empty', () => {
+    it('calls "textUnselected" RPC method when clearing text selection', () => {
       createGuest();
 
       simulateSelectionWithoutText();
 
-      assert.calledWith(hostRPC().call, 'textUnselectedIn', null);
-    });
-
-    it('calls "textUnselectedIn" RPC method with the subFrameIdentifier as argument if selection is empty', () => {
-      const subFrameIdentifier = 'subframe identifier';
-      createGuest({ subFrameIdentifier });
-
-      simulateSelectionWithoutText();
-
-      assert.calledWith(hostRPC().call, 'textUnselectedIn', subFrameIdentifier);
+      assert.calledWith(hostRPC().call, 'textUnselected');
     });
 
     it('unselects text if another iframe has made a selection', () => {
@@ -687,7 +680,7 @@ describe('Guest', () => {
 
       simulateSelectionWithText();
       hostRPC().call.resetHistory();
-      emitHostEvent('clearSelectionExceptIn', 'subframe identifier');
+      emitHostEvent('clearSelection');
 
       assert.calledOnce(removeAllRanges);
       notifySelectionChanged(null); // removing the text selection triggers the selection observer
@@ -698,7 +691,7 @@ describe('Guest', () => {
       // On next selection clear it should be inform the host.
       notifySelectionChanged(null);
       assert.calledOnce(hostRPC().call);
-      assert.calledWithExactly(hostRPC().call, 'textUnselectedIn', null);
+      assert.calledWithExactly(hostRPC().call, 'textUnselected');
     });
 
     it("doesn't unselect text if frame identifier matches", () => {
@@ -809,22 +802,6 @@ describe('Guest', () => {
   });
 
   describe('#createAnnotation', () => {
-    it('creates an annotation if host calls "createAnnotationIn" RPC method', async () => {
-      createGuest();
-      await delay(0);
-      sidebarRPC().call.resetHistory(); // Discard `documentInfoChanged` call
-
-      emitHostEvent('createAnnotationIn', 'dummy');
-      await delay(0);
-
-      assert.notCalled(sidebarRPC().call);
-
-      emitHostEvent('createAnnotationIn', null);
-      await delay(0);
-
-      assert.calledWith(sidebarRPC().call, 'createAnnotation');
-    });
-
     it('adds document metadata to the annotation', async () => {
       const guest = createGuest();
 

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -7,15 +7,11 @@
  * Events that the guest sends to the host
  */
 export type GuestToHostEvent =
-  /**
-   * The guest informs the host that text has been unselected at a frame with that identifier.
-   */
-  | 'textUnselectedIn'
+  /** The guest informs the host that text has been unselected. */
+  | 'textUnselected'
 
-  /**
-   * The guest informs the host that text has been selected at a frame with that identifier.
-   */
-  | 'textSelectedIn'
+  /** The guest informs the host that text has been selected. */
+  | 'textSelected'
 
   /**
    * The guest informs the host that the anchors have been changed in the main annotatable frame.
@@ -68,15 +64,11 @@ export type GuestToSidebarEvent =
  * Events that the host sends to the guest
  */
 export type HostToGuestEvent =
-  /**
-   * The host requests a guest with a specific frame identifier to create an annotation.
-   */
-  | 'createAnnotationIn'
+  /** The host requests a guest to create an annotation. */
+  | 'createAnnotation'
 
-  /**
-   * The host informs guests that text should be unselected, except in the guest with a given frame identifier
-   */
-  | 'clearSelectionExceptIn'
+  /** The host informs guests that text should be unselected. */
+  | 'clearSelection'
 
   /**
    * The host informs guests to focus on a set of annotations


### PR DESCRIPTION
After #4176, the 'create note' button has stopped working in
VitalSource. That's because we don't create the guest frame in the host
frame. Creating a note relayed on one of the guest frames having a
frameIdentifier` with value `null`. That's not longer the case.

Now, when creating a page note we send the request to the first
connected guest frame. This is analogous to #4177.

In addition, we only send `textUnselected`, `textSelected` and
`createAnnotation` RPC events to only specific guest frames. That
simplifies the logic by avoiding to send a `frameIdentifier`.