### PR TITLE
Get document related tasks running again locally

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ release = u'1.0.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+# language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = docs
 skipsdist = true
 requires =
+  tox>=3.25.0,<4
   tox-faster
   tox-pyenv
   tox-run-command


### PR DESCRIPTION
Discovered testing:

 * https://github.com/hypothesis/client/pull/5099

We aren't tox 4 compatible yet and need to pin it. In Sphinx 5 setting `language = None` is now frowned upon and raises an error, which causes us to fail. This removes the line which along with the tox change allows doc related tasks to work.

## Testing notes

 * `make checkdocs` - Should work
 * `make docs` - Should serve a page to view the docs
