### PR TITLE
Remove .npmrc file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-sign-git-tag=true


### PR DESCRIPTION
Yarn v3 doesn't use this, and before that we were overriding the one setting in this file.