### PR TITLE
Refine types of `config` parameters in annotator code

### DIFF
--- a/src/annotator/components/NotebookModal.js
+++ b/src/annotator/components/NotebookModal.js
@@ -9,7 +9,7 @@ import { createAppConfig } from '../config/app';
  * Configuration used to launch the notebook application.
  *
  * This includes the URL for the iframe and configuration to pass to the
- * application using a config fragment (see {@link addConfigFragment}).
+ * application on launch.
  *
  * @typedef {{ notebookAppUrl: string } & Record<string, unknown>} NotebookConfig
  */

--- a/src/annotator/components/NotebookModal.js
+++ b/src/annotator/components/NotebookModal.js
@@ -6,8 +6,17 @@ import { addConfigFragment } from '../../shared/config-fragment';
 import { createAppConfig } from '../config/app';
 
 /**
+ * Configuration used to launch the notebook application.
+ *
+ * This includes the URL for the iframe and configuration to pass to the
+ * application using a config fragment (see {@link addConfigFragment}).
+ *
+ * @typedef {{ notebookAppUrl: string } & Record<string, unknown>} NotebookConfig
+ */
+
+/**
  * @typedef NotebookIframeProps
- * @prop {Record<string, any>} config
+ * @prop {NotebookConfig} config
  * @prop {string} groupId
  */
 
