### PR TITLE
Update shared components in AnnotationShareControl; convert to TS

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationShareControl.js
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.js
@@ -1,10 +1,12 @@
+import { useElementShouldClose } from '@hypothesis/frontend-shared';
 import {
   Card,
   IconButton,
-  TextInput,
-  TextInputWithButton,
-  useElementShouldClose,
-} from '@hypothesis/frontend-shared';
+  Input,
+  InputGroup,
+  CopyIcon,
+  ShareIcon,
+} from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 import { useEffect, useRef, useState } from 'preact/hooks';
 
@@ -127,70 +129,70 @@ function AnnotationShareControl({
   return (
     <div className="relative" ref={shareRef}>
       <IconButton
-        icon="share"
+        icon={ShareIcon}
         title="Share"
         onClick={toggleSharePanel}
         expanded={isOpen}
       />
       {isOpen && (
-        <Card
-          classes={classnames(
-            // Prefer width 96 (24rem) but ensure that component isn't wider
-            // than 85vw
-            'w-96 max-w-[85vw]',
-            // Position this Card above its IconButton. Account for larger
-            // IconButtons in touch interfaces
-            'absolute bottom-8 right-1 touch:bottom-touch-minimum',
-            'space-y-2 p-2',
-            // Cards do not have a border in the clean theme. Turn it back on.
-            'theme-clean:border theme-clean:border-solid theme-clean:border-grey-3'
-          )}
+        <div
+          // Position this Card above its IconButton. Account for larger
+          // IconButtons in touch interfaces
+          className="absolute bottom-8 right-1 touch:bottom-touch-minimum"
         >
-          <div className="flex items-center">
+          <Card
+            classes={classnames(
+              // Prefer width 96 (24rem) but ensure that component isn't wider
+              // than 85vw
+              'w-96 max-w-[85vw]',
+              'space-y-2 p-2'
+            )}
+            width="custom"
+          >
             <h2 className="text-brand text-lg font-medium">
               Share this annotation
             </h2>
-          </div>
-          <div
-            className={classnames(
-              // Slightly larger font size for touch devices to correspond with
-              // larger button and input sizes
-              'flex w-full text-sm touch:text-base'
-            )}
-          >
-            <TextInputWithButton>
-              <TextInput
-                aria-label="Use this URL to share this annotation"
-                type="text"
-                value={shareUri}
-                readOnly
-                inputRef={inputRef}
-              />
-              <IconButton
-                icon="copy"
-                title="Copy share link to clipboard"
-                onClick={copyShareLink}
-                variant="dark"
-              />
-            </TextInputWithButton>
-          </div>
-          <div className="text-base font-normal" data-testid="share-details">
-            {inContextAvailable ? (
-              <>{annotationSharingInfo}</>
-            ) : (
-              <>
-                This annotation cannot be shared in its original context because
-                it was made on a document that is not available on the web. This
-                link shares the annotation by itself.
-              </>
-            )}
-          </div>
-          {showShareLinks && <ShareLinks shareURI={shareUri} />}
-          <MenuArrow
-            direction="down"
-            classes="bottom-[-9px] right-1 touch:right-[9px]"
-          />
-        </Card>
+            <div
+              className={classnames(
+                // Slightly larger font size for touch devices to correspond with
+                // larger button and input sizes
+                'flex w-full text-sm touch:text-base'
+              )}
+            >
+              <InputGroup>
+                <Input
+                  aria-label="Use this URL to share this annotation"
+                  type="text"
+                  value={shareUri}
+                  readOnly
+                  elementRef={inputRef}
+                />
+                <IconButton
+                  icon={CopyIcon}
+                  title="Copy share link to clipboard"
+                  onClick={copyShareLink}
+                  variant="dark"
+                />
+              </InputGroup>
+            </div>
+            <div className="text-base font-normal" data-testid="share-details">
+              {inContextAvailable ? (
+                <>{annotationSharingInfo}</>
+              ) : (
+                <>
+                  This annotation cannot be shared in its original context
+                  because it was made on a document that is not available on the
+                  web. This link shares the annotation by itself.
+                </>
+              )}
+            </div>
+            {showShareLinks && <ShareLinks shareURI={shareUri} />}
+            <MenuArrow
+              direction="down"
+              classes="bottom-[-8px] right-1 touch:right-[9px]"
+            />
+          </Card>
+        </div>
       )}
     </div>
   );

--- a/src/sidebar/components/Annotation/AnnotationShareControl.tsx
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.tsx
@@ -10,30 +10,36 @@ import {
 import classnames from 'classnames';
 import { useEffect, useRef, useState } from 'preact/hooks';
 
+import { isIOS } from '../../../shared/user-agent';
+import type { Annotation, Group } from '../../../types/api';
+
 import { isShareableURI } from '../../helpers/annotation-sharing';
-import { copyText } from '../../util/copy-to-clipboard';
 import { isPrivate } from '../../helpers/permissions';
 import { withServices } from '../../service-context';
-import { isIOS } from '../../../shared/user-agent';
+import type { ToastMessengerService } from '../../services/toast-messenger';
+import { copyText } from '../../util/copy-to-clipboard';
 
 import MenuArrow from '../MenuArrow';
 import ShareLinks from '../ShareLinks';
 
-/**
- * @typedef {import('../../../types/api').Annotation} Annotation
- * @typedef {import('../../../types/api').Group} Group
- */
+export type AnnotationShareControlProps = {
+  /** The annotation in question */
+  annotation: Annotation;
 
-/**
- * @typedef AnnotationShareControlProps
- * @prop {Annotation} annotation - The annotation in question
- * @prop {Group} [group] -
- *  Group that the annotation is in. If missing, this component will not render.
- *  FIXME: Refactor after root cause is addressed.
- *  See https://github.com/hypothesis/client/issues/1542
- * @prop {string} shareUri - The URI to view the annotation on its own
- * @prop {import('../../services/toast-messenger').ToastMessengerService} toastMessenger
- */
+  /**
+   *  Group that the annotation is in. If missing, this component will not
+   *  render.
+   * FIXME: Refactor after root cause is addressed. See
+   *  https://github.com/hypothesis/client/issues/1542
+   */
+  group?: Group;
+
+  /** The URI to view the annotation on its own */
+  shareUri: string;
+
+  // Injected
+  toastMessenger: ToastMessengerService;
+};
 
 function selectionOverflowsInputElement() {
   // On iOS the selection overflows the input element
@@ -51,11 +57,11 @@ function AnnotationShareControl({
   toastMessenger,
   group,
   shareUri,
-}) {
+}: AnnotationShareControlProps) {
   const annotationIsPrivate = isPrivate(annotation.permissions);
   const inContextAvailable = isShareableURI(annotation.uri);
-  const shareRef = useRef(/** @type {HTMLDivElement|null} */ (null));
-  const inputRef = useRef(/** @type {HTMLInputElement|null} */ (null));
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const shareRef = useRef<HTMLDivElement | null>(null);
 
   const [isOpen, setOpen] = useState(false);
   const wasOpen = useRef(isOpen);

--- a/src/sidebar/components/Annotation/test/AnnotationShareControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationShareControl-test.js
@@ -19,7 +19,9 @@ describe('AnnotationShareControl', () => {
   let container;
 
   const getIconButton = (wrapper, iconName) => {
-    return wrapper.find('IconButton').filter({ icon: iconName });
+    return wrapper
+      .find('IconButton')
+      .filterWhere(n => n.find(iconName).exists());
   };
 
   function createComponent(props = {}) {
@@ -111,7 +113,7 @@ describe('AnnotationShareControl', () => {
 
   it('toggles the share control element when the button is clicked', () => {
     const wrapper = createComponent();
-    const button = getIconButton(wrapper, 'share');
+    const button = getIconButton(wrapper, 'ShareIcon');
 
     act(() => {
       button.props().onClick();
@@ -135,7 +137,7 @@ describe('AnnotationShareControl', () => {
       const wrapper = createComponent();
       openElement(wrapper);
 
-      getIconButton(wrapper, 'copy').props().onClick();
+      getIconButton(wrapper, 'CopyIcon').props().onClick();
 
       assert.calledWith(
         fakeCopyToClipboard.copyText,
@@ -147,7 +149,7 @@ describe('AnnotationShareControl', () => {
       const wrapper = createComponent();
       openElement(wrapper);
 
-      getIconButton(wrapper, 'copy').props().onClick();
+      getIconButton(wrapper, 'CopyIcon').props().onClick();
 
       assert.calledWith(
         fakeToastMessenger.success,
@@ -160,7 +162,7 @@ describe('AnnotationShareControl', () => {
       const wrapper = createComponent();
       openElement(wrapper);
 
-      getIconButton(wrapper, 'copy').props().onClick();
+      getIconButton(wrapper, 'CopyIcon').props().onClick();
 
       assert.calledWith(fakeToastMessenger.error, 'Unable to copy link');
     });


### PR DESCRIPTION
Part of #4860 

This PR updates the shared components in AnnotationShareControl and converts it to TS.

This is the component that shows the sharing options for an individual annotation:

<img width="431" alt="image" src="https://user-images.githubusercontent.com/439947/211387341-6e395971-2263-4259-89e3-9b5791d7c665.png">

There should be no user-visible changes here.