### PR TITLE
Invoke `gulp watch` indirectly through `yarn`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 
 .PHONY: dev
 dev: node_modules/.uptodate
-	node_modules/.bin/gulp watch
+	yarn gulp watch
 
 .PHONY: test
 test: node_modules/.uptodate


### PR DESCRIPTION
In the Makefile, a number of JS command line executables (for example,
`prettier`, `eslint`, `tsc`) are currently invoked indirectly using
`yarn`, instead of using the whole path `node_modules/.bin/[...]`. I
think it makes a more cleaner and consistent option to invoke `gulp
watch` through `yarn`.