### PR TITLE
Add a config file to let Read the Docs know about our dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: requirements/docs.txt


### PR DESCRIPTION
Currently on Read the Docs our build is failing for the client: https://readthedocs.org/projects/h-client/

This is due to a dependency on MyST-Parser which Read the Docs doesn't know about. We can add a config file to try and let it know about our dependencies.

This file is based on the example given at: https://docs.readthedocs.io/en/stable/config-file/v2.html with the following modifications:

 * Use Python 3.9 like the project does
 * Point at our docs fixed dependency file

## Testing notes

You can see a passing build here:

 * https://readthedocs.org/projects/h-client/builds/19127255/