### PR TITLE
Update `MenuItem` and refactor `icon` handling

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationPublishControl.tsx
+++ b/src/sidebar/components/Annotation/AnnotationPublishControl.tsx
@@ -1,6 +1,9 @@
 import {
   Button,
   CancelIcon,
+  GlobeIcon,
+  GroupsIcon,
+  LockIcon,
   MenuExpandIcon,
 } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
@@ -114,13 +117,13 @@ function AnnotationPublishControl({
             align="left"
           >
             <MenuItem
-              icon={group.type === 'open' ? 'public' : 'groups'}
+              icon={group.type === 'open' ? GlobeIcon : GroupsIcon}
               label={group.name}
               isSelected={!isPrivate}
               onClick={() => onSetPrivate(false)}
             />
             <MenuItem
-              icon="lock"
+              icon={LockIcon}
               label="Only Me"
               isSelected={isPrivate}
               onClick={() => onSetPrivate(true)}

--- a/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
@@ -1,3 +1,8 @@
+import {
+  GlobeIcon,
+  GroupsIcon,
+  LockIcon,
+} from '@hypothesis/frontend-shared/lib/next';
 import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
@@ -140,7 +145,7 @@ describe('AnnotationPublishControl', () => {
           const wrapper = createAnnotationPublishControl();
           const shareMenuItem = wrapper.find('MenuItem').first();
 
-          assert.equal(shareMenuItem.prop('icon'), 'groups');
+          assert.equal(shareMenuItem.props().icon, GroupsIcon);
         });
       });
 
@@ -153,7 +158,7 @@ describe('AnnotationPublishControl', () => {
           const wrapper = createAnnotationPublishControl();
           const shareMenuItem = wrapper.find('MenuItem').first();
 
-          assert.equal(shareMenuItem.prop('icon'), 'public');
+          assert.equal(shareMenuItem.props().icon, GlobeIcon);
         });
       });
     });
@@ -173,7 +178,7 @@ describe('AnnotationPublishControl', () => {
         const wrapper = createAnnotationPublishControl();
         const privateMenuItem = wrapper.find('MenuItem').at(1);
 
-        assert.equal(privateMenuItem.prop('icon'), 'lock');
+        assert.equal(privateMenuItem.prop('icon'), LockIcon);
       });
 
       it('should have an "Only me" label', () => {

--- a/src/sidebar/components/GroupList/GroupList.js
+++ b/src/sidebar/components/GroupList/GroupList.js
@@ -1,4 +1,5 @@
 import classnames from 'classnames';
+import { PlusIcon } from '@hypothesis/frontend-shared/lib/next';
 import { useMemo, useState } from 'preact/hooks';
 
 import { serviceConfig } from '../../config/service-config';
@@ -158,7 +159,11 @@ function GroupList({ settings }) {
       )}
 
       {canCreateNewGroup && (
-        <MenuItem icon="add" href={newGroupLink} label="New private group" />
+        <MenuItem
+          icon={PlusIcon}
+          href={newGroupLink}
+          label="New private group"
+        />
       )}
     </Menu>
   );

--- a/src/sidebar/components/GroupList/GroupListItem.js
+++ b/src/sidebar/components/GroupList/GroupListItem.js
@@ -1,4 +1,9 @@
 import classnames from 'classnames';
+import {
+  CopyIcon,
+  ExternalIcon,
+  LeaveIcon,
+} from '@hypothesis/frontend-shared/lib/next';
 
 import { orgName } from '../../helpers/group-list-item-common';
 import { withServices } from '../../service-context';
