### PR TITLE
Publish hidden toast message when there are new pending updates

### DIFF
--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -6,6 +6,7 @@ import {
   ShareIcon,
 } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
+import { useEffect } from 'preact/hooks';
 
 import type { SidebarSettings } from '../../types/config';
 import { serviceConfig } from '../config/service-config';
@@ -14,6 +15,7 @@ import { applyTheme } from '../helpers/theme';
 import { withServices } from '../service-context';
 import type { FrameSyncService } from '../services/frame-sync';
 import type { StreamerService } from '../services/streamer';
+import type { ToastMessengerService } from '../services/toast-messenger';
 import { useSidebarStore } from '../store';
 import GroupList from './GroupList';
 import SearchInput from './SearchInput';
@@ -38,6 +40,7 @@ export type TopBarProps = {
   frameSync: FrameSyncService;
   settings: SidebarSettings;
   streamer: StreamerService;
+  toastMessenger: ToastMessengerService;
 };
 
 /**
@@ -52,6 +55,7 @@ function TopBar({
   frameSync,
   settings,
   streamer,
+  toastMessenger,
 }: TopBarProps) {
   const showSharePageButton = !isThirdPartyService(settings);
   const loginLinkStyle = applyTheme(['accentColor'], settings);
@@ -72,6 +76,17 @@ function TopBar({
   const isAnnotationsPanelOpen = store.isSidebarPanelOpen(
     'shareGroupAnnotations'
   );
+
+  useEffect(() => {
+    if (pendingUpdateCount > 0) {
+      toastMessenger.success(
+        `There are ${pendingUpdateCount} new annotations.`,
+        {
+          visuallyHidden: true,
+        }
+      );
+    }
+  }, [pendingUpdateCount, toastMessenger]);
 
   /**
    * Open the help panel, or, if a service callback is configured to handle
@@ -175,4 +190,9 @@ function TopBar({
   );
 }
 
-export default withServices(TopBar, ['frameSync', 'settings', 'streamer']);
+export default withServices(TopBar, [
+  'frameSync',
+  'settings',
+  'streamer',
+  'toastMessenger',
+]);

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -75,17 +75,29 @@ describe('TopBar', () => {
     );
   }
 
-  it('shows the pending update count', () => {
-    fakeStore.pendingUpdateCount.returns(1);
-    const wrapper = createTopBar();
-    const applyBtn = getButton(wrapper, 'RefreshIcon');
-    assert.isTrue(applyBtn.exists());
+  [1, 10, 50].forEach(pendingUpdateCount => {
+    it('shows the pending update count', () => {
+      fakeStore.pendingUpdateCount.returns(pendingUpdateCount);
+      const wrapper = createTopBar();
+      const applyBtn = getButton(wrapper, 'RefreshIcon');
+
+      assert.isTrue(applyBtn.exists());
+      assert.calledWith(
+        fakeToastMessenger.success,
+        `There are ${pendingUpdateCount} new annotations.`,
+        {
+          visuallyHidden: true,
+        }
+      );
+    });
   });
 
   it('does not show the pending update count when there are no updates', () => {
     const wrapper = createTopBar();
     const applyBtn = getButton(wrapper, 'RefreshIcon');
+
     assert.isFalse(applyBtn.exists());
+    assert.notCalled(fakeToastMessenger.success);
   });
 
   it('applies updates when clicked', () => {

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -9,6 +9,7 @@ describe('TopBar', () => {
   let fakeFrameSync;
   let fakeStore;
   let fakeStreamer;
+  let fakeToastMessenger;
   let fakeIsThirdPartyService;
   let fakeServiceConfig;
 
@@ -33,6 +34,10 @@ describe('TopBar', () => {
 
     fakeStreamer = {
       applyPendingUpdates: sinon.stub(),
+    };
+
+    fakeToastMessenger = {
+      success: sinon.stub(),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -64,6 +69,7 @@ describe('TopBar', () => {
         isSidebar={true}
         settings={fakeSettings}
         streamer={fakeStreamer}
+        toastMessenger={fakeToastMessenger}
         {...props}
       />
     );


### PR DESCRIPTION
This PR addresses https://github.com/hypothesis/product-backlog/issues/1422, by publishing a hidden toast message when the `TopBar` component detects a change on `pendingUpdateCount` and the value is greater than 0.

That's the same condition that makes pending updates button to be displayed.

That toast message will not be rendered, but it will be announced to screen readers.

This PR also supersedes https://github.com/hypothesis/client/pull/5288

### Pending steps

- [x] Test behavior.
- [x] Refine toast message. -> https://github.com/hypothesis/client/pull/5306#discussion_r1131603658
- [x] Throttle announced messages, so that we don't overwhelm a user working on a very active document and group. -> https://github.com/hypothesis/client/pull/5306
- [x] ~Consider adding keyboard behavior so that pressing a key results in new annotations to be loaded~ (moving this to a follow-up PR: https://github.com/hypothesis/client/pull/5307).
- [x] Proper manual testing (orca has decided to behave weirdly today 😅)