### PR TITLE
Use book or chapter URL in VS integration depending on "book_as_single_document" flag

### DIFF
--- a/src/annotator/features.js
+++ b/src/annotator/features.js
@@ -11,7 +11,7 @@ import { warnOnce } from '../shared/warn-once';
  *
  * @type {string[]}
  */
-const annotatorFlags = ['html_side_by_side'];
+const annotatorFlags = ['book_as_single_document', 'html_side_by_side'];
 
 /**
  * An observable container of feature flags.

--- a/src/annotator/integrations/index.js
+++ b/src/annotator/integrations/index.js
@@ -25,7 +25,9 @@ export function createIntegration(annotator) {
 
   const vsFrameRole = vitalSourceFrameRole();
   if (vsFrameRole === 'content') {
-    return new VitalSourceContentIntegration();
+    return new VitalSourceContentIntegration(document.body, {
+      features: annotator.features,
+    });
   }
 
   return new HTMLIntegration({ features: annotator.features });

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -212,6 +212,7 @@ export class VitalSourceContentIntegration
   private _textLayer?: ImageTextLayer;
 
   constructor(
+    /* istanbul ignore next - defaults are overridden in tests */
     container: HTMLElement = document.body,
     options: { features: IFeatureFlags }
   ) {


### PR DESCRIPTION
**~~Depends on https://github.com/hypothesis/client/pull/4895~~**

Add the plumbing needed to make the VitalSource integration return either the book or chapter URL depending on the value of the "book_as_single_document" flag. Additionally handle changes in this flag after the integration is created by notifying the guest about the URI change.

When the flag is enabled, the "book URL" that is returned is currently a placeholder that will in future be replaced by a real value fetched from the `<mosaic-book>` element in the container frame.

**Testing:**

1. Go to the VitalSource EPUB test page at http://localhost:3000/document/vitalsource-epub. The document URL show in the client's "About this version" panel will be 
http://localhost:3000/document/little-women-1, and will change as you navigate between chapters.
2. Turn on the "book_as_single_document" flag in http://localhost:5000/admin/features
3. Reload the VitalSource EPUB test page. The document URL will now show as https://bookshelf.vitalsource.com/reader/books/1234 and will remain the same as you navigate between chapters.