### PR TITLE
Upload code coverage data to Codecov during CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,3 +24,5 @@ jobs:
         yarn typecheck
     - name: Test
       run: yarn test
+    - name: Upload coverage report
+      run: yarn run report-coverage


### PR DESCRIPTION
This used to be handled by Jenkins, but now needs to be done by GitHub Actions.

Per the notes at https://github.com/codecov/codecov-action#usage, no token is required when uploading reports from GitHub Actions for a public repository.