### PR TITLE
Send `isShared` with annotation notifications, use `notify`

### DIFF
--- a/src/sidebar/services/annotation-activity.js
+++ b/src/sidebar/services/annotation-activity.js
@@ -1,3 +1,4 @@
+import { isShared } from '../helpers/permissions';
 import * as postMessageJsonRpc from '../util/postmessage-json-rpc';
 
 /**
@@ -45,16 +46,16 @@ export class AnnotationActivityService {
       date: activityDate,
       annotation: {
         id: annotation.id,
+        isShared: isShared(annotation.permissions),
       },
     };
 
     if (this._reportConfig.events.includes(eventType)) {
-      postMessageJsonRpc.call(
+      postMessageJsonRpc.notify(
         this._rpc.targetFrame,
         this._rpc.origin,
         this._reportConfig.method,
-        [eventType, data],
-        3000
+        [eventType, data]
       );
     }
   }

--- a/src/sidebar/services/test/annotation-activity-test.js
+++ b/src/sidebar/services/test/annotation-activity-test.js
@@ -3,6 +3,7 @@ import * as fixtures from '../../test/annotation-fixtures';
 import { AnnotationActivityService, $imports } from '../annotation-activity';
 
 describe('AnnotationActivityService', () => {
+  let fakePermissions;
   let fakePostMessageJsonRpc;
 
   let fakeRpcSettings;
@@ -10,8 +11,12 @@ describe('AnnotationActivityService', () => {
   let fakeSettings;
 
   beforeEach(() => {
+    fakePermissions = {
+      isShared: sinon.stub().returns(true),
+    };
+
     fakePostMessageJsonRpc = {
-      call: sinon.stub(),
+      notify: sinon.stub(),
     };
 
     fakeRpcSettings = {
@@ -30,6 +35,7 @@ describe('AnnotationActivityService', () => {
     };
 
     $imports.$mock({
+      '../helpers/permissions': fakePermissions,
       '../util/postmessage-json-rpc': fakePostMessageJsonRpc,
     });
   });
@@ -45,9 +51,9 @@ describe('AnnotationActivityService', () => {
 
       svc.reportActivity('update', annotation);
 
-      assert.calledOnce(fakePostMessageJsonRpc.call);
+      assert.calledOnce(fakePostMessageJsonRpc.notify);
       assert.calledWith(
-        fakePostMessageJsonRpc.call,
+        fakePostMessageJsonRpc.notify,
         window,
         'https://www.example.com',
         'remoteMethod'
@@ -60,8 +66,8 @@ describe('AnnotationActivityService', () => {
 
       svc.reportActivity('update', annotation);
 
-      const eventType = fakePostMessageJsonRpc.call.getCall(0).args[3][0];
-      const data = fakePostMessageJsonRpc.call.getCall(0).args[3][1];
+      const eventType = fakePostMessageJsonRpc.notify.getCall(0).args[3][0];
+      const data = fakePostMessageJsonRpc.notify.getCall(0).args[3][1];
 
       assert.equal(eventType, 'update');
       assert.deepEqual(data, {
@@ -70,6 +76,7 @@ describe('AnnotationActivityService', () => {
         date: new Date(annotation.updated).toISOString(),
         annotation: {
           id: annotation.id,
+          isShared: true,
         },
       });
     });
@@ -82,7 +89,7 @@ describe('AnnotationActivityService', () => {
 
       svc.reportActivity('update', annotation);
 
-      assert.notCalled(fakePostMessageJsonRpc.call);
+      assert.notCalled(fakePostMessageJsonRpc.notify);
     });
 
     it('does not invoke remote activity method if reportActivity not configured', () => {
@@ -91,7 +98,7 @@ describe('AnnotationActivityService', () => {
 
       svc.reportActivity('update', annotation);
 
-      assert.notCalled(fakePostMessageJsonRpc.call);
+      assert.notCalled(fakePostMessageJsonRpc.notify);
     });
 
     it('does not invoke remote activity method if annotation event type is not one of configured events', () => {
@@ -100,7 +107,7 @@ describe('AnnotationActivityService', () => {
 
       svc.reportActivity('delete', annotation);
 
-      assert.notCalled(fakePostMessageJsonRpc.call);
+      assert.notCalled(fakePostMessageJsonRpc.notify);
     });
 
     it('uses annotation created date as `date` for `create` events', () => {
@@ -109,7 +116,7 @@ describe('AnnotationActivityService', () => {
 
       svc.reportActivity('create', annotation);
 
-      const data = fakePostMessageJsonRpc.call.getCall(0).args[3][1];
+      const data = fakePostMessageJsonRpc.notify.getCall(0).args[3][1];
 
       assert.equal(data.date, new Date(annotation.created).toISOString());
     });
@@ -120,7 +127,7 @@ describe('AnnotationActivityService', () => {
 
       svc.reportActivity('update', annotation);
 
-      const data = fakePostMessageJsonRpc.call.getCall(0).args[3][1];
+      const data = fakePostMessageJsonRpc.notify.getCall(0).args[3][1];
 
       assert.equal(data.date, new Date(annotation.updated).toISOString());
     });
@@ -145,7 +152,7 @@ describe('AnnotationActivityService', () => {
 
         svc.reportActivity('delete', annotation);
 
-        const data = fakePostMessageJsonRpc.call.getCall(0).args[3][1];
+        const data = fakePostMessageJsonRpc.notify.getCall(0).args[3][1];
         assert.equal(data.date, now.toISOString());
       });
     });

--- a/src/sidebar/util/postmessage-json-rpc.js
+++ b/src/sidebar/util/postmessage-json-rpc.js
@@ -98,3 +98,21 @@ export function call(
       throw err;
     });
 }
+
+/**
+ * Send a JSON-RPC 2.0 notification request to another frame via `postMessage`.
+ * No response is expected.
+ *
+ * @param {Window} frame - Frame to send call to
+ * @param {string} origin - Origin filter for `window.postMessage` call
+ * @param {string} method - Name of the JSON-RPC method
+ * @param {unknown[]} params - Parameters of the JSON-RPC method
+ */
+export function notify(frame, origin, method, params = []) {
+  const request = {
+    jsonrpc: '2.0',
+    method,
+    params,
+  };
+  frame.postMessage(request, origin);
+}

