### PR TITLE
Only send annotations to appropriate chapter frames in EPUBs

### DIFF
--- a/src/sidebar/helpers/annotation-segment.ts
+++ b/src/sidebar/helpers/annotation-segment.ts
@@ -1,0 +1,30 @@
+import { stripCFIAssertions } from '../util/cfi';
+
+import type { SegmentInfo } from '../../types/annotator';
+import type { Annotation, EPUBContentSelector } from '../../types/api';
+
+/**
+ * Return true if an annotation matches the currently loaded segment of a document.
+ *
+ * For web pages and PDFs, this is always true. In EPUBs, this is used to send
+ * only the annotations for the current chapter to the guest frame.
+ */
+export function annotationMatchesSegment(
+  ann: Annotation,
+  segment: SegmentInfo
+) {
+  const selector = ann.target[0].selector?.find(
+    s => s.type === 'EPUBContentSelector'
+  ) as EPUBContentSelector;
+
+  if (!selector) {
+    return true;
+  }
+
+  return Boolean(
+    (segment.url && selector.url === segment.url) ||
+      (segment.cfi &&
+        selector.cfi &&
+        stripCFIAssertions(selector.cfi) === stripCFIAssertions(segment.cfi))
+  );
+}

--- a/src/sidebar/helpers/test/annotation-segment-test.js
+++ b/src/sidebar/helpers/test/annotation-segment-test.js
@@ -1,0 +1,73 @@
+import { annotationMatchesSegment } from '../annotation-segment';
+
+describe('annotationMatchesSegment', () => {
+  it('returns true if annotation has no segment selectors', () => {
+    const ann = {
+      target: [
+        {
+          selectors: [
+            {
+              type: 'TextQuoteSelector',
+              exact: 'test',
+            },
+          ],
+        },
+      ],
+    };
+
+    const segment = { cfi: '/2' };
+
+    // If an annotation does not have segment information, we can't tell if
+    // it matches the current segment or not. We optimistically assume it does.
+    assert.isTrue(annotationMatchesSegment(ann, segment));
+  });
+
+  [
+    // Both segment and annotation have CFIs.
+    {
+      segment: { cfi: '/2' },
+      selector: { type: 'EPUBContentSelector', cfi: '/2' },
+      expected: true,
+    },
+    {
+      segment: { cfi: '/2' },
+      selector: { type: 'EPUBContentSelector', cfi: '/4' },
+      expected: false,
+    },
+    // CFIs may contain assertions in `[...]` brackets. We could use these to
+    // check whether a CFI made on an older version of a document is still
+    // valid. These are currently ignored however.
+    {
+      segment: { cfi: '/2[idref=4]' },
+      selector: { type: 'EPUBContentSelector', cfi: '/2[idref=5]' },
+      expected: true,
+    },
+    // Neither segment nor annotation have properties that can be compared.
+    {
+      segment: { cfi: '/2' },
+      selector: { type: 'EPUBContentSelector', url: '/chapters/01.xhtml' },
+      expected: false,
+    },
+    {
+      segment: { url: '/chapters/01.xhtml' },
+      selector: { type: 'EPUBContentSelector', cfi: '/2' },
+      expected: false,
+    },
+    // Both segment and annotation have URLs that can be compared.
+    {
+      segment: { url: '/chapters/02.xhtml' },
+      selector: { type: 'EPUBContentSelector', url: '/chapters/02.xhtml' },
+      expected: true,
+    },
+    {
+      segment: { url: '/chapters/02.xhtml' },
+      selector: { type: 'EPUBContentSelector', url: '/chapters/04.xhtml' },
+      expected: false,
+    },
+  ].forEach(({ segment, selector, expected }, index) => {
+    it(`returns true if CFI or URL matches current segment (${index})`, () => {
+      const ann = { target: [{ selector: [selector] }] };
+      assert.equal(annotationMatchesSegment(ann, segment), expected);
+    });
+  });
+});

--- a/src/sidebar/helpers/test/annotation-segment-test.js
+++ b/src/sidebar/helpers/test/annotation-segment-test.js
@@ -64,6 +64,26 @@ describe('annotationMatchesSegment', () => {
       selector: { type: 'EPUBContentSelector', url: '/chapters/04.xhtml' },
       expected: false,
     },
+    // CFIs do not match but URLs do. The successful match wins.
+    {
+      segment: { cfi: '/2', url: '/chapters/02.xhtml' },
+      selector: {
+        type: 'EPUBContentSelector',
+        cfi: '/4',
+        url: '/chapters/02.xhtml',
+      },
+      expected: true,
+    },
+    // CFIs match but URLs do not. The successful match wins.
+    {
+      segment: { cfi: '/2', url: '/chapters/03.xhtml' },
+      selector: {
+        type: 'EPUBContentSelector',
+        cfi: '/2',
+        url: '/chapters/02.xhtml',
+      },
+      expected: true,
+    },
   ].forEach(({ segment, selector, expected }, index) => {
     it(`returns true if CFI or URL matches current segment (${index})`, () => {
       const ann = { target: [{ selector: [selector] }] };

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -347,6 +347,57 @@ describe('FrameSyncService', () => {
       );
     });
 
+    context('in EPUB documents', () => {
+      it('sends annotations to frame if current segment matches frame', async () => {
+        const bookURI = 'https://publisher.com/books/1234';
+
+        const chapter1ann = {
+          uri: bookURI,
+          target: [
+            {
+              selector: [
+                {
+                  type: 'EPUBContentSelector',
+                  cfi: '/2',
+                  url: '/chapters/01.xhtml',
+                },
+              ],
+            },
+          ],
+        };
+        const chapter2ann = {
+          uri: bookURI,
+          target: [
+            {
+              selector: [
+                {
+                  type: 'EPUBContentSelector',
+                  cfi: '/4',
+                  url: '/chapters/02.xhtml',
+                },
+              ],
+            },
+          ],
+        };
+
+        await connectGuest();
+        emitGuestEvent('documentInfoChanged', {
+          uri: bookURI,
+          segmentInfo: {
+            cfi: '/4',
+            url: '/chapters/02.xhtml',
+          },
+        });
+        fakeStore.setState({ annotations: [chapter1ann, chapter2ann] });
+
+        assert.calledWithMatch(
+          guestRPC().call,
+          'loadAnnotations',
+          sinon.match([formatAnnot(chapter2ann)])
+        );
+      });
+    });
+
     it('sends a "loadAnnotations" message only for new annotations', async () => {
       const frameInfo = fixtures.htmlDocumentInfo;
       await connectGuest();


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/4923**

Add logic in the sidebar so that annotations are only sent to the guest frame when their respective chapters match.

**Summary of changes:**

- Add `annotationMatchesSegment` function in `src/sidebar/helpers/annotation-segment.ts` for comparing annotation selectors against a frame's segment info.
- Use this function in `FrameSyncService` to avoid sending annotations to a frame if the annotation's segment (ie. which chapter it was made on) does not match the frame's segment

**Testing:**

In the VitalSource EPUB demo (http://localhost:3000/document/vitalsource-epub), annotations for chapters other than the currently displayed one should no longer be anchored in the content. A known/expected issue is that after annotations are fetched from the API, annotations for chapters other than the current one will not be displayed until after a short delay (500ms). See notes in the second commit for an explanation of this temporary issue.

In non-EPUB documents, the behavior should be the same as before.