### PR TITLE
Fix alignment of menu caret on Notebook user filter menu

### DIFF
--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -135,7 +135,7 @@ function NotebookView({ loadAnnotationsService, streamer }) {
           {groupName}
         </h1>
       </header>
-      <div>
+      <div className="justify-self-start">
         <NotebookFilters />
       </div>
       <div className="flex items-center lg:justify-self-end text-lg font-medium">


### PR DESCRIPTION
This PR fixes a small visual regression that I'd wager popped up when I transitioned the `NotebookView` to tailwind. Or it's possible it pre-existed even that change. I could dig it up if necessary. Anyway, the up-pointing menu caret was showing up way too far to the right when the user-filter menu was opened:

<img width="422" alt="image" src="https://user-images.githubusercontent.com/439947/167192359-911f10be-c3e8-4883-b9fd-ccb80598d47c.png">

This little change fixes it. The problem was that the `Menu` container element was stretching to fill its entire grid
slot even though the menu content itself only filled a small part of that horizontal space. This change makes the content in that grid cell justify to the start of the grid cell instead of stretching to fill the whole slot. After:

<img width="709" alt="image" src="https://user-images.githubusercontent.com/439947/167192677-42459c09-44ca-432b-84e4-4a0f63ecea40.png">
