### PR TITLE
Remove obsolete CSS style overrides for PDF.js text layer

### DIFF
--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -68,8 +68,6 @@ function drawHighlightsAbovePDFCanvas(highlightEls) {
     '.hypothesis-highlight-layer'
   );
 
-  const isCssBlendSupported = CSS.supports('mix-blend-mode', 'multiply');
-
   if (!svgHighlightLayer) {
     // Create SVG layer. This must be in the same stacking context as
     // the canvas so that CSS `mix-blend-mode` can be used to control how SVG
@@ -88,20 +86,12 @@ function drawHighlightsAbovePDFCanvas(highlightEls) {
     svgStyle.width = '100%';
     svgStyle.height = '100%';
 
-    if (isCssBlendSupported) {
-      // Use multiply blending so that highlights drawn on top of text darken it
-      // rather than making it lighter. This improves contrast and thus readability
-      // of highlighted text, especially for overlapping highlights.
-      //
-      // This choice optimizes for the common case of dark text on a light background.
-      svgStyle.mixBlendMode = 'multiply';
-    } else {
-      // For older browsers (eg. Edge < 79) we draw all the highlights as
-      // opaque and then make the entire highlight layer transparent. This means
-      // that there is no visual indication of whether text has one or multiple
-      // highlights, but it preserves readability.
-      svgStyle.opacity = '0.3';
-    }
+    // Use multiply blending so that highlights drawn on top of text darken it
+    // rather than making it lighter. This improves contrast and thus readability
+    // of highlighted text, especially for overlapping highlights.
+    //
+    // This choice optimizes for the common case of dark text on a light background.
+    svgStyle.mixBlendMode = 'multiply';
   }
 
   const canvasRect = canvasEl.getBoundingClientRect();
@@ -114,12 +104,7 @@ function drawHighlightsAbovePDFCanvas(highlightEls) {
     rect.setAttribute('y', (highlightRect.top - canvasRect.top).toString());
     rect.setAttribute('width', highlightRect.width.toString());
     rect.setAttribute('height', highlightRect.height.toString());
-
-    if (isCssBlendSupported) {
-      rect.setAttribute('class', 'hypothesis-svg-highlight');
-    } else {
-      rect.setAttribute('class', 'hypothesis-svg-highlight is-opaque');
-    }
+    rect.setAttribute('class', 'hypothesis-svg-highlight');
 
     // Make the highlight in the text layer transparent.
     highlightEl.classList.add('is-transparent');

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -253,7 +253,7 @@ describe('annotator/highlighter', () => {
       it('creates an SVG layer above the PDF canvas and draws a highlight in that', () => {
         const page = createPDFPageWithHighlight();
         const canvas = page.querySelector('canvas');
-        const svgLayer = page.querySelector('svg');
+        const svgLayer = page.querySelector('svg.hypothesis-highlight-layer');
 
         // Verify SVG layer was created.
         assert.ok(svgLayer);
@@ -264,6 +264,7 @@ describe('annotator/highlighter', () => {
         const svgRect = page.querySelector('rect');
         assert.ok(svgRect);
         assert.equal(highlight.svgHighlight, svgRect);
+        assert.equal(svgRect.getAttribute('class'), 'hypothesis-svg-highlight');
       });
 
       it('re-uses the existing SVG layer for the page if present', () => {
@@ -315,53 +316,6 @@ describe('annotator/highlighter', () => {
         // ...but the highlight should be visually hidden so the SVG should
         // not be created.
         assert.isNull(container.querySelector('rect'));
-      });
-
-      describe('CSS blend mode support testing', () => {
-        beforeEach(() => {
-          sinon.stub(CSS, 'supports');
-        });
-
-        afterEach(() => {
-          CSS.supports.restore();
-        });
-
-        it('renders highlights when mix-blend-mode is supported', () => {
-          const container = document.createElement('div');
-          render(<PDFPage />, container);
-          CSS.supports.withArgs('mix-blend-mode', 'multiply').returns(true);
-
-          highlightPDFRange(container);
-
-          // When mix blending is available, the highlight layer has default
-          // opacity and highlight rects are transparent.
-          const highlightLayer = container.querySelector(
-            '.hypothesis-highlight-layer'
-          );
-          assert.equal(highlightLayer.style.opacity, '');
-          const rect = container.querySelector('rect');
-          assert.equal(rect.getAttribute('class'), 'hypothesis-svg-highlight');
-        });
-
-        it('renders highlights when mix-blend-mode is not supported', () => {
-          const container = document.createElement('div');
-          render(<PDFPage />, container);
-          CSS.supports.withArgs('mix-blend-mode', 'multiply').returns(false);
-
-          highlightPDFRange(container);
-
-          // When mix blending is not available, highlight rects are opaque and
-          // the entire highlight layer is transparent.
-          const highlightLayer = container.querySelector(
-            '.hypothesis-highlight-layer'
-          );
-          assert.equal(highlightLayer.style.opacity, '0.3');
-          const rect = container.querySelector('rect');
-          assert.include(
-            rect.getAttribute('class'),
-            'hypothesis-svg-highlight is-opaque'
-          );
-        });
       });
     });
   });

--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -53,15 +53,14 @@
         background-color: transparent;
       }
 
-      // In document viewers where the highlight is drawn _on top of_ the text
-      // (eg. PDF.js) too many nested highlights can make the underlying text unreadable.
-      // Therefore we make any highlights that are 3+ levels deep transparent.
+      // Limit the number of different highlight shades by making highlights
+      // that are 3+ levels deep transparent.
       //
-      // In web pages highlights are drawn _underneath_ the text so nested
-      // highlights don't reduce text contrast as much, but we still only use
-      // two levels of highlight color for consistency.
+      // This was historically done to improve readability in PDFs [1], but that
+      // is no longer an issue as in PDFs highlights are created by drawing
+      // SVGs on top of the <canvas>.
       //
-      // See https://github.com/hypothesis/client/issues/1995.
+      // [1] https://github.com/hypothesis/client/issues/1995.
       & .hypothesis-highlight {
         background-color: transparent;
       }

--- a/src/styles/annotator/pdfjs-overrides.scss
+++ b/src/styles/annotator/pdfjs-overrides.scss
@@ -1,25 +1,7 @@
-@import '../variables';
-
-// In order for our highlights to be visible we need to use solid colors.
-#viewer.has-transparent-text-layer .textLayer {
-  opacity: 1;
-  ::selection {
-    background: rgba(0, 0, 255, 0.2);
-  }
-  ::-moz-selection {
-    background: rgba(0, 0, 255, 0.2);
-  }
-}
-
 // Hide annotation layer while selecting text.
 // See https://github.com/hypothesis/client/issues/1464
 #viewer.is-selecting .annotationLayer {
   display: none;
-}
-
-// When using search funcionality of PDF.js the matches should highlight the content but not cover it. Fix for #648
-.textLayer .highlight.selected {
-  background-color: rgba(0, 100, 0, 0.5);
 }
 
 // Override PDFjs base font-size of miniscule `10px` to reset REM size.

--- a/src/styles/annotator/pdfjs-overrides.scss
+++ b/src/styles/annotator/pdfjs-overrides.scss
@@ -4,10 +4,9 @@
   display: none;
 }
 
