### PR TITLE
Replace unsafe uses of `hasOwnProperty` with `Object.hasOwn` polyfill

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,10 +4,6 @@
     "prefer-arrow-callback": ["error", { "allowNamedFunctions": true }],
     "object-shorthand": ["error", "properties"],
 
-    // We have some `object.hasOwnProperty` calls that need to be replaced with
-    // `Object.hasOwn` (or a polyfill).
-    "no-prototype-builtins": "off",
-
     // Replaced by TypeScript's static checking.
     "react/prop-types": "off"
   },

--- a/src/annotator/config/config-func-settings-from.js
+++ b/src/annotator/config/config-func-settings-from.js
@@ -1,3 +1,5 @@
+import { hasOwn } from '../../shared/has-own';
+
 /**
  * @typedef HypothesisWindowProps
  * @prop {() => Record<string, unknown>} [hypothesisConfig] - Function that returns configuration
@@ -22,7 +24,7 @@
  * @return {Record<string, unknown>} - Any config settings returned by hypothesisConfig()
  */
 export function configFuncSettingsFrom(window_) {
-  if (!window_.hasOwnProperty('hypothesisConfig')) {
+  if (!hasOwn(window_, 'hypothesisConfig')) {
     return {};
   }
 

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -1,3 +1,4 @@
+import { hasOwn } from '../../shared/has-own';
 import { parseJsonConfig } from '../../boot/parse-json-config';
 import { toBoolean } from '../../shared/type-coercions';
 
@@ -150,11 +151,11 @@ export function settingsFrom(window_) {
    * @param {string} name - Unique name of the setting
    */
   function hostPageSetting(name) {
-    if (configFuncSettings.hasOwnProperty(name)) {
+    if (hasOwn(configFuncSettings, name)) {
       return configFuncSettings[name];
     }
 
-    if (jsonConfigs.hasOwnProperty(name)) {
+    if (hasOwn(jsonConfigs, name)) {
       return jsonConfigs[name];
     }
 

--- a/src/annotator/integrations/test/pdf-metadata-test.js
+++ b/src/annotator/integrations/test/pdf-metadata-test.js
@@ -21,7 +21,7 @@ class FakeMetadata {
   }
 
   has(key) {
-    return this._metadata.hasOwnProperty(key);
+    return Object.hasOwn(this._metadata, key);
   }
 }
 

--- a/src/boot/parse-json-config.js
+++ b/src/boot/parse-json-config.js
@@ -1,20 +1,4 @@
 /**
- * `Object.assign()`-like helper. Used because this script needs to work
- * in IE 10/11 without polyfills.
- *
- * @param {Record<string, unknown>} dest
- * @param {Record<string, unknown>} src
- */
-function assign(dest, src) {
-  for (const k in src) {
-    if (src.hasOwnProperty(k)) {
-      dest[k] = src[k];
-    }
-  }
-  return dest;
-}
-
-/**
  * Return a parsed `js-hypothesis-config` object from the document, or `{}`.
  *
  * Find all `<script class="js-hypothesis-config">` tags in the given document,
@@ -48,7 +32,7 @@ export function parseJsonConfig(document) {
       );
       settings = {};
     }
-    assign(config, settings);
+    Object.assign(config, settings);
   }
 
   return config;

--- a/src/shared/has-own.js
+++ b/src/shared/has-own.js
@@ -1,0 +1,12 @@
+/**
+ * Polyfill for `Object.hasOwn`.
+ *
+ * `hasOwn(someObject, property)` should be used instead of
+ * `someObject.hasOwnProperty(name)`.
+ *
+ * @param {object} object
+ * @param {string} property
+ */
+export function hasOwn(object, property) {
+  return Object.prototype.hasOwnProperty.call(object, property);
+}

--- a/src/shared/test/has-own-test.js
+++ b/src/shared/test/has-own-test.js
@@ -1,0 +1,14 @@
+import { hasOwn } from '../has-own';
+
+describe('hasOwn', () => {
+  [
+    [{ foo: 'bar' }, 'foo', true],
+    [{ foo: 'bar' }, 'bar', false],
+    [Object.create(null), 'foo', false],
+    [{ hasOwnProperty: 'foo' }, 'hasOwnProperty', true],
+  ].forEach(([object, property, expected]) => {
+    it('returns true if object has own property', () => {
+      assert.equal(hasOwn(object, property), expected);
+    });
+  });
+});

--- a/src/shared/test/has-own-test.js
+++ b/src/shared/test/has-own-test.js
@@ -5,6 +5,7 @@ describe('hasOwn', () => {
     [{ foo: 'bar' }, 'foo', true],
     [{ foo: 'bar' }, 'baz', false],
     [Object.create(null), 'foo', false],
+    [{}, 'hasOwnProperty', false],
     [{ hasOwnProperty: 'foo' }, 'hasOwnProperty', true],
   ].forEach(([object, property, expected]) => {
     it('returns true if object has own property', () => {

--- a/src/shared/test/has-own-test.js
+++ b/src/shared/test/has-own-test.js
@@ -3,7 +3,7 @@ import { hasOwn } from '../has-own';
 describe('hasOwn', () => {
   [
     [{ foo: 'bar' }, 'foo', true],
-    [{ foo: 'bar' }, 'bar', false],
+    [{ foo: 'bar' }, 'baz', false],
     [Object.create(null), 'foo', false],
     [{ hasOwnProperty: 'foo' }, 'hasOwnProperty', true],
   ].forEach(([object, property, expected]) => {

--- a/src/sidebar/helpers/build-thread.js
+++ b/src/sidebar/helpers/build-thread.js
@@ -1,3 +1,5 @@
+import { hasOwn } from '../../shared/has-own';
+
 /**
  * @typedef {import('../../types/api').Annotation} Annotation
  *
@@ -342,7 +344,7 @@ export function buildThread(annotations, options) {
       collapsed: thread.collapsed,
     };
 
-    if (options.expanded.hasOwnProperty(thread.id)) {
+    if (hasOwn(options.expanded, thread.id)) {
       // This thread has been explicitly expanded/collapsed by user
       threadStates.collapsed = !options.expanded[thread.id];
     } else {

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -5,6 +5,7 @@
 
 import { createSelector } from 'reselect';
 
+import { hasOwn } from '../../../shared/has-own';
 import * as metadata from '../../helpers/annotation-metadata';
 import { isSaved } from '../../helpers/annotation-metadata';
 import { countIf, toTrueMap, trueKeys } from '../../util/collections';
@@ -239,7 +240,7 @@ const reducers = {
    */
   UPDATE_ANCHOR_STATUS(state, action) {
     const annotations = state.annotations.map(annot => {
-      if (!action.statusUpdates.hasOwnProperty(annot.$tag)) {
+      if (!hasOwn(action.statusUpdates, annot.$tag)) {
         return annot;
       }
 

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -12,8 +12,8 @@
 
 import { createSelector } from 'reselect';
 
+import { hasOwn } from '../../../shared/has-own';
 import { createStoreModule, makeAction } from '../create-store';
-
 import { annotationsModule } from './annotations';
 import { groupsModule } from './groups';
 import { routeModule } from './route';
@@ -215,7 +215,7 @@ const pendingUpdateCount = createSelector(
  * @param {string} id
  */
 function hasPendingDeletion(state, id) {
-  return state.pendingDeletions.hasOwnProperty(id);
+  return hasOwn(state.pendingDeletions, id);
 }
 
 export const realTimeUpdatesModule = createStoreModule(initialState, {

--- a/src/sidebar/util/url.js
+++ b/src/sidebar/util/url.js
@@ -1,3 +1,5 @@
+import { hasOwn } from '../../shared/has-own';
+
 /**
  * Replace parameters in a URL template with values from a `params` object.
  *
@@ -16,7 +18,7 @@ export function replaceURLParams(url, params) {
   /** @type {Record<string, Param>} */
   const unusedParams = {};
   for (const param in params) {
-    if (params.hasOwnProperty(param)) {
+    if (hasOwn(params, param)) {
       const value = params[param];
       const urlParam = ':' + param;
       if (url.indexOf(urlParam) !== -1) {


### PR DESCRIPTION
`hasOwnProperty` is unsafe if called on an object which may potentially
have its own or an inherited property called "hasOwnProperty" or which
has a null prototype. Add a polyfill for the [modern alternative](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn#syntax) and
remove the ESLint suppression.

 - Replace various uses of `hasOwnProperty` with `hasOwn` polyfill. In
   tests we can use `Object.hasOwn` directly, since tests only run in
   modern browsers.

 - Remove obsolete `Object.assign` polyfill in `parse-json-config.js`.
   IE 10/11 have been unsupported for long enough that I think we can
   stop worrying about it in the boot script.

Fixes https://github.com/hypothesis/client/issues/3517