### PR TITLE
Add keyboard shortcut to load pending updates

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -336,6 +336,12 @@ export class Sidebar {
     annotationCounts(document.body, this._sidebarRPC);
     sidebarTrigger(document.body, () => this.open());
 
+    document.documentElement.addEventListener(
+      'keypress',
+      /** @param {KeyboardEvent} e */ e =>
+        this._sidebarRPC.call('keypress', e.key)
+    );
+
     this._sidebarRPC.on(
       'featureFlagsUpdated',
       /** @param {Record<string, boolean>} flags */ flags =>

--- a/src/shared/shortcut.ts
+++ b/src/shared/shortcut.ts
@@ -1,5 +1,7 @@
 import { useEffect } from 'preact/hooks';
 
+import type { FrameSyncService } from '../sidebar/services/frame-sync';
+
 /**
  * Bit flags indicating modifiers required by a shortcut or pressed in a key event.
  */
@@ -119,4 +121,24 @@ export function useShortcut(
     }
     return installShortcut(shortcut, onPress, { rootElement });
   }, [shortcut, onPress, rootElement]);
+}
+
+export function useGlobalShortcut({
+  frameSync,
+  shortcut,
+  onPress,
+  options,
+}: {
+  frameSync: FrameSyncService;
+  shortcut: string | null;
+  onPress: () => void;
+  options?: ShortcutOptions;
+}) {
+  useShortcut(shortcut, onPress, options);
+  useEffect(() => {
+    if (!shortcut) {
+      return undefined;
+    }
+    return frameSync.onHostKeyPressed(shortcut, onPress);
+  }, [frameSync, shortcut, onPress]);
 }

--- a/src/sidebar/components/PendingUpdatesButton.tsx
+++ b/src/sidebar/components/PendingUpdatesButton.tsx
@@ -1,6 +1,7 @@
 import { IconButton, RefreshIcon } from '@hypothesis/frontend-shared/lib/next';
 import { useEffect } from 'preact/hooks';
 
+import { useShortcut } from '../../shared/shortcut';
 import { withServices } from '../service-context';
 import type { StreamerService } from '../services/streamer';
 import type { ToastMessengerService } from '../services/toast-messenger';
@@ -19,6 +20,9 @@ function PendingUpdatesButton({
   const store = useSidebarStore();
   const pendingUpdateCount = store.pendingUpdateCount();
   const hasPendingUpdates = store.hasPendingUpdates();
+  const applyPendingUpdates = () => streamer.applyPendingUpdates();
+
+  useShortcut('.', () => hasPendingUpdates && applyPendingUpdates());
 
   useEffect(() => {
     if (hasPendingUpdates) {
@@ -35,7 +39,7 @@ function PendingUpdatesButton({
   return (
     <IconButton
       icon={RefreshIcon}
-      onClick={() => streamer.applyPendingUpdates()}
+      onClick={applyPendingUpdates}
       size="xs"
       variant="primary"
       title={`Show ${pendingUpdateCount} new/updated ${

--- a/src/sidebar/components/PendingUpdatesButton.tsx
+++ b/src/sidebar/components/PendingUpdatesButton.tsx
@@ -1,19 +1,22 @@
 import { IconButton, RefreshIcon } from '@hypothesis/frontend-shared/lib/next';
 import { useEffect } from 'preact/hooks';
 
-import { useShortcut } from '../../shared/shortcut';
+import { useGlobalShortcut } from '../../shared/shortcut';
 import { withServices } from '../service-context';
+import type { FrameSyncService } from '../services/frame-sync';
 import type { StreamerService } from '../services/streamer';
 import type { ToastMessengerService } from '../services/toast-messenger';
 import { useSidebarStore } from '../store';
 
 export type PendingUpdatesButtonProps = {
   // Injected
+  frameSync: FrameSyncService;
   streamer: StreamerService;
   toastMessenger: ToastMessengerService;
 };
 
 function PendingUpdatesButton({
+  frameSync,
   streamer,
   toastMessenger,
 }: PendingUpdatesButtonProps) {
@@ -22,13 +25,20 @@ function PendingUpdatesButton({
   const hasPendingUpdates = store.hasPendingUpdates();
   const applyPendingUpdates = () => streamer.applyPendingUpdates();
 
-  useShortcut('.', () => hasPendingUpdates && applyPendingUpdates());
+  useGlobalShortcut({
+    shortcut: '.',
+    onPress: () => hasPendingUpdates && applyPendingUpdates(),
+    frameSync,
+  });
 
   useEffect(() => {
     if (hasPendingUpdates) {
-      toastMessenger.notice(`New annotations are available.`, {
-        visuallyHidden: true,
-      });
+      toastMessenger.notice(
+        `New annotations are available. Press "." to load them.`,
+        {
+          visuallyHidden: true,
+        }
+      );
     }
   }, [hasPendingUpdates, toastMessenger]);
 
@@ -50,6 +60,7 @@ function PendingUpdatesButton({
 }
 
 export default withServices(PendingUpdatesButton, [
+  'frameSync',
   'streamer',
   'toastMessenger',
 ]);

--- a/src/sidebar/components/test/PendingUpdatesButton-test.js
+++ b/src/sidebar/components/test/PendingUpdatesButton-test.js
@@ -54,7 +54,7 @@ describe('PendingUpdatesButton', () => {
       assert.isTrue(wrapper.find('IconButton').exists());
       assert.calledWith(
         fakeToastMessenger.notice,
-        `New annotations are available.`,
+        `New annotations are available. Press "." to load them.`,
         {
           visuallyHidden: true,
         }

--- a/src/sidebar/components/test/PendingUpdatesButton-test.js
+++ b/src/sidebar/components/test/PendingUpdatesButton-test.js
@@ -75,4 +75,16 @@ describe('PendingUpdatesButton', () => {
 
     assert.called(fakeStreamer.applyPendingUpdates);
   });
+
+  it('applies updates when `.` is pressed', () => {
+    createButton(1);
+    document.body.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: '.',
+        bubbles: true,
+      })
+    );
+
+    assert.called(fakeStreamer.applyPendingUpdates);
+  });
 });

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -111,7 +111,12 @@ export type HostToSidebarEvent =
   /**
    * The host informs the sidebar that the sidebar has been opened.
    */
-  | 'sidebarOpened';
+  | 'sidebarOpened'
+
+  /**
+   * A key has been pressed in host.
+   */
+  | 'keypress';
 
 /**
  * Events that the sidebar sends to the guest(s)


### PR DESCRIPTION
This PR complements what was done in https://github.com/hypothesis/client/pull/5306, adding a keyboard shortcut to load pending annotations.

Thanks to this we can extend the toasted message so that screen readers can announce an action for when new annotations are available.

However, there's a big challenge to solve here. The screen reader announces the message no matter the active frame, as long as the sidebar is not collapsed, which means the shortcut needs to be captured by any frame and the action be forwarded to the actual listener.

This PR also introduces the logic to capture `keypress` events on the host frame, to then send them to the sidebar via RPC messaging.

Then, a new `useGlobalShortcut` hook is created, which combines `useShortcut` (to listen to events on the active frame) and listening to messages of a specific type coming from the host frame, so that we can invoke the listener even if the event was triggered there.