### PR TITLE
Add keyboard shortcut for toggling highlight visibility

### DIFF
--- a/src/annotator/components/Toolbar.js
+++ b/src/annotator/components/Toolbar.js
@@ -46,7 +46,7 @@ function ToolbarButton({ ...buttonProps }) {
  */
 function StatusNotifier({ highlightsVisible }) {
   return (
-    <div className="sr-only" aria-live="polite" data-testid="toolbar-status">
+    <div className="sr-only" role="status" data-testid="toolbar-status">
       {highlightsVisible ? 'Highlights visible' : 'Highlights hidden'}
     </div>
   );

--- a/src/annotator/components/Toolbar.js
+++ b/src/annotator/components/Toolbar.js
@@ -31,6 +31,28 @@ function ToolbarButton({ ...buttonProps }) {
 }
 
 /**
+ * @typedef StatusNotifierProps
+ * @prop {boolean} highlightsVisible
+ */
+
+/**
+ * Hidden component that announces certain Hypothesis states.
+ *
+ * This is useful to inform assistive technology users when these states
+ * have been changed (eg. whether highlights are visible), given that they can
+ * be changed in multiple ways (keyboard shortcuts, toolbar button) etc.
+ *
+ * @param {StatusNotifierProps} props
+ */
+function StatusNotifier({ highlightsVisible }) {
+  return (
+    <div className="sr-only" aria-live="polite" data-testid="toolbar-status">
+      {highlightsVisible ? 'Highlights visible' : 'Highlights hidden'}
+    </div>
+  );
+}
+
+/**
  * @typedef ToolbarProps
  *
  * @prop {() => void} closeSidebar -
@@ -143,6 +165,7 @@ export default function Toolbar({
               onClick={createAnnotation}
             />
           </div>
+          <StatusNotifier highlightsVisible={showHighlights} />
         </>
       )}
     </div>

--- a/src/annotator/components/test/Toolbar-test.js
+++ b/src/annotator/components/test/Toolbar-test.js
@@ -83,6 +83,16 @@ describe('Toolbar', () => {
     assert.calledWith(toggleHighlights);
   });
 
+  it('announces highlight visibility', () => {
+    const wrapper = createToolbar({ showHighlights: false });
+
+    const statusEl = wrapper.find('[data-testid="toolbar-status"]');
+    assert.equal(statusEl.text(), 'Highlights hidden');
+
+    wrapper.setProps({ showHighlights: true });
+    assert.equal(statusEl.text(), 'Highlights visible');
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility([

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -295,6 +295,14 @@ export class Sidebar {
         .forEach(rpc => rpc.call('clearSelection'));
     });
 
+    guestRPC.on(
+      'highlightsVisibleChanged',
+      /** @param {boolean} visible */
+      visible => {
+        this.setHighlightsVisible(visible);
+      }
+    );
+
     // The listener will do nothing if the sidebar doesn't have a bucket bar
     // (clean theme)
     const bucketBar = this.bucketBar;

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1414,4 +1414,32 @@ describe('Guest', () => {
       assert.isTrue(guest.sideBySideActive);
     });
   });
+
+  describe('keyboard shortcuts', () => {
+    it('toggles highlights when shortcut is pressed', () => {
+      const guest = createGuest();
+      guest.setHighlightsVisible(true, false /* notifyHost */);
+      assert.equal(guest.highlightsVisible, true);
+
+      guest.element.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          ctrlKey: true,
+          shiftKey: true,
+          key: 'h',
+        })
+      );
+      assert.equal(guest.highlightsVisible, false);
+      assert.calledWith(hostRPC().call, 'highlightsVisibleChanged', false);
+
+      guest.element.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          ctrlKey: true,
+          shiftKey: true,
+          key: 'h',
+        })
+      );
+      assert.equal(guest.highlightsVisible, true);
+      assert.calledWith(hostRPC().call, 'highlightsVisibleChanged', true);
+    });
+  });
 });

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -318,6 +318,18 @@ describe('Sidebar', () => {
       assert.neverCalledWith(guestRPC(1).call, 'clearSelection');
       assert.calledWith(guestRPC(2).call, 'clearSelection');
     });
+
+    it('updates state of highlights-visible button when state is changed in guest', () => {
+      const sidebar = createSidebar();
+      connectGuest(sidebar);
+      assert.isFalse(fakeToolbar.highlightsVisible);
+
+      emitGuestEvent('highlightsVisibleChanged', true);
+      assert.isTrue(fakeToolbar.highlightsVisible);
+
+      emitGuestEvent('highlightsVisibleChanged', false);
+      assert.isFalse(fakeToolbar.highlightsVisible);
+    });
   });
 
   describe('events from sidebar frame', () => {

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -16,7 +16,13 @@ export type GuestToHostEvent =
   /**
    * The guest informs the host that the anchors have been changed in the main annotatable frame.
    */
-  | 'anchorsChanged';
+  | 'anchorsChanged'
+
+  /**
+   * Visibility of highlights was toggled from the guest frame (it can also be
+   * toggled from the host frame).
+   */
+  | 'highlightsVisibleChanged';
 
 /**
  * Events that the guest sends to the sidebar

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -19,8 +19,9 @@ export type GuestToHostEvent =
   | 'anchorsChanged'
 
   /**
-   * Visibility of highlights was toggled from the guest frame (it can also be
-   * toggled from the host frame).
+   * Visibility of highlights was toggled from the guest frame. This event is
+   * not sent if highlights are turned on/off in the frame in response to a
+   * command from the sidebar or host frames.
    */
   | 'highlightsVisibleChanged';
 


### PR DESCRIPTION
Add a keyboard shortcut, Ctrl+Shift+H, for toggling highlight visibility, and announce when highlight visibility changes via an `aria-live` notification. I chose this shortcut as appears to be usable on Windows and Mac in Chrome, Firefox and Safari without conflicting with major OS / browser / PDF.js functions. I originally tried to use a single-character shortcut, but then became aware of a requirement that it must be possible to disable such shortcuts. See https://github.com/hypothesis/client/pull/4793#issuecomment-1248166051.

This provides a convenient way for screen reader users and others to toggle the noise/distraction of highlights on or off. The need is more acute for screen reader users as we announce the start and end of each annotation via hidden "annotation start" and "annotation end" text.

There are three parts to this:

- Add a shortcut handler in `Guest` to toggle highlights when the Ctrl+Shift+H shortcut is pressed
- Announce "Highlights visible" or "Highlights hidden" when visibility is changed. This is implemented via an aria-live element rendered by the `Toolbar` component.

Fixes https://github.com/hypothesis/client/issues/4740.

**Testing:**

1. Annotate an HTML or PDF document with the client
2. Activate screen reader
3. Press Ctrl+Shift+H when the document is focused. Highlights should toggle on/off and "Highlights visible" or "Highlights hidden" should be announced