### PR TITLE
Remove book_as_single_document flag and throw if book ID is missing

### DIFF
--- a/src/annotator/features.js
+++ b/src/annotator/features.js
@@ -11,11 +11,7 @@ import { warnOnce } from '../shared/warn-once';
  *
  * @type {string[]}
  */
-const annotatorFlags = [
-  'book_as_single_document',
-  'html_side_by_side',
-  'styled_highlight_clusters',
-];
+const annotatorFlags = ['html_side_by_side', 'styled_highlight_clusters'];
 
 /**
  * An observable container of feature flags.

--- a/src/annotator/integrations/index.js
+++ b/src/annotator/integrations/index.js
@@ -25,9 +25,7 @@ export function createIntegration(annotator) {
 
   const vsFrameRole = vitalSourceFrameRole();
   if (vsFrameRole === 'content') {
-    return new VitalSourceContentIntegration(document.body, {
-      features: annotator.features,
-    });
+    return new VitalSourceContentIntegration(document.body);
   }
 
   return new HTMLIntegration({ features: annotator.features });

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1451,7 +1451,7 @@ describe('Guest', () => {
     assert.isFalse(sidebarRPC().call.calledWith('documentInfoChanged'));
 
     emitSidebarEvent('featureFlagsUpdated', {
-      book_as_single_document: true,
+      some_new_feature: true,
     });
 
     await delay(0);


### PR DESCRIPTION
This removes the feature flag for treating VitalSource books as one document, instead of treating each chapter as a separate document, following completion of https://github.com/hypothesis/h/issues/7709.

 - Remove the book_as_single_document flag, as we have now enabled this flag for everyone in production
 - Throw if the `isbn` property is missing from the book info returned by VitalSource. If this ever happens, we want to fail loudly instead of silently capturing a URL with no book ID on it.

To observe the result of the second change, if you remove the `isbn` property here https://github.com/hypothesis/client/blob/bb4fc1768cdf8f0c3d2041884d702efd66c9fa66/dev-server/static/scripts/vitalsource-mosaic-book-element.js#L155 and then open http://localhost:3000/document/vitalsource-epub you'll see that the client remains in a loading state and a console error appears, rather than silently using the wrong document URL. This is not graceful, but the most important thing I want to get deployed ASAP is to fail loudly in this situation.