### PR TITLE
Add prettier plugin to automatically order imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@rollup/plugin-virtual": "^3.0.0",
     "@sentry/browser": "^7.1.1",
     "@sentry/cli": "^2.0.2",
+    "@trivago/prettier-plugin-sort-imports": "^4.0.0",
     "@types/dompurify": "^2.3.3",
     "@types/escape-html": "^1.0.1",
     "@types/hammerjs": "^2.0.41",
@@ -102,7 +103,10 @@
   "browserslist": "chrome 70, firefox 70, safari 11.1",
   "prettier": {
     "arrowParens": "avoid",
-    "singleQuote": true
+    "singleQuote": true,
+    "importOrder": ["^[./]"],
+    "importOrderSeparation": true,
+    "importOrderCaseInsensitive": true
   },
   "main": "./build/boot.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/showdown": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^5.35.1",
     "@typescript-eslint/parser": "^5.35.1",
+    "@vue/compiler-sfc": "./scripts/stub-package",
     "approx-string-match": "^2.0.0",
     "autoprefixer": "^10.0.1",
     "aws-sdk": "^2.345.0",
@@ -105,8 +106,7 @@
     "arrowParens": "avoid",
     "singleQuote": true,
     "importOrder": ["^[./]"],
-    "importOrderSeparation": true,
-    "importOrderCaseInsensitive": true
+    "importOrderSeparation": true
   },
   "main": "./build/boot.js",
   "scripts": {

--- a/scripts/stub-package/package.json
+++ b/scripts/stub-package/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vue/compiler-sfc",
+  "version": "3.0.0",
+  "description": "This is a workaround for a peer dependency on @trivago/prettier-plugin-sort-imports which is not properly marked as optional. To be removed once solved: https://github.com/trivago/prettier-plugin-sort-imports/issues/201",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/src/annotator/adder.tsx
+++ b/src/annotator/adder.tsx
@@ -1,10 +1,9 @@
 import { render } from 'preact';
 
-import AdderToolbar from './components/AdderToolbar';
-import type { Command } from './components/AdderToolbar';
 import { isTouchDevice } from '../shared/user-agent';
 import type { Destroyable } from '../types/annotator';
-
+import AdderToolbar from './components/AdderToolbar';
+import type { Command } from './components/AdderToolbar';
 import { createShadowRoot } from './util/shadow-root';
 
 export enum ArrowDirection {

--- a/src/annotator/anchoring/html.ts
+++ b/src/annotator/anchoring/html.ts
@@ -4,7 +4,6 @@ import type {
   TextPositionSelector,
   TextQuoteSelector,
 } from '../../types/api';
-
 import { RangeAnchor, TextPositionAnchor, TextQuoteAnchor } from './types';
 
 type Options = {

--- a/src/annotator/anchoring/pdf.ts
+++ b/src/annotator/anchoring/pdf.ts
@@ -1,18 +1,16 @@
 /* global PDFViewerApplication */
-
 import { warnOnce } from '../../shared/warn-once';
-import { translateOffsets } from '../util/normalize';
-import { matchQuote } from './match-quote';
-import { createPlaceholder } from './placeholder';
-import { TextPosition, TextRange } from './text-range';
-import { TextQuoteAnchor } from './types';
-
 import type {
   TextPositionSelector,
   TextQuoteSelector,
   Selector,
 } from '../../types/api';
 import type { PDFPageView, PDFViewer } from '../../types/pdfjs';
+import { translateOffsets } from '../util/normalize';
+import { matchQuote } from './match-quote';
+import { createPlaceholder } from './placeholder';
+import { TextPosition, TextRange } from './text-range';
+import { TextQuoteAnchor } from './types';
 
 type PDFTextRange = {
   pageIndex: number;

--- a/src/annotator/anchoring/test/fake-pdf-viewer-application.js
+++ b/src/annotator/anchoring/test/fake-pdf-viewer-application.js
@@ -9,7 +9,6 @@
  * each of the relevant classes in PDF.js. The APIs of the fakes should conform
  * to the corresponding interfaces defined in `src/types/pdfjs.js`.
  */
-
 import { TinyEmitter as EventEmitter } from 'tiny-emitter';
 
 import { RenderingStates } from '../pdf';

--- a/src/annotator/anchoring/test/html-baselines/index.js
+++ b/src/annotator/anchoring/test/html-baselines/index.js
@@ -20,10 +20,8 @@
 //  3. Fetch the annotations for the web page via the Hypothesis API and save
 //     them as `<fixture name>.json` in this directory
 //  4. Add an entry to the fixture list below.
-
 import minimalDoc from './minimal.html';
 import minimalJSON from './minimal.json';
-
 import wikipediaDoc from './wikipedia-regression-testing.html';
 import wikipediaJSON from './wikipedia-regression-testing.json';
 

--- a/src/annotator/anchoring/test/html-test.js
+++ b/src/annotator/anchoring/test/html-test.js
@@ -1,5 +1,4 @@
 import * as html from '../html';
-
 import fixture from './html-anchoring-fixture.html';
 import { htmlBaselines } from './html-baselines';
 

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -1,8 +1,7 @@
 import { delay } from '../../../test-util/wait';
-import * as pdfAnchoring from '../pdf';
 import { matchQuote } from '../match-quote';
+import * as pdfAnchoring from '../pdf';
 import { TextRange } from '../text-range';
-
 import { FakePDFViewerApplication } from './fake-pdf-viewer-application';
 
 /**

--- a/src/annotator/anchoring/test/text-range-test.js
+++ b/src/annotator/anchoring/test/text-range-test.js
@@ -1,6 +1,5 @@
-import { TextPosition, TextRange, ResolveDirection } from '../text-range';
-
 import { assertNodesEqual, textNodes } from '../../../test-util/compare-dom';
+import { TextPosition, TextRange, ResolveDirection } from '../text-range';
 
 const html = `
 <main>

--- a/src/annotator/anchoring/test/trim-range-test.js
+++ b/src/annotator/anchoring/test/trim-range-test.js
@@ -1,6 +1,6 @@
 import { textNodes } from '../../../test-util/compare-dom';
-import { trimRange } from '../trim-range';
 import { TextRange } from '../text-range';
+import { trimRange } from '../trim-range';
 
 describe('annotator/anchoring/trim-range', () => {
   let container;

--- a/src/annotator/anchoring/test/types-test.js
+++ b/src/annotator/anchoring/test/types-test.js
@@ -1,11 +1,10 @@
+import { TextRange } from '../text-range';
 import {
   RangeAnchor,
   TextPositionAnchor,
   TextQuoteAnchor,
   $imports,
 } from '../types';
-
-import { TextRange } from '../text-range';
 
 // These are primarily basic API tests for the anchoring classes. Tests for
 // anchoring a variety of HTML and PDF content exist in `html-test` and

--- a/src/annotator/anchoring/types.js
+++ b/src/annotator/anchoring/types.js
@@ -7,7 +7,6 @@
  *  2. Insulating the rest of the code from API changes in the underlying anchoring
  *     libraries.
  */
-
 import { matchQuote } from './match-quote';
 import { TextRange, TextPosition } from './text-range';
 import { nodeFromXPath, xpathFromNode } from './xpath';

--- a/src/annotator/bucket-bar-client.js
+++ b/src/annotator/bucket-bar-client.js
@@ -1,5 +1,4 @@
 import { ListenerCollection } from '../shared/listener-collection';
-
 import { computeAnchorPositions } from './util/buckets';
 
 /**

--- a/src/annotator/components/AdderToolbar.tsx
+++ b/src/annotator/components/AdderToolbar.tsx
@@ -1,4 +1,3 @@
-import classnames from 'classnames';
 import {
   AnnotateIcon,
   ButtonBase,
@@ -7,6 +6,7 @@ import {
   PointerUpIcon,
 } from '@hypothesis/frontend-shared/lib/next';
 import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
+import classnames from 'classnames';
 
 import { useShortcut } from '../../shared/shortcut';
 

--- a/src/annotator/components/ContentInfoBanner.js
+++ b/src/annotator/components/ContentInfoBanner.js
@@ -1,11 +1,10 @@
-import classnames from 'classnames';
-
 import {
   Link,
   LinkBase,
   CaretLeftIcon,
   CaretRightIcon,
 } from '@hypothesis/frontend-shared/lib/next';
+import classnames from 'classnames';
 
 /**
  * @typedef {import('../../types/annotator').ContentInfoConfig} ContentInfoConfig

--- a/src/annotator/components/NotebookModal.tsx
+++ b/src/annotator/components/NotebookModal.tsx
@@ -1,6 +1,6 @@
 import { IconButton, CancelIcon } from '@hypothesis/frontend-shared/lib/next';
-import { useEffect, useRef, useState } from 'preact/hooks';
 import classnames from 'classnames';
+import { useEffect, useRef, useState } from 'preact/hooks';
 
 import { addConfigFragment } from '../../shared/config-fragment';
 import { createAppConfig } from '../config/app';

--- a/src/annotator/components/Toolbar.tsx
+++ b/src/annotator/components/Toolbar.tsx
@@ -1,3 +1,4 @@
+import type { ButtonCommonProps } from '@hypothesis/frontend-shared/lib/components/input/ButtonBase';
 import {
   ButtonBase,
   AnnotateIcon,
@@ -12,7 +13,6 @@ import type {
   IconComponent,
   PresentationalProps,
 } from '@hypothesis/frontend-shared/lib/types';
-import type { ButtonCommonProps } from '@hypothesis/frontend-shared/lib/components/input/ButtonBase';
 import classnames from 'classnames';
 import type { JSX, RefObject } from 'preact';
 

--- a/src/annotator/components/test/ClusterToolbar-test.js
+++ b/src/annotator/components/test/ClusterToolbar-test.js
@@ -1,4 +1,5 @@
 import { mount } from 'enzyme';
+
 import {
   highlightStyles,
   defaultClusterStyles,

--- a/src/annotator/components/test/NotebookModal-test.js
+++ b/src/annotator/components/test/NotebookModal-test.js
@@ -1,5 +1,5 @@
-import { act } from 'preact/test-utils';
 import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
 
 import { addConfigFragment } from '../../../shared/config-fragment';
 import { EventBus } from '../../util/emitter';

--- a/src/annotator/components/test/Toolbar-test.js
+++ b/src/annotator/components/test/Toolbar-test.js
@@ -1,8 +1,7 @@
 import { mount } from 'enzyme';
 
-import Toolbar from '../Toolbar';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
+import Toolbar from '../Toolbar';
 
 const noop = () => {};
 

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -1,6 +1,6 @@
+import { toBoolean } from '../../shared/type-coercions';
 import { isBrowserExtension } from './is-browser-extension';
 import { settingsFrom } from './settings';
-import { toBoolean } from '../../shared/type-coercions';
 import { urlFromLinkTag } from './url-from-link-tag';
 
 /**

--- a/src/annotator/config/settings.js
+++ b/src/annotator/config/settings.js
@@ -1,7 +1,6 @@
-import { hasOwn } from '../../shared/has-own';
 import { parseJsonConfig } from '../../boot/parse-json-config';
+import { hasOwn } from '../../shared/has-own';
 import { toBoolean } from '../../shared/type-coercions';
-
 import { configFuncSettingsFrom } from './config-func-settings-from';
 import { urlFromLinkTag } from './url-from-link-tag';
 

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -4,27 +4,6 @@ import { ListenerCollection } from '../shared/listener-collection';
 import { PortFinder, PortRPC } from '../shared/messaging';
 import { generateHexString } from '../shared/random';
 import { matchShortcut } from '../shared/shortcut';
-
-import { Adder } from './adder';
-import { TextRange } from './anchoring/text-range';
-import { BucketBarClient } from './bucket-bar-client';
-import { HighlightClusterController } from './highlight-clusters';
-import { FeatureFlags } from './features';
-import {
-  getHighlightsContainingNode,
-  highlightRange,
-  removeAllHighlights,
-  removeHighlights,
-  setHighlightsFocused,
-  setHighlightsVisible,
-} from './highlighter';
-import { createIntegration } from './integrations';
-import * as rangeUtil from './range-util';
-import { SelectionObserver, selectedRange } from './selection-observer';
-import { findClosestOffscreenAnchor } from './util/buckets';
-import { frameFillsAncestor } from './util/frame';
-import { normalizeURI } from './util/url';
-
 import type {
   AnnotationData,
   Annotator,
@@ -42,6 +21,25 @@ import type {
   GuestToSidebarEvent,
   SidebarToGuestEvent,
 } from '../types/port-rpc-events';
+import { Adder } from './adder';
+import { TextRange } from './anchoring/text-range';
+import { BucketBarClient } from './bucket-bar-client';
+import { FeatureFlags } from './features';
+import { HighlightClusterController } from './highlight-clusters';
+import {
+  getHighlightsContainingNode,
+  highlightRange,
+  removeAllHighlights,
+  removeHighlights,
+  setHighlightsFocused,
+  setHighlightsVisible,
+} from './highlighter';
+import { createIntegration } from './integrations';
+import * as rangeUtil from './range-util';
+import { SelectionObserver, selectedRange } from './selection-observer';
+import { findClosestOffscreenAnchor } from './util/buckets';
+import { frameFillsAncestor } from './util/frame';
+import { normalizeURI } from './util/url';
 
 /** HTML element created by the highlighter with an associated annotation. */
 type AnnotationHighlight = HTMLElement & { _annotation?: AnnotationData };

--- a/src/annotator/highlight-clusters.tsx
+++ b/src/annotator/highlight-clusters.tsx
@@ -5,11 +5,9 @@ import type {
   FeatureFlags as IFeatureFlags,
 } from '../types/annotator';
 import type { HighlightCluster } from '../types/shared';
-
 import ClusterToolbar from './components/ClusterToolbar';
-import { createShadowRoot } from './util/shadow-root';
-
 import { updateClusters } from './highlighter';
+import { createShadowRoot } from './util/shadow-root';
 
 export type HighlightStyle = {
   color: string;

--- a/src/annotator/highlighter.ts
+++ b/src/annotator/highlighter.ts
@@ -1,8 +1,7 @@
 import classnames from 'classnames';
 
-import type { HighlightCluster } from '../types/shared';
 import { generateHexString } from '../shared/random';
-
+import type { HighlightCluster } from '../types/shared';
 import { isInPlaceholder } from './anchoring/placeholder';
 import { isNodeInRange } from './range-util';
 

--- a/src/annotator/index.ts
+++ b/src/annotator/index.ts
@@ -1,6 +1,5 @@
 // Load polyfill for :focus-visible pseudo-class.
 import 'focus-visible';
-
 // Enable debug checks for Preact. Removed in prod builds by Rollup config.
 import 'preact/debug';
 
@@ -9,8 +8,8 @@ import {
   installPortCloseWorkaroundForSafari,
 } from '../shared/messaging';
 import type { Destroyable } from '../types/annotator';
-import { getConfig } from './config/index';
 import type { NotebookConfig } from './components/NotebookModal';
+import { getConfig } from './config/index';
 import { Guest } from './guest';
 import type { GuestConfig } from './guest';
 import {

--- a/src/annotator/integrations/html-metadata.js
+++ b/src/annotator/integrations/html-metadata.js
@@ -16,7 +16,6 @@
  *
  * @typedef {import('../../types/annotator').DocumentMetadata} Metadata
  */
-
 import { normalizeURI } from '../util/url';
 
 /**

--- a/src/annotator/integrations/html.js
+++ b/src/annotator/integrations/html.js
@@ -2,14 +2,13 @@ import { TinyEmitter } from 'tiny-emitter';
 
 import { anchor, describe } from '../anchoring/html';
 import { TextRange } from '../anchoring/text-range';
-
+import { NavigationObserver } from '../util/navigation-observer';
+import { scrollElementIntoView } from '../util/scroll';
 import { HTMLMetadata } from './html-metadata';
 import {
   guessMainContentArea,
   preserveScrollPosition,
 } from './html-side-by-side';
-import { NavigationObserver } from '../util/navigation-observer';
-import { scrollElementIntoView } from '../util/scroll';
 
 /**
  * @typedef {import('../../types/annotator').Anchor} Anchor

--- a/src/annotator/integrations/pdf.tsx
+++ b/src/annotator/integrations/pdf.tsx
@@ -2,24 +2,7 @@ import debounce from 'lodash.debounce';
 import { render } from 'preact';
 import { TinyEmitter } from 'tiny-emitter';
 
-import { TextRange } from '../anchoring/text-range';
 import { ListenerCollection } from '../../shared/listener-collection';
-import {
-  RenderingStates,
-  anchor,
-  canDescribe,
-  describe,
-  documentHasText,
-} from '../anchoring/pdf';
-import { isInPlaceholder, removePlaceholder } from '../anchoring/placeholder';
-import Banners from '../components/Banners';
-import ContentInfoBanner from '../components/ContentInfoBanner';
-import WarningBanner from '../components/WarningBanner';
-import { createShadowRoot } from '../util/shadow-root';
-import { offsetRelativeTo, scrollElement } from '../util/scroll';
-
-import { PDFMetadata } from './pdf-metadata';
-
 import type {
   Anchor,
   AnnotationData,
@@ -30,6 +13,21 @@ import type {
 } from '../../types/annotator';
 import type { Selector } from '../../types/api';
 import type { PDFViewer, PDFViewerApplication } from '../../types/pdfjs';
+import {
+  RenderingStates,
+  anchor,
+  canDescribe,
+  describe,
+  documentHasText,
+} from '../anchoring/pdf';
+import { isInPlaceholder, removePlaceholder } from '../anchoring/placeholder';
+import { TextRange } from '../anchoring/text-range';
+import Banners from '../components/Banners';
+import ContentInfoBanner from '../components/ContentInfoBanner';
+import WarningBanner from '../components/WarningBanner';
+import { offsetRelativeTo, scrollElement } from '../util/scroll';
+import { createShadowRoot } from '../util/shadow-root';
+import { PDFMetadata } from './pdf-metadata';
 
 /**
  * Window with additional globals set by PDF.js.

--- a/src/annotator/integrations/test/html-metadata-test.js
+++ b/src/annotator/integrations/test/html-metadata-test.js
@@ -9,7 +9,6 @@
  ** Dual licensed under the MIT and GPLv3 licenses.
  ** https://github.com/openannotation/annotator/blob/master/LICENSE
  */
-
 import { HTMLMetadata } from '../html-metadata';
 
 describe('HTMLMetadata', () => {

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -1,7 +1,7 @@
 import { delay } from '../../../test-util/wait';
-import { FakePDFViewerApplication } from '../../anchoring/test/fake-pdf-viewer-application';
 import { RenderingStates } from '../../anchoring/pdf';
 import { createPlaceholder } from '../../anchoring/placeholder';
+import { FakePDFViewerApplication } from '../../anchoring/test/fake-pdf-viewer-application';
 import { PDFIntegration, isPDF, $imports } from '../pdf';
 
 function awaitEvent(target, eventName) {

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -2,13 +2,6 @@ import { TinyEmitter } from 'tiny-emitter';
 
 import { documentCFI } from '../../shared/cfi';
 import { ListenerCollection } from '../../shared/listener-collection';
-import { FeatureFlags } from '../features';
-import { onDocumentReady } from '../frame-observer';
-import { HTMLIntegration } from './html';
-import { preserveScrollPosition } from './html-side-by-side';
-import { ImageTextLayer } from './image-text-layer';
-import { injectClient } from '../hypothesis-injector';
-
 import type {
   Anchor,
   AnnotationData,
@@ -16,12 +9,18 @@ import type {
   SegmentInfo,
   SidebarLayout,
 } from '../../types/annotator';
+import type { EPUBContentSelector, Selector } from '../../types/api';
 import type {
   ContentFrameGlobals,
   MosaicBookElement,
 } from '../../types/vitalsource';
-import type { EPUBContentSelector, Selector } from '../../types/api';
+import { FeatureFlags } from '../features';
+import { onDocumentReady } from '../frame-observer';
+import { injectClient } from '../hypothesis-injector';
 import type { InjectConfig } from '../hypothesis-injector';
+import { HTMLIntegration } from './html';
+import { preserveScrollPosition } from './html-side-by-side';
+import { ImageTextLayer } from './image-text-layer';
 
 // When activating side-by-side mode for VitalSource PDF documents, make sure
 // at least this much space (in pixels) is left for the PDF document. Any

--- a/src/annotator/notebook.js
+++ b/src/annotator/notebook.js
@@ -1,6 +1,7 @@
-import { createShadowRoot } from './util/shadow-root';
 import { render } from 'preact';
+
 import NotebookModal from './components/NotebookModal';
+import { createShadowRoot } from './util/shadow-root';
 
 /**
  * @typedef {import('../types/annotator').Destroyable} Destroyable

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -4,7 +4,6 @@ import { addConfigFragment } from '../shared/config-fragment';
 import { sendErrorsTo } from '../shared/frame-error-capture';
 import { ListenerCollection } from '../shared/listener-collection';
 import { PortRPC } from '../shared/messaging';
-
 import { annotationCounts } from './annotation-counts';
 import { BucketBar } from './bucket-bar';
 import { createAppConfig } from './config/app';

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -1,5 +1,5 @@
-import { act } from 'preact/test-utils';
 import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
 
 import { Adder, ArrowDirection, $imports } from '../adder';
 

--- a/src/annotator/test/highlight-clusters-test.js
+++ b/src/annotator/test/highlight-clusters-test.js
@@ -1,8 +1,6 @@
 import { waitFor } from '../../test-util/wait';
-
-import { HighlightClusterController, $imports } from '../highlight-clusters';
-
 import { FeatureFlags } from '../features';
+import { HighlightClusterController, $imports } from '../highlight-clusters';
 
 describe('HighlightClusterController', () => {
   let fakeFeatures;

--- a/src/annotator/test/integration/anchoring-test.js
+++ b/src/annotator/test/integration/anchoring-test.js
@@ -1,6 +1,5 @@
 // Tests that the expected parts of the page are highlighted when annotations
 // with various combinations of selector are anchored.
-
 import { Guest, $imports as guestImports } from '../../guest';
 import testPageHTML from './test-page.html';
 

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -4,15 +4,12 @@
 // The same boot script is used for both entry points so that the browser
 // already has it cached when it encounters the reference in the sidebar
 // application.
-
-import { parseJsonConfig } from './parse-json-config';
-
-import { bootHypothesisClient, bootSidebarApp } from './boot';
-import { processUrlTemplate } from './url-template';
-import { isBrowserSupported } from './browser-check';
-
 // @ts-ignore - This file is generated before the boot bundle is built.
 import manifest from '../../build/manifest.json';
+import { bootHypothesisClient, bootSidebarApp } from './boot';
+import { isBrowserSupported } from './browser-check';
+import { parseJsonConfig } from './parse-json-config';
+import { processUrlTemplate } from './url-template';
 
 /**
  * @typedef {import('./boot').AnnotatorConfig} AnnotatorConfig

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -4,6 +4,7 @@
 // The same boot script is used for both entry points so that the browser
 // already has it cached when it encounters the reference in the sidebar
 // application.
+//
 // @ts-ignore - This file is generated before the boot bundle is built.
 import manifest from '../../build/manifest.json';
 import { bootHypothesisClient, bootSidebarApp } from './boot';

--- a/src/shared/prompts.tsx
+++ b/src/shared/prompts.tsx
@@ -1,7 +1,6 @@
+import { Button, Modal } from '@hypothesis/frontend-shared/lib/next';
 import { render } from 'preact';
 import type { ComponentChildren } from 'preact';
-
-import { Button, Modal } from '@hypothesis/frontend-shared/lib/next';
 
 export type ConfirmModalProps = {
   title?: string;

--- a/src/shared/test/keyboard-navigation-test.js
+++ b/src/shared/test/keyboard-navigation-test.js
@@ -2,8 +2,8 @@ import { options as preactOptions, render } from 'preact';
 import { useRef } from 'preact/hooks';
 import { act } from 'preact/test-utils';
 
-import { useArrowKeyNavigation } from '../keyboard-navigation';
 import { waitFor } from '../../test-util/wait';
+import { useArrowKeyNavigation } from '../keyboard-navigation';
 
 function Toolbar({ navigationOptions = {} }) {
   const containerRef = useRef();

--- a/src/sidebar/components/Annotation/Annotation.tsx
+++ b/src/sidebar/components/Annotation/Annotation.tsx
@@ -3,7 +3,6 @@ import classnames from 'classnames';
 import { useMemo } from 'preact/hooks';
 
 import type { Annotation as IAnnotation } from '../../../types/api';
-import { useSidebarStore } from '../../store';
 import {
   annotationRole,
   isOrphan,
@@ -11,9 +10,9 @@ import {
   quote,
 } from '../../helpers/annotation-metadata';
 import { annotationDisplayName } from '../../helpers/annotation-user';
-import type { AnnotationsService } from '../../services/annotations';
 import { withServices } from '../../service-context';
-
+import type { AnnotationsService } from '../../services/annotations';
+import { useSidebarStore } from '../../store';
 import AnnotationActionBar from './AnnotationActionBar';
 import AnnotationBody from './AnnotationBody';
 import AnnotationEditor from './AnnotationEditor';

--- a/src/sidebar/components/Annotation/AnnotationActionBar.tsx
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.tsx
@@ -10,7 +10,6 @@ import {
 import { confirm } from '../../../shared/prompts';
 import type { SavedAnnotation } from '../../../types/api';
 import type { SidebarSettings } from '../../../types/config';
-
 import { serviceConfig } from '../../config/service-config';
 import { annotationRole } from '../../helpers/annotation-metadata';
 import {
@@ -22,7 +21,6 @@ import { withServices } from '../../service-context';
 import type { AnnotationsService } from '../../services/annotations';
 import type { ToastMessengerService } from '../../services/toast-messenger';
 import { useSidebarStore } from '../../store';
-
 import AnnotationShareControl from './AnnotationShareControl';
 
 function flaggingEnabled(settings: SidebarSettings) {

--- a/src/sidebar/components/Annotation/AnnotationBody.tsx
+++ b/src/sidebar/components/Annotation/AnnotationBody.tsx
@@ -8,13 +8,11 @@ import { useMemo, useState } from 'preact/hooks';
 
 import type { Annotation } from '../../../types/api';
 import type { SidebarSettings } from '../../../types/config';
-
-import { useSidebarStore } from '../../store';
 import { isThirdPartyUser } from '../../helpers/account-id';
 import { isHidden } from '../../helpers/annotation-metadata';
-import { withServices } from '../../service-context';
 import { applyTheme } from '../../helpers/theme';
-
+import { withServices } from '../../service-context';
+import { useSidebarStore } from '../../store';
 import Excerpt from '../Excerpt';
 import MarkdownView from '../MarkdownView';
 import TagList from '../TagList';

--- a/src/sidebar/components/Annotation/AnnotationEditor.tsx
+++ b/src/sidebar/components/Annotation/AnnotationEditor.tsx
@@ -2,22 +2,20 @@ import { useCallback, useState } from 'preact/hooks';
 
 import type { Annotation } from '../../../types/api';
 import type { SidebarSettings } from '../../../types/config';
-import { withServices } from '../../service-context';
 import {
   annotationRole,
   isReply,
   isSaved,
 } from '../../helpers/annotation-metadata';
 import { applyTheme } from '../../helpers/theme';
+import { withServices } from '../../service-context';
 import type { AnnotationsService } from '../../services/annotations';
 import type { TagsService } from '../../services/tags';
 import type { ToastMessengerService } from '../../services/toast-messenger';
 import { useSidebarStore } from '../../store';
 import type { Draft } from '../../store/modules/drafts';
-
 import MarkdownEditor from '../MarkdownEditor';
 import TagEditor from '../TagEditor';
-
 import AnnotationLicense from './AnnotationLicense';
 import AnnotationPublishControl from './AnnotationPublishControl';
 

--- a/src/sidebar/components/Annotation/AnnotationHeader.tsx
+++ b/src/sidebar/components/Annotation/AnnotationHeader.tsx
@@ -7,9 +7,6 @@ import { useMemo } from 'preact/hooks';
 
 import type { Annotation } from '../../../types/api';
 import type { SidebarSettings } from '../../../types/config';
-
-import { withServices } from '../../service-context';
-import { useSidebarStore } from '../../store';
 import {
   domainAndTitle,
   isHighlight,
@@ -21,7 +18,8 @@ import {
   annotationDisplayName,
 } from '../../helpers/annotation-user';
 import { isPrivate } from '../../helpers/permissions';
-
+import { withServices } from '../../service-context';
+import { useSidebarStore } from '../../store';
 import AnnotationDocumentInfo from './AnnotationDocumentInfo';
 import AnnotationShareInfo from './AnnotationShareInfo';
 import AnnotationTimestamps from './AnnotationTimestamps';

--- a/src/sidebar/components/Annotation/AnnotationPublishControl.tsx
+++ b/src/sidebar/components/Annotation/AnnotationPublishControl.tsx
@@ -10,10 +10,8 @@ import classnames from 'classnames';
 
 import type { Group } from '../../../types/api';
 import type { SidebarSettings } from '../../../types/config';
-
-import { withServices } from '../../service-context';
 import { applyTheme } from '../../helpers/theme';
-
+import { withServices } from '../../service-context';
 import Menu from '../Menu';
 import MenuItem from '../MenuItem';
 

--- a/src/sidebar/components/Annotation/AnnotationQuote.tsx
+++ b/src/sidebar/components/Annotation/AnnotationQuote.tsx
@@ -1,10 +1,8 @@
 import classnames from 'classnames';
 
 import type { SidebarSettings } from '../../../types/config';
-
-import { withServices } from '../../service-context';
 import { applyTheme } from '../../helpers/theme';
-
+import { withServices } from '../../service-context';
 import Excerpt from '../Excerpt';
 import StyledText from '../StyledText';
 

--- a/src/sidebar/components/Annotation/AnnotationShareControl.tsx
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.tsx
@@ -12,14 +12,12 @@ import { useEffect, useRef, useState } from 'preact/hooks';
 
 import { isIOS } from '../../../shared/user-agent';
 import type { Annotation } from '../../../types/api';
-
 import { isShareableURI } from '../../helpers/annotation-sharing';
 import { isPrivate } from '../../helpers/permissions';
 import { withServices } from '../../service-context';
 import type { ToastMessengerService } from '../../services/toast-messenger';
 import { useSidebarStore } from '../../store';
 import { copyText } from '../../util/copy-to-clipboard';
-
 import MenuArrow from '../MenuArrow';
 import ShareLinks from '../ShareLinks';
 

--- a/src/sidebar/components/Annotation/EmptyAnnotation.tsx
+++ b/src/sidebar/components/Annotation/EmptyAnnotation.tsx
@@ -1,5 +1,5 @@
-import AnnotationReplyToggle from './AnnotationReplyToggle';
 import type { AnnotationProps } from './Annotation';
+import AnnotationReplyToggle from './AnnotationReplyToggle';
 
 type EmptyAnnotationProps = Omit<
   AnnotationProps,

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -1,10 +1,8 @@
 import { mount } from 'enzyme';
 
-import * as fixtures from '../../../test/annotation-fixtures';
-
 import { checkAccessibility } from '../../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
-
+import * as fixtures from '../../../test/annotation-fixtures';
 import Annotation, { $imports } from '../Annotation';
 
 describe('Annotation', () => {

--- a/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
@@ -1,13 +1,11 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import AnnotationActionBar, { $imports } from '../AnnotationActionBar';
-
-import * as fixtures from '../../../test/annotation-fixtures';
-
 import { checkAccessibility } from '../../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
 import { waitFor } from '../../../../test-util/wait';
+import * as fixtures from '../../../test/annotation-fixtures';
+import AnnotationActionBar, { $imports } from '../AnnotationActionBar';
 
 describe('AnnotationActionBar', () => {
   let fakeAnnotation;

--- a/src/sidebar/components/Annotation/test/AnnotationBody-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationBody-test.js
@@ -1,11 +1,9 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import * as fixtures from '../../../test/annotation-fixtures';
-
 import { checkAccessibility } from '../../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
-
+import * as fixtures from '../../../test/annotation-fixtures';
 import AnnotationBody, { $imports } from '../AnnotationBody';
 
 describe('AnnotationBody', () => {

--- a/src/sidebar/components/Annotation/test/AnnotationDocumentInfo-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationDocumentInfo-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
-
 import AnnotationDocumentInfo from '../AnnotationDocumentInfo';
 
 describe('AnnotationDocumentInfo', () => {

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -1,12 +1,10 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import * as fixtures from '../../../test/annotation-fixtures';
-import { waitFor } from '../../../../test-util/wait';
-
 import { checkAccessibility } from '../../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
-
+import { waitFor } from '../../../../test-util/wait';
+import * as fixtures from '../../../test/annotation-fixtures';
 import AnnotationEditor, { $imports } from '../AnnotationEditor';
 
 describe('AnnotationEditor', () => {

--- a/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
@@ -1,10 +1,8 @@
 import { mount } from 'enzyme';
 
-import * as fixtures from '../../../test/annotation-fixtures';
-
 import { checkAccessibility } from '../../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
-
+import * as fixtures from '../../../test/annotation-fixtures';
 import AnnotationHeader, { $imports } from '../AnnotationHeader';
 
 describe('AnnotationHeader', () => {

--- a/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
@@ -7,7 +7,6 @@ import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
-
 import AnnotationPublishControl, {
   $imports,
 } from '../AnnotationPublishControl';

--- a/src/sidebar/components/Annotation/test/AnnotationQuote-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationQuote-test.js
@@ -2,7 +2,6 @@ import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
-
 import AnnotationQuote, { $imports } from '../AnnotationQuote';
 
 describe('AnnotationQuote', () => {

--- a/src/sidebar/components/Annotation/test/AnnotationReplyToggle-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationReplyToggle-test.js
@@ -2,7 +2,6 @@ import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
-
 import AnnotationReplyToggle from '../AnnotationReplyToggle';
 
 describe('AnnotationReplyToggle', () => {

--- a/src/sidebar/components/Annotation/test/AnnotationShareControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationShareControl-test.js
@@ -3,7 +3,6 @@ import { act } from 'preact/test-utils';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
-
 import AnnotationShareControl, { $imports } from '../AnnotationShareControl';
 
 describe('AnnotationShareControl', () => {

--- a/src/sidebar/components/Annotation/test/AnnotationShareInfo-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationShareInfo-test.js
@@ -2,7 +2,6 @@ import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
-
 import AnnotationShareInfo, { $imports } from '../AnnotationShareInfo';
 
 describe('AnnotationShareInfo', () => {

--- a/src/sidebar/components/Annotation/test/AnnotationTimestamps-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationTimestamps-test.js
@@ -2,7 +2,6 @@ import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
-
 import AnnotationTimestamps, { $imports } from '../AnnotationTimestamps';
 
 describe('AnnotationTimestamps', () => {

--- a/src/sidebar/components/Annotation/test/AnnotationUser-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationUser-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
-
 import AnnotationUser from '../AnnotationUser';
 
 describe('AnnotationUser', () => {

--- a/src/sidebar/components/Annotation/test/EmptyAnnotation-test.js
+++ b/src/sidebar/components/Annotation/test/EmptyAnnotation-test.js
@@ -2,7 +2,6 @@ import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
-
 import EmptyAnnotation, { $imports } from '../EmptyAnnotation';
 
 describe('EmptyAnnotation', () => {

--- a/src/sidebar/components/AnnotationView.tsx
+++ b/src/sidebar/components/AnnotationView.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState } from 'preact/hooks';
 
-import { useSidebarStore } from '../store';
 import { withServices } from '../service-context';
 import type { LoadAnnotationsService } from '../services/load-annotations';
+import { useSidebarStore } from '../store';
 import { useRootThread } from './hooks/use-root-thread';
-
-import ThreadList from './ThreadList';
 import SidebarContentError from './SidebarContentError';
+import ThreadList from './ThreadList';
 
 type AnnotationViewProps = {
   onLogin: () => void;

--- a/src/sidebar/components/AnnotationView.tsx
+++ b/src/sidebar/components/AnnotationView.tsx
@@ -3,9 +3,9 @@ import { useEffect, useState } from 'preact/hooks';
 import { withServices } from '../service-context';
 import type { LoadAnnotationsService } from '../services/load-annotations';
 import { useSidebarStore } from '../store';
-import { useRootThread } from './hooks/use-root-thread';
 import SidebarContentError from './SidebarContentError';
 import ThreadList from './ThreadList';
+import { useRootThread } from './hooks/use-root-thread';
 
 type AnnotationViewProps = {
   onLogin: () => void;

--- a/src/sidebar/components/Excerpt.tsx
+++ b/src/sidebar/components/Excerpt.tsx
@@ -3,9 +3,9 @@ import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useLayoutEffect, useRef, useState } from 'preact/hooks';
 
-import { observeElementSize } from '../util/observe-element-size';
-import { withServices } from '../service-context';
 import { applyTheme } from '../helpers/theme';
+import { withServices } from '../service-context';
+import { observeElementSize } from '../util/observe-element-size';
 
 type InlineControlsProps = {
   isCollapsed: boolean;

--- a/src/sidebar/components/FilterSelect.tsx
+++ b/src/sidebar/components/FilterSelect.tsx
@@ -1,8 +1,7 @@
-import classnames from 'classnames';
 import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
+import classnames from 'classnames';
 
 import type { FilterOption } from '../store/modules/filters';
-
 import Menu from './Menu';
 import MenuItem from './MenuItem';
 

--- a/src/sidebar/components/FilterStatus.tsx
+++ b/src/sidebar/components/FilterStatus.tsx
@@ -10,7 +10,6 @@ import { useMemo } from 'preact/hooks';
 
 import { countVisible } from '../helpers/thread';
 import { useSidebarStore } from '../store';
-
 import { useRootThread } from './hooks/use-root-thread';
 
 type FilterStatusMessageProps = {

--- a/src/sidebar/components/GroupList/GroupList.js
+++ b/src/sidebar/components/GroupList/GroupList.js
@@ -1,5 +1,5 @@
-import classnames from 'classnames';
 import { PlusIcon } from '@hypothesis/frontend-shared/lib/next';
+import classnames from 'classnames';
 import { useMemo, useState } from 'preact/hooks';
 
 import { serviceConfig } from '../../config/service-config';
@@ -9,10 +9,8 @@ import { groupsByOrganization } from '../../helpers/group-organizations';
 import { isThirdPartyService } from '../../helpers/is-third-party-service';
 import { withServices } from '../../service-context';
 import { useSidebarStore } from '../../store';
-
 import Menu from '../Menu';
 import MenuItem from '../MenuItem';
-
 import GroupListSection from './GroupListSection';
 
 /**

--- a/src/sidebar/components/GroupList/GroupListItem.js
+++ b/src/sidebar/components/GroupList/GroupListItem.js
@@ -1,16 +1,15 @@
-import classnames from 'classnames';
 import {
   CopyIcon,
   ExternalIcon,
   LeaveIcon,
 } from '@hypothesis/frontend-shared/lib/next';
+import classnames from 'classnames';
 
+import { confirm } from '../../../shared/prompts';
 import { orgName } from '../../helpers/group-list-item-common';
 import { withServices } from '../../service-context';
 import { useSidebarStore } from '../../store';
 import { copyText } from '../../util/copy-to-clipboard';
-import { confirm } from '../../../shared/prompts';
-
 import MenuItem from '../MenuItem';
 
 /**

--- a/src/sidebar/components/GroupList/GroupListSection.js
+++ b/src/sidebar/components/GroupList/GroupListSection.js
@@ -1,5 +1,4 @@
 import MenuSection from '../MenuSection';
-
 import GroupListItem from './GroupListItem';
 
 /**

--- a/src/sidebar/components/GroupList/test/GroupList-test.js
+++ b/src/sidebar/components/GroupList/test/GroupList-test.js
@@ -1,9 +1,8 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import GroupList, { $imports } from '../GroupList';
-
 import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
+import GroupList, { $imports } from '../GroupList';
 
 describe('GroupList', () => {
   let fakeServiceConfig;

--- a/src/sidebar/components/GroupList/test/GroupListSection-test.js
+++ b/src/sidebar/components/GroupList/test/GroupListSection-test.js
@@ -1,8 +1,7 @@
 import { mount } from 'enzyme';
 
-import GroupListSection, { $imports } from '../GroupListSection';
-
 import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
+import GroupListSection, { $imports } from '../GroupListSection';
 
 describe('GroupListSection', () => {
   const testGroups = [

--- a/src/sidebar/components/HelpPanel.tsx
+++ b/src/sidebar/components/HelpPanel.tsx
@@ -7,11 +7,10 @@ import type { ComponentChildren as Children } from 'preact';
 import { useCallback, useMemo, useState } from 'preact/hooks';
 
 import { username } from '../helpers/account-id';
-import { useSidebarStore } from '../store';
-import type { SessionService } from '../services/session';
-import { withServices } from '../service-context';
 import { VersionData } from '../helpers/version-data';
-
+import { withServices } from '../service-context';
+import type { SessionService } from '../services/session';
+import { useSidebarStore } from '../store';
 import SidebarPanel from './SidebarPanel';
 import Tutorial from './Tutorial';
 import VersionInfo from './VersionInfo';

--- a/src/sidebar/components/HypothesisApp.js
+++ b/src/sidebar/components/HypothesisApp.js
@@ -7,14 +7,12 @@ import { shouldAutoDisplayTutorial } from '../helpers/session';
 import { applyTheme } from '../helpers/theme';
 import { withServices } from '../service-context';
 import { useSidebarStore } from '../store';
-
 import AnnotationView from './AnnotationView';
-import SidebarView from './SidebarView';
-import StreamView from './StreamView';
-
 import HelpPanel from './HelpPanel';
 import NotebookView from './NotebookView';
 import ShareAnnotationsPanel from './ShareAnnotationsPanel';
+import SidebarView from './SidebarView';
+import StreamView from './StreamView';
 import ToastMessages from './ToastMessages';
 import TopBar from './TopBar';
 

--- a/src/sidebar/components/LoginPromptPanel.tsx
+++ b/src/sidebar/components/LoginPromptPanel.tsx
@@ -5,7 +5,6 @@ import {
 } from '@hypothesis/frontend-shared/lib/next';
 
 import { useSidebarStore } from '../store';
-
 import SidebarPanel from './SidebarPanel';
 
 export type LoginPromptPanelProps = {

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -15,11 +15,12 @@ import {
   ListUnorderedIcon,
 } from '@hypothesis/frontend-shared/lib/next';
 import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
-import type { Ref, JSX } from 'preact';
-
 import classnames from 'classnames';
+import type { Ref, JSX } from 'preact';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
+import { useArrowKeyNavigation } from '../../shared/keyboard-navigation';
+import { isMacOS } from '../../shared/user-agent';
 import {
   LinkType,
   convertSelectionToLink,
@@ -27,9 +28,6 @@ import {
   toggleSpanStyle,
 } from '../markdown-commands';
 import type { EditorState } from '../markdown-commands';
-import { isMacOS } from '../../shared/user-agent';
-import { useArrowKeyNavigation } from '../../shared/keyboard-navigation';
-
 import MarkdownView from './MarkdownView';
 
 /**

--- a/src/sidebar/components/MarkdownView.js
+++ b/src/sidebar/components/MarkdownView.js
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef } from 'preact/hooks';
 
 import { replaceLinksWithEmbeds } from '../media-embedder';
 import { renderMathAndMarkdown } from '../render-markdown';
-
 import StyledText from './StyledText';
 
 /**

--- a/src/sidebar/components/Menu.tsx
+++ b/src/sidebar/components/Menu.tsx
@@ -1,6 +1,6 @@
-import classnames from 'classnames';
 import { useElementShouldClose } from '@hypothesis/frontend-shared';
 import { MenuExpandIcon } from '@hypothesis/frontend-shared/lib/next';
+import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 

--- a/src/sidebar/components/MenuItem.tsx
+++ b/src/sidebar/components/MenuItem.tsx
@@ -1,9 +1,9 @@
-import classnames from 'classnames';
-import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
 import {
   CaretUpIcon,
   MenuExpandIcon,
 } from '@hypothesis/frontend-shared/lib/next';
+import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
+import classnames from 'classnames';
 import type { ComponentChildren, Ref } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 

--- a/src/sidebar/components/ModerationBanner.tsx
+++ b/src/sidebar/components/ModerationBanner.tsx
@@ -6,12 +6,11 @@ import {
 import classnames from 'classnames';
 
 import type { Annotation } from '../../types/api';
-
+import * as annotationMetadata from '../helpers/annotation-metadata';
+import { withServices } from '../service-context';
 import type { APIService } from '../services/api';
 import type { ToastMessengerService } from '../services/toast-messenger';
 import { useSidebarStore } from '../store';
-import * as annotationMetadata from '../helpers/annotation-metadata';
-import { withServices } from '../service-context';
 
 export type ModerationBannerProps = {
   annotation: Annotation;

--- a/src/sidebar/components/NotebookFilters.tsx
+++ b/src/sidebar/components/NotebookFilters.tsx
@@ -1,9 +1,8 @@
 import { ProfileIcon } from '@hypothesis/frontend-shared/lib/next';
 
 import { useSidebarStore } from '../store';
-import { useUserFilterOptions } from './hooks/use-filter-options';
-
 import FilterSelect from './FilterSelect';
+import { useUserFilterOptions } from './hooks/use-filter-options';
 
 /**
  * Filters for the Notebook

--- a/src/sidebar/components/NotebookResultCount.tsx
+++ b/src/sidebar/components/NotebookResultCount.tsx
@@ -1,7 +1,7 @@
 import { Spinner } from '@hypothesis/frontend-shared/lib/next';
 
-import { useRootThread } from './hooks/use-root-thread';
 import { countVisible } from '../helpers/thread';
+import { useRootThread } from './hooks/use-root-thread';
 
 export type NotebookResultCountProps = {
   /**

--- a/src/sidebar/components/NotebookView.tsx
+++ b/src/sidebar/components/NotebookView.tsx
@@ -12,10 +12,10 @@ import { withServices } from '../service-context';
 import type { LoadAnnotationsService } from '../services/load-annotations';
 import type { StreamerService } from '../services/streamer';
 import { useSidebarStore } from '../store';
-import { useRootThread } from './hooks/use-root-thread';
 import NotebookFilters from './NotebookFilters';
 import NotebookResultCount from './NotebookResultCount';
 import PaginatedThreadList from './PaginatedThreadList';
+import { useRootThread } from './hooks/use-root-thread';
 
 export type NotebookViewProps = {
   // injected

--- a/src/sidebar/components/NotebookView.tsx
+++ b/src/sidebar/components/NotebookView.tsx
@@ -12,11 +12,10 @@ import { withServices } from '../service-context';
 import type { LoadAnnotationsService } from '../services/load-annotations';
 import type { StreamerService } from '../services/streamer';
 import { useSidebarStore } from '../store';
-
+import { useRootThread } from './hooks/use-root-thread';
 import NotebookFilters from './NotebookFilters';
 import NotebookResultCount from './NotebookResultCount';
 import PaginatedThreadList from './PaginatedThreadList';
-import { useRootThread } from './hooks/use-root-thread';
 
 export type NotebookViewProps = {
   // injected

--- a/src/sidebar/components/PaginatedThreadList.js
+++ b/src/sidebar/components/PaginatedThreadList.js
@@ -1,7 +1,6 @@
 import { useMemo } from 'preact/hooks';
 
 import { countVisible } from '../helpers/thread';
-
 import PaginationNavigation from './PaginationNavigation';
 import ThreadList from './ThreadList';
 

--- a/src/sidebar/components/PaginationNavigation.tsx
+++ b/src/sidebar/components/PaginationNavigation.tsx
@@ -1,10 +1,10 @@
+import type { ButtonCommonProps } from '@hypothesis/frontend-shared/lib/components/input/ButtonBase';
 import {
   ButtonBase,
   ArrowLeftIcon,
   ArrowRightIcon,
 } from '@hypothesis/frontend-shared/lib/next';
 import type { PresentationalProps } from '@hypothesis/frontend-shared/lib/types';
-import type { ButtonCommonProps } from '@hypothesis/frontend-shared/lib/components/input/ButtonBase';
 import classnames from 'classnames';
 import type { JSX } from 'preact';
 

--- a/src/sidebar/components/SelectionTabs.tsx
+++ b/src/sidebar/components/SelectionTabs.tsx
@@ -11,10 +11,9 @@ import type { ComponentChildren } from 'preact';
 
 import type { SidebarSettings } from '../../types/config';
 import type { TabName } from '../../types/sidebar';
-
 import { applyTheme } from '../helpers/theme';
-import type { AnnotationsService } from '../services/annotations';
 import { withServices } from '../service-context';
+import type { AnnotationsService } from '../services/annotations';
 import { useSidebarStore } from '../store';
 
 type TabProps = {

--- a/src/sidebar/components/ShareAnnotationsPanel.tsx
+++ b/src/sidebar/components/ShareAnnotationsPanel.tsx
@@ -7,13 +7,12 @@ import {
   Spinner,
 } from '@hypothesis/frontend-shared/lib/next';
 
-import { useSidebarStore } from '../store';
 import { pageSharingLink } from '../helpers/annotation-sharing';
-import { copyText } from '../util/copy-to-clipboard';
 import { withServices } from '../service-context';
 import type { ToastMessengerService } from '../services/toast-messenger';
+import { useSidebarStore } from '../store';
+import { copyText } from '../util/copy-to-clipboard';
 import { notNull } from '../util/typing';
-
 import ShareLinks from './ShareLinks';
 import SidebarPanel from './SidebarPanel';
 

--- a/src/sidebar/components/SidebarPanel.tsx
+++ b/src/sidebar/components/SidebarPanel.tsx
@@ -6,7 +6,6 @@ import scrollIntoView from 'scroll-into-view';
 
 import type { PanelName } from '../../types/sidebar';
 import { useSidebarStore } from '../store';
-
 import Slider from './Slider';
 
 export type SidebarPanelProps = {

--- a/src/sidebar/components/SidebarView.tsx
+++ b/src/sidebar/components/SidebarView.tsx
@@ -7,12 +7,12 @@ import type { LoadAnnotationsService } from '../services/load-annotations';
 import type { StreamerService } from '../services/streamer';
 import { useSidebarStore } from '../store';
 import FilterStatus from './FilterStatus';
-import { useRootThread } from './hooks/use-root-thread';
 import LoggedOutMessage from './LoggedOutMessage';
 import LoginPromptPanel from './LoginPromptPanel';
 import SelectionTabs from './SelectionTabs';
 import SidebarContentError from './SidebarContentError';
 import ThreadList from './ThreadList';
+import { useRootThread } from './hooks/use-root-thread';
 
 export type SidebarViewProps = {
   onLogin: () => void;

--- a/src/sidebar/components/SidebarView.tsx
+++ b/src/sidebar/components/SidebarView.tsx
@@ -6,10 +6,8 @@ import type { FrameSyncService } from '../services/frame-sync';
 import type { LoadAnnotationsService } from '../services/load-annotations';
 import type { StreamerService } from '../services/streamer';
 import { useSidebarStore } from '../store';
-
-import { useRootThread } from './hooks/use-root-thread';
-
 import FilterStatus from './FilterStatus';
+import { useRootThread } from './hooks/use-root-thread';
 import LoggedOutMessage from './LoggedOutMessage';
 import LoginPromptPanel from './LoginPromptPanel';
 import SelectionTabs from './SelectionTabs';

--- a/src/sidebar/components/SortMenu.tsx
+++ b/src/sidebar/components/SortMenu.tsx
@@ -1,7 +1,6 @@
 import { SortIcon } from '@hypothesis/frontend-shared/lib/next';
 
 import { useSidebarStore } from '../store';
-
 import Menu from './Menu';
 import MenuItem from './MenuItem';
 

--- a/src/sidebar/components/StreamSearchInput.js
+++ b/src/sidebar/components/StreamSearchInput.js
@@ -1,6 +1,5 @@
-import { useSidebarStore } from '../store';
 import { withServices } from '../service-context';
-
+import { useSidebarStore } from '../store';
 import SearchInput from './SearchInput';
 
 /**

--- a/src/sidebar/components/StreamView.tsx
+++ b/src/sidebar/components/StreamView.tsx
@@ -5,8 +5,8 @@ import type { APIService } from '../services/api';
 import type { ToastMessengerService } from '../services/toast-messenger';
 import { useSidebarStore } from '../store';
 import * as searchFilter from '../util/search-filter';
-import { useRootThread } from './hooks/use-root-thread';
 import ThreadList from './ThreadList';
+import { useRootThread } from './hooks/use-root-thread';
 
 export type StreamViewProps = {
   // injected

--- a/src/sidebar/components/StreamView.tsx
+++ b/src/sidebar/components/StreamView.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useEffect } from 'preact/hooks';
 
-import * as searchFilter from '../util/search-filter';
 import { withServices } from '../service-context';
 import type { APIService } from '../services/api';
 import type { ToastMessengerService } from '../services/toast-messenger';
-import { useRootThread } from './hooks/use-root-thread';
 import { useSidebarStore } from '../store';
-
+import * as searchFilter from '../util/search-filter';
+import { useRootThread } from './hooks/use-root-thread';
 import ThreadList from './ThreadList';
 
 export type StreamViewProps = {

--- a/src/sidebar/components/TagEditor.tsx
+++ b/src/sidebar/components/TagEditor.tsx
@@ -4,7 +4,6 @@ import { useRef, useState } from 'preact/hooks';
 
 import { withServices } from '../service-context';
 import type { TagsService } from '../services/tags';
-
 import AutocompleteList from './AutocompleteList';
 import TagList from './TagList';
 import TagListItem from './TagListItem';

--- a/src/sidebar/components/Thread.tsx
+++ b/src/sidebar/components/Thread.tsx
@@ -7,12 +7,11 @@ import {
 import classnames from 'classnames';
 import { useCallback, useMemo } from 'preact/hooks';
 
-import { useSidebarStore } from '../store';
-import { withServices } from '../service-context';
-import { countHidden, countVisible } from '../helpers/thread';
 import type { Thread as IThread } from '../helpers/build-thread';
+import { countHidden, countVisible } from '../helpers/thread';
+import { withServices } from '../service-context';
 import type { ThreadsService } from '../services/threads';
-
+import { useSidebarStore } from '../store';
 import Annotation from './Annotation';
 import AnnotationHeader from './Annotation/AnnotationHeader';
 import EmptyAnnotation from './Annotation/EmptyAnnotation';

--- a/src/sidebar/components/ThreadCard.tsx
+++ b/src/sidebar/components/ThreadCard.tsx
@@ -3,12 +3,10 @@ import debounce from 'lodash.debounce';
 import { useCallback, useEffect, useMemo, useRef } from 'preact/hooks';
 
 import type { Annotation } from '../../types/api';
-
 import type { Thread as IThread } from '../helpers/build-thread';
+import { withServices } from '../service-context';
 import type { FrameSyncService } from '../services/frame-sync';
 import { useSidebarStore } from '../store';
-import { withServices } from '../service-context';
-
 import Thread from './Thread';
 
 /**

--- a/src/sidebar/components/ThreadList.tsx
+++ b/src/sidebar/components/ThreadList.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useLayoutEffect, useMemo, useState } from 'preact/hooks';
 import classnames from 'classnames';
 import debounce from 'lodash.debounce';
+import { useEffect, useLayoutEffect, useMemo, useState } from 'preact/hooks';
 
 import { ListenerCollection } from '../../shared/listener-collection';
 import type { Annotation, EPUBContentSelector } from '../../types/api';
@@ -11,7 +11,6 @@ import {
 } from '../helpers/visible-threads';
 import { useSidebarStore } from '../store';
 import { getElementHeightWithMargins } from '../util/dom';
-
 import ThreadCard from './ThreadCard';
 
 // The precision of the `scrollPosition` value in pixels; values will be rounded

--- a/src/sidebar/components/ToastMessages.tsx
+++ b/src/sidebar/components/ToastMessages.tsx
@@ -1,4 +1,3 @@
-import classnames from 'classnames';
 import {
   Card,
   Link,
@@ -6,11 +5,12 @@ import {
   CautionIcon,
   CheckIcon,
 } from '@hypothesis/frontend-shared/lib/next';
+import classnames from 'classnames';
 
+import { withServices } from '../service-context';
 import type { ToastMessengerService } from '../services/toast-messenger';
 import { useSidebarStore } from '../store';
 import type { ToastMessage } from '../store/modules/toast-messages';
-import { withServices } from '../service-context';
 
 type ToastMessageItemProps = {
   message: ToastMessage;

--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -8,7 +8,6 @@ import {
 import classnames from 'classnames';
 
 import type { SidebarSettings } from '../../types/config';
-
 import { serviceConfig } from '../config/service-config';
 import { isThirdPartyService } from '../helpers/is-third-party-service';
 import { applyTheme } from '../helpers/theme';
@@ -16,7 +15,6 @@ import { withServices } from '../service-context';
 import type { FrameSyncService } from '../services/frame-sync';
 import type { StreamerService } from '../services/streamer';
 import { useSidebarStore } from '../store';
-
 import GroupList from './GroupList';
 import SearchInput from './SearchInput';
 import SortMenu from './SortMenu';

--- a/src/sidebar/components/Tutorial.tsx
+++ b/src/sidebar/components/Tutorial.tsx
@@ -8,7 +8,6 @@ import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
 import classnames from 'classnames';
 
 import type { SidebarSettings } from '../../types/config';
-
 import { isThirdPartyService } from '../helpers/is-third-party-service';
 import { withServices } from '../service-context';
 

--- a/src/sidebar/components/UserMenu.tsx
+++ b/src/sidebar/components/UserMenu.tsx
@@ -10,7 +10,6 @@ import {
 import { withServices } from '../service-context';
 import type { FrameSyncService } from '../services/frame-sync';
 import { useSidebarStore } from '../store';
-
 import Menu from './Menu';
 import MenuItem from './MenuItem';
 import MenuSection from './MenuSection';

--- a/src/sidebar/components/VersionInfo.tsx
+++ b/src/sidebar/components/VersionInfo.tsx
@@ -3,9 +3,9 @@ import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 
 import type { VersionData } from '../helpers/version-data';
+import { withServices } from '../service-context';
 import type { ToastMessengerService } from '../services/toast-messenger';
 import { copyText } from '../util/copy-to-clipboard';
-import { withServices } from '../service-context';
 
 type VersionInfoItemProps = {
   label: string;

--- a/src/sidebar/components/hooks/use-filter-options.js
+++ b/src/sidebar/components/hooks/use-filter-options.js
@@ -1,8 +1,8 @@
 import { useMemo } from 'preact/hooks';
 
-import { useSidebarStore } from '../../store';
 import { username } from '../../helpers/account-id';
 import { annotationDisplayName } from '../../helpers/annotation-user';
+import { useSidebarStore } from '../../store';
 
 /** @typedef {import('../../store/modules/filters').FilterOption} FilterOption */
 

--- a/src/sidebar/components/hooks/use-root-thread.js
+++ b/src/sidebar/components/hooks/use-root-thread.js
@@ -1,7 +1,7 @@
 import { useMemo } from 'preact/hooks';
 
-import { useSidebarStore } from '../../store';
 import { threadAnnotations } from '../../helpers/thread-annotations';
+import { useSidebarStore } from '../../store';
 
 /** @typedef {import('../../helpers/build-thread').Thread} Thread */
 

--- a/src/sidebar/components/test/AnnotationView-test.js
+++ b/src/sidebar/components/test/AnnotationView-test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 
-import { waitFor } from '../../../test-util/wait';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import { waitFor } from '../../../test-util/wait';
 import AnnotationView, { $imports } from '../AnnotationView';
 
 describe('AnnotationView', () => {

--- a/src/sidebar/components/test/AutocompleteList-test.js
+++ b/src/sidebar/components/test/AutocompleteList-test.js
@@ -1,9 +1,8 @@
 import { mount } from 'enzyme';
 
-import AutocompleteList, { $imports } from '../AutocompleteList';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import AutocompleteList, { $imports } from '../AutocompleteList';
 
 describe('AutocompleteList', () => {
   let fakeList;

--- a/src/sidebar/components/test/Excerpt-test.js
+++ b/src/sidebar/components/test/Excerpt-test.js
@@ -1,9 +1,8 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import Excerpt, { $imports } from '../Excerpt';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
+import Excerpt, { $imports } from '../Excerpt';
 
 describe('Excerpt', () => {
   const SHORT_DIV = <div id="foo" style={{ height: 5 }} />;

--- a/src/sidebar/components/test/FilterSelect-test.js
+++ b/src/sidebar/components/test/FilterSelect-test.js
@@ -1,11 +1,9 @@
 import { ProfileIcon } from '@hypothesis/frontend-shared/lib/next';
 import { mount } from 'enzyme';
 
-import FilterSelect, { $imports } from '../FilterSelect';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
-
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import FilterSelect, { $imports } from '../FilterSelect';
 
 describe('FilterSelect', () => {
   let someOptions;

--- a/src/sidebar/components/test/HelpPanel-test.js
+++ b/src/sidebar/components/test/HelpPanel-test.js
@@ -1,10 +1,9 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import HelpPanel, { $imports } from '../HelpPanel';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import HelpPanel, { $imports } from '../HelpPanel';
 
 describe('HelpPanel', () => {
   let fakeSessionService;

--- a/src/sidebar/components/test/LoggedOutMessage-test.js
+++ b/src/sidebar/components/test/LoggedOutMessage-test.js
@@ -1,9 +1,8 @@
 import { mount } from 'enzyme';
 
-import LoggedOutMessage, { $imports } from '../LoggedOutMessage';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import LoggedOutMessage, { $imports } from '../LoggedOutMessage';
 
 describe('LoggedOutMessage', () => {
   let fakeStore;

--- a/src/sidebar/components/test/LoginPromptPanel-test.js
+++ b/src/sidebar/components/test/LoginPromptPanel-test.js
@@ -1,9 +1,8 @@
 import { mount } from 'enzyme';
 
-import LoginPromptPanel, { $imports } from '../LoginPromptPanel';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import LoginPromptPanel, { $imports } from '../LoginPromptPanel';
 
 describe('LoginPromptPanel', () => {
   let fakeOnLogin;

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -2,11 +2,10 @@ import { mount } from 'enzyme';
 import { render } from 'preact';
 import { act } from 'preact/test-utils';
 
+import { checkAccessibility } from '../../../test-util/accessibility';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import { LinkType } from '../../markdown-commands';
 import MarkdownEditor, { $imports } from '../MarkdownEditor';
-
-import { mockImportedComponents } from '../../../test-util/mock-imported-components';
-import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('MarkdownEditor', () => {
   const formatResult = {

--- a/src/sidebar/components/test/MarkdownView-test.js
+++ b/src/sidebar/components/test/MarkdownView-test.js
@@ -1,8 +1,7 @@
 import { mount } from 'enzyme';
 
-import MarkdownView, { $imports } from '../MarkdownView';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
+import MarkdownView, { $imports } from '../MarkdownView';
 
 describe('MarkdownView', () => {
   let fakeRenderMathAndMarkdown;

--- a/src/sidebar/components/test/Menu-test.js
+++ b/src/sidebar/components/test/Menu-test.js
@@ -1,11 +1,10 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
+import { checkAccessibility } from '../../../test-util/accessibility';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import Menu from '../Menu';
 import { $imports } from '../Menu';
-
-import { mockImportedComponents } from '../../../test-util/mock-imported-components';
-import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('Menu', () => {
   let container;

--- a/src/sidebar/components/test/MenuItem-test.js
+++ b/src/sidebar/components/test/MenuItem-test.js
@@ -2,10 +2,9 @@ import { EditIcon } from '@hypothesis/frontend-shared/lib/next';
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import MenuItem, { $imports } from '../MenuItem';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import MenuItem, { $imports } from '../MenuItem';
 
 describe('MenuItem', () => {
   let containers = [];

--- a/src/sidebar/components/test/MenuKeyboardNavigation-test.js
+++ b/src/sidebar/components/test/MenuKeyboardNavigation-test.js
@@ -1,9 +1,8 @@
 import { mount } from 'enzyme';
 
-import MenuKeyboardNavigation, { $imports } from '../MenuKeyboardNavigation';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import MenuKeyboardNavigation, { $imports } from '../MenuKeyboardNavigation';
 
 describe('MenuKeyboardNavigation', () => {
   let fakeCloseMenu;

--- a/src/sidebar/components/test/MenuSection-test.js
+++ b/src/sidebar/components/test/MenuSection-test.js
@@ -1,10 +1,9 @@
 import { mount } from 'enzyme';
 
-import MenuSection from '../MenuSection';
-import { $imports } from '../MenuSection';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import MenuSection from '../MenuSection';
+import { $imports } from '../MenuSection';
 
 describe('MenuSection', () => {
   const createMenuSection = props =>

--- a/src/sidebar/components/test/ModerationBanner-test.js
+++ b/src/sidebar/components/test/ModerationBanner-test.js
@@ -1,10 +1,9 @@
 import { mount } from 'enzyme';
 
-import * as fixtures from '../../test/annotation-fixtures';
-import ModerationBanner, { $imports } from '../ModerationBanner';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import * as fixtures from '../../test/annotation-fixtures';
+import ModerationBanner, { $imports } from '../ModerationBanner';
 
 const moderatedAnnotation = fixtures.moderatedAnnotation;
 

--- a/src/sidebar/components/test/NotebookFilters-test.js
+++ b/src/sidebar/components/test/NotebookFilters-test.js
@@ -1,10 +1,9 @@
 import { ProfileIcon } from '@hypothesis/frontend-shared/lib/next';
 import { mount } from 'enzyme';
 
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import NotebookFilters from '../NotebookFilters';
 import { $imports } from '../NotebookFilters';
-
-import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('NotebookFilters', () => {
   let fakeStore;

--- a/src/sidebar/components/test/NotebookResultCount-test.js
+++ b/src/sidebar/components/test/NotebookResultCount-test.js
@@ -1,7 +1,6 @@
 import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-
 import NotebookResultCount, { $imports } from '../NotebookResultCount';
 
 describe('NotebookResultCount', () => {

--- a/src/sidebar/components/test/PaginatedThreadList-test.js
+++ b/src/sidebar/components/test/PaginatedThreadList-test.js
@@ -1,8 +1,7 @@
 import { mount } from 'enzyme';
 
-import PaginatedThreadList, { $imports } from '../PaginatedThreadList';
-
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import PaginatedThreadList, { $imports } from '../PaginatedThreadList';
 
 describe('PaginatedThreadList', () => {
   // Fake props

--- a/src/sidebar/components/test/PaginationNavigation-test.js
+++ b/src/sidebar/components/test/PaginationNavigation-test.js
@@ -2,7 +2,6 @@ import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
 import { checkAccessibility } from '../../../test-util/accessibility';
-
 import PaginationNavigation, { $imports } from '../PaginationNavigation';
 
 describe('PaginationNavigation', () => {

--- a/src/sidebar/components/test/SearchInput-test.js
+++ b/src/sidebar/components/test/SearchInput-test.js
@@ -1,10 +1,9 @@
 import { mount } from 'enzyme';
 
+import { checkAccessibility } from '../../../test-util/accessibility';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import SearchInput from '../SearchInput';
 import { $imports } from '../SearchInput';
-
-import { mockImportedComponents } from '../../../test-util/mock-imported-components';
-import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('SearchInput', () => {
   let fakeIsMacOS;

--- a/src/sidebar/components/test/SelectionTabs-test.js
+++ b/src/sidebar/components/test/SelectionTabs-test.js
@@ -1,9 +1,8 @@
 import { mount } from 'enzyme';
 
-import SelectionTabs, { $imports } from '../SelectionTabs';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import SelectionTabs, { $imports } from '../SelectionTabs';
 
 describe('SelectionTabs', () => {
   // mock services

--- a/src/sidebar/components/test/ShareAnnotationsPanel-test.js
+++ b/src/sidebar/components/test/ShareAnnotationsPanel-test.js
@@ -1,10 +1,9 @@
 import { mount } from 'enzyme';
 
-import ShareAnnotationsPanel from '../ShareAnnotationsPanel';
-import { $imports } from '../ShareAnnotationsPanel';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import ShareAnnotationsPanel from '../ShareAnnotationsPanel';
+import { $imports } from '../ShareAnnotationsPanel';
 
 describe('ShareAnnotationsPanel', () => {
   let fakeStore;

--- a/src/sidebar/components/test/ShareLinks-test.js
+++ b/src/sidebar/components/test/ShareLinks-test.js
@@ -1,9 +1,8 @@
 import { mount } from 'enzyme';
 
-import ShareLinks, { $imports } from '../ShareLinks';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import ShareLinks, { $imports } from '../ShareLinks';
 
 describe('ShareLinks', () => {
   const shareLink =

--- a/src/sidebar/components/test/SidebarContentError-test.js
+++ b/src/sidebar/components/test/SidebarContentError-test.js
@@ -1,10 +1,9 @@
 import { mount } from 'enzyme';
 
-import SidebarContentError from '../SidebarContentError';
-import { $imports } from '../SidebarContentError';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import SidebarContentError from '../SidebarContentError';
+import { $imports } from '../SidebarContentError';
 
 describe('SidebarContentError', () => {
   let fakeStore;

--- a/src/sidebar/components/test/SidebarPanel-test.js
+++ b/src/sidebar/components/test/SidebarPanel-test.js
@@ -1,9 +1,8 @@
 import { mount } from 'enzyme';
 
-import SidebarPanel, { $imports } from '../SidebarPanel';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import SidebarPanel, { $imports } from '../SidebarPanel';
 
 describe('SidebarPanel', () => {
   let fakeStore;

--- a/src/sidebar/components/test/SortMenu-test.js
+++ b/src/sidebar/components/test/SortMenu-test.js
@@ -1,9 +1,8 @@
 import { mount } from 'enzyme';
 
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import SortMenu from '../SortMenu';
 import { $imports } from '../SortMenu';
-
-import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('SortMenu', () => {
   let fakeStore;

--- a/src/sidebar/components/test/StreamSearchInput-test.js
+++ b/src/sidebar/components/test/StreamSearchInput-test.js
@@ -1,9 +1,8 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import StreamSearchInput, { $imports } from '../StreamSearchInput';
-
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import StreamSearchInput, { $imports } from '../StreamSearchInput';
 
 describe('StreamSearchInput', () => {
   let fakeRouter;

--- a/src/sidebar/components/test/StreamView-test.js
+++ b/src/sidebar/components/test/StreamView-test.js
@@ -2,7 +2,6 @@ import { mount } from 'enzyme';
 
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import { waitFor } from '../../../test-util/wait';
-
 import StreamView, { $imports } from '../StreamView';
 
 describe('StreamView', () => {

--- a/src/sidebar/components/test/TagEditor-test.js
+++ b/src/sidebar/components/test/TagEditor-test.js
@@ -1,12 +1,11 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
+import { checkAccessibility } from '../../../test-util/accessibility';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import AutocompleteList from '../AutocompleteList';
 import TagEditor from '../TagEditor';
 import { $imports } from '../TagEditor';
-
-import { checkAccessibility } from '../../../test-util/accessibility';
-import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 
 describe('TagEditor', () => {
   let containers = [];

--- a/src/sidebar/components/test/TagListItem-test.js
+++ b/src/sidebar/components/test/TagListItem-test.js
@@ -1,9 +1,8 @@
 import { mount } from 'enzyme';
 
-import TagListItem from '../TagListItem';
-import TagList from '../TagList';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
+import TagList from '../TagList';
+import TagListItem from '../TagListItem';
 
 describe('TagListItem', () => {
   const createComponent = props =>

--- a/src/sidebar/components/test/Thread-test.js
+++ b/src/sidebar/components/test/Thread-test.js
@@ -1,11 +1,10 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import Thread from '../Thread';
-import { $imports } from '../Thread';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import Thread from '../Thread';
+import { $imports } from '../Thread';
 
 // Utility functions to build nested threads
 let lastThreadId = 0;

--- a/src/sidebar/components/test/ThreadCard-test.js
+++ b/src/sidebar/components/test/ThreadCard-test.js
@@ -1,9 +1,8 @@
 import { mount } from 'enzyme';
 
-import ThreadCard, { $imports } from '../ThreadCard';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import ThreadCard, { $imports } from '../ThreadCard';
 
 describe('ThreadCard', () => {
   let container;

--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -1,11 +1,10 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import ThreadList from '../ThreadList';
-import { $imports } from '../ThreadList';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import ThreadList from '../ThreadList';
+import { $imports } from '../ThreadList';
 
 describe('ThreadList', () => {
   let fakeDomUtil;

--- a/src/sidebar/components/test/ToastMessages-test.js
+++ b/src/sidebar/components/test/ToastMessages-test.js
@@ -1,10 +1,9 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import { mockImportedComponents } from '../../../test-util/mock-imported-components';
-
-import ToastMessages, { $imports } from '../ToastMessages';
 import { checkAccessibility } from '../../../test-util/accessibility';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import ToastMessages, { $imports } from '../ToastMessages';
 
 describe('ToastMessages', () => {
   let fakeStore;

--- a/src/sidebar/components/test/Tutorial-test.js
+++ b/src/sidebar/components/test/Tutorial-test.js
@@ -1,9 +1,8 @@
 import { mount } from 'enzyme';
 
-import Tutorial, { $imports } from '../Tutorial';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';
+import Tutorial, { $imports } from '../Tutorial';
 
 describe('Tutorial', () => {
   let fakeIsThirdPartyService;

--- a/src/sidebar/components/test/VersionInfo-test.js
+++ b/src/sidebar/components/test/VersionInfo-test.js
@@ -1,10 +1,9 @@
 import { mount } from 'enzyme';
 
+import { checkAccessibility } from '../../../test-util/accessibility';
+import { mockImportedComponents } from '../../../test-util/mock-imported-components';
 import VersionInfo from '../VersionInfo';
 import { $imports } from '../VersionInfo';
-
-import { mockImportedComponents } from '../../../test-util/mock-imported-components';
-import { checkAccessibility } from '../../../test-util/accessibility';
 
 describe('VersionInfo', () => {
   let fakeVersionData;

--- a/src/sidebar/components/test/slider-test.js
+++ b/src/sidebar/components/test/slider-test.js
@@ -1,8 +1,7 @@
 import { mount } from 'enzyme';
 
-import Slider from '../Slider';
-
 import { checkAccessibility } from '../../../test-util/accessibility';
+import Slider from '../Slider';
 
 describe('Slider', () => {
   let container;

--- a/src/sidebar/config/build-settings.js
+++ b/src/sidebar/config/build-settings.js
@@ -1,6 +1,6 @@
+import * as postMessageJsonRpc from '../util/postmessage-json-rpc';
 import { getApiUrl } from './get-api-url';
 import { hostPageConfig } from './host-config';
-import * as postMessageJsonRpc from '../util/postmessage-json-rpc';
 
 /**
  * @typedef {import('../../types/config').ConfigFromHost} ConfigFromHost

--- a/src/sidebar/config/get-api-url.js
+++ b/src/sidebar/config/get-api-url.js
@@ -1,5 +1,4 @@
 /** @typedef {import('../../types/config').SidebarSettings} SidebarSettings */
-
 import { serviceConfig } from './service-config';
 
 /**

--- a/src/sidebar/cross-origin-rpc.js
+++ b/src/sidebar/cross-origin-rpc.js
@@ -1,5 +1,4 @@
 import { warnOnce } from '../shared/warn-once';
-
 import { normalizeGroupIds } from './helpers/groups';
 
 /**

--- a/src/sidebar/helpers/annotation-segment.ts
+++ b/src/sidebar/helpers/annotation-segment.ts
@@ -1,5 +1,4 @@
 import { stripCFIAssertions } from '../../shared/cfi';
-
 import type { SegmentInfo } from '../../types/annotator';
 import type { Annotation, EPUBContentSelector } from '../../types/api';
 

--- a/src/sidebar/helpers/annotation-sharing.js
+++ b/src/sidebar/helpers/annotation-sharing.js
@@ -2,7 +2,6 @@
  * @typedef {import('../../types/api').Annotation} Annotation
  * @typedef {import('../../types/config').SidebarSettings} SidebarSettings
  */
-
 import { serviceConfig } from '../config/service-config';
 
 /**

--- a/src/sidebar/helpers/annotation-user.js
+++ b/src/sidebar/helpers/annotation-user.js
@@ -2,7 +2,6 @@
  * @typedef {import("../../types/api").Annotation} Annotation
  * @typedef {import('../../types/config').SidebarSettings} SidebarSettings
  */
-
 import { isThirdPartyUser, username } from './account-id';
 
 /**

--- a/src/sidebar/helpers/groups.js
+++ b/src/sidebar/helpers/groups.js
@@ -3,7 +3,6 @@
  * @typedef {import('../../types/api').Group} Group
  * @typedef {import('../../types/api').GroupIdentifier} GroupIdentifier
  */
-
 import escapeStringRegexp from 'escape-string-regexp';
 
 import { serviceConfig } from '../config/service-config';

--- a/src/sidebar/helpers/is-third-party-service.js
+++ b/src/sidebar/helpers/is-third-party-service.js
@@ -1,7 +1,6 @@
 /**
  * @typedef {import('../../types/config').SidebarSettings} SidebarSettings
  */
-
 import { serviceConfig } from '../config/service-config';
 
 /**

--- a/src/sidebar/helpers/tabs.js
+++ b/src/sidebar/helpers/tabs.js
@@ -1,5 +1,4 @@
 // Functions that determine which tab an annotation should be displayed in.
-
 import * as metadata from '../helpers/annotation-metadata';
 
 /**

--- a/src/sidebar/helpers/test/build-thread-test.js
+++ b/src/sidebar/helpers/test/build-thread-test.js
@@ -1,5 +1,5 @@
-import { buildThread } from '../build-thread';
 import * as metadata from '../../helpers/annotation-metadata';
+import { buildThread } from '../build-thread';
 
 // Fixture with two top level annotations, one note and one reply
 const SIMPLE_FIXTURE = [

--- a/src/sidebar/helpers/test/thread-annotations-test.js
+++ b/src/sidebar/helpers/test/thread-annotations-test.js
@@ -1,8 +1,7 @@
 import * as annotationFixtures from '../../test/annotation-fixtures';
-
+import { immutable } from '../../util/immutable';
 import { threadAnnotations, $imports } from '../thread-annotations';
 import { sorters } from '../thread-sorters';
-import { immutable } from '../../util/immutable';
 
 const fixtures = immutable({
   emptyThread: {

--- a/src/sidebar/helpers/thread-annotations.js
+++ b/src/sidebar/helpers/thread-annotations.js
@@ -1,10 +1,9 @@
-import { buildThread } from './build-thread';
-
 import { memoize } from '../util/memoize';
 import { generateFacetedFilter } from '../util/search-filter';
-import { filterAnnotations } from './view-filter';
+import { buildThread } from './build-thread';
 import { shouldShowInTab } from './tabs';
 import { sorters } from './thread-sorters';
+import { filterAnnotations } from './view-filter';
 
 /** @typedef {import('../../types/api').Annotation} Annotation */
 /** @typedef {import('./build-thread').Thread} Thread */

--- a/src/sidebar/helpers/view-filter.js
+++ b/src/sidebar/helpers/view-filter.js
@@ -2,9 +2,8 @@
  * @typedef {import('../../types/api').Annotation} Annotation
  * @typedef {import('../util/search-filter').Facet} Facet
  */
-
-import { quote } from './annotation-metadata';
 import * as unicodeUtils from '../util/unicode';
+import { quote } from './annotation-metadata';
 
 /**
  * @typedef Filter

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -1,6 +1,5 @@
 // Load polyfill for :focus-visible pseudo-class.
 import 'focus-visible';
-// The entry point component for the app.
 import { render } from 'preact';
 // Enable debugging checks for Preact. Removed in prod builds by Rollup config.
 import 'preact/debug';

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -1,11 +1,41 @@
-import { parseJsonConfig } from '../boot/parse-json-config';
+// Load polyfill for :focus-visible pseudo-class.
+import 'focus-visible';
+// The entry point component for the app.
+import { render } from 'preact';
+// Enable debugging checks for Preact. Removed in prod builds by Rollup config.
+import 'preact/debug';
 
-import { checkEnvironment } from './config/check-env';
+import { parseJsonConfig } from '../boot/parse-json-config';
+import { Injector } from '../shared/injector';
+import HypothesisApp from './components/HypothesisApp';
+import LaunchErrorPanel from './components/LaunchErrorPanel';
 import { buildSettings } from './config/build-settings';
+import { checkEnvironment } from './config/check-env';
 import {
   startServer as startRPCServer,
   preStartServer as preStartRPCServer,
 } from './cross-origin-rpc.js';
+import { ServiceContext } from './service-context';
+import { AnnotationActivityService } from './services/annotation-activity';
+import { AnnotationsService } from './services/annotations';
+import { APIService } from './services/api';
+import { APIRoutesService } from './services/api-routes';
+import { AuthService } from './services/auth';
+import { AutosaveService } from './services/autosave';
+import { FrameSyncService } from './services/frame-sync';
+import { GroupsService } from './services/groups';
+import { LoadAnnotationsService } from './services/load-annotations';
+import { LocalStorageService } from './services/local-storage';
+import { PersistedDefaultsService } from './services/persisted-defaults';
+import { RouterService } from './services/router';
+import { ServiceURLService } from './services/service-url';
+import { SessionService } from './services/session';
+import { StreamFilter } from './services/stream-filter';
+import { StreamerService } from './services/streamer';
+import { TagsService } from './services/tags';
+import { ThreadsService } from './services/threads';
+import { ToastMessengerService } from './services/toast-messenger';
+import { createSidebarStore } from './store';
 import { disableOpenerForExternalLinks } from './util/disable-opener-for-external-links';
 import * as sentry from './util/sentry';
 
@@ -29,12 +59,6 @@ if (configFromSidebar.sentry && envOk) {
 
 // Prevent tab-jacking.
 disableOpenerForExternalLinks(document.body);
-
-// Load polyfill for :focus-visible pseudo-class.
-import 'focus-visible';
-
-// Enable debugging checks for Preact. Removed in prod builds by Rollup config.
-import 'preact/debug';
 
 /**
  * @param {import('./services/api').APIService} api
@@ -87,39 +111,6 @@ function setupFrameSync(frameSync, store) {
     frameSync.connect();
   }
 }
-
-// The entry point component for the app.
-import { render } from 'preact';
-import HypothesisApp from './components/HypothesisApp';
-import LaunchErrorPanel from './components/LaunchErrorPanel';
-import { ServiceContext } from './service-context';
-
-// Services.
-import { AnnotationsService } from './services/annotations';
-import { AnnotationActivityService } from './services/annotation-activity';
-import { APIService } from './services/api';
-import { APIRoutesService } from './services/api-routes';
-import { AuthService } from './services/auth';
-import { AutosaveService } from './services/autosave';
-import { FrameSyncService } from './services/frame-sync';
-import { GroupsService } from './services/groups';
-import { LoadAnnotationsService } from './services/load-annotations';
-import { LocalStorageService } from './services/local-storage';
-import { PersistedDefaultsService } from './services/persisted-defaults';
-import { RouterService } from './services/router';
-import { ServiceURLService } from './services/service-url';
-import { SessionService } from './services/session';
-import { StreamFilter } from './services/stream-filter';
-import { StreamerService } from './services/streamer';
-import { TagsService } from './services/tags';
-import { ThreadsService } from './services/threads';
-import { ToastMessengerService } from './services/toast-messenger';
-
-// Redux store.
-import { createSidebarStore } from './store';
-
-// Utilities.
-import { Injector } from '../shared/injector';
 
 /**
  * Launch the client application corresponding to the current URL.

--- a/src/sidebar/service-context.js
+++ b/src/sidebar/service-context.js
@@ -11,7 +11,6 @@
 /**
  * @typedef {import("redux").Store} Store
  */
-
 import { createContext } from 'preact';
 import { useContext } from 'preact/hooks';
 

--- a/src/sidebar/services/auth.ts
+++ b/src/sidebar/services/auth.ts
@@ -1,12 +1,10 @@
 import { TinyEmitter } from 'tiny-emitter';
 
 import type { SidebarSettings } from '../../types/config';
+import { serviceConfig } from '../config/service-config';
 import { OAuthClient } from '../util/oauth-client';
 import type { TokenInfo } from '../util/oauth-client';
 import { resolve } from '../util/url';
-
-import { serviceConfig } from '../config/service-config';
-
 import type { APIRoutesService } from './api-routes';
 import type { LocalStorageService } from './local-storage';
 import type { ToastMessengerService } from './toast-messenger';

--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -9,10 +9,6 @@ import {
   isMessage,
   isMessageEqual,
 } from '../../shared/messaging';
-import { isReply, isPublic } from '../helpers/annotation-metadata';
-import { annotationMatchesSegment } from '../helpers/annotation-segment';
-import { watch } from '../util/watch';
-
 import type { Message } from '../../shared/messaging';
 import type { AnnotationData, DocumentInfo } from '../../types/annotator';
 import type { Annotation } from '../../types/api';
@@ -22,8 +18,11 @@ import type {
   SidebarToGuestEvent,
   GuestToSidebarEvent,
 } from '../../types/port-rpc-events';
+import { isReply, isPublic } from '../helpers/annotation-metadata';
+import { annotationMatchesSegment } from '../helpers/annotation-segment';
 import type { SidebarStore } from '../store';
 import type { Frame } from '../store/modules/frames';
+import { watch } from '../util/watch';
 import type { AnnotationsService } from './annotations';
 
 /**

--- a/src/sidebar/services/groups.js
+++ b/src/sidebar/services/groups.js
@@ -1,5 +1,7 @@
 import shallowEqual from 'shallowequal';
 
+// @ts-ignore - TS doesn't know about SVG files.
+import { default as logo } from '../../images/icons/logo.svg';
 import { serviceConfig } from '../config/service-config';
 import { isReply } from '../helpers/annotation-metadata';
 import { combineGroups } from '../helpers/groups';
@@ -9,9 +11,6 @@ import { watch } from '../util/watch';
 /** @typedef {import('../../types/api').Group} Group */
 
 const DEFAULT_ORG_ID = '__default__';
-
-// @ts-ignore - TS doesn't know about SVG files.
-import { default as logo } from '../../images/icons/logo.svg';
 
 const DEFAULT_ORGANIZATION = {
   id: DEFAULT_ORG_ID,

--- a/src/sidebar/services/load-annotations.ts
+++ b/src/sidebar/services/load-annotations.ts
@@ -1,13 +1,11 @@
 import type { Annotation } from '../../types/api';
-
 import { isReply } from '../helpers/annotation-metadata';
 import { SearchClient } from '../search-client';
 import type { SortBy, SortOrder } from '../search-client';
 import type { SidebarStore } from '../store';
-
 import type { APIService } from './api';
-import type { StreamerService } from './streamer';
 import type { StreamFilter } from './stream-filter';
+import type { StreamerService } from './streamer';
 
 export type LoadAnnotationOptions = {
   groupId: string;

--- a/src/sidebar/services/test/annotation-activity-test.js
+++ b/src/sidebar/services/test/annotation-activity-test.js
@@ -1,5 +1,4 @@
 import * as fixtures from '../../test/annotation-fixtures';
-
 import { AnnotationActivityService, $imports } from '../annotation-activity';
 
 describe('AnnotationActivityService', () => {

--- a/src/sidebar/services/test/annotations-test.js
+++ b/src/sidebar/services/test/annotations-test.js
@@ -1,5 +1,4 @@
 import * as fixtures from '../../test/annotation-fixtures';
-
 import { AnnotationsService, $imports } from '../annotations';
 
 describe('AnnotationsService', () => {

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -1,7 +1,6 @@
 import fetchMock from 'fetch-mock';
 
 import { APIService } from '../api';
-
 // API route directory.
 //
 // This should mirror https://hypothes.is/api/. The domain name has been changed
@@ -12,6 +11,7 @@ import { APIService } from '../api';
 // `curl https://hypothes.is/api/ | sed 's/hypothes.is/example.com/g' | jq . > api-index.json`
 //
 import apiIndex from './api-index.json';
+
 const routes = apiIndex.links;
 
 describe('APIService', () => {

--- a/src/sidebar/services/test/autosave-test.js
+++ b/src/sidebar/services/test/autosave-test.js
@@ -1,7 +1,6 @@
+import { waitFor } from '../../../test-util/wait';
 import * as annotationFixtures from '../../test/annotation-fixtures';
 import { fakeReduxStore } from '../../test/fake-redux-store';
-import { waitFor } from '../../../test-util/wait';
-
 import { AutosaveService, $imports } from '../autosave';
 
 describe('AutosaveService', () => {

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -1,10 +1,9 @@
 import EventEmitter from 'tiny-emitter';
 
 import { Injector } from '../../../shared/injector';
+import { delay } from '../../../test-util/wait';
 import * as annotationFixtures from '../../test/annotation-fixtures';
 import { fakeReduxStore } from '../../test/fake-redux-store';
-import { delay } from '../../../test-util/wait';
-
 import { FrameSyncService, $imports, formatAnnot } from '../frame-sync';
 
 class FakeWindow extends EventTarget {

--- a/src/sidebar/services/test/router-test.js
+++ b/src/sidebar/services/test/router-test.js
@@ -1,4 +1,5 @@
 import EventEmitter from 'tiny-emitter';
+
 import { RouterService } from '../router';
 
 const fixtures = [

--- a/src/sidebar/store/create-store.ts
+++ b/src/sidebar/store/create-store.ts
@@ -1,5 +1,4 @@
 /* global process */
-
 import * as redux from 'redux';
 import thunk from 'redux-thunk';
 

--- a/src/sidebar/store/modules/activity.js
+++ b/src/sidebar/store/modules/activity.js
@@ -2,7 +2,6 @@
  * Store module which tracks activity happening in the application that may
  * need to be reflected in the UI.
  */
-
 import { createStoreModule, makeAction } from '../create-store';
 
 /** @typedef {import('../../../types/api').Annotation} Annotation */

--- a/src/sidebar/store/modules/annotations.ts
+++ b/src/sidebar/store/modules/annotations.ts
@@ -2,19 +2,16 @@
  * State management for the set of annotations currently loaded into the
  * sidebar.
  */
-
 import type { Dispatch } from 'redux';
 import { createSelector } from 'reselect';
 
 import { hasOwn } from '../../../shared/has-own';
 import type { Annotation, SavedAnnotation } from '../../../types/api';
 import type { HighlightCluster } from '../../../types/shared';
-
 import * as metadata from '../../helpers/annotation-metadata';
 import { isHighlight, isSaved } from '../../helpers/annotation-metadata';
 import { countIf, toTrueMap, trueKeys } from '../../util/collections';
 import { createStoreModule, makeAction } from '../create-store';
-
 import { routeModule } from './route';
 import type { State as RouteState } from './route';
 import { sessionModule } from './session';

--- a/src/sidebar/store/modules/groups.js
+++ b/src/sidebar/store/modules/groups.js
@@ -1,7 +1,6 @@
 import { createSelector } from 'reselect';
 
 import { createStoreModule, makeAction } from '../create-store';
-
 import { sessionModule } from './session';
 
 /**

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -9,7 +9,6 @@
  * @typedef {import('./groups').State} GroupsState
  * @typedef {import('./route').State} RouteState
  */
-
 import { createSelector } from 'reselect';
 
 import { hasOwn } from '../../../shared/has-own';

--- a/src/sidebar/store/modules/sidebar-panels.js
+++ b/src/sidebar/store/modules/sidebar-panels.js
@@ -11,7 +11,6 @@
 /**
  * @typedef {import("../../../types/sidebar").PanelName} PanelName
  */
-
 import { createStoreModule, makeAction } from '../create-store';
 
 const initialState = {

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -1,5 +1,5 @@
-import * as fixtures from '../../../test/annotation-fixtures';
 import * as metadata from '../../../helpers/annotation-metadata';
+import * as fixtures from '../../../test/annotation-fixtures';
 import { createStore } from '../../create-store';
 import { annotationsModule } from '../annotations';
 import { routeModule } from '../route';

--- a/src/sidebar/store/modules/test/drafts-test.js
+++ b/src/sidebar/store/modules/test/drafts-test.js
@@ -1,9 +1,9 @@
+import { immutable } from '../../../util/immutable';
 import { createStore } from '../../create-store';
 import { annotationsModule } from '../annotations';
 import { draftsModule } from '../drafts';
 import { Draft } from '../drafts';
 import { selectionModule } from '../selection';
-import { immutable } from '../../../util/immutable';
 
 const fixtures = immutable({
   draftWithText: {

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -1,7 +1,7 @@
+import { immutable } from '../../../util/immutable';
 import { createStore } from '../../create-store';
 import { groupsModule } from '../groups';
 import { sessionModule } from '../session';
-import { immutable } from '../../../util/immutable';
 
 describe('sidebar/store/modules/groups', () => {
   const publicGroup = immutable({

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -1,9 +1,9 @@
+import * as fixtures from '../../../test/annotation-fixtures';
 import { createStore } from '../../create-store';
 import { annotationsModule } from '../annotations';
 import { filtersModule } from '../filters';
-import { selectionModule } from '../selection';
 import { routeModule } from '../route';
-import * as fixtures from '../../../test/annotation-fixtures';
+import { selectionModule } from '../selection';
 
 describe('sidebar/store/modules/selection', () => {
   let store;

--- a/src/sidebar/store/test/create-store-test.js
+++ b/src/sidebar/store/test/create-store-test.js
@@ -1,5 +1,4 @@
 /* global process */
-
 import { createStore, createStoreModule } from '../create-store';
 
 function initialState(value = 0) {

--- a/src/sidebar/store/test/debug-middleware-test.js
+++ b/src/sidebar/store/test/debug-middleware-test.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 import * as redux from 'redux';
 
 import { debugMiddleware } from '../debug-middleware';

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -1,10 +1,10 @@
 import { render } from 'preact';
 import { act } from 'preact/test-utils';
 
-import * as annotationFixtures from '../../test/annotation-fixtures';
-import { createSidebarStore, useSidebarStore } from '../index';
-import { immutable } from '../../util/immutable';
 import { ServiceContext } from '../../service-context';
+import * as annotationFixtures from '../../test/annotation-fixtures';
+import { immutable } from '../../util/immutable';
+import { createSidebarStore, useSidebarStore } from '../index';
 
 const defaultAnnotation = annotationFixtures.defaultAnnotation;
 const newAnnotation = annotationFixtures.newAnnotation;

--- a/src/sidebar/store/test/util-test.js
+++ b/src/sidebar/store/test/util-test.js
@@ -1,5 +1,4 @@
 import { fakeReduxStore } from '../../test/fake-redux-store';
-
 import { actionTypes, awaitStateChange } from '../util';
 
 describe('sidebar/store/util', () => {

--- a/src/sidebar/test/bootstrap.js
+++ b/src/sidebar/test/bootstrap.js
@@ -1,15 +1,15 @@
-// Expose the sinon assertions.
-sinon.assert.expose(assert, { prefix: null });
-
 // Patch extra assert helper methods
-import { patch } from '../../test-util/assert-methods';
-patch(assert);
-
+import { configure } from 'enzyme';
+import { Adapter } from 'enzyme-adapter-preact-pure';
 // Configure Enzyme for UI tests.
 import 'preact/debug';
 
-import { configure } from 'enzyme';
-import { Adapter } from 'enzyme-adapter-preact-pure';
+import { patch } from '../../test-util/assert-methods';
+
+// Expose the sinon assertions.
+sinon.assert.expose(assert, { prefix: null });
+
+patch(assert);
 
 configure({ adapter: new Adapter() });
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,4 +1,5 @@
 import type { ClientAnnotationData } from './shared';
+
 /**
  * Type definitions for objects returned from the Hypothesis API.
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -2021,6 +2021,9 @@
     "@typescript-eslint/types" "5.51.0"
     eslint-visitor-keys "^3.3.0"
 
+"@vue/compiler-sfc@./scripts/stub-package":
+  version "3.0.0"
+
 abbrev@1, abbrev@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@babel/code-frame@^7.18.6":
+"@babel/code-frame@^7.16.7", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
   integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
@@ -25,6 +25,27 @@
   version "7.20.10"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.10.tgz#9d92fa81b87542fff50e848ed585b4212c1d34ec"
   integrity sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==
+
+"@babel/core@7.17.8":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.17.8.tgz#3dac27c190ebc3a4381110d46c80e77efe172e1a"
+  integrity sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==
+  dependencies:
+    "@ampproject/remapping" "^2.1.0"
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.7"
+    "@babel/helper-compilation-targets" "^7.17.7"
+    "@babel/helper-module-transforms" "^7.17.7"
+    "@babel/helpers" "^7.17.8"
+    "@babel/parser" "^7.17.8"
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.17.3"
+    "@babel/types" "^7.17.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
 
 "@babel/core@^7.0.0", "@babel/core@^7.1.6", "@babel/core@^7.12.3":
   version "7.20.12"
@@ -46,6 +67,24 @@
     gensync "^1.0.0-beta.2"
     json5 "^2.2.2"
     semver "^6.3.0"
+
+"@babel/generator@7.17.7":
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.7.tgz#8da2599beb4a86194a3b24df6c085931d9ee45ad"
+  integrity sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==
+  dependencies:
+    "@babel/types" "^7.17.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.17.3", "@babel/generator@^7.17.7":
+  version "7.20.14"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.14.tgz#9fa772c9f86a46c6ac9b321039400712b96f64ce"
+  integrity sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==
+  dependencies:
+    "@babel/types" "^7.20.7"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
 
 "@babel/generator@^7.20.7":
   version "7.20.7"
@@ -136,15 +175,15 @@
     resolve "^1.14.2"
     semver "^6.1.2"
 
+"@babel/helper-environment-visitor@^7.16.7", "@babel/helper-environment-visitor@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
+  integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
+
 "@babel/helper-environment-visitor@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.6.tgz#b7eee2b5b9d70602e59d1a6cad7dd24de7ca6cd7"
   integrity sha512-8n6gSfn2baOY+qlp+VSzsosjCVGFqWKmDF0cCWOybh52Dw3SEyoWR1KrhMJASjLwIEkkAufZ0xvr+SxLHSpy2Q==
-
-"@babel/helper-environment-visitor@^7.18.9":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
-  integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
 
 "@babel/helper-explode-assignable-expression@^7.18.6":
   version "7.18.6"
@@ -152,6 +191,14 @@
   integrity sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==
   dependencies:
     "@babel/types" "^7.18.6"
+
+"@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz#941574ed5390682e872e52d3f38ce9d1bef4648c"
+  integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==
+  dependencies:
+    "@babel/template" "^7.18.10"
+    "@babel/types" "^7.19.0"
 
 "@babel/helper-function-name@^7.18.6":
   version "7.18.6"
@@ -169,15 +216,7 @@
     "@babel/template" "^7.18.6"
     "@babel/types" "^7.18.9"
 
-"@babel/helper-function-name@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz#941574ed5390682e872e52d3f38ce9d1bef4648c"
-  integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==
-  dependencies:
-    "@babel/template" "^7.18.10"
-    "@babel/types" "^7.19.0"
-
-"@babel/helper-hoist-variables@^7.18.6":
+"@babel/helper-hoist-variables@^7.16.7", "@babel/helper-hoist-variables@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
   integrity sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
@@ -205,7 +244,7 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-module-transforms@^7.18.6", "@babel/helper-module-transforms@^7.19.6", "@babel/helper-module-transforms@^7.20.11":
+"@babel/helper-module-transforms@^7.17.7", "@babel/helper-module-transforms@^7.18.6", "@babel/helper-module-transforms@^7.19.6", "@babel/helper-module-transforms@^7.20.11":
   version "7.20.11"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz#df4c7af713c557938c50ea3ad0117a7944b2f1b0"
   integrity sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==
@@ -305,7 +344,7 @@
   dependencies:
     "@babel/types" "^7.18.9"
 
-"@babel/helper-split-export-declaration@^7.18.6":
+"@babel/helper-split-export-declaration@^7.16.7", "@babel/helper-split-export-declaration@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz#7367949bc75b20c6d5a5d4a97bba2824ae8ef075"
   integrity sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==
@@ -317,15 +356,15 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
   integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
 
+"@babel/helper-validator-identifier@^7.16.7", "@babel/helper-validator-identifier@^7.19.1":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
+  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
+
 "@babel/helper-validator-identifier@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
   integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
-
-"@babel/helper-validator-identifier@^7.19.1":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
-  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
 
 "@babel/helper-validator-option@^7.18.6":
   version "7.18.6"
@@ -352,6 +391,15 @@
     "@babel/traverse" "^7.18.11"
     "@babel/types" "^7.18.10"
 
+"@babel/helpers@^7.17.8":
+  version "7.20.13"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.20.13.tgz#e3cb731fb70dc5337134cadc24cbbad31cc87ad2"
+  integrity sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==
+  dependencies:
+    "@babel/template" "^7.20.7"
+    "@babel/traverse" "^7.20.13"
+    "@babel/types" "^7.20.7"
+
 "@babel/helpers@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.20.7.tgz#04502ff0feecc9f20ecfaad120a18f011a8e6dce"
@@ -370,10 +418,20 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/parser@7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.9.tgz#f2dde0c682ccc264a9a8595efd030a5cc8fd2539"
+  integrity sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==
+
 "@babel/parser@^7.14.7", "@babel/parser@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.7.tgz#66fe23b3c8569220817d5feb8b9dcdc95bb4f71b"
   integrity sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==
+
+"@babel/parser@^7.17.3", "@babel/parser@^7.17.8", "@babel/parser@^7.20.13":
+  version "7.20.15"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.15.tgz#eec9f36d8eaf0948bb88c87a46784b5ee9fd0c89"
+  integrity sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1051,7 +1109,7 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/template@^7.18.10", "@babel/template@^7.18.6", "@babel/template@^7.20.7":
+"@babel/template@^7.16.7", "@babel/template@^7.18.10", "@babel/template@^7.18.6", "@babel/template@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
   integrity sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==
@@ -1059,6 +1117,38 @@
     "@babel/code-frame" "^7.18.6"
     "@babel/parser" "^7.20.7"
     "@babel/types" "^7.20.7"
+
+"@babel/traverse@7.17.3":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.3.tgz#0ae0f15b27d9a92ba1f2263358ea7c4e7db47b57"
+  integrity sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.3"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.17.3"
+    "@babel/types" "^7.17.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.17.3", "@babel/traverse@^7.20.13":
+  version "7.20.13"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.13.tgz#817c1ba13d11accca89478bd5481b2d168d07473"
+  integrity sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.20.7"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.20.13"
+    "@babel/types" "^7.20.7"
+    debug "^4.1.0"
+    globals "^11.1.0"
 
 "@babel/traverse@^7.18.11", "@babel/traverse@^7.18.6", "@babel/traverse@^7.18.9", "@babel/traverse@^7.19.1", "@babel/traverse@^7.20.10", "@babel/traverse@^7.20.12", "@babel/traverse@^7.20.7":
   version "7.20.12"
@@ -1076,7 +1166,15 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.19.4", "@babel/types@^7.20.2", "@babel/types@^7.20.7", "@babel/types@^7.4.4":
+"@babel/types@7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
+  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.17.0", "@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.19.4", "@babel/types@^7.20.2", "@babel/types@^7.20.7", "@babel/types@^7.4.4":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.7.tgz#54ec75e252318423fc07fb644dc6a58a64c09b7f"
   integrity sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==
@@ -1694,6 +1792,19 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
+"@trivago/prettier-plugin-sort-imports@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.0.0.tgz#e0936d87fb8d65865c857e6a6dba644103db1b30"
+  integrity sha512-Tyuk5ZY4a0e2MNFLdluQO9F6d1awFQYXVVujEPFfvKPPXz8DADNHzz73NMhwCSXGSuGGZcA/rKOyZBrxVNMxaA==
+  dependencies:
+    "@babel/core" "7.17.8"
+    "@babel/generator" "7.17.7"
+    "@babel/parser" "7.18.9"
+    "@babel/traverse" "7.17.3"
+    "@babel/types" "7.17.0"
+    javascript-natural-sort "0.7.1"
+    lodash "4.17.21"
 
 "@types/component-emitter@^1.2.10":
   version "1.2.11"
@@ -5545,6 +5656,11 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+javascript-natural-sort@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
+  integrity sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==
+
 jmespath@0.16.0:
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
@@ -5605,7 +5721,7 @@ json-stringify-nice@^1.1.4:
   resolved "https://registry.yarnpkg.com/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz#2c937962b80181d3f317dd39aa323e14f5a60a67"
   integrity sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==
 
-json5@^2.2.2:
+json5@^2.1.2, json5@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -5892,7 +6008,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.15.0, lodash@^4.17.21:
+lodash@4.17.21, lodash@^4.15.0, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -7984,7 +8100,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@^0.5.6:
+source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=


### PR DESCRIPTION
This is an alternative approach to what was proposed in https://github.com/hypothesis/client/pull/5231

It serves the same purpose, automating the ordering of imports, but via `prettier` instead of `eslint`, as the kind of task fits better with prettier's scope.

Based on the discussions from the original PR, we will have just two groups of imports, separated by an empty line. Each group is ordered alphabetically:

* external imports
* internal imports

```ts
import { ... } from '@hypothesis/...';
import { ... } from 'classnames';
import { ... } from 'foo';

import { ... } from '../../../aaa';
import { ... } from '../../../bbb';
import { ... } from '../../../ccc';
import { ... } from '../../aaa';
import { ... } from '../../bbb';
import { ... } from '../../ccc';
import { ... } from '../aaa';
import { ... } from '../bbb';
import { ... } from '../ccc';
import { ... } from './aaa';
import { ... } from './bbb';
import { ... } from './ccc';
```

The plugin used for this is https://github.com/trivago/prettier-plugin-sort-imports. I have explored others but this one seems to be the one with higher adoption and better maintained.

~Again, I have applied the changes only to a couple of files, as a POC.~ I have applied it to all files in order to check if anything breaks.