### PR TITLE
Specify types for remaining JSON responses that didn't have them

### DIFF
--- a/src/sidebar/search-client.js
+++ b/src/sidebar/search-client.js
@@ -3,7 +3,7 @@ import { TinyEmitter } from 'tiny-emitter';
 /**
  * @typedef {import('../types/api').Annotation} Annotation
  * @typedef {import('../types/api').SearchQuery} SearchQuery
- * @typedef {import('../types/api').SearchResult} SearchResult
+ * @typedef {import('../types/api').SearchResponse} SearchResponse
  *
  */
 
@@ -47,7 +47,8 @@ function defaultPageSize(index) {
  */
 export class SearchClient extends TinyEmitter {
   /**
-   * @param {(query: SearchQuery) => Promise<SearchResult>} searchFn - Function for querying the search API
+   * @param {(query: SearchQuery) => Promise<SearchResponse>} searchFn -
+   *   Callback that executes a search request against the Hypothesis API
    * @param {object} options
    *   @param {(index: number) => number} [options.getPageSize] -
    *     Callback that returns the page size to use when fetching the index'th

--- a/src/sidebar/util/fetch.js
+++ b/src/sidebar/util/fetch.js
@@ -41,7 +41,7 @@ export class FetchError extends Error {
  *
  * @param {string} url
  * @param {RequestInit} [init] - Parameters for `fetch` request
- * @return {Promise<any>} - Parsed JSON response or `null` if response status is 204 (No Content)
+ * @return {Promise<unknown>} - Parsed JSON response or `null` if response status is 204 (No Content)
  * @throws {FetchError} if the request fails, returns a non-2xx status or a JSON
  *   response is expected but cannot be parsed
  */

--- a/src/sidebar/util/oauth-client.js
+++ b/src/sidebar/util/oauth-client.js
@@ -2,6 +2,17 @@ import { generateHexString } from '../../shared/random';
 import { fetchJSON } from './fetch';
 
 /**
+ * OAuth access token response.
+ *
+ * See https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+ *
+ * @typedef AccessTokenResponse
+ * @prop {string} access_token
+ * @prop {number} expires_in
+ * @prop {string} refresh_token
+ */
+
+/**
  * An object holding the details of an access token from the tokenUrl endpoint.
  *
  * @typedef TokenInfo
@@ -213,15 +224,17 @@ export class OAuthClient {
   /**
    * Fetch an OAuth access token.
    *
+   * See https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
+   *
    * @param {Record<string, string>} data - Parameters for form POST request
    * @return {Promise<TokenInfo>}
    */
   async _getAccessToken(data) {
-    // The request to `tokenEndpoint` returns an OAuth "Access Token Response".
-    // See https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.4
     let response;
     try {
-      response = await this._formPost(this.tokenEndpoint, data);
+      response = /** @type {AccessTokenResponse} */ (
+        await this._formPost(this.tokenEndpoint, data)
+      );
     } catch (err) {
       throw new TokenError('Failed to fetch access token', err);
     }

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -231,7 +231,7 @@
  *
  * See https://h.readthedocs.io/en/latest/api-reference/#tag/annotations/paths/~1search/get
  *
- * @typedef SearchResult
+ * @typedef SearchResponse
  * @prop {number} total
  * @prop {Annotation[]} rows
  * @prop {Annotation[]} [replies] - Unofficial property that is populated if

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -6,7 +6,7 @@
  */
 
 /**
- * An entry in the API index response (`/api`) describing an API route.
+ * Metadata specifying how to call an API route.
  *
  * @typedef RouteMetadata
  * @prop {string} method - HTTP method
@@ -15,10 +15,25 @@
  */
 
 /**
- * Structure of the `links` field of the API index response (`/api`) describing
- * available API routes.
+ * A nested map of API route name to route metadata.
  *
  * @typedef {{ [key: string]: RouteMap|RouteMetadata }} RouteMap
+ */
+
+/**
+ * Structure of the API index response (`/api`).
+ *
+ * @typedef IndexResponse
+ * @prop {RouteMap} links
+ */
+
+/**
+ * Structure of the Hypothesis links response (`/api/links`).
+ *
+ * This is a map of link name (eg. "account.settings") to URL. The URL may
+ * include ":"-prefixed placeholders/variables.
+ *
+ * @typedef {Record<string, string>} LinksResponse
  */
 
 /**


### PR DESCRIPTION
Make `fetchJSON` return `Promise<unknown>` rather than `Promise<any>`
and add appropriate types and casts for the remaining API / OAuth
responses that didn't have them.

Also rename the `SearchResult` type used by the `/api/search` response to `SearchResponse` for consistency.