### PR TITLE
Make sure user profile modal is not added to the DOM until it's opened for the first time

### DIFF
--- a/src/annotator/components/ProfileModal.tsx
+++ b/src/annotator/components/ProfileModal.tsx
@@ -14,11 +14,15 @@ type ProfileModalProps = {
 export function ProfileModal({ eventBus, config }: ProfileModalProps) {
   const [isHidden, setIsHidden] = useState(true);
   const emitterRef = useRef<Emitter | null>(null);
+  // Used only to track when was this modal first open, delaying the iframe to
+  // be loaded until strictly necessary.
+  const [hasOpened, setHasOpened] = useState(false);
 
   useEffect(() => {
     const emitter = eventBus.createEmitter();
     emitter.subscribe('openProfile', () => {
       setIsHidden(false);
+      setHasOpened(true);
     });
     emitterRef.current = emitter;
 
@@ -31,6 +35,10 @@ export function ProfileModal({ eventBus, config }: ProfileModalProps) {
     setIsHidden(true);
     emitterRef.current?.publish('closeProfile');
   };
+
+  if (!hasOpened) {
+    return null;
+  }
 
   return (
     <div

--- a/src/annotator/components/test/ProfileModal-test.js
+++ b/src/annotator/components/test/ProfileModal-test.js
@@ -34,17 +34,15 @@ describe('ProfileModal', () => {
     components.forEach(component => component.unmount());
   });
 
-  it('hides modal on first render', () => {
+  it('does not render anything before the modal has been opened at least once', () => {
     const wrapper = createComponent();
-    const outer = wrapper.find(outerSelector);
-
-    assert.isTrue(outer.hasClass('hidden'));
+    assert.equal(wrapper.find(outerSelector).length, 0);
   });
 
   it('shows modal on "openProfile" event', () => {
     const wrapper = createComponent();
 
-    emitter.publish('openProfile', 'myGroup');
+    emitter.publish('openProfile');
     wrapper.update();
 
     const outer = wrapper.find(outerSelector);
@@ -57,7 +55,7 @@ describe('ProfileModal', () => {
   it('hides modal on closing', () => {
     const wrapper = createComponent();
 
-    emitter.publish('openProfile', 'myGroup');
+    emitter.publish('openProfile');
     wrapper.update();
 
     let outer = wrapper.find(outerSelector);


### PR DESCRIPTION
> This PR was initially going to be part of https://github.com/hypothesis/client/pull/5217, but I thought it would hide the specific change and was better to split it.
>
> However, #5217 should not be merged without this, so this PR needs to be merged first.

This PR adds logic to make sure the `ProfileModal` does not render anything until it has been opened for the first time, to make sure we don't waste resources and network requests loading something that will not be used in most of the cases.

The way it's done is by setting a boolean state which is initially `false` and when the `'openProfile'` event is triggered, we toggle its value to `true`.

### Testing steps

1. Follow the steps on https://github.com/hypothesis/client/pull/5217.
2. Go to http://localhost:3000/, inspect the DOM, and make sure the `<hypothesis-profile />` element only contains a link.
![image](https://user-images.githubusercontent.com/2719332/217801467-2d34d6ed-cec9-4872-984e-a70c1d649db5.png)
3. Open the sidebar, click on the user icon, and click "Your profile". It will open a modal with dummy content
4. Inspect the DOM, and make sure the `<hypothesis-profile />` element now has some children.
![image](https://user-images.githubusercontent.com/2719332/217801777-3b61eab3-5851-4b2b-95ae-9662521cdcf8.png)

---

> 👇🏼 This is not relevant anymore. Working now.

However, there's an important consideration, **this logic does not work**. The reason is that it relies on the `useSidebarStore` hook in order to check for enabled features (for `client_user_profile` feature flag), but this hook cannot be invoked from outside the sidebar.

Possible next steps:

- ~Find a way to check for feature flags without relying on the `useSidebarStore` hook.~
- ~Find a way to make the `useSidebarStore` hook work outside the sidebar (I would discard this one because it's counterintuitive).~
- Simplify the whole approach and just set the flag to `true` when `'openProfile'` is triggered, considering the entry point triggering that event is already based on the `client_user_profile` feature flag. <- **This option was selected**