### PR TITLE
Update shared components in annotator `Toolbar`; update to TS

### DIFF
--- a/src/annotator/components/Toolbar.js
+++ b/src/annotator/components/Toolbar.js
@@ -1,32 +1,41 @@
-import { IconButton } from '@hypothesis/frontend-shared';
+import {
+  ButtonBase,
+  AnnotateIcon,
+  CancelIcon,
+  CaretRightIcon,
+  CaretLeftIcon,
+  HideIcon,
+  NoteIcon,
+  ShowIcon,
+} from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 
 /**
- * @typedef {import("@hypothesis/frontend-shared/lib/components/buttons").IconButtonProps} IconButtonProps
- *
- * @typedef {Omit<IconButtonProps, "className">} ToolbarButtonProps
+ * @typedef {import('@hypothesis/frontend-shared/lib/types').PresentationalProps} PresentationalProps
+ * @typedef {import('@hypothesis/frontend-shared/lib/components/input/ButtonBase').ButtonCommonProps} ButtonCommonProps
+ * @typedef {Omit<import('preact').JSX.HTMLAttributes<HTMLButtonElement>, 'icon'|'size'>} HTMLButtonAttributes
+ * @typedef {import('@hypothesis/frontend-shared/lib/types').IconComponent} IconComponent
  */
 
 /**
  * Style an IconButton for use on the Toolbar
  *
- * @param {ToolbarButtonProps} props
+ * @param {PresentationalProps & ButtonCommonProps & HTMLButtonAttributes & {icon: IconComponent}} props
  */
