### PR TITLE
Migrate remaining "thread"-related components to TW

### DIFF
--- a/src/sidebar/components/ThreadCard.js
+++ b/src/sidebar/components/ThreadCard.js
@@ -1,3 +1,4 @@
+import { Card } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import debounce from 'lodash.debounce';
 import { useCallback, useMemo } from 'preact/hooks';
@@ -63,7 +64,11 @@ function ThreadCard({ frameSync, thread }) {
 
   return (
     /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-    <div
+    <Card
+      classes={classnames('p-3 cursor-pointer', {
+        'is-focused': isFocused,
+      })}
+      data-testid="thread-card"
       onClick={e => {
         // Prevent click events intended for another action from
         // triggering a page scroll.
@@ -74,12 +79,9 @@ function ThreadCard({ frameSync, thread }) {
       onMouseEnter={() => focusThreadAnnotation(threadTag)}
       onMouseLeave={() => focusThreadAnnotation(null)}
       key={thread.id}
-      className={classnames('ThreadCard p-3', {
-        'is-focused': isFocused,
-      })}
     >
       {threadContent}
-    </div>
+    </Card>
   );
 }
 

--- a/src/sidebar/components/ThreadList.js
+++ b/src/sidebar/components/ThreadList.js
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useMemo, useState } from 'preact/hooks';
+import classnames from 'classnames';
 import debounce from 'lodash.debounce';
 
 import { ListenerCollection } from '../../shared/listener-collection';
@@ -204,7 +205,19 @@ function ThreadList({ threads }) {
     <div>
       <div style={{ height: offscreenUpperHeight }} />
       {visibleThreads.map(child => (
-        <div className="ThreadList__card" id={child.id} key={child.id}>
+        <div
+          className={classnames(
+            // The goal is to space out each annotation card vertically. Typically
+            // this is better handled by applying vertical spacing to the parent
+            // element (e.g. `space-y-3`) but in this case, the constraints of
+            // sibling divs before and after the list of annotation cards prevents
+            // this, so a bottom margin is added to each card's wrapping element.
+            'mb-3'
+          )}
+          data-testid="thread-card-container"
+          id={child.id}
+          key={child.id}
+        >
           <ThreadCard thread={child} />
         </div>
       ))}

--- a/src/sidebar/components/test/ThreadCard-test.js
+++ b/src/sidebar/components/test/ThreadCard-test.js
@@ -11,6 +11,8 @@ describe('ThreadCard', () => {
   let fakeStore;
   let fakeThread;
 
+  const threadCardSelector = 'div[data-testid="thread-card"]';
+
   function createComponent(props) {
     return mount(
       <ThreadCard frameSync={fakeFrameSync} thread={fakeThread} {...props} />
@@ -54,14 +56,14 @@ describe('ThreadCard', () => {
 
     const wrapper = createComponent();
 
-    assert(wrapper.find('.ThreadCard').hasClass('is-focused'));
+    assert.isTrue(wrapper.find(threadCardSelector).hasClass('is-focused'));
   });
 
   describe('mouse and click events', () => {
     it('scrolls to the annotation when the `ThreadCard` is clicked', () => {
       const wrapper = createComponent();
 
-      wrapper.find('.ThreadCard').simulate('click');
+      wrapper.find(threadCardSelector).simulate('click');
 
       assert.calledWith(fakeFrameSync.scrollToAnnotation, 'myTag');
     });
@@ -69,7 +71,7 @@ describe('ThreadCard', () => {
     it('focuses the annotation thread when mouse enters', () => {
       const wrapper = createComponent();
 
-      wrapper.find('.ThreadCard').simulate('mouseenter');
+      wrapper.find(threadCardSelector).simulate('mouseenter');
 
       assert.calledWith(fakeFrameSync.focusAnnotations, sinon.match(['myTag']));
     });
@@ -77,7 +79,7 @@ describe('ThreadCard', () => {
     it('unfocuses the annotation thread when mouse exits', () => {
       const wrapper = createComponent();
 
-      wrapper.find('.ThreadCard').simulate('mouseleave');
+      wrapper.find(threadCardSelector).simulate('mouseleave');
 
       assert.calledWith(fakeFrameSync.focusAnnotations, sinon.match([]));
     });
@@ -89,10 +91,10 @@ describe('ThreadCard', () => {
         const nodeChild = document.createElement('div');
         nodeTarget.appendChild(nodeChild);
 
-        wrapper.find('.ThreadCard').props().onClick({
+        wrapper.find(threadCardSelector).props().onClick({
           target: nodeTarget,
         });
-        wrapper.find('.ThreadCard').props().onClick({
+        wrapper.find(threadCardSelector).props().onClick({
           target: nodeChild,
         });
         assert.notCalled(fakeFrameSync.scrollToAnnotation);

--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -256,7 +256,7 @@ describe('ThreadList', () => {
 
       // Calculate expected total height of thread list contents.
       const getRect = wrapper => wrapper.getDOMNode().getBoundingClientRect();
-      const cards = wrapper.find('.ThreadList__card');
+      const cards = wrapper.find('[data-testid="thread-card-container"]');
       const spaceBelowEachCard =
         getRect(cards.at(1)).top - getRect(cards.at(0)).bottom;
       const totalThreadHeight = fakeTopThread.children.reduce(

--- a/src/styles/sidebar/components/ThreadCard.scss
+++ b/src/styles/sidebar/components/ThreadCard.scss
@@ -1,9 +1,0 @@
-@use '../../variables' as var;
-@use '../../mixins/layout';
-@use '../../mixins/molecules';
-@use '../../mixins/utils';
-
-.ThreadCard {
-  @include molecules.card;
-  cursor: pointer;
-}

--- a/src/styles/sidebar/components/ThreadList.scss
+++ b/src/styles/sidebar/components/ThreadList.scss
@@ -1,5 +1,0 @@
-@use '../../variables' as var;
-
-.ThreadList__card {
-  margin-bottom: var.$layout-space;
-}

--- a/src/styles/sidebar/components/_index.scss
+++ b/src/styles/sidebar/components/_index.scss
@@ -25,7 +25,6 @@
 @use './SearchInput';
 @use './StyledText';
 @use './ThreadCard';
-@use './ThreadList';
 @use './ToastMessages';
 @use './VersionInfo';
 

--- a/src/styles/sidebar/components/_index.scss
+++ b/src/styles/sidebar/components/_index.scss
@@ -24,7 +24,6 @@
 @use './SelectionTabs';
 @use './SearchInput';
 @use './StyledText';
-@use './ThreadCard';
 @use './ToastMessages';
 @use './VersionInfo';
 


### PR DESCRIPTION
This small PR migrates `ThreadList` and `ThreadCard` to tailwind, now that the shared `Card` component can forward `div` attributes.

### User-visible changes

The vertical space between annotation cards decreases from 13px to 12px with these changes, to get the spacing on-scale. Since we have a historical love of tight vertical design, I hope this will be acceptable. The change does not catch my eye, personally. 

~~Depends on #4422~~
Part of https://github.com/hypothesis/client/issues/4377