### PR TITLE
Update bump-version.mjs for compatibility with semver v7

### DIFF
--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -6,6 +6,6 @@ import semver from 'semver';
 //   node bump-version.mjs minor 1.2.3  # Outputs 1.3.0
 const partStr = process.argv[2];
 const versionStr = process.argv[3];
-const version = semver(versionStr);
+const version = semver.parse(versionStr);
 version.inc(partStr);
 console.log(version.toString());


### PR DESCRIPTION
The export of this CommonJS module is not a function any more. We currently don't have an explicit dependency on the semver package but get it as a transitive dependency of other packages. We should probably change that.

This issue caused the failure in https://github.com/hypothesis/client/actions/runs/3113608664/jobs/5048508949.