### PR TITLE
Extract helper function to determine current script origin

### DIFF
--- a/src/shared/current-script-origin.ts
+++ b/src/shared/current-script-origin.ts
@@ -1,0 +1,11 @@
+export function currentScriptOrigin(): string | null {
+  // It might be possible to simplify this as `url` appears to be required
+  // according to the HTML spec.
+  //
+  // See https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties.
+  const { url } = import.meta;
+  if (!url) {
+    return null;
+  }
+  return new URL(url).origin;
+}

--- a/src/sidebar/util/sentry.js
+++ b/src/sidebar/util/sentry.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 import { parseConfigFragment } from '../../shared/config-fragment';
+import { currentScriptOrigin } from '../../shared/current-script-origin';
 import { handleErrorsInFrames } from '../../shared/frame-error-capture';
 import { warnOnce } from '../../shared/warn-once';
 
@@ -15,18 +16,6 @@ const maxEventsToSendPerSession = 5;
 
 /** @type {(() => void)|null} */
 let removeFrameErrorHandler = null;
-
-function currentScriptOrigin() {
-  // It might be possible to simplify this as `url` appears to be required
-  // according to the HTML spec.
-  //
-  // See https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties.
-  let url = import.meta.url;
-  if (!url) {
-    return null;
-  }
-  return new URL(url).origin;
-}
 
 /**
  * Initialize the Sentry integration.


### PR DESCRIPTION
This PR extracts a local helper function to its own module so that it can be used somewhere else.

I intend to use this function in the boot script, in order to determine if it was loaded from the browser extension and have dynamic logic based on that. I have tested it works for that purpose, by copy-pasting it first.

I have also considered using this in `src/boot/url-template.js`, where there's a similar function, but I need to test that further as it's not exactly the same logic.