### PR TITLE
Implement browser extension update trigger after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,8 +120,18 @@ jobs:
       run: scripts/deploy-to-s3.js --bucket ${{ env.S3_BUCKET }}
 
   update-extension:
+    environment: production
     needs: release-prod
     runs-on: ubuntu-latest
     steps:
     - name: Update extension
-      run: echo "TODO - Publish the new version of the extension"
+      uses: actions/github-script@v5
+      with:
+        github-token: ${{ secrets.cross_repo_workflow_trigger_token }}
+        script: |
+          await github.rest.actions.createWorkflowDispatch({
+            owner: 'hypothesis',
+            repo: 'browser-extension',
+            workflow_id: 'update-client.yml',
+            ref: 'main',
+          });


### PR DESCRIPTION
Fill in the steps to trigger the update-client workflow in the browser-extension repository after a new client version is released.

The GITHUB_TOKEN that actions get by default is scoped to the current repo, so a different one is required for cross-repository workflow triggers. There was a discussion around which user or app the token should be associated with, see [1].

[1] https://hypothes-is.slack.com/archives/C4K6M7P5E/p1663845478224189