@@ -40,7 +49,7 @@ function NotebookIframe({ config, groupId }) {
 /**
  * @typedef NotebookModalProps
  * @prop {import('../util/emitter').EventBus} eventBus
- * @prop {Record<string, any>} config
+ * @prop {NotebookConfig} config
  */
 
 /**

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -94,6 +94,17 @@ function removeTextSelection() {
 }
 
 /**
+ * Subset of the Hypothesis client configuration that is used by {@link Guest}.
+ *
+ * @typedef GuestConfig
+ * @prop {string} [subFrameIdentifier] - An identifier used by this guest to
+ *   identify the current frame when communicating with the sidebar. This is
+ *   only set in non-host frames.
+ * @prop {'jstor'} [contentPartner] - Configures a banner or other indicators
+ *   showing where the content has come from.
+ */
+
+/**
  * `Guest` is the central class of the annotator that handles anchoring (locating)
  * annotations in the document when they are fetched by the sidebar, rendering
  * highlights for them and handling subsequent interactions with the highlights.
@@ -121,7 +132,7 @@ export class Guest {
    * @param {HTMLElement} element -
    *   The root element in which the `Guest` instance should be able to anchor
    *   or create annotations. In an ordinary web page this typically `document.body`.
-   * @param {Record<string, any>} [config]
+   * @param {GuestConfig} [config]
    * @param {Window} [hostFrame] -
    *   Host frame which this guest is associated with. This is expected to be
    *   an ancestor of the guest frame. It may be same or cross origin.

--- a/src/annotator/hypothesis-injector.js
+++ b/src/annotator/hypothesis-injector.js
@@ -7,6 +7,15 @@ import { onNextDocumentReady, FrameObserver } from './frame-observer';
  */
 
 /**
+ * Options for injecting the client into child frames.
+ *
+ * This includes the URL of the client's boot script, plus configuration
+ * for the client when it loads in the child frame.
+ *
+ * @typedef {{ clientUrl: string } & Record<string, unknown>} InjectConfig
+ */
+
+/**
  * HypothesisInjector injects the Hypothesis client into same-origin iframes.
  *
  * The client will be injected automatically into frames that have the
@@ -19,8 +28,7 @@ export class HypothesisInjector {
   /**
    * @param {Element} element - root of the DOM subtree to watch for the
    *   addition and removal of annotatable iframes
-   * @param {Record<string, any>} config - Annotator configuration that is
-   *   injected, along with the Hypothesis client, into the child iframes
+   * @param {InjectConfig} config
    */
   constructor(element, config) {
     this._config = config;
@@ -59,8 +67,7 @@ function hasHypothesis(iframe) {
  * See {@link onDocumentReady}.
  *
  * @param {HTMLIFrameElement} frame
- * @param {Record<string, any>} config - Annotator configuration that is
- *   injected, along with the Hypothesis client, into the child iframes
+ * @param {InjectConfig} config -
  */
 export async function injectClient(frame, config) {
   if (hasHypothesis(frame)) {

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -35,6 +35,14 @@ const sidebarLinkElement = /** @type {HTMLLinkElement} */ (
 );
 
 /**
+ * @typedef {import('./components/NotebookModal').NotebookConfig} NotebookConfig
+ * @typedef {import('./guest').GuestConfig} GuestConfig
+ * @typedef {import('./hypothesis-injector').InjectConfig} InjectConfig
+ * @typedef {import('./sidebar').SidebarConfig} SidebarConfig
+ * @typedef {import('./sidebar').SidebarContainerConfig} SidebarContainerConfig
+ */
+
+/**
  * Entry point for the part of the Hypothesis client that runs in the page being
  * annotated.
  *
@@ -47,7 +55,9 @@ const sidebarLinkElement = /** @type {HTMLLinkElement} */ (
  * client is initially loaded, is also the only guest frame.
  */
 function init() {
-  const annotatorConfig = getConfig('annotator');
+  const annotatorConfig = /** @type {GuestConfig & InjectConfig} */ (
+    getConfig('annotator')
+  );
 
   const hostFrame = annotatorConfig.subFrameIdentifier ? window.parent : window;
 
@@ -59,7 +69,7 @@ function init() {
     const removeWorkaround = installPortCloseWorkaroundForSafari();
     destroyables.push({ destroy: removeWorkaround });
 
-    const sidebarConfig = getConfig('sidebar');
+    const sidebarConfig = /** @type {SidebarConfig} */ (getConfig('sidebar'));
 
     const hypothesisAppsOrigin = new URL(
       /** @type {string} */ (sidebarConfig.sidebarAppUrl)
@@ -71,7 +81,7 @@ function init() {
     const notebook = new Notebook(
       document.body,
       eventBus,
-      getConfig('notebook')
+      /** @type {NotebookConfig} */ (getConfig('notebook'))
     );
 
     portProvider.on('frameConnected', (source, port) =>

--- a/src/annotator/integrations/vitalsource.js
+++ b/src/annotator/integrations/vitalsource.js
@@ -11,6 +11,7 @@ import { injectClient } from '../hypothesis-injector';
  * @typedef {import('../../types/annotator').Integration} Integration
  * @typedef {import('../../types/annotator').Selector} Selector
  * @typedef {import('../../types/annotator').SidebarLayout} SidebarLayout
+ * @typedef {import('../hypothesis-injector').InjectConfig} InjectConfig
  */
 
 // When activating side-by-side mode for VitalSource PDF documents, make sure
@@ -67,8 +68,8 @@ export function vitalSourceFrameRole(window_ = window) {
  */
 export class VitalSourceInjector {
   /**
-   * @param {Record<string, any>} config - Annotator configuration that is
-   *   injected, along with the Hypothesis client, into the book content iframes
+   * @param {InjectConfig} config - Configuration for injecting the client into
+   *   book content frames
    */
   constructor(config) {
     const bookElement = findBookElement();

--- a/src/annotator/notebook.js
+++ b/src/annotator/notebook.js
@@ -2,7 +2,10 @@ import { createShadowRoot } from './util/shadow-root';
 import { render } from 'preact';
 import NotebookModal from './components/NotebookModal';
 
-/** @typedef {import('../types/annotator').Destroyable} Destroyable */
+/**
+ * @typedef {import('../types/annotator').Destroyable} Destroyable
+ * @typedef {import('./components/NotebookModal').NotebookConfig} NotebookConfig
+ */
 
 /** @implements {Destroyable} */
 export class Notebook {
@@ -10,9 +13,9 @@ export class Notebook {
    * @param {HTMLElement} element
    * @param {import('./util/emitter').EventBus} eventBus -
    *   Enables communication between components sharing the same eventBus
-   * @param {Record<string, any>} config
+   * @param {NotebookConfig} config
    */
-  constructor(element, eventBus, config = {}) {
+  constructor(element, eventBus, config) {
     /**
      * Un-styled shadow host for the notebook content.
      * This isolates the notebook from the page's styles.

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -18,6 +18,7 @@ import { createShadowRoot } from './util/shadow-root';
  * @typedef {import('../types/annotator').AnchorPosition} AnchorPosition
  * @typedef {import('../types/annotator').SidebarLayout} SidebarLayout
  * @typedef {import('../types/annotator').Destroyable} Destroyable
+ * @typedef {import('../types/config').Service} Service
  * @typedef {import('../types/port-rpc-events').GuestToHostEvent} GuestToHostEvent
  * @typedef {import('../types/port-rpc-events').HostToGuestEvent} HostToGuestEvent
  * @typedef {import('../types/port-rpc-events').HostToSidebarEvent} HostToSidebarEvent
@@ -28,9 +29,33 @@ import { createShadowRoot } from './util/shadow-root';
 export const MIN_RESIZE = 280;
 
 /**
+ * Client configuration used to launch the sidebar application.
+ *
+ * This includes the URL for the iframe and configuration to pass to the
+ * application using a config fragment (see {@link addConfigFragment}).
+ *
+ * @typedef {{ sidebarAppUrl: string } & Record<string, unknown>} SidebarConfig
+ */
+
+/**
+ * Client configuration used by the sidebar container ({@link Sidebar}).
+ *
+ * @typedef SidebarContainerConfig
+ * @prop {Service[]} [services] - Details of the annotation service the
+ *   client should connect to. This includes callbacks provided by the host
+ *   page to handle certain actions in the sidebar (eg. the Login button).
+ * @prop {string} [externalContainerSelector] - CSS selector of a container
+ *   element in the host page which the sidebar should be added into, instead
+ *   of creating a new container.
+ * @prop {(layout: SidebarLayout) => void} [onLayoutChange] - Callback that
+ *   allows the host page to react to the sidebar being opened, closed or
+ *   resized
+ */
+
+/**
  * Create the iframe that will load the sidebar application.
  *
- * @param {Record<string, unknown>} config
+ * @param {SidebarConfig} config
  * @return {HTMLIFrameElement}
  */
 function createSidebarIframe(config) {
@@ -63,9 +88,9 @@ export class Sidebar {
    * @param {HTMLElement} element
    * @param {import('./util/emitter').EventBus} eventBus -
    *   Enables communication between components sharing the same eventBus
-   * @param {Record<string, any>} [config]
+   * @param {SidebarContainerConfig & SidebarConfig} config
    */
-  constructor(element, eventBus, config = {}) {
+  constructor(element, eventBus, config) {
     this._emitter = eventBus.createEmitter();
 
     /**
@@ -345,7 +370,7 @@ export class Sidebar {
       this.show();
     });
 
-    /** @type {Array<[SidebarToHostEvent, function]>} */
+    /** @type {Array<[SidebarToHostEvent, Function|undefined]>} */
     const eventHandlers = [
       ['loginRequested', this.onLoginRequest],
       ['logoutRequested', this.onLogoutRequest],

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -32,7 +32,7 @@ export const MIN_RESIZE = 280;
  * Client configuration used to launch the sidebar application.
  *
  * This includes the URL for the iframe and configuration to pass to the
- * application using a config fragment (see {@link addConfigFragment}).
+ * application on launch.
  *
  * @typedef {{ sidebarAppUrl: string } & Record<string, unknown>} SidebarConfig
  */


### PR DESCRIPTION
Various functions and constructors in the annotator code accepted a `config`
parameter with an uninformative `Record<string, any>` type.  Replace these types
with more specific ones that specify required / known optional properties
directly and use `Record<string, unknown>` for properties which are forwarded to
other contexts.

Also improve the documentation for the `getConfig` function which serves
as the entry point for reading configuration in the annotator.