### PR TITLE
Bump `@hypothesis/frontend-shared` to v6.0.0 and update all imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "^1.2.0",
-    "@hypothesis/frontend-shared": "^5.6.0",
+    "@hypothesis/frontend-shared": "^6.0.0",
     "@npmcli/arborist": "^6.1.1",
     "@octokit/rest": "^19.0.3",
     "@rollup/plugin-babel": "^6.0.0",

--- a/src/annotator/components/AdderToolbar.tsx
+++ b/src/annotator/components/AdderToolbar.tsx
@@ -4,7 +4,7 @@ import {
   HighlightIcon,
   PointerDownIcon,
   PointerUpIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
 import classnames from 'classnames';
 

--- a/src/annotator/components/Buckets.tsx
+++ b/src/annotator/components/Buckets.tsx
@@ -1,4 +1,4 @@
-import { PointerButton } from '@hypothesis/frontend-shared/lib/next';
+import { PointerButton } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import type { Bucket } from '../util/buckets';

--- a/src/annotator/components/ClusterToolbar.tsx
+++ b/src/annotator/components/ClusterToolbar.tsx
@@ -6,7 +6,7 @@ import {
   CaretRightIcon,
   HideIcon,
   HighlightIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback, useState } from 'preact/hooks';
 

--- a/src/annotator/components/ContentInfoBanner.tsx
+++ b/src/annotator/components/ContentInfoBanner.tsx
@@ -3,7 +3,7 @@ import {
   LinkBase,
   CaretLeftIcon,
   CaretRightIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import type { ContentInfoConfig } from '../../types/annotator';

--- a/src/annotator/components/NotebookModal.tsx
+++ b/src/annotator/components/NotebookModal.tsx
@@ -1,4 +1,4 @@
-import { IconButton, CancelIcon } from '@hypothesis/frontend-shared/lib/next';
+import { IconButton, CancelIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useEffect, useRef, useState } from 'preact/hooks';
 

--- a/src/annotator/components/ProfileModal.tsx
+++ b/src/annotator/components/ProfileModal.tsx
@@ -1,4 +1,4 @@
-import { CancelIcon, IconButton } from '@hypothesis/frontend-shared/lib/next';
+import { CancelIcon, IconButton } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useEffect, useRef, useState } from 'preact/hooks';
 

--- a/src/annotator/components/Toolbar.tsx
+++ b/src/annotator/components/Toolbar.tsx
@@ -1,4 +1,3 @@
-import type { ButtonCommonProps } from '@hypothesis/frontend-shared/lib/components/input/ButtonBase';
 import {
   ButtonBase,
   AnnotateIcon,
@@ -8,7 +7,8 @@ import {
   HideIcon,
   NoteIcon,
   ShowIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
+import type { ButtonCommonProps } from '@hypothesis/frontend-shared/lib/components/input/ButtonBase';
 import type {
   IconComponent,
   PresentationalProps,

--- a/src/annotator/components/WarningBanner.tsx
+++ b/src/annotator/components/WarningBanner.tsx
@@ -1,4 +1,4 @@
-import { CautionIcon, Link } from '@hypothesis/frontend-shared/lib/next';
+import { CautionIcon, Link } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 /**

--- a/src/shared/components/BaseToastMessages.tsx
+++ b/src/shared/components/BaseToastMessages.tsx
@@ -4,7 +4,7 @@ import {
   CancelIcon,
   CautionIcon,
   CheckIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 export type ToastMessage = {

--- a/src/shared/prompts.tsx
+++ b/src/shared/prompts.tsx
@@ -1,4 +1,4 @@
-import { Button, ModalDialog } from '@hypothesis/frontend-shared/lib/next';
+import { Button, ModalDialog } from '@hypothesis/frontend-shared';
 import { render } from 'preact';
 import { createRef } from 'preact';
 import type { RefObject } from 'preact';

--- a/src/sidebar/components/Annotation/Annotation.tsx
+++ b/src/sidebar/components/Annotation/Annotation.tsx
@@ -1,4 +1,4 @@
-import { CardActions, Spinner } from '@hypothesis/frontend-shared/lib/next';
+import { CardActions, Spinner } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useMemo } from 'preact/hooks';
 

--- a/src/sidebar/components/Annotation/AnnotationActionBar.tsx
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.tsx
@@ -5,7 +5,7 @@ import {
   FlagFilledIcon,
   ReplyIcon,
   TrashIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 
 import { confirm } from '../../../shared/prompts';
 import type { SavedAnnotation } from '../../../types/api';

--- a/src/sidebar/components/Annotation/AnnotationBody.tsx
+++ b/src/sidebar/components/Annotation/AnnotationBody.tsx
@@ -1,8 +1,4 @@
-import {
-  Button,
-  CollapseIcon,
-  ExpandIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+import { Button, CollapseIcon, ExpandIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useMemo, useState } from 'preact/hooks';
 

--- a/src/sidebar/components/Annotation/AnnotationDocumentInfo.tsx
+++ b/src/sidebar/components/Annotation/AnnotationDocumentInfo.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@hypothesis/frontend-shared/lib/next';
+import { Link } from '@hypothesis/frontend-shared';
 
 export type AnnotationDocumentInfoProps = {
   /** The domain associated with the document */

--- a/src/sidebar/components/Annotation/AnnotationHeader.tsx
+++ b/src/sidebar/components/Annotation/AnnotationHeader.tsx
@@ -2,7 +2,7 @@ import {
   LinkButton,
   HighlightIcon,
   LockIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import { useMemo } from 'preact/hooks';
 
 import type { Annotation } from '../../../types/api';

--- a/src/sidebar/components/Annotation/AnnotationLicense.tsx
+++ b/src/sidebar/components/Annotation/AnnotationLicense.tsx
@@ -1,8 +1,4 @@
-import {
-  Link,
-  CcStdIcon,
-  CcZeroIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+import { Link, CcStdIcon, CcZeroIcon } from '@hypothesis/frontend-shared';
 
 /**
  * Render information about CC licensing

--- a/src/sidebar/components/Annotation/AnnotationPublishControl.tsx
+++ b/src/sidebar/components/Annotation/AnnotationPublishControl.tsx
@@ -5,7 +5,7 @@ import {
   GroupsIcon,
   LockIcon,
   MenuExpandIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import type { Group } from '../../../types/api';

--- a/src/sidebar/components/Annotation/AnnotationReplyToggle.tsx
+++ b/src/sidebar/components/Annotation/AnnotationReplyToggle.tsx
@@ -1,4 +1,4 @@
-import { ButtonBase } from '@hypothesis/frontend-shared/lib/next';
+import { ButtonBase } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 export type AnnotationReplyToggleProps = {

--- a/src/sidebar/components/Annotation/AnnotationShareControl.tsx
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.tsx
@@ -6,7 +6,7 @@ import {
   InputGroup,
   CopyIcon,
   ShareIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useEffect, useRef, useState } from 'preact/hooks';
 

--- a/src/sidebar/components/Annotation/AnnotationShareInfo.tsx
+++ b/src/sidebar/components/Annotation/AnnotationShareInfo.tsx
@@ -1,8 +1,4 @@
-import {
-  LinkBase,
-  GlobeIcon,
-  GroupsIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+import { LinkBase, GlobeIcon, GroupsIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import type { Group } from '../../../types/api';

--- a/src/sidebar/components/Annotation/AnnotationTimestamps.tsx
+++ b/src/sidebar/components/Annotation/AnnotationTimestamps.tsx
@@ -1,4 +1,4 @@
-import { LinkBase } from '@hypothesis/frontend-shared/lib/next';
+import { LinkBase } from '@hypothesis/frontend-shared';
 import { useEffect, useMemo, useState } from 'preact/hooks';
 
 import {

--- a/src/sidebar/components/Annotation/AnnotationUser.tsx
+++ b/src/sidebar/components/Annotation/AnnotationUser.tsx
@@ -1,4 +1,4 @@
-import { LinkBase } from '@hypothesis/frontend-shared/lib/next';
+import { LinkBase } from '@hypothesis/frontend-shared';
 
 type AnnotationUserProps = {
   authorLink?: string;

--- a/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
@@ -1,8 +1,4 @@
-import {
-  GlobeIcon,
-  GroupsIcon,
-  LockIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+import { GlobeIcon, GroupsIcon, LockIcon } from '@hypothesis/frontend-shared';
 import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../../test-util/accessibility';

--- a/src/sidebar/components/AutocompleteList.tsx
+++ b/src/sidebar/components/AutocompleteList.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@hypothesis/frontend-shared/lib/next';
+import { Card } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useMemo } from 'preact/hooks';
 

--- a/src/sidebar/components/Excerpt.tsx
+++ b/src/sidebar/components/Excerpt.tsx
@@ -1,4 +1,4 @@
-import { LinkButton } from '@hypothesis/frontend-shared/lib/next';
+import { LinkButton } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useLayoutEffect, useRef, useState } from 'preact/hooks';

--- a/src/sidebar/components/FilterStatus.tsx
+++ b/src/sidebar/components/FilterStatus.tsx
@@ -4,7 +4,7 @@ import {
   Card,
   CardContent,
   Spinner,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useMemo } from 'preact/hooks';
 

--- a/src/sidebar/components/GroupList/GroupList.tsx
+++ b/src/sidebar/components/GroupList/GroupList.tsx
@@ -1,4 +1,4 @@
-import { PlusIcon } from '@hypothesis/frontend-shared/lib/next';
+import { PlusIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useMemo, useState } from 'preact/hooks';
 

--- a/src/sidebar/components/GroupList/GroupListItem.tsx
+++ b/src/sidebar/components/GroupList/GroupListItem.tsx
@@ -1,8 +1,4 @@
-import {
-  CopyIcon,
-  ExternalIcon,
-  LeaveIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+import { CopyIcon, ExternalIcon, LeaveIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import { confirm } from '../../../shared/prompts';

--- a/src/sidebar/components/HelpPanel.tsx
+++ b/src/sidebar/components/HelpPanel.tsx
@@ -1,8 +1,5 @@
-import { Link, LinkButton } from '@hypothesis/frontend-shared/lib/next';
-import {
-  ArrowRightIcon,
-  ExternalIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+import { Link, LinkButton } from '@hypothesis/frontend-shared';
+import { ArrowRightIcon, ExternalIcon } from '@hypothesis/frontend-shared';
 import type { ComponentChildren as Children } from 'preact';
 import { useCallback, useMemo, useState } from 'preact/hooks';
 

--- a/src/sidebar/components/LaunchErrorPanel.tsx
+++ b/src/sidebar/components/LaunchErrorPanel.tsx
@@ -1,4 +1,4 @@
-import { Panel } from '@hypothesis/frontend-shared/lib/next';
+import { Panel } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 export type LaunchErrorPanelProps = {

--- a/src/sidebar/components/LoggedOutMessage.tsx
+++ b/src/sidebar/components/LoggedOutMessage.tsx
@@ -3,7 +3,7 @@ import {
   LinkBase,
   LinkButton,
   LogoIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 
 import { useSidebarStore } from '../store';
 

--- a/src/sidebar/components/LoginPromptPanel.tsx
+++ b/src/sidebar/components/LoginPromptPanel.tsx
@@ -2,7 +2,7 @@ import {
   Button,
   CardActions,
   RestrictedIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 
 import { useSidebarStore } from '../store';
 import SidebarPanel from './SidebarPanel';

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -1,8 +1,4 @@
-import {
-  ButtonBase,
-  IconButton,
-  LinkBase,
-} from '@hypothesis/frontend-shared/lib/next';
+import { ButtonBase, IconButton, LinkBase } from '@hypothesis/frontend-shared';
 import {
   EditorLatexIcon,
   EditorQuoteIcon,
@@ -13,7 +9,7 @@ import {
   LinkIcon,
   ListOrderedIcon,
   ListUnorderedIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
 import classnames from 'classnames';
 import type { Ref, JSX } from 'preact';

--- a/src/sidebar/components/Menu.tsx
+++ b/src/sidebar/components/Menu.tsx
@@ -1,5 +1,5 @@
 import { useElementShouldClose } from '@hypothesis/frontend-shared';
-import { MenuExpandIcon } from '@hypothesis/frontend-shared/lib/next';
+import { MenuExpandIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';

--- a/src/sidebar/components/MenuArrow.tsx
+++ b/src/sidebar/components/MenuArrow.tsx
@@ -1,7 +1,4 @@
-import {
-  PointerDownIcon,
-  PointerUpIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+import { PointerDownIcon, PointerUpIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 type MenuArrowProps = {

--- a/src/sidebar/components/MenuItem.tsx
+++ b/src/sidebar/components/MenuItem.tsx
@@ -1,7 +1,4 @@
-import {
-  CaretUpIcon,
-  MenuExpandIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+import { CaretUpIcon, MenuExpandIcon } from '@hypothesis/frontend-shared';
 import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
 import classnames from 'classnames';
 import type { ComponentChildren, Ref } from 'preact';

--- a/src/sidebar/components/ModerationBanner.tsx
+++ b/src/sidebar/components/ModerationBanner.tsx
@@ -1,8 +1,4 @@
-import {
-  ButtonBase,
-  FlagIcon,
-  HideIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+import { ButtonBase, FlagIcon, HideIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import type { Annotation } from '../../types/api';

--- a/src/sidebar/components/NotebookFilters.tsx
+++ b/src/sidebar/components/NotebookFilters.tsx
@@ -1,4 +1,4 @@
-import { ProfileIcon } from '@hypothesis/frontend-shared/lib/next';
+import { ProfileIcon } from '@hypothesis/frontend-shared';
 
 import { useSidebarStore } from '../store';
 import FilterSelect from './FilterSelect';

--- a/src/sidebar/components/NotebookResultCount.tsx
+++ b/src/sidebar/components/NotebookResultCount.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from '@hypothesis/frontend-shared/lib/next';
+import { Spinner } from '@hypothesis/frontend-shared';
 
 import { countVisible } from '../helpers/thread';
 import { useRootThread } from './hooks/use-root-thread';

--- a/src/sidebar/components/NotebookView.tsx
+++ b/src/sidebar/components/NotebookView.tsx
@@ -1,4 +1,4 @@
-import { Link, Panel } from '@hypothesis/frontend-shared/lib/next';
+import { Link, Panel } from '@hypothesis/frontend-shared';
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import scrollIntoView from 'scroll-into-view';
 

--- a/src/sidebar/components/PaginationNavigation.tsx
+++ b/src/sidebar/components/PaginationNavigation.tsx
@@ -1,9 +1,9 @@
-import type { ButtonCommonProps } from '@hypothesis/frontend-shared/lib/components/input/ButtonBase';
 import {
   ButtonBase,
   ArrowLeftIcon,
   ArrowRightIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
+import type { ButtonCommonProps } from '@hypothesis/frontend-shared/lib/components/input/ButtonBase';
 import type { PresentationalProps } from '@hypothesis/frontend-shared/lib/types';
 import classnames from 'classnames';
 import type { JSX } from 'preact';

--- a/src/sidebar/components/PendingUpdatesButton.tsx
+++ b/src/sidebar/components/PendingUpdatesButton.tsx
@@ -1,4 +1,4 @@
-import { IconButton, RefreshIcon } from '@hypothesis/frontend-shared/lib/next';
+import { IconButton, RefreshIcon } from '@hypothesis/frontend-shared';
 import { useCallback, useEffect } from 'preact/hooks';
 
 import { useShortcut } from '../../shared/shortcut';

--- a/src/sidebar/components/ProfileView.tsx
+++ b/src/sidebar/components/ProfileView.tsx
@@ -5,7 +5,7 @@ import {
   CheckIcon,
   Scroll,
   SpinnerSpokesIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import type { PresentationalProps } from '@hypothesis/frontend-shared/lib/types';
 import classnames from 'classnames';
 import type { ComponentChildren, JSX } from 'preact';

--- a/src/sidebar/components/SearchInput.tsx
+++ b/src/sidebar/components/SearchInput.tsx
@@ -3,7 +3,7 @@ import {
   Input,
   SearchIcon,
   Spinner,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { RefObject } from 'preact';
 import { useCallback, useRef, useState } from 'preact/hooks';

--- a/src/sidebar/components/SelectionTabs.tsx
+++ b/src/sidebar/components/SelectionTabs.tsx
@@ -5,7 +5,7 @@ import {
   CardContent,
   LinkButton,
   PlusIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 

--- a/src/sidebar/components/ShareAnnotationsPanel.tsx
+++ b/src/sidebar/components/ShareAnnotationsPanel.tsx
@@ -5,7 +5,7 @@ import {
   InputGroup,
   LockIcon,
   Spinner,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 
 import { pageSharingLink } from '../helpers/annotation-sharing';
 import { withServices } from '../service-context';

--- a/src/sidebar/components/ShareLinks.tsx
+++ b/src/sidebar/components/ShareLinks.tsx
@@ -3,7 +3,7 @@ import {
   EmailIcon,
   SocialFacebookIcon,
   SocialTwitterIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
 
 type ShareLinkProps = {

--- a/src/sidebar/components/SidebarContentError.tsx
+++ b/src/sidebar/components/SidebarContentError.tsx
@@ -1,8 +1,4 @@
-import {
-  Button,
-  Panel,
-  RestrictedIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+import { Button, Panel, RestrictedIcon } from '@hypothesis/frontend-shared';
 
 import { useSidebarStore } from '../store';
 

--- a/src/sidebar/components/SidebarPanel.tsx
+++ b/src/sidebar/components/SidebarPanel.tsx
@@ -1,4 +1,4 @@
-import { Dialog } from '@hypothesis/frontend-shared/lib/next';
+import { Dialog } from '@hypothesis/frontend-shared';
 import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useRef } from 'preact/hooks';

--- a/src/sidebar/components/SortMenu.tsx
+++ b/src/sidebar/components/SortMenu.tsx
@@ -1,4 +1,4 @@
-import { SortIcon } from '@hypothesis/frontend-shared/lib/next';
+import { SortIcon } from '@hypothesis/frontend-shared';
 
 import { useSidebarStore } from '../store';
 import Menu from './Menu';

--- a/src/sidebar/components/TagEditor.tsx
+++ b/src/sidebar/components/TagEditor.tsx
@@ -1,5 +1,5 @@
 import { useElementShouldClose } from '@hypothesis/frontend-shared';
-import { Input } from '@hypothesis/frontend-shared/lib/next';
+import { Input } from '@hypothesis/frontend-shared';
 import { useRef, useState } from 'preact/hooks';
 
 import { withServices } from '../service-context';

--- a/src/sidebar/components/TagListItem.tsx
+++ b/src/sidebar/components/TagListItem.tsx
@@ -1,4 +1,4 @@
-import { Link, CancelIcon } from '@hypothesis/frontend-shared/lib/next';
+import { Link, CancelIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 export type TagListItemProps = {

--- a/src/sidebar/components/Thread.tsx
+++ b/src/sidebar/components/Thread.tsx
@@ -3,7 +3,7 @@ import {
   ButtonBase,
   CaretRightIcon,
   MenuExpandIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback, useMemo } from 'preact/hooks';
 

--- a/src/sidebar/components/ThreadCard.tsx
+++ b/src/sidebar/components/ThreadCard.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent } from '@hypothesis/frontend-shared/lib/next';
+import { Card, CardContent } from '@hypothesis/frontend-shared';
 import debounce from 'lodash.debounce';
 import { useCallback, useEffect, useMemo, useRef } from 'preact/hooks';
 

--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -3,7 +3,7 @@ import {
   LinkButton,
   HelpIcon,
   ShareIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import type { SidebarSettings } from '../../types/config';

--- a/src/sidebar/components/Tutorial.tsx
+++ b/src/sidebar/components/Tutorial.tsx
@@ -3,7 +3,7 @@ import {
   AnnotateIcon,
   HighlightIcon,
   ReplyIcon,
-} from '@hypothesis/frontend-shared/lib/next';
+} from '@hypothesis/frontend-shared';
 import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
 import classnames from 'classnames';
 

--- a/src/sidebar/components/UserMenu.tsx
+++ b/src/sidebar/components/UserMenu.tsx
@@ -1,4 +1,4 @@
-import { ProfileIcon } from '@hypothesis/frontend-shared/lib/next';
+import { ProfileIcon } from '@hypothesis/frontend-shared';
 import { useState } from 'preact/hooks';
 
 import type { Service, SidebarSettings } from '../../types/config';

--- a/src/sidebar/components/VersionInfo.tsx
+++ b/src/sidebar/components/VersionInfo.tsx
@@ -1,4 +1,4 @@
-import { Button, CopyIcon } from '@hypothesis/frontend-shared/lib/next';
+import { Button, CopyIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 

--- a/src/sidebar/components/test/FilterSelect-test.js
+++ b/src/sidebar/components/test/FilterSelect-test.js
@@ -1,4 +1,4 @@
-import { ProfileIcon } from '@hypothesis/frontend-shared/lib/next';
+import { ProfileIcon } from '@hypothesis/frontend-shared';
 import { mount } from 'enzyme';
 
 import { checkAccessibility } from '../../../test-util/accessibility';

--- a/src/sidebar/components/test/MenuItem-test.js
+++ b/src/sidebar/components/test/MenuItem-test.js
@@ -1,4 +1,4 @@
-import { EditIcon } from '@hypothesis/frontend-shared/lib/next';
+import { EditIcon } from '@hypothesis/frontend-shared';
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 

--- a/src/sidebar/components/test/NotebookFilters-test.js
+++ b/src/sidebar/components/test/NotebookFilters-test.js
@@ -1,4 +1,4 @@
-import { ProfileIcon } from '@hypothesis/frontend-shared/lib/next';
+import { ProfileIcon } from '@hypothesis/frontend-shared';
 import { mount } from 'enzyme';
 
 import { mockImportedComponents } from '../../../test-util/mock-imported-components';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
     fancy-log "^1.3.3"
     glob "^7.2.0"
 
-"@hypothesis/frontend-shared@^5.6.0":
-  version "5.14.0"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-5.14.0.tgz#465729295b29cc537867f12e009f211204e08d93"
-  integrity sha512-IyGQdWYkj+92wZV64OPBSOrRjPvANjpHroz85GjkX8UMuBQG3ngUuFh1k0KQ2sZmUyDbILbD5mNuhc5syrqx0A==
+"@hypothesis/frontend-shared@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-6.0.0.tgz#27ef2944c406145e9ccee2d852ad73c179ff3ea9"
+  integrity sha512-sJIxjBLVq5YGdQIYT1ayV8GQ/NlUxXY5nJMcG45Xxl7hgmrmwL+4G7l9h2gAD2PwXx1Rt9gjbdF9Zmrq6Yp0IQ==
   dependencies:
     highlight.js "^11.6.0"
 


### PR DESCRIPTION
This PR updates to a new major version of `frontend-shared`, and also updates all imports in this app to use `frontend-shared`'s main entrypoint.

Part of https://github.com/hypothesis/frontend-shared/issues/991