### PR TITLE
Change in-creation annotation excerpt collapser from div to button

### DIFF
--- a/src/sidebar/components/Excerpt.tsx
+++ b/src/sidebar/components/Excerpt.tsx
@@ -1,4 +1,4 @@
-import { LinkButton } from '@hypothesis/frontend-shared';
+import { ButtonBase, LinkButton } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useLayoutEffect, useRef, useState } from 'preact/hooks';
@@ -27,7 +27,7 @@ function InlineControls({
       className={classnames(
         // Position these controls at the bottom right of the excerpt
         'absolute block right-0 bottom-0',
-        // Give extra width for larger tap target and gradient fade
+        // Give extra width for larger tap target and gradient fade.
         // Fade transparent-to-white left-to-right to make the toggle
         // control text (More/Less) more readable above other text.
         // This gradient is implemented to-left to take advantage of Tailwind's
@@ -161,37 +161,38 @@ function Excerpt({
       : onToggleCollapsed(collapsed);
 
   return (
-    <div
-      data-testid="excerpt-container"
-      className={classnames(
-        'relative overflow-hidden',
-        'transition-[max-height] ease-in duration-150'
-      )}
-      style={contentStyle}
-    >
+    <div className="relative">
       <div
+        data-testid="excerpt-container"
         className={classnames(
-          // Establish new block-formatting context to prevent margin-collapsing
-          // in descendent elements from potentially "leaking out" and pushing
-          // this element down from the top of the container.
-          // See https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
-          // See https://github.com/hypothesis/client/issues/1518
-          'inline-block w-full'
+          'overflow-hidden',
+          'transition-[max-height] ease-in duration-150'
         )}
-        data-testid="excerpt-content"
-        ref={contentElement}
+        style={contentStyle}
       >
-        {children}
+        <div
+          className={classnames(
+            // Establish new block-formatting context to prevent margin-collapsing
+            // in descendent elements from potentially "leaking out" and pushing
+            // this element down from the top of the container.
+            // See https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
+            // See https://github.com/hypothesis/client/issues/1518
+            'inline-block w-full'
+          )}
+          data-testid="excerpt-content"
+          ref={contentElement}
+        >
+          {children}
+        </div>
       </div>
-      <div
+      <ButtonBase
         data-testid="excerpt-expand"
-        role="presentation"
         onClick={() => setCollapsed(false)}
-        className={classnames(
+        classes={classnames(
           // This element provides a clickable area at the bottom of an
           // expandable excerpt to expand it.
           'transition-[opacity] duration-150 ease-linear',
-          'absolute w-full bottom-0 h-touch-minimum',
+          'absolute w-full bottom-0 left-0 h-touch-minimum',
           {
             // For expandable excerpts not using inlineControls, style this
             // element with a custom shadow-like gradient

--- a/src/sidebar/components/test/Excerpt-test.js
+++ b/src/sidebar/components/test/Excerpt-test.js
@@ -110,7 +110,7 @@ describe('Excerpt', () => {
   it('calls `onToggleCollapsed` when user clicks in bottom area to expand excerpt', () => {
     const onToggleCollapsed = sinon.stub();
     const wrapper = createExcerpt({ onToggleCollapsed }, TALL_DIV);
-    const control = wrapper.find('[data-testid="excerpt-expand"]');
+    const control = wrapper.find('button[data-testid="excerpt-expand"]');
     assert.equal(getExcerptHeight(wrapper), 40);
     control.simulate('click');
     assert.called(onToggleCollapsed);


### PR DESCRIPTION
This PR is attempting to fix https://github.com/hypothesis/product-backlog/issues/1425

This changes the element used to display the full text when an annotation is being created, from a `div` to a `ButtonBase` component from `frontend-shared`, which ultimately renders a `button`.

That allows the element to be focusable, and screen readers will announce its `title` when focused (which is `"Show the full excerpt"`), making it more accessible, and matching the fact that it is set as `cursor: pointer`.

When trying to interact with the component using the keyboard, this is now the tab sequence:

https://github.com/hypothesis/client/assets/2719332/dd7f42b8-c236-44f7-9bbb-902d397a553a

Previously, this was it:

https://github.com/hypothesis/client/assets/2719332/3b1641f9-e067-4cd8-b484-1afad6ea9cba

> This PR is easier to review hiding whitespaces.