### PR TITLE
Ensure we do not set text color on HTML highlights in PDF documents

### DIFF
--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -113,6 +113,7 @@
   // highlight effect is created by another element.
   &.is-transparent {
     background-color: transparent !important;
+    color: inherit !important;
   }
 }
 


### PR DESCRIPTION
We need to emphatically not set a foreground color for span-like HTML highlights in PDF documents. The `is-transparent` class has historically been managed with `!important` rules, which in this use case seems relatively sensible.

Testing:

* On `main`, view a dev-server PDF document with the `style_clustered_highlights` feature flag enabled. You will see some subtle ghosting that results from setting a foreground color.
* On this branch, this issue is resolved.