### PR TITLE
Always capture EPUBContentSelector, PageSelector in VitalSource books

### DIFF
--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -360,63 +360,53 @@ describe('annotator/integrations/vitalsource', () => {
       assert.calledWith(fakeHTMLIntegration.scrollToAnchor, anchor);
     });
 
-    context('when "book_as_single_document" flag is on', () => {
-      beforeEach(() => {
-        featureFlags.update({ book_as_single_document: true });
+    it('adds selector for current EPUB book Content Document', async () => {
+      const integration = createIntegration();
+      integration.contentContainer();
+      assert.calledWith(fakeHTMLIntegration.contentContainer);
+
+      const range = new Range();
+      const selectors = await integration.describe(range);
+
+      const cfiSelector = selectors.find(s => s.type === 'EPUBContentSelector');
+
+      assert.ok(cfiSelector);
+      assert.deepEqual(cfiSelector, {
+        type: 'EPUBContentSelector',
+        url: resolveURL('/pages/chapter_02.xhtml'),
+        cfi: '/2',
+        title: 'Chapter two (from TOC)',
       });
 
-      it('adds selector for current EPUB book Content Document', async () => {
-        const integration = createIntegration();
-        integration.contentContainer();
-        assert.calledWith(fakeHTMLIntegration.contentContainer);
+      const pageSelector = selectors.find(s => s.type === 'PageSelector');
+      assert.notOk(pageSelector);
+    });
 
-        const range = new Range();
-        const selectors = await integration.describe(range);
+    it('adds selector for current PDF book page', async () => {
+      fakeBookElement.selectPDFBook();
 
-        const cfiSelector = selectors.find(
-          s => s.type === 'EPUBContentSelector'
-        );
+      const integration = createIntegration();
+      integration.contentContainer();
+      assert.calledWith(fakeHTMLIntegration.contentContainer);
 
-        assert.ok(cfiSelector);
-        assert.deepEqual(cfiSelector, {
-          type: 'EPUBContentSelector',
-          url: resolveURL('/pages/chapter_02.xhtml'),
-          cfi: '/2',
-          title: 'Chapter two (from TOC)',
-        });
+      const range = new Range();
+      const selectors = await integration.describe(range);
+      const cfiSelector = selectors.find(s => s.type === 'EPUBContentSelector');
 
-        const pageSelector = selectors.find(s => s.type === 'PageSelector');
-        assert.notOk(pageSelector);
+      assert.ok(cfiSelector);
+      assert.deepEqual(cfiSelector, {
+        type: 'EPUBContentSelector',
+        url: resolveURL('/pages/2'),
+        cfi: '/1',
+        title: 'First chapter',
       });
 
-      it('adds selector for current PDF book page', async () => {
-        fakeBookElement.selectPDFBook();
-
-        const integration = createIntegration();
-        integration.contentContainer();
-        assert.calledWith(fakeHTMLIntegration.contentContainer);
-
-        const range = new Range();
-        const selectors = await integration.describe(range);
-        const cfiSelector = selectors.find(
-          s => s.type === 'EPUBContentSelector'
-        );
-
-        assert.ok(cfiSelector);
-        assert.deepEqual(cfiSelector, {
-          type: 'EPUBContentSelector',
-          url: resolveURL('/pages/2'),
-          cfi: '/1',
-          title: 'First chapter',
-        });
-
-        const pageSelector = selectors.find(s => s.type === 'PageSelector');
-        assert.ok(pageSelector);
-        assert.deepEqual(pageSelector, {
-          type: 'PageSelector',
-          index: 1,
-          label: '2',
-        });
+      const pageSelector = selectors.find(s => s.type === 'PageSelector');
+      assert.ok(pageSelector);
+      assert.deepEqual(pageSelector, {
+        type: 'PageSelector',
+        index: 1,
+        label: '2',
       });
     });
 

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -320,9 +320,6 @@ export class VitalSourceContentIntegration
 
   async describe(root: HTMLElement, range: Range) {
     const selectors: Selector[] = this._htmlIntegration.describe(root, range);
-    if (!this._bookIsSingleDocument()) {
-      return selectors;
-    }
 
     const {
       cfi,


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/5074**

In preparation for enabling the `book_as_single_document` feature for everyone, enable capturing the `EPUBContentSelector` selector whether the feature flag is enabled or not.

Once this is released, all new VS annotations will have all the data they will need after they are migrated to the new format [1] and only the annotation URL will need to be changed. This will leave us with only a fixed set of older annotations for which we will need to obtain the missing CFI and chapter title data.

An expected issue when this change is deployed, is that annotations created after this is deployed will sort _before_ annotations created earlier. This is because annotations with CFIs always sort before those without CFIs:

<img width="1379" alt="Annotation sort order" src="https://user-images.githubusercontent.com/2458/207882839-1122b812-2417-47aa-a6ad-d62fee2fbcdb.png">

I believe we can get away with this as the issue should be short-lived, as we'll backfill this selector for existing annotations.

[1] See https://github.com/hypothesis/h/issues/7709