### PR TITLE
Give keyboard focus to first annotation in selection when clicking "Show" button in adder toolbar

### DIFF
--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -267,7 +267,7 @@ describe('Guest', () => {
 
         emitHostEvent('selectAnnotations', tags, toggle);
 
-        assert.calledWith(guest.selectAnnotations, tags, toggle);
+        assert.calledWith(guest.selectAnnotations, tags, { toggle });
         assert.calledWith(sidebarRPC().call, 'openSidebar');
       });
     });
@@ -805,7 +805,12 @@ describe('Guest', () => {
       FakeAdder.instance.options.onShowAnnotations(tags);
 
       assert.calledWith(sidebarRPC().call, 'openSidebar');
-      assert.calledWith(sidebarRPC().call, 'showAnnotations', tags);
+      assert.calledWith(
+        sidebarRPC().call,
+        'showAnnotations',
+        tags,
+        true // Focus annotation in sidebar
+      );
     });
   });
 
@@ -816,14 +821,19 @@ describe('Guest', () => {
 
       guest.selectAnnotations(tags);
 
-      assert.calledWith(sidebarRPC().call, 'showAnnotations', tags);
+      assert.calledWith(
+        sidebarRPC().call,
+        'showAnnotations',
+        tags,
+        false // Don't focus annotation in sidebar
+      );
     });
 
     it('toggles the annotations if `toggle` is true', () => {
       const guest = createGuest();
       const tags = ['t1', 't2'];
 
-      guest.selectAnnotations(tags, true /* toggle */);
+      guest.selectAnnotations(tags, { toggle: true });
 
       assert.calledWith(sidebarRPC().call, 'toggleAnnotationSelection', tags);
     });
@@ -834,6 +844,20 @@ describe('Guest', () => {
       guest.selectAnnotations([]);
 
       assert.calledWith(sidebarRPC().call, 'openSidebar');
+    });
+
+    it('focuses first selected annotation in sidebar if `focusInSidebar` is true', () => {
+      const guest = createGuest();
+      const tags = ['t1', 't2'];
+
+      guest.selectAnnotations(tags, { focusInSidebar: true });
+
+      assert.calledWith(
+        sidebarRPC().call,
+        'showAnnotations',
+        tags,
+        true // Focus in sidebar
+      );
     });
   });
 

--- a/src/sidebar/components/ThreadCard.js
+++ b/src/sidebar/components/ThreadCard.js
@@ -1,7 +1,7 @@
 import { Card } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import debounce from 'lodash.debounce';
-import { useCallback, useMemo } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef } from 'preact/hooks';
 
 import { useSidebarStore } from '../store';
 import { withServices } from '../service-context';
@@ -63,6 +63,17 @@ function ThreadCard({ frameSync, thread }) {
   // parent component but the `Thread` itself has not changed.
   const threadContent = useMemo(() => <Thread thread={thread} />, [thread]);
 
+  // Handle requests to give this thread keyboard focus.
+  const focusRequest = store.annotationFocusRequest();
+  const cardRef = useRef(/** @type {HTMLElement|null} */ (null));
+  useEffect(() => {
+    if (focusRequest !== thread.id || !cardRef.current) {
+      return;
+    }
+    cardRef.current.focus();
+    store.clearAnnotationFocusRequest();
+  }, [focusRequest, store, thread.id]);
+
   return (
     /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
     <Card
@@ -70,6 +81,8 @@ function ThreadCard({ frameSync, thread }) {
         'is-hovered': isHovered,
       })}
       data-testid="thread-card"
