### PR TITLE
Convert `TopBar` to Tailwind

### DIFF
--- a/src/sidebar/components/SortMenu.js
+++ b/src/sidebar/components/SortMenu.js
@@ -28,8 +28,8 @@ export default function SortMenu() {
   });
 
   const menuLabel = (
-    <span className="TopBar__menu-label">
-      <Icon name="sort" classes="TopBar__menu-icon" />
+    <span className="p-1">
+      <Icon name="sort" />
     </span>
   );
 

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -107,10 +107,7 @@ function TopBar({
   return (
     <div
       className={classnames(
-        // This absolute-positioned top bar allows content to scroll beneath it;
-        // the use of `transform-gpu` can kick on hardware acceleration to make
-        // this smoother
-        'absolute h-10 left-0 top-0 right-0 z-4 transform-gpu',
+        'absolute h-10 left-0 top-0 right-0 z-4',
         'text-grey-7 border-b theme-clean:border-b-0 bg-white'
       )}
       data-testid="top-bar"

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -1,4 +1,5 @@
 import { IconButton, LinkButton } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
 
 import { serviceConfig } from '../config/service-config';
 import { isThirdPartyService } from '../helpers/is-third-party-service';
@@ -13,20 +14,47 @@ import StreamSearchInput from './StreamSearchInput';
 import UserMenu from './UserMenu';
 
 /**
- * @typedef {import('../../types/config').SidebarSettings} SidebarSettings
  * @typedef {import('../components/UserMenu').AuthState} AuthState
+ * @typedef {import('preact').ComponentChildren} Children
+ * @typedef {import('../services/frame-sync').FrameSyncService} FrameSyncService
+ * @typedef {import('../../types/config').SidebarSettings} SidebarSettings
+ * @typedef {import('../services/streamer').StreamerService} StreamerService
  */
+
+/**
+ * Render "page" content in a container that centers it and constrains its
+ * maximum width.
+ *
+ * @param {object} props
+ *   @param {Children} props.children
+ *   @param {string} [props.classes]
+ * @returns
+ */
+function SidebarContent({ children, classes }) {
+  return (
+    <div
+      className={classnames(
+        // Center this content (auto margins). For larger viewports, set a
+        // maximum width (768px) and add some horizontal padding.
+        'mx-auto lg:px-16 lg:max-w-3xl',
+        classes
+      )}
+    >
+      {children}
+    </div>
+  );
+}
 
 /**
  * @typedef TopBarProps
  * @prop {AuthState} auth
- * @prop {import('../services/frame-sync').FrameSyncService} frameSync
+ * @prop {FrameSyncService} frameSync - injected
  * @prop {boolean} isSidebar - Flag indicating whether the app is the sidebar or a top-level page.
- * @prop {() => any} onLogin - Callback invoked when user clicks "Login" button.
- * @prop {() => any} onLogout - Callback invoked when user clicks "Logout" action in account menu.
- * @prop {() => any} onSignUp - Callback invoked when user clicks "Sign up" button.
- * @prop {SidebarSettings} settings
- * @prop {import('../services/streamer').StreamerService} streamer
+ * @prop {() => void} onLogin - Callback invoked when user clicks "Login" button.
+ * @prop {() => void} onLogout - Callback invoked when user clicks "Logout" action in account menu.
+ * @prop {() => void} onSignUp - Callback invoked when user clicks "Sign up" button.
+ * @prop {SidebarSettings} settings - injected
+ * @prop {StreamerService} streamer - injected
  */
 
 /**
@@ -76,45 +104,59 @@ function TopBar({
     }
   };
 
-  const loginControl = (
-    <>
-      {auth.status === 'unknown' && (
-        <span className="TopBar__login-links">⋯</span>
-      )}
-      {auth.status === 'logged-out' && (
-        <span className="TopBar__login-links text-lg font-medium hyp-u-horizontal-spacing--2">
-          <LinkButton
-            classes="InlineLinkButton"
-            onClick={onSignUp}
-            style={loginLinkStyle}
-            variant="primary"
-          >
-            Sign up
-          </LinkButton>
-          <div>/</div>
-          <LinkButton
-            classes="InlineLinkButton"
-            onClick={onLogin}
-            style={loginLinkStyle}
-            variant="primary"
-          >
-            Log in
-          </LinkButton>
-        </span>
-      )}
-      {auth.status === 'logged-in' && (
-        <UserMenu auth={auth} onLogout={onLogout} />
-      )}
-    </>
-  );
-
   return (
-    <div className="TopBar">
-      {/* Single-annotation and stream views. */}
-      {!isSidebar && (
-        <div className="TopBar__inner content">
-          <StreamSearchInput />
-          <div className="hyp-u-stretch" />
+    <div
+      className={classnames(
+        // This absolute-positioned top bar allows content to scroll beneath it;
+        // the use of `transform-gpu` can kick on hardware acceleration to make
+        // this smoother
+        'absolute h-10 left-0 top-0 right-0 z-4 transform-gpu',
+        'text-grey-7 border-b theme-clean:border-b-0 bg-white'
+      )}
+      data-testid="top-bar"
+    >
+      <SidebarContent
+        classes={classnames(
+          'flex items-center h-full',
+          // This precise horizontal padding makes the edges of its contents
+          // align accurately with the edges of annotation cards in the sidebar
+          'px-[9px]',
+          // Text sizing will size icons in buttons correctly
+          'text-xl'
+        )}
+        data-testid="top-bar-content"
+      >
+        {isSidebar ? <GroupList /> : <StreamSearchInput />}
+        <div className="grow flex items-center justify-end">
+          {isSidebar && (
+            <>
+              {pendingUpdateCount > 0 && (
+                <IconButton
+                  icon="refresh"
+                  onClick={applyPendingUpdates}
+                  size="small"
+                  variant="primary"
+                  title={`Show ${pendingUpdateCount} new/updated ${
+                    pendingUpdateCount === 1 ? 'annotation' : 'annotations'
+                  }`}
+                />
+              )}
+              <SearchInput
+                query={filterQuery || null}
+                onSearch={store.setFilterQuery}
+              />
+              <SortMenu />
+              {showSharePageButton && (
+                <IconButton
+                  icon="share"
+                  expanded={isAnnotationsPanelOpen}
+                  onClick={toggleSharePanel}
+                  size="small"
+                  title="Share annotations on this page"
+                />
+              )}
+            </>
+          )}
           <IconButton
             icon="help"
             expanded={isHelpPanelOpen}
@@ -122,49 +164,39 @@ function TopBar({
             size="small"
             title="Help"
           />
-          {loginControl}
-        </div>
-      )}
-      {/* Sidebar view */}
-      {isSidebar && (
-        <div className="TopBar__inner content">
-          <GroupList />
-          <div className="hyp-u-stretch" />
-          {pendingUpdateCount > 0 && (
-            <IconButton
-              icon="refresh"
-              onClick={applyPendingUpdates}
-              size="small"
-              variant="primary"
-              title={`Show ${pendingUpdateCount} new/updated ${
-                pendingUpdateCount === 1 ? 'annotation' : 'annotations'
-              }`}
-            />
+          {auth.status === 'logged-in' ? (
+            <UserMenu auth={auth} onLogout={onLogout} />
+          ) : (
+            <div
+              className="flex items-center text-lg font-medium space-x-1"
+              data-testid="login-links"
+            >
+              {auth.status === 'unknown' && <span>⋯</span>}
+              {auth.status === 'logged-out' && (
+                <>
+                  <LinkButton
+                    classes="inline"
+                    onClick={onSignUp}
+                    style={loginLinkStyle}
+                    variant="primary"
+                  >
+                    Sign up
+                  </LinkButton>
+                  <div>/</div>
+                  <LinkButton
+                    classes="inline"
+                    onClick={onLogin}
+                    style={loginLinkStyle}
+                    variant="primary"
+                  >
+                    Log in
+                  </LinkButton>
+                </>
+              )}
+            </div>
           )}
-          <SearchInput
-            query={filterQuery || null}
-            onSearch={store.setFilterQuery}
-          />
-          <SortMenu />
-          {showSharePageButton && (
-            <IconButton
-              icon="share"
-              expanded={isAnnotationsPanelOpen}
-              onClick={toggleSharePanel}
-              size="small"
-              title="Share annotations on this page"
-            />
-          )}
-          <IconButton
-            icon="help"
-            expanded={isHelpPanelOpen}
-            onClick={requestHelp}
-            size="small"
-            title="Help"
-          />
-          {loginControl}
         </div>
-      )}
+      </SidebarContent>
     </div>
   );
 }

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -87,8 +87,8 @@ function UserMenu({ auth, frameSync, onLogout, settings }) {
   })();
 
   const menuLabel = (
-    <span className="TopBar__menu-label">
-      <Icon name="profile" classes="TopBar__menu-icon" />
+    <span className="p-1">
+      <Icon name="profile" />
     </span>
   );
   return (

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -127,7 +127,7 @@ describe('TopBar', () => {
   });
 
   describe('login/account actions', () => {
-    const getLoginText = wrapper => wrapper.find('.TopBar__login-links');
+    const getLoginText = wrapper => wrapper.find('[data-testid="login-links"]');
 
     it('Shows ellipsis when login state is unknown', () => {
       const wrapper = createTopBar({ auth: { status: 'unknown' } });

--- a/src/styles/sidebar/components/TopBar.scss
+++ b/src/styles/sidebar/components/TopBar.scss
@@ -1,8 +1,0 @@
-@use '../../variables' as var;
-
-.TopBar {
-  // FIXME This is used by SortMenu and UserMenu.
-  &__menu-label {
-    padding: var.$layout-space--xxsmall;
-  }
-}

--- a/src/styles/sidebar/components/TopBar.scss
+++ b/src/styles/sidebar/components/TopBar.scss
@@ -1,82 +1,8 @@
-@use '../../mixins/buttons';
-@use '../../mixins/layout';
-@use '../../mixins/utils';
 @use '../../variables' as var;
 
 .TopBar {
-  @include utils.font--xlarge;
-  @include utils.border--bottom;
-  color: var.$grey-mid;
-  background: var.$white;
-  height: var.$top-bar-height;
-  @media (pointer: coarse) {
-    // Nov-23-2020: removing 4px is an interim solution to increase the size
-    // of the annotator-bar buttons without affecting the size of the sidebar
-    // https://github.com/hypothesis/client/pull/2745/files#r527824220
-    height: var.$touch-target-size - 4px;
-  }
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  z-index: 5;
-
-  // Force TopBar onto a new compositor layer so that it does not judder when
-  // the window is scrolled.
-  transform: translate3d(0, 0, 0);
-
+  // FIXME This is used by SortMenu and UserMenu.
   &__menu-label {
     padding: var.$layout-space--xxsmall;
   }
-}
-
-.TopBar__login-button {
-  @include buttons.button;
-  @include utils.font--large;
-  padding: 0 var.$layout-space--xxsmall;
-  color: var.$color-brand;
-
-  &:hover {
-    color: var.$color-link-hover;
-  }
-
-  @media (pointer: coarse) {
-    min-width: inherit;
-    min-height: inherit;
-  }
-}
-
-.TopBar__login-links {
-  @include layout.row;
-  flex-shrink: 0;
-}
-
-.TopBar__inner {
-  @include layout.sidebar-content;
-  @include layout.row(right, center);
-
-  // FIXME: This odd font size rule is because the spinner uses a `1em` dimension
-  // and we want to assure it displays at the same dimensions as the other icons
-  // in this top bar
-  font-size: var.$icon-size--medium;
-
-  // the edges of the TopBar's contents should be aligned
-  // with the edges of annotation cards displayed below
-  $h-padding: 9px;
-
-  padding-left: $h-padding;
-  padding-right: $h-padding;
-
-  height: 100%;
-}
-
-.TopBar__inner .GroupList {
-  justify-self: flex-start;
-  margin-right: auto;
-  white-space: nowrap;
-}
-
-/** Clean theme affordances */
-#{var.$sidebar--theme-clean} .TopBar {
-  border-bottom: none;
 }

--- a/src/styles/sidebar/components/_index.scss
+++ b/src/styles/sidebar/components/_index.scss
@@ -29,7 +29,6 @@
 @use './ThreadCard';
 @use './ThreadList';
 @use './ToastMessages';
-@use './TopBar';
 @use './VersionInfo';
 
 // TODO: Put these in @layer components after shared component styles have

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -131,6 +131,7 @@ export default {
       screens: {
         touch: { raw: '(pointer: coarse)' },
         md: '480px',
+        lg: '768px',
         // Narrow mobile screens
         'annotator-sm': '240px',
         // Wider mobile screens/small tablets
@@ -151,6 +152,7 @@ export default {
         1: '1',
         2: '2',
         3: '3',
+        4: '4',
         max: '2147483647',
       },
     },


### PR DESCRIPTION
This PR breaks off a reasonably-sized chunk of https://github.com/hypothesis/client/pull/4403 : transition `TopBar` to Tailwind. There should be no user-visible changes here.

Part of https://github.com/hypothesis/client/issues/4377