### PR TITLE
Ensure the TagEditor Input has an `id` or `aria-label`

### DIFF
--- a/src/sidebar/components/TagEditor.tsx
+++ b/src/sidebar/components/TagEditor.tsx
@@ -280,6 +280,7 @@ function TagEditor({
           aria-autocomplete="list"
           aria-activedescendant={activeDescendant}
           aria-controls={`${tagEditorId}-AutocompleteList`}
+          aria-label="Add tags"
           dir="auto"
         />
         <AutocompleteList


### PR DESCRIPTION
This small PR fixes a console warning that was being output when the TagEditor component is rendered.

Our updated shared `Input` component will bleat (console warning) if it's not given either an `id` or an `aria-label`. Add `aria-label` here.