+      elementRef={cardRef}
+      tabIndex={0}
       onClick={e => {
         // Prevent click events intended for another action from
         // triggering a page scroll.

--- a/src/sidebar/components/ThreadCard.js
+++ b/src/sidebar/components/ThreadCard.js
@@ -77,12 +77,12 @@ function ThreadCard({ frameSync, thread }) {
   return (
     /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
     <Card
-      classes={classnames('p-3 cursor-pointer', {
+      classes={classnames('p-3 cursor-pointer focus-visible-ring', {
         'is-hovered': isHovered,
       })}
       data-testid="thread-card"
       elementRef={cardRef}
-      tabIndex={0}
+      tabIndex={-1}
       onClick={e => {
         // Prevent click events intended for another action from
         // triggering a page scroll.

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -372,15 +372,22 @@ export class FrameSyncService {
        *   to the first annotation in the selection.
        */
       (tags, focusFirstInSelection = false) => {
+        // Since annotations are selected by ID rather than tag, this logic
+        // currently only supports saved annotations.
         const ids = this._store.findIDsForTags(tags);
         this._store.selectAnnotations(ids);
         this._store.selectTab('annotation');
 
         // Attempt to transfer keyboard focus to the first selected annotation.
-        // This may be blocked in WebKit-based browsers if the user has not
-        // previously interacted with the frame.
+        //
+        // To do this we need to focus both the annotation card and the frame
+        // itself. It doesn't matter in which order.
         if (ids.length > 0 && focusFirstInSelection) {
+          // Request the annotation card to be focused. This is handled asynchronously.
           this._store.setAnnotationFocusRequest(ids[0]);
+
+          // Focus the sidebar frame. This may fail in WebKit-based browsers
+          // if the user has no interacted with the frame since it loaded.
           window.focus();
         }
       }

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -366,9 +366,23 @@ export class FrameSyncService {
 
     guestRPC.on(
       'showAnnotations',
-      /** @param {string[]} tags */ tags => {
-        this._store.selectAnnotations(this._store.findIDsForTags(tags));
+      /**
+       * @param {string[]} tags
+       * @param {boolean} focusFirstInSelection - Whether to give keyboard focus
+       *   to the first annotation in the selection.
+       */
+      (tags, focusFirstInSelection = false) => {
+        const ids = this._store.findIDsForTags(tags);
+        this._store.selectAnnotations(ids);
         this._store.selectTab('annotation');
+
+        // Attempt to transfer keyboard focus to the first selected annotation.
+        // This may be blocked in WebKit-based browsers if the user has not
+        // previously interacted with the frame.
+        if (ids.length > 0 && focusFirstInSelection) {
+          this._store.setAnnotationFocusRequest(ids[0]);
+          window.focus();
+        }
       }
     );
 

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -138,6 +138,7 @@ describe('FrameSyncService', () => {
         openSidebarPanel: sinon.stub(),
         selectAnnotations: sinon.stub(),
         selectTab: sinon.stub(),
+        setAnnotationFocusRequest: sinon.stub(),
         setSidebarOpened: sinon.stub(),
         toggleSelectedAnnotations: sinon.stub(),
         updateAnchorStatus: sinon.stub(),
@@ -662,6 +663,26 @@ describe('FrameSyncService', () => {
 
       assert.calledWith(fakeStore.selectAnnotations, ['id1', 'id2', 'id3']);
       assert.calledWith(fakeStore.selectTab, 'annotation');
+    });
+
+    it('does not request keyboard focus if `focusFirstInSelection` is false', () => {
+      fakeStore.findIDsForTags.returns(['id1', 'id2', 'id3']);
+      emitGuestEvent(
+        'showAnnotations',
+        ['tag1', 'tag2', 'tag3'],
+        false /* focus */
+      );
+      assert.notCalled(fakeStore.setAnnotationFocusRequest);
+    });
+
+    it('requests keyboard focus for first annotation in selection', () => {
+      fakeStore.findIDsForTags.returns(['id1', 'id2', 'id3']);
+      emitGuestEvent(
+        'showAnnotations',
+        ['tag1', 'tag2', 'tag3'],
+        true /* focus */
+      );
+      assert.calledWith(fakeStore.setAnnotationFocusRequest, 'id1');
     });
   });
 

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -684,6 +684,14 @@ describe('FrameSyncService', () => {
       );
       assert.calledWith(fakeStore.setAnnotationFocusRequest, 'id1');
     });
+
+    it('does not request keyboard focus if no IDs could be found for annotation', () => {
+      // Simulate no IDs being found. This could happen if annotations are not
+      // saved or have been deleted since the request was sent.
+      fakeStore.findIDsForTags.returns([]);
+      emitGuestEvent('showAnnotations', ['tag1'], true /* focus */);
+      assert.notCalled(fakeStore.setAnnotationFocusRequest);
+    });
   });
 
   describe('on "hoverAnnotations" message', () => {

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -73,6 +73,13 @@ function initialState(settings) {
      * @type {SortKey}
      */
     sortKey: TAB_SORTKEY_DEFAULT.annotation,
+
+    /**
+     * ID or tag of an annotation that should be given keyboard focus.
+     *
+     * @type {string|null}
+     */
+    focusRequest: null,
   };
 }
 
@@ -102,6 +109,10 @@ const resetSelection = () => {
 };
 
 const reducers = {
+  CLEAR_ANNOTATION_FOCUS_REQUEST() {
+    return { focusRequest: null };
+  },
+
   CLEAR_SELECTION() {
     return resetSelection();
   },
@@ -130,6 +141,14 @@ const reducers = {
     const newExpanded = { ...state.expanded };
     newExpanded[action.id] = action.expanded;
     return { expanded: newExpanded };
+  },
+
+  /**
+   * @param {State} state
+   * @param {{ id: string }} action
+   */
+  SET_ANNOTATION_FOCUS_REQUEST(state, action) {
+    return { focusRequest: action.id };
   },
 
   /**
@@ -262,6 +281,25 @@ function selectAnnotations(ids) {
 }
 
 /**
+ * Request the UI to give keyboard focus to a given annotation.
+ *
+ * Once the UI has processed this request, it should be cleared with
+ * {@link clearAnnotationFocusRequest}.
+ *
+ * @param {string} id
+ */
+function setAnnotationFocusRequest(id) {
+  return makeAction(reducers, 'SET_ANNOTATION_FOCUS_REQUEST', { id });
+}
+
+/**
+ * Clear an annotation focus request created with {@link setAnnotationFocusRequest}.
+ */
+function clearAnnotationFocusRequest() {
+  return makeAction(reducers, 'CLEAR_ANNOTATION_FOCUS_REQUEST', undefined);
+}
+
+/**
  * Set the currently-selected tab to `tabKey`.
  *
  * @param {TabName} tabKey
@@ -319,6 +357,11 @@ function toggleSelectedAnnotations(toggleIds) {
  */
 function expandedMap(state) {
   return state.expanded;
+}
+
+/** @param {State} state */
+function annotationFocusRequest(state) {
+  return state.focusRequest;
 }
 
 const forcedVisibleThreads = createSelector(
@@ -396,9 +439,11 @@ export const selectionModule = createStoreModule(initialState, {
   reducers,
 
   actionCreators: {
+    clearAnnotationFocusRequest,
     clearSelection,
     selectAnnotations,
     selectTab,
+    setAnnotationFocusRequest,
     setExpanded,
     setForcedVisible,
     setSortKey,
@@ -407,6 +452,7 @@ export const selectionModule = createStoreModule(initialState, {
 
   selectors: {
     expandedMap,
+    annotationFocusRequest,
     forcedVisibleThreads,
     hasSelectedAnnotations,
     selectedAnnotations,

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -37,7 +37,7 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('setExpanded()', () => {
+  describe('setExpanded', () => {
     it('sets the expanded state of the annotation', () => {
       store.setExpanded('parent_id', true);
       store.setExpanded('whatnot', false);
@@ -96,7 +96,7 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('selectAnnotations()', () => {
+  describe('selectAnnotations', () => {
     it('adds the passed annotations to the selectedAnnotations', () => {
       store.selectAnnotations([1, 2, 3]);
       assert.deepEqual(getSelectionState().selected, {
@@ -123,7 +123,7 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('toggleSelectedAnnotations()', () => {
+  describe('toggleSelectedAnnotations', () => {
     it('adds annotations missing from the selectedAnnotations', () => {
       store.selectAnnotations([1, 2]);
       store.toggleSelectedAnnotations([3, 4]);
@@ -146,7 +146,7 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('CHANGE_FOCUS_MODE_USER', () => {
+  describe('changeFocusModeUser', () => {
     it('clears selection', () => {
       store.selectAnnotations([1, 2, 3]);
       store.setForcedVisible(2, true);
@@ -161,7 +161,7 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('SET_FILTER', () => {
+  describe('setFilter', () => {
     it('clears selection', () => {
       store.selectAnnotations([1, 2, 3]);
       store.setForcedVisible(2, true);
@@ -173,7 +173,7 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('SET_FILTER_QUERY', () => {
+  describe('setFilterQuery', () => {
     it('clears selection', () => {
       store.selectAnnotations([1, 2, 3]);
       store.setForcedVisible(2, true);
@@ -185,7 +185,7 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('SET_FOCUS_MODE', () => {
+  describe('toggleFocusMode', () => {
     it('clears selection', () => {
       store.selectAnnotations([1, 2, 3]);
       store.setForcedVisible(2, true);
@@ -197,14 +197,16 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('#REMOVE_ANNOTATIONS', () => {
+  describe('removeAnnotations', () => {
     it('removing an annotation should also remove it from the selection', () => {
       store.selectAnnotations([1, 2, 3]);
       store.setForcedVisible(2, true);
       store.setForcedVisible(1, true);
       store.setExpanded(1, true);
       store.setExpanded(2, true);
+
       store.removeAnnotations([{ id: 2 }]);
+
       assert.deepEqual(getSelectionState().selected, {
         1: true,
         3: true,
@@ -214,7 +216,7 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
-  describe('selectTab()', () => {
+  describe('selectTab', () => {
     it('sets the selected tab', () => {
       store.selectTab('annotation');
       assert.equal(getSelectionState().selectedTab, 'annotation');

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -161,6 +161,16 @@ describe('sidebar/store/modules/selection', () => {
     });
   });
 
+  describe('setAnnotationFocusRequest', () => {
+    it('sets annotation ID returned by `annotationFocusRequest`', () => {
+      assert.equal(store.annotationFocusRequest(), null);
+      store.setAnnotationFocusRequest('ann1');
+      assert.equal(store.annotationFocusRequest(), 'ann1');
+      store.clearAnnotationFocusRequest();
+      assert.equal(store.annotationFocusRequest(), null);
+    });
+  });
+
   describe('setFilter', () => {
     it('clears selection', () => {
       store.selectAnnotations([1, 2, 3]);


### PR DESCRIPTION
This change provides a convenient way for screen reader users and others to efficiently navigate from a highlight to the corresponding annotation in the sidebar. When the user triggers the "Show" button in the adder toolbar (by clicking it or using the "s" keyboard shortcut), the sidebar frame will request focus and the annotation card element within the sidebar will be focused.

With these changes, the steps for a screen reader user to read the comment corresponding to a highlight in the document are:

1. Select the text in the document containing one or more highlights
2. Press the "s" shortcut
3. The annotation card corresponding to the first highlight will be focused in the sidebar. The user can then tell their screen reader to read the contents of the card (eg. using Cmd+Option+A in VoiceOver) or browse replies

**Limitations:**

There is a constraint that WebKit-based browsers (eg. Safari) may block step 3 (specifically the `window.focus()` call in the sidebar) if the user has not interacted with the sidebar since it loaded. The only workaround I'm aware of is for users to enter the sidebar frame at least once before they start reading through the document.

**Summary of code changes:**

- Add `setAnnotationFocusRequest`/`clearAnnotationFocusRequest` actions to the store. This specifies an ID of an annotation to be focused in the UI.
- Add a `focusFirstInSelection` flag to the "showAnnotations" message that the guest sends to the sidebar when the "Show" button in the adder is clicked. This flag controls whether the first annotation in the selection is focused. We need this flag because there are several other actions in the guest which cause this message to be sent to the sidebar, and we don't always want them to result in keyboard focus being transferred to the sidebar.
- Handle the focus flag in `FrameSyncService` by using `setAnnotationFocusRequest` to create a focus request and calling `window.focus()`
- Respond to the focus flag in `ThreadCard` by  focusing the thread card element, if the thread's ID matches the focus request in the store. Once the request has been handled, it is cleared in the store.

**Related work:**

There isn't currently a convenient way to navigate from the sidebar back to exactly where the highlights are in the document,  although it is possible to scroll to the approximate region by clicking on a card. I think we'll probably want to add some shortcut for this.

A code clarity issue is that we have several existing ways in which annotations can be "focused" in the sidebar that don't mean "giving the annotation keyboard focus". These include when a user hovers a highlight and we change the styling of the corresponding annotation card, as well as when we "focus" on a particular user's annotations in the LMS. Using the term focus for several different concepts is going to cause confusion. I plan some renaming, of at least the actions/state related to hovering an annotation, to address this.

Fixes https://github.com/hypothesis/client/issues/4741
