### PR TITLE
Convert SearchClient to TypeScript

### DIFF
--- a/src/sidebar/search-client.ts
+++ b/src/sidebar/search-client.ts
@@ -128,14 +128,14 @@ export class SearchClient extends TinyEmitter {
   async _getPage(query: SearchQuery, searchAfter?: string, pageIndex = 0) {
     const pageSize = this._getPageSize(pageIndex);
 
-    const searchQuery = {
+    const searchQuery: SearchQuery = {
       limit: pageSize,
       sort: this._sortBy,
       order: this._sortOrder,
       _separate_replies: this._separateReplies,
 
       ...query,
-    } as SearchQuery;
+    };
 
     if (searchAfter) {
       searchQuery.search_after = searchAfter;


### PR DESCRIPTION
Convert SearchClient to TS and improve the class documentation to better explain its responsibilities.

This is preparation for adding a client-side fix for https://github.com/hypothesis/client/issues/5219.