### PR TITLE
Make top/bottom bucket scrolling work when using a custom bucket container

### DIFF
--- a/src/annotator/bucket-bar.tsx
+++ b/src/annotator/bucket-bar.tsx
@@ -7,10 +7,7 @@ import { createShadowRoot } from './util/shadow-root';
 
 export type BucketBarOptions = {
   onFocusAnnotations: (tags: string[]) => void;
-  onScrollToClosestOffScreenAnchor: (
-    tags: string[],
-    direction: 'down' | 'up'
-  ) => void;
+  onScrollToAnnotation: (tag: string) => void;
   onSelectAnnotations: (tags: string[], toggle: boolean) => void;
 };
 
@@ -23,14 +20,14 @@ export type BucketBarOptions = {
 export class BucketBar implements Destroyable {
   private _bucketsContainer: HTMLElement;
   private _onFocusAnnotations: BucketBarOptions['onFocusAnnotations'];
-  private _onScrollToClosestOffScreenAnchor: BucketBarOptions['onScrollToClosestOffScreenAnchor'];
+  private _onScrollToAnnotation: BucketBarOptions['onScrollToAnnotation'];
   private _onSelectAnnotations: BucketBarOptions['onSelectAnnotations'];
 
   constructor(
     container: HTMLElement,
     {
       onFocusAnnotations,
-      onScrollToClosestOffScreenAnchor,
+      onScrollToAnnotation,
       onSelectAnnotations,
     }: BucketBarOptions
   ) {
@@ -50,7 +47,7 @@ export class BucketBar implements Destroyable {
     container.appendChild(this._bucketsContainer);
 
     this._onFocusAnnotations = onFocusAnnotations;
-    this._onScrollToClosestOffScreenAnchor = onScrollToClosestOffScreenAnchor;
+    this._onScrollToAnnotation = onScrollToAnnotation;
     this._onSelectAnnotations = onSelectAnnotations;
 
     // Immediately render the bucket bar
@@ -70,9 +67,7 @@ export class BucketBar implements Destroyable {
         below={buckets.below}
         buckets={buckets.buckets}
         onFocusAnnotations={tags => this._onFocusAnnotations(tags)}
-        onScrollToClosestOffScreenAnchor={(tags, direction) =>
-          this._onScrollToClosestOffScreenAnchor(tags, direction)
-        }
+        onScrollToAnnotation={tag => this._onScrollToAnnotation(tag)}
         onSelectAnnotations={(tags, toogle) =>
           this._onSelectAnnotations(tags, toogle)
         }

--- a/src/annotator/components/Buckets.tsx
+++ b/src/annotator/components/Buckets.tsx
@@ -4,16 +4,14 @@ import type { Bucket } from '../util/buckets';
 
 export type BucketsProps = {
   /**
-   * Bucket containing the $tags of any annotations that are offscreen above
-   * the current viewport. If the set of $tags is non-empty, up navigation
-   * will be rendered.
+   * Bucket containing anchors that are above the bucket bar. If non-empty,
+   * an "Up" bucket will be rendered.
    */
   above: Bucket;
 
   /**
-   * Bucket containing the $tags of any annotations that are offscreen below
-   * the current viewport. If the set of $tags is non-empty, down navigation
-   * will be rendered.
+   * Bucket containing anchors that are below the bucket bar. If non-empty,
+   * a "Down" bucket will be rendered.
    */
   below: Bucket;
 
@@ -23,10 +21,7 @@ export type BucketsProps = {
    */
   buckets: Bucket[];
   onFocusAnnotations: ($tags: string[]) => void;
-  onScrollToClosestOffScreenAnchor: (
-    $tags: string[],
-    direction: 'down' | 'up'
-  ) => void;
+  onScrollToAnnotation: ($tag: string) => void;
   onSelectAnnotations: ($tags: string[], toggle: boolean) => void;
 };
 
@@ -43,11 +38,12 @@ export default function Buckets({
   below,
   buckets,
   onFocusAnnotations,
-  onScrollToClosestOffScreenAnchor,
+  onScrollToAnnotation,
   onSelectAnnotations,
 }: BucketsProps) {
-  const showUpNavigation = above.tags.size > 0;
-  const showDownNavigation = below.tags.size > 0;
+  const showUpNavigation = above.anchors.length > 0;
+  const showDownNavigation = below.anchors.length > 0;
+  const bucketTags = (b: Bucket) => b.anchors.map(a => a.tag);
 
   return (
     <ul className="relative">
@@ -59,16 +55,20 @@ export default function Buckets({
           <PointerButton
             data-testid="up-navigation-button"
             direction="up"
-            onClick={() =>
-              onScrollToClosestOffScreenAnchor([...above.tags], 'up')
-            }
+            onClick={() => {
+              const anchors = [...above.anchors].sort(
+                (a, b) => a.bottom - b.bottom
+              );
+              const bottomAnchor = anchors[anchors.length - 1];
+              onScrollToAnnotation(bottomAnchor.tag);
+            }}
             onBlur={() => onFocusAnnotations([])}
-            onFocus={() => onFocusAnnotations([...above.tags])}
-            onMouseEnter={() => onFocusAnnotations([...above.tags])}
+            onFocus={() => onFocusAnnotations(bucketTags(above))}
+            onMouseEnter={() => onFocusAnnotations(bucketTags(above))}
             onMouseOut={() => onFocusAnnotations([])}
-            title={`Go up to next annotations (${above.tags.size})`}
+            title={`Go up to next annotations (${above.anchors.length})`}
           >
-            {above.tags.size}
+            {above.anchors.length}
           </PointerButton>
         </li>
       )}
@@ -82,17 +82,17 @@ export default function Buckets({
             direction="left"
             onClick={event =>
               onSelectAnnotations(
-                [...bucket.tags],
+                bucketTags(bucket),
                 event.metaKey || event.ctrlKey
               )
             }
             onBlur={() => onFocusAnnotations([])}
-            onFocus={() => onFocusAnnotations([...bucket.tags])}
-            onMouseEnter={() => onFocusAnnotations([...bucket.tags])}
+            onFocus={() => onFocusAnnotations(bucketTags(bucket))}
+            onMouseEnter={() => onFocusAnnotations(bucketTags(bucket))}
             onMouseOut={() => onFocusAnnotations([])}
-            title={`Select nearby annotations (${bucket.tags.size})`}
+            title={`Select nearby annotations (${bucket.anchors.length})`}
           >
-            {bucket.tags.size}
+            {bucket.anchors.length}
           </PointerButton>
         </li>
       ))}
@@ -104,16 +104,18 @@ export default function Buckets({
           <PointerButton
             data-testid="down-navigation-button"
             direction="down"
-            onClick={() =>
-              onScrollToClosestOffScreenAnchor([...below.tags], 'down')
-            }
+            onClick={() => {
+              const anchors = [...below.anchors].sort((a, b) => a.top - b.top);
+              const topAnchor = anchors[0];
+              onScrollToAnnotation(topAnchor.tag);
+            }}
             onBlur={() => onFocusAnnotations([])}
-            onFocus={() => onFocusAnnotations([...below.tags])}
-            onMouseEnter={() => onFocusAnnotations([...below.tags])}
+            onFocus={() => onFocusAnnotations(bucketTags(below))}
+            onMouseEnter={() => onFocusAnnotations(bucketTags(below))}
             onMouseOut={() => onFocusAnnotations([])}
-            title={`Go up to next annotations (${below.tags.size})`}
+            title={`Go up to next annotations (${below.anchors.length})`}
           >
-            {below.tags.size}
+            {below.anchors.length}
           </PointerButton>
         </li>
       )}

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -501,7 +501,7 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
     if (!anchor?.highlights) {
       return;
     }
-    this._scrollToAnchor(anchor);
+    await this._scrollToAnchor(anchor);
   }
 
   async _connectSidebar() {

--- a/src/annotator/sidebar.tsx
+++ b/src/annotator/sidebar.tsx
@@ -214,10 +214,8 @@ export class Sidebar implements Destroyable {
         this.bucketBar = new BucketBar(bucketBarContainer, {
           onFocusAnnotations: tags =>
             this._guestRPC.forEach(rpc => rpc.call('hoverAnnotations', tags)),
-          onScrollToClosestOffScreenAnchor: (tags, direction) =>
-            this._guestRPC.forEach(rpc =>
-              rpc.call('scrollToClosestOffScreenAnchor', tags, direction)
-            ),
+          onScrollToAnnotation: tag =>
+            this._guestRPC.forEach(rpc => rpc.call('scrollToAnnotation', tag)),
           onSelectAnnotations: (tags, toggle) =>
             this._guestRPC.forEach(rpc =>
               rpc.call('selectAnnotations', tags, toggle)

--- a/src/annotator/test/bucket-bar-test.js
+++ b/src/annotator/test/bucket-bar-test.js
@@ -6,7 +6,7 @@ describe('BucketBar', () => {
   let container;
   let fakeComputeBuckets;
   let fakeOnFocusAnnotations;
-  let fakeOnScrollToClosestOffScreenAnchor;
+  let fakeOnScrollToAnnotation;
   let fakeOnSelectAnnotations;
 
   beforeEach(() => {
@@ -17,7 +17,7 @@ describe('BucketBar', () => {
     fakeComputeBuckets = sinon.stub().returns({});
 
     fakeOnFocusAnnotations = sinon.stub();
-    fakeOnScrollToClosestOffScreenAnchor = sinon.stub();
+    fakeOnScrollToAnnotation = sinon.stub();
     fakeOnSelectAnnotations = sinon.stub();
 
     const FakeBuckets = props => {
@@ -40,7 +40,7 @@ describe('BucketBar', () => {
   const createBucketBar = () => {
     const bucketBar = new BucketBar(container, {
       onFocusAnnotations: fakeOnFocusAnnotations,
-      onScrollToClosestOffScreenAnchor: fakeOnScrollToClosestOffScreenAnchor,
+      onScrollToAnnotation: fakeOnScrollToAnnotation,
       onSelectAnnotations: fakeOnSelectAnnotations,
     });
     bucketBars.push(bucketBar);
@@ -64,14 +64,10 @@ describe('BucketBar', () => {
     assert.calledWith(fakeOnFocusAnnotations, tags);
   });
 
-  it('passes "onScrollToClosestOffScreenAnchor" to the Bucket component', () => {
+  it('passes "onScrollToAnnotation" to the Bucket component', () => {
     createBucketBar();
-    const tags = ['t1', 't2'];
-    const direction = 'down';
-
-    bucketProps.onScrollToClosestOffScreenAnchor(tags, direction);
-
-    assert.calledWith(fakeOnScrollToClosestOffScreenAnchor, tags, direction);
+    bucketProps.onScrollToAnnotation('t1');
+    assert.calledWith(fakeOnScrollToAnnotation, 't1');
   });
 
   it('passes "onSelectAnnotations" to the Bucket component', () => {

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -1115,22 +1115,15 @@ describe('Sidebar', () => {
       assert.calledWith(guestRPC().call, 'hoverAnnotations', tags);
     });
 
-    it('calls the "scrollToClosestOffScreenAnchor" RPC method', () => {
+    it('calls the "scrollToAnnotation" RPC method', () => {
       const sidebar = createSidebar();
       connectGuest(sidebar);
-      const { onScrollToClosestOffScreenAnchor } =
-        FakeBucketBar.getCall(0).args[1];
-      const tags = ['t1', 't2'];
-      const direction = 'down';
+      const { onScrollToAnnotation } = FakeBucketBar.getCall(0).args[1];
+      const tag = 't1';
 
-      onScrollToClosestOffScreenAnchor(tags, direction);
+      onScrollToAnnotation(tag);
 
-      assert.calledWith(
-        guestRPC().call,
-        'scrollToClosestOffScreenAnchor',
-        tags,
-        direction
-      );
+      assert.calledWith(guestRPC().call, 'scrollToAnnotation', tag);
     });
 
     it('calls the "selectAnnotations" RPC method', () => {

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -95,9 +95,9 @@ export type HostToGuestEvent =
   | 'sidebarLayoutChanged'
 
   /**
-   * The host informs guests to scroll to the closest off-screen anchor associated with a set of annotations.
+   * Scroll to an annotation given its tag.
    */
-  | 'scrollToClosestOffScreenAnchor';
+  | 'scrollToAnnotation';
 
 /**
  * Events that the host sends to the sidebar


### PR DESCRIPTION
When using a custom bucket container, the top / bottom buckets may be positioned
differently than the code previously assumed (137x px below the top of the
viewport, 20px above the bottom). Redo the logic to work regardless of bucket
container positioning. Instead of trying to determine whether an anchor is
on-screen or not, just pick the anchor with the lowest bottom or highest top as
the "nearest" one, depending on which direction we are scrolling in.

This is implemented by:

 - Changing `Bucket` objects to record not just the tags from anchors in
   them, but the list of `AnchorPosition` objects from which the bucket
   was built. These objects include the top and bottom positions of the
   anchor.

 - Make clicking on the "Up" bucket search the anchor list for the
   anchor with the lowest bottom position, and send a request to the
   guest to scroll to that anchor.

 - Make clicking on the "Down" bucket search the anchor list for the
   anchor with the highest top position, and send a request to the
   guest to scroll to that anchor.

 - Removing all the logic for finding and scrolling to the "nearest
   off-screen anchor"

Part of https://github.com/hypothesis/client/issues/5488.


**Testing:**

To test this, you'll need to use the latest version of the Via video player and make the screen narrow. This will result in a bucket bar that has a significantly different vertical position than the client's usual one:

<img width="721" alt="Narrow video player" src="https://github.com/hypothesis/client/assets/2458/aff59c8f-272a-4163-8476-fbf4e2e6c731">


On `main`, if you create an annotation and then scroll the transcript down so the bucket is just out of view and is now "somewhere behind the video", then click on the "Up" bucket, the transcript won't scroll. This is because on `main` only anchors that are outside the viewport (minus a top/bottom margin) are considered. On this branch, the "Up" bucket now works, because it simply scrolls to whichever anchor associated with that bucket has the bounding rectangle with the lowest bottom point.