### PR TITLE
Remove requirements-dev.in

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,0 @@
-# Python requirements needed to run the `make docs` command.
-recommonmark
-sphinx
-sphinx-autobuild
-sphinx_rtd_theme


### PR DESCRIPTION
This file isn't used (we use `requirements/*.{in,txt}`)