### PR TITLE
WIP: Check for anchoring timeout in service instead of store

### DIFF
--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -212,13 +212,16 @@ export class FrameSyncService {
       prevAnnotations: Annotation[]
     ) => {
       let publicAnns = 0;
+      // `$tag`s of top-level annotations loaded in the sidebar store
       const inSidebar = new Set<string>();
+      // Top-level annotations that have been added and should be communicated
+      // to guest frames
       const added = [] as Annotation[];
 
       // Determine which annotations have been added or deleted in the sidebar.
       annotations.forEach(annot => {
         if (isReply(annot)) {
-          // The frame does not need to know about replies
+          // Guest frames do not need to know about replies
           return;
         }
 


### PR DESCRIPTION
There has been this longstanding FIXME in the `annotations` store module that bugs me. The `addAnnotations` action creator adds annotations to the store state _and_ schedules a check to see if they anchored within a given timeout.

This sketch attempts to extract the "check to see if annotations anchored" logic into the `load-annotations` service.

The assumptions I'm making are:

* We only need to check for anchoring timeouts for annotations when they are going to be shown context with the annotated content (translation: we're in the sidebar).
* We only need to check for anchoring timeouts for annotations that were loaded from the API service. Annotations created by the annotator (i.e. "unsaved annotations") are "guaranteed" to be anchored.

I'd like a sanity check on this general idea before cleaning it up.