### PR TITLE
Replace incorrect use of `any` with `void` in callback return types

### DIFF
--- a/src/annotator/components/AdderToolbar.js
+++ b/src/annotator/components/AdderToolbar.js
@@ -60,7 +60,7 @@ function AdderToolbarArrow({ arrowDirection }) {
  *  @param {number} [props.badgeCount]
  *  @param {string} [props.icon]
  *  @param {string} props.label
- *  @param {() => any} props.onClick
+ *  @param {() => void} props.onClick
  *  @param {string|null} props.shortcut
  */
 function ToolbarButton({ badgeCount, icon, label, onClick, shortcut }) {
@@ -99,7 +99,7 @@ function ToolbarButton({ badgeCount, icon, label, onClick, shortcut }) {
  *   should appear above the toolbar pointing Up or below the toolbar pointing
  *   Down.
  * @prop {boolean} isVisible - Whether to show the toolbar or not.
- * @prop {(c: Command) => any} onCommand - Called when a toolbar button is clicked.
+ * @prop {(c: Command) => void} onCommand - Called when a toolbar button is clicked.
  * @prop {number} [annotationCount] -
  *   Number of annotations associated with the selected text.
  *   If non-zero, a "Show" button is displayed to allow the user to see the

--- a/src/annotator/components/Toolbar.js
+++ b/src/annotator/components/Toolbar.js
@@ -33,10 +33,10 @@ function ToolbarButton({ ...buttonProps }) {
 /**
  * @typedef ToolbarProps
  *
- * @prop {() => any} closeSidebar -
+ * @prop {() => void} closeSidebar -
  *   Callback for the "Close sidebar" button. This button is only shown when
  *   `useMinimalControls` is true and the sidebar is open.
- * @prop {() => any} createAnnotation -
+ * @prop {() => void} createAnnotation -
  *   Callback for the "Create annotation" / "Create page note" button. The type
  *   of annotation depends on whether there is a text selection and is decided
  *   by the caller.
@@ -45,9 +45,9 @@ function ToolbarButton({ ...buttonProps }) {
  *   Icon to show on the "Create annotation" button indicating what kind of annotation
  *   will be created.
  * @prop {boolean} showHighlights - Are highlights currently visible in the document?
- * @prop {() => any} toggleHighlights -
+ * @prop {() => void} toggleHighlights -
  *   Callback to toggle visibility of highlights in the document.
- * @prop {() => any} toggleSidebar -
+ * @prop {() => void} toggleSidebar -
  *   Callback to toggle the visibility of the sidebar.
  * @prop {import("preact").Ref<HTMLButtonElement>} [toggleSidebarRef] -
  *   Ref that gets set to the toolbar button for toggling the sidebar.

--- a/src/annotator/integrations/html-side-by-side.js
+++ b/src/annotator/integrations/html-side-by-side.js
@@ -217,7 +217,7 @@ function getScrollAnchor(root, viewport) {
  * and tries to preserve the position of this content within the viewport
  * after the callback is invoked.
  *
- * @param {() => any} callback - Callback that will apply the layout change
+ * @param {() => void} callback - Callback that will apply the layout change
  * @param {Element} [scrollRoot]
  * @param {DOMRect} [viewport] - Area to consider "in the viewport". Defaults to
  *   the viewport of the current window.

--- a/src/annotator/range-util.js
+++ b/src/annotator/range-util.js
@@ -42,7 +42,7 @@ export function isNodeInRange(range, node) {
  * `callback` for each of them.
  *
  * @param {Range} range
- * @param {(n: Node) => any} callback
+ * @param {(n: Node) => void} callback
  */
 export function forEachNodeInRange(range, callback) {
   const root = range.commonAncestorContainer;

--- a/src/annotator/selection-observer.js
+++ b/src/annotator/selection-observer.js
@@ -25,7 +25,7 @@ export class SelectionObserver {
   /**
    * Start observing changes to the current selection in the document.
    *
-   * @param {(range: Range|null) => any} callback -
+   * @param {(range: Range|null) => void} callback -
    *   Callback invoked with the selected region of the document when it has
    *   changed.
    * @param {Document} document_ - Test seam

--- a/src/annotator/toolbar.js
+++ b/src/annotator/toolbar.js
@@ -4,9 +4,9 @@ import Toolbar from './components/Toolbar';
 
 /**
  * @typedef ToolbarOptions
- * @prop {() => any} createAnnotation
- * @prop {(open: boolean) => any} setSidebarOpen
- * @prop {(visible: boolean) => any} setHighlightsVisible
+ * @prop {() => void} createAnnotation
+ * @prop {(open: boolean) => void} setSidebarOpen
+ * @prop {(visible: boolean) => void} setHighlightsVisible
  */
 
 /**

--- a/src/shared/shortcut.js
+++ b/src/shared/shortcut.js
@@ -73,7 +73,7 @@ export function matchShortcut(event, shortcut) {
  * component, you probably want the `useShortcut` hook.
  *
  * @param {string} shortcut - Shortcut key sequence. See `matchShortcut`.
- * @param {(e: KeyboardEvent) => any} onPress - A function to call when the shortcut matches
+ * @param {(e: KeyboardEvent) => void} onPress - A function to call when the shortcut matches
  * @param {ShortcutOptions} [options]
  * @return {() => void} A function that removes the shortcut
  */
@@ -111,7 +111,7 @@ export function installShortcut(
  *
  * @param {string|null} shortcut -
  *   A shortcut key sequence to match or `null` to disable. See `matchShortcut`.
- * @param {(e: KeyboardEvent) => any} onPress - A function to call when the shortcut matches
+ * @param {(e: KeyboardEvent) => void} onPress - A function to call when the shortcut matches
  * @param {ShortcutOptions} [options]
  */
 export function useShortcut(shortcut, onPress, { rootElement } = {}) {

--- a/src/sidebar/components/Annotation/AnnotationActionBar.js
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.js
@@ -20,7 +20,7 @@ import AnnotationShareControl from './AnnotationShareControl';
 /**
  * @typedef AnnotationActionBarProps
  * @prop {SavedAnnotation} annotation - The annotation in question
- * @prop {() => any} onReply - Callbacks for when action buttons are clicked/tapped
+ * @prop {() => void} onReply - Callbacks for when action buttons are clicked/tapped
  * @prop {import('../../services/annotations').AnnotationsService} annotationsService
  * @prop {SidebarSettings} settings
  * @prop {import('../../services/toast-messenger').ToastMessengerService} toastMessenger

--- a/src/sidebar/components/Annotation/AnnotationReplyToggle.js
+++ b/src/sidebar/components/Annotation/AnnotationReplyToggle.js
@@ -2,7 +2,7 @@ import { LinkButton } from '@hypothesis/frontend-shared';
 
 /**
  * @typedef AnnotationReplyToggleProps
- * @prop {() => any} onToggleReplies
+ * @prop {() => void} onToggleReplies
  * @prop {number} replyCount
  * @prop {boolean} threadIsCollapsed
  */

--- a/src/sidebar/components/AnnotationView.js
+++ b/src/sidebar/components/AnnotationView.js
@@ -9,7 +9,7 @@ import SidebarContentError from './SidebarContentError';
 
 /**
  * @typedef AnnotationViewProps
- * @prop {() => any} onLogin
+ * @prop {() => void} onLogin
  * @prop {import('../services/load-annotations').LoadAnnotationsService} loadAnnotationsService
  */
 

--- a/src/sidebar/components/Excerpt.js
+++ b/src/sidebar/components/Excerpt.js
@@ -9,7 +9,7 @@ import { applyTheme } from '../helpers/theme';
 /**
  * @typedef InlineControlsProps
  * @prop {boolean} isCollapsed
- * @prop {(collapsed: boolean) => any} setCollapsed
+ * @prop {(collapsed: boolean) => void} setCollapsed
  * @prop {Record<string, string>} [linkStyle]
  */
 

--- a/src/sidebar/components/FilterSelect.js
+++ b/src/sidebar/components/FilterSelect.js
@@ -11,7 +11,7 @@ import MenuItem from './MenuItem';
  * @typedef FilterSelectProps
  * @prop {FilterOption} defaultOption
  * @prop {string} [icon]
- * @prop {(selectedFilter: FilterOption) => any} onSelect
+ * @prop {(selectedFilter: FilterOption) => void} onSelect
  * @prop {FilterOption[]} options
  * @prop {FilterOption} [selectedOption]
  * @prop {string} title

--- a/src/sidebar/components/GroupList/GroupListItem.js
+++ b/src/sidebar/components/GroupList/GroupListItem.js
@@ -14,7 +14,7 @@ import MenuItem from '../MenuItem';
  * @typedef GroupListItemProps
  * @prop {Group} group
  * @prop {boolean} [isExpanded] - Whether the submenu for this group is expanded
- * @prop {(expand: boolean) => any} onExpand -
+ * @prop {(expand: boolean) => void} onExpand -
  *   Callback invoked to expand or collapse the current group
  * @prop {import('../../services/groups').GroupsService} groups
  * @prop {import('../../services/toast-messenger').ToastMessengerService} toastMessenger

--- a/src/sidebar/components/GroupList/GroupListSection.js
+++ b/src/sidebar/components/GroupList/GroupListSection.js
@@ -12,7 +12,7 @@ import GroupListItem from './GroupListItem';
  *  - The `Group` whose submenu is currently expanded, or `null` if no group is currently expanded
  * @prop {Group[]} groups - The list of groups to be displayed in the group list section
  * @prop {string} [heading] - The string name of the group list section
- * @prop {(group: Group|null) => any} onExpandGroup -
+ * @prop {(group: Group|null) => void} onExpandGroup -
  *   Callback invoked when a group is expanded or collapsed.  The argument is the group being
  *   expanded, or `null` if the expanded group is being collapsed.
  */

--- a/src/sidebar/components/LoggedOutMessage.js
+++ b/src/sidebar/components/LoggedOutMessage.js
@@ -4,7 +4,7 @@ import { useStoreProxy } from '../store/use-store';
 
 /**
  * @typedef LoggedOutMessageProps
- * @prop {() => any} onLogin
+ * @prop {() => void} onLogin
  */
 
 /**

--- a/src/sidebar/components/LoginPromptPanel.js
+++ b/src/sidebar/components/LoginPromptPanel.js
@@ -6,8 +6,8 @@ import SidebarPanel from './SidebarPanel';
 
 /**
  * @typedef LoginPromptPanelProps
- * @prop {() => any} onLogin
- * @prop {() => any} onSignUp
+ * @prop {() => void} onLogin
+ * @prop {() => void} onSignUp
  */
 
 /**

--- a/src/sidebar/components/Menu.js
+++ b/src/sidebar/components/Menu.js
@@ -49,7 +49,7 @@ let ignoreNextClick = false;
  * @prop {string} [contentClass] - Additional CSS classes to apply to the menu.
  * @prop {boolean} [defaultOpen] - Whether the menu is open or closed when initially rendered.
  *   Ignored if `open` is present.
- * @prop {(open: boolean) => any} [onOpenChanged] - Callback invoked when the menu is
+ * @prop {(open: boolean) => void} [onOpenChanged] - Callback invoked when the menu is
  *   opened or closed.  This can be used, for example, to reset any ephemeral state that the
  *   menu content may have.
  * @prop {boolean} [open] - Whether the menu is currently open; overrides internal state

--- a/src/sidebar/components/MenuItem.js
+++ b/src/sidebar/components/MenuItem.js
@@ -34,8 +34,8 @@ import Slider from './Slider';
  *   indicate the current state; `true` if the submenu is visible. Note. Omit this prop,
  *    or set it to null, if there is no `submenu`.
  * @prop {string} label - Label of the menu item.
- * @prop {(e: Event) => any} [onClick] - Callback to invoke when the menu item is clicked.
- * @prop {(e: Event) => any} [onToggleSubmenu] -
+ * @prop {(e: Event) => void} [onClick] - Callback to invoke when the menu item is clicked.
+ * @prop {(e: Event) => void} [onToggleSubmenu] -
  *   Callback when the user clicks on the toggle to change the expanded state of the menu.
  * @prop {object} [submenu] -
  *   Contents of the submenu for this item.  This is typically a list of `MenuItem` components

--- a/src/sidebar/components/MenuKeyboardNavigation.js
+++ b/src/sidebar/components/MenuKeyboardNavigation.js
@@ -9,7 +9,7 @@ function isElementVisible(element) {
 /**
  * @typedef MenuKeyboardNavigationProps
  * @prop {string} [className]
- * @prop {(e: KeyboardEvent) => any} [closeMenu] - Callback when the menu is closed via keyboard input
+ * @prop {(e: KeyboardEvent) => void} [closeMenu] - Callback when the menu is closed via keyboard input
  * @prop {boolean} [visible] - When  true`, sets focus on the first item in the list
  * @prop {import('preact').ComponentChildren} children - Array of nodes which may contain <MenuItems> or any nodes
  */

--- a/src/sidebar/components/SearchInput.js
+++ b/src/sidebar/components/SearchInput.js
@@ -10,7 +10,7 @@ import { useStoreProxy } from '../store/use-store';
  *   If true, the input field is always shown. If false, the input field is only shown
  *   if the query is non-empty.
  * @prop {string|null} query - The currently active filter query
- * @prop {(value: string) => any} onSearch -
+ * @prop {(value: string) => void} onSearch -
  *   Callback to invoke when the current filter query changes
  */
 

--- a/src/sidebar/components/SelectionTabs.js
+++ b/src/sidebar/components/SelectionTabs.js
@@ -19,7 +19,7 @@ import { withServices } from '../service-context';
  * @prop {boolean} isSelected - Is this tab currently selected?
  * @prop {boolean} isWaitingToAnchor - Are there any annotations still waiting to anchor?
  * @prop {string} label - A string label to use for a11y
- * @prop {() => any} onSelect - Callback to invoke when this tab is selected
+ * @prop {() => void} onSelect - Callback to invoke when this tab is selected
  */
 
 /**

--- a/src/sidebar/components/SidebarContentError.js
+++ b/src/sidebar/components/SidebarContentError.js
@@ -6,7 +6,7 @@ import { useStoreProxy } from '../store/use-store';
  * @typedef SidebarContentErrorProps
  * @prop {'annotation'|'group'} errorType
  * @prop {boolean} [showClearSelection] - Whether to show a "Clear selection" button.
- * @prop {() => any} onLoginRequest - A function that will launch the login flow for the user.
+ * @prop {() => void} onLoginRequest - A function that will launch the login flow for the user.
  */
 
 /**

--- a/src/sidebar/components/SidebarPanel.js
+++ b/src/sidebar/components/SidebarPanel.js
@@ -18,7 +18,7 @@ import Slider from './Slider';
  *   A string identifying this panel. Only one `panelName` may be active at any time.
  *   Multiple panels with the same `panelName` would be "in sync", opening and closing together.
  * @prop {string} title - The panel's title
- * @prop {(active: boolean) => any} [onActiveChanged] -
+ * @prop {(active: boolean) => void} [onActiveChanged] -
  *   Optional callback to invoke when this panel's active status changes
  */
 

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -14,8 +14,8 @@ import ThreadList from './ThreadList';
 
 /**
  * @typedef SidebarViewProps
- * @prop {() => any} onLogin
- * @prop {() => any} onSignUp
+ * @prop {() => void} onLogin
+ * @prop {() => void} onSignUp
  * @prop {import('../services/frame-sync').FrameSyncService} frameSync
  * @prop {import('../services/load-annotations').LoadAnnotationsService} loadAnnotationsService
  * @prop {import('../services/streamer').StreamerService} streamer

--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -20,7 +20,7 @@ let tagEditorIdCounter = 0;
  * @typedef TagEditorProps
  * @prop {(tag: string) => boolean} onAddTag - Callback to add a tag to the annotation
  * @prop {(tag: string) => boolean} onRemoveTag - Callback to remove a tag from the annotation
- * @prop {(tag: string) => any} onTagInput - Callback when inputted tag text changes
+ * @prop {(tag: string) => void} onTagInput - Callback when inputted tag text changes
  * @prop {string[]} tagList - The list of tags for the annotation under edit
  * @prop {import('../services/tags').TagsService} tags
  */

--- a/src/sidebar/components/ToastMessages.js
+++ b/src/sidebar/components/ToastMessages.js
@@ -11,7 +11,7 @@ import { withServices } from '../service-context';
 /**
  * @typedef ToastMessageProps
  * @prop {ToastMessage} message - The message object to render
- * @prop {(id: string) => any} onDismiss
+ * @prop {(id: string) => void} onDismiss
  */
 
 /**

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -26,7 +26,7 @@ import MenuSection from './MenuSection';
 /**
  * @typedef UserMenuProps
  * @prop {AuthStateLoggedIn} auth - object representing authenticated user and auth status
- * @prop {() => any} onLogout - onClick callback for the "log out" button
+ * @prop {() => void} onLogout - onClick callback for the "log out" button
  * @prop {import('../services/frame-sync').FrameSyncService} frameSync
  * @prop {SidebarSettings} settings
  */

--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -63,8 +63,8 @@ function stripInternalProperties(obj) {
  * @prop {() => string|null} getClientId -
  *   Function that returns a per-session client ID to include with the request
  *   or `null`.
- * @prop {() => any} onRequestStarted - Callback invoked when the API request starts.
- * @prop {() => any} onRequestFinished - Callback invoked when the API request finishes.
+ * @prop {() => void} onRequestStarted - Callback invoked when the API request starts.
+ * @prop {() => void} onRequestFinished - Callback invoked when the API request finishes.
  */
 
 /**

--- a/src/sidebar/services/load-annotations.js
+++ b/src/sidebar/services/load-annotations.js
@@ -19,7 +19,7 @@ import { SearchClient } from '../search-client';
  *   with the expected presentation order of annotations/threads in the current
  *   view.
  * @prop {SortOrder} [sortOrder]
- * @prop {(error: Error) => any} [onError] - Optional error handler for
+ * @prop {(error: Error) => void} [onError] - Optional error handler for
  *   SearchClient. Default error handling logs errors to console.
  * @prop {'uri'|'group'} [streamFilterBy] - Set the websocket stream
  *   to filter by either URIs or groupIds.

--- a/src/sidebar/util/observe-element-size.js
+++ b/src/sidebar/util/observe-element-size.js
@@ -8,7 +8,7 @@ import { ListenerCollection } from '../../shared/listener-collection';
  * updates are no longer needed.
  *
  * @param {Element} element - HTML element to watch
- * @param {(width: number, height: number) => any} onSizeChanged -
+ * @param {(width: number, height: number) => void} onSizeChanged -
  *   Callback to invoke with the `clientWidth` and `clientHeight` of the
  *   element when a change in its size is detected.
  * @return {() => void}

--- a/src/sidebar/util/watch.js
+++ b/src/sidebar/util/watch.js
@@ -42,7 +42,7 @@ import shallowEqual from 'shallowequal';
  *   subscribe to notifications of _potential_ changes in the watched values.
  * @param {Function|Array<Function>} watchFns - A function or array of functions
  *   which return the current watched values
- * @param {(current: any, previous: any) => any} callback -
+ * @param {(current: any, previous: any) => void} callback -
  *   A callback that is invoked when the watched values changed. It is passed
  *   the current and previous values respectively. If `watchFns` is an array,
  *   the `current` and `previous` arguments will be arrays of current and


### PR DESCRIPTION
When declaring a prop or parameter callback whose result is unused, the
return type should be `void` rather than `any`. In this context the
return type specifies what the callee _requires_, not what the caller
_provides_.