### PR TITLE
Add `showContentInfo` embedder RPC method that triggers display of content info banner

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -436,6 +436,12 @@ export class Guest {
       annotations => annotations.forEach(annotation => this.anchor(annotation))
     );
 
+    this._sidebarRPC.on(
+      'showContentInfo',
+      /** @param {ContentInfoConfig} info */
+      info => this._integration.showContentInfo?.(info)
+    );
+
     // Connect to sidebar and send document info/URIs to it.
     //
     // RPC calls are deferred until a connection is made, so these steps can

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -494,6 +494,26 @@ describe('Guest', () => {
         });
       });
     });
+
+    describe('on "showContentInfo" event', () => {
+      const contentInfo = {
+        logo: {},
+        item: { title: 'Some article' },
+        links: {},
+      };
+
+      it('triggers display of content info in integration', () => {
+        createGuest();
+        emitSidebarEvent('showContentInfo', contentInfo);
+        assert.calledWith(fakeIntegration.showContentInfo, contentInfo);
+      });
+
+      it('does nothing if integration does not support content info display', () => {
+        createGuest();
+        fakeIntegration.showContentInfo = null;
+        emitSidebarEvent('showContentInfo', contentInfo);
+      });
+    });
   });
 
   describe('document events', () => {

--- a/src/sidebar/cross-origin-rpc.js
+++ b/src/sidebar/cross-origin-rpc.js
@@ -3,6 +3,7 @@ import { warnOnce } from '../shared/warn-once';
 import { normalizeGroupIds } from './helpers/groups';
 
 /**
+ * @typedef {import('../types/annotator').ContentInfoConfig} ContentInfoConfig
  * @typedef {import('../types/rpc').FocusUserInfo} FocusUserInfo
  */
 
@@ -30,6 +31,11 @@ const registeredMethods = store => {
         console.error('No matching groups found in list of filtered group IDs');
       }
       store.filterGroups(filteredGroupIds);
+    },
+
+    /** @param {ContentInfoConfig} contentInfo */
+    showContentInfo: contentInfo => {
+      store.setContentInfo(contentInfo);
     },
   };
 };

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -238,6 +238,15 @@ export class FrameSyncService {
         onStoreAnnotationsChanged(annotations, frames, prevAnnotations),
       shallowEqual
     );
