### PR TITLE
JSTOR content banner layout

### DIFF
--- a/dev-server/documents/pdf/jstor.config.json
+++ b/dev-server/documents/pdf/jstor.config.json
@@ -7,8 +7,8 @@
         "title": "Document provided by JSTOR"
       },
       "item": {
-        "title": "Chapter 2: A chapter",
-        "containerTitle": "Book Title Here"
+        "title": "Populations of Thrips tabaci, with Special Reference to Virus Transmission",
+        "containerTitle": "Journal of Animal Ecology"
       },
       "links": {
         "previousItem": "https://jstor.org/stable/book123.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
     "@hypothesis/frontend-build": "1.2.0",
-    "@hypothesis/frontend-shared": "5.2.0",
+    "@hypothesis/frontend-shared": "5.2.1",
     "@octokit/rest": "^19.0.3",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^22.0.0",

--- a/src/annotator/components/ContentInfoBanner.js
+++ b/src/annotator/components/ContentInfoBanner.js
@@ -1,4 +1,10 @@
-import { LabeledButton, Link } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+
+import {
+  Link,
+  CaretLeftIcon,
+  CaretRightIcon,
+} from '@hypothesis/frontend-shared/lib/next';
 
 /**
  * @typedef {import('../../types/annotator').ContentInfoConfig} ContentInfoConfig
@@ -8,39 +14,110 @@ import { LabeledButton, Link } from '@hypothesis/frontend-shared';
  * A banner that displays information about the current document and the entity
  * that is providing access to it (eg. JSTOR).
  *
+ * Layout columns:
+ *  - Logo
+ *  - Container title (only shown on screens at `2xl` breakpoint and wider)
+ *  - Item title with previous and next links
+ *
  * @param {object} props
  *   @param {ContentInfoConfig} props.info
- *   @param {() => void} props.onClose
  */
-export default function ContentInfoBanner({ info, onClose }) {
+export default function ContentInfoBanner({ info }) {
   return (
-    <div className="flex items-center border-b gap-x-4 px-2 py-1 bg-white text-annotator-lg">
-      <Link href={info.logo.link} target="_blank" data-testid="logo-link">
-        <img src={info.logo.logo} alt={info.logo.title} />
-      </Link>
-      <div className="grow">
-        {info.links.previousItem && (
-          <Link href={info.links.previousItem} target="_blank">
-            Previous article
-          </Link>
-        )}
-        {info.item.title}
-        {info.item.containerTitle && (
-          <span>
-            {' '}
-            from <i>{info.item.containerTitle}</i>
-          </span>
-        )}
-        {info.links.nextItem && (
-          <Link href={info.links.nextItem} target="_blank">
-            Next article
+    <div
+      className={classnames(
+        'h-10 bg-white px-4 text-slate-7 text-annotator-base border-b',
+        'grid items-center',
+        // Two columns in narrower viewports; three in wider
+        'grid-cols-[100px_minmax(0,auto)] gap-x-4',
+        '2xl:grid-cols-[100px_minmax(0,auto)_minmax(0,auto)] 2xl:gap-x-3'
+      )}
+    >
+      <div data-testid="content-logo">
+        {info.logo && (
+          <Link href={info.logo.link} target="_blank" data-testid="logo-link">
+            <img
+              alt={info.logo.title}
+              src={info.logo.logo}
+              data-testid="logo-image"
+            />
           </Link>
         )}
       </div>
-      <div className="text-annotator-base">
-        <LabeledButton onClick={onClose} data-testid="close-button">
-          Close
-        </LabeledButton>
+      <div
+        className={classnames(
+          // Container title (this element) is not shown on narrow screens
+          'hidden',
+          '2xl:block 2xl:whitespace-nowrap 2xl:overflow-hidden 2xl:text-ellipsis',
+          'font-semibold'
+        )}
+        data-testid="content-container-info"
+        title={info.item.containerTitle}
+      >
+        {info.item.containerTitle}
+      </div>
+      <div
+        className={classnames(
+          // Flex layout for item title, next and previous links
+          'flex justify-center items-center gap-x-2'
+        )}
+        data-testid="content-item-info"
+      >
+        <div
+          className={classnames(
+            // Narrower viewports center this flex content:
+            // this element is not needed for alignment
+            'hidden',
+            // Wider viewports align this flex content to the right:
+            // This empty element is needed to fill extra space at left
+            '2xl:block 2xl:grow'
+          )}
+        />
+        {info.links.previousItem && (
+          <>
+            <Link
+              classes="flex gap-x-1 items-center text-annotator-sm whitespace-nowrap"
+              title="Open previous item"
+              href={info.links.previousItem}
+              underline="always"
+              target="_blank"
+              data-testid="content-previous-link"
+            >
+              <CaretLeftIcon className="w-em h-em" />
+              <span>Previous</span>
+            </Link>
+            <div className="text-annotator-sm">|</div>
+          </>
+        )}
+        <div
+          className={classnames(
+            // This element will shrink and truncate fluidly.
+            // Overriding min-width `auto` prevents the content from overflowing
+            // See https://stackoverflow.com/a/66689926/434243.
+            'min-w-0 whitespace-nowrap overflow-hidden text-ellipsis shrink font-medium'
+          )}
+        >
+          <span title={info.item.title} data-testid="content-item-title">
+            {info.item.title}
+          </span>
+        </div>
+
+        {info.links.nextItem && (
+          <>
+            <div className="text-annotator-sm">|</div>
+            <Link
+              title="Open next item"
+              classes="flex gap-x-1 items-center text-annotator-sm whitespace-nowrap"
+              href={info.links.nextItem}
+              underline="always"
+              target="_blank"
+              data-testid="content-next-link"
+            >
+              <span>Next</span>
+              <CaretRightIcon className="w-em h-em" />
+            </Link>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -278,10 +278,7 @@ export class PDFIntegration extends TinyEmitter {
     render(
       <Banners>
         {this._bannerState.contentInfo && (
-          <ContentInfoBanner
-            info={this._bannerState.contentInfo}
-            onClose={() => this._updateBannerState({ contentInfo: null })}
-          />
+          <ContentInfoBanner info={this._bannerState.contentInfo} />
         )}
         {this._bannerState.noTextWarning && <WarningBanner />}
       </Banners>,

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -249,19 +249,6 @@ describe('annotator/integrations/pdf', () => {
         assert.isNotNull(banner);
         assert.include(banner.shadowRoot.textContent, contentInfo.item.title);
       });
-
-      it('closes content info banner when "Close" button is clicked', () => {
-        pdfIntegration = createPDFIntegration();
-        pdfIntegration.showContentInfo(contentInfo);
-        const banner = getBanner();
-        const closeButton = banner.shadowRoot.querySelector(
-          'button[data-testid=close-button]'
-        );
-
-        closeButton.click();
-
-        assert.isNull(getBanner());
-      });
     });
 
     it('does not show a warning when PDF has selectable text', async () => {

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -170,6 +170,8 @@ export default {
         sm: '360px',
         md: '480px',
         lg: '768px',
+        xl: '1024px',
+        '2xl': '1220px',
         // Narrow mobile screens
         'annotator-sm': '240px',
         // Wider mobile screens/small tablets

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,10 +1043,10 @@
     fancy-log "^1.3.3"
     glob "^7.2.0"
 
-"@hypothesis/frontend-shared@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.2.0.tgz#0da42f2fbbde98fb959c5e2c6d0dae676f4fc3b7"
-  integrity sha512-FWqIPBaO+wUCq6tecg21O9+XTRAtGFBrVvvTgRwvrCsxZVsD3ywnoNB1Gq5Uk/jqWa5Kews7EBGRy069EgwMcg==
+"@hypothesis/frontend-shared@5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.2.1.tgz#b06257f83a706dd1cd57904f9822cdbfb943605d"
+  integrity sha512-B9jyv5tfrU+0lIjLrSc7U/I8MDs+bIHU5C4eJz9NwuqHl8kBsHcTu15sQFFQVGJDZnVoCxQWuJBQ6N48xrJECA==
   dependencies:
     highlight.js "^11.6.0"
 


### PR DESCRIPTION
This adds layout for the (JSTOR) content banner.

Wide screens:

<img width="1567" alt="image" src="https://user-images.githubusercontent.com/439947/181568558-1184e15a-8f4f-4641-a95e-a53da075a08a.png">

Narrower screens:

<img width="1174" alt="image" src="https://user-images.githubusercontent.com/439947/181568704-f3f998b1-f74b-4bdd-a074-044d3f70bacc.png">
