### PR TITLE
Remove unused .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,0 @@
-# Exclude large local dirs from the Docker build context to make the image build
-# faster.
-
-.git/
-build/
-coverage/
-node_modules/


### PR DESCRIPTION
This is unused since the move from Jenkins to GitHub Actions for CI/CD.