### PR TITLE
Describe new annotations as "New" in aria-label

### DIFF
--- a/src/sidebar/components/Annotation/Annotation.js
+++ b/src/sidebar/components/Annotation/Annotation.js
@@ -100,10 +100,14 @@ function Annotation({
     [annotation, defaultAuthority, displayNamesEnabled]
   );
 
+  const annotationDescription = isSaved(annotation)
+    ? annotationRole(annotation)
+    : `New ${annotationRole(annotation).toLowerCase()}`;
+
   return (
     <article
       className="space-y-4"
-      aria-label={`${annotationRole(annotation)} by ${authorName}`}
+      aria-label={`${annotationDescription} by ${authorName}`}
     >
       <AnnotationHeader
         annotation={annotation}

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -79,12 +79,21 @@ describe('Annotation', () => {
   });
 
   describe('annotation accessibility (ARIA) attributes', () => {
-    it('should add an `aria-label` composed of annotation type and author name', () => {
+    it('should add a descriptive `aria-label` for an existing annotation', () => {
       const wrapper = createComponent();
 
       assert.equal(
         wrapper.find('article').props()['aria-label'],
         'Annotation by Richard Lionheart'
+      );
+    });
+
+    it('should add a descriptive `aria-label` for a new annotation', () => {
+      const wrapper = createComponent({ annotation: fixtures.newAnnotation() });
+
+      assert.equal(
+        wrapper.find('article').props()['aria-label'],
+        'New annotation by Richard Lionheart'
       );
     });
   });


### PR DESCRIPTION
This PR makes a small tweak to the `aria-label` on `article` elements pertaining to annotations. It prefixes new (unsaved) annotations with "New" to give an extra hint to screen-reader users.

Related to https://github.com/hypothesis/product-backlog/issues/1344

Before:

<img width="764" alt="image" src="https://user-images.githubusercontent.com/439947/176175736-caaf19b6-f5e2-421f-ac9a-0d75836a7894.png">

After (2 examples):

<img width="866" alt="image" src="https://user-images.githubusercontent.com/439947/176175749-6872c403-121f-4384-ba97-e17361851c8a.png">

<img width="857" alt="image" src="https://user-images.githubusercontent.com/439947/176176243-09758f66-4057-46c2-adab-a18486a91b54.png">

