### PR TITLE
Fix search icon button in top bar for touch devices

### DIFF
--- a/src/sidebar/components/SearchInput.tsx
+++ b/src/sidebar/components/SearchInput.tsx
@@ -195,6 +195,16 @@ export default function SearchInput({
             onClick={() => input.current?.focus()}
             size="xs"
             title="Search annotations"
+            // The containing form has a white background. The top bar is only
+            // 40px high. If we allow standard touch-minimum height here (44px),
+            // the visible white background exceeds the height of the top bar in
+            // touch contexts. Disable touch sizing, then add back the width
+            // rule to keep horizontal spacing consistent.
+            // FIXME:
+            // Button/IconButton are due a pass for responsive styling and
+            // appropriate styling API controls (@hypothesis/frontend-shared)
+            disableTouchSizing
+            classes="touch:min-w-touch-minimum"
           />
         </div>
       )}


### PR DESCRIPTION
Lee pointed out [this bug in the client today](https://github.com/hypothesis/client/issues/5308), randomly, and I realized I hadn't fixed it!

Ensure height of search icon button doesn't exceed height of top bar. This is necessary because the containing form has a white background. Other icon buttons in the top bar also exceed the height of the bar on touch devices, but this isn't evident because they have transparent backgrounds.

I'm not going to try to sugar coat it: we've got multiple usability issues in the top bar, especially for touch device users. It's been on our back-radar for years to redesign the search interface. This is just a targeted surgical fix for the specific issue noted.

Before:

<img width="481" alt="image" src="https://github.com/hypothesis/client/assets/439947/43427680-5adb-46de-b00e-05f0bca4de41">


After:

<img width="458" alt="image" src="https://github.com/hypothesis/client/assets/439947/5633b83b-3b54-4592-8cf0-ef47c8cebe80">


Fixes https://github.com/hypothesis/client/issues/5308