### PR TITLE
Make sure border is enabled on AnnotationShareControl in the clean theme

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationShareControl.js
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.js
@@ -160,7 +160,7 @@ function AnnotationShareControl({
             'absolute bottom-8 right-1 touch:bottom-touch-minimum',
             'space-y-2 p-2',
             // Cards do not have a border in the clean theme. Turn it back on.
-            'theme-clean:border'
+            'theme-clean:border theme-clean:border-solid theme-clean:border-grey-3'
           )}
         >
           <div className="flex items-center">


### PR DESCRIPTION
This small PR fixes a visual regression introduced by a recent change to `AnnotationShareControl` in the clean theme. Though I believe the border for the control had been re-enabled for the clean theme by using `theme-clean:border`, it wasn't enough. There's a little bit of eventual follow-up work here to change it so disabling the border in the first place uses `border-width: 0` instead of `border: none`.

Before fix in clean theme:

<img width="402" alt="image" src="https://user-images.githubusercontent.com/439947/162210991-9f8dd44d-552f-4c53-a1c5-09850261f603.png">

And after:

<img width="413" alt="image" src="https://user-images.githubusercontent.com/439947/162210748-58446005-e81a-4b7e-ac15-f467de0bd715.png">
