### PR TITLE
Update bucket bar when scrollable containers are scrolled

### DIFF
--- a/src/annotator/bucket-bar-client.ts
+++ b/src/annotator/bucket-bar-client.ts
@@ -39,7 +39,14 @@ export class BucketBarClient implements Destroyable {
 
     this._listeners.add(window, 'resize', () => this.update());
     this._listeners.add(window, 'scroll', () => this.update());
-    this._listeners.add(contentContainer, 'scroll', () => this.update());
+
+    // Update bucket positions when container or scrollable descendants are
+    // scrolled.
+    this._listeners.add(contentContainer, 'scroll', () => this.update(), {
+      // "scroll" event does not bubble, so use a capture listener to observe
+      // event in descendants.
+      capture: true,
+    });
   }
 
   destroy() {

--- a/src/annotator/test/bucket-bar-client-test.js
+++ b/src/annotator/test/bucket-bar-client-test.js
@@ -66,6 +66,19 @@ describe('BucketBarClient', () => {
     assert.calledWith(fakeRPC.call, 'anchorsChanged');
   });
 
+  it('should update buckets when descendant of contentContainer element scrolls', async () => {
+    createBucketBarClient();
+
+    const scrollBox = document.createElement('div');
+    contentContainer.append(scrollBox);
+
+    scrollBox.dispatchEvent(new Event('scroll'));
+    await delay(0);
+
+    assert.calledOnce(fakeRPC.call);
+    assert.calledWith(fakeRPC.call, 'anchorsChanged');
+  });
+
   describe('#destroy', () => {
     it('stops listening for events', async () => {
       const bucketBarClient = createBucketBarClient();

--- a/src/shared/listener-collection.ts
+++ b/src/shared/listener-collection.ts
@@ -2,6 +2,7 @@ type Listener = {
   eventTarget: EventTarget;
   eventType: string;
   listener: (event: Event) => void;
+  options?: AddEventListenerOptions;
 };
 
 /**
@@ -49,6 +50,7 @@ export class ListenerCollection {
       eventType,
       // eslint-disable-next-line object-shorthand
       listener: listener as EventListener,
+      options,
     });
     return symbol;
   }
@@ -59,15 +61,15 @@ export class ListenerCollection {
   remove(listenerId: symbol) {
     const event = this._listeners.get(listenerId);
     if (event) {
-      const { eventTarget, eventType, listener } = event;
-      eventTarget.removeEventListener(eventType, listener);
+      const { eventTarget, eventType, listener, options } = event;
+      eventTarget.removeEventListener(eventType, listener, options);
       this._listeners.delete(listenerId);
     }
   }
 
   removeAll() {
-    this._listeners.forEach(({ eventTarget, eventType, listener }) => {
-      eventTarget.removeEventListener(eventType, listener);
+    this._listeners.forEach(({ eventTarget, eventType, listener, options }) => {
+      eventTarget.removeEventListener(eventType, listener, options);
     });
     this._listeners.clear();
   }

--- a/src/shared/test/listener-collection-test.js
+++ b/src/shared/test/listener-collection-test.js
@@ -33,19 +33,40 @@ describe('ListenerCollection', () => {
       assert.calledOnce(listener1);
       assert.notCalled(listener2);
     });
+
+    it('removes listeners with non-default options', () => {
+      const listener = sinon.stub();
+      const listenerId = listeners.add(window, 'resize', listener, {
+        capture: true,
+      });
+
+      window.dispatchEvent(new Event('resize'));
+      assert.calledOnce(listener);
+
+      listeners.remove(listenerId);
+      listener.resetHistory();
+
+      window.dispatchEvent(new Event('resize'));
+      assert.notCalled(listener);
+    });
   });
 
   describe('#removeAll', () => {
     it('unregisters all event listeners', () => {
       const listener1 = sinon.stub();
       const listener2 = sinon.stub();
+      const listener3 = sinon.stub();
+
       listeners.add(window, 'resize', listener1);
       listeners.add(window, 'resize', listener2);
-      listeners.removeAll();
+      listeners.add(window, 'resize', listener3, { capture: true });
 
+      listeners.removeAll();
       window.dispatchEvent(new Event('resize'));
+
       assert.notCalled(listener1);
       assert.notCalled(listener2);
+      assert.notCalled(listener3);
     });
   });
 });


### PR DESCRIPTION
The bucket bar updated the location of buckets when the document or root content
element was scrolled, but not when scrollable descendants (eg.  created by
`overflow: scroll`) were scrolled. This is because we were listening for the
`scroll` event, which does not bubble. Use a capture listener instead.

In the process I found a bug with removing capture listeners in `ListenerCollection`. This is fixed in the first commit.

Fixes #5463

**Testing:**

1. Go to http://localhost:3000/ui-playground/data-scrollbox
2. Activate the client using the local dev bookmarklet [1]
3. Annotate content inside the ScrollBox example near the top of the page.
4. Scroll the scrollbox and verify that the buckets move

[1] This is the prod H bookmarklet modified to use the local client:

```

javascript:(function()%7Bwindow.hypothesisConfig=function()%7Breturn%7BshowHighlights:true,appType:'bookmarklet'%7D;%7D;var%20d=document,s=d.createElement('script');s.setAttribute('src','http://localhost:5000/embed.js');d.body.appendChild(s)%7D)();

```
