### PR TITLE
Do not render user profile if the feature is disabled

### DIFF
--- a/src/sidebar/components/HypothesisApp.tsx
+++ b/src/sidebar/components/HypothesisApp.tsx
@@ -47,6 +47,8 @@ function HypothesisApp({
   const profile = store.profile();
   const route = store.route();
   const isModalRoute = route === 'notebook' || route === 'profile';
+  const shouldRenderProfile =
+    route === 'profile' && store.isFeatureEnabled('client_user_profile');
 
   const backgroundStyle = useMemo(
     () => applyTheme(['appBackgroundColor'], settings),
@@ -166,7 +168,7 @@ function HypothesisApp({
           <main>
             {route === 'annotation' && <AnnotationView onLogin={login} />}
             {route === 'notebook' && <NotebookView />}
-            {route === 'profile' && <ProfileView />}
+            {shouldRenderProfile && <ProfileView />}
             {route === 'stream' && <StreamView />}
             {route === 'sidebar' && (
               <SidebarView onLogin={login} onSignUp={signUp} />

--- a/src/sidebar/components/test/HypothesisApp-test.js
+++ b/src/sidebar/components/test/HypothesisApp-test.js
@@ -14,6 +14,7 @@ describe('HypothesisApp', () => {
   let fakeShouldAutoDisplayTutorial = null;
   let fakeSettings = null;
   let fakeToastMessenger = null;
+  let fakeIsFeatureEnabled;
 
   const createComponent = (props = {}) => {
     return mount(
@@ -32,6 +33,7 @@ describe('HypothesisApp', () => {
     fakeApplyTheme = sinon.stub().returns({});
     fakeServiceConfig = sinon.stub();
     fakeShouldAutoDisplayTutorial = sinon.stub().returns(false);
+    fakeIsFeatureEnabled = sinon.stub().returns(true);
 
     fakeStore = {
       clearGroups: sinon.stub(),
@@ -53,6 +55,8 @@ describe('HypothesisApp', () => {
       route: sinon.stub().returns('sidebar'),
 
       getLink: sinon.stub(),
+
+      isFeatureEnabled: fakeIsFeatureEnabled,
     };
 
     fakeAuth = {};
@@ -133,6 +137,14 @@ describe('HypothesisApp', () => {
       const wrapper = createComponent();
       assert.isTrue(wrapper.find(contentComponent).exists());
     });
+  });
+
+  it('does not render profile if the feature is not enabled', () => {
+    fakeStore.route.returns('profile');
+    fakeIsFeatureEnabled.returns(false);
+
+    const wrapper = createComponent();
+    assert.isFalse(wrapper.find('ProfileView').exists());
   });
 
   describe('auto-opening tutorial', () => {


### PR DESCRIPTION
This PR changes how the profile app behaves, making sure it renders blank if the corresponding feature flag is disabled.

This is already handled via user menu entry point, but the app could be opened stand-alone and this covers that scenario.

### Testing

1. On your local `h` instance, switch to branch `profile-mini-app`.
2. Enable the feature `client_user_profile`.
3. Visit http://locahost:5000/user-profile and verify that you can see "Profile" (this is dummy content that will be replaced by the actual content later)
4. Disable the feature `client_user_profile`.
5. Visit http://locahost:5000/user-profile again and verify the page is now empty.