### PR TITLE
Update shared components in AnnotationReplyToggle and convert to TS

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationReplyToggle.tsx
+++ b/src/sidebar/components/Annotation/AnnotationReplyToggle.tsx
@@ -1,4 +1,5 @@
-import { LinkButton } from '@hypothesis/frontend-shared';
+import { ButtonBase } from '@hypothesis/frontend-shared/lib/next';
+import classnames from 'classnames';
 
 export type AnnotationReplyToggleProps = {
   onToggleReplies: () => void;
@@ -18,9 +19,18 @@ function AnnotationReplyToggle({
   const toggleText = `${toggleAction} (${replyCount})`;
 
   return (
-    <LinkButton onClick={onToggleReplies} title={toggleText}>
+    <ButtonBase
+      classes={classnames(
+        // This button has a non-standard color combination: it uses a lighter
+        // text color than other LinkButtons
+        'text-grey-7 enabled:hover:text-brand-dark',
+        'no-underline enabled:hover:underline'
+      )}
+      onClick={onToggleReplies}
+      title={toggleText}
+    >
       {toggleText}
-    </LinkButton>
+    </ButtonBase>
   );
 }
 

--- a/src/sidebar/components/Annotation/AnnotationReplyToggle.tsx
+++ b/src/sidebar/components/Annotation/AnnotationReplyToggle.tsx
@@ -1,23 +1,19 @@
 import { LinkButton } from '@hypothesis/frontend-shared';
 
-/**
- * @typedef AnnotationReplyToggleProps
- * @prop {() => void} onToggleReplies
- * @prop {number} replyCount
- * @prop {boolean} threadIsCollapsed
- */
-
+export type AnnotationReplyToggleProps = {
+  onToggleReplies: () => void;
+  replyCount: number;
+  threadIsCollapsed: boolean;
+};
 /**
  * Render a thread-card control to toggle (expand or collapse) all of this
  * thread's children.
- *
- * @param {AnnotationReplyToggleProps} props
  */
 function AnnotationReplyToggle({
   onToggleReplies,
   replyCount,
   threadIsCollapsed,
-}) {
+}: AnnotationReplyToggleProps) {
   const toggleAction = threadIsCollapsed ? 'Show replies' : 'Hide replies';
   const toggleText = `${toggleAction} (${replyCount})`;
 

--- a/src/sidebar/components/Annotation/test/AnnotationReplyToggle-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationReplyToggle-test.js
@@ -44,7 +44,7 @@ describe('AnnotationReplyToggle', () => {
 
   it('invokes the toggle callback when clicked', () => {
     const wrapper = createComponent();
-    const button = wrapper.find('LinkButton');
+    const button = wrapper.find('button');
 
     act(() => {
       button.props().onClick();


### PR DESCRIPTION
Part of #4860

There are no user-visible changes here.

I debated for a while before settling on using `ButtonBase` here. There are two similar-but-not-the-same color combinations for `LinkButton` supported: `text` and `text-light`. The `text` color is darker and `text-light` is lighter. Initially I had thought "let's push for consolidation" and use one of those colors. But this is a long-standing piece of the UI and I had trouble picking between the two "standard" link colors: `text` seemed to dark and stark; `text-light` a little too receding. So I opted to leave the resulting color the same as before.

I've long thought this little piece of UI would benefit from a slight redesign, perhaps to look more like the disclosure toggle it is and less like a link, which it is not. But let's defer that for the moment...

Speaking of disclosure, however, I will likely open a follow-up PR to add a few ARIA attributes to this component's button for better accessibility.