@@ -95,15 +100,20 @@ function GroupListItem({
   const copyLinkLabel =
     group.type === 'private' ? 'Copy invite link' : 'Copy activity link';
 
+  const leftChannelContent = group.logo ? (
+    <img className="w-4 h-4" alt={orgName(group)} src={group.logo} />
+  ) : (
+    <span className="sr-only">{orgName(group)}</span>
+  );
+
   return (
     <MenuItem
-      icon={group.logo || 'blank'}
-      iconAlt={orgName(group)}
       isDisabled={!isSelectable}
       isExpanded={hasActionMenu ? isExpanded : false}
       isSelected={isSelected}
       isSubmenuVisible={hasActionMenu ? isExpanded : undefined}
       label={group.name}
+      leftChannelContent={leftChannelContent}
       onClick={isSelectable ? focusGroup : toggleSubmenu}
       onToggleSubmenu={toggleSubmenu}
       submenu={
@@ -113,7 +123,7 @@ function GroupListItem({
               <li>
                 <MenuItem
                   href={activityUrl}
-                  icon="external"
+                  icon={ExternalIcon}
                   isSubmenuItem={true}
                   label="View group activity"
                 />
@@ -123,7 +133,7 @@ function GroupListItem({
               <li>
                 <MenuItem
                   onClick={() => copyLink(activityUrl)}
-                  icon="copy"
+                  icon={CopyIcon}
                   isSubmenuItem={true}
                   label={copyLinkLabel}
                 />
@@ -132,7 +142,7 @@ function GroupListItem({
             {group.canLeave && (
               <li>
                 <MenuItem
-                  icon="leave"
+                  icon={LeaveIcon}
                   isSubmenuItem={true}
                   label="Leave group"
                   onClick={leaveGroup}

--- a/src/sidebar/components/GroupList/test/GroupListItem-test.js
+++ b/src/sidebar/components/GroupList/test/GroupListItem-test.js
@@ -127,9 +127,9 @@ describe('GroupListItem', () => {
       .returns(group.organization.name);
 
     const wrapper = createGroupListItem(group);
-    const altText = wrapper.find('MenuItem').prop('iconAlt');
+    const leftContent = wrapper.find('MenuItem').prop('leftChannelContent');
 
-    assert.equal(altText, group.organization.name);
+    assert.equal(leftContent.props.alt, group.organization.name);
   });
 
   describe('selected state', () => {

--- a/src/sidebar/components/MenuItem.tsx
+++ b/src/sidebar/components/MenuItem.tsx
@@ -1,24 +1,27 @@
 import classnames from 'classnames';
 import { Icon } from '@hypothesis/frontend-shared';
+import {
+  MenuExpandIcon,
+  MenuCollapseIcon,
+} from '@hypothesis/frontend-shared/lib/next';
+import type { ComponentChildren, Ref } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 
 import MenuKeyboardNavigation from './MenuKeyboardNavigation';
 import Slider from './Slider';
 
-/**
- * @typedef {import('../icons').sidebarIcons} SidebarIcons
- */
+type SubmenuToggleProps = {
+  title: string;
+  isExpanded: boolean;
+  onToggleSubmenu?: (e: Event) => void;
+};
 
-/**
- * Render a clickable div that will toggle the expanded state of the
- * associated submenu via `onToggleSubmenu`.
- *
- * @param {object} props
- *   @param {string} props.title
- *   @param {boolean} props.isExpanded
- *   @param {(e: Event) => void} [props.onToggleSubmenu]
- */
-function SubmenuToggle({ title, isExpanded, onToggleSubmenu }) {
+function SubmenuToggle({
+  title,
+  isExpanded,
+  onToggleSubmenu,
+}: SubmenuToggleProps) {
+  const Icon = isExpanded ? MenuCollapseIcon : MenuExpandIcon;
   return (
     <div
       data-testid="submenu-toggle"
@@ -52,48 +55,70 @@ function SubmenuToggle({ title, isExpanded, onToggleSubmenu }) {
     >
       <Icon
         name={isExpanded ? 'collapse-menu' : 'expand-menu'}
-        classes="w-3 h-3"
+        className="w-3 h-3"
       />
     </div>
   );
 }
 
-/**
- * @typedef MenuItemProps
- * @prop {string} [href] -
- *   URL of the external link to open when this item is clicked. Either the `href` or an
- *   `onClick` callback should be supplied.
- * @prop {string} [iconAlt] - Alt text for icon.
- * @prop {string} [icon] -
- *   Name or URL of icon to display. If the value is a URL it is displayed using an `<img>`;
- *   if it is a non-URL string it is assumed to be the `name` of a registered icon.
- *   If the property is `"blank"` a blank placeholder is displayed in place of an icon.
- *   The placeholder is useful to keep menu item labels aligned.
- * @prop {boolean} [isDisabled] -
- *   Dim the label to indicate that this item is not currently available.  The `onClick`
- *   callback will still be invoked when this item is clicked and the submenu, if any,
- *   can still be toggled.
- * @prop {boolean} [isExpanded] -
- *   Indicates that the submenu associated with this item is currently open.
- * @prop {boolean} [isSelected] -
- *   Display an indicator to show that this menu item represents something which is currently
- *   selected/active/focused.
- * @prop {boolean} [isSubmenuItem] -
- *   True if this item is part of a submenu, in which case it is rendered with a different
- *   style (shaded background)
- * @prop {boolean|undefined} [isSubmenuVisible] -
- *   If present, display a button to toggle the sub-menu associated with this item and
- *   indicate the current state; `true` if the submenu is visible. Note. Omit this prop,
- *    or set it to null, if there is no `submenu`.
- * @prop {string} label - Label of the menu item.
- * @prop {(e: Event) => void} [onClick] - Callback to invoke when the menu item is clicked.
- * @prop {(e: Event) => void} [onToggleSubmenu] -
- *   Callback when the user clicks on the toggle to change the expanded state of the menu.
- * @prop {object} [submenu] -
- *   Contents of the submenu for this item.  This is typically a list of `MenuItem` components
- *    with the `isSubmenuItem` prop set to `true`, but can include other content as well.
- *    The submenu is only rendered if `isSubmenuVisible` is `true`.
- */
+export type MenuItemProps = {
+  /**
+   * URL of the external link to open when this item is clicked. Either the
+   * `href` or an `onClick` callback should be supplied.
+   */
+  href?: string;
+  /** Alt text for icon */
+  iconAlt?: string;
+
+  /**
+   * Name or URL of icon to display. If the value is a URL it is displayed using
+   * an `<img>`; if it is a non-URL string it is assumed to be the `name` of a
+   * registered icon. If the property is `"blank"` a blank placeholder is
+   * displayed in place of an icon. The placeholder is useful to keep menu item
+   * labels aligned.
+   */
+  icon?: string;
+
+  /**
+   * Dim the label to indicate that this item is not currently available.  The
+   * `onClick` callback will still be invoked when this item is clicked and the
+   * submenu, if any, can still be toggled.
+   */
+  isDisabled?: boolean;
+
+  /** Indicates that the submenu associated with this item is currently open */
+  isExpanded?: boolean;
+
+  /**
+   * Display an indicator to show that this menu item represents something which
+   * is currently selected/active/focused.
+   */
+  isSelected?: boolean;
+
+  /**
+   * True if this item is part of a submenu, in which case it is rendered with a
+   * different style (shaded background)
+   */
+  isSubmenuItem?: boolean;
+
+  /**
+   * If present, display a button to toggle the sub-menu associated with this
+   * item and indicate the current state; `true` if the submenu is visible.
+   * Note. Omit this prop, or set it to null, if there is no `submenu`.
+   */
+  isSubmenuVisible?: boolean;
+
+  label: string;
+  onClick?: (e: Event) => void;
+  onToggleSubmenu?: (e: Event) => void;
+  /**
+   * Contents of the submenu for this item.  This is typically a list of
+   * `MenuItem` components with the `isSubmenuItem` prop set to `true`, but can
+   * include other content as well. The submenu is only rendered if
+   * `isSubmenuVisible` is `true`.
+   */
+  submenu?: ComponentChildren;
+};
 
 /**
  * An item in a dropdown menu.
@@ -105,13 +130,11 @@ function SubmenuToggle({ title, isExpanded, onToggleSubmenu }) {
  * is provided, or perform a custom action via the `onClick` callback.
  *
  * The icon can either be an external SVG image, referenced by URL, or the
- * name of an icon registered in the application. @see {SidebarIcons}
+ * name of an icon registered in the application.
  *
  * For items that have submenus, the `MenuItem` will call the `renderSubmenu`
  * prop to render the content of the submenu, when the submenu is visible.
  * Note that the `submenu` is not supported for link (`href`) items.
- *
- * @param {MenuItemProps} props
  */
 export default function MenuItem({
   href,
@@ -126,14 +149,12 @@ export default function MenuItem({
   onClick,
   onToggleSubmenu,
   submenu,
-}) {
+}: MenuItemProps) {
   const iconIsUrl = icon && icon.indexOf('/') !== -1;
 
-  const menuItemRef =
-    /** @type {{ current: HTMLAnchorElement & HTMLDivElement }} */ (useRef());
+  const menuItemRef = useRef<HTMLAnchorElement | HTMLDivElement | null>(null);
 
-  /** @type {number|undefined} */
-  let focusTimer;
+  let focusTimer: number | undefined;
 
   // menuItem can be either a link or a button
   let menuItem;
@@ -148,19 +169,17 @@ export default function MenuItem({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  /** @param {Event} event */
-  const onCloseSubmenu = event => {
+  const onCloseSubmenu = (event: Event) => {
     if (onToggleSubmenu) {
       onToggleSubmenu(event);
     }
     // The focus won't work without delaying rendering.
     focusTimer = setTimeout(() => {
-      menuItemRef.current.focus();
+      menuItemRef.current!.focus();
     });
   };
 
-  /** @param {KeyboardEvent} event */
-  const onKeyDown = event => {
+  const onKeyDown = (event: KeyboardEvent) => {
     switch (event.key) {
       case 'ArrowRight':
         if (onToggleSubmenu) {
@@ -264,7 +283,7 @@ export default function MenuItem({
     // The menu item is a link
     menuItem = (
       <a
-        ref={menuItemRef}
+        ref={menuItemRef as Ref<HTMLAnchorElement>}
         className={wrapperClasses}
         data-testid="menu-item"
         href={href}
@@ -282,7 +301,7 @@ export default function MenuItem({
     // In either case there may be an optional submenu.
     menuItem = (
       <div
-        ref={menuItemRef}
+        ref={menuItemRef as Ref<HTMLDivElement>}
         className={wrapperClasses}
         data-testid="menu-item"
         tabIndex={-1}
@@ -301,10 +320,10 @@ export default function MenuItem({
     <>
       {menuItem}
       {hasSubmenuVisible && (
-        <Slider visible={/** @type {boolean} */ (isSubmenuVisible)}>
+        <Slider visible={isSubmenuVisible}>
           <MenuKeyboardNavigation
             closeMenu={onCloseSubmenu}
-            visible={/** @type {boolean} */ (isSubmenuVisible)}
+            visible={isSubmenuVisible}
             className="border-b"
           >
             {submenu}

--- a/src/sidebar/components/test/MenuItem-test.js
+++ b/src/sidebar/components/test/MenuItem-test.js
@@ -134,7 +134,7 @@ describe('MenuItem', () => {
       assert.equal(wrapper.find(menuItemSelector).prop('aria-expanded'), true);
 
       wrapper.setProps({ isSubmenuVisible: false });
-      assert.isTrue(wrapper.exists('Icon[name="expand-menu"]'));
+      assert.isTrue(wrapper.exists('MenuExpandIcon'));
       assert.equal(wrapper.find(menuItemSelector).prop('aria-haspopup'), true);
       assert.equal(wrapper.find(menuItemSelector).prop('aria-expanded'), false);
       assert.isNotOk(wrapper.find(menuItemSelector).prop('aria-expanded'));

--- a/src/sidebar/components/test/MenuItem-test.js
+++ b/src/sidebar/components/test/MenuItem-test.js
@@ -1,3 +1,4 @@
+import { EditIcon } from '@hypothesis/frontend-shared/lib/next';
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
@@ -38,13 +39,6 @@ describe('MenuItem', () => {
       assert.equal(link.length, 1);
       assert.equal(link.prop('href'), 'https://example.com');
       assert.equal(link.prop('rel'), 'noopener noreferrer');
-    });
-
-    it('renders an `<img>` icon if an icon URL is provided', () => {
-      const src = 'https://example.com/icon.svg';
-      const wrapper = createMenuItem({ icon: src });
-      const icon = wrapper.find('img');
-      assert.equal(icon.prop('src'), src);
     });
 
     it('invokes `onClick` callback when pressing `Enter` or space', () => {
@@ -93,20 +87,25 @@ describe('MenuItem', () => {
   });
 
   describe('icons for top-level menu items', () => {
-    it('renders an icon if an icon name is provided', () => {
-      const wrapper = createMenuItem({ icon: 'edit' });
-      assert.isTrue(wrapper.exists('Icon[name="edit"]'));
+    it('renders an icon if an icon is provided', () => {
+      const wrapper = createMenuItem({ icon: EditIcon });
+      assert.isTrue(wrapper.exists('EditIcon'));
     });
 
-    it('adds a left container if `icon` is "blank"', () => {
-      const wrapper = createMenuItem({ icon: 'blank' });
-      assert.equal(
-        wrapper.find('[data-testid="left-item-container"]').length,
-        1
+    it('adds a left container if left content is provided', () => {
+      const wrapper = createMenuItem({
+        leftChannelContent: <span>Hi</span>,
+        icon: EditIcon,
+      });
+      const leftChannel = wrapper.find('[data-testid="left-item-container"]');
+      assert.equal(leftChannel.text(), 'Hi');
+      assert.isFalse(
+        wrapper.exists('EditIcon'),
+        'Icon ignored if left channel content provided'
       );
     });
 
-    it('does not add a left container if `icon` is missing', () => {
+    it('does not add a left container if neither icon nor left content provided', () => {
       const wrapper = createMenuItem();
       assert.equal(
         wrapper.find('[data-testid="left-item-container"]').length,
@@ -115,7 +114,7 @@ describe('MenuItem', () => {
     });
 
     it('renders an icon on the left if `icon` provided', () => {
-      const wrapper = createMenuItem({ icon: 'edit' });
+      const wrapper = createMenuItem({ icon: EditIcon });
       const leftItem = wrapper.find('[data-testid="left-item-container"]');
 
       // There should be only one icon space, on the left.
@@ -174,16 +173,12 @@ describe('MenuItem', () => {
 
     it('renders submenu item icons on the right', () => {
       const wrapper = createMenuItem({
-        icon: 'edit',
+        icon: EditIcon,
         isSubmenuItem: true,
         submenu: <div role="menuitem">Submenu content</div>,
       });
       const rightItem = wrapper.find('[data-testid="right-item-container"]');
-
-      assert.equal(rightItem.length, 1);
-
-      // The actual icon for the submenu should be shown on the right.
-      assert.equal(rightItem.at(0).children().length, 1);
+      assert.isTrue(rightItem.find('EditIcon').exists());
     });
 
     it('does not render submenu content if `isSubmenuVisible` is undefined', () => {


### PR DESCRIPTION
This is yet another part of #4860 but this one required a little more work.

This PR updates `MenuItem` to use updated shared components, and updates components that use it to pass `IconComponent`s instead of strings for the `icon` prop.

This required some additional refactoring because, in this case, the `icon` string could be:

* The name of a registered icon
* A URL (in which case an `img` with the URL as `src` was rendered)
* The literal string "blank" (in which case space was rendered to the left of the menu item's label

These changes remove the string-based logic related to icons. The logic was pushed up into the `GroupListItem` component, which was the only component that actually needed the functionality. Now consumers can set a `leftChannelContent` prop to set any content they'd like in the left channel.