### PR TITLE
Update `SidebarPanel` to use updated shared `Panel` component

### DIFF
--- a/src/sidebar/components/LoginPromptPanel.tsx
+++ b/src/sidebar/components/LoginPromptPanel.tsx
@@ -1,4 +1,8 @@
-import { Button, CardActions } from '@hypothesis/frontend-shared/lib/next';
+import {
+  Button,
+  CardActions,
+  RestrictedIcon,
+} from '@hypothesis/frontend-shared/lib/next';
 
 import { useSidebarStore } from '../store';
 
@@ -23,7 +27,7 @@ export default function LoginPromptPanel({
   }
   return (
     <SidebarPanel
-      icon="restricted"
+      icon={RestrictedIcon}
       title="Login needed"
       panelName="loginPrompt"
     >

--- a/src/sidebar/components/SidebarPanel.tsx
+++ b/src/sidebar/components/SidebarPanel.tsx
@@ -1,4 +1,5 @@
-import { Panel } from '@hypothesis/frontend-shared';
+import { Panel } from '@hypothesis/frontend-shared/lib/next';
+import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useRef } from 'preact/hooks';
 import scrollIntoView from 'scroll-into-view';
@@ -11,7 +12,7 @@ import Slider from './Slider';
 export type SidebarPanelProps = {
   children: ComponentChildren;
   /** An optional icon name for display next to the panel's title */
-  icon?: string;
+  icon?: IconComponent;
   /**
    * A string identifying this panel. Only one `panelName` may be active at any
    * time. Multiple panels with the same `panelName` would be "in sync", opening
@@ -29,7 +30,7 @@ export type SidebarPanelProps = {
  */
 export default function SidebarPanel({
   children,
-  icon = '',
+  icon,
   panelName,
   title,
   onActiveChanged,

--- a/src/sidebar/components/SidebarPanel.tsx
+++ b/src/sidebar/components/SidebarPanel.tsx
@@ -1,32 +1,31 @@
 import { Panel } from '@hypothesis/frontend-shared';
+import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useRef } from 'preact/hooks';
 import scrollIntoView from 'scroll-into-view';
 
+import type { PanelName } from '../../types/sidebar';
 import { useSidebarStore } from '../store';
 
 import Slider from './Slider';
 
-/**
- * @typedef {import("../../types/sidebar").PanelName} PanelName
- */
-
-/**
- * @typedef SidebarPanelProps
- * @prop {import("preact").ComponentChildren} children
- * @prop {string} [icon] - An optional icon name for display next to the panel's title
- * @prop {PanelName} panelName -
- *   A string identifying this panel. Only one `panelName` may be active at any time.
- *   Multiple panels with the same `panelName` would be "in sync", opening and closing together.
- * @prop {string} title - The panel's title
- * @prop {(active: boolean) => void} [onActiveChanged] -
- *   Optional callback to invoke when this panel's active status changes
- */
+export type SidebarPanelProps = {
+  children: ComponentChildren;
+  /** An optional icon name for display next to the panel's title */
+  icon?: string;
+  /**
+   * A string identifying this panel. Only one `panelName` may be active at any
+   * time. Multiple panels with the same `panelName` would be "in sync", opening
+   * and closing together.
+   */
+  panelName: PanelName;
+  title: string;
+  /** Optional callback to invoke when this panel's active status changes */
+  onActiveChanged?: (active: boolean) => void;
+};
 
 /**
  * Base component for a sidebar panel. Only one sidebar panel
  * (as defined by the panel's `panelName`) is active (visible) at one time.
- *
- * @param {SidebarPanelProps} props
  */
 export default function SidebarPanel({
   children,
@@ -34,11 +33,11 @@ export default function SidebarPanel({
   panelName,
   title,
   onActiveChanged,
-}) {
+}: SidebarPanelProps) {
   const store = useSidebarStore();
   const panelIsActive = store.isSidebarPanelOpen(panelName);
 
-  const panelElement = useRef(/** @type {HTMLDivElement|null}*/ (null));
+  const panelElement = useRef<HTMLDivElement | null>(null);
   const panelWasActive = useRef(panelIsActive);
 
   // Scroll the panel into view if it has just been opened


### PR DESCRIPTION
This PR updates `SidebarPanel` to use the updated `Panel` component (and convert to TS).

This _does_ have (intentional) user-facing changes:

* The padding of `Panel` is now consistent with (the default padding for) `Card` (not surprising since the new `Panel` uses `Card` behind the scenes). This means that updated panels now have the same padding as annotation cards, which is a good thing.
* The heading text is slightly larger, 16px instead of 14.3px (?! yeah). This gives us more sizing contrast with base text, and is consistent with other "heading"-type design patterns.

Before:

<img width="422" alt="image" src="https://user-images.githubusercontent.com/439947/212343710-e69f540d-d5b4-462a-89e7-a8f3b6815bef.png">

<img width="420" alt="image" src="https://user-images.githubusercontent.com/439947/212343649-0472c476-0b16-4e54-b61a-378e5a087732.png">

<img width="422" alt="image" src="https://user-images.githubusercontent.com/439947/212343610-4f17f5b3-a87c-424b-abe2-063c29c98b8d.png">

After:

<img width="425" alt="image" src="https://user-images.githubusercontent.com/439947/212341836-daceb3e4-a5a1-4585-8121-91e33f620661.png">

<img width="424" alt="image" src="https://user-images.githubusercontent.com/439947/212341792-372df7f7-b330-4cca-8534-a19a77a921a3.png">

<img width="421" alt="image" src="https://user-images.githubusercontent.com/439947/212341897-153b1b26-4ad7-40ee-9607-628c7ea19628.png">

Part of #4860 