### PR TITLE
Build `annotator` and `sidebar` tailwind entry points separately

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -11,26 +11,55 @@ import gulp from 'gulp';
 import serveDev from './dev-server/serve-dev.js';
 import servePackage from './dev-server/serve-package.js';
 import tailwindConfig from './tailwind.config.mjs';
+import annotatorTailwindConfig from './tailwind-annotator.config.mjs';
+import sidebarTailwindConfig from './tailwind-sidebar.config.mjs';
 
 gulp.task('build-js', () => buildJS('./rollup.config.mjs'));
 gulp.task('watch-js', () => watchJS('./rollup.config.mjs'));
 
-gulp.task('build-css', () =>
+gulp.task('build-annotator-tailwind-css', () =>
+  buildCSS(['./src/styles/annotator/annotator.scss'], {
+    tailwindConfig: annotatorTailwindConfig,
+  })
+);
+
+gulp.task('build-sidebar-tailwind-css', () =>
   buildCSS(
     [
-      // Hypothesis client
-      './src/styles/annotator/annotator.scss',
+      // sidebar styles (with tailwind)
+      './src/styles/sidebar/sidebar.scss',
+      // TODO: After tailwind migration complete, should this
+      // be managed with its own tailwind config?
+      './src/styles/ui-playground/ui-playground.scss',
+    ],
+    { tailwindConfig: sidebarTailwindConfig }
+  )
+);
+
+// These CSS source files should not use Tailwind, as they are used in
+// third-party contexts.
+// TODO: Remove `tailwindConfig` after updating `sass` task in `frontend-build`.
+// Setting it is necessary currently to suppress a build warning.
+gulp.task('build-standalone-css', () =>
+  buildCSS(
+    [
+      // other styles used by annotator (standalone)
       './src/styles/annotator/highlights.scss',
       './src/styles/annotator/pdfjs-overrides.scss',
-      './src/styles/sidebar/sidebar.scss',
 
       // Vendor
       './node_modules/katex/dist/katex.min.css',
-
-      // Development tools
-      './src/styles/ui-playground/ui-playground.scss',
     ],
     { tailwindConfig }
+  )
+);
+
+gulp.task(
+  'build-css',
+  gulp.parallel(
+    'build-annotator-tailwind-css',
+    'build-sidebar-tailwind-css',
+    'build-standalone-css'
   )
 );
 

--- a/tailwind-annotator.config.mjs
+++ b/tailwind-annotator.config.mjs
@@ -1,0 +1,11 @@
+import tailwindConfig from './tailwind.config.mjs';
+
+export default {
+  presets: [tailwindConfig],
+  content: [
+    './src/annotator/components/**/*.js',
+    './node_modules/@hypothesis/frontend-shared/lib/**/*.js',
+    // This module references `sidebar-frame` and related classes
+    './src/annotator/sidebar.js',
+  ],
+};

--- a/tailwind-sidebar.config.mjs
+++ b/tailwind-sidebar.config.mjs
@@ -1,0 +1,10 @@
+import tailwindConfig from './tailwind.config.mjs';
+
+export default {
+  presets: [tailwindConfig],
+  content: [
+    './src/sidebar/components/**/*.js',
+    './dev-server/ui-playground/components/**/*.js',
+    './node_modules/@hypothesis/frontend-shared/lib/**/*.js',
+  ],
+};


### PR DESCRIPTION
I realized yesterday afternoon (mild facepalm) that `annotator` output CSS contained tailwind utility classes that only applied to `sidebar` components and vice versa. This is because both were built against the same tailwind config, with the same `content` globs. Tailwind output CSS has a relatively small footprint so this isn't a massive fubar, but we should batten down the hatches here so we're not delivering unused or duplicate CSS.

This PR attempts to divvy up the two tailwind entry points with separate configuration to only include tailwind styles that are relevant to the given entry point.

We could take this a little further by splitting up the CSS `watch` task for performance improvement.

Keeping this in draft until I do a little more testing to make sure everything that's needed in CSS is present where it needs to be.

----

Split up the build of `annotator` and `sidebar` tailwind CSS into
separate tasks so they can be built against distinct tailwind
configuration. This allows the definition of `content` globs that are
specific to each entry point, avoiding the inclusion of irrelevant
styles in output CSS.

The other standalone CSS entry points — highlights, pdfjs-overrides,
katex — can be built against any tailwind configuration as they do not
enable any tailwind layers (and thus do not include any tailwind
utility classes).