### PR TITLE
Bump `@hypothesis/frontend-shared` to v5.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,9 @@
   "prettier": {
     "arrowParens": "avoid",
     "singleQuote": true,
-    "importOrder": ["^[./]"],
+    "importOrder": [
+      "^[./]"
+    ],
     "importOrderSeparation": true
   },
   "main": "./build/boot.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,9 +1237,9 @@
     glob "^7.2.0"
 
 "@hypothesis/frontend-shared@^5.6.0":
-  version "5.11.0"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.11.0.tgz#2edcbe738130da88cc568c6548993e5c25c7e128"
-  integrity sha512-gqfbocJkRjdv/fr72NclPsWxpITFGa4nbxD+wI1Ysazd0eKd2ND7+sOCNqKKTfkPHRFv/qukv6HNXJncdlEG8Q==
+  version "5.11.1"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.11.1.tgz#0951ae416905b60306e8e1eaa7694d47801912b1"
+  integrity sha512-uaBquPfe4rLYe9ufwalpHsPgijtTRH2r30g72buOBGZRQ45Omp9xRxoNCkgm1VmKLQBWopcIdHjOak6U1nxVZg==
   dependencies:
     highlight.js "^11.6.0"
 


### PR DESCRIPTION
This PR bumps the `frontend-shared` package to fix a visual regression in `Panel`s that don't have buttons (`SidebarPanel` in the client). These changes remove some extra padding.

Before:
<img width="423" alt="Screen Shot 2023-02-21 at 9 03 20 AM" src="https://user-images.githubusercontent.com/439947/220367004-0a4122fe-c18f-498f-9d03-ead66da82263.png">

After:
<img width="424" alt="Screen Shot 2023-02-21 at 9 02 32 AM" src="https://user-images.githubusercontent.com/439947/220367037-528c3f37-235c-4402-9100-6e31258da40d.png">