### PR TITLE
Add missing parameter and variable types in src/annotator/

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -31,6 +31,7 @@ export const ARROW_POINTING_UP = 2;
  * @prop {ArrowDirection} arrowDirection - Direction of the adder's arrow.
  */
 
+/** @param {number} pixels */
 function toPx(pixels) {
   return pixels.toString() + 'px';
 }
@@ -325,6 +326,7 @@ export class Adder {
   }
 
   _render() {
+    /** @param {import('./components/AdderToolbar').Command} command */
     const handleCommand = command => {
       switch (command) {
         case 'annotate':

--- a/src/annotator/anchoring/xpath.js
+++ b/src/annotator/anchoring/xpath.js
@@ -30,6 +30,7 @@ function getNodePosition(node) {
   return pos;
 }
 
+/** @param {Node} node */
 function getPathSegment(node) {
   const name = getNodeName(node);
   const pos = getNodePosition(node);

--- a/src/annotator/components/Buckets.js
+++ b/src/annotator/components/Buckets.js
@@ -11,7 +11,7 @@ import classnames from 'classnames';
  * the sidebar.
  *
  * @param {object} props
- *   @prop {Children} props.children
+ *   @param {Children} props.children
  */
 function BucketList({ children }) {
   return (
@@ -38,8 +38,8 @@ function BucketList({ children }) {
  * Render a vertically-positioned bucket-list item.
  *
  * @param {object} props
- *  @prop {Children} props.children
- *  @prop {number} props.topPosition - The vertical top position, in pixels,
+ *  @param {Children} props.children
+ *  @param {number} props.topPosition - The vertical top position, in pixels,
  *   for this bucket item relative to the top of the containing BucketList
  */
 function BucketItem({ children, topPosition }) {

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -18,6 +18,7 @@ import { urlFromLinkTag } from './url-from-link-tag';
  */
 
 /**
+ * @param {Window} window_
  * @return {SettingsGetters}
  */
 export function settingsFrom(window_) {

--- a/src/annotator/features.js
+++ b/src/annotator/features.js
@@ -1,7 +1,9 @@
 import { warnOnce } from '../shared/warn-once';
 
+/** @type {Record<string, boolean>} */
 let _features = {};
 
+/** @param {Record<string, boolean>} features */
 const _set = features => {
   _features = features || {};
 };
@@ -18,6 +20,7 @@ export const features = {
     _set({});
   },
 
+  /** @param {string} flag */
   flagEnabled: function (flag) {
     if (!(flag in _features)) {
       warnOnce('looked up unknown feature', flag);

--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -226,8 +226,8 @@ export function highlightRange(range, cssClass = 'hypothesis-highlight') {
 
   // Group text nodes into spans of adjacent nodes. If a group of text nodes are
   // adjacent, we only need to create one highlight element for the group.
-  let textNodeSpans = [];
-  let prevNode = null;
+  let textNodeSpans = /** @type {Text[][]} */ ([]);
+  let prevNode = /** @type {Node|null} */ (null);
   let currentSpan = null;
 
   textNodes.forEach(node => {
@@ -246,11 +246,11 @@ export function highlightRange(range, cssClass = 'hypothesis-highlight') {
   const whitespace = /^\s*$/;
   textNodeSpans = textNodeSpans.filter(span =>
     // Check for at least one text node with non-space content.
-    span.some(node => !whitespace.test(node.nodeValue))
+    span.some(node => !whitespace.test(node.data))
   );
 
   // Wrap each text node span with a `<hypothesis-highlight>` element.
-  const highlights = [];
+  const highlights = /** @type {HighlightElement[]} */ ([]);
   textNodeSpans.forEach(nodes => {
     // A custom element name is used here rather than `<span>` to reduce the
     // likelihood of highlights being hidden by page styling.
@@ -259,7 +259,8 @@ export function highlightRange(range, cssClass = 'hypothesis-highlight') {
     const highlightEl = document.createElement('hypothesis-highlight');
     highlightEl.className = cssClass;
 
-    nodes[0].parentNode.replaceChild(highlightEl, nodes[0]);
+    const parent = /** @type {Node} */ (nodes[0].parentNode);
+    parent.replaceChild(highlightEl, nodes[0]);
     nodes.forEach(node => highlightEl.appendChild(node));
 
     highlights.push(highlightEl);

--- a/src/annotator/integrations/html-metadata.js
+++ b/src/annotator/integrations/html-metadata.js
@@ -272,6 +272,8 @@ export class HTMLMetadata {
   /**
    * Convert a possibly relative URI to an absolute one. This will throw an
    * exception if the URL cannot be parsed.
+   *
+   * @param {string} url
    */
   _absoluteUrl(url) {
     return normalizeURI(url, this.document.baseURI);

--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -261,7 +261,7 @@ export class PDFIntegration {
   // This method (re-)anchors annotations when pages are rendered and destroyed.
   _update() {
     // A list of annotations that need to be refreshed.
-    const refreshAnnotations = [];
+    const refreshAnnotations = /** @type {AnnotationData[]} */ ([]);
 
     const pageCount = this.pdfViewer.pagesCount;
     for (let pageIndex = 0; pageIndex < pageCount; pageIndex++) {

--- a/src/annotator/range-util.js
+++ b/src/annotator/range-util.js
@@ -66,16 +66,17 @@ export function forEachNodeInRange(range, callback) {
  */
 export function getTextBoundingBoxes(range) {
   const whitespaceOnly = /^\s*$/;
-  const textNodes = [];
+  const textNodes = /** @type {Text[]} */ ([]);
   forEachNodeInRange(range, node => {
     if (
       node.nodeType === Node.TEXT_NODE &&
       !(/** @type {string} */ (node.textContent).match(whitespaceOnly))
     ) {
-      textNodes.push(node);
+      textNodes.push(/** @type {Text} */ (node));
     }
   });
 
+  /** @type {DOMRect[]} */
   let rects = [];
   textNodes.forEach(node => {
     const nodeRange = node.ownerDocument.createRange();

--- a/src/annotator/sidebar-trigger.js
+++ b/src/annotator/sidebar-trigger.js
@@ -5,9 +5,8 @@ const SIDEBAR_TRIGGER_BTN_ATTR = 'data-hypothesis-trigger';
  * trigger data attribute.
  *
  * @param {Element} rootEl - The DOM element which contains the trigger elements.
- * @param {object} showFn - Function which shows the sidebar.
+ * @param {() => void} showFn - Function which shows the sidebar.
  */
-
 export function sidebarTrigger(rootEl, showFn) {
   const triggerElems = rootEl.querySelectorAll(
     '[' + SIDEBAR_TRIGGER_BTN_ATTR + ']'

--- a/src/annotator/util/shadow-root.js
+++ b/src/annotator/util/shadow-root.js
@@ -1,5 +1,7 @@
 /**
  * Load stylesheets for annotator UI components into the shadow DOM root.
+ *
+ * @param {ShadowRoot} shadowRoot
  */
 function loadStyles(shadowRoot) {
   // Find the preloaded stylesheet added by the boot script.


### PR DESCRIPTION
Add missing types found while trying to typecheck src/annotator with `noImplicitAny` enabled.

There are more to come. This PR contains simple cases that required no or only very minimal changes to surrounding code.