### PR TITLE
Add missing aria-live region to "announce" real-time updates

### DIFF
--- a/src/sidebar/components/PendingUpdatesButton.tsx
+++ b/src/sidebar/components/PendingUpdatesButton.tsx
@@ -1,0 +1,33 @@
+import { IconButton, RefreshIcon } from '@hypothesis/frontend-shared/lib/next';
+
+export type PendingUpdatesButtonProps = {
+  pendingUpdateCount: number;
+  onClick: () => void;
+};
+
+export default function PendingUpdatesButton({
+  pendingUpdateCount,
+  onClick,
+}: PendingUpdatesButtonProps) {
+  if (pendingUpdateCount === 0) {
+    // The "wrapper" has to be always present for the aria-live to work
+    return <span aria-live="polite" />;
+  }
+
+  const title = `Show ${pendingUpdateCount} new/updated ${
+    pendingUpdateCount === 1 ? 'annotation' : 'annotations'
+  }`;
+
+  return (
+    <span aria-live="polite">
+      <IconButton
+        icon={RefreshIcon}
+        onClick={onClick}
+        size="xs"
+        variant="primary"
+        title={title}
+      />
+      <span className="sr-only">{title}</span>
+    </span>
+  );
+}

--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -106,17 +106,26 @@ function TopBar({
         <div className="grow flex items-center justify-end">
           {isSidebar && (
             <>
-              {pendingUpdateCount > 0 && (
-                <IconButton
-                  icon={RefreshIcon}
-                  onClick={applyPendingUpdates}
-                  size="xs"
-                  variant="primary"
-                  title={`Show ${pendingUpdateCount} new/updated ${
-                    pendingUpdateCount === 1 ? 'annotation' : 'annotations'
-                  }`}
-                />
-              )}
+              <span aria-live="polite">
+                {pendingUpdateCount > 0 && (
+                  <>
+                    <IconButton
+                      icon={RefreshIcon}
+                      onClick={applyPendingUpdates}
+                      size="xs"
+                      variant="primary"
+                      title={`Show ${pendingUpdateCount} new/updated ${
+                        pendingUpdateCount === 1 ? 'annotation' : 'annotations'
+                      }`}
+                    />
+                    <span className="sr-only">
+                      Show {pendingUpdateCount} new/updated {
+                      pendingUpdateCount === 1 ? 'annotation' : 'annotations'
+                    }
+                    </span>
+                  </>
+                )}
+              </span>
               <SearchInput
                 query={filterQuery || null}
                 onSearch={store.setFilterQuery}

--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -2,7 +2,6 @@ import {
   IconButton,
   LinkButton,
   HelpIcon,
-  RefreshIcon,
   ShareIcon,
 } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
@@ -16,6 +15,7 @@ import type { FrameSyncService } from '../services/frame-sync';
 import type { StreamerService } from '../services/streamer';
 import { useSidebarStore } from '../store';
 import GroupList from './GroupList';
+import PendingUpdatesButton from './PendingUpdatesButton';
 import SearchInput from './SearchInput';
 import SortMenu from './SortMenu';
 import StreamSearchInput from './StreamSearchInput';
@@ -106,26 +106,10 @@ function TopBar({
         <div className="grow flex items-center justify-end">
           {isSidebar && (
             <>
-              <span aria-live="polite">
-                {pendingUpdateCount > 0 && (
-                  <>
-                    <IconButton
-                      icon={RefreshIcon}
-                      onClick={applyPendingUpdates}
-                      size="xs"
-                      variant="primary"
-                      title={`Show ${pendingUpdateCount} new/updated ${
-                        pendingUpdateCount === 1 ? 'annotation' : 'annotations'
-                      }`}
-                    />
-                    <span className="sr-only">
-                      Show {pendingUpdateCount} new/updated {
-                      pendingUpdateCount === 1 ? 'annotation' : 'annotations'
-                    }
-                    </span>
-                  </>
-                )}
-              </span>
+              <PendingUpdatesButton
+                pendingUpdateCount={pendingUpdateCount}
+                onClick={applyPendingUpdates}
+              />
               <SearchInput
                 query={filterQuery || null}
                 onSearch={store.setFilterQuery}

--- a/src/sidebar/components/test/PendingUpdatesButton-test.js
+++ b/src/sidebar/components/test/PendingUpdatesButton-test.js
@@ -1,0 +1,37 @@
+import { mount } from 'enzyme';
+
+import PendingUpdatesButton from '../PendingUpdatesButton';
+
+describe('PendingUpdatesButton', () => {
+  let fakeOnClick;
+
+  beforeEach(() => {
+    fakeOnClick = sinon.stub();
+  });
+
+  const createButton = count =>
+    mount(
+      <PendingUpdatesButton pendingUpdateCount={count} onClick={fakeOnClick} />
+    );
+
+  it('shows an empty wrapper when there are no pending updates', () => {
+    const wrapper = createButton(0);
+    assert.isTrue(wrapper.find('span[aria-live="polite"]').exists());
+    assert.isFalse(wrapper.find('IconButton').exists());
+  });
+
+  it('shows the pending update count', () => {
+    const wrapper = createButton(1);
+    assert.isTrue(wrapper.find('span[aria-live="polite"]').exists());
+    assert.isTrue(wrapper.find('IconButton').exists());
+  });
+
+  it('applies updates when clicked', () => {
+    const wrapper = createButton(1);
+    const applyBtn = wrapper.find('IconButton');
+
+    applyBtn.props().onClick();
+
+    assert.called(fakeOnClick);
+  });
+});

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -69,23 +69,9 @@ describe('TopBar', () => {
     );
   }
 
-  it('shows the pending update count', () => {
-    fakeStore.pendingUpdateCount.returns(1);
-    const wrapper = createTopBar();
-    const applyBtn = getButton(wrapper, 'RefreshIcon');
-    assert.isTrue(applyBtn.exists());
-  });
-
-  it('does not show the pending update count when there are no updates', () => {
-    const wrapper = createTopBar();
-    const applyBtn = getButton(wrapper, 'RefreshIcon');
-    assert.isFalse(applyBtn.exists());
-  });
-
   it('applies updates when clicked', () => {
-    fakeStore.pendingUpdateCount.returns(1);
     const wrapper = createTopBar();
-    const applyBtn = getButton(wrapper, 'RefreshIcon');
+    const applyBtn = wrapper.find('PendingUpdatesButton');
 
     applyBtn.props().onClick();
 


### PR DESCRIPTION
This PR fixes https://github.com/hypothesis/product-backlog/issues/1422, by providing an `aria-live="polite"` region around the real-time updates button, so that screen readers can announce it when it appears on screen.

The button itself has an `aria-label` attribute, which I assumed would be used by the screen reader, but it doesn't seem to be the case (tested with `orca`).

Because of that, this PR also adds an `sr-only` element with the same contents, that does get announced by the screen reader.

Since there's now a small logic to compose the button's title, and it is then used in two places, I have also extracted it to its own component, simplifying the `TopBar` component in the process.