### PR TITLE
Side by side host config

### DIFF
--- a/dev-server/templates/client-config.js.mustache
+++ b/dev-server/templates/client-config.js.mustache
@@ -29,6 +29,11 @@
       //   groups: ['a-group-id', 'another-group-id'],
       // }],
 
+      // Example side-by-side config
+      // sideBySide: {
+      //   mode: 'manual'
+      // },
+
       // Open the sidebar when the page loads
       openSidebar: true,
 

--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -450,6 +450,39 @@ loads.
                               // relative from the receiving iframe.
     }
 
+.. option:: sideBySide
+
+  ``Object``. This option lets you customize how side-by-side mode behaves.
+
+  .. note::
+
+    Side-by-side mode allows the space used by the web page's main content
+    area to be adapted while the sidebar is open, ensuring it does not overlap
+    with annotatable content.
+
+  For example:
+
+  .. code-block:: javascript
+
+     window.hypothesisConfig = () => ({
+       sideBySide: {
+         mode: 'manual'
+       }
+     });
+
+  The following keys are supported in the :option:`sideBySide` object.
+
+  .. option:: mode
+
+    ``auto`` or ``manual``. Auto is the default value, where the main page
+    content will be automatically resized to fit alongside the sidebar, while manual
+    indicates the web page wants to take full control of handling side-by-side.
+    This disables automatic resizing of the content.
+
+    When setting it to ``manual``, you should
+    `listen for layout changes </publishers/events/#cmdoption-arg-hypothesis-layoutchange>`_
+    and adapt content to fit alongside the sidebar, if it is reasonable to do so.
+
 Asset and Sidebar App Location
 ##############################
 
@@ -465,7 +498,7 @@ These settings configure where the client's assets are loaded from.
    the URL where the contents of the hypothesis package are hosted, including
    the trailing slash. (Default: for production builds:
    ``"https://cdn.hypothes.is/hypothesis/X.Y.Z/"``, for development builds:
-   ``"http://localhost:3001/hypothesis/X.Y.Z/""`.
+   ``"http://localhost:3001/hypothesis/X.Y.Z/"``.
    ``X.Y.Z`` is the package version from ``package.json``).
 
 .. option:: sidebarAppUrl

--- a/src/annotator/config/index.ts
+++ b/src/annotator/config/index.ts
@@ -31,12 +31,21 @@ type ConfigDefinitionMap = Record<string, ConfigDefinition>;
  */
 type Context = 'sidebar' | 'notebook' | 'profile' | 'annotator' | 'all';
 
