### PR TITLE
Only load PDF.js style overrides in PDF.js

### DIFF
--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -29,6 +29,10 @@ const commonPolyfills = [
  */
 
 /**
+ * @typedef {Window & { PDFViewerApplication?: object }} MaybePDFWindow
+ */
+
+/**
  * Mark an element as having been added by the boot script.
  *
  * This marker is later used to know which elements to remove when unloading
@@ -197,17 +201,23 @@ export function bootHypothesisClient(doc, config) {
 
   const polyfills = polyfillBundles(commonPolyfills);
 
+  // Override styling in certain document viewers.
+  const viewerStyles = [];
+  if (
+    /** @type {MaybePDFWindow} */ (window).PDFViewerApplication !== undefined
+  ) {
+    viewerStyles.push('styles/pdfjs-overrides.css');
+  }
+
   injectAssets(
     doc,
     config,
     [
-      // Vendor code and polyfills
       ...polyfills,
+      ...viewerStyles,
 
       'scripts/annotator.bundle.js',
-
       'styles/highlights.css',
-      'styles/pdfjs-overrides.css',
     ],
 
     // Force re-evaluation of JS module scripts, so that the annotator entry

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -104,10 +104,27 @@ describe('bootstrap', () => {
       const expectedAssets = [
         'scripts/annotator.bundle.1234.js#ts=123',
         'styles/highlights.1234.css',
-        'styles/pdfjs-overrides.1234.css',
       ].map(assetUrl);
 
       assert.deepEqual(findAssets(iframe.contentDocument), expectedAssets);
+    });
+
+    it('loads styling overrides in PDF.js', () => {
+      clock.tick(123); // Set timestamp used by module cache-busting fragment.
+
+      window.PDFViewerApplication = {};
+      try {
+        runBoot('annotator');
+        const expectedAssets = [
+          'scripts/annotator.bundle.1234.js#ts=123',
+          'styles/highlights.1234.css',
+          'styles/pdfjs-overrides.1234.css',
+        ].map(assetUrl);
+
+        assert.deepEqual(findAssets(iframe.contentDocument), expectedAssets);
+      } finally {
+        delete window.PDFViewerApplication;
+      }
     });
 
     it('preloads assets used wihin shadow roots in the annotation layer', () => {


### PR DESCRIPTION
Only load the `pdfjs-overrides.css` bundle when the client is loaded in
PDF.js.

This fixes an issue where a global styling change that was recently
added specifically for PDF.js [1] ended up affecting other web pages
[2].

We will eventually need to find an alternative solution to the problem that prompted https://github.com/hypothesis/client/pull/4208, that works for all web pages. However it still makes sense not to load style overrides intended for PDF.js in other contexts.

[1] https://github.com/hypothesis/client/pull/4208
[2] https://github.com/hypothesis/product-backlog/issues/1270#issuecomment-1039647361

---

**Testing:**

1. Load the client in a normal web page, verify that the pdfjs-overrides.css stylesheet is not added to the `<head>` element
2. Load the client in PDF.js, verify that the pdfjs-overrides.css stylesheet is added to the `<head>` element