### PR TITLE
Fix unloading of client in pages / books with annotation-enables iframes

### DIFF
--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -1,3 +1,5 @@
+import { TinyEmitter } from 'tiny-emitter';
+
 import { ListenerCollection } from '../shared/listener-collection';
 import { PortFinder, PortRPC } from '../shared/messaging';
 import { generateHexString } from '../shared/random';
@@ -119,7 +121,7 @@ export type GuestConfig = {
  * each frame connects to the sidebar and host frames as part of its
  * initialization.
  */
-export class Guest implements Annotator, Destroyable {
+export class Guest extends TinyEmitter implements Annotator, Destroyable {
   public element: HTMLElement;
 
   /** Ranges of the current text selection. */
@@ -193,6 +195,8 @@ export class Guest implements Annotator, Destroyable {
     config: GuestConfig = {},
     hostFrame: Window = window
   ) {
+    super();
+
     this.element = element;
     this._hostFrame = hostFrame;
     this._highlightsVisible = false;
@@ -400,6 +404,8 @@ export class Guest implements Annotator, Destroyable {
         this.fitSideBySide(sidebarLayout);
       }
     });
+
+    this._hostRPC.on('close', () => this.emit('hostDisconnected'));
 
     // Discover and connect to the host frame. All RPC events must be
     // registered before creating the channel.

--- a/src/annotator/hypothesis-injector.js
+++ b/src/annotator/hypothesis-injector.js
@@ -62,7 +62,9 @@ function hasHypothesis(iframe) {
  */
 export function removeTemporaryClientConfig(document_ = document) {
   const tempConfigEls = Array.from(
-    document_.querySelectorAll('script.js-temp-config')
+    document_.querySelectorAll(
+      'script.js-hypothesis-config[data-remove-on-unload]'
+    )
   );
   tempConfigEls.forEach(el => el.remove());
 }
@@ -114,7 +116,8 @@ export async function injectClient(frame, config, frameId) {
   };
 
   const configElement = document.createElement('script');
-  configElement.className = 'js-hypothesis-config js-temp-config';
+  configElement.className = 'js-hypothesis-config';
+  configElement.setAttribute('data-remove-on-unload', '');
   configElement.type = 'application/json';
   configElement.innerText = JSON.stringify(injectedConfig);
 

--- a/src/annotator/hypothesis-injector.js
+++ b/src/annotator/hypothesis-injector.js
@@ -48,13 +48,23 @@ export class HypothesisInjector {
 }
 
 /**
- * Check if the client was added to a frame by {@link injectHypothesis}.
+ * Check if the client was added to a frame by {@link injectClient}.
  *
  * @param {HTMLIFrameElement} iframe
  */
 function hasHypothesis(iframe) {
   const iframeDocument = /** @type {Document} */ (iframe.contentDocument);
   return iframeDocument.querySelector('script.js-hypothesis-config') !== null;
+}
+
+/**
+ * Remove the temporary configuration data added to a document by {@link injectClient}.
+ */
+export function removeTemporaryClientConfig(document_ = document) {
+  const tempConfigEls = Array.from(
+    document_.querySelectorAll('script.js-temp-config')
+  );
+  tempConfigEls.forEach(el => el.remove());
 }
 
 /**
@@ -65,6 +75,10 @@ function hasHypothesis(iframe) {
  *
  * This waits for the frame to finish loading before injecting the client.
  * See {@link onDocumentReady}.
+ *
+ * This function does nothing if the client has already been added to the frame.
+ * This is determined by the presence of temporary configuration `<script>`s
+ * added by this function, which can be removed with {@link removeTemporaryClientConfig}.
  *
  * @param {HTMLIFrameElement} frame
  * @param {InjectConfig} config -
@@ -100,7 +114,7 @@ export async function injectClient(frame, config, frameId) {
   };
 
   const configElement = document.createElement('script');
-  configElement.className = 'js-hypothesis-config';
+  configElement.className = 'js-hypothesis-config js-temp-config';
   configElement.type = 'application/json';
   configElement.innerText = JSON.stringify(injectedConfig);
 

--- a/src/annotator/hypothesis-injector.js
+++ b/src/annotator/hypothesis-injector.js
@@ -58,7 +58,8 @@ function hasHypothesis(iframe) {
 }
 
 /**
- * Remove the temporary configuration data added to a document by {@link injectClient}.
+ * Remove the temporary client configuration added to a document by
+ * {@link injectClient} or {@link HypothesisInjector}.
  */
 export function removeTemporaryClientConfig(document_ = document) {
   const tempConfigEls = Array.from(

--- a/src/annotator/index.ts
+++ b/src/annotator/index.ts
@@ -18,7 +18,10 @@ import { getConfig } from './config/index';
 import type { NotebookConfig } from './components/NotebookModal';
 import { Guest } from './guest';
 import type { GuestConfig } from './guest';
-import { HypothesisInjector } from './hypothesis-injector';
+import {
+  HypothesisInjector,
+  removeTemporaryClientConfig,
+} from './hypothesis-injector';
 import type { InjectConfig } from './hypothesis-injector';
 import {
   VitalSourceInjector,
@@ -112,6 +115,10 @@ function init() {
     // page by the boot script.
     const clientAssets = document.querySelectorAll('[data-hypothesis-asset]');
     clientAssets.forEach(el => el.remove());
+
+    // If this is a guest-only frame, remove client config added by the host
+    // frame. This enables the client to later be re-loaded in this frame.
+    removeTemporaryClientConfig();
   });
 }
 

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1363,6 +1363,16 @@ describe('Guest', () => {
     });
   });
 
+  it('emits "hostDisconnected" event when host frame closes connection with guest', () => {
+    const guest = createGuest();
+    const hostDisconnected = sinon.stub();
+    guest.on('hostDisconnected', hostDisconnected);
+
+    emitHostEvent('close');
+
+    assert.called(hostDisconnected);
+  });
+
   it('discovers and creates a channel for communication with the sidebar', async () => {
     const { port1 } = new MessageChannel();
     fakePortFinder.discover.resolves(port1);


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/5006 and https://github.com/hypothesis/client/pull/5007**

This PR fixes an issue where de-activating and later re-activating the Hypothesis extension in a VitalSource book, or another page containing annotation-enabled iframes, did not work properly. With these changes, the second test case in https://github.com/hypothesis/client/pull/5006 should work.

Aside from the dev server test case mentioned in #5006, you can also test this branch by building the browser extension using it and toggling Hypothesis on a VitalSource book.

**Summary of changes:**

- Make `Guest` listen for the host frame disconnecting and emit a `hostDisconnected` event, which the annotator entry point handles by unloading the client in the same way as if the client was directly unloaded in the guest frame.
- Add `removeTemporaryClientConfig` helper to remove the `<script class="js-hypothesis-config">` scripts added when Hypothesis injects the client into a child iframe. This helper is called in the entry point when the client is unloaded. Removing these scripts is necessary for subsequent re-activation to work.