### PR TITLE
Inject client into newly loaded VitalSource book chapters sooner

### DIFF
--- a/src/annotator/hypothesis-injector.js
+++ b/src/annotator/hypothesis-injector.js
@@ -1,6 +1,6 @@
 import { parseJsonConfig } from '../boot/parse-json-config';
 import { generateHexString } from '../shared/random';
-import { onDocumentReady, FrameObserver } from './frame-observer';
+import { onNextDocumentReady, FrameObserver } from './frame-observer';
 
 /**
  * @typedef {import('../types/annotator').Destroyable} Destroyable
@@ -67,7 +67,7 @@ export async function injectClient(frame, config) {
     return;
   }
 
-  await onDocumentReady(frame);
+  await onNextDocumentReady(frame);
 
   // Propagate the client resource locations from the current frame.
   //

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -1,4 +1,4 @@
-import { delay } from '../../../test-util/wait';
+import { delay, waitFor } from '../../../test-util/wait';
 import {
   VitalSourceInjector,
   VitalSourceContentIntegration,
@@ -127,7 +127,8 @@ describe('annotator/integrations/vitalsource', () => {
       }, 'Book container element not found');
     });
 
-    it('injects client into content frame', () => {
+    it('injects client into content frame', async () => {
+      await waitFor(() => fakeInjectClient.called);
       assert.calledWith(fakeInjectClient, fakeViewer.contentFrame, fakeConfig);
     });
 
@@ -150,7 +151,7 @@ describe('annotator/integrations/vitalsource', () => {
         assert.notCalled(fakeInjectClient);
 
         fakeViewer.finishChapterLoad(newChapterContent);
-        await delay(0);
+        await waitFor(() => fakeInjectClient.called);
         assert.calledWith(
           fakeInjectClient,
           fakeViewer.contentFrame,
@@ -160,6 +161,7 @@ describe('annotator/integrations/vitalsource', () => {
     });
 
     it("doesn't re-inject if content frame is removed", async () => {
+      await waitFor(() => fakeInjectClient.called);
       fakeInjectClient.resetHistory();
 
       // Remove the content frame. This will trigger a re-injection check, but
@@ -171,6 +173,7 @@ describe('annotator/integrations/vitalsource', () => {
     });
 
     it("doesn't re-inject if content frame siblings change", async () => {
+      await waitFor(() => fakeInjectClient.called);
       fakeInjectClient.resetHistory();
 
       // Modify the DOM tree. This will trigger a re-injection check, but do

--- a/src/annotator/test/integration/hypothesis-injector-test.js
+++ b/src/annotator/test/integration/hypothesis-injector-test.js
@@ -1,5 +1,5 @@
-import { delay } from '../../../test-util/wait';
-import { DEBOUNCE_WAIT, onDocumentReady } from '../../frame-observer';
+import { delay, waitFor } from '../../../test-util/wait';
+import { DEBOUNCE_WAIT, onNextDocumentReady } from '../../frame-observer';
 import {
   HypothesisInjector,
   injectClient,
@@ -24,8 +24,8 @@ describe('HypothesisInjector integration test', () => {
 
   // Wait for `HypothesisInjector.injectClient` to finish injecting the client
   // into the page.
-  async function waitForInjectClient() {
-    await delay(0);
+  async function waitForInjectClient(frame) {
+    await waitFor(() => getHypothesisScript(frame));
   }
 
   function getHypothesisScript(iframe) {
@@ -125,7 +125,7 @@ describe('HypothesisInjector integration test', () => {
     // Now initialize
     createHypothesisInjector();
 
-    await waitForInjectClient();
+    await waitForInjectClient(validFrame);
 
     assert.isNotNull(
       getHypothesisScript(validFrame),
@@ -142,7 +142,7 @@ describe('HypothesisInjector integration test', () => {
     const iframe = createAnnotatableIFrame();
 
     createHypothesisInjector();
-    await waitForInjectClient();
+    await waitForInjectClient(iframe);
 
     const scriptElement = getHypothesisScript(iframe);
     assert.isNotNull(
@@ -165,7 +165,7 @@ describe('HypothesisInjector integration test', () => {
     iframe.contentDocument.body.append(configScript);
 
     createHypothesisInjector();
-    await onDocumentReady(iframe);
+    await onNextDocumentReady(iframe);
 
     assert.isNull(
       getHypothesisScript(iframe),
@@ -181,7 +181,7 @@ describe('HypothesisInjector integration test', () => {
     const iframe = createAnnotatableIFrame();
 
     await waitForFrameObserver();
-    await waitForInjectClient();
+    await waitForInjectClient(iframe);
     assert.isNotNull(
       getHypothesisScript(iframe),
       'expected dynamically added iframe to include the Hypothesis script'
@@ -193,7 +193,7 @@ describe('HypothesisInjector integration test', () => {
 
     // Now initialize
     createHypothesisInjector();
-    await waitForInjectClient();
+    await waitForInjectClient(iframe);
 
     assert.isNotNull(
       getHypothesisScript(iframe),
@@ -207,7 +207,7 @@ describe('HypothesisInjector integration test', () => {
     assert.isNull(getHypothesisScript(iframe));
 
     await waitForFrameObserver();
-    await waitForInjectClient();
+    await waitForInjectClient(iframe);
 
     assert.isNotNull(
       getHypothesisScript(iframe),
@@ -223,7 +223,7 @@ describe('HypothesisInjector integration test', () => {
     const iframe = createAnnotatableIFrame();
 
     await waitForFrameObserver();
-    await waitForInjectClient();
+    await waitForInjectClient(iframe);
 
     assert.isNotNull(
       getHypothesisScript(iframe),
@@ -237,7 +237,7 @@ describe('HypothesisInjector integration test', () => {
     assert.isNull(getHypothesisScript(iframe));
 
     await waitForFrameObserver();
-    await waitForInjectClient();
+    await waitForInjectClient(iframe);
 
     assert.isNotNull(
       getHypothesisScript(iframe),


### PR DESCRIPTION
When a new content frame was found in VitalSource the client was only injected
either if the frame is already loaded, or when the frame next emits a `load`
event. In the latter case this waits until the document and its subresources
have fully loaded. This can be slow in EPUB chapters that have a lot of images.
Improve this by replacing the frame `load` event observer with a call to a new
`onDocumentReady` function which fires as soon as a document becomes interactive
(according to its `readyState`).

 - Rename existing `onDocumentReady` utility to `onNextDocumentReady` to
   make it clear that it only fires once, and change the implementation to
   be a wrapper around a new `onDocumentReady` function.

 - Add new `onDocumentReady` utility which monitors a frame for changes in the
   content document and invokes a callback each time a document becomes _ready_
   (`readyState` is `interactive` or `complete`).

 - Redo the tests for utilities in `frame-observer.js` so that they use
   real iframes rather than fake ones. Iframes have a complex interface
   and loading sequence, so we really need to use the real thing for
   tests to give us confidence.

 - Use `onDocumentReady` in the VitalSource integration to respond more quickly
   to book content loading in a new content frame.

 - Modify several tests for `FrameObserver`, `VitalSourceInjector` and
   `HypothesisInjector` to be less sensitive to exact timings of events,
   as these changed between the previous and new methods for detecting
   when a document is ready.

Fixes https://github.com/hypothesis/client/issues/4270

---

**Testing:**

**In the dev server:**

1. Go to http://localhost:3000/document/vitalsource-epub.
2. Click the Next / Previous chapter buttons and check that the document URL (shown in the Help panel in the sidebar) updates immediately.

To see the effect compared with master more noticeably, add a slow-loading image to one of the chapter HTML files. Previously the URL would not update, when navigating to that chapter, until the media loaded. Now it will load as soon as the HTML has been fetched and parsed.

**With the extension:**

1. Build the browser extension from this branch and activate it in an VitalSource EPUB book that has lots of images. For example https://bookshelf.vitalsource.com/reader/books/9781449364458.
4. Open the sidebar and go to the "About this version" panel
5. Navigate between chapters using the VS UI

As you navigate between chapters, you should see that the current chapter URL shown in the "URL" field updates quickly, without waiting for all images in the document to load. Also if you select text as soon as you see the content of a new chapter, you should immediately see the Hypothesis adder appear. In contrast on master the URL in the "About this version" panel will take longer to update after changing chapters, and the Hypothesis adder may not immediately appear when text is selected in a newly loaded chapter.