### PR TITLE
Make `ProfileModal` have a default export

### DIFF
--- a/src/annotator/components/ProfileModal.tsx
+++ b/src/annotator/components/ProfileModal.tsx
@@ -11,7 +11,7 @@ type ProfileModalProps = {
   config: ProfileConfig;
 };
 
-export function ProfileModal({ eventBus, config }: ProfileModalProps) {
+export default function ProfileModal({ eventBus, config }: ProfileModalProps) {
   const [isHidden, setIsHidden] = useState(true);
   const emitterRef = useRef<Emitter | null>(null);
   // Used only to track when was this modal first open, delaying the iframe to

--- a/src/annotator/components/test/ProfileModal-test.js
+++ b/src/annotator/components/test/ProfileModal-test.js
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
 import { EventBus } from '../../util/emitter';
-import { ProfileModal } from '../ProfileModal';
+import ProfileModal from '../ProfileModal';
 
 describe('ProfileModal', () => {
   const profileURL = 'https://test.hypothes.is/user-profile';

--- a/src/annotator/profile.tsx
+++ b/src/annotator/profile.tsx
@@ -2,7 +2,7 @@ import { render } from 'preact';
 
 import type { Destroyable } from '../types/annotator';
 import type { ProfileConfig } from './components/ProfileModal';
-import { ProfileModal } from './components/ProfileModal';
+import ProfileModal from './components/ProfileModal';
 import type { EventBus } from './util/emitter';
 import { createShadowRoot } from './util/shadow-root';
 

--- a/src/annotator/test/profile-test.js
+++ b/src/annotator/test/profile-test.js
@@ -34,7 +34,7 @@ describe('Profile', () => {
     };
 
     $imports.$mock({
-      './components/ProfileModal': { ProfileModal: FakeProfileModal },
+      './components/ProfileModal': FakeProfileModal,
     });
   });
 


### PR DESCRIPTION
This changes the `export` in `ProfileModal` to be a `default export`, for consistency with other components.