### PR TITLE
Send annotation to first frame when there is no URI match or main frame

### DIFF
--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -37,21 +37,26 @@ export function formatAnnot({ $tag, target, uri }) {
 /**
  * Return the frame which best matches an annotation.
  *
- * If there is a frame whose URL exactly matches the annotation, it will be
- * returned. Otherwise the main frame will be returned. Currently this may fail
- * to return the expected frame if an annotation was fetched from h that
- * does not match one of the frame URIs. This can happen due to URI expansion /
- * document equivalence in h.
- *
  * @param {Frame[]} frames
  * @param {Annotation} ann
  */
 function frameForAnnotation(frames, ann) {
-  const frame = frames.find(f => f.uri === ann.uri);
-  if (frame) {
-    return frame;
+  // Choose frame with an exact URL match if possible. In the unlikely situation
+  // where multiple frames have the same URL, we'll use whichever connected first.
+  const uriMatch = frames.find(f => f.uri === ann.uri);
+  if (uriMatch) {
+    return uriMatch;
   }
-  return frames.find(f => f.id === null);
+
+  // If there is no exact URL match, choose the main/host frame for consistent results.
+  const mainFrame = frames.find(f => f.id === null);
+  if (mainFrame) {
+    return mainFrame;
+  }
+
+  // If there is no main frame (eg. in VitalSource), fall back to whichever
+  // frame connected first.
+  return frames[0];
 }
 
 /**

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -351,7 +351,6 @@ describe('FrameSyncService', () => {
     it('sends a "publicAnnotationCountChanged" message to the frame when there are public annotations', async () => {
       await connectGuest();
       emitGuestEvent('documentInfoChanged', fixtures.htmlDocumentInfo);
-      fakeStore.frames()[0].isAnnotationFetchComplete = true;
 
       fakeStore.setState({
         annotations: [annotationFixtures.publicAnnotation()],
@@ -367,7 +366,6 @@ describe('FrameSyncService', () => {
     it('sends a "publicAnnotationCountChanged" message to the frame when there are only private annotations', async () => {
       await connectGuest();
       emitGuestEvent('documentInfoChanged', fixtures.htmlDocumentInfo);
-      fakeStore.frames()[0].isAnnotationFetchComplete = true;
 
       const annot = annotationFixtures.defaultAnnotation();
       delete annot.permissions;


### PR DESCRIPTION
This is a refinement of https://github.com/hypothesis/client/pull/4131.

Handle the case when an annotation is returned from the backend whose URL does
not match the frame URL and where there is no "main" guest frame. This can
happen in VitalSource, where no guest is created in the host frame.

The general solution to this is to change the client and h so that it can always
determine which query URL an annotation from h matched. See [1]. This is an
interim step which will work in VitalSource and similar scenarios.

The second commit in this PR reworks how `store.frames()` is implemented in the `FrameSyncService` tests to make tests easier to write and encourage the results to be consistent with the real application.

You won't see any immediate effects in manual testing because we don't yet rely on document equivalence in the VS integration.

[1] https://github.com/hypothesis/client/issues/4191
