### PR TITLE
Refactor `buildSettings` internals and add RPCSettings to settings

### DIFF
--- a/src/sidebar/config/build-settings.js
+++ b/src/sidebar/config/build-settings.js
@@ -5,7 +5,9 @@ import * as postMessageJsonRpc from '../util/postmessage-json-rpc';
 /**
  * @typedef {import('../../types/config').ConfigFromHost} ConfigFromHost
  * @typedef {import('../../types/config').ConfigFromSidebar} ConfigFromSidebar
+ * @typedef {import('../../types/config').RPCSettings} RPCSettings
  * @typedef {import('../../types/config').SidebarSettings} SidebarSettings
+ * @typedef {import('../../types/config').Service['groups']} ServiceGroups
  */
 
 /**
@@ -29,81 +31,98 @@ function getAncestorFrame(levels, window_ = window) {
 }
 
 /**
- * Merge client configuration from h service with config from the hash fragment.
+ * Which groups to load and show in the sidebar may be dictated in
+ * ConfigFromHost configuration: the special value `$rpc:requestGroups`
+ * indicates that the list of groups should be requested asynchronously.
  *
- * @param {ConfigFromSidebar} appConfig - App config settings rendered into `app.html` by the h service.
- * @param {ConfigFromHost} hostPageConfig - App configuration specified by the embedding frame.
- * @return {SidebarSettings} - The merged settings.
+ * This function (maybe) mutates values in the provided `configFromHost`'s
+ * ServiceGroups: `$rpc:requestGroups` values are replaced with
+ * `Promise<string[]>`.
+ *
+ * @see ServiceGroups
+ *
+ * @param {ConfigFromHost} configFromHost
+ * @param {RPCSettings} rpcSettings
+ * @returns {ConfigFromHost}
  */
