### PR TITLE
Compare annotation locations by CFI and text position

### DIFF
--- a/src/sidebar/helpers/annotation-metadata.js
+++ b/src/sidebar/helpers/annotation-metadata.js
@@ -322,6 +322,8 @@ export function location(annotation) {
   let cfi;
   let position;
 
+  // nb. We ignore the possibility of an annotation having multiple targets here.
+  // h and the client only support one.
   for (const selector of targets[0]?.selector ?? []) {
     if (selector.type === 'TextPositionSelector') {
       position = selector.start;

--- a/src/sidebar/helpers/test/annotation-metadata-test.js
+++ b/src/sidebar/helpers/test/annotation-metadata-test.js
@@ -222,8 +222,8 @@ describe('sidebar/helpers/annotation-metadata', () => {
   });
 
   describe('location', () => {
-    it('returns the position for annotations with a text position', () => {
-      assert.equal(
+    it('returns position for annotations with a text position', () => {
+      assert.deepEqual(
         annotationMetadata.location({
           target: [
             {
@@ -236,12 +236,35 @@ describe('sidebar/helpers/annotation-metadata', () => {
             },
           ],
         }),
-        100
+        { cfi: undefined, position: 100 }
       );
     });
 
-    it('returns +ve infinity for annotations without a text position', () => {
-      assert.equal(
+    it('returns CFI for annotations with a CFI', () => {
+      assert.deepEqual(
+        annotationMetadata.location({
+          target: [
+            {
+              selector: [
+                {
+                  type: 'EPUBContentSelector',
+                  cfi: '/2/4',
+                  url: 'content/chapter2.xhtml',
+                },
+                {
+                  type: 'TextPositionSelector',
+                  start: 200,
+                },
+              ],
+            },
+          ],
+        }),
+        { cfi: '/2/4', position: 200 }
+      );
+    });
+
+    it('returns undefined for annotations without a text position', () => {
+      assert.deepEqual(
         annotationMetadata.location({
           target: [
             {
@@ -249,7 +272,7 @@ describe('sidebar/helpers/annotation-metadata', () => {
             },
           ],
         }),
-        Number.POSITIVE_INFINITY
+        { cfi: undefined, position: undefined }
       );
     });
   });

--- a/src/sidebar/helpers/test/thread-sorters-test.js
+++ b/src/sidebar/helpers/test/thread-sorters-test.js
@@ -77,25 +77,37 @@ describe('sidebar/util/thread-sorters', () => {
   });
 
   describe('sorting by document location', () => {
+    // Create a position-only location. This is the common case for a web page
+    // or PDF.
+    function posLocation(pos) {
+      return { position: pos };
+    }
+
+    // Create a location with an EPUB CFI and position. This would occur in
+    // an ebook.
+    function cfiLocation(cfi, pos) {
+      return { cfi, position: pos };
+    }
+
     [
       {
-        a: { annotation: { location: 5 } },
-        b: { annotation: { location: 10 } },
+        a: { annotation: { location: posLocation(5) } },
+        b: { annotation: { location: posLocation(10) } },
         expected: -1,
       },
       {
-        a: { annotation: { location: 10 } },
-        b: { annotation: { location: 10 } },
+        a: { annotation: { location: posLocation(10) } },
+        b: { annotation: { location: posLocation(10) } },
         expected: 0,
       },
       {
-        a: { annotation: { location: 10 } },
-        b: { annotation: { location: 5 } },
+        a: { annotation: { location: posLocation(10) } },
+        b: { annotation: { location: posLocation(5) } },
         expected: 1,
       },
       {
         a: {},
-        b: { annotation: { location: 5 } },
+        b: { annotation: { location: posLocation(5) } },
         expected: -1,
       },
       {
@@ -104,12 +116,53 @@ describe('sidebar/util/thread-sorters', () => {
         expected: 0,
       },
       {
-        a: { annotation: { location: 10 } },
+        a: { annotation: { location: posLocation(10) } },
         b: {},
         expected: 1,
       },
     ].forEach(testCase => {
       it('sorts by annotation location', () => {
+        assert.equal(
+          // Disable eslint: `sorters` properties start with capital letters
+          // to match their displayed sort option values
+          /* eslint-disable-next-line new-cap */
+          sorters.Location(testCase.a, testCase.b),
+          testCase.expected
+        );
+      });
+    });
+
+    [
+      // CFI only
+      {
+        a: { annotation: { location: cfiLocation('/2/2') } },
+        b: { annotation: { location: cfiLocation('/2/4') } },
+        expected: -1,
+      },
+      {
+        a: { annotation: { location: cfiLocation('/2/4') } },
+        b: { annotation: { location: cfiLocation('/2/4') } },
+        expected: 0,
+      },
+      {
+        a: { annotation: { location: cfiLocation('/2/4') } },
+        b: { annotation: { location: cfiLocation('/2/2') } },
+        expected: 1,
+      },
+
+      // CFI and position
+      {
+        a: { annotation: { location: cfiLocation('/2/2', 100) } },
+        b: { annotation: { location: cfiLocation('/2/4', 10) } },
+        expected: -1,
+      },
+      {
+        a: { annotation: { location: cfiLocation('/2/4', 100) } },
+        b: { annotation: { location: cfiLocation('/2/4', 10) } },
+        expected: 1,
+      },
+    ].forEach((testCase, index) => {
+      it(`sorts by CFI when present (${index})`, () => {
         assert.equal(
           // Disable eslint: `sorters` properties start with capital letters
           // to match their displayed sort option values

--- a/src/sidebar/helpers/thread-sorters.js
+++ b/src/sidebar/helpers/thread-sorters.js
@@ -96,6 +96,7 @@ export const sorters = {
     if (aLocation.cfi && bLocation.cfi) {
       const cfiResult = compareCFIs(aLocation.cfi, bLocation.cfi);
       if (cfiResult !== 0) {
+        // Annotations are in different chapters.
         return Math.sign(cfiResult);
       }
     } else if (aLocation.cfi) {


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/4903**

For annotations on EPUBs, text position selectors can only be validly compared when they come from annotations made on the same EPUB Content Document. For annotations that come from different content documents, it is necessary to first compare the ordering of the content documents using CFIs, and then compare text positions.

For VitalSource, comparing CFIs is sufficient since they are provided for all book types. It would be logical in future to also consider `PageSelector` selectors, and use the page index.

The use of `Number.POSITIVE_INFINITY` was replaced with `Number.MAX_SAFE_INTEGER` when handling annotations without positions, as `Math.sign(MAX_SAFE_INTEGER - MAX_SAFE_INTEGER)` is 0 (ie. treat two annotations with missing positions as having the same position), but `Math.sign(POSITIVE_INFINITY - POSITIVE_INFINITY)` is NaN.

**Testing:**

1. Open http://localhost:3000/document/vitalsource-epub.
2. On Chapter One annotate the word "Christmas" in the 6th paragraph that begins "Nobody spoke for a minute...".
3. Navigate to Chapter Two and annotate the word "Christmas" in the first paragraph that begins "Jo was the first to wake"
4. On `main`, the annotation made on Chapter Two will appear above the annotation on Chapter One in the sidebar since it it was made closer to the start of the respective chapter and thus has a smaller text position. On this branch, the chapter ordering will be taken into account and the annotation on Chapter One will sort above the annotation on chapter Two.