### PR TITLE
Ignore meta tag if `content` attribute is empty

### DIFF
--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="citation_doi" content>
   <title>Hypothesis Client Test</title>
 <style>
   body {

--- a/src/annotator/integrations/html-metadata.js
+++ b/src/annotator/integrations/html-metadata.js
@@ -123,7 +123,7 @@ export class HTMLMetadata {
     for (let meta of Array.from(this.document.querySelectorAll('meta'))) {
       const name = meta.getAttribute(attribute);
       const { content } = meta;
-      if (name) {
+      if (name && content) {
         const match = name.match(RegExp(`^${prefix}${delimiter}(.+)$`, 'i'));
         if (match) {
           const n = match[1];

--- a/src/annotator/integrations/test/html-metadata-test.js
+++ b/src/annotator/integrations/test/html-metadata-test.js
@@ -157,6 +157,16 @@ describe('HTMLMetadata', () => {
       assert.deepEqual(metadata.highwire.title, ['Foo']);
     });
 
+    it('should ignore meta tags without content', () => {
+      tempDocumentHead.innerHTML = `
+        <meta name="citation_doi" content>
+        <meta name="DC.type">
+      `;
+      const metadata = testDocument.getDocumentMetadata();
+      assert.isEmpty(metadata.highwire);
+      assert.isEmpty(metadata.dc);
+    });
+
     it('should return Dublin Core metadata', () => {
       assert.ok(metadata.dc);
       assert.deepEqual(metadata.dc.identifier, [


### PR DESCRIPTION
If the meta tag contains a empty `content` attribute it is ignored.
Example: `<meta name="citation_doi" content>`

Closes https://github.com/hypothesis/product-backlog/issues/1290