### PR TITLE
Avoid unloading annotations after VitalSource segment navigation

### DIFF
--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -345,6 +345,7 @@ export class Guest implements Annotator, Destroyable {
       uri: normalizeURI(uri),
       metadata,
       segmentInfo,
+      persistent: this._integration.persistFrame?.() ?? false,
     };
   }
 

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -29,6 +29,7 @@ import type {
   Anchor,
   ContentInfoConfig,
   Destroyable,
+  DocumentInfo,
   Integration,
   SidebarLayout,
 } from '../types/annotator';
@@ -333,7 +334,7 @@ export class Guest implements Annotator, Destroyable {
   /**
    * Retrieve metadata for the current document.
    */
-  async getDocumentInfo() {
+  async getDocumentInfo(): Promise<DocumentInfo> {
     const [uri, metadata, segmentInfo] = await Promise.all([
       this._integration.uri(),
       this._integration.getMetadata(),

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -280,6 +280,11 @@ describe('annotator/integrations/vitalsource', () => {
       assert.isTrue(integration.waitForFeatureFlags());
     });
 
+    it('asks sidebar to persist annotations after frame unloads', () => {
+      const integration = createIntegration();
+      assert.isTrue(integration.persistFrame());
+    });
+
     it('delegates to HTMLIntegration for side-by-side mode', () => {
       const integration = createIntegration();
       assert.calledOnce(FakeHTMLIntegration);

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -539,6 +539,12 @@ export class VitalSourceContentIntegration
     }
   }
 
+  persistFrame() {
+    // Hint to the sidebar that it should not unload annotations when the
+    // guest frame using this integration unloads.
+    return true;
+  }
+
   async segmentInfo(): Promise<SegmentInfo> {
     const pageInfo = await this._bookElement.getCurrentPage();
     return {

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1430,6 +1430,7 @@ describe('Guest', () => {
         documentFingerprint: 'test-fingerprint',
       },
       segmentInfo: undefined,
+      persistent: false,
     });
   });
 
@@ -1448,13 +1449,14 @@ describe('Guest', () => {
     assert.isTrue(sidebarRPC().call.calledWith('documentInfoChanged'));
   });
 
-  it('sends segment info to sidebar when available', async () => {
+  it('sends segment info and persistent hint to sidebar when available', async () => {
     fakeIntegration.uri.resolves('https://bookstore.com/books/1234');
     fakeIntegration.getMetadata.resolves({ title: 'A little book' });
     fakeIntegration.segmentInfo = sinon.stub().resolves({
       cfi: '/2',
       url: '/chapters/02.xhtml',
     });
+    fakeIntegration.persistFrame = sinon.stub().returns(true);
 
     createGuest();
     await delay(0);
@@ -1468,6 +1470,7 @@ describe('Guest', () => {
         cfi: '/2',
         url: '/chapters/02.xhtml',
       },
+      persistent: true,
     });
   });
 
@@ -1485,6 +1488,7 @@ describe('Guest', () => {
         title: 'Page 1',
       },
       segmentInfo: undefined,
+      persistent: false,
     });
 
     sidebarRPCCall.resetHistory();
@@ -1500,6 +1504,7 @@ describe('Guest', () => {
         title: 'Page 2',
       },
       segmentInfo: undefined,
+      persistent: false,
     });
   });
 

--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -288,6 +288,7 @@ export class FrameSyncService {
         metadata: info.metadata,
         uri: info.uri,
         segment: info.segmentInfo,
+        persistent: info.persistent,
       });
     });
 
