### PR TITLE
Ensure 1px visibility of collapsed sidebar for screen readers to work

### DIFF
--- a/src/styles/annotator/components/sidebar.scss
+++ b/src/styles/annotator/components/sidebar.scss
@@ -48,7 +48,7 @@
     }
 
     &.sidebar-collapsed {
-      @apply ml-0;
+      @apply ml-[-1px];
     }
   }
 


### PR DESCRIPTION
Surprisingly, this makes screen readers consider the sidebar is "visible" when collapsed, as it is still 1px inside the viewport.

With this change screen readers will announce changes in the toast messages `aria-live` region, even when the sidebar is "collapsed", which will help address https://github.com/hypothesis/product-backlog/issues/1426

Of course this is a dirty hack, and probably addressing the symptom more than the root cause, but at least helps understand how the screen readers work.

The sidebar is also `visibility: hidden` when collapsed, but that doesn't seem to affect the screen readers.