### PR TITLE
Break words in text layer when adjacent chars do not overlap vertically

### DIFF
--- a/src/annotator/integrations/image-text-layer.ts
+++ b/src/annotator/integrations/image-text-layer.ts
@@ -57,6 +57,13 @@ function analyzeLayout(charBoxes: DOMRect[], text: string): ColumnBox[] {
     const char = text[i];
     const isSpace = /\s/.test(char);
 
+    if (
+      currentWord.text.length > 0 &&
+      !rectsOverlapVertically(currentWord.rect, rect)
+    ) {
+      addWord();
+    }
+
     currentWord.rect = unionRects(currentWord.rect, rect);
 
     // To simplify downstream logic, normalize whitespace.


### PR DESCRIPTION
For text selection to work well, in VitalSource PDF books, it is important that `<hypothesis-text-word>` elements do not span multiple lines. Previously the layout analysis only created new words after a space. Since most lines end with a whole word, this was sufficient in most cases. However this doesn't work if a word is broken across multiple lines (eg. with a hyphen). To handle this case, also create a word break if the current character does not vertically overlap the previous character. This may create some false positives (ie. unnecessary word breaks), but that doesn't harm text selection.

Fixes #5066

**Testing:**

The example page at http://localhost:3000/document/vitalsource-pdf does not include any lines ending with a hyphen. If you apply the diff below however, it will simulate the same result for lines ending with the word "and" (there is one near the top).

```diff
diff --git a/src/annotator/integrations/image-text-layer.js b/src/annotator/integrations/image-text-layer.js
index 87411c8ae..c5b6e0f72 100644
--- a/src/annotator/integrations/image-text-layer.js
+++ b/src/annotator/integrations/image-text-layer.js
@@ -58,19 +58,19 @@ function analyzeLayout(charBoxes, text) {
     const char = text[i];
     const isSpace = /\s/.test(char);
 
-    if (
-      currentWord.text.length > 0 &&
-      !rectsOverlapVertically(currentWord.rect, rect)
-    ) {
-      addWord();
-    }
+    // if (
+    //   currentWord.text.length > 0 &&
+    //   !rectsOverlapVertically(currentWord.rect, rect)
+    // ) {
+    //   addWord();
+    // }
 
     currentWord.rect = unionRects(currentWord.rect, rect);
 
     // To simplify downstream logic, normalize whitespace.
     currentWord.text += isSpace ? ' ' : char;
 
-    if (isSpace) {
+    if (isSpace && currentWord.text.trim() !== "and") {
       addWord();
     }
   }
```

With the `rectsOverlapVertically(...)` logic commented out, selecting the line ending "...in his Essay on the Nature and" also selects the next line. With the logic enabled, that line can still be selected.

We still need the `isSpace` logic as otherwise all words in the line would be put into one `<hypothesis-text-word>` element, which will degrade horizontal positioning accuracy for characters nearer to the end of the line, depending on the font.