### PR TITLE
Remove unneeded `normalizeKeyName` utility use

### DIFF
--- a/src/shared/shortcut.js
+++ b/src/shared/shortcut.js
@@ -1,5 +1,3 @@
-import { normalizeKeyName } from '@hypothesis/frontend-shared';
-
 import { useEffect } from 'preact/hooks';
 
 /**
@@ -55,7 +53,7 @@ export function matchShortcut(event, shortcut) {
 
   return (
     actualModifiers === requiredModifiers &&
-    normalizeKeyName(event.key).toLowerCase() === requiredKey
+    event.key.toLowerCase() === requiredKey
   );
 }
 

--- a/src/sidebar/components/Annotation/AnnotationEditor.js
+++ b/src/sidebar/components/Annotation/AnnotationEditor.js
@@ -1,4 +1,3 @@
-import { normalizeKeyName } from '@hypothesis/frontend-shared';
 import { useCallback, useState } from 'preact/hooks';
 
 import { withServices } from '../../service-context';
@@ -165,7 +164,7 @@ function AnnotationEditor({
   // Allow saving of annotation by pressing CMD/CTRL-Enter
   /** @param {KeyboardEvent} event */
   const onKeyDown = event => {
-    const key = normalizeKeyName(event.key);
+    const key = event.key;
     if (isEmpty) {
       return;
     }

--- a/src/sidebar/components/MarkdownEditor.js
+++ b/src/sidebar/components/MarkdownEditor.js
@@ -3,7 +3,6 @@ import {
   IconButton,
   LabeledButton,
   Link,
-  normalizeKeyName,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
@@ -394,7 +393,7 @@ export default function MarkdownEditor({
     }
 
     for (let [command, key] of Object.entries(SHORTCUT_KEYS)) {
-      if (key === normalizeKeyName(event.key)) {
+      if (key === event.key) {
         event.stopPropagation();
         event.preventDefault();
         handleCommand(/** @type {Command} */ (command));

--- a/src/sidebar/components/Menu.js
+++ b/src/sidebar/components/Menu.js
@@ -1,9 +1,5 @@
 import classnames from 'classnames';
-import {
-  Icon,
-  normalizeKeyName,
-  useElementShouldClose,
-} from '@hypothesis/frontend-shared';
+import { Icon, useElementShouldClose } from '@hypothesis/frontend-shared';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 
 import MenuArrow from './MenuArrow';
@@ -137,7 +133,7 @@ export default function Menu({
   // It should also close if the user presses a key which activates menu items.
   /** @param {KeyboardEvent} event */
   const handleMenuKeyDown = event => {
-    const key = normalizeKeyName(event.key);
+    const key = event.key;
     if (key === 'Enter' || key === ' ') {
       // The browser will not open the link if the link element is removed
       // from within the keypress event that triggers it. Add a little

--- a/src/sidebar/components/MenuItem.js
+++ b/src/sidebar/components/MenuItem.js
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { Icon, normalizeKeyName } from '@hypothesis/frontend-shared';
+import { Icon } from '@hypothesis/frontend-shared';
 import { useEffect, useRef } from 'preact/hooks';
 
 import MenuKeyboardNavigation from './MenuKeyboardNavigation';
@@ -161,7 +161,7 @@ export default function MenuItem({
 
   /** @param {KeyboardEvent} event */
   const onKeyDown = event => {
-    switch (normalizeKeyName(event.key)) {
+    switch (event.key) {
       case 'ArrowRight':
         if (onToggleSubmenu) {
           event.stopPropagation();

--- a/src/sidebar/components/MenuKeyboardNavigation.js
+++ b/src/sidebar/components/MenuKeyboardNavigation.js
@@ -1,4 +1,3 @@
-import { normalizeKeyName } from '@hypothesis/frontend-shared';
 import { useEffect, useRef } from 'preact/hooks';
 
 /** @param {HTMLElement} element */
@@ -62,7 +61,7 @@ export default function MenuKeyboardNavigation({
 
     let handled = false;
 
-    switch (normalizeKeyName(event.key)) {
+    switch (event.key) {
       case 'ArrowLeft':
       case 'Escape':
         if (closeMenu) {

--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -1,8 +1,4 @@
-import {
-  normalizeKeyName,
-  useElementShouldClose,
-  TextInput,
-} from '@hypothesis/frontend-shared';
+import { useElementShouldClose, TextInput } from '@hypothesis/frontend-shared';
 import { useRef, useState } from 'preact/hooks';
 
 import { withServices } from '../service-context';
@@ -172,7 +168,7 @@ function TagEditor({
    * @param {KeyboardEvent} e
    */
   const handleKeyDown = e => {
-    switch (normalizeKeyName(e.key)) {
+    switch (e.key) {
       case 'ArrowUp':
         // Select the previous item in the suggestion list
         changeSelectedItem(-1);


### PR DESCRIPTION
`normalizeKeyName` provided normalization of `event.key` names for
key* events for legacy browsers. We no longer support those legacy
browsers (IE11, Legacy Edge), so this utility is no longer necessary.

This will also allow us to remove this utility from the `frontend-shared` package from whence it comes.