+
+    watch(
+      this._store.subscribe,
+      () => this._store.getContentInfo(),
+      contentInfo => {
+        const mainGuest = this._guestRPC.get(null);
+        mainGuest?.call('showContentInfo', contentInfo);
+      }
+    );
   }
 
   /**
@@ -272,6 +281,16 @@ export class FrameSyncService {
 
         frameIdentifier = info.frameIdentifier;
         this._guestRPC.set(frameIdentifier, guestRPC);
+
+        // Show the content info banner, if this is the main guest frame and
+        // if we already have the data for it.
+        //
+        // We send this only after "documentInfoChanged" is received, because
+        // we don't know before then if this is the main guest or not.
+        const contentInfo = this._store.getContentInfo();
+        if (frameIdentifier === null && contentInfo) {
+          guestRPC.call('showContentInfo', contentInfo);
+        }
 
         this._store.connectFrame({
           id: info.frameIdentifier,

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -605,21 +605,8 @@ describe('FrameSyncService', () => {
       assert.calledWith(channel.call, 'setHighlightsVisible', false);
     });
 
-    [
-      {
-        haveContentInfo: false,
-        isMainGuest: true,
-      },
-      {
-        haveContentInfo: true,
-        isMainGuest: false,
-      },
-      {
-        haveContentInfo: true,
-        isMainGuest: true,
-      },
-    ].forEach(({ haveContentInfo, isMainGuest }) => {
-      it('sends content info to main guest if available', async () => {
+    [true, false].forEach(haveContentInfo => {
+      it('sends content info to guest if available', async () => {
         let channel;
         setupPortRPC = rpc => {
           channel = rpc;
@@ -632,12 +619,12 @@ describe('FrameSyncService', () => {
         await connectGuest();
         emitGuestEvent('documentInfoChanged', {
           uri: 'https://publisher.org/article.pdf',
-          frameIdentifier: isMainGuest ? null : 'sub-frame',
+          frameIdentifier: null,
         });
 
         assert.equal(
           channel.call.calledWith('showContentInfo', contentInfo),
-          haveContentInfo && isMainGuest
+          haveContentInfo
         );
       });
     });
@@ -829,7 +816,7 @@ describe('FrameSyncService', () => {
   context('when content info in store changes', () => {
     const contentInfo = { item: { title: 'Some article' } };
 
-    it('sends content info to main guest', async () => {
+    it('sends new content info to guests', async () => {
       await frameSync.connect();
       await connectGuest();
       emitGuestEvent('documentInfoChanged', {
@@ -840,19 +827,6 @@ describe('FrameSyncService', () => {
       fakeStore.setContentInfo(contentInfo);
 
       assert.calledWith(guestRPC().call, 'showContentInfo', contentInfo);
-    });
-
-    it("doesn't send content info to non-main guests", async () => {
-      await frameSync.connect();
-      await connectGuest();
-      emitGuestEvent('documentInfoChanged', {
-        uri: 'https://publisher.org/article.pdf',
-        frameIdentifier: 'sub-frame',
-      });
-
-      fakeStore.setContentInfo(contentInfo);
-
-      assert.isFalse(guestRPC().call.calledWith('showContentInfo'));
     });
   });
 });

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -617,10 +617,6 @@ describe('FrameSyncService', () => {
         }
 
         await connectGuest();
-        emitGuestEvent('documentInfoChanged', {
-          uri: 'https://publisher.org/article.pdf',
-          frameIdentifier: null,
-        });
 
         assert.equal(
           channel.call.calledWith('showContentInfo', contentInfo),
@@ -819,10 +815,6 @@ describe('FrameSyncService', () => {
     it('sends new content info to guests', async () => {
       await frameSync.connect();
       await connectGuest();
-      emitGuestEvent('documentInfoChanged', {
-        uri: 'https://publisher.org/article.pdf',
-        frameIdentifier: null,
-      });
 
       fakeStore.setContentInfo(contentInfo);
 

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -605,14 +605,14 @@ describe('FrameSyncService', () => {
       assert.calledWith(channel.call, 'setHighlightsVisible', false);
     });
 
-    [true, false].forEach(haveContentInfo => {
+    [true, false].forEach(contentInfoAvailable => {
       it('sends content info to guest if available', async () => {
         let channel;
         setupPortRPC = rpc => {
           channel = rpc;
         };
         const contentInfo = { item: { title: 'Some article' } };
-        if (haveContentInfo) {
+        if (contentInfoAvailable) {
           fakeStore.setContentInfo(contentInfo);
         }
 
@@ -624,7 +624,7 @@ describe('FrameSyncService', () => {
 
         assert.equal(
           channel.call.calledWith('showContentInfo', contentInfo),
-          haveContentInfo
+          contentInfoAvailable
         );
       });
     });

--- a/src/sidebar/store/modules/test/viewer-test.js
+++ b/src/sidebar/store/modules/test/viewer-test.js
@@ -26,4 +26,16 @@ describe('store/modules/viewer', () => {
       assert.isTrue(store.hasSidebarOpened());
     });
   });
+
+  describe('getContentInfo', () => {
+    it('returns data for content info banner', () => {
+      const contentInfo = {
+        logo: {},
+        item: { title: 'Some article' },
+        links: {},
+      };
+      store.setContentInfo(contentInfo);
+      assert.deepEqual(store.getContentInfo(), contentInfo);
+    });
+  });
 });

--- a/src/sidebar/store/modules/viewer.js
+++ b/src/sidebar/store/modules/viewer.js
@@ -1,6 +1,10 @@
 import { createStoreModule, makeAction } from '../create-store';
 
 /**
+ * @typedef {import('../../../types/annotator').ContentInfoConfig} ContentInfoConfig
+ */
+
+/**
  * This module defines actions and state related to the display mode of the
  * sidebar.
  */
