### PR TITLE
Add `useAnnotationAuthor*` hooks and use them in `AnnotationHeader`

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationHeader.js
+++ b/src/sidebar/components/Annotation/AnnotationHeader.js
@@ -3,15 +3,17 @@ import { useMemo } from 'preact/hooks';
 
 import { withServices } from '../../service-context';
 import { useSidebarStore } from '../../store';
-import { isThirdPartyUser, username } from '../../helpers/account-id';
 import {
   domainAndTitle,
   isHighlight,
   isReply,
   hasBeenEdited,
 } from '../../helpers/annotation-metadata';
-import { annotationDisplayName } from '../../helpers/annotation-user';
 import { isPrivate } from '../../helpers/permissions';
+import {
+  useAnnotationAuthorName,
+  useAnnotationAuthorLink,
+} from '../hooks/use-annotation-author';
 
 import AnnotationDocumentInfo from './AnnotationDocumentInfo';
 import AnnotationShareInfo from './AnnotationShareInfo';
@@ -57,27 +59,8 @@ function AnnotationHeader({
   settings,
 }) {
   const store = useSidebarStore();
-  const defaultAuthority = store.defaultAuthority();
-  const displayNamesEnabled = store.isFeatureEnabled('client_display_names');
-
-  const isThirdParty = isThirdPartyUser(annotation.user, defaultAuthority);
-  const authorDisplayName = annotationDisplayName(
-    annotation,
-    isThirdParty,
-    displayNamesEnabled
-  );
-
-  const authorLink = (() => {
-    if (!isThirdParty) {
-      return store.getLink('user', { user: annotation.user });
-    } else {
-      return (
-        (settings.usernameUrl &&
-          `${settings.usernameUrl}${username(annotation.user)}`) ??
-        undefined
-      );
-    }
-  })();
+  const authorDisplayName = useAnnotationAuthorName(annotation);
+  const authorLink = useAnnotationAuthorLink(annotation, settings);
 
   const isCollapsedReply = isReply(annotation) && threadIsCollapsed;
 

--- a/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
@@ -8,8 +8,6 @@ import { mockImportedComponents } from '../../../../test-util/mock-imported-comp
 import AnnotationHeader, { $imports } from '../AnnotationHeader';
 
 describe('AnnotationHeader', () => {
-  let fakeAccountId;
-  let fakeAnnotationDisplayName;
   let fakeDomainAndTitle;
   let fakeGroup;
   let fakeIsHighlight;
@@ -18,6 +16,8 @@ describe('AnnotationHeader', () => {
   let fakeIsPrivate;
   let fakeSettings;
   let fakeStore;
+  let fakeUseAnnotationAuthorName;
+  let fakeUseAnnotationAuthorLink;
 
   const createAnnotationHeader = props => {
     return mount(
@@ -46,36 +46,31 @@ describe('AnnotationHeader', () => {
     fakeHasBeenEdited = sinon.stub().returns(false);
     fakeIsPrivate = sinon.stub();
 
-    fakeAccountId = {
-      isThirdPartyUser: sinon.stub().returns(false),
-      username: sinon.stub().returnsArg(0),
-    };
-
-    fakeAnnotationDisplayName = sinon.stub().returns('Robbie Burns');
-
     fakeSettings = { usernameUrl: 'http://foo.bar/' };
 
     fakeStore = {
-      defaultAuthority: sinon.stub().returns('foo.com'),
       getGroup: sinon.stub().returns(fakeGroup),
-      getLink: sinon.stub().returns('http://example.com'),
-      isFeatureEnabled: sinon.stub().returns(false),
       route: sinon.stub().returns('sidebar'),
       setExpanded: sinon.stub(),
     };
 
+    fakeUseAnnotationAuthorName = sinon.stub().returns('Annotation Author');
+    fakeUseAnnotationAuthorLink = sinon
+      .stub()
+      .returns('http://www.example/com/user/annogirl');
+
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
+      '../hooks/use-annotation-author': {
+        useAnnotationAuthorName: fakeUseAnnotationAuthorName,
+        useAnnotationAuthorLink: fakeUseAnnotationAuthorLink,
+      },
       '../../store': { useSidebarStore: () => fakeStore },
-      '../../helpers/account-id': fakeAccountId,
       '../../helpers/annotation-metadata': {
         domainAndTitle: fakeDomainAndTitle,
         isHighlight: fakeIsHighlight,
         isReply: fakeIsReply,
         hasBeenEdited: fakeHasBeenEdited,
-      },
-      '../../helpers/annotation-user': {
-        annotationDisplayName: fakeAnnotationDisplayName,
       },
       '../../helpers/permissions': {
         isPrivate: fakeIsPrivate,
@@ -114,42 +109,20 @@ describe('AnnotationHeader', () => {
   });
 
   describe('annotation author (user) information', () => {
-    it('should link to author activity if first-party', () => {
-      fakeAccountId.isThirdPartyUser.returns(false);
-
+    it('should pass annotation author link to `AnnotationUser`', () => {
       const wrapper = createAnnotationHeader();
 
       assert.equal(
         wrapper.find('AnnotationUser').props().authorLink,
-        'http://example.com'
+        'http://www.example/com/user/annogirl'
       );
-    });
-
-    it('should link to author activity if third-party and has settings URL', () => {
-      fakeAccountId.isThirdPartyUser.returns(true);
-      const fakeAnnotation = fixtures.defaultAnnotation();
-
-      const wrapper = createAnnotationHeader({ annotation: fakeAnnotation });
-
-      assert.equal(
-        wrapper.find('AnnotationUser').props().authorLink,
-        `http://foo.bar/${fakeAnnotation.user}`
-      );
-    });
-
-    it('should not link to author if third-party and no settings URL', () => {
-      fakeAccountId.isThirdPartyUser.returns(true);
-
-      const wrapper = createAnnotationHeader({ settings: {} });
-
-      assert.isUndefined(wrapper.find('AnnotationUser').props().authorLink);
     });
 
     it('should pass the display name to AnnotationUser', () => {
       const wrapper = createAnnotationHeader();
       assert.equal(
         wrapper.find('AnnotationUser').props().displayName,
-        'Robbie Burns'
+        'Annotation Author'
       );
     });
   });

--- a/src/sidebar/components/hooks/test/use-annotation-author-test.js
+++ b/src/sidebar/components/hooks/test/use-annotation-author-test.js
@@ -1,0 +1,161 @@
+import { mount } from 'enzyme';
+
+import {
+  useAnnotationAuthorName,
+  useAnnotationAuthorLink,
+  $imports,
+} from '../use-annotation-author';
+
+describe('sidebar/components/hooks/use-annotation-author', () => {
+  let fakeAccountId;
+  let fakeStore;
+  let lastAuthorName;
+  let lastAuthorLink;
+  let fakeAnnotation;
+  let fakeSettings;
+
+  // Mount a dummy component to be able to use the hook
+  function DummyComponent({
+    annotation = fakeAnnotation,
+    settings = fakeSettings,
+  }) {
+    lastAuthorName = useAnnotationAuthorName(annotation);
+    lastAuthorLink = useAnnotationAuthorLink(annotation, settings);
+  }
+
+  beforeEach(() => {
+    fakeAnnotation = {
+      user: 'dingbat',
+      user_info: { display_name: 'Ding Bat' },
+    };
+    fakeAccountId = {
+      isThirdPartyUser: sinon.stub(),
+      username: sinon.stub().returnsArg(0),
+    };
+
+    fakeSettings = {
+      usernameUrl: 'http://www.example.com/user/',
+    };
+
+    fakeStore = {
+      defaultAuthority: sinon.stub().returns('foo.com'),
+      getLink: sinon.stub().returns('http://www.example.com/link'),
+      isFeatureEnabled: sinon.stub(),
+    };
+
+    $imports.$mock({
+      '../../helpers/account-id': fakeAccountId,
+      '../../store': { useSidebarStore: () => fakeStore },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  describe('useAnnotationAuthorName', () => {
+    context('first-party user', () => {
+      beforeEach(() => {
+        fakeAccountId.isThirdPartyUser.returns(false);
+      });
+
+      it('should use display name if feature flag enabled and display name available', () => {
+        fakeStore.isFeatureEnabled
+          .withArgs('client_display_names')
+          .returns(true);
+        mount(<DummyComponent />);
+
+        assert.equal(lastAuthorName, 'Ding Bat');
+      });
+      it('should use username if feature flag enabled but display name unavailable', () => {
+        fakeStore.isFeatureEnabled
+          .withArgs('client_display_names')
+          .returns(true);
+
+        mount(<DummyComponent annotation={{ user: 'dingbat' }} />);
+
+        assert.equal(lastAuthorName, 'dingbat');
+      });
+
+      it('should use username if feature flag disabled', () => {
+        fakeStore.isFeatureEnabled
+          .withArgs('client_display_names')
+          .returns(false);
+
+        mount(<DummyComponent />);
+
+        assert.equal(lastAuthorName, 'dingbat');
+      });
+    });
+
+    context('third-party user', () => {
+      beforeEach(() => {
+        fakeAccountId.isThirdPartyUser.returns(true);
+      });
+
+      it('should use display name if available', () => {
+        // The value of this feature flag should be irrelevant
+        fakeStore.isFeatureEnabled
+          .withArgs('client_display_names')
+          .returns(false);
+
+        mount(<DummyComponent />);
+
+        assert.equal(lastAuthorName, 'Ding Bat');
+      });
+
+      it('should use username if no display name is available', () => {
+        mount(<DummyComponent annotation={{ user: 'dingbat' }} />);
+
+        assert.equal(lastAuthorName, 'dingbat');
+      });
+    });
+  });
+
+  describe('useAnnotationAuthorLink', () => {
+    context('first-party user', () => {
+      beforeEach(() => {
+        fakeAccountId.isThirdPartyUser.returns(false);
+      });
+
+      it('should return user link from store', () => {
+        fakeStore.getLink
+          .withArgs('user')
+          .returns('http://www.example.com/user-link');
+
+        mount(<DummyComponent />);
+
+        assert.equal(lastAuthorLink, 'http://www.example.com/user-link');
+        assert.calledWith(
+          fakeStore.getLink,
+          'user',
+          sinon.match({ user: 'dingbat' })
+        );
+      });
+    });
+
+    context('third-party user', () => {
+      beforeEach(() => {
+        fakeAccountId.isThirdPartyUser.returns(true);
+      });
+
+      it('should return URL formatted from `usernameUrl` in `settings`', () => {
+        fakeSettings = {
+          usernameUrl: 'http://www.example.com/user/',
+        };
+
+        mount(<DummyComponent />);
+
+        assert.equal(lastAuthorLink, 'http://www.example.com/user/dingbat');
+      });
+
+      it('should not return a URL if no `usernameUrl` in `settings`', () => {
+        fakeSettings = {};
+
+        mount(<DummyComponent />);
+
+        assert.isUndefined(lastAuthorLink);
+      });
+    });
+  });
+});

--- a/src/sidebar/components/hooks/use-annotation-author.js
+++ b/src/sidebar/components/hooks/use-annotation-author.js
@@ -1,0 +1,58 @@
+import { useMemo } from 'preact/hooks';
+
+import { useSidebarStore } from '../../store';
+import { isThirdPartyUser, username } from '../../helpers/account-id';
+
+/**
+ * @typedef {import("../../../types/api").Annotation} Annotation
+ * @typedef {import('../../../types/config').SidebarSettings} SidebarSettings
+ */
+
+/**
+ * Generate the appropriate display name for an annotation's author.
+ *
+ * @param {Annotation} annotation
+ * @return {string}
+ */
+export function useAnnotationAuthorName(annotation) {
+  const store = useSidebarStore();
+  const defaultAuthority = store.defaultAuthority();
+  const displayNamesEnabled = store.isFeatureEnabled('client_display_names');
+
+  return useMemo(() => {
+    const isThirdParty = isThirdPartyUser(annotation.user, defaultAuthority);
+
+    const useDisplayName = displayNamesEnabled || isThirdParty;
+
+    const authorDisplayName =
+      useDisplayName && annotation.user_info?.display_name
+        ? annotation.user_info.display_name
+        : username(annotation.user);
+
+    return authorDisplayName;
+  }, [annotation, defaultAuthority, displayNamesEnabled]);
+}
+
+/**
+ * Determine the user-page URL for the author of an annotation or undefined
+ * if one cannot be generated.
+ *
+ * @param {Annotation} annotation
+ * @param {SidebarSettings} settings
+ * @return {string|undefined}
+ */
+export function useAnnotationAuthorLink(annotation, settings) {
+  const store = useSidebarStore();
+  const defaultAuthority = store.defaultAuthority();
+  const isThirdParty = isThirdPartyUser(annotation.user, defaultAuthority);
+  const authorLink = !isThirdParty
+    ? store.getLink('user', { user: annotation.user })
+    : undefined;
+
+  return useMemo(() => {
+    if (isThirdParty && settings.usernameUrl) {
+      return `${settings.usernameUrl}${username(annotation.user)}`;
+    }
+    return authorLink;
+  }, [authorLink, settings.usernameUrl, annotation.user, isThirdParty]);
+}


### PR DESCRIPTION
This PR extracts the repetitive boiler code needed to determine an annotation's author's display name and link into hooks so that they may be re-used more easily in components. They are then used here immediately in `AnnotationHeader`. I intend to make use of the `useAnnotationAuthorName` hook in `Annotation` to generate ARIA attributes shortly.

Part of https://github.com/hypothesis/product-backlog/issues/1341