### PR TITLE
User profile modal

### DIFF
--- a/src/annotator/components/ProfileModal.tsx
+++ b/src/annotator/components/ProfileModal.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from 'preact/hooks';
-import classnames from 'classnames';
 import { CancelIcon, IconButton } from '@hypothesis/frontend-shared/lib/next';
+import classnames from 'classnames';
+import { useEffect, useRef, useState } from 'preact/hooks';
 
 import type { Emitter, EventBus } from '../util/emitter';
 
@@ -14,11 +14,15 @@ type ProfileModalProps = {
 export function ProfileModal({ eventBus, config }: ProfileModalProps) {
   const [isHidden, setIsHidden] = useState(true);
   const emitterRef = useRef<Emitter | null>(null);
+  // Used only to track when was this modal first open, delaying the iframe to
+  // be loaded until strictly necessary.
+  const [hasOpened, setHasOpened] = useState(false);
 
   useEffect(() => {
     const emitter = eventBus.createEmitter();
     emitter.subscribe('openProfile', () => {
       setIsHidden(false);
+      setHasOpened(true);
     });
     emitterRef.current = emitter;
 
@@ -31,6 +35,10 @@ export function ProfileModal({ eventBus, config }: ProfileModalProps) {
     setIsHidden(true);
     emitterRef.current?.publish('closeProfile');
   };
+
+  if (!hasOpened) {
+    return null;
+  }
 
   return (
     <div

--- a/src/annotator/components/ProfileModal.tsx
+++ b/src/annotator/components/ProfileModal.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+import classnames from 'classnames';
+import { CancelIcon, IconButton } from '@hypothesis/frontend-shared/lib/next';
+
+import type { Emitter, EventBus } from '../util/emitter';
+
+export type ProfileConfig = { profileAppUrl: string } & Record<string, unknown>;
+
+type ProfileModalProps = {
+  eventBus: EventBus;
+  config: ProfileConfig;
+};
+
+export function ProfileModal({ eventBus, config }: ProfileModalProps) {
+  const [isHidden, setIsHidden] = useState(true);
+  const emitterRef = useRef<Emitter | null>(null);
+
+  useEffect(() => {
+    const emitter = eventBus.createEmitter();
+    emitter.subscribe('openProfile', () => {
+      setIsHidden(false);
+    });
+    emitterRef.current = emitter;
+
+    return () => {
+      emitter.destroy();
+    };
+  }, [eventBus]);
+
+  const onClose = () => {
+    setIsHidden(true);
+    emitterRef.current?.publish('closeProfile');
+  };
+
+  return (
+    <div
+      className={classnames(
+        'fixed z-max top-0 left-0 right-0 bottom-0 p-3 bg-black/50',
+        { hidden: isHidden }
+      )}
+      data-testid="profile-outer"
+    >
+      <div className="relative w-full h-full" data-testid="profile-inner">
+        <div className="absolute right-0 m-3">
+          <IconButton
+            title="Close the Profile"
+            onClick={onClose}
+            variant="dark"
+            classes={classnames(
+              // Remove the dark variant's background color to avoid
+              // interfering with modal overlays. Re-activate the dark variant's
+              // background color on hover.
+              // See https://github.com/hypothesis/client/issues/3676
+              '!bg-transparent enabled:hover:!bg-grey-3'
+            )}
+          >
+            <CancelIcon className="w-4 h-4" />
+          </IconButton>
+        </div>
+        <iframe
+          title={'Hypothesis profile'}
+          className="h-full w-full border-0"
+          src={config.profileAppUrl}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/annotator/components/test/ProfileModal-test.js
+++ b/src/annotator/components/test/ProfileModal-test.js
@@ -1,0 +1,75 @@
+import { act } from 'preact/test-utils';
+import { mount } from 'enzyme';
+
+import { EventBus } from '../../util/emitter';
+import { ProfileModal } from '../ProfileModal';
+
+describe('ProfileModal', () => {
+  const profileURL = 'https://test.hypothes.is/user-profile';
+
+  let components;
+  let eventBus;
+  let emitter;
+
+  const outerSelector = '[data-testid="profile-outer"]';
+
+  const createComponent = config => {
+    const component = mount(
+      <ProfileModal
+        eventBus={eventBus}
+        config={{ profileAppUrl: profileURL, ...config }}
+      />
+    );
+    components.push(component);
+    return component;
+  };
+
+  beforeEach(() => {
+    components = [];
+    eventBus = new EventBus();
+    emitter = eventBus.createEmitter();
+  });
+
+  afterEach(() => {
+    components.forEach(component => component.unmount());
+  });
+
+  it('hides modal on first render', () => {
+    const wrapper = createComponent();
+    const outer = wrapper.find(outerSelector);
+
+    assert.isTrue(outer.hasClass('hidden'));
+  });
+
+  it('shows modal on "openProfile" event', () => {
+    const wrapper = createComponent();
+
+    emitter.publish('openProfile', 'myGroup');
+    wrapper.update();
+
+    const outer = wrapper.find(outerSelector);
+    assert.isFalse(outer.hasClass('hidden'));
+
+    const iframe = wrapper.find('iframe');
+    assert.equal(iframe.prop('src'), profileURL);
+  });
+
+  it('hides modal on closing', () => {
+    const wrapper = createComponent();
+
+    emitter.publish('openProfile', 'myGroup');
+    wrapper.update();
+
+    let outer = wrapper.find(outerSelector);
+    assert.isFalse(outer.hasClass('hidden'));
+
+    act(() => {
+      wrapper.find('IconButton').prop('onClick')();
+    });
+    wrapper.update();
+
+    outer = wrapper.find(outerSelector);
+
+    assert.isTrue(outer.hasClass('hidden'));
+  });
+});

--- a/src/annotator/components/test/ProfileModal-test.js
+++ b/src/annotator/components/test/ProfileModal-test.js
@@ -1,5 +1,5 @@
-import { act } from 'preact/test-utils';
 import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
 
 import { EventBus } from '../../util/emitter';
 import { ProfileModal } from '../ProfileModal';
@@ -34,17 +34,15 @@ describe('ProfileModal', () => {
     components.forEach(component => component.unmount());
   });
 
-  it('hides modal on first render', () => {
+  it('does not render anything before the modal has been opened at least once', () => {
     const wrapper = createComponent();
-    const outer = wrapper.find(outerSelector);
-
-    assert.isTrue(outer.hasClass('hidden'));
+    assert.equal(wrapper.find(outerSelector).length, 0);
   });
 
   it('shows modal on "openProfile" event', () => {
     const wrapper = createComponent();
 
-    emitter.publish('openProfile', 'myGroup');
+    emitter.publish('openProfile');
     wrapper.update();
 
     const outer = wrapper.find(outerSelector);
@@ -57,7 +55,7 @@ describe('ProfileModal', () => {
   it('hides modal on closing', () => {
     const wrapper = createComponent();
 
-    emitter.publish('openProfile', 'myGroup');
+    emitter.publish('openProfile');
     wrapper.update();
 
     let outer = wrapper.find(outerSelector);

--- a/src/annotator/index.ts
+++ b/src/annotator/index.ts
@@ -10,6 +10,7 @@ import {
 import type { Destroyable } from '../types/annotator';
 import type { NotebookConfig } from './components/NotebookModal';
 import { getConfig } from './config/index';
+import type { ProfileConfig } from './components/ProfileModal';
 import { Guest } from './guest';
 import type { GuestConfig } from './guest';
 import {
@@ -22,6 +23,7 @@ import {
   vitalSourceFrameRole,
 } from './integrations/vitalsource';
 import { Notebook } from './notebook';
+import { Profile } from './profile';
 import { Sidebar } from './sidebar';
 import type { SidebarConfig } from './sidebar';
 import { EventBus } from './util/emitter';
@@ -74,11 +76,16 @@ function init() {
       eventBus,
       getConfig('notebook') as NotebookConfig
     );
+    const profile = new Profile(
+      document.body,
+      eventBus,
+      getConfig('profile') as ProfileConfig
+    );
 
     portProvider.on('frameConnected', (source, port) =>
       sidebar.onFrameConnected(source, port)
     );
-    destroyables.push(portProvider, sidebar, notebook);
+    destroyables.push(portProvider, sidebar, notebook, profile);
   }
 
   const vsFrameRole = vitalSourceFrameRole();

--- a/src/annotator/index.ts
+++ b/src/annotator/index.ts
@@ -9,8 +9,8 @@ import {
 } from '../shared/messaging';
 import type { Destroyable } from '../types/annotator';
 import type { NotebookConfig } from './components/NotebookModal';
-import { getConfig } from './config/index';
 import type { ProfileConfig } from './components/ProfileModal';
+import { getConfig } from './config/index';
 import { Guest } from './guest';
 import type { GuestConfig } from './guest';
 import {

--- a/src/annotator/profile.tsx
+++ b/src/annotator/profile.tsx
@@ -1,7 +1,6 @@
 import { render } from 'preact';
 
 import type { Destroyable } from '../types/annotator';
-
 import type { ProfileConfig } from './components/ProfileModal';
 import { ProfileModal } from './components/ProfileModal';
 import type { EventBus } from './util/emitter';

--- a/src/annotator/profile.tsx
+++ b/src/annotator/profile.tsx
@@ -1,0 +1,29 @@
+import { render } from 'preact';
+
+import type { Destroyable } from '../types/annotator';
+
+import type { ProfileConfig } from './components/ProfileModal';
+import { ProfileModal } from './components/ProfileModal';
+import type { EventBus } from './util/emitter';
+import { createShadowRoot } from './util/shadow-root';
+
+export class Profile implements Destroyable {
+  private _outerContainer: HTMLElement;
+  public shadowRoot: ShadowRoot;
+
+  constructor(element: HTMLElement, eventBus: EventBus, config: ProfileConfig) {
+    this._outerContainer = document.createElement('hypothesis-profile');
+    element.appendChild(this._outerContainer);
+    this.shadowRoot = createShadowRoot(this._outerContainer);
+
+    render(
+      <ProfileModal eventBus={eventBus} config={config} />,
+      this.shadowRoot
+    );
+  }
+
+  destroy(): void {
+    render(null, this.shadowRoot);
+    this._outerContainer.remove();
+  }
+}

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -369,8 +369,9 @@ export class Sidebar {
 
     this._sidebarRPC.on('closeSidebar', () => this.close());
 
-    // Sidebar listens to the `openNotebook` event coming from the sidebar's
-    // iframe and re-publishes it via the emitter to the Notebook
+    // Sidebar listens to the `openNotebook` and `openProfile` events coming
+    // from the sidebar's iframe and re-publishes it via the emitter to the
+    // Notebook/Profile
     this._sidebarRPC.on(
       'openNotebook',
       /** @param {string} groupId */
@@ -379,6 +380,13 @@ export class Sidebar {
         this._emitter.publish('openNotebook', groupId);
       }
     );
+    this._sidebarRPC.on('openProfile', () => {
+      this.hide();
+      this._emitter.publish('openProfile');
+    });
+    this._emitter.subscribe('closeProfile', () => {
+      this.show();
+    });
 
     this._emitter.subscribe('closeNotebook', () => {
       this.show();

--- a/src/annotator/test/profile-test.js
+++ b/src/annotator/test/profile-test.js
@@ -1,0 +1,74 @@
+import { useEffect } from 'preact/hooks';
+import { act } from 'preact/test-utils';
+
+import { Profile, $imports } from '../profile';
+import { EventBus } from '../util/emitter';
+
+describe('Profile', () => {
+  // `Profile` instances created by current test
+  let profiles;
+  let container;
+  let cleanUpCallback;
+
+  const createProfile = (config = {}) => {
+    const eventBus = new EventBus();
+    const profile = new Profile(container, eventBus, config);
+
+    profiles.push(profile);
+
+    return profile;
+  };
+
+  beforeEach(() => {
+    profiles = [];
+    container = document.createElement('div');
+    cleanUpCallback = sinon.stub();
+
+    const FakeProfileModal = () => {
+      useEffect(() => {
+        return () => {
+          cleanUpCallback();
+        };
+      }, []);
+      return <div id="profile-modal" />;
+    };
+
+    $imports.$mock({
+      './components/ProfileModal': { ProfileModal: FakeProfileModal },
+    });
+  });
+
+  afterEach(() => {
+    profiles.forEach(n => n.destroy());
+    $imports.$restore();
+  });
+
+  describe('profile container', () => {
+    it('creates the container', () => {
+      assert.isFalse(container.hasChildNodes());
+      const profile = createProfile();
+      const shadowRoot = profile._outerContainer.shadowRoot;
+      assert.isNotNull(shadowRoot);
+      assert.isNotNull(shadowRoot.querySelector('#profile-modal'));
+    });
+
+    it('removes the container', () => {
+      const profile = createProfile();
+      profile.destroy();
+      assert.isFalse(container.hasChildNodes());
+    });
+
+    it('calls the clean up function of the ProfileModal when the container is removed', () => {
+      // Necessary to run the useEffect for first time and register the cleanup function
+      let profile;
+      act(() => {
+        profile = createProfile();
+      });
+      // Necessary to run the cleanup function of the useEffect
+      act(() => {
+        profile.destroy();
+      });
+      assert.called(cleanUpCallback);
+    });
+  });
+});

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -380,6 +380,28 @@ describe('Sidebar', () => {
       });
     });
 
+    describe('on "openProfile" event', () => {
+      it('hides the sidebar', () => {
+        const sidebar = createSidebar();
+        sinon.stub(sidebar, 'hide').callThrough();
+        sinon.stub(sidebar._emitter, 'publish');
+        emitSidebarEvent('openProfile');
+        assert.calledWith(sidebar._emitter.publish, 'openProfile');
+        assert.calledOnce(sidebar.hide);
+        assert.notEqual(sidebar.iframeContainer.style.visibility, 'hidden');
+      });
+    });
+
+    describe('on "closeProfile" internal event', () => {
+      it('shows the sidebar', () => {
+        const sidebar = createSidebar();
+        sinon.stub(sidebar, 'show').callThrough();
+        sidebar._emitter.publish('closeProfile');
+        assert.calledOnce(sidebar.show);
+        assert.equal(sidebar.iframeContainer.style.visibility, '');
+      });
+    });
+
     describe('on "loginRequested" event', () => {
       it('calls the onLoginRequest callback function if one was provided', () => {
         const onLoginRequest = sandbox.stub();

--- a/src/shared/messaging/port-provider.js
+++ b/src/shared/messaging/port-provider.js
@@ -22,16 +22,18 @@ import { isMessage, isMessageEqual, isSourceWindow } from './port-util';
  *    where either (1) the hypothesis client has been injected or (2) the
  *    hypothesis client has been configured to act exclusively as a `guest` (not
  *    showing the sidebar).
- * - `notebook`: another hypothesis app that runs in a separate iframe.
- * - `sidebar`: the main hypothesis app. It runs in an iframe on a different
- *    origin than the host and is responsible for the communication with the
- *    backend (fetching and saving annotations).
+ * - `notebook` and `profile`: front-end app views that each have their own
+ *    iframe.
+ * - `sidebar`: the main hypothesis front-end app. It runs in an iframe on a
+ *    different origin than the host and is responsible for the communication
+ *    with the backend (fetching and saving annotations).
  *
  * This layout represents the current arrangement of frames:
  *
  * `host` frame
  * |-> `sidebar` iframe
  * |-> `notebook` iframe
+ * |-> `profile` iframe
  * |-> [`guest` iframes]
  *
  * Currently, we support communication between the following pairs of frames:

--- a/src/shared/messaging/port-util.js
+++ b/src/shared/messaging/port-util.js
@@ -2,7 +2,7 @@
  * Message sent by `PortProvider` and `PortFinder` to establish a
  * MessageChannel-based connection between two frames.
  *
- * @typedef {'guest'|'host'|'notebook'|'sidebar'} Frame
+ * @typedef {'guest'|'host'|'notebook'|'profile'|'sidebar'} Frame
  *
  * @typedef Message
  * @prop {Frame} frame1 - Role of the source frame

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -10,6 +10,7 @@ import { useSidebarStore } from '../store';
 import AnnotationView from './AnnotationView';
 import HelpPanel from './HelpPanel';
 import NotebookView from './NotebookView';
+import ProfileView from './ProfileView';
 import ShareAnnotationsPanel from './ShareAnnotationsPanel';
 import SidebarView from './SidebarView';
 import StreamView from './StreamView';
@@ -41,6 +42,7 @@ function HypothesisApp({ auth, frameSync, settings, session, toastMessenger }) {
   const store = useSidebarStore();
   const profile = store.profile();
   const route = store.route();
+  const isModalRoute = route === 'notebook' || route === 'profile';
 
   const backgroundStyle = useMemo(
     () => applyTheme(['appBackgroundColor'], settings),
@@ -135,15 +137,15 @@ function HypothesisApp({ auth, frameSync, settings, session, toastMessenger }) {
         {
           'theme-clean': isThemeClean,
           // Make room at top for the TopBar (40px) plus custom padding (9px)
-          // but not in the Notebook, which doesn't use the TopBar
-          'pt-[49px]': route !== 'notebook',
-          'p-4 lg:p-12': route === 'notebook',
+          // but not in the Notebook or Profile, which don't use the TopBar
+          'pt-[49px]': !isModalRoute,
+          'p-4 lg:p-12': isModalRoute,
         }
       )}
       data-testid="hypothesis-app"
       style={backgroundStyle}
     >
-      {route !== 'notebook' && (
+      {!isModalRoute && (
         <TopBar
           onLogin={login}
           onSignUp={signUp}
@@ -160,6 +162,7 @@ function HypothesisApp({ auth, frameSync, settings, session, toastMessenger }) {
           <main>
             {route === 'annotation' && <AnnotationView onLogin={login} />}
             {route === 'notebook' && <NotebookView />}
+            {route === 'profile' && <ProfileView />}
             {route === 'stream' && <StreamView />}
             {route === 'sidebar' && (
               <SidebarView onLogin={login} onSignUp={signUp} />

--- a/src/sidebar/components/ProfileView.tsx
+++ b/src/sidebar/components/ProfileView.tsx
@@ -1,3 +1,4 @@
+/* istanbul ignore next - this is a temporary dummy implementation */
 export default function ProfileView() {
   return <div className="text-center">Profile</div>;
 }

--- a/src/sidebar/components/ProfileView.tsx
+++ b/src/sidebar/components/ProfileView.tsx
@@ -1,0 +1,3 @@
+export default function ProfileView() {
+  return <div className="text-center">Profile</div>;
+}

--- a/src/sidebar/components/test/HypothesisApp-test.js
+++ b/src/sidebar/components/test/HypothesisApp-test.js
@@ -120,6 +120,10 @@ describe('HypothesisApp', () => {
       contentComponent: 'NotebookView',
     },
     {
+      route: 'profile',
+      contentComponent: 'ProfileView',
+    },
+    {
       route: 'stream',
       contentComponent: 'StreamView',
     },


### PR DESCRIPTION
This pull request introduces the logic needed to display the new user profile mini-app when clicking in the `Your profile` entry point introduced in https://github.com/hypothesis/client/pull/5216.

### Testing steps

1. Follow the steps from https://github.com/hypothesis/client/pull/5216.
2. It should be possible to open the modal by:
    * Clicking on "Your profile"
    * Pressing the `p` key.
3. It should be possible to also close the modal by clicking on the close button.

### Todo

- [x] Add basic tests for `profile.ts`, so that we can later potentially refactor it confidently.
- [x] Add basic tests for `ProfileModal`, so that we can later refactor it confidently.
- [x] Add tests for new logic in `sidebar.js`

Refs: #5213 

> This PR takes part of the work done in https://github.com/hypothesis/client/pull/5214