### PR TITLE
AnnotationPublishControl: Update shared components, convert to TS

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationPublishControl.js
+++ b/src/sidebar/components/Annotation/AnnotationPublishControl.js
@@ -1,4 +1,8 @@
-import { Icon, LabeledButton } from '@hypothesis/frontend-shared';
+import {
+  Button,
+  CancelIcon,
+  MenuExpandIcon,
+} from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 
 import { withServices } from '../../service-context';
@@ -50,14 +54,14 @@ function AnnotationPublishControl({
       className="w-9 h-9 flex items-center justify-center text-color-text-inverted"
       style={buttonStyle}
     >
-      <Icon name="expand-menu" classes="w-4 h-4" />
+      <MenuExpandIcon className="w-4 h-4" />
     </div>
   );
 
   return (
     <div className="flex flex-row gap-x-3">
       <div className="flex relative">
-        <LabeledButton
+        <Button
           classes={classnames(
             // Turn off right-side border radius to align with menu-open button
             'rounded-r-none'
@@ -66,11 +70,11 @@ function AnnotationPublishControl({
           style={buttonStyle}
           onClick={onSave}
           disabled={isDisabled}
-          size="large"
+          size="lg"
           variant="primary"
         >
           Post to {isPrivate ? 'Only Me' : group.name}
-        </LabeledButton>
+        </Button>
         {/* This wrapper div is necessary because of peculiarities with
              Safari: see https://github.com/hypothesis/client/issues/2302 */}
         <div
@@ -113,14 +117,10 @@ function AnnotationPublishControl({
         </div>
       </div>
       <div>
-        <LabeledButton
-          classes="p-2.5"
-          icon="cancel"
-          onClick={onCancel}
-          size="large"
-        >
+        <Button data-testid="cancel-button" onClick={onCancel} size="lg">
+          <CancelIcon />
           Cancel
-        </LabeledButton>
+        </Button>
       </div>
     </div>
   );

--- a/src/sidebar/components/Annotation/AnnotationPublishControl.tsx
+++ b/src/sidebar/components/Annotation/AnnotationPublishControl.tsx
@@ -5,28 +5,40 @@ import {
 } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 
+import type { Group } from '../../../types/api';
+import type { SidebarSettings } from '../../../types/config';
+
 import { withServices } from '../../service-context';
 import { applyTheme } from '../../helpers/theme';
 
 import Menu from '../Menu';
 import MenuItem from '../MenuItem';
 
-/**
- * @typedef {import('../../../types/api').Group} Group
- * @typedef {import('../../../types/config').SidebarSettings} SidebarSettings
- */
+export type AnnotationPublishControlProps = {
+  /** The group this annotation or draft would publish to */
+  group: Group;
 
-/**
- * @typedef AnnotationPublishControlProps
- * @prop {Group} group - The group this annotation or draft would publish to
- * @prop {boolean} [isDisabled]
- *  - Should the save button be disabled? Hint: it will be if the annotation has no content
- * @prop {boolean} isPrivate - Annotation or draft is "Only Me"
- * @prop {() => void} onCancel - Callback for cancel button click
- * @prop {() => void} onSave - Callback for save button click
- * @prop {(isPrivate: boolean) => void} onSetPrivate - Callback for save button click
- * @prop {SidebarSettings} settings - Injected service
- */
+  /**
+   * Should the save button be disabled? Hint: it will be if the annotation has
+   * no content
+   */
+  isDisabled?: boolean;
+
+  /** Annotation or draft is "Only Me" */
+  isPrivate: boolean;
+
+  /** Callback for cancel button click */
+  onCancel: () => void;
+
+  /** Callback for save button click */
+  onSave: () => void;
+
+  /** Callback when privacy level is changed (publish to group vs. Only me) */
+  onSetPrivate: (isPrivate: boolean) => void;
+
+  // Injected
+  settings: SidebarSettings;
+};
 
 /**
  * Render a compound control button for publishing (saving) an annotation:
@@ -43,7 +55,7 @@ function AnnotationPublishControl({
   onSave,
   onSetPrivate,
   settings,
-}) {
+}: AnnotationPublishControlProps) {
   const buttonStyle = applyTheme(
     ['ctaTextColor', 'ctaBackgroundColor'],
     settings

--- a/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
@@ -62,7 +62,7 @@ describe('AnnotationPublishControl', () => {
   });
 
   const getPublishButton = wrapper =>
-    wrapper.find('LabeledButton[data-testid="publish-control-button"]');
+    wrapper.find('Button[data-testid="publish-control-button"]');
 
   describe('theming', () => {
     it('should apply theme styles', () => {
@@ -188,9 +188,7 @@ describe('AnnotationPublishControl', () => {
   describe('cancel button', () => {
     it('should invoke the `onCancel` callback when cancel button clicked', () => {
       const wrapper = createAnnotationPublishControl();
-      const cancelBtn = wrapper
-        .find('LabeledButton')
-        .filter({ icon: 'cancel' });
+      const cancelBtn = wrapper.find('Button[data-testid="cancel-button"]');
 
       cancelBtn.props().onClick();
 


### PR DESCRIPTION
Part of #4860 

This PR updates the component that renders publish (and cancel) buttons in the annotation-editing interface:

<img width="258" alt="image" src="https://user-images.githubusercontent.com/439947/211339603-6686eb8f-8f92-456f-a483-c71f2bdbcce6.png">

There should be no user-visible changes.

Testing:

1. Check out `main` branch. In any page of local webserver, edit an existing annotation to expand the editing interface.
2. Check out this branch. In any page of local webserver, edit an existing annotation to expand the editing interface.

The interfaces should appear and behave identically.