### PR TITLE
Implement side-by-side mode for VitalSource PDF ("fixed layout") books

### DIFF
--- a/dev-server/documents/html/vitalsource-pdf.mustache
+++ b/dev-server/documents/html/vitalsource-pdf.mustache
@@ -44,7 +44,7 @@
           const styles = document.createElement('style');
           styles.innerHTML = `
             iframe {
-              width: 80%;
+              width: 100%;
               height: 800px;
               resize: both;
               overflow: auto;

--- a/src/annotator/integrations/image-text-layer.js
+++ b/src/annotator/integrations/image-text-layer.js
@@ -178,11 +178,19 @@ export class ImageTextLayer {
      */
     this.container = container;
 
-    // Adjust box sizes when image is resized. We currently assume this
-    // corresponds to a frame resize. We could use `ResizeObserver` instead in
-    // supporting browsers.
     this._updateBoxSizes = debounce(updateBoxSizes, { maxWait: 50 });
     this._listeners = new ListenerCollection();
+
+    if (typeof ResizeObserver !== 'undefined') {
+      this._imageSizeObserver = new ResizeObserver(() => {
+        this._updateBoxSizes();
+      });
+      this._imageSizeObserver.observe(image);
+    }
+
+    // Fallback for browsers that don't support ResizeObserver (Safari < 13.4).
+    // Due to the debouncing, we can register this listener in all browsers for
+    // simplicity, without downsides.
     this._listeners.add(window, 'resize', this._updateBoxSizes);
   }
 
@@ -190,5 +198,6 @@ export class ImageTextLayer {
     this.container.remove();
     this._listeners.removeAll();
     this._updateBoxSizes.cancel();
+    this._imageSizeObserver?.disconnect();
   }
 }

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -350,6 +350,36 @@ describe('annotator/integrations/vitalsource', () => {
 
         assert.calledOnce(fakeImageTextLayer.destroy);
       });
+
+      context('when side-by-side mode is toggled', () => {
+        it('resizes page image', () => {
+          createPageImageAndData();
+          const integration = createIntegration();
+
+          // Activate side-by-side mode. Page image should be resized to fit
+          // alongside sidebar.
+          const sidebarWidth = 150;
+          const expectedWidth = window.innerWidth - sidebarWidth;
+          integration.fitSideBySide({ expanded: true, width: sidebarWidth });
+          assert.equal(fakePageImage.parentElement.style.textAlign, 'left');
+          assert.equal(fakePageImage.style.width, `${expectedWidth}px`);
+
+          // Deactivate side-by-side mode. Style overrides should be removed.
+          integration.fitSideBySide({ expanded: false });
+          assert.equal(fakePageImage.parentElement.style.textAlign, '');
+          assert.equal(fakePageImage.style.width, '');
+        });
+
+        it('does not resize page image if there is not enough space', () => {
+          createPageImageAndData();
+          const integration = createIntegration();
+
+          const sidebarWidth = window.innerWidth - 200;
+          integration.fitSideBySide({ expanded: true, width: sidebarWidth });
+          assert.equal(fakePageImage.parentElement.style.textAlign, '');
+          assert.equal(fakePageImage.style.width, '');
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/4245.**~~

This implements simple side-by-side support for VitalSource PDF books. From the user's point of view it works similarly to how side-by-side mode works in PDFs, where the entire page content is simply resized in a uniform way. Providing the text was big enough in the first place and the screen is large enough, the resized text can still be readable.

The current implementation relies on ResizeObserver. In browsers that don't support this, side-by-side mode will not take effect (ie. it will work as before). This only applies to Safari < 13.4.

The change comes in two parts:

1. The logic in `ImageTextLayer` which updates the text layer when the window is resized has been generalized to use `ResizeObserver` to detect any cause of image size changes. The previous method has been left as a fallback for browsers that don't support ResizeObserver.
2. The VitalSource integration now uses different logic to implement side-by-side mode when the book is a PDF as opposed to HTML document. In a PDF it resizes the book image, triggering an update of the text layer due to (1), and also adjusts some styling to make sure the image is left-aligned within the containing `<body>`.

Closes https://github.com/hypothesis/product-backlog/issues/1258

----

**Testing:**

1. Go to http://localhost:3000/document/vitalsource-pdf and make an annotation.
2. Toggle the sidebar open and closed
3. Repeat (2) but make the browser window very narrow first

In step (2) the page image should be resized to fit alongside the sidebar, and the text layer should be rescaled appropriately. In step (3) the page image should no longer be resized once the available space for it, alongside the sidebar, would be less than 250px wide.