### PR TITLE
Sketch: Trim user-selected text upon selection

### DIFF
--- a/dev-server/documents/html/whitespace.mustache
+++ b/dev-server/documents/html/whitespace.mustache
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Document with whitespace examples</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style type="text/css">
+      p {
+        border: 1px dashed grey;
+        padding: 1em;
+      }
+
+      span {
+        border: 1px dotted pink;
+        padding: 0.5em;
+      }
+    </style>
+  </head>
+  <body>
+  <h1>HTML document with examples of whitespace</h1>
+  <p>This HTML document contains various types of whitespace, including HTML entities
+  representing Unicode whitespace characters, as well as empty elements.
+  It is intended to help test text selection.</p>
+    <div id="toplevel">
+      <div id="apple">
+        <p></p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam
+          fringilla ultrices lacus consequat pretium.
+          <span>Curabitur posuere <i>posuere</i> <span></span></span>
+          rhoncus. <b>Maecenas</b> sit <span></span>amet velit<span
+          > </span> eget arcu aliquam pretium sed a tellus. Praesent sodales
+          enim id justo bibendum condimentum sit amet sit amet lorem.
+        </p>
+
+        <p>&nbsp;h<span> &#8195; &#8195;</span>i</p>
+
+        <p><span>&#8197;&#8197;&#8197;&#8197;</span></p>
+
+        <p>
+          Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec
+          felis mauris, tristique aliquet dolor ac, facilisis dapibus metus.
+          Morbi euismod congue erat, nec &#8201;&#8201;&#8201;&#8201;luctus
+          ligula dapibus ac. Integer fringilla aliquet tellus, ac sodales justo
+          semper quis.
+        </p>
+
+        <p>林花謝了春紅 太匆匆<br />無奈&nbsp;&nbsp;&#8195;朝來寒雨 晚來風<br />
+        胭脂淚 留人醉 幾時重<br />自是人生長恨 水長東</p>
+
+      </div>
+    </div>
+
+    <div id="aplusb">&#8197;</div>
+    <div id="banana">
+      <span></span>
+      <p>
+        Phasellus vehicula augue eget maximus tristique. In in lectus volutpat,
+        eleifend lectus ac, interdum risus. Mauris nec accumsan dolor, rhoncus
+        tempor ligula. Nulla congue, lectus et accumsan placerat, massa ligula
+        molestie odio, mollis interdum lectus purus id turpis. Vestibulum ante
+        ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae;
+        Mauris tempus libero id ipsum iaculis, &#8232; &#8232;id maximus erat
+        varius. Nulla facilisis erat sit amet lacus placerat, ac lobortis sem
+        volutpat. In hac habitasse platea dictumst. Nulla ornare rutrum ipsum in
+        pulvinar. Praesent &#8233; &#8233;n &#8233; diam purus, bibendum eu ex a,
+        faucibus convallis sapien. Proin tempus finibus nisi eu aliquam.
+      </p>
+    </div>
+
+    <p>&nbsp;</p>
+
+    <p>
+      In id odio a velit dictum molestie. Fusce et congue metus, varius faucibus
+      eros. Suspendisse sagittis venenatis nunc nec dignissim. Curabitur
+      fringilla, leo eget vehicula bibendum, enim orci eleifend mauris, vitae
+      sagittis ante arcu vel neque. &#5760; &#5760; &#5760;Quisque varius semper
+      nisl, a auctor enim pellentesque sed. Aliquam a lorem lectus. Morbi
+      gravida tristique dignissim. Suspendisse placerat sollicitudin erat, eget
+      tristique ante eleifend quis.
+    </p>
+
+    <p>
+      &nbsp; &nbsp; Ut tempor, felis iaculis ultrices posuere, lectus quam
+      accumsan ante, id commodo est sem et neque. Duis sit amet massa ac quam
+      pretium ornare. Vivamus sed dui at felis consequat interdum nec sit amet
+      elit. Donec hendrerit neque congue ultrices ornare. Fusce libero eros,
+      consectetur id feugiat sit amet, eleifend vitae ante. &#8194; &#8194;
+      &#8194; &#8194; &#8194;Sed a est placerat, fermentum justo eu, porttitor
+      nisl. In augue nunc, viverra eu varius id, interdum et libero. Vestibulum
+      congue accumsan sapien, sed sodales nunc vehicula quis. Etiam tincidunt
+      lacus nec sem ullamcorper, nec vulputate risus vulputate. Mauris fermentum
+      odio vitae diam lobortis sollicitudin. Nam sit amet congue urna, nec
+      varius urna.&nbsp;&nbsp;&nbsp;
+    </p>
+
+    <p>
+      Ut venenatis fringilla mauris, eget egestas neque sagittis id. Etiam
+      imperdiet eros quis placerat &#8199;&#8199;&#8199;&#8199;&#8199;suscipit.
+      Suspendisse sed ornare nunc. Duis finibus justo nec mi tempor mattis. Sed
+      pulvinar, dolor non bibendum tempor, dolor nunc vulputate massa, at
+      efficitur nulla enim id sapien. Integer imperdiet arcu vitae leo
+      ullamcorper commodo. Nunc at nisi ut arcu euismod venenatis quis in nisl.
+    </p>
+    {{{ hypothesisScript }}}
+  </body>
+</html>

