### PR TITLE
Notify new guests of current sidebar layout

### DIFF
--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -856,6 +856,21 @@ describe('Sidebar', () => {
         });
       });
 
+      it('notifies new guests of current sidebar layout', () => {
+        sidebar.open();
+
+        connectGuest(sidebar);
+
+        assert.calledWith(
+          guestRPC().call,
+          'sidebarLayoutChanged',
+          sinon.match({
+            expanded: true,
+            width: DEFAULT_WIDTH + fakeToolbar.getWidth(),
+          })
+        );
+      });
+
       it('notifies when sidebar is panned left', () => {
         sidebar._gestureState = { initial: -DEFAULT_WIDTH };
         sidebar._onPan({ type: 'panleft', deltaX: -50 });


### PR DESCRIPTION
Notify newly connected guest frames of the current sidebar layout. This
allows newly created guests to properly activate side-by-side mode if the
sidebar is already open and the guest supports it. This is relevant when
navigating between chapters in a VitalSource book.