### PR TITLE
Deactivate side-by-side mode when client is unloaded

### DIFF
--- a/src/annotator/integrations/html.ts
+++ b/src/annotator/integrations/html.ts
@@ -148,6 +148,7 @@ export class HTMLIntegration extends TinyEmitter implements Integration {
   }
 
   destroy() {
+    this._deactivateSideBySide();
     this._navObserver.disconnect();
     this._metaObserver.disconnect();
     this.features.off('flagsChanged', this._flagsChanged);

--- a/src/annotator/integrations/pdf.tsx
+++ b/src/annotator/integrations/pdf.tsx
@@ -167,6 +167,14 @@ export class PDFIntegration extends TinyEmitter implements Integration {
   }
 
   destroy() {
+    this.fitSideBySide({
+      // Dummy layout that will cause side-by-side mode to be undone.
+      expanded: false,
+      width: 0,
+      toolbarWidth: 0,
+      height: window.innerHeight,
+    });
+
     this._listeners.removeAll();
     this._pdfViewer.viewer.classList.remove('has-transparent-text-layer');
     this._observer.disconnect();

--- a/src/annotator/integrations/test/html-test.js
+++ b/src/annotator/integrations/test/html-test.js
@@ -88,7 +88,7 @@ describe('HTMLIntegration', () => {
 
   // Generate a dummy response for `guessMainContentArea`. This response
   // is what would be returned when the content fills the full width of the
-  // viewport, mins space for an open sidebar and some padding.
+  // viewport, minus space for an open sidebar and some padding.
   //
   // The sidebar space is included because `fitSideBySide` adjusts the margins
   // on the body before calling `guessMainContentArea`.

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -244,6 +244,19 @@ describe('annotator/integrations/pdf', () => {
           )
         );
       });
+
+      it('undoes side-by-side layout changes', () => {
+        pdfIntegration = createPDFIntegration();
+        pdfIntegration.fitSideBySide({
+          expanded: true,
+          width: 100,
+        });
+        assert.isTrue(pdfIntegration.sideBySideActive());
+
+        pdfIntegration.destroy();
+
+        assert.isFalse(pdfIntegration.sideBySideActive());
+      });
     });
 
     function getBanner() {

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -275,15 +275,28 @@ describe('annotator/integrations/vitalsource', () => {
   }
 
   describe('VitalSourceContentIntegration', () => {
+    // List of active integrations.
     let integrations;
+
     let fakeBookElement;
 
+    /** Create a new integration and add it to the active list. */
     function createIntegration() {
       const integration = new VitalSourceContentIntegration(document.body, {
         bookElement: fakeBookElement,
       });
       integrations.push(integration);
       return integration;
+    }
+
+    /** Destroy an integration and remove it from the active list. */
+    function destroyIntegration(integration) {
+      const idx = integrations.indexOf(integration);
+      if (idx === -1) {
+        throw new Error('Integration is not in list of active integrations');
+      }
+      integrations.splice(idx, 1);
+      integration.destroy();
     }
 
     beforeEach(() => {
@@ -683,6 +696,18 @@ describe('annotator/integrations/vitalsource', () => {
         integration.destroy();
 
         assert.calledOnce(fakeImageTextLayer.destroy);
+      });
+
+      it('disables side-by-side mode when destroyed', () => {
+        createPageImageAndData();
+        const integration = createIntegration();
+
+        integration.fitSideBySide({ expanded: true, width: 100 });
+        assert.isTrue(integration.sideBySideActive());
+
+        destroyIntegration(integration);
+
+        assert.isFalse(integration.sideBySideActive());
       });
 
       context('when side-by-side mode is toggled', () => {

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -308,7 +308,19 @@ export class VitalSourceContentIntegration
   }
 
   destroy() {
-    this._textLayer?.destroy();
+    if (this._textLayer) {
+      this._textLayer.destroy();
+
+      // Turn off side-by-side for PDF books. For EPUBs this is handled by
+      // `this._htmlIntegration.destroy()`.
+      this.fitSideBySide({
+        // Dummy layout. Setting `expanded: false` disables side-by-side mode.
+        expanded: false,
+        height: window.innerHeight,
+        width: 0,
+        toolbarWidth: 0,
+      });
+    }
     this._listeners.removeAll();
     this._htmlIntegration.destroy();
   }


### PR DESCRIPTION
Make the `destroy` method of the `*Integration` classes undo any layout changes that were made to enable side-by-side mode. This reverts the layout of the web page / app to its original state when the client is unloaded.

This is mainly relevant in the browser extension, but other pages might have reasons to support unloading the client.

**Testing:**

1. Go to http://localhost:3000
2. Make the window narrow enough that some side-by-side effects can be seen, but not so narrow that it deactivates entirely
3. Click the "Unload client" button on the page. The side-by-side changes (eg. making lines wrap) should be undone.

This can also be tested with the extension locally. De-activating the extension should undo side-by-side changes. For PDFs this change is not relevant most of the time since de-activating the extension leaves our PDF.js-based viewer and returns to the native viewer. However it is possible to test the extension's PDF integration outside of the bundled viewer using https://mozilla.github.io/pdf.js/legacy/web/viewer.html.