### PR TITLE
Revert "Bump puppeteer from 18.2.1 to 19.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "postcss": "^8.0.3",
     "preact": "^10.4.0",
     "prettier": "2.7.1",
-    "puppeteer": "^19.0.0",
+    "puppeteer": "^18.0.3",
     "redux": "^4.0.1",
     "redux-thunk": "^2.1.0",
     "reselect": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7037,10 +7037,10 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer-core@19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-19.0.0.tgz#8d0198550e04c7d5e0847200ba257b2a777dbd3b"
-  integrity sha512-OljQ9W5M4cBX68vnOAGbcRkVENDHn6lfj6QYoGsnLQsxPAh6ExTQAhHauwdFdQkhYdDExZFWlKArnBONzeHY+g==
+puppeteer-core@18.2.1:
+  version "18.2.1"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-18.2.1.tgz#9b7827bb2bf478bb615e2c21425e4659555dc1fe"
+  integrity sha512-MRtTAZfQTluz3U2oU/X2VqVWPcR1+94nbA2V6ZrSZRVEwLqZ8eclZ551qGFQD/vD2PYqHJwWOW/fpC721uznVw==
   dependencies:
     cross-fetch "3.1.5"
     debug "4.3.4"
@@ -7053,15 +7053,15 @@ puppeteer-core@19.0.0:
     unbzip2-stream "1.4.3"
     ws "8.9.0"
 
-puppeteer@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-19.0.0.tgz#848986e6ecec37b19cd5a7327ad2fcf1f1cb83fd"
-  integrity sha512-3Ga5IVerQQ2hKU9q7T28RmcUsd8F2kL6cYuPcPCzeclSjmHhGydPBZL/KJKC02sG6J6Wfry85uiWpbkjQ5qBiw==
+puppeteer@^18.0.3:
+  version "18.2.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-18.2.1.tgz#08967cd423efe511ee4c6e3a5c882ffaf2e6bbf3"
+  integrity sha512-7+UhmYa7wxPh2oMRwA++k8UGVDxh3YdWFB52r9C3tM81T6BU7cuusUSxImz0GEYSOYUKk/YzIhkQ6+vc0gHbxQ==
   dependencies:
     https-proxy-agent "5.0.1"
     progress "2.0.3"
     proxy-from-env "1.1.0"
-    puppeteer-core "19.0.0"
+    puppeteer-core "18.2.1"
 
 qjobs@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Reverts hypothesis/client#4874

This update causes CI to fail in GH actions with:

```
[13:55:43] Starting Karma...

START:
17 10 [20](https://github.com/hypothesis/client/actions/runs/3265732944/jobs/5368414189#step:8:21)22 13:55:43.690:INFO [karma-server]: Karma v6.4.1 server started at http://localhost:9876/
17 10 2022 13:55:43.692:INFO [launcher]: Launching browsers ChromeHeadless_Custom with concurrency unlimited
17 10 2022 13:55:43.786:INFO [launcher]: Starting browser ChromeHeadless
17 10 2022 13:55:43.835:ERROR [launcher]: Cannot start ChromeHeadless
	Can not find the binary /home/runner/.cache/puppeteer/chrome/linux-1045629/chrome-linux/chrome
	Please set env variable CHROME_BIN
17 10 2022 13:55:43.835:ERROR [launcher]: ChromeHeadless stdout: 
17 10 2022 13:55:43.835:ERROR [launcher]: ChromeHeadless stderr: 

Finished in 0 secs / 0 secs @ 13:55:43 GMT+0000 (Coordinated Universal Time)

[13:55:43] '<anonymous>' errored after 30 s
[13:55:43] Error: Karma run failed with status 1
    at file:///home/runner/work/client/client/node_modules/@hypothesis/frontend-build/lib/tests.js:78:16
    at removeAllListeners (/home/runner/work/client/client/node_modules/karma/lib/server.js:468:9)
    at /home/runner/work/client/client/node_modules/karma/lib/server.js:475:9
    at Server.close (node:net:1767:9)
    at Object.onceWrapper (node:events:627:28)
    at Server.emit (node:events:525:35)
    at Server.emit (node:domain:552:15)
    at emitCloseNT (node:net:1820:8)
    at processTicksAndRejections (node:internal/process/task_queues:82:[21](https://github.com/hypothesis/client/actions/runs/3265732944/jobs/5368414189#step:8:22))
[13:55:43] 'test' errored after [30](https://github.com/hypothesis/client/actions/runs/3265732944/jobs/5368414189#step:8:31) s
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 1.
```

A few notes:

* Tests are running fine locally for me on Mac M1 (Chrome Headless launches fine) with this change (i.e. my local environment is not affected by this). This is still the case if I blow away `node_modules` first.
* We _are_ setting `CHROME_BIN` in `karma.config.js`: `process.env.CHROME_BIN = require('puppeteer').executablePath();`. 
* I am unclear on what makes our Chrome Headless "Custom" (`browsers: ['ChromeHeadless_Custom'],`) so it would be good to fill that knowledge gap.
* There is change to cache paths in this puppeteer release: that may be relevant: https://github.com/puppeteer/puppeteer/pull/9095