### PR TITLE
Preserve logical scroll position after toggling side-by-side mode in web pages / VitalSource EPUBs

### DIFF
--- a/src/annotator/integrations/html-side-by-side.js
+++ b/src/annotator/integrations/html-side-by-side.js
@@ -100,7 +100,7 @@ function* textNodesInRect(root, rect) {
       const element = /** @type {Element} */ (node);
       const elementRect = element.getBoundingClientRect();
 
-      // Skip over subtrees which are entirely outside the viewport or hidden.
+      // Only examine subtrees which are visible and intersect the viewport.
       if (rectIntersects(elementRect, rect)) {
         yield* textNodesInRect(element, rect);
       }

--- a/src/annotator/integrations/html.js
+++ b/src/annotator/integrations/html.js
@@ -3,7 +3,10 @@ import scrollIntoView from 'scroll-into-view';
 import { anchor, describe } from '../anchoring/html';
 
 import { HTMLMetadata } from './html-metadata';
-import { guessMainContentArea } from './html-side-by-side';
+import {
+  guessMainContentArea,
+  preserveScrollPosition,
+} from './html-side-by-side';
 
 /**
  * @typedef {import('../../types/annotator').Anchor} Anchor
@@ -107,40 +110,44 @@ export class HTMLIntegration {
     const padding = 12;
     const rightMargin = sidebarWidth + padding;
 
-    // nb. Adjusting the body size this way relies on the page not setting a
-    // width on the body. For sites that do this won't work.
-    document.body.style.marginRight = `${rightMargin}px`;
+    preserveScrollPosition(() => {
+      // nb. Adjusting the body size this way relies on the page not setting a
+      // width on the body. For sites that do this won't work.
+      document.body.style.marginRight = `${rightMargin}px`;
 
-    const contentArea = guessMainContentArea(document.body);
-    if (contentArea) {
-      // Check if we can give the main content more space by letting the
-      // sidebar overlap stuff in the document to the right of the main content.
-      const freeSpace = Math.max(
-        0,
-        window.innerWidth - rightMargin - contentArea.right
-      );
-      if (freeSpace > 0) {
-        const adjustedMargin = Math.max(0, rightMargin - freeSpace);
-        document.body.style.marginRight = `${adjustedMargin}px`;
-      }
+      const contentArea = guessMainContentArea(document.body);
+      if (contentArea) {
+        // Check if we can give the main content more space by letting the
+        // sidebar overlap stuff in the document to the right of the main content.
+        const freeSpace = Math.max(
+          0,
+          window.innerWidth - rightMargin - contentArea.right
+        );
+        if (freeSpace > 0) {
+          const adjustedMargin = Math.max(0, rightMargin - freeSpace);
+          document.body.style.marginRight = `${adjustedMargin}px`;
+        }
 
-      // If the main content appears to be right up against the edge of the
-      // window, add padding for readability.
-      if (contentArea.left < padding) {
-        document.body.style.marginLeft = `${padding}px`;
+        // If the main content appears to be right up against the edge of the
+        // window, add padding for readability.
+        if (contentArea.left < padding) {
+          document.body.style.marginLeft = `${padding}px`;
+        }
+      } else {
+        document.body.style.marginLeft = '';
+        document.body.style.marginRight = '';
       }
-    } else {
-      document.body.style.marginLeft = '';
-      document.body.style.marginRight = '';
-    }
+    });
   }
 
   /**
    * Undo the effects of `activateSideBySide`.
    */
   _deactivateSideBySide() {
-    document.body.style.marginLeft = '';
-    document.body.style.marginRight = '';
+    preserveScrollPosition(() => {
+      document.body.style.marginLeft = '';
+      document.body.style.marginRight = '';
+    });
   }
 
   async getMetadata() {

--- a/src/annotator/integrations/test/html-test.js
+++ b/src/annotator/integrations/test/html-test.js
@@ -4,6 +4,7 @@ describe('HTMLIntegration', () => {
   let fakeHTMLAnchoring;
   let fakeHTMLMetadata;
   let fakeGuessMainContentArea;
+  let fakePreserveScrollPosition;
   let fakeScrollIntoView;
 
   beforeEach(() => {
@@ -20,6 +21,7 @@ describe('HTMLIntegration', () => {
     fakeScrollIntoView = sinon.stub().yields();
 
     fakeGuessMainContentArea = sinon.stub().returns(null);
+    fakePreserveScrollPosition = sinon.stub().yields();
 
     const HTMLMetadata = sinon.stub().returns(fakeHTMLMetadata);
     $imports.$mock({
@@ -28,6 +30,7 @@ describe('HTMLIntegration', () => {
       './html-metadata': { HTMLMetadata },
       './html-side-by-side': {
         guessMainContentArea: fakeGuessMainContentArea,
+        preserveScrollPosition: fakePreserveScrollPosition,
       },
     });
   });
@@ -144,6 +147,14 @@ describe('HTMLIntegration', () => {
         integration.fitSideBySide({ expanded: true, width: sidebarWidth });
 
         assert.deepEqual(getMargins(), [null, null]);
+      });
+
+      it('saves and restores the scroll position after adjusting margins', () => {
+        const integration = createIntegration();
+
+        integration.fitSideBySide({ expanded: true, width: sidebarWidth });
+
+        assert.calledOnce(fakePreserveScrollPosition);
       });
 
       it('removes margins on body element when side-by-side mode is deactivated', () => {

--- a/src/annotator/util/geometry.js
+++ b/src/annotator/util/geometry.js
@@ -1,0 +1,79 @@
+/**
+ * Return the intersection of two rects.
+ *
+ * @param {DOMRect} rectA
+ * @param {DOMRect} rectB
+ */
+export function intersectRects(rectA, rectB) {
+  const left = Math.max(rectA.left, rectB.left);
+  const right = Math.min(rectA.right, rectB.right);
+  const top = Math.max(rectA.top, rectB.top);
+  const bottom = Math.min(rectA.bottom, rectB.bottom);
+  return new DOMRect(left, top, right - left, bottom - top);
+}
+
+/**
+ * Return `true` if a rect is _empty_.
+ *
+ * An empty rect is defined as one with zero or negative width/height, eg.
+ * as returned by `new DOMRect()` or `Element.getBoundingClientRect()` for a
+ * hidden element.
+ *
+ * @param {DOMRect} rect
+ */
+export function rectIsEmpty(rect) {
+  return rect.width <= 0 || rect.height <= 0;
+}
+
+/**
+ * Return true if the lines a-b and c-d overlap (ie. the length of their
+ * intersection is non-zero).
+ *
+ * The inputs must be normalized such that b >= a and d >= c.
+ *
+ * @param {number} a
+ * @param {number} b
+ * @param {number} c
+ * @param {number} d
+ */
+function linesOverlap(a, b, c, d) {
+  const maxStart = Math.max(a, c);
+  const minEnd = Math.min(b, d);
+  return maxStart < minEnd;
+}
+
+/**
+ * Return true if the intersection of `rectB` and `rectA` is non-empty.
+ *
+ * @param {DOMRect} rectA
+ * @param {DOMRect} rectB
+ */
+export function rectIntersects(rectA, rectB) {
+  if (rectIsEmpty(rectA) || rectIsEmpty(rectB)) {
+    return false;
+  }
+
+  return (
+    linesOverlap(rectA.left, rectA.right, rectB.left, rectB.right) &&
+    linesOverlap(rectA.top, rectA.bottom, rectB.top, rectB.bottom)
+  );
+}
+
+/**
+ * Return true if `rectB` is fully contained within `rectA`
+ *
+ * @param {DOMRect} rectA
+ * @param {DOMRect} rectB
+ */
+export function rectContains(rectA, rectB) {
+  if (rectIsEmpty(rectA) || rectIsEmpty(rectB)) {
+    return false;
+  }
+
+  return (
+    rectB.left >= rectA.left &&
+    rectB.right <= rectA.right &&
+    rectB.top >= rectA.top &&
+    rectB.bottom <= rectA.bottom
+  );
+}

--- a/src/annotator/util/geometry.js
+++ b/src/annotator/util/geometry.js
@@ -26,8 +26,13 @@ export function rectIsEmpty(rect) {
 }
 
 /**
- * Return true if the lines a-b and c-d overlap (ie. the length of their
+ * Return true if the 1D lines a-b and c-d overlap (ie. the length of their
  * intersection is non-zero).
+ *
+ * For example, the following lines overlap:
+ *
+ *   a----b
+ *      c------d
  *
  * The inputs must be normalized such that b >= a and d >= c.
  *

--- a/src/annotator/util/test/geometry-test.js
+++ b/src/annotator/util/test/geometry-test.js
@@ -1,0 +1,85 @@
+import {
+  intersectRects,
+  rectContains,
+  rectIntersects,
+  rectIsEmpty,
+} from '../geometry';
+
+function rectEquals(a, b) {
+  return (
+    a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height
+  );
+}
+
+describe('annotator/util/geometry', () => {
+  describe('intersectRects', () => {
+    it('returns the intersection of two rects', () => {
+      const rect = intersectRects(
+        new DOMRect(0, 0, 500, 500),
+        new DOMRect(10, 10, 500, 500)
+      );
+      assert.isTrue(rectEquals(rect, new DOMRect(10, 10, 490, 490)));
+    });
+  });
+
+  describe('rectIsEmpty', () => {
+    it('returns true for null rects', () => {
+      assert.isTrue(rectIsEmpty(new DOMRect()));
+    });
+
+    it('returns true for inverted rects', () => {
+      assert.isTrue(rectIsEmpty(new DOMRect(10, 10, -10, -10)));
+    });
+
+    it('returns false for rects with positive width and height', () => {
+      assert.isFalse(rectIsEmpty(new DOMRect(0, 0, 1, 1)));
+    });
+  });
+
+  describe('rectIntersects', () => {
+    it('returns false if either rect is empty', () => {
+      assert.isFalse(rectIntersects(new DOMRect(0, 0, 10, 10), new DOMRect()));
+      assert.isFalse(rectIntersects(new DOMRect(), new DOMRect(0, 0, 10, 10)));
+    });
+
+    it('returns false if rects do not intersect', () => {
+      assert.isFalse(
+        rectIntersects(new DOMRect(0, 0, 10, 10), new DOMRect(100, 0, 10, 10))
+      );
+      assert.isFalse(
+        rectIntersects(new DOMRect(0, 0, 10, 10), new DOMRect(0, 100, 10, 10))
+      );
+    });
+
+    it('returns false if rects touch but do not intersect', () => {
+      assert.isFalse(
+        rectIntersects(new DOMRect(0, 0, 10, 10), new DOMRect(10, 10, 10, 10))
+      );
+    });
+
+    it('returns true if rects intersect', () => {
+      assert.isTrue(
+        rectIntersects(new DOMRect(0, 0, 10, 10), new DOMRect(5, 5, 10, 10))
+      );
+    });
+  });
+
+  describe('rectContains', () => {
+    it('returns false if either rect is empty', () => {
+      assert.isFalse(rectContains(new DOMRect(0, 0, 10, 10), new DOMRect()));
+      assert.isFalse(rectContains(new DOMRect(), new DOMRect(0, 0, 10, 10)));
+    });
+
+    it('returns false if first rect does not fully contain second rect', () => {
+      assert.isFalse(
+        rectContains(new DOMRect(0, 0, 10, 10), new DOMRect(2, 2, 10, 10))
+      );
+    });
+
+    it('returns true if first rect contains second rect', () => {
+      assert.isTrue(
+        rectContains(new DOMRect(0, 0, 10, 10), new DOMRect(2, 2, 8, 8))
+      );
+    });
+  });
+});


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/4245**

Toggling side-by-side mode in a web page reflows the content. If the absolute
scroll position stays the same, the logical position in the document will change
and the user would have to scroll to find the content they were
previously reading.

To avoid this add logic which picks content in the viewport to use as a _scroll
anchor_, before the document is resized. After the document is resized, the
scroll position is changed so that the vertical position of the scroll anchor in
the viewport is the same as before. This keeps most of the content on screen.

The scroll anchor is currently chosen by picking the first _word_
(non-whitespace substring of a text node) which is visible in the viewport,
represented as a DOM Range. This fine-grained scroll anchor is chosen rather
than eg. just a DOM element, because long paragraphs may change in size
substantially relative to the viewport after resizing the document, so just
preserving the location of the paragraph element would not preserve the content
that is on screen.

 - Add `preserveScrollPosition` helper in html-side-by-side.js which
   picks a scroll anchor, invokes a callback and then restores the
   position of the scroll anchor.

 - Make the HTML integration use `preserveScrollPosition` to preserve
   the scroll position after activating and de-activating side-by-side
   mode

 - Add helper functions in src/annotator/util/geometry.js for comparing
   DOMRect objects
   
----

**Testing:**

1. Go to http://localhost:3000/document/vitalsource-epub
2. Scroll part way down the document and make an annotation
3. Toggle the sidebar

The highlight created in step 2 should remain visible in the viewport, whereas before this branch it would disappear above/below the viewport, depending on whether the sidebar is being open or closed and how far the document has been scrolled.