### PR TITLE
Update shared components in `SidebarContentError`; convert to TS

### DIFF
--- a/src/sidebar/components/SidebarContentError.js
+++ b/src/sidebar/components/SidebarContentError.js
@@ -1,4 +1,8 @@
-import { LabeledButton, Panel } from '@hypothesis/frontend-shared';
+import {
+  Button,
+  Panel,
+  RestrictedIcon,
+} from '@hypothesis/frontend-shared/lib/next';
 
 import { useSidebarStore } from '../store';
 
@@ -41,21 +45,21 @@ export default function SidebarContentError({
 
   return (
     <div className="mb-4">
-      <Panel icon="restricted" title={errorTitle}>
+      <Panel icon={RestrictedIcon} title={errorTitle}>
         <p>{errorMessage}</p>
         <div className="flex justify-end space-x-2">
           {showClearSelection && (
-            <LabeledButton
+            <Button
               variant={isLoggedIn ? 'primary' : undefined}
               onClick={() => store.clearSelection()}
             >
               Show all annotations
-            </LabeledButton>
+            </Button>
           )}
           {!isLoggedIn && (
-            <LabeledButton variant="primary" onClick={onLoginRequest}>
+            <Button variant="primary" onClick={onLoginRequest}>
               Log in
-            </LabeledButton>
+            </Button>
           )}
         </div>
       </Panel>

--- a/src/sidebar/components/SidebarContentError.tsx
+++ b/src/sidebar/components/SidebarContentError.tsx
@@ -6,24 +6,25 @@ import {
 
 import { useSidebarStore } from '../store';
 
-/**
- * @typedef SidebarContentErrorProps
- * @prop {'annotation'|'group'} errorType
- * @prop {boolean} [showClearSelection] - Whether to show a "Clear selection" button.
- * @prop {() => void} onLoginRequest - A function that will launch the login flow for the user.
- */
+export type SidebarContentErrorProps = {
+  errorType: 'annotation' | 'group';
+
+  /** Whether or not to render a "Clear selection" button */
+  showClearSelection?: boolean;
+
+  /** A function that will launch the login flow for the user */
+  onLoginRequest: () => void;
+};
 
 /**
  * Show an error indicating that an annotation or group referenced in the URL
  * could not be fetched.
- *
- * @param {SidebarContentErrorProps} props
  */
 export default function SidebarContentError({
   errorType,
   onLoginRequest,
   showClearSelection = false,
-}) {
+}: SidebarContentErrorProps) {
   const store = useSidebarStore();
   const isLoggedIn = store.isLoggedIn();
 

--- a/src/sidebar/components/test/SidebarContentError-test.js
+++ b/src/sidebar/components/test/SidebarContentError-test.js
@@ -36,7 +36,7 @@ describe('SidebarContentError', () => {
 
   const findButtonByText = (wrapper, text) => {
     return wrapper
-      .find('LabeledButton')
+      .find('button')
       .filterWhere(button => button.text() === text)
       .at(0);
   };


### PR DESCRIPTION
This is the last Sidebar component that needs component updates, leaving just a handful in the annotator! :tada: Part of #4860 

There are minor user-facing changes here in line with other components being updated to use the new `Panel`: header font is larger and margins are adjusted.

Before:

<img width="427" alt="Screen Shot 2023-01-19 at 2 09 24 PM" src="https://user-images.githubusercontent.com/439947/213538999-f689c62a-41b9-42ce-9ee7-1cb7656e98e0.png">

After:

<img width="427" alt="Screen Shot 2023-01-19 at 2 09 19 PM" src="https://user-images.githubusercontent.com/439947/213539023-9ad51981-3d96-44c7-be69-f54678b05711.png">


The easiest way to see this in the UI is to negate the conditional(s) around it in the `SidebarView` component, e.g. change

```
      {hasDirectLinkedAnnotationError && (
        <SidebarContentError
          errorType="annotation"
          onLoginRequest={onLogin}
          showClearSelection={true}
        />
      )}
```

to

```
      {!hasDirectLinkedAnnotationError && (
        <SidebarContentError
          errorType="annotation"
          onLoginRequest={onLogin}
          showClearSelection={true}
        />
      )}
```
