### PR TITLE
Override base font sizing in PDFjs styles

### DIFF
--- a/src/styles/annotator/pdfjs-overrides.scss
+++ b/src/styles/annotator/pdfjs-overrides.scss
@@ -21,3 +21,11 @@
 .textLayer .highlight.selected {
   background-color: rgba(0, 100, 0, 0.5);
 }
+
+// Override PDFjs base font-size of miniscule `10px` to reset REM size.
+// This is necessary for styling components in shadow DOMs that rely on REM-
+// based scales.
+// See https://github.com/mozilla/pdf.js/issues/14555
+html {
+  font-size: 100%;
+}


### PR DESCRIPTION
PDFjs' CSS sets `font-size: 10px` on the `html` element. This sets
1rem = `10px` which is tiny. Our styles work in rem units for spacing,
so padding, margins, etc. are too tight with that `10px` base size.

Set `html` font-size back to 100% for now. This does not have any
apparent effect on PDFjs styling, as `body` sets `font-size: 16px`
anyway.

We should also look at better solutions here. Perhaps we could compile annotator styles against a tailwind config that uses a pixel-based (i.e. absolute units instead of relative ones) spacing scale. We should also be sizing our fonts in rem units as well as our spacing — at least then everything would scale to the document's root font size instead of just the spacing, which definitely looks awkward. Or maybe I will discover a way to reset REM from within a shadow DOM still...we'll see!

See https://github.com/mozilla/pdf.js/issues/14555