-function fetchConfigEmbed(appConfig, hostPageConfig) {
-  const sidebarSettings = {
-    ...appConfig,
-    ...hostPageConfig,
-  };
-  sidebarSettings.apiUrl = getApiUrl(sidebarSettings);
-  return sidebarSettings;
+function fetchServiceGroups(configFromHost, rpcSettings) {
+  const services = configFromHost.services;
+  if (!Array.isArray(services)) {
+    return configFromHost;
+  }
+  services.forEach((service, index) => {
+    if (service.groups === '$rpc:requestGroups') {
+      // The `groups` need to be fetched from a secondary RPC call and
+      // there should be no timeout as it may be waiting for user input.
+      service.groups = postMessageJsonRpc
+        .call(
+          rpcSettings.targetFrame,
+          rpcSettings.origin,
+          'requestGroups',
+          [index],
+          0 // no timeout
+        )
+        .catch(() => {
+          throw new Error('Unable to fetch groups');
+        });
+    }
+  });
+  return configFromHost;
 }
 
 /**
- * Merge client configuration from h service with config fetched from
- * a parent frame asynchronously.
+ * Derive RPC settings from the provided `ConfigFromHost`, if any are present.
  *
- * Use this method to retrieve the config asynchronously from a parent
- * frame via RPC. See tests for more details.
- *
- * @param {ConfigFromSidebar} appConfig - Settings rendered into `app.html` by the h service.
- * @param {Window} parentFrame - Frame to send call to.
- * @param {string} origin - Origin filter for `window.postMessage` call.
- * @return {Promise<SidebarSettings>} - The merged settings.
+ * @param {ConfigFromHost} configFromHost
+ * @param {Window} window_
+ * @return {import('../../types/config').RPCSettings|null}
  */
-async function fetchConfigRpc(appConfig, parentFrame, origin) {
-  const remoteConfig = await postMessageJsonRpc.call(
-    parentFrame,
-    origin,
+function buildRPCSettings(configFromHost, window_) {
+  const rpcConfig = configFromHost.requestConfigFromFrame;
+  if (!rpcConfig) {
+    return null;
+  } else if (
+    typeof rpcConfig.ancestorLevel !== 'number' ||
+    typeof rpcConfig.origin !== 'string'
+  ) {
+    throw new Error(
+      'Improper `requestConfigFromFrame` object. Both `ancestorLevel` and `origin` need to be specified'
+    );
+  }
+  return {
+    targetFrame: getAncestorFrame(rpcConfig.ancestorLevel, window_),
+    origin: rpcConfig.origin,
+  };
+}
+
+/**
+ * Retrieve ConfigFromHost to use for settings from the ancestor frame indicated
+ * in `rpcSettings`
+ *
+ * @param {ConfigFromHost} hostConfigFromURL
+ * @param {RPCSettings} rpcSettings
+ * @return {Promise<ConfigFromHost>}
+ */
+async function getHostConfigByRPC(hostConfigFromURL, rpcSettings) {
+  const hostConfigFromFrame = await postMessageJsonRpc.call(
+    rpcSettings.targetFrame,
+    rpcSettings.origin,
     'requestConfig',
     [],
     3000
   );
-  /**
-   * @param {string} method
-   * @param {any[]} args
-   */
-  const rpcCall = (method, args = [], timeout = 3000) =>
-    postMessageJsonRpc.call(parentFrame, origin, method, args, timeout);
-  const sidebarSettings = fetchConfigEmbed(appConfig, remoteConfig);
-  return fetchGroupsAsync(sidebarSettings, rpcCall);
-}
 
-/**
- * Potentially mutates the `groups` config object(s) to be a promise that
- * resolves right away if the `groups` value exists in the original
- * config, or returns a promise that resolves with a secondary RPC
- * call to `requestGroups` when the `groups` value is '$rpc:requestGroups'
- * If the `groups` value is missing or falsely then it won't be mutated.
- *
- * This allows the app to start with an incomplete config and then lazily
- * fill in the `groups` value(s) later when its ready. This helps speed
- * up the loading process.
- *
- * @param {SidebarSettings} config - The configuration object to mutate. This should
- *  already have the `services` value
- * @param {function} rpcCall - RPC method
- *  (method, args, timeout) => Promise
- * @return {Promise<SidebarSettings>} - The mutated settings
- */
-async function fetchGroupsAsync(config, rpcCall) {
-  if (Array.isArray(config.services)) {
-    config.services.forEach((service, index) => {
-      if (service.groups === '$rpc:requestGroups') {
-        // The `groups` need to be fetched from a secondary RPC call and
-        // there should be no timeout as it may be waiting for user input.
-        service.groups = rpcCall('requestGroups', [index], null).catch(() => {
-          throw new Error('Unable to fetch groups');
-        });
-      }
-    });
-  }
-  return config;
+  // In the case where the appropriate `ConfigFromHost` is sourced from another
+  // frame by RPC, the original `ConfigFromHost` (`hostConfigFromURL`) is
+  // discarded.
+  //
+  // The `group` property, however, is currently not available in the remote
+  // `ConfigFromHost` and needs to be restored. This property is used by the
+  // Notebook.
+  return {
+    ...hostConfigFromFrame,
+    ...(hostConfigFromURL.group ? { group: hostConfigFromURL.group } : {}),
+  };
 }
 
 /**
@@ -111,47 +130,42 @@ async function fetchGroupsAsync(config, rpcCall) {
  * with `ConfigFromHost` from an appropriate source.
  *
  * `ConfigFromHost` may come from either:
- *  - The URL hash of the iframe, written by the annotator when creating the
- *    sidebar's iframe, OR
- *  - By sending an RPC request for host configuration to a known ancestor frame
+ *  - The URL framgent of the sidebar's iframe src, written by the annotator
+ *    when creating the sidebar's iframe, OR
+ *  - By sending an RPC request for host configuration to a designated ancestor
+ *    frame (This is used in the LMS context)
  *
- * @param {ConfigFromSidebar} appConfig
- * @param {Window} window_ - Test seam.
- * @return {Promise<SidebarSettings>} - The merged settings.
+ * @param {ConfigFromSidebar} configFromSidebar
+ * @param {Window} window_ - Test seam
+ * @return {Promise<SidebarSettings>} - The merged settings
  */
-export async function buildSettings(appConfig, window_ = window) {
-  const hostConfig = hostPageConfig(window);
+export async function buildSettings(configFromSidebar, window_ = window) {
+  const hostConfigFromURL = hostPageConfig(window);
 
-  const requestConfigFromFrame = hostConfig.requestConfigFromFrame;
-
-  if (!requestConfigFromFrame) {
-    // Directly embed: just get the config.
-    return fetchConfigEmbed(appConfig, hostConfig);
-  }
-  if (
-    typeof requestConfigFromFrame.ancestorLevel === 'number' &&
-    typeof requestConfigFromFrame.origin === 'string'
-  ) {
-    // Know parent frame: send RPC directly to the parent.
-    const parentFrame = getAncestorFrame(
-      requestConfigFromFrame.ancestorLevel,
-      window_
+  const rpcSettings = buildRPCSettings(hostConfigFromURL, window_);
+  let configFromHost;
+  if (rpcSettings) {
+    // The presence of RPCSettings indicates that we should
+    // source the ConfigFromHost from another frame, and potentially load
+    // the correct groups asynchronously as well.
+    const hostConfigFromFrame = await getHostConfigByRPC(
+      hostConfigFromURL,
+      rpcSettings
     );
-
-    const rpcSidebarSettings = await fetchConfigRpc(
-      appConfig,
-      parentFrame,
-      requestConfigFromFrame.origin
-    );
-    // Add back the optional focused group id from the host page config
-    // as this is needed in the Notebook.
-    return {
-      ...rpcSidebarSettings,
-      ...(hostConfig.group ? { group: hostConfig.group } : {}),
-    };
+    configFromHost = fetchServiceGroups(hostConfigFromFrame, rpcSettings);
   } else {
-    throw new Error(
-      'Improper `requestConfigFromFrame` object. Both `ancestorLevel` and `origin` need to be specified'
-    );
+    configFromHost = hostConfigFromURL;
   }
+
+  /** @type {SidebarSettings} */
+  const sidebarSettings = {
+    ...configFromSidebar,
+    ...configFromHost,
+  };
+  if (rpcSettings) {
+    sidebarSettings.rpc = rpcSettings;
+  }
+  sidebarSettings.apiUrl = getApiUrl(sidebarSettings);
+
+  return sidebarSettings;
 }

--- a/src/types/config.js
+++ b/src/types/config.js
@@ -88,11 +88,19 @@
  */
 
 /**
+ * RPC settings derived from `ConfigFromHost['requestConfigFromFrame']`
+ *
+ * @typedef RPCSettings
+ * @prop {Window} targetFrame
+ * @prop {RequestConfigFromFrameOptions['origin']} origin
+ */
+
+/**
  * The `settings` object used in the sidebar app that is a result of merging
  * (filtered and validated) configuration from the host page with configuration
  * from h / the browser extension.
  *
- * @typedef {ConfigFromHost & ConfigFromSidebar} SidebarSettings
+ * @typedef {ConfigFromHost & ConfigFromSidebar & { rpc?: RPCSettings }} SidebarSettings
  */
 
 // Make TypeScript treat this file as a module.


### PR DESCRIPTION
This PR is primarily concerned with refactoring the internal logic in `build-settings` module to be less ambiguous and more amenable to extension. The only outward-facing changes is that some information pertaining to making RPC requests is now retained on a new `RPCSettings` object that is part of `SidebarSettings`. We will need to "persist" information about which frame and origin to make RPC requests at (in settings) to be able to communicate about annotation activity to the LMS app to support improved Canvas grading submissions.

Part of https://github.com/hypothesis/lms/issues/3647

~~Depends on #4351 (that one's ready to go, just held up by GitHub outages today, will deploy in the morning)~~