### PR TITLE
Increase timeout in test

### DIFF
--- a/src/annotator/test/integration/hypothesis-injector-test.js
+++ b/src/annotator/test/integration/hypothesis-injector-test.js
@@ -25,7 +25,7 @@ describe('HypothesisInjector integration test', () => {
   // Wait for `HypothesisInjector.injectClient` to finish injecting the client
   // into the page.
   async function waitForInjectClient(frame) {
-    await waitFor(() => getHypothesisScript(frame));
+    await waitFor(() => getHypothesisScript(frame), 100 /* timeout */);
   }
 
   function getHypothesisScript(iframe) {


### PR DESCRIPTION
`waitFor` has a short default timeout of 10ms and this test sometimes
failed in CI. Try increasing it to reduce flakiness. We might want to
consider changing the `waitFor` default in future, although we also want
to encourage test authors to avoid writing tests that frequently wait
for long (> 10ms) periods of time.