+function throwInvalidContext(context: string): never {
+  throw new Error(`Invalid application context used: "${context}"`);
+}
+
 /**
  * Returns the configuration keys that are relevant to a particular context.
  */
 function configurationKeys(context: Context): string[] {
   const contexts = {
-    annotator: ['clientUrl', 'contentInfoBanner', 'subFrameIdentifier'],
+    annotator: [
+      'clientUrl',
+      'contentInfoBanner',
+      'subFrameIdentifier',
+      'sideBySide',
+    ],
     sidebar: [
       'appType',
       'annotations',
@@ -68,21 +77,12 @@ function configurationKeys(context: Context): string[] {
     profile: ['profileAppUrl'],
   };
 
-  switch (context) {
-    case 'annotator':
-      return contexts.annotator;
-    case 'sidebar':
-      return contexts.sidebar;
-    case 'notebook':
-      return contexts.notebook;
-    case 'profile':
-      return contexts.profile;
-    case 'all':
-      // Complete list of configuration keys used for testing.
-      return Object.values(contexts).flat();
-    default:
-      throw new Error(`Invalid application context used: "${context}"`);
+  if (context === 'all') {
+    // Complete list of configuration keys used for testing.
+    return Object.values(contexts).flat();
   }
+
+  return contexts[context] ?? throwInvalidContext(context);
 }
 
 const getHostPageSetting: ValueGetter = (settings, name) =>
@@ -206,6 +206,10 @@ const configDefinitions: ConfigDefinitionMap = {
     allowInBrowserExt: false,
     defaultValue: null,
     getValue: getHostPageSetting,
+  },
+  sideBySide: {
+    allowInBrowserExt: true,
+    getValue: settings => settings.sideBySide,
   },
 };
 

--- a/src/annotator/config/settings.ts
+++ b/src/annotator/config/settings.ts
@@ -1,6 +1,9 @@
 import { parseJsonConfig } from '../../boot/parse-json-config';
 import { hasOwn } from '../../shared/has-own';
+import { isObject } from '../../shared/is-object';
 import { toBoolean } from '../../shared/type-coercions';
+import type { SideBySideOptions } from '../../types/annotator';
+import { isSideBySideMode } from '../integrations/html-side-by-side';
 import { configFuncSettingsFrom } from './config-func-settings-from';
 import { urlFromLinkTag } from './url-from-link-tag';
 
@@ -14,6 +17,7 @@ export type SettingsGetters = {
   notebookAppUrl: string;
   profileAppUrl: string;
   hostPageSetting: (name: string) => unknown;
+  sideBySide: SideBySideOptions;
 };
 
 /**
@@ -39,7 +43,7 @@ export function settingsFrom(window_: Window): SettingsGetters {
    * Return the `#annotations:*` ID from the given URL's fragment.
    *
    * If the URL contains a `#annotations:<ANNOTATION_ID>` fragment then return
-   * the annotation ID extracted from the fragment. Otherwise return `null`.
+   * the annotation ID extracted from the fragment. Otherwise, return `null`.
    *
    * @return The extracted ID, or null.
    */
@@ -99,16 +103,27 @@ export function settingsFrom(window_: Window): SettingsGetters {
     }
   }
 
+  function sideBySide(): SideBySideOptions {
+    const value = hostPageSetting('sideBySide');
+
+    return {
+      mode:
+        !isObject(value) || !('mode' in value) || !isSideBySideMode(value.mode)
+          ? 'auto'
+          : value.mode,
+    };
+  }
+
   /**
    * Return the config.query setting from the host page or from the URL.
    *
    * If the host page contains a js-hypothesis-config script containing a
    * query setting then return that.
    *
-   * Otherwise if the host page's URL has a `#annotations:query:*` (or
+   * Otherwise, if the host page's URL has a `#annotations:query:*` (or
    * `#annotations:q:*`) fragment then return the query value from that.
    *
-   * Otherwise return null.
+   * Otherwise, return null.
    *
    * @return The config.query setting, or null.
    */
@@ -177,6 +192,9 @@ export function settingsFrom(window_: Window): SettingsGetters {
     },
     get query() {
       return query();
+    },
+    get sideBySide() {
+      return sideBySide();
     },
     hostPageSetting,
   };

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -16,6 +16,7 @@ describe('annotator/config/index', () => {
       showHighlights: 'fakeValue',
       sidebarAppUrl: 'fakeValue',
       query: 'fakeValue',
+      sideBySide: { mode: 'auto' },
     });
     fakeIsBrowserExtension = sinon.stub();
 
@@ -96,6 +97,7 @@ describe('annotator/config/index', () => {
             subFrameIdentifier: 'fakeValue',
             theme: null,
             usernameUrl: null,
+            sideBySide: { mode: 'auto' },
           },
           config
         );
@@ -130,6 +132,7 @@ describe('annotator/config/index', () => {
             subFrameIdentifier: 'fakeValue',
             theme: 'fakeValue',
             usernameUrl: 'fakeValue',
+            sideBySide: { mode: 'auto' },
           },
           config
         );
