### PR TITLE
Add keyboard shortcut to PendingUpdatesButton

### DIFF
--- a/src/sidebar/components/PendingUpdatesButton.tsx
+++ b/src/sidebar/components/PendingUpdatesButton.tsx
@@ -1,5 +1,5 @@
 import { IconButton, RefreshIcon } from '@hypothesis/frontend-shared/lib/next';
-import { useEffect } from 'preact/hooks';
+import { useCallback, useEffect } from 'preact/hooks';
 
 import { useShortcut } from '../../shared/shortcut';
 import { withServices } from '../service-context';
@@ -20,7 +20,10 @@ function PendingUpdatesButton({
   const store = useSidebarStore();
   const pendingUpdateCount = store.pendingUpdateCount();
   const hasPendingUpdates = store.hasPendingUpdates();
-  const applyPendingUpdates = () => streamer.applyPendingUpdates();
+  const applyPendingUpdates = useCallback(
+    () => streamer.applyPendingUpdates(),
+    [streamer]
+  );
 
   useShortcut('l', () => hasPendingUpdates && applyPendingUpdates());
 

--- a/src/sidebar/components/PendingUpdatesButton.tsx
+++ b/src/sidebar/components/PendingUpdatesButton.tsx
@@ -1,6 +1,7 @@
 import { IconButton, RefreshIcon } from '@hypothesis/frontend-shared/lib/next';
 import { useEffect } from 'preact/hooks';
 
+import { useShortcut } from '../../shared/shortcut';
 import { withServices } from '../service-context';
 import type { StreamerService } from '../services/streamer';
 import type { ToastMessengerService } from '../services/toast-messenger';
@@ -19,11 +20,18 @@ function PendingUpdatesButton({
   const store = useSidebarStore();
   const pendingUpdateCount = store.pendingUpdateCount();
   const hasPendingUpdates = store.hasPendingUpdates();
+  const applyPendingUpdates = () => streamer.applyPendingUpdates();
+
+  useShortcut('l', () => hasPendingUpdates && applyPendingUpdates());
 
   useEffect(() => {
     if (hasPendingUpdates) {
-      toastMessenger.notice(`New annotations are available.`, {
+      toastMessenger.notice('New annotations are available.', {
         visuallyHidden: true,
+      });
+      toastMessenger.notice('Press "l" to load new annotations.', {
+        visuallyHidden: true,
+        delayed: true,
       });
     }
   }, [hasPendingUpdates, toastMessenger]);
@@ -35,7 +43,7 @@ function PendingUpdatesButton({
   return (
     <IconButton
       icon={RefreshIcon}
-      onClick={() => streamer.applyPendingUpdates()}
+      onClick={applyPendingUpdates}
       size="xs"
       variant="primary"
       title={`Show ${pendingUpdateCount} new/updated ${

--- a/src/sidebar/components/test/PendingUpdatesButton-test.js
+++ b/src/sidebar/components/test/PendingUpdatesButton-test.js
@@ -54,9 +54,17 @@ describe('PendingUpdatesButton', () => {
       assert.isTrue(wrapper.find('IconButton').exists());
       assert.calledWith(
         fakeToastMessenger.notice,
-        `New annotations are available.`,
+        'New annotations are available.',
         {
           visuallyHidden: true,
+        }
+      );
+      assert.calledWith(
+        fakeToastMessenger.notice,
+        'Press "l" to load new annotations.',
+        {
+          visuallyHidden: true,
+          delayed: true,
         }
       );
     });
@@ -72,6 +80,18 @@ describe('PendingUpdatesButton', () => {
     const applyBtn = wrapper.find('IconButton');
 
     applyBtn.props().onClick();
+
+    assert.called(fakeStreamer.applyPendingUpdates);
+  });
+
+  it('applies updates when keyboard shortcut is pressed', () => {
+    createButton(1);
+    document.body.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'l',
+        bubbles: true,
+      })
+    );
 
     assert.called(fakeStreamer.applyPendingUpdates);
   });


### PR DESCRIPTION
This PR adds a shortcut that can be used to load pending annotations, via `useShortcut`. It also enhances the message we toast when the new annotations are available, so that the user knows about this shortcut.

Since this shortcut will only work if the frame containing `PendingUpdatesButton` is focused, the toast message is actually split in two, the original one which is imediatelly toasted, and the part mentioning the shortcut, which is "delayed" until the frame is focused, by taking advantage of the logic implemented in https://github.com/hypothesis/client/pull/5323.

### Testing steps:

1. Check out this branch and start the screen reader
2. Make sure the sidebar is not focused
3. Create an annotation from a different device, so that you don't have to focus a different window
    * The screen reader should announce `New annotations are available.` (there could be other unrelated stuff announced before this)
4. Click inside the sidebar.
    * The screen reader should announce `Press "l" to load new annotations.`
5. Pressing `l` should load the pending annotations, hiding the `PendingUpdatesButton`.
6. Now make sure the sidebar is focused.
7. Create an annotation from a different device
    * The screen reader should announce `New annotations are available.` immediately followed by `Press "l" to load new annotations.`