### PR TITLE
Prevent side-by-side state getting out of sync between Guest and Integration

### DIFF
--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -216,7 +216,6 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
 
   private _bucketBarClient: BucketBarClient;
 
-  private _sideBySideActive: boolean;
   private _listeners: ListenerCollection;
 
   /**
@@ -314,8 +313,6 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
       hostRPC: this._hostRPC,
     });
 
-    this._sideBySideActive = false;
-
     // Setup event handlers on the root element
     this._listeners = new ListenerCollection();
     this._setupElementEvents();
@@ -334,15 +331,17 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
     // elements in the sidebar's vertical toolbar or adder won't close the
     // sidebar.
     const maybeCloseSidebar = (element: Element) => {
-      if (this._sideBySideActive) {
-        // Don't hide the sidebar if event was disabled because the sidebar
-        // doesn't overlap the content.
+      // Don't hide the sidebar if event was disabled because the sidebar
+      // doesn't overlap the content.
+      if (this._integration.sideBySideActive()) {
         return;
       }
+
+      // Don't hide the sidebar if the event comes from an element that contains a highlight
       if (annotationsAt(element).length) {
-        // Don't hide the sidebar if the event comes from an element that contains a highlight
         return;
       }
+
       this._sidebarRPC.call('closeSidebar');
     };
 
@@ -458,7 +457,7 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
       this.element.dispatchEvent(
         new LayoutChangeEvent({
           sidebarLayout,
-          sideBySideActive: this._sideBySideActive,
+          sideBySideActive: this._integration.sideBySideActive(),
         })
       );
     });
@@ -849,22 +848,7 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
    * @param sidebarLayout
    */
   fitSideBySide(sidebarLayout: SidebarLayout) {
-    this._sideBySideActive = this._integration.fitSideBySide(sidebarLayout);
-    this.element.classList.toggle(
-      'hypothesis-sidebyside-active',
-      this._sideBySideActive
-    );
-  }
-
-  /**
-   * Return true if side-by-side mode is currently active.
-   *
-   * Side-by-side mode is activated or de-activated when `fitSideBySide` is called
-   * depending on whether the sidebar is expanded and whether there is room for
-   * the content alongside the sidebar.
-   */
-  get sideBySideActive() {
-    return this._sideBySideActive;
+    this._integration.fitSideBySide(sidebarLayout);
   }
 
   /**

--- a/src/annotator/integrations/html.ts
+++ b/src/annotator/integrations/html.ts
@@ -168,7 +168,15 @@ export class HTMLIntegration extends TinyEmitter implements Integration {
       this._deactivateSideBySide();
     }
     this._sideBySideActive = active;
+    this.container.classList.toggle(
+      'hypothesis-sidebyside-active',
+      this._sideBySideActive
+    );
     return active;
+  }
+
+  sideBySideActive() {
+    return this._sideBySideActive;
   }
 
   /**

--- a/src/annotator/integrations/pdf.tsx
+++ b/src/annotator/integrations/pdf.tsx
@@ -94,6 +94,8 @@ export class PDFIntegration extends TinyEmitter implements Integration {
   private _reanchoringMaxWait: number;
   private _updateAnnotationLayerVisibility: () => void;
 
+  private _sideBySideActive: boolean;
+
   /**
    * @param annotator
    * @param options
@@ -137,6 +139,7 @@ export class PDFIntegration extends TinyEmitter implements Integration {
     };
     this._updateBannerState(this._bannerState);
     this._checkForSelectableText();
+    this._sideBySideActive = false;
 
     // Hide annotation layer when the user is making a selection. The annotation
     // layer appears above the invisible text layer and can interfere with text
@@ -416,7 +419,13 @@ export class PDFIntegration extends TinyEmitter implements Integration {
     // This will cause PDF pages to re-render if their scaling has changed
     this._pdfViewer.update();
 
+    this._sideBySideActive = active;
+
     return active;
+  }
+
+  sideBySideActive() {
+    return this._sideBySideActive;
   }
 
   /**

--- a/src/annotator/integrations/test/html-test.js
+++ b/src/annotator/integrations/test/html-test.js
@@ -183,6 +183,7 @@ describe('HTMLIntegration', () => {
     it('does nothing when disabled', () => {
       const integration = createIntegration();
       integration.fitSideBySide({});
+      assert.isFalse(integration.sideBySideActive());
     });
 
     context('when enabled', () => {
@@ -195,6 +196,7 @@ describe('HTMLIntegration', () => {
 
         integration.fitSideBySide({ expanded: true, width: sidebarWidth });
 
+        assert.isTrue(integration.sideBySideActive());
         assert.deepEqual(getMargins(), [padding, sidebarWidth + padding]);
       });
 
@@ -205,6 +207,7 @@ describe('HTMLIntegration', () => {
         // window.innerWidth (800) - 321 = 479 --> too small
         integration.fitSideBySide({ expanded: true, width: 321 });
 
+        assert.isFalse(integration.sideBySideActive());
         assert.deepEqual(getMargins(), [null, null]);
       });
 
@@ -337,6 +340,26 @@ describe('HTMLIntegration', () => {
           assert.equal(updatedMargins[0], expectedLeftMargin);
           assert.isBelow(updatedMargins[0], autoMargin);
         });
+      });
+
+      it('sets an html class on the element if side by side is activated', () => {
+        const integration = createIntegration();
+
+        integration.fitSideBySide({ expanded: true, width: 100 });
+
+        assert.isTrue(
+          integration.container.classList.contains(
+            'hypothesis-sidebyside-active'
+          )
+        );
+
+        integration.fitSideBySide({ expanded: false, width: 100 });
+
+        assert.isFalse(
+          integration.container.classList.contains(
+            'hypothesis-sidebyside-active'
+          )
+        );
       });
     });
 

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -398,6 +398,7 @@ describe('annotator/integrations/pdf', () => {
       it('resizes and activates side-by-side mode when sidebar expanded', () => {
         sandbox.stub(window, 'innerWidth').value(1350);
         pdfIntegration = createPDFIntegration();
+        assert.isFalse(pdfIntegration.sideBySideActive());
 
         const active = pdfIntegration.fitSideBySide({
           expanded: true,
@@ -406,6 +407,7 @@ describe('annotator/integrations/pdf', () => {
         });
 
         assert.isTrue(active);
+        assert.isTrue(pdfIntegration.sideBySideActive());
         assert.calledOnce(fakePDFViewerApplication.pdfViewer.update);
         assert.equal(pdfContainer().style.width, 'calc(100% - 428px)');
       });
@@ -430,6 +432,7 @@ describe('annotator/integrations/pdf', () => {
           });
 
           assert.isTrue(active);
+          assert.isTrue(pdfIntegration.sideBySideActive());
           assert.calledOnce(fakePDFViewerApplication.pdfViewer.update);
           assert.equal(pdfContainer().style.width, 'calc(100% - 428px)');
         });
@@ -447,6 +450,7 @@ describe('annotator/integrations/pdf', () => {
         });
 
         assert.isFalse(active);
+        assert.isFalse(pdfIntegration.sideBySideActive());
         assert.equal(pdfContainer().style.width, 'calc(100% - 115px)');
       });
 
@@ -462,6 +466,7 @@ describe('annotator/integrations/pdf', () => {
         });
 
         assert.isFalse(active);
+        assert.isFalse(pdfIntegration.sideBySideActive());
         assert.calledOnce(fakePDFViewerApplication.pdfViewer.update);
         assert.equal(pdfContainer().style.width, 'calc(100% - 115px)');
       });

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -79,6 +79,8 @@ describe('annotator/integrations/vitalsource', () => {
       fitSideBySide: sinon.stub().returns(false),
       getAnnotatableRange: sinon.stub().returnsArg(0),
       scrollToAnchor: sinon.stub(),
+      sideBySideActive: sinon.stub().returns(false),
+
       sideBySideEnabled: false,
     };
 
@@ -313,11 +315,13 @@ describe('annotator/integrations/vitalsource', () => {
       assert.isTrue(htmlOptions.features.flagEnabled('html_side_by_side'));
 
       fakeHTMLIntegration.fitSideBySide.returns(true);
+      fakeHTMLIntegration.sideBySideActive.returns(true);
       const layout = { expanded: true, width: 150 };
       const isActive = integration.fitSideBySide(layout);
 
       assert.isTrue(isActive);
       assert.calledWith(fakeHTMLIntegration.fitSideBySide, layout);
+      assert.isTrue(integration.sideBySideActive());
     });
 
     it('stops mouse events from propagating to parent frame', () => {
@@ -692,12 +696,16 @@ describe('annotator/integrations/vitalsource', () => {
           const sidebarWidth = window.innerWidth - 481;
           const expectedWidth = window.innerWidth - sidebarWidth;
           integration.fitSideBySide({ expanded: true, width: sidebarWidth });
+
+          assert.isTrue(integration.sideBySideActive());
           assert.equal(fakePageImage.parentElement.style.textAlign, 'left');
           assert.equal(fakePageImage.style.width, `${expectedWidth}px`);
           assert.calledOnce(fakeImageTextLayer.updateSync);
 
           // Deactivate side-by-side mode. Style overrides should be removed.
           integration.fitSideBySide({ expanded: false });
+
+          assert.isFalse(integration.sideBySideActive());
           assert.equal(fakePageImage.parentElement.style.textAlign, '');
           assert.equal(fakePageImage.style.width, '');
           assert.calledTwice(fakeImageTextLayer.updateSync);
@@ -710,6 +718,8 @@ describe('annotator/integrations/vitalsource', () => {
           // This will leave less than 480px available to the main content
           const sidebarWidth = window.innerWidth - 479;
           integration.fitSideBySide({ expanded: true, width: sidebarWidth });
+
+          assert.isFalse(integration.sideBySideActive());
           assert.equal(fakePageImage.parentElement.style.textAlign, '');
           assert.equal(fakePageImage.style.width, '');
         });

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -179,6 +179,7 @@ describe('Guest', () => {
       navigateToSegment: sinon.stub(),
       scrollToAnchor: sinon.stub().resolves(),
       showContentInfo: sinon.stub(),
+      sideBySideActive: sinon.stub().returns(false),
       uri: sinon.stub().resolves('https://example.com/test.pdf'),
     });
 
@@ -633,9 +634,7 @@ describe('Guest', () => {
 
     it('does not hide sidebar if side-by-side mode is active', () => {
       for (let event of ['mousedown', 'touchstart']) {
-        // Activate side-by-side mode
-        fakeIntegration.fitSideBySide.returns(true);
-        guest.fitSideBySide({ expanded: true, width: 100 });
+        fakeIntegration.sideBySideActive.returns(true);
 
         rootElement.dispatchEvent(new Event(event));
 
@@ -1546,38 +1545,6 @@ describe('Guest', () => {
       guest.fitSideBySide(layout);
 
       assert.calledWith(fakeIntegration.fitSideBySide, layout);
-    });
-
-    it('sets an html class on the element if side by side is activated', () => {
-      const guest = createGuest();
-      fakeIntegration.fitSideBySide.returns(true);
-      const layout = { expanded: true, width: 100 };
-
-      guest.fitSideBySide(layout);
-
-      assert.isTrue(
-        guest.element.classList.contains('hypothesis-sidebyside-active')
-      );
-
-      fakeIntegration.fitSideBySide.returns(false);
-      guest.fitSideBySide(layout);
-
-      assert.isFalse(
-        guest.element.classList.contains('hypothesis-sidebyside-active')
-      );
-    });
-
-    it('enables closing sidebar on document click if side-by-side is not activated', () => {
-      const guest = createGuest();
-      fakeIntegration.fitSideBySide.returns(false);
-      const layout = { expanded: true, width: 100 };
-
-      guest.fitSideBySide(layout);
-      assert.isFalse(guest.sideBySideActive);
-
-      fakeIntegration.fitSideBySide.returns(true);
-      guest.fitSideBySide(layout);
-      assert.isTrue(guest.sideBySideActive);
     });
   });
 

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -183,6 +183,16 @@ export type IntegrationBase = {
   fitSideBySide(layout: SidebarLayout): boolean;
 
   /**
+   * Return true if side-by-side mode is currently active.
+   *
+   * In most cases this will only change when `fitSideBySide` is called, but in
+   * some integrations this may change at other times. For example this can
+   * happen if the content layout changed and there is more or less room than
+   * before.
+   */
+  sideBySideActive(): boolean;
+
+  /**
    * Return a DOM Range representing the extent of annotatable content within
    * `range`, or `null` if `range` does not contain any annotatable content.
    * For example, `range` might be trimmed of leading or trailing whitespace.


### PR DESCRIPTION
Both the `Guest` and `HTMLIntegration` maintained separate state for whether side-by-side mode was active or not. These states could get out of sync if the side-by-side feature flag was disabled when the guest first called `fitSideBySide` and then later enabled, as a result of the user logging into a different profile. In that case side-by-side would be enabled from the integration's perspective, but `Guest._sideBySideActive` would remain false.

More generally this mismatch could occur in future if, for any reason, the integration decided to disable side-by-side outside of the context of a call to `fitSideBySide`.

The result of this error was that clicking somewhere in the page would cause the sidebar to close, because the Guest thought that side-by-side was disabled, even though it was actually active.

**Testing:**

1. Enable the `html_side_by_side` feature flag for everyone
2. Go to http://localhost:3000 and wait for the sidebar to load and open
3. Click somewhere in the document

Since the feature flag is active, side-by-side mode should be enabled and the sidebar should remain open after step 3. On `main` however the sidebar closes. If the sidebar is then opened again, it remains open after clicking in the document. On this branch, the sidebar remains open after step 3.