### PR TITLE
Annotator module ts migration

### DIFF
--- a/src/annotator/bucket-bar-client.ts
+++ b/src/annotator/bucket-bar-client.ts
@@ -10,7 +10,12 @@ import { computeAnchorPositions } from './util/buckets';
 type HostRPC = PortRPC<HostToGuestEvent, GuestToHostEvent>;
 
 export type BucketBarClientOptions = {
+  /**
+   * The scrollable container element for the document content. All the highlights
+   * that the bucket bar's buckets point at should be contained within this element.
+   */
   contentContainer: Element;
+
   hostRPC: HostRPC;
 };
 

--- a/src/annotator/bucket-bar.tsx
+++ b/src/annotator/bucket-bar.tsx
@@ -1,34 +1,35 @@
 import { render } from 'preact';
 
+import type { AnchorPosition, Destroyable } from '../types/annotator';
 import Buckets from './components/Buckets';
 import { computeBuckets } from './util/buckets';
 
-/**
- * @typedef {import('../types/annotator').AnchorPosition} AnchorPosition
- * @typedef {import('../types/annotator').Destroyable} Destroyable
- */
+export type BucketBarOptions = {
+  onFocusAnnotations: (tags: string[]) => void;
+  onScrollToClosestOffScreenAnchor: (
+    tags: string[],
+    direction: 'down' | 'up'
+  ) => void;
+  onSelectAnnotations: (tags: string[], toggle: boolean) => void;
+};
 
 /**
  * Controller for the "bucket bar" shown alongside the sidebar indicating where
  * annotations are in the document.
- *
- * @implements {Destroyable}
  */
