### PR TITLE
Convert SearchInput to Tailwind and fix a few glaring issues

### DIFF
--- a/src/styles/sidebar/components/SearchInput.scss
+++ b/src/styles/sidebar/components/SearchInput.scss
@@ -2,44 +2,44 @@
 @use '../../mixins/layout';
 @use '../../variables' as var;
 
-.SearchInput__form {
-  @include layout.row;
-  position: relative;
-  color: var.$color-text;
-}
+// .SearchInput__form {
+//   @include layout.row;
+//   position: relative;
+//   color: var.$color-text;
+// }
 
-.SearchInput__button-container {
-  order: 0;
-}
+// .SearchInput__button-container {
+//   order: 0;
+// }
 
 .SearchInput__input {
-  @include forms.form-input;
+  //@include forms.form-input;
 
-  flex-grow: 1;
-  order: 1;
+  //flex-grow: 1;
+  //order: 1;
 
-  // Disable default browser styling for the input.
-  &:not(:focus) {
-    border: none;
-    padding: 0px;
-  }
+  // // Disable default browser styling for the input.
+  // &:not(:focus) {
+  //   border: none;
+  //   padding: 0px;
+  // }
 
   // The search box expands when focused, via a change in the
   // `max-width` property.
-  max-width: 0px;
+  //max-width: 0px;
 
-  transition: max-width 0.3s ease-out, padding-left 0.3s ease-out;
+  //transition: max-width 0.3s ease-out;
 
-  &:disabled {
-    background: none;
-    color: var.$color-text--light;
-  }
+  // &:disabled {
+  //   background: none;
+  //   color: var.$color-text--light;
+  // }
 
   // Expand the search input when focused (triggered by clicking
   // on the search icon) or when `is-expanded` is applied.
-  &:focus,
-  &.is-expanded {
-    max-width: 150px;
-    padding-left: 6px;
-  }
+  // &:focus,
+  // &.is-expanded {
+  //   max-width: 150px;
+  //   padding-left: 6px;
+  // }
 }


### PR DESCRIPTION
This PR migrates the `SearchInput` component to Tailwind. We know that there are many things to improve in the way that our search UI works. I tried to fix just the most glaring and obvious defects as part of these changes. 

After a conversation with Rob this morning, I spent some time seeing if there was a quick way to do a "little more" but it snowballed real quick. My assessment is that we shouldn't try to make many further changes without a fully-sanctioned "fix the search" project. I'd be happy to explain in a separate conversation. In short, the specifics of the way the search input is currently implemented make it particularly brittle and we'd need to do some shuffling around of state and components to get this to work in a more friendly way (regardless of what visual design we wanted to do). The behavior of this component is dictated by its design (CSS) implementation at present.

I'm hoping that the changes here aren't going to be too controversial. I'd describe them as fixes more than changes for the most part.

## Fixes/Small Improvements

1. Fix alignment of search icon when search input field is expanded.
    
    Before:
    <img width="202" alt="image" src="https://user-images.githubusercontent.com/439947/164776177-8be825ee-2ed6-4c0a-b8ed-5cd2abb32fe8.png">

3. Fix overlap of focus ring.
4. Fix size changing jump when focusing and unfocusing the input.
5. Make collisions with long group names a tiny bit less horrifying.
6. Make the input easier to see when query is applied but input is not focused.
7. Use `TextInput` shared component for more consistent styling with other text-input elements.
