### PR TITLE
Make sure help panel is focused when open, and focus is restored when closed

### DIFF
--- a/src/sidebar/components/SidebarPanel.tsx
+++ b/src/sidebar/components/SidebarPanel.tsx
@@ -1,4 +1,4 @@
-import { Panel } from '@hypothesis/frontend-shared/lib/next';
+import { Dialog } from '@hypothesis/frontend-shared/lib/next';
 import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useRef } from 'preact/hooks';
@@ -6,7 +6,6 @@ import scrollIntoView from 'scroll-into-view';
 
 import type { PanelName } from '../../types/sidebar';
 import { useSidebarStore } from '../store';
-import Slider from './Slider';
 
 export type SidebarPanelProps = {
   children: ComponentChildren;
@@ -47,9 +46,7 @@ export default function SidebarPanel({
       if (panelIsActive && panelElement.current) {
         scrollIntoView(panelElement.current);
       }
-      if (typeof onActiveChanged === 'function') {
-        onActiveChanged(panelIsActive);
-      }
+      onActiveChanged?.(panelIsActive);
     }
   }, [panelIsActive, onActiveChanged]);
 
@@ -58,12 +55,19 @@ export default function SidebarPanel({
   }, [store, panelName]);
 
   return (
-    <Slider visible={panelIsActive}>
-      <div ref={panelElement} className="mb-4">
-        <Panel title={title} icon={icon} onClose={closePanel}>
+    <>
+      {panelIsActive && (
+        <Dialog
+          restoreFocus
+          ref={panelElement}
+          classes="mb-4"
+          title={title}
+          icon={icon}
+          onClose={closePanel}
+        >
           {children}
-        </Panel>
-      </div>
-    </Slider>
+        </Dialog>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
> This PR requires https://github.com/hypothesis/frontend-shared/pull/941

This PR leverages the new `Dialog` component capabilities to be focused when opened, and restore focus when closed, to enhance the help panel.

There's one limitation though. The help panel is currently wrapped in a `Slider`, which adds a nice slide-down/slide-up animation when opened/closed.

This makes the `initialFocus="auto"` in the `Dialog` to not work as expected.

As a POC I have removed the slider, just to verify that we can fix the accessibility issue with the new `Dialog`. However, if we want to keep the animation, the `Dialog` needs to be evolved.

You can see the new behavior here.

https://user-images.githubusercontent.com/2719332/229075333-0efb6632-9f24-4288-a37b-d0dae162fc73.mp4

