### PR TITLE
Revise `pointer-events` handling for bucket bar container

### DIFF
--- a/src/annotator/sidebar.tsx
+++ b/src/annotator/sidebar.tsx
@@ -203,7 +203,11 @@ export class Sidebar implements Destroyable {
 
           // Use a grey background, with lower opacity with the sidebar is
           // collapsed, so the page content behind it can be read.
-          'bg-grey-2 sidebar-collapsed:bg-black/[.08]'
+          'bg-grey-2 sidebar-collapsed:bg-black/[.08]',
+
+          // Allow pointer events to go through this container to page elements
+          // (eg. scroll bar thumbs) which are behind it.
+          'pointer-events-none'
         );
         this.iframeContainer.append(sidebarEdge);
 


### PR DESCRIPTION
In 34521471252d40f706afbbf63a92fc8ab7f7a3aa the `pointer-events: none` style was removed from the bucket bar background. This fixed a problem where clicks in-between buckets (eg. when trying to click on a bucket) could cause the sidebar to close. It introduced a new issue however where it made clicking on page elements behind the bucket bar impossible. This can interfere with clicking on scroll bar thumbs in pages where the thumb gets drawn below the Hypothesis sidebar for example.

This PR fixes the issue by:

1. Re-adding the `pointer-events: none` style back to the bucket bar container
2. Adding code in the `Guest` to avoid closing the sidebar if the user clicks in the transparent areas of the bucket bar container. 

For added context, see https://github.com/hypothesis/support/issues/38#issuecomment-1614785180.

**Testing:**

1. Go to http://localhost:3000
2. Resize the window to be narrow enough that side-by-side is disabled
3. Click within the bucket bar just above or below a bucket. The sidebar should remain open.
4. Click elsewhere in the document. The sidebar should close.