### PR TITLE
Use `ModalDialog` for modal prompts

### DIFF
--- a/src/shared/prompts.tsx
+++ b/src/shared/prompts.tsx
@@ -1,5 +1,7 @@
-import { Button, Modal } from '@hypothesis/frontend-shared/lib/next';
+import { Button, ModalDialog } from '@hypothesis/frontend-shared/lib/next';
 import { render } from 'preact';
+import { createRef } from 'preact';
+import type { RefObject } from 'preact';
 import type { ComponentChildren } from 'preact';
 
 export type ConfirmModalProps = {
@@ -25,6 +27,7 @@ export async function confirm({
   message,
   confirmAction = 'Yes',
 }: ConfirmModalProps): Promise<boolean> {
+  const cancelButton = createRef<HTMLElement | undefined>();
   const container = document.createElement('div');
   container.setAttribute('data-testid', 'confirm-container');
 
@@ -43,10 +46,14 @@ export async function confirm({
     };
 
     render(
-      <Modal
+      <ModalDialog
         buttons={
           <>
-            <Button data-testid="cancel-button" onClick={() => close(false)}>
+            <Button
+              elementRef={cancelButton}
+              data-testid="cancel-button"
+              onClick={() => close(false)}
+            >
               Cancel
             </Button>
             <Button
@@ -58,11 +65,12 @@ export async function confirm({
             </Button>
           </>
         }
+        initialFocus={cancelButton as RefObject<HTMLElement>}
         title={title}
         onClose={() => close(false)}
       >
         {message}
-      </Modal>,
+      </ModalDialog>,
       container
     );
   });


### PR DESCRIPTION
Replace deprecated `Modal` with `ModalDialog` for accessibility improvements.

Part of https://github.com/hypothesis/product-backlog/issues/1424

This PR updates the component used for modal "prompts" in the client. These are used:

* To confirm annotation deletion
* To confirm leaving a group
* To confirm logging out when there are unsaved drafts

<img width="466" alt="image" src="https://user-images.githubusercontent.com/439947/232493905-c3f8224f-5d34-431e-a8b5-30d9e55ec45f.png">

After these changes the modal looks the same, but has a number of accessibility improvements for keyboard navigation and for users of assistive technology:

* Focus is now trapped and tab-sequence only includes navigable items (in this case, the close, Cancel, and confirm buttons). It is no longer possible to tab or shift-tab out of the modal and inadvertently dismiss it.
* Clicking outside of the modal no longer dismisses it.
* Focus is restored after the modal is closed, whether by ESC, close button or action button[^1]
* Initial focus is now set on the "Cancel" button instead of the modal itself

_Note_: I did not update tests because the changed functionality is part of `ModalDialog` itself.

### Testing

Run this branch and click the "Delete" button in any annotation's footer actions. You should see that:

* The modal opens with initial focus on "Cancel"
* Tabbing or shift-tabbing cycles through the navigable elements in the modal
* Pressing ESC, close or Cancel returns focus to the "Delete" icon
* Clicking outside of the modal does not close it

[^1]: In most cases. In cases where the confirm action leads to a deletion of the entity from which the modal was opened, there's no obvious element to return focus to. We might be able to improve on this in the future.