### PR TITLE
Treat route query params as optional

### DIFF
--- a/src/sidebar/components/AnnotationView.tsx
+++ b/src/sidebar/components/AnnotationView.tsx
@@ -22,7 +22,7 @@ function AnnotationView({
   onLogin,
 }: AnnotationViewProps) {
   const store = useSidebarStore();
-  const annotationId = store.routeParams().id;
+  const annotationId = store.routeParams().id ?? '';
   const rootThread = useRootThread();
   const userid = store.profile().userid;
 

--- a/src/sidebar/components/StreamSearchInput.tsx
+++ b/src/sidebar/components/StreamSearchInput.tsx
@@ -14,7 +14,7 @@ export type StreamSearchInputProps = {
  */
 function StreamSearchInput({ router }: StreamSearchInputProps) {
   const store = useSidebarStore();
-  const query = store.routeParams().q;
+  const { q } = store.routeParams();
   const setQuery = (query: string) => {
     // Re-route the user to `/stream` if they are on `/a/:id` and then set
     // the search query.
@@ -22,7 +22,7 @@ function StreamSearchInput({ router }: StreamSearchInputProps) {
   };
 
   return (
-    <SearchInput query={query} onSearch={setQuery} alwaysExpanded={true} />
+    <SearchInput query={q ?? ''} onSearch={setQuery} alwaysExpanded={true} />
   );
 }
 

--- a/src/sidebar/store/modules/route.js
+++ b/src/sidebar/store/modules/route.js
@@ -19,7 +19,7 @@ const initialState = {
    * - The "stream" route has a "q" (query) parameter.
    * - The "sidebar" route has no parameters.
    *
-   * @type {Record<string, string>}
+   * @type {Record<string, string | undefined>}
    */
   params: {},
 };


### PR DESCRIPTION
The route params were set as `Record<string, string>`, which means TS will infer type `string` for any property we try to read from them.

However, if that property does not exist we can end up with a runtime error when taking for granted a string that ends up being `undefined`.

This PR changes the type to `Record<string, string | undefined>`, which is closer to reality and forces us to be more defensive about the properties we try to read from there.