### PR TITLE
Always show Notebook option in User menu

### DIFF
--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -45,7 +45,6 @@ function UserMenu({ auth, frameSync, onLogout, settings }) {
 
   const isThirdParty = isThirdPartyUser(auth.userid, defaultAuthority);
   const service = serviceConfig(settings);
-  const isNotebookEnabled = store.isFeatureEnabled('notebook_launch');
   const [isOpen, setOpen] = useState(false);
 
   /** @param {keyof import('../../types/config').Service} feature */
@@ -92,9 +91,9 @@ function UserMenu({ auth, frameSync, onLogout, settings }) {
     </span>
   );
   return (
-    // FIXME: KeyDown handling is temporary for Notebook "easter egg"
+    // Allow keyboard shortcut 'n' to open Notebook
     /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
-    <div className="UserMenu" onKeyDown={onKeyDown}>
+    <div data-testid="user-menu" onKeyDown={onKeyDown}>
       <Menu
         label={menuLabel}
         title={auth.displayName}
@@ -114,12 +113,7 @@ function UserMenu({ auth, frameSync, onLogout, settings }) {
               href={store.getLink('account.settings')}
             />
           )}
-          {isNotebookEnabled && (
-            <MenuItem
-              label="Open notebook"
-              onClick={() => onSelectNotebook()}
-            />
-          )}
+          <MenuItem label="Open notebook" onClick={() => onSelectNotebook()} />
         </MenuSection>
         {isLogoutEnabled && (
           <MenuSection>

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -46,7 +46,6 @@ describe('UserMenu', () => {
       defaultAuthority: sinon.stub().returns('hypothes.is'),
       focusedGroupId: sinon.stub().returns('mygroup'),
       getLink: sinon.stub(),
-      isFeatureEnabled: sinon.stub().returns(false),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -183,50 +182,38 @@ describe('UserMenu', () => {
   });
 
   describe('open notebook item', () => {
-    context('notebook feature is enabled', () => {
-      it('includes the open notebook item', () => {
-        fakeStore.isFeatureEnabled.withArgs('notebook_launch').returns(true);
-        const wrapper = createUserMenu();
+    it('includes the open notebook item', () => {
+      const wrapper = createUserMenu();
 
-        const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
-        assert.isTrue(openNotebookItem.exists());
-      });
-
-      it('triggers a message when open-notebook item is clicked', () => {
-        fakeStore.isFeatureEnabled.withArgs('notebook_launch').returns(true);
-        const wrapper = createUserMenu();
-
-        const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
-        openNotebookItem.props().onClick();
-        assert.calledOnce(fakeFrameSync.notifyHost);
-        assert.calledWith(fakeFrameSync.notifyHost, 'openNotebook', 'mygroup');
-      });
-
-      it('opens the notebook and closes itself when `n` is typed', () => {
-        const wrapper = createUserMenu();
-        // Make the menu "open"
-        act(() => {
-          wrapper.find('Menu').props().onOpenChanged(true);
-        });
-        wrapper.update();
-        assert.isTrue(wrapper.find('Menu').props().open);
-
-        wrapper.find('.UserMenu').simulate('keydown', { key: 'n' });
-        assert.calledOnce(fakeFrameSync.notifyHost);
-        assert.calledWith(fakeFrameSync.notifyHost, 'openNotebook', 'mygroup');
-        // Now the menu is "closed" again
-        assert.isFalse(wrapper.find('Menu').props().open);
-      });
+      const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
+      assert.isTrue(openNotebookItem.exists());
     });
 
-    context('notebook feature is not enabled', () => {
-      it('does not include the open notebook item', () => {
-        fakeStore.isFeatureEnabled.withArgs('notebook_launch').returns(false);
-        const wrapper = createUserMenu();
+    it('triggers a message when open-notebook item is clicked', () => {
+      const wrapper = createUserMenu();
 
-        const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
-        assert.isFalse(openNotebookItem.exists());
+      const openNotebookItem = findMenuItem(wrapper, 'Open notebook');
+      openNotebookItem.props().onClick();
+      assert.calledOnce(fakeFrameSync.notifyHost);
+      assert.calledWith(fakeFrameSync.notifyHost, 'openNotebook', 'mygroup');
+    });
+
+    it('opens the notebook and closes itself when `n` is typed', () => {
+      const wrapper = createUserMenu();
+      // Make the menu "open"
+      act(() => {
+        wrapper.find('Menu').props().onOpenChanged(true);
       });
+      wrapper.update();
+      assert.isTrue(wrapper.find('Menu').props().open);
+
+      wrapper
+        .find('[data-testid="user-menu"]')
+        .simulate('keydown', { key: 'n' });
+      assert.calledOnce(fakeFrameSync.notifyHost);
+      assert.calledWith(fakeFrameSync.notifyHost, 'openNotebook', 'mygroup');
+      // Now the menu is "closed" again
+      assert.isFalse(wrapper.find('Menu').props().open);
     });
   });
 


### PR DESCRIPTION
Show Notebook option in UserMenu regardless of feature-flag status.

By removing the last remaining old-style className from the element `div` here, this also counts as "converted to Tailwind" so we can tick that box at the same time.