### PR TITLE
Move `contentInfo` state from viewer to frames store module

### DIFF
--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -8,6 +8,7 @@ import shallowEqual from 'shallowequal';
 import { createStoreModule, makeAction } from '../create-store';
 
 /**
+ * @typedef {import('../../../types/annotator').ContentInfoConfig} ContentInfoConfig
  * @typedef {import('../../../types/annotator').DocumentMetadata} DocumentMetadata
  */
 
@@ -23,6 +24,14 @@ import { createStoreModule, makeAction } from '../create-store';
 const initialState = {
   /** @type {Frame[]} */
   frames: [],
+
+  /**
+   * Data for the content information banner shown above the content in the main
+   * guest frame.
+   *
+   * @type {ContentInfoConfig|null}
+   */
+  contentInfo: null,
 };
 
 /** @typedef {typeof initialState} State */
@@ -71,6 +80,14 @@ const reducers = {
     });
     return { frames };
   },
+
+  /**
+   * @param {State} state
+   * @param {{ info: ContentInfoConfig }} action
+   */
+  SET_CONTENT_INFO(state, action) {
+    return { contentInfo: action.info };
+  },
 };
 
 /**
@@ -105,6 +122,11 @@ function updateFrameAnnotationFetchStatus(uri, isFetchComplete) {
     uri,
     isAnnotationFetchComplete: isFetchComplete,
   });
+}
+
+/** @param {ContentInfoConfig} info */
+function setContentInfo(info) {
+  return makeAction(reducers, 'SET_CONTENT_INFO', { info });
 }
 
 /**
@@ -178,6 +200,11 @@ const searchUris = createShallowEqualSelector(
   uris => uris
 );
 
+/** @param {State} state */
+function getContentInfo(state) {
+  return state.contentInfo;
+}
+
 export const framesModule = createStoreModule(initialState, {
   namespace: 'frames',
   reducers,
@@ -185,10 +212,12 @@ export const framesModule = createStoreModule(initialState, {
   actionCreators: {
     connectFrame,
     destroyFrame,
+    setContentInfo,
     updateFrameAnnotationFetchStatus,
   },
 
   selectors: {
+    getContentInfo,
     frames,
     mainFrame,
     searchUris,

--- a/src/sidebar/store/modules/test/frames-test.js
+++ b/src/sidebar/store/modules/test/frames-test.js
@@ -194,4 +194,16 @@ describe('sidebar/store/modules/frames', () => {
       });
     });
   });
+
+  describe('getContentInfo', () => {
+    it('returns data for content info banner', () => {
+      const contentInfo = {
+        logo: {},
+        item: { title: 'Some article' },
+        links: {},
+      };
+      store.setContentInfo(contentInfo);
+      assert.deepEqual(store.getContentInfo(), contentInfo);
+    });
+  });
 });

--- a/src/sidebar/store/modules/test/viewer-test.js
+++ b/src/sidebar/store/modules/test/viewer-test.js
@@ -26,16 +26,4 @@ describe('store/modules/viewer', () => {
       assert.isTrue(store.hasSidebarOpened());
     });
   });
-
-  describe('getContentInfo', () => {
-    it('returns data for content info banner', () => {
-      const contentInfo = {
-        logo: {},
-        item: { title: 'Some article' },
-        links: {},
-      };
-      store.setContentInfo(contentInfo);
-      assert.deepEqual(store.getContentInfo(), contentInfo);
-    });
-  });
 });

--- a/src/sidebar/store/modules/viewer.js
+++ b/src/sidebar/store/modules/viewer.js
@@ -1,10 +1,6 @@
 import { createStoreModule, makeAction } from '../create-store';
 
 /**
- * @typedef {import('../../../types/annotator').ContentInfoConfig} ContentInfoConfig
- */
-
-/**
  * This module defines actions and state related to the display mode of the
  * sidebar.
  */
@@ -15,14 +11,6 @@ const initialState = {
    * current state of the sidebar, but tracks whether it has ever been open
    */
   sidebarHasOpened: false,
-
-  /**
-   * Data for the content information banner shown above the content in the main
-   * guest frame.
-   *
-   * @type {ContentInfoConfig|null}
-   */
-  contentInfo: null,
 };
 
 /** @typedef {typeof initialState} State */
@@ -40,14 +28,6 @@ const reducers = {
     // Otherwise, nothing to do here
     return {};
   },
-
-  /**
-   * @param {State} state
-   * @param {{ info: ContentInfoConfig }} action
-   */
-  SET_CONTENT_INFO(state, action) {
-    return { contentInfo: action.info };
-  },
 };
 
 /**
@@ -62,25 +42,13 @@ function hasSidebarOpened(state) {
   return state.sidebarHasOpened;
 }
 
-/** @param {ContentInfoConfig} info */
-function setContentInfo(info) {
-  return makeAction(reducers, 'SET_CONTENT_INFO', { info });
-}
-
-/** @param {State} state */
-function getContentInfo(state) {
-  return state.contentInfo;
-}
-
 export const viewerModule = createStoreModule(initialState, {
   namespace: 'viewer',
   reducers,
   actionCreators: {
-    setContentInfo,
     setSidebarOpened,
   },
   selectors: {
-    getContentInfo,
     hasSidebarOpened,
   },
 });


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/4682**

This state holds the data for the `ContentInfoBanner` component shown in
the main guest, so it makes more sense to colocate it with other data in
the sidebar store related to connected guest frames.