### PR TITLE
Include all .d.ts files from src/types/ in main tsconfig.json

### DIFF
--- a/src/sidebar/components/ThreadCard.js
+++ b/src/sidebar/components/ThreadCard.js
@@ -25,14 +25,18 @@ import Thread from './Thread';
  */
 function ThreadCard({ frameSync, thread }) {
   const store = useStoreProxy();
-  const threadTag = thread.annotation && thread.annotation.$tag;
+  const threadTag = thread.annotation?.$tag ?? null;
   const isFocused = threadTag && store.isAnnotationFocused(threadTag);
   const focusThreadAnnotation = useMemo(
     () =>
-      debounce(tag => {
-        const focusTags = tag ? [tag] : [];
-        frameSync.focusAnnotations(focusTags);
-      }, 10),
+      debounce(
+        /** @param {string|null} tag */
+        tag => {
+          const focusTags = tag ? [tag] : [];
+          frameSync.focusAnnotations(focusTags);
+        },
+        10
+      ),
     [frameSync]
   );
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -24,7 +24,7 @@
     // code for the browser.
     "types": []
   },
-  "include": ["**/*.js", "types/process.d.ts"],
+  "include": ["**/*.js", "types/*.d.ts"],
   "exclude": [
     // Tests are not checked.
     "**/test/**/*.js",

--- a/src/types/lodash.debounce.d.ts
+++ b/src/types/lodash.debounce.d.ts
@@ -1,23 +1,26 @@
 // Self-contained types for lodash.debounce that include only the functionality
 // we use and avoids adding types for the whole of lodash to our dependencies.
 declare module 'lodash.debounce' {
-  interface DebouncedFunction {
-    (): void;
+  interface DebouncedFunction<Args extends unknown[]> {
+    (...args: Args): void;
     cancel(): void;
     flush(): void;
   }
 
   interface DebounceOptions {
+    leading?: boolean;
     maxWait?: number;
+    trailing?: boolean;
   }
 
-  export default function debounce(
-    callback: () => void,
+  export default function debounce<Args extends unknown[]>(
+    callback: (...args: Args) => void,
     options?: DebounceOptions
-  ): DebouncedFunction;
+  ): DebouncedFunction<Args>;
 
-  export default function debounce(
-    callback: () => void,
-    delay: number
-  ): DebouncedFunction;
+  export default function debounce<Args extends unknown[]>(
+    callback: (...args: Args) => void,
+    delay: number,
+    options?: DebounceOptions
+  ): DebouncedFunction<Args>;
 }


### PR DESCRIPTION
 - Include all src/types/*.d.ts files when typechecking with the main
   tsconfig.json config. Previously some of these were only included
   when using tsconfig.no-any.json.

 - Update our custom types for lodash.debounce to support arguments.
   This is needed by some of the `Thread*` components. I added the
   `leading` and `trailing` options for completeness, though we don't
   use them anywhere.

 - Add missing types in debounced callbacks in ThreadCard. These are now
   required due to the previous change.