### PR TITLE
Update tailwind config content globs for typescript

### DIFF
--- a/tailwind-annotator.config.mjs
+++ b/tailwind-annotator.config.mjs
@@ -3,9 +3,9 @@ import tailwindConfig from './tailwind.config.mjs';
 export default {
   presets: [tailwindConfig],
   content: [
-    './src/annotator/components/**/*.js',
-    './node_modules/@hypothesis/frontend-shared/lib/**/*.js',
+    './src/annotator/components/**/*.{js,ts,tsx}',
+    './node_modules/@hypothesis/frontend-shared/lib/**/*.{js,ts,tsx}',
     // This module references `sidebar-frame` and related classes
-    './src/annotator/sidebar.js',
+    './src/annotator/sidebar.{js,ts,tsx}',
   ],
 };

--- a/tailwind-sidebar.config.mjs
+++ b/tailwind-sidebar.config.mjs
@@ -3,8 +3,8 @@ import tailwindConfig from './tailwind.config.mjs';
 export default {
   presets: [tailwindConfig],
   content: [
-    './src/sidebar/components/**/*.js',
-    './dev-server/ui-playground/components/**/*.js',
-    './node_modules/@hypothesis/frontend-shared/lib/**/*.js',
+    './src/sidebar/components/**/*.{js,ts,tsx}',
+    './dev-server/ui-playground/components/**/*.{js,ts,tsx}',
+    './node_modules/@hypothesis/frontend-shared/lib/**/*.{js,ts,tsx}',
   ],
 };

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -6,12 +6,12 @@ const focusBlue = '#59a7e8';
 export default {
   presets: [tailwindConfig],
   content: [
-    './src/sidebar/components/**/*.js',
-    './src/annotator/components/**/*.js',
-    './dev-server/ui-playground/components/**/*.js',
-    './node_modules/@hypothesis/frontend-shared/lib/**/*.js',
+    './src/sidebar/components/**/*.{js,ts,tsx}',
+    './src/annotator/components/**/*.{js,ts,tsx}',
+    './dev-server/ui-playground/components/**/*.{js,ts,tsx}',
+    './node_modules/@hypothesis/frontend-shared/lib/**/*.{js,ts,tsx}',
     // This module references `sidebar-frame` and related classes
-    './src/annotator/sidebar.js',
+    './src/annotator/sidebar.{js,ts,tsx}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
Ensure that `content` globs for tailwind configurations include `.ts` and `.tsx` modules. Fixes a regression in which styles are lost for the `HelpPanel`.

Before:

<img width="421" alt="image" src="https://user-images.githubusercontent.com/439947/187198224-ba2de76e-6850-4753-bf4a-2b7be57d86ad.png">

After:

<img width="423" alt="image" src="https://user-images.githubusercontent.com/439947/187198155-3b3d0d08-9ac4-4008-9fa4-861e45d405f7.png">
