### PR TITLE
Add prototyped notification preference UI to `ProfileView`

### DIFF
--- a/src/sidebar/components/ProfileView.tsx
+++ b/src/sidebar/components/ProfileView.tsx
@@ -1,15 +1,151 @@
+import {
+  Card,
+  CardContent,
+  Checkbox,
+  CheckIcon,
+  Scroll,
+  SpinnerSpokesIcon,
+} from '@hypothesis/frontend-shared/lib/next';
+import type { PresentationalProps } from '@hypothesis/frontend-shared/lib/types';
+import classnames from 'classnames';
+import type { ComponentChildren, JSX } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+
 import { useSidebarStore } from '../store';
 
+type ToastBadgeProps = PresentationalProps & {
+  children: ComponentChildren;
+  /**
+   * Callback invoked when toast is "done" and is requesting to be
+   * closed/removed
+   */
+  onClose?: () => void;
+} & JSX.HTMLAttributes<HTMLDivElement>;
+
+/**
+ * Render a success "toast" badge.
+ *
+ * This uses an animation to pulse on render, then slowly fade out over several
+ * seconds. After its animation is complete, any provided `onClose` will be
+ * invoked.
+ */
+/* istanbul ignore next: Prototyped UI; add tests when solidified */
+function ToastBadge({
+  classes,
+  children,
+  onClose = () => {},
+  ...htmlAttributes
+}: ToastBadgeProps) {
+  return (
+    <div
+      className={classnames(
+        'flex items-center gap-x-1 py-1 px-2 rounded',
+        'bg-green-success/10 animate-pulse-fade-out',
+        classes
+      )}
+      onAnimationEnd={onClose}
+      {...htmlAttributes}
+    >
+      <CheckIcon className="text-green-success w-em h-em p-[0.125em]" />
+      <div className="text-sm">{children}</div>
+    </div>
+  );
+}
+
+/**
+ * Prototype of a subset of user-preferences/-profile management.
+ */
+/* istanbul ignore next: Prototyped UI; add tests when solidified */
 export default function ProfileView() {
   const store = useSidebarStore();
+  /** Is there a "request in flight" (fake) to save the digest preference? */
+  const [loading, setLoading] = useState(false);
+
+  /**
+   * Increment each time a save is completed, then reset to 0 to close (remove)
+   * the success toast badge
+   */
+  const [saveCount, setSaveCount] = useState(0);
+
+  useEffect(
+    /**
+     * Fake a 1s network request delay after checkbox is checked or unchecked.
+     * This exercises the "loading" UI state for the checkbox.
+     */
+    () => {
+      let savingTimeout: number;
+
+      if (loading) {
+        savingTimeout = setTimeout(() => {
+          setLoading(false);
+          // "Save was successful": increment the save count to ensure the
+          // toast badge gets re-rendered
+          setSaveCount(prevCount => prevCount + 1);
+        }, 1000);
+      }
+
+      return () => {
+        clearTimeout(savingTimeout);
+      };
+    },
+    [loading]
+  );
 
   if (!store.isFeatureEnabled('client_user_profile')) {
     return null;
   }
 
+  // Render save-success message after each successful save, but do not render
+  // it when a "request is in flight". This removal and re-adding across a
+  // sequence of saves ensures that the browser sees the message as newly- added
+  // to the accessiblity DOM and screen readers should announce it at the
+  // appropriate times.
+  const withSaveMessage = saveCount > 0 && !loading;
+
   return (
-    <div className="text-center" data-testid="profile-container">
-      Profile
-    </div>
+    <Card data-testid="profile-container">
+      <div
+        className={classnames(
+          // Ensure there is enough height to clear both the heading text and the
+          // success toast message without any danger of a jiggle
+          'h-12',
+          'px-3 border-b flex items-center'
+        )}
+      >
+        <div className="grow">
+          <h1 className="text-xl text-slate-7 font-normal">Notifications</h1>
+        </div>
+        <ul className="sr-only" aria-live="polite">
+          {withSaveMessage && (
+            <li key={saveCount}>Notification preferences saved</li>
+          )}
+        </ul>
+        {saveCount > 0 && (
+          <ToastBadge
+            key={
+              // The key is used here to ensure the `ToastBadge` re-renders and
+              // thus restarts its animation each time a save completes.
+              saveCount
+            }
+            onClose={() => setSaveCount(0)}
+          >
+            Saved
+          </ToastBadge>
+        )}
+      </div>
+      <Scroll>
+        <CardContent size="lg">
+          <Checkbox
+            defaultChecked={true}
+            disabled={loading}
+            onChange={() => setLoading(true)}
+            checkedIcon={loading ? SpinnerSpokesIcon : undefined}
+            icon={loading ? SpinnerSpokesIcon : undefined}
+          >
+            Email me a daily summary of activity in my courses
+          </Checkbox>
+        </CardContent>
+      </Scroll>
+    </Card>
   );
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -21,6 +21,7 @@ export default {
         'fade-in': 'fade-in 0.3s forwards',
         'fade-in-slow': 'fade-in 1s ease-in',
         'fade-out': 'fade-out 0.3s forwards',
+        'pulse-fade-out': 'pulse-fade-out 5s ease-in-out forwards',
         'slide-in-from-right': 'slide-in-from-right 0.3s forwards ease-in-out',
       },
       borderRadius: {
@@ -147,6 +148,21 @@ export default {
         'fade-out': {
           '0%': {
             opacity: '1',
+          },
+          '100%': {
+            opacity: '0',
+          },
+        },
+        'pulse-fade-out': {
+          '0%': {
+            opacity: '1',
+            transform: 'scale(1.1)',
+          },
+          '8%': {
+            transform: 'scale(1)',
+          },
+          '90%': {
+            opacity: '0.8',
           },
           '100%': {
             opacity: '0',


### PR DESCRIPTION
This PR adds prototyped UI behavior to the `ProfileView`. It adds a single notification preference, which is enabled by default:

<img width="732" alt="image" src="https://user-images.githubusercontent.com/439947/220173079-19bb01fd-0579-4ce3-80ca-dc3087f0f391.png">

The changes here demonstrate some plausible UI behavior when interacting with the interface elements. Checking or unchecking the checkbox kicks off a fake "loading" state, representing network request time, and then puts up a little "alert toast" message to show that saving was successful. There is also an `aria-live` region that announces the save successes for screen readers.

Note that each time the saving "operation" completes, the alert toast will re-pulse and reset. It will fade out and go away about 6 seconds after the last-initiated save completes:

![notification-preference](https://user-images.githubusercontent.com/439947/220173522-05f84146-f518-4da8-b88d-3232487c447f.gif)

Tightening this down will be an iterative process, but I want to keep things moving forward, so here is a first PR! Note that I've excluded the two components in the `ProfileView` module from test coverage for now.

Known issues:

* On narrow screens, the close button for the `ProfileModal` can partially overlay the right edge of the white "card". This is an issue also present in the Notebook, so I'd like to fix it as a separate task.
* If you "save" the notification preference, then close the profile view, then re-open it, the "Saved" toast message will still be present for a few seconds. To properly address this, the `ProfileView` needs to be able to know when it has been opened or closed.

Fixes https://github.com/hypothesis/frontend-shared/issues/819