-// Override PDFjs base font-size of miniscule `10px` to reset REM size.
-// This is necessary for styling components in shadow DOMs that rely on REM-
-// based scales.
-// See https://github.com/mozilla/pdf.js/issues/14555
+// Override tiny base 10px font-size in older versions of PDF.js. This is
+// necessary for styling components in shadow DOMs that rely on REM- based
+// scales. See https://github.com/mozilla/pdf.js/issues/14555.
 html {
   font-size: 100%;
 }


### PR DESCRIPTION
This PR removes obsolete CSS style overrides for the PDF.js text layer in `pdfjs-overrides.scss`. These used to be needed when Hypothesis highlights in PDFs were created by a `background-color` property on `<hypothesis-highlight>` elements in the PDF.js text layer. However we now draw the visible highlights in a separate `<svg>` that is placed on top of PDF.js's canvas. These obsolete styles sometimes caused rendering issues with the text selection (eg. dark areas between words) as shown in (this comment)[https://github.com/hypothesis/private-issues/issues/108#issuecomment-1115392598].

In addition I have also removed, in separate commits, some related obsolete code for browsers that don't support the CSS `mix-blend-mode` property (see [current browser support](https://caniuse.com/mdn-css_properties_mix-blend-mode)) and updated some out-of-date comments related to highlight styles.

Once this ships we can close https://github.com/hypothesis/private-issues/issues/108.