### PR TITLE
Enable prototyped clustered highlights in PDF documents

### DIFF
--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -1,5 +1,3 @@
-import classnames from 'classnames';
-
 import { ListenerCollection } from '../shared/listener-collection';
 import { PortFinder, PortRPC } from '../shared/messaging';
 import { generateHexString } from '../shared/random';
@@ -526,7 +524,7 @@ export class Guest implements Annotator, Destroyable {
 
       const highlights = highlightRange(
         range,
-        classnames('hypothesis-highlight', anchor.annotation?.$cluster)
+        anchor.annotation?.$cluster /* cssClass */
       ) as AnnotationHighlight[];
       highlights.forEach(h => {
         h._annotation = anchor.annotation;

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -242,9 +242,12 @@ export class Guest implements Annotator, Destroyable {
     }
 
     if (this._integration.canStyleClusteredHighlights?.()) {
-      this._clusterToolbar = new HighlightClusterController(element, {
-        features: this.features,
-      });
+      this._clusterToolbar = new HighlightClusterController(
+        this._integration.contentContainer(),
+        {
+          features: this.features,
+        }
+      );
     }
 
     this._hostRPC = new PortRPC();

--- a/src/annotator/highlight-clusters.tsx
+++ b/src/annotator/highlight-clusters.tsx
@@ -77,7 +77,7 @@ export class HighlightClusterController implements Destroyable {
     // For now, the controls are fixed at top-left of screen. This is temporary.
     Object.assign(this._outerContainer.style, {
       position: 'fixed',
-      top: '4px',
+      top: `${this._element.offsetTop + 4}px`,
       left: '4px',
     });
 

--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -1,3 +1,5 @@
+import classnames from 'classnames';
+
 import { isInPlaceholder } from './anchoring/placeholder';
 import { isNodeInRange } from './range-util';
 
@@ -50,8 +52,9 @@ function getPDFCanvas(highlightEl) {
  * @param {HighlightElement[]} highlightEls -
  *   An element that wraps the highlighted text in the transparent text layer
  *   above the PDF.
+ * @param {string} [cssClass] - CSS class(es) to add to the SVG highlight elements
  */
-function drawHighlightsAbovePDFCanvas(highlightEls) {
+function drawHighlightsAbovePDFCanvas(highlightEls, cssClass) {
   if (highlightEls.length === 0) {
     return;
   }
@@ -104,7 +107,10 @@ function drawHighlightsAbovePDFCanvas(highlightEls) {
     rect.setAttribute('y', (highlightRect.top - canvasRect.top).toString());
     rect.setAttribute('width', highlightRect.width.toString());
     rect.setAttribute('height', highlightRect.height.toString());
-    rect.setAttribute('class', 'hypothesis-svg-highlight');
+    rect.setAttribute(
+      'class',
+      classnames('hypothesis-svg-highlight', cssClass)
+    );
 
     // Make the highlight in the text layer transparent.
     highlightEl.classList.add('is-transparent');
@@ -199,10 +205,10 @@ function wholeTextNodesInRange(range) {
  * element of the specified class and returns the highlight Elements.
  *
  * @param {Range} range - Range to be highlighted
- * @param {string} cssClass - A CSS class to use for the highlight
+ * @param {string} [cssClass] - CSS class(es) to add to the highlight elements
  * @return {HighlightElement[]} - Elements wrapping text in `normedRange` to add a highlight effect
  */
-export function highlightRange(range, cssClass = 'hypothesis-highlight') {
+export function highlightRange(range, cssClass) {
   const textNodes = wholeTextNodesInRange(range);
 
   // Check if this range refers to a placeholder for not-yet-rendered content in
@@ -242,7 +248,7 @@ export function highlightRange(range, cssClass = 'hypothesis-highlight') {
 
     /** @type {HighlightElement} */
     const highlightEl = document.createElement('hypothesis-highlight');
-    highlightEl.className = cssClass;
+    highlightEl.className = classnames('hypothesis-highlight', cssClass);
 
     const parent = /** @type {Node} */ (nodes[0].parentNode);
     parent.replaceChild(highlightEl, nodes[0]);
@@ -261,7 +267,7 @@ export function highlightRange(range, cssClass = 'hypothesis-highlight') {
   // to reduce the number of forced reflows. We also skip creating them for
   // unrendered pages for performance reasons.
   if (!inPlaceholder) {
-    drawHighlightsAbovePDFCanvas(highlights);
+    drawHighlightsAbovePDFCanvas(highlights, cssClass);
   }
 
   return highlights;

--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -202,6 +202,11 @@ export class PDFIntegration extends TinyEmitter {
     return canDescribe(range);
   }
 
+  /* istanbul ignore next */
+  canStyleClusteredHighlights() {
+    return true;
+  }
+
   /**
    * Generate selectors for the text in `range`.
    *

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1162,7 +1162,7 @@ describe('Guest', () => {
 
       assert.equal(
         highlighter.highlightRange.lastCall.args[1],
-        'hypothesis-highlight user-annotations'
+        'user-annotations'
       );
     });
 

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -47,26 +47,30 @@ function PDFPage({ showPlaceholder = false }) {
  *
  * @param {HTMLElement} pageContainer - HTML element into which `PDFPage`
  *   component has been rendered
+ * @param {string} [cssClass] additional CSS class(es) to apply to the highlight
+ *   and SVG rect elements
  * @return {HTMLElement} - `<hypothesis-highlight>` element
  */
-function highlightPDFRange(pageContainer) {
+function highlightPDFRange(pageContainer, cssClass = '') {
   const textSpan = pageContainer.querySelector('.testText');
   const range = new Range();
   range.setStartBefore(textSpan.childNodes[0]);
   range.setEndAfter(textSpan.childNodes[0]);
-  return highlightRange(range);
+  return highlightRange(range, cssClass);
 }
 
 /**
  * Render a fake PDF.js page (`PDFPage`) and return its container.
  *
+ * @param {string} [cssClass] additional CSS class(es) to apply to the highlight
+ *   and SVG rect elements
  * @return {HTMLElement}
  */
-function createPDFPageWithHighlight() {
+function createPDFPageWithHighlight(cssClass = '') {
   const container = document.createElement('div');
   render(<PDFPage />, container);
 
-  highlightPDFRange(container);
+  highlightPDFRange(container, cssClass);
 
   return container;
 }
@@ -81,12 +85,13 @@ describe('annotator/highlighter', () => {
       range.setStartBefore(text);
       range.setEndAfter(text);
 
-      const result = highlightRange(range);
+      const result = highlightRange(range, 'extra-css-class');
 
       assert.equal(result.length, 1);
       assert.strictEqual(el.childNodes[0], result[0]);
       assert.equal(result[0].nodeName, 'HYPOTHESIS-HIGHLIGHT');
       assert.isTrue(result[0].classList.contains('hypothesis-highlight'));
+      assert.isTrue(result[0].classList.contains('extra-css-class'));
     });
 
     const testText = 'one two three';
@@ -144,7 +149,7 @@ describe('annotator/highlighter', () => {
 
       assert.equal(
         el.innerHTML,
-        'foo <hypothesis-highlight class="">bar baz</hypothesis-highlight>'
+        'foo <hypothesis-highlight class="hypothesis-highlight">bar baz</hypothesis-highlight>'
       );
     });
 
@@ -248,6 +253,14 @@ describe('annotator/highlighter', () => {
         const page = createPDFPageWithHighlight();
         const highlight = page.querySelector('hypothesis-highlight');
         assert.isTrue(highlight.classList.contains('is-transparent'));
+      });
+
+      it('add extra CSS classes to both the highlight and SVG rect', () => {
+        const page = createPDFPageWithHighlight('extra-css-class');
+        const highlight = page.querySelector('hypothesis-highlight');
+        const svgRect = page.querySelector('rect');
+        assert.isTrue(highlight.classList.contains('extra-css-class'));
+        assert.isTrue(svgRect.classList.contains('extra-css-class'));
       });
 
       it('creates an SVG layer above the PDF canvas and draws a highlight in that', () => {

--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -31,14 +31,9 @@
 }
 
 // Configure highlight styling.
-
 // Map `--hypothesis-*` root values to local `--highlight-*` values
+.hypothesis-highlight,
 .hypothesis-svg-highlight {
-  --highlight-color: var(--hypothesis-highlight-color);
-  --highlight-color-focused: var(--hypothesis-highlight-focused-color);
-}
-
-.hypothesis-highlight {
   --highlight-color: var(--hypothesis-highlight-color);
   --highlight-blend-mode: var(--hypothesis-highlight-blend-mode);
   --highlight-decoration: var(--hypothesis-highlight-decoration);
@@ -56,7 +51,8 @@
 
 // Configure clustered highlight styling. The `.hypothesis-highlights-clustered`
 // class is managed by `highlight-clusters`
-.hypothesis-highlights-clustered .hypothesis-highlight {
+.hypothesis-highlights-clustered .hypothesis-highlight,
+.hypothesis-highlights-clustered .hypothesis-svg-highlight {
   // When clustered highlights are active, use an opaque blue for focused
   // annotations so we don't end up with a funny color mix
   --highlight-color-focused: var(--hypothesis-color-blue);


### PR DESCRIPTION
This PR enables basic clustered highlight styling and controls for PDF documents. The styling approach for PDFs, for now, is more basic than HTML documents in that there is no distinct styling for nested highlights and no blending of overlaid highlight colors.

@robertknight and I discussed today how we might enhance this in the future, but that will require moderate to significant effort, so getting this basic variant enabled seems like a step forward. The good news is that I believe this styling approach to be simple and resilient.

The first commit here refactors `highlighter` very slightly to pass extra CSS classes through to the drawn SVG rects, and to be consistent about extending, not replacing, CSS classes with the `cssClass` argument.

## Testing

* Enable the `styled_highlight_clusters` feature flag at http://localhost:5000/admin/features
* View a PDF document in the dev server, e.g. http://localhost:3000/pdf/budlong
* You should see controls positioned at top left, and basic clustered highlight styling should be applied