### PR TITLE
Remove obsolete ESLint rule overrides

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,15 +4,9 @@
     "prefer-arrow-callback": ["error", { "allowNamedFunctions": true }],
     "object-shorthand": ["error", "properties"],
 
-    // Suppressed to make ESLint v6 migration easier.
+    // We have some `object.hasOwnProperty` calls that need to be replaced with
+    // `Object.hasOwn` (or a polyfill).
     "no-prototype-builtins": "off",
-
-    // Handled by Prettier.
-    "comma-dangle": "off",
-
-    // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
-    "react/jsx-uses-react": "off",
-    "react/react-in-jsx-scope": "off",
 
     // Replaced by TypeScript's static checking.
     "react/prop-types": "off"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "escape-html": "^1.0.3",
     "escape-string-regexp": "^4.0.0",
     "eslint": "^8.3.0",
-    "eslint-config-hypothesis": "^2.4.0",
+    "eslint-config-hypothesis": "^2.6.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-mocha": "^10.0.1",
     "eslint-plugin-react": "^7.12.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3173,10 +3173,10 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-hypothesis@^2.4.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-hypothesis/-/eslint-config-hypothesis-2.5.0.tgz#bc9c281b07923666696c5df1c1f96f3cbace266b"
-  integrity sha512-3KiknU/zX117ggOhDetdbnqn+RupdIsp4XXl9kn8NICc/1ObVY3dt802L01A//ajCGHgiYu5/vR2afsuChlnhw==
+eslint-config-hypothesis@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-hypothesis/-/eslint-config-hypothesis-2.6.0.tgz#627a3f0478c6d732ea776d813be6a70ac2f2d9dd"
+  integrity sha512-CMQSym4Oz2RVKwAAD+cftYPoSRzj3CUBfkytf0UG41wBsKh7eHGCAer8AcibYP8G2JelKoB6K6CzOYviCiBi/A==
 
 eslint-plugin-jsx-a11y@^6.2.3:
   version "6.6.0"


### PR DESCRIPTION
Remove ESLint rule overrides that are no longer required once
https://github.com/hypothesis/frontend-toolkit/pull/42 is shipped.

While doing this I also added a clarification about why one of the remaining overrides _is_ still required.