### PR TITLE
Fix scrolling to highlights in XHTML documents, including EPUBs

### DIFF
--- a/src/annotator/integrations/html.js
+++ b/src/annotator/integrations/html.js
@@ -1,5 +1,3 @@
-import scrollIntoView from 'scroll-into-view';
-
 import { anchor, describe } from '../anchoring/html';
 
 import { HTMLMetadata } from './html-metadata';
@@ -7,6 +5,7 @@ import {
   guessMainContentArea,
   preserveScrollPosition,
 } from './html-side-by-side';
+import { scrollElementIntoView } from '../util/scroll';
 
 /**
  * @typedef {import('../../types/annotator').Anchor} Anchor
@@ -161,10 +160,11 @@ export class HTMLIntegration {
   /**
    * @param {Anchor} anchor
    */
-  scrollToAnchor(anchor) {
-    const highlights = /** @type {Element[]} */ (anchor.highlights);
-    return new Promise(resolve => {
-      scrollIntoView(highlights[0], resolve);
-    });
+  async scrollToAnchor(anchor) {
+    const highlight = anchor.highlights?.[0];
+    if (!highlight) {
+      return;
+    }
+    await scrollElementIntoView(highlight);
   }
 }

--- a/src/annotator/util/scroll.js
+++ b/src/annotator/util/scroll.js
@@ -49,7 +49,7 @@ export function offsetRelativeTo(element, parent) {
 export async function scrollElement(
   element,
   offset,
-  /* istanbul ignore next - default options are overridden in tests */
+  /* istanbul ignore next - defaults are overridden in tests */
   { maxDuration = 500 } = {}
 ) {
   const startOffset = element.scrollTop;
@@ -81,6 +81,7 @@ export async function scrollElement(
  */
 export async function scrollElementIntoView(
   element,
+  /* istanbul ignore next - defaults are overridden in tests */
   { maxDuration = 500 } = {}
 ) {
   // Make the body's `tagName` return an upper-case string in XHTML documents

--- a/src/annotator/util/scroll.js
+++ b/src/annotator/util/scroll.js
@@ -1,3 +1,5 @@
+import scrollIntoView from 'scroll-into-view';
+
 /**
  * Return a promise that resolves on the next animation frame.
  */
@@ -68,4 +70,20 @@ export async function scrollElement(
     scrollFraction = Math.min(1.0, (Date.now() - scrollStart) / scrollDuration);
     element.scrollTop = interpolate(startOffset, endOffset, scrollFraction);
   }
+}
+
+/**
+ * Smoothly scroll an element into view.
+ *
+ * @param {HTMLElement} element
+ * @param {object} options
+ *   @prop {number} maxDuration
+ */
+export async function scrollElementIntoView(
+  element,
+  { maxDuration = 500 } = {}
+) {
+  await new Promise(resolve =>
+    scrollIntoView(element, { time: maxDuration }, resolve)
+  );
 }

--- a/src/annotator/util/scroll.js
+++ b/src/annotator/util/scroll.js
@@ -77,7 +77,7 @@ export async function scrollElement(
  *
  * @param {HTMLElement} element
  * @param {object} options
- *   @prop {number} maxDuration
+ *   @param {number} [options.maxDuration]
  */
 export async function scrollElementIntoView(
   element,

--- a/src/annotator/util/scroll.js
+++ b/src/annotator/util/scroll.js
@@ -83,6 +83,18 @@ export async function scrollElementIntoView(
   element,
   { maxDuration = 500 } = {}
 ) {
+  // Make the body's `tagName` return an upper-case string in XHTML documents
+  // like it does in HTML documents. This is a workaround for
+  // `scrollIntoView`'s detection of the <body> element. See
+  // https://github.com/KoryNunn/scroll-into-view/issues/101.
+  const body = element.closest('body');
+  if (body && body.tagName !== 'BODY') {
+    Object.defineProperty(body, 'tagName', {
+      value: 'BODY',
+      configurable: true,
+    });
+  }
+
   await new Promise(resolve =>
     scrollIntoView(element, { time: maxDuration }, resolve)
   );

--- a/src/annotator/util/test/scroll-test.js
+++ b/src/annotator/util/test/scroll-test.js
@@ -1,4 +1,8 @@
-import { offsetRelativeTo, scrollElement } from '../scroll';
+import {
+  offsetRelativeTo,
+  scrollElement,
+  scrollElementIntoView,
+} from '../scroll';
 
 describe('annotator/util/scroll', () => {
   let containers;
@@ -66,6 +70,44 @@ describe('annotator/util/scroll', () => {
 
       assert.equal(container.scrollTop, 2000);
       container.remove();
+    });
+  });
+
+  describe('scrollElementIntoView', () => {
+    let container;
+    let target;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      container.style.height = '500px';
+      container.style.overflow = 'auto';
+      container.style.position = 'relative';
+      document.body.append(container);
+
+      target = document.createElement('div');
+      target.style.position = 'absolute';
+      target.style.top = '1000px';
+      target.style.height = '20px';
+      target.style.width = '100px';
+      container.append(target);
+
+      assert.isTrue(container.scrollHeight > container.clientHeight);
+    });
+
+    afterEach(() => {
+      target.remove();
+    });
+
+    // A basic test for scrolling. We assume that the underlying implementation
+    // has more detailed tests.
+    it('scrolls element into view', async () => {
+      await scrollElementIntoView(target, { maxDuration: 1 });
+
+      const containerRect = container.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+
+      assert.isTrue(containerRect.top <= targetRect.top);
+      assert.isTrue(containerRect.bottom >= targetRect.bottom);
     });
   });
 });

--- a/src/annotator/util/test/scroll-test.js
+++ b/src/annotator/util/test/scroll-test.js
@@ -109,5 +109,22 @@ describe('annotator/util/scroll', () => {
       assert.isTrue(containerRect.top <= targetRect.top);
       assert.isTrue(containerRect.bottom >= targetRect.bottom);
     });
+
+    it('installs scroll-into-view workaround for XHTML documents', async () => {
+      try {
+        Object.defineProperty(document.body, 'tagName', {
+          value: 'body',
+          configurable: true,
+        });
+        assert.equal(document.body.tagName, 'body');
+
+        await scrollElementIntoView(target, { maxDuration: 1 });
+
+        assert.equal(document.body.tagName, 'BODY');
+      } finally {
+        // Remove property override installed by this test.
+        delete document.body.tagName;
+      }
+    });
   });
 });

