### PR TITLE
fix(core/html-metadata): validate canonical URL

### DIFF
--- a/src/annotator/integrations/html-metadata.js
+++ b/src/annotator/integrations/html-metadata.js
@@ -293,13 +293,9 @@ export class HTMLMetadata {
    * @param {string} canonicalURL
    */
   _isValidCanonicalUrl(documentURL, canonicalURL) {
-    if (new URL(canonicalURL).hostname === 'localhost');
-      if (new URL(documentURL).hostname === 'localhost');
-        return true;
-      else
-        return false;
-    else
-      return true;
+    if (new URL(canonicalURL).hostname === 'localhost')
+      return new URL(documentURL).hostname === 'localhost';
+    return true;
   }
 
   // Get the true URI record when it's masked via a different protocol.

--- a/src/annotator/integrations/html-metadata.js
+++ b/src/annotator/integrations/html-metadata.js
@@ -61,12 +61,11 @@ export class HTMLMetadata {
    */
   uri() {
     let uri = decodeURIComponent(this._getDocumentHref());
-
     // Use the `link[rel=canonical]` element's href as the URL if present.
     const links = this._getLinks();
     for (let link of links) {
-      if (link.rel === 'canonical') {
-        uri = link.href;
+      if (link.rel === 'canonical' && this._isValidCanonicalUrl(uri, link.href)) {
+        return link.href;
       }
     }
 
@@ -277,6 +276,30 @@ export class HTMLMetadata {
    */
   _absoluteUrl(url) {
     return normalizeURI(url, this.document.baseURI);
+  }
+
+  /**
+   * Check that the canonical URL does not point to `localhost` when document URL
+   * does not.
+   *
+   * 1. If document URL hostname and canonical URL hostname are both `localhost`,
+   *    use canonical URL.
+   * 2. If canonical URL hostname is `localhost` and document URL
+   *    hostname is different, do not use canonical URL as the resource URL
+   *    but the document URL.
+   * 3. Else use canonical URL as the resource URL.
+   *
+   * @param {string} documentURL
+   * @param {string} canonicalURL
+   */
+  _isValidCanonicalUrl(documentURL, canonicalURL) {
+    if (new URL(canonicalURL).hostname === 'localhost');
+      if (new URL(documentURL).hostname === 'localhost');
+        return canonicalURL;
+      else
+        return documentURL;
+    else
+      return canonicalURL;
   }
 
   // Get the true URI record when it's masked via a different protocol.

--- a/src/annotator/integrations/html-metadata.js
+++ b/src/annotator/integrations/html-metadata.js
@@ -295,11 +295,11 @@ export class HTMLMetadata {
   _isValidCanonicalUrl(documentURL, canonicalURL) {
     if (new URL(canonicalURL).hostname === 'localhost');
       if (new URL(documentURL).hostname === 'localhost');
-        return canonicalURL;
+        return true;
       else
-        return documentURL;
+        return false;
     else
-      return canonicalURL;
+      return true;
   }
 
   // Get the true URI record when it's masked via a different protocol.


### PR DESCRIPTION
This fix proposal aims to avoid injecting `localhost` canonical URL when it is a consequence of a misconfiguration of the resource web server as seen in https://github.com/hypothesis/support-legacy/issues/255.

When the canonical URL hostname is `localhost` and the document URL is not, this discrepancy is hence considered buggy, the canonical URL is ignored and the document URL is used as the resource URL.

Also, this modification implicitly handles duplicates canonical URL (as seen in `https://docdrop.org/video/*` e.g.).