### PR TITLE
Use boolean values for aria-selected in JSX

### DIFF
--- a/src/sidebar/components/AutocompleteList.tsx
+++ b/src/sidebar/components/AutocompleteList.tsx
@@ -72,7 +72,7 @@ export default function AutocompleteList<Item>({
         <li
           key={`AutocompleteList-${index}`}
           role="option"
-          aria-selected={(activeItem === index).toString()}
+          aria-selected={activeItem === index}
           className={classnames(
             'flex items-center',
             'border-l-4 py-1 px-3 cursor-pointer hover:bg-grey-2',

--- a/src/sidebar/components/test/AutocompleteList-test.js
+++ b/src/sidebar/components/test/AutocompleteList-test.js
@@ -54,8 +54,8 @@ describe('AutocompleteList', () => {
 
   it('sets `aria-selected` on the <li> at the matching index to `activeItem`', () => {
     const wrapper = createComponent({ open: true, activeItem: 0 });
-    assert.equal(wrapper.find('li').at(0).prop('aria-selected'), 'true');
-    assert.equal(wrapper.find('li').at(1).prop('aria-selected'), 'false');
+    assert.equal(wrapper.find('li').at(0).prop('aria-selected'), true);
+    assert.equal(wrapper.find('li').at(1).prop('aria-selected'), false);
   });
 
   it('calls `onSelect` when an <li> is clicked with the corresponding item', () => {


### PR DESCRIPTION
In preparation for preact 10.13.0, updating occurences of `aria-selected` to use a boolean value instead of a string.

Preact 10.13.0 no longer accepts any string, only `'true'`, `'false'`, `undefined` or boolean.

The generated HTML is equivalent when using booleans here.