### PR TITLE
Enable caching for ESLint and Prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 coverage/
 docs/_build/
 
+.eslintcache
+
 # The client uses Yarn rather than npm to manage the lockfile.
 package-lock.json
 

--- a/package.json
+++ b/package.json
@@ -108,9 +108,9 @@
   "main": "./build/boot.js",
   "scripts": {
     "build": "cross-env NODE_ENV=production gulp build",
-    "lint": "eslint .",
-    "checkformatting": "prettier --check '**/*.{js,scss,ts,tsx,d.ts}'",
-    "format": "prettier --list-different --write '**/*.{js,scss,ts,tsx,d.ts}'",
+    "lint": "eslint --cache .",
+    "checkformatting": "prettier --cache --check '**/*.{js,scss,ts,tsx,d.ts}'",
+    "format": "prettier --cache --list-different --write '**/*.{js,scss,ts,tsx,d.ts}'",
     "test": "gulp test",
     "typecheck": "tsc --build tsconfig.json",
     "report-coverage": "codecov -f coverage/coverage-final.json",


### PR DESCRIPTION
On my system, with up-to-date caches, this reduces the duration of `yarn lint` from ~10s to ~1.5s and `yarn format` from ~7s to ~1.4s.

See https://prettier.io/docs/en/cli.html#--cache and https://eslint.org/docs/latest/user-guide/command-line-interface#caching.