### PR TITLE
Add interim fix for search input visual regression

### DIFF
--- a/src/sidebar/components/SearchInput.tsx
+++ b/src/sidebar/components/SearchInput.tsx
@@ -161,7 +161,9 @@ export default function SearchInput({
           },
           {
             // Make the input dimensionless when not expanded (or focused)
-            'max-w-0 p-0': !isExpanded,
+            // Make the 0-padding rule `!important` so that it doesn't get
+            // superseded by `Input` padding
+            'max-w-0 !p-0': !isExpanded,
             // Make the input have dimensions and padding when focused or
             // expanded. The left-margin is to make room for the focus ring of
             // the search icon-button when navigating by keyboard. Set a


### PR DESCRIPTION
I'd like to get a fix out for the visual regression reported this morning. I will immediately (as in, now) follow up to see how to "fix this correctly" so we don't require a `!important` rule here.

![image](https://user-images.githubusercontent.com/439947/219036267-c5fc95d0-0392-4dc6-a60d-5fe68530f49a.png)


Ensure that the `p-0` (0 padding) class rule supersedes the shared `Input` component padding in cases when the search input is not expanded.

Fixes #5249