### PR TITLE
Sidebar decouple tests

### DIFF
--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -2,7 +2,7 @@ import { TinyEmitter } from 'tiny-emitter';
 
 import { addConfigFragment } from '../../shared/config-fragment';
 import { Sidebar, MIN_RESIZE, $imports } from '../sidebar';
-import { Emitter, EventBus } from '../util/emitter';
+import { Emitter } from '../util/emitter';
 
 const DEFAULT_WIDTH = 350;
 const DEFAULT_HEIGHT = 600;
@@ -367,9 +367,8 @@ describe('Sidebar', () => {
       it('hides the sidebar', () => {
         const sidebar = createSidebar();
         sinon.stub(sidebar, 'hide').callThrough();
-        sinon.stub(sidebar._emitter, 'publish');
         emitSidebarEvent('openNotebook', 'mygroup');
-        assert.calledWith(sidebar._emitter.publish, 'openNotebook', 'mygroup');
+
         assert.calledOnce(sidebar.hide);
         assert.notEqual(sidebar.iframeContainer.style.visibility, 'hidden');
       });
@@ -379,7 +378,7 @@ describe('Sidebar', () => {
       it('shows the sidebar', () => {
         const sidebar = createSidebar();
         sinon.stub(sidebar, 'show').callThrough();
-        sidebar._emitter.publish('closeNotebook');
+        fakeEmitter.publish('closeNotebook');
         assert.calledOnce(sidebar.show);
         assert.equal(sidebar.iframeContainer.style.visibility, '');
       });
@@ -389,9 +388,8 @@ describe('Sidebar', () => {
       it('hides the sidebar', () => {
         const sidebar = createSidebar();
         sinon.stub(sidebar, 'hide').callThrough();
-        sinon.stub(sidebar._emitter, 'publish');
         emitSidebarEvent('openProfile');
-        assert.calledWith(sidebar._emitter.publish, 'openProfile');
+
         assert.calledOnce(sidebar.hide);
         assert.notEqual(sidebar.iframeContainer.style.visibility, 'hidden');
       });
@@ -401,7 +399,7 @@ describe('Sidebar', () => {
       it('shows the sidebar', () => {
         const sidebar = createSidebar();
         sinon.stub(sidebar, 'show').callThrough();
-        sidebar._emitter.publish('closeProfile');
+        fakeEmitter.publish('closeProfile');
         assert.calledOnce(sidebar.show);
         assert.equal(sidebar.iframeContainer.style.visibility, '');
       });
@@ -409,23 +407,25 @@ describe('Sidebar', () => {
 
     describe('on "toastMessageAdded" event', () => {
       it('re-publishes event via emitter', () => {
-        const sidebar = createSidebar();
-        sinon.stub(sidebar._emitter, 'publish');
+        createSidebar();
+
+        const eventHandler = sinon.stub();
+        fakeEmitter.subscribe('toastMessageAdded', eventHandler);
         emitSidebarEvent('toastMessageAdded', {});
-        assert.calledWith(sidebar._emitter.publish, 'toastMessageAdded', {});
+
+        assert.calledWith(eventHandler, {});
       });
     });
 
     describe('on "toastMessageDismissed" event', () => {
       it('re-publishes event via emitter', () => {
-        const sidebar = createSidebar();
-        sinon.stub(sidebar._emitter, 'publish');
+        createSidebar();
+
+        const eventHandler = sinon.stub();
+        fakeEmitter.subscribe('toastMessageDismissed', eventHandler);
         emitSidebarEvent('toastMessageDismissed', 'someId');
-        assert.calledWith(
-          sidebar._emitter.publish,
-          'toastMessageDismissed',
-          'someId'
-        );
+
+        assert.calledWith(eventHandler, 'someId');
       });
     });
 

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -366,10 +366,8 @@ describe('Sidebar', () => {
     describe('on "openNotebook" event', () => {
       it('hides the sidebar', () => {
         const sidebar = createSidebar();
-        sinon.stub(sidebar, 'hide').callThrough();
         emitSidebarEvent('openNotebook', 'mygroup');
 
-        assert.calledOnce(sidebar.hide);
         assert.notEqual(sidebar.iframeContainer.style.visibility, 'hidden');
       });
     });
@@ -377,9 +375,8 @@ describe('Sidebar', () => {
     describe('on "closeNotebook" internal event', () => {
       it('shows the sidebar', () => {
         const sidebar = createSidebar();
-        sinon.stub(sidebar, 'show').callThrough();
+
         fakeEmitter.publish('closeNotebook');
-        assert.calledOnce(sidebar.show);
         assert.equal(sidebar.iframeContainer.style.visibility, '');
       });
     });
@@ -387,10 +384,8 @@ describe('Sidebar', () => {
     describe('on "openProfile" event', () => {
       it('hides the sidebar', () => {
         const sidebar = createSidebar();
-        sinon.stub(sidebar, 'hide').callThrough();
         emitSidebarEvent('openProfile');
 
-        assert.calledOnce(sidebar.hide);
         assert.notEqual(sidebar.iframeContainer.style.visibility, 'hidden');
       });
     });
@@ -398,9 +393,8 @@ describe('Sidebar', () => {
     describe('on "closeProfile" internal event', () => {
       it('shows the sidebar', () => {
         const sidebar = createSidebar();
-        sinon.stub(sidebar, 'show').callThrough();
+
         fakeEmitter.publish('closeProfile');
-        assert.calledOnce(sidebar.show);
         assert.equal(sidebar.iframeContainer.style.visibility, '');
       });
     });

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -366,8 +366,12 @@ describe('Sidebar', () => {
     describe('on "openNotebook" event', () => {
       it('hides the sidebar', () => {
         const sidebar = createSidebar();
+
+        const eventHandler = sinon.stub();
+        fakeEmitter.subscribe('openNotebook', eventHandler);
         emitSidebarEvent('openNotebook', 'mygroup');
 
+        assert.calledWith(eventHandler, 'mygroup');
         assert.notEqual(sidebar.iframeContainer.style.visibility, 'hidden');
       });
     });
@@ -384,8 +388,12 @@ describe('Sidebar', () => {
     describe('on "openProfile" event', () => {
       it('hides the sidebar', () => {
         const sidebar = createSidebar();
+
+        const eventHandler = sinon.stub();
+        fakeEmitter.subscribe('openProfile', eventHandler);
         emitSidebarEvent('openProfile');
 
+        assert.calledOnce(eventHandler);
         assert.notEqual(sidebar.iframeContainer.style.visibility, 'hidden');
       });
     });

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -1,6 +1,8 @@
+import { TinyEmitter } from 'tiny-emitter';
+
 import { addConfigFragment } from '../../shared/config-fragment';
 import { Sidebar, MIN_RESIZE, $imports } from '../sidebar';
-import { EventBus } from '../util/emitter';
+import { Emitter, EventBus } from '../util/emitter';
 
 const DEFAULT_WIDTH = 350;
 const DEFAULT_HEIGHT = 600;
@@ -25,6 +27,7 @@ describe('Sidebar', () => {
   let FakeToolbarController;
   let fakeToolbar;
   let fakeSendErrorsTo;
+  let fakeEmitter;
 
   before(() => {
     sinon.stub(window, 'requestAnimationFrame').yields();
@@ -97,7 +100,7 @@ describe('Sidebar', () => {
     document.body.appendChild(container);
     containers.push(container);
 
-    const eventBus = new EventBus();
+    const eventBus = { createEmitter: () => fakeEmitter };
     const sidebar = new Sidebar(container, eventBus, config);
     sidebars.push(sidebar);
 
@@ -149,6 +152,8 @@ describe('Sidebar', () => {
     FakeToolbarController = sinon.stub().returns(fakeToolbar);
 
     fakeSendErrorsTo = sinon.stub();
+
+    fakeEmitter = new Emitter(new TinyEmitter());
 
     const fakeCreateAppConfig = sinon.spy((appURL, config) => {
       const appConfig = { ...config };


### PR DESCRIPTION
This PR refactors a bit the sidebar test, so that it relies less on internal implementation details.

The changes are primarily related with the part testing forwarding of events `RPC -> emitter` and `emitter -> RPC`.

* The tests no longer try to directly access the internal `_emitter` prop, which is private, and was just incidentally working because the tests are not written in TypeScript yet. Instead, a mock is injected, and any assertion is run against the mock directly.
* Some tests where mocking some of the sidebar public methods (`open` and `close`). Now, instead of that, we just assert on the result of calling those methods.