### PR TITLE
Sidebar store ts migration

### DIFF
--- a/src/sidebar/store/debug-middleware.ts
+++ b/src/sidebar/store/debug-middleware.ts
@@ -1,7 +1,4 @@
-/**
- * @typedef {import('redux').Action} Action
- * @typedef {import('redux').Store} Store
- */
+import type { Action, Store } from 'redux';
 
 /**
  * A debug utility that prints information about internal application state
@@ -12,17 +9,13 @@
  * When enabled, every action that changes application state will be printed
  * to the console, along with the application state before and after the action
  * was handled.
- *
- * @param {Store} store
  */
-export function debugMiddleware(store) {
+export function debugMiddleware(store: Store) {
   /* eslint-disable no-console */
   let serial = 0;
 
-  /** @param {(a: Action) => void} next */
-  return next => {
-    /** @param {Action} action */
-    return action => {
+  return (next: (a: Action) => void) => {
+    return (action: Action) => {
       // @ts-ignore The window interface needs to be expanded to include this property
       if (!window.debug) {
         next(action);

--- a/src/sidebar/store/index.ts
+++ b/src/sidebar/store/index.ts
@@ -1,3 +1,4 @@
+import type { SidebarSettings } from '../../types/config';
 import { useService } from '../service-context';
 import { createStore } from './create-store';
 import { debugMiddleware } from './debug-middleware';
@@ -19,7 +20,7 @@ import { toastMessagesModule } from './modules/toast-messages';
 import { viewerModule } from './modules/viewer';
 import { useStore } from './use-store';
 
-/** @typedef {ReturnType<createSidebarStore>} SidebarStore */
+export type SidebarStore = ReturnType<typeof createSidebarStore>;
 
 /**
  * Create the central state store for the sidebar application.
@@ -30,15 +31,14 @@ import { useStore } from './use-store';
  *
  * [1] https://redux.js.org
  *
- * @param {import('../../types/config').SidebarSettings} settings
  * @inject
  */
-export function createSidebarStore(settings) {
+export function createSidebarStore(settings: SidebarSettings) {
   const middleware = [debugMiddleware];
 
   // `const` type gives `modules` a tuple type, which allows `createStore`
   // to infer properties (eg. action and selector methods) of returned store.
-  const modules = /** @type {const} */ ([
+  const modules = [
     activityModule,
     annotationsModule,
     defaultsModule,
@@ -55,7 +55,7 @@ export function createSidebarStore(settings) {
     sidebarPanelsModule,
     toastMessagesModule,
     viewerModule,
-  ]);
+  ] as const;
   return createStore(modules, [settings], middleware);
 }
 
@@ -67,6 +67,6 @@ export function createSidebarStore(settings) {
  * {@link useStore}.
  */
 export function useSidebarStore() {
-  const store = /** @type {SidebarStore} */ (useService('store'));
+  const store = useService('store') as SidebarStore;
   return useStore(store);
 }

--- a/src/sidebar/store/util.ts
+++ b/src/sidebar/store/util.ts
@@ -1,17 +1,17 @@
-/** @typedef {import('redux').Store} Store */
+import type { Store } from 'redux';
 
 /**
  * Return an object where each key in `updateFns` is mapped to the key itself.
  *
- * @template {Record<string,Function>} T
- * @param {T} reducers - Object containing reducer functions
- * @return {{ [index in keyof T]: string }}
+ * @param reducers - Object containing reducer functions
  */
-export function actionTypes(reducers) {
-  return Object.keys(reducers).reduce((types, key) => {
+export function actionTypes<T extends Record<string, unknown>>(
+  reducers: T
+): { [index in keyof T]: string } {
+  return Object.keys(reducers).reduce<any>((types, key) => {
     types[key] = key;
     return types;
-  }, /** @type {any} */ ({}));
+  }, {});
 }
 
 /**
@@ -20,13 +20,13 @@ export function actionTypes(reducers) {
  * `await` returns a Promise which resolves when a selector function,
  * which reads values from a Redux store, returns non-null.
  *
- * @template T
- * @param {import('redux').Store} store
- * @param {(s: Store) => T|null} selector - Function which returns a value from the
- *   store if the criteria is met or `null` otherwise.
- * @return {Promise<T>}
+ * @param selector - Function which returns a value from the store if the
+ *   criteria is met or `null` otherwise.
  */
-export function awaitStateChange(store, selector) {
+export function awaitStateChange<T>(
+  store: Store,
+  selector: (s: Store) => T | null
+): Promise<T> {
   const result = selector(store);
   if (result !== null) {
     return Promise.resolve(result);


### PR DESCRIPTION
Migrating some files from `sidebar/store` to TypeScript.

I have left `use-store` out, because typing that correctly has proved to be challenging. Even with some in-place type casts, then code consuming `useStore` also fails type checks.