### PR TITLE
PoC: Common nested highlight-styling approach for HTML and PDFs

### DIFF
--- a/src/annotator/components/ClusterToolbar.tsx
+++ b/src/annotator/components/ClusterToolbar.tsx
@@ -68,7 +68,6 @@ function ClusterStyleControl({
               <div
                 style={{
                   backgroundColor: highlightStyles[styleName].color,
-                  textDecoration: highlightStyles[styleName].decoration,
                 }}
                 className={classnames(
                   'block w-6 h-6 rounded-full flex items-center justify-center',

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -613,6 +613,7 @@ export class Guest implements Annotator, Destroyable {
 
   _updateAnchors(anchors: Anchor[], notify: boolean) {
     this.anchors = anchors;
+    this._clusterToolbar?.scheduleClusterUpdates();
     if (notify) {
       this._bucketBarClient.update(this.anchors);
     }

--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -2,34 +2,56 @@
   // Default highlight styling configuration
   --hypothesis-highlight-color: rgba(255, 255, 60, 0.4);
   --hypothesis-highlight-focused-color: rgba(156, 230, 255, 0.5);
-  --hypothesis-highlight-blend-mode: normal;
-  --hypothesis-highlight-decoration: none;
   --hypothesis-highlight-text-color: inherit;
 
   --hypothesis-highlight-second-color: rgba(206, 206, 60, 0.4);
   --hypothesis-highlight-third-color: transparent;
 
   // Colors available for clustered highlights
-  --hypothesis-color-blue: #e0f2fe;
-  --hypothesis-color-yellow: #fef9c3;
-  --hypothesis-color-purple: #ede9fe;
-  --hypothesis-color-orange: #ffedd5;
-  --hypothesis-color-green: #d1fae5;
-  --hypothesis-color-grey: #f5f5f4;
-  --hypothesis-color-pink: #ffe4e6;
+  // TODO: This color does not have enough contrast with green or blue highlight colors
+  --hypothesis-color-cyan: #cffafe;
+
+  --hypothesis-color-blue: rgb(224, 243, 255);
+  --hypothesis-color-blue-1: rgb(203, 235, 255);
+  --hypothesis-color-blue-2: rgb(187, 228, 255);
+
+  --hypothesis-color-yellow: rgb(254, 249, 195);
+  --hypothesis-color-yellow-1: rgb(253, 243, 149); // Full
+  --hypothesis-color-yellow-2: rgb(252, 235, 111); // 0.75
+
+  --hypothesis-color-purple: rgb(234, 231, 254); // 215, 209, 253
+  // == multiply at .8 opacity on white
+  --hypothesis-color-purple-1: rgb(219, 213, 253); // 188, 178, 251
+  // == multiply 1 @.4 opacity on white
+  --hypothesis-color-purple-2: rgb(206, 199, 252);
+
+  --hypothesis-color-orange: rgb(255, 237, 214);
+  --hypothesis-color-orange-1: rgb(255, 223, 187);
+  --hypothesis-color-orange-2: rgb(255, 212, 167);
+
+  --hypothesis-color-green: rgb(209, 250, 229);
+  --hypothesis-color-green-1: rgb(179, 246, 211);
+  --hypothesis-color-green-2: rgb(144, 241, 188);
+
+  --hypothesis-color-pink: rgb(255, 229, 231);
+  --hypothesis-color-pink-1: rgb(255, 211, 213);
+  --hypothesis-color-pink-2: rgb(254, 197, 199);
 
   // Clustered highlight styling configuration
   // These values are updated by the `highlight-clusters` module
-  --hypothesis-cluster-blend-mode: multiply;
   --hypothesis-cluster-text-color: #333333;
+
   --hypothesis-other-content-color: var(--hypothesis-color-yellow);
-  --hypothesis-other-content-decoration: none;
+  --hypothesis-other-content-color-1: var(--hypothesis-color-yellow);
+  --hypothesis-other-content-color-2: var(--hypothesis-color-yellow);
 
   --hypothesis-user-highlights-color: var(--hypothesis-color-yellow);
-  --hypothesis-user-highlights-decoration: none;
+  --hypothesis-user-highlights-color-1: var(--hypothesis-color-yellow);
+  --hypothesis-user-highlights-color-2: var(--hypothesis-color-yellow);
 
   --hypothesis-user-annotations-color: var(--hypothesis-color-yellow);
-  --hypothesis-user-annotations-decoration: none;
+  --hypothesis-user-annotations-color-1: var(--hypothesis-color-yellow);
+  --hypothesis-user-annotations-color-2: var(--hypothesis-color-yellow);
 }
 
 // Configure highlight styling.
@@ -38,8 +60,6 @@
 .hypothesis-svg-highlight {
   --highlight-color: var(--hypothesis-highlight-color);
   --highlight-text-color: var(--hypothesis-highlight-text-color);
-  --highlight-blend-mode: var(--hypothesis-highlight-blend-mode);
-  --highlight-decoration: var(--hypothesis-highlight-decoration);
   --highlight-color-focused: var(--hypothesis-highlight-focused-color);
 
   & .hypothesis-highlight {
@@ -52,56 +72,58 @@
   }
 }
 
+@mixin clusterHighlightStyles($clusterValue) {
+  .hypothesis-highlight.#{$clusterValue},
+  .hypothesis-svg-highlight.#{$clusterValue} {
+    // Base color for this cluster value
+    --highlight-color: var(--hypothesis-#{$clusterValue}-color);
+
+    // Style highlights based on DOM hierarchy of <hypothesis-highlight>
+    // elements. This is applicable to HTML documents.
+    & > .#{$clusterValue} {
+      --highlight-color: var(--hypothesis-#{$clusterValue}-color-1);
+    }
+
+    & > .#{$clusterValue} > .#{$clusterValue} {
+      --highlight-color: var(--hypothesis-#{$clusterValue}-color-2);
+    }
+
+    // Style highlights based on data attributes set by `highlight-clusters`
+    // This is available on any document type/integration that supports cluster
+    // highlights.
+
+    // Styling for any cluster-level depth > 1
+    &[data-cluster-level] {
+      --highlight-color: var(--hypothesis-#{$clusterValue}-color-2);
+    }
+
+    &[data-cluster-level='1'] {
+      --highlight-color: var(--hypothesis-#{$clusterValue}-color-1);
+    }
+
+    &[data-cluster-level='0'] {
+      --highlight-color: var(--hypothesis-#{$clusterValue}-color);
+    }
+  }
+}
+
 // Configure clustered highlight styling. The `.hypothesis-highlights-clustered`
 // class is managed by `highlight-clusters`
-
-.hypothesis-highlights-clustered .hypothesis-highlight {
-  --highlight-text-color: var(--hypothesis-cluster-text-color);
-}
-
-.hypothesis-highlights-clustered .hypothesis-highlight,
-.hypothesis-highlights-clustered .hypothesis-svg-highlight {
-  // When clustered highlights are active, use an opaque blue for focused
-  // annotations so we don't end up with a funny color mix
-  --highlight-color-focused: var(--hypothesis-color-blue);
-
-  &.user-annotations {
-    --highlight-color: var(--hypothesis-user-annotations-color);
-    --highlight-decoration: var(--hypothesis-user-annotations-decoration);
-
-    & > .user-annotations {
-      --highlight-color: var(--hypothesis-user-annotations-color);
-      --highlight-blend-mode: var(--hypothesis-cluster-blend-mode);
-    }
+.hypothesis-highlights-clustered {
+  .hypothesis-highlight,
+  .hypothesis-svg-highlight {
+    // When clustered highlights are active, use an opaque color for focused
+    // annotations so we don't end up with a funny color mix
+    --highlight-color-focused: var(--hypothesis-color-cyan);
   }
 
-  &.user-highlights {
-    --highlight-color: var(--hypothesis-user-highlights-color);
-    --highlight-decoration: var(--hypothesis-user-highlights-decoration);
-
-    & > .user-highlights {
-      --highlight-color: var(--hypothesis-user-highlights-color);
-      --highlight-blend-mode: var(--hypothesis-cluster-blend-mode);
-    }
+  .hypothesis-highlight {
+    --highlight-text-color: var(--hypothesis-cluster-text-color);
   }
 
-  &.other-content {
-    --highlight-color: var(--hypothesis-other-content-color);
-    --highlight-decoration: var(--hypothesis-other-content-decoration);
-
-    & > .other-content {
-      --highlight-color: var(--hypothesis-other-content-color);
-      --highlight-blend-mode: var(--hypothesis-cluster-blend-mode);
-    }
-  }
-}
-
-// No matter what kind of highlight styling is applied, make sure nested
-// highlights don't pile up too high with blending.
-.hypothesis-highlight {
-  & & & & & {
-    --highlight-blend-mode: normal;
-  }
+  @include clusterHighlightStyles('user-highlights');
+  @include clusterHighlightStyles('user-annotations');
+  @include clusterHighlightStyles('other-content');
 }
 
 // Apply highlight styling.
@@ -124,6 +146,7 @@
 // Apply styling using `--highlight-` values when highlights are visible
 // The `.hypothesis-highlights-always-on` class is managed by `highlighter`
 .hypothesis-highlights-always-on .hypothesis-svg-highlight {
+  transition: fill 300ms;
   fill: var(--highlight-color);
 
   &.is-opaque {
@@ -138,8 +161,7 @@
 .hypothesis-highlights-always-on .hypothesis-highlight {
   color: var(--highlight-text-color);
   background-color: var(--highlight-color);
-  text-decoration: var(--highlight-decoration);
-  mix-blend-mode: var(--highlight-blend-mode);
+  transition: background-color 300ms;
 
   cursor: pointer;
 
@@ -167,7 +189,6 @@
   &.hypothesis-highlight-focused {
     mix-blend-mode: normal !important;
     background-color: var(--highlight-color-focused) !important;
-    text-decoration: none;
 
     .hypothesis-highlight {
       background-color: transparent !important;


### PR DESCRIPTION
This PR prototypes an approach to applying nested, clustered highlight styling in both HTML and PDF documents.

From a high level, this is what has changed:

* Nested cluster highlights are now styled in all document type integrations that support clustered highlighting (currently: HTML and PDF).
* Applied nested styling is the same in both HTML and PDF documents. Nested clusters are shown two levels deep. Opaque colors are used instead of relying on blend modes (any level of opacity or blending is not feasible for the way we draw highlights in PDF documents).
* There is no "blending" of multiple colors of highlights — for the moment. May well re-introduce this as we build this out...
* Nested highlight styles are applied based on selectors with child combinators (hierarchical selectors based on DOM structure) _or_ `data-` attributes.
* HTML document highlights can be styled without additional intervention via the hierarchical selectors
* PDF SVG highlights lack DOM hierarchy. Instead, a scheduled, debounced task evaluates the structure of `<hypothesis-highlight>` elements in the document (all highlighted document types, including PDFs, _have_ these elements, they're just invisible in PDF's case) any time the set of anchors/highlights is dirtied by the `Guest`'s `detach` method[^1]. `data-` attributes are added to both `<hypothesis-highlight>` and SVG highlight `rect` elements. These can now be styled via attribute selectors in CSS.

I had shied away from evaluating the entire set of highlights in the document too often, but the simple debounced method seems to work quite handily. In back-of-the-napkin performance benchmarking with several hundred nested annotations and highlights on the entire text of _Anna Karenina_, I have not seen the traversal function/updates exceed 0.8ms, with typical times in the 0.1-0.5ms range. Granted this is on a nice new laptop, but I feel like this general order of magnitude is...not gonna be a problem? BUT PLEASE DISABUSE ME if I am being real sloppy here.

**I'd like to evaluate whether this is a feasible place to start**, without getting too caught up in the specifics of the colors being used (i.e. the styles themselves), though I am starting to make some tweaks in that direction. I am quite aware that the highlight-hover/focus color in this PR will not work as-is as it has very little contrast with the available blue and green highlight colors[^2].

Code in the controller and SCSS is still loose (prototype quality).

Deeply nested clustered highlights in HTML as of this PR:

<img width="1318" alt="image" src="https://user-images.githubusercontent.com/439947/201973919-20283566-6dab-4a60-9d9a-7b793c3d3865.png">

PDF with some nested highlights:

<img width="998" alt="image" src="https://user-images.githubusercontent.com/439947/201974034-50ce740f-aa9c-44bc-8fb0-d4dbcb795e06.png">



[^1]: `detach` is also called when _adding_ any anchor highlights, so it covers our bases
[^2]: In an effort to zoom in on what really matters, I've backed out of supporting other CSS properties than background/fill color for now, and dropped the grey color as an option as feedback suggested it was too low-contrast to be useful. As such, I've re-introduced a blue color as an option for highlight coloring, but it doesn't work along with our focus color, so I have some more adjustment to do there.

