### PR TITLE
Consolidate the text-size utility-class scale

### DIFF
--- a/src/annotator/components/NotebookModal.tsx
+++ b/src/annotator/components/NotebookModal.tsx
@@ -119,13 +119,14 @@ export default function NotebookModal({
       data-testid="notebook-outer"
     >
       <div className="relative w-full h-full" data-testid="notebook-inner">
-        <div className="absolute right-0 text-xl m-3">
+        <div className="absolute right-0 m-3">
           <IconButton
-            icon={CancelIcon}
             title="Close the Notebook"
             onClick={onClose}
             variant="dark"
-          />
+          >
+            <CancelIcon className="w-4 h-4" />
+          </IconButton>
         </div>
         <NotebookIframe key={iframeKey} config={config} groupId={groupId} />
       </div>

--- a/src/sidebar/components/Annotation/Annotation.tsx
+++ b/src/sidebar/components/Annotation/Annotation.tsx
@@ -35,7 +35,7 @@ function SavingMessage() {
       <span
         // Slowly fade in the Spinner such that it only shows up if the saving
         // is slow
-        className="text-xl animate-fade-in-slow"
+        className="text-[16px] animate-fade-in-slow"
       >
         <Spinner size="sm" />
       </span>

--- a/src/sidebar/components/Annotation/AnnotationActionBar.tsx
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.tsx
@@ -118,7 +118,7 @@ function AnnotationActionBar({
   };
 
   return (
-    <div className="flex text-xl" data-testid="annotation-action-bar">
+    <div className="flex text-[16px]" data-testid="annotation-action-bar">
       {showEditAction && (
         <IconButton icon={EditIcon} title="Edit" onClick={onEdit} />
       )}

--- a/src/sidebar/components/Annotation/AnnotationHeader.tsx
+++ b/src/sidebar/components/Annotation/AnnotationHeader.tsx
@@ -110,7 +110,7 @@ function AnnotationHeader({
       <div className="flex gap-x-1 items-baseline flex-wrap-reverse">
         {isPrivate(annotation.permissions) && !isEditing && (
           <LockIcon
-            className="text-tiny w-em h-em"
+            className="w-[10px] h-[10px]"
             title="This annotation is visible only to you"
           />
         )}
@@ -152,7 +152,7 @@ function AnnotationHeader({
           {!isEditing && isHighlight(annotation) && (
             <HighlightIcon
               title="This is a highlight. Click 'edit' to add a note or tag."
-              className="text-tiny w-em h-em text-color-text-light"
+              className="w-[10px] h-[10px] text-color-text-light"
             />
           )}
           {showDocumentInfo && (

--- a/src/sidebar/components/Annotation/AnnotationLicense.tsx
+++ b/src/sidebar/components/Annotation/AnnotationLicense.tsx
@@ -17,8 +17,8 @@ export default function AnnotationLicense() {
         target="_blank"
         title="View more information about the Creative Commons Public Domain dedication"
       >
-        <CcStdIcon className="w-em h-em text-tiny" />
-        <CcZeroIcon className="w-em h-em ml-px text-tiny" />
+        <CcStdIcon className="w-[10px] h-[10px]" />
+        <CcZeroIcon className="w-[10px] h-[10px] ml-px" />
         <div className="ml-1">
           Annotations can be freely reused by anyone for any purpose.
         </div>

--- a/src/sidebar/components/Annotation/AnnotationLicense.tsx
+++ b/src/sidebar/components/Annotation/AnnotationLicense.tsx
@@ -9,7 +9,7 @@ import {
  */
 export default function AnnotationLicense() {
   return (
-    <div className="pt-2 border-t text-sm leading-none">
+    <div className="pt-2 border-t text-xs leading-none">
       <Link
         classes="flex items-center"
         color="text-light"

--- a/src/sidebar/components/Annotation/AnnotationShareControl.tsx
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.tsx
@@ -158,7 +158,7 @@ function AnnotationShareControl({
               className={classnames(
                 // Slightly larger font size for touch devices to correspond with
                 // larger button and input sizes
-                'flex w-full text-sm touch:text-base'
+                'flex w-full text-xs touch:text-base'
               )}
             >
               <InputGroup>

--- a/src/sidebar/components/Annotation/AnnotationShareControl.tsx
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.tsx
@@ -151,7 +151,7 @@ function AnnotationShareControl({
             )}
             width="custom"
           >
-            <h2 className="text-brand text-lg font-medium">
+            <h2 className="text-brand text-md font-medium">
               Share this annotation
             </h2>
             <div

--- a/src/sidebar/components/Annotation/AnnotationTimestamps.tsx
+++ b/src/sidebar/components/Annotation/AnnotationTimestamps.tsx
@@ -80,7 +80,7 @@ export default function AnnotationTimestamps({
     <div>
       {withEditedTimestamp && (
         <span
-          className="text-color-text-light text-sm italic"
+          className="text-color-text-light text-xs italic"
           data-testid="timestamp-edited"
           title={updated.absolute}
         >

--- a/src/sidebar/components/FilterSelect.tsx
+++ b/src/sidebar/components/FilterSelect.tsx
@@ -35,7 +35,7 @@ function FilterSelect({
       className={classnames(
         // Don't allow the label text to wrap
         'shrink-0 flex items-center gap-x-2',
-        'text-color-text font-bold text-lg'
+        'text-color-text font-bold text-md'
       )}
     >
       {Icon && <Icon className="w-4 h-4" />}

--- a/src/sidebar/components/GroupList/GroupList.js
+++ b/src/sidebar/components/GroupList/GroupList.js
@@ -90,7 +90,7 @@ function GroupList({ settings }) {
       <span
         className={classnames(
           // Don't allow this label to shrink (wrap to next line)
-          'shrink-0 flex items-center gap-x-1 text-lg text-color-text font-bold'
+          'shrink-0 flex items-center gap-x-1 text-md text-color-text font-bold'
         )}
       >
         {icon && (

--- a/src/sidebar/components/HelpPanel.tsx
+++ b/src/sidebar/components/HelpPanel.tsx
@@ -53,7 +53,7 @@ function HelpPanelTab({ linkText, url }: HelpPanelTabProps) {
     <div
       // Set this element's flex-basis and also establish
       // a flex container (centered on both axes)
-      className="flex-1 flex items-center justify-center border-r last-of-type:border-r-0 text-lg font-medium"
+      className="flex-1 flex items-center justify-center border-r last-of-type:border-r-0 text-md font-medium"
     >
       <Link color="text-light" href={url} target="_blank">
         <div className="flex items-center gap-x-2">
@@ -144,7 +144,7 @@ function HelpPanel({ session }: HelpPanelProps) {
     >
       <div className="space-y-4">
         <div className="flex items-center">
-          <h3 className="grow text-lg font-medium" data-testid="subpanel-title">
+          <h3 className="grow text-md font-medium" data-testid="subpanel-title">
             {subPanelTitles[activeSubPanel]}
           </h3>
           {activeSubPanel === 'versionInfo' && (

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -139,7 +139,7 @@ type ToolbarButtonProps = {
 
 function ToolbarButton({
   disabled = false,
-  icon,
+  icon: Icon,
   label,
   onClick,
   shortcutKey,
@@ -154,7 +154,6 @@ function ToolbarButton({
 
   const buttonProps = {
     disabled,
-    icon,
     onClick,
     title: tooltip,
   };
@@ -170,10 +169,11 @@ function ToolbarButton({
     );
   }
   return (
-    <IconButton
-      classes="px-2 py-2.5 text-tiny touch:text-base"
-      {...buttonProps}
-    />
+    <IconButton classes="px-2 py-2.5" {...buttonProps}>
+      {Icon && (
+        <Icon className="w-[10px] h-[10px] touch:w-[13px] touch:h-[13px]" />
+      )}
+    </IconButton>
   );
 }
 

--- a/src/sidebar/components/Menu.js
+++ b/src/sidebar/components/Menu.js
@@ -214,7 +214,7 @@ export default function Menu({
               'focus-visible-ring',
               // Position menu content near bottom of menu label/toggle control
               'absolute top-[calc(100%+5px)] z-1 border shadow',
-              'bg-white text-lg',
+              'bg-white text-md',
               {
                 'left-0': align === 'left',
                 'right-0': align === 'right',

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -138,7 +138,7 @@ function NotebookView({ loadAnnotationsService, streamer }) {
       <div className="justify-self-start">
         <NotebookFilters />
       </div>
-      <div className="flex items-center lg:justify-self-end text-lg font-medium">
+      <div className="flex items-center lg:justify-self-end text-md font-medium">
         {pendingUpdateCount > 0 && !hasAppliedFilter && (
           <IconButton
             icon="refresh"

--- a/src/sidebar/components/NotebookView.js
+++ b/src/sidebar/components/NotebookView.js
@@ -131,7 +131,7 @@ function NotebookView({ loadAnnotationsService, streamer }) {
   return (
     <div className="grid gap-2 lg:grid-cols-2" data-testid="notebook-container">
       <header className="leading-none lg:col-span-2" ref={threadListScrollTop}>
-        <h1 className="text-2xl font-bold" data-testid="notebook-group-name">
+        <h1 className="text-xl font-bold" data-testid="notebook-group-name">
           {groupName}
         </h1>
       </header>

--- a/src/sidebar/components/PaginationNavigation.tsx
+++ b/src/sidebar/components/PaginationNavigation.tsx
@@ -66,7 +66,7 @@ function PaginationNavigation({
 
   return (
     <div
-      className="flex items-center text-lg"
+      className="flex items-center text-md"
       data-testid="pagination-navigation"
     >
       <div className="w-28 h-10">

--- a/src/sidebar/components/SelectionTabs.tsx
+++ b/src/sidebar/components/SelectionTabs.tsx
@@ -74,7 +74,7 @@ function Tab({
       <>
         {children}
         {count > 0 && !isWaitingToAnchor && (
-          <span className="relative bottom-[3px] left-[2px] text-tiny">
+          <span className="relative bottom-[3px] left-[2px] text-[10px]">
             {count}
           </span>
         )}

--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -146,7 +146,7 @@ function TopBar({
             <UserMenu onLogout={onLogout} />
           ) : (
             <div
-              className="flex items-center text-lg font-medium space-x-1"
+              className="flex items-center text-md font-medium space-x-1"
               data-testid="login-links"
             >
               {!isLoggedIn && !hasFetchedProfile && <span>⋯</span>}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -82,10 +82,10 @@ export default {
         // which will grow during the conversion-to-Tailwind process. These
         // are descriptive, not aspirational or prescriptive.
         xs: ['11px', '1.4'],
-        sm: ['11px', '1.4'],
+        sm: ['13px', '1.4'],
         base: ['13px', '1.4'], // Current base font size for sidebar
         md: ['14px'],
-        lg: ['14px'],
+        lg: ['16px'],
         xl: ['18px'],
         'touch-base': ['16px', '1.4'], // Used for touch interfaces in certain UIs
         // Font sizes for annotator controls that should scale with text in the

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -83,6 +83,7 @@ export default {
         // are descriptive, not aspirational or prescriptive.
         sm: ['11px', '1.4'],
         base: ['13px', '1.4'], // Current base font size for sidebar
+        md: ['14px'],
         lg: ['14px'],
         xl: ['16px'],
         '2xl': ['18px'],

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -81,7 +81,6 @@ export default {
         // This is a collection of font sizes used in existing sidebar components,
         // which will grow during the conversion-to-Tailwind process. These
         // are descriptive, not aspirational or prescriptive.
-        tiny: ['10px'],
         sm: ['11px', '1.4'],
         base: ['13px', '1.4'], // Current base font size for sidebar
         lg: ['14px'],

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -86,8 +86,7 @@ export default {
         base: ['13px', '1.4'], // Current base font size for sidebar
         md: ['14px'],
         lg: ['14px'],
-        xl: ['16px'],
-        '2xl': ['18px'],
+        xl: ['18px'],
         'touch-base': ['16px', '1.4'], // Used for touch interfaces in certain UIs
         // Font sizes for annotator controls that should scale with text in the
         // document. These can only be used within shadow roots that include the

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -81,6 +81,7 @@ export default {
         // This is a collection of font sizes used in existing sidebar components,
         // which will grow during the conversion-to-Tailwind process. These
         // are descriptive, not aspirational or prescriptive.
+        xs: ['11px', '1.4'],
         sm: ['11px', '1.4'],
         base: ['13px', '1.4'], // Current base font size for sidebar
         md: ['14px'],


### PR DESCRIPTION
As we worked through all of the app components and converted their styling to Tailwind (from BEM-style SASS with several layers of abstraction), we attempted to consolidate the various pixel-based font sizes used across the app into a Tailwind type-size scale. We got this essentially right, but not entirely. It's hard to get it right without having the whole picture in front of us, which we do now.

This PR adjusts the text sizing values used by Tailwind for the the `client` app to center more accurately on the `base` size, and overlay better with the shared component library.

There should be no user-visible changes.

The type size values have all been bumped down by one level (e.g. former `xl` value is now the `lg` value; former `lg` value is now the (new) `md` value). This results in values that feel more appropriate for their size name. e.g. `text-large` is now a "large-ish" size instead of being barely larger than the `sm` size. 

The motivating situation is an updated shared component, Panel, which applies `text-lg` to heading text. With this re-centered text scale, that heading text is appropriately sized.

The first commit tackles a related issue: the use of text-size utility classes to size icons. (See commit message for more details). There were some places where we were using named text-size utility classes to size icons that introduced confusion and entanglement.

I'll add some inline comments to explain further; please bug me if this PR description doesn't draw a clear enough picture of what's going on here or you want any Tailwind-specific explanations.
