### PR TITLE
Update JS engine feature tests

### DIFF
--- a/src/boot/browser-check.js
+++ b/src/boot/browser-check.js
@@ -13,8 +13,7 @@ export function isBrowserSupported() {
   // a falsey value if they fail.
   const checks = [
     // ES APIs.
-    () => Promise.resolve(),
-    () => new Map(),
+    () => Object.fromEntries([]),
 
     // DOM API checks for frequently-used APIs.
     () => new URL(document.location.href), // URL constructor.


### PR DESCRIPTION
`Object.fromEntries` is showing up in Sentry as the most frequent error from browsers [1] that are outside our supported range, so use it as a representative feature to decide whether the client can load at all. We assume that this can subsume the previous ES2015-era feature tests.

`Object.fromEntries` is available since Chrome 73 (Mar 2019), Safari 12.1 (Mar 2019), Firefox 63 (Oct 2018).

[1] https://sentry.io/organizations/hypothesis/issues/3747304654