### PR TITLE
Add `$cluster` client property to annotation objects

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -1,3 +1,5 @@
+import classnames from 'classnames';
+
 import { ListenerCollection } from '../shared/listener-collection';
 import { PortFinder, PortRPC } from '../shared/messaging';
 import { generateHexString } from '../shared/random';
@@ -543,7 +545,10 @@ export class Guest {
       }
 
       const highlights = /** @type {AnnotationHighlight[]} */ (
-        highlightRange(range)
+        highlightRange(
+          range,
+          classnames('hypothesis-highlight', anchor.annotation?.$cluster)
+        )
       );
       highlights.forEach(h => {
         h._annotation = anchor.annotation;
@@ -656,6 +661,7 @@ export class Guest {
       document: info.metadata,
       target,
       $highlight: highlight,
+      $cluster: highlight ? 'user-highlights' : 'user-annotations',
       $tag: 'a:' + generateHexString(8),
     };
 

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -959,6 +959,18 @@ describe('Guest', () => {
       assert.equal(annotation.$highlight, true);
     });
 
+    it('sets `$cluster` to `user-highlights` if `highlight` is true', async () => {
+      const guest = createGuest();
+      const annotation = await guest.createAnnotation({ highlight: true });
+      assert.equal(annotation.$cluster, 'user-highlights');
+    });
+
+    it('sets `$cluster` to `user-annotations` if `highlight` is false', async () => {
+      const guest = createGuest();
+      const annotation = await guest.createAnnotation({ highlight: false });
+      assert.equal(annotation.$cluster, 'user-annotations');
+    });
+
     it('triggers a "createAnnotation" event', async () => {
       const guest = createGuest();
 
@@ -1123,6 +1135,22 @@ describe('Guest', () => {
         'syncAnchoringStatus',
         annotation,
       ]);
+    });
+
+    it('provides CSS classes for anchor highlight elements', async () => {
+      const guest = createGuest();
+      const annotation = {
+        $cluster: 'user-annotations',
+        target: [{ selector: [{ type: 'TextQuoteSelector', exact: 'hello' }] }],
+      };
+      fakeIntegration.anchor.resolves(range);
+
+      await guest.anchor(annotation);
+
+      assert.equal(
+        highlighter.highlightRange.lastCall.args[1],
+        'hypothesis-highlight user-annotations'
+      );
     });
 
     it('returns a promise of the anchors for the annotation', () => {

--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -37,8 +37,14 @@ type DocumentInfo = {
  * JavaScript, it includes only the information needed to uniquely identify it
  * within the current session and anchor it in the document.
  */
-export function formatAnnot({ $tag, target, uri }: Annotation): AnnotationData {
+export function formatAnnot({
+  $cluster,
+  $tag,
+  target,
+  uri,
+}: Annotation): AnnotationData {
   return {
+    $cluster,
     $tag,
     target,
     uri,

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -17,7 +17,7 @@ class FakeWindow extends EventTarget {
 const testAnnotation = annotationFixtures.defaultAnnotation();
 
 const fixtures = {
-  ann: { $tag: 't1', ...testAnnotation },
+  ann: { $cluster: 'user-annotations', $tag: 't1', ...testAnnotation },
 
   // New annotation received from the frame
   newAnnFromFrame: {
@@ -218,6 +218,17 @@ describe('FrameSyncService', () => {
       frameSync.connect();
       const port = await connectGuest();
       assert.calledWith(guestRPC().connect, port);
+    });
+  });
+
+  describe('formatAnnot', () => {
+    it('formats annotations with only those properties needed by the annotator', () => {
+      assert.hasAllKeys(formatAnnot(fixtures.ann), [
+        '$cluster',
+        '$tag',
+        'target',
+        'uri',
+      ]);
     });
   });
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1,7 +1,18 @@
 /**
+ * Clusters provide the client application a mechanism for categorizing
+ * annotations so that their drawn anchor highlights may be styled distinctively
+ * in the annotated document. An annotation can only belong to one cluster.
+ */
+export type HighlightCluster =
+  | 'other-content' // default cluster: content not belonging to the current user
+  | 'user-annotations' // An annotation belonging to the current user
+  | 'user-highlights'; // A highlight (highlights are private; they always belong to the current user)
+
+/**
  * Annotation properties not present on API objects, but added by the client
  */
 export type ClientAnnotationData = {
+  $cluster?: HighlightCluster;
   /**
    * Client-side identifier: set even if annotation does not have a
    * server-provided `id` (i.e. is unsaved)


### PR DESCRIPTION
This property is set when an annotation object is initialized in:

* annotator: In `guest`, when a user creates a new annotation or highlight via the adder controls
* sidebar: In the `annotations` store module when annotation objects are initialized before being added to the store

This property is communicated between the sidebar and the annotator when exchanging annotation data. In the annotator, the value of this property is used to set an additional CSS class on drawn anchor highlights (`<hypothesis-highlight>` `span`s).

The presence of this CSS class will allow subsequent differentiated styling for highlight clusters.

Impact: Every `hypothesis-highlight` span will have an additional CSS class corresponding to its `$cluster`. However, there is no visible change as we are not applying any styles for those classes (yet).

Part of #4916 