### PR TITLE
Add screenreader-announced keyboard shortcuts for AdderToolbar

### DIFF
--- a/src/annotator/components/AdderToolbar.tsx
+++ b/src/annotator/components/AdderToolbar.tsx
@@ -101,6 +101,46 @@ function ToolbarButton({
   );
 }
 
+/**
+ * Render non-visible content for screen readers to announce adder keyboard
+ * shortcuts and count of annotations associated with the current selection.
+ */
+function AdderToolbarShortcuts({
+  annotationCount,
+  isVisible,
+}: {
+  annotationCount: number;
+  isVisible: boolean;
+}) {
+  return (
+    <div className="sr-only">
+      <span
+        aria-live="polite"
+        aria-atomic="true"
+        role="status"
+        data-testid="annotation-count-announce"
+      >
+        {annotationCount > 0 && (
+          <span>
+            {annotationCount}{' '}
+            {annotationCount === 1 ? 'annotation' : 'annotations'} for this
+            selection.
+          </span>
+        )}
+      </span>
+      <ul aria-live="polite" data-testid="annotate-shortcuts-announce">
+        {isVisible && (
+          <>
+            {annotationCount > 0 && <li>Press {"'S'"} to show annotations.</li>}
+            <li>Press {"'A'"} to annotate.</li>
+            <li>Press {"'H'"} to highlight.</li>
+          </>
+        )}
+      </ul>
+    </div>
+  );
+}
+
 export type Command = 'annotate' | 'highlight' | 'show' | 'hide';
 
 type AdderToolbarProps = {
@@ -240,6 +280,10 @@ export default function AdderToolbar({
         )}
       </div>
       <AdderToolbarArrow arrowDirection={arrowDirection} />
+      <AdderToolbarShortcuts
+        annotationCount={annotationCount}
+        isVisible={isVisible}
+      />
     </div>
   );
 }

--- a/src/annotator/components/AdderToolbar.tsx
+++ b/src/annotator/components/AdderToolbar.tsx
@@ -126,9 +126,7 @@ type AdderToolbarProps = {
  * The toolbar that is displayed above or below selected text in the document,
  * providing options to create annotations or highlights.
  *
-<<<<<<< HEAD:src/annotator/components/AdderToolbar.js
  * @param {AdderToolbarProps} props
-=======
  * The toolbar has nuanced styling for hover. The component structure is:
  *
  * <AdderToolbar>
@@ -159,7 +157,6 @@ type AdderToolbarProps = {
  *   badge will darken when its parent button is hovered, even if it is not
  *   hovered directly.
  *
->>>>>>> 544c8e5c6 (Convert `AdderToolbar` to TypeScript):src/annotator/components/AdderToolbar.tsx
  */
 export default function AdderToolbar({
   arrowDirection,

--- a/src/annotator/components/test/AdderToolbar-test.js
+++ b/src/annotator/components/test/AdderToolbar-test.js
@@ -1,4 +1,68 @@
+import { mount } from 'enzyme';
+
+import AdderToolbar from '../AdderToolbar';
+
+// nb. Most tests for `AdderToolbar` are currently covered by `adder-test.js`.
+// This needs refactoring to test the `AdderToolbar` on its own as a unit.
 describe('AdderToolbar', () => {
-  // nb. Most tests for `AdderToolbar` are currently covered by `adder-test.js`.
-  // This needs refactoring to test the `AdderToolbar` on its own as a unit.
+  const createComponent = props =>
+    mount(
+      <AdderToolbar
+        direction="up"
+        annotationCount={0}
+        onCommand={() => {}}
+        isVisible={true}
+        {...props}
+      />
+    );
+
+  describe('keyboard shortcut content for screen readers', () => {
+    it('renders keyboard shortcuts for annotate and highlight actions', () => {
+      const wrapper = createComponent();
+      const shortcutListItems = wrapper
+        .find('[data-testid="annotate-shortcuts-announce"]')
+        .find('li');
+
+      assert.equal(shortcutListItems.length, 2);
+      assert.include(shortcutListItems.at(0).text(), 'annotate');
+      assert.include(shortcutListItems.at(1).text(), 'highlight');
+    });
+
+    it('does not render keyboard shortcut items if adder is not visible', () => {
+      const wrapper = createComponent({ isVisible: false });
+
+      const shortcutListItems = wrapper
+        .find('[data-testid="annotate-shortcuts-announce"]')
+        .find('li');
+
+      assert.equal(shortcutListItems.length, 0);
+    });
+
+    it('renders a keyboard shortcut to show annotations when there are annotations to show', () => {
+      const wrapper = createComponent({ annotationCount: 2 });
+      const shortcutListItems = wrapper
+        .find('[data-testid="annotate-shortcuts-announce"]')
+        .find('li');
+
+      assert.equal(shortcutListItems.length, 3);
+      assert.include(shortcutListItems.at(0).text(), 'show annotations');
+    });
+
+    it('renders status information about annotation count when there are annotations to show', () => {
+      const wrapper = createComponent({ annotationCount: 2 });
+      const annotationCountStatus = wrapper.find(
+        '[data-testid="annotation-count-announce"]'
+      );
+      assert.include(annotationCountStatus.text(), '2 annotations');
+    });
+
+    it('does not render status information about annotation count when there are no annotations', () => {
+      const wrapper = createComponent({ annotationCount: 0 });
+      const annotationCountStatus = wrapper.find(
+        '[data-testid="annotation-count-announce"]'
+      );
+
+      assert.isEmpty(annotationCountStatus.text());
+    });
+  });
 });


### PR DESCRIPTION
This PR adds screen-reader only `aria-live` regions to the `AdderToolbar` to announce keyboard shortcuts for screen readers. The goal is to make these keyboard shortcuts discoverable to users of assistive technology without being too terribly annoying.

The implementation philosophy hews close to [documented intent and behavior of `aria-live` regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) without added cleverness. 

## Initially, these were the announcements

The intended announced content (and what I am observing in Chrome with VoiceOver on MacOS):

* The first time the adder toolbar is shown (i.e. the first time the user selects text in the guest page):
    * If there are (5, in these examples) associated annotations to show: _5 annotations for this selection. Press 's' to show annotations for the selected text. Press 'a' to create an annotation. Press 'h' to highlight._
    * If no annotations (this is the most common case): _Press 'a' to create an annotation. Press 'h' to highlight._
* Subsequent text selections (adder popups):
    * If there are no associated annotations with the selection: no announcement
    * If there are associated annotations with the selection:
        * If this is the first time there have been associated annotations with any selection (i.e. previous selections did not have any associated annotations): _5 annotations for this selection. Press 's' to show annotations for the selected text._
        * Else: _5 annotations for this selection._

## After some feedback, these are the current announcements

_Any_ time the adder is shown:

* If there are associated annotations for the selected text:  _5 annotations for this selection. Press 'S' to show annotations. Press 'A' to annotate. Press 'H' to highlight._
* If no associated annotations: _Press 'A' to annotate. Press 'H' to highlight._

We will want to get user feedback about whether these repeated announcements are troublesome.

Fixes https://github.com/hypothesis/client/issues/4742