### PR TITLE
Pass information about current page/chapter of book to sidebar

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -311,14 +311,16 @@ export class Guest {
    * Retrieve metadata for the current document.
    */
   async getDocumentInfo() {
-    const [uri, metadata] = await Promise.all([
+    const [uri, metadata, segmentInfo] = await Promise.all([
       this._integration.uri(),
       this._integration.getMetadata(),
+      this._integration.segmentInfo?.(),
     ]);
 
     return {
       uri: normalizeURI(uri),
       metadata,
+      segmentInfo,
     };
   }
 

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -400,6 +400,17 @@ describe('annotator/integrations/vitalsource', () => {
       });
     });
 
+    describe('#segmentInfo', () => {
+      it('returns metadata for current page/chapter', async () => {
+        const integration = createIntegration();
+        const segment = await integration.segmentInfo();
+        assert.deepEqual(segment, {
+          cfi: '/2',
+          url: '/pages/chapter_02.xhtml',
+        });
+      });
+    });
+
     describe('#uri', () => {
       beforeEach(() => {
         const bookURI =

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -12,6 +12,7 @@ import type {
   Anchor,
   FeatureFlags as IFeatureFlags,
   Integration,
+  SegmentInfo,
   SidebarLayout,
 } from '../../types/annotator';
 import type { Selector } from '../../types/api';
@@ -505,6 +506,14 @@ export class VitalSourceContentIntegration
     return {
       title: document.title,
       link: [],
+    };
+  }
+
+  async segmentInfo(): Promise<SegmentInfo> {
+    const pageInfo = await this._bookElement.getCurrentPage();
+    return {
+      cfi: pageInfo.cfi,
+      url: pageInfo.absoluteURL,
     };
   }
 

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1382,6 +1382,30 @@ describe('Guest', () => {
         title: 'Test title',
         documentFingerprint: 'test-fingerprint',
       },
+      segmentInfo: undefined,
+    });
+  });
+
+  it('sends segment info to sidebar when available', async () => {
+    fakeIntegration.uri.resolves('https://bookstore.com/books/1234');
+    fakeIntegration.getMetadata.resolves({ title: 'A little book' });
+    fakeIntegration.segmentInfo = sinon.stub().resolves({
+      cfi: '/2',
+      url: '/chapters/02.xhtml',
+    });
+
+    createGuest();
+    await delay(0);
+
+    assert.calledWith(sidebarRPC().call, 'documentInfoChanged', {
+      uri: 'https://bookstore.com/books/1234',
+      metadata: {
+        title: 'A little book',
+      },
+      segmentInfo: {
+        cfi: '/2',
+        url: '/chapters/02.xhtml',
+      },
     });
   });
 
@@ -1398,6 +1422,7 @@ describe('Guest', () => {
       metadata: {
         title: 'Page 1',
       },
+      segmentInfo: undefined,
     });
 
     sidebarRPCCall.resetHistory();
@@ -1412,6 +1437,7 @@ describe('Guest', () => {
       metadata: {
         title: 'Page 2',
       },
+      segmentInfo: undefined,
     });
   });
 

--- a/src/sidebar/components/VersionInfo.js
+++ b/src/sidebar/components/VersionInfo.js
@@ -70,6 +70,11 @@ function VersionInfo({ toastMessenger, versionData }) {
         <VersionInfoItem label="Fingerprint">
           {versionData.fingerprint}
         </VersionInfoItem>
+        {versionData.segment && (
+          <VersionInfoItem label="Segment">
+            {versionData.segment}
+          </VersionInfoItem>
+        )}
         <VersionInfoItem label="Account">{versionData.account}</VersionInfoItem>
         <VersionInfoItem label="Date">{versionData.timestamp}</VersionInfoItem>
       </dl>

--- a/src/sidebar/components/test/VersionInfo-test.js
+++ b/src/sidebar/components/test/VersionInfo-test.js
@@ -61,7 +61,20 @@ describe('VersionInfo', () => {
     assert.include(componentText, 'fakeFingerprint');
     assert.include(componentText, 'fakeAccount');
     assert.include(componentText, 'fakeTimestamp');
+
+    // No `segment` property is set on the `versionData` prop by default, so
+    // the "Segment" field should not be displayed.
+    assert.notInclude(componentText, 'Segment');
   });
+
+  it('renders segment info if `versionData.segment` is set', () => {
+    fakeVersionData.segment = 'CFI: /2, URL: /chapters/foo.xhtml';
+    const wrapper = createComponent();
+    const componentText = wrapper.text();
+    assert.include(componentText, 'Segment');
+    assert.include(componentText, 'CFI: /2, URL: /chapters/foo.xhtml');
+  });
+
   describe('copy version info to clipboard', () => {
     it('copies version info to clipboard when copy button clicked', () => {
       const wrapper = createComponent();

--- a/src/sidebar/helpers/test/version-data-test.js
+++ b/src/sidebar/helpers/test/version-data-test.js
@@ -80,6 +80,18 @@ describe('sidebar/helpers/version-data', () => {
         ]);
         assert.equal(versionData.fingerprint, 'DEADBEEF');
       });
+
+      it('sets `segment` property if `segment` is present in frame details', () => {
+        const versionData = new VersionData({}, [
+          { segment: { cfi: '/2', url: '/chapters/02.xhtml' } },
+        ]);
+        assert.equal(versionData.segment, 'CFI: /2, URL: /chapters/02.xhtml');
+      });
+
+      it('does not set `segment` property if `segment` is not present in frame details', () => {
+        const versionData = new VersionData({}, []);
+        assert.isUndefined(versionData.segment);
+      });
     });
   });
 

