### PR TITLE
Retrieve VitalSource book ID and metadata from <mosaic-book> element

### DIFF
--- a/dev-server/static/scripts/vitalsource-mosaic-book-element.js
+++ b/dev-server/static/scripts/vitalsource-mosaic-book-element.js
@@ -4,6 +4,9 @@
  *
  * This element is created in the book's container frame, and the element holds
  * the book's current content frame within its Shadow DOM.
+ *
+ * See `src/annotator/integrations/vitalsource.ts` for details of the APIs of
+ * this element which the Hypothesis client relies on.
  */
 export class MosaicBookElement extends HTMLElement {
   constructor() {
@@ -56,6 +59,11 @@ export class MosaicBookElement extends HTMLElement {
     this.setChapter(0, { initialLoad: true });
   }
 
+  /**
+   * Set the currently loaded chapter.
+   *
+   * NOTE: This is a custom API that is not present on the real `<mosaic-book>` element.
+   */
   setChapter(index, { initialLoad = false } = {}) {
     if (index < 0 || index >= this.chapterURLs.length) {
       return;

--- a/dev-server/static/scripts/vitalsource-mosaic-book-element.js
+++ b/dev-server/static/scripts/vitalsource-mosaic-book-element.js
@@ -98,4 +98,24 @@ export class MosaicBookElement extends HTMLElement {
     this.prevButton.disabled = index === 0;
     this.nextButton.disabled = index === this.chapterURLs.length - 1;
   }
+
+  getBookInfo() {
+    const book = this.getAttribute('book');
+
+    if (book === 'little-women') {
+      return {
+        format: 'epub',
+        isbn: '9780451532084',
+        title: 'Little Women',
+      };
+    } else if (book === 'test-pdf') {
+      return {
+        format: 'pbk',
+        isbn: 'TEST-PDF',
+        title: 'Test PDF',
+      };
+    } else {
+      throw new Error('Unknown book ID');
+    }
+  }
 }

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -258,6 +258,7 @@ export class VitalSourceContentIntegration
     const bookElement =
       options.bookElement ?? findBookElement(window.parent.document);
     if (!bookElement) {
+      /* istanbul ignore next */
       throw new Error(
         'Failed to find <mosaic-book> element in container frame'
       );

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -44,8 +44,9 @@ type BookInfo = {
 /**
  * `<mosaic-book>` custom element in the VitalSource container frame.
  *
- * This element has various extra methods that can be used to fetch book
- * metadata, get information about the current location and navigate the book.
+ * This element is part of the VitalSource viewer. It contains the book content
+ * inside a frame within its Shadow DOM, and also has methods that can be used
+ * to fetch book metadata, get the current location and navigate the book.
  */
 type MosaicBookElement = HTMLElement & {
   /** Returns metadata about the currently loaded book. */


### PR DESCRIPTION
When the "book_as_single_document" flag is enabled, retrieve the book ID and title from the `<mosaic-book>` element in the container frame, and use it to populate the URI and metadata for annotations.

**Testing:**

1. When the "book_as_single_document" flag enabled, visit http://localhost:3000/document/vitalsource-epub
2. The document URL shown in the Help panel should be https://bookshelf.vitalsource.com/reader/books/9780451532084
3. Visit http://localhost:3000/document/vitalsource-pdf. The document URL in the Help panel should be 
https://bookshelf.vitalsource.com/reader/books/TEST-PDF.
4. Create an annotation on any chapter in http://localhost:3000/document/vitalsource-epub and open the notebook. The document title displayed for the annotation should be "Little Women".

Note that it is currently expected that annotations for chapters of the EPUB book, other than the one you are on, may orphan. This is because the client currently sends all annotations to the guest, regardless of whether the annotation's chapter matches that of the content frame.