### PR TITLE
Typecheck src/sidebar/store with `noImplicitAny`

### DIFF
--- a/src/sidebar/components/Annotation/Annotation.js
+++ b/src/sidebar/components/Annotation/Annotation.js
@@ -76,7 +76,7 @@ function Annotation({
 
   const draft = annotation && store.getDraft(annotation);
 
-  const hasQuote = annotation && !!quote(annotation);
+  const annotationQuote = annotation ? quote(annotation) : null;
   const isFocused = annotation && store.isAnnotationFocused(annotation.$tag);
   const isSaving = annotation && store.isSavingAnnotation(annotation);
   const isEditing = annotation && !!draft && !isSaving;
@@ -104,9 +104,9 @@ function Annotation({
             threadIsCollapsed={threadIsCollapsed}
           />
 
-          {hasQuote && (
+          {annotationQuote && (
             <AnnotationQuote
-              quote={quote(annotation)}
+              quote={annotationQuote}
               isFocused={isFocused}
               isOrphan={isOrphan(annotation)}
             />

--- a/src/sidebar/components/Annotation/AnnotationQuote.js
+++ b/src/sidebar/components/Annotation/AnnotationQuote.js
@@ -15,15 +15,15 @@ import StyledText from '../StyledText';
  * @prop {string} quote
  * @prop {boolean} [isFocused]
  * @prop {boolean} [isOrphan]
- * @prop {SidebarSettings} [settings] - Used for theming.
+ * @prop {SidebarSettings} settings
  */
 
 /**
  * Display the selected text from the document associated with an annotation.
  *
- * @parm {AnnotationQuoteProps} props
+ * @param {AnnotationQuoteProps} props
  */
-function AnnotationQuote({ quote, isFocused, isOrphan, settings = {} }) {
+function AnnotationQuote({ quote, isFocused, isOrphan, settings }) {
   return (
     <Excerpt collapsedHeight={35} inlineControls={true} overflowThreshold={20}>
       <StyledText classes={classnames({ 'p-redacted-text': isOrphan })}>

--- a/src/sidebar/service-context.js
+++ b/src/sidebar/service-context.js
@@ -65,13 +65,14 @@ export const ServiceContext = createContext(fallbackInjector);
  *   // Wrap `MyComponent` to inject "settings" service from context.
  *   export default withServices(MyComponent, ['settings']);
  *
- * @template Props
+ * @template {Record<string, unknown>} Props
  * @template {string} ServiceName
  * @param {ComponentType<Props>} Component
  * @param {ServiceName[]} serviceNames - List of prop names that should be injected
  * @return {ComponentType<Omit<Props,ServiceName>>}
  */
 export function withServices(Component, serviceNames) {
+  /** @param {Omit<Props,ServiceName>} props */
   function Wrapper(props) {
     // Get the current dependency injector instance that is provided by a
     // `ServiceContext.Provider` somewhere higher up the component tree.
@@ -96,7 +97,9 @@ export function withServices(Component, serviceNames) {
         services[service] = injector.get(service);
       }
     }
-    return <Component {...services} {...props} />;
+
+    const propsWithServices = /** @type {Props} */ ({ ...services, ...props });
+    return <Component {...propsWithServices} />;
   }
 
   // Set the name of the wrapper for use in debug tools and queries in Enzyme

--- a/src/sidebar/store/debug-middleware.js
+++ b/src/sidebar/store/debug-middleware.js
@@ -1,4 +1,9 @@
 /**
+ * @typedef {import('redux').Action} Action
+ * @typedef {import('redux').Store} Store
+ */
+
+/**
  * A debug utility that prints information about internal application state
  * changes to the console.
  *
@@ -8,14 +13,16 @@
  * to the console, along with the application state before and after the action
  * was handled.
  *
- * @param {import("redux").Store} store
+ * @param {Store} store
  */
 export function debugMiddleware(store) {
   /* eslint-disable no-console */
   let serial = 0;
 
-  return function (next) {
-    return function (action) {
+  /** @param {(a: Action) => void} next */
+  return next => {
+    /** @param {Action} action */
+    return action => {
       // @ts-ignore The window interface needs to be expanded to include this property
       if (!window.debug) {
         next(action);

--- a/src/sidebar/store/util.js
+++ b/src/sidebar/store/util.js
@@ -21,7 +21,7 @@ export function actionTypes(reducers) {
  * which reads values from a Redux store, returns non-null.
  *
  * @template T
- * @param {object} store - Redux store
+ * @param {import('redux').Store} store - Redux store
  * @param {(s: Store) => T|null} selector - Function which returns a value from the
  *   store if the criteria is met or `null` otherwise.
  * @return {Promise<T>}

--- a/src/sidebar/store/util.js
+++ b/src/sidebar/store/util.js
@@ -21,7 +21,7 @@ export function actionTypes(reducers) {
  * which reads values from a Redux store, returns non-null.
  *
  * @template T
- * @param {import('redux').Store} store - Redux store
+ * @param {import('redux').Store} store
  * @param {(s: Store) => T|null} selector - Function which returns a value from the
  *   store if the criteria is met or `null` otherwise.
  * @return {Promise<T>}

--- a/src/tsconfig.no-any.json
+++ b/src/tsconfig.no-any.json
@@ -29,7 +29,7 @@
     "shared/**/*.js",
     "sidebar/config/*.js",
     "sidebar/helpers/*.js",
-    "sidebar/store/create-store.js",
+    "sidebar/store/**/*.js",
     "sidebar/util/*.js",
     "types/*.d.ts"
   ],


### PR DESCRIPTION
This adds remaining types to modules in src/sidebar/store/ to enable that directory to typecheck with `noImplicitAny`. In the process some JSDoc mistakes were found with `AnnotationQuote` which have been fixed.