### PR TITLE
Simplify and improve typing of `watch` utility

### DIFF
--- a/src/sidebar/services/features.js
+++ b/src/sidebar/services/features.js
@@ -23,17 +23,10 @@ export class FeaturesService {
   }
 
   init() {
-    const currentFlags = () => this._store.profile().features;
-    const sendFeatureFlags = () => {
-      this._frameSync.notifyHost('featureFlagsUpdated', currentFlags() || {});
-    };
-
-    // Re-send feature flags to connected frames when flags change or a new
-    // frame connects.
     watch(
       this._store.subscribe,
-      [currentFlags, () => this._store.frames()],
-      sendFeatureFlags
+      () => this._store.profile().features,
+      flags => this._frameSync.notifyHost('featureFlagsUpdated', flags || {})
     );
   }
 }

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -1,3 +1,5 @@
+import shallowEqual from 'shallowequal';
+
 import { serviceConfig } from '../config/service-config';
 import { isReply } from '../helpers/annotation-metadata';
 import { combineGroups } from '../helpers/groups';
@@ -157,9 +159,7 @@ export class GroupsService {
     watch(
       this._store.subscribe,
       () => this._mainURI(),
-      () => {
-        this.load();
-      }
+      () => this.load()
     );
 
     // Reload groups when user ID changes. This is a bit inefficient since it
@@ -167,17 +167,19 @@ export class GroupsService {
     // logging in or logging out.
     watch(
       this._store.subscribe,
-      [
-        () => this._store.hasFetchedProfile(),
-        () => this._store.profile().userid,
-      ],
+      () =>
+        /** @type {const} */ ([
+          this._store.hasFetchedProfile(),
+          this._store.profile().userid,
+        ]),
       (_, [prevFetchedProfile]) => {
         if (!prevFetchedProfile) {
           // Ignore the first time that the profile is loaded.
           return;
         }
         this.load();
-      }
+      },
+      shallowEqual
     );
   }
 

--- a/src/sidebar/services/streamer.js
+++ b/src/sidebar/services/streamer.js
@@ -268,9 +268,7 @@ export class StreamerService {
       watch(
         this._store.subscribe,
         () => this._store.profile().userid,
-        () => {
-          this._reconnect();
-        }
+        () => this._reconnect()
       );
     }
 

--- a/src/sidebar/services/test/features-test.js
+++ b/src/sidebar/services/test/features-test.js
@@ -55,23 +55,4 @@ describe('FeaturesService', () => {
       fakeStore.profile().features
     );
   });
-
-  it('should broadcast feature flags to annotator if a new frame connects', () => {
-    createService();
-
-    // First update, with no changes to frames.
-    notifyStoreSubscribers();
-    assert.notCalled(fakeFrameSync.notifyHost);
-
-    // Second update, with changes to frames.
-    fakeStore.frames.returns([{ uri: 'https://example.com' }]);
-
-    notifyStoreSubscribers();
-
-    assert.calledWith(
-      fakeFrameSync.notifyHost,
-      'featureFlagsUpdated',
-      fakeStore.profile().features
-    );
-  });
 });


### PR DESCRIPTION
Simplify and improve type safety of the `watch` utility that we use in various services to react to store changes. This utility used to be able to accept either a single function to compute the watched value or an array of functions. It now just accepts a single function, which makes it simpler to specify how the types of the other arguments relate to the watched value. There is also a new argument that explicitly specifies the function used to check whether the current and previous watched values are equal or not. If omitted (set to `null`) it defaults to a strict equality check.

In the process of updating consumers I found that the `FeaturesService` was re-sending feature flags to the host frame every time the guest frames changed, which is pointless. It now only re-sends feature flags to the host frame when the flags themselves change. In future we'll have to figure out how to communicate flags from the sidebar to the guest frames.

