### PR TITLE
Convert annotator/integrations/vitalsource.js to TypeScript syntax

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,6 +32,7 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-this-alias": "off",
 
     // Enforce consistency in cases where TypeScript supports old and new

--- a/src/annotator/frame-observer.js
+++ b/src/annotator/frame-observer.js
@@ -156,7 +156,7 @@ export function onNextDocumentReady(frame) {
  * next document fully loads (ie. when the frame's `load` event fires).
  *
  * @param {HTMLIFrameElement} frame
- * @param {(...args: [Error]|[null, Document]) => void} callback
+ * @param {(err: Error|null, document?: Document) => void} callback
  * @param {object} options
  *   @param {number} [options.pollInterval]
  * @return {() => void} Callback that unsubscribes from future changes


### PR DESCRIPTION
This is a purely syntactic change, except for a small simplification of a callback type in frame-observer.js. This is in preparation for a bunch of upcoming changes to this integration.