### PR TITLE
Catch mouseup/mousedown events earlier in SelectionObserver

### DIFF
--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -225,7 +225,7 @@ describe('annotator/integrations/vitalsource', () => {
     it('stops mouse events from propagating to parent frame', () => {
       createIntegration();
 
-      const events = ['mousedown', 'mouseup', 'mouseout'];
+      const events = ['mouseup', 'mouseout'];
 
       for (let eventName of events) {
         const listener = sinon.stub();

--- a/src/annotator/integrations/vitalsource.js
+++ b/src/annotator/integrations/vitalsource.js
@@ -214,12 +214,10 @@ export class VitalSourceContentIntegration {
     // from showing its native selection menu, which obscures the client's
     // annotation toolbar.
     //
-    // VitalSource only checks the selection on the `mouseup` and `mouseout` events,
-    // but we also need to stop `mousedown` to prevent the client's `SelectionObserver`
-    // from thinking that the mouse is held down when a selection change occurs.
-    // This has the unwanted side effect of allowing the adder to appear while
-    // dragging the mouse.
-    const stopEvents = ['mousedown', 'mouseup', 'mouseout'];
+    // To avoid interfering with the client's own selection handling, this
+    // event blocking must happen at the same level or higher in the DOM tree
+    // than where SelectionObserver listens.
+    const stopEvents = ['mouseup', 'mouseout'];
     for (let event of stopEvents) {
       this._listeners.add(document.documentElement, event, e => {
         e.stopPropagation();

--- a/src/annotator/selection-observer.js
+++ b/src/annotator/selection-observer.js
@@ -42,7 +42,7 @@ export class SelectionObserver {
     };
 
     /** @param {Event} event */
-    this._eventHandler = event => {
+    const eventHandler = event => {
       if (event.type === 'mousedown') {
         isMouseDown = true;
       }
@@ -76,10 +76,13 @@ export class SelectionObserver {
 
     this._document = document_;
     this._listeners = new ListenerCollection();
-    this._events = ['mousedown', 'mouseup', 'selectionchange'];
-    for (let event of this._events) {
-      this._listeners.add(document_, event, this._eventHandler);
-    }
+
+    this._listeners.add(document_, 'selectionchange', eventHandler);
+
+    // Mouse events are handled on the body because propagation may be stopped
+    // before they reach the document in some environments (eg. VitalSource).
+    this._listeners.add(document_.body, 'mousedown', eventHandler);
+    this._listeners.add(document_.body, 'mouseup', eventHandler);
 
     // Report the initial selection.
     scheduleCallback(1);


### PR DESCRIPTION
Listen for mouseup/mousedown events on the document body rather than document
itself, so that we can still capture them if an event listener on
`document.body` or `document.documentElement` stops propagation of the event.
The VitalSource integration does this for example to prevent VitalSource's own
selection UI appearing, but ordinary web pages could do something similar.

In VitalSource books, this change makes the adder behave the same as it does in
HTML and PDF documents where, when making a selection with the mouse, the adder
only appears when the mouse is released so it doesn't get in the way during the
selection.

While updating the tests for this change, they were converted to use a real
document, as the complexity of mocking the relevant parts of the DOM document
interface accurately is now too high.