### PR TITLE
Toast messages forwarding

### DIFF
--- a/src/annotator/sidebar.ts
+++ b/src/annotator/sidebar.ts
@@ -602,6 +602,7 @@ export class Sidebar implements Destroyable {
     }
 
     this._updateLayoutState(true);
+    this._sidebarRPC.call('sidebarOpened');
   }
 
   close() {
@@ -617,6 +618,7 @@ export class Sidebar implements Destroyable {
     }
 
     this._updateLayoutState(false);
+    this._sidebarRPC.call('sidebarClosed');
   }
 
   /**

--- a/src/annotator/sidebar.ts
+++ b/src/annotator/sidebar.ts
@@ -602,10 +602,11 @@ export class Sidebar implements Destroyable {
     }
 
     this._updateLayoutState(true);
-    this._sidebarRPC.call('sidebarOpened');
   }
 
   close() {
+    this._sidebarRPC.call('sidebarClosed');
+
     if (this.iframeContainer) {
       this.iframeContainer.style.marginLeft = '';
       this.iframeContainer.classList.add('sidebar-collapsed');
@@ -618,7 +619,6 @@ export class Sidebar implements Destroyable {
     }
 
     this._updateLayoutState(false);
-    this._sidebarRPC.call('sidebarClosed');
   }
 
   /**

--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -159,7 +159,7 @@ export class FrameSyncService {
    */
   private _scheduleAnchorStatusUpdate: DebouncedFunction<[]>;
 
-  /** Tells if the sidebar is currently open or closed */
+  /** Indicates if the sidebar is currently open or closed */
   private _sidebarIsOpen: boolean;
 
   // Test seam
@@ -198,7 +198,7 @@ export class FrameSyncService {
       this._pendingAnchorStatusUpdates.clear();
     }, 10);
 
-    this._sidebarIsOpen = true;
+    this._sidebarIsOpen = false;
 
     this._setupSyncToGuests();
     this._setupHostEvents();
