### PR TITLE
Convert remaining annotator components to TypeScript

### DIFF
--- a/src/annotator/components/Banners.js
+++ b/src/annotator/components/Banners.js
@@ -1,9 +1,0 @@
-/**
- * Render banners at the top of a document in a stacked column.
- *
- * @param {object} props
- *   @param {import("preact").ComponentChildren} props.children
- */
-export default function Banners({ children }) {
-  return <div className="flex flex-col">{children}</div>;
-}

--- a/src/annotator/components/Banners.tsx
+++ b/src/annotator/components/Banners.tsx
@@ -1,0 +1,10 @@
+import type { ComponentChildren } from 'preact';
+
+export type BannersProps = { children: ComponentChildren };
+
+/**
+ * Render banners at the top of a document in a stacked column.
+ */
+export default function Banners({ children }: BannersProps) {
+  return <div className="flex flex-col">{children}</div>;
+}

--- a/src/annotator/components/ContentInfoBanner.tsx
+++ b/src/annotator/components/ContentInfoBanner.tsx
@@ -6,9 +6,9 @@ import {
 } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
 
-/**
- * @typedef {import('../../types/annotator').ContentInfoConfig} ContentInfoConfig
- */
+import type { ContentInfoConfig } from '../../types/annotator';
+
+export type ContentInfoBannerProps = { info: ContentInfoConfig };
 
 /**
  * A banner that displays information about the current document and the entity
@@ -18,11 +18,8 @@ import classnames from 'classnames';
  *  - Logo
  *  - Container title (only shown on screens at `2xl` breakpoint and wider)
  *  - Item title with previous and next links
- *
- * @param {object} props
- *   @param {ContentInfoConfig} props.info
  */
-export default function ContentInfoBanner({ info }) {
+export default function ContentInfoBanner({ info }: ContentInfoBannerProps) {
   // Format item title to show subtitle
   let itemTitle = info.item.title;
   if (info.item.subtitle) {


### PR DESCRIPTION
This converts the remaining components in `src/annotator/components` to TS.