### PR TITLE
Forward hidden toast messages to host frame

### DIFF
--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -1,9 +1,11 @@
 import * as Hammer from 'hammerjs';
+import { render } from 'preact';
 
 import { addConfigFragment } from '../shared/config-fragment';
 import { sendErrorsTo } from '../shared/frame-error-capture';
 import { ListenerCollection } from '../shared/listener-collection';
 import { PortRPC } from '../shared/messaging';
+import HostToastMessages from '../sidebar/components/HostToastMessages';
 import { annotationCounts } from './annotation-counts';
 import { BucketBar } from './bucket-bar';
 import { createAppConfig } from './config/app';
@@ -161,6 +163,13 @@ export class Sidebar {
       shadowRoot.appendChild(this.iframeContainer);
 
       element.appendChild(this.hypothesisSidebar);
+
+      const messagesElement = document.createElement('div');
+      shadowRoot.appendChild(messagesElement);
+      render(
+        <HostToastMessages sidebarRPC={this._sidebarRPC} />,
+        messagesElement
+      );
     }
 
     // Register the sidebar as a handler for Hypothesis errors in this frame.

--- a/src/shared/injector.js
+++ b/src/shared/injector.js
@@ -64,6 +64,15 @@ export class Injector {
       return this._instances.get(name);
     }
 
