### PR TITLE
Do not render user profile if the feature is disabled

### DIFF
--- a/src/sidebar/components/ProfileView.tsx
+++ b/src/sidebar/components/ProfileView.tsx
@@ -1,4 +1,15 @@
-/* istanbul ignore next - this is a temporary dummy implementation */
+import { useSidebarStore } from '../store';
+
 export default function ProfileView() {
-  return <div className="text-center">Profile</div>;
+  const store = useSidebarStore();
+
+  if (!store.isFeatureEnabled('client_user_profile')) {
+    return null;
+  }
+
+  return (
+    <div className="text-center" data-testid="profile-container">
+      Profile
+    </div>
+  );
 }

--- a/src/sidebar/components/test/ProfileView-test.js
+++ b/src/sidebar/components/test/ProfileView-test.js
@@ -1,0 +1,37 @@
+import { mount } from 'enzyme';
+
+import ProfileView, { $imports } from '../ProfileView';
+
+describe('ProfileView', () => {
+  let fakeStore;
+  let fakeIsFeatureEnabled;
+
+  beforeEach(() => {
+    fakeIsFeatureEnabled = sinon.stub().returns(true);
+    fakeStore = {
+      isFeatureEnabled: fakeIsFeatureEnabled,
+    };
+
+    $imports.$mock({
+      '../store': { useSidebarStore: () => fakeStore },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  const createComponent = () => mount(<ProfileView />);
+
+  it('renders content when feature flag is enabled', () => {
+    const wrapper = createComponent();
+    assert.isTrue(wrapper.find('[data-testid="profile-container"]').exists());
+  });
+
+  it('does not render content when feature flag is disabled', () => {
+    fakeIsFeatureEnabled.returns(false);
+
+    const wrapper = createComponent();
+    assert.isFalse(wrapper.find('[data-testid="profile-container"]').exists());
+  });
+});


### PR DESCRIPTION
> This PR replaces https://github.com/hypothesis/client/pull/5252

This PR changes how the profile app behaves, making sure it renders blank if the corresponding feature flag is disabled.

This is already handled via user menu entry point, but the app could be opened stand-alone and this covers that scenario.

### Testing

1. On your local `h` instance, switch to branch `profile-mini-app`.
2. Enable the feature `client_user_profile`.
3. Visit http://locahost:5000/user-profile and verify that you can see "Profile" (this is dummy content that will be replaced by the actual content later)
4. Disable the feature `client_user_profile`.
5. Visit http://locahost:5000/user-profile again and verify the page is now empty.