### PR TITLE
Update shared components in LoginPromptPanel; convert to TS

### DIFF
--- a/src/sidebar/components/LoginPromptPanel.tsx
+++ b/src/sidebar/components/LoginPromptPanel.tsx
@@ -1,4 +1,4 @@
-import { Actions, LabeledButton } from '@hypothesis/frontend-shared';
+import { Button, CardActions } from '@hypothesis/frontend-shared/lib/next';
 
 import { useSidebarStore } from '../store';
 
@@ -28,14 +28,14 @@ export default function LoginPromptPanel({
       panelName="loginPrompt"
     >
       <p>Please log in to create annotations or highlights.</p>
-      <Actions>
-        <LabeledButton title="Sign up" onClick={onSignUp}>
+      <CardActions>
+        <Button title="Sign up" onClick={onSignUp}>
           Sign up
-        </LabeledButton>
-        <LabeledButton title="Log in" variant="primary" onClick={onLogin}>
+        </Button>
+        <Button title="Log in" variant="primary" onClick={onLogin}>
           Log in
-        </LabeledButton>
-      </Actions>
+        </Button>
+      </CardActions>
     </SidebarPanel>
   );
 }

--- a/src/sidebar/components/LoginPromptPanel.tsx
+++ b/src/sidebar/components/LoginPromptPanel.tsx
@@ -4,18 +4,18 @@ import { useSidebarStore } from '../store';
 
 import SidebarPanel from './SidebarPanel';
 
-/**
- * @typedef LoginPromptPanelProps
- * @prop {() => void} onLogin
- * @prop {() => void} onSignUp
- */
+export type LoginPromptPanelProps = {
+  onLogin: () => void;
+  onSignUp: () => void;
+};
 
 /**
  * A sidebar panel that prompts a user to log in (or sign up) to annotate.
- *
- * @param {LoginPromptPanelProps} props
  */
-export default function LoginPromptPanel({ onLogin, onSignUp }) {
+export default function LoginPromptPanel({
+  onLogin,
+  onSignUp,
+}: LoginPromptPanelProps) {
   const store = useSidebarStore();
   const isLoggedIn = store.isLoggedIn();
   if (isLoggedIn) {


### PR DESCRIPTION
Marching along with another little one here.

No user-visible changes.

## Testing

1. Log out of the client
2. Select some text; click Annotate or Highlight
3. You should see a panel in the sidebar prompting you to log in or sign up <-- That's the LoginPromptPanel. It should look the same on `main` and this branch.

Part of https://github.com/hypothesis/client/issues/4860