### PR TITLE
Do not move body to the right when enabling HTML side-by-side

### DIFF
--- a/src/annotator/integrations/test/html-test.js
+++ b/src/annotator/integrations/test/html-test.js
@@ -178,6 +178,96 @@ describe('HTMLIntegration', () => {
         integration.fitSideBySide({ expanded: false });
         assert.deepEqual(getMargins(), [null, null]);
       });
+
+      context('main content area has margin:auto', () => {
+        const bodyWidth = 400;
+        const autoMargin = Math.floor((window.innerWidth - bodyWidth) / 2);
+
+        function getComputedMargins(element) {
+          const leftMargin = Math.floor(
+            parseInt(window.getComputedStyle(element).marginLeft, 10)
+          );
+          const rightMargin = Math.floor(
+            parseInt(window.getComputedStyle(element).marginRight, 10)
+          );
+          return [leftMargin, rightMargin];
+        }
+
+        // Add a style node to set a max-width and auto margins on the body
+        function appendBodyStyles(document_) {
+          const el = document_.createElement('style');
+          el.type = 'text/css';
+          el.textContent = `body { margin: 0 auto; max-width: ${bodyWidth}px }`;
+          el.classList.add('js-style-test');
+          document_.body.appendChild(el);
+        }
+
+        before(() => {
+          appendBodyStyles(document);
+        });
+
+        after(() => {
+          // Remove test styles
+          const elements = document.querySelectorAll('.js-style-test');
+          for (let i = 0; i < elements.length; i++) {
+            elements[i].remove();
+          }
+        });
+
+        beforeEach(() => {
+          // In these tests, we're treating the body element as the
+          // main content area.
+          //
+          // `guessMainContent` area is called _after_ a right margin is set
+          // on the body, so we'll return here the updated computed left and
+          // right position of the body to emulate a real-life result
+          fakeGuessMainContentArea.callsFake(bodyEl => {
+            const margins = getComputedMargins(bodyEl);
+            return { left: margins[0], right: window.innerWidth - margins[1] };
+          });
+        });
+
+        it('should not move the main content to the right', () => {
+          const integration = createIntegration();
+          // Before enabling side-by-side, the horizontal margins on the body
+          // are derived based on `margin: auto` in the stylesheet
+          assert.deepEqual(getComputedMargins(document.body), [
+            autoMargin,
+            autoMargin,
+          ]);
+
+          // Will result in a right margin of 112px (100 + 12 padding)
+          integration.fitSideBySide({ expanded: true, width: 100 });
+
+          // Without intervention, the left margin would have _increased_ to
+          // balance out the remaining space, that is:
+          // innerWidth - bodyWidth - 112 > 200
+          //
+          // To prevent content jumping to the right, implementation sets left
+          // margin to original auto margin
+          assert.deepEqual(getComputedMargins(document.body), [
+            autoMargin,
+            112,
+          ]);
+        });
+
+        it('may move the main content to the left to make room for sidebar', () => {
+          const integration = createIntegration();
+
+          // Will result in right margin of 262 (250 + 12 padding)
+          integration.fitSideBySide({ expanded: true, width: 250 });
+
+          // The amount of space available to the left of the body is now _less_
+          // than the original auto-left-margin. This is fine: let the auto
+          // margin re-adjust to the available amount of space (move to the left):
+          const updatedMargins = getComputedMargins(document.body);
+          const expectedLeftMargin = Math.floor(
+            window.innerWidth - bodyWidth - 262
+          );
+          assert.equal(updatedMargins[0], expectedLeftMargin);
+          assert.isBelow(updatedMargins[0], autoMargin);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This ~~draft~~ PR proposes a ~~possible~~ fix for https://github.com/hypothesis/client/issues/4280 in which body left margin can jump to the right in certain cases when enabling HTML side-by-side mode.

## To Test

* Turn the HTML side-by-side "feature flag" on in `annotator/integrations/html`
* Visit http://localhost:3000/document/doyle-centered in the local dev server and toggle the sidebar off and on. Resize the window and otherwise play around a bit.

On this branch, the content (body's) left margin adjusts as you'd intuitively expect and doesn't jump to the right.

On `master`, the body (content) jumps to the right when the sidebar is opened.

Fixes https://github.com/hypothesis/client/issues/4280