### PR TITLE
Highlight clusters: Mini-prototype 2

### DIFF
--- a/src/annotator/cluster-styles.tsx
+++ b/src/annotator/cluster-styles.tsx
@@ -1,0 +1,172 @@
+import { render } from 'preact';
+
+import ClusterToolbar from './components/ClusterToolbar';
+import type {
+  Destroyable,
+  FeatureFlags as IFeatureFlags,
+} from '../types/annotator';
+import type { HighlightCluster } from '../types/shared';
+import { createShadowRoot } from './util/shadow-root';
+
+export type HighlightStyle = {
+  color: string;
+  decoration: string;
+};
+
+export type HighlightStyles = Record<string, HighlightStyle>;
+export type AppliedStyles = Record<HighlightCluster, keyof HighlightStyles>;
+
+// Available styles that users can apply to highlight clusters
+export const highlightStyles: HighlightStyles = {
+  hidden: {
+    color: 'transparent',
+    decoration: 'none',
+  },
+  green: {
+    color: 'var(--hypothesis-color-green)',
+    decoration: 'none',
+  },
+  orange: {
+    color: 'var(--hypothesis-color-orange)',
+    decoration: 'none',
+  },
+  pink: {
+    color: 'var(--hypothesis-color-pink)',
+    decoration: 'none',
+  },
+  purple: {
+    color: 'var(--hypothesis-color-purple)',
+    decoration: 'none',
+  },
+  yellow: {
+    color: 'var(--hypothesis-color-yellow)',
+    decoration: 'none',
+  },
+  grey: {
+    color: 'var(--hypothesis-color-grey)',
+    decoration: 'underline dotted',
+  },
+};
+
+// The default styles applied to each highlight cluster. For now, this is
+// hard-coded.
+export const defaultStyles: AppliedStyles = {
+  'other-content': 'yellow',
+  'user-annotations': 'orange',
+  'user-highlights': 'purple',
+};
+
+export class ClusterStyleController implements Destroyable {
+  appliedStyles: AppliedStyles;
+  private _element: HTMLElement;
+  private _features: IFeatureFlags;
+  private _outerContainer: HTMLElement;
+  private _shadowRoot: ShadowRoot;
+
+  constructor(element: HTMLElement, options: { features: IFeatureFlags }) {
+    this._element = element;
+    this._features = options.features;
+
+    this._outerContainer = document.createElement(
+      'hypothesis-highlight-cluster-toolbar'
+    );
+    this._element.appendChild(this._outerContainer);
+    this._shadowRoot = createShadowRoot(this._outerContainer);
+
+    // For now, the controls are fixed at top-left of screen. This is temporary.
+    Object.assign(this._outerContainer.style, {
+      position: 'fixed',
+      top: 0,
+      left: 0,
+    });
+
+    this.appliedStyles = defaultStyles;
+
+    this._init();
+
+    this._features.on('flagsChanged', () => {
+      this._activate(this._isActive());
+    });
+
+    this._render();
+  }
+
+  destroy() {
+    render(null, this._shadowRoot); // unload the Preact component
+    this._activate(false); // De-activate cluster styling
+    this._outerContainer.remove();
+  }
+
+  /**
+   * Set initial values for :root CSS custom properties (variables) based on the
+   * applied styles for each cluster. This has no effect if this feature
+   * is not active.
+   */
+  _init() {
+    (
+      Object.keys(this.appliedStyles) as Array<keyof typeof this.appliedStyles>
+    ).forEach(cluster => {
+      this._setClusterStyle(cluster, this.appliedStyles[cluster]);
+    });
+
+    this._activate(this._isActive());
+  }
+
+  _isActive() {
+    return this._features.flagEnabled('styled_highlight_clusters');
+  }
+
+  /**
+   * Activate cluster highlighting if `active` is set.
+   */
+  _activate(active: boolean) {
+    this._element?.classList?.toggle('hypothesis-highlights-clustered', active);
+    this._render();
+  }
+
+  /**
+   * Set CSS variables for the highlight `cluster` to apply the
+   * {@link HighlightStyle} `highlightStyles[styleName]`
+   */
+  _setClusterStyle(
+    cluster: HighlightCluster,
+    styleName: keyof typeof highlightStyles
+  ) {
+    const styleRules = highlightStyles[styleName];
+
+    (Object.keys(styleRules) as Array<keyof HighlightStyle>).forEach(
+      ruleName => {
+        document.documentElement.style.setProperty(
+          `--hypothesis-${cluster}-${ruleName}`,
+          styleRules[ruleName]
+        );
+      }
+    );
+  }
+
+  /**
+   * Respond to user input to change the applied style for a cluster
+   */
+  _onChangeClusterStyle(
+    cluster: HighlightCluster,
+    styleName: keyof typeof highlightStyles
+  ) {
+    this.appliedStyles[cluster] = styleName;
+    this._setClusterStyle(cluster, styleName);
+    this._render();
+  }
+
+  _render() {
+    render(
+      <ClusterToolbar
+        active={this._isActive()}
+        availableStyles={highlightStyles}
+        currentStyles={this.appliedStyles}
+        setClusterStyle={(cluster, styleName) =>
+          this._onChangeClusterStyle(cluster, styleName)
+        }
+      />,
+      this._shadowRoot
+    );
+  }
+}

