### PR TITLE
Update LoggedOutMessage shared components and convert to TS

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "1.2.0",
-    "@hypothesis/frontend-shared": "5.4.2",
+    "@hypothesis/frontend-shared": "5.5.0",
     "@npmcli/arborist": "^5.6.2",
     "@octokit/rest": "^19.0.3",
     "@rollup/plugin-babel": "^6.0.0",

--- a/src/sidebar/components/LoggedOutMessage.js
+++ b/src/sidebar/components/LoggedOutMessage.js
@@ -1,4 +1,9 @@
-import { Link, LinkButton, Icon } from '@hypothesis/frontend-shared';
+import {
+  Link,
+  LinkBase,
+  LinkButton,
+  LogoIcon,
+} from '@hypothesis/frontend-shared/lib/next';
 
 import { useSidebarStore } from '../store';
 
@@ -23,27 +28,28 @@ function LoggedOutMessage({ onLogin }) {
         This is a public annotation created with Hypothesis. <br />
         To reply or make your own annotations on this document,{' '}
         <Link
-          classes="inline text-color-text underline hover:underline"
+          color="text"
           href={store.getLink('signup')}
           target="_blank"
+          underline="always"
         >
           create a free account
         </Link>{' '}
         or{' '}
-        <LinkButton classes="inline underline" onClick={onLogin} variant="dark">
+        <LinkButton inline color="text" onClick={onLogin} underline="always">
           log in
         </LinkButton>
         .
       </span>
       <div>
-        <Link
+        <LinkBase
           href="https://hypothes.is"
           aria-label="Hypothesis homepage"
           target="_blank"
           title="Hypothesis homepage"
         >
-          <Icon name="logo" classes="w-16 h-16 text-grey-7" />
-        </Link>
+          <LogoIcon className="w-16 h-16 text-grey-7" />
+        </LinkBase>
       </div>
     </div>
   );

--- a/src/sidebar/components/LoggedOutMessage.tsx
+++ b/src/sidebar/components/LoggedOutMessage.tsx
@@ -7,19 +7,16 @@ import {
 
 import { useSidebarStore } from '../store';
 
-/**
- * @typedef LoggedOutMessageProps
- * @prop {() => void} onLogin
- */
+export type LoggedOutMessageProps = {
+  onLogin: () => void;
+};
 
 /**
  * Render a call-to-action to log in or sign up. This message is intended to be
  * displayed to non-auth'd users when viewing a single annotation in a
  * direct-linked context (i.e. URL with syntax `/#annotations:<annotation_id>`)
- *
- * @param {LoggedOutMessageProps} props
  */
-function LoggedOutMessage({ onLogin }) {
+function LoggedOutMessage({ onLogin }: LoggedOutMessageProps) {
   const store = useSidebarStore();
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1132,10 +1132,10 @@
     fancy-log "^1.3.3"
     glob "^7.2.0"
 
-"@hypothesis/frontend-shared@5.4.2":
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.4.2.tgz#d9a693f292aec9c43e44544de12f84fcd7b56734"
-  integrity sha512-SyscaCm865SBojyKcB3TLfS1sLkpIvHIolbNoiMqhHB4PBF+G89fUtPmBEM5QdIgmYjhztvvSwHT+PSDCWAS0g==
+"@hypothesis/frontend-shared@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.5.0.tgz#1d359b03b4a80efb5e35d0e83879bdb1dd9df6a5"
+  integrity sha512-vUGzRbp3k2iFY4hfa3Ps0u9ObLplB/0v+/Aei8Fd3LYyxgw4/8tukF6Ru+NE1896QIMG9qKPu8TQ7DLy2otsog==
   dependencies:
     highlight.js "^11.6.0"
 


### PR DESCRIPTION
Depends on #4931 because of a bugfix to `inline` for `LinkButton`s in `frontend-shared` 5.5.0.

This is a housekeeping PR to keep component updates moving forward, and also converts this component to TS.

There is no user-visible change.

Part of https://github.com/hypothesis/client/issues/4860