### PR TITLE
Remove 'ready' RPC event

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -197,7 +197,7 @@ export class Sidebar {
     this._notifyOfLayoutChange(false);
     this._setupSidebarEvents();
 
-    this._sidebarRPC.on('ready', () => {
+    this._sidebarRPC.on('connect', () => {
       // Show the UI
       if (this.iframeContainer) {
         this.iframeContainer.style.display = '';

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -72,7 +72,7 @@ describe('Sidebar', () => {
    * when the sidebar has loaded and is ready.
    */
   const connectSidebarApp = () => {
-    emitSidebarEvent('ready');
+    emitSidebarEvent('connect');
   };
 
   /**

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -370,7 +370,6 @@ export class FrameSyncService {
     // Create channel for sidebar-host communication.
     const hostPort = await this._portFinder.discover('host');
     this._hostRPC.connect(hostPort);
-    this._hostRPC.call('ready');
 
     // Listen for guests connecting to the sidebar.
     this._listeners.add(hostPort, 'message', event => {

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -186,12 +186,6 @@ describe('FrameSyncService', () => {
       assert.calledWith(hostRPC().connect, sidebarPort);
     });
 
-    it('notifies the host frame that the sidebar is ready to be displayed', async () => {
-      await frameSync.connect();
-
-      assert.calledWith(hostRPC().call, 'ready');
-    });
-
     it('connects to new guests', async () => {
       frameSync.connect();
       const port = await connectGuest();

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -146,11 +146,6 @@ export type SidebarToGuestEvent =
  */
 export type SidebarToHostEvent =
   /**
-   * The sidebar notifies the host that it has loaded and is ready to be displayed.
-   */
-  | 'ready'
-
-  /**
    * The sidebar relays to the host to close the sidebar.
    */
   | 'closeSidebar'


### PR DESCRIPTION
The new built-in "connect" PortRPC event (see #4175) makes the `ready`
RPC event redundant. The host frame now uses the `connect` event to know
when the sidebar frame is connected, and hence display it.