### PR TITLE
Simplify how we handle remounting/reloading of the notebook iframe in modal

### DIFF
--- a/src/annotator/components/test/NotebookModal-test.js
+++ b/src/annotator/components/test/NotebookModal-test.js
@@ -55,55 +55,19 @@ describe('NotebookModal', () => {
 
   it('shows modal on "openNotebook" event', () => {
     const wrapper = createComponent();
-    let outer = wrapper.find(outerSelector);
 
-    assert.isFalse(outer.exists());
-    assert.isFalse(wrapper.find('iframe').exists());
+    assert.isFalse(wrapper.find(outerSelector).exists());
 
     emitter.publish('openNotebook', 'myGroup');
     wrapper.update();
 
-    outer = wrapper.find(outerSelector);
-    assert.isFalse(outer.hasClass('hidden'));
+    assert.isTrue(wrapper.find(outerSelector).exists());
 
     const iframe = wrapper.find('iframe');
     assert.equal(
       iframe.prop('src'),
       addConfigFragment(notebookURL, { group: 'myGroup' })
     );
-  });
-
-  it('creates a new iframe element on every "openNotebook" event', () => {
-    const wrapper = createComponent();
-
-    emitter.publish('openNotebook', '1');
-    wrapper.update();
-
-    const iframe1 = wrapper.find('iframe');
-    assert.equal(
-      iframe1.prop('src'),
-      addConfigFragment(notebookURL, { group: '1' })
-    );
-
-    emitter.publish('openNotebook', '1');
-    wrapper.update();
-
-    const iframe2 = wrapper.find('iframe');
-    assert.equal(
-      iframe2.prop('src'),
-      addConfigFragment(notebookURL, { group: '1' })
-    );
-    assert.notEqual(iframe1.getDOMNode(), iframe2.getDOMNode());
-
-    emitter.publish('openNotebook', '2');
-    wrapper.update();
-
-    const iframe3 = wrapper.find('iframe');
-    assert.equal(
-      iframe3.prop('src'),
-      addConfigFragment(notebookURL, { group: '2' })
-    );
-    assert.notEqual(iframe1.getDOMNode(), iframe3.getDOMNode());
   });
 
   it('makes the document unscrollable on "openNotebook" event', () => {
@@ -120,17 +84,14 @@ describe('NotebookModal', () => {
     emitter.publish('openNotebook', 'myGroup');
     wrapper.update();
 
-    let outer = wrapper.find(outerSelector);
-    assert.isFalse(outer.hasClass('hidden'));
+    assert.isTrue(wrapper.find(outerSelector).exists());
 
     act(() => {
       wrapper.find('IconButton').prop('onClick')();
     });
     wrapper.update();
 
-    outer = wrapper.find(outerSelector);
-
-    assert.isTrue(outer.hasClass('hidden'));
+    assert.isFalse(wrapper.find(outerSelector).exists());
   });
 
   it('resets document scrollability on closing the modal', () => {


### PR DESCRIPTION
We are currently mounting the contents of `NotebookModal` the first time it is opened, when it gets its first `groupId`.

In parallel, we handle another local state flag which is used to tell if it's hidden, and dynamically set a CSS class based on it.

Also, since we want the contents of the iframe to be reloaded every time the notebook is open, we have a third local state used to track an incremental value used as the iframe's `key`, to force preact to remount it.

This PR simplifies the logic by doing the next:

* We make sure the `groupId` is reset when the modal is closed, making the contets to be unmounted.
* We get rid of the state used to set a key in the iframe, as the change above now implicitly enforces the iframe to be recreated every time the modal is opened.
* We change some side effects to depend on the `groupId` instead of `isHidden`, allowing `isHidden` to be removed as well.

The result is that the behavior is the same in practice, but with a simplified local state.