### PR TITLE
Support versions of PDF.js >= v3.2.146

### DIFF
--- a/src/annotator/anchoring/pdf.js
+++ b/src/annotator/anchoring/pdf.js
@@ -314,7 +314,12 @@ async function anchorByPosition(pageIndex, start, end) {
     // `getPageTextContent` and the text layer content. Any other differences
     // will cause mis-anchoring.
 
-    const root = page.textLayer.textLayerDiv;
+    const root = page.textLayer.textLayerDiv ?? page.textLayer.div;
+    if (!root) {
+      /* istanbul ignore next */
+      throw new Error('Unable to find PDF.js text layer root');
+    }
+
     const textLayerStr = /** @type {string} */ (root.textContent);
 
     const [textLayerStart, textLayerEnd] = translateOffsets(

--- a/src/types/pdfjs.js
+++ b/src/types/pdfjs.js
@@ -146,7 +146,8 @@
 /**
  * @typedef TextLayer
  * @prop {boolean} renderingDone
- * @prop {HTMLElement} textLayerDiv
+ * @prop {HTMLElement} [div] - New name for root element of text layer in PDF.js >= v3.2.146
+ * @prop {HTMLElement} [textLayerDiv] - Old name for root element of text layer
  */
 
 export {};


### PR DESCRIPTION
This release includes https://github.com/mozilla/pdf.js/pull/15722 which changed the property that stores the root of the text layer.

The tests mocks still use the old `textLayerDiv` name because that is what is used in the PDF.js release that we currently ship.

To test:

1. Create a temporary local branch using this branch as a start point
2. Run `scripts/update-pdfjs` to update the version of PDF.js in the dev server to the latest version from PDF.js's GitHub repo
3. Restart dev server and go to a hosted PDF (eg. http://localhost:3000/pdf/gatsby)

On `main`, anchoring will fail for all annotations and they will appear in the "Orphans" tab. On this branch anchoring should work again.