### PR TITLE
Add `typecheck-no-any` to `lint` target in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ endif
 lint: node_modules/.uptodate
 	yarn run lint
 	yarn run typecheck
+	yarn run typecheck-no-any
 
 .PHONY: docs
 docs: python


### PR DESCRIPTION
I got thrown today because I was getting a linting/typecheck error on CI but couldn't reproduce locally until I remembered that `yarn typecheck` and `yarn typecheck-no-any` are separate scripts in `package.json`.

That's fine, makes sense, but I'd like it to be a little easier to run both locally. To wit I've updated the `lint` target of the `Makefile`, which is in turn used by `make sure` (which I rely on).