### PR TITLE
Re-render Adder when `annotationsForSelection` property changes

### DIFF
--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -144,8 +144,8 @@ export class Adder {
    * Set the annotation IDs associated with the current selection.
    *
    * Setting this to a non-empty list causes the "Show" button to appear in
-   * the toolbar, triggering the `onShowAnnotations` callback passed to the
-   * constructor when clicked.
+   * the toolbar. Clicking the "Show" button  triggers the `onShowAnnotations`
+   * callback passed to the constructor.
    */
   set annotationsForSelection(ids) {
     this._annotationsForSelection = ids;

--- a/src/annotator/adder.js
+++ b/src/annotator/adder.js
@@ -127,14 +127,28 @@ export class Adder {
     this._onShowAnnotations = options.onShowAnnotations;
 
     /**
-     * Annotation tags associated with the current selection. If non-empty,
-     * a "Show" button appears in the toolbar. Clicking the button calls the
-     * `onShowAnnotations` callback with the current value of `annotationsForSelection`.
+     * Annotation tags associated with the current selection.
      *
      * @type {string[]}
      */
-    this.annotationsForSelection = [];
+    this._annotationsForSelection = [];
 
+    this._render();
+  }
+
+  get annotationsForSelection() {
+    return this._annotationsForSelection;
+  }
+
+  /**
+   * Set the annotation IDs associated with the current selection.
+   *
+   * Setting this to a non-empty list causes the "Show" button to appear in
+   * the toolbar, triggering the `onShowAnnotations` callback passed to the
+   * constructor when clicked.
+   */
+  set annotationsForSelection(ids) {
+    this._annotationsForSelection = ids;
     this._render();
   }
 

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -118,6 +118,23 @@ describe('Adder', () => {
       assert.equal(showBtn.querySelector('span').textContent, '2');
     });
 
+    it('updates "Show" button when `annotationsForSelection` changes', () => {
+      adder.show(rect(100, 200, 100, 20), false);
+
+      adder.annotationsForSelection = [];
+      let showButton = getButton('Show');
+      assert.notOk(showButton);
+
+      adder.annotationsForSelection = [{ $tag: '123' }, { $tag: '456' }];
+      showButton = getButton('Show');
+      assert.ok(showButton);
+      assert.include(showButton.textContent, '2');
+
+      adder.annotationsForSelection = [];
+      showButton = getButton('Show');
+      assert.notOk(showButton);
+    });
+
     it('calls onShowAnnotations callback when Show button is clicked', () => {
       adder.annotationsForSelection = ['ann1'];
       showAdder();


### PR DESCRIPTION
This fixes an issue where the `show` method could position the adder
incorrectly if the emptiness of `annotationsForSelection` changed since
the adder was previously displayed. This is because the size of the
adder was outdated at the point when `show` calls `_calculateTarget` to
determine the adder position. Re-rendering as soon as
`annotationsForSelection` changes resolves this.

Fixes #3293

**TODO:**

- [x] Add a test