### PR TITLE
Add test case for `Cross-Origin-Opener-Policy` breaking login popup

### DIFF
--- a/dev-server/documents/html/coop-test.mustache
+++ b/dev-server/documents/html/coop-test.mustache
@@ -1,0 +1,35 @@
+<!-- Header: Cross-Origin-Opener-Policy: same-origin -->
+<html>
+  <head>
+    <title>Cross-Origin-Opener-Policy test document</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        font-size: 1rem;
+        line-height: 1.5rem;
+      }
+      main {
+        max-width: 600px;
+        margin-top: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Cross-Origin-Opener-Policy test</h1>
+      <p>
+        This page tests the client on a document which is served with a
+        <a
+          href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy"
+          ><code>Cross-Origin-Opener-Policy: same-origin</code></a
+        >
+        header. This header prevents popup windows from accessing their opener
+        using
+        <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/opener"
+          ><code>window.opener</code></a
+        >, which affects the client's login popup.
+      </p>
+      {{{ hypothesisScript }}}
+    </main>
+  </body>
+</html>

--- a/dev-server/documents/html/xhtml-test.mustache
+++ b/dev-server/documents/html/xhtml-test.mustache
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The dev server serves all HTML content with the text/html MIME type
+  by default. Much (most?) "XHTML" content on the web is served this way.
+  However serving with the correct MIME type affects browser behavior, so
+  it is important to use that here.
+-->
+<!-- Header: Content-Type: application/xhtml+xml -->
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>XHTML test document</title>

--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -29,6 +29,7 @@
     <ul>
       <li><a href="/document/z-index">Content with high <code>z-index</code> style</a></li>
       <li><a href="/document/shadow-dom">Content in shadow DOM</a></li>
+      <li><a href="/document/coop-test"><code>Cross-Origin-Opener-Policy</code> test</a></li>
       <li><a href="/document/host-in-shadow-root">Hypothesis loaded into frame in shadow root</a></li>
       <li><a href="/document/parent-frame">Annotation-enabled iframe</a></li>
       <li><a href="/document/sidebar-external-container">Sidebar in external container</a></li>


### PR DESCRIPTION
Add a test page to the dev server which reproduces the issue from https://github.com/hypothesis/product-backlog/issues/1333 where a page setting the [`Cross-Origin-Opener-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy) header breaks the client's login popup.

- The first commit adds a generic mechanism for setting custom headers in test pages by adding `<!-- Header: <Key>:<Value> -->` comments in the test pages, and refactors the existing XHTML test to use it
- The second commit adds a test page at http://localhost:3000/document/coop-test which sets a `Cross-Origin-Opener-Policy: same-origin` header. If you try to log in on this page the client will display an error about being unable to open a popup window. Note that if the user is already logged in on another page, the existing login will persist. The problem only affects trying to perform a new login.

Screenshot of what happens if you try to log in on the new test page:

<img width="919" alt="Client login fail" src="https://user-images.githubusercontent.com/2458/160998382-020331f2-4acb-410f-848d-96020bd01676.png">

