### PR TITLE
Util ts migration

### DIFF
--- a/src/annotator/util/buckets.ts
+++ b/src/annotator/util/buckets.ts
@@ -43,7 +43,7 @@ export type WorkingBucket = {
   top: number;
 
   /**
-   * he bottommost (highest) vertical offset for the anchors in this bucket —
+   * The bottommost (highest) vertical offset for the anchors in this bucket —
    * the highest `top` position value, akin to the bottom of a theoretical box
    * drawn around all the anchor highlights in this bucket
    */

--- a/src/annotator/util/emitter.ts
+++ b/src/annotator/util/emitter.ts
@@ -1,54 +1,48 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
+/*
+ * Disable @typescript-eslint/ban-types for the whole file, as changing the
+ * event's callback type away from `Function` has multiple implications that
+ * should be addressed separately
+ */
 import { TinyEmitter } from 'tiny-emitter';
 
-/** @typedef {import('../../types/annotator').Destroyable} Destroyable */
+import type { Destroyable } from '../../types/annotator';
 
 /**
  * Emitter is a communication class that implements the publisher/subscriber
  * pattern. It allows sending and listening events through a shared EventBus.
  * The different elements of the application can communicate with each other
  * without being tightly coupled.
- *
- * @implements {Destroyable}
  */
-export class Emitter {
-  /**
-   * @param {TinyEmitter} emitter
-   */
-  constructor(emitter) {
-    this._emitter = emitter;
+export class Emitter implements Destroyable {
+  private _emitter: TinyEmitter;
+  private _subscriptions: [event: string, callback: Function][];
 
-    /** @type {[event: string, callback: Function][]} */
+  constructor(emitter: TinyEmitter) {
+    this._emitter = emitter;
     this._subscriptions = [];
   }
 
   /**
    * Fire an event.
-   *
-   * @param {string} event
-   * @param {unknown[]} args
    */
-  publish(event, ...args) {
+  publish(event: string, ...args: unknown[]) {
     this._emitter.emit(event, ...args);
   }
 
   /**
    * Register an event listener.
-   *
-   * @param {string} event
-   * @param {Function} callback
    */
-  subscribe(event, callback) {
+  subscribe(event: string, callback: Function) {
     this._emitter.on(event, callback);
     this._subscriptions.push([event, callback]);
   }
 
   /**
    * Remove an event listener.
-   *
-   * @param {string} event
-   * @param {Function} callback
    */
-  unsubscribe(event, callback) {
+  unsubscribe(event: string, callback: Function) {
     this._emitter.off(event, callback);
     this._subscriptions = this._subscriptions.filter(
       ([subEvent, subCallback]) =>
@@ -60,7 +54,7 @@ export class Emitter {
    * Remove all event listeners.
    */
   destroy() {
-    for (let [event, callback] of this._subscriptions) {
+    for (const [event, callback] of this._subscriptions) {
       this._emitter.off(event, callback);
     }
     this._subscriptions = [];
@@ -68,6 +62,8 @@ export class Emitter {
 }
 
 export class EventBus {
+  private _emitter: TinyEmitter;
+
   constructor() {
     this._emitter = new TinyEmitter();
   }

--- a/src/annotator/util/frame.ts
+++ b/src/annotator/util/frame.ts
@@ -1,10 +1,7 @@
 /**
  * Test whether an iframe fills the viewport of an ancestor frame.
- *
- * @param {Window} frame
- * @param {Window} ancestor
  */
-export function frameFillsAncestor(frame, ancestor) {
+export function frameFillsAncestor(frame: Window, ancestor: Window): boolean {
   if (frame === ancestor) {
     return true;
   }

--- a/src/annotator/util/normalize.ts
+++ b/src/annotator/util/normalize.ts
@@ -1,13 +1,13 @@
 /**
  * Find the smallest offset in `str` which contains at least `count` chars
  * that match `filter` before it.
- *
- * @param {string} str
- * @param {number} count
- * @param {(char: string) => boolean} filter
- * @param {number} [startPos]
  */
-function advance(str, count, filter, startPos = 0) {
+function advance(
+  str: string,
+  count: number,
+  filter: (char: string) => boolean,
+  startPos = 0
+): number {
   let pos = startPos;
   while (pos < str.length && count > 0) {
     if (filter(str[pos])) {
@@ -20,13 +20,13 @@ function advance(str, count, filter, startPos = 0) {
 
 /**
  * Count characters which match `filter` in `str`.
- *
- * @param {string} str
- * @param {(char: string) => boolean} filter
- * @param {number} startPos
- * @param {number} endPos
  */
-function countChars(str, filter, startPos, endPos) {
+function countChars(
+  str: string,
+  filter: (char: string) => boolean,
+  startPos: number,
+  endPos: number
+): number {
   let count = 0;
   for (let pos = startPos; pos < endPos; pos++) {
     if (filter(str[pos])) {
@@ -58,20 +58,23 @@ function countChars(str, filter, startPos, endPos) {
  *   // The returned offsets select the substring "b c" in the "output" argument.
  *   translateOffsets('abcd', ' a b c d ', 1, 3, char => char !== ' ')
  *
- * @param {string} input
- * @param {string} output
- * @param {number} start - Start offset in `input`
- * @param {number} end - End offset in `input`
- * @param {(ch: string) => boolean} filter - Filter function that returns true
- *   if a character should be counted when relating positions between `input`
- *   and `output`.
- * @return {[number, number]} - Start and end offsets in `output`
+ * @param start - Start offset in `input`
+ * @param end - End offset in `input`
+ * @param filter - Filter function that returns true if a character should be
+ *   counted when relating positions between `input` and `output`.
+ * @return Start and end offsets in `output`
  */
-export function translateOffsets(input, output, start, end, filter) {
+export function translateOffsets(
+  input: string,
+  output: string,
+  start: number,
+  end: number,
+  filter: (ch: string) => boolean
+): [number, number] {
   const beforeStartCount = countChars(input, filter, 0, start);
   const startToEndCount = countChars(input, filter, start, end);
 
-  // Find smallest offset in `output` with same number of non-ignored characters
+  // Find the smallest offset in `output` with same number of non-ignored characters
   // before it as before `start` in the input. This offset might correspond to
   // an ignored character.
   let outputStart = advance(output, beforeStartCount, filter);

--- a/src/annotator/util/scroll.ts
+++ b/src/annotator/util/scroll.ts
@@ -3,7 +3,7 @@ import scrollIntoView from 'scroll-into-view';
 /**
  * Return a promise that resolves on the next animation frame.
  */
-function nextAnimationFrame() {
+function nextAnimationFrame(): Promise<number> {
   return new Promise(resolve => {
     requestAnimationFrame(resolve);
   });
@@ -12,46 +12,44 @@ function nextAnimationFrame() {
 /**
  * Linearly interpolate between two values.
  *
- * @param {number} a
- * @param {number} b
- * @param {number} fraction - Value in [0, 1]
+ * @param fraction - Value in [0, 1]
  */
-function interpolate(a, b, fraction) {
+function interpolate(a: number, b: number, fraction: number): number {
   return a + fraction * (b - a);
 }
 
 /**
  * Return the offset of `element` from the top of a positioned ancestor `parent`.
  *
- * @param {HTMLElement} element
- * @param {HTMLElement} parent - Positioned ancestor of `element`
- * @return {number}
+ * @param parent - Positioned ancestor of `element`
  */
-export function offsetRelativeTo(element, parent) {
+export function offsetRelativeTo(
+  element: HTMLElement,
+  parent: HTMLElement
+): number {
   let offset = 0;
   while (element !== parent && parent.contains(element)) {
     offset += element.offsetTop;
-    element = /** @type {HTMLElement} */ (element.offsetParent);
+    element = element.offsetParent as HTMLElement;
   }
   return offset;
 }
 
+type DurationOptions = { maxDuration?: number };
+
 /**
  * Scroll `element` until its `scrollTop` offset reaches a target value.
  *
- * @param {Element} element - Container element to scroll
- * @param {number} offset - Target value for the scroll offset
- * @param {object} options
- *   @param {number} [options.maxDuration]
- * @return {Promise<void>} - A promise that resolves once the scroll animation
- *   is complete
+ * @param element - Container element to scroll
+ * @param offset - Target value for the scroll offset
+ * @return A promise that resolves once the scroll animation is complete
  */
 export async function scrollElement(
-  element,
-  offset,
+  element: Element,
+  offset: number,
   /* istanbul ignore next - defaults are overridden in tests */
-  { maxDuration = 500 } = {}
-) {
+  { maxDuration = 500 }: DurationOptions = {}
+): Promise<void> {
   const startOffset = element.scrollTop;
   const endOffset = offset;
   const scrollStart = Date.now();
@@ -74,16 +72,12 @@ export async function scrollElement(
 
 /**
  * Smoothly scroll an element into view.
- *
- * @param {HTMLElement} element
- * @param {object} options
- *   @param {number} [options.maxDuration]
  */
 export async function scrollElementIntoView(
-  element,
+  element: HTMLElement,
   /* istanbul ignore next - defaults are overridden in tests */
-  { maxDuration = 500 } = {}
-) {
+  { maxDuration = 500 }: DurationOptions = {}
+): Promise<void> {
   // Make the body's `tagName` return an upper-case string in XHTML documents
   // like it does in HTML documents. This is a workaround for
   // `scrollIntoView`'s detection of the <body> element. See

--- a/src/annotator/util/scroll.ts
+++ b/src/annotator/util/scroll.ts
@@ -35,7 +35,7 @@ export function offsetRelativeTo(
   return offset;
 }
 
-type DurationOptions = { maxDuration?: number };
+export type DurationOptions = { maxDuration?: number };
 
 /**
  * Scroll `element` until its `scrollTop` offset reaches a target value.

--- a/src/annotator/util/shadow-root.ts
+++ b/src/annotator/util/shadow-root.ts
@@ -1,14 +1,12 @@
 /**
  * Load stylesheets for annotator UI components into the shadow DOM root.
- *
- * @param {ShadowRoot} shadowRoot
  */
-function loadStyles(shadowRoot) {
+function loadStyles(shadowRoot: ShadowRoot) {
   // Find the preloaded stylesheet added by the boot script.
-  const url = /** @type {HTMLLinkElement|undefined} */ (
+  const url = (
     document.querySelector(
       'link[rel="preload"][href*="/build/styles/annotator.css"]'
-    )
+    ) as HTMLLinkElement | undefined
   )?.href;
 
   if (!url) {
@@ -25,10 +23,9 @@ function loadStyles(shadowRoot) {
  * Create the shadow root for an annotator UI component and load the annotator
  * CSS styles into it.
  *
- * @param {HTMLElement} container - Container element to render the UI into
- * @return {ShadowRoot}
+ * @param container - Container element to render the UI into
  */
-export function createShadowRoot(container) {
+export function createShadowRoot(container: HTMLElement): ShadowRoot {
   const shadowRoot = container.attachShadow({ mode: 'open' });
   loadStyles(shadowRoot);
 
@@ -53,10 +50,8 @@ export function createShadowRoot(container) {
  * Another benefit is that click and touchstart typically causes the sidebar to close.
  * By preventing the bubble up of these events, we don't have to individually stop
  * the propagation.
- *
- * @param {HTMLElement|ShadowRoot} element
  */
-function stopEventPropagation(element) {
+function stopEventPropagation(element: HTMLElement | ShadowRoot) {
   element.addEventListener('mouseup', event => event.stopPropagation());
   element.addEventListener('mousedown', event => event.stopPropagation());
   element.addEventListener('touchstart', event => event.stopPropagation(), {

--- a/src/annotator/util/url.ts
+++ b/src/annotator/util/url.ts
@@ -3,11 +3,13 @@
  *
  * This makes it absolute and strips the fragment identifier.
  *
- * @param {string} uri - Relative or absolute URL
- * @param {string} [base] - Base URL to resolve relative to. Defaults to
- *   the document's base URL.
+ * @param uri - Relative or absolute URL
+ * @param base - Base URL to resolve relative to. Defaults to the document's base URL.
  */
-export function normalizeURI(uri, base = document.baseURI) {
+export function normalizeURI(
+  uri: string,
+  base: string = document.baseURI
+): string {
   const absUrl = new URL(uri, base).href;
 
   // Remove the fragment identifier.


### PR DESCRIPTION
This PR migrates to TypeScript all remaining non-ts files from `annotator/util`.