### PR TITLE
Fix memoization bug with annotation author metadata functions

### DIFF
--- a/src/sidebar/components/Annotation/Annotation.js
+++ b/src/sidebar/components/Annotation/Annotation.js
@@ -85,6 +85,9 @@ function Annotation({
 
   const showActions = !isSaving && !isEditing && isSaved(annotation);
 
+  const defaultAuthority = store.defaultAuthority();
+  const displayNamesEnabled = store.isFeatureEnabled('client_display_names');
+
   const onReply = () => {
     if (isSaved(annotation) && userid) {
       annotationsService.reply(annotation, userid);
@@ -92,8 +95,9 @@ function Annotation({
   };
 
   const authorName = useMemo(
-    () => annotationDisplayName(annotation, store),
-    [annotation, store]
+    () =>
+      annotationDisplayName(annotation, defaultAuthority, displayNamesEnabled),
+    [annotation, defaultAuthority, displayNamesEnabled]
   );
 
   return (

--- a/src/sidebar/components/Annotation/AnnotationHeader.js
+++ b/src/sidebar/components/Annotation/AnnotationHeader.js
@@ -9,7 +9,10 @@ import {
   isReply,
   hasBeenEdited,
 } from '../../helpers/annotation-metadata';
-import { annotationAuthorInfo } from '../../helpers/annotation-user';
+import {
+  annotationAuthorLink,
+  annotationDisplayName,
+} from '../../helpers/annotation-user';
 import { isPrivate } from '../../helpers/permissions';
 
 import AnnotationDocumentInfo from './AnnotationDocumentInfo';
@@ -57,9 +60,19 @@ function AnnotationHeader({
 }) {
   const store = useSidebarStore();
 
-  const { authorDisplayName, authorLink } = useMemo(
-    () => annotationAuthorInfo(annotation, store, settings),
-    [annotation, store, settings]
+  const defaultAuthority = store.defaultAuthority();
+  const displayNamesEnabled = store.isFeatureEnabled('client_display_names');
+  const userURL = store.getLink('user', { user: annotation.user });
+
+  const authorName = useMemo(
+    () =>
+      annotationDisplayName(annotation, defaultAuthority, displayNamesEnabled),
+    [annotation, defaultAuthority, displayNamesEnabled]
+  );
+
+  const authorLink = useMemo(
+    () => annotationAuthorLink(annotation, settings, defaultAuthority, userURL),
+    [annotation, settings, defaultAuthority, userURL]
   );
 
   const isCollapsedReply = isReply(annotation) && threadIsCollapsed;
@@ -109,10 +122,7 @@ function AnnotationHeader({
             title="This annotation is visible only to you"
           />
         )}
-        <AnnotationUser
-          authorLink={authorLink}
-          displayName={authorDisplayName}
-        />
+        <AnnotationUser authorLink={authorLink} displayName={authorName} />
         {replyCount > 0 && isCollapsedReply && (
           <LinkButton onClick={onReplyCountClick} title="Expand replies">
             {`${replyCount} ${replyCount > 1 ? 'replies' : 'reply'}`}

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -54,8 +54,13 @@ describe('Annotation', () => {
     };
 
     fakeStore = {
+      defaultAuthority: sinon.stub().returns('example.com'),
       getDraft: sinon.stub().returns(null),
       isAnnotationFocused: sinon.stub().returns(false),
+      isFeatureEnabled: sinon
+        .stub()
+        .withArgs('client_display_names')
+        .returns(true),
       isSavingAnnotation: sinon.stub().returns(false),
       profile: sinon.stub().returns({ userid: 'acct:foo@bar.com' }),
       setExpanded: sinon.stub(),

--- a/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
@@ -8,7 +8,8 @@ import { mockImportedComponents } from '../../../../test-util/mock-imported-comp
 import AnnotationHeader, { $imports } from '../AnnotationHeader';
 
 describe('AnnotationHeader', () => {
-  let fakeAnnotationAuthorInfo;
+  let fakeAnnotationAuthorLink;
+  let fakeAnnotationDisplayName;
   let fakeDomainAndTitle;
   let fakeGroup;
   let fakeIsHighlight;
@@ -32,6 +33,10 @@ describe('AnnotationHeader', () => {
   };
 
   beforeEach(() => {
+    fakeAnnotationAuthorLink = sinon
+      .stub()
+      .returns('http://www.example.com/user/');
+    fakeAnnotationDisplayName = sinon.stub().returns('Wackford Squeers');
     fakeDomainAndTitle = sinon.stub().returns({});
     fakeGroup = {
       name: 'My Group',
@@ -45,15 +50,19 @@ describe('AnnotationHeader', () => {
     fakeHasBeenEdited = sinon.stub().returns(false);
     fakeIsPrivate = sinon.stub();
 
-    fakeAnnotationAuthorInfo = sinon.stub().returns({
-      authorDisplayName: 'Robbie Burns',
-      authorLink: 'http://www.example.com',
-    });
-
     fakeSettings = { usernameUrl: 'http://foo.bar/' };
 
     fakeStore = {
+      defaultAuthority: sinon.stub().returns('example.com'),
+      isFeatureEnabled: sinon
+        .stub()
+        .withArgs('client_display_names')
+        .returns(true),
       getGroup: sinon.stub().returns(fakeGroup),
+      getLink: sinon
+        .stub()
+        .withArgs('user')
+        .returns('http://www.example.com/user/'),
       route: sinon.stub().returns('sidebar'),
       setExpanded: sinon.stub(),
     };
@@ -68,7 +77,8 @@ describe('AnnotationHeader', () => {
         hasBeenEdited: fakeHasBeenEdited,
       },
       '../../helpers/annotation-user': {
-        annotationAuthorInfo: fakeAnnotationAuthorInfo,
+        annotationAuthorLink: fakeAnnotationAuthorLink,
+        annotationDisplayName: fakeAnnotationDisplayName,
       },
       '../../helpers/permissions': {
         isPrivate: fakeIsPrivate,
@@ -112,15 +122,12 @@ describe('AnnotationHeader', () => {
 
       assert.equal(
         wrapper.find('AnnotationUser').props().authorLink,
-        'http://www.example.com'
+        'http://www.example.com/user/'
       );
     });
 
     it('should not link to author if none provided', () => {
-      fakeAnnotationAuthorInfo.returns({
-        authorDisplayName: 'Robbie Burns',
-        authorLink: undefined,
-      });
+      fakeAnnotationAuthorLink.returns(undefined);
 
       const wrapper = createAnnotationHeader();
 
@@ -131,7 +138,7 @@ describe('AnnotationHeader', () => {
       const wrapper = createAnnotationHeader();
       assert.equal(
         wrapper.find('AnnotationUser').props().displayName,
-        'Robbie Burns'
+        'Wackford Squeers'
       );
     });
   });

--- a/src/sidebar/components/hooks/test/use-filter-options-test.js
+++ b/src/sidebar/components/hooks/test/use-filter-options-test.js
@@ -51,7 +51,12 @@ describe('sidebar/components/hooks/use-user-filter-options', () => {
 
     fakeStore = {
       allAnnotations: sinon.stub().returns([]),
+      defaultAuthority: sinon.stub().returns('example.com'),
       getFocusFilters: sinon.stub().returns({}),
+      isFeatureEnabled: sinon
+        .stub()
+        .withArgs('client_display_names')
+        .returns(true),
       profile: sinon.stub().returns({}),
     };
 

--- a/src/sidebar/components/hooks/use-filter-options.js
+++ b/src/sidebar/components/hooks/use-filter-options.js
@@ -17,6 +17,8 @@ export function useUserFilterOptions() {
   const annotations = store.allAnnotations();
   const focusFilters = store.getFocusFilters();
   const currentUsername = username(store.profile().userid);
+  const defaultAuthority = store.defaultAuthority();
+  const displayNamesEnabled = store.isFeatureEnabled('client_display_names');
 
   return useMemo(() => {
     // Determine unique users (authors) in annotation collection
@@ -24,7 +26,11 @@ export function useUserFilterOptions() {
     const users = {};
     annotations.forEach(annotation => {
       const username_ = username(annotation.user);
-      users[username_] = annotationDisplayName(annotation, store);
+      users[username_] = annotationDisplayName(
+        annotation,
+        defaultAuthority,
+        displayNamesEnabled
+      );
     });
 
     // If user-focus is configured (even if not applied) add a filter
@@ -57,5 +63,11 @@ export function useUserFilterOptions() {
     });
 
     return userOptions;
-  }, [annotations, currentUsername, focusFilters.user, store]);
+  }, [
+    annotations,
+    currentUsername,
+    defaultAuthority,
+    displayNamesEnabled,
+    focusFilters.user,
+  ]);
 }

--- a/src/sidebar/helpers/annotation-user.js
+++ b/src/sidebar/helpers/annotation-user.js
@@ -1,10 +1,10 @@
 /**
  * @typedef {import("../../types/api").Annotation} Annotation
  * @typedef {import('../../types/config').SidebarSettings} SidebarSettings
- * @typedef {import('../store').SidebarStore} SidebarStore
  */
 
 import { isThirdPartyUser, username } from './account-id';
+
 /**
  * What string should we use to represent the author (user) of a given
  * annotation: a display name or a username?
@@ -18,15 +18,17 @@ import { isThirdPartyUser, username } from './account-id';
  * username or the display name.
  *
  * @param {Pick<Annotation, 'user'|'user_info'>} annotation
- * @param {SidebarStore} store
+ * @param {string} defaultAuthority
+ * @param {boolean} displayNamesEnabled
  *
  * @return {string}
  */
-export function annotationDisplayName(annotation, store) {
-  const defaultAuthority = store.defaultAuthority();
+export function annotationDisplayName(
+  annotation,
+  defaultAuthority,
+  displayNamesEnabled
+) {
   const isThirdParty = isThirdPartyUser(annotation.user, defaultAuthority);
-
-  const displayNamesEnabled = store.isFeatureEnabled('client_display_names');
 
   const useDisplayName = displayNamesEnabled || isThirdParty;
   return useDisplayName && annotation.user_info?.display_name
@@ -40,15 +42,20 @@ export function annotationDisplayName(annotation, store) {
  * provided in `settings`.
  *
  * @param {Pick<Annotation, 'user'>} annotation
- * @param {SidebarStore} store
  * @param {SidebarSettings} settings
+ * @param {string} defaultAuthority
+ * @param {string} [userLink]
  */
-export function annotationAuthorLink(annotation, store, settings) {
-  const defaultAuthority = store.defaultAuthority();
+export function annotationAuthorLink(
+  annotation,
+  settings,
+  defaultAuthority,
+  userLink
+) {
   const isThirdParty = isThirdPartyUser(annotation.user, defaultAuthority);
 
-  if (!isThirdParty) {
-    return store.getLink('user', { user: annotation.user });
+  if (!isThirdParty && userLink) {
+    return userLink;
   }
 
   return (
@@ -56,18 +63,4 @@ export function annotationAuthorLink(annotation, store, settings) {
       `${settings.usernameUrl}${username(annotation.user)}`) ??
     undefined
   );
-}
-
-/**
- * Retrieve both author display name and link.
- *
- * @param {Pick<Annotation, 'user'|'user_info'>} annotation
- * @param {SidebarStore} store
- * @param {SidebarSettings} settings
- */
-export function annotationAuthorInfo(annotation, store, settings) {
-  return {
-    authorDisplayName: annotationDisplayName(annotation, store),
-    authorLink: annotationAuthorLink(annotation, store, settings),
-  };
 }


### PR DESCRIPTION
This dull but needed PR refactors the way that annotation author display names and URLs to author pages are determined to avoid memoization bugs. This means, unfortunately, that less of the logic can be encapsulated, as callers need to pass the arguments that are pertinent to memoization.

Fixes #4536