--- a/src/sidebar/helpers/version-data.js
+++ b/src/sidebar/helpers/version-data.js
@@ -1,4 +1,8 @@
 /**
+ * @typedef {import('../../types/annotator').SegmentInfo} SegmentInfo
+ */
+
+/**
  * @typedef AuthState
  * @prop {string|null} [userid]
  * @prop {string} [displayName]
@@ -17,6 +21,7 @@
  * @typedef DocumentInfo
  * @prop {string=} [uri] - Current document URL
  * @prop {DocMetadata} [metadata] - Document metadata
+ * @prop {SegmentInfo} [segment]
  */
 
 export class VersionData {
@@ -47,6 +52,21 @@ export class VersionData {
 
     this.account = accountString;
     this.timestamp = new Date().toString();
+
+    const segmentInfo = documentInfo[0]?.segment;
+    if (segmentInfo) {
+      const segmentFields = [];
+      if (segmentInfo.cfi) {
+        segmentFields.push(['CFI', segmentInfo.cfi]);
+      }
+      if (segmentInfo.url) {
+        segmentFields.push(['URL', segmentInfo.url]);
+      }
+
+      this.segment = segmentFields
+        .map(([field, value]) => `${field}: ${value}`)
+        .join(', ');
+    }
   }
 
   /**

--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -12,7 +12,11 @@ import { isReply, isPublic } from '../helpers/annotation-metadata';
 import { watch } from '../util/watch';
 
 import type { Message } from '../../shared/messaging';
-import type { AnnotationData, DocumentMetadata } from '../../types/annotator';
+import type {
+  AnnotationData,
+  DocumentMetadata,
+  SegmentInfo,
+} from '../../types/annotator';
 import type { Annotation } from '../../types/api';
 import type {
   SidebarToHostEvent,
@@ -27,6 +31,7 @@ import type { AnnotationsService } from './annotations';
 type DocumentInfo = {
   uri: string;
   metadata: DocumentMetadata;
+  segmentInfo?: SegmentInfo;
 };
 
 /**
@@ -274,6 +279,7 @@ export class FrameSyncService {
         id: sourceId,
         metadata: info.metadata,
         uri: info.uri,
+        segment: info.segmentInfo,
       });
     });
 

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -35,6 +35,19 @@ const fixtures = {
       link: [],
     },
   },
+
+  // Argument to the `documentInfoChanged` call made by a guest displaying an EPUB
+  // document.
+  epubDocumentInfo: {
+    uri: testAnnotation.uri,
+    metadata: {
+      title: 'Test book',
+    },
+    segmentInfo: {
+      cfi: '/2',
+      url: '/chapters/02.xhtml',
+    },
+  },
 };
 
 describe('FrameSyncService', () => {
@@ -579,25 +592,29 @@ describe('FrameSyncService', () => {
       frameSync.connect();
     });
 
-    it('adds guest frame details to the store', async () => {
-      const frameInfo = fixtures.htmlDocumentInfo;
-      const frameId = 'test-frame';
+    [fixtures.htmlDocumentInfo, fixtures.epubDocumentInfo].forEach(
+      frameInfo => {
+        it('adds guest frame details to the store', async () => {
+          const frameId = 'test-frame';
 
-      await connectGuest(frameId);
-      emitGuestEvent('documentInfoChanged', frameInfo);
+          await connectGuest(frameId);
+          emitGuestEvent('documentInfoChanged', frameInfo);
 
-      assert.deepEqual(fakeStore.frames(), [
-        {
-          id: frameId,
-          metadata: frameInfo.metadata,
-          uri: frameInfo.uri,
+          assert.deepEqual(fakeStore.frames(), [
+            {
+              id: frameId,
+              metadata: frameInfo.metadata,
+              uri: frameInfo.uri,
+              segment: frameInfo.segmentInfo,
 
-          // This would be false in the real application initially, but in these
-          // tests we pretend that the fetch completed immediately.
-          isAnnotationFetchComplete: true,
-        },
-      ]);
-    });
+              // This would be false in the real application initially, but in these
+              // tests we pretend that the fetch completed immediately.
+              isAnnotationFetchComplete: true,
+            },
+          ]);
+        });
+      }
+    );
 
     it("synchronizes highlight visibility in the guest with the sidebar's controls", async () => {
       let channel;

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -10,6 +10,7 @@ import { createStoreModule, makeAction } from '../create-store';
 /**
  * @typedef {import('../../../types/annotator').ContentInfoConfig} ContentInfoConfig
  * @typedef {import('../../../types/annotator').DocumentMetadata} DocumentMetadata
+ * @typedef {import('../../../types/annotator').SegmentInfo} SegmentInfo
  */
 
 /**
@@ -19,6 +20,9 @@ import { createStoreModule, makeAction } from '../create-store';
  * @prop {DocumentMetadata} metadata - Metadata about the document currently loaded in this frame
  * @prop {string} uri - Current primary URI of the document being displayed
  * @prop {boolean} [isAnnotationFetchComplete]
+ * @prop {SegmentInfo} [segment] - Information about the section of a document
+ *   that is currently loaded. This is for content such as EPUBs, where the
+ *   content displayed in a guest frame is only part of the whole document.
  */
 
 const initialState = {

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -50,6 +50,19 @@ export type DocumentMetadata = {
 };
 
 /**
+ * Identifies a loadable chunk or segment of a document.
+ *
+ * Some document viewers do not load the whole document at once. For example
+ * an EPUB reader will load one Content Document from the publication at a time.
+ */
+export type SegmentInfo = {
+  /** Canonical Fragment Identifier for an EPUB Content Document */
+  cfi?: string;
+  /** Relative or absolute URL of the segment. */
+  url?: string;
+};
+
+/**
  * A subset of annotation data allowing the representation of an annotation in
  * the document.
  */
@@ -168,14 +181,25 @@ export type IntegrationBase = {
    * false otherwise.
    */
   fitSideBySide(layout: SidebarLayout): boolean;
+
   /** Return the metadata of the currently loaded document, such as title, PDF fingerprint, etc. */
   getMetadata(): Promise<DocumentMetadata>;
+
+  /**
+   * Return information about which section of the document is currently loaded.
+   *
+   * This is used for content such as EPUBs, where typically one Content Document
+   * (typically one chapter) is loaded at a time.
+   */
+  segmentInfo?(): Promise<SegmentInfo>;
+
   /**
    * Return the URL of the currently loaded document.
    *
    * This may be different than the current URL (`location.href`) in a PDF for example.
    */
   uri(): Promise<string>;
+
   /**
    * Scroll to an anchor.
    *


### PR DESCRIPTION
This PR adds information about the current page/chapter (generically referred to as a "segment") of a book to the `documentInfoChanged` message passed from the guest to the sidebar. This information is displayed in the Help panel for diagnostic purposes. In future it will be used to filter which annotations are sent to the guest frame, so that only annotations that match the current page/chapter are sent. It will also be used by the sidebar to know if scrolling to an annotation will require triggering a navigation in the document (eg. to a different chapter or page).

**Summary of changes:**

- Add optional `segmentInfo` method to `Integration` interface which returns information about the current page/chapter etc.
- Implement `Integration.segmentInfo` in the VitalSource integration
- Make `Guest` call this method if present and pass the results to the sidebar in the `documentInfoChanged` call
- In `FrameSyncService`, add the segment info to the `Frame` object created in the store, if present
- Add a new "Segment" field to the Help panel that displays the segment information for the main frame, if present

**Testing:**

In the VitalSource demo documents, a new "Segment" field should appear in the Help panel:

<img width="427" alt="Segment info field" src="https://user-images.githubusercontent.com/2458/199712741-b27aa440-16bf-400a-a310-e6ee9ad6ab9d.png">

In other document types, this field will not appear.
