### PR TITLE
Fix `onDocumentReady` handling of disconnected frames

### DIFF
--- a/src/annotator/frame-observer.js
+++ b/src/annotator/frame-observer.js
@@ -186,8 +186,15 @@ export function onDocumentReady(frame, callback, { pollInterval = 10 } = {}) {
 
   const checkForDocumentChange = () => {
     const currentDocument = frame.contentDocument;
+
+    // `contentDocument` may be null if the frame navigated to a URL that is
+    // cross-origin, or if the `<iframe>` was removed from the document.
     if (!currentDocument) {
-      callback(new Error('Frame is cross-origin'));
+      cancelPoll();
+      const errorMessage = frame.isConnected
+        ? 'Frame is cross-origin'
+        : 'Frame is disconnected';
+      callback(new Error(errorMessage));
       return;
     }
 

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -198,7 +198,13 @@ export class VitalSourceInjector {
       }
       contentFrames.add(frame);
       onDocumentReady(frame, (err, document_) => {
-        const body = document_?.body;
+        if (err) {
+          return;
+        }
+
+        // If `err` is null, then `document_` will be set.
+        const body = document_!.body;
+
         const isBookContent =
           body &&
           // Check that this is not the temporary page containing encrypted and


### PR DESCRIPTION
This PR fixes a bug in the `onDocumentReady` helper, which is used to monitor VitalSource content frames for navigations. When a chapter navigation occurred and the previous chapter's frame was removed from the DOM, this helper would fire its callback repeatedly with the same error. The issue didn't cause any visible problems since the callback did nothing in this case, but it wasted resources.

- Add missing logic in `onDocumentReady` to cancel a `setInterval` poll after reporting an error
- Make `onDocumentReady` call callback with more appropriate error if the frame's `contentDocument` is not accessible because the frame was removed from the document, as opposed to being navigated to a cross-origin URL
- Add missing check for `onDocumentReady` calling its callback with an error in the VitalSource integration