### PR TITLE
Remove kind of circular RPC event

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -316,7 +316,10 @@ export class Guest {
     this._hostRPC.on(
       'focusAnnotations',
       /** @param {string[]} tags */
-      tags => this._focusAnnotations(tags)
+      tags => {
+        this._focusAnnotations(tags);
+        this._sidebarRPC.call('focusAnnotations', tags);
+      }
     );
 
     this._hostRPC.on(
@@ -639,8 +642,6 @@ export class Guest {
         setHighlightsFocused(anchor.highlights, toggle);
       }
     }
-
-    this._sidebarRPC.call('focusAnnotations', tags);
   }
 
   /**


### PR DESCRIPTION
When the host frame sends a `focusAnnotations` RPC event to the guest
frame, we want to relay the event to the sidebar frame.

However, when the `focusAnnotations` RPC event is coming from the sidebar
frame, we don't want the guest frame to send the event back to the
sidebar frame.

[Based in this comment.](https://github.com/hypothesis/client/pull/4128#issuecomment-1017804981)

`Guest.#__focusAnnotations` is used regardless the source frame of the `focusAnnotations` RPC event.