### PR TITLE
Upgrade `@hypothesis/frontend-shared` to 5.4.0 and use `LinkBase`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "1.2.0",
-    "@hypothesis/frontend-shared": "5.3.0",
+    "@hypothesis/frontend-shared": "5.4.0",
     "@octokit/rest": "^19.0.3",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^22.0.0",

--- a/src/annotator/components/ContentInfoBanner.js
+++ b/src/annotator/components/ContentInfoBanner.js
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 
 import {
   Link,
-  LinkUnstyled,
+  LinkBase,
   CaretLeftIcon,
   CaretRightIcon,
 } from '@hypothesis/frontend-shared/lib/next';
@@ -103,14 +103,15 @@ export default function ContentInfoBanner({ info }) {
             'min-w-0 whitespace-nowrap overflow-hidden text-ellipsis shrink font-medium'
           )}
         >
-          <LinkUnstyled
+          <LinkBase
             title={itemTitle}
             href={info.links.currentItem}
             data-testid="content-item-link"
             target="_blank"
+            unstyled
           >
             {itemTitle}
-          </LinkUnstyled>
+          </LinkBase>
         </div>
 
         {info.links.nextItem && (

--- a/src/annotator/components/test/ContentInfoBanner-test.js
+++ b/src/annotator/components/test/ContentInfoBanner-test.js
@@ -46,7 +46,7 @@ describe('ContentInfoBanner', () => {
   it('shows item title', () => {
     const wrapper = createComponent();
 
-    const link = wrapper.find('LinkUnstyled[data-testid="content-item-link"]');
+    const link = wrapper.find('LinkBase[data-testid="content-item-link"]');
     assert.equal(link.text(), 'Chapter 2: Some book chapter');
     assert.equal(link.prop('target'), '_blank');
   });
@@ -56,7 +56,7 @@ describe('ContentInfoBanner', () => {
 
     const wrapper = createComponent();
 
-    const link = wrapper.find('LinkUnstyled[data-testid="content-item-link"]');
+    const link = wrapper.find('LinkBase[data-testid="content-item-link"]');
     assert.equal(link.text(), 'Chapter 2');
   });
 
@@ -70,9 +70,7 @@ describe('ContentInfoBanner', () => {
       'Expansive Book'
     );
     assert.equal(
-      wrapper
-        .find('LinkUnstyled[data-testid="content-item-link"]')
-        .prop('title'),
+      wrapper.find('LinkBase[data-testid="content-item-link"]').prop('title'),
       'Chapter 2: Some book chapter'
     );
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,10 +1110,10 @@
     fancy-log "^1.3.3"
     glob "^7.2.0"
 
-"@hypothesis/frontend-shared@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.3.0.tgz#3448f7b5a0486059ee99f0c684408809f4f6ef21"
-  integrity sha512-yTHjgmwkBdTtfgJDLfpwXSx5oRIeHv3O/fh00QyGBPQ9VBx1KWQB6tY3yUMcvSCz4nRgnHvij/X+wYLT6b/rFA==
+"@hypothesis/frontend-shared@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.4.0.tgz#60b10bf5d576879176c0355dad883b465d43714d"
+  integrity sha512-GROm1HUzEto84Mwlix2pUoZfQNLPhqKIn+Y6d1gnwjvDUU2YxUOm+TWYtqmIRCEtEAb5jnm/VUsRJ7DdI8mYlg==
   dependencies:
     highlight.js "^11.6.0"
 


### PR DESCRIPTION
`@hypothesis/frontend-shared` 5.4.0 has a breaking change of swapping out `Unstyled` components in favor of `Base` components. This is the only place an `Unstyled` component was actually used. This PR both updates the dependency and swaps in the updated component in the JSTOR banner.