### PR TITLE
Document issue with `useStore` + `useMemo` and fix potential missing re-render

### DIFF
--- a/src/sidebar/store/use-store.js
+++ b/src/sidebar/store/use-store.js
@@ -38,6 +38,24 @@ class CacheEntry {
  *
  * The returned wrapper has the same API as the store itself.
  *
+ * The returned wrapper does not change its identity if the store updates. This
+ * means you need to be careful when using it with hooks that have dependencies,
+ * such as `useMemo`, `useEffect` or `useCallback`. Given code like this:
+ *
+ * ```
+ * const calculatedValue = useMemo(() => calculateSomething(store.getSomeValue()), [store]);
+ * ```
+ *
+ * `calulatedValue` will not be recalculated if the result of
+ * `store.getSomeValue()` changes, because the `store` reference itself does not
+ * change. A workaround is to extract the values from the store and pass those
+ * into the closure:
+ *
+ * ```
+ * const someValue = store.getSomeValue();
+ * const calculatedValue = useMemo(() => calculateSomething(someValue), [someValue]);
+ * ```
+ *
  * @example
  *   // A hook which encapsulates looking up the specific store instance,
  *   // eg. via `useContext`.

--- a/src/sidebar/store/use-store.js
+++ b/src/sidebar/store/use-store.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useReducer } from 'preact/hooks';
+import { useLayoutEffect, useRef, useReducer } from 'preact/hooks';
 
 /**
  * Result of a cached store selector method call.
@@ -129,7 +129,7 @@ export function useStore(store) {
 
   // Register a subscriber which clears cache and re-renders component when
   // relevant store state changes.
-  useEffect(() => {
+  useLayoutEffect(() => {
     const cleanup = store.subscribe(() => {
       const invalidEntry = cache.find(
         // nb. A potential problem here is that the method arguments may refer


### PR DESCRIPTION
This PR fixes a potential missing re-render in `useStore` if the store changes in between the initial render of a component, and `useEffect` callbacks firing, by swapping out `useEffect` for `useLayoutEffect`. We've never actually encountered a problem due to this issue IIRC, but we might as well prevent it from happening.

I also documented a hazard with using the returned wrapper together with hooks that accept dependencies. I think the hazard could be eliminated with some API / behavior changes [1], but this requires some further experimentation.

[1] Roughly what I had in mind was that the `Proxy` returned by `useStore` would get re-created whenever relevant data changes in the store. This would mean that any `useMemo`s etc. would get invalidated as necessary. However we have a bunch of effects which use the store to dispatch actions, and those shouldn't be re-run unnecessarily.