@@ -11,6 +15,13 @@ const initialState = {
    * current state of the sidebar, but tracks whether it has ever been open
    */
   sidebarHasOpened: false,
+
+  /**
+   * Data for the content information banner shown in the host frame.
+   *
+   * @type {ContentInfoConfig|null}
+   */
+  contentInfo: null,
 };
 
 /** @typedef {typeof initialState} State */
@@ -28,6 +39,14 @@ const reducers = {
     // Otherwise, nothing to do here
     return {};
   },
+
+  /**
+   * @param {State} state
+   * @param {{ info: ContentInfoConfig }} action
+   */
+  SET_CONTENT_INFO(state, action) {
+    return { contentInfo: action.info };
+  },
 };
 
 /**
@@ -42,13 +61,25 @@ function hasSidebarOpened(state) {
   return state.sidebarHasOpened;
 }
 
+/** @param {ContentInfoConfig} info */
+function setContentInfo(info) {
+  return makeAction(reducers, 'SET_CONTENT_INFO', { info });
+}
+
+/** @param {State} state */
+function getContentInfo(state) {
+  return state.contentInfo;
+}
+
 export const viewerModule = createStoreModule(initialState, {
   namespace: 'viewer',
   reducers,
   actionCreators: {
+    setContentInfo,
     setSidebarOpened,
   },
   selectors: {
+    getContentInfo,
     hasSidebarOpened,
   },
 });

--- a/src/sidebar/store/modules/viewer.js
+++ b/src/sidebar/store/modules/viewer.js
@@ -17,7 +17,8 @@ const initialState = {
   sidebarHasOpened: false,
 
   /**
-   * Data for the content information banner shown in the host frame.
+   * Data for the content information banner shown above the content in the main
+   * guest frame.
    *
    * @type {ContentInfoConfig|null}
    */

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -132,7 +132,12 @@ export type SidebarToGuestEvent =
   /**
    * The sidebar relays to the guest(s) to set the annotation highlights on/off.
    */
-  | 'setHighlightsVisible';
+  | 'setHighlightsVisible'
+
+  /**
+   * Show a banner with information about the current content.
+   */
+  | 'showContentInfo';
 
 /**
  * Events that the sidebar sends to the host


### PR DESCRIPTION
Add a `showContentInfo` embedder RPC method that the LMS frontend can use to trigger display of the content info banner in the PDF viewer. The LMS frontend will use this to trigger display of the JSTOR banner in JSTOR articles - see https://github.com/hypothesis/lms/pull/4284.

The flow of events in the client looks like this:

1. Client receives a `showContentInfo` request from embedder frame (the LMS frontend) with a `ContentInfoConfig` argument
2. The content info data is saved in the store via a `setContentInfo` action. This information is currently saved in the `viewer.js` module, though I'm not completely happy with that.
3. The `FrameSyncService` service sends the content info to the main guest frame[^1] 1) if present in the store when the main frame connects and 2) if the content info changes after the main frame connects. The content info is sent to the main frame via a `showContentInfo` sidebar->guest request. The message is sent to the guest rather than the host because the guest owns the `Integration`, which is ultimately responsible for displaying the banner.
4. When the guest receives the `showContentInfo` request, it passes it to the integration via an `integration.showContentInfo` call. If the integration doesn't implement `showContentInfo`, nothing happens.

If in future we decide to re-use the banner outside the LMS context, then step (1) will be swapped out with some other service being responsible for fetching the data. The other steps should remain the same.

When working on this PR I realized that the code that handles RPC requests from the LMS in the sidebar is going to be confusing for a new developer as it is spread across multiple modules and doesn't use the same "embedder" terminology that we use elsewhere. I think we need to do some refactoring here, but that is outside the scope of this PR.

[^1]: Technically `FrameSyncService` sends the data to _all_ guests, as it is faster. We can get away with this at present because there is only one guest in all scenarios where the content banner is used. See notes in frame-sync-service.js.

**Testing:**

1. Check out https://github.com/hypothesis/lms/pull/4284 in the LMS app and this branch in the client
2. Create a JSTOR assignment using  your local LMS app
3. Launch the JSTOR assignment and you should see the content banner appear, with the correct title and JSTOR logo. Note that only the title and logo are populated. Other metadata fields will be added later.