### PR TITLE
Enforce non-empty configuration when boot script is run from the browser extension

### DIFF
--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -21,6 +21,18 @@ if (isBrowserSupported()) {
   const config = /** @type {AnnotatorConfig|SidebarAppConfig} */ (
     parseJsonConfig(document)
   );
+
+  // When the boot script is executed from the browser extension, at least one
+  // config is required
+  const isExtensionContext = !!(
+    /** @type {any} */ (window).chrome?.runtime?.id
+  );
+  if (!Object.keys(config).length && isExtensionContext) {
+    throw new Error(
+      'Could not start Hypothesis extension as configuration is missing'
+    );
+  }
+
   const assetRoot = processUrlTemplate(config.assetRoot || '__ASSET_ROOT__');
 
   // Check whether this is the sidebar app (indicated by the presence of a


### PR DESCRIPTION
This is an attempt to work around what's described in https://github.com/hypothesis/browser-extension/issues/1179

This would cover only the usage of the browser extension in webs. For PDFs, a similar check needs to be done in the pdfjs-init, where we can directly prevent the loading of the boot script if there's no config.

Considerations on this PR / topics to discuss.

* I have decided to throw an error when the browser extension executes the boot script and no config is found. Another option would be to silently early-exit.
* The logic to determine if the script was run by the browser extension couple a bit the client with the chrome extension. Not sure if there's a better way to do this though.
* I haven't covered this with tests, as we don't seem to have a test for the index file. Perhaps we could extract the content of index to a function that can be tested and also imported from the index, leaving the index to a simple import-and-run-function script.

### Testing steps

1. Checkout this branch
2. Build and publish: `make build && npx yalc publish`.
3. On your local browser-extension repo, install the client you just published: `npx yalc add hypothesis`.
4. Fake the config not being loaded, by commenting out `injectConfig` from the `injectIntoHTML` function:
    ```diff
    /**
     * @param {Tab} tab
     * @param {object} config
     */
    async function injectIntoHTML(tab, config) {
    - await injectConfig(tab.id, config);
    + // await injectConfig(tab.id, config);
      return executeClientBootScript(tab.id);
    }
    ``` 
5. Build the dev extension `make build SETTINGS_FILE=settings/<custom.json>`
6. Load your local extension in the browser.
7. Try to activate the extension on a page. It should not load the sidebar, and you should see the error in the browser console.