### PR TITLE
Allow for whitespace differences between page text and text layer

### DIFF
--- a/src/annotator/util/normalize.js
+++ b/src/annotator/util/normalize.js
@@ -1,0 +1,79 @@
+/**
+ * Find the smallest offset in `str` which contains at least `count` chars
+ * that match `filter` before it.
+ *
+ * @param {string} str
+ * @param {number} count
+ * @param {(char: string) => boolean} filter
+ * @param {number} [startPos]
+ */
+function advance(str, count, filter, startPos = 0) {
+  let pos = startPos;
+  while (pos < str.length && count > 0) {
+    if (filter(str[pos])) {
+      --count;
+    }
+    ++pos;
+  }
+  return pos;
+}
+
+/**
+ * Count characters which match `filter` in `str`.
+ *
+ * @param {string} str
+ * @param {(char: string) => boolean} filter
+ * @param {number} startPos
+ * @param {number} endPos
+ */
+function countChars(str, filter, startPos, endPos) {
+  let count = 0;
+  for (let pos = startPos; pos < endPos; pos++) {
+    if (filter(str[pos])) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+/**
+ * Translate a (start, end) pair of offsets in an input string to corresponding
+ * offsets in an output string, where positions in the input and output strings
+ * are related by counting the number of preceding characters that pass a
+ * filter.
+ *
+ * In typical usage, the output string is a corrupted version of the input
+ * string, where characters that do not match the filter (eg. whitespace)
+ * have been inserted or deleted at arbitrary locations.
+ *
+ * Where there are multiple possible offsets in the output string that
+ * correspond to the input offsets, the largest start offset and smallest end
+ * offset are chosen.
+ *
+ * @example
+ *   // Input offsets specify the substring "bc" in the input. Result specifies
+ *   // the corresponding "b c" substring in the output.
+ *   translateOffsets('abcd', ' a b c d ', 1, 3, char => char !== ' ')
+ *
+ * @param {string} inputStr
+ * @param {string} outputStr
+ * @param {number} start - Start offset in `inputStr`
+ * @param {number} end - End offset in `inputStr`
+ * @param {(ch: string) => boolean} filter
+ * @return {[number, number]} - Start and end offsets in `outputStr`
+ */
+export function translateOffsets(inputStr, outputStr, start, end, filter) {
+  const startCount = countChars(inputStr, filter, 0, start);
+  const startToEndCount = countChars(inputStr, filter, start, end);
+
+  // Find smallest offset with `startCount` matching chars before it in output,
+  // then adjust to the largest such offset.
+  let outStart = advance(outputStr, startCount, filter);
+  while (outStart < outputStr.length && !filter(outputStr[outStart])) {
+    ++outStart;
+  }
+
+  const outEnd = advance(outputStr, startToEndCount, filter, outStart);
+
+  return [outStart, outEnd];
+}

--- a/src/annotator/util/normalize.js
+++ b/src/annotator/util/normalize.js
@@ -37,43 +37,47 @@ function countChars(str, filter, startPos, endPos) {
 }
 
 /**
- * Translate a (start, end) pair of offsets in an input string to corresponding
- * offsets in an output string, where positions in the input and output strings
- * are related by counting the number of preceding characters that pass a
- * filter.
+ * Translate a (start, end) pair of offsets for an "input" string into
+ * corresponding offsets in an "output" string.
  *
- * In typical usage, the output string is a corrupted version of the input
- * string, where characters that do not match the filter (eg. whitespace)
- * have been inserted or deleted at arbitrary locations.
+ * Positions in the input and output strings are related by counting
+ * the number of "important" characters before them, as determined by a
+ * filter function.
+ *
+ * An example usage would be to find equivalent positions in two strings which
+ * contain the same text content except for the addition or removal of
+ * whitespace at arbitrary locations in the output string.
  *
  * Where there are multiple possible offsets in the output string that
  * correspond to the input offsets, the largest start offset and smallest end
  * offset are chosen.
  *
  * @example
- *   // Input offsets specify the substring "bc" in the input. Result specifies
- *   // the corresponding "b c" substring in the output.
+ *   // The input offsets (1, 3) select the substring "bc" in the "input" argument.
+ *   // The returned offsets select the substring "b c" in the "output" argument.
  *   translateOffsets('abcd', ' a b c d ', 1, 3, char => char !== ' ')
  *
- * @param {string} inputStr
- * @param {string} outputStr
- * @param {number} start - Start offset in `inputStr`
- * @param {number} end - End offset in `inputStr`
- * @param {(ch: string) => boolean} filter
- * @return {[number, number]} - Start and end offsets in `outputStr`
+ * @param {string} input
+ * @param {string} output
+ * @param {number} start - Start offset in `input`
+ * @param {number} end - End offset in `input`
+ * @param {(ch: string) => boolean} filter - Filter function that returns true
+ *   if a character should be counted when relating positions between `input`
+ *   and `output`.
+ * @return {[number, number]} - Start and end offsets in `output`
  */
-export function translateOffsets(inputStr, outputStr, start, end, filter) {
-  const startCount = countChars(inputStr, filter, 0, start);
-  const startToEndCount = countChars(inputStr, filter, start, end);
+export function translateOffsets(input, output, start, end, filter) {
+  const beforeStartCount = countChars(input, filter, 0, start);
+  const startToEndCount = countChars(input, filter, start, end);
 
   // Find smallest offset with `startCount` matching chars before it in output,
   // then adjust to the largest such offset.
-  let outStart = advance(outputStr, startCount, filter);
-  while (outStart < outputStr.length && !filter(outputStr[outStart])) {
-    ++outStart;
+  let outputStart = advance(output, beforeStartCount, filter);
+  while (outputStart < output.length && !filter(output[outputStart])) {
+    ++outputStart;
   }
 
-  const outEnd = advance(outputStr, startToEndCount, filter, outStart);
+  const outputEnd = advance(output, startToEndCount, filter, outputStart);
 
-  return [outStart, outEnd];
+  return [outputStart, outputEnd];
 }

--- a/src/annotator/util/normalize.js
+++ b/src/annotator/util/normalize.js
@@ -50,7 +50,8 @@ function countChars(str, filter, startPos, endPos) {
  *
  * Where there are multiple possible offsets in the output string that
  * correspond to the input offsets, the largest start offset and smallest end
- * offset are chosen.
+ * offset are chosen. In other words, leading and trailing ignored characters
+ * are trimmed from the output.
  *
  * @example
  *   // The input offsets (1, 3) select the substring "bc" in the "input" argument.
@@ -70,13 +71,19 @@ export function translateOffsets(input, output, start, end, filter) {
   const beforeStartCount = countChars(input, filter, 0, start);
   const startToEndCount = countChars(input, filter, start, end);
 
-  // Find smallest offset with `startCount` matching chars before it in output,
-  // then adjust to the largest such offset.
+  // Find smallest offset in `output` with same number of non-ignored characters
+  // before it as before `start` in the input. This offset might correspond to
+  // an ignored character.
   let outputStart = advance(output, beforeStartCount, filter);
+
+  // Increment this offset until it points to a non-ignored character. This
+  // "trims" leading ignored characters from the result.
   while (outputStart < output.length && !filter(output[outputStart])) {
     ++outputStart;
   }
 
+  // Find smallest offset in `output` with same number of non-ignored characters
+  // before it as before `end` in the input.
   const outputEnd = advance(output, startToEndCount, filter, outputStart);
 
   return [outputStart, outputEnd];

--- a/src/annotator/util/test/normalize-test.js
+++ b/src/annotator/util/test/normalize-test.js
@@ -110,5 +110,26 @@ describe('annotator/util/normalize', () => {
       assert.equal(outStart, outStr.indexOf('c'));
       assert.equal(outEnd, outStart);
     });
+
+    it('does not return offsets beyond output string length', () => {
+      const inStr = 'foo bar baz';
+      const start = inStr.indexOf('bar');
+      const end = start + 'bar'.length;
+
+      const outStrs = ['', 'foo   b', 'fooba'];
+      for (let outStr of outStrs) {
+        const [outStart, outEnd] = translateOffsets(
+          inStr,
+          outStr,
+          start,
+          end,
+          isNotSpace
+        );
+        const outSubStr = outStr.slice(outStart, outEnd);
+        assert.equal(outSubStr, inStr.slice(start, start + outSubStr.length));
+        assert.isAtMost(outStart, outStr.length);
+        assert.isAtMost(outEnd, outStr.length);
+      }
+    });
   });
 });

--- a/src/annotator/util/test/normalize-test.js
+++ b/src/annotator/util/test/normalize-test.js
@@ -1,0 +1,114 @@
+import { translateOffsets } from '../normalize';
+
+const isNotSpace = str => /\S/.test(str);
+
+describe('annotator/util/normalize', () => {
+  describe('translateOffsets', () => {
+    [
+      // Strings with no ignored chars
+      {
+        inStr: 'abcd',
+        outStr: 'abcd',
+        inMatch: 'abcd',
+        outMatch: 'abcd',
+      },
+      // Strings with some ignored chars
+      {
+        inStr: '   ab    cd  ',
+        outStr: ' a   b  c   d ',
+        inMatch: 'ab    cd',
+        outMatch: 'a   b  c   d',
+      },
+      {
+        inStr: ' foo   bar\nbaz',
+        outStr: 'foob  arbaz',
+        inMatch: 'bar',
+        outMatch: 'b  ar',
+      },
+    ].forEach(({ inStr, outStr, inMatch, outMatch }, index) => {
+      it(`returns translated offsets (${index})`, () => {
+        const start = inStr.indexOf(inMatch);
+        assert.notEqual(start, -1, 'Input substring not found');
+        const end = start + inMatch.length;
+
+        const expectedStart = outStr.indexOf(outMatch);
+        assert.notEqual(expectedStart, -1, 'Output substring not found');
+        const expectedEnd = expectedStart + outMatch.length;
+
+        const [outStart, outEnd] = translateOffsets(
+          inStr,
+          outStr,
+          start,
+          end,
+          isNotSpace
+        );
+
+        assert.equal(outStart, expectedStart, 'Incorrect start offset');
+        assert.equal(outEnd, expectedEnd, 'Incorrect end offset');
+      });
+    });
+
+    it('returns offsets at end of string if input contains only ignored chars', () => {
+      const inStr = '     ';
+      const outStr = inStr;
+      const [outStart, outEnd] = translateOffsets(
+        inStr,
+        outStr,
+        0,
+        5,
+        isNotSpace
+      );
+      assert.equal(outStart, 5);
+      assert.equal(outEnd, 5);
+    });
+
+    it('handles start offsets < 0', () => {
+      const inStr = 'abcd';
+      const outStr = '  a      bcd';
+      const start = -3;
+      const end = inStr.length;
+      const [outStart, outEnd] = translateOffsets(
+        inStr,
+        outStr,
+        start,
+        end,
+        isNotSpace
+      );
+      assert.equal(outStart, outStr.indexOf('a'));
+      assert.equal(outEnd, outStr.indexOf('d') + 1);
+    });
+
+    it('handles end offsets greater than string length', () => {
+      const inStr = 'abcd';
+      const outStr = '  a      bcd';
+      const start = inStr.indexOf('c');
+      const end = inStr.length + 5;
+      const [outStart, outEnd] = translateOffsets(
+        inStr,
+        outStr,
+        start,
+        end,
+        isNotSpace
+      );
+      assert.equal(outStart, outStr.indexOf('c'));
+      assert.equal(outEnd, outStr.indexOf('d') + 1);
+    });
+
+    it('returns equal offsets if start/end input offsets are equal', () => {
+      const inStr = 'abcd';
+      const outStr = 'a b c d';
+      const start = inStr.indexOf('c');
+
+      const [outStart, outEnd] = translateOffsets(
+        inStr,
+        outStr,
+        start,
+        start,
+        isNotSpace
+      );
+
+      assert.equal(outStart, outStr.indexOf('c'));
+      assert.equal(outEnd, outStart);
+    });
+  });
+});

--- a/src/types/pdfjs.js
+++ b/src/types/pdfjs.js
@@ -63,7 +63,8 @@
 
 /**
  * @typedef GetTextContentParameters
- * @prop {boolean} normalizeWhitespace
+ * @prop {boolean} normalizeWhitespace - Whether to convert all whitespace to
+ *   an ASCII space char. Obsolete since https://github.com/mozilla/pdf.js/pull/14527.
  */
 
 /**


### PR DESCRIPTION
When anchoring a quote in a PDF, the quote is first searched in text
extracted using PDF.js's `PDFPage.getTextContent` API, and the resulting
positions are used to create a range within the hidden text layer of a
page.

An issue we've seen several times when doing PDF.js upgrades is minor
changes to which spaces are included in the text layer. In the past
we've adapted our text extraction to match the text layer each time.
This slows down the process of upgrading PDF.js and makes maintaining
compatibility with a range of PDF.js releases more difficult. In the
most recent update, an `includeMarkedContent` option was added to the
`getTextContent` API, and the presence of that option could affect
whether certain whitespaces are included in the output or not [1].

Try to address this issue generally by mapping offsets from the page
text into offsets in the text layer in a way that ignores whitespace
differences.

A user-visible consequence of this change is that any leading or trailing whitespace in quotes
is not highlighted, due to the way character positions in the page text are translated
to character positions in the text layer.

 - Add `translateOffsets` utility, which translates a (start, end) pair
   of offsets in one string into offsets in another, ignoring certain
   characters in the strings.

 - Use `translateOffsets` utility in PDF anchoring to map quote offsets
   in the page text returned by `PDFPage.getTextContent` into offsets in
   the `textContent` of the text layer element.

Fixes https://github.com/hypothesis/client/issues/4331
Dependency of https://github.com/hypothesis/product-backlog/issues/1283

[1] https://github.com/hypothesis/browser-extension/pull/799#issuecomment-1079864595