### PR TITLE
Add types to sidebarPanels, toastMessages, viewer store modules

### DIFF
--- a/src/sidebar/store/modules/sidebar-panels.js
+++ b/src/sidebar/store/modules/sidebar-panels.js
@@ -12,9 +12,7 @@
  * @typedef {import("../../../types/sidebar").PanelName} PanelName
  */
 
-import * as util from '../util';
-
-import { createStoreModule } from '../create-store';
+import { createStoreModule, makeAction } from '../create-store';
 
 const initialState = {
   /**
@@ -31,12 +29,22 @@ const initialState = {
   activePanelName: null,
 };
 
+/** @typedef {typeof initialState} State */
+
 const reducers = {
-  OPEN_SIDEBAR_PANEL: function (state, action) {
+  /**
+   * @param {State} state
+   * @param {{ panelName: PanelName }} action
+   */
+  OPEN_SIDEBAR_PANEL(state, action) {
     return { activePanelName: action.panelName };
   },
 
-  CLOSE_SIDEBAR_PANEL: function (state, action) {
+  /**
+   * @param {State} state
+   * @param {{ panelName: PanelName }} action
+   */
+  CLOSE_SIDEBAR_PANEL(state, action) {
     let activePanelName = state.activePanelName;
     if (action.panelName === activePanelName) {
       // `action.panelName` is indeed the currently-active panel; deactivate
@@ -48,6 +56,10 @@ const reducers = {
     };
   },
 
+  /**
+   * @param {State} state
+   * @param {{ panelName: PanelName, panelState?: boolean }} action
+   */
   TOGGLE_SIDEBAR_PANEL: function (state, action) {
     let activePanelName;
     // Is the panel in question currently the active panel?
@@ -75,15 +87,13 @@ const reducers = {
   },
 };
 
-const actions = util.actionTypes(reducers);
-
 /**
  * Designate `panelName` as the currently-active panel name
  *
  * @param {PanelName} panelName
  */
 function openSidebarPanel(panelName) {
-  return { type: actions.OPEN_SIDEBAR_PANEL, panelName };
+  return makeAction(reducers, 'OPEN_SIDEBAR_PANEL', { panelName });
 }
 
 /**
@@ -92,7 +102,7 @@ function openSidebarPanel(panelName) {
  * @param {PanelName} panelName
  */
 function closeSidebarPanel(panelName) {
-  return { type: actions.CLOSE_SIDEBAR_PANEL, panelName };
+  return makeAction(reducers, 'CLOSE_SIDEBAR_PANEL', { panelName });
 }
 
 /**
@@ -104,18 +114,17 @@ function closeSidebarPanel(panelName) {
  *   Should the panel be active? Omit this prop to simply toggle the value.
  */
 function toggleSidebarPanel(panelName, panelState) {
-  return {
-    type: actions.TOGGLE_SIDEBAR_PANEL,
+  return makeAction(reducers, 'TOGGLE_SIDEBAR_PANEL', {
     panelName,
     panelState,
-  };
+  });
 }
 
 /**
  * Is the panel indicated by `panelName` currently active (open)?
  *
+ * @param {State} state
  * @param {PanelName} panelName
- * @return {boolean} - `true` if `panelName` is the currently-active panel
  */
 function isSidebarPanelOpen(state, panelName) {
   return state.activePanelName === panelName;

--- a/src/sidebar/store/modules/toast-messages.js
+++ b/src/sidebar/store/modules/toast-messages.js
@@ -1,6 +1,4 @@
-import { createStoreModule } from '../create-store';
-
-import * as util from '../util';
+import { createStoreModule, makeAction } from '../create-store';
 
 /**
  * @typedef ToastMessage
@@ -22,21 +20,35 @@ const initialState = {
   messages: [],
 };
 
+/** @typedef {typeof initialState} State */
+
 const reducers = {
-  ADD_MESSAGE: function (state, action) {
+  /**
+   * @param {State} state
+   * @param {{ message: ToastMessage }} action
+   */
+  ADD_MESSAGE(state, action) {
     return {
       messages: state.messages.concat({ ...action.message }),
     };
   },
 
-  REMOVE_MESSAGE: function (state, action) {
+  /**
+   * @param {State} state
+   * @param {{ id: string }} action
+   */
+  REMOVE_MESSAGE(state, action) {
     const updatedMessages = state.messages.filter(
       message => message.id !== action.id
     );
     return { messages: updatedMessages };
   },
 
-  UPDATE_MESSAGE: function (state, action) {
+  /**
+   * @param {State} state
+   * @param {{ message: ToastMessage }} action
+   */
+  UPDATE_MESSAGE(state, action) {
     const updatedMessages = state.messages.map(message => {
       if (message.id && message.id === action.message.id) {
         return { ...action.message };
@@ -47,15 +59,13 @@ const reducers = {
   },
 };
 
-const actions = util.actionTypes(reducers);
-
 /** Actions */
 
 /**
  * @param {ToastMessage} message
  */
 function addMessage(message) {
-  return { type: actions.ADD_MESSAGE, message };
+  return makeAction(reducers, 'ADD_MESSAGE', { message });
 }
 
 /**
@@ -64,7 +74,7 @@ function addMessage(message) {
  * @param {string} id
  */
 function removeMessage(id) {
-  return { type: actions.REMOVE_MESSAGE, id };
+  return makeAction(reducers, 'REMOVE_MESSAGE', { id });
 }
 
 /**
@@ -73,7 +83,7 @@ function removeMessage(id) {
  * @param {ToastMessage} message
  */
 function updateMessage(message) {
-  return { type: actions.UPDATE_MESSAGE, message };
+  return makeAction(reducers, 'UPDATE_MESSAGE', { message });
 }
 
 /** Selectors */
@@ -81,8 +91,8 @@ function updateMessage(message) {
 /**
  * Retrieve a message by `id`
  *
+ * @param {State} state
  * @param {string} id
- * @return {object|undefined}
  */
 function getMessage(state, id) {
   return state.messages.find(message => message.id === id);
@@ -91,7 +101,7 @@ function getMessage(state, id) {
 /**
  * Retrieve all current messages
  *
- * @return {object[]}
+ * @param {State} state
  */
 function getMessages(state) {
   return state.messages;
@@ -102,9 +112,9 @@ function getMessages(state) {
  * text exists in the state's collection of messages. This matches messages
  * by content, not by ID (true uniqueness).
  *
+ * @param {State} state
  * @param {string} type
  * @param {string} text
- * @return {boolean}
  */
 function hasMessage(state, type, text) {
   return state.messages.some(message => {

--- a/src/sidebar/store/modules/viewer.js
+++ b/src/sidebar/store/modules/viewer.js
@@ -1,6 +1,4 @@
-import * as util from '../util';
-
-import { createStoreModule } from '../create-store';
+import { createStoreModule, makeAction } from '../create-store';
 
 /**
  * This module defines actions and state related to the display mode of the
@@ -15,8 +13,14 @@ const initialState = {
   sidebarHasOpened: false,
 };
 
+/** @typedef {typeof initialState} State */
+
 const reducers = {
-  SET_SIDEBAR_OPENED: (state, action) => {
+  /**
+   * @param {State} state
+   * @param {{ opened: boolean }} action
+   */
+  SET_SIDEBAR_OPENED(state, action) {
     if (action.opened === true) {
       // If the sidebar is open, track that it has ever been opened
       return { sidebarHasOpened: true };
@@ -26,19 +30,14 @@ const reducers = {
   },
 };
 
-const actions = util.actionTypes(reducers);
-
-// Action creators
-
 /**
  * @param {boolean} opened - If the sidebar is open
  */
 function setSidebarOpened(opened) {
-  return { type: actions.SET_SIDEBAR_OPENED, opened };
+  return makeAction(reducers, 'SET_SIDEBAR_OPENED', { opened });
 }
 
-// Selectors
-
+/** @param {State} state */
 function hasSidebarOpened(state) {
   return state.sidebarHasOpened;
 }


### PR DESCRIPTION
Modify the sidebarPanels, toastMessages and viewer store modules to add missing types, following the conventions established in https://github.com/hypothesis/client/pull/4328.