### PR TITLE
Convert several simpler sidebar components to Tailwind

### DIFF
--- a/src/sidebar/components/LaunchErrorPanel.js
+++ b/src/sidebar/components/LaunchErrorPanel.js
@@ -1,4 +1,5 @@
 import { Panel } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
 
 /**
  * @typedef LaunchErrorPanelProps
@@ -15,7 +16,13 @@ import { Panel } from '@hypothesis/frontend-shared';
  */
 export default function LaunchErrorPanel({ error }) {
   return (
-    <div className="LaunchErrorPanel">
+    <div
+      className={classnames(
+        // The large top-margin is to ensure the panel clears the close button
+        // in the Notebook
+        'm-2 mt-12'
+      )}
+    >
       <Panel title="Unable to start Hypothesis">{error.message}</Panel>
     </div>
   );

--- a/src/sidebar/components/SidebarContentError.js
+++ b/src/sidebar/components/SidebarContentError.js
@@ -43,7 +43,7 @@ export default function SidebarContentError({
     <div className="mb-4">
       <Panel icon="restricted" title={errorTitle}>
         <p>{errorMessage}</p>
-        <div className="hyp-u-layout-row--justify-right hyp-u-horizontal-spacing">
+        <div className="flex justify-end space-x-2">
           {showClearSelection && (
             <LabeledButton
               variant={isLoggedIn ? 'primary' : undefined}

--- a/src/styles/sidebar/components/LaunchErrorPanel.scss
+++ b/src/styles/sidebar/components/LaunchErrorPanel.scss
@@ -1,6 +1,0 @@
-.LaunchErrorPanel {
-  // Top margin ensures that the error notice appears below the Notebook's
-  // "Close" button.
-  margin: 0.5rem;
-  margin-top: 3rem;
-}

--- a/src/styles/sidebar/components/_index.scss
+++ b/src/styles/sidebar/components/_index.scss
@@ -12,7 +12,6 @@
 @use './FilterSelect';
 @use './GroupList';
 @use './GroupListItem';
-@use './LaunchErrorPanel';
 @use './Menu';
 @use './MenuItem';
 @use './MenuSection';


### PR DESCRIPTION
This PR converts several simple remaining sidebar components as we near the completion of https://github.com/hypothesis/client/issues/4377.

- Convert `LaunchErrorPanel`
- Convert `SidebarContentError`
- Convert `SortMenu`

There are no visual changes for the user here.

Part of https://github.com/hypothesis/client/issues/4377