-function ToolbarButton({ ...buttonProps }) {
-  const { icon, title, ...restProps } = buttonProps;
+function ToolbarButton({ icon: Icon, ...buttonProps }) {
   return (
-    <IconButton
-      className={classnames(
+    <ButtonBase
+      classes={classnames(
         'w-[30px] h-[30px]', // These buttons have precise dimensions
         'rounded-px', // size of border radius in absolute units
         'flex items-center justify-center',
         'border bg-white text-grey-6 hover:text-grey-9',
         'shadow transition-colors'
       )}
-      icon={icon}
-      title={title}
-      {...restProps}
-    />
+      {...buttonProps}
+    >
+      <Icon />
+    </ButtonBase>
   );
 }
 
@@ -71,7 +80,7 @@ function StatusNotifier({ highlightsVisible }) {
  *   Callback to toggle visibility of highlights in the document.
  * @prop {() => void} toggleSidebar -
  *   Callback to toggle the visibility of the sidebar.
- * @prop {import("preact").Ref<HTMLButtonElement>} [toggleSidebarRef] -
+ * @prop {import("preact").RefObject<HTMLElement>} [toggleSidebarRef] -
  *   Ref that gets set to the toolbar button for toggling the sidebar.
  *   This is exposed to enable the drag-to-resize functionality of this
  *   button.
@@ -114,8 +123,8 @@ export default function Toolbar({
           absolutely positioned some way down the edge of the sidebar.
       */}
       {useMinimalControls && isSidebarOpen && (
-        <IconButton
-          className={classnames(
+        <ButtonBase
+          classes={classnames(
             'w-[27px] h-[27px] mt-[140px] ml-px-1.5',
             'flex items-center justify-center bg-white border',
             'text-grey-6 hover:text-grey-9 transition-colors',
@@ -126,32 +135,34 @@ export default function Toolbar({
             'shadow-sidebar'
           )}
           title="Close annotation sidebar"
-          icon="cancel"
           onClick={closeSidebar}
-        />
+        >
+          <CancelIcon />
+        </ButtonBase>
       )}
       {!useMinimalControls && (
         <>
-          <IconButton
-            className={classnames(
+          <ButtonBase
+            classes={classnames(
               // Height and width to align with the sidebar's top bar
-              'h-[40px] w-[33px] pl-px-1.5',
+              'h-[40px] w-[33px] pl-[6px]',
               'bg-white text-grey-5 hover:text-grey-9',
               // Turn on left and bottom borders to continue the
               // border of the sidebar's top bar
               'border-l border-b'
             )}
-            buttonRef={toggleSidebarRef}
+            elementRef={toggleSidebarRef}
             title="Annotation sidebar"
-            icon={isSidebarOpen ? 'caret-right' : 'caret-left'}
             expanded={isSidebarOpen}
             pressed={isSidebarOpen}
             onClick={toggleSidebar}
-          />
+          >
+            {isSidebarOpen ? <CaretRightIcon /> : <CaretLeftIcon />}
+          </ButtonBase>
           <div className="space-y-px-1.5 mt-px-2">
             <ToolbarButton
               title="Show highlights"
-              icon={showHighlights ? 'show' : 'hide'}
+              icon={showHighlights ? ShowIcon : HideIcon}
               selected={showHighlights}
               onClick={toggleHighlights}
             />
@@ -161,7 +172,7 @@ export default function Toolbar({
                   ? 'New page note'
                   : 'New annotation'
               }
-              icon={newAnnotationType === 'note' ? 'note' : 'annotate'}
+              icon={newAnnotationType === 'note' ? NoteIcon : AnnotateIcon}
               onClick={createAnnotation}
             />
           </div>

--- a/src/annotator/components/Toolbar.tsx
+++ b/src/annotator/components/Toolbar.tsx
@@ -8,21 +8,26 @@ import {
   NoteIcon,
   ShowIcon,
 } from '@hypothesis/frontend-shared/lib/next';
+import type {
+  IconComponent,
+  PresentationalProps,
+} from '@hypothesis/frontend-shared/lib/types';
+import type { ButtonCommonProps } from '@hypothesis/frontend-shared/lib/components/input/ButtonBase';
 import classnames from 'classnames';
+import type { JSX, RefObject } from 'preact';
 
-/**
- * @typedef {import('@hypothesis/frontend-shared/lib/types').PresentationalProps} PresentationalProps
- * @typedef {import('@hypothesis/frontend-shared/lib/components/input/ButtonBase').ButtonCommonProps} ButtonCommonProps
- * @typedef {Omit<import('preact').JSX.HTMLAttributes<HTMLButtonElement>, 'icon'|'size'>} HTMLButtonAttributes
- * @typedef {import('@hypothesis/frontend-shared/lib/types').IconComponent} IconComponent
- */
+// TODO: ToolbarButton should be extracted as a shared design pattern or
+// component
+type ToolbarButtonProps = PresentationalProps &
+  ButtonCommonProps &
+  Omit<JSX.HTMLAttributes<HTMLButtonElement>, 'icon' | 'size'> & {
+    icon: IconComponent;
+  };
 
 /**
  * Style an IconButton for use on the Toolbar
- *
- * @param {PresentationalProps & ButtonCommonProps & HTMLButtonAttributes & {icon: IconComponent}} props
  */
-function ToolbarButton({ icon: Icon, ...buttonProps }) {
+function ToolbarButton({ icon: Icon, ...buttonProps }: ToolbarButtonProps) {
   return (
     <ButtonBase
       classes={classnames(
@@ -40,20 +45,13 @@ function ToolbarButton({ icon: Icon, ...buttonProps }) {
 }
 
 /**
- * @typedef StatusNotifierProps
- * @prop {boolean} highlightsVisible
- */
-
-/**
  * Hidden component that announces certain Hypothesis states.
  *
  * This is useful to inform assistive technology users when these states
  * have been changed (eg. whether highlights are visible), given that they can
  * be changed in multiple ways (keyboard shortcuts, toolbar button) etc.
- *
- * @param {StatusNotifierProps} props
  */
-function StatusNotifier({ highlightsVisible }) {
+function StatusNotifier({ highlightsVisible }: { highlightsVisible: boolean }) {
   return (
     <div className="sr-only" role="status" data-testid="toolbar-status">
       {highlightsVisible ? 'Highlights visible' : 'Highlights hidden'}
@@ -61,33 +59,51 @@ function StatusNotifier({ highlightsVisible }) {
   );
 }
 
-/**
- * @typedef ToolbarProps
- *
- * @prop {() => void} closeSidebar -
- *   Callback for the "Close sidebar" button. This button is only shown when
- *   `useMinimalControls` is true and the sidebar is open.
- * @prop {() => void} createAnnotation -
- *   Callback for the "Create annotation" / "Create page note" button. The type
- *   of annotation depends on whether there is a text selection and is decided
- *   by the caller.
- * @prop {boolean} isSidebarOpen - Is the sidebar currently visible?
- * @prop {'annotation'|'note'} newAnnotationType -
- *   Icon to show on the "Create annotation" button indicating what kind of annotation
- *   will be created.
- * @prop {boolean} showHighlights - Are highlights currently visible in the document?
- * @prop {() => void} toggleHighlights -
- *   Callback to toggle visibility of highlights in the document.
- * @prop {() => void} toggleSidebar -
- *   Callback to toggle the visibility of the sidebar.
- * @prop {import("preact").RefObject<HTMLElement>} [toggleSidebarRef] -
- *   Ref that gets set to the toolbar button for toggling the sidebar.
- *   This is exposed to enable the drag-to-resize functionality of this
- *   button.
- * @prop {boolean} [useMinimalControls] -
- *   If true, all controls are hidden except for the "Close sidebar" button
- *   when the sidebar is open. This is enabled in the "clean" theme.
- */
+export type ToolbarProps = {
+  /**
+   * Callback for the "Close sidebar" button. This button is only shown when
+   * `useMinimalControls` is true and the sidebar is open.
+   */
+  closeSidebar: () => void;
+
+  /** Callback for when "Create annotation" button is clicked. */
+  createAnnotation: () => void;
+
+  /** Is the sidebar currently open? */
+  isSidebarOpen: boolean;
+
+  /**
+   * Informs which icon to show on the "Create annotation" button and what type
+   * of annotation should be created by the `createAnnotation` callback. The
+   * type of annotation depends on whether there is a text selection in the
+   * document.
+   */
+  newAnnotationType: 'annotation' | 'note';
+
+  /** Are highlights currently visible in the document? */
+  showHighlights: boolean;
+
+  /** Callback for the show/hide highlights button */
+  toggleHighlights: () => void;
+
+  /**
+   * Callback for toggling the visibility of the sidebar when the show/hide
+   * sidebar button is clicked
+   */
+  toggleSidebar: () => void;
+
+  /**
+   * Ref to apply to the show/hide-sidebar button. This is exposed to enable
+   * drag-to-resize functionality.
+   */
+  toggleSidebarRef?: RefObject<HTMLElement>;
+
+  /**
+   * When true, all controls are hidden except for the "Close sidebar" button
+   * when the sidebar is open. This is enabled for the "clean" theme.
+   */
+  useMinimalControls?: boolean;
+};
 
 /**
  * Controls on the edge of the sidebar for opening/closing the sidebar,
@@ -96,8 +112,6 @@ function StatusNotifier({ highlightsVisible }) {
  * This component and its buttons are sized with absolute units such that they
  * don't scale with changes to the host page's root font size. They will still
  * properly scale with user/browser zooming.
- *
- * @param {ToolbarProps} props
  */
 export default function Toolbar({
   closeSidebar,
@@ -109,7 +123,7 @@ export default function Toolbar({
   toggleSidebar,
   toggleSidebarRef,
   useMinimalControls = false,
-}) {
+}: ToolbarProps) {
   return (
     <div
       className={classnames(


### PR DESCRIPTION
Part of #4860 ... getting so close.

This PR updates shared components in the `Toolbar`, which displays some buttons to the left of the sidebar:

<img width="55" alt="image" src="https://user-images.githubusercontent.com/439947/213755940-5ce5a1c1-5820-4339-8296-04efe5f13e34.png">

There are no user-visible changes here.