### PR TITLE
Refactor AuthService to be more conventional, make more sense

### DIFF
--- a/src/sidebar/services/api.js
+++ b/src/sidebar/services/api.js
@@ -217,7 +217,7 @@ export class APIService {
     /** @param {string} route */
     const apiCall = route =>
       createAPICall(links, route, {
-        getAccessToken: auth.getAccessToken,
+        getAccessToken: () => auth.getAccessToken(),
         getClientId,
         onRequestStarted: store.apiRequestStarted,
         onRequestFinished: store.apiRequestFinished,

--- a/src/sidebar/services/test/auth-test.js
+++ b/src/sidebar/services/test/auth-test.js
@@ -137,7 +137,7 @@ describe('AuthService', () => {
     context('when the access token request fails', () => {
       const expectedErr = new Error('Grant token exchange failed');
       beforeEach('make access token requests fail', () => {
-        fakeClient.exchangeGrantToken.returns(Promise.reject(expectedErr));
+        fakeClient.exchangeGrantToken.rejects(expectedErr);
       });
 
       function assertThatAccessTokenPromiseWasRejectedAnd(func) {


### PR DESCRIPTION
This PR converts `AuthService` to TypeScript and then refactors it per a long-lived TODO in the module ("// TODO - Convert these to ordinary class methods." referring to the three intended-public methods `getAccessToken`, `login` and `logout`).

I've left the logic fundamentally intact, and made no changes to tests. I optimized the resulting class for readability of the three public methods: I did extract a bit of grant-token-related logic from `getAccessToken` into its own (private) method to make the `getAccessToken` method easier to scan. I updated and clarified a few comments in some places.

I did have to make one change to the API service to ensure that `getAccessToken` is always invoked on an/the AuthService _instance_: without this change there is no `this` available in the `getAccessToken` callback and everything asplodes. It's good to get all of this stuff more and more consistent...

