### PR TITLE
Replace various uses of `any` with `unknown`

### DIFF
--- a/src/annotator/util/emitter.js
+++ b/src/annotator/util/emitter.js
@@ -25,7 +25,7 @@ export class Emitter {
    * Fire an event.
    *
    * @param {string} event
-   * @param {any[]} args
+   * @param {unknown[]} args
    */
   publish(event, ...args) {
     this._emitter.emit(event, ...args);

--- a/src/shared/injector.js
+++ b/src/shared/injector.js
@@ -1,6 +1,6 @@
 /**
  * @typedef Provider
- * @prop {any} [value] - The value for the object
+ * @prop {unknown} [value] - The value for the object
  * @prop {Function} [class] - A class that should be instantiated to create the object
  * @prop {Function} [factory] - Function that should be called to create the object
  */
@@ -57,7 +57,7 @@ export class Injector {
    * Construct or return the existing instance of an object with a given `name`
    *
    * @param {string} name - Name of object to construct
-   * @return {any} - The constructed object
+   * @return {unknown} - The constructed object
    */
   get(name) {
     if (this._instances.has(name)) {
@@ -144,7 +144,8 @@ export class Injector {
    * Run a function which uses one or more dependencies provided by the
    * container.
    *
-   * @param {Function} callback -
+   * @template T
+   * @param {(...args: any[]) => T} callback -
    *   A callback to run, with dependencies annotated in the same way as
    *   functions or classes passed to `register`.
    * @return {any} - Returns the result of running the function.

--- a/src/shared/messaging/port-provider.js
+++ b/src/shared/messaging/port-provider.js
@@ -217,7 +217,7 @@ export class PortProvider {
    *     `Message`.
    *   @param {string} options.allowedOrigin - the `origin` must match this
    *     value. If `allowedOrigin` is '*', the origin is ignored.
-   *   @param {any} options.data - the data to be compared with `allowedMessage`.
+   *   @param {unknown} options.data - the data to be compared with `allowedMessage`.
    *   @param {string} options.origin - the origin to be compared with
    *     `allowedOrigin`.
    */

--- a/src/shared/warn-once.js
+++ b/src/shared/warn-once.js
@@ -7,7 +7,7 @@ let shownWarnings = new Set();
  * This is useful to avoid spamming the console if a warning is emitted in a
  * context that may be called frequently.
  *
- * @param {...any} args -
+ * @param {...unknown} args -
  *   Arguments to forward to `console.warn`. The arguments `toString()` values
  *   are concatenated into a string key which is used to determine if the warning
  *   has been logged before.

--- a/src/sidebar/config/build-settings.js
+++ b/src/sidebar/config/build-settings.js
@@ -56,17 +56,19 @@ function fetchServiceGroups(configFromHost, rpcSettings) {
     if (service.groups === '$rpc:requestGroups') {
       // The `groups` need to be fetched from a secondary RPC call and
       // there should be no timeout as it may be waiting for user input.
-      service.groups = postMessageJsonRpc
-        .call(
-          rpcSettings.targetFrame,
-          rpcSettings.origin,
-          'requestGroups',
-          [index],
-          0 // no timeout
-        )
-        .catch(() => {
-          throw new Error('Unable to fetch groups');
-        });
+      service.groups = /** @type {Promise<string[]>} */ (
+        postMessageJsonRpc
+          .call(
+            rpcSettings.targetFrame,
+            rpcSettings.origin,
+            'requestGroups',
+            [index],
+            0 // no timeout
+          )
+          .catch(() => {
+            throw new Error('Unable to fetch groups');
+          })
+      );
     }
   });
   return configFromHost;
@@ -105,12 +107,14 @@ function buildRPCSettings(configFromAnnotator, window_) {
  * @return {Promise<ConfigFromEmbedder>}
  */
 async function getEmbedderConfig(configFromAnnotator, rpcSettings) {
-  const configFromEmbedder = await postMessageJsonRpc.call(
-    rpcSettings.targetFrame,
-    rpcSettings.origin,
-    'requestConfig',
-    [],
-    3000
+  const configFromEmbedder = /** @type {ConfigFromEmbedder} */ (
+    await postMessageJsonRpc.call(
+      rpcSettings.targetFrame,
+      rpcSettings.origin,
+      'requestConfig',
+      [],
+      3000
+    )
   );
 
   // In cases where host configuration is requested from the embedder frame

--- a/src/sidebar/service-context.js
+++ b/src/sidebar/service-context.js
@@ -17,7 +17,7 @@ import { useContext } from 'preact/hooks';
 
 /**
  * @typedef ServiceProvider
- * @prop {(serviceName: string) => any} get
+ * @prop {(serviceName: string) => unknown} get
  */
 
 /** @type {ServiceProvider} */
@@ -117,7 +117,6 @@ export function withServices(Component, serviceNames) {
  * context of custom hooks.
  *
  * @param {string} service - Name of the service to look up
- * @return {object}
  */
 export function useService(service) {
   const injector = useContext(ServiceContext);

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -409,7 +409,7 @@ export class FrameSyncService {
    * Send an RPC message to the host frame.
    *
    * @param {SidebarToHostEvent} method
-   * @param {any[]} args
+   * @param {unknown[]} args
    */
   notifyHost(method, ...args) {
     this._hostRPC.call(method, ...args);

--- a/src/sidebar/store/use-store.js
+++ b/src/sidebar/store/use-store.js
@@ -7,8 +7,8 @@ class CacheEntry {
   /**
    * @param {string} name - Method name
    * @param {Function} method - Method implementation
-   * @param {any[]} args - Arguments to the selector
-   * @param {any} result - Result of the invocation
+   * @param {unknown[]} args - Arguments to the selector
+   * @param {unknown} result - Result of the invocation
    */
   constructor(name, method, args, result) {
     this.name = name;
@@ -19,7 +19,7 @@ class CacheEntry {
 
   /**
    * @param {string} name
-   * @param {any[]} args
+   * @param {unknown[]} args
    */
   matches(name, args) {
     return (

--- a/src/sidebar/util/postmessage-json-rpc.js
+++ b/src/sidebar/util/postmessage-json-rpc.js
@@ -18,10 +18,10 @@ function createTimeout(delay, message) {
  * @param {Window} frame - Frame to send call to
  * @param {string} origin - Origin filter for `window.postMessage` call
  * @param {string} method - Name of the JSON-RPC method
- * @param {any[]} params - Parameters of the JSON-RPC method
+ * @param {unknown[]} params - Parameters of the JSON-RPC method
  * @param {number} [timeout] - Maximum time to wait in ms
  * @param {Window} [window_] - Test seam.
- * @return {Promise<any>} - A Promise for the response to the call
+ * @return {Promise<unknown>} - A Promise for the response to the call
  */
 export function call(
   frame,

--- a/src/test-util/wait.js
+++ b/src/test-util/wait.js
@@ -1,10 +1,11 @@
 /**
  * Wait for a condition to evaluate to a truthy value.
  *
- * @param {() => any} condition - Function that returns a truthy value when some condition is met
+ * @template T
+ * @param {() => T} condition - Function that returns a truthy value when some condition is met
  * @param {number} timeout - Max delay in milliseconds to wait
  * @param {string} what - Description of condition that is being waited for
- * @return {Promise<any>} - Result of the `condition` function
+ * @return {Promise<T>} - Result of the `condition` function
  */
 export async function waitFor(
   condition,

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -72,8 +72,8 @@
  * be stored in the Hypothesis backend and ranges in the document.
  *
  * @typedef AnchoringImpl
- * @prop {(root: HTMLElement, selectors: Selector[], options: any) => Promise<Range>} anchor
- * @prop {(root: HTMLElement, range: Range, options: any) => Selector[]|Promise<Selector[]>} describe
+ * @prop {(root: HTMLElement, selectors: Selector[], options: unknown) => Promise<Range>} anchor
+ * @prop {(root: HTMLElement, range: Range, options: unknown) => Selector[]|Promise<Selector[]>} describe
  */
 
 /**


### PR DESCRIPTION
This includes the results of RPC calls to the LMS app, which must now be explicitly cast to the expected result type. Otherwise I didn't have to change any code which used the values.