### PR TITLE
Install icu-data-full package in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM alpine:3.16
 
 RUN apk update && apk add --no-cache \
   chromium \
+  icu-data-full \
   git \
   make \
   nodejs \


### PR DESCRIPTION
Following a recent update to the Alpine 3.16 image, a test for the `formatData`
JS function started failing. The test configures the `Intl` JS API to produce
German output but it was producing English output instead.

The build log for the Docker image included a note that the icu-data-en Alpine
package was being installed and that icu-data-full needs to be installed to get
non-English locale support. See also
https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.16.0#ICU_data_split.