### PR TITLE
Tweak notebook close button so that it's less obvious that it renders over other modals inside the iframe

### DIFF
--- a/src/annotator/components/NotebookModal.tsx
+++ b/src/annotator/components/NotebookModal.tsx
@@ -124,6 +124,13 @@ export default function NotebookModal({
             title="Close the Notebook"
             onClick={onClose}
             variant="dark"
+            classes={classnames(
+              // Remove the dark variant's background color to avoid
+              // interfering with modal overlays. Re-activate the dark variant's
+              // background color on hover.
+              // See https://github.com/hypothesis/client/issues/3676
+              '!bg-transparent enabled:hover:!bg-grey-3'
+            )}
           >
             <CancelIcon className="w-4 h-4" />
           </IconButton>


### PR DESCRIPTION
This is another attempt to fix #3676

In this case, this solution does not try to actually solve the problem, as attempted in #5139, because the changes needed are too much.

Instead, this just tweaks the "visuals" of the notebook close button, by removing `variant="dark"`, so that it is less obvious that it is rendered over the "delete annotation" modal. It's still on top, but it's visually "less ugly".

https://user-images.githubusercontent.com/2719332/214013575-f6c793b0-2578-4169-a556-0cf713e187fb.mp4