### PR TITLE
Use center rather than top position of anchor for bucket-on-screen test

### DIFF
--- a/src/annotator/util/buckets.ts
+++ b/src/annotator/util/buckets.ts
@@ -54,8 +54,8 @@ export type WorkingBucket = {
 // `window.innerHeight - BUCKET_BOTTOM_THRESHOLD` are considered "on-screen"
 // and will be bucketed. This is to account for bucket-bar tool buttons (top
 // and the height of the bottom navigation bucket (bottom)
-const BUCKET_TOP_THRESHOLD = 137;
-const BUCKET_BOTTOM_THRESHOLD = 22;
+export const BUCKET_TOP_THRESHOLD = 137;
+export const BUCKET_BOTTOM_THRESHOLD = 22;
 // Generated buckets of annotation anchor highlights should be spaced by
 // at least this amount, in pixels
 const BUCKET_GAP_SIZE = 60;
@@ -167,10 +167,11 @@ export function computeBuckets(anchorPositions: AnchorPosition[]): BucketSet {
 
   // Build buckets from position information
   anchorPositions.forEach(aPos => {
-    if (aPos.top < BUCKET_TOP_THRESHOLD) {
+    const center = (aPos.top + aPos.bottom) / 2;
+    if (center < BUCKET_TOP_THRESHOLD) {
       aboveTags.add(aPos.tag);
       return;
-    } else if (aPos.top > window.innerHeight - BUCKET_BOTTOM_THRESHOLD) {
+    } else if (center > window.innerHeight - BUCKET_BOTTOM_THRESHOLD) {
       belowTags.add(aPos.tag);
       return;
     }


### PR DESCRIPTION
Use the position of the center of an anchor instead of the top to determine whether it should be counted as off-screen or not. Since buckets in the bucket bar are drawn where the center is, this ensures that on-screen buckets merge into off-screen ones at a natural point, instead of when there is still a gap between the two (for the "above screen" bucket) or after the on-screen bucket has gone below the "below screen" bucket.

Fixes #5525