### PR TITLE
Mini-Prototype: Apply different colors to different "clusters" of anchor highlights in HTML documents

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -1,3 +1,5 @@
+import classnames from 'classnames';
+
 import { ListenerCollection } from '../shared/listener-collection';
 import { PortFinder, PortRPC } from '../shared/messaging';
 import { generateHexString } from '../shared/random';
@@ -542,8 +544,14 @@ export class Guest {
         return;
       }
 
+      const isClustered = !!anchor.annotation?.$cluster;
       const highlights = /** @type {AnnotationHighlight[]} */ (
-        highlightRange(range)
+        highlightRange(
+          range,
+          classnames('hypothesis-highlight', {
+            [`cluster cluster-${anchor.annotation?.$cluster}`]: isClustered,
+          })
+        )
       );
       highlights.forEach(h => {
         h._annotation = anchor.annotation;

--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -1,26 +1,114 @@
-$color-highlight: rgba(255, 255, 60, 0.4);
-$color-highlight-second: rgba(206, 206, 60, 0.4);
-$color-highlight-focused: rgba(156, 230, 255, 0.5);
+@use 'tailwindcss/components';
 
-// Hide content from sighted users but make it visible to screen readers.
-//
-// Resources:
-// - https://webaim.org/techniques/css/invisiblecontent/ (see "CSS clip")
-// - https://cloudfour.com/thinks/see-no-evil-hidden-content-and-accessibility/#showing-additional-content-for-screen-readers
-// - https://tailwindcss.com/docs/screen-readers#screen-reader-only-elements Tailwind's `sr-only` class
-@mixin screen-reader-only {
-  // Take the content out of the normal layout flow.
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  white-space: nowrap;
+body {
+  --hypothesis-color-yellow: #fef9c3;
+  --hypothesis-color-yellow--nested: #fef08a;
 
-  // Visually hide the content and prevent it from interfering with mouse/touch
-  // text selection by clipping it to an empty box. Compared to moving content with
-  // `top`/`left` this is less likely to cause the browser to scroll to a
-  // different part of the page when the hidden text has screen-reader focus.
-  clip: rect(0 0 0 0);
-  overflow: hidden;
+  --hypothesis-color-purple: #ede9fe;
+  --hypothesis-color-orange: #ffedd5;
+  --hypothesis-color-blue: #e0f2fe;
+  --hypothesis-color-green: #d1fae5;
+
+  // Default anchor highlight colors
+  --hypothesis-highlight-color: var(--hypothesis-color-yellow);
+  --hypothesis-highlight-color--second: var(--hypothesis-color-yellow--nested);
+
+  // Color for focused annotations
+  --hypothesis-highlight-color--focused: var(--hypothesis-color-blue);
+
+  // Default colors for anchor clusters
+  --hypothesis-cluster-all: var(--hypothesis-color-yellow);
+  --hypothesis-cluster-my-highlights: var(--hypothesis-color-purple);
+  --hypothesis-cluster-my-annotations: var(--hypothesis-color-orange);
+}
+
+// Highlight coloring without clustering
+.hypothesis-highlight {
+  mix-blend-mode: normal;
+  --highlight-color: var(--hypothesis-highlight-color);
+
+  & > .hypothesis-highlight {
+    --highlight-color: var(--hypothesis-highlight-color--second);
+  }
+}
+
+.cluster {
+  mix-blend-mode: normal;
+
+  &.cluster-all {
+    --highlight-color: var(--hypothesis-cluster-all);
+    & > & {
+      mix-blend-mode: multiply;
+    }
+  }
+
+  &.cluster-my-highlights {
+    --highlight-color: var(--hypothesis-cluster-my-highlights);
+    & > & {
+      mix-blend-mode: multiply;
+    }
+  }
+
+  &.cluster-my-annotations {
+    --highlight-color: var(--hypothesis-cluster-my-annotations);
+    & > & {
+      mix-blend-mode: multiply;
+    }
+  }
+
+  // Disable `mix-blend-mode: multiply` to avoid making background colors
+  // too dark when several levels deep
+  & > & > & > & > & {
+    mix-blend-mode: normal;
+  }
+}
+
+.hypothesis-highlights-always-on {
+  .hypothesis-highlight {
+    background-color: var(--highlight-color);
+
+    // For PDFs, we still create highlight elements to wrap the text but the
+    // highlight effect is created by another element.
+    &.is-transparent {
+      background-color: transparent !important;
+    }
+
+    // When an annotation card is hovered in the sidebar, the corresponding
+    // highlights are shown with a "focused" color.
+    &.hypothesis-highlight-focused {
+      mix-blend-mode: normal !important;
+      background-color: var(--hypothesis-highlight-color--focused) !important;
+
+      .hypothesis-highlight {
+        background-color: transparent !important;
+      }
+    }
+
+    cursor: pointer;
+
+    // Make highlights visible to screen readers.
+    // See also - https://developer.paciellogroup.com/blog/2017/12/short-note-on-making-your-mark-more-accessible/.
+    &::before {
+      @apply sr-only;
+
+      // nb. The leading/trailing spaces are intended to ensure the text is treated
+      // as separate words by assistive technologies from the content before/after it.
+      content: ' annotation start ';
+    }
+    &::after {
+      @apply sr-only;
+      content: ' annotation end ';
+    }
+  }
+}
+
+// Prototype: Leaving PDF highlights alone for now
+
+.hypothesis-svg-highlight {
+  // These are untouched
+  --highlight-color: rgba(255, 255, 60, 0.4);
+  --highlight-color--second: rgba(206, 206, 60, 0.4);
+  --highlight-color--focused: rgba(156, 230, 255, 0.5);
 }
 
 // SVG highlights when the "Show Highlights" toggle is turned off.
@@ -32,70 +120,10 @@ $color-highlight-focused: rgba(156, 230, 255, 0.5);
 // of the annotated document when highlights are enabled/disabled.
 .hypothesis-highlights-always-on {
   .hypothesis-svg-highlight {
-    fill: $color-highlight;
-
-    &.is-opaque {
-      fill: yellow;
-    }
+    fill: var(--highlight-color);
 
     &.is-focused {
-      fill: $color-highlight-focused;
-    }
-  }
-
-  .hypothesis-highlight {
-    background-color: $color-highlight;
-
-    // For PDFs, we still create highlight elements to wrap the text but the
-    // highlight effect is created by another element.
-    &.is-transparent {
-      background-color: transparent;
-    }
-
-    cursor: pointer;
-
-    // Make highlights visible to screen readers.
-    // See also - https://developer.paciellogroup.com/blog/2017/12/short-note-on-making-your-mark-more-accessible/.
-    &::before {
-      @include screen-reader-only;
-
-      // nb. The leading/trailing spaces are intended to ensure the text is treated
-      // as separate words by assistive technologies from the content before/after it.
-      content: ' annotation start ';
-    }
-    &::after {
-      @include screen-reader-only;
-      content: ' annotation end ';
-    }
-
-    // Give a highlight inside a larger highlight a different color to stand out.
-    & .hypothesis-highlight {
-      background-color: $color-highlight-second;
-      &.is-transparent {
-        background-color: transparent;
-      }
-
-      // Limit the number of different highlight shades by making highlights
-      // that are 3+ levels deep transparent.
-      //
-      // This was historically done to improve readability in PDFs [1], but that
-      // is no longer an issue as in PDFs highlights are created by drawing
-      // SVGs on top of the <canvas>.
-      //
-      // [1] https://github.com/hypothesis/client/issues/1995.
-      & .hypothesis-highlight {
-        background-color: transparent;
-      }
-    }
-
-    // When an annotation card is hovered in the sidebar, the corresponding
-    // highlights are shown with a "focused" color.
-    &.hypothesis-highlight-focused {
-      background-color: $color-highlight-focused !important;
-
-      .hypothesis-highlight {
-        background-color: transparent !important;
-      }
+      fill: var(--highlight-color--focused);
     }
   }
 }

--- a/src/types/annotator.js
+++ b/src/types/annotator.js
@@ -29,6 +29,9 @@
  * An object representing an annotation in the document.
  *
  * @typedef AnnotationData
+ * @prop {'all'|'my-annotations'|'my-highlights'} [$cluster] - Which cluster of
+ *   anchors this annotation should be placed in by the annotator. Each cluster
+ *   of anchors is styled uniquely. Default `all`.
  * @prop {string} uri
  * @prop {Target[]} target
  * @prop {string} $tag


### PR DESCRIPTION
This mini-prototype satisfies a tech discovery goal for the "Visually-grouped highlights" project. It demonstrates how multiple visual styles may be applied to different "clusters" of anchor highlights in an annotatable document.

In this prototype, the current user's annotations are shown as orange, their highlights as purple and everyone else's content as yellow. 

Prototype disclaimer applies: Code in this branch is prototype quality only. Naming and organization is loose.

### What this explores

* Styling different annotation highlights with different colors and combinations thereof
* Providing clustering hints from the sidebar to the annotator when loading annotations (via a frontend `$cluster` prop on `AnnotationData` objects)
* Using mapped CSS variables for styling, such that these values may be altered dynamically by the app

### Play around with it a bit

* Pull and check out this branch and run `make dev`
* Visit http://localhost:3000/document/doyle or any of your preferred content-rich HTML test documents and make a bunch of annotations and highlights as different users
* Try logging in as different users to see the different combinations of highlight colors
* Try changing the coloring of a cluster of highlights in the browser console to see the mechanism by which our JS will be able to manipulate these values in future iterations.
    * Make all of the current user's annotations and highlights green:
    ```
     document.body.style.setProperty('--hypothesis-cluster-my-highlights', 'var(--hypothesis-color-green)');
     document.body.style.setProperty('--hypothesis-cluster-my-annotations', 'var(--hypothesis-color-green)');
    ```
    * "reset" all of the current user's annotations and highlights to match the default (yellow) color:
    ```
    document.body.style.setProperty('--hypothesis-cluster-my-highlights', 'var(--hypothesis-highlight-color)');
    document.body.style.setProperty('--hypothesis-cluster-my-annotations', 'var(--hypothesis-highlight-color)');
    ```
    * Available colors are `green`, `orange`, `yellow`, `purple` right now

### Known limitations (not part of this exploration):

* Highlight color will be incorrect for newly-created annotations until the page is reloaded
* PDF highlights are still all one color (i.e. PDF anchor cluster styling is not implemented, yet)
* The reduced palette used here is not the proposed palette; it's just a "working palette"
* While the set of colors and the styling/blend mode works "pretty well" for big sets of entangled, nestled anchor highlights belonging to different clusters (see screenshots included here), it is not "tuned" and I'd expect we'll find combinations in which we'll need to make improvements.

### Screenshots

Example of anchor highlight-cluster styling for a pile of 23 nested annotations and highlights by different users, here seen by the user who created the majority of them. This represents a fairly extreme amount of annotation (i.e. probably atypical for a normal document):

<img width="1365" alt="image" src="https://user-images.githubusercontent.com/439947/197239534-07ef0ad6-2fcf-42e6-a353-23a028f74b12.png">

The same set of annotations, viewed by another user (who didn't create as many):

<img width="1364" alt="image" src="https://user-images.githubusercontent.com/439947/197240202-2fc6a2ea-c71a-401c-a998-7626d657f1ca.png">

A more typical set of anchor highlights:

<img width="1367" alt="image" src="https://user-images.githubusercontent.com/439947/197240290-9b62b45c-f0b4-4985-8749-ffc6abf81bf6.png">


