### PR TITLE
Clarify structure of settings-building module in sidebar

### DIFF
--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -2,7 +2,7 @@ import { parseJsonConfig } from '../boot/parse-json-config';
 import * as rendererOptions from '../shared/renderer-options';
 
 import { checkEnvironment } from './config/check-env';
-import { fetchConfig } from './config/fetch-config';
+import { buildSettings } from './config/build-settings';
 import {
   startServer as startRPCServer,
   preStartServer as preStartRPCServer,
@@ -140,10 +140,10 @@ import { Injector } from '../shared/injector';
 /**
  * Launch the client application corresponding to the current URL.
  *
- * @param {object} config
+ * @param {import("../types/config").MergedConfig} settings
  * @param {HTMLElement} appEl - Root HTML container for the app
  */
-function startApp(config, appEl) {
+function startApp(settings, appEl) {
   const container = new Injector();
 
   // Register services.
@@ -175,7 +175,7 @@ function startApp(config, appEl) {
   // that use them, since they don't depend on instances of other services.
   container
     .register('$window', { value: window })
-    .register('settings', { value: config });
+    .register('settings', { value: settings });
 
   // Initialize services.
   container.run(initServices);
@@ -214,8 +214,8 @@ const appEl = /** @type {HTMLElement} */ (
 // Start capturing RPC requests before we start the RPC server (startRPCServer)
 preStartRPCServer();
 
-fetchConfig(appConfig)
-  .then(config => {
-    startApp(config, appEl);
+buildSettings(appConfig)
+  .then(settings => {
+    startApp(settings, appEl);
   })
   .catch(err => reportLaunchError(err, appEl));


### PR DESCRIPTION
The goal of this PR is to reduce the complexity and increase the clarity of the functions and module that compose the object that is used as `settings` for the `sidebar` before extending some settings to support additional RPC communication between LMS and the client. As such, it is part of https://github.com/hypothesis/lms/issues/3647

These changes attempt to:

* Use naming that is more clear for what the settings-building module, references and functions are/do. Be consistent about "configuration" ("inputs" to  compose into settings) versus "settings" (outputs)
* Adjust functions to have clearer responsibilities
* Add typing where it's helpful
* I've changed the module name and its exported function name but did not make API changes. Existing tests passed with one or two exceptions that actually highlighted what I believe was invalid behavior.

There are other places that could be improved in the area of config/settings here, but I've attempted to draw a box around things tightly so we don't dive in to a "project" here. These changes should make extending settings with some RPC details more comprehensible for us and for future devs.

A couple of related things that I didn't touch but I'm aware of:

* What's the history and future-plan for the "legacy" (deprecated) host-configuration retrieval from an undesignated ancestor frame? I can do a little digging around here.
* There's more typing to do...

I'm opening this PR in draft because I'm feeling a little muzzy here toward the end of my day and I'd like to do more reflection and testing when I'm fresher.

