### PR TITLE
Simplify login popup creation flow

### DIFF
--- a/src/sidebar/services/auth.js
+++ b/src/sidebar/services/auth.js
@@ -270,9 +270,15 @@ export class AuthService extends TinyEmitter {
      * then exchange for access and refresh tokens.
      */
     async function login() {
-      const authWindow = OAuthClient.openAuthPopupWindow($window);
+      // Any async steps before the call to `client.authorize` must complete
+      // in less than ~1 second, otherwise the browser's popup blocker may block
+      // the popup.
+      //
+      // `oauthClient` is async in case in needs to fetch links from the API.
+      // This should already have happened by the time this function is called
+      // however, so it will just be returning a cached value.
       const client = await oauthClient();
-      const code = await client.authorize($window, authWindow);
+      const code = await client.authorize($window);
 
       // Save the auth code. It will be exchanged for an access token when the
       // next API request is made.

--- a/src/sidebar/services/test/auth-test.js
+++ b/src/sidebar/services/test/auth-test.js
@@ -82,7 +82,6 @@ describe('AuthService', () => {
       fakeClient.config = config;
       return fakeClient;
     };
-    FakeOAuthClient.openAuthPopupWindow = sinon.stub();
 
     fakeWindow = new FakeWindow();
 
@@ -530,12 +529,9 @@ describe('AuthService', () => {
       fakeSettings.services = [];
     });
 
-    it('calls OAuthClient#authorize', () => {
-      const fakePopup = {};
-      FakeOAuthClient.openAuthPopupWindow.returns(fakePopup);
-      return auth.login().then(() => {
-        assert.calledWith(fakeClient.authorize, fakeWindow, fakePopup);
-      });
+    it('calls OAuthClient#authorize', async () => {
+      await auth.login();
+      assert.calledWith(fakeClient.authorize, fakeWindow);
     });
 
     it('resolves when auth completes successfully', () => {


### PR DESCRIPTION
The process of creating and navigating the login popup used to involve two
steps, first creating a blank window and then navigating it to the final
authorization URL. This was needed because, in Firefox, the popup window had to
be created in the same turn of the event loop as the user's click on the "Log
in" button (otherwise the popup blocker would trigger) but generating the
authorization URL involved an async "fetch" of API links.

The major browsers have now all settled on a more flexible model for allowing
popups in response to user gestures, where the popup must be opened within a
certain time window of the gesture. In practice the timeout seems to be ~1000ms
in Safari and longer than that in other browsers.

In this context we expect the async delay between the user clicking the "Log in"
button and us creating the popup to be ~0ms, since the API links should already
have been fetched at this point and so we're just fetching locally cached values.

Based on this assumption, the flow for creating the login popup window has been
simplified to create the popup window at the final URL immediately, removing the
need to open a blank window as a first step.

Simplifying the code here will make it easier to change how the popup window and
sidebar communicate, eg. to resolve an issue with the new
Cross-Origin-Opener-Policy header [1].

[1] https://github.com/hypothesis/product-backlog/issues/1333

**Testing:**

Try logging into the client in Safari, Firefox and Chrome. It should behave the same as before.

**Related reading:**

- [Original Firefox issue I filed, closed 4 years ago](https://bugzilla.mozilla.org/show_bug.cgi?id=1425419)
- [Related standardization discussion](https://github.com/whatwg/html/issues/1903)
- [Relevant HTML spec section, updated 4 years ago after the previous discussion](https://html.spec.whatwg.org/multipage/interaction.html#tracking-user-activation)
