### PR TITLE
Update shared components in `ModerationBanner`; convert to TS

### DIFF
--- a/src/sidebar/components/ModerationBanner.js
+++ b/src/sidebar/components/ModerationBanner.js
@@ -1,4 +1,8 @@
-import { Icon, LabeledButton } from '@hypothesis/frontend-shared';
+import {
+  ButtonBase,
+  FlagIcon,
+  HideIcon,
+} from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 
 import { useSidebarStore } from '../store';
@@ -88,7 +92,11 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
           'bg-grey-6': annotation.hidden,
         })}
       >
-        <Icon name={annotation.hidden ? 'hide' : 'flag'} />
+        {annotation.hidden ? (
+          <HideIcon className="w-em h-em" />
+        ) : (
+          <FlagIcon className="w-em h-em" />
+        )}
       </div>
       <div className="self-center grow">
         {!annotation.hidden && (
@@ -100,18 +108,21 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
         {annotation.hidden && <span>Hidden from users</span>}
       </div>
       <div className="self-center pr-2">
-        <LabeledButton
-          classes="py-1 bg-slate-1"
+        <ButtonBase
+          classes={classnames(
+            'px-1.5 py-1 bg-slate-1 text-grey-7 bg-grey-2',
+            'enabled:hover:text-grey-9 enabled:hover:bg-grey-3 disabled:text-grey-5',
+            'aria-pressed:bg-grey-3 aria-expanded:bg-grey-3'
+          )}
           onClick={annotation.hidden ? unhideAnnotation : hideAnnotation}
           title={
             annotation.hidden
               ? 'Make this annotation visible to everyone'
               : 'Hide this annotationn from non-moderators'
           }
-          variant="dark"
         >
           {annotation.hidden ? 'Unhide' : 'Hide'}
-        </LabeledButton>
+        </ButtonBase>
       </div>
     </div>
   );

--- a/src/sidebar/components/ModerationBanner.tsx
+++ b/src/sidebar/components/ModerationBanner.tsx
@@ -5,30 +5,31 @@ import {
 } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 
+import type { Annotation } from '../../types/api';
+
+import type { APIService } from '../services/api';
+import type { ToastMessengerService } from '../services/toast-messenger';
 import { useSidebarStore } from '../store';
 import * as annotationMetadata from '../helpers/annotation-metadata';
 import { withServices } from '../service-context';
 
-/**
- * @typedef {import('../../types/api').Annotation} Annotation
- */
+export type ModerationBannerProps = {
+  annotation: Annotation;
+
+  // injected
+  api: APIService;
+  toastMessenger: ToastMessengerService;
+};
 
 /**
- * @typedef ModerationBannerProps
- * @prop {Annotation} annotation -
- *   The annotation object for this banner. This contains state about the flag count
- *   or its hidden value.
- * @prop {import('../services/api').APIService} api
- * @prop {import('../services/toast-messenger').ToastMessengerService} toastMessenger
+ * Banner allows moderators to hide/unhide the flagged annotation from other
+ * users.
  */
-
-/**
- * Banner allows moderators to hide/unhide the flagged
- * annotation from other users.
- *
- * @param {ModerationBannerProps} props
- */
-function ModerationBanner({ annotation, api, toastMessenger }) {
+function ModerationBanner({
+  annotation,
+  api,
+  toastMessenger,
+}: ModerationBannerProps) {
   const store = useSidebarStore();
   const flagCount = annotationMetadata.flagCount(annotation);
 
@@ -39,7 +40,7 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
    * Hide an annotation from non-moderator users.
    */
   const hideAnnotation = () => {
-    const id = /** @type {string} */ (annotation.id);
+    const id = annotation.id!;
     api.annotation
       .hide({ id })
       .then(() => {
@@ -54,7 +55,7 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
    * Un-hide an annotation from non-moderator users.
    */
   const unhideAnnotation = () => {
-    const id = /** @type {string} */ (annotation.id);
+    const id = annotation.id!;
     api.annotation
       .unhide({ id })
       .then(() => {
@@ -72,9 +73,7 @@ function ModerationBanner({ annotation, api, toastMessenger }) {
     <div
       className={classnames(
         'flex gap-x-3 bg-grey-1 text-color-text font-semibold',
-        // Vertical margins should ultimately be handled by the parent, but
-        // until we can refactor outer components (e.g. `ThreadCard`), this
-        // component manages its own bottom margin
+        // FIXME: Refactor margins: where possible manage them in a parent
         'mb-2 ',
         {
           // For top-level annotations, use negative margins to "break out" of


### PR DESCRIPTION
Part of #4860 

This component is rendered at the top of an annotation card if the annotation has been flagged by a user and/or hidden by a moderator.

Here are a couple of examples:

<img width="431" alt="image" src="https://user-images.githubusercontent.com/439947/213536277-cfcd67b7-02cd-4d2f-b320-970cee48ddeb.png">

There are no user-visible changes.

Let me know if you need any help testing this (it involves logging in as multiple users and performing some actions).