### PR TITLE
Update `prompts` module to use updated `Modal` component

### DIFF
--- a/src/shared/prompts.tsx
+++ b/src/shared/prompts.tsx
@@ -2,27 +2,29 @@ import { render } from 'preact';
 
 import { ConfirmModal } from '@hypothesis/frontend-shared';
 
+export type ConfirmModalProps = {
+  title?: string;
+  message: string;
+  confirmAction?: string;
+};
+
 /**
  * Show the user a prompt asking them to confirm an action.
  *
  * This is like an async version of `window.confirm` except that:
  *
- *  - It can be used inside iframes (browsers are starting to prevent this
- *    for the native `window.confirm` dialog)
+ *  - It can be used inside iframes (browsers are starting to prevent this for
+ *    the native `window.confirm` dialog)
  *  - The visual style of the dialog matches the Hypothesis design system
  *
- * @param {object} options - Options for the `ConfirmModal`
- *   @param {string} [options.title]
- *   @param {string} options.message
- *   @param {string} [options.confirmAction]
- * @return {Promise<boolean>} - Promise that resolves with `true` if the user
- *   confirmed the action or `false` if they canceled it.
+ * @return - Promise that resolves with `true` if the user confirmed the action
+ *   or `false` if they canceled it.
  */
 export async function confirm({
   title = 'Confirm',
   message,
   confirmAction = 'Yes',
-}) {
+}: ConfirmModalProps): Promise<boolean> {
   const container = document.createElement('div');
   container.setAttribute('data-testid', 'confirm-container');
 
@@ -34,8 +36,7 @@ export async function confirm({
   document.body.appendChild(container);
 
   return new Promise(resolve => {
-    /** @param {boolean} result */
-    const close = result => {
+    const close = (result: boolean) => {
       render(null, container);
       container.remove();
       resolve(result);

--- a/src/shared/prompts.tsx
+++ b/src/shared/prompts.tsx
@@ -1,10 +1,11 @@
 import { render } from 'preact';
+import type { ComponentChildren } from 'preact';
 
-import { ConfirmModal } from '@hypothesis/frontend-shared';
+import { Button, Modal } from '@hypothesis/frontend-shared/lib/next';
 
 export type ConfirmModalProps = {
   title?: string;
-  message: string;
+  message: ComponentChildren;
   confirmAction?: string;
 };
 
@@ -43,13 +44,26 @@ export async function confirm({
     };
 
     render(
-      <ConfirmModal
+      <Modal
+        buttons={
+          <>
+            <Button data-testid="cancel-button" onClick={() => close(false)}>
+              Cancel
+            </Button>
+            <Button
+              data-testid="confirm-button"
+              variant="primary"
+              onClick={() => close(true)}
+            >
+              {confirmAction}
+            </Button>
+          </>
+        }
         title={title}
-        message={message}
-        confirmAction={confirmAction}
-        onConfirm={() => close(true)}
-        onCancel={() => close(false)}
-      />,
+        onClose={() => close(false)}
+      >
+        {message}
+      </Modal>,
       container
     );
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,9 +1139,9 @@
     glob "^7.2.0"
 
 "@hypothesis/frontend-shared@^5.6.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.7.0.tgz#be76d200c15ba3e889738f7226a5b87207766ef8"
-  integrity sha512-qB5+WhvXUha73QjZPkN4losbpKZQt2sL4zhblW3URBs3aWE9HYZFpI7V+QuvyYRdtSyCTHQohWn5pnXrtek+WA==
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.8.0.tgz#c32774578d8179508b84429ef41dd040a7285636"
+  integrity sha512-ObJQj9smBPbjiyEJmSIF1zPSy+4m95WL0oAamPkMCWugBQtV7jfhuaYMLeXqKSqetFiIuVk2VevXYEblocEsaA==
   dependencies:
     highlight.js "^11.6.0"
 


### PR DESCRIPTION
This PR:

* Converts the `prompts` module to TSX
* Bumps the `@hypothesis/frontend-shared` package to v5.8.0
* Replaces deprecated `ConfirmModal` usage in `prompts` with updated `Modal`

The API for the `confirm` function is backwards-compatible. The `message` type has been broadened from `string` to `ComponentChildren` for future ergonomics.

User-facing changes should be confined to the slight proportional updates that are introduced in the newer `Panel` component (`Modal` renders a `Panel`).

You can see a confirm-modal in play by:

* Clicking the "Delete" icon-button in an annotation card
* Logging out when there is an unsaved annotation draft
* Clicking the "Leave group" menu item in a group's submenu

<img width="428" alt="image" src="https://user-images.githubusercontent.com/439947/217329858-6c2ee726-eb61-4bf9-8730-02663bc57325.png">


`ConfirmModal` is the last legacy shared component in use in the client, so this is exciting...