### PR TITLE
Announce when saving highlights, deleting annotations

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationActionBar.js
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.js
@@ -2,6 +2,7 @@ import { IconButton } from '@hypothesis/frontend-shared';
 
 import { confirm } from '../../../shared/prompts';
 import { serviceConfig } from '../../config/service-config';
+import { annotationRole } from '../../helpers/annotation-metadata';
 import {
   sharingEnabled,
   annotationSharingLink,
@@ -72,15 +73,17 @@ function AnnotationActionBar({
     sharingEnabled(settings) && annotationSharingLink(annotation);
 
   const onDelete = async () => {
+    const annType = annotationRole(annotation);
     if (
       await confirm({
-        title: 'Delete annotation?',
-        message: 'Are you sure you want to delete this annotation?',
+        title: `Delete ${annType.toLowerCase()}?`,
+        message: `Are you sure you want to delete this ${annType.toLowerCase()}?`,
         confirmAction: 'Delete',
       })
     ) {
       try {
         await annotationsService.delete(annotation);
+        toastMessenger.success(`${annType} deleted`, { visuallyHidden: true });
       } catch (err) {
         toastMessenger.error(err.message);
       }

--- a/src/sidebar/components/Annotation/AnnotationEditor.js
+++ b/src/sidebar/components/Annotation/AnnotationEditor.js
@@ -2,7 +2,11 @@ import { normalizeKeyName } from '@hypothesis/frontend-shared';
 import { useCallback, useState } from 'preact/hooks';
 
 import { withServices } from '../../service-context';
-import { isReply, isSaved } from '../../helpers/annotation-metadata';
+import {
+  annotationRole,
+  isReply,
+  isSaved,
+} from '../../helpers/annotation-metadata';
 import { applyTheme } from '../../helpers/theme';
 import { useSidebarStore } from '../../store';
 
@@ -139,8 +143,12 @@ function AnnotationEditor({
     if (pendingTag) {
       onAddTag(pendingTag);
     }
+    const successMessage = `${annotationRole(annotation)} ${
+      isSaved(annotation) ? 'updated' : 'saved'
+    }`;
     try {
       await annotationsService.save(annotation);
+      toastMessenger.success(successMessage, { visuallyHidden: true });
     } catch (err) {
       toastMessenger.error('Saving annotation failed');
     }

--- a/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
@@ -68,6 +68,7 @@ describe('AnnotationActionBar', () => {
 
     fakeToastMessenger = {
       error: sinon.stub(),
+      success: sinon.stub(),
     };
 
     fakeOnReply = sinon.stub();
@@ -167,6 +168,23 @@ describe('AnnotationActionBar', () => {
       });
 
       assert.calledWith(fakeAnnotationsService.delete, fakeAnnotation);
+    });
+
+    it('sets a visually-hidden message when deletion succeeds', async () => {
+      allowOnly('delete');
+      fakeConfirm.resolves(true);
+      const button = getButton(createComponent(), 'trash');
+
+      await act(async () => {
+        await button.props().onClick();
+      });
+
+      await waitFor(() => fakeToastMessenger.success.called);
+      // Annotation fixture used evaluates as a highlight because it is missing
+      // selectors
+      assert.calledWith(fakeToastMessenger.success, 'Highlight deleted', {
+        visuallyHidden: true,
+      });
     });
 
     it('sets a flash message if there is an error with deletion', async () => {

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -52,6 +52,7 @@ describe('AnnotationEditor', () => {
     };
     fakeToastMessenger = {
       error: sinon.stub(),
+      success: sinon.stub(),
     };
 
     fakeStore = {
@@ -163,6 +164,20 @@ describe('AnnotationEditor', () => {
 
       assert.calledOnce(fakeAnnotationsService.save);
       assert.calledWith(fakeAnnotationsService.save, annotation);
+    });
+
+    it('shows a visually-hidden toast message on success', async () => {
+      const annotation = fixtures.defaultAnnotation();
+      const wrapper = createComponent({ annotation });
+
+      await wrapper.find('AnnotationPublishControl').props().onSave();
+
+      await waitFor(() => fakeToastMessenger.success.called);
+      // The defaultAnnotation() fixture evaluates as a previously-saved
+      // highlight because it lacks selectors
+      assert.calledWith(fakeToastMessenger.success, 'Highlight updated', {
+        visuallyHidden: true,
+      });
     });
 
     it('checks for unsaved tags on save', async () => {

--- a/src/sidebar/components/ToastMessages.js
+++ b/src/sidebar/components/ToastMessages.js
@@ -16,7 +16,9 @@ import { withServices } from '../service-context';
 
 /**
  * An individual toast message: a brief and transient success or error message.
- * The message may be dismissed by clicking on it.
+ * The message may be dismissed by clicking on it. `visuallyHidden` toast
+ * messages will not be visible but are still available to screen readers.
+ *
  * Otherwise, the `toastMessenger` service handles removing messages after a
  * certain amount of time.
  *
@@ -42,6 +44,7 @@ function ToastMessage({ message, onDismiss }) {
     /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */
     <Card
       classes={classnames('p-0 flex border', {
+        'sr-only': message.visuallyHidden,
         'border-red-error': message.type === 'error',
         'border-yellow-notice': message.type === 'notice',
         'border-green-success': message.type === 'success',

--- a/src/sidebar/components/test/ToastMessages-test.js
+++ b/src/sidebar/components/test/ToastMessages-test.js
@@ -90,6 +90,17 @@ describe('ToastMessages', () => {
       assert.calledOnce(fakeToastMessenger.dismiss);
     });
 
+    it('should set a screen-reader-only class on `visuallyHidden` messages', () => {
+      const message = fakeSuccessMessage();
+      message.visuallyHidden = true;
+      fakeStore.getToastMessages.returns([message]);
+
+      const wrapper = createComponent();
+
+      const messageContainer = wrapper.find('ToastMessage').getDOMNode();
+      assert.include(messageContainer.className, 'sr-only');
+    });
+
     it('should not dismiss the message if a "More info" link is clicked', () => {
       fakeStore.getToastMessages.returns([fakeNoticeMessage()]);
 

--- a/src/sidebar/services/autosave.js
+++ b/src/sidebar/services/autosave.js
@@ -8,10 +8,12 @@ import { retryPromiseOperation } from '../util/retry';
 export class AutosaveService {
   /**
    * @param {import('./annotations').AnnotationsService} annotationsService
+   * @param {import('./toast-messenger').ToastMessengerService} toastMessenger
    * @param {import('../store').SidebarStore} store
    */
-  constructor(annotationsService, store) {
+  constructor(annotationsService, toastMessenger, store) {
     this._annotationsService = annotationsService;
+    this._toastMessenger = toastMessenger;
     this._store = store;
 
     // A set of annotation $tags that have save requests in-flight
@@ -55,6 +57,11 @@ export class AutosaveService {
         this._saving.add(htag);
 
         retryPromiseOperation(() => this._annotationsService.save(highlight))
+          .then(() => {
+            this._toastMessenger.success('Highlight saved', {
+              visuallyHidden: true,
+            });
+          })
           .catch(() => {
             // save failed after retries
             this._failed.add(htag);

--- a/src/sidebar/services/test/toast-messenger-test.js
+++ b/src/sidebar/services/test/toast-messenger-test.js
@@ -39,11 +39,15 @@ describe('ToastMessengerService', () => {
     it('adds a new success toast message to the store', () => {
       fakeStore.hasToastMessage.returns(false);
 
-      service.success('hooray');
+      service.success('hooray', { visuallyHidden: true });
 
       assert.calledWith(
         fakeStore.addToastMessage,
-        sinon.match({ type: 'success', message: 'hooray' })
+        sinon.match({
+          type: 'success',
+          message: 'hooray',
+          visuallyHidden: true,
+        })
       );
     });
 

--- a/src/sidebar/services/toast-messenger.js
+++ b/src/sidebar/services/toast-messenger.js
@@ -11,6 +11,8 @@ const MESSAGE_DISMISS_DELAY = 500;
  * @typedef MessageOptions
  * @prop {boolean} [autoDismiss=true] - Whether the toast message automatically disappears.
  * @prop {string} [moreInfoURL=''] - Optional URL for users to visit for "more info"
+ * @prop {boolean} [visuallyHidden=false] - When `true`, message will be visually
+ *   hidden but still available to screen readers.
  */
 
 /**
@@ -58,7 +60,7 @@ export class ToastMessengerService {
   _addMessage(
     type,
     messageText,
-    { autoDismiss = true, moreInfoURL = '' } = {}
+    { autoDismiss = true, moreInfoURL = '', visuallyHidden = false } = {}
   ) {
     // Do not add duplicate messages (messages with the same type and text)
     if (this._store.hasToastMessage(type, messageText)) {
@@ -66,7 +68,13 @@ export class ToastMessengerService {
     }
 
     const id = generateHexString(10);
-    const message = { type, id, message: messageText, moreInfoURL };
+    const message = {
+      type,
+      id,
+      message: messageText,
+      moreInfoURL,
+      visuallyHidden,
+    };
 
     this._store.addToastMessage({
       isDismissed: false,

--- a/src/sidebar/store/modules/test/toast-messages-test.js
+++ b/src/sidebar/store/modules/test/toast-messages-test.js
@@ -11,6 +11,7 @@ describe('store/modules/toast-messages', () => {
       id: 'myToast',
       type: 'anyType',
       message: 'This is a message',
+      visuallyHidden: false,
     };
   });
 
@@ -27,6 +28,7 @@ describe('store/modules/toast-messages', () => {
         assert.equal(messages[0].id, 'myToast');
         assert.equal(messages[0].type, 'anyType');
         assert.equal(messages[0].message, 'This is a message');
+        assert.isFalse(messages[0].visuallyHidden);
       });
 
       it('adds duplicate messages to the array of messages in state', () => {

--- a/src/sidebar/store/modules/toast-messages.js
+++ b/src/sidebar/store/modules/toast-messages.js
@@ -7,6 +7,7 @@ import { createStoreModule, makeAction } from '../create-store';
  * @prop {string} message
  * @prop {string} moreInfoURL
  * @prop {boolean} isDismissed
+ * @prop {boolean} visuallyHidden
  */
 
 /**


### PR DESCRIPTION
Depends on #4530 

This PR builds on visually-hidden toast messages to add announcements when:

* An annotation is deleted
* A highlight is (auto-)saved

Fixes https://github.com/hypothesis/product-backlog/issues/1346
Fixes https://github.com/hypothesis/product-backlog/issues/1343