### PR TITLE
Convert remaining Annotation* components to tailwind

### DIFF
--- a/src/sidebar/components/Annotation/Annotation.js
+++ b/src/sidebar/components/Annotation/Annotation.js
@@ -1,4 +1,4 @@
-import { Actions } from '@hypothesis/frontend-shared';
+import { Actions, Spinner } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import { useStoreProxy } from '../../store/use-store';
@@ -17,6 +17,23 @@ import AnnotationReplyToggle from './AnnotationReplyToggle';
  * @typedef {import("../../../types/api").SavedAnnotation} SavedAnnotation
  * @typedef {import('../../../types/api').Group} Group
  */
+
+function SavingMessage() {
+  return (
+    <div
+      className={classnames(
+        'flex grow justify-end items-center gap-x-1',
+        // Make sure height matches that of action-bar icons so that there
+        // isn't a height change when transitioning in and out of saving state
+        'h-8 touch:h-touch-minimum'
+      )}
+      data-testid="saving-message"
+    >
+      <Spinner classes="text-xl" size="small" />
+      <div className="text-color-text-light font-medium">Saving...</div>
+    </div>
+  );
+}
 
 /**
  * @typedef AnnotationProps
@@ -57,8 +74,10 @@ function Annotation({
   const isEditing = annotation && !!draft && !isSaving;
 
   const userid = store.profile().userid;
-  const showActions = !isSaving && !isEditing;
-  const showReplyToggle = !isReply && !hasAppliedFilter && replyCount > 0;
+  const showActions =
+    annotation && !isSaving && !isEditing && isSaved(annotation);
+  const showReplyToggle =
+    !isReply && !isEditing && !hasAppliedFilter && replyCount > 0;
 
   const onReply = () => {
     if (annotation && isSaved(annotation)) {
@@ -67,12 +86,7 @@ function Annotation({
   };
 
   return (
-    <article
-      className={classnames('hyp-u-vertical-spacing', {
-        'is-collapsed': threadIsCollapsed,
-        'is-focused': isFocused,
-      })}
-    >
+    <article className="space-y-4">
       {annotation && (
         <>
           <AnnotationHeader
@@ -107,32 +121,20 @@ function Annotation({
       )}
 
       {!isCollapsedReply && (
-        <footer>
-          <div className="hyp-u-layout-row">
-            {showReplyToggle && (
-              <AnnotationReplyToggle
-                onToggleReplies={onToggleReplies}
-                replyCount={replyCount}
-                threadIsCollapsed={threadIsCollapsed}
-              />
-            )}
-            {isSaving && (
-              <div
-                className="hyp-u-layout-row--justify-right hyp-u-stretch"
-                data-testid="saving-message"
-              >
-                Saving...
-              </div>
-            )}
-            {annotation && showActions && isSaved(annotation) && (
-              <Actions classes="hyp-u-stretch">
-                <AnnotationActionBar
-                  annotation={annotation}
-                  onReply={onReply}
-                />
-              </Actions>
-            )}
-          </div>
+        <footer className="flex items-center">
+          {showReplyToggle && (
+            <AnnotationReplyToggle
+              onToggleReplies={onToggleReplies}
+              replyCount={replyCount}
+              threadIsCollapsed={threadIsCollapsed}
+            />
+          )}
+          {isSaving && <SavingMessage />}
+          {showActions && (
+            <Actions classes="grow">
+              <AnnotationActionBar annotation={annotation} onReply={onReply} />
+            </Actions>
+          )}
         </footer>
       )}
     </article>

--- a/src/sidebar/components/Annotation/Annotation.js
+++ b/src/sidebar/components/Annotation/Annotation.js
@@ -29,7 +29,15 @@ function SavingMessage() {
       )}
       data-testid="saving-message"
     >
-      <Spinner classes="text-xl" size="small" />
+      <Spinner
+        classes={classnames(
+          'text-xl',
+          // Slowly fade in the Spinner such that it only shows up if
+          // the saving is slow
+          'animate-fade-in-slow'
+        )}
+        size="small"
+      />
       <div className="text-color-text-light font-medium">Saving...</div>
     </div>
   );

--- a/src/sidebar/components/Annotation/AnnotationActionBar.js
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.js
@@ -109,7 +109,7 @@ function AnnotationActionBar({
   };
 
   return (
-    <div className="AnnotationActionBar hyp-u-layout-row text-xl font-medium">
+    <div className="flex text-xl" data-testid="annotation-action-bar">
       {showEditAction && (
         <IconButton icon="edit" title="Edit" onClick={onEdit} />
       )}

--- a/src/sidebar/components/Annotation/AnnotationLicense.js
+++ b/src/sidebar/components/Annotation/AnnotationLicense.js
@@ -5,16 +5,16 @@ import { Icon, Link } from '@hypothesis/frontend-shared';
  */
 export default function AnnotationLicense() {
   return (
-    <div className="hyp-u-padding--top hyp-u-border--top text-sm leading-none">
+    <div className="pt-2 border-t text-sm leading-none">
       <Link
-        classes="hyp-u-layout-row--align-center p-link--muted"
+        classes="flex items-center text-color-text-light"
         href="http://creativecommons.org/publicdomain/zero/1.0/"
         target="_blank"
         title="View more information about the Creative Commons Public Domain dedication"
       >
         <Icon name="cc-std" classes="text-tiny" />
-        <Icon name="cc-zero" classes="hyp-u-margin--left--1 text-tiny" />
-        <div className="hyp-u-margin--left--2">
+        <Icon name="cc-zero" classes="ml-px text-tiny" />
+        <div className="ml-1">
           Annotations can be freely reused by anyone for any purpose.
         </div>
       </Link>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -16,6 +16,7 @@ export default {
       animation: {
         adderPopUp: 'adderPopUp 0.08s ease-in forwards',
         adderPopDown: 'adderPopDown 0.08s ease-in forwards',
+        'fade-in-slow': 'fade-in 1s ease-in',
       },
       borderRadius: {
         // Tailwind provides a default set of border-radius utility styles
@@ -110,6 +111,14 @@ export default {
           '100%': {
             opacity: '1',
             transform: 'scale(1) translateY(0px)',
+          },
+        },
+        'fade-in': {
+          '0%': {
+            opacity: '0',
+          },
+          '100%': {
+            opacity: '1',
           },
         },
       },


### PR DESCRIPTION
This PR converts the remaining components in the `Annotations` directory to Tailwind and updates them to recent conventions.

The only visual change here is a _fix_ to height-jumping in the footer when saving an annotation. Normally this blips by fairly quickly; these screen videos have network throttled to make it go by more slowly. I also added a Spinner to the "saving message" here.

In the "after" variant, the height of the annotation's footer does not change when switching between the "Saving" message and the action-bar icons. Before, the annotation-card height would jump a little after saving was complete.

Before:
![before-saving](https://user-images.githubusercontent.com/439947/161287485-2f89a3bb-bd13-4f12-af0d-6ee26bbc2cb8.gif)

After:
![after-saving](https://user-images.githubusercontent.com/439947/161287507-2dfbfee9-086f-4d30-aca7-b63e4b77c214.gif)

Part of https://github.com/hypothesis/client/issues/4347