--- a/src/annotator/components/ClusterToolbar.tsx
+++ b/src/annotator/components/ClusterToolbar.tsx
@@ -1,0 +1,154 @@
+import {
+  Card,
+  CardContent,
+  HideIcon,
+} from '@hypothesis/frontend-shared/lib/next';
+import classnames from 'classnames';
+import { useCallback } from 'preact/hooks';
+
+import type { HighlightCluster } from '../../types/shared';
+import type { AppliedStyles, HighlightStyles } from '../cluster-styles';
+
+type ClusterStyleControlProps = {
+  cluster: HighlightCluster;
+  label: string;
+  onChange: (e: Event) => void;
+  currentStyles: AppliedStyles;
+  highlightStyles: HighlightStyles;
+};
+
+/**
+ * Render controls for changing a single highlight cluster's style
+ */
+function ClusterStyleControl({
+  cluster,
+  label,
+  onChange,
+  currentStyles,
+  highlightStyles,
+}: ClusterStyleControlProps) {
+  const appliedStyleName = currentStyles[cluster];
+  const isHidden = appliedStyleName === 'hidden'; // This style is somewhat special
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-x-2 text-annotator-base">
+        <div
+          className="grow text-color-text px-2 py-1 rounded"
+          style={{
+            backgroundColor: highlightStyles[appliedStyleName].color,
+          }}
+        >
+          {label}
+        </div>
+      </div>
+      <div className="flex items-center gap-x-2">
+        {Object.keys(highlightStyles).map(styleName => (
+          <div className="relative" key={`${cluster}-${styleName}`}>
+            <input
+              className={classnames(
+                // Position this atop its label and size it to the same dimensions
+                'absolute w-6 h-6',
+                // Make radio input visually hidden, but
+                // some screen readers won't read out elements with 0 opacity
+                'opacity-[.00001]',
+                'cursor-pointer'
+              )}
+              name={cluster}
+              id={`${cluster}-${styleName}`}
+              checked={appliedStyleName === styleName}
+              onChange={onChange}
+              type="radio"
+              value={styleName}
+            />
+            <label className="block" htmlFor={`${cluster}-${styleName}`}>
+              <div
+                style={{
+                  backgroundColor: highlightStyles[styleName].color,
+                  textDecoration: highlightStyles[styleName].decoration,
+                }}
+                className={classnames(
+                  'block w-6 h-6 rounded-full flex items-center justify-center',
+                  {
+                    'border-2 border-slate-0': appliedStyleName !== styleName,
+                    'border-2 border-slate-3': appliedStyleName === styleName,
+                  }
+                )}
+              >
+                {styleName === 'hidden' && (
+                  <HideIcon
+                    className={classnames('w-3 h-3"', {
+                      'text-slate-3': !isHidden,
+                      'text-slate-7': isHidden,
+                    })}
+                  />
+                )}
+              </div>
+              <span className="sr-only">{styleName}</span>
+            </label>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type ClusterToolbarProps = {
+  /* Is cluster highlight styling active? Do not render the toolbar if not */
+  active: boolean;
+  availableStyles: HighlightStyles;
+  currentStyles: AppliedStyles;
+  setClusterStyle: (cluster: HighlightCluster, styleName: string) => void;
+};
+
+/**
+ * Render controls to change highlight-cluster styling.
+ */
+export default function ClusterToolbar({
+  active,
+  availableStyles,
+  currentStyles,
+  setClusterStyle,
+}: ClusterToolbarProps) {
+  const handleStyleChange = useCallback(
+    (changeEvent: Event) => {
+      const input = changeEvent.target as HTMLInputElement;
+      const cluster = input.name as HighlightCluster;
+      const styleName = input.value;
+
+      setClusterStyle(cluster, styleName);
+    },
+    [setClusterStyle]
+  );
+
+  if (!active) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardContent size="sm">
+        <ClusterStyleControl
+          highlightStyles={availableStyles}
+          label="My annotations"
+          cluster="user-annotations"
+          onChange={handleStyleChange}
+          currentStyles={currentStyles}
+        />
+        <ClusterStyleControl
+          highlightStyles={availableStyles}
+          label="My highlights"
+          cluster="user-highlights"
+          onChange={handleStyleChange}
+          currentStyles={currentStyles}
+        />
+        <ClusterStyleControl
+          highlightStyles={availableStyles}
+          label="Everybody's content"
+          cluster="other-content"
+          onChange={handleStyleChange}
+          currentStyles={currentStyles}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/annotator/features.js
+++ b/src/annotator/features.js
@@ -11,7 +11,11 @@ import { warnOnce } from '../shared/warn-once';
  *
  * @type {string[]}
  */
-const annotatorFlags = ['book_as_single_document', 'html_side_by_side'];
+const annotatorFlags = [
+  'book_as_single_document',
+  'html_side_by_side',
+  'styled_highlight_clusters',
+];
 
 /**
  * An observable container of feature flags.

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -1,3 +1,5 @@
+import classnames from 'classnames';
+
 import { ListenerCollection } from '../shared/listener-collection';
 import { PortFinder, PortRPC } from '../shared/messaging';
 import { generateHexString } from '../shared/random';
@@ -6,6 +8,7 @@ import { matchShortcut } from '../shared/shortcut';
 import { Adder } from './adder';
 import { TextRange } from './anchoring/text-range';
 import { BucketBarClient } from './bucket-bar-client';
+import { ClusterStyleController } from './cluster-styles';
 import { FeatureFlags } from './features';
 import {
   getHighlightsContainingNode,
@@ -196,6 +199,10 @@ export class Guest {
     });
 
     this.features = new FeatureFlags();
+
+    this._clusterToolbar = new ClusterStyleController(element, {
+      features: this.features,
+    });
 
     /**
      * Integration that handles document-type specific functionality in the
@@ -543,7 +550,10 @@ export class Guest {
       }
 
       const highlights = /** @type {AnnotationHighlight[]} */ (
-        highlightRange(range)
+        highlightRange(
+          range,
+          classnames('hypothesis-highlight', anchor.annotation?.$cluster)
+        )
       );
       highlights.forEach(h => {
         h._annotation = anchor.annotation;
@@ -656,6 +666,7 @@ export class Guest {
       document: info.metadata,
       target,
       $highlight: highlight,
+      $cluster: highlight ? 'user-highlights' : 'user-annotations',
       $tag: 'a:' + generateHexString(8),
     };
 

--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -37,8 +37,14 @@ type DocumentInfo = {
  * JavaScript, it includes only the information needed to uniquely identify it
  * within the current session and anchor it in the document.
  */
-export function formatAnnot({ $tag, target, uri }: Annotation): AnnotationData {
+export function formatAnnot({
+  $cluster,
+  $tag,
+  target,
+  uri,
+}: Annotation): AnnotationData {
   return {
+    $cluster,
     $tag,
     target,
     uri,

--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -1,55 +1,140 @@
-$color-highlight: rgba(255, 255, 60, 0.4);
-$color-highlight-second: rgba(206, 206, 60, 0.4);
-$color-highlight-focused: rgba(156, 230, 255, 0.5);
+@use 'tailwindcss/components';
 
-// Hide content from sighted users but make it visible to screen readers.
-//
-// Resources:
-// - https://webaim.org/techniques/css/invisiblecontent/ (see "CSS clip")
-// - https://cloudfour.com/thinks/see-no-evil-hidden-content-and-accessibility/#showing-additional-content-for-screen-readers
-// - https://tailwindcss.com/docs/screen-readers#screen-reader-only-elements Tailwind's `sr-only` class
-@mixin screen-reader-only {
-  // Take the content out of the normal layout flow.
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  white-space: nowrap;
+/**
+ * Base highlight styling. Highlights are styled:
+ *
+ * - In HTML documents: opaque light yellow, with nested highlights styled a
+ *   darker opaque yellow. There are two levels of visual distinction.
+ * - In PDF documents: All highlights are the same color of yellow, but nested
+ *   highlights appear more intense at each level because they use
+ *   mix-blend-mode: multiply.
+ */
+:root {
+  --hypothesis-color-default: #ffffb1;
+  --hypothesis-color-default-nested: #ebeb82;
 
-  // Visually hide the content and prevent it from interfering with mouse/touch
-  // text selection by clipping it to an empty box. Compared to moving content with
-  // `top`/`left` this is less likely to cause the browser to scroll to a
-  // different part of the page when the hidden text has screen-reader focus.
-  clip: rect(0 0 0 0);
-  overflow: hidden;
+  --hypothesis-color-blue: #e0f2fe;
+
+  --hypothesis-highlight-color-focused: var(--hypothesis-color-blue);
 }
 
-// SVG highlights when the "Show Highlights" toggle is turned off.
+.hypothesis-highlight {
+  --highlight-color: var(--hypothesis-color-default);
+  --highlight-decoration: none;
+}
+
+.hypothesis-highlight > .hypothesis-highlight {
+  --highlight-color: var(--hypothesis-color-default-nested);
+}
+
+// Variable/cluster styling not supported for PDF highlights (which are SVGs) yet
+.hypothesis-svg-highlight {
+  --highlight-color: rgba(255, 255, 60, 0.4);
+  --highlight-color-focused: rgba(156, 230, 255, 0.5);
+}
+
+/**
+ * Clustered highlight styling. This is enabled by the presence of the
+ * .hypothesis-highlights-clustered class on the guest's `element` (typically
+ * <body>). Each cluster of highlights may be styled independently. At present
+ * this is limited to highlight color and underlining.
+ *
+ * `cluster-styles` in the annotator updates the cluster- related CSS variables
+ *  per user inputs/preferences and manages the presence of the
+ *  .hypothesis-highlights-clustered class.
+ *
+ * This styling is currently only supported for HTML documents.
+ */
+:root {
+  --hypothesis-color-yellow: #fef9c3;
+  --hypothesis-color-purple: #ede9fe;
+  --hypothesis-color-orange: #ffedd5;
+  --hypothesis-color-green: #d1fae5;
+  --hypothesis-color-grey: #f5f5f4;
+  --hypothesis-color-pink: #ffe4e6;
+
+  --hypothesis-other-content-color: var(--hypothesis-color-default);
+  --hypothesis-other-content-decoration: none;
+
+  --hypothesis-user-highlights-color: var(--hypothesis-color-default);
+  --hypothesis-user-highlights-decoration: none;
+
+  --hypothesis-user-annotations-color: var(--hypothesis-color-default);
+  --hypothesis-user-annotations-decoration: none;
+}
+
+.hypothesis-highlights-clustered {
+  .hypothesis-highlight.other-content {
+    --highlight-color: var(--hypothesis-other-content-color);
+    --highlight-decoration: var(--hypothesis-other-content-decoration);
+  }
+
+  .hypothesis-highlight.user-highlights {
+    --highlight-color: var(--hypothesis-user-highlights-color);
+    --highlight-decoration: var(--hypothesis-user-highlights-decoration);
+  }
+
+  .hypothesis-highlight.user-annotations {
+    --highlight-color: var(--hypothesis-user-annotations-color);
+    --highlight-decoration: var(--hypothesis-user-annotations-decoration);
+  }
+
+  .other-content > .other-content,
+  .user-highlights > .user-highlights,
+  .user-annotations > .user-annotations {
+    mix-blend-mode: multiply;
+  }
+
+  &
+    .hypothesis-highlight
+    > .hypothesis-highlight
+    > .hypothesis-highlight
+    > .hypothesis-highlight
+    > .hypothesis-highlight {
+    // Cut off multiply blending to ensure that deeply-nested annotations don't get too dark
+    mix-blend-mode: normal;
+  }
+}
+
+// Highlights are non-visible when .hypothesis-highlight-always-on class not present.
+.hypothesis-highlight {
+  background-color: transparent;
+}
+
 .hypothesis-svg-highlight {
   fill: transparent;
 }
 
-// `hypothesis-highlights-always-on` is a class that is toggled on the root
-// of the annotated document when highlights are enabled/disabled.
+// Apply styling when highlights are visible
 .hypothesis-highlights-always-on {
   .hypothesis-svg-highlight {
-    fill: $color-highlight;
-
-    &.is-opaque {
-      fill: yellow;
-    }
+    fill: var(--highlight-color);
 
     &.is-focused {
-      fill: $color-highlight-focused;
+      fill: var(--highlight-color-focused);
     }
   }
 
   .hypothesis-highlight {
-    background-color: $color-highlight;
+    background-color: var(--highlight-color);
+    text-decoration: var(--highlight-decoration);
 
     // For PDFs, we still create highlight elements to wrap the text but the
     // highlight effect is created by another element.
     &.is-transparent {
-      background-color: transparent;
+      background-color: transparent !important;
+    }
+
+    // When an annotation card is hovered in the sidebar, the corresponding
+    // highlights are shown with a "focused" color.
+    &.hypothesis-highlight-focused {
+      mix-blend-mode: normal !important;
+      background-color: var(--hypothesis-highlight-color-focused) !important;
+      text-decoration: none;
+
+      .hypothesis-highlight {
+        background-color: transparent !important;
+      }
     }
 
     cursor: pointer;
@@ -57,45 +142,15 @@ $color-highlight-focused: rgba(156, 230, 255, 0.5);
     // Make highlights visible to screen readers.
     // See also - https://developer.paciellogroup.com/blog/2017/12/short-note-on-making-your-mark-more-accessible/.
     &::before {
-      @include screen-reader-only;
+      @apply sr-only;
 
       // nb. The leading/trailing spaces are intended to ensure the text is treated
       // as separate words by assistive technologies from the content before/after it.
       content: ' annotation start ';
     }
     &::after {
-      @include screen-reader-only;
+      @apply sr-only;
       content: ' annotation end ';
-    }
-
-    // Give a highlight inside a larger highlight a different color to stand out.
-    & .hypothesis-highlight {
-      background-color: $color-highlight-second;
-      &.is-transparent {
-        background-color: transparent;
-      }
-
-      // Limit the number of different highlight shades by making highlights
-      // that are 3+ levels deep transparent.
-      //
-      // This was historically done to improve readability in PDFs [1], but that
-      // is no longer an issue as in PDFs highlights are created by drawing
-      // SVGs on top of the <canvas>.
-      //
-      // [1] https://github.com/hypothesis/client/issues/1995.
-      & .hypothesis-highlight {
-        background-color: transparent;
-      }
-    }
-
-    // When an annotation card is hovered in the sidebar, the corresponding
-    // highlights are shown with a "focused" color.
-    &.hypothesis-highlight-focused {
-      background-color: $color-highlight-focused !important;
-
-      .hypothesis-highlight {
-        background-color: transparent !important;
-      }
     }
   }
 }

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1,7 +1,17 @@
 /**
+ * An annotation belongs to exactly one cluster. The anchor highlights for each
+ * cluster can be styled distinctly in the document.
+ */
+export type HighlightCluster =
+  | 'other-content' // default cluster: content not belonging to the current user
+  | 'user-annotations'
+  | 'user-highlights';
+
+/**
  * Annotation properties not present on API objects, but added by the client
  */
 export type ClientAnnotationData = {
+  $cluster?: HighlightCluster;
   /**
    * Client-side identifier: set even if annotation does not have a
    * server-provided `id` (i.e. is unsaved)


### PR DESCRIPTION
This PR contains a second mini-prototype that demonstrates highlight-cluster styling functionality.

This prototype responds to the `styled_highlight_clusters` feature flag added to `h` this week and adds controls such that the styles for each highlight cluster may be changed.

<img width="2042" alt="image" src="https://user-images.githubusercontent.com/439947/198686602-1c31229a-3044-44b4-a031-12cb821dd261.png">


<img width="244" alt="image" src="https://user-images.githubusercontent.com/439947/198685910-8c9249f7-181b-4df3-8d58-cd998b839e23.png">

### Playing around with it

* Pull and run this branch
* ensure that the `styled_highlight_clusters` feature flag is present on http://localhost:5000/admin/features (pull changes to `h` if not)
* Enable the flag
* Load any HTML sample document on the local dev server, e.g. http://localhost:3000/document/doyle
* Disable the flag: Highlights should look the same as they always have before

### What this explores and solves

* The mechanisms for dynamically updating the styles of multiple highlight clusters
* The ability to respond to user input to update cluster styles
* Structuring the code to minimize integration points
* Responding to a feature flag

### Known shortcomings

* ~~Highlight color will be incorrect for newly-created annotations until the page is reloaded~~ Fixed!
* If the feature flag is set, the controls will still show up on PDF pages, even though they don't do anything.
* If the feature flag is set, the controls will still show up for logged-out users and includes "My annotations" and "My highlights" which aren't relevant — i.e. the controls need tuning for this state.

### Things that are coming in later iterations

* The appearance, position and interface of the controls should be considered just a sketch. Revision of that UI will come at a later step.
* User-set styles are not persisted and are reset on page load.
* PDF anchor cluster styling is not implemented (yet): this only works for HTML documents.
* While the set of colors and the styling/blend mode works "pretty well" for big sets of entangled, nestled anchor highlights belonging to different clusters (see screenshots included here), it is not "tuned" and I'd expect we'll find combinations in which we'll need to make improvements.

### Technical notes and highlights

I've tried to minimize integration points so that this feature can be removed easily.  Feature-specific stuff is encapsulated within the `ClusterToolbar` component and the `ClusterStyleController` class in the annotator. `highlights.scss` has significant changes but should have the same net effect as it always has if the feature is not activated. 

`$cluster` is now set when annotation objects are initialized in both the `annotator` or the `sidebar`. In the `sidebar`, this happens within the `annotations` store module. The largest change to existing code is that the `addAnnotations` reducer needs access to the currently-auth'ed user's ID to assess whether a given annotation belongs to the current user. This introduces a dependency on the `session` store module, which I don't love. I'd say this change bears some scrutiny.

The other changes to existing code are minor:

* `frame-sync` adds the `$cluster` prop to annotations sent from the `sidebar` to the `annotator`
* The `guest` instantiates the `ClusterStyleController`, sets cluster CSS classes for anchor highlights (this has no effect if the feature is not active), and sets `$cluster` on newly-initialized annotation objects (the corollary to the `sidebar`-side initialization).