### PR TITLE
Reuse `translateOffsets` utility in PDF quote anchoring

### DIFF
--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -1,5 +1,6 @@
 /* global PDFViewerApplication */
 
+import { warnOnce } from '../../shared/warn-once';
 import { translateOffsets } from '../util/normalize';
 import { matchQuote } from './match-quote';
 import { createPlaceholder } from './placeholder';
@@ -323,6 +324,16 @@ async function anchorByPosition(pageIndex, start, end) {
       end,
       isNotSpace
     );
+
+    const textLayerQuote = stripSpaces(
+      textLayerStr.slice(textLayerStart, textLayerEnd)
+    );
+    const pageTextQuote = stripSpaces(pageText.slice(start, end));
+    if (textLayerQuote !== pageTextQuote) {
+      warnOnce(
+        'Text layer text does not match page text. Highlights will be mis-aligned.'
+      );
+    }
 
     const startPos = new TextPosition(root, textLayerStart);
     const endPos = new TextPosition(root, textLayerEnd);

--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -431,6 +431,8 @@ async function anchorQuote(quoteSelector, positionHint) {
       if (page < expectedPageIndex) {
         strippedHint = strippedText.length; // Prefer matches closer to end of page.
       } else if (page === expectedPageIndex) {
+        // Translate expected offset in whitespace-inclusive version of page
+        // text into offset in whitespace-stripped version of page text.
         [strippedHint] = translateOffsets(
           text,
           strippedText,
@@ -454,6 +456,8 @@ async function anchorQuote(quoteSelector, positionHint) {
     }
 
     if (!bestMatch || match.score > bestMatch.match.score) {
+      // Translate match offset from whitespace-stripped version of page text
+      // back to original text.
       const [start, end] = translateOffsets(
         strippedText,
         text,

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -531,6 +531,11 @@ describe('annotator/anchoring/pdf', () => {
     });
 
     it('anchors with mismatch if text layer differs from PDF.js text API output', async () => {
+      const warnOnce = sinon.stub();
+      pdfAnchoring.$imports.$mock({
+        '../../shared/warn-once': { warnOnce },
+      });
+
       viewer.pdfViewer.setCurrentPage(1);
       const selection = 'zombie in possession';
       const range = findText(container, selection);
@@ -548,6 +553,10 @@ describe('annotator/anchoring/pdf', () => {
 
       const anchoredRange = await pdfAnchoring.anchor(container, [quote]);
       assert.equal(anchoredRange.toString(), 'zomby in possession o');
+      assert.calledWith(
+        warnOnce,
+        'Text layer text does not match page text. Highlights will be mis-aligned.'
+      );
     });
 
     it('anchors to a placeholder element if the page is not rendered', () => {


### PR DESCRIPTION
When anchoring quote selectors in PDFs, the quote is anchored in a version of the PDF page text that has whitespace stripped out [1]. The offsets of the best match is then translated back to the whitespace-inclusive version of the text.

This commit refactors this translation to re-use the `translateOffsets` utility added in https://github.com/hypothesis/client/pull/4355. It also re-introduces a check that was removed in that PR, which checks for non-whitespace differences in the matched quote in the PDF text extracted by `getPageTextContent`, and the corresponding content in the text layer. Such differences indicate an unexpected difference between the text layer and the text extracted via PDF.js APIs for a page, and it is useful to flag this issue.

[1] This makes whitespace changes "free" from the perspective of the fuzzy anchoring cost function (see `matchQuote`)