### PR TITLE
Don't hide empty annotation message when thread is collapsed

### DIFF
--- a/src/sidebar/components/Annotation/EmptyAnnotation.js
+++ b/src/sidebar/components/Annotation/EmptyAnnotation.js
@@ -18,7 +18,6 @@ export default function EmptyAnnotation({
   threadIsCollapsed,
   onToggleReplies,
 }) {
-  const isCollapsedReply = isReply && threadIsCollapsed;
   return (
     <article
       className="space-y-4"
@@ -26,11 +25,9 @@ export default function EmptyAnnotation({
         isReply ? 'Reply' : 'Annotation'
       } with unavailable content`}
     >
-      {!isCollapsedReply && (
-        <div>
-          <em>Message not available.</em>
-        </div>
-      )}
+      <div>
+        <em>Message not available.</em>
+      </div>
       {onToggleReplies && (
         <footer className="flex items-center">
           <AnnotationReplyToggle

--- a/src/sidebar/components/Annotation/test/EmptyAnnotation-test.js
+++ b/src/sidebar/components/Annotation/test/EmptyAnnotation-test.js
@@ -74,15 +74,6 @@ describe('EmptyAnnotation', () => {
         'Reply with unavailable content'
       );
     });
-
-    it('should not render a message if collapsed reply', () => {
-      const wrapper = createComponent({
-        isReply: true,
-        threadIsCollapsed: true,
-      });
-
-      assert.equal(wrapper.text(), '');
-    });
   });
 
   it(


### PR DESCRIPTION
This small PR addresses a visual defect that we've been noticing.

Before these changes, the "Message not available."  message for `EmptyAnnotation`s (deleted annotations that still have replies) was suppressed when the thread was `collapsed`, which resulted in an odd visual state (note right-pointing caret with nothing next to it):

<img width="419" alt="image" src="https://user-images.githubusercontent.com/439947/168671540-454b9d8d-3dea-4ae1-9029-53cd86116efa.png">


I believe this situation arose because of an evolution of how threads are handled when they are `visible`/not `visible` versus `collapsed`/not `collapsed` (aka "expanded"). Toggling reply threads by clicking on them as a user will toggle their `collapsed` state. A thread that doesn't match applied filters will have its `visible` property set to `false`. 

An `Annotation` (or `EmptyAnnotation`) will not be rendered for a thread that is `visible=false`. That hasn't changed over time. What has changed is that in the past, `Thread` was responsible for rendering the "Message not available" message. We ended up in a situation where that message was showing up when a thread was `visible=false`, which is undesirable. 

Now that this message is handled by `EmptyAnnotation` and `EmptyAnnotation` will not get rendered if a `thread` is `visible=false`, we can safely always show this message and be confident that it will only show up when it's supposed to.

After:

<img width="422" alt="image" src="https://user-images.githubusercontent.com/439947/168671463-69959eb7-ee92-4f1f-a7c8-8741e91d1393.png">