@@ -296,9 +297,16 @@ export class FrameSyncService {
 
     guestRPC.on('close', () => {
       const frame = this._store.frames().find(f => f.id === sourceId);
-      if (frame) {
+      if (frame && !frame.persistent) {
         this._store.destroyFrame(frame);
       }
+
+      // Mark annotations as no longer being loaded in the guest, even if
+      // the frame was marked as `persistent`. In that case if a new guest
+      // connects with the same ID as the one that just went away, we'll send
+      // the already-loaded annotations to the new guest.
+      this._inFrame.clear();
+
       guestRPC.destroy();
       this._guestRPC.delete(sourceId);
     });

--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -13,11 +13,7 @@ import { annotationMatchesSegment } from '../helpers/annotation-segment';
 import { watch } from '../util/watch';
 
 import type { Message } from '../../shared/messaging';
-import type {
-  AnnotationData,
-  DocumentMetadata,
-  SegmentInfo,
-} from '../../types/annotator';
+import type { AnnotationData, DocumentInfo } from '../../types/annotator';
 import type { Annotation } from '../../types/api';
 import type {
   SidebarToHostEvent,
@@ -28,12 +24,6 @@ import type {
 import type { SidebarStore } from '../store';
 import type { Frame } from '../store/modules/frames';
 import type { AnnotationsService } from './annotations';
-
-type DocumentInfo = {
-  uri: string;
-  metadata: DocumentMetadata;
-  segmentInfo?: SegmentInfo;
-};
 
 /**
  * Return a minimal representation of an annotation that can be sent from the

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -20,6 +20,8 @@ import { createStoreModule, makeAction } from '../create-store';
  * @prop {DocumentMetadata} metadata - Metadata about the document currently loaded in this frame
  * @prop {string} uri - Current primary URI of the document being displayed
  * @prop {boolean} [isAnnotationFetchComplete]
+ * @prop {boolean} persistent - Should this frame be retained in the sidebar
+ *   if the guest disconnects?
  * @prop {SegmentInfo} [segment] - Information about the section of a document
  *   that is currently loaded. This is for content such as EPUBs, where the
  *   content displayed in a guest frame is only part of the whole document.

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -227,6 +227,12 @@ export type IntegrationBase = {
    * sidebar before sending initial document info to the sidebar.
    */
   waitForFeatureFlags?(): boolean;
+
+  /**
+   * Whether the Guest should set the {@link DocumentInfo.persistent} flag when
+   * reporting document information to the sidebar.
+   */
+  persistFrame?(): boolean;
 };
 
 export type Integration = Destroyable & TinyEmitter & IntegrationBase;
@@ -317,4 +323,13 @@ export type DocumentInfo = {
    * This is used in EPUBs for example.
    */
   segmentInfo?: SegmentInfo;
+
+  /**
+   * A hint that the frame is likely to be replaced by another guest frame
+   * showing a different segment of the same document in future.
+   *
+   * This flag is used to facilitate more seamless transitions between
+   * book chapters.
+   */
+  persistent: boolean;
 };

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -296,3 +296,25 @@ export type ContentInfoConfig = {
   container: ContentInfoItem;
   links: ContentInfoLinks;
 };
+
+/**
+ * Details about the document that is loaded in a guest frame.
+ */
+export type DocumentInfo = {
+  /**
+   * The main URI of the document. This is the primary URI that is associated with
+   * annotations created on the document.
+   */
+  uri: string;
+
+  /** Additional URIs and other metadata about the document. */
+  metadata: DocumentMetadata;
+
+  /**
+   * Information about which segment (page, chapter etc.) of a multi-segment
+   * document is loaded in a guest frame.
+   *
+   * This is used in EPUBs for example.
+   */
+  segmentInfo?: SegmentInfo;
+};


### PR DESCRIPTION
This PR makes transitions between VitalSource book chapters more seamless by avoiding unloading and then reloading annotations when a chapter navigation occurs. As well as making the navigation look better, it also avoids losing the user's scroll position in the sidebar.

To accomplish this, the concept of "persistent" frames is introduced. This is a flag which can be set on a `Frame` in the sidebar's store to prevent annotations from being unloaded when the associated guest unloads. This flag is set in response to a hint provided by the `Guest` in its `documentInfoChanged` message. The guest in turn gets this hint via `Integration.persistFrame`. The VitalSource integration sets this hint for the content frame.

The first commit moves the existing `DocumentInfo` type, which is the argument for the `documentInfoChanged` message, from `frame-sync-service.ts` to the shared `annotator.ts` types module. The second commit adds the code for persistent frames.

**Testing:**

1. Go to http://localhost:3000/document/vitalsource-epub, make annotations on different chapters and click on the annotations in the sidebar. The book should navigate without losing the scroll position in the sidebar or reloading annotations.
2. To compare behavior with an integration that does not use persistent frames, go to http://localhost:3000/document/parent-frame. Make annotations on the main frame and iframe, and then click the "Toggle frame" button. Annotations will be unloaded/loaded as the frame is removed and re-added.

A known limitation with (2) is that annotations get re-anchored in the main frame each time the iframe is removed or re-added, leading to flickering of highlights in the main frame. Fixing this will require the sidebar to remember more granularly which frames have annotations anchored in them.