### PR TITLE
Initial support for client-side navigation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # upgrade everything by simply updating the Alpine version.
 #
 # Alpine is updated every 6 months so all packages are pretty recent.
-FROM alpine:3.13
+FROM alpine:3.16
 
 RUN apk update && apk add --no-cache \
   chromium \

--- a/dev-server/documents/html/client-side-navigation.mustache
+++ b/dev-server/documents/html/client-side-navigation.mustache
@@ -1,0 +1,62 @@
+<!doctype>
+<html>
+  <title>Client-side navigation test</title>
+  <body>
+  <h1 id="header"></h1>
+  <p id="intro"></p>
+  <hr>
+  <p id="content"></p>
+  <hr>
+  <div id="navLinks">
+    <!-- Omit page param for Page 1, otherwise we'd need a rel-canonical link
+         to make `page=1` equivalent to not setting the param. -->
+    <a href="client-side-navigation">Page 1</a>
+    <a href="client-side-navigation?page=2">Page 2</a>
+    <a href="client-side-navigation?page=3">Page 3</a>
+  </div>
+  <div style="padding-top: 10px;">
+    <label for="replaceStateCheckbox">Use <code>replaceState</code> instead of <code>pushState</code>?</label><input type="checkbox" id="replaceStateCheckbox">
+  </div>
+  <script type="module">
+    const pageContent = [
+      'Some extra content that is only on the first page.',
+      'Word that only appear on the second page.',
+      'Thoughts on the third page',
+    ];
+
+    const setContent = (url) => {
+      const page = new URL(url).searchParams.get('page') ?? 1;
+      const header = document.querySelector('#header');
+      const intro = document.querySelector('#intro');
+      const content = document.querySelector('#content');
+
+      header.textContent = `Page ${page}`;
+      intro.textContent =
+        `You are currently on page ${page}. Use the links below to perform a
+         client-side navigation and then try using Back/Forwards.`;
+
+      const pageText = pageContent[parseInt(page) - 1];
+      content.textContent = pageText || '';
+    };
+
+    const replaceStateCheckbox = document.querySelector('#replaceStateCheckbox');
+
+    const navLinks = document.querySelector('#navLinks');
+    navLinks.addEventListener('click', e => {
+      e.preventDefault();
+      if (e.target.href) {
+        if (replaceStateCheckbox.checked) {
+          history.replaceState({}, null, e.target.href);
+        } else {
+          history.pushState({}, null, e.target.href);
+        }
+        setContent(e.target.href);
+      }
+    });
+
+    setContent(location.href);
+    window.addEventListener('popstate', () => setContent(location.href));
+  </script>
+  {{{ hypothesisScript }}}
+  </body>
+</html>

--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -27,6 +27,7 @@
     <h3>Scenario HTML test documents</h3>
     <p>These documents test less common scenarios and edge cases.</p>
     <ul>
