### PR TITLE
Remove unused legacy shared-component CSS

### DIFF
--- a/src/styles/annotator/components/_index.scss
+++ b/src/styles/annotator/components/_index.scss
@@ -1,5 +1,4 @@
 @use 'tailwindcss/components';
-@use '@hypothesis/frontend-shared/styles';
 
 // Annotator-specific components.
 @use './sidebar';

--- a/src/styles/sidebar/components/_index.scss
+++ b/src/styles/sidebar/components/_index.scss
@@ -1,9 +1,5 @@
 @use 'tailwindcss/components';
 
-// Shared styles
-// -----------------
-@use '@hypothesis/frontend-shared/styles';
-
 // UI (Preact) Components
 // ----------
 @use './StyledText';


### PR DESCRIPTION
Now that all of the `client` components have been updated to use the newer batch of components from `frontend-shared`, we no longer need to include the old, non-Tailwind CSS.

This results in a significant reduction in built-CSS filesize for both `sidebar` and `annotator`; I will confirm exactly how much reduction once I see this build in production.

Locally, the size of `annotator` and `sidebar` CSS are reduced by ~43% and ~37% respectively.

## Testing

Check out this branch, restart your local dev server (to ensure CSS is rebuilt) and click around your local dev server. Everything should look as it did...