### PR TITLE
Establish minimum threshold for HTML and VitalSource PDF side-by-side

### DIFF
--- a/src/annotator/integrations/html.js
+++ b/src/annotator/integrations/html.js
@@ -13,6 +13,11 @@ import { scrollElementIntoView } from '../util/scroll';
  * @typedef {import('../../types/annotator').SidebarLayout} SidebarLayout
  */
 
+// When activating side-by-side mode, make sure there is at least this amount
+// of space (in pixels) left for the document's content. Any narrower and the
+// content line lengths and scale are too short to be readable.
+const MIN_HTML_WIDTH = 480;
+
 /**
  * Document type integration for ordinary web pages.
  *
@@ -54,11 +59,14 @@ export class HTMLIntegration {
    * @param {SidebarLayout} layout
    */
   fitSideBySide(layout) {
+    const maximumWidthToFit = window.innerWidth - layout.width;
+    const active = layout.expanded && maximumWidthToFit >= MIN_HTML_WIDTH;
+
     if (!this.sideBySideEnabled) {
       return false;
     }
 
-    if (layout.expanded) {
+    if (active) {
       this._activateSideBySide(layout.width);
       return true;
     } else {

--- a/src/annotator/integrations/test/html-test.js
+++ b/src/annotator/integrations/test/html-test.js
@@ -128,6 +128,16 @@ describe('HTMLIntegration', () => {
         assert.deepEqual(getMargins(), [padding, sidebarWidth + padding]);
       });
 
+      it('does not set left and right margins if there is not enough room to enable', () => {
+        const integration = createIntegration();
+
+        // Minimum available content width for side-by-side is 480
+        // window.innerWidth (800) - 321 = 479 --> too small
+        integration.fitSideBySide({ expanded: true, width: 321 });
+
+        assert.deepEqual(getMargins(), [null, null]);
+      });
+
       it('allows sidebar to overlap non-main content on the side of the page', () => {
         const integration = createIntegration();
 

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -413,7 +413,8 @@ describe('annotator/integrations/vitalsource', () => {
 
           // Activate side-by-side mode. Page image should be resized to fit
           // alongside sidebar.
-          const sidebarWidth = 150;
+          // Minimum threshold for enabling side-by-side mode is 480px
+          const sidebarWidth = window.innerWidth - 481;
           const expectedWidth = window.innerWidth - sidebarWidth;
           integration.fitSideBySide({ expanded: true, width: sidebarWidth });
           assert.equal(fakePageImage.parentElement.style.textAlign, 'left');
@@ -431,7 +432,8 @@ describe('annotator/integrations/vitalsource', () => {
           createPageImageAndData();
           const integration = createIntegration();
 
-          const sidebarWidth = window.innerWidth - 200;
+          // This will leave less than 480px available to the main content
+          const sidebarWidth = window.innerWidth - 479;
           integration.fitSideBySide({ expanded: true, width: sidebarWidth });
           assert.equal(fakePageImage.parentElement.style.textAlign, '');
           assert.equal(fakePageImage.style.width, '');

--- a/src/annotator/integrations/vitalsource.js
+++ b/src/annotator/integrations/vitalsource.js
@@ -13,6 +13,11 @@ import { injectClient } from '../hypothesis-injector';
  * @typedef {import('../../types/annotator').SidebarLayout} SidebarLayout
  */
 
+// When activating side-by-side mode for VitalSource PDF documents, make sure
+// at least this much space (in pixels) is left for the PDF document. Any
+// smaller and it feels unreadable or too-zoomed-out
+const MIN_CONTENT_WIDTH = 480;
+
 /**
  * Return the custom DOM element that contains the book content iframe.
  */
@@ -303,10 +308,9 @@ export class VitalSourceContentIntegration {
       // Update the PDF image size and alignment to fit alongside the sidebar.
       // `ImageTextLayer` will handle adjusting the text layer to match.
       const newWidth = window.innerWidth - layout.width;
-      const minWidth = 250;
 
       preserveScrollPosition(() => {
-        if (layout.expanded && newWidth > minWidth) {
+        if (layout.expanded && newWidth > MIN_CONTENT_WIDTH) {
           // The VS book viewer sets `text-align: center` on the <body> element
           // by default, which centers the book image in the page. When the sidebar
           // is open we need the image to be left-aligned.


### PR DESCRIPTION
This PR attempts to find an appropriate minimum content-width threshold for enabling side-by-side mode in HTML (as used by VitalSource EPUB) and VitalSource PDF content integrations.

At present I've landed on `576` (in pixels) for a plausible value[^1]. *This is very much up for debate*. I felt that this was the minimum size at which content still felt usable and readable. I encourage experimentation. You'll need to build the local extension to try this out with VitalSource PDF documents. You can flip on the HTML side-by-side feature flag to try it locally for HTML files.

Fixes https://github.com/hypothesis/client/issues/4300

[^1]: ~36 characters (minimum; in reality more with variable-width font) when font-size 100%/1rem — this is too short for an ideal line length, which should be 50-75 chars, but it's...tolerable