### PR TITLE
Use same `Guest._frameIdentifier` as assigned by `PortProvider`

### DIFF
--- a/src/shared/messaging/port-finder.js
+++ b/src/shared/messaging/port-finder.js
@@ -42,7 +42,7 @@ export class PortFinder {
    * Request a specific port from the host frame
    *
    * @param {Frame} target - the frame aiming to be discovered
-   * @return {Promise<MessagePort>}
+   * @return {Promise<{port: MessagePort, requestId: string}>}
    */
   async discover(target) {
     let isValidRequest = false;
@@ -106,7 +106,7 @@ export class PortFinder {
           clearInterval(intervalId);
           clearTimeout(timeoutId);
           this._listeners.remove(listenerId);
-          resolve(ports[0]);
+          resolve({ port: ports[0], requestId });
         }
       });
 

--- a/src/shared/messaging/port-util.js
+++ b/src/shared/messaging/port-util.js
@@ -38,6 +38,7 @@ export function isMessage(data) {
  *
  * @param {any} data
  * @param {Partial<Message>} message
+ * @return {data is Message}
  */
 export function isMessageEqual(data, message) {
   if (!isMessage(data)) {


### PR DESCRIPTION
`Guest` class relies on a frame identifier set by the injector to
uniquely identify itself when communicating with the sidebar frame. This
identifier can have two types: `null`, when the hypothesis client was
initially loaded, and `string`, when the client is injected.

In this PR, the `Guest` waits until `PortFinder` to return a `requestId`
set by `PortProvider`. This `requestId` can be used to uniquely identify
guest frame during its lifetime.

This change allows to remove a mechanism in `FrameSync` that replaces a
temporal ID by a permanent one that comes with the metadata information
in the `documentInfoChanged` RPC event.