### PR TITLE
Use shared `Callout` for toast-message styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "^2.0.0",
-    "@hypothesis/frontend-shared": "^6.0.0",
+    "@hypothesis/frontend-shared": "^6.4.0",
     "@npmcli/arborist": "^6.1.1",
     "@octokit/rest": "^19.0.3",
     "@rollup/plugin-babel": "^6.0.0",

--- a/src/shared/components/BaseToastMessages.tsx
+++ b/src/shared/components/BaseToastMessages.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  Link,
-  CancelIcon,
-  CautionIcon,
-  CheckIcon,
-} from '@hypothesis/frontend-shared';
+import { Callout, Link } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 export type ToastMessage = {
@@ -34,72 +28,40 @@ function ToastMessageItem({ message, onDismiss }: ToastMessageItemProps) {
       ? `${message.type.charAt(0).toUpperCase() + message.type.slice(1)}: `
       : '';
 
-  let Icon;
-  switch (message.type) {
-    case 'success':
-      Icon = CheckIcon;
-      break;
-    case 'error':
-      Icon = CancelIcon;
-      break;
-    case 'notice':
-    default:
-      Icon = CautionIcon;
-      break;
-  }
   /**
-   * a11y linting is disabled here: There is a click-to-remove handler on a
-   * non-interactive element. This allows sighted users to get the toast message
-   * out of their way if it interferes with interacting with the underlying
-   * components. This shouldn't pose the same irritation to users with screen-
-   * readers as the rendered toast messages shouldn't impede interacting with
-   * the underlying document.
+   * There is a click-to-remove handler on a non-interactive element. This
+   * allows sighted users to get the toast message out of their way if it
+   * interferes with interacting with the underlying components. This shouldn't
+   * pose the same irritation to users with screen- readers as the rendered
+   * toast messages shouldn't impede interacting with the underlying document.
    */
   return (
-    /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */
-    <Card
-      classes={classnames('flex', {
+    <Callout
+      classes={classnames({
         'sr-only': message.visuallyHidden,
-        'border-red-error': message.type === 'error',
-        'border-yellow-notice': message.type === 'notice',
-        'border-green-success': message.type === 'success',
       })}
+      status={message.type}
       onClick={() => onDismiss(message.id)}
+      variant="raised"
     >
-      <div
-        className={classnames('flex items-center p-3 text-white', {
-          'bg-red-error': message.type === 'error',
-          'bg-yellow-notice': message.type === 'notice',
-          'bg-green-success': message.type === 'success',
-        })}
-      >
-        <Icon
-          className={classnames(
-            // Adjust alignment of icon to appear more aligned with text
-            'mt-[2px]'
-          )}
-        />
-      </div>
-      <div className="grow p-3" data-testid="toast-message-text">
-        <strong>{prefix}</strong>
-        {message.message}
-        {message.moreInfoURL && (
-          <div className="text-right">
-            <Link
-              href={message.moreInfoURL}
-              onClick={
-                event =>
-                  event.stopPropagation() /* consume the event so that it does not dismiss the message */
-              }
-              target="_new"
-              underline="none"
-            >
-              More info
-            </Link>
-          </div>
-        )}
-      </div>
-    </Card>
+      <strong>{prefix}</strong>
+      {message.message}
+      {message.moreInfoURL && (
+        <div className="text-right">
+          <Link
+            href={message.moreInfoURL}
+            onClick={
+              event =>
+                event.stopPropagation() /* consume the event so that it does not dismiss the message */
+            }
+            target="_new"
+            underline="none"
+          >
+            More info
+          </Link>
+        </div>
+      )}
+    </Callout>
   );
 }
 
@@ -128,25 +90,22 @@ export default function BaseToastMessages({
       >
         {messages.map(message => (
           <li
-            className={classnames(
-              'relative w-full container hover:cursor-pointer',
-              {
-                // Add a bottom margin to visible messages only. Typically, we'd
-                // use a `space-y-2` class on the parent to space children.
-                // Doing that here could cause an undesired top margin on
-                // the first visible message in a list that contains (only)
-                // visually-hidden messages before it.
-                // See https://tailwindcss.com/docs/space#limitations
-                'mb-2': !message.visuallyHidden,
-                // Slide in from right in narrow viewports; fade in larger
-                // viewports to toast message isn't flying too far
-                'motion-safe:animate-slide-in-from-right lg:animate-fade-in':
-                  !message.isDismissed,
-                // Only ever fade in if motion-reduction is preferred
-                'motion-reduce:animate-fade-in': !message.isDismissed,
-                'animate-fade-out': message.isDismissed,
-              }
-            )}
+            className={classnames('relative w-full container', {
+              // Add a bottom margin to visible messages only. Typically, we'd
+              // use a `space-y-2` class on the parent to space children.
+              // Doing that here could cause an undesired top margin on
+              // the first visible message in a list that contains (only)
+              // visually-hidden messages before it.
+              // See https://tailwindcss.com/docs/space#limitations
+              'mb-2': !message.visuallyHidden,
+              // Slide in from right in narrow viewports; fade in larger
+              // viewports to toast message isn't flying too far
+              'motion-safe:animate-slide-in-from-right lg:animate-fade-in':
+                !message.isDismissed,
+              // Only ever fade in if motion-reduction is preferred
+              'motion-reduce:animate-fade-in': !message.isDismissed,
+              'animate-fade-out': message.isDismissed,
+            })}
             key={message.id}
           >
             <ToastMessageItem message={message} onDismiss={onMessageDismiss} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1670,15 +1670,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^6.0.0":
-  version: 6.3.0
-  resolution: "@hypothesis/frontend-shared@npm:6.3.0"
+"@hypothesis/frontend-shared@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@hypothesis/frontend-shared@npm:6.4.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^2.10.0-alpha.1
   peerDependencies:
     preact: ^10.4.0
-  checksum: edfbcd95a743b2ab43d5a695b264d553ff9fd262b1b474454de774f8eaf34c29d351d38aa651905f1c2b44dd56c9db1b388ce126ce9860c513de235f2c3dd7d7
+  checksum: f417c7fcde5661a5381e3411cfaca9de6ccf0379cc38d5ba1013dbd1d7bd8e665cbb075c1e96fb2069c5b21696a3240d33f12c0615fcaa5f7b6b9fbf0f6ad54a
   languageName: node
   linkType: hard
 
@@ -6671,7 +6671,7 @@ __metadata:
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.16.7
     "@hypothesis/frontend-build": ^2.0.0
-    "@hypothesis/frontend-shared": ^6.0.0
+    "@hypothesis/frontend-shared": ^6.4.0
     "@npmcli/arborist": ^6.1.1
     "@octokit/rest": ^19.0.3
     "@rollup/plugin-babel": ^6.0.0


### PR DESCRIPTION
This PR replaces custom `Card` styling with a new `Callout` shared component (available in `@hypothesis/frontend-shared` v6.4.0) for toast messages.

The motivation for this bit of work was to validate that the new `Callout` component does provide a drop-in bit of UI for toast messages (it sure seems to work fine) and give me a glimpse of what things I should consider for a shared `ToastMessages`-type component.