### PR TITLE
New updates toast message only when button is displayed

### DIFF
--- a/src/sidebar/components/PendingUpdatesButton.tsx
+++ b/src/sidebar/components/PendingUpdatesButton.tsx
@@ -1,0 +1,48 @@
+import { IconButton, RefreshIcon } from '@hypothesis/frontend-shared/lib/next';
+import { useEffect } from 'preact/hooks';
+
+import { withServices } from '../service-context';
+import type { ToastMessengerService } from '../services/toast-messenger';
+
+export type PendingUpdatesButtonProps = {
+  pendingUpdateCount: number;
+  onClick: () => void;
+
+  // Injected
+  toastMessenger: ToastMessengerService;
+};
+
+function PendingUpdatesButton({
+  pendingUpdateCount,
+  onClick,
+  toastMessenger,
+}: PendingUpdatesButtonProps) {
+  useEffect(() => {
+    if (pendingUpdateCount > 0) {
+      toastMessenger.success(
+        `There are ${pendingUpdateCount} new annotations.`,
+        {
+          visuallyHidden: true,
+        }
+      );
+    }
+  }, [pendingUpdateCount, toastMessenger]);
+
+  if (pendingUpdateCount === 0) {
+    return null;
+  }
+
+  return (
+    <IconButton
+      icon={RefreshIcon}
+      onClick={onClick}
+      size="xs"
+      variant="primary"
+      title={`Show ${pendingUpdateCount} new/updated ${
+        pendingUpdateCount === 1 ? 'annotation' : 'annotations'
+      }`}
+    />
+  );
+}
+
+export default withServices(PendingUpdatesButton, ['toastMessenger']);

--- a/src/sidebar/components/PendingUpdatesButton.tsx
+++ b/src/sidebar/components/PendingUpdatesButton.tsx
@@ -2,18 +2,18 @@ import { IconButton, RefreshIcon } from '@hypothesis/frontend-shared/lib/next';
 import { useEffect } from 'preact/hooks';
 
 import { withServices } from '../service-context';
