### PR TITLE
Make annotator component UI scale correctly to host page

### DIFF
--- a/src/annotator/components/AdderToolbar.js
+++ b/src/annotator/components/AdderToolbar.js
@@ -76,10 +76,10 @@ function ToolbarButton({ badgeCount, icon, label, onClick, shortcut }) {
         'transition-colors duration-200',
         'dim-item'
       )}
-      icon={icon}
       onClick={onClick}
       title={title}
     >
+      {icon && <Icon classes="text-annotator-lg" name={icon} title={title} />}
       {typeof badgeCount === 'number' && <NumberIcon badgeCount={badgeCount} />}
       <span className="font-normal">{label}</span>
     </LabeledButton>

--- a/src/annotator/components/Buckets.js
+++ b/src/annotator/components/Buckets.js
@@ -61,6 +61,10 @@ function BucketItem({ children, topPosition }) {
  * A list of buckets, including up and down navigation (when applicable) and
  * on-screen buckets
  *
+ * This component and its buttons are sized with absolute units such that they
+ * don't scale with changes to the host page's root font size. They will still
+ * properly scale with user/browser zooming.
+ *
  * @param {object} props
  *   @param {Bucket} props.above
  *   @param {Bucket} props.below

--- a/src/annotator/components/Toolbar.js
+++ b/src/annotator/components/Toolbar.js
@@ -18,8 +18,9 @@ function ToolbarButton({ ...buttonProps }) {
     <IconButton
       className={classnames(
         'w-[30px] h-[30px]', // These buttons have precise dimensions
+        'rounded-px', // size of border radius in absolute units
         'flex items-center justify-center',
-        'border rounded bg-white text-grey-6 hover:text-grey-9 text-annotator-lg',
+        'border bg-white text-grey-6 hover:text-grey-9',
         'shadow transition-colors'
       )}
       icon={icon}
@@ -61,6 +62,10 @@ function ToolbarButton({ ...buttonProps }) {
  * Controls on the edge of the sidebar for opening/closing the sidebar,
  * controlling highlight visibility and creating new page notes.
  *
+ * This component and its buttons are sized with absolute units such that they
+ * don't scale with changes to the host page's root font size. They will still
+ * properly scale with user/browser zooming.
+ *
  * @param {ToolbarProps} props
  */
 export default function Toolbar({
@@ -75,7 +80,12 @@ export default function Toolbar({
   useMinimalControls = false,
 }) {
   return (
-    <div className="absolute left-[-33px] w-[33px] z-2">
+    <div
+      className={classnames(
+        'absolute left-[-33px] w-[33px] z-2',
+        'text-px-base leading-none' // non-scaling sizing
+      )}
+    >
       {/* In the clean theme (`useMinimalControls` is `true`),
           the only button that should appear is a button
           to close the sidebar, and only if the sidebar is open. This button is
@@ -84,9 +94,9 @@ export default function Toolbar({
       {useMinimalControls && isSidebarOpen && (
         <IconButton
           className={classnames(
-            'w-[27px] h-[27px] mt-[140px] ml-[6px]',
+            'w-[27px] h-[27px] mt-[140px] ml-px-1.5',
             'flex items-center justify-center bg-white border',
-            'text-grey-6 hover:text-grey-9 text-annotator-lg transition-colors',
+            'text-grey-6 hover:text-grey-9 transition-colors',
             // Turn off right border to blend with sidebar
             'border-r-0',
             // A more intense shadow than other ToolbarButtons, to match that
@@ -103,8 +113,8 @@ export default function Toolbar({
           <IconButton
             className={classnames(
               // Height and width to align with the sidebar's top bar
-              'h-[40px] w-[33px]',
-              'bg-white text-grey-5 pl-1.5 hover:text-grey-9',
+              'h-[40px] w-[33px] pl-px-1.5',
+              'bg-white text-grey-5 hover:text-grey-9',
               // Turn on left and bottom borders to continue the
               // border of the sidebar's top bar
               'border-l border-b'
@@ -116,7 +126,7 @@ export default function Toolbar({
             pressed={isSidebarOpen}
             onClick={toggleSidebar}
           />
-          <div className="space-y-1.5 mt-2">
+          <div className="space-y-px-1.5 mt-px-2">
             <ToolbarButton
               title="Show highlights"
               icon={showHighlights ? 'show' : 'hide'}

--- a/src/styles/annotator/components/Buckets.scss
+++ b/src/styles/annotator/components/Buckets.scss
@@ -12,10 +12,16 @@
   // down or left. On its own, it will be lozenge-shaped. Compose with one
   // of the directional classes below to style a button fully, e.g.
   // `classname="BucketButton LeftBucketButton`
+
+  // These buttons use absolute units for sizing, fonts, border-radius. This is
+  // purposeful: they should not scale with root-font scaling in the host page.
+  // This is to make sure they still properly align with the sidebar UI.
+  //
+  // These will still properly scale if the user zooms the font in the browser.
   .BucketButton {
     // A lozenge-shaped element with very small text
-    @apply w-[26px] h-[16px] absolute border bg-white shadow rounded;
-    @apply font-sans text-center text-tiny font-bold text-color-text-light leading-none;
+    @apply w-[26px] h-[16px] absolute border bg-white shadow rounded-px;
+    @apply font-sans text-center text-px-tiny font-bold text-color-text-light leading-none;
 
     // Establish :before and :after content for later manipulation into
     // different pointer shapes and directions
@@ -27,7 +33,7 @@
 
   // Style a `BucketButton` to point left
   .LeftBucketButton {
-    @apply rounded-r rounded-l-sm;
+    @apply rounded-r-px rounded-l-px-sm;
 
     // Position to the left of the button and centered vertically
     &::before,
@@ -54,7 +60,7 @@
   // Style a `BucketButton` to point up
   .UpBucketButton {
     // Z-index assures that left-pointing buttons will scroll behind this
-    @apply z-1 rounded-t-sm rounded-b;
+    @apply z-1 rounded-t-px-sm rounded-b-px;
 
     // Position above the button and horizontally centered
     &::before,
@@ -79,7 +85,7 @@
   // Style a `BucketButton` to point down
   .DownBucketButton {
     // Z-index assures that left-pointing buttons will scroll behind this
-    @apply z-1 rounded-t rounded-b-sm;
+    @apply z-1 rounded-t-px rounded-b-px-sm;
 
     // Position below the button and horizontally centered
     &::before,

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -17,6 +17,14 @@ export default {
         adderPopUp: 'adderPopUp 0.08s ease-in forwards',
         adderPopDown: 'adderPopDown 0.08s ease-in forwards',
       },
+      borderRadius: {
+        // Tailwind provides a default set of border-radius utility styles
+        // in rem units. Add some values for places where border radius needs
+        // to be a fixed size and not scale with changes to root font size
+        // example: bucket bar indicator buttons
+        'px-sm': '2px',
+        px: '4px',
+      },
       boxShadow: {
         DEFAULT: '0 1px 1px rgba(0, 0, 0, 0.1)',
         adderToolbar: '0px 2px 10px 0px rgba(0, 0, 0, 0.25)',
@@ -45,18 +53,26 @@ export default {
       // in the app (descriptive), but should not be interpreted as defining
       // an ideal design system (prescriptive).
       fontSize: {
+        // This is a collection of font sizes used in existing sidebar components,
+        // which will grow during the conversion-to-Tailwind process. These
+        // are descriptive, not aspirational or prescriptive.
         tiny: ['10px'],
         sm: ['11px', '1.4'],
-        base: ['13px', '1.4'],
+        base: ['13px', '1.4'], // Current base font size for sidebar
         lg: ['14px'],
         xl: ['16px'],
-        // Keep separate font settings for the annotator; these may need to
-        // remain as pixels when sidebar converts to rems or otherwise be
-        // independent of sidebar font sizes
-        'annotator-sm': ['12px'],
-        'annotator-base': ['14px'],
-        'annotator-lg': ['16px'],
-        'annotator-xl': ['18px'],
+        // rem-based font sizes for annotator controls that should scale
+        // with text scaling in the underlying document
+        'annotator-sm': ['0.75rem'],
+        'annotator-base': ['0.875rem'],
+        'annotator-lg': ['1rem'],
+        'annotator-xl': ['1.125rem'],
+        // These are known cases when we want absolute sizing for fonts so
+        // that they do not scale, for example annotator components that are
+        // rendered next to the sidebar (which doesn't scale with host root
+        // font sizing)
+        'px-tiny': ['10px'],
+        'px-base': ['16px'],
       },
       keyframes: {
         adderPopDown: {
@@ -93,6 +109,15 @@ export default {
         'annotator-md': '480px',
         // Tablet and up
         'annotator-lg': '600px',
+      },
+      spacing: {
+        // These are selective, pixel-specific variants of Tailwind's default
+        // rem-based spacing scale and follow the same naming conventions with
+        // a `px-` prefix. They should only be used where UI should not scale
+        // with text scaling (i.e. `1rem != 16px`). Example: spacing between
+        // buttons in the annotator toolbar
+        'px-1.5': '6px',
+        'px-2': '8px',
       },
       zIndex: {
         1: '1',


### PR DESCRIPTION
This PR takes a stab at making annotator controls scale as a user might expect in different scenarios related to text scaling. There were some inconsistencies that came up when integrating with VitalSource viewer controls, and this attempts to resolve those.

These changes have the following opinions:

* The adder popup should harmonize with the underlying reading material in the host page, and as such should scale to the text scaling of the host page. Same with the warning banner that shows up above PDFs with no select-able text.
* The annotator’s “toolbar” buttons (toggle the sidebar, show/hide highlights, add annotation/page note) and the bucket bar are really conceptually part of the sidebar UI, and should _not_ scale in proportion to host-page text scaling. We’re somewhat bound to this approach for the time being as the sidebar itself does not scale to host-page font scaling and scaling these components would break their alignment with other sidebar UI.

Fixes https://github.com/hypothesis/client/issues/4248

## Testing

Visit the two test pages in the local dev server that set a non-100% root font size on the host page:

* [Document with tiny root font size](http://localhost:3000/document/doyle-tiny)
* [Document with huge root font size](http://localhost:3000/document/doyle-huge)

Also, try changing your browser’s preference for font sizing. In Chrome, you can search for “font size” in the settings and set something other than medium. Then visit:

* [Document with “normal” root font size](http://localhost:3000/document/doyle) or any other test document

(Don’t forget to change it back when swapping between testing/branches!)

You can also build the local extension with this branch to see these changes take effect for VitalSource EPUB books when you change the font size using the reader controls.

_Note_: The adder does not change size if you use VitalSource controls to zoom a PDF book. It is likely the effort to scale the controls here would not be worth the result.

### On the `master` branch/before

* On the tiny and huge font-size pages, the spacing/padding of the adder popup scales but the icons and text size do not.

![C9F9E76F-0435-4183-95E0-DC9B72969A49](https://user-images.githubusercontent.com/439947/156448066-1c33b93d-1ee4-4c4d-9860-e9b082907113.png)

![5EE0F42F-201A-4A52-97FE-E9CEED86EE0B](https://user-images.githubusercontent.com/439947/156448105-ddf12943-ff69-4b4f-a7b0-7a7b210e1b47.png)

Spacing between buttons in toolbar is too tight (tiny page):

![8A6CE6B2-9C76-4CC4-AC17-7DC63C2FCB64](https://user-images.githubusercontent.com/439947/156448124-dcb71890-527e-4bf4-9a77-855d17236e87.png)

Or too loose (huge page):

![C15EB641-06F7-482F-BE24-6A9382A17A6F](https://user-images.githubusercontent.com/439947/156448144-6a4c6c1e-4f83-4018-a2e8-8a2a68d1f19f.png)

Border-radius on bucket-bar buttons is not enough (tiny):

![2C16C406-E12B-4995-9814-847F1372FD16](https://user-images.githubusercontent.com/439947/156448204-232044aa-ef81-40bd-8a88-688dd02d138b.png)

Or too much (huge):

![49677D27-313D-4B1B-91DB-0BDD68737401](https://user-images.githubusercontent.com/439947/156448219-964258f4-5403-48a5-a4f2-9028ce0ed5d7.png)

* With browser text sizing preferences changed, the adder again looks disproportionate on the “normal” font-size document (results will vary depending on which font size you set; this is “very large” in Chrome):

![484F89B6-67C4-49AD-AB82-4F86ADA51554](https://user-images.githubusercontent.com/439947/156448244-303ee0d8-a105-4259-a343-dae688d953ca.png)

And also on a PDF page:

![05754877-0E31-404F-AAD0-174369B49E4F](https://user-images.githubusercontent.com/439947/156448255-75d1d21e-db73-4af4-bbc2-cb3b21a3a48d.png)

### On this branch/after

* The adder scales proportionally to underlying root font size:

Tiny document:

![E3ED1788-AE3D-4A97-86F1-D58E25C7E99A](https://user-images.githubusercontent.com/439947/156448279-80f2043d-d9b6-46cb-8503-bf32fc43a153.png)

Huge document:

![6A3F2F14-2486-480A-9B25-DAB84BDCD368](https://user-images.githubusercontent.com/439947/156448291-e84a43ea-5c05-40c9-ae7a-cb0a8dc8d6e5.png)

* Spacing and sizing of toolbar buttons is consistent in all cases:

![22E31CDB-1EC4-410A-8C65-DA91DB20BB25](https://user-images.githubusercontent.com/439947/156448308-d8d9e7a9-a69c-4f09-82c9-2b2325c971ce.png)

* Border-radius is always the same on bucket buttons:

![0BD5D2E9-C782-4978-A1E1-8D40A6BA571A](https://user-images.githubusercontent.com/439947/156448325-a12182da-03a3-4777-8ec1-5fea7dc37b73.png)

## Background: the difference between page zooming and text scaling
Our controls already properly scale when the user changes their page zoom. This is because browsers zoom everything when page zooming is changed: “pixels” change size, images change size, text changes size. Everything stays proportional unless you, the web page author, have done something truly leftfield. Both the underlying host page and the sidebar will get zoomed in and out together. You can try this today by using your browser’s zoom controls.

Zooming is different from _text scaling_, in which the root font size changes but absolute units don’t zoom. These changes are aimed at improving UI when text scaling changes in the host page.

### Causes of text scaling changes

The text scaling in the host page might change because:

* The webpage author has set a `font-size` value on the `html` element that is something other than `100%` or `16px` 
* The user has set a preference in their browser for font sizing
* Something programatically changes the font size on the `html` element when the user changes preferences (this is the case in VitalSource’s reader)

### The crux is in the mismatch

When the text scaling (root font size) of the host page changes to something other than 100%, that means there is a _mismatch_ in root font size between the host document and the sidebar frame.

The sidebar frame has its own `html` element and has a root font size of `100%` . In the sidebar, `1rem` is always dependably `16px`.  We can not make any assumptions about the pixel equivalent of `1rem` in the host document.

## Resolving the scaling mismatch
### Going with the flow

One option (a sound one with respect to the spirit of the web) is not to fight the root element’s opinion about what `1rem` should equate to. That means applying styling with relative, rem-based units only such that everything scales to that underlying rem value. This is the road I’ve taken here with the adder pop-up. It will size itself according to the host document’s base font sizing.

The warning banner shown on PDFs with no text content will also scale.

### Being assertive about dimensions

The other controls that are rendered by the annotator — and are thus inside of the host document and outside of the sidebar’s iframe — constitute an interesting conundrum. These include the “toolbar” buttons to the left of the sidebar itself and the bucket bar.

If we style them with relative units and allow them to scale with the host page, they will be out of alignment with the sidebar UI. Rounded corners aren’t rounded enough (in smaller font sizes) or are way too roundy (in larger font sizes); spacing gets out of whack in relation to the sidebar.

I’ve opted to treat these UI elements as “part of the sidebar” visual/UI unit and have ensured that all dimensions are expressed in pixels. 

They will still zoom correctly on full-page zoom, but will not scale with text. 

This seems to be consistent with how VitalSource handles non-text UI with font scaling, as well. The overlying controls do not scale.



