### PR TITLE
WIP: PoC sketch of `aria-` labeling attributes for `Annotation` `article` elements

### DIFF
--- a/src/sidebar/components/Annotation/Annotation.js
+++ b/src/sidebar/components/Annotation/Annotation.js
@@ -1,8 +1,15 @@
 import { Actions, Spinner } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
+import { useMemo } from 'preact/hooks';
 
 import { useSidebarStore } from '../../store';
-import { isOrphan, isSaved, quote } from '../../helpers/annotation-metadata';
+import {
+  isHighlight,
+  isOrphan,
+  isSaved,
+  quote,
+} from '../../helpers/annotation-metadata';
+import { annotationDisplayName } from '../../helpers/annotation-user';
 import { withServices } from '../../service-context';
 
 import AnnotationActionBar from './AnnotationActionBar';
@@ -84,8 +91,30 @@ function Annotation({
     }
   };
 
+  const authorName = useMemo(
+    () => annotationDisplayName(annotation, store),
+    [annotation, store]
+  );
+
+  let annotationType;
+  if (isHighlight(annotation)) {
+    annotationType = 'Highlight';
+  } else if (isReply) {
+    annotationType = 'Reply';
+  } else {
+    annotationType = 'Annotation';
+  }
+
+  const quoteElementId = annotationQuote
+    ? `annotation-quote-${annotation.$tag}`
+    : undefined;
+
   return (
-    <article className="space-y-4">
+    <article
+      className="space-y-4"
+      aria-label={`${annotationType} by ${authorName}`}
+      aria-describedby={quoteElementId}
+    >
       <AnnotationHeader
         annotation={annotation}
         isEditing={isEditing}
@@ -95,6 +124,7 @@ function Annotation({
 
       {annotationQuote && (
         <AnnotationQuote
+          elementId={quoteElementId}
           quote={annotationQuote}
           isFocused={isFocused}
           isOrphan={isOrphan(annotation)}

--- a/src/sidebar/components/Annotation/AnnotationQuote.js
+++ b/src/sidebar/components/Annotation/AnnotationQuote.js
@@ -12,6 +12,7 @@ import StyledText from '../StyledText';
 
 /**
  * @typedef AnnotationQuoteProps
+ * @prop {string} [elementId]
  * @prop {string} quote
  * @prop {boolean} [isFocused]
  * @prop {boolean} [isOrphan]
@@ -23,7 +24,7 @@ import StyledText from '../StyledText';
  *
  * @param {AnnotationQuoteProps} props
  */
-function AnnotationQuote({ quote, isFocused, isOrphan, settings }) {
+function AnnotationQuote({ elementId, quote, isFocused, isOrphan, settings }) {
   return (
     <Excerpt collapsedHeight={35} inlineControls={true} overflowThreshold={20}>
       <StyledText classes={classnames({ 'p-redacted-text': isOrphan })}>
@@ -31,6 +32,7 @@ function AnnotationQuote({ quote, isFocused, isOrphan, settings }) {
           className={classnames('hover:border-l-blue-quote', {
             'border-l-blue-quote': isFocused,
           })}
+          id={elementId}
           style={applyTheme(['selectionFontFamily'], settings)}
         >
           {quote}


### PR DESCRIPTION
This PR is pursuant to https://github.com/hypothesis/product-backlog/issues/1341 and aims to find an approach to adding `aria-label` and `aria-describedby` attributes to `Annotation` `article` elements to better identify and describe their content.

As described in [this comment](https://github.com/hypothesis/product-backlog/issues/1341#issuecomment-1116161495), different "types" of annotations need to be labeled and described differently.

Adding an appropriate `aria-label` attribute is fairly straightforward, now that we have a more convenient way to obtain annotation author display names—presuming the labels I've chosen here are useful and helpful.

For highlights and top-level annotations, adding an `aria-describedby` reference to the ID corresponding to the annotation's quote (aka "highlighted text") seems plausible. That content is always plain-text. Note that replies don't have quotes.

I explored the possibility of referencing the annotation's (or reply's) content ("excerpt") as an additional way to describe it. There are a few problems with this:

* We currently render annotation content as HTML. Documentation for `aria-describedby` says that the content of the referenced element should be plaintext. Ostensibly, we could render another, hidden element with the plaintext content and reference _that_ as `aria-describedby`, but that feels off to me...especially because:
* I'm not convinced that the full content of the annotation or reply is _useful_ `aria-describedby` content as it is, well, the _content_ of the element being described.

What I'd like to do is come to consensus relatively quickly about what feels like a good first attempt here at `aria-label` and `aria-describedby` so we can get it in front of users and get some feedback. This more than many other things we put out there feels like it needs real-world validation from people using different kinds of screen readers and browser accessibility tools.

