### PR TITLE
Fail loudly if VitalSource page info fields are missing

### DIFF
--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -405,7 +405,7 @@ describe('annotator/integrations/vitalsource', () => {
       });
     });
 
-    ['absoluteURL', 'cfi', 'index', 'page'].forEach(field => {
+    ['absoluteURL', 'cfi'].forEach(field => {
       it(`throws if page info field "${field}" is missing`, async () => {
         fakeBookElement.selectPDFBook();
 
@@ -428,7 +428,7 @@ describe('annotator/integrations/vitalsource', () => {
         assert.instanceOf(error, Error);
         assert.equal(
           error.message,
-          `Chapter metadata field "${field}" is missing`
+          `Page metadata field "${field}" is missing`
         );
       });
     });

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -405,6 +405,34 @@ describe('annotator/integrations/vitalsource', () => {
       });
     });
 
+    ['absoluteURL', 'cfi', 'index', 'page'].forEach(field => {
+      it(`throws if page info field "${field}" is missing`, async () => {
+        fakeBookElement.selectPDFBook();
+
+        const pageInfo = { ...(await fakeBookElement.getCurrentPage()) };
+        delete pageInfo[field];
+        fakeBookElement.getCurrentPage = async () => pageInfo;
+
+        const integration = createIntegration();
+        integration.contentContainer();
+        assert.calledWith(fakeHTMLIntegration.contentContainer);
+
+        const range = new Range();
+        let error;
+        try {
+          await integration.describe(range);
+        } catch (err) {
+          error = err;
+        }
+
+        assert.instanceOf(error, Error);
+        assert.equal(
+          error.message,
+          `Chapter metadata field "${field}" is missing`
+        );
+      });
+    });
+
     describe('#getMetadata', () => {
       it('returns book metadata', async () => {
         const integration = createIntegration();

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -337,7 +337,7 @@ export class VitalSourceContentIntegration
     // currently limit page number selectors to PDFs until more is understood
     // about when EPUB page numbers are reliable/likely to remain stable.
     const bookInfo = this._bookElement.getBookInfo();
-    if (bookInfo.format === 'pbk') {
+    if (bookInfo.format === 'pbk' && typeof pageIndex === 'number') {
       extraSelectors.push({
         type: 'PageSelector',
         index: pageIndex,
@@ -433,12 +433,12 @@ export class VitalSourceContentIntegration
     // If changes in VitalSource ever mean that critical chapter/page metadata
     // fields are missing, fail loudly. Otherwise we might create annotations
     // that cannot be re-anchored in future.
-    const expectedFields = ['absoluteURL', 'cfi', 'index', 'page'];
-    for (const field of expectedFields) {
+    const requiredFields = ['absoluteURL', 'cfi'];
+    for (const field of requiredFields) {
       // nb. We intentionally allow properties anywhere on the prototype chain,
       // rather than requiring `hasOwnProperty`.
       if (!(field in pageInfo)) {
-        throw new Error(`Chapter metadata field "${field}" is missing`);
+        throw new Error(`Page metadata field "${field}" is missing`);
       }
     }
 

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -430,6 +430,18 @@ export class VitalSourceContentIntegration
       includeTitle ? this._bookElement.getTOC() : undefined,
     ]);
 
+    // If changes in VitalSource ever mean that critical chapter/page metadata
+    // fields are missing, fail loudly. Otherwise we might create annotations
+    // that cannot be re-anchored in future.
+    const expectedFields = ['absoluteURL', 'cfi', 'index', 'page'];
+    for (const field of expectedFields) {
+      // nb. We intentionally allow properties anywhere on the prototype chain,
+      // rather than requiring `hasOwnProperty`.
+      if (!(field in pageInfo)) {
+        throw new Error(`Chapter metadata field "${field}" is missing`);
+      }
+    }
+
     let title;
 
     if (toc) {

--- a/src/types/vitalsource.ts
+++ b/src/types/vitalsource.ts
@@ -64,13 +64,13 @@ export type PageInfo = {
    * The page label for the first page of the segment. This is the page number
    * that is displayed in the VitalSource navigation controls when the
    * chapter is scrolled to the top.
+   *
+   * This may be missing in EPUBs that do not contain page break information.
+   * It should always be present in PDF books.
    */
   page?: string;
 
-  /**
-   * Index of the current segment within the sequence of pages or content
-   * documents that make up the book.
-   */
+  /** Index of the current page. Only available in PDF-based books. */
   index?: number;
 
   /**

--- a/src/types/vitalsource.ts
+++ b/src/types/vitalsource.ts
@@ -65,13 +65,13 @@ export type PageInfo = {
    * that is displayed in the VitalSource navigation controls when the
    * chapter is scrolled to the top.
    */
-  page: string;
+  page?: string;
 
   /**
    * Index of the current segment within the sequence of pages or content
    * documents that make up the book.
    */
-  index: number;
+  index?: number;
 
   /**
    * Title of the entry in the table of contents that refers to the current


### PR DESCRIPTION
If for any reason VitalSource's `<mosaic-book>` API does not return the page/chapter info fields that the Hypothesis client is expecting, fail loudly [1] so we find out about the issue, rather than silently creating annotations with missing/incorrect chapter location information. I don't currently know of any situation where this is expected to happen, so this is protection against future changes or differences in behaviors with certain books that we have not observed yet.

In the process I adjusted the types for the VitalSource APIs to reflect that page indices/labels may not be present. This can happen with EPUBs where the publisher did not provide page break information. These cases can be identified from the lack of page numbers near the Prev/Next page buttons in the bottom-right corner of the VitalSource UI.

[1] "Fail loudly" means that the VitalSource integration throws an error when the `Guest` tries to fetch page metadata. This is currently handled in an un-graceful way by logging an error in the browser console and the sidebar remains in a loading state. This sounds bad, but I'd prefer this than have someone create a whole bunch of annotations which later disappear or end up appearing on the wrong book.