### PR TITLE
Use "hovered" instead of "focused" to refer to hovered annotations/highlights

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -229,13 +229,13 @@ export class Guest {
     this._setupElementEvents();
 
     /**
-     * Tags of currently focused annotations. This is used to set the focused
+     * Tags of currently hovered annotations. This is used to set the hovered
      * state correctly for new highlights if the associated annotation is already
-     * focused in the sidebar.
+     * hovered in the sidebar.
      *
      * @type {Set<string>}
      */
-    this._focusedAnnotations = new Set();
+    this._hoveredAnnotations = new Set();
   }
 
   // Add DOM event listeners for clicks, taps etc. on the document and
@@ -279,13 +279,13 @@ export class Guest {
     this._listeners.add(this.element, 'mouseover', ({ target }) => {
       const tags = annotationsAt(/** @type {Element} */ (target));
       if (tags.length && this._highlightsVisible) {
-        this._sidebarRPC.call('focusAnnotations', tags);
+        this._sidebarRPC.call('hoverAnnotations', tags);
       }
     });
 
     this._listeners.add(this.element, 'mouseout', () => {
       if (this._highlightsVisible) {
-        this._sidebarRPC.call('focusAnnotations', []);
+        this._sidebarRPC.call('hoverAnnotations', []);
       }
     });
 
@@ -333,9 +333,9 @@ export class Guest {
     this._hostRPC.on('createAnnotation', () => this.createAnnotation());
 
     this._hostRPC.on(
-      'focusAnnotations',
+      'hoverAnnotations',
       /** @param {string[]} tags */
-      tags => this._focusAnnotations(tags)
+      tags => this._hoverAnnotations(tags)
     );
 
     this._hostRPC.on(
@@ -382,9 +382,9 @@ export class Guest {
     // Handlers for events sent when user hovers or clicks on an annotation card
     // in the sidebar.
     this._sidebarRPC.on(
-      'focusAnnotations',
+      'hoverAnnotations',
       /** @param {string[]} tags */
-      tags => this._focusAnnotations(tags)
+      tags => this._hoverAnnotations(tags)
     );
 
     this._sidebarRPC.on(
@@ -538,7 +538,7 @@ export class Guest {
       });
       anchor.highlights = highlights;
 
-      if (this._focusedAnnotations.has(anchor.annotation.$tag)) {
+      if (this._hoveredAnnotations.has(anchor.annotation.$tag)) {
         setHighlightsFocused(highlights, true);
       }
     };
@@ -663,9 +663,9 @@ export class Guest {
    *
    * @param {string[]} tags
    */
-  _focusAnnotations(tags) {
-    this._focusedAnnotations.clear();
-    tags.forEach(tag => this._focusedAnnotations.add(tag));
+  _hoverAnnotations(tags) {
+    this._hoveredAnnotations.clear();
+    tags.forEach(tag => this._hoveredAnnotations.add(tag));
 
     for (let anchor of this.anchors) {
       if (anchor.highlights) {
@@ -674,7 +674,7 @@ export class Guest {
       }
     }
 
-    this._sidebarRPC.call('focusAnnotations', tags);
+    this._sidebarRPC.call('hoverAnnotations', tags);
   }
 
   /**
@@ -781,12 +781,12 @@ export class Guest {
   }
 
   /**
-   * Return the tags of annotations that are currently displayed in a focused
+   * Return the tags of annotations that are currently displayed in a hovered
    * state.
    *
    * @return {Set<string>}
    */
-  get focusedAnnotationTags() {
-    return this._focusedAnnotations;
+  get hoveredAnnotationTags() {
+    return this._hoveredAnnotations;
   }
 }

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -142,7 +142,7 @@ export class Sidebar {
       } else {
         this.bucketBar = new BucketBar(this.iframeContainer, {
           onFocusAnnotations: tags =>
-            this._guestRPC.forEach(rpc => rpc.call('focusAnnotations', tags)),
+            this._guestRPC.forEach(rpc => rpc.call('hoverAnnotations', tags)),
           onScrollToClosestOffScreenAnchor: (tags, direction) =>
             this._guestRPC.forEach(rpc =>
               rpc.call('scrollToClosestOffScreenAnchor', tags, direction)

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -220,17 +220,17 @@ describe('Guest', () => {
       });
     });
 
-    describe('on "focusAnnotations" event', () => {
+    describe('on "hoverAnnotations" event', () => {
       it('focus on annotations', () => {
         const guest = createGuest();
-        sandbox.stub(guest, '_focusAnnotations').callThrough();
+        sandbox.stub(guest, '_hoverAnnotations').callThrough();
         const tags = ['t1', 't2'];
         sidebarRPC().call.resetHistory();
 
-        emitHostEvent('focusAnnotations', tags);
+        emitHostEvent('hoverAnnotations', tags);
 
-        assert.calledWith(guest._focusAnnotations, tags);
-        assert.calledWith(sidebarRPC().call, 'focusAnnotations', tags);
+        assert.calledWith(guest._hoverAnnotations, tags);
+        assert.calledWith(sidebarRPC().call, 'hoverAnnotations', tags);
       });
     });
 
@@ -274,8 +274,8 @@ describe('Guest', () => {
   });
 
   describe('events from sidebar frame', () => {
-    describe('on "focusAnnotations" event', () => {
-      it('focuses any annotations with a matching tag', () => {
+    describe('on "hoverAnnotations" event', () => {
+      it('marks associated highlights as focused', () => {
         const highlight0 = document.createElement('span');
         const highlight1 = document.createElement('span');
         const guest = createGuest();
@@ -284,7 +284,7 @@ describe('Guest', () => {
           { annotation: { $tag: 'tag2' }, highlights: [highlight1] },
         ];
 
-        emitSidebarEvent('focusAnnotations', ['tag1']);
+        emitSidebarEvent('hoverAnnotations', ['tag1']);
 
         assert.calledWith(
           highlighter.setHighlightsFocused,
@@ -293,7 +293,7 @@ describe('Guest', () => {
         );
       });
 
-      it('unfocuses any annotations without a matching tag', () => {
+      it('marks highlights of other annotations as not focused', () => {
         const highlight0 = document.createElement('span');
         const highlight1 = document.createElement('span');
         const guest = createGuest();
@@ -302,7 +302,7 @@ describe('Guest', () => {
           { annotation: { $tag: 'tag2' }, highlights: [highlight1] },
         ];
 
-        emitSidebarEvent('focusAnnotations', ['tag1']);
+        emitSidebarEvent('hoverAnnotations', ['tag1']);
 
         assert.calledWith(
           highlighter.setHighlightsFocused,
@@ -311,13 +311,13 @@ describe('Guest', () => {
         );
       });
 
-      it('updates focused tag set', () => {
+      it('updates hovered tag set', () => {
         const guest = createGuest();
 
-        emitSidebarEvent('focusAnnotations', ['tag1']);
-        emitSidebarEvent('focusAnnotations', ['tag2', 'tag3']);
+        emitSidebarEvent('hoverAnnotations', ['tag1']);
+        emitSidebarEvent('hoverAnnotations', ['tag2', 'tag3']);
 
-        assert.deepEqual([...guest.focusedAnnotationTags], ['tag2', 'tag3']);
+        assert.deepEqual([...guest.hoveredAnnotationTags], ['tag2', 'tag3']);
       });
     });
 
@@ -591,13 +591,13 @@ describe('Guest', () => {
       // Hover the highlight
       fakeHighlight.dispatchEvent(new Event('mouseover', { bubbles: true }));
       assert.calledWith(highlighter.getHighlightsContainingNode, fakeHighlight);
-      assert.calledWith(sidebarRPC().call, 'focusAnnotations', [
+      assert.calledWith(sidebarRPC().call, 'hoverAnnotations', [
         'highlight-ann-tag',
       ]);
 
       // Un-hover the highlight
       fakeHighlight.dispatchEvent(new Event('mouseout', { bubbles: true }));
-      assert.calledWith(sidebarRPC().call, 'focusAnnotations', []);
+      assert.calledWith(sidebarRPC().call, 'hoverAnnotations', []);
     });
 
     it('does not focus annotations in the sidebar when a non-highlight element is hovered', () => {
@@ -1157,11 +1157,11 @@ describe('Guest', () => {
       };
       const annotation = { $tag: 'tag1', target: [target] };
 
-      // Focus the annotation (in the sidebar) before it is anchored in the page.
-      const [, focusAnnotationsCallback] = sidebarRPC().on.args.find(
-        args => args[0] === 'focusAnnotations'
+      // Hover the annotation (in the sidebar) before it is anchored in the page.
+      const [, hoverAnnotationsCallback] = sidebarRPC().on.args.find(
+        args => args[0] === 'hoverAnnotations'
       );
-      focusAnnotationsCallback([annotation.$tag]);
+      hoverAnnotationsCallback([annotation.$tag]);
       const anchors = await guest.anchor(annotation);
 
       // Check that the new highlights are already in the focused state.

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -1007,7 +1007,7 @@ describe('Sidebar', () => {
       assert.isNull(sidebar.bucketBar);
     });
 
-    it('calls the "focusAnnotations" RPC method', () => {
+    it('calls the "hoverAnnotations" RPC method', () => {
       const sidebar = createSidebar();
       connectGuest(sidebar);
       const { onFocusAnnotations } = FakeBucketBar.getCall(0).args[1];
@@ -1015,7 +1015,7 @@ describe('Sidebar', () => {
 
       onFocusAnnotations(tags);
 
-      assert.calledWith(guestRPC().call, 'focusAnnotations', tags);
+      assert.calledWith(guestRPC().call, 'hoverAnnotations', tags);
     });
 
     it('calls the "scrollToClosestOffScreenAnchor" RPC method', () => {

--- a/src/sidebar/components/Annotation/Annotation.js
+++ b/src/sidebar/components/Annotation/Annotation.js
@@ -77,7 +77,7 @@ function Annotation({
   const draft = store.getDraft(annotation);
   const userid = store.profile().userid;
 
-  const isFocused = store.isAnnotationFocused(annotation.$tag);
+  const isHovered = store.isAnnotationHovered(annotation.$tag);
   const isSaving = store.isSavingAnnotation(annotation);
 
   const isEditing = !!draft && !isSaving;
@@ -119,7 +119,7 @@ function Annotation({
       {annotationQuote && (
         <AnnotationQuote
           quote={annotationQuote}
-          isFocused={isFocused}
+          isHovered={isHovered}
           isOrphan={isOrphan(annotation)}
         />
       )}

--- a/src/sidebar/components/Annotation/AnnotationQuote.js
+++ b/src/sidebar/components/Annotation/AnnotationQuote.js
@@ -13,7 +13,7 @@ import StyledText from '../StyledText';
 /**
  * @typedef AnnotationQuoteProps
  * @prop {string} quote
- * @prop {boolean} [isFocused]
+ * @prop {boolean} [isHovered]
  * @prop {boolean} [isOrphan]
  * @prop {SidebarSettings} settings
  */
@@ -23,13 +23,13 @@ import StyledText from '../StyledText';
  *
  * @param {AnnotationQuoteProps} props
  */
-function AnnotationQuote({ quote, isFocused, isOrphan, settings }) {
+function AnnotationQuote({ quote, isHovered, isOrphan, settings }) {
   return (
     <Excerpt collapsedHeight={35} inlineControls={true} overflowThreshold={20}>
       <StyledText classes={classnames({ 'p-redacted-text': isOrphan })}>
         <blockquote
           className={classnames('hover:border-l-blue-quote', {
-            'border-l-blue-quote': isFocused,
+            'border-l-blue-quote': isHovered,
           })}
           style={applyTheme(['selectionFontFamily'], settings)}
         >

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -56,7 +56,7 @@ describe('Annotation', () => {
     fakeStore = {
       defaultAuthority: sinon.stub().returns('example.com'),
       getDraft: sinon.stub().returns(null),
-      isAnnotationFocused: sinon.stub().returns(false),
+      isAnnotationHovered: sinon.stub().returns(false),
       isFeatureEnabled: sinon
         .stub()
         .withArgs('client_display_names')
@@ -107,12 +107,12 @@ describe('Annotation', () => {
       assert.isTrue(quote.exists());
     });
 
-    it('sets the quote to "focused" if annotation is currently focused', () => {
-      fakeStore.isAnnotationFocused.returns(true);
+    it('sets the quote to hovered if annotation is currently hovered', () => {
+      fakeStore.isAnnotationHovered.returns(true);
       fakeMetadata.quote.returns('quote');
       const wrapper = createComponent();
 
-      assert.isTrue(wrapper.find('AnnotationQuote').props().isFocused);
+      assert.isTrue(wrapper.find('AnnotationQuote').props().isHovered);
     });
 
     it('does not render quote if annotation does not have a quote', () => {

--- a/src/sidebar/components/Annotation/test/AnnotationQuote-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationQuote-test.js
@@ -12,7 +12,7 @@ describe('AnnotationQuote', () => {
     return mount(
       <AnnotationQuote
         quote={'test quote'}
-        isFocused={false}
+        isHovered={false}
         isOrphan={false}
         settings={{}}
         {...props}

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -117,7 +117,7 @@ function SidebarView({
   // and focus it
   useEffect(() => {
     if (linkedAnnotationAnchorTag) {
-      frameSync.focusAnnotations([linkedAnnotationAnchorTag]);
+      frameSync.hoverAnnotations([linkedAnnotationAnchorTag]);
       frameSync.scrollToAnnotation(linkedAnnotationAnchorTag);
       store.selectTab(directLinkedTab);
     } else if (linkedAnnotation) {

--- a/src/sidebar/components/ThreadCard.js
+++ b/src/sidebar/components/ThreadCard.js
@@ -27,14 +27,14 @@ import Thread from './Thread';
 function ThreadCard({ frameSync, thread }) {
   const store = useSidebarStore();
   const threadTag = thread.annotation?.$tag ?? null;
-  const isFocused = threadTag && store.isAnnotationFocused(threadTag);
+  const isHovered = threadTag && store.isAnnotationHovered(threadTag);
   const focusThreadAnnotation = useMemo(
     () =>
       debounce(
         /** @param {string|null} tag */
         tag => {
           const focusTags = tag ? [tag] : [];
-          frameSync.focusAnnotations(focusTags);
+          frameSync.hoverAnnotations(focusTags);
         },
         10
       ),
@@ -67,7 +67,7 @@ function ThreadCard({ frameSync, thread }) {
     /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
     <Card
       classes={classnames('p-3 cursor-pointer', {
-        'is-focused': isFocused,
+        'is-hovered': isHovered,
       })}
       data-testid="thread-card"
       onClick={e => {

--- a/src/sidebar/components/test/SidebarView-test.js
+++ b/src/sidebar/components/test/SidebarView-test.js
@@ -26,7 +26,7 @@ describe('SidebarView', () => {
 
   beforeEach(() => {
     fakeFrameSync = {
-      focusAnnotations: sinon.stub(),
+      hoverAnnotations: sinon.stub(),
       scrollToAnnotation: sinon.stub(),
     };
     fakeLoadAnnotationsService = {
@@ -147,9 +147,9 @@ describe('SidebarView', () => {
         createComponent();
         assert.calledOnce(fakeFrameSync.scrollToAnnotation);
         assert.calledWith(fakeFrameSync.scrollToAnnotation, 'myTag');
-        assert.calledOnce(fakeFrameSync.focusAnnotations);
+        assert.calledOnce(fakeFrameSync.hoverAnnotations);
         assert.calledWith(
-          fakeFrameSync.focusAnnotations,
+          fakeFrameSync.hoverAnnotations,
           sinon.match(['myTag'])
         );
       });

--- a/src/sidebar/components/test/ThreadCard-test.js
+++ b/src/sidebar/components/test/ThreadCard-test.js
@@ -22,11 +22,11 @@ describe('ThreadCard', () => {
   beforeEach(() => {
     fakeDebounce = sinon.stub().returnsArg(0);
     fakeFrameSync = {
-      focusAnnotations: sinon.stub(),
+      hoverAnnotations: sinon.stub(),
       scrollToAnnotation: sinon.stub(),
     };
     fakeStore = {
-      isAnnotationFocused: sinon.stub().returns(false),
+      isAnnotationHovered: sinon.stub().returns(false),
       route: sinon.stub(),
     };
 
@@ -51,12 +51,12 @@ describe('ThreadCard', () => {
     assert(wrapper.find('Thread').props().thread === fakeThread);
   });
 
-  it('applies a focused CSS class if the annotation thread is focused', () => {
-    fakeStore.isAnnotationFocused.returns(true);
+  it('applies a hovered CSS class if the annotation thread is hovered', () => {
+    fakeStore.isAnnotationHovered.returns(true);
 
     const wrapper = createComponent();
 
-    assert.isTrue(wrapper.find(threadCardSelector).hasClass('is-focused'));
+    assert.isTrue(wrapper.find(threadCardSelector).hasClass('is-hovered'));
   });
 
   describe('mouse and click events', () => {
@@ -73,7 +73,7 @@ describe('ThreadCard', () => {
 
       wrapper.find(threadCardSelector).simulate('mouseenter');
 
-      assert.calledWith(fakeFrameSync.focusAnnotations, sinon.match(['myTag']));
+      assert.calledWith(fakeFrameSync.hoverAnnotations, sinon.match(['myTag']));
     });
 
     it('unfocuses the annotation thread when mouse exits', () => {
@@ -81,7 +81,7 @@ describe('ThreadCard', () => {
 
       wrapper.find(threadCardSelector).simulate('mouseleave');
 
-      assert.calledWith(fakeFrameSync.focusAnnotations, sinon.match([]));
+      assert.calledWith(fakeFrameSync.hoverAnnotations, sinon.match([]));
     });
 
     ['button', 'a'].forEach(tag => {

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -373,9 +373,9 @@ export class FrameSyncService {
     );
 
     guestRPC.on(
-      'focusAnnotations',
+      'hoverAnnotations',
       /** @param {string[]} tags */ tags => {
-        this._store.focusAnnotations(tags || []);
+        this._store.hoverAnnotations(tags || []);
       }
     );
 
@@ -489,16 +489,16 @@ export class FrameSyncService {
   }
 
   /**
-   * Focus annotations with the given $tags.
+   * Mark annotations as hovered.
    *
-   * This is used to indicate the highlight in the document that corresponds to
-   * a given annotation in the sidebar.
+   * This is used to indicate the highlights in the document that correspond
+   * to hovered annotations in the sidebar.
    *
    * @param {string[]} tags - annotation $tags
    */
-  focusAnnotations(tags) {
-    this._store.focusAnnotations(tags);
-    this._guestRPC.forEach(rpc => rpc.call('focusAnnotations', tags));
+  hoverAnnotations(tags) {
+    this._store.hoverAnnotations(tags);
+    this._guestRPC.forEach(rpc => rpc.call('hoverAnnotations', tags));
   }
 
   /**

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -133,7 +133,7 @@ describe('FrameSyncService', () => {
         },
 
         findIDsForTags: sinon.stub(),
-        focusAnnotations: sinon.stub(),
+        hoverAnnotations: sinon.stub(),
         isLoggedIn: sinon.stub().returns(false),
         openSidebarPanel: sinon.stub(),
         selectAnnotations: sinon.stub(),
@@ -665,7 +665,7 @@ describe('FrameSyncService', () => {
     });
   });
 
-  describe('on "focusAnnotations" message', () => {
+  describe('on "hoverAnnotations" message', () => {
     beforeEach(async () => {
       frameSync.connect();
       await connectGuest();
@@ -673,8 +673,8 @@ describe('FrameSyncService', () => {
 
     it('focuses the annotations', () => {
       frameSync.connect();
-      emitGuestEvent('focusAnnotations', ['tag1', 'tag2', 'tag3']);
-      assert.calledWith(fakeStore.focusAnnotations, ['tag1', 'tag2', 'tag3']);
+      emitGuestEvent('hoverAnnotations', ['tag1', 'tag2', 'tag3']);
+      assert.calledWith(fakeStore.hoverAnnotations, ['tag1', 'tag2', 'tag3']);
     });
   });
 
@@ -730,25 +730,25 @@ describe('FrameSyncService', () => {
     });
   });
 
-  describe('#focusAnnotations', () => {
+  describe('#hoverAnnotations', () => {
     beforeEach(async () => {
       frameSync.connect();
       await connectGuest();
     });
 
     it('should update the focused annotations in the store', () => {
-      frameSync.focusAnnotations(['a1', 'a2']);
+      frameSync.hoverAnnotations(['a1', 'a2']);
       assert.calledWith(
-        fakeStore.focusAnnotations,
+        fakeStore.hoverAnnotations,
         sinon.match.array.deepEquals(['a1', 'a2'])
       );
     });
 
     it('should focus the associated highlights in the guest', () => {
-      frameSync.focusAnnotations([1, 2]);
+      frameSync.hoverAnnotations([1, 2]);
       assert.calledWith(
         guestRPC().call,
-        'focusAnnotations',
+        'hoverAnnotations',
         sinon.match.array.deepEquals([1, 2])
       );
     });

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -106,12 +106,14 @@ const initialState = {
    */
   annotations: [],
   /**
-   * A set of annotations that are currently "focused" — e.g. hovered over in
-   * the UI.
+   * Annotations whose cards or highlights are currently hovered.
+   *
+   * The styling of the highlights/cards of these annotations are adjusted to
+   * show the correspondence between the two.
    *
    * @type {Record<string, boolean>}
    */
-  focused: {},
+  hovered: {},
   /**
    * A map of annotations that should appear as "highlighted", e.g. the
    * target of a single-annotation view
@@ -177,15 +179,15 @@ const reducers = {
   },
 
   CLEAR_ANNOTATIONS() {
-    return { annotations: [], focused: {}, highlighted: {} };
+    return { annotations: [], highlighted: {}, hovered: {} };
   },
 
   /**
    * @param {State} state
-   * @param {{ focusedTags: string[] }} action
+   * @param {{ tags: string[] }} action
    */
-  FOCUS_ANNOTATIONS(state, action) {
-    return { focused: toTrueMap(action.focusedTags) };
+  HOVER_ANNOTATIONS(state, action) {
+    return { hovered: toTrueMap(action.tags) };
   },
 
   /**
@@ -354,14 +356,13 @@ function clearAnnotations() {
 }
 
 /**
- * Replace the current set of focused annotations with the annotations
- * identified by `tags`. All provided annotations (`tags`) will be set to
- * `true` in the `focused` map.
+ * Replace the current set of hovered annotations with the annotations
+ * identified by `tags`.
  *
- * @param {string[]} tags - Identifiers of annotations to focus
+ * @param {string[]} tags
  */
-function focusAnnotations(tags) {
-  return makeAction(reducers, 'FOCUS_ANNOTATIONS', { focusedTags: tags });
+function hoverAnnotations(tags) {
+  return makeAction(reducers, 'HOVER_ANNOTATIONS', { tags });
 }
 
 /**
@@ -512,12 +513,12 @@ function findIDsForTags(state, tags) {
 }
 
 /**
- * Retrieve currently-focused annotation identifiers
+ * Retrieve currently-hovered annotation identifiers
  */
-const focusedAnnotations = createSelector(
+const hoveredAnnotations = createSelector(
   /** @param {State} state */
-  state => state.focused,
-  focused => trueKeys(focused)
+  state => state.hovered,
+  hovered => trueKeys(hovered)
 );
 
 /**
@@ -530,13 +531,13 @@ const highlightedAnnotations = createSelector(
 );
 
 /**
- * Is the annotation referenced by `$tag` currently focused?
+ * Is the annotation identified by `$tag` currently hovered?
  *
  * @param {State} state
  * @param {string} $tag
  */
-function isAnnotationFocused(state, $tag) {
-  return state.focused[$tag] === true;
+function isAnnotationHovered(state, $tag) {
+  return state.hovered[$tag] === true;
 }
 
 /**
@@ -606,7 +607,7 @@ export const annotationsModule = createStoreModule(initialState, {
   actionCreators: {
     addAnnotations,
     clearAnnotations,
-    focusAnnotations,
+    hoverAnnotations,
     hideAnnotation,
     highlightAnnotations,
     removeAnnotations,
@@ -620,9 +621,9 @@ export const annotationsModule = createStoreModule(initialState, {
     annotationExists,
     findAnnotationByID,
     findIDsForTags,
-    focusedAnnotations,
+    hoveredAnnotations,
     highlightedAnnotations,
-    isAnnotationFocused,
+    isAnnotationHovered,
     isWaitingToAnchorAnnotations,
     newAnnotations,
     newHighlights,

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -151,33 +151,33 @@ describe('sidebar/store/modules/annotations', () => {
       it('should clear annotations and annotation state from the store', () => {
         const annot = fixtures.defaultAnnotation();
         store.addAnnotations([annot]);
-        store.focusAnnotations([annot.id]);
+        store.hoverAnnotations([annot.id]);
         store.highlightAnnotations([annot.id]);
 
         store.clearAnnotations();
 
         assert.isEmpty(store.getState().annotations.annotations);
-        assert.isEmpty(store.focusedAnnotations());
+        assert.isEmpty(store.hoveredAnnotations());
         assert.isEmpty(store.highlightedAnnotations());
       });
     });
 
-    describe('focusAnnotations', () => {
+    describe('hoverAnnotations', () => {
       it('adds the provided annotation IDs to the focused annotations', () => {
-        store.focusAnnotations(['1', '2', '3']);
-        assert.deepEqual(store.focusedAnnotations(), ['1', '2', '3']);
+        store.hoverAnnotations(['1', '2', '3']);
+        assert.deepEqual(store.hoveredAnnotations(), ['1', '2', '3']);
       });
 
       it('replaces any other focused annotation IDs', () => {
-        store.focusAnnotations(['1']);
-        store.focusAnnotations(['2', '3']);
-        assert.deepEqual(store.focusedAnnotations(), ['2', '3']);
+        store.hoverAnnotations(['1']);
+        store.hoverAnnotations(['2', '3']);
+        assert.deepEqual(store.hoveredAnnotations(), ['2', '3']);
       });
 
       it('sets focused annotations to an empty object if no IDs provided', () => {
-        store.focusAnnotations(['1']);
-        store.focusAnnotations([]);
-        assert.isEmpty(store.focusedAnnotations());
+        store.hoverAnnotations(['1']);
+        store.hoverAnnotations([]);
+        assert.isEmpty(store.hoveredAnnotations());
       });
     });
 
@@ -198,14 +198,14 @@ describe('sidebar/store/modules/annotations', () => {
       });
     });
 
-    describe('isAnnotationFocused', () => {
-      it('returns true if the provided annotation ID is in the set of focused annotations', () => {
-        store.focusAnnotations([1, 2]);
-        assert.isTrue(store.isAnnotationFocused(2));
+    describe('isAnnotationHovered', () => {
+      it('returns true if the provided annotation ID is in the set of hovered annotations', () => {
+        store.hoverAnnotations([1, 2]);
+        assert.isTrue(store.isAnnotationHovered(2));
       });
 
-      it('returns false if the provided annotation ID is not in the set of focused annotations', () => {
-        assert.isFalse(store.isAnnotationFocused(2));
+      it('returns false if the provided annotation ID is not in the set of hovered annotations', () => {
+        assert.isFalse(store.isAnnotationHovered(2));
       });
     });
   });

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -33,9 +33,10 @@ export type GuestToSidebarEvent =
   | 'closeSidebar'
 
   /**
-   * The guest is asking the sidebar to focus on certain annotations.
+   * Indicate in the sidebar which annotation cards correspond to hovered
+   * highlights in the guest.
    */
-  | 'focusAnnotations'
+  | 'hoverAnnotations'
 
   /**
    * The guest is asking the sidebar to relay the message to the host to open the sidebar.
@@ -71,9 +72,10 @@ export type HostToGuestEvent =
   | 'clearSelection'
 
   /**
-   * The host informs guests to focus on a set of annotations
+   * Indicate in the guest which highlights correspond to hovered buckets in
+   * the bucket bar.
    */
-  | 'focusAnnotations'
+  | 'hoverAnnotations'
 
   /**
    * The host informs guests to select/toggle on a set of annotations
@@ -115,9 +117,10 @@ export type SidebarToGuestEvent =
   | 'featureFlagsUpdated'
 
   /**
-   * The sidebar is asking the guest(s) to focus on certain annotations.
+   * Indicate in the guest which highlights correspond to hovered annotations
+   * in the sidebar.
    */
-  | 'focusAnnotations'
+  | 'hoverAnnotations'
 
   /**
    * The sidebar is asking the guest(s) to load annotations.


### PR DESCRIPTION
The term "focused" is overloaded as it can refer to several different
states in which an annotation can be specially marked:

 1. When the user hovers an annotation card or the corresponding
    highlights in the document or buckets in the bucket bar

 2. When the annotation card has keyboard focus

 3. When there is a focused user (eg. when grading a student in the LMS
    app) and the annotation belongs to that user

To try and reduce this confusion, use the term "hovered" to refer to
(1). The `focusAnnotations` methods and messages have been renamed
`hoverAnnotations`, which is not strictly accurate as it is the user who
is doing the hovering, but I think it will make sense to readers.

Note that in this PR the `highlighter.js` module still uses the term "focused" for the state that is applied when an annotation is hovered. The modules that deal with annotations or threads all use the term "hovered".

Related Slack thread: https://hypothes-is.slack.com/archives/C1M8NH76X/p1662120636296739