### PR TITLE
Allow integrations to adjust user-selected ranges

### DIFF
--- a/src/annotator/anchoring/test/text-range-test.js
+++ b/src/annotator/anchoring/test/text-range-test.js
@@ -452,5 +452,21 @@ describe('annotator/anchoring/text-range', () => {
         assert.equal(textRange.end.offset, 10);
       });
     });
+
+    describe('trimmedRange', () => {
+      it('adjusts Range start and end positions to remove whitespace', () => {
+        const el = document.createElement('div');
+        el.textContent = ' one two three ';
+
+        const range = new Range();
+        range.selectNodeContents(el);
+
+        const textRange = TextRange.fromRange(range).toRange();
+        const trimmedRange = TextRange.trimmedRange(range);
+
+        assert.equal(trimmedRange.startOffset, textRange.startOffset + 1);
+        assert.equal(trimmedRange.endOffset, textRange.endOffset - 1);
+      });
+    });
   });
 });

--- a/src/annotator/anchoring/test/text-range-test.js
+++ b/src/annotator/anchoring/test/text-range-test.js
@@ -1,6 +1,6 @@
 import { TextPosition, TextRange, ResolveDirection } from '../text-range';
 
-import { assertNodesEqual } from '../../../test-util/compare-dom';
+import { assertNodesEqual, textNodes } from '../../../test-util/compare-dom';
 
 const html = `
 <main>
@@ -11,22 +11,6 @@ const html = `
   </article>
 </main>
 `;
-
-/**
- * Return all the `Text` descendants of `node`
- *
- * @param {Node} node
- * @return {Text[]}
- */
-function textNodes(node) {
-  const nodes = [];
-  const iter = document.createNodeIterator(node, NodeFilter.SHOW_TEXT);
-  let current;
-  while ((current = iter.nextNode())) {
-    nodes.push(current);
-  }
-  return nodes;
-}
 
 describe('annotator/anchoring/text-range', () => {
   describe('TextPosition', () => {

--- a/src/annotator/anchoring/test/trim-range-test.js
+++ b/src/annotator/anchoring/test/trim-range-test.js
@@ -1,0 +1,273 @@
+import { textNodes } from '../../../test-util/compare-dom';
+import { trimRange } from '../trim-range';
+import { TextRange } from '../text-range';
+
+describe('annotator/anchoring/trim-range', () => {
+  let container;
+
+  const htmlContent = `
+  <div id="A">
+    <div id="B">&#8233;z<p id="C"><span id="D">&nbsp; charm&nbsp;</span> a </p> </div>
+    <div id="E">
+      <p id="F"> <span id="G">&nbsp;<span id="H"><!-- comment -->f </span></span></p>
+    </div>
+    <div id="I"></div>
+  </div>
+  <div id="J"> <span id="K"> t </span><div id="L"></div><div id="M">&nbsp;<div> </div>
+        `;
+
+  afterEach(() => {
+    container?.remove();
+  });
+
+  const addContent = innerHTML => {
+    container = document.createElement('div');
+    container.innerHTML = innerHTML;
+    document.body.appendChild(container);
+    return container;
+  };
+
+  const addTextContent = text => {
+    const wrappingNode = document.createElement('p');
+    wrappingNode.innerHTML = text;
+    document.body.appendChild(wrappingNode);
+    return wrappingNode;
+  };
+
+  /**
+   * Return a Range that selects text content in `container` from `startOffset`
+   * to `endOffset`. Will select entire textContent of `container` if no offsets
+   * are provided.
+   *
+   * @param {Element} container
+   * @param {number} [startOffset] - or 0 if not present
+   * @param {number} [endOffset] - or length of text content if not present
+   */
+  const rangeFromOffsets = (container, startOffset, endOffset) => {
+    return TextRange.fromOffsets(
+      container,
+      startOffset ?? 0,
+      endOffset ?? container.textContent.length
+    ).toRange();
+  };
+
+  /**
+   * Return a Range that starts before `startElement` and ends after
+   * `endElement`. The returned Range will start and end on a Text node.
+   */
+  const textRangeBetween = (startElement, endElement) => {
+    const range = new Range();
+    range.setStartBefore(startElement);
+    range.setEndAfter(endElement);
+    return TextRange.fromRange(range).toRange();
+  };
+
+  describe('Trimming by adjusting offsets within existing start and end containers', () => {
+    [
+      ['Non-whitespace', 0, 0],
+      ['&nbsp;One whitespace', 0, 1],
+      ['&nbsp;&#8194;Multiple whitespace', 0, 2],
+      ['Internal whitespace', 8, 9],
+      ['Internal&#5760; whitespace', 8, 10],
+    ].forEach(([testContent, initialStartOffset, expectedTrimmedOffset]) => {
+      it('trims start offset forward until following character is non-whitespace', () => {
+        container = addTextContent(testContent);
+        const textRange = rangeFromOffsets(container, initialStartOffset);
+
+        const trimmedRange = trimRange(textRange);
+
+        assert.equal(textRange.startContainer, trimmedRange.startContainer);
+        assert.equal(trimmedRange.startOffset, expectedTrimmedOffset);
+      });
+    });
+
+    [
+      ['End', 3, 3],
+      ['End ', 4, 3],
+      ['End &nbsp;&#8197; ', 6, 3],
+      ['Mid space', 4, 3],
+      ['Mid &nbsp;&#8197;spaces', 6, 3],
+    ].forEach(([testContent, initialEndOffset, trimmedEndOffset]) => {
+      it('trims end offset back until preceding character is non-whitespace', () => {
+        container = addTextContent(testContent);
+        const textRange = rangeFromOffsets(container, 0, initialEndOffset);
+
+        const trimmedRange = trimRange(textRange);
+
+        assert.equal(textRange.endContainer, trimmedRange.endContainer);
+        assert.equal(trimmedRange.endOffset, trimmedEndOffset);
+      });
+    });
+  });
+
+  describe('Trimming by changing start or end containers and their offsets', () => {
+    [
+      {
+        range: { from: '#A' },
+        expected: { start: '#B', offset: 1, char: 'z' },
+      },
+      {
+        range: { from: '#B' },
+        expected: { start: '#B', offset: 1, char: 'z' },
+      },
+      {
+        range: { from: '#C' },
+        expected: { start: '#D', offset: 2, char: 'c' },
+      },
+      {
+        range: { from: '#D' },
+        expected: { start: '#D', offset: 2, char: 'c' },
+      },
+      {
+        range: { from: '#E' },
+        expected: { start: '#H', offset: 0, char: 'f' },
+      },
+      {
+        range: { from: '#F' },
+        expected: { start: '#H', offset: 0, char: 'f' },
+      },
+      {
+        range: { from: '#G' },
+        expected: { start: '#H', offset: 0, char: 'f' },
+      },
+      {
+        range: { from: '#I', to: '#J' },
+        expected: { start: '#K', offset: 1, char: 't' },
+      },
+      {
+        range: { from: '#I', to: '#L' },
+        expected: { start: '#K', offset: 1, char: 't' },
+      },
+    ].forEach(({ range, expected }) => {
+      it('moves start position forward to first non-whitespace character in range', () => {
+        container = addContent(htmlContent);
+
+        const textRange = textRangeBetween(
+          document.querySelector(range.from),
+          document.querySelector(range.to ?? range.from)
+        );
+
+        const trimmedRange = trimRange(textRange);
+
+        assert.equal(
+          trimmedRange.startContainer,
+          textNodes(document.querySelector(expected.start))[0],
+          `Trimmed startContainer is first text node inside of ${expected.start}`
+        );
+
+        assert.equal(trimmedRange.startOffset, expected.offset);
+        assert.equal(
+          trimmedRange.startContainer.textContent.charAt(
+            trimmedRange.startOffset
+          ),
+          expected.char,
+          `First character at trimmed start position is ${expected.char}`
+        );
+      });
+    });
+
+    [
+      {
+        range: { from: '#A' },
+        expected: { end: '#H', offset: 1, char: 'f' },
+      },
+      {
+        range: { from: '#B' },
+        expected: { end: '#C', offset: 2, char: 'a' },
+      },
+      {
+        range: { from: '#C' },
+        expected: { end: '#C', offset: 2, char: 'a' },
+      },
+      {
+        range: { from: '#D' },
+        expected: { end: '#D', offset: 7, char: 'm' },
+      },
+      {
+        range: { from: '#E' },
+        expected: { end: '#H', offset: 1, char: 'f' },
+      },
+      {
+        range: { from: '#F' },
+        expected: { end: '#H', offset: 1, char: 'f' },
+      },
+      {
+        range: { from: '#G' },
+        expected: { end: '#H', offset: 1, char: 'f' },
+      },
+      {
+        range: { from: '#H' },
+        expected: { end: '#H', offset: 1, char: 'f' },
+      },
+      {
+        range: { from: '#A', to: '#J' },
+        expected: { end: '#K', offset: 2, char: 't' },
+      },
+    ].forEach(({ range, expected }) => {
+      it('moves end position backward to nearest non-whitespace character', () => {
+        container = addContent(htmlContent);
+
+        const textRange = textRangeBetween(
+          document.querySelector(range.from),
+          document.querySelector(range.to ?? range.from)
+        );
+
+        const trimmedRange = trimRange(textRange);
+
+        const endTextNodes = textNodes(document.querySelector(expected.end));
+
+        assert.equal(
+          trimmedRange.endContainer,
+          endTextNodes[endTextNodes.length - 1],
+          `Trimmed endContainer is last text node inside of ${expected.end}`
+        );
+
+        assert.equal(trimmedRange.endOffset, expected.offset);
+        assert.equal(
+          trimmedRange.endContainer.textContent.charAt(
+            trimmedRange.endOffset - 1
+          ),
+          expected.char,
+          `Character before trimmed end position is ${expected.char}`
+        );
+      });
+    });
+  });
+
+  it('throws if the range contains no non-whitespace text content', () => {
+    container = addContent('<p id="empty">&nbsp;&nbsp;<p>');
+
+    const textRange = textRangeBetween(
+      document.querySelector('#empty'),
+      document.querySelector('#empty')
+    );
+
+    assert.throws(
+      () => trimRange(textRange),
+      RangeError,
+      'Range contains no non-whitespace text'
+    );
+  });
+
+  it('throws if the range does not start or end on a text node', () => {
+    container = addContent('<p id="notText">Some text<p>');
+    const pElement = document.querySelector('p#notText');
+
+    const range = new Range();
+    range.setStartBefore(pElement);
+    range.setEndAfter(pElement);
+    assert.throws(
+      () => trimRange(range),
+      RangeError,
+      'Range startContainer is not a text node'
+    );
+
+    const pTextNode = textNodes(pElement)[0];
+    range.setStart(pTextNode, 0);
+    assert.throws(
+      () => trimRange(range),
+      RangeError,
+      'Range endContainer is not a text node'
+    );
+  });
+});

--- a/src/annotator/anchoring/text-range.ts
+++ b/src/annotator/anchoring/text-range.ts
@@ -1,3 +1,5 @@
+import { trimRange } from './trim-range';
+
 /**
  * Return the combined length of text nodes contained in `node`.
  */
@@ -313,5 +315,13 @@ export class TextRange {
       new TextPosition(root, start),
       new TextPosition(root, end)
     );
+  }
+
+  /**
+   * Return a new Range representing `range` trimmed of any leading or trailing
+   * whitespace
+   */
+  static trimmedRange(range: Range): Range {
+    return trimRange(TextRange.fromRange(range).toRange());
   }
 }

--- a/src/annotator/anchoring/trim-range.ts
+++ b/src/annotator/anchoring/trim-range.ts
@@ -1,0 +1,220 @@
+/**
+ * From which direction to evaluate strings or nodes: from the start of a string
+ * or range seeking Forwards, or from the end seeking Backwards.
+ */
+enum TrimDirection {
+  Forwards = 1,
+  Backwards,
+}
+
+/**
+ * An object representing metadata for a Range position (e.g. for use with
+ * Range.setStart or Range.setEnd)
+ */
+type RangePosition = {
+  offset: number;
+  node: Node;
+};
+
+/**
+ * Return the offset of the nearest non-whitespace character to `baseOffset`
+ * within the string `text`, looking in the `direction` indicated. Return -1 if
+ * no non-whitespace character exists between `baseOffset` (inclusive) and the
+ * terminus of the string (start or end depending on `direction`).
+ */
+function closestNonSpaceInString(
+  text: string,
+  baseOffset: number,
+  direction: TrimDirection
+): number {
+  const nextChar =
+    direction === TrimDirection.Forwards ? baseOffset : baseOffset - 1;
+  if (text.charAt(nextChar).trim() !== '') {
+    // baseOffset is already valid: it points at a non-whitespace character
+    return baseOffset;
+  }
+
+  let availableChars: string;
+  let availableNonWhitespaceChars: string;
+
+  if (direction === TrimDirection.Backwards) {
+    availableChars = text.substring(0, baseOffset);
+    availableNonWhitespaceChars = availableChars.trimEnd();
+  } else {
+    availableChars = text.substring(baseOffset);
+    availableNonWhitespaceChars = availableChars.trimStart();
+  }
+
+  if (!availableNonWhitespaceChars.length) {
+    return -1;
+  }
+
+  const offsetDelta =
+    availableChars.length - availableNonWhitespaceChars.length;
+
+  return direction === TrimDirection.Backwards
+    ? baseOffset - offsetDelta
+    : baseOffset + offsetDelta;
+}
+
+/**
+ * Calculate a new Range start position (TrimDirection.Forwards) or end position
+ * (Backwards) for `range` that represents the nearest non-whitespace character,
+ * moving into the `range` away from the relevant initial boundary node towards
+ * the terminating boundary node.
+ *
+ * @throws {RangeError} If no text node with non-whitespace characters found
+ */
+function closestNonSpaceInRange(
+  range: Range,
+  direction: TrimDirection
+): RangePosition {
+  const nodeIter =
+    range.commonAncestorContainer.ownerDocument!.createNodeIterator(
+      range.commonAncestorContainer,
+      NodeFilter.SHOW_TEXT
+    );
+
+  const initialBoundaryNode =
+    direction === TrimDirection.Forwards
+      ? range.startContainer
+      : range.endContainer;
+
+  const terminalBoundaryNode =
+    direction === TrimDirection.Forwards
+      ? range.endContainer
+      : range.startContainer;
+
+  let currentNode = nodeIter.nextNode();
+
+  // Advance the NodeIterator to the `initialBoundaryNode`
+  while (currentNode && currentNode !== initialBoundaryNode) {
+    currentNode = nodeIter.nextNode();
+  }
+
+  if (direction === TrimDirection.Backwards) {
+    // Reverse the NodeIterator direction. This will return the same node
+    // as the previous `nextNode()` call (initial boundary node).
+    currentNode = nodeIter.previousNode();
+  }
+
+  let trimmedOffset = -1;
+
+  const advance = () => {
+    currentNode =
+      direction === TrimDirection.Forwards
+        ? nodeIter.nextNode()
+        : nodeIter.previousNode();
+
+    if (currentNode) {
+      const nodeText = currentNode.textContent!;
+      const baseOffset =
+        direction === TrimDirection.Forwards ? 0 : nodeText.length;
+      trimmedOffset = closestNonSpaceInString(nodeText, baseOffset, direction);
+    }
+  };
+
+  while (
+    currentNode &&
+    trimmedOffset === -1 &&
+    currentNode !== terminalBoundaryNode
+  ) {
+    advance();
+  }
+
+  if (currentNode && trimmedOffset >= 0) {
+    return { node: currentNode, offset: trimmedOffset };
+  }
+  /* istanbul ignore next */
+  throw new RangeError('No text nodes with non-whitespace text found in range');
+}
+
+/**
+ * Return a new DOM Range that adjusts the start and end positions of `range` as
+ * needed such that:
+ *
+ * - `startContainer` and `endContainer` text nodes both contain at least one
+ *   non-whitespace character within the Range's text content
+ * - `startOffset` and `endOffset` both reference non-whitespace characters,
+ *   with `startOffset` immediately before the first non-whitespace character
+ *   and `endOffset` immediately after the last
+ *
+ * Whitespace characters are those that are removed by `String.prototype.trim()`
+ *
+ * @param range - A DOM Range that whose `startContainer` and `endContainer` are
+ *   both text nodes, and which contains at least one non-whitespace character.
+ * @throws {RangeError}
+ */
+export function trimRange(range: Range): Range {
+  if (!range.toString().trim().length) {
+    throw new RangeError('Range contains no non-whitespace text');
+  }
+  if (range.startContainer.nodeType !== Node.TEXT_NODE) {
+    throw new RangeError('Range startContainer is not a text node');
+  }
+  if (range.endContainer.nodeType !== Node.TEXT_NODE) {
+    throw new RangeError('Range endContainer is not a text node');
+  }
+
+  const trimmedRange = range.cloneRange();
+
+  let startTrimmed = false;
+  let endTrimmed = false;
+
+  const trimmedOffsets = {
+    start: closestNonSpaceInString(
+      range.startContainer.textContent!,
+      range.startOffset,
+      TrimDirection.Forwards
+    ),
+    end: closestNonSpaceInString(
+      range.endContainer.textContent!,
+      range.endOffset,
+      TrimDirection.Backwards
+    ),
+  };
+
+  if (trimmedOffsets.start >= 0) {
+    trimmedRange.setStart(range.startContainer, trimmedOffsets.start);
+    startTrimmed = true;
+  }
+
+  // Note: An offset of 0 is invalid for an end offset, as no text in the
+  // node would be included in the range.
+  if (trimmedOffsets.end > 0) {
+    trimmedRange.setEnd(range.endContainer, trimmedOffsets.end);
+    endTrimmed = true;
+  }
+
+  if (startTrimmed && endTrimmed) {
+    return trimmedRange;
+  }
+
+  if (!startTrimmed) {
+    // There are no (non-whitespace) characters between `startOffset` and the
+    // end of the `startContainer` node.
+    const { node, offset } = closestNonSpaceInRange(
+      trimmedRange,
+      TrimDirection.Forwards
+    );
+
+    if (node && offset >= 0) {
+      trimmedRange.setStart(node, offset);
+    }
+  }
+
+  if (!endTrimmed) {
+    // There are no (non-whitespace) characters between the start of the Range's
+    // `endContainer` text content and the `endOffset`.
+    const { node, offset } = closestNonSpaceInRange(
+      trimmedRange,
+      TrimDirection.Backwards
+    );
+
+    if (node && offset > 0) {
+      trimmedRange.setEnd(node, offset);
+    }
+  }
+
+  return trimmedRange;
+}

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -706,7 +706,8 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
    * Show or hide the adder toolbar when the selection changes.
    */
   _onSelection(range: Range) {
-    if (!this._integration.canAnnotate(range)) {
+    const annotatableRange = this._integration.getAnnotatableRange(range);
+    if (!annotatableRange) {
       this._onClearSelection();
       return;
     }
@@ -720,7 +721,7 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
       return;
     }
 
-    this.selectedRanges = [range];
+    this.selectedRanges = [annotatableRange];
     this._hostRPC.call('textSelected');
 
     this._adder.annotationsForSelection = annotationsForSelection();

--- a/src/annotator/integrations/html.js
+++ b/src/annotator/integrations/html.js
@@ -1,6 +1,7 @@
 import { TinyEmitter } from 'tiny-emitter';
 
 import { anchor, describe } from '../anchoring/html';
+import { TextRange } from '../anchoring/text-range';
 
 import { HTMLMetadata } from './html-metadata';
 import {
@@ -105,8 +106,21 @@ export class HTMLIntegration extends TinyEmitter {
     }
   }
 
-  canAnnotate() {
-    return true;
+  /**
+   * Return a Range trimmed to remove any leading or trailing whitespace, or
+   * `null` if no valid trimmed Range can be created from `range`
+   *
+   * @param {Range} range
+   */
+  getAnnotatableRange(range) {
+    try {
+      return TextRange.trimmedRange(range);
+    } catch (err) {
+      if (err instanceof RangeError) {
+        return null;
+      }
+      throw err;
+    }
   }
 
   canStyleClusteredHighlights() {

--- a/src/annotator/integrations/pdf.js
+++ b/src/annotator/integrations/pdf.js
@@ -2,6 +2,7 @@ import debounce from 'lodash.debounce';
 import { render } from 'preact';
 import { TinyEmitter } from 'tiny-emitter';
 
+import { TextRange } from '../anchoring/text-range';
 import { ListenerCollection } from '../../shared/listener-collection';
 import {
   RenderingStates,
@@ -198,12 +199,24 @@ export class PDFIntegration extends TinyEmitter {
   }
 
   /**
-   * Return true if the text in a range lies within the text layer of a PDF.
+   * Trim `range` to remove leading or trailing empty content, then check to see
+   * if that trimmed Range lies within a single PDF page's text layer. If so,
+   * return the trimmed Range.
    *
    * @param {Range} range
    */
-  canAnnotate(range) {
-    return canDescribe(range);
+  getAnnotatableRange(range) {
+    try {
+      const trimmedRange = TextRange.trimmedRange(range);
+      if (canDescribe(trimmedRange)) {
+        return trimmedRange;
+      }
+    } catch (err) {
+      if (!(err instanceof RangeError)) {
+        throw err;
+      }
+    }
+    return null;
   }
 
   /* istanbul ignore next */

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -80,6 +80,7 @@ describe('annotator/integrations/vitalsource', () => {
       ]),
       destroy: sinon.stub(),
       fitSideBySide: sinon.stub().returns(false),
+      getAnnotatableRange: sinon.stub().returnsArg(0),
       scrollToAnchor: sinon.stub(),
       sideBySideEnabled: false,
     };
@@ -296,9 +297,12 @@ describe('annotator/integrations/vitalsource', () => {
       integrations.forEach(int => int.destroy());
     });
 
-    it('allows annotation', () => {
+    it('delegates to HTML integration to check if selected content is annotatable', () => {
       const integration = createIntegration();
-      assert.isTrue(integration.canAnnotate());
+      const range = new Range();
+
+      assert.equal(integration.getAnnotatableRange(range), range);
+      assert.calledWith(fakeHTMLIntegration.getAnnotatableRange, range);
     });
 
     it('asks guest to wait for feature flags before sending document info', () => {

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -304,8 +304,8 @@ export class VitalSourceContentIntegration
     }
   }
 
-  canAnnotate() {
-    return true;
+  getAnnotatableRange(range: Range) {
+    return this._htmlIntegration.getAnnotatableRange(range);
   }
 
   destroy() {

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -139,7 +139,7 @@ describe('Guest', () => {
 
     fakeIntegration = Object.assign(new TinyEmitter(), {
       anchor: sinon.stub(),
-      canAnnotate: sinon.stub().returns(true),
+      getAnnotatableRange: sinon.stub().returnsArg(0),
       canStyleClusteredHighlights: sinon.stub().returns(false),
       contentContainer: sinon.stub().returns({}),
       describe: sinon.stub(),
@@ -726,8 +726,7 @@ describe('Guest', () => {
     it('hides the adder if the integration indicates that the selection cannot be annotated', () => {
       // Simulate integration indicating text is not part of annotatable content
       // (eg. text that is part of the PDF.js UI)
-      fakeIntegration.canAnnotate.returns(false);
-
+      fakeIntegration.getAnnotatableRange = sinon.stub().returns(null);
       createGuest();
       simulateSelectionWithText();
 

--- a/src/test-util/compare-dom.js
+++ b/src/test-util/compare-dom.js
@@ -46,3 +46,19 @@ export function assertNodesEqual(actual, expected) {
     );
   }
 }
+
+/**
+ * Return all the `Text` descendants of `node`
+ *
+ * @param {Node} node
+ * @return {Text[]}
+ */
+export function textNodes(node) {
+  const nodes = [];
+  const iter = document.createNodeIterator(node, NodeFilter.SHOW_TEXT);
+  let current;
+  while ((current = iter.nextNode())) {
+    nodes.push(current);
+  }
+  return nodes;
+}

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -157,11 +157,6 @@ export type SidebarLayout = {
  */
 export type IntegrationBase = {
   /**
-   * Return whether the specified DOM range is part of the annotatable content
-   * of the current document.
-   */
-  canAnnotate(range: Range): boolean;
-  /**
    * Return whether this integration supports styling multiple clusters of highlights
    */
   canStyleClusteredHighlights?(): boolean;
@@ -184,6 +179,14 @@ export type IntegrationBase = {
    * false otherwise.
    */
   fitSideBySide(layout: SidebarLayout): boolean;
+
+  /**
+   * Return a DOM Range representing the extent of annotatable content within
+   * `range`, or `null` if `range` does not contain any annotatable content.
+   * For example, `range` might be trimmed of leading or trailing whitespace.
+   * `range` may be returned unmodified if already valid.
+   */
+  getAnnotatableRange(range: Range): Range | null;
 
   /** Return the metadata of the currently loaded document, such as title, PDF fingerprint, etc. */
   getMetadata(): Promise<DocumentMetadata>;


### PR DESCRIPTION
This PR evolved from #5067 (text-range trimming). The behavior changes in this PR ensure that:

* Users cannot annotate empty content (a selection containing only whitespace will never show the Adder)
* The Range used for annotation/highlighting does not contain any leading or trailing whitespace (i.e. is "trimmed"). This change fixes #5024

This PR uses the same implementation of `trimRange` (with some feedback integrated) as #5067, but adds tests. It also adds range trimming at an Integration level via a new `getAnnotatableRange` method (which replaces `canAnnotate`).

Previously, when a user selected (a range of) text, the `guest` would ask its associated Integration whether the Range contained annotatable content by calling `canAnnotate` on the Integration and passing the current `Range` (expecting a boolean result). Now we have a situation in which we want to know both whether the input Range has any annotatable content per the Integration's opinion, and also give the Integration a chance to adjust the `Range` as it sees fit (i.e. current use case: trim it). Naming such an operation is a little awkward; at this point I've got:

```
  /**
   * Return a DOM Range representing the extent of annotatable content within
   * `range`, or `null` if `range` does not contain any annotatable content.
   * `range` may be returned unmodified if already valid.
   */
  getAnnotatableRange(range: Range): Range | null;
```

But am wholly open to other ideas. We could split this into two methods, but I want to avoid performing the range-trimming operation twice for performance reasons.

So, I'm looking for feedback on:

* The set of tests for `trimRange`, and
* The `IntegrationBase` API for validating and optionally trimming user-selected Ranges

## Testing

On this branch, visit http://localhost:3000/document/whitespace

* If you make any selections that only contain whitespace characters of any sort, you should not see the Adder pop up
* If you make a selection that leads or ends with whitespace, the selected range should be unaltered (and you should see the Adder), but if you click "Annotate" or "Highlight", the drawn highlight will snap to/trim to the first and last non-whitespace characters in the selection. The associated annotation or highlight's text content should not have any leading or trailing whitespace.

Contrast this with behavior on the `whitespace-example-document` branch (or `main` if that has been merged):

* If you make any selections that only contain whitespace:
    * If the entire text node is empty, you will not see the Adder, but:
    * If the selection is empty but there is text in the same text node, you will see the Adder, and it is possible to annotate/highlight empty content
* If you make any selections that lead or end in whitespace: That whitespace will be retained as part of the annotated/highlighted content

Fixes #5024