--- a/src/annotator/util/test/scroll-test.js
+++ b/src/annotator/util/test/scroll-test.js
@@ -112,6 +112,8 @@ describe('annotator/util/scroll', () => {
 
     it('installs scroll-into-view workaround for XHTML documents', async () => {
       try {
+        // Simulate an XHTML document, where `tagName` is not upper-cased as
+        // it is for HTML documents.
         Object.defineProperty(document.body, 'tagName', {
           value: 'body',
           configurable: true,


### PR DESCRIPTION
This PR works around an issue in the scroll-into-view dependency (see code comments) which caused the document to be scrolled to the wrong location when clicking on an annotation card or bucket bar item in XHTML documents. This affected EPUBs, including VitalSource, since EPUB content documents are XHTML.

The first commit adds a wrapper around scroll-into-view in src/annotator/util/scroll.js and changes `HTMLIntegration` to use it. The second commit adds to the wrapper a workaround for XHTML documents.

Currently we only use scroll-into-view in one place in the annotator code, but if we need similar functionality in future we can re-use the wrapper.

Fixes https://github.com/hypothesis/product-backlog/issues/1243

----

**Alternative approaches:**

There are some alternative approaches that could have been used:

1. Use the native [Element.scrollIntoView](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) method. The main downside of this is browser support. All browsers support instant scrolling but Safari does not support the options for smooth scrolling and alignment.
2. Write a new smooth-scrolling utility. This could give us more control over behavior, performance and code clarity. However it would require more effort to implement and test. I've opted to defer this until we have stronger reasons to do it.

----

**Testing:**

With a VitalSource EPUB:

1. Build the browser extension using this client branch and activate it in a VS EPUB
3. Create a highlight mid-way down the page
4. Scroll away from the highlight and then click the annotation card in the sidebar

On master, step 3 will scroll to the wrong location. On this branch it will scroll to the correct location.

With an XHTML document:

Similar to the above steps for VS, but use https://www.w3.org/People/mimasa/test/xhtml2/spec-examples/ as the document.