### PR TITLE
Fix issues with "Great Book" format VitalSource EPUBs

### DIFF
--- a/src/annotator/integrations/html-side-by-side.js
+++ b/src/annotator/integrations/html-side-by-side.js
@@ -1,6 +1,17 @@
 import { intersectRects, rectContains, rectIntersects } from '../util/geometry';
 
 /**
+ * CSS selectors used to find elements that are considered potentially part
+ * of the main content of a page.
+ */
+const contentSelectors = [
+  'p',
+
+  // Paragraphs in VitalSource "Great Book" format ebooks.
+  '.para',
+];
+
+/**
  * Attempt to guess the region of the page that contains the main content.
  *
  * @param {Element} root
@@ -21,7 +32,8 @@ export function guessMainContentArea(root) {
   // In future we might want to expand this to consider other text containers,
   // since some pages, especially eg. in ebooks, may not have any paragraphs
   // (eg. instead they may only contain tables or lists or headings).
-  const paragraphs = Array.from(root.querySelectorAll('p'))
+  const contentSelector = contentSelectors.join(',');
+  const paragraphs = Array.from(root.querySelectorAll(contentSelector))
     .map(p => {
       // Gather some data about them.
       const rect = p.getBoundingClientRect();

--- a/src/annotator/integrations/test/html-side-by-side-test.js
+++ b/src/annotator/integrations/test/html-side-by-side-test.js
@@ -6,6 +6,11 @@ import {
 describe('annotator/integrations/html-side-by-side', () => {
   let contentElements;
 
+  function addContentElementToDocument(element) {
+    contentElements.push(element);
+    document.body.append(element);
+  }
+
   function createContent(paragraphs) {
     const paraElements = paragraphs.map(({ content, left, width }) => {
       const el = document.createElement('p');
@@ -18,9 +23,7 @@ describe('annotator/integrations/html-side-by-side', () => {
 
     const root = document.createElement('div');
     root.append(...paraElements);
-
-    document.body.append(root);
-    contentElements.push(root);
+    addContentElementToDocument(root);
 
     return root;
   }
@@ -61,6 +64,23 @@ describe('annotator/integrations/html-side-by-side', () => {
       const area = guessMainContentArea(content);
 
       assert.deepEqual(area, { left: 10, right: 110 });
+    });
+
+    [
+      '<p>content</p>',
+
+      // Paragraphs in VitalSource "Great Book" format ebooks.
+      '<div class="para">content</div>',
+    ].forEach(contentHTML => {
+      it('finds content area with various paragraph types', () => {
+        const content = document.createElement('div');
+        content.innerHTML = contentHTML;
+        addContentElementToDocument(content);
+
+        const area = guessMainContentArea(content);
+
+        assert.ok(area);
+      });
     });
 
     it('ignores the positions of hidden paragraphs', () => {

--- a/src/annotator/integrations/vitalsource.js
+++ b/src/annotator/integrations/vitalsource.js
@@ -59,17 +59,28 @@ export class VitalSourceInjector {
 
     /** @param {HTMLIFrameElement} frame */
     const injectIfContentReady = frame => {
-      // Check if this frame contains decoded ebook content, as opposed to
-      // invisible and encrypted book content, which is created initially after a
-      // chapter navigation. These encrypted pages are replaced with the real
-      // content after a form submission.
-      //
-      // The format of the decoded HTML can vary, but as a simple heuristic,
-      // we look for a text paragraph.
-      //
-      // If the document has not yet finished loading, then we rely on this function
-      // being called again once loading completes.
-      const isBookContent = frame.contentDocument?.querySelector('p');
+      // Check if this frame contains decoded ebook content. If the document has
+      // not yet finished loading, then we rely on this function being called
+      // again once loading completes.
+
+      const body = frame.contentDocument?.body;
+      const isBookContent =
+        body &&
+        // Check that this is not the blank document which is displayed in
+        // brand new iframes before any of their content has loaded.
+        body.children.length > 0 &&
+        // Check that this is not the temporary page containing encrypted and
+        // invisible book content, which is replaced with the real content after
+        // a form submission. These pages look something like:
+        //
+        // ```
+        // <html>
+        //   <title>content</title>
+        //   <body><div id="page-content">{ Base64 encoded data }</div></body>
+        // </html>
+        // ```
+        !body.querySelector('#page-content');
+
       if (isBookContent) {
         injectClient(frame, config);
       }


### PR DESCRIPTION
VitalSource makes various classic texts freely available as EPUBs. These books are EPUBs but their format is described as "Great Book" in the VitalSource library. These EPUBs have some quirks which prevented the client from working with them. Mainly they don't use semantic `<p>` elements for paragraphs of text. This caused two problems:

1. The `VitalSourceInjector` class failed to detect that these were valid book content chapters and did not inject the client into them.
2. The side-by-side support did not consider the `<div class="para">` elements which are used for paragraphs of text when determining the main content area.

The two commits in this PR fix each of these issues respectively. The fix for the first issue also resolves an issue where the client would fail to inject into some other EPUB chapters which only had non-paragraph content, such as only having tables, cover images, lists or headings.

----

**Testing:**

1. Build the browser extension using this branch of the client
2. Open up a classic book that uses the "Great Book" format in VitalSource (eg. https://bookshelf.vitalsource.com/reader/books/L-999-70024)
3. Navigate to a content chapter and activate the extension
4. Select text and try toggling the sidebar

In step 4 the Hypothesis adder should appear when selecting text and the content should resize to fit alongside the sidebar when it is opened.