### PR TITLE
Normalise the value of the specified attribute to lower-case: `<meta name|property="[value to lowercase]">`

### DIFF
--- a/src/annotator/integrations/html-metadata.js
+++ b/src/annotator/integrations/html-metadata.js
@@ -126,11 +126,11 @@ export class HTMLMetadata {
       if (name && content) {
         const match = name.match(RegExp(`^${prefix}${delimiter}(.+)$`, 'i'));
         if (match) {
-          const n = match[1];
-          if (tags[n]) {
-            tags[n].push(content);
+          const key = match[1].toLowerCase();
+          if (tags[key]) {
+            tags[key].push(content);
           } else {
-            tags[n] = [content];
+            tags[key] = [content];
           }
         }
       }

--- a/src/annotator/integrations/test/html-metadata-test.js
+++ b/src/annotator/integrations/test/html-metadata-test.js
@@ -157,14 +157,26 @@ describe('HTMLMetadata', () => {
       assert.deepEqual(metadata.highwire.title, ['Foo']);
     });
 
-    it('should ignore meta tags without content', () => {
-      tempDocumentHead.innerHTML = `
-        <meta name="citation_doi" content>
-        <meta name="DC.type">
-      `;
-      const metadata = testDocument.getDocumentMetadata();
-      assert.isEmpty(metadata.highwire);
-      assert.isEmpty(metadata.dc);
+    context('in "meta" elements', () => {
+      it('should ignore if "content" attribute is not present', () => {
+        tempDocumentHead.innerHTML = `
+          <meta name="citation_doi" content>
+          <meta name="DC.type">
+        `;
+        const metadata = testDocument.getDocumentMetadata();
+        assert.isEmpty(metadata.highwire);
+        assert.isEmpty(metadata.dc);
+      });
+
+      it('should lower-case the value of the specified attribute', () => {
+        tempDocumentHead.innerHTML = `
+          <meta name="CITATION_DOI" content="10.1175/JCLI-D-11-00015.1">
+          <meta property="OG:URL" content="https://fb.com">
+        `;
+        const metadata = testDocument.getDocumentMetadata();
+        assert.deepEqual(metadata.highwire.doi, ['10.1175/JCLI-D-11-00015.1']);
+        assert.deepEqual(metadata.facebook.url, ['https://fb.com']);
+      });
     });
 
     it('should return Dublin Core metadata', () => {


### PR DESCRIPTION
Previously the following attributes in the meta tag:

```
<meta name="DC_IDENTIFIER" .../>
<meta name="EPRINTS.TITLE_" .../>
<meta property="OG:URL" .../>
<meta name="CITATION_DOI" .../>
<meta name="PRISM_TITLE" .../>
<meta name="TWITTER:SITE" .../>
```

produced a metadata dictionary like this:

```
{
  dc: {IDENTIFIER: [...] },
  eprints: {TITLE: [...]},
  facebook: {URL: [...]},
  highwire: {DOI: [...]},
  twitter: {SITE: [...]}
}
```

Now, with the modifications introduced in this PR, it produces a
metadata dictionary where all the keys are lowercase:
```
{
  dc: {identifier: [...] },
  eprints: {title: [...]},
  facebook: {url: [...]},
  highwire: {doi: [...]},
  twitter: {site: [...]}
}
```

I have confirmed that `h` expects the lowercase version of the keys
`identifier` and `doi`:

https://github.com/hypothesis/h/blob/73dacc722367c44903ff3c6f610712ba8f43934d/h/util/document_claims.py#L222

https://github.com/hypothesis/h/blob/73dacc722367c44903ff3c6f610712ba8f43934d/h/util/document_claims.py#L247

Hence, if they are not provided as lowercase version, they will be
ignored and the document equivalence will not work.

Closes https://github.com/hypothesis/client/issues/671