### PR TITLE
Update shared components in `ShareAnnotationsPanel`; convert to TS

### DIFF
--- a/src/sidebar/components/ShareAnnotationsPanel.tsx
+++ b/src/sidebar/components/ShareAnnotationsPanel.tsx
@@ -1,10 +1,11 @@
 import {
+  CopyIcon,
   IconButton,
+  Input,
+  InputGroup,
+  LockIcon,
   Spinner,
-  Icon,
-  TextInput,
-  TextInputWithButton,
-} from '@hypothesis/frontend-shared';
+} from '@hypothesis/frontend-shared/lib/next';
 
 import { useSidebarStore } from '../store';
 import { pageSharingLink } from '../helpers/annotation-sharing';
@@ -57,7 +58,7 @@ function ShareAnnotationsPanel({ toastMessenger }: ShareAnnotationPanelProps) {
     <SidebarPanel title={panelTitle} panelName="shareGroupAnnotations">
       {!sharingReady && (
         <div className="flex flex-row items-center justify-center">
-          <Spinner />
+          <Spinner size="md" />
         </div>
       )}
       {sharingReady && (
@@ -78,20 +79,20 @@ function ShareAnnotationsPanel({ toastMessenger }: ShareAnnotationPanelProps) {
                 )}
               </div>
               <div>
-                <TextInputWithButton>
-                  <TextInput
+                <InputGroup>
+                  <Input
                     aria-label="Use this URL to share these annotations"
                     type="text"
                     value={shareURI}
                     readOnly
                   />
                   <IconButton
-                    icon="copy"
+                    icon={CopyIcon}
                     onClick={copyShareLink}
                     title="Copy share link"
                     variant="dark"
                   />
-                </TextInputWithButton>
+                </InputGroup>
               </div>
               <p data-testid="sharing-details">
                 {notNull(focusedGroup).type === 'private' ? (
@@ -108,8 +109,8 @@ function ShareAnnotationsPanel({ toastMessenger }: ShareAnnotationPanelProps) {
                 )}{' '}
                 <span>
                   Private (
-                  <Icon name="lock" classes="inline -mt-0.5" /> <em>Only Me</em>
-                  ) annotations are only visible to you.
+                  <LockIcon className="inline w-em h-em ml-0.5 -mt-0.5" />{' '}
+                  <em>Only Me</em>) annotations are only visible to you.
                 </span>
               </p>
               <div className="text-[24px]">

--- a/src/sidebar/components/ShareAnnotationsPanel.tsx
+++ b/src/sidebar/components/ShareAnnotationsPanel.tsx
@@ -10,15 +10,16 @@ import { useSidebarStore } from '../store';
 import { pageSharingLink } from '../helpers/annotation-sharing';
 import { copyText } from '../util/copy-to-clipboard';
 import { withServices } from '../service-context';
+import type { ToastMessengerService } from '../services/toast-messenger';
 import { notNull } from '../util/typing';
 
 import ShareLinks from './ShareLinks';
 import SidebarPanel from './SidebarPanel';
 
-/**
- * @typedef ShareAnnotationsPanelProps
- * @prop {import('../services/toast-messenger').ToastMessengerService} toastMessenger
- */
+export type ShareAnnotationPanelProps = {
+  // injected
+  toastMessenger: ToastMessengerService;
+};
 
 /**
  * A panel for sharing the current group's annotations on the current document.
@@ -26,10 +27,8 @@ import SidebarPanel from './SidebarPanel';
  * Links within this component allow a user to share the set of annotations that
  * are on the current page (as defined by the main frame's URI) and contained
  * within the app's currently-focused group.
- *
- * @param {ShareAnnotationsPanelProps} props
  */
-function ShareAnnotationsPanel({ toastMessenger }) {
+function ShareAnnotationsPanel({ toastMessenger }: ShareAnnotationPanelProps) {
   const store = useSidebarStore();
   const mainFrame = store.mainFrame();
   const focusedGroup = store.focusedGroup();
@@ -41,13 +40,14 @@ function ShareAnnotationsPanel({ toastMessenger }) {
   const sharingReady = focusedGroup && mainFrame;
 
   const shareURI =
-    sharingReady &&
-    pageSharingLink(notNull(mainFrame).uri, notNull(focusedGroup).id);
+    sharingReady && pageSharingLink(mainFrame.uri, focusedGroup.id);
 
   const copyShareLink = () => {
     try {
-      copyText(/** @type {string} */ (shareURI));
-      toastMessenger.success('Copied share link to clipboard');
+      if (shareURI) {
+        copyText(shareURI);
+        toastMessenger.success('Copied share link to clipboard');
+      }
     } catch (err) {
       toastMessenger.error('Unable to copy link');
     }


### PR DESCRIPTION
Yep, another one. Part of #4860

Subtle user-facing changes:

* Horizonal padding on copy icon button is slightly increased
* Text color on input is lighter to match other `Input`s in the interface

Just the input area, before:

<img width="390" alt="image" src="https://user-images.githubusercontent.com/439947/212371201-0d0fd585-492a-4d42-ada2-f9f1018a1f61.png">


After:

<img width="392" alt="image" src="https://user-images.githubusercontent.com/439947/212370471-d252a6eb-0692-4c1c-9973-18e507a23542.png">


I noticed while working in here that the input doesn't gain focus when the panel is opened (cf. `AnnotationShareControl`, which does). We should make that happen.