+import type { StreamerService } from '../services/streamer';
 import type { ToastMessengerService } from '../services/toast-messenger';
 import { useSidebarStore } from '../store';
 
 export type PendingUpdatesButtonProps = {
-  onClick: () => void;
-
   // Injected
+  streamer: StreamerService;
   toastMessenger: ToastMessengerService;
 };
 
 function PendingUpdatesButton({
-  onClick,
+  streamer,
   toastMessenger,
 }: PendingUpdatesButtonProps) {
   const store = useSidebarStore();
@@ -22,17 +22,11 @@ function PendingUpdatesButton({
 
   useEffect(() => {
     if (hasPendingUpdates) {
-      toastMessenger.success(
-        `There are ${pendingUpdateCount} new annotations.`,
-        {
-          visuallyHidden: true,
-        }
-      );
+      toastMessenger.notice(`New annotations are available.`, {
+        visuallyHidden: true,
+      });
     }
-    // We only want this effect to trigger when changing from no-updates to at
-    // least one update, not every time the amount changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasPendingUpdates]);
+  }, [hasPendingUpdates, toastMessenger]);
 
   if (!hasPendingUpdates) {
     return null;
@@ -41,7 +35,7 @@ function PendingUpdatesButton({
   return (
     <IconButton
       icon={RefreshIcon}
-      onClick={onClick}
+      onClick={() => streamer.applyPendingUpdates()}
       size="xs"
       variant="primary"
       title={`Show ${pendingUpdateCount} new/updated ${
@@ -51,4 +45,7 @@ function PendingUpdatesButton({
   );
 }
 
-export default withServices(PendingUpdatesButton, ['toastMessenger']);
+export default withServices(PendingUpdatesButton, [
+  'streamer',
+  'toastMessenger',
+]);

--- a/src/sidebar/components/PendingUpdatesButton.tsx
+++ b/src/sidebar/components/PendingUpdatesButton.tsx
@@ -3,9 +3,9 @@ import { useEffect } from 'preact/hooks';
 
 import { withServices } from '../service-context';
 import type { ToastMessengerService } from '../services/toast-messenger';
+import { useSidebarStore } from '../store';
 
 export type PendingUpdatesButtonProps = {
-  pendingUpdateCount: number;
   onClick: () => void;
 
   // Injected
@@ -13,12 +13,15 @@ export type PendingUpdatesButtonProps = {
 };
 
 function PendingUpdatesButton({
-  pendingUpdateCount,
   onClick,
   toastMessenger,
 }: PendingUpdatesButtonProps) {
+  const store = useSidebarStore();
+  const pendingUpdateCount = store.pendingUpdateCount();
+  const hasPendingUpdates = store.hasPendingUpdates();
+
   useEffect(() => {
-    if (pendingUpdateCount > 0) {
+    if (hasPendingUpdates) {
       toastMessenger.success(
         `There are ${pendingUpdateCount} new annotations.`,
         {
@@ -26,9 +29,12 @@ function PendingUpdatesButton({
         }
       );
     }
-  }, [pendingUpdateCount, toastMessenger]);
+    // We only want this effect to trigger when changing from no-updates to at
+    // least one update, not every time the amount changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasPendingUpdates]);
 
-  if (pendingUpdateCount === 0) {
+  if (!hasPendingUpdates) {
     return null;
   }
 

--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -6,6 +6,7 @@ import {
   ShareIcon,
 } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
+import { useEffect } from 'preact/hooks';
 
 import type { SidebarSettings } from '../../types/config';
 import { serviceConfig } from '../config/service-config';
@@ -14,6 +15,7 @@ import { applyTheme } from '../helpers/theme';
 import { withServices } from '../service-context';
 import type { FrameSyncService } from '../services/frame-sync';
 import type { StreamerService } from '../services/streamer';
+import type { ToastMessengerService } from '../services/toast-messenger';
 import { useSidebarStore } from '../store';
 import GroupList from './GroupList';
 import SearchInput from './SearchInput';
@@ -38,6 +40,7 @@ export type TopBarProps = {
   frameSync: FrameSyncService;
   settings: SidebarSettings;
   streamer: StreamerService;
+  toastMessenger: ToastMessengerService;
 };
 
 /**
@@ -52,6 +55,7 @@ function TopBar({
   frameSync,
   settings,
   streamer,
+  toastMessenger,
 }: TopBarProps) {
   const showSharePageButton = !isThirdPartyService(settings);
   const loginLinkStyle = applyTheme(['accentColor'], settings);
@@ -72,6 +76,17 @@ function TopBar({
   const isAnnotationsPanelOpen = store.isSidebarPanelOpen(
     'shareGroupAnnotations'
   );
+
+  useEffect(() => {
+    if (pendingUpdateCount > 0) {
+      toastMessenger.success(
+        `There are ${pendingUpdateCount} new annotations.`,
+        {
+          visuallyHidden: true,
+        }
+      );
+    }
+  }, [pendingUpdateCount, toastMessenger]);
 
   /**
    * Open the help panel, or, if a service callback is configured to handle
@@ -175,4 +190,9 @@ function TopBar({
   );
 }
 
-export default withServices(TopBar, ['frameSync', 'settings', 'streamer']);
+export default withServices(TopBar, [
+  'frameSync',
+  'settings',
+  'streamer',
+  'toastMessenger',
+]);

--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -2,11 +2,9 @@ import {
   IconButton,
   LinkButton,
   HelpIcon,
-  RefreshIcon,
   ShareIcon,
 } from '@hypothesis/frontend-shared/lib/next';
 import classnames from 'classnames';
-import { useEffect } from 'preact/hooks';
 
 import type { SidebarSettings } from '../../types/config';
 import { serviceConfig } from '../config/service-config';
@@ -15,9 +13,9 @@ import { applyTheme } from '../helpers/theme';
 import { withServices } from '../service-context';
 import type { FrameSyncService } from '../services/frame-sync';
 import type { StreamerService } from '../services/streamer';
-import type { ToastMessengerService } from '../services/toast-messenger';
 import { useSidebarStore } from '../store';
 import GroupList from './GroupList';
+import PendingUpdatesButton from './PendingUpdatesButton';
 import SearchInput from './SearchInput';
 import SortMenu from './SortMenu';
 import StreamSearchInput from './StreamSearchInput';
@@ -40,7 +38,6 @@ export type TopBarProps = {
   frameSync: FrameSyncService;
   settings: SidebarSettings;
   streamer: StreamerService;
-  toastMessenger: ToastMessengerService;
 };
 
 /**
@@ -55,7 +52,6 @@ function TopBar({
   frameSync,
   settings,
   streamer,
-  toastMessenger,
 }: TopBarProps) {
   const showSharePageButton = !isThirdPartyService(settings);
   const loginLinkStyle = applyTheme(['accentColor'], settings);
@@ -76,17 +72,6 @@ function TopBar({
   const isAnnotationsPanelOpen = store.isSidebarPanelOpen(
     'shareGroupAnnotations'
   );
-
-  useEffect(() => {
-    if (pendingUpdateCount > 0) {
-      toastMessenger.success(
-        `There are ${pendingUpdateCount} new annotations.`,
-        {
-          visuallyHidden: true,
-        }
-      );
-    }
-  }, [pendingUpdateCount, toastMessenger]);
 
   /**
    * Open the help panel, or, if a service callback is configured to handle
@@ -121,17 +106,10 @@ function TopBar({
         <div className="grow flex items-center justify-end">
           {isSidebar && (
             <>
-              {pendingUpdateCount > 0 && (
-                <IconButton
-                  icon={RefreshIcon}
-                  onClick={applyPendingUpdates}
-                  size="xs"
-                  variant="primary"
-                  title={`Show ${pendingUpdateCount} new/updated ${
-                    pendingUpdateCount === 1 ? 'annotation' : 'annotations'
-                  }`}
-                />
-              )}
+              <PendingUpdatesButton
+                pendingUpdateCount={pendingUpdateCount}
+                onClick={applyPendingUpdates}
+              />
               <SearchInput
                 query={filterQuery || null}
                 onSearch={store.setFilterQuery}
@@ -190,9 +168,4 @@ function TopBar({
   );
 }
 
-export default withServices(TopBar, [
-  'frameSync',
-  'settings',
-  'streamer',
-  'toastMessenger',
-]);
+export default withServices(TopBar, ['frameSync', 'settings', 'streamer']);

--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -58,7 +58,6 @@ function TopBar({
 
   const store = useSidebarStore();
   const filterQuery = store.filterQuery();
-  const pendingUpdateCount = store.pendingUpdateCount();
   const isLoggedIn = store.isLoggedIn();
   const hasFetchedProfile = store.hasFetchedProfile();
 
@@ -106,10 +105,7 @@ function TopBar({
         <div className="grow flex items-center justify-end">
           {isSidebar && (
             <>
-              <PendingUpdatesButton
-                pendingUpdateCount={pendingUpdateCount}
-                onClick={applyPendingUpdates}
-              />
+              <PendingUpdatesButton onClick={applyPendingUpdates} />
               <SearchInput
                 query={filterQuery || null}
                 onSearch={store.setFilterQuery}

--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -12,7 +12,6 @@ import { isThirdPartyService } from '../helpers/is-third-party-service';
 import { applyTheme } from '../helpers/theme';
 import { withServices } from '../service-context';
 import type { FrameSyncService } from '../services/frame-sync';
-import type { StreamerService } from '../services/streamer';
 import { useSidebarStore } from '../store';
 import GroupList from './GroupList';
 import PendingUpdatesButton from './PendingUpdatesButton';
@@ -37,7 +36,6 @@ export type TopBarProps = {
   // injected
   frameSync: FrameSyncService;
   settings: SidebarSettings;
-  streamer: StreamerService;
 };
 
 /**
@@ -51,7 +49,6 @@ function TopBar({
   onSignUp,
   frameSync,
   settings,
-  streamer,
 }: TopBarProps) {
   const showSharePageButton = !isThirdPartyService(settings);
   const loginLinkStyle = applyTheme(['accentColor'], settings);
@@ -60,8 +57,6 @@ function TopBar({
   const filterQuery = store.filterQuery();
   const isLoggedIn = store.isLoggedIn();
   const hasFetchedProfile = store.hasFetchedProfile();
-
-  const applyPendingUpdates = () => streamer.applyPendingUpdates();
 
   const toggleSharePanel = () => {
     store.toggleSidebarPanel('shareGroupAnnotations');
@@ -105,7 +100,7 @@ function TopBar({
         <div className="grow flex items-center justify-end">
           {isSidebar && (
             <>
-              <PendingUpdatesButton onClick={applyPendingUpdates} />
+              <PendingUpdatesButton />
               <SearchInput
                 query={filterQuery || null}
                 onSearch={store.setFilterQuery}
@@ -164,4 +159,4 @@ function TopBar({
   );
 }
 
-export default withServices(TopBar, ['frameSync', 'settings', 'streamer']);
+export default withServices(TopBar, ['frameSync', 'settings']);

--- a/src/sidebar/components/test/PendingUpdatesButton-test.js
+++ b/src/sidebar/components/test/PendingUpdatesButton-test.js
@@ -1,0 +1,60 @@
+import { mount } from 'enzyme';
+
+import PendingUpdatesButton from '../PendingUpdatesButton';
+
+describe('PendingUpdatesButton', () => {
+  let fakeOnClick;
+  let fakeToastMessenger;
+
+  beforeEach(() => {
+    fakeOnClick = sinon.stub();
+    fakeToastMessenger = {
+      success: sinon.stub(),
+    };
+  });
+
+  const createButton = count =>
+    mount(
+      <PendingUpdatesButton
+        pendingUpdateCount={count}
+        onClick={fakeOnClick}
+        toastMessenger={fakeToastMessenger}
+      />
+    );
+
+  it('shows an empty wrapper when there are no pending updates', () => {
+    const wrapper = createButton(0);
+
+    assert.isFalse(wrapper.find('IconButton').exists());
+    assert.notCalled(fakeToastMessenger.success);
+  });
+
+  [1, 10, 50].forEach(pendingUpdateCount => {
+    it('shows the pending update count', () => {
+      const wrapper = createButton(pendingUpdateCount);
+
+      assert.isTrue(wrapper.find('IconButton').exists());
+      assert.calledWith(
+        fakeToastMessenger.success,
+        `There are ${pendingUpdateCount} new annotations.`,
+        {
+          visuallyHidden: true,
+        }
+      );
+    });
+  });
+
+  it('shows the pending update count', () => {
+    const wrapper = createButton(1);
+    assert.isTrue(wrapper.find('IconButton').exists());
+  });
+
+  it('applies updates when clicked', () => {
+    const wrapper = createButton(1);
+    const applyBtn = wrapper.find('IconButton');
+
+    applyBtn.props().onClick();
+
+    assert.called(fakeOnClick);
+  });
+});

--- a/src/sidebar/components/test/PendingUpdatesButton-test.js
+++ b/src/sidebar/components/test/PendingUpdatesButton-test.js
@@ -1,26 +1,42 @@
 import { mount } from 'enzyme';
 
-import PendingUpdatesButton from '../PendingUpdatesButton';
+import PendingUpdatesButton, { $imports } from '../PendingUpdatesButton';
 
 describe('PendingUpdatesButton', () => {
   let fakeOnClick;
   let fakeToastMessenger;
+  let fakeStore;
 
   beforeEach(() => {
     fakeOnClick = sinon.stub();
     fakeToastMessenger = {
       success: sinon.stub(),
     };
+    fakeStore = {
+      pendingUpdateCount: sinon.stub().returns(0),
+      hasPendingUpdates: sinon.stub().returns(true),
+    };
+
+    $imports.$mock({
+      '../store': { useSidebarStore: () => fakeStore },
+    });
   });
 
-  const createButton = count =>
-    mount(
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  const createButton = count => {
+    fakeStore.pendingUpdateCount.returns(count);
+    fakeStore.hasPendingUpdates.returns(count > 0);
+
+    return mount(
       <PendingUpdatesButton
-        pendingUpdateCount={count}
         onClick={fakeOnClick}
         toastMessenger={fakeToastMessenger}
       />
     );
+  };
 
   it('shows an empty wrapper when there are no pending updates', () => {
     const wrapper = createButton(0);

--- a/src/sidebar/components/test/PendingUpdatesButton-test.js
+++ b/src/sidebar/components/test/PendingUpdatesButton-test.js
@@ -3,18 +3,20 @@ import { mount } from 'enzyme';
 import PendingUpdatesButton, { $imports } from '../PendingUpdatesButton';
 
 describe('PendingUpdatesButton', () => {
-  let fakeOnClick;
   let fakeToastMessenger;
   let fakeStore;
+  let fakeStreamer;
 
   beforeEach(() => {
-    fakeOnClick = sinon.stub();
     fakeToastMessenger = {
-      success: sinon.stub(),
+      notice: sinon.stub(),
     };
     fakeStore = {
       pendingUpdateCount: sinon.stub().returns(0),
       hasPendingUpdates: sinon.stub().returns(true),
+    };
+    fakeStreamer = {
+      applyPendingUpdates: sinon.stub(),
     };
 
     $imports.$mock({
@@ -32,7 +34,7 @@ describe('PendingUpdatesButton', () => {
 
     return mount(
       <PendingUpdatesButton
-        onClick={fakeOnClick}
+        streamer={fakeStreamer}
         toastMessenger={fakeToastMessenger}
       />
     );
@@ -42,7 +44,7 @@ describe('PendingUpdatesButton', () => {
     const wrapper = createButton(0);
 
     assert.isFalse(wrapper.find('IconButton').exists());
-    assert.notCalled(fakeToastMessenger.success);
+    assert.notCalled(fakeToastMessenger.notice);
   });
 
   [1, 10, 50].forEach(pendingUpdateCount => {
@@ -51,8 +53,8 @@ describe('PendingUpdatesButton', () => {
 
       assert.isTrue(wrapper.find('IconButton').exists());
       assert.calledWith(
-        fakeToastMessenger.success,
-        `There are ${pendingUpdateCount} new annotations.`,
+        fakeToastMessenger.notice,
+        `New annotations are available.`,
         {
           visuallyHidden: true,
         }
@@ -71,6 +73,6 @@ describe('PendingUpdatesButton', () => {
 
     applyBtn.props().onClick();
 
-    assert.called(fakeOnClick);
+    assert.called(fakeStreamer.applyPendingUpdates);
   });
 });

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -75,17 +75,29 @@ describe('TopBar', () => {
     );
   }
 
-  it('shows the pending update count', () => {
-    fakeStore.pendingUpdateCount.returns(1);
-    const wrapper = createTopBar();
-    const applyBtn = getButton(wrapper, 'RefreshIcon');
-    assert.isTrue(applyBtn.exists());
+  [1, 10, 50].forEach(pendingUpdateCount => {
+    it('shows the pending update count', () => {
+      fakeStore.pendingUpdateCount.returns(pendingUpdateCount);
+      const wrapper = createTopBar();
+      const applyBtn = getButton(wrapper, 'RefreshIcon');
+
+      assert.isTrue(applyBtn.exists());
+      assert.calledWith(
+        fakeToastMessenger.success,
+        `There are ${pendingUpdateCount} new annotations.`,
+        {
+          visuallyHidden: true,
+        }
+      );
+    });
   });
 
   it('does not show the pending update count when there are no updates', () => {
     const wrapper = createTopBar();
     const applyBtn = getButton(wrapper, 'RefreshIcon');
+
     assert.isFalse(applyBtn.exists());
+    assert.notCalled(fakeToastMessenger.success);
   });
 
   it('applies updates when clicked', () => {

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -20,7 +20,6 @@ describe('TopBar', () => {
       hasFetchedProfile: sinon.stub().returns(false),
       isLoggedIn: sinon.stub().returns(false),
       isSidebarPanelOpen: sinon.stub().returns(false),
-      pendingUpdateCount: sinon.stub().returns(0),
       setFilterQuery: sinon.stub(),
       toggleSidebarPanel: sinon.stub(),
     };
@@ -70,7 +69,6 @@ describe('TopBar', () => {
   }
 
   it('applies updates when clicked', () => {
-    fakeStore.pendingUpdateCount.returns(1);
     const wrapper = createTopBar();
     const updatesBtn = wrapper.find('PendingUpdatesButton');
 

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -9,6 +9,7 @@ describe('TopBar', () => {
   let fakeFrameSync;
   let fakeStore;
   let fakeStreamer;
+  let fakeToastMessenger;
   let fakeIsThirdPartyService;
   let fakeServiceConfig;
 
@@ -33,6 +34,10 @@ describe('TopBar', () => {
 
     fakeStreamer = {
       applyPendingUpdates: sinon.stub(),
+    };
+
+    fakeToastMessenger = {
+      success: sinon.stub(),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -64,6 +69,7 @@ describe('TopBar', () => {
         isSidebar={true}
         settings={fakeSettings}
         streamer={fakeStreamer}
+        toastMessenger={fakeToastMessenger}
         {...props}
       />
     );

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -68,15 +68,6 @@ describe('TopBar', () => {
     );
   }
 
-  it('applies updates when clicked', () => {
-    const wrapper = createTopBar();
-    const updatesBtn = wrapper.find('PendingUpdatesButton');
-
-    updatesBtn.props().onClick();
-
-    assert.called(fakeStreamer.applyPendingUpdates);
-  });
-
   describe('`HelpButton` and help requests', () => {
     context('no help service handler configured in services (default)', () => {
       it('toggles Help Panel on click', () => {

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -9,7 +9,6 @@ describe('TopBar', () => {
   let fakeFrameSync;
   let fakeStore;
   let fakeStreamer;
-  let fakeToastMessenger;
   let fakeIsThirdPartyService;
   let fakeServiceConfig;
 
@@ -34,10 +33,6 @@ describe('TopBar', () => {
 
     fakeStreamer = {
       applyPendingUpdates: sinon.stub(),
-    };
-
-    fakeToastMessenger = {
-      success: sinon.stub(),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -69,43 +64,17 @@ describe('TopBar', () => {
         isSidebar={true}
         settings={fakeSettings}
         streamer={fakeStreamer}
-        toastMessenger={fakeToastMessenger}
         {...props}
       />
     );
   }
 
-  [1, 10, 50].forEach(pendingUpdateCount => {
-    it('shows the pending update count', () => {
-      fakeStore.pendingUpdateCount.returns(pendingUpdateCount);
-      const wrapper = createTopBar();
-      const applyBtn = getButton(wrapper, 'RefreshIcon');
-
-      assert.isTrue(applyBtn.exists());
-      assert.calledWith(
-        fakeToastMessenger.success,
-        `There are ${pendingUpdateCount} new annotations.`,
-        {
-          visuallyHidden: true,
-        }
-      );
-    });
-  });
-
-  it('does not show the pending update count when there are no updates', () => {
-    const wrapper = createTopBar();
-    const applyBtn = getButton(wrapper, 'RefreshIcon');
-
-    assert.isFalse(applyBtn.exists());
-    assert.notCalled(fakeToastMessenger.success);
-  });
-
   it('applies updates when clicked', () => {
     fakeStore.pendingUpdateCount.returns(1);
     const wrapper = createTopBar();
-    const applyBtn = getButton(wrapper, 'RefreshIcon');
+    const updatesBtn = wrapper.find('PendingUpdatesButton');
 
-    applyBtn.props().onClick();
+    updatesBtn.props().onClick();
 
     assert.called(fakeStreamer.applyPendingUpdates);
   });

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -217,6 +217,17 @@ function hasPendingDeletion(state, id) {
   return hasOwn(state.pendingDeletions, id);
 }
 
+/**
+ * Return true if an annotation has been deleted on the server but the deletion
+ * has not yet been applied.
+ *
+ * @param {State} state
+ * @return {boolean}
+ */
+function hasPendingUpdates(state) {
+  return Object.keys(state.pendingUpdates).length > 0;
+}
+
 export const realTimeUpdatesModule = createStoreModule(initialState, {
   namespace: 'realTimeUpdates',
   reducers,
@@ -226,6 +237,7 @@ export const realTimeUpdatesModule = createStoreModule(initialState, {
   },
   selectors: {
     hasPendingDeletion,
+    hasPendingUpdates,
     pendingDeletions,
     pendingUpdates,
     pendingUpdateCount,

--- a/src/sidebar/store/modules/real-time-updates.js
+++ b/src/sidebar/store/modules/real-time-updates.js
@@ -218,8 +218,8 @@ function hasPendingDeletion(state, id) {
 }
 
 /**
- * Return true if an annotation has been deleted on the server but the deletion
- * has not yet been applied.
+ * Return true if an annotation has been created on the server, but it has not
+ * yet been applied.
  *
  * @param {State} state
  * @return {boolean}

--- a/src/sidebar/store/modules/test/real-time-updates-test.js
+++ b/src/sidebar/store/modules/test/real-time-updates-test.js
@@ -182,4 +182,15 @@ describe('sidebar/store/modules/real-time-updates', () => {
       assert.equal(store.hasPendingDeletion('deleted-ann'), true);
     });
   });
+
+  describe('hasPendingUpdates', () => {
+    it('returns false if there are no pending updates', () => {
+      assert.equal(store.hasPendingUpdates(), false);
+    });
+
+    it('returns true if there are pending updates', () => {
+      addPendingUpdates(store);
+      assert.equal(store.hasPendingUpdates(), true);
+    });
+  });
 });


### PR DESCRIPTION
This PR changes the logic introduced in https://github.com/hypothesis/client/pull/5305 to make sure the message is toasted only when pending updates goes from 0 to a value greater than zero, which effectively means it is toasted when the button to refresh notifications is displayed.

If for any reason the pending notifications are increased before the notifications are refreshed, this prevents the message to be toasted again, which might be overwhelming on documents with a lot of activity.

### Testing steps:

1. Change to this branch on your local client instance.
2. Open it using your local network address (192.168.x.x:3000), not `localhost:3000`.
3. Make sure you are logged in and the sidebar is "focused".
4. Run a screen reader service.
5. Open the same network address on a different device which is on the same network (I have been testing it with my mobile phone).
6. Login and add an annotation on the second device: The screen reader on the first device should announce that there's a new annotation available.
7. Before clicking on the refresh button, add another annotation from the second device: The screen reader should not announce anything.
8. Click on refresh annotations on the first device.
9. Add another annotation from the second device: The screen reader should announce that there are new annotations available.