### PR TITLE
Revert "Bump @rollup/plugin-terser from 0.1.0 to 0.2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@rollup/plugin-json": "^5.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@rollup/plugin-replace": "^5.0.0",
-    "@rollup/plugin-terser": "^0.2.0",
+    "@rollup/plugin-terser": "^0.1.0",
     "@rollup/plugin-virtual": "^3.0.0",
     "@sentry/browser": "^7.1.1",
     "@sentry/cli": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,13 +1557,11 @@
     "@rollup/pluginutils" "^5.0.1"
     magic-string "^0.26.4"
 
-"@rollup/plugin-terser@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-terser/-/plugin-terser-0.2.0.tgz#07994c6ca48fcbf352efbdb01d0273557d7a3991"
-  integrity sha512-UBr4WNXBFipKW2C2db9JIzIdq9bFZsaTZwKeAd9Y0N9Pv9G2XgRhaimGdotx1+Wf/2XTuTJ+FVS2SO+y2WyiUQ==
+"@rollup/plugin-terser@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-terser/-/plugin-terser-0.1.0.tgz#7530c0f11667637419d71820461646c418526041"
+  integrity sha512-N2KK+qUfHX2hBzVzM41UWGLrEmcjVC37spC8R3c9mt3oEDFKh3N2e12/lLp9aVSt86veR0TQiCNQXrm8C6aiUQ==
   dependencies:
-    serialize-javascript "^6.0.0"
-    smob "^0.0.6"
     terser "^5.15.1"
 
 "@rollup/plugin-virtual@^3.0.0":
@@ -7679,7 +7677,7 @@ send@0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serialize-javascript@6.0.0, serialize-javascript@^6.0.0:
+serialize-javascript@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
   integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
@@ -7775,11 +7773,6 @@ smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
-
-smob@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/smob/-/smob-0.0.6.tgz#09b268fea916158a2781c152044c6155adbb8aa1"
-  integrity sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
Reverts hypothesis/client#5052.

This should fix a deployment failure seen in https://github.com/hypothesis/client/actions/runs/3685637971/jobs/6236873772.

Upstream issue: https://github.com/rollup/plugins/issues/1366

```
[13:03:55] 'build-js' errored after 3.99 s
[37](https://github.com/hypothesis/client/actions/runs/3685637971/jobs/6236873772#step:6:38)
[13:03:55] ReferenceError: __filename is not defined in ES module scope
[38](https://github.com/hypothesis/client/actions/runs/3685637971/jobs/6236873772#step:6:39)
    at terser (file:///home/runner/work/client/client/node_modules/@rollup/plugin-terser/dist/es/index.js:121:19)
[39](https://github.com/hypothesis/client/actions/runs/3685637971/jobs/6236873772#step:6:40)
    at file:///home/runner/work/client/client/rollup.config.mjs:16:5
[40](https://github.com/hypothesis/client/actions/runs/3685637971/jobs/6236873772#step:6:41)
    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
[41](https://github.com/hypothesis/client/actions/runs/3685637971/jobs/6236873772#step:6:42)
    at async Promise.all (index 0)
[42](https://github.com/hypothesis/client/actions/runs/3685637971/jobs/6236873772#step:6:43)
    at async ESMLoader.import (node:internal/modules/esm/loader:526:24)
[43](https://github.com/hypothesis/client/actions/runs/3685637971/jobs/6236873772#step:6:44)
    at async readConfig (file:///home/runner/work/client/client/node_modules/@hypothesis/frontend-build/lib/rollup.js:13:31)
[44](https://github.com/hypothesis/client/actions/runs/3685637971/jobs/6236873772#step:6:45)
    at async buildJS (file:///home/runner/work/client/client/node_modules/@hypothesis/frontend-build/lib/rollup.js:23:19)
```