### PR TITLE
Fill in remaining missing types in store modules, except for `filters` module

### DIFF
--- a/src/sidebar/store/modules/direct-linked.js
+++ b/src/sidebar/store/modules/direct-linked.js
@@ -92,6 +92,8 @@ const reducers = {
 
 /**
  * Set the direct linked group id.
+ *
+ * @param {string} groupId
  */
 function setDirectLinkedGroupId(groupId) {
   return makeAction(reducers, 'UPDATE_DIRECT_LINKED_GROUP_ID', {
@@ -101,6 +103,8 @@ function setDirectLinkedGroupId(groupId) {
 
 /**
  * Set the direct linked annotation's id.
+ *
+ * @param {string} annId
  */
 function setDirectLinkedAnnotationId(annId) {
   return makeAction(reducers, 'UPDATE_DIRECT_LINKED_ANNOTATION_ID', {

--- a/src/sidebar/store/modules/drafts.js
+++ b/src/sidebar/store/modules/drafts.js
@@ -1,10 +1,12 @@
 import { createSelector } from 'reselect';
 
-import * as metadata from '../../helpers/annotation-metadata';
 import { createStoreModule, makeAction } from '../create-store';
 import { removeAnnotations } from './annotations';
 
-/** @typedef {import('../../../types/api').Annotation} Annotation */
+/**
+ * @typedef {import('redux-thunk/extend-redux')} Dummy
+ * @typedef {import('../../../types/api').Annotation} Annotation
+ */
 
 /**
  * The drafts store provides temporary storage for unsaved edits to new or
@@ -117,10 +119,14 @@ function createDraft(annotation, changes) {
  * An empty draft has no text and no reference tags.
  */
 function deleteNewAndEmptyDrafts() {
+  /**
+   * @param {import('redux').Dispatch} dispatch
+   * @param {() => { drafts: State }} getState
+   */
   return (dispatch, getState) => {
     const newDrafts = getState().drafts.filter(draft => {
       return (
-        metadata.isNew(draft.annotation) &&
+        !draft.annotation.id &&
         !getDraftIfNotEmpty(getState().drafts, draft.annotation)
       );
     });

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -5,8 +5,7 @@ import {
 } from 'reselect';
 import shallowEqual from 'shallowequal';
 
-import * as util from '../util';
-import { createStoreModule } from '../create-store';
+import { createStoreModule, makeAction } from '../create-store';
 
 /**
  * @typedef {import('../../../types/annotator').DocumentMetadata} DocumentMetadata
@@ -27,15 +26,27 @@ const initialState = [];
 /** @typedef {typeof initialState} State */
 
 const reducers = {
-  CONNECT_FRAME: function (state, action) {
+  /**
+   * @param {State} state
+   * @param {{ frame: Frame }} action
+   */
+  CONNECT_FRAME(state, action) {
     return [...state, action.frame];
   },
 
-  DESTROY_FRAME: function (state, action) {
+  /**
+   * @param {State} state
+   * @param {{ frame: Frame }} action
+   */
+  DESTROY_FRAME(state, action) {
     return state.filter(f => f !== action.frame);
   },
 
-  UPDATE_FRAME_ANNOTATION_FETCH_STATUS: function (state, action) {
+  /**
+   * @param {State} state
+   * @param {{ uri: string, isAnnotationFetchComplete: boolean }} action
+   */
+  UPDATE_FRAME_ANNOTATION_FETCH_STATUS(state, action) {
     const frames = state.map(frame => {
       const match = frame.uri && frame.uri === action.uri;
       if (match) {
@@ -50,15 +61,13 @@ const reducers = {
   },
 };
 
-const actions = util.actionTypes(reducers);
-
 /**
  * Add a frame to the list of frames currently connected to the sidebar app.
  *
  * @param {Frame} frame
  */
 function connectFrame(frame) {
-  return { type: actions.CONNECT_FRAME, frame };
+  return makeAction(reducers, 'CONNECT_FRAME', { frame });
 }
 
 /**
@@ -67,7 +76,7 @@ function connectFrame(frame) {
  * @param {Frame} frame
  */
 function destroyFrame(frame) {
-  return { type: actions.DESTROY_FRAME, frame };
+  return makeAction(reducers, 'DESTROY_FRAME', { frame });
 }
 
 /**
@@ -77,17 +86,16 @@ function destroyFrame(frame) {
  * @param {boolean} isFetchComplete
  */
 function updateFrameAnnotationFetchStatus(uri, isFetchComplete) {
-  return {
-    type: actions.UPDATE_FRAME_ANNOTATION_FETCH_STATUS,
-    isAnnotationFetchComplete: isFetchComplete,
+  return makeAction(reducers, 'UPDATE_FRAME_ANNOTATION_FETCH_STATUS', {
     uri,
-  };
+    isAnnotationFetchComplete: isFetchComplete,
+  });
 }
 
 /**
  * Return the list of frames currently connected to the sidebar app.
  *
- * @return {Frame[]}
+ * @param {State} state
  */
 function frames(state) {
   return state;

--- a/src/sidebar/store/modules/links.js
+++ b/src/sidebar/store/modules/links.js
@@ -1,10 +1,15 @@
-import { actionTypes } from '../util';
 import { replaceURLParams } from '../../util/url';
-import { createStoreModule } from '../create-store';
+import { createStoreModule, makeAction } from '../create-store';
 
 const initialState = /** @type {Record<string, string>|null} */ (null);
 
+/** @typedef {typeof initialState} State */
+
 const reducers = {
+  /**
+   * @param {State} state
+   * @param {{ links: Record<string, string> }} action
+   */
   UPDATE_LINKS(state, action) {
     return {
       ...action.links,
@@ -12,18 +17,13 @@ const reducers = {
   },
 };
 
-const actions = actionTypes(reducers);
-
 /**
  * Update the link map
  *
  * @param {Record<string, string>} links - Link map fetched from the `/api/links` endpoint
  */
 function updateLinks(links) {
-  return {
-    type: actions.UPDATE_LINKS,
-    links,
-  };
+  return makeAction(reducers, 'UPDATE_LINKS', { links });
 }
 
 /**
@@ -31,9 +31,9 @@ function updateLinks(links) {
  *
  * Returns an empty string if links have not been fetched yet.
  *
+ * @param {State} state
  * @param {string} linkName
  * @param {Record<string, string>} [params]
- * @return {string}
  */
 function getLink(state, linkName, params = {}) {
   if (!state) {

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -216,6 +216,7 @@ const reducers = {
       newTab = 'annotation';
     }
 
+    /** @param {BooleanMap} collection */
     const removeAnns = collection => {
       action.annotationsToRemove.forEach(annotation => {
         if (annotation.id) {
@@ -251,6 +252,7 @@ function clearSelection() {
  * @param {string[]} ids - Identifiers of annotations to select
  */
 function selectAnnotations(ids) {
+  /** @param {import('redux').Dispatch} dispatch */
   return dispatch => {
     dispatch(clearSelection());
     dispatch(
@@ -291,7 +293,11 @@ function setForcedVisible(id, visible) {
   return makeAction(reducers, 'SET_FORCED_VISIBLE', { id, visible });
 }
 
-/** Sets the sort key for the annotation list. */
+/**
+ * Sets the sort key for the annotation list.
+ *
+ * @param {SortKey} key
+ */
 function setSortKey(key) {
   return makeAction(reducers, 'SET_SORT_KEY', { key });
 }
@@ -375,6 +381,7 @@ const sortKeys = createSelector(
   /** @param {State} state */
   state => state.selectedTab,
   selectedTab => {
+    /** @type {SortKey[]} */
     const sortKeysForTab = ['Newest', 'Oldest'];
     if (selectedTab !== 'note') {
       // Location is inapplicable to Notes tab

--- a/src/sidebar/store/modules/session.js
+++ b/src/sidebar/store/modules/session.js
@@ -2,6 +2,7 @@ import { createStoreModule, makeAction } from '../create-store';
 
 /**
  * @typedef {import('../../../types/api').Profile} Profile
+ * @typedef {import('../../../types/config').SidebarSettings} SidebarSettings
  */
 
 /**
@@ -27,7 +28,7 @@ const initialProfile = {
  * @prop {Profile} profile
  */
 
-/** @return {State} */
+/** @param {SidebarSettings} settings */
 function initialState(settings) {
   return {
     /**


### PR DESCRIPTION
Fill in the remaining missing types in store modules, except for the `filters` module which I'm going to split into a separate PR.