### PR TITLE
Update uses of `ButtonBase` to `Button`

### DIFF
--- a/src/annotator/components/AdderToolbar.tsx
+++ b/src/annotator/components/AdderToolbar.tsx
@@ -1,6 +1,6 @@
 import {
   AnnotateIcon,
-  ButtonBase,
+  Button,
   HighlightIcon,
   PointerDownIcon,
   PointerUpIcon,
@@ -76,10 +76,8 @@ function ToolbarButton({
   const title = shortcut ? `${label} (${shortcut})` : label;
 
   return (
-    <ButtonBase
+    <Button
       classes={classnames(
-        'flex-col gap-y-1 py-2.5 px-2',
-        'text-annotator-sm leading-none',
         // Default color when the toolbar is not hovered
         'text-grey-7',
         // When the parent .group element is hovered (but this element itself is
@@ -93,11 +91,22 @@ function ToolbarButton({
       )}
       onClick={onClick}
       title={title}
+      size="custom"
+      variant="custom"
     >
-      {Icon && <Icon className="text-annotator-lg" title={title} />}
-      {typeof badgeCount === 'number' && <NumberIcon badgeCount={badgeCount} />}
-      <span>{label}</span>
-    </ButtonBase>
+      <div
+        className={classnames(
+          'flex flex-col items-center gap-y-1 py-2.5 px-2',
+          'text-annotator-sm leading-none'
+        )}
+      >
+        {Icon && <Icon className="text-annotator-lg" title={title} />}
+        {typeof badgeCount === 'number' && (
+          <NumberIcon badgeCount={badgeCount} />
+        )}
+        <span data-testid="adder-button-label">{label}</span>
+      </div>
+    </Button>
   );
 }
 

--- a/src/annotator/components/Toolbar.tsx
+++ b/src/annotator/components/Toolbar.tsx
@@ -1,5 +1,5 @@
 import {
-  ButtonBase,
+  Button,
   AnnotateIcon,
   CancelIcon,
   CaretRightIcon,
@@ -29,18 +29,18 @@ type ToolbarButtonProps = PresentationalProps &
  */
 function ToolbarButton({ icon: Icon, ...buttonProps }: ToolbarButtonProps) {
   return (
-    <ButtonBase
+    <Button
       classes={classnames(
-        'w-[30px] h-[30px]', // These buttons have precise dimensions
-        'rounded-px', // size of border radius in absolute units
-        'flex items-center justify-center',
-        'border bg-white text-grey-6 hover:text-grey-9',
-        'shadow transition-colors'
+        'justify-center rounded-px',
+        'w-[30px] h-[30px]',
+        'shadow border bg-white text-grey-6 hover:text-grey-9'
       )}
       {...buttonProps}
+      size="custom"
+      variant="custom"
     >
       <Icon />
-    </ButtonBase>
+    </Button>
   );
 }
 
@@ -137,8 +137,9 @@ export default function Toolbar({
           absolutely positioned some way down the edge of the sidebar.
       */}
       {useMinimalControls && isSidebarOpen && (
-        <ButtonBase
+        <Button
           classes={classnames(
+            'transition-colors focus-visible-ring ring-inset',
             'w-[27px] h-[27px] mt-[140px] ml-px-1.5',
             'flex items-center justify-center bg-white border',
             'text-grey-6 hover:text-grey-9 transition-colors',
@@ -150,14 +151,16 @@ export default function Toolbar({
           )}
           title="Close annotation sidebar"
           onClick={closeSidebar}
+          unstyled
         >
           <CancelIcon />
-        </ButtonBase>
+        </Button>
       )}
       {!useMinimalControls && (
         <>
-          <ButtonBase
+          <Button
             classes={classnames(
+              'transition-colors focus-visible-ring ring-inset',
               // Height and width to align with the sidebar's top bar
               'h-[40px] w-[33px] pl-[6px]',
               'bg-white text-grey-5 hover:text-grey-9',
@@ -170,9 +173,10 @@ export default function Toolbar({
             expanded={isSidebarOpen}
             pressed={isSidebarOpen}
             onClick={toggleSidebar}
+            unstyled
           >
             {isSidebarOpen ? <CaretRightIcon /> : <CaretLeftIcon />}
-          </ButtonBase>
+          </Button>
           <div className="space-y-px-1.5 mt-px-2">
             <ToolbarButton
               title="Show highlights"

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -143,7 +143,7 @@ describe('Adder', () => {
 
     it("calls onAnnotate callback when Annotate button's label is clicked", () => {
       const annotateLabel = getContent(adder).querySelector(
-        'button[title^="Annotate"] > span'
+        'button[title^="Annotate"] [data-testid="adder-button-label"]'
       );
       annotateLabel.dispatchEvent(new Event('click', { bubbles: true }));
       assert.called(adderCallbacks.onAnnotate);

--- a/src/sidebar/components/Annotation/AnnotationReplyToggle.tsx
+++ b/src/sidebar/components/Annotation/AnnotationReplyToggle.tsx
@@ -1,4 +1,4 @@
-import { ButtonBase } from '@hypothesis/frontend-shared';
+import { Button } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 export type AnnotationReplyToggleProps = {
@@ -19,18 +19,19 @@ function AnnotationReplyToggle({
   const toggleText = `${toggleAction} (${replyCount})`;
 
   return (
-    <ButtonBase
+    <Button
       classes={classnames(
         // This button has a non-standard color combination: it uses a lighter
-        // text color than other LinkButtons
+        // text color than other Buttons
         'text-grey-7 enabled:hover:text-brand-dark',
-        'no-underline enabled:hover:underline'
+        'enabled:hover:underline'
       )}
       onClick={onToggleReplies}
       title={toggleText}
+      variant="custom"
     >
       {toggleText}
-    </ButtonBase>
+    </Button>
   );
 }
 

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -1,4 +1,4 @@
-import { ButtonBase, IconButton, Link } from '@hypothesis/frontend-shared';
+import { Button, IconButton, Link } from '@hypothesis/frontend-shared';
 import {
   EditorLatexIcon,
   EditorQuoteIcon,
@@ -156,12 +156,14 @@ function ToolbarButton({
 
   if (label) {
     return (
-      <ButtonBase
-        classes="text-grey-7 hover:text-grey-9 p-1.5"
+      <Button
+        classes="p-1.5 text-grey-7 hover:text-grey-9"
         {...buttonProps}
+        size="custom"
+        variant="custom"
       >
         {label}
-      </ButtonBase>
+      </Button>
     );
   }
   return (

--- a/src/sidebar/components/ModerationBanner.tsx
+++ b/src/sidebar/components/ModerationBanner.tsx
@@ -1,4 +1,4 @@
-import { ButtonBase, FlagIcon, HideIcon } from '@hypothesis/frontend-shared';
+import { Button, FlagIcon, HideIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import type { Annotation } from '../../types/api';
@@ -102,9 +102,10 @@ function ModerationBanner({
         {annotation.hidden && <span>Hidden from users</span>}
       </div>
       <div className="self-center pr-2">
-        <ButtonBase
+        <Button
           classes={classnames(
-            'px-1.5 py-1 bg-slate-1 text-grey-7 bg-grey-2',
+            'px-1.5 py-1',
+            'bg-slate-1 text-grey-7 bg-grey-2',
             'enabled:hover:text-grey-9 enabled:hover:bg-grey-3 disabled:text-grey-5',
             'aria-pressed:bg-grey-3 aria-expanded:bg-grey-3'
           )}
@@ -114,9 +115,11 @@ function ModerationBanner({
               ? 'Make this annotation visible to everyone'
               : 'Hide this annotationn from non-moderators'
           }
+          size="custom"
+          variant="custom"
         >
           {annotation.hidden ? 'Unhide' : 'Hide'}
-        </ButtonBase>
+        </Button>
       </div>
     </div>
   );

--- a/src/sidebar/components/PaginationNavigation.tsx
+++ b/src/sidebar/components/PaginationNavigation.tsx
@@ -1,5 +1,5 @@
 import {
-  ButtonBase,
+  Button,
   ArrowLeftIcon,
   ArrowRightIcon,
 } from '@hypothesis/frontend-shared';
@@ -16,14 +16,17 @@ type NavigationButtonProps = PresentationalProps &
 
 function NavigationButton({ ...buttonProps }: NavigationButtonProps) {
   return (
-    <ButtonBase
+    <Button
       classes={classnames(
-        'px-3.5 py-2.5 gap-x-1 font-semibold',
+        'px-3.5 py-2.5 gap-x-1',
+        'font-semibold',
         // These colors are the same as the "dark" variant of IconButton
         'text-grey-7 bg-grey-2 enabled:hover:text-grey-9 enabled:hover:bg-grey-3',
         'disabled:text-grey-5 aria-pressed:bg-grey-3 aria-expanded:bg-grey-3'
       )}
       {...buttonProps}
+      size="custom"
+      variant="custom"
     />
   );
 }

--- a/src/sidebar/components/Thread.tsx
+++ b/src/sidebar/components/Thread.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  ButtonBase,
   CaretRightIcon,
   MenuExpandIcon,
 } from '@hypothesis/frontend-shared';
@@ -53,20 +52,23 @@ function ThreadCollapseControl({
           'bg-white'
         )}
       >
-        <ButtonBase
+        <Button
           classes={classnames(
             // Pull the button up a little to align horizontally with the
             // thread/annotation's header. Override large touch targets for
             // touch interfaces; we need to conserve space here
-            '-mt-1 touch:min-w-[auto] touch:min-h-[auto] p-[6.5px] text-grey-5 hover:text-grey-7'
+            '-mt-1 touch:min-w-[auto] touch:min-h-[auto] p-[6.5px]',
+            'text-grey-5 hover:text-grey-7'
           )}
           data-testid="toggle-button"
           expanded={!threadIsCollapsed}
           title={toggleTitle}
           onClick={onToggleReplies}
+          size="custom"
+          variant="custom"
         >
           <ToggleIcon className="w-em h-em" />
-        </ButtonBase>
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
This PR replaces use of `ButtonBase` (deprecated) with `Button` from the `@hypothesis/frontend-shared` package and does a little bit of styling housekeeping.

In a few places, I've moved some classes around to better align with convention. There is one visual change here. I improved the keyboard focus ring for the button that expands and collapses the sidebar.

Before:

<img width="300" alt="Screen Shot 2023-05-25 at 11 56 42 AM" src="https://github.com/hypothesis/client/assets/439947/86486053-6437-4385-adcc-01b442de5a96">

After:

<img width="225" alt="Screen Shot 2023-05-25 at 11 32 09 AM" src="https://github.com/hypothesis/client/assets/439947/ea9e7042-5bab-4efe-bc52-b94e0e7890d7">

Fixes https://github.com/hypothesis/frontend-shared/issues/1050