### PR TITLE
Split `useStore` hook into general and app-specific hooks

### DIFF
--- a/src/sidebar/components/Annotation/Annotation.js
+++ b/src/sidebar/components/Annotation/Annotation.js
@@ -1,7 +1,7 @@
 import { Actions, Spinner } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
-import { useStoreProxy } from '../../store/use-store';
+import { useSidebarStore } from '../../store';
 import { isOrphan, isSaved, quote } from '../../helpers/annotation-metadata';
 import { withServices } from '../../service-context';
 
@@ -72,7 +72,7 @@ function Annotation({
 }) {
   const isCollapsedReply = isReply && threadIsCollapsed;
 
-  const store = useStoreProxy();
+  const store = useSidebarStore();
 
   const draft = annotation && store.getDraft(annotation);
 

--- a/src/sidebar/components/Annotation/AnnotationActionBar.js
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.js
@@ -8,7 +8,7 @@ import {
 } from '../../helpers/annotation-sharing';
 import { isPrivate, permits } from '../../helpers/permissions';
 import { withServices } from '../../service-context';
-import { useStoreProxy } from '../../store/use-store';
+import { useSidebarStore } from '../../store';
 
 import AnnotationShareControl from './AnnotationShareControl';
 
@@ -48,7 +48,7 @@ function AnnotationActionBar({
   settings,
   toastMessenger,
 }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const userProfile = store.profile();
   const annotationGroup = store.getGroup(annotation.group);
   const isLoggedIn = store.isLoggedIn();

--- a/src/sidebar/components/Annotation/AnnotationBody.js
+++ b/src/sidebar/components/Annotation/AnnotationBody.js
@@ -2,7 +2,7 @@ import { Icon, LabeledButton } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useMemo, useState } from 'preact/hooks';
 
-import { useStoreProxy } from '../../store/use-store';
+import { useSidebarStore } from '../../store';
 import { isThirdPartyUser } from '../../helpers/account-id';
 import { isHidden } from '../../helpers/annotation-metadata';
 import { withServices } from '../../service-context';
@@ -71,7 +71,7 @@ function AnnotationBody({ annotation, settings }) {
   // collapsing/expanding is relevant?
   const [collapsible, setCollapsible] = useState(false);
 
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const defaultAuthority = store.defaultAuthority();
   const draft = store.getDraft(annotation);
 

--- a/src/sidebar/components/Annotation/AnnotationEditor.js
+++ b/src/sidebar/components/Annotation/AnnotationEditor.js
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'preact/hooks';
 import { withServices } from '../../service-context';
 import { isReply, isSaved } from '../../helpers/annotation-metadata';
 import { applyTheme } from '../../helpers/theme';
-import { useStoreProxy } from '../../store/use-store';
+import { useSidebarStore } from '../../store';
 
 import MarkdownEditor from '../MarkdownEditor';
 import TagEditor from '../TagEditor';
@@ -46,7 +46,7 @@ function AnnotationEditor({
     /** @type {string|null} */ (null)
   );
 
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const group = store.getGroup(annotation.group);
 
   const shouldShowLicense =

--- a/src/sidebar/components/Annotation/AnnotationHeader.js
+++ b/src/sidebar/components/Annotation/AnnotationHeader.js
@@ -2,7 +2,7 @@ import { Icon, LinkButton } from '@hypothesis/frontend-shared';
 import { useMemo } from 'preact/hooks';
 
 import { withServices } from '../../service-context';
-import { useStoreProxy } from '../../store/use-store';
+import { useSidebarStore } from '../../store';
 import { isThirdPartyUser, username } from '../../helpers/account-id';
 import {
   domainAndTitle,
@@ -56,7 +56,7 @@ function AnnotationHeader({
   threadIsCollapsed,
   settings,
 }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const defaultAuthority = store.defaultAuthority();
   const displayNamesEnabled = store.isFeatureEnabled('client_display_names');
 

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -64,7 +64,7 @@ describe('Annotation', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../../helpers/annotation-metadata': fakeMetadata,
-      '../../store/use-store': { useStoreProxy: () => fakeStore },
+      '../../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
@@ -95,7 +95,7 @@ describe('AnnotationActionBar', () => {
         annotationSharingLink: fakeAnnotationSharingLink,
       },
       '../../helpers/permissions': { permits: fakePermits },
-      '../../store/use-store': { useStoreProxy: () => fakeStore },
+      '../../store': { useSidebarStore: () => fakeStore },
       '../../../shared/prompts': { confirm: fakeConfirm },
     });
   });

--- a/src/sidebar/components/Annotation/test/AnnotationBody-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationBody-test.js
@@ -60,7 +60,7 @@ describe('AnnotationBody', () => {
     $imports.$mock({
       '../../helpers/account-id': { isThirdPartyUser: fakeIsThirdPartyUser },
       '../../helpers/theme': { applyTheme: fakeApplyTheme },
-      '../../store/use-store': { useStoreProxy: () => fakeStore },
+      '../../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -64,7 +64,7 @@ describe('AnnotationEditor', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../../store/use-store': { useStoreProxy: () => fakeStore },
+      '../../store': { useSidebarStore: () => fakeStore },
       '../../helpers/theme': { applyTheme: fakeApplyTheme },
     });
     // `AnnotationLicense` is a presentation-only component and is only used

--- a/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
@@ -66,7 +66,7 @@ describe('AnnotationHeader', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../../store/use-store': { useStoreProxy: () => fakeStore },
+      '../../store': { useSidebarStore: () => fakeStore },
       '../../helpers/account-id': fakeAccountId,
       '../../helpers/annotation-metadata': {
         domainAndTitle: fakeDomainAndTitle,

--- a/src/sidebar/components/AnnotationView.js
+++ b/src/sidebar/components/AnnotationView.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'preact/hooks';
 
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 import { withServices } from '../service-context';
 import { useRootThread } from './hooks/use-root-thread';
 
@@ -19,7 +19,7 @@ import SidebarContentError from './SidebarContentError';
  * @param {AnnotationViewProps} props
  */
 function AnnotationView({ loadAnnotationsService, onLogin }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const annotationId = store.routeParams().id;
   const rootThread = useRootThread();
   const userid = store.profile().userid;

--- a/src/sidebar/components/FilterStatus.js
+++ b/src/sidebar/components/FilterStatus.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { useMemo } from 'preact/hooks';
 
 import { countVisible } from '../helpers/thread';
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 
 import { useRootThread } from './hooks/use-root-thread';
 
@@ -69,7 +69,7 @@ function FilterStatusPanel({
   focusDisplayName,
   resultCount,
 }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   return (
     <Card classes="mb-3 p-3">
       <div className="flex items-center justify-center space-x-1">
@@ -133,7 +133,7 @@ function FilterStatusPanel({
  * @param {FilterModeProps} props
  */
 function SelectionFilterStatus({ filterState, rootThread }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const directLinkedId = store.directLinkedAnnotationId();
   // The total number of top-level annotations (visible or not)
   const totalCount = store.annotationCount();
@@ -188,7 +188,7 @@ function SelectionFilterStatus({ filterState, rootThread }) {
  * @param {FilterModeProps} props
  */
 function QueryFilterStatus({ filterState, rootThread }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const visibleCount = countVisible(rootThread);
   const resultCount = visibleCount - filterState.forcedVisibleCount;
 
@@ -233,7 +233,7 @@ function QueryFilterStatus({ filterState, rootThread }) {
  * @param {FilterModeProps} props
  */
 function FocusFilterStatus({ filterState, rootThread }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const visibleCount = countVisible(rootThread);
   const resultCount = visibleCount - filterState.forcedVisibleCount;
 
@@ -280,7 +280,7 @@ function FocusFilterStatus({ filterState, rootThread }) {
 export default function FilterStatus() {
   const rootThread = useRootThread();
 
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const focusState = store.focusState();
   const forcedVisibleCount = store.forcedVisibleThreads().length;
   const filterQuery = store.filterQuery();

--- a/src/sidebar/components/GroupList/GroupList.js
+++ b/src/sidebar/components/GroupList/GroupList.js
@@ -6,7 +6,7 @@ import { orgName } from '../../helpers/group-list-item-common';
 import { groupsByOrganization } from '../../helpers/group-organizations';
 import { isThirdPartyService } from '../../helpers/is-third-party-service';
 import { withServices } from '../../service-context';
-import { useStoreProxy } from '../../store/use-store';
+import { useSidebarStore } from '../../store';
 
 import Menu from '../Menu';
 import MenuItem from '../MenuItem';
@@ -41,7 +41,7 @@ function publisherProvidedIcon(settings) {
  * @param {GroupListProps} props
  */
 function GroupList({ settings }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const currentGroups = store.getCurrentlyViewingGroups();
   const featuredGroups = store.getFeaturedGroups();
   const myGroups = store.getMyGroups();

--- a/src/sidebar/components/GroupList/GroupListItem.js
+++ b/src/sidebar/components/GroupList/GroupListItem.js
@@ -1,6 +1,6 @@
 import { orgName } from '../../helpers/group-list-item-common';
 import { withServices } from '../../service-context';
-import { useStoreProxy } from '../../store/use-store';
+import { useSidebarStore } from '../../store';
 import { copyText } from '../../util/copy-to-clipboard';
 import { confirm } from '../../../shared/prompts';
 
@@ -40,7 +40,7 @@ function GroupListItem({
   const isSelectable =
     (group.scopes && !group.scopes.enforced) || group.isScopedToUri;
 
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const focusedGroupId = store.focusedGroupId();
   const isSelected = group.id === focusedGroupId;
 

--- a/src/sidebar/components/GroupList/test/GroupList-test.js
+++ b/src/sidebar/components/GroupList/test/GroupList-test.js
@@ -57,7 +57,7 @@ describe('GroupList', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../../store/use-store': { useStoreProxy: () => fakeStore },
+      '../../store': { useSidebarStore: () => fakeStore },
       '../../config/service-config': { serviceConfig: fakeServiceConfig },
     });
   });

--- a/src/sidebar/components/GroupList/test/GroupListItem-test.js
+++ b/src/sidebar/components/GroupList/test/GroupListItem-test.js
@@ -67,7 +67,7 @@ describe('GroupListItem', () => {
         copyText: fakeCopyText,
       },
       '../../helpers/group-list-item-common': fakeGroupListItemCommon,
-      '../../store/use-store': { useStoreProxy: () => fakeStore },
+      '../../store': { useSidebarStore: () => fakeStore },
       '../../../shared/prompts': { confirm: fakeConfirm },
     });
   });

--- a/src/sidebar/components/HelpPanel.js
+++ b/src/sidebar/components/HelpPanel.js
@@ -1,7 +1,7 @@
 import { Icon, Link, LinkButton } from '@hypothesis/frontend-shared';
 import { useCallback, useMemo, useState } from 'preact/hooks';
 
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 import { withServices } from '../service-context';
 import { VersionData } from '../helpers/version-data';
 
@@ -63,7 +63,7 @@ function HelpPanelTab({ linkText, url }) {
  * @param {HelpPanelProps} props
  */
 function HelpPanel({ auth, session }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const frames = store.frames();
   const mainFrame = store.mainFrame();
 

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -7,7 +7,7 @@ import { parseAccountID } from '../helpers/account-id';
 import { shouldAutoDisplayTutorial } from '../helpers/session';
 import { applyTheme } from '../helpers/theme';
 import { withServices } from '../service-context';
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 
 import AnnotationView from './AnnotationView';
 import SidebarView from './SidebarView';
@@ -68,7 +68,7 @@ function authStateFromProfile(profile) {
  * @param {HypothesisAppProps} props
  */
 function HypothesisApp({ auth, frameSync, settings, session, toastMessenger }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const hasFetchedProfile = store.hasFetchedProfile();
   const profile = store.profile();
   const route = store.route();

--- a/src/sidebar/components/LoggedOutMessage.js
+++ b/src/sidebar/components/LoggedOutMessage.js
@@ -1,6 +1,6 @@
 import { Link, LinkButton, Icon } from '@hypothesis/frontend-shared';
 
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 
 /**
  * @typedef LoggedOutMessageProps
@@ -15,7 +15,7 @@ import { useStoreProxy } from '../store/use-store';
  * @param {LoggedOutMessageProps} props
  */
 function LoggedOutMessage({ onLogin }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
 
   return (
     <div className="flex flex-col items-center m-6 space-y-6">

--- a/src/sidebar/components/LoginPromptPanel.js
+++ b/src/sidebar/components/LoginPromptPanel.js
@@ -1,6 +1,6 @@
 import { Actions, LabeledButton } from '@hypothesis/frontend-shared';
 
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 
 import SidebarPanel from './SidebarPanel';
 
@@ -16,7 +16,7 @@ import SidebarPanel from './SidebarPanel';
  * @param {LoginPromptPanelProps} props
  */
 export default function LoginPromptPanel({ onLogin, onSignUp }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const isLoggedIn = store.isLoggedIn();
   if (isLoggedIn) {
     return null;

--- a/src/sidebar/components/ModerationBanner.js
+++ b/src/sidebar/components/ModerationBanner.js
@@ -1,7 +1,7 @@
 import { Icon, LabeledButton } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 import * as annotationMetadata from '../helpers/annotation-metadata';
 import { withServices } from '../service-context';
 
@@ -25,7 +25,7 @@ import { withServices } from '../service-context';
  * @param {ModerationBannerProps} props
  */
 function ModerationBanner({ annotation, api, toastMessenger }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const flagCount = annotationMetadata.flagCount(annotation);
 
   const isHiddenOrFlagged =

--- a/src/sidebar/components/NotebookFilters.js
+++ b/src/sidebar/components/NotebookFilters.js
@@ -1,4 +1,4 @@
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 import { useUserFilterOptions } from './hooks/use-filter-options';
 
 import FilterSelect from './FilterSelect';
@@ -11,7 +11,7 @@ import FilterSelect from './FilterSelect';
  * Filters for the Notebook
  */
 function NotebookFilters() {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
 
   const userFilter = store.getFilter('user');
   const userFilterOptions = useUserFilterOptions();

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -4,7 +4,7 @@ import scrollIntoView from 'scroll-into-view';
 
 import { ResultSizeError } from '../search-client';
 import { withServices } from '../service-context';
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 
 import NotebookFilters from './NotebookFilters';
 import NotebookResultCount from './NotebookResultCount';
@@ -23,7 +23,7 @@ import { useRootThread } from './hooks/use-root-thread';
  * @param {NotebookViewProps} props
  */
 function NotebookView({ loadAnnotationsService, streamer }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
 
   const filters = store.getFilterValues();
   const focusedGroup = store.focusedGroup();

--- a/src/sidebar/components/SearchInput.js
+++ b/src/sidebar/components/SearchInput.js
@@ -2,7 +2,7 @@ import { IconButton, Spinner } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useRef, useState } from 'preact/hooks';
 
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 
 /**
  * @typedef SearchInputProps
@@ -26,7 +26,7 @@ import { useStoreProxy } from '../store/use-store';
  * @param {SearchInputProps} props
  */
 export default function SearchInput({ alwaysExpanded, query, onSearch }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const isLoading = store.isLoading();
   const input = /** @type {{ current: HTMLInputElement }} */ (useRef());
 

--- a/src/sidebar/components/SelectionTabs.js
+++ b/src/sidebar/components/SelectionTabs.js
@@ -7,8 +7,8 @@ import {
 import classnames from 'classnames';
 
 import { applyTheme } from '../helpers/theme';
-import { useStoreProxy } from '../store/use-store';
 import { withServices } from '../service-context';
+import { useSidebarStore } from '../store';
 
 /**
  * @typedef {import('../../types/config').SidebarSettings} SidebarSettings
@@ -91,7 +91,7 @@ function Tab({
  * @param {SelectionTabsProps} props
  */
 function SelectionTabs({ annotationsService, isLoading, settings }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const selectedTab = store.selectedTab();
   const noteCount = store.noteCount();
   const annotationCount = store.annotationCount();

--- a/src/sidebar/components/ShareAnnotationsPanel.js
+++ b/src/sidebar/components/ShareAnnotationsPanel.js
@@ -6,7 +6,7 @@ import {
   TextInputWithButton,
 } from '@hypothesis/frontend-shared';
 
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 import { pageSharingLink } from '../helpers/annotation-sharing';
 import { copyText } from '../util/copy-to-clipboard';
 import { withServices } from '../service-context';
@@ -30,7 +30,7 @@ import SidebarPanel from './SidebarPanel';
  * @param {ShareAnnotationsPanelProps} props
  */
 function ShareAnnotationsPanel({ toastMessenger }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const mainFrame = store.mainFrame();
   const focusedGroup = store.focusedGroup();
   const groupName = (focusedGroup && focusedGroup.name) || '...';

--- a/src/sidebar/components/SidebarContentError.js
+++ b/src/sidebar/components/SidebarContentError.js
@@ -1,6 +1,6 @@
 import { LabeledButton, Panel } from '@hypothesis/frontend-shared';
 
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 
 /**
  * @typedef SidebarContentErrorProps
@@ -20,7 +20,7 @@ export default function SidebarContentError({
   onLoginRequest,
   showClearSelection = false,
 }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const isLoggedIn = store.isLoggedIn();
 
   const errorTitle =

--- a/src/sidebar/components/SidebarPanel.js
+++ b/src/sidebar/components/SidebarPanel.js
@@ -2,7 +2,7 @@ import { Panel } from '@hypothesis/frontend-shared';
 import { useCallback, useEffect, useRef } from 'preact/hooks';
 import scrollIntoView from 'scroll-into-view';
 
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 
 import Slider from './Slider';
 
@@ -35,7 +35,7 @@ export default function SidebarPanel({
   title,
   onActiveChanged,
 }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const panelIsActive = store.isSidebarPanelOpen(panelName);
 
   const panelElement = useRef(/** @type {HTMLDivElement|null}*/ (null));

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'preact/hooks';
 
 import { useRootThread } from './hooks/use-root-thread';
 import { withServices } from '../service-context';
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 import { tabForAnnotation } from '../helpers/tabs';
 
 import FilterStatus from './FilterStatus';
@@ -36,7 +36,7 @@ function SidebarView({
   const rootThread = useRootThread();
 
   // Store state values
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const focusedGroupId = store.focusedGroupId();
   const hasAppliedFilter =
     store.hasAppliedFilter() || store.hasSelectedAnnotations();

--- a/src/sidebar/components/SortMenu.js
+++ b/src/sidebar/components/SortMenu.js
@@ -1,6 +1,6 @@
 import { Icon } from '@hypothesis/frontend-shared';
 
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 
 import Menu from './Menu';
 import MenuItem from './MenuItem';
@@ -9,7 +9,7 @@ import MenuItem from './MenuItem';
  * A drop-down menu of sorting options for a collection of annotations.
  */
 export default function SortMenu() {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   // The currently-applied sort order
   const sortKey = store.sortKey();
   // All available sorting options. These change depending on current

--- a/src/sidebar/components/StreamSearchInput.js
+++ b/src/sidebar/components/StreamSearchInput.js
@@ -1,4 +1,4 @@
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 import { withServices } from '../service-context';
 
 import SearchInput from './SearchInput';
@@ -16,7 +16,7 @@ import SearchInput from './SearchInput';
  * @param {StreamSearchInputProps} props
  */
 function StreamSearchInput({ router }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const query = store.routeParams().q;
   /** @param {string} query */
   const setQuery = query => {

--- a/src/sidebar/components/StreamView.js
+++ b/src/sidebar/components/StreamView.js
@@ -3,7 +3,7 @@ import { useCallback, useEffect } from 'preact/hooks';
 import * as searchFilter from '../util/search-filter';
 import { withServices } from '../service-context';
 import { useRootThread } from './hooks/use-root-thread';
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 
 import ThreadList from './ThreadList';
 
@@ -19,7 +19,7 @@ import ThreadList from './ThreadList';
  * @param {StreamViewProps} props
  */
 function StreamView({ api, toastMessenger }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const currentQuery = store.routeParams().q;
 
   /**

--- a/src/sidebar/components/Thread.js
+++ b/src/sidebar/components/Thread.js
@@ -2,7 +2,7 @@ import { IconButton, LabeledButton } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback, useMemo } from 'preact/hooks';
 
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 import { withServices } from '../service-context';
 import { countHidden, countVisible } from '../helpers/thread';
 
@@ -26,7 +26,7 @@ import ModerationBanner from './ModerationBanner';
  *   @param {boolean} props.threadIsCollapsed
  */
 function HiddenThreadCardHeader({ annotation, ...restProps }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
 
   // These two lines are copied from the AnnotationHeader component to mimic the
   // exact same behaviour.
@@ -129,7 +129,7 @@ function Thread({ thread, threadsService }) {
     child => countVisible(child) > 0
   );
 
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const hasAppliedFilter = store.hasAppliedFilter();
   const onToggleReplies = useCallback(
     () => store.setExpanded(thread.id, !!thread.collapsed),

--- a/src/sidebar/components/ThreadCard.js
+++ b/src/sidebar/components/ThreadCard.js
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import debounce from 'lodash.debounce';
 import { useCallback, useMemo } from 'preact/hooks';
 
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 import { withServices } from '../service-context';
 
 import Thread from './Thread';
@@ -25,7 +25,7 @@ import Thread from './Thread';
  * @param {ThreadCardProps} props
  */
 function ThreadCard({ frameSync, thread }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const threadTag = thread.annotation?.$tag ?? null;
   const isFocused = threadTag && store.isAnnotationFocused(threadTag);
   const focusThreadAnnotation = useMemo(

--- a/src/sidebar/components/ThreadList.js
+++ b/src/sidebar/components/ThreadList.js
@@ -7,7 +7,7 @@ import {
   calculateVisibleThreads,
   THREAD_DIMENSION_DEFAULTS,
 } from '../helpers/visible-threads';
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 import { getElementHeightWithMargins } from '../util/dom';
 
 import ThreadCard from './ThreadCard';
@@ -109,7 +109,7 @@ function ThreadList({ threads }) {
       [topLevelThreads, threadHeights, scrollPosition, scrollContainerHeight]
     );
 
-  const store = useStoreProxy();
+  const store = useSidebarStore();
 
   // Get the `$tag` of the most recently created unsaved annotation.
   const newAnnotationTag = (() => {

--- a/src/sidebar/components/ToastMessages.js
+++ b/src/sidebar/components/ToastMessages.js
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import { Icon } from '@hypothesis/frontend-shared';
 
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 import { withServices } from '../service-context';
 
 /**
@@ -86,7 +86,7 @@ function ToastMessage({ message, onDismiss }) {
  * @param {ToastMessagesProps} props
  */
 function ToastMessages({ toastMessenger }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const messages = store.getToastMessages();
   return (
     <div>

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -5,7 +5,7 @@ import { serviceConfig } from '../config/service-config';
 import { isThirdPartyService } from '../helpers/is-third-party-service';
 import { applyTheme } from '../helpers/theme';
 import { withServices } from '../service-context';
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 
 import GroupList from './GroupList';
 import SearchInput from './SearchInput';
@@ -53,7 +53,7 @@ function TopBar({
   const showSharePageButton = !isThirdPartyService(settings);
   const loginLinkStyle = applyTheme(['accentColor'], settings);
 
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const filterQuery = store.filterQuery();
   const pendingUpdateCount = store.pendingUpdateCount();
 

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -4,7 +4,7 @@ import { useState } from 'preact/hooks';
 import { serviceConfig } from '../config/service-config';
 import { isThirdPartyUser } from '../helpers/account-id';
 import { withServices } from '../service-context';
-import { useStoreProxy } from '../store/use-store';
+import { useSidebarStore } from '../store';
 
 import Menu from './Menu';
 import MenuItem from './MenuItem';
@@ -40,7 +40,7 @@ import MenuSection from './MenuSection';
  * @param {UserMenuProps} props
  */
 function UserMenu({ auth, frameSync, onLogout, settings }) {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const defaultAuthority = store.defaultAuthority();
 
   const isThirdParty = isThirdPartyUser(auth.userid, defaultAuthority);

--- a/src/sidebar/components/hooks/test/use-filter-options-test.js
+++ b/src/sidebar/components/hooks/test/use-filter-options-test.js
@@ -60,7 +60,7 @@ describe('sidebar/components/hooks/use-user-filter-options', () => {
     $imports.$mock({
       '../../helpers/account-id': fakeAccountId,
       '../../helpers/annotation-user': fakeAnnotationUser,
-      '../../store/use-store': { useStoreProxy: () => fakeStore },
+      '../../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/hooks/test/use-root-thread-test.js
+++ b/src/sidebar/components/hooks/test/use-root-thread-test.js
@@ -18,7 +18,7 @@ describe('sidebar/components/hooks/use-root-thread', () => {
     fakeThreadAnnotations = sinon.stub().returns('fakeThreadAnnotations');
 
     $imports.$mock({
-      '../../store/use-store': { useStoreProxy: () => fakeStore },
+      '../../store': { useSidebarStore: () => fakeStore },
       '../../helpers/thread-annotations': {
         threadAnnotations: fakeThreadAnnotations,
       },

--- a/src/sidebar/components/hooks/use-filter-options.js
+++ b/src/sidebar/components/hooks/use-filter-options.js
@@ -1,6 +1,6 @@
 import { useMemo } from 'preact/hooks';
 
-import { useStoreProxy } from '../../store/use-store';
+import { useSidebarStore } from '../../store';
 import { isThirdPartyUser, username } from '../../helpers/account-id';
 import { annotationDisplayName } from '../../helpers/annotation-user';
 
@@ -13,7 +13,7 @@ import { annotationDisplayName } from '../../helpers/annotation-user';
  * @return {FilterOption[]}
  */
 export function useUserFilterOptions() {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const annotations = store.allAnnotations();
   const defaultAuthority = store.defaultAuthority();
   const displayNamesEnabled = store.isFeatureEnabled('client_display_names');

--- a/src/sidebar/components/hooks/use-root-thread.js
+++ b/src/sidebar/components/hooks/use-root-thread.js
@@ -1,6 +1,6 @@
 import { useMemo } from 'preact/hooks';
 
-import { useStoreProxy } from '../../store/use-store';
+import { useSidebarStore } from '../../store';
 import { threadAnnotations } from '../../helpers/thread-annotations';
 
 /** @typedef {import('../../helpers/build-thread').Thread} Thread */
@@ -12,7 +12,7 @@ import { threadAnnotations } from '../../helpers/thread-annotations';
  * @return {Thread}
  */
 export function useRootThread() {
-  const store = useStoreProxy();
+  const store = useSidebarStore();
   const annotations = store.allAnnotations();
   const query = store.filterQuery();
   const route = store.route();

--- a/src/sidebar/components/test/AnnotationView-test.js
+++ b/src/sidebar/components/test/AnnotationView-test.js
@@ -32,7 +32,7 @@ describe('AnnotationView', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       './hooks/use-root-thread': { useRootThread: fakeUseRootThread },
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/FilterStatus-test.js
+++ b/src/sidebar/components/test/FilterStatus-test.js
@@ -53,7 +53,7 @@ describe('FilterStatus', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       './hooks/use-root-thread': { useRootThread: fakeUseRootThread },
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
       '../helpers/thread': fakeThreadUtil,
     });
   });

--- a/src/sidebar/components/test/HelpPanel-test.js
+++ b/src/sidebar/components/test/HelpPanel-test.js
@@ -39,7 +39,7 @@ describe('HelpPanel', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
       '../helpers/version-data': { VersionData: FakeVersionData },
     });
   });

--- a/src/sidebar/components/test/HypothesisApp-test.js
+++ b/src/sidebar/components/test/HypothesisApp-test.js
@@ -79,7 +79,7 @@ describe('HypothesisApp', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../config/service-config': { serviceConfig: fakeServiceConfig },
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
       '../helpers/session': {
         shouldAutoDisplayTutorial: fakeShouldAutoDisplayTutorial,
       },

--- a/src/sidebar/components/test/LoggedOutMessage-test.js
+++ b/src/sidebar/components/test/LoggedOutMessage-test.js
@@ -19,7 +19,7 @@ describe('LoggedOutMessage', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/LoginPromptPanel-test.js
+++ b/src/sidebar/components/test/LoginPromptPanel-test.js
@@ -31,7 +31,7 @@ describe('LoginPromptPanel', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/ModerationBanner-test.js
+++ b/src/sidebar/components/test/ModerationBanner-test.js
@@ -41,7 +41,7 @@ describe('ModerationBanner', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/NotebookFilters-test.js
+++ b/src/sidebar/components/test/NotebookFilters-test.js
@@ -26,7 +26,7 @@ describe('NotebookFilters', () => {
       './hooks/use-filter-options': {
         useUserFilterOptions: fakeUseUserFilterOptions,
       },
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/NotebookView-test.js
+++ b/src/sidebar/components/test/NotebookView-test.js
@@ -43,7 +43,7 @@ describe('NotebookView', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       './hooks/use-root-thread': { useRootThread: fakeUseRootThread },
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
       'scroll-into-view': fakeScrollIntoView,
     });
   });

--- a/src/sidebar/components/test/SearchInput-test.js
+++ b/src/sidebar/components/test/SearchInput-test.js
@@ -24,7 +24,7 @@ describe('SearchInput', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/SelectionTabs-test.js
+++ b/src/sidebar/components/test/SelectionTabs-test.js
@@ -46,7 +46,7 @@ describe('SelectionTabs', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/ShareAnnotationsPanel-test.js
+++ b/src/sidebar/components/test/ShareAnnotationsPanel-test.js
@@ -45,7 +45,7 @@ describe('ShareAnnotationsPanel', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
       '../helpers/annotation-sharing': {
         pageSharingLink: fakePageSharingLink,
       },

--- a/src/sidebar/components/test/SidebarContentError-test.js
+++ b/src/sidebar/components/test/SidebarContentError-test.js
@@ -25,7 +25,7 @@ describe('SidebarContentError', () => {
       isLoggedIn: sinon.stub().returns(true),
     };
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
     });
     $imports.$mock(mockImportedComponents());
   });

--- a/src/sidebar/components/test/SidebarPanel-test.js
+++ b/src/sidebar/components/test/SidebarPanel-test.js
@@ -22,7 +22,7 @@ describe('SidebarPanel', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
       'scroll-into-view': fakeScrollIntoView,
     });
   });

--- a/src/sidebar/components/test/SidebarView-test.js
+++ b/src/sidebar/components/test/SidebarView-test.js
@@ -69,7 +69,7 @@ describe('SidebarView', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       './hooks/use-root-thread': { useRootThread: fakeUseRootThread },
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
       '../helpers/tabs': fakeTabsUtil,
     });
   });

--- a/src/sidebar/components/test/SortMenu-test.js
+++ b/src/sidebar/components/test/SortMenu-test.js
@@ -21,7 +21,7 @@ describe('SortMenu', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/StreamSearchInput-test.js
+++ b/src/sidebar/components/test/StreamSearchInput-test.js
@@ -18,7 +18,7 @@ describe('StreamSearchInput', () => {
     };
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/StreamView-test.js
+++ b/src/sidebar/components/test/StreamView-test.js
@@ -41,7 +41,7 @@ describe('StreamView', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       './hooks/use-root-thread': { useRootThread: fakeUseRootThread },
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
       '../util/search-filter': fakeSearchFilter,
     });
   });

--- a/src/sidebar/components/test/Thread-test.js
+++ b/src/sidebar/components/test/Thread-test.js
@@ -98,7 +98,7 @@ describe('Thread', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
       '../helpers/thread': fakeThreadUtil,
     });
   });

--- a/src/sidebar/components/test/ThreadCard-test.js
+++ b/src/sidebar/components/test/ThreadCard-test.js
@@ -38,7 +38,7 @@ describe('ThreadCard', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       'lodash.debounce': fakeDebounce,
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -66,7 +66,7 @@ describe('ThreadList', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
       '../util/dom': fakeDomUtil,
       '../helpers/visible-threads': fakeVisibleThreadsUtil,
     });

--- a/src/sidebar/components/test/ToastMessages-test.js
+++ b/src/sidebar/components/test/ToastMessages-test.js
@@ -55,7 +55,7 @@ describe('ToastMessages', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -40,7 +40,7 @@ describe('TopBar', () => {
       './SidebarContent': true,
     });
     $imports.$mock({
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
       '../helpers/is-third-party-service': {
         isThirdPartyService: fakeIsThirdPartyService,
       },

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -55,7 +55,7 @@ describe('UserMenu', () => {
         isThirdPartyUser: fakeIsThirdPartyUser,
       },
       '../config/service-config': { serviceConfig: fakeServiceConfig },
-      '../store/use-store': { useStoreProxy: () => fakeStore },
+      '../store': { useSidebarStore: () => fakeStore },
     });
   });
 

--- a/src/sidebar/store/create-store.js
+++ b/src/sidebar/store/create-store.js
@@ -187,9 +187,9 @@ function assignOnce(target, source) {
  * selector and action methods rather than `getState` or `dispatch`. This
  * makes it easier to refactor the internal state structure.
  *
- * Preact UI components access stores via the `useStoreProxy` hook defined in
- * `use-store.js`. This returns a proxy which enables UI components to observe
- * what store state a component depends upon and re-render when it changes.
+ * Preact UI components access stores via the `useStore` hook. This returns a
+ * proxy which enables UI components to observe what store state a component
+ * depends upon and re-render when it changes.
  *
  * @template {readonly Module<any,any,any,any>[]} Modules
  * @param {Modules} modules

--- a/src/sidebar/store/index.js
+++ b/src/sidebar/store/index.js
@@ -1,3 +1,4 @@
+import { useService } from '../service-context';
 import { createStore } from './create-store';
 import { debugMiddleware } from './debug-middleware';
 import { activityModule } from './modules/activity';
@@ -16,6 +17,7 @@ import { sessionModule } from './modules/session';
 import { sidebarPanelsModule } from './modules/sidebar-panels';
 import { toastMessagesModule } from './modules/toast-messages';
 import { viewerModule } from './modules/viewer';
+import { useStore } from './use-store';
 
 /** @typedef {ReturnType<createSidebarStore>} SidebarStore */
 
@@ -55,4 +57,16 @@ export function createSidebarStore(settings) {
     viewerModule,
   ]);
   return createStore(modules, [settings], middleware);
+}
+
+/**
+ * Hook for accessing the sidebar's store in UI components.
+ *
+ * Returns a wrapper around the store which tracks its usage by the component
+ * and re-renders the component when relevant data in the store changes. See
+ * {@link useStore}.
+ */
+export function useSidebarStore() {
+  const store = /** @type {SidebarStore} */ (useService('store'));
+  return useStore(store);
 }

--- a/src/sidebar/store/test/use-store-test.js
+++ b/src/sidebar/store/test/use-store-test.js
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
 import { createStore, createStoreModule } from '../create-store';
-import { useStoreProxy, $imports } from '../use-store';
+import { useStore } from '../use-store';
 
 // Store module for use with `createStore` in tests.
 const initialState = () => ({ things: [] });
@@ -36,34 +36,27 @@ const thingsModule = createStoreModule(initialState, {
 });
 
 describe('sidebar/store/use-store', () => {
-  afterEach(() => {
-    $imports.$restore();
-  });
-
-  describe('useStoreProxy', () => {
+  describe('useStore', () => {
     let store;
     let renderCount;
 
     beforeEach(() => {
       renderCount = 0;
       store = createStore([thingsModule]);
-
       store.addThing('foo');
       store.addThing('bar');
-
-      $imports.$mock({
-        '../service-context': {
-          useService: name => (name === 'store' ? store : null),
-        },
-      });
     });
+
+    function useTestStore() {
+      return useStore(store);
+    }
 
     function renderTestComponent() {
       let proxy;
 
       const TestComponent = () => {
         ++renderCount;
-        proxy = useStoreProxy();
+        proxy = useTestStore();
 
         return <div>{proxy.thingCount()}</div>;
       };

--- a/src/sidebar/store/use-store.js
+++ b/src/sidebar/store/use-store.js
@@ -44,7 +44,7 @@ class CacheEntry {
  *   function useAppStore() {
  *     // Get the store from somewhere, eg. a prop or context.
  *     const appStore = ...;
- *     return useStore(store);
+ *     return useStore(appStore);
  *   }
  *
  *   function MyComponent() {


### PR DESCRIPTION
Split the `useStoreProxy` hook into a generic/base `useStore` hook that handles
wrapping a store created with `createStore`, and a `useSidebarStore` hook that
handles looking up the sidebar's main store via `useService('store')` and
passing it to the base hook.

This follows the existing separation of responsibilities between `createStore`
vs `createSidebarStore`, and would potentially allow us to split the generic
store infrastructure code into a separate package for use in other projects in
future.