-export class BucketBar {
-  /**
-   * @param {HTMLElement} container
-   * @param {object} options
-   *   @param {(tags: string[]) => void} options.onFocusAnnotations
-   *   @param {(tags: string[], direction: 'down'|'up') => void} options.onScrollToClosestOffScreenAnchor
-   *   @param {(tags: string[], toggle: boolean) => void} options.onSelectAnnotations
-   */
+export class BucketBar implements Destroyable {
+  private _bucketsContainer: HTMLDivElement;
+  private _onFocusAnnotations: BucketBarOptions['onFocusAnnotations'];
+  private _onScrollToClosestOffScreenAnchor: BucketBarOptions['onScrollToClosestOffScreenAnchor'];
+  private _onSelectAnnotations: BucketBarOptions['onSelectAnnotations'];
+
   constructor(
-    container,
+    container: HTMLElement,
     {
       onFocusAnnotations,
       onScrollToClosestOffScreenAnchor,
       onSelectAnnotations,
-    }
+    }: BucketBarOptions
   ) {
     this._bucketsContainer = document.createElement('div');
     container.appendChild(this._bucketsContainer);
@@ -46,10 +47,7 @@ export class BucketBar {
     this._bucketsContainer.remove();
   }
 
-  /**
-   * @param {AnchorPosition[]} positions
-   */
-  update(positions) {
+  update(positions: AnchorPosition[]) {
     const buckets = computeBuckets(positions);
     render(
       <Buckets

--- a/src/annotator/features.ts
+++ b/src/annotator/features.ts
@@ -1,48 +1,38 @@
 import { TinyEmitter } from 'tiny-emitter';
 
 import { warnOnce } from '../shared/warn-once';
-
-/**
- * @typedef {import('../types/annotator').FeatureFlags} IFeatureFlags
- */
+import type { FeatureFlags as IFeatureFlags } from '../types/annotator';
 
 /**
  * List of feature flags that annotator code tests for.
- *
- * @type {string[]}
  */
 const annotatorFlags = ['html_side_by_side', 'styled_highlight_clusters'];
 
 /**
  * An observable container of feature flags.
- *
- * @implements {IFeatureFlags}
  */
-export class FeatureFlags extends TinyEmitter {
+export class FeatureFlags extends TinyEmitter implements IFeatureFlags {
+  /** Map of flag name to enabled state. */
+  private _flags: Map<string, boolean>;
+  private _knownFlags: string[];
+
   /**
-   * @param {string[]} knownFlags - Test seam. This is a list of known flags
-   *   used to catch mistakes where code checks for an obsolete feature flag.
+   * @param knownFlags - Test seam. This is a list of known flags used to catch
+   *        mistakes where code checks for an obsolete feature flag.
    */
-  constructor(knownFlags = annotatorFlags) {
+  constructor(knownFlags: string[] = annotatorFlags) {
     super();
 
-    /**
-     * Map of flag name to enabled state.
-     *
-     * @type {Map<string, boolean>}
-     */
-    this._flags = new Map();
+    this._flags = new Map<string, boolean>();
     this._knownFlags = knownFlags;
   }
 
   /**
    * Update the stored flags and notify observers via a "flagsChanged" event.
-   *
-   * @param {Record<string, boolean>} flags
    */
-  update(flags) {
+  update(flags: Record<string, boolean>) {
     this._flags.clear();
-    for (let [flag, on] of Object.entries(flags)) {
+    for (const [flag, on] of Object.entries(flags)) {
       this._flags.set(flag, on);
     }
     this.emit('flagsChanged');
@@ -54,11 +44,8 @@ export class FeatureFlags extends TinyEmitter {
    * This will return false if the feature flags have not yet been received from
    * the backend. Code that uses a feature flag should handle subsequent changes
    * to the flag's state by listening for the "flagsChanged" event.
-   *
-   * @param {string} flag
-   * @return {boolean}
    */
-  flagEnabled(flag) {
+  flagEnabled(flag: string): boolean {
     if (!this._knownFlags.includes(flag)) {
       warnOnce('Looked up unknown feature', flag);
       return false;
@@ -72,7 +59,7 @@ export class FeatureFlags extends TinyEmitter {
    * To test whether an individual flag is enabled, use {@link flagEnabled}
    * instead.
    */
-  allFlags() {
+  allFlags(): Record<string, boolean> {
     return Object.fromEntries(this._flags);
   }
 }

--- a/src/annotator/selection-observer.ts
+++ b/src/annotator/selection-observer.ts
@@ -1,12 +1,9 @@
 import { ListenerCollection } from '../shared/listener-collection';
 
 /**
- * Return the current selection or `null` if there is no selection or it is empty.
- *
- * @param {Document} document
- * @return {Range|null}
+ * Return the current selection or `null` if there is no selection, or it is empty.
  */
-export function selectedRange(document) {
+export function selectedRange(document: Document): Range | null {
   const selection = document.getSelection();
   if (!selection || selection.rangeCount === 0) {
     return null;
@@ -22,15 +19,21 @@ export function selectedRange(document) {
  * An observer that watches for and buffers changes to the document's current selection.
  */
 export class SelectionObserver {
+  private _pendingCallback: number | null;
+  private _document: Document;
+  private _listeners: ListenerCollection;
+
   /**
    * Start observing changes to the current selection in the document.
    *
-   * @param {(range: Range|null) => void} callback -
-   *   Callback invoked with the selected region of the document when it has
-   *   changed.
-   * @param {Document} document_ - Test seam
+   * @param callback - Callback invoked with the selected region of the document
+   *                   when it has changed.
+   * @param document_ - Test seam
    */
-  constructor(callback, document_ = document) {
+  constructor(
+    callback: (range: Range | null) => void,
+    document_: Document = document
+  ) {
     let isMouseDown = false;
 
     this._pendingCallback = null;
@@ -41,8 +44,7 @@ export class SelectionObserver {
       }, delay);
     };
 
-    /** @param {Event} event */
-    const eventHandler = event => {
+    const eventHandler = (event: Event) => {
       if (event.type === 'mousedown') {
         isMouseDown = true;
       }
@@ -93,7 +95,7 @@ export class SelectionObserver {
     this._cancelPendingCallback();
   }
 
-  _cancelPendingCallback() {
+  private _cancelPendingCallback() {
     if (this._pendingCallback) {
       clearTimeout(this._pendingCallback);
       this._pendingCallback = null;

--- a/src/annotator/selection-observer.ts
+++ b/src/annotator/selection-observer.ts
@@ -19,6 +19,7 @@ export function selectedRange(document: Document): Range | null {
  * An observer that watches for and buffers changes to the document's current selection.
  */
 export class SelectionObserver {
+  /** Tracks the timeout ID of the last scheduled callback */
   private _pendingCallback: number | null;
   private _document: Document;
   private _listeners: ListenerCollection;

--- a/src/annotator/sidebar-trigger.ts
+++ b/src/annotator/sidebar-trigger.ts
@@ -4,10 +4,10 @@ const SIDEBAR_TRIGGER_BTN_ATTR = 'data-hypothesis-trigger';
  * Show the sidebar when user clicks on an element with the
  * trigger data attribute.
  *
- * @param {Element} rootEl - The DOM element which contains the trigger elements.
- * @param {() => void} showFn - Function which shows the sidebar.
+ * @param rootEl - The DOM element which contains the trigger elements.
+ * @param showFn - Function which shows the sidebar.
  */
-export function sidebarTrigger(rootEl, showFn) {
+export function sidebarTrigger(rootEl: Element, showFn: () => void) {
   const triggerElems = rootEl.querySelectorAll(
     '[' + SIDEBAR_TRIGGER_BTN_ATTR + ']'
   );


### PR DESCRIPTION
This PR migrates a bunch of files from the annotator module to TypeScript.

A few were left out to make reviews easier. Continues on https://github.com/hypothesis/client/pull/5357