### PR TITLE
Check type of `window.navigation` global before using it

### DIFF
--- a/src/annotator/util/navigation-observer.js
+++ b/src/annotator/util/navigation-observer.js
@@ -1,3 +1,4 @@
+/* global Navigation */
 import { ListenerCollection } from '../../shared/listener-collection';
 
 /**
@@ -39,6 +40,28 @@ function stripFragment(url) {
 }
 
 /**
+ * Return the Navigation API entry point for the current window.
+ *
+ * This is a wrapper around `window.navigation` which checks both that the
+ * object exists and has the expected type. See also
+ * https://github.com/hypothesis/client/issues/5324.
+ *
+ * @return {EventTarget|null}
+ */
+export function getNavigation() {
+  const navigation = /** @type {any} */ (window).navigation;
+  if (
+    // @ts-expect-error - Navigation API is missing from TS
+    typeof Navigation === 'function' &&
+    // @ts-expect-error
+    navigation instanceof Navigation
+  ) {
+    return navigation;
+  }
+  return null;
+}
+
+/**
  * Utility for detecting client-side navigations of an HTML document.
  *
  * This uses the Navigation API [1] if available, or falls back to
@@ -76,8 +99,7 @@ export class NavigationObserver {
       }
     };
 
-    // @ts-expect-error - TS is missing Navigation API types.
-    const navigation = window.navigation;
+    const navigation = getNavigation();
     if (navigation) {
       this._listeners.add(navigation, 'navigatesuccess', () =>
         checkForURLChange()


### PR DESCRIPTION
Fix a crash on web pages which define a global variable called `navigation`, which conflicts with the `window.navigation` entry point for the Navigation API.

If such a variable exists, the existing fallback to `window.history` will be used instead.

Related to this, we might in future need to introduce more general guards to verify globals which are liable to get overridden, before we use them. Another case where this has happened is the `URL` constructor. For some APIs, we could get a reference to the original by creating a temporary iframe. That probably won't work with `window.navigation` though, since it is an object that relates to a specific window.

Fixes #5324

**Testing:**

1. Check out this branch
2. Activate development client bookmarklet on https://www.poetryoutloud.org (this website defines a `navigation` global which is a `NodeList` object) in Chrome