### PR TITLE
Update ARIA attributes in `TagEditor`

### DIFF
--- a/src/sidebar/components/TagEditor.tsx
+++ b/src/sidebar/components/TagEditor.tsx
@@ -262,12 +262,6 @@ function TagEditor({
         id={tagEditorId}
         data-testid="combobox-container"
         ref={closeWrapperRef}
-        // Disabled because aria-controls must be attached to the <input> field
-        // eslint-disable-next-line jsx-a11y/role-has-required-aria-props
-        role="combobox"
-        aria-expanded={suggestionsListOpen.toString()}
-        aria-owns={`${tagEditorId}-AutocompleteList`}
-        aria-haspopup="listbox"
       >
         <Input
           onInput={handleOnInput}
@@ -280,8 +274,10 @@ function TagEditor({
           aria-autocomplete="list"
           aria-activedescendant={activeDescendant}
           aria-controls={`${tagEditorId}-AutocompleteList`}
+          aria-expanded={suggestionsListOpen.toString()}
           aria-label="Add tags"
           dir="auto"
+          role="combobox"
         />
         <AutocompleteList
           id={`${tagEditorId}-AutocompleteList`}

--- a/src/sidebar/components/TagEditor.tsx
+++ b/src/sidebar/components/TagEditor.tsx
@@ -24,8 +24,8 @@ export type TagEditorProps = {
 /**
  * Component to edit annotation's tags.
  *
- * Component accessibility is modeled after "Combobox with Listbox Popup Examples" found here:
- * https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html
+ * Component accessibility is modeled after "Combobox with Listbox Autocomplete Example" found here:
+ * https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-autocomplete-list.html
  */
 function TagEditor({
   onAddTag,

--- a/src/sidebar/components/test/TagEditor-test.js
+++ b/src/sidebar/components/test/TagEditor-test.js
@@ -453,23 +453,13 @@ describe('TagEditor', () => {
   });
 
   describe('accessibility attributes and ids', () => {
-    const comboboxSelector = '[data-testid="combobox-container"]';
+    const comboboxSelector = 'input[role="combobox"]';
     it('creates multiple <TagEditor> components with unique AutocompleteList `id` props', () => {
       const wrapper1 = createComponent();
       const wrapper2 = createComponent();
       assert.notEqual(
         wrapper1.find('AutocompleteList').prop('id'),
         wrapper2.find('AutocompleteList').prop('id')
-      );
-    });
-
-    it('sets the <AutocompleteList> `id` prop to the same value as the `aria-owns` attribute', () => {
-      const wrapper = createComponent();
-      wrapper.find('AutocompleteList');
-
-      assert.equal(
-        wrapper.find(comboboxSelector).prop('aria-owns'),
-        wrapper.find('AutocompleteList').prop('id')
       );
     });
 


### PR DESCRIPTION
This PR updates a few ARIA attributes in the `TagEditor` `combobox` to make automated accessibility tests pass (and to meet accessibility needs!). It does this primarily by assigning the `combobox` role and related `aria-` attributes to the `input` element instead of the wrapper/container. [It was noted when the component was first added](https://github.com/hypothesis/client/pull/1714#discussion_r372264262) that the `combobox` role should be assigned to the `input`, but it doesn't look like that happened for one reason or another.

Recent changes to `axe-core` https://github.com/hypothesis/client/pull/5118 cause automated tests to fail for this component; changes in this PR will make them pass again.

Also updated the URL for the applicable WAI-ARIA combobox example as the old link no longer works, and took some time to verify that we are supporting the needed navigation and behavior (we are).

Further work could happen here in future to change the component composition (and disentangle tag-specific logic from combobox/listbox behavior) but that is a bit of a dive so I'm going to defer for now.