### PR TITLE
Bump `@hypothesis/frontend-shared` and update uses of `Link`

### DIFF
--- a/src/annotator/components/ContentInfoBanner.tsx
+++ b/src/annotator/components/ContentInfoBanner.tsx
@@ -1,6 +1,5 @@
 import {
   Link,
-  LinkBase,
   CaretLeftIcon,
   CaretRightIcon,
 } from '@hypothesis/frontend-shared';
@@ -37,7 +36,12 @@ export default function ContentInfoBanner({ info }: ContentInfoBannerProps) {
     >
       <div data-testid="content-logo">
         {info.logo && (
-          <Link href={info.logo.link} target="_blank" data-testid="logo-link">
+          <Link
+            href={info.logo.link}
+            target="_blank"
+            data-testid="logo-link"
+            underline="none"
+          >
             <img
               alt={info.logo.title}
               src={info.logo.logo}
@@ -78,15 +82,16 @@ export default function ContentInfoBanner({ info }: ContentInfoBannerProps) {
         {info.links.previousItem && (
           <>
             <Link
-              classes="flex gap-x-1 items-center text-annotator-sm whitespace-nowrap"
               title="Open previous item"
               href={info.links.previousItem}
               underline="always"
               target="_blank"
               data-testid="content-previous-link"
             >
-              <CaretLeftIcon className="w-em h-em" />
-              <span>Previous</span>
+              <div className="flex gap-x-1 items-center text-annotator-sm whitespace-nowrap">
+                <CaretLeftIcon className="w-em h-em" />
+                <span>Previous</span>
+              </div>
             </Link>
             <div className="text-annotator-sm">|</div>
           </>
@@ -99,7 +104,7 @@ export default function ContentInfoBanner({ info }: ContentInfoBannerProps) {
             'min-w-0 whitespace-nowrap overflow-hidden text-ellipsis shrink font-medium'
           )}
         >
-          <LinkBase
+          <Link
             title={itemTitle}
             href={info.links.currentItem}
             data-testid="content-item-link"
@@ -107,7 +112,7 @@ export default function ContentInfoBanner({ info }: ContentInfoBannerProps) {
             unstyled
           >
             {itemTitle}
-          </LinkBase>
+          </Link>
         </div>
 
         {info.links.nextItem && (
@@ -115,14 +120,15 @@ export default function ContentInfoBanner({ info }: ContentInfoBannerProps) {
             <div className="text-annotator-sm">|</div>
             <Link
               title="Open next item"
-              classes="flex gap-x-1 items-center text-annotator-sm whitespace-nowrap"
               href={info.links.nextItem}
               underline="always"
               target="_blank"
               data-testid="content-next-link"
             >
-              <span>Next</span>
-              <CaretRightIcon className="w-em h-em" />
+              <div className="flex gap gap-x-1 items-center text-annotator-sm whitespace-nowrap">
+                <span>Next</span>
+                <CaretRightIcon className="w-em h-em" />
+              </div>
             </Link>
           </>
         )}

--- a/src/annotator/components/test/ContentInfoBanner-test.js
+++ b/src/annotator/components/test/ContentInfoBanner-test.js
@@ -46,7 +46,7 @@ describe('ContentInfoBanner', () => {
   it('shows item title', () => {
     const wrapper = createComponent();
 
-    const link = wrapper.find('LinkBase[data-testid="content-item-link"]');
+    const link = wrapper.find('Link[data-testid="content-item-link"]');
     assert.equal(link.text(), 'Chapter 2: Some book chapter');
     assert.equal(link.prop('target'), '_blank');
   });
@@ -56,7 +56,7 @@ describe('ContentInfoBanner', () => {
 
     const wrapper = createComponent();
 
-    const link = wrapper.find('LinkBase[data-testid="content-item-link"]');
+    const link = wrapper.find('Link[data-testid="content-item-link"]');
     assert.equal(link.text(), 'Chapter 2');
   });
 
@@ -70,7 +70,7 @@ describe('ContentInfoBanner', () => {
       'Expansive Book'
     );
     assert.equal(
-      wrapper.find('LinkBase[data-testid="content-item-link"]').prop('title'),
+      wrapper.find('Link[data-testid="content-item-link"]').prop('title'),
       'Chapter 2: Some book chapter'
     );
   });

--- a/src/shared/components/BaseToastMessages.tsx
+++ b/src/shared/components/BaseToastMessages.tsx
@@ -92,6 +92,7 @@ function ToastMessageItem({ message, onDismiss }: ToastMessageItemProps) {
                   event.stopPropagation() /* consume the event so that it does not dismiss the message */
               }
               target="_new"
+              underline="none"
             >
               More info
             </Link>

--- a/src/sidebar/components/Annotation/AnnotationDocumentInfo.tsx
+++ b/src/sidebar/components/Annotation/AnnotationDocumentInfo.tsx
@@ -23,7 +23,7 @@ export default function AnnotationDocumentInfo({
       <div className="text-color-text-light">
         on &quot;
         {link ? (
-          <Link href={link} target="_blank">
+          <Link href={link} target="_blank" underline="none">
             {title}
           </Link>
         ) : (

--- a/src/sidebar/components/Annotation/AnnotationLicense.tsx
+++ b/src/sidebar/components/Annotation/AnnotationLicense.tsx
@@ -7,16 +7,18 @@ export default function AnnotationLicense() {
   return (
     <div className="pt-2 border-t text-xs leading-none">
       <Link
-        classes="flex items-center"
-        color="text-light"
         href="http://creativecommons.org/publicdomain/zero/1.0/"
         target="_blank"
         title="View more information about the Creative Commons Public Domain dedication"
+        underline="none"
+        variant="text-light"
       >
-        <CcStdIcon className="w-[10px] h-[10px]" />
-        <CcZeroIcon className="w-[10px] h-[10px] ml-px" />
-        <div className="ml-1">
-          Annotations can be freely reused by anyone for any purpose.
+        <div className="flex items-center">
+          <CcStdIcon className="w-[10px] h-[10px]" />
+          <CcZeroIcon className="w-[10px] h-[10px] ml-px" />
+          <div className="ml-1">
+            Annotations can be freely reused by anyone for any purpose.
+          </div>
         </div>
       </Link>
     </div>

--- a/src/sidebar/components/Annotation/AnnotationShareInfo.tsx
+++ b/src/sidebar/components/Annotation/AnnotationShareInfo.tsx
@@ -1,4 +1,4 @@
-import { LinkBase, GlobeIcon, GroupsIcon } from '@hypothesis/frontend-shared';
+import { Link, GlobeIcon, GroupsIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import type { Group } from '../../../types/api';
@@ -23,23 +23,26 @@ function AnnotationShareInfo({ group, isPrivate }: AnnotationShareInfoProps) {
   return (
     <>
       {group && linkToGroup && (
-        <LinkBase
+        <Link
           // The light-text hover color is not a standard color for a Link, so
-          // LinkBase is used here
+          // a custom variant is used
           classes={classnames(
-            'flex items-baseline gap-x-1',
-            'text-color-text-light hover:text-color-text-light hover:underline'
+            'text-color-text-light hover:text-color-text-light'
           )}
           href={group.links.html}
           target="_blank"
+          underline="hover"
+          variant="custom"
         >
-          {group.type === 'open' ? (
-            <GlobeIcon className="w-2.5 h-2.5" />
-          ) : (
-            <GroupsIcon className="w-2.5 h-2.5" />
-          )}
-          <span>{group.name}</span>
-        </LinkBase>
+          <div className="flex items-baseline gap-x-1">
+            {group.type === 'open' ? (
+              <GlobeIcon className="w-2.5 h-2.5" />
+            ) : (
+              <GroupsIcon className="w-2.5 h-2.5" />
+            )}
+            <span>{group.name}</span>
+          </div>
+        </Link>
       )}
       {isPrivate && !linkToGroup && (
         <div className="text-color-text-light" data-testid="private-info">

--- a/src/sidebar/components/Annotation/AnnotationTimestamps.tsx
+++ b/src/sidebar/components/Annotation/AnnotationTimestamps.tsx
@@ -1,4 +1,4 @@
-import { LinkBase } from '@hypothesis/frontend-shared';
+import { Link } from '@hypothesis/frontend-shared';
 import { useEffect, useMemo, useState } from 'preact/hooks';
 
 import {
@@ -88,16 +88,18 @@ export default function AnnotationTimestamps({
         </span>
       )}
       {annotationURL ? (
-        <LinkBase
+        <Link
           // The light-text hover color is not a standard color for a Link, so
           // LinkBase is used here
-          classes="text-color-text-light hover:text-color-text-light hover:underline"
+          classes="text-color-text-light hover:text-color-text-light"
           target="_blank"
           title={created.absolute}
           href={annotationURL}
+          underline="hover"
+          variant="custom"
         >
           {created.relative}
-        </LinkBase>
+        </Link>
       ) : (
         <span
           className="color-text-color-light"

--- a/src/sidebar/components/Annotation/AnnotationUser.tsx
+++ b/src/sidebar/components/Annotation/AnnotationUser.tsx
@@ -1,4 +1,4 @@
-import { LinkBase } from '@hypothesis/frontend-shared';
+import { Link } from '@hypothesis/frontend-shared';
 
 type AnnotationUserProps = {
   authorLink?: string;
@@ -14,9 +14,9 @@ function AnnotationUser({ authorLink, displayName }: AnnotationUserProps) {
 
   if (authorLink) {
     return (
-      <LinkBase href={authorLink} target="_blank">
+      <Link href={authorLink} target="_blank" underline="none" variant="custom">
         {user}
-      </LinkBase>
+      </Link>
     );
   }
 

--- a/src/sidebar/components/HelpPanel.tsx
+++ b/src/sidebar/components/HelpPanel.tsx
@@ -51,7 +51,7 @@ function HelpPanelTab({ linkText, url }: HelpPanelTabProps) {
       // a flex container (centered on both axes)
       className="flex-1 flex items-center justify-center border-r last-of-type:border-r-0 text-md font-medium"
     >
-      <Link color="text-light" href={url} target="_blank">
+      <Link variant="text-light" href={url} target="_blank" underline="none">
         <div className="flex items-center gap-x-2">
           <span>{linkText}</span> <ExternalIcon className="w-3 h-3" />
         </div>

--- a/src/sidebar/components/LoggedOutMessage.tsx
+++ b/src/sidebar/components/LoggedOutMessage.tsx
@@ -1,9 +1,4 @@
-import {
-  Link,
-  LinkBase,
-  LinkButton,
-  LogoIcon,
-} from '@hypothesis/frontend-shared';
+import { Link, LinkButton, LogoIcon } from '@hypothesis/frontend-shared';
 
 import { useSidebarStore } from '../store';
 
@@ -25,7 +20,7 @@ function LoggedOutMessage({ onLogin }: LoggedOutMessageProps) {
         This is a public annotation created with Hypothesis. <br />
         To reply or make your own annotations on this document,{' '}
         <Link
-          color="text"
+          variant="text"
           href={store.getLink('signup')}
           target="_blank"
           underline="always"
@@ -39,14 +34,16 @@ function LoggedOutMessage({ onLogin }: LoggedOutMessageProps) {
         .
       </span>
       <div>
-        <LinkBase
+        <Link
           href="https://hypothes.is"
           aria-label="Hypothesis homepage"
           target="_blank"
           title="Hypothesis homepage"
+          underline="none"
+          variant="custom"
         >
           <LogoIcon className="w-16 h-16 text-grey-7" />
-        </LinkBase>
+        </Link>
       </div>
     </div>
   );

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -1,4 +1,4 @@
-import { ButtonBase, IconButton, LinkBase } from '@hypothesis/frontend-shared';
+import { ButtonBase, IconButton, Link } from '@hypothesis/frontend-shared';
 import {
   EditorLatexIcon,
   EditorQuoteIcon,
@@ -292,20 +292,25 @@ function Toolbar({ isPreviewing, onCommand, onTogglePreview }: ToolbarProps) {
         title="Bulleted list"
       />
       <div className="grow flex justify-end">
-        <LinkBase
-          classes={classnames(
-            'flex justify-center items-center',
-            'text-grey-7 hover:!text-grey-7',
-            'touch:h-touch-minimum touch:w-touch-minimum',
-            'px-2 py-2.5'
-          )}
+        <Link
+          classes="text-grey-7 hover:!text-grey-7"
           href="https://web.hypothes.is/help/formatting-annotations-with-markdown/"
           target="_blank"
           title="Formatting help"
           aria-label="Formatting help"
+          underline="none"
+          variant="custom"
         >
-          <HelpIcon className="w-2.5 h-2.5" />
-        </LinkBase>
+          <div
+            className={classnames(
+              'flex justify-center items-center',
+              'touch:h-touch-minimum touch:w-touch-minimum',
+              'px-2 py-2.5 touch:p-0'
+            )}
+          >
+            <HelpIcon className="w-2.5 h-2.5" />
+          </div>
+        </Link>
 
         <ToolbarButton
           label={isPreviewing ? 'Write' : 'Preview'}

--- a/src/sidebar/components/ShareLinks.tsx
+++ b/src/sidebar/components/ShareLinks.tsx
@@ -1,5 +1,5 @@
 import {
-  LinkBase,
+  Link,
   EmailIcon,
   SocialFacebookIcon,
   SocialTwitterIcon,
@@ -23,19 +23,21 @@ type ShareLinkProps = {
 function ShareLink({ label, icon: Icon, uri }: ShareLinkProps) {
   return (
     <li>
-      <LinkBase
+      <Link
         aria-label={label}
-        classes="text-grey-6 hover:text-color-text block"
+        classes="text-grey-6 hover:text-color-text"
         href={uri}
         title={label}
         target="_blank"
+        variant="custom"
+        underline="none"
       >
         <Icon
           // Make the icons sized to the current text size to allow for
           // differently-sized sharing icon links
           className="w-em h-em"
         />
-      </LinkBase>
+      </Link>
     </li>
   );
 }

--- a/src/sidebar/components/TagListItem.tsx
+++ b/src/sidebar/components/TagListItem.tsx
@@ -26,12 +26,13 @@ export default function TagListItem({
       <div className="grow px-1.5 py-1 touch:p-2">
         {href ? (
           <Link
-            color="text-light"
+            variant="text-light"
             href={href}
             lang=""
             target="_blank"
             aria-label={`Tag: ${tag}`}
             title={`View annotations with tag: ${tag}`}
+            underline="none"
           >
             {tag}
           </Link>

--- a/src/styles/sidebar/components/_index.scss
+++ b/src/styles/sidebar/components/_index.scss
@@ -36,11 +36,6 @@
   }
 }
 
-// Applies to <Link>
-.p-muted-link {
-  @apply text-color-text-light hover:text-color-text-light hover:underline;
-}
-
 // Applies to any text: strikeout effect
 .p-redacted-text {
   @apply line-through grayscale contrast-50 text-color-text-light;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,9 +1192,9 @@
     glob "^10.0.0"
 
 "@hypothesis/frontend-shared@^6.0.0":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-6.1.1.tgz#c3bd46f162e20c9c5612dd66f3fa4bb2e911f674"
-  integrity sha512-GGk6eb8pRNuqLN+QtQHQn+CC2ab7m5+a6cye0MSWkvuEclh8wLSxEHQk8/74xN9BJeWRWPbBNEswxKui8kph/A==
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@hypothesis/frontend-shared/-/frontend-shared-6.2.0.tgz#c226a2b4509ac46b2de4a82559d367b18b027f5a"
+  integrity sha512-3fFbVlwTbb7KzZL2AcPrbgj1svaQfpgRNqX00GDD1B3SRm8391hnHiWs0hKnElyJmJ3gcTyguRNCw4zVGzw9Iw==
   dependencies:
     highlight.js "^11.6.0"
     wouter-preact "^2.10.0-alpha.1"
@@ -4897,9 +4897,9 @@ he@1.2.0:
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 highlight.js@^11.6.0:
-  version "11.7.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.7.0.tgz#3ff0165bc843f8c9bce1fd89e2fda9143d24b11e"
-  integrity sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ==
+  version "11.8.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.8.0.tgz#966518ea83257bae2e7c9a48596231856555bb65"
+  integrity sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==
 
 homedir-polyfill@^1.0.1:
   version "1.0.3"
@@ -9175,9 +9175,9 @@ workerpool@6.2.1:
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
 wouter-preact@^2.10.0-alpha.1:
-  version "2.10.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/wouter-preact/-/wouter-preact-2.10.0-alpha.1.tgz#213394a210d1566f8bd5bfc794909b10cafb09b2"
-  integrity sha512-V6K8YBIURy9PHbF1e2P0gCuhCy0Oe0GbD1EZ1VxEWLU/rtBZ7IwkTj+6QVJ236NFbCklDuwL68PiUg44sSgq/w==
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/wouter-preact/-/wouter-preact-2.11.0.tgz#587b12381a5b582be19cd2dcc77e9b6837fe5437"
+  integrity sha512-0eGcl9kI1lk/85/6uri46s5rP+j92F1US2FHzG1ezwF97l0Mas/1n0q9YmKNX3s1VzMxO+ajYKRfAKbsxn+/sA==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   name wrap-ansi-cjs


### PR DESCRIPTION
This PR updates the `@hypothesis/frontend-shared` package and then updates the use of links:

* Change (deprecated) `LinkBase` to `Link` with styling API props
* Set `underline` props on all `Link` uses, as we may wish to change the default value of that prop in future
* Where possible, move styling off of `Link` and onto other elements (i.e. don't style children with `classes`)

There should be no user-visible changes here.

Part of https://github.com/hypothesis/frontend-shared/issues/1050