### PR TITLE
Set `underline` prop on `LinkButton`

### DIFF
--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -138,6 +138,7 @@ function TopBar({
                     classes="inline"
                     onClick={onSignUp}
                     style={loginLinkStyle}
+                    underline="none"
                   >
                     Sign up
                   </LinkButton>
@@ -146,6 +147,7 @@ function TopBar({
                     classes="inline"
                     onClick={onLogin}
                     style={loginLinkStyle}
+                    underline="none"
                   >
                     Log in
                   </LinkButton>


### PR DESCRIPTION
This tiny PR ensures that `underline` is set on the last couple of remaining `LinkButton`s that didn't set it. This will allow us to change the underlining default without disrupting existing links/link-buttons. https://github.com/hypothesis/frontend-shared/issues/599
