### PR TITLE
Add missing chapter titles in VitalSource EPUB test document

### DIFF
--- a/dev-server/static/scripts/vitalsource-mosaic-book-element.js
+++ b/dev-server/static/scripts/vitalsource-mosaic-book-element.js
@@ -63,12 +63,14 @@ export class MosaicBookElement extends HTMLElement {
         },
         {
           absoluteURL: '/document/little-women-2',
+          chapterTitle: 'Chapter Two',
           cfi: '/4',
           index: 1,
           page: '20',
         },
         {
           absoluteURL: '/document/little-women-3',
+          chapterTitle: 'Chapter Three',
           cfi: '/6',
           index: 2,
           page: '30',


### PR DESCRIPTION
This information is not currently displayed in the UI, but it is captured with annotations in the `EPUBContentSelector` selector.