### PR TITLE
Refactor internal helpers used by `createStore`

### DIFF
--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -85,8 +85,7 @@ import { immutable } from '../util/immutable';
  * Create a Redux reducer from a store module's reducer map.
  *
  * @template State
- * @param {Record<string, (s: State, a: redux.Action) => Partial<State>>} reducers -
- *   Map of reducers from a store module.
+ * @param {ReducerMap<State>} reducers
  */
 function createReducer(reducers) {
   /** @param {redux.Action} action */

--- a/src/sidebar/store/test/create-store-test.js
+++ b/src/sidebar/store/test/create-store-test.js
@@ -8,8 +8,8 @@ function initialState(value = 0) {
   return { count: value };
 }
 
-const modules = [
-  // namespaced module A
+// Store modules that have the same state but under difference namespaces.
+const counterModules = [
   createStoreModule(initialState, {
     namespace: 'a',
 
@@ -41,7 +41,6 @@ const modules = [
     },
   }),
 
-  // namespaced module B
   createStoreModule(initialState, {
     namespace: 'b',
 
@@ -68,8 +67,71 @@ const modules = [
   }),
 ];
 
+// Store module whose state is an array.
+const tagsModule = createStoreModule([], {
+  namespace: 'tags',
+
+  reducers: {
+    ADD_TAG(state, action) {
+      return [...state, action.tag];
+    },
+  },
+
+  actionCreators: {
+    addTag(tag) {
+      return { type: 'ADD_TAG', tag };
+    },
+  },
+
+  selectors: {
+    getTags(state) {
+      return state;
+    },
+  },
+});
+
+// Store module with reducers that update only a subset of the state.
+const groupsModule = createStoreModule(
+  {
+    currentGroup: null,
+    groups: [],
+  },
+  {
+    namespace: 'groups',
+
+    reducers: {
+      ADD_GROUP(state, action) {
+        return { groups: [...state.groups, action.group] };
+      },
+
+      SELECT_GROUP(state, action) {
+        return { currentGroup: action.id };
+      },
+    },
+
+    actionCreators: {
+      addGroup(group) {
+        return { type: 'ADD_GROUP', group };
+      },
+      selectGroup(id) {
+        return { type: 'SELECT_GROUP', id };
+      },
+    },
+
+    selectors: {
+      allGroups(state) {
+        return state.groups;
+      },
+
+      currentGroup(state) {
+        return state.groups.find(g => g.id === state.currentGroup);
+      },
+    },
+  }
+);
+
 function counterStore(initArgs = [], middleware = []) {
-  return createStore(modules, initArgs, middleware);
+  return createStore(counterModules, initArgs, middleware);
 }
 
 describe('createStore', () => {
@@ -107,20 +169,20 @@ describe('createStore', () => {
 
   it('adds selectors as methods to the store', () => {
     const store = counterStore();
-    store.dispatch(modules[A].actionCreators.incrementA(5));
+    store.dispatch(counterModules[A].actionCreators.incrementA(5));
     assert.equal(store.getCountA(), 5);
   });
 
   it('adds root selectors as methods to the store', () => {
     const store = counterStore();
-    store.dispatch(modules[A].actionCreators.incrementA(5));
+    store.dispatch(counterModules[A].actionCreators.incrementA(5));
     assert.equal(store.getCountAFromRoot(), 5);
   });
 
   it('applies `thunk` middleware by default', () => {
     const store = counterStore();
     const doubleAction = (dispatch, getState) => {
-      dispatch(modules[A].actionCreators.incrementA(getState().a.count));
+      dispatch(counterModules[A].actionCreators.incrementA(getState().a.count));
     };
 
     store.incrementA(5);
@@ -183,6 +245,32 @@ describe('createStore', () => {
     });
     const store = createStore([module]);
     assert.equal(store.getState().test.value, 42);
+  });
+
+  it('supports modules whose state is an array', () => {
+    const store = createStore([tagsModule]);
+    assert.deepEqual(store.getTags(), []);
+    store.addTag('tag-1');
+    store.addTag('tag-2');
+    assert.deepEqual(store.getTags(), ['tag-1', 'tag-2']);
+  });
+
+  it('combines state updates from reducers with initial module state', () => {
+    const store = createStore([groupsModule]);
+
+    const group1 = { id: 'g1', name: 'Test group 1' };
+    const group2 = { id: 'g2', name: 'Test group 2' };
+
+    // Trigger reducers which update different module state. For this to work
+    // the result of each reducer must be combined with existing state.
+    store.addGroup(group1);
+    store.addGroup(group2);
+
+    store.selectGroup('g1');
+    assert.deepEqual(store.currentGroup(), group1);
+
+    store.selectGroup('g2');
+    assert.deepEqual(store.currentGroup(), group2);
   });
 
   if (process.env.NODE_ENV !== 'production') {

--- a/src/sidebar/store/test/create-store-test.js
+++ b/src/sidebar/store/test/create-store-test.js
@@ -273,6 +273,56 @@ describe('createStore', () => {
     assert.deepEqual(store.currentGroup(), group2);
   });
 
+  it('throws if two store modules define the same selector', () => {
+    const moduleA = createStoreModule(
+      {},
+      {
+        namespace: 'a',
+        reducers: {},
+        actionCreators: {},
+        selectors: { testSelector() {} },
+      }
+    );
+    const moduleB = createStoreModule(
+      {},
+      {
+        namespace: 'b',
+        reducers: {},
+        actionCreators: {},
+        selectors: { testSelector() {} },
+      }
+    );
+    assert.throws(
+      () => createStore([moduleA, moduleB]),
+      "Cannot add duplicate 'testSelector' property to object"
+    );
+  });
+
+  it('throws if two store modules define the same action', () => {
+    const moduleA = createStoreModule(
+      {},
+      {
+        namespace: 'a',
+        reducers: {},
+        actionCreators: { testAction() {} },
+        selectors: {},
+      }
+    );
+    const moduleB = createStoreModule(
+      {},
+      {
+        namespace: 'b',
+        reducers: {},
+        actionCreators: { testAction() {} },
+        selectors: {},
+      }
+    );
+    assert.throws(
+      () => createStore([moduleA, moduleB]),
+      "Cannot add duplicate 'testAction' property to object"
+    );
+  });
+
   if (process.env.NODE_ENV !== 'production') {
     it('freezes store state in development builds', () => {
       const store = counterStore();

--- a/src/sidebar/store/test/create-store-test.js
+++ b/src/sidebar/store/test/create-store-test.js
@@ -2,8 +2,6 @@
 
 import { createStore, createStoreModule } from '../create-store';
 
-const A = 0;
-
 function initialState(value = 0) {
   return { count: value };
 }
@@ -169,20 +167,20 @@ describe('createStore', () => {
 
   it('adds selectors as methods to the store', () => {
     const store = counterStore();
-    store.dispatch(counterModules[A].actionCreators.incrementA(5));
+    store.dispatch(counterModules[0].actionCreators.incrementA(5));
     assert.equal(store.getCountA(), 5);
   });
 
   it('adds root selectors as methods to the store', () => {
     const store = counterStore();
-    store.dispatch(counterModules[A].actionCreators.incrementA(5));
+    store.dispatch(counterModules[0].actionCreators.incrementA(5));
     assert.equal(store.getCountAFromRoot(), 5);
   });
 
   it('applies `thunk` middleware by default', () => {
     const store = counterStore();
     const doubleAction = (dispatch, getState) => {
-      dispatch(counterModules[A].actionCreators.incrementA(getState().a.count));
+      dispatch(counterModules[0].actionCreators.incrementA(getState().a.count));
     };
 
     store.incrementA(5);

--- a/src/sidebar/store/test/util-test.js
+++ b/src/sidebar/store/test/util-test.js
@@ -1,48 +1,12 @@
 import { fakeReduxStore } from '../../test/fake-redux-store';
 
-import * as util from '../util';
-
-const fixtures = {
-  update: {
-    ADD_ANNOTATIONS: function (state, action) {
-      if (!state.annotations) {
-        return { annotations: action.annotations };
-      }
-      return { annotations: state.annotations.concat(action.annotations) };
-    },
-    SELECT_TAB: function (state, action) {
-      return { tab: action.tab };
-    },
-  },
-  selectors: {
-    namespace1: {
-      selectors: {
-        countAnnotations1: localState => localState.annotations.length,
-      },
-
-      rootSelectors: {
-        rootCountAnnotations1: rootState =>
-          rootState.namespace1.annotations.length,
-      },
-    },
-    namespace2: {
-      selectors: {
-        countAnnotations2: localState => localState.annotations.length,
-      },
-
-      rootSelectors: {
-        rootCountAnnotations2: rootState =>
-          rootState.namespace2.annotations.length,
-      },
-    },
-  },
-};
+import { actionTypes, awaitStateChange } from '../util';
 
 describe('sidebar/store/util', () => {
   describe('actionTypes', () => {
     it('returns an object with values equal to keys', () => {
       assert.deepEqual(
-        util.actionTypes({
+        actionTypes({
           SOME_ACTION: sinon.stub(),
           ANOTHER_ACTION: sinon.stub(),
         }),
@@ -54,143 +18,7 @@ describe('sidebar/store/util', () => {
     });
   });
 
-  describe('createReducer', () => {
-    it('returns an object if input state is undefined', () => {
-      // See redux.js:assertReducerShape in the "redux" package.
-      const reducer = util.createReducer(fixtures.update);
-      const initialState = reducer(undefined, {
-        type: 'DUMMY_ACTION',
-      });
-      assert.isOk(initialState);
-    });
-
-    it('returns a reducer that combines each update function from the input object', () => {
-      const reducer = util.createReducer(fixtures.update);
-      const newState = reducer(
-        {},
-        {
-          type: 'ADD_ANNOTATIONS',
-          annotations: [{ id: 1 }],
-        }
-      );
-      assert.deepEqual(newState, {
-        annotations: [{ id: 1 }],
-      });
-    });
-
-    it('returns a new object if the action was handled', () => {
-      const reducer = util.createReducer(fixtures.update);
-      const originalState = { someFlag: false };
-      assert.notEqual(
-        reducer(originalState, { type: 'SELECT_TAB', tab: 'notes' }),
-        originalState
-      );
-    });
-
-    it('returns the original object if the action was not handled', () => {
-      const reducer = util.createReducer(fixtures.update);
-      const originalState = { someFlag: false };
-      assert.equal(
-        reducer(originalState, { type: 'UNKNOWN_ACTION' }),
-        originalState
-      );
-    });
-
-    it('preserves state not modified by the update function', () => {
-      const reducer = util.createReducer(fixtures.update);
-      const newState = reducer(
-        { otherFlag: false },
-        {
-          type: 'ADD_ANNOTATIONS',
-          annotations: [{ id: 1 }],
-        }
-      );
-      assert.deepEqual(newState, {
-        otherFlag: false,
-        annotations: [{ id: 1 }],
-      });
-    });
-
-    it('supports reducer functions that return an array', () => {
-      const action = {
-        type: 'FIRST_ITEM',
-        item: 'bar',
-      };
-      const addItem = {
-        FIRST_ITEM(state, action) {
-          // Concatenate the array with a new item.
-          return [...state, action.item];
-        },
-      };
-      const reducer = util.createReducer(addItem);
-      const newState = reducer(['foo'], action);
-      assert.equal(newState.length, 2);
-    });
-  });
-
-  describe('bindSelectors', () => {
-    it('binds selectors to current value of module state', () => {
-      const getState = sinon.stub().returns({
-        namespace1: {
-          annotations: [{ id: 1 }],
-        },
-        namespace2: {
-          annotations: [{ id: 2 }],
-        },
-      });
-      const bound = util.bindSelectors(fixtures.selectors, getState);
-      assert.equal(bound.countAnnotations1(), 1);
-      assert.equal(bound.countAnnotations2(), 1);
-    });
-
-    it('binds root selectors to current value of root state', () => {
-      const getState = sinon.stub().returns({
-        namespace1: {
-          annotations: [{ id: 1 }],
-        },
-        namespace2: {
-          annotations: [{ id: 2 }],
-        },
-      });
-      const bound = util.bindSelectors(fixtures.selectors, getState);
-      assert.equal(bound.rootCountAnnotations1(), 1);
-      assert.equal(bound.rootCountAnnotations2(), 1);
-    });
-
-    it('throws an error if selector names in different modules conflict', () => {
-      const getState = () => ({});
-      assert.throws(() => {
-        util.bindSelectors(
-          {
-            moduleA: {
-              selectors: { someSelector: () => {} },
-            },
-            moduleB: {
-              selectors: { someSelector: () => {} },
-            },
-          },
-          getState
-        );
-      }, 'Duplicate selector "someSelector"');
-    });
-
-    it('throws an error if selector names in different modules conflict', () => {
-      const getState = () => ({});
-      assert.throws(() => {
-        util.bindSelectors(
-          {
-            moduleA: {
-              selectors: { someSelector: () => {} },
-              rootSelectors: { someSelector: () => {} },
-            },
-          },
-          getState
-        );
-      });
-    });
-  });
-
-  describe('awaitStateChange()', () => {
+  describe('awaitStateChange', () => {
     let store;
 
     beforeEach(() => {
@@ -209,11 +37,9 @@ describe('sidebar/store/util', () => {
     it('should return promise that resolves to a non-null value', () => {
       const expected = 5;
       store.setState({ val: 5 });
-      return util
-        .awaitStateChange(store, getValWhenGreaterThanTwo)
-        .then(actual => {
-          assert.equal(actual, expected);
-        });
+      return awaitStateChange(store, getValWhenGreaterThanTwo).then(actual => {
+        assert.equal(actual, expected);
+      });
     });
 
     it('should wait for awaitStateChange to return a non-null value', () => {
@@ -221,7 +47,7 @@ describe('sidebar/store/util', () => {
       const expected = 5;
 
       store.setState({ val: 2 });
-      valPromise = util.awaitStateChange(store, getValWhenGreaterThanTwo);
+      valPromise = awaitStateChange(store, getValWhenGreaterThanTwo);
       store.setState({ val: 5 });
 
       return valPromise.then(actual => {

--- a/src/sidebar/store/util.js
+++ b/src/sidebar/store/util.js
@@ -15,66 +15,6 @@ export function actionTypes(reducers) {
 }
 
 /**
- * Create a standard Redux reducer function from a map of action types to reducers.
- *
- * @template {object} State
- * @param {Record<string, (s: State, action: any) => Partial<State>>} reducers -
- *   Object mapping action types to reducer functions. The result of the
- *   reducer is merged with the existing state.
- */
-export function createReducer(reducers) {
-  return (state = /** @type {State} */ ({}), action) => {
-    const reducer = reducers[action.type];
-    if (!reducer) {
-      return state;
-    }
-    const stateChanges = reducer(state, action);
-
-    // Some modules return an array rather than an object. They need to be
-    // handled differently so we don't convert them to an object.
-    if (Array.isArray(stateChanges)) {
-      return stateChanges;
-    }
-
-    return {
-      // @ts-expect-error - TS isn't certain `state` is spreadable here. Trust us!
-      ...state,
-      ...stateChanges,
-    };
-  };
-}
-
-/**
- * Takes a mapping of namespaced modules and the store's `getState()` function
- * and returns an aggregated flat object with all the selectors at the root
- * level. The keys to this object are functions that call the original
- * selectors with the `state` argument set to the current value of `getState()`.
- */
-export function bindSelectors(namespaces, getState) {
-  const boundSelectors = {};
-  Object.keys(namespaces).forEach(namespace => {
-    const { selectors, rootSelectors = {} } = namespaces[namespace];
-
-    Object.keys(selectors).forEach(selector => {
-      if (boundSelectors[selector]) {
-        throw new Error(`Duplicate selector "${selector}"`);
-      }
-      boundSelectors[selector] = (...args) =>
-        selectors[selector](getState()[namespace], ...args);
-    });
-
-    Object.keys(rootSelectors).forEach(selector => {
-      if (boundSelectors[selector]) {
-        throw new Error(`Duplicate selector "${selector}"`);
-      }
-      boundSelectors[selector] = (...args) =>
-        rootSelectors[selector](getState(), ...args);
-    });
-  });
-  return boundSelectors;
-}
-
-/**
  * Return a value from app state when it meets certain criteria.
  *
  * `await` returns a Promise which resolves when a selector function,

--- a/src/tsconfig.no-any.json
+++ b/src/tsconfig.no-any.json
@@ -29,6 +29,7 @@
     "shared/**/*.js",
     "sidebar/config/*.js",
     "sidebar/helpers/*.js",
+    "sidebar/store/create-store.js",
     "sidebar/util/*.js",
     "types/*.d.ts"
   ],


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/4328.**~~

Refactor the `createStore` implementation by moving two internal helpers, `bindSelectors` and `createReducer`, into the same module as the `createStore` function itself, and rewriting the tests to check the relevant behavior of `createStore` rather than testing the helpers directly.

This decouples the tests from internal implementation details, adds missing types to these helpers, and makes the implementation of `createStore` easier to grok by putting all the logic closer together.