### PR TITLE
Don't close sidebar when clicking on bucket bar background

### DIFF
--- a/src/annotator/components/Buckets.tsx
+++ b/src/annotator/components/Buckets.tsx
@@ -59,10 +59,7 @@ export default function Buckets({
         // https://github.com/hypothesis/client/pull/2750
         'absolute w-[23px] left-[-22px] h-full',
         // The background is set to low opacity when the sidebar is collapsed.
-        'bg-grey-2 sidebar-collapsed:bg-black/[.08]',
-        // Disable pointer events along the sidebar itself; re-enable them in
-        // the list elements containing bucket buttons
-        'pointer-events-none'
+        'bg-grey-2 sidebar-collapsed:bg-black/[.08]'
       )}
     >
       {showUpNavigation && (

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -328,6 +328,11 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
   _setupElementEvents() {
     // Hide the sidebar in response to a document click or tap, so it doesn't obscure
     // the document content.
+    //
+    // Hypothesis UI elements (`<hypothesis->`) have logic to prevent clicks in
+    // them from propagating out of their shadow roots, and hence clicking on
+    // elements in the sidebar's vertical toolbar or adder won't close the
+    // sidebar.
     const maybeCloseSidebar = (element: Element) => {
       if (this._sideBySideActive) {
         // Don't hide the sidebar if event was disabled because the sidebar


### PR DESCRIPTION
Prevent the sidebar from closing when clicking the grey background [1] behind
buckets or toolbar buttons. Visually this background is part of the sidebar, so
it seems unexpected that clicking it closes the sidebar.  Also if a user misses
a bucket's hit target, it is annoying if the sidebar gets closed and moves the
bucket/button.

Remove the `pointer-events: none` style from the grey background behind the
bucket bar. As a result clicks on this background will go to this background
element instead of the document content behind it. Due to existing logic in the
`createShadowRoot` helper, `mousedown` events within `<hypothesis-*>` element
shadow roots have their propagation stopped and so they don't reach the code in
`Guest` which closes the sidebar.

[1] The "grey background" is this region:

<img width="69" alt="Sidebar background" src="https://github.com/hypothesis/client/assets/2458/ee77168a-c009-4d03-8e70-47bb2b15fb5c">
