### PR TITLE
Move VitalSource content frame types to types/vitalsource.ts

### DIFF
--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -17,7 +17,10 @@ import type {
   SegmentInfo,
   SidebarLayout,
 } from '../../types/annotator';
-import type { MosaicBookElement } from '../../types/vitalsource';
+import type {
+  ContentFrameGlobals,
+  MosaicBookElement,
+} from '../../types/vitalsource';
 import type { EPUBContentSelector, Selector } from '../../types/api';
 import type { InjectConfig } from '../hypothesis-injector';
 
@@ -137,34 +140,6 @@ export class VitalSourceInjector {
     this._frameObserver.disconnect();
   }
 }
-
-/**
- * Bounding box of a single character in the page.
- *
- * Coordinates are expressed in percentage distance from the top-left corner
- * of the rendered page.
- */
-type GlyphBox = {
-  l: number;
-  r: number;
-  t: number;
-  b: number;
-};
-
-type PDFGlyphData = {
-  glyphs: GlyphBox[];
-};
-
-/**
- * Data that the VitalSource book reader renders into the page about the
- * content and location of text in the image.
- */
-type PDFTextData = {
-  /** Locations of each text character in the page */
-  glyphs: PDFGlyphData;
-  /** The text in the page */
-  words: string;
-};
 
 function getPDFPageImage() {
   return document.querySelector('img#pbk-page') as HTMLImageElement | null;
@@ -291,7 +266,7 @@ export class VitalSourceContentIntegration
     // image.
     const bookImage = getPDFPageImage();
 
-    const pageData = (window as any).innerPageData as PDFTextData | undefined;
+    const pageData = (window as ContentFrameGlobals).innerPageData;
 
     if (bookImage && pageData) {
       const charRects = pageData.glyphs.glyphs.map(glyph => {

--- a/src/types/vitalsource.ts
+++ b/src/types/vitalsource.ts
@@ -1,9 +1,12 @@
 /**
- * This module defines the types exposed by the VitalSource Bookshelf reader
+ * This module defines the APIs exposed by the VitalSource Bookshelf reader
  * to our JavaScript code running in the viewer.
  *
  * The primary entry point is the `<mosaic-book>` custom element in the container
  * frame, whose API is described by {@link MosaicBookElement}.
+ *
+ * In content frames, there are also global variables containing data needed
+ * to generate the text layer. See {@link ContentFrameGlobals}.
  */
 
 /**
@@ -173,4 +176,39 @@ export type MosaicBookElement = HTMLElement & {
    * Navigate the book to the page or content document whose URL matches `url`.
    */
   goToURL(url: string): void;
+};
+
+/**
+ * Bounding box of a single character in the page.
+ *
+ * Coordinates are expressed in percentage distance from the top-left corner
+ * of the rendered page.
+ */
+export type GlyphBox = {
+  l: number;
+  r: number;
+  t: number;
+  b: number;
+};
+
+export type PDFGlyphData = {
+  glyphs: GlyphBox[];
+};
+
+/**
+ * Data that the VitalSource book reader renders into the content frame for
+ * PDF-based books, containing the content and location of text.
+ */
+export type PDFTextData = {
+  /** Locations of each text character in the page */
+  glyphs: PDFGlyphData;
+  /** The text in the page */
+  words: string;
+};
+
+/**
+ * Globals that VitalSource adds to the `Window` object in the content frame.
+ */
+export type ContentFrameGlobals = {
+  innerPageData?: PDFTextData;
 };


### PR DESCRIPTION
Co-locate these types with other types that are determined by the VitalSource book reader, as opposed to us. This also gives us a single module (types/vitalsource.ts) that we can point to in order to explain which APIs from Bookshelf we rely on.