### PR TITLE
PDF nested highlights 1 of ~3: Style highlight clusters with defined colors instead of CSS blending

### DIFF
--- a/src/annotator/components/ClusterToolbar.tsx
+++ b/src/annotator/components/ClusterToolbar.tsx
@@ -32,7 +32,7 @@ function ClusterStyleControl({
   highlightStyles,
 }: ClusterStyleControlProps) {
   const appliedStyleName = currentStyles[cluster];
-  const isHidden = appliedStyleName === 'hidden'; // This style is somewhat special
+  const isHidden = appliedStyleName === 'transparent'; // This style is somewhat special
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-x-2 text-annotator-base">
@@ -68,7 +68,6 @@ function ClusterStyleControl({
               <div
                 style={{
                   backgroundColor: highlightStyles[styleName].color,
-                  textDecoration: highlightStyles[styleName].decoration,
                 }}
                 className={classnames(
                   'block w-6 h-6 rounded-full flex items-center justify-center',
@@ -78,7 +77,7 @@ function ClusterStyleControl({
                   }
                 )}
               >
-                {styleName === 'hidden' && (
+                {styleName === 'transparent' && (
                   <HideIcon
                     className={classnames('w-3 h-3', {
                       'text-slate-3': !isHidden,

--- a/src/annotator/components/test/ClusterToolbar-test.js
+++ b/src/annotator/components/test/ClusterToolbar-test.js
@@ -1,5 +1,8 @@
 import { mount } from 'enzyme';
-import { highlightStyles, defaultStyles } from '../../highlight-clusters';
+import {
+  highlightStyles,
+  defaultClusterStyles,
+} from '../../highlight-clusters';
 import ClusterToolbar from '../ClusterToolbar';
 
 const noop = () => {};
@@ -10,7 +13,7 @@ describe('ClusterToolbar', () => {
       <ClusterToolbar
         active={true}
         availableStyles={highlightStyles}
-        currentStyles={defaultStyles}
+        currentStyles={defaultClusterStyles}
         onStyleChange={noop}
         {...props}
       />
@@ -50,7 +53,7 @@ describe('ClusterToolbar', () => {
 
     assert.equal(
       wrapper.find('ClusterStyleControl').length,
-      Object.keys(defaultStyles).length
+      Object.keys(defaultClusterStyles).length
     );
   });
 

--- a/src/annotator/highlight-clusters.tsx
+++ b/src/annotator/highlight-clusters.tsx
@@ -11,7 +11,8 @@ import { createShadowRoot } from './util/shadow-root';
 
 export type HighlightStyle = {
   color: string;
-  decoration: string;
+  secondColor: string;
+  thirdColor: string;
 };
 
 export type HighlightStyles = Record<string, HighlightStyle>;
@@ -19,39 +20,46 @@ export type AppliedStyles = Record<HighlightCluster, keyof HighlightStyles>;
 
 // Available styles that users can apply to highlight clusters
 export const highlightStyles: HighlightStyles = {
-  hidden: {
+  transparent: {
     color: 'transparent',
-    decoration: 'none',
-  },
-  green: {
-    color: 'var(--hypothesis-color-green)',
-    decoration: 'none',
-  },
-  orange: {
-    color: 'var(--hypothesis-color-orange)',
-    decoration: 'none',
+    secondColor: 'transparent',
+    thirdColor: 'transparent',
   },
   pink: {
     color: 'var(--hypothesis-color-pink)',
-    decoration: 'none',
+    secondColor: 'var(--hypothesis-color-pink-1)',
+    thirdColor: 'var(--hypothesis-color-pink-2)',
   },
-  purple: {
-    color: 'var(--hypothesis-color-purple)',
-    decoration: 'none',
+  orange: {
+    color: 'var(--hypothesis-color-orange)',
+    secondColor: 'var(--hypothesis-color-orange-1)',
+    thirdColor: 'var(--hypothesis-color-orange-2)',
   },
   yellow: {
     color: 'var(--hypothesis-color-yellow)',
-    decoration: 'none',
+    secondColor: 'var(--hypothesis-color-yellow-1)',
+    thirdColor: 'var(--hypothesis-color-yellow-2)',
+  },
+  green: {
+    color: 'var(--hypothesis-color-green)',
+    secondColor: 'var(--hypothesis-color-green-1)',
+    thirdColor: 'var(--hypothesis-color-green-2)',
+  },
+  purple: {
+    color: 'var(--hypothesis-color-purple)',
+    secondColor: 'var(--hypothesis-color-purple-1)',
+    thirdColor: 'var(--hypothesis-color-purple-2)',
   },
   grey: {
     color: 'var(--hypothesis-color-grey)',
-    decoration: 'underline dotted',
+    secondColor: 'var(--hypothesis-color-grey-1)',
+    thirdColor: 'var(--hypothesis-color-grey-2)',
   },
 };
 
 // The default styles applied to each highlight cluster. For now, this is
 // hard-coded.
-export const defaultStyles: AppliedStyles = {
+export const defaultClusterStyles: AppliedStyles = {
   'other-content': 'yellow',
   'user-annotations': 'orange',
   'user-highlights': 'purple',
@@ -81,7 +89,7 @@ export class HighlightClusterController implements Destroyable {
       left: '4px',
     });
 
-    this.appliedStyles = defaultStyles;
+    this.appliedStyles = defaultClusterStyles;
 
     this._init();
 
@@ -107,7 +115,7 @@ export class HighlightClusterController implements Destroyable {
     for (const cluster of Object.keys(this.appliedStyles) as Array<
       keyof typeof this.appliedStyles
     >) {
-      this._setClusterStyle(cluster, this.appliedStyles[cluster]);
+      this._setClusterStyles(cluster, this.appliedStyles[cluster]);
     }
 
     this._activate(this._isActive());
@@ -126,10 +134,17 @@ export class HighlightClusterController implements Destroyable {
   }
 
   /**
+   * Set a value for an individual CSS variable at :root
+   */
+  _setClusterStyle(key: string, value: string) {
+    document.documentElement.style.setProperty(key, value);
+  }
+
+  /**
    * Set CSS variables for the highlight `cluster` to apply the
    * {@link HighlightStyle} `highlightStyles[styleName]`
    */
-  _setClusterStyle(
+  _setClusterStyles(
     cluster: HighlightCluster,
     styleName: keyof typeof highlightStyles
   ) {
@@ -138,9 +153,9 @@ export class HighlightClusterController implements Destroyable {
     for (const ruleName of Object.keys(styleRules) as Array<
       keyof HighlightStyle
     >) {
-      document.documentElement.style.setProperty(
+      this._setClusterStyle(
         `--hypothesis-${cluster}-${ruleName}`,
-        styleRules[ruleName]
+        styleRules[ruleName] as string
       );
     }
   }
@@ -153,7 +168,7 @@ export class HighlightClusterController implements Destroyable {
     styleName: keyof typeof highlightStyles
   ) {
     this.appliedStyles[cluster] = styleName;
-    this._setClusterStyle(cluster, styleName);
+    this._setClusterStyles(cluster, styleName);
     this._render();
   }
 

--- a/src/annotator/test/highlight-clusters-test.js
+++ b/src/annotator/test/highlight-clusters-test.js
@@ -58,8 +58,8 @@ describe('HighlightClusterController', () => {
     const toolbar = createToolbar();
 
     // Properties should be set for each cluster (keys of `toolbar.appliedStyles`)
-    // Each cluster has two properties (variables) to be set
-    const expectedCount = Object.keys(toolbar.appliedStyles).length * 2;
+    // Each cluster has three colors
+    const expectedCount = Object.keys(toolbar.appliedStyles).length * 3;
 
     assert.equal(fakeSetProperty.callCount, expectedCount);
   });
@@ -108,6 +108,6 @@ describe('HighlightClusterController', () => {
     fakeSetProperty.resetHistory();
     toolbarProps.onStyleChange('user-highlights', 'green');
 
-    assert.equal(fakeSetProperty.callCount, 2);
+    assert.equal(fakeSetProperty.callCount, 3);
   });
 });

--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -1,35 +1,55 @@
 :root {
   // Default highlight styling configuration
   --hypothesis-highlight-color: rgba(255, 255, 60, 0.4);
+  --hypothesis-highlight-secondColor: rgba(206, 206, 60, 0.4);
+  --hypothesis-highlight-thirdColor: transparent;
+
   --hypothesis-highlight-focused-color: rgba(156, 230, 255, 0.5);
-  --hypothesis-highlight-blend-mode: normal;
-  --hypothesis-highlight-decoration: none;
   --hypothesis-highlight-text-color: inherit;
 
-  --hypothesis-highlight-second-color: rgba(206, 206, 60, 0.4);
-  --hypothesis-highlight-third-color: transparent;
+  --hypothesis-color-cyan: #cffafe;
 
   // Colors available for clustered highlights
-  --hypothesis-color-blue: #e0f2fe;
-  --hypothesis-color-yellow: #fef9c3;
-  --hypothesis-color-purple: #ede9fe;
-  --hypothesis-color-orange: #ffedd5;
-  --hypothesis-color-green: #d1fae5;
+
   --hypothesis-color-grey: #f5f5f4;
-  --hypothesis-color-pink: #ffe4e6;
+  --hypothesis-color-grey-1: #e7e5e4;
+  --hypothesis-color-grey-2: #d6d3d1;
+
+  --hypothesis-color-yellow: rgb(254, 249, 195);
+  --hypothesis-color-yellow-1: rgb(253, 243, 149);
+  --hypothesis-color-yellow-2: rgb(252, 235, 111);
+
+  --hypothesis-color-purple: rgb(234, 231, 254);
+  --hypothesis-color-purple-1: rgb(219, 213, 253);
+  --hypothesis-color-purple-2: rgb(206, 199, 252);
+
+  --hypothesis-color-orange: rgb(255, 237, 214);
+  --hypothesis-color-orange-1: rgb(255, 223, 187);
+  --hypothesis-color-orange-2: rgb(255, 212, 167);
+
+  --hypothesis-color-green: rgb(209, 250, 229);
+  --hypothesis-color-green-1: rgb(179, 246, 211);
+  --hypothesis-color-green-2: rgb(144, 241, 188);
+
+  --hypothesis-color-pink: rgb(255, 229, 231);
+  --hypothesis-color-pink-1: rgb(255, 211, 213);
+  --hypothesis-color-pink-2: rgb(254, 197, 199);
 
   // Clustered highlight styling configuration
   // These values are updated by the `highlight-clusters` module
-  --hypothesis-cluster-blend-mode: multiply;
   --hypothesis-cluster-text-color: #333333;
+
   --hypothesis-other-content-color: var(--hypothesis-color-yellow);
-  --hypothesis-other-content-decoration: none;
+  --hypothesis-other-content-secondColor: var(--hypothesis-color-yellow);
+  --hypothesis-other-content-thirdColor: var(--hypothesis-color-yellow);
 
   --hypothesis-user-highlights-color: var(--hypothesis-color-yellow);
-  --hypothesis-user-highlights-decoration: none;
+  --hypothesis-user-highlights-secondColor: var(--hypothesis-color-yellow);
+  --hypothesis-user-highlights-thirdColor: var(--hypothesis-color-yellow);
 
   --hypothesis-user-annotations-color: var(--hypothesis-color-yellow);
-  --hypothesis-user-annotations-decoration: none;
+  --hypothesis-user-annotations-secondColor: var(--hypothesis-color-yellow);
+  --hypothesis-user-annotations-thirdColor: var(--hypothesis-color-yellow);
 }
 
 // Configure highlight styling.
@@ -38,70 +58,53 @@
 .hypothesis-svg-highlight {
   --highlight-color: var(--hypothesis-highlight-color);
   --highlight-text-color: var(--hypothesis-highlight-text-color);
-  --highlight-blend-mode: var(--hypothesis-highlight-blend-mode);
-  --highlight-decoration: var(--hypothesis-highlight-decoration);
   --highlight-color-focused: var(--hypothesis-highlight-focused-color);
 
   & .hypothesis-highlight {
-    --highlight-color: var(--hypothesis-highlight-second-color);
+    --highlight-color: var(--hypothesis-highlight-secondColor);
 
     .hypothesis-highlight {
       // Highlights more than two levels deep are transparent by default.
-      --highlight-color: var(--hypothesis-highlight-third-color);
+      --highlight-color: var(--hypothesis-highlight-thirdColor);
+    }
+  }
+}
+
+@mixin clusterHighlightStyles($clusterValue) {
+  .hypothesis-highlight.#{$clusterValue},
+  .hypothesis-svg-highlight.#{$clusterValue} {
+    // Base color for this cluster value
+    --highlight-color: var(--hypothesis-#{$clusterValue}-color);
+
+    // Style highlights based on DOM hierarchy of <hypothesis-highlight>
+    // elements. This is applicable to HTML documents.
+    & > .#{$clusterValue} {
+      --highlight-color: var(--hypothesis-#{$clusterValue}-secondColor);
+    }
+
+    & > .#{$clusterValue} > .#{$clusterValue} {
+      --highlight-color: var(--hypothesis-#{$clusterValue}-thirdColor);
     }
   }
 }
 
 // Configure clustered highlight styling. The `.hypothesis-highlights-clustered`
 // class is managed by `highlight-clusters`
-
-.hypothesis-highlights-clustered .hypothesis-highlight {
-  --highlight-text-color: var(--hypothesis-cluster-text-color);
-}
-
-.hypothesis-highlights-clustered .hypothesis-highlight,
-.hypothesis-highlights-clustered .hypothesis-svg-highlight {
-  // When clustered highlights are active, use an opaque blue for focused
-  // annotations so we don't end up with a funny color mix
-  --highlight-color-focused: var(--hypothesis-color-blue);
-
-  &.user-annotations {
-    --highlight-color: var(--hypothesis-user-annotations-color);
-    --highlight-decoration: var(--hypothesis-user-annotations-decoration);
-
-    & > .user-annotations {
-      --highlight-color: var(--hypothesis-user-annotations-color);
-      --highlight-blend-mode: var(--hypothesis-cluster-blend-mode);
-    }
+.hypothesis-highlights-clustered {
+  .hypothesis-highlight,
+  .hypothesis-svg-highlight {
+    // When clustered highlights are active, use an opaque color for focused
+    // annotations so we don't end up with a funny color mix
+    --highlight-color-focused: var(--hypothesis-color-cyan);
   }
 
-  &.user-highlights {
-    --highlight-color: var(--hypothesis-user-highlights-color);
-    --highlight-decoration: var(--hypothesis-user-highlights-decoration);
-
-    & > .user-highlights {
-      --highlight-color: var(--hypothesis-user-highlights-color);
-      --highlight-blend-mode: var(--hypothesis-cluster-blend-mode);
-    }
+  .hypothesis-highlight {
+    --highlight-text-color: var(--hypothesis-cluster-text-color);
   }
 
-  &.other-content {
-    --highlight-color: var(--hypothesis-other-content-color);
-    --highlight-decoration: var(--hypothesis-other-content-decoration);
-
-    & > .other-content {
-      --highlight-color: var(--hypothesis-other-content-color);
-      --highlight-blend-mode: var(--hypothesis-cluster-blend-mode);
-    }
-  }
-}
-
-// No matter what kind of highlight styling is applied, make sure nested
-// highlights don't pile up too high with blending.
-.hypothesis-highlight {
-  & & & & & {
-    --highlight-blend-mode: normal;
-  }
+  @include clusterHighlightStyles('user-highlights');
+  @include clusterHighlightStyles('user-annotations');
+  @include clusterHighlightStyles('other-content');
 }
 
 // Apply highlight styling.
@@ -124,6 +127,7 @@
 // Apply styling using `--highlight-` values when highlights are visible
 // The `.hypothesis-highlights-always-on` class is managed by `highlighter`
 .hypothesis-highlights-always-on .hypothesis-svg-highlight {
+  transition: fill 300ms;
   fill: var(--highlight-color);
 
   &.is-opaque {
@@ -138,8 +142,7 @@
 .hypothesis-highlights-always-on .hypothesis-highlight {
   color: var(--highlight-text-color);
   background-color: var(--highlight-color);
-  text-decoration: var(--highlight-decoration);
-  mix-blend-mode: var(--highlight-blend-mode);
+  transition: background-color 300ms;
 
   cursor: pointer;
 
@@ -167,7 +170,6 @@
   &.hypothesis-highlight-focused {
     mix-blend-mode: normal !important;
     background-color: var(--highlight-color-focused) !important;
-    text-decoration: none;
 
     .hypothesis-highlight {
       background-color: transparent !important;


### PR DESCRIPTION
This PR prepares to add support for styling nested PDF clustered highlights.

Set explicit second and third colors to use for nested highlights in highlight clusters, instead of using `mix-blend-mode: multiply`. This will allow us to style drawn SVG highlights for PDFS, as transparency or blending is not feasible for those.

Reorganize CSS and CSS variables a bit to prepare for next steps.

User-visible change: as clustered highlights no longer use `mix-blend-mode: multiply`, you will not see "blended" highlight colors in HTML documents when different highlight clusters overlap. _It is likely we will re-introduce some form of this_, but first we need to solidify the common approach across different document types.

PDF clustered highlight styling as of this set of changes does not yet style nested highlights. That's coming in the next PR.