### PR TITLE
Remove obsolete comment in `<mosaic-book>` fake

### DIFF
--- a/dev-server/static/scripts/vitalsource-mosaic-book-element.js
+++ b/dev-server/static/scripts/vitalsource-mosaic-book-element.js
@@ -9,9 +9,6 @@
  * This element is created in the book's container frame, and the element holds
  * the book's current content frame within its Shadow DOM.
  *
- * See `src/annotator/integrations/vitalsource.ts` for details of the APIs of
- * this element which the Hypothesis client relies on.
- *
  * @implements {IMosaicBookElement}
  */
 export class MosaicBookElement extends HTMLElement {


### PR DESCRIPTION
This should have been removed in 2e30052d500722d962c6627eb2dbf753a88555e5.