### PR TITLE
Add `EPUBContentSelector` and `PageSelector` selectors in VitalSource books

### DIFF
--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -42,6 +42,60 @@ type BookInfo = {
 };
 
 /**
+ * Metadata about a segment of a VitalSource book.
+ *
+ * Some VS APIs refer to a segment as a "page" (see
+ * {@link MosaicBookElement.getCurrentPage} but the amount of content in
+ * a segment depends on the book type and publisher. In a PDF-based book,
+ * each segment corresponds to a single page of a PDF. In an EPUB-based book,
+ * a segment is a single "Content Document" within the EPUB. This typically
+ * corresponds to one chapter of the book, but it could be more or less
+ * granular.
+ */
+type PageInfo = {
+  /**
+   * Path of the resource within the book that contains the segment's resources.
+   *
+   * eg. In an EPUB a content document might have a URL such as
+   * "https://jigsaw.vitalsource.com/books/1234/epub/OEBPS/html/chapter06.html". The corresponding
+   * `absoluteURL` entry would be "/books/1234/epub/OEBPS/html/chapter06.html".
+   */
+  absoluteURL: string;
+
+  /**
+   * Identifies the entry in the EPUB's table of contents that corresponds to
+   * this page/segment.
+   *
+   * See https://idpf.org/epub/linking/cfi/#sec-path-res.
+   *
+   * For PDF-based books, VitalSource creates a synthetic CFI which is the page
+   * index, eg. "/1" for the second page.
+   */
+  cfi: string;
+
+  /**
+   * The page label for the first page of the segment. This is the page number
+   * that is displayed in the VitalSource navigation controls when the
+   * chapter is scrolled to the top.
+   */
+  page: string;
+
+  /**
+   * Index of the current segment within the sequence of pages or content
+   * documents that make up the book.
+   */
+  index: number;
+
+  /**
+   * Title of the entry in the table of contents that refers to the current
+   * segment. For PDF-based books, a chapter will often have multiple pages
+   * and all these pages will have the same title. In EPUBs, each content
+   * document will typically have a different title.
+   */
+  chapterTitle: string;
+};
+
+/**
  * `<mosaic-book>` custom element in the VitalSource container frame.
  *
  * This element is part of the VitalSource viewer. It contains the book content
@@ -51,6 +105,12 @@ type BookInfo = {
 type MosaicBookElement = HTMLElement & {
   /** Returns metadata about the currently loaded book. */
   getBookInfo(): BookInfo;
