### PR TITLE
Convert `annotations` store module to TS

### DIFF
--- a/src/sidebar/store/modules/annotations.ts
+++ b/src/sidebar/store/modules/annotations.ts
@@ -3,31 +3,70 @@
  * sidebar.
  */
 
+import type { Dispatch } from 'redux';
 import { createSelector } from 'reselect';
 
 import { hasOwn } from '../../../shared/has-own';
+import type { Annotation, SavedAnnotation } from '../../../types/api';
+import type { HighlightCluster } from '../../../types/shared';
+
 import * as metadata from '../../helpers/annotation-metadata';
 import { isHighlight, isSaved } from '../../helpers/annotation-metadata';
 import { countIf, toTrueMap, trueKeys } from '../../util/collections';
 import { createStoreModule, makeAction } from '../create-store';
 
 import { routeModule } from './route';
+import type { State as RouteState } from './route';
 import { sessionModule } from './session';
+import type { State as SessionState } from './session';
 
-/**
- * @typedef {'anchored'|'orphan'|'timeout'} AnchorStatus
- * @typedef {import('../../../types/api').Annotation} Annotation
- * @typedef {import('../../../types/shared').HighlightCluster} HighlightCluster
- * @typedef {import('../../../types/shared').ClientAnnotationData} ClientAnnotationData
- * @typedef {import('../../../types/api').SavedAnnotation} SavedAnnotation
- */
+type AnchorStatus = 'anchored' | 'orphan' | 'timeout';
 
-/**
- * @typedef AnnotationStub
- * @prop {string} [id] - service-provided identifier if annotation has been
- *       persisted to the service
- * @prop {string} [$tag] - local-generated identifier
- */
+type AnchorStatusUpdates = {
+  [$tag: string]: AnchorStatus;
+};
+
+type AnnotationStub = {
+  /**
+   * Service-provided identifier if annotation has been
+   * persisted to the service
+   */
+  id?: string;
+
+  /** Local-generated identifier */
+  $tag?: string;
+};
+
+const initialState = {
+  annotations: [],
+  highlighted: {},
+  hovered: {},
+  nextTag: 1,
+} as {
+  /** Set of currently-loaded annotations */
+  annotations: Annotation[];
+
+  /**
+   * The $tags of annotations that should appear as "highlighted", e.g. the
+   * target of a single-annotation view. NB: This feature is currently not
+   * supported in the application UI.
+   */
+  highlighted: { [$tag: string]: boolean };
+
+  /**
+   * The $tags of annotations whose cards or highlights are currently hovered.
+   * The styling of the highlights/cards of these annotations are adjusted to
+   * show the correspondence between the two.
+   */
+  hovered: { [$tag: string]: boolean };
+
+  /**
+   * The local tag to assign to the next annotation that is loaded into the app
+   */
+  nextTag: number;
+};
+
+export type State = typeof initialState;
 
 /**
  * Return a copy of `current` with all matching annotations in `annotations`
@@ -35,14 +74,14 @@ import { sessionModule } from './session';
  *
  * Annotations in `annotations` may be complete annotations or "stubs" with only
  * the `id` field set.
- *
- * @param {Annotation[]} current
- * @param {AnnotationStub[]} annotations
  */
