### PR TITLE
Eliminate a few coverage misses

### DIFF
--- a/src/annotator/adder.tsx
+++ b/src/annotator/adder.tsx
@@ -339,8 +339,6 @@ export class Adder implements Destroyable {
         case 'hide':
           this.hide();
           break;
-        default:
-          break;
       }
     };
 

--- a/src/annotator/components/test/AdderToolbar-test.js
+++ b/src/annotator/components/test/AdderToolbar-test.js
@@ -9,7 +9,6 @@ describe('AdderToolbar', () => {
     mount(
       <AdderToolbar
         direction="up"
-        annotationCount={0}
         onCommand={() => {}}
         isVisible={true}
         {...props}

--- a/src/annotator/components/test/Toolbar-test.js
+++ b/src/annotator/components/test/Toolbar-test.js
@@ -16,7 +16,6 @@ describe('Toolbar', () => {
         isSidebarOpen={false}
         showHighlights={false}
         newAnnotationType="note"
-        useMinimalControls={false}
         {...props}
       />
     );

--- a/src/annotator/integrations/pdf.tsx
+++ b/src/annotator/integrations/pdf.tsx
@@ -104,6 +104,7 @@ export class PDFIntegration extends TinyEmitter implements Integration {
    */
   constructor(
     annotator: Annotator,
+    /* istanbul ignore next */
     options: { reanchoringMaxWait?: number } = {}
   ) {
     super();

--- a/src/sidebar/components/FilterStatus.tsx
+++ b/src/sidebar/components/FilterStatus.tsx
@@ -17,16 +17,16 @@ type FilterStatusMessageProps = {
    * A count of items that are visible but do not match the filters (i.e. items
    * that have been "forced visible" by the user)
    */
-  additionalCount?: number;
+  additionalCount: number;
 
   /** Singular unit of the items being shown, e.g. "result" or "annotation" */
-  entitySingular?: string;
+  entitySingular: string;
 
   /** Plural unit of the items being shown */
-  entityPlural?: string;
+  entityPlural: string;
 
   /** Currently-applied filter query string, if any */
-  filterQuery?: string | null;
+  filterQuery: string | null;
 
   /** Display name for the user currently focused, if any */
   focusDisplayName?: string | null;
@@ -44,9 +44,9 @@ type FilterStatusMessageProps = {
  * Render status text describing the currently-applied filters.
  */
 function FilterStatusMessage({
-  additionalCount = 0,
-  entitySingular = 'annotation',
-  entityPlural = 'annotations',
+  additionalCount,
+  entitySingular,
+  entityPlural,
   filterQuery,
   focusDisplayName,
   resultCount,

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -119,8 +119,6 @@ function handleToolbarCommand(
     case 'list':
       update(state => toggleBlockStyle(state, '* '));
       break;
-    default:
-      throw new Error(`Unknown toolbar command "${command}"`);
   }
 }
 
@@ -331,7 +329,7 @@ export type MarkdownEditorProps = {
   textStyle?: Record<string, string>;
 
   /** The markdown text to edit */
-  text?: string;
+  text: string;
 
   onEditText?: (text: string) => void;
 };
@@ -340,9 +338,9 @@ export type MarkdownEditorProps = {
  * Viewer/editor for the body of an annotation in markdown format.
  */
 export default function MarkdownEditor({
-  label = '',
+  label,
   onEditText = () => {},
-  text = '',
+  text,
   textStyle = {},
 }: MarkdownEditorProps) {
   // Whether the preview mode is currently active.

--- a/src/sidebar/helpers/build-thread.ts
+++ b/src/sidebar/helpers/build-thread.ts
@@ -93,7 +93,7 @@ function hasPathToRoot(
 function setParent(
   threads: Record<string, Thread>,
   id: string,
-  parents: string[] = []
+  parents: string[]
 ) {
   if (threads[id].parent || !parents.length) {
     // Parent already assigned, do not try to change it.

--- a/src/sidebar/service-context.tsx
+++ b/src/sidebar/service-context.tsx
@@ -76,6 +76,7 @@ export function withServices<
       // Debugging check to make sure the store is used correctly.
       if (process.env.NODE_ENV !== 'production') {
         if (service === 'store') {
+          /* istanbul ignore next - Ignore debug code */
           throw new Error(
             'Do not use `withServices` to inject the `store` service. Use the `useStore` hook instead'
           );

--- a/src/sidebar/util/immutable.ts
+++ b/src/sidebar/util/immutable.ts
@@ -31,6 +31,7 @@ function deepFreeze<T extends object>(object: T) {
  */
 export function immutable<T extends object>(object: T) {
   if (process.env.NODE_ENV === 'production') {
+    /* istanbul ignore next */
     return object;
   } else {
     return deepFreeze(object);

--- a/src/sidebar/util/postmessage-json-rpc.ts
+++ b/src/sidebar/util/postmessage-json-rpc.ts
@@ -26,6 +26,7 @@ export function call<T>(
   method: string,
   /* istanbul ignore next */
   params: unknown[] = [],
+  /* istanbul ignore next */
   timeout = 2000,
   /* istanbul ignore next */
   window_: Window = window


### PR DESCRIPTION
 - Remove unused `default`s for `switch` statements
 - Fix coverage misses related to un-evaluated default arguments by either:

   - Removing the default if we always set the argument
   - Removing overrides in tests which are the same as the default
   - Ignoring the default for coverage purposes