### PR TITLE
Fix typo in tutorial instruction

### DIFF
--- a/src/sidebar/components/Tutorial.tsx
+++ b/src/sidebar/components/Tutorial.tsx
@@ -72,7 +72,7 @@ function Tutorial({ settings }: TutorialProps) {
           >
             join link
           </Link>
-          ).
+          .
         </li>
       )}
       <li>


### PR DESCRIPTION
There was a wayward close-paren.

Fixes https://github.com/hypothesis/product-backlog/issues/1332