@@ -227,7 +230,12 @@ describe('annotator/config/index', () => {
     [
       {
         app: 'annotator',
-        expectedKeys: ['clientUrl', 'contentInfoBanner', 'subFrameIdentifier'],
+        expectedKeys: [
+          'clientUrl',
+          'contentInfoBanner',
+          'subFrameIdentifier',
+          'sideBySide',
+        ],
       },
       {
         app: 'sidebar',

--- a/src/annotator/config/test/settings-test.js
+++ b/src/annotator/config/test/settings-test.js
@@ -395,4 +395,47 @@ describe('annotator/config/settingsFrom', () => {
       });
     });
   });
+
+  describe('#sideBySide', () => {
+    [
+      {
+        input: 'foo',
+        expectedResult: { mode: 'auto' },
+      },
+      {
+        input: {},
+        expectedResult: { mode: 'auto' },
+      },
+      {
+        input: { mode: 'invalid' },
+        expectedResult: { mode: 'auto' },
+      },
+      {
+        input: { mode: 'auto' },
+        expectedResult: { mode: 'auto' },
+      },
+      {
+        input: { mode: 'manual' },
+        expectedResult: { mode: 'manual' },
+      },
+    ].forEach(({ input, expectedResult }) => {
+      it('parses config from script', () => {
+        fakeParseJsonConfig.returns({
+          sideBySide: input,
+        });
+        const settings = settingsFrom(fakeWindow());
+
+        assert.deepEqual(settings.sideBySide, expectedResult);
+      });
+
+      it('parses config from window', () => {
+        fakeConfigFuncSettingsFrom.returns({
+          sideBySide: input,
+        });
+        const settings = settingsFrom(fakeWindow());
+
+        assert.deepEqual(settings.sideBySide, expectedResult);
+      });
+    });
+  });
 });

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -13,6 +13,7 @@ import type {
   DocumentInfo,
   Integration,
   SidebarLayout,
+  SideBySideOptions,
 } from '../types/annotator';
 import type { Target } from '../types/api';
 import type {
@@ -103,6 +104,8 @@ export type GuestConfig = {
 
   /** Configures a banner or other indicators showing where the content has come from. */
   contentInfoBanner?: ContentInfoConfig;
+
+  sideBySide?: SideBySideOptions;
 };
 
 /**
@@ -182,6 +185,8 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
   public anchors: Anchor[];
 
   public features: FeatureFlags;
+
+  public sideBySide?: SideBySideOptions;
 
   /** Promise that resolves when feature flags are received from the sidebar. */
   private _featureFlagsReceived: Promise<void>;
@@ -291,6 +296,8 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
     this._featureFlagsReceived = new Promise(resolve => {
       this.features.on('flagsChanged', resolve);
     });
+
+    this.sideBySide = config.sideBySide;
 
     this._integration = createIntegration(this);
     this._integration.on('uriChanged', () => this._sendDocumentInfo());

--- a/src/annotator/integrations/html-side-by-side.ts
+++ b/src/annotator/integrations/html-side-by-side.ts
@@ -1,3 +1,4 @@
+import type { SideBySideMode } from '../../types/annotator';
 import { rectContains, rectIntersects } from '../util/geometry';
 import { nodeIsElement, nodeIsText } from '../util/node';
 
@@ -227,4 +228,8 @@ export function preserveScrollPosition(
   scrollRoot.scrollTop += scrollDelta;
 
   return scrollDelta;
+}
+
+export function isSideBySideMode(mode: unknown): mode is SideBySideMode {
+  return typeof mode === 'string' && ['auto', 'manual'].includes(mode);
 }

--- a/src/annotator/integrations/index.ts
+++ b/src/annotator/integrations/index.ts
@@ -20,5 +20,8 @@ export function createIntegration(annotator: Annotator): Integration {
     return new VitalSourceContentIntegration(document.body);
   }
 
-  return new HTMLIntegration({ features: annotator.features });
+  return new HTMLIntegration({
+    features: annotator.features,
+    sideBySideOptions: annotator.sideBySide,
+  });
 }

