### PR TITLE
Transition `WarningBanner` to tailwind, shared components

### DIFF
--- a/src/annotator/components/WarningBanner.js
+++ b/src/annotator/components/WarningBanner.js
@@ -1,4 +1,5 @@
-import { SvgIcon } from '@hypothesis/frontend-shared';
+import { Icon, Link } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
 
 /**
  * A banner shown at the top of the PDF viewer if the PDF cannot be annotated
@@ -6,20 +7,26 @@ import { SvgIcon } from '@hypothesis/frontend-shared';
  */
 export default function WarningBanner() {
   return (
-    <div className="WarningBanner WarningBanner--notice">
-      <div className="WarningBanner__type">
-        <SvgIcon name="caution" className="WarningBanner__icon" />
-      </div>
-      <div className="WarningBanner__message">
-        <strong>This PDF does not contain selectable text:</strong>{' '}
-        <a
-          target="_blank"
-          rel="noreferrer"
-          href="https://web.hypothes.is/help/how-to-ocr-optimize-pdfs/"
-        >
-          Learn how to fix this
-        </a>{' '}
-        in order to annotate with Hypothesis.
+    <div className="bg-white">
+      <div
+        className={classnames(
+          'flex items-center gap-x-2',
+          'border border-yellow-notice bg-yellow-notice/10 text-annotator-base'
+        )}
+      >
+        <div className="bg-yellow-notice text-white p-2">
+          <Icon name="caution" classes="text-annotator-xl" />
+        </div>
+        <div>
+          <strong>This PDF does not contain selectable text:</strong>{' '}
+          <Link
+            target="_blank"
+            href="https://web.hypothes.is/help/how-to-ocr-optimize-pdfs/"
+          >
+            Learn how to fix this
+          </Link>{' '}
+          in order to annotate with Hypothesis.
+        </div>
       </div>
     </div>
   );

--- a/src/styles/annotator/components/WarningBanner.scss
+++ b/src/styles/annotator/components/WarningBanner.scss
@@ -1,7 +1,0 @@
-@use '../mixins/molecules';
-@use '../variables' as var;
-
-.WarningBanner {
-  @include molecules.banner;
-  font-size: var.$annotator-adder-font-size;
-}

--- a/src/styles/annotator/components/_index.scss
+++ b/src/styles/annotator/components/_index.scss
@@ -1,10 +1,6 @@
 @use 'tailwindcss/components';
 @use '@hypothesis/frontend-shared/styles';
 
-// Extensions and overrides to patterns from `frontend-shared`
-@use '../../frontend-shared';
-
 // Annotator-specific components.
 @use './AdderToolbar';
 @use './Buckets';
-@use './WarningBanner';

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -52,6 +52,7 @@ export default {
         // remain as pixels when sidebar converts to rems or otherwise be
         // independent of sidebar font sizes
         'annotator-sm': ['12px'],
+        'annotator-base': ['14px'],
         'annotator-lg': ['16px'],
         'annotator-xl': ['18px'],
       },


### PR DESCRIPTION
This PR transitions the annotator `WarningBanner` component to Tailwind, updates it to use shared components, and finishes establishing the `components` layer for `annotator` CSS.

I did take this opportunity to bump up the font size here because it was painfully tiny at the outset. Also, the link was missing styling (!), which was rectified by using a `Link` shared component.

Before:

<img width="1575" alt="Screen Shot 2022-02-25 at 2 52 51 PM" src="https://user-images.githubusercontent.com/439947/155798269-95562e0e-9999-4f00-b3c4-8b886881ec89.png">

After:

<img width="1570" alt="Screen Shot 2022-02-25 at 3 26 14 PM" src="https://user-images.githubusercontent.com/439947/155798298-0e6b1555-807f-4192-bd32-d7852e44a6b8.png">

The previous SASS implementation re-used an underlying mixin pattern that is also used by `ToastMessages`. I considered implementing a `Banner` component or somesuch that both this component and `ToastMessage` could use, but the abstraction doesn't seem worth the cost just yet, as there isn't a lot of overlap when you get down to it. When I get to the point of converting `ToastMessages` to TW, I'll re-assess and probably create a shared component somewhere in the mix there.

Depends on #4254 for convenience of merging changes to the font sizes for the annotator.

## Test

To see this component show up, apply this patch:

```diff
diff --git a/src/annotator/integrations/pdf.js b/src/annotator/integrations/pdf.js
index 2f5c294d7..bc244ccde 100644
--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -210,7 +210,7 @@ export class PDFIntegration {

     try {
       const hasText = await documentHasText();
-      this._toggleNoSelectableTextWarning(!hasText);
+      this._toggleNoSelectableTextWarning(hasText);
     } catch (err) {
       /* istanbul ignore next */
       console.warn('Unable to check for text in PDF:', err);
```

and view http://localhost:3000/pdf/budlong in the local dev server.
