### PR TITLE
Navigate to appropriate book chapter before scrolling to annotation

### DIFF
--- a/dev-server/static/scripts/vitalsource-mosaic-book-element.js
+++ b/dev-server/static/scripts/vitalsource-mosaic-book-element.js
@@ -162,4 +162,24 @@ export class MosaicBookElement extends HTMLElement {
   async getCurrentPage() {
     return this.pageData[this.pageIndex];
   }
+
+  goToCfi(cfi) {
+    for (let [i, page] of this.pageData.entries()) {
+      if (page.cfi === cfi) {
+        this.setPage(i);
+        return;
+      }
+    }
+    throw new Error(`No page found with CFI "${cfi}"`);
+  }
+
+  goToURL(url) {
+    for (let [i, page] of this.pageData.entries()) {
+      if (page.url === url) {
+        this.setPage(i);
+        return;
+      }
+    }
+    throw new Error(`No page found with URL "${url}"`);
+  }
 }

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -444,6 +444,10 @@ export class Guest implements Annotator, Destroyable {
       this._integration.showContentInfo?.(info)
     );
 
+    this._sidebarRPC.on('navigateToSegment', (annotation: AnnotationData) =>
+      this._integration.navigateToSegment?.(annotation)
+    );
+
     // Connect to sidebar and send document info/URIs to it.
     //
     // RPC calls are deferred until a connection is made, so these steps can

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -10,12 +10,13 @@ import { injectClient } from '../hypothesis-injector';
 
 import type {
   Anchor,
+  AnnotationData,
   FeatureFlags as IFeatureFlags,
   Integration,
   SegmentInfo,
   SidebarLayout,
 } from '../../types/annotator';
-import type { Selector } from '../../types/api';
+import type { EPUBContentSelector, Selector } from '../../types/api';
 import type { InjectConfig } from '../hypothesis-injector';
 
 // When activating side-by-side mode for VitalSource PDF documents, make sure
@@ -112,6 +113,16 @@ type MosaicBookElement = HTMLElement & {
    * chapter/segment (in an EPUB-based book).
    */
   getCurrentPage(): Promise<PageInfo>;
+
+  /**
+   * Navigate the book to the page or content document whose CFI matches `cfi`.
+   */
+  goToCfi(cfi: string): void;
+
+  /**
+   * Navigate the book to the page or content document whose URL matches `url`.
+   */
+  goToURL(url: string): void;
 };
 
 /**
@@ -507,6 +518,19 @@ export class VitalSourceContentIntegration
       title: document.title,
       link: [],
     };
+  }
+
+  navigateToSegment(ann: AnnotationData) {
+    const selector = ann.target[0].selector?.find(
+      s => s.type === 'EPUBContentSelector'
+    ) as EPUBContentSelector | undefined;
+    if (selector?.cfi) {
+      this._bookElement.goToCfi(selector.cfi);
+    } else if (selector?.url) {
+      this._bookElement.goToURL(selector.url);
+    } else {
+      throw new Error('No segment information available');
+    }
   }
 
   async segmentInfo(): Promise<SegmentInfo> {

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -149,6 +149,7 @@ describe('Guest', () => {
         title: 'Test title',
         documentFingerprint: 'test-fingerprint',
       }),
+      navigateToSegment: sinon.stub(),
       scrollToAnchor: sinon.stub().resolves(),
       showContentInfo: sinon.stub(),
       uri: sinon.stub().resolves('https://example.com/test.pdf'),
@@ -423,6 +424,15 @@ describe('Guest', () => {
 
         assert.notCalled(eventEmitted);
         assert.notCalled(fakeIntegration.scrollToAnchor);
+      });
+    });
+
+    describe('on "navigateToSegment" event', () => {
+      it('requests integration to navigate to segment associated with annotation', () => {
+        createGuest();
+        const annotation = {};
+        emitSidebarEvent('navigateToSegment', annotation);
+        assert.calledWith(fakeIntegration.navigateToSegment, annotation);
       });
     });
 

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -116,9 +116,9 @@ function SidebarView({
   // When a `linkedAnnotationAnchorTag` becomes available, scroll to it
   // and focus it
   useEffect(() => {
-    if (linkedAnnotationAnchorTag) {
+    if (linkedAnnotation && linkedAnnotationAnchorTag) {
       frameSync.hoverAnnotations([linkedAnnotationAnchorTag]);
-      frameSync.scrollToAnnotation(linkedAnnotationAnchorTag);
+      frameSync.scrollToAnnotation(linkedAnnotation);
       store.selectTab(directLinkedTab);
     } else if (linkedAnnotation) {
       // Make sure to allow for orphaned annotations (which won't have an anchor)

--- a/src/sidebar/components/ThreadCard.js
+++ b/src/sidebar/components/ThreadCard.js
@@ -9,6 +9,7 @@ import { withServices } from '../service-context';
 import Thread from './Thread';
 
 /**
+ * @typedef {import('../../types/api').Annotation} Annotation
  * @typedef {import('../../types/config').SidebarSettings} SidebarSettings
  */
 
