### PR TITLE
Remove local `tall` media query (screen) and consolidate `FilterSelect` height

### DIFF
--- a/src/sidebar/components/FilterSelect.tsx
+++ b/src/sidebar/components/FilterSelect.tsx
@@ -47,9 +47,11 @@ function FilterSelect({
       label={menuLabel}
       title={title}
       contentClass={classnames(
-        // Don't let filter list get too terribly tall. On shorter screens,
-        // restrict to 70vh; set a static max-height for taller screens.
-        'max-h-[70vh] tall:max-h-[504px] overflow-y-auto'
+        // Don't let filter list get too terribly tall. Where space allows,
+        // use `504px` (this odd number is to maximize the likelihood that the
+        // overflow cutoff is in the middle of an option, making it more obvious
+        // that the list is scrollable), but don't exceed 60vh.
+        'max-h-[min(60vh,504px)] overflow-y-auto'
       )}
     >
       {filterOptions.map(filterOption => (

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -179,7 +179,6 @@ export default {
         'annotator-md': '480px',
         // Tablet and up
         'annotator-lg': '600px',
-        tall: { raw: '(min-height: 700px)' },
       },
       spacing: {
         // These are selective, pixel-specific variants of Tailwind's default


### PR DESCRIPTION
The `tall` `screen` value in this project's config conflicts with the `tall` value in the `frontend-shared` Tailwind preset. This project's `tall` was only being used in one place, and it turns out the styling needs there can be more cleanly accomplished without media queries.

Use `min()` to set a constrained max-height on filter-select lists[^1][^2]. The outcome is basically the same (though I changed the maximum height from `70vh` to `60vh` based on personal discretion).

This will fix the issue in which shared `Modal`s are rendered too low on the screen for medium-tall viewports, observed by @robertknight.

After these changes, a long filter list on a tall screen:
<img width="222" alt="Screen Shot 2023-02-20 at 3 08 53 PM" src="https://user-images.githubusercontent.com/439947/220191347-20cdf169-0d8c-4da5-b17f-0f0359f3c6b1.png">

And on a short screen:
<img width="246" alt="Screen Shot 2023-02-20 at 3 09 07 PM" src="https://user-images.githubusercontent.com/439947/220191372-919779f2-56be-468b-9641-7edacd73cc39.png">

[^1]: The styling of `FilterSelect` is still coupled to the Notebook-screen context in which it is used: there's an underlying assumption that the `FilterSelect` is rendered near the top of the viewport. This needs to be untangled at some point but is beyond the scope of these changes.

[^2]: Another styling task might be to make scrollability more obvious in these lists, a la scroll-hinting shadows or another affordance. Anyway...
