### PR TITLE
Extract `EmptyAnnotation` to prep for accessibility and other enhancements

### DIFF
--- a/src/sidebar/components/Annotation/EmptyAnnotation.js
+++ b/src/sidebar/components/Annotation/EmptyAnnotation.js
@@ -1,0 +1,45 @@
+import AnnotationReplyToggle from './AnnotationReplyToggle';
+
+/**
+ * @typedef {import('./Annotation').AnnotationProps} AnnotationProps
+ * @typedef {Omit<AnnotationProps, 'annotation' | 'annotationsService'>} EmptyAnnotationProps
+ */
+
+/**
+ * Render an "annotation" when the annotation itself is missing. This can
+ * happen when an annotation is deleted by its author but there are still
+ * replies that pertain to it.
+ *
+ * @param {EmptyAnnotationProps} props
+ */
+export default function EmptyAnnotation({
+  isReply,
+  replyCount,
+  threadIsCollapsed,
+  onToggleReplies,
+}) {
+  const isCollapsedReply = isReply && threadIsCollapsed;
+  return (
+    <article
+      className="space-y-4"
+      aria-label={`${
+        isReply ? 'Reply' : 'Annotation'
+      } with unavailable content`}
+    >
+      {!isCollapsedReply && (
+        <div>
+          <em>Message not available.</em>
+        </div>
+      )}
+      {onToggleReplies && (
+        <footer className="flex items-center">
+          <AnnotationReplyToggle
+            onToggleReplies={onToggleReplies}
+            replyCount={replyCount}
+            threadIsCollapsed={threadIsCollapsed}
+          />
+        </footer>
+      )}
+    </article>
+  );
+}

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -8,8 +8,6 @@ import { mockImportedComponents } from '../../../../test-util/mock-imported-comp
 import Annotation, { $imports } from '../Annotation';
 
 describe('Annotation', () => {
-  let fakeOnToggleReplies;
-
   // Dependency Mocks
   let fakeMetadata;
 
@@ -31,9 +29,7 @@ describe('Annotation', () => {
       <Annotation
         annotation={fixtures.defaultAnnotation()}
         annotationsService={fakeAnnotationsService}
-        hasAppliedFilter={false}
         isReply={false}
-        onToggleReplies={fakeOnToggleReplies}
         replyCount={0}
         threadIsCollapsed={true}
         {...props}
@@ -42,8 +38,6 @@ describe('Annotation', () => {
   };
 
   beforeEach(() => {
-    fakeOnToggleReplies = sinon.stub();
-
     fakeAnnotationsService = {
       reply: sinon.stub(),
       save: sinon.stub().resolves(),
@@ -111,8 +105,10 @@ describe('Annotation', () => {
   });
 
   describe('reply thread toggle', () => {
-    it('should render a toggle button if the annotation has replies', () => {
+    it('should render a toggle button if provided with a toggle callback', () => {
+      const fakeOnToggleReplies = sinon.stub();
       const wrapper = createComponent({
+        onToggleReplies: fakeOnToggleReplies,
         replyCount: 5,
         threadIsCollapsed: true,
       });
@@ -125,30 +121,8 @@ describe('Annotation', () => {
       assert.equal(toggle.props().threadIsCollapsed, true);
     });
 
-    it('should not render a reply toggle if the annotation has no replies', () => {
+    it('should not render a reply toggle if no toggle callback provided', () => {
       const wrapper = createComponent({
-        isReply: false,
-        replyCount: 0,
-        threadIsCollapsed: true,
-      });
-
-      assert.isFalse(wrapper.find('AnnotationReplyToggle').exists());
-    });
-
-    it('should not render a reply toggle if there are applied filters', () => {
-      const wrapper = createComponent({
-        hasAppliedFilter: true,
-        isReply: false,
-        replyCount: 5,
-        threadIsCollapsed: true,
-      });
-
-      assert.isFalse(wrapper.find('AnnotationReplyToggle').exists());
-    });
-
-    it('should not render a reply toggle if the annotation itself is a reply', () => {
-      const wrapper = createComponent({
-        isReply: true,
         replyCount: 5,
         threadIsCollapsed: true,
       });
@@ -220,52 +194,6 @@ describe('Annotation', () => {
 
         assert.isTrue(wrapper.find('AnnotationBody').exists());
         assert.isTrue(wrapper.find('footer').exists());
-      });
-    });
-
-    context('missing annotation', () => {
-      it('should render a message about annotation unavailability', () => {
-        const wrapper = createComponent({ annotation: undefined });
-
-        assert.equal(wrapper.text(), 'Message not available.');
-      });
-
-      it('should not render a message if collapsed reply', () => {
-        const wrapper = createComponent({
-          annotation: undefined,
-          isReply: true,
-          threadIsCollapsed: true,
-        });
-
-        assert.equal(wrapper.text(), '');
-      });
-
-      it('should render reply toggle controls if there are replies', () => {
-        const wrapper = createComponent({
-          annotation: undefined,
-          replyCount: 5,
-          threadIsCollapsed: true,
-        });
-
-        const toggle = wrapper.find('AnnotationReplyToggle');
-
-        assert.isTrue(toggle.exists());
-        assert.equal(toggle.props().onToggleReplies, fakeOnToggleReplies);
-        assert.equal(toggle.props().replyCount, 5);
-        assert.equal(toggle.props().threadIsCollapsed, true);
-      });
-
-      it('should not render reply toggle controls if collapsed reply', () => {
-        const wrapper = createComponent({
-          annotation: undefined,
-          isReply: true,
-          replyCount: 5,
-          threadIsCollapsed: true,
-        });
-
-        const toggle = wrapper.find('AnnotationReplyToggle');
-
-        assert.isFalse(toggle.exists());
       });
     });
   });

--- a/src/sidebar/components/Annotation/test/EmptyAnnotation-test.js
+++ b/src/sidebar/components/Annotation/test/EmptyAnnotation-test.js
@@ -1,0 +1,108 @@
+import { mount } from 'enzyme';
+
+import { checkAccessibility } from '../../../../test-util/accessibility';
+import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
+
+import EmptyAnnotation, { $imports } from '../EmptyAnnotation';
+
+describe('EmptyAnnotation', () => {
+  const createComponent = props => {
+    return mount(
+      <EmptyAnnotation
+        isReply={false}
+        replyCount={0}
+        threadIsCollapsed={true}
+        {...props}
+      />
+    );
+  };
+
+  beforeEach(() => {
+    $imports.$mock(mockImportedComponents());
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  describe('reply thread toggle', () => {
+    it('should render a toggle button if toggle callback provided', () => {
+      const fakeOnToggleReplies = sinon.stub();
+      const wrapper = createComponent({
+        onToggleReplies: fakeOnToggleReplies,
+        replyCount: 5,
+        threadIsCollapsed: true,
+      });
+
+      const toggle = wrapper.find('AnnotationReplyToggle');
+
+      assert.isTrue(toggle.exists());
+      assert.equal(toggle.props().onToggleReplies, fakeOnToggleReplies);
+      assert.equal(toggle.props().replyCount, 5);
+      assert.equal(toggle.props().threadIsCollapsed, true);
+    });
+
+    it('should not render a reply toggle if no callback provided', () => {
+      const wrapper = createComponent({
+        isReply: false,
+        replyCount: 5,
+        threadIsCollapsed: true,
+      });
+
+      assert.isFalse(wrapper.find('AnnotationReplyToggle').exists());
+    });
+  });
+
+  describe('labeling and description', () => {
+    it('should render a label and message for top-level missing annotations', () => {
+      const wrapper = createComponent();
+
+      assert.equal(
+        wrapper.find('article').props()['aria-label'],
+        'Annotation with unavailable content'
+      );
+      assert.equal(wrapper.text(), 'Message not available.');
+    });
+
+    it('should label the EmptyAnnotation as a reply if it is a reply', () => {
+      const wrapper = createComponent({
+        isReply: true,
+      });
+
+      assert.equal(
+        wrapper.find('article').props()['aria-label'],
+        'Reply with unavailable content'
+      );
+    });
+
+    it('should not render a message if collapsed reply', () => {
+      const wrapper = createComponent({
+        isReply: true,
+        threadIsCollapsed: true,
+      });
+
+      assert.equal(wrapper.text(), '');
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        content: () => createComponent(),
+      },
+      {
+        name: 'when a collapsed top-level thread',
+        content: () => {
+          return createComponent({ isReply: false, threadIsCollapsed: true });
+        },
+      },
+      {
+        name: 'when a collapsed reply',
+        content: () => {
+          return createComponent({ isReply: true, threadIsCollapsed: true });
+        },
+      },
+    ])
+  );
+});

--- a/src/sidebar/components/Thread.js
+++ b/src/sidebar/components/Thread.js
@@ -8,6 +8,7 @@ import { countHidden, countVisible } from '../helpers/thread';
 
 import Annotation from './Annotation';
 import AnnotationHeader from './Annotation/AnnotationHeader';
+import EmptyAnnotation from './Annotation/EmptyAnnotation';
 import ModerationBanner from './ModerationBanner';
 
 /** @typedef {import('../helpers/build-thread').Thread} Thread */
@@ -107,29 +108,40 @@ function Thread({ thread, threadsService }) {
     [store, thread.id, thread.collapsed]
   );
 
+  const showReplyToggle =
+    !isReply && !isEditing && !hasAppliedFilter && thread.replyCount > 0;
+
   // Memoize annotation content to avoid re-rendering an annotation when content
   // in other annotations/threads change.
   const annotationContent = useMemo(
     () =>
       thread.visible && (
         <>
-          {thread.annotation && (
-            <ModerationBanner annotation={thread.annotation} />
+          {thread.annotation ? (
+            <>
+              <ModerationBanner annotation={thread.annotation} />
+              <Annotation
+                annotation={thread.annotation}
+                isReply={isReply}
+                onToggleReplies={showReplyToggle ? onToggleReplies : undefined}
+                replyCount={thread.replyCount}
+                threadIsCollapsed={thread.collapsed}
+              />
+            </>
+          ) : (
+            <EmptyAnnotation
+              isReply={isReply}
+              onToggleReplies={showReplyToggle ? onToggleReplies : undefined}
+              replyCount={thread.replyCount}
+              threadIsCollapsed={thread.collapsed}
+            />
           )}
-          <Annotation
-            annotation={thread.annotation}
-            hasAppliedFilter={hasAppliedFilter}
-            isReply={isReply}
-            onToggleReplies={onToggleReplies}
-            replyCount={thread.replyCount}
-            threadIsCollapsed={thread.collapsed}
-          />
         </>
       ),
     [
-      hasAppliedFilter,
       isReply,
       onToggleReplies,
+      showReplyToggle,
       thread.annotation,
       thread.replyCount,
       thread.collapsed,

--- a/src/sidebar/components/test/Thread-test.js
+++ b/src/sidebar/components/test/Thread-test.js
@@ -158,6 +158,45 @@ describe('Thread', () => {
     });
   });
 
+  describe('toggling replies for top-level threads', () => {
+    it('provides an `onToggleReplies` callback for top-level threads with replies', () => {
+      const threadWithChildren = buildThreadWithChildren();
+      const wrapper = createComponent({ thread: threadWithChildren });
+      assert.isFunction(wrapper.find('Annotation').props().onToggleReplies);
+    });
+
+    it('does not provide a toggle callback if thread is being edited', () => {
+      fakeStore.getDraft.returns({});
+      const threadWithChildren = buildThreadWithChildren();
+
+      const wrapper = createComponent({ thread: threadWithChildren });
+      assert.isUndefined(wrapper.find('Annotation').props().onToggleReplies);
+    });
+
+    it('does not provide a toggle callback if thread is a reply', () => {
+      const threadWithChildren = buildThreadWithChildren();
+      threadWithChildren.parent = 1;
+
+      const wrapper = createComponent({ thread: threadWithChildren });
+      assert.isUndefined(wrapper.find('Annotation').props().onToggleReplies);
+    });
+
+    it('does not provide a toggle callback if there is an applied filter', () => {
+      fakeStore.hasAppliedFilter.returns(true);
+      const threadWithChildren = buildThreadWithChildren();
+
+      const wrapper = createComponent({ thread: threadWithChildren });
+      assert.isUndefined(wrapper.find('Annotation').props().onToggleReplies);
+    });
+
+    it('does not provide a toggle callback if there are no replies', () => {
+      const thread = createThread();
+      const wrapper = createComponent({ thread });
+
+      assert.isUndefined(wrapper.find('Annotation').props().onToggleReplies);
+    });
+  });
+
   context('collapsed thread with annotation and children', () => {
     let collapsedThread;
 
@@ -193,7 +232,7 @@ describe('Thread', () => {
     it('renders an annotation component', () => {
       const wrapper = createComponent({ thread: noAnnotationThread });
 
-      const annotation = wrapper.find('Annotation');
+      const annotation = wrapper.find('EmptyAnnotation');
 
       assert.isTrue(annotation.exists());
     });


### PR DESCRIPTION
This PR breaks out `EmptyAnnotation` from `Annotation`. This was something we had done in the past and then I recombined them because it seemed to make sense at the time.

I'm on a trajectory that will include pushing more state into `Annotation`, and it was getting cumbersome managing that component for the possible absence of an `annotation` prop. That is, `Annotation` and `EmptyAnnotation` are diverging more and I think it will be easier to manage them right now as two separate components.

`EmptyAnnotation` gets the first of what will be a bunch of upcoming `aria-label` attributes.

I can elaborate on the larger trajectory here if you're curious, but I'll not over-clutter this PR's description for now.

Part of https://github.com/hypothesis/product-backlog/issues/1341

Oh, right, and there should be no visible changes for users.