### PR TITLE
Remove no longer needed jsdoc type definitions inside TS file

### DIFF
--- a/src/sidebar/components/ThreadCard.tsx
+++ b/src/sidebar/components/ThreadCard.tsx
@@ -9,23 +9,13 @@ import type { FrameSyncService } from '../services/frame-sync';
 import { useSidebarStore } from '../store';
 import Thread from './Thread';
 
-/**
- * @typedef {import('../../types/api').Annotation} Annotation
- * @typedef {import('../../types/config').SidebarSettings} SidebarSettings
- */
-
-/**
- * @typedef ThreadCardProps
- * @prop {import('../helpers/build-thread').Thread} thread
- * @prop {import('../services/frame-sync').FrameSyncService} frameSync
- */
-
 export type ThreadCardProps = {
   thread: IThread;
 
   // injected
   frameSync: FrameSyncService;
 };
+
 /**
  * A "top-level" `Thread`, rendered as a "card" in the sidebar. A `Thread`
  * renders its own child `Thread`s within itself.


### PR DESCRIPTION
I found these jsdoc type definitions that seem to have been forgotten after migrating this file to TypeScript.