### PR TITLE
Convert TagEditor to tailwind

### DIFF
--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -1,6 +1,7 @@
 import {
   normalizeKeyName,
   useElementShouldClose,
+  TextInput,
 } from '@hypothesis/frontend-shared';
 import { useRef, useState } from 'preact/hooks';
 
@@ -270,7 +271,7 @@ function TagEditor({
     activeItem >= 0 ? `${tagEditorId}-AutocompleteList-item-${activeItem}` : '';
 
   return (
-    <div className="TagEditor space-y-4">
+    <div className="space-y-4">
       <TagList>
         {tagList.map(tag => {
           return <TagListItem key={tag} onRemoveTag={onRemoveTag} tag={tag} />;
@@ -278,7 +279,7 @@ function TagEditor({
       </TagList>
       <div
         id={tagEditorId}
-        className="TagEditor__combobox-wrapper"
+        data-testid="combobox-container"
         ref={closeWrapperRef}
         // Disabled because aria-controls must be attached to the <input> field
         // eslint-disable-next-line jsx-a11y/role-has-required-aria-props
@@ -287,13 +288,13 @@ function TagEditor({
         aria-owns={`${tagEditorId}-AutocompleteList`}
         aria-haspopup="listbox"
       >
-        <input
+        <TextInput
+          classes="w-full"
           onInput={handleOnInput}
           onKeyDown={handleKeyDown}
           onFocus={handleFocus}
-          ref={inputEl}
+          inputRef={inputEl}
           placeholder="Add new tags"
-          className="TagEditor__input"
           type="text"
           autoComplete="off"
           aria-autocomplete="list"

--- a/src/sidebar/components/test/TagEditor-test.js
+++ b/src/sidebar/components/test/TagEditor-test.js
@@ -88,10 +88,8 @@ describe('TagEditor', () => {
 
   it('adds appropriate tag values to the elements', () => {
     const wrapper = createComponent();
-    wrapper.find('li').forEach((tag, i) => {
-      assert.isTrue(tag.hasClass('TagEditor__item'));
-      assert.include(tag.text(), fakeTags[i]);
-      assert.equal(tag.prop('aria-label'), `Tag: ${fakeTags[i]}`);
+    wrapper.find('TagListItem').forEach((tag, i) => {
+      assert.equal(tag.props().tag, fakeTags[i]);
     });
   });
 
@@ -455,6 +453,7 @@ describe('TagEditor', () => {
   });
 
   describe('accessibility attributes and ids', () => {
+    const comboboxSelector = '[data-testid="combobox-container"]';
     it('creates multiple <TagEditor> components with unique AutocompleteList `id` props', () => {
       const wrapper1 = createComponent();
       const wrapper2 = createComponent();
@@ -469,7 +468,7 @@ describe('TagEditor', () => {
       wrapper.find('AutocompleteList');
 
       assert.equal(
-        wrapper.find('.TagEditor__combobox-wrapper').prop('aria-owns'),
+        wrapper.find(comboboxSelector).prop('aria-owns'),
         wrapper.find('AutocompleteList').prop('id')
       );
     });
@@ -479,13 +478,13 @@ describe('TagEditor', () => {
       wrapper.find('input').instance().value = 'non-empty'; // to open list
       typeInput(wrapper);
       assert.equal(
-        wrapper.find('.TagEditor__combobox-wrapper').prop('aria-expanded'),
+        wrapper.find(comboboxSelector).prop('aria-expanded'),
         'true'
       );
       selectOption(wrapper, 'tag4');
       wrapper.update();
       assert.equal(
-        wrapper.find('.TagEditor__combobox-wrapper').prop('aria-expanded'),
+        wrapper.find(comboboxSelector).prop('aria-expanded'),
         'false'
       );
     });

--- a/src/styles/sidebar/components/TagEditor.scss
+++ b/src/styles/sidebar/components/TagEditor.scss
@@ -1,8 +1,0 @@
-@use '../../mixins/forms';
-
-.TagEditor {
-  &__input {
-    @include forms.form-input;
-    width: 100%;
-  }
-}

--- a/src/styles/sidebar/components/_index.scss
+++ b/src/styles/sidebar/components/_index.scss
@@ -27,7 +27,6 @@
 @use './SelectionTabs';
 @use './SearchInput';
 @use './StyledText';
-@use './TagEditor';
 @use './Thread';
 @use './ThreadCard';
 @use './ThreadList';


### PR DESCRIPTION
Also, use shared `TextInput` component for presentational consistency.

The only visual change is the different focus outline and lesser border-radius that the shared `TextInput` uses versus the locally-styled one.

Before:

<img width="417" alt="image" src="https://user-images.githubusercontent.com/439947/161831289-6d2fac08-951d-4e45-bca7-704e74cfdd7b.png">

After:

<img width="397" alt="image" src="https://user-images.githubusercontent.com/439947/161831333-88e8a603-a0dd-49cb-a456-255393c6e15c.png">

Part of https://github.com/hypothesis/client/issues/4377