--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -44,6 +44,7 @@
       <li><a href="/document/doyle-huge"><i>The Disappearance of Lady Carfax</i> with huge (24px) root font size in host page</a></li>
       <li><a href="/document/doyle-centered"><i>The Disappearance of Lady Carfax</i> with a centered, max-width body</a></li>
       <li><a href="/document/xhtml-test">XHTML document (served with XHTML mime type)</a></li>
+      <li><a href="/document/whitespace">HTML document with different types of whitespace content</a></li>
     </ul>
 
     <h3>VitalSource test documents</h3>

--- a/src/annotator/anchoring/trim-range.ts
+++ b/src/annotator/anchoring/trim-range.ts
@@ -1,0 +1,223 @@
+/**
+ * From which direction to evaluate strings or nodes: from the START of a string
+ * or range looking forward, or from the END of a string or range looking
+ * backward.
+ */
+enum FromPosition {
+  START = 1,
+  END,
+}
+
+/**
+ * Return the offset of the nearest non-whitespace character to `baseOffset`
+ * within `text`, looking in the `direction` indicated. Return -1 if no
+ * non-whitespace character exists between `baseOffset` and the terminus of the
+ * string (start or end depending on `direction`).
+ */
+function trimTextOffset(
+  text: string,
+  baseOffset: number,
+  direction = FromPosition.START
+): number {
+  const nextChar =
+    direction === FromPosition.START ? baseOffset : baseOffset - 1;
+  if (text.charAt(nextChar).trim() !== '') {
+    // baseOffset is already a valid offset
+    return baseOffset;
+  }
+
+  let availableChars: string;
+  let availableNonWhitespaceChars: string;
+
+  if (direction === FromPosition.END) {
+    availableChars = text.substring(0, baseOffset);
+    availableNonWhitespaceChars = availableChars.trimEnd();
+  } else {
+    availableChars = text.substring(baseOffset);
+    availableNonWhitespaceChars = availableChars.trimStart();
+  }
+
+  if (!availableNonWhitespaceChars.length) {
+    return -1;
+  }
+
+  const offsetDelta =
+    availableChars.length - availableNonWhitespaceChars.length;
+
+  return direction === FromPosition.END
+    ? baseOffset - offsetDelta
+    : baseOffset + offsetDelta;
+}
+
+type TrimTextContainerOptions = {
+  direction?: FromPosition;
+  root?: Node;
+};
+
+/**
+ * Return a Node and numerical offset representing the nearest non-whitespace
+ * character to `container`, moving toward `boundaryContainer`.
+ *
+ * Iterate through text nodes in the `direction` indicated toward
+ * `boundaryContainer` from `container`, looking for the first text node that
+ * has non-whitespace text content in it. Return that node, and an offset that
+ * references either the first non-whitespace character (when direction is
+ * FromPosition.START) or the last (direction is FromPosition.END) within that
+ * node.
+ *
+ * @throws {RangeError} If no text node with non-whitespace characters found
+ * between `container` and `boundaryContainer`
+ */
+function trimTextContainer(
+  container: Text,
+  boundaryContainer: Text,
+  { direction = FromPosition.START, root }: TrimTextContainerOptions
+) {
+  const nodeIter = container.ownerDocument!.createNodeIterator(
+    root ?? container,
+    NodeFilter.SHOW_TEXT
+  );
+  let currentNode = nodeIter.nextNode();
+
+  while (currentNode && currentNode !== container) {
+    currentNode = nodeIter.nextNode();
+  }
+
+  if (direction === FromPosition.END) {
+    // Reverse the NodeIterator direction. This will return the same node
+    // as the previous `nextNode()` call (`container`).
+    currentNode = nodeIter.previousNode();
+  }
+
+  let trimmedOffset = -1;
+
+  const advance = () => {
+    currentNode =
+      direction === FromPosition.START
+        ? nodeIter.nextNode()
+        : nodeIter.previousNode();
+
+    if (currentNode) {
+      const nodeText = currentNode.textContent ?? '';
+      const baseOffset = direction === FromPosition.START ? 0 : nodeText.length;
+      trimmedOffset = trimTextOffset(nodeText, baseOffset, direction);
+    }
+  };
+
+  // Start the examination at the first text node before/after the `container`
+  // i.e. do not evaluate the `container` itself
+  advance();
+
+  while (
+    currentNode &&
+    trimmedOffset === -1 &&
+    currentNode !== boundaryContainer
+  ) {
+    advance();
+  }
+
+  if (currentNode && trimmedOffset >= 0) {
+    return { node: currentNode, offset: trimmedOffset };
+  } else {
+    throw new RangeError(
+      'No text nodes with non-whitespace text found in range'
+    );
+  }
+}
+
+/**
+ * Return a new DOM Range that trims `range`, ensuring that:
+ *
+ * - `startContainer` and `endContainer` Text nodes both contain at least one
+ *   non-whitespace character within the Range's text content
+ * - `startOffset` and `endOffset` both point at non-whitespace characters
+ */
+export function trimRange(range: Range): Range {
+  if (!range.toString().trim().length) {
+    throw new RangeError('Range contains no non-whitespace text');
+  }
+  if (range.startContainer.nodeType !== Node.TEXT_NODE) {
+    throw new RangeError('Range startContainer is not a text node');
+  }
+  if (range.endContainer.nodeType !== Node.TEXT_NODE) {
+    throw new RangeError('Range endContainer is not a text node');
+  }
+
+  const trimmedRange = range.cloneRange();
+
+  let startTrimmed = false;
+  let endTrimmed = false;
+
+  const nodeText = (node: Node) => {
+    return (node as Text).textContent ?? '';
+  };
+
+  const trimmedOffsets = {
+    start: trimTextOffset(
+      nodeText(range.startContainer),
+      range.startOffset,
+      FromPosition.START
+    ),
+    end: trimTextOffset(
+      nodeText(range.endContainer),
+      range.endOffset,
+      FromPosition.END
+    ),
+  };
+
+  if (trimmedOffsets.start >= 0) {
+    if (trimmedOffsets.start !== range.startOffset) {
+      trimmedRange.setStart(range.startContainer, trimmedOffsets.start);
+    }
+    startTrimmed = true;
+  }
+
+  // Note: An offset of 0 is invalid for an end offset, as no text in the
+  // node would be included in the range.
+  if (trimmedOffsets.end > 0) {
+    if (trimmedOffsets.end !== range.endOffset) {
+      trimmedRange.setEnd(range.endContainer, trimmedOffsets.end);
+    }
+    endTrimmed = true;
+  }
+
+  if (startTrimmed && endTrimmed) {
+    return trimmedRange;
+  }
+
+  if (!startTrimmed) {
+    // There are no (non-whitespace) characters between `startOffset` and the
+    // end of the `startContainer` node.
+    const { node, offset } = trimTextContainer(
+      trimmedRange.startContainer as Text,
+      trimmedRange.endContainer as Text,
+      {
+        direction: FromPosition.START,
+        root: trimmedRange.commonAncestorContainer,
+      }
+    );
+
+    if (node && offset >= 0) {
+      trimmedRange.setStart(node, offset);
+    }
+  }
+
+  if (!endTrimmed) {
+    // There are no (non-whitespace) characters between the start of the Range's
+    // `endContainer` text content and the `endOffset`.
+    const { node, offset } = trimTextContainer(
+      trimmedRange.endContainer as Text,
+      trimmedRange.startContainer as Text,
+      {
+        direction: FromPosition.END,
+        root: trimmedRange.commonAncestorContainer,
+      }
+    );
+
+    if (node && offset > 0) {
+      trimmedRange.setEnd(node, offset);
+    }
+  }
+
+  return trimmedRange;
+}

