### PR TITLE
Enable side-by-side mode for web pages behind a feature flag

### DIFF
--- a/src/annotator/features.js
+++ b/src/annotator/features.js
@@ -3,14 +3,20 @@ import { TinyEmitter } from 'tiny-emitter';
 import { warnOnce } from '../shared/warn-once';
 
 /**
+ * @typedef {import('../types/annotator').FeatureFlags} IFeatureFlags
+ */
+
+/**
  * List of feature flags that annotator code tests for.
  *
  * @type {string[]}
  */
-const annotatorFlags = [];
+const annotatorFlags = ['html_side_by_side'];
 
 /**
  * An observable container of feature flags.
+ *
+ * @implements {IFeatureFlags}
  */
 export class FeatureFlags extends TinyEmitter {
   /**

--- a/src/annotator/integrations/html.js
+++ b/src/annotator/integrations/html.js
@@ -58,6 +58,9 @@ export class HTMLIntegration {
       const sideBySide = features.flagEnabled('html_side_by_side');
       if (sideBySide !== this._sideBySideEnabled) {
         this._sideBySideEnabled = sideBySide;
+
+        // `fitSideBySide` is normally called by Guest when the sidebar layout
+        // changes. When the feature flag changes, we need to re-run the method.
         if (this._lastLayout) {
           this.fitSideBySide(this._lastLayout);
         }

--- a/src/annotator/integrations/index.js
+++ b/src/annotator/integrations/index.js
@@ -31,5 +31,5 @@ export function createIntegration(annotator, { contentPartner } = {}) {
     return new VitalSourceContentIntegration();
   }
 
-  return new HTMLIntegration();
+  return new HTMLIntegration({ features: annotator.features });
 }

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -212,9 +212,11 @@ describe('annotator/integrations/vitalsource', () => {
 
     it('delegates to HTMLIntegration for side-by-side mode', () => {
       const integration = createIntegration();
-      fakeHTMLIntegration.fitSideBySide.returns(true);
-      assert.isTrue(fakeHTMLIntegration.sideBySideEnabled);
+      assert.calledOnce(FakeHTMLIntegration);
+      const htmlOptions = FakeHTMLIntegration.args[0][0];
+      assert.isTrue(htmlOptions.features.flagEnabled('html_side_by_side'));
 
+      fakeHTMLIntegration.fitSideBySide.returns(true);
       const layout = { expanded: true, width: 150 };
       const isActive = integration.fitSideBySide(layout);
 

--- a/src/annotator/integrations/vitalsource.js
+++ b/src/annotator/integrations/vitalsource.js
@@ -208,7 +208,12 @@ export class VitalSourceContentIntegration {
    */
   constructor(container = document.body) {
     const features = new FeatureFlags();
+
+    // Forcibly enable the side-by-side feature for VS books. This feature is
+    // only behind a flag for regular web pages, which are typically more
+    // complex and varied than EPUB books.
     features.update({ html_side_by_side: true });
+
     this._htmlIntegration = new HTMLIntegration({ container, features });
 
     this._listeners = new ListenerCollection();

--- a/src/annotator/integrations/vitalsource.js
+++ b/src/annotator/integrations/vitalsource.js
@@ -1,4 +1,5 @@
 import { ListenerCollection } from '../../shared/listener-collection';
+import { FeatureFlags } from '../features';
 import { onDocumentReady } from '../frame-observer';
 import { HTMLIntegration } from './html';
 import { preserveScrollPosition } from './html-side-by-side';
@@ -206,8 +207,9 @@ export class VitalSourceContentIntegration {
    * @param {HTMLElement} container
    */
   constructor(container = document.body) {
-    this._htmlIntegration = new HTMLIntegration(container);
-    this._htmlIntegration.sideBySideEnabled = true;
+    const features = new FeatureFlags();
+    features.update({ html_side_by_side: true });
+    this._htmlIntegration = new HTMLIntegration({ container, features });
 
     this._listeners = new ListenerCollection();
 

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -2,6 +2,8 @@
  * Type definitions for objects passed between the annotator and sidebar.
  */
 
+/** @typedef {import('tiny-emitter').TinyEmitter} TinyEmitter */
+
 /**
  * Object representing a region of a document that an annotation
  * has been anchored to.
@@ -77,11 +79,21 @@
  */
 
 /**
+ * Interface for querying a collection of feature flags and subscribing to
+ * flag updates.
+ *
+ * Emits a "flagsChanged" event when the flags are updated.
+ *
+ * @typedef {TinyEmitter & { flagEnabled: (flag: string) => boolean }} FeatureFlags
+ */
+
+/**
  * Subset of the `Guest` class that is exposed to integrations.
  *
  * @typedef Annotator
  * @prop {Anchor[]} anchors
  * @prop {(ann: AnnotationData) => Promise<Anchor[]>} anchor
+ * @prop {FeatureFlags} features
  */
 
 /**


### PR DESCRIPTION
Enable support for side-by-side mode for all web pages, behind an `html_side_by_side` feature flag.

- Pass feature flags from the `Guest` through to the `HTMLIntegration`
- In the VitalSource integration, instead pass a dummy `FeatureFlags` which has side-by-side mode always enabled

Marked as a draft because I want to review the plumbing of feature flags through to the HTMLIntegration and the approach used to forcibly enable it for the VitalSource integration.

**Testing:**

1. Enable the `html_side_by_side` feature flag in h (see https://github.com/hypothesis/h/pull/7428)
2. Visit a test HTML document (eg. http://localhost:3000/document/doyle) and open the sidebar. The page should be resized.
3. Repeat previous step with feature flag turned off. The page should not be resized.

A variation on Step 3 is to turn on the feature flag only for certain users. When you log in / log out the feature should be enabled/disabled.

Fixes https://github.com/hypothesis/client/issues/4332.