### PR TITLE
Prepare everything to support profile as a new loadable mini-app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
     environment: qa
     env:
       NOTEBOOK_APP_URL: https://qa.hypothes.is/notebook
+      PROFILE_APP_URL: https://qa.hypothes.is/user-profile
       SIDEBAR_APP_URL: https://qa.hypothes.is/app.html
 
     steps:
@@ -69,6 +70,7 @@ jobs:
     environment: production
     env:
       NOTEBOOK_APP_URL: https://hypothes.is/notebook
+      PROFILE_APP_URL: https://hypothes.is/user-profile
       SIDEBAR_APP_URL: https://hypothes.is/app.html
 
     steps:

--- a/docs/developers/envvars.rst
+++ b/docs/developers/envvars.rst
@@ -13,7 +13,7 @@ build tasks.
 .. envvar:: PROFILE_APP_URL
 
    The default value for the :option:`profileAppUrl` config setting (the URL of
-   the profile app's iframe), used when the host page does not contain a
+   the user profile iframe), used when the host page does not contain a
    :option:`profileAppUrl` setting.
    ``https://hypothes.is/user-profile`` by default.
 

--- a/docs/developers/envvars.rst
+++ b/docs/developers/envvars.rst
@@ -10,6 +10,13 @@ build tasks.
    the notebook app's iframe).
    ``https://hypothes.is/notebook`` by default.
 
