### PR TITLE
Remove border between panel header and content

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationShareControl.js
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.js
@@ -163,7 +163,7 @@ function AnnotationShareControl({
             'theme-clean:border'
           )}
         >
-          <div className="flex items-center pb-2 border-b">
+          <div className="flex items-center">
             <h2 className="text-brand text-lg font-medium">
               Share this annotation
             </h2>


### PR DESCRIPTION
I fat-fingered a rebase and put a border back I meant to remove in #4365 

This removes the border between the panel heading and content in `AnnotationShareControl`.

Before:

<img width="420" alt="image" src="https://user-images.githubusercontent.com/439947/160834980-419c11fe-3865-4637-b249-79129eab29ea.png">

After:

<img width="417" alt="image" src="https://user-images.githubusercontent.com/439947/160835020-45a79222-2665-43f5-a4a4-911d98fb1b30.png">