--- a/src/annotator/range-util.js
+++ b/src/annotator/range-util.js
@@ -114,7 +114,11 @@ export function selectionFocusRect(selection) {
   if (selection.isCollapsed) {
     return null;
   }
-  const textBoxes = getTextBoundingBoxes(selection.getRangeAt(0));
+  const range = selection.getRangeAt(0);
+  if (range.toString().trim() === '') {
+    return null;
+  }
+  const textBoxes = getTextBoundingBoxes(range);
   if (textBoxes.length === 0) {
     return null;
   }


### PR DESCRIPTION
This PR sketches a possible way that we might better trim user-selected text content for annotation (or highlighting).

By doing this, we can ensure that the resulting `range` used by the `guest` to represent user-selected annotatable content starts exactly before the first non-whitespace character and ends exactly after the last non-whitespace character in the user's selection.

In this sketch, `Guest` directly creates and trims `TextRange` objects, and the `trimRange` function is in a utility module. This is just for prototyping purposes. Presumably, this (range trimming) would be handled at the Integration level, and `trimRange` would be available as an instance method on `TextObject` or as an option on the `toRange` instance method.

The first commit here adds a demonstration document with various types of whitespace and content: http://localhost:3000/document/whitespace

Expected behavior:

* It is no longer possible to annotate empty content (this is a change!). Selecting content that only contains whitespace characters will not show the Adder.
* If a selection contains either leading or trailing whitespace (or both), the visible selection will be unchanged[^1]. However, the range generated from the selection is trimmed behind the scenes. When clicking `Annotate` or `Highlight` (at which point the user selection is cleared), the drawn highlight does not include leading or trailing whitespace and the extracted annotation text will likewise exclude leading or trailing whitespace.
* It is possible to annotate the last text on the first page of the PDF linked in [this Github comment](https://github.com/hypothesis/client/issues/5024#issuecomment-1330815135), as the range is trimmed behind the scenes and thus no longer crosses page boundaries.

`trimRange` takes a `Range` that already starts and ends on text nodes[^2] and returns a new `Range` that is guaranteed to start and end exactly on non-whitespace characters, or throw if it can't.

It first attempts to move offsets around in the `Range`'s `startContainer` and `endContainer` to point at non-whitespace characters (or leaves them alone if they're already valid).

In cases where there are no non-whitespace characters between the start offset and the end of the start container's text content, or there are no non-whitespace characters between the start of the end container's content and the end offset, it will attempt to find a new start or end position, respectively.

It traverses nodes in the range in the relevant direction (forwards or backwards) until it finds a text node with non-whitespace text content. If seeking a new start position, it will set the start position to point at the first non-whitespace character in the first text node it finds with non-whitespace content, going forwards. If seeking a new end position, it will set the end position to the last non-whitespace character in the first non-empty text node it encounters, going backwards.

[^1]: Because it's simpler, but more importantly because the user "owns" the selection at this point, and it is presumptuous and potentially jumpy/janky for us to mess with it.
[^2]: DOM Ranges created by `TextRange.fromRange(range).toRange()` are currently guaranteed to start and end on text nodes, but they might not be the "right" ones, and/or the offsets may point at whitespace characters. We may wish to generalize range-trimming later not to assume text nodes, but let's leave that aside for now.
