### PR TITLE
Stream: make sure we fall back to empty string when query is not present

### DIFF
--- a/src/sidebar/components/StreamView.tsx
+++ b/src/sidebar/components/StreamView.tsx
@@ -53,7 +53,7 @@ function StreamView({ api, toastMessenger }: StreamViewProps) {
     // Sort the stream so that the newest annotations are at the top
     store.setSortKey('Newest');
     store.clearAnnotations();
-    loadAnnotations(currentQuery).catch(err => {
+    loadAnnotations(currentQuery ?? '').catch(err => {
       toastMessenger.error(`Unable to fetch annotations: ${err.message}`);
     });
   }, [currentQuery, loadAnnotations, store, toastMessenger]);

--- a/src/sidebar/components/test/StreamView-test.js
+++ b/src/sidebar/components/test/StreamView-test.js
@@ -97,6 +97,9 @@ describe('StreamView', () => {
       'reply_2',
       'reply_3',
     ]);
+
+    // Assert that we use an empty string as query, when the `q` param is not set
+    assert.calledWith(fakeSearchFilter.toObject, '');
   });
 
   it('displays an error if fetching annotations fails', async () => {


### PR DESCRIPTION
This fixes the stream when a search query has not been provided, by falling back to empty string.

### Testing steps:

* Run local `h` and `client` instances, both on `main` branch.
* Visit http://localhost:5000/stream.
  * You will see an error for a moment.
  * The loading will never finish and no annotations will be displayed.
* Switch to this branch on `client`.
* Visit http://localhost:5000/stream again. In this case the annotations should be properly loaded.

