### PR TITLE
Add 'Your profile' item to UserMenu

### DIFF
--- a/src/sidebar/components/UserMenu.tsx
+++ b/src/sidebar/components/UserMenu.tsx
@@ -45,16 +45,21 @@ function UserMenu({ frameSync, onLogout, settings }: UserMenuProps) {
     !isThirdParty || serviceSupports('onProfileRequestProvided');
   const isLogoutEnabled =
     !isThirdParty || serviceSupports('onLogoutRequestProvided');
+  const isProfileEnabled = store.isFeatureEnabled('client_user_profile');
 
   const onSelectNotebook = () => {
     frameSync.notifyHost('openNotebook', store.focusedGroupId());
   };
+  const onSelectProfile = () => frameSync.notifyHost('openProfile');
 
   // Access to the Notebook:
   // type the key 'n' when user menu is focused/open
   const onKeyDown = (event: KeyboardEvent) => {
     if (event.key === 'n') {
       onSelectNotebook();
+      setOpen(false);
+    } else if (isProfileEnabled && event.key === 'p') {
+      onSelectProfile();
       setOpen(false);
     }
   };
@@ -94,6 +99,9 @@ function UserMenu({ frameSync, onLogout, settings }: UserMenuProps) {
               label="Account settings"
               href={store.getLink('account.settings')}
             />
+          )}
+          {isProfileEnabled && (
+            <MenuItem label="Your profile" onClick={() => onSelectProfile()} />
           )}
           <MenuItem label="Open notebook" onClick={() => onSelectNotebook()} />
         </MenuSection>

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -194,6 +194,11 @@ export type SidebarToHostEvent =
   | 'openNotebook'
 
   /**
+   * The sidebar is asking the host to open the user profile.
+   */
+  | 'openProfile'
+
+  /**
    * The sidebar is asking the host to open the sidebar (side-effect of creating
    * an annotation).
    */


### PR DESCRIPTION
This pull request adds a new menu item `Your profile` that is dynamically displayed in the `UserMenu` for users which have the `client_user_profile` feature flag enabled.

For now, this item just broadcasts an `openProfile` message to the host frame, but there's no logic attached to it yet. It will come on the next pull request.

The intention is to display a modal with a new mini-app on it, similar to the `notebook`.

![image](https://user-images.githubusercontent.com/2719332/216614721-c4a7c488-de38-44cc-87a9-0e29211693c9.png)

### Testing steps

1. Checkout to this branch.
1. Checkout to the `profile-mini-app` branch in your local instance of `h`.
1. Login with an admin account (like `devdata_admin`), then go to http://localhost:5000/admin/features and enable `client_user_profile` (for "everyone" is ok).
1. Go to http://localhost:3000
1. Open the sidebar.
1. Click on the user icon. The menu should include the "Your profile" option.
1. Pressing the `p` key should hide the menu.
1. The menu entry should not be displayed for users without `client_user_profile` enabled

> This PR takes part of the work done in https://github.com/hypothesis/client/pull/5214