### PR TITLE
Make sure sidebar is set to `display: none` when hidden

### DIFF
--- a/src/annotator/sidebar.tsx
+++ b/src/annotator/sidebar.tsx
@@ -657,13 +657,13 @@ export class Sidebar implements Destroyable {
    * Shows the sidebar's controls
    */
   show() {
-    this.iframeContainer?.classList.remove('is-hidden');
+    this.iframeContainer?.classList.remove('hidden');
   }
 
   /**
    * Hides the sidebar's controls
    */
   hide() {
-    this.iframeContainer?.classList.add('is-hidden');
+    this.iframeContainer?.classList.add('hidden');
   }
 }

--- a/src/styles/annotator/components/sidebar.scss
+++ b/src/styles/annotator/components/sidebar.scss
@@ -36,10 +36,6 @@
     // Wider screens: apply transition when opening/closing of the sidebar
     @apply annotator-lg:sidebar-transition-margin;
 
-    &.is-hidden {
-      @apply sidebar-transition-visibility;
-    }
-
     // We can't use `theme-clean:` or `sidebar-collapsed:` tailwind modifiers
     // here because this is the one place in the project where the relevant
     // classes are assigned to the same element, not a parent element.


### PR DESCRIPTION
This PR replaces the usage of our custom `is-hidden` class in the sidebar, which effectively sets the element to `visibility: hidden`, with tailwind's `hidden` class, which sets it to `display: none`.

Thanks to this, when the sidebar is hidden, screen readers do not announce toast messages happening there, which can lead to duplicated announcements when other apps are open as modals, like the notebook.

Visually, there should be no differences (I was not able to tell, at least).

### Testing steps:

1. Check out this branch.
2. Open the notebook.
3. Run a screen reader.
4. From another device, create a new annotation.
5. The screen reader should announce that there are new annotations available, but only once.