### PR TITLE
Fix margin nit on complex lists of toast messages

### DIFF
--- a/src/sidebar/components/ToastMessages.js
+++ b/src/sidebar/components/ToastMessages.js
@@ -117,13 +117,20 @@ function ToastMessages({ toastMessenger }) {
       <ul
         aria-live="polite"
         aria-relevant="additions"
-        className="absolute z-2 left-0 w-full space-y-2"
+        className="absolute z-2 left-0 w-full"
       >
         {messages.map(message => (
           <li
             className={classnames(
               'relative w-full container hover:cursor-pointer',
               {
+                // Add a bottom margin to visible messages only. Typically we'd
+                // use a `space-y-2` class on the parent to space children.
+                // Doing that here could cause an undesired top margin on
+                // the first visible message in a list that contains (only)
+                // visually-hidden messages before it.
+                // See https://tailwindcss.com/docs/space#limitations
+                'mb-2': !message.visuallyHidden,
                 // Slide in from right in narrow viewports; fade in in
                 // larger viewports to toast message isn't flying too far
                 'motion-safe:animate-slide-in-from-right lg:animate-fade-in':


### PR DESCRIPTION
Bah! I _did_ test the "new" toast messages with combinations of different kinds of toast messages, but I failed to encounter this particular combination until now.

This PR fixes a small margin jump that can occur in the following circumstances:

* The user takes an action that spawns a non-visible toast message AND
* Within 5 seconds, the user takes an action that spawns a visible toast message

In these cases—a list of active toast messages contains one or more non-visible messages before a visible message—an undesirable top margin was being applied to the first visible message. That margin goes away when the non-visible toast messages expire, causing a small jump. You can see that in the before here:

![toast-message-margins-before](https://user-images.githubusercontent.com/439947/169045233-b2bb153f-aeba-40e6-890b-c4dc41ffcbe4.gif)

and it is resolved after:

![toast-message-margins-after](https://user-images.githubusercontent.com/439947/169045270-03c45758-5db7-4d16-9535-a835643126d3.gif)

I'm annoyed at myself because it did occur to me that such things might occur, but I thought I had tested the relevant combinations. Mea culpa. In reality, this situation would likely not arise often (it requires quick and nimble click-fingers to spawn two messages that quickly).
