### PR TITLE
Add temporary fix for crash when creating page notes

### DIFF
--- a/src/sidebar/components/ThreadList.tsx
+++ b/src/sidebar/components/ThreadList.tsx
@@ -39,7 +39,15 @@ export type ThreadListProps = {
  * belongs to.
  */
 function getSegmentSelector(ann: Annotation): EPUBContentSelector | undefined {
-  return ann.target[0].selector?.find(s => s.type === 'EPUBContentSelector') as
+  const target = ann.target[0];
+  if (!target) {
+    // Page Notes that have just been created do not have a target. All saved
+    // annotations and new annotations/highlights do.
+    //
+    // FIXME - Fix this inconsistency for page notes.
+    return undefined;
+  }
+  return target.selector?.find(s => s.type === 'EPUBContentSelector') as
     | EPUBContentSelector
     | undefined;
 }

--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -26,8 +26,8 @@ describe('ThreadList', () => {
     return wrapper;
   }
 
-  function createThread(tag) {
-    const target = [
+  function createThread(tag, target) {
+    const defaultTarget = [
       {
         source: 'https://example.com',
       },
@@ -35,7 +35,7 @@ describe('ThreadList', () => {
     return {
       id: tag,
       children: [],
-      annotation: { $tag: tag, target },
+      annotation: { $tag: tag, target: target ?? defaultTarget },
     };
   }
 
@@ -61,7 +61,10 @@ describe('ThreadList', () => {
         createThread('t1'),
         createThread('t2'),
         createThread('t3'),
-        createThread('t4'),
+
+        // Add an annotation with an empty target. This matches how new
+        // (but not saved) page notes are currently created.
+        createThread('t4', []),
       ],
     };
 


### PR DESCRIPTION
The `getSegmentSelector` function assumed all annotations have at least one target. This is true for all saved annotations and all new annotations with selectors, but is not true for new page notes.

This is a stop-gap fix. The better solution will be to eliminate the inconsistency and make it so that all annotations have a non-empty `target` field.