### PR TITLE
Bump `@hypothesis/frontend-shared` to v5.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "1.2.0",
-    "@hypothesis/frontend-shared": "5.5.1",
+    "@hypothesis/frontend-shared": "5.6.0",
     "@npmcli/arborist": "^6.1.1",
     "@octokit/rest": "^19.0.3",
     "@rollup/plugin-babel": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1146,10 +1146,10 @@
     fancy-log "^1.3.3"
     glob "^7.2.0"
 
-"@hypothesis/frontend-shared@5.5.1":
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.5.1.tgz#847c951bb0d68b2bcd06592280715303bee4ccfc"
-  integrity sha512-Y4sGp92FXIJixYJdcxN4rO6u0V7N2AAsxXqx2aMQYfkTK7TU4YFiYhYpzd61430pUiKFY0UU2bL3EDKBkkaiKg==
+"@hypothesis/frontend-shared@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.6.0.tgz#b0158ebefe06699918e4c9af807f09100f193670"
+  integrity sha512-tjtyVSoTwFalYc4R9vFob1zWdvZpH9rfOC2fiMO0SlTEL9D0pgP9XdGc57dS8RsxWAtNaaDw/C0PB8i2keEWiQ==
   dependencies:
     highlight.js "^11.6.0"
 


### PR DESCRIPTION
Hand-bumping the `frontend-shared` package to get access to updated `Panel` layout[^1]. `5.6.0` does not introduce any other changes visible to the consumer.

[^1]: None of the `client` components use the new `Panel` (yet), so no user-visible changes here