### PR TITLE
Update wait-for-npm-release.sh after Yarn v3 update

### DIFF
--- a/scripts/wait-for-npm-release.sh
+++ b/scripts/wait-for-npm-release.sh
@@ -6,9 +6,15 @@
 # This script is needed because a new release of a package is not always
 # immediately available after "npm publish" returns.
 #
-# Usage: wait-for-npm-release.sh [<dist-tag>]
+# Usage: wait-for-npm-release.sh [<dist-tag>] [<version>]
 #
 # <dist-tag> defaults to "latest".
+# <version> defaults to the "version" field from package.json.
+
+package_name=hypothesis
+timeout=60
+start_time=$(date +%s)
+end_time=$((start_time + timeout))
 
 if [ -z "$1" ]; then
   dist_tag=latest
@@ -16,12 +22,26 @@ else
   dist_tag=$1
 fi
 
-expected_version=$(node -p "require('./package.json').version")
-while [ true ]
+if [ -z "$2" ]; then
+  expected_version=$(node -p "require('./package.json').version")
+else
+  expected_version=$2
+fi
+
+echo "Waiting for $package_name@$expected_version to be published as \"$dist_tag\" on npm..."
+
+while true
 do
-  released_version=$(yarn info -s hypothesis dist-tags.$dist_tag)
+  released_version=$(npm info "$package_name" "dist-tags.$dist_tag")
   if [ "$released_version" = "$expected_version" ]; then
+    echo "Package version $expected_version found on npm."
     break
+  fi
+
+  current_time=$(date +%s)
+  if [ "$current_time" -ge "$end_time" ]; then
+    echo "Timeout reached. Package was not published after $timeout seconds."
+    exit 1
   fi
 
   sleep 1


### PR DESCRIPTION
Fix an issue where the `scripts/wait-for-npm-release.sh` script failed in https://github.com/hypothesis/client/actions/runs/5265798261/jobs/9519030535 after updating to Yarn v3, due to the `yarn info` command no longer working as before.

 - Use `npm info` to get the latest published version. The `yarn info` command now does something different and has a different output format
 - Add log output to make it more obvious what is going on in CI logs
 - Add a 60s timeout, so the script doesn't end up running indefinitely in CI if something goes wrong

**Testing:**

1. Run `./scripts/wait-for-npm-release.sh latest 1.1296.0`. The script will exit with status 0 and this output:

```
Waiting for hypothesis@1.1296.0 to be published as "latest" on npm...
Package version 1.1296.0 found on npm.
```

2. Run `./scripts/wait-for-npm-release.sh latest 1.1296.0-invalid-version`. The script will exit after 60s with status 1 and this output:

```
Waiting for hypothesis@1.1296.0-invalid-version to be published as "latest" on npm...
Timeout reached. Package was not published after 60 seconds.
```