### PR TITLE
Use default environment for update-extension job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,6 @@ jobs:
       run: scripts/deploy-to-s3.js --bucket ${{ env.S3_BUCKET }}
 
   update-extension:
-    environment: production
     needs: release-prod
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Using the "production" environment for the job results in a prompt for approval, which we only want to happen for the actual production release. Using the default environment should allow this job to execute automatically after the production client release.

The secret used by this job has been migrated from being an environment secret to a repository secret.