### PR TITLE
Add local example document with margin-auto, max-width content area

### DIFF
--- a/dev-server/documents/html/doyle-centered.mustache
+++ b/dev-server/documents/html/doyle-centered.mustache
@@ -1,0 +1,1538 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Narrow, centered document, by Arthur Conan Doyle</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+
+    <style type="text/css">
+      BODY {
+        color: Black;
+        background: White;
+        margin-left: auto;
+        margin-right: auto;
+        max-width: 640px;
+        font-family: 'Times New Roman', serif;
+        text-align: justify;
+      }
+
+      P {
+        text-indent: 4%;
+      }
+
+      P.noindent {
+        text-indent: 0%;
+      }
+
+      P.poem {
+        text-indent: 0%;
+        margin-left: 10%;
+        font-size: small;
+      }
+
+      P.letter {
+        font-size: small;
+        margin-left: 10%;
+        margin-right: 10%;
+      }
+
+      P.finis {
+        text-align: center;
+        text-indent: 0%;
+        margin-left: 0%;
+        margin-right: 0%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <p>
+      The Project Gutenberg EBook of The Disappearance of Lady Frances Carfax,
+      by Arthur Conan Doyle
+    </p>
+
+    <p>
+      This eBook is for the use of anyone anywhere at no cost and with almost no
+      restrictions whatsoever. You may copy it, give it away or re-use it under
+      the terms of the Project Gutenberg License included with this eBook or
+      online at www.gutenberg.net
+    </p>
+
+    <ul>
+      <li>Title: The Disappearance of Lady Frances Carfax</li>
+      <li>Author: Arthur Conan Doyle</li>
+      <li>Posting Date: October 23, 2008 [EBook #2348]</li>
+      <li>Release Date: October, 2000</li>
+      <li>[Last updated: May 3, 2011]</li>
+      <li>Language: English</li>
+      <li>Character set encoding: ISO-8859-1</li>
+    </ul>
+
+    <p>
+      *** START OF THIS PROJECT GUTENBERG EBOOK DISAPPEARANCE OF LADY CARFAX ***
+    </p>
+
+    Produced by David Brannan. HTML version by Al Haines.<br />
+
+    <br /><br />
+
+    <h1 align="center">
+      The Disappearance of Lady Frances Carfax
+    </h1>
+
+    <br />
+
+    <h3 align="center">
+      By
+    </h3>
+
+    <h2 align="center">
+      Sir Arthur Conan Doyle
+    </h2>
+
+    <br /><br /><br />
+
+    <p>
+      "But why Turkish?" asked Mr. Sherlock Holmes, gazing fixedly at my boots.
+      I was reclining in a cane-backed chair at the moment, and my protruded
+      feet had attracted his ever-active attention.
+    </p>
+
+    <p>
+      "English," I answered in some surprise. "I got them at Latimer's, in
+      Oxford Street."
+    </p>
+
+    <p>
+      Holmes smiled with an expression of weary patience.
+    </p>
+
+    <p>
+      "The bath!" he said; "the bath! Why the relaxing and expensive Turkish
+      rather than the invigorating home-made article?"
+    </p>
+
+    <p>
+      "Because for the last few days I have been feeling rheumatic and old. A
+      Turkish bath is what we call an alterative in medicine--a fresh
+      starting-point, a cleanser of the system.
+    </p>
+
+    <p>
+      "By the way, Holmes," I added, "I have no doubt the connection between my
+      boots and a Turkish bath is a perfectly self-evident one to a logical
+      mind, and yet I should be obliged to you if you would indicate it."
+    </p>
+
+    <p>
+      "The train of reasoning is not very obscure, Watson," said Holmes with a
+      mischievous twinkle. "It belongs to the same elementary class of deduction
+      which I should illustrate if I were to ask you who shared your cab in your
+      drive this morning."
+    </p>
+
+    <p>
+      "I don't admit that a fresh illustration is an explanation," said I with
+      some asperity.
+    </p>
+
+    <p>
+      "Bravo, Watson! A very dignified and logical remonstrance. Let me see,
+      what were the points? Take the last one first--the cab. You observe that
+      you have some splashes on the left sleeve and shoulder of your coat. Had
+      you sat in the centre of a hansom you would probably have had no splashes,
+      and if you had they would certainly have been symmetrical. Therefore it is
+      clear that you sat at the side. Therefore it is equally clear that you had
+      a companion."
+    </p>
+
+    <p>
+      "That is very evident."
+    </p>
+
+    <p>
+      "Absurdly commonplace, is it not?"
+    </p>
+
+    <p>
+      "But the boots and the bath?"
+    </p>
+
+    <p>
+      "Equally childish. You are in the habit of doing up your boots in a
+      certain way. I see them on this occasion fastened with an elaborate double
+      bow, which is not your usual method of tying them. You have, therefore,
+      had them off. Who has tied them? A bootmaker--or the boy at the bath. It
+      is unlikely that it is the bootmaker, since your boots are nearly new.
+      Well, what remains? The bath. Absurd, is it not? But, for all that, the
+      Turkish bath has served a purpose."
+    </p>
+
+    <p>
+      "What is that?"
+    </p>
+
+    <p>
+      "You say that you have had it because you need a change. Let me suggest
+      that you take one. How would Lausanne do, my dear Watson--first-class
+      tickets and all expenses paid on a princely scale?"
+    </p>
+
+    <p>
+      "Splendid! But why?"
+    </p>
+
+    <p>
+      Holmes leaned back in his armchair and took his notebook from his pocket.
+    </p>
+
+    <p>
+      "One of the most dangerous classes in the world," said he, "is the
+      drifting and friendless woman. She is the most harmless and often the most
+      useful of mortals, but she is the inevitable inciter of crime in others.
+      She is helpless. She is migratory. She has sufficient means to take her
+      from country to country and from hotel to hotel. She is lost, as often as
+      not, in a maze of obscure pensions and boardinghouses. She is a stray
+      chicken in a world of foxes. When she is gobbled up she is hardly missed.
+      I much fear that some evil has come to the Lady Frances Carfax."
+    </p>
+
+    <p>
+      I was relieved at this sudden descent from the general to the particular.
+      Holmes consulted his notes.
+    </p>
+
+    <p>
+      "Lady Frances," he continued, "is the sole survivor of the direct family
+      of the late Earl of Rufton. The estates went, as you may remember, in the
+      male line. She was left with limited means, but with some very remarkable
+      old Spanish jewellery of silver and curiously cut diamonds to which she
+      was fondly attached--too attached, for she refused to leave them with her
+      banker and always carried them about with her. A rather pathetic figure,
+      the Lady Frances, a beautiful woman, still in fresh middle age, and yet,
+      by a strange change, the last derelict of what only twenty years ago was a
+      goodly fleet."
+    </p>
+
+    <p>
+      "What has happened to her, then?"
+    </p>
+
+    <p>
+      "Ah, what has happened to the Lady Frances? Is she alive or dead? There is
+      our problem. She is a lady of precise habits, and for four years it has
+      been her invariable custom to write every second week to Miss Dobney, her
+      old governess, who has long retired and lives in Camberwell. It is this
+      Miss Dobney who has consulted me. Nearly five weeks have passed without a
+      word. The last letter was from the Hotel National at Lausanne. Lady
+      Frances seems to have left there and given no address. The family are
+      anxious, and as they are exceedingly wealthy no sum will be spared if we
+      can clear the matter up."
+    </p>
+
+    <p>
+      "Is Miss Dobney the only source of information? Surely she had other
+      correspondents?"
+    </p>
+
+    <p>
+      "There is one correspondent who is a sure draw, Watson. That is the bank.
+      Single ladies must live, and their passbooks are compressed diaries. She
+      banks at Silvester's. I have glanced over her account. The last check but
+      one paid her bill at Lausanne, but it was a large one and probably left
+      her with cash in hand. Only one check has been drawn since."
+    </p>
+
+    <p>
+      "To whom, and where?"
+    </p>
+
+    <p>
+      "To Miss Marie Devine. There is nothing to show where the check was drawn.
+      It was cashed at the Credit Lyonnais at Montpellier less than three weeks
+      ago. The sum was fifty pounds."
+    </p>
+
+    <p>
+      "And who is Miss Marie Devine?"
+    </p>
+
+    <p>
+      "That also I have been able to discover. Miss Marie Devine was the maid of
+      Lady Frances Carfax. Why she should have paid her this check we have not
+      yet determined. I have no doubt, however, that your researches will soon
+      clear the matter up."
+    </p>
+
+    <p>
+      "MY researches!"
+    </p>
+
+    <p>
+      "Hence the health-giving expedition to Lausanne. You know that I cannot
+      possibly leave London while old Abrahams is in such mortal terror of his
+      life. Besides, on general principles it is best that I should not leave
+      the country. Scotland Yard feels lonely without me, and it causes an
+      unhealthy excitement among the criminal classes. Go, then, my dear Watson,
+      and if my humble counsel can ever be valued at so extravagant a rate as
+      two pence a word, it waits your disposal night and day at the end of the
+      Continental wire."
+    </p>
+
+    <p>
+      Two days later found me at the Hotel National at Lausanne, where I
+      received every courtesy at the hands of M. Moser, the well-known manager.
+      Lady Frances, as he informed me, had stayed there for several weeks. She
+      had been much liked by all who met her. Her age was not more than forty.
+      She was still handsome and bore every sign of having in her youth been a
+      very lovely woman. M. Moser knew nothing of any valuable jewellery, but it
+      had been remarked by the servants that the heavy trunk in the lady's
+      bedroom was always scrupulously locked. Marie Devine, the maid, was as
+      popular as her mistress. She was actually engaged to one of the head
+      waiters in the hotel, and there was no difficulty in getting her address.
+      It was 11 Rue de Trajan, Montpellier. All this I jotted down and felt that
+      Holmes himself could not have been more adroit in collecting his facts.
+    </p>
+
+    <p>
+      Only one corner still remained in the shadow. No light which I possessed
+      could clear up the cause for the lady's sudden departure. She was very
+      happy at Lausanne. There was every reason to believe that she intended to
+      remain for the season in her luxurious rooms overlooking the lake. And yet
+      she had left at a single day's notice, which involved her in the useless
+      payment of a week's rent. Only Jules Vibart, the lover of the maid, had
+      any suggestion to offer. He connected the sudden departure with the visit
+      to the hotel a day or two before of a tall, dark, bearded man. "Un
+      sauvage--un veritable sauvage!" cried Jules Vibart. The man had rooms
+      somewhere in the town. He had been seen talking earnestly to Madame on the
+      promenade by the lake. Then he had called. She had refused to see him. He
+      was English, but of his name there was no record. Madame had left the
+      place immediately afterwards. Jules Vibart, and, what was of more
+      importance, Jules Vibart's sweetheart, thought that this call and the
+      departure were cause and effect. Only one thing Jules would not discuss.
+      That was the reason why Marie had left her mistress. Of that he could or
+      would say nothing. If I wished to know, I must go to Montpellier and ask
+      her.
+    </p>
+
+    <p>
+      So ended the first chapter of my inquiry. The second was devoted to the
+      place which Lady Frances Carfax had sought when she left Lausanne.
+      Concerning this there had been some secrecy, which confirmed the idea that
+      she had gone with the intention of throwing someone off her track.
+      Otherwise why should not her luggage have been openly labelled for Baden?
+      Both she and it reached the Rhenish spa by some circuitous route. This
+      much I gathered from the manager of Cook's local office. So to Baden I
+      went, after dispatching to Holmes an account of all my proceedings and
+      receiving in reply a telegram of half-humorous commendation.
+    </p>
+
+    <p>
+      At Baden the track was not difficult to follow. Lady Frances had stayed at
+      the Englischer Hof for a fortnight. While there she had made the
+      acquaintance of a Dr. Shlessinger and his wife, a missionary from South
+      America. Like most lonely ladies, Lady Frances found her comfort and
+      occupation in religion. Dr. Shlessinger's remarkable personality, his
+      whole hearted devotion, and the fact that he was recovering from a disease
+      contracted in the exercise of his apostolic duties affected her deeply.
+      She had helped Mrs. Shlessinger in the nursing of the convalescent saint.
+      He spent his day, as the manager described it to me, upon a lounge-chair
+      on the veranda, with an attendant lady upon either side of him. He was
+      preparing a map of the Holy Land, with special reference to the kingdom of
+      the Midianites, upon which he was writing a monograph. Finally, having
+      improved much in health, he and his wife had returned to London, and Lady
+      Frances had started thither in their company. This was just three weeks
+      before, and the manager had heard nothing since. As to the maid, Marie,
+      she had gone off some days beforehand in floods of tears, after informing
+      the other maids that she was leaving service forever. Dr. Shlessinger had
+      paid the bill of the whole party before his departure.
+    </p>
+
+    <p>
+      "By the way," said the landlord in conclusion, "you are not the only
+      friend of Lady Frances Carfax who is inquiring after her just now. Only a
+      week or so ago we had a man here upon the same errand."
+    </p>
+
+    <p>
+      "Did he give a name?" I asked.
+    </p>
+
+    <p>
+      "None; but he was an Englishman, though of an unusual type."
+    </p>
+
+    <p>
+      "A savage?" said I, linking my facts after the fashion of my illustrious
+      friend.
+    </p>
+
+    <p>
+      "Exactly. That describes him very well. He is a bulky, bearded, sunburned
+      fellow, who looks as if he would be more at home in a farmers' inn than in
+      a fashionable hotel. A hard, fierce man, I should think, and one whom I
+      should be sorry to offend."
+    </p>
+
+    <p>
+      Already the mystery began to define itself, as figures grow clearer with
+      the lifting of a fog. Here was this good and pious lady pursued from place
+      to place by a sinister and unrelenting figure. She feared him, or she
+      would not have fled from Lausanne. He had still followed. Sooner or later
+      he would overtake her. Had he already overtaken her? Was THAT the secret
+      of her continued silence? Could the good people who were her companions
+      not screen her from his violence or his blackmail? What horrible purpose,
+      what deep design, lay behind this long pursuit? There was the problem
+      which I had to solve.
+    </p>
+
+    <p>
+      To Holmes I wrote showing how rapidly and surely I had got down to the
+      roots of the matter. In reply I had a telegram asking for a description of
+      Dr. Shlessinger's left ear. Holmes's ideas of humour are strange and
+      occasionally offensive, so I took no notice of his ill-timed jest--indeed,
+      I had already reached Montpellier in my pursuit of the maid, Marie, before
+      his message came.
+    </p>
+
+    <p>
+      I had no difficulty in finding the ex-servant and in learning all that she
+      could tell me. She was a devoted creature, who had only left her mistress
+      because she was sure that she was in good hands, and because her own
+      approaching marriage made a separation inevitable in any case. Her
+      mistress had, as she confessed with distress, shown some irritability of
+      temper towards her during their stay in Baden, and had even questioned her
+      once as if she had suspicions of her honesty, and this had made the
+      parting easier than it would otherwise have been. Lady Frances had given
+      her fifty pounds as a wedding-present. Like me, Marie viewed with deep
+      distrust the stranger who had driven her mistress from Lausanne. With her
+      own eyes she had seen him seize the lady's wrist with great violence on
+      the public promenade by the lake. He was a fierce and terrible man. She
+      believed that it was out of dread of him that Lady Frances had accepted
+      the escort of the Shlessingers to London. She had never spoken to Marie
+      about it, but many little signs had convinced the maid that her mistress
+      lived in a state of continual nervous apprehension. So far she had got in
+      her narrative, when suddenly she sprang from her chair and her face was
+      convulsed with surprise and fear. "See!" she cried. "The miscreant follows
+      still! There is the very man of whom I speak."
+    </p>
+
+    <p>
+      Through the open sitting-room window I saw a huge, swarthy man with a
+      bristling black beard walking slowly down the centre of the street and
+      staring eagerly at the numbers of the houses. It was clear that, like
+      myself, he was on the track of the maid. Acting upon the impulse of the
+      moment, I rushed out and accosted him.
+    </p>
+
+    <p>
+      "You are an Englishman," I said.
+    </p>
+
+    <p>
+      "What if I am?" he asked with a most villainous scowl.
+    </p>
+
+    <p>
+      "May I ask what your name is?"
+    </p>
+
+    <p>
+      "No, you may not," said he with decision.
+    </p>
+
+    <p>
+      The situation was awkward, but the most direct way is often the best.
+    </p>
+
+    <p>
+      "Where is the Lady Frances Carfax?" I asked.
+    </p>
+
+    <p>
+      He stared at me with amazement.
+    </p>
+
+    <p>
+      "What have you done with her? Why have you pursued her? I insist upon an
+      answer!" said I.
+    </p>
+
+    <p>
+      The fellow gave a bellow of anger and sprang upon me like a tiger. I have
+      held my own in many a struggle, but the man had a grip of iron and the
+      fury of a fiend. His hand was on my throat and my senses were nearly gone
+      before an unshaven French ouvrier in a blue blouse darted out from a
+      cabaret opposite, with a cudgel in his hand, and struck my assailant a
+      sharp crack over the forearm, which made him leave go his hold. He stood
+      for an instant fuming with rage and uncertain whether he should not renew
+      his attack. Then, with a snarl of anger, he left me and entered the
+      cottage from which I had just come. I turned to thank my preserver, who
+      stood beside me in the roadway.
+    </p>
+
+    <p>
+      "Well, Watson," said he, "a very pretty hash you have made of it! I rather
+      think you had better come back with me to London by the night express."
+    </p>
+
+    <p>
+      An hour afterwards, Sherlock Holmes, in his usual garb and style, was
+      seated in my private room at the hotel. His explanation of his sudden and
+      opportune appearance was simplicity itself, for, finding that he could get
+      away from London, he determined to head me off at the next obvious point
+      of my travels. In the disguise of a workingman he had sat in the cabaret
+      waiting for my appearance.
+    </p>
+
+    <p>
+      "And a singularly consistent investigation you have made, my dear Watson,"
+      said he. "I cannot at the moment recall any possible blunder which you
+      have omitted. The total effect of your proceeding has been to give the
+      alarm everywhere and yet to discover nothing."
+    </p>
+
+    <p>
+      "Perhaps you would have done no better," I answered bitterly.
+    </p>
+
+    <p>
+      "There is no 'perhaps' about it. I HAVE done better. Here is the Hon.
+      Philip Green, who is a fellow-lodger with you in this hotel, and we may
+      find him the starting-point for a more successful investigation."
+    </p>
+
+    <p>
+      A card had come up on a salver, and it was followed by the same bearded
+      ruffian who had attacked me in the street. He started when he saw me.
+    </p>
+
+    <p>
+      "What is this, Mr. Holmes?" he asked. "I had your note and I have come.
+      But what has this man to do with the matter?"
+    </p>
+
+    <p>
+      "This is my old friend and associate, Dr. Watson, who is helping us in
+      this affair."
+    </p>
+
+    <p>
+      The stranger held out a huge, sunburned hand, with a few words of apology.
+    </p>
+
+    <p>
+      "I hope I didn't harm you. When you accused me of hurting her I lost my
+      grip of myself. Indeed, I'm not responsible in these days. My nerves are
+      like live wires. But this situation is beyond me. What I want to know, in
+      the first place, Mr. Holmes, is, how in the world you came to hear of my
+      existence at all."
+    </p>
+
+    <p>
+      "I am in touch with Miss Dobney, Lady Frances's governess."
+    </p>
+
+    <p>
+      "Old Susan Dobney with the mob cap! I remember her well."
+    </p>
+
+    <p>
+      "And she remembers you. It was in the days before--before you found it
+      better to go to South Africa."
+    </p>
+
+    <p>
+      "Ah, I see you know my whole story. I need hide nothing from you. I swear
+      to you, Mr. Holmes, that there never was in this world a man who loved a
+      woman with a more wholehearted love than I had for Frances. I was a wild
+      youngster, I know--not worse than others of my class. But her mind was
+      pure as snow. She could not bear a shadow of coarseness. So, when she came
+      to hear of things that I had done, she would have no more to say to me.
+      And yet she loved me--that is the wonder of it!--loved me well enough to
+      remain single all her sainted days just for my sake alone. When the years
+      had passed and I had made my money at Barberton I thought perhaps I could
+      seek her out and soften her. I had heard that she was still unmarried, I
+      found her at Lausanne and tried all I knew. She weakened, I think, but her
+      will was strong, and when next I called she had left the town. I traced
+      her to Baden, and then after a time heard that her maid was here. I'm a
+      rough fellow, fresh from a rough life, and when Dr. Watson spoke to me as
+      he did I lost hold of myself for a moment. But for God's sake tell me what
+      has become of the Lady Frances."
+    </p>
+
+    <p>
+      "That is for us to find out," said Sherlock Holmes with peculiar gravity.
+      "What is your London address, Mr. Green?"
+    </p>
+
+    <p>
+      "The Langham Hotel will find me."
+    </p>
+
+    <p>
+      "Then may I recommend that you return there and be on hand in case I
+      should want you? I have no desire to encourage false hopes, but you may
+      rest assured that all that can be done will be done for the safety of Lady
+      Frances. I can say no more for the instant. I will leave you this card so
+      that you may be able to keep in touch with us. Now, Watson, if you will
+      pack your bag I will cable to Mrs. Hudson to make one of her best efforts
+      for two hungry travellers at 7:30 to-morrow."
+    </p>
+
+    <p></p>
+
+    <p>
+      A telegram was awaiting us when we reached our Baker Street rooms, which
+      Holmes read with an exclamation of interest and threw across to me.
+      "Jagged or torn," was the message, and the place of origin, Baden.
+    </p>
+
+    <p>
+      "What is this?" I asked.
+    </p>
+
+    <p>
+      "It is everything," Holmes answered. "You may remember my seemingly
+      irrelevant question as to this clerical gentleman's left ear. You did not
+      answer it."
+    </p>
+
+    <p>
+      "I had left Baden and could not inquire."
+    </p>
+
+    <p>
+      "Exactly. For this reason I sent a duplicate to the manager of the
+      Englischer Hof, whose answer lies here."
+    </p>
+
+    <p>
+      "What does it show?"
+    </p>
+
+    <p>
+      "It shows, my dear Watson, that we are dealing with an exceptionally
+      astute and dangerous man. The Rev. Dr. Shlessinger, missionary from South
+      America, is none other than Holy Peters, one of the most unscrupulous
+      rascals that Australia has ever evolved--and for a young country it has
+      turned out some very finished types. His particular specialty is the
+      beguiling of lonely ladies by playing upon their religious feelings, and
+      his so-called wife, an Englishwoman named Fraser, is a worthy helpmate.
+      The nature of his tactics suggested his identity to me, and this physical
+      peculiarity--he was badly bitten in a saloon-fight at Adelaide in
+      '89--confirmed my suspicion. This poor lady is in the hands of a most
+      infernal couple, who will stick at nothing, Watson. That she is already
+      dead is a very likely supposition. If not, she is undoubtedly in some sort
+      of confinement and unable to write to Miss Dobney or her other friends. It
+      is always possible that she never reached London, or that she has passed
+      through it, but the former is improbable, as, with their system of
+      registration, it is not easy for foreigners to play tricks with the
+      Continental police; and the latter is also unlikely, as these rouges could
+      not hope to find any other place where it would be as easy to keep a
+      person under restraint. All my instincts tell me that she is in London,
+      but as we have at present no possible means of telling where, we can only
+      take the obvious steps, eat our dinner, and possess our souls in patience.
+      Later in the evening I will stroll down and have a word with friend
+      Lestrade at Scotland Yard."
+    </p>
+
+    <p>
+      But neither the official police nor Holmes's own small but very efficient
+      organization sufficed to clear away the mystery. Amid the crowded millions
+      of London the three persons we sought were as completely obliterated as if
+      they had never lived. Advertisements were tried, and failed. Clues were
+      followed, and led to nothing. Every criminal resort which Shlessinger
+      might frequent was drawn in vain. His old associates were watched, but
+      they kept clear of him. And then suddenly, after a week of helpless
+      suspense there came a flash of light. A silver-and-brilliant pendant of
+      old Spanish design had been pawned at Bovington's, in Westminster Road.
+      The pawner was a large, clean-shaven man of clerical appearance. His name
+      and address were demonstrably false. The ear had escaped notice, but the
+      description was surely that of Shlessinger.
+    </p>
+
+    <p>
+      Three times had our bearded friend from the Langham called for news--the
+      third time within an hour of this fresh development. His clothes were
+      getting looser on his great body. He seemed to be wilting away in his
+      anxiety. "If you will only give me something to do!" was his constant
+      wail. At last Holmes could oblige him.
+    </p>
+
+    <p>
+      "He has begun to pawn the jewels. We should get him now."
+    </p>
+
+    <p>
+      "But does this mean that any harm has befallen the Lady Frances?"
+    </p>
+
+    <p>
+      Holmes shook his head very gravely.
+    </p>
+
+    <p>
+      "Supposing that they have held her prisoner up to now, it is clear that
+      they cannot let her loose without their own destruction. We must prepare
+      for the worst."
+    </p>
+
+    <p>
+      "What can I do?"
+    </p>
+
+    <p>
+      "These people do not know you by sight?"
+    </p>
+
+    <p>
+      "No."
+    </p>
+
+    <p>
+      "It is possible that he will go to some other pawnbroker in the future. In
+      that case, we must begin again. On the other hand, he has had a fair price
+      and no questions asked, so if he is in need of ready-money he will
+      probably come back to Bovington's. I will give you a note to them, and
+      they will let you wait in the shop. If the fellow comes you will follow
+      him home. But no indiscretion, and, above all, no violence. I put you on
+      your honour that you will take no step without my knowledge and consent."
+    </p>
+
+    <p>
+      For two days the Hon. Philip Green (he was, I may mention, the son of the
+      famous admiral of that name who commanded the Sea of Azof fleet in the
+      Crimean War) brought us no news. On the evening of the third he rushed
+      into our sitting-room, pale, trembling, with every muscle of his powerful
+      frame quivering with excitement.
+    </p>
+
+    <p>
+      "We have him! We have him!" he cried.
+    </p>
+
+    <p>
+      He was incoherent in his agitation. Holmes soothed him with a few words
+      and thrust him into an armchair.
+    </p>
+
+    <p>
+      "Come, now, give us the order of events," said he.
+    </p>
+
+    <p>
+      "She came only an hour ago. It was the wife, this time, but the pendant
+      she brought was the fellow of the other. She is a tall, pale woman, with
+      ferret eyes."
+    </p>
+
+    <p>
+      "That is the lady," said Holmes.
+    </p>
+
+    <p>
+      "She left the office and I followed her. She walked up the Kennington
+      Road, and I kept behind her. Presently she went into a shop. Mr. Holmes,
+      it was an undertaker's."
+    </p>
+
+    <p>
+      My companion started. "Well?" he asked in that vibrant voice which told of
+      the fiery soul behind the cold gray face.
+    </p>
+
+    <p>
+      "She was talking to the woman behind the counter. I entered as well. 'It
+      is late,' I heard her say, or words to that effect. The woman was excusing
+      herself. 'It should be there before now,' she answered. 'It took longer,
+      being out of the ordinary.' They both stopped and looked at me, so I asked
+      some questions and then left the shop."
+    </p>
+
+    <p>
+      "You did excellently well. What happened next?"
+    </p>
+
+    <p>
+      "The woman came out, but I had hid myself in a doorway. Her suspicions had
+      been aroused, I think, for she looked round her. Then she called a cab and
+      got in. I was lucky enough to get another and so to follow her. She got
+      down at last at No. 36, Poultney Square, Brixton. I drove past, left my
+      cab at the corner of the square, and watched the house."
+    </p>
+
+    <p>
+      "Did you see anyone?"
+    </p>
+
+    <p>
+      "The windows were all in darkness save one on the lower floor. The blind
+      was down, and I could not see in. I was standing there, wondering what I
+      should do next, when a covered van drove up with two men in it. They
+      descended, took something out of the van, and carried it up the steps to
+      the hall door. Mr. Holmes, it was a coffin."
+    </p>
+
+    <p>
+      "Ah!"
+    </p>
+
+    <p>
+      "For an instant I was on the point of rushing in. The door had been opened
+      to admit the men and their burden. It was the woman who had opened it. But
+      as I stood there she caught a glimpse of me, and I think that she
+      recognized me. I saw her start, and she hastily closed the door. I
+      remembered my promise to you, and here I am."
+    </p>
+
+    <p>
+      "You have done excellent work," said Holmes, scribbling a few words upon a
+      half-sheet of paper. "We can do nothing legal without a warrant, and you
+      can serve the cause best by taking this note down to the authorities and
+      getting one. There may be some difficulty, but I should think that the
+      sale of the jewellery should be sufficient. Lestrade will see to all
+      details."
+    </p>
+
+    <p>
+      "But they may murder her in the meanwhile. What could the coffin mean, and
+      for whom could it be but for her?"
+    </p>
+
+    <p>
+      "We will do all that can be done, Mr. Green. Not a moment will be lost.
+      Leave it in our hands. Now Watson," he added as our client hurried away,
+      "he will set the regular forces on the move. We are, as usual, the
+      irregulars, and we must take our own line of action. The situation strikes
+      me as so desperate that the most extreme measures are justified. Not a
+      moment is to be lost in getting to Poultney Square.
+    </p>
+
+    <p>
+      "Let us try to reconstruct the situation," said he as we drove swiftly
+      past the Houses of Parliament and over Westminster Bridge. "These villains
+      have coaxed this unhappy lady to London, after first alienating her from
+      her faithful maid. If she has written any letters they have been
+      intercepted. Through some confederate they have engaged a furnished house.
+      Once inside it, they have made her a prisoner, and they have become
+      possessed of the valuable jewellery which has been their object from the
+      first. Already they have begun to sell part of it, which seems safe enough
+      to them, since they have no reason to think that anyone is interested in
+      the lady's fate. When she is released she will, of course, denounce them.
+      Therefore, she must not be released. But they cannot keep her under lock
+      and key forever. So murder is their only solution."
+    </p>
+
+    <p>
+      "That seems very clear."
+    </p>
+
+    <p>
+      "Now we will take another line of reasoning. When you follow two separate
+      chains of thought, Watson, you will find some point of intersection which
+      should approximate to the truth. We will start now, not from the lady but
+      from the coffin and argue backward. That incident proves, I fear, beyond
+      all doubt that the lady is dead. It points also to an orthodox burial with
+      proper accompaniment of medical certificate and official sanction. Had the
+      lady been obviously murdered, they would have buried her in a hole in the
+      back garden. But here all is open and regular. What does this mean? Surely
+      that they have done her to death in some way which has deceived the doctor
+      and simulated a natural end--poisoning, perhaps. And yet how strange that
+      they should ever let a doctor approach her unless he were a confederate,
+      which is hardly a credible proposition."
+    </p>
+
+    <p>
+      "Could they have forged a medical certificate?"
+    </p>
+
+    <p>
+      "Dangerous, Watson, very dangerous. No, I hardly see them doing that. Pull
+      up, cabby! This is evidently the undertaker's, for we have just passed the
+      pawnbroker's. Would you go in, Watson? Your appearance inspires
+      confidence. Ask what hour the Poultney Square funeral takes place
+      to-morrow."
+    </p>
+
+    <p>
+      The woman in the shop answered me without hesitation that it was to be at
+      eight o'clock in the morning. "You see, Watson, no mystery; everything
+      above-board! In some way the legal forms have undoubtedly been complied
+      with, and they think that they have little to fear. Well, there's nothing
+      for it now but a direct frontal attack. Are you armed?"
+    </p>
+
+    <p>
+      "My stick!"
+    </p>
+
+    <p>
+      "Well, well, we shall be strong enough. 'Thrice is he armed who hath his
+      quarrel just.' We simply can't afford to wait for the police or to keep
+      within the four corners of the law. You can drive off, cabby. Now, Watson,
+      we'll just take our luck together, as we have occasionally in the past."
+    </p>
+
+    <p>
+      He had rung loudly at the door of a great dark house in the centre of
+      Poultney Square. It was opened immediately, and the figure of a tall woman
+      was outlined against the dim-lit hall.
+    </p>
+
+    <p>
+      "Well, what do you want?" she asked sharply, peering at us through the
+      darkness.
+    </p>
+
+    <p>
+      "I want to speak to Dr. Shlessinger," said Holmes.
+    </p>
+
+    <p>
+      "There is no such person here," she answered, and tried to close the door,
+      but Holmes had jammed it with his foot.
+    </p>
+
+    <p>
+      "Well, I want to see the man who lives here, whatever he may call
+      himself," said Holmes firmly.
+    </p>
+
+    <p>
+      She hesitated. Then she threw open the door. "Well, come in!" said she.
+      "My husband is not afraid to face any man in the world." She closed the
+      door behind us and showed us into a sitting-room on the right side of the
+      hall, turning up the gas as she left us. "Mr. Peters will be with you in
+      an instant," she said.
+    </p>
+
+    <p>
+      Her words were literally true, for we had hardly time to look around the
+      dusty and moth-eaten apartment in which we found ourselves before the door
+      opened and a big, clean-shaven bald-headed man stepped lightly into the
+      room. He had a large red face, with pendulous cheeks, and a general air of
+      superficial benevolence which was marred by a cruel, vicious mouth.
+    </p>
+
+    <p>
+      "There is surely some mistake here, gentlemen," he said in an unctuous,
+      make-everything-easy voice. "I fancy that you have been misdirected.
+      Possibly if you tried farther down the street--"
+    </p>
+
+    <p>
+      "That will do; we have no time to waste," said my companion firmly. "You
+      are Henry Peters, of Adelaide, late the Rev. Dr. Shlessinger, of Baden and
+      South America. I am as sure of that as that my own name is Sherlock
+      Holmes."
+    </p>
+
+    <p>
+      Peters, as I will now call him, started and stared hard at his formidable
+      pursuer. "I guess your name does not frighten me, Mr. Holmes," said he
+      coolly. "When a man's conscience is easy you can't rattle him. What is
+      your business in my house?"
+    </p>
+
+    <p>
+      "I want to know what you have done with the Lady Frances Carfax, whom you
+      brought away with you from Baden."
+    </p>
+
+    <p>
+      "I'd be very glad if you could tell me where that lady may be," Peters
+      answered coolly. "I've a bill against her for nearly a hundred pounds, and
+      nothing to show for it but a couple of trumpery pendants that the dealer
+      would hardly look at. She attached herself to Mrs. Peters and me at
+      Baden--it is a fact that I was using another name at the time--and she
+      stuck on to us until we came to London. I paid her bill and her ticket.
+      Once in London, she gave us the slip, and, as I say, left these
+      out-of-date jewels to pay her bills. You find her, Mr. Holmes, and I'm
+      your debtor."
+    </p>
+
+    <p>
+      "I MEAN to find her," said Sherlock Holmes. "I'm going through this house
+      till I do find her."
+    </p>
+
+    <p>
+      "Where is your warrant?"
+    </p>
+
+    <p>
+      Holmes half drew a revolver from his pocket. "This will have to serve till
+      a better one comes."
+    </p>
+
+    <p>
+      "Why, you're a common burglar."
+    </p>
+
+    <p>
+      "So you might describe me," said Holmes cheerfully. "My companion is also
+      a dangerous ruffian. And together we are going through your house."
+    </p>
+
+    <p>
+      Our opponent opened the door.
+    </p>
+
+    <p>
+      "Fetch a policeman, Annie!" said he. There was a whisk of feminine skirts
+      down the passage, and the hall door was opened and shut.
+    </p>
+
+    <p>
+      "Our time is limited, Watson," said Holmes. "If you try to stop us,
+      Peters, you will most certainly get hurt. Where is that coffin which was
+      brought into your house?"
+    </p>
+
+    <p>
+      "What do you want with the coffin? It is in use. There is a body in it."
+    </p>
+
+    <p>
+      "I must see the body."
+    </p>
+
+    <p>
+      "Never with my consent."
+    </p>
+
+    <p>
+      "Then without it." With a quick movement Holmes pushed the fellow to one
+      side and passed into the hall. A door half opened stood immediately before
+      us. We entered. It was the dining-room. On the table, under a half-lit
+      chandelier, the coffin was lying. Holmes turned up the gas and raised the
+      lid. Deep down in the recesses of the coffin lay an emaciated figure. The
+      glare from the lights above beat down upon an aged and withered face. By
+      no possible process of cruelty, starvation, or disease could this worn-out
+      wreck be the still beautiful Lady Frances. Holmes's face showed his
+      amazement, and also his relief.
+    </p>
+
+    <p>
+      "Thank God!" he muttered. "It's someone else."
+    </p>
+
+    <p>
+      "Ah, you've blundered badly for once, Mr. Sherlock Holmes," said Peters,
+      who had followed us into the room.
+    </p>
+
+    <p>
+      "Who is the dead woman?"
+    </p>
+
+    <p>
+      "Well, if you really must know, she is an old nurse of my wife's, Rose
+      Spender by name, whom we found in the Brixton Workhouse Infirmary. We
+      brought her round here, called in Dr. Horsom, of 13 Firbank Villas--mind
+      you take the address, Mr. Holmes--and had her carefully tended, as
+      Christian folk should. On the third day she died--certificate says senile
+      decay--but that's only the doctor's opinion, and of course you know
+      better. We ordered her funeral to be carried out by Stimson and Co., of
+      the Kennington Road, who will bury her at eight o'clock to-morrow morning.
+      Can you pick any hole in that, Mr. Holmes? You've made a silly blunder,
+      and you may as well own up to it. I'd give something for a photograph of
+      your gaping, staring face when you pulled aside that lid expecting to see
+      the Lady Frances Carfax and only found a poor old woman of ninety."
+    </p>
+
+    <p>
+      Holmes's expression was as impassive as ever under the jeers of his
+      antagonist, but his clenched hands betrayed his acute annoyance.
+    </p>
+
+    <p>
+      "I am going through your house," said he.
+    </p>
+
+    <p>
+      "Are you, though!" cried Peters as a woman's voice and heavy steps sounded
+      in the passage. "We'll soon see about that. This way, officers, if you
+      please. These men have forced their way into my house, and I cannot get
+      rid of them. Help me to put them out."
+    </p>
+
+    <p>
+      A sergeant and a constable stood in the doorway. Holmes drew his card from
+      his case.
+    </p>
+
+    <p>
+      "This is my name and address. This is my friend, Dr. Watson."
+    </p>
+
+    <p>
+      "Bless you, sir, we know you very well," said the sergeant, "but you can't
+      stay here without a warrant."
+    </p>
+
+    <p>
+      "Of course not. I quite understand that."
+    </p>
+
+    <p>
+      "Arrest him!" cried Peters.
+    </p>
+
+    <p>
+      "We know where to lay our hands on this gentleman if he is wanted," said
+      the sergeant majestically, "but you'll have to go, Mr. Holmes."
+    </p>
+
+    <p>
+      "Yes, Watson, we shall have to go."
+    </p>
+
+    <p>
+      A minute later we were in the street once more. Holmes was as cool as
+      ever, but I was hot with anger and humiliation. The sergeant had followed
+      us.
+    </p>
+
+    <p>
+      "Sorry, Mr. Holmes, but that's the law."
+    </p>
+
+    <p>
+      "Exactly, Sergeant, you could not do otherwise."
+    </p>
+
+    <p>
+      "I expect there was good reason for your presence there. If there is
+      anything I can do--"
+    </p>
+
+    <p>
+      "It's a missing lady, Sergeant, and we think she is in that house. I
+      expect a warrant presently."
+    </p>
+
+    <p>
+      "Then I'll keep my eye on the parties, Mr. Holmes. If anything comes
+      along, I will surely let you know."
+    </p>
+
+    <p>
+      It was only nine o'clock, and we were off full cry upon the trail at once.
+      First we drove to Brixton Workhouse Infirmary, where we found that it was
+      indeed the truth that a charitable couple had called some days before,
+      that they had claimed an imbecile old woman as a former servant, and that
+      they had obtained permission to take her away with them. No surprise was
+      expressed at the news that she had since died.
+    </p>
+
+    <p>
+      The doctor was our next goal. He had been called in, had found the woman
+      dying of pure senility, had actually seen her pass away, and had signed
+      the certificate in due form. "I assure you that everything was perfectly
+      normal and there was no room for foul play in the matter," said he.
+      Nothing in the house had struck him as suspicious save that for people of
+      their class it was remarkable that they should have no servant. So far and
+      no further went the doctor.
+    </p>
+
+    <p>
+      Finally we found our way to Scotland Yard. There had been difficulties of
+      procedure in regard to the warrant. Some delay was inevitable. The
+      magistrate's signature might not be obtained until next morning. If Holmes
+      would call about nine he could go down with Lestrade and see it acted
+      upon. So ended the day, save that near midnight our friend, the sergeant,
+      called to say that he had seen flickering lights here and there in the
+      windows of the great dark house, but that no one had left it and none had
+      entered. We could but pray for patience and wait for the morrow.
+    </p>
+
+    <p>
+      Sherlock Holmes was too irritable for conversation and too restless for
+      sleep. I left him smoking hard, with his heavy, dark brows knotted
+      together, and his long, nervous fingers tapping upon the arms of his
+      chair, as he turned over in his mind every possible solution of the
+      mystery. Several times in the course of the night I heard him prowling
+      about the house. Finally, just after I had been called in the morning, he
+      rushed into my room. He was in his dressing-gown, but his pale,
+      hollow-eyed face told me that his night had been a sleepless one.
+    </p>
+
+    <p>
+      "What time was the funeral? Eight, was it not?" he asked eagerly. "Well,
+      it is 7:20 now. Good heavens, Watson, what has become of any brains that
+      God has given me? Quick, man, quick! It's life or death--a hundred chances
+      on death to one on life. I'll never forgive myself, never, if we are too
+      late!"
+    </p>
+
+    <p>
+      Five minutes had not passed before we were flying in a hansom down Baker
+      Street. But even so it was twenty-five to eight as we passed Big Ben, and
+      eight struck as we tore down the Brixton Road. But others were late as
+      well as we. Ten minutes after the hour the hearse was still standing at
+      the door of the house, and even as our foaming horse came to a halt the
+      coffin, supported by three men, appeared on the threshold. Holmes darted
+      forward and barred their way.
+    </p>
+
+    <p>
+      "Take it back!" he cried, laying his hand on the breast of the foremost.
+      "Take it back this instant!"
+    </p>
+
+    <p>
+      "What the devil do you mean? Once again I ask you, where is your warrant?"
+      shouted the furious Peters, his big red face glaring over the farther end
+      of the coffin.
+    </p>
+
+    <p>
+      "The warrant is on its way. The coffin shall remain in the house until it
+      comes."
+    </p>
+
+    <p>
+      The authority in Holmes's voice had its effect upon the bearers. Peters
+      had suddenly vanished into the house, and they obeyed these new orders.
+      "Quick, Watson, quick! Here is a screw-driver!" he shouted as the coffin
+      was replaced upon the table. "Here's one for you, my man! A sovereign if
+      the lid comes off in a minute! Ask no questions--work away! That's good!
+      Another! And another! Now pull all together! It's giving! It's giving! Ah,
+      that does it at last."
+    </p>
+
+    <p>
+      With a united effort we tore off the coffin-lid. As we did so there came
+      from the inside a stupefying and overpowering smell of chloroform. A body
+      lay within, its head all wreathed in cotton-wool, which had been soaked in
+      the narcotic. Holmes plucked it off and disclosed the statuesque face of a
+      handsome and spiritual woman of middle age. In an instant he had passed
+      his arm round the figure and raised her to a sitting position.
+    </p>
+
+    <p>
+      "Is she gone, Watson? Is there a spark left? Surely we are not too late!"
+    </p>
+
+    <p>
+      For half an hour it seemed that we were. What with actual suffocation, and
+      what with the poisonous fumes of the chloroform, the Lady Frances seemed
+      to have passed the last point of recall. And then, at last, with
+      artificial respiration, with injected ether, and with every device that
+      science could suggest, some flutter of life, some quiver of the eyelids,
+      some dimming of a mirror, spoke of the slowly returning life. A cab had
+      driven up, and Holmes, parting the blind, looked out at it. "Here is
+      Lestrade with his warrant," said he. "He will find that his birds have
+      flown. And here," he added as a heavy step hurried along the passage, "is
+      someone who has a better right to nurse this lady than we have. Good
+      morning, Mr. Green; I think that the sooner we can move the Lady Frances
+      the better. Meanwhile, the funeral may proceed, and the poor old woman who
+      still lies in that coffin may go to her last resting-place alone."
+    </p>
+
+    <p>
+      "Should you care to add the case to your annals, my dear Watson," said
+      Holmes that evening, "it can only be as an example of that temporary
+      eclipse to which even the best-balanced mind may be exposed. Such slips
+      are common to all mortals, and the greatest is he who can recognize and
+      repair them. To this modified credit I may, perhaps, make some claim. My
+      night was haunted by the thought that somewhere a clue, a strange
+      sentence, a curious observation, had come under my notice and had been too
+      easily dismissed. Then, suddenly, in the gray of the morning, the words
+      came back to me. It was the remark of the undertaker's wife, as reported
+      by Philip Green. She had said, 'It should be there before now. It took
+      longer, being out of the ordinary.' It was the coffin of which she spoke.
+      It had been out of the ordinary. That could only mean that it had been
+      made to some special measurement. But why? Why? Then in an instant I
+      remembered the deep sides, and the little wasted figure at the bottom. Why
+      so large a coffin for so small a body? To leave room for another body.
+      Both would be buried under the one certificate. It had all been so clear,
+      if only my own sight had not been dimmed. At eight the Lady Frances would
+      be buried. Our one chance was to stop the coffin before it left the house.
+    </p>
+
+    <p>
+      "It was a desperate chance that we might find her alive, but it WAS a
+      chance, as the result showed. These people had never, to my knowledge,
+      done a murder. They might shrink from actual violence at the last. The
+      could bury her with no sign of how she met her end, and even if she were
+      exhumed there was a chance for them. I hoped that such considerations
+      might prevail with them. You can reconstruct the scene well enough. You
+      saw the horrible den upstairs, where the poor lady had been kept so long.
+      They rushed in and overpowered her with their chloroform, carried her
+      down, poured more into the coffin to insure against her waking, and then
+      screwed down the lid. A clever device, Watson. It is new to me in the
+      annals of crime. If our ex-missionary friends escape the clutches of
+      Lestrade, I shall expect to hear of some brilliant incidents in their
+      future career."
+    </p>
+
+    <br /><br /><br /><br />
+
+    <p>
+      End of the Project Gutenberg EBook of The Disappearance of Lady Frances
+      Carfax, by Arthur Conan Doyle *** END OF THIS PROJECT GUTENBERG EBOOK
+      DISAPPEARANCE OF LADY CARFAX *** ***** This file should be named
+      2348-h.htm or 2348-h.zip ***** This and all associated files of various
+      formats will be found in: http://www.gutenberg.org/2/3/4/2348/ Produced by
+      David Brannan. HTML version by Al Haines. Updated editions will replace
+      the previous one--the old editions will be renamed. Creating the works
+      from public domain print editions means that no one owns a United States
+      copyright in these works, so the Foundation (and you!) can copy and
+      distribute it in the United States without permission and without paying
+      copyright royalties. Special rules, set forth in the General Terms of Use
+      part of this license, apply to copying and distributing Project
+      Gutenberg-tm electronic works to protect the PROJECT GUTENBERG-tm concept
+      and trademark. Project Gutenberg is a registered trademark, and may not be
+      used if you charge for the eBooks, unless you receive specific permission.
+      If you do not charge anything for copies of this eBook, complying with the
+      rules is very easy. You may use this eBook for nearly any purpose such as
+      creation of derivative works, reports, performances and research. They may
+      be modified and printed and given away--you may do practically ANYTHING
+      with public domain eBooks. Redistribution is subject to the trademark
+      license, especially commercial redistribution. *** START: FULL LICENSE ***
+      THE FULL PROJECT GUTENBERG LICENSE PLEASE READ THIS BEFORE YOU DISTRIBUTE
+      OR USE THIS WORK To protect the Project Gutenberg-tm mission of promoting
+      the free distribution of electronic works, by using or distributing this
+      work (or any other work associated in any way with the phrase "Project
+      Gutenberg"), you agree to comply with all the terms of the Full Project
+      Gutenberg-tm License (available with this file or online at
+      http://gutenberg.net/license). Section 1. General Terms of Use and
+      Redistributing Project Gutenberg-tm electronic works 1.A. By reading or
+      using any part of this Project Gutenberg-tm electronic work, you indicate
+      that you have read, understand, agree to and accept all the terms of this
+      license and intellectual property (trademark/copyright) agreement. If you
+      do not agree to abide by all the terms of this agreement, you must cease
+      using and return or destroy all copies of Project Gutenberg-tm electronic
+      works in your possession. If you paid a fee for obtaining a copy of or
+      access to a Project Gutenberg-tm electronic work and you do not agree to
+      be bound by the terms of this agreement, you may obtain a refund from the
+      person or entity to whom you paid the fee as set forth in paragraph 1.E.8.
+      1.B. "Project Gutenberg" is a registered trademark. It may only be used on
+      or associated in any way with an electronic work by people who agree to be
+      bound by the terms of this agreement. There are a few things that you can
+      do with most Project Gutenberg-tm electronic works even without complying
+      with the full terms of this agreement. See paragraph 1.C below. There are
+      a lot of things you can do with Project Gutenberg-tm electronic works if
+      you follow the terms of this agreement and help preserve free future
+      access to Project Gutenberg-tm electronic works. See paragraph 1.E below.
+      1.C. The Project Gutenberg Literary Archive Foundation ("the Foundation"
+      or PGLAF), owns a compilation copyright in the collection of Project
+      Gutenberg-tm electronic works. Nearly all the individual works in the
+      collection are in the public domain in the United States. If an individual
+      work is in the public domain in the United States and you are located in
+      the United States, we do not claim a right to prevent you from copying,
+      distributing, performing, displaying or creating derivative works based on
+      the work as long as all references to Project Gutenberg are removed. Of
+      course, we hope that you will support the Project Gutenberg-tm mission of
+      promoting free access to electronic works by freely sharing Project
+      Gutenberg-tm works in compliance with the terms of this agreement for
+      keeping the Project Gutenberg-tm name associated with the work. You can
+      easily comply with the terms of this agreement by keeping this work in the
+      same format with its attached full Project Gutenberg-tm License when you
+      share it without charge with others. 1.D. The copyright laws of the place
+      where you are located also govern what you can do with this work.
+      Copyright laws in most countries are in a constant state of change. If you
+      are outside the United States, check the laws of your country in addition
+      to the terms of this agreement before downloading, copying, displaying,
+      performing, distributing or creating derivative works based on this work
+      or any other Project Gutenberg-tm work. The Foundation makes no
+      representations concerning the copyright status of any work in any country
+      outside the United States. 1.E. Unless you have removed all references to
+      Project Gutenberg: 1.E.1. The following sentence, with active links to, or
+      other immediate access to, the full Project Gutenberg-tm License must
+      appear prominently whenever any copy of a Project Gutenberg-tm work (any
+      work on which the phrase "Project Gutenberg" appears, or with which the
+      phrase "Project Gutenberg" is associated) is accessed, displayed,
+      performed, viewed, copied or distributed: This eBook is for the use of
+      anyone anywhere at no cost and with almost no restrictions whatsoever. You
+      may copy it, give it away or re-use it under the terms of the Project
+      Gutenberg License included with this eBook or online at www.gutenberg.net
+      1.E.2. If an individual Project Gutenberg-tm electronic work is derived
+      from the public domain (does not contain a notice indicating that it is
+      posted with permission of the copyright holder), the work can be copied
+      and distributed to anyone in the United States without paying any fees or
+      charges. If you are redistributing or providing access to a work with the
+      phrase "Project Gutenberg" associated with or appearing on the work, you
+      must comply either with the requirements of paragraphs 1.E.1 through 1.E.7
+      or obtain permission for the use of the work and the Project Gutenberg-tm
+      trademark as set forth in paragraphs 1.E.8 or 1.E.9. 1.E.3. If an
+      individual Project Gutenberg-tm electronic work is posted with the
+      permission of the copyright holder, your use and distribution must comply
+      with both paragraphs 1.E.1 through 1.E.7 and any additional terms imposed
+      by the copyright holder. Additional terms will be linked to the Project
+      Gutenberg-tm License for all works posted with the permission of the
+      copyright holder found at the beginning of this work. 1.E.4. Do not unlink
+      or detach or remove the full Project Gutenberg-tm License terms from this
+      work, or any files containing a part of this work or any other work
+      associated with Project Gutenberg-tm. 1.E.5. Do not copy, display,
+      perform, distribute or redistribute this electronic work, or any part of
+      this electronic work, without prominently displaying the sentence set
+      forth in paragraph 1.E.1 with active links or immediate access to the full
+      terms of the Project Gutenberg-tm License. 1.E.6. You may convert to and
+      distribute this work in any binary, compressed, marked up, nonproprietary
+      or proprietary form, including any word processing or hypertext form.
+      However, if you provide access to or distribute copies of a Project
+      Gutenberg-tm work in a format other than "Plain Vanilla ASCII" or other
+      format used in the official version posted on the official Project
+      Gutenberg-tm web site (www.gutenberg.net), you must, at no additional
+      cost, fee or expense to the user, provide a copy, a means of exporting a
+      copy, or a means of obtaining a copy upon request, of the work in its
+      original "Plain Vanilla ASCII" or other form. Any alternate format must
+      include the full Project Gutenberg-tm License as specified in paragraph
+      1.E.1. 1.E.7. Do not charge a fee for access to, viewing, displaying,
+      performing, copying or distributing any Project Gutenberg-tm works unless
+      you comply with paragraph 1.E.8 or 1.E.9. 1.E.8. You may charge a
+      reasonable fee for copies of or providing access to or distributing
+      Project Gutenberg-tm electronic works provided that - You pay a royalty
+      fee of 20% of the gross profits you derive from the use of Project
+      Gutenberg-tm works calculated using the method you already use to
+      calculate your applicable taxes. The fee is owed to the owner of the
+      Project Gutenberg-tm trademark, but he has agreed to donate royalties
+      under this paragraph to the Project Gutenberg Literary Archive Foundation.
+      Royalty payments must be paid within 60 days following each date on which
+      you prepare (or are legally required to prepare) your periodic tax
+      returns. Royalty payments should be clearly marked as such and sent to the
+      Project Gutenberg Literary Archive Foundation at the address specified in
+      Section 4, "Information about donations to the Project Gutenberg Literary
+      Archive Foundation." - You provide a full refund of any money paid by a
+      user who notifies you in writing (or by e-mail) within 30 days of receipt
+      that s/he does not agree to the terms of the full Project Gutenberg-tm
+      License. You must require such a user to return or destroy all copies of
+      the works possessed in a physical medium and discontinue all use of and
+      all access to other copies of Project Gutenberg-tm works. - You provide,
+      in accordance with paragraph 1.F.3, a full refund of any money paid for a
+      work or a replacement copy, if a defect in the electronic work is
+      discovered and reported to you within 90 days of receipt of the work. -
+      You comply with all other terms of this agreement for free distribution of
+      Project Gutenberg-tm works. 1.E.9. If you wish to charge a fee or
+      distribute a Project Gutenberg-tm electronic work or group of works on
+      different terms than are set forth in this agreement, you must obtain
+      permission in writing from both the Project Gutenberg Literary Archive
+      Foundation and Michael Hart, the owner of the Project Gutenberg-tm
+      trademark. Contact the Foundation as set forth in Section 3 below. 1.F.
+      1.F.1. Project Gutenberg volunteers and employees expend considerable
+      effort to identify, do copyright research on, transcribe and proofread
+      public domain works in creating the Project Gutenberg-tm collection.
+      Despite these efforts, Project Gutenberg-tm electronic works, and the
+      medium on which they may be stored, may contain "Defects," such as, but
+      not limited to, incomplete, inaccurate or corrupt data, transcription
+      errors, a copyright or other intellectual property infringement, a
+      defective or damaged disk or other medium, a computer virus, or computer
+      codes that damage or cannot be read by your equipment. 1.F.2. LIMITED
+      WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right of Replacement or
+      Refund" described in paragraph 1.F.3, the Project Gutenberg Literary
+      Archive Foundation, the owner of the Project Gutenberg-tm trademark, and
+      any other party distributing a Project Gutenberg-tm electronic work under
+      this agreement, disclaim all liability to you for damages, costs and
+      expenses, including legal fees. YOU AGREE THAT YOU HAVE NO REMEDIES FOR
+      NEGLIGENCE, STRICT LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT
+      EXCEPT THOSE PROVIDED IN PARAGRAPH F3. YOU AGREE THAT THE FOUNDATION, THE
+      TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+      LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+      INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+      DAMAGE. 1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+      defect in this electronic work within 90 days of receiving it, you can
+      receive a refund of the money (if any) you paid for it by sending a
+      written explanation to the person you received the work from. If you
+      received the work on a physical medium, you must return the medium with
+      your written explanation. The person or entity that provided you with the
+      defective work may elect to provide a replacement copy in lieu of a
+      refund. If you received the work electronically, the person or entity
+      providing it to you may choose to give you a second opportunity to receive
+      the work electronically in lieu of a refund. If the second copy is also
+      defective, you may demand a refund in writing without further
+      opportunities to fix the problem. 1.F.4. Except for the limited right of
+      replacement or refund set forth in paragraph 1.F.3, this work is provided
+      to you 'AS-IS' WITH NO OTHER WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED,
+      INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR
+      ANY PURPOSE. 1.F.5. Some states do not allow disclaimers of certain
+      implied warranties or the exclusion or limitation of certain types of
+      damages. If any disclaimer or limitation set forth in this agreement
+      violates the law of the state applicable to this agreement, the agreement
+      shall be interpreted to make the maximum disclaimer or limitation
+      permitted by the applicable state law. The invalidity or unenforceability
+      of any provision of this agreement shall not void the remaining
+      provisions. 1.F.6. INDEMNITY - You agree to indemnify and hold the
+      Foundation, the trademark owner, any agent or employee of the Foundation,
+      anyone providing copies of Project Gutenberg-tm electronic works in
+      accordance with this agreement, and any volunteers associated with the
+      production, promotion and distribution of Project Gutenberg-tm electronic
+      works, harmless from all liability, costs and expenses, including legal
+      fees, that arise directly or indirectly from any of the following which
+      you do or cause to occur: (a) distribution of this or any Project
+      Gutenberg-tm work, (b) alteration, modification, or additions or deletions
+      to any Project Gutenberg-tm work, and (c) any Defect you cause. Section 2.
+      Information about the Mission of Project Gutenberg-tm Project Gutenberg-tm
+      is synonymous with the free distribution of electronic works in formats
+      readable by the widest variety of computers including obsolete, old,
+      middle-aged and new computers. It exists because of the efforts of
+      hundreds of volunteers and donations from people in all walks of life.
+      Volunteers and financial support to provide volunteers with the assistance
+      they need, is critical to reaching Project Gutenberg-tm's goals and
+      ensuring that the Project Gutenberg-tm collection will remain freely
+      available for generations to come. In 2001, the Project Gutenberg Literary
+      Archive Foundation was created to provide a secure and permanent future
+      for Project Gutenberg-tm and future generations. To learn more about the
+      Project Gutenberg Literary Archive Foundation and how your efforts and
+      donations can help, see Sections 3 and 4 and the Foundation web page at
+      http://www.pglaf.org. Section 3. Information about the Project Gutenberg
+      Literary Archive Foundation The Project Gutenberg Literary Archive
+      Foundation is a non profit 501(c)(3) educational corporation organized
+      under the laws of the state of Mississippi and granted tax exempt status
+      by the Internal Revenue Service. The Foundation's EIN or federal tax
+      identification number is 64-6221541. Its 501(c)(3) letter is posted at
+      http://pglaf.org/fundraising. Contributions to the Project Gutenberg
+      Literary Archive Foundation are tax deductible to the full extent
+      permitted by U.S. federal laws and your state's laws. The Foundation's
+      principal office is located at 4557 Melan Dr. S. Fairbanks, AK, 99712.,
+      but its volunteers and employees are scattered throughout numerous
+      locations. Its business office is located at 809 North 1500 West, Salt
+      Lake City, UT 84116, (801) 596-1887, email business@pglaf.org. Email
+      contact links and up to date contact information can be found at the
+      Foundation's web site and official page at http://pglaf.org For additional
+      contact information: Dr. Gregory B. Newby Chief Executive and Director
+      gbnewby@pglaf.org Section 4. Information about Donations to the Project
+      Gutenberg Literary Archive Foundation Project Gutenberg-tm depends upon
+      and cannot survive without wide spread public support and donations to
+      carry out its mission of increasing the number of public domain and
+      licensed works that can be freely distributed in machine readable form
+      accessible by the widest array of equipment including outdated equipment.
+      Many small donations ($1 to $5,000) are particularly important to
+      maintaining tax exempt status with the IRS. The Foundation is committed to
+      complying with the laws regulating charities and charitable donations in
+      all 50 states of the United States. Compliance requirements are not
+      uniform and it takes a considerable effort, much paperwork and many fees
+      to meet and keep up with these requirements. We do not solicit donations
+      in locations where we have not received written confirmation of
+      compliance. To SEND DONATIONS or determine the status of compliance for
+      any particular state visit http://pglaf.org While we cannot and do not
+      solicit contributions from states where we have not met the solicitation
+      requirements, we know of no prohibition against accepting unsolicited
+      donations from donors in such states who approach us with offers to
+      donate. International donations are gratefully accepted, but we cannot
+      make any statements concerning tax treatment of donations received from
+      outside the United States. U.S. laws alone swamp our small staff. Please
+      check the Project Gutenberg Web pages for current donation methods and
+      addresses. Donations are accepted in a number of other ways including
+      including checks, online payments and credit card donations. To donate,
+      please visit: http://pglaf.org/donate Section 5. General Information About
+      Project Gutenberg-tm electronic works. Professor Michael S. Hart is the
+      originator of the Project Gutenberg-tm concept of a library of electronic
+      works that could be freely shared with anyone. For thirty years, he
+      produced and distributed Project Gutenberg-tm eBooks with only a loose
+      network of volunteer support. Project Gutenberg-tm eBooks are often
+      created from several printed editions, all of which are confirmed as
+      Public Domain in the U.S. unless a copyright notice is included. Thus, we
+      do not necessarily keep eBooks in compliance with any particular paper
+      edition. Most people start at our Web site which has the main PG search
+      facility: http://www.gutenberg.net This Web site includes information
+      about Project Gutenberg-tm, including how to make donations to the Project
+      Gutenberg Literary Archive Foundation, how to help produce our new eBooks,
+      and how to subscribe to our email newsletter to hear about new eBooks.
+    </p>
+  {{{ hypothesisScript }}}
+  </body>
+</html>

--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -38,6 +38,7 @@
           configuration option enabled</a></li>
       <li><a href="/document/doyle-tiny"><i>The Disappearance of Lady Carfax</i> with tiny (10px) root font size in host page</a></li>
       <li><a href="/document/doyle-huge"><i>The Disappearance of Lady Carfax</i> with huge (24px) root font size in host page</a></li>
+      <li><a href="/document/doyle-centered"><i>The Disappearance of Lady Carfax</i> with a centered, max-width body</a></li>
     </ul>
 
     <h3>VitalSource test documents</h3>


### PR DESCRIPTION
This PR adds a test HTML document to the dev server that:

* Uses `margin-left:auto` and `margin-right:auto` to center the `body`
* Sets a `max-width` on the `body`

This echoes the layout of some Great Books EPUBs provided by VitalSource (and maybe some others). e.g. https://bookshelf.vitalsource.com/reader/books/L-999-70867/epubcfi/6/2[idloc_000.xhtml-itemref]!/4[eid1]/2[eid2]%4050:4

(It's also not an uncommon layout approach web-wide).

It can be used to test how HTML side-by-side affects auto-centered margins. I'll open a corresponding issue to explain.