### PR TITLE
Trigger custom DOM event when layout changes

### DIFF
--- a/docs/publishers/events.rst
+++ b/docs/publishers/events.rst
@@ -1,0 +1,45 @@
+Events
+======
+
+The Hypothesis client emits custom DOM events at ``document.body``, to which your app can react.
+
+They extend `CustomEvent <https://developer.mozilla.org/docs/Web/API/CustomEvent>`_, so their payload can be found inside the ``detail`` property.
+
+.. option:: hypothesis:layoutchange
+
+   This event is emitted when the sidebar layout changes. eg. when it is opened or closed.
+
+Properties
+----------
+
+.. option:: sidebarLayout
+
+  .. option:: expanded
+
+     ``Boolean`` True if the sidebar is open
+
+  .. option:: width
+
+     ``Number`` The width of the sidebar in pixels
+
+  .. option:: height
+
+     ``Number`` The height of the sidebar in pixels
+
+.. option:: sideBySideActive
+
+  ``Boolean`` Indicates whether side-by-side mode is active
+
+.. code-block:: javascript
+
+    document.body.addEventListener('hypothesis:layoutchange', event => {
+      console.log(event.detail.sidebarLayout.expanded);
+      console.log(event.detail.sidebarLayout.width);
+      console.log(event.detail.sidebarLayout.height);
+      console.log(event.detail.sideBySideActive);
+    });
+
+.. note::
+
+  `See also "onLayoutChange" </publishers/config/#cmdoption-arg-onLayoutChange>`_ function, for an alternative way
+  to make your app programmatically react to layout changes.

--- a/docs/publishers/index.rst
+++ b/docs/publishers/index.rst
@@ -13,3 +13,4 @@ pages will help you get started.
    embedding
    config
    host-page-integration
+   events

--- a/src/annotator/events.ts
+++ b/src/annotator/events.ts
@@ -1,0 +1,16 @@
+import type { SidebarLayout } from '../types/annotator';
+
+type LayoutChangeEventDetail = {
+  isSideBySideActive: boolean;
+  sidebarLayout: SidebarLayout;
+};
+
+export class LayoutChangeEvent extends CustomEvent<LayoutChangeEventDetail> {
+  constructor(detail: LayoutChangeEventDetail) {
+    super('hypothesis:layoutchange', {
+      bubbles: true,
+      cancelable: false,
+      detail,
+    });
+  }
+}

--- a/src/annotator/events.ts
+++ b/src/annotator/events.ts
@@ -1,7 +1,7 @@
 import type { SidebarLayout } from '../types/annotator';
 
 type LayoutChangeEventDetail = {
-  isSideBySideActive: boolean;
+  sideBySideActive: boolean;
   sidebarLayout: SidebarLayout;
 };
 

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -24,6 +24,7 @@ import type {
 import { Adder } from './adder';
 import { TextRange } from './anchoring/text-range';
 import { BucketBarClient } from './bucket-bar-client';
+import { LayoutChangeEvent } from './events';
 import { FeatureFlags } from './features';
 import { HighlightClusterController } from './highlight-clusters';
 import {
@@ -453,6 +454,16 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
       if (frameFillsAncestor(window, hostFrame)) {
         this.fitSideBySide(sidebarLayout);
       }
+
+      // Emit a custom event that the host page can respond to. This is useful
+      // if the host app needs to change its layout depending on the sidebar's
+      // visibility and size.
+      this.element.dispatchEvent(
+        new LayoutChangeEvent({
+          sidebarLayout,
+          isSideBySideActive: this._sideBySideActive,
+        })
+      );
     });
 
     this._hostRPC.on('close', () => this.emit('hostDisconnected'));
@@ -748,7 +759,7 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
   }
 
   /**
-   * Scroll to the closest off screen anchor.
+   * Scroll to the closest off-screen anchor.
    */
   private async _scrollToClosestOffScreenAnchor(
     tags: string[],

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -461,7 +461,7 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
       this.element.dispatchEvent(
         new LayoutChangeEvent({
           sidebarLayout,
-          isSideBySideActive: this._sideBySideActive,
+          sideBySideActive: this._sideBySideActive,
         })
       );
     });

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -259,6 +259,24 @@ describe('Guest', () => {
 
         assert.notCalled(fakeIntegration.fitSideBySide);
       });
+
+      it('emits a "hypothesis:layoutchange" DOM event', done => {
+        const guest = createGuest();
+        const dummyLayout = {
+          expanded: true,
+          width: 100,
+          height: 300,
+          toolbarWidth: 10,
+        };
+
+        guest.element.addEventListener('hypothesis:layoutchange', e => {
+          assert.equal(e.detail.sidebarLayout, dummyLayout);
+          // This ensures the test will timeout if this event is not emitted
+          done();
+        });
+
+        emitHostEvent('sidebarLayoutChanged', dummyLayout);
+      });
     });
 
     describe('on "hoverAnnotations" event', () => {

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -260,7 +260,7 @@ describe('Guest', () => {
         assert.notCalled(fakeIntegration.fitSideBySide);
       });
 
-      it('emits a "hypothesis:layoutchange" DOM event', done => {
+      it('emits a "hypothesis:layoutchange" DOM event', () => {
         const guest = createGuest();
         const dummyLayout = {
           expanded: true,
@@ -268,14 +268,20 @@ describe('Guest', () => {
           height: 300,
           toolbarWidth: 10,
         };
+        const listener = sinon.stub();
 
-        guest.element.addEventListener('hypothesis:layoutchange', e => {
-          assert.equal(e.detail.sidebarLayout, dummyLayout);
-          // This ensures the test will timeout if this event is not emitted
-          done();
-        });
+        guest.element.addEventListener('hypothesis:layoutchange', listener);
 
         emitHostEvent('sidebarLayoutChanged', dummyLayout);
+
+        assert.calledWith(
+          listener,
+          sinon.match({
+            detail: sinon.match({
+              sidebarLayout: dummyLayout,
+            }),
+          })
+        );
       });
     });
 


### PR DESCRIPTION
Closes #5553

This PR adds a new custom DOM event that gets emitted every time the sidebar opens or closes.

The event wraps the `SidebarLayout`, and a flag telling if side-by-side mode is active.

### Testing

A simple way to test if the event is being properly dispatched is capturing it in the dev server.

1. Open the `dev-server/static/scripts/index.js`.
2. Add the next block after `setUpControls()` call.
    ```diff
    setupControls();
    + document.body.addEventListener('hypothesis:layoutchange', console.log);
    ```
3. Go to http://localhost:3000 and open the browser console
4. Open and close the sidebar a few times. You should see the event being printed.

This PR also adds a new documentation page:

1. Run `make docs`.
2. Once docs are built, go to http://127.0.0.1:8000/publishers/events/

I have only added one new page, but we might want to document others (for example, `scrolltorange`), so maybe we need to add sub-pages there.

### TODO

- [x] Check if it's possible to delay the event and trigger it only after sidebar animation is done (when relevant).
- [x] Document event
  ![image](https://github.com/hypothesis/client/assets/2719332/10a8ee82-e263-483f-84b7-dfb54b837d4f)
- [x] ~Consider capturing event in dev env to console-log it~ I think adding a console log might be too noisy for a page where we usually need to debug stuff. I'll think on something afterwards.