@@ -532,10 +532,12 @@ export class FrameSyncService {
   }
 
   private _setupToastMessengerEvents() {
-    this._toastMessenger.on('toastMessagePushed', (message: ToastMessage) => {
-      // Forward hidden messages to "host" when sidebar is collapsed
+    this._toastMessenger.on('toastMessageAdded', (message: ToastMessage) => {
+      // Forward hidden messages to "host" when sidebar is collapsed, with the
+      // intention that another container can be used to render those messages
+      // there, ensuring screen readers announce them.
       if (message.visuallyHidden && !this._sidebarIsOpen) {
-        this.notifyHost('toastMessagePushed', message);
+        this.notifyHost('toastMessageAdded', message);
       }
     });
     this._toastMessenger.on('toastMessageDismissed', (messageId: string) => {

--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -538,6 +538,9 @@ export class FrameSyncService {
         this.notifyHost('toastMessagePushed', message);
       }
     });
+    this._toastMessenger.on('toastMessageDismissed', (messageId: string) => {
+      this.notifyHost('toastMessageDismissed', messageId);
+    });
   }
 
   /**

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -55,6 +55,7 @@ describe('FrameSyncService', () => {
   let FakePortRPC;
 
   let fakeAnnotationsService;
+  let fakeToastMessenger;
   let fakePortRPCs;
   let fakePortFinder;
 
@@ -70,6 +71,7 @@ describe('FrameSyncService', () => {
 
   beforeEach(() => {
     fakeAnnotationsService = { create: sinon.stub() };
+    fakeToastMessenger = new EventEmitter();
     fakePortRPCs = [];
     setupPortRPC = null;
 
@@ -173,6 +175,7 @@ describe('FrameSyncService', () => {
       .register('$window', { value: fakeWindow })
       .register('annotationsService', { value: fakeAnnotationsService })
       .register('store', { value: fakeStore })
+      .register('toastMessenger', { value: fakeToastMessenger })
       .register('frameSync', FrameSyncService)
       .get('frameSync');
   });

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -1126,4 +1126,32 @@ describe('FrameSyncService', () => {
       assert.calledWith(guestRPC().call, 'showContentInfo', contentInfo);
     });
   });
+
+  context('when a toast message is pushed', () => {
+    it('forwards the message to the host if it is hidden and the sidebar is collapsed', () => {
+      const message = { visuallyHidden: true };
+
+      emitHostEvent('sidebarClosed');
+      fakeToastMessenger.emit('toastMessagePushed', message);
+
+      assert.calledWith(hostRPC().call, 'toastMessagePushed', message);
+    });
+
+    it('ignores the message if it is not hidden', () => {
+      const message = { visuallyHidden: false };
+
+      emitHostEvent('sidebarClosed');
+      fakeToastMessenger.emit('toastMessagePushed', message);
+
+      assert.neverCalledWith(hostRPC().call, 'toastMessagePushed', message);
+    });
+
+    it('ignores the message if the sidebar is not collapsed', () => {
+      const message = { visuallyHidden: true };
+
+      fakeToastMessenger.emit('toastMessagePushed', message);
+
+      assert.neverCalledWith(hostRPC().call, 'toastMessagePushed', message);
+    });
+  });
 });

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -1127,31 +1127,31 @@ describe('FrameSyncService', () => {
     });
   });
 
-  context('when a toast message is pushed', () => {
+  context('when a toast message is added', () => {
     it('forwards the message to the host if it is hidden and the sidebar is collapsed', () => {
       const message = { visuallyHidden: true };
 
       emitHostEvent('sidebarClosed');
-      fakeToastMessenger.emit('toastMessagePushed', message);
+      fakeToastMessenger.emit('toastMessageAdded', message);
 
-      assert.calledWith(hostRPC().call, 'toastMessagePushed', message);
+      assert.calledWith(hostRPC().call, 'toastMessageAdded', message);
     });
 
     it('ignores the message if it is not hidden', () => {
       const message = { visuallyHidden: false };
 
-      emitHostEvent('sidebarClosed');
-      fakeToastMessenger.emit('toastMessagePushed', message);
+      fakeToastMessenger.emit('toastMessageAdded', message);
 
-      assert.neverCalledWith(hostRPC().call, 'toastMessagePushed', message);
+      assert.neverCalledWith(hostRPC().call, 'toastMessageAdded', message);
     });
 
     it('ignores the message if the sidebar is not collapsed', () => {
       const message = { visuallyHidden: true };
 
-      fakeToastMessenger.emit('toastMessagePushed', message);
+      emitHostEvent('sidebarOpened');
+      fakeToastMessenger.emit('toastMessageAdded', message);
 
-      assert.neverCalledWith(hostRPC().call, 'toastMessagePushed', message);
+      assert.neverCalledWith(hostRPC().call, 'toastMessageAdded', message);
     });
   });
 

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -1154,4 +1154,14 @@ describe('FrameSyncService', () => {
       assert.neverCalledWith(hostRPC().call, 'toastMessagePushed', message);
     });
   });
+
+  context('when a toast message is dismissed', () => {
+    it('forwards the message ID to the host', () => {
+      const messageId = 'someId';
+
+      fakeToastMessenger.emit('toastMessageDismissed', messageId);
+
+      assert.calledWith(hostRPC().call, 'toastMessageDismissed', messageId);
+    });
+  });
 });

--- a/src/sidebar/services/test/toast-messenger-test.js
+++ b/src/sidebar/services/test/toast-messenger-test.js
@@ -84,6 +84,20 @@ describe('ToastMessengerService', () => {
       assert.calledOnce(fakeStore.getToastMessage);
       assert.notCalled(fakeStore.updateToastMessage);
     });
+
+    it('emits "toastMessageAdded" event', () => {
+      fakeStore.hasToastMessage.returns(false);
+
+      const fakeHandler = sinon.stub();
+      service.on('toastMessageAdded', fakeHandler);
+
+      service.success('hooray', {});
+
+      assert.calledWith(
+        fakeHandler,
+        sinon.match({ message: 'hooray', type: 'success' })
+      );
+    });
   });
 
   describe('#notice', () => {
@@ -202,6 +216,21 @@ describe('ToastMessengerService', () => {
 
       assert.calledOnce(fakeStore.removeToastMessage);
       assert.calledWith(fakeStore.removeToastMessage, 'someid');
+    });
+
+    it('emits "toastMessageDismissed" event', () => {
+      fakeStore.getToastMessage.returns({
+        id: 'someid',
+        type: 'success',
+        message: 'yay',
+        isDismissed: false,
+      });
+
+      const fakeHandler = sinon.stub();
+      service.on('toastMessageDismissed', fakeHandler);
+
+      service.dismiss('someid');
+      assert.calledWith(fakeHandler, 'someid');
     });
   });
 

--- a/src/sidebar/services/toast-messenger.ts
+++ b/src/sidebar/services/toast-messenger.ts
@@ -1,3 +1,5 @@
+import { TinyEmitter } from 'tiny-emitter';
+
 import { generateHexString } from '../../shared/random';
 import type { SidebarStore } from '../store';
 
@@ -44,7 +46,7 @@ type MessageData = {
  * messages may be manually dismissed with the `#dismiss()` method.
  */
 // @inject
-export class ToastMessengerService {
+export class ToastMessengerService extends TinyEmitter {
   private _store: SidebarStore;
   private _window: Window;
 
@@ -55,6 +57,8 @@ export class ToastMessengerService {
   private _delayedMessageQueue: MessageData[];
 
   constructor(store: SidebarStore, $window: Window) {
+    super();
+
     this._store = store;
     this._window = $window;
     this._delayedMessageQueue = [];
@@ -127,6 +131,7 @@ export class ToastMessengerService {
       isDismissed: false,
       ...message,
     });
+    this.emit('toastMessagePushed', message);
 
     if (autoDismiss) {
       // Attempt to dismiss message after a set time period. NB: The message may

--- a/src/sidebar/services/toast-messenger.ts
+++ b/src/sidebar/services/toast-messenger.ts
@@ -83,6 +83,7 @@ export class ToastMessengerService extends TinyEmitter {
     const message = this._store.getToastMessage(messageId);
     if (message && !message.isDismissed) {
       this._store.updateToastMessage({ ...message, isDismissed: true });
+      this.emit('toastMessageDismissed', messageId);
       setTimeout(() => {
         this._store.removeToastMessage(messageId);
       }, MESSAGE_DISMISS_DELAY);

--- a/src/sidebar/services/toast-messenger.ts
+++ b/src/sidebar/services/toast-messenger.ts
@@ -132,7 +132,7 @@ export class ToastMessengerService extends TinyEmitter {
       isDismissed: false,
       ...message,
     });
-    this.emit('toastMessagePushed', message);
+    this.emit('toastMessageAdded', message);
 
     if (autoDismiss) {
       // Attempt to dismiss message after a set time period. NB: The message may

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -235,7 +235,7 @@ export type SidebarToHostEvent =
   /**
    * The sidebar is asking the host to toast a message
    */
-  | 'toastMessagePushed'
+  | 'toastMessageAdded'
 
   /**
    * The sidebar is asking the host to dismiss a toast message

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -235,4 +235,9 @@ export type SidebarToHostEvent =
   /**
    * The sidebar is asking the host to toast a message
    */
-  | 'toastMessagePushed';
+  | 'toastMessagePushed'
+
+  /**
+   * The sidebar is asking the host to dismiss a toast message
+   */
+  | 'toastMessageDismissed';

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -111,7 +111,12 @@ export type HostToSidebarEvent =
   /**
    * The host informs the sidebar that the sidebar has been opened.
    */
-  | 'sidebarOpened';
+  | 'sidebarOpened'
+
+  /**
+   * The host informs the sidebar that the sidebar has been closed.
+   */
+  | 'sidebarClosed';
 
 /**
  * Events that the sidebar sends to the guest(s)
@@ -225,4 +230,9 @@ export type SidebarToHostEvent =
    * The sidebar is asking the host to do a partner site sign-up.
    * https://h.readthedocs.io/projects/client/en/latest/publishers/config/#cmdoption-arg-onsignuprequest
    */
-  | 'signupRequested';
+  | 'signupRequested'
+
+  /**
+   * The sidebar is asking the host to toast a message
+   */
+  | 'toastMessagePushed';


### PR DESCRIPTION
This PR does a number of changes in preparation to be able to "render" toast messages in an `aria-live` region in the host frame, that can be used by screen readers while the sidebar is collapsed.

This PR does not cover the actual rendering yet, just the logic to handle the communication between frames.

* The `ToastMessengerService` becomes an event emitter, and emits a new event every time a new message is toasted, or a message is dismissed, no matter the message.
* The `FrameSyncService` now depends on the `ToastMessengerService`, in order to listen for the new events mentioned above.
* When a message is emitted, it checks if it's a hidden message, and the sidebar is collapsed, and only in that case it forwards the message to the host frame.
* When a dismiss is emitted, it always forwards the message to the host frame, to let it react accordingly.
* The host frame does not yet handle the new RPC messages. This will come on a follow-up PR.
* In order to determine if the sidebar is collapsed from within the sidebar itself (which runs on an iframe), I have used the already existing `sidebarOpened` frame event, and created a new `sidebarClosed` companion one. Both are called by the `Sidebar` class from the host frame.

The last point is a bit controversial, but I couldn't find a better way to determine if the sidebar is collapsed or not.

I considered doing a simple DOM check, since the `FrameSyncService` already depends on the `window`, but the only "thing" useful to tell if it's collapsed, is the `.sidebar-collapsed` class, which lives outside of the iframe, and therefore, cannot be queried from within it.

I also tried checking the dimensions of the sidebar in order to know if it's outside of the viewport, but when consulting these form within the iframe it also does not return trustworthy results.