### PR TITLE
Toggle an HTML class on the guest element to denote side-by-side status

### DIFF
--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -849,6 +849,10 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
    */
   fitSideBySide(sidebarLayout: SidebarLayout) {
     this._sideBySideActive = this._integration.fitSideBySide(sidebarLayout);
+    this.element.classList.toggle(
+      'hypothesis-sidebyside-active',
+      this._sideBySideActive
+    );
   }
 
   /**

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1547,6 +1547,25 @@ describe('Guest', () => {
       assert.calledWith(fakeIntegration.fitSideBySide, layout);
     });
 
+    it('sets an html class on the element if side by side is activated', () => {
+      const guest = createGuest();
+      fakeIntegration.fitSideBySide.returns(true);
+      const layout = { expanded: true, width: 100 };
+
+      guest.fitSideBySide(layout);
+
+      assert.isTrue(
+        guest.element.classList.contains('hypothesis-sidebyside-active')
+      );
+
+      fakeIntegration.fitSideBySide.returns(false);
+      guest.fitSideBySide(layout);
+
+      assert.isFalse(
+        guest.element.classList.contains('hypothesis-sidebyside-active')
+      );
+    });
+
     it('enables closing sidebar on document click if side-by-side is not activated', () => {
       const guest = createGuest();
       fakeIntegration.fitSideBySide.returns(false);


### PR DESCRIPTION
I'd be open to adding a data attribute instead, but we've used classes for such things in the past.

Fixes #5527