### PR TITLE
Explicitly set excludeTrailingPunctuationFromURLs to true in showdown config

### DIFF
--- a/src/sidebar/render-markdown.js
+++ b/src/sidebar/render-markdown.js
@@ -31,6 +31,7 @@ function renderMarkdown(markdown) {
     converter = new showdown.Converter({
       extensions: [targetBlank],
       simplifiedAutoLink: true,
+      excludeTrailingPunctuationFromURLs: true,
       // Since we're using simplifiedAutoLink we also use
       // literalMidWordUnderscores because otherwise _'s in URLs get
       // transformed into <em>'s.

--- a/src/sidebar/test/render-markdown-test.js
+++ b/src/sidebar/test/render-markdown-test.js
@@ -45,6 +45,16 @@ describe('render-markdown', () => {
           'https://hypothes.is/stream?q=tag:group_test_needs_card</a></p>'
       );
     });
+
+    ['.', ',', '!', '?'].forEach(symbol => {
+      it('should autolink URLs excluding trailing punctuation symbols', () => {
+        assert.equal(
+          render(`See this link - http://arxiv.org/article${symbol}`),
+          '<p>See this link - <a href="http://arxiv.org/article" target="_blank">' +
+            `http://arxiv.org/article</a>${symbol}</p>`
+        );
+      });
+    });
   });
 
   describe('markdown rendering', () => {


### PR DESCRIPTION
This PR fixes https://github.com/hypothesis/client/issues/4333, by setting `excludeTrailingPunctuationFromURLs: true` in showdown, so that it ignores punctuation (`.`, `,`, `!`, etc) at the end of links when parsing annotations markdown.

~In theory this should not be required with the showdown version we are using, and in fact, I "verified" it some days ago, but yesterday I noticed we had a regression and this bug was back.~ Ok, setting `excludeTrailingPunctuationFromURLs` is still required. They have deprecated it in their main branch, but there's still no release including this change, so this PR is relevant.

I have checked if we have downgraded the dependency by accident, but doesn't seem to be the case, so I have explicitly enabled this option, which fixes the wrong links generation.