### PR TITLE
Use `PendingUpdatesButton` in notebook

### DIFF
--- a/src/sidebar/components/NotebookView.tsx
+++ b/src/sidebar/components/NotebookView.tsx
@@ -1,9 +1,4 @@
-import {
-  IconButton,
-  Link,
-  Panel,
-  RefreshIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+import { Link, Panel } from '@hypothesis/frontend-shared/lib/next';
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import scrollIntoView from 'scroll-into-view';
 
@@ -15,6 +10,7 @@ import { useSidebarStore } from '../store';
 import NotebookFilters from './NotebookFilters';
 import NotebookResultCount from './NotebookResultCount';
 import PaginatedThreadList from './PaginatedThreadList';
+import PendingUpdatesButton from './PendingUpdatesButton';
 import { useRootThread } from './hooks/use-root-thread';
 
 export type NotebookViewProps = {
@@ -36,7 +32,6 @@ function NotebookView({ loadAnnotationsService, streamer }: NotebookViewProps) {
   const hasAppliedFilter = store.hasAppliedFilter();
   const isLoading = store.isLoading();
   const resultCount = store.annotationResultCount();
-  const pendingUpdateCount = store.pendingUpdateCount();
 
   const rootThread = useRootThread();
 
@@ -127,10 +122,6 @@ function NotebookView({ loadAnnotationsService, streamer }: NotebookViewProps) {
     }
   }, [paginationPage]);
 
-  const tooltip = `Show ${pendingUpdateCount} new or updated ${
-    pendingUpdateCount > 1 ? 'annotations' : 'annotation'
-  }`;
-
   return (
     <div className="grid gap-2 lg:grid-cols-2" data-testid="notebook-container">
       <header className="leading-none lg:col-span-2" ref={threadListScrollTop}>
@@ -142,15 +133,7 @@ function NotebookView({ loadAnnotationsService, streamer }: NotebookViewProps) {
         <NotebookFilters />
       </div>
       <div className="flex items-center lg:justify-self-end text-md font-medium">
-        {pendingUpdateCount > 0 && !hasAppliedFilter && (
-          <IconButton
-            data-testid="refresh-button"
-            icon={RefreshIcon}
-            onClick={() => streamer.applyPendingUpdates()}
-            variant="primary"
-            title={tooltip}
-          />
-        )}
+        <PendingUpdatesButton />
         <NotebookResultCount
           forcedVisibleCount={forcedVisibleCount}
           isFiltered={hasAppliedFilter}

--- a/src/sidebar/components/test/NotebookView-test.js
+++ b/src/sidebar/components/test/NotebookView-test.js
@@ -31,13 +31,11 @@ describe('NotebookView', () => {
       isLoading: sinon.stub().returns(false),
       annotationResultCount: sinon.stub().returns(0),
       setSortKey: sinon.stub(),
-      pendingUpdateCount: sinon.stub().returns(0),
       hasFetchedProfile: sinon.stub().returns(true),
     };
 
     fakeStreamer = {
       connect: sinon.stub(),
-      applyPendingUpdates: sinon.stub(),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -147,38 +145,6 @@ describe('NotebookView', () => {
   it('renders filters', () => {
     const wrapper = createComponent();
     assert.isTrue(wrapper.find('NotebookFilters').exists());
-  });
-
-  describe('synchronization of annotations', () => {
-    beforeEach(() => {
-      fakeStore.focusedGroup.returns({ id: 'hallothere', name: 'Hallo' });
-      fakeStore.pendingUpdateCount.returns(3);
-    });
-
-    it("doesn't display button to synchronize annotations if filters are applied", () => {
-      fakeStore.hasAppliedFilter.returns(true);
-      const wrapper = createComponent();
-
-      const button = wrapper.find('button[data-testid="refresh-button"]');
-      assert.isFalse(button.exists());
-    });
-
-    it('shows button to synchronize annotations if no filters are applied', () => {
-      const wrapper = createComponent();
-
-      const button = wrapper.find('button[data-testid="refresh-button"]');
-      assert.isTrue(button.exists());
-      assert.include(button.prop('title'), 'Show 3 new or updated annotations');
-    });
-
-    it('synchronizes pending annotations', () => {
-      const wrapper = createComponent();
-
-      const button = wrapper.find('button[data-testid="refresh-button"]');
-      assert.isTrue(button.exists());
-      button.prop('onClick')();
-      assert.called(fakeStreamer.applyPendingUpdates);
-    });
   });
 
   describe('pagination', () => {


### PR DESCRIPTION
This PR replaces the new annotations indicator in the notebook with the `PendingUpdatesButton` introduced in https://github.com/hypothesis/client/pull/5306.

There should be no visual changes, but this button brings notifications for screen readers out of the box. Also, the notebook will benefit from any further improvements made on this component (like support for keyboard shortcuts).

In order to test this, follow the steps from https://github.com/hypothesis/client/pull/5306, but replacing step three:

```diff
- 3. Make sure you are logged in and the sidebar is "focused".
+ 3. Make sure you are logged in and the notebook is open.
```