### PR TITLE
Make sure sidebar panels are focused when open, and focus is restored when closed

### DIFF
--- a/src/sidebar/components/SidebarPanel.tsx
+++ b/src/sidebar/components/SidebarPanel.tsx
@@ -1,4 +1,4 @@
-import { Panel } from '@hypothesis/frontend-shared/lib/next';
+import { Dialog } from '@hypothesis/frontend-shared/lib/next';
 import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useRef } from 'preact/hooks';
@@ -47,9 +47,7 @@ export default function SidebarPanel({
       if (panelIsActive && panelElement.current) {
         scrollIntoView(panelElement.current);
       }
-      if (typeof onActiveChanged === 'function') {
-        onActiveChanged(panelIsActive);
-      }
+      onActiveChanged?.(panelIsActive);
     }
   }, [panelIsActive, onActiveChanged]);
 
@@ -58,12 +56,20 @@ export default function SidebarPanel({
   }, [store, panelName]);
 
   return (
-    <Slider visible={panelIsActive}>
-      <div ref={panelElement} className="mb-4">
-        <Panel title={title} icon={icon} onClose={closePanel}>
+    <>
+      {panelIsActive && (
+        <Dialog
+          restoreFocus
+          ref={panelElement}
+          classes="mb-4"
+          title={title}
+          icon={icon}
+          onClose={closePanel}
+          transitionComponent={Slider}
+        >
           {children}
-        </Panel>
-      </div>
-    </Slider>
+        </Dialog>
+      )}
+    </>
   );
 }

--- a/src/sidebar/components/Slider.tsx
+++ b/src/sidebar/components/Slider.tsx
@@ -7,6 +7,9 @@ export type SliderProps = {
 
   /** Whether the content should be visible or not. */
   visible: boolean;
+
+  /** Invoked once the open/close transitions have finished */
+  onTransitionEnd?: (direction: 'in' | 'out') => void;
 };
 
 /**
@@ -17,9 +20,13 @@ export type SliderProps = {
  * DOM using `display: none` so it does not appear in the keyboard navigation
  * order.
  *
- * Currently the only reveal/expand direction supported is top-down.
+ * Currently, the only reveal/expand direction supported is top-down.
  */
-export default function Slider({ children, visible }: SliderProps) {
+export default function Slider({
+  children,
+  visible,
+  onTransitionEnd,
+}: SliderProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [containerHeight, setContainerHeight] = useState(visible ? 'auto' : 0);
 
@@ -68,13 +75,15 @@ export default function Slider({ children, visible }: SliderProps) {
   const handleTransitionEnd = useCallback(() => {
     if (visible) {
       setContainerHeight('auto');
+      onTransitionEnd?.('in');
     } else {
       // When the collapse animation completes, stop rendering the content so
       // that the browser has fewer nodes to render and the content is removed
       // from keyboard navigation.
       setContentVisible(false);
+      onTransitionEnd?.('out');
     }
-  }, [setContainerHeight, visible]);
+  }, [setContainerHeight, visible, onTransitionEnd]);
 
   const isFullyVisible = containerHeight === 'auto';
 

--- a/src/sidebar/components/test/SidebarPanel-test.js
+++ b/src/sidebar/components/test/SidebarPanel-test.js
@@ -15,7 +15,7 @@ describe('SidebarPanel', () => {
     fakeScrollIntoView = sinon.stub();
 
     fakeStore = {
-      isSidebarPanelOpen: sinon.stub().returns(false),
+      isSidebarPanelOpen: sinon.stub().returns(true),
       toggleSidebarPanel: sinon.stub(),
     };
 
@@ -36,16 +36,16 @@ describe('SidebarPanel', () => {
       icon: 'restricted',
     });
 
-    const panel = wrapper.find('Panel');
+    const dialog = wrapper.find('Dialog');
 
-    assert.equal(panel.props().icon, 'restricted');
-    assert.equal(panel.props().title, 'My Panel');
+    assert.equal(dialog.props().icon, 'restricted');
+    assert.equal(dialog.props().title, 'My Panel');
   });
 
   it('provides an `onClose` handler that closes the panel', () => {
     const wrapper = createSidebarPanel({ panelName: 'flibberty' });
 
-    wrapper.find('Panel').props().onClose();
+    wrapper.find('Dialog').props().onClose();
 
     assert.calledWith(fakeStore.toggleSidebarPanel, 'flibberty', false);
   });
@@ -59,7 +59,7 @@ describe('SidebarPanel', () => {
   it('hides content if not active', () => {
     fakeStore.isSidebarPanelOpen.returns(false);
     const wrapper = createSidebarPanel();
-    assert.isFalse(wrapper.find('Slider').prop('visible'));
+    assert.isFalse(wrapper.find('Dialog').exists());
   });
 
   context('when panel state changes', () => {


### PR DESCRIPTION
> This PR requires https://github.com/hypothesis/frontend-shared/pull/957
> It is also a continuation of https://github.com/hypothesis/client/pull/5361, where some of the improvements suggested there have been applied.

This PR makes use of the new `Dialog` focusing capabilities, to make sure the sidebar panels are focused when opened, and the focus is restored once closed.

It's done in a way that the `Slider` transitions are kept, so it has no visual changes.

https://user-images.githubusercontent.com/2719332/231728608-73e66618-1c33-4415-ac66-734095278845.mp4

This PR also fixes https://github.com/hypothesis/product-backlog/issues/1421

### TODO

- [x] Fix tests

### Testing steps

1. ~First make sure your local `frontend-shared` is up to date. Then build it with `make build`, and "publish" it with `npx yalc publish`.~ Not needed anymore.
2. Clone this branch on your local `client` ~, and run `npx yalc add @hypothesis/frontend-shared` to install the version you published in previous step.~
3. Use the keyboard to open sidebar panels ("share annotations" or "help" ones can be used for testing).
4. Check the focus behaves as expected, focusing the panel after the open transition has finished, and recovering focus to the button when close transition ends.