### PR TITLE
Add customizable side-by-side mode to HTMLIntegration

### DIFF
--- a/src/annotator/integrations/test/html-test.js
+++ b/src/annotator/integrations/test/html-test.js
@@ -64,8 +64,8 @@ describe('HTMLIntegration', () => {
     $imports.$restore();
   });
 
-  function createIntegration() {
-    return new HTMLIntegration({ features });
+  function createIntegration(sideBySideOptions) {
+    return new HTMLIntegration({ features, sideBySideOptions });
   }
 
   it('implements `anchor` and `destroy` using HTML anchoring', async () => {
@@ -378,6 +378,18 @@ describe('HTMLIntegration', () => {
       assert.isTrue(isSideBySideActive());
 
       features.update({ html_side_by_side: false });
+      assert.isFalse(isSideBySideActive());
+    });
+
+    it('manual side-by-side is not changed by enabled feature flag', () => {
+      features.update({ html_side_by_side: true });
+      const integration = createIntegration({ mode: 'manual' });
+
+      integration.fitSideBySide({ expanded: true, width: sidebarWidth });
+      assert.isFalse(isSideBySideActive());
+
+      // Even if the feature flag is enabled, side-by-side stays disabled/manual
+      features.update({ html_side_by_side: true });
       assert.isFalse(isSideBySideActive());
     });
   });

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -336,3 +336,16 @@ export type DocumentInfo = {
    */
   persistent: boolean;
 };
+
+/**
+ * `auto`: The client will decide if side-by-side is enabled. If enabled, it
+ *         will apply some heuristics to determine how the content is affected.
+ *         This is default value.
+ * `manual`: The host app wants to manually take full control of side-by-side,
+ *           effectively disabling the logic in client.
+ */
+export type SideBySideMode = 'auto' | 'manual';
+
+export type SideBySideOptions = {
+  mode: SideBySideMode;
+};


### PR DESCRIPTION
This PR introduces options in `HTMLIntegration`, designed for host applications to have more control over `side-by-side` mode.

Currently, the only supported option is `mode`, which can take these values:

* `auto`: It's the client's default value. It will apply some heuristics to determine how the content is affected.
* `manual`: expresses the intention of the host app to take control of side-by-side, disabling the logic in the client.

### This PR does not cover

* How host apps provide these options: https://github.com/hypothesis/client/pull/5605
* ~How these options apply to other integrations (PDF and VitalSource).~ We won't support this for now

These will come in follow-up PRs and discussions.

> This PR is part of https://github.com/hypothesis/client/issues/5571