### PR TITLE
Remove CI status badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 Hypothesis client
 =================
 
-[![Continuous integration](https://github.com/hypothesis/client/workflows/Continuous%20integration/badge.svg?branch=main)][gha]
 [![npm version](https://img.shields.io/npm/v/hypothesis.svg)][npm]
 [![BSD licensed](https://img.shields.io/badge/license-BSD-blue.svg)][license]
 


### PR DESCRIPTION
This badge is no longer working because the CI workflow does not run directly on the `main` branch. Instead the Release workflow runs, and CI is part of that. We could make the badge reference the Release workflow instead, but the badge is now somewhat redundant as check statuses are easily available from the Actions tab on GitHub. This is different than when badges originally became popular, when only third-party CI (eg. Travis) was available.