### PR TITLE
Send frame identifier for guests as part of connection setup

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -192,6 +192,7 @@ export class Guest {
     this._portFinder = new PortFinder({
       hostFrame: this._hostFrame,
       source: 'guest',
+      sourceId: this._frameIdentifier ?? undefined,
     });
 
     this.features = new FeatureFlags();
@@ -316,7 +317,6 @@ export class Guest {
     return {
       uri: normalizeURI(uri),
       metadata,
-      frameIdentifier: this._frameIdentifier,
     };
   }
 

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1354,7 +1354,6 @@ describe('Guest', () => {
         title: 'Test title',
         documentFingerprint: 'test-fingerprint',
       },
-      frameIdentifier: null,
     });
   });
 
@@ -1371,7 +1370,6 @@ describe('Guest', () => {
       metadata: {
         title: 'Page 1',
       },
-      frameIdentifier: null,
     });
 
     sidebarRPCCall.resetHistory();
@@ -1386,7 +1384,6 @@ describe('Guest', () => {
       metadata: {
         title: 'Page 2',
       },
-      frameIdentifier: null,
     });
   });
 

--- a/src/shared/messaging/index.ts
+++ b/src/shared/messaging/index.ts
@@ -1,4 +1,6 @@
 export { PortFinder } from './port-finder';
 export { PortProvider } from './port-provider';
 export { PortRPC, installPortCloseWorkaroundForSafari } from './port-rpc';
-export { isMessageEqual } from './port-util';
+export { isMessage, isMessageEqual } from './port-util';
+
+export type { Message } from './port-util';

--- a/src/shared/messaging/port-finder.js
+++ b/src/shared/messaging/port-finder.js
@@ -25,12 +25,14 @@ export class PortFinder {
   /**
    * @param {object} options
    *   @param {Exclude<Frame, 'host'>} options.source - the role of this frame
+   *   @param {string} [options.sourceId] - Identifier for this frame
    *   @param {Window} options.hostFrame - the frame where the `PortProvider` is
    *     listening for messages.
    */
-  constructor({ hostFrame, source }) {
+  constructor({ hostFrame, source, sourceId }) {
     this._hostFrame = hostFrame;
     this._source = source;
+    this._sourceId = sourceId;
     this._listeners = new ListenerCollection();
   }
 
@@ -69,6 +71,7 @@ export class PortFinder {
             frame2: target,
             type: 'request',
             requestId,
+            sourceId: this._sourceId,
           },
           '*'
         );

--- a/src/shared/messaging/port-provider.js
+++ b/src/shared/messaging/port-provider.js
@@ -144,7 +144,7 @@ export class PortProvider {
         return;
       }
 
-      const { frame1, frame2, requestId } = data;
+      const { frame1, frame2, requestId, sourceId } = data;
       const channel = /** @type {Channel} */ (`${frame1}-${frame2}`);
 
       if (!isSourceWindow(source)) {
@@ -183,7 +183,11 @@ export class PortProvider {
           ? this._sidebarHostChannel
           : new MessageChannel();
 
-      const message = { frame1, frame2, type: 'offer', requestId };
+      // The message that is sent to the target frame that the source wants to
+      // connect to, as well as the source frame requesting the connection.
+      // Each message is accompanied by a port for the appropriate end of the
+      // connection.
+      const message = { frame1, frame2, type: 'offer', requestId, sourceId };
 
       // If the source window has an opaque origin [1], `event.origin` will be
       // the string "null". This is not a legal value for the `targetOrigin`

--- a/src/shared/messaging/port-util.js
+++ b/src/shared/messaging/port-util.js
@@ -1,15 +1,21 @@
 /**
- * These types are the used in by `PortProvider` and `PortFinder` for the
- * inter-frame discovery and communication processes.
+ * Message sent by `PortProvider` and `PortFinder` to establish a
+ * MessageChannel-based connection between two frames.
  *
  * @typedef {'guest'|'host'|'notebook'|'sidebar'} Frame
  *
  * @typedef Message
- * @prop {Frame} frame1
- * @prop {Frame} frame2
- * @prop {'offer'|'request'} type
- * @prop {string} requestId - ID of the request. Used to associate `offer`
- *   responses with requests and enable PortProvider to ignore re-sent requests.
+ * @prop {Frame} frame1 - Role of the source frame
+ * @prop {Frame} frame2 - Role of the target frame
+ * @prop {'offer'|'request'} type - Message type. "request" messages are sent
+ *   by the source frame to the host frame to request a connection. "offer"
+ *   messages are sent from the host frame back to the source frame and also
+ *   to the target frame, accompanied by a MessagePort.
+ * @prop {string} requestId - ID of the request. Used to associate "offer"
+ *   messages with their corresponding "request" messages.
+ * @prop {string} [sourceId] - Identifier for the source frame. This is useful
+ *   in cases where multiple source frames with a given role may connect to
+ *   the same destination frame.
  */
 
 /**

--- a/src/shared/messaging/test/port-provider-test.js
+++ b/src/shared/messaging/test/port-provider-test.js
@@ -158,6 +158,7 @@ describe('PortProvider', () => {
         frame2: 'host',
         type: 'request',
         requestId: 'abcdef',
+        sourceId: undefined,
       };
 
       await sendPortFinderRequest({
@@ -178,6 +179,7 @@ describe('PortProvider', () => {
         frame2: 'sidebar',
         type: 'request',
         requestId: 'abcdef',
+        sourceId: undefined,
       };
 
       await sendPortFinderRequest({ data, origin: 'null' });
@@ -193,6 +195,7 @@ describe('PortProvider', () => {
         frame2: 'sidebar',
         type: 'request',
         requestId: 'abcdef',
+        sourceId: undefined,
       };
 
       for (let i = 0; i < 4; ++i) {
@@ -228,6 +231,7 @@ describe('PortProvider', () => {
         frame2: 'sidebar',
         type: 'request',
         requestId: 'ghijkl',
+        sourceId: 'test-frame',
       };
       await sendPortFinderRequest({
         data,


### PR DESCRIPTION
Guest frames pass an identifier for their associated browser frame to the sidebar. The sidebar in turn uses this identifier as a key to refer to different guests in various places (eg. see "frames" module in the store and `FrameSyncService._guestRPC` map). This identifier used to be sent as part of the `documentInfoChanged` message after a guest <-> sidebar connection is established, rather than as part of the initial connection metadata. As a result the sidebar had to invent a temporary ID for the new guest, which was used until it learned the real ID.

This commit simplifies the picture by adding a `sourceId` attribute to frame connection setup messages. This replaces the `frameIdentifier` in the `documentInfoChanged` message, and allows the sidebar to know the final ID of the guest as soon as it connects.

A question you might ask while looking at this is "why does the guest send an identifier to the sidebar at all?", as opposed to having the sidebar invent an identifier itself when a new guest connects. The answer at this point is mostly for historical reasons. However, I _think_ it is going to be useful as a way for a new guest to indicate when it is _replacing_ another guest as opposed to being a new guest. The initial use case for this is that when a user changes chapters in VitalSource, my current plan is that the guest for the new chapter will transparently replace the one for the old frame, in a way that doesn't cause annotations for the book to be reloaded in the sidebar. I'm not completely sure this will be the best solution, but the refactoring in this PR is a useful cleanup regardless.