### PR TITLE
Add `aria-expanded` attribute to AnnotationReplyToggle

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationReplyToggle.tsx
+++ b/src/sidebar/components/Annotation/AnnotationReplyToggle.tsx
@@ -1,4 +1,5 @@
-import { LinkButton } from '@hypothesis/frontend-shared';
+import { ButtonBase } from '@hypothesis/frontend-shared/lib/next';
+import classnames from 'classnames';
 
 export type AnnotationReplyToggleProps = {
   onToggleReplies: () => void;
@@ -18,9 +19,18 @@ function AnnotationReplyToggle({
   const toggleText = `${toggleAction} (${replyCount})`;
 
   return (
-    <LinkButton onClick={onToggleReplies} title={toggleText}>
+    <ButtonBase
+      classes={classnames(
+        // This button has a non-standard color combination: it uses a lighter
+        // text color than other LinkButtons
+        'text-grey-7 enabled:hover:text-brand-dark',
+        'no-underline enabled:hover:underline'
+      )}
+      onClick={onToggleReplies}
+      title={toggleText}
+    >
       {toggleText}
-    </LinkButton>
+    </ButtonBase>
   );
 }
 

--- a/src/sidebar/components/Annotation/AnnotationReplyToggle.tsx
+++ b/src/sidebar/components/Annotation/AnnotationReplyToggle.tsx
@@ -1,23 +1,19 @@
 import { LinkButton } from '@hypothesis/frontend-shared';
 
-/**
- * @typedef AnnotationReplyToggleProps
- * @prop {() => void} onToggleReplies
- * @prop {number} replyCount
- * @prop {boolean} threadIsCollapsed
- */
-
+export type AnnotationReplyToggleProps = {
+  onToggleReplies: () => void;
+  replyCount: number;
+  threadIsCollapsed: boolean;
+};
 /**
  * Render a thread-card control to toggle (expand or collapse) all of this
  * thread's children.
- *
- * @param {AnnotationReplyToggleProps} props
  */
 function AnnotationReplyToggle({
   onToggleReplies,
   replyCount,
   threadIsCollapsed,
-}) {
+}: AnnotationReplyToggleProps) {
   const toggleAction = threadIsCollapsed ? 'Show replies' : 'Hide replies';
   const toggleText = `${toggleAction} (${replyCount})`;
 

--- a/src/sidebar/components/Annotation/AnnotationReplyToggle.tsx
+++ b/src/sidebar/components/Annotation/AnnotationReplyToggle.tsx
@@ -26,6 +26,7 @@ function AnnotationReplyToggle({
         'text-grey-7 enabled:hover:text-brand-dark',
         'no-underline enabled:hover:underline'
       )}
+      expanded={!threadIsCollapsed}
       onClick={onToggleReplies}
       title={toggleText}
     >

--- a/src/sidebar/components/Annotation/test/AnnotationReplyToggle-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationReplyToggle-test.js
@@ -44,7 +44,7 @@ describe('AnnotationReplyToggle', () => {
 
   it('invokes the toggle callback when clicked', () => {
     const wrapper = createComponent();
-    const button = wrapper.find('LinkButton');
+    const button = wrapper.find('button');
 
     act(() => {
       button.props().onClick();

--- a/src/sidebar/components/Annotation/test/AnnotationReplyToggle-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationReplyToggle-test.js
@@ -37,6 +37,17 @@ describe('AnnotationReplyToggle', () => {
     assert.match(wrapper.text(), /^Hide replies/);
   });
 
+  it('sets `aria-expanded` based on thread collapsed status', () => {
+    const expandedWrapper = createComponent({ threadIsCollapsed: false });
+    const collapsedWrapper = createComponent({ threadIsCollapsed: true });
+
+    const expandedButton = expandedWrapper.find('button').getDOMNode();
+    const collapsedButton = collapsedWrapper.find('button').getDOMNode();
+
+    assert.equal(expandedButton.getAttribute('aria-expanded'), 'true');
+    assert.equal(collapsedButton.getAttribute('aria-expanded'), 'false');
+  });
+
   it('shows the reply count', () => {
     const wrapper = createComponent({ replyCount: 7 });
     assert.equal(wrapper.text(), 'Show replies (7)');
@@ -55,8 +66,15 @@ describe('AnnotationReplyToggle', () => {
 
   it(
     'should pass a11y checks',
-    checkAccessibility({
-      content: () => createComponent(),
-    })
+    checkAccessibility([
+      {
+        name: 'when collapsed',
+        content: () => createComponent(),
+      },
+      {
+        name: 'when expanded',
+        content: () => createComponent({ threadIsCollapsed: false }),
+      },
+    ])
   );
 });


### PR DESCRIPTION
~~Depends on #5123~~

This small PR adds an `aria-expanded` attribute to the button in `AnnotationReplyToggle`. This is a small accessibility affordance.

This would be more useful if we also assigned an `aria-controls` attribute to associate this button with the container with all of the replies in it. While not hard, per se, this is a little more involved because it involves:

* Always rendering a container for replies (at present, the container `ul` is only rendered when expanded)
* Drilling down a thread-id to the AnnotationReplyToggle component so that a corresponding `aria-controls` ID value can be generated in `AnnotationReplyToggle`. This ends up being fiddly because the drilling has to go through both `Annotation` and `EmptyAnnotation` and reminds me that the component breakdown between `Thread`, `Annotation`, `EmptyAnnotation`, etc. is not quite ideal. Given that threads are not available in the store (this is a historical/evolution thing), I wonder if we might consider introducing a context or something — this sort of thing has come up before (a leafy component wanting access to some small bit of data off of the current thread). Anyway. A thing to think about on another day.