### PR TITLE
Minor JSDoc comment cleanup

### DIFF
--- a/src/annotator/config/is-browser-extension.js
+++ b/src/annotator/config/is-browser-extension.js
@@ -2,7 +2,7 @@
  * Return true if the client is from a browser extension.
  *
  * @param {string} url
- * @returns {boolean} - Returns true if this instance of the Hypothesis client is one
+ * @return {boolean} - Returns true if this instance of the Hypothesis client is one
  *   distributed in a browser extension, false if it's one embedded in a
  *   website.
  *

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -122,9 +122,6 @@ function removeTextSelection() {
  * each frame connects to the sidebar and host frames as part of its
  * initialization.
  *
- * The anchoring implementation defaults to a generic one for HTML documents and
- * can be overridden to handle different document types.
- *
  * @implements {Annotator}
  * @implements {Destroyable}
  */

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -71,9 +71,7 @@ function init() {
 
     const sidebarConfig = /** @type {SidebarConfig} */ (getConfig('sidebar'));
 
-    const hypothesisAppsOrigin = new URL(
-      /** @type {string} */ (sidebarConfig.sidebarAppUrl)
-    ).origin;
+    const hypothesisAppsOrigin = new URL(sidebarConfig.sidebarAppUrl).origin;
     const portProvider = new PortProvider(hypothesisAppsOrigin);
 
     const eventBus = new EventBus();
@@ -85,7 +83,7 @@ function init() {
     );
 
     portProvider.on('frameConnected', (source, port) =>
-      /** @type {Sidebar} */ (sidebar).onFrameConnected(source, port)
+      sidebar.onFrameConnected(source, port)
     );
     destroyables.push(portProvider, sidebar, notebook);
   }

--- a/src/annotator/index.js
+++ b/src/annotator/index.js
@@ -116,7 +116,8 @@ function init() {
 /**
  * Returns a Promise that resolves when the document has loaded (but subresources
  * may still be loading).
- * @returns {Promise<void>}
+ *
+ * @return {Promise<void>}
  */
 function documentReady() {
   return new Promise(resolve => {

--- a/src/sidebar/components/VersionInfo.js
+++ b/src/sidebar/components/VersionInfo.js
@@ -11,7 +11,7 @@ import { withServices } from '../service-context';
  */
 
 /**
- * @param {Object} props
+ * @param {object} props
  *   @param {string} props.label
  *   @param {import('preact').ComponentChildren} props.children
  *   @param {string} [props.classes]

--- a/src/sidebar/config/build-settings.js
+++ b/src/sidebar/config/build-settings.js
@@ -45,7 +45,7 @@ function getEmbedderFrame(levels, window_ = window) {
  *
  * @param {ConfigFromHost} configFromHost
  * @param {RPCSettings} rpcSettings
- * @returns {ConfigFromHost}
+ * @return {ConfigFromHost}
  */
 function fetchServiceGroups(configFromHost, rpcSettings) {
   const services = configFromHost.services;

--- a/src/sidebar/config/get-api-url.js
+++ b/src/sidebar/config/get-api-url.js
@@ -6,7 +6,7 @@ import { serviceConfig } from './service-config';
  * Function that returns apiUrl from the settings object.
  *
  * @param {SidebarSettings} settings - The settings object
- * @returns {string} The apiUrl from the service or the default apiUrl from the settings
+ * @return {string} The apiUrl from the service or the default apiUrl from the settings
  * @throws {Error} If the settings has a service but the service doesn't have an apiUrl
  *
  */

--- a/src/sidebar/helpers/annotation-user.js
+++ b/src/sidebar/helpers/annotation-user.js
@@ -20,7 +20,7 @@ import { username } from './account-id';
  * @param {boolean} isThirdPartyUser - Is the annotation's user third-party?
  * @param {boolean} isFeatureFlagEnabled - Is the `client_display_names`
  *   feature flag enabled
- * @returns {string}
+ * @return {string}
  */
 export function annotationDisplayName(
   annotation,

--- a/src/sidebar/helpers/groups.js
+++ b/src/sidebar/helpers/groups.js
@@ -105,7 +105,7 @@ function uriMatchesScopes(uri, scopes) {
  *
  * @param {GroupIdentifier[]} groupIds
  * @param {Group[]} groups
- * @returns {Group[]}
+ * @return {Group[]}
  */
 function findGroupsByAnyIds(groupIds, groups) {
   return groups.filter(

--- a/src/sidebar/helpers/permissions.js
+++ b/src/sidebar/helpers/permissions.js
@@ -8,9 +8,9 @@
  * specific user) or `'group'` (for a group).
  *
  * @typedef Permissions
- * @property {string[]} read - List of principals that can read the annotation
- * @property {string[]} update - List of principals that can edit the annotation
- * @property {string[]} delete - List of principals that can delete the
+ * @prop {string[]} read - List of principals that can read the annotation
+ * @prop {string[]} update - List of principals that can edit the annotation
+ * @prop {string[]} delete - List of principals that can delete the
  * annotation
  */
 

--- a/src/sidebar/media-embedder.js
+++ b/src/sidebar/media-embedder.js
@@ -56,7 +56,7 @@ function iframe(src, aspectRatio = 16 / 9) {
  * it's assumed to be seconds and is left alone.
  *
  * @param {string} timeValue - value of `t` or `start` param in YouTube URL
- * @returns {string} timeValue in seconds
+ * @return {string} timeValue in seconds
  * @example
  * formatYouTubeTime('5m'); // returns '300'
  * formatYouTubeTime('20m10s'); // returns '1210'
@@ -91,7 +91,7 @@ function parseTimeString(timeValue) {
  * all parameter possibilities.
  *
  * @param {HTMLAnchorElement} link
- * @returns {string} formatted filtered URL query string, e.g. '?start=90' or
+ * @return {string} formatted filtered URL query string, e.g. '?start=90' or
  *   an empty string if the filtered query is empty.
  * @example
  * // returns '?end=10&start=5'

--- a/src/sidebar/services/auth.js
+++ b/src/sidebar/services/auth.js
@@ -8,7 +8,7 @@ import { resolve } from '../util/url';
  * @typedef {import('../util/oauth-client').TokenInfo} TokenInfo
  *
  * @typedef RefreshOptions
- * @property {boolean} persist - True if access tokens should be persisted for
+ * @prop {boolean} persist - True if access tokens should be persisted for
  *   use in future sessions.
  */
 

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -25,7 +25,7 @@ import { watch } from '../util/watch';
  * within the current session and anchor it in the document.
  *
  * @param {Annotation} annotation
- * @returns {AnnotationData}
+ * @return {AnnotationData}
  */
 export function formatAnnot({ $tag, target, uri }) {
   return {

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -83,7 +83,6 @@ export class RouterService {
       case 'annotation':
         {
           const id = params.id;
-          // @ts-ignore - TS doesn't know what properties `queryParams` has.
           delete queryParams.id;
           url = `/a/${id}`;
         }

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -2,9 +2,9 @@ import escapeStringRegexp from 'escape-string-regexp';
 
 /**
  * @typedef Tag
- * @property {string} text - The label of the tag
- * @property {number} count - The number of times this tag has been used.
- * @property {number} updated - The timestamp when this tag was last used.
+ * @prop {string} text - The label of the tag
+ * @prop {number} count - The number of times this tag has been used.
+ * @prop {number} updated - The timestamp when this tag was last used.
  */
 
 const TAGS_LIST_KEY = 'hypothesis.user.tags.list';

--- a/src/sidebar/test/annotation-fixtures.js
+++ b/src/sidebar/test/annotation-fixtures.js
@@ -173,8 +173,8 @@ export function oldReply() {
 
 /**
  * @typedef ModerationState
- * @property {boolean} hidden
- * @property {number} flagCount
+ * @prop {boolean} hidden
+ * @prop {number} flagCount
  */
 
 /**

--- a/src/sidebar/util/search-filter.js
+++ b/src/sidebar/util/search-filter.js
@@ -120,8 +120,8 @@ export function toObject(searchText) {
 
 /**
  * @typedef Facet
- * @property {'and'|'or'} operator
- * @property {string[]|number[]} terms
+ * @prop {'and'|'or'} operator
+ * @prop {string[]|number[]} terms
  */
 
 /**

--- a/src/sidebar/util/time.js
+++ b/src/sidebar/util/time.js
@@ -36,7 +36,7 @@ function delta(date, now) {
  * @param {Date} date
  * @param {Intl.DateTimeFormatOptions} options
  * @param {Intl} Intl - Test seam. JS `Intl` API implementation.
- * @returns {string}
+ * @return {string}
  */
 function format(date, options, Intl = window.Intl) {
   const key = JSON.stringify(options);

--- a/src/sidebar/util/watch.js
+++ b/src/sidebar/util/watch.js
@@ -12,9 +12,6 @@
  *     // Extract some data of interest from the store.
  *     () => store.getValue(),
  *
- *     // Use strict comparison of values
- *     null,
- *
  *     // Callback that is invoked each time the extracted data changes.
  *     (currentValue, prevValue) => { ... }
  *   );
@@ -28,10 +25,10 @@
  *     store.subscribe,
  *     () => [store.getValueA(), store.getValueB()],
  *
+ *     ([currentValueA, currentValueB], [prevValueA, prevValueB]) => { ... },
+ *
  *     // Compare each element of the result
  *     shallowEqual,
- *
- *     ([currentValueA, currentValueB], [prevValueA, prevValueB]) => { ... }
  *   );
  *
  * @template T


### PR DESCRIPTION
This PR contains some small JSDoc comment cleanups. See commit messages for details.

- Standardize on `@prop` over `@property`
- Replace remaining `Object` type with preferred `object`
- Standardize on `@return` over `@returns`
- Remove an obsolete `@ts-ignore`
- Update `watch` examples to match interface (Lyza noticed this mistake in a previous PR and I somehow failed to push this correction before merging)
- Remove an obsolete comment in annotator/guest.js
- Remove obsolete type casts in annotator/index.js