### PR TITLE
Ignore fixed-positioned content which choosing a scroll anchor

### DIFF
--- a/src/annotator/integrations/test/html-side-by-side-test.js
+++ b/src/annotator/integrations/test/html-side-by-side-test.js
@@ -163,6 +163,40 @@ the fighting was.`;
       );
     });
 
+    it('ignores fixed-position content when choosing a scroll anchor', () => {
+      // Set up a DOM structure that emulates a page with a sticky heading:
+      //
+      // <div> // Scroll root
+      //   <div> // Inner container
+      //     <nav> // Fixed-position navbar
+      //     <p>..</p> // Content
+      //   </div>
+      // </div>
+      //
+      // Here the `<nav>` contains the top-left most text node in the viewport,
+      // but we should it because of its fixed position.
+      //
+      // The inner container is used to check that the element filtering is
+      // applied as the DOM tree is recursively traversed.
+      const nav = document.createElement('nav');
+      nav.style.position = 'fixed';
+      nav.style.left = '0px';
+      nav.style.top = '0px';
+      nav.textContent = 'Some heading';
+      const inner = document.createElement('div');
+      inner.append(nav, content);
+      scrollRoot.append(inner);
+
+      scrollRoot.scrollTop = 200;
+      const delta = preserveScrollPosition(() => {
+        scrollRoot.style.width = '150px';
+      }, scrollRoot);
+
+      // The scroll position should be adjusted. This would be zero if the
+      // text in the <nav> element was used as a scroll anchor.
+      assert.notEqual(delta, 0);
+    });
+
     it('does not restore the scroll position if no anchor content could be found', () => {
       // Fill content with empty text, which cannot be used as a scroll anchor.
       content.textContent = ' '.repeat(documentText.length);


### PR DESCRIPTION
When choosing a scroll anchor to preserve the visible content after toggling
side-by-side mode in HTML documents, ignore content in elements with `position: fixed` or `position: sticky` styles, since this content won't significantly shift its position as a result of the document content being resized.

A typical scenario where this matters is a website with a `position: sticky` or `position: fixed` navbar. For example, on [this article](https://www.theatlantic.com/ideas/archive/2022/02/social-media-illness-teen-girls/622916/) I found that the "Sign in" and "Subscribe" links in the navbar were chosen as scroll anchors, and so the visible content in the document was not preserved as the sidebar was opened and closed. The new behavior on this page is better than before, though still not perfect, as text which is _under_ the navbar can still be chosen as a scroll anchor. We'd ideally choose only text which is visible to the user.