### PR TITLE
Handle hovering annotations which are not loaded in guest frame

### DIFF
--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -55,13 +55,6 @@ function SidebarView({
   const sidebarHasOpened = store.hasSidebarOpened();
   const userId = store.profile().userid;
 
-  // The local `$tag` of a direct-linked annotation; populated once it
-  // has anchored: meaning that it's ready to be focused and scrolled to
-  const linkedAnnotationAnchorTag =
-    linkedAnnotation && linkedAnnotation.$orphan === false
-      ? linkedAnnotation.$tag
-      : null;
-
   // If, after loading completes, no `linkedAnnotation` object is present when
   // a `linkedAnnotationId` is set, that indicates an error
   const hasDirectLinkedAnnotationError =
@@ -116,21 +109,15 @@ function SidebarView({
   // When a `linkedAnnotationAnchorTag` becomes available, scroll to it
   // and focus it
   useEffect(() => {
-    if (linkedAnnotation && linkedAnnotationAnchorTag) {
-      frameSync.hoverAnnotations([linkedAnnotationAnchorTag]);
+    if (linkedAnnotation && linkedAnnotation.$orphan === false) {
+      frameSync.hoverAnnotation(linkedAnnotation);
       frameSync.scrollToAnnotation(linkedAnnotation);
       store.selectTab(directLinkedTab);
     } else if (linkedAnnotation) {
       // Make sure to allow for orphaned annotations (which won't have an anchor)
       store.selectTab(directLinkedTab);
     }
-  }, [
-    directLinkedTab,
-    frameSync,
-    linkedAnnotation,
-    linkedAnnotationAnchorTag,
-    store,
-  ]);
+  }, [directLinkedTab, frameSync, linkedAnnotation, store]);
 
   // Connect to the streamer when the sidebar has opened or if user is logged in
   const hasFetchedProfile = store.hasFetchedProfile();

--- a/src/sidebar/components/ThreadCard.js
+++ b/src/sidebar/components/ThreadCard.js
@@ -32,11 +32,8 @@ function ThreadCard({ frameSync, thread }) {
   const focusThreadAnnotation = useMemo(
     () =>
       debounce(
-        /** @param {string|null} tag */
-        tag => {
-          const focusTags = tag ? [tag] : [];
-          frameSync.hoverAnnotations(focusTags);
-        },
+        /** @param {Annotation|null} ann */
+        ann => frameSync.hoverAnnotation(ann),
         10
       ),
     [frameSync]
@@ -94,7 +91,7 @@ function ThreadCard({ frameSync, thread }) {
           scrollToAnnotation(thread.annotation);
         }
       }}
-      onMouseEnter={() => focusThreadAnnotation(threadTag ?? null)}
+      onMouseEnter={() => focusThreadAnnotation(thread.annotation ?? null)}
       onMouseLeave={() => focusThreadAnnotation(null)}
       key={thread.id}
     >

--- a/src/sidebar/components/test/SidebarView-test.js
+++ b/src/sidebar/components/test/SidebarView-test.js
@@ -26,7 +26,7 @@ describe('SidebarView', () => {
 
   beforeEach(() => {
     fakeFrameSync = {
-      hoverAnnotations: sinon.stub(),
+      hoverAnnotation: sinon.stub(),
       scrollToAnnotation: sinon.stub(),
     };
     fakeLoadAnnotationsService = {
@@ -148,11 +148,8 @@ describe('SidebarView', () => {
         createComponent();
         assert.calledOnce(fakeFrameSync.scrollToAnnotation);
         assert.calledWith(fakeFrameSync.scrollToAnnotation, fakeAnnotation);
-        assert.calledOnce(fakeFrameSync.hoverAnnotations);
-        assert.calledWith(
-          fakeFrameSync.hoverAnnotations,
-          sinon.match(['myTag'])
-        );
+        assert.calledOnce(fakeFrameSync.hoverAnnotation);
+        assert.calledWith(fakeFrameSync.hoverAnnotation, fakeAnnotation);
       });
 
       it('selects the correct tab for direct-linked annotations once anchored', () => {

--- a/src/sidebar/components/test/ThreadCard-test.js
+++ b/src/sidebar/components/test/ThreadCard-test.js
@@ -27,7 +27,7 @@ describe('ThreadCard', () => {
 
     fakeDebounce = sinon.stub().returnsArg(0);
     fakeFrameSync = {
-      hoverAnnotations: sinon.stub(),
+      hoverAnnotation: sinon.stub(),
       scrollToAnnotation: sinon.stub(),
     };
     fakeStore = {
@@ -84,7 +84,7 @@ describe('ThreadCard', () => {
 
       wrapper.find(threadCardSelector).simulate('mouseenter');
 
-      assert.calledWith(fakeFrameSync.hoverAnnotations, sinon.match(['myTag']));
+      assert.calledWith(fakeFrameSync.hoverAnnotation, fakeThread.annotation);
     });
 
     it('unfocuses the annotation thread when mouse exits', () => {
@@ -92,7 +92,7 @@ describe('ThreadCard', () => {
 
       wrapper.find(threadCardSelector).simulate('mouseleave');
 
-      assert.calledWith(fakeFrameSync.hoverAnnotations, sinon.match([]));
+      assert.calledWith(fakeFrameSync.hoverAnnotation, null);
     });
 
     ['button', 'a'].forEach(tag => {

--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -530,13 +530,13 @@ export class FrameSyncService {
   hoverAnnotation(ann: Annotation | null) {
     this._pendingHoverTag = null;
 
+    const tags = ann ? [ann.$tag] : [];
+    this._store.hoverAnnotations(tags);
+
     if (!ann) {
       this._guestRPC.forEach(rpc => rpc.call('hoverAnnotations', []));
       return;
     }
-
-    const tags = ann ? [ann.$tag] : [];
-    this._store.hoverAnnotations(tags);
 
     // If annotation is not currently anchored in a guest, schedule hover for
     // when annotation is anchored. This can happen if an annotation is for a

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -926,6 +926,9 @@ describe('FrameSyncService', () => {
         fakeStore.hoverAnnotations,
         sinon.match.array.deepEquals([fixtures.ann.$tag])
       );
+
+      frameSync.hoverAnnotation(null);
+      assert.calledWith(fakeStore.hoverAnnotations, []);
     });
 
     it('focuses the associated highlights in the guest', () => {

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -947,7 +947,6 @@ describe('FrameSyncService', () => {
 
       // Create an annotation with a CFI that doesn't match `fixtures.epubDocumentInfo`.
       const ann = createEPUBAnnotation('/4/8');
-      fakeStore.findIDsForTags.withArgs([ann.$tag]).returns([ann.id]);
 
       // Request hover of annotation. The annotation is marked as hovered in
       // the sidebar, but nothing is sent to the guest since the annotation's
@@ -1001,7 +1000,6 @@ describe('FrameSyncService', () => {
 
       // Create an annotation with a CFI that doesn't match `fixtures.epubDocumentInfo`.
       const ann = createEPUBAnnotation('/4/8');
-      fakeStore.findIDsForTags.withArgs([ann.$tag]).returns([ann.id]);
 
       // Request a scroll to this annotation, this will require a navigation of
       // the guest frame.


### PR DESCRIPTION
When a user hovers an annotation card for an EPUB chapter that is different than the one currently loaded in the guest, and then clicks on that annotation to navigate the guest to that chapter, ensure that the highlights in the document are displayed in a hovered state once anchoring completes.

This is handled similar to `FrameSyncService.scrollToAnnotation`, by setting a flag if the annotation is not loaded in the guest, which triggers a "hoverAnnotations" RPC call once the annotation is anchored.

The first commit implements this fix for annotation hovering after a chapter navigation. The second commit is a cleanup which changes the pending scroll/hover annotation IDs to be tags rather than IDs, which is now possible following the changes in https://github.com/hypothesis/client/pull/4962.

**Testing:**

Follow the same testing steps as https://github.com/hypothesis/client/pull/4962. On `main`, when clicking an annotation triggers a navigation to a different chapter, the highlight in the document will be un-focused after the navigation + scroll. On this branch the highlight should be displayed in a hovered state after the navigation + scroll.