@@ -42,9 +43,9 @@ function ThreadCard({ frameSync, thread }) {
   );
 
   const scrollToAnnotation = useCallback(
-    /** @param {string} tag */
-    tag => {
-      frameSync.scrollToAnnotation(tag);
+    /** @param {Annotation} ann */
+    ann => {
+      frameSync.scrollToAnnotation(ann);
     },
     [frameSync]
   );
@@ -88,9 +89,9 @@ function ThreadCard({ frameSync, thread }) {
         // triggering a page scroll.
         if (
           !isFromButtonOrLink(/** @type {Element} */ (e.target)) &&
-          threadTag
+          thread.annotation
         ) {
-          scrollToAnnotation(threadTag);
+          scrollToAnnotation(thread.annotation);
         }
       }}
       onMouseEnter={() => focusThreadAnnotation(threadTag ?? null)}

--- a/src/sidebar/components/test/SidebarView-test.js
+++ b/src/sidebar/components/test/SidebarView-test.js
@@ -134,19 +134,20 @@ describe('SidebarView', () => {
 
   context('when viewing a direct-linked annotation', () => {
     context('successful direct-linked annotation', () => {
+      let fakeAnnotation;
+
       beforeEach(() => {
+        fakeAnnotation = { $orphan: false, $tag: 'myTag' };
         fakeStore.isLoading.returns(false);
         fakeStore.annotationExists.withArgs('someId').returns(true);
         fakeStore.directLinkedAnnotationId.returns('someId');
-        fakeStore.findAnnotationByID
-          .withArgs('someId')
-          .returns({ $orphan: false, $tag: 'myTag' });
+        fakeStore.findAnnotationByID.withArgs('someId').returns(fakeAnnotation);
       });
 
       it('focuses and scrolls to direct-linked annotations once anchored', () => {
         createComponent();
         assert.calledOnce(fakeFrameSync.scrollToAnnotation);
-        assert.calledWith(fakeFrameSync.scrollToAnnotation, 'myTag');
+        assert.calledWith(fakeFrameSync.scrollToAnnotation, fakeAnnotation);
         assert.calledOnce(fakeFrameSync.hoverAnnotations);
         assert.calledWith(
           fakeFrameSync.hoverAnnotations,

--- a/src/sidebar/components/test/ThreadCard-test.js
+++ b/src/sidebar/components/test/ThreadCard-test.js
@@ -73,7 +73,10 @@ describe('ThreadCard', () => {
 
       wrapper.find(threadCardSelector).simulate('click');
 
-      assert.calledWith(fakeFrameSync.scrollToAnnotation, 'myTag');
+      assert.calledWith(
+        fakeFrameSync.scrollToAnnotation,
+        fakeThread.annotation
+      );
     });
 
     it('focuses the annotation thread when mouse enters', () => {

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -190,6 +190,14 @@ export type IntegrationBase = {
   getMetadata(): Promise<DocumentMetadata>;
 
   /**
+   * Navigate to the segment of a document associated with an annotation.
+   *
+   * This is used to navigate to eg. the chapter of an EPUB which corresponds
+   * to an annotation in the sidebar.
+   */
+  navigateToSegment?(ann: AnnotationData): void;
+
+  /**
    * Return information about which section of the document is currently loaded.
    *
    * This is used for content such as EPUBs, where typically one Content Document

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -134,6 +134,9 @@ export type SidebarToGuestEvent =
    */
   | 'loadAnnotations'
 
+  /** Navigate to the segment of a book associated with an annotation. */
+  | 'navigateToSegment'
+
   /**
    * The sidebar is asking the guest(s) to scroll to certain annotation.
    */


### PR DESCRIPTION
When clicking an annotation in the sidebar that corresponds to a different chapter of a VitalSource book than the one that is currently loaded, navigate the book to the chapter associated with the annotation.

**Summary of changes:**

 - Add `goToCfi` and `goToURL` to the set of `<mosaic-book>` APIs that the client uses, and implementations of these in the VitalSource EPUB demo.
 - Add optional `navigateToSegment` method for integrations, which triggers a navigation to the segment (eg. EPUB chapter) of a document that matches an annotation's selectors.
 - Add new `navigateToSegment` sidebar => guest RPC call, which forwards to the integration's `navigateToSegment` implementation.
 - Change `FrameSyncService.scrollToAnnotation` to accept an annotation rather than just a tag, so the service can conveniently match the annotation against the EPUB chapter information for the guest
 - Add logic in `FrameSyncService.scrollToAnnotation` to invoke the `navigateToSegment` RPC method instead of `scrollToAnnotation` if the annotation is in a different segment of the document than is currently loaded.

   Once the navigation to the new segment has completed, the document still needs to be scrolled to the annotation. FrameSyncService service handles this by recording the ID of the annotation in a `_pendingScrollToId` field, and then performing the scroll once the annotation anchors.

**Testing:**

1. In the EPUB demo at http://localhost:3000/document/vitalsource-epub, create the following annotations:
   - Annotation at top of chapter one
   - Annotation in the middle of chapter one (should require frame to be scrolled)
   - Annotation at top of chapter two
   - Annotation in the middle of chapter two
2. Click on the different annotation cards in the sidebar. The client should navigate the book and scroll as needed.

An expected issue is that annotations reload after each navigation, so some sidebar state is lost (eg. scroll position in sidebar). This is going to be addressed separately.