### PR TITLE
Migrate NotebookFilters to TS

### DIFF
--- a/src/sidebar/components/NotebookFilters.tsx
+++ b/src/sidebar/components/NotebookFilters.tsx
@@ -6,10 +6,6 @@ import { useUserFilterOptions } from './hooks/use-filter-options';
 import FilterSelect from './FilterSelect';
 
 /**
- * @typedef {import('../store/modules/filters').FilterOption} FilterOption
- */
-
-/**
  * Filters for the Notebook
  */
 function NotebookFilters() {


### PR DESCRIPTION
This PR migrates the `NotebookFilters` component to TypeScript