### PR TITLE
Allow GitHub CI workflows to be dispatched manually

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,6 +2,7 @@ name: Continuous integration
 on:
   pull_request:
   workflow_call:
+  workflow_dispatch:
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should give us a way to trigger CI for a PR if GitHub has failed to do so for any reason.