+    if (name.endsWith('Factory')) {
+      const [actualName] = name.split('Factory');
+      const instance = () => this.get(actualName);
+
+      this._instances.set(name, instance);
+
+      return instance;
+    }
+
     const provider = this._providers.get(name);
 
     if (!provider) {

--- a/src/sidebar/components/DependencyLessToastMessages.tsx
+++ b/src/sidebar/components/DependencyLessToastMessages.tsx
@@ -1,0 +1,153 @@
+import {
+  Card,
+  Link,
+  CancelIcon,
+  CautionIcon,
+  CheckIcon,
+} from '@hypothesis/frontend-shared/lib/next';
+import classnames from 'classnames';
+
+import type { ToastMessage } from '../store/modules/toast-messages';
+
+type ToastMessageItemProps = {
+  message: ToastMessage;
+  onDismiss: (id: string) => void;
+};
+
+/**
+ * An individual toast message: a brief and transient success or error message.
+ * The message may be dismissed by clicking on it. `visuallyHidden` toast
+ * messages will not be visible but are still available to screen readers.
+ *
+ * Otherwise, the `toastMessenger` service handles removing messages after a
+ * certain amount of time.
+ */
+function ToastMessageItem({ message, onDismiss }: ToastMessageItemProps) {
+  // Capitalize the message type for prepending; Don't prepend a message
+  // type for "notice" messages
+  const prefix =
+    message.type !== 'notice'
+      ? `${message.type.charAt(0).toUpperCase() + message.type.slice(1)}: `
+      : '';
+
+  let Icon;
+  switch (message.type) {
+    case 'success':
+      Icon = CheckIcon;
+      break;
+    case 'error':
+      Icon = CancelIcon;
+      break;
+    case 'notice':
+    default:
+      Icon = CautionIcon;
+      break;
+  }
+  /**
+   * a11y linting is disabled here: There is a click-to-remove handler on a
+   * non-interactive element. This allows sighted users to get the toast message
+   * out of their way if it interferes with interacting with the underlying
+   * components. This shouldn't pose the same irritation to users with screen-
+   * readers as the rendered toast messages shouldn't impede interacting with
+   * the underlying document.
+   */
+  return (
+    /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */
+    <Card
+      classes={classnames('flex', {
+        'sr-only': message.visuallyHidden,
+        'border-red-error': message.type === 'error',
+        'border-yellow-notice': message.type === 'notice',
+        'border-green-success': message.type === 'success',
+      })}
+      onClick={() => onDismiss(message.id)}
+    >
+      <div
+        className={classnames('flex items-center p-3 text-white', {
+          'bg-red-error': message.type === 'error',
+          'bg-yellow-notice': message.type === 'notice',
+          'bg-green-success': message.type === 'success',
+        })}
+      >
+        <Icon
+          className={classnames(
+            // Adjust alignment of icon to appear more aligned with text
+            'mt-[2px]'
+          )}
+        />
+      </div>
+      <div className="grow p-3" data-testid="toast-message-text">
+        <strong>{prefix}</strong>
+        {message.message}
+        {message.moreInfoURL && (
+          <div className="text-right">
+            <Link
+              href={message.moreInfoURL}
+              onClick={
+                event =>
+                  event.stopPropagation() /* consume the event so that it does not dismiss the message */
+              }
+              target="_new"
+            >
+              More info
+            </Link>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+export type DependencyLessToastMessageProps = {
+  messages: ToastMessage[];
+  onMessageDismiss: (messageId: string) => void;
+};
+
+/**
+ * A collection of toast messages. These are rendered within an `aria-live`
+ * region for accessibility with screen readers.
+ */
+export default function DependencyLessToastMessages({
+  messages,
+  onMessageDismiss,
+}: DependencyLessToastMessageProps) {
+  // The `ul` containing any toast messages is absolute-positioned and the full
+  // width of the viewport. Each toast message `li` has its position and width
+  // constrained by `container` configuration in tailwind.
+  return (
+    <div>
+      <ul
+        aria-live="polite"
+        aria-relevant="additions"
+        className="absolute z-2 left-0 w-full"
+      >
+        {messages.map(message => (
+          <li
+            className={classnames(
+              'relative w-full container hover:cursor-pointer',
+              {
+                // Add a bottom margin to visible messages only. Typically we'd
+                // use a `space-y-2` class on the parent to space children.
+                // Doing that here could cause an undesired top margin on
+                // the first visible message in a list that contains (only)
+                // visually-hidden messages before it.
+                // See https://tailwindcss.com/docs/space#limitations
+                'mb-2': !message.visuallyHidden,
+                // Slide in from right in narrow viewports; fade in in
+                // larger viewports to toast message isn't flying too far
+                'motion-safe:animate-slide-in-from-right lg:animate-fade-in':
+                  !message.isDismissed,
+                // Only ever fade in if motion-reduction is preferred
+                'motion-reduce:animate-fade-in': !message.isDismissed,
+                'animate-fade-out': message.isDismissed,
+              }
+            )}
+            key={message.id}
+          >
+            <ToastMessageItem message={message} onDismiss={onMessageDismiss} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/sidebar/components/HostToastMessages.tsx
+++ b/src/sidebar/components/HostToastMessages.tsx
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from 'preact/hooks';
+
+import type { PortRPC } from '../../shared/messaging';
+import type {
+  HostToSidebarEvent,
+  SidebarToHostEvent,
+} from '../../types/port-rpc-events';
+import type { ToastMessage } from '../store/modules/toast-messages';
+import DependencyLessToastMessages from './DependencyLessToastMessages';
+
+export type HostToastMessagesProps = {
+  sidebarRPC: PortRPC<SidebarToHostEvent, HostToSidebarEvent>;
+};
+
+/**
+ * A component designed to render toast messages coming from the sidebar, in a
+ * way that they "appear" in the viewport even when the sidebar is collapsed.
+ * This is useful to make sure screen readers announce hidden messages.
+ */
+export default function HostToastMessages({
+  sidebarRPC,
+}: HostToastMessagesProps) {
+  const [messages, setMessages] = useState<ToastMessage[]>([]);
+  const pushNewMessage = useCallback(
+    (newMessage: ToastMessage) => setMessages(prev => [...prev, newMessage]),
+    []
+  );
+
+  useEffect(() => {
+    sidebarRPC.on('toastMessagePushed', (message: ToastMessage) => {
+      console.log('Hi!');
+      pushNewMessage(message);
+    });
+  }, [sidebarRPC, pushNewMessage]);
+
+  return (
+    <DependencyLessToastMessages
+      messages={messages}
+      onMessageDismiss={() => {}}
+    />
+  );
+}

--- a/src/sidebar/components/ToastMessages.tsx
+++ b/src/sidebar/components/ToastMessages.tsx
@@ -1,105 +1,7 @@
-import {
-  Card,
-  Link,
-  CancelIcon,
-  CautionIcon,
-  CheckIcon,
-} from '@hypothesis/frontend-shared/lib/next';
-import classnames from 'classnames';
-
 import { withServices } from '../service-context';
 import type { ToastMessengerService } from '../services/toast-messenger';
 import { useSidebarStore } from '../store';
-import type { ToastMessage } from '../store/modules/toast-messages';
-
-type ToastMessageItemProps = {
-  message: ToastMessage;
-  onDismiss: (id: string) => void;
-};
-
-/**
- * An individual toast message: a brief and transient success or error message.
- * The message may be dismissed by clicking on it. `visuallyHidden` toast
- * messages will not be visible but are still available to screen readers.
- *
- * Otherwise, the `toastMessenger` service handles removing messages after a
- * certain amount of time.
- */
-function ToastMessageItem({ message, onDismiss }: ToastMessageItemProps) {
-  // Capitalize the message type for prepending; Don't prepend a message
-  // type for "notice" messages
-  const prefix =
-    message.type !== 'notice'
-      ? `${message.type.charAt(0).toUpperCase() + message.type.slice(1)}: `
-      : '';
-
-  let Icon;
-  switch (message.type) {
-    case 'success':
-      Icon = CheckIcon;
-      break;
-    case 'error':
-      Icon = CancelIcon;
-      break;
-    case 'notice':
-    default:
-      Icon = CautionIcon;
-      break;
-  }
-  /**
-   * a11y linting is disabled here: There is a click-to-remove handler on a
-   * non-interactive element. This allows sighted users to get the toast message
-   * out of their way if it interferes with interacting with the underlying
-   * components. This shouldn't pose the same irritation to users with screen-
-   * readers as the rendered toast messages shouldn't impede interacting with
-   * the underlying document.
-   */
-  return (
-    /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */
-    <Card
-      classes={classnames('flex', {
-        'sr-only': message.visuallyHidden,
-        'border-red-error': message.type === 'error',
-        'border-yellow-notice': message.type === 'notice',
-        'border-green-success': message.type === 'success',
-      })}
-      onClick={() => onDismiss(message.id)}
-    >
-      <div
-        className={classnames('flex items-center p-3 text-white', {
-          'bg-red-error': message.type === 'error',
-          'bg-yellow-notice': message.type === 'notice',
-          'bg-green-success': message.type === 'success',
-        })}
-      >
-        <Icon
-          className={classnames(
-            // Adjust alignment of icon to appear more aligned with text
-            'mt-[2px]'
-          )}
-        />
-      </div>
-      <div className="grow p-3" data-testid="toast-message-text">
-        <strong>{prefix}</strong>
-        {message.message}
-        {message.moreInfoURL && (
-          <div className="text-right">
-            <Link
-              href={message.moreInfoURL}
-              onClick={
-                event =>
-                  event.stopPropagation() /* consume the event so that it does not dismiss the message */
-              }
-              target="_new"
-            >
-              More info
-            </Link>
-          </div>
-        )}
-      </div>
-    </Card>
-  );
-}
+import DependencyLessToastMessages from './DependencyLessToastMessages';
 
 export type ToastMessageProps = {
   // injected
@@ -113,47 +15,12 @@ export type ToastMessageProps = {
 function ToastMessages({ toastMessenger }: ToastMessageProps) {
   const store = useSidebarStore();
   const messages = store.getToastMessages();
-  // The `ul` containing any toast messages is absolute-positioned and the full
-  // width of the viewport. Each toast message `li` has its position and width
-  // constrained by `container` configuration in tailwind.
+
   return (
-    <div>
-      <ul
-        aria-live="polite"
-        aria-relevant="additions"
-        className="absolute z-2 left-0 w-full"
-      >
-        {messages.map(message => (
-          <li
-            className={classnames(
-              'relative w-full container hover:cursor-pointer',
-              {
-                // Add a bottom margin to visible messages only. Typically we'd
-                // use a `space-y-2` class on the parent to space children.
-                // Doing that here could cause an undesired top margin on
-                // the first visible message in a list that contains (only)
-                // visually-hidden messages before it.
-                // See https://tailwindcss.com/docs/space#limitations
-                'mb-2': !message.visuallyHidden,
-                // Slide in from right in narrow viewports; fade in in
-                // larger viewports to toast message isn't flying too far
-                'motion-safe:animate-slide-in-from-right lg:animate-fade-in':
-                  !message.isDismissed,
-                // Only ever fade in if motion-reduction is preferred
-                'motion-reduce:animate-fade-in': !message.isDismissed,
-                'animate-fade-out': message.isDismissed,
-              }
-            )}
-            key={message.id}
-          >
-            <ToastMessageItem
-              message={message}
-              onDismiss={(id: string) => toastMessenger.dismiss(id)}
-            />
-          </li>
-        ))}
-      </ul>
-    </div>
+    <DependencyLessToastMessages
+      messages={messages}
+      onMessageDismiss={(id: string) => toastMessenger.dismiss(id)}
+    />
   );
 }
 

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -225,4 +225,9 @@ export type SidebarToHostEvent =
    * The sidebar is asking the host to do a partner site sign-up.
    * https://h.readthedocs.io/projects/client/en/latest/publishers/config/#cmdoption-arg-onsignuprequest
    */
-  | 'signupRequested';
+  | 'signupRequested'
+
+  /**
+   * The sidebar is asking the host to toast a message
+   */
+  | 'toastMessagePushed';


### PR DESCRIPTION
> This PR is just a rough draft to discuss intent and direction. Many changes are still required before it is ready to merge.

This relates to https://github.com/hypothesis/product-backlog/issues/1426, extending the `ToastMessengerService` so that it can forward non-visible messages to the host frame, via `FrameSyncService`, making sure they are "pushed" to an `aria-live` region which is "visible" even when the sidebar is collapsed.

Delayed messages would never be affected by this, because they are only pushed when their parent frame (the sidebar) is focused.

There are a couple of secondary changes here that are not related with the main PR. The intention is to extract them once the discussion around this feature is ready, but they are here for now for the sake of testing. They have their own inline comment on this PR for clarity.