### PR TITLE
Support native TypeScript modules

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": [
+    "@babel/preset-typescript",
     [
       "@babel/preset-react",
       {

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,11 @@
 {
-  "extends": ["hypothesis", "plugin:jsx-a11y/recommended"],
+  "extends": [
+    "hypothesis",
+    "plugin:jsx-a11y/recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
   "rules": {
     "prefer-arrow-callback": ["error", { "allowNamedFunctions": true }],
     "object-shorthand": ["error", "properties"],
@@ -9,7 +15,26 @@
     "no-prototype-builtins": "off",
 
     // Replaced by TypeScript's static checking.
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+
+    // Upgrade TS rules from warning to error.
+    "@typescript-eslint/no-unused-vars": "error",
+
+    // Disable TS rules that we dislike.
+    "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-this-alias": "off",
+
+    // Enforce consistency in cases where TypeScript supports old and new
+    // syntaxes for the same thing.
+    //
+    // - Require `<var> as <type>` for casts
+    // - Require `import type` for type imports. The corresponding rule for
+    //   exports is not enabled yet because that requires setting up type-aware
+    //   linting.
+    "@typescript-eslint/consistent-type-assertions": "error",
+    "@typescript-eslint/consistent-type-imports": "error"
   },
   "overrides": [
     {

--- a/dev-server/.eslintrc
+++ b/dev-server/.eslintrc
@@ -7,7 +7,5 @@
   },
   "rules": {
     "@typescript-eslint/no-var-requires": "off",
-    "no-console": "off",
-    "react-hooks/rules-of-hooks": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "axe-core": "^4.0.0",
     "babel-plugin-inject-args": "^1.0.0",
     "babel-plugin-istanbul": "^6.0.0",
-    "babel-plugin-mockable-imports": "^2.0.0",
+    "babel-plugin-mockable-imports": "^2.0.1",
     "babel-plugin-transform-async-to-promises": "^0.8.6",
     "chai": "^4.1.2",
     "chance": "^1.0.13",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@babel/core": "^7.1.6",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
+    "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "1.2.0",
     "@hypothesis/frontend-shared": "5.3.0",
     "@octokit/rest": "^19.0.3",
@@ -107,8 +108,8 @@
   "scripts": {
     "build": "cross-env NODE_ENV=production gulp build",
     "lint": "eslint .",
-    "checkformatting": "prettier --check '**/*.{js,scss,d.ts}'",
-    "format": "prettier --list-different --write '**/*.{js,scss,d.ts}'",
+    "checkformatting": "prettier --check '**/*.{js,scss,ts,tsx,d.ts}'",
+    "format": "prettier --list-different --write '**/*.{js,scss,ts,tsx,d.ts}'",
     "test": "gulp test",
     "typecheck": "tsc --build tsconfig.json",
     "report-coverage": "codecov -f coverage/coverage-final.json",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@types/scroll-into-view": "^1.16.0",
     "@types/shallowequal": "^1.1.1",
     "@types/showdown": "^2.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.35.1",
+    "@typescript-eslint/parser": "^5.35.1",
     "approx-string-match": "^2.0.0",
     "autoprefixer": "^10.0.1",
     "aws-sdk": "^2.345.0",

--- a/rollup-tests.config.mjs
+++ b/rollup-tests.config.mjs
@@ -39,6 +39,7 @@ export default {
     }),
     nodeResolve({
       browser: true,
+      extensions: ['.js', '.ts', '.tsx'],
 
       // Disallow use of browser polyfills for Node builtin modules. We're
       // trying to avoid dependencies which rely on these.
@@ -60,6 +61,7 @@ export default {
     babel({
       babelHelpers: 'bundled',
       exclude: 'node_modules/**',
+      extensions: ['.js', '.ts', '.tsx'],
       presets: [
         [
           '@babel/preset-react',

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -86,8 +86,9 @@ function bundleConfig({ name, entry, format = 'es' }) {
       babel({
         babelHelpers: 'bundled',
         exclude: 'node_modules/**',
+        extensions: ['.js', '.ts', '.tsx'],
       }),
-      nodeResolve(),
+      nodeResolve({ extensions: ['.js', '.ts', '.tsx'] }),
       commonjs({ include: 'node_modules/**' }),
       string({
         include: '**/*.svg',

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "parserOptions": {
-    "sourceType": "module"
-  }
-}

--- a/src/karma.config.js
+++ b/src/karma.config.js
@@ -1,9 +1,11 @@
 /* global __dirname, process */
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require('path');
 
 let chromeFlags = [];
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 process.env.CHROME_BIN = require('puppeteer').executablePath();
 
 if (process.env.RUNNING_IN_DOCKER) {

--- a/src/shared/listener-collection.ts
+++ b/src/shared/listener-collection.ts
@@ -1,9 +1,8 @@
-/**
- * @typedef Listener
- * @prop {EventTarget} eventTarget
- * @prop {string} eventType
- * @prop {(event: Event) => void} listener
- */
+type Listener = {
+  eventTarget: EventTarget;
+  eventType: string;
+  listener: (event: Event) => void;
+};
 
 /**
  * Return the event type that a listener will receive.
@@ -13,57 +12,51 @@
  * The event type is extracted from the target's `on${Type}` property (eg.
  * `HTMLElement.onkeydown` here) If there is no such property, the type defaults
  * to `Event`.
- *
- * @template {EventTarget} Target
- * @template {string} Type
- * @typedef {`on${Type}` extends keyof Target ?
- *   Target[`on${Type}`] extends ((...args: any[]) => void)|null ?
- *     Parameters<NonNullable<Target[`on${Type}`]>>[0]
- *  : Event : Event} EventType
  */
+type EventType<
+  Target extends EventTarget,
+  Type extends string
+> = `on${Type}` extends keyof Target
+  ? Target[`on${Type}`] extends ((...args: any[]) => void) | null
+    ? Parameters<NonNullable<Target[`on${Type}`]>>[0]
+    : Event
+  : Event;
 
 /**
  * Utility that provides a way to conveniently remove a set of DOM event
  * listeners when they are no longer needed.
  */
 export class ListenerCollection {
+  private _listeners: Map<symbol, Listener>;
+
   constructor() {
-    /** @type {Map<Symbol, Listener>} */
     this._listeners = new Map();
   }
 
   /**
    * Add a listener and return an ID that can be used to remove it later
-   *
-   * @template {string} Type
-   * @template {EventTarget} Target
-   * @param {Target} eventTarget
-   * @param {Type} eventType
-   * @param {(event: EventType<Target, Type>) => void} listener
-   * @param {AddEventListenerOptions} [options]
    */
-  add(eventTarget, eventType, listener, options) {
-    eventTarget.addEventListener(
-      eventType,
-      /** @type {EventListener} */ (listener),
-      options
-    );
+  add<Type extends string, Target extends EventTarget>(
+    eventTarget: Target,
+    eventType: Type,
+    listener: (event: EventType<Target, Type>) => void,
+    options?: AddEventListenerOptions
+  ) {
+    eventTarget.addEventListener(eventType, listener as EventListener, options);
     const symbol = Symbol();
     this._listeners.set(symbol, {
       eventTarget,
       eventType,
       // eslint-disable-next-line object-shorthand
-      listener: /** @type {EventListener} */ (listener),
+      listener: listener as EventListener,
     });
     return symbol;
   }
 
   /**
    * Remove a specific listener.
-   *
-   * @param {Symbol} listenerId
    */
-  remove(listenerId) {
+  remove(listenerId: symbol) {
     const event = this._listeners.get(listenerId);
     if (event) {
       const { eventTarget, eventType, listener } = event;

--- a/src/sidebar/components/HelpPanel.tsx
+++ b/src/sidebar/components/HelpPanel.tsx
@@ -1,7 +1,10 @@
 import { Icon, Link, LinkButton } from '@hypothesis/frontend-shared';
+import type { ComponentChildren as Children } from 'preact';
 import { useCallback, useMemo, useState } from 'preact/hooks';
 
+import type { AuthState } from '../helpers/version-data';
 import { useSidebarStore } from '../store';
+import type { SessionService } from '../services/session';
 import { withServices } from '../service-context';
 import { VersionData } from '../helpers/version-data';
 
@@ -9,19 +12,18 @@ import SidebarPanel from './SidebarPanel';
 import Tutorial from './Tutorial';
 import VersionInfo from './VersionInfo';
 
-/**
- * @typedef {import('../helpers/version-data').AuthState} AuthState
- * @typedef {import("preact").ComponentChildren} Children
- */
+type HelpPanelNavigationButtonProps = {
+  children: Children;
+  onClick: (e: Event) => void;
+};
 
 /**
  * Navigation link-button to swap between sub-panels in the help panel
- *
- * @param {object} props
- *   @param {Children} props.children
- *   @param {(e: Event) => void} props.onClick
  */
-function HelpPanelNavigationButton({ children, onClick }) {
+function HelpPanelNavigationButton({
+  children,
+  onClick,
+}: HelpPanelNavigationButtonProps) {
   return (
     <LinkButton classes="leading-none text-brand" onClick={onClick}>
       {children}
@@ -30,14 +32,17 @@ function HelpPanelNavigationButton({ children, onClick }) {
   );
 }
 
+type HelpPanelTabProps = {
+  /** What the tab's link should say. */
+  linkText: string;
+  /** Where the tab's link should go. */
+  url: string;
+};
+
 /**
  * External link "tabs" inside of the help panel.
- *
- * @param {object} props
- *   @param {string} props.linkText - What the tab's link should say
- *   @param {string} props.url - Where the tab's link should go
  */
-function HelpPanelTab({ linkText, url }) {
+function HelpPanelTab({ linkText, url }: HelpPanelTabProps) {
   return (
     <div className="flex-1 border-r last-of-type:border-r-0">
       <Link
@@ -51,18 +56,15 @@ function HelpPanelTab({ linkText, url }) {
   );
 }
 
-/**
- * @typedef HelpPanelProps
- * @prop {AuthState} auth
- * @prop {import('../services/session').SessionService} session
- */
+type HelpPanelProps = {
+  auth: AuthState;
+  session: SessionService;
+};
 
 /**
  * A help sidebar panel with two sub-panels: tutorial and version info.
- *
- * @param {HelpPanelProps} props
  */
-function HelpPanel({ auth, session }) {
+function HelpPanel({ auth, session }: HelpPanelProps) {
   const store = useSidebarStore();
   const frames = store.frames();
   const mainFrame = store.mainFrame();
@@ -78,11 +80,10 @@ function HelpPanel({ auth, session }) {
     tutorial: 'Getting started',
     versionInfo: 'About this version',
   };
+  type PanelKey = keyof typeof subPanelTitles;
 
   // The "Tutorial" (getting started) subpanel is the default panel shown
-  const [activeSubPanel, setActiveSubPanel] = useState(
-    /** @type {keyof subPanelTitles} */ ('tutorial')
-  );
+  const [activeSubPanel, setActiveSubPanel] = useState<PanelKey>('tutorial');
 
   // Build version details about this session/app
   const versionData = useMemo(() => {
@@ -107,18 +108,13 @@ function HelpPanel({ auth, session }) {
   // create-new-ticket form
   const supportTicketURL = `https://web.hypothes.is/get-help/?sys_info=${versionData.asEncodedURLString()}`;
 
-  /**
-   * @param {Event} e
-   * @param {keyof subPanelTitles} panelName
-   */
-  const openSubPanel = (e, panelName) => {
+  const openSubPanel = (e: Event, panelName: PanelKey) => {
     e.preventDefault();
     setActiveSubPanel(panelName);
   };
 
   const onActiveChanged = useCallback(
-    /** @param {boolean} active */
-    active => {
+    (active: boolean) => {
       if (!active && hasAutoDisplayPreference) {
         // If the tutorial is currently being auto-displayed, update the user
         // preference to disable the auto-display from happening on subsequent

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -23,7 +23,7 @@
     // code for the browser.
     "types": []
   },
-  "include": ["**/*.js", "types/*.d.ts"],
+  "include": ["**/*.js", "**/*.ts", "**/*.tsx", "types/*.d.ts"],
   "exclude": [
     // Tests are not checked.
     "**/test/**/*.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,6 +1531,11 @@
   resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.41.tgz#f6ecf57d1b12d2befcce00e928a6a097c22980aa"
   integrity sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==
 
+"@types/json-schema@^7.0.9":
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+
 "@types/katex@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@types/katex/-/katex-0.14.0.tgz#b84c0afc3218069a5ad64fe2a95321881021b5fe"
@@ -1584,6 +1589,86 @@
   integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
   dependencies:
     "@types/node" "*"
+
+"@typescript-eslint/eslint-plugin@^5.35.1":
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.35.1.tgz#0d822bfea7469904dfc1bb8f13cabd362b967c93"
+  integrity sha512-RBZZXZlI4XCY4Wzgy64vB+0slT9+yAPQRjj/HSaRwUot33xbDjF1oN9BLwOLTewoOI0jothIltZRe9uJCHf8gg==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.35.1"
+    "@typescript-eslint/type-utils" "5.35.1"
+    "@typescript-eslint/utils" "5.35.1"
+    debug "^4.3.4"
+    functional-red-black-tree "^1.0.1"
+    ignore "^5.2.0"
+    regexpp "^3.2.0"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/parser@^5.35.1":
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.35.1.tgz#bf2ee2ebeaa0a0567213748243fb4eec2857f04f"
+  integrity sha512-XL2TBTSrh3yWAsMYpKseBYTVpvudNf69rPOWXWVBI08My2JVT5jR66eTt4IgQFHA/giiKJW5dUD4x/ZviCKyGg==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.35.1"
+    "@typescript-eslint/types" "5.35.1"
+    "@typescript-eslint/typescript-estree" "5.35.1"
+    debug "^4.3.4"
+
+"@typescript-eslint/scope-manager@5.35.1":
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.35.1.tgz#ccb69d54b7fd0f2d0226a11a75a8f311f525ff9e"
+  integrity sha512-kCYRSAzIW9ByEIzmzGHE50NGAvAP3wFTaZevgWva7GpquDyFPFcmvVkFJGWJJktg/hLwmys/FZwqM9EKr2u24Q==
+  dependencies:
+    "@typescript-eslint/types" "5.35.1"
+    "@typescript-eslint/visitor-keys" "5.35.1"
+
+"@typescript-eslint/type-utils@5.35.1":
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.35.1.tgz#d50903b56758c5c8fc3be52b3be40569f27f9c4a"
+  integrity sha512-8xT8ljvo43Mp7BiTn1vxLXkjpw8wS4oAc00hMSB4L1/jIiYbjjnc3Qp2GAUOG/v8zsNCd1qwcqfCQ0BuishHkw==
+  dependencies:
+    "@typescript-eslint/utils" "5.35.1"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/types@5.35.1":
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.35.1.tgz#af355fe52a0cc88301e889bc4ada72f279b63d61"
+  integrity sha512-FDaujtsH07VHzG0gQ6NDkVVhi1+rhq0qEvzHdJAQjysN+LHDCKDKCBRlZFFE0ec0jKxiv0hN63SNfExy0KrbQQ==
+
+"@typescript-eslint/typescript-estree@5.35.1":
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.35.1.tgz#db878a39a0dbdc9bb133f11cdad451770bfba211"
+  integrity sha512-JUqE1+VRTGyoXlDWWjm6MdfpBYVq+hixytrv1oyjYIBEOZhBCwtpp5ZSvBt4wIA1MKWlnaC2UXl2XmYGC3BoQA==
+  dependencies:
+    "@typescript-eslint/types" "5.35.1"
+    "@typescript-eslint/visitor-keys" "5.35.1"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.35.1":
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.35.1.tgz#ae1399afbfd6aa7d0ed1b7d941e9758d950250eb"
+  integrity sha512-v6F8JNXgeBWI4pzZn36hT2HXXzoBBBJuOYvoQiaQaEEjdi5STzux3Yj8v7ODIpx36i/5s8TdzuQ54TPc5AITQQ==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.35.1"
+    "@typescript-eslint/types" "5.35.1"
+    "@typescript-eslint/typescript-estree" "5.35.1"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.35.1":
+  version "5.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.35.1.tgz#285e9e34aed7c876f16ff646a3984010035898e6"
+  integrity sha512-cEB1DvBVo1bxbW/S5axbGPE6b7FIMAbo3w+AGq6zNDA7+NYJOIkKj/sInfTv4edxd4PxJSgdN4t6/pbvgA+n5g==
+  dependencies:
+    "@typescript-eslint/types" "5.35.1"
+    eslint-visitor-keys "^3.3.0"
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -2711,7 +2796,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, debug@~4.3.1, debug@~4.3.2:
+debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -3313,6 +3398,14 @@ eslint-plugin-react@^7.12.4:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.7"
 
+eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
@@ -3410,6 +3503,11 @@ esrecurse@^4.3.0:
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
     estraverse "^5.2.0"
+
+estraverse@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
+  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   version "5.3.0"
@@ -5279,6 +5377,13 @@ loupe@^2.3.1:
   dependencies:
     get-func-name "^2.0.0"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 lru-cache@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -6772,6 +6877,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
@@ -7473,10 +7585,17 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
-tslib@^1.9.3:
+tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tsutils@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
+  dependencies:
+    tslib "^1.8.1"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -7961,6 +8080,11 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.2:
   version "1.10.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2093,10 +2093,10 @@ babel-plugin-istanbul@^6.0.0:
     istanbul-lib-instrument "^5.0.4"
     test-exclude "^6.0.0"
 
-babel-plugin-mockable-imports@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-mockable-imports/-/babel-plugin-mockable-imports-2.0.0.tgz#78c01fcdd5f9ecbc7ded29165f4c3f6e3d458514"
-  integrity sha512-xYwXtDV8f3Jz0xOrs8NSbp5pdlfbaCCOotRb0zuJEs5+vJlMvzKjOymVCAMUNzDZJCruO4YQw93ppm4XTLKYBg==
+babel-plugin-mockable-imports@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-mockable-imports/-/babel-plugin-mockable-imports-2.0.1.tgz#4f51c80cfb43f4900dcfab70f8f3ed6caaaf7c8a"
+  integrity sha512-/6rA20YQAwjRFtcAJ+677pON1NL1oynH0+jm1MRWHKVOq55nTUP7TX7k6UlrJFYBl0pdKakOC3TFLXXHvF/GfA==
 
 babel-plugin-polyfill-corejs2@^0.3.2:
   version "0.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,6 +76,19 @@
     browserslist "^4.20.2"
     semver "^6.3.0"
 
+"@babel/helper-create-class-features-plugin@^7.16.7":
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.13.tgz#63e771187bd06d234f95fdf8bd5f8b6429de6298"
+  integrity sha512-hDvXp+QYxSRL+23mpAlSGxHMDyIGChm0/AwTfTAAK5Ufe40nCsyNdaYCGuK91phn/fVu9kqayImRDkvNAgdrsA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.18.9"
+    "@babel/helper-member-expression-to-functions" "^7.18.9"
+    "@babel/helper-optimise-call-expression" "^7.18.6"
+    "@babel/helper-replace-supers" "^7.18.9"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+
 "@babel/helper-create-class-features-plugin@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.6.tgz#6f15f8459f3b523b39e00a99982e2c040871ed72"
@@ -276,7 +289,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
   integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
 
-"@babel/helper-validator-option@^7.18.6":
+"@babel/helper-validator-option@^7.16.7", "@babel/helper-validator-option@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
   integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
@@ -581,6 +594,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-syntax-typescript@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.7.tgz#39c9b55ee153151990fb038651d58d3fd03f98f8"
+  integrity sha512-YhUIJHHGkqPgEcMYkPCKTyGUdoGKWtopIycQyjJH8OjvRgOYsXsaKehLVPScKJWAULPxMa4N1vCe6szREFlZ7A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-arrow-functions@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.18.6.tgz#19063fcf8771ec7b31d742339dac62433d0611fe"
@@ -851,6 +871,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.9"
 
+"@babel/plugin-transform-typescript@^7.16.7":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.8.tgz#591ce9b6b83504903fa9dd3652c357c2ba7a1ee0"
+  integrity sha512-bHdQ9k7YpBDO2d0NVfkj51DpQcvwIzIusJ7mEUaMlbZq3Kt/U47j24inXZHQ5MDiYpCs+oZiwnXyKedE8+q7AQ==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/plugin-syntax-typescript" "^7.16.7"
+
 "@babel/plugin-transform-unicode-escapes@^7.18.10":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.18.10.tgz#1ecfb0eda83d09bbcb77c09970c2dd55832aa246"
@@ -969,6 +998,15 @@
     "@babel/plugin-transform-react-jsx" "^7.18.6"
     "@babel/plugin-transform-react-jsx-development" "^7.18.6"
     "@babel/plugin-transform-react-pure-annotations" "^7.18.6"
+
+"@babel/preset-typescript@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz#ab114d68bb2020afc069cd51b37ff98a046a70b9"
+  integrity sha512-WbVEmgXdIyvzB77AQjGBEyYPZx+8tTsO50XtfozQrkW8QB2rLJpH2lgx0TRw5EJrBxOZQ+wCcyPVQvS8tjEHpQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-validator-option" "^7.16.7"
+    "@babel/plugin-transform-typescript" "^7.16.7"
 
 "@babel/runtime-corejs3@^7.10.2":
   version "7.12.1"


### PR DESCRIPTION
Following discussion in the frontend sync yesterday, this is a branch I had locally that enables use of native TypeScript (.ts and .tsx) modules alongside our existing JS modules which use JSDoc for specifying types.

I also included two commits that convert a JSX-using module and a non-JSX-using module to .tsx and .ts respectively. These serve to test support for TS modules across our various tools (bundler, linting, formatting, tests etc.) and also illustrate some of the conventions I recommend we use in cases where TypeScript, for historical reasons, supports multiple syntaxes for the same thing [1].

Summary of changes:

 - Support TypeScript in Rollup bundle builds, using Babel to handle parsing .ts files and stripping out types
 - Support TypeScript in ESLint, via [typescript-eslint](https://typescript-eslint.io)
 - Convert HelpPanel.js to HelpPanel.tsx
 - Convert listener-collection.js to listener-collection.ts

~~There is currently one issue I'm aware of where running tests prints a warning related to `$imports` and Babel. Some changes will be required to https://github.com/robertknight/babel-plugin-mockable-imports to fix this.~~ (_Update: Fixed in babel-plugin-mockable-imports v2.0.1_)

[1] Specifically, whether to use `type` vs `interface` for defining certain types, whether to use `as` for casts vs angle brackets, and using `import type` for importing types rather than values.