### PR TITLE
Add missing types to MarkdownEditor

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.js
+++ b/src/sidebar/components/Annotation/AnnotationEditor.js
@@ -107,7 +107,8 @@ function AnnotationEditor({
   );
 
   const onEditText = useCallback(
-    ({ text }) => {
+    /** @param {string} text */
+    text => {
       store.createDraft(draft.annotation, { ...draft, text });
     },
     [draft, store]

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -98,7 +98,7 @@ describe('AnnotationEditor', () => {
       const editor = wrapper.find('MarkdownEditor');
 
       act(() => {
-        editor.props().onEditText({ text: 'updated text' });
+        editor.props().onEditText('updated text');
       });
 
       const call = fakeStore.createDraft.getCall(0);

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -119,9 +119,7 @@ describe('MarkdownEditor', () => {
 
         button.simulate('click');
 
-        assert.calledWith(onEditText, {
-          text: 'formatted text',
-        });
+        assert.calledWith(onEditText, 'formatted text');
         const [formatFunction, ...args] = effect;
         assert.calledWith(
           formatFunction,
@@ -184,9 +182,7 @@ describe('MarkdownEditor', () => {
               key: keyEvent.key,
             });
 
-            assert.calledWith(onEditText, {
-              text: 'formatted text',
-            });
+            assert.calledWith(onEditText, 'formatted text');
             const [formatFunction, ...args] = effect;
             assert.calledWith(
               formatFunction,
@@ -235,9 +231,7 @@ describe('MarkdownEditor', () => {
     const input = wrapper.find('textarea').getDOMNode();
     input.value = 'changed';
     wrapper.find('textarea').simulate('input');
-    assert.calledWith(onEditText, {
-      text: 'changed',
-    });
+    assert.calledWith(onEditText, 'changed');
   });
 
   it('enters preview mode when Preview button is clicked', () => {


### PR DESCRIPTION
 - Add missing types in MarkdownEditor implementation

 - Simplify `onEditText` prop to take a single `text` string argument
   instead of an object with a `text` property