### PR TITLE
Provide ARIA `role="status"` for search results text

### DIFF
--- a/src/sidebar/components/test/FilterStatus-test.js
+++ b/src/sidebar/components/test/FilterStatus-test.js
@@ -3,17 +3,6 @@ import { mount } from 'enzyme';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import FilterStatus, { $imports } from '../FilterStatus';
 
-function getFilterState() {
-  return {
-    filterQuery: null,
-    focusActive: false,
-    focusConfigured: false,
-    focusDisplayName: null,
-    forcedVisibleCount: 0,
-    selectedCount: 0,
-  };
-}
-
 function getFocusState() {
   return {
     active: false,
@@ -40,7 +29,6 @@ describe('FilterStatus', () => {
       clearSelection: sinon.stub(),
       directLinkedAnnotationId: sinon.stub(),
       filterQuery: sinon.stub().returns(null),
-      filterState: sinon.stub().returns(getFilterState()),
       focusState: sinon.stub().returns(getFocusState()),
       forcedVisibleThreads: sinon.stub().returns([]),
       isLoading: sinon.stub().returns(false),
@@ -59,7 +47,7 @@ describe('FilterStatus', () => {
   });
 
   function assertFilterText(wrapper, text) {
-    const filterText = wrapper.find('[data-testid="filter-text"]').text();
+    const filterText = wrapper.find('[role="status"]').text();
     assert.equal(filterText, text);
   }
 
@@ -91,9 +79,12 @@ describe('FilterStatus', () => {
   });
 
   context('(State 1): no search filters active', () => {
-    it('should return null if filter state indicates no active filters', () => {
+    it('should render hidden but available to screen readers', () => {
       const wrapper = createComponent();
-      assert.equal(wrapper.children().length, 0);
+      const containerEl = wrapper.find('Card').getDOMNode();
+
+      assert.include(containerEl.className, 'sr-only');
+      assertFilterText(wrapper, '');
     });
   });
 


### PR DESCRIPTION
This PR adds `role="status"` to an appropriate persistent element such that assistive technology is able to report changes to search filtering and results.

These changes refactor `FilterStatus` considerably in its _internal_ implementation (API unchanged and functionality virtually unchanged; see below). This refactor was done for two reasons:

1. The DOM structure needed to be different. The requirements of being able to support a `role="status"` element means that that the "status" element needs to be present in the DOM consistently, instead of showing up and going away as filters are set and cleared. That is, the "status" container needs to persist, and the content (text) within it can change over time and be announced by screen readers. This is similar to how we handle the container for toast messages. `role="status"` containers are a kind of `aria-live` region, so their constraints are similar.
2. I can remember back when the `FilterStatus` component and its internal subcomponents were created, there was some feedback about them being quite...complex, but they were allowed to land because they were comprehensively commented and organized. This refactor removes a mid-layer of sub-components and a distracting typed object that was getting passed around. The result is 2 components vs. 5, and about ~20% fewer LOC. I believe it is now possible to hold this in one's head more comfortably.

The only _functional_ change here is that the element containing text describing applied filters and their results has a `role="status"` attribute. You can see that tests are minimally altered to:

* Remove an unused test function
* Change expectations for how this component renders when there are no applied filters (it is present, but hidden)
* Change selector for textual content tests to use `role="status"` attribute selector

I did some rudimentary testing with VoiceOver and indeed filtering changes are announced. Whether they're exactly as a real user would prefer is another question and might require us to reach out for feedback.

## Testing

If you care to test the functioning of `FilterStatus`, it can be helpful to uncomment/add "focused user" configuration in `dev-server/templates/client-config.js.mustache` as much of the complexity is in the interactions with "user-focus" mode. Such testing is welcome though not required as test coverage is fairly robust in this area.

Fixes https://github.com/hypothesis/product-backlog/issues/1349