### PR TITLE
Make JSTOR logo open link in a new tab

### DIFF
--- a/src/annotator/components/ContentPartnerBanner.js
+++ b/src/annotator/components/ContentPartnerBanner.js
@@ -16,7 +16,7 @@ export default function ContentPartnerBanner({ provider, onClose }) {
     <div className="flex items-center border-b gap-x-4 px-2 py-1 bg-white text-annotator-lg">
       {provider === 'jstor' && (
         <>
-          <Link href="https://jstor.org">
+          <Link href="https://jstor.org" target="_blank">
             <Icon
               classes="w-[97px] h-[25px]"
               name="jstor"


### PR DESCRIPTION
In the context of our LMS app, this banner is displayed inside a nested
iframe, so it is important to open the link in a new tab.