### PR TITLE
Rollback focusable and actionable ThreadCard

### DIFF
--- a/src/sidebar/components/ThreadCard.tsx
+++ b/src/sidebar/components/ThreadCard.tsx
@@ -68,9 +68,7 @@ function ThreadCard({ frameSync, thread }: ThreadCardProps) {
       classes="cursor-pointer focus-visible-ring theme-clean:border-none"
       data-testid="thread-card"
       elementRef={cardRef}
-      tabIndex={0}
-      role="button"
-      aria-label="Press Enter to scroll annotation into view"
+      tabIndex={-1}
       onClick={e => {
         // Prevent click events intended for another action from
         // triggering a page scroll.
@@ -80,18 +78,6 @@ function ThreadCard({ frameSync, thread }: ThreadCardProps) {
       }}
       onMouseEnter={() => setThreadHovered(thread.annotation ?? null)}
       onMouseLeave={() => setThreadHovered(null)}
-      onKeyDown={e => {
-        // Simulate default button behavior, where `Enter` and `Space` trigger
-        // click action.
-        // Make sure the event was triggered on the card itself and not a children
-        if (
-          e.target === cardRef.current &&
-          ['Enter', ' '].includes(e.key) &&
-          thread.annotation
-        ) {
-          scrollToAnnotation(thread.annotation);
-        }
-      }}
       key={thread.id}
     >
       <CardContent>{threadContent}</CardContent>

--- a/src/sidebar/components/test/ThreadCard-test.js
+++ b/src/sidebar/components/test/ThreadCard-test.js
@@ -114,52 +114,6 @@ describe('ThreadCard', () => {
     });
   });
 
-  describe('keyboard events', () => {
-    ['Enter', ' '].forEach(key => {
-      it('scrolls to annotation when `Enter` or `Space` are pressed', () => {
-        const wrapper = createComponent();
-
-        wrapper.find(threadCardSelector).simulate('keydown', { key });
-
-        assert.calledWith(
-          fakeFrameSync.scrollToAnnotation,
-          fakeThread.annotation
-        );
-      });
-
-      it('does not scroll to annotation when event target is not the Card', () => {
-        const wrapper = createComponent();
-
-        // Trigger keydown through the prop itself, as `target` cannot be
-        // overwritten on an event
-        wrapper.find(threadCardSelector).prop('onKeyDown')({
-          key,
-          target: 'foo',
-        });
-
-        assert.notCalled(fakeFrameSync.scrollToAnnotation);
-      });
-
-      it('does not scroll to annotation when it is not set', () => {
-        const wrapper = createComponent({ thread: {} });
-
-        wrapper.find(threadCardSelector).simulate('keydown', { key });
-
-        assert.notCalled(fakeFrameSync.scrollToAnnotation);
-      });
-    });
-
-    ['a', 'b', 'Escape', 'ArrowDown'].forEach(key => {
-      it('does not scroll to annotation when key other than `Enter` or `Space` is pressed', () => {
-        const wrapper = createComponent();
-
-        wrapper.find(threadCardSelector).simulate('keypress', { key });
-
-        assert.notCalled(fakeFrameSync.scrollToAnnotation);
-      });
-    });
-  });
-
   describe('keyboard focus request handling', () => {
     [null, 'other-annotation'].forEach(focusRequest => {
       it('does not focus thread if there is no matching focus request', () => {


### PR DESCRIPTION
This PR rolls back the changes introduced in https://github.com/hypothesis/client/pull/5539 and https://github.com/hypothesis/client/pull/5570, that were trying to address https://github.com/hypothesis/product-backlog/issues/1425, as it has introduced a number of side effects we didn't foresee.

The change of making the annotation card focusable introduced a problem for users using assistive technology as it became difficult or impossible to "tab into" focusable elements within the annotation card.

We want to go back to the starting point and put some extra thinking in the problem afterwards.