-function excludeAnnotations(current, annotations) {
+function excludeAnnotations(
+  current: Annotation[],
+  annotations: AnnotationStub[]
+) {
   const ids = new Set();
   const tags = new Set();
-  for (let annot of annotations) {
+  for (const annot of annotations) {
     if (annot.id) {
       ids.add(annot.id);
     }
@@ -57,19 +96,11 @@ function excludeAnnotations(current, annotations) {
   });
 }
 
-/**
- * @param {Annotation[]} annotations
- * @param {string} id
- */
-function findByID(annotations, id) {
+function findByID(annotations: Annotation[], id: string) {
   return annotations.find(a => a.id === id);
 }
 
-/**
- * @param {Annotation[]} annotations
- * @param {string} tag
- */
-function findByTag(annotations, tag) {
+function findByTag(annotations: Annotation[], tag: string) {
   return annotations.find(a => a.$tag === tag);
 }
 
@@ -80,73 +111,44 @@ function findByTag(annotations, tag) {
  * `annotation` may either be new (unsaved) or a persisted annotation retrieved
  * from the service.
  *
- * @param {Omit<Annotation, '$anchorTimeout'>} annotation
- * @param {string} tag - The `$tag` value that should be used for this if it
- *                       doesn't have a `$tag` already
- * @param {string|null} currentUserId - The account id of the currently-auth'd
- *                       user, if any
- * @return {Annotation} - API annotation data with client annotation data merged
+ * @param tag - The `$tag` value that should be used for this if it doesn't have
+ * a `$tag` already
+ * @return - API annotation data with client annotation data merged
  */
-function initializeAnnotation(annotation, tag, currentUserId) {
+function initializeAnnotation(
+  annotation: Omit<Annotation, '$anchorTimeout'>,
+  tag: string,
+  currentUserId: string | null
+): Annotation {
   let orphan = annotation.$orphan;
 
   if (!annotation.id) {
-    // New annotations must be anchored
+    // Unsaved (new) annotations must be anchored
     orphan = false;
   }
 
-  let $cluster = /** @type {HighlightCluster} */ ('other-content');
+  let $cluster: HighlightCluster = 'other-content';
   if (annotation.user === currentUserId) {
     $cluster = isHighlight(annotation) ? 'user-highlights' : 'user-annotations';
   }
 
-  return Object.assign(
-    {},
-    annotation,
-    /** @type {ClientAnnotationData} */ ({
-      $anchorTimeout: false,
-      $cluster,
-      $tag: annotation.$tag || tag,
-      $orphan: orphan,
-    })
-  );
+  return Object.assign({}, annotation, {
+    $anchorTimeout: false,
+    $cluster,
+    $tag: annotation.$tag || tag,
+    $orphan: orphan,
+  });
 }
 
-const initialState = {
-  /**
-   * Set of all currently loaded annotations.
-   *
-   * @type {Annotation[]}
-   */
-  annotations: [],
-  /**
-   * Annotations whose cards or highlights are currently hovered.
-   *
-   * The styling of the highlights/cards of these annotations are adjusted to
-   * show the correspondence between the two.
-   *
-   * @type {Record<string, boolean>}
-   */
-  hovered: {},
-  /**
-   * A map of annotations that should appear as "highlighted", e.g. the
-   * target of a single-annotation view
-   *
-   * @type {Record<string, boolean>}
-   */
-  highlighted: {},
-  /** The local tag to assign to the next annotation that is loaded into the app. */
-  nextTag: 1,
-};
-
-/** @typedef {typeof initialState} State */
-
 const reducers = {
-  /**
-   * @param {State} state
-   * @param {{ annotations: Annotation[], currentAnnotationCount: number, currentUserId: string|null }} action
-   */
-  ADD_ANNOTATIONS(state, action) {
+  ADD_ANNOTATIONS(
+    state: State,
+    action: {
+      annotations: Annotation[];
+      currentAnnotationCount: number;
+      currentUserId: string | null;
+    }
+  ): Partial<State> {
     const updatedIDs = new Set();
     const updatedTags = new Set();
 
@@ -155,7 +157,7 @@ const reducers = {
     const updated = [];
     let nextTag = state.nextTag;
 
-    for (let annot of action.annotations) {
+    for (const annot of action.annotations) {
       let existing;
       if (annot.id) {
         existing = findByID(state.annotations, annot.id);
@@ -182,7 +184,7 @@ const reducers = {
       }
     }
 
-    for (let annot of state.annotations) {
+    for (const annot of state.annotations) {
       if (!updatedIDs.has(annot.id) && !updatedTags.has(annot.$tag)) {
         unchanged.push(annot);
       }
@@ -194,23 +196,15 @@ const reducers = {
     };
   },
 
-  CLEAR_ANNOTATIONS() {
+  CLEAR_ANNOTATIONS(): Partial<State> {
     return { annotations: [], highlighted: {}, hovered: {} };
   },
 
-  /**
-   * @param {State} state
-   * @param {{ tags: string[] }} action
-   */
-  HOVER_ANNOTATIONS(state, action) {
+  HOVER_ANNOTATIONS(state: State, action: { tags: string[] }): Partial<State> {
     return { hovered: toTrueMap(action.tags) };
   },
 
-  /**
-   * @param {State} state
-   * @param {{ id: string }} action
-   */
-  HIDE_ANNOTATION(state, action) {
+  HIDE_ANNOTATION(state: State, action: { id: string }): Partial<State> {
     const anns = state.annotations.map(ann => {
       if (ann.id !== action.id) {
         return ann;
@@ -220,29 +214,26 @@ const reducers = {
     return { annotations: anns };
   },
 
-  /**
-   * @param {State} state
-   * @param {{ highlighted: Record<string, boolean> }} action
-   */
-  HIGHLIGHT_ANNOTATIONS(state, action) {
+  HIGHLIGHT_ANNOTATIONS(
+    state: State,
+    action: Pick<State, 'highlighted'>
+  ): Partial<State> {
     return { highlighted: action.highlighted };
   },
 
-  /**
-   * @param {State} state
-   * @param {{ annotationsToRemove: AnnotationStub[], remainingAnnotations: Annotation[] }} action
-   */
-  REMOVE_ANNOTATIONS(state, action) {
+  REMOVE_ANNOTATIONS(
+    state: State,
+    action: {
+      annotationsToRemove: AnnotationStub[];
+      remainingAnnotations: Annotation[];
+    }
+  ): Partial<State> {
     return {
       annotations: [...action.remainingAnnotations],
     };
   },
 
-  /**
-   * @param {State} state
-   * @param {{ id: string }} action
-   */
-  UNHIDE_ANNOTATION(state, action) {
+  UNHIDE_ANNOTATION(state: State, action: { id: string }): Partial<State> {
     const anns = state.annotations.map(ann => {
       if (ann.id !== action.id) {
         return ann;
@@ -252,11 +243,10 @@ const reducers = {
     return { annotations: anns };
   },
 
-  /**
-   * @param {State} state
-   * @param {{ statusUpdates: Record<string, AnchorStatus> }} action
-   */
-  UPDATE_ANCHOR_STATUS(state, action) {
+  UPDATE_ANCHOR_STATUS(
+    state: State,
+    action: { statusUpdates: AnchorStatusUpdates }
+  ): Partial<State> {
     const annotations = state.annotations.map(annot => {
       if (!hasOwn(action.statusUpdates, annot.$tag)) {
         return annot;
@@ -272,11 +262,10 @@ const reducers = {
     return { annotations };
   },
 
-  /**
-   * @param {State} state
-   * @param {{ id: string, isFlagged: boolean }} action
-   */
-  UPDATE_FLAG_STATUS(state, action) {
+  UPDATE_FLAG_STATUS(
+    state: State,
+    action: { id: string; isFlagged: boolean }
+  ): Partial<State> {
     const annotations = state.annotations.map(annot => {
       const match = annot.id && annot.id === action.id;
       if (match) {
@@ -306,16 +295,18 @@ const reducers = {
 /* Action creators */
 
 /**
- * Add these `annotations` to the current collection of annotations in the store.
- *
- * @param {Annotation[]} annotations - Array of annotation objects to add.
+ * Add these `annotations` to the current collection of annotations in the
+ * store.
  */
-function addAnnotations(annotations) {
-  /**
-   * @param {import('redux').Dispatch} dispatch
-   * @param {() => { annotations: State, route: import('./route').State, session: import('./session').State }} getState
-   */
-  return function (dispatch, getState) {
+function addAnnotations(annotations: Annotation[]) {
+  return function (
+    dispatch: Dispatch,
+    getState: () => {
+      annotations: State;
+      route: RouteState;
+      session: SessionState;
+    }
+  ) {
     const added = annotations.filter(annot => {
       return (
         !annot.id || !findByID(getState().annotations.annotations, annot.id)
@@ -344,24 +335,25 @@ function addAnnotations(annotations) {
     // successfully anchor then the status will be updated.
     const ANCHORING_TIMEOUT = 500;
 
-    const anchoringIDs = added
+    const anchoringIds = added
       .filter(metadata.isWaitingToAnchor)
       .map(ann => ann.id);
-    if (anchoringIDs.length > 0) {
+
+    if (anchoringIds.length > 0) {
       setTimeout(() => {
         // Find annotations which haven't yet been anchored in the document.
         const anns = getState().annotations.annotations;
-        const annsStillAnchoring = anchoringIDs
+        const annsStillAnchoring = anchoringIds
           .map(id => (id ? findByID(anns, id) : null))
           .filter(ann => ann && metadata.isWaitingToAnchor(ann));
 
         // Mark anchoring as timed-out for these annotations.
         const anchorStatusUpdates = annsStillAnchoring.reduce(
           (updates, ann) => {
-            updates[/** @type {Annotation} */ (ann).$tag] = 'timeout';
+            updates[ann!.$tag] = 'timeout';
             return updates;
           },
-          /** @type {Record<string, 'timeout'>} */ ({})
+          {} as AnchorStatusUpdates
         );
         dispatch(updateAnchorStatus(anchorStatusUpdates));
       }, ANCHORING_TIMEOUT);
@@ -377,10 +369,8 @@ function clearAnnotations() {
 /**
  * Replace the current set of hovered annotations with the annotations
  * identified by `tags`.
- *
- * @param {string[]} tags
  */
-function hoverAnnotations(tags) {
+function hoverAnnotations(tags: string[]) {
   return makeAction(reducers, 'HOVER_ANNOTATIONS', { tags });
 }
 
@@ -389,10 +379,8 @@ function hoverAnnotations(tags) {
  *
  * This updates an annotation to reflect the fact that it has been hidden from
  * non-moderators.
- *
- * @param {string} id
  */
-function hideAnnotation(id) {
+function hideAnnotation(id: string) {
   return makeAction(reducers, 'HIDE_ANNOTATION', { id });
 }
 
@@ -403,10 +391,8 @@ function hideAnnotation(id) {
  * linked to for example. Replaces the current map of highlighted annotations.
  * All provided annotations (`ids`) will be set to `true` in the `highlighted`
  * map.
- *
- * @param {string[]} ids - annotations to highlight
  */
-function highlightAnnotations(ids) {
+function highlightAnnotations(ids: string[]) {
   return makeAction(reducers, 'HIGHLIGHT_ANNOTATIONS', {
     highlighted: toTrueMap(ids),
   });
@@ -415,16 +401,11 @@ function highlightAnnotations(ids) {
 /**
  * Remove annotations from the currently displayed set.
  *
- * @param {AnnotationStub[]} annotations -
- *   Annotations to remove. These may be complete annotations or stubs which
- *   only contain an `id` property.
+ * @param annotations - Annotations to remove. These may be complete annotations
+ *   or stubs which only contain an `id` property.
  */
-export function removeAnnotations(annotations) {
-  /**
-   * @param {import('redux').Dispatch} dispatch
-   * @param {() => { annotations: State }} getState
-   */
-  return (dispatch, getState) => {
+export function removeAnnotations(annotations: AnnotationStub[]) {
+  return (dispatch: Dispatch, getState: () => { annotations: State }) => {
     const remainingAnnotations = excludeAnnotations(
       getState().annotations.annotations,
       annotations
@@ -443,31 +424,22 @@ export function removeAnnotations(annotations) {
  *
  * This updates an annotation to reflect the fact that it has been made visible
  * to non-moderators.
- *
- * @param {string} id
  */
-function unhideAnnotation(id) {
+function unhideAnnotation(id: string) {
   return makeAction(reducers, 'UNHIDE_ANNOTATION', { id });
 }
 
 /**
  * Update the anchoring status of an annotation
- *
- * @param {Record<string, AnchorStatus>} statusUpdates - Map of annotation tag to orphan status
  */
-function updateAnchorStatus(statusUpdates) {
+function updateAnchorStatus(statusUpdates: AnchorStatusUpdates) {
   return makeAction(reducers, 'UPDATE_ANCHOR_STATUS', { statusUpdates });
 }
 
 /**
  * Updating the flagged status of an annotation.
- *
- * @param {string} id - Annotation ID
- * @param {boolean} isFlagged - The flagged status of the annotation. True if
- *        the user has flagged the annotation.
- *
  */
-function updateFlagStatus(id, isFlagged) {
+function updateFlagStatus(id: string, isFlagged: boolean) {
   return makeAction(reducers, 'UPDATE_FLAG_STATUS', { id, isFlagged });
 }
 
@@ -477,37 +449,22 @@ function updateFlagStatus(id, isFlagged) {
  * Count the number of annotations (as opposed to notes or orphans)
  */
 const annotationCount = createSelector(
-  /** @param {State} state */
-  state => state.annotations,
+  (state: State) => state.annotations,
   annotations => countIf(annotations, metadata.isAnnotation)
 );
 
-/**
- * Retrieve all annotations currently in the store
- *
- * @param {State} state
- */
-function allAnnotations(state) {
+function allAnnotations(state: State) {
   return state.annotations;
 }
 
 /**
  * Does the annotation indicated by `id` exist in the collection?
- *
- * @param {State} state
- * @param {string} id
  */
-function annotationExists(state, id) {
+function annotationExists(state: State, id: string) {
   return state.annotations.some(annot => annot.id === id);
 }
 
-/**
- * Return the annotation with the given ID
- *
- * @param {State} state
- * @param {string} id
- */
-function findAnnotationByID(state, id) {
+function findAnnotationByID(state: State, id: string) {
   return findByID(state.annotations, id);
 }
 
@@ -516,13 +473,10 @@ function findAnnotationByID(state, id) {
  *
  * If an annotation does not have an ID because it has not been created on
  * the server, there will be no entry for it in the returned array.
- *
- * @param {State} state
- * @param {string[]} tags - Local tags of annotations to look up
  */
-function findIDsForTags(state, tags) {
+function findIDsForTags(state: State, tags: string[]) {
   const ids = [];
-  for (let tag of tags) {
+  for (const tag of tags) {
     const annot = findByTag(state.annotations, tag);
     if (annot && annot.id) {
       ids.push(annot.id);
@@ -535,8 +489,7 @@ function findIDsForTags(state, tags) {
  * Retrieve currently-hovered annotation identifiers
  */
 const hoveredAnnotations = createSelector(
-  /** @param {State} state */
-  state => state.hovered,
+  (state: State) => state.hovered,
   hovered => trueKeys(hovered)
 );
 
@@ -544,18 +497,14 @@ const hoveredAnnotations = createSelector(
  * Retrieve currently-highlighted annotation identifiers
  */
 const highlightedAnnotations = createSelector(
-  /** @param {State} state */
-  state => state.highlighted,
+  (state: State) => state.highlighted,
   highlighted => trueKeys(highlighted)
 );
 
 /**
  * Is the annotation identified by `$tag` currently hovered?
- *
- * @param {State} state
- * @param {string} $tag
  */
-function isAnnotationHovered(state, $tag) {
+function isAnnotationHovered(state: State, $tag: string) {
   return state.hovered[$tag] === true;
 }
 
@@ -563,8 +512,7 @@ function isAnnotationHovered(state, $tag) {
  * Are there any annotations still waiting to anchor?
  */
 const isWaitingToAnchorAnnotations = createSelector(
-  /** @param {State} state */
-  state => state.annotations,
+  (state: State) => state.annotations,
   annotations => annotations.some(metadata.isWaitingToAnchor)
 );
 
@@ -573,8 +521,7 @@ const isWaitingToAnchorAnnotations = createSelector(
  * to the server
  */
 const newAnnotations = createSelector(
-  /** @param {State} state */
-  state => state.annotations,
+  (state: State) => state.annotations,
   annotations =>
     annotations.filter(ann => metadata.isNew(ann) && !metadata.isHighlight(ann))
 );
@@ -584,8 +531,7 @@ const newAnnotations = createSelector(
  * to the server
  */
 const newHighlights = createSelector(
-  /** @param {State} state */
-  state => state.annotations,
+  (state: State) => state.annotations,
   annotations =>
     annotations.filter(ann => metadata.isNew(ann) && metadata.isHighlight(ann))
 );
@@ -594,8 +540,7 @@ const newHighlights = createSelector(
  * Count the number of page notes currently in the collection
  */
 const noteCount = createSelector(
-  /** @param {State} state */
-  state => state.annotations,
+  (state: State) => state.annotations,
   annotations => countIf(annotations, metadata.isPageNote)
 );
 
@@ -603,21 +548,15 @@ const noteCount = createSelector(
  * Count the number of orphans currently in the collection
  */
 const orphanCount = createSelector(
-  /** @param {State} state */
-  state => state.annotations,
+  (state: State) => state.annotations,
   annotations => countIf(annotations, metadata.isOrphan)
 );
 
 /**
  * Return all loaded annotations which have been saved to the server
- *
- * @param {State} state
- * @return {SavedAnnotation[]}
  */
-function savedAnnotations(state) {
-  return /** @type {SavedAnnotation[]} */ (
-    state.annotations.filter(ann => isSaved(ann))
-  );
+function savedAnnotations(state: State): SavedAnnotation[] {
+  return state.annotations.filter(ann => isSaved(ann)) as SavedAnnotation[];
 }
 
 export const annotationsModule = createStoreModule(initialState, {


### PR DESCRIPTION
I thought: _I want to do a little cleanup with some UI state details related to annotations, so I'll just convert the annotations store module first_.

Eh, it wasn't _that_ huge of a task, but it is the first store module we've transitioned to TS, and it's chunky.

There are various ways that we can type these store modules; I made a few swags here but am not attached to any particular approach...