### PR TITLE
Add `yarn typecheck-no-any` command

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,8 @@ jobs:
     - name: Lint
       run: yarn lint
     - name: Typecheck
-      run: yarn typecheck
+      run: |
+        yarn typecheck
+        yarn typecheck-no-any
     - name: Test
       run: yarn test

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "format": "prettier --list-different --write '**/*.{js,scss,d.ts}'",
     "test": "gulp test",
     "typecheck": "tsc --build tsconfig.json",
+    "typecheck-no-any": "tsc --build src/tsconfig.no-any.json",
     "report-coverage": "codecov -f coverage/coverage-final.json",
     "version": "make clean build"
   }

--- a/src/shared/messaging/port-rpc.js
+++ b/src/shared/messaging/port-rpc.js
@@ -55,7 +55,7 @@ const PROTOCOL = 'frame-rpc';
  *
  * @param {MessagePort} port
  * @param {string} method
- * @param {any[]} [arguments]
+ * @param {any[]} [args]
  * @param {number} [sequence] - Sequence number used for replies
  */
 function sendCall(port, method, args = [], sequence = -1) {

--- a/src/shared/prompts.js
+++ b/src/shared/prompts.js
@@ -12,9 +12,9 @@ import { ConfirmModal } from '@hypothesis/frontend-shared';
  *  - The visual style of the dialog matches the Hypothesis design system
  *
  * @param {object} options - Options for the `ConfirmModal`
- *   @prop {string} [title]
- *   @prop {string} message
- *   @prop {string} [confirmAction]
+ *   @param {string} [options.title]
+ *   @param {string} options.message
+ *   @param {string} [options.confirmAction]
  * @return {Promise<boolean>} - Promise that resolves with `true` if the user
  *   confirmed the action or `false` if they canceled it.
  */

--- a/src/shared/random.js
+++ b/src/shared/random.js
@@ -1,3 +1,4 @@
+/** @param {number} val */
 function byteToHex(val) {
   const str = val.toString(16);
   return str.length === 1 ? '0' + str : str;

--- a/src/shared/renderer-options.js
+++ b/src/shared/renderer-options.js
@@ -4,7 +4,7 @@ import { options } from 'preact';
  * Setup workarounds for setting certain HTML element properties or attributes
  * in some browsers.
  *
- * @param {object} _options - Test seam
+ * @param {import('preact').Options} _options - Test seam
  */
 export function setupBrowserFixes(_options = options) {
   let needsDirAutoFix = false;
@@ -21,9 +21,10 @@ export function setupBrowserFixes(_options = options) {
     const prevHook = _options.vnode;
     _options.vnode = vnode => {
       if (typeof vnode.type === 'string') {
-        if ('dir' in vnode.props && vnode.props.dir === 'auto') {
+        const props = /** @type {{ dir?: string }} */ (vnode.props);
+        if ('dir' in props && props.dir === 'auto') {
           // Re-assign `vnode.props.dir` if its value is "auto"
-          vnode.props.dir = '';
+          props.dir = '';
         }
       }
       // Call previously defined hook if there was any

--- a/src/shared/shortcut.js
+++ b/src/shared/shortcut.js
@@ -2,7 +2,11 @@ import { normalizeKeyName } from '@hypothesis/frontend-shared';
 
 import { useEffect } from 'preact/hooks';
 
-// Bit flags indicating modifiers required by a shortcut or pressed in a key event.
+/**
+ * Bit flags indicating modifiers required by a shortcut or pressed in a key event.
+ *
+ * @type {Record<string, number>}
+ */
 const modifiers = {
   alt: 1,
   ctrl: 2,
@@ -78,6 +82,7 @@ export function installShortcut(
   onPress,
   { rootElement = document.body } = {}
 ) {
+  /** @param {KeyboardEvent} event */
   const onKeydown = event => {
     if (matchShortcut(event, shortcut)) {
       onPress(event);

--- a/src/shared/warn-once.js
+++ b/src/shared/warn-once.js
@@ -1,4 +1,5 @@
-let shownWarnings = {};
+/** @type {Set<string>} */
+let shownWarnings = new Set();
 
 /**
  * Log a warning if it has not already been reported.
@@ -13,13 +14,13 @@ let shownWarnings = {};
  */
 export function warnOnce(...args) {
   const key = args.join();
-  if (key in shownWarnings) {
+  if (shownWarnings.has(key)) {
     return;
   }
   console.warn(...args);
-  shownWarnings[key] = true;
+  shownWarnings.add(key);
 }
 
 warnOnce.reset = () => {
-  shownWarnings = {};
+  shownWarnings.clear();
 };

--- a/src/tsconfig.no-any.json
+++ b/src/tsconfig.no-any.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "checkJs": true,
+    "lib": ["es2020", "dom", "dom.iterable"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "module": "es2020",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2020",
+
+    // Let argument to catch statement be `any` rather than `unknown`.
+    "useUnknownInCatchVariables": false,
+
+    // Prevent automatic inclusion of global variables defined in `@types/<name>` packages.
+    // This prevents eg. Node globals from `@types/node` being included when writing
+    // code for the browser.
+    "types": []
+  },
+  "include": ["shared/**/*.js", "types/process.d.ts"],
+  "exclude": [
+    // Tests are not checked.
+    "**/test/**/*.js",
+    "test-util/**/*.js",
+    "karma.config.js"
+  ]
+}


### PR DESCRIPTION
Add a command which runs TypeScript against a subset of the codebase, currently
just src/shared/, with the `noImplicitAny` option enabled.

This will allow us to gradually work towards the goal of having the entire
client codebase typecheck with this option enabled [1]. Once this state is reached
the `noImplicitAny` option can be enabled in the main TS config file
(src/tsconfig.json) and the `yarn typecheck-no-any` command and associated TS
config file can be removed.

[1] See https://github.com/hypothesis/client/issues/3918