--- a/src/annotator/integrations/test/html-side-by-side-test.js
+++ b/src/annotator/integrations/test/html-side-by-side-test.js
@@ -1,5 +1,6 @@
 import {
   guessMainContentArea,
+  isSideBySideMode,
   preserveScrollPosition,
 } from '../html-side-by-side';
 
@@ -252,6 +253,21 @@ the fighting was.`;
 
       assert.equal(delta, 0);
       assert.equal(scrollRoot.scrollTop, initialScrollTop);
+    });
+  });
+
+  describe('isSideBySideMode', () => {
+    [
+      { mode: 'auto', expectedResult: true },
+      { mode: 'manual', expectedResult: true },
+      { mode: 'invalid', expectedResult: false },
+      { mode: 123, expectedResult: false },
+      { mode: {}, expectedResult: false },
+      { mode: false, expectedResult: false },
+    ].forEach(({ mode, expectedResult }) => {
+      it('returns expected result for different modes', () => {
+        assert.equal(expectedResult, isSideBySideMode(mode));
+      });
     });
   });
 });

--- a/src/shared/is-object.ts
+++ b/src/shared/is-object.ts
@@ -1,0 +1,3 @@
+export function isObject(value: unknown): value is object {
+  return value !== null && typeof value === 'object';
+}

--- a/src/shared/test/is-object-test.js
+++ b/src/shared/test/is-object-test.js
@@ -1,0 +1,20 @@
+import { isObject } from '../is-object';
+
+describe('isObject', () => {
+  [
+    { value: {}, expectedResult: true },
+    { value: { foo: 'bar' }, expectedResult: true },
+    { value: [], expectedResult: true },
+    { value: new Event(''), expectedResult: true },
+    { value: new Error(''), expectedResult: true },
+    { value: null, expectedResult: false },
+    { value: undefined, expectedResult: false },
+    { value: 'foo', expectedResult: false },
+    { value: 123, expectedResult: false },
+    { value: () => {}, expectedResult: false },
+  ].forEach(({ value, expectedResult }) => {
+    it('returns expected result', () => {
+      assert.equal(expectedResult, isObject(value));
+    });
+  });
+});

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -134,6 +134,7 @@ export type Annotator = {
   anchors: Anchor[];
   anchor(ann: AnnotationData): Promise<Anchor[]>;
   features: FeatureFlags;
+  sideBySide?: SideBySideOptions;
 };
 
 /**


### PR DESCRIPTION
This PR adds the logic needed to parse `sideBySide` config options and pass them to the `HTMLIntegration` by guest object.

It also documents the shape of the `sideBySide` config object.

### Testing steps

* With the feature flag enabled:
  1. Make sure you have `html_side_by_side` enabled for your user or all users in your local h instance: http://localhost:5000/admin/features
  2. Go to http://localhost:3000. The sidebar should be kept open if you click/interact with the main content.
  3. Now edit the `client-config.js.mustache` file, uncommenting the `sideBySide` config block
      ```diff
      - // sideBySide: {
      - //   mode: 'manual'
      - // },
      + sideBySide: {
      +   mode: 'manual'
      + },
      ```
  4. Repeat step 2, but this time, clicking/interacting with the main content should close the sidebar, which means side-by-side was "disabled".
* With the feature flag disabled:
  1. Make sure you have `html_side_by_side` disabled for your user or all users in your local h instance: http://localhost:5000/admin/features
  2. Go to http://localhost:3000. The sidebar should get closed if you click/interact with the main content.
  3. Now edit the `client-config.js.mustache` file, setting the `mode` to `auto`.
      ```diff
      sideBySide: {
      -   mode: 'manual'
      +   mode: 'auto'
      },
      ```
  4. Repeat step 2. The behavior should still be the same, as the feature flag takes precedence and does not allow to explicitly "enable" side-by-side.

> This PR is part of https://github.com/hypothesis/client/issues/5571