### PR TITLE
Update shared components in NotebookView; convert to TS

### DIFF
--- a/src/sidebar/components/NotebookView.tsx
+++ b/src/sidebar/components/NotebookView.tsx
@@ -4,6 +4,8 @@ import scrollIntoView from 'scroll-into-view';
 
 import { ResultSizeError } from '../search-client';
 import { withServices } from '../service-context';
+import type { LoadAnnotationsService } from '../services/load-annotations';
+import type { StreamerService } from '../services/streamer';
 import { useSidebarStore } from '../store';
 
 import NotebookFilters from './NotebookFilters';
@@ -11,18 +13,17 @@ import NotebookResultCount from './NotebookResultCount';
 import PaginatedThreadList from './PaginatedThreadList';
 import { useRootThread } from './hooks/use-root-thread';
 
-/**
- * @typedef NotebookViewProps
- * @prop {import('../services/load-annotations').LoadAnnotationsService} loadAnnotationsService
- * @prop {import('../services/streamer').StreamerService} streamer
- */
-
+export type NotebookViewProps = {
+  // injected
+  loadAnnotationsService: LoadAnnotationsService;
+  streamer: StreamerService;
+};
 /**
  * The main content of the "notebook" route (https://hypothes.is/notebook)
  *
  * @param {NotebookViewProps} props
  */
-function NotebookView({ loadAnnotationsService, streamer }) {
+function NotebookView({ loadAnnotationsService, streamer }: NotebookViewProps) {
   const store = useSidebarStore();
 
   const filters = store.getFilterValues();
@@ -56,8 +57,7 @@ function NotebookView({ loadAnnotationsService, streamer }) {
   // of them: this is a performance safety valve.
   const maxResults = 5000;
 
-  /** @param {Error} error */
-  const onLoadError = error => {
+  const onLoadError = (error: Error) => {
     if (error instanceof ResultSizeError) {
       setHasTooManyAnnotationsError(true);
     }
@@ -102,8 +102,7 @@ function NotebookView({ loadAnnotationsService, streamer }) {
     }
   }, [loadAnnotationsService, groupId, store]);
 
-  /** @param {number} newPage */
-  const onChangePage = newPage => {
+  const onChangePage = (newPage: number) => {
     setPaginationPage(newPage);
   };
 
@@ -113,7 +112,7 @@ function NotebookView({ loadAnnotationsService, streamer }) {
   }, [filters, focusedGroup]);
 
   // Scroll back to here when pagination page changes
-  const threadListScrollTop = useRef(/** @type {HTMLElement|null}*/ (null));
+  const threadListScrollTop = useRef<HTMLElement | null>(null);
   useLayoutEffect(() => {
     // TODO: Transition and effects here should be improved
     if (paginationPage !== lastPaginationPage.current) {

--- a/src/sidebar/components/NotebookView.tsx
+++ b/src/sidebar/components/NotebookView.tsx
@@ -1,4 +1,9 @@
-import { IconButton, Panel } from '@hypothesis/frontend-shared';
+import {
+  IconButton,
+  Link,
+  Panel,
+  RefreshIcon,
+} from '@hypothesis/frontend-shared/lib/next';
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import scrollIntoView from 'scroll-into-view';
 
@@ -140,7 +145,8 @@ function NotebookView({ loadAnnotationsService, streamer }: NotebookViewProps) {
       <div className="flex items-center lg:justify-self-end text-md font-medium">
         {pendingUpdateCount > 0 && !hasAppliedFilter && (
           <IconButton
-            icon="refresh"
+            data-testid="refresh-button"
+            icon={RefreshIcon}
             onClick={() => streamer.applyPendingUpdates()}
             variant="primary"
             title={tooltip}
@@ -157,14 +163,21 @@ function NotebookView({ loadAnnotationsService, streamer }: NotebookViewProps) {
         {hasTooManyAnnotationsError && (
           <div className="py-4" data-testid="notebook-messages">
             <Panel title="Too many results to show">
-              This preview of the Notebook can show{' '}
-              <strong>up to {maxResults} results</strong> at a time (there are{' '}
-              {resultCount} to show here).{' '}
-              <a href="mailto:support@hypothes.is?subject=Hypothesis%20Notebook&body=Please%20notify%20me%20when%20the%20Hypothesis%20Notebook%20is%20updated%20to%20support%20more%20than%205000%20annotations">
-                Contact us
-              </a>{' '}
-              if you would like to be notified when support for more annotations
-              is available.
+              <p>
+                This preview of the Notebook can show{' '}
+                <strong>up to {maxResults} results</strong> at a time (there are{' '}
+                {resultCount} to show here).
+              </p>
+              <p>
+                <Link
+                  href="mailto:support@hypothes.is?subject=Hypothesis%20Notebook&body=Please%20notify%20me%20when%20the%20Hypothesis%20Notebook%20is%20updated%20to%20support%20more%20than%205000%20annotations"
+                  underline="always"
+                >
+                  Contact us
+                </Link>{' '}
+                if you would like to be notified when support for more
+                annotations is available.
+              </p>
             </Panel>
           </div>
         )}

--- a/src/sidebar/components/test/NotebookView-test.js
+++ b/src/sidebar/components/test/NotebookView-test.js
@@ -159,14 +159,14 @@ describe('NotebookView', () => {
       fakeStore.hasAppliedFilter.returns(true);
       const wrapper = createComponent();
 
-      const button = wrapper.find('IconButton[icon="refresh"]');
+      const button = wrapper.find('button[data-testid="refresh-button"]');
       assert.isFalse(button.exists());
     });
 
     it('shows button to synchronize annotations if no filters are applied', () => {
       const wrapper = createComponent();
 
-      const button = wrapper.find('IconButton[icon="refresh"]');
+      const button = wrapper.find('button[data-testid="refresh-button"]');
       assert.isTrue(button.exists());
       assert.include(button.prop('title'), 'Show 3 new or updated annotations');
     });
@@ -174,7 +174,7 @@ describe('NotebookView', () => {
     it('synchronizes pending annotations', () => {
       const wrapper = createComponent();
 
-      const button = wrapper.find('IconButton[icon="refresh"]');
+      const button = wrapper.find('button[data-testid="refresh-button"]');
       assert.isTrue(button.exists());
       button.prop('onClick')();
       assert.called(fakeStreamer.applyPendingUpdates);


### PR DESCRIPTION
Yet another in the march towards completing #4860 

There is a small visual change: an `a` element (link) in the "there are too many annotations to display" sad path messaging has been updated to use a `Link` component, and is now underlined (that is the convention we're moving toward for links, underlining them).