### PR TITLE
Update actions/github-script to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Update extension
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.cross_repo_workflow_trigger_token }}
         script: |


### PR DESCRIPTION
This PR Updates `actions/github-script`  to v6, solving a deprecation warning.