### PR TITLE
Wait for URL change after calling `history.back()`

### DIFF
--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -496,8 +496,14 @@ describe('annotator/integrations/vitalsource', () => {
         history.pushState({}, '', bookURI);
       });
 
-      afterEach(() => {
+      afterEach(async () => {
+        const urlChanged = new Promise(resolve => {
+          window.addEventListener('popstate', () => resolve(), { once: true });
+        });
+
         history.back();
+
+        await urlChanged;
       });
 
       context('when "book_as_single_document" flag is off', () => {


### PR DESCRIPTION
Avoid the temporary URL navigation done by VitalSource tests from affecting other tests by pausing in `afterEach` until the async `history.back()` operation has completed. Note this API doesn't return a promise. [Waiting for `popstate`](https://developer.mozilla.org/en-US/docs/Web/API/History/back) is how MDN recommends waiting.

A more elaborate solution would be to change the VitalSource integration to read from an injected fake location in tests. I might pursue that if this change runs into problems.

Fixes #5004