### PR TITLE
Remove `tox-pip-sync`

### DIFF
--- a/requirements/checkdocs.in
+++ b/requirements/checkdocs.in
@@ -1,4 +1,5 @@
 pip-tools
+pip-sync-faster
 myst-parser
 sphinx-autobuild
 sphinx

--- a/requirements/checkdocs.txt
+++ b/requirements/checkdocs.txt
@@ -53,8 +53,12 @@ packaging==21.3
     #   sphinx
 pep517==0.13.0
     # via build
-pip-tools==6.8.0
+pip-sync-faster==0.0.2
     # via -r requirements/checkdocs.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/checkdocs.in
+    #   pip-sync-faster
 pygments==2.12.0
     # via sphinx
 pyparsing==3.0.9

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,4 +1,5 @@
 pip-tools
+pip-sync-faster
 myst-parser
 sphinx-autobuild
 sphinx

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -53,8 +53,12 @@ packaging==21.3
     #   sphinx
 pep517==0.13.0
     # via build
-pip-tools==6.8.0
+pip-sync-faster==0.0.2
     # via -r requirements/docs.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/docs.in
+    #   pip-sync-faster
 pygments==2.12.0
     # via sphinx
 pyparsing==3.0.9

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = docs
 skipsdist = true
 requires =
-  tox-pip-sync
+  tox-faster
   tox-pyenv
   tox-run-command
 
@@ -13,5 +13,6 @@ deps =
 passenv =
     HOME
 commands =
+    pip-sync-faster requirements/{env:TOX_ENV_NAME}.txt --pip-args '--disable-pip-version-check'
     docs: sphinx-autobuild -qT --open-browser -b dirhtml -d {envdir}/doctrees docs {envdir}/html
     checkdocs: sphinx-build -qTWn -b dirhtml -d {envdir}/doctrees docs {envdir}/html


### PR DESCRIPTION
The same as we've done for all our other projects. The client only uses tox to serve its Sphinx documentation site (the site that's published to https://h.readthedocs.io/projects/client/en/latest/) locally. To test run:

    make docs

and open http://localhost:8000/
