### PR TITLE
Allow different prefixes per selected line when clicking MarkdownButtons

### DIFF
--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -118,7 +118,9 @@ function handleToolbarCommand(
       update(insertMath);
       break;
     case 'numlist':
-      update(state => toggleBlockStyle(state, '1. '));
+      update(state =>
+        toggleBlockStyle(state, lineIndex => `${lineIndex + 1}. `)
+      );
       break;
     case 'list':
       update(state => toggleBlockStyle(state, '* '));

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -101,7 +101,7 @@ describe('MarkdownEditor', () => {
     {
       command: 'Numbered list',
       key: 'o',
-      effect: [fakeMarkdownCommands.toggleBlockStyle, '1. '],
+      effect: [fakeMarkdownCommands.toggleBlockStyle, sinon.match.func],
     },
   ];
   commands.forEach(({ command, key, effect }) => {

--- a/src/sidebar/test/markdown-commands-test.js
+++ b/src/sidebar/test/markdown-commands-test.js
@@ -111,6 +111,17 @@ describe('markdown commands', () => {
         assert.equal(formatState(output), fixture.output);
       });
     });
+
+    it('adds formatting to multi-line blocks', () => {
+      const output = commands.toggleBlockStyle(
+        parseState('one\n<sel>two\nthree\nfour</sel>\nfive'),
+        lineIndex => `::${lineIndex * 2}:: `
+      );
+      assert.equal(
+        formatState(output),
+        'one\n::0:: <sel>two\n::2:: three\n::4:: four</sel>\nfive'
+      );
+    });
   });
 
   describe('link formatting', () => {


### PR DESCRIPTION
This PR fixes #4362, by allowing dynamically built prefixes when formatting multiples lines of markdown at once.

Currently, we apply a static prefix to all selected lines. This allows to pass a callback which receives the line index (starting at 0), potentially resolving a different prefix per line.

It is done in a backwards compatible way, to minimize changes, so for all cases where we still want to apply the same prefix to all lines, it still supports providing a static string.

[md-ordered-list.webm](https://user-images.githubusercontent.com/2719332/213670653-0b355fe8-ca70-4307-a7c2-da31950a14e1.webm)

## Todo

- [x] Add test that trully covers the behavior of the new callback, by checking the actual prefixes being set.