+
+  /**
+   * Returns metadata about the current page (in a PDF-based book) or
+   * chapter/segment (in an EPUB-based book).
+   */
+  getCurrentPage(): Promise<PageInfo>;
 };
 
 /**
@@ -352,8 +412,34 @@ export class VitalSourceContentIntegration
     return this._htmlIntegration.anchor(root, selectors);
   }
 
-  describe(root: HTMLElement, range: Range) {
-    return this._htmlIntegration.describe(root, range);
+  async describe(root: HTMLElement, range: Range) {
+    const selectors: Selector[] = this._htmlIntegration.describe(root, range);
+    if (!this._bookIsSingleDocument()) {
+      return selectors;
+    }
+
+    const pageInfo = await this._bookElement.getCurrentPage();
+    const extraSelectors: Selector[] = [
+      {
+        type: 'EPUBContentSelector',
+        cfi: pageInfo.cfi,
+        url: pageInfo.absoluteURL,
+        title: pageInfo.chapterTitle,
+      },
+    ];
+
+    const bookInfo = this._bookElement.getBookInfo();
+    if (bookInfo.format === 'pbk') {
+      extraSelectors.push({
+        type: 'PageSelector',
+        index: pageInfo.index,
+        label: pageInfo.page,
+      });
+    }
+
+    selectors.push(...extraSelectors);
+
+    return selectors;
   }
 
   contentContainer() {

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -419,6 +419,10 @@ export class VitalSourceContentIntegration
     }
 
     const pageInfo = await this._bookElement.getCurrentPage();
+
+    // We generate an "EPUBContentSelector" with a CFI for all VS books,
+    // although for PDF-based books the CFI is a string generated from the
+    // page number.
     const extraSelectors: Selector[] = [
       {
         type: 'EPUBContentSelector',
@@ -428,6 +432,11 @@ export class VitalSourceContentIntegration
       },
     ];
 
+    // If this is a PDF-based book, add a page selector. PDFs always have page
+    // numbers available. EPUB-based books _may_ have information about how
+    // content maps to page numbers in a printed edition of the book. We
+    // currently limit page number selectors to PDFs until more is understood
+    // about when EPUB page numbers are reliable/likely to remain stable.
     const bookInfo = this._bookElement.getBookInfo();
     if (bookInfo.format === 'pbk') {
       extraSelectors.push({

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -69,10 +69,64 @@ export type RangeSelector = {
 };
 
 /**
+ * Selector which identifies the Content Document within an EPUB that an
+ * annotation was made in.
+ */
+export type EPUBContentSelector = {
+  type: 'EPUBContentSelector';
+
+  /**
+   * URL of the content document. This can either be an absolute HTTP URL, or
+   * a URL that is relative to the root of the EPUB.
+   */
+  url: string;
+
+  /**
+   * EPUB Canonical Fragment Identifier for the table of contents entry that
+   * corresponds to the content document.
+   */
+  cfi?: string;
+
+  /** Title of the content document. */
+  title?: string;
+};
+
+/**
+ * Selector which identifies the page of a document that an annotation was made
+ * on.
+ *
+ * This selector is only applicable for document types where the association of
+ * content and page numbers can be done in a way that is independent of the
+ * viewer and display settings. This includes inherently paginated documents
+ * such as PDFs, but also content such as EPUBs when they include information
+ * about the location of page breaks in printed versions of a book. It does
+ * not include ordinary web pages or EPUBs without page break information
+ * however.
+ */
+export type PageSelector = {
+  type: 'PageSelector';
+
+  /** The zero-based index of the page in the document's page sequence. */
+  index: number;
+
+  /**
+   * Either the page number that is displayed on the page, or the 1-based
+   * number of the page in the document's page sequence, if the pages do not
+   * have numbers on them.
+   */
+  label?: string;
+};
+
+/**
  * Serialized representation of a region of a document which an annotation
  * pertains to.
  */
-export type Selector = TextQuoteSelector | TextPositionSelector | RangeSelector;
+export type Selector =
+  | TextQuoteSelector
+  | TextPositionSelector
+  | RangeSelector
+  | EPUBContentSelector
+  | PageSelector;
 
 /**
  * An entry in the `target` field of an annotation which identifies the document


### PR DESCRIPTION
This PR introduces two new selector types, `EPUBContentSelector` and `PageSelector`, and changes the VitalSource integration to capture them. The `EPUBContentSelector` selector is specific to EPUBs (but not VitalSource), and identifies the Content Document within an EPUB that an annotation was made on. It includes the [CFI](https://idpf.org/epub/linking/cfi/) of the current content document, as well as the URL of the document within the book and the title. `PageSelector` is applicable for any document types which have a fixed division into a sequence of pages, such as PDFs or VitalSource books created from PDFs. We _may_ be able to use `PageSelector` selectors for EPUBs, but only if they include information about the location of page breaks in printed editions of the book, as opposed to having the division into pages be dynamically determined by the book viewer.

An issue that is not yet resolved is how/whether to create a link between selectors. Some selector types (eg. text quotes) can be used with or without reference to the chapter/page selector. Other selector types (eg. text position, XPath) only make sense if applied to the content indicated by the chapter/page selector.

Summary of changes:

- Add `EPUBContentSelector` and `PageSelector` selector types in `types/api.ts`
- Modify VitalSourceContentIntegration to capture these selector types if "book_as_single_document" flag is enabled
- Modify the fake `<mosaic-book>` element used by http://localhost:3000/document/vitalsource-epub and http://localhost:3000/document/vitalsource-pdf to implement the `getCurrentPage` API which returns the data needed for these selectors