### PR TITLE
Only provided clustered highlights for integrations that support it

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -199,11 +199,6 @@ export class Guest {
     });
 
     this.features = new FeatureFlags();
-
-    this._clusterToolbar = new HighlightClusterController(element, {
-      features: this.features,
-    });
-
     /**
      * Integration that handles document-type specific functionality in the
      * guest.
@@ -215,6 +210,12 @@ export class Guest {
     });
     if (config.contentInfoBanner) {
       this._integration.showContentInfo?.(config.contentInfoBanner);
+    }
+
+    if (this._integration.canStyleClusteredHighlights?.()) {
+      this._clusterToolbar = new HighlightClusterController(element, {
+        features: this.features,
+      });
     }
 
     /**
@@ -485,6 +486,7 @@ export class Guest {
     this._selectionObserver.disconnect();
     this._adder.destroy();
     this._bucketBarClient.destroy();
+    this._clusterToolbar?.destroy();
 
     removeAllHighlights(this.element);
 

--- a/src/annotator/integrations/html.js
+++ b/src/annotator/integrations/html.js
@@ -109,6 +109,10 @@ export class HTMLIntegration extends TinyEmitter {
     return true;
   }
 
+  canStyleClusteredHighlights() {
+    return true;
+  }
+
   destroy() {
     this._navObserver.disconnect();
     this._metaObserver.disconnect();

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -163,6 +163,10 @@ export type IntegrationBase = {
    */
   canAnnotate(range: Range): boolean;
   /**
+   * Return whether this integration supports styling multiple clusters of highlights
+   */
+  canStyleClusteredHighlights?(): boolean;
+  /**
    * Attempt to resolve a set of serialized selectors to the corresponding content in the current document.
    */
   anchor(root: HTMLElement, selectors: Selector[]): Promise<Range>;


### PR DESCRIPTION
Allow an integration to declare whether or not it supports clustered highlights. At this time, only HTML documents support the feature.

Fixes #4925