### PR TITLE
Build and load annotator bundle as a non-module script

### DIFF
--- a/dev-server/documents/html/xhtml-test.mustache
+++ b/dev-server/documents/html/xhtml-test.mustache
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>XHTML test document</title>
+    <style>
+      body {
+        font-size: 1rem;
+        line-height: 1.5rem;
+      }
+      main {
+        max-width: 500px;
+        margin-left: 50px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>XHTML test document</h1>
+    <main>
+      <p>
+        This is an
+        <a href="https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/XHTML"
+          >XHTML</a
+        >
+        test document. Note that browser behavior when processing an XHTML
+        document depends not only on the content itself but also the
+        <code>Content-Type</code> header that the document is served with. This
+        document should be served with the correct
+        <code>application/xhtml+xml</code> MIME type. See
+        <a
+          href="https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/XHTML#xhtml_document"
+          >this MDN article</a
+        >
+        for details.
+      </p>
+      <h2>Test content from <em>Heart of Darkness</em></h2>
+      <p>
+        <i
+          >This is some content that allows testing scrolling functionality, as
+          that had problems with XHTML at one point.</i
+        >
+      </p>
+      <p>
+        The Nellie, a cruising yawl, swung to her anchor without a flutter of
+        the sails, and was at rest. The flood had made, the wind was nearly
+        calm, and being bound down the river, the only thing for it was to come
+        to and wait for the turn of the tide.
+      </p>
+
+      <p>
+        The sea-reach of the Thames stretched before us like the beginning of an
+        interminable waterway. In the offing the sea and the sky were welded
+        together without a joint, and in the luminous space the tanned sails of
+        the barges drifting up with the tide seemed to stand still in red
+        clusters of canvas sharply peaked, with gleams of varnished sprits. A
+        haze rested on the low shores that ran out to sea in vanishing flatness.
+        The air was dark above Gravesend, and farther back still seemed
+        condensed into a mournful gloom, brooding motionless over the biggest,
+        and the greatest, town on earth.
+      </p>
+
+      <p>
+        The Director of Companies was our captain and our host. We four
+        affectionately watched his back as he stood in the bows looking to
+        seaward. On the whole river there was nothing that looked half so
+        nautical. He resembled a pilot, which to a seaman is trustworthiness
+        personified. It was difficult to realize his work was not out there in
+        the luminous estuary, but behind him, within the brooding gloom.
+      </p>
+
+      <p>
+        Between us there was, as I have already said somewhere, the bond of the
+        sea. Besides holding our hearts together through long periods of
+        separation, it had the effect of making us tolerant of each other’s
+        yarns—and even convictions. The Lawyer—the best of old fellows—had,
+        because of his many years and many virtues, the only cushion on deck,
+        and was lying on the only rug. The Accountant had brought out already a
+        box of dominoes, and was toying architecturally with the bones. Marlow
+        sat cross-legged right aft, leaning against the mizzen-mast. He had
+        sunken cheeks, a yellow complexion, a straight back, an ascetic aspect,
+        and, with his arms dropped, the palms of hands outwards, resembled an
+        idol. The director, satisfied the anchor had good hold, made his way aft
+        and sat down amongst us. We exchanged a few words lazily. Afterwards
+        there was silence on board the yacht. For some reason or other we did
+        not begin that game of dominoes. We felt meditative, and fit for nothing
+        but placid staring. The day was ending in a serenity of still and
+        exquisite brilliance. The water shone pacifically; the sky, without a
+        speck, was a benign immensity of unstained light; the very mist on the
+        Essex marsh was like a gauzy and radiant fabric, hung from the wooded
+        rises inland, and draping the low shores in diaphanous folds. Only the
+        gloom to the west, brooding over the upper reaches, became more sombre
+        every minute, as if angered by the approach of the sun.
+      </p>
+
+      <p>
+        And at last, in its curved and imperceptible fall, the sun sank low, and
+        from glowing white changed to a dull red without rays and without heat,
+        as if about to go out suddenly, stricken to death by the touch of that
+        gloom brooding over a crowd of men.
+      </p>
+
+      <p>...</p>
+    </main>
+    {{{ hypothesisScript }}}
+  </body>
+</html>

--- a/dev-server/serve-dev.js
+++ b/dev-server/serve-dev.js
@@ -106,6 +106,15 @@ function serveDev(port, config) {
 
   // Serve HTML documents with injected client script
   app.get('/document/:document', (req, res, next) => {
+    // All HTML documents are served with the `text/html` mime type by default,
+    // even though some declare themselves to be XHTML. This mirrors how most
+    // content on the web is served. However we do have some test pages that
+    // need to be served with the correct XHTML mime type, as that alters
+    // browser behavior. See https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/XHTML.
+    if (req.params.document.startsWith('xhtml-')) {
+      res.set('Content-Type', 'application/xhtml+xml');
+    }
+
     if (fs.existsSync(`${HTML_PATH}${req.params.document}.mustache`)) {
       res.render(req.params.document, templateContext(config));
     } else {

--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -39,6 +39,7 @@
       <li><a href="/document/doyle-tiny"><i>The Disappearance of Lady Carfax</i> with tiny (10px) root font size in host page</a></li>
       <li><a href="/document/doyle-huge"><i>The Disappearance of Lady Carfax</i> with huge (24px) root font size in host page</a></li>
       <li><a href="/document/doyle-centered"><i>The Disappearance of Lady Carfax</i> with a centered, max-width body</a></li>
+      <li><a href="/document/xhtml-test">XHTML document (served with XHTML mime type)</a></li>
     </ul>
 
     <h3>VitalSource test documents</h3>

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -38,7 +38,7 @@ if (isProd) {
   );
 }
 
-function bundleConfig({ name, entry }) {
+function bundleConfig({ name, entry, format = 'es' }) {
   return {
     input: {
       [name]: entry,
@@ -47,6 +47,7 @@ function bundleConfig({ name, entry }) {
       dir: 'build/scripts/',
       chunkFileNames: `${name}-[name].bundle.js`,
       entryFileNames: '[name].bundle.js',
+      format,
       sourcemap: true,
 
       // Rewrite source paths from "../../src/path/to/module.js" to
@@ -97,7 +98,20 @@ function bundleConfig({ name, entry }) {
 }
 
 export default [
-  bundleConfig({ name: 'annotator', entry: 'src/annotator/index.js' }),
+  bundleConfig({
+    name: 'annotator',
+    entry: 'src/annotator/index.js',
+
+    // The annotator bundle is created as a non-module script because module
+    // scripts are not supported in Safari in XHTML documents.
+    // See https://github.com/hypothesis/client/issues/4350#issuecomment-1079101754.
+    //
+    // Non-module scripts also re-evaluate if they are added to the page multiple
+    // times, which is important if the client is unloaded and then re-loaded
+    // into a page, although that is possible to work around with a module script
+    // by changing the URL fragment each time.
+    format: 'iife',
+  }),
   bundleConfig({ name: 'sidebar', entry: 'src/sidebar/index.js' }),
   bundleConfig({
     name: 'ui-playground',

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -1,6 +1,6 @@
 import { bootHypothesisClient, bootSidebarApp, $imports } from '../boot';
 
-function assetUrl(url) {
+function assetURL(url) {
   return `https://marginal.ly/client/build/${url}`;
 }
 
@@ -74,16 +74,16 @@ describe('bootstrap', () => {
     const scripts = Array.from(
       doc_.querySelectorAll('script[data-hypothesis-asset]')
     ).map(el => {
-      return el.src;
+      return { src: el.src, type: el.type === 'module' ? 'module' : 'script' };
     });
 
     const styles = Array.from(
       doc_.querySelectorAll('link[rel="stylesheet"][data-hypothesis-asset]')
     ).map(el => {
-      return el.href;
+      return { src: el.href, type: 'stylesheet' };
     });
 
-    return scripts.concat(styles).sort();
+    return scripts.concat(styles).sort((a, b) => a.src.localeCompare(b.src));
   }
 
   describe('bootHypothesisClient', () => {
@@ -102,9 +102,9 @@ describe('bootstrap', () => {
 
       runBoot('annotator');
       const expectedAssets = [
-        'scripts/annotator.bundle.1234.js#ts=123',
-        'styles/highlights.1234.css',
-      ].map(assetUrl);
+        { src: assetURL('scripts/annotator.bundle.1234.js'), type: 'script' },
+        { src: assetURL('styles/highlights.1234.css'), type: 'stylesheet' },
+      ];
 
       assert.deepEqual(findAssets(iframe.contentDocument), expectedAssets);
     });
@@ -116,10 +116,13 @@ describe('bootstrap', () => {
       try {
         runBoot('annotator');
         const expectedAssets = [
-          'scripts/annotator.bundle.1234.js#ts=123',
-          'styles/highlights.1234.css',
-          'styles/pdfjs-overrides.1234.css',
-        ].map(assetUrl);
+          { src: assetURL('scripts/annotator.bundle.1234.js'), type: 'script' },
+          { src: assetURL('styles/highlights.1234.css'), type: 'stylesheet' },
+          {
+            src: assetURL('styles/pdfjs-overrides.1234.css'),
+            type: 'stylesheet',
+          },
+        ];
 
         assert.deepEqual(findAssets(iframe.contentDocument), expectedAssets);
       } finally {
@@ -174,11 +177,14 @@ describe('bootstrap', () => {
       runBoot('annotator');
 
       const polyfillsLoaded = findAssets(iframe.contentDocument).filter(a =>
-        a.match(/polyfills/)
+        a.src.match(/polyfills/)
       );
       assert.called(fakePolyfills.requiredPolyfillSets);
       assert.deepEqual(polyfillsLoaded, [
-        assetUrl('scripts/polyfills-es2017.bundle.1234.js#ts=0'),
+        {
+          src: assetURL('scripts/polyfills-es2017.bundle.1234.js'),
+          type: 'script',
+        },
       ]);
     });
   });
@@ -187,10 +193,10 @@ describe('bootstrap', () => {
     it('loads assets for the sidebar application', () => {
       runBoot('sidebar');
       const expectedAssets = [
-        'scripts/sidebar.bundle.1234.js',
-        'styles/katex.min.1234.css',
-        'styles/sidebar.1234.css',
-      ].map(assetUrl);
+        { src: assetURL('scripts/sidebar.bundle.1234.js'), type: 'module' },
+        { src: assetURL('styles/katex.min.1234.css'), type: 'stylesheet' },
+        { src: assetURL('styles/sidebar.1234.css'), type: 'stylesheet' },
+      ];
 
       assert.deepEqual(findAssets(iframe.contentDocument), expectedAssets);
     });
@@ -222,11 +228,14 @@ describe('bootstrap', () => {
       runBoot('sidebar');
 
       const polyfillsLoaded = findAssets(iframe.contentDocument).filter(a =>
-        a.match(/polyfills/)
+        a.src.match(/polyfills/)
       );
       assert.called(fakePolyfills.requiredPolyfillSets);
       assert.deepEqual(polyfillsLoaded, [
-        assetUrl('scripts/polyfills-es2017.bundle.1234.js'),
+        {
+          src: assetURL('scripts/polyfills-es2017.bundle.1234.js'),
+          type: 'module',
+        },
       ]);
     });
   });


### PR DESCRIPTION
Safari does not support loading module scripts in XHTML pages that are served
with the "application/xhtml" mime type [1]. This is very rare on the open web (XHTML
is rare and XHTML documents served with "application/xhtml" as opposed to
"text/html" as the MIME type are rarer still [2]) but more common in ebooks.

There is [open issue for Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=717643) that says it has the same issue, yet in practice it seems that the client does load properly in Chrome and Firefox on an XHTML page. See https://github.com/hypothesis/client/issues/4350#issuecomment-1079101754 for some test pages.

[1] https://bugs.webkit.org/show_bug.cgi?id=227469
[2] https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/XHTML#xhtml_document

---

**TODO:**

- [x] Add some notes about testing this locally with Safari (see https://github.com/hypothesis/client/pull/4353#issuecomment-1080741721)
