### PR TITLE
Move notebook close button inside the notebook modal itself

### DIFF
--- a/src/annotator/components/NotebookModal.tsx
+++ b/src/annotator/components/NotebookModal.tsx
@@ -1,4 +1,3 @@
-import { IconButton, CancelIcon } from '@hypothesis/frontend-shared/lib/next';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import classnames from 'classnames';
 
@@ -94,17 +93,13 @@ export default function NotebookModal({
       setIframeKey(iframeKey => iframeKey + 1);
       setGroupId(groupId);
     });
+    emitter.subscribe('closeNotebook', () => setIsHidden(true));
     emitterRef.current = emitter;
 
     return () => {
       emitter.destroy();
     };
   }, [eventBus]);
-
-  const onClose = () => {
-    setIsHidden(true);
-    emitterRef.current?.publish('closeNotebook');
-  };
 
   if (groupId === null) {
     return null;
@@ -119,15 +114,6 @@ export default function NotebookModal({
       data-testid="notebook-outer"
     >
       <div className="relative w-full h-full" data-testid="notebook-inner">
-        <div className="absolute right-0 m-3">
-          <IconButton
-            title="Close the Notebook"
-            onClick={onClose}
-            variant="dark"
-          >
-            <CancelIcon className="w-4 h-4" />
-          </IconButton>
-        </div>
         <NotebookIframe key={iframeKey} config={config} groupId={groupId} />
       </div>
     </div>

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -1,3 +1,4 @@
+import { CancelIcon, IconButton } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 import { useEffect, useMemo } from 'preact/hooks';
 
@@ -145,6 +146,17 @@ function HypothesisApp({ auth, frameSync, settings, session, toastMessenger }) {
       data-testid="hypothesis-app"
       style={backgroundStyle}
     >
+      {route === 'notebook' && (
+        <div className="absolute right-0 top-0 m-3">
+          <IconButton
+            title="Close the Notebook"
+            onClick={() => {}}
+            variant="dark"
+          >
+            <CancelIcon className="w-4 h-4" />
+          </IconButton>
+        </div>
+      )}
       {route !== 'notebook' && (
         <TopBar
           onLogin={login}


### PR DESCRIPTION
This is a WIP attempt to fix #3676 

### Context

The issue described there happens because the notebook close button is not part of the `iframe` where the rest of the notebook is rendered.

Using some z-index definitions here and there it has been made the button to be rendered "on top" of the notebook (for ovbious reasons), but the delete annotation modal, on the other hand, should be rendered "on top" of it.

However, this modal is rendered inside of the `iframe` itself.

So long story short, we want an element which is outside of the `iframe`, to be rendered "over" one element of the `iframe`, but "below" another element of the `iframe`, which doesn't seem to be possible.

### Possible solution

The solution I'm exploring involves moving the button to the `HypothesisApp` component, which will make it render inside the `iframe` and simplify the interaction with the other two "layers".

However, this requires changing how the click interaction is handled on it. Right now it publishes a `closeNotebook` event, and handles the "toggling" of the modal via local state.

What I'm trying to do is listen for the  `closeNotebook` event instead, and react to it to handle the local state, but I'm struggling to get the `eventBus` object "injected" in the `HypothesisApp` component.

I'm also not sure if this is the approach we want to take, or if it will even work.