### PR TITLE
Extract shared client-only annotation types

### DIFF
--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -91,7 +91,6 @@ function initializeAnnotation(annotation, tag) {
   }
 
   return Object.assign({}, annotation, {
-    // Flag indicating whether waiting for the annotation to anchor timed out.
     $anchorTimeout: false,
     $tag: annotation.$tag || tag,
     $orphan: orphan,

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -1,7 +1,8 @@
 import type { TinyEmitter } from 'tiny-emitter';
 
-import type { Selector, Target } from './api';
+import type { Annotation, Selector, Target } from './api';
 import type { PDFViewerApplication } from './pdfjs';
+import type { ClientAnnotationData } from './shared';
 
 /**
  * Object representing a region of a document that an annotation
@@ -49,27 +50,13 @@ export type DocumentMetadata = {
 };
 
 /**
- * An object representing an annotation in the document.
+ * A subset of annotation data allowing the representation of an annotation in
+ * the document.
  */
-export type AnnotationData = {
-  uri: string;
-  target: Target[];
-  $tag: string;
-
-  /**
-   * Flag indicating that this annotation was created using the "Highlight" button,
-   * as opposed to "Annotate".
-   */
-  $highlight?: boolean;
-
-  /**
-   * Flag indicating that this annotation was not found in the document.
-   * It is initially `undefined` while anchoring is in progress and then set to
-   * `true` if anchoring failed or `false` if it succeeded.
-   */
-  $orphan?: boolean;
-  document?: DocumentMetadata;
-};
+export type AnnotationData = ClientAnnotationData &
+  Pick<Annotation, 'target' | 'uri'> & {
+    document?: DocumentMetadata;
+  };
 
 /**
  * An object representing the location in a document that an annotation is

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,3 +1,4 @@
+import type { ClientAnnotationData } from './shared';
 /**
  * Type definitions for objects returned from the Hypothesis API.
  *
@@ -84,7 +85,7 @@ export type Target = {
   selector?: Selector[];
 };
 
-export type Annotation = {
+export type Annotation = ClientAnnotationData & {
   /**
    * The server-assigned ID for the annotation. This is only set once the
    * annotation has been saved to the backend.
@@ -145,11 +146,6 @@ export type Annotation = {
   user_info?: {
     display_name: string | null;
   };
-
-  // Properties not present on API objects, but added by client.
-  $highlight?: boolean;
-  $orphan?: boolean;
-  $anchorTimeout?: boolean;
 };
 
 /**

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1,0 +1,28 @@
+/**
+ * Annotation properties not present on API objects, but added by the client
+ */
+export type ClientAnnotationData = {
+  /**
+   * Client-side identifier: set even if annotation does not have a
+   * server-provided `id` (i.e. is unsaved)
+   */
+  $tag: string;
+
+  /**
+   * Flag indicating whether waiting for the annotation to anchor timed out
+   */
+  $anchorTimeout?: boolean;
+
+  /**
+   * Flag indicating that this annotation was created using the "Highlight" button,
+   * as opposed to "Annotate".
+   */
+  $highlight?: boolean;
+
+  /**
+   * Flag indicating that this annotation was not found in the document.
+   * It is initially `undefined` while anchoring is in progress and then set to
+   * `true` if anchoring failed or `false` if it succeeded.
+   */
+  $orphan?: boolean;
+};


### PR DESCRIPTION
This PR extracts annotation properties set by the client into a shared type module and intersects them with annotation-like types in `api` and `annotator`. We'll be adding a new property (`$cluster`) shortly, so this the right time to DRY this out a little.

There is some very evident follow-up work here. As of before, and still in these changes, client-only properties are intersected with server-provided properties to construct the `Annotation` type in `api`. This is kind of wrong: We should distinguish between the annotation properties as owned and returned by the server versus an object representing that plus merged client properties. However, the `api.Annotation` type is so widely used that it'll require a bit of time to address this, so I am deferring it. This is a pre-existing issue, so this PR doesn't introduce _new_ problems.