### PR TITLE
Use store selectors instead of drilled `AuthState` object prop

### DIFF
--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -3,7 +3,6 @@ import { useEffect, useMemo } from 'preact/hooks';
 
 import { confirm } from '../../shared/prompts';
 import { serviceConfig } from '../config/service-config';
-import { parseAccountID } from '../helpers/account-id';
 import { shouldAutoDisplayTutorial } from '../helpers/session';
 import { applyTheme } from '../helpers/theme';
 import { withServices } from '../service-context';
@@ -20,34 +19,8 @@ import ToastMessages from './ToastMessages';
 import TopBar from './TopBar';
 
 /**
- * @typedef {import('../../types/api').Profile} Profile
  * @typedef {import('../../types/config').SidebarSettings} SidebarSettings
- * @typedef {import('./UserMenu').AuthState} AuthState
  */
-
-/**
- * Return the user's authentication status from their profile.
- *
- * @param {Profile} profile - The profile object from the API.
- * @return {AuthState}
- */
-function authStateFromProfile(profile) {
-  const parsed = parseAccountID(profile.userid);
-  if (parsed && profile.userid) {
-    let displayName = parsed.username;
-    if (profile.user_info && profile.user_info.display_name) {
-      displayName = profile.user_info.display_name;
-    }
-    return {
-      status: 'logged-in',
-      displayName,
-      userid: profile.userid,
-      username: parsed.username,
-    };
-  } else {
-    return { status: 'logged-out' };
-  }
-}
 
 /**
  * @typedef HypothesisAppProps
@@ -68,17 +41,8 @@ function authStateFromProfile(profile) {
  */
 function HypothesisApp({ auth, frameSync, settings, session, toastMessenger }) {
   const store = useSidebarStore();
-  const hasFetchedProfile = store.hasFetchedProfile();
   const profile = store.profile();
   const route = store.route();
-
-  /** @type {AuthState} */
-  const authState = useMemo(() => {
-    if (!hasFetchedProfile) {
-      return { status: 'unknown' };
-    }
-    return authStateFromProfile(profile);
-  }, [hasFetchedProfile, profile]);
 
   const backgroundStyle = useMemo(
     () => applyTheme(['appBackgroundColor'], settings),
@@ -183,7 +147,6 @@ function HypothesisApp({ auth, frameSync, settings, session, toastMessenger }) {
     >
       {route !== 'notebook' && (
         <TopBar
-          auth={authState}
           onLogin={login}
           onSignUp={signUp}
           onLogout={logout}
@@ -192,7 +155,7 @@ function HypothesisApp({ auth, frameSync, settings, session, toastMessenger }) {
       )}
       <div className="container">
         <ToastMessages />
-        <HelpPanel auth={authState.status === 'logged-in' ? authState : {}} />
+        <HelpPanel />
         <ShareAnnotationsPanel />
 
         {route && (

--- a/src/sidebar/components/TopBar.js
+++ b/src/sidebar/components/TopBar.js
@@ -14,7 +14,6 @@ import StreamSearchInput from './StreamSearchInput';
 import UserMenu from './UserMenu';
 
 /**
- * @typedef {import('../components/UserMenu').AuthState} AuthState
  * @typedef {import('preact').ComponentChildren} Children
  * @typedef {import('../services/frame-sync').FrameSyncService} FrameSyncService
  * @typedef {import('../../types/config').SidebarSettings} SidebarSettings
@@ -23,7 +22,6 @@ import UserMenu from './UserMenu';
 
 /**
  * @typedef TopBarProps
- * @prop {AuthState} auth
  * @prop {FrameSyncService} frameSync - injected
  * @prop {boolean} isSidebar - Flag indicating whether the app is the sidebar or a top-level page.
  * @prop {() => void} onLogin - Callback invoked when user clicks "Login" button.
@@ -40,7 +38,6 @@ import UserMenu from './UserMenu';
  * @param {TopBarProps} props
  */
 function TopBar({
-  auth,
   frameSync,
   isSidebar,
   onLogin,
@@ -55,6 +52,8 @@ function TopBar({
   const store = useSidebarStore();
   const filterQuery = store.filterQuery();
   const pendingUpdateCount = store.pendingUpdateCount();
+  const isLoggedIn = store.isLoggedIn();
+  const hasFetchedProfile = store.hasFetchedProfile();
 
   const applyPendingUpdates = () => streamer.applyPendingUpdates();
 
@@ -134,15 +133,15 @@ function TopBar({
             size="small"
             title="Help"
           />
-          {auth.status === 'logged-in' ? (
-            <UserMenu auth={auth} onLogout={onLogout} />
+          {isLoggedIn ? (
+            <UserMenu onLogout={onLogout} />
           ) : (
             <div
               className="flex items-center text-lg font-medium space-x-1"
               data-testid="login-links"
             >
-              {auth.status === 'unknown' && <span>⋯</span>}
-              {auth.status === 'logged-out' && (
+              {!isLoggedIn && !hasFetchedProfile && <span>⋯</span>}
+              {!isLoggedIn && hasFetchedProfile && (
                 <>
                   <LinkButton
                     classes="inline"

--- a/src/sidebar/components/UserMenu.js
+++ b/src/sidebar/components/UserMenu.js
@@ -2,7 +2,10 @@ import { Icon } from '@hypothesis/frontend-shared';
 import { useState } from 'preact/hooks';
 
 import { serviceConfig } from '../config/service-config';
-import { isThirdPartyUser } from '../helpers/account-id';
+import {
+  isThirdPartyUser,
+  username as getUsername,
+} from '../helpers/account-id';
 import { withServices } from '../service-context';
 import { useSidebarStore } from '../store';
 
@@ -15,17 +18,7 @@ import MenuSection from './MenuSection';
  * /
 
 /**
- * @typedef AuthStateLoggedIn
- * @prop {'logged-in'} status
- * @prop {string} displayName
- * @prop {string} userid
- * @prop {string} username
- * @typedef {{status: 'logged-out'|'unknown'} | AuthStateLoggedIn}  AuthState
- */
-
-/**
  * @typedef UserMenuProps
- * @prop {AuthStateLoggedIn} auth - object representing authenticated user and auth status
  * @prop {() => void} onLogout - onClick callback for the "log out" button
  * @prop {import('../services/frame-sync').FrameSyncService} frameSync
  * @prop {SidebarSettings} settings
@@ -39,12 +32,15 @@ import MenuSection from './MenuSection';
  *
  * @param {UserMenuProps} props
  */
-function UserMenu({ auth, frameSync, onLogout, settings }) {
+function UserMenu({ frameSync, onLogout, settings }) {
   const store = useSidebarStore();
   const defaultAuthority = store.defaultAuthority();
+  const profile = store.profile();
 
-  const isThirdParty = isThirdPartyUser(auth.userid, defaultAuthority);
+  const isThirdParty = isThirdPartyUser(profile.userid, defaultAuthority);
   const service = serviceConfig(settings);
+  const username = getUsername(profile.userid);
+  const displayName = profile.user_info?.display_name ?? username;
   const [isOpen, setOpen] = useState(false);
 
   /** @param {keyof import('../../types/config').Service} feature */
@@ -78,7 +74,7 @@ function UserMenu({ auth, frameSync, onLogout, settings }) {
     const props = {};
     if (isSelectableProfile) {
       if (!isThirdParty) {
-        props.href = store.getLink('user', { user: auth.username });
+        props.href = store.getLink('user', { user: username });
       }
       props.onClick = onProfileSelected;
     }
@@ -96,14 +92,14 @@ function UserMenu({ auth, frameSync, onLogout, settings }) {
     <div data-testid="user-menu" onKeyDown={onKeyDown}>
       <Menu
         label={menuLabel}
-        title={auth.displayName}
+        title={displayName}
         align="right"
         open={isOpen}
         onOpenChanged={setOpen}
       >
         <MenuSection>
           <MenuItem
-            label={auth.displayName}
+            label={displayName}
             isDisabled={!isSelectableProfile}
             {...profileItemProps}
           />

--- a/src/sidebar/components/test/HelpPanel-test.js
+++ b/src/sidebar/components/test/HelpPanel-test.js
@@ -7,7 +7,6 @@ import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('HelpPanel', () => {
-  let fakeAuth;
   let fakeSessionService;
   let fakeStore;
   let frames;
@@ -16,20 +15,23 @@ describe('HelpPanel', () => {
   let fakeVersionData;
 
   function createComponent(props) {
-    return mount(
-      <HelpPanel auth={fakeAuth} session={fakeSessionService} {...props} />
-    );
+    return mount(<HelpPanel session={fakeSessionService} {...props} />);
   }
 
   beforeEach(() => {
     frames = [];
-    fakeAuth = {};
     fakeSessionService = { dismissSidebarTutorial: sinon.stub() };
     fakeStore = {
       frames: () => frames,
       mainFrame: () => frames.find(f => !f.id) ?? null,
       profile: sinon.stub().returns({
-        preferences: { show_sidebar_tutorial: true },
+        preferences: {
+          show_sidebar_tutorial: true,
+        },
+        userid: 'acct:delores@hypothes.is',
+        user_info: {
+          display_name: 'Delores',
+        },
       }),
     };
     fakeVersionData = {
@@ -85,6 +87,16 @@ describe('HelpPanel', () => {
   });
 
   context('when viewing versionInfo sub-panel', () => {
+    it('provides info about the current user', () => {
+      createComponent();
+
+      const userInfo = FakeVersionData.getCall(0).args[0];
+      assert.deepEqual(userInfo, {
+        userid: 'acct:delores@hypothes.is',
+        displayName: 'Delores',
+      });
+    });
+
     it('shows document info for current frames', () => {
       // Unsorted frames
       frames = [

--- a/src/sidebar/components/test/HypothesisApp-test.js
+++ b/src/sidebar/components/test/HypothesisApp-test.js
@@ -145,68 +145,6 @@ describe('HypothesisApp', () => {
     });
   });
 
-  describe('"status" field of "auth" prop passed to children', () => {
-    const getStatus = wrapper => wrapper.find('TopBar').prop('auth').status;
-
-    it('is "unknown" if profile has not yet been fetched', () => {
-      fakeStore.hasFetchedProfile.returns(false);
-      const wrapper = createComponent();
-      assert.equal(getStatus(wrapper), 'unknown');
-    });
-
-    it('is "logged-out" if userid is null', () => {
-      fakeStore.profile.returns({ userid: null });
-      const wrapper = createComponent();
-      assert.equal(getStatus(wrapper), 'logged-out');
-    });
-
-    it('is "logged-in" if userid is non-null', () => {
-      fakeStore.profile.returns({ userid: 'acct:jimsmith@hypothes.is' });
-      const wrapper = createComponent();
-      assert.equal(getStatus(wrapper), 'logged-in');
-    });
-  });
-
-  [
-    {
-      // User who has set a display name
-      profile: {
-        userid: 'acct:jim@hypothes.is',
-        user_info: {
-          display_name: 'Jim Smith',
-        },
-      },
-      expectedAuth: {
-        status: 'logged-in',
-        userid: 'acct:jim@hypothes.is',
-        username: 'jim',
-        displayName: 'Jim Smith',
-      },
-    },
-    {
-      // User who has not set a display name
-      profile: {
-        userid: 'acct:jim@hypothes.is',
-        user_info: {
-          display_name: null,
-        },
-      },
-      expectedAuth: {
-        status: 'logged-in',
-        userid: 'acct:jim@hypothes.is',
-        username: 'jim',
-        displayName: 'jim',
-      },
-    },
-  ].forEach(({ profile, expectedAuth }) => {
-    it('passes expected "auth" prop to children', () => {
-      fakeStore.profile.returns(profile);
-      const wrapper = createComponent();
-      const auth = wrapper.find('TopBar').prop('auth');
-      assert.deepEqual(auth, expectedAuth);
-    });
-  });
-
   describe('"Sign up" action', () => {
     const clickSignUp = wrapper => wrapper.find('TopBar').props().onSignUp();
 

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -17,6 +17,8 @@ describe('TopBar', () => {
 
     fakeStore = {
       filterQuery: sinon.stub().returns(null),
+      hasFetchedProfile: sinon.stub().returns(false),
+      isLoggedIn: sinon.stub().returns(false),
       isSidebarPanelOpen: sinon.stub().returns(false),
       pendingUpdateCount: sinon.stub().returns(0),
       setFilterQuery: sinon.stub(),
@@ -54,10 +56,8 @@ describe('TopBar', () => {
   }
 
   function createTopBar(props = {}) {
-    const auth = { status: 'unknown' };
     return mount(
       <TopBar
-        auth={auth}
         frameSync={fakeFrameSync}
         isSidebar={true}
         settings={fakeSettings}
@@ -131,18 +131,21 @@ describe('TopBar', () => {
     const getLoginText = wrapper => wrapper.find('[data-testid="login-links"]');
 
     it('Shows ellipsis when login state is unknown', () => {
-      const wrapper = createTopBar({ auth: { status: 'unknown' } });
+      fakeStore.hasFetchedProfile.returns(false);
+      fakeStore.isLoggedIn.returns(false);
+      const wrapper = createTopBar();
       const loginText = getLoginText(wrapper);
       assert.isTrue(loginText.exists());
       assert.equal(loginText.text(), '⋯');
     });
 
     it('Shows "Log in" and "Sign up" links when user is logged out', () => {
+      fakeStore.hasFetchedProfile.returns(true);
+      fakeStore.isLoggedIn.returns(false);
       const onLogin = sinon.stub();
       const onSignUp = sinon.stub();
 
       const wrapper = createTopBar({
-        auth: { status: 'logged-out' },
         onLogin,
         onSignUp,
       });
@@ -155,14 +158,16 @@ describe('TopBar', () => {
     });
 
     it('Shows user menu when logged in', () => {
+      fakeStore.hasFetchedProfile.returns(true);
+      fakeStore.isLoggedIn.returns(true);
+
       const onLogout = sinon.stub();
-      const auth = { status: 'logged-in' };
-      const wrapper = createTopBar({ auth, onLogout });
+      const wrapper = createTopBar({ onLogout });
       assert.isFalse(getLoginText(wrapper).exists());
 
       const userMenu = wrapper.find('UserMenu');
       assert.isTrue(userMenu.exists());
-      assert.include(userMenu.props(), { auth, onLogout });
+      assert.include(userMenu.props(), { onLogout });
     });
   });
 

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -5,7 +5,7 @@ import { mockImportedComponents } from '../../../test-util/mock-imported-compone
 import UserMenu, { $imports } from '../UserMenu';
 
 describe('UserMenu', () => {
-  let fakeAuth;
+  let fakeProfile;
   let fakeFrameSync;
   let fakeIsThirdPartyUser;
   let fakeOnLogout;
@@ -16,7 +16,6 @@ describe('UserMenu', () => {
   const createUserMenu = () => {
     return mount(
       <UserMenu
-        auth={fakeAuth}
         frameSync={fakeFrameSync}
         onLogout={fakeOnLogout}
         settings={fakeSettings}
@@ -31,11 +30,11 @@ describe('UserMenu', () => {
   };
 
   beforeEach(() => {
-    fakeAuth = {
-      displayName: 'Eleanor Fishtail',
-      status: 'logged-in',
+    fakeProfile = {
+      user_info: {
+        display_name: 'Eleanor Fishtail',
+      },
       userid: 'acct:eleanorFishtail@hypothes.is',
-      username: 'eleanorFishy',
     };
     fakeFrameSync = { notifyHost: sinon.stub() };
     fakeIsThirdPartyUser = sinon.stub();
@@ -46,6 +45,7 @@ describe('UserMenu', () => {
       defaultAuthority: sinon.stub().returns('hypothes.is'),
       focusedGroupId: sinon.stub().returns('mygroup'),
       getLink: sinon.stub(),
+      profile: sinon.stub().returns(fakeProfile),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -72,21 +72,30 @@ describe('UserMenu', () => {
       it('should be enabled', () => {
         const wrapper = createUserMenu();
 
-        const profileMenuItem = findMenuItem(wrapper, fakeAuth.displayName);
+        const profileMenuItem = findMenuItem(
+          wrapper,
+          fakeProfile.user_info.display_name
+        );
         assert.notOk(profileMenuItem.prop('isDisabled'));
       });
 
       it('should have a link (href)', () => {
         const wrapper = createUserMenu();
 
-        const profileMenuItem = findMenuItem(wrapper, fakeAuth.displayName);
+        const profileMenuItem = findMenuItem(
+          wrapper,
+          fakeProfile.user_info.display_name
+        );
         assert.equal(profileMenuItem.prop('href'), 'profile-link');
       });
 
       it('should have a callback', () => {
         const wrapper = createUserMenu();
 
-        const profileMenuItem = findMenuItem(wrapper, fakeAuth.displayName);
+        const profileMenuItem = findMenuItem(
+          wrapper,
+          fakeProfile.user_info.display_name
+        );
         assert.isFunction(profileMenuItem.prop('onClick'));
       });
     });
@@ -101,7 +110,10 @@ describe('UserMenu', () => {
 
         const wrapper = createUserMenu();
 
-        const profileMenuItem = findMenuItem(wrapper, fakeAuth.displayName);
+        const profileMenuItem = findMenuItem(
+          wrapper,
+          fakeProfile.user_info.display_name
+        );
         assert.isTrue(profileMenuItem.prop('isDisabled'));
       });
 
@@ -110,7 +122,10 @@ describe('UserMenu', () => {
 
         const wrapper = createUserMenu();
 
-        const profileMenuItem = findMenuItem(wrapper, fakeAuth.displayName);
+        const profileMenuItem = findMenuItem(
+          wrapper,
+          fakeProfile.user_info.display_name
+        );
         assert.isTrue(profileMenuItem.prop('isDisabled'));
       });
 
@@ -119,7 +134,10 @@ describe('UserMenu', () => {
 
         const wrapper = createUserMenu();
 
-        const profileMenuItem = findMenuItem(wrapper, fakeAuth.displayName);
+        const profileMenuItem = findMenuItem(
+          wrapper,
+          fakeProfile.user_info.display_name
+        );
         assert.notOk(profileMenuItem.prop('isDisabled'));
       });
 
@@ -128,7 +146,10 @@ describe('UserMenu', () => {
 
         const wrapper = createUserMenu();
 
-        const profileMenuItem = findMenuItem(wrapper, fakeAuth.displayName);
+        const profileMenuItem = findMenuItem(
+          wrapper,
+          fakeProfile.user_info.display_name
+        );
         assert.isFunction(profileMenuItem.prop('onClick'));
       });
     });
@@ -138,7 +159,10 @@ describe('UserMenu', () => {
         fakeServiceConfig.returns({ onProfileRequestProvided: true });
         fakeIsThirdPartyUser.returns(true);
         const wrapper = createUserMenu();
-        const profileMenuItem = findMenuItem(wrapper, fakeAuth.displayName);
+        const profileMenuItem = findMenuItem(
+          wrapper,
+          fakeProfile.user_info.display_name
+        );
         const onProfileSelected = profileMenuItem.prop('onClick');
 
         onProfileSelected();
@@ -150,7 +174,10 @@ describe('UserMenu', () => {
       it('should not fire profile event for first-party user', () => {
         fakeIsThirdPartyUser.returns(false);
         const wrapper = createUserMenu();
-        const profileMenuItem = findMenuItem(wrapper, fakeAuth.displayName);
+        const profileMenuItem = findMenuItem(
+          wrapper,
+          fakeProfile.user_info.display_name
+        );
         const onProfileSelected = profileMenuItem.prop('onClick');
 
         onProfileSelected();

--- a/src/sidebar/helpers/version-data.js
+++ b/src/sidebar/helpers/version-data.js
@@ -1,37 +1,22 @@
 /**
  * @typedef {import('../../types/annotator').SegmentInfo} SegmentInfo
+ * @typedef {import('../store/modules/frames').Frame} Frame
  */
 
 /**
- * @typedef AuthState
+ * @typedef UserDetails
  * @prop {string|null} [userid]
  * @prop {string} [displayName]
  */
 
-/**
- * An object representing document metadata.
- *
- * @typedef DocMetadata
- * @prop {string=} documentFingerprint - Optional PDF fingerprint for current document
- */
-
-/**
- * An object representing document info.
- *
- * @typedef DocumentInfo
- * @prop {string=} [uri] - Current document URL
- * @prop {DocMetadata} [metadata] - Document metadata
- * @prop {SegmentInfo} [segment]
- */
-
 export class VersionData {
   /**
-   * @param {AuthState} userInfo
-   * @param {DocumentInfo[]} documentInfo - Metadata for connected frames.
+   * @param {UserDetails} userInfo
+   * @param {Frame[]} documentFrames - Metadata for connected frames.
    *   If there are multiple frames, the "main" one should be listed first.
    * @param {Window} window_ - test seam
    */
-  constructor(userInfo, documentInfo, window_ = window) {
+  constructor(userInfo, documentFrames, window_ = window) {
     const noValueString = 'N/A';
 
     let accountString = noValueString;
@@ -44,16 +29,16 @@ export class VersionData {
 
     this.version = '__VERSION__';
     this.userAgent = window_.navigator.userAgent;
-    this.urls = documentInfo.map(di => di.uri).join(', ') || noValueString;
+    this.urls = documentFrames.map(df => df.uri).join(', ') || noValueString;
 
     // We currently assume that only the main (first) frame may have a fingerprint.
     this.fingerprint =
-      documentInfo[0]?.metadata?.documentFingerprint ?? noValueString;
+      documentFrames[0]?.metadata?.documentFingerprint ?? noValueString;
 
     this.account = accountString;
     this.timestamp = new Date().toString();
 
-    const segmentInfo = documentInfo[0]?.segment;
+    const segmentInfo = documentFrames[0]?.segment;
     if (segmentInfo) {
       const segmentFields = [];
       if (segmentInfo.cfi) {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -139,6 +139,10 @@ export type Target = {
   selector?: Selector[];
 };
 
+export type UserInfo = {
+  display_name: string | null;
+};
+
 export type Annotation = ClientAnnotationData & {
   /**
    * The server-assigned ID for the annotation. This is only set once the
@@ -197,9 +201,7 @@ export type Annotation = ClientAnnotationData & {
     html?: string;
   };
 
-  user_info?: {
-    display_name: string | null;
-  };
+  user_info?: UserInfo;
 };
 
 /**
@@ -213,9 +215,7 @@ export type Profile = {
     show_sidebar_tutorial?: boolean;
   };
   features: Record<string, boolean>;
-  user_info?: {
-    display_name: string | null;
-  };
+  user_info?: UserInfo;
 };
 
 export type Organization = {


### PR DESCRIPTION
Instead of drilling a single `AuthState` object cobbled together by `HypothesisApp` down through a number of components — each of which make use of different properties on the object in different ways — get what's needed in each component using store selectors

Resolve related, potentially-confusing duplicate or misleading type names in `version-data`.

This simplifies `HypothesisApp` and reduces potential for type-related confusion.