### PR TITLE
Actually build the app after running `yarn version`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,9 @@ jobs:
         QA_VERSION=$(git tag --list | sort --version-sort --reverse | head -n1 | tail -c +2)-$LAST_COMMIT_HASH
         echo "QA_VERSION=$QA_VERSION" >> $GITHUB_ENV
     - name: Build app
-      run: yarn version "$QA_VERSION"
+      run: |
+        yarn version "$QA_VERSION"
+        make clean build
     - name: Upload files to Sentry
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.sentry_auth_token }}
@@ -95,7 +97,9 @@ jobs:
         git push https://github.com/hypothesis/client.git v$NEW_VERSION
         sleep 2  # Wait for GitHub to see new tag
     - name: Build app
-      run: yarn version $NEW_VERSION
+      run: |
+        yarn version $NEW_VERSION
+        make clean build
     - name: Upload files to Sentry
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.sentry_auth_token }}

--- a/package.json
+++ b/package.json
@@ -117,8 +117,7 @@
     "format": "prettier --cache --list-different --write '**/*.{js,scss,ts,tsx,d.ts}'",
     "test": "gulp test",
     "test:watch": "gulp test --live",
-    "typecheck": "tsc --build tsconfig.json",
-    "version": "make clean build"
+    "typecheck": "tsc --build tsconfig.json"
   },
   "packageManager": "yarn@3.6.0"
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/hypothesis/client/pull/5543.

In Yarn v3, the "version" script defined in `package.json` is no longer run any more when running `yarn version`. So run the corresponding commands directly from the GHA workflow.