### PR TITLE
Add missing types for PortRPC method handlers

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -367,8 +367,10 @@ export class Guest {
   }
 
   async _connectSidebar() {
-    this._sidebarRPC.on('featureFlagsUpdated', flags =>
-      this.features.update(flags)
+    this._sidebarRPC.on(
+      'featureFlagsUpdated',
+      /** @param {Record<string, boolean>} flags */ flags =>
+        this.features.update(flags)
     );
 
     // Handlers for events sent when user hovers or clicks on an annotation card
@@ -409,9 +411,12 @@ export class Guest {
     );
 
     // Handler for controls on the sidebar
-    this._sidebarRPC.on('setHighlightsVisible', showHighlights => {
-      this.setHighlightsVisible(showHighlights);
-    });
+    this._sidebarRPC.on(
+      'setHighlightsVisible',
+      /** @param {boolean} showHighlights */ showHighlights => {
+        this.setHighlightsVisible(showHighlights);
+      }
+    );
 
     this._sidebarRPC.on(
       'deleteAnnotation',

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -329,8 +329,10 @@ export class Sidebar {
     annotationCounts(document.body, this._sidebarRPC);
     sidebarTrigger(document.body, () => this.open());
 
-    this._sidebarRPC.on('featureFlagsUpdated', flags =>
-      this.features.update(flags)
+    this._sidebarRPC.on(
+      'featureFlagsUpdated',
+      /** @param {Record<string, boolean>} flags */ flags =>
+        this.features.update(flags)
     );
 
     this._sidebarRPC.on('connect', () => {


### PR DESCRIPTION
Previously the arguments of the callback passed to `PortRPC.on` were
inferred as `any`. Make the callback type generic so that the caller is
forced to specify what types the arguments have.

Internally within PortRPC, use `unknown` rather than `any` for RPC
method arguments where possible.

Note that this change does not ensure that an RPC method is called (via `call`)
using arguments of the same types that the handler expects, but at least it is
now easier to check that the `call` and `on` uses match up and that arguments
are typed within the handler.