--- a/src/sidebar/util/test/postmessage-json-rpc-test.js
+++ b/src/sidebar/util/test/postmessage-json-rpc-test.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'tiny-emitter';
 
-import { call, $imports } from '../postmessage-json-rpc';
+import { call, notify, $imports } from '../postmessage-json-rpc';
 
 class FakeWindow {
   constructor() {
@@ -13,6 +13,25 @@ class FakeWindow {
 describe('sidebar/util/postmessage-json-rpc', () => {
   const origin = 'https://embedder.com';
   const messageId = 42;
+
+  describe('notify', () => {
+    let frame;
+
+    beforeEach(() => {
+      frame = { postMessage: sinon.stub() };
+    });
+
+    it('should send a JSON-RPC 2.0 notification to the frame', () => {
+      notify(frame, origin, 'testMethod', [1, 2, 3]);
+
+      assert.calledOnce(frame.postMessage);
+      assert.calledWith(frame.postMessage, {
+        jsonrpc: '2.0',
+        method: 'testMethod',
+        params: [1, 2, 3],
+      });
+    });
+  });
 
   describe('call', () => {
     let frame;


### PR DESCRIPTION
This PR adds JSON-RPC 2.0 notification support for _sending_ notification requests. It also adds an `isShared` property to annotation metadata that is sent with annotation activity notifications.

I'd had grander visions when I set out of bringing the JSON-RPC-over-postMessage implementation into alignment with `lms`, but that is a hefty task as they diverge in some fundamental ways that are not easy to bring into line without some focus. So instead I opted for the lightest possible touch here.

I have some working local code for `lms` that will only submit grading submissions when `isShared` is `true` on annotation activity (i.e. I've tested this end-to-end as intended). These changes have no effect on current `master` in `lms` — I tested against that to verify that assignment submissions are still working as expected (auto-submission after first annotation activity, whether private or not).

Part of https://github.com/hypothesis/client/issues/4484