### PR TITLE
Revert mousedown propagation change

### DIFF
--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -225,7 +225,7 @@ describe('annotator/integrations/vitalsource', () => {
     it('stops mouse events from propagating to parent frame', () => {
       createIntegration();
 
-      const events = ['mouseup', 'mouseout'];
+      const events = ['mouseup', 'mousedown', 'mouseout'];
 
       for (let eventName of events) {
         const listener = sinon.stub();

--- a/src/annotator/integrations/vitalsource.js
+++ b/src/annotator/integrations/vitalsource.js
@@ -217,7 +217,7 @@ export class VitalSourceContentIntegration {
     // To avoid interfering with the client's own selection handling, this
     // event blocking must happen at the same level or higher in the DOM tree
     // than where SelectionObserver listens.
-    const stopEvents = ['mouseup', 'mouseout'];
+    const stopEvents = ['mouseup', 'mousedown', 'mouseout'];
     for (let event of stopEvents) {
       this._listeners.add(document.documentElement, event, e => {
         e.stopPropagation();


### PR DESCRIPTION
Revert the mousedown propagation change from e70287cfac7eccfea518cb8671865151e9639087.
In order to prevent VitalSource's own text selection highlight from
appearing, it is necessary to stop propagation of both mouseup and
mousedown events.

I must have made a mistake when testing the change in VS originally.