### PR TITLE
Rename internal mouse event-handling function to avoid confusion

### DIFF
--- a/src/sidebar/components/ThreadCard.tsx
+++ b/src/sidebar/components/ThreadCard.tsx
@@ -36,7 +36,7 @@ function ThreadCard({ frameSync, thread }: ThreadCardProps) {
   const store = useSidebarStore();
   const threadTag = thread.annotation?.$tag ?? null;
   const isHovered = !!(threadTag && store.isAnnotationHovered(threadTag));
-  const focusThreadAnnotation = useMemo(
+  const setThreadHovered = useMemo(
     () =>
       debounce((ann: Annotation | null) => frameSync.hoverAnnotation(ann), 10),
     [frameSync]
@@ -89,8 +89,8 @@ function ThreadCard({ frameSync, thread }: ThreadCardProps) {
           scrollToAnnotation(thread.annotation);
         }
       }}
-      onMouseEnter={() => focusThreadAnnotation(thread.annotation ?? null)}
-      onMouseLeave={() => focusThreadAnnotation(null)}
+      onMouseEnter={() => setThreadHovered(thread.annotation ?? null)}
+      onMouseLeave={() => setThreadHovered(null)}
       key={thread.id}
     >
       <CardContent>{threadContent}</CardContent>


### PR DESCRIPTION
This teeny-tiny PR attempts to fix a small confusion with respect to focusing vs. hovering an annotation.

As "focusing" and "hovering" an annotation are two separate things, rename an internal handler function that makes a thread appear hovered.