### PR TITLE
Make temporary VitalSource page loaded after navigation more realistic

### DIFF
--- a/dev-server/documents/html/vitalsource-temp-page.mustache
+++ b/dev-server/documents/html/vitalsource-temp-page.mustache
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <title>content</title>
+  </head>
+  <body>
+    <!-- Temporary page that VitalSource viewer loads immediately after a
+         navigation to a different chapter.
+
+         In the real version of this page, the #page-content element contains
+         encrypted data for the page.
+
+         The VitalSource integration recognizes this page and doesn't try to
+         inject the client into it. -->
+    <div id="page-content">abcdef</div>
+  </body>
+</html>

--- a/dev-server/static/scripts/vitalsource-mosaic-book-element.js
+++ b/dev-server/static/scripts/vitalsource-mosaic-book-element.js
@@ -127,7 +127,7 @@ export class MosaicBookElement extends HTMLElement {
       //    submission, which returns the decoded HTML.
       //
       // The client should only inject into the new frame after step 3.
-      this.contentFrame.src = 'about:blank';
+      this.contentFrame.src = '/document/vitalsource-temp-page';
       setTimeout(() => {
         // Set the final URL in a way that doesn't update the `src` attribute
         // of the iframe, to make sure the client isn't relying on that.


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/client/pull/4952**~~

Make the temporary page loaded during a VitalSource chapter navigation more realistic by:

 1. Having a URL that is not `about:blank`.
 2. Having content with a `#page-content` element

Change (1) enables the `onDocumentReady` helper to realize that the initial `about:blank` URL of the new chapter's iframe is about to navigate to a different URL (the URL of the temporary page). See the `hasBlankDocumentThatWillNavigate` function.

Change (2) allows the `onDocumentReady` callback in `VitalSourceInjector` to detect that the temporary page is not the real chapter content, and skip loading the client into it.

Together these two changes are steps towards more seamless handling of chapter transitions in the sidebar.