### PR TITLE
Replace `rem` units with a CSS variable for annotator font sizes

### DIFF
--- a/src/styles/annotator/annotator.scss
+++ b/src/styles/annotator/annotator.scss
@@ -12,6 +12,13 @@
 // `:host` rules have lower precedence than global CSS, unless `!important` is used.
 // See https://stackoverflow.com/questions/54821175/.
 :host {
+  // Define the reference font size used by `text-annotator-<size>` utilities.
+  //
+  // We try to respect the document's standard font size, but clamp to ensure
+  // text is always readable. See https://github.com/hypothesis/client/issues/4615.
+  --hypothesis-font-size: 16px; // Fallback
+  --hypothesis-font-size: clamp(16px, 1rem, 24px);
+
   // Our host elements have zero width/height, as they are just containers for
   // the shadow roots. Therefore we must override any page styles which would
   // cause them to clip their contents. See eg. https://github.com/hypothesis/client/issues/4641.

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -88,12 +88,13 @@ export default {
         xl: ['16px'],
         '2xl': ['18px'],
         'touch-base': ['16px', '1.4'], // Used for touch interfaces in certain UIs
-        // rem-based font sizes for annotator controls that should scale
-        // with text scaling in the underlying document
-        'annotator-sm': ['0.75rem'],
-        'annotator-base': ['0.875rem'],
-        'annotator-lg': ['1rem'],
-        'annotator-xl': ['1.125rem'],
+        // Font sizes for annotator controls that should scale with text in the
+        // document. These can only be used within shadow roots that include the
+        // annotator.css bundle.
+        'annotator-sm': ['calc(0.75 * var(--hypothesis-font-size))'],
+        'annotator-base': ['calc(0.875 * var(--hypothesis-font-size))'],
+        'annotator-lg': ['var(--hypothesis-font-size)'],
+        'annotator-xl': ['calc(1.125 * var(--hypothesis-font-size))'],
         // These are known cases when we want absolute sizing for fonts so
         // that they do not scale, for example annotator components that are
         // rendered next to the sidebar (which doesn't scale with host root


### PR DESCRIPTION
Various annotator UI components use rem-based font sizes to try and make the
annotator UI match the document. However various sites (eg. Stack Overflow,
OpenStax) set the root font size to a value that results in the Hypothesis UI
elements having unreadably small or excessively large text. Also for these sites
the rem-size doesn't reflect the actual "default" font size of the page as
perceived by the user.

To resolve this, change the font sizes from using rem units to a value
calculated from a `--hypothesis-font-size` CSS variable. This variable is set to
match 1rem when that lies in a reasonable range (16-24px) but is clamped to lie
within that range otherwise. In future we could change the way the reference
point is computed to try and match the "default" font size on the page, if that
is not 1rem.

Fixes https://github.com/hypothesis/client/issues/4615