### PR TITLE
Display chapter headings above cards in sidebar

### DIFF
--- a/src/sidebar/components/ThreadList.tsx
+++ b/src/sidebar/components/ThreadList.tsx
@@ -270,9 +270,9 @@ export default function ThreadList({ threads }: ThreadListProps) {
           key={child.id}
         >
           {headings.get(child) && (
-            <h2 className="text-md text-grey-7 font-bold pt-3 pb-2">
+            <h3 className="text-md text-grey-7 font-bold pt-3 pb-2">
               {headings.get(child)}
-            </h2>
+            </h3>
           )}
           <ThreadCard thread={child} />
         </div>

--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -331,7 +331,7 @@ describe('ThreadList', () => {
     };
 
     const getHeading = container => {
-      const heading = container.find('h2');
+      const heading = container.find('h3');
       return heading.exists() ? heading.text() : null;
     };
 

--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -317,7 +317,7 @@ describe('ThreadList', () => {
   });
 
   describe('chapter headings', () => {
-    const addThread = (cfi, title) => {
+    const addThreadInChapter = (cfi, title) => {
       const id = `t${fakeTopThread.children.length + 1}`;
       const thread = createThread(id);
       thread.annotation.target[0].selector = [
@@ -341,15 +341,15 @@ describe('ThreadList', () => {
 
     it('renders section headings above first annotation from each section', () => {
       // Add two groups of annotations.
-      addThread('/2/4', 'Chapter One');
-      addThread('/2/4', 'Chapter One');
-      addThread('/2/6', 'Chapter Two');
-      addThread('/2/6', 'Chapter Two');
+      addThreadInChapter('/2/4', 'Chapter One');
+      addThreadInChapter('/2/4', 'Chapter One');
+      addThreadInChapter('/2/6', 'Chapter Two');
+      addThreadInChapter('/2/6', 'Chapter Two');
 
       // When annotations are sorted by date, rather than location, headings
       // may be repeated.
-      addThread('/2/4', 'Chapter One');
-      addThread('/2/4', 'Chapter One');
+      addThreadInChapter('/2/4', 'Chapter One');
+      addThreadInChapter('/2/4', 'Chapter One');
 
       const wrapper = createComponent();
 
@@ -365,12 +365,12 @@ describe('ThreadList', () => {
 
     it('uses last non-empty heading for each chapter', () => {
       // Add annotations for same chapter but with different captured headings.
-      addThread('/2/4', 'Chapter 1');
-      addThread('/2/4', 'Chapter One');
-      addThread('/2/4', undefined);
+      addThreadInChapter('/2/4', 'Chapter 1');
+      addThreadInChapter('/2/4', 'Chapter One');
+      addThreadInChapter('/2/4', undefined);
 
       // Add an annotation for a different chapter with no associated heading.
-      addThread('/2/8', undefined);
+      addThreadInChapter('/2/8', undefined);
 
       const wrapper = createComponent();
 


### PR DESCRIPTION
Display chapter headings in sidebar, for annotations in VitalSource books.

For each thread a "heading key" is extracted, which is currently the EPUB Content Document's CFI, taken from the "EPUBContentSelector" selector. When rendering threads a heading is displayed above each thread where the key is different than the previously rendered thread. To avoid adding complexity to the virtualization calculations, the headings are rendered as part of the first thread in the group, and so the height of the heading element is included in the measured height for that thread.

Headings are not displayed in HTML or PDF documents. To support headings on other document types in future we could use a different heading key and heading data source.

Headings are currently displayed in the notebook as well as the sidebar. If there are a mix of annotations from different sources then the HTML / PDF annotations will not have headings above them. A known issue is that there is no "blank" heading to create a boundary between VS annotations and HTML / PDF annotations.

**Testing:**

1. Go to http://localhost:3000/document/vitalsource-epub and make annotations on different chapters
2. Chapter headings should be displayed above annotations in sidebar
3. For other document types (HTML, PDF) there should be no headings. In future it could be nice to extract headings from the document and display them too.

**Examples:**

Headings, when annotations are sorted by location. In this mode, headings should not be repeated:

<img width="475" alt="EPUB chapter headings" src="https://user-images.githubusercontent.com/2458/202456258-1c3facb5-e6ab-447d-a984-7176a28c8ee8.png">

Headings, when annotations are sorted by date. In this mode, headings can be repeated:

<img width="474" alt="Repeated EPUB chapter headings" src="https://user-images.githubusercontent.com/2458/202456649-e8df7355-b4ea-4fc2-afda-77f988039082.png">