+.. envvar:: PROFILE_APP_URL
+
+   The default value for the :option:`profileAppUrl` config setting (the URL of
+   the profile app's iframe), used when the host page does not contain a
+   :option:`profileAppUrl` setting.
+   ``https://hypothes.is/user-profile`` by default.
+
 .. envvar:: SIDEBAR_APP_URL
 
    The default value for the :option:`sidebarAppUrl` config setting (the URL of

--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -475,3 +475,7 @@ These settings configure where the client's assets are loaded from.
 .. option:: notebookAppUrl
 
    ``String``. The URL for the notebook application (Default: ``"https://hypothes.is/notebook"``).
+
+.. option:: profileAppUrl
+
+   ``String``. The URL for the profile application (Default: ``"https://hypothes.is/user-profile"``).

--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -478,4 +478,4 @@ These settings configure where the client's assets are loaded from.
 
 .. option:: profileAppUrl
 
-   ``String``. The URL for the profile application (Default: ``"https://hypothes.is/user-profile"``).
+   ``String``. The URL for the user profile application (Default: ``"https://hypothes.is/user-profile"``).

--- a/rollup-boot.config.mjs
+++ b/rollup-boot.config.mjs
@@ -21,6 +21,10 @@ const notebookAppUrl = process.env.NOTEBOOK_APP_URL
   ? `${process.env.NOTEBOOK_APP_URL}`
   : `${localhost}:5000/notebook`;
 
+const profileAppUrl = process.env.PROFILE_APP_URL
+  ? `${process.env.PROFILE_APP_URL}`
+  : `${localhost}:5000/user-profile`;
+
 const sidebarAppUrl = process.env.SIDEBAR_APP_URL
   ? `${process.env.SIDEBAR_APP_URL}`
   : `${localhost}:5000/app.html`;
@@ -52,6 +56,7 @@ export default {
       values: {
         __ASSET_ROOT__: assetRoot,
         __NOTEBOOK_APP_URL__: notebookAppUrl,
+        __PROFILE_APP_URL__: profileAppUrl,
         __SIDEBAR_APP_URL__: sidebarAppUrl,
       },
     }),

--- a/src/annotator/components/ProfileModal.tsx
+++ b/src/annotator/components/ProfileModal.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+import classnames from 'classnames';
+import { CancelIcon, IconButton } from '@hypothesis/frontend-shared/lib/next';
+
+import type { Emitter, EventBus } from '../util/emitter';
+
+export type ProfileConfig = { profileAppUrl: string } & Record<string, unknown>;
+
+type ProfileModalProps = {
+  eventBus: EventBus;
+  config: ProfileConfig;
+};
+
+export function ProfileModal({ eventBus, config }: ProfileModalProps) {
+  const [isHidden, setIsHidden] = useState(true);
+  const originalDocumentOverflowStyle = useRef('');
+  const emitterRef = useRef<Emitter | null>(null);
+
+  // Stores the original overflow CSS property of document.body and reset it
+  // when the component is destroyed
+  useEffect(() => {
+    originalDocumentOverflowStyle.current = document.body.style.overflow;
+
+    return () => {
+      document.body.style.overflow = originalDocumentOverflowStyle.current;
+    };
+  }, []);
+
+  // The overflow CSS property is set to hidden to prevent scrolling of the host page,
+  // while the profile modal is open. It is restored when the modal is closed.
+  useEffect(() => {
+    if (isHidden) {
+      document.body.style.overflow = originalDocumentOverflowStyle.current;
+    } else {
+      document.body.style.overflow = 'hidden';
+    }
+  }, [isHidden]);
+
+  useEffect(() => {
+    const emitter = eventBus.createEmitter();
+    emitter.subscribe('openProfile', () => {
+      console.log('Open!');
+      setIsHidden(false);
+    });
+    emitterRef.current = emitter;
+
+    return () => {
+      emitter.destroy();
+    };
+  }, [eventBus]);
+
+  const onClose = () => {
+    setIsHidden(true);
+    emitterRef.current?.publish('closeProfile');
+  };
+
+  return (
+    <div
+      className={classnames(
+        'fixed z-max top-0 left-0 right-0 bottom-0 p-3 bg-black/50',
+        { hidden: isHidden }
+      )}
+      data-testid="profile-outer"
+    >
+      <div className="relative w-full h-full" data-testid="profile-inner">
+        <div className="absolute right-0 m-3">
+          <IconButton
+            title="Close the Profile"
+            onClick={onClose}
+            variant="dark"
+            classes={classnames(
+              // Remove the dark variant's background color to avoid
+              // interfering with modal overlays. Re-activate the dark variant's
+              // background color on hover.
+              // See https://github.com/hypothesis/client/issues/3676
+              '!bg-transparent enabled:hover:!bg-grey-3'
+            )}
+          >
+            <CancelIcon className="w-4 h-4" />
+          </IconButton>
+        </div>
+        <iframe
+          title={'Hypothesis profile'}
+          className="h-full w-full border-0"
+          // Enable media in annotations to be shown fullscreen.
+          // TODO: Use `allow="fullscreen" once `allow` attribute available for
+          // iframe elements in all supported browsers
+          // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-allow
+          // eslint-disable-next-line react/no-unknown-property
+          allowFullScreen
+          src={config.profileAppUrl}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/annotator/components/ProfileModal.tsx
+++ b/src/annotator/components/ProfileModal.tsx
@@ -39,7 +39,6 @@ export function ProfileModal({ eventBus, config }: ProfileModalProps) {
   useEffect(() => {
     const emitter = eventBus.createEmitter();
     emitter.subscribe('openProfile', () => {
-      console.log('Open!');
       setIsHidden(false);
     });
     emitterRef.current = emitter;

--- a/src/annotator/components/ProfileModal.tsx
+++ b/src/annotator/components/ProfileModal.tsx
@@ -13,28 +13,7 @@ type ProfileModalProps = {
 
 export function ProfileModal({ eventBus, config }: ProfileModalProps) {
   const [isHidden, setIsHidden] = useState(true);
-  const originalDocumentOverflowStyle = useRef('');
   const emitterRef = useRef<Emitter | null>(null);
-
-  // Stores the original overflow CSS property of document.body and reset it
-  // when the component is destroyed
-  useEffect(() => {
-    originalDocumentOverflowStyle.current = document.body.style.overflow;
-
-    return () => {
-      document.body.style.overflow = originalDocumentOverflowStyle.current;
-    };
-  }, []);
-
-  // The overflow CSS property is set to hidden to prevent scrolling of the host page,
-  // while the profile modal is open. It is restored when the modal is closed.
-  useEffect(() => {
-    if (isHidden) {
-      document.body.style.overflow = originalDocumentOverflowStyle.current;
-    } else {
-      document.body.style.overflow = 'hidden';
-    }
-  }, [isHidden]);
 
   useEffect(() => {
     const emitter = eventBus.createEmitter();
@@ -81,12 +60,6 @@ export function ProfileModal({ eventBus, config }: ProfileModalProps) {
         <iframe
           title={'Hypothesis profile'}
           className="h-full w-full border-0"
-          // Enable media in annotations to be shown fullscreen.
-          // TODO: Use `allow="fullscreen" once `allow` attribute available for
-          // iframe elements in all supported browsers
-          // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-allow
-          // eslint-disable-next-line react/no-unknown-property
-          allowFullScreen
           src={config.profileAppUrl}
         />
       </div>

--- a/src/annotator/config/app.js
+++ b/src/annotator/config/app.js
@@ -36,7 +36,7 @@ export function createAppConfig(appURL, config) {
   appConfig.origin = new URL(appURL).origin;
 
   // Pass the version of the client, so we can check if it is the same as the
-  // one used in the sidebar/notebook.
+  // one used in the sidebar/notebook/profile.
   appConfig.version = '__VERSION__';
 
   // Pass the URL of the page that embedded the client.

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -23,7 +23,7 @@ import { urlFromLinkTag } from './url-from-link-tag';
  * Named subset of the Hypothesis client configuration that is relevant in
  * a particular context.
  *
- * @typedef {'sidebar'|'notebook'|'annotator'|'all'} Context
+ * @typedef {'sidebar'|'notebook'|'profile'|'annotator'|'all'} Context
  */
 
 /**
@@ -61,6 +61,9 @@ function configurationKeys(context) {
       'theme',
       'usernameUrl',
     ],
+    profile: [ // TODO Check what's missing
+      'profileAppUrl',
+    ]
   };
 
   switch (context) {
@@ -70,9 +73,11 @@ function configurationKeys(context) {
       return contexts.sidebar;
     case 'notebook':
       return contexts.notebook;
+    case 'profile':
+      return contexts.profile;
     case 'all':
       // Complete list of configuration keys used for testing.
-      return [...contexts.annotator, ...contexts.sidebar, ...contexts.notebook];
+      return Object.values(contexts).flat();
     default:
       throw new Error(`Invalid application context used: "${context}"`);
   }
@@ -176,6 +181,11 @@ const configDefinitions = {
     allowInBrowserExt: true,
     defaultValue: null,
     getValue: settings => settings.notebookAppUrl,
+  },
+  profileAppUrl: {
+    allowInBrowserExt: true,
+    defaultValue: null,
+    getValue: settings => settings.profileAppUrl,
   },
   sidebarAppUrl: {
     allowInBrowserExt: true,

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -62,7 +62,6 @@ function configurationKeys(context) {
       'usernameUrl',
     ],
     profile: [
-      // TODO Check what's missing
       'profileAppUrl',
     ],
   };

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -61,9 +61,10 @@ function configurationKeys(context) {
       'theme',
       'usernameUrl',
     ],
-    profile: [ // TODO Check what's missing
+    profile: [
+      // TODO Check what's missing
       'profileAppUrl',
-    ]
+    ],
   };
 
   switch (context) {

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -14,6 +14,7 @@ import { urlFromLinkTag } from './url-from-link-tag';
  * @prop {string} clientUrl
  * @prop {string} sidebarAppUrl
  * @prop {string} notebookAppUrl
+ * @prop {string} profileAppUrl
  * @prop {(name: string) => unknown} hostPageSetting
  */
 
@@ -174,6 +175,9 @@ export function settingsFrom(window_) {
     },
     get notebookAppUrl() {
       return urlFromLinkTag(window_, 'notebook', 'html');
+    },
+    get profileAppUrl() {
+      return urlFromLinkTag(window_, 'profile', 'html');
     },
     get showHighlights() {
       return showHighlights();

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -259,6 +259,10 @@ describe('annotator/config/index', () => {
           'usernameUrl',
         ],
       },
+      {
+        app: 'profile',
+        expectedKeys: ['profileAppUrl'],
+      },
     ].forEach(test => {
       it(`ignores values not belonging to "${test.app}" context`, () => {
         const config = getConfig(test.app, 'WINDOW');

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -12,6 +12,7 @@ describe('annotator/config/index', () => {
       clientUrl: 'fakeValue',
       group: 'fakeValue',
       notebookAppUrl: 'fakeValue',
+      profileAppUrl: 'fakeValue',
       showHighlights: 'fakeValue',
       sidebarAppUrl: 'fakeValue',
       query: 'fakeValue',
@@ -83,6 +84,7 @@ describe('annotator/config/index', () => {
             focus: null,
             group: 'fakeValue',
             notebookAppUrl: 'fakeValue',
+            profileAppUrl: 'fakeValue',
             onLayoutChange: null,
             openSidebar: true, // coerced
             query: 'fakeValue',
@@ -115,6 +117,7 @@ describe('annotator/config/index', () => {
             focus: 'fakeValue',
             group: 'fakeValue',
             notebookAppUrl: 'fakeValue',
+            profileAppUrl: 'fakeValue',
             onLayoutChange: 'fakeValue',
             openSidebar: true, // coerced
             query: 'fakeValue',
@@ -171,6 +174,7 @@ describe('annotator/config/index', () => {
         focus: null,
         group: null,
         notebookAppUrl: null,
+        profileAppUrl: null,
         onLayoutChange: null,
         openSidebar: false,
         query: null,

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -35,6 +35,16 @@ describe('annotator/config/settingsFrom', () => {
     });
   });
 
+  describe('#profileAppUrl', () => {
+    it('calls urlFromLinkTag with appropriate params', () => {
+      assert.equal(
+        settingsFrom(window).profileAppUrl,
+        'http://example.com/app.html'
+      );
+      assert.calledWith(fakeUrlFromLinkTag, window, 'profile', 'html');
+    });
+  });
+
   describe('#sidebarAppUrl', () => {
     it('calls urlFromLinkTag with appropriate params', () => {
       assert.equal(

--- a/src/annotator/index.ts
+++ b/src/annotator/index.ts
@@ -11,6 +11,7 @@ import {
 import type { Destroyable } from '../types/annotator';
 import { getConfig } from './config/index';
 import type { NotebookConfig } from './components/NotebookModal';
+import type { ProfileConfig } from './components/ProfileModal';
 import { Guest } from './guest';
 import type { GuestConfig } from './guest';
 import {
@@ -26,6 +27,7 @@ import { Notebook } from './notebook';
 import { Sidebar } from './sidebar';
 import type { SidebarConfig } from './sidebar';
 import { EventBus } from './util/emitter';
+import { Profile } from './profile';
 
 // Look up the URL of the sidebar. This element is added to the page by the
 // boot script before the "annotator" bundle loads.
@@ -75,11 +77,16 @@ function init() {
       eventBus,
       getConfig('notebook') as NotebookConfig
     );
+    const profile = new Profile(
+      document.body,
+      eventBus,
+      getConfig('profile') as ProfileConfig
+    );
 
     portProvider.on('frameConnected', (source, port) =>
       sidebar.onFrameConnected(source, port)
     );
-    destroyables.push(portProvider, sidebar, notebook);
+    destroyables.push(portProvider, sidebar, notebook, profile);
   }
 
   const vsFrameRole = vitalSourceFrameRole();

--- a/src/annotator/profile.tsx
+++ b/src/annotator/profile.tsx
@@ -1,0 +1,29 @@
+import { render } from 'preact';
+
+import type { Destroyable } from '../types/annotator';
+
+import type { ProfileConfig } from './components/ProfileModal';
+import { ProfileModal } from './components/ProfileModal';
+import type { EventBus } from './util/emitter';
+import { createShadowRoot } from './util/shadow-root';
+
+export class Profile implements Destroyable {
+  private _outerContainer: HTMLElement;
+  public shadowRoot: ShadowRoot;
+
+  constructor(element: HTMLElement, eventBus: EventBus, config: ProfileConfig) {
+    this._outerContainer = document.createElement('hypothesis-profile');
+    element.appendChild(this._outerContainer);
+    this.shadowRoot = createShadowRoot(this._outerContainer);
+
+    render(
+      <ProfileModal eventBus={eventBus} config={config} />,
+      this.shadowRoot
+    );
+  }
+
+  destroy(): void {
+    render(null, this.shadowRoot);
+    this._outerContainer.remove();
+  }
+}

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -370,8 +370,9 @@ export class Sidebar {
 
     this._sidebarRPC.on('closeSidebar', () => this.close());
 
-    // Sidebar listens to the `openNotebook` event coming from the sidebar's
-    // iframe and re-publishes it via the emitter to the Notebook
+    // Sidebar listens to the `openNotebook` and `openProfile` events coming
+    // from the sidebar's iframe and re-publishes it via the emitter to the
+    // Notebook/Profile
     this._sidebarRPC.on(
       'openNotebook',
       /** @param {string} groupId */
@@ -380,8 +381,15 @@ export class Sidebar {
         this._emitter.publish('openNotebook', groupId);
       }
     );
+    this._sidebarRPC.on('openProfile', () => {
+      this.hide();
+      this._emitter.publish('openProfile');
+    });
 
     this._emitter.subscribe('closeNotebook', () => {
+      this.show();
+    });
+    this._emitter.subscribe('closeProfile', () => {
       this.show();
     });
 

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -10,7 +10,7 @@
  * @typedef AnnotatorConfig
  * @prop {string} assetRoot - The root URL to which URLs in `manifest` are relative
  * @prop {string} notebookAppUrl - The URL of the sidebar's notebook
- * @prop {string} profileAppUrl - The URL of the sidebar's profile
+ * @prop {string} profileAppUrl - The URL of the sidebar's user profile view
  * @prop {string} sidebarAppUrl - The URL of the sidebar's HTML page
  * @prop {Record<string,string>} manifest -
  *   A mapping from canonical asset path to cache-busted asset path
@@ -155,7 +155,7 @@ export function bootHypothesisClient(doc, config) {
   // Register the URL of the notebook app which the Hypothesis client should load.
   injectLink(doc, 'notebook', 'html', config.notebookAppUrl);
 
-  // Register the URL of the profile app which the Hypothesis client should load.
+  // Register the URL of the user profile app which the Hypothesis client should load.
   injectLink(doc, 'profile', 'html', config.profileAppUrl);
 
   // Preload the styles used by the shadow roots of annotator UI elements.

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -10,6 +10,7 @@
  * @typedef AnnotatorConfig
  * @prop {string} assetRoot - The root URL to which URLs in `manifest` are relative
  * @prop {string} notebookAppUrl - The URL of the sidebar's notebook
+ * @prop {string} profileAppUrl - The URL of the sidebar's profile
  * @prop {string} sidebarAppUrl - The URL of the sidebar's HTML page
  * @prop {Record<string,string>} manifest -
  *   A mapping from canonical asset path to cache-busted asset path

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -155,6 +155,9 @@ export function bootHypothesisClient(doc, config) {
   // Register the URL of the notebook app which the Hypothesis client should load.
   injectLink(doc, 'notebook', 'html', config.notebookAppUrl);
 
+  // Register the URL of the profile app which the Hypothesis client should load.
+  injectLink(doc, 'profile', 'html', config.profileAppUrl);
+
   // Preload the styles used by the shadow roots of annotator UI elements.
   preloadURL(doc, 'style', assetURL(config, 'styles/annotator.css'));
 

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -39,6 +39,9 @@ if (isBrowserSupported()) {
     const notebookAppUrl = processUrlTemplate(
       annotatorConfig.notebookAppUrl || '__NOTEBOOK_APP_URL__'
     );
+    const profileAppUrl = processUrlTemplate(
+      annotatorConfig.profileAppUrl || '__PROFILE_APP_URL__'
+    );
     const sidebarAppUrl = processUrlTemplate(
       annotatorConfig.sidebarAppUrl || '__SIDEBAR_APP_URL__'
     );
@@ -46,6 +49,7 @@ if (isBrowserSupported()) {
       assetRoot,
       manifest,
       notebookAppUrl,
+      profileAppUrl,
       sidebarAppUrl,
     });
   }

--- a/src/shared/messaging/port-provider.js
+++ b/src/shared/messaging/port-provider.js
@@ -22,7 +22,7 @@ import { isMessage, isMessageEqual, isSourceWindow } from './port-util';
  *    where either (1) the hypothesis client has been injected or (2) the
  *    hypothesis client has been configured to act exclusively as a `guest` (not
  *    showing the sidebar).
- * - `notebook`: another hypothesis app that runs in a separate iframe.
+ * - `notebook` and `profile`: hypothesis apps that run in a separate iframe.
  * - `sidebar`: the main hypothesis app. It runs in an iframe on a different
  *    origin than the host and is responsible for the communication with the
  *    backend (fetching and saving annotations).
@@ -32,6 +32,7 @@ import { isMessage, isMessageEqual, isSourceWindow } from './port-util';
  * `host` frame
  * |-> `sidebar` iframe
  * |-> `notebook` iframe
+ * |-> `profile` iframe
  * |-> [`guest` iframes]
  *
  * Currently, we support communication between the following pairs of frames:

--- a/src/shared/messaging/port-provider.js
+++ b/src/shared/messaging/port-provider.js
@@ -22,10 +22,11 @@ import { isMessage, isMessageEqual, isSourceWindow } from './port-util';
  *    where either (1) the hypothesis client has been injected or (2) the
  *    hypothesis client has been configured to act exclusively as a `guest` (not
  *    showing the sidebar).
- * - `notebook` and `profile`: hypothesis apps that run in a separate iframe.
- * - `sidebar`: the main hypothesis app. It runs in an iframe on a different
- *    origin than the host and is responsible for the communication with the
- *    backend (fetching and saving annotations).
+ * - `notebook` and `profile`: front-end app views that each have their own
+ *    iframe.
+ * - `sidebar`: the main hypothesis front-end app. It runs in an iframe on a
+ *    different origin than the host and is responsible for the communication
+ *    with the backend (fetching and saving annotations).
  *
  * This layout represents the current arrangement of frames:
  *

--- a/src/shared/messaging/port-util.js
+++ b/src/shared/messaging/port-util.js
@@ -2,7 +2,7 @@
  * Message sent by `PortProvider` and `PortFinder` to establish a
  * MessageChannel-based connection between two frames.
  *
- * @typedef {'guest'|'host'|'notebook'|'sidebar'} Frame
+ * @typedef {'guest'|'host'|'notebook'|'profile'|'sidebar'} Frame
  *
  * @typedef Message
  * @prop {Frame} frame1 - Role of the source frame

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -44,6 +44,7 @@ function HypothesisApp({ auth, frameSync, settings, session, toastMessenger }) {
   const store = useSidebarStore();
   const profile = store.profile();
   const route = store.route();
+  const isModalRoute = route === 'notebook' || route === 'profile';
 
   const backgroundStyle = useMemo(
     () => applyTheme(['appBackgroundColor'], settings),
@@ -139,14 +140,14 @@ function HypothesisApp({ auth, frameSync, settings, session, toastMessenger }) {
           'theme-clean': isThemeClean,
           // Make room at top for the TopBar (40px) plus custom padding (9px)
           // but not in the Notebook or Profile, which don't use the TopBar
-          'pt-[49px]': route !== 'notebook',
-          'p-4 lg:p-12': route === 'notebook' || route === 'profile',
+          'pt-[49px]': !isModalRoute,
+          'p-4 lg:p-12': isModalRoute,
         }
       )}
       data-testid="hypothesis-app"
       style={backgroundStyle}
     >
-      {route !== 'notebook' && (
+      {!isModalRoute && (
         <TopBar
           onLogin={login}
           onSignUp={signUp}

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -14,6 +14,7 @@ import StreamView from './StreamView';
 
 import HelpPanel from './HelpPanel';
 import NotebookView from './NotebookView';
+import ProfileView from './ProfileView';
 import ShareAnnotationsPanel from './ShareAnnotationsPanel';
 import ToastMessages from './ToastMessages';
 import TopBar from './TopBar';
@@ -137,9 +138,9 @@ function HypothesisApp({ auth, frameSync, settings, session, toastMessenger }) {
         {
           'theme-clean': isThemeClean,
           // Make room at top for the TopBar (40px) plus custom padding (9px)
-          // but not in the Notebook, which doesn't use the TopBar
+          // but not in the Notebook or Profile, which don't use the TopBar
           'pt-[49px]': route !== 'notebook',
-          'p-4 lg:p-12': route === 'notebook',
+          'p-4 lg:p-12': route === 'notebook' || route === 'profile',
         }
       )}
       data-testid="hypothesis-app"
@@ -162,6 +163,7 @@ function HypothesisApp({ auth, frameSync, settings, session, toastMessenger }) {
           <main>
             {route === 'annotation' && <AnnotationView onLogin={login} />}
             {route === 'notebook' && <NotebookView />}
+            {route === 'profile' && <ProfileView />}
             {route === 'stream' && <StreamView />}
             {route === 'sidebar' && (
               <SidebarView onLogin={login} onSignUp={signUp} />

--- a/src/sidebar/components/ProfileView.tsx
+++ b/src/sidebar/components/ProfileView.tsx
@@ -1,0 +1,3 @@
+export default function ProfileView() {
+  return <div className="text-center">Profile</div>;
+}

--- a/src/sidebar/components/UserMenu.tsx
+++ b/src/sidebar/components/UserMenu.tsx
@@ -45,16 +45,22 @@ function UserMenu({ frameSync, onLogout, settings }: UserMenuProps) {
     !isThirdParty || serviceSupports('onProfileRequestProvided');
   const isLogoutEnabled =
     !isThirdParty || serviceSupports('onLogoutRequestProvided');
+  const isProfileEnabled =
+    /* isThirdParty || */ store.isFeatureEnabled('client_new_profile');
 
   const onSelectNotebook = () => {
     frameSync.notifyHost('openNotebook', store.focusedGroupId());
   };
+  const onSelectProfile = () => frameSync.notifyHost('openProfile');
 
   // Access to the Notebook:
   // type the key 'n' when user menu is focused/open
   const onKeyDown = (event: KeyboardEvent) => {
     if (event.key === 'n') {
       onSelectNotebook();
+      setOpen(false);
+    } else if (event.key === 'p') {
+      onSelectProfile();
       setOpen(false);
     }
   };
@@ -94,6 +100,9 @@ function UserMenu({ frameSync, onLogout, settings }: UserMenuProps) {
               label="Account settings"
               href={store.getLink('account.settings')}
             />
+          )}
+          {isProfileEnabled && (
+            <MenuItem label="Open profile" onClick={() => onSelectProfile()} />
           )}
           <MenuItem label="Open notebook" onClick={() => onSelectNotebook()} />
         </MenuSection>

--- a/src/sidebar/components/UserMenu.tsx
+++ b/src/sidebar/components/UserMenu.tsx
@@ -102,7 +102,7 @@ function UserMenu({ frameSync, onLogout, settings }: UserMenuProps) {
             />
           )}
           {isProfileEnabled && (
-            <MenuItem label="Open profile" onClick={() => onSelectProfile()} />
+            <MenuItem label="Your profile" onClick={() => onSelectProfile()} />
           )}
           <MenuItem label="Open notebook" onClick={() => onSelectNotebook()} />
         </MenuSection>

--- a/src/sidebar/components/UserMenu.tsx
+++ b/src/sidebar/components/UserMenu.tsx
@@ -45,9 +45,8 @@ function UserMenu({ frameSync, onLogout, settings }: UserMenuProps) {
     !isThirdParty || serviceSupports('onProfileRequestProvided');
   const isLogoutEnabled =
     !isThirdParty || serviceSupports('onLogoutRequestProvided');
-  const isProfileEnabled = /* isThirdParty || */ store.isFeatureEnabled(
-    'client_user_profile'
-  );
+  const isProfileEnabled =
+    isThirdParty && store.isFeatureEnabled('client_user_profile');
 
   const onSelectNotebook = () => {
     frameSync.notifyHost('openNotebook', store.focusedGroupId());
@@ -60,7 +59,7 @@ function UserMenu({ frameSync, onLogout, settings }: UserMenuProps) {
     if (event.key === 'n') {
       onSelectNotebook();
       setOpen(false);
-    } else if (event.key === 'p') {
+    } else if (isProfileEnabled && event.key === 'p') {
       onSelectProfile();
       setOpen(false);
     }

--- a/src/sidebar/components/UserMenu.tsx
+++ b/src/sidebar/components/UserMenu.tsx
@@ -45,8 +45,9 @@ function UserMenu({ frameSync, onLogout, settings }: UserMenuProps) {
     !isThirdParty || serviceSupports('onProfileRequestProvided');
   const isLogoutEnabled =
     !isThirdParty || serviceSupports('onLogoutRequestProvided');
-  const isProfileEnabled =
-    /* isThirdParty || */ store.isFeatureEnabled('client_new_profile');
+  const isProfileEnabled = /* isThirdParty || */ store.isFeatureEnabled(
+    'client_user_profile'
+  );
 
   const onSelectNotebook = () => {
     frameSync.notifyHost('openNotebook', store.focusedGroupId());

--- a/src/sidebar/components/test/HypothesisApp-test.js
+++ b/src/sidebar/components/test/HypothesisApp-test.js
@@ -120,6 +120,10 @@ describe('HypothesisApp', () => {
       contentComponent: 'NotebookView',
     },
     {
+      route: 'profile',
+      contentComponent: 'ProfileView',
+    },
+    {
       route: 'stream',
       contentComponent: 'StreamView',
     },

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -242,7 +242,7 @@ describe('UserMenu', () => {
         fakeIsThirdPartyUser.returns(isThirdParty);
 
         const wrapper = createUserMenu();
-        const openProfileItem = findMenuItem(wrapper, 'Open profile');
+        const openProfileItem = findMenuItem(wrapper, 'Your profile');
 
         assert.equal(
           isFeatureEnabled && isThirdParty,
@@ -256,7 +256,7 @@ describe('UserMenu', () => {
       fakeIsThirdPartyUser.returns(true);
 
       const wrapper = createUserMenu();
-      const openProfileItem = findMenuItem(wrapper, 'Open profile');
+      const openProfileItem = findMenuItem(wrapper, 'Your profile');
 
       openProfileItem.props().onClick();
       assert.calledOnce(fakeFrameSync.notifyHost);

--- a/src/sidebar/services/router.js
+++ b/src/sidebar/services/router.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {'annotation'|'notebook'|'stream'|'sidebar'} RouteName
+ * @typedef {'annotation'|'notebook'|'profile'|'stream'|'sidebar'} RouteName
  * @typedef {Record<string,string>} RouteParams
  */
 
@@ -58,6 +58,9 @@ export class RouterService {
       case 'notebook':
         route = 'notebook';
         break;
+      case 'user-profile':
+        route = 'profile';
+        break;
       case 'stream':
         route = 'stream';
         break;
@@ -89,6 +92,9 @@ export class RouterService {
         break;
       case 'notebook':
         url = '/notebook';
+        break;
+      case 'profile':
+        url = '/user-profile';
         break;
       case 'stream':
         url = '/stream';

--- a/src/sidebar/services/test/router-test.js
+++ b/src/sidebar/services/test/router-test.js
@@ -16,6 +16,11 @@ const fixtures = [
     params: {},
   },
   {
+    path: '/user-profile',
+    route: 'profile',
+    params: {},
+  },
+  {
     path: '/a/foo',
     route: 'annotation',
     params: { id: 'foo' },

--- a/src/sidebar/store/modules/route.js
+++ b/src/sidebar/store/modules/route.js
@@ -1,7 +1,7 @@
 import { createStoreModule, makeAction } from '../create-store';
 
 /**
- * @typedef {'annotation'|'notebook'|'sidebar'|'stream'} RouteName
+ * @typedef {'annotation'|'notebook'|'profile'|'sidebar'|'stream'} RouteName
  */
 
 const initialState = {

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -194,6 +194,11 @@ export type SidebarToHostEvent =
   | 'openNotebook'
 
   /**
+   * The sidebar is asking the host to open the profile.
+   */
+  | 'openProfile'
+
+  /**
    * The sidebar is asking the host to open the sidebar (side-effect of creating
    * an annotation).
    */

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -194,7 +194,7 @@ export type SidebarToHostEvent =
   | 'openNotebook'
 
   /**
-   * The sidebar is asking the host to open the profile.
+   * The sidebar is asking the host to open the user profile.
    */
   | 'openProfile'
 


### PR DESCRIPTION
This PR has been split and is superseeded by:

* [User profile initial config](https://github.com/hypothesis/client/pull/5215) (*ready to review*)
  * └── [Add 'Your profile' item to UserMenu]() (*ready to review*)
    *  └── [User profile modal](https://github.com/hypothesis/client/pull/5217) (*draft*)

Separated reviews can be performed there.

---

This adds a new optional entry in the `UserMenu`, and prepares all the configurations and docs for the upcoming profile mini-app.

For now only the minimum logic required to open the new mini-app has been implemented. Once opened, it just loads an empty component.

![image](https://user-images.githubusercontent.com/2719332/216314916-b78cd156-4c89-4299-9d64-f3fb92564355.png)

### Test steps:

The new entry point is displayed in the menu only for LMS users that have the new `client_user_profile` flag enabled, so this needs to be tested from an LMS.

1. Checkout to this branch.
1. Checkout to the `profile-mini-app` branch in your local instance of `h`.
1. Login with an admin account (like `devdata_admin`), then go to http://localhost:5000/admin/features and enable `client_user_profile` (for "everyone" is ok).
1. Open an assignment on the LMS of your choice.
1. Open the sidebar and log-in if needed.
1. Click on the user icon. The menu should include the "Open profile" option.
1. Click on it to open the profile modal.
1. It should also be possible to close the profile modal and get back to the sidebar.
1. The menu entry should not be displayed for users without `client_user_profile` enabled, even in an LMS.
1. The menu entry should not be displayed outside of an LMS.

### Todo:

- [ ] Add basic tests for `profile.ts`, so that we can later potentially refactor it confidently.
- [ ] Add basic tests for `ProfileModal`, so that we can later refactor it confidently.

### Not covered

Right know the possible user flows are:

* Sidebar is open -> The user opens the notebook, which hides the sidebar.
* Notebook is open -> The user closes it, which hides the notebook and shows the sidebar.
* Sidebar is open -> The user opens the profile, which hides the sidebar.
* Profile is open -> The user closes it, which hides the profile and shows the sidebar.

I have not covered what would happen if the notebook is open and the user opens the profile, or the other way around, because those actions are not possible via the standard UI, and would introduce a lot of complexity.