### PR TITLE
Link to item from content-info banner

### DIFF
--- a/dev-server/documents/pdf/jstor.config.json
+++ b/dev-server/documents/pdf/jstor.config.json
@@ -8,11 +8,16 @@
       },
       "item": {
         "title": "Populations of Thrips tabaci, with Special Reference to Virus Transmission",
-        "containerTitle": "Journal of Animal Ecology"
+        "subtitle": "A subtitle"
+      },
+      "container": {
+        "title": "Journal of Animal Ecology",
+        "subtitle": "Container subtitle"
       },
       "links": {
         "previousItem": "https://jstor.org/stable/book123.1",
-        "nextItem": "https://jstor.org/stable/book123.2"
+        "nextItem": "https://jstor.org/stable/book123.3",
+        "currentItem": "https://jstor.org/stable/book123.2"
       }
     }
   }

--- a/src/annotator/components/ContentInfoBanner.js
+++ b/src/annotator/components/ContentInfoBanner.js
@@ -2,6 +2,7 @@ import classnames from 'classnames';
 
 import {
   Link,
+  LinkUnstyled,
   CaretLeftIcon,
   CaretRightIcon,
 } from '@hypothesis/frontend-shared/lib/next';
@@ -23,6 +24,10 @@ import {
  *   @param {ContentInfoConfig} props.info
  */
 export default function ContentInfoBanner({ info }) {
+  // Format item title to show subtitle
+  const itemTitle = `${info.item.title}${info.item.subtitle && ': '}${
+    info.item.subtitle
+  }`;
   return (
     <div
       className={classnames(
@@ -52,9 +57,9 @@ export default function ContentInfoBanner({ info }) {
           'font-semibold'
         )}
         data-testid="content-container-info"
-        title={info.item.containerTitle}
+        title={info.container.title}
       >
-        {info.item.containerTitle}
+        {info.container.title}
       </div>
       <div
         className={classnames(
@@ -97,9 +102,13 @@ export default function ContentInfoBanner({ info }) {
             'min-w-0 whitespace-nowrap overflow-hidden text-ellipsis shrink font-medium'
           )}
         >
-          <span title={info.item.title} data-testid="content-item-title">
-            {info.item.title}
-          </span>
+          <LinkUnstyled
+            title={itemTitle}
+            href={info.links.currentItem}
+            data-testid="content-item-link"
+          >
+            {itemTitle}
+          </LinkUnstyled>
         </div>
 
         {info.links.nextItem && (

--- a/src/annotator/components/ContentInfoBanner.js
+++ b/src/annotator/components/ContentInfoBanner.js
@@ -25,9 +25,10 @@ import {
  */
 export default function ContentInfoBanner({ info }) {
   // Format item title to show subtitle
-  const itemTitle = `${info.item.title}${info.item.subtitle && ': '}${
-    info.item.subtitle
-  }`;
+  let itemTitle = info.item.title;
+  if (info.item.subtitle) {
+    itemTitle += `: ${info.item.subtitle}`;
+  }
   return (
     <div
       className={classnames(

--- a/src/annotator/components/ContentInfoBanner.js
+++ b/src/annotator/components/ContentInfoBanner.js
@@ -106,6 +106,7 @@ export default function ContentInfoBanner({ info }) {
             title={itemTitle}
             href={info.links.currentItem}
             data-testid="content-item-link"
+            target="_blank"
           >
             {itemTitle}
           </LinkUnstyled>

--- a/src/annotator/components/ContentInfoBanner.js
+++ b/src/annotator/components/ContentInfoBanner.js
@@ -34,7 +34,7 @@ export default function ContentInfoBanner({ info }) {
         'h-10 bg-white px-4 text-slate-7 text-annotator-base border-b',
         'grid items-center',
         // Two columns in narrower viewports; three in wider
-        'grid-cols-[100px_minmax(0,auto)] gap-x-4',
+        'grid-cols-[100px_minmax(0,auto)]',
         '2xl:grid-cols-[100px_minmax(0,auto)_minmax(0,auto)] 2xl:gap-x-3'
       )}
     >

--- a/src/annotator/components/test/ContentInfoBanner-test.js
+++ b/src/annotator/components/test/ContentInfoBanner-test.js
@@ -51,6 +51,15 @@ describe('ContentInfoBanner', () => {
     assert.equal(link.prop('target'), '_blank');
   });
 
+  it('handles missing subtitle', () => {
+    delete contentInfo.item.subtitle;
+
+    const wrapper = createComponent();
+
+    const link = wrapper.find('LinkUnstyled[data-testid="content-item-link"]');
+    assert.equal(link.text(), 'Chapter 2');
+  });
+
   it('provides disclosure of long titles through title attributes', () => {
     const wrapper = createComponent();
 

--- a/src/annotator/components/test/ContentInfoBanner-test.js
+++ b/src/annotator/components/test/ContentInfoBanner-test.js
@@ -17,8 +17,13 @@ describe('ContentInfoBanner', () => {
       },
 
       item: {
-        title: 'Chapter 2: Some book chapter',
-        containerTitle: 'Expansive Book',
+        title: 'Chapter 2',
+        subtitle: 'Some book chapter',
+      },
+
+      container: {
+        title: 'Expansive Book',
+        subtitle: 'The revenge',
       },
 
       links: {
@@ -41,9 +46,7 @@ describe('ContentInfoBanner', () => {
   it('shows item title', () => {
     const wrapper = createComponent();
 
-    // TODO: This should be a link once the item link is available in
-    // content-info metadata
-    const title = wrapper.find('span[data-testid="content-item-title"]');
+    const title = wrapper.find('LinkUnstyled[data-testid="content-item-link"]');
     assert.equal(title.text(), 'Chapter 2: Some book chapter');
   });
 
@@ -57,7 +60,9 @@ describe('ContentInfoBanner', () => {
       'Expansive Book'
     );
     assert.equal(
-      wrapper.find('span[data-testid="content-item-title"]').prop('title'),
+      wrapper
+        .find('LinkUnstyled[data-testid="content-item-link"]')
+        .prop('title'),
       'Chapter 2: Some book chapter'
     );
   });

--- a/src/annotator/components/test/ContentInfoBanner-test.js
+++ b/src/annotator/components/test/ContentInfoBanner-test.js
@@ -46,8 +46,9 @@ describe('ContentInfoBanner', () => {
   it('shows item title', () => {
     const wrapper = createComponent();
 
-    const title = wrapper.find('LinkUnstyled[data-testid="content-item-link"]');
-    assert.equal(title.text(), 'Chapter 2: Some book chapter');
+    const link = wrapper.find('LinkUnstyled[data-testid="content-item-link"]');
+    assert.equal(link.text(), 'Chapter 2: Some book chapter');
+    assert.equal(link.prop('target'), '_blank');
   });
 
   it('provides disclosure of long titles through title attributes', () => {
@@ -80,10 +81,12 @@ describe('ContentInfoBanner', () => {
         prevLink.prop('href'),
         'https://www.jstor.org/stable/book.123.1'
       );
+      assert.equal(prevLink.prop('target'), '_blank');
       assert.equal(
         nextLink.prop('href'),
         'https://www.jstor.org/stable/book.123.3'
       );
+      assert.equal(nextLink.prop('target'), '_blank');
     });
 
     it('does not display previous link if unavailable', () => {

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -228,7 +228,9 @@ describe('annotator/integrations/pdf', () => {
         },
         item: {
           title: 'Chapter 2: A chapter',
-          containerTitle: 'Book Title Here',
+        },
+        container: {
+          title: 'Book Title Here',
         },
         links: {
           previousItem: 'https://jstor.org/stable/book123.1',

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -201,8 +201,7 @@
  *
  * @typedef ContentInfoItem
  * @prop {string} title - Title of the current article, chapter etc.
- * @prop {string} containerTitle - Title of the journal issue, book etc. which
- *   contains the current work
+ * @prop {string} [subtitle]
  */
 
 /**
@@ -211,6 +210,7 @@
  * @typedef ContentInfoLinks
  * @prop {string} [previousItem] - Previous item in the book, journal etc.
  * @prop {string} [nextItem] - Next item in the book, journal etc.
+ * @prop {string} currentItem - This item in the content provider's context
  */
 
 /**
@@ -222,7 +222,9 @@
  *
  * @typedef {object} ContentInfoConfig
  * @prop {ContentInfoLogo} logo - Logo of the content provider
- * @prop {ContentInfoItem} item
+ * @prop {ContentInfoItem} item - Metadata about the current content item
+ * @prop {ContentInfoItem} container - Metadata about the container (journal or
+ *   book, e.g.) the current `item` is part of
  * @prop {ContentInfoLinks} links
  */
 


### PR DESCRIPTION
This PR adds a link to the current item in the content-info banner, and updates some types and lookups to account for changes to the object passed in the RPC call from the LMS app.

### Test me out

* On this branch, create/configure a `localhost` assignment in https://hypothesis.instructure.com/courses/125 to use JSTOR content
* JSTOR article ID `26893773` works well for testing. You could also try a few other IDs from [this gist](https://gist.github.com/robertknight/a2b045b717d6c7dda18879df91c16e90) with the caveat that many of those items are inaccessible for assignment content (expected)
* Launch the assignment

You should see, when the banner loads:

* The current item title is linked and that the link goes to the item in a new tab
* The item title displays the title and subtitle, separated by a colon
* The link title (hover to see) is the full title with subtitle even if the visible text is ellipsis-truncated


Fixes https://github.com/hypothesis/lms/issues/4292