### PR TITLE
Add 'context: void(0)' to tests rollup config to fix warning

### DIFF
--- a/rollup-tests.config.mjs
+++ b/rollup-tests.config.mjs
@@ -16,6 +16,11 @@ export default {
     sourcemap: true,
   },
   treeshake: false,
+  // Suppress a warning (https://rollupjs.org/guide/en/#error-this-is-undefined)
+  // due to https://github.com/babel/babel/issues/9149.
+  //
+  // Any code string other than "undefined" which evaluates to `undefined` will work here.
+  context: 'void(0)',
   plugins: [
     // Replace some problematic dependencies which are imported but not actually
     // used with stubs. Per @rollup/plugin-virtual's docs, this must be listed


### PR DESCRIPTION
Relates to https://github.com/hypothesis/lms/pull/5360