### PR TITLE
PDF nested highlights 3 of 3: Clone SVG highlights when focusing them

### DIFF
--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -165,7 +165,7 @@
     fill: yellow;
   }
 
-  &.is-focused {
+  &[data-is-focused] {
     fill: var(--highlight-color-focused);
   }
 }


### PR DESCRIPTION
Clone instead of move SVG highlights when focusing such that their original order is not lost when they are subsequently unfocused.

I was able to refactor this approach such that `highlighter`'s API remains unchanged.

Testing:

* On `main`, view a PDF document with a number of nested highlights. Hover annotations in the sidebar to focus them in the Guest frame. You will see that the highlight stacking order after focusing/unfocusing changes sometimes because the by-nesting-level is interfered with when SVG highlights are moved around by the focusing logic.
* On this branch, the same PDF document's highlight stacking should remain constant after highlights are focused/unfocused.