### PR TITLE
Fix alignment of replies in RTL languages

### DIFF
--- a/src/sidebar/components/Thread.js
+++ b/src/sidebar/components/Thread.js
@@ -205,7 +205,15 @@ function Thread({ thread, threadsService }) {
             data-testid="thread-children"
           >
             {visibleChildren.map(child => (
-              <li key={child.id} className="mt-2">
+              <li
+                key={child.id}
+                className={classnames(
+                  'mt-2',
+                  // Ensure correct rendering of replies with RTL content.
+                  // See https://github.com/hypothesis/client/issues/4705.
+                  '[text-align:start]'
+                )}
+              >
                 <Thread thread={child} threadsService={threadsService} />
               </li>
             ))}


### PR DESCRIPTION
`<li>` elements have a default style of `text-align: match-parent`. This
resulted in a computed `text-align: left` style for paragraphs in replies [1], which
have an `<li>` ancestor. As a result replies written in RTL languages (eg.
Hebrew) were rendered left-to-right, instead of right-to-left as intended. Fix
this by adding a `text-align: start` on the `<li>`. This sets the alignment for
descendants to match the computed `direction` property. The `direction` for
replies is computed based on their content due to a `dir="auto"` attribute on
`StyledText` components.

Fixes https://github.com/hypothesis/client/issues/4705

[1] I not completely certain why `text-align: match-parent` causes the computed style to be `text-align: left`. The [docs for `match-parent`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align) say "Similar to inherit, but the values start and end are calculated according to the parent's [direction](https://developer.mozilla.org/en-US/docs/Web/CSS/direction) and are replaced by the appropriate left or right value." What I think is happening is that `text-align: match-parent` is evaluated for the `li` element to `left`, and then the computed value of `left` is inherited by child elements.