+      <li><a href="/document/client-side-navigation">Client-side navigation / SPA</a></li>
       <li><a href="/document/z-index">Content with high <code>z-index</code> style</a></li>
       <li><a href="/document/shadow-dom">Content in shadow DOM</a></li>
       <li><a href="/document/coop-test"><code>Cross-Origin-Opener-Policy</code> test</a></li>

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -194,6 +194,10 @@ export class Guest {
     this._integration = createIntegration(this, {
       contentPartner: config.contentPartner,
     });
+    this._integration.on('uriChanged', async () => {
+      const metadata = await this.getDocumentInfo();
+      this._sidebarRPC.call('documentInfoChanged', metadata);
+    });
 
     /**
      * Channel for host-guest communication.

--- a/src/annotator/integrations/html.js
+++ b/src/annotator/integrations/html.js
@@ -1,3 +1,5 @@
+import { TinyEmitter } from 'tiny-emitter';
+
 import { anchor, describe } from '../anchoring/html';
 
 import { HTMLMetadata } from './html-metadata';
@@ -28,13 +30,15 @@ const MIN_HTML_WIDTH = 480;
  *
  * @implements {Integration}
  */
-export class HTMLIntegration {
+export class HTMLIntegration extends TinyEmitter {
   /**
    * @param {object} options
    *   @param {FeatureFlags} options.features
    *   @param {HTMLElement} [options.container]
    */
   constructor({ features, container = document.body }) {
+    super();
+
     this.features = features;
     this.container = container;
     this.anchor = anchor;

--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -1,5 +1,6 @@
 import debounce from 'lodash.debounce';
 import { render } from 'preact';
+import { TinyEmitter } from 'tiny-emitter';
 
 import { ListenerCollection } from '../../shared/listener-collection';
 import {
@@ -62,7 +63,7 @@ export function isPDF() {
  * Integration that works with PDF.js
  * @implements {Integration}
  */
-export class PDFIntegration {
+export class PDFIntegration extends TinyEmitter {
   /**
    * @param {Annotator} annotator
    * @param {object} options
@@ -72,6 +73,8 @@ export class PDFIntegration {
    *     re-anchoring to complete when scrolling to an un-rendered page.
    */
   constructor(annotator, options = {}) {
+    super();
+
     this.annotator = annotator;
 
     const window_ = /** @type {HypothesisWindow} */ (window);

--- a/src/annotator/integrations/test/html-test.js
+++ b/src/annotator/integrations/test/html-test.js
@@ -404,6 +404,10 @@ describe('HTMLIntegration', () => {
     const onURIChanged = sinon.stub();
     integration.on('uriChanged', onURIChanged);
 
+    // Report a navigation, but do not change the URL returned by `fakeHTMLMetadata.uri`.
+    //
+    // This can happen if the page has a `<link rel=canonical>` that gets used
+    // as the document URI instead of the URL in the URL bar.
     notifyNavigation();
 
     assert.notCalled(onURIChanged);

--- a/src/annotator/integrations/vitalsource.js
+++ b/src/annotator/integrations/vitalsource.js
@@ -1,3 +1,5 @@
+import { TinyEmitter } from 'tiny-emitter';
+
 import { ListenerCollection } from '../../shared/listener-collection';
 import { FeatureFlags } from '../features';
 import { onDocumentReady } from '../frame-observer';
@@ -202,11 +204,13 @@ function makeContentFrameScrollable(frame) {
  *
  * @implements {Integration}
  */
-export class VitalSourceContentIntegration {
+export class VitalSourceContentIntegration extends TinyEmitter {
   /**
    * @param {HTMLElement} container
    */
   constructor(container = document.body) {
+    super();
+
     const features = new FeatureFlags();
 
     // Forcibly enable the side-by-side feature for VS books. This feature is

--- a/src/annotator/util/navigation-observer.js
+++ b/src/annotator/util/navigation-observer.js
@@ -3,7 +3,7 @@ import { ListenerCollection } from '../../shared/listener-collection';
 /**
  * Monkey-patch an object to observe calls to a method.
  *
- * The observer is not notified if the method throws.
+ * The `handler` is not invoked if the observed method throws.
  *
  * @template {any} T
  * @param {T} object
@@ -20,12 +20,13 @@ function observeCalls(object, method, handler) {
     throw new Error('Can only intercept functions');
   }
 
-  // @ts-expect-error
-  object[method] = (...args) => {
+  /** @param {unknown[]} args */
+  const wrapper = (...args) => {
     const result = origHandler.call(object, ...args);
     handler(...args);
     return result;
   };
+  object[method] = /** @type {any} */ (wrapper);
 
   return () => {
     object[method] = origHandler;

--- a/src/annotator/util/navigation-observer.js
+++ b/src/annotator/util/navigation-observer.js
@@ -1,0 +1,99 @@
+import { ListenerCollection } from '../../shared/listener-collection';
+
+/**
+ * Monkey-patch an object to observe calls to a method.
+ *
+ * The observer is not notified if the method throws.
+ *
+ * @template {any} T
+ * @param {T} object
+ * @param {keyof T} method
+ * @param {(...args: unknown[]) => void} handler - Handler that is invoked
+ *   after the monitored method has been called.
+ * @return {() => void} Callback that removes the observer and restores `object[method]`.
+ */
+function observeCalls(object, method, handler) {
+  const origHandler = object[method];
+
+  /* istanbul ignore next */
+  if (typeof origHandler !== 'function') {
+    throw new Error('Can only intercept functions');
+  }
+
+  // @ts-expect-error
+  object[method] = (...args) => {
+    const result = origHandler.call(object, ...args);
+    handler(...args);
+    return result;
+  };
+
+  return () => {
+    object[method] = origHandler;
+  };
+}
+
+/** @param {string} url */
+function stripFragment(url) {
+  return url.replace(/#.*/, '');
+}
+
+/**
+ * Utility for detecting client-side navigations of an HTML document.
+ *
+ * This uses the Navigation API [1] if available, or falls back to
+ * monkey-patching the History API [2] otherwise.
+ *
+ * Only navigations which change the path or query params are reported. URL
+ * updates which change only the hash fragment are assumed to be navigations to
+ * different parts of the same logical document. Also Hypothesis in general
+ * ignores the hash fragment when comparing URLs.
+ *
+ * [1] https://wicg.github.io/navigation-api/
+ * [2] https://developer.mozilla.org/en-US/docs/Web/API/History
+ */
+export class NavigationObserver {
+  /**
+   * Begin observing navigation changes.
+   *
+   * @param {(url: string) => void} onNavigate - Callback invoked when a navigation
+   *   occurs. The callback is fired after the navigation has completed and the
+   *   new URL is reflected in `location.href`.
+   * @param {() => string} getLocation - Test seam that returns the current URL
+   */
+  constructor(
+    onNavigate,
+    /* istanbul ignore next - default overridden in tests */
+    getLocation = () => location.href
+  ) {
+    this._listeners = new ListenerCollection();
+
+    let lastURL = getLocation();
+    const checkForURLChange = (newURL = getLocation()) => {
+      if (stripFragment(lastURL) !== stripFragment(newURL)) {
+        lastURL = newURL;
+        onNavigate(newURL);
+      }
+    };
+
+    // @ts-expect-error - TS is missing Navigation API types.
+    const navigation = window.navigation;
+    if (navigation) {
+      this._listeners.add(navigation, 'navigatesuccess', () =>
+        checkForURLChange()
+      );
+    } else {
+      const unpatchers = [
+        observeCalls(window.history, 'pushState', () => checkForURLChange()),
+        observeCalls(window.history, 'replaceState', () => checkForURLChange()),
+      ];
+      this._unpatchHistory = () => unpatchers.forEach(cleanup => cleanup());
+      this._listeners.add(window, 'popstate', () => checkForURLChange());
+    }
+  }
+
+  /** Stop observing navigation changes. */
+  disconnect() {
+    this._unpatchHistory?.();
+    this._listeners.removeAll();
+  }
+}

--- a/src/annotator/util/test/navigation-observer-test.js
+++ b/src/annotator/util/test/navigation-observer-test.js
@@ -1,0 +1,126 @@
+import { NavigationObserver } from '../navigation-observer';
+
+function runTest(initialURL, callback) {
+  const onNavigate = sinon.stub();
+  const getURL = sinon.stub().returns(initialURL);
+  const observer = new NavigationObserver(onNavigate, getURL);
+  try {
+    callback(observer, onNavigate, getURL);
+  } finally {
+    observer.disconnect();
+  }
+}
+
+describe('NavigationObserver', () => {
+  context('when the Navigation API is supported', () => {
+    it('reports navigation when a "navigatesuccess" event fires', () => {
+      runTest('https://example.com/page-1', (observer, onNavigate, getURL) => {
+        getURL.returns('https://example.com/page-2');
+        window.navigation.dispatchEvent(new Event('navigatesuccess'));
+        assert.calledWith(onNavigate, 'https://example.com/page-2');
+      });
+    });
+
+    it('stops reporting navigations after observer is disconnected', () => {
+      runTest('https://example.com/page-1', (observer, onNavigate, getURL) => {
+        getURL.returns('https://example.com/page-2');
+
+        observer.disconnect();
+
+        window.navigation.dispatchEvent(new Event('navigatesuccess'));
+        assert.notCalled(onNavigate);
+      });
+    });
+  });
+
+  context('when the Navigation API is not supported', () => {
+    let origNavigation;
+
+    before(() => {
+      origNavigation = window.navigation;
+      window.navigation = null;
+    });
+
+    after(() => {
+      window.navigation = origNavigation;
+    });
+
+    it('reports navigation when `history.pushState` is called', () => {
+      runTest('https://example.com/page-1', (observer, onNavigate, getURL) => {
+        getURL.returns('https://example.com/page-2');
+        window.history.pushState({}, null, location.href /* dummy */);
+        assert.calledWith(onNavigate, 'https://example.com/page-2');
+      });
+    });
+
+    it('reports navigation when `history.replaceState` is called', () => {
+      runTest('https://example.com/page-1', (observer, onNavigate, getURL) => {
+        getURL.returns('https://example.com/page-2');
+        window.history.replaceState({}, null, location.href /* dummy */);
+        assert.calledWith(onNavigate, 'https://example.com/page-2');
+      });
+    });
+
+    it('reports navigation when a "popstate" event fires', () => {
+      runTest('https://example.com/page-1', (observer, onNavigate, getURL) => {
+        getURL.returns('https://example.com/page-2');
+        window.dispatchEvent(new Event('popstate'));
+        assert.calledWith(onNavigate, 'https://example.com/page-2');
+      });
+    });
+
+    it('stops reporting navigations after observer is disconnected', () => {
+      runTest('https://example.com/page-1', (observer, onNavigate, getURL) => {
+        getURL.returns('https://example.com/page-2');
+
+        observer.disconnect();
+        window.history.pushState({}, null, location.href /* dummy */);
+
+        assert.notCalled(onNavigate);
+      });
+    });
+  });
+
+  [
+    // Path change
+    {
+      oldURL: 'https://example.com/path-1',
+      newURL: 'https://example.com/path-2',
+      shouldFire: true,
+    },
+
+    // Query param change
+    {
+      oldURL: 'https://example.com/path?page=1',
+      newURL: 'https://example.com/path?page=2',
+      shouldFire: true,
+    },
+
+    // Hash fragment change
+    {
+      oldURL: 'https://example.com/path#section-1',
+      newURL: 'https://example.com/path#section-2',
+      shouldFire: false,
+    },
+
+    {
+      oldURL: 'https://example.com/path#section-1',
+      newURL: 'https://example.com/path',
+      shouldFire: false,
+    },
+  ].forEach(({ oldURL, newURL, shouldFire }) => {
+    it('only fires an event if the path or query params change', () => {
+      runTest(oldURL, (observer, onNavigate, getURL) => {
+        getURL.returns(newURL);
+
+        window.navigation.dispatchEvent(new Event('navigatesuccess'));
+
+        if (shouldFire) {
+          assert.calledWith(onNavigate, newURL);
+        } else {
+          assert.notCalled(onNavigate);
+        }
+      });
+    });
+  });
+});

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -31,7 +31,14 @@ const reducers = {
    * @param {{ frame: Frame }} action
    */
   CONNECT_FRAME(state, action) {
-    return [...state, action.frame];
+    const frameIndex = state.findIndex(frame => frame.id === action.frame.id);
+    const newFrames = [...state];
+    if (frameIndex !== -1) {
+      newFrames[frameIndex] = action.frame;
+    } else {
+      newFrames.push(action.frame);
+    }
+    return newFrames;
   },
 
   /**
@@ -62,7 +69,10 @@ const reducers = {
 };
 
 /**
- * Add a frame to the list of frames currently connected to the sidebar app.
+ * Add or replace a frame in the list of connected frames.
+ *
+ * If a frame exists with the same ID as `frame` it is replaced, otherwise
+ * a new frame is added.
  *
  * @param {Frame} frame
  */
@@ -71,7 +81,7 @@ function connectFrame(frame) {
 }
 
 /**
- * Remove a frame from the list of frames currently connected to the sidebar app.
+ * Remove a frame from the list of connected frames.
  *
  * @param {Frame} frame
  */

--- a/src/sidebar/store/modules/test/frames-test.js
+++ b/src/sidebar/store/modules/test/frames-test.js
@@ -10,22 +10,46 @@ describe('sidebar/store/modules/frames', () => {
   });
 
   describe('#connectFrame', () => {
-    it('adds the frame to the list of connected frames', () => {
-      const frame = { uri: 'http://example.com' };
+    it('adds first frame to the list of connected frames', () => {
+      const frame = { id: 'frameA', uri: 'http://example.com' };
       store.connectFrame(frame);
       assert.deepEqual(store.frames(), [frame]);
+    });
+
+    [null, 'frameA'].forEach(frameId => {
+      it('replaces existing frame with the same ID', () => {
+        const frame = { id: frameId, uri: 'https://example.com/page-1' };
+        const updatedFrame = { id: frameId, uri: 'https://example.com/page-2' };
+
+        store.connectFrame(frame);
+        store.connectFrame(updatedFrame);
+
+        assert.deepEqual(store.frames(), [updatedFrame]);
+      });
+    });
+
+    it('appends frame if ID does not match existing frames', () => {
+      const frame = { id: null, uri: 'https://example.com/' };
+      const subframe = { id: 'frameA', uri: 'https://example.com/an-iframe' };
+
+      store.connectFrame(frame);
+      store.connectFrame(subframe);
+
+      assert.deepEqual(store.frames(), [frame, subframe]);
     });
   });
 
   describe('#destroyFrame', () => {
     it('removes the frame from the list of connected frames', () => {
       const frameList = [
-        { uri: 'http://example.com' },
-        { uri: 'http://example.org' },
+        { id: 'frameA', uri: 'http://example.com' },
+        { id: 'frameB', uri: 'http://example.org' },
       ];
+
       store.connectFrame(frameList[0]);
       store.connectFrame(frameList[1]);
       store.destroyFrame(frameList[0]);
+
       assert.deepEqual(store.frames(), [frameList[1]]);
     });
   });
@@ -33,9 +57,11 @@ describe('sidebar/store/modules/frames', () => {
   describe('#updateFrameAnnotationFetchStatus', () => {
     it('updates the isAnnotationFetchComplete status of the frame', () => {
       const frame = {
+        id: null,
         uri: 'http://example.com',
       };
       const expectedFrame = {
+        id: null,
         uri: 'http://example.com',
         isAnnotationFetchComplete: true,
       };
@@ -125,9 +151,11 @@ describe('sidebar/store/modules/frames', () => {
         when: 'multiple HTML frames',
         frames: [
           {
+            id: 'frameA',
             uri: 'https://publisher.org/article.html',
           },
           {
+            id: 'frameB',
             uri: 'https://publisher.org/article2.html',
           },
         ],

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -140,7 +140,7 @@
  *   This will only be called if the anchor has at least one highlight (ie.
  *   `anchor.highlights` is a non-empty array)
  *
- * @typedef {Destroyable & IntegrationBase} Integration
+ * @typedef {Destroyable & TinyEmitter & IntegrationBase} Integration
  */
 
 /**


### PR DESCRIPTION
Add initial support for handling client-side navigations initiated via `window.history` methods or [navigation.navigate](https://wicg.github.io/navigation-api/#global-navigate). This makes the client update the loaded set of annotations as you navigate around a web site or application which is an SPA, or which uses Turbolinks style techniques to optimize navigation within the site.

Fixes https://github.com/hypothesis/product-backlog/issues/1135 - At least the main part of it, some sites have additional issues. See comments below and _Limitations_ section.

Fixes https://github.com/hypothesis/product-backlog/issues/493 (but see https://github.com/hypothesis/client/pull/4629#issuecomment-1174734446 about issue with Adder)

**Summary of changes:**

1. Add a test page at http://localhost:3000/document/client-side-navigation that uses client-side navigation to handle links in the footer
2. Add a `NavigationObserver` utility in `src/annotator/util/navigation-observer.js` which uses the Navigation API (preferred) or History API (fallback) to observe changes in the current URL (as reported by `location.href`)
3. Make `Integration`s into event emitters, so they can report changes in the document URL and other events to the `Guest`
4. Use `NavigationObserver` and `MutationObserver` within `HTMLIntegration` to detect client-side changes to the document URL and emit a `uriChanged` event. The `MutationObserver` is used to monitor `<head>`, since in documents with a `<link rel=canonical>` element, that is where the URL comes from.
5. Respond to the `uriChanged` event from the current integration in `Guest`, and notify the sidebar via a `documentInfoChanged` RPC call. This is an existing call that is handled in `FrameSyncService`.
6. Modify the `connectFrame` action in the sidebar to replace the existing frame with the same ID, if there is one, rather than always appending to the frames list.

There is one commit for each of the steps above, so I suggest to look through them in sequence. Each step could be landed independently, so I could split this PR into smaller ones if desired. I've left all the commits in this PR so that the whole feature can be tested end-to-end.

## Testing

1. Go to http://localhost:3000/document/client-side-navigation and annotate some text. Click one of the footer links to switch to different pages via client-side navigation, and annotate the different pages. As you switch between pages, the loaded set of annotations should update. Also the URL reported in the client's About panel will update.
2. Load the bookmarklet or extension on a site which uses client navigation (eg. https://nextjs.org/docs/getting-started) and navigate between different pages. The client should update the loaded set of annotations as you do.

Some other sites, that use client side navigation, which you can test with:

- React docs (eg. https://reactjs.org/docs/handling-events.html)
- Medium (eg. https://medium.com/@mheidj/how-to-brace-yourself-for-bad-news-ce83af44b17a)
- Substack (eg. https://www.readthepresentage.com/ - Click "Let me read it first")

## Limitations

### Knowing when a navigation is "complete"

When using history API monkey-patching to observe navigations, we don't have a way to know for certain when all the content on the page has been updated to reflect the new URL. This is because page updates via the history API are a single "change the URL" operation, without a way to tell the browser (or us) when all the DOM elements have been updated. The Navigation API provides a platform-level solution to this problem, as `navigatesuccess` only fires once the web app reports that the navigation has successfully completed.

The ah, optimistic, approach taken in this PR is to capture the document URL and metadata just after the URL has changed, and hope the page has been updated by the time we've fetched the annotations for the new URL, so that we can anchor the content appropriately.

Note that when creating new annotations, we always capture the document URL and metadata at the time when the annotation is created.

A future improvement here could be to add some heuristics to try and detect when a navigation has finished. We could also send metadata updates to the sidebar outside the context of a navigation.

### Pages that don't update their content fully

Some pages don't properly update all their metadata tags to reflect the new URL after a client-side navigation. YouTube (https://github.com/hypothesis/product-backlog/issues/1288) is a notable example. This is an existing problem that affects creating new annotations after a client-side navigation. In future we may use some heuristics to detect stale metadata tags and ignore them.

### Unsaved drafts

If there is an unsaved draft at the time when a navigation occurs, the draft persists after the navigation and is not unloaded.  When the draft is saved, it gets attached to the URL/metadata that was present at the point when it was originally created. It currently remains in the sidebar after being saved, even though it refers to a different URL. This behavior is not something that was explicitly implemented, it is just an artifact of the current implementation, but is actually not entirely terrible. A more polished solution might involve indicating somehow that